### PR TITLE
fix(testpage): await the AL page trigger's ValueTask so a control's OnValidate error is not silently discarded

### DIFF
--- a/AlRunner.Tests/PageTriggerAwaitTests.cs
+++ b/AlRunner.Tests/PageTriggerAwaitTests.cs
@@ -1,0 +1,159 @@
+// PageTriggerAwaitTests — issue #2359 (a page control's OnValidate error was silently
+// discarded because the trigger's ValueTask was thrown away).
+//
+// This is a RUNNER-MECHANISM test, not a claim about what real BC does. It pins
+// RunnerPageInstance.AwaitTriggerResult, the helper every page-trigger dispatch site in
+// RunnerPageInstance now routes its MethodInfo.Invoke result through.
+//
+// The BEHAVIOURAL claim ("a page control's own OnValidate can refuse a value with Error()
+// and TestPage SetValue surfaces that error") is proven upstream against a live BC service
+// tier — see StefanMaron/BusinessCentral.AL.Language.Tests, codeunit 60820
+// "TP Control OnValidate Error".
+//
+// Why the helper needs pinning at all: BC's AL compiler emits a precompiled page's trigger
+// as an async method (measured on Base App page 9170 "Profile Card":
+// ProfileIdField_a45_OnValidate returns ValueTask, RoleCenterIdField_a45_OnLookup returns
+// ValueTask<bool>). MethodInfo.Invoke hands back the awaitable, so an Error() raised inside
+// the trigger is parked on it as a faulted state instead of being thrown at the call site.
+// Discarding that value made the runner report success for AL that had plainly failed —
+// the silent failure .claude/rules/loud-failures.md forbids.
+
+using System;
+using System.Threading.Tasks;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class PageTriggerAwaitTests
+{
+    private sealed class TriggerShapeException : Exception
+    {
+        public TriggerShapeException(string message) : base(message) { }
+    }
+
+    // --- the defect, in the exact shape the Base App page produced -------------------
+
+    [Fact]
+    public void FaultedValueTask_RethrowsTheOriginalException()
+    {
+        // `async ValueTask` trigger that raises: the exception lives on the awaitable.
+        static async ValueTask Body()
+        {
+            await Task.Yield();
+            throw new TriggerShapeException("the control refuses this value");
+        }
+
+        var pending = Body();
+
+        // Not an AggregateException, and not a TargetInvocationException: AL callers —
+        // asserterror above all — must observe the error the trigger actually raised.
+        var ex = Assert.Throws<TriggerShapeException>(
+            () => RunnerPageInstance.AwaitTriggerResult(pending));
+        Assert.Equal("the control refuses this value", ex.Message);
+    }
+
+    [Fact]
+    public void FaultedGenericValueTask_RethrowsTheOriginalException()
+    {
+        static async ValueTask<bool> Body()
+        {
+            await Task.Yield();
+            throw new TriggerShapeException("the lookup refuses this value");
+        }
+
+        var ex = Assert.Throws<TriggerShapeException>(
+            () => RunnerPageInstance.AwaitTriggerResult(Body()));
+        Assert.Equal("the lookup refuses this value", ex.Message);
+    }
+
+    [Fact]
+    public void FaultedTask_RethrowsTheOriginalException()
+    {
+        static async Task Body()
+        {
+            await Task.Yield();
+            throw new TriggerShapeException("task-shaped trigger refused");
+        }
+
+        var ex = Assert.Throws<TriggerShapeException>(
+            () => RunnerPageInstance.AwaitTriggerResult(Body()));
+        Assert.Equal("task-shaped trigger refused", ex.Message);
+    }
+
+    // --- the OnLookup half: the awaitable's VALUE has to come back -------------------
+
+    [Fact]
+    public void GenericValueTask_YieldsTheValueTheTriggerReturned()
+    {
+        static async ValueTask<bool> Accepted()
+        {
+            await Task.Yield();
+            return true;
+        }
+
+        static async ValueTask<bool> Cancelled()
+        {
+            await Task.Yield();
+            return false;
+        }
+
+        // RaiseOnLookup tests `result is true`. Before this helper existed it tested that
+        // against the ValueTask<bool> itself, which is never true, so every lookup on a
+        // precompiled page read as "the user cancelled" no matter what the trigger returned.
+        Assert.Equal(true, RunnerPageInstance.AwaitTriggerResult(Accepted()));
+        Assert.Equal(false, RunnerPageInstance.AwaitTriggerResult(Cancelled()));
+    }
+
+    [Fact]
+    public void GenericTask_YieldsTheValueTheTriggerReturned()
+    {
+        static async Task<bool> Accepted()
+        {
+            await Task.Yield();
+            return true;
+        }
+
+        Assert.Equal(true, RunnerPageInstance.AwaitTriggerResult(Accepted()));
+    }
+
+    // --- completing normally, and the non-async emit shape ---------------------------
+
+    [Fact]
+    public void CompletedValueTask_YieldsNullAndDoesNotThrow()
+    {
+        Assert.Null(RunnerPageInstance.AwaitTriggerResult(default(ValueTask)));
+        Assert.Null(RunnerPageInstance.AwaitTriggerResult(Task.CompletedTask));
+        Assert.Null(RunnerPageInstance.AwaitTriggerResult(null));
+    }
+
+    [Fact]
+    public void NonAwaitableResult_IsPassedThroughUnchanged()
+    {
+        // The runner's OWN AL emit produces `void` page triggers (measured: source-compiled
+        // page 64901's ControlGuarded_a45_OnValidate returns Void), so a trigger that is not
+        // async at all must keep working, and a hypothetical non-async Boolean OnLookup must
+        // still answer with its bool rather than being swallowed.
+        Assert.Equal(true, RunnerPageInstance.AwaitTriggerResult(true));
+        Assert.Equal("plain", RunnerPageInstance.AwaitTriggerResult("plain"));
+        Assert.Equal(7, RunnerPageInstance.AwaitTriggerResult(7));
+    }
+
+    [Fact]
+    public void ADeferredTriggerIsWaitedFor_NotJustStarted()
+    {
+        // The other half of the same defect: a discarded awaitable is also an UNFINISHED one.
+        // A trigger that suspends must have completed its side effects before the helper
+        // returns, or the AL that follows SetValue observes a half-run trigger.
+        var landed = false;
+
+        async ValueTask Body()
+        {
+            await Task.Delay(30);
+            landed = true;
+        }
+
+        RunnerPageInstance.AwaitTriggerResult(Body());
+        Assert.True(landed, "AwaitTriggerResult must block until the trigger has finished");
+    }
+}

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -829,7 +829,10 @@ internal sealed class RunnerPageInstance
         var byRef = new ByRef<NavText>(() => value, v => value = v);
 
         object? result;
-        try { result = trigger.Method.Invoke(trigger.Target, new object?[] { byRef }); }
+        // AwaitTriggerResult, not a bare Invoke: BC emits `trigger OnLookup(...): Boolean` as
+        // `ValueTask<bool>`, so the raw Invoke result never pattern-matches `is true` and every
+        // lookup read as "the user cancelled" — see AwaitTriggerResult's remarks.
+        try { result = AwaitTriggerResult(trigger.Method.Invoke(trigger.Target, new object?[] { byRef })); }
         catch (TargetInvocationException tie) when (tie.InnerException != null)
         {
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
@@ -1321,7 +1324,9 @@ internal sealed class RunnerPageInstance
                 ?? TryFindActionRefTargetTriggerOnExtension(instance, extensionId, actionId);
             if (match == null) continue;
 
-            try { match.Value.Method.Invoke(match.Value.Target, null); }
+            // AwaitTriggerResult for the same reason Invoke uses it: this OnAction is emitted
+            // async too, so dropping the awaitable swallowed any Error() the action raised.
+            try { AwaitTriggerResult(match.Value.Method.Invoke(match.Value.Target, null)); }
             catch (TargetInvocationException tie) when (tie.InnerException != null)
             {
                 System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
@@ -1350,13 +1355,86 @@ internal sealed class RunnerPageInstance
 
     private void Invoke(TriggerMatch trigger)
     {
-        try { trigger.Method.Invoke(trigger.Target, null); }
+        try { AwaitTriggerResult(trigger.Method.Invoke(trigger.Target, null)); }
         catch (TargetInvocationException tie) when (tie.InnerException != null)
         {
             // An Error() inside the AL trigger is the trigger's own outcome, not a runner
             // failure — rethrow it unwrapped so the AL stack survives.
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
         }
+    }
+
+    /// <summary>
+    /// Block on the Task / ValueTask an AL page trigger returned, and answer with the value it
+    /// produced (null for a void trigger).
+    ///
+    /// BC's AL compiler emits EVERY page trigger as an async method — measured on the Base App's
+    /// precompiled page 9170 "Profile Card": <c>ProfileIdField_a45_OnValidate</c> returns
+    /// <c>ValueTask</c> and <c>RoleCenterIdField_a45_OnLookup</c> returns
+    /// <c>ValueTask&lt;bool&gt;</c>. <c>MethodInfo.Invoke</c> therefore hands back the awaitable,
+    /// not the outcome, and an <c>Error()</c> the trigger raised is parked on it as a faulted
+    /// state rather than thrown. Every call site here used to drop that value on the floor, so:
+    ///
+    /// <list type="bullet">
+    /// <item>a page control's OnValidate could raise, and TestPage SetValue reported success —
+    /// the AL Error() was measurably present (<c>status=Faulted</c>, e.g.
+    /// "You cannot disable the profile that is used as default.") and simply discarded, which is
+    /// the silent-out-of-scope failure loud-failures.md forbids; and</item>
+    /// <item>OnLookup's <c>result is true</c> pattern-matched a <c>ValueTask&lt;bool&gt;</c>
+    /// against a <c>bool</c>, which is never true, so every lookup on such a page reported
+    /// "the user cancelled" no matter what the trigger returned.</item>
+    /// </list>
+    ///
+    /// Blocking is the correct shape here for the same reason it already is in
+    /// <c>CodeunitPatches.AwaitIfTask</c> and <c>CodeunitEventDispatcher.ObserveAsyncResult</c>
+    /// (the two sibling AL dispatchers that already do this): the runner drives AL synchronously,
+    /// so these are complete or complete inline, and <c>GetAwaiter().GetResult()</c> rethrows the
+    /// ORIGINAL exception rather than an AggregateException — which is what the AL caller,
+    /// including <c>asserterror</c>, has to observe.
+    ///
+    /// A trigger that returned an ordinary (non-awaitable) value is passed through unchanged, so
+    /// a future non-async emit shape keeps working.
+    /// </summary>
+    internal static object? AwaitTriggerResult(object? result)
+    {
+        switch (result)
+        {
+            case null:
+                return null;
+            case System.Threading.Tasks.Task task:
+                task.GetAwaiter().GetResult();
+                return TaskResultOrNull(task);
+            case System.Threading.Tasks.ValueTask valueTask:
+                valueTask.GetAwaiter().GetResult();
+                return null;
+        }
+
+        var type = result.GetType();
+        if (type.IsGenericType
+            && type.GetGenericTypeDefinition() == typeof(System.Threading.Tasks.ValueTask<>))
+        {
+            // ValueTask<T> has no non-generic surface to await through, so go via AsTask() —
+            // the same route CodeunitEventDispatcher.ObserveAsyncResult takes.
+            var asTask = type.GetMethod("AsTask", BindingFlags.Public | BindingFlags.Instance)
+                ?? throw new InvalidOperationException(
+                    $"ValueTask<T>.AsTask not found while awaiting an AL page trigger ({type.FullName}) "
+                    + "— BC/runtime shape changed.");
+            var task = (System.Threading.Tasks.Task)asTask.Invoke(result, null)!;
+            task.GetAwaiter().GetResult();
+            return TaskResultOrNull(task);
+        }
+
+        // Not awaitable — an ordinary return value.
+        return result;
+    }
+
+    /// <summary>Task&lt;T&gt;.Result for a completed generic task; null for a plain Task.</summary>
+    private static object? TaskResultOrNull(System.Threading.Tasks.Task task)
+    {
+        var type = task.GetType();
+        return type.IsGenericType
+            ? type.GetProperty("Result", BindingFlags.Public | BindingFlags.Instance)?.GetValue(task)
+            : null;
     }
 
     /// <summary>

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -1055,13 +1055,31 @@ internal sealed class RunnerPageInstance
     /// dispatch reaches the page's override; a page that declares none lands on NavForm's
     /// implementation, which is the correct no-op/true.
     /// </summary>
+    /// <summary>
+    /// Invoke one of the page's own record triggers (OnOpenPage, OnQueryClosePage, OnNewRecord,
+    /// OnInsertRecord, …) and answer with what it produced.
+    ///
+    /// Routed through <see cref="AwaitTriggerResult"/> for the same reason the control-trigger
+    /// path is (#2359), and the consequences here are worse, because two of these triggers'
+    /// RETURN VALUES are load-bearing:
+    ///
+    /// <list type="bullet">
+    /// <item><c>RaiseOnClosePage</c> tests <c>is false</c> to honour OnQueryClosePage's veto,
+    /// and <c>RaiseOnInsertRecord</c> tests <c>is not false</c> to honour OnInsertRecord's.
+    /// Against a raw <c>ValueTask&lt;bool&gt;</c> neither pattern can ever match, so a page that
+    /// refused to close, or refused an insert, was closed and inserted anyway.</item>
+    /// <item>An <c>Error()</c> raised in OnOpenPage or OnQueryClosePage was parked on the
+    /// discarded awaitable and never reached the AL that called <c>OpenNew()</c> /
+    /// <c>Close()</c> — the same silent success the control-trigger half produced.</item>
+    /// </list>
+    /// </summary>
     private object? InvokeRecordTrigger(string name, Type[] parameterTypes, object[] arguments)
     {
         var trigger = _form.GetType().GetMethod(name,
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
             binder: null, types: parameterTypes, modifiers: null);
         if (trigger == null) return null;
-        try { return trigger.Invoke(_form, arguments); }
+        try { return AwaitTriggerResult(trigger.Invoke(_form, arguments)); }
         catch (TargetInvocationException tie) when (tie.InnerException != null)
         {
             // An Error() inside the trigger is the trigger's own outcome, not a runner

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -1428,13 +1428,25 @@ internal sealed class RunnerPageInstance
         return result;
     }
 
-    /// <summary>Task&lt;T&gt;.Result for a completed generic task; null for a plain Task.</summary>
+    /// <summary>
+    /// <c>Task&lt;T&gt;.Result</c> for a completed generic task; null for a task that carries no
+    /// value.
+    ///
+    /// "Carries no value" is not the same as "is not generic": an <c>async Task</c> method
+    /// materialises at runtime as <c>Task&lt;VoidTaskResult&gt;</c>, where <c>VoidTaskResult</c>
+    /// is the BCL's internal placeholder struct. Reading <c>.Result</c> off that hands back a
+    /// boxed placeholder — a non-null object standing in for a void trigger — which would then
+    /// flow out of AwaitTriggerResult as if the trigger had returned something. Filter it out by
+    /// name; the type is internal to System.Private.CoreLib so there is nothing to compare
+    /// against.
+    /// </summary>
     private static object? TaskResultOrNull(System.Threading.Tasks.Task task)
     {
         var type = task.GetType();
-        return type.IsGenericType
-            ? type.GetProperty("Result", BindingFlags.Public | BindingFlags.Instance)?.GetValue(task)
-            : null;
+        if (!type.IsGenericType) return null;
+        var resultType = type.GetGenericArguments()[0];
+        if (resultType.FullName == "System.Threading.Tasks.VoidTaskResult") return null;
+        return type.GetProperty("Result", BindingFlags.Public | BindingFlags.Instance)?.GetValue(task);
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #2359

BC's AL compiler emits a **precompiled** page's triggers as async methods. Measured on the Base
Application's page 9170 "Profile Card" (BC 28.1.49838.53910), by tracing the runner's own
dispatch:

```
Page9170.ProfileIdField_a45_OnValidate    -> System.Threading.Tasks.ValueTask
Page9170.RoleCenterIdField_a45_OnLookup   -> System.Threading.Tasks.ValueTask`1[System.Boolean]
```

`RunnerPageInstance` invoked them with `MethodInfo.Invoke` and discarded the result, so an
`Error()` raised inside a trigger was parked on the awaitable as a faulted state and never
thrown at the call site. The same trace with the `ValueTask` converted so its state is readable
shows the errors were all present and all dropped:

```
-> ValueTask status=Faulted ex=NavNCLDialogException:You cannot disable the profile that is used as default.
-> ValueTask status=Faulted ex=NavTestFieldException:Object Subtype must be equal to 'RoleCenter' ...
-> ValueTask status=Faulted ex=NavNCLDialogException:A profile with Profile ID "BLANK" already exist, ...
```

Triggers that did not raise read `status=RanToCompletion`, which is why this survived so long:
the state machine completed synchronously, so every **side effect** still landed and only the
**error** path was lost. That is the silent failure `loud-failures.md` forbids, and it is worse
than a missing validate — the page reports success and the value the AL just refused is sitting
in the row.

`asserterror` itself is innocent. `NavMethodScope_AssertErrorCore` catches bare `Exception`, so
anything thrown would have counted; nothing was thrown. The stack top just happens to be the
statement that noticed.

## Fixing the shape, not the reported line

The reported symptom was one call site. Four have the same defect, and they are fixed together:

1. **`Invoke(TriggerMatch)`** — powers `RaiseOnValidate`, `RaiseOnAction`, `RaiseOnDrillDown`.
   This is the one the issue reproduces.
2. **`RaiseOnLookup`** — tested `result is true` against what is actually a `ValueTask<bool>`,
   which is never `true`, so **every** `OnLookup` on a precompiled page reported "the user
   cancelled" regardless of what the trigger returned. Measured on page 9170's
   `RoleCenterIdField.Lookup()`.
3. **`TryRaiseExtensionOnlyAction`** — discards a pageextension `OnAction`'s awaitable.
4. **`InvokeRecordTrigger`** — the page's own record triggers (`OnOpenPage`,
   `OnQueryClosePage`, `OnClosePage`, `OnNewRecord`, `OnInsertRecord`, `OnAfterGetRecord`).
   The worst of the four, because two of those return values are the page's **veto**:
   `RaiseOnClosePage` tests `is false` and `RaiseOnInsertRecord` tests `is not false`, neither
   of which can ever match a raw `ValueTask<bool>` — so a page that refused to close, or
   refused an insert, was closed and inserted anyway.

Sites 2–4 were found by looking for the shape rather than the symptom; **no test in the
measurements below moved because of 3 or 4 specifically**, and they are fixed anyway because
leaving one of four paths with the blind spot is a defect whether or not anything reaches it
today.

The three questions, answered explicitly:

- *Same wrong pattern at another call site?* Yes — the four above, all in
  `RunnerPageInstance.cs`.
- *Sibling function making the same assumption?* No others found. Two sibling AL dispatchers
  already do this correctly and are the reference shape the new helper follows:
  `CodeunitPatches.AwaitIfTask` and `CodeunitEventDispatcher.ObserveAsyncResult`. The page
  dispatcher simply never got it.
- *Two paths writing the same state with different invariants?* The table-field half of
  `SetValue` already did `_record.ALValidateAsync(...).GetAwaiter().GetResult()` while the
  page-control half that runs immediately after it did not — that asymmetry **is** this bug,
  and it is now gone.

## The runner's own AL emit is not affected, and that matters

A source-compiled page's trigger is emitted `void` (measured: page 64901's
`ControlGuarded_a45_OnValidate -> Void`), and a probe suite over a source-compiled page passes
both before and after this change. So this only ever affected pages arriving from a
**precompiled dependency** — Base App, System App, ISV apps — which is exactly why no existing
runner-local or corpus test caught it. It is also why the proving test upstream drives a Base
Application page rather than one the corpus declares.

## Tests

**Upstream (the BC-behaviour claim).** `StefanMaron/BusinessCentral.AL.Language.Tests`,
codeunit 60820 "TP Control OnValidate Error" — a page control's own `OnValidate` can refuse a
value with `Error()`, and that error reaches the caller of TestPage `SetValue`. Pinned on Base
Application page 9170 against this app's own profile fixture, so the expected message cannot
drift with demo data. **This PR does not bump the submodule pin** — that PR is not merged yet,
so the pin bump and the `count-baseline` update are not folded in here.

RED → GREEN measured locally against a checkout of that corpus branch:

| arm | before | after |
|---|---|---|
| `ControlOnValidateError_ReachesTheCaller` | FAIL (`An error was expected inside an ASSERTERROR statement`) | PASS |
| `ControlOnValidateError_IsTheControlsOwnMessage` | FAIL (same) | PASS |
| `ControlOnValidate_AcceptsAValueItDoesNotRefuse` | PASS | PASS |

The mirror arm passing in **both** states is the point: it rules out "the fix made every
`SetValue` throw".

**Runner-side (the mechanism).** `AlRunner.Tests/PageTriggerAwaitTests.cs` pins
`AwaitTriggerResult`: a faulted `ValueTask` / `ValueTask<bool>` / `Task` rethrows the original
exception (not an `AggregateException`, not a `TargetInvocationException`), a
`ValueTask<bool>` yields its bool, a non-awaitable value passes through unchanged, and a
suspending trigger is waited for rather than merely started. That last-but-one case is not
decoration — the test caught a real wrinkle while being written: an `async Task` method
materialises as `Task<VoidTaskResult>`, so reading `.Result` off it handed back a boxed BCL
placeholder in place of "the trigger returned nothing".

## Measured impact

Microsoft `Tests-SINGLESERVER`, `Codeunit138698` "AllProfile V2 Test", BC 28.1.49838.53910:

| | before | after |
|---|---|---|
| pass | 6 | 10 |
| fail | 21 | 17 |
| failures classified `runtime/Runtime.NavMethodScope.AssertError` | 6 | 0 |

Five now pass outright. The sixth (`TestCannotselectANonRoleCenterPageAsRoleCenter`) gets past
its `asserterror` and fails one line later on #2326, a separate gap.

## The cluster this came from, split

This started as 15 `NavMethodScope.AssertError` failures across six codeunits. They are not one
defect, and the rest are filed rather than folded in here:

| tests | cause |
|---|---|
| `Codeunit138698` ×6, `Codeunit134201` ×1 | **this PR** |
| `Codeunit132903` ×2 | #2341 — `TestPage 9807 was never parsed from AL source` blocks 28 of that codeunit's 29 tests; already claimed |
| `Codeunit139460` ×3 | #2381 — a Base App `[EventSubscriber(ObjectType::Table, Database::User, 'OnAfterModifyEvent')]` never fires |
| `Codeunit139004` ×1 | #2382 — Company Information's `OnClosePage` experience-tier refusal |
| `Codeunit136601` ×2 | #2383 — a Config. Template Line default value is not checked against the target field's TableRelation |

## Verification run in this state

- al-language corpus: **2224 / 2224**
- `tests/runner-extras` (`--strict --count-baseline`): **202 / 202**
- `dotnet test AlRunner.Tests`: 1375 passed, 3 failed — all three are
  `ProvisionExplicitModesTests` failing on `Network is unreachable
  (bcartifacts-...azurefd.net:443)`; this sandbox has no route to the BC artifact CDN. Unrelated
  to this change and pre-existing.
- Source-compiled-page probe suite: passes before and after (see above).
