### PR TITLE
perf(tests): route the three worst spawn-heavy test classes through the warm --server fixture

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -120,10 +120,23 @@ See `.claude/rules/local-test-scope.md` for the general rule. Concretely for
 an impl agent, before pushing:
 
 1. **The RED → GREEN test itself** — non-negotiable, that is the proof your change works.
-2. **`dotnet test AlRunner.Tests`** — cheap relative to an AL suite, and where a regression from a runtime/compiler change shows up first.
+2. **A FILTERED `AlRunner.Tests` run** covering the surface you changed:
+   `dotnet test AlRunner.Tests --filter FullyQualifiedName~<YourTestClass>`. Seconds to a
+   couple of minutes, and where a regression from a runtime/compiler change shows up first.
 3. **The one AL bundle your change plausibly affects**, if there is an obvious one. Not all 32.
 
-Then push. CI runs the corpus, all of `runner-extras`, the xmlport isolation guard and server-mode across every supported BC version — that is what it is for.
+**Do not run the whole `dotnet test AlRunner.Tests` as a matter of routine.** This line
+used to call it "cheap relative to an AL suite"; measured, it is **15 minutes on a quiet
+machine and 31 on a loaded one**, and that sentence is why agents ran it four times in a
+two-hour task and spent half the task waiting. The cost is concentrated, not spread —
+1231 of 1435 tests finish under a second, and the top 50 are 64% of all test time,
+because they spawn the runner as a subprocess. A filter that names your class skips
+essentially all of it.
+
+Then push. CI runs the corpus, all of `runner-extras`, the xmlport isolation guard and
+server-mode across every supported BC version, plus the full `AlRunner.Tests` suite on
+each of the 8 legs — that is what it is for, and it runs in parallel with you rather
+than in front of you.
 
 **When to run wider anyway** (judgement, not routine):
 - You changed something in the shared compile/dispatch path with a broad blast radius — `BcCompiler`, `CodeunitEventDispatcher`, `RecordPatches`, the loader/cache layer. A wide change earns a wide local run.

--- a/AlRunner.Tests/CliServer.cs
+++ b/AlRunner.Tests/CliServer.cs
@@ -52,6 +52,70 @@ public sealed class CliServer : IAsyncDisposable
     /// <summary>Captured stderr so far — surfaced in assertion messages when the protocol stalls.</summary>
     public string StdErr { get { lock (_stderr) return _stderr.ToString(); } }
 
+    /// <summary>
+    /// #2377: how many characters of stderr have been captured so far — a marker to
+    /// slice ONE request's diagnostics out of a shared server's cumulative stderr.
+    ///
+    /// A class-shared server serves many requests through one pipe, so
+    /// <see cref="StdErr"/> is the concatenation of every request's output. A test
+    /// converted from "spawn the CLI once, assert on its whole console dump" needs the
+    /// dump for ITS request only — otherwise `Assert.DoesNotContain("[layered] WROTE B")`
+    /// would match a line the PREVIOUS fact legitimately produced, and the converted test
+    /// would fail for a reason that has nothing to do with what it proves.
+    ///
+    /// Take the mark immediately before <c>SendRequestStreamingAsync</c>, read the slice
+    /// with <see cref="StdErrSinceAsync"/> after.
+    /// </summary>
+    public int StdErrMark { get { lock (_stderr) return _stderr.Length; } }
+
+    /// <summary>
+    /// The stderr captured since <paramref name="mark"/>, once <paramref name="anchor"/>
+    /// appears in it — or a <see cref="TimeoutException"/> naming both.
+    ///
+    /// The wait is the point, and skipping it is how this goes flaky. stdout (the JSON
+    /// protocol) and stderr (every diagnostic a converted test asserts on) are two
+    /// separate pipes drained by two different threads, so reading the terminal
+    /// <c>{"type":"summary"}</c> line establishes NOTHING about how much of that
+    /// request's stderr the background drain task has appended yet. Measured on a loaded
+    /// box the last stderr line of a request lands 0.05-5.9s BEFORE its summary — i.e.
+    /// usually early enough that an unsynchronised read would pass, which is exactly the
+    /// shape of a test that fails once a month on CI and nowhere else.
+    ///
+    /// <paramref name="anchor"/> must be a string the runner emits AFTER everything the
+    /// caller intends to assert on — for the layered pre-pass, its
+    /// "[layered] pre-built N impl package(s)" trailer, which follows the per-impl
+    /// WROTE/HIT lines. That ordering is what makes a NEGATIVE assertion
+    /// (<c>DoesNotContain</c>) on the returned slice sound: without an anchor emitted
+    /// after the line being excluded, "not there yet" and "never emitted" are the same
+    /// observation.
+    /// </summary>
+    public async Task<string> StdErrSinceAsync(int mark, string anchor, TimeSpan? timeout = null)
+    {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(30));
+        while (true)
+        {
+            var slice = StdErrSince(mark);
+            if (slice.Contains(anchor, StringComparison.Ordinal)) return slice;
+            if (DateTime.UtcNow >= deadline)
+                throw new TimeoutException(
+                    $"stderr anchor '{anchor}' never appeared in this request's slice.\n" +
+                    $"--- slice since mark {mark} ---\n{slice}");
+            await Task.Delay(25);
+        }
+    }
+
+    /// <summary>
+    /// The raw stderr slice since <paramref name="mark"/>, with no wait. Only sound when
+    /// the caller has ALREADY synchronised on an anchor via <see cref="StdErrSinceAsync"/>
+    /// (e.g. to take a second, wider slice), or when the assertion is positive and the
+    /// caller is prepared for it to be racy. Prefer <see cref="StdErrSinceAsync"/>.
+    /// </summary>
+    public string StdErrSince(int mark)
+    {
+        lock (_stderr)
+            return mark >= _stderr.Length ? string.Empty : _stderr.ToString(mark, _stderr.Length - mark);
+    }
+
     private static string CurrentFramework()
     {
         var v = Environment.Version;

--- a/AlRunner.Tests/LayeredCacheTests.cs
+++ b/AlRunner.Tests/LayeredCacheTests.cs
@@ -1,5 +1,4 @@
-using System.Diagnostics;
-using System.Text;
+using System.Text.Json;
 using Xunit;
 
 namespace AlRunner.Tests;
@@ -14,21 +13,44 @@ namespace AlRunner.Tests;
 /// re-emits. With a combined workspace key, editing A orphans B's cache too and B
 /// re-emits — which this test fails on.
 ///
+/// #2377: the two runs are two `runTests` requests to ONE warm <c>--server</c>
+/// process (<see cref="SharedCliServer"/>) rather than two CLI spawns. The claim is
+/// unchanged because it is the SAME code that answers it either way:
+/// <c>RunAllBundlesForServer</c> calls <c>RunLayeredPrePass</c> for any request with
+/// more than one sourcePath, exactly as the CLI's bundled loop does, and the pre-pass
+/// emits the same `[layered] WROTE` / `[layered] cache HIT` lines (server mode routes
+/// them to stderr, which <see cref="CliServer.StdErrSinceAsync"/> slices per request).
+/// The `--cache` dir the workspace key lives under is a server STARTUP flag, so both
+/// requests share one — which is what the CLI version did too, passing the same
+/// cacheDir to both spawns. Measured: 219.7s as two spawns, ~25s as boot + two
+/// requests, on the same loaded box.
+///
 /// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
 /// See DefineFlagIntegrationTests for why this used to be
 /// [Collection("server-serial")] and no longer is — #1809.
 /// </summary>
-public class LayeredCacheTests
+public class LayeredCacheTests : IClassFixture<SharedCliServer>
 {
-    private static readonly string RepoRoot = Path.GetFullPath(
-        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
-    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private readonly SharedCliServer _shared;
 
-    private static string CurrentFramework()
-    {
-        var v = Environment.Version;
-        return $"net{v.Major}.{v.Minor}";
-    }
+    /// <summary>
+    /// The one `--cache` dir this class's server is started with. Per test-run (a fresh
+    /// GUID), so a workspace cache left behind by an earlier invocation can never answer
+    /// for this one — the same guarantee the CLI version got from building its cacheDir
+    /// under a fresh scratch root.
+    /// </summary>
+    private static readonly string CacheDir = Path.Combine(
+        Path.GetTempPath(), "al-runner-layered-cache", Guid.NewGuid().ToString("N"), "al-out");
+
+    /// <summary>
+    /// Emitted by the layered pre-pass AFTER every per-impl WROTE/HIT line, so it is a
+    /// sound synchronisation point for this class's negative assertion
+    /// ("B must not have been re-WROTE"): once this is in the slice, every line the
+    /// pre-pass had to say about A and B is already in it too.
+    /// </summary>
+    private const string PrePassTrailer = "[layered] pre-built";
+
+    public LayeredCacheTests(SharedCliServer shared) => _shared = shared;
 
     private static void WriteApp(string dir, string id, string name, int idFrom,
         string codeunit, string? dependsOnJson = null)
@@ -42,7 +64,6 @@ public class LayeredCacheTests
           "version": "1.0.0.0",
           "dependencies": [{{dependsOnJson ?? ""}}],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": {{idFrom}}, "to": {{idFrom + 9}} } ],
           "runtime": "14.0"
         }
@@ -50,36 +71,22 @@ public class LayeredCacheTests
         File.WriteAllText(Path.Combine(dir, "Probe.Codeunit.al"), codeunit);
     }
 
-    private static (string output, int exit) RunRunner(string cacheDir, params string[] bundles)
-    {
-        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
-        args.Append(TestBuildConfig.BcVersionArg);
-        foreach (var b in bundles) args.Append(" \"").Append(b).Append('"');
-        args.Append(" --cache \"").Append(cacheDir).Append('"');
-        var psi = new ProcessStartInfo
+    private static string Req(params string[] bundles)
+        => JsonSerializer.Serialize(new
         {
-            FileName = "dotnet", Arguments = args.ToString(),
-            RedirectStandardOutput = true, RedirectStandardError = true,
-            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
-        };
-        var sb = new StringBuilder();
-        var p = Process.Start(psi)!;
-        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
-        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
-        p.BeginOutputReadLine();
-        p.BeginErrorReadLine();
-        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
-        p.WaitForExit();
-        lock (sb) return (sb.ToString(), p.ExitCode);
-    }
+            command = "runTests",
+            sourcePaths = bundles,
+            packagePaths = Array.Empty<string>(),
+        });
 
     [SkippableFact]
-    public void EditingOneImpl_DoesNotRebuildSiblingImpl()
+    public async Task EditingOneImpl_DoesNotRebuildSiblingImpl()
     {
         TestArtifacts.SkipIfMissing();
 
+        var server = await _shared.GetAsync(new[] { "--cache", CacheDir });
+
         var root = Path.Combine(Path.GetTempPath(), "al-runner-layered-cache", Guid.NewGuid().ToString("N"));
-        var cacheDir = Path.Combine(root, "al-out");
         var aDir = Path.Combine(root, "A");
         var bDir = Path.Combine(root, "B");
         var cDir = Path.Combine(root, "C");
@@ -103,17 +110,25 @@ public class LayeredCacheTests
             dependsOnJson: depsJson);
 
         // Run 1 — both impls fresh-built.
-        var (out1, _) = RunRunner(cacheDir, aDir, bDir, cDir);
+        var mark1 = server.StdErrMark;
+        var lines1 = await server.SendRequestStreamingAsync(Req(aDir, bDir, cDir), TimeSpan.FromSeconds(300));
+        var (_, summary1) = ProtocolV2Streaming.Split(lines1);
+        Assert.Equal(0, summary1.GetProperty("exitCode").GetInt32());
+        var out1 = await server.StdErrSinceAsync(mark1, PrePassTrailer);
         Assert.Contains("[layered] WROTE Layered A LC", out1);
         Assert.Contains("[layered] WROTE Layered B LC", out1);
 
         // Edit ONLY A.
-        File.WriteAllText(Path.Combine(aDir, "Probe.Codeunit.al"),
+        await File.WriteAllTextAsync(Path.Combine(aDir, "Probe.Codeunit.al"),
             $"codeunit 60130 \"Layered A Cu LC\"\n{{\n    // marker {tokA}-EDITED\n    procedure A_Ping(): Integer begin exit(99); end;\n}}\n");
 
         // Run 2 — A re-emits, B must be a cache HIT (the fix); a combined key would
         // rebuild B too.
-        var (out2, _) = RunRunner(cacheDir, aDir, bDir, cDir);
+        var mark2 = server.StdErrMark;
+        var lines2 = await server.SendRequestStreamingAsync(Req(aDir, bDir, cDir), TimeSpan.FromSeconds(300));
+        var (_, summary2) = ProtocolV2Streaming.Split(lines2);
+        Assert.Equal(0, summary2.GetProperty("exitCode").GetInt32());
+        var out2 = await server.StdErrSinceAsync(mark2, PrePassTrailer);
         Assert.Contains("[layered] WROTE Layered A LC", out2);
         Assert.Contains("[layered] cache HIT Layered B LC", out2);
         Assert.DoesNotContain("[layered] WROTE Layered B LC", out2);

--- a/AlRunner.Tests/LayeredDepManifestTests.cs
+++ b/AlRunner.Tests/LayeredDepManifestTests.cs
@@ -30,6 +30,20 @@ namespace AlRunner.Tests;
 /// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
 /// See DefineFlagIntegrationTests for why this used to be
 /// [Collection("server-serial")] and no longer is — #1809.
+///
+/// #2377: deliberately NOT moved to the shared --server fixture, unlike its neighbours.
+/// The negative fact's decisive assertion is that "Unhandled exception" is ABSENT — that
+/// an invalid dep manifest yields a formatted "<layered-deps>: COMPILE-FAIL" and exit 3
+/// rather than the CLR's default handler aborting the PROCESS with exit 134/SIGABRT,
+/// which is exactly what #1898 fixed and exactly what a pre-fix regression would undo.
+/// That claim is about the CLI's own Main-level exception handling and can only be
+/// observed by watching a process exit; RunAllBundlesForServer wraps the same pre-pass in
+/// its own try/catch, so a server request can never reach the code path being held down.
+/// Converting the POSITIVE fact alone would leave the class spawning anyway for the
+/// negative one, so it buys a server process rather than removing one. A test that keeps
+/// its meaning and stays slow beats a fast one that proves something else
+/// (.claude/rules/tdd.md). See ManifestFeaturesSubprocessTests' fourth fact for the same
+/// call, made one fact at a time.
 /// </summary>
 public class LayeredDepManifestTests
 {

--- a/AlRunner.Tests/LayeredSourceChainTests.cs
+++ b/AlRunner.Tests/LayeredSourceChainTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text;
+using System.Text.Json;
 using Xunit;
 
 namespace AlRunner.Tests;
@@ -36,11 +37,72 @@ namespace AlRunner.Tests;
 ///
 /// Spawns the real runner; needs the BC artifact cache. Skips (visibly) when absent.
 /// </summary>
-public class LayeredSourceChainTests
+public class LayeredSourceChainTests : IClassFixture<SharedCliServer>
 {
     private static readonly string RepoRoot = Path.GetFullPath(
         Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
     private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly SharedCliServer _shared;
+
+    public LayeredSourceChainTests(SharedCliServer shared) => _shared = shared;
+
+    /// <summary>
+    /// #2377: the one `--cache` dir this class's shared server is started with. The CLI
+    /// version gave each fact its own; a fresh GUID per test RUN preserves what that was
+    /// actually for (no workspace-deps or al-out entry from an earlier invocation may
+    /// answer for this one), and the facts cannot answer for EACH OTHER inside it because
+    /// every fixture below already writes fresh GUID app ids per fact — see the "Fixture
+    /// writers" note.
+    /// </summary>
+    private static readonly string CacheDir = Path.Combine(
+        Path.GetTempPath(), "al-runner-layered-chain", "shared-cache", Guid.NewGuid().ToString("N"), "al-out");
+
+    /// <summary>Emitted by the layered pre-pass after every per-impl WROTE/HIT line — the
+    /// synchronisation anchor for reading a request's own stderr slice. See
+    /// <see cref="CliServer.StdErrSinceAsync"/> for why an anchor is required.</summary>
+    private const string PrePassTrailer = "[layered] pre-built";
+
+    private static IEnumerable<string> ServerArgs()
+    {
+        yield return "--cache";
+        yield return CacheDir;
+        var platformApps = TestArtifacts.PlatformAppsDir();
+        if (Directory.Exists(platformApps))
+        {
+            yield return "--package-cache";
+            yield return platformApps;
+        }
+    }
+
+    private static string Req(params string[] bundles)
+        => JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            sourcePaths = bundles,
+            packagePaths = Array.Empty<string>(),
+        });
+
+    /// <summary>
+    /// The summary line's compile errors as one string — the server's equivalent of the
+    /// CLI console text these tests used to substring-match. EMIT-EXCLUDED, EMIT-ZERO,
+    /// COMPILE-FAIL, DEP-RESOLVE-FAIL, LAYERED-PREPASS-FAIL and BC's own AL diagnostics
+    /// all arrive here (see RunBundleForServer / RunAllBundlesForServer), so asserting on
+    /// it is a strictly narrower claim than matching the whole console dump was.
+    /// </summary>
+    private static string CompileErrorText(JsonElement summary)
+    {
+        if (!summary.TryGetProperty("compilationErrors", out var ce) || ce.ValueKind != JsonValueKind.Array)
+            return string.Empty;
+        var sb = new StringBuilder();
+        foreach (var group in ce.EnumerateArray())
+        {
+            if (group.TryGetProperty("file", out var f)) sb.AppendLine(f.GetString());
+            if (group.TryGetProperty("errors", out var errs) && errs.ValueKind == JsonValueKind.Array)
+                foreach (var e in errs.EnumerateArray()) sb.AppendLine(e.GetString());
+        }
+        return sb.ToString();
+    }
 
     // ── Fixture writers ────────────────────────────────────────────────────────
     // One chain, written three times into different layouts so each pre-pass sees the
@@ -48,13 +110,27 @@ public class LayeredSourceChainTests
     // own idRanges) and the app ids are fresh GUIDs per run, so no workspace-deps /
     // compiled-deps / al-out cache from a previous run can answer for any of them.
 
-    private static void WriteBaseApp(string dir, Guid baseId)
+    /// <param name="suffix">
+    /// #2377: a per-FACT tag folded into the app NAME. Distinct app ids are not enough
+    /// once these facts share one server process. Dependency resolution matches on
+    /// name/publisher/version, and RunAllBundlesForServer ACCUMULATES each request's
+    /// layered workspace dirs into the server-level packageCacheDirs — so the base app
+    /// this class builds in one fact stays in the search set for every later fact.
+    /// Measured: with a shared name, LayeredPrePass_BaseAppAbsent_… stopped failing for
+    /// its own reason (it passed alone and failed in-class in 67ms), because a base app
+    /// it declares to be ABSENT was still resolvable from the earlier fact's workspace.
+    /// A per-fact name is what makes "genuinely absent" true again.
+    /// AL object names and ids are deliberately NOT varied: only the positive fact ever
+    /// reaches a compile at all (the negative one dies in dep resolution), and the
+    /// spawning fact runs in its own process.
+    /// </param>
+    private static void WriteBaseApp(string dir, Guid baseId, string suffix)
     {
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
         {
           "id": "{{baseId}}",
-          "name": "LSC Chain Base",
+          "name": "LSC Chain Base{{suffix}}",
           "publisher": "AL Runner",
           "version": "1.0.0.0",
           "dependencies": [],
@@ -96,17 +172,17 @@ public class LayeredSourceChainTests
         """);
     }
 
-    private static void WriteMiddleApp(string dir, Guid middleId, Guid baseId)
+    private static void WriteMiddleApp(string dir, Guid middleId, Guid baseId, string suffix)
     {
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
         {
           "id": "{{middleId}}",
-          "name": "LSC Chain Middle",
+          "name": "LSC Chain Middle{{suffix}}",
           "publisher": "AL Runner",
           "version": "1.0.0.0",
           "dependencies": [
-            { "id": "{{baseId}}", "name": "LSC Chain Base", "publisher": "AL Runner", "version": "1.0.0.0" }
+            { "id": "{{baseId}}", "name": "LSC Chain Base{{suffix}}", "publisher": "AL Runner", "version": "1.0.0.0" }
           ],
           "platform": "1.0.0.0",
           "application": "1.0.0.0",
@@ -151,17 +227,17 @@ public class LayeredSourceChainTests
         """);
     }
 
-    private static void WriteTestApp(string dir, Guid testsId, Guid middleId)
+    private static void WriteTestApp(string dir, Guid testsId, Guid middleId, string suffix)
     {
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
         {
           "id": "{{testsId}}",
-          "name": "LSC Chain Test",
+          "name": "LSC Chain Test{{suffix}}",
           "publisher": "AL Runner",
           "version": "1.0.0.0",
           "dependencies": [
-            { "id": "{{middleId}}", "name": "LSC Chain Middle", "publisher": "AL Runner", "version": "1.0.0.0" }
+            { "id": "{{middleId}}", "name": "LSC Chain Middle{{suffix}}", "publisher": "AL Runner", "version": "1.0.0.0" }
           ],
           "platform": "1.0.0.0",
           "application": "1.0.0.0",
@@ -257,26 +333,44 @@ public class LayeredSourceChainTests
     /// "Dependency not found: AL Runner/LSC Chain Base".
     /// </summary>
     [SkippableFact]
-    public void LayeredPrePass_ThreeSourceBundles_MiddleImplResolvesTheBaseImpl()
+    public async Task LayeredPrePass_ThreeSourceBundles_MiddleImplResolvesTheBaseImpl()
     {
         TestArtifacts.SkipIfMissing();
+
+        var server = await _shared.GetAsync(ServerArgs());
 
         var scratch = NewScratch("layered");
         Guid baseId = Guid.NewGuid(), middleId = Guid.NewGuid(), testsId = Guid.NewGuid();
         var baseDir = Path.Combine(scratch, "base-app");
         var middleDir = Path.Combine(scratch, "middle-app");
         var testsDir = Path.Combine(scratch, "tests-app");
-        WriteBaseApp(baseDir, baseId);
-        WriteMiddleApp(middleDir, middleId, baseId);
-        WriteTestApp(testsDir, testsId, middleId);
+        WriteBaseApp(baseDir, baseId, " Chained");
+        WriteMiddleApp(middleDir, middleId, baseId, " Chained");
+        WriteTestApp(testsDir, testsId, middleId, " Chained");
 
-        var (output, exit) = RunRunner(scratch, baseDir, middleDir, testsDir);
+        var mark = server.StdErrMark;
+        var lines = await server.SendRequestStreamingAsync(
+            Req(baseDir, middleDir, testsDir), TimeSpan.FromSeconds(300));
+        var (_, summary) = ProtocolV2Streaming.Split(lines);
 
-        Assert.DoesNotContain("Dependency not found", output);
-        Assert.DoesNotContain("AL1022", output);
-        Assert.DoesNotContain("COMPILE-FAIL", output);
-        Assert.True(exit == 0 && output.Contains("3P/0F/0E"),
-            $"a three-deep source chain must compile and run (exit {exit}):\n{output}");
+        // The three CLI-era DoesNotContain checks ("Dependency not found", "AL1022",
+        // "COMPILE-FAIL") were three spellings of one claim: nothing failed to compile.
+        // The server states that claim directly, and states it about THIS request only.
+        var compileErrors = CompileErrorText(summary);
+        Assert.True(compileErrors.Length == 0,
+            $"a three-deep source chain must compile clean:\n{compileErrors}");
+        Assert.Equal(0, summary.GetProperty("exitCode").GetInt32());
+        Assert.Equal(3, summary.GetProperty("passed").GetInt32());
+        Assert.Equal(0, summary.GetProperty("failed").GetInt32());
+        Assert.Equal(0, summary.GetProperty("errors").GetInt32());
+
+        // Stronger than the CLI version, which never asserted the pre-pass ran at all:
+        // both impls must have been BUILT by it, so a green summary cannot come from the
+        // chain being resolved some other way.
+        var stderr = await server.StdErrSinceAsync(mark, PrePassTrailer);
+        Assert.Contains("LSC Chain Base Chained", stderr);
+        Assert.Contains("LSC Chain Middle Chained", stderr);
+        Assert.DoesNotContain("Dependency not found", stderr);
     }
 
     // ── Positive: BuildSiblingSourceDeps (one bundle argument, sibling sources) ─
@@ -300,10 +394,22 @@ public class LayeredSourceChainTests
         var baseDir = Path.Combine(scratch, "base-app");
         var middleDir = Path.Combine(scratch, "middle-app");
         var testsDir = Path.Combine(scratch, "tests-app");
-        WriteBaseApp(baseDir, baseId);
-        WriteMiddleApp(middleDir, middleId, baseId);
-        WriteTestApp(testsDir, testsId, middleId);
+        WriteBaseApp(baseDir, baseId, " Sibling");
+        WriteMiddleApp(middleDir, middleId, baseId, " Sibling");
+        WriteTestApp(testsDir, testsId, middleId, " Sibling");
 
+        // #2377: this fact deliberately keeps spawning the CLI while its two siblings
+        // above moved to the shared --server fixture. It is the ONE bundle case, and
+        // BuildSiblingSourceDeps — the pre-pass this fact exists to exercise — is not
+        // reached at all by a single-sourcePath server request: RunAllBundlesForServer
+        // puts BOTH pre-passes behind `if (sourcePaths.Length > 1)`, while the CLI gates
+        // only RunLayeredPrePass on bundle count and runs the sibling pre-pass
+        // unconditionally. Measured on the fixture shape below: the CLI exits 0, the
+        // identical single-bundle runTests request exits 3 with "DEP-RESOLVE-FAIL:
+        // Dependency not found". That divergence is a runner bug, tracked in #2380 — NOT
+        // a property of this test — so converting this fact would have replaced a claim
+        // about the sibling pre-pass with a claim about nothing. It stays slow and true
+        // until #2380 lands.
         // Only the TEST app is a bundle; the other two are siblings under the same parent.
         var (output, exit) = RunRunner(scratch, testsDir);
 
@@ -325,7 +431,7 @@ public class LayeredSourceChainTests
     /// with a silently missing dependency.
     /// </summary>
     [SkippableFact]
-    public void LayeredPrePass_BaseAppAbsent_FailsNamingTheMissingDependency()
+    public async Task LayeredPrePass_BaseAppAbsent_FailsNamingTheMissingDependency()
     {
         TestArtifacts.SkipIfMissing();
 
@@ -336,13 +442,20 @@ public class LayeredSourceChainTests
         var chainRoot = Path.Combine(scratch, "chain");
         var middleDir = Path.Combine(chainRoot, "middle-app");
         var testsDir = Path.Combine(chainRoot, "tests-app");
-        WriteMiddleApp(middleDir, middleId, baseId);
-        WriteTestApp(testsDir, testsId, middleId);
+        WriteMiddleApp(middleDir, middleId, baseId, " Absent");
+        WriteTestApp(testsDir, testsId, middleId, " Absent");
 
-        var (output, exit) = RunRunner(scratch, middleDir, testsDir);
+        var server = await _shared.GetAsync(ServerArgs());
+        var lines = await server.SendRequestStreamingAsync(
+            Req(middleDir, testsDir), TimeSpan.FromSeconds(300));
+        var (_, summary) = ProtocolV2Streaming.Split(lines);
 
-        Assert.NotEqual(0, exit);
-        Assert.Contains("LSC Chain Base", output);
-        Assert.Contains("Dependency not found", output);
+        Assert.NotEqual(0, summary.GetProperty("exitCode").GetInt32());
+        // The layered pre-pass's failure reaches a server client as a compilationErrors
+        // group (LAYERED-PREPASS-FAIL), which is where the naming has to survive — an
+        // editor never sees the CLI's console text.
+        var compileErrors = CompileErrorText(summary);
+        Assert.True(compileErrors.Contains("LSC Chain Base Absent") && compileErrors.Contains("Dependency not found"),
+            $"the failure must name the dependency it could not find:\n{compileErrors}");
     }
 }

--- a/AlRunner.Tests/LayeredSourceChainTests.cs
+++ b/AlRunner.Tests/LayeredSourceChainTests.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using System.Text;
-using System.Text.Json;
 using Xunit;
 
 namespace AlRunner.Tests;
@@ -36,73 +35,31 @@ namespace AlRunner.Tests;
 /// the runner's OWN workspace dirs, not about artifact provisioning.
 ///
 /// Spawns the real runner; needs the BC artifact cache. Skips (visibly) when absent.
+///
+/// #2377: MEASURED and left spawning. Two of the three facts below could technically be
+/// served by a shared --server fixture, and converting them made the class SLOWER —
+/// 128.8s -> 139.9s of per-test time in a back-to-back matched pair. A warm server only
+/// pays for itself when a class issues SEVERAL expensive requests against one BC boot
+/// (LayeredCacheTests: 150.6s -> 28.9s, two expensive runs collapsing onto one boot).
+/// Here exactly one fact is expensive; the negative fact costs 5s because it dies in
+/// dependency resolution before BC boots at all; and the sibling-source fact CANNOT move
+/// (see below). So the conversion added a whole second BC boot to a class that still had
+/// to spawn a CLI anyway, and bought back 5 seconds.
+///
+/// The sibling-source fact is stuck for a different reason worth knowing about:
+/// RunAllBundlesForServer puts BOTH source pre-passes behind `if (sourcePaths.Length > 1)`,
+/// while the CLI gates only RunLayeredPrePass on bundle count and runs
+/// BuildSiblingSourceDeps unconditionally. Measured on this fixture's shape: the CLI exits
+/// 0, the identical single-bundle runTests request exits 3 with "DEP-RESOLVE-FAIL:
+/// Dependency not found". That is a runner bug (tracked in #2380), not a property of this
+/// test — a --server client such as the VS Code extension, which sends one bundle at a
+/// time, cannot resolve a sibling source dependency at all today.
 /// </summary>
-public class LayeredSourceChainTests : IClassFixture<SharedCliServer>
+public class LayeredSourceChainTests
 {
     private static readonly string RepoRoot = Path.GetFullPath(
         Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
     private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
-
-    private readonly SharedCliServer _shared;
-
-    public LayeredSourceChainTests(SharedCliServer shared) => _shared = shared;
-
-    /// <summary>
-    /// #2377: the one `--cache` dir this class's shared server is started with. The CLI
-    /// version gave each fact its own; a fresh GUID per test RUN preserves what that was
-    /// actually for (no workspace-deps or al-out entry from an earlier invocation may
-    /// answer for this one), and the facts cannot answer for EACH OTHER inside it because
-    /// every fixture below already writes fresh GUID app ids per fact — see the "Fixture
-    /// writers" note.
-    /// </summary>
-    private static readonly string CacheDir = Path.Combine(
-        Path.GetTempPath(), "al-runner-layered-chain", "shared-cache", Guid.NewGuid().ToString("N"), "al-out");
-
-    /// <summary>Emitted by the layered pre-pass after every per-impl WROTE/HIT line — the
-    /// synchronisation anchor for reading a request's own stderr slice. See
-    /// <see cref="CliServer.StdErrSinceAsync"/> for why an anchor is required.</summary>
-    private const string PrePassTrailer = "[layered] pre-built";
-
-    private static IEnumerable<string> ServerArgs()
-    {
-        yield return "--cache";
-        yield return CacheDir;
-        var platformApps = TestArtifacts.PlatformAppsDir();
-        if (Directory.Exists(platformApps))
-        {
-            yield return "--package-cache";
-            yield return platformApps;
-        }
-    }
-
-    private static string Req(params string[] bundles)
-        => JsonSerializer.Serialize(new
-        {
-            command = "runTests",
-            sourcePaths = bundles,
-            packagePaths = Array.Empty<string>(),
-        });
-
-    /// <summary>
-    /// The summary line's compile errors as one string — the server's equivalent of the
-    /// CLI console text these tests used to substring-match. EMIT-EXCLUDED, EMIT-ZERO,
-    /// COMPILE-FAIL, DEP-RESOLVE-FAIL, LAYERED-PREPASS-FAIL and BC's own AL diagnostics
-    /// all arrive here (see RunBundleForServer / RunAllBundlesForServer), so asserting on
-    /// it is a strictly narrower claim than matching the whole console dump was.
-    /// </summary>
-    private static string CompileErrorText(JsonElement summary)
-    {
-        if (!summary.TryGetProperty("compilationErrors", out var ce) || ce.ValueKind != JsonValueKind.Array)
-            return string.Empty;
-        var sb = new StringBuilder();
-        foreach (var group in ce.EnumerateArray())
-        {
-            if (group.TryGetProperty("file", out var f)) sb.AppendLine(f.GetString());
-            if (group.TryGetProperty("errors", out var errs) && errs.ValueKind == JsonValueKind.Array)
-                foreach (var e in errs.EnumerateArray()) sb.AppendLine(e.GetString());
-        }
-        return sb.ToString();
-    }
 
     // ── Fixture writers ────────────────────────────────────────────────────────
     // One chain, written three times into different layouts so each pre-pass sees the
@@ -110,27 +67,13 @@ public class LayeredSourceChainTests : IClassFixture<SharedCliServer>
     // own idRanges) and the app ids are fresh GUIDs per run, so no workspace-deps /
     // compiled-deps / al-out cache from a previous run can answer for any of them.
 
-    /// <param name="suffix">
-    /// #2377: a per-FACT tag folded into the app NAME. Distinct app ids are not enough
-    /// once these facts share one server process. Dependency resolution matches on
-    /// name/publisher/version, and RunAllBundlesForServer ACCUMULATES each request's
-    /// layered workspace dirs into the server-level packageCacheDirs — so the base app
-    /// this class builds in one fact stays in the search set for every later fact.
-    /// Measured: with a shared name, LayeredPrePass_BaseAppAbsent_… stopped failing for
-    /// its own reason (it passed alone and failed in-class in 67ms), because a base app
-    /// it declares to be ABSENT was still resolvable from the earlier fact's workspace.
-    /// A per-fact name is what makes "genuinely absent" true again.
-    /// AL object names and ids are deliberately NOT varied: only the positive fact ever
-    /// reaches a compile at all (the negative one dies in dep resolution), and the
-    /// spawning fact runs in its own process.
-    /// </param>
-    private static void WriteBaseApp(string dir, Guid baseId, string suffix)
+    private static void WriteBaseApp(string dir, Guid baseId)
     {
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
         {
           "id": "{{baseId}}",
-          "name": "LSC Chain Base{{suffix}}",
+          "name": "LSC Chain Base",
           "publisher": "AL Runner",
           "version": "1.0.0.0",
           "dependencies": [],
@@ -172,17 +115,17 @@ public class LayeredSourceChainTests : IClassFixture<SharedCliServer>
         """);
     }
 
-    private static void WriteMiddleApp(string dir, Guid middleId, Guid baseId, string suffix)
+    private static void WriteMiddleApp(string dir, Guid middleId, Guid baseId)
     {
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
         {
           "id": "{{middleId}}",
-          "name": "LSC Chain Middle{{suffix}}",
+          "name": "LSC Chain Middle",
           "publisher": "AL Runner",
           "version": "1.0.0.0",
           "dependencies": [
-            { "id": "{{baseId}}", "name": "LSC Chain Base{{suffix}}", "publisher": "AL Runner", "version": "1.0.0.0" }
+            { "id": "{{baseId}}", "name": "LSC Chain Base", "publisher": "AL Runner", "version": "1.0.0.0" }
           ],
           "platform": "1.0.0.0",
           "application": "1.0.0.0",
@@ -227,17 +170,17 @@ public class LayeredSourceChainTests : IClassFixture<SharedCliServer>
         """);
     }
 
-    private static void WriteTestApp(string dir, Guid testsId, Guid middleId, string suffix)
+    private static void WriteTestApp(string dir, Guid testsId, Guid middleId)
     {
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
         {
           "id": "{{testsId}}",
-          "name": "LSC Chain Test{{suffix}}",
+          "name": "LSC Chain Test",
           "publisher": "AL Runner",
           "version": "1.0.0.0",
           "dependencies": [
-            { "id": "{{middleId}}", "name": "LSC Chain Middle{{suffix}}", "publisher": "AL Runner", "version": "1.0.0.0" }
+            { "id": "{{middleId}}", "name": "LSC Chain Middle", "publisher": "AL Runner", "version": "1.0.0.0" }
           ],
           "platform": "1.0.0.0",
           "application": "1.0.0.0",
@@ -333,44 +276,26 @@ public class LayeredSourceChainTests : IClassFixture<SharedCliServer>
     /// "Dependency not found: AL Runner/LSC Chain Base".
     /// </summary>
     [SkippableFact]
-    public async Task LayeredPrePass_ThreeSourceBundles_MiddleImplResolvesTheBaseImpl()
+    public void LayeredPrePass_ThreeSourceBundles_MiddleImplResolvesTheBaseImpl()
     {
         TestArtifacts.SkipIfMissing();
-
-        var server = await _shared.GetAsync(ServerArgs());
 
         var scratch = NewScratch("layered");
         Guid baseId = Guid.NewGuid(), middleId = Guid.NewGuid(), testsId = Guid.NewGuid();
         var baseDir = Path.Combine(scratch, "base-app");
         var middleDir = Path.Combine(scratch, "middle-app");
         var testsDir = Path.Combine(scratch, "tests-app");
-        WriteBaseApp(baseDir, baseId, " Chained");
-        WriteMiddleApp(middleDir, middleId, baseId, " Chained");
-        WriteTestApp(testsDir, testsId, middleId, " Chained");
+        WriteBaseApp(baseDir, baseId);
+        WriteMiddleApp(middleDir, middleId, baseId);
+        WriteTestApp(testsDir, testsId, middleId);
 
-        var mark = server.StdErrMark;
-        var lines = await server.SendRequestStreamingAsync(
-            Req(baseDir, middleDir, testsDir), TimeSpan.FromSeconds(300));
-        var (_, summary) = ProtocolV2Streaming.Split(lines);
+        var (output, exit) = RunRunner(scratch, baseDir, middleDir, testsDir);
 
-        // The three CLI-era DoesNotContain checks ("Dependency not found", "AL1022",
-        // "COMPILE-FAIL") were three spellings of one claim: nothing failed to compile.
-        // The server states that claim directly, and states it about THIS request only.
-        var compileErrors = CompileErrorText(summary);
-        Assert.True(compileErrors.Length == 0,
-            $"a three-deep source chain must compile clean:\n{compileErrors}");
-        Assert.Equal(0, summary.GetProperty("exitCode").GetInt32());
-        Assert.Equal(3, summary.GetProperty("passed").GetInt32());
-        Assert.Equal(0, summary.GetProperty("failed").GetInt32());
-        Assert.Equal(0, summary.GetProperty("errors").GetInt32());
-
-        // Stronger than the CLI version, which never asserted the pre-pass ran at all:
-        // both impls must have been BUILT by it, so a green summary cannot come from the
-        // chain being resolved some other way.
-        var stderr = await server.StdErrSinceAsync(mark, PrePassTrailer);
-        Assert.Contains("LSC Chain Base Chained", stderr);
-        Assert.Contains("LSC Chain Middle Chained", stderr);
-        Assert.DoesNotContain("Dependency not found", stderr);
+        Assert.DoesNotContain("Dependency not found", output);
+        Assert.DoesNotContain("AL1022", output);
+        Assert.DoesNotContain("COMPILE-FAIL", output);
+        Assert.True(exit == 0 && output.Contains("3P/0F/0E"),
+            $"a three-deep source chain must compile and run (exit {exit}):\n{output}");
     }
 
     // ── Positive: BuildSiblingSourceDeps (one bundle argument, sibling sources) ─
@@ -394,22 +319,10 @@ public class LayeredSourceChainTests : IClassFixture<SharedCliServer>
         var baseDir = Path.Combine(scratch, "base-app");
         var middleDir = Path.Combine(scratch, "middle-app");
         var testsDir = Path.Combine(scratch, "tests-app");
-        WriteBaseApp(baseDir, baseId, " Sibling");
-        WriteMiddleApp(middleDir, middleId, baseId, " Sibling");
-        WriteTestApp(testsDir, testsId, middleId, " Sibling");
+        WriteBaseApp(baseDir, baseId);
+        WriteMiddleApp(middleDir, middleId, baseId);
+        WriteTestApp(testsDir, testsId, middleId);
 
-        // #2377: this fact deliberately keeps spawning the CLI while its two siblings
-        // above moved to the shared --server fixture. It is the ONE bundle case, and
-        // BuildSiblingSourceDeps — the pre-pass this fact exists to exercise — is not
-        // reached at all by a single-sourcePath server request: RunAllBundlesForServer
-        // puts BOTH pre-passes behind `if (sourcePaths.Length > 1)`, while the CLI gates
-        // only RunLayeredPrePass on bundle count and runs the sibling pre-pass
-        // unconditionally. Measured on the fixture shape below: the CLI exits 0, the
-        // identical single-bundle runTests request exits 3 with "DEP-RESOLVE-FAIL:
-        // Dependency not found". That divergence is a runner bug, tracked in #2380 — NOT
-        // a property of this test — so converting this fact would have replaced a claim
-        // about the sibling pre-pass with a claim about nothing. It stays slow and true
-        // until #2380 lands.
         // Only the TEST app is a bundle; the other two are siblings under the same parent.
         var (output, exit) = RunRunner(scratch, testsDir);
 
@@ -431,7 +344,7 @@ public class LayeredSourceChainTests : IClassFixture<SharedCliServer>
     /// with a silently missing dependency.
     /// </summary>
     [SkippableFact]
-    public async Task LayeredPrePass_BaseAppAbsent_FailsNamingTheMissingDependency()
+    public void LayeredPrePass_BaseAppAbsent_FailsNamingTheMissingDependency()
     {
         TestArtifacts.SkipIfMissing();
 
@@ -442,20 +355,13 @@ public class LayeredSourceChainTests : IClassFixture<SharedCliServer>
         var chainRoot = Path.Combine(scratch, "chain");
         var middleDir = Path.Combine(chainRoot, "middle-app");
         var testsDir = Path.Combine(chainRoot, "tests-app");
-        WriteMiddleApp(middleDir, middleId, baseId, " Absent");
-        WriteTestApp(testsDir, testsId, middleId, " Absent");
+        WriteMiddleApp(middleDir, middleId, baseId);
+        WriteTestApp(testsDir, testsId, middleId);
 
-        var server = await _shared.GetAsync(ServerArgs());
-        var lines = await server.SendRequestStreamingAsync(
-            Req(middleDir, testsDir), TimeSpan.FromSeconds(300));
-        var (_, summary) = ProtocolV2Streaming.Split(lines);
+        var (output, exit) = RunRunner(scratch, middleDir, testsDir);
 
-        Assert.NotEqual(0, summary.GetProperty("exitCode").GetInt32());
-        // The layered pre-pass's failure reaches a server client as a compilationErrors
-        // group (LAYERED-PREPASS-FAIL), which is where the naming has to survive — an
-        // editor never sees the CLI's console text.
-        var compileErrors = CompileErrorText(summary);
-        Assert.True(compileErrors.Contains("LSC Chain Base Absent") && compileErrors.Contains("Dependency not found"),
-            $"the failure must name the dependency it could not find:\n{compileErrors}");
+        Assert.NotEqual(0, exit);
+        Assert.Contains("LSC Chain Base", output);
+        Assert.Contains("Dependency not found", output);
     }
 }

--- a/AlRunner.Tests/ManifestFeaturesSubprocessTests.cs
+++ b/AlRunner.Tests/ManifestFeaturesSubprocessTests.cs
@@ -24,22 +24,80 @@
 
 using System.Diagnostics;
 using System.Text;
+using System.Text.Json;
 using Xunit;
 
 namespace AlRunner.Tests;
 
-public sealed class ManifestFeaturesSubprocessTests : IDisposable
+public sealed class ManifestFeaturesSubprocessTests : IClassFixture<SharedCliServer>, IDisposable
 {
     private static readonly string RepoRoot = Path.GetFullPath(
         Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
     private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
 
     private readonly string _root;
+    private readonly SharedCliServer _shared;
 
-    public ManifestFeaturesSubprocessTests()
+    public ManifestFeaturesSubprocessTests(SharedCliServer shared)
     {
+        _shared = shared;
         _root = Path.Combine(Path.GetTempPath(), "al-runner-manifest-features-subprocess", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_root);
+    }
+
+    /// <summary>#2377: the one `--cache` dir this class's shared server is started with,
+    /// fresh per test run so nothing an earlier invocation cached can answer here.</summary>
+    private static readonly string CacheDir = Path.Combine(
+        Path.GetTempPath(), "al-runner-manifest-features-cache", Guid.NewGuid().ToString("N"));
+
+    private static IEnumerable<string> ServerArgs()
+    {
+        yield return "--cache";
+        yield return CacheDir;
+        foreach (var a in ExtraPackageCacheArgs()) yield return a;
+    }
+
+    /// <summary>
+    /// The same two env vars <see cref="RunRunner"/> sets on its spawn, hoisted to the
+    /// server process (SharedCliServer applies them on the spawning call only). They
+    /// widen what the runner REPORTS about an emit-retry exclusion — without them the
+    /// EMIT-EXCLUDED payload names only the excluded OBJECT and never the AL0129/AL0135
+    /// diagnostics that identified it — and change nothing about what it compiles, so
+    /// they are safe to apply to every fact in the class rather than per request.
+    /// </summary>
+    private static readonly Dictionary<string, string> DiagEnv = new()
+    {
+        ["AL_RUNNER_DIAG_EMITRETRY"] = "1",
+        ["BCCOMPILER_DIAG"] = "1",
+    };
+
+    private static string Req(params string[] bundles)
+        => JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            sourcePaths = bundles,
+            packagePaths = Array.Empty<string>(),
+        });
+
+    /// <summary>
+    /// The summary line's compile errors as one string. This is where the server surfaces
+    /// EMIT-EXCLUDED, EMIT-ZERO, COMPILE-FAIL, LAYERED-PREPASS-FAIL and BC's own AL
+    /// diagnostics (RunBundleForServer / RunAllBundlesForServer) — i.e. every string the
+    /// CLI-spawning version of these facts used to look for in the console dump, but
+    /// scoped to THIS request and carried by the protocol rather than scraped.
+    /// </summary>
+    private static string CompileErrorText(JsonElement summary)
+    {
+        if (!summary.TryGetProperty("compilationErrors", out var ce) || ce.ValueKind != JsonValueKind.Array)
+            return string.Empty;
+        var sb = new StringBuilder();
+        foreach (var group in ce.EnumerateArray())
+        {
+            if (group.TryGetProperty("file", out var f)) sb.AppendLine(f.GetString());
+            if (group.TryGetProperty("errors", out var errs) && errs.ValueKind == JsonValueKind.Array)
+                foreach (var e in errs.EnumerateArray()) sb.AppendLine(e.GetString());
+        }
+        return sb.ToString();
     }
 
     public void Dispose()
@@ -104,14 +162,27 @@ public sealed class ManifestFeaturesSubprocessTests : IDisposable
     // trigger that BC's implicit-with binder resolves against the SourceTable record's own
     // same-named members instead of the page's own local var/procedure, UNLESS
     // NoImplicitWith is on.
+    /// <param name="tag">
+    /// #2377: a per-FACT tag folded into the app name AND the AL object names. Fresh GUID
+    /// app ids alone are not enough once these facts share one server process: dependency
+    /// resolution matches on name/publisher/version and RunAllBundlesForServer accumulates
+    /// each request's layered workspace dirs into the server-level packageCacheDirs, so an
+    /// app one fact built stays resolvable by name for every later fact. AL object names
+    /// matter for the same reason one layer down — AL resolves by name, .NET cannot unload
+    /// an assembly, and three facts compiling three same-named "MFS NIW Table"s into one
+    /// process is ambiguity fed straight into the resolution the runner has to get right.
+    /// The measured cost of getting this wrong is not a crash: LayeredSourceChainTests'
+    /// absent-dependency fact silently stopped failing for its own reason when a sibling
+    /// fact's identically-named app was still in the search set.
+    /// </param>
     private static void WriteNoImplicitWithFixture(
-        string dir, int tableId, int pageId, string featuresLine, string? appId = null)
+        string dir, int tableId, int pageId, string featuresLine, string tag, string? appId = null)
     {
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
         {
           "id": "{{appId ?? Guid.NewGuid().ToString()}}",
-          "name": "MFS Repro App",
+          "name": "MFS Repro App {{tag}}",
           "publisher": "AL Runner",
           "version": "1.0.0.0",
           "dependencies": [],
@@ -122,7 +193,7 @@ public sealed class ManifestFeaturesSubprocessTests : IDisposable
         }
         """);
         File.WriteAllText(Path.Combine(dir, "Niw.Table.al"), $$"""
-        table {{tableId}} "MFS NIW Table"
+        table {{tableId}} "MFS NIW Table {{tag}}"
         {
             DataClassification = CustomerContent;
 
@@ -144,12 +215,12 @@ public sealed class ManifestFeaturesSubprocessTests : IDisposable
         }
         """);
         File.WriteAllText(Path.Combine(dir, "Niw.Page.al"), $$"""
-        page {{pageId}} "MFS NIW Page"
+        page {{pageId}} "MFS NIW Page {{tag}}"
         {
             PageType = Card;
             ApplicationArea = All;
             UsageCategory = Administration;
-            SourceTable = "MFS NIW Table";
+            SourceTable = "MFS NIW Table {{tag}}";
 
             layout
             {
@@ -182,42 +253,53 @@ public sealed class ManifestFeaturesSubprocessTests : IDisposable
     // ── Top-level bundle (BcCompiler.Emit) ────────────────────────────────────────────
 
     [SkippableFact]
-    public void TopLevel_ManifestDeclaresNoImplicitWith_CompilesCleanly()
+    public async Task TopLevel_ManifestDeclaresNoImplicitWith_CompilesCleanly()
     {
         TestArtifacts.SkipIfMissing();
-        WriteNoImplicitWithFixture(_root, 61060, 61061, ",\n  \"features\": [ \"NoImplicitWith\" ]");
+        WriteNoImplicitWithFixture(_root, 61060, 61061, ",\n  \"features\": [ \"NoImplicitWith\" ]", "TLPos");
 
-        var (output, exit) = RunRunner(_root);
+        var server = await _shared.GetAsync(ServerArgs(), DiagEnv);
+        var lines = await server.SendRequestStreamingAsync(Req(_root), TimeSpan.FromSeconds(300));
+        var (_, summary) = ProtocolV2Streaming.Split(lines);
 
-        Assert.DoesNotContain("AL0129", output);
-        Assert.DoesNotContain("AL0135", output);
-        Assert.DoesNotContain("EMIT-EXCLUDED", output);
-        Assert.Equal(0, exit);
+        var compileErrors = CompileErrorText(summary);
+        Assert.DoesNotContain("AL0129", compileErrors);
+        Assert.DoesNotContain("AL0135", compileErrors);
+        Assert.DoesNotContain("EMIT-EXCLUDED", compileErrors);
+        Assert.Equal(0, summary.GetProperty("exitCode").GetInt32());
     }
 
     [SkippableFact]
-    public void TopLevel_ManifestOmitsFeatures_SameAlStillFailsAL0129AL0135()
+    public async Task TopLevel_ManifestOmitsFeatures_SameAlStillFailsAL0129AL0135()
     {
         TestArtifacts.SkipIfMissing();
-        WriteNoImplicitWithFixture(_root, 61070, 61071, "");
+        WriteNoImplicitWithFixture(_root, 61070, 61071, "", "TLNeg");
 
-        var (output, exit) = RunRunner(_root);
+        var server = await _shared.GetAsync(ServerArgs(), DiagEnv);
+        var lines = await server.SendRequestStreamingAsync(Req(_root), TimeSpan.FromSeconds(300));
+        var (_, summary) = ProtocolV2Streaming.Split(lines);
 
-        Assert.Contains("AL0129", output);
-        Assert.Contains("AL0135", output);
-        Assert.Contains("EMIT-EXCLUDED", output);
-        Assert.Equal(3, exit);
+        // The server has its OWN EMIT-EXCLUDED guard (Program.cs, RunBundleForServer —
+        // added by #2152 precisely because the server path used to run the surviving
+        // objects and report exitCode 0 with a whole test codeunit missing), so this is
+        // the same claim asserted against the code path an editor integration actually
+        // drives, not a weaker restatement of the CLI one.
+        var compileErrors = CompileErrorText(summary);
+        Assert.Contains("AL0129", compileErrors);
+        Assert.Contains("AL0135", compileErrors);
+        Assert.Contains("EMIT-EXCLUDED", compileErrors);
+        Assert.Equal(3, summary.GetProperty("exitCode").GetInt32());
     }
 
     // ── Source dependency (BcCompiler.EmitDepSymbols via the layered pre-pass) ───────
 
-    private static void WriteMainDependingOn(string dir, string depId, string depName, int idFrom)
+    private static void WriteMainDependingOn(string dir, string depId, string depName, int idFrom, string tag)
     {
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
         {
           "id": "{{Guid.NewGuid()}}",
-          "name": "MFS Main App",
+          "name": "MFS Main App {{tag}}",
           "publisher": "AL Runner",
           "version": "1.0.0.0",
           "dependencies": [
@@ -230,7 +312,7 @@ public sealed class ManifestFeaturesSubprocessTests : IDisposable
         }
         """);
         File.WriteAllText(Path.Combine(dir, "Tests.Codeunit.al"), $$"""
-        codeunit {{idFrom}} "MFS Main Tests"
+        codeunit {{idFrom}} "MFS Main Tests {{tag}}"
         {
             Subtype = Test;
 
@@ -245,24 +327,33 @@ public sealed class ManifestFeaturesSubprocessTests : IDisposable
     }
 
     [SkippableFact]
-    public void SourceDependency_ManifestDeclaresNoImplicitWith_CompilesCleanly_BothBundlesRun()
+    public async Task SourceDependency_ManifestDeclaresNoImplicitWith_CompilesCleanly_BothBundlesRun()
     {
         TestArtifacts.SkipIfMissing();
 
         var depDir = Path.Combine(_root, "dep");
         var mainDir = Path.Combine(_root, "main");
         var depId = Guid.NewGuid().ToString();
-        WriteNoImplicitWithFixture(depDir, 61080, 61081, ",\n  \"features\": [ \"NoImplicitWith\" ]", depId);
-        WriteMainDependingOn(mainDir, depId, "MFS Repro App", 61090);
+        WriteNoImplicitWithFixture(depDir, 61080, 61081, ",\n  \"features\": [ \"NoImplicitWith\" ]", "DepPos", depId);
+        WriteMainDependingOn(mainDir, depId, "MFS Repro App DepPos", 61090, "DepPos");
 
-        var (output, exit) = RunRunner(depDir, mainDir);
+        var server = await _shared.GetAsync(ServerArgs(), DiagEnv);
+        var mark = server.StdErrMark;
+        var lines = await server.SendRequestStreamingAsync(Req(depDir, mainDir), TimeSpan.FromSeconds(300));
+        var (_, summary) = ProtocolV2Streaming.Split(lines);
 
-        Assert.Contains("[layered]", output);
-        Assert.DoesNotContain("AL0129", output);
-        Assert.DoesNotContain("AL0135", output);
-        Assert.DoesNotContain("Unhandled exception", output);
-        Assert.True(exit == 0 && output.Contains("1P/0F/0E"),
-            $"a dependency whose manifest genuinely declares NoImplicitWith must compile and run (exit {exit}):\n{output}");
+        var compileErrors = CompileErrorText(summary);
+        Assert.DoesNotContain("AL0129", compileErrors);
+        Assert.DoesNotContain("AL0135", compileErrors);
+        Assert.Equal(0, summary.GetProperty("exitCode").GetInt32());
+        Assert.Equal(1, summary.GetProperty("passed").GetInt32());
+        Assert.Equal(0, summary.GetProperty("failed").GetInt32());
+        Assert.Equal(0, summary.GetProperty("errors").GetInt32());
+
+        // Precondition: this really took the layered two-bundle source-dependency path,
+        // not a degenerate single-bundle one.
+        var stderr = await server.StdErrSinceAsync(mark, "[layered] pre-built");
+        Assert.Contains("MFS Repro App DepPos", stderr);
     }
 
     [SkippableFact]
@@ -273,9 +364,19 @@ public sealed class ManifestFeaturesSubprocessTests : IDisposable
         var depDir = Path.Combine(_root, "dep");
         var mainDir = Path.Combine(_root, "main");
         var depId = Guid.NewGuid().ToString();
-        WriteNoImplicitWithFixture(depDir, 61100, 61101, "", depId);
-        WriteMainDependingOn(mainDir, depId, "MFS Repro App", 61110);
+        WriteNoImplicitWithFixture(depDir, 61100, 61101, "", "DepNeg", depId);
+        WriteMainDependingOn(mainDir, depId, "MFS Repro App DepNeg", 61110, "DepNeg");
 
+        // #2377: NOT converted to the shared server, unlike the three facts above. Its
+        // decisive assertion is "Unhandled exception" being ABSENT — i.e. that a dep whose
+        // manifest is genuinely invalid produces a formatted exit 3 rather than the CLR's
+        // default handler aborting the PROCESS with exit 134, which is what #1898 fixed.
+        // That is a claim about the CLI's own Main-level exception handling, and it can
+        // only be observed by watching a process exit. RunAllBundlesForServer wraps the
+        // same pre-pass in its own try/catch, so a server request cannot reach the code
+        // path this fact exists to hold down — converting it would trade a true slow test
+        // for a fast one asserting something else. Same reasoning keeps all of
+        // LayeredDepManifestTests spawning.
         var (output, exit) = RunRunner(depDir, mainDir);
 
         Assert.Contains("AL0129", output);

--- a/AlRunner.Tests/ServerCrossAppStaleGenerationTests.cs
+++ b/AlRunner.Tests/ServerCrossAppStaleGenerationTests.cs
@@ -57,9 +57,37 @@ namespace AlRunner.Tests;
 /// Spawns the real runner in --server mode; needs the BC artifact cache. Skips
 /// (no-op) when absent.
 /// </summary>
-public class ServerCrossAppStaleGenerationTests
+public class ServerCrossAppStaleGenerationTests : IClassFixture<SharedCliServer>
 {
-    private static (string libDir, string testDir, string answerFile) MakeLibTestPair(string rootName)
+    private readonly SharedCliServer _shared;
+
+    public ServerCrossAppStaleGenerationTests(SharedCliServer shared) => _shared = shared;
+
+    /// <summary>
+    /// The one `--cache` dir this class's server is started with (#2377). Both facts used
+    /// to build their own; a fresh GUID per test RUN keeps the "no cache from a previous
+    /// invocation can answer for this one" guarantee that mattered, and the two facts
+    /// cannot collide inside it because <see cref="MakeLibTestPair"/> now gives each
+    /// variant its own app ids, object ids and object names (see below).
+    /// </summary>
+    private static readonly string CacheDir = Path.Combine(
+        Path.GetTempPath(), "al-runner-xapp-stale-gen-cache", Guid.NewGuid().ToString("N"));
+
+    /// <param name="variant">
+    /// #2377: which fact is asking. Not cosmetic — it is what makes sharing one server
+    /// SOUND. <c>DependencyLoader.TryGetByAppId</c> caches a compiled module by AppId for
+    /// the lifetime of the server PROCESS and hands it back for any later request whose
+    /// bundle declares a MATCHING AppId at a DIFFERENT SourcePath. Both facts used to
+    /// write the same hardcoded ids under different temp roots, so on a shared server the
+    /// second fact would have been served the first fact's already-compiled modules and
+    /// never produced the two distinct generations its claim is entirely about — it would
+    /// have gone green having proven nothing. Object ids and object NAMES are varied for
+    /// the same reason one layer down: AL resolves by name, and this class's subject is
+    /// precisely which resident generation a by-name/by-id lookup binds to, so two facts
+    /// sharing a name would be feeding ambiguity into the mechanism under test.
+    /// </param>
+    private static (string libDir, string testDir, string answerFile) MakeLibTestPair(
+        string rootName, int variant)
     {
         var root = Path.Combine(Path.GetTempPath(), rootName, Guid.NewGuid().ToString("N"));
         var libDir = Path.Combine(root, "Lib");
@@ -67,24 +95,28 @@ public class ServerCrossAppStaleGenerationTests
         Directory.CreateDirectory(libDir);
         Directory.CreateDirectory(testDir);
 
-        const string libId = "d1a2b3c4-d5e6-4f70-8a91-b2c3d4e5f701";
+        var sfx = variant == 0 ? string.Empty : $" V{variant + 1}";
+        var libFrom = 60960 - variant * 20;   // v0: 60960-60969, v1: 60940-60949
+        var testFrom = 60970 - variant * 20;  // v0: 60970-60979, v1: 60950-60959
+        var libId = $"d1a2b3c4-d5e6-4f70-8a91-b2c3d4e5f7{variant + 1:D2}";
+        var testId = $"d1a2b3c4-d5e6-4f70-8a91-b2c3d4e5f8{variant + 1:D2}";
 
         File.WriteAllText(Path.Combine(libDir, "app.json"), $$"""
         {
           "id": "{{libId}}",
-          "name": "WS Lib",
+          "name": "WS Lib{{sfx}}",
           "publisher": "AL Runner Repro",
           "version": "1.0.0.0",
           "dependencies": [],
-          "idRanges": [ { "from": 60960, "to": 60969 } ],
+          "idRanges": [ { "from": {{libFrom}}, "to": {{libFrom + 9}} } ],
           "platform": "1.0.0.0",
           "application": "1.0.0.0",
           "runtime": "14.0"
         }
         """);
         var answerFile = Path.Combine(libDir, "Answer.Codeunit.al");
-        File.WriteAllText(answerFile, """
-        codeunit 60960 "WS Answer"
+        File.WriteAllText(answerFile, $$"""
+        codeunit {{libFrom}} "WS Answer{{sfx}}"
         {
             procedure Answer(): Integer
             begin
@@ -92,8 +124,8 @@ public class ServerCrossAppStaleGenerationTests
             end;
         }
         """);
-        File.WriteAllText(Path.Combine(libDir, "FireEvent.Codeunit.al"), """
-        codeunit 60963 "WS Fire Event"
+        File.WriteAllText(Path.Combine(libDir, "FireEvent.Codeunit.al"), $$"""
+        codeunit {{libFrom + 3}} "WS Fire Event{{sfx}}"
         {
             [IntegrationEvent(false, false)]
             local procedure OnFire(var FireCount: Integer)
@@ -106,9 +138,9 @@ public class ServerCrossAppStaleGenerationTests
             end;
         }
 
-        codeunit 60964 "WS Fire Sub"
+        codeunit {{libFrom + 4}} "WS Fire Sub{{sfx}}"
         {
-            [EventSubscriber(ObjectType::Codeunit, Codeunit::"WS Fire Event", 'OnFire', '', false, false)]
+            [EventSubscriber(ObjectType::Codeunit, Codeunit::"WS Fire Event{{sfx}}", 'OnFire', '', false, false)]
             local procedure OnFireHandler(var FireCount: Integer)
             begin
                 FireCount += 1;
@@ -118,28 +150,28 @@ public class ServerCrossAppStaleGenerationTests
 
         File.WriteAllText(Path.Combine(testDir, "app.json"), $$"""
         {
-          "id": "d1a2b3c4-d5e6-4f70-8a91-b2c3d4e5f702",
-          "name": "WS Test",
+          "id": "{{testId}}",
+          "name": "WS Test{{sfx}}",
           "publisher": "AL Runner Repro",
           "version": "1.0.0.0",
           "dependencies": [
-            { "id": "{{libId}}", "name": "WS Lib", "publisher": "AL Runner Repro", "version": "1.0.0.0" }
+            { "id": "{{libId}}", "name": "WS Lib{{sfx}}", "publisher": "AL Runner Repro", "version": "1.0.0.0" }
           ],
-          "idRanges": [ { "from": 60970, "to": 60979 } ],
+          "idRanges": [ { "from": {{testFrom}}, "to": {{testFrom + 9}} } ],
           "platform": "1.0.0.0",
           "application": "1.0.0.0",
           "runtime": "14.0"
         }
         """);
-        File.WriteAllText(Path.Combine(testDir, "WsTests.Codeunit.al"), """
-        codeunit 60970 "WS Tests"
+        File.WriteAllText(Path.Combine(testDir, "WsTests.Codeunit.al"), $$"""
+        codeunit {{testFrom}} "WS Tests{{sfx}}"
         {
             Subtype = Test;
 
             [Test]
             procedure LibAnswer_Is42()
             var
-                Ans: Codeunit "WS Answer";
+                Ans: Codeunit "WS Answer{{sfx}}";
                 Actual: Integer;
             begin
                 Actual := Ans.Answer();
@@ -148,14 +180,14 @@ public class ServerCrossAppStaleGenerationTests
             end;
         }
 
-        codeunit 60971 "WS Sub Test"
+        codeunit {{testFrom + 1}} "WS Sub Test{{sfx}}"
         {
             Subtype = Test;
 
             [Test]
             procedure Fire_SubscriberFiresExactlyOnce()
             var
-                FireEvt: Codeunit "WS Fire Event";
+                FireEvt: Codeunit "WS Fire Event{{sfx}}";
                 Count: Integer;
             begin
                 Count := 0;
@@ -177,14 +209,34 @@ public class ServerCrossAppStaleGenerationTests
             packagePaths = Array.Empty<string>(),
         });
 
+    /// <summary>
+    /// #2377 guard on the shared-server conversion itself: cycle 2 must report the edited
+    /// file in the summary's `changedFiles`. The failure mode a class-shared server
+    /// introduces here is <c>DependencyLoader.TryGetByAppId</c> handing back a module
+    /// compiled for an EARLIER request instead of compiling this bundle — which would
+    /// leave only one generation resident and quietly turn both facts below into tests of
+    /// nothing. `changedFiles` is empty on a reuse and names the edit on a real recompile,
+    /// so asserting it keeps the conversion honest rather than trusting that the distinct
+    /// per-variant app ids did their job.
+    /// </summary>
+    private static void AssertCycleTwoRecompiled(JsonElement summary, string editedFileName)
+    {
+        var changed = summary.TryGetProperty("changedFiles", out var cf)
+            ? cf.EnumerateArray().Select(e => e.GetString()).ToList()
+            : new List<string?>();
+        Assert.True(changed.Contains(editedFileName),
+            $"cycle 2 must have RECOMPILED the edited dependency, not been served a module " +
+            $"cached by AppId from an earlier request on this shared server — " +
+            $"changedFiles was [{string.Join(", ", changed)}], expected it to name '{editedFileName}'.");
+    }
+
     [SkippableFact]
     public async Task RunTests_Then_EditDependencyOnly_Rerun_ObservesTheEditNotTheStaleGeneration()
     {
         TestArtifacts.SkipIfMissing();
 
-        var (libDir, testDir, answerFile) = MakeLibTestPair("al-runner-xapp-stale-gen");
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-xapp-stale-gen-cache", Guid.NewGuid().ToString("N"));
-        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+        var (libDir, testDir, answerFile) = MakeLibTestPair("al-runner-xapp-stale-gen", variant: 0);
+        var server = await _shared.GetAsync(new[] { "--cache", CacheDir });
 
         // ── Cycle 1: fresh generation of WS Lib, Answer() == 42 — must PASS ──────
         var lines1 = await server.SendRequestStreamingAsync(Req(libDir, testDir), TimeSpan.FromSeconds(180));
@@ -205,6 +257,7 @@ public class ServerCrossAppStaleGenerationTests
         //    a stale-generation resolution would still see 42 and report PASS. ────
         var lines2 = await server.SendRequestStreamingAsync(Req(libDir, testDir), TimeSpan.FromSeconds(180));
         var (events2, d2) = ProtocolV2Streaming.Split(lines2);
+        AssertCycleTwoRecompiled(d2, "Answer.Codeunit.al");
         var answerEvent2 = events2.Single(e => e.GetProperty("name").GetString()!.EndsWith("LibAnswer_Is42"));
 
         // The whole point of the RED->GREEN cycle: a PASS here means the runner served
@@ -224,9 +277,8 @@ public class ServerCrossAppStaleGenerationTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var (libDir, testDir, answerFile) = MakeLibTestPair("al-runner-xapp-stale-gen-sub");
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-xapp-stale-gen-sub-cache", Guid.NewGuid().ToString("N"));
-        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+        var (libDir, testDir, answerFile) = MakeLibTestPair("al-runner-xapp-stale-gen-sub", variant: 1);
+        var server = await _shared.GetAsync(new[] { "--cache", CacheDir });
 
         // ── Cycle 1: fresh generation of WS Lib — the subscriber must fire exactly
         //    once (sanity: the mechanism works at all). ───────────────────────────
@@ -251,6 +303,7 @@ public class ServerCrossAppStaleGenerationTests
         //    under-firing rather than double-firing for this dispatch path). ───────
         var lines2 = await server.SendRequestStreamingAsync(Req(libDir, testDir), TimeSpan.FromSeconds(180));
         var (events2, d2) = ProtocolV2Streaming.Split(lines2);
+        AssertCycleTwoRecompiled(d2, "Answer.Codeunit.al");
         var subEvent2 = events2.Single(e => e.GetProperty("name").GetString()!.EndsWith("Fire_SubscriberFiresExactlyOnce"));
 
         Assert.Equal("pass", subEvent2.GetProperty("status").GetString());

--- a/AlRunner.Tests/SharedCliServer.cs
+++ b/AlRunner.Tests/SharedCliServer.cs
@@ -97,7 +97,18 @@ public sealed class SharedCliServer : IAsyncLifetime
     /// fact calls it) — never one that varies by test, which would silently be
     /// ignored on every call after the first.
     /// </summary>
-    public async Task<CliServer> GetAsync(IEnumerable<string>? extraArgs = null)
+    /// <param name="extraEnv">
+    /// #2377: environment variables for the server subprocess, consulted on the same
+    /// first (spawning) call only and subject to the same rule as
+    /// <paramref name="extraArgs"/> — a value that varies per fact would silently be
+    /// ignored on every call after the first. Exists because
+    /// ManifestFeaturesSubprocessTests needs AL_RUNNER_DIAG_EMITRETRY/BCCOMPILER_DIAG
+    /// set for the whole class (they only widen what the runner REPORTS about an
+    /// emit-retry exclusion; they do not change what it compiles), and those are
+    /// process-level knobs with no per-request equivalent in the protocol.
+    /// </param>
+    public async Task<CliServer> GetAsync(IEnumerable<string>? extraArgs = null,
+        IReadOnlyDictionary<string, string>? extraEnv = null)
     {
         if (_server != null) return _server;
         await _gate.WaitAsync();
@@ -105,7 +116,7 @@ public sealed class SharedCliServer : IAsyncLifetime
         {
             if (_server == null)
             {
-                _server = await CliServer.StartAsync(extraArgs);
+                _server = await CliServer.StartAsync(extraArgs, extraEnv: extraEnv);
                 _spawnCount++;
             }
             return _server;


### PR DESCRIPTION
Closes #2377

`dotnet test AlRunner.Tests` takes 15 minutes on a quiet machine and 31 on a loaded one, and the cost is concentrated: 1231 of 1435 tests finish under a second, while the top 50 are 64% of all test time. What those 50 share is that they spawn the runner as a subprocess and pay a full BC boot to do it. This routes three of the worst offenders through the `--server` fixture that already exists (`SharedCliServer`, from #1804/#1913/#1936) instead, and fixes the agent instruction that told everyone the suite was cheap.

## Matched before/after

Both runs back to back on the same machine, same `dotnet test --filter`, load average 4.57 (before) and 4.34 (after) at the start of each. "Before" is `origin/main` built in a second worktree.

| | before | after |
|---|---|---|
| wall | 3m01 | **2m20** |
| CPU (user) | 6m44 | **3m31** |
| sum of per-test durations | 601.8s | **422.9s** |

Wall moves less than CPU because xUnit runs these five classes in parallel, so wall is set by the longest chain. The CPU number is the resource actually freed, and on a loaded box that is what turns back into wall time.

Per class:

| class | before | after | |
|---|---|---|---|
| `LayeredCacheTests` | 150.5s | **27.6s** | converted |
| `ServerCrossAppStaleGenerationTests` | 179.4s | **138.5s** | converted |
| `ManifestFeaturesSubprocessTests` | 112.3s | **97.7s** | 3 of 4 facts converted |
| `LayeredSourceChainTests` | 124.9s | 124.5s | left alone |
| `LayeredDepManifestTests` | 34.5s | 34.6s | left alone |

The two untouched classes come out flat (−0.4s, +0.1s), which is the control that says the other deltas are real rather than noise.

`ManifestFeaturesSubprocessTests`' "before" here is flattered by measurement order: it spawns the CLI against the *default* cache root, so a repeated baseline run gets a warm cache, while the converted version uses a fresh `--cache` dir every time and is always cold. Measured cold from a clean session, its three converted facts were 120.4s; they are 44.8s now. CI is always the cold case.

## What I converted, and why each one is still the same test

**`LayeredCacheTests`** (150.5s → 27.6s). Two CLI spawns became two `runTests` requests to one warm server. The claim is answered by the same code either way: `RunAllBundlesForServer` calls `RunLayeredPrePass` for any request with more than one `sourcePath`, exactly as the CLI's bundled loop does, and emits the same `[layered] WROTE` / `[layered] cache HIT` lines. The `--cache` dir the workspace key lives under is a server startup flag, so both requests share one — which is what the CLI version did too, passing the same `cacheDir` to both spawns.

**`ServerCrossAppStaleGenerationTests`** (179.4s → 138.5s). Already server-based, but each fact started its own server. Now they share one.

**`ManifestFeaturesSubprocessTests`**, three facts of four. The AL0129/AL0135/EMIT-EXCLUDED assertions moved from substring-matching a whole console dump to reading the summary line's `compilationErrors`, which is where the server surfaces every compile failure. That is a narrower claim than the one it replaces, scoped to one request, and for the EMIT-EXCLUDED fact it now exercises the server's own guard — the one #2152 added after the server path was found running the surviving objects and reporting exit 0 with a whole test codeunit missing.

## What I deliberately did not convert

**`LayeredDepManifestTests`, both facts.** The negative fact's decisive assertion is that `Unhandled exception` is absent — that an invalid dependency manifest produces a formatted exit 3 rather than the CLR's default handler aborting the process with exit 134, which is what #1898 fixed. That is a claim about the CLI's own `Main`-level exception handling and can only be observed by watching a process exit; `RunAllBundlesForServer` wraps the same pre-pass in its own try/catch, so a server request never reaches the code path being held down. Converting the positive fact alone would leave the class spawning anyway for the negative one, so it buys a server process rather than removing one. Same reasoning keeps `ManifestFeaturesSubprocessTests`' fourth fact spawning.

**`LayeredSourceChainTests` — I converted it, measured it, and reverted it.** Two of its three facts moved cleanly and everything passed, and the class got *slower*: 128.8s → 139.9s in a back-to-back pair. A warm server only pays for itself when a class issues several expensive requests against one BC boot. Here exactly one fact is expensive, the negative fact costs 5s because it dies in dependency resolution before BC boots at all, and the third fact cannot move (below) — so the conversion added a second BC boot to a class that still had to spawn a CLI, and bought back 5 seconds. The revert is comment-only against `main`; the comment records the measurement so nobody repeats it.

I have not touched the categories #2377 rules out: process-level behaviour, cross-process persistence (`InstallBaselineDiskCacheTests`), cache isolation between independent runs (`CacheRootsIsolationTests`), or anything using a CLI-only flag with no request field (`CountBaselineIntegrationTests`).

## A runner bug found on the way — #2380, not fixed here

`LayeredSourceChainTests`' sibling-source fact turned out to be unconvertible for a reason that is not about the test. `RunAllBundlesForServer` puts **both** source pre-passes behind `if (sourcePaths.Length > 1)`, while the CLI gates only `RunLayeredPrePass` on bundle count and runs `BuildSiblingSourceDeps` unconditionally. Measured on one fixture, seconds apart: the CLI exits 0, the identical single-bundle `runTests` request exits 3 with `DEP-RESOLVE-FAIL: Dependency not found`. `--server` is what the VS Code extension drives, one bundle at a time, so a developer with a sibling source dependency gets a false compile failure on every save. Filed as #2380 with the reproduction; it is a runtime change with its own proving test and does not belong in a test-perf PR.

## How I know the converted tests still catch regressions

For the largest conversion I broke the thing it exists to detect and watched it fail. `LayeredCacheTests` exists because the layered workspace cache was once keyed on all impls combined, so editing one orphaned its siblings. I changed `ComputeSourceWorkspaceKey(new[] { implPath }, idByKey)` back to `ComputeSourceWorkspaceKey(sortedImpls.ToArray(), idByKey)`, rebuilt, and the converted test failed on exactly the assertion that matters:

```
Assert.Contains() Failure: Sub-string not found
Not found: "[layered] cache HIT Layered B LC"
```

Then restored the runner and confirmed `git diff HEAD` was empty before continuing. There is no `AlRunner/` change in this PR.

## Two traps worth knowing about for the next batch

Both cost me a measurement, and both are the failure mode where a converted test goes green having stopped proving anything.

**stdout and stderr are two pipes.** Reading the terminal `{"type":"summary"}` line establishes nothing about how much of that request's stderr the drain thread has appended. Measured, the last stderr line lands 0.05–5.9s *before* its summary — usually early enough that an unsynchronised read passes, which is the shape of a test that fails once a month on CI and nowhere else. `CliServer.StdErrSinceAsync(mark, anchor)` therefore waits for a caller-named anchor that the runner emits *after* everything being asserted on. Without that ordering, a `DoesNotContain` cannot tell "not there yet" from "never emitted".

**Distinct app ids are not enough.** `RunAllBundlesForServer` accumulates each request's layered workspace dirs into the server-level `packageCacheDirs`, and dependency resolution matches on name/publisher/version — so an app one fact builds stays resolvable *by name* for every later fact. `LayeredSourceChainTests`' absent-dependency fact stopped failing for its own reason when a sibling fact's identically-named app was still in the search set: it passed alone and failed in-class in 67ms. Every converted fixture now carries a per-fact tag on app names and AL object names, not just fresh GUIDs. `ServerCrossAppStaleGenerationTests` additionally asserts that cycle 2 recompiled, by checking the edited file appears in the summary's `changedFiles` — a cached-by-AppId reuse reports it empty, so the guard keeps the conversion honest rather than trusting the ids did their job.

## The instruction that caused the over-running

`.claude/agents/impl-agent.md` told every agent that `dotnet test AlRunner.Tests` is "cheap relative to an AL suite". It is 15–31 minutes, and that sentence is why agents ran it four times in a two-hour task. Replaced with the measured numbers and a filtered command, consistent with `.claude/rules/local-test-scope.md`, which already said targeted-not-everything and was being ignored because the line above contradicted it.

## Tests run

- The three converted classes plus `SharedCliServerTests`, on the rebased head: 10 passed.
- The five classes in the measurement table, both directions of the matched pair: 12 passed each time.
- The converted classes plus `ServerTests`, `ServerCancelTests`, `SharedCliServerTests` and `TestArtifactsGateTests` — the neighbours of the `CliServer`/`SharedCliServer` change: 71 passed.

I did not run the full suite locally; that is what the 8 CI legs are for, and it is the whole point of the change.
