### PR TITLE
docs(agents): opening a corpus PR needs no approval

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -17,7 +17,9 @@ If you are handed an identity outside the pool, use it for this task but say so 
 
 The `al-runner-tests` skill (`.claude/skills/al-runner-tests/SKILL.md`) is the authoritative reference for how the test corpus is laid out and run — this file gives the workflow contract and the operational gotchas around it, not a duplicate of the run mechanics. Read the skill before Step 3.
 
-**Public posting needs approval** beyond the mechanical steps below (filing a runner-gap issue on this repo, opening your own implementation PR) — see `.claude/rules/public-posting-approval.md` before writing a comment, a PR review comment, or anything posted to another repo.
+**These need no approval:** filing a runner-gap issue on this repo (and correcting the body of one you filed), opening your own implementation PR, and **opening a pull request on the corpus repo** (`StefanMaron/BusinessCentral.AL.Language.Tests`). Getting a BC-behavior claim in front of a real service tier is a normal step, not a blocker — open the corpus PR yourself, then tell the orchestrator when its 8 BC legs are green so it can merge. **You never merge a corpus PR yourself.**
+
+**Everything else needs approval first** — comments on issues or PRs (including on the corpus repo), PR review comments, anything else posted to another repo. See `.claude/rules/public-posting-approval.md`.
 
 ## Step 1 — Resume active work
 ```

--- a/.claude/rules/public-posting-approval.md
+++ b/.claude/rules/public-posting-approval.md
@@ -5,15 +5,24 @@ explicit approval before it posts. Use the `plain-language` skill (American
 English, first-person, no LLM-typical metaphor/jargon) for anything
 outward-facing.
 
-**The carve-out is narrow:** filing new issues on this repo
-(`StefanMaron/BusinessCentral.AL.Runner`) needs no approval — that channel
-exists specifically so agents can report gaps and follow-ups without a human
-in the loop. Everything else needs approval first:
+**Two things need no approval**, because both are channels that exist
+specifically so agents can work without a human in the loop:
 
-- Comments on issues or PRs (this repo or any other).
+- **Filing new issues on this repo** (`StefanMaron/BusinessCentral.AL.Runner`),
+  and editing the body of an issue you filed to correct it.
+- **Opening a pull request on the corpus repo**
+  (`StefanMaron/BusinessCentral.AL.Language.Tests`). Getting a BC-behavior claim
+  in front of a real service tier is step 2 of the workflow in
+  `bc-behavior-tests-go-upstream.md` — gating it stalled agents for no benefit,
+  since the corpus CI adjudicates the claim and a human still merges. **Open it
+  yourself; the orchestrator reviews and merges it when all 8 BC legs are green.**
+  You still do not merge it.
+
+Everything else needs approval first:
+
+- Comments on issues or PRs (this repo or any other), including on the corpus repo.
 - PR review comments.
-- Anything posted to another repo — including opening a PR, or commenting on
-  one, in `StefanMaron/BusinessCentral.AL.Language.Tests`.
+- Anything else posted to another repo.
 
 This does not gate the mechanical steps of the established agent workflow
 (claiming an issue, opening your own implementation PR with `Closes #N`,


### PR DESCRIPTION
Repo owner's call: opening PRs on the corpus repo is not gated. Agents open them; the orchestrator reviews and merges when all 8 BC legs are green.

The old wording gated it, and it cost real time today — two agents finished their upstream tests, pushed or committed them, then stopped to ask. Correctly, under the rule as written.

Getting a BC-behavior claim in front of a real service tier is step 2 of `bc-behavior-tests-go-upstream.md`. Gating it stalls the workflow for no benefit: the corpus CI adjudicates the claim, and a human still merges.

**Changed**
- `.claude/rules/public-posting-approval.md` — corpus PRs join issue-filing in the no-approval list. Agents still never *merge* a corpus PR.
- `.claude/agents/impl-agent.md` — same, in the file agents actually load.

**Unchanged:** commenting on issues or PRs, including on the corpus repo, stays gated. That is editorial content, not a mechanical workflow step.

Also records that correcting the body of an issue you filed needs no approval — the same channel as filing it, already being relied on today.