### PR TITLE
fix(events): bind IncludeSender to the sender parameter at any position

### DIFF
--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -140,6 +140,16 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
             // producing a 73s single-threaded tail (it is 3rd-heaviest at ~196s of serial
             // work; see the file header and issue #1887 for the measured timeline).
             ["InstallSeedDepCompanyCacheTests"] = 196,
+            // #2348: EmptySetupTable_Get/EmptySetupTable_TestField now call DeleteAll() on
+            // "Source Code Setup" before asserting it's empty (fixing IncludeSender's
+            // sender-position dispatch also fixed a latent install-time bug that used to
+            // leave that table's own default-row insert silently broken, so a fresh company
+            // may now legitimately arrive with a row already in it — DeleteAll() makes
+            // emptiness a fact the test guarantees instead of one it used to inherit).
+            // Absent from this table before, fell back to UnmeasuredWeightSeconds; measured
+            // 60.8s on the BC 28.3 leg of the first CI run after the fix, tripping
+            // check-collection-weights.py. Rounded down per the file header's rule.
+            ["MissingTestDataDiagnosisTests"] = 60,
             // #2175: measured 31.8s (28.2) to 61.2s (27.5) across the eight legs of one
             // run — it crosses the 60s freshness threshold only under load, so it failed
             // whichever leg happened to be slow while being absent here. The low-end rule

--- a/AlRunner.Tests/DispatchSenderParameterClassificationTests.cs
+++ b/AlRunner.Tests/DispatchSenderParameterClassificationTests.cs
@@ -7,7 +7,7 @@ namespace AlRunner.Tests;
 
 /// <summary>
 /// Pins <see cref="BcRuntime.IsSenderParameter"/> — the seam that decides whether a
-/// subscriber's leading parameter is the "Sender" of an IncludeSender=true event.
+/// subscriber parameter is the "Sender" of an IncludeSender=true event, at ANY position.
 ///
 /// Issue #1956: a table-declared <c>[IntegrationEvent(true, false)]</c> passed <c>null</c> as
 /// the sender. Root cause: <c>IsSenderParameter</c> recognised a sender only by walking the
@@ -19,6 +19,14 @@ namespace AlRunner.Tests;
 /// answered false. The parameter then fell through to the scope-field lookup, found no field
 /// (an IncludeSender event declares no parameters, so AL never emits one), and
 /// <c>CoerceArg(null, ...)</c> passed a silent null — see <c>.claude/rules/loud-failures.md</c>.
+///
+/// Issue #2348: <c>IsSenderParameter</c> additionally required <c>paramIndex == 0</c>, but real
+/// BC binds the sender wherever the subscriber declared it — Base Application's
+/// <c>MfgItemJnlPostLine.OnPostOutput</c> declares its sender LAST. The position guard is gone;
+/// what still distinguishes an actual sender from a genuinely-declared record/codeunit-typed
+/// event argument at the SAME position is the caller-side rule in InvokeOneSubscriber: the
+/// scope-field lookup runs first and wins, so a parameter only reaches IsSenderParameter when no
+/// publisher-scope field matches its name.
 ///
 /// <see cref="NavCodeunitHandle"/> does NOT implement <see cref="INavRecordHandle"/> (verified:
 /// NavCodeunitHandle's interfaces are INavValueMetadata, IEquatable, IComparable, ITreeObject,
@@ -33,28 +41,35 @@ namespace AlRunner.Tests;
 /// AlRunner.BcRuntime.DispatchCore ... NullReferenceException"; after: the subscriber's
 /// AddEntry write lands and the test's Registry.Get('FROM-TABLE-SENDER') succeeds), and belongs
 /// upstream in the corpus per bc-behavior-tests-go-upstream.md since it's a claim about BC
-/// behaviour. This test pins the specific classification defect at the seam — the same pattern
-/// DispatchEventPublisherDeclTypeTests.cs and DispatchCoerceArgByRefTests.cs use for their
-/// seams in the same file.
+/// behaviour. Likewise the #2348 sender-position claim (first / middle / last, plus the
+/// asserterror-through-sender case) is upstream. This test pins the specific classification
+/// defect at the seam — the same pattern DispatchEventPublisherDeclTypeTests.cs and
+/// DispatchCoerceArgByRefTests.cs use for their seams in the same file.
 /// </summary>
 public class DispatchSenderParameterClassificationTests
 {
     private static void CodeunitSenderShape(NavCodeunitHandle sender) { }
     private static void RecordSenderShape(INavRecordHandle sender) { }
-    private static void TwoParams_RecordFirst(INavRecordHandle first, int second) { }
     private static void UnrelatedLeadingType(string notASender) { }
+    private static void NonLeadingCodeunitHandle(int first, NavCodeunitHandle notLeading) { }
     private static void NonLeadingRecordHandle(int first, INavRecordHandle notLeading) { }
+    private static void TrailingCodeunitHandle(int first, string second, NavCodeunitHandle sender) { }
 
     private static ParameterInfo FirstParamOf(string methodName) =>
         typeof(DispatchSenderParameterClassificationTests)
             .GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static)!
             .GetParameters()[0];
 
+    private static ParameterInfo ParamOf(string methodName, int index) =>
+        typeof(DispatchSenderParameterClassificationTests)
+            .GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetParameters()[index];
+
     [Fact]
     public void CodeunitHandleTypedLeadingParameter_IsRecognizedAsSender()
     {
         // Regression guard: the pre-existing, already-working codeunit case must survive
-        // the #1956 fix unchanged.
+        // the #1956/#2348 fixes unchanged.
         var p = FirstParamOf(nameof(CodeunitSenderShape));
 
         Assert.True(BcRuntime.IsSenderParameter(p, paramIndex: 0));
@@ -71,25 +86,34 @@ public class DispatchSenderParameterClassificationTests
     }
 
     [Fact]
-    public void RecordHandleTypedParameter_NotAtLeadingPosition_IsNotSender()
+    public void CodeunitHandleTypedParameter_NotAtLeadingPosition_IsStillSender()
     {
-        // Position matters independent of type-shape: only a LEADING parameter can be a
-        // sender. A record-typed parameter declared later is a genuinely different argument.
-        var p = typeof(DispatchSenderParameterClassificationTests)
-            .GetMethod(nameof(NonLeadingRecordHandle), BindingFlags.NonPublic | BindingFlags.Static)!
-            .GetParameters()[1];
+        // The #2348 fix: position no longer matters — only type-shape does. A codeunit-handle
+        // typed parameter declared at a non-zero index (e.g. Base App's
+        // MfgItemJnlPostLine.OnPostOutput, sender LAST) must be recognized. Before the fix this
+        // was FALSE solely because of the removed `paramIndex != 0` guard.
+        var p = ParamOf(nameof(NonLeadingCodeunitHandle), 1);
 
-        Assert.False(BcRuntime.IsSenderParameter(p, paramIndex: 1));
+        Assert.True(BcRuntime.IsSenderParameter(p, paramIndex: 1));
     }
 
     [Fact]
-    public void RecordHandleTypedLeadingParameter_ButPassedIndexOne_IsNotSender()
+    public void RecordHandleTypedParameter_NotAtLeadingPosition_IsStillSender()
     {
-        // Same "leading" requirement, expressed the other way: even a record-shaped, textually
-        // first parameter is not a sender if the caller reports it at a non-zero position.
-        var p = FirstParamOf(nameof(TwoParams_RecordFirst));
+        // Same #2348 fix, table-publisher (interface) shape.
+        var p = ParamOf(nameof(NonLeadingRecordHandle), 1);
 
-        Assert.False(BcRuntime.IsSenderParameter(p, paramIndex: 1));
+        Assert.True(BcRuntime.IsSenderParameter(p, paramIndex: 1));
+    }
+
+    [Fact]
+    public void CodeunitHandleTypedParameter_AtTrailingPositionTwo_IsStillSender()
+    {
+        // Position 2 of 3 — not just "second of two" — matching the real MfgItemJnlPostLine
+        // shape where the sender is the last of several declared parameters.
+        var p = ParamOf(nameof(TrailingCodeunitHandle), 2);
+
+        Assert.True(BcRuntime.IsSenderParameter(p, paramIndex: 2));
     }
 
     [Fact]

--- a/AlRunner.Tests/DispatchSenderParameterClassificationTests.cs
+++ b/AlRunner.Tests/DispatchSenderParameterClassificationTests.cs
@@ -126,4 +126,42 @@ public class DispatchSenderParameterClassificationTests
 
         Assert.False(BcRuntime.IsSenderParameter(p, paramIndex: 0));
     }
+
+    // ── #2348 follow-up: AllowsSenderSubstitution (the omitted-trailing-parameter fix) ──
+    //
+    // AL lets a subscriber omit trailing publisher parameters entirely, sender included
+    // (confirmed empirically against a real compiled bundle: a subscriber declaring only a
+    // PREFIX of the publisher's parameters compiles and dispatches). An earlier version of
+    // this fix required the subscriber's parameter count to be EXACTLY one more than the
+    // publisher's declared arity, which rejected that legal shape and regressed a
+    // sender-first subscriber that also omits a trailing parameter — worse than even the
+    // pre-#2348 position-0-only behaviour, which tolerated it. AllowsSenderSubstitution
+    // replaces the arity count with counting how many of THIS subscriber's own parameters
+    // had no matching scope field: exactly one is the only shape IncludeSender's contract
+    // produces, at any position, with any number of trailing parameters omitted.
+
+    [Fact]
+    public void AllowsSenderSubstitution_ExactlyOneUnmatchedParameter_IsAllowed()
+    {
+        // The IncludeSender shape: every declared event argument matched a scope field,
+        // and the sender itself is the sole leftover.
+        Assert.True(BcRuntime.AllowsSenderSubstitution(unmatchedFieldCount: 1));
+    }
+
+    [Fact]
+    public void AllowsSenderSubstitution_NoUnmatchedParameters_IsNotAllowed()
+    {
+        // A subscriber that omits trailing parameters and does NOT declare a sender: every
+        // parameter it kept matched a scope field, so there is nothing left to substitute.
+        Assert.False(BcRuntime.AllowsSenderSubstitution(unmatchedFieldCount: 0));
+    }
+
+    [Fact]
+    public void AllowsSenderSubstitution_TwoOrMoreUnmatchedParameters_IsNotAllowed()
+    {
+        // Two or more parameters missing a scope field is not a shape IncludeSender's
+        // contract can produce — substituting a guess here would be exactly the silent
+        // wrong answer .claude/rules/loud-failures.md forbids.
+        Assert.False(BcRuntime.AllowsSenderSubstitution(unmatchedFieldCount: 2));
+    }
 }

--- a/AlRunner.Tests/MissingTestDataDiagnosisTests.cs
+++ b/AlRunner.Tests/MissingTestDataDiagnosisTests.cs
@@ -73,6 +73,13 @@ public sealed class MissingTestDataDiagnosisTests : IDisposable
     /// "Source Code Setup" is the table #2240 measured 12 of its 16 failures on. "Payment
     /// Method" is a Base App table the runner starts empty and this fixture inserts into, so
     /// "populated" is a fact the test creates rather than one it inherits.
+    ///
+    /// "Source Code Setup" itself is NOT guaranteed empty by construction any more (#2348):
+    /// fixing IncludeSender sender-position dispatch also fixed a latent install-time bug that
+    /// used to leave Codeunit2's OnBeforeSourceCodeSetupInsert NRE-ing silently, which — before
+    /// that fix — happened to keep this table permanently empty as a side effect. A correct
+    /// runner may now legitimately seed it during install, so the two "EmptySetupTable_*"
+    /// procedures below call DeleteAll() first to make "no rows" a fact THIS TEST guarantees.
     /// </summary>
     private static void WriteFixture(string dir)
     {
@@ -101,6 +108,13 @@ public sealed class MissingTestDataDiagnosisTests : IDisposable
             var
                 SourceCodeSetup: Record "Source Code Setup";
             begin
+                // #2348: fixing IncludeSender sender-position dispatch also fixed a latent
+                // install-time bug that used to leave this table's own default-row insert
+                // silently broken, so a fresh company may now legitimately arrive with a row
+                // already in it (Codeunit2's OnBeforeSourceCodeSetupInsert firing correctly).
+                // DeleteAll() first so "no rows" is still a fact this test GUARANTEES, not one
+                // it merely used to inherit from a broken install.
+                SourceCodeSetup.DeleteAll();
                 SourceCodeSetup.Get();
             end;
 
@@ -121,6 +135,8 @@ public sealed class MissingTestDataDiagnosisTests : IDisposable
             var
                 SourceCodeSetup: Record "Source Code Setup";
             begin
+                // Same #2348 guarantee as EmptySetupTable_Get above — DeleteAll() first.
+                SourceCodeSetup.DeleteAll();
                 SourceCodeSetup.Init();
                 SourceCodeSetup.TestField("Sales Journal");
             end;

--- a/AlRunner/Patches/CodeunitEventDispatcher.cs
+++ b/AlRunner/Patches/CodeunitEventDispatcher.cs
@@ -364,19 +364,21 @@ public static partial class BcRuntime
     }
 
     /// <summary>
-    /// Is this parameter (positionally) capable of being the "Sender" param of an
-    /// IncludeSender=true event subscriber? AL emits it as a positional first parameter whose
-    /// name is "Sender" (case-insensitive) and whose type is either <c>NavCodeunitHandle</c> (or
-    /// a typed codeunit-handle subclass, for a codeunit publisher) or <c>INavRecordHandle</c> (an
-    /// interface, or a concrete <c>Record&lt;N&gt;</c> implementing it, for a TABLE publisher —
-    /// #1956). This only answers the TYPE-SHAPE question; the call site additionally requires
-    /// no scope field matched this parameter's name before treating it as sender (see
-    /// InvokeOneSubscriber) — that's what distinguishes an actual sender from a coincidentally
-    /// leading, genuinely-declared record/codeunit-typed event argument.
+    /// Is this parameter capable of being the "Sender" param of an IncludeSender=true event
+    /// subscriber? Real BC does not require the sender to be the first parameter — the AL
+    /// compiler preserves the subscriber's declared parameter order in the emitted signature,
+    /// so a sender declared last (e.g. Base Application's
+    /// <c>MfgItemJnlPostLine.OnPostOutput</c>) arrives at whatever index it was written at
+    /// (#2348). Its type is either <c>NavCodeunitHandle</c> (or a typed codeunit-handle
+    /// subclass, for a codeunit publisher) or <c>INavRecordHandle</c> (an interface, or a
+    /// concrete <c>Record&lt;N&gt;</c> implementing it, for a TABLE publisher — #1956). This
+    /// only answers the TYPE-SHAPE question; the call site additionally requires no scope field
+    /// matched this parameter's name before treating it as sender (see InvokeOneSubscriber) —
+    /// that's what distinguishes an actual sender from a genuinely-declared record/codeunit-typed
+    /// event argument at any position.
     /// </summary>
     internal static bool IsSenderParameter(ParameterInfo p, int paramIndex)
     {
-        if (paramIndex != 0) return false;
         // Codeunit publisher: AL emits sender as Codeunit50047 (the publisher CLR type) — the
         // bundle's typed handle. The runtime type ancestry traces back to NavCodeunitHandle.
         var t = p.ParameterType;

--- a/AlRunner/Patches/CodeunitEventDispatcher.cs
+++ b/AlRunner/Patches/CodeunitEventDispatcher.cs
@@ -190,6 +190,15 @@ public static partial class BcRuntime
         string eventMethodName = scopeName.Substring(0, us);
 
         if (!TryDecodeEventPublisherDeclType(declName, out var publisherKind, out int publisherId)) return;
+        // #2348 safety net: the publisher's OWN declared event method (the local procedure
+        // carrying [IntegrationEvent]/[BusinessEvent]) tells us exactly how many parameters
+        // the AL author declared — NOT counting IncludeSender's implicit sender. A subscriber
+        // is only allowed to bind a sender when its own parameter count is EXACTLY one more
+        // than this — see IsSenderParameter's doc comment for why relying on "no scope field
+        // matched" alone is not safe on its own.
+        int? publisherEventArity = declType.GetMethod(eventMethodName,
+                BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
+            ?.GetParameters().Length;
         IReadOnlyList<MethodInfo>? subs = publisherKind switch
         {
             PublisherKindCodeunit => EventSubscriberPatches.GetCodeunitSubscribers(publisherId, eventMethodName),
@@ -232,11 +241,11 @@ public static partial class BcRuntime
                     // into an event, e.g. System Application Test Library's 132513
                     // "Confirm Test Library" answering OnBeforeGuiAllowed with false).
                     foreach (var bound in BoundInstancesOf(ExtractCodeunitIdFromTypeName(sub.DeclaringType!)))
-                        InvokeOneSubscriber(publisherScope, scopeType, pubObj, sub, bound);
+                        InvokeOneSubscriber(publisherScope, scopeType, pubObj, sub, bound, publisherEventArity);
                 }
                 else
                 {
-                    InvokeOneSubscriber(publisherScope, scopeType, pubObj, sub, null);
+                    InvokeOneSubscriber(publisherScope, scopeType, pubObj, sub, null, publisherEventArity);
                 }
             }
             catch (TargetInvocationException tie)
@@ -399,7 +408,7 @@ public static partial class BcRuntime
     private static PropertyInfo? _pNavCodeunitHandle_Target;
 
     private static void InvokeOneSubscriber(object publisherScope, Type scopeType, object treeObj, MethodInfo subscriberMethod,
-        object? boundInstance)
+        object? boundInstance, int? publisherEventArity)
     {
         EnsureCodeunitHandleReflection();
 
@@ -449,20 +458,31 @@ public static partial class BcRuntime
         // publisher itself (wrapped in a NavCodeunitHandle for a codeunit publisher, or passed
         // straight through for a table publisher — see IsSenderParameter/#1956).
         //
-        // Field lookup runs FIRST and wins: an IncludeSender=true event declares no parameters
-        // at all, so AL never emits a scope field for its "Sender" — the field-vs-sender
-        // branches can never both match the SAME parameter. A leading parameter that DOES have
-        // a matching scope field is a genuinely declared, record-typed (or codeunit-typed)
-        // event ARGUMENT, not a sender, and must keep taking its value from the scope.
+        // Field lookup runs FIRST and wins: an IncludeSender=true event's SENDER parameter has
+        // no scope field (see IsSenderParameter's doc comment for why), so the field-vs-sender
+        // branches can never both match the SAME parameter. A parameter that DOES have a
+        // matching scope field is a genuinely declared, record-typed (or codeunit-typed) event
+        // ARGUMENT, not a sender, and must keep taking its value from the scope.
+        //
+        // "No matching scope field" is necessary but not SUFFICIENT, though (#2348): a
+        // subscriber parameter can lack a matching field for other reasons too (a stale-named
+        // arg, a rename mismatch, anything the compiler emits that this lookup doesn't
+        // recognise). Before treating that fallthrough as sender-shaped, the ARITY must also
+        // fit — the subscriber has EXACTLY ONE more parameter than the publisher itself
+        // declared for this event. That is the one condition IncludeSender's own contract
+        // guarantees; anything else can produce a genuinely-still-null desired value, and
+        // substituting the publisher instance instead would be a silent wrong answer (see
+        // .claude/rules/loud-failures.md) rather than the intended one.
         int publisherCodeunitId = ExtractCodeunitIdFromTypeName(treeObj.GetType());
         var parms = subscriberMethod.GetParameters();
+        bool arityAllowsSender = publisherEventArity.HasValue && parms.Length == publisherEventArity.Value + 1;
         var args = new object?[parms.Length];
         for (int i = 0; i < parms.Length; i++)
         {
             var p = parms[i];
             var fld = scopeType.GetField(p.Name!,
                 BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-            if (fld == null && IsSenderParameter(p, i))
+            if (fld == null && arityAllowsSender && IsSenderParameter(p, i))
             {
                 if (typeof(Microsoft.Dynamics.Nav.Runtime.INavRecordHandle).IsAssignableFrom(p.ParameterType))
                 {

--- a/AlRunner/Patches/CodeunitEventDispatcher.cs
+++ b/AlRunner/Patches/CodeunitEventDispatcher.cs
@@ -190,15 +190,6 @@ public static partial class BcRuntime
         string eventMethodName = scopeName.Substring(0, us);
 
         if (!TryDecodeEventPublisherDeclType(declName, out var publisherKind, out int publisherId)) return;
-        // #2348 safety net: the publisher's OWN declared event method (the local procedure
-        // carrying [IntegrationEvent]/[BusinessEvent]) tells us exactly how many parameters
-        // the AL author declared — NOT counting IncludeSender's implicit sender. A subscriber
-        // is only allowed to bind a sender when its own parameter count is EXACTLY one more
-        // than this — see IsSenderParameter's doc comment for why relying on "no scope field
-        // matched" alone is not safe on its own.
-        int? publisherEventArity = declType.GetMethod(eventMethodName,
-                BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static)
-            ?.GetParameters().Length;
         IReadOnlyList<MethodInfo>? subs = publisherKind switch
         {
             PublisherKindCodeunit => EventSubscriberPatches.GetCodeunitSubscribers(publisherId, eventMethodName),
@@ -241,11 +232,11 @@ public static partial class BcRuntime
                     // into an event, e.g. System Application Test Library's 132513
                     // "Confirm Test Library" answering OnBeforeGuiAllowed with false).
                     foreach (var bound in BoundInstancesOf(ExtractCodeunitIdFromTypeName(sub.DeclaringType!)))
-                        InvokeOneSubscriber(publisherScope, scopeType, pubObj, sub, bound, publisherEventArity);
+                        InvokeOneSubscriber(publisherScope, scopeType, pubObj, sub, bound);
                 }
                 else
                 {
-                    InvokeOneSubscriber(publisherScope, scopeType, pubObj, sub, null, publisherEventArity);
+                    InvokeOneSubscriber(publisherScope, scopeType, pubObj, sub, null);
                 }
             }
             catch (TargetInvocationException tie)
@@ -402,13 +393,25 @@ public static partial class BcRuntime
         return false;
     }
 
+    /// <summary>
+    /// Is a subscriber allowed to bind a field-lookup fallthrough parameter as the sender,
+    /// given how many of THIS subscriber's own declared parameters had no matching
+    /// publisher-scope field? Extracted as a pure, unit-testable seam pinning the exact
+    /// threshold (#2348): exactly ONE unmatched parameter is the only shape IncludeSender's
+    /// contract actually produces, whether or not the subscriber also omits trailing
+    /// publisher parameters (AL allows that — see the call site's doc comment). Zero
+    /// unmatched parameters means there is no sender to bind. Two or more means this lookup
+    /// doesn't understand what's going on and must not guess.
+    /// </summary>
+    internal static bool AllowsSenderSubstitution(int unmatchedFieldCount) => unmatchedFieldCount == 1;
+
     private static Type? _tNavCodeunitHandle;
     private static ConstructorInfo? _ciNavCodeunitHandleByIdInt;
     private static ConstructorInfo? _ciNavCodeunitHandleByInstance;
     private static PropertyInfo? _pNavCodeunitHandle_Target;
 
     private static void InvokeOneSubscriber(object publisherScope, Type scopeType, object treeObj, MethodInfo subscriberMethod,
-        object? boundInstance, int? publisherEventArity)
+        object? boundInstance)
     {
         EnsureCodeunitHandleReflection();
 
@@ -467,22 +470,38 @@ public static partial class BcRuntime
         // "No matching scope field" is necessary but not SUFFICIENT, though (#2348): a
         // subscriber parameter can lack a matching field for other reasons too (a stale-named
         // arg, a rename mismatch, anything the compiler emits that this lookup doesn't
-        // recognise). Before treating that fallthrough as sender-shaped, the ARITY must also
-        // fit — the subscriber has EXACTLY ONE more parameter than the publisher itself
-        // declared for this event. That is the one condition IncludeSender's own contract
-        // guarantees; anything else can produce a genuinely-still-null desired value, and
-        // substituting the publisher instance instead would be a silent wrong answer (see
-        // .claude/rules/loud-failures.md) rather than the intended one.
+        // recognise). An EARLIER version of this fix required the subscriber's parameter count
+        // to be EXACTLY one more than the publisher's own declared arity — but AL subscribers
+        // are allowed to omit trailing publisher parameters entirely (confirmed empirically:
+        // the AL compiler accepts a subscriber declaring only a PREFIX of the publisher's
+        // parameters, sender included, at any position within that prefix), so an omitting
+        // subscriber has FEWER parameters than arity+1 and that exact-equality check wrongly
+        // rejected it — a real regression vs. even the pre-#2348 position-0-only behaviour for
+        // a sender-first subscriber that also omits a trailing parameter.
+        //
+        // The correct discriminator doesn't need the publisher's raw arity at all: exactly ONE
+        // parameter across this SPECIFIC subscriber's own declared list may go unmatched. Two
+        // or more unmatched parameters means something this lookup doesn't understand is going
+        // on, and this must NOT guess which one (if any) is the sender — see
+        // .claude/rules/loud-failures.md. A single unmatched parameter is only substituted when
+        // it is also shaped like a sender (IsSenderParameter's type check).
         int publisherCodeunitId = ExtractCodeunitIdFromTypeName(treeObj.GetType());
         var parms = subscriberMethod.GetParameters();
-        bool arityAllowsSender = publisherEventArity.HasValue && parms.Length == publisherEventArity.Value + 1;
+        var flds = new FieldInfo?[parms.Length];
+        int unmatchedCount = 0;
+        for (int i = 0; i < parms.Length; i++)
+        {
+            flds[i] = scopeType.GetField(parms[i].Name!,
+                BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+            if (flds[i] == null) unmatchedCount++;
+        }
+        bool allowSenderSubstitution = AllowsSenderSubstitution(unmatchedCount);
         var args = new object?[parms.Length];
         for (int i = 0; i < parms.Length; i++)
         {
             var p = parms[i];
-            var fld = scopeType.GetField(p.Name!,
-                BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-            if (fld == null && arityAllowsSender && IsSenderParameter(p, i))
+            var fld = flds[i];
+            if (fld == null && allowSenderSubstitution && IsSenderParameter(p, i))
             {
                 if (typeof(Microsoft.Dynamics.Nav.Runtime.INavRecordHandle).IsAssignableFrom(p.ParameterType))
                 {

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -150,7 +150,7 @@ assembly for `[NavEventSubscriber]` methods at startup and calls matching subscr
 **What works:**
 - Custom `[IntegrationEvent]` / `[BusinessEvent]` publishers with any subscriber signature.
 - Subscribers that receive `var` parameters (e.g. `var Rec: Record X`, `var IsHandled: Boolean`) — the rewriter forwards all event parameters, and `var` arguments are wrapped in `ByRef<T>` so mutations propagate back to the publisher.
-- `IncludeSender = true` — the sender codeunit instance is prepended as the first argument.
+- `IncludeSender = true` — the sender codeunit instance is bound to the subscriber's sender parameter regardless of its position in the declared parameter list (matching real BC — #2348).
 - Database event subscribers (`OnAfterModify`, `OnBeforeInsert`, etc.) receive `Rec` and can read or modify fields; the mutations are visible to the caller after the trigger returns.
 
 ### No UI rendering


### PR DESCRIPTION
Closes #2348

## Summary
`IsSenderParameter` required the sender parameter to be at index 0. Real BC binds the sender wherever the subscriber declared it — Base Application's `MfgItemJnlPostLine.OnPostOutput` declares its sender LAST, which NREd on the first dereference (the reported gap). Drops the position guard.

Position alone isn't sufficient once every index is in play, so two follow-up commits harden the discriminator:

1. **Arity check** (superseded by commit 3, see below) — a fallthrough (no matching scope field) was only treated as sender when the subscriber's parameter count was exactly one more than the publisher's declared arity. Caught a real false-positive: Base Application's `Codeunit2.OnBeforeSourceCodeSetupInsert` legitimately has a non-first sender, and CI's `MissingTestDataDiagnosisTests` failure led to root-causing that this was in fact *correct* dispatch — the fix let Base App's own install-time seeding finish for the first time, previously silently broken by the same #2348 defect. `MissingTestDataDiagnosisTests` fixed at the test level (`DeleteAll()` first) rather than reverted.
2. **Reviewer finding, addressed** — the exact-arity check from (1) rejects a legal AL shape: a subscriber may omit trailing publisher parameters entirely, sender included, so its parameter count is `arity + 1 - omitted`, not always `arity + 1`. For a sender-first subscriber that also omits a trailing parameter this was a real regression vs. even the pre-#2348 `paramIndex == 0` behaviour. Confirmed empirically against a real compiled bundle (before changing anything) that this shape is legal AL and compiles. Replaced the arity count entirely with a per-subscriber invariant that needs no raw arity number: **exactly one of the subscriber's own declared parameters may lack a matching scope field.** Extracted as `BcRuntime.AllowsSenderSubstitution(int unmatchedFieldCount)` — a pure, unit-testable seam pinning the `== 1` threshold.

## Fix the shape, not just the reported line
1. **Same wrong pattern elsewhere?** `IsSenderParameter` was the only caller of the position guard; `InvokeOneSubscriber` (its only call site) had no other position assumption once removed.
2. **Sibling function, same assumption?** No other method classifies sender parameters; codeunit- and table-publisher branches share the same fixed call.
3. **Two paths, same invariant?** Only one path builds subscriber args. This is where both hardening rounds came from: CI failure → root-caused to a real Base App shape → arity check → reviewer caught the arity check itself was wrong for legal parameter omission → replaced with the unmatched-count invariant, verified against a fresh compiled repro before landing.

## Test plan
- **RED → GREEN**, reproduced from the issue's AL (sender first/middle/last + asserterror-through-sender): before, 1P/3F with the reported `NullReferenceException`; after, 4P/0F.
- **Omission regression, reproduced and fixed**: built a standalone AL repro (publisher with 2 declared params, IncludeSender=true; subscribers omitting the trailing param, sender first and sender last) — failed with the exact-arity guard (2/3, NREs matching the reviewer's prediction), passes 3/3 with the unmatched-count fix.
- `AlRunner.Tests/DispatchSenderParameterClassificationTests.cs`: 9/9 pass — the position-independence cases from the first commit, plus 3 new cases pinning `AllowsSenderSubstitution`'s `== 1` threshold directly (0 unmatched → not allowed, 1 → allowed, 2 → not allowed).
- `AlRunner.Tests/MissingTestDataDiagnosisTests.cs`: 3/4 pass locally on Windows; the 4th (`WithTestDataOn_AnEmptyTableSaysWhyItIsStillEmpty`) fails identically on a clean `main` worktree with `PlatformNotSupportedException: Unix file modes are not supported on this platform` — pre-existing, Linux-only code path.
- **BC-behavior claims opened upstream**: [StefanMaron/BusinessCentral.AL.Language.Tests#97](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/97) — sender first/middle/last, error-through-sender, and (added for this review round) sender + omitted trailing parameter for both sender-first and sender-last. Verified locally against this runner build: 9/9 pass. The submodule pin is not bumped in this PR since #97 hasn't merged yet (purely additive coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VvUgMSPokJWzeFNVQxD5J