### PR TITLE
fix(query): retarget wildcard filters on query columns to the source field

### DIFF
--- a/AlRunner.Tests/QueryWildcardFilterProjectionTests.cs
+++ b/AlRunner.Tests/QueryWildcardFilterProjectionTests.cs
@@ -1,0 +1,207 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #2299 — <c>Query.SetFilter(&lt;column&gt;, 'ABC*')</c> (a wildcard filter on a query
+/// column) crashed at the first <c>Read()</c> with <c>InvalidCastException: Unable to cast
+/// object of type 'NCLMetaQueryColumn' to type 'NCLMetaField'</c>. <c>SetRange</c> on the same
+/// column worked, because BC's own <c>TempTableDataProvider.RecordBufferEvaluatorVisitor
+/// .Evaluate</c> casts <c>expressionContext.Metadata</c> to <c>NCLMetaField</c> for every
+/// non-Unary/Binary filter-expression leaf (wildcard, full-text, ...), and
+/// <c>RecordPatches.QueryProjection.RetargetFilterExpression</c> only retargeted Unary/Binary
+/// expressions from the query column's <c>ExpressionContext</c> to its source table field's —
+/// a <c>WildcardFilterExpression</c> was returned unretargeted, still keyed by the
+/// NCLMetaQueryColumn.
+///
+/// This is a RUNNER-MECHANISM test, not a claim about what real BC does: it pins that our own
+/// filter-retargeting step now covers the Wildcard shape, not just Unary/Binary. The BEHAVIORAL
+/// claim (real BC evaluates a wildcard filter on a query column against the column's source
+/// field, same as Record.SetFilter) is proven upstream against a live BC service tier — see
+/// StefanMaron/BusinessCentral.AL.Language.Tests, per docs/rules/bc-behavior-tests-go-upstream.md.
+///
+/// The fixture also exercises the sibling defect the same repro surfaced: [Test] procedure
+/// declaration-order preservation (#1766) broke whenever one test's name is a strict prefix of
+/// another's in the same codeunit (e.g. "Wildcard" / "Wildcard_NoMatch") — TestExecutor's
+/// nested-scope-type lookup used an end-anchored-only regex, so the longer name's scope type
+/// could match the shorter name's lookup too, and FirstOrDefault picked whichever came first in
+/// reflection order instead of the correct one. That silently reordered these tests relative to
+/// AL source order, letting one test's committed row leak into an earlier-declared test's result
+/// under the runner's default TestIsolation=Codeunit (data is intentionally NOT rolled back
+/// between tests in the same codeunit — see docs/limitations.md's "Test isolation modes").
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
+/// </summary>
+public class QueryWildcardFilterProjectionTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(string bundle)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" \"").Append(bundle).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private static string WriteBundle()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-query-wildcard-2299", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        File.WriteAllText(Path.Combine(root, "app.json"), """
+        {
+          "id": "c7d1e4f2-2299-4a1b-9c3d-000000002299",
+          "name": "QWF 2299 Repro",
+          "publisher": "Repro2299",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62450, "to": 62459 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "QwfLocal.al"), """
+        table 62450 "QWF Local"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "Code"; Code[20]) { }
+            }
+            keys { key(PK; "Code") { Clustered = true; } }
+        }
+
+        query 62451 "QWF Local Rows"
+        {
+            QueryType = Normal;
+            elements
+            {
+                dataitem(QwfLocal; "QWF Local")
+                {
+                    column(Code; "Code") { }
+                }
+            }
+        }
+
+        codeunit 62452 "QWF 2299 Tests"
+        {
+            Subtype = Test;
+
+            var
+                Log: Text;
+
+            // Both procedure names deliberately share the "SetFilterWildcard" prefix — the
+            // shorter name is a strict prefix of the longer one, the exact shape that broke
+            // #1766's declaration-order preservation (see class doc comment). Declared in
+            // this order (Wildcard, then Wildcard_NoMatch, then SetRange_Control) so a
+            // regression in either the wildcard retargeting OR the ordering fix reproduces as
+            // a wrong row count here, under the runner's real (undocumented-away)
+            // TestIsolation=Codeunit no-rollback-between-tests default.
+            [Test]
+            procedure SetFilterWildcard()
+            var
+                QwfLocal: Record "QWF Local";
+                LocalRows: Query "QWF Local Rows";
+                RowCount: Integer;
+            begin
+                Log += 'Wildcard;';
+                QwfLocal.Init();
+                QwfLocal."Code" := 'LW1';
+                QwfLocal.Insert();
+
+                LocalRows.SetFilter(Code, 'LW*');
+                LocalRows.Open();
+                while LocalRows.Read() do
+                    RowCount += 1;
+                LocalRows.Close();
+
+                if RowCount <> 1 then
+                    Error('Order=%1 Expected 1 row (only this test''s own LW1), got %2', Log, RowCount);
+            end;
+
+            [Test]
+            procedure SetFilterWildcard_NoMatch()
+            var
+                QwfLocal: Record "QWF Local";
+                LocalRows: Query "QWF Local Rows";
+                RowCount: Integer;
+            begin
+                Log += 'NoMatch;';
+                QwfLocal.Init();
+                QwfLocal."Code" := 'LW2';
+                QwfLocal.Insert();
+
+                LocalRows.SetFilter(Code, 'ZZ*');
+                LocalRows.Open();
+                while LocalRows.Read() do
+                    RowCount += 1;
+                LocalRows.Close();
+
+                if RowCount <> 0 then
+                    Error('Order=%1 Expected 0 rows, got %2', Log, RowCount);
+            end;
+
+            [Test]
+            procedure SetRangeControl()
+            var
+                QwfLocal: Record "QWF Local";
+                LocalRows: Query "QWF Local Rows";
+                RowCount: Integer;
+            begin
+                Log += 'Range;';
+                QwfLocal.Init();
+                QwfLocal."Code" := 'LW3';
+                QwfLocal.Insert();
+
+                LocalRows.SetRange(Code, 'LW3');
+                LocalRows.Open();
+                while LocalRows.Read() do
+                    RowCount += 1;
+                LocalRows.Close();
+
+                if RowCount <> 1 then
+                    Error('Order=%1 Expected 1 row, got %2', Log, RowCount);
+            end;
+        }
+        """);
+
+        return root;
+    }
+
+    [SkippableFact]
+    public void WildcardFilterOnQueryColumn_MatchesSourceField_InSourceDeclarationOrder()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var bundle = WriteBundle();
+        var (output, exitCode) = RunRunner(bundle);
+
+        // Never silently pass a run that failed to even get the test codeunit compiled/run.
+        Assert.DoesNotContain("EMIT-EXCLUDED", output);
+        Assert.DoesNotContain("COMPILE FAIL", output);
+        Assert.DoesNotContain("InvalidCastException", output);
+        // All three tests must have run and passed — 3P/0F/0E is TestExecutor's own
+        // per-bundle summary line (see CrossBundleModuleIdentityDedupTests for the same
+        // convention).
+        Assert.Contains("3P/0F/0E", output);
+    }
+}

--- a/AlRunner/Patches/RecordPatches.QueryProjection.cs
+++ b/AlRunner/Patches/RecordPatches.QueryProjection.cs
@@ -288,6 +288,7 @@ public static partial class RecordPatches
     private static Type? _tFilterFieldDictionary;
     private static Type? _tUnaryFilterExpr;
     private static Type? _tBinaryFilterExpr;
+    private static Type? _tWildcardFilterExpr;
     private static Type? _tFilterExpr;
     private static Type? _tNavFieldMetadata;
     private static bool _filterReflectionReady;
@@ -311,6 +312,7 @@ public static partial class RecordPatches
         _tFilterFieldDictionary = asm.GetType(rt + "FilterFieldDictionary");
         _tUnaryFilterExpr = asm.GetType(rt + "UnaryFilterExpression");
         _tBinaryFilterExpr = asm.GetType(rt + "BinaryFilterExpression");
+        _tWildcardFilterExpr = asm.GetType(rt + "WildcardFilterExpression");
         _tFilterExpr = asm.GetType(rt + "FilterExpression");
         _tNavFieldMetadata = asm.GetType(rt + "INavFieldMetadata");
         _tNCLMetaQueryColumn = asm.GetType(rt + "NCLMetaQueryColumn");
@@ -503,7 +505,25 @@ public static partial class RecordPatches
                 .First(c => c.GetParameters().Length == 3 && c.GetParameters()[0].ParameterType.Name == "FilterExpressionType");
             return ctor.Invoke(new object?[] { exprType, newLeft, newRight });
         }
-        // Other expression kinds (wildcard/fieldEqualsField/etc.) are not produced by
+        // #2299: Query.SetFilter(<col>, 'ABC*') on a query column DOES produce a
+        // WildcardFilterExpression (SetRange with an exact value produces the Unary/Binary
+        // shapes above, but a filter containing wildcard characters does not). Left
+        // unretargeted, its ExpressionContext.Metadata stays the NCLMetaQueryColumn key, and
+        // BC's own TempTableDataProvider.RecordBufferEvaluatorVisitor.Evaluate unconditionally
+        // casts `(NCLMetaField)expressionContext.Metadata` for the wildcard branch — an
+        // InvalidCastException at the first Read(), not a silent non-match. Rebuild it against
+        // the retargeted (real table field) context the same way Unary/Binary already are.
+        if (_tWildcardFilterExpr!.IsInstanceOfType(expr))
+        {
+            // public WildcardFilterExpression(bool isNegated, string pattern, bool isCaseAndAccentInsensitive, FilterExpressionContext expressionContext)
+            var isNegated = t.GetProperty("IsNegated", BindingFlags.Public | BindingFlags.Instance)!.GetValue(expr);
+            var pattern = t.GetProperty("Pattern", BindingFlags.Public | BindingFlags.Instance)!.GetValue(expr);
+            var isCaseAndAccentInsensitive = t.GetProperty("IsCaseAndAccentInsensitive", BindingFlags.Public | BindingFlags.Instance)!.GetValue(expr);
+            var ctor = _tWildcardFilterExpr.GetConstructors()
+                .First(c => c.GetParameters().Length == 4 && c.GetParameters()[0].ParameterType == typeof(bool));
+            return ctor.Invoke(new object?[] { isNegated, pattern, isCaseAndAccentInsensitive, targetCtx });
+        }
+        // Other expression kinds (fieldEqualsField/fullText/etc.) are not produced by
         // single-column SetRange/SetFilter; leave them (will not match a table field and
         // is a documented follow-up if a test relies on them).
         return expr;

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -820,8 +820,17 @@ public sealed class TestExecutor
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, MethodInfo[]> _sourceOrderCache = new();
     private static Type? _signatureSpanAttrType;
     private static bool _signatureSpanAttrTypeResolved;
+    // #2299 (test-order-preservation side effect): anchored at BOTH ends. Unanchored at
+    // the start, this let a nested scope type belonging to a DIFFERENT, longer method name
+    // that happens to start with this method's name (e.g. "LocalTableQuery_SetFilterWildcard"
+    // is a strict prefix of "LocalTableQuery_SetFilterWildcard_NoMatch") match here too: the
+    // remainder after stripping the shorter method's name is "_NoMatch_Scope_123", which still
+    // satisfies an end-anchored-only "_Scope_+\d+$" (it ends with "_Scope_123"). FirstOrDefault
+    // then silently picked the wrong nested type's declaration line, corrupting the very
+    // ordering #1766 exists to preserve whenever one [Test] procedure's name is a prefix of
+    // another's in the same codeunit.
     private static readonly System.Text.RegularExpressions.Regex _scopeTypeSuffix =
-        new(@"_Scope_+\d+$", System.Text.RegularExpressions.RegexOptions.Compiled);
+        new(@"^_Scope_+\d+$", System.Text.RegularExpressions.RegexOptions.Compiled);
 
     /// <summary>
     /// Returns <paramref name="t"/>'s public instance methods ordered by AL source


### PR DESCRIPTION
Closes #2299

## Root cause

`Query.SetFilter(<col>, 'ABC*')` crashed at the first `Read()` with
`InvalidCastException: Unable to cast object of type 'NCLMetaQueryColumn' to
type 'NCLMetaField'`. BC's own
`TempTableDataProvider.RecordBufferEvaluatorVisitor.Evaluate` (decompiled from
`Microsoft.Dynamics.Nav.Ncl.dll`) casts `(NCLMetaField)expressionContext.Metadata`
for every non-Unary/Binary filter-expression leaf (wildcard, full-text, ...).
`RecordPatches.QueryProjection.RetargetFilterExpression` already rebuilds a
query-column-keyed filter against the column's source table field for the
Unary/Binary shapes `SetRange`/simple `SetFilter` comparisons produce -- that's
why `SetRange` worked -- but a `WildcardFilterExpression` (what a `SetFilter`
call whose pattern contains a wildcard character actually produces) was
returned unretargeted, so its `ExpressionContext.Metadata` stayed the
`NCLMetaQueryColumn`.

Fix: reconstruct the `WildcardFilterExpression` (public ctor:
`(bool isNegated, string pattern, bool isCaseAndAccentInsensitive,
FilterExpressionContext expressionContext)`) against the retargeted context,
the same way Unary/Binary already are.

## A sibling bug the exact repro surfaced

Reproducing the issue's own AL verbatim (three `[Test]` procedures, two of
which share a name prefix: `LocalTableQuery_SetFilterWildcard` and
`LocalTableQuery_SetFilterWildcard_NoMatch`) still failed after the cast fix,
with data from the second test leaking into the first's read. Under the
runner's default `TestIsolation=Codeunit` (rows are intentionally **not**
rolled back between `[Test]`s in the same codeunit -- see
`docs/limitations.md`), that only produces a correct result if tests run in
AL source declaration order, which `TestExecutor.OrderTestMethodsBySourceDeclaration`
(#1766) exists to guarantee.

Its nested-scope-type lookup matched on `nt.Name.StartsWith(m.Name) &&
_scopeTypeSuffix.IsMatch(remainder)`, where `_scopeTypeSuffix` was
`_Scope_+\d+$` -- anchored at the end only. For the prefix pair above, the
remainder after stripping the shorter method's name from the longer method's
scope-type name is `_NoMatch_Scope_123`, which still satisfies an
end-anchored-only pattern (it ends with `_Scope_123`). `FirstOrDefault` could
then resolve the shorter method's declaration line from the LONGER method's
scope type, corrupting the sort order whenever one `[Test]` procedure's name
is a strict prefix of another's in the same codeunit. Anchoring the regex at
both ends (`^_Scope_+\d+$`) fixes it.

## Tests

- `AlRunner.Tests/QueryWildcardFilterProjectionTests.cs` -- runner-mechanism
  test pinning both fixes together (it reproduces the exact prefix-name shape
  that exposed the ordering bug), spawning the real runner against a small
  fixture bundle.
- Upstream corpus PR (real BC 27.0-28.4 adjudicates the BC-behavior claim):
  StefanMaron/BusinessCentral.AL.Language.Tests#99 -- adds two tests to
  `TestQueryObject.al` that actually `Open()`/`Read()` after a wildcard
  `SetFilter` (the existing test only checked `GetFilters()` text, never read
  rows, so it couldn't have caught this). Not yet merged; the submodule pin is
  **not** bumped in this PR -- see follow-up note below.

## RED -> GREEN

Confirmed against the issue's own minimal repro (local table, no
dependencies): before the fix, `InvalidCastException` at first `Read()` on
both wildcard cases, `SetRange` control passing. After the fix, all three
pass with the oracle row counts (1 row for `'LW*'`, 0 rows for `'ZZ*'`, 1 row
for the `SetRange` control) -- matching the issue's real-BC 28.4 verdict
(3/3 PASS) exactly.

Also verified the new corpus tests (`Codeunit60205`, `TestQueryObject.al`)
pass against this runner build, from a local checkout of the corpus PR
branch.

## Fix the shape, not just the reported line

- Checked for other unretargeted filter-expression shapes in
  `RetargetFilterExpression`: `FieldEqualsFieldFilterExpression` and
  `FullTextFilterExpression` are the only other leaf kinds `TempTableDataProvider`'s
  visitor dispatches through `Evaluate`'s same cast. `FieldEqualsFieldFilterExpression`
  is what a `DataItemLink` produces, not a single-column `SetRange`/`SetFilter`;
  `FullTextFilterExpression`'s constructor is `internal` to `Ncl.dll`, so it can't be
  reconstructed the same way without extra reflection plumbing. Neither is exercised
  by this repro, and I have not traced what AL surface (if any) actually produces a
  `FullTextFilterExpression` at runtime -- left as a documented follow-up rather than
  speculatively adding reflection-heavy handling for a shape nothing here currently
  constructs.
- Checked whether the `_scopeTypeSuffix` anchoring bug could affect other
  callers of `OrderTestMethodsBySourceDeclaration` -- it's the only call site,
  and the fix is a pure precision tightening (anchoring both ends can only
  make matches *more* correct, never drop a previously-correct match), so no
  other change was needed.

## Follow-up

- StefanMaron/BusinessCentral.AL.Language.Tests#99 needs to merge before the
  submodule pin can be bumped here (a pin bump can't be its own PR -- see
  `al-language-submodule.md`). Once merged, a follow-up PR bumps the pin
  together with the `tests/expectations/count-baseline/` update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VvUgMSPokJWzeFNVQxD5J
