### PR TITLE
fix(test-exec): make a watchdog-timeout suite abort loud, not silent

### DIFF
--- a/AlRunner.Tests/SuiteAbortOnTimeoutTests.cs
+++ b/AlRunner.Tests/SuiteAbortOnTimeoutTests.cs
@@ -1,0 +1,161 @@
+// SuiteAbortOnTimeoutTests — RED->GREEN guard for issue #2415.
+//
+// When one AL test hangs and its per-test watchdog fires, TestExecutor.Run used to
+// respond with a bare `return results;` from deep inside the codeunit/method loop —
+// ending the WHOLE Run() call for the rest of THIS codeunit and every LATER codeunit
+// in the same app group, silently. Because Run() returned normally (no exception),
+// Program.cs's only source of "suite errors" (the catch around executor.Run) never
+// fired either, so a run that dropped real tests still printed "0 suite errors" and
+// could exit clean. Measured for real: 730 tests ran vs. 834 on a full corpus leg,
+// 104 missing, nothing in the output saying so.
+//
+// This fixture is deliberately NOT placed under tests/runner-extras/: that directory
+// is swept in ONE process by CI with `--strict --count-baseline`, so a bundle that
+// intentionally times out and exits non-zero would permanently fail every OTHER
+// suite in that sweep. TestTimeoutFlagTests.cs established the isolated-subprocess
+// pattern for exactly this class of test (per-test-watchdog verification); this
+// follows it.
+//
+// Ghost-test trap avoided: the fixture's codeunit declares three [Test] procedures in
+// source order — Hangs, NeverRuns1, NeverRuns2. A no-op fix (the silent early return
+// left in place, or a fix that merely changes the return value's shape without
+// surfacing anything) makes the assertions below fail because the output carries
+// neither the codeunit name, nor the count "2", nor a non-zero exit code.
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class SuiteAbortOnTimeoutTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly string _root;
+
+    public SuiteAbortOnTimeoutTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-suite-abort-on-timeout", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        WriteFixture(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    /// <summary>
+    /// Writes a minimal AL package: app.json (no dependencies) and a test codeunit
+    /// with THREE [Test] procedures in source order — the first loops forever (the
+    /// ONLY way it ever "finishes" is the runner's per-test timeout firing), the
+    /// other two are trivial no-ops that must never actually run.
+    /// </summary>
+    private static void WriteFixture(string dir)
+    {
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "c3d4e5f6-a7b8-9012-3456-7890abcdef12",
+          "name": "Suite Abort On Timeout Test Fixture",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62210, "to": 62219 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(dir, "SuiteAbort.Codeunit.al"), """
+        codeunit 62211 "Suite Abort On Timeout Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure Hangs()
+            begin
+                while true do;
+            end;
+
+            [Test]
+            procedure NeverRuns1()
+            begin
+            end;
+
+            [Test]
+            procedure NeverRuns2()
+            begin
+            end;
+        }
+        """);
+    }
+
+    private (string output, int exit) RunRunner(params string[] extraArgs)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" \"{_root}\"");
+        foreach (var a in extraArgs) args.Append($" {a}");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived  += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        // The fixture's first [Test] never returns on its own; give the runner
+        // subprocess enough headroom above the (short) --test-timeout to finish the
+        // whole run, but well under a genuine hang.
+        if (!p.WaitForExit(120_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>
+    /// Positive: a hang must be reported loudly. The codeunit name and the exact
+    /// count of [Test] methods it never got to (2 — NeverRuns1 and NeverRuns2) must
+    /// both appear in the output, alongside a non-zero "suite errors" tally.
+    /// </summary>
+    [SkippableFact]
+    public void HungTest_AbortsCodeunit_ReportsCodeunitAndSkippedCount()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, exit) = RunRunner("--test-timeout 2");
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("Suite Abort On Timeout Tests", output);
+        Assert.Contains("SUITE ABORTED", output);
+        // The exact denominator: 2 further [Test] methods (NeverRuns1, NeverRuns2)
+        // never ran. A fix that reports SOME count but not this one would still be
+        // lying about the run's true shape.
+        Assert.Contains("2 further [Test] method(s)", output);
+        // "0 suite errors" was the bug's own signature line — must never appear
+        // alongside a run that dropped tests.
+        Assert.DoesNotContain("0 suite errors", output);
+    }
+
+    /// <summary>
+    /// Negative: NeverRuns1/NeverRuns2 must not silently vanish from a passing count
+    /// either — the summary line's test total must still include the hung test
+    /// itself (reported as an Error, not dropped), proving the abort is additive
+    /// reporting on top of the existing per-test outcome, not a replacement for it.
+    /// </summary>
+    [SkippableFact]
+    public void HungTest_StillCountsTowardsTheRunsTestTotal()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, _) = RunRunner("--test-timeout 2");
+
+        Assert.Contains("Hangs", output);
+        Assert.Contains("Test exceeded 2s timeout.", output);
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3010,6 +3010,13 @@ foreach (var bundle in bundles)
                 tests = OverrideTddDependentResults(executor.Run(asm));
                 execSw.Stop();
                 AlRunner.PerfTrace.Log($"TestExecutor.Run {rel} {execSw.ElapsedMilliseconds}ms");
+                // #2415: Run() returns normally even when a watchdog timeout aborted the
+                // rest of this app group's codeunits — it doesn't throw, so the catch
+                // below never sees it. Fold its own suite-error lines in here so the
+                // "N suite errors" summary and the exit code (computedExitCode's
+                // CompileErrors check) both reflect the abandoned tests.
+                if (executor.AbortReasons.Count > 0)
+                    bundleErrors.AddRange(executor.AbortReasons.Select(r => $"{rel}: TEST-TIMEOUT-ABORT: {r}"));
             }
             catch (Exception ex)
             {
@@ -3139,6 +3146,11 @@ foreach (var bundle in bundles)
                 }
                 BcRuntime.OosHooksActive = true;
                 tests = OverrideTddDependentResults(executor.Run(asm));
+                // #2415: see the bundled-mode call site's identical comment — Run()
+                // returns normally on a watchdog-timeout abort, so the catch below
+                // never sees it.
+                if (executor.AbortReasons.Count > 0)
+                    bundleErrors.AddRange(executor.AbortReasons.Select(r => $"{suiteName}: TEST-TIMEOUT-ABORT: {r}"));
             }
             catch (Exception ex)
             {

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -140,6 +140,16 @@ public sealed class TestExecutor
     /// </summary>
     public Infrastructure.ExpectationManifest? Expectations { get; set; }
 
+    // #2415: a hung test's watchdog fires correctly (RunOne's TIMEOUT branch), but the
+    // codeunit/type loop below used to respond with a bare `return results;` — ending the
+    // WHOLE Run() call, silently, with no exception and no record of what was abandoned.
+    // Program.cs's catch-and-report-as-suite-error path only fires when Run() THROWS, so a
+    // clean early return left `bundleErrors` at 0 and the test count merely smaller, exactly
+    // as if fewer tests existed. Populated by RecordAbortedSuite, reset at the top of every
+    // Run() call (this executor instance is reused across bundles/app-groups) so a suite
+    // that aborted does not leak its reasons into the next, clean one.
+    public IReadOnlyList<string> AbortReasons { get; private set; } = Array.Empty<string>();
+
     // #1867: process-lifetime cache of the dependency-assemblies' Install triggers +
     // Company-Initialize (codeunit 2) — the invariant portion of the per-app-group
     // "install-seed" sequence, keyed by InstallTriggerRunner.CurrentDependencySetKey()
@@ -289,6 +299,7 @@ public sealed class TestExecutor
     {
         var totalSw = System.Diagnostics.Stopwatch.StartNew();
         var results = new List<TestResult>();
+        AbortReasons = Array.Empty<string>();   // #2415: this instance is reused across Run() calls
         var ctorParam = typeof(Microsoft.Dynamics.Nav.Runtime.ITreeObject);
         var filter = NormaliseFilter(TestFilter);
         var typeSw = System.Diagnostics.Stopwatch.StartNew();
@@ -496,8 +507,9 @@ public sealed class TestExecutor
         // instance under Codeunit isolation is therefore faithful, and Test isolation's
         // fresh instance per test is AL's TestIsolation = Function.
         var perTestInstance = Isolation == TestIsolation.Test;
-        foreach (var t in types)
+        for (int ti = 0; ti < types.Length; ti++)
         {
+            var t = types[ti];
             // Cooperative cancellation: stop before instantiating the next test
             // codeunit. See the Run() doc comment — never mid-test.
             if (cancellationToken.IsCancellationRequested) break;
@@ -575,10 +587,12 @@ public sealed class TestExecutor
             var isFirstMethod = true;
 
             var loopSw = System.Diagnostics.Stopwatch.StartNew();
+            var orderedMethods = OrderTestMethodsBySourceDeclaration(t);
             try
             {
-                foreach (var m in OrderTestMethodsBySourceDeclaration(t))
+                for (int mi = 0; mi < orderedMethods.Length; mi++)
                 {
+                    var m = orderedMethods[mi];
                     // Cooperative cancellation: stop before running the next test
                     // method inside this already-instantiated codeunit.
                     if (cancellationToken.IsCancellationRequested) break;
@@ -662,9 +676,16 @@ public sealed class TestExecutor
 
                     // Timeout is judged on the RAW outcome: even if a manifest entry
                     // reclassifies the hung test, its runaway thread still poisons the
-                    // process, so the suite must stop either way.
+                    // process, so the suite must stop either way. #2415: make the stop
+                    // loud — count what this abandons (the rest of this codeunit, plus
+                    // every later codeunit the outer loop will now never reach) before
+                    // returning, so the caller can report a non-zero suite-error count
+                    // instead of a quietly-smaller test total.
                     if (IsTimeout(raw))
+                    {
+                        RecordAbortedSuite(t, m, displayName, orderedMethods, mi, types, ti, filter);
                         return results;
+                    }
                 }
                 methodLoopMs += loopSw.ElapsedMilliseconds;
             }
@@ -1079,6 +1100,52 @@ public sealed class TestExecutor
     // TestTimeoutFlagTests), not a classification channel, and the same fact now has
     // to be answered for protocol-v2's `errorKind` too. One source of truth.
     private static bool IsTimeout(TestResult result) => result.TimedOut;
+
+    // #2415: called right before the timeout path's early `return results;`. Counts
+    // every [Test] method this abort abandons — the rest of THIS codeunit (methods
+    // after `mi` in source-declaration order) plus every later test codeunit the
+    // outer loop (`types[ti+1..]`) will now never reach — and records one loud,
+    // human-readable line naming the hang's origin and the total. Deliberately does
+    // NOT consult the expectations manifest for `skip`-declared methods among the
+    // abandoned ones: undercounting here would silently understate the loss again,
+    // which is exactly the failure mode this method exists to close off; a handful of
+    // legitimately-skipped tests inflating the count by a few is the safe direction.
+    private void RecordAbortedSuite(Type hungType, MethodInfo hungMethod, string hungDisplayName,
+        MethodInfo[] orderedMethodsInHungType, int hungMethodIndex,
+        Type[] allTypes, int hungTypeIndex, string? filter)
+    {
+        int remainingInCodeunit = 0;
+        for (int mi = hungMethodIndex + 1; mi < orderedMethodsInHungType.Length; mi++)
+        {
+            var mm = orderedMethodsInHungType[mi];
+            if (!IsTestMethod(mm)) continue;
+            if (filter != null && !MethodMatchesFilter(hungType.Name, mm.Name, filter)) continue;
+            remainingInCodeunit++;
+        }
+
+        int remainingCodeunits = 0, remainingInOtherCodeunits = 0;
+        for (int ti = hungTypeIndex + 1; ti < allTypes.Length; ti++)
+        {
+            var t2 = allTypes[ti];
+            if (!IsTestCodeunit(t2)) continue;
+            if (filter != null && !CodeunitMatchesFilter(t2, filter)) continue;
+            var count = t2.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+                .Count(mm => IsTestMethod(mm) && (filter == null || MethodMatchesFilter(t2.Name, mm.Name, filter)));
+            if (count == 0) continue;
+            remainingCodeunits++;
+            remainingInOtherCodeunits += count;
+        }
+
+        var total = remainingInCodeunit + remainingInOtherCodeunits;
+        var reason = $"{hungDisplayName} ({hungType.Name}).{hungMethod.Name}: watchdog timeout aborted the run — " +
+            $"{remainingInCodeunit} further [Test] method(s) in this codeunit" +
+            (remainingCodeunits > 0
+                ? $" and {remainingInOtherCodeunits} in {remainingCodeunits} subsequent codeunit(s)"
+                : "") +
+            $" did not run ({total} total)";
+        Console.Error.WriteLine($"[test-exec] SUITE ABORTED: {reason}");
+        AbortReasons = AbortReasons.Append(reason).ToList();
+    }
 
     private static Exception Unwrap(Exception ex)
     {


### PR DESCRIPTION
Closes #2415

## What was wrong

When a `[Test]`'s per-test watchdog fired correctly, `TestExecutor.Run` responded with
a bare `return results;` from deep inside the codeunit/method loop — ending the whole
`Run()` call for the rest of that codeunit AND every later codeunit in the app group,
silently. Program.cs's only source of "suite errors" is the `catch` around
`executor.Run()`, which never fires here because `Run()` returns normally, so a run
that dropped 104 real tests still printed "0 suite errors" and exited clean. Measured
on a real `Tests-SINGLESERVER` run: 730 tests ran vs. 834 on `main`, concentrated in
two codeunits (one of which ran zero tests at all).

## The fix

`TestExecutor.Run` now counts what a timeout is about to abandon — the remaining
`[Test]` methods in the hung codeunit, plus every qualifying `[Test]` method in every
later codeunit the type loop will now never reach — and records one human-readable
line (`RecordAbortedSuite`), exposed via a new `AbortReasons` property, before
returning. Program.cs folds those into `bundleErrors` (the bundle's existing
"N suite errors" counter). That counter already forces `computedExitCode`'s
compile-error branch (exit 3) whenever it's non-empty — see the pre-existing
`// Without this the run exits 0: bucket Stage stays Executed, so suite errors reached
neither branch above` comment, which #2403-era work already put in place for
EMIT-FAIL/COMPILE-FAIL/EXEC-FAIL. So this PR is almost entirely about not losing the
information at the source, not new exit-code plumbing.

Console output now looks like:

```
[test-exec] SUITE ABORTED: Suite Abort On Timeout Tests (Codeunit62211).Hangs: watchdog timeout aborted the run — 2 further [Test] method(s) in this codeunit did not run (2 total)
  → 0P/0F/1E across 1 tests, 1 suite errors (9.6s)
```
and the process exits `3`.

## Explicitly out of scope

Recovering the abandoned tests so they actually run — this PR only makes the abort
loud and accounted for, per the issue. The specific #2414 hang that exposed this is
also untouched.

## Same-shape check

Grepped `TestExecutor.cs` for every early `return`/`break` out of the per-codeunit and
per-method loops. Found one sibling with the identical shape (silently drops the rest
of a codeunit's `[Test]` methods with no suite-error signal): under `TestIsolation.Test`,
if re-instantiating a codeunit for its second-or-later test returns `null` after the
first instantiation of that same type already succeeded, the loop does a bare `break`.
The code's own comment says this "should never happen" (unlike a hung test, which is
completely ordinary), and I have no reproducer, so I filed it separately rather than
folding an unverified fix into this PR: #2420.

## Testing

- `AlRunner.Tests/SuiteAbortOnTimeoutTests.cs` — new, isolated-subprocess test in the
  `TestTimeoutFlagTests.cs` style (writes its own throwaway fixture with a hanging
  `[Test]` plus two more in the same codeunit, spawns the runner against just that).
  RED confirmed against the pre-fix `TestExecutor.cs`/`Program.cs` (reverted via
  `git checkout HEAD --`, restored from a saved copy — not `git stash`, per this repo's
  own rule), GREEN with the fix.
- Not placed under `tests/runner-extras/`: that whole tree is swept in ONE process by
  CI with `--strict --count-baseline`, so a bundle that deliberately times out and
  exits non-zero would permanently fail every other suite in that sweep.
- Ran `TestTimeoutFlagTests` and `TestFilterFlagTests` (closest existing coverage of
  the loop I restructured to an indexed `for`) and `DapServerTests` (the other consumer
  of `Run()`'s cancellation-token path) — all green, no regressions.
- Manually re-ran `tests/runner-extras/date-virtual-table-window` (small, no
  dependencies) end to end — still 3P/0F/0E, unaffected.
- Did not run the full `dotnet test AlRunner.Tests` or the full corpus locally (per
  `local-test-scope.md`); CI's matrix covers those.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf