### PR TITLE
fix(query): compute single-dataitem FlowField query columns instead of NRE-ing or corrupting the value

### DIFF
--- a/AlRunner.QueryJoin/JoinExecutor.cs
+++ b/AlRunner.QueryJoin/JoinExecutor.cs
@@ -30,6 +30,13 @@ public static class JoinExecutor
     private static PropertyInfo? _pQueryDefDataItems;
     private static PropertyInfo? _pQueryDefOrderBy;
     private static PropertyInfo? _pDataItemMetaTable;
+    // #2300: NCLMetaQueryDataItem.SubQueryDefinition — non-null for a synthesized dataitem
+    // BC's own NCLMetaQuery.CreateSubQueryForFlowFieldCalculation builds when a query column
+    // is a FlowField. Such a dataitem has no `tableNo` of its own (it wraps an OuterApply
+    // sub-query instead), so calling its `.MetaTable` getter NREs — exactly what BC's own
+    // NCLMetaQueryDefinition.GetAllDataItems avoids by testing this same property and NOT
+    // recursing/yielding a dataitem that has one. See GetRealDataItems below.
+    private static PropertyInfo? _pDataItemSubQueryDefinition;
     private static PropertyInfo? _pDataItemLinks;
     private static PropertyInfo? _pDataItemLinkType;
     private static PropertyInfo? _pDataItemName;
@@ -66,6 +73,7 @@ public static class JoinExecutor
         _pQueryDefDataItems = tQueryDef.GetProperty("DataItems", F)!;
         _pQueryDefOrderBy = tQueryDef.GetProperty("OrderBy", F)!;
         _pDataItemMetaTable = tDataItem.GetProperty("MetaTable", F)!;
+        _pDataItemSubQueryDefinition = tDataItem.GetProperty("SubQueryDefinition", F)!;
         _pDataItemLinks = tDataItem.GetProperty("DataItemLinks", F)!;
         _pDataItemLinkType = tDataItem.GetProperty("DataItemLinkType", F)!;
         _pDataItemName = tDataItem.GetProperty("Name", F)!;
@@ -96,13 +104,31 @@ public static class JoinExecutor
         _ready = true;
     }
 
-    /// <summary>True iff this query definition has more than one (flat) dataitem — i.e. a join.</summary>
-    public static bool IsMultiDataItem(object queryDefinition)
+    /// <summary>
+    /// The query's REAL (table-backed) dataitems — excludes any FlowField-calculation
+    /// synthesized dataitem BC's own NCLMetaQuery.CreateSubQueryForFlowFieldCalculation
+    /// added (SubQueryDefinition != null; see field comment above). Those columns are
+    /// computed separately (RecordPatches.QueryProjection.cs's FlowFieldPatches.
+    /// CalcOneFlowFieldForQueryRow), not by joining over their sub-query's own dataitem —
+    /// mirrors BC's own NCLMetaQueryDefinition.GetAllDataItems test, just without the
+    /// recursion into the sub-query's DataItems (this runner never executes that sub-query).
+    /// </summary>
+    private static List<object> GetRealDataItems(object queryDefinition)
     {
         EnsureReflection(queryDefinition);
-        var items = (ICollection)_pQueryDefDataItems!.GetValue(queryDefinition)!;
-        return items.Count > 1;
+        var raw = ((IEnumerable)_pQueryDefDataItems!.GetValue(queryDefinition)!).Cast<object>();
+        var result = new List<object>();
+        foreach (var di in raw)
+        {
+            if (_pDataItemSubQueryDefinition!.GetValue(di) != null) continue;
+            result.Add(di);
+        }
+        return result;
     }
+
+    /// <summary>True iff this query definition has more than one (flat, real) dataitem — i.e. a join.</summary>
+    public static bool IsMultiDataItem(object queryDefinition)
+        => GetRealDataItems(queryDefinition).Count > 1;
 
     private static void Log(JoinContext ctx, string m) => ctx.Log(m);
 
@@ -154,7 +180,13 @@ public static class JoinExecutor
         EnsureReflection(queryDef);
         Log(ctx, "reflection ready");
 
-        var dataItems = ((IEnumerable)_pQueryDefDataItems!.GetValue(queryDef)!).Cast<object>().ToList();
+        // #2300: excludes a FlowField-calculation synthesized dataitem, same as IsMultiDataItem
+        // above — a real multi-dataitem join that ALSO selects a FlowField column would
+        // otherwise crash here calling .MetaTable on the synthesized dataitem. That combination
+        // isn't wired up to compute the FlowField column's value here yet (tracked as a
+        // follow-up; the single-real-dataitem FlowField case is handled entirely before this
+        // method is ever reached, via IsMultiDataItem now reporting "not multi").
+        var dataItems = GetRealDataItems(queryDef);
 
         // 1. Read every dataitem's rows (honouring its own table filters). Validate the join
         //    shape up-front so an unsupported case throws BEFORE any partial output.

--- a/AlRunner.Tests/QueryFlowFieldColumnProjectionTests.cs
+++ b/AlRunner.Tests/QueryFlowFieldColumnProjectionTests.cs
@@ -1,0 +1,213 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #2300 — a Query with a FlowField column NREs while BC builds the FlowField's
+/// synthesized OuterApply sub-dataitem (NCLMetaQuery.CreateSubQueryForFlowFieldCalculation
+/// → SqlTableDataProviderHelper.CreateDataItemFromFlowField → NCLMetaTable.SqlTableName →
+/// NavSqlStatementHelper.ConvertToSqlIdentifier), because the skeleton NavSqlDatabaseProperties
+/// leaves the private `invalidIdentifierChars` field null (GetUninitializedObject skips field
+/// initializers) and ConvertToSqlIdentifier iterates it unconditionally.
+///
+/// Fixing that NRE alone was not the whole story: once the sub-dataitem's metadata built
+/// successfully, TWO further mechanism bugs in THIS runner's own query-projection code
+/// surfaced (neither is BC's own code):
+///
+///   1. RecordPatches.QueryProjection.DataAccessSource_GetDataAccessForQuery used
+///      NCLMetaQueryDefinition.IncludedTables to decide whether a query is effectively
+///      single-table. That BC-real property intentionally recurses into a FlowField
+///      sub-dataitem's OWN inner table (BC's SQL needs it there) — so a query with one real
+///      dataitem plus a FlowField column reported 2 included tables, always routing into the
+///      (unrelated, and here unsupported) multi-dataitem JOIN path instead of the plain
+///      single-table path.
+///
+///   2. BuildProjectionPlan iterated NCLMetaQueryDefinition.Columns, which flattens EVERY
+///      dataitem's QueryColumns — including the FlowField sub-dataitem's own internal
+///      aggregate column. That column's AggregationType (Sum/etc) routed it through the
+///      #2137 GROUP BY machinery, and its SourceTableField resolves to the SOURCE table's
+///      field (e.g. the summed field on the FlowField's source table) — NOT a field on the
+///      OUTER row's own table. Reading that field's ColumnIndex against the outer row buffer
+///      returned whatever unrelated field actually sits at that slot on the outer table
+///      (observed: the outer table's own SystemId, a Guid — surfacing as
+///      "NavNCLConversionException: Unable to convert from NavGuid to Int32" at the AL
+///      assignment). NCLMetaQueryDataItem.SourceFlowField (set by BC's own
+///      CreateSubQueryForFlowFieldCalculation) is the correct discriminator: a column whose
+///      ParentDataItem carries one must be computed via FlowFieldPatches.
+///      CalcOneFlowFieldForQueryRow (the same per-row FlowField calculation Record.CalcFields
+///      uses), never via TableSlot or the generic aggregation path.
+///
+/// This is a RUNNER-MECHANISM test, not a claim about what real BC does: it pins OUR OWN
+/// pipeline (the skeleton-state fix plus the two projection-layer fixes above), not the BC
+/// behavior itself. The BEHAVIORAL claim (a query FlowField column reads the same calculated
+/// value Record.CalcFields would) is proven upstream against a live BC service tier — see
+/// StefanMaron/BusinessCentral.AL.Language.Tests, per docs/rules/bc-behavior-tests-go-upstream.md.
+///
+/// Only the single-real-dataitem case is covered here. A query joining a Base Application
+/// table (e.g. "Item Ledger Entry") and selecting one of ITS FlowFields hits a DIFFERENT,
+/// unrelated NRE (NavQuery.ValidateExpectedType / ValidateTablesNotVirtual — the #2295 shape,
+/// a namespace-qualified RelatedTable on a dependency table not being normalized) before ever
+/// reaching the FlowField machinery this fix addresses — tracked separately.
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
+/// </summary>
+public class QueryFlowFieldColumnProjectionTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(string bundle)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" \"").Append(bundle).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private static string WriteBundle()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-query-flowfield-2300", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        File.WriteAllText(Path.Combine(root, "app.json"), """
+        {
+          "id": "c7d1e4f2-2300-4a1b-9c3d-000000002300",
+          "name": "QFF 2300 Repro",
+          "publisher": "Repro2300",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62460, "to": 62469 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "QffLine.al"), """
+        table 62460 "QFF Line"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "Entry No."; Integer) { }
+                field(2; "Header No."; Code[20]) { }
+                field(3; Amount; Decimal) { }
+            }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "QffHeader.al"), """
+        table 62461 "QFF Header"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "No."; Code[20]) { }
+                field(2; "Total Amount"; Decimal)
+                {
+                    FieldClass = FlowField;
+                    CalcFormula = sum("QFF Line".Amount where("Header No." = field("No.")));
+                }
+            }
+            keys { key(PK; "No.") { Clustered = true; } }
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "QffQuery.al"), """
+        query 62462 "QFF Header FlowField"
+        {
+            QueryType = Normal;
+            elements
+            {
+                dataitem(QffHeader; "QFF Header")
+                {
+                    column(No; "No.") { }
+                    column(TotalAmount; "Total Amount") { }
+                }
+            }
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "QffTests.al"), """
+        codeunit 62463 "QFF 2300 Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure FlowFieldColumn_ReadsCalculatedValue()
+            var
+                QffHeader: Record "QFF Header";
+                QffLine: Record "QFF Line";
+                Q: Query "QFF Header FlowField";
+                Total: Decimal;
+            begin
+                QffHeader.Init(); QffHeader."No." := 'H1'; QffHeader.Insert();
+                QffLine.Init(); QffLine."Entry No." := 1; QffLine."Header No." := 'H1'; QffLine.Amount := 10.5; QffLine.Insert();
+                QffLine.Init(); QffLine."Entry No." := 2; QffLine."Header No." := 'H1'; QffLine.Amount := 4.5; QffLine.Insert();
+
+                Q.SetRange(No, 'H1');
+                Q.Open();
+                if not Q.Read() then
+                    Error('expected one row');
+                Total := Q.TotalAmount;
+                Q.Close();
+                if Total <> 15 then
+                    Error('Expected 15, got %1', Total);
+            end;
+
+            [Test]
+            procedure FlowFieldColumn_NoMatchingSourceRows_ReadsZero()
+            var
+                QffHeader: Record "QFF Header";
+                Q: Query "QFF Header FlowField";
+                Total: Decimal;
+            begin
+                QffHeader.Init(); QffHeader."No." := 'H2'; QffHeader.Insert();
+
+                Q.SetRange(No, 'H2');
+                Q.Open();
+                if not Q.Read() then
+                    Error('expected one row');
+                Total := Q.TotalAmount;
+                Q.Close();
+                if Total <> 0 then
+                    Error('Expected 0 (no matching QFF Line rows), got %1', Total);
+            end;
+        }
+        """);
+
+        return root;
+    }
+
+    [SkippableFact]
+    public void QueryFlowFieldColumn_ReadsCalculatedValue_InsteadOfCrashingOrCorruptingTheValue()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var bundle = WriteBundle();
+        var (output, exitCode) = RunRunner(bundle);
+
+        // Never silently pass a run that failed to even get the test codeunit compiled/run.
+        Assert.DoesNotContain("EMIT-EXCLUDED", output);
+        Assert.DoesNotContain("COMPILE FAIL", output);
+        // The two crashes this issue reports, both must be gone.
+        Assert.DoesNotContain("NavSqlStatementHelper.ConvertToSqlIdentifier", output);
+        Assert.DoesNotContain("NavNCLConversionException", output);
+        // Both tests must have run and passed — 2P/0F/0E is TestExecutor's own per-bundle
+        // summary line (see CrossBundleModuleIdentityDedupTests for the same convention).
+        Assert.Contains("2P/0F/0E", output);
+    }
+}

--- a/AlRunner/Patches/FlowFieldPatches.cs
+++ b/AlRunner/Patches/FlowFieldPatches.cs
@@ -903,15 +903,30 @@ public static class FlowFieldPatches
     /// </summary>
     internal static NavValue? CalcOneFlowFieldForQueryRow(object rowBuffer, NCLMetaField flowFieldMeta)
     {
-        object? session = null;
-        try
-        {
-            var tNCT = flowFieldMeta.GetType().Assembly.GetType("Microsoft.Dynamics.Nav.Runtime.NavCurrentThread");
-            var pSess = tNCT?.GetProperty("Session", BindingFlags.Public | BindingFlags.Static);
-            session = pSess?.GetValue(null);
-        }
-        catch { }
-        if (session == null) return null;
+        // NavCurrentThread.Session must resolve on every real test run (CalcFlowFieldValuesCore
+        // below is unreachable without it, and every other FlowField entry point in this file —
+        // RecordImpl_CalcFieldsAsync_3 above — relies on the SAME static resolving). Swallowing
+        // a reflection failure here and returning null would silently read a query FlowField
+        // column as unset/default instead of its calculated value — the loud-failures.md silent
+        // default this file exists to avoid everywhere else. Fail loudly instead, naming the
+        // surface and the field, so a genuine artifact incompatibility is visible rather than
+        // read back as "the value is 0/empty".
+        var tNCT = flowFieldMeta.GetType().Assembly.GetType("Microsoft.Dynamics.Nav.Runtime.NavCurrentThread")
+            ?? throw new InvalidOperationException(
+                $"CalcOneFlowFieldForQueryRow('{flowFieldMeta.FieldName}' on "
+                + $"'{flowFieldMeta.Parent?.TableName}'): Microsoft.Dynamics.Nav.Runtime.NavCurrentThread "
+                + "type not found in the Ncl assembly — cannot resolve the current NavSession to "
+                + "compute this query FlowField column.");
+        var pSess = tNCT.GetProperty("Session", BindingFlags.Public | BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                $"CalcOneFlowFieldForQueryRow('{flowFieldMeta.FieldName}' on "
+                + $"'{flowFieldMeta.Parent?.TableName}'): NavCurrentThread.Session property not "
+                + "found — cannot resolve the current NavSession to compute this query FlowField column.");
+        var session = pSess.GetValue(null)
+            ?? throw new InvalidOperationException(
+                $"CalcOneFlowFieldForQueryRow('{flowFieldMeta.FieldName}' on "
+                + $"'{flowFieldMeta.Parent?.TableName}'): NavCurrentThread.Session returned null — "
+                + "no current session to compute this query FlowField column against.");
 
         // The runner is single-company; token 0 is the runner's own unnamed company (see
         // RecordPatches.cs's companyTokens skeleton-state comment) — the same value every other

--- a/AlRunner/Patches/FlowFieldPatches.cs
+++ b/AlRunner/Patches/FlowFieldPatches.cs
@@ -885,6 +885,45 @@ public static class FlowFieldPatches
         }
     }
 
+    /// <summary>
+    /// #2300 — compute a FlowField's value for one QUERY result row, the same way a `Record.
+    /// CalcFields` call computes it for one record row (via <see cref="CalcFlowFieldValuesCore"/>
+    /// — the same source-row enumeration, formula-filter resolution and aggregation, just entered
+    /// from the query projection layer instead of RecordImplementation). BC's own query engine
+    /// answers this by naming the FlowField a synthesized `OuterApply` sub-dataitem
+    /// (<c>NCLMetaQuery.CreateSubQueryForFlowFieldCalculation</c>) and letting SQL execute it —
+    /// the runner has no SQL to run that sub-query against, so it computes the value directly
+    /// against the in-memory store instead. <paramref name="rowBuffer"/> is the QUERY row
+    /// (<c>ReadOnlyRecordBuffer</c>, boxed as <c>object</c> since QueryProjection.cs isn't allowed
+    /// to hand a typed reference across the same isolation boundary that keeps AlRunner.QueryJoin
+    /// Ncl-free) — it satisfies BC's own <c>IRecordBuffer</c> the same as a record's
+    /// <c>MutableRecordBuffer</c> does, which is what <c>GetFilterFromMetaFilterCollection</c>
+    /// actually requires (its parameter type is the interface, not the concrete buffer type), so
+    /// CalcFlowFieldValuesCore needs no changes to accept it.
+    /// </summary>
+    internal static NavValue? CalcOneFlowFieldForQueryRow(object rowBuffer, NCLMetaField flowFieldMeta)
+    {
+        object? session = null;
+        try
+        {
+            var tNCT = flowFieldMeta.GetType().Assembly.GetType("Microsoft.Dynamics.Nav.Runtime.NavCurrentThread");
+            var pSess = tNCT?.GetProperty("Session", BindingFlags.Public | BindingFlags.Static);
+            session = pSess?.GetValue(null);
+        }
+        catch { }
+        if (session == null) return null;
+
+        // The runner is single-company; token 0 is the runner's own unnamed company (see
+        // RecordPatches.cs's companyTokens skeleton-state comment) — the same value every other
+        // FlowField/query code path in this runner uses when no per-record company token is
+        // available.
+        var results = new List<Tuple<INavFieldMetadata, NavValue>>();
+        CalcFlowFieldValuesCore(session, companyToken: 0, rowBuffer,
+            parentFiltersAndMarks: null, securityFiltering: null, alIsolationLevel: null,
+            new NCLMetaField[] { flowFieldMeta }, recursionLevel: 0, results);
+        return results.Count > 0 ? results[0].Item2 : null;
+    }
+
     // ── BC recursion guards ──────────────────────────────────────────────────
     // FlowFieldsHelper's own constant, and its own exception. Both guards are BC's, not the
     // runner's: a self-referencing or mutually-referencing CalcFormula must produce exactly

--- a/AlRunner/Patches/RecordPatches.QueryProjection.cs
+++ b/AlRunner/Patches/RecordPatches.QueryProjection.cs
@@ -156,8 +156,23 @@ public static partial class RecordPatches
     {
         EnsureGetDataAccessForQueryReflection(self);
 
-        var includedTables = (System.Collections.IEnumerable)_pQueryDefIncludedTables!.GetValue(queryDefinition)!;
-        var tableList = includedTables.Cast<object>().ToList();
+        // #2300: NOT NCLMetaQueryDefinition.IncludedTables. That BC-real property calls
+        // NCLMetaQueryDefinition.GetAllDataItems, which for a FlowField-calculation synthesized
+        // dataitem (SubQueryDefinition != null — see JoinExecutor.cs's field comment) does NOT
+        // skip it, it recurses into dataItem.SubQueryDefinition.DataItems and includes THAT
+        // table too (real BC needs it there for its own SQL sub-query). This runner never runs
+        // that sub-query — the FlowField column is computed directly instead (FlowFieldPatches.
+        // CalcOneFlowFieldForQueryRow) — so from here a query with one real dataitem plus a
+        // FlowField column must still resolve to ONE table, not two, or the "all tables share
+        // one DataAccess" check below wrongly routes it into the multi-dataitem JOIN path.
+        var tableList = new List<object>();
+        var rawDataItems = (System.Collections.IEnumerable)_pQueryDefDataItems2!.GetValue(queryDefinition)!;
+        foreach (var di in rawDataItems)
+        {
+            if (_pDataItemSubQueryDefinition2?.GetValue(di) != null) continue;
+            var t = _pDataItemMetaTable2b!.GetValue(di);
+            if (t != null) tableList.Add(t);
+        }
 
         // Resolve each included table's DataAccess via the (already-hooked) per-table route.
         var accesses = new List<object>();
@@ -186,6 +201,10 @@ public static partial class RecordPatches
         return accesses[0];
     }
 
+    private static PropertyInfo? _pQueryDefDataItems2;
+    private static PropertyInfo? _pDataItemSubQueryDefinition2;
+    private static PropertyInfo? _pDataItemMetaTable2b;
+
     private static void EnsureGetDataAccessForQueryReflection(object dataAccessSource)
     {
         if (_pQueryDefIncludedTables != null) return;
@@ -195,6 +214,17 @@ public static partial class RecordPatches
         _pQueryDefIncludedTables = tQueryDef.GetProperty("IncludedTables",
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("NCLMetaQueryDefinition.IncludedTables not found");
+        // #2300: DataItems is internal (no InternalsVisibleTo from al-runner.dll), so it must be
+        // read by reflection here, unlike IncludedTables' sibling fields above which happen to be
+        // reachable directly elsewhere in this file.
+        _pQueryDefDataItems2 = tQueryDef.GetProperty("DataItems",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("NCLMetaQueryDefinition.DataItems not found");
+        var tDataItem = nclAsm.GetType(rt + "NCLMetaQueryDataItem")!;
+        _pDataItemSubQueryDefinition2 = tDataItem.GetProperty("SubQueryDefinition",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        _pDataItemMetaTable2b = tDataItem.GetProperty("MetaTable",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
         var tDataAccess = nclAsm.GetType(rt + "DataAccess")!;
         _pDataAccessDataProvider = tDataAccess.GetProperty("DataProvider",
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
@@ -810,6 +840,12 @@ public static partial class RecordPatches
         // straight to NavValue.CreateNavValueFromObject / FlowFieldPatches.TypedDefaultForField
         // to produce a value of the COLUMN's own declared type, not the source field's.
         public NCLMetaQueryColumn Column = null!;
+        // #2300: non-null when SourceTableField.FieldClass == FlowField. A FlowField has no
+        // stored slot in the table's row buffer (TableSlot's ColumnIndex points at storage that
+        // was never written), so BuildRow computes it directly via FlowFieldPatches instead of
+        // reading the buffer, the same way BC's own query engine computes it via a synthesized
+        // OuterApply sub-query this runner has no SQL to execute.
+        public NCLMetaField? FlowFieldMeta;
     }
 
     private sealed class ProjectionPlan
@@ -920,6 +956,16 @@ public static partial class RecordPatches
             if (c.Aggregation != AggregationType.None)
             {
                 fields[c.QuerySlot] = ComputeAggregate(c, groupRows);
+                continue;
+            }
+            // #2300: a non-aggregated FlowField column — compute directly rather than reading
+            // the (never-written) buffer slot. Method=Sum/etc. on a FlowField SOURCE column is
+            // routed through ComputeAggregate above instead, which still reads the buffer slot;
+            // that combination is unmeasured (no oracle case covers it) and left as a documented
+            // follow-up rather than guessed at here.
+            if (c.FlowFieldMeta != null && groupRows.Count > 0)
+            {
+                fields[c.QuerySlot] = FlowFieldPatches.CalcOneFlowFieldForQueryRow(groupRows[0], c.FlowFieldMeta);
                 continue;
             }
             if (c.TableSlot < 0 || groupRows.Count == 0 || c.TableSlot >= groupRows[0].FieldCount)
@@ -1037,6 +1083,27 @@ public static partial class RecordPatches
         return arr;
     }
 
+    private static PropertyInfo? _pDataItemSourceFlowField;
+    private static bool _sourceFlowFieldResolved;
+
+    /// <summary>
+    /// #2300: NCLMetaQueryDataItem.SourceFlowField (internal — reflection required, same as
+    /// every other internal Ncl member this file already reaches this way). Non-null on the
+    /// synthesized FlowField-calculation sub-dataitem BC's own NCLMetaQuery.
+    /// CreateSubQueryForFlowFieldCalculation builds; identifies WHICH FlowField NCLMetaField
+    /// this dataitem's own aggregate result column stands in for.
+    /// </summary>
+    private static NCLMetaField? GetSourceFlowField(object dataItem)
+    {
+        if (!_sourceFlowFieldResolved)
+        {
+            _sourceFlowFieldResolved = true;
+            _pDataItemSourceFlowField = dataItem.GetType().GetProperty("SourceFlowField",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        }
+        return _pDataItemSourceFlowField?.GetValue(dataItem) as NCLMetaField;
+    }
+
     private static ProjectionPlan BuildProjectionPlan(object nclMetaQuery)
     {
         var queryDef = (NCLMetaQueryDefinition)_tNCLMetaQuery!.GetProperty("QueryDefinition", BindingFlags.Public | BindingFlags.Instance)!
@@ -1051,29 +1118,57 @@ public static partial class RecordPatches
             if (querySlot > maxSlot) maxSlot = querySlot;
 
             int tableSlot = -1;
-            // SourceTableField throws NotSupportedException for a ConstValue column (no
-            // source field at all — pre-existing, documented follow-up, unrelated to #2137);
-            // treat that as "unsupported → leave at default", same as before this fix.
-            try
+            NCLMetaField? flowFieldMeta = null;
+
+            // #2300: a column whose dataitem is a FlowField-calculation synthesized subquery
+            // (SUB$<dataitem>$<column>, DataItemLinkType.OuterApply) represents the OUTER
+            // "TotalAmount"-style result — the very column AL's compiled Id/ColumnIndex expect
+            // (CreateSubQueryForFlowFieldCalculation builds it with flowFieldColumn.Id/
+            // .QueryColumnIndex verbatim). ITS OWN AggregationType is Sum/Count/etc — BC's
+            // SQL groups it away inside the sub-query, invisibly to the outer projection — and
+            // its SourceTableField resolves to the SOURCE field on the SUB-QUERY's OWN inner
+            // table (e.g. "Qff Line".Amount), not a field on THIS row's table at all. Reading
+            // that field's ColumnIndex against the CURRENT (outer-table) row buffer is exactly
+            // the #2300 corruption: whatever real, unrelated field happens to sit at that slot
+            // on the OUTER table (observed: the table's own SystemId, a Guid) gets returned
+            // instead. This must be checked and handled BEFORE the generic aggregation/
+            // TableSlot branches below, which would otherwise take it first.
+            var sourceFlowField = GetSourceFlowField(col.ParentDataItem);
+            if (sourceFlowField != null)
             {
-                if (col.ColumnType != QueryColumnType.ConstValue)
-                {
-                    var srcField = col.SourceTableField;
-                    if (srcField != null) tableSlot = srcField.ColumnIndex;
-                }
+                flowFieldMeta = sourceFlowField;
             }
-            catch { tableSlot = -1; }
+            else
+            {
+                // SourceTableField throws NotSupportedException for a ConstValue column (no
+                // source field at all — pre-existing, documented follow-up, unrelated to #2137);
+                // treat that as "unsupported → leave at default", same as before this fix.
+                try
+                {
+                    if (col.ColumnType != QueryColumnType.ConstValue)
+                    {
+                        var srcField = col.SourceTableField;
+                        if (srcField != null) tableSlot = srcField.ColumnIndex;
+                    }
+                }
+                catch { tableSlot = -1; }
+            }
 
             var aggregation = col.AggregationType;
-            if (aggregation != AggregationType.None) hasAggregate = true;
+            // A FlowField-calculation column is computed whole (FlowFieldPatches.
+            // CalcOneFlowFieldForQueryRow), independent of the runner's OWN #2137 GROUP BY —
+            // its Sum/Count/etc AggregationType describes what BC's SQL sub-query does
+            // INTERNALLY, not an aggregation this projection layer must additionally perform.
+            if (flowFieldMeta == null && aggregation != AggregationType.None) hasAggregate = true;
 
             columnPlans.Add(new ColumnPlan
             {
                 QuerySlot = querySlot,
                 TableSlot = tableSlot,
-                Aggregation = aggregation,
-                IsGroupKey = aggregation == AggregationType.None && col.ColumnType == QueryColumnType.Normal,
+                Aggregation = flowFieldMeta == null ? aggregation : AggregationType.None,
+                IsGroupKey = flowFieldMeta == null && aggregation == AggregationType.None && col.ColumnType == QueryColumnType.Normal,
                 Column = col,
+                FlowFieldMeta = flowFieldMeta,
             });
         }
         return new ProjectionPlan { SlotCount = maxSlot + 1, Columns = columnPlans.ToArray(), HasAggregate = hasAggregate };

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -430,6 +430,22 @@ public static partial class RecordPatches
                 ?.SetValue(sqlDbProps, new object());
             tSqlDbProps.GetField("databasePropertiesReady", BindingFlags.NonPublic | BindingFlags.Instance)
                 ?.SetValue(sqlDbProps, true);
+            // #2300: NavSqlDatabaseProperties.InvalidIdentifierChars is read by
+            // NavSqlStatementHelper.ConvertToSqlIdentifier (via NCLMetaTable.SqlTableName),
+            // which a Query with a FlowField column reaches while naming the FlowField's
+            // synthesized sub-dataitem (NCLMetaQuery.CreateSubQueryForFlowFieldCalculation
+            // → SqlTableDataProviderHelper.CreateDataItemFromFlowField). GetUninitializedObject
+            // leaves the private `invalidIdentifierChars` field null, and ConvertToSqlIdentifier
+            // iterates it unconditionally — NRE before any row is read, regardless of whether the
+            // identifier it's naming actually contains an invalid character. Populate it from BC's
+            // own internal constant (read via reflection, not restated as a literal, so a future
+            // BC version's different default is picked up automatically rather than silently
+            // diverging) — the same value the real ctor assigns before any SQL round-trip.
+            var fDefaultInvalidChars = tSqlDbProps.GetField("DefaultInvalidIdentifierChars",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            var defaultInvalidChars = fDefaultInvalidChars?.GetRawConstantValue() as string ?? ".\"\\/'%][";
+            tSqlDbProps.GetField("invalidIdentifierChars", BindingFlags.NonPublic | BindingFlags.Instance)
+                ?.SetValue(sqlDbProps, defaultInvalidChars);
             fSqlDbProps.SetValue(_skeletonDatabase, sqlDbProps);
         }
         // companyTokens — BC's own NavDatabase ctor does `companyTokens = new CompanyTokens(this)`,


### PR DESCRIPTION
No linked issue: this PR fixes the single-real-dataitem FlowField query case investigated
under issue 2300, but does not close it -- two of that issue's three oracle cases still
need #2295 and #2423 as well. See #2300 for the full picture and #2423 for the gap this
PR's own investigation found and filed.

## Root cause (three parts)

1. **The reported NRE.** BC builds a FlowField query column's synthesized `OuterApply`
   sub-dataitem via `NCLMetaQuery.CreateSubQueryForFlowFieldCalculation ->
   SqlTableDataProviderHelper.CreateDataItemFromFlowField -> NCLMetaTable.SqlTableName ->
   NavSqlStatementHelper.ConvertToSqlIdentifier`. The skeleton `NavSqlDatabaseProperties`
   (built via `GetUninitializedObject`, which skips field initializers) left the private
   `invalidIdentifierChars` field null, and `ConvertToSqlIdentifier` iterates it
   unconditionally -- NRE before any row is read, regardless of whether the identifier
   being named actually contains an invalid character. Fixed by populating it from BC's own
   internal `NavSqlDatabaseProperties.DefaultInvalidIdentifierChars` constant, read via
   reflection rather than restated as a literal.

2. **Fixing that NRE moved the failure, not removed it.**
   `DataAccessSource_GetDataAccessForQuery` decided whether a query is effectively
   single-table using `NCLMetaQueryDefinition.IncludedTables`. That BC-real property
   intentionally recurses into a FlowField sub-dataitem's own inner source table (real BC's
   SQL needs it there for its own sub-query) -- so a query with ONE real dataitem plus a
   FlowField column always reported 2 included tables and got routed into the (here
   unsupported) multi-dataitem JOIN path. Fixed by deriving the table list from the query's
   real (non-subquery) dataitems instead of `IncludedTables`.

3. **The value corruption this surfaced.** `BuildProjectionPlan` iterated
   `NCLMetaQueryDefinition.Columns`, which flattens every dataitem's `QueryColumns` --
   including the FlowField sub-dataitem's own internal aggregate column. That column's
   `AggregationType` (Sum/etc) routed it through the #2137 GROUP BY machinery, and its
   `SourceTableField` resolves to the SOURCE table's field (e.g. the summed field on the
   FlowField's source table), not a field on the outer row's own table -- reading that
   field's `ColumnIndex` against the outer row buffer returned whatever unrelated field
   actually sits at that slot on the OUTER table. In the reported repro this was the outer
   table's own `SystemId` (a Guid), surfacing as `NavNCLConversionException: Unable to
   convert from NavGuid to Int32` at the AL assignment.
   `NCLMetaQueryDataItem.SourceFlowField` (set by BC's own
   `CreateSubQueryForFlowFieldCalculation`) is the correct discriminator: a column whose
   `ParentDataItem` carries one is now computed via `FlowFieldPatches.
   CalcOneFlowFieldForQueryRow` (the same per-row calculation `Record.CalcFields` already
   uses) instead of `TableSlot`/the generic aggregation path.

## What's fixed and what isn't

**Fixed and GREEN:** the local-table FlowField case (`LocalFlowFieldColumn_ReadsCalculatedValue`)
-- a single real dataitem with a `Method`-less FlowField column reads the correct calculated
value (15, matching the oracle).

**Still RED, on purpose -- this PR alone is not sufficient for issue 2300** -- its other
two oracle cases need MORE than this PR:

- `IleFlowFieldColumn_ReadsCalculatedValue` (single dataitem, `Item Ledger Entry` FlowField)
  is blocked ONLY on #2295: confirmed via the issue's own three-case repro that it hits a
  **different, unrelated** NRE before ever reaching the FlowField machinery this PR fixes --
  `NavQuery.ValidateExpectedType` -- the exact shape tracked in #2295 (a namespace-qualified
  `RelatedTable` on a dependency table not being normalized). Once #2295 lands, this case is
  expected to pass without further work here; I'll verify that in #2295's own PR against the
  combined `main`.
- `JoinIleFlowFieldColumn_ReadsCalculatedValue` (JOIN + FlowField column) is blocked on BOTH
  #2295 AND a SEPARATE gap this PR deliberately does not fix: `AlRunner.QueryJoin.
  JoinExecutor.BuildJoinProjectionPlan` (and its al-runner-side mirror,
  `RecordPatches.QueryProjection.ComputeJoinColumnSlotMap`) still enumerate ALL raw dataitems,
  including the FlowField-calculation synthesized sub-dataitem, and have no code path routing
  a FlowField-sourced column through `FlowFieldPatches.CalcOneFlowFieldForQueryRow` the way
  the single-dataitem path (this PR) now does -- so even once #2295 unblocks the query's
  metadata construction, the join projection will still read either a wrong value or throw a
  type-conversion exception. Filed as #2423, with the mechanism this repro's investigation
  found. This case will NOT pass once #2295 merges; it needs #2423 as well.

## Tests

- `AlRunner.Tests/QueryFlowFieldColumnProjectionTests.cs` -- runner-mechanism test pinning
  all three fixes together (local-table case only, `platform` not `application`), spawning
  the real runner. Asserts the sum, and a zero-source-rows case.
- Upstream corpus PR (real BC 27.0-28.4 adjudicates the BC-behavior claim):
  StefanMaron/BusinessCentral.AL.Language.Tests#100 -- all 8 BC legs green. Adds a query
  FlowField column test to the corpus (no existing test read a query FlowField column's
  value). Not yet merged; the submodule pin is **not** bumped in this PR -- see follow-up
  note below.

## RED -> GREEN

Confirmed against the issue's own minimal repro (local table + Base App `Item Ledger Entry`,
three cases), rebuilt on top of #2416's merged `main` (`5604ea19`): before this fix, all
three cases fail (`InvalidOperationException: no NCLMetaTable for table 0` for the local
case, `NullReferenceException` for both ILE cases). After this fix: the local case passes
with the oracle value (15); the two ILE cases still fail, now with the #2295-shape NRE
instead of the #2300-shape one -- confirming this fix addresses exactly what it claims to and
nothing more.

## Loud failures

`FlowFieldPatches.CalcOneFlowFieldForQueryRow` originally swallowed a failure to resolve
`NavCurrentThread.Session` via reflection and returned `null` in that case -- a silent
default on the read path, forbidden by `.claude/rules/loud-failures.md` (a query FlowField
column would read back as unset/default instead of throwing when the artifact genuinely
lacks the expected shape). Changed to throw `InvalidOperationException` naming the surface,
the FlowField, and its owning table, at each of the three points reflection could fail
(type not found, property not found, value null) -- matching the idiom this file already
uses elsewhere (e.g. `FlowFieldsHelper_CalcFieldsAsync`'s `RunnerOutOfScopeException` for an
unresolvable `FieldDictionary<NavValue>`).

## Fix the shape, not just the reported line

- Checked whether the `IncludedTables`-vs-real-dataitems mismatch could affect a
  multi-real-dataitem query that ALSO has a FlowField column (not one of the three oracle
  cases): `JoinExecutor.Execute`'s own dataitem enumeration was fixed the same way
  (`GetRealDataItems`, excluding `SubQueryDefinition != null` dataitems) so it no longer
  crashes calling `.MetaTable` on a FlowField sub-dataitem -- but `BuildJoinProjectionPlan`
  and its al-runner-side mirror `ComputeJoinColumnSlotMap` were deliberately left untouched
  (documented in a code comment): that combination isn't wired to compute a FlowField column's
  value at all yet, and touching only one of the two methods the file explicitly requires to
  mirror each other would have been worse than leaving both consistent with each other and
  with the pre-existing gap.

## Follow-up

- StefanMaron/BusinessCentral.AL.Language.Tests#100 needs to merge before the submodule pin
  can be bumped here (a pin bump can't be its own PR -- see `al-language-submodule.md`). Once
  merged, a follow-up PR bumps the pin together with the `tests/expectations/count-baseline/`
  update.
- #2295 is expected to unblock the two ILE oracle cases; verification will happen in that
  PR against the combined `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VvUgMSPokJWzeFNVQxD5J
