### PR TITLE
fix(query): normalize a module-qualified RelatedTable on Query dataitems

### DIFF
--- a/AlRunner.QueryJoin/JoinExecutor.cs
+++ b/AlRunner.QueryJoin/JoinExecutor.cs
@@ -551,6 +551,32 @@ public static class JoinExecutor
         int maxSlot = -1;
         var dataItems = ((IEnumerable)_pQueryDefDataItems!.GetValue(queryDef)!).Cast<object>().ToList();
 
+        // #2423: a multi-real-dataitem JOIN that also selects a FlowField column reaches this
+        // plan with the FlowField-calculation synthesized dataitem (SubQueryDefinition != null
+        // -- see the field comment above) still in the RAW dataitem list, same as GetRealDataItems
+        // filters out elsewhere. Its own "column" is a real NCLMetaQueryColumn with the outer
+        // AL-compiled Id/ColumnIndex (see #2300's PR body), so ResolveTableSlot below resolves it
+        // to a field on the FlowField's SOURCE table -- a table this join never reads a row buffer
+        // for at all (Execute's own row-reading, above, already excludes this dataitem). Before
+        // this guard, that silently produced the column's typed default (observed: 0 instead of
+        // the oracle's 7.25) -- a wrong answer read back with no error, exactly the silent default
+        // .claude/rules/loud-failures.md forbids. Neither BuildJoinProjectionPlan nor its
+        // al-runner-side mirror ComputeJoinColumnSlotMap route a FlowField column through
+        // FlowFieldPatches.CalcOneFlowFieldForQueryRow the way the single-dataitem projection path
+        // (#2300) does -- tracked as the remaining gap in #2423. Fail loudly instead of guessing.
+        foreach (var di in dataItems)
+        {
+            if (_pDataItemSubQueryDefinition!.GetValue(di) == null) continue;
+            var subDataItemName = (string)_pDataItemName!.GetValue(di)!;
+            throw ctx.OutOfScope(
+                "NavQuery (multi-dataitem join with a FlowField column)",
+                $"query-join-flowfield-column-not-implemented -- dataitem '{subDataItemName}' is the " +
+                "synthesized FlowField-calculation sub-dataitem for a column selected alongside a " +
+                "real multi-dataitem JOIN; this runner does not yet compute a FlowField column's " +
+                "value in the join projection path (only the single-real-dataitem case is wired, " +
+                "via FlowFieldPatches.CalcOneFlowFieldForQueryRow) -- see #2423");
+        }
+
         // Pass 1: genuinely-projected (non-filter-only) columns get their real ColumnIndex slot.
         foreach (var di in dataItems)
         {

--- a/AlRunner.Tests/BcAppSymbolCacheQueryModuleQualifierTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCacheQueryModuleQualifierTests.cs
@@ -1,0 +1,177 @@
+// BcAppSymbolCacheQueryModuleQualifierTests — proves BcAppSymbolCache.TryParseQueryDataItem
+// strips the module qualifier off a Query dataitem's RelatedTable (issue #2295).
+//
+// Gap being fixed
+// ----------------
+// A Query dataitem bound to a table from a DIFFERENT module (a dependency application's
+// table — Base Application's Item is the reported case, but the shape is any cross-module
+// reference) arrives in SymbolReference.json as a module-qualified name:
+// "#<appIdNoHyphens>#Item", not the plain "Item". BcAppSymbolCache.TryParseQueryDataItem used
+// to preserve that string verbatim as QueryDataItemSymbol.RelatedTable.
+// RecordPatches.ResolveTableIdByName then compares it against ordinary (unqualified) table
+// names and never matches, so RecordPatches.NclMetaQueryBuilder.BuildMetaQueryDesign abandons
+// the build and the Query is constructed with NCLMetaQuery=NULL — every SetRange/Open/Read on
+// it then NREs deep inside precompiled NavQuery methods (ValidateExpectedType,
+// ValidateTablesNotVirtual), long before any AL-observable "table not found" error. Report
+// dataitems already had this normalization (BcAppSymbolCache.StripModuleQualifier, applied by
+// CollectReportDataItems); Query dataitems did not.
+//
+// Test strategy
+// -------------
+// Constructs a minimal .app (a zip with a hand-written SymbolReference.json — the same
+// zip-with-raw-JSON technique BcAppSymbolCacheQueryMethodVersionTests uses) whose Query
+// dataitem's RelatedTable is module-qualified, exactly the shape the compiler emits for a
+// cross-module reference. Calls BcAppSymbolCache.Get() directly — no full AL compile, no Base
+// Application dependency needed, so this stays within the C#-fixture "platform, never
+// application" rule while still exercising the REAL parsing code path end to end. Asserts the
+// parsed RelatedTable is the unqualified name, for both the root dataitem and a nested one
+// (the fix lives in the one recursive TryParseQueryDataItem call, so both must normalize).
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(CacheRootsSerialCollection.Name)]
+public sealed class BcAppSymbolCacheQueryModuleQualifierTests
+{
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "bc-symbol-cache-query-module-qualifier-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static string WriteApp(string dir, string fileName, string queryName)
+    {
+        var appPath = Path.Combine(dir, fileName);
+        using (var zip = new FileStream(appPath, FileMode.Create))
+        using (var za = new ZipArchive(zip, ZipArchiveMode.Create))
+        {
+            var entry = za.CreateEntry("SymbolReference.json");
+            using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+            // "#437dbf0e84ff417a965ded2bb9650972#Item" — the exact qualified-reference shape
+            // from the issue's own diagnostic output, on both the root dataitem AND a nested
+            // one (a table from yet another module, so the two don't coincidentally match).
+            w.Write($$"""
+                {
+                  "RuntimeVersion": "15.1",
+                  "Queries": [
+                    {
+                      "Id": 90310,
+                      "Name": "{{queryName}}",
+                      "Properties": [ { "Name": "QueryType", "Value": "Normal" } ],
+                      "Elements": [
+                        {
+                          "Id": 1,
+                          "Name": "Item",
+                          "RelatedTable": "#437dbf0e84ff417a965ded2bb9650972#Item",
+                          "Properties": [],
+                          "Columns": [
+                            { "Id": 1, "Name": "No", "SourceColumn": "No.", "Properties": [] }
+                          ],
+                          "Filters": [],
+                          "DataItems": [
+                            {
+                              "Id": 2,
+                              "Name": "ItemLedgerEntry",
+                              "RelatedTable": "#9a1b2c3d4e5f60718293a4b5c6d7e8f9#Item Ledger Entry",
+                              "Properties": [ { "Name": "SqlJoinType", "Value": "InnerJoin" }, { "Name": "DataItemLink", "Value": "\"No.\" = Item.\"No.\"" } ],
+                              "Columns": [
+                                { "Id": 2, "Name": "EntryNo", "SourceColumn": "Entry No.", "Properties": [] }
+                              ],
+                              "Filters": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """);
+        }
+        return appPath;
+    }
+
+    [Fact]
+    public void Get_QueryDataItemWithModuleQualifiedRelatedTable_StripsQualifierOnRootAndNested()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var queryName = "IQ Item Rows " + Guid.NewGuid().ToString("N");
+            var appPath = WriteApp(dir, "iq-" + Guid.NewGuid().ToString("N") + ".app", queryName);
+
+            BcAppSymbolCache.ResetProcessCacheForTests();
+
+            var symbols = BcAppSymbolCache.Get(appPath);
+
+            var query = Assert.Single(symbols.Queries, q => q.Name == queryName);
+            var root = Assert.Single(query.DataItems);
+            var nested = Assert.Single(root.DataItems);
+
+            // The decisive assertions: both dataitems' RelatedTable is the PLAIN name — the
+            // qualifier is gone, not just tolerated somewhere downstream — which is exactly
+            // what RecordPatches.ResolveTableIdByName needs to match against ordinary
+            // (unqualified) table names.
+            Assert.Equal("Item", root.RelatedTable);
+            Assert.Equal("Item Ledger Entry", nested.RelatedTable);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    /// <summary>
+    /// Negative/control companion: an UNQUALIFIED RelatedTable (an application-local table,
+    /// the shape every other Query test in this repo already exercises) must pass through
+    /// unchanged — StripModuleQualifier only strips a leading module-qualifier form, and
+    /// this proves the fix does not corrupt the far more common local-table case.
+    /// </summary>
+    [Fact]
+    public void Get_QueryDataItemWithPlainRelatedTable_IsUnchanged()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var queryName = "IQ Plain Rows " + Guid.NewGuid().ToString("N");
+            var appPath = Path.Combine(dir, "iq-plain-" + Guid.NewGuid().ToString("N") + ".app");
+            using (var zip = new FileStream(appPath, FileMode.Create))
+            using (var za = new ZipArchive(zip, ZipArchiveMode.Create))
+            {
+                var entry = za.CreateEntry("SymbolReference.json");
+                using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+                w.Write($$"""
+                    {
+                      "RuntimeVersion": "15.1",
+                      "Queries": [
+                        {
+                          "Id": 90311,
+                          "Name": "{{queryName}}",
+                          "Properties": [ { "Name": "QueryType", "Value": "Normal" } ],
+                          "Elements": [
+                            {
+                              "Id": 1,
+                              "Name": "LocalTable",
+                              "RelatedTable": "IQ Local Table",
+                              "Properties": [],
+                              "Columns": [ { "Id": 1, "Name": "No", "SourceColumn": "No.", "Properties": [] } ],
+                              "Filters": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                    """);
+            }
+
+            BcAppSymbolCache.ResetProcessCacheForTests();
+
+            var symbols = BcAppSymbolCache.Get(appPath);
+
+            var query = Assert.Single(symbols.Queries, q => q.Name == queryName);
+            var root = Assert.Single(query.DataItems);
+            Assert.Equal("IQ Local Table", root.RelatedTable);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}

--- a/AlRunner.Tests/QueryJoinFlowFieldColumnOosTests.cs
+++ b/AlRunner.Tests/QueryJoinFlowFieldColumnOosTests.cs
@@ -1,0 +1,195 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #2423 -- a multi-real-dataitem JOIN query that ALSO selects a FlowField column
+/// silently read the column's typed default (observed: 0) instead of the calculated value,
+/// once #2295 unblocked the query's own metadata construction. #2300 fixed the
+/// single-real-dataitem FlowField case (via NCLMetaQueryDataItem.SourceFlowField and
+/// FlowFieldPatches.CalcOneFlowFieldForQueryRow), but deliberately left the join projection
+/// path (AlRunner.QueryJoin.JoinExecutor.BuildJoinProjectionPlan and its al-runner-side
+/// mirror RecordPatches.QueryProjection.ComputeJoinColumnSlotMap) unwired for a FlowField
+/// column: both still resolve the FlowField sub-dataitem's own aggregate column via a
+/// generic TableSlot read against the SOURCE table (the FlowField's own source, not any
+/// table the join actually reads a row buffer for), which silently produced the column's
+/// typed default rather than either the real value or an error.
+///
+/// This is a RUNNER-MECHANISM test pinning the loud-failure guard #2423's own investigation
+/// added: BuildJoinProjectionPlan/ComputeJoinColumnSlotMap now throw
+/// RunnerOutOfScopeException (reason query-join-flowfield-column-not-implemented, naming the
+/// synthesized sub-dataitem and "see #2423") the moment they encounter that sub-dataitem,
+/// instead of silently defaulting the column -- a silent wrong answer is exactly what
+/// .claude/rules/loud-failures.md forbids. Implementing the real join+FlowField computation
+/// is tracked in #2423 itself, not this test.
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
+/// </summary>
+public class QueryJoinFlowFieldColumnOosTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(string bundle)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" \"").Append(bundle).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private static string WriteBundle()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-query-join-flowfield-oos-2423", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        File.WriteAllText(Path.Combine(root, "app.json"), """
+        {
+          "id": "c7d1e4f2-2423-4a1b-9c3d-000000002423",
+          "name": "QJF 2423 Repro",
+          "publisher": "Repro2423",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62470, "to": 62479 } ],
+          "runtime": "14.0"
+        }
+        """);
+        // Entirely application-local (no dependency needed): "Qjf Link" joins to "Qjf Header",
+        // whose "Total Amount" is a FlowField summing "Qjf Line" -- the same shape as #2300's
+        // JoinIleFlowFieldColumn_ReadsCalculatedValue (a local table inner-joined to a table
+        // whose FlowField column is selected), just without the Base Application dependency a
+        // C# fixture app.json may not declare.
+        File.WriteAllText(Path.Combine(root, "QjfLine.al"), """
+        table 62470 "Qjf Line"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "Entry No."; Integer) { }
+                field(2; "Header No."; Code[20]) { }
+                field(3; Amount; Decimal) { }
+            }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "QjfHeader.al"), """
+        table 62471 "Qjf Header"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "No."; Code[20]) { }
+                field(2; "Total Amount"; Decimal)
+                {
+                    FieldClass = FlowField;
+                    CalcFormula = sum("Qjf Line".Amount where("Header No." = field("No.")));
+                }
+            }
+            keys { key(PK; "No.") { Clustered = true; } }
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "QjfLink.al"), """
+        table 62472 "Qjf Link"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "Entry No."; Integer) { }
+                field(2; "Header No."; Code[20]) { }
+            }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "QjfJoinFlowField.al"), """
+        query 62473 "QJF Join FlowField"
+        {
+            QueryType = Normal;
+            elements
+            {
+                dataitem(QjfLink; "Qjf Link")
+                {
+                    column(LinkEntryNo; "Entry No.") { }
+                    dataitem(QjfHeader; "Qjf Header")
+                    {
+                        DataItemLink = "No." = QjfLink."Header No.";
+                        SqlJoinType = InnerJoin;
+                        column(TotalAmount; "Total Amount") { }
+                    }
+                }
+            }
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "QjfTests.al"), """
+        codeunit 62474 "QJF 2423 Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure JoinWithFlowFieldColumn_ThrowsOutOfScope_InsteadOfReadingZeroSilently()
+            var
+                QjfHeader: Record "Qjf Header";
+                QjfLine: Record "Qjf Line";
+                QjfLink: Record "Qjf Link";
+                Q: Query "QJF Join FlowField";
+                Cost: Decimal;
+            begin
+                QjfHeader.Init(); QjfHeader."No." := 'H1'; QjfHeader.Insert();
+                QjfLine.Init(); QjfLine."Entry No." := 1; QjfLine."Header No." := 'H1'; QjfLine.Amount := 7.25; QjfLine.Insert();
+                QjfLink.Init(); QjfLink."Entry No." := 1; QjfLink."Header No." := 'H1'; QjfLink.Insert();
+
+                Q.Open();
+                if not Q.Read() then
+                    Error('expected one row');
+                Cost := Q.TotalAmount;
+                Q.Close();
+                // If the runner ever silently returns a value here instead of throwing, this
+                // assertion catches the exact #2423 corruption directly: the pre-guard
+                // behavior was reading 0 (the column's typed default) instead of 7.25.
+                if Cost <> 7.25 then
+                    Error('Expected the runner to throw RunnerOutOfScopeException (see #2423), not silently read %1', Cost);
+            end;
+        }
+        """);
+
+        return root;
+    }
+
+    [SkippableFact]
+    public void QueryJoinWithFlowFieldColumn_ThrowsLoudOutOfScope_InsteadOfSilentlyDefaultingToZero()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var bundle = WriteBundle();
+        var (output, exitCode) = RunRunner(bundle);
+
+        Assert.DoesNotContain("EMIT-EXCLUDED", output);
+        Assert.DoesNotContain("COMPILE FAIL", output);
+        // The decisive assertions: the test FAILS at runtime because
+        // RunnerOutOfScopeException propagates before the AL Error() call could ever fire,
+        // and the failure carries the #2423 loud-failure guard's own reason string -- not a
+        // silently-wrong AL-level "Expected the runner..." message, and not any unrelated
+        // crash.
+        Assert.Contains("query-join-flowfield-column-not-implemented", output);
+        Assert.Contains("see #2423", output);
+        Assert.DoesNotContain("Expected the runner to throw", output);
+        Assert.Contains("0P/1F/0E", output);
+    }
+}

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -88,7 +88,13 @@ internal static partial class BcAppSymbolCache
     // app declares no permission sets" — so a cached System Application would keep
     // answering `MetadataPermissionSet.Get(<null guid>, 'SUPER')` with "does not exist",
     // the exact #2313 bug, rather than missing the cache.
-    private const int CacheVersion = 18;
+    // v19: TryParseQueryDataItem now strips the module qualifier off RelatedTable (issue
+    // #2295), same normalization CollectReportDataItems already applied to report dataitems.
+    // A v18 payload has the qualified `#<appId>#TableName` form baked into RelatedTable, which
+    // ResolveTableIdByName never matches — so a cached query over a dependency table would
+    // keep failing to build its NCLMetaQuery design and NRE on Open()/SetRange(), the exact
+    // #2295 bug replayed from cache rather than a cache miss.
+    private const int CacheVersion = 19;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
     // Issue #1820 — path -> content-hash memo. ComputeAppContentHash needs to read the
     // WHOLE .app to hash it (unlike the FileInfo.Length/LastWriteTimeUtc stat it replaced,
@@ -886,7 +892,13 @@ internal static partial class BcAppSymbolCache
     private static QueryDataItemSymbol? TryParseQueryDataItem(JsonElement el)
     {
         var name = el.TryGetProperty("Name", out var nameProp) ? nameProp.GetString() ?? string.Empty : string.Empty;
-        var relatedTable = el.TryGetProperty("RelatedTable", out var rtProp) ? rtProp.GetString() ?? string.Empty : string.Empty;
+        // #2295: a dataitem bound to a table from another module (Base Application's Item,
+        // say) arrives module-qualified (#<appIdNoHyphens>#Item), same as a report dataitem —
+        // see StripModuleQualifier's doc comment. Left qualified, ResolveTableIdByName never
+        // matches it, BuildMetaQueryDesign abandons the build, and the query is constructed
+        // with NCLMetaQuery=NULL — every ALSetRangeSafe/Open/Read on it then NREs.
+        var relatedTable = StripModuleQualifier(
+            el.TryGetProperty("RelatedTable", out var rtProp) ? rtProp.GetString() : null) ?? string.Empty;
         int id = el.TryGetProperty("Id", out var idProp) && idProp.TryGetInt32(out var i) ? i : 0;
         var props = SymbolProperties(el);
         props.TryGetValue("SqlJoinType", out var sqlJoinType);

--- a/AlRunner/Patches/RecordPatches.QueryProjection.cs
+++ b/AlRunner/Patches/RecordPatches.QueryProjection.cs
@@ -332,6 +332,11 @@ public static partial class RecordPatches
     private static PropertyInfo? _pDataItemQueryColumnsQ;
     private static PropertyInfo? _pColColumnTypeQ;
     private static PropertyInfo? _pColColumnIndexQ2;
+    // #2423: same discriminator JoinExecutor.cs uses (SubQueryDefinition != null marks the
+    // FlowField-calculation synthesized dataitem) plus its Name, for the loud-failure guard
+    // ComputeJoinColumnSlotMap's own copy of BuildJoinProjectionPlan's algorithm must carry too.
+    private static PropertyInfo? _pDataItemSubQueryDefinitionQ;
+    private static PropertyInfo? _pDataItemNameQ;
 
     private static void EnsureFilterReflection()
     {
@@ -352,6 +357,8 @@ public static partial class RecordPatches
         _pQueryDefDataItemsQ = _tNCLMetaQueryDefinition?.GetProperty("DataItems", anyInstance);
         _pDataItemQueryColumnsQ = _tNCLMetaQueryDataItem?.GetProperty("QueryColumns", anyInstance);
         _pColColumnTypeQ = _tNCLMetaQueryColumn?.GetProperty("ColumnType", anyInstance);
+        _pDataItemSubQueryDefinitionQ = _tNCLMetaQueryDataItem?.GetProperty("SubQueryDefinition", anyInstance);
+        _pDataItemNameQ = _tNCLMetaQueryDataItem?.GetProperty("Name", anyInstance);
         _filterReflectionReady = true;
     }
 
@@ -374,6 +381,28 @@ public static partial class RecordPatches
         var map = new Dictionary<object, int>();
         if (_pQueryDefDataItemsQ == null || _pDataItemQueryColumnsQ == null) return map;
         var dataItems = ((System.Collections.IEnumerable)_pQueryDefDataItemsQ.GetValue(queryDef)!).Cast<object>().ToList();
+
+        // #2423: mirrors JoinExecutor.BuildJoinProjectionPlan's own guard EXACTLY (this method's
+        // own doc comment requires the two algorithms to change together) -- a multi-real-dataitem
+        // JOIN that also selects a FlowField column still carries the FlowField-calculation
+        // synthesized dataitem (SubQueryDefinition != null) in this RAW dataitem list. Before this
+        // guard its column resolved to a field on the FlowField's SOURCE table, a table this join
+        // never reads a row buffer for, silently producing the column's typed default (0) instead
+        // of the calculated value -- the silent default .claude/rules/loud-failures.md forbids.
+        // Neither this method nor JoinExecutor's copy route a FlowField column through
+        // FlowFieldPatches.CalcOneFlowFieldForQueryRow in the join path yet -- tracked in #2423.
+        foreach (var diCheck in dataItems)
+        {
+            if (_pDataItemSubQueryDefinitionQ?.GetValue(diCheck) == null) continue;
+            var subDataItemName = _pDataItemNameQ?.GetValue(diCheck) as string ?? "<unknown>";
+            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                "NavQuery (multi-dataitem join with a FlowField column)",
+                $"query-join-flowfield-column-not-implemented -- dataitem '{subDataItemName}' is the " +
+                "synthesized FlowField-calculation sub-dataitem for a column selected alongside a " +
+                "real multi-dataitem JOIN; this runner does not yet compute a FlowField column's " +
+                "value in the join projection path (only the single-real-dataitem case is wired, " +
+                "via FlowFieldPatches.CalcOneFlowFieldForQueryRow) -- see #2423");
+        }
 
         int maxSlot = -1;
         foreach (var di in dataItems)


### PR DESCRIPTION
Closes #2295

## Root cause

The Query is present in `SymbolReference.json`; a dataitem bound to a table from another
module (Base Application's Item, in the reported case) is emitted qualified:
`#<appIdNoHyphens>#Item`. `BcAppSymbolCache.TryParseQueryDataItem` preserved that string
verbatim as `RelatedTable`. `RecordPatches.ResolveTableIdByName` compares it directly against
ordinary (unqualified) table names, so resolution fails, `BuildMetaQueryDesign` abandons the
build, and the runtime Query is constructed with `NCLMetaQuery=NULL` -- every
`SetRange`/`Open`/`Read` on it then NREs deep inside precompiled `NavQuery` methods
(`ValidateExpectedType`, `ValidateTablesNotVirtual`), long before any AL-observable error.

`BcAppSymbolCache.StripModuleQualifier` already exists and is applied to report dataitems
(`CollectReportDataItems`) -- it was never applied to Query dataitems. Fix: apply it in
`TryParseQueryDataItem`. The function is recursive, so both root and nested dataitems
normalize from the one change. Bumps `CacheVersion` (18 -> 19) since this changes persisted
symbol-cache parsing semantics -- a stale cached entry still carries the qualified string and
would silently reintroduce the bug from cache.

## Tests

- `AlRunner.Tests/BcAppSymbolCacheQueryModuleQualifierTests.cs` -- runner-mechanism test
  pinning the parsing fix directly: constructs a minimal `.app` (a zip with a hand-written
  `SymbolReference.json`, no full AL compile, no Base Application dependency needed) whose
  Query dataitem's `RelatedTable` is module-qualified on both a root and a nested dataitem,
  and asserts both normalize. A companion negative test confirms a plain (unqualified,
  application-local) `RelatedTable` passes through unchanged.
- `AlRunner.Tests/QueryJoinFlowFieldColumnOosTests.cs` -- runner-mechanism test pinning the
  loud-failure guard this PR adds to the join-with-FlowField-column path (see the composition
  section below): an entirely application-local three-table join+FlowField repro (no
  dependency needed, so it stays within the C#-fixture `platform`-not-`application` rule)
  asserts the run fails with `query-join-flowfield-column-not-implemented` and `see #2423` in
  its output, and explicitly asserts the OLD silent-wrong-answer message never appears.
- Upstream corpus PR (real BC 27.0-28.4 adjudicates the BC-behavior claim):
  StefanMaron/BusinessCentral.AL.Language.Tests#101 -- **all 8 BC legs green** (27.0, 27.3,
  27.5, 28.0, 28.1, 28.2, 28.3, 28.4). Adds `IQ Item Rows`, a source-defined query over Base
  Application's `Item` table, plus two tests: it returns the matching inserted row, and a
  non-matching `SetRange` excludes it. Not yet merged; the submodule pin is **not** bumped in
  this PR -- see follow-up note below.

## RED -> GREEN

Confirmed against the issue's own minimal repro (`IQ Item Rows` query over Base App `Item`,
two `[Test]` cases), rebuilt on top of #2422's merged `main` (`3ae095d6`): before this fix,
both `PublicQueryOverDependencyTableOpens` and `PublicQueryOverDependencyTableAcceptsSetRange`
NRE with the exact stacks the issue reports. After this fix, both pass.

## Composition proof with #2300, and a loud-failure guard this PR adds

This is what issue 2300's own PR (#2422) predicted would unblock its `IleFlowFieldColumn_
ReadsCalculatedValue` oracle case. Re-ran #2300's full three-case repro
(`QffLocalFlowField.Query.al` / `QffIleFlowField.Query.al` / `QffJoinIleFlowField.Query.al`,
from that issue's body) against THIS branch, i.e. against #2295's fix stacked on #2422's
merged `main`:

```
PASS  Codeunit64616.LocalFlowFieldColumn_ReadsCalculatedValue (12ms)
PASS  Codeunit64616.IleFlowFieldColumn_ReadsCalculatedValue (24ms)
FAIL  Codeunit64616.JoinIleFlowFieldColumn_ReadsCalculatedValue (12ms)
      Unexpected out-of-scope: NavQuery (multi-dataitem join with a FlowField column)
      (reason: query-join-flowfield-column-not-implemented -- dataitem
      'SUB$ItemLedgerEntry$CostAmountActual' is the synthesized FlowField-calculation
      sub-dataitem for a column selected alongside a real multi-dataitem JOIN; this runner
      does not yet compute a FlowField column's value in the join projection path (only the
      single-real-dataitem case is wired, via FlowFieldPatches.CalcOneFlowFieldForQueryRow)
      -- see #2423)
```

- **`LocalFlowFieldColumn_ReadsCalculatedValue` -- GREEN**, as it already was after #2422.
- **`IleFlowFieldColumn_ReadsCalculatedValue` -- GREEN**, confirming this fix is exactly what
  #2422's PR body predicted would unblock it: no more NRE, and the single-dataitem FlowField
  case over a dependency table now reads the correct calculated value (12.5, per that issue's
  oracle).
- **`JoinIleFlowFieldColumn_ReadsCalculatedValue` -- still RED, as predicted, but the failure
  mode changed twice in this PR.** First observation (before this PR's second commit): no
  more NRE -- the query metadata now builds and the join executes -- but the projected
  FlowField value silently read back as `0` (the column's typed default) instead of the
  oracle's `7.25`. That is exactly the silent-wrong-answer shape `.claude/rules/
  loud-failures.md` forbids, and since THIS PR is what makes the join-with-FlowField-column
  code path reachable at all (by fixing the metadata-construction NRE it was previously
  blocked behind), this PR is what has to carry the guard rather than leaving it for #2423.
  Added a loud-failure check to both `AlRunner.QueryJoin.JoinExecutor.
  BuildJoinProjectionPlan` and its al-runner-side mirror `RecordPatches.QueryProjection.
  ComputeJoinColumnSlotMap` (the file's own doc comment requires the two to change together):
  the moment either encounters the FlowField-calculation synthesized sub-dataitem
  (`NCLMetaQueryDataItem.SubQueryDefinition != null`) in a query that also has a real
  multi-dataitem join, it now throws `RunnerOutOfScopeException` naming the synthesized
  sub-dataitem, the reason (`query-join-flowfield-column-not-implemented`), and `see #2423`,
  instead of silently defaulting the column. The case is still red -- correctly -- but now
  fails LOUDLY with a message that points straight at #2423, not silently with a wrong number.
  #2423 tracks the real implementation (bridging `FlowFieldPatches.
  CalcOneFlowFieldForQueryRow` across the `AlRunner.QueryJoin` isolation boundary the same way
  `ComputeAggregate` already does); this PR does not implement that, only guards it.

## Fix the shape, not just the reported line

- Checked every other `RelatedTable` read site in `AlRunner/Patches/*.cs` for the same
  unnormalized-qualifier shape: `DependencyReportMetadata.cs` and
  `RecordPatches.ReportMetadataVirtualTable.cs` both consume the ALREADY-normalized
  `ReportDataItemSymbol.RelatedTable` (via `CollectReportDataItems`, untouched by this PR).
  `RecordPatches.AlReportParser.cs` is a source-level AL parser (not `SymbolReference.json`),
  uses `LastNameSegment(...)`, a different mechanism for a different input shape -- not
  applicable here. No other unnormalized site found.

## Follow-up

- StefanMaron/BusinessCentral.AL.Language.Tests#101 needs to merge before the submodule pin
  can be bumped here (a pin bump can't be its own PR -- see `al-language-submodule.md`). Once
  merged, a follow-up PR bumps the pin together with the `tests/expectations/count-baseline/`
  update.
- #2423 tracks the remaining JOIN + FlowField-column gap this PR's own verification run
  surfaced concretely (`Expected 7.25, got 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VvUgMSPokJWzeFNVQxD5J
