### PR TITLE
fix(hooks): nudge on shell READS of C# too, not just searches

### DIFF
--- a/.claude/hooks/prefer-code-navigation.py
+++ b/.claude/hooks/prefer-code-navigation.py
@@ -5,20 +5,41 @@ Measured 2026-09-02 across 17 subagents in one session: 3,237 Bash calls, of
 which 2,716 (84%) were grep/sed/cat/head/find over the source tree.
 `tools/lsp-query.py` was called ONCE in total and `graphify` twice.
 
+Re-measured later the same day over 11 agents and 1,048 tool calls: 940 Bash,
+of which 533 were sed/cat/head READS averaging 2.0 KB and only 5 were grep/rg.
+602 of 940 Bash calls (64%) were read/search through the shell; the navigation
+tools were used 14 times.
+
+That re-measurement found a hole in this hook. It matched only grep/rg/ag, so
+it was guarding the 5 search calls and ignoring the 533 reads -- the dominant
+cost -- even though the paragraph above named sed/cat/head from the start. It
+also missed `command grep`, which is the form CLAUDE.md tells everyone to use
+here (plain `grep` is a shell function that rejects -E/--include). Both are
+fixed below.
+
 The cost driver is the NUMBER of round trips, not the size of any one result --
-the whole conversation is re-sent on every call, so 200 small greps cost far
-more than 20 targeted ones.
+the whole conversation is re-sent on every call, so 500 small reads cost far
+more than 50 targeted ones.
 
 This hook is ADVISORY. It never blocks a call; it prints one short reminder so
-an agent does not have to remember, or discover, the cheaper path. It fires only
-for text search aimed at C# under AlRunner/, which is where the navigation tools
-actually answer better than grep does.
+an agent does not have to remember, or discover, the cheaper path. It fires for
+reads and searches aimed at C# under AlRunner/, which is where the navigation
+tools answer better than the shell does.
 """
 import json
 import re
 import sys
 
-TEXT_SEARCH = re.compile(r'(?:^|[|;&]\s*)\s*(?:grep|rg|ag)\b')
+# `command grep` is the spelling CLAUDE.md mandates here, so it must match too.
+TEXT_SEARCH = re.compile(r'(?:^|[|;&]\s*)\s*(?:command\s+)?(?:grep|rg|ag)\b')
+# Reading source through the shell is the larger cost, and it was unguarded.
+READ_VERB = re.compile(
+    r'(?:^|[|;&]\s*)\s*(?:command\s+)?(?:sed|cat|head|tail|awk|less|more)\b')
+# A read only counts when it actually names a C# file -- otherwise
+# `dotnet build AlRunner | tail -5` would nudge on every build.
+NAMES_CS_FILE = re.compile(r'\S*\.cs\b')
+# Writing a C# file is not a lookup: heredocs, redirections and in-place sed.
+WRITES_CS = re.compile(r'<<|>>?\s*\S*\.cs\b|\bsed\s+(?:-\w+\s+)*-i\b')
 # Only nudge when the search is plausibly aimed at the C# sources.
 TARGETS_CS = re.compile(r'AlRunner[\w./-]*|--include[= ]\S*\.cs|\*\.cs|\.cs\b')
 # Things that are legitimately grep's job, not a symbol lookup.
@@ -27,8 +48,8 @@ NOT_A_SYMBOL_LOOKUP = re.compile(
 
 MESSAGE = (
     "Code-navigation reminder (advisory, nothing was blocked).\n"
-    "For 'where is this defined' / 'what calls this' in AlRunner/*.cs, these answer in ONE\n"
-    "call what grep needs several to approximate, and without comment/string false positives:\n"
+    "For reading or searching AlRunner/*.cs, these answer in ONE call what a sequence of\n"
+    "sed/cat/head/grep approximates, and without comment/string false positives:\n"
     "  tools/lsp-query.py symbol  <Name>      # definition\n"
     "  tools/lsp-query.py callers <Name>      # call sites   (exit 2 = server failed, NOT 'none')\n"
     "  tools/context-pack.py <Name> [<Name>...]   # definition + callers + context, one round trip\n"
@@ -50,9 +71,12 @@ def main() -> int:
     if payload.get("tool_name") != "Bash":
         return 0
     cmd = (payload.get("tool_input") or {}).get("command", "") or ""
-    if not TEXT_SEARCH.search(cmd):
+
+    searching = bool(TEXT_SEARCH.search(cmd)) and bool(TARGETS_CS.search(cmd))
+    reading = bool(READ_VERB.search(cmd)) and bool(NAMES_CS_FILE.search(cmd))
+    if not (searching or reading):
         return 0
-    if not TARGETS_CS.search(cmd):
+    if WRITES_CS.search(cmd):
         return 0
     if NOT_A_SYMBOL_LOOKUP.search(cmd):
         return 0

--- a/.claude/hooks/test_prefer_code_navigation.py
+++ b/.claude/hooks/test_prefer_code_navigation.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Unit tests for prefer-code-navigation.py.
+
+The hook is advisory, so "did it fire" is the only observable behaviour: it
+prints the reminder to stderr and always exits 0. These tests assert on that
+stderr, against synthetic Bash payloads.
+
+Usage: python3 test_prefer_code_navigation.py
+Exits 0 when every case passes, 1 on the first failure.
+"""
+
+import json
+import pathlib
+import subprocess
+import sys
+
+HOOK = pathlib.Path(__file__).resolve().parent / "prefer-code-navigation.py"
+
+CASES = []
+
+
+def case(name, command, should_fire, tool="Bash"):
+    CASES.append((name, command, should_fire, tool))
+
+
+# --- reads of C# sources: the dominant cost, and what this hook missed ---
+# Measured 2026-09-02 over one session: 533 sed/cat/head reads against 5 grep/rg
+# calls. The hook matched only grep/rg/ag, so it guarded the 5 and ignored the 533.
+case("sed -n range over a C# file", "sed -n '600,680p' AlRunner/Patches/NavReportSync.cs", True)
+case("cat a C# file", "cat AlRunner/Patches/RequestPageTestPage.cs", True)
+case("head a C# file", "head -60 AlRunner/BcRuntime.cs", True)
+case("tail a C# file", "tail -40 AlRunner/Program.cs", True)
+case("awk over a C# file", "awk 'NR>100 && NR<200' AlRunner/Patches/RecordPatches.cs", True)
+
+# --- searches: the behaviour that already worked, and must keep working ---
+case("rg over the C# tree", "rg -n 'IsProcessingOnly' --glob '*.cs' AlRunner", True)
+case("grep with an explicit .cs include", "command grep -rn Foo --include=*.cs AlRunner", True)
+
+# --- must NOT fire: these are legitimately the shell's job ---
+case("build output piped to tail names AlRunner but reads no .cs",
+     "dotnet build AlRunner -c Release | tail -5", False)
+case("running the runner and trimming output",
+     "dotnet run --project AlRunner -c Release -- bundle --out x.json | head -20", False)
+case("reading a log", "sed -n '1,50p' /tmp/run.log", False)
+case("reading AL sources", "command grep -n 'SaveAsXml' tests/al-language/foo.al", False)
+case("reading a results JSON", "cat scratchpad/results.json", False)
+case("git log", "git log --oneline -5 -- AlRunner", False)
+case("writing a C# file with a heredoc must not nudge",
+     "cat > AlRunner/Patches/New.cs <<'EOF'\nclass X {}\nEOF", False)
+case("redirecting into a C# file must not nudge",
+     "sed 's/a/b/' in.txt > AlRunner/Patches/Out.cs", False)
+case("a non-Bash tool is ignored", "sed -n '1,10p' AlRunner/Program.cs", False, tool="Read")
+
+
+def run():
+    failures = 0
+    for name, command, should_fire, tool in CASES:
+        payload = json.dumps({"tool_name": tool, "tool_input": {"command": command}})
+        r = subprocess.run(
+            [sys.executable, str(HOOK)], input=payload, capture_output=True, text=True
+        )
+        fired = "Code-navigation reminder" in r.stderr
+        ok = (fired == should_fire) and r.returncode == 0
+        if ok:
+            print(f"PASS  {name}")
+        else:
+            failures += 1
+            print(f"FAIL  {name}")
+            print(f"      expected fire={should_fire}, got fire={fired}, exit={r.returncode}")
+            print(f"      cmd: {command!r}")
+
+    print(f"\n{len(CASES) - failures}/{len(CASES)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())


### PR DESCRIPTION
`.claude/hooks/prefer-code-navigation.py` matched only search verbs (`grep`/`rg`/`ag`). Re-measured over 11 agents and 1,048 tool calls:

| | count |
|---|---|
| Bash calls | 940 of 1,048 |
| `sed`/`cat`/`head` **reads** (avg 2.0 KB) | **533** |
| `grep`/`rg` searches | 5 |
| read-or-search through the shell | 602 of 940 (64%) |
| navigation-tool calls (`lsp-query`, `context-pack`, `graphify`) | 14 |

So the hook was guarding the 5 and ignoring the 533 — the dominant cost — even though its own docstring named `sed`/`cat`/`head` from the start.

It also never matched `command grep`, which is the spelling `CLAUDE.md` mandates here: plain `grep` is a shell function that rejects `-E`/`--include` and exits 0 with **no output**, which reads exactly like "no matches".

The driver is the **number** of round trips, not the size of any one result — the whole conversation is re-sent on every call, so 500 small reads cost far more than 50 targeted ones.

## Guards against false positives

Both of these a naive version gets wrong, and both are covered by tests:

- a read only counts when it actually **names** a `.cs` file, so `dotnet build AlRunner | tail -5` does not nudge on every build;
- **writing** a C# file is not a lookup — heredocs, `>`/`>>` redirection and `sed -i` are excluded.

Still advisory: `exit 0`, never blocks. Grep over C# is sometimes exactly right, and a blocking hook would cost more than the greps it prevents.

## Test

`.claude/hooks/test_prefer_code_navigation.py`, 16 cases covering **both directions** — the reads and searches that must nudge, and the builds, logs, AL sources, JSON, `git log` and file-writes that must not.

The hook had no test at all, which is why this gap survived. Measured against the old hook: **10/16**. With this change: **16/16**.

```
$ python3 .claude/hooks/test_prefer_code_navigation.py
...
16/16 passed
```

Closes #2434

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf