### PR TITLE
fix(rollback): a plain nested BC transaction is not a commit point

### DIFF
--- a/AlRunner.Tests/AssertErrorRollbackNestedTransactionTests.cs
+++ b/AlRunner.Tests/AssertErrorRollbackNestedTransactionTests.cs
@@ -1,0 +1,204 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Runner-mechanism test for issue #2413: a write made before a plain nested BC transaction
+/// (Query.Open()'s RunOnBeforeOpenTriggerAsync — Session.BeginTransaction() /
+/// Session.EndTransaction(commit: true)) survived a LATER, unrelated asserterror, because
+/// AlRunner.Infrastructure.NclCecilRewrite ("8g", AlRunner#1946) prepended
+/// RecordPatches.NoteTransactionEnd to BOTH SessionTransactionExtensions.EndTransaction and
+/// .EndTransactionWorldAndTransaction, and NoteTransactionEnd calls MarkCommitPoint()
+/// whenever commit is true. That is right only for a completed transaction WORLD (a guarded
+/// Codeunit.Run, or `Ok := XmlPort.Import(...)`) — real BC's plain EndTransaction only pops a
+/// nested level of the CALLER's already-open transaction, and does not commit anything.
+///
+/// The BEHAVIORAL claim ("Query.Open()/statement-form XmlPort.Import() between a write and a
+/// later unrelated asserterror do not make that write durable") is a plain-BC-behaviour claim
+/// and belongs upstream — see StefanMaron/BusinessCentral.AL.Language.Tests PR extending
+/// error-handling/ with Codeunit 60945 "Test AssertError Rollback NTx", per
+/// .claude/rules/bc-behavior-tests-go-upstream.md. This test exists so a regression in OUR
+/// OWN commit-point bookkeeping fails loudly here, spawning the real runner against a
+/// synthetic bundle, without depending on the submodule pin having moved yet (the corpus PR
+/// had not merged when this test was written).
+///
+/// No Library Assert / Base Application dependency (no "application" in the fixture's
+/// app.json — see .claude/rules/no-base-app-in-csharp-tests.md): Query is a platform-level
+/// object type, so each test raises its own Error() with the observed state and the runner's
+/// own PASS/FAIL output is the assertion surface.
+/// </summary>
+public class AssertErrorRollbackNestedTransactionTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(params string[] bundles)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        foreach (var b in bundles) args.Append(" \"").Append(b).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    [SkippableFact]
+    public void UnrelatedAssertError_RollsBackWritesMadeBeforePlainNestedTransaction()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-assert-error-rollback-ntx-2413", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        File.WriteAllText(Path.Combine(root, "app.json"), """
+        {
+          "id": "b2413000-0000-4000-8000-000000002413",
+          "name": "AssertErrorRollbackNestedTx2413",
+          "publisher": "Repro2413",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62413, "to": 62419 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(root, "AentProbe.al"), """
+        table 62413 "AENT Probe"
+        {
+            DataClassification = SystemMetadata;
+
+            fields
+            {
+                field(1; "Entry No."; Integer) { }
+                field(2; "Integer Field"; Integer) { }
+            }
+
+            keys
+            {
+                key(PK; "Entry No.") { Clustered = true; }
+            }
+        }
+
+        query 62413 "AENT Probe Query"
+        {
+            elements
+            {
+                dataitem(Row; "AENT Probe")
+                {
+                    column(EntryNo; "Entry No.") { }
+                    column(IntegerValue; "Integer Field") { }
+                }
+            }
+        }
+
+        codeunit 62413 "AENT Tests"
+        {
+            Subtype = Test;
+            TestPermissions = Disabled;
+
+            local procedure Initialize()
+            var
+                Probe: Record "AENT Probe";
+            begin
+                Probe.DeleteAll();
+                Commit();
+            end;
+
+            // Regression shape (AlRunner#2413): a committed row, then an uncommitted Modify,
+            // then Query.Open()/Read()/Close() — a plain nested transaction that must NOT
+            // become a commit point — then a later, unrelated asserterror. The Modify must
+            // still roll back.
+            [Test]
+            procedure Modify_QueryOpen_UnrelatedError_ModifyRollsBack()
+            var
+                Probe: Record "AENT Probe";
+                ProbeQuery: Query "AENT Probe Query";
+            begin
+                Initialize();
+                Probe.Init();
+                Probe."Entry No." := 1;
+                Probe."Integer Field" := 10;
+                Probe.Insert();
+                Commit();
+
+                Probe.Get(1);
+                Probe."Integer Field" := 99;
+                Probe.Modify();
+
+                ProbeQuery.Open();
+                ProbeQuery.Read();
+                ProbeQuery.Close();
+
+                asserterror Error('boom');
+
+                Clear(Probe);
+                Probe.Get(1);
+                if Probe."Integer Field" <> 10 then
+                    Error('AENT1 FAIL: expected Integer Field=10 after Query.Open() + unrelated error rolled back the uncommitted Modify, got %1', Probe."Integer Field");
+            end;
+
+            // Same regression shape with an uncommitted Insert instead of a Modify.
+            [Test]
+            procedure Insert_QueryOpen_UnrelatedError_InsertRollsBack()
+            var
+                Probe: Record "AENT Probe";
+                ProbeQuery: Query "AENT Probe Query";
+            begin
+                Initialize();
+                Probe.Init();
+                Probe."Entry No." := 7;
+                Probe.Insert();
+
+                ProbeQuery.Open();
+                ProbeQuery.Read();
+                ProbeQuery.Close();
+
+                asserterror Error('boom');
+
+                if Probe.Count() <> 0 then
+                    Error('AENT2 FAIL: expected Count()=0 after Query.Open() + unrelated error rolled back the uncommitted Insert, got %1', Probe.Count());
+            end;
+
+            // Must-not-regress control: Query.Open() with NO pending write at all must not
+            // itself throw or otherwise disrupt an unrelated asserterror afterwards.
+            [Test]
+            procedure QueryOpen_NoWrite_UnrelatedError_NoThrow()
+            var
+                ProbeQuery: Query "AENT Probe Query";
+            begin
+                Initialize();
+
+                ProbeQuery.Open();
+                ProbeQuery.Close();
+
+                asserterror Error('boom');
+            end;
+        }
+        """);
+
+        var (output, exitCode) = RunRunner(root);
+
+        Assert.True(exitCode == 0,
+            $"Expected all three tests to pass (exit 0); got exit {exitCode}.\n{output}");
+        Assert.DoesNotContain("FAIL", output);
+        Assert.Contains("PASS  Codeunit62413.Modify_QueryOpen_UnrelatedError_ModifyRollsBack", output);
+        Assert.Contains("PASS  Codeunit62413.Insert_QueryOpen_UnrelatedError_InsertRollsBack", output);
+        Assert.Contains("PASS  Codeunit62413.QueryOpen_NoWrite_UnrelatedError_NoThrow", output);
+    }
+}

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -1792,30 +1792,39 @@ public static class NclCecilRewrite
             Console.Error.WriteLine("[Cecil] Rewrote SessionTransactionExtensions.Rollback → row-store rollback");
         }
 
-        // 8g. SessionTransactionExtensions.EndTransaction / EndTransactionWorldAndTransaction —
-        //     see RecordPatches.NoteTransactionEnd.
+        // 8g. SessionTransactionExtensions.EndTransactionWorldAndTransaction — see
+        //     RecordPatches.NoteTransactionEnd.
         //
-        //     AL Runner#1946: BC's own APIs wrap their internal work in an explicit nested
-        //     transaction (decompiled, unmodified Ncl body of the static overload of
-        //     NavXmlPort.Import — the one the corpus proved this against:
-        //     Session.BeginTransaction(); ...; finally { Session.EndTransaction(commit); } for
-        //     DataError.ThrowError, or Session.BeginTransactionWorldAndTransaction(); ...;
-        //     finally { Session.EndTransactionWorldAndTransaction(commit); } for
-        //     DataError.TrapError — AL's compiler picks TrapError whenever the call's boolean
-        //     result is captured into a variable, e.g. `Ok := XmlPort.Import(...)`, which is
-        //     the common, idiomatic AL shape and the one that actually reaches this bug).
-        //     A real commit there is exactly as durable, from AL's point of view, as an
-        //     explicit Commit() statement — but only MarkCommitPoint's two existing call sites
-        //     (AL's own Commit() and the per-test isolation boundary) ever advanced the
-        //     rollback baseline, so a LATER, unrelated asserterror in the caller rolled all the
-        //     way back to test-method start, wiping out rows a nested BC API had already
-        //     committed. Reproducible with no XmlPort involved at all — see
-        //     RecordPatches.NoteTransactionEnd's doc comment.
+        //     AL Runner#1946 (revised by #2413): BC's own APIs wrap their internal work in one
+        //     of two kinds of nested transaction. A TRANSACTION WORLD
+        //     (Session.BeginTransactionWorldAndTransaction(); ...; finally {
+        //     Session.EndTransactionWorldAndTransaction(commit); } — the guarded `Codeunit.Run`
+        //     form, and `Ok := XmlPort.Import(...)`, i.e. DataError.TrapError, which AL's
+        //     compiler picks whenever the call's boolean result is captured into a variable)
+        //     commits durably: a real `commit == true` there is exactly as durable, from AL's
+        //     point of view, as an explicit Commit() statement, so a LATER, unrelated
+        //     asserterror in the caller must not roll it back. A PLAIN NESTED transaction
+        //     (Session.BeginTransaction(); ...; finally { Session.EndTransaction(commit); } —
+        //     Query.Open, statement-form XmlPort.Import i.e. DataError.ThrowError) is not a
+        //     commit at all: it joins the caller's already-open transaction and
+        //     EndTransaction(true) at that depth only pops it, so nothing reaches the database
+        //     until the OUTER transaction (the test framework's own boundary, or an explicit
+        //     AL Commit()) completes.
         //
-        //     Prepend, not replace: the original bodies (SessionTransactionManager.EndTransaction
-        //     / EndTransactionWorldAndTransaction) already run safely today (every passing
-        //     XmlPort Export/Import test goes through one of them), so this only adds the
-        //     missing commit-point bookkeeping alongside them.
+        //     #1946 hooked BOTH methods on the strength of a reproduction that turned out not
+        //     to distinguish them — no XmlPort involved, just Insert() then an unrelated
+        //     trapped Error(), which #2402 later measured keeps the row on real BC only when an
+        //     EARLIER test method had committed the same key, not because EndTransaction is a
+        //     commit point. #2413 measured the two kinds directly against real BC: hooking the
+        //     plain EndTransaction wrongly turns Query.Open and statement-form XmlPort.Import
+        //     into commit points, so writes made BEFORE them survive an asserterror that real
+        //     BC rolls back (P1, P2, P3, P8 in #2413). Only EndTransactionWorldAndTransaction
+        //     gets the hook now.
+        //
+        //     Prepend, not replace: the original body
+        //     (SessionTransactionManager.EndTransactionWorldAndTransaction) already runs safely
+        //     today (every passing guarded-Codeunit.Run / `Ok := XmlPort.Import` test goes
+        //     through it), so this only adds the missing commit-point bookkeeping alongside it.
         {
             var sessTxType2 = asm.MainModule.Types
                 .FirstOrDefault(t => t.FullName == "Microsoft.Dynamics.Nav.Runtime.SessionTransactionExtensions")
@@ -1828,17 +1837,14 @@ public static class NclCecilRewrite
                 ?? throw new InvalidOperationException(
                     "[Cecil] RecordPatches.NoteTransactionEnd not found");
 
-            foreach (var methodName in new[] { "EndTransaction", "EndTransactionWorldAndTransaction" })
-            {
-                var endTransactionMethod = sessTxType2.Methods
-                    .FirstOrDefault(m => m.Name == methodName && m.IsStatic
-                                         && m.Parameters.Count == 2 && m.HasBody
-                                         && m.Parameters[1].ParameterType.FullName == "System.Boolean")
-                    ?? throw new InvalidOperationException(
-                        $"[Cecil] SessionTransactionExtensions.{methodName}(NavSession, bool) not found — Ncl shape changed; do not commit");
+            var endTransactionMethod = sessTxType2.Methods
+                .FirstOrDefault(m => m.Name == "EndTransactionWorldAndTransaction" && m.IsStatic
+                                     && m.Parameters.Count == 2 && m.HasBody
+                                     && m.Parameters[1].ParameterType.FullName == "System.Boolean")
+                ?? throw new InvalidOperationException(
+                    "[Cecil] SessionTransactionExtensions.EndTransactionWorldAndTransaction(NavSession, bool) not found — Ncl shape changed; do not commit");
 
-                PrependStaticCall(asm.MainModule, endTransactionMethod, noteTransactionEndHelper, argSlots: 2);
-            }
+            PrependStaticCall(asm.MainModule, endTransactionMethod, noteTransactionEndHelper, argSlots: 2);
         }
 
 

--- a/AlRunner/Patches/RecordPatches.TransactionSnapshot.cs
+++ b/AlRunner/Patches/RecordPatches.TransactionSnapshot.cs
@@ -98,39 +98,48 @@ public static partial class RecordPatches
     public static void MarkCommitPoint() => _txCommitPoint.Clear();
 
     /// <summary>
-    /// Prepended to SessionTransactionExtensions.EndTransaction(NavSession, bool commit) and
-    /// .EndTransactionWorldAndTransaction(NavSession, bool commit) — see AlRunner#1946.
+    /// Prepended ONLY to SessionTransactionExtensions.EndTransactionWorldAndTransaction(NavSession,
+    /// bool commit) — see AlRunner#1946, revised by #2413. NOT prepended to the plain
+    /// EndTransaction overload; see the "8g" comment in NclCecilRewrite.cs for why.
     ///
-    /// BC's own APIs run their internal work inside an explicit nested transaction. The
-    /// static overload of <c>NavXmlPort.Import</c> is one — decompiled, unmodified Ncl body:
-    /// <c>Session.BeginTransaction(); ...; finally { Session.EndTransaction(commit); }</c> for
-    /// <c>DataError.ThrowError</c>, or <c>Session.BeginTransactionWorldAndTransaction(); ...;
-    /// finally { Session.EndTransactionWorldAndTransaction(commit); }</c> for
-    /// <c>DataError.TrapError</c>. AL's compiler picks <c>TrapError</c> whenever the call's
-    /// boolean result is captured into a variable — e.g. <c>Ok := XmlPort.Import(...)</c> —
-    /// which is the common, idiomatic AL shape, so both extension methods need the hook, not
-    /// just the more obviously-named one.
+    /// BC's own APIs run their internal work inside one of two kinds of nested transaction.
+    /// A TRANSACTION WORLD — <c>Session.BeginTransactionWorldAndTransaction(); ...; finally {
+    /// Session.EndTransactionWorldAndTransaction(commit); }</c>, decompiled, unmodified Ncl
+    /// body of the guarded <c>Codeunit.Run</c> form and of <c>NavXmlPort.Import</c> when AL's
+    /// compiler picks <c>DataError.TrapError</c> (the call's boolean result captured into a
+    /// variable, e.g. <c>Ok := XmlPort.Import(...)</c>, the common idiomatic AL shape) — is
+    /// exactly as durable, from AL's point of view, as an explicit <c>Commit()</c> statement:
+    /// a later, unrelated <c>asserterror</c> in the CALLER must not roll back work an inner
+    /// transaction world already committed.
     ///
-    /// A real <c>commit == true</c> there is exactly as durable, from AL's point of view, as
-    /// an explicit <c>Commit()</c> statement: a later, unrelated <c>asserterror</c> in the
-    /// CALLER must not roll back work an inner API already committed.
+    /// A PLAIN NESTED transaction — <c>Session.BeginTransaction(); ...; finally {
+    /// Session.EndTransaction(commit); }</c>, used by e.g. <c>NavQuery.Open</c>'s
+    /// <c>RunOnBeforeOpenTriggerAsync</c> and by statement-form <c>XmlPort.Import(...)</c>
+    /// (<c>DataError.ThrowError</c>) — is NOT a commit at all: it joins the caller's
+    /// already-open transaction, and <c>EndTransaction(true)</c> at that depth only pops the
+    /// nested level. Nothing reaches the database until the OUTER transaction completes (the
+    /// test framework's own per-test boundary, or an explicit AL <c>Commit()</c>). #2413
+    /// measured this directly against real BC: a write made BEFORE a <c>Query.Open()</c> or a
+    /// statement-form <c>XmlPort.Import</c>, followed by a later, unrelated
+    /// <c>asserterror</c>, IS rolled back on real BC — treating the plain
+    /// <c>EndTransaction(true)</c> as a commit point wrongly kept it durable here.
     ///
-    /// Before this hook, only AL's own <c>Commit()</c> and the per-test isolation boundary
-    /// called <see cref="MarkCommitPoint"/>, so <see cref="RollbackToCommitPoint"/> rolled
-    /// all the way back to test-method start on ANY later trapped error — including rows a
-    /// nested BC API (like XmlPort.Import) had already committed inside its own transaction.
-    /// Observably: <c>XmlPort.Import(id, Stream, Rec)</c> inserts a row, a LATER, unrelated
-    /// statement in the same test method throws (even caught by <c>asserterror</c>), and the
-    /// earlier insert vanished — reproducible with no XmlPort involved at all, just a plain
-    /// <c>Record.Insert()</c> followed by an unrelated failing <c>Record.Delete()</c>.
+    /// Before the #1946 hook, only AL's own <c>Commit()</c> and the per-test isolation
+    /// boundary called <see cref="MarkCommitPoint"/>, so <see cref="RollbackToCommitPoint"/>
+    /// rolled all the way back to test-method start on ANY later trapped error — including
+    /// rows a nested BC transaction WORLD had already committed. #1946 fixed that by hooking
+    /// both extension methods; #2413 narrowed it to just the world-and-transaction one, since
+    /// hooking the plain one over-commits (see the "8g" comment for the reproduction that made
+    /// #1946 believe otherwise).
     ///
     /// This must NOT fire for a plain <c>Record.Insert/Modify/Delete/Rename</c> call — those
-    /// never call <c>EndTransaction</c> themselves (see <see cref="ALDatabasePatches.NoteRecordWrite"/>);
-    /// they just participate in whatever transaction is already open, ended by the test
-    /// framework's own boundary or an explicit AL <c>Commit()</c>. So this only ever marks a
-    /// commit point for a real nested-transaction completion, not for every write — the
-    /// corpus's <c>OnModify_Throws_ValueNotModified</c> (an uncommitted plain
-    /// <c>Insert()</c> IS rolled back by a later trapped error) still holds.
+    /// never call <c>EndTransactionWorldAndTransaction</c> themselves (see
+    /// <see cref="ALDatabasePatches.NoteRecordWrite"/>); they just participate in whatever
+    /// transaction is already open, ended by the test framework's own boundary or an explicit
+    /// AL <c>Commit()</c>. So this only ever marks a commit point for a real transaction-world
+    /// completion, not for every write — the corpus's <c>OnModify_Throws_ValueNotModified</c>
+    /// (an uncommitted plain <c>Insert()</c> IS rolled back by a later trapped error) still
+    /// holds.
     /// </summary>
     public static void NoteTransactionEnd(object? session, bool commit)
     {


### PR DESCRIPTION
Closes #2413

## Problem

`AlRunner/Infrastructure/NclCecilRewrite.cs` (section "8g", #1946) prepended
`RecordPatches.NoteTransactionEnd` to BOTH
`SessionTransactionExtensions.EndTransaction` and
`.EndTransactionWorldAndTransaction`, and `NoteTransactionEnd` calls
`MarkCommitPoint()` whenever `commit` is true. That's right only for a
completed **transaction world** (a guarded `Codeunit.Run`, or
`Ok := XmlPort.Import(...)`) — real BC's plain `EndTransaction` only pops a
nested level of the caller's already-open transaction and does not commit
anything. `Query.Open()`'s `RunOnBeforeOpenTriggerAsync` and statement-form
`XmlPort.Import(...)` both use the plain form, so a write made before either
of them, with no intervening `Commit()`, wrongly survived a later, unrelated
`asserterror`.

## Fix

Narrows the "8g" Cecil hook to `EndTransactionWorldAndTransaction` only; the
plain `EndTransaction` body now runs unmodified, exactly as it did before
#1946. Updated the doc comments in both files (`NclCecilRewrite.cs`'s "8g"
section and `RecordPatches.NoteTransactionEnd`'s XML doc) to state the
corrected rule instead of the disproven one #1946 left behind.

## Fix the shape, not just the reported line

- Grepped `NclCecilRewrite.cs` for every other prepend targeting these two
  extension methods — the "8g" section was the only call site, so there's no
  sibling registration carrying the same over-broad hook.
- Read every other reader of `_txCommitPoint` / `MarkCommitPoint`
  (`RollbackToCommitPoint`, `NoteTransactionWrite`,
  `ForceDurableFailedInserts`) in `RecordPatches.TransactionSnapshot.cs` —
  none of them independently assume a plain `EndTransaction` ever marks a
  commit point, so narrowing the hook at its one call site doesn't leave a
  sibling path holding the old, wrong assumption.

## Verification

- **Upstream corpus test** (plain-BC-behaviour claim, per
  `.claude/rules/bc-behavior-tests-go-upstream.md`):
  StefanMaron/BusinessCentral.AL.Language.Tests#105 adds Codeunit 60945 "Test
  AssertError Rollback NTx" — a committed row, an uncommitted write, then
  `Query.Open()`/statement-form `XmlPort.Import(...)`, then a later, unrelated
  `asserterror`. RED confirmed by pointing this runner at that corpus branch
  before the fix, GREEN after. **Not merged yet at the time of this PR** — the
  submodule pin is **not** bumped here; it will be a separate, later PR once
  #105's 8 BC legs are green (a pin bump can never be its own PR, and folding
  an unmerged upstream branch's SHA into this repo's pin isn't appropriate
  either).
- **Runner-mechanism test** (`AlRunner.Tests/AssertErrorRollbackNestedTransactionTests.cs`)
  covers the same shapes with `dotnet test`, since the require-tests gate
  needs a test under `tests/` or `AlRunner.Tests/` and the pin can't move yet.
  No `"application"` in its fixture `app.json` — Query is a platform-level
  object type, so no Base Application closure needed.
- Full local **al-language corpus**: 2302/2302 passing, no regressions
  (`pass-oos`, `pass-known-gap`, `pass-divergence` counts unchanged).
- Full local **runner-extras**: 207/207 passing, no regressions.

## Original reproduction (from the issue)

| Shape | Runner before fix | Runner after fix | Real BC 28.4 |
|---|---|---|---|
| P1 modify -> Query.Open -> error | row keeps new value | rolled back | rolled back |
| P2 insert -> Query.Open -> error | row survives | rolled back | rolled back |
| P3 uncommitted insert -> Query.Open -> unrelated error | PRESENT | ABSENT | ABSENT |
| P8 statement-form XmlPort.Import -> unrelated error | PRESENT | ABSENT | ABSENT |
| P4/P5/P7/P9 (transaction-world shapes) | already correct | unchanged, still correct | - |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013VvUgMSPokJWzeFNVQxD5J