### PR TITLE
fix(test-exec): make an unreachable null-instance branch throw, not break

### DIFF
--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -645,13 +645,29 @@ public sealed class TestExecutor
                         instMs += stageSw.ElapsedMilliseconds;
                         if (fresh == null)
                         {
-                            // The very first instantiation of this type (above) already
-                            // succeeded with a matching constructor, so this can only
-                            // mean the type stopped being instantiable mid-codeunit,
-                            // which should never happen — treat it the same as the
-                            // outer "no matching ctor" case rather than fail every
-                            // remaining test one by one.
-                            break;
+                            // Unreachable today, and deliberately loud rather than silent.
+                            //
+                            // InstantiateCodeunit returns null in exactly one case: no
+                            // constructor taking a single ITreeObject. Every other failure
+                            // throws and is caught just above. Reaching here means the FIRST
+                            // instantiation of this same `t` returned non-null (otherwise the
+                            // `instance == null` check further up would have skipped the whole
+                            // codeunit), so a matching constructor exists — and
+                            // Type.GetConstructors() cannot change for a loaded type while the
+                            // process runs. So this branch cannot execute.
+                            //
+                            // It used to `break`, which would have silently dropped every
+                            // remaining [Test] in the codeunit — the exact shape #2415 fixed
+                            // elsewhere in this loop. If InstantiateCodeunit ever gains a second
+                            // reason to return null, that silent truncation would come back with
+                            // nothing reporting it. Throwing means the day it becomes reachable
+                            // is the day it is seen (#2420).
+                            throw new InvalidOperationException(
+                                $"TestExecutor: re-instantiating test codeunit '{t.Name}' returned null "
+                                + $"before '{m.Name}', although its first instantiation succeeded. "
+                                + "InstantiateCodeunit only returns null when no ITreeObject constructor "
+                                + "exists, which cannot change for a loaded type — so this indicates a "
+                                + "change in InstantiateCodeunit, not a fault in the AL under test.");
                         }
                         testInstance = fresh;
                     }


### PR DESCRIPTION
`TestExecutor.Run`'s per-test re-instantiation path answered a null from `InstantiateCodeunit` with a bare `break`, which would silently drop every remaining `[Test]` in that codeunit — the exact shape #2415 fixed elsewhere in the same loop.

## The branch cannot execute today

1. **`TestExecutor.cs:570`** — `if (instance == null) continue;` skips the whole codeunit when the *first* instantiation returns null.
2. So reaching the branch proves the first call returned non-null for this same `t`.
3. **`InstantiateCodeunit` (line 936)** returns null in exactly one case: `GetConstructors().FirstOrDefault(c => one ITreeObject parameter)` finds nothing. Every other failure throws, and the `catch` immediately above already reports that as its own error.
4. `Type.GetConstructors()` is immutable for a loaded type.

A matching constructor therefore provably exists by the time the branch is reached, and null cannot come back. The old comment said "should never happen"; the accurate statement is "cannot happen, and here is why" — which the new comment records.

## Why change it at all

Because the line is dead, not because it is broken. If `InstantiateCodeunit` ever gains a second reason to return null, this branch quietly becomes a live test-dropper and nothing reports it — silently fewer tests, exit code unchanged. Throwing means the day it becomes reachable is the day it is seen, per `.claude/rules/loud-failures.md`. It costs one line to carry.

## No test, deliberately

The entire claim is that the line is unreachable. A test would have to change production code to manufacture a path that does not exist, and faking a null return would prove nothing about the real behavior. Asserting that an unreachable line stays unreachable is the kind of test `.claude/rules/tdd.md` calls noise. Discussed in #2420.

## Regression check

Full al-language corpus at the current pin: **2302/2302, exit 0**, including the `--count-baseline` guard.

Closes #2420

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf