### PR TITLE
fix(query): compute a JOIN's FlowField column instead of throwing OOS

### DIFF
--- a/AlRunner.QueryJoin/JoinContext.cs
+++ b/AlRunner.QueryJoin/JoinContext.cs
@@ -50,6 +50,16 @@ public sealed class JoinContext
     /// </summary>
     public required Func<object /*column*/, object?[] /*rawValues*/, object?> ComputeAggregate;
 
+    /// <summary>
+    /// #2423: (queryRowBuffer as object, NCLMetaField as object) → the calculated FlowField
+    /// value (boxed NavValue, or null). Bridges to al-runner's FlowFieldPatches.
+    /// CalcOneFlowFieldForQueryRow (#2300) so a JOIN that also selects a FlowField column
+    /// computes it the same way the single-real-dataitem path does, instead of reading an
+    /// unrelated TableSlot on the FlowField's source table (which this join never reads a row
+    /// buffer for at all).
+    /// </summary>
+    public required Func<object /*rowBuffer*/, object /*flowFieldMeta*/, object?> CalcFlowFieldForRow;
+
     /// <summary>Diagnostic log sink (al-runner's QLog).</summary>
     public required Action<string> Log;
 

--- a/AlRunner.QueryJoin/JoinExecutor.cs
+++ b/AlRunner.QueryJoin/JoinExecutor.cs
@@ -37,6 +37,19 @@ public static class JoinExecutor
     // NCLMetaQueryDefinition.GetAllDataItems avoids by testing this same property and NOT
     // recursing/yielding a dataitem that has one. See GetRealDataItems below.
     private static PropertyInfo? _pDataItemSubQueryDefinition;
+    // #2423: NCLMetaQueryDataItem.SourceFlowField — non-null on the same synthesized dataitem
+    // (SubQueryDefinition != null) when it is specifically a FlowField-calculation sub-query
+    // (as opposed to some other synthesized-subquery shape this runner does not otherwise
+    // support). Identifies WHICH source-table NCLMetaField the sub-dataitem's own result
+    // column stands in for — see ResolveFlowFieldOwnerName / GetSourceFlowField.
+    private static PropertyInfo? _pDataItemSourceFlowField;
+    // NCLMetaField.Parent (the owning NCLMetaTable) and NCLMetaTable.TableId — used to find
+    // which REAL dataitem in the join owns the FlowField's source table (BC's own
+    // NCLMetaQueryDataItem.CreateWithSubQuery passes a null dataItemLinksCreator for the
+    // FlowField sub-dataitem, so there is no DataItemLink back to the owner to read instead —
+    // confirmed by decompiling NCLMetaQuery.CreateSubQueryForFlowFieldCalculation).
+    private static PropertyInfo? _pFieldParent;
+    private static PropertyInfo? _pTableTableId;
     private static PropertyInfo? _pDataItemLinks;
     private static PropertyInfo? _pDataItemLinkType;
     private static PropertyInfo? _pDataItemName;
@@ -74,6 +87,7 @@ public static class JoinExecutor
         _pQueryDefOrderBy = tQueryDef.GetProperty("OrderBy", F)!;
         _pDataItemMetaTable = tDataItem.GetProperty("MetaTable", F)!;
         _pDataItemSubQueryDefinition = tDataItem.GetProperty("SubQueryDefinition", F)!;
+        _pDataItemSourceFlowField = tDataItem.GetProperty("SourceFlowField", F);
         _pDataItemLinks = tDataItem.GetProperty("DataItemLinks", F)!;
         _pDataItemLinkType = tDataItem.GetProperty("DataItemLinkType", F)!;
         _pDataItemName = tDataItem.GetProperty("Name", F)!;
@@ -251,6 +265,28 @@ public static class JoinExecutor
                 var fields = new object?[plan.SlotCount];
                 foreach (var col in plan.Columns)
                 {
+                    // #2423: a FlowField column has no TableSlot at all (its SourceTableField
+                    // resolves to a field on the FlowField's SOURCE table — a table this join
+                    // never reads a row buffer for — the same corruption the BuildJoinProjectionPlan
+                    // guard used to catch loudly). Compute it directly against the OWNER
+                    // dataitem's row in this combo, the same way the single-real-dataitem path
+                    // (#2300) computes it via FlowFieldPatches.CalcOneFlowFieldForQueryRow —
+                    // routed through ctx.CalcFlowFieldForRow across the isolation boundary.
+                    if (col.FlowFieldMeta != null)
+                    {
+                        if (!combo.TryGetValue(col.OwnerName, out var ownerBuf) || ownerBuf == null)
+                        {
+                            // LeftOuterJoin unmatched owner row → the FlowField's typed default,
+                            // same treatment as an unmatched child's stored field (never a null
+                            // slot — NREs NavQuery.GetColumnValue).
+                            fields[col.QuerySlot] = ctx.TypedDefaultForField(col.FlowFieldMeta);
+                        }
+                        else
+                        {
+                            fields[col.QuerySlot] = ctx.CalcFlowFieldForRow(ownerBuf, col.FlowFieldMeta);
+                        }
+                        continue;
+                    }
                     if (col.TableSlot < 0) continue; // unsupported column → default
                     if (!combo.TryGetValue(col.OwnerName, out var buf) || buf == null)
                     {
@@ -523,6 +559,12 @@ public static class JoinExecutor
         // "None" unless Method = Sum/Count/Average/Min/Max (issue #2146). Every non-filter-only
         // column is either a GROUP BY key (Aggregation == "None") or aggregated — never both.
         public string Aggregation = "None";
+        // #2423: non-null (NCLMetaField as object) when this column is the FlowField-calculation
+        // synthesized sub-dataitem's own result column — computed via ctx.CalcFlowFieldForRow
+        // against OwnerName's row in the combo instead of read off TableSlot (which is left -1
+        // for a FlowField column: SourceTableField resolves to the sub-query's INNER table, a
+        // table this join never reads a row buffer for at all — see BuildJoinProjectionPlan).
+        public object? FlowFieldMeta;
     }
     private sealed class JoinProjectionPlan
     {
@@ -550,37 +592,44 @@ public static class JoinExecutor
         var plan = new JoinProjectionPlan();
         int maxSlot = -1;
         var dataItems = ((IEnumerable)_pQueryDefDataItems!.GetValue(queryDef)!).Cast<object>().ToList();
+        var realDataItems = GetRealDataItems(queryDef);
 
         // #2423: a multi-real-dataitem JOIN that also selects a FlowField column reaches this
         // plan with the FlowField-calculation synthesized dataitem (SubQueryDefinition != null
         // -- see the field comment above) still in the RAW dataitem list, same as GetRealDataItems
-        // filters out elsewhere. Its own "column" is a real NCLMetaQueryColumn with the outer
-        // AL-compiled Id/ColumnIndex (see #2300's PR body), so ResolveTableSlot below resolves it
-        // to a field on the FlowField's SOURCE table -- a table this join never reads a row buffer
-        // for at all (Execute's own row-reading, above, already excludes this dataitem). Before
-        // this guard, that silently produced the column's typed default (observed: 0 instead of
-        // the oracle's 7.25) -- a wrong answer read back with no error, exactly the silent default
-        // .claude/rules/loud-failures.md forbids. Neither BuildJoinProjectionPlan nor its
-        // al-runner-side mirror ComputeJoinColumnSlotMap route a FlowField column through
-        // FlowFieldPatches.CalcOneFlowFieldForQueryRow the way the single-dataitem projection path
-        // (#2300) does -- tracked as the remaining gap in #2423. Fail loudly instead of guessing.
+        // filters out elsewhere (as a ROW SOURCE only -- it never gets a combo entry, since
+        // Execute's own row-reading already excludes it). Its own column carries the outer
+        // AL-compiled Id/ColumnIndex (see #2300's PR body) and IS still projected -- routed
+        // through FlowFieldMeta/ctx.CalcFlowFieldForRow below (mirroring the single-dataitem
+        // path, #2300), never through ResolveTableSlot, which would resolve to a field on the
+        // FlowField's SOURCE table -- a table this join never reads a row buffer for at all,
+        // the silent-default corruption .claude/rules/loud-failures.md forbids (observed before
+        // this fix: 0 instead of the oracle's 7.25).
+        //
+        // A synthesized dataitem that is NOT the FlowField-calculation shape (SubQueryDefinition
+        // != null but SourceFlowField == null -- e.g. BC's own aggregation-filter sub-dataitems,
+        // NCLMetaQuery.CreateDataItemsForAggregationFiltersWithFlowFieldAsSource) is a shape this
+        // runner does not otherwise support in the join path -- fail loudly rather than guess.
         foreach (var di in dataItems)
         {
             if (_pDataItemSubQueryDefinition!.GetValue(di) == null) continue;
+            if (_pDataItemSourceFlowField?.GetValue(di) != null) continue; // FlowField calc — handled below.
             var subDataItemName = (string)_pDataItemName!.GetValue(di)!;
             throw ctx.OutOfScope(
-                "NavQuery (multi-dataitem join with a FlowField column)",
-                $"query-join-flowfield-column-not-implemented -- dataitem '{subDataItemName}' is the " +
-                "synthesized FlowField-calculation sub-dataitem for a column selected alongside a " +
-                "real multi-dataitem JOIN; this runner does not yet compute a FlowField column's " +
-                "value in the join projection path (only the single-real-dataitem case is wired, " +
-                "via FlowFieldPatches.CalcOneFlowFieldForQueryRow) -- see #2423");
+                "NavQuery (multi-dataitem join with a synthesized sub-dataitem)",
+                $"query-join-synthesized-subquery-not-implemented -- dataitem '{subDataItemName}' is a " +
+                "synthesized sub-dataitem (SubQueryDefinition != null) that is not a FlowField-calculation " +
+                "sub-query; this runner does not support this join sub-shape in-memory; see docs/scope.md");
         }
 
         // Pass 1: genuinely-projected (non-filter-only) columns get their real ColumnIndex slot.
         foreach (var di in dataItems)
         {
             var name = (string)_pDataItemName!.GetValue(di)!;
+            object? flowFieldMeta = _pDataItemSourceFlowField?.GetValue(di);
+            string? flowFieldOwnerName = flowFieldMeta != null
+                ? ResolveFlowFieldOwnerName(ctx, realDataItems, flowFieldMeta)
+                : null;
             var cols = ((IEnumerable?)_pDataItemQueryColumns!.GetValue(di))?.Cast<object>() ?? Enumerable.Empty<object>();
             foreach (var col in cols)
             {
@@ -588,7 +637,19 @@ public static class JoinExecutor
                 int querySlot = (int)_pColColumnIndex!.GetValue(col)!;
                 if (querySlot < 0) continue; // defensive: shouldn't happen for a non-filter-only column.
                 if (querySlot > maxSlot) maxSlot = querySlot;
-                plan.Columns.Add(new JoinColumn { QuerySlot = querySlot, OwnerName = name, TableSlot = ResolveTableSlot(col, out var srcField), SourceField = srcField, ColumnObj = col, Aggregation = AggregationOf(col) });
+                if (flowFieldMeta != null)
+                {
+                    // Force Aggregation = "None": AggregationOf(col) reports the sub-query's OWN
+                    // internal Sum/Count/etc (real BC's SQL groups it away invisibly inside the
+                    // OuterApply sub-query) -- not an aggregation this join's own #2146 implicit
+                    // GROUP BY must additionally perform, mirroring the single-dataitem path's
+                    // BuildProjectionPlan (RecordPatches.QueryProjection.cs) treatment.
+                    plan.Columns.Add(new JoinColumn { QuerySlot = querySlot, OwnerName = flowFieldOwnerName!, TableSlot = -1, SourceField = null, ColumnObj = col, Aggregation = "None", FlowFieldMeta = flowFieldMeta });
+                }
+                else
+                {
+                    plan.Columns.Add(new JoinColumn { QuerySlot = querySlot, OwnerName = name, TableSlot = ResolveTableSlot(col, out var srcField), SourceField = srcField, ColumnObj = col, Aggregation = AggregationOf(col) });
+                }
             }
         }
 
@@ -615,8 +676,66 @@ public static class JoinExecutor
             }
         }
 
+        // #2423: a FlowField column combined with a #2146 implicit GROUP BY (some other column
+        // in this same join has Method = Sum/Count/Average/Min/Max) is unmeasured -- no oracle
+        // case covers a query grouping alongside a joined FlowField column, and BuildGroupedRows'
+        // ResolveComboValue has no FlowField branch (it would silently read TableSlot = -1 as a
+        // GROUP BY key, producing null/default). Fail loudly rather than guess, same as the
+        // single-dataitem path leaves this combination as a documented follow-up (see BuildRow's
+        // #2300 comment in RecordPatches.QueryProjection.cs).
+        if (plan.Columns.Any(c => c.FlowFieldMeta != null) && plan.Columns.Any(c => c.Aggregation != "None"))
+            throw ctx.OutOfScope(
+                "NavQuery (multi-dataitem join with a FlowField column)",
+                "query-join-flowfield-column-with-groupby-not-implemented -- this join selects both a " +
+                "FlowField column and an aggregated (Method = Sum/Count/Average/Min/Max) column; the " +
+                "implicit GROUP BY this runner performs for the aggregated column (#2146) has no " +
+                "FlowField-calculation branch; see docs/scope.md");
+
         plan.SlotCount = Math.Max(maxSlot + 1, nextExtraSlot);
         return plan;
+    }
+
+    /// <summary>
+    /// #2423: which REAL (row-buffer-bearing) dataitem in this join owns <paramref
+    /// name="flowFieldMeta"/>'s source table — i.e. which combo[name] carries the row
+    /// CalcOneFlowFieldForQueryRow needs. NCLMetaQueryDataItem.CreateWithSubQuery passes a
+    /// null dataItemLinksCreator for the FlowField-calculation sub-dataitem (confirmed by
+    /// decompiling NCLMetaQuery.CreateSubQueryForFlowFieldCalculation), so there is no
+    /// DataItemLink back to the owner to read — match on the owning table's TableId instead
+    /// (NCLMetaField.Parent). Exactly one real dataitem must match; zero (owner table not in
+    /// this join — shouldn't happen, BC only builds this sub-dataitem for a column ON one of
+    /// the join's own dataitems) or more than one (a self-join on the FlowField's table) both
+    /// throw loudly rather than silently pick a possibly-wrong dataitem.
+    /// </summary>
+    private static string ResolveFlowFieldOwnerName(JoinContext ctx, List<object> realDataItems, object flowFieldMeta)
+    {
+        _pFieldParent ??= flowFieldMeta.GetType().GetProperty("Parent", F);
+        var owningTable = _pFieldParent?.GetValue(flowFieldMeta);
+        if (owningTable == null)
+            throw ctx.OutOfScope(
+                "NavQuery (multi-dataitem join with a FlowField column)",
+                "query-join-flowfield-owner-unresolved -- NCLMetaField.Parent did not resolve a table " +
+                "for the FlowField column; cannot locate its owning dataitem in the join; see docs/scope.md");
+        _pTableTableId ??= owningTable.GetType().GetProperty("TableId", F);
+        var ownerTableId = _pTableTableId?.GetValue(owningTable);
+
+        string? matchName = null;
+        int matches = 0;
+        foreach (var di in realDataItems)
+        {
+            var table = _pDataItemMetaTable!.GetValue(di);
+            var tableId = table == null ? null : _pTableTableId?.GetValue(table);
+            if (tableId == null || ownerTableId == null || !tableId.Equals(ownerTableId)) continue;
+            matches++;
+            matchName = (string)_pDataItemName!.GetValue(di)!;
+        }
+        if (matches != 1)
+            throw ctx.OutOfScope(
+                "NavQuery (multi-dataitem join with a FlowField column)",
+                $"query-join-flowfield-owner-ambiguous -- found {matches} real dataitem(s) whose table " +
+                "matches the FlowField's owning table (0 = not in this join; >1 = a self-join on that " +
+                "table); cannot unambiguously pick the FlowField's owner row; see docs/scope.md");
+        return matchName!;
     }
 
     private static int ResolveTableSlot(object col, out object? srcField)

--- a/AlRunner.Tests/QueryJoinFlowFieldColumnOosTests.cs
+++ b/AlRunner.Tests/QueryJoinFlowFieldColumnOosTests.cs
@@ -5,25 +5,25 @@ using Xunit;
 namespace AlRunner.Tests;
 
 /// <summary>
-/// Issue #2423 -- a multi-real-dataitem JOIN query that ALSO selects a FlowField column
-/// silently read the column's typed default (observed: 0) instead of the calculated value,
+/// Issue #2423 -- a multi-real-dataitem JOIN query that ALSO selects a FlowField column used
+/// to silently read the column's typed default (observed: 0) instead of the calculated value,
 /// once #2295 unblocked the query's own metadata construction. #2300 fixed the
 /// single-real-dataitem FlowField case (via NCLMetaQueryDataItem.SourceFlowField and
-/// FlowFieldPatches.CalcOneFlowFieldForQueryRow), but deliberately left the join projection
-/// path (AlRunner.QueryJoin.JoinExecutor.BuildJoinProjectionPlan and its al-runner-side
-/// mirror RecordPatches.QueryProjection.ComputeJoinColumnSlotMap) unwired for a FlowField
-/// column: both still resolve the FlowField sub-dataitem's own aggregate column via a
-/// generic TableSlot read against the SOURCE table (the FlowField's own source, not any
-/// table the join actually reads a row buffer for), which silently produced the column's
-/// typed default rather than either the real value or an error.
+/// FlowFieldPatches.CalcOneFlowFieldForQueryRow); #2423 extends the SAME mechanism across the
+/// join projection path (AlRunner.QueryJoin.JoinExecutor.BuildJoinProjectionPlan and its
+/// al-runner-side mirror RecordPatches.QueryProjection.ComputeJoinColumnSlotMap): the
+/// FlowField sub-dataitem's column is now routed through ctx.CalcFlowFieldForRow against the
+/// resolved OWNER real dataitem's row in the join combo, instead of a generic TableSlot read
+/// against the FlowField's SOURCE table (a table the join never reads a row buffer for at all).
 ///
-/// This is a RUNNER-MECHANISM test pinning the loud-failure guard #2423's own investigation
-/// added: BuildJoinProjectionPlan/ComputeJoinColumnSlotMap now throw
-/// RunnerOutOfScopeException (reason query-join-flowfield-column-not-implemented, naming the
-/// synthesized sub-dataitem and "see #2423") the moment they encounter that sub-dataitem,
-/// instead of silently defaulting the column -- a silent wrong answer is exactly what
-/// .claude/rules/loud-failures.md forbids. Implementing the real join+FlowField computation
-/// is tracked in #2423 itself, not this test.
+/// This is a RUNNER-MECHANISM suite: it pins that the runner (a) now COMPUTES the value
+/// correctly for a FlowField column on either side of a join (this class's own #2423 fix,
+/// verified independently upstream by StefanMaron/BusinessCentral.AL.Language.Tests#106's
+/// "JoinFlowFieldColumn_ReadsCalculatedValue" against real BC), and (b) still fails LOUDLY
+/// (never silently) for the one sub-shape left unimplemented: a FlowField column combined with
+/// the join's own #2146 implicit GROUP BY (some other column aggregated Sum/Count/Average/
+/// Min/Max) -- unmeasured, no oracle case covers it, and BuildGroupedRows' ResolveComboValue
+/// has no FlowField branch.
 ///
 /// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
 /// </summary>
@@ -55,129 +55,320 @@ public class QueryJoinFlowFieldColumnOosTests
         lock (sb) return (sb.ToString(), p.ExitCode);
     }
 
-    private static string WriteBundle()
+    private static string WriteBundle(string appJsonName, string idRangeFrom, string idRangeTo, string extraFiles)
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-query-join-flowfield-oos-2423", Guid.NewGuid().ToString("N"));
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-query-join-flowfield-2423", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
 
-        File.WriteAllText(Path.Combine(root, "app.json"), """
+        File.WriteAllText(Path.Combine(root, "app.json"), $$"""
         {
           "id": "c7d1e4f2-2423-4a1b-9c3d-000000002423",
-          "name": "QJF 2423 Repro",
+          "name": "{{appJsonName}}",
           "publisher": "Repro2423",
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "idRanges": [ { "from": 62470, "to": 62479 } ],
+          "idRanges": [ { "from": {{idRangeFrom}}, "to": {{idRangeTo}} } ],
           "runtime": "14.0"
         }
         """);
-        // Entirely application-local (no dependency needed): "Qjf Link" joins to "Qjf Header",
-        // whose "Total Amount" is a FlowField summing "Qjf Line" -- the same shape as #2300's
-        // JoinIleFlowFieldColumn_ReadsCalculatedValue (a local table inner-joined to a table
-        // whose FlowField column is selected), just without the Base Application dependency a
-        // C# fixture app.json may not declare.
-        File.WriteAllText(Path.Combine(root, "QjfLine.al"), """
-        table 62470 "Qjf Line"
-        {
-            DataClassification = SystemMetadata;
-            fields
-            {
-                field(1; "Entry No."; Integer) { }
-                field(2; "Header No."; Code[20]) { }
-                field(3; Amount; Decimal) { }
-            }
-            keys { key(PK; "Entry No.") { Clustered = true; } }
-        }
-        """);
-        File.WriteAllText(Path.Combine(root, "QjfHeader.al"), """
-        table 62471 "Qjf Header"
-        {
-            DataClassification = SystemMetadata;
-            fields
-            {
-                field(1; "No."; Code[20]) { }
-                field(2; "Total Amount"; Decimal)
-                {
-                    FieldClass = FlowField;
-                    CalcFormula = sum("Qjf Line".Amount where("Header No." = field("No.")));
-                }
-            }
-            keys { key(PK; "No.") { Clustered = true; } }
-        }
-        """);
-        File.WriteAllText(Path.Combine(root, "QjfLink.al"), """
-        table 62472 "Qjf Link"
-        {
-            DataClassification = SystemMetadata;
-            fields
-            {
-                field(1; "Entry No."; Integer) { }
-                field(2; "Header No."; Code[20]) { }
-            }
-            keys { key(PK; "Entry No.") { Clustered = true; } }
-        }
-        """);
-        File.WriteAllText(Path.Combine(root, "QjfJoinFlowField.al"), """
-        query 62473 "QJF Join FlowField"
-        {
-            QueryType = Normal;
-            elements
-            {
-                dataitem(QjfLink; "Qjf Link")
-                {
-                    column(LinkEntryNo; "Entry No.") { }
-                    dataitem(QjfHeader; "Qjf Header")
-                    {
-                        DataItemLink = "No." = QjfLink."Header No.";
-                        SqlJoinType = InnerJoin;
-                        column(TotalAmount; "Total Amount") { }
-                    }
-                }
-            }
-        }
-        """);
-        File.WriteAllText(Path.Combine(root, "QjfTests.al"), """
-        codeunit 62474 "QJF 2423 Tests"
-        {
-            Subtype = Test;
-
-            [Test]
-            procedure JoinWithFlowFieldColumn_ThrowsOutOfScope_InsteadOfReadingZeroSilently()
-            var
-                QjfHeader: Record "Qjf Header";
-                QjfLine: Record "Qjf Line";
-                QjfLink: Record "Qjf Link";
-                Q: Query "QJF Join FlowField";
-                Cost: Decimal;
-            begin
-                QjfHeader.Init(); QjfHeader."No." := 'H1'; QjfHeader.Insert();
-                QjfLine.Init(); QjfLine."Entry No." := 1; QjfLine."Header No." := 'H1'; QjfLine.Amount := 7.25; QjfLine.Insert();
-                QjfLink.Init(); QjfLink."Entry No." := 1; QjfLink."Header No." := 'H1'; QjfLink.Insert();
-
-                Q.Open();
-                if not Q.Read() then
-                    Error('expected one row');
-                Cost := Q.TotalAmount;
-                Q.Close();
-                // If the runner ever silently returns a value here instead of throwing, this
-                // assertion catches the exact #2423 corruption directly: the pre-guard
-                // behavior was reading 0 (the column's typed default) instead of 7.25.
-                if Cost <> 7.25 then
-                    Error('Expected the runner to throw RunnerOutOfScopeException (see #2423), not silently read %1', Cost);
-            end;
-        }
-        """);
-
+        File.WriteAllText(Path.Combine(root, "extra.al"), extraFiles);
         return root;
     }
 
+    // Entirely application-local (no dependency needed): "Qjf Link" joins to "Qjf Header",
+    // whose "Total Amount" is a FlowField summing "Qjf Line" -- the same shape as #2300's
+    // JoinIleFlowFieldColumn_ReadsCalculatedValue (a local table inner-joined to a table
+    // whose FlowField column is selected), just without the Base Application dependency a C#
+    // fixture app.json may not declare (no-base-app-in-csharp-tests.md).
+    private const string ChildSideShape = """
+    table 62470 "Qjf Line"
+    {
+        DataClassification = SystemMetadata;
+        fields
+        {
+            field(1; "Entry No."; Integer) { }
+            field(2; "Header No."; Code[20]) { }
+            field(3; Amount; Decimal) { }
+        }
+        keys { key(PK; "Entry No.") { Clustered = true; } }
+    }
+    table 62471 "Qjf Header"
+    {
+        DataClassification = SystemMetadata;
+        fields
+        {
+            field(1; "No."; Code[20]) { }
+            field(2; "Total Amount"; Decimal)
+            {
+                FieldClass = FlowField;
+                CalcFormula = sum("Qjf Line".Amount where("Header No." = field("No.")));
+            }
+        }
+        keys { key(PK; "No.") { Clustered = true; } }
+    }
+    table 62472 "Qjf Link"
+    {
+        DataClassification = SystemMetadata;
+        fields
+        {
+            field(1; "Entry No."; Integer) { }
+            field(2; "Header No."; Code[20]) { }
+        }
+        keys { key(PK; "Entry No.") { Clustered = true; } }
+    }
+    // FlowField column ("Total Amount") is on the CHILD (non-driving, joined) dataitem.
+    query 62473 "QJF Join FlowField"
+    {
+        QueryType = Normal;
+        elements
+        {
+            dataitem(QjfLink; "Qjf Link")
+            {
+                column(LinkEntryNo; "Entry No.") { }
+                dataitem(QjfHeader; "Qjf Header")
+                {
+                    DataItemLink = "No." = QjfLink."Header No.";
+                    SqlJoinType = InnerJoin;
+                    column(TotalAmount; "Total Amount") { }
+                }
+            }
+        }
+    }
+    codeunit 62474 "QJF 2423 Tests"
+    {
+        Subtype = Test;
+
+        [Test]
+        procedure JoinWithFlowFieldColumn_ReadsCalculatedValue()
+        var
+            QjfHeader: Record "Qjf Header";
+            QjfLine: Record "Qjf Line";
+            QjfLink: Record "Qjf Link";
+            Q: Query "QJF Join FlowField";
+            Total: Decimal;
+        begin
+            QjfHeader.Init(); QjfHeader."No." := 'H1'; QjfHeader.Insert();
+            QjfLine.Init(); QjfLine."Entry No." := 1; QjfLine."Header No." := 'H1'; QjfLine.Amount := 7.25; QjfLine.Insert();
+            QjfLink.Init(); QjfLink."Entry No." := 1; QjfLink."Header No." := 'H1'; QjfLink.Insert();
+
+            Q.Open();
+            if not Q.Read() then
+                Error('expected one row');
+            Total := Q.TotalAmount;
+            Q.Close();
+            if Total <> 7.25 then
+                Error('Expected 7.25, got %1', Total);
+        end;
+    }
+    """;
+
+    // Same fixture shape, but the FlowField column ("Total Amount") is on the DRIVING (first,
+    // parent) dataitem instead of the child -- the join's own combo-lookup and owner
+    // resolution must not depend on which side of the join carries the FlowField (#2423
+    // acceptance criteria: "either side").
+    private const string ParentSideShape = """
+    table 62480 "Qjf2 Line"
+    {
+        DataClassification = SystemMetadata;
+        fields
+        {
+            field(1; "Entry No."; Integer) { }
+            field(2; "Header No."; Code[20]) { }
+            field(3; Amount; Decimal) { }
+        }
+        keys { key(PK; "Entry No.") { Clustered = true; } }
+    }
+    table 62481 "Qjf2 Header"
+    {
+        DataClassification = SystemMetadata;
+        fields
+        {
+            field(1; "No."; Code[20]) { }
+            field(2; "Total Amount"; Decimal)
+            {
+                FieldClass = FlowField;
+                CalcFormula = sum("Qjf2 Line".Amount where("Header No." = field("No.")));
+            }
+        }
+        keys { key(PK; "No.") { Clustered = true; } }
+    }
+    table 62482 "Qjf2 Link"
+    {
+        DataClassification = SystemMetadata;
+        fields
+        {
+            field(1; "Entry No."; Integer) { }
+            field(2; "Header No."; Code[20]) { }
+        }
+        keys { key(PK; "Entry No.") { Clustered = true; } }
+    }
+    // FlowField column ("Total Amount") is on the PARENT (driving) dataitem.
+    query 62483 "QJF2 Join FlowField"
+    {
+        QueryType = Normal;
+        elements
+        {
+            dataitem(Qjf2Header; "Qjf2 Header")
+            {
+                column(TotalAmount; "Total Amount") { }
+                dataitem(Qjf2Link; "Qjf2 Link")
+                {
+                    DataItemLink = "Header No." = Qjf2Header."No.";
+                    SqlJoinType = InnerJoin;
+                    column(LinkEntryNo; "Entry No.") { }
+                }
+            }
+        }
+    }
+    codeunit 62484 "QJF2 2423 Tests"
+    {
+        Subtype = Test;
+
+        [Test]
+        procedure JoinWithFlowFieldOnParentDataItem_ReadsCalculatedValue()
+        var
+            Qjf2Header: Record "Qjf2 Header";
+            Qjf2Line: Record "Qjf2 Line";
+            Qjf2Link: Record "Qjf2 Link";
+            Q: Query "QJF2 Join FlowField";
+            Total: Decimal;
+        begin
+            Qjf2Header.Init(); Qjf2Header."No." := 'H1'; Qjf2Header.Insert();
+            Qjf2Line.Init(); Qjf2Line."Entry No." := 1; Qjf2Line."Header No." := 'H1'; Qjf2Line.Amount := 3.5; Qjf2Line.Insert();
+            Qjf2Line.Init(); Qjf2Line."Entry No." := 2; Qjf2Line."Header No." := 'H1'; Qjf2Line.Amount := 6.5; Qjf2Line.Insert();
+            Qjf2Link.Init(); Qjf2Link."Entry No." := 1; Qjf2Link."Header No." := 'H1'; Qjf2Link.Insert();
+
+            Q.Open();
+            if not Q.Read() then
+                Error('expected one row');
+            Total := Q.TotalAmount;
+            Q.Close();
+            if Total <> 10 then
+                Error('Expected 10, got %1', Total);
+        end;
+    }
+    """;
+
+    // FlowField column + a #2146 implicit GROUP BY (another column Method = Sum) in the SAME
+    // join -- unmeasured combination (no oracle case), so the runner must still throw loudly
+    // rather than silently read a null/default GROUP BY key for the FlowField column.
+    private const string GroupByShape = """
+    table 62490 "Qjf3 Line"
+    {
+        DataClassification = SystemMetadata;
+        fields
+        {
+            field(1; "Entry No."; Integer) { }
+            field(2; "Header No."; Code[20]) { }
+            field(3; Amount; Decimal) { }
+        }
+        keys { key(PK; "Entry No.") { Clustered = true; } }
+    }
+    table 62491 "Qjf3 Header"
+    {
+        DataClassification = SystemMetadata;
+        fields
+        {
+            field(1; "No."; Code[20]) { }
+            field(2; "Total Amount"; Decimal)
+            {
+                FieldClass = FlowField;
+                CalcFormula = sum("Qjf3 Line".Amount where("Header No." = field("No.")));
+            }
+        }
+        keys { key(PK; "No.") { Clustered = true; } }
+    }
+    table 62492 "Qjf3 Link"
+    {
+        DataClassification = SystemMetadata;
+        fields
+        {
+            field(1; "Entry No."; Integer) { }
+            field(2; "Header No."; Code[20]) { }
+            field(3; Qty; Integer) { }
+        }
+        keys { key(PK; "Entry No.") { Clustered = true; } }
+    }
+    query 62493 "QJF3 Join FlowField Group"
+    {
+        QueryType = Normal;
+        elements
+        {
+            dataitem(Qjf3Link; "Qjf3 Link")
+            {
+                column(SumQty; Qty) { Method = Sum; }
+                dataitem(Qjf3Header; "Qjf3 Header")
+                {
+                    DataItemLink = "No." = Qjf3Link."Header No.";
+                    SqlJoinType = InnerJoin;
+                    column(TotalAmount; "Total Amount") { }
+                }
+            }
+        }
+    }
+    codeunit 62494 "QJF3 2423 Tests"
+    {
+        Subtype = Test;
+
+        [Test]
+        procedure JoinWithFlowFieldColumnAndGroupBy_ThrowsOutOfScope_InsteadOfSilentlyDefaulting()
+        var
+            Qjf3Header: Record "Qjf3 Header";
+            Qjf3Line: Record "Qjf3 Line";
+            Qjf3Link: Record "Qjf3 Link";
+            Q: Query "QJF3 Join FlowField Group";
+            Total: Decimal;
+        begin
+            Qjf3Header.Init(); Qjf3Header."No." := 'H1'; Qjf3Header.Insert();
+            Qjf3Line.Init(); Qjf3Line."Entry No." := 1; Qjf3Line."Header No." := 'H1'; Qjf3Line.Amount := 7.25; Qjf3Line.Insert();
+            Qjf3Link.Init(); Qjf3Link."Entry No." := 1; Qjf3Link."Header No." := 'H1'; Qjf3Link.Qty := 2; Qjf3Link.Insert();
+
+            Q.Open();
+            if not Q.Read() then
+                Error('expected one row');
+            Total := Q.TotalAmount;
+            Q.Close();
+            // If the runner ever silently returns a value here instead of throwing, this
+            // assertion catches it directly.
+            if Total <> 7.25 then
+                Error('Expected the runner to throw RunnerOutOfScopeException (see #2423), not silently read %1', Total);
+        end;
+    }
+    """;
+
     [SkippableFact]
-    public void QueryJoinWithFlowFieldColumn_ThrowsLoudOutOfScope_InsteadOfSilentlyDefaultingToZero()
+    public void JoinWithFlowFieldColumn_OnChildDataItem_ReadsCalculatedValue()
     {
         TestArtifacts.SkipIfMissing();
 
-        var bundle = WriteBundle();
+        var bundle = WriteBundle("QJF 2423 Repro", "62470", "62479", ChildSideShape);
+        var (output, exitCode) = RunRunner(bundle);
+
+        Assert.DoesNotContain("EMIT-EXCLUDED", output);
+        Assert.DoesNotContain("COMPILE FAIL", output);
+        Assert.Contains("1P/0F/0E", output);
+    }
+
+    [SkippableFact]
+    public void JoinWithFlowFieldColumn_OnParentDataItem_ReadsCalculatedValue()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var bundle = WriteBundle("QJF2 2423 Repro", "62480", "62489", ParentSideShape);
+        var (output, exitCode) = RunRunner(bundle);
+
+        Assert.DoesNotContain("EMIT-EXCLUDED", output);
+        Assert.DoesNotContain("COMPILE FAIL", output);
+        Assert.Contains("1P/0F/0E", output);
+    }
+
+    [SkippableFact]
+    public void JoinWithFlowFieldColumnAndGroupBy_ThrowsLoudOutOfScope_InsteadOfSilentlyDefaulting()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var bundle = WriteBundle("QJF3 2423 Repro", "62490", "62499", GroupByShape);
         var (output, exitCode) = RunRunner(bundle);
 
         Assert.DoesNotContain("EMIT-EXCLUDED", output);
@@ -187,8 +378,8 @@ public class QueryJoinFlowFieldColumnOosTests
         // and the failure carries the #2423 loud-failure guard's own reason string -- not a
         // silently-wrong AL-level "Expected the runner..." message, and not any unrelated
         // crash.
-        Assert.Contains("query-join-flowfield-column-not-implemented", output);
-        Assert.Contains("see #2423", output);
+        Assert.Contains("query-join-flowfield-column-with-groupby-not-implemented", output);
+        Assert.Contains("see docs/scope.md", output);
         Assert.DoesNotContain("Expected the runner to throw", output);
         Assert.Contains("0P/1F/0E", output);
     }

--- a/AlRunner/Patches/RecordPatches.QueryJoin.cs
+++ b/AlRunner/Patches/RecordPatches.QueryJoin.cs
@@ -95,6 +95,7 @@ public static partial class RecordPatches
         Set("ToNavValueArray", FieldType("ToNavValueArray"), nameof(Join_ToNavValueArray));
         Set("TypedDefaultForField", FieldType("TypedDefaultForField"), nameof(Join_TypedDefaultForField));
         Set("ComputeAggregate", FieldType("ComputeAggregate"), nameof(Join_ComputeAggregate));
+        Set("CalcFlowFieldForRow", FieldType("CalcFlowFieldForRow"), nameof(Join_CalcFlowFieldForRow));
         Set("Log", FieldType("Log"), nameof(Join_Log));
         Set("OutOfScope", FieldType("OutOfScope"), nameof(Join_OutOfScope));
         return ctx;

--- a/AlRunner/Patches/RecordPatches.QueryProjection.cs
+++ b/AlRunner/Patches/RecordPatches.QueryProjection.cs
@@ -337,6 +337,9 @@ public static partial class RecordPatches
     // ComputeJoinColumnSlotMap's own copy of BuildJoinProjectionPlan's algorithm must carry too.
     private static PropertyInfo? _pDataItemSubQueryDefinitionQ;
     private static PropertyInfo? _pDataItemNameQ;
+    // #2423: mirrors JoinExecutor's own _pDataItemSourceFlowField — distinguishes the
+    // FlowField-calculation synthesized sub-dataitem from any other synthesized-subquery shape.
+    private static PropertyInfo? _pDataItemSourceFlowFieldQ;
 
     private static void EnsureFilterReflection()
     {
@@ -359,6 +362,7 @@ public static partial class RecordPatches
         _pColColumnTypeQ = _tNCLMetaQueryColumn?.GetProperty("ColumnType", anyInstance);
         _pDataItemSubQueryDefinitionQ = _tNCLMetaQueryDataItem?.GetProperty("SubQueryDefinition", anyInstance);
         _pDataItemNameQ = _tNCLMetaQueryDataItem?.GetProperty("Name", anyInstance);
+        _pDataItemSourceFlowFieldQ = _tNCLMetaQueryDataItem?.GetProperty("SourceFlowField", anyInstance);
         _filterReflectionReady = true;
     }
 
@@ -383,25 +387,24 @@ public static partial class RecordPatches
         var dataItems = ((System.Collections.IEnumerable)_pQueryDefDataItemsQ.GetValue(queryDef)!).Cast<object>().ToList();
 
         // #2423: mirrors JoinExecutor.BuildJoinProjectionPlan's own guard EXACTLY (this method's
-        // own doc comment requires the two algorithms to change together) -- a multi-real-dataitem
-        // JOIN that also selects a FlowField column still carries the FlowField-calculation
-        // synthesized dataitem (SubQueryDefinition != null) in this RAW dataitem list. Before this
-        // guard its column resolved to a field on the FlowField's SOURCE table, a table this join
-        // never reads a row buffer for, silently producing the column's typed default (0) instead
-        // of the calculated value -- the silent default .claude/rules/loud-failures.md forbids.
-        // Neither this method nor JoinExecutor's copy route a FlowField column through
-        // FlowFieldPatches.CalcOneFlowFieldForQueryRow in the join path yet -- tracked in #2423.
+        // own doc comment requires the two algorithms to change together). The FlowField-
+        // calculation synthesized sub-dataitem (SubQueryDefinition != null, SourceFlowField !=
+        // null) IS now given a slot below like any other column — its ColumnIndex is unaffected
+        // by how JoinExecutor computes its VALUE (via ctx.CalcFlowFieldForRow, not TableSlot), so
+        // this mirror needs no FlowField-specific branch of its own, only the throw removed for
+        // that shape. A synthesized sub-dataitem that is NOT the FlowField-calculation shape
+        // (SourceFlowField == null — some other synthesized-subquery shape this runner does not
+        // otherwise support in the join path) still throws loudly rather than guess.
         foreach (var diCheck in dataItems)
         {
             if (_pDataItemSubQueryDefinitionQ?.GetValue(diCheck) == null) continue;
+            if (_pDataItemSourceFlowFieldQ?.GetValue(diCheck) != null) continue; // FlowField calc — gets a slot below.
             var subDataItemName = _pDataItemNameQ?.GetValue(diCheck) as string ?? "<unknown>";
             throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                "NavQuery (multi-dataitem join with a FlowField column)",
-                $"query-join-flowfield-column-not-implemented -- dataitem '{subDataItemName}' is the " +
-                "synthesized FlowField-calculation sub-dataitem for a column selected alongside a " +
-                "real multi-dataitem JOIN; this runner does not yet compute a FlowField column's " +
-                "value in the join projection path (only the single-real-dataitem case is wired, " +
-                "via FlowFieldPatches.CalcOneFlowFieldForQueryRow) -- see #2423");
+                "NavQuery (multi-dataitem join with a synthesized sub-dataitem)",
+                $"query-join-synthesized-subquery-not-implemented -- dataitem '{subDataItemName}' is a " +
+                "synthesized sub-dataitem (SubQueryDefinition != null) that is not a FlowField-calculation " +
+                "sub-query; this runner does not support this join sub-shape in-memory; see docs/scope.md");
         }
 
         int maxSlot = -1;
@@ -1102,6 +1105,16 @@ public static partial class RecordPatches
         var values = rawValues.Select(v => (NavValue?)v);
         return ComputeAggregateCore(column.AggregationType, column, rawValues.Length, values);
     }
+
+    /// <summary>
+    /// Adapter for AlRunner.QueryJoin.JoinContext.CalcFlowFieldForRow (#2423): the isolated
+    /// JoinExecutor hands back the OWNER dataitem's own row buffer (boxed) and the FlowField's
+    /// NCLMetaField (boxed) for a JOIN that also selects a FlowField column; forwards to the
+    /// same FlowFieldPatches.CalcOneFlowFieldForQueryRow the single-real-dataitem path (#2300)
+    /// uses, so the aggregation/formula math is not duplicated across the assembly boundary.
+    /// </summary>
+    private static object? Join_CalcFlowFieldForRow(object rowBuffer, object flowFieldMeta)
+        => FlowFieldPatches.CalcOneFlowFieldForQueryRow(rowBuffer, (NCLMetaField)flowFieldMeta);
 
     private static Type? _tNavValue;
     private static Array ToNavValueArray(object?[] values)


### PR DESCRIPTION
Closes #2423

A multi-real-dataitem JOIN query that also selects a FlowField column
silently read the column's typed default (observed: 0) instead of the
calculated value. Issue #2300 fixed the single-real-dataitem FlowField case
(via `NCLMetaQueryDataItem.SourceFlowField` and
`FlowFieldPatches.CalcOneFlowFieldForQueryRow`), and its own investigation
added the loud out-of-scope guard for the join case that #2423 tracked.

This extends the same mechanism across the join projection path:

- `AlRunner.QueryJoin.JoinContext` gets a new
  `CalcFlowFieldForRow(rowBuffer, flowFieldMeta)` delegate, adapted in
  `RecordPatches.QueryJoin.cs` to forward to the existing
  `FlowFieldPatches.CalcOneFlowFieldForQueryRow` so the aggregation/formula
  math is not duplicated across the assembly boundary.
- `JoinExecutor.BuildJoinProjectionPlan` (and its al-runner-side mirror
  `RecordPatches.QueryProjection.ComputeJoinColumnSlotMap`, which the code's
  own comment requires to change together) now recognise the
  FlowField-calculation synthesized sub-dataitem
  (`SubQueryDefinition != null && SourceFlowField != null`) and route its
  column through `ctx.CalcFlowFieldForRow` against the resolved *owner*
  dataitem's row in the join combo, instead of a generic `TableSlot` read
  against the FlowField's source table — a table the join never reads a row
  buffer for at all, which is what produced the silent typed default.
- The owner dataitem is resolved via `NCLMetaField.Parent` → `TableId`,
  matched against the join's real dataitems (`ResolveFlowFieldOwnerName`),
  since BC's own `NCLMetaQueryDataItem.CreateWithSubQuery` passes a null
  `dataItemLinksCreator` for this sub-dataitem — there is no `DataItemLink`
  back to the owner to read instead (confirmed by decompiling
  `NCLMetaQuery.CreateSubQueryForFlowFieldCalculation`).
- Verified on **either side** of the join (FlowField column on the driving
  dataitem, and on the joined/child dataitem).

**Two sub-shapes remain out of scope and still fail loudly, each named
individually** (`.claude/rules/loud-failures.md`):
- a FlowField column combined with the join's own #2146 implicit GROUP BY
  (`query-join-flowfield-column-with-groupby-not-implemented`) — unmeasured,
  no oracle case covers a query grouping alongside a joined FlowField column,
  and `BuildGroupedRows`' `ResolveComboValue` has no FlowField branch.
- any other synthesized-subquery shape that is not a FlowField calculation
  (`query-join-synthesized-subquery-not-implemented`) — e.g. BC's own
  aggregation-filter sub-dataitems
  (`NCLMetaQuery.CreateDataItemsForAggregationFiltersWithFlowFieldAsSource`).

## Upstream verification

[`StefanMaron/BusinessCentral.AL.Language.Tests#106`](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/106)
pins that a JOIN's FlowField column reads the calculated value against real
BC. 7/8 legs are green; the BC 28.4 leg failed on an unrelated pre-existing
infra flake (a SignalR `Initialize` error on codeunit 60066 during test-hub
teardown) — every test codeunit relevant to this issue passed on every leg,
including 28.4. Not bumping the submodule pin in this PR since the corpus
change doesn't add a new corpus test the runner needs to pass; the proving
test here is the runner-mechanism suite below plus the upstream PR itself.

## Tests

- `AlRunner.Tests/QueryJoinFlowFieldColumnOosTests.cs` — RUNNER-MECHANISM
  suite, extended from the previous OOS-pinning test into three cases: the
  FlowField column on the child dataitem reads the calculated value (7.25),
  the FlowField column on the parent/driving dataitem reads the calculated
  value (10, summed across two lines), and the FlowField+GROUP BY combination
  still throws the new, more specific, loud OOS reason.
- Full corpus (`tests/al-language/tests/al-language`): 2302/2302 pass.
- `tests/runner-extras`: 207/207 pass.
- Local repro of #2300's three-case bundle (case 1/2 already green, case 3 —
  the join+FlowField case — now green too, was OOS before this fix).

## Investigation: does the same shape appear elsewhere?

- **Other call sites of the same pattern** — `BuildJoinProjectionPlan` and
  `ComputeJoinColumnSlotMap` are the only two places that build a join's
  column-to-slot plan (the code's own doc comment requires them to change
  together), and both were updated in this PR.
- **Sibling functions sharing the blind spot** — `ResolveTableSlot` (still
  used for every non-FlowField column) was left untouched; the FlowField
  column now takes an entirely separate path (`FlowFieldMeta` / `TableSlot =
  -1`) rather than reusing `ResolveTableSlot` incorrectly, so there's no
  shared invariant to drift.
- **Two paths, one invariant** — the al-runner-side mirror
  (`ComputeJoinColumnSlotMap`) and the isolated `JoinExecutor`'s own plan
  builder now both recognise `SourceFlowField` and both skip the throw for
  that shape identically; verified by grepping both for the same guard
  pattern and confirming the corpus + runner-extras + RED/GREEN cases exercise
  the mirror's own plan (it decides `ColumnIndex`) as well as the isolated
  assembly's (it decides the value).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpvEPTKD7UWdDxUQiHdqR9