### PR TITLE
fix(query): apply a query column's static ColumnFilter property

### DIFF
--- a/AlRunner.Tests/QueryColumnFilterProjectionTests.cs
+++ b/AlRunner.Tests/QueryColumnFilterProjectionTests.cs
@@ -1,0 +1,249 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #2418 — a query column's static <c>ColumnFilter</c> property was parsed nowhere:
+/// <c>BcAppSymbolCache.ParseQueryColumns</c> carried only <c>Caption</c>/<c>Method</c> (#2137),
+/// so <c>RecordPatches.NclMetaQueryBuilder</c> never saw the filter and the synthesized
+/// <c>MetaQuery.ColumnFilters</c> design list stayed empty; even if it had been populated,
+/// <c>RecordPatches.QueryProjection.TranslateQueryFilters</c> only read the request's RUNTIME
+/// filters (<c>SetRange</c>/<c>SetFilter</c>), never <c>NCLMetaQuery.ColumnFilters</c> (the
+/// static ones BC's own <c>CreateDynamicQuery</c>/<c>BuildFilterExpressionCollection</c> would
+/// build). On a <c>Method = Sum</c> column this is a HAVING-clause filter (drops groups whose
+/// aggregated total fails it); on a plain column it is a WHERE-clause filter (drops raw rows).
+/// A runtime <c>SetRange</c>/<c>SetFilter</c> on the SAME column REPLACES the static filter
+/// rather than combining with it.
+///
+/// This is a RUNNER-MECHANISM test, not a claim about what real BC does — same posture as
+/// QueryHavingAndJoinAggregationProjectionTests.cs for #2146. The BEHAVIORAL claim (what BC
+/// itself does with a static ColumnFilter on an aggregated vs. a plain column, and that a
+/// runtime filter on the same column replaces it) is being adjudicated by the al-language
+/// corpus's own CI against a real BC service tier
+/// (StefanMaron/BusinessCentral.AL.Language.Tests, query/TestQueryColumnFilter.al) — the
+/// submodule pin bump is a follow-up once that corpus PR merges, per
+/// .claude/rules/al-language-submodule.md. This test exists so a regression in OUR OWN
+/// ColumnFilter-parsing/design-population/WHERE-HAVING-routing pipeline
+/// (BcAppSymbolCache → RecordPatches.AlSourceParser.TryParseColumnFilterText →
+/// RecordPatches.NclMetaQueryBuilder.BuildMetaQueryDesign →
+/// RecordPatches.QueryProjection.TranslateQueryFilters) fails loudly here without needing a
+/// full corpus run to notice.
+///
+/// Both scenarios are deliberately designed so a naive (wrong/no-op) implementation would
+/// produce a DIFFERENT, distinguishable answer:
+///   - The Sum scenario has a group whose total is exactly 0 (100 + -100) — a no-op
+///     ColumnFilter would let it through alongside the positive-total group, so the row COUNT
+///     assertion alone fails if the filter is dropped.
+///   - The plain-column scenario has rows for TWO customers — a no-op ColumnFilter would
+///     return both, so asserting only the filtered customer's rows appear fails if dropped.
+///   - The runtime-replaces-static scenario picks a runtime filter that the STATIC filter
+///     alone would reject (C1's total is 0, failing "> 0") — if the runtime filter were
+///     merely ANDed with the static one instead of replacing it, the result would stay empty.
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
+/// </summary>
+public class QueryColumnFilterProjectionTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(string bundle)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" \"").Append(bundle).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private static string WriteBundle()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-query-columnfilter-2418", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        File.WriteAllText(Path.Combine(root, "app.json"), """
+        {
+          "id": "d8e2f5a3-2418-4b2c-9d4e-000000002418",
+          "name": "QCF 2418 Repro",
+          "publisher": "Repro2418",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62480, "to": 62489 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "QcfColumnFilter.al"), """
+        table 62480 "QCF Order"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "Entry No."; Integer) { }
+                field(2; "Cust No."; Code[20]) { }
+                field(3; Amount; Decimal) { }
+            }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+
+        query 62481 "QCF Order Sum Filtered"
+        {
+            QueryType = Normal;
+            OrderBy = ascending(CustNo);
+            elements
+            {
+                dataitem(Order; "QCF Order")
+                {
+                    column(CustNo; "Cust No.") { }
+                    column(TotalAmount; Amount)
+                    {
+                        ColumnFilter = TotalAmount = filter(> 0);
+                        Method = Sum;
+                    }
+                }
+            }
+        }
+
+        query 62482 "QCF Order Filtered"
+        {
+            QueryType = Normal;
+            OrderBy = ascending(EntryNo);
+            elements
+            {
+                dataitem(Order; "QCF Order")
+                {
+                    column(EntryNo; "Entry No.") { }
+                    column(CustNo; "Cust No.")
+                    {
+                        ColumnFilter = CustNo = const('C1');
+                    }
+                    column(Amount; Amount) { }
+                }
+            }
+        }
+
+        codeunit 62483 "QCF 2418 Tests"
+        {
+            Subtype = Test;
+
+            local procedure Seed()
+            var
+                Order: Record "QCF Order";
+            begin
+                Order.DeleteAll();
+                Order.Init(); Order."Entry No." := 1; Order."Cust No." := 'C1'; Order.Amount := 100; Order.Insert();
+                Order.Init(); Order."Entry No." := 2; Order."Cust No." := 'C1'; Order.Amount := -100; Order.Insert();
+                Order.Init(); Order."Entry No." := 3; Order."Cust No." := 'C2'; Order.Amount := 50; Order.Insert();
+            end;
+
+            // C1's group total is 0 (100 + -100), which fails the static "> 0" ColumnFilter;
+            // only C2 (total 50) may survive.
+            [Test]
+            procedure ColumnFilterOnSum_ExcludesZeroTotalGroup()
+            var
+                Q: Query "QCF Order Sum Filtered";
+                RowCount: Integer;
+            begin
+                Seed();
+                Q.Open();
+                while Q.Read() do begin
+                    RowCount += 1;
+                    if Q.CustNo <> 'C2' then
+                        Error('static ColumnFilter > 0 must keep only C2, got CustNo %1', Q.CustNo);
+                    if Q.TotalAmount <> 50 then
+                        Error('C2''s aggregated TotalAmount must be 50, got %1', Q.TotalAmount);
+                end;
+                Q.Close();
+
+                if RowCount <> 1 then
+                    Error('static ColumnFilter > 0 must keep exactly 1 group (C2), got %1 rows', RowCount);
+            end;
+
+            // A runtime SetFilter on the SAME aggregated column REPLACES the static
+            // ColumnFilter: C1's total (0) fails the static "> 0" filter but satisfies the
+            // runtime "<10" filter, so switching filters must bring C1 back and drop C2
+            // (whose total 50 fails "<10").
+            [Test]
+            procedure ColumnFilterOnSum_RuntimeFilterReplacesStatic()
+            var
+                Q: Query "QCF Order Sum Filtered";
+                RowCount: Integer;
+                LastCust: Code[20];
+                LastTotal: Decimal;
+            begin
+                Seed();
+                Q.SetFilter(TotalAmount, '<%1', 10);
+                Q.Open();
+                while Q.Read() do begin
+                    RowCount += 1;
+                    LastCust := Q.CustNo;
+                    LastTotal := Q.TotalAmount;
+                end;
+                Q.Close();
+
+                if RowCount <> 1 then
+                    Error('runtime filter must replace the static one, keeping exactly C1, got %1 rows', RowCount);
+                if LastCust <> 'C1' then
+                    Error('C1 must be the surviving group under the runtime filter, got %1', LastCust);
+                if LastTotal <> 0 then
+                    Error('C1''s group total must be 0 (100 + -100), got %1', LastTotal);
+            end;
+
+            // A static ColumnFilter on a PLAIN (non-aggregated) column is WHERE-style: it
+            // drops raw rows before any grouping. Only C1's two rows may survive.
+            [Test]
+            procedure ColumnFilterOnPlainColumn_FiltersRawRows()
+            var
+                Q: Query "QCF Order Filtered";
+                RowCount: Integer;
+            begin
+                Seed();
+                Q.Open();
+                while Q.Read() do begin
+                    RowCount += 1;
+                    if Q.CustNo <> 'C1' then
+                        Error('static ColumnFilter const(C1) must keep only C1 rows, got CustNo %1', Q.CustNo);
+                end;
+                Q.Close();
+
+                if RowCount <> 2 then
+                    Error('both of C1''s raw rows must survive, none of C2''s; got %1 rows', RowCount);
+            end;
+        }
+        """);
+
+        return root;
+    }
+
+    [SkippableFact]
+    public void ColumnFilter_AppliesHavingAndWhereStyle_AndRuntimeFilterReplacesStatic()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var bundle = WriteBundle();
+        var (output, exitCode) = RunRunner(bundle);
+
+        // Never silently pass a run that failed to even get the test codeunit compiled/run.
+        Assert.DoesNotContain("EMIT-EXCLUDED", output);
+        Assert.DoesNotContain("COMPILE FAIL", output);
+        // All three tests must have run and passed — 3P/0F/0E is TestExecutor's own per-bundle
+        // summary line (see QueryHavingAndJoinAggregationProjectionTests for the same convention).
+        Assert.Contains("3P/0F/0E", output);
+    }
+}

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -311,7 +311,12 @@ internal static partial class BcAppSymbolCache
     // for an unaggregated column. Names match Microsoft.Dynamics.Nav.Types.AggregationType's
     // member names exactly, so RecordPatches.NclMetaQueryBuilder.AddColumn can hand it straight
     // to SetProp's Enum.Parse without translation.
-    internal sealed record QueryColumnSymbol(int Id, string Name, string SourceColumn, string? Caption, string? Method);
+    // ColumnFilter (#2418) is the AL `ColumnFilter = <Field> = const(...)/filter(...) [, ...]`
+    // property, carried verbatim ("AssignedQuantity = filter(> 0)") — parsed by
+    // RecordPatches.TryParseColumnFilterText in RecordPatches.NclMetaQueryBuilder.BuildMetaQueryDesign
+    // once every column's id is known (a ColumnFilter condition may name any query column of
+    // the same dataitem, not just the column that declares the property).
+    internal sealed record QueryColumnSymbol(int Id, string Name, string SourceColumn, string? Caption, string? Method, string? ColumnFilter);
 
     // #1820: ContentHash replaces Length/LastWriteUtcTicks. The KEY (below, in Get) already
     // switched from mtime to a content hash, so an old Length/LastWriteUtcTicks payload can
@@ -930,7 +935,8 @@ internal static partial class BcAppSymbolCache
             var props = SymbolProperties(col);
             props.TryGetValue("Caption", out var caption);
             props.TryGetValue("Method", out var method); // issue #2137 — Method = Sum/Count/Average/Min/Max
-            result.Add(new QueryColumnSymbol(id, name, sourceColumn, caption, method));
+            props.TryGetValue("ColumnFilter", out var columnFilter); // issue #2418
+            result.Add(new QueryColumnSymbol(id, name, sourceColumn, caption, method, columnFilter));
         }
         return result;
     }

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -888,6 +888,126 @@ public static partial class RecordPatches
         }
         return null;
     }
+
+    /// <summary>
+    /// Parses a query column's <c>ColumnFilter</c> property text (#2418) — a comma-separated
+    /// list of <c>&lt;QueryColumnName&gt; = const(&lt;value&gt;) / filter(&lt;expr&gt;)</c>
+    /// conditions, exactly BC's <c>MetaQueryColumnFilter.TypeOfFilter/Value</c> shape (verified
+    /// against the decompiled <c>Microsoft.Dynamics.Nav.Types.Metadata.MetaQueryColumnFilter</c>
+    /// and <c>NCLMetaQuery.BuildFilterExpressionCollection</c>).
+    /// <para>Text-only (no AL syntax tree involved): the runner never parses a query's AL source
+    /// into a query-object syntax tree — queries are read back from the compiled
+    /// SymbolReference.json (<c>BcAppSymbolCache</c>), same for source-compiled and precompiled
+    /// dep queries — so the property arrives as a plain string in both cases and there is no
+    /// tree to reparse against. Reuses <see cref="ConstValueText"/> / <see cref="FilterValueText"/>
+    /// so a quoted identifier inside the filter/const value is rewritten exactly the same way a
+    /// CalcFormula/TableRelation condition already is (#2305).</para>
+    /// <para>The LHS names a QUERY COLUMN of the same query, not a table field — BC's grammar has
+    /// no <c>field(...)</c> link form here (there is no "referencing row" for ColumnFilter to
+    /// read a field from, unlike CalcFormula's where-clause). A shape this parser does not
+    /// recognise refuses the WHOLE property, matching the CalcFormula/TableRelation discipline
+    /// (#1709/#1737): applying only the conditions understood would silently narrow-or-widen the
+    /// filter versus what BC's compiler actually emitted.</para>
+    /// </summary>
+    internal static List<ParsedColumnFilter>? TryParseColumnFilterText(string? text)
+    {
+        var s = (text ?? "").Trim();
+        if (s.Length == 0) return new List<ParsedColumnFilter>();
+
+        var result = new List<ParsedColumnFilter>();
+        foreach (var raw in SplitTopLevelCommas(s))
+        {
+            var entry = raw.Trim();
+            if (entry.Length == 0) continue;
+
+            var eq = TopLevelIndexOf(entry, '=');
+            if (eq < 0)
+            {
+                Console.Error.WriteLine($"[ColumnFilter] REFUSED '{s}': no '=' in condition '{entry}'");
+                return null;
+            }
+            var fieldName = Unquote(entry[..eq].Trim());
+            var rhs = entry[(eq + 1)..].Trim();
+
+            if (TryMatchCallKeyword(rhs, "const", out var constOpen))
+            {
+                var close = MatchingCloseParen(rhs, constOpen);
+                if (close < 0)
+                {
+                    Console.Error.WriteLine($"[ColumnFilter] REFUSED '{s}': unterminated const(...) in '{entry}'");
+                    return null;
+                }
+                result.Add(new ParsedColumnFilter(fieldName, ParsedColumnFilterKind.Const,
+                    ConstValueText(rhs.Substring(constOpen + 1, close - constOpen - 1))));
+            }
+            else if (TryMatchCallKeyword(rhs, "filter", out var filterOpen))
+            {
+                var close = MatchingCloseParen(rhs, filterOpen);
+                if (close < 0)
+                {
+                    Console.Error.WriteLine($"[ColumnFilter] REFUSED '{s}': unterminated filter(...) in '{entry}'");
+                    return null;
+                }
+                result.Add(new ParsedColumnFilter(fieldName, ParsedColumnFilterKind.Filter,
+                    FilterValueText(rhs.Substring(filterOpen + 1, close - filterOpen - 1))));
+            }
+            else
+            {
+                Console.Error.WriteLine($"[ColumnFilter] REFUSED '{s}': unsupported condition '{entry}'");
+                return null;
+            }
+        }
+        return result;
+    }
+
+    /// <summary>True when <paramref name="s"/> starts (ignoring case) with
+    /// <paramref name="keyword"/> immediately followed by optional spaces and <c>(</c>, whose
+    /// index is returned in <paramref name="open"/>.</summary>
+    private static bool TryMatchCallKeyword(string s, string keyword, out int open)
+    {
+        open = -1;
+        if (s.Length <= keyword.Length) return false;
+        if (string.Compare(s, 0, keyword, 0, keyword.Length, StringComparison.OrdinalIgnoreCase) != 0) return false;
+        var j = keyword.Length;
+        while (j < s.Length && s[j] == ' ') j++;
+        if (j >= s.Length || s[j] != '(') return false;
+        open = j;
+        return true;
+    }
+
+    /// <summary>Splits <paramref name="s"/> on top-level commas — ones not inside a quoted
+    /// identifier or parentheses (so <c>const('A, B')</c> and nested <c>filter(...)</c> value
+    /// commas are not mistaken for condition separators).</summary>
+    private static List<string> SplitTopLevelCommas(string s)
+    {
+        var parts = new List<string>();
+        var start = 0;
+        var depth = 0;
+        for (var i = 0; i < s.Length; i++)
+        {
+            if (s[i] == '"') { i = SkipAlQuoted(s, i) - 1; continue; }
+            if (s[i] == '(') depth++;
+            else if (s[i] == ')') depth--;
+            else if (s[i] == ',' && depth == 0) { parts.Add(s[start..i]); start = i + 1; }
+        }
+        parts.Add(s[start..]);
+        return parts;
+    }
+
+    /// <summary>Index of the first top-level occurrence of <paramref name="c"/> in
+    /// <paramref name="s"/> — outside any quoted identifier or parentheses — or -1.</summary>
+    private static int TopLevelIndexOf(string s, char c)
+    {
+        var depth = 0;
+        for (var i = 0; i < s.Length; i++)
+        {
+            if (s[i] == '"') { i = SkipAlQuoted(s, i) - 1; continue; }
+            if (s[i] == '(') depth++;
+            else if (s[i] == ')') depth--;
+            else if (s[i] == c && depth == 0) return i;
+        }
+        return -1;
+    }
 }
 
 // ─── Data holders ────────────────────────────────────────────────────────────
@@ -951,6 +1071,20 @@ internal record ParsedRelationArm(string TableName, string? FieldName, List<Pars
 /// field declares no ObsoleteReason (distinct from an explicit empty string).</param>
 internal record ParsedField(int FieldId, string FieldName, string TypeName, int Length, bool IsFlowField = false, ParsedCalcFormula? CalcFormula = null, string? OptionMembers = null, string? InitValueText = null, bool IsAutoIncrement = false, string? Caption = null, List<ParsedRelationArm>? RelationArms = null, bool RelationValidate = true, bool IsFlowFilter = false, string ObsoleteState = "No", string? ObsoleteReason = null);
 internal record ParsedKey(string Name, List<int> FieldIds);
+
+/// <summary>Which value shape a <see cref="ParsedColumnFilter"/> condition carries — matches
+/// <c>Microsoft.Dynamics.Nav.Types.Metadata.FilterType</c>'s CONST/FILTER members exactly
+/// (#2418).</summary>
+internal enum ParsedColumnFilterKind { Const, Filter }
+
+/// <summary>One condition of a query column's <c>ColumnFilter</c> property (#2418) —
+/// <c>&lt;FieldName&gt; = const(&lt;Value&gt;)</c> or <c>&lt;FieldName&gt; = filter(&lt;Value&gt;)</c>.
+/// <paramref name="FieldName"/> names a QUERY COLUMN of the same query (resolved to a
+/// <c>QueryColumnId</c> by <c>RecordPatches.NclMetaQueryBuilder</c>, which is the only place
+/// with every column's id in hand); <paramref name="Value"/> is already unquoted/rewritten by
+/// <c>ConstValueText</c> / <c>FilterValueText</c> — ready to hand to
+/// <c>MetaQueryColumnFilter.Value</c> as-is.</summary>
+internal record ParsedColumnFilter(string FieldName, ParsedColumnFilterKind Kind, string Value);
 /// <param name="LookupPageName">The table's declared <c>LookupPageId</c> as WRITTEN — a page
 /// name (<c>"Customer List"</c>) or a bare id in text form. Both sources state it by name:
 /// AL source writes the reference, and a dependency's SymbolReference.json records

--- a/AlRunner/Patches/RecordPatches.NclMetaQueryBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaQueryBuilder.cs
@@ -30,6 +30,7 @@ public static partial class RecordPatches
     private static Type? _tMetaQueryColumn;
     private static Type? _tMetaQueryOrderBy;
     private static Type? _tMetaQueryDataItemLink;
+    private static Type? _tMetaQueryColumnFilter; // #2418
     private static MethodInfo? _mCreateDynamicQuery;
 
     private static void QLog(string msg)
@@ -50,6 +51,7 @@ public static partial class RecordPatches
         _tMetaQueryColumn = typesAsm?.GetType(md + "MetaQueryColumn");
         _tMetaQueryOrderBy = typesAsm?.GetType(md + "MetaQueryOrderBy");
         _tMetaQueryDataItemLink = typesAsm?.GetType(md + "MetaQueryDataItemLink");
+        _tMetaQueryColumnFilter = typesAsm?.GetType(md + "MetaQueryColumnFilter"); // #2418
 
         // public static NCLMetaQuery CreateDynamicQuery(ApplicationObjectId, MetaQuery, Type, NavAppGroup)
         if (_tNCLMetaQuery != null)
@@ -156,6 +158,13 @@ public static partial class RecordPatches
         // (columnName/dataItemName → columnId) so OrderBy can map names → column ids.
         var columnIdByName = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
+        // #2418: raw ColumnFilter property text, collected per-column while columns are built.
+        // Resolution (query-column NAME → id) happens in a SEPARATE pass after every dataitem's
+        // columns are in columnIdByName, because a ColumnFilter condition may name any query
+        // column of the query — including one defined later in dataitem/column order than the
+        // column that declares the property.
+        var pendingColumnFilters = new List<string>();
+
         bool isRoot = true;
         foreach (var diSym in FlattenDataItems(sym.DataItems))
         {
@@ -209,6 +218,8 @@ public static partial class RecordPatches
                 }
                 AddColumn(di, id: col.Id, name: col.Name, fieldNo: fieldNo, index: resultColumnIndex++, caption: col.Caption, method: col.Method);
                 columnIdByName[col.Name] = col.Id;
+                if (!string.IsNullOrEmpty(col.ColumnFilter))
+                    pendingColumnFilters.Add(col.ColumnFilter!);
             }
 
             // Filter-only columns (dataitem filter(...) elements). They carry a real BC
@@ -242,6 +253,42 @@ public static partial class RecordPatches
 
             GetList(mq, "DataItems").Add(di);
             isRoot = false;
+        }
+
+        // #2418: resolve every ColumnFilter condition collected above, now that every dataitem's
+        // columns are in columnIdByName. An unresolvable field name or an unparseable condition
+        // abandons the WHOLE build (loud, matching the other "abandoning build" guards above) —
+        // silently dropping just that condition would make the query return groups/rows real BC
+        // excludes, the exact class of bug #2418 reports.
+        if (_tMetaQueryColumnFilter != null)
+        {
+            foreach (var raw in pendingColumnFilters)
+            {
+                var parsed = TryParseColumnFilterText(raw);
+                if (parsed == null)
+                {
+                    QLog($"BuildMetaQueryDesign({queryId}): ColumnFilter '{raw}' could not be parsed — abandoning build");
+                    return null;
+                }
+                foreach (var cond in parsed)
+                {
+                    if (!columnIdByName.TryGetValue(cond.FieldName, out var targetColumnId))
+                    {
+                        QLog($"BuildMetaQueryDesign({queryId}): ColumnFilter '{raw}' names unknown query column '{cond.FieldName}' — abandoning build");
+                        return null;
+                    }
+                    var cf = Activator.CreateInstance(_tMetaQueryColumnFilter)!;
+                    SetProp(cf, "QueryColumnId", targetColumnId);
+                    SetProp(cf, "TypeOfFilter", cond.Kind == ParsedColumnFilterKind.Const ? "CONST" : "FILTER");
+                    SetProp(cf, "Value", cond.Value);
+                    GetList(mq, "ColumnFilters").Add(cf);
+                }
+            }
+        }
+        else if (pendingColumnFilters.Count > 0)
+        {
+            QLog($"BuildMetaQueryDesign({queryId}): ColumnFilter present but MetaQueryColumnFilter reflection unavailable — abandoning build");
+            return null;
         }
 
         // OrderBy: SymbolReference carries "ascending(Col1,Col2)" / "descending(...)". Map

--- a/AlRunner/Patches/RecordPatches.QueryProjection.cs
+++ b/AlRunner/Patches/RecordPatches.QueryProjection.cs
@@ -462,59 +462,113 @@ public static partial class RecordPatches
         EnsureFilterReflection();
         var filtersAndMarks = request.GetType().GetProperty("FiltersAndMarks", BindingFlags.Public | BindingFlags.Instance)!
             .GetValue(request);
-        if (filtersAndMarks == null) return request;
-        var filters = _tFiltersAndMarks!.GetProperty("Filters", BindingFlags.Public | BindingFlags.Instance)!
-            .GetValue(filtersAndMarks);
-        if (filters == null) return request;
+        object? filters = null;
+        if (filtersAndMarks != null)
+            filters = _tFiltersAndMarks!.GetProperty("Filters", BindingFlags.Public | BindingFlags.Instance)!
+                .GetValue(filtersAndMarks);
 
         // FilterFieldDictionary.Items : Tuple<INavFieldMetadata, FilterExpression>[]
-        var items = (Array?)_tFilterFieldDictionary!.GetProperty("Items", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?
+        var items = filters == null ? null : (Array?)_tFilterFieldDictionary!.GetProperty("Items", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?
             .GetValue(filters);
-        if (items == null || items.Length == 0) return request; // no field filters → nothing to do.
 
         var translatedTuples = new List<object>();
         bool anyTranslated = false;
-        foreach (var item in items)
-        {
-            // Tuple<INavFieldMetadata, FilterExpression>
-            var key = item!.GetType().GetProperty("Item1")!.GetValue(item);
-            var expr = item.GetType().GetProperty("Item2")!.GetValue(item);
-            if (key != null && _tNCLMetaQueryColumn != null && _tNCLMetaQueryColumn.IsInstanceOfType(key))
+        // #2418: query columns that already carry a RUNTIME (SetRange/SetFilter) filter — a
+        // runtime filter on a column REPLACES its static ColumnFilter (verified against real
+        // BC 28.4, see #2418), so the static-ColumnFilter pass below skips these entirely.
+        var runtimeFilteredColumnIds = new HashSet<int>();
+        if (items != null)
+            foreach (var item in items)
             {
-                if (((NCLMetaQueryColumn)key).AggregationType != AggregationType.None)
+                // Tuple<INavFieldMetadata, FilterExpression>
+                var key = item!.GetType().GetProperty("Item1")!.GetValue(item);
+                var expr = item.GetType().GetProperty("Item2")!.GetValue(item);
+                if (key != null && _tNCLMetaQueryColumn != null && _tNCLMetaQueryColumn.IsInstanceOfType(key))
                 {
-                    // HAVING-clause filter — exclude from the WHERE-style push-down (pushing it
-                    // unchanged would make FindImplementation try to cast this NCLMetaQueryColumn
-                    // key to NCLMetaField and fail; retargeting it to the source field would
-                    // filter raw pre-aggregation rows, which is the #2137-class bug). Hand it
-                    // back for post-aggregation evaluation instead.
-                    havingFilters.Add((key!, expr!));
-                    anyTranslated = true;
-                    continue;
-                }
+                    runtimeFilteredColumnIds.Add(((NCLMetaQueryColumn)key).Id);
+                    if (((NCLMetaQueryColumn)key).AggregationType != AggregationType.None)
+                    {
+                        // HAVING-clause filter — exclude from the WHERE-style push-down (pushing it
+                        // unchanged would make FindImplementation try to cast this NCLMetaQueryColumn
+                        // key to NCLMetaField and fail; retargeting it to the source field would
+                        // filter raw pre-aggregation rows, which is the #2137-class bug). Hand it
+                        // back for post-aggregation evaluation instead.
+                        havingFilters.Add((key!, expr!));
+                        anyTranslated = true;
+                        continue;
+                    }
 
-                var srcField = key.GetType().GetProperty("SourceTableField", BindingFlags.Public | BindingFlags.Instance)!.GetValue(key);
-                if (srcField != null && expr != null)
-                {
-                    var srcCtx = srcField.GetType().GetProperty("ExpressionContext", BindingFlags.Public | BindingFlags.Instance)!.GetValue(srcField);
-                    var retargeted = RetargetFilterExpression(expr, srcCtx!);
-                    translatedTuples.Add(MakeFieldTuple(srcField, retargeted));
-                    anyTranslated = true;
-                    continue;
+                    var srcField = key.GetType().GetProperty("SourceTableField", BindingFlags.Public | BindingFlags.Instance)!.GetValue(key);
+                    if (srcField != null && expr != null)
+                    {
+                        var srcCtx = srcField.GetType().GetProperty("ExpressionContext", BindingFlags.Public | BindingFlags.Instance)!.GetValue(srcField);
+                        var retargeted = RetargetFilterExpression(expr, srcCtx!);
+                        translatedTuples.Add(MakeFieldTuple(srcField, retargeted));
+                        anyTranslated = true;
+                        continue;
+                    }
                 }
+                translatedTuples.Add(item); // already table-keyed or no source — keep as-is.
             }
-            translatedTuples.Add(item); // already table-keyed or no source — keep as-is.
+
+        // #2418: static `ColumnFilter` conditions (NCLMetaQuery.ColumnFilters, built in
+        // NclMetaQueryBuilder.BuildMetaQueryDesign from the AL `ColumnFilter` property) — same
+        // WHERE/HAVING routing as a runtime filter on that column, applied only when no runtime
+        // filter already targets it (a runtime filter REPLACES the static one, never combines).
+        var staticColumnFilters = GetStaticColumnFilters(metaAppObj!);
+        foreach (var (col, expr) in staticColumnFilters)
+        {
+            if (runtimeFilteredColumnIds.Contains(col.Id)) continue;
+            if (col.AggregationType != AggregationType.None)
+            {
+                havingFilters.Add((col, expr));
+                anyTranslated = true;
+                continue;
+            }
+            if (col.SourceTableField != null)
+            {
+                var retargeted = RetargetFilterExpression(expr, col.SourceTableField.ExpressionContext);
+                translatedTuples.Add(MakeFieldTuple(col.SourceTableField, retargeted));
+                anyTranslated = true;
+            }
         }
+
         if (!anyTranslated) return request;
 
         // Build FilterFieldDictionary(IEnumerable<Tuple<INavFieldMetadata, FilterExpression>>)
         var newFilters = BuildFilterFieldDictionary(translatedTuples);
-        var markedRecords = _tFiltersAndMarks.GetProperty("MarkedRecords", BindingFlags.Public | BindingFlags.Instance)!.GetValue(filtersAndMarks);
-        var newFam = Activator.CreateInstance(_tFiltersAndMarks, newFilters, markedRecords)!;
+        var markedRecords = filtersAndMarks == null ? null
+            : _tFiltersAndMarks!.GetProperty("MarkedRecords", BindingFlags.Public | BindingFlags.Instance)!.GetValue(filtersAndMarks);
+        var newFam = Activator.CreateInstance(_tFiltersAndMarks!, newFilters, markedRecords)!;
         return CloneRequestWithFilters(request, newFam);
     }
 
     private static Type? _tNCLMetaQueryColumn;
+    private static PropertyInfo? _pNCLMetaQueryColumnFilters; // #2418
+
+    /// <summary>
+    /// The query's static <c>ColumnFilter</c> conditions — <c>NCLMetaQuery.ColumnFilters</c>
+    /// (a <c>ReadOnlyCollection&lt;Tuple&lt;NCLMetaQueryColumn, FilterExpression&gt;&gt;</c>),
+    /// built by BC's own <c>BuildFilterExpressionCollection</c> from the design-time
+    /// <c>MetaQuery.ColumnFilters</c> list <c>NclMetaQueryBuilder.BuildMetaQueryDesign</c>
+    /// populates (#2418). The property is <c>internal</c> to Ncl.dll, hence reflection.
+    /// Never null on a real <c>NCLMetaQuery</c> — an empty collection when the query declares
+    /// no <c>ColumnFilter</c> at all.
+    /// </summary>
+    private static IEnumerable<(NCLMetaQueryColumn Column, object Expr)> GetStaticColumnFilters(object metaAppObj)
+    {
+        _pNCLMetaQueryColumnFilters ??= _tNCLMetaQuery!.GetProperty("ColumnFilters",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        var raw = _pNCLMetaQueryColumnFilters?.GetValue(metaAppObj) as System.Collections.IEnumerable;
+        if (raw == null) yield break;
+        foreach (var tuple in raw)
+        {
+            var col = tuple!.GetType().GetProperty("Item1")!.GetValue(tuple);
+            var expr = tuple.GetType().GetProperty("Item2")!.GetValue(tuple);
+            if (col is NCLMetaQueryColumn c && expr != null)
+                yield return (c, expr);
+        }
+    }
 
     private static object MakeFieldTuple(object field, object expr)
     {


### PR DESCRIPTION
Closes #2418

## Problem

A query column's static `ColumnFilter` property was ignored. On a `Method = Sum` column it must act as a HAVING filter, dropping groups whose aggregated total fails it; on a plain column it must act as a WHERE filter over raw rows. The runner returned every group/row regardless.

Reproduced on `main` before this fix (`Codeunit64673.ColumnFilterOnSum_ExcludesZeroBalanceGroup` FAILs: `group A returned with AssignedQuantity 0 despite ColumnFilter > 0`), matching the issue's own real-BC-verified repro.

## Root cause

Two places dropped the property:

1. `AlRunner/Patches/BcAppSymbolCache.cs`'s `ParseQueryColumns` carried only `Caption`/`Method` (#2137) off a column's symbol Properties bag, so `RecordPatches.NclMetaQueryBuilder` never saw `ColumnFilter` and the synthesized design `MetaQuery.ColumnFilters` list stayed empty.
2. `AlRunner/Patches/RecordPatches.QueryProjection.cs`'s `TranslateQueryFilters` only read the request's RUNTIME filters (`SetRange`/`SetFilter`), never `NCLMetaQuery.ColumnFilters` -- the static ones BC's own `CreateDynamicQuery`/`BuildFilterExpressionCollection` build (verified by decompiling `Microsoft.Dynamics.Nav.Types.Metadata.MetaQueryColumnFilter` and `NCLMetaQuery.BuildFilterExpressionCollection` in `Microsoft.Dynamics.Nav.Ncl.dll`).

## Fix

- `RecordPatches.AlSourceParser.TryParseColumnFilterText` -- a new text parser (the runner never builds an AL syntax tree for queries; they're read back from compiled `SymbolReference.json`) for `ColumnFilter`'s `<Column> = const(...)/filter(...)[, ...]` grammar, reusing the same `ConstValueText`/`FilterValueText` value-rewriting rules CalcFormula/TableRelation already use (#2305).
- `RecordPatches.NclMetaQueryBuilder.BuildMetaQueryDesign` -- resolves each parsed condition's column NAME against every column of the query (a condition may name any column, not just the one declaring the property) and populates the design-time `MetaQuery.ColumnFilters` list, which BC's own `CreateDynamicQuery` turns into `NCLMetaQuery.ColumnFilters`.
- `RecordPatches.QueryProjection.TranslateQueryFilters` -- now also reads `NCLMetaQuery.ColumnFilters` (via reflection; it's `internal` to `Ncl.dll`) and folds each condition into the SAME WHERE/HAVING routing already applied to runtime filters (aggregated column -> HAVING, evaluated post-aggregation; plain column -> WHERE, retargeted to the source field) -- but only for a column that has NO runtime filter, since a runtime `SetRange`/`SetFilter` REPLACES the static `ColumnFilter` rather than combining with it (verified against real BC 28.4 in the issue's own repro table).

## Sibling-shape check (per workflow: fix the shape, not just the reported line)

- **Same wrong pattern at another call site?** Yes -- the multi-dataitem JOIN path's `ApplyJoinRuntimeFilters` (same file) has the identical gap: it also only reads the request's runtime `FiltersAndMarks`, never `NCLMetaQuery.ColumnFilters`. Filed as a follow-up: #2444 (not fixed here -- this file is under concurrent edit for #2423's join+FlowField work, and the join path's aggregation/filter routing already carries its own tracked follow-ups (#2146), so a minimal, single-path fix here is lower risk than expanding scope into a hot shared file).
- **Sibling function, same blind spot?** `ApplyHavingFilters` (post-aggregation HAVING evaluation) is shared correctly -- it evaluates whatever `havingFilters` it's handed, so once `TranslateQueryFilters` correctly classifies a static aggregated-column filter into `havingFilters`, the existing evaluation code needs no change. No blind spot found there.
- **Two paths writing the same state with different invariants?** `BuildMetaQueryDesign`'s other "abandon build" guards (unresolved table, unresolved field) are all loud (return `null`, `QLog`'d); the new `ColumnFilter` resolution follows the same discipline -- an unparseable condition or an unknown referenced column name abandons the whole build rather than silently dropping just that condition.

## Testing

- RED -> GREEN: reproduced the issue's own repro (`ColumnFilterOnSum_ExcludesZeroBalanceGroup`) failing on `main`, passing after the fix. Extended the repro locally with the runtime-filter-replaces-static and plain-column WHERE-style shapes from the issue's own verification table -- all pass.
- Full corpus (`tests/al-language`), 2307 tests: 0 failures.
- `tests/runner-extras`, 207 tests: 0 failures.
- New C# mechanism test `AlRunner.Tests/QueryColumnFilterProjectionTests.cs` (filtered run: 1 passed) -- pins the runner's own parsing/design-population/WHERE-HAVING-routing pipeline independent of the corpus pin.
- Upstream BC-behavior test opened against the corpus: StefanMaron/BusinessCentral.AL.Language.Tests#107 (not yet merged -- the submodule pin is **not** bumped in this PR; that's a follow-up once #107's BC legs are green and it merges, per `.claude/rules/al-language-submodule.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpvEPTKD7UWdDxUQiHdqR9
