### PR TITLE
feat(report): run the request page from Report.Run and write the dataset it asks for

### DIFF
--- a/AlRunner.Tests/DependencyReportDataItemLinkTests.cs
+++ b/AlRunner.Tests/DependencyReportDataItemLinkTests.cs
@@ -1,0 +1,203 @@
+// DependencyReportDataItemLinkTests — the two pieces of a PRECOMPILED report's metadata the
+// runner reconstructs from SymbolReference.json that a report DATASET cannot do without.
+//
+// Both were invisible until #2436 made Report.Run() actually build a dataset. Before that a
+// report ran with BC's NullResultSetProcessor, which discards every row and evaluates no
+// column, so neither omission had an observable effect.
+//
+// 1. DataItemLink / DataItemLinkReference — the parent-child join.
+//    DataItemIterator.SetDataItemLink resolves DataItemLinkReference against each data
+//    item's DataItemVarName and hands DataItemLink to RecordDataItemLink, which parses it
+//    with BC's own TableViewParser. With neither element present the nested data item has
+//    no restriction at all and iterates its WHOLE table once per parent row. Measured on
+//    report 411 "Vendor - Payment Receipt" against Microsoft's own ERMPurchDocReports
+//    tests: 645,593 rows and a 1.45 GB dataset file, still growing when the 60s watchdog
+//    aborted the suite — against 6 rows and 17 KB once the link is emitted.
+//
+// 2. A column's FieldType has to be a DATASET column type, not the AL type of its source
+//    expression. NavDataSetBuilder.AddColumnToDataTable turns FieldType into a CLR column
+//    type through CommonTypeInformation.ResolveClrType, which throws
+//    "ArgumentException: UnsupportedType" for anything it has no mapping for — killing the
+//    whole dataset over one column. A column whose expression is a Label arrives from the
+//    symbol file as "Label", and there is no Label dataset column; report 411 alone has 23.
+//
+// These assert on the runner's own reconstruction, which is why they live here rather than
+// in the corpus: what BC does with a request page and a dataset is pinned upstream in
+// handlers/TestReportRunWithRequestPage.al.
+
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Joins CacheRootsSerialCollection for the same reason BcAppSymbolCacheReportTests does:
+// BcAppSymbolCache.Get() resolves its on-disk path through the process-global CacheRoots
+// override (#1821).
+[Collection(CacheRootsSerialCollection.Name)]
+public class DependencyReportDataItemLinkTests
+{
+    private static string WriteApp(string dir, string symbolReferenceJson)
+    {
+        var appPath = Path.Combine(dir, Guid.NewGuid().ToString("N") + ".app");
+        using var zip = new FileStream(appPath, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+        return appPath;
+    }
+
+    // The shape report 411 "Vendor - Payment Receipt" really has in the Base Application's
+    // SymbolReference.json, trimmed to the three data items that matter: an outer record
+    // item, the Integer page loop under it, and a nested item joined back to the outer one.
+    private const string SymbolReference = """
+        {
+          "RuntimeVersion": "15.1",
+          "Namespaces": [
+            {
+              "Name": "Purchases",
+              "Reports": [
+                {
+                  "Id": 411,
+                  "Name": "Vendor - Payment Receipt",
+                  "Properties": [
+                    { "Name": "Caption", "Value": "Vendor - Payment Receipt" }
+                  ],
+                  "DataItems": [
+                    {
+                      "Id": 1,
+                      "Name": "Vendor Ledger Entry",
+                      "RelatedTable": "Vendor Ledger Entry",
+                      "Properties": [
+                        { "Name": "DataItemTableView", "Value": "sorting(\"Document Type\", \"Vendor No.\")" }
+                      ],
+                      "DataItems": [
+                        {
+                          "Id": 2,
+                          "Name": "PageLoop",
+                          "RelatedTable": "#8874ed3a064342479ced7a7002f7135d#Integer",
+                          "Indentation": 1,
+                          "Properties": [
+                            { "Name": "DataItemTableView", "Value": "sorting(Number) where(Number = const(1))" }
+                          ],
+                          "DataItems": [
+                            {
+                              "Id": 3,
+                              "Name": "DetailedVendorLedgEntry1",
+                              "RelatedTable": "Detailed Vendor Ledg. Entry",
+                              "Indentation": 2,
+                              "Properties": [
+                                { "Name": "DataItemLink", "Value": "\"Applied Vend. Ledger Entry No.\" = field(\"Entry No.\")" },
+                                { "Name": "DataItemLinkReference", "Value": "Vendor Ledger Entry" },
+                                { "Name": "PrintOnlyIfDetail", "Value": "1" }
+                              ],
+                              "Columns": [
+                                {
+                                  "Id": 10,
+                                  "Name": "AppliedVLENo_DtldVendLedgEntry",
+                                  "TypeDefinition": { "Name": "Integer" }
+                                },
+                                {
+                                  "Id": 11,
+                                  "Name": "PageCaptionLbl",
+                                  "TypeDefinition": { "Name": "Label" }
+                                },
+                                {
+                                  "Id": 12,
+                                  "Name": "AttachmentBlob",
+                                  "TypeDefinition": { "Name": "BLOB" }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    [Fact]
+    public void ReportDataItem_CarriesItsJoinBackToTheParent()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var appPath = WriteApp(dir, SymbolReference);
+
+            var report = Assert.Single(BcAppSymbolCache.Get(appPath).Reports, r => r.Id == 411);
+            var joined = Assert.Single(report.DataItems, d => d.Name == "DetailedVendorLedgEntry1");
+
+            // The link, verbatim as the symbol file states it — DataItemIterator hands this
+            // string to BC's own TableViewParser, so the AL spelling is what it wants.
+            Assert.Equal(
+                "\"Applied Vend. Ledger Entry No.\" = field(\"Entry No.\")",
+                joined.DataItemLink);
+            // The reference is the PARENT DATA ITEM's name, which is what
+            // SetDataItemLink matches against DataItemVarName — not a table name.
+            Assert.Equal("Vendor Ledger Entry", joined.DataItemLinkReference);
+            Assert.True(joined.PrintOnlyIfDetail,
+                "PrintOnlyIfDetail is stated as \"1\" and decides whether a parent row with no "
+                + "detail rows appears in the dataset at all.");
+
+            // Negative direction: an item that states no link must not acquire one. The outer
+            // record item and the Integer page loop are both unjoined, and inventing a link
+            // for either would filter rows the report is supposed to produce.
+            var outer = Assert.Single(report.DataItems, d => d.Name == "Vendor Ledger Entry");
+            Assert.Null(outer.DataItemLink);
+            Assert.Null(outer.DataItemLinkReference);
+            Assert.False(outer.PrintOnlyIfDetail);
+
+            var pageLoop = Assert.Single(report.DataItems, d => d.Name == "PageLoop");
+            Assert.Null(pageLoop.DataItemLink);
+            Assert.Null(pageLoop.DataItemLinkReference);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReportMetadataXml_StatesTheJoinAndOnlyDatasetColumnTypes()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var appPath = WriteApp(dir, SymbolReference);
+
+            var report = Assert.Single(BcAppSymbolCache.Get(appPath).Reports, r => r.Id == 411);
+            var xml = RecordPatches.EmitReportXml(report, sourceExprByColumn: null);
+
+            // MetaDataItem reads these two by element name (uppercased) and nothing else
+            // supplies them, so their absence is the whole defect.
+            Assert.Contains(
+                "<DataItemLink>\"Applied Vend. Ledger Entry No.\" = field(\"Entry No.\")</DataItemLink>",
+                xml);
+            Assert.Contains("<DataItemLinkReference>Vendor Ledger Entry</DataItemLinkReference>", xml);
+            Assert.Contains("<PrintOnlyIfDetail>1</PrintOnlyIfDetail>", xml);
+
+            // A column type ResolveClrType understands is written through unchanged...
+            Assert.Contains("<FriendlyFieldName>AppliedVLENo_DtldVendLedgEntry</FriendlyFieldName>", xml);
+            Assert.Contains("<FieldType>Integer</FieldType>", xml);
+            Assert.Contains("<FieldType>BLOB</FieldType>", xml);
+            // ...and one it does not (Label is an AL type, never a dataset column type)
+            // becomes Text rather than reaching ResolveClrType and taking the whole
+            // document down with ArgumentException: UnsupportedType.
+            Assert.DoesNotContain("<FieldType>Label</FieldType>", xml);
+            Assert.Contains("<FieldType>Text</FieldType>", xml);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -94,7 +94,9 @@ internal static partial class BcAppSymbolCache
     // ResolveTableIdByName never matches — so a cached query over a dependency table would
     // keep failing to build its NCLMetaQuery design and NRE on Open()/SetRange(), the exact
     // #2295 bug replayed from cache rather than a cache miss.
-    private const int CacheVersion = 19;
+    // v20: added Reports' data-item DataItemLink / DataItemLinkReference / PrintOnlyIfDetail,
+    // without which a nested data item of a precompiled report has no join at all (#2436).
+    private const int CacheVersion = 20;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
     // Issue #1820 — path -> content-hash memo. ComputeAppContentHash needs to read the
     // WHOLE .app to hash it (unlike the FileInfo.Length/LastWriteTimeUtc stat it replaced,
@@ -238,7 +240,13 @@ internal static partial class BcAppSymbolCache
     internal sealed record ReportDataItemSymbol(
         int Id, string Name, string RelatedTable, int Indentation,
         string? DataItemTableView, string? RequestFilterFields,
-        List<ReportColumnSymbol>? Columns = null);
+        List<ReportColumnSymbol>? Columns = null,
+        // The parent-child join. Without these two a nested data item has no restriction at
+        // all and iterates its WHOLE table once per parent row — for report 411
+        // "Vendor - Payment Receipt" that is hundreds of thousands of rows where BC produces
+        // a handful. Invisible until a dataset was actually built from them (#2436).
+        string? DataItemLink = null, string? DataItemLinkReference = null,
+        bool PrintOnlyIfDetail = false);
 
     /// <summary>
     /// One <c>column(Name; SourceExpr)</c> of a report data item, as SymbolReference.json
@@ -828,9 +836,14 @@ internal static partial class BcAppSymbolCache
             props.TryGetValue("DataItemTableView", out var tableView);
             tableView = RecordPatches.TableViewText(tableView);
             props.TryGetValue("RequestFilterFields", out var filterFields);
+            props.TryGetValue("DataItemLink", out var dataItemLink);
+            props.TryGetValue("DataItemLinkReference", out var dataItemLinkReference);
+            props.TryGetValue("PrintOnlyIfDetail", out var printOnlyIfDetail);
 
             into.Add(new ReportDataItemSymbol(dataItemId, name, relatedTable, indent, tableView, filterFields,
-                ParseReportColumns(di)));
+                ParseReportColumns(di),
+                RecordPatches.TableViewText(dataItemLink), dataItemLinkReference,
+                printOnlyIfDetail is "1" or "true" or "True"));
             CollectReportDataItems(di, indent + 1, into);
         }
     }

--- a/AlRunner/Patches/DependencyReportMetadata.cs
+++ b/AlRunner/Patches/DependencyReportMetadata.cs
@@ -183,7 +183,9 @@ public static partial class RecordPatches
     /// emit produces for a source-compiled report. Data items are flat siblings carrying
     /// their nesting as <c>DataItemIndent</c> — the same encoding the emitted XML uses.
     /// </summary>
-    private static string EmitReportXml(
+    // internal, not private, so DependencyReportDataItemLinkTests can assert the document
+    // for one report symbol without a whole loaded dependency set behind it.
+    internal static string EmitReportXml(
         BcAppSymbolCache.ReportSymbol report, Dictionary<string, string>? sourceExprByColumn)
     {
         var settings = new XmlWriterSettings { Indent = true, Encoding = new UTF8Encoding(false) };
@@ -236,6 +238,17 @@ public static partial class RecordPatches
         w.WriteElementString("DataItemVarName", di.Name);
         if (!string.IsNullOrEmpty(di.DataItemTableView))
             w.WriteElementString("DataItemTableView", di.DataItemTableView);
+        // The parent-child join. DataItemIterator.SetDataItemLink resolves the reference by
+        // DataItemVarName and hands the link string to RecordDataItemLink, which parses it
+        // with BC's own TableViewParser — so the AL spelling the symbol file states
+        // (`"Applied Vend. Ledger Entry No." = field("Entry No.")`) is what it wants.
+        // Omitting them left every nested data item of a precompiled report unrestricted.
+        if (!string.IsNullOrEmpty(di.DataItemLink))
+            w.WriteElementString("DataItemLink", di.DataItemLink);
+        if (!string.IsNullOrEmpty(di.DataItemLinkReference))
+            w.WriteElementString("DataItemLinkReference", di.DataItemLinkReference);
+        if (di.PrintOnlyIfDetail)
+            w.WriteElementString("PrintOnlyIfDetail", "1");
         if (!string.IsNullOrEmpty(di.RequestFilterFields))
             w.WriteElementString("ReqFilterFields", di.RequestFilterFields);
 
@@ -256,8 +269,7 @@ public static partial class RecordPatches
         if (col.Id != 0)
             w.WriteElementString("ID", col.Id.ToString(System.Globalization.CultureInfo.InvariantCulture));
         w.WriteElementString("FriendlyFieldName", col.Name);
-        if (CanonicalNavTypeName(col.TypeName) is { } fieldType)
-            w.WriteElementString("FieldType", fieldType);
+        w.WriteElementString("FieldType", DataSetColumnNavTypeName(col.TypeName));
 
         // FieldNo is only stated when the expression is a plain field of the data item's own
         // table. A computed column (`Format(...)`, a variable, a nested record's field) has
@@ -287,8 +299,8 @@ public static partial class RecordPatches
     /// Matching against the live enum (rather than a hand-written table) also means a type
     /// this BC version added needs no change here.
     ///
-    /// Returns null for a type the enum does not know, so the column is emitted without a
-    /// FieldType instead of with an unparseable one.
+    /// Returns null for a type the enum does not know; see
+    /// <see cref="DataSetColumnNavTypeName"/> for what the caller writes then.
     /// </summary>
     private static string? CanonicalNavTypeName(string? typeName)
     {
@@ -303,6 +315,50 @@ public static partial class RecordPatches
                 if (string.Equals(member, name, StringComparison.OrdinalIgnoreCase))
                     return member;
             return null;
+        });
+    }
+
+    private static readonly ConcurrentDictionary<string, string> _dataSetColumnNavTypeNames = new();
+    private static System.Reflection.MethodInfo? _tryResolveClrType;
+
+    /// <summary>
+    /// The <c>FieldType</c> to write for a report column, which is not quite the AL type of
+    /// the column's source expression.
+    ///
+    /// A report column's FieldType has to be a type a DATASET COLUMN can hold, because
+    /// <c>NavDataSetBuilder.AddColumnToDataTable</c> turns it into a CLR column type through
+    /// <c>CommonTypeInformation.ResolveClrType</c> — and that throws
+    /// <c>ArgumentException: UnsupportedType</c> for anything it has no mapping for, which
+    /// kills the whole dataset over one column. The symbol file states the AL type instead,
+    /// and some AL types are not dataset types at all: a column whose source expression is a
+    /// <c>Label</c> arrives as "Label", and there is no such dataset column. Report 407
+    /// "Purchase - Receipt" alone has 23 of them.
+    ///
+    /// Text is the honest answer for those: a Label's value IS text, and it is what the
+    /// column renders as in the dataset. The four types
+    /// <c>AddColumnToDataTable</c> special-cases before calling ResolveClrType (RecordID,
+    /// Option, Duration, Enum) are passed through untouched — it already knows they are
+    /// string columns and never asks ResolveClrType about them.
+    ///
+    /// Asking the live <c>TryResolveClrType</c> rather than listing types here means a type
+    /// a future BC version adds to the dataset needs no change, and one it removes degrades
+    /// to Text instead of throwing.
+    /// </summary>
+    private static string DataSetColumnNavTypeName(string? typeName)
+    {
+        var canonical = CanonicalNavTypeName(typeName);
+        if (canonical == null) return "Text";
+        return _dataSetColumnNavTypeNames.GetOrAdd(canonical, static name =>
+        {
+            if (name is "RecordID" or "Option" or "Duration" or "Enum") return name;
+            if (_navTypeEnum == null) return "Text";
+            _tryResolveClrType ??= _navTypeEnum.Assembly
+                .GetType("Microsoft.Dynamics.Nav.Types.CommonTypeInformation")?
+                .GetMethod("TryResolveClrType", System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+            if (_tryResolveClrType == null) return "Text";
+            var args = new object?[] { Enum.Parse(_navTypeEnum, name), null };
+            try { return _tryResolveClrType.Invoke(null, args) is true ? name : "Text"; }
+            catch (System.Reflection.TargetInvocationException) { return "Text"; }
         });
     }
 

--- a/AlRunner/Patches/NavReportSync.RunRequestPage.cs
+++ b/AlRunner/Patches/NavReportSync.RunRequestPage.cs
@@ -1,0 +1,286 @@
+// NavReportSync — the request page Report.Run() opens, and the dataset a test asks for
+// from inside its [RequestPageHandler].
+//
+// WHAT WAS MISSING (#2436)
+//   SyncRun ran a report's lifecycle and then, for any report that is not ProcessingOnly,
+//   threw out-of-scope on layout resolution. Two things were wrong with that for a report
+//   run UNDER A TEST:
+//
+//     1. The request page was never opened at all, so a [RequestPageHandler] declared for
+//        the report was silently never called. That is not what BC does — its
+//        RunReportInternalCoreAsync opens the request page whenever
+//        `UseRequestForm && RequestOptionsPage != null`, and under test that page goes to
+//        the declared handler.
+//     2. Microsoft's dominant report-test shape closes that request page with
+//        `TestRequestPage.SaveAsXml(parametersFile, dataSetFile)`, which asks for the
+//        report's DATASET, not a rendered layout. The dataset is report EXECUTION, which is
+//        in scope (docs/scope.md#report-rendering puts only RENDERING out of scope), so
+//        throwing on layout ended tests that never wanted a layout.
+//
+// WHAT THIS ADDS, AND WHOSE CODE DOES THE WORK
+//   Every decision below is BC's own, taken from NavReport.RunReportInternalCoreAsync /
+//   RunRequestPageCoreAsync / ReportResultSetProcessorFactory.GetTestResultProcessor:
+//
+//     * open the request page (BC's TestHandleModalForm dispatches it to the handler);
+//     * FormResult.Cancel  → the report body does not run, and no error is raised;
+//     * FormResult.OK on a report that is NOT ProcessingOnly → BC does not offer an OK
+//       action on such a request page at all, so invoking one raises BC's own
+//       "The built-in action = OK is not found on the page." (RequestPageTestPage);
+//     * TestExecution.ReportOutputFileName set (what NavTestPage.ALSaveAsXml writes) →
+//       install BC's own ReportSaveAsXmlRenderer as the data-item loop's ResultSetProcessor
+//       and let it write the dataset file, instead of resolving a layout.
+//
+//   Nothing here re-implements a dataset format or a renderer: the file is produced by
+//   Ncl's ReportSaveAsXmlRenderer over a NavDataSet built by Types' NavDataSetBuilder, the
+//   same two objects BC uses on a real service tier.
+//
+// DELIBERATE DIVERGENCE
+//   When the request page cannot be dispatched because the test declares no handler for it,
+//   this falls back to NOT opening one — the pre-#2436 behaviour. Real BC raises there. The
+//   runner cannot yet tell "no handler declared" apart from "handler lookup did not reach
+//   us", and turning the second into an error would refuse reports that run fine today, so
+//   the fallback is additive on purpose. It is recorded in docs/limitations.md.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace AlRunner;
+
+public static partial class NavReportSync
+{
+    /// <summary>How the request page Report.Run() opened was closed.</summary>
+    internal enum RequestPageOutcome
+    {
+        /// <summary>No request page was opened (none exists, `UseRequestPage(false)`, or no handler).</summary>
+        NotShown,
+        /// <summary>The handler closed it with OK / LookupOK — no report intent selected.</summary>
+        ConfirmedPlainOk,
+        /// <summary>The handler asked for an output (SaveAsXml, preview, print, …).</summary>
+        ConfirmedWithIntent,
+        /// <summary>The handler cancelled. BC returns ReportExecutionResult.Cancel; the body never runs.</summary>
+        Cancelled,
+    }
+
+    /// <summary>
+    /// Open the report's request page so its <c>[RequestPageHandler]</c> fires, mirroring
+    /// <c>RunReportInternalCoreAsync</c>'s <c>runWithRequestPage</c> branch:
+    /// <c>!(!UseRequestForm || IsBackGroundSession) &amp;&amp; displayResult &amp;&amp; RequestOptionsPage != null</c>.
+    /// <c>displayResult</c> is true for Run/RunModal, which is the only caller here.
+    /// </summary>
+    private static RequestPageOutcome RunRequestPageForReportRun(object navReport, Type navReportBase)
+    {
+        if (!ReadBoolProperty(navReport, "UseRequestForm", fallback: true)) return RequestPageOutcome.NotShown;
+        if (ReadBoolProperty(navReport, "IsBackGroundSession", fallback: false)) return RequestPageOutcome.NotShown;
+
+        var pRequestPage = FindProperty(navReport.GetType(), "RequestOptionsPage");
+        if (pRequestPage == null) return RequestPageOutcome.NotShown;
+        object? requestPage;
+        try { requestPage = pRequestPage.GetValue(navReport); }
+        catch (TargetInvocationException) { return RequestPageOutcome.NotShown; }
+        if (requestPage == null) return RequestPageOutcome.NotShown;
+
+        int reportId = TryGetObjectId(navReport, navReportBase);
+        try
+        {
+            // offersOk: a plain OK closes a request page only when the report has no output
+            // to choose — i.e. it is ProcessingOnly. On a report that renders, real BC does
+            // not put an OK action on the page at all; see RequestPageTestPage.GetBuiltInAction.
+            RunRequestPageForHandler(navReport, reportId, parameters: null,
+                offersOk: IsProcessingOnly(navReport, navReportBase));
+        }
+        catch (AlRunner.Infrastructure.RunnerOutOfScopeException ex)
+            when (ex.Message.Contains("request-page-dispatch", StringComparison.Ordinal))
+        {
+            // ONLY "the request page was built but BC found no handler for it" — see
+            // RunRequestPageForHandler. Report.Run() worked without a request page before
+            // #2436 and must keep working; see DELIBERATE DIVERGENCE at the top of the file.
+            //
+            // The reason filter is load-bearing. Catching every RunnerOutOfScopeException
+            // swallowed the ones raised INSIDE the handler — a handler that sets a
+            // request-page control raises request-page-control, and turning that into "no
+            // request page" made the run fall through to the layout throw, which reported
+            // report rendering as the unsupported surface when the actual one was the
+            // control. That is a worse message, not a smaller failure.
+            if (Environment.GetEnvironmentVariable("AL_RUNNER_DIAG_RP") == "1")
+                Console.Error.WriteLine(
+                    $"[NavReportSync] Run({reportId}): no [RequestPageHandler] matched — continuing without a request page");
+            return RequestPageOutcome.NotShown;
+        }
+
+        var page = AlRunner.Patches.RequestPageTestPage.TryGetFor(requestPage);
+        var formResult = page?.FormResult;
+        if (Environment.GetEnvironmentVariable("AL_RUNNER_DIAG_RP") == "1")
+            Console.Error.WriteLine($"[NavReportSync] Run({reportId}): request page closed with {formResult}");
+
+        // BC's RunRequestPageCoreAsync maps the FormResult onto a ReportIntent: Pdf / Word /
+        // Excel / Xml / ExcelDataset → Download, Preview / PreviewPrint → Preview,
+        // Print → Print, Schedule → Schedule; everything else (OK, Cancel, None) → None.
+        var name = formResult?.ToString();
+        switch (name)
+        {
+            case "Cancel":
+                return RequestPageOutcome.Cancelled;
+            case "OK":
+            case "LookupOK":
+                // Only reachable for a ProcessingOnly report — offersOk above makes OK absent
+                // on any other request page, so BC's own "built-in action = OK is not found"
+                // fires before this ever sees an OK from a report that renders.
+                return RequestPageOutcome.ConfirmedPlainOk;
+            case null:
+            case "None":
+                // A handler that returned without closing the page. BC treats an unclosed
+                // request page as cancelled — there is no intent and no confirmation.
+                return RequestPageOutcome.Cancelled;
+            default:
+                return RequestPageOutcome.ConfirmedWithIntent;
+        }
+    }
+
+    // ── the test dataset (TestRequestPage.SaveAsXml) ──────────────────────────
+
+    private static Type? _reportSaveAsXmlRendererType;
+    private static ConstructorInfo? _reportSaveAsXmlRendererCtor;
+    private static Type? _getReportParametersDelegateType;
+    private static MethodInfo? _navReportGetParameters;
+    private static MethodInfo? _createNavDataSet;
+
+    /// <summary>
+    /// Build the processor BC's <c>ReportResultSetProcessorFactory.GetTestResultProcessor</c>
+    /// builds when a test asked for a dataset: <c>NavTestPage.ALSaveAsXml</c> (what AL's
+    /// <c>TestRequestPage.SaveAsXml(parametersFile, dataSetFile)</c> compiles to) parks the two
+    /// file names plus <c>FormResult.Xml</c> on the session's TestExecution, and this reads them
+    /// back off it. Returns null when no dataset was asked for.
+    ///
+    /// The three TestExecution fields are cleared afterwards, exactly as BC's own factory does —
+    /// otherwise the next report to run in the same test session would write over this test's
+    /// dataset file.
+    /// </summary>
+    private static object? TryCreateTestDatasetProcessor(object navReport)
+    {
+        var testExecution = FindProperty(navReport.GetType(), "Session")?.GetValue(navReport) is object session
+            ? FindProperty(session.GetType(), "TestExecution")?.GetValue(session)
+            : null;
+        if (testExecution == null) return null;
+
+        var pOutFile = FindProperty(testExecution.GetType(), "ReportOutputFileName");
+        var pParamFile = FindProperty(testExecution.GetType(), "ReportParameterOutputFileName");
+        var pFormat = FindProperty(testExecution.GetType(), "ReportOutputFormat");
+        if (pOutFile?.GetValue(testExecution) is not string dataSetFileName || dataSetFileName.Length == 0)
+            return null;
+        var parametersFileName = pParamFile?.GetValue(testExecution) as string;
+
+        var metadata = FindProperty(navReport.GetType(), "Metadata")?.GetValue(navReport)
+            ?? throw new InvalidOperationException(
+                "NavReport.Metadata is null — cannot build the dataset a [RequestPageHandler] asked for");
+
+        var renderer = CreateReportSaveAsXmlRenderer(navReport, parametersFileName, dataSetFileName, metadata);
+
+        // BC clears all three here, not after rendering.
+        pOutFile!.SetValue(testExecution, null);
+        pParamFile?.SetValue(testExecution, null);
+        if (pFormat != null && pFormat.PropertyType.IsEnum)
+            pFormat.SetValue(testExecution, Enum.Parse(pFormat.PropertyType, "None"));
+
+        if (Environment.GetEnvironmentVariable("AL_RUNNER_DIAG_RP") == "1")
+            Console.Error.WriteLine($"[NavReportSync] dataset requested → {dataSetFileName}");
+        return renderer;
+    }
+
+    private static object CreateReportSaveAsXmlRenderer(
+        object navReport, string? parametersFileName, string dataSetFileName, object metaReport)
+    {
+        var nclAsm = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(a => a.GetName().Name == "Microsoft.Dynamics.Nav.Ncl")
+            ?? throw new InvalidOperationException("Ncl assembly not loaded");
+        var typesAsm = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(a => a.GetName().Name == "Microsoft.Dynamics.Nav.Types")
+            ?? throw new InvalidOperationException("Types assembly not loaded");
+
+        _reportSaveAsXmlRendererType ??= nclAsm.GetType("Microsoft.Dynamics.Nav.Runtime.ReportSaveAsXmlRenderer")
+            ?? throw new InvalidOperationException(
+                "ReportSaveAsXmlRenderer not found in Ncl — Ncl shape changed; do not commit");
+        _getReportParametersDelegateType ??=
+            _reportSaveAsXmlRendererType.GetNestedType("GetReportParameters", BindingFlags.Public | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException(
+                "ReportSaveAsXmlRenderer.GetReportParameters delegate not found — Ncl shape changed; do not commit");
+        // internal ReportSaveAsXmlRenderer(string parametersFileName, GetReportParameters
+        //                                  reportParameters, string dataSetFileName, NavDataSet dataSet)
+        _reportSaveAsXmlRendererCtor ??= _reportSaveAsXmlRendererType
+            .GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            .FirstOrDefault(c =>
+            {
+                var ps = c.GetParameters();
+                return ps.Length == 4
+                    && ps[0].ParameterType == typeof(string)
+                    && ps[1].ParameterType == _getReportParametersDelegateType
+                    && ps[2].ParameterType == typeof(string);
+            })
+            ?? throw new InvalidOperationException(
+                "ReportSaveAsXmlRenderer(string, GetReportParameters, string, NavDataSet) not found — "
+                + "Ncl shape changed; do not commit");
+
+        // NavReport.GetParameters() : KeyValuePair<string,string>[] — the same method BC hands
+        // the renderer, so the parameters file carries the filters the handler actually set.
+        _navReportGetParameters ??= FindMethodUpHierarchy(navReport.GetType(), "GetParameters")
+            ?? throw new InvalidOperationException(
+                "NavReport.GetParameters() not found — Ncl shape changed; do not commit");
+
+        _createNavDataSet ??= typesAsm.GetType("Microsoft.Dynamics.Nav.Types.NavDataSetBuilder")?
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .FirstOrDefault(m => m.Name == "CreateNavDataSet"
+                                 && m.GetParameters().Length == 1
+                                 && m.GetParameters()[0].ParameterType.IsInstanceOfType(metaReport))
+            ?? throw new InvalidOperationException(
+                "NavDataSetBuilder.CreateNavDataSet(MetaReport) not found — Types shape changed; do not commit");
+
+        var dataSet = Invoke(_createNavDataSet, null!, new[] { metaReport });
+        var getParameters = Delegate.CreateDelegate(_getReportParametersDelegateType, navReport, _navReportGetParameters);
+        try
+        {
+            return _reportSaveAsXmlRendererCtor.Invoke(
+                new object?[] { parametersFileName, getParameters, dataSetFileName, dataSet });
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
+            throw; // unreachable
+        }
+    }
+
+    /// <summary>
+    /// <c>ResultSetProcessor.StartAsync()</c> / <c>FinishAsync()</c> — the pair
+    /// <c>ExecuteDataItemIteratorAsync</c> brackets <c>LoopRootDataItemsAsync</c> with. For the
+    /// XML renderer, StartAsync writes the document header + schema and FinishAsync closes it,
+    /// so the file only exists if both run.
+    /// </summary>
+    private static void InvokeProcessorLifecycle(object processor, string methodName)
+    {
+        var m = processor.GetType().GetMethod(methodName,
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                    binder: null, types: Type.EmptyTypes, modifiers: null)
+            ?? throw new InvalidOperationException(
+                $"{processor.GetType().Name}.{methodName}() not found — Ncl shape changed; do not commit");
+        AwaitValueTask(Invoke(m, processor, Array.Empty<object?>()));
+    }
+
+    private static bool ReadBoolProperty(object target, string name, bool fallback)
+    {
+        var p = FindProperty(target.GetType(), name);
+        if (p == null || p.PropertyType != typeof(bool)) return fallback;
+        try { return p.GetValue(target) is bool b ? b : fallback; }
+        catch (TargetInvocationException) { return fallback; }
+    }
+
+    private static MethodInfo? FindMethodUpHierarchy(Type? t, string name)
+    {
+        for (; t != null; t = t.BaseType)
+        {
+            var m = t.GetMethod(name,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly,
+                binder: null, types: Type.EmptyTypes, modifiers: null);
+            if (m != null) return m;
+        }
+        return null;
+    }
+}

--- a/AlRunner/Patches/NavReportSync.cs
+++ b/AlRunner/Patches/NavReportSync.cs
@@ -39,7 +39,7 @@ using System.Runtime.CompilerServices;
 
 namespace AlRunner;
 
-public static class NavReportSync
+public static partial class NavReportSync
 {
     /// <summary>Diagnostic marker; gated by AL_RUNNER_DIAG_IC=1.</summary>
     public static void Diag(string msg)
@@ -311,7 +311,9 @@ public static class NavReportSync
                 "not-yet-implemented — the runner could not construct report " + reportId +
                 " to run its request page. See docs/scope.md");
 
-        var confirmed = RunRequestPageForHandler(report, reportId, parameters);
+        // offersOk: true — RunRequestPage opens the page with ReportIntent.Parameters, where a
+        // plain OK means "these are the parameters" and is available on every request page.
+        var confirmed = RunRequestPageForHandler(report, reportId, parameters, offersOk: true);
 
         // BC's own RunRequestPageAsync reaches GetReportParameters through
         // RunReportAsync(…, ReportIntent.Parameters, …), which sets NavReport.success when
@@ -442,6 +444,17 @@ public static class NavReportSync
         var parent = BcRuntime.SkeletonSession;
         var instance = CreateReportInstance(meta, parent!, skipRestoreSavedReportSettings: true);
 
+        // BC's NavReport.RunReportAsync: `if (requestWindow.HasValue) UseRequestForm =
+        // requestWindow.Value;`. The static overloads always pass a value (the Cecil rewrite
+        // fills BC's own default, true, for the overloads that omit it), so the caller's
+        // `Report.Run(id, false, …)` is what decides whether a request page opens at all.
+        // Ignoring it made `RequestWindow = false` open one anyway once #2436 taught Run()
+        // to open request pages — which is an "Unhandled UI" error for a test that, quite
+        // reasonably, declared no [RequestPageHandler] because it asked for no request page.
+        var pUseRequestForm = FindProperty(instance.GetType(), "UseRequestForm");
+        if (pUseRequestForm != null && pUseRequestForm.CanWrite && pUseRequestForm.PropertyType == typeof(bool))
+            pUseRequestForm.SetValue(instance, requestWindow);
+
         if (record != null)
         {
             var setTableView = instance.GetType().GetMethods(
@@ -467,7 +480,10 @@ public static class NavReportSync
     /// Returns whether the page was CONFIRMED (the handler invoked OK), which is what
     /// decides whether BC hands the caller parameters or an empty string.
     /// </summary>
-    private static bool RunRequestPageForHandler(object report, int reportId, string? parameters)
+    /// <param name="offersOk">Whether the request page has a plain OK built-in action —
+    /// see RequestPageTestPage.GetBuiltInAction. True for the parameters-capture entry point
+    /// (RunRequestPage); for Report.Run() only when the report is ProcessingOnly.</param>
+    private static bool RunRequestPageForHandler(object report, int reportId, string? parameters, bool offersOk)
     {
         var pRequestPage = FindProperty(report.GetType(), "RequestOptionsPage");
         if (pRequestPage == null) return true;
@@ -482,7 +498,7 @@ public static class NavReportSync
         // Register the request-page surface BC's dispatch will ask the client session for
         // (RunnerTestClientSession.GetPage) — it is keyed by this form, and is also how the
         // handler's OK/Cancel is read back below.
-        var testPage = AlRunner.Patches.RequestPageTestPage.Bind(requestPage, report, reportId);
+        var testPage = AlRunner.Patches.RequestPageTestPage.Bind(requestPage, report, reportId, offersOk);
         if (Environment.GetEnvironmentVariable("AL_RUNNER_DIAG_RP") == "1")
         {
             try
@@ -635,8 +651,31 @@ public static class NavReportSync
         {
             InvokeVirtual(_onInitReport, navReport);
             ApplyCallerTableViewBeforePreReport(navReport);
+
+            // The request page, and what the test's [RequestPageHandler] does with it —
+            // BC's RunReportInternalCoreAsync runs it here, between applying the caller's
+            // table view and any report trigger. See NavReportSync.RunRequestPage.cs.
+            var outcome = RunRequestPageForReportRun(navReport, navReportBase);
+            if (outcome == RequestPageOutcome.Cancelled)
+            {
+                // BC: ReportExecutionResult.Cancel. No trigger runs, no layout is resolved,
+                // and no error is raised — cancelling a request page is an ordinary outcome.
+                if (Environment.GetEnvironmentVariable("AL_RUNNER_DIAG_IC") == "1")
+                    Console.Error.WriteLine("[NavReportSync] SyncRun: request page cancelled — report body not executed");
+                return true;
+            }
+            // BC's RunReportInternalCoreAsync calls this immediately before it builds the
+            // result-set processor, and it is the counterpart of the ApplySetTableView above:
+            // Apply copies TableViewRecord -> Record so triggers and the request-page handler
+            // see the caller's filters, Store copies Record -> TableViewRecord so the ones
+            // they ADDED survive the loop. The data-item loop starts each item from
+            // TableViewRecord (SetDataItemTableView), so anything only on Record is thrown
+            // away — which is how a request page's filter, and a Report.SetTableView applied
+            // to a data item the loop re-seeds, both went missing.
+            StoreCallerTableViewBeforeLoop(navReport);
+
             InvokeVirtual(_onPreReport, navReport);
-            InvokeDataItems(navReport);
+            bool datasetWritten = InvokeDataItems(navReport);
             InvokeVirtual(_onPostReport, navReport);
 
             // Strict AL semantics: when the AL source declares `ProcessingOnly =
@@ -648,7 +687,12 @@ public static class NavReportSync
             // rewritten to throw an OOS InvalidOperationException on
             // ThrowError). The error therefore originates from the actual
             // layout-resolution code path, not from a guard at the top of Run.
-            if (!IsProcessingOnly(navReport, navReportBase))
+            //
+            // Unless a dataset was what the run asked for: `TestRequestPage.SaveAsXml`
+            // selects FormResult.Xml, which BC maps to ReportIntent.Download with an Xml
+            // target format and answers with a dataset — no layout is resolved on that
+            // path even on a real service tier (#2436).
+            if (!datasetWritten && !IsProcessingOnly(navReport, navReportBase))
                 InvokeLayoutForReport(navReport, navReportBase);
             return false;
         }
@@ -689,6 +733,25 @@ public static class NavReportSync
     {
         if (_applySetTableViewForAllDataItems == null) return;
         Invoke(_applySetTableViewForAllDataItems, navReport, Array.Empty<object?>());
+    }
+
+    private static MethodInfo? _storeSetTableViewForAllDataItems;
+
+    /// <summary>
+    /// BC's own <c>DataItemIterator.StoreSetTableViewForAllDataItems()</c> —
+    /// <c>item.TableViewRecord.RecordImplementation.CopyFiltersSortingMarkList(item.Record)</c>
+    /// for every data item. See the call site for why the loop needs it.
+    /// </summary>
+    private static void StoreCallerTableViewBeforeLoop(object navReport)
+    {
+        Type? iter = navReport.GetType();
+        while (iter != null && iter.Name != "DataItemIterator") iter = iter.BaseType;
+        if (iter == null) return;
+        _storeSetTableViewForAllDataItems ??= iter.GetMethod("StoreSetTableViewForAllDataItems",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            null, Type.EmptyTypes, null);
+        if (_storeSetTableViewForAllDataItems == null) return;
+        Invoke(_storeSetTableViewForAllDataItems, navReport, Array.Empty<object?>());
     }
 
     // NavControlException lives in Microsoft.Dynamics.Nav.Types and is
@@ -840,13 +903,19 @@ public static class NavReportSync
     /// faithful shape for the runner's non-rendering Run(). Only installed when the report
     /// does not already carry a processor.
     /// </summary>
-    private static void InvokeDataItems(object navReport)
+    /// <returns>
+    /// True when the loop wrote a report DATASET, i.e. the run's
+    /// <c>[RequestPageHandler]</c> asked for one with <c>TestRequestPage.SaveAsXml</c> and
+    /// BC's own <c>ReportSaveAsXmlRenderer</c> produced the file. The caller uses this to
+    /// decide whether a layout still has to be resolved — a dataset run resolves none.
+    /// </returns>
+    private static bool InvokeDataItems(object navReport)
     {
         Type? iter = navReport.GetType();
         while (iter != null && iter.Name != "DataItemIterator") iter = iter.BaseType;
-        if (iter == null) return;
+        if (iter == null) return false;
 
-        EnsureResultSetProcessor(navReport, iter);
+        var datasetProcessor = EnsureResultSetProcessor(navReport, iter);
 
         _applyDataItemTableView ??= iter.GetMethod("ApplyDataItemTableViewAndRequestFormFilters",
             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
@@ -861,30 +930,53 @@ public static class NavReportSync
         if (_applyDataItemTableView != null)
             Invoke(_applyDataItemTableView, navReport, Array.Empty<object?>());
 
+
+        // StartAsync → loop → FinishAsync is the bracket ExecuteDataItemIteratorAsync puts
+        // around LoopRootDataItemsAsync. It is only driven for the dataset renderer: the
+        // NullResultSetProcessor path discards rows either way, and its FinishAsync raises
+        // events the runner never wires up.
+        if (datasetProcessor != null) InvokeProcessorLifecycle(datasetProcessor, "StartAsync");
         AwaitValueTask(Invoke(_loopRootDataItems, navReport, Array.Empty<object?>()));
+        if (datasetProcessor != null) InvokeProcessorLifecycle(datasetProcessor, "FinishAsync");
+        return datasetProcessor != null;
     }
 
     /// <summary>
     /// Give the data-item loop the <c>IResultSetProcessor</c> it writes rows into.
-    /// <c>NullResultSetProcessor</c> is BC's own discard implementation, chosen by BC's
-    /// factory for a layout-less report, so using it here is not a runner stand-in.
+    ///
+    /// When the run's <c>[RequestPageHandler]</c> asked for a dataset with
+    /// <c>TestRequestPage.SaveAsXml</c>, that is BC's own <c>ReportSaveAsXmlRenderer</c> —
+    /// the instance <c>ReportResultSetProcessorFactory.GetTestResultProcessor</c> builds on
+    /// a real service tier — and the rows the loop produces land in the file the test named.
+    /// Otherwise it is <c>NullResultSetProcessor</c>, BC's own discard implementation and
+    /// what its factory returns for a report with no layout, so neither is a runner stand-in.
     /// </summary>
-    private static void EnsureResultSetProcessor(object navReport, Type dataItemIteratorType)
+    /// <returns>The dataset renderer when one was installed, else null.</returns>
+    private static object? EnsureResultSetProcessor(object navReport, Type dataItemIteratorType)
     {
         _resultSetProcessorProp ??= dataItemIteratorType.GetProperty("ResultSetProcessor",
             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-        if (_resultSetProcessorProp == null) return;
-        if (_resultSetProcessorProp.GetValue(navReport) != null) return;
+        if (_resultSetProcessorProp == null) return null;
+        if (_resultSetProcessorProp.GetValue(navReport) != null) return null;
+
+        var setter = _resultSetProcessorProp.GetSetMethod(nonPublic: true)
+            ?? throw new InvalidOperationException(
+                "DataItemIterator.ResultSetProcessor has no setter — Ncl shape changed; do not commit");
+
+        var datasetProcessor = TryCreateTestDatasetProcessor(navReport);
+        if (datasetProcessor != null)
+        {
+            setter.Invoke(navReport, new[] { datasetProcessor });
+            return datasetProcessor;
+        }
 
         _nullResultSetProcessorType ??= dataItemIteratorType.Assembly
             .GetType("Microsoft.Dynamics.Nav.Runtime.NullResultSetProcessor")
             ?? throw new InvalidOperationException(
                 "NullResultSetProcessor not found in Ncl — Ncl shape changed; do not commit");
 
-        var setter = _resultSetProcessorProp.GetSetMethod(nonPublic: true)
-            ?? throw new InvalidOperationException(
-                "DataItemIterator.ResultSetProcessor has no setter — Ncl shape changed; do not commit");
         setter.Invoke(navReport, new[] { Activator.CreateInstance(_nullResultSetProcessorType) });
+        return null;
     }
 
     /// <summary>
@@ -1140,7 +1232,34 @@ public static class NavReportSync
         {
             Console.Error.WriteLine($"[NavReportSync] captionML seed failed: {ex.Message}");
         }
+        SeedUseRequestFormFromMetadata(navReport, meta);
         return true;
+    }
+
+    /// <summary>
+    /// Replicate the one line of <c>NavReport.EndInitializationAsync</c> that is now
+    /// AL-observable: <c>UseRequestForm = Metadata.UseRequestForm</c>.
+    ///
+    /// The runner blanks <c>EndInitialization</c> (its real body sync-over-asyncs and runs
+    /// metadata-bound side effects the runner supplies itself — see the Cecil rewrite), which
+    /// left <c>UseRequestForm</c> at its <c>false</c> default on every report. That was
+    /// invisible while <c>Report.Run()</c> never opened a request page. It stopped being
+    /// invisible with #2436: <c>UseRequestForm</c> is exactly the flag BC's
+    /// <c>RunReportInternalCoreAsync</c> reads to decide whether to open one, so leaving it
+    /// false made a <c>[RequestPageHandler]</c> unreachable for every report.
+    ///
+    /// Seeded here, at metadata-install time, so AL's own <c>Report.UseRequestPage(false)</c>
+    /// still wins — BC's ordering is the same (EndInitialization runs during construction,
+    /// before any AL statement can touch the report variable).
+    /// </summary>
+    private static void SeedUseRequestFormFromMetadata(object navReport, object metaReport)
+    {
+        var pTarget = FindProperty(navReport.GetType(), "UseRequestForm");
+        if (pTarget == null || !pTarget.CanWrite || pTarget.PropertyType != typeof(bool)) return;
+        var pSource = FindProperty(metaReport.GetType(), "UseRequestForm");
+        if (pSource == null || pSource.PropertyType != typeof(bool)) return;
+        try { pTarget.SetValue(navReport, pSource.GetValue(metaReport)); }
+        catch (TargetInvocationException) { /* a report that refuses the flag keeps its default */ }
     }
 
     /// <summary>

--- a/AlRunner/Patches/RequestPageTestPage.cs
+++ b/AlRunner/Patches/RequestPageTestPage.cs
@@ -39,15 +39,17 @@ internal sealed class RequestPageTestPage : MockITestPage
 {
     private readonly object _report;
     private readonly int _reportId;
+    private readonly bool _offersOk;
     private readonly Dictionary<string, ITestFilter> _dataItemFilters = new(StringComparer.OrdinalIgnoreCase);
     private FormResult _formResult = FormResult.None;
 
     private readonly Guid _formHandle;
 
-    private RequestPageTestPage(object requestPageForm, object report, int reportId)
+    private RequestPageTestPage(object requestPageForm, object report, int reportId, bool offersOk)
     {
         _report = report;
         _reportId = reportId;
+        _offersOk = offersOk;
         _formHandle = ReadProperty(requestPageForm, "Handle") is Guid handle ? handle : Guid.Empty;
     }
 
@@ -67,9 +69,15 @@ internal sealed class RequestPageTestPage : MockITestPage
     // it — hence one table keyed by the form, weak so a finished report is collectable.
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<object, RequestPageTestPage> _byForm = new();
 
-    internal static RequestPageTestPage Bind(object requestPageForm, object report, int reportId)
+    /// <param name="offersOk">
+    /// Whether this request page has a plain OK built-in action at all — see
+    /// <see cref="GetBuiltInAction"/>. True when the page was opened to capture PARAMETERS
+    /// (<c>Report.RunRequestPage</c>), or when the report is ProcessingOnly; false for a
+    /// plain <c>Report.Run()</c> on a report that renders.
+    /// </param>
+    internal static RequestPageTestPage Bind(object requestPageForm, object report, int reportId, bool offersOk)
     {
-        var page = new RequestPageTestPage(requestPageForm, report, reportId);
+        var page = new RequestPageTestPage(requestPageForm, report, reportId, offersOk);
         _byForm.Remove(requestPageForm);
         _byForm.Add(requestPageForm, page);
         return page;
@@ -87,8 +95,30 @@ internal sealed class RequestPageTestPage : MockITestPage
     /// <summary>True once the handler confirmed with OK (or LookupOK).</summary>
     internal bool Confirmed => _formResult is FormResult.OK or FormResult.LookupOK;
 
+    /// <summary>
+    /// The request page's built-in actions. Invoking one records how the page was closed.
+    ///
+    /// Returning null for OK is LOAD-BEARING and measured, not defensive. On a real service
+    /// tier a request page opened by a plain <c>Report.Run()</c> on a report that is NOT
+    /// ProcessingOnly has no OK action at all: OK selects no report output, and BC answers
+    /// <c>NavTestActionNotFoundException</c> — "The built-in action = OK is not found on the
+    /// page." — rather than running the report and then objecting. The same page DOES offer
+    /// OK when it was opened to capture parameters (<c>Report.RunRequestPage</c>), because
+    /// there OK means "these are the parameters", not "produce output".
+    ///
+    /// Both halves are pinned upstream in the al-language corpus
+    /// (handlers/TestReportRunWithRequestPage.al and handlers/TestReportRunRequestPage.al),
+    /// green on BC 27.0 through 28.4. Answering every result with an action made the
+    /// difference invisible here.
+    ///
+    /// Null is how BC's NavTestPageBase.GetBuiltInAction is told an action is absent — it
+    /// raises the exception itself, so the message is BC's own rather than one written here.
+    /// </summary>
     public override ITestAction GetBuiltInAction(FormResult formResult)
-        => new RecordingBuiltInAction(this, formResult);
+    {
+        if (!_offersOk && formResult is FormResult.OK or FormResult.LookupOK) return null!;
+        return new RecordingBuiltInAction(this, formResult);
+    }
 
     /// <summary>
     /// The filter group for one of the report's data items, addressed by the data item's AL

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -189,7 +189,22 @@ dispatch, and report/request-page variables support a limited standalone surface
   [#1918](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/1918); pass an
   explicit page id in the meantime.
 - Request pages can be handled via `[RequestPageHandler]`, but this is handler dispatch
-  only, not real request-page rendering.
+  only, not real request-page rendering. `Report.Run()` / `RunModal()` open the request page
+  and route it to the declared handler, exactly as a real service tier does under test:
+  a handler that cancels leaves the report body unexecuted, and one that calls
+  `TestRequestPage.SaveAsXml(parametersFile, dataSetFile)` gets the report's dataset written
+  to that file (so `Codeunit "Library - Report Dataset"` can load it) instead of a layout.
+  Two differences from real BC remain:
+    - A request page whose handler reads or writes a **control** bound to a report global
+      (`RequestPage.ShowAmountsInLCY.SetValue(true)`) is refused with
+      `out-of-scope: TestRequestPage control … request-page-control`. Resolving one needs the
+      request page's `NavForm.SourceExpressions` table, which the runner only builds for
+      forms it drives as a `TestPage`. Tracked in
+      [#2442](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2442).
+    - When no declared handler matches the request page, the runner continues WITHOUT
+      opening one rather than raising BC's `Unhandled UI` error. It cannot yet tell "the
+      test declared no handler" apart from "handler lookup did not reach us", and refusing
+      on the second would break reports that run fine today.
 - Report variables support `Run()`, `RunRequestPage()`, `SetTableView()`, and
   helper procedures. Report triggers execute: `OnPreReport`, `OnPreDataItem`,
   `OnAfterGetRecord` (once per row in the in-memory table), `OnPostDataItem`, and
@@ -200,12 +215,10 @@ dispatch, and report/request-page variables support a limited standalone surface
 - The static `Report.Run(id[, requestWindow[, systemPrinter[, record]]])` /
   `Report.RunModal(id, ...)` forms (called on the `Report` codeunit-like object, without
   first declaring a report variable) execute the report the same way the report-variable
-  form does — construct the report from its id, then run the same trigger lifecycle.
-  `requestWindow` / `systemPrinter` are accepted but not acted on: no dialog is ever raised
-  from `Run`/`RunModal` (request pages are handler dispatch only, see above); a report that
-  needs its request page's `[RequestPageHandler]` to fire should call the static/instance
-  `RunRequestPage()` explicitly. The `Report.Run(ReportRunOptions)` overload is not
-  implemented and throws `out-of-scope: static NavReport.Run`.
+  form does — construct the report from its id, then run the same trigger lifecycle, and
+  open the request page when `requestWindow` says to. `systemPrinter` is accepted but not
+  acted on: nothing prints. The `Report.Run(ReportRunOptions)` overload is not implemented
+  and throws `out-of-scope: static NavReport.Run`.
 
 ### No debugger infrastructure
 

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -116,8 +116,18 @@ tier with SQL Server.
 | API | Reason |
 |---|---|
 | `Report.SaveAsPdf` / `SaveAsHtml` / `SaveAsExcel` / `SaveAsWord` / `SaveAsDocx` | No layout renderer. Cecil-rewritten to throw `InvalidOperationException("out-of-scope: NavReport.SaveAs* ...")`. Tests `asserterror` + `Assert.ExpectedError('out-of-scope: NavReport.SaveAs')`. |
-| `Report.RunRequestPage(...)` | No UI tier — request-page dialog can't be rendered or driven. Throws OOS at the sync wrapper before entering `RunReportAsync`. |
-| Static `Report.Run(id, ...)` / `Report.RunModal(id, ...)` | In-process construction from a metadata id is not yet wired; throws OOS with the reportId in the message. Construct the report as an AL variable and call instance `Run()` instead — that path executes triggers. |
+| Request-page **controls** bound to report globals (`RequestPage.ShowAmountsInLCY.SetValue(…)`) | Resolving one needs the request page's `NavForm.SourceExpressions` table, which the runner only builds for forms it drives as a `TestPage`. Throws `out-of-scope: TestRequestPage control … request-page-control`. Data-item filters and the built-in actions ARE answered. See [#2442](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2442). |
+
+**Running a request page is in scope; rendering one is not.** `Report.Run()` /
+`RunModal()` / `RunRequestPage()` open the report's request page and let BC's own
+`NavTestExecution.TestHandleModalForm` route it to the declared
+`[RequestPageHandler]` — no dialog is drawn, and nothing about that needs a UI tier.
+How the handler closes the page decides what happens next, the same as on a real
+service tier: `Cancel` leaves the report body unexecuted, and
+`TestRequestPage.SaveAsXml(parametersFile, dataSetFile)` produces the report's
+**dataset** at that path (through BC's own `ReportSaveAsXmlRenderer`, so
+`Codeunit "Library - Report Dataset"` loads it) rather than resolving a layout.
+A dataset is report *execution*, not rendering.
 
 **Layout *selection* is in scope; layout *content* is not.** A report's
 `rendering { layout(Name) { Type; MimeType; LayoutFile; … } }` declarations are


### PR DESCRIPTION
Closes #2436

`Report.Run()` on a report that is not `ProcessingOnly` threw out-of-scope on layout resolution before producing anything, which ended Microsoft's dominant report-test shape: run the report, then read the dataset. Four separate defects were in the way, each one enough on its own.

## 1. `Report.Run()` never opened the request page

BC's `RunReportInternalCoreAsync` opens one whenever `UseRequestForm && RequestOptionsPage != null`, and under test that page goes to the declared `[RequestPageHandler]`. `SyncRun` skipped it entirely, so a handler declared for a report the test ran was silently never called. How the handler closes the page decides the outcome, and that is now honoured: `Cancel` leaves the report body unexecuted and raises nothing.

## 2. `UseRequestForm` was `false` on every report

BC sets it in `EndInitializationAsync`, whose body the runner blanks. The Cecil comment there listed it among side effects that are "not AL-observable" — true only while nothing read it. It is exactly the flag that decides whether a request page opens, so leaving it false made every `[RequestPageHandler]` unreachable even after fix 1.

It is now seeded from `Metadata.UseRequestForm` at metadata-install time, so AL's own `Report.UseRequestPage(false)` still wins (BC's ordering is the same), and honoured from the static `Report.Run(id, requestWindow, …)` forms, which accepted `requestWindow` and ignored it. Ignoring it was harmless until fix 1; afterwards it turned `RequestWindow = false` into an `Unhandled UI` error for tests that reasonably declared no handler.

## 3. `TestRequestPage.SaveAsXml` asks for a dataset, not a layout

`NavTestPage.ALSaveAsXml` parks two file names plus `FormResult.Xml` on the session's `TestExecution` — exactly where `ReportResultSetProcessorFactory.GetTestResultProcessor` reads them back. The runner now builds the same `ReportSaveAsXmlRenderer` that factory builds and installs it as the data-item loop's `ResultSetProcessor`, bracketing the loop with the `StartAsync` / `FinishAsync` pair `ExecuteDataItemIteratorAsync` uses.

Nothing about the dataset format is reimplemented: the file is written by Ncl's own renderer over a `NavDataSet` from Types' `NavDataSetBuilder`. And no layout is resolved on that path — not here and not on a real service tier, where `FormResult.Xml` maps to `ReportIntent.Download` with an Xml target format.

## 4. Two gaps in the metadata reconstructed for a *precompiled* report

Both invisible until a dataset was actually built from one, because `NullResultSetProcessor` discards every row and evaluates no column.

- **`DataItemLink` / `DataItemLinkReference` were never emitted.** `DataItemIterator.SetDataItemLink` resolves the reference against each data item's `DataItemVarName` and hands the link to `RecordDataItemLink`; with neither element present a nested data item has no restriction and iterates its whole table once per parent row. Report 411 "Vendor - Payment Receipt" produced **645,593 rows and a 1.45 GB file**, still growing when the 60s watchdog aborted the suite. With the link: 6 rows, 17 KB. `PrintOnlyIfDetail` comes along, since it decides whether a parent row with no detail appears at all.
- **A column's `FieldType` has to be a dataset column type**, not the AL type of its source expression. `NavDataSetBuilder.AddColumnToDataTable` runs it through `CommonTypeInformation.ResolveClrType`, which throws `ArgumentException: UnsupportedType` for anything it cannot map — killing the whole dataset over one column. A column whose expression is a `Label` arrives as `"Label"`, and report 411 alone has 23. Types `ResolveClrType` does not know now degrade to `Text`; the four `AddColumnToDataTable` special-cases (RecordID, Option, Duration, Enum) pass through untouched. Asked of the live method rather than a hard-coded list, so a type a future BC adds needs no change here.

## RED → GREEN

**Upstream corpus** — StefanMaron/BusinessCentral.AL.Language.Tests#103, merged, green on BC 27.0 / 27.3 / 27.5 / 28.0 / 28.1 / 28.2 / 28.3 / 28.4. Three claims: `Run()` routes the request page to the handler and runs the body over both seeded rows; a cancelling handler leaves the body unexecuted and raises nothing; a non-`ProcessingOnly` report's request page has no `OK` action.

Against that file, before → after:

| | before | after |
|---|---|---|
| `Report_Run_OpensTheRequestPageAndRunsTheBodyWhenTheHandlerConfirms` | FAIL — request page never opened | PASS |
| `Report_Run_CancelledRequestPageRunsNothingAndRaisesNoError` | FAIL — request page never opened | PASS |
| `Report_Run_NonProcessingOnlyRequestPageHasNoOKAction` | FAIL — out-of-scope `NavReport.<Layout>` | PASS |

**Two of those assertions started as deliberate guesses so corpus CI would print the real values, and it did — both guesses were wrong.** After `Report.Run()` the caller's report variable does *not* carry the report's globals back (`RowsProcessed()` reads 0 even when the body iterated every row), so row counts are taken from a log table; and a non-`ProcessingOnly` report's request page has no `OK` action at all, so BC answers "The built-in action = OK is not found on the page." rather than running and then objecting. The runner now matches both — `RequestPageTestPage.GetBuiltInAction` returns null for `OK`/`LookupOK` on such a page, which is how `NavTestPageBase` is told an action is absent, so the message is BC's own.

**Microsoft's `Tests-SINGLESERVER`**, BC 28.1, same backup and company as #2436's measurement: **393 → 405 passing**, 834 total, no suite abort.

**Runner-side mechanism tests** — `AlRunner.Tests/DependencyReportDataItemLinkTests.cs` pins both halves of defect 4 on the reconstruction itself, positive and negative (an item that states no link must not acquire one).

## Did I look for the same shape elsewhere?

1. **Same wrong pattern at another call site?** Yes, one, and it is fixed here: the static `Report.Run(id, requestWindow, …)` forms accepted `requestWindow` and dropped it, which only became a defect once `Run()` learned to open request pages. Found by two existing corpus tests going red.
2. **Sibling function making the same assumption?** `SyncRunRequestPage` shares `RunRequestPageForHandler`, and it needed the opposite answer for `OK`: a request page opened to capture PARAMETERS does offer `OK`, which is why `offersOk` is threaded through rather than derived inside. `TestReportRunRequestPage.al` is green upstream on exactly that and stays green here.
3. **Two paths writing the same state with different invariants?** Yes. `ApplySetTableViewForAllDataItems` (TableViewRecord → Record) ran without its counterpart `StoreSetTableViewForAllDataItems` (Record → TableViewRecord), which BC calls immediately before building the result-set processor. Without it, filters added after the apply — by a request-page handler, or by a data item the loop re-seeds — were thrown away by `SetDataItemTableView`. Added, in BC's own order.

I also narrowed my own first attempt: catching every `RunnerOutOfScopeException` around the request-page run swallowed the ones raised *inside* the handler, so a refusal to resolve a request-page control was reported as a report-rendering failure. It is now matched on the `request-page-dispatch` reason only, which is what moved 35 tests from a misleading message to an accurate one.

## What is left in the cluster, and where it went

Of the 83 tests #2436 measured ending on `NavReport.<Layout>`:

| now ends on | count | tracked by |
|---|---|---|
| request-page controls bound to report globals | 35 | #2442, filed |
| `NavReport.<Layout>` — the `ProcessingOnly`-detection half | 31 | #2397 |
| `NavReport.<Layout>` — one report in `Codeunit136906` | 1 | #2397's shape |
| recovered, or moved to unrelated causes | the rest | — |

The 35 are the largest remaining chunk and genuinely a different feature: a request page's controls bind to report globals rather than a source table, and resolving one needs the request page's `NavForm.SourceExpressions`, which the runner builds only for forms it drives as a `TestPage`. That is too large to fold in here, so it is filed with its reproducer and measurement rather than half-done.

## Not in this PR: the submodule pin

The corpus is currently 12 tests ahead of what the runner satisfies — from corpus PRs 102, 104 and 105, merged in parallel with mine (permission-set metadata, transaction rollback, query commit boundaries). None are report tests and none are affected by this change: at the pin `main` carries today, the whole corpus is 2302/2302 green with this change applied. Bumping the pin here would turn this PR red for twelve tests that belong to other work, so the bump belongs with whoever fixes them.

## Verification run in this state

- al-language corpus at `main`'s pin, `--strict --count-baseline`: **2302 / 2302**, exit 0
- `tests/runner-extras`: **207 / 207**, exit 0
- `dotnet test AlRunner.Tests --filter` over the new class plus `BcAppSymbolCacheReportTests`, `NavReportSyncApplySetTableViewReflectionTests`, and the CLI self-documentation / doc-drift tests: **65 passed, 0 failed**
- `Tests-SINGLESERVER`, BC 28.1: **405 / 834**, no suite abort

## Docs

`docs/limitations.md` and `docs/scope.md` now describe what `Report.Run()` does with a request page, the dataset path, and the two remaining differences from real BC — the refused control (#2442) and the deliberate divergence where an unmatched handler means "continue without a request page" instead of BC's `Unhandled UI` error, because the runner cannot yet tell that apart from "handler lookup did not reach us".

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
