### PR TITLE
fix(report): read ProcessingOnly from dependency symbols, not only parsed AL source

### DIFF
--- a/AlRunner.Tests/DependencyReportProcessingOnlyTests.cs
+++ b/AlRunner.Tests/DependencyReportProcessingOnlyTests.cs
@@ -1,0 +1,231 @@
+// DependencyReportProcessingOnlyTests — runner-mechanism guard for #2397.
+//
+// The gap
+// -------
+// RecordPatches.IsReportProcessingOnly answered from _parsedReports alone, and that
+// dictionary only ever holds reports the runner compiled FROM AL SOURCE. Every report
+// living in a precompiled dependency .app (all 659 Base Application reports, System
+// Application, any ISV app) is absent from it, so the expression fell through to `false`
+// — "not processing-only" — no matter what the report actually declares.
+//
+// NavReportSync.TryRunOrControlFlow reads exactly that answer to decide whether Run()
+// must attempt a layout, so a genuinely processing-only Base App report got a layout
+// attempt and died on the out-of-scope rendering throw. Measured on Base Application
+// 28.1.49838.53910: report 950 "Create Time Sheets" declares
+// `{ "Name": "ProcessingOnly", "Value": "1" }` in SymbolReference.json, and the runner
+// still answered false for it — 31 Tests-SINGLESERVER tests in Codeunit136506 ended there.
+//
+// What this file pins
+// -------------------
+// The runner-only C# mechanism: given a registered dependency .app, ProcessingOnly is read
+// from that app's own symbol data, AL's default is applied when the symbol file states
+// nothing, an unknown report still answers false, and a report the runner DID source-parse
+// keeps its source-parsed answer even when a dependency declares the same id differently.
+// The BC-observable claim underneath it (report 950 runs to completion and writes rows) is
+// plain BC behaviour and belongs upstream against a service tier, not here.
+//
+// The .app shape below (a zip holding SymbolReference.json) mirrors
+// BcAppSymbolCacheReportTests and DependencyPageMetadataXmlTests.
+using System.Collections;
+using System.IO.Compression;
+using System.Reflection;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// This class drives TryParseReportFile and reads _parsedReports back, so the parser-statics
+// guard requires RecordPatchesSerialCollection. It also reaches BcAppSymbolCache (via
+// AddBcAppPath), which normally argues for CacheRootsSerialCollection — a class can only
+// join one. RecordPatches wins because the parse statics are the ones that would produce a
+// WRONG answer under a race: every .app written here is a fresh GUID-named file, and the
+// symbol cache key is content-addressed (BcAppSymbolCacheContentAddressedKeyTests), so the
+// worst a concurrent CacheRoots override can do is turn a cache HIT into a MISS and make
+// Get() re-parse the same file to the same result.
+[Collection(RecordPatchesSerialCollection.Name)]
+public class DependencyReportProcessingOnlyTests
+{
+    private static readonly Type RecordPatchesType = typeof(RecordPatches);
+
+    // Ids far outside every other test's range: _parsedReports and the registered .app list
+    // are both process-global, so a shared id could read back another test's fact.
+    private const int DepProcessingOnlyReportId = 88123601;
+    private const int DepLayoutReportId = 88123602;
+    private const int SourceWinsReportId = 88123603;
+    private const int SourceOnlyProcessingOnlyReportId = 88123604;
+    private const int UnknownReportId = 88123609;
+
+    // Two dependency reports that differ ONLY in the ProcessingOnly property, plus a third
+    // whose id is also declared in AL source below. 88123602 states no ProcessingOnly at
+    // all, which is how the vast majority of real Base App reports look — it must keep
+    // answering false, or this fix would silence the layout throw for every report (that
+    // is #2436's subject, deliberately not touched here).
+    private const string SymbolReference = """
+        {
+          "RuntimeVersion": "15.1",
+          "Namespaces": [
+            {
+              "Name": "DRPO",
+              "Reports": [
+                {
+                  "Id": 88123601,
+                  "Name": "DRPO Create Time Sheets",
+                  "Properties": [
+                    { "Name": "Caption", "Value": "DRPO Create Time Sheets" },
+                    { "Name": "ProcessingOnly", "Value": "1" }
+                  ]
+                },
+                {
+                  "Id": 88123602,
+                  "Name": "DRPO Standard Invoice",
+                  "Properties": [
+                    { "Name": "Caption", "Value": "DRPO Standard Invoice" }
+                  ]
+                },
+                {
+                  "Id": 88123603,
+                  "Name": "DRPO Shadowed Report",
+                  "Properties": [
+                    { "Name": "ProcessingOnly", "Value": "1" }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    // The runner's own bundle declares 88123603 WITHOUT ProcessingOnly (so: AL's default,
+    // false) and 88123604 WITH it. 88123603 is the precedence probe — the dependency above
+    // says "1" for the same id.
+    private const string AlSource = """
+        report 88123603 "DRPO Shadowed Report"
+        {
+            Caption = 'DRPO Shadowed Report';
+        }
+
+        report 88123604 "DRPO Source Processing Only"
+        {
+            ProcessingOnly = true;
+        }
+        """;
+
+    private static string WriteApp(string dir, string symbolReferenceJson)
+    {
+        var appPath = Path.Combine(dir, Guid.NewGuid().ToString("N") + ".app");
+        using var zip = new FileStream(appPath, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+        return appPath;
+    }
+
+    [Fact]
+    public void DependencyReportDeclaringProcessingOnly_IsReportedProcessingOnly()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SymbolReference));
+
+            // The whole point of #2397: this report exists ONLY in a precompiled
+            // dependency, so nothing ever parsed its AL source, and it still has to answer
+            // with what the dependency's own symbol data states.
+            Assert.True(RecordPatches.IsReportProcessingOnly(DepProcessingOnlyReportId),
+                $"report {DepProcessingOnlyReportId} declares ProcessingOnly in the dependency's "
+                + "SymbolReference.json, so the runner must not send it down the layout path");
+
+            // Negative, same .app, same code path: a report that declares no ProcessingOnly
+            // takes AL's default and MUST still be treated as layout-bound. Without this the
+            // fix could pass by answering true for everything.
+            Assert.False(RecordPatches.IsReportProcessingOnly(DepLayoutReportId),
+                $"report {DepLayoutReportId} declares no ProcessingOnly, so AL's default (false) "
+                + "applies and the layout attempt must still happen");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReportNoSourceAndNoDependencyDeclares_IsNotProcessingOnly()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SymbolReference));
+
+            // Control: the .app really is registered and readable, so the assertion below
+            // is an observation rather than a vacuous "nothing was loaded".
+            Assert.True(RecordPatches.IsReportProcessingOnly(DepProcessingOnlyReportId));
+
+            Assert.False(RecordPatches.IsReportProcessingOnly(UnknownReportId),
+                "an id no source and no dependency describes keeps AL's default of false — the "
+                + "symbol fallback must not invent an answer for a report nobody declares");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SourceParsedReport_KeepsItsOwnAnswer_EvenWhenADependencyDeclaresTheSameId()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SymbolReference));
+            ParseReports(AlSource);
+
+            // Control: both ids really did reach the parser.
+            Assert.True(ParsedReportExists(SourceWinsReportId));
+            Assert.True(ParsedReportExists(SourceOnlyProcessingOnlyReportId));
+
+            // The bundle's own source declares no ProcessingOnly for 88123603 while the
+            // dependency states "1". A source-parsed entry always beats a dependency's
+            // (see the AlReportParser file header), so the answer is AL's default, false.
+            // An implementation that ORs the two together returns true here.
+            Assert.False(RecordPatches.IsReportProcessingOnly(SourceWinsReportId),
+                "a report the runner source-compiled must keep its source-parsed ProcessingOnly, "
+                + "not inherit a dependency's value for the same id");
+
+            // And the pre-existing source-only path is unchanged.
+            Assert.True(RecordPatches.IsReportProcessingOnly(SourceOnlyProcessingOnlyReportId),
+                "a source-parsed report declaring ProcessingOnly = true must still answer true");
+        }
+        finally
+        {
+            ForgetParsedReports();
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static void ParseReports(string source)
+    {
+        var m = RecordPatchesType.GetMethod("TryParseReportFile", BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("RecordPatches.TryParseReportFile not found by reflection.");
+        m.Invoke(null, new object[] { source });
+    }
+
+    private static IDictionary ParsedReports() => (IDictionary)RecordPatchesType
+        .GetField("_parsedReports", BindingFlags.NonPublic | BindingFlags.Static)!.GetValue(null)!;
+
+    private static bool ParsedReportExists(int id) => ParsedReports().Contains(id);
+
+    // Drop the fixtures out of the process-wide parser state so they cannot leak.
+    private static void ForgetParsedReports()
+    {
+        var d = ParsedReports();
+        d.Remove(SourceWinsReportId);
+        d.Remove(SourceOnlyProcessingOnlyReportId);
+    }
+}

--- a/AlRunner/Patches/DependencyReportMetadata.cs
+++ b/AlRunner/Patches/DependencyReportMetadata.cs
@@ -102,6 +102,49 @@ public static partial class RecordPatches
         return null;
     }
 
+    // ── ProcessingOnly for a report the runner never source-compiled ─────────
+
+    /// <summary>
+    /// Ids of every report that a loaded dependency's SymbolReference.json declares
+    /// <c>ProcessingOnly</c> on. Reports the symbol files describe WITHOUT the property, and
+    /// reports no symbol file describes at all, are both absent — AL's default for
+    /// ProcessingOnly is false, so "absent" and "stated false" are the same answer here and
+    /// a set is the whole representation needed.
+    /// </summary>
+    private static HashSet<int>? _depProcessingOnlyReportIds;
+
+    /// <summary>
+    /// Generation the set above was built from. The registered-.app list grows as
+    /// dependencies load, and this question is first asked well before the last one is
+    /// registered, so a set memoized without this key would freeze an early, short answer
+    /// for the rest of the run.
+    /// </summary>
+    private static int _depProcessingOnlyBuiltFrom = -1;
+
+    /// <summary>
+    /// Whether a PRECOMPILED dependency declares <c>ProcessingOnly</c> on this report.
+    /// This is the only route to the property for a Base Application / System Application /
+    /// ISV report: the runner never parses their AL source, so <c>_parsedReports</c> cannot
+    /// hold them, and an R2R .app ships no compiled metadata form of its objects. The
+    /// symbol file is the compiler's own statement of the property, so nothing here is
+    /// inferred — a report the symbol files do not describe simply is not in the set.
+    /// </summary>
+    internal static bool IsDependencyReportProcessingOnly(int reportId)
+    {
+        var generation = _bcAppPaths.Count;
+        var set = _depProcessingOnlyReportIds;
+        if (set == null || _depProcessingOnlyBuiltFrom != generation)
+        {
+            set = new HashSet<int>();
+            foreach (var symbol in EnumerateBcAppReportSymbols())
+                if (symbol.ProcessingOnly)
+                    set.Add(symbol.Id);
+            _depProcessingOnlyReportIds = set;
+            _depProcessingOnlyBuiltFrom = generation;
+        }
+        return set.Contains(reportId);
+    }
+
     // ── column source expressions ────────────────────────────────────────────
 
     // `column(Name; Expression)` — the name is a plain or quoted AL identifier, the

--- a/AlRunner/Patches/NavReportSync.cs
+++ b/AlRunner/Patches/NavReportSync.cs
@@ -639,9 +639,10 @@ public static class NavReportSync
             InvokeDataItems(navReport);
             InvokeVirtual(_onPostReport, navReport);
 
-            // Strict AL semantics: when the AL source declares `ProcessingOnly =
-            // false` (the AL default), Run() must attempt rendering after the
-            // lifecycle triggers. The runner has no service tier and cannot
+            // Strict AL semantics: when the report declares `ProcessingOnly =
+            // false` (the AL default) — in its own AL source, or in the symbol
+            // data of the precompiled dependency it came from — Run() must
+            // attempt rendering after the lifecycle triggers. The runner has no service tier and cannot
             // render layouts, so the rendering attempt must surface as an
             // AL-observable error. We trigger that via NavReport.RDLCLayout —
             // a public static method that forwards to GetLayoutCore (Cecil-
@@ -705,7 +706,10 @@ public static class NavReportSync
         return false;
     }
 
-    // Looks up ProcessingOnly from the parsed AL source (RecordPatches).
+    // Looks up ProcessingOnly through RecordPatches, which answers from the parsed AL
+    // source when the runner compiled the report and from the dependency .app's
+    // SymbolReference.json when it did not (#2397 — every Base Application report takes
+    // the second path).
     // Falls back to true when the report ID cannot be resolved — defensive
     // so unknown reports do not trip the rendering guard.
     private static bool IsProcessingOnly(object navReport, Type navReportBase)

--- a/AlRunner/Patches/RecordPatches.AlReportParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlReportParser.cs
@@ -103,13 +103,28 @@ public static partial class RecordPatches
     }
 
     /// <summary>
-    /// AL-source-derived ProcessingOnly for the given report ID. Returns
-    /// <c>false</c> when the report is unknown — matches the AL default and
-    /// causes the runner to throw an out-of-scope error at Run time (no
-    /// rendering pipeline available without a service tier).
+    /// ProcessingOnly for the given report ID, from whichever source actually describes
+    /// that report.
+    ///
+    /// A source-parsed entry wins, for the same reason it wins everywhere else
+    /// _parsedReports is read (see this file's header): the bundle's own AL is the report
+    /// the runner is really going to run. When there is no source-parsed entry the answer
+    /// comes from the registered dependency .app files' SymbolReference.json — that path
+    /// covers every Base Application / System Application / ISV report, which is all of
+    /// them, since the runner source-compiles none of those (#2397). Before it existed this
+    /// method fell straight through to <c>false</c> for a precompiled report no matter what
+    /// the report declared, so NavReportSync sent genuinely processing-only Base App
+    /// reports (e.g. 950 "Create Time Sheets", which states ProcessingOnly in its symbols)
+    /// down the layout path and they died on the out-of-scope rendering throw.
+    ///
+    /// Still <c>false</c> when neither source describes the report — that is AL's own
+    /// default, and it keeps the rendering guard in place for reports nobody declares
+    /// processing-only.
     /// </summary>
     public static bool IsReportProcessingOnly(int reportId) =>
-        _parsedReports.TryGetValue(reportId, out var p) && p.ProcessingOnly;
+        _parsedReports.TryGetValue(reportId, out var p)
+            ? p.ProcessingOnly
+            : IsDependencyReportProcessingOnly(reportId);
 }
 
 internal record ParsedReport(int Id, string Name, bool IsExtension, bool ProcessingOnly = false)


### PR DESCRIPTION
Closes #2397

## The bug, confirmed before fixing

`RecordPatches.IsReportProcessingOnly` answered from `_parsedReports` alone:

```csharp
_parsedReports.TryGetValue(reportId, out var p) && p.ProcessingOnly;
```

That dictionary only ever holds reports the runner compiled from AL source. Every report in a precompiled dependency `.app` is absent from it, so the expression fell through to `false` — "not processing-only" — no matter what the report actually declares. `NavReportSync.TryRunOrControlFlow` reads exactly that answer to decide whether `Run()` must attempt a layout, so a genuinely processing-only Base App report got a layout attempt and died on the out-of-scope rendering throw.

I measured the claim rather than assuming it. Reading `SymbolReference.json` out of `Microsoft_Base Application_28.1.49838.53910.app` (recursing into the nested `.app` payload — the outer archive is an R2R wrapper and a non-recursive scan finds nothing), report 950 "Create Time Sheets" states:

```json
{ "Name": "ProcessingOnly", "Value": "1" }
```

The runner answered `false` for it. Base Application 28.1 ships 659 reports through that same path.

## The fix

Fall back to the registered dependency `.app` files' own symbol data when there is no source-parsed entry. `BcAppSymbolCache.ReportSymbol` already carried `ProcessingOnly` and already parsed it correctly, so nothing new is read out of the `.app` — the property just had no consumer on this path. The set of processing-only dependency report ids is memoized on the registered-app count, the same generation key `KnownReportIdSet` uses, because this question gets asked before the last dependency is registered.

A source-parsed entry still wins, for the same reason it wins everywhere else `_parsedReports` is read. A report neither source nor symbols describe still answers `false` — AL's own default, which keeps the rendering guard in place.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** No. I checked every non-test read of `_parsedReports`. `KnownReportIdSet` (which `BuildNCLMetaReport` gates on) already merges parsed ids, dependency symbol ids and compiled ids. The Report Metadata / Report Data Items virtual tables already build rows from both parsed and symbol sources. `NavReportSync` already routes report metadata XML through `TryBuildDependencyReportMetadata`. `IsReportProcessingOnly` was the single accessor with no symbol fallback.
2. **Does a sibling function make the same assumption?** `UseRequestPage` is the obvious sibling — it lives on the same `ParsedReport`/`ReportSymbol` pair. Its only consumer is the Report Metadata virtual table, which already reads it from whichever of the two sources describes the report. No gap there.
3. **Do two paths writing the same state keep the same invariant?** The precedence invariant ("a source-parsed entry always beats a dependency's", stated in the `AlReportParser` file header) now holds on this path too; before the change the question could not arise, because the dependency side was never consulted. The third test below pins it explicitly, so an implementation that ORs the two sources together fails.

## Tests

New `AlRunner.Tests/DependencyReportProcessingOnlyTests.cs` — a runner-mechanism test, not a BC-behaviour claim. The BC-observable statement underneath this (report 950 runs to completion and writes rows) is plain BC behaviour and belongs upstream, so it is deliberately not asserted here.

Strict RED to GREEN. Before the fix, 2 of 3 failed for the right reason (`88123601` answered `false`); after, 3 of 3 pass.

- positive: a dependency report declaring `ProcessingOnly` is reported processing-only
- negative, same `.app`: a dependency report declaring no `ProcessingOnly` keeps AL's default of `false`, so the layout attempt still happens — this is what stops the fix from silencing the throw for every report
- negative: an id neither source nor symbols describe answers `false`
- precedence: a source-parsed report keeps its own answer when a dependency declares the same id differently

Deliberately out of scope: this does not change layout-throw behaviour for genuinely non-processing-only reports.

Run locally: the new class (RED then GREEN), plus a filtered `AlRunner.Tests` sweep over the surface changed (`~Report`, `~BcAppSymbolCache`, `~ParserStaticsIsolationGuard`, `~DependencyPageMetadataXml`) — 154 passed, 0 failed, 19 skipped.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf