### PR TITLE
fix(testpage): render an Option/Enum ordinal as the control's text in ValueToString

### DIFF
--- a/AlRunner.Tests/TestPageOptionValueEnumCaptionTests.cs
+++ b/AlRunner.Tests/TestPageOptionValueEnumCaptionTests.cs
@@ -124,4 +124,113 @@ public sealed class TestPageOptionValueEnumCaptionTests
 
         Assert.Equal(1, resolved.Value);
     }
+
+    // ── DisplayOrdinal — issue #2367 ────────────────────────────────────────────────
+    //
+    // The runner-mechanism half of #2367. The BC-behaviour claim ("AssertEquals on an
+    // Option/Enum control compares the control's text on both sides, so passing the option
+    // value the record holds is a match") is proven upstream against a live service tier —
+    // StefanMaron/BusinessCentral.AL.Language.Tests#108, branch
+    // agent/impl-3/testpage-option-assertequals, four tests in "Test Page Extended" (60126).
+    //
+    // What is pinned HERE is our own contract: BC's NavTestField.ALAssertEquals and
+    // ALSetValue rebuild an AL option value against NavValueMetadata.DefaultMetadata(FieldType),
+    // which throws the field's member table away, and then call ITestField.ValueToString on
+    // the resulting bare ordinal. So ValueToString is the one place the control's own option
+    // table can be put back, and DisplayOrdinal is what puts it back. Both of the runner's
+    // real ITestField implementations (LiveNavTestField, PageVariableTestField) route through
+    // it.
+    //
+    // RED/GREEN: reverting either ValueToString to `Convert.ToString(value, InvariantCulture)`
+    // leaves these passing but breaks the upstream tests; deleting DisplayOrdinal's caption/
+    // member lookup (returning null unconditionally) fails RendersTheOrdinalAsItsDeclaredCaption
+    // and RendersTheOrdinalAsItsMemberName here, in milliseconds.
+
+    [Fact]
+    public void DisplayOrdinal_EnumControl_RendersTheOrdinalAsItsDeclaredCaption()
+    {
+        var current = NavOption.Create(BuildEnumMetadata(), 0);
+        var captions = TestPageOptionValue.EnumCaptions(current);
+
+        // 1, not 0: the ordinal must come from the ARGUMENT, not from the value the control
+        // happens to be holding. Answering "Fields" here would still look like a caption.
+        Assert.Equal("Blocks", TestPageOptionValue.DisplayOrdinal(current, 1, captions));
+        Assert.Equal("Images", TestPageOptionValue.DisplayOrdinal(current, 2, captions));
+    }
+
+    // The plain Option primitive has no per-value Caption, so its members are what the
+    // control shows — the same fallback Display already used for the read direction.
+    [Fact]
+    public void DisplayOrdinal_PlainOptionControl_RendersTheOrdinalAsItsMemberName()
+    {
+        var current = NavOption.Create(NCLOptionMetadata.Create("Field,Block,Image"), 0);
+
+        Assert.Equal("Block", TestPageOptionValue.DisplayOrdinal(current, 1, captions: null));
+        Assert.Equal("Image", TestPageOptionValue.DisplayOrdinal(current, 2, captions: null));
+    }
+
+    // The invariant #2367 was a violation of: the text the write path produces for an ordinal
+    // and the text the read path (Display, behind ITestField.Value) produces for the same
+    // ordinal must be one and the same. They disagreed — Value said "Blocks", ValueToString
+    // said "1" — and AssertEquals compares one against the other.
+    [Fact]
+    public void DisplayOrdinal_AgreesWithDisplay_ForEveryMemberOfTheSet()
+    {
+        var metadata = BuildEnumMetadata();
+        var current = NavOption.Create(metadata, 0);
+        var captions = TestPageOptionValue.EnumCaptions(current);
+        var expected = new[] { "Fields", "Blocks", "Images" };
+
+        foreach (var ordinal in new[] { 0, 1, 2 })
+        {
+            var read = TestPageOptionValue.Display(NavOption.Create(metadata, ordinal), captions);
+            var write = TestPageOptionValue.DisplayOrdinal(current, ordinal, captions);
+
+            // Naming the concrete text matters: comparing the two paths to each other alone
+            // would still hold if BOTH collapsed to null, which is exactly the no-op an
+            // agreement-only assertion cannot distinguish from a working one.
+            Assert.Equal(expected[ordinal], read);
+            Assert.Equal(expected[ordinal], write);
+        }
+    }
+
+    // A NavOption that still carries its own metadata is accepted too — ALSetValue's
+    // CreateNavValueFromObject can hand back a NavOption rather than a boxed int.
+    [Fact]
+    public void DisplayOrdinal_NavOptionArgument_RendersThatOptionsOrdinal()
+    {
+        var metadata = BuildEnumMetadata();
+        var current = NavOption.Create(metadata, 0);
+        var captions = TestPageOptionValue.EnumCaptions(current);
+
+        Assert.Equal("Blocks",
+            TestPageOptionValue.DisplayOrdinal(current, NavOption.Create(metadata, 1), captions));
+    }
+
+    // Null means "not mine — use your own Convert.ToString", which is what keeps this fix
+    // additive. Three ways to land there, each asserted rather than assumed:
+
+    [Fact]
+    public void DisplayOrdinal_ControlIsNotOptionBound_ReturnsNull()
+        => Assert.Null(TestPageOptionValue.DisplayOrdinal(null, 1, captions: null));
+
+    [Fact]
+    public void DisplayOrdinal_OrdinalOutsideTheOptionSet_ReturnsNull()
+    {
+        var current = NavOption.Create(NCLOptionMetadata.Create("Field,Block,Image"), 0);
+
+        Assert.Null(TestPageOptionValue.DisplayOrdinal(current, 7, captions: null));
+    }
+
+    // Deliberately narrow: a string is NOT reinterpreted as an option. ALSetValue's
+    // `value is NavStringValue` fast path never reaches ValueToString, so a string arriving
+    // would mean some other caller with an unexamined contract.
+    [Fact]
+    public void DisplayOrdinal_NonOrdinalArgument_ReturnsNull()
+    {
+        var current = NavOption.Create(NCLOptionMetadata.Create("Field,Block,Image"), 0);
+
+        Assert.Null(TestPageOptionValue.DisplayOrdinal(current, "1", captions: null));
+        Assert.Null(TestPageOptionValue.DisplayOrdinal(current, null, captions: null));
+    }
 }

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -1456,16 +1456,62 @@ internal static class TestPageOptionValue
     /// silently write a different member.
     /// </summary>
     internal static string? Display(NavOption option, string[]? captions)
-    {
-        var metadata = option.NavOptionMetadata;
-        if (metadata == null) return null;
+        => option.NavOptionMetadata is { } metadata
+            ? DisplayOrdinal(metadata, option.Value, captions)
+            : null;
 
-        var index = IndexOfOrdinal(metadata, option.Value);
+    /// <summary>
+    /// The same text <see cref="Display"/> produces, for a BARE ORDINAL rather than for a
+    /// NavOption that already carries its own metadata (issue #2367).
+    ///
+    /// <c>NavTestField.ALAssertEquals</c> and <c>ALSetValue</c> — the real, precompiled BC
+    /// methods the AL compiler emits for <c>TestPage.&lt;field&gt;.AssertEquals(&lt;option&gt;)</c>
+    /// and <c>SetValue(&lt;option&gt;)</c> — never hand an AL Option/Enum value to
+    /// <see cref="ITestField"/> as-is. They round-trip it through
+    /// <c>NavValue.CreateNavValueFromObject(NavValueMetadata.DefaultMetadata(FieldType), value)</c>,
+    /// whose <c>NavNclType.NavOption</c> arm rebuilds the value against the DEFAULT option
+    /// metadata, and then hand the resulting <c>ClientObject</c> — a bare ordinal, with the
+    /// field's own member/caption table gone — to <see cref="ITestField.ValueToString"/>.
+    ///
+    /// So <c>ValueToString</c> is where the control's own option table has to be put back.
+    /// The metadata comes from the value the control currently holds, which is the control's
+    /// option set; only the ordinal comes from the caller.
+    /// </summary>
+    internal static string? DisplayOrdinal(NavOption? current, object? value, string[]? captions)
+        => current?.NavOptionMetadata is { } metadata && TryAsOrdinal(value, out var ordinal)
+            ? DisplayOrdinal(metadata, ordinal, captions)
+            : null;
+
+    private static string? DisplayOrdinal(object metadata, int ordinal, string[]? captions)
+    {
+        var index = IndexOfOrdinal(metadata, ordinal);
         if (index < 0) return null;
 
         if (captions != null && index < captions.Length) return captions[index];
         var options = Members(metadata);
         return index < options.Length ? options[index] : null;
+    }
+
+    // Deliberately narrow. An ordinal is what BC's own round trip leaves behind for an
+    // Option/Enum, and nothing else on this path is one: a string is not accepted here
+    // because ALSetValue's `value is NavStringValue` fast path never reaches ValueToString,
+    // so a string arriving would mean some OTHER caller with an unexamined contract, and
+    // silently reinterpreting its text as an option would be exactly the kind of guess
+    // loud-failures.md exists to prevent. Anything unrecognised falls back to the caller's
+    // own Convert.ToString, i.e. to the behaviour before #2367.
+    private static bool TryAsOrdinal(object? value, out int ordinal)
+    {
+        switch (value)
+        {
+            case NavOption option: ordinal = option.Value; return true;
+            case int i:            ordinal = i;            return true;
+            case short s:          ordinal = s;            return true;
+            case byte b:           ordinal = b;            return true;
+            case sbyte sb:         ordinal = sb;           return true;
+            case long l when l >= int.MinValue && l <= int.MaxValue:
+                                   ordinal = (int)l;       return true;
+            default:               ordinal = 0;            return false;
+        }
     }
 
     /// <summary>
@@ -1795,7 +1841,16 @@ internal sealed class LiveNavTestField : ITestField
     }
 
     public void Invoke() { }
-    public string ValueToString(object? value) => Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+
+    // An Option/Enum-bound control renders an ordinal as the text the control SHOWS, the same
+    // spelling the Value getter answers with — issue #2367. BC's own ALAssertEquals/ALSetValue
+    // strip an AL option value down to a bare ordinal before calling this (see
+    // TestPageOptionValue.DisplayOrdinal for the exact chain), so leaving it as
+    // Convert.ToString made AssertEquals compare the ordinal '2' against the control's
+    // 'Pending Approval' and report a mismatch for the value the record actually held.
+    public string ValueToString(object? value)
+        => TestPageOptionValue.DisplayOrdinal(CurrentOption(), value, OptionCaptions())
+           ?? Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
 
     // AL that walks an option set (building a picker, asserting the members a field offers) got
     // an empty string for every index, which reads as "this option has blank members" rather
@@ -1959,7 +2014,20 @@ internal sealed class PageVariableTestField : ITestField
     /// <summary>Run the control's OnDrillDown trigger — see LiveNavTestField.Drilldown.</summary>
     public void Drilldown() => _page.RaiseOnDrillDown(_controlId);
     public void Invoke() { }
-    public string ValueToString(object? value) => Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
+
+    // An Option/Enum-bound control renders an ordinal as the text the control SHOWS, the same
+    // spelling the Value getter answers with — issue #2367. BC's own ALAssertEquals/ALSetValue
+    // strip an AL option value down to a bare ordinal before calling this (see
+    // TestPageOptionValue.DisplayOrdinal for the exact chain), so leaving it as
+    // Convert.ToString made AssertEquals compare the ordinal '2' against the control's
+    // 'Pending Approval' and report a mismatch for the value the record actually held.
+    // The Rec-bound sibling above had the identical gap; both are fixed together because both
+    // Value getters already render captions, so either one left alone would keep disagreeing
+    // with its own read side.
+    public string ValueToString(object? value)
+        => TestPageOptionValue.DisplayOrdinal(CurrentOption(), value,
+               CurrentOption() is { } option ? _page.TryGetOptionCaptions(_controlId, option) : null)
+           ?? Convert.ToString(value, CultureInfo.InvariantCulture) ?? string.Empty;
     public string GetOption(int index) => string.Empty;
 }
 


### PR DESCRIPTION
Closes #2367

`TestPage.<OptionField>.AssertEquals(<option value>)` compared the AL value's ordinal against the page control's caption, so a correct value reported as a mismatch:

```
NavTestAssertEqualsException: AssertEquals for Field: Status Expected = '2', Actual = 'Pending Approval'
```

## Which side was wrong

The actual side. BC's own `NavTestField.ALAssertEquals` and `ALSetValue` never hand an AL Option/Enum value to `ITestField` as-is — they round-trip it through `NavValue.CreateNavValueFromObject(NavValueMetadata.DefaultMetadata(FieldType), value)`, whose `NavNclType.NavOption` arm rebuilds the value against the **default** option metadata and throws the field's own member table away. What reaches `ITestField.ValueToString` is a bare ordinal.

So `ValueToString` is the one place the control's option table can be put back, and both of the runner's real `ITestField` implementations answered `Convert.ToString(value, InvariantCulture)` there. Their `Value` getters already rendered the caption, so the read and write halves of the same control disagreed about what an option even looks like.

The fix routes `ValueToString` through the same `TestPageOptionValue` path the `Value` getter already used.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — `PageVariableTestField.ValueToString` had the identical line, for a control bound to a page variable rather than a record field. Fixed in the same commit. `MockITestField` (the minimal all-defaults mock) also has one, but it models no option state at all, so there is nothing to render through; left alone. `RequestPageTestPage.GetField` throws `RunnerOutOfScopeException`, so it has no such path.
2. **Sibling function making the same assumption?** The `Value` getters were already correct on both classes, which is what made the asymmetry invisible.
3. **Two paths, same invariant?** This was the defect. `Value` (read) said `Blocks`; `ValueToString` (write, and the expected side of `AssertEquals`) said `1`. `TestPageOptionValue.Display`'s own doc comment already stated the invariant — "deliberately the same spelling `Resolve` accepts first, so `SetValue(Value())` is a no-op" — and `ValueToString` was outside it. `DisplayOrdinal_AgreesWithDisplay_ForEveryMemberOfTheSet` now pins it.

Also found while checking siblings, not fixed here and filed separately: `PageVariableTestField.OptionCount` returns `0` and `GetOption` returns `''` unconditionally, while the Rec-bound `LiveNavTestField` implements both. That is option-set *walking* rather than value rendering, a different surface.

## Where the proving test lives

The BC-behaviour claim is plain BC behaviour, so it went upstream: **StefanMaron/BusinessCentral.AL.Language.Tests#108** (branch `agent/impl-3/testpage-option-assertequals`), four tests in `"Test Page Extended"` (60126) over both the Enum-typed `"Status Field"` and the plain Option primitive `"Option Field"`, each with a positive and a negative arm. The negative arms are the discriminating half: they read the failure message and assert the option's own text appears on both sides, which a comparison against the raw ordinal fails.

The submodule pin is **not** bumped here (other pin-bump PRs are in flight), so this PR carries a runner-side mechanism test under `AlRunner.Tests/` instead, in the existing `TestPageOptionValueEnumCaptionTests` file that already covers this class for issue #1928.

## Verification

**RED to GREEN, upstream corpus tests** — run against the corpus branch, same runner build:

| | before | after |
|---|---|---|
| `Page_TestField_AssertEquals_EnumField_MatchesOptionValue` | FAIL `Expected = '2', Actual = 'Active'` | PASS |
| `Page_TestField_AssertEquals_EnumField_WrongOptionValueFails` | FAIL `Expected = '1'`, no `Draft` in message | PASS |
| `Page_TestField_AssertEquals_OptionField_MatchesOptionValue` | FAIL `Expected = '2', Actual = 'Active'` | PASS |
| `Page_TestField_AssertEquals_OptionField_WrongOptionValueFails` | FAIL `Expected = '3'`, no `Closed` in message | PASS |

**RED to GREEN, mechanism tests** — with `DisplayOrdinal`'s lookup stubbed to return null, `DisplayOrdinal_EnumControl_RendersTheOrdinalAsItsDeclaredCaption`, `..._PlainOptionControl_RendersTheOrdinalAsItsMemberName` and `..._NavOptionArgument_RendersThatOptionsOrdinal` fail; restored, 13/13 pass.

**Microsoft `Tests-SINGLESERVER`**, BC 28.1, `--test-data` against `BusinessCentral-W1.bak` / `CRONUS International Ltd_`, both legs on the same build:

| | before | after |
|---|---|---|
| pass | 409 | **420** |
| fail | 401 | 389 |
| error | 24 | 25 |

Exactly the 11 `Codeunit134202.ShowDocumentFromApprovalEntryFor*` tests move to pass, and nothing newly fails. One test changes classification rather than outcome: `Codeunit132900.AddApplicationIDInSaaSTest` was failing on this same bug (`AssertEquals for Field: License Type Expected = '4', Actual = 'External User'`) and now gets past that line to a separate, deeper gap (`The following UI handlers were not executed: ConfirmHandlerNo`), which is filed separately.

**Corpus:** 2302/2302, unchanged.
**`tests/runner-extras`:** 207/207.
**`AlRunner.Tests`,** filtered to the surface changed (`~TestPage`, `~EnumOptionMatching`, `~PageEnumFieldMetadata`): 67 passed, 1 skipped.

No doc updates: no CLI surface, scope or limitation changes.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
