### PR TITLE
fix(page-metadata): emit SourceObject and Expressions for a dependency page with no source table

### DIFF
--- a/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
+++ b/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
@@ -47,6 +47,7 @@ public class DependencyPageMetadataXmlTests
     // cached answer instead of this one's.
     private const int ListPageId = 88123401;
     private const int UnknownPageId = 88123409;
+    private const int NavigatePageId = 88123402;
 
     private const string SymbolReference = """
         {
@@ -60,6 +61,14 @@ public class DependencyPageMetadataXmlTests
                 { "Name": "PageType", "Value": "List" },
                 { "Name": "SourceTable", "Value": "700" },
                 { "Name": "SourceTableTemporary", "Value": "true" }
+              ]
+            },
+            {
+              "Id": 88123402,
+              "Name": "DPX Test Navigate Page",
+              "Properties": [
+                { "Name": "Caption", "Value": "DPX Wizard Caption" },
+                { "Name": "PageType", "Value": "NavigatePage" }
               ]
             }
           ]
@@ -107,6 +116,106 @@ public class DependencyPageMetadataXmlTests
             // post-load control-id-uniqueness check).
             var content = root.SelectSingleNode("m:Content", ns);
             Assert.NotNull(content);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+
+    /// <summary>
+    /// #2451: a dependency page that declares NO SourceTable — the NavigatePage / wizard /
+    /// StandardDialog shape, 167 of them in Base Application 28.1 alone — must still carry an
+    /// EMPTY <c>&lt;SourceObject /&gt;</c> element and an <c>&lt;Expressions /&gt;</c> element,
+    /// for the same reason the empty <c>&lt;Content /&gt;</c> element above is written
+    /// unconditionally: BC dereferences all three without a null check.
+    ///
+    /// <para><c>MetadataProvider.MergePageAndTable</c> reads
+    /// <c>masterPage.PageProperties.SourceObject.SourceTable &gt; 0</c> with no guard on
+    /// <c>SourceObject</c>, and <c>LoadExpressionRelationTables</c> does a bare
+    /// <c>foreach (… in masterPage.Expressions)</c>. A MISSING element deserializes to null
+    /// rather than to an empty one, so omitting either NREs inside BC's own metadata merge —
+    /// which <c>RunnerPageInstance.TryCreateRecordless</c> catches, returning null, which
+    /// silently demotes the TestPage to the navigation mock whose every action answers
+    /// <c>Enabled = true</c> and whose <c>Invoke()</c> is a no-op.</para>
+    ///
+    /// <para>"Always present" is measured, not assumed: across the 3187 page metadata
+    /// documents the real AL compiler emitted into this machine's dependency-compile
+    /// sidecars, <c>&lt;SourceObject&gt;</c> appears in 3187 (1114 of them with no
+    /// <c>SourceTable</c> attribute at all) and <c>&lt;Properties&gt;</c>,
+    /// <c>&lt;Content&gt;</c> and <c>&lt;Expressions&gt;</c> each appear in 3187. Those four
+    /// are exactly the elements this synthesizer must never omit.</para>
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_PageWithoutSourceTable_StillEmitsEmptySourceObjectAndExpressions()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var appPath = WriteApp(dir, SymbolReference);
+            RecordPatches.AddBcAppPath(appPath);
+
+            var xml = RecordPatches.TryBuildDependencyPageMetadata(NavigatePageId);
+            Assert.NotNull(xml);
+
+            var doc = new XmlDocument();
+            doc.LoadXml(xml!);
+            var ns = new XmlNamespaceManager(doc.NameTable);
+            ns.AddNamespace("m", "urn:schemas-microsoft-com:dynamics:NAV:MetaObjects");
+
+            var root = doc.DocumentElement!;
+            var properties = (XmlElement)root.SelectSingleNode("m:Properties", ns)!;
+            Assert.Equal("NavigatePage", properties.GetAttribute("PageType"));
+
+            // Present…
+            var sourceObject = (XmlElement?)properties.SelectSingleNode("m:SourceObject", ns);
+            Assert.NotNull(sourceObject);
+            // …and empty, because the page genuinely has no source table. Writing a
+            // SourceTable="0" instead would make MergePageAndTable's `> 0` test read a
+            // table id the page does not have, which is a different wrong answer.
+            Assert.False(sourceObject!.HasAttribute("SourceTable"));
+            Assert.False(sourceObject.HasAttribute("SourceTableTemporary"));
+
+            Assert.NotNull(root.SelectSingleNode("m:Expressions", ns));
+            Assert.NotNull(root.SelectSingleNode("m:Content", ns));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The negative half: a page that DOES declare a source table must not be given the
+    /// empty element — its <c>SourceTable</c> (and the flags that only mean anything
+    /// alongside one) must still be carried through, so the fix above cannot be satisfied by
+    /// unconditionally writing an empty <c>&lt;SourceObject /&gt;</c> for every page.
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_PageWithSourceTable_KeepsSourceTableOnTheSameElement()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var appPath = WriteApp(dir, SymbolReference);
+            RecordPatches.AddBcAppPath(appPath);
+
+            var xml = RecordPatches.TryBuildDependencyPageMetadata(ListPageId);
+            Assert.NotNull(xml);
+
+            var doc = new XmlDocument();
+            doc.LoadXml(xml!);
+            var ns = new XmlNamespaceManager(doc.NameTable);
+            ns.AddNamespace("m", "urn:schemas-microsoft-com:dynamics:NAV:MetaObjects");
+
+            var sourceObject = (XmlElement)doc.DocumentElement!
+                .SelectSingleNode("m:Properties/m:SourceObject", ns)!;
+            Assert.Equal("700", sourceObject.GetAttribute("SourceTable"));
+            Assert.Equal("1", sourceObject.GetAttribute("SourceTableTemporary"));
+            Assert.NotNull(doc.DocumentElement!.SelectSingleNode("m:Expressions", ns));
         }
         finally
         {

--- a/AlRunner/Patches/DependencyPageMetadataXml.cs
+++ b/AlRunner/Patches/DependencyPageMetadataXml.cs
@@ -110,9 +110,24 @@ public static partial class RecordPatches
                 w.WriteEndElement();
                 w.WriteEndElement();
             }
+            // ALWAYS written, even for a page with no source table (issue #2451). Same
+            // reason as the empty <Content> element below: MetaPageDefinition deserializes a
+            // MISSING element to null rather than to an empty one, and BC dereferences this
+            // one WITHOUT a null check —
+            // MetadataProvider.MergePageAndTable reads
+            // `masterPage.PageProperties.SourceObject.SourceTable > 0` as its first act.
+            // Omitting it NREs inside BC's own metadata merge, which
+            // RunnerPageInstance.TryCreateRecordless catches and turns into null, which
+            // silently demotes the TestPage to the navigation mock — every action there
+            // answers Enabled = true and Invoke() is a literal no-op.
+            //
+            // The real AL compiler writes it unconditionally too: across the 3187 page
+            // metadata documents in this machine's dependency-compile sidecars,
+            // <SourceObject> appears in all 3187, and in 1114 of them it carries no
+            // SourceTable attribute at all — the empty form written here.
+            w.WriteStartElement("SourceObject");
             if (page.SourceTableId > 0)
             {
-                w.WriteStartElement("SourceObject");
                 w.WriteAttributeString("SourceTable",
                     page.SourceTableId.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 if (page.SourceTableTemporary)
@@ -120,9 +135,24 @@ public static partial class RecordPatches
                 if (!page.InsertAllowed) w.WriteAttributeString("InsertAllowed", "0");
                 if (!page.ModifyAllowed) w.WriteAttributeString("ModifyAllowed", "0");
                 if (!page.DeleteAllowed) w.WriteAttributeString("DeleteAllowed", "0");
-                w.WriteEndElement();
             }
+            // The attributes above only mean anything alongside a SourceTable, so a page
+            // without one gets the bare element the compiler itself emits — not
+            // SourceTable="0", which would answer "table 0" to a question about a table the
+            // page does not have.
+            w.WriteEndElement(); // SourceObject
             w.WriteEndElement(); // Properties
+
+            // Present-but-empty for the third time, and for the third identical reason:
+            // MetadataProvider.LoadExpressionRelationTables iterates
+            // `masterPage.Expressions` with no null check, so a missing element NREs one
+            // statement after the SourceObject read above. The real compiler emits it on all
+            // 3187 documents measured. No expressions are reconstructed here — the
+            // synthesizer carries no control tree (see the file header) — so this
+            // deserializes to an empty collection, which is what a page with no bound
+            // controls would have anyway.
+            w.WriteStartElement("Expressions");
+            w.WriteEndElement();
 
             // An empty (but present) Content element, not an absent one: NCLMetaForm.
             // LoadPageMetadata()'s own post-load check (EnsureNoControlIdAppearsMoreThanOnce)


### PR DESCRIPTION
Closes #2451

## What was wrong

`TimeSheetWizardStep6CreateTimeSheets` reports `The following UI handlers were not
executed: CreateTimeSheetsHandler`, and the handler is a `[RequestPageHandler]` for
precompiled report 950. It is not a request-page dispatch gap, and it does not share a
cause with #2442. The test presses `TimeSheetSetupWizard.FinishAction.Invoke()`, and that
`Invoke()` was a literal no-op, so `Report.Run(Report::"Create Time Sheets")` inside the
page's `OnAction` never ran and there was never a request page to dispatch.

The chain, measured rather than reasoned:

1. Page 977 "Time Sheet Setup Wizard" is a Base App `NavigatePage` and declares no
   `SourceTable`. `TestPageClientConstructionRule.Resolve` correctly answers
   `LiveRecordless` for it.
2. `TestPageFactory.TryBuildRecordless` → `RunnerPageInstance.TryCreateRecordless` calls
   `NavForm.EnsureMetadataLoaded()`, which NREs inside
   `MetadataProvider.MergePageAndTable`.
3. `TryCreateRecordless` catches that and returns null, so the `case
   TestPageClientKind.LiveRecordless when …` guard fails, the `switch` falls through, and
   the TestPage gets `MockITestPage` — whose `GetAction` hands back a `MockITestAction`
   with `Enabled => true` and an empty `Invoke()`.

The NRE is the runner's own doing. `DependencyPageMetadataXml.EmitPageXml` writes
`<SourceObject>` only when the page has a source table, and never writes `<Expressions>`
at all. `MetaPageDefinition` deserializes a **missing** element to null rather than to an
empty one, and BC dereferences both without a guard — `MergePageAndTable` reads
`masterPage.PageProperties.SourceObject.SourceTable > 0` as its first act, and
`LoadExpressionRelationTables` does a bare `foreach (… in masterPage.Expressions)`.

The file already documented exactly this trap for `<Content>` and wrote that one
unconditionally. Its two siblings now are too.

## Why "always emit" is the right answer

Measured, not assumed. Across the 3187 page metadata documents the real AL compiler
emitted into this machine's dependency-compile sidecars
(`~/.cache/al-runner/compiled-deps/*.page-metadata.json`):

| element | documents containing it |
|---|---|
| `<Properties>` | 3187 / 3187 |
| `<SourceObject>` (child of `Properties`, and its only child element) | 3187 / 3187 |
| `<Content>` | 3187 / 3187 |
| `<Expressions>` | 3187 / 3187 |

1114 of the 3187 `<SourceObject>` elements carry no `SourceTable` attribute at all —
they are written as the bare `<SourceObject />` this change now emits. A page with no
source table gets the empty element, not `SourceTable="0"`, because `MergePageAndTable`
tests `> 0` and "table 0" is a different wrong answer.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site?** The runner has exactly two metadata-XML
   synthesizers, `DependencyPageMetadataXml` and `DependencyReportMetadata`. For pages, the
   table above is the complete set of always-present elements, and all four are now written
   unconditionally — there is no third omission left of this shape. The report synthesizer
   uses a different schema and its consumer
   (`RunnerXmlMetadataLoader.GetMetaObjectXmlMetadata`) refuses loudly with a
   `RunnerOutOfScopeException` rather than degrading silently, so a missing element there
   cannot produce this failure mode. It does omit elements the compiler always writes
   (`RequestPage`, `Labels`, `Layouts`, `DataAccessIntent`, …); no NRE is observed on that
   path today, so I have not changed it speculatively and filed the audit instead.
2. **Does a sibling make the same assumption?** The other producer of the same
   `NCLObjectXmlMetadata` for a page is `AlPageMetadataRegistry`, holding the compiler's own
   output — which is where the 3187-document measurement comes from, so it satisfies the
   invariant by construction. Both producers now agree.
3. **Two paths writing the same state with different invariants?** That was precisely the
   defect: compiler-captured page XML always carried `SourceObject`/`Expressions`, the
   synthesized path did not, and only the synthesized one NREd. They now maintain the same
   invariant.

## Measurements

All on this machine, BC 28.1, Microsoft `Tests-SINGLESERVER` bucket, `--test-data` from
`BusinessCentral-W1.bak`, company `CRONUS International Ltd_`. Baseline re-measured on
`origin/main` (4a4ac73b) rather than taken from the issue — `main` moved after #2451 was
written, so its "421 pass" figure is stale.

| | before | after |
|---|---|---|
| bucket total | 834 | 834 |
| bucket pass | 443 | **452** |
| bucket fail | 366 | 359 |
| bucket error | 25 | 23 |
| Codeunit136506 pass (45 tests) | 12 | **19** |

Ten tests go red → green, deterministically: the whole-bucket run was executed twice with
the fix and produced byte-identical per-test results.

```
Codeunit136506.TimeSheetWizardStep6CreateTimeSheets       ERROR -> PASS   (the one #2451 called out)
Codeunit136506.TimeSheetWizardStep2Actions                ERROR -> PASS
Codeunit136506.TimeSheetWizardStep3FirstWeekday           FAIL  -> PASS
Codeunit136506.TimeSheetWizardStep3TimeSheetAdmin         FAIL  -> PASS
Codeunit136506.TimeSheetWizardStep4TimeSheetByJobApproval FAIL  -> PASS
Codeunit136506.TimeSheetWizardMatchEmployeeVsResource     FAIL  -> PASS
Codeunit136506.TimeSheetWizardMatchEmployeeVsResourceSaaS FAIL  -> PASS
Codeunit138698.TestCopyProfileCancel                      FAIL  -> PASS
Codeunit138698.TestProfileCardNew                         FAIL  -> PASS
Codeunit139470.TestTrialDialogIsShownWhenOpeningANonEval… ERROR -> PASS
```

Two tests move the other way, and neither is a regression this change introduces:

- `Codeunit134200.SalesOrderPostOnItemRestriction` PASS → FAIL **in the whole-bucket run
  only**. It passes when Codeunit134200 runs on its own with this change (77/80, the same
  three failures as before). The failure is `NavCSideDuplicateKeyException: The record in
  table Error Message already exists. ID='189'`, i.e. rows left in table 700 by an earlier
  codeunit. That collision is pre-existing — it already occurs twice in the baseline
  whole-bucket run, first in Codeunit134201 — and this change makes more AL actually
  execute, so it occurs five times and catches one more test. Filed separately.
- `Codeunit134912.ShowTermsAndConditions` FAIL → ERROR. Failing both before and after; it
  now gets far enough to report its declared `[PageHandler]` unconsumed instead of hitting
  an unhandled `Message` dialog earlier.

Not moved:

- al-language corpus: **2302 / 2302**, exit 0, with `--strict --count-baseline`.
- `tests/runner-extras`: **207 / 207**, exit 0, with `--strict --count-baseline`.
- `dotnet test AlRunner.Tests --filter "…DependencyPage|…PageMetadata|…TestPageClient|…PageShape"`: 24 / 24.

## Tests

`AlRunner.Tests/DependencyPageMetadataXmlTests.cs` gains two cases, both red before the
change and green after:

- `…_PageWithoutSourceTable_StillEmitsEmptySourceObjectAndExpressions` — a dependency page
  with no `SourceTable` must still get a `<SourceObject>` element, that element must carry
  neither `SourceTable` nor `SourceTableTemporary`, and `<Expressions>` and `<Content>` must
  be present.
- `…_PageWithSourceTable_KeepsSourceTableOnTheSameElement` — the negative half, so the fix
  cannot be satisfied by unconditionally writing an empty element for every page:
  `SourceTable="700"` and `SourceTableTemporary="1"` must still come through.

The BC-observable claim underneath — that a `NavigatePage` action's `Enabled` follows the
page global its `OnAction` assigns — is plain BC behaviour and is not asserted here; the
corpus cannot express this case anyway, because a corpus page is source-compiled by the
runner and therefore takes the `AlPageMetadataRegistry` path that was never broken. What
this file pins is the runner-only mechanism: the synthesized document's element set.

## Follow-ups filed, not silently skipped

- #2460 — six `TimeSheetWizardStepNControls` tests still fail on `Action X must be
  disabled`. The synthesized dependency page XML reconstructs no action or control tree, so
  `ActionDefinition(actionId)` is null and `EvaluateProperty` defaults to `true`. The issue
  carries the `SymbolReference.json` action tree and the `p{pageId}p{pageId}{name}`
  expression-key convention needed to close it.
- #2461 — the demotion to the navigation mock is silent in practice: neither
  `[RunnerPageInstance] page 977: could not build the record-less AL page object …` (stdout)
  nor `[TestPage] …; using navigation mock.` (stderr) reaches the run log, which is why this
  survived.
- #2462 — the table-700 `Error Message` ID collision described above.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
