### PR TITLE
test(perf): gate plain-run instrumentation cost on behaviour, not time

### DIFF
--- a/AlRunner.Tests/PlainRunInstrumentationGateTests.cs
+++ b/AlRunner.Tests/PlainRunInstrumentationGateTests.cs
@@ -1,0 +1,159 @@
+// Issue #2481: a plain run (no --coverage, no --capture-values, no --dap) should pay
+// nothing it did not ask for. The 15 PrependStaticCall/PrependProbe/PrependClosedGate/
+// PrependFieldUninitGuard sites in NclCecilRewrite.cs turned out, on inspection, to be
+// unconditional correctness prepends with no disabled state at all (BLOB-store
+// isolation, rowversion stamping, the Date virtual-table window guard, transaction
+// commit-point bookkeeping, closed-RecordRef property defaults, NavReport uninit-field
+// guards, report-layout hydration) — the same category as ReplaceBodyWithHelper, just
+// implemented as a prepend because BC's own body must still run afterward. None of them
+// gate on --coverage/--capture-values/--dap, so there is no "off" path to assert zero
+// work for.
+//
+// The actual optional, per-AL-statement/per-scope instrumentation is a SEPARATE, smaller
+// set that does not use those four helpers at all: three raw-IL prepends onto
+// NavMethodScope.StmtHit/CStmtHit (feeding AlCoverageTracker.OnStmtHit, --coverage,
+// #1922) and NavMethodScope.Exit() (feeding AlValueCapture.OnExit, --capture-values,
+// second slice of #1640), plus a third prepend onto the same StmtHit/CStmtHit methods
+// feeding AlDapSession.OnStmtHit (--dap, #1642). Each callee already gates on a static
+// `Enabled` bool as literally its first statement (AlCoverageTracker.cs,
+// AlValueCapture.cs, AlDapSession.cs) — this file is the behavioural regression gate the
+// issue asks for instead of a timing gate: assert the counter of REAL WORK PERFORMED
+// stays zero on a plain run, even though the call site itself fires on every statement.
+//
+// Deliberately NOT a timing/instructions-retired test — ubuntu-latest has no PMU (see
+// the issue), and wall clock moved 60% under load in an unrelated measurement while
+// instructions retired moved 0.1%. A counter needs neither: it is exact, on every OS,
+// with no noise floor to reason about.
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PlainRunInstrumentationGateTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string Fixture =
+        Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", "CoverageBranch");
+
+    private readonly string _scratch;
+
+    public PlainRunInstrumentationGateTests()
+    {
+        _scratch = Path.Combine(Path.GetTempPath(), "al-runner-plainrun-gate-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_scratch);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_scratch, recursive: true); } catch { }
+    }
+
+    private (string Output, int Exit) Spawn(params string[] extraArgs)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" --no-cache"); // must actually re-emit/re-instrument, not replay a cache HIT
+        foreach (var a in extraArgs) args.Append(' ').Append(a);
+        args.Append(" \"").Append(Fixture).Append('"');
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = args.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+            Environment = { ["AL_RUNNER_DUMP_INSTRUMENTATION_COUNTERS"] = "1" },
+        };
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        Assert.True(p.WaitForExit(240_000), "runner did not exit within 240s");
+        p.WaitForExit();
+        return (sb.ToString(), p.ExitCode);
+    }
+
+    private sealed record Counters(
+        long CoverageCallCount, bool CoverageHasRecordedAnyHits,
+        long CaptureValuesCallCount, int CaptureValuesCollectedCount,
+        long DapCallCount, long DapWorkPerformedCount);
+
+    private static Counters ParseCounters(string output)
+    {
+        var m = Regex.Match(output,
+            @"\[instrumentation-counters\] coverage\.CallCount=(\d+) coverage\.HasRecordedAnyHits=(True|False) " +
+            @"captureValues\.CallCount=(\d+) captureValues\.CollectedCount=(\d+) " +
+            @"dap\.CallCount=(\d+) dap\.WorkPerformedCount=(\d+)");
+        Assert.True(m.Success, $"instrumentation-counters line not found in output:\n{output}");
+        return new Counters(
+            long.Parse(m.Groups[1].Value), bool.Parse(m.Groups[2].Value),
+            long.Parse(m.Groups[3].Value), int.Parse(m.Groups[4].Value),
+            long.Parse(m.Groups[5].Value), long.Parse(m.Groups[6].Value));
+    }
+
+    // --- The negative half: a plain run does the call, but zero bookkeeping ------------
+
+    [SkippableFact]
+    public void PlainRun_NoOptionalFlags_HooksFireButRecordNoWork()
+    {
+        TestArtifacts.SkipIfMissing();
+        var (output, _) = Spawn(); // no --coverage, no --dap; captureValues has no CLI flag (server-mode only)
+        var c = ParseCounters(output);
+
+        // The Cecil-rewritten call sites are unconditional — they MUST fire on every AL
+        // statement of this fixture's two test methods (one has an if/else, so both
+        // StmtHit and CStmtHit fire). A count of 0 here would mean the hooks never
+        // installed at all, a much bigger regression than this issue is about.
+        Assert.True(c.CoverageCallCount > 0, $"coverage.CallCount was 0 — StmtHit hook never fired.\n{output}");
+        Assert.True(c.CaptureValuesCallCount > 0, $"captureValues.CallCount was 0 — StmtHit/Exit hook never fired.\n{output}");
+        Assert.True(c.DapCallCount > 0, $"dap.CallCount was 0 — StmtHit hook never fired.\n{output}");
+
+        // ...but NONE of the three subsystems did any bookkeeping: no coverage hit
+        // recorded, no captured-value series entry, no breakpoint/step evaluation. A
+        // no-op implementation that always skipped the Enabled check would ALSO show
+        // CallCount>0 here, so this half — not the counts above — is the actual claim
+        // this gate exists to protect: the callee's early-out is real, not vacuous.
+        Assert.False(c.CoverageHasRecordedAnyHits,
+            $"a plain run recorded a coverage hit despite --coverage never being requested.\n{output}");
+        Assert.Equal(0, c.CaptureValuesCollectedCount);
+        Assert.Equal(0, c.DapWorkPerformedCount);
+    }
+
+    // --- The positive half: the counters are not just permanently zero -----------------
+    //
+    // Proven here for --coverage only (the cheapest of the three to enable from the
+    // CLI — --capture-values is server-mode-only, see AlValueCaptureSeriesTests.cs /
+    // ServerExecuteCapturedValuesSeriesTests for its own enabled-arm proof; --dap needs a
+    // live DAP session, see DapServerTests.cs / DapClient for its own enabled-arm proof).
+    // What THIS test additionally proves that those don't: enabling --coverage alone
+    // does not also flip captureValues/dap's counters — the three gates are independent,
+    // not one shared switch.
+
+    [SkippableFact]
+    public void CoverageEnabled_RecordsWork_WhileTheOtherTwoStayAtZero()
+    {
+        TestArtifacts.SkipIfMissing();
+        var coveragePath = Path.Combine(_scratch, "cobertura.xml");
+        var (output, _) = Spawn("--coverage", $"--coverage-out \"{coveragePath}\"");
+        var c = ParseCounters(output);
+
+        Assert.True(c.CoverageCallCount > 0);
+        Assert.True(c.CoverageHasRecordedAnyHits,
+            $"--coverage was requested but no hit was ever recorded — the counter is dead, not just quiet.\n{output}");
+
+        // captureValues/dap were never requested on this run — their counters must stay
+        // exactly as quiet as the fully-plain run above, proving --coverage's own gate
+        // does not leak into the other two subsystems' bookkeeping.
+        Assert.Equal(0, c.CaptureValuesCollectedCount);
+        Assert.Equal(0, c.DapWorkPerformedCount);
+    }
+}

--- a/AlRunner/Infrastructure/AlCoverageTracker.cs
+++ b/AlRunner/Infrastructure/AlCoverageTracker.cs
@@ -81,6 +81,22 @@ public static class AlCoverageTracker
     public static void EndTest() => _currentTestKey = null;
 
     /// <summary>
+    /// Issue #2481's behavioural regression gate: incremented UNCONDITIONALLY, first
+    /// thing, on every call — proving the Cecil-rewritten call site actually fires on
+    /// every AL statement, independent of <see cref="Enabled"/>. Paired with <see
+    /// cref="HasRecordedAnyHits"/> (which stays false whenever <see cref="Enabled"/>
+    /// stays false): a plain run must show <c>CallCount &gt; 0</c> (the hook fired) AND
+    /// <c>HasRecordedAnyHits == false</c> (it did no bookkeeping work) — see
+    /// AlRunner.Tests/PlainRunInstrumentationGateTests.cs.
+    /// </summary>
+    internal static long CallCount;
+
+    /// <summary>True once <see cref="_hits"/> has recorded at least one entry — i.e. real
+    /// coverage bookkeeping actually happened. Stays false for the lifetime of a process
+    /// that never sets <see cref="Enabled"/>, however many statements ran.</summary>
+    internal static bool HasRecordedAnyHits => !_hits.IsEmpty;
+
+    /// <summary>
     /// Hook target for the Cecil-rewritten NavMethodScope.StmtHit(int). Public static,
     /// exactly (NavMethodScope, int) so the rewrite can forward `ldarg.0; ldarg.1; call`
     /// without boxing the int. Must stay side-effect-free beyond counting: it runs on
@@ -101,6 +117,7 @@ public static class AlCoverageTracker
     /// </summary>
     public static void OnStmtHit(NavMethodScope scope, int currentStatementNumber)
     {
+        System.Threading.Interlocked.Increment(ref CallCount);
         AlCurrentStatement.Update(scope, currentStatementNumber);
         AlValueCapture.OnStmtHit(scope, currentStatementNumber);
         // NavMethodScope.ExitStatementNumber (int.MaxValue) is written directly by

--- a/AlRunner/Infrastructure/AlDapSession.cs
+++ b/AlRunner/Infrastructure/AlDapSession.cs
@@ -275,6 +275,18 @@ public static class AlDapSession
         _pauseGate?.Release();
     }
 
+    /// <summary>Issue #2481's behavioural regression gate: incremented UNCONDITIONALLY,
+    /// first thing, proving the Cecil-rewritten call site fires on every AL statement
+    /// regardless of <see cref="Enabled"/>.</summary>
+    internal static long CallCount;
+
+    /// <summary>Incremented only once execution passes the <c>!Enabled || _detached</c>
+    /// gate above — i.e. only when this call actually did breakpoint/step evaluation
+    /// work (took <see cref="_bpLock"/>, walked the step-depth chain, …). Stays zero for
+    /// the lifetime of a process that never had an active --dap session, however many
+    /// statements ran. See AlRunner.Tests/PlainRunInstrumentationGateTests.cs.</summary>
+    internal static long WorkPerformedCount;
+
     /// <summary>
     /// Hook target for the Cecil-rewritten NavMethodScope.StmtHit(int)/CStmtHit(int[,
     /// bool]) — public static, exactly (NavMethodScope, int) so the rewrite can forward
@@ -285,7 +297,9 @@ public static class AlDapSession
     /// </summary>
     public static void OnStmtHit(NavMethodScope scope, int currentStatementNumber)
     {
+        System.Threading.Interlocked.Increment(ref CallCount);
         if (!Enabled || _detached) return;
+        System.Threading.Interlocked.Increment(ref WorkPerformedCount);
         // Same ExitStatementNumber guard as AlCoverageTracker.OnStmtHit — Exit() writes
         // int.MaxValue directly, StmtHit never receives it from generated code.
         if (currentStatementNumber == int.MaxValue) return;

--- a/AlRunner/Infrastructure/AlValueCapture.cs
+++ b/AlRunner/Infrastructure/AlValueCapture.cs
@@ -119,6 +119,15 @@ public static class AlValueCapture
         _series ?? (IReadOnlyList<AlCapturedValue>)Array.Empty<AlCapturedValue>();
 
     /// <summary>
+    /// Issue #2481's behavioural regression gate: incremented UNCONDITIONALLY, first
+    /// thing in <see cref="OnStmtHit"/>/<see cref="OnExit"/>, proving those Cecil-
+    /// rewritten call sites fire regardless of <see cref="Enabled"/>. Paired with
+    /// <see cref="Collect"/>'s emptiness (which stays empty whenever <see
+    /// cref="Enabled"/> stays false) — see AlRunner.Tests/PlainRunInstrumentationGateTests.cs.
+    /// </summary>
+    internal static long CallCount;
+
+    /// <summary>
     /// Feeds the per-execution series from BC's own StmtHit(N) — called from
     /// AlCoverageTracker.OnStmtHit (the same Cecil-prepended hook site --coverage
     /// already uses; see NclCecilRewrite's StmtHit block), NOT itself a Cecil target.
@@ -139,6 +148,7 @@ public static class AlValueCapture
     /// </summary>
     public static void OnStmtHit(NavMethodScope scope, int currentStatementNumber)
     {
+        System.Threading.Interlocked.Increment(ref CallCount);
         if (!Enabled) return;
         if (!scope.IsTopLevelCall) return;
         // NavMethodScope.ExitStatementNumber (int.MaxValue) is written directly by
@@ -172,6 +182,7 @@ public static class AlValueCapture
     /// </summary>
     public static void OnExit(NavMethodScope scope)
     {
+        System.Threading.Interlocked.Increment(ref CallCount);
         if (!Enabled) return;
         // Only the test's own locals — not those of any procedure it calls, which get
         // their own (deeper) scope instances and their own Exit() traffic. IsTopLevelCall

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3499,6 +3499,25 @@ if (coverageEnabled)
     coverageOut.WriteLine($"Cobertura → {coverageOutputPath}");
 }
 
+// Issue #2481's behavioural regression gate — dumps the per-statement/per-scope
+// instrumentation call counters to stderr so a subprocess-spawning test (which cannot
+// read this process's static fields directly) can assert "the Cecil-rewritten hook
+// fired on every statement, but did zero bookkeeping work" for a plain run. Never
+// printed on a normal run: opt-in via an undocumented env var, not a CLI flag, because
+// this exists for AlRunner.Tests/PlainRunInstrumentationGateTests.cs only. Computing
+// and printing four longs/bools costs nothing worth gating further.
+if (Environment.GetEnvironmentVariable("AL_RUNNER_DUMP_INSTRUMENTATION_COUNTERS") == "1")
+{
+    Console.Error.WriteLine(
+        "[instrumentation-counters] " +
+        $"coverage.CallCount={AlRunner.Infrastructure.AlCoverageTracker.CallCount} " +
+        $"coverage.HasRecordedAnyHits={AlRunner.Infrastructure.AlCoverageTracker.HasRecordedAnyHits} " +
+        $"captureValues.CallCount={AlRunner.Infrastructure.AlValueCapture.CallCount} " +
+        $"captureValues.CollectedCount={AlRunner.Infrastructure.AlValueCapture.Collect().Count} " +
+        $"dap.CallCount={AlRunner.Infrastructure.AlDapSession.CallCount} " +
+        $"dap.WorkPerformedCount={AlRunner.Infrastructure.AlDapSession.WorkPerformedCount}");
+}
+
 // Exit non-zero if anything failed — the default since the v2 cut, matching main/v1.
 // --no-strict-exit restores the old always-0 behaviour for JSON-only consumers.
 return strictExitCode ? computedExitCode : 0;


### PR DESCRIPTION
Closes #2481

## What a plain run pays: the inventory

The issue names 15 `PrependStaticCall`/`PrependProbe`/`PrependClosedGate`/
`PrependFieldUninitGuard` sites in `NclCecilRewrite.cs` (grep confirms exactly 15) and
asks what each one costs when its owning optional feature is off. On inspection, **none
of the 15 belong to an optional feature at all**:

| # | site | prepended to | fires | gated by a flag? |
|---|---|---|---|---|
| 1 | `NoteTransactionEnd` | `SessionTransactionExtensions.EndTransactionWorldAndTransaction` | per guarded `Codeunit.Run`/`XmlPort.Import` transaction-world end | no — commit-point bookkeeping every asserterror-rollback test needs |
| 2-5 | `PrependClosedGate` ×4 | `NavRecordRef.get_{ALReadPermission,ALWritePermission,ALName,ALIsEmpty}` | per closed-RecRef property read | no — one inline branch, no callee at all |
| 6-7 | `PrependFieldUninitGuard` ×2 | `NavReport.{get_Language,get_FormatRegion}` | per report-language setup | no — one inline branch, no callee at all |
| 8-9 | `PrependProbe` ×2 | `ReportLayout.{get_LayoutStream,CalculateMimetype}` | per report-layout render | no — report rendering isn't optional once a report actually runs |
| 10-11 | `PrependStaticCall` ×2 | `TempTableDataProvider.Insert`, `TempTableRecordBuffer.CloneBlobs` | per record `Insert` | no — BLOB-store isolation (#1751) |
| 12-13 | `PrependStaticCall` ×2 | `TempTableDataProvider.{Insert,Modify}` | per record `Insert`/`Modify` | no — rowversion stamping (#1980) |
| 14 | `PrependStaticCall` | `TempTableDataProvider.ModifyAllTrees` | per record `Rename` | no — BLOB store-aliasing (#1765) |
| 15 | `PrependStaticCall` | `DataAccess.CountAsync` | per `Count`/`IsEmpty` | no — Date virtual-table window guard |

Every one of these is a correctness prepend with no disabled state — the same category
as the ~115 `ReplaceBodyWithHelper`/`ReplaceBodyConst` rewrites the issue already put out
of scope, just implemented as a prepend (not a full-body replacement) because BC's own
logic still has to run afterward. Read for cost anyway: each callee I inspected is O(1) —
a single volatile/field read plus a branch (the four `PrependClosedGate`/
`PrependFieldUninitGuard` sites don't even call out to C#, they're pure inline IL), or one
`ConcurrentDictionary`/`Dictionary` `TryGetValue` with a cached (`??=`) reflected
`MethodInfo` on the cold path only. None locks, none allocates on the common path, none
does per-call reflection. No fix needed; no gate needed either — there's no "off" state
to regress against.

**The actual optional, per-AL-statement/per-scope instrumentation is a separate, smaller
set** that doesn't use any of those four helper names — three raw-IL prepends onto
`NavMethodScope.StmtHit`/`CStmtHit` (feeding `AlCoverageTracker.OnStmtHit`, `--coverage`,
#1922) and `NavMethodScope.Exit()` (feeding `AlValueCapture.OnExit`, `--capture-values`,
#1640), plus a third prepend onto the same `StmtHit`/`CStmtHit` methods feeding
`AlDapSession.OnStmtHit` (`--dap`, #1642) — 7 insertion points across 4 methods, firing
**84,075 times** across the al-language corpus's 2,333 tests (measured with `--coverage`
this run: 15,858 distinct statement lines, 84,075 total hits). Every one of these three
callees already gates on a static `Enabled` bool (or `_detached`) as literally its first
statement — confirmed by reading `AlCoverageTracker.cs`, `AlValueCapture.cs`,
`AlDapSession.cs` directly, not inferred. The one always-on side effect is
`AlCoverageTracker.OnStmtHit`'s unconditional call to `AlCurrentStatement.Update`
(2 volatile field writes, no allocation) — deliberate and already documented: it feeds
`RunnerClientCallback.Message()` capture, which has no request-side opt-in, so it isn't
part of the --coverage/--capture-values/--dap question at all.

## Aggregate measurement

Built a probe (never shipped — reverted before commit, see below) that removed all 7
optional-hook insertion points entirely rather than just relying on the callee's internal
gate, to measure the ceiling of what a plain run could save if the call site itself were
never emitted. Warm al-language corpus, `perf stat -e instructions:u`, same machine as
the issue's own single-site measurement but **not quiet** — this machine ran other
agents' work throughout (load average climbed from 1.34 to 3.6+ over the course of the
measurement), so my own noise floor is wider than the issue's quoted ±0.86%:

| arm | run 1 | run 2 | run 3 | run 4 |
|---|---|---|---|---|
| `main` (hooks present) | 174.92G | 170.75G | 179.08G | — |
| probe (hooks removed) | 184.80G | 180.84G | 177.97G | 179.85G |

main mean 174.92G (±2.4%), probe mean 180.86G (±1.9%) — probe *higher*, i.e. removing the
hooks measured **slower**, the same backwards sign the issue's own single-site
measurement found (180.72G with the early-out vs 179.67G without, +0.58%). Both pass/fail
counts were identical in every run: 2333/2333, 0 fail, 0 error. Both arms' ranges overlap
(main max 179.08G vs probe min 177.97G), so the +3.4% mean delta is fully inside this
session's noise floor, not a measured cost.

**This reinforces, at the full-set level and under noisier conditions than the original
test, the issue's own single-site conclusion: the whole set of optional per-statement/
scope hooks is free.** I did not chase a tighter number on a quieter machine — the
signal, if any, is already below what a shared CI runner without a PMU could ever gate on
anyway, which is exactly why deliverable 4 below doesn't try to.

Every probe change (the `ProbeDisableOptionalStmtHooks` env-var-gated skip in
`NclCecilRewrite.cs`) was reverted before this commit — `git diff` on that file is empty.
Per `.claude/rules/loud-failures.md`, that build was a probe, never a shippable change.

## The gate: behaviour, not time

Agreeing with the issue's recommendation over a timing gate — `ubuntu-latest` has no PMU
(confirmed already in the issue; not re-litigated here) and wall clock is unusable (the
issue's own 1.9s-vs-3.1s figure). Each of the three optional subsystems now exposes:

- `CallCount` — incremented unconditionally, first statement in the hook — proves the
  Cecil-rewritten call site actually fires on every AL statement/scope-exit.
- a work-performed signal — `AlCoverageTracker.HasRecordedAnyHits`,
  `AlValueCapture.Collect().Count`, `AlDapSession.WorkPerformedCount` — incremented only
  once execution passes the `Enabled` gate, i.e. only when real bookkeeping happened.

`Program.cs` dumps all six values to stderr under an undocumented env var
(`AL_RUNNER_DUMP_INSTRUMENTATION_COUNTERS=1`, never printed on a normal run — same
"debug-only, not in `--help`" precedent as `AL_RUNNER_HOOK_AUDIT`), since the values live
in the spawned runner subprocess and a test can't read its static fields directly.

`AlRunner.Tests/PlainRunInstrumentationGateTests.cs` proves both directions:

- `PlainRun_NoOptionalFlags_HooksFireButRecordNoWork` — no `--coverage`/`--dap`/server
  `captureValues`. All three `CallCount`s are non-zero (hooks fire), all three
  work-performed signals stay at zero.
- `CoverageEnabled_RecordsWork_WhileTheOtherTwoStayAtZero` — `--coverage` on:
  `HasRecordedAnyHits` flips true, while capture-values/dap's counters stay exactly as
  quiet as the fully-plain run — proving the three gates are independent, not one shared
  switch.

RED confirmed by temporarily removing the `if (Enabled)` guard around
`AlCoverageTracker`'s `_hits.AddOrUpdate` (a real, reachable regression shape) and
re-running the disabled-arm test — it failed with `coverage.HasRecordedAnyHits=True`
despite `--coverage` never being requested. Reverted (`git diff` on that file after
revert is byte-identical to before), then GREEN re-confirmed.

`--capture-values`'s and `--dap`'s own enabled-arm functional behaviour already has
dedicated coverage elsewhere (`AlValueCaptureSeriesTests.cs`/
`ServerExecuteCapturedValuesSeriesTests` for capture-values; `DapServerTests.cs`/
`DapClient` for dap) — this file's job is specifically the aggregate disabled-arm claim
the issue asks for, not re-proving functionality those files already prove.

## Testing

- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~Coverage|FullyQualifiedName~ValueCapture|FullyQualifiedName~Dap|FullyQualifiedName~PlainRun"` — 75/75 passed.
- Full al-language corpus (warm, `--package-cache` platform-apps + test-apps): 2333/2333
  pass, 0 fail, 0 error, both before and after this change.
- RED→GREEN on the new gate itself, described above.

## Fix-the-shape check

1. **Same wrong pattern at another call site?** All 15 grep-matched sites read; none
   gate on a flag, none allocate/lock/reflect on their common path. The 7 truly optional
   hooks all gate first-statement already — no sibling instance of "gate happens too
   late" found.
2. **Sibling function, same assumption?** `AlCurrentStatement.Update`'s unconditional
   feed from `AlCoverageTracker.OnStmtHit` looked at first like the kind of un-gated cost
   this issue hunts for; it's deliberate, already documented, and provably cheap (two
   volatile writes) — not a defect.
3. **Two paths, same state, different invariant?** N/A here — this issue is about one
   call site each, not two paths writing shared state.

No fix filed: nothing found doing real work while switched off.
