### PR TITLE
fix(server): warm-server-reload cluster — precompiled tableextensions, install-baseline restore, affectedOnly env key

### DIFF
--- a/AlRunner.Tests/RecordPatchesWarmReloadExtensionIndexTests.cs
+++ b/AlRunner.Tests/RecordPatchesWarmReloadExtensionIndexTests.cs
@@ -40,15 +40,24 @@ using Xunit;
 
 namespace AlRunner.Tests;
 
-[Collection(BcEngineCollection.Name)]
+// RecordPatchesSerialCollection, not BcEngineCollection: this class calls
+// RecordPatches.ResetForReload() directly, which ParserStaticsIsolationGuardTests requires
+// to be in RecordPatchesSerialCollection (the AL parse statics are process-wide, and xunit
+// runs collections in parallel — see that guard's own header for #1696). Both
+// RecordPatchesSerialCollection and BcEngineCollection set DisableParallelization = true,
+// and xUnit runs every DisableParallelization collection serially relative to every OTHER
+// one too (see CollectionCostOrderer.cs), so this still can't race a BcEngineCollection
+// class. The BC engine bootstrap itself runs at [ModuleInitializer] time (BcEngineBootstrap,
+// BcEngineCollection.cs), unconditionally, before any test — BcEngineFixture is only a
+// convenience DI wrapper over BcEngineBootstrap.Ready/SkipReason, so reading those directly
+// works identically without joining BcEngineCollection.
+[Collection(RecordPatchesSerialCollection.Name)]
 public sealed class RecordPatchesWarmReloadExtensionIndexTests : IDisposable
 {
-    private readonly BcEngineFixture _engine;
     private readonly string _root;
 
-    public RecordPatchesWarmReloadExtensionIndexTests(BcEngineFixture engine)
+    public RecordPatchesWarmReloadExtensionIndexTests()
     {
-        _engine = engine;
         _root = Path.Combine(Path.GetTempPath(), "al-runner-2478-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_root);
     }
@@ -70,8 +79,8 @@ public sealed class RecordPatchesWarmReloadExtensionIndexTests : IDisposable
     [SkippableFact]
     public void ResetForReload_RebuildsPrecompiledExtensionMergeOnNextRequest()
     {
-        TestArtifacts.SkipIf(!_engine.Ready,
-            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+        TestArtifacts.SkipIf(!BcEngineBootstrap.Ready,
+            BcEngineBootstrap.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
 
         // Object ids process-wide unique among AlRunner.Tests statics (shared _parsedTables /
         // _metaTableCache), and outside every other file's declared ranges — 939xx is used by

--- a/AlRunner.Tests/RecordPatchesWarmReloadExtensionIndexTests.cs
+++ b/AlRunner.Tests/RecordPatchesWarmReloadExtensionIndexTests.cs
@@ -1,0 +1,178 @@
+// RecordPatchesWarmReloadExtensionIndexTests — proves #2478: on a warm --server (or
+// --watch) process, the SECOND and every later per-request reset must re-merge precompiled
+// tableextension fields, exactly as the first request did.
+//
+// Root cause (per #2478's own investigation, reproduced here at the mechanism level rather
+// than through a spawned --server process against a real Base Application closure)
+// ------------------------------------------------------------------------------------------
+// BcRuntime.ResetForNewBundleReload() -> RecordPatches.ResetForReload() runs once per
+// runTests request in server mode (Program.cs's RunAllBundlesForServer) and once per
+// --watch iteration. That reset clears _parsedExtensionFields and sets
+// _bcSymbolExtensionIndexBuilt = false, intending the extension merge to re-run on next
+// use — but it leaves _bcSymbolTableIndex populated. The ONLY call site for
+// EnsureBcSymbolExtensionIndex() sits inside EnsureBcSymbolTableIndex(), after that method's
+// `if (_bcSymbolTableIndex != null) return;` guard — so once _bcSymbolTableIndex survives a
+// reset, the extension merge never runs again for the rest of the process's life, and every
+// metatable built from the second request on is missing its precompiled tableextension
+// fields.
+//
+// Why a direct unit test, not a spawned --server process against real Base Application
+// ------------------------------------------------------------------------------------------
+// The upstream repro (Microsoft Tests-TestLibraries's dependency closure) needs a real BC
+// service-tier artifact set and violates .claude/rules/no-base-app-in-csharp-tests.md if
+// reproduced as a C# fixture's "application" dependency. RecordPatches.AddBcAppPath accepts
+// ANY precompiled .app carrying a SymbolReference.json — the same synthetic in-process .app
+// technique RecordPatchesPrecompiledTableExtEvictionTests.cs (#2126) already uses reproduces
+// the EXACT defective call chain (EnsureBcSymbolTableIndex -> EnsureBcSymbolExtensionIndex)
+// without any real BC dependency, so this test drives it directly, simulating two requests:
+//   1. Reference an unrelated table so the symbol table + extension indexes get built once
+//      ("request 1"), and confirm the base table's extension field resolves.
+//   2. Call RecordPatches.ResetForReload() directly — the exact method the server calls
+//      between requests — then re-register the SAME source dir (the server re-registers a
+//      bundle's own source on every request; _bcAppPaths is registered once at startup and
+//      is deliberately NOT re-added here, matching production).
+//   3. Reference the unrelated table again ("request 2") and confirm the extension field
+//      STILL resolves. Without the fix this throws "extension field 50 ... not found".
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class RecordPatchesWarmReloadExtensionIndexTests : IDisposable
+{
+    private readonly BcEngineFixture _engine;
+    private readonly string _root;
+
+    public RecordPatchesWarmReloadExtensionIndexTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-2478-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private static void WriteApp(string path, string symbolReferenceJson)
+    {
+        using var zip = new FileStream(path, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+    }
+
+    [SkippableFact]
+    public void ResetForReload_RebuildsPrecompiledExtensionMergeOnNextRequest()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // Object ids process-wide unique among AlRunner.Tests statics (shared _parsedTables /
+        // _metaTableCache), and outside every other file's declared ranges — 939xx is used by
+        // RecordPatchesPrecompiledTableExtEvictionTests.cs at 93900-93902; this file uses
+        // 93910-93912.
+        const int baseTableId = 93910;
+        const string baseTableName = "Bug2478 Base";
+        const int triggerTableId = 93911;
+        const int extId = 93912;
+        const int extFieldId = 50;
+        const string extFieldName = "ExtField2478";
+
+        var baseDir = Path.Combine(_root, "base");
+        Directory.CreateDirectory(baseDir);
+        File.WriteAllText(Path.Combine(baseDir, "Base.al"), $$"""
+            table {{baseTableId}} "{{baseTableName}}"
+            {
+                fields
+                {
+                    field(1; "No."; Code[20]) { }
+                }
+                keys
+                {
+                    key(PK; "No.") { Clustered = true; }
+                }
+            }
+            """);
+
+        var sr = $$"""
+            {
+              "RuntimeVersion": "15.1",
+              "Namespaces": [],
+              "Tables": [
+                {
+                  "Id": {{triggerTableId}},
+                  "Name": "Bug2478 Trigger",
+                  "Fields": [
+                    { "TypeDefinition": { "Name": "Code[20]" }, "Properties": [], "Id": 1, "Name": "No." }
+                  ],
+                  "Keys": [
+                    { "Name": "PK", "FieldNames": [ "No." ] }
+                  ]
+                }
+              ],
+              "TableExtensions": [
+                {
+                  "TargetObject": "{{baseTableName}}",
+                  "Fields": [
+                    { "TypeDefinition": { "Name": "Code[10]" }, "Properties": [], "Id": {{extFieldId}}, "Name": "{{extFieldName}}" }
+                  ],
+                  "Id": {{extId}},
+                  "Name": "Bug2478Ext"
+                }
+              ]
+            }
+            """;
+        var appPath = Path.Combine(_root, "dep.app");
+        WriteApp(appPath, sr);
+
+        var skeleton = AlRunner.BcRuntime.SkeletonNCLMetadata;
+        Assert.NotNull(skeleton);
+
+        // ── REQUEST 1 ────────────────────────────────────────────────────────────────
+        RecordPatches.AddSourceDir(baseDir);
+        RecordPatches.AddBcAppPath(appPath);
+
+        var trigger1 = RecordPatches.NCLMetadata_GetMetaTableById(skeleton!, triggerTableId, false, 0);
+        Assert.Equal(triggerTableId, trigger1.TableId);
+
+        var base1 = RecordPatches.EnsureTableInMetadataCache(baseTableId);
+        Assert.NotNull(base1);
+        var field1 = RecordPatches.NCLMetaTable_GetFieldByNoExt(base1!, extId, extFieldId);
+        Assert.Equal(extFieldId, field1.FieldNo);
+        Assert.Equal(extFieldName, field1.FieldName);
+
+        // ── SIMULATE THE --server / --watch PER-REQUEST RESET ──────────────────────────
+        // Exactly BcRuntime.ResetForNewBundleReload()'s delegate target. _bcAppPaths is
+        // registered once by Program.cs at startup, never per-request, so AddBcAppPath is
+        // deliberately NOT called again here — matching production.
+        RecordPatches.ResetForReload();
+        RecordPatches.AddSourceDir(baseDir);
+
+        // ── REQUEST 2 ────────────────────────────────────────────────────────────────
+        var trigger2 = RecordPatches.NCLMetadata_GetMetaTableById(skeleton!, triggerTableId, false, 0);
+        Assert.Equal(triggerTableId, trigger2.TableId);
+
+        var base2 = RecordPatches.EnsureTableInMetadataCache(baseTableId);
+        Assert.NotNull(base2);
+        // [THEN] the extension field is STILL present on request 2. Without the fix,
+        // EnsureBcSymbolTableIndex's guard short-circuits before EnsureBcSymbolExtensionIndex
+        // ever runs again, _parsedExtensionFields stays empty forever after the first reset,
+        // and this throws "extension field 50 from extension 93912 not found".
+        var field2 = RecordPatches.NCLMetaTable_GetFieldByNoExt(base2!, extId, extFieldId);
+        Assert.Equal(extFieldId, field2.FieldNo);
+        Assert.Equal(extFieldName, field2.FieldName);
+
+        // ── ASSERT (negative): a genuinely nonexistent field still raises loudly on request 2 ──
+        const int nonExistentFieldId = 999999;
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            RecordPatches.NCLMetaTable_GetFieldByNoExt(base2!, extId, nonExistentFieldId));
+        Assert.Contains($"extension field {nonExistentFieldId}", ex.Message);
+        Assert.Contains("not found", ex.Message);
+    }
+}

--- a/AlRunner.Tests/RecordPatchesWarmReloadInstallBaselineTests.cs
+++ b/AlRunner.Tests/RecordPatchesWarmReloadInstallBaselineTests.cs
@@ -49,15 +49,24 @@ using Xunit;
 
 namespace AlRunner.Tests;
 
-[Collection(BcEngineCollection.Name)]
+// RecordPatchesSerialCollection, not BcEngineCollection: this class calls
+// RecordPatches.ResetForReload() directly, which ParserStaticsIsolationGuardTests requires
+// to be in RecordPatchesSerialCollection (see that guard's own header for #1696 — the AL
+// parse statics are process-wide, and xunit runs collections in parallel). Both
+// RecordPatchesSerialCollection and BcEngineCollection set DisableParallelization = true,
+// and xUnit runs every DisableParallelization collection serially relative to every OTHER
+// one too (see CollectionCostOrderer.cs), so this still can't race a BcEngineCollection
+// class. The BC engine bootstrap itself runs at [ModuleInitializer] time (BcEngineBootstrap,
+// BcEngineCollection.cs), unconditionally, before any test — BcEngineFixture is only a
+// convenience DI wrapper over BcEngineBootstrap.Ready/SkipReason, so reading those directly
+// works identically without joining BcEngineCollection.
+[Collection(RecordPatchesSerialCollection.Name)]
 public sealed class RecordPatchesWarmReloadInstallBaselineTests : IDisposable
 {
-    private readonly BcEngineFixture _engine;
     private readonly string _root;
 
-    public RecordPatchesWarmReloadInstallBaselineTests(BcEngineFixture engine)
+    public RecordPatchesWarmReloadInstallBaselineTests()
     {
-        _engine = engine;
         _root = Path.Combine(Path.GetTempPath(), "al-runner-2480-tests", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_root);
     }
@@ -107,8 +116,8 @@ public sealed class RecordPatchesWarmReloadInstallBaselineTests : IDisposable
     [SkippableFact]
     public void RestoreInstallBaselineSnapshot_ThrowsWhenTableShapeChangedAcrossReload()
     {
-        TestArtifacts.SkipIf(!_engine.Ready,
-            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+        TestArtifacts.SkipIf(!BcEngineBootstrap.Ready,
+            BcEngineBootstrap.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
 
         // 93920-93921: process-wide unique among AlRunner.Tests statics — 939xx is also used
         // by RecordPatchesPrecompiledTableExtEvictionTests.cs (93900-93902) and
@@ -168,8 +177,8 @@ public sealed class RecordPatchesWarmReloadInstallBaselineTests : IDisposable
     [SkippableFact]
     public void RestoreInstallBaselineSnapshot_SucceedsWhenTableShapeUnchangedAcrossReload()
     {
-        TestArtifacts.SkipIf(!_engine.Ready,
-            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+        TestArtifacts.SkipIf(!BcEngineBootstrap.Ready,
+            BcEngineBootstrap.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
 
         // Distinct id range from the negative fact above so the two tests' shared statics
         // (_parsedTables / _metaTableCache) cannot interfere with each other.

--- a/AlRunner.Tests/RecordPatchesWarmReloadInstallBaselineTests.cs
+++ b/AlRunner.Tests/RecordPatchesWarmReloadInstallBaselineTests.cs
@@ -1,0 +1,216 @@
+// RecordPatchesWarmReloadInstallBaselineTests — proves #2480: a warm --server (or --watch)
+// process's install-baseline cache (TestExecutor._depCompanyBaselineCache, a PROCESS-lifetime
+// dictionary that no per-request reset touches) must not restore a table's rows against a
+// stale NCLMetaTable object captured on a PREVIOUS request.
+//
+// Root cause (per #2480's own investigation)
+// ------------------------------------------------------------------------------------------
+// RunAllBundlesForServer calls BcRuntime.ResetForNewBundleReload() per request, which clears
+// RecordPatches._metaTableCache and _dataAccessByTable — so request 2 builds brand NEW
+// NCLMetaTable instances for every table. TestExecutor._depCompanyBaselineCache sits OUTSIDE
+// that reset (deliberately — it is the #1867 process-lifetime cache that makes a warm
+// second app-group/request skip re-running dependency Install triggers). Its
+// InstallBaselineSnapshot stores, per table, BaselineTable(TableId, MetaTable, Rows) with
+// MetaTable being the NCLMetaTable object captured on request 1. RestoreInstallBaselineSnapshot
+// used that captured object DIRECTLY — never re-resolving it against the CURRENT process
+// epoch's live NCLMetadata caches — to construct the table's data access
+// (`_mCreateTempDataAccess.Invoke(source, new[] { table.MetaTable })`) and every restored row's
+// ReadOnlyRecordBuffer. #2478 is what usually makes a shape drift observable (a precompiled
+// tableextension merge silently dropped on request 2), but the underlying defect — trusting a
+// captured object reference across a request boundary the runtime has already invalidated — is
+// real independent of #2478: any warm-reload scenario where a table's AL source genuinely
+// changes shape between two requests hits it too, which is what this test forces directly.
+//
+// The on-disk install-baseline tier (RecordPatches.InstallBaselineDisk.cs,
+// TryDeserializeInstallBaselineSnapshot) already re-resolves every table through
+// EnsureTableInMetadataCache(tableId) and refuses to restore when FieldCount doesn't match —
+// exactly the reconciliation the in-memory path was missing. RestoreInstallBaselineSnapshot now
+// does the same: re-resolve, and throw loudly (.claude/rules/loud-failures.md) rather than
+// silently restore rows against a shape it cannot reconcile — RestoreInstallBaselineSnapshot has
+// no MISS-fallback path to recompute from, so a silent reconciliation attempt would risk
+// misaligning field values instead of refusing outright.
+//
+// Why a direct unit test, not a spawned --server process against real dependency Install
+// triggers writing rows
+// ------------------------------------------------------------------------------------------
+// A real end-to-end repro needs a genuinely PRECOMPILED dependency .app with an executable
+// Install-trigger body — .claude/rules/no-base-app-in-csharp-tests.md forbids reaching for
+// Base Application to get one, and hand-authoring a fresh compiled .app with real IL is a much
+// larger undertaking than the defect requires proving. The defect is entirely about metadata
+// object identity at restore time, independent of whether any row was ever install-trigger
+// seeded, so this test drives RecordPatches' own snapshot/restore entry points directly (the
+// same technique RecordPatchesWarmReloadExtensionIndexTests / #2478 and
+// RecordPatchesPrecompiledTableExtEvictionTests / #2126 already use), forcing the exact
+// "table shape changed between two --server requests" scenario rather than relying on #2478's
+// specific tableextension-merge mechanism to manufacture the drift.
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class RecordPatchesWarmReloadInstallBaselineTests : IDisposable
+{
+    private readonly BcEngineFixture _engine;
+    private readonly string _root;
+
+    public RecordPatchesWarmReloadInstallBaselineTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-2480-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private static void WriteOneFieldTable(string dir, int tableId, string tableName)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "T.al"), $$"""
+            table {{tableId}} "{{tableName}}"
+            {
+                fields
+                {
+                    field(1; "No."; Code[20]) { }
+                }
+                keys
+                {
+                    key(PK; "No.") { Clustered = true; }
+                }
+            }
+            """);
+    }
+
+    private static void WriteTwoFieldTable(string dir, int tableId, string tableName)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "T.al"), $$"""
+            table {{tableId}} "{{tableName}}"
+            {
+                fields
+                {
+                    field(1; "No."; Code[20]) { }
+                    field(2; "Extra"; Code[10]) { }
+                }
+                keys
+                {
+                    key(PK; "No.") { Clustered = true; }
+                }
+            }
+            """);
+    }
+
+    [SkippableFact]
+    public void RestoreInstallBaselineSnapshot_ThrowsWhenTableShapeChangedAcrossReload()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // 93920-93921: process-wide unique among AlRunner.Tests statics — 939xx is also used
+        // by RecordPatchesPrecompiledTableExtEvictionTests.cs (93900-93902) and
+        // RecordPatchesWarmReloadExtensionIndexTests.cs (93910-93912).
+        const int tableId = 93920;
+        const string tableName = "Bug2480 Base";
+
+        var dir = Path.Combine(_root, "neg");
+        WriteOneFieldTable(dir, tableId, tableName);
+        RecordPatches.AddSourceDir(dir);
+
+        var v1 = RecordPatches.EnsureTableInMetadataCache(tableId);
+        Assert.NotNull(v1);
+        var fieldCount1 = v1!.FieldCount;
+
+        var source = RecordPatches.ResolveSkeletonDataAccessSource();
+        Assert.NotNull(source);
+
+        // A snapshot exactly as TestExecutor._depCompanyBaselineCache would hold one: no rows
+        // needed to prove the defect — RestoreInstallBaselineSnapshot binds the table's data
+        // access to `table.MetaTable` unconditionally, before it ever looks at Rows.
+        var snapshot = new RecordPatches.InstallBaselineSnapshot(
+            new List<RecordPatches.BaselineSource>
+            {
+                new(source!, new List<RecordPatches.BaselineTable>
+                {
+                    new(tableId, v1, Array.Empty<NavValue[]>()),
+                }),
+            },
+            IsolatedStorage: null, RecordLinks: null, AutoIncrement: null);
+
+        // ── SIMULATE THE --server / --watch PER-REQUEST RESET ──────────────────────────
+        // TestExecutor._depCompanyBaselineCache (holding `snapshot` above) is a process
+        // static that NO reset touches — exactly like production between two runTests
+        // requests to one warm server process.
+        RecordPatches.ResetForReload();
+
+        // Request 2's bundle load re-registers source — but the table's AL source genuinely
+        // changed shape (a developer edited it between requests), so the CURRENT process
+        // epoch's metatable for this id is now a different SHAPE, not just a different object.
+        WriteTwoFieldTable(dir, tableId, tableName);
+        RecordPatches.AddSourceDir(dir);
+        var v2 = RecordPatches.EnsureTableInMetadataCache(tableId);
+        Assert.NotNull(v2);
+        Assert.NotEqual(fieldCount1, v2!.FieldCount); // sanity: the shape genuinely changed
+
+        // [THEN] restoring the request-1 snapshot must refuse rather than silently bind the
+        // live process to a stale-shaped NCLMetaTable object. Before the fix this does not
+        // throw at all — RestoreInstallBaselineSnapshot used `table.MetaTable` (v1) directly.
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => RecordPatches.RestoreInstallBaselineSnapshot(snapshot));
+        Assert.Contains(tableId.ToString(), ex.Message);
+        Assert.Contains(fieldCount1.ToString(), ex.Message);
+        Assert.Contains(v2.FieldCount.ToString(), ex.Message);
+    }
+
+    [SkippableFact]
+    public void RestoreInstallBaselineSnapshot_SucceedsWhenTableShapeUnchangedAcrossReload()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // Distinct id range from the negative fact above so the two tests' shared statics
+        // (_parsedTables / _metaTableCache) cannot interfere with each other.
+        const int tableId = 93921;
+        const string tableName = "Bug2480 Base Stable";
+
+        var dir = Path.Combine(_root, "pos");
+        WriteOneFieldTable(dir, tableId, tableName);
+        RecordPatches.AddSourceDir(dir);
+
+        var v1 = RecordPatches.EnsureTableInMetadataCache(tableId);
+        Assert.NotNull(v1);
+
+        var source = RecordPatches.ResolveSkeletonDataAccessSource();
+        Assert.NotNull(source);
+
+        var snapshot = new RecordPatches.InstallBaselineSnapshot(
+            new List<RecordPatches.BaselineSource>
+            {
+                new(source!, new List<RecordPatches.BaselineTable>
+                {
+                    new(tableId, v1, Array.Empty<NavValue[]>()),
+                }),
+            },
+            IsolatedStorage: null, RecordLinks: null, AutoIncrement: null);
+
+        RecordPatches.ResetForReload();
+
+        // Request 2 re-registers the IDENTICAL table definition — the common warm-reload case
+        // (only some OTHER file in the bundle changed). The object is rebuilt fresh either way
+        // (ResetForReload always clears _metaTableCache), but the SHAPE is unchanged.
+        WriteOneFieldTable(dir, tableId, tableName);
+        RecordPatches.AddSourceDir(dir);
+        var v2 = RecordPatches.EnsureTableInMetadataCache(tableId);
+        Assert.NotNull(v2);
+        Assert.Equal(v1!.FieldCount, v2!.FieldCount); // sanity: shape genuinely unchanged
+
+        // [THEN] restore must still succeed — the fix re-resolves against the live cache
+        // instead of refusing outright just because the OBJECT is not the one captured on
+        // request 1.
+        var restoreEx = Record.Exception(() => RecordPatches.RestoreInstallBaselineSnapshot(snapshot));
+        Assert.Null(restoreEx);
+    }
+}

--- a/AlRunner.Tests/ServerAffectedSelectionMultiSourcePathsTests.cs
+++ b/AlRunner.Tests/ServerAffectedSelectionMultiSourcePathsTests.cs
@@ -1,0 +1,166 @@
+// ServerAffectedSelectionMultiSourcePathsTests — proves part of #2479: a warm --server
+// process's affectedOnly narrowing must survive an edit to a DEPENDENCY app when the request
+// has more than one sourcePaths entry (the app + separate test-app shape the README
+// documents as supported).
+//
+// Root cause
+// ------------------------------------------------------------------------------------------
+// RunBundleForServer builds `selectionEnvironmentKey` — the signal affectedOnly's per-test
+// coverage baseline uses to decide whether "the resolved environment changed in a way
+// per-test coverage can't reason about" — from `effectivePkgDirs`, the FULL resolved package
+// cache dir list. For a multi-sourcePaths request, RunLayeredPrePass/BuildSiblingSourceDeps
+// (Program.cs) synthesize one workspace directory PER dependency app, under CacheRoots'
+// "workspace-deps" root, and add it to the process-wide packageCacheDirs — that
+// directory's PATH is keyed on the dependency's own source CONTENT, so it changes every time
+// the dependency is edited, and old entries are never removed (the process-lifetime list only
+// grows across requests). Folding that directory into the environment key made every
+// dependency edit look like an "environment changed" event, permanently forcing
+// affectedOnly to re-run the WHOLE closure on every later request — even though the
+// incremental change model had ALREADY identified precisely which object changed
+// (changedObjects was populated correctly; forcedFull was still true).
+//
+// The fix excludes every directory under the workspace-deps root from the environment key
+// (effectivePkgDirs itself is untouched, so dependency resolution still sees them).
+//
+// This is the multi-sourcePaths sibling of ServerAffectedSelectionTests.cs, which only ever
+// sends a single sourcePaths entry and therefore never exercises RunLayeredPrePass at all.
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class ServerAffectedSelectionMultiSourcePathsTests
+{
+    private static string MakeAppBundle(string root, string helperBody)
+    {
+        var dir = Path.Combine(root, "app");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "a1b2c3d4-6001-4a11-9111-111111111111",
+          "name": "Multi Affected App SX",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 60360, "to": 60369 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Helper.al"), helperBody);
+        return dir;
+    }
+
+    private static string MakeTestAppBundle(string root)
+    {
+        var dir = Path.Combine(root, "test-app");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "a1b2c3d4-6002-4a11-9222-222222222222",
+          "name": "Multi Affected Test App SX",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "a1b2c3d4-6001-4a11-9111-111111111111", "name": "Multi Affected App SX",
+              "publisher": "AL Runner", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 60370, "to": 60379 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Tests.al"), """
+        codeunit 60370 "Multi Affected Tests SX"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure OnlyA()
+            var
+                H: Codeunit "Multi Affected Helper SX";
+            begin
+                if H.Value() <> 1 then
+                    Error('OnlyA failed');
+            end;
+        }
+        """);
+        return dir;
+    }
+
+    private static string RunTestsRequest(string appDir, string testAppDir)
+        => JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            sourcePaths = new[] { appDir, testAppDir },
+            packagePaths = Array.Empty<string>(),
+            affectedOnly = true,
+            perTestCoverage = true,
+        });
+
+    [SkippableFact]
+    public async Task AffectedOnly_DependencyEditBetweenRequests_StillNarrows()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-server-affected-multi", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var appDir = MakeAppBundle(root, """
+        codeunit 60360 "Multi Affected Helper SX"
+        {
+            procedure Value(): Integer
+            begin
+                exit(1);
+            end;
+        }
+        """);
+        var testAppDir = MakeTestAppBundle(root);
+
+        await using var server = await CliServer.StartAsync(new[] { "--no-cache" });
+
+        // Request 1: first cycle, necessarily a full run (no baseline yet).
+        var lines1 = await server.SendRequestStreamingAsync(RunTestsRequest(appDir, testAppDir));
+        var (events1, summary1) = ProtocolV2Streaming.Split(lines1);
+        Assert.Single(events1);
+        Assert.Equal("pass", events1[0].GetProperty("status").GetString());
+
+        // Edit the DEPENDENCY app (not the test-app) — a real content change, not a no-op.
+        File.WriteAllText(Path.Combine(appDir, "Helper.al"), """
+        codeunit 60360 "Multi Affected Helper SX"
+        {
+            procedure Value(): Integer
+            var
+                X: Integer;
+            begin
+                X := 1;
+                exit(X);
+            end;
+        }
+        """);
+
+        // Request 2: same warm server process, same two sourcePaths.
+        var lines2 = await server.SendRequestStreamingAsync(RunTestsRequest(appDir, testAppDir));
+        var (events2, summary2) = ProtocolV2Streaming.Split(lines2);
+        Assert.Single(events2);
+        Assert.Equal("pass", events2[0].GetProperty("status").GetString());
+
+        Assert.True(summary2.TryGetProperty("selection", out var selection2), string.Join(" | ", lines2));
+        // [THEN] narrowing survives a dependency edit — before the fix, the synthesized
+        // workspace directory RunLayeredPrePass adds for the edited dependency changed
+        // selectionEnvironmentKey, and forcedFull was true with reason "coverage baseline
+        // environment changed (BC version/artifact/package cache)" despite changedObjects
+        // already correctly identifying the edited codeunit.
+        Assert.False(selection2.GetProperty("forcedFull").GetBoolean(),
+            $"expected affectedOnly to narrow despite the dependency edit, got: {string.Join(" | ", lines2)}");
+        Assert.Contains(selection2.GetProperty("changedObjects").EnumerateArray().Select(x => x.GetString()),
+            x => x != null && x.Contains("Multi Affected Helper SX", StringComparison.Ordinal));
+
+        // Request 3: nothing changed — narrowing must still hold (proves the fix didn't
+        // just get lucky on request 2's specific key, but leaves a STABLE key going forward).
+        var lines3 = await server.SendRequestStreamingAsync(RunTestsRequest(appDir, testAppDir));
+        var (events3, summary3) = ProtocolV2Streaming.Split(lines3);
+        Assert.True(summary3.TryGetProperty("selection", out var selection3), string.Join(" | ", lines3));
+        Assert.False(selection3.GetProperty("forcedFull").GetBoolean(),
+            $"expected narrowing to remain stable on an unchanged re-request, got: {string.Join(" | ", lines3)}");
+    }
+}

--- a/AlRunner/Patches/RecordPatches.BcAppFallback.cs
+++ b/AlRunner/Patches/RecordPatches.BcAppFallback.cs
@@ -55,6 +55,31 @@ public static partial class RecordPatches
     private static readonly HashSet<int> _bcMissCache = new();
 
     /// <summary>
+    /// Drop every lazily-built BC .app index so the next lookup rebuilds them from
+    /// <see cref="_bcAppPaths"/> from scratch — including <see cref="_bcSymbolExtensionIndexBuilt"/>,
+    /// which is what actually re-triggers <see cref="EnsureBcSymbolExtensionIndex"/> (its only
+    /// call site is inside <see cref="EnsureBcSymbolTableIndex"/>, gated by
+    /// <c>_bcSymbolTableIndex != null</c> — so nulling the table index without ALSO resetting
+    /// the extension-built flag would still short-circuit the merge).
+    ///
+    /// Two callers, and #2478 was exactly this pair being out of sync: <see cref="AddBcAppPath"/>
+    /// already invalidated all four fields inline when a NEW .app was registered; <c>ResetForReload</c>
+    /// (RecordPatches.cs) independently reset only <c>_bcSymbolExtensionIndexBuilt</c>, leaving
+    /// <c>_bcSymbolTableIndex</c> populated — so on a warm --server/--watch reload,
+    /// EnsureBcSymbolTableIndex's own-index guard returned early forever, and the extension merge
+    /// silently never ran again for the rest of the process's life. Routing both call sites
+    /// through one method makes that divergence impossible to reintroduce.
+    /// Must be called while holding <see cref="_bcTableIndexLock"/>.
+    /// </summary>
+    private static void InvalidateBcAppIndexes()
+    {
+        _bcTableIndex = null;
+        _bcSymbolTableIndex = null;
+        _bcSymbolQueryIndex = null;
+        _bcSymbolExtensionIndexBuilt = false;
+    }
+
+    /// <summary>
     /// Register a BC dependency .app path so its AL table sources can be used
     /// as a fallback when a test's own src/ doesn't define a referenced table.
     /// Called from Program.cs after DependencyLoader.LoadAll.
@@ -86,10 +111,7 @@ public static partial class RecordPatches
                         enumSymbol.DefaultImplementations?.ToArray(),
                         enumSymbol.UnknownImplementations?.ToArray());
                 // Invalidate the indexes so newly-added .app gets picked up on next miss.
-                _bcTableIndex = null;
-                _bcSymbolTableIndex = null;
-                _bcSymbolQueryIndex = null;
-                _bcSymbolExtensionIndexBuilt = false;
+                InvalidateBcAppIndexes();
             }
         }
     }

--- a/AlRunner/Patches/RecordPatches.InstallBaseline.cs
+++ b/AlRunner/Patches/RecordPatches.InstallBaseline.cs
@@ -349,7 +349,36 @@ public static partial class RecordPatches
                 static _ => new ConcurrentDictionary<int, object>());
             foreach (var table in source.Tables)
             {
-                var dataAccess = _mCreateTempDataAccess!.Invoke(source.Source, new[] { table.MetaTable })!;
+                // #2480: table.MetaTable was captured in a PREVIOUS process epoch — possibly
+                // a prior --server/--watch request, since this snapshot can be
+                // TestExecutor's process-lifetime dep+company cache, which no per-request
+                // reset touches. BcRuntime.ResetForNewBundleReload() always rebuilds
+                // _metaTableCache from scratch, so table.MetaTable may no longer be the
+                // object registered in the live NCLMetadata caches even when its SHAPE is
+                // unchanged, and if the table's AL source genuinely changed shape between
+                // requests the stale object's field layout no longer matches what live AL
+                // code expects (#2478 is the most common way that happens, but not the
+                // only one). Re-resolve against the CURRENT process's cache — mirroring the
+                // on-disk restore path's own reconciliation
+                // (RecordPatches.InstallBaselineDisk.cs, TryDeserializeInstallBaselineSnapshot)
+                // — and refuse outright when the live shape doesn't match what was captured:
+                // this method has no MISS-fallback path to recompute from, so silently
+                // proceeding with a shape it cannot reconcile would misalign field values
+                // instead of refusing (.claude/rules/loud-failures.md).
+                var liveMeta = EnsureTableInMetadataCache(table.TableId)
+                    ?? throw new InvalidOperationException(
+                        $"[RecordPatches] install-baseline restore: no live NCLMetaTable for " +
+                        $"table {table.TableId} in this process — the cached snapshot cannot be restored.");
+                var capturedMeta = (NCLMetaTable)table.MetaTable;
+                if (liveMeta.FieldCount != capturedMeta.FieldCount)
+                    throw new InvalidOperationException(
+                        $"[RecordPatches] install-baseline restore: table {table.TableId} now has " +
+                        $"{liveMeta.FieldCount} field(s) in this process, the cached snapshot was " +
+                        $"captured with {capturedMeta.FieldCount} — its shape changed since the " +
+                        "snapshot was captured (e.g. a warm --server/--watch reload of an edited " +
+                        "dependency), so the cached install baseline is stale and unsafe to restore.");
+
+                var dataAccess = _mCreateTempDataAccess!.Invoke(source.Source, new object[] { liveMeta })!;
                 perTable[table.TableId] = dataAccess;
                 var provider = GetDataProvider(dataAccess)!;
                 var insert = provider.GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance)
@@ -372,7 +401,7 @@ public static partial class RecordPatches
                 foreach (var values in table.Rows)
                 {
                     var readOnly = new ReadOnlyRecordBuffer(
-                        (NCLMetaApplicationObject)table.MetaTable, CloneValues(values));
+                        (NCLMetaApplicationObject)liveMeta, CloneValues(values));
                     var mutable = _ibMutableBufferCtor.Invoke(new object[] { readOnly });
                     insert.Invoke(provider, new object?[] { 0, mutable, insertOptions, null });
                     restoredRows++;

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -170,7 +170,16 @@ public static partial class RecordPatches
         _parsedTables.Clear();
         _parsedExtensionFields.Clear();
         _extensionIdsByBaseTable.Clear();
-        _bcSymbolExtensionIndexBuilt = false; // re-merge BC precompiled extensions on next build
+        // #2478: must invalidate _bcSymbolTableIndex too, not just _bcSymbolExtensionIndexBuilt —
+        // EnsureBcSymbolExtensionIndex's only call site is inside EnsureBcSymbolTableIndex, gated
+        // by `_bcSymbolTableIndex != null`. Leaving that index populated made the flag reset above
+        // a no-op forever: on request 2 of a warm --server/--watch process, EnsureBcSymbolTableIndex
+        // short-circuited before ever reaching the extension merge again, so precompiled
+        // tableextension fields silently vanished from every metatable from the second request on.
+        // Shares InvalidateBcAppIndexes with AddBcAppPath (RecordPatches.BcAppFallback.cs) so the
+        // two call sites can't drift apart again the way they did here.
+        lock (_bcTableIndexLock)
+            InvalidateBcAppIndexes();
         _fieldTriggersWiredTables.Clear();
         _parsedPages.Clear();
         _parsedPageExtensions.Clear();

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3644,6 +3644,15 @@ return strictExitCode ? computedExitCode : 0;
         return results;
     }
 
+    // True when `path` is `root` itself or nested somewhere under it. Both are
+    // full-pathed by the caller; trailing-separator-insensitive.
+    static bool IsUnderDirectory(string path, string root)
+    {
+        var normalizedRoot = root.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return string.Equals(path, normalizedRoot, StringComparison.OrdinalIgnoreCase)
+            || path.StartsWith(normalizedRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+    }
+
     // Compile + run one bundle, resetting bundle-derived caches first so an edited
     // same-identity bundle is picked up (server reload contract). Mirrors the
     // bundled-mode path of the normal run loop for a single bundle. The run step
@@ -3674,9 +3683,33 @@ return strictExitCode ? computedExitCode : 0;
             .Concat(packageCacheDirs)
             .Distinct()
             .ToList();
+        // #2479: the environment key gates affectedOnly's per-test coverage baseline on
+        // "did the resolved environment change in a way per-test coverage can't reason
+        // about" (BC version/artifact/configured package caches) — deliberately a COARSER
+        // signal than the incremental change model, which already answers "did a
+        // dependency's CONTENT change" precisely via changedObjects. RunLayeredPrePass /
+        // BuildSiblingSourceDeps (multi-sourcePaths requests only) give each impl a
+        // content-keyed workspace dir under CacheRoots "workspace-deps" and add it to the process-wide
+        // packageCacheDirs — that path changes every time the impl's own source changes,
+        // since it is keyed on exactly that content, and OLD entries are never removed (the
+        // process-lifetime list only ever grows across requests). Folding either into this
+        // key made every dependency edit look like an "environment changed" event too,
+        // forcing a full re-run of the WHOLE multi-bundle request on the NEXT request even
+        // though changedObjects had already identified precisely what changed — the
+        // environment check re-litigated a question the incremental model had already
+        // answered correctly. Exclude every dir under the workspace-deps root (not just
+        // the ones this specific request happened to add — a per-request list would still
+        // leave a PRIOR request's stale entry in effectivePkgDirs, which is exactly what a
+        // first attempt at this fix, scoped only to "this request's own additions", missed);
+        // effectivePkgDirs above is untouched, so actual dependency resolution still sees
+        // every synthesized dir it needs.
+        var workspaceDepsRoot = AlRunner.Infrastructure.CacheRoots.Resolve("workspace-deps");
+        var envKeyPkgDirs = effectivePkgDirs
+            .Where(d => !IsUnderDirectory(Path.GetFullPath(d), workspaceDepsRoot))
+            .ToList();
         var selectionEnvironmentKey =
             $"{AlRunner.Infrastructure.BcArtifacts.SelectedVersion}|{AlRunner.Infrastructure.BcArtifacts.ServiceTierDir}|"
-            + string.Join("|", effectivePkgDirs
+            + string.Join("|", envKeyPkgDirs
                 .Select(d => Path.GetFullPath(d))
                 .OrderBy(d => d, StringComparer.Ordinal));
 


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.99.0
Closes #2478
Closes #2480

All three issues in the `area: warm-server-reload` cluster share one boundary: what happens
to process state between two `runTests` requests on one `--server` process (and the same
code path `--watch` uses per iteration). Worked in the maintainer-specified order: #2478
first (it makes #2480's stale binding observable), then #2480, then #2479.

## #2478 — precompiled tableextension fields missing from request 2 on

`RecordPatches.ResetForReload()` cleared `_parsedExtensionFields` and reset
`_bcSymbolExtensionIndexBuilt = false`, but left `_bcSymbolTableIndex` populated. The only
call site for `EnsureBcSymbolExtensionIndex()` sits inside `EnsureBcSymbolTableIndex()`,
gated by `_bcSymbolTableIndex != null` — so once that index survived a reset, the extension
merge never ran again for the rest of the process's life, and every metatable built from the
second request on silently dropped its precompiled tableextension fields.

Fix: route both `AddBcAppPath` (which already invalidated all four related fields inline)
and `ResetForReload` through one `InvalidateBcAppIndexes()` helper, so the two invalidation
sites can't drift apart again.

Proving test: `RecordPatchesWarmReloadExtensionIndexTests` reproduces the exact defective
call chain via `RecordPatches`' own public entry points (the same synthetic in-process `.app`
technique `RecordPatchesPrecompiledTableExtEvictionTests` / #2126 already uses, so no Base
Application dependency is needed) — simulates two requests around a direct call to
`ResetForReload()`, and confirms the extension field still resolves on request 2 (RED before
the fix: `extension field 50 from extension 93912 not found`).

## #2480 — install-baseline rows restored against a stale metatable object

`TestExecutor._depCompanyBaselineCache` is a process-lifetime cache no per-request reset
touches (by design — it's what makes a warm request skip re-running dependency Install
triggers). Its `InstallBaselineSnapshot` stores `BaselineTable(TableId, MetaTable, Rows)`
with `MetaTable` captured on a PREVIOUS request. `RestoreInstallBaselineSnapshot` used that
captured object directly to construct the table's data access and every restored row's
`ReadOnlyRecordBuffer`, even though `ResetForNewBundleReload()` rebuilds `_metaTableCache`
from scratch every request — so a restore always binds the live process to an object no
longer registered anywhere. #2478 is the most common way that becomes an OBSERVABLE field
mismatch (`NavNCLInvalidComparisonException`), but the underlying defect — trusting a
captured reference across a request boundary the runtime has already invalidated — is real
independent of #2478.

Fix mirrors the on-disk restore path's own reconciliation
(`RecordPatches.InstallBaselineDisk.cs`): re-resolve every table through
`EnsureTableInMetadataCache(tableId)` at restore time and throw loudly when `FieldCount`
doesn't match, rather than silently proceeding with a shape it cannot reconcile (this method
has no MISS-fallback path to recompute from).

Proving tests: `RecordPatchesWarmReloadInstallBaselineTests` — a negative fact forces a
genuine shape change between two simulated requests (RED before the fix: no exception is
thrown at all — the restore silently binds to the stale 1-field object even though the live
metatable now has 2 fields) and a positive fact proves the common case (object identity
changes on every reload, shape doesn't) still restores successfully.

## #2479 — affectedOnly / incremental compile for multi-sourcePaths requests (partial)

**#2479 stays open after this PR.** I found and fixed one concrete, reproducible defect in the
same mechanism area, but could not reproduce the full symptom from the issue's own Pageworks
repro (1012 tests: `affectedOnly` never narrows, for either bundle, no matter what changes)
with a minimal synthetic fixture.

**What I found and fixed:** `RunBundleForServer`'s `selectionEnvironmentKey` — the signal
`affectedOnly`'s per-test coverage baseline uses to decide whether "the resolved environment
changed in a way per-test coverage can't reason about" — was built from the full
`effectivePkgDirs` list. For a multi-`sourcePaths` request, `RunLayeredPrePass` /
`BuildSiblingSourceDeps` give each dependency a content-keyed workspace directory (under
`CacheRoots` `"workspace-deps"`) and add it to the process-wide `packageCacheDirs`; that
path changes every time the dependency's own source changes, and old entries are never
removed. Folding it into the environment key made every dependency edit look like an
"environment changed" event, forcing a full re-run of the whole request even though the
incremental change model had already identified precisely what changed
(`changedObjects` was populated correctly; `forcedFull` was still `true` with reason
`"coverage baseline environment changed (BC version/artifact/package cache)"`).

Fixed by excluding every directory under the workspace-deps root from the environment key —
`effectivePkgDirs` itself is untouched, so dependency resolution still sees them.

Proving test: `ServerAffectedSelectionMultiSourcePathsTests` — app + separate test-app
sourcePaths, edits the dependency app between two `--server` requests, confirms narrowing
survives (RED before the fix, with the exact reason string above; GREEN after; a third
request with nothing changed confirms the fix leaves a stable key going forward, not just a
lucky one-off).

**What I could not reproduce.** Following the coordinator's distinguishing guidance
(single-`sourcePaths` `--server` vs multi-path `--watch`, since external measurement showed
`--watch` engaging the incremental path correctly for a single 2606-test bundle), I ran five
separate minimal multi-bundle `--server` repros against a from-scratch synthetic app +
test-app pair (no Base Application, no real dependency scanner involvement):

1. Edit only the test-app's own file between two requests — narrows correctly.
2. Same, with the on-disk AL-output cache warmed from an earlier throwaway invocation before
   the server started (so the "app" bundle's request 1 is a cache HIT) — narrows correctly.
3. Same scenario driven under `--watch` instead of `--server` — no "FULL REBUILD" reported
   on cycle 2 (RAD fast path taken).
4. A test-app file declaring TWO objects (disqualifying it from the RAD "exactly 1 object per
   file" fast path), editing a DIFFERENT single-object file in the same bundle — narrows
   correctly.
5. Editing the dependency app's own file — this is the one that reproduced (fixed above).

None of 1-4 reproduced "no previous per-test coverage baseline" / "no incremental baseline
yet" persisting indefinitely for either bundle, which is the Pageworks report's actual
symptom. My working hypothesis is that this needs the SCALE or specific object-per-file shape
of a large real test app to trigger — a `moduleName` collision, a classification edge case in
`TryEmitIncremental`'s fast path, or something in how `RunLayeredPrePass`/
`BuildSiblingSourceDeps` interact with a larger dependency graph that a 2-file/2-bundle
fixture can't exercise. I did not want to guess at a fix for a mechanism I could not observe
directly (`.claude/rules/no-assumption-fixes.md`), so #2479 stays open with this partial fix
landed and the repro gap documented here for whoever picks it up next — a realistic
multi-file/multi-object test-app fixture (ideally derived from an actual failing case) is
the concrete next step named in the issue's own body.

## Fix the shape, not just the reported line

- Checked every other `_bcSymbolTableIndex`/`_bcSymbolQueryIndex`/`_bcSymbolExtensionIndexBuilt`
  invalidation site (`RegisterBundleQuerySymbolsJson`) — it only touches
  `_bcSymbolQueryIndex`, which has no paired "extension index built" flag, so it isn't the
  same divergent-pair shape as #2478. No change needed there.
- Checked every other `_mCreateTempDataAccess.Invoke(..., meta)` call site for the same
  "captured object survives a reload boundary via a process-lifetime cache" shape as #2480.
  The other call sites (`RecordPatches.CompanySystemTable.cs`,
  `RecordPatches.TestDataHydration.cs`) all resolve their `meta` parameter fresh within the
  same call, from the caller, in the same process epoch — `TestExecutor._depCompanyBaselineCache`
  is the only PROCESS-LIFETIME cache holding a captured `NCLMetaTable` object across a reload
  boundary, and it's now fixed at its sole consumption point.

## Test plan

- [x] RED → GREEN for #2478 (`RecordPatchesWarmReloadExtensionIndexTests`)
- [x] RED → GREEN for #2480 (`RecordPatchesWarmReloadInstallBaselineTests`, both directions)
- [x] RED → GREEN for the #2479 environment-key defect (`ServerAffectedSelectionMultiSourcePathsTests`)
- [x] No regression: `RecordPatchesPrecompiledTableExtEvictionTests`,
  `InstallSeedDepCompanyCacheTests`, `InstallBaselineDiskCacheTests`,
  `InstallBaselineVirtualTableExclusionTests`, `TestDataLazyHydrationTests`,
  `ServerAffectedSelectionTests`, `ServerTests`, `ServerCancelTests`, `ServerProtocol*`,
  `LayeredSourceChainTests`, `LayeredCacheTests`, `SourceDepSymbolsWithoutPackageCacheTests`,
  `LayeredDepManifestTests`, `SiblingSourceDepProvisioningReportingTests` — all pass locally.
- [ ] CI (all BC versions)

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
