### PR TITLE
test(subprocess): drain the async output readers before reading captured stdout

### DIFF
--- a/AlRunner.Tests/AggregatePermissionSetVirtualTableTests.cs
+++ b/AlRunner.Tests/AggregatePermissionSetVirtualTableTests.cs
@@ -67,6 +67,14 @@ public sealed class AggregatePermissionSetVirtualTableTests
             try { proc.Kill(entireProcessTree: true); } catch { }
             throw new TimeoutException("al-runner did not exit within 120s.");
         }
+        // WaitForExit(int) returns as soon as the process exits and does NOT wait for the
+        // async BeginOutputReadLine/BeginErrorReadLine callbacks to drain -- only the
+        // parameterless overload does. Without this the last stdout lines can still be in
+        // flight when we read outSb, so an Assert.Contains on a line the runner definitely
+        // printed fails intermittently, and more often the more loaded the machine is.
+        // That made main red on a DIFFERENT pre-28.0 leg on three consecutive merges.
+        // 65 of the 67 subprocess-spawning test files here already do this; these two did not.
+        proc.WaitForExit();
         return (proc.ExitCode, outSb.ToString(), errSb.ToString());
     }
 

--- a/AlRunner.Tests/CountryFlagTests.cs
+++ b/AlRunner.Tests/CountryFlagTests.cs
@@ -56,6 +56,14 @@ public sealed class CountryFlagTests
             try { proc.Kill(entireProcessTree: true); } catch { }
             throw new TimeoutException("al-runner did not exit within 120s.");
         }
+        // WaitForExit(int) returns as soon as the process exits and does NOT wait for the
+        // async BeginOutputReadLine/BeginErrorReadLine callbacks to drain -- only the
+        // parameterless overload does. Without this the last stdout lines can still be in
+        // flight when we read outSb, so an Assert.Contains on a line the runner definitely
+        // printed fails intermittently, and more often the more loaded the machine is.
+        // That made main red on a DIFFERENT pre-28.0 leg on three consecutive merges.
+        // 65 of the 67 subprocess-spawning test files here already do this; these two did not.
+        proc.WaitForExit();
         return (proc.ExitCode, outSb.ToString(), errSb.ToString());
     }
 


### PR DESCRIPTION
Closes #2496

`main` has been intermittently red since 2026-09-03 07:35. Three consecutive merges each failed on a **different** pre-28.0 BC leg, each on the **same single test**:

| merge | PR | failing leg |
|---|---|---|
| `d5ec5fde` | #2477 | BC 27.3 |
| `28cdcf65` | #2486 | BC 27.0 |
| `a1b39d02` | #2483 | BC 27.5 |

`AggregatePermissionSetVirtualTableTests.AggregatePermissionSet_SourceDeclaredPermissionSet_BothTestsPass`, always with `Assert.Contains() Failure: Not found: "PASS  Codeunit60702.AggregatePermissionSe"...`

A failing-leg set that moves while the failing test does not is a load-dependent flake, not a regression in the commits under it.

## Cause

`Process.WaitForExit(int)` returns as soon as the process exits and does **not** wait for the async `BeginOutputReadLine`/`BeginErrorReadLine` callbacks to drain. Only the parameterless overload does. Two helpers read their captured stdout straight after the timed wait, so the runner's last lines could still be in flight.

That matches every symptom: `exit == 0` passes because the exit code is available immediately, while the `Assert.Contains` on a line the runner definitely printed fails; it is intermittent; and it gets likelier the more loaded the machine is, which is why it lands on whichever pre-28.0 leg is slowest and never the same one twice.

## Fix

Add the drain to the two files that lacked it. **No production code changes.**

This restores the repo's own convention rather than inventing one: 67 files in `AlRunner.Tests` spawn the runner with async readers, and **65 already call the parameterless `WaitForExit()`**. These two were the exceptions — `AggregatePermissionSetVirtualTableTests.cs` (added by #2477, the one going red) and `CountryFlagTests.cs` (same helper shape, same latent bug, had not surfaced yet).

Each call site now carries a comment explaining why the second wait is required, so the next copy-paste keeps it.

## Verification

Both test classes pass locally: 5/5. The real verification is the three legs that have been failing going green here.

## Follow-up worth considering, deliberately not done here

A guard asserting that every file using `BeginOutputReadLine` also calls the parameterless `WaitForExit()`, so a 66th cannot arrive by copy-paste. Kept out to hold this change narrow while `main` is red.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf