### PR TITLE
test(scheduling): record BcVersionDefaultDocumentationTests' measured weight

### DIFF
--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -159,6 +159,15 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
             // while leaving dispatch order exactly as it was, which is the tail the gate
             // exists to prevent. Carry the observed maximum instead.
             ["StartupOutputReexecDedupTests"] = 61,
+            // #2498: measured 46.6s (27.5) to 62.3s (28.4) on run 33732947853 — it crosses
+            // the 60s freshness threshold only on the slower leg, so it tripped
+            // check-collection-weights.py on 28.4 while staying under it on 27.5. Same
+            // shape as StartupOutputReexecDedupTests directly above, and the same rule
+            // applies: carry the observed MAXIMUM, not the low end. Rounding down to 46
+            // would satisfy the gate while still dispatching it near
+            // UnmeasuredWeightSeconds, which is the single-threaded tail #1887 exists to
+            // prevent.
+            ["BcVersionDefaultDocumentationTests"] = 62,
             // #2178: 3 tests, each spawning a real runner subprocess over a three-app source
             // chain (two of them compile all three apps cold). Measured 53.3s (28.3) to
             // 90.5s (27.5) across the eight legs of its first CI run, where it was absent


### PR DESCRIPTION
Closes #2498

`check-collection-weights.py` failed the BC 28.4 leg on PR #2475 with:

```
STALE CollectionCostOrderer.MeasuredWeightSeconds TABLE (issue #1887)
     62.3s  BcVersionDefaultDocumentationTests
```

The collection is absent from the table, so it falls back to `UnmeasuredWeightSeconds` (30s) and can be dispatched as a single-threaded tail late in a run — the failure #1887 exists to prevent.

## Measured

Run `33732947853`, two legs of the same run: **46.6s (27.5)** and **62.3s (28.4)**. It crosses the 60s freshness threshold only on the slower leg, which is why 28.4 tripped and 27.5 did not.

## Why 62 and not 46

The convention documented on the `StartupOutputReexecDedupTests` entry directly above: carry the observed maximum, not the low end, when the low end sits near the fallback. Rounding down to 46 would satisfy the gate while still dispatching this near `UnmeasuredWeightSeconds` — leaving the tail in place and only silencing the alarm.

## Why this is not in #2475

It surfaced there, but is unrelated to it: that PR's C# suite was fully green (1657/1657) and the leg failed only on this maintenance gate. It does not reproduce on `main`, so it is timing-sensitive rather than caused by any branch. Fixing it centrally keeps #2475's diff on topic and unblocks anyone else who lands on a slow 28.4 runner.

No production code changes.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf