### PR TITLE
fix: Aggregate Permission Set redrives its union on every touch

### DIFF
--- a/AlRunner.Tests/AggregatePermissionSetVirtualTableTests.cs
+++ b/AlRunner.Tests/AggregatePermissionSetVirtualTableTests.cs
@@ -96,6 +96,11 @@ public sealed class AggregatePermissionSetVirtualTableTests
             // Negative: an undeclared role id still fails, not a silent success.
             Assert.Contains(
                 "PASS  Codeunit60702.AggregatePermissionSet_GetOnUndeclaredRoleId_Fails", stdout);
+            // #2473: the table must NOT snapshot at first touch -- a Tenant Permission Set
+            // row inserted after an earlier touch must be visible on a later one, and a
+            // subsequently deleted row must not remain a ghost.
+            Assert.Contains(
+                "PASS  Codeunit60702.AggregatePermissionSet_TenantRowInsertedAfterEarlierTouch_IsVisible", stdout);
             Assert.DoesNotContain("FAIL", stdout);
         }
         finally

--- a/AlRunner.Tests/Fixtures/AggregatePermissionSet/ApsFixtureTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/AggregatePermissionSet/ApsFixtureTests.Codeunit.al
@@ -40,4 +40,57 @@ codeunit 60702 "APS Fixture Tests"
                 AggregatePermissionSet.Scope::System, ThisModule.Id(), 'NO SUCH PERM SET'),
             'Get() must return false for a role id nothing declares');
     end;
+
+    [Test]
+    procedure AggregatePermissionSet_TenantRowInsertedAfterEarlierTouch_IsVisible()
+    // CLAIM (runner mechanism, issue #2473): PopulateAggregatePermissionSetVirtualTable
+    // must NOT snapshot the Tenant Permission Set union at first touch. Before the fix it
+    // gated on a one-shot ConditionalWeakTable flag per in-memory provider, so a SECOND
+    // touch after AL inserted a brand new Tenant Permission Set row was a no-op and the
+    // new row never appeared -- the root of a 14-test cascade in Microsoft's own
+    // Tests-SINGLESERVER Codeunit134614 (see #2357/#2393).
+    var
+        AggregatePermissionSetFirstTouch: Record "Aggregate Permission Set";
+        AggregatePermissionSet: Record "Aggregate Permission Set";
+        AggregatePermissionSetAfterDelete: Record "Aggregate Permission Set";
+        TenantPermissionSet: Record "Tenant Permission Set";
+        EmptyGuid: Guid;
+    begin
+        // An EARLIER, unrelated touch of Aggregate Permission Set, through a DIFFERENT
+        // record variable -- the same shape as the real cascade (#2357/#2393): one test
+        // opens the table first, an unrelated later test then writes Tenant Permission Set
+        // and expects the union to reflect it. A one-shot "populate once" implementation
+        // freezes its answer at THIS moment. Role ID is Code[20] on this table, so the probe
+        // value must fit. Get()'s return value is consumed (not used as a bare statement) so
+        // a miss returns false instead of raising.
+        if AggregatePermissionSetFirstTouch.Get(AggregatePermissionSetFirstTouch.Scope::System, EmptyGuid, 'NOT A REAL ROLE ID') then;
+
+        if TenantPermissionSet.Get(EmptyGuid, 'APS NEW TENANT ROLE') then
+            TenantPermissionSet.Delete();
+
+        Clear(TenantPermissionSet);
+        TenantPermissionSet."App ID" := EmptyGuid;
+        TenantPermissionSet."Role ID" := 'APS NEW TENANT ROLE';
+        TenantPermissionSet.Name := 'APS New Tenant Role';
+        TenantPermissionSet.Assignable := true;
+        TenantPermissionSet.Insert();
+
+        Assert.IsTrue(
+            AggregatePermissionSet.Get(AggregatePermissionSet.Scope::Tenant, EmptyGuid, 'APS NEW TENANT ROLE'),
+            'a Tenant Permission Set row inserted AFTER an earlier touch of Aggregate Permission Set must be visible on a later touch');
+        Assert.AreEqual(
+            'APS New Tenant Role', AggregatePermissionSet.Name,
+            'Name must round-trip from the newly-inserted Tenant Permission Set row');
+
+        // Negative: deleting the row must not leave a ghost behind -- proves the fix fully
+        // redrives the union rather than only ever topping it up. A THIRD, still-untouched
+        // record variable, same reason as AggregatePermissionSetFirstTouch above: a NavRecord
+        // resolves its DataAccess (and this file's populate call) once, on its own first
+        // touch, and caches it thereafter -- reusing `AggregatePermissionSet` here would
+        // prove nothing about a later touch.
+        TenantPermissionSet.Delete();
+        Assert.IsFalse(
+            AggregatePermissionSetAfterDelete.Get(AggregatePermissionSetAfterDelete.Scope::Tenant, EmptyGuid, 'APS NEW TENANT ROLE'),
+            'a Tenant Permission Set row deleted after being visible must not remain a ghost row in Aggregate Permission Set');
+    end;
 }

--- a/AlRunner/Patches/RecordPatches.AggregatePermissionSetVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AggregatePermissionSetVirtualTable.cs
@@ -58,13 +58,36 @@
 //   SINGLESERVER, Microsoft's own AL) runs completely unmodified; only the metadata under it
 //   changes, exactly as RecordPatches.MetadataPermissionSetVirtualTable.cs does for its
 //   sibling table.
+//
+// LIVE, NOT SNAPSHOTTED (issue #2473)
+//   An earlier shape of this file populated the store ONCE per provider (a
+//   ConditionalWeakTable-guarded flag) and never again. That was faithful the moment of
+//   first touch, but "Tenant Permission Set" (2000000165) is an ordinarily-writable table —
+//   AL can Insert/Delete/Rename its rows at any time — and on a real service tier every
+//   later Get()/FindSet() against Aggregate Permission Set re-derives the union fresh, so a
+//   row inserted after the first touch IS visible there. The one-shot guard made it
+//   invisible here instead: the actual root of the 14-test "already bound" cascade in
+//   Codeunit134614, not the event-binding mechanism #2393 ruled out. Every touch now clears
+//   this table's OWN store (ClearProviderInPlace, RecordPatches.TransactionSnapshot.cs —
+//   Tenant/Metadata Permission Set themselves are untouched) and redrives the whole union,
+//   so a later delete/rename of the underlying Tenant Permission Set row cannot leave a
+//   ghost behind either — a top-up-only shape (inserting only NEW keys, never removing
+//   stale ones) would have exactly that gap, the same asymmetry
+//   RecordPatches.AllProfileVirtualTable.cs's own banner documents for a table backed by
+//   AL-writable data.
+//
+//   RecordPatches.MetadataPermissionSetVirtualTable.cs's sibling `_mpsPopulatedByProvider`
+//   guard was audited for the same shape and does NOT have this gap: its rows come from
+//   ParsedPermissionSets (this run's own compiled AL source) and each dependency .app's
+//   SymbolReference.json (EnumerateKnownPermissionSets) — both fixed for the lifetime of one
+//   runner invocation, not runtime-writable AL data, so a repeated top-up there can only
+//   ever re-discover the SAME fixed set, never miss a write that happened after first touch.
 
 using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using AlRunner.Infrastructure;
 using Microsoft.Dynamics.Nav.Runtime;
@@ -74,12 +97,6 @@ namespace AlRunner.Patches;
 public static partial class RecordPatches
 {
     internal const int AggregatePermissionSetVirtualTableId = 2000000167;
-
-    // Per in-memory-provider guard: the drain below is eager and one-shot, so repeated
-    // population attempts (one per lazy touch of the table) must only ever insert once per
-    // provider instance — the same idempotency shape as
-    // RecordPatches.MetadataPermissionSetVirtualTable.cs's own `_mpsPopulatedByProvider`.
-    private static readonly ConditionalWeakTable<object, object> _apsPopulatedByProvider = new();
 
     private static bool _apsReflectionReady;
     private static Type? _apsProviderType;                    // Microsoft.Dynamics.Nav.Runtime.AggregatePermissionSetDataProvider
@@ -110,10 +127,23 @@ public static partial class RecordPatches
                 "Aggregate Permission Set (virtual table 2000000167)",
                 "aggregate-permission-set-virtual-table — data access has no in-memory provider; see docs/scope.md");
 
-        // One materialisation per provider instance — the drain below is eager and yields the
-        // whole union every call, so a second call would try to insert the same rows again.
-        if (_apsPopulatedByProvider.TryGetValue(store, out _)) return;
-        _apsPopulatedByProvider.AddOrUpdate(store, store);
+        // Recompute the WHOLE union fresh on every touch — on a real service tier
+        // Aggregate Permission Set has no persistent state of its own; every Get()/FindSet()
+        // re-derives from Metadata Permission Set and Tenant Permission Set at that moment
+        // (EagerVirtualDataProvider, see the file banner). An earlier shape here gated on a
+        // one-shot "populate once" flag per provider, so the SECOND and every later touch
+        // was a no-op: a Tenant Permission Set row inserted after the first touch never
+        // appeared (#2473) — the actual root of a 14-test cascade in Microsoft's own
+        // Tests-SINGLESERVER Codeunit134614 (#2357/#2393).
+        //
+        // Clearing this table's OWN store (not Tenant/Metadata Permission Set, which are
+        // untouched) before every redrive, rather than a top-up-only insert, also keeps a
+        // later Tenant Permission Set DELETE/RENAME from leaving a ghost row behind here —
+        // the same asymmetric gap RecordPatches.AllProfileVirtualTable.cs's own banner
+        // warns a top-up-only shape would have for a table backed by AL-writable data.
+        // ClearProviderInPlace (RecordPatches.TransactionSnapshot.cs) only nulls the row
+        // trees, not the "table" metadata field, so the provider stays usable afterward.
+        ClearProviderInPlace(store);
 
         var nclMetadata = _apsSessionNclMetadata!.GetValue(session)
             ?? throw new RunnerOutOfScopeException(

--- a/tests/expectations/known-gaps-aggregate-permission-set.json
+++ b/tests/expectations/known-gaps-aggregate-permission-set.json
@@ -6,13 +6,5 @@
     "Mode": "expect-fail-known-gap",
     "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2474",
     "Note": "Real BC answers Name = the permission set's own Role ID for a Caption-less permission set. The runner answers the declared name with its original casing instead: expected <ALTPERMISSIONSET>, actual <ALTPermissionSet>. Role ID is a Code[20] column and BC upper-cases a NavCode, so the divergence here is the missing NavCode normalisation, not a missing fallback -- the fallback itself is present (see #2433, which fixed the same fallback for the sibling Metadata Permission Set virtual table). Test passes on real BC 27.0 through 28.4 -- StefanMaron/BusinessCentral.AL.Language.Tests#111. Tracked as #2474; the fix removes this entry."
-  },
-  {
-    "codeunitId": 60931,
-    "CodeunitName": "Test Aggregate Permission Set",
-    "Method": "AggregatePermissionSet_TenantScopeDeclaration_IsPresent",
-    "Mode": "expect-fail-known-gap",
-    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2473",
-    "Note": "The Aggregate Permission Set union is snapshotted once per run and never reflects a later Insert into Tenant Permission Set, so a row written by the test itself is not reachable through the Tenant scope. Real BC recomputes the union per request. Test passes on real BC 27.0 through 28.4 -- StefanMaron/BusinessCentral.AL.Language.Tests#111. Tracked as #2473; the fix removes this entry."
   }
 ]


### PR DESCRIPTION
Closes #2473

## What

`PopulateAggregatePermissionSetVirtualTable` gated on a one-shot
`ConditionalWeakTable` flag per in-memory provider, so a `Tenant Permission Set`
row inserted after the table's first touch never appeared -- the store had
already been marked "populated" and every later touch was a no-op. On a real
service tier Aggregate Permission Set has no persistent state of its own: it's
an `EagerVirtualDataProvider` -- every `Get()`/`FindSet()` re-derives from
`Metadata Permission Set` / `Tenant Permission Set` at that moment.

Every touch now clears the table's own in-memory store
(`ClearProviderInPlace`, reused from `RecordPatches.TransactionSnapshot.cs`)
and redrives the whole union fresh, rather than a top-up-only insert -- so a
later delete or rename of the underlying `Tenant Permission Set` row can't
leave a ghost row behind either.

Also removes the `expect-fail-known-gap` entry for
`AggregatePermissionSet_TenantScopeDeclaration_IsPresent` (codeunit 60931,
already present at the current corpus pin) -- it passes now, verified against
the actual pinned submodule.

## The three questions

1. **Same wrong pattern elsewhere?** `MetadataPermissionSetVirtualTable.cs`
   has the identical-looking one-shot-guard shape (`_mpsPopulatedByProvider`),
   so I audited it directly. It does NOT have this gap: its rows come from
   `ParsedPermissionSets` (this run's own compiled AL source) and each
   dependency `.app`'s `SymbolReference.json`, both fixed for the lifetime of
   one runner invocation -- not runtime-writable AL data like
   `Tenant Permission Set` is. A repeated top-up there can only ever
   rediscover the same fixed set, so nothing to fix. Documented in the file's
   own banner.
2. **Sibling function, same assumption?** `AllProfileVirtualTable.cs` already
   documents the same underlying tension (a table backed by AL-writable data
   must not use a top-up-only shape, or a delete leaves a ghost) for `All
   Profile`; that table solves it by staying one-shot because IT is directly
   AL-writable, unlike Aggregate Permission Set which only reads through to
   writable tables. No fix needed there, but I referenced its banner in mine
   since the reasoning is the same shape.
3. **Two write paths, same invariant?** N/A here -- Aggregate Permission Set
   has exactly one write path (this populate function); Tenant/Metadata
   Permission Set are untouched, ordinary tables.

## Why this doesn't close the 14-test Codeunit134614 cascade

The issue was filed noting this "plausibly" unlocks up to 14 tests in
Microsoft's own Tests-SINGLESERVER `Codeunit134614`. **Measured, not
predicted:** it does not, and I did not assume it would.

| variant | Codeunit134614 |
|---|---|
| baseline (main, before this PR) | 1P/14F |
| this PR | 1P/14F -- unchanged |

The second test in the codeunit, `TestViewAggregatePermissionsSets`, still
fails, but on a **different** assertion than the one this issue described --
"Newly created tenant permission set not found" inside
`TestPage "Permission Sets"`'s own row walk, not a raw
`Record "Aggregate Permission Set".Get()`. A raw `Record` in the very same
test procedure sees the freshly-created row fine (proving this fix works);
the `TestPage`-driven search does not. That's a distinct, undiagnosed gap --
filed separately as #2504 rather than guessed at here.

## Testing

- **RED->GREEN, runner-local:** `AlRunner.Tests/Fixtures/AggregatePermissionSet`
  fixture, new test `AggregatePermissionSet_TenantRowInsertedAfterEarlierTouch_IsVisible`
  (positive: insert after an earlier touch becomes visible; negative: a
  subsequent delete does not leave a ghost row). Confirmed failing before the
  fix, passing after, verified by checking out the pre-fix file and rerunning.
- **RED->GREEN against the corpus, locally:** `AggregatePermissionSet_TenantScopeDeclaration_IsPresent`
  (codeunit 60931, already in the pinned submodule) flips from the classified
  known-gap failure to a genuine pass with this fix; verified by running the
  actual `tests/al-language/tests/al-language` submodule scoped to
  `Codeunit60931.*`.
- **Upstream corpus PR (new, deterministic test):**
  StefanMaron/BusinessCentral.AL.Language.Tests#116 -- adds a single
  self-contained test that doesn't depend on running after another test in
  the same codeunit (same claim, more robust). No submodule pin bump in this
  PR: the fix is already fully provable against the currently-pinned corpus
  test, so the bump isn't blocking. If #116 merges before this PR does, I'll
  fold the pin bump in.
- **Follow-up issue filed:** #2504, for the newly-discovered `TestPage`
  buffer gap.
- Filtered C# suite: `dotnet test AlRunner.Tests --filter FullyQualifiedName~AggregatePermissionSetVirtualTableTests` -- pass.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf