### PR TITLE
fix(server): stop affectedOnly from silently dropping tests across a multi-sourcePaths request

### DIFF
--- a/AlRunner.Tests/ServerAffectedSelectionCrossBundleFallbackTests.cs
+++ b/AlRunner.Tests/ServerAffectedSelectionCrossBundleFallbackTests.cs
@@ -1,0 +1,193 @@
+// ServerAffectedSelectionCrossBundleFallbackTests — proves #2492: a warm --server process's
+// affectedOnly narrowing must not silently drop a test in one bundle when a SIBLING bundle in
+// the SAME multi-sourcePaths request could not be attributed to a change model this cycle.
+//
+// Root cause (see issue #2492 for the full investigation against a real corpus — the mechanism
+// this test isolates, not the RAD "already declared" trigger that surfaced it there)
+// ------------------------------------------------------------------------------------------
+// Each bundle's own affectedOnly selection is decided from ONLY that bundle's own
+// TryEmitIncremental cycle: its own `changedObjects` and its own `changeModelFallbackReason`.
+// When bundle A's cycle falls back (RAD failure, an app.json edit, anything
+// TryEmitIncremental itself cannot narrow), bundle A correctly runs everything — but a SIBLING
+// bundle B, whose OWN files did not change, sees an EMPTY changedObjects set and happily
+// narrows using its OWN per-test coverage baseline. If B's covered-objects entry for a test
+// does not happen to overlap whatever changed (a real limitation of this corpus's per-test
+// coverage attribution — see #2492's own writeup), that test is silently skipped even though
+// bundle A could not prove nothing relevant to it changed. A green run then reports fewer
+// tests than a from-scratch run, with no error (RunnerOutOfScopeException doesn't apply here —
+// this is a selection-narrowing defect, not an unsupported-surface one).
+//
+// The fix: RunAllBundlesForServer now propagates ANY bundle's changeModelFallbackReason to
+// every bundle processed AFTER it in the SAME request (bundles are processed in sourcePaths
+// order — dependency app before test app is the supported/documented shape), forcing THEIR
+// selection to forcedFull too rather than trusting narrowing it cannot prove correct.
+//
+// Trigger used here: editing the dependency's Helper.al to declare a SECOND object in the
+// same file. TryEmitIncremental's own fast path requires exactly one declared object per
+// touched file — one of the issue's own documented forced-fallback conditions — so this
+// deterministically makes the dependency's NEXT cycle fall back with a non-null
+// changeModelFallbackReason, without touching app identity/version (which collides with the
+// layered-prepass's own content-keyed workspace cache under an unrelated guard, #1850). This
+// is a DIFFERENT trigger than the RAD "already declared" failure #2492 was actually filed
+// against (attempts at a minimal repro for THAT specific trigger did not reproduce in a small
+// fixture); this test exercises the selection-propagation fix directly, independent of which
+// of TryEmitIncremental's own branches set changeModelFallbackReason.
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class ServerAffectedSelectionCrossBundleFallbackTests
+{
+    private static string MakeAppBundle(string root, string version)
+    {
+        var dir = Path.Combine(root, "app");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "a1b2c3d4-7001-4a11-9111-111111111111",
+          "name": "CrossBundle Fallback App SX",
+          "publisher": "AL Runner",
+          "version": "{{version}}",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 60380, "to": 60389 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Helper.al"), """
+        codeunit 60380 "CrossBundle Helper SX"
+        {
+            procedure Value(): Integer
+            begin
+                exit(1);
+            end;
+        }
+        """);
+        return dir;
+    }
+
+    private static string MakeTestAppBundle(string root)
+    {
+        var dir = Path.Combine(root, "test-app");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "a1b2c3d4-7002-4a11-9222-222222222222",
+          "name": "CrossBundle Fallback Test App SX",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "a1b2c3d4-7001-4a11-9111-111111111111", "name": "CrossBundle Fallback App SX",
+              "publisher": "AL Runner", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 60390, "to": 60399 } ],
+          "runtime": "14.0"
+        }
+        """);
+        // OnlyA deliberately does NOT call into the dependency's Helper codeunit — a
+        // self-contained test whose recorded coverage maps cleanly to ONLY its own codeunit
+        // (no cross-bundle statement, so no "unmappable -> unknown -> always safely included"
+        // escape hatch masking the bug this test proves). That is exactly the shape #2492's
+        // real corpus repro's at-risk tests turned out to have: coverage attribution only ever
+        // resolves a test's own declaring codeunit, never a helper it calls — see this file's
+        // header comment. The dependency is still DECLARED (app.json), which is what makes
+        // this a genuine multi-sourcePaths request exercising RunLayeredPrePass.
+        File.WriteAllText(Path.Combine(dir, "Tests.al"), """
+        codeunit 60390 "CrossBundle Fallback Tests SX"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure OnlyA()
+            begin
+                if 1 <> 1 then
+                    Error('OnlyA failed');
+            end;
+        }
+        """);
+        return dir;
+    }
+
+    private static string RunTestsRequest(string appDir, string testAppDir)
+        => JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            sourcePaths = new[] { appDir, testAppDir },
+            packagePaths = Array.Empty<string>(),
+            affectedOnly = true,
+            perTestCoverage = true,
+        });
+
+    [SkippableFact]
+    public async Task AffectedOnly_SiblingBundleFallback_DoesNotSilentlySkipUnrelatedTest()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-server-affected-crossfallback", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var appDir = MakeAppBundle(root, "1.0.0.0");
+        var testAppDir = MakeTestAppBundle(root);
+
+        await using var server = await CliServer.StartAsync(new[] { "--no-cache" });
+
+        // Request 1: first cycle for both bundles, necessarily a full run (no baseline yet).
+        var lines1 = await server.SendRequestStreamingAsync(RunTestsRequest(appDir, testAppDir));
+        var (events1, summary1) = ProtocolV2Streaming.Split(lines1);
+        Assert.Single(events1);
+        Assert.Equal("pass", events1[0].GetProperty("status").GetString());
+        Assert.True(summary1.TryGetProperty("selection", out var selection1), string.Join(" | ", lines1));
+        Assert.Equal(1, selection1.GetProperty("ran").GetInt32());
+        Assert.Equal(0, selection1.GetProperty("skipped").GetInt32());
+
+        // Make the DEPENDENCY app's Helper.al declare a SECOND object in the same file.
+        // TryEmitIncremental's own fast-path requires exactly one declared object per touched
+        // file (ClassifyDeclaredObject returns "declares 2 object(s) ... fast path requires
+        // exactly 1 per file", the issue's own documented forced-fallback condition) — this
+        // app's NEXT cycle falls back with a non-null changeModelFallbackReason, deterministic
+        // and without touching app identity/version (which collides with the layered-prepass's
+        // own content-keyed workspace cache under a different, unrelated guard — #1850).
+        // Unlike the RAD "already declared" trigger #2492 was actually filed against (which a
+        // minimal fixture does not reproduce — see this file's header comment), this exercises
+        // a DIFFERENT one of TryEmitIncremental's own documented fallback triggers, which is
+        // enough: the fix under test reacts to changeModelFallbackReason being non-null,
+        // regardless of which of TryEmitIncremental's own branches set it.
+        File.WriteAllText(Path.Combine(appDir, "Helper.al"), """
+        codeunit 60380 "CrossBundle Helper SX"
+        {
+            procedure Value(): Integer
+            begin
+                exit(1);
+            end;
+        }
+        codeunit 60381 "CrossBundle Helper SX 2"
+        {
+        }
+        """);
+
+        // Request 2: same warm server process, same two sourcePaths. The TEST app's own files
+        // are untouched, so its own incremental cycle sees zero changes and would, pre-fix,
+        // narrow using an empty changed-object set against OnlyA's own recorded coverage —
+        // which does not overlap an empty set, so OnlyA gets silently skipped despite the
+        // dependency app being unable to prove nothing relevant to it changed.
+        var lines2 = await server.SendRequestStreamingAsync(RunTestsRequest(appDir, testAppDir));
+        var (events2, summary2) = ProtocolV2Streaming.Split(lines2);
+        Assert.True(summary2.TryGetProperty("selection", out var selection2), string.Join(" | ", lines2));
+
+        // [THEN] the sibling bundle's unattributable cycle forces this bundle's own narrowing
+        // off too — OnlyA runs, it is not silently skipped. Before the fix, `ran` was 0 and
+        // `skipped` was 1 here even though the overall exit code and `total` still read as a
+        // clean, successful run — exactly the "green but fewer tests than exist" defect #2492
+        // reports. Asserting on the raw event stream (not just the selection counters) proves
+        // the test genuinely EXECUTED, not merely that the counters claim it did.
+        Assert.Single(events2);
+        Assert.Equal("pass", events2[0].GetProperty("status").GetString());
+        Assert.Equal("OnlyA", events2[0].GetProperty("name").GetString().Split('.')[^1]);
+        Assert.Equal(1, selection2.GetProperty("ran").GetInt32());
+        Assert.Equal(0, selection2.GetProperty("skipped").GetInt32());
+        Assert.True(selection2.GetProperty("forcedFull").GetBoolean(),
+            $"expected the dependency bundle's unattributable cycle to force this bundle's " +
+            $"narrowing off too, got: {string.Join(" | ", lines2)}");
+    }
+}

--- a/AlRunner/BcCompiler.Incremental.cs
+++ b/AlRunner/BcCompiler.Incremental.cs
@@ -674,6 +674,112 @@ public sealed partial class BcCompiler
             ? baseline.ObjectByPath.ToDictionary(kv => kv.Key, kv => ToAffectedObjectId(kv.Value), StringComparer.Ordinal)
             : null;
 
+    /// <summary>
+    /// #2492: a side-effect-free "peek" at which AL objects changed in <paramref name="moduleName"/>'s
+    /// OWN files since its last recorded RAD baseline — no <c>CreateForRad</c>, no <c>Emit</c>, no
+    /// baseline mutation, and (unlike <see cref="TryEmitIncremental"/>) no requirement that the
+    /// resolved dependency set is unchanged, since a dependency-symbol change is not this method's
+    /// concern.
+    ///
+    /// Exists for a multi-<c>sourcePaths</c> server request's affectedOnly selection: a test in
+    /// bundle B can cover an AL object declared in bundle A (a real cross-app call, not a
+    /// hypothetical — see issue #2492's Pageworks/Pageworks.Test repro), so B's own per-file diff
+    /// alone can never tell whether A changed. The caller peeks EVERY bundle in the request BEFORE
+    /// deciding any bundle's coverage-based narrowing, and unions the results — see
+    /// <c>RunAllBundlesForServer</c> in Program.cs.
+    ///
+    /// Returns null when this bundle's own changed-object set cannot be determined with
+    /// confidence — no baseline yet, a touched file could not be parsed/classified, or a
+    /// removed file was not tracked. The caller MUST treat null as "unknown, do not narrow" (the
+    /// same posture <see cref="TryEmitIncremental"/>'s own null-changedObjects fallback already
+    /// takes), never as "nothing changed here". Deliberately over-inclusive rather than precise: a
+    /// rename is reported as BOTH the old and the new identity changing (no vacated/appeared
+    /// pairing), and a removed/added file's declared identity is always included — extra entries
+    /// only cause a test to run that didn't strictly need to, never the silent loss this method
+    /// exists to close.
+    ///
+    /// Deliberately does NOT check the manifest fingerprint <see cref="TryEmitIncremental"/> does
+    /// (identity/version/preprocessor-symbols/features) — that check exists there to decide
+    /// whether the REAL RAD compile is safe to attempt at all, using <c>_currentAppId</c>/
+    /// <c>_currentPublisher</c>/<c>_currentVersion</c>, static state that is only valid while the
+    /// real per-bundle compile flow has scoped it via <c>SetCurrentAppIdentity</c>. A caller
+    /// peeking every bundle in a multi-<c>sourcePaths</c> request UP FRONT, before any bundle's own
+    /// compile has scoped that state, cannot rely on it — and does not need to: an app.json change
+    /// this method fails to notice only means a slightly stale (but still safe, still additive)
+    /// contribution to the caller's union, never a false "nothing changed".
+    /// </summary>
+    internal IReadOnlyList<AffectedObjectId>? PeekChangedObjects(
+        IEnumerable<string> alFolders, string moduleName, string? appRootDir)
+    {
+        if (!_radBaselines.TryGetValue(moduleName, out var baseline))
+            return null;
+
+        var dirs = alFolders.Where(Directory.Exists).Distinct().ToList();
+        var alFiles = dirs.SelectMany(d => AlRunner.Infrastructure.SafeDirectoryScan.Files(d, "*.al")).Distinct().ToList();
+
+        var manifestAppJsonPath = (appRootDir != null && File.Exists(Path.Combine(appRootDir, "app.json")))
+            ? Path.Combine(appRootDir, "app.json")
+            : dirs.Select(d => Path.Combine(d, "app.json")).FirstOrDefault(File.Exists);
+        var manifestInputs = ReadManifestCompilerInputs(manifestAppJsonPath);
+
+        var currentHashes = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var f in alFiles) currentHashes[f] = HashFile(f);
+
+        var addedPaths = new List<string>();
+        var removedPaths = new List<string>();
+        var modifiedPaths = new List<string>();
+        foreach (var kv in currentHashes)
+        {
+            if (!baseline.FileHashByPath.TryGetValue(kv.Key, out var oldHash)) addedPaths.Add(kv.Key);
+            else if (!string.Equals(oldHash, kv.Value, StringComparison.Ordinal)) modifiedPaths.Add(kv.Key);
+        }
+        foreach (var oldPath in baseline.FileHashByPath.Keys)
+            if (!currentHashes.ContainsKey(oldPath)) removedPaths.Add(oldPath);
+
+        if (addedPaths.Count == 0 && removedPaths.Count == 0 && modifiedPaths.Count == 0)
+            return Array.Empty<AffectedObjectId>();
+
+        var parseOpts = RadParseOptions(manifestInputs);
+        var compOpts = RadCompilationOptions(manifestInputs);
+        var changed = new HashSet<RadObjectIdentity>();
+
+        foreach (var path in removedPaths)
+        {
+            if (!baseline.ObjectByPath.TryGetValue(path, out var oldIdentity))
+                return null; // untracked removal — only the real compile path can adjudicate this
+            changed.Add(oldIdentity);
+        }
+
+        foreach (var path in addedPaths.Concat(modifiedPaths))
+        {
+            NavSyntax.SyntaxTree tree;
+            try
+            {
+                var src = File.ReadAllText(path);
+                tree = NavSyntax.SyntaxTree.ParseObjectText(src, path: path, encoding: null!, parseOpts, default);
+            }
+            catch { return null; }
+
+            var (identity, error) = ClassifyDeclaredObject(tree, compOpts);
+            if (identity == null) return null;
+            changed.Add(identity.Value);
+
+            // An in-place rename (path already tracked under a DIFFERENT identity) vacates the
+            // old identity too — report both rather than pairing them, per this method's own
+            // over-inclusive-by-design contract above.
+            if (baseline.ObjectByPath.TryGetValue(path, out var oldIdentityAtSamePath)
+                && IdentityKey(oldIdentityAtSamePath) != IdentityKey(identity.Value))
+                changed.Add(oldIdentityAtSamePath);
+        }
+
+        return changed
+            .OrderBy(i => i.Kind.ToString(), StringComparer.Ordinal)
+            .ThenBy(i => i.Id ?? int.MaxValue)
+            .ThenBy(i => i.Name, StringComparer.Ordinal)
+            .Select(ToAffectedObjectId)
+            .ToArray();
+    }
+
     /// <summary>Projects to the NavCA-free shape Program.cs is allowed to name.
     /// See <see cref="AffectedObjectId"/> for why that boundary exists.</summary>
     private static AffectedObjectId ToAffectedObjectId(RadObjectIdentity id)

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3626,6 +3626,82 @@ return strictExitCode ? computedExitCode : 0;
         // REQUEST (not per process lifetime) — server sessions have no single
         // "argument order" the way a CLI invocation does, and nothing downstream reads
         // it across requests.
+        // #2492: a test in one bundle can cover an AL object declared in ANOTHER bundle in
+        // this SAME multi-sourcePaths request — a real cross-app dependency call, not a
+        // hypothetical (the Pageworks/Pageworks.Test repro in that issue). Each bundle's own
+        // affectedOnly selection below only ever sees ITS OWN changed-object set, so a change
+        // to a DEPENDENCY app silently narrowed away every test in a DEPENDENT app that
+        // covered it — a green run reporting fewer tests than a from-scratch run, with no
+        // error. Peek every bundle's own changed-object set BEFORE any bundle's selection
+        // decision (cheap: file-hash diff + parsing only the touched files, no BC Compilation/
+        // Emit — see PeekChangedObjects), and union them so each bundle's overlap check can see
+        // changes that happened in a sibling bundle. Gated on affectedOnly and more than one
+        // bundle — a single-bundle request already sees its own full change set.
+        List<AffectedObjectId>? requestWideChangedObjects = null;
+        if (useIncrementalChangeModel && sourcePaths.Length > 1)
+        {
+            requestWideChangedObjects = new List<AffectedObjectId>();
+            foreach (var peekBundleDir in sourcePaths)
+            {
+                var peekAbs = Path.GetFullPath(peekBundleDir);
+                var peekBucketRoot = FindBucketRoot(peekAbs) ?? peekAbs;
+                var peekModuleName = $"V2_{Path.GetFileName(peekAbs)}";
+                var peekPaths = new List<string>();
+                foreach (var suite in EnumerateSuites(peekAbs))
+                    peekPaths.AddRange(CollectSuitePaths(suite, peekBucketRoot));
+                peekPaths = peekPaths.Distinct().ToList();
+
+                var peeked = emitter.PeekChangedObjects(peekPaths, peekModuleName, peekBucketRoot);
+                if (peeked == null)
+                {
+                    // Unknown for at least one bundle (no baseline yet, app.json changed, an
+                    // unclassifiable file) — cannot safely narrow ANYWHERE in this request.
+                    // Null the whole union: every bundle below then merges nothing new in and
+                    // keeps whatever its OWN cycle already decided, same as before this fix —
+                    // never worse than the pre-#2492 behaviour, only better when every bundle's
+                    // own change set peeks clean.
+                    requestWideChangedObjects = null;
+                    break;
+                }
+                requestWideChangedObjects.AddRange(peeked);
+            }
+        }
+        // #2492, second half: the union above widens what a bundle SEES as changed, but this
+        // corpus's per-test coverage only ever attributes a passing test to the codeunit that
+        // DECLARES it — a helper (same-app OR cross-app) it calls into never appears in its
+        // coveredObjects set (confirmed empirically: of 1012 tests, only the handful whose
+        // OWN declaring codeunit id happened to be in `changedObjects` had ANY coverage entry
+        // at all; every other test's statement-to-object mapping missed and fell back to
+        // "unknown", which is why they were never at risk). For the few tests that DO have an
+        // entry, the union above cannot help them — their entry never mentions the sibling
+        // bundle's changed object no matter how complete the union is, because the entry was
+        // never built from statements INSIDE that object to begin with. So when a sibling
+        // bundle's own incremental cycle fell back to a full rebuild (changeModelFallbackReason
+        // != null) this cycle, coverage-based narrowing cannot be trusted to have seen whatever
+        // that bundle's tests actually depend on — propagate that bundle's fallback as a reason
+        // for EVERY bundle processed AFTER it in this SAME request, so their own narrowing is
+        // disabled (forcedFull) instead of silently trusting an attribution gap. Bundles are
+        // processed in `sourcePaths` order — the one documented/supported shape is dependency
+        // app before test app (see README), which is exactly the order this needs to see the
+        // dependency's fallback before deciding the test app's selection.
+        var effectiveBeforeRun = beforeRun;
+        if (beforeRun != null)
+        {
+            var union = requestWideChangedObjects;
+            string? sawFallbackReason = null;
+            effectiveBeforeRun = (bundlePath, moduleName, selectionEnvironmentKey, changedObjects, changeModelFallbackReason) =>
+            {
+                var merged = union == null || changedObjects == null ? changedObjects : changedObjects.Concat(union).ToList();
+                var effectiveFallbackReason = changeModelFallbackReason
+                    ?? (sawFallbackReason != null
+                        ? $"an earlier bundle in this request fell back this cycle ({sawFallbackReason})"
+                        : null);
+                if (changeModelFallbackReason != null)
+                    sawFallbackReason ??= $"{moduleName}: {changeModelFallbackReason}";
+                beforeRun(bundlePath, moduleName, selectionEnvironmentKey, merged, effectiveFallbackReason);
+            };
+        }
+
         var bundleIndex = 0;
         foreach (var bundleDir in sourcePaths)
         {
@@ -3636,7 +3712,7 @@ return strictExitCode ? computedExitCode : 0;
             AlRunner.Infrastructure.PhaseLog.BeginBundle(relBundle, bundleIndex);
             var result = RunBundleForServer(bundleDir, requestPackagePaths, runStep,
                 useIncrementalChangeModel,
-                beforeRun,
+                effectiveBeforeRun,
                 out var emitElapsed, out var compileElapsed, out var runElapsed);
             AlRunner.Infrastructure.PhaseLog.EndBundle(emitElapsed, compileElapsed, runElapsed);
             results.Add(result);


### PR DESCRIPTION
Closes #2492

## What was actually happening

I instrumented the real Pageworks/Pageworks.Test corpus repro from the issue and confirmed the exact mechanism. It's a selection-narrowing defect, not a compile-time object loss:

- Editing the dependency app (Pageworks) makes its own RAD emit fail ("already declared"), so it correctly falls back to a full rebuild and runs everything (it has no tests, so this is invisible).
- The test app (Pageworks.Test) never touched its own files this cycle, so its own `TryEmitIncremental` sees zero local changes and proceeds to narrow using `affectedOnly`'s per-test coverage baseline.
- That coverage baseline, for this corpus, only ever attributes a passing test to the codeunit that *declares* it — a helper it calls into (same-app or cross-app) never shows up in its `coveredObjects` set. For the ~1000 tests with no coverage entry at all, narrowing safely defaults to "run it". For the handful that *do* have an entry, their entry has nothing to do with what actually changed, so the overlap check fails and they get silently skipped.
- The request still exits 0 with no compile error — `total` just reads lower than a from-scratch run.

The `ElementKey`/`IdentityElementKeyOf` lead the issue flagged as unconfirmed turned out **not** to be the cause: both branches produce the identical `"id:71179699"` key for a `Codeunit` (it isn't in `IdlessSymbolKinds`). Instrumenting `ExcludeObjects` directly showed the self-baseline's `Codeunits` array was already **empty** before any key comparison happened — a separate, deeper defect in `RecordIncrementalBaseline`'s use of `SymbolJsonWriter.GetModuleDefinition`, filed as #2507. It explains *why* RAD emit fails on a real app, but the silent test loss doesn't depend on it: I proved that with a synthetic fixture whose fallback trigger is unrelated to RAD entirely (see the new test).

## The fix

`RunAllBundlesForServer` now:

1. **Peeks every bundle's own changed-object set up front** via a new side-effect-free `BcCompiler.PeekChangedObjects` (file-hash diff + parsing only the touched files, no `Compilation.Emit`) and unions the results, so a change in one bundle is visible to every bundle's coverage-overlap check in the same request.
2. **Propagates any bundle's `changeModelFallbackReason` to every bundle processed after it** in the same request (bundles run in `sourcePaths` order, dependency app before test app is the documented/supported shape), forcing their own narrowing off too — since the coverage tracker's attribution gap means the union above can't be trusted to have seen everything a bundle's tests actually depend on.

Both together make the acceptance criterion hold: a `--server` request whose incremental emit fails returns the same test total as a from-scratch run.

## Fix the shape, not just the line

- **Same wrong pattern elsewhere?** The other `RunAllBundlesForServer` call site (`execute`) passes `useIncrementalChangeModel: false, beforeRun: null` — affectedOnly narrowing doesn't apply there at all, so nothing to fix.
- **Sibling function, same assumption?** The CLI `--watch` path (`emitter.TryEmitIncremental` at the other call site in `Program.cs`) has no `affectedOnly`/per-test-selection concept at all — it only accelerates emit, never skips a test — so this class of bug is exclusive to `--server` mode and there's no second instance to fix.
- **Two paths, same invariant?** Yes — before this fix, a bundle's own `changeModelFallbackReason` disabled narrowing for *itself* but a sibling's fallback was invisible; now both halves see the same signal.

## Tests

- `AlRunner.Tests/ServerAffectedSelectionCrossBundleFallbackTests.cs` (new): two-bundle `--server` fixture, `affectedOnly:true`. Request 1 passes cleanly. Between requests, the dependency's own file is edited to declare two objects (one of `TryEmitIncremental`'s own documented forced-fallback conditions), deliberately avoiding the version-bump trigger I tried first, which collided with an unrelated #1850 "duplicate app id" guard from the layered-prepass's own content-keyed cache. Request 2 asserts the sibling test still runs (not skipped) and `forcedFull` is true.
  - RED confirmed against the pre-fix code (reverted via `git checkout HEAD --`, restored byte-for-byte afterward and diffed to confirm): `ran:0, skipped:1`, exact same "green but a test vanished" shape as the real corpus.
  - GREEN with the fix restored.
- Regression check: all 4 pre-existing `ServerAffectedSelection*` tests still pass, plus the full `Server*`/`Incremental*` AlRunner.Tests surface (89 passed, 14 skipped for missing artifacts, 0 failed).
- Manually re-verified against the real Pageworks/Pageworks.Test corpus (`--server`, two `runTests` requests, one file edit between them) — `total` stays 1012 across both requests, matching a from-scratch run.

## Follow-up filed

#2507 — `RecordIncrementalBaseline`'s `ModuleDefinition` comes back completely empty for a real app, which is why RAD emit fails on it in the first place. Not required for this fix (the fallback is safe now regardless of why RAD fails), but worth fixing so incremental compile actually accelerates real apps.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
