### PR TITLE
fix(testpage): enforce field MinValue/MaxValue on TestPage SetValue

### DIFF
--- a/AlRunner.Tests/TestPageMinMaxValueDispatchTests.cs
+++ b/AlRunner.Tests/TestPageMinMaxValueDispatchTests.cs
@@ -1,0 +1,249 @@
+// TestPageMinMaxValueDispatchTests — issue #2495.
+//
+// This is a RUNNER-MECHANISM test, not a claim about what real BC does: it proves that OUR OWN
+// wiring — LiveNavTestField.Value's setter in MockTestPage.cs calling TestPageMinMaxValue.Check,
+// fed by RecordPatches.TryGetParsedFieldMinMax reading the AL-declared MinValue/MaxValue field
+// properties — enforces a bounded field's range on a TestPage control write, and specifically
+// does NOT enforce it on Rec.Validate or a plain field assignment (measured against real BC
+// 28.1/28.4, see issue #2490's arm A2/D2).
+//
+// The BEHAVIORAL claim (what real BC does on each of these four surfaces, and the exact error
+// text) is the corpus's to adjudicate — see StefanMaron/BusinessCentral.AL.Language.Tests, per
+// .claude/rules/bc-behavior-tests-go-upstream.md. This test exists so a regression in OUR OWN
+// dispatch mechanism fails loudly here, in seconds, without needing the corpus's al-language
+// submodule pin bumped first.
+//
+// RED/GREEN proof: before RecordPatches.TryGetParsedFieldMinMax and TestPageMinMaxValue.Check
+// existed, SetValue_BelowMin_Decimal_RaisesFromTestPageOnly below failed with
+// "An error was expected inside an ASSERTERROR statement." (SetValue let -1 through silently),
+// while the negative tests (Validate/assignment) already passed.
+
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPageMinMaxValueDispatchTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly string _root;
+
+    public TestPageMinMaxValueDispatchTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-minmax-dispatch", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private static string[] ExtraPackageCacheArgs()
+    {
+        var platformApps = TestArtifacts.PlatformAppsDir();
+        return Directory.Exists(platformApps)
+            ? new[] { "--package-cache", platformApps }
+            : Array.Empty<string>();
+    }
+
+    private void WriteBundle()
+    {
+        Directory.CreateDirectory(_root);
+        File.WriteAllText(Path.Combine(_root, "app.json"), """
+        {
+          "id": "d1e2f3a4-5b6c-4890-9a1b-6c7d8e9f0b2d",
+          "name": "Runner Mechanism - TestPage MinValue MaxValue Dispatch",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62400, "to": 62409 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "MmvRow.Table.al"), """
+        table 62400 "Mmv Row"
+        {
+            DataClassification = CustomerContent;
+
+            fields
+            {
+                field(1; PK; Code[10]) { }
+                field(2; Completion; Decimal)
+                {
+                    MinValue = 0;
+                    MaxValue = 100;
+                }
+            }
+
+            keys
+            {
+                key(K; PK) { Clustered = true; }
+            }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "MmvCard.Page.al"), """
+        page 62401 "Mmv Card"
+        {
+            PageType = Card;
+            SourceTable = "Mmv Row";
+            ApplicationArea = All;
+            UsageCategory = Administration;
+
+            layout
+            {
+                area(Content)
+                {
+                    field(RecCompletion; Rec.Completion) { ApplicationArea = All; }
+                }
+            }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "MmvTests.Codeunit.al"), """
+        codeunit 62402 "Mmv Tests"
+        {
+            Subtype = Test;
+            TestPermissions = Disabled;
+
+            local procedure Seed()
+            var
+                Row: Record "Mmv Row";
+            begin
+                Row.DeleteAll();
+                Row.Init();
+                Row.PK := 'R1';
+                Row.Insert();
+            end;
+
+            [Test]
+            procedure SetValue_BelowMin_Decimal_RaisesFromTestPageOnly()
+            var
+                Row: Record "Mmv Row";
+                Card: TestPage "Mmv Card";
+            begin
+                Seed();
+
+                Card.OpenEdit();
+                Card.First();
+                asserterror Card.RecCompletion.SetValue(-1);
+                if StrPos(GetLastErrorText(), 'greater than or equal to') = 0 then
+                    Error('expected a MinValue-shaped error, got: %1', GetLastErrorText());
+                Card.Close();
+
+                Row.Get('R1');
+                if Row.Completion <> 0 then
+                    Error('a rejected SetValue must not have persisted, got %1', Row.Completion);
+            end;
+
+            [Test]
+            procedure SetValue_AboveMax_Decimal_Raises()
+            var
+                Card: TestPage "Mmv Card";
+            begin
+                Seed();
+
+                Card.OpenEdit();
+                Card.First();
+                asserterror Card.RecCompletion.SetValue(101);
+                if StrPos(GetLastErrorText(), 'less than or equal to') = 0 then
+                    Error('expected a MaxValue-shaped error, got: %1', GetLastErrorText());
+                Card.Close();
+            end;
+
+            [Test]
+            procedure SetValue_WithinBounds_Succeeds()
+            var
+                Card: TestPage "Mmv Card";
+            begin
+                Seed();
+
+                Card.OpenEdit();
+                Card.First();
+                Card.RecCompletion.SetValue(50);
+                if Card.RecCompletion.AsDecimal() <> 50 then
+                    Error('expected 50, got %1', Card.RecCompletion.AsDecimal());
+                Card.Close();
+            end;
+
+            [Test]
+            procedure Validate_BelowMin_DoesNotRaise()
+            var
+                Row: Record "Mmv Row";
+            begin
+                Row.Init();
+                Row.PK := 'R2';
+                Row.Validate(Completion, -1);
+                Row.Insert();
+                if Row.Completion <> -1 then
+                    Error('expected -1 to be stored (Validate does not enforce MinValue), got %1', Row.Completion);
+            end;
+
+            [Test]
+            procedure DirectAssignment_BelowMin_DoesNotRaise()
+            var
+                Row: Record "Mmv Row";
+            begin
+                Row.Init();
+                Row.PK := 'R3';
+                Row.Completion := -1;
+                Row.Insert();
+                if Row.Completion <> -1 then
+                    Error('expected -1 to be stored (plain assignment does not enforce MinValue), got %1', Row.Completion);
+            end;
+        }
+        """);
+    }
+
+    private (string output, int exit) RunBundled()
+    {
+        var args = new StringBuilder(
+            TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg + $" \"{_root}\"");
+        foreach (var a in ExtraPackageCacheArgs()) args.Append($" \"{a}\"");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(600_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>
+    /// Positive (SetValue enforces, on both the below-min and above-max sides, and lets an
+    /// in-range write through) and negative (Rec.Validate and plain assignment both stay
+    /// unenforced) in one bundle — the shape #2495 depends on the runner getting each of these
+    /// right simultaneously, since the fix must not "leak" enforcement into Validate.
+    /// </summary>
+    [SkippableFact]
+    public void MinMaxValue_EnforcedOnlyOnTestPageSetValue()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        WriteBundle();
+        var (output, exit) = RunBundled();
+
+        Assert.True(exit == 0, $"Expected the bundle to pass; exit={exit}\n{output}");
+        Assert.Contains("PASS  Codeunit62402.SetValue_BelowMin_Decimal_RaisesFromTestPageOnly", output);
+        Assert.Contains("PASS  Codeunit62402.SetValue_AboveMax_Decimal_Raises", output);
+        Assert.Contains("PASS  Codeunit62402.SetValue_WithinBounds_Succeeds", output);
+        Assert.Contains("PASS  Codeunit62402.Validate_BelowMin_DoesNotRaise", output);
+        Assert.Contains("PASS  Codeunit62402.DirectAssignment_BelowMin_DoesNotRaise", output);
+        Assert.DoesNotContain("FAIL", output);
+    }
+}

--- a/AlRunner/Patches/BcAppSymbolCache.TableExtensions.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.TableExtensions.cs
@@ -141,8 +141,11 @@ internal static partial class BcAppSymbolCache
                 props.TryGetValue("InitValue", out var initValue);
                 var isAutoIncrement = props.TryGetValue("AutoIncrement", out var autoIncrement)
                     && (autoIncrement == "1" || autoIncrement.Equals("true", StringComparison.OrdinalIgnoreCase));
+                props.TryGetValue("MinValue", out var minValue); // #2495
+                props.TryGetValue("MaxValue", out var maxValue);
                 fields.Add(new ParsedField(fieldId, fieldName, typeName, SymbolTypeLength(typeName), isFlowField, null,
-                    optionMembers, initValue, isAutoIncrement, IsFlowFilter: isFlowFilter));
+                    optionMembers, initValue, isAutoIncrement, IsFlowFilter: isFlowFilter,
+                    MinValue: minValue, MaxValue: maxValue));
             }
         }
         return new TableExtensionSymbol(extId, extName, targetTableName, fields);

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -1131,8 +1131,11 @@ internal static partial class BcAppSymbolCache
                 props.TryGetValue("InitValue", out var initValue);
                 var isAutoIncrement = props.TryGetValue("AutoIncrement", out var autoIncrement)
                     && (autoIncrement == "1" || autoIncrement.Equals("true", StringComparison.OrdinalIgnoreCase));
+                props.TryGetValue("MinValue", out var minValue); // #2495
+                props.TryGetValue("MaxValue", out var maxValue);
                 fields.Add(new ParsedField(fieldId, fieldName, typeName, SymbolTypeLength(typeName), isFlowField, calcFormula,
-                    optionMembers, initValue, isAutoIncrement, IsFlowFilter: isFlowFilter));
+                    optionMembers, initValue, isAutoIncrement, IsFlowFilter: isFlowFilter,
+                    MinValue: minValue, MaxValue: maxValue));
             }
         }
 

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -1634,6 +1634,82 @@ internal static class TestPageOptionValue
 /// question about what real BC's own text-to-Boolean evaluate accepts on this surface, so it stays
 /// out of scope here and throws loudly rather than guessing.
 /// </summary>
+/// <summary>
+/// Enforces a field's declared <c>MinValue</c>/<c>MaxValue</c> AL properties on a TestPage
+/// control write (issue #2495). Measured against real BC (28.1 / 28.4, see #2490's arm A2):
+/// a Decimal field with <c>MinValue = 0;</c> raises
+/// <c>Validation error for Field: &lt;caption&gt;,  Message = 'The value must be greater than
+/// or equal to 0. Value: -1.00. (Select Refresh to discard errors)'</c> from a TestPage
+/// SetValue, while the SAME write via <c>Rec.Validate</c> or a plain field assignment raises
+/// nothing at all — this is a client/page-layer check, not a table-trigger one, so it must
+/// stay out of NavRecord.ALValidateAsync (which Rec.Validate also calls).
+///
+/// <para>Only numeric field types are checked — MinValue/MaxValue is meaningless on Text/Code/
+/// Boolean/etc., and AL does not let those types declare it.</para>
+///
+/// <para>The bound text is read via <see cref="RecordPatches.TryGetParsedFieldMinMax"/> — the
+/// parse-time source, not the constructed <c>NCLMetaField</c> — because NCLMetaField
+/// (Microsoft.Dynamics.Nav.Runtime) does not expose MinValue/MaxValue on the built runtime
+/// object at all (confirmed empirically: no Min/MaxValue-named member of any accessibility),
+/// even though <c>MetaField</c> (Microsoft.Dynamics.Nav.Types.Metadata, what the runner's
+/// NclMetaTableBuilder constructs FROM) does carry them. Same rationale as
+/// <see cref="RecordPatches.TryGetParsedFieldCaption"/> reading Caption straight from the parsed
+/// table rather than through NCLMetaField's own getter.</para>
+/// </summary>
+internal static class TestPageMinMaxValue
+{
+    internal static void Check(NCLMetaTable table, int fieldNo, NavType fieldType, string rawValue, string caption)
+    {
+        if (fieldType is not (NavType.Decimal or NavType.Integer or NavType.BigInteger)) return;
+        if (!table.TryGetFieldByNo(fieldNo, out var field) || field == null) return;
+
+        var (minText, maxText) = RecordPatches.TryGetParsedFieldMinMax(table.TableId, fieldNo);
+        if (string.IsNullOrEmpty(minText) && string.IsNullOrEmpty(maxText)) return;
+
+        // AL's TestPage SetValue is string-typed for every control, and the generic
+        // ALCompiler.ToNavValue(value) path taken above (there is no per-type conversion for a
+        // Decimal/Integer control here, unlike the Boolean special-case) always produces a
+        // NavText — so the bound check parses the RAW string the test wrote, exactly as BC's own
+        // client-side field validation would before ever constructing a typed NavValue.
+        if (!decimal.TryParse(rawValue, NumberStyles.Any, CultureInfo.InvariantCulture, out var value)) return;
+
+        var isInteger = fieldType is NavType.Integer or NavType.BigInteger;
+
+        if (!string.IsNullOrEmpty(minText) && decimal.TryParse(minText, NumberStyles.Any, CultureInfo.InvariantCulture, out var min)
+            && value < min)
+            throw MakeError(caption, isInteger, "greater than or equal to", minText!, value);
+
+        if (!string.IsNullOrEmpty(maxText) && decimal.TryParse(maxText, NumberStyles.Any, CultureInfo.InvariantCulture, out var max)
+            && value > max)
+            throw MakeError(caption, isInteger, "less than or equal to", maxText!, value);
+    }
+
+    // The offending VALUE renders with the field's decimal places (2 by default for a Decimal,
+    // none for an Integer/BigInteger — measured against real BC, #2490's arm A2: "-1.00"). The
+    // BOUND is echoed as BC declared it (the raw MinValue/MaxValue AL text, e.g. "0"), NOT
+    // reformatted to the field's decimal places — also measured in #2490's arm A2, where the
+    // bound reads "0" while the value reads "-1.00" for the identical Decimal field.
+    private static string FormatValue(decimal d, bool isInteger)
+        => isInteger ? d.ToString("0", CultureInfo.InvariantCulture)
+                     : d.ToString("0.00", CultureInfo.InvariantCulture);
+
+    private static System.Exception MakeError(string caption, bool isInteger, string comparison, string boundText, decimal value)
+    {
+        var msg = $"Validation error for Field: {caption},  Message = 'The value must be {comparison} "
+            + $"{boundText}. Value: {FormatValue(value, isInteger)}. "
+            + "(Select Refresh to discard errors)'";
+
+        var t = System.Type.GetType(
+            "Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLDialogException, Microsoft.Dynamics.Nav.Types");
+        if (t != null)
+        {
+            var ctor = t.GetConstructor(new[] { typeof(string) });
+            if (ctor != null) return (System.Exception)ctor.Invoke(new object[] { msg });
+        }
+        return new System.InvalidOperationException(msg);
+    }
+}
+
 internal static class TestPageBooleanValue
 {
     internal static NavValue Resolve(string value, string context)
@@ -1737,6 +1813,14 @@ internal sealed class LiveNavTestField : ITestField
                 : FieldType == NavType.Boolean
                     ? TestPageBooleanValue.Resolve(value, $"TestPage SetValue (field {_fieldNo})")
                     : ALCompiler.ToNavValue(value);
+
+            // MinValue/MaxValue (#2495): measured against real BC (28.1/28.4), a bounded field's
+            // MinValue/MaxValue is enforced on a TestPage control WRITE, but NOT on Rec.Validate
+            // or a plain field assignment — so this check belongs here, at the page-write layer,
+            // and must not move into ALValidateAsync below (that is also what Rec.Validate calls,
+            // and pulling the check in there would enforce it on Validate too, which real BC does
+            // not). See TestPageMinMaxValue.Check's own doc comment for the exact message shape.
+            TestPageMinMaxValue.Check(_record.MetaTable, _fieldNo, FieldType, value, Caption);
 
             // Setting a field on a page is a VALIDATE, not an assignment. That is what fills in
             // the caption when a user picks an id, and what lets a field refuse a value outright.

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -349,9 +349,18 @@ public static partial class RecordPatches
             relationArms = ParseRelationArms(tr, fname);
         }
 
+        // MinValue / MaxValue (#2495): raw AL expression text, unquoted — these are numeric
+        // literals (e.g. `MinValue = 0;`), never a quoted string, so no unescaping is needed.
+        // Passed through to MetaField.minValue/maxValue (both plain strings); NCL's own
+        // TestPage-control-write validation is what parses and enforces them, so the runner's
+        // only job is carrying the declared text.
+        var minValue = PropValue(props, "MinValue")?.ToString()?.Trim();
+        var maxValue = PropValue(props, "MaxValue")?.ToString()?.Trim();
+
         return new ParsedField(fid, fname, ftype, length, isFlowField, calcFormula,
             optionMembers, initValueText, isAutoIncrement, caption,
-            relationArms, relationValidate, isFlowFilter, obsoleteState, obsoleteReason);
+            relationArms, relationValidate, isFlowFilter, obsoleteState, obsoleteReason,
+            minValue, maxValue);
     }
 
     /// <summary>
@@ -1069,7 +1078,11 @@ internal record ParsedRelationArm(string TableName, string? FieldName, List<Pars
 /// names exactly, so <c>Enum.Parse</c> in BuildMetaField needs no translation table (#1780).</param>
 /// <param name="ObsoleteReason">The declared reason text, unquoted/unescaped, or null when the
 /// field declares no ObsoleteReason (distinct from an explicit empty string).</param>
-internal record ParsedField(int FieldId, string FieldName, string TypeName, int Length, bool IsFlowField = false, ParsedCalcFormula? CalcFormula = null, string? OptionMembers = null, string? InitValueText = null, bool IsAutoIncrement = false, string? Caption = null, List<ParsedRelationArm>? RelationArms = null, bool RelationValidate = true, bool IsFlowFilter = false, string ObsoleteState = "No", string? ObsoleteReason = null);
+/// <param name="MinValue">The declared AL expression text for MinValue (e.g. "0"), or null when
+/// undeclared. Passed through to MetaField.minValue (a string) unparsed — NCL's own field
+/// validation on TestPage SetValue is what evaluates and formats it (#2495).</param>
+/// <param name="MaxValue">Same shape as <see cref="MinValue"/>, for MaxValue.</param>
+internal record ParsedField(int FieldId, string FieldName, string TypeName, int Length, bool IsFlowField = false, ParsedCalcFormula? CalcFormula = null, string? OptionMembers = null, string? InitValueText = null, bool IsAutoIncrement = false, string? Caption = null, List<ParsedRelationArm>? RelationArms = null, bool RelationValidate = true, bool IsFlowFilter = false, string ObsoleteState = "No", string? ObsoleteReason = null, string? MinValue = null, string? MaxValue = null);
 internal record ParsedKey(string Name, List<int> FieldIds);
 
 /// <summary>Which value shape a <see cref="ParsedColumnFilter"/> condition carries — matches

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -88,6 +88,38 @@ public static partial class RecordPatches
         return null;
     }
 
+    /// <summary>
+    /// The field's declared MinValue/MaxValue AL text (#2495), straight from the parsed table
+    /// source — same rationale as <see cref="TryGetParsedFieldCaption"/>. NCLMetaField
+    /// (Microsoft.Dynamics.Nav.Runtime) does not expose these at all — CreateFromMetaTable's
+    /// AssignFromMetaTable only copies them into MetaField's OWN validation machinery, not onto
+    /// any property this runner can read back off the constructed NCLMetaField instance
+    /// (confirmed empirically: NCLMetaField has no Min/MaxValue-named member of any accessibility).
+    /// So MinValue/MaxValue enforcement (TestPageMinMaxValue.Check in MockTestPage.cs) reads the
+    /// parse-time source directly, same as Caption does, rather than the runtime metadata object.
+    /// A field not found (extension field merged in under a different table, or a table never
+    /// parsed) answers (null, null) — the caller then simply enforces nothing, matching "field
+    /// declares no MinValue/MaxValue".
+    /// </summary>
+    internal static (string? Min, string? Max) TryGetParsedFieldMinMax(int tableId, int fieldNo)
+    {
+        if (!_parsedTables.TryGetValue(tableId, out var parsed))
+        {
+            // Extension fields for this base table are tracked separately (see
+            // _parsedExtensionFields in BuildNCLMetaTable) and may be the only place a
+            // tableextension-added bounded field's MinValue/MaxValue lives.
+            return (null, null);
+        }
+        foreach (var f in parsed.Fields)
+            if (f.FieldId == fieldNo)
+                return (f.MinValue, f.MaxValue);
+        if (_parsedExtensionFields.TryGetValue(parsed.TableName.ToLowerInvariant(), out var ext))
+            foreach (var f in ext)
+                if (f.FieldId == fieldNo)
+                    return (f.MinValue, f.MaxValue);
+        return (null, null);
+    }
+
     private static NCLMetaTable? BuildNCLMetaTable(int tableId)
     {
         if (!_parsedTables.TryGetValue(tableId, out var parsed))
@@ -489,6 +521,21 @@ public static partial class RecordPatches
             if (p.Name == "obsoleteReason" && !string.IsNullOrEmpty(f.ObsoleteReason))
             {
                 args[i] = f.ObsoleteReason;
+                continue;
+            }
+            // MinValue / MaxValue (#2495): carried through as the declared AL text. NCL's
+            // TestPage-control-write validation path reads NCLMetaField.minValue/maxValue and
+            // does the parse + range check + error-message formatting itself — real BC does
+            // NOT enforce these on Rec.Validate or plain field assignment, only on a page
+            // control write, so this builder's only job is not swallowing the declaration.
+            if (p.Name == "minValue" && !string.IsNullOrEmpty(f.MinValue))
+            {
+                args[i] = f.MinValue;
+                continue;
+            }
+            if (p.Name == "maxValue" && !string.IsNullOrEmpty(f.MaxValue))
+            {
+                args[i] = f.MaxValue;
                 continue;
             }
             if (p.Name == "relations" && relationsObj != null)


### PR DESCRIPTION
Closes #2495

## Summary
A field's declared `MinValue`/`MaxValue` was parsed nowhere and enforced nowhere, so a TestPage control's `SetValue` on a bounded field let an out-of-range value through silently.

Measured against real BC (28.1/28.4, see issue #2490's arm A2/D2): the bound is enforced on a TestPage control write only. `Rec.Validate` and a plain field assignment do NOT enforce it. The fix therefore lives at the TestPage-write layer (`MockTestPage.cs`'s `LiveNavTestField.Value` setter, via a new `TestPageMinMaxValue.Check`), not in `NavRecord.ALValidateAsync` (which `Rec.Validate` also calls) — putting it there would have made the SetValue case pass while silently breaking the Validate-does-not-enforce behavior.

`RecordPatches.TryGetParsedFieldMinMax` reads the AL-declared `MinValue`/`MaxValue` text from the parsed table source (both a plain `table` and a `tableextension` field share the same `ParseFieldSyntax` path), and from precompiled `.app` `SymbolReference.json` for both a base table's own fields and a precompiled tableextension's fields. `NCLMetaField` (the runtime metadata object, `Microsoft.Dynamics.Nav.Runtime`) does not expose `MinValue`/`MaxValue` at all — confirmed empirically via reflection over the loaded assembly — so the check reads the parse-time source directly, the same pattern `TryGetParsedFieldCaption` already uses for `Caption`.

## Shape check (per the workflow's "fix the shape, not just the reported line")
- **Same wrong pattern elsewhere?** `ParsedField` already carries a handful of AL field properties this way (`ObsoleteState`/`ObsoleteReason`, `Caption`, `TableRelation`, `OptionMembers`) — `MinValue`/`MaxValue` is the same shape, now added alongside them in both the source-parser and both `BcAppSymbolCache` call sites (precompiled base table, precompiled tableextension), so nothing is half-covered.
- **Sibling field properties with the same gap?** Yes — `NotBlank`, `ValuesAllowed`, `Numeric`, `CharAllowed` are similarly unplumbed (confirmed via the same `MetaField` ctor reflection: they're real ctor parameters, never populated). Out of scope for this fix (different enforcement surfaces/semantics need their own BC measurement); noting for a follow-up rather than silently leaving it undiscovered.
- **Two code paths, same invariant?** `Rec.Validate` and plain assignment both correctly stay unenforced — both are covered by explicit negative tests (runner-side and, once merged, upstream) so a future change to `ALValidateAsync` can't silently leak enforcement into Validate.

## Tests
- Runner-mechanism test: `AlRunner.Tests/TestPageMinMaxValueDispatchTests.cs` — proves the dispatch wiring (SetValue enforces on both bounds and both numeric types; Validate/assignment do not), independent of the corpus.
- BC-behavior test (upstream, not yet merged): StefanMaron/BusinessCentral.AL.Language.Tests#117 — the corpus's own CI is the adjudicator for the exact error text and the four-surface asymmetry. The submodule pin bump + count-baseline update will follow in this PR once #117 is green on both BC legs and merged.

## RED to GREEN
Local repro against a private cache:
- Before: SetValue(-1)/SetValue(101) on a MinValue=0/MaxValue=100 Decimal field raised nothing — asserterror failed with "An error was expected".
- After: both raise "Validation error for Field: Completion,  Message = 'The value must be greater than or equal to 0. Value: -1.00. (Select Refresh to discard errors)'" (and the mirror for max), matching the text measured against real BC in #2490's arm A2. Rec.Validate/plain assignment on the same field continue to store the out-of-range value with no error, matching #2490's arm D2.