### PR TITLE
fix(startup): make ncl-shadow publish/prune safe under concurrent al-runner startups

### DIFF
--- a/AlRunner.Tests/NclShadowConcurrentStartupTests.cs
+++ b/AlRunner.Tests/NclShadowConcurrentStartupTests.cs
@@ -402,81 +402,43 @@ public sealed class NclShadowConcurrentStartupTests
     }
 
     // ─────────────────────────────────────────────────────────────────────────
-    // NclCecilRewrite.FileContentEquals — outcome 4 (redundant child re-copy)
+    // BcArtifacts.GetAssemblyNameWithRetry — the original #2489 crash site
     // ─────────────────────────────────────────────────────────────────────────
 
-    /// <summary>Positive: identical content at both paths compares equal — the case
-    /// RewriteInPlace's cache-HIT branch now uses to skip a pointless (and, under
-    /// concurrent shadow-dir startups, actively racy) re-copy of Ncl.dll that a sibling
-    /// or the parent EnsureShadowDir build already wrote.</summary>
+    /// <summary>Positive + regression pin: a transient exclusive lock on the target file
+    /// (standing in for NclCecilRewrite.RewriteInPlace's atomic-replace rename landing at
+    /// the wrong moment — the field report's own "MoveDirectory ... Access is denied"
+    /// shape, one level down at the file-read side) must NOT make the read fail outright.
+    /// Before this fix, AssemblyName.GetAssemblyName had no retry, so this exact
+    /// contention crashed BcArtifacts.VerifyEngineConsistency in the field. The lock is
+    /// released from a background task shortly after the read starts, well inside the
+    /// method's retry budget.</summary>
     [Fact]
-    public void FileContentEquals_IdenticalBytes_ReturnsTrue()
+    public void GetAssemblyNameWithRetry_TransientExclusiveLock_RetriesUntilReadable()
     {
-        var dir = NewTempDir("content-equal");
+        var dir = NewTempDir("assemblyname-retry");
         try
         {
-            var a = Path.Combine(dir, "a.dll");
-            var b = Path.Combine(dir, "b.dll");
-            var bytes = new byte[50000];
-            new Random(42).NextBytes(bytes);
-            File.WriteAllBytes(a, bytes);
-            File.WriteAllBytes(b, bytes);
+            var path = Path.Combine(dir, "Some.Assembly.dll");
+            // A real, loadable managed assembly — the runner's own test assembly makes a
+            // convenient, always-available stand-in for the shadow dir's Ncl.dll.
+            File.Copy(typeof(NclShadowConcurrentStartupTests).Assembly.Location, path);
 
-            Assert.True(NclCecilRewrite.FileContentEquals(a, b));
-        }
-        finally { Directory.Delete(dir, recursive: true); }
-    }
+            using var exclusiveLock = new FileStream(
+                path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
 
-    /// <summary>Negative: different content (even same length) compares unequal — proves
-    /// the check reads bytes rather than just comparing size/timestamps, which would let a
-    /// genuinely stale destination silently keep wrong content.</summary>
-    [Fact]
-    public void FileContentEquals_SameLengthDifferentBytes_ReturnsFalse()
-    {
-        var dir = NewTempDir("content-unequal");
-        try
-        {
-            var a = Path.Combine(dir, "a.dll");
-            var b = Path.Combine(dir, "b.dll");
-            File.WriteAllBytes(a, new byte[] { 1, 2, 3, 4 });
-            File.WriteAllBytes(b, new byte[] { 1, 2, 3, 5 });
+            var releaseAfter = Task.Run(async () =>
+            {
+                await Task.Delay(300);
+                exclusiveLock.Dispose();
+            });
 
-            Assert.False(NclCecilRewrite.FileContentEquals(a, b));
-        }
-        finally { Directory.Delete(dir, recursive: true); }
-    }
+            // Blocks on the lock above for a few retry iterations, then succeeds once
+            // the background task above disposes it.
+            var name = AlRunner.Infrastructure.BcArtifacts.GetAssemblyNameWithRetry(path);
 
-    /// <summary>Negative: different length compares unequal without needing to read the
-    /// larger file (the cheap-path assertion is implicit — this just proves correctness).</summary>
-    [Fact]
-    public void FileContentEquals_DifferentLength_ReturnsFalse()
-    {
-        var dir = NewTempDir("content-unequal-len");
-        try
-        {
-            var a = Path.Combine(dir, "a.dll");
-            var b = Path.Combine(dir, "b.dll");
-            File.WriteAllBytes(a, new byte[] { 1, 2, 3 });
-            File.WriteAllBytes(b, new byte[] { 1, 2, 3, 4, 5 });
-
-            Assert.False(NclCecilRewrite.FileContentEquals(a, b));
-        }
-        finally { Directory.Delete(dir, recursive: true); }
-    }
-
-    /// <summary>Negative: destination missing entirely is "not equal", not an exception —
-    /// RewriteInPlace's normal write path must still run for a fresh shadowDir build.</summary>
-    [Fact]
-    public void FileContentEquals_DestMissing_ReturnsFalse()
-    {
-        var dir = NewTempDir("content-dest-missing");
-        try
-        {
-            var a = Path.Combine(dir, "a.dll");
-            File.WriteAllBytes(a, new byte[] { 1, 2, 3 });
-            var b = Path.Combine(dir, "does-not-exist.dll");
-
-            Assert.False(NclCecilRewrite.FileContentEquals(a, b));
+            Assert.NotNull(name.Name);
+            releaseAfter.Wait(TimeSpan.FromSeconds(5));
         }
         finally { Directory.Delete(dir, recursive: true); }
     }

--- a/AlRunner.Tests/NclShadowConcurrentStartupTests.cs
+++ b/AlRunner.Tests/NclShadowConcurrentStartupTests.cs
@@ -334,6 +334,47 @@ public sealed class NclShadowConcurrentStartupTests
         finally { Directory.Delete(root, recursive: true); }
     }
 
+    /// <summary>Positive + regression pin: healing must ADD only the files actually
+    /// missing, never overwrite one that already exists at that path — even when its
+    /// content differs from the healing build's. File.Copy(overwrite: true) on an
+    /// EXISTING file truncates-and-rewrites it in place, which corrupts a memory-mapped
+    /// reader (a sibling process with that exact file loaded as an assembly) even though
+    /// that sibling never touched the shadow dir itself past its own startup — confirmed
+    /// as the residual cause of a live CI regression after the whole-directory-swap fix
+    /// (BatchAppIdentityTests: a specific app's compiled test output going missing,
+    /// still reproducing after the swap-vs-in-place fix, until this "never overwrite an
+    /// existing file" tightening landed).</summary>
+    [Fact]
+    public void PublishShadowDir_SelfHeal_NeverOverwritesAnExistingHealableFile()
+    {
+        var root = NewTempDir("publish-selfheal-no-overwrite");
+        try
+        {
+            var origFull = @"C:\install\any";
+            var shadowDir = Path.Combine(root, "key");
+            Directory.CreateDirectory(shadowDir);
+            File.WriteAllText(Path.Combine(shadowDir, MarkerFileName), origFull);
+            // Ncl.dll ALREADY present with distinct content — stands in for a file a
+            // live sibling process might already have memory-mapped.
+            File.WriteAllBytes(Path.Combine(shadowDir, NclFileName), new byte[] { 0x11, 0x22, 0x33 });
+            // al-runner.dll and the manifests deliberately missing — the incomplete shape.
+
+            var tempDir = Path.Combine(root, "key.building.nooverwrite");
+            WriteCompleteShadowDir(tempDir, origFull, dllBytes: new byte[] { 9, 9, 9 });
+            File.WriteAllBytes(Path.Combine(tempDir, NclFileName), new byte[] { 0xAA, 0xBB, 0xCC }); // different content
+
+            NclShadowRuntime.PublishShadowDir(tempDir, shadowDir, origFull);
+
+            // Ncl.dll's PRE-EXISTING bytes must survive untouched — never overwritten,
+            // even though tempDir's copy has different content.
+            Assert.Equal(new byte[] { 0x11, 0x22, 0x33 }, File.ReadAllBytes(Path.Combine(shadowDir, NclFileName)));
+            // The genuinely missing files were still filled in, so the dir IS complete.
+            Assert.True(NclShadowRuntime.IsShadowDirComplete(shadowDir, origFull));
+            Assert.Equal(new byte[] { 9, 9, 9 }, File.ReadAllBytes(Path.Combine(shadowDir, EntryDllName)));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
     /// <summary>Negative: after self-healing, a subsequent EnsureShadowDir-style reuse
     /// check against the now-healed dir reports it reusable — proving the fix actually
     /// un-sticks the state rather than merely not-crashing once.</summary>

--- a/AlRunner.Tests/NclShadowConcurrentStartupTests.cs
+++ b/AlRunner.Tests/NclShadowConcurrentStartupTests.cs
@@ -1,0 +1,409 @@
+// NclShadowConcurrentStartupTests — #2489: several `al-runner` processes racing to build
+// the SAME `ncl-shadow` cache root observed four outcomes: prune deleting files out of a
+// sibling's in-flight `.building.*` temp dir, a resulting shadow dir published complete
+// enough to pass the old rename-into-place check but missing its entry DLL forever after
+// (sticky — nothing revisited it once published), the `MoveDirectory ... Access is
+// denied` crash that surfaced only the rarest of those, and every re-exec'd child
+// redundantly re-copying Microsoft.Dynamics.Nav.Ncl.dll into a dir siblings are reading
+// from. This file pins the three mechanism fixes directly, deterministically — no
+// subprocess race needed since each fix is a pure function over on-disk shape.
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class NclShadowConcurrentStartupTests
+{
+    private static string NewTempDir(string label)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"ncl-shadow-race-{label}-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private const string MarkerFileName = ".al-runner-shadow-source";
+    private const string EntryDllName = "al-runner.dll";
+    private const string NclFileName = "Microsoft.Dynamics.Nav.Ncl.dll";
+
+    private static void WriteCompleteShadowDir(string dir, string origFull, byte[]? dllBytes = null)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, MarkerFileName), origFull);
+        File.WriteAllBytes(Path.Combine(dir, EntryDllName), dllBytes ?? new byte[] { 1, 2, 3 });
+        File.WriteAllBytes(Path.Combine(dir, NclFileName), new byte[] { 4, 5, 6 });
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // PruneStaleShadowDirs — must never touch a sibling's *.building.* temp dir
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Positive + regression pin: even when the shadow root holds far more than
+    /// `keepNewest` entries, any directory whose name contains ".building." is excluded
+    /// from BOTH the candidate set and the keepNewest count — it must survive untouched,
+    /// content and all, no matter how old its LastWriteTimeUtc looks. Before this fix a
+    /// `.building.*` dir was ordinary prune fodder once the root held more than
+    /// `keepNewest` total entries; #2489 measured this deleting files out of a sibling's
+    /// in-flight build 44 times across 5 runs at N=10.</summary>
+    [Fact]
+    public void PruneStaleShadowDirs_NeverDeletesBuildingDirs_EvenWhenOldestAndRootIsFull()
+    {
+        var root = NewTempDir("prune-protects-building");
+        try
+        {
+            // 6 old "published" dirs (all older than the building dir) plus 1 in-flight
+            // .building dir that is, by name pattern alone, the one a naive LRU-by-time
+            // prune would pick as "oldest and therefore prunable first" once the .building
+            // dir's LastWriteTimeUtc is made even older via a stale touch below.
+            var buildingDir = Path.Combine(root, "somekey.building." + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(buildingDir);
+            var sentinel = Path.Combine(buildingDir, "Microsoft.Extensions.Http.dll");
+            File.WriteAllText(sentinel, "mid-copy content a sibling is still writing");
+            Directory.SetLastWriteTimeUtc(buildingDir, DateTime.UtcNow.AddHours(-10));
+
+            for (var i = 0; i < 6; i++)
+            {
+                var d = Path.Combine(root, $"published-{i}-{Guid.NewGuid():N}");
+                Directory.CreateDirectory(d);
+                File.WriteAllText(Path.Combine(d, "x.txt"), "x");
+                Directory.SetLastWriteTimeUtc(d, DateTime.UtcNow.AddHours(-1 - i));
+            }
+
+            var protectedDir = Path.Combine(root, "protected-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(protectedDir);
+
+            NclShadowRuntime.PruneStaleShadowDirs(root, protectedDir, keepNewest: 2);
+
+            Assert.True(Directory.Exists(buildingDir), "a .building.* dir must never be pruned");
+            Assert.True(File.Exists(sentinel), "content mid-copy inside a .building.* dir must survive prune");
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>Negative (cost-control half): a directory that does NOT carry ".building."
+    /// in its name is still ordinary prune fodder once the root exceeds keepNewest — the
+    /// exclusion above must be specific to the building-marker pattern, not a regression
+    /// into "prune never deletes anything".</summary>
+    [Fact]
+    public void PruneStaleShadowDirs_StillPrunesOrdinaryStaleDirs()
+    {
+        var root = NewTempDir("prune-still-works");
+        try
+        {
+            var oldest = Path.Combine(root, "published-oldest-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(oldest);
+            Directory.SetLastWriteTimeUtc(oldest, DateTime.UtcNow.AddDays(-30));
+
+            for (var i = 0; i < 3; i++)
+            {
+                var d = Path.Combine(root, $"published-{i}-{Guid.NewGuid():N}");
+                Directory.CreateDirectory(d);
+                Directory.SetLastWriteTimeUtc(d, DateTime.UtcNow.AddHours(-1 - i));
+            }
+
+            var protectedDir = Path.Combine(root, "protected-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(protectedDir);
+
+            NclShadowRuntime.PruneStaleShadowDirs(root, protectedDir, keepNewest: 2);
+
+            Assert.False(Directory.Exists(oldest), "an ordinary (non-.building.) stale dir must still be pruned");
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // IsShadowDirComplete
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsShadowDirComplete_AllFilesPresentAndMarkerMatches_ReturnsTrue()
+    {
+        var dir = NewTempDir("complete-true");
+        try
+        {
+            WriteCompleteShadowDir(dir, origFull: @"C:\install\any");
+            Assert.True(NclShadowRuntime.IsShadowDirComplete(dir, @"C:\install\any"));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    /// <summary>Negative + regression pin for outcome 3: marker present but the entry DLL
+    /// missing — exactly the shape #2489 measured as sticky output of a partial-prune
+    /// race (missing, variously, al-runner.dll / al-runner.exe / al-runner.deps.json /
+    /// .al-runner-shadow-source).</summary>
+    [Fact]
+    public void IsShadowDirComplete_MarkerPresentButEntryDllMissing_ReturnsFalse()
+    {
+        var dir = NewTempDir("complete-missing-dll");
+        try
+        {
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, MarkerFileName), @"C:\install\any");
+            File.WriteAllBytes(Path.Combine(dir, NclFileName), new byte[] { 1 });
+            // al-runner.dll deliberately absent.
+
+            Assert.False(NclShadowRuntime.IsShadowDirComplete(dir, @"C:\install\any"));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void IsShadowDirComplete_MarkerPointsAtDifferentInstall_ReturnsFalse()
+    {
+        var dir = NewTempDir("complete-wrong-install");
+        try
+        {
+            WriteCompleteShadowDir(dir, origFull: @"C:\install\OTHER");
+            Assert.False(NclShadowRuntime.IsShadowDirComplete(dir, @"C:\install\any"));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void IsShadowDirComplete_DirDoesNotExist_ReturnsFalse()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "ncl-shadow-race-does-not-exist-" + Guid.NewGuid().ToString("N"));
+        Assert.False(NclShadowRuntime.IsShadowDirComplete(dir, @"C:\install\any"));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // PublishShadowDir — atomic publish + self-heal (outcomes 2 and 3)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Positive: the ordinary, uncontended case — shadowDir does not exist yet,
+    /// so tempDir is simply renamed into place.</summary>
+    [Fact]
+    public void PublishShadowDir_ShadowDirAbsent_MovesTempDirIntoPlace()
+    {
+        var root = NewTempDir("publish-clean");
+        try
+        {
+            var origFull = @"C:\install\any";
+            var tempDir = Path.Combine(root, "key.building.abc");
+            WriteCompleteShadowDir(tempDir, origFull, dllBytes: new byte[] { 9, 9, 9 });
+            var shadowDir = Path.Combine(root, "key");
+
+            NclShadowRuntime.PublishShadowDir(tempDir, shadowDir, origFull);
+
+            Assert.False(Directory.Exists(tempDir), "temp dir must be consumed by the move");
+            Assert.True(NclShadowRuntime.IsShadowDirComplete(shadowDir, origFull));
+            Assert.Equal(new byte[] { 9, 9, 9 }, File.ReadAllBytes(Path.Combine(shadowDir, EntryDllName)));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>Positive + regression pin for outcome 2 (the ORIGINAL lost-race handler's
+    /// job, preserved): a sibling already published a COMPLETE shadowDir first — adopt it,
+    /// discard our own temp build, and do not overwrite the winner's content.</summary>
+    [Fact]
+    public void PublishShadowDir_SiblingAlreadyPublishedComplete_AdoptsWinnerAndDiscardsOwnBuild()
+    {
+        var root = NewTempDir("publish-adopt");
+        try
+        {
+            var origFull = @"C:\install\any";
+            var shadowDir = Path.Combine(root, "key");
+            WriteCompleteShadowDir(shadowDir, origFull, dllBytes: new byte[] { 1, 1, 1 }); // the "winner"
+
+            var tempDir = Path.Combine(root, "key.building.def");
+            WriteCompleteShadowDir(tempDir, origFull, dllBytes: new byte[] { 2, 2, 2 }); // our own build
+
+            NclShadowRuntime.PublishShadowDir(tempDir, shadowDir, origFull);
+
+            Assert.False(Directory.Exists(tempDir), "own temp build must be discarded on a lost clean race");
+            Assert.Equal(new byte[] { 1, 1, 1 }, File.ReadAllBytes(Path.Combine(shadowDir, EntryDllName)));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>Positive + the actual #2489 regression pin (outcome 3): a sibling
+    /// (or a past run, before this fix) published an INCOMPLETE shadowDir — marker present,
+    /// entry DLL missing. Before this fix that state was sticky forever: Directory.Move
+    /// onto an existing dir always throws, and the old handler treated ANY IOException
+    /// with Directory.Exists(shadowDir) true as "someone else won cleanly", discarding the
+    /// good build and leaving the broken one in place. Now: self-heal — move the broken
+    /// one aside, publish the good build in its place.</summary>
+    [Fact]
+    public void PublishShadowDir_SiblingPublishedIncomplete_SelfHealsByReplacingWithOwnCompleteBuild()
+    {
+        var root = NewTempDir("publish-selfheal");
+        try
+        {
+            var origFull = @"C:\install\any";
+            var shadowDir = Path.Combine(root, "key");
+            Directory.CreateDirectory(shadowDir);
+            File.WriteAllText(Path.Combine(shadowDir, MarkerFileName), origFull);
+            File.WriteAllBytes(Path.Combine(shadowDir, NclFileName), new byte[] { 4, 5, 6 });
+            // al-runner.dll deliberately missing — the exact sticky shape #2489 measured.
+
+            var tempDir = Path.Combine(root, "key.building.ghi");
+            WriteCompleteShadowDir(tempDir, origFull, dllBytes: new byte[] { 7, 7, 7 });
+
+            NclShadowRuntime.PublishShadowDir(tempDir, shadowDir, origFull);
+
+            Assert.True(NclShadowRuntime.IsShadowDirComplete(shadowDir, origFull),
+                "the incomplete published dir must be healed into a complete one");
+            Assert.Equal(new byte[] { 7, 7, 7 }, File.ReadAllBytes(Path.Combine(shadowDir, EntryDllName)));
+            Assert.False(Directory.Exists(tempDir));
+
+            // No leftover ".stale." dir from the self-heal (best-effort cleanup succeeded
+            // in this uncontended scenario).
+            Assert.Empty(Directory.GetDirectories(root)
+                .Where(d => Path.GetFileName(d).Contains(".stale.", StringComparison.OrdinalIgnoreCase)));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    /// <summary>Negative: after self-healing, a subsequent EnsureShadowDir-style reuse
+    /// check against the now-healed dir reports it reusable — proving the fix actually
+    /// un-sticks the state rather than merely not-crashing once.</summary>
+    [Fact]
+    public void PublishShadowDir_AfterSelfHeal_ResultIsReusableOnNextCheck()
+    {
+        var root = NewTempDir("publish-selfheal-reusable");
+        try
+        {
+            var origFull = @"C:\install\any";
+            var shadowDir = Path.Combine(root, "key");
+            Directory.CreateDirectory(shadowDir);
+            File.WriteAllText(Path.Combine(shadowDir, MarkerFileName), origFull);
+            // Neither al-runner.dll nor Ncl.dll present — worse than the field case, still
+            // must heal.
+
+            var tempDir = Path.Combine(root, "key.building.jkl");
+            WriteCompleteShadowDir(tempDir, origFull);
+
+            NclShadowRuntime.PublishShadowDir(tempDir, shadowDir, origFull);
+
+            Assert.True(NclShadowRuntime.IsShadowDirComplete(shadowDir, origFull));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // NclCecilRewrite.FileContentEquals — outcome 4 (redundant child re-copy)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Positive: identical content at both paths compares equal — the case
+    /// RewriteInPlace's cache-HIT branch now uses to skip a pointless (and, under
+    /// concurrent shadow-dir startups, actively racy) re-copy of Ncl.dll that a sibling
+    /// or the parent EnsureShadowDir build already wrote.</summary>
+    [Fact]
+    public void FileContentEquals_IdenticalBytes_ReturnsTrue()
+    {
+        var dir = NewTempDir("content-equal");
+        try
+        {
+            var a = Path.Combine(dir, "a.dll");
+            var b = Path.Combine(dir, "b.dll");
+            var bytes = new byte[50000];
+            new Random(42).NextBytes(bytes);
+            File.WriteAllBytes(a, bytes);
+            File.WriteAllBytes(b, bytes);
+
+            Assert.True(NclCecilRewrite.FileContentEquals(a, b));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    /// <summary>Negative: different content (even same length) compares unequal — proves
+    /// the check reads bytes rather than just comparing size/timestamps, which would let a
+    /// genuinely stale destination silently keep wrong content.</summary>
+    [Fact]
+    public void FileContentEquals_SameLengthDifferentBytes_ReturnsFalse()
+    {
+        var dir = NewTempDir("content-unequal");
+        try
+        {
+            var a = Path.Combine(dir, "a.dll");
+            var b = Path.Combine(dir, "b.dll");
+            File.WriteAllBytes(a, new byte[] { 1, 2, 3, 4 });
+            File.WriteAllBytes(b, new byte[] { 1, 2, 3, 5 });
+
+            Assert.False(NclCecilRewrite.FileContentEquals(a, b));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    /// <summary>Negative: different length compares unequal without needing to read the
+    /// larger file (the cheap-path assertion is implicit — this just proves correctness).</summary>
+    [Fact]
+    public void FileContentEquals_DifferentLength_ReturnsFalse()
+    {
+        var dir = NewTempDir("content-unequal-len");
+        try
+        {
+            var a = Path.Combine(dir, "a.dll");
+            var b = Path.Combine(dir, "b.dll");
+            File.WriteAllBytes(a, new byte[] { 1, 2, 3 });
+            File.WriteAllBytes(b, new byte[] { 1, 2, 3, 4, 5 });
+
+            Assert.False(NclCecilRewrite.FileContentEquals(a, b));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    /// <summary>Negative: destination missing entirely is "not equal", not an exception —
+    /// RewriteInPlace's normal write path must still run for a fresh shadowDir build.</summary>
+    [Fact]
+    public void FileContentEquals_DestMissing_ReturnsFalse()
+    {
+        var dir = NewTempDir("content-dest-missing");
+        try
+        {
+            var a = Path.Combine(dir, "a.dll");
+            File.WriteAllBytes(a, new byte[] { 1, 2, 3 });
+            var b = Path.Combine(dir, "does-not-exist.dll");
+
+            Assert.False(NclCecilRewrite.FileContentEquals(a, b));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Concurrency: N in-process PublishShadowDir races, deterministically ordered
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Positive: N concurrent PublishShadowDir calls against the SAME shadowDir
+    /// key (mirroring N daemons started at once, all computing the same content-hash
+    /// key) all succeed with no unhandled exception, and the final published dir is
+    /// complete — never left half-built, never left with one process's crash. Uses real
+    /// Task.Run concurrency (not a fixed interleaving) since the property under test —
+    /// "every attempt converges to some ONE complete result" — must hold for whichever
+    /// thread happens to win, not for one specific schedule.</summary>
+    [Fact]
+    public void PublishShadowDir_NConcurrentPublishersToSameKey_AllSucceedAndResultIsComplete()
+    {
+        var root = NewTempDir("publish-concurrent");
+        try
+        {
+            var origFull = @"C:\install\any";
+            var shadowDir = Path.Combine(root, "key");
+            const int n = 10;
+
+            var tempDirs = new string[n];
+            for (var i = 0; i < n; i++)
+            {
+                tempDirs[i] = Path.Combine(root, $"key.building.{i:D2}-{Guid.NewGuid():N}");
+                WriteCompleteShadowDir(tempDirs[i], origFull, dllBytes: BitConverter.GetBytes(i));
+            }
+
+            var exceptions = new System.Collections.Concurrent.ConcurrentBag<Exception>();
+            var tasks = tempDirs.Select(td => Task.Run(() =>
+            {
+                try { NclShadowRuntime.PublishShadowDir(td, shadowDir, origFull); }
+                catch (Exception ex) { exceptions.Add(ex); }
+            })).ToArray();
+            Task.WaitAll(tasks, TimeSpan.FromSeconds(30));
+
+            Assert.Empty(exceptions);
+            Assert.True(NclShadowRuntime.IsShadowDirComplete(shadowDir, origFull),
+                "the published dir must be complete after N concurrent publishers race to the same key");
+
+            // Every temp dir must have been consumed (moved or deleted) — none left
+            // orphaned under contention.
+            foreach (var td in tempDirs)
+                Assert.False(Directory.Exists(td), $"{td} must not be left behind");
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+}

--- a/AlRunner.Tests/NclShadowConcurrentStartupTests.cs
+++ b/AlRunner.Tests/NclShadowConcurrentStartupTests.cs
@@ -31,6 +31,8 @@ public sealed class NclShadowConcurrentStartupTests
         File.WriteAllText(Path.Combine(dir, MarkerFileName), origFull);
         File.WriteAllBytes(Path.Combine(dir, EntryDllName), dllBytes ?? new byte[] { 1, 2, 3 });
         File.WriteAllBytes(Path.Combine(dir, NclFileName), new byte[] { 4, 5, 6 });
+        File.WriteAllText(Path.Combine(dir, "al-runner.deps.json"), "{}");
+        File.WriteAllText(Path.Combine(dir, "al-runner.runtimeconfig.json"), "{}");
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -146,6 +148,29 @@ public sealed class NclShadowConcurrentStartupTests
         finally { Directory.Delete(dir, recursive: true); }
     }
 
+    /// <summary>Negative + regression pin: the issue's own field observation listed
+    /// al-runner.deps.json among the files variously missing from an incomplete
+    /// published dir. A dir with the entry DLL and Ncl.dll present but the deps
+    /// manifest missing still fails `dotnet exec` (hostfxr needs it), so it must not be
+    /// reported complete.</summary>
+    [Fact]
+    public void IsShadowDirComplete_DepsManifestMissing_ReturnsFalse()
+    {
+        var dir = NewTempDir("complete-missing-deps");
+        try
+        {
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, MarkerFileName), @"C:\install\any");
+            File.WriteAllBytes(Path.Combine(dir, EntryDllName), new byte[] { 1 });
+            File.WriteAllBytes(Path.Combine(dir, NclFileName), new byte[] { 1 });
+            File.WriteAllText(Path.Combine(dir, "al-runner.runtimeconfig.json"), "{}");
+            // al-runner.deps.json deliberately absent.
+
+            Assert.False(NclShadowRuntime.IsShadowDirComplete(dir, @"C:\install\any"));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
     [Fact]
     public void IsShadowDirComplete_MarkerPointsAtDifferentInstall_ReturnsFalse()
     {
@@ -247,8 +272,8 @@ public sealed class NclShadowConcurrentStartupTests
 
             // No leftover ".stale." dir from the self-heal (best-effort cleanup succeeded
             // in this uncontended scenario).
-            Assert.Empty(Directory.GetDirectories(root)
-                .Where(d => Path.GetFileName(d).Contains(".stale.", StringComparison.OrdinalIgnoreCase)));
+            Assert.DoesNotContain(Directory.GetDirectories(root),
+                d => Path.GetFileName(d).Contains(".stale.", StringComparison.OrdinalIgnoreCase));
         }
         finally { Directory.Delete(root, recursive: true); }
     }
@@ -393,8 +418,9 @@ public sealed class NclShadowConcurrentStartupTests
                 try { NclShadowRuntime.PublishShadowDir(td, shadowDir, origFull); }
                 catch (Exception ex) { exceptions.Add(ex); }
             })).ToArray();
-            Task.WaitAll(tasks, TimeSpan.FromSeconds(30));
+            var allCompleted = Task.WaitAll(tasks, TimeSpan.FromSeconds(30));
 
+            Assert.True(allCompleted, "all N publishers must finish within the timeout");
             Assert.Empty(exceptions);
             Assert.True(NclShadowRuntime.IsShadowDirComplete(shadowDir, origFull),
                 "the published dir must be complete after N concurrent publishers race to the same key");

--- a/AlRunner.Tests/NclShadowConcurrentStartupTests.cs
+++ b/AlRunner.Tests/NclShadowConcurrentStartupTests.cs
@@ -240,13 +240,69 @@ public sealed class NclShadowConcurrentStartupTests
         finally { Directory.Delete(root, recursive: true); }
     }
 
+    /// <summary>Positive + regression pin for the whole-directory-swap defect this fix
+    /// replaced: an earlier version of the self-heal did <c>Directory.Move(shadowDir,
+    /// staleAside)</c>, which is unsafe whenever a SIBLING PROCESS IS ALREADY RUNNING
+    /// from shadowDir — its AppContext.BaseDirectory was fixed to that exact path at its
+    /// own startup, so renaming the directory away breaks any later path-based lookup it
+    /// does off that string (confirmed as the root cause of a live CI regression: two
+    /// BatchAppIdentityTests failures whose subprocess output truncated mid-run after the
+    /// self-heal fired concurrently). This test proves the CURRENT shape: shadowDir's own
+    /// PATH is never renamed during a heal — a file handle opened against the original
+    /// path before the heal keeps reading the SAME bytes it already had, exactly as a
+    /// live process's already-open handles would.</summary>
+    [Fact]
+    public void PublishShadowDir_SelfHeal_NeverRenamesShadowDirItself()
+    {
+        var root = NewTempDir("publish-selfheal-no-rename");
+        try
+        {
+            var origFull = @"C:\install\any";
+            var shadowDir = Path.Combine(root, "key");
+            Directory.CreateDirectory(shadowDir);
+            File.WriteAllText(Path.Combine(shadowDir, MarkerFileName), origFull);
+            File.WriteAllBytes(Path.Combine(shadowDir, NclFileName), new byte[] { 4, 5, 6 });
+            // al-runner.dll deliberately missing — the incomplete shape.
+
+            // A file NOT among the ones the heal copies (see HealableFileNames) —
+            // stands in for a lazily loaded, load-by-path assembly a live sibling
+            // process might resolve off AppContext.BaseDirectory partway through its
+            // run (AlRunner.QueryJoin.dll, Win32Stubs, satellite resources — see the
+            // #2166/#2168 comments on MirrorInstallDirectory). A whole-directory swap
+            // (Directory.Move(shadowDir, staleAside) then delete staleAside) would take
+            // this file down with it; an in-place heal must leave it untouched at the
+            // exact same path.
+            var sentinelPath = Path.Combine(shadowDir, "AlRunner.QueryJoin.dll");
+            File.WriteAllBytes(sentinelPath, new byte[] { 0xAB, 0xCD });
+
+            var tempDir = Path.Combine(root, "key.building.noswap");
+            WriteCompleteShadowDir(tempDir, origFull, dllBytes: new byte[] { 8, 8, 8 });
+
+            NclShadowRuntime.PublishShadowDir(tempDir, shadowDir, origFull);
+
+            Assert.True(Directory.Exists(shadowDir));
+            Assert.True(NclShadowRuntime.IsShadowDirComplete(shadowDir, origFull));
+
+            // The sentinel survived at the SAME path with the SAME bytes — proves the
+            // heal never renamed shadowDir out from under whatever else lived in it.
+            Assert.True(File.Exists(sentinelPath), "an unrelated file in shadowDir must survive an in-place heal");
+            Assert.Equal(new byte[] { 0xAB, 0xCD }, File.ReadAllBytes(sentinelPath));
+
+            // No ".stale." sibling directory anywhere under root — the whole-directory
+            // rename path is gone, not just avoided in this one case.
+            Assert.DoesNotContain(Directory.GetDirectories(root),
+                d => Path.GetFileName(d).Contains(".stale.", StringComparison.OrdinalIgnoreCase));
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
     /// <summary>Positive + the actual #2489 regression pin (outcome 3): a sibling
     /// (or a past run, before this fix) published an INCOMPLETE shadowDir — marker present,
     /// entry DLL missing. Before this fix that state was sticky forever: Directory.Move
     /// onto an existing dir always throws, and the old handler treated ANY IOException
     /// with Directory.Exists(shadowDir) true as "someone else won cleanly", discarding the
-    /// good build and leaving the broken one in place. Now: self-heal — move the broken
-    /// one aside, publish the good build in its place.</summary>
+    /// good build and leaving the broken one in place. Now: self-heal in place — copy the
+    /// missing files from the good build directly into the existing dir.</summary>
     [Fact]
     public void PublishShadowDir_SiblingPublishedIncomplete_SelfHealsByReplacingWithOwnCompleteBuild()
     {

--- a/AlRunner/Infrastructure/BcArtifacts.cs
+++ b/AlRunner/Infrastructure/BcArtifacts.cs
@@ -457,11 +457,35 @@ public static class BcArtifacts
             p => AlRunner.Provisioning.ArtifactDownloader.ResolveVersion(p, log),
             out tier);
 
+    /// <summary>
+    /// #2489: <paramref name="path"/> here is the shadow-dir Ncl.dll that
+    /// <c>NclCecilRewrite.RewriteInPlace</c> atomically replaces (temp-write + rename)
+    /// at every process's own startup. Under concurrent same-key subprocess spawns
+    /// (measured: AlRunner.Tests classes sharing one ncl-shadow key) a plain
+    /// <c>AssemblyName.GetAssemblyName</c> read here can land squarely inside that
+    /// rename — <c>ERROR_SHARING_VIOLATION</c> on Windows, or a transient not-found on
+    /// either platform if caught between the old name being removed and the new one
+    /// appearing. Extracted so the retry itself is directly unit-testable without
+    /// touching <see cref="SelectedVersion"/>'s global, lazily-initialized state.
+    /// </summary>
+    internal static System.Reflection.AssemblyName GetAssemblyNameWithRetry(string path)
+    {
+        const int maxAttempts = 20;
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try { return System.Reflection.AssemblyName.GetAssemblyName(path); }
+            catch (IOException) when (attempt < maxAttempts) { System.Threading.Thread.Sleep(100); }
+            catch (UnauthorizedAccessException) when (attempt < maxAttempts) { System.Threading.Thread.Sleep(100); }
+        }
+        return System.Reflection.AssemblyName.GetAssemblyName(path); // final attempt — let it throw if still failing
+    }
+
     public static void VerifyEngineConsistency(string binDir)
     {
         var ncl = Path.Combine(binDir, "Microsoft.Dynamics.Nav.Ncl.dll");
         if (!File.Exists(ncl)) return; // nothing to compare against
-        var engineVer = System.Reflection.AssemblyName.GetAssemblyName(ncl).Version;
+
+        var engineVer = GetAssemblyNameWithRetry(ncl).Version;
         if (engineVer == null) return;
 
         var selected = SelectedVersion;

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -8782,10 +8782,7 @@ public static class NclCecilRewrite
     /// key, several processes legitimately read this SAME path around the same moment a
     /// sibling MISS-writer is <c>AtomicReplace</c>-ing it (temp-write + rename). On
     /// Windows a reader can catch that rename mid-flight and get
-    /// <c>ERROR_SHARING_VIOLATION</c> — measured directly: <c>File.ReadAllBytes</c> with
-    /// no retry here is exactly what <see cref="FileContentEquals"/>'s cache-HIT
-    /// optimization made MORE likely to hit, by adding a second unguarded read of the
-    /// same path right before this one. Same bounded retry/backoff shape as
+    /// <c>ERROR_SHARING_VIOLATION</c>. Same bounded retry/backoff shape as
     /// <see cref="AtomicReplace(string, byte[])"/>'s own writer-side retry, just for a
     /// reader instead.
     /// </summary>
@@ -8799,30 +8796,6 @@ public static class NclCecilRewrite
             catch (UnauthorizedAccessException) when (attempt < maxAttempts) { System.Threading.Thread.Sleep(250); }
         }
         return File.ReadAllBytes(path); // final attempt — let it throw if still failing
-    }
-
-    /// <summary>
-    /// True when <paramref name="destPath"/> already holds byte-identical content to
-    /// <paramref name="sourcePath"/> — used by <see cref="RewriteInPlace"/>'s cache-HIT
-    /// branch (#2489) to skip a write that would just reproduce bytes already there. Size
-    /// check first (cheap, avoids reading the larger file on the common "genuinely
-    /// different" path); any I/O failure reading either file (missing, a sibling
-    /// mid-write/mid-rename of the shared cache entry — see
-    /// <see cref="ReadAllBytesWithRetry"/>) is treated as "not equal" so the caller falls
-    /// through to the normal (retrying) write path rather than throwing here.
-    /// </summary>
-    internal static bool FileContentEquals(string sourcePath, string destPath)
-    {
-        try
-        {
-            if (!File.Exists(destPath)) return false;
-            var sourceInfo = new FileInfo(sourcePath);
-            var destInfo = new FileInfo(destPath);
-            if (sourceInfo.Length != destInfo.Length) return false;
-            return ReadAllBytesWithRetry(sourcePath).AsSpan().SequenceEqual(ReadAllBytesWithRetry(destPath));
-        }
-        catch (IOException) { return false; }
-        catch (UnauthorizedAccessException) { return false; }
     }
 
     public static bool RewriteInPlace(string srcDir, string binNclPath)
@@ -8860,26 +8833,19 @@ public static class NclCecilRewrite
         {
             Console.Error.WriteLine($"[Cecil] Cecil cache HIT (key={shortKey})");
 
-            // #2489: a shadow-re-exec CHILD (see NclShadowRuntime) starts from a
-            // directory whose Ncl.dll was ALREADY populated from this exact cache entry
-            // — by the PARENT process's own EnsureShadowDir call, which runs this same
-            // rewrite-or-cache-copy logic before publishing the shadow dir. Re-copying
-            // here is then pure waste that's also actively harmful under concurrent
-            // startups: several shadow children sharing one published dir (same key) all
-            // re-run this method at their own startup, so several `AtomicReplaceFrom`
-            // writers hit the identical destination file at once, right as
-            // BcArtifacts.VerifyEngineConsistency (a reader with no retry of its own) is
-            // trying to read it — measured as "used by another process" at N=4 on an
-            // empty root. Skip the copy entirely when the destination already holds
-            // these exact bytes; only a genuinely stale/missing/differing destination
-            // needs the write.
-            if (FileContentEquals(cachePath, binNclPath))
-            {
-                Console.Error.WriteLine($"[Cecil] {binNclPath} already matches the cached Ncl — skipping copy");
-                PruneCacheFiles(cacheDir, cachePath, keepNewest: 8);
-                return false;
-            }
-
+            // #2489: an earlier version of this method skipped this AtomicReplaceFrom
+            // call entirely when the destination already held these exact bytes (a
+            // shadow-re-exec CHILD's own Ncl.dll, already populated by the PARENT
+            // process's EnsureShadowDir call before publishing). That optimization was
+            // withdrawn — it could not be distinguished from a residual, hard-to-pin
+            // regression measured under CI's real concurrent-subprocess load
+            // (AlRunner.Tests classes racing this exact shared-key path), and
+            // AtomicReplaceFrom's rename-based replace is ALREADY safe for concurrent
+            // readers on its own (an open handle/mmap to the old inode keeps working
+            // through a rename; nothing here truncates a file in place). The
+            // BcArtifacts.VerifyEngineConsistency read this comment used to cite as the
+            // race motivating the skip is hardened directly instead — see its own retry
+            // wrapper — so removing the skip does not reopen that hole.
             AtomicReplaceFrom(cachePath, binNclPath);
             Console.Error.WriteLine($"[Cecil] Copied cached Ncl to {binNclPath}");
             PruneCacheFiles(cacheDir, cachePath, keepNewest: 8);

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -8819,7 +8819,7 @@ public static class NclCecilRewrite
             var sourceInfo = new FileInfo(sourcePath);
             var destInfo = new FileInfo(destPath);
             if (sourceInfo.Length != destInfo.Length) return false;
-            return File.ReadAllBytes(sourcePath).AsSpan().SequenceEqual(File.ReadAllBytes(destPath));
+            return ReadAllBytesWithRetry(sourcePath).AsSpan().SequenceEqual(ReadAllBytesWithRetry(destPath));
         }
         catch (IOException) { return false; }
         catch (UnauthorizedAccessException) { return false; }

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -8773,7 +8773,57 @@ public static class NclCecilRewrite
 
     /// <inheritdoc cref="AtomicReplace(string, byte[])"/>
     private static void AtomicReplaceFrom(string sourcePath, string destPath)
-        => AtomicReplace(destPath, File.ReadAllBytes(sourcePath));
+        => AtomicReplace(destPath, ReadAllBytesWithRetry(sourcePath));
+
+    /// <summary>
+    /// #2489: <paramref name="path"/> here is always the shared <c>ncl-cecil</c> cache
+    /// entry (keyed by content hash, so every process racing the same key writes
+    /// byte-identical bytes) — under N concurrent shadow-dir builds/re-execs sharing one
+    /// key, several processes legitimately read this SAME path around the same moment a
+    /// sibling MISS-writer is <c>AtomicReplace</c>-ing it (temp-write + rename). On
+    /// Windows a reader can catch that rename mid-flight and get
+    /// <c>ERROR_SHARING_VIOLATION</c> — measured directly: <c>File.ReadAllBytes</c> with
+    /// no retry here is exactly what <see cref="FileContentEquals"/>'s cache-HIT
+    /// optimization made MORE likely to hit, by adding a second unguarded read of the
+    /// same path right before this one. Same bounded retry/backoff shape as
+    /// <see cref="AtomicReplace(string, byte[])"/>'s own writer-side retry, just for a
+    /// reader instead.
+    /// </summary>
+    private static byte[] ReadAllBytesWithRetry(string path)
+    {
+        const int maxAttempts = 60;
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try { return File.ReadAllBytes(path); }
+            catch (IOException) when (attempt < maxAttempts) { System.Threading.Thread.Sleep(250); }
+            catch (UnauthorizedAccessException) when (attempt < maxAttempts) { System.Threading.Thread.Sleep(250); }
+        }
+        return File.ReadAllBytes(path); // final attempt — let it throw if still failing
+    }
+
+    /// <summary>
+    /// True when <paramref name="destPath"/> already holds byte-identical content to
+    /// <paramref name="sourcePath"/> — used by <see cref="RewriteInPlace"/>'s cache-HIT
+    /// branch (#2489) to skip a write that would just reproduce bytes already there. Size
+    /// check first (cheap, avoids reading the larger file on the common "genuinely
+    /// different" path); any I/O failure reading either file (missing, a sibling
+    /// mid-write/mid-rename of the shared cache entry — see
+    /// <see cref="ReadAllBytesWithRetry"/>) is treated as "not equal" so the caller falls
+    /// through to the normal (retrying) write path rather than throwing here.
+    /// </summary>
+    internal static bool FileContentEquals(string sourcePath, string destPath)
+    {
+        try
+        {
+            if (!File.Exists(destPath)) return false;
+            var sourceInfo = new FileInfo(sourcePath);
+            var destInfo = new FileInfo(destPath);
+            if (sourceInfo.Length != destInfo.Length) return false;
+            return File.ReadAllBytes(sourcePath).AsSpan().SequenceEqual(File.ReadAllBytes(destPath));
+        }
+        catch (IOException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
+    }
 
     public static bool RewriteInPlace(string srcDir, string binNclPath)
     {
@@ -8809,6 +8859,27 @@ public static class NclCecilRewrite
         if (File.Exists(cachePath))
         {
             Console.Error.WriteLine($"[Cecil] Cecil cache HIT (key={shortKey})");
+
+            // #2489: a shadow-re-exec CHILD (see NclShadowRuntime) starts from a
+            // directory whose Ncl.dll was ALREADY populated from this exact cache entry
+            // — by the PARENT process's own EnsureShadowDir call, which runs this same
+            // rewrite-or-cache-copy logic before publishing the shadow dir. Re-copying
+            // here is then pure waste that's also actively harmful under concurrent
+            // startups: several shadow children sharing one published dir (same key) all
+            // re-run this method at their own startup, so several `AtomicReplaceFrom`
+            // writers hit the identical destination file at once, right as
+            // BcArtifacts.VerifyEngineConsistency (a reader with no retry of its own) is
+            // trying to read it — measured as "used by another process" at N=4 on an
+            // empty root. Skip the copy entirely when the destination already holds
+            // these exact bytes; only a genuinely stale/missing/differing destination
+            // needs the write.
+            if (FileContentEquals(cachePath, binNclPath))
+            {
+                Console.Error.WriteLine($"[Cecil] {binNclPath} already matches the cached Ncl — skipping copy");
+                PruneCacheFiles(cacheDir, cachePath, keepNewest: 8);
+                return false;
+            }
+
             AtomicReplaceFrom(cachePath, binNclPath);
             Console.Error.WriteLine($"[Cecil] Copied cached Ncl to {binNclPath}");
             PruneCacheFiles(cacheDir, cachePath, keepNewest: 8);

--- a/AlRunner/Infrastructure/NclShadowRuntime.cs
+++ b/AlRunner/Infrastructure/NclShadowRuntime.cs
@@ -184,20 +184,14 @@ public static class NclShadowRuntime
 
         var shadowRoot = CacheRoots.Resolve("ncl-shadow");
         var shadowDir = Path.Combine(shadowRoot, key);
-        var markerPath = Path.Combine(shadowDir, MarkerFileName);
         var shadowDll = Path.Combine(shadowDir, EntryDllName);
-        var shadowNcl = Path.Combine(shadowDir, NclFileName);
 
         // AL_RUNNER_NCL_CACHE=0 (NclCecilRewrite's own escape hatch) means "always do a
         // fresh Cecil rewrite" — honour that here too rather than silently reusing a
         // stale shadow dir built before the flag was set.
         var forceFresh = Environment.GetEnvironmentVariable("AL_RUNNER_NCL_CACHE") == "0";
 
-        var reusable = !forceFresh
-            && File.Exists(markerPath)
-            && File.ReadAllText(markerPath) == origFull
-            && File.Exists(shadowDll)
-            && File.Exists(shadowNcl);
+        var reusable = !forceFresh && IsShadowDirComplete(shadowDir, origFull);
 
         if (reusable)
         {
@@ -239,26 +233,129 @@ public static class NclShadowRuntime
             // shadowDir that isn't complete.
             File.WriteAllText(Path.Combine(tempDir, MarkerFileName), origFull);
 
-            Directory.Move(tempDir, shadowDir);
-        }
-        catch (IOException) when (Directory.Exists(shadowDir))
-        {
-            // Lost the race: another process's Directory.Move landed first. Its
-            // directory is complete by construction (only ever created via this same
-            // rename-into-place path), and — same key — content-equivalent to what we
-            // would have built. Discard our temp build rather than leave it orphaned.
-            try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+            PublishShadowDir(tempDir, shadowDir, origFull);
         }
         finally
         {
             // Belt-and-braces cleanup if something above threw for an unrelated reason
-            // (e.g. RewriteInPlace failing) — don't leave a half-built temp dir behind.
+            // (e.g. RewriteInPlace failing), or PublishShadowDir already consumed/moved
+            // tempDir away — don't leave a half-built temp dir behind.
             try { if (Directory.Exists(tempDir)) Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
         }
 
         PruneStaleShadowDirs(shadowRoot, shadowDir, keepNewest: 4);
 
         return shadowDll;
+    }
+
+    /// <summary>
+    /// True when <paramref name="shadowDir"/> is a fully-built, reusable shadow dir for
+    /// <paramref name="origFull"/>: marker present and pointing at this exact install, plus
+    /// the entry assembly and Ncl.dll both on disk. Pulled out of the reuse-check in
+    /// <see cref="EnsureShadowDir"/> so <see cref="PublishShadowDir"/> can use the SAME
+    /// definition of "complete" to decide between adopting a sibling's already-published
+    /// dir and self-healing one that publish left incomplete (#2489).
+    /// </summary>
+    internal static bool IsShadowDirComplete(string shadowDir, string origFull)
+    {
+        var markerPath = Path.Combine(shadowDir, MarkerFileName);
+        var shadowDll = Path.Combine(shadowDir, EntryDllName);
+        var shadowNcl = Path.Combine(shadowDir, NclFileName);
+        try
+        {
+            return File.Exists(markerPath)
+                && File.ReadAllText(markerPath) == origFull
+                && File.Exists(shadowDll)
+                && File.Exists(shadowNcl);
+        }
+        catch (IOException)
+        {
+            // A sibling process racing a delete/replace of this exact dir right now —
+            // treat as "not complete" rather than letting the read explode; the caller
+            // will either adopt a later-observed complete dir or rebuild.
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Publishes <paramref name="tempDir"/> (a fully-built shadow dir, marker written last)
+    /// onto <paramref name="shadowDir"/>, atomically, and self-heals the two concurrent-
+    /// startup failure modes #2489 measured on top of the original lost-race handler:
+    ///
+    /// 1. <b>Clean race</b> — nobody else has published yet: <c>Directory.Move</c> (rename,
+    ///    atomic on the same volume) lands directly.
+    /// 2. <b>Lost a clean race</b> — a sibling's rename landed first and its directory is
+    ///    COMPLETE (only ever produced by this same path, so it's content-equivalent):
+    ///    adopt it, discard <paramref name="tempDir"/>.
+    /// 3. <b>Lost to an INCOMPLETE publish</b> — a sibling (or a past run, before this fix)
+    ///    published a dir with the marker but missing the entry DLL/Ncl.dll (e.g.
+    ///    <c>PruneStaleShadowDirs</c> deleted files out of its <c>.building.*</c> temp dir
+    ///    while it was still being mirrored, before this fix excluded that name pattern).
+    ///    That state used to be sticky forever — nothing revisited it once published, and
+    ///    <c>Directory.Move</c> onto an existing directory always throws, which the old
+    ///    lost-race handler treated as "someone else won" unconditionally. Self-heal
+    ///    instead: move the incomplete directory aside, publish ours in its place, then
+    ///    best-effort delete the stale one. Retried a few times since another process
+    ///    self-healing the SAME incomplete dir at the same moment can transiently collide.
+    /// </summary>
+    internal static void PublishShadowDir(string tempDir, string shadowDir, string origFull)
+    {
+        const int maxAttempts = 20;
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            if (!Directory.Exists(shadowDir))
+            {
+                try
+                {
+                    Directory.Move(tempDir, shadowDir);
+                    return;
+                }
+                catch (IOException) when (Directory.Exists(shadowDir))
+                {
+                    // A sibling published between our Exists check and our Move —
+                    // fall through to the adopt/self-heal logic below.
+                }
+            }
+
+            if (IsShadowDirComplete(shadowDir, origFull))
+            {
+                // Lost the race, but to a COMPLETE, content-equivalent directory (only
+                // ever produced by this same rename-into-place path) — adopt it.
+                try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+                return;
+            }
+
+            // shadowDir exists but is incomplete — self-heal by moving it aside and
+            // retrying. Best-effort: another process may be doing the exact same thing
+            // to the exact same directory right now, so a failure here just falls
+            // through to the next attempt rather than being fatal.
+            var staleAside = Path.Combine(
+                Path.GetDirectoryName(shadowDir)!,
+                $"{Path.GetFileName(shadowDir)}.stale.{Guid.NewGuid():N}");
+            try
+            {
+                Directory.Move(shadowDir, staleAside);
+                Console.Error.WriteLine(
+                    $"[reexec] Self-healing incomplete shadow dir at {shadowDir} (moved aside to {staleAside})");
+            }
+            catch (IOException)
+            {
+                // Someone else is already mid-self-heal (or mid-publish) of this exact
+                // dir — loop around and re-observe rather than racing them further.
+                continue;
+            }
+
+            try { Directory.Delete(staleAside, recursive: true); } catch { /* best effort */ }
+            // Loop around: shadowDir no longer exists (or a sibling just re-published
+            // it), so the top of the next iteration re-evaluates from scratch.
+        }
+
+        // Exhausted retries under sustained contention — leave tempDir for the finally
+        // block in EnsureShadowDir to clean up, and let the caller rebuild next call
+        // rather than publish something we can no longer prove is complete.
+        Console.Error.WriteLine(
+            $"[reexec] WARN: could not publish shadow dir at {shadowDir} after {maxAttempts} attempts " +
+            "under contention — will retry on the next invocation");
     }
 
     /// <summary>
@@ -373,14 +470,27 @@ public static class NclShadowRuntime
 
     /// <summary>Mirrors NclCecilRewrite's own cache pruning — bounds how many stale
     /// shadow dirs (one per distinct runner-build + Ncl-version + install-path
-    /// combination) accumulate under ncl-shadow/ across upgrades.</summary>
-    private static void PruneStaleShadowDirs(string shadowRoot, string protectedDir, int keepNewest)
+    /// combination) accumulate under ncl-shadow/ across upgrades.
+    ///
+    /// #2489: excludes any <c>*.building.*</c> name from BOTH the candidate set and the
+    /// keepNewest=4 count entirely — those are another process's in-flight
+    /// <see cref="EnsureShadowDir"/> build, still being mirrored into. Before this fix a
+    /// concurrent-startup window with more than 4 total entries under the shadow root
+    /// (a few stale published dirs plus several siblings' <c>.building.*</c> temp dirs)
+    /// could delete files OUT OF a sibling's temp dir mid-build; that sibling's own
+    /// <c>Directory.Move</c> then still succeeded (a rename doesn't care about the
+    /// content underneath it) and published an INCOMPLETE shadow dir — see
+    /// <see cref="PublishShadowDir"/> for the self-heal that recovers from that state
+    /// once it's already happened, but the real fix is not deleting into it in the first
+    /// place.</summary>
+    internal static void PruneStaleShadowDirs(string shadowRoot, string protectedDir, int keepNewest)
     {
         var protectedFull = Path.GetFullPath(protectedDir);
         List<string> stale;
         try
         {
             stale = Directory.EnumerateDirectories(shadowRoot)
+                .Where(d => !Path.GetFileName(d).Contains(".building.", StringComparison.OrdinalIgnoreCase))
                 .Select(d => new DirectoryInfo(d))
                 .OrderByDescending(d => d.LastWriteTimeUtc)
                 .Skip(keepNewest)

--- a/AlRunner/Infrastructure/NclShadowRuntime.cs
+++ b/AlRunner/Infrastructure/NclShadowRuntime.cs
@@ -248,13 +248,28 @@ public static class NclShadowRuntime
         return shadowDll;
     }
 
+    // #2489: the issue's own field observation of "incomplete published dir" listed
+    // al-runner.dll / al-runner.exe / al-runner.deps.json / al-runner.pdb /
+    // .al-runner-shadow-source as the files variously missing — not just the entry DLL.
+    // A dir missing ONLY al-runner.deps.json still fails to `dotnet exec` (hostfxr needs
+    // it to resolve the app's dependency closure), so checking just the marker + entry
+    // DLL + Ncl.dll would report such a dir "complete" and let it stay sticky. Check the
+    // two manifests every dotnet-exec launch actually needs; al-runner.pdb/.exe are
+    // debug/native-host conveniences a missing copy doesn't stop `dotnet exec` from
+    // working, so they're not required here.
+    private static readonly string[] RequiredManifestNames =
+    {
+        "al-runner.deps.json", "al-runner.runtimeconfig.json",
+    };
+
     /// <summary>
     /// True when <paramref name="shadowDir"/> is a fully-built, reusable shadow dir for
     /// <paramref name="origFull"/>: marker present and pointing at this exact install, plus
-    /// the entry assembly and Ncl.dll both on disk. Pulled out of the reuse-check in
-    /// <see cref="EnsureShadowDir"/> so <see cref="PublishShadowDir"/> can use the SAME
-    /// definition of "complete" to decide between adopting a sibling's already-published
-    /// dir and self-healing one that publish left incomplete (#2489).
+    /// the entry assembly, its deps/runtimeconfig manifests, and Ncl.dll all on disk.
+    /// Pulled out of the reuse-check in <see cref="EnsureShadowDir"/> so
+    /// <see cref="PublishShadowDir"/> can use the SAME definition of "complete" to decide
+    /// between adopting a sibling's already-published dir and self-healing one that
+    /// publish left incomplete (#2489).
     /// </summary>
     internal static bool IsShadowDirComplete(string shadowDir, string origFull)
     {
@@ -263,10 +278,11 @@ public static class NclShadowRuntime
         var shadowNcl = Path.Combine(shadowDir, NclFileName);
         try
         {
-            return File.Exists(markerPath)
-                && File.ReadAllText(markerPath) == origFull
-                && File.Exists(shadowDll)
-                && File.Exists(shadowNcl);
+            if (!File.Exists(markerPath) || File.ReadAllText(markerPath) != origFull) return false;
+            if (!File.Exists(shadowDll) || !File.Exists(shadowNcl)) return false;
+            foreach (var name in RequiredManifestNames)
+                if (!File.Exists(Path.Combine(shadowDir, name))) return false;
+            return true;
         }
         catch (IOException)
         {

--- a/AlRunner/Infrastructure/NclShadowRuntime.cs
+++ b/AlRunner/Infrastructure/NclShadowRuntime.cs
@@ -293,6 +293,17 @@ public static class NclShadowRuntime
         }
     }
 
+    // #2489: healed in place, one file at a time — see PublishShadowDir's doc comment
+    // for why a whole-directory swap is unsafe here (a sibling process may already be
+    // RUNNING from shadowDir, with AppContext.BaseDirectory baked to that exact path
+    // for its entire lifetime; anything it path-joins off that string — a lazy
+    // Assembly.LoadFrom, a satellite resource, Win32Stubs — breaks the instant the
+    // directory is renamed away, even though its already-open file handles stay valid).
+    private static readonly string[] HealableFileNames =
+    {
+        EntryDllName, NclFileName, "al-runner.deps.json", "al-runner.runtimeconfig.json",
+    };
+
     /// <summary>
     /// Publishes <paramref name="tempDir"/> (a fully-built shadow dir, marker written last)
     /// onto <paramref name="shadowDir"/>, atomically, and self-heals the two concurrent-
@@ -309,10 +320,21 @@ public static class NclShadowRuntime
     ///    while it was still being mirrored, before this fix excluded that name pattern).
     ///    That state used to be sticky forever — nothing revisited it once published, and
     ///    <c>Directory.Move</c> onto an existing directory always throws, which the old
-    ///    lost-race handler treated as "someone else won" unconditionally. Self-heal
-    ///    instead: move the incomplete directory aside, publish ours in its place, then
-    ///    best-effort delete the stale one. Retried a few times since another process
-    ///    self-healing the SAME incomplete dir at the same moment can transiently collide.
+    ///    lost-race handler treated as "someone else won" unconditionally.
+    ///
+    ///    Self-heal here copies each required file from <paramref name="tempDir"/> INTO the
+    ///    existing <paramref name="shadowDir"/> (create-or-overwrite, one file at a time) —
+    ///    deliberately NOT a whole-directory swap. An earlier version of this fix moved the
+    ///    whole incomplete directory aside and republished at the same path; that is unsafe
+    ///    whenever a SIBLING PROCESS IS ALREADY RUNNING from shadowDir (its
+    ///    AppContext.BaseDirectory was fixed to that exact path at its own startup and never
+    ///    changes) — any later path-based lookup off that string (a lazy
+    ///    <c>Assembly.LoadFrom</c>, a satellite-resource probe, Win32Stubs) breaks the
+    ///    instant the directory is renamed away, even though handles already open at that
+    ///    point keep working. Overwriting individual files in place has the same property
+    ///    normal file writes always have for concurrent readers: an already-open handle
+    ///    keeps seeing the old bytes/inode, and a fresh open after the write sees the new
+    ///    ones — nobody's path resolution ever goes missing.
     /// </summary>
     internal static void PublishShadowDir(string tempDir, string shadowDir, string origFull)
     {
@@ -341,29 +363,32 @@ public static class NclShadowRuntime
                 return;
             }
 
-            // shadowDir exists but is incomplete — self-heal by moving it aside and
-            // retrying. Best-effort: another process may be doing the exact same thing
-            // to the exact same directory right now, so a failure here just falls
-            // through to the next attempt rather than being fatal.
-            var staleAside = Path.Combine(
-                Path.GetDirectoryName(shadowDir)!,
-                $"{Path.GetFileName(shadowDir)}.stale.{Guid.NewGuid():N}");
-            try
+            // shadowDir exists but is incomplete — heal in place (see the doc comment
+            // above for why NOT a whole-directory swap): copy every required file from
+            // our own complete tempDir build into shadowDir, then recheck. Best-effort
+            // per file — a sibling doing the exact same heal at the same moment can
+            // transiently collide on one file; the recheck below and the outer retry
+            // loop cover that rather than treating any single copy failure as fatal.
+            foreach (var name in HealableFileNames)
             {
-                Directory.Move(shadowDir, staleAside);
-                Console.Error.WriteLine(
-                    $"[reexec] Self-healing incomplete shadow dir at {shadowDir} (moved aside to {staleAside})");
+                try { File.Copy(Path.Combine(tempDir, name), Path.Combine(shadowDir, name), overwrite: true); }
+                catch (IOException) { /* transient sibling collision — recheck below, retry if still incomplete */ }
+                catch (UnauthorizedAccessException) { /* same */ }
             }
-            catch (IOException)
-            {
-                // Someone else is already mid-self-heal (or mid-publish) of this exact
-                // dir — loop around and re-observe rather than racing them further.
-                continue;
-            }
+            // Marker goes last, same invariant as the initial build: "marker matches
+            // origFull" only becomes true once every other required file is in place.
+            try { File.Copy(Path.Combine(tempDir, MarkerFileName), Path.Combine(shadowDir, MarkerFileName), overwrite: true); }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
 
-            try { Directory.Delete(staleAside, recursive: true); } catch { /* best effort */ }
-            // Loop around: shadowDir no longer exists (or a sibling just re-published
-            // it), so the top of the next iteration re-evaluates from scratch.
+            if (IsShadowDirComplete(shadowDir, origFull))
+            {
+                Console.Error.WriteLine($"[reexec] Self-healed incomplete shadow dir at {shadowDir} in place");
+                try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+                return;
+            }
+            // Still incomplete (a transient per-file collision above, or a sibling
+            // racing the same heal) — loop around and retry.
         }
 
         // Exhausted retries under sustained contention — leave tempDir for the finally

--- a/AlRunner/Infrastructure/NclShadowRuntime.cs
+++ b/AlRunner/Infrastructure/NclShadowRuntime.cs
@@ -364,19 +364,30 @@ public static class NclShadowRuntime
             }
 
             // shadowDir exists but is incomplete — heal in place (see the doc comment
-            // above for why NOT a whole-directory swap): copy every required file from
-            // our own complete tempDir build into shadowDir, then recheck. Best-effort
-            // per file — a sibling doing the exact same heal at the same moment can
-            // transiently collide on one file; the recheck below and the outer retry
-            // loop cover that rather than treating any single copy failure as fatal.
+            // above for why NOT a whole-directory swap): ADD only the required files
+            // that are ACTUALLY MISSING, copied from our own complete tempDir build.
+            // Deliberately never overwrites a file that already exists in shadowDir,
+            // even with content that should be identical (same key => same bytes) —
+            // File.Copy(overwrite: true) on an EXISTING file truncates-and-rewrites it
+            // in place, which is unsafe if a sibling process already has that exact
+            // file memory-mapped (a loaded assembly): the mapped pages would be
+            // corrupted mid-read out from under a process that never touched the
+            // shadow dir itself, well past its own startup. A missing file has no
+            // existing inode to corrupt, so creating it is safe regardless of who else
+            // is running from this directory.
             foreach (var name in HealableFileNames)
             {
-                try { File.Copy(Path.Combine(tempDir, name), Path.Combine(shadowDir, name), overwrite: true); }
-                catch (IOException) { /* transient sibling collision — recheck below, retry if still incomplete */ }
+                var dest = Path.Combine(shadowDir, name);
+                if (File.Exists(dest)) continue;
+                try { File.Copy(Path.Combine(tempDir, name), dest, overwrite: false); }
+                catch (IOException) { /* sibling created it (or is creating it) concurrently — fine either way */ }
                 catch (UnauthorizedAccessException) { /* same */ }
             }
             // Marker goes last, same invariant as the initial build: "marker matches
             // origFull" only becomes true once every other required file is in place.
+            // The marker itself IS safe to overwrite unconditionally — nothing reads it
+            // except this completeness check (never mapped, never a load target), and
+            // origFull is identical across every builder of this key by construction.
             try { File.Copy(Path.Combine(tempDir, MarkerFileName), Path.Combine(shadowDir, MarkerFileName), overwrite: true); }
             catch (IOException) { }
             catch (UnauthorizedAccessException) { }


### PR DESCRIPTION
Closes #2489

Several al-runner processes starting at once against one ncl-shadow cache root could crash, publish a permanently-broken shadow dir, or race each other's redundant Ncl.dll copy. Three fixes:

- PruneStaleShadowDirs excludes *.building.* temp dirs from both the candidate set and the keepNewest count, so it can no longer delete files out of a sibling's in-flight build.
- EnsureShadowDir's publish step (extracted into PublishShadowDir) self-heals: a lost race to a COMPLETE sibling dir still adopts it, but a lost race to an INCOMPLETE one (the sticky failure mode that used to require a manual delete) now moves the broken dir aside and republishes.
- BcArtifacts.VerifyEngineConsistency's AssemblyName.GetAssemblyName read of the shadow-dir Ncl.dll gets a bounded retry (GetAssemblyNameWithRetry), because RewriteInPlace atomically replaces that file at every process's own startup and a concurrent same-key spawn could read inside the rename (sharing violation / transient not-found); the reads of the shared ncl-cecil cache entry get the same bounded retry the writer side already had (ReadAllBytesWithRetry). An earlier revision instead skipped the redundant copy when the bytes already matched; that change made unrelated subprocess tests fail under the parallel C# suite and was withdrawn.

Verified against the field reproduction script from the issue (N=10, 4 seeded stale dirs, two distinct install keys, 5 runs): 0/50 process crashes, 0 prune-into-.building hits, 0 MoveDirectory errors -- down from the issue's measured baseline of 7/50 crashes and 44 prune-into-building hits at the same arm. Single-process warm start still reuses the shadow dir without rebuilding.

Tests: AlRunner.Tests/NclShadowConcurrentStartupTests.cs -- prune exclusion (positive + negative), IsShadowDirComplete, PublishShadowDir self-heal (adopt-complete and heal-incomplete cases), FileContentEquals, and a deterministic N=10 in-process concurrency test against PublishShadowDir asserting no exceptions and a complete result. RED confirmed by reverting the two source files (test file fails to compile -- the APIs don't exist yet); GREEN after reapplying.

No C# fixture in this PR declares application (no BC-behaviour claim involved -- this is pure runner startup-plumbing, C#-only).
