### PR TITLE
fix: Aggregate Permission Set redrives its union on every Get()/Find() request

### DIFF
--- a/AlRunner.Tests/AggregatePermissionSetVirtualTableTests.cs
+++ b/AlRunner.Tests/AggregatePermissionSetVirtualTableTests.cs
@@ -101,6 +101,11 @@ public sealed class AggregatePermissionSetVirtualTableTests
             // subsequently deleted row must not remain a ghost.
             Assert.Contains(
                 "PASS  Codeunit60702.AggregatePermissionSet_TenantRowInsertedAfterEarlierTouch_IsVisible", stdout);
+            // #2504: redriving on DISPATCH alone is not enough -- a record variable REUSED
+            // for a second Get() after an intervening write must see the fresh row too, not
+            // just a freshly-declared variable's own first touch.
+            Assert.Contains(
+                "PASS  Codeunit60702.AggregatePermissionSet_SameRecordVariableReusedAcrossWrite_SeesFreshRow", stdout);
             Assert.DoesNotContain("FAIL", stdout);
         }
         finally

--- a/AlRunner.Tests/Fixtures/AggregatePermissionSet/ApsFixtureTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/AggregatePermissionSet/ApsFixtureTests.Codeunit.al
@@ -93,4 +93,50 @@ codeunit 60702 "APS Fixture Tests"
             AggregatePermissionSetAfterDelete.Get(AggregatePermissionSetAfterDelete.Scope::Tenant, EmptyGuid, 'APS NEW TENANT ROLE'),
             'a Tenant Permission Set row deleted after being visible must not remain a ghost row in Aggregate Permission Set');
     end;
+
+    [Test]
+    procedure AggregatePermissionSet_SameRecordVariableReusedAcrossWrite_SeesFreshRow()
+    // CLAIM (runner mechanism, issue #2504): the SAME record variable, reused for a
+    // touch/insert/re-touch sequence -- exactly what TestPage "Permission Sets"' own row
+    // walk does with ONE bound Rec across .First()/.Next() -- must see the fresh row too,
+    // not just a freshly-declared variable's own first touch (#2473's fix alone only
+    // covered that narrower case: a NavRecord resolves its DataAccess wrapper once, on its
+    // own first Get()/Find(), and every LATER call on that SAME instance skipped this
+    // file's populate step entirely before this fix). Real BC's own
+    // VirtualAndTempTransactionalDataCache.TryFind/TryGetByPrimaryKey unconditionally
+    // report a cache miss for every request, so a real service tier recomputes this table
+    // on EVERY Get()/Find(), cached wrapper or not.
+    var
+        AggregatePermissionSet: Record "Aggregate Permission Set";
+        TenantPermissionSet: Record "Tenant Permission Set";
+        EmptyGuid: Guid;
+    begin
+        // First touch on this ONE variable -- primes it, same as any ordinary first Get().
+        if AggregatePermissionSet.Get(AggregatePermissionSet.Scope::System, EmptyGuid, 'NOT A REAL ROLE ID') then;
+
+        if TenantPermissionSet.Get(EmptyGuid, 'APS REUSED VAR ROLE') then
+            TenantPermissionSet.Delete();
+
+        Clear(TenantPermissionSet);
+        TenantPermissionSet."App ID" := EmptyGuid;
+        TenantPermissionSet."Role ID" := 'APS REUSED VAR ROLE';
+        TenantPermissionSet.Name := 'APS Reused Var Role';
+        TenantPermissionSet.Assignable := true;
+        TenantPermissionSet.Insert();
+
+        // SAME variable, second Get() -- this is exactly the shape that stayed stale before
+        // the #2504 fix (only three separate variables proved #2473's own fix worked).
+        Assert.IsTrue(
+            AggregatePermissionSet.Get(AggregatePermissionSet.Scope::Tenant, EmptyGuid, 'APS REUSED VAR ROLE'),
+            'a record variable reused for a second Get() after an intervening write must see the new row, not the state from its own first touch');
+        Assert.AreEqual(
+            'APS Reused Var Role', AggregatePermissionSet.Name,
+            'Name must round-trip from the newly-inserted Tenant Permission Set row, read through the REUSED variable');
+
+        TenantPermissionSet.Delete();
+        // Negative, SAME variable again: a third Get() on it must not see a ghost either.
+        Assert.IsFalse(
+            AggregatePermissionSet.Get(AggregatePermissionSet.Scope::Tenant, EmptyGuid, 'APS REUSED VAR ROLE'),
+            'a record variable reused for a third Get() after the row was deleted must not see a ghost row');
+    end;
 }

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -7376,6 +7376,24 @@ public static class NclCecilRewrite
                 H(recordPatches, "DataAccess_DateWindowGuardForCount"),
                 argSlots: 2); // `this` — the DataAccess — and the count request
 
+            // ── DataAccess.InternalTryGetByPrimaryKeyAsync — Aggregate Permission Set live
+            //    redrive (issue #2504) ──────────────────────────────────────────────────
+            // Record.Get() with a full primary key never reaches InnerFindAsync at all — it
+            // takes DataAccess's OWN primary-key path (InternalTryGetByPrimaryKeyAsync →
+            // provider.TryGetByPrimaryKeyAsync/TryGetBySystemIdAsync, confirmed by decompiling
+            // Ncl.dll), so the InnerFindAsync guard above never sees a plain Get(). Real BC's
+            // own VirtualAndTempTransactionalDataCache.TryGetByPrimaryKey unconditionally
+            // returns Unknown (a cache miss) for every request, so a real service tier
+            // recomputes this table on every single Get() too, not only the first. We target
+            // InternalTryGetByPrimaryKeyAsync (not the tiny public TryGetByPrimaryKeyAsync,
+            // which just forwards to it) for the same R2R-inlining reason InnerFindAsync is
+            // targeted over FindAsync above. For every table but Aggregate Permission Set this
+            // is one int comparison and returns; the original body then runs unchanged.
+            PrependStaticCall(nclMod,
+                ByParams(Rt + "DataAccess", "InternalTryGetByPrimaryKeyAsync", "PrimaryKeyCacheRequest"),
+                H(recordPatches, "DataAccess_AggregatePermissionSetGuardForGet"),
+                argSlots: 2); // `this` — the DataAccess — and the primary-key request
+
             // ── NavDatabase / NavRecordId collation comparers ───────────────────
             ReplaceBodyWithHelper(nclMod,
                 FindNclMethod(nclMod, Rt + "NavDatabase", "get_CollationAwareStringComparer", 0),

--- a/AlRunner/Patches/RecordPatches.AggregatePermissionSetVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AggregatePermissionSetVirtualTable.cs
@@ -82,6 +82,36 @@
 //   SymbolReference.json (EnumerateKnownPermissionSets) — both fixed for the lifetime of one
 //   runner invocation, not runtime-writable AL data, so a repeated top-up there can only
 //   ever re-discover the SAME fixed set, never miss a write that happened after first touch.
+//
+// PER-REQUEST REDRIVE, NOT JUST PER-DISPATCH (issue #2504)
+//   The populate-on-touch shape above only fires from NavDataAccessSource_GetDataAccessForTable
+//   (RecordPatches.cs), which real BC's own RecordImplementation.InitializeImpl calls AT MOST
+//   ONCE per NavRecord instance (`if (dataAccess == null) dataAccess = ...GetDataAccessForTable(...)`,
+//   confirmed by decompiling Ncl.dll) -- every LATER Get()/FindSet() on that SAME instance reads
+//   straight from the already-resolved DataAccess, never re-dispatching. That is fine on a real
+//   service tier: DataAccess.GetVirtualDataAccess ALSO caches its DataAccess wrapper per
+//   (session, tableId), but VirtualAndTempTransactionalDataCache.TryFind/TryGetByPrimaryKey
+//   unconditionally return "miss" for every request (confirmed by decompiling both), so every
+//   single Get()/Find() -- cached wrapper or not -- falls through to the PROVIDER fresh. Real BC
+//   never caches ROWS, only the wrapper OBJECT.
+//
+//   Our TempTableDataProvider is the opposite: it stores materialised rows, and reading them
+//   after the wrapper is cached does NOT re-run this file's populate step. A single record
+//   variable held across a "touch, write elsewhere, touch again" sequence -- exactly what
+//   TestPage "Permission Sets"' own row walk does with ONE bound Rec across `.First()`/`.Next()`
+//   -- stayed stale even with the #2473 fix, which only fixed the FIRST TOUCH OF A NEW VARIABLE
+//   case. Confirmed empirically while proving #2473: a single shared record variable across a
+//   touch->insert->verify sequence stayed stale; three separate variables (each its own first
+//   touch) were required to observe the fix.
+//
+//   DataAccess_AggregatePermissionSetGuardForGet (Get()-by-primary-key, prepended to
+//   DataAccess.InternalTryGetByPrimaryKeyAsync) and the Aggregate-Permission-Set branch added to
+//   DataAccess_IsManagedFindRequest (Find()/FindSet(), RecordPatches.FieldFindIntercept.cs --
+//   the SAME prepend site the Date virtual table's window guard already uses) redrive the store
+//   on EVERY request that targets this table, using the REQUEST's own MetaApplicationObject
+//   rather than a value captured at DataAccess-creation time. This matches real BC's actual
+//   "the wrapper is cached, the rows never are" model instead of trying to catch every place a
+//   NavRecord variable might be reused.
 
 using System;
 using System.Collections;
@@ -339,5 +369,52 @@ public static partial class RecordPatches
             ?? throw new InvalidOperationException("NavSession.NCLMetadata property not found");
 
         _apsReflectionReady = true;
+    }
+
+    private static bool _apsLiveGuardReady;
+    private static PropertyInfo? _apsDataAccessSession;   // DataAccess.Session
+
+    private static void EnsureAggregatePermissionSetLiveGuardReflection(object dataAccess)
+    {
+        if (_apsLiveGuardReady) return;
+        var nclAsm = dataAccess.GetType().Assembly;
+        const string rt = "Microsoft.Dynamics.Nav.Runtime.";
+        var tDataAccess = nclAsm.GetType(rt + "DataAccess")
+            ?? throw new InvalidOperationException("DataAccess type not found in Ncl");
+        _apsDataAccessSession = tDataAccess.GetProperty("Session",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("DataAccess.Session not found");
+        _apsLiveGuardReady = true;
+    }
+
+    /// <summary>
+    /// Prepended (PrependStaticCall, see NclCecilRewrite) to
+    /// DataAccess.InternalTryGetByPrimaryKeyAsync(PrimaryKeyCacheRequest) -- EVERY table's
+    /// Get()-by-primary-key path, real BC's own InitializeImpl only ever resolves a NavRecord's
+    /// DataAccess wrapper once, so this is the only place a SECOND Get() on an already-open
+    /// variable is ever seen. For every table but Aggregate Permission Set this is one
+    /// dictionary-free int comparison and returns.
+    /// </summary>
+    public static void DataAccess_AggregatePermissionSetGuardForGet(object self, object request)
+    {
+        if (FindRequestTableId(request) != AggregatePermissionSetVirtualTableId) return;
+        RedriveAggregatePermissionSetForRequest(self, request);
+    }
+
+    /// <summary>
+    /// Shared by the Get()-by-key prepend above and the Aggregate-Permission-Set branch in
+    /// DataAccess_IsManagedFindRequest (RecordPatches.FieldFindIntercept.cs, the find/FindSet
+    /// path): repopulate the store fresh for THIS one request, reading the table straight off
+    /// the request's own MetaApplicationObject (an NCLMetaTable for a table-scoped request --
+    /// confirmed NCLMetaTable : NCLMetaApplicationObject by decompiling Ncl.dll) rather than a
+    /// value captured once when the DataAccess wrapper was first created.
+    /// </summary>
+    private static void RedriveAggregatePermissionSetForRequest(object dataAccess, object request)
+    {
+        EnsureAggregatePermissionSetLiveGuardReflection(dataAccess);
+        if (FindRequestMetaApplicationObject(request) is not NCLMetaTable metaTable) return;
+        var session = _apsDataAccessSession!.GetValue(dataAccess);
+        if (session == null) return;
+        PopulateAggregatePermissionSetVirtualTable(dataAccess, metaTable, session);
     }
 }

--- a/AlRunner/Patches/RecordPatches.FieldFindIntercept.cs
+++ b/AlRunner/Patches/RecordPatches.FieldFindIntercept.cs
@@ -141,6 +141,16 @@ public static partial class RecordPatches
             EnsureDateWindowCoversRequest(self, request);
             return false;
         }
+        if (tableId == AggregatePermissionSetVirtualTableId)
+        {
+            // Find()/FindSet() side of issue #2504: this table's rows are recomputed on
+            // EVERY request on a real service tier, not just at DataAccess-wrapper-creation
+            // time -- see RecordPatches.AggregatePermissionSetVirtualTable.cs's "PER-REQUEST
+            // REDRIVE" banner. Redrive, then fall through to the ORIGINAL InnerFindAsync,
+            // which now reads a fresh store.
+            RedriveAggregatePermissionSetForRequest(self, request);
+            return false;
+        }
         return tableId == FieldFindTableId;
     }
 
@@ -168,6 +178,23 @@ public static partial class RecordPatches
             return _pMaoObjIdLight!.GetValue(mao) is int i ? i : -1;
         }
         catch { return -1; }
+    }
+
+    /// <summary>
+    /// The request's own MetaApplicationObject -- an NCLMetaTable for a table-scoped request
+    /// (NCLMetaTable : NCLMetaApplicationObject). Shares the light reflection
+    /// FindRequestTableId resolves. Used by RecordPatches.AggregatePermissionSetVirtualTable.cs
+    /// to redrive against the table the CURRENT request names, not one captured earlier.
+    /// </summary>
+    private static object? FindRequestMetaApplicationObject(object request)
+    {
+        try
+        {
+            _ = FindRequestTableId(request); // ensures _pReqMaoLight is resolved
+            if (!_lightReady) return null;
+            return _pReqMaoLight!.GetValue(request);
+        }
+        catch { return null; }
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #2504

## What

#2473 made `PopulateAggregatePermissionSetVirtualTable` redrive the store on
every call to `NavDataAccessSource_GetDataAccessForTable` -- but that dispatch,
decompiling `Ncl.dll` confirms, is only ever invoked once per `NavRecord`
instance (`RecordImplementation.InitializeImpl`: `if (dataAccess == null)
dataAccess = ...GetDataAccessForTable(...)`). Every LATER `Get()`/`Find()` on
that SAME instance reused the already-resolved `DataAccess` and never
re-dispatched, so a single record variable held across a
touch/write/re-touch sequence stayed stale -- exactly the shape
`TestPage "Permission Sets"` uses with one bound `Rec` walked via
`.First()`/`.Next()`.

Confirmed empirically while proving #2473 itself: a single shared record
variable across a touch->insert->verify sequence stayed stale even with that
fix applied; three separate variables (each its own first touch) were needed
to see it work.

Decompiling further: real BC does not have this gap.
`DataAccess.GetVirtualDataAccess` caches its wrapper per (session, tableId)
exactly like our `perTable` dict does, but
`VirtualAndTempTransactionalDataCache.TryFind`/`TryGetByPrimaryKey`
unconditionally report a cache miss for EVERY request (both hardcode
`return false` / `CacheLookupResult.Unknown`), so a real service tier
recomputes this table's union on every single `Get()`/`Find()` -- cached
wrapper or not. Real BC caches the wrapper OBJECT, never the ROWS.

Two new Cecil prepends match that: redrive the store on every request that
targets this table, reading the table straight off the REQUEST's own
`MetaApplicationObject` (an `NCLMetaTable` for a table-scoped request) rather
than a value captured once when the `DataAccess` wrapper was first created.

- `DataAccess_AggregatePermissionSetGuardForGet`, prepended to
  `DataAccess.InternalTryGetByPrimaryKeyAsync` -- the `Get()`-by-primary-key
  path, which never reaches `InnerFindAsync` at all.
- A new branch inside the EXISTING `DataAccess_IsManagedFindRequest` predicate
  (the same prepend site the Date virtual table's window guard already uses
  on `DataAccess.InnerFindAsync`) -- the `Find()`/`FindSet()` path.

Both target the large async state-machine methods (`InternalTryGetByPrimaryKeyAsync`,
`InnerFindAsync`), not their tiny public wrappers, for the same R2R-inlining
reason `RecordPatches.FieldFindIntercept.cs`'s own banner documents.

## The three questions

1. **Same wrong pattern elsewhere?** Audited every other virtual-table
   populate function reachable from `NavDataAccessSource_GetDataAccessForTable`
   (AllObj, AllObjWithCaption, Metadata Permission Set, Date, Integer, Report
   Layout List, Report Metadata, Table Metadata, Page Metadata). All of them
   share this same "populate on dispatch, not on request" property, but only
   Aggregate Permission Set is unioned from an ordinarily AL-writable table
   (`Tenant Permission Set`) that can change mid-run -- the others are all
   either genuinely static for a run's lifetime (compiled AL source, resolved
   metadata) or, for Date/Integer, already handle their own on-demand
   widening at find-time via a purpose-built window guard. No further fix
   needed there; noted for anyone auditing this shape again.
2. **Sibling function, same assumption?** `DataAccess_DateWindowGuardForCount`
   already establishes the "unconditional prepend, guard table id inside"
   pattern for `CountAsync`; this PR reuses the exact same shape rather than
   inventing a new one.
3. **Two write paths, same invariant?** N/A -- this is a READ-side gap, not a
   write-path divergence.

## Measured against Codeunit134614 (per explicit instruction -- do not assume)

| variant | Codeunit134614 |
|---|---|
| before this fix (main, #2473 already merged) | 1P/14F |
| after this fix | 1P/14F -- unchanged |

This fix does NOT clear the cascade. Diagnosed why with a temporary local
probe (not committed, Microsoft's own AL with one extra `[Test]` pasted in,
run and discarded): `TestPage "Permission Sets"` (id 9802) shows **zero
rows** on `.First()`, independent of any staleness -- its `SourceTableId` is
9009 with `SourceTableTemporary: true`, i.e. the page is bound to a SEPARATE
temporary buffer table Microsoft's own AL fills from Aggregate Permission Set,
not to Aggregate Permission Set directly. Whatever runs that fill logic in the
runner isn't reaching it at all. That's a different, deeper gap, filed
separately as #2511 rather than folded in here.

## Testing

- **RED->GREEN, runner-local:** new test
  `AggregatePermissionSet_SameRecordVariableReusedAcrossWrite_SeesFreshRow` in
  `AlRunner.Tests/Fixtures/AggregatePermissionSet` (positive: same variable's
  second `Get()` after an intervening write sees the new row; negative: a
  third `Get()` after delete does not see a ghost). Confirmed failing without
  this fix (with #2473 still applied), passing with it, by checking out the
  pre-fix files and rerunning.
- Full `al-language` corpus (2348 tests) and `runner-extras` (213 tests): both
  pass clean, matching `tests/expectations/count-baseline/`. No pin bump in
  this PR.
- `Codeunit60931` (upstream, `AggregatePermissionSet_TenantScopeDeclaration_IsPresent`
  and the new deterministic test from #116) still green against the current pin.
- Filtered C# suite:
  `dotnet test AlRunner.Tests --filter FullyQualifiedName~AggregatePermissionSetVirtualTableTests`
  -- pass.
- Follow-up issue filed: #2511, for the TestPage-over-temporary-SourceTable gap.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf