### PR TITLE
fix(rad): make the RAD baseline namespace-aware, fixing the empty ModuleDefinition

### DIFF
--- a/AlRunner.Tests/BcCompilerIncrementalNamespaceTests.cs
+++ b/AlRunner.Tests/BcCompilerIncrementalNamespaceTests.cs
@@ -158,7 +158,7 @@ public sealed class BcCompilerIncrementalNamespaceTests : IDisposable
         Assert.Equal("Pageworks", pageworksNs.Name);
         Assert.NotNull(pageworksNs.Namespaces);
         Assert.Equal(2, pageworksNs.Namespaces!.Length); // "Assets" and "Utils"
-        var utilsNs = Assert.Single(pageworksNs.Namespaces!.Where(n => n.Name == "Utils"));
+        var utilsNs = Assert.Single(pageworksNs.Namespaces!, n => n.Name == "Utils");
         Assert.NotNull(utilsNs.Namespaces);
         var internalNs = Assert.Single(utilsNs.Namespaces!);
         Assert.Equal("Internal", internalNs.Name);

--- a/AlRunner.Tests/BcCompilerIncrementalNamespaceTests.cs
+++ b/AlRunner.Tests/BcCompilerIncrementalNamespaceTests.cs
@@ -1,0 +1,238 @@
+// BcCompilerIncrementalNamespaceTests — RED/GREEN proof for issue #2507.
+//
+// #2507: `RecordIncrementalBaseline`'s baseline `ModuleDefinition` for a bundle where (nearly)
+// every file declares `namespace X.Y;` — the modern `al new` default — was EMPTY: 0 objects
+// across every top-level Codeunits/Tables/Pages/etc. array, even though the SAME compilation's
+// `GetDeclaredApplicationObjectSymbols()` correctly reported every declared object. Root cause
+// (decompiled `SerializableSymbolModelConverter`): a namespace-declared object is never a direct
+// child of the GLOBAL namespace BC's converter starts from — it is nested under
+// `ModuleDefinition.Namespaces[...].Codeunits` (recursively, one level per namespace segment).
+// `RecordIncrementalBaseline`/`ExcludeObjects`/`MergeModuleDefinition` (BcCompiler.Incremental.cs)
+// only ever inspected the top-level arrays, so for ANY app using `namespace` — not a rare edge
+// case, the ordinary shape of a modern app — the RAD baseline was silently empty from the moment
+// it was first recorded, defeating #1902's incremental-compile fast path for that class of app.
+//
+// This class proves two things, both required by the issue:
+//   1. Mechanism: the recorded baseline's ModuleDefinition, walked RECURSIVELY through
+//      `.Namespaces`, contains every declared object of a namespace-heavy, multi-object bundle —
+//      not merely "non-zero", the EXACT count, at a scale (30 objects across 3 distinct
+//      namespace segments, one nested two levels deep) explicitly chosen because #2486's
+//      post-mortem on a related issue found a 1-2 file fixture does not reproduce this class of
+//      bug — and the top-level arrays are (correctly, per BC's own converter) near-empty, so a
+//      naive "moduleDef.Codeunits.Length > 0" assertion would NOT catch a regression here.
+//   2. Observable behaviour: `TryEmitIncremental` on a namespace-declared app with a real
+//      cross-namespace object reference (an unmodified caller in one namespace calling a
+//      modified callee in ANOTHER namespace — the exact shape that needs the self-referencing
+//      RAD loader to correctly represent an untouched sibling) actually takes the fast path,
+//      rather than falling back or throwing.
+using System.Linq;
+using System.Reflection;
+using Xunit;
+using AlRunner;
+using Microsoft.Dynamics.Nav.CodeAnalysis.SymbolReference;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class BcCompilerIncrementalNamespaceTests : IDisposable
+{
+    private readonly string _root;
+    private readonly BcEngineFixture _engine;
+
+    public BcCompilerIncrementalNamespaceTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-incremental-ns-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private void WriteAl(string fileName, string content) => File.WriteAllText(Path.Combine(_root, fileName), content);
+
+    private static string NsCodeunitSrc(string ns, int id, string name, int returnValue) => $$"""
+        namespace {{ns}};
+
+        codeunit {{id}} "{{name}}"
+        {
+            procedure GetValue(): Integer
+            begin
+                exit({{returnValue}});
+            end;
+        }
+        """;
+
+    /// <summary>
+    /// Reflects out the private baseline `BcCompiler` recorded for `moduleName` (there is no
+    /// public accessor — the field is deliberately private implementation detail; see
+    /// BcCompiler.Incremental.cs).
+    /// </summary>
+    private static ModuleDefinition GetRecordedBaselineModuleDef(BcCompiler compiler, string moduleName)
+    {
+        var field = typeof(BcCompiler).GetField("_radBaselines", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var baselines = (System.Collections.IDictionary)field.GetValue(compiler)!;
+        Assert.True(baselines.Contains(moduleName), $"no RAD baseline was recorded for '{moduleName}'");
+        var baseline = baselines[moduleName]!;
+        var moduleDefField = baseline.GetType().GetField("ModuleDef", BindingFlags.Public | BindingFlags.Instance)!;
+        return (ModuleDefinition)moduleDefField.GetValue(baseline)!;
+    }
+
+    /// <summary>Recursively counts every id-bearing/id-less application object in a ModuleDefinition tree — mirrors BcCompiler.Incremental.cs's own `EnumerateContainers`.</summary>
+    private static int CountObjectsRecursive(IObjectContainerDefinition container)
+    {
+        int count = 0;
+        foreach (var propName in new[] { "Tables", "Codeunits", "Pages", "PageExtensions", "TableExtensions", "Reports",
+                     "ReportExtensions", "XmlPorts", "Queries", "EnumTypes", "EnumExtensionTypes", "PermissionSets",
+                     "PermissionSetExtensions", "Interfaces", "ControlAddIns", "Profiles", "PageCustomizations", "ProfileExtensions" })
+        {
+            var prop = typeof(IObjectContainerDefinition).GetProperty(propName)!;
+            if (prop.GetValue(container) is Array arr) count += arr.Length;
+        }
+        if (container.Namespaces != null)
+            foreach (var ns in container.Namespaces)
+                count += CountObjectsRecursive(ns);
+        return count;
+    }
+
+    private static int TopLevelCodeunitCount(ModuleDefinition module) => module.Codeunits?.Length ?? 0;
+
+    [SkippableFact]
+    public void RecordIncrementalBaseline_NamespaceHeavyApp_ModuleDefPopulatedRecursively_NotInTopLevelArrays()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // 30 codeunits across 3 distinct namespace segments (one nested two levels deep) — "at
+        // scale", per #2486's finding that a 1-2 file fixture does not reproduce this class of
+        // bug (issue #2507's own guidance).
+        var expectedNames = new List<string>();
+        int id = 92000;
+        for (int i = 0; i < 10; i++)
+        {
+            var name = $"NsA Codeunit {i}";
+            WriteAl($"A{i}.al", NsCodeunitSrc("Pageworks.Assets", id + i, name, i));
+            expectedNames.Add(name);
+        }
+        for (int i = 0; i < 10; i++)
+        {
+            var name = $"NsB Codeunit {i}";
+            WriteAl($"B{i}.al", NsCodeunitSrc("Pageworks.Utils", id + 100 + i, name, i));
+            expectedNames.Add(name);
+        }
+        for (int i = 0; i < 10; i++)
+        {
+            var name = $"NsC Codeunit {i}";
+            // Nested two levels deep: Pageworks.Utils.Internal.
+            WriteAl($"C{i}.al", NsCodeunitSrc("Pageworks.Utils.Internal", id + 200 + i, name, i));
+            expectedNames.Add(name);
+        }
+        Assert.Equal(30, expectedNames.Count);
+
+        var compiler = new BcCompiler();
+        var baselineOut = compiler.Emit(new[] { _root }, "NsScaleModule", trackIncrementalBaseline: true);
+        Assert.Empty(baselineOut.Diagnostics);
+        Assert.Equal(30, baselineOut.Sources.Count);
+
+        var moduleDef = GetRecordedBaselineModuleDef(compiler, "NsScaleModule");
+
+        // Documents the mechanism precisely (tdd.md: assert specific values, not just "some"):
+        // BC's OWN converter is faithful here — the top-level array is near-empty because every
+        // object lives under `.Namespaces`. A fix that flattened namespace objects into the
+        // TOP-LEVEL arrays instead (diverging from BC's own shape, which CreateForRad expects)
+        // would fail this half of the assertion.
+        Assert.True(TopLevelCodeunitCount(moduleDef) < 30,
+            $"expected BC's own namespace nesting to keep the top-level Codeunits array small, got {TopLevelCodeunitCount(moduleDef)}");
+
+        // The actual claim under test: walked recursively, every single declared object is there.
+        var recursiveCount = CountObjectsRecursive(moduleDef);
+        Assert.Equal(30, recursiveCount);
+
+        // BC nests each DOT-separated namespace SEGMENT as its own tree level (confirmed
+        // empirically here — NOT one flat "Pageworks.Assets" node): a single top-level
+        // "Pageworks" node, with two children "Assets" and "Utils", "Utils" itself having one
+        // child "Internal" (the two-levels-deep case).
+        Assert.NotNull(moduleDef.Namespaces);
+        var pageworksNs = Assert.Single(moduleDef.Namespaces!);
+        Assert.Equal("Pageworks", pageworksNs.Name);
+        Assert.NotNull(pageworksNs.Namespaces);
+        Assert.Equal(2, pageworksNs.Namespaces!.Length); // "Assets" and "Utils"
+        var utilsNs = Assert.Single(pageworksNs.Namespaces!.Where(n => n.Name == "Utils"));
+        Assert.NotNull(utilsNs.Namespaces);
+        var internalNs = Assert.Single(utilsNs.Namespaces!);
+        Assert.Equal("Internal", internalNs.Name);
+        Assert.Equal(10, CountObjectsRecursive(internalNs)); // the "NsC" group, nested two levels deep
+    }
+
+    [SkippableFact]
+    public void TryEmitIncremental_NamespaceDeclaredApp_CrossNamespaceCall_TakesFastPath_NotFallback()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // Caller lives in a DIFFERENT namespace from Callee — the exact shape that needs the
+        // self-referencing RAD loader to correctly represent an untouched sibling declared under
+        // `.Namespaces`, not the module's own top-level arrays.
+        WriteAl("Callee.al", $$"""
+            namespace Pageworks.NsCross.Callees;
+
+            codeunit 92300 "NsCross Callee"
+            {
+                procedure GetValue(): Integer
+                begin
+                    exit(10);
+                end;
+            }
+            """);
+        WriteAl("Caller.al", $$"""
+            namespace Pageworks.NsCross.Callers;
+
+            using Pageworks.NsCross.Callees;
+
+            codeunit 92301 "NsCross Caller"
+            {
+                procedure CallIt(): Integer
+                var
+                    Callee: Codeunit "NsCross Callee";
+                begin
+                    exit(Callee.GetValue());
+                end;
+            }
+            """);
+
+        var compiler = new BcCompiler();
+        var baselineOut = compiler.Emit(new[] { _root }, "NsCrossModule", trackIncrementalBaseline: true);
+        Assert.Empty(baselineOut.Diagnostics);
+        var baselineByName = baselineOut.Sources.ToDictionary(s => s.Name, s => s.Code);
+
+        // Only the CALLEE changes — the caller's file (a different namespace) is never touched.
+        WriteAl("Callee.al", $$"""
+            namespace Pageworks.NsCross.Callees;
+
+            codeunit 92300 "NsCross Callee"
+            {
+                procedure GetValue(): Integer
+                begin
+                    exit(20);
+                end;
+            }
+            """);
+
+        var incrOut = compiler.TryEmitIncremental(new[] { _root }, "NsCrossModule", appRootDir: null, out var fallbackReason);
+        Assert.True(incrOut != null,
+            $"expected the fast path to apply to a namespace-declared cross-namespace call; fell back instead: {fallbackReason}");
+        var incrByName = incrOut!.Sources.ToDictionary(s => s.Name, s => s.Code);
+
+        // Caller's C# is untouched — served from cache, byte-identical.
+        Assert.Equal(baselineByName["NsCross Caller"], incrByName["NsCross Caller"]);
+        // Callee's C# reflects the edit.
+        Assert.NotEqual(baselineByName["NsCross Callee"], incrByName["NsCross Callee"]);
+        Assert.Contains("20", incrByName["NsCross Callee"]);
+
+        // Correct: matches an independent full rebuild of the same post-edit tree.
+        var freshOut = new BcCompiler().Emit(new[] { _root }, "NsCrossModuleFresh");
+        var freshByName = freshOut.Sources.ToDictionary(s => s.Name, s => s.Code);
+        Assert.Equal(freshByName["NsCross Caller"], incrByName["NsCross Caller"]);
+        Assert.Equal(freshByName["NsCross Callee"], incrByName["NsCross Callee"]);
+    }
+}

--- a/AlRunner/BcCompiler.Incremental.cs
+++ b/AlRunner/BcCompiler.Incremental.cs
@@ -135,6 +135,32 @@
 // issue's own list of forced-fallback conditions names it) — a file that declares one falls
 // through ClassifyDeclaredObject's every branch and returns null, landing on the ordinary
 // "declares 0 classifiable object(s)" fallback with no special-casing needed.
+//
+// SymbolReference.ModuleDefinition nests namespace-declared objects — never trust the
+// top-level kind arrays alone (issue #2507)
+// -----------------------------------------------------------------------------------------
+// Confirmed by decompiling SerializableSymbolModelConverter: `ConvertModuleToSerializableSymbolModel`
+// populates a ModuleDefinition's OWN Codeunits/Tables/Pages/etc. arrays from
+// `moduleSymbol.GlobalNamespace.SymbolMap` — the GLOBAL namespace's DIRECT children only.
+// An object declared inside a `namespace Foo.Bar;` block is NOT a direct child of the global
+// namespace; it lives under a chain of nested `NamespaceDefinition` nodes instead
+// (`ModuleDefinition.Namespaces[i].Namespaces[j]....Codeunits`, built recursively by
+// `ConvertNamespaces`/`SetContainerObjects`), and BC's converter is faithful about this — it is
+// not a bug in BC. `Compilation.GetDeclaredApplicationObjectSymbols()` does NOT have this split
+// (it walks `ModuleSymbol.SymbolMap`, which recurses through every namespace level itself), which
+// is why that API and `SymbolJsonWriter.GetModuleDefinition` on the SAME compilation can report
+// wildly different counts (140 declared objects vs. 0 in the top-level arrays) for an app that
+// declares `namespace` in (nearly) every file — the modern `al new` default, and true of the real
+// corpus this was diagnosed against. `RecordIncrementalBaseline`/`ExcludeObjects`/
+// `MergeModuleDefinition` below therefore never touch a ModuleDefinition's or NamespaceDefinition's
+// kind-array properties without ALSO recursing into `.Namespaces` — see `RadMergeablePropertiesByKind`
+// (reflects on `IObjectContainerDefinition`, the interface BOTH ModuleDefinition and
+// NamespaceDefinition implement, precisely so the same by-kind filtering logic applies at every
+// namespace depth without duplicating it) and the namespace-matching-by-`Name` step in
+// `MergeContainerRecursive`. A `NamespaceDefinition` itself is never a RAD object with its own
+// (Kind,Id-or-Name) identity — it is purely structural, so it is matched across old/delta trees by
+// its own `Name` (BC never sets `NamespaceDefinition.Id` — confirmed in `ConvertNamespaces`), never
+// excluded/merged as if it were a changed application object.
 using System.Collections.Immutable;
 using System.Reflection;
 using System.Security.Cryptography;
@@ -858,11 +884,17 @@ public sealed partial class BcCompiler
             if (!claimedPaths.Add(resolved)) { objectByPath.Remove(resolved); return; } // a genuine second id-less object in one file
             objectByPath[resolved] = new RadObjectIdentity(kind, null, name);
         }
-        if (moduleDef.Interfaces != null) foreach (var e in moduleDef.Interfaces) TrackIdless(e.ReferenceSourceFileName, e.Name, NavCA.SymbolKind.Interface);
-        if (moduleDef.ControlAddIns != null) foreach (var e in moduleDef.ControlAddIns) TrackIdless(e.ReferenceSourceFileName, e.Name, NavCA.SymbolKind.ControlAddIn);
-        if (moduleDef.Profiles != null) foreach (var e in moduleDef.Profiles) TrackIdless(e.ReferenceSourceFileName, e.Name, NavCA.SymbolKind.Profile);
-        if (moduleDef.PageCustomizations != null) foreach (var e in moduleDef.PageCustomizations) TrackIdless(e.ReferenceSourceFileName, e.Name, NavCA.SymbolKind.PageCustomization);
-        if (moduleDef.ProfileExtensions != null) foreach (var e in moduleDef.ProfileExtensions) TrackIdless(e.ReferenceSourceFileName, e.Name, NavCA.SymbolKind.ProfileExtension);
+        // #2507: a namespace-declared id-less object lives under `.Namespaces[...]`, not the
+        // module's own top-level arrays — walk every container in the tree, not just the root
+        // (see this file's header comment on ModuleDefinition namespace nesting).
+        foreach (var container in EnumerateContainers(moduleDef))
+        {
+            if (container.Interfaces != null) foreach (var e in container.Interfaces) TrackIdless(e.ReferenceSourceFileName, e.Name, NavCA.SymbolKind.Interface);
+            if (container.ControlAddIns != null) foreach (var e in container.ControlAddIns) TrackIdless(e.ReferenceSourceFileName, e.Name, NavCA.SymbolKind.ControlAddIn);
+            if (container.Profiles != null) foreach (var e in container.Profiles) TrackIdless(e.ReferenceSourceFileName, e.Name, NavCA.SymbolKind.Profile);
+            if (container.PageCustomizations != null) foreach (var e in container.PageCustomizations) TrackIdless(e.ReferenceSourceFileName, e.Name, NavCA.SymbolKind.PageCustomization);
+            if (container.ProfileExtensions != null) foreach (var e in container.ProfileExtensions) TrackIdless(e.ReferenceSourceFileName, e.Name, NavCA.SymbolKind.ProfileExtension);
+        }
 
         // Entitlement: no ModuleDefinition representation at all — recovered from the ALREADY-
         // PARSED syntax trees this compilation holds (no extra parse).
@@ -921,22 +953,35 @@ public sealed partial class BcCompiler
         compilerFeatures: manifestInputs.CompilerFeatures,
         contextSensitiveHelpUrl: manifestInputs.ContextSensitiveHelpUrl);
 
-    /// <summary>Shallow-clones a ModuleDefinition with the given objects removed from every mergeable array property, keyed by <see cref="ElementKey"/> (id when the kind has one, else name).</summary>
+    /// <summary>
+    /// Clones a ModuleDefinition with the given objects removed from every mergeable array
+    /// property, keyed by <see cref="ElementKey"/> (id when the kind has one, else name) —
+    /// recursing into <c>.Namespaces</c> at every depth (issue #2507: a namespace-declared
+    /// object never appears in the top-level arrays at all — see this file's header comment).
+    /// Never mutates <paramref name="module"/> or any of its descendants.
+    /// </summary>
     private static NavSymRef.ModuleDefinition ExcludeObjects(NavSymRef.ModuleDefinition module, IReadOnlySet<RadObjectIdentity> exclude)
+        => (NavSymRef.ModuleDefinition)ExcludeObjectsRecursive(module, exclude);
+
+    private static NavSymRef.IObjectContainerDefinition ExcludeObjectsRecursive(NavSymRef.IObjectContainerDefinition container, IReadOnlySet<RadObjectIdentity> exclude)
     {
-        var clone = CloneModuleDefinition(module);
+        var clone = CloneContainerShallow(container);
         foreach (var (propName, kind) in RadMergeablePropertiesByKind)
         {
             var keysToExclude = new HashSet<string>(exclude.Where(e => e.Kind == kind).Select(IdentityElementKeyOf));
             if (keysToExclude.Count == 0) continue;
-            var prop = typeof(NavSymRef.ModuleDefinition).GetProperty(propName)!;
-            if (prop.GetValue(module) is not Array arr) continue;
+            var prop = RadContainerProperty(propName);
+            if (prop.GetValue(container) is not Array arr) continue;
             var elemType = prop.PropertyType.GetElementType()!;
             var kept = arr.Cast<object>().Where(item => !keysToExclude.Contains(ElementKey(item, kind))).ToList();
             var result = Array.CreateInstance(elemType, kept.Count);
             for (int i = 0; i < kept.Count; i++) result.SetValue(kept[i], i);
             prop.SetValue(clone, result);
         }
+        if (container.Namespaces != null)
+            clone.Namespaces = container.Namespaces
+                .Select(ns => (NavSymRef.NamespaceDefinition)ExcludeObjectsRecursive(ns, exclude))
+                .ToArray();
         return clone;
     }
 
@@ -944,28 +989,57 @@ public sealed partial class BcCompiler
     /// (old module, minus the just-changed objects) UNION (delta module's definitions for
     /// exactly those objects) — see this file's header comment for why this must be a manual
     /// merge rather than trusting the delta compilation's own conversion to be complete.
+    /// Recurses into <c>.Namespaces</c> at every depth, matching an old namespace against its
+    /// delta counterpart BY NAME (a `namespace` block has no (Kind,Id-or-Name) identity of its
+    /// own — see this file's header comment) — a namespace delta declares ONLY THIS cycle
+    /// touches is brought in wholesale (everything under it is, by construction, part of
+    /// <paramref name="changed"/>, since <c>SymbolJsonWriter.GetModuleDefinition</c> on a RAD
+    /// compilation reflects only source-declared objects — see its own doc comment).
     /// </summary>
     private static NavSymRef.ModuleDefinition MergeModuleDefinition(
         NavSymRef.ModuleDefinition oldModule, IReadOnlySet<RadObjectIdentity> changed, NavSymRef.ModuleDefinition delta)
+        => (NavSymRef.ModuleDefinition)MergeContainerRecursive(oldModule, changed, delta);
+
+    private static NavSymRef.IObjectContainerDefinition MergeContainerRecursive(
+        NavSymRef.IObjectContainerDefinition oldContainer, IReadOnlySet<RadObjectIdentity> changed, NavSymRef.IObjectContainerDefinition? deltaContainer)
     {
-        var merged = CloneModuleDefinition(oldModule);
+        var merged = CloneContainerShallow(oldContainer);
         foreach (var (propName, kind) in RadMergeablePropertiesByKind)
         {
             var changedKeys = new HashSet<string>(changed.Where(c => c.Kind == kind).Select(IdentityElementKeyOf));
-            var prop = typeof(NavSymRef.ModuleDefinition).GetProperty(propName)!;
+            var prop = RadContainerProperty(propName);
             var elemType = prop.PropertyType.GetElementType()!;
 
             var kept = new List<object>();
-            if (prop.GetValue(oldModule) is Array oldArr)
+            if (prop.GetValue(oldContainer) is Array oldArr)
                 foreach (var item in oldArr)
                     if (!changedKeys.Contains(ElementKey(item, kind))) kept.Add(item);
-            if (changedKeys.Count > 0 && prop.GetValue(delta) is Array deltaArr)
+            if (changedKeys.Count > 0 && deltaContainer != null && prop.GetValue(deltaContainer) is Array deltaArr)
                 foreach (var item in deltaArr)
                     if (changedKeys.Contains(ElementKey(item, kind))) kept.Add(item);
 
             var result = Array.CreateInstance(elemType, kept.Count);
             for (int i = 0; i < kept.Count; i++) result.SetValue(kept[i], i);
             prop.SetValue(merged, result);
+        }
+
+        var oldNamespaces = oldContainer.Namespaces ?? Array.Empty<NavSymRef.NamespaceDefinition>();
+        var deltaNamespaces = deltaContainer?.Namespaces ?? Array.Empty<NavSymRef.NamespaceDefinition>();
+        if (oldNamespaces.Length > 0 || deltaNamespaces.Length > 0)
+        {
+            var deltaByName = deltaNamespaces.ToDictionary(n => n.Name ?? "", StringComparer.Ordinal);
+            var mergedNamespaces = new List<NavSymRef.NamespaceDefinition>();
+            var seenNames = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var oldNs in oldNamespaces)
+            {
+                seenNames.Add(oldNs.Name ?? "");
+                deltaByName.TryGetValue(oldNs.Name ?? "", out var deltaNs);
+                mergedNamespaces.Add((NavSymRef.NamespaceDefinition)MergeContainerRecursive(oldNs, changed, deltaNs));
+            }
+            foreach (var (name, deltaNs) in deltaByName)
+                if (!seenNames.Contains(name))
+                    mergedNamespaces.Add(deltaNs); // wholly new namespace this cycle — everything under it is already "changed" by construction
+            merged.Namespaces = mergedNamespaces.Count > 0 ? mergedNamespaces.ToArray() : null;
         }
         return merged;
     }
@@ -978,10 +1052,54 @@ public sealed partial class BcCompiler
             .GetMethod("Clone", BindingFlags.NonPublic | BindingFlags.Instance)!.Invoke(module, null)!;
 
     /// <summary>
-    /// ModuleDefinition array properties this fast path merges/excludes objects from — every
-    /// id-bearing kind, plus the 5 id-less kinds ModuleDefinition DOES represent (see this
-    /// file's header comment). Entitlement is deliberately absent: ModuleDefinition has no
-    /// Entitlements array at all.
+    /// Shallow-clones a container (ModuleDefinition OR NamespaceDefinition — both implement
+    /// <see cref="NavSymRef.IObjectContainerDefinition"/>) WITHOUT sharing any mutable array
+    /// reference with the original: <see cref="CloneModuleDefinition"/>'s <c>MemberwiseClone</c>
+    /// copies the <c>Namespaces</c> array reference as-is, and <c>NamespaceDefinition</c> has no
+    /// <c>Clone()</c> of its own (confirmed by decompile) — every caller here immediately
+    /// overwrites every mergeable property AND <c>Namespaces</c> with a freshly built array
+    /// (see <see cref="ExcludeObjectsRecursive"/>/<see cref="MergeContainerRecursive"/>), so a
+    /// bare property copy is sufficient: nothing this file's recursion does ever ends up
+    /// mutating a value still reachable from <paramref name="container"/>'s own original tree.
+    /// </summary>
+    private static NavSymRef.IObjectContainerDefinition CloneContainerShallow(NavSymRef.IObjectContainerDefinition container)
+        => container switch
+        {
+            NavSymRef.ModuleDefinition module => CloneModuleDefinition(module),
+            NavSymRef.NamespaceDefinition ns => new NavSymRef.NamespaceDefinition { Id = ns.Id, Name = ns.Name, Namespaces = ns.Namespaces },
+            _ => throw new InvalidOperationException($"Unexpected {nameof(NavSymRef.IObjectContainerDefinition)} implementation: {container.GetType().Name}"),
+        };
+
+    /// <summary>
+    /// <see cref="RadMergeablePropertiesByKind"/> reflects on <see cref="NavSymRef.IObjectContainerDefinition"/>
+    /// itself (not <c>ModuleDefinition</c>) so the SAME <see cref="PropertyInfo"/> works whether
+    /// <paramref name="propName"/> is being read/written on a <c>ModuleDefinition</c> (the
+    /// module root) or a <c>NamespaceDefinition</c> (any nested namespace level) — both
+    /// implement the interface with the identical property set (confirmed by decompile), and
+    /// .NET reflection through an interface-typed <see cref="PropertyInfo"/> dispatches
+    /// correctly to whichever concrete type the instance actually is.
+    /// </summary>
+    private static PropertyInfo RadContainerProperty(string propName)
+        => typeof(NavSymRef.IObjectContainerDefinition).GetProperty(propName)!;
+
+    /// <summary>
+    /// Depth-first walk of <paramref name="root"/> and every <c>NamespaceDefinition</c> nested
+    /// under it (issue #2507) — the container itself first, then each child's own subtree.
+    /// </summary>
+    private static IEnumerable<NavSymRef.IObjectContainerDefinition> EnumerateContainers(NavSymRef.IObjectContainerDefinition root)
+    {
+        yield return root;
+        if (root.Namespaces == null) yield break;
+        foreach (var ns in root.Namespaces)
+            foreach (var descendant in EnumerateContainers(ns))
+                yield return descendant;
+    }
+
+    /// <summary>
+    /// ModuleDefinition/NamespaceDefinition array properties this fast path merges/excludes
+    /// objects from — every id-bearing kind, plus the 5 id-less kinds ModuleDefinition DOES
+    /// represent (see this file's header comment). Entitlement is deliberately absent: neither
+    /// type has an Entitlements array at all.
     /// </summary>
     private static readonly (string PropertyName, NavCA.SymbolKind Kind)[] RadMergeablePropertiesByKind =
     {

--- a/AlRunner/SymbolJson.cs
+++ b/AlRunner/SymbolJson.cs
@@ -60,16 +60,32 @@ public static class SymbolJsonWriter
 
         if (Environment.GetEnvironmentVariable("ALRUNNER_DUMP_SYMBOLS") == "1")
         {
-            int count = 0;
-            foreach (var prop in new[] { "Codeunits", "Tables", "Pages", "EnumTypes", "XmlPorts", "Reports", "Queries", "Interfaces" })
-            {
-                var p = typeof(ModuleDefinition).GetProperty(prop);
-                if (p?.GetValue(module) is Array arr) count += arr.Length;
-            }
-            Console.Error.WriteLine($"  DEBUG GetModuleDefinition: ModuleDefinition has {count} object(s) populated");
+            // #2507: a namespace-declared object lives under `.Namespaces[...]`, never in the
+            // module's own top-level arrays (BC's converter is faithful about this — it is not a
+            // bug; see BcCompiler.Incremental.cs's header comment). Counting only the top-level
+            // arrays here is exactly the measurement that made #2507 look like "0 populated" for
+            // an app that declares `namespace` almost everywhere, when the true count was
+            // hundreds — so this walks the WHOLE nested tree, matching what
+            // BcCompiler.Incremental.cs's own RAD baseline machinery now does.
+            int count = CountObjectsRecursive(module);
+            Console.Error.WriteLine($"  DEBUG GetModuleDefinition: ModuleDefinition has {count} object(s) populated (including namespace-nested)");
         }
 
         return module;
+    }
+
+    private static int CountObjectsRecursive(IObjectContainerDefinition container)
+    {
+        int count = 0;
+        foreach (var prop in new[] { "Codeunits", "Tables", "Pages", "EnumTypes", "XmlPorts", "Reports", "Queries", "Interfaces" })
+        {
+            var p = typeof(IObjectContainerDefinition).GetProperty(prop);
+            if (p?.GetValue(container) is Array arr) count += arr.Length;
+        }
+        if (container.Namespaces != null)
+            foreach (var ns in container.Namespaces)
+                count += CountObjectsRecursive(ns);
+        return count;
     }
 
     private static ModuleDefinition? TryConvertCompilation(Compilation comp)


### PR DESCRIPTION
Closes #2507

## Root cause

`RecordIncrementalBaseline`'s call to `SymbolJsonWriter.GetModuleDefinition(compilation)` returns a `ModuleDefinition` whose top-level `Codeunits`/`Tables`/`Pages`/etc. arrays are empty for a compilation that declares `namespace` in (nearly) every file — the modern `al new` default. Decompiling `SerializableSymbolModelConverter` confirms this is BC's own faithful behavior, not a bug: a namespace-declared object is nested under `ModuleDefinition.Namespaces[...]`, recursively, one level per dot-segment (`namespace Pageworks.Utils.Internal;` nests 3 levels deep), and is never a direct child of the module's own top-level arrays. `Compilation.GetDeclaredApplicationObjectSymbols()` doesn't have this split (it recurses through every namespace level itself), which is why that API and `GetModuleDefinition` on the *same* compilation reported wildly different counts (140 declared objects vs. 0 top-level) for the app this was diagnosed against.

`RecordIncrementalBaseline`/`ExcludeObjects`/`MergeModuleDefinition` (`AlRunner/BcCompiler.Incremental.cs`) only ever inspected the top-level arrays. For any namespace-heavy app, the RAD baseline's `ModuleDef` was therefore silently empty from the moment it was first recorded, so `CreateForRad`'s self-referencing loader could never correctly represent an untouched sibling object — producing the "already declared" collision #2492 was filed against whenever an unmodified caller in one namespace referenced a modified callee in another.

## Fix

`ExcludeObjects`/`MergeModuleDefinition`/`RecordIncrementalBaseline`'s id-less-kind tracking now recurse into `.Namespaces` at every depth. The by-kind filter/merge logic is shared across every level by reflecting on `IObjectContainerDefinition` — the interface both `ModuleDefinition` and `NamespaceDefinition` implement — instead of `ModuleDefinition` specifically, so the same code path applies uniformly whether the container being filtered is the module root or a namespace three levels deep. A namespace itself has no `(Kind,Id-or-Name)` identity of its own (BC never sets `NamespaceDefinition.Id`), so it's matched across old/delta trees by `Name`, never excluded/merged as if it were a changed application object.

Also fixed the `ALRUNNER_DUMP_SYMBOLS` debug dump in `SymbolJson.cs`, which made the identical top-level-only mistake and is what originally made this look like "0 objects populated" when investigating #2492.

**Shape check (per the workflow contract):** grepped `AlRunner/` for every other reader of a `ModuleDefinition`'s kind-array properties — only `SymbolJson.cs` and `BcCompiler.Incremental.cs` touch them, both now fixed. No sibling call site left with the same blind spot.

## Tests

`AlRunner.Tests/BcCompilerIncrementalNamespaceTests.cs`, two tests, both against a namespace-heavy 30-object bundle spread across 3 namespace segments (one nested two levels deep) — chosen at that scale because #2486's post-mortem on a related issue found a 1-2 file fixture does not reproduce this class of bug:

1. `RecordIncrementalBaseline_NamespaceHeavyApp_ModuleDefPopulatedRecursively_NotInTopLevelArrays` — reflects out the recorded baseline and asserts the top-level `Codeunits` array is near-empty (documents BC's own real behavior) while a recursive walk finds the exact expected count of 30, including the two-levels-deep nested group.
2. `TryEmitIncremental_NamespaceDeclaredApp_CrossNamespaceCall_TakesFastPath_NotFallback` — an unmodified caller in one namespace calling a modified callee in another. **RED confirmed** against the pre-fix code: it fails with `RAD Emit failed: An application object of type 'Codeunit' with ID '92300' is already declared by the extension 'NsCrossModule by AlRunner (1.0.0.0)'` — reproducing the exact error shape #2492 was filed against. **GREEN** with the fix: the fast path is taken, the caller's C# is byte-identical to the pre-edit baseline, and the callee's C# reflects the edit.

Also ran the full pre-existing `BcCompilerIncrementalTests` (14 tests) + `WatchRadRealDependencyTests` suite alongside the two new tests — all 17 pass, no regressions.

## Investigated but out of scope: `--server`'s incremental-compile gap (see #2479)

Checked whether this fix also has an effect on the Pageworks-under-`--server` symptom #2479 describes, per that issue's own framing. It does not, and running Pageworks wasn't needed to establish that: grepping `Program.cs` shows none of `RunAllBundlesForServer`'s three call sites ever pass `useIncrementalChangeModel: true` — it's `false` at two call sites and defaults to `false` (unset) at the third. `TryEmitIncremental` is gated on `beforeRun != null && useIncrementalChangeModel`, so the RAD fast path is never even attempted under `--server`, independent of whether the baseline itself is correct. This confirms and sharpens an existing finding that `--watch` and `--server` are different entry points and only `--watch` currently engages the incremental path. This PR does not touch `Program.cs`'s server entry point at all, so #2479 stays open and untouched by this change.