### PR TITLE
fix(codeunit): trap and roll back a failed guarded Codeunit.Run for both call spellings

### DIFF
--- a/AlRunner.Tests/CodeunitRunGuardRollbackTests.cs
+++ b/AlRunner.Tests/CodeunitRunGuardRollbackTests.cs
@@ -1,0 +1,234 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Runner-mechanism test for issue #2334: a failed guarded <c>Codeunit.Run</c> neither
+/// trapped (instance form) nor rolled back its own writes.
+///
+/// Two independent defects, both fixed here:
+///
+/// 1. <c>CodeunitPatches.NavCodeunit_DoRunAsync</c> (the instance form,
+///    <c>SomeCodeunitVar.Run(...)</c>) had no <c>catch when (guarded)</c> — only the
+///    static form (<c>Codeunit.Run(Codeunit::X)</c>, via
+///    <c>CodeunitPatches.NavCodeunit_RunCodeunit</c>) trapped the inner error and
+///    returned <c>false</c>. The two spellings of the same AL construct behaved
+///    differently.
+///
+/// 2. <c>ALDatabasePatches.EndGuardedRunTransaction(commit: false)</c> was a documented
+///    no-op — a failed guarded run's own writes were never rolled back. Fixed by giving
+///    <c>RecordPatches.TransactionSnapshot</c> a scope-relative snapshot
+///    (<c>PushTransactionWorldScope</c> / <c>PopTransactionWorldScope</c>), independent
+///    of the top-level "since the last real commit" one, so a scope's own writes can be
+///    undone without discarding whatever the caller left uncommitted before entering it.
+///
+/// The BEHAVIORAL claim ("both spellings of a guarded Codeunit.Run trap the same way and
+/// roll their own writes back on failure") is a plain BC-behaviour claim and belongs
+/// upstream — see the StefanMaron/BusinessCentral.AL.Language.Tests PR extending
+/// TestCodeunitRunGuard.al (Codeunit 60217), per
+/// .claude/rules/bc-behavior-tests-go-upstream.md. This test pins the RUNNER's OWN
+/// mechanism so a regression fails loudly here, without depending on the submodule pin
+/// having moved yet.
+///
+/// No Library Assert dependency (no "application" in the fixture's app.json — see
+/// .claude/rules/no-base-app-in-csharp-tests.md): each test raises its own Error() with
+/// the observed value, so the runner's own PASS/FAIL output is the assertion surface.
+/// </summary>
+public class CodeunitRunGuardRollbackTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(params string[] bundles)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        foreach (var b in bundles) args.Append(" \"").Append(b).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    [SkippableFact]
+    public void GuardedRun_InstanceForm_TrapsAndRollsBack_BothSpellingsAgree()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-codeunit-run-guard-2334", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        File.WriteAllText(Path.Combine(root, "app.json"), """
+        {
+          "id": "b2334000-0000-4000-8000-000000002334",
+          "name": "CodeunitRunGuard2334",
+          "publisher": "Repro2334",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62334, "to": 62339 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(root, "CrgProbe.al"), """
+        table 62334 "CRG Probe"
+        {
+            DataClassification = SystemMetadata;
+
+            fields
+            {
+                field(1; "Entry No."; Integer) { }
+            }
+
+            keys
+            {
+                key(PK; "Entry No.") { Clustered = true; }
+            }
+        }
+
+        codeunit 62335 "CRG Erroring"
+        {
+            trigger OnRun()
+            begin
+                Error('CRG-BOOM');
+            end;
+        }
+
+        codeunit 62336 "CRG Write Then Error"
+        {
+            trigger OnRun()
+            var
+                Probe: Record "CRG Probe";
+            begin
+                Probe.Init();
+                Probe."Entry No." := 1;
+                Probe.Insert();
+                Error('CRG-WRITE-BOOM');
+            end;
+        }
+
+        codeunit 62337 "CRG Tests"
+        {
+            Subtype = Test;
+            TestPermissions = Disabled;
+
+            local procedure Initialize()
+            var
+                Probe: Record "CRG Probe";
+            begin
+                Probe.DeleteAll();
+                Commit();
+            end;
+
+            // Half 1: the STATIC form already trapped before this fix (regression guard).
+            [Test]
+            procedure StaticForm_TrapsInnerError_ReturnsFalse()
+            var
+                Ok: Boolean;
+            begin
+                Initialize();
+                Ok := Codeunit.Run(Codeunit::"CRG Erroring");
+                if Ok then
+                    Error('CRG1 FAIL: static-form guarded Codeunit.Run must return false on an erroring OnRun.');
+            end;
+
+            // Half 1: the INSTANCE form must trap identically — this is the exact defect
+            // #2334 reports (only the static form trapped; the instance form rethrew).
+            [Test]
+            procedure InstanceForm_TrapsInnerError_ReturnsFalse()
+            var
+                RunGuard: Codeunit "CRG Erroring";
+                Ok: Boolean;
+            begin
+                Initialize();
+                Ok := RunGuard.Run();
+                if Ok then
+                    Error('CRG2 FAIL: instance-form guarded Run() must return false on an erroring OnRun.');
+            end;
+
+            // Half 2: a guarded run's own writes must not survive when it fails, for BOTH
+            // spellings — EndGuardedRunTransaction(commit: false) used to be a no-op.
+            [Test]
+            procedure StaticForm_WriteThenError_RollsBackInsertedRow()
+            var
+                Probe: Record "CRG Probe";
+                Ok: Boolean;
+            begin
+                Initialize();
+                Ok := Codeunit.Run(Codeunit::"CRG Write Then Error");
+                if Ok then
+                    Error('CRG3 FAIL: static-form guarded Codeunit.Run must return false.');
+                if Probe.Count() <> 0 then
+                    Error('CRG3 FAIL: expected Count()=0 after a failed static-form guarded run''s own Insert, got %1', Probe.Count());
+            end;
+
+            [Test]
+            procedure InstanceForm_WriteThenError_RollsBackInsertedRow()
+            var
+                Probe: Record "CRG Probe";
+                RunGuard: Codeunit "CRG Write Then Error";
+                Ok: Boolean;
+            begin
+                Initialize();
+                Ok := RunGuard.Run();
+                if Ok then
+                    Error('CRG4 FAIL: instance-form guarded Run() must return false.');
+                if Probe.Count() <> 0 then
+                    Error('CRG4 FAIL: expected Count()=0 after a failed instance-form guarded run''s own Insert, got %1', Probe.Count());
+            end;
+
+            // Must-not-regress control: a write made by the CALLER before a guarded run
+            // that itself writes-then-fails must survive — the scope-relative rollback
+            // must undo only the failed scope's OWN writes, not everything since the last
+            // commit point (that would be the top-level RollbackToCommitPoint behaviour,
+            // which this mechanism is deliberately NOT reusing here).
+            [Test]
+            procedure CallerUncommittedWrite_SurvivesInnerGuardedRunFailure()
+            var
+                Probe: Record "CRG Probe";
+                Ok: Boolean;
+            begin
+                Initialize();
+                Probe.Init();
+                Probe."Entry No." := 9;
+                Probe.Insert();
+                Commit();
+
+                Ok := Codeunit.Run(Codeunit::"CRG Write Then Error");
+                if Ok then
+                    Error('CRG5 FAIL: static-form guarded Codeunit.Run must return false.');
+
+                Probe.Reset();
+                if Probe.Count() <> 1 then
+                    Error('CRG5 FAIL: expected the caller''s own committed row to survive the inner run''s rollback, got Count()=%1', Probe.Count());
+            end;
+        }
+        """);
+
+        var (output, exitCode) = RunRunner(root);
+
+        Assert.True(exitCode == 0,
+            $"Expected all five guarded-Codeunit.Run tests to pass (exit 0); got exit {exitCode}.\n{output}");
+        Assert.DoesNotContain("FAIL", output);
+        Assert.Contains("PASS  Codeunit62337.StaticForm_TrapsInnerError_ReturnsFalse", output);
+        Assert.Contains("PASS  Codeunit62337.InstanceForm_TrapsInnerError_ReturnsFalse", output);
+        Assert.Contains("PASS  Codeunit62337.StaticForm_WriteThenError_RollsBackInsertedRow", output);
+        Assert.Contains("PASS  Codeunit62337.InstanceForm_WriteThenError_RollsBackInsertedRow", output);
+        Assert.Contains("PASS  Codeunit62337.CallerUncommittedWrite_SurvivesInnerGuardedRunFailure", output);
+    }
+}

--- a/AlRunner/Patches/ALDatabasePatches.cs
+++ b/AlRunner/Patches/ALDatabasePatches.cs
@@ -107,6 +107,17 @@ public static class ALDatabasePatches
     }
 
     /// <summary>
+    /// BC's TransactionManager PUSH of the nested logical transaction a GUARDED
+    /// <c>Codeunit.Run</c> opens — the counterpart of <see cref="EndGuardedRunTransaction"/>.
+    /// Call before invoking the guarded run's OnRun, for BOTH the instance form
+    /// (<c>CodeunitPatches.NavCodeunit_DoRunAsync</c>) and the static form
+    /// (<c>CodeunitPatches.NavCodeunit_RunCodeunit</c>) — see AlRunner#2334, which is exactly
+    /// about those two spellings of the same AL construct having drifted apart.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void BeginGuardedRunTransaction() => RecordPatches.PushTransactionWorldScope();
+
+    /// <summary>
     /// BC's TransactionManager end of the nested logical transaction a GUARDED
     /// <c>Codeunit.Run</c> opens — the other half of
     /// <see cref="ThrowIfWriteTransactionStarted"/>, which only models the entry guard.
@@ -115,9 +126,11 @@ public static class ALDatabasePatches
     /// (decompiled Ncl.dll):
     ///
     ///     activeSession.BeginTransactionWorldAndTransaction();
+    ///     RecordState recordState = record?.CreateRecordState();
+    ///     recordState?.BackupTableAndRecordHandle();
     ///     try     { OnRun(record); result = true; }
-    ///     catch (NavBaseException) { /* suppressed */ }
-    ///     finally { activeSession.EndTransactionWorldAndTransaction(result); }
+    ///     catch (NavBaseException) { recordState?.RestoreRecord(); }
+    ///     finally { recordState?.Dispose(); activeSession.EndTransactionWorldAndTransaction(result); }
     ///
     /// TransactionManager.BeginTransaction PUSHES a new LogicalTransaction; EndTransactionImpl
     /// POPS it, committing when `commit` is true. So the run codeunit's writes set
@@ -139,18 +152,26 @@ public static class ALDatabasePatches
     /// the run's rows back. ALDatabase_ALCommit is precisely that: clear the write-transaction
     /// flag, and mark a commit point.
     ///
-    /// NOT modelled: the <c>commit == false</c> half. BC's EndTransactionWorldAndTransaction(false)
-    /// rolls the failed run's own rows back; the runner's snapshot store cannot express a
-    /// rollback to the scope's ENTRY state (RecordPatches.NoteTransactionWrite re-baselines on
-    /// every write, so RollbackToCommitPoint only restores the state before the LAST write per
-    /// table). Rather than half-restore, this leaves the failure path exactly as it behaves
-    /// today, tracked as its own gap — see AlRunner#2334.
+    /// The <c>commit == false</c> half (AlRunner#2334): restore every table THIS scope wrote
+    /// to, back to its image at scope entry — see RecordPatches.PushTransactionWorldScope /
+    /// PopTransactionWorldScope for the scope-relative (not commit-point-relative) snapshot
+    /// this needed. The <c>RecordState.RestoreRecord()</c> half above — reverting the PASSED
+    /// record VARIABLE's own in-memory field values, distinct from the table row — is NOT
+    /// modelled; the runner has no equivalent of BC's RecordState backup/restore for a single
+    /// AL record variable. Left as a follow-up if a test needs it.
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void EndGuardedRunTransaction(bool commit)
     {
-        if (!commit) return;
-        ALDatabase_ALCommit();
+        if (commit)
+        {
+            RecordPatches.PopTransactionWorldScope(restore: false);
+            ALDatabase_ALCommit();
+        }
+        else
+        {
+            RecordPatches.PopTransactionWorldScope(restore: true);
+        }
     }
 
     /// <summary>

--- a/AlRunner/Patches/CodeunitPatches.cs
+++ b/AlRunner/Patches/CodeunitPatches.cs
@@ -162,6 +162,8 @@ public static partial class BcRuntime
         // Without the closing half the runner left its single write-transaction flag set and
         // refused every later guarded Codeunit.Run in the same caller. See
         // ALDatabasePatches.EndGuardedRunTransaction and AlRunner#2332.
+        if (guarded) ALDatabasePatches.BeginGuardedRunTransaction();
+
         bool ran = false;
         try
         {
@@ -173,6 +175,16 @@ public static partial class BcRuntime
         {
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(tie.InnerException);
             return default;
+        }
+        catch when (guarded)
+        {
+            // BC's DoRunAsync `errorLevel != DataError.ThrowError` branch wraps OnRun in
+            // `catch (NavBaseException) { /* suppressed */ }` — the guarded (Boolean-result-
+            // consumed) form of `Codeunit.Run` traps its inner error and returns false,
+            // exactly like the static form's `catch when (trap)` in NavCodeunit_RunCodeunit
+            // below. Before this, only the static spelling trapped; the instance spelling
+            // (`SomeCodeunitVar.Run(Rec)`) rethrew at the AL caller instead. See AlRunner#2334.
+            return new System.Threading.Tasks.ValueTask<bool>(false);
         }
         finally
         {
@@ -202,8 +214,10 @@ public static partial class BcRuntime
         if (guarded)
             ALDatabasePatches.ThrowIfWriteTransactionStarted();
 
-        // The closing half of the same bracket — see NavCodeunit_DoRunAsync above and
-        // ALDatabasePatches.EndGuardedRunTransaction.
+        // The opening/closing halves of the same bracket — see NavCodeunit_DoRunAsync above
+        // and ALDatabasePatches.BeginGuardedRunTransaction / EndGuardedRunTransaction.
+        if (guarded) ALDatabasePatches.BeginGuardedRunTransaction();
+
         bool ran = false;
         try
         {

--- a/AlRunner/Patches/RecordPatches.TransactionSnapshot.cs
+++ b/AlRunner/Patches/RecordPatches.TransactionSnapshot.cs
@@ -170,7 +170,16 @@ public static partial class RecordPatches
         {
             if (!perTable.TryGetValue(tableId, out var dataAccess)) continue;
             var key = (source, tableId);
-            if (_txCommitPoint.ContainsKey(key)) continue;
+
+            // Two independent "first write since X" trackers can both need this same
+            // pre-write image: the top-level commit-point tracker (X = last real commit),
+            // and the innermost open transaction-world scope, if any (X = that scope's own
+            // entry) — see PushTransactionWorldScope. Capture once, store into whichever of
+            // the two haven't already seen a write to this table.
+            var needsCommitPointSnapshot = !_txCommitPoint.ContainsKey(key);
+            var scopeDict = _txScopeStack.Count > 0 ? _txScopeStack.Peek() : null;
+            var needsScopeSnapshot = scopeDict != null && !scopeDict.ContainsKey(key);
+            if (!needsCommitPointSnapshot && !needsScopeSnapshot) continue;
 
             var provider = GetDataProvider(dataAccess);
             if (provider == null || provider.GetType().Name != "TempTableDataProvider") continue;
@@ -187,7 +196,80 @@ public static partial class RecordPatches
                     if (row is TempTableRecordBuffer buffer)
                         rows.Add(CloneValues(buffer.ToArray()));
 
-            _txCommitPoint[key] = new BaselineTable(tableId, metaTable, rows.ToArray());
+            var baseline = new BaselineTable(tableId, metaTable, rows.ToArray());
+            if (needsCommitPointSnapshot) _txCommitPoint[key] = baseline;
+            if (needsScopeSnapshot) scopeDict![key] = baseline;
+        }
+    }
+
+    // ── Nested transaction-world scopes (a guarded Codeunit.Run's own commit/rollback
+    // bracket) ──────────────────────────────────────────────────────────────────────────
+    // BC's BeginTransactionWorldAndTransaction / EndTransactionWorldAndTransaction(commit)
+    // push and pop a LOGICAL transaction around a guarded Codeunit.Run's own OnRun — see
+    // ALDatabasePatches.BeginGuardedRunTransaction / EndGuardedRunTransaction and
+    // AlRunner#2334. A commit==false pop must restore ONLY the rows THIS scope itself wrote
+    // — rolling all the way back to the last real commit point would also discard whatever
+    // the CALLER left uncommitted before entering the guarded run, which BC does not do.
+    // That needs its own, non-refreshing entry image per open scope, tracked independently
+    // of _txCommitPoint's "since the last real commit" one — hence the stack, and the
+    // dual-write in NoteTransactionWrite above.
+    //
+    // NOT verified against real BC: nested guarded runs (a guarded Codeunit.Run whose OnRun
+    // itself calls another guarded Codeunit.Run). PopTransactionWorldScope's commit==true
+    // branch forgets any OLDER snapshot an enclosing scope holds for a table this scope
+    // itself touched, so a LATER failure in the enclosing scope cannot undo the inner
+    // scope's already-committed write — reasoned from "a transaction-world commit is as
+    // durable as an explicit Commit()" (see NoteTransactionEnd below), not measured against
+    // a real BC service tier. This shape is not exercised by any known corpus or
+    // runner-extras test today.
+    private static readonly Stack<Dictionary<(object Source, int TableId), BaselineTable>> _txScopeStack = new();
+
+    /// <summary>
+    /// Open a new transaction-world scope — the runner's replacement for BC's
+    /// <c>Session.BeginTransactionWorldAndTransaction()</c>. Call before invoking the guarded
+    /// run's OnRun; pair with <see cref="PopTransactionWorldScope"/> in a finally.
+    /// </summary>
+    public static void PushTransactionWorldScope() => _txScopeStack.Push(new());
+
+    /// <summary>
+    /// Close the innermost transaction-world scope — the runner's replacement for BC's
+    /// <c>Session.EndTransactionWorldAndTransaction(commit)</c>.
+    ///
+    /// <paramref name="restore"/> == true (commit == false): restore every table this scope
+    /// wrote to back to its image at scope entry, undoing exactly this scope's own writes.
+    ///
+    /// <paramref name="restore"/> == false (commit == true): the scope's writes are now as
+    /// durable as an explicit Commit() (see NoteTransactionEnd) — forget any older snapshot
+    /// any enclosing scope, or the top-level commit-point tracker, is still holding for the
+    /// tables this scope touched, so neither can roll a durably-committed write back past
+    /// this point.
+    /// </summary>
+    public static void PopTransactionWorldScope(bool restore)
+    {
+        if (_txScopeStack.Count == 0) return; // defensive; Begin/End must always pair
+        var scope = _txScopeStack.Pop();
+        if (scope.Count == 0) return;
+
+        if (restore)
+        {
+            foreach (var ((source, tableId), saved) in scope)
+            {
+                if (!_dataAccessByTable.TryGetValue(source, out var perTable)) continue;
+                if (!perTable.TryGetValue(tableId, out var dataAccess)) continue;
+                var provider = GetDataProvider(dataAccess);
+                if (provider == null || provider.GetType().Name != "TempTableDataProvider") continue;
+
+                ClearProviderInPlace(provider);
+                InsertRows(provider, saved.MetaTable, saved.Rows);
+            }
+            return;
+        }
+
+        foreach (var key in scope.Keys)
+        {
+            _txCommitPoint.Remove(key);
+            foreach (var enclosing in _txScopeStack)
+                enclosing.Remove(key);
         }
     }
 


### PR DESCRIPTION
Closes #2334

## Problem

A failed guarded `Codeunit.Run` (Boolean result consumed) got two things wrong:

1. **The instance form did not trap.** `Codeunit.Run(Codeunit::X)` (static form, via
   `CodeunitPatches.NavCodeunit_RunCodeunit`) had `catch when (trap) { return false; }`.
   `SomeCodeunitVar.Run(Rec)` (instance form, via `CodeunitPatches.NavCodeunit_DoRunAsync`)
   had no such catch — it rethrew the inner exception at the AL caller. Two spellings of
   the same AL construct behaved differently.
2. **The failed run's writes were not rolled back**, for either spelling.
   `ALDatabasePatches.EndGuardedRunTransaction(commit: false)` was a documented no-op: the
   existing snapshot store (`RecordPatches.TransactionSnapshot`) only expresses "roll back
   to the last real commit point," because `NoteTransactionWrite` re-baselines each table on
   its first write since that commit point — not "roll back to this scope's own entry
   state."

## Fix

- `CodeunitPatches.NavCodeunit_DoRunAsync` now has `catch when (guarded)` mirroring the
  static form's trap, matching BC's decompiled `DoRunAsync` (`catch (NavBaseException) {
  /* suppressed */ }` in the `errorLevel != DataError.ThrowError` branch).
- Gave `RecordPatches.TransactionSnapshot` a **scope-relative** snapshot stack
  (`PushTransactionWorldScope` / `PopTransactionWorldScope`), independent of the
  commit-point tracker. `NoteTransactionWrite` now captures a table's pre-write image into
  both trackers independently (whichever hasn't already seen a write to that table since
  its own establishment point). A failed scope's `PopTransactionWorldScope(restore: true)`
  restores only the tables *that scope itself* wrote to, back to their state at scope entry
  — not to the last commit point, which would also discard whatever the caller left
  uncommitted before entering the guarded run.
- `ALDatabasePatches.BeginGuardedRunTransaction()` (new) pushes the scope; wired into BOTH
  `NavCodeunit_DoRunAsync` and `NavCodeunit_RunCodeunit`, matching the two existing
  `EndGuardedRunTransaction` call sites.

### Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — the rollback half (`commit == false`
   no-op) was broken identically in the STATIC form (`NavCodeunit_RunCodeunit`), not just
   the instance form the issue reported. Both call sites now share the same
   Begin/End bracket.
2. **Sibling function, same assumption?** `RecordPatches.RollbackToCommitPoint` (the
   existing asserterror-rollback mechanism) made the same "single flat snapshot" assumption
   the new scope-relative rollback needed to NOT make. Extended `NoteTransactionWrite` to
   feed both trackers independently rather than reusing one for both purposes.
3. **Same invariant on both write paths?** Yes — `PopTransactionWorldScope`'s
   `restore: false` (commit) branch forgets any older snapshot an enclosing scope or the
   commit-point tracker holds for a table this scope touched, so a later enclosing-scope
   failure can't roll a durably-committed inner write back past its own commit point
   (reasoned, not measured against real BC for nested guarded runs — documented as such in
   the code, since no known test exercises that nesting).

## Measured impact (honest number, not the issue's predicted 17)

Microsoft's `Tests-SINGLESERVER` `Codeunit136608` ("ERM RS Validate and Apply"), BC
28.1.49838.53910, `--test-data` against `BusinessCentral-W1.bak`:

| | before | after |
|---|---|---|
| pass/fail | 29P / 30F | **38P / 21F** |

9 tests moved FAIL→PASS, 0 regressions:
`DelayedInsertOnApplyProductionForecastEntryWhenConfigTableHasMandatoryFieldNotFilled`,
`DelayedInsertOnApplyProductionForecastEntryWhenConfigTableHasMandatoryFieldsFilled`,
`NonKeyFieldsValidatedOnDelayedInsert`,
`PackageDataApplying_ApplyMultipleRecordsWithWrongRecordProcessingOrder_PackageErrorGenerated`,
`PackageDataApplying_ApplyRecordWithWrongRelation_PackageErrorGenerated`,
`PackageDataApplying_MasterThenRelatedThenMasterAgain_NoPackageErrorsAfterLastApply`,
`PackageDataApplying_RunApplyWithTableFilter_PackageErrorsForOtherTablesSaved`,
`VerifyDimensionsTableIsAppliedWhenTableWithDimSetIDIsSelected`,
`VerifyDimensionsTableIsNotAppliedWhenTableWithDimSetIDIsSelectedAndDimSetEntryIsEmpty`.

3 of the tests the original issue named as targets (`DelayedInsertFalseOnApplyConfigPackageTableWhenWrongRelation`,
`DelayedInsertTrueOnApplyConfigPackageTableWhenWrongRelation`,
`PackageDataApplying_RecordWithWrongRelationInPK_RecordNotInserted`) are **still failing**,
with the identical symptom as before this fix — evidence that the specific write path
they exercise (`Config. Package Management.InsertPackageRecord`) does not route through
either `NavCodeunit.Run*` entry point this fix touches, so it needs its own investigation.
Filed separately as #2528 rather than guessed at here.

## Not modelled (documented, not silently dropped)

- `RecordState.RestoreRecord()` — BC's `DoRunAsync` also reverts the PASSED record
  variable's own in-memory field values on failure (distinct from the table row). Not
  implemented; no test in this PR or upstream needs it yet. Documented in
  `ALDatabasePatches.EndGuardedRunTransaction`'s doc comment as a follow-up.
- Nested guarded runs (a guarded `Codeunit.Run` whose `OnRun` itself calls another guarded
  `Codeunit.Run`) — the commit-forgetting logic in `PopTransactionWorldScope` is reasoned
  from BC's documented "commit is as durable as an explicit `Commit()`" semantics, not
  measured against a real BC service tier for this specific nesting shape. Documented in
  `RecordPatches.TransactionSnapshot.cs`.

## Tests

- Upstream corpus PR (both spellings + rollback, extends `TestCodeunitRunGuard.al`):
  StefanMaron/BusinessCentral.AL.Language.Tests#119
- Runner-side mechanism test (pins the runner's own trap+rollback behavior without
  depending on the submodule pin having moved yet, per
  `.claude/rules/bc-behavior-tests-go-upstream.md`):
  `AlRunner.Tests/CodeunitRunGuardRollbackTests.cs`. RED confirmed (reverting the three
  patch files makes it fail with the pre-fix symptom), GREEN after.
- The submodule pin is **not** bumped in this PR — the corpus PR hasn't merged yet. Once it
  does, the pin bump + `test-count-baseline.json` update will follow in a small companion
  commit/PR per `.claude/rules/al-language-submodule.md`.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf