### PR TITLE
fix(rad): stop losing a namespace-nested sibling's array on a RAD self-loader clone

### DIFF
--- a/AlRunner.Tests/BcCompilerIncrementalCrossKindSiblingTests.cs
+++ b/AlRunner.Tests/BcCompilerIncrementalCrossKindSiblingTests.cs
@@ -1,0 +1,181 @@
+// BcCompilerIncrementalCrossKindSiblingTests — RED/GREEN proof for issue #2479's remaining
+// half (same-bundle self-edit inside a namespace-declared app).
+//
+// #2479 (comment 2026-09-03T14:57:01Z): editing a codeunit inside a real project's TEST app,
+// where the touched codeunit references a REPORT declared in a separate .al file of the SAME
+// bundle, failed the incremental (RAD) emit with "RAD Emit failed: The name
+// '<ReportObjectName>' does not exist in the current context" — even though the report itself
+// was never touched. Narrowed down here (bisecting kind and namespace-presence independently, at
+// unit scale — no Pageworks/real-project repro needed):
+//   - a namespace-declared codeunit referencing an untouched namespace-declared CODEUNIT sibling
+//     was already covered (BcCompilerIncrementalNamespaceTests) and works;
+//   - the SAME shape but with the untouched sibling of a DIFFERENT id-bearing kind (Table,
+//     Report, ...) and BOTH objects namespace-declared reproduces the crash;
+//   - neither ingredient alone reproduces it: a flat (non-namespaced) codeunit referencing a
+//     flat Table/Report sibling compiles fine (see the existing cross-object-call tests), and a
+//     namespaced codeunit referencing a namespaced CODEUNIT sibling also compiles fine.
+//
+// Root cause (BcCompiler.Incremental.cs's `ExcludeObjectsRecursive`, fixed alongside this file):
+// building the self-loader's baseline module cloned every NAMESPACE container by hand (BC's own
+// `ModuleDefinition.Clone()` has no `NamespaceDefinition` counterpart), and the per-kind loop
+// only ever called `prop.SetValue(clone, ...)` for a kind that actually had something excluded
+// THIS cycle. Editing a Codeunit excludes only the Codeunit kind, so every OTHER kind's array
+// (Tables, Reports, Pages, ...) was left at its CLR default — null — on every namespace clone.
+// BC's binder resolved a reference into that null array far enough to bind SOME symbol, but
+// never gave it a real `NavTypeKind`, and `Compilation.Emit` crashed deep inside
+// `CodeGenerator.EmitFieldInitializer` with "Unexpected value 'None' of type NavTypeKind" the
+// moment codegen tried to emit that variable's scope-class field initializer — the exact crash
+// class this file's own header comment already documents for an unresolved DotNet type,
+// reproduced here for an unresolved namespace-nested AL sibling instead. A same-kind sibling
+// (Codeunit referencing Codeunit) never hit this, because excluding the touched Codeunit already
+// forced the Codeunits property to be reassigned on the clone.
+using Xunit;
+using AlRunner;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class BcCompilerIncrementalCrossKindSiblingTests : IDisposable
+{
+    private readonly string _root;
+    private readonly BcEngineFixture _engine;
+
+    public BcCompilerIncrementalCrossKindSiblingTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-incremental-crosskind-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private void WriteAl(string fileName, string content) => File.WriteAllText(Path.Combine(_root, fileName), content);
+
+    private static Dictionary<string, string> ByName(BcEmitOutput output)
+        => output.Sources.ToDictionary(s => s.Name, s => s.Code);
+
+    [SkippableFact]
+    public void TryEmitIncremental_NamespacedCodeunitReferencesReportSiblingInSeparateFile_EditingOnlyTheCodeunit_TakesFastPath()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        WriteAl("Report.al", """
+            namespace Pageworks.Test;
+
+            report 90260 "Incr Report Sibling"
+            {
+                UsageCategory = None;
+                ProcessingOnly = true;
+
+                dataset
+                {
+                }
+            }
+            """);
+        string CallerSrc(int returnValue) => $$"""
+            namespace Pageworks.Test;
+
+            codeunit 90261 "Incr Report Caller"
+            {
+                procedure Marker(): Integer
+                var
+                    Rep: Report "Incr Report Sibling";
+                begin
+                    Rep.UseRequestPage(false);
+                    Rep.RunModal();
+                    exit({{returnValue}});
+                end;
+            }
+            """;
+        WriteAl("Caller.al", CallerSrc(1));
+
+        var compiler = new BcCompiler();
+        var baselineOut = compiler.Emit(new[] { _root }, "CrossKindReportModule", trackIncrementalBaseline: true);
+        Assert.Empty(baselineOut.Diagnostics);
+        var baselineByName = ByName(baselineOut);
+        Assert.Equal(2, baselineByName.Count);
+
+        // Edit ONLY the codeunit that declares a `Report "Incr Report Sibling"` variable. The
+        // report itself is never touched.
+        WriteAl("Caller.al", CallerSrc(2));
+
+        var incrOut = compiler.TryEmitIncremental(new[] { _root }, "CrossKindReportModule", appRootDir: null, out var fallbackReason);
+        Assert.True(incrOut != null,
+            $"expected the fast path to apply for a namespaced codeunit-only edit referencing an untouched namespaced report sibling; fell back instead: {fallbackReason}");
+        var incrByName = ByName(incrOut!);
+
+        // Caller's C# reflects the edit.
+        Assert.Contains("2", incrByName["Incr Report Caller"]);
+        // The untouched report's C# is served from cache, byte-identical.
+        Assert.Equal(baselineByName["Incr Report Sibling"], incrByName["Incr Report Sibling"]);
+
+        // Correct: matches an independent full rebuild of the same post-edit tree.
+        var freshOut = new BcCompiler().Emit(new[] { _root }, "CrossKindReportModuleFresh");
+        var freshByName = ByName(freshOut);
+        Assert.Equal(freshByName["Incr Report Caller"], incrByName["Incr Report Caller"]);
+        Assert.Equal(freshByName["Incr Report Sibling"], incrByName["Incr Report Sibling"]);
+    }
+
+    [SkippableFact]
+    public void TryEmitIncremental_NamespacedCodeunitReferencesTableSiblingInSeparateFile_EditingOnlyTheCodeunit_TakesFastPath()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        WriteAl("Table.al", """
+            namespace Pageworks.Test;
+
+            table 90262 "Incr Table Sibling"
+            {
+                DataClassification = CustomerContent;
+                fields
+                {
+                    field(1; "No."; Code[20]) { }
+                }
+                keys { key(PK; "No.") { Clustered = true; } }
+            }
+            """);
+        string CallerSrc(int returnValue) => $$"""
+            namespace Pageworks.Test;
+
+            codeunit 90263 "Incr Table Caller"
+            {
+                procedure Marker(): Integer
+                var
+                    Rec: Record "Incr Table Sibling";
+                begin
+                    Rec.Init();
+                    exit({{returnValue}});
+                end;
+            }
+            """;
+        WriteAl("Caller.al", CallerSrc(1));
+
+        var compiler = new BcCompiler();
+        var baselineOut = compiler.Emit(new[] { _root }, "CrossKindTableModule", trackIncrementalBaseline: true);
+        Assert.Empty(baselineOut.Diagnostics);
+        var baselineByName = ByName(baselineOut);
+        // Only the codeunit produces runtime C# (the table's shape is metadata, not a
+        // separate emitted object here) — assert the codeunit is present rather than a fixed
+        // total, matching how BC counts objects vs. emitted sources.
+        Assert.Contains("Incr Table Caller", baselineByName.Keys);
+
+        // Edit ONLY the codeunit that declares a `Record "Incr Table Sibling"` variable. The
+        // table itself is never touched.
+        WriteAl("Caller.al", CallerSrc(2));
+
+        var incrOut = compiler.TryEmitIncremental(new[] { _root }, "CrossKindTableModule", appRootDir: null, out var fallbackReason);
+        Assert.True(incrOut != null,
+            $"expected the fast path to apply for a namespaced codeunit-only edit referencing an untouched namespaced table sibling; fell back instead: {fallbackReason}");
+        var incrByName = ByName(incrOut!);
+
+        Assert.Contains("2", incrByName["Incr Table Caller"]);
+
+        // Correct: matches an independent full rebuild of the same post-edit tree.
+        var freshOut = new BcCompiler().Emit(new[] { _root }, "CrossKindTableModuleFresh");
+        var freshByName = ByName(freshOut);
+        Assert.Equal(freshByName["Incr Table Caller"], incrByName["Incr Table Caller"]);
+    }
+}

--- a/AlRunner/BcCompiler.Incremental.cs
+++ b/AlRunner/BcCompiler.Incremental.cs
@@ -968,10 +968,29 @@ public sealed partial class BcCompiler
         var clone = CloneContainerShallow(container);
         foreach (var (propName, kind) in RadMergeablePropertiesByKind)
         {
-            var keysToExclude = new HashSet<string>(exclude.Where(e => e.Kind == kind).Select(IdentityElementKeyOf));
-            if (keysToExclude.Count == 0) continue;
             var prop = RadContainerProperty(propName);
             if (prop.GetValue(container) is not Array arr) continue;
+            var keysToExclude = new HashSet<string>(exclude.Where(e => e.Kind == kind).Select(IdentityElementKeyOf));
+            if (keysToExclude.Count == 0)
+            {
+                // #2479: nothing of THIS kind is being excluded from THIS container — but the
+                // property must still be copied onto the clone. `CloneContainerShallow`'s
+                // NamespaceDefinition branch (unlike ModuleDefinition's own BC-provided Clone())
+                // only ever sets Id/Name/Namespaces, so any kind this loop does not otherwise
+                // touch is left at its CLR default (null) on a namespace clone. A namespaced
+                // bundle where the touched/excluded object is a Codeunit and an untouched
+                // sibling is any OTHER kind (Table, Report, Page, …) previously lost that
+                // sibling's entire array here — the self-loader then handed BC's binder a
+                // namespace with a null Tables/Reports/… array, and CreateForRad's codegen
+                // crashed deep inside EmitFieldInitializer with "Unexpected value 'None' of type
+                // NavTypeKind" (a symbol that resolves far enough for name lookup but was never
+                // given a real TypeKind). A same-kind sibling (Codeunit referencing Codeunit) was
+                // never affected, because excluding the touched Codeunit already forced this
+                // loop's Codeunits branch to run and (correctly) reassign the property. See
+                // BcCompilerIncrementalCrossKindSiblingTests for the RED/GREEN proof.
+                prop.SetValue(clone, arr);
+                continue;
+            }
             var elemType = prop.PropertyType.GetElementType()!;
             var kept = arr.Cast<object>().Where(item => !keysToExclude.Contains(ElementKey(item, kind))).ToList();
             var result = Array.CreateInstance(elemType, kept.Count);
@@ -1055,12 +1074,28 @@ public sealed partial class BcCompiler
     /// Shallow-clones a container (ModuleDefinition OR NamespaceDefinition — both implement
     /// <see cref="NavSymRef.IObjectContainerDefinition"/>) WITHOUT sharing any mutable array
     /// reference with the original: <see cref="CloneModuleDefinition"/>'s <c>MemberwiseClone</c>
-    /// copies the <c>Namespaces</c> array reference as-is, and <c>NamespaceDefinition</c> has no
-    /// <c>Clone()</c> of its own (confirmed by decompile) — every caller here immediately
-    /// overwrites every mergeable property AND <c>Namespaces</c> with a freshly built array
-    /// (see <see cref="ExcludeObjectsRecursive"/>/<see cref="MergeContainerRecursive"/>), so a
-    /// bare property copy is sufficient: nothing this file's recursion does ever ends up
-    /// mutating a value still reachable from <paramref name="container"/>'s own original tree.
+    /// copies every property (including every mergeable array) verbatim, but
+    /// <c>NamespaceDefinition</c> has no <c>Clone()</c> of its own (confirmed by decompile), so
+    /// this hand-rolled branch sets ONLY <c>Id</c>/<c>Name</c>/<c>Namespaces</c> — every
+    /// mergeable-array property starts out unset (CLR default, i.e. null) on a namespace clone.
+    ///
+    /// #2479: that means EVERY caller here MUST explicitly set every mergeable property on the
+    /// result, for every kind — not just the kinds it is actually excluding/merging — or a
+    /// namespace-nested kind the caller had no reason to touch this cycle silently loses its
+    /// entire array. <see cref="MergeContainerRecursive"/> always does
+    /// (`prop.SetValue(merged, result)` runs unconditionally for every kind in
+    /// <see cref="RadMergeablePropertiesByKind"/>). <see cref="ExcludeObjectsRecursive"/> did NOT
+    /// before this fix — it skipped `prop.SetValue` entirely whenever nothing of that kind was
+    /// being excluded, so a namespaced bundle where the touched object was a Codeunit left every
+    /// OTHER kind's array null on the clone. BC's binder resolved a reference into a null Tables/
+    /// Reports/… array far enough to bind a symbol, but never gave it a real
+    /// <c>NavTypeKind</c> — <c>Compilation.Emit</c> crashed deep inside
+    /// <c>CodeGenerator.EmitFieldInitializer</c> with "Unexpected value 'None' of type
+    /// NavTypeKind" the first time an untouched, namespace-nested, non-Codeunit sibling (Table,
+    /// Report, Page, …) was referenced from the edited object's own syntax tree. See
+    /// BcCompilerIncrementalCrossKindSiblingTests for the RED/GREEN proof — a same-kind sibling
+    /// (Codeunit referencing Codeunit) never hit this, because excluding the touched Codeunit
+    /// already forced the Codeunits property to be set.
     /// </summary>
     private static NavSymRef.IObjectContainerDefinition CloneContainerShallow(NavSymRef.IObjectContainerDefinition container)
         => container switch


### PR DESCRIPTION
Closes #2479

## Summary

The remaining half of #2479: editing a codeunit inside a namespace-declared bundle
that references a Table/Report/Page/... sibling declared in a separate file, in the
SAME bundle, previously crashed the incremental (RAD) emit with "RAD Emit failed: The
name '...' does not exist in the current context" and forced a full recompile
every time, even though the sibling was never touched.

## Root cause

`TryEmitIncremental`'s `ExcludeObjectsRecursive` (in `BcCompiler.Incremental.cs`) skips
`prop.SetValue` on the cloned `NamespaceDefinition` whenever nothing of a given kind
is being excluded that cycle. `CloneContainerShallow`'s `NamespaceDefinition` branch
only ever sets `Id`/`Name`/`Namespaces` by hand (`NamespaceDefinition` has no
BC-provided `Clone()`), so any mergeable-array property the loop never touched was
left at its CLR default — `null` — on the clone.

Editing a namespaced Codeunit excludes only the Codeunit kind, so every OTHER kind's
array (Tables, Reports, Pages, ...) came back `null` in the self-loader's baseline
module handed to `Compilation.CreateForRad`. BC's binder resolved a reference into
that null array far enough to bind *some* symbol, but never gave it a real
`NavTypeKind`, and `Compilation.Emit` crashed deep inside
`CodeGenerator.EmitFieldInitializer` with "Unexpected value 'None' of type
NavTypeKind" — the exact crash class this file's own header comment already documents
for an unresolved DotNet type, reproduced here for an unresolved namespace-nested AL
sibling instead. A same-kind sibling (Codeunit referencing Codeunit) never hit this,
because excluding the touched Codeunit already forced the Codeunits property to be
reassigned — which is exactly why the only existing namespace+RAD test
(`BcCompilerIncrementalNamespaceTests`) never caught it: it only ever exercises a
codeunit referencing another codeunit.

`MergeContainerRecursive` (the baseline-merge step run after a successful cycle)
already sets every property unconditionally and was never affected. I audited every
other caller of `CloneContainerShallow`/`RadMergeablePropertiesByKind` in the repo —
`ExcludeObjectsRecursive` was the only one skipping the assignment.

## Fix

`ExcludeObjectsRecursive` now always calls `prop.SetValue` for every kind: when
nothing of that kind is excluded, it copies the array over verbatim instead of
leaving the clone's property unset. Updated the misleading `CloneContainerShallow` doc
comment that claimed "every caller here immediately overwrites every mergeable
property" — that was the very assumption this bug violated.

## Testing

- **Unit scale (RED → GREEN)**: `AlRunner.Tests/BcCompilerIncrementalCrossKindSiblingTests.cs`
  — two new tests, a namespaced codeunit referencing an untouched namespaced Report
  sibling and an untouched namespaced Table sibling in a separate file, each proving
  the fast path is taken and the edit lands correctly after editing only the codeunit.
  Confirmed RED against the pre-fix code (`Unexpected value 'None' of type
  NavTypeKind`), GREEN after.
- **No regressions**: full `BcCompilerIncremental*`, `ServerAffectedSelection*`,
  `TddWatchTests`, `WatchRadRealDependencyTests` suites all pass (44 tests).
- **Real-project verification against Pageworks + Pageworks.Test** (1012 tests,
  `--server`, two `runTests` requests in one warm process, editing
  `PageworksImageTest.Codeunit.al` — codeunit 50164 — between them, exactly
  reproducing #2479's own repro):
  - Before this fix: `forcedFull: true` on request 2, every time.
  - After this fix: `selection: {mode: affected, ran: 1003, skipped: 9,
    changedObjects: ["Codeunit 50164 PageworksImageTest"], forcedFull: false}` — real
    narrowing, matching the object #2479 named.

Both directions #2479 asked for now narrow correctly: editing the dependency app
(`Pageworks`, fixed by #2507/#2527) and editing the test app itself (`Pageworks.Test`,
fixed here).

### Fix the shape, not just the reported line

1. **Same wrong pattern elsewhere?** Only two callers of `CloneContainerShallow` exist
   in the file — `ExcludeObjectsRecursive` (fixed) and `MergeContainerRecursive`
   (already correct, sets every property unconditionally). No other caller reflects
   over `IObjectContainerDefinition`/`RadMergeablePropertiesByKind` in a way that
   clones+mutates (the one other user, `SymbolJsonWriter.CountObjectsRecursive`, is a
   read-only counter).
2. **Sibling function, same assumption?** Checked and ruled out above —
   `MergeContainerRecursive` already held the correct invariant.
3. **Two paths writing the same state — same invariant?** Yes: this was exactly the
   defect. `MergeContainerRecursive` always reassigns every property;
   `ExcludeObjectsRecursive` didn't. They now match.