### PR TITLE
fix(testpage): TestPage over a temporary SourceTable Integer opens empty

### DIFF
--- a/AlRunner.Tests/TestPageSourceTableTemporaryIntegerTests.cs
+++ b/AlRunner.Tests/TestPageSourceTableTemporaryIntegerTests.cs
@@ -1,0 +1,195 @@
+// TestPageSourceTableTemporaryIntegerTests — issue #2516.
+//
+// A page (or ListPart) declared SourceTable = Integer; SourceTableTemporary = true; must
+// bind to its OWN empty temporary rowset when driven through a TestPage, exactly like a
+// temporary source table over any other table. TestPageFactory.TryBuild used to hardcode
+// isTemporary: false for every TestPage-driven page, so a temporary-Integer page's Rec
+// fell through to GetDataAccessForTableCore's virtual-table population branch (the
+// materialised [-1000..100000] window) instead of GetDataAccessForTableCore's `if
+// (isTemporary) return _mCreateTempDataAccess...` short-circuit, which never reaches that
+// branch at all. See AlRunner/Patches/TestPageFactory.cs and
+// AlRunner/Patches/RecordPatches.cs (NavDataAccessSource_GetDataAccessForTable).
+//
+// This is a RUNNER-MECHANISM test: it exercises TestPageFactory.TryBuild's isTemporary
+// resolution end to end via a real bundle run, not a claim about what real BC does. The
+// BEHAVIORAL claim ("SourceTableTemporary = true opens empty in Cloud") is proven upstream
+// against a live BC service tier — see StefanMaron/BusinessCentral.AL.Language.Tests PR
+// adding TestTempIntegerListPart.al (60622-60630), per
+// .claude/rules/bc-behavior-tests-go-upstream.md.
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPageSourceTableTemporaryIntegerTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly string _root;
+
+    public TestPageSourceTableTemporaryIntegerTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-temp-integer-testpage", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private static string[] ExtraPackageCacheArgs()
+    {
+        var platformApps = TestArtifacts.PlatformAppsDir();
+        return Directory.Exists(platformApps)
+            ? new[] { "--package-cache", platformApps }
+            : Array.Empty<string>();
+    }
+
+    private static (string output, int exit) RunRunner(params string[] bundles)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        foreach (var a in ExtraPackageCacheArgs()) args.Append($" \"{a}\"");
+        foreach (var b in bundles) args.Append(" \"").Append(b).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private void WriteFixture()
+    {
+        File.WriteAllText(Path.Combine(_root, "app.json"), """
+        {
+          "id": "6ffcc9c3-2516-4e2c-a2a5-2516251625160001",
+          "name": "TempIntTestPage Repro",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 90200, "to": 90209 } ],
+          "runtime": "17.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "Part.Page.al"), """
+        page 90200 "TIT SelfLoad Part"
+        {
+            PageType = ListPart;
+            SourceTable = Integer;
+            SourceTableTemporary = true;
+            ApplicationArea = All;
+
+            layout
+            {
+                area(Content)
+                {
+                    repeater(Group)
+                    {
+                        field(Number; Rec.Number) { ApplicationArea = All; }
+                        field(ValueAtNumber; Values[Rec.Number]) { ApplicationArea = All; }
+                    }
+                }
+            }
+
+            var
+                Values: array[20] of Decimal;
+
+            trigger OnOpenPage()
+            var
+                i: Integer;
+            begin
+                for i := 1 to 3 do begin
+                    Values[i] := i * 10;
+                    Rec.Init();
+                    Rec.Number := i;
+                    Rec.Insert();
+                end;
+            end;
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "EmptyPart.Page.al"), """
+        page 90201 "TIT Empty Part"
+        {
+            PageType = ListPart;
+            SourceTable = Integer;
+            SourceTableTemporary = true;
+            ApplicationArea = All;
+
+            layout
+            {
+                area(Content)
+                {
+                    repeater(Group)
+                    {
+                        field(Number; Rec.Number) { ApplicationArea = All; }
+                    }
+                }
+            }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "Test.Codeunit.al"), """
+        codeunit 90202 "TIT Test"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure DirectOpen_StartsEmpty()
+            var
+                Part: TestPage "TIT Empty Part";
+            begin
+                Part.OpenView();
+                if Part.First() then
+                    Error('never-populated temporary-Integer part must start empty, First() returned true');
+                Part.Close();
+            end;
+
+            [Test]
+            procedure SelfLoaded_FirstRowIsNumberOne()
+            var
+                Part: TestPage "TIT SelfLoad Part";
+            begin
+                Part.OpenView();
+                if not Part.First() then
+                    Error('part must have rows after its own OnOpenPage runs');
+                if Part.Number.Value() <> '1' then
+                    Error('first row Number expected 1, got %1', Part.Number.Value());
+                if Part.ValueAtNumber.Value() <> '10' then
+                    Error('first row Values[Number] expected 10, got %1', Part.ValueAtNumber.Value());
+                Part.Close();
+            end;
+        }
+        """);
+    }
+
+    [SkippableFact]
+    public void TempIntegerListPart_TestPage_BindsOwnEmptyRowset_NotVirtualTable()
+    {
+        WriteFixture();
+        var (output, exit) = RunRunner(_root);
+        TestArtifacts.SkipIf(output.Contains("no BC artifact") || output.Contains("[bc] no engines"),
+            "no BC engine artifact provisioned in this environment");
+
+        Assert.True(exit == 0,
+            $"expected both tests to pass (isTemporary must route to an empty rowset, not the Integer virtual table); exit={exit}\n{output}");
+        Assert.Contains("pass:", output);
+        Assert.DoesNotContain("FAIL", output);
+    }
+}

--- a/AlRunner/Patches/TestPageFactory.cs
+++ b/AlRunner/Patches/TestPageFactory.cs
@@ -42,11 +42,17 @@ internal static class TestPageFactory
             return null;
         }
 
-        // isTemporary: false — TestPage over a temporary-source-table page is not this
-        // path's concern today; only the plain-page-variable caller below currently needs
-        // it (issue #1719's Page 700 "Error Messages"), and changing this one's shape is
-        // out of scope for that fix.
-        var record = TryBuildBlankRecord(owner, tableId, isTemporary: false, out var recordWhy);
+        // isTemporary must match the page's own SourceTableTemporary declaration — same
+        // resolver the plain-page-variable caller below already uses (issue #1719's Page
+        // 700 "Error Messages"). A TestPage over a page declaring SourceTableTemporary =
+        // true must get its own empty temporary rowset, exactly like every other
+        // temporary-source-table page: GetDataAccessForTableCore's `if (isTemporary)`
+        // branch short-circuits BEFORE any of the virtual-table population blocks
+        // (Field/AllObj/Integer/AllProfile/...), so leaving this hardcoded false was what
+        // routed a temporary Integer source to the runner's materialised Integer virtual
+        // table (window [-1000..100000]) instead of a private empty buffer — issue #2516.
+        var isTemporary = RecordPatches.ResolveSourceTableTemporaryForAnyPage(pageId);
+        var record = TryBuildBlankRecord(owner, tableId, isTemporary, out var recordWhy);
         if (record == null)
         {
             why = $"page {pageId}: {recordWhy}";


### PR DESCRIPTION
Closes #2516

TestPageFactory.TryBuild hardcoded `isTemporary: false` for every TestPage-driven
page, so a page declaring `SourceTable = Integer; SourceTableTemporary = true;`
bound to the runner's materialised Integer virtual table window (Number starting
at -1000) instead of an empty temporary rowset — First() returned true on an
empty page, Insert() of Number = 1 threw a duplicate key, and array[Rec.Number]
columns threw Index out of bounds.

`GetDataAccessForTableCore`'s `if (isTemporary)` branch short-circuits BEFORE
any of the virtual-table population blocks (Field/AllObj/Integer/AllProfile/...),
so the fix is to resolve the page's own SourceTableTemporary declaration via
`RecordPatches.ResolveSourceTableTemporaryForAnyPage` — the same resolver the
plain-page-variable caller (`CodeunitPatches.NavFormHandle_CreateTarget`,
`FormStaticRunModalPatches`) already uses — instead of hardcoding false.

## Shape check
- Grepped every other TestPage/page-record construction site for the same
  hardcoded-false pattern: `TestPageFactory.TryBuild` was the only one; the two
  sibling callers already resolved `isTemporary` correctly, which is what made
  the fix a one-line change rather than a new mechanism.
- Confirmed against the issue's own audit bundle (`tmp/gap-repros/audit-2516`):
  arms C (self-loaded part, hosted), D (direct-open, starts empty) and E
  (direct-open, self-loaded) flip from FAIL to PASS. Arms A/B (host-pushed rows)
  remain FAIL, but on the SEPARATE `TestPage.<part>` vs `CurrPage.<part>.Page`
  instance-identity gap already tracked in #2201 — exactly as the issue's own
  differential table predicted this fix would not need to touch that gap.

## Tests
- `AlRunner.Tests/TestPageSourceTableTemporaryIntegerTests.cs` — new runner-mechanism
  test (no Base Application dependency), RED confirmed against the pre-fix code
  (`Number expected 1, got -1000`), GREEN after.
- BC-behavior proof upstream: StefanMaron/BusinessCentral.AL.Language.Tests#121
  (`TestTempIntegerListPart.al`, objects 60622-60630), covering direct-open-starts-empty,
  self-loaded-first-row-is-1, and host-pushed-via-CurrPage.Part.Page.Load — all three
  arms this fix addresses. Corpus CI running; will fold the submodule pin bump into
  this PR once it merges (per `.claude/rules/al-language-submodule.md`).