### PR TITLE
fix(testpage): GoToRecord no longer resolves position by field caption

### DIFF
--- a/AlRunner.Tests/TestPageGoToRecordPositionCaptionTests.cs
+++ b/AlRunner.Tests/TestPageGoToRecordPositionCaptionTests.cs
@@ -1,0 +1,75 @@
+// TestPageGoToRecordPositionCaptionTests — pins the C# CONTRACT issue #2515's fix depends
+// on, not "what BC does" (that's the job of the companion corpus PR,
+// StefanMaron/BusinessCentral.AL.Language.Tests#122, which proves the AL-observable
+// behavior against real BC 27.5/28.3 once merged).
+//
+// NavRecord.ALGetPosition()'s default overload (useCaptions: true) encodes the cursor
+// position string using field CAPTIONS, and ALSetPosition decodes it through the same
+// SETVIEW-style filter parser AL filter views use, resolving each token by caption. On a
+// table with two fields sharing a caption -- legal AL, common on older tables -- that
+// decode raises BC's own NavNCLFieldNotFoundException instead of positioning. NavRecord is
+// real, unmodified BC engine code (Ncl.dll) we cannot rewrite the body of (see
+// precompiled-dll-respect.md), so the fix is which of its two public overloads
+// MockTestPage.cs calls, not a patch to NavRecord itself. There is no reflection surface
+// that exercises this without a loaded BC runtime/session, so what's provable here is that
+// the source no longer calls the caption-encoding default overload at any of its
+// GoToRecord-reachable cursor-position call sites.
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPageGoToRecordPositionCaptionTests
+{
+    private static string MockTestPageSource()
+    {
+        // AlRunner.Tests/bin/<config>/<tfm>/ -> repo root is four levels up.
+        var dir = AppContext.BaseDirectory;
+        var repoRoot = Path.GetFullPath(Path.Combine(dir, "..", "..", "..", ".."));
+        var path = Path.Combine(repoRoot, "AlRunner", "Patches", "MockTestPage.cs");
+        Assert.True(File.Exists(path), $"expected to find {path}");
+        return File.ReadAllText(path);
+    }
+
+    [Fact]
+    public void NoCallSite_UsesTheCaptionEncodingDefaultOverload()
+    {
+        var source = MockTestPageSource();
+
+        // A bare `.ALGetPosition()` -- no argument -- resolves to NavRecord's
+        // useCaptions:true default, which is exactly the overload issue #2515 showed
+        // throws on a table with a duplicate field caption. Every call site in this file
+        // must pass the overload explicitly.
+        // Exclude comment lines -- the fix's own explanatory comment names the default
+        // overload in prose, which is not a call site.
+        var codeLines = source.Split('\n');
+        var bareCallCount = 0;
+        foreach (var line in codeLines)
+        {
+            var trimmed = line.TrimStart();
+            if (trimmed.StartsWith("//")) continue;
+            var codePart = Regex.Replace(line, @"//.*$", "");
+            bareCallCount += Regex.Matches(codePart, @"\.ALGetPosition\(\s*\)").Count;
+        }
+        Assert.True(bareCallCount == 0,
+            $"found {bareCallCount} bare ALGetPosition() call(s) in MockTestPage.cs -- " +
+            "these resolve to NavRecord's useCaptions:true default and reintroduce #2515's " +
+            "ambiguous-caption throw on the GoToRecord not-found path.");
+    }
+
+    [Fact]
+    public void EveryPositionCaptureCallSite_ExplicitlyDisablesCaptions()
+    {
+        var source = MockTestPageSource();
+
+        // Every call this file makes to capture a cursor position for later restore
+        // (FindRowFromTableFieldValues' not-found restore, EnterNewRowLine's return
+        // position, and GetBookmark) must resolve field-by-NUMBER, matching every other
+        // cursor move in this class (ALSetPosition/GetFieldValue already take field
+        // numbers, never captions).
+        var explicitCalls = Regex.Matches(source, @"\.ALGetPosition\(\s*useCaptions:\s*false\s*\)");
+        Assert.Equal(3, explicitCalls.Count);
+    }
+}

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -1172,7 +1172,7 @@ internal class LiveNavTestPage : MockITestPage
     {
         if (!ShowsNewRowLine) return false;
 
-        _newRowLineReturnPosition = record.ALGetPosition();
+        _newRowLineReturnPosition = record.ALGetPosition(useCaptions: false);
 
         // The rows either side of the insertion point decide the AutoSplitKey number, and
         // ALInit is about to wipe the row the cursor is on — so the position is captured
@@ -1250,7 +1250,18 @@ internal class LiveNavTestPage : MockITestPage
     // reaches through RequireRecord first.
     private void SnapshotBeforeImage() => _record!.OldRecord.ALAssign(_record);
 
-    public override object? GetBookmark() => RequireRecord("GetBookmark()").ALGetPosition();
+    // useCaptions: false — NavRecord.ALGetPosition()'s default (useCaptions: true) encodes
+    // the position string using field CAPTIONS, and ALSetPosition decodes it through the
+    // same SETVIEW-style filter parser TableViewParser.ParseTableFilters uses for AL filter
+    // views, which resolves each token by caption. On a table with two fields sharing a
+    // caption (legal AL) that decode throws BC's own NavNCLFieldNotFoundException
+    // ("... is ambiguous between multiple fields ...") instead of positioning — real BC
+    // does not throw here (issue #2515). Positioning by field NUMBER, exactly like every
+    // other cursor move in this class (ALSetPosition/GetFieldValue take field numbers, never
+    // captions), sidesteps the ambiguous caption lookup entirely. Both overloads are real
+    // BC's own public API on NavRecord; this only picks the one that matches how the rest of
+    // the runner already talks to a record.
+    public override object? GetBookmark() => RequireRecord("GetBookmark()").ALGetPosition(useCaptions: false);
 
     public override bool GoToBookmark(object bookmark)
     {
@@ -1275,7 +1286,7 @@ internal class LiveNavTestPage : MockITestPage
         if (fieldNos.Length != values.Length) return false;
 
         var record = RequireRecord("locating a row");
-        var original = record.ALGetPosition();
+        var original = record.ALGetPosition(useCaptions: false);
         var hasCurrent = !string.IsNullOrEmpty(original);
 
         // Scan the WHOLE rowset, always starting from the first (or last, when searching


### PR DESCRIPTION
Closes #2515

NavRecord.ALGetPosition()'s default overload (useCaptions: true) encodes the cursor position string using field CAPTIONS, and ALSetPosition decodes it through the same SETVIEW-style filter parser AL filter views use, resolving each token by caption. On a table with two fields sharing a caption -- legal AL, common on older tables -- that decode raises BC's own NavNCLFieldNotFoundException instead of positioning. Real BC returns false and leaves the cursor unchanged.

MockTestPage.cs now calls ALGetPosition(useCaptions: false) at its three call sites (the not-found restore in FindRowFromTableFieldValues, the new-row-line return position, and GetBookmark), positioning by field number instead -- exactly like every other cursor move in this file. Both overloads are real BC's own public API on NavRecord; this only picks the one that already matches how the rest of the runner talks to a record, so it needs no DLL rewrite.

Wider-shape check: ALGetView() has the identical useCaptions: true default and round-trips through the same TableViewParser, but the runner has no no-arg call site for it (grep across AlRunner turned up nothing) -- SetTableView/GetView usage all keeps BC's own unmodified body via a different, non-caption path. GetBookmark's return value never reaches AL (there is no TestPage.GetBookmark in the AL surface), so this change has no observable effect there.

Second gap noted in the issue (a ModalPageHandler for a list opened via Page.RunModal(id, Rec) after SetRange on two dup-captioned composite-key fields, where GoToRecord allegedly missed a row BC finds): built a RunModal + SetRange + GoToRecord repro on both a dup-caption and a unique-caption table against this fix -- both pass. Not reproduced here; reporting as a separate finding rather than folding an unverified fix into this PR.

BC-behavior proof: StefanMaron/BusinessCentral.AL.Language.Tests#122 (not yet merged -- the submodule pin bump will follow in a separate commit on this PR once that lands). Verified locally in the meantime: the corpus test is RED against origin/main's runner build (NavNCLFieldNotFoundException) and GREEN against this branch's build, using the same corpus source checked out standalone.

Testing:
- New AL Runner build + the reporter's minimal repro bundle: 9/9 pass (was 7/9).
- dotnet test AlRunner.Tests --filter FullyQualifiedName~TestPage: 58/58 pass.
- Existing corpus GoToRecord tests (codeunits 60697, 60126, 60736, 60909): 7/7 pass, no regression.
- New corpus test (codeunit 60044, PR #122 above): RED on origin/main, GREEN on this branch.