### PR TITLE
fix(cli): print the informational version from --version

### DIFF
--- a/AlRunner.Tests/CliDocumentationTests.cs
+++ b/AlRunner.Tests/CliDocumentationTests.cs
@@ -356,6 +356,38 @@ public sealed class CliDocumentationTests
     }
 
     /// <summary>
+    /// --version printed only the 4-part AssemblyVersion (2.10.0.0), so a locally packed
+    /// dev build and the nuget.org release of the same line answered identically and the
+    /// prerelease/local suffix that `dotnet pack -p:Version=...` stamps into the
+    /// informational version was invisible from the CLI (issue #2536). The printed
+    /// version must be the built assembly's informational version, verbatim.
+    /// </summary>
+    [Fact]
+    public void Version_PrintsInformationalVersion()
+    {
+        var runnerDll = Path.Combine(RepoRoot, "AlRunner", "bin", TestBuildConfig.Configuration,
+            TestBuildConfig.Framework, "al-runner.dll");
+        var expected = FileVersionInfo.GetVersionInfo(runnerDll).ProductVersion;
+        Assert.False(string.IsNullOrWhiteSpace(expected), $"No informational version stamped in {runnerDll}");
+
+        var (exit, stdout, stderr) = RunCli("--version");
+        Assert.True(exit == 0, $"--version must exit 0. exit={exit}\n{stderr}");
+        Assert.Equal($"al-runner v{expected}", stdout.Trim());
+    }
+
+    /// <summary>
+    /// Negative: the informational version is never the bare 4-part AssemblyVersion the
+    /// old code printed. A build without a stamped informational version would fall back
+    /// to it, so this guards that the pipeline's stamp actually reaches the binary.
+    /// </summary>
+    [Fact]
+    public void Version_IsNotTheBareFourPartAssemblyVersion()
+    {
+        var (_, stdout, _) = RunCli("--version");
+        Assert.DoesNotMatch(new Regex(@"^al-runner v\d+\.\d+\.\d+\.\d+$"), stdout.Trim());
+    }
+
+    /// <summary>
     /// The REPORTING A RUNNER GAP section is the replacement for telemetry (#1643,
     /// closed as not-planned). It must actually be able to produce a report: a
     /// caller with only the binary needs the repository URL, and the section must

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5553,6 +5553,16 @@ static string SanitiseFilename(string name)
 // self-reported version can never drift between the two surfaces (#2072).
 static string VersionString()
 {
+    // Prefer the informational version: it is what `dotnet pack -p:Version=...` stamps,
+    // so it carries the package version including any prerelease/local suffix
+    // (2.10.0-local.<sha>), whereas AssemblyVersion is always the 4-part numeric form
+    // (2.10.0.0) and cannot tell a locally packed dev build from the nuget.org release.
+    var infoVer = typeof(Program).Assembly
+        .GetCustomAttributes(typeof(System.Reflection.AssemblyInformationalVersionAttribute), false)
+        .OfType<System.Reflection.AssemblyInformationalVersionAttribute>()
+        .FirstOrDefault()?.InformationalVersion;
+    if (!string.IsNullOrWhiteSpace(infoVer))
+        return $"al-runner v{infoVer}";
     var asmVer = typeof(Program).Assembly.GetName().Version?.ToString() ?? "unknown";
     return $"al-runner v{asmVer}";
 }


### PR DESCRIPTION
Closes #2536

## Problem

`al-runner --version` printed `Assembly.GetName().Version`, the 4-part `AssemblyVersion`, so every build of a release line answered `al-runner v2.10.0.0`: a locally packed dev build (`dotnet pack -p:Version=2.10.0-local.<sha>`) and the nuget.org release were indistinguishable from the CLI.

## Fix

`VersionString()` in `AlRunner/Program.cs` now prefers `AssemblyInformationalVersionAttribute` (the SDK stamps it from the package `Version`, suffix included) and falls back to the assembly version only when no informational version is present. `--help`'s first line reuses `VersionString()`, so both surfaces stay identical.

## Tests

`AlRunner.Tests/CliDocumentationTests.cs`:
- `Version_PrintsInformationalVersion` — output equals `al-runner v` + the built assembly's `FileVersionInfo.ProductVersion`, verbatim.
- `Version_IsNotTheBareFourPartAssemblyVersion` — negative guard against the old shape.

RED on the unfixed code (`Expected: "al-runner v2.0.0-preview.1"  Actual: "al-runner v2.0.0.0"`, 2 failed), GREEN after (CliDocumentationTests 20/20). Existing consumers match `^al-runner v\S+` or `Contains("al-runner v")`, unaffected.