### PR TITLE
fix(testpage): GoToRecord not-found restore refreshes non-key fields

### DIFF
--- a/AlRunner.Tests/TestPageGoToRecordNotFoundRestoreRefreshTests.cs
+++ b/AlRunner.Tests/TestPageGoToRecordNotFoundRestoreRefreshTests.cs
@@ -1,0 +1,74 @@
+// TestPageGoToRecordNotFoundRestoreRefreshTests — pins the C# CONTRACT issue #2537's fix
+// depends on, not "what BC does" (that's the job of the companion corpus PR,
+// StefanMaron/BusinessCentral.AL.Language.Tests#123, which proves the AL-observable behavior
+// against real BC 27.0/27.3/27.5/28.0/28.1/28.2/28.3/28.4 -- 8/8 legs green -- once merged).
+//
+// NavRecord.ALSetPosition (real, unmodified BC engine code in Ncl.dll) only writes the
+// primary-key columns of the record buffer from a parsed position string; it does not
+// re-fetch or otherwise refresh non-key columns. FindRowFromTableFieldValues's not-found
+// restore used to call `record.ALSetPosition(original); Loaded(true);` alone, which left
+// non-key fields holding whatever row the internal not-found scan last visited, under the
+// restored row's own key. The fix re-finds the original row through the same
+// MoveFirst/MoveNextDataRow path a normal search already uses -- which refreshes every
+// field via NavRecord.ALFindFirstAsync/ALNextAsync, not a key-only SetPosition -- instead of
+// restoring via a raw position write. There is no reflection surface that exercises this
+// without a loaded BC runtime/session, so what's provable here is that the source no longer
+// takes the key-only restore shortcut.
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPageGoToRecordNotFoundRestoreRefreshTests
+{
+    private static string MockTestPageSource()
+    {
+        var dir = AppContext.BaseDirectory;
+        var repoRoot = Path.GetFullPath(Path.Combine(dir, "..", "..", "..", ".."));
+        var path = Path.Combine(repoRoot, "AlRunner", "Patches", "MockTestPage.cs");
+        Assert.True(File.Exists(path), $"expected to find {path}");
+        return File.ReadAllText(path);
+    }
+
+    private static string FindRowFromTableFieldValuesBody(string source)
+    {
+        var start = source.IndexOf("public override bool FindRowFromTableFieldValues(int[] fieldNos, object[] values, bool forward)", StringComparison.Ordinal);
+        Assert.True(start >= 0, "could not locate FindRowFromTableFieldValues in MockTestPage.cs");
+
+        // Take a generous window past the signature -- enough to contain the whole method
+        // body without needing a real brace-matcher for a test this narrow.
+        var window = source.Substring(start, Math.Min(4000, source.Length - start));
+        return window;
+    }
+
+    [Fact]
+    public void NotFoundRestore_NoLongerUsesTheKeyOnlyPositionWrite()
+    {
+        var body = FindRowFromTableFieldValuesBody(MockTestPageSource());
+
+        // This exact shape -- ALSetPosition immediately followed by Loaded(true) as the
+        // ENTIRE not-found restore -- is what left non-key fields stale, because
+        // ALSetPosition alone never re-reads the row's non-key columns.
+        var oldShape = Regex.IsMatch(body, @"record\.ALSetPosition\(original\);\s*Loaded\(true\);");
+        Assert.False(oldShape,
+            "FindRowFromTableFieldValues's not-found path still restores via a bare " +
+            "ALSetPosition(original) + Loaded(true) -- this reintroduces #2537's stale " +
+            "non-key-field defect.");
+    }
+
+    [Fact]
+    public void NotFoundRestore_RefindsTheOriginalRowByItsOwnPrimaryKey()
+    {
+        var body = FindRowFromTableFieldValuesBody(MockTestPageSource());
+
+        // The restore must capture the original row's OWN primary-key field numbers/values
+        // before scanning moves the cursor away, then re-locate that row by walking forward
+        // through MoveFirst/MoveNextDataRow -- the same load path a normal search already
+        // uses, which refreshes every field (not just the key).
+        Assert.Contains("originalKeyFieldNos", body, StringComparison.Ordinal);
+        Assert.Contains("originalKeyValues", body, StringComparison.Ordinal);
+        Assert.Contains("MoveNextDataRow()", body, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -1286,8 +1286,31 @@ internal class LiveNavTestPage : MockITestPage
         if (fieldNos.Length != values.Length) return false;
 
         var record = RequireRecord("locating a row");
-        var original = record.ALGetPosition(useCaptions: false);
-        var hasCurrent = !string.IsNullOrEmpty(original);
+
+        // Capture the ORIGINAL row's own primary-key field numbers and values (not just a
+        // position string) before scanning moves the cursor away from it. A not-found result
+        // must restore the exact row the page was on — including every NON-key field it was
+        // showing — and NavRecord.ALSetPosition (real BC engine code, unmodified) only writes
+        // the primary-key columns of the record buffer, leaving non-key columns holding
+        // whatever the internal scan below last read (issue #2537: GoToRecord(existing row A)
+        // then GoToRecord(absent row) left the page's non-key field reading row C's value
+        // under key A, because the scan's last MoveNextDataRow landed on C before failing).
+        // Re-finding the original row through the SAME MoveFirst/MoveNextDataRow path the
+        // search below already uses is what refreshes a row's non-key columns correctly (they
+        // go through NavRecord.ALFindFirstAsync/ALNextAsync, not the key-only SetPosition), so
+        // the restore reuses that exact mechanism instead of a raw position write.
+        var hasCurrent = !string.IsNullOrEmpty(record.ALGetPosition(useCaptions: false));
+        int[]? originalKeyFieldNos = null;
+        object?[]? originalKeyValues = null;
+        if (hasCurrent)
+        {
+            var originalPrimaryKey = record.MetaTable?.PrimaryKey;
+            if (originalPrimaryKey != null && originalPrimaryKey.KeyFieldCount > 0)
+            {
+                originalKeyFieldNos = originalPrimaryKey.KeyFieldsList.Select(f => f.FieldNo).ToArray();
+                originalKeyValues = originalKeyFieldNos.Select(fieldNo => ReadClientObject(fieldNo)).ToArray();
+            }
+        }
 
         // Scan the WHOLE rowset, always starting from the first (or last, when searching
         // backward) row — never from wherever the page happens to be positioned. `forward`
@@ -1306,7 +1329,19 @@ internal class LiveNavTestPage : MockITestPage
             hasRow = forward ? MoveNextDataRow() : MovePrevious();
         }
 
-        if (hasCurrent) { record.ALSetPosition(original); Loaded(true); }
+        if (originalKeyFieldNos != null)
+        {
+            // Re-find the original row by its own primary key, walking forward from the top
+            // exactly like the search above — this goes through a real MoveFirst/
+            // MoveNextDataRow load, refreshing every field (not just the key) from the row's
+            // own stored values, instead of a raw key-only ALSetPosition.
+            hasRow = MoveFirst();
+            while (hasRow)
+            {
+                if (Matches(originalKeyFieldNos, originalKeyValues!)) break;
+                hasRow = MoveNextDataRow();
+            }
+        }
         return false;
     }
 


### PR DESCRIPTION
Closes #2537

NavRecord.ALSetPosition (real BC engine code in Ncl.dll, unmodified) only writes the primary-key columns of the record buffer from a parsed position string; it never re-fetches non-key columns. FindRowFromTableFieldValues's not-found restore used to rely on ALSetPosition alone (record.ALSetPosition(original); Loaded(true);), so a page positioned on a row that is not the last row an internal not-found scan visits ended up with non-key fields holding a different row's values under the restored row's own key.

The restore now captures the original row's own primary-key field numbers and values before scanning, then re-finds that row by walking forward through MoveFirst/MoveNextDataRow -- the same load path a normal search already uses, which refreshes every field via NavRecord.ALFindFirstAsync/ALNextAsync rather than a key-only SetPosition.

BC-behavior proof: StefanMaron/BusinessCentral.AL.Language.Tests#123 (not yet merged -- the submodule pin bump will follow in a separate commit on this PR once that lands). Verified against real BC first via an observation probe run on all 8 legs (27.0/27.3/27.5/28.0/28.1/28.2/28.3/28.4), which reported identically on every leg:

OBS found=No key=A desc=Alpha

i.e. real BC keeps the row's full original values, not a mix with whichever row the internal not-found scan last visited. The probe was then replaced with real assertions encoding that measured result; all 8 legs pass.

## Testing
- New minimal generic repro bundle (C:\Users\FlemmingBK\tmp\gap-repros\gotorecord-stale-nonkey): RED before the fix (1P/1F -- Arm2 failed with Expected Alpha, Actual Charlie), GREEN after (2P/0F).
- Reporter's original #2515 repro bundle: still 9/9 pass, no regression.
- dotnet test AlRunner.Tests --filter FullyQualifiedName~TestPage: 61/61 pass.
- New runner-side mechanism test (TestPageGoToRecordNotFoundRestoreRefreshTests.cs), standing in for the corpus proving test until #123 merges and the submodule pin can be bumped in this PR.