### PR TITLE
fix(rad): stop the incremental fast path shipping a caller bound to the old overload

### DIFF
--- a/AlRunner.Tests/BcCompilerIncrementalOverloadRebindTests.cs
+++ b/AlRunner.Tests/BcCompilerIncrementalOverloadRebindTests.cs
@@ -1,0 +1,223 @@
+// BcCompilerIncrementalOverloadRebindTests — issue #2548. The one edit shape where the
+// incremental (RAD) fast path's "an unmodified caller never needs re-emitting" argument does not
+// hold, and where the damage is SILENT.
+//
+// BcCompiler.Incremental.cs's header argues that reusing an untouched object's cached C# is always
+// safe, because a cross-object call compiles to
+// `new NavCodeunitHandle(this, <object id>).Target.Invoke(<memberId>, args)` and a breaking edit
+// surfaces as NavNCLMissingMethodException at the call site — loud, not silent.
+//
+// That holds for every edit that RETIRES or MOVES an existing member's id. It does not hold for
+// one that ADDS a member under a name the object already had:
+//
+//   * `MethodSymbol.CalculateMethodIdForNewVersions` is method-local, so adding `Which(Integer)`
+//     beside `Which(Decimal)` leaves the Decimal overload's id — and its `case` label in the
+//     re-emitted callee's OnInvoke switch — bit-identical.
+//   * What moves is the id the CALLER bakes. Before the edit an Integer argument widened to
+//     `Which(Decimal)`; after it, overload resolution picks `Which(Integer)`.
+//   * An un-rebound caller therefore dispatches a member that STILL EXISTS, and gets the previous
+//     overload's answer. No exception, no diagnostic, no log line.
+//
+// Measured RED on main @ 2eebaedd: the fast path was taken with an empty fallbackReason, the
+// callee's C# matched a cold build, and the caller's C# did not.
+//
+// Both tests here are needed, and each is the other's control:
+//   * AddingAnOverload… asserts the fallback happens and says why. Alone, "always fall back"
+//     would satisfy it — which would delete the fast path.
+//   * AddingAProcedureUnderANewName… asserts the fast path is still taken for the neighbouring
+//     shape AND that what it ships equals a cold build. Alone, "never fall back" would satisfy it.
+//
+// Credit: the hazard, the fixture shape and the compiler contract underneath it were found and
+// pinned by Mikkel Mansa Vilhelmsen (vhn) in his AL Runner fork (RadSameAppOverloadTests,
+// RadSameAppOverloadWatchTests). His fork rebinds the callers from an object-reference graph it
+// maintains; this repo has no such graph, so the fallback is the available correct answer.
+using Xunit;
+using AlRunner;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class BcCompilerIncrementalOverloadRebindTests : IDisposable
+{
+    private readonly string _root;
+    private readonly BcEngineFixture _engine;
+
+    public BcCompilerIncrementalOverloadRebindTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-incremental-overload-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private void WriteAl(string fileName, string content) => File.WriteAllText(Path.Combine(_root, fileName), content);
+
+    private static Dictionary<string, string> ByName(BcEmitOutput output)
+        => output.Sources.ToDictionary(s => s.Name, s => s.Code);
+
+    /// <summary>The callee. One Decimal overload of `Which`; `Sibling` is never called and exists
+    /// so the codeunit has a member neither edit disturbs.</summary>
+    private const string LibBefore = """
+        codeunit 90270 "Incr Ovl Lib"
+        {
+            procedure Which(Seed: Decimal): Text
+            begin
+                exit('DECIMAL');
+            end;
+
+            procedure Sibling(Value: Integer): Integer
+            begin
+                exit(Value);
+            end;
+        }
+        """;
+
+    /// <summary>The hazardous edit: a second overload of the SAME name, Integer where the existing
+    /// one takes Decimal. Placed after the existing members so nothing about the result can be
+    /// attributed to declaration order.</summary>
+    private const string LibWithOverload = """
+        codeunit 90270 "Incr Ovl Lib"
+        {
+            procedure Which(Seed: Decimal): Text
+            begin
+                exit('DECIMAL');
+            end;
+
+            procedure Which(Seed: Integer): Text
+            begin
+                exit('INTEGER');
+            end;
+
+            procedure Sibling(Value: Integer): Integer
+            begin
+                exit(Value);
+            end;
+        }
+        """;
+
+    /// <summary>The control edit: the same amount of new code, under a name the object did not
+    /// already have. Overload resolution at every existing call site is untouched and no existing
+    /// member's id moves, so this must stay on the fast path.</summary>
+    private const string LibWithNewName = """
+        codeunit 90270 "Incr Ovl Lib"
+        {
+            procedure Which(Seed: Decimal): Text
+            begin
+                exit('DECIMAL');
+            end;
+
+            procedure Fresh(Seed: Integer): Text
+            begin
+                exit('FRESH');
+            end;
+
+            procedure Sibling(Value: Integer): Integer
+            begin
+                exit(Value);
+            end;
+        }
+        """;
+
+    /// <summary>The caller, byte-for-byte identical across both edits. It passes an INTEGER to a
+    /// method that today has only a Decimal overload, so overload resolution HERE is what the
+    /// hazardous edit changes — which is why it is only ever re-emitted if the delta decides it
+    /// must be.</summary>
+    private const string CallerSrc = """
+        codeunit 90271 "Incr Ovl Caller"
+        {
+            procedure Call(): Text
+            var
+                Lib: Codeunit "Incr Ovl Lib";
+                Seed: Integer;
+            begin
+                Seed := 2;
+                exit(Lib.Which(Seed));
+            end;
+        }
+        """;
+
+    /// <summary>Compiles the fixture, records an incremental baseline, then applies
+    /// <paramref name="editedLib"/> and returns both the incremental attempt and an independent
+    /// cold build of the same post-edit tree.</summary>
+    private (BcEmitOutput? Incremental, string FallbackReason, Dictionary<string, string> Baseline, Dictionary<string, string> Fresh)
+        RunEdit(string editedLib)
+    {
+        WriteAl("Lib.al", LibBefore);
+        WriteAl("Caller.al", CallerSrc);
+
+        var compiler = new BcCompiler();
+        var baselineOut = compiler.Emit(new[] { _root }, "OverloadRebindModule", trackIncrementalBaseline: true);
+        Assert.Empty(baselineOut.Diagnostics);
+        var baselineByName = ByName(baselineOut);
+        Assert.Equal(2, baselineByName.Count);
+
+        // Edit ONLY the callee. The caller's file is not touched at all.
+        WriteAl("Lib.al", editedLib);
+
+        var incrOut = compiler.TryEmitIncremental(
+            new[] { _root }, "OverloadRebindModule", appRootDir: null, out var fallbackReason);
+
+        var freshOut = new BcCompiler().Emit(new[] { _root }, "OverloadRebindModuleFresh");
+        Assert.Empty(freshOut.Diagnostics);
+        return (incrOut, fallbackReason, baselineByName, ByName(freshOut));
+    }
+
+    /// <summary>
+    /// The hazard. Adding an overload must not leave the fast path shipping a caller that still
+    /// dispatches the member id of the overload it used to bind to.
+    /// </summary>
+    [SkippableFact]
+    public void TryEmitIncremental_AddingAnOverloadToACallee_FallsBackInsteadOfShippingAStaleCaller()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var (incremental, fallbackReason, baseline, fresh) = RunEdit(LibWithOverload);
+
+        // Fixture guard: the edit really did move what the caller binds to. Without this the
+        // whole test could pass against an edit that changed nothing.
+        Assert.NotEqual(baseline["Incr Ovl Caller"], fresh["Incr Ovl Caller"]);
+
+        Assert.True(incremental == null,
+            "the incremental path took the fast path for an added overload. The caller was not "
+            + "re-emitted, so it still dispatches the member id of `Which(Decimal)` even though an "
+            + "Integer argument now binds to `Which(Integer)`. That member still exists in the "
+            + "re-emitted callee, so the call succeeds and returns the PREVIOUS overload's answer — "
+            + "no exception, no diagnostic. Shipped caller C# "
+            + (incremental != null && ByName(incremental)["Incr Ovl Caller"] == fresh["Incr Ovl Caller"]
+                ? "matched a cold build, so something else changed — re-derive this test."
+                : "did NOT match a cold build."));
+
+        // A fallback nobody can read is the silent default loud-failures.md forbids: the reason
+        // must name the object and the shape, not just say "full compile".
+        Assert.Contains("Incr Ovl Lib", fallbackReason, StringComparison.Ordinal);
+        Assert.Contains("overload", fallbackReason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The control, and the reason the fallback above is not simply "give up on everything": a
+    /// procedure added under a name NEW to the object changes no existing call site's overload
+    /// resolution and moves no existing member's id, so the fast path must still apply — and what
+    /// it ships must equal a cold build of the same tree.
+    /// </summary>
+    [SkippableFact]
+    public void TryEmitIncremental_AddingAProcedureUnderANewName_StaysOnTheFastPathAndMatchesAColdBuild()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var (incremental, fallbackReason, _, fresh) = RunEdit(LibWithNewName);
+
+        Assert.True(incremental != null,
+            "adding a procedure under a name the object did not already have fell back to a full "
+            + "compile. Nothing an existing caller baked can have moved — overload resolution never "
+            + "considered this name and no existing member's id changed — so the added-overload "
+            + $"guard is over-triggering. fallbackReason: {fallbackReason}");
+
+        var incrementalByName = ByName(incremental!);
+        Assert.Equal(fresh["Incr Ovl Lib"], incrementalByName["Incr Ovl Lib"]);
+        Assert.Equal(fresh["Incr Ovl Caller"], incrementalByName["Incr Ovl Caller"]);
+    }
+}

--- a/AlRunner/BcCompiler.Incremental.cs
+++ b/AlRunner/BcCompiler.Incremental.cs
@@ -650,6 +650,22 @@ public sealed partial class BcCompiler
             if (!baseline.SourceByKey.ContainsKey(kv.Key)) unionedSources.Add(kv.Value);
 
         var deltaModuleDef = SymbolJsonWriter.GetModuleDefinition(radComp);
+
+        // #2548: the ONE hole in this file's "an unmodified caller is always safe" argument, and
+        // it is silent. See OverloadAddedUnderAnExistingName for the mechanism. Checked here
+        // because this is the first point where BOTH serialized surfaces exist, and the last
+        // point at which returning null is still free — nothing below has been committed yet.
+        if (OverloadAddedUnderAnExistingName(baseline.ModuleDef, deltaModuleDef, allChangedIdentities) is { } overloaded)
+        {
+            fallbackReason =
+                $"{overloaded} gained a procedure under a name it already declared (an added overload). "
+                + "That moves which member id an UNMODIFIED caller binds to without moving any existing "
+                + "member's own id, so reusing the caller's cached C# would leave it dispatching the "
+                + "previous overload — silently, since that member still exists. Falling back to a full "
+                + "compile for this cycle";
+            return null;
+        }
+
         var mergedModuleDef = MergeModuleDefinition(baseline.ModuleDef, allChangedIdentities, deltaModuleDef);
 
         var newFileHashByPath = new Dictionary<string, string>(baseline.FileHashByPath, StringComparer.Ordinal);
@@ -1065,6 +1081,100 @@ public sealed partial class BcCompiler
 
     /// <summary>Same format as <see cref="ElementKey"/> ("id:&lt;n&gt;"/"name:&lt;x&gt;"), derived from a <see cref="RadObjectIdentity"/> instead of a reflected element.</summary>
     private static string IdentityElementKeyOf(RadObjectIdentity id) => id.Id.HasValue ? "id:" + id.Id.Value : "name:" + id.Name;
+
+    /// <summary>
+    /// Names the first changed object that gained a procedure under a name it ALREADY declared,
+    /// or null when none did. Issue #2548 — the one edit shape this file's header argument does
+    /// not cover, and the only one whose damage is silent.
+    ///
+    /// <para><b>The mechanism.</b> BC's <c>MethodSymbol.CalculateMethodIdForNewVersions</c> is
+    /// method-local: adding <c>Which(Integer)</c> beside <c>Which(Decimal)</c> moves neither the
+    /// Decimal overload's id nor its <c>case</c> label in the re-emitted callee's <c>OnInvoke</c>
+    /// switch. What moves is the id the CALLER bakes — an Integer argument used to widen to
+    /// <c>Which(Decimal)</c> and now binds to <c>Which(Integer)</c>. An un-rebound caller
+    /// therefore dispatches a member that still exists and gets the PREVIOUS overload's answer:
+    /// no <c>NavNCLMissingMethodException</c>, no diagnostic, no log line. Every other breaking
+    /// edit retires or moves an existing id and is loud at the call site, exactly as this file's
+    /// header describes.</para>
+    ///
+    /// <para><b>Why a full-compile fallback rather than a rebind.</b> Rebinding needs to know who
+    /// the callers ARE, which needs an object-reference graph this fast path does not maintain.
+    /// Falling back is correct, is already this path's answer to everything it cannot prove safe,
+    /// and costs one cycle on an edit shape that is rare next to ordinary body edits.</para>
+    ///
+    /// <para><b>Why the comparison is serialized-against-serialized.</b> Both sides come out of
+    /// <c>SymbolJsonWriter.GetModuleDefinition</c>-shaped module definitions, so both describe the
+    /// same public surface under the same rules — in particular BC serializes no <c>local</c>
+    /// method on either side, so adding a local overload (which no other object can call, and
+    /// which therefore cannot move anyone's baked id) does not trip this. Comparing the new
+    /// SYNTAX against the old serialized surface would, and would fall back for nothing.</para>
+    ///
+    /// <para><b>Deliberately narrow.</b> Only "a name that already had at least one member now has
+    /// more" triggers. A procedure added under a NEW name changes no existing call site's overload
+    /// resolution and moves no id, so it stays on the fast path; so does a body edit, a rename, and
+    /// a signature change (loud at runtime). An object absent from, or ambiguous in, either
+    /// definition is skipped rather than treated as a trigger: an ADDED object has no baseline copy
+    /// and no pre-existing callers, and a kind with no <c>Methods</c> array has no member ids for
+    /// anyone to bake.</para>
+    ///
+    /// <para>Credit: the hazard and the compiler contract under it were found and pinned by Mikkel
+    /// Mansa Vilhelmsen (vhn) in his AL Runner fork.</para>
+    /// </summary>
+    private static string? OverloadAddedUnderAnExistingName(
+        NavSymRef.ModuleDefinition before, NavSymRef.ModuleDefinition after, IReadOnlySet<RadObjectIdentity> changed)
+    {
+        foreach (var id in changed)
+        {
+            if (RadMethodNameCounts(before, id) is not { } previous || previous.Count == 0) continue;
+            if (RadMethodNameCounts(after, id) is not { } current) continue;
+            foreach (var (name, count) in current)
+                if (previous.TryGetValue(name, out var had) && count > had)
+                    return $"{id.Kind} '{id.Name}'";
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// How many serialized methods <paramref name="id"/> declares under each name in
+    /// <paramref name="module"/>, or null when the object is absent, present more than once, or
+    /// has no readable <c>Methods</c> array.
+    ///
+    /// <para>Null is "cannot answer", never "no methods" — an empty dictionary is the latter, and
+    /// <see cref="OverloadAddedUnderAnExistingName"/> distinguishes them. Names are counted
+    /// case-insensitively because AL identifiers are.</para>
+    /// </summary>
+    private static Dictionary<string, int>? RadMethodNameCounts(NavSymRef.ModuleDefinition module, RadObjectIdentity id)
+    {
+        var propName = RadMergeablePropertiesByKind.FirstOrDefault(p => p.Kind == id.Kind).PropertyName;
+        if (propName == null) return null;
+        var prop = RadContainerProperty(propName);
+        var wanted = IdentityElementKeyOf(id);
+
+        object? found = null;
+        // Every namespace depth, not just the module's own arrays (#2507).
+        foreach (var container in EnumerateContainers(module))
+        {
+            if (prop.GetValue(container) is not Array arr) continue;
+            foreach (var item in arr)
+            {
+                if (item == null || ElementKey(item, id.Kind) != wanted) continue;
+                if (found != null) return null; // ambiguous — two copies, no defensible answer
+                found = item;
+            }
+        }
+        if (found == null) return null;
+        if (found.GetType().GetProperty("Methods")?.GetValue(found) is not Array methods) return null;
+
+        var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        foreach (var method in methods)
+        {
+            if (method == null) continue;
+            if (method.GetType().GetProperty("Name")?.GetValue(method) is not string name || name.Length == 0)
+                return null; // unkeyable member — do not pretend to have counted the surface
+            counts[name] = counts.TryGetValue(name, out var n) ? n + 1 : 1;
+        }
+        return counts;
+    }
 
     private static NavSymRef.ModuleDefinition CloneModuleDefinition(NavSymRef.ModuleDefinition module)
         => (NavSymRef.ModuleDefinition)typeof(NavSymRef.ModuleDefinition)

--- a/AlRunner/BcCompiler.Incremental.cs
+++ b/AlRunner/BcCompiler.Incremental.cs
@@ -1123,10 +1123,15 @@ public sealed partial class BcCompiler
     private static string? OverloadAddedUnderAnExistingName(
         NavSymRef.ModuleDefinition before, NavSymRef.ModuleDefinition after, IReadOnlySet<RadObjectIdentity> changed)
     {
-        foreach (var id in changed)
+        if (changed.Count == 0) return null;
+        var previousByObject = RadMethodNameCounts(before, changed);
+        if (previousByObject.Count == 0) return null;
+        var currentByObject = RadMethodNameCounts(after, changed);
+
+        foreach (var (id, previous) in previousByObject)
         {
-            if (RadMethodNameCounts(before, id) is not { } previous || previous.Count == 0) continue;
-            if (RadMethodNameCounts(after, id) is not { } current) continue;
+            if (previous == null || previous.Count == 0) continue;
+            if (!currentByObject.TryGetValue(id, out var current) || current == null) continue;
             foreach (var (name, count) in current)
                 if (previous.TryGetValue(name, out var had) && count > had)
                     return $"{id.Kind} '{id.Name}'";
@@ -1135,42 +1140,64 @@ public sealed partial class BcCompiler
     }
 
     /// <summary>
-    /// How many serialized methods <paramref name="id"/> declares under each name in
-    /// <paramref name="module"/>, or null when the object is absent, present more than once, or
-    /// has no readable <c>Methods</c> array.
+    /// How many serialized methods each object in <paramref name="wanted"/> declares under each
+    /// name, in one pass over <paramref name="module"/> — every namespace depth included (#2507).
     ///
-    /// <para>Null is "cannot answer", never "no methods" — an empty dictionary is the latter, and
-    /// <see cref="OverloadAddedUnderAnExistingName"/> distinguishes them. Names are counted
-    /// case-insensitively because AL identifiers are.</para>
+    /// <para>One pass, not one per identity: a bulk change (a branch switch, a bulk rename) can put
+    /// hundreds of objects in the change set, and asking per identity would re-walk the whole
+    /// module — reflection <c>GetValue</c> over every element of every kind array — once per one of
+    /// them.</para>
+    ///
+    /// <para>An object missing from the result was not found. A null VALUE is "found, but cannot be
+    /// counted" — present more than once (ambiguous), no readable <c>Methods</c> array, or a member
+    /// with no usable name. Both are non-answers to
+    /// <see cref="OverloadAddedUnderAnExistingName"/> and neither is "no methods", which is an
+    /// empty dictionary. Names are counted case-insensitively because AL identifiers are.</para>
     /// </summary>
-    private static Dictionary<string, int>? RadMethodNameCounts(NavSymRef.ModuleDefinition module, RadObjectIdentity id)
+    private static Dictionary<RadObjectIdentity, Dictionary<string, int>?> RadMethodNameCounts(
+        NavSymRef.ModuleDefinition module, IReadOnlySet<RadObjectIdentity> wanted)
     {
-        var propName = RadMergeablePropertiesByKind.FirstOrDefault(p => p.Kind == id.Kind).PropertyName;
-        if (propName == null) return null;
-        var prop = RadContainerProperty(propName);
-        var wanted = IdentityElementKeyOf(id);
+        var byKindAndKey = new Dictionary<(NavCA.SymbolKind Kind, string Key), RadObjectIdentity>();
+        foreach (var id in wanted)
+            if (RadMergeablePropertiesByKind.Any(p => p.Kind == id.Kind))
+                byKindAndKey[(id.Kind, IdentityElementKeyOf(id))] = id;
 
-        object? found = null;
-        // Every namespace depth, not just the module's own arrays (#2507).
+        var result = new Dictionary<RadObjectIdentity, Dictionary<string, int>?>();
+        if (byKindAndKey.Count == 0) return result;
+
+        var kindsWanted = byKindAndKey.Keys.Select(k => k.Kind).ToHashSet();
         foreach (var container in EnumerateContainers(module))
         {
-            if (prop.GetValue(container) is not Array arr) continue;
-            foreach (var item in arr)
+            foreach (var (propName, kind) in RadMergeablePropertiesByKind)
             {
-                if (item == null || ElementKey(item, id.Kind) != wanted) continue;
-                if (found != null) return null; // ambiguous — two copies, no defensible answer
-                found = item;
+                if (!kindsWanted.Contains(kind)) continue;
+                if (RadContainerProperty(propName).GetValue(container) is not Array arr) continue;
+                foreach (var item in arr)
+                {
+                    if (item == null) continue;
+                    if (!byKindAndKey.TryGetValue((kind, ElementKey(item, kind)), out var id)) continue;
+                    // A second copy of a key is ambiguous: which one answers would be decided by
+                    // array order rather than by the edit. Refuse to answer for it.
+                    result[id] = result.ContainsKey(id) ? null : RadMemberNameCounts(item);
+                }
             }
         }
-        if (found == null) return null;
-        if (found.GetType().GetProperty("Methods")?.GetValue(found) is not Array methods) return null;
+        return result;
+    }
 
+    /// <summary>
+    /// One serialized object's method-name multiset, or null when a member cannot be named — see
+    /// <see cref="RadMethodNameCounts"/> for how null is read.
+    /// </summary>
+    private static Dictionary<string, int>? RadMemberNameCounts(object element)
+    {
+        if (element.GetType().GetProperty("Methods")?.GetValue(element) is not Array methods) return null;
         var counts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
         foreach (var method in methods)
         {
             if (method == null) continue;
             if (method.GetType().GetProperty("Name")?.GetValue(method) is not string name || name.Length == 0)
-                return null; // unkeyable member — do not pretend to have counted the surface
+                return null;
             counts[name] = counts.TryGetValue(name, out var n) ? n + 1 : 1;
         }
         return counts;


### PR DESCRIPTION
Closes #2548

## What was wrong

The incremental (RAD) fast path could ship an assembly that dispatches the **wrong overload**, with
no exception, no diagnostic and no log line.

`BcCompiler.Incremental.cs`'s header argues that an unmodified caller never needs re-emitting,
because a cross-object call dispatches by `(object id, member hash)` at runtime and a breaking edit
throws `NavNCLMissingMethodException` at the call site — loud, not silent. That argument covers
every edit that **retires or moves** an existing member's id. It does not cover an **addition**:

- `MethodSymbol.CalculateMethodIdForNewVersions` is method-local, so adding `Which(Integer)` beside
  `Which(Decimal)` leaves the Decimal overload's id — and its `case` label in the re-emitted
  callee's `OnInvoke` switch — bit-identical.
- What moves is the id the **caller** bakes. Before the edit an Integer argument widened to
  `Which(Decimal)`; after it, overload resolution picks `Which(Integer)`.
- The caller is not re-emitted, so it keeps dispatching a member that **still exists** and gets the
  previous overload's answer.

Measured RED on `main` @ `2eebaedd`: the fast path ran with an empty `fallbackReason`, the callee's
generated C# matched a cold build, and the caller's did not.

## The fix

This repo's fast path maintains no object-reference graph, so it cannot name the callers to
re-emit. It now detects the shape and **falls back to a full compile for that cycle**, with a reason
naming the object and what happened.

The check runs right after `SymbolJsonWriter.GetModuleDefinition(radComp)` — the first point where
both serialized surfaces exist, and the last point at which returning null is still free. It
compares each changed object's serialized **method-name multiset** against the committed baseline's
and triggers only when a name that already had at least one member now has more.

Deliberately narrow, in both directions:

- Serialized-against-serialized, so BC's own exclusion of `local` methods keeps a local-only
  overload (which nothing outside the object can call) on the fast path.
- A procedure added under a **new** name, a body edit, a rename and a signature change all stay on
  the fast path. The first is pinned by the control test; the last is already loud at runtime.
- Namespace-aware via the existing `EnumerateContainers` walk (#2507), so it sees an object nested
  at any depth.

## Tests

`AlRunner.Tests/BcCompilerIncrementalOverloadRebindTests.cs`, two tests that are each other's
control — "always fall back" satisfies the first alone and would delete the fast path; "never fall
back" satisfies the second alone and is the bug:

| test | claim |
|---|---|
| `…AddingAnOverloadToACallee_FallsBackInsteadOfShippingAStaleCaller` | RED on `main`. Asserts the fallback happens and that its reason names the object and the shape. Guarded by `Assert.NotEqual(baseline caller C#, cold-build caller C#)`, so it cannot pass against an edit that did nothing. |
| `…AddingAProcedureUnderANewName_StaysOnTheFastPathAndMatchesAColdBuild` | The fast path still applies for the neighbouring shape, and what it ships is byte-identical to an independent cold build of the same tree. |

No Base Application and no running AL — the acceptance criterion is the one
`BcCompilerIncrementalCrossKindSiblingTests` already uses.

Local: 2/2 green; the 27 tests across `BcCompilerIncremental*`, `WatchFullRebuildReason*`,
`ServerAffected*` and `WatchRadRealDependency*` stay green.

## Credit

The hazard, the fixture shape, and the `RequiresRuntimeOverloadDisambiguation` /
`CalculateMethodIdForNewVersions` contract underneath it were found and pinned by **Mikkel Mansa
Vilhelmsen (vhn)** in his AL Runner fork (`RadSameAppOverloadTests`,
`RadSameAppOverloadWatchTests`, `ModuleDefinitionOps.CompareObjectSurface`). His fork rebinds the
callers from an object-reference graph it maintains, which is the better long-term answer and is
being evaluated separately. This PR is the minimum needed to stop the silent wrong answer here.

## Not covered

A related hole in the same argument: an edit that changes a callee's return **subtype** or a
parameter **name** moves no member id either, so an incremental cycle compiles clean where a cold
build would raise a diagnostic in the unmodified caller. That is a missed *diagnostic*, not a wrong
*dispatch*, and needs its own reproducer.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
