### PR TITLE
fix(metadata): carry a table's declared Caption onto its NCLMetaTable

### DIFF
--- a/AlRunner.Tests/TableCaptionResolutionTests.cs
+++ b/AlRunner.Tests/TableCaptionResolutionTests.cs
@@ -1,0 +1,206 @@
+// TableCaptionResolutionTests — RED→GREEN guard for #2545.
+//
+// AL's `Caption` on a table was parsed (AlObjectCaptionParser → _parsedObjectCaptions)
+// and served to AllObjWithCaption, but never reached the NCLMetaTable the runner builds.
+// BC answers Rec.TableCaption() and RecordRef.Caption() off that MetaTable's merged
+// caption MultiLanguage and falls back to the object NAME when there is none — so the
+// missing wiring did not produce an empty caption, it produced the table's name, which
+// looks plausible.
+//
+// The BC-behavior half is proved upstream, where a real service tier adjudicates it:
+// BusinessCentral.AL.Language.Tests `Test Record TableCaption` (60831) against fixture
+// `ALT Captioned` (60830). These tests pin what that corpus test cannot reach, because
+// it is not expressible in AL: ResolveTableCaption prefers the AL source, and PRESENCE
+// in _parsedObjectCaptions is authoritative even when the recorded caption is null. A
+// table the runner parsed from source owns its object id for this run, so "parsed,
+// declares no Caption" must answer null rather than fall through and inherit a same-id
+// caption out of some registered .app's symbols. Only a runner test can stage that id
+// collision, and only a runner test can stage a dependency-symbol caption with no .app
+// on disk.
+//
+// The other half of the fix — CallMetaTableCtor setting BOTH `caption` and `captionML`,
+// because BC's read is the merged MultiLanguage and the plain string alone does nothing
+// (the same pairing BuildMetaField already does one level down for a FIELD's caption,
+// #1777) — is proved by the corpus test, which fails if either is missing.
+using System.Collections;
+using System.Reflection;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(RecordPatchesSerialCollection.Name)]
+public class TableCaptionResolutionTests
+{
+    private static readonly Type RecordPatchesType = typeof(AlRunner.Patches.RecordPatches);
+
+    // Ids picked outside every other parser test's range so a leak is obvious.
+    private const int CaptionedTableId = 61984;
+    private const int SilentTableId = 61985;
+
+    private const string CaptionedTableName = "TCR Captioned";
+    private const string CaptionedTableCaption = "TCR Captioned Table Caption";
+
+    // One table whose Caption differs from its name, one declaring no Caption at all.
+    // The two names are never equal to their captions, so an implementation answering
+    // with the name fails on the value, not merely on null-ness.
+    private static string Fixture() => $$"""
+        table {{CaptionedTableId}} "{{CaptionedTableName}}"
+        {
+            Caption = '{{CaptionedTableCaption}}';
+            fields { field(1; "No."; Code[20]) { } }
+        }
+
+        table {{SilentTableId}} "TCR Silent"
+        {
+            fields { field(1; "No."; Code[20]) { } }
+        }
+        """;
+
+    [Fact]
+    public void ResolveTableCaption_ReturnsTheDeclaredCaption()
+    {
+        try
+        {
+            Invoke("TryParseObjectCaptionFile", Fixture());
+
+            Assert.Equal(CaptionedTableCaption, ResolveTableCaption(CaptionedTableId));
+            // The caption differs from the name on purpose: returning the name is the
+            // exact wrong answer #2545 reports, and it would pass a non-null assertion.
+            Assert.NotEqual(CaptionedTableName, ResolveTableCaption(CaptionedTableId));
+        }
+        finally { ForgetObjectCaptions(); }
+    }
+
+    [Fact]
+    public void ResolveTableCaption_IsNullWhenTheTableDeclaresNoCaption()
+    {
+        try
+        {
+            Invoke("TryParseObjectCaptionFile", Fixture());
+
+            // Null, not the name and not string.Empty. AL's default caption is the object
+            // name, and BC's own NCLMetaTable applies that fallback — inventing it here
+            // would set `caption` to the name and defeat the fallback rather than use it.
+            Assert.Null(ResolveTableCaption(SilentTableId));
+            // Control: the parser demonstrably ran over this source, so the null above is
+            // an observation about the declaration and not about an unparsed fixture.
+            Assert.True(HasObjectCaption("Table", SilentTableId),
+                "the object-caption parser recorded no entry for the undeclared table — the fixture or the parser changed");
+        }
+        finally { ForgetObjectCaptions(); }
+    }
+
+    [Fact]
+    public void ResolveTableCaption_IsNullForATableTheRunnerNeverSaw()
+    {
+        try
+        {
+            Invoke("TryParseObjectCaptionFile", Fixture());
+
+            // Negative: nothing was ever parsed for 61999, and no .app in this test
+            // process declares it, so there is no caption to answer with.
+            Assert.Null(ResolveTableCaption(61999));
+        }
+        finally { ForgetObjectCaptions(); }
+    }
+
+    [Fact]
+    public void ResolveTableCaption_ParsedSourceWithNoCaptionDoesNotInheritASymbolCaption()
+    {
+        try
+        {
+            Invoke("TryParseObjectCaptionFile", Fixture());
+            // A registered .app claims the SAME table id and does declare a caption.
+            SetSymbolTableCaptions(new Dictionary<int, string?>
+            {
+                [SilentTableId] = "Symbol Caption That Must Not Win",
+                [CaptionedTableId] = "Symbol Caption That Must Not Win Either",
+            });
+
+            // Source presence wins in BOTH directions: the parsed table that declares no
+            // Caption stays null, and the one that declares a Caption keeps its own.
+            Assert.Null(ResolveTableCaption(SilentTableId));
+            Assert.Equal(CaptionedTableCaption, ResolveTableCaption(CaptionedTableId));
+        }
+        finally
+        {
+            ForgetObjectCaptions();
+            SetSymbolTableCaptions(null);
+        }
+    }
+
+    [Fact]
+    public void ResolveTableCaption_FallsBackToTheSymbolCaptionForAnUnparsedTable()
+    {
+        try
+        {
+            // No source parsed for this id at all — a precompiled dependency table. Its
+            // declared caption lives on the .app's SymbolReference Objects[] entry, which
+            // is what _bcSymbolTableCaptions holds.
+            SetSymbolTableCaptions(new Dictionary<int, string?>
+            {
+                [61986] = "Dependency Table Caption",
+                [61987] = null,
+            });
+
+            Assert.Equal("Dependency Table Caption", ResolveTableCaption(61986));
+            // A dependency table that declares no Caption answers null, so BC's own name
+            // fallback stands there too.
+            Assert.Null(ResolveTableCaption(61987));
+        }
+        finally { SetSymbolTableCaptions(null); }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static void Invoke(string method, string source)
+    {
+        var m = RecordPatchesType.GetMethod(method, BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                $"RecordPatches.{method} not found by reflection — signature may have changed.");
+        m.Invoke(null, new object[] { source });
+    }
+
+    private static string? ResolveTableCaption(int tableId)
+    {
+        var m = RecordPatchesType.GetMethod("ResolveTableCaption",
+                    BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.Public)
+            ?? throw new InvalidOperationException("RecordPatches.ResolveTableCaption not found by reflection.");
+        return (string?)m.Invoke(null, new object[] { tableId });
+    }
+
+    private static IDictionary ObjectCaptions() => (IDictionary)RecordPatchesType
+        .GetField("_parsedObjectCaptions", BindingFlags.NonPublic | BindingFlags.Static)!.GetValue(null)!;
+
+    private static bool HasObjectCaption(string kind, int id) => ObjectCaptions().Contains((kind, id));
+
+    private static void ForgetObjectCaptions()
+    {
+        var d = ObjectCaptions();
+        foreach (var id in new[] { CaptionedTableId, SilentTableId })
+            d.Remove(("Table", id));
+    }
+
+    // _bcSymbolTableCaptions is normally built by EnsureBcSymbolTableIndex from registered
+    // .app files. Writing it directly is what lets these tests stage an id collision
+    // between source and symbols without a real .app on disk. Setting it non-null also
+    // makes EnsureBcSymbolTableIndex's own short-circuit irrelevant here, because that
+    // gate reads _bcSymbolTableIndex, which stays as the surrounding process left it.
+    private static void SetSymbolTableCaptions(Dictionary<int, string?>? captions)
+    {
+        var indexField = RecordPatchesType.GetField("_bcSymbolTableIndex", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var captionField = RecordPatchesType.GetField("_bcSymbolTableCaptions", BindingFlags.NonPublic | BindingFlags.Static)!;
+        if (captions == null)
+        {
+            captionField.SetValue(null, null);
+            indexField.SetValue(null, null);
+            return;
+        }
+        // A non-null table index is what stops EnsureBcSymbolTableIndex rebuilding (and
+        // wiping) the captions this test just staged.
+        if (indexField.GetValue(null) == null)
+            indexField.SetValue(null, Activator.CreateInstance(indexField.FieldType));
+        captionField.SetValue(null, captions);
+    }
+
+}

--- a/AlRunner/Patches/RecordPatches.AlObjectCaptionParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlObjectCaptionParser.cs
@@ -107,4 +107,36 @@ public static partial class RecordPatches
         => string.Equals(kind, "Report", StringComparison.OrdinalIgnoreCase)
             ? (_parsedReports.TryGetValue(id, out var report) ? report.Caption : null)
             : _parsedObjectCaptions.TryGetValue((kind, id), out var caption) ? caption : null;
+
+    /// <summary>
+    /// The Caption a table declares, or null when it declares none — which is also what a
+    /// table the runner has never seen the source or symbols for answers, because AL's
+    /// default caption is the object name and BC's own NCLMetaTable applies that fallback
+    /// itself (see NclMetaTableBuilder's caption block). Null therefore means "leave the
+    /// MetaTable ctor's caption parameters unset", never "the caption is empty".
+    ///
+    /// AllObjWithCaption answers the same question through <see cref="SourceCaptionFor"/>
+    /// plus EnumerateBcAppObjects; this is the metadata-side answer, for the caption BC
+    /// reads off NCLMetaTable when AL calls Rec.TableCaption() / RecordRef.Caption() and
+    /// when BC interpolates a table name into its own error text.
+    ///
+    /// Presence in <see cref="_parsedObjectCaptions"/> is authoritative even when the value
+    /// is null: a table parsed from AL source owns its object id for this run, so
+    /// "parsed, declares no Caption" must NOT fall through and inherit a same-id table
+    /// caption out of some registered .app's symbols.
+    /// </summary>
+    internal static string? ResolveTableCaption(int tableId)
+    {
+        if (_parsedObjectCaptions.TryGetValue(("Table", tableId), out var sourceCaption))
+            return sourceCaption;
+
+        lock (_bcTableIndexLock)
+        {
+            EnsureBcSymbolTableIndex();
+            return _bcSymbolTableCaptions != null
+                && _bcSymbolTableCaptions.TryGetValue(tableId, out var symbolCaption)
+                    ? symbolCaption
+                    : null;
+        }
+    }
 }

--- a/AlRunner/Patches/RecordPatches.BcAppFallback.cs
+++ b/AlRunner/Patches/RecordPatches.BcAppFallback.cs
@@ -40,6 +40,14 @@ public static partial class RecordPatches
     // Lazy fallback index: tableId → (appPath, alSource). Built only when symbols miss.
     private static Dictionary<int, (string AppPath, string Source)>? _bcTableIndex;
     private static Dictionary<int, (string AppPath, ParsedTable Table)>? _bcSymbolTableIndex;
+    // tableId → the Caption that table's .app declares, or null when it declares none.
+    // SymbolReference.json records a table's Caption on its Objects[] entry, not on the
+    // Tables[] entry _bcSymbolTableIndex is built from, so this is a second dictionary
+    // filled from the same scan rather than another field on that tuple. Read by
+    // ResolveTableCaption (RecordPatches.AlObjectCaptionParser.cs) so a PRECOMPILED
+    // dependency table's declared caption reaches the NCLMetaTable the runner builds for
+    // it, the same way a source-parsed table's does.
+    private static Dictionary<int, string?>? _bcSymbolTableCaptions;
     // Query symbol index: queryId → QuerySymbol, built from registered .app SymbolReference.json.
     private static Dictionary<int, BcAppSymbolCache.QuerySymbol>? _bcSymbolQueryIndex;
     // Raw SymbolReference.json files registered as query-symbol-only sources (the bundle's
@@ -75,6 +83,10 @@ public static partial class RecordPatches
     {
         _bcTableIndex = null;
         _bcSymbolTableIndex = null;
+        // Built in the same pass as _bcSymbolTableIndex and gated on it being null, so it
+        // has to be dropped together with it or a warm --server/--watch reload would serve
+        // the previous registration epoch's captions.
+        _bcSymbolTableCaptions = null;
         _bcSymbolQueryIndex = null;
         _bcSymbolExtensionIndexBuilt = false;
     }
@@ -177,7 +189,13 @@ public static partial class RecordPatches
                 _bcMissCache.Add(tableId);
                 return false;
             }
-            // Parse the source slice that contains this table id.
+            // Parse the source slice that contains this table id. The table parser reads the
+            // structural shape (fields, keys, properties it knows); the object-caption parser
+            // is a separate extractor and owns the object's top-level Caption. This path is
+            // lazy and per-id, so it does not go through ParseAllRegisteredSourceFiles, which
+            // is where the two normally run together (#1903). Without the second call a table
+            // reached only through this fallback would have its caption silently dropped.
+            TryParseObjectCaptionFile(entry.Source);
             TryParseTableFile(entry.Source);
             if (_parsedTables.ContainsKey(tableId))
             {
@@ -328,6 +346,8 @@ public static partial class RecordPatches
                     {
                         if (_parsedTables.ContainsKey(id)) continue;
                         if (!alreadySeenSources.Add(entry.Source)) continue;
+                        // Same pairing as the lazy per-id path above — see its comment.
+                        TryParseObjectCaptionFile(entry.Source);
                         TryParseTableFile(entry.Source);
                         if (_parsedTables.ContainsKey(id)) parsedNow++;
                     }
@@ -470,13 +490,23 @@ public static partial class RecordPatches
     {
         if (_bcSymbolTableIndex != null) return;
         var idx = new Dictionary<int, (string, ParsedTable)>();
+        var captions = new Dictionary<int, string?>();
         foreach (var appPath in _bcAppPaths)
         {
             try
             {
-                foreach (var table in BcAppSymbolCache.Get(appPath).Tables)
+                var symbols = BcAppSymbolCache.Get(appPath);
+                foreach (var table in symbols.Tables)
                     if (!idx.ContainsKey(table.TableId))
                         idx[table.TableId] = (appPath, table);
+                // Same first-app-wins rule as the table index above, so the two dictionaries
+                // cannot disagree about which .app a given table id came from. TryAdd rather
+                // than an indexer assignment: the value may legitimately be null (the table
+                // declares no Caption), and null must still claim the id so a later .app's
+                // same-id caption does not overwrite it.
+                foreach (var obj in symbols.Objects)
+                    if (string.Equals(obj.Kind, "Table", StringComparison.OrdinalIgnoreCase))
+                        captions.TryAdd(obj.Id, obj.Caption);
             }
             catch (Exception ex)
             {
@@ -484,6 +514,7 @@ public static partial class RecordPatches
             }
         }
         _bcSymbolTableIndex = idx;
+        _bcSymbolTableCaptions = captions;
         if (idx.Count > 0)
             Console.Error.WriteLine($"[RecordPatches] BcAppFallback: indexed {idx.Count} symbol table id(s) across {_bcAppPaths.Count} BC .app file(s)");
         // Co-build the extension index whenever the table index is (re)built.

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -204,8 +204,13 @@ public static partial class RecordPatches
 
             // Build MetaTable via named-parameter ctor.  The public ctor takes many
             // named params with defaults; we resolve by name and fall back to defaults.
+            // #2545 — the table's own declared Caption. Null when it declares none, which is
+            // the common case and leaves the ctor's caption parameters unset so BC's own
+            // object-name fallback stands. See ResolveTableCaption.
+            var tableCaption = ResolveTableCaption(tableId);
+
             var defaultMetaTable = CallMetaTableCtor(tableId, parsed.TableName, fields, allKeys.ToArray(),
-                parsed.IsTableTypeTemporary, parsed.DataPerCompany, lookupFormId);
+                parsed.IsTableTypeTemporary, parsed.DataPerCompany, tableCaption, lookupFormId);
             if (defaultMetaTable == null) return null;
 
             // NavAppGroup.BaseGroup
@@ -312,7 +317,7 @@ public static partial class RecordPatches
     }
 
     private static object? CallMetaTableCtor(int id, string name, object[] fields, object[] allKeys,
-        bool isTableTypeTemporary, bool isDataPerCompany, int lookupFormId = 0)
+        bool isTableTypeTemporary, bool isDataPerCompany, string? caption, int lookupFormId = 0)
     {
         if (_tMetaTable == null) return null;
         var ctor = _tMetaTable.GetConstructors()
@@ -327,6 +332,21 @@ public static partial class RecordPatches
             var p = ps[i];
             if (p.Name == "id") { args[i] = id; continue; }
             if (p.Name == "name") { args[i] = name; continue; }
+            // #2545 — the table's declared Caption, the exact shape BuildMetaField already
+            // uses for a FIELD's caption one level down. BC answers Rec.TableCaption() and
+            // RecordRef.Caption() from the MetaTable's MERGED caption MultiLanguage, and
+            // falls back to the object NAME when there is none — so leaving these unset did
+            // not produce an empty caption, it produced the name, which looks plausible and
+            // is the harder failure to notice. Both parameters are set: the plain `caption`
+            // string is not what BC's merged read consults, and the ML is not what a plain
+            // caption read consults. A table with no declared Caption leaves both unset so
+            // BC's own name fallback stands.
+            if (p.Name == "caption" && !string.IsNullOrEmpty(caption)) { args[i] = caption; continue; }
+            if (p.Name == "captionML" && !string.IsNullOrEmpty(caption))
+            {
+                var ml = BuildEnuMultiLanguage(p.ParameterType, caption!);
+                if (ml != null) { args[i] = ml; continue; }
+            }
             if (p.Name == "fields")
             {
                 // ImmutableArray<MetaField>


### PR DESCRIPTION
Closes #2545

## What was wrong

`Rec.TableCaption()` returned the table's **name** even when the table declared a
`Caption` property. The caption was already parsed — `AlObjectCaptionParser` records it in
`_parsedObjectCaptions` and `AllObjWithCaption` serves it — but it never reached the
`NCLMetaTable` the runner builds, and BC answers `TableCaption()` / `RecordRef.Caption()`
off that MetaTable's merged caption MultiLanguage. Both caption parameters were left at
their ctor defaults, so BC applied its own object-name fallback: the wrong answer looked
plausible rather than empty.

`docs/scope.md` already claimed table captions carry "real values for AL-compiled tables",
so this makes that claim true rather than changing it.

## RED

Measured on `origin/main` at `2eebaedd`, a two-table probe bundle (one table declaring
`Caption = 'Probe Row Caption'`, one declaring none):

```
FAIL  Codeunit71000.TableCaption_DeclaredCaption
      EXPECTED "Probe Row Caption" GOT "Tc Probe Row"
PASS  Codeunit71000.TableCaption_NoDeclaredCaption
```

Both pass after the change.

## The fix, in three parts

- `CallMetaTableCtor` fills **both** `caption` and `captionML` — the same pairing
  `BuildMetaField` already does one level down for a field's caption (#1777). Setting only
  the plain string is the natural-looking half-fix and does nothing, because BC's read is
  the merged MultiLanguage.
- `ResolveTableCaption` answers from the AL source first, and **presence** in
  `_parsedObjectCaptions` is authoritative even when the recorded value is null. A table
  parsed from source owns its object id for this run, so "parsed, declares no Caption"
  answers null instead of inheriting a same-id caption out of some registered `.app`.
- A precompiled dependency table's declared caption resolves too. SymbolReference records
  a table's Caption on its `Objects[]` entry, not the `Tables[]` entry `_bcSymbolTableIndex`
  is built from, so `_bcSymbolTableCaptions` is filled from the same scan and invalidated
  together with it.

The two `BcAppFallback` paths that lazily parse embedded dependency source now call
`TryParseObjectCaptionFile` alongside `TryParseTableFile`. Those paths bypass
`ParseAllRegisteredSourceFiles`, which is where the two extractors normally run together
(#1903), so a table reached only through the fallback had its caption dropped.

A table declaring no Caption still leaves both ctor parameters unset, so BC's own
object-name fallback stands and is never reimplemented here.

## Proving tests

**BC behavior — upstream.** `StefanMaron/BusinessCentral.AL.Language.Tests` PR #124 adds
`ALT Captioned` (60830, name and Caption deliberately different) and `Test Record
TableCaption` (60831). **All 8 BC legs green** (27.0, 27.3, 27.5, 28.0, 28.1, 28.2, 28.3,
28.4), so a real service tier has adjudicated all five assertions:

1. `TableCaption()` returns the declared Caption.
2. `TableName()` on the same table still returns the object name, so a fix answering both
   from the caption cannot pass.
3. A table with no declared Caption returns its name.
4. and 5. The same pair through `RecordRef.Caption()` / `RecordRef.Name()`.

That PR is merged. The submodule pin bump is deliberately **not** in this PR — the
orchestrator is doing one catch-up bump covering the whole wave, because every PR folding
its own bump conflicts on `tests/expectations/count-baseline/test-count-baseline.json`
(#2485).

**Runner-internal — here.** `AlRunner.Tests/TableCaptionResolutionTests.cs` pins what the
corpus test cannot reach because it is not expressible in AL: the source-presence rule,
and the dependency-symbol fallback staged without an `.app` on disk. Both directions of
the id-collision case are asserted.

## Local runs

- Corpus: 2361/2361 pass.
- `tests/runner-extras`: 215/215 pass.
- `TableCaptionResolutionTests` + `ReportCaptionConsolidationTests`: 10/10 pass.

## Credit

The gap was found in Mikkel Mansa Vilhelmsen's (`vhn`) fork, commit `c7644769`
"fix(metadata): preserve declared table captions". His code was not copied — this is an
independent implementation with its own upstream-adjudicated test.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
