### PR TITLE
Evaluate the TestPage control property expression instead of looking it up as a name

### DIFF
--- a/AlRunner.Tests/PageControlExpressionTests.cs
+++ b/AlRunner.Tests/PageControlExpressionTests.cs
@@ -202,6 +202,30 @@ public sealed class PageControlExpressionTests
     public void CharacterOutsideTheGrammar_Fails()
         => Assert.Contains("not part of the client-expression grammar", Failure("Flag & Flag"));
 
+    // A comparison against an operand this cannot read must fail rather than pick an ordering.
+    // Nothing in ordinary AL produces one -- a blank Text arrives as "" and a zero Decimal as 0,
+    // both measured -- so a null here means the identifier resolved to something unrecognized,
+    // and inventing an answer would write a made-up value into a page's contract.
+    [Fact]
+    public void ComparisonAgainstAnUnreadableOperand_Fails()
+    {
+        var resolver = Resolver(("Opaque", new object()), ("Flag", true));
+        Assert.Contains("cannot compare", Failure("Opaque = Flag", resolver));
+    }
+
+    // The counterpart: a blank string and a zero really do compare as values, so tightening the
+    // rule above must not have made ordinary data fail.
+    [Theory]
+    [InlineData("Blank = ''", true)]
+    [InlineData("Blank <> ''", false)]
+    [InlineData("Zero > 0", false)]
+    [InlineData("Zero = 0", true)]
+    public void BlankAndZero_CompareAsValuesNotAsMissing(string text, bool expected)
+    {
+        var resolver = Resolver(("Blank", ""), ("Zero", 0m));
+        Assert.Equal(expected, Eval(text, resolver));
+    }
+
     [Fact]
     public void DivisionByZero_Fails()
         => Assert.Contains("divide by zero", Failure("Qty / 0 = 1"));

--- a/AlRunner.Tests/PageControlExpressionTests.cs
+++ b/AlRunner.Tests/PageControlExpressionTests.cs
@@ -7,7 +7,8 @@
 //
 // Every literal expression string below was measured, not invented: it is the text the BC 28.1 AL
 // compiler wrote into the metadata for the AL quoted beside it. The mangled `p65901p65901X` names
-// are page globals on page 65901; the bare names are fields on its source table.
+// are page globals on page 65901; the bare names are source-table fields, which appear in the
+// emitted text the same way even though the runner's own resolver does not answer them (#2596).
 
 using AlRunner.Patches;
 using Xunit;
@@ -70,22 +71,21 @@ public sealed class PageControlExpressionTests
     [InlineData("p65901p65901HideIt or p65901p65901Flag2", true)]
     // AL: Visible = not (HideIt or LockIt)
     [InlineData("not ( p65901p65901HideIt or p65901p65901LockIt )", true)]
-    // AL: Visible = Rec.Flag              (a source-table field, not a page global)
+    // A name the resolver supplies from somewhere other than the expression table. The runner's
+    // own resolver answers only registered source expressions -- see RunnerPageInstance and
+    // issue #2596 -- but the parser itself is agnostic about where a name comes from.
     [InlineData("Flag", true)]
-    // AL: Visible = not Rec.Flag
     [InlineData("not Flag", false)]
-    // AL: Visible = Rec.Value <> ''
     [InlineData("Value <> ''", true)]
-    // AL: Visible = Rec."Spaced Name"     (a name that needed AL quotes keeps them)
+    // A name that needed AL quotes keeps them in the emitted text.
     [InlineData("\"Spaced Name\"", true)]
-    // AL: Visible = Rec.Qty > 0
     [InlineData("Qty > 0", true)]
-    // AL: Visible = Rec.Kind = Rec.Kind::Second   (the enum member arrives as its ORDINAL)
+    // An enum comparand arrives as its ORDINAL, so nothing has to resolve an enum member.
     [InlineData("Kind = 1", true)]
     // AL: Visible = (Rec.Value = 'x') or Flag2
     [InlineData("( Value = 'x' ) or p65901p65901Flag2", true)]
     [InlineData("( Value = 'x' ) or p65901p65901LockIt", false)]
-    // AL: Visible = Rec.Qty > 1 + 1       (arithmetic does appear)
+    // Arithmetic does appear in the emitted text.
     [InlineData("Qty > 1 + 1", true)]
     [InlineData("Qty > 4 + 4", false)]
     public void MeasuredShapes_EvaluateToTheirAlAnswer(string text, bool expected)
@@ -163,7 +163,7 @@ public sealed class PageControlExpressionTests
     {
         var failure = Failure("not p65901p65901Missing");
         Assert.Contains("p65901p65901Missing", failure);
-        Assert.Contains("source record", failure);
+        Assert.Contains("publishes a binding for", failure);
     }
 
     [Fact]

--- a/AlRunner.Tests/PageControlExpressionTests.cs
+++ b/AlRunner.Tests/PageControlExpressionTests.cs
@@ -1,0 +1,215 @@
+// Unit tests for the client-expression parser behind a page control's Visible/Editable/Enabled.
+//
+// These are runner-local on purpose. What BC ANSWERS for `Visible = not Flag` is BC behavior and
+// is adjudicated upstream by the corpus against a real service tier. What the AL compiler WRITES
+// into the page metadata, and how this runner reads it back, is a runner-internal claim that no
+// service tier can settle — which is what these pin.
+//
+// Every literal expression string below was measured, not invented: it is the text the BC 28.1 AL
+// compiler wrote into the metadata for the AL quoted beside it. The mangled `p65901p65901X` names
+// are page globals on page 65901; the bare names are fields on its source table.
+
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PageControlExpressionTests
+{
+    /// <summary>
+    /// A resolver over a fixed set of names, standing in for the page's source-expression table
+    /// and its source record. Anything not listed resolves to nothing, which is what makes the
+    /// unresolved-name tests below mean something.
+    /// </summary>
+    private static PageControlExpression.ResolveIdentifier Resolver(
+        params (string Name, object? Value)[] known)
+        => (string name, bool quoted, out object? value) =>
+        {
+            foreach (var (n, v) in known)
+                if (n == name) { value = v; return true; }
+            value = null;
+            return false;
+        };
+
+    private static readonly PageControlExpression.ResolveIdentifier Page = Resolver(
+        ("p65901p65901HideIt", false),
+        ("p65901p65901LockIt", false),
+        ("p65901p65901Flag2", true),
+        ("Flag", true),
+        ("Value", "v"),
+        ("Qty", 5m),
+        ("Kind", 1),
+        ("Spaced Name", true),
+        ("NotABool", "some text"));
+
+    private static bool Eval(string text, PageControlExpression.ResolveIdentifier? resolve = null)
+    {
+        var ok = PageControlExpression.TryEvaluateBoolean(
+            text, resolve ?? Page, out var value, out var failure);
+        Assert.True(ok, $"'{text}' should evaluate, but failed: {failure}");
+        return value;
+    }
+
+    private static string Failure(string text, PageControlExpression.ResolveIdentifier? resolve = null)
+    {
+        var ok = PageControlExpression.TryEvaluateBoolean(
+            text, resolve ?? Page, out _, out var failure);
+        Assert.False(ok, $"'{text}' should NOT evaluate, but it returned a value");
+        Assert.NotNull(failure);
+        return failure!;
+    }
+
+    // ---- the measured shapes ------------------------------------------------------------------
+
+    [Theory]
+    // AL: Visible = not HideIt            (HideIt is false, so this is true)
+    [InlineData("not p65901p65901HideIt", true)]
+    // AL: Visible = HideIt and LockIt     (both false)
+    [InlineData("p65901p65901HideIt and p65901p65901LockIt", false)]
+    // AL: Visible = HideIt or Flag2       (Flag2 is true)
+    [InlineData("p65901p65901HideIt or p65901p65901Flag2", true)]
+    // AL: Visible = not (HideIt or LockIt)
+    [InlineData("not ( p65901p65901HideIt or p65901p65901LockIt )", true)]
+    // AL: Visible = Rec.Flag              (a source-table field, not a page global)
+    [InlineData("Flag", true)]
+    // AL: Visible = not Rec.Flag
+    [InlineData("not Flag", false)]
+    // AL: Visible = Rec.Value <> ''
+    [InlineData("Value <> ''", true)]
+    // AL: Visible = Rec."Spaced Name"     (a name that needed AL quotes keeps them)
+    [InlineData("\"Spaced Name\"", true)]
+    // AL: Visible = Rec.Qty > 0
+    [InlineData("Qty > 0", true)]
+    // AL: Visible = Rec.Kind = Rec.Kind::Second   (the enum member arrives as its ORDINAL)
+    [InlineData("Kind = 1", true)]
+    // AL: Visible = (Rec.Value = 'x') or Flag2
+    [InlineData("( Value = 'x' ) or p65901p65901Flag2", true)]
+    [InlineData("( Value = 'x' ) or p65901p65901LockIt", false)]
+    // AL: Visible = Rec.Qty > 1 + 1       (arithmetic does appear)
+    [InlineData("Qty > 1 + 1", true)]
+    [InlineData("Qty > 4 + 4", false)]
+    public void MeasuredShapes_EvaluateToTheirAlAnswer(string text, bool expected)
+        => Assert.Equal(expected, Eval(text));
+
+    // ---- precedence ---------------------------------------------------------------------------
+
+    // AL's precedence is Pascal's, not C's: `and` binds like multiplication, `or` like addition,
+    // and the comparison operators bind LOOSEST. So `A = B and C` is `A = (B and C)`.
+    //
+    // The operands are chosen so the two readings disagree. HideIt is false, Flag2 true, LockIt
+    // false:
+    //   AL:      false = (true and false)  ->  false = false  ->  TRUE
+    //   C-style: (false = true) and false  ->  false and false ->  false
+    [Fact]
+    public void Comparison_BindsLooserThanAnd_AsInAl()
+        => Assert.True(Eval("p65901p65901HideIt = p65901p65901Flag2 and p65901p65901LockIt"));
+
+    // `not` binds tighter than `and`. Both operands false, so the two readings disagree:
+    //   tight: (not false) and false  ->  true and false  ->  FALSE
+    //   loose: not (false and false)  ->  not false       ->  true
+    [Fact]
+    public void Not_BindsTighterThanAnd()
+        => Assert.False(Eval("not p65901p65901HideIt and p65901p65901LockIt"));
+
+    // `and` binds tighter than `or`: `false and false or true` is `(false and false) or true` =
+    // true, while `false and (false or true)` would be false.
+    [Fact]
+    public void And_BindsTighterThanOr()
+        => Assert.True(Eval("p65901p65901HideIt and p65901p65901LockIt or p65901p65901Flag2"));
+
+    // ---- operators ----------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    [InlineData("TRUE", true)]
+    [InlineData("not true", false)]
+    [InlineData("true xor true", false)]
+    [InlineData("true xor false", true)]
+    [InlineData("1 = 1", true)]
+    [InlineData("1 <> 1", false)]
+    [InlineData("2 > 1", true)]
+    [InlineData("2 >= 2", true)]
+    [InlineData("1 < 2", true)]
+    [InlineData("2 <= 1", false)]
+    [InlineData("7 div 2 = 3", true)]
+    [InlineData("7 mod 2 = 1", true)]
+    [InlineData("6 / 2 = 3", true)]
+    [InlineData("2 * 3 = 6", true)]
+    [InlineData("5 - 3 = 2", true)]
+    [InlineData("- 3 < 0", true)]
+    public void Operators_ProduceTheirAlAnswer(string text, bool expected)
+        => Assert.Equal(expected, Eval(text));
+
+    // AL compares Text and Code case-insensitively, so 'v' = 'V' is true. An ordinal comparison
+    // would answer false here and diverge from BC on exactly the shape these properties take.
+    [Fact]
+    public void StringComparison_IsCaseInsensitive_AsInAl()
+        => Assert.True(Eval("Value = 'V'"));
+
+    // The AL string literal escape is a doubled quote.
+    [Fact]
+    public void StringLiteral_ReadsADoubledQuoteAsOne()
+        => Assert.True(Eval("'it''s' = 'IT''S'"));
+
+    // ---- failures are loud, never a default ---------------------------------------------------
+
+    // The whole point of the surrounding code: an expression that cannot be evaluated must be
+    // reported as a failure so the caller raises RunnerOutOfScopeException. Answering "true" for
+    // a Visible we could not compute would make every test of a page's contract unfailable.
+
+    [Fact]
+    public void UnresolvedName_Fails_AndNamesIt()
+    {
+        var failure = Failure("not p65901p65901Missing");
+        Assert.Contains("p65901p65901Missing", failure);
+        Assert.Contains("source record", failure);
+    }
+
+    [Fact]
+    public void NonBooleanResult_Fails_AndSaysWhatItWas()
+    {
+        var failure = Failure("NotABool");
+        Assert.Contains("some text", failure);
+        Assert.Contains("not a Boolean", failure);
+    }
+
+    [Fact]
+    public void NotAppliedToANonBoolean_Fails()
+        => Assert.Contains("not a Boolean", Failure("not Qty"));
+
+    [Fact]
+    public void AndAppliedToNonBooleans_Fails()
+        => Assert.Contains("not both Boolean", Failure("Qty and Qty"));
+
+    [Fact]
+    public void UnclosedParenthesis_Fails()
+        => Assert.Contains("not closed", Failure("not ( Flag"));
+
+    [Fact]
+    public void TrailingText_Fails()
+        => Assert.Contains("unparsed text", Failure("Flag Flag"));
+
+    [Fact]
+    public void EmptyText_Fails()
+        => Assert.Contains("empty", Failure("   "));
+
+    [Fact]
+    public void UnterminatedStringLiteral_Fails()
+        => Assert.Contains("unterminated string", Failure("Value = 'x"));
+
+    [Fact]
+    public void CharacterOutsideTheGrammar_Fails()
+        => Assert.Contains("not part of the client-expression grammar", Failure("Flag & Flag"));
+
+    [Fact]
+    public void DivisionByZero_Fails()
+        => Assert.Contains("divide by zero", Failure("Qty / 0 = 1"));
+
+    // A procedure call cannot reach here — the AL compiler rejects one in a client expression with
+    // AL0322 — but if the metadata ever carried one, it must fail rather than resolve to a default.
+    [Fact]
+    public void ProcedureCallShape_Fails()
+        => Assert.False(PageControlExpression.TryEvaluateBoolean(
+            "IsShown ( )", Page, out _, out _));
+}

--- a/AlRunner.Tests/RunnerPageInstanceVisibleSnapshotTests.cs
+++ b/AlRunner.Tests/RunnerPageInstanceVisibleSnapshotTests.cs
@@ -1,0 +1,122 @@
+// The open-time snapshot behind a control's own Visible.
+//
+// Measured on all 8 BC versions through corpus PR #125: after a TestPage changes a page global
+// that a control's Visible is bound to, real BC keeps reporting the value from when the page was
+// opened, while the SAME control's Editable and Enabled follow the change. A group's Visible
+// follows it too — corpus TestPageFieldVisibleGroup_Tests flips a group's Visible expression
+// after the page is open, reads a field inside it as newly visible, and is green on real BC.
+//
+// So exactly one property is frozen and everything around it is live. These tests pin the
+// mechanism that makes that possible: RunnerPageInstance.SnapshotExpressionValues reads every
+// registered source expression once, and a later change to the same expression must move a live
+// read while leaving the snapshot alone. Each half is the other's control — a snapshot that
+// tracked changes would fail the first test, and a "snapshot" that was really a constant would
+// fail the second.
+//
+// This is a runner-internal claim. What BC ANSWERS is the corpus's business, not a C# test's.
+
+using System.Collections;
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class RunnerPageInstanceVisibleSnapshotTests
+{
+    /// <summary>
+    /// Stands in for one entry of NavForm.SourceExpressions. RunnerPageInstance.GetValue finds
+    /// the parameterless Get() by reflection, so a plain class with that shape is enough — and
+    /// using the real GetValue is the point: a fake that bypassed it would prove nothing about
+    /// how the snapshot actually reads an expression.
+    /// </summary>
+    private sealed class FakeExpression
+    {
+        internal bool Current;
+        public NavValue Get() => NavBoolean.Create(Current);
+    }
+
+    private sealed class ThrowingExpression
+    {
+        public NavValue Get() => throw new InvalidOperationException("this expression cannot be read yet");
+    }
+
+    private static IDictionary Table(params (string Name, object Expression)[] entries)
+    {
+        var table = new Hashtable();
+        foreach (var (name, expression) in entries) table[name] = expression;
+        return table;
+    }
+
+    // The frozen half. The snapshot is taken while the expression reads false; flipping the
+    // expression to true afterwards must not move it.
+    [Fact]
+    public void Snapshot_KeepsTheValueFromWhenItWasTaken()
+    {
+        var expression = new FakeExpression { Current = false };
+        var snapshot = RunnerPageInstance.SnapshotExpressionValues(Table(("p1p1HideIt", expression)));
+
+        expression.Current = true;
+
+        Assert.True(snapshot.TryGetValue("p1p1HideIt", out var frozen));
+        Assert.Equal(false, frozen);
+    }
+
+    // The live half, and the control for the test above: the SAME change the snapshot ignores
+    // must be visible to a live read through the same accessor the runner uses for Editable and
+    // Enabled. Without this, a snapshot that always answered false would look correct.
+    [Fact]
+    public void ALiveRead_SeesTheChangeTheSnapshotIgnores()
+    {
+        var expression = new FakeExpression { Current = false };
+        var snapshot = RunnerPageInstance.SnapshotExpressionValues(Table(("p1p1HideIt", expression)));
+
+        expression.Current = true;
+
+        Assert.Equal(false, snapshot["p1p1HideIt"]);
+        Assert.Equal(true, RunnerPageInstance.GetValue(expression)?.ClientObject);
+    }
+
+    // Every registered expression is captured, not just the first, and each keeps its own value.
+    [Fact]
+    public void Snapshot_CapturesEveryRegisteredExpressionSeparately()
+    {
+        var hide = new FakeExpression { Current = true };
+        var lockIt = new FakeExpression { Current = false };
+
+        var snapshot = RunnerPageInstance.SnapshotExpressionValues(
+            Table(("p1p1HideIt", hide), ("p1p1LockIt", lockIt)));
+
+        Assert.Equal(true, snapshot["p1p1HideIt"]);
+        Assert.Equal(false, snapshot["p1p1LockIt"]);
+    }
+
+    // Negative: one expression that cannot be read at open time must not cost the page its whole
+    // snapshot. It is omitted, so the control bound to it falls back to a live read — which is
+    // what happened before the snapshot existed, and which keeps the loud failure at the read
+    // that asks for it rather than turning it into a page-construction failure.
+    [Fact]
+    public void AnExpressionThatCannotBeRead_IsOmittedWithoutLosingTheOthers()
+    {
+        var readable = new FakeExpression { Current = true };
+
+        var snapshot = RunnerPageInstance.SnapshotExpressionValues(
+            Table(("p1p1Broken", new ThrowingExpression()), ("p1p1HideIt", readable)));
+
+        Assert.False(snapshot.ContainsKey("p1p1Broken"));
+        Assert.Equal(true, snapshot["p1p1HideIt"]);
+    }
+
+    // A null entry is not an expression and must not be snapshotted as a null VALUE — that would
+    // make a control bound to it read "evaluated to null, which is not a Boolean" from the
+    // snapshot instead of falling through to the page's own binding lookup.
+    [Fact]
+    public void ANullEntry_IsNotSnapshotted()
+    {
+        var table = new Hashtable { ["p1p1Missing"] = null };
+
+        var snapshot = RunnerPageInstance.SnapshotExpressionValues(table);
+
+        Assert.False(snapshot.ContainsKey("p1p1Missing"));
+    }
+}

--- a/AlRunner/Patches/PageControlExpression.cs
+++ b/AlRunner/Patches/PageControlExpression.cs
@@ -25,7 +25,9 @@
 //
 //   - A page global arrives under its emitted name and is registered in the page's
 //     SourceExpressions table. A source-table field arrives as the FIELD NAME and is not in that
-//     table at all, so identifier resolution has two sources, in that order.
+//     table at all. Which of those the caller answers is the caller's decision -- this parser only
+//     asks. RunnerPageInstance answers registered expressions only; see issue #2596 for what real
+//     BC does with a field reference, which is not what reading the live record would give.
 //   - An enum or option comparand is already an ORDINAL (`Kind = 1`), so nothing here has to
 //     resolve an enum member.
 //   - A name needing quoting keeps its AL double quotes (`"Spaced Name"`).
@@ -41,8 +43,8 @@
 // `A = (B and C)` in AL, and why AL code parenthesizes comparisons that it combines. Getting this
 // backwards would silently mis-evaluate expressions that parse either way.
 //
-// Anything this cannot parse, and any identifier that resolves to neither a registered expression
-// nor a field on the source record, is reported to the caller as a failure so it can raise
+// Anything this cannot parse, and any identifier the caller cannot resolve, is reported back as a
+// failure so the caller can raise
 // RunnerOutOfScopeException naming the expression. Per .claude/rules/loud-failures.md, an
 // expression we cannot evaluate must never come back as a default answer: `Visible` and `Editable`
 // ARE the page's contract, and inventing "true" for one makes every test of that contract
@@ -67,8 +69,8 @@ internal static class PageControlExpression
     /// method never guesses a value.
     /// </summary>
     /// <param name="resolve">
-    /// Resolves one identifier to its current value. Returns false when the name is neither a
-    /// registered source expression nor a field on the page's source record.
+    /// Resolves one identifier to its current value. Returns false when the caller does not
+    /// recognise the name.
     /// </param>
     internal static bool TryEvaluateBoolean(
         string text,
@@ -95,9 +97,10 @@ internal static class PageControlExpression
     }
 
     /// <summary>
-    /// Resolve one identifier — a registered source-expression name, or a field name on the
-    /// page's source record — to its current value. <paramref name="quoted"/> says the name
-    /// arrived in AL double quotes, which only ever happens for a field name.
+    /// Resolve one identifier to its current value, and return false when it cannot be resolved.
+    /// What counts as resolvable is the caller's decision, not this parser's.
+    /// <paramref name="quoted"/> says the name arrived in AL double quotes, which the emitted
+    /// spelling of a page global never needs.
     /// </summary>
     internal delegate bool ResolveIdentifier(string name, bool quoted, out object? value);
 
@@ -407,8 +410,7 @@ internal static class PageControlExpression
         private object? Resolve(string name, bool quoted)
         {
             if (_resolve(name, quoted, out var value)) return value;
-            _failure = $"'{name}' is neither an expression the page publishes a binding for "
-                     + "nor a field on its source record";
+            _failure = $"'{name}' is not a name the page publishes a binding for";
             return null;
         }
 

--- a/AlRunner/Patches/PageControlExpression.cs
+++ b/AlRunner/Patches/PageControlExpression.cs
@@ -1,0 +1,540 @@
+// Evaluate the AL "client expression" the compiler writes into a page control's Visible,
+// Editable or Enabled property.
+//
+// These properties do not take a variable name. They take an expression, and the AL compiler
+// writes its SOURCE TEXT into the page metadata with the identifiers already resolved to their
+// emitted spelling. Measured on BC 28.1, for a page 65901 with globals HideIt/LockIt/Flag2 and a
+// source table carrying Value, Flag, Qty, Kind and "Spaced Name":
+//
+//   AL on the control                       metadata property text
+//   --------------------------------------  ----------------------------------------------
+//   Visible = HideIt                        p65901p65901HideIt
+//   Visible = not HideIt                    not p65901p65901HideIt
+//   Visible = HideIt and LockIt             p65901p65901HideIt and p65901p65901LockIt
+//   Visible = not (HideIt or LockIt)        not ( p65901p65901HideIt or p65901p65901LockIt )
+//   Visible = Rec.Flag                      Flag
+//   Visible = not Rec.Flag                  not Flag
+//   Visible = Rec.Value <> ''               Value <> ''
+//   Visible = Rec."Spaced Name"             "Spaced Name"
+//   Visible = Rec.Qty > 0                   Qty > 0
+//   Visible = Rec.Kind = Rec.Kind::Second   Kind = 1
+//   Visible = (Rec.Value = 'x') or Flag2    ( Value = 'x' ) or p65901p65901Flag2
+//   Visible = Rec.Qty > 1 + 1               Qty > 1 + 1
+//
+// Four things that shape the parser, all of them measured rather than assumed:
+//
+//   - A page global arrives under its emitted name and is registered in the page's
+//     SourceExpressions table. A source-table field arrives as the FIELD NAME and is not in that
+//     table at all, so identifier resolution has two sources, in that order.
+//   - An enum or option comparand is already an ORDINAL (`Kind = 1`), so nothing here has to
+//     resolve an enum member.
+//   - A name needing quoting keeps its AL double quotes (`"Spaced Name"`).
+//   - Tokens are separated by single spaces, but nothing may depend on that: the tokenizer reads
+//     the text character by character.
+//
+// The grammar is bounded by the compiler, which rejects a procedure call in one of these
+// properties: "AL0322: Procedure calls is not valid for client expressions. Client expressions can
+// only use simple data types and field references."
+//
+// Precedence follows AL's, which is Pascal's and NOT C's — `and` binds like multiplication, `or`
+// like addition, and the comparison operators are LOWEST. That is why `A = B and C` means
+// `A = (B and C)` in AL, and why AL code parenthesizes comparisons that it combines. Getting this
+// backwards would silently mis-evaluate expressions that parse either way.
+//
+// Anything this cannot parse, and any identifier that resolves to neither a registered expression
+// nor a field on the source record, is reported to the caller as a failure so it can raise
+// RunnerOutOfScopeException naming the expression. Per .claude/rules/loud-failures.md, an
+// expression we cannot evaluate must never come back as a default answer: `Visible` and `Editable`
+// ARE the page's contract, and inventing "true" for one makes every test of that contract
+// unfailable.
+
+using System.Globalization;
+
+namespace AlRunner.Patches;
+
+/// <summary>
+/// Parser and evaluator for the client-expression grammar the AL compiler writes into a page
+/// control's boolean properties. Pure: identifier and field resolution are supplied by the caller.
+/// </summary>
+internal static class PageControlExpression
+{
+    /// <summary>
+    /// Evaluate <paramref name="text"/> to a Boolean.
+    ///
+    /// Returns false and sets <paramref name="failure"/> when the text cannot be parsed, an
+    /// identifier cannot be resolved, an operator is applied to operands it does not accept, or
+    /// the result is not a Boolean. The caller turns that into a loud out-of-scope failure; this
+    /// method never guesses a value.
+    /// </summary>
+    /// <param name="resolve">
+    /// Resolves one identifier to its current value. Returns false when the name is neither a
+    /// registered source expression nor a field on the page's source record.
+    /// </param>
+    internal static bool TryEvaluateBoolean(
+        string text,
+        ResolveIdentifier resolve,
+        out bool value,
+        out string? failure)
+    {
+        value = false;
+        failure = null;
+
+        if (!TryTokenize(text, out var tokens, out failure)) return false;
+
+        var parser = new Parser(tokens, resolve);
+        if (!parser.TryParse(out var result, out failure)) return false;
+
+        if (result is not bool b)
+        {
+            failure = $"it evaluated to '{Describe(result)}', which is not a Boolean";
+            return false;
+        }
+
+        value = b;
+        return true;
+    }
+
+    /// <summary>
+    /// Resolve one identifier — a registered source-expression name, or a field name on the
+    /// page's source record — to its current value. <paramref name="quoted"/> says the name
+    /// arrived in AL double quotes, which only ever happens for a field name.
+    /// </summary>
+    internal delegate bool ResolveIdentifier(string name, bool quoted, out object? value);
+
+    // ---- tokens -------------------------------------------------------------------------------
+
+    internal enum TokenKind { Identifier, QuotedIdentifier, Number, String, Operator, LeftParen, RightParen }
+
+    internal readonly record struct Token(TokenKind Kind, string Text);
+
+    /// <summary>
+    /// Split the property text into tokens. Whitespace separates but is not required to: the
+    /// emitted form puts single spaces around every operator, and this does not rely on that.
+    /// </summary>
+    internal static bool TryTokenize(string text, out List<Token> tokens, out string? failure)
+    {
+        tokens = new List<Token>();
+        failure = null;
+
+        var i = 0;
+        while (i < text.Length)
+        {
+            var c = text[i];
+
+            if (char.IsWhiteSpace(c)) { i++; continue; }
+
+            if (c == '(') { tokens.Add(new Token(TokenKind.LeftParen, "(")); i++; continue; }
+            if (c == ')') { tokens.Add(new Token(TokenKind.RightParen, ")")); i++; continue; }
+
+            // AL string literal: single quotes, with '' as an escaped quote.
+            if (c == '\'')
+            {
+                i++;
+                var literal = new System.Text.StringBuilder();
+                var closed = false;
+                while (i < text.Length)
+                {
+                    if (text[i] == '\'')
+                    {
+                        if (i + 1 < text.Length && text[i + 1] == '\'') { literal.Append('\''); i += 2; continue; }
+                        i++; closed = true; break;
+                    }
+                    literal.Append(text[i]); i++;
+                }
+                if (!closed) { failure = "it contains an unterminated string literal"; return false; }
+                tokens.Add(new Token(TokenKind.String, literal.ToString()));
+                continue;
+            }
+
+            // AL quoted identifier: double quotes, for a name that needs them ("Spaced Name").
+            if (c == '"')
+            {
+                i++;
+                var name = new System.Text.StringBuilder();
+                var closed = false;
+                while (i < text.Length)
+                {
+                    if (text[i] == '"')
+                    {
+                        if (i + 1 < text.Length && text[i + 1] == '"') { name.Append('"'); i += 2; continue; }
+                        i++; closed = true; break;
+                    }
+                    name.Append(text[i]); i++;
+                }
+                if (!closed) { failure = "it contains an unterminated quoted name"; return false; }
+                tokens.Add(new Token(TokenKind.QuotedIdentifier, name.ToString()));
+                continue;
+            }
+
+            if (char.IsDigit(c))
+            {
+                var start = i;
+                while (i < text.Length && (char.IsDigit(text[i]) || text[i] == '.')) i++;
+                tokens.Add(new Token(TokenKind.Number, text[start..i]));
+                continue;
+            }
+
+            // An identifier the compiler emitted. Page globals come out as p<id>p<id><Name>;
+            // field names come out as written. Underscores appear in both.
+            if (char.IsLetter(c) || c == '_')
+            {
+                var start = i;
+                while (i < text.Length && (char.IsLetterOrDigit(text[i]) || text[i] == '_')) i++;
+                tokens.Add(new Token(TokenKind.Identifier, text[start..i]));
+                continue;
+            }
+
+            // Two-character operators first, so <> and <= are not read as < followed by junk.
+            if (i + 1 < text.Length)
+            {
+                var pair = text.Substring(i, 2);
+                if (pair is "<>" or "<=" or ">=")
+                {
+                    tokens.Add(new Token(TokenKind.Operator, pair)); i += 2; continue;
+                }
+            }
+
+            if (c is '=' or '<' or '>' or '+' or '-' or '*' or '/')
+            {
+                tokens.Add(new Token(TokenKind.Operator, c.ToString())); i++; continue;
+            }
+
+            failure = $"it contains the character '{c}', which is not part of the client-expression grammar";
+            return false;
+        }
+
+        return true;
+    }
+
+    // ---- parser -------------------------------------------------------------------------------
+
+    // AL's precedence, lowest binding first. This is Pascal's, not C's: `and` sits with the
+    // multiplying operators and `or` with the adding ones, so the comparison operators bind
+    // loosest of all.
+    //
+    //   1. = <> < <= > >=        (lowest)
+    //   2. + - or xor
+    //   3. * / div mod and
+    //   4. not, unary + -        (highest)
+    private sealed class Parser
+    {
+        private readonly List<Token> _tokens;
+        private readonly ResolveIdentifier _resolve;
+        private int _at;
+        private string? _failure;
+
+        internal Parser(List<Token> tokens, ResolveIdentifier resolve)
+        {
+            _tokens = tokens;
+            _resolve = resolve;
+        }
+
+        internal bool TryParse(out object? result, out string? failure)
+        {
+            result = null;
+            failure = null;
+
+            if (_tokens.Count == 0)
+            {
+                failure = "it is empty";
+                return false;
+            }
+
+            var value = Comparison();
+            if (_failure != null) { failure = _failure; return false; }
+
+            if (_at != _tokens.Count)
+            {
+                failure = $"there is unparsed text starting at '{_tokens[_at].Text}'";
+                return false;
+            }
+
+            result = value;
+            return true;
+        }
+
+        private Token? Peek => _at < _tokens.Count ? _tokens[_at] : null;
+
+        private bool NextIsOperator(params string[] names)
+        {
+            var t = Peek;
+            if (t is not { Kind: TokenKind.Operator or TokenKind.Identifier }) return false;
+            foreach (var n in names)
+                if (string.Equals(t.Value.Text, n, StringComparison.OrdinalIgnoreCase)) return true;
+            return false;
+        }
+
+        private object? Comparison()
+        {
+            var left = Additive();
+            if (_failure != null) return null;
+
+            while (NextIsOperator("=", "<>", "<", "<=", ">", ">="))
+            {
+                var op = _tokens[_at++].Text;
+                var right = Additive();
+                if (_failure != null) return null;
+                left = Compare(op, left, right);
+                if (_failure != null) return null;
+            }
+            return left;
+        }
+
+        private object? Additive()
+        {
+            var left = Multiplicative();
+            if (_failure != null) return null;
+
+            while (NextIsOperator("+", "-", "or", "xor"))
+            {
+                var op = _tokens[_at++].Text;
+                var right = Multiplicative();
+                if (_failure != null) return null;
+                left = Binary(op, left, right);
+                if (_failure != null) return null;
+            }
+            return left;
+        }
+
+        private object? Multiplicative()
+        {
+            var left = Unary();
+            if (_failure != null) return null;
+
+            while (NextIsOperator("*", "/", "div", "mod", "and"))
+            {
+                var op = _tokens[_at++].Text;
+                var right = Unary();
+                if (_failure != null) return null;
+                left = Binary(op, left, right);
+                if (_failure != null) return null;
+            }
+            return left;
+        }
+
+        private object? Unary()
+        {
+            if (NextIsOperator("not"))
+            {
+                _at++;
+                var operand = Unary();
+                if (_failure != null) return null;
+                if (operand is not bool b)
+                {
+                    _failure = $"'not' was applied to '{Describe(operand)}', which is not a Boolean";
+                    return null;
+                }
+                return !b;
+            }
+
+            if (NextIsOperator("-"))
+            {
+                _at++;
+                var operand = Unary();
+                if (_failure != null) return null;
+                if (!TryAsNumber(operand, out var d))
+                {
+                    _failure = $"unary '-' was applied to '{Describe(operand)}', which is not a number";
+                    return null;
+                }
+                return -d;
+            }
+
+            if (NextIsOperator("+")) { _at++; return Unary(); }
+
+            return Primary();
+        }
+
+        private object? Primary()
+        {
+            var t = Peek;
+            if (t == null)
+            {
+                _failure = "it ends where a value was expected";
+                return null;
+            }
+
+            switch (t.Value.Kind)
+            {
+                case TokenKind.LeftParen:
+                {
+                    _at++;
+                    var inner = Comparison();
+                    if (_failure != null) return null;
+                    if (Peek is not { Kind: TokenKind.RightParen })
+                    {
+                        _failure = "a '(' is not closed";
+                        return null;
+                    }
+                    _at++;
+                    return inner;
+                }
+
+                case TokenKind.String:
+                    _at++;
+                    return t.Value.Text;
+
+                case TokenKind.Number:
+                    _at++;
+                    if (!decimal.TryParse(t.Value.Text, NumberStyles.Number, CultureInfo.InvariantCulture, out var n))
+                    {
+                        _failure = $"'{t.Value.Text}' is not a number this can read";
+                        return null;
+                    }
+                    return n;
+
+                case TokenKind.QuotedIdentifier:
+                    _at++;
+                    return Resolve(t.Value.Text, quoted: true);
+
+                case TokenKind.Identifier:
+                {
+                    // `true` and `false` are the only reserved words that reach here as values.
+                    // Every other word is a name. `not`/`and`/`or`/`xor`/`div`/`mod` are consumed
+                    // as operators before Primary ever sees them.
+                    if (string.Equals(t.Value.Text, "true", StringComparison.OrdinalIgnoreCase)) { _at++; return true; }
+                    if (string.Equals(t.Value.Text, "false", StringComparison.OrdinalIgnoreCase)) { _at++; return false; }
+                    _at++;
+                    return Resolve(t.Value.Text, quoted: false);
+                }
+
+                default:
+                    _failure = $"'{t.Value.Text}' cannot start a value";
+                    return null;
+            }
+        }
+
+        private object? Resolve(string name, bool quoted)
+        {
+            if (_resolve(name, quoted, out var value)) return value;
+            _failure = $"'{name}' is neither an expression the page publishes a binding for "
+                     + "nor a field on its source record";
+            return null;
+        }
+
+        private object? Binary(string op, object? left, object? right)
+        {
+            if (string.Equals(op, "and", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(op, "or", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(op, "xor", StringComparison.OrdinalIgnoreCase))
+            {
+                // Both operands are already evaluated. AL's `and`/`or` do not short-circuit
+                // either, so evaluating both is faithful, and there is nothing here that could
+                // have a side effect: the grammar has no procedure calls in it.
+                if (left is not bool l || right is not bool r)
+                {
+                    _failure = $"'{op}' was applied to '{Describe(left)}' and '{Describe(right)}', "
+                             + "which are not both Boolean";
+                    return null;
+                }
+                return op.ToLowerInvariant() switch
+                {
+                    "and" => l && r,
+                    "or" => l || r,
+                    _ => l ^ r,
+                };
+            }
+
+            if (!TryAsNumber(left, out var a) || !TryAsNumber(right, out var b))
+            {
+                _failure = $"'{op}' was applied to '{Describe(left)}' and '{Describe(right)}', "
+                         + "which are not both numbers";
+                return null;
+            }
+
+            switch (op.ToLowerInvariant())
+            {
+                case "+": return a + b;
+                case "-": return a - b;
+                case "*": return a * b;
+                case "/":
+                case "div":
+                case "mod":
+                    if (b == 0)
+                    {
+                        _failure = $"'{op}' would divide by zero";
+                        return null;
+                    }
+                    return op.ToLowerInvariant() switch
+                    {
+                        "/" => a / b,
+                        "div" => decimal.Truncate(a / b),
+                        _ => a % b,
+                    };
+                default:
+                    _failure = $"'{op}' is not an operator this can evaluate";
+                    return null;
+            }
+        }
+
+        private object? Compare(string op, object? left, object? right)
+        {
+            int order;
+
+            if (left is string || right is string)
+            {
+                // AL compares Text and Code case-insensitively, so 'a' = 'A' is true. Using an
+                // ordinal comparison here would answer differently from BC on exactly the shape
+                // these properties are written in.
+                order = string.Compare(
+                    left as string ?? Describe(left),
+                    right as string ?? Describe(right),
+                    StringComparison.OrdinalIgnoreCase);
+            }
+            else if (left is bool lb && right is bool rb)
+            {
+                order = lb.CompareTo(rb);
+            }
+            else if (TryAsNumber(left, out var a) && TryAsNumber(right, out var b))
+            {
+                order = a.CompareTo(b);
+            }
+            else if (left == null || right == null)
+            {
+                order = left == null && right == null ? 0 : 1;
+            }
+            else
+            {
+                _failure = $"'{op}' was applied to '{Describe(left)}' and '{Describe(right)}', "
+                         + "which this cannot compare";
+                return null;
+            }
+
+            return op switch
+            {
+                "=" => order == 0,
+                "<>" => order != 0,
+                "<" => order < 0,
+                "<=" => order <= 0,
+                ">" => order > 0,
+                ">=" => order >= 0,
+                _ => null,
+            };
+        }
+    }
+
+    private static bool TryAsNumber(object? value, out decimal number)
+    {
+        switch (value)
+        {
+            case decimal d: number = d; return true;
+            case int i: number = i; return true;
+            case long l: number = l; return true;
+            case short s: number = s; return true;
+            case byte b: number = b; return true;
+            case double db: number = (decimal)db; return true;
+            case float f: number = (decimal)f; return true;
+            default: number = 0; return false;
+        }
+    }
+
+    /// <summary>A value's spelling for a failure message. Never used to compute an answer.</summary>
+    internal static string Describe(object? value)
+        => value switch
+        {
+            null => "null",
+            bool b => b ? "true" : "false",
+            IFormattable f => f.ToString(null, CultureInfo.InvariantCulture),
+            _ => value.ToString() ?? "null",
+        };
+}

--- a/AlRunner/Patches/PageControlExpression.cs
+++ b/AlRunner/Patches/PageControlExpression.cs
@@ -489,12 +489,12 @@ internal static class PageControlExpression
             {
                 order = a.CompareTo(b);
             }
-            else if (left == null || right == null)
-            {
-                order = left == null && right == null ? 0 : 1;
-            }
             else
             {
+                // No invented ordering for a missing operand. AL has no null here — a blank Text
+                // arrives as "" and a zero Decimal as 0, both measured — so a null means the
+                // identifier resolved to something this does not understand, and answering the
+                // comparison anyway would put a value the runner made up into a page's contract.
                 _failure = $"'{op}' was applied to '{Describe(left)}' and '{Describe(right)}', "
                          + "which this cannot compare";
                 return null;

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -524,28 +524,26 @@ internal sealed class RunnerPageInstance
     /// <summary>
     /// Resolve one identifier inside a control-property expression.
     ///
-    /// Two sources, in BC's own order. A page global is registered in the page's source-expression
-    /// table under the emitted name the metadata carries. A source-table field is not in that table
-    /// at all — the metadata carries the FIELD NAME — so it is read off the record the page is
-    /// bound to. A name in neither is a genuine failure and must not resolve to a default.
+    /// Registered source expressions only. A page global is registered in the page's
+    /// source-expression table under the emitted name the metadata carries, and that is the one
+    /// source this resolves against.
+    ///
+    /// A source-table FIELD reference is deliberately NOT resolved here, even though the metadata
+    /// carries the field name and the record is right there. Measured on all 8 BC versions
+    /// (corpus PR #125's measurement pass): real BC evaluates such an expression as if the field
+    /// held its type default, whatever row the page is on — opening a card on a row with
+    /// Flag = true and on a row with Flag = false produced byte-identical readings of
+    /// `Visible = Rec.Flag`, `Visible = not Rec.Flag` and `Visible = Rec.Value &lt;&gt; ''`.
+    /// Reading the live record would therefore answer something BC does not answer, and a value
+    /// this runner made up is worse than the loud refusal the caller raises instead
+    /// (.claude/rules/loud-failures.md). Issue #2596 tracks it, with the transcripts.
     /// </summary>
     private bool ResolveExpressionIdentifier(string name, bool quoted, out object? value)
     {
-        // An unquoted name can be either; a quoted one is always a field, because the emitted
-        // spelling of a page global never needs quoting. Trying the expression table for both is
-        // harmless and keeps the two paths from having to agree on that.
         var expression = _sourceExpressions[name];
         if (expression != null)
         {
             value = GetValue(expression)?.ClientObject;
-            return true;
-        }
-
-        var metaTable = _record?.MetaTable;
-        if (metaTable != null && metaTable.TryGetFieldByName(name, out var field) && field != null)
-        {
-            var raw = _record!.GetFieldValue(field.FieldNo);
-            value = raw is NavValue navValue ? navValue.ClientObject : raw;
             return true;
         }
 

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -490,24 +490,67 @@ internal sealed class RunnerPageInstance
         if (string.Equals(raw, "true", StringComparison.OrdinalIgnoreCase) || raw == "1") return true;
         if (string.Equals(raw, "false", StringComparison.OrdinalIgnoreCase) || raw == "0") return false;
 
+        // The whole property text as one registered name. This is the shape a bare page global
+        // takes, it is by far the most common one, and taking it first means the parser below
+        // never sees a name whose own spelling happens to contain grammar characters.
         var expression = _sourceExpressions[raw];
-        if (expression == null)
-            // Loudly, not true-by-default: this property IS the page's read-only contract,
-            // and answering "editable" for one we could not evaluate makes every test of
-            // that contract unfailable. Naming the expression is what makes the gap fixable.
-            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                $"TestPage page {_pageId} element {elementId} — {propertyName}",
-                $"testpage-control-property — the property is bound to expression '{raw}', which "
-                + "the page publishes no binding for, so its value cannot be evaluated. "
-                + "See docs/scope.md");
+        if (expression != null)
+        {
+            var direct = GetValue(expression);
+            return direct?.ClientObject is bool db
+                ? db
+                : throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                    $"TestPage page {_pageId} element {elementId} — {propertyName}",
+                    $"testpage-control-property — expression '{raw}' evaluated to "
+                    + $"'{direct?.ClientObject ?? "null"}', which is not a Boolean. See docs/scope.md");
+        }
 
-        var value = GetValue(expression);
-        return value?.ClientObject is bool b
-            ? b
-            : throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                $"TestPage page {_pageId} element {elementId} — {propertyName}",
-                $"testpage-control-property — expression '{raw}' evaluated to "
-                + $"'{value?.ClientObject ?? "null"}', which is not a Boolean. See docs/scope.md");
+        // Not one bare name, so it is an expression: `not Flag`, `A and B`, `Value <> ''`. The
+        // AL compiler writes the source text of these properties into the metadata with the
+        // identifiers already resolved to their emitted spelling — see PageControlExpression for
+        // the measured shapes and the grammar.
+        if (PageControlExpression.TryEvaluateBoolean(raw, ResolveExpressionIdentifier, out var evaluated, out var why))
+            return evaluated;
+
+        // Loudly, not true-by-default: this property IS the page's read-only contract, and
+        // answering "editable" for one we could not evaluate makes every test of that contract
+        // unfailable. Naming the expression and what went wrong is what makes the gap fixable.
+        throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            $"TestPage page {_pageId} element {elementId} — {propertyName}",
+            $"testpage-control-property — the property is bound to expression '{raw}', which "
+            + $"cannot be evaluated: {why}. See docs/scope.md");
+    }
+
+    /// <summary>
+    /// Resolve one identifier inside a control-property expression.
+    ///
+    /// Two sources, in BC's own order. A page global is registered in the page's source-expression
+    /// table under the emitted name the metadata carries. A source-table field is not in that table
+    /// at all — the metadata carries the FIELD NAME — so it is read off the record the page is
+    /// bound to. A name in neither is a genuine failure and must not resolve to a default.
+    /// </summary>
+    private bool ResolveExpressionIdentifier(string name, bool quoted, out object? value)
+    {
+        // An unquoted name can be either; a quoted one is always a field, because the emitted
+        // spelling of a page global never needs quoting. Trying the expression table for both is
+        // harmless and keeps the two paths from having to agree on that.
+        var expression = _sourceExpressions[name];
+        if (expression != null)
+        {
+            value = GetValue(expression)?.ClientObject;
+            return true;
+        }
+
+        var metaTable = _record?.MetaTable;
+        if (metaTable != null && metaTable.TryGetFieldByName(name, out var field) && field != null)
+        {
+            var raw = _record!.GetFieldValue(field.FieldNo);
+            value = raw is NavValue navValue ? navValue.ClientObject : raw;
+            return true;
+        }
+
+        value = null;
+        return false;
     }
 
     /// <summary>

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -44,6 +44,7 @@ internal sealed class RunnerPageInstance
     private readonly NavRecord? _record;
     private readonly int _pageId;
     private readonly System.Collections.IDictionary _sourceExpressions;
+    private Dictionary<string, object?> _expressionValuesAtOpen;
 
     // Lazily-constructed NavFormExtension instances for the pageextensions that extend
     // this page (issue #1923) — one per extension id, built on first trigger lookup and
@@ -71,6 +72,42 @@ internal sealed class RunnerPageInstance
         _record = record;
         _pageId = pageId;
         _sourceExpressions = sourceExpressions;
+        _expressionValuesAtOpen = SnapshotExpressionValues(sourceExpressions);
+    }
+
+    /// <summary>
+    /// Every registered source expression's value as it stands when the page is built.
+    ///
+    /// A control's OWN Visible is answered from this, not from the live table — measured on
+    /// all 8 BC versions through corpus PR #125: after a TestPage changes a page global that
+    /// a control's Visible is bound to, BC keeps reporting the value from when the page was
+    /// opened, while the same control's Editable and Enabled do follow the change. A group's
+    /// Visible follows it too (corpus TestPageFieldVisibleGroup_Tests flips a group after
+    /// open and is green on real BC), so only the control's own Visible is frozen here.
+    ///
+    /// Snapshotting the VALUES rather than eagerly evaluating every control's expression
+    /// keeps the loud failure where it belongs: an expression that cannot be evaluated still
+    /// raises at the read that asks for it, naming the control, instead of turning one
+    /// unreadable property into a page-construction failure for the whole page.
+    /// </summary>
+    internal static Dictionary<string, object?> SnapshotExpressionValues(System.Collections.IDictionary expressions)
+    {
+        var snapshot = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (System.Collections.DictionaryEntry entry in expressions)
+        {
+            if (entry.Key is not string name || entry.Value == null) continue;
+            try
+            {
+                snapshot[name] = GetValue(entry.Value)?.ClientObject;
+            }
+            catch
+            {
+                // One expression that cannot be read at open time must not cost the page its
+                // whole snapshot. Omitting it means the control bound to it falls back to the
+                // live value, which is what this did before the snapshot existed.
+            }
+        }
+        return snapshot;
     }
 
     internal object Form => _form;
@@ -342,10 +379,10 @@ internal sealed class RunnerPageInstance
 
     /// <summary>Editable for a data-bound control, combined with the page's own state.</summary>
     internal bool ControlEditable(int controlId)
-        => PageEditable && EvaluateProperty(ControlDefinition(controlId)?.Editable, "Editable", controlId);
+        => PageEditable && EvaluateProperty(ControlDefinition(controlId)?.Editable, "Editable", controlId, atOpen: false);
 
     internal bool ControlEnabled(int controlId)
-        => EvaluateProperty(ControlDefinition(controlId)?.Enabled, "Enabled", controlId);
+        => EvaluateProperty(ControlDefinition(controlId)?.Enabled, "Enabled", controlId, atOpen: false);
 
     /// <summary>
     /// A control's effective visibility is its own <c>Visible</c> combined with EVERY
@@ -365,7 +402,9 @@ internal sealed class RunnerPageInstance
     /// </summary>
     internal bool ControlVisible(int controlId)
     {
-        if (!EvaluateProperty(ControlDefinition(controlId)?.Visible, "Visible", controlId))
+        // atOpen: the control's OWN Visible is the one property real BC does not re-evaluate
+        // after the page is open. See SnapshotExpressionValues.
+        if (!EvaluateProperty(ControlDefinition(controlId)?.Visible, "Visible", controlId, atOpen: true))
             return false;
 
         if (_form is not NavForm form) return true;
@@ -390,7 +429,10 @@ internal sealed class RunnerPageInstance
             if (parent is not Microsoft.Dynamics.Nav.Types.Metadata.ControlGroupDefinition group)
                 return true;
 
-            if (!EvaluateProperty(group.Visible, "Visible", group.ID))
+            // LIVE, unlike the control's own Visible above. Corpus
+            // TestPageFieldVisibleGroup_Tests flips a group's Visible expression after the
+            // page is open and reads a field inside it as newly visible, green on real BC.
+            if (!EvaluateProperty(group.Visible, "Visible", group.ID, atOpen: false))
                 return false;
 
             currentId = group.ID;
@@ -464,10 +506,13 @@ internal sealed class RunnerPageInstance
         => raw != null && (string.Equals(raw, "false", StringComparison.OrdinalIgnoreCase) || raw == "0");
 
     internal bool ActionEnabled(int actionId)
-        => EvaluateProperty(ActionDefinition(actionId)?.Enabled, "Enabled", actionId);
+        => EvaluateProperty(ActionDefinition(actionId)?.Enabled, "Enabled", actionId, atOpen: false);
 
+    // Live, like every other property except a CONTROL's own Visible. An action's own Visible
+    // has not been measured against real BC either way, so it keeps the behaviour it had
+    // rather than inheriting a freeze from a measurement that was not about it.
     internal bool ActionVisible(int actionId)
-        => EvaluateProperty(ActionDefinition(actionId)?.Visible, "Visible", actionId);
+        => EvaluateProperty(ActionDefinition(actionId)?.Visible, "Visible", actionId, atOpen: false);
 
     private Microsoft.Dynamics.Nav.Types.Metadata.ControlDefinition? ControlDefinition(int controlId)
         => _form is NavForm form && form.MetadataHelper.TryGetControlDefinitionById(controlId, out var d) ? d : null;
@@ -479,7 +524,7 @@ internal sealed class RunnerPageInstance
     /// Resolve one of the boolean control properties. Absent means the AL declared none, and
     /// the AL default for all three is true.
     /// </summary>
-    private bool EvaluateProperty(string? raw, string propertyName, int elementId)
+    private bool EvaluateProperty(string? raw, string propertyName, int elementId, bool atOpen)
     {
         if (string.IsNullOrEmpty(raw)) return true;
 
@@ -493,6 +538,14 @@ internal sealed class RunnerPageInstance
         // The whole property text as one registered name. This is the shape a bare page global
         // takes, it is by far the most common one, and taking it first means the parser below
         // never sees a name whose own spelling happens to contain grammar characters.
+        if (atOpen && _expressionValuesAtOpen.TryGetValue(raw, out var frozen))
+            return frozen is bool fb
+                ? fb
+                : throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                    $"TestPage page {_pageId} element {elementId} — {propertyName}",
+                    $"testpage-control-property — expression '{raw}' evaluated to "
+                    + $"'{frozen ?? "null"}', which is not a Boolean. See docs/scope.md");
+
         var expression = _sourceExpressions[raw];
         if (expression != null)
         {
@@ -509,7 +562,10 @@ internal sealed class RunnerPageInstance
         // AL compiler writes the source text of these properties into the metadata with the
         // identifiers already resolved to their emitted spelling — see PageControlExpression for
         // the measured shapes and the grammar.
-        if (PageControlExpression.TryEvaluateBoolean(raw, ResolveExpressionIdentifier, out var evaluated, out var why))
+        if (PageControlExpression.TryEvaluateBoolean(
+                raw,
+                atOpen ? ResolveExpressionIdentifierAtOpen : ResolveExpressionIdentifier,
+                out var evaluated, out var why))
             return evaluated;
 
         // Loudly, not true-by-default: this property IS the page's read-only contract, and
@@ -538,6 +594,17 @@ internal sealed class RunnerPageInstance
     /// this runner made up is worse than the loud refusal the caller raises instead
     /// (.claude/rules/loud-failures.md). Issue #2596 tracks it, with the transcripts.
     /// </summary>
+    /// <summary>
+    /// The same resolution as <see cref="ResolveExpressionIdentifier"/>, but answering from the
+    /// open-time snapshot. Used only for a control's own Visible — the one property real BC
+    /// does not re-evaluate after the page is open.
+    /// </summary>
+    private bool ResolveExpressionIdentifierAtOpen(string name, bool quoted, out object? value)
+    {
+        if (_expressionValuesAtOpen.TryGetValue(name, out value)) return true;
+        return ResolveExpressionIdentifier(name, quoted, out value);
+    }
+
     private bool ResolveExpressionIdentifier(string name, bool quoted, out object? value)
     {
         var expression = _sourceExpressions[name];
@@ -937,7 +1004,17 @@ internal sealed class RunnerPageInstance
     /// missing record rather than a trigger that never ran.
     /// </summary>
     internal void RaiseOnOpenPage()
-        => InvokeRecordTrigger("OnOpenPage", Type.EmptyTypes, Array.Empty<object>());
+    {
+        InvokeRecordTrigger("OnOpenPage", Type.EmptyTypes, Array.Empty<object>());
+
+        // Re-take the open-time snapshot AFTER the trigger, not before. OnOpenPage is where a
+        // page seeds the globals its control properties are bound to, and the constructor runs
+        // well before it — snapshotting only there froze every such global at its type default,
+        // which the corpus caught immediately: the five TPCE tests whose global is true at open
+        // all failed. The constructor still takes one, so a page whose OnOpenPage never runs
+        // still has a snapshot rather than none.
+        _expressionValuesAtOpen = SnapshotExpressionValues(_sourceExpressions);
+    }
 
     /// <summary>
     /// Run the page's OnQueryClosePage / OnClosePage triggers, in BC's order. OnQueryClosePage


### PR DESCRIPTION
Two things, both settled by measurement against real BC on all 8 versions rather than by reading the AL: **what** a control property expression evaluates to, and **when** it is evaluated. The runner was wrong about both.

## 1. The expression was never parsed

`Visible`, `Editable` and `Enabled` on a page control take an AL client expression, not a variable name. `RunnerPageInstance.EvaluateProperty` treated the whole property text as one registered expression name, so anything that was not a single bare identifier missed the `SourceExpressions` lookup and raised `RunnerOutOfScopeException`. `Visible = not Flag` was refused. The Base Application source for 28.1 has 692 negated ones: 394 `Visible`, 214 `Enabled`, 84 `Editable`.

`PageControlExpression` parses the grammar the compiler actually writes, with AL's precedence — Pascal's, not C's: `and` binds like multiplication, `or` like addition, and the comparison operators bind loosest, so `A = B and C` means `A = (B and C)`. Two unit tests pick operands where the two readings disagree, because a test that passes under either proves nothing about which is implemented.

Measured on BC 28.1, for a page with globals HideIt/LockIt/Flag2 over a table carrying Value, Flag, Qty, Kind and "Spaced Name":

| AL on the control | Metadata property text |
|---|---|
| `Visible = not HideIt` | `not p65901p65901HideIt` |
| `Visible = HideIt and LockIt` | `p65901p65901HideIt and p65901p65901LockIt` |
| `Visible = not (HideIt or LockIt)` | `not ( p65901p65901HideIt or p65901p65901LockIt )` |
| `Visible = Rec.Flag` | `Flag` |
| `Visible = Rec.Value <> ''` | `Value <> ''` |
| `Visible = Rec."Spaced Name"` | `"Spaced Name"` |
| `Visible = Rec.Kind = Rec.Kind::Second` | `Kind = 1` |
| `Visible = Rec.Qty > 1 + 1` | `Qty > 1 + 1` |

A page global arrives under its emitted name and is in the `SourceExpressions` table; a source-table field arrives as the bare field **name** and is not; an enum comparand is already an ordinal; a quoted name keeps its quotes; arithmetic appears. The grammar is bounded — the compiler rejects a procedure call here with AL0322.

## 2. Every property was live. Only two of them should be.

This is the part the corpus falsified, and it was wrong **before this branch as well as on it** — `EvaluateProperty` always read the expression live, including for the bare-identifier case that already worked.

Measured on all 8 BC versions through [corpus PR #125](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/125), transcripts byte-identical on every one: after a TestPage changes a page global, a control's **own `Visible`** keeps the value it had when the page was opened, while the **same control's `Editable` and `Enabled` follow the change**. A **group's** `Visible` follows it too — corpus `TestPageFieldVisibleGroup_Tests` flips a group's expression after open, reads a field inside it as newly visible, and is green on real BC.

So exactly one property is frozen and everything around it is live. `RunnerPageInstance` now snapshots every registered source expression's value and answers a control's own `Visible` from that snapshot; the ancestor-group walk, `Editable`, `Enabled` and an action's `Enabled` read live.

An **action's own `Visible`** stays live: that case has not been measured either way, so it keeps the behavior it had rather than inheriting a freeze from a measurement that was not about it.

The snapshot is taken **after `OnOpenPage`**, not only in the constructor. `OnOpenPage` is where a page seeds the globals these properties are bound to, and the constructor runs well before it — snapshotting only there froze every such global at its type default, which the corpus caught at once: the five TPCE tests whose global is true at open all failed. The constructor still takes one, so a page whose `OnOpenPage` never runs has a snapshot rather than none.

Snapshotting the **values** rather than eagerly evaluating every control's expression keeps the loud failure where it belongs: an unevaluable expression still raises at the read that asks for it, naming the control, instead of turning one unreadable property into a page-construction failure for the whole page.

## 3. Source-table field references — deliberately not changed here

Measured in the same pass: an expression referencing a source-table field evaluates as if the field held its **type default**, whatever row the page is on. A card opened on a row with `Flag = true` and then on a row with `Flag = false` read `Visible = Rec.Flag` false both times, and `Visible = Rec.Value <> ''` false while `Value` held `'Some Value'` — with the page on the right row, since a control's `Value()` returned `'Some Value'` on one open and blank on the other.

An earlier revision of this branch resolved those from the live record. That answers something BC does not answer, so it was removed: a field reference keeps raising `RunnerOutOfScopeException`, exactly as before this branch — a loud refusal rather than an invented value. Reproducing the type-default answer is its own change and needs its own corpus test first; #2596 tracks it with the transcripts.

## Verification

- End to end on BC 28.1, one global driving all three properties: **before** `open=111 after=000` (all live), **after** `open=111 after=100` (Visible frozen, the other two live) — which is BC's transcript.
- All 12 TPCE tests from the now-merged corpus suite pass; the corpus is otherwise unchanged.
- 58 C# tests. Five pin the snapshot mechanism, each half the other's control: the snapshot keeps its value when the expression changes, a live read through the same accessor sees that change, every expression is captured separately, one unreadable expression does not cost the page its snapshot, and a null entry is not snapshotted as a null value. The rest pin the parser, including 13 that assert a specific failure message rather than a value.

[Corpus PR #133](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/133) adds the BC-behavior test for the liveness split. The submodule pin bump is deliberately not in this PR — per #2485 the orchestrator does one catch-up bump for the wave.

## Credit

Found by Mikkel Mansa Vilhelmsen (@vhn-mmv), who fixed the `not <identifier>` case in commit `e90eaca7` on his fork. Measuring the emitted text showed the same lookup refuses the rest of the grammar; measuring the corpus showed the timing was wrong too.

Closes #2546

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf