### PR TITLE
fix(server): make affectedOnly coverage attribution request-wide, not per-module

### DIFF
--- a/AlRunner.Tests/ServerAffectedSelectionMultiSourcePathsTests.cs
+++ b/AlRunner.Tests/ServerAffectedSelectionMultiSourcePathsTests.cs
@@ -163,4 +163,168 @@ public class ServerAffectedSelectionMultiSourcePathsTests
         Assert.False(selection3.GetProperty("forcedFull").GetBoolean(),
             $"expected narrowing to remain stable on an unchanged re-request, got: {string.Join(" | ", lines3)}");
     }
+
+    // #2535: the mirror problem to the one above. `AffectedOnly_DependencyEditBetweenRequests_StillNarrows`
+    // proves the CHANGED-object side survives a cross-bundle edit (#2492's PeekChangedObjects
+    // union). This proves the COVERAGE-attribution side: a test whose own execution reaches
+    // into a DEPENDENCY bundle's object must still get a real coverage entry (not "unmappable"),
+    // so narrowing can tell which of two cross-bundle-calling tests is actually affected by an
+    // edit — mirroring the single-bundle `AffectedOnly_ChangedObjectRunsOnlyIntersectingTests`
+    // shape (edit one helper, only the test that calls it reruns) but with the helpers declared
+    // in a SEPARATE (dependency) bundle from the tests that call them.
+    //
+    // Real-corpus measurement (Pageworks + Pageworks.Test, 1012 tests, instrumented attribution
+    // loop): of 1012 tests, 897 were `unmappable` (a statement's FilePath pointed into the
+    // Pageworks — dependency — bundle, which the Pageworks.Test module's own
+    // TryGetTrackedObjectsByPath map has no entry for), 106 were not-passed/no-statements, and
+    // only 9 mapped — every one of those 9 with a coverage-set SIZE OF EXACTLY 1 (their own
+    // declaring codeunit only). That rules out the competing "coverage sets are over-attributed
+    // and overlap everything" theory: mapped sets are minimal, not enormous — the defect is the
+    // 897 unmappable, not over-broad coverage among the few that do map.
+    private static string MakeAppBundleTwoHelpers(string root)
+    {
+        var dir = Path.Combine(root, "app2");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "a1b2c3d4-6003-4a11-9333-333333333333",
+          "name": "Multi Affected App2 SX",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 60380, "to": 60389 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "HelperA.al"), """
+        codeunit 60380 "Multi Affected Helper2A SX"
+        {
+            procedure ValueA(): Integer
+            begin
+                exit(1);
+            end;
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "HelperB.al"), """
+        codeunit 60381 "Multi Affected Helper2B SX"
+        {
+            procedure ValueB(): Integer
+            begin
+                exit(2);
+            end;
+        }
+        """);
+        return dir;
+    }
+
+    private static string MakeTestApp2Bundle(string root)
+    {
+        var dir = Path.Combine(root, "test-app2");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "a1b2c3d4-6004-4a11-9444-444444444444",
+          "name": "Multi Affected Test App2 SX",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "a1b2c3d4-6003-4a11-9333-333333333333", "name": "Multi Affected App2 SX",
+              "publisher": "AL Runner", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 60390, "to": 60399 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Tests.al"), """
+        codeunit 60390 "Multi Affected Tests2 SX"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure OnlyA()
+            var
+                H: Codeunit "Multi Affected Helper2A SX";
+            begin
+                if H.ValueA() <> 1 then
+                    Error('OnlyA failed');
+            end;
+
+            [Test]
+            procedure OnlyB()
+            var
+                H: Codeunit "Multi Affected Helper2B SX";
+            begin
+                if H.ValueB() <> 2 then
+                    Error('OnlyB failed');
+            end;
+        }
+        """);
+        return dir;
+    }
+
+    private static string RunTestsRequest2(string appDir, string testAppDir)
+        => JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            sourcePaths = new[] { appDir, testAppDir },
+            packagePaths = Array.Empty<string>(),
+            affectedOnly = true,
+            perTestCoverage = true,
+        });
+
+    [SkippableFact]
+    public async Task AffectedOnly_CrossBundleCoverage_RunsOnlyTheTestThatCallsTheEditedHelper()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-server-affected-crossbundle", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var appDir = MakeAppBundleTwoHelpers(root);
+        var testAppDir = MakeTestApp2Bundle(root);
+
+        await using var server = await CliServer.StartAsync(new[] { "--no-cache" });
+
+        // Request 1: first cycle (no baseline yet) — necessarily runs both tests and
+        // records their per-test coverage, which for EACH test crosses into the
+        // DEPENDENCY bundle's helper codeunit (a real cross-app call, not a hypothetical).
+        var lines1 = await server.SendRequestStreamingAsync(RunTestsRequest2(appDir, testAppDir));
+        var (events1, _) = ProtocolV2Streaming.Split(lines1);
+        Assert.Equal(2, events1.Count);
+        Assert.All(events1, e => Assert.Equal("pass", e.GetProperty("status").GetString()));
+
+        // Edit HelperA only — OnlyB's helper (HelperB) is untouched.
+        File.WriteAllText(Path.Combine(appDir, "HelperA.al"), """
+        codeunit 60380 "Multi Affected Helper2A SX"
+        {
+            procedure ValueA(): Integer
+            var
+                X: Integer;
+            begin
+                X := 1;
+                exit(X);
+            end;
+        }
+        """);
+
+        // Request 2: same warm process. [THEN] each test's coverage entry must have been
+        // built from a REQUEST-WIDE file-to-object map (not a per-module one), so its
+        // helper-codeunit statement resolved instead of making the whole test
+        // "unmappable" -> always-run. Editing HelperA must rerun ONLY OnlyA — before the
+        // fix, BOTH were unmappable and BOTH always reran regardless of what changed
+        // (ran=2, skipped=0, indistinguishable from a from-scratch run).
+        var lines2 = await server.SendRequestStreamingAsync(RunTestsRequest2(appDir, testAppDir));
+        var (events2, summary2) = ProtocolV2Streaming.Split(lines2);
+        Assert.True(summary2.TryGetProperty("selection", out var selection2), string.Join(" | ", lines2));
+        Assert.False(selection2.GetProperty("forcedFull").GetBoolean(),
+            $"expected affectedOnly to narrow across the bundle boundary, got: {string.Join(" | ", lines2)}");
+        Assert.Equal(1, selection2.GetProperty("ran").GetInt32());
+        Assert.Equal(1, selection2.GetProperty("skipped").GetInt32());
+        Assert.Single(events2);
+        Assert.EndsWith(".OnlyA", events2[0].GetProperty("name").GetString(), StringComparison.Ordinal);
+        Assert.Equal("pass", events2[0].GetProperty("status").GetString());
+        Assert.Contains(selection2.GetProperty("changedObjects").EnumerateArray().Select(x => x.GetString()),
+            x => x != null && x.Contains("Multi Affected Helper2A SX", StringComparison.Ordinal));
+    }
 }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5025,12 +5025,40 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                     .GroupBy(t => $"{t.Codeunit}.{t.Method}", StringComparer.Ordinal)
                     .ToDictionary(g => g.Key, g => g.Last(), StringComparer.Ordinal);
 
+                // #2535: file-to-object attribution must be REQUEST-WIDE (every bundle's
+                // module unioned into one map), not per-module. `statements` is RUNTIME
+                // coverage — it contains every statement the test actually executed,
+                // including statements in a DEPENDENCY bundle's files (a real cross-app
+                // call, not a hypothetical: see the Pageworks/Pageworks.Test repro in
+                // #2535, mirroring #2492's PeekChangedObjects cross-bundle case on the
+                // CHANGED-object side — see that method's docstring). A per-module map
+                // cannot resolve a path belonging to a sibling bundle's module, so a single
+                // ordinary cross-app helper call made the whole test "unmappable" ->
+                // permanently "unknown" -> the test reran on EVERY future edit no matter
+                // how unrelated, forever. Measured on the real corpus (1012 tests): 897
+                // were unmappable this way, only 9 ever got a real coverage entry, and
+                // every one of those 9 had a coverage-set size of exactly 1 (their own
+                // declaring codeunit only) — so the defect is unmappable cross-bundle
+                // statements, not over-broad coverage sets. Built ONCE per request (not
+                // per bundle) from every module this request has already resolved.
+                var requestWideTrackedObjectsByPath = new Dictionary<string, AffectedObjectId>(StringComparer.Ordinal);
+                foreach (var trackedModuleName in requestModuleByBundle.Values.Distinct(StringComparer.Ordinal))
+                {
+                    var m = emitter.TryGetTrackedObjectsByPath(trackedModuleName);
+                    if (m == null) continue;
+                    foreach (var kv in m)
+                        requestWideTrackedObjectsByPath[kv.Key] = kv.Value;
+                }
+
                 foreach (var (bundlePath, discoveredTests) in requestDiscoveredTestsByBundle)
                 {
                     if (!requestModuleByBundle.TryGetValue(bundlePath, out var moduleName)) continue;
                     if (!requestEnvironmentByBundle.TryGetValue(bundlePath, out var envKey)) continue;
-                    var trackedObjectsByPath = emitter.TryGetTrackedObjectsByPath(moduleName);
-                    if (trackedObjectsByPath == null) continue;
+                    // Still require THIS bundle's own module to have a RAD baseline before
+                    // attributing ITS tests at all — same posture as before #2535, only the
+                    // per-statement lookup below now consults the request-wide map instead
+                    // of just this one module's.
+                    if (emitter.TryGetTrackedObjectsByPath(moduleName) == null) continue;
 
                     var nextCoverage = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
                     var nextUnknown = new HashSet<string>(StringComparer.Ordinal);
@@ -5054,7 +5082,7 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                         var unmappable = false;
                         foreach (var s in statements)
                         {
-                            if (!trackedObjectsByPath.TryGetValue(s.FilePath, out var identity))
+                            if (!requestWideTrackedObjectsByPath.TryGetValue(s.FilePath, out var identity))
                             {
                                 unmappable = true;
                                 break;


### PR DESCRIPTION
Closes #2535

## Measurement first

Instrumented the attribution loop (temporarily, not part of this diff) and ran it against the real Pageworks/Pageworks.Test corpus (1012 tests) exactly as the issue describes:

| branch | count |
|---|---:|
| not-passed / no-statements | 106 |
| unmappable (a statement's `FilePath` pointed into the Pageworks dependency bundle) | 897 |
| mapped (real coverage entry) | 9 |

Every one of the 9 mapped entries had a coverage-set size of **exactly 1** (their own declaring codeunit only). That settles the two competing theories the issue named: the defect is the 897 unmappable tests, not over-broad coverage among the few that do map.

## Mechanism

`Program.cs`'s per-test attribution loop mapped each executed statement's `FilePath` through `emitter.TryGetTrackedObjectsByPath(moduleName)` for **only the test's own module**. A test's per-test statement table is runtime coverage — it includes every statement the test actually executed, including statements in a dependency bundle's files on an ordinary cross-app call. A single such statement made the whole test `unmappable` → permanently `nextUnknown` → it reran on every future edit regardless of relevance.

#2492 already fixed the mirror problem on the **changed-object** side (`PeekChangedObjects` peeks and unions every bundle in the request before any bundle's overlap check — see that method's docstring). This applies the identical shape to the **coverage-attribution** side: build one file-to-object map spanning every module already resolved in the request, instead of one map per bundle.

## Fix the shape, not just the line

- **Same wrong pattern elsewhere?** `TryGetTrackedObjectsByPath` had exactly one other call site in the whole codebase (the one this PR changes) — no sibling instance to fix.
- **Sibling function, same assumption?** `PeekChangedObjects` (the changed-object side) already unions across bundles since #2492; this PR brings the coverage side up to the same invariant. Both sides of the overlap check (`coveredObjects.Overlaps(activeChangedObjectKeys)`) are now request-wide.
- **Two paths, same invariant?** Yes — before this fix only the changed-object side saw the full request; the coverage side did not, which is exactly what made #2535 possible even after #2492 landed.

## Tests

`AlRunner.Tests/ServerAffectedSelectionMultiSourcePathsTests.cs`, new test `AffectedOnly_CrossBundleCoverage_RunsOnlyTheTestThatCallsTheEditedHelper`:

- Two-bundle fixture (dependency app with two helper codeunits, test app with two tests each calling a different helper, same shape as the existing single-bundle `AffectedOnly_ChangedObjectRunsOnlyIntersectingTests`, but crossing a bundle boundary).
- RED (confirmed against the pre-fix code): editing one helper reran **both** tests (`ran: 2, skipped: 0`) — both were unmappable and both always ran regardless of what changed.
- GREEN (with the fix): editing one helper reruns **only** the test that calls it (`ran: 1, skipped: 1`).

Regression check: `Server*`/`Incremental*`/`Affected*` AlRunner.Tests surface — 123 passed, 18 skipped (missing artifacts), 0 failed.

## Real-corpus before/after

Same Pageworks/Pageworks.Test repro as the issue, rebuilt with the fix:

| edit | before | after |
|---|---|---|
| Codeunit 71179699 `PageworksRunLengthEncoder` | 1012→1003 (9 skipped, ~1%) | 1012→110 (902 skipped, ~89%) |
| Codeunit 71179705 `PageworksFontMetrics` | 1012→1003 (**identical** set to the edit above) | 1012→119 (893 skipped, ~88%, a **different** selection) |

The issue's core complaint — two unrelated edits producing an identical selection — no longer holds.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
