### PR TITLE
perf(gc): run the runner under Server GC

### DIFF
--- a/AlRunner.Tests/PhaseLogIntegrationTests.cs
+++ b/AlRunner.Tests/PhaseLogIntegrationTests.cs
@@ -539,4 +539,24 @@ public sealed class PhaseLogIntegrationTests : IDisposable
         Assert.True(proc.GetProperty("wall_ms").GetInt64() > 0);
         Assert.True(proc.GetProperty("peak_rss_bytes").GetInt64() > 8L * 1024 * 1024);
     }
+
+    /// <summary>
+    /// The behavioral half of the Server GC contract (#2577): a real runner process, launched
+    /// the way every other spawn in this suite launches it, must observe
+    /// <c>GCSettings.IsServerGC</c> true. <see cref="ServerGcConfigTests"/> asserts the shipped
+    /// runtimeconfig declares it; this asserts the declaration actually reaches the process.
+    /// A phase log is the only channel that can carry the answer out of a subprocess whose
+    /// stdout several tests here assert on verbatim.
+    /// </summary>
+    [Fact]
+    public void TheRunnerProcess_RunsUnderServerGc()
+    {
+        var (_, exit) = RunRaw(_logPath, "--version");
+        Assert.Equal(0, exit);
+
+        var proc = Assert.Single(ReadRecords(_logPath, "process"));
+        Assert.True(proc.GetProperty("server_gc").GetBoolean(),
+            "the runner process ran under Workstation GC — see AlRunner.csproj's "
+            + "ServerGarbageCollection note for what that costs");
+    }
 }

--- a/AlRunner.Tests/ServerGcConfigTests.cs
+++ b/AlRunner.Tests/ServerGcConfigTests.cs
@@ -1,0 +1,71 @@
+// ServerGcConfigTests — the shipped runner must run under Server GC (issue #2577).
+//
+// Nothing declared a GC mode, so every user got the .NET default (Workstation). A cold AL
+// compile allocates heavily and keeps most of it reachable until Roslyn finishes, which is
+// the workload Server GC exists for.
+//
+// Measured here on the al-language corpus (2361 tests), cold cache, same Release binary,
+// DOTNET_gcServer the only variable, 12-core Linux box. Instructions retired (user mode)
+// rather than wall clock, because wall clock on a shared box moves for reasons that have
+// nothing to do with the change:
+//
+//   Workstation   707.8  700.4  679.8  701.8  699.9  714.8  G instructions
+//   Server        658.1  645.2  658.9  657.2  656.1         G instructions
+//
+// 6.2% fewer, and the two sets do not overlap. A warm single-bundle run — the common case
+// for a user with one project — moved the same direction (38.10 G to 36.16 G, 5.1%), so the
+// small case does not pay for the large one.
+//
+// The cost is peak resident memory: 2.2 GB to 4.9 GB on this 12-core box, because Server GC
+// scales its heap count with core count. See AlRunner.csproj's note for the full table.
+//
+// Why a CONFIG test and not only the behavioral one
+// -------------------------------------------------
+// PhaseLogIntegrationTests.TheRunnerProcess_RunsUnderServerGc spawns a real runner and reads
+// GCSettings.IsServerGC back out of its phase log. That is the stronger claim, because it
+// proves the setting reached the process. But it is also satisfiable for the wrong reason: a
+// developer or CI runner with DOTNET_gcServer=1 exported makes it pass with the csproj
+// property deleted. This file closes that hole by asserting the shipped runtimeconfig.json —
+// the only thing a user who sets no environment variables gets.
+//
+// There is deliberately no test asserting background/concurrent GC stays on. That is the
+// .NET default and nothing here sets it, so the test would assert nothing on every run that
+// matters.
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ServerGcConfigTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    /// <summary>
+    /// The runtimeconfig.json beside the al-runner.dll the tests actually spawn — resolved
+    /// through <see cref="TestBuildConfig"/> so this can never assert about a different build
+    /// than the rest of the suite exercises.
+    /// </summary>
+    private static string RuntimeConfigPath => Path.Combine(
+        RepoRoot, "AlRunner", "bin", TestBuildConfig.Configuration,
+        TestBuildConfig.Framework, "al-runner.runtimeconfig.json");
+
+    [Fact]
+    public void ShippedRuntimeConfig_EnablesServerGc()
+    {
+        Assert.True(File.Exists(RuntimeConfigPath),
+            $"no runtimeconfig at '{RuntimeConfigPath}' — build AlRunner before running this suite");
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(RuntimeConfigPath));
+        var props = doc.RootElement.GetProperty("runtimeOptions").GetProperty("configProperties");
+
+        // Absent is a distinct failure from present-and-false: it means the csproj property
+        // was removed and every user silently fell back to Workstation GC, which is the
+        // state this repo sat in while every benchmark harness exported DOTNET_gcServer=1
+        // by hand and no shipped run ever got it.
+        Assert.True(props.TryGetProperty("System.GC.Server", out var serverGc),
+            "System.GC.Server is absent from the shipped runtimeconfig — restore "
+            + "<ServerGarbageCollection>true</ServerGarbageCollection> in AlRunner.csproj");
+        Assert.Equal(JsonValueKind.True, serverGc.ValueKind);
+    }
+}

--- a/AlRunner/AlRunner.csproj
+++ b/AlRunner/AlRunner.csproj
@@ -37,6 +37,54 @@
          improved (156.0s -> 133.7s) with an unchanged fail-set.
          Regression cover: AlRunner.Tests/StartupJitModeTests. -->
 
+    <!-- Server GC (#2577). A cold AL compile allocates at a few hundred MB/s and keeps most
+         of it reachable until Roslyn finishes, so the workload is GC-throughput-bound and one
+         Workstation GC heap cannot keep up. Nothing here declared a GC mode, so every user got
+         the .NET default. That went unnoticed because every benchmark harness in this repo
+         exported DOTNET_gcServer=1 by hand — the harness measured a configuration no shipped
+         run ever had.
+
+         Two measurements, on workloads an order of magnitude apart. Same binary in each,
+         DOTNET_gcServer the only variable.
+
+         1. NP Retail (7,053 AL files / 6,949 objects), 6-core / 12 GB, by @vhn:
+
+              BC AL emit (compilation.Emit)   837.7s -> 331.3s
+              Roslyn bind + IL gen            293.9s -> 103.8s
+              whole emit+compile+load        1173.6s -> 483.0s
+              run wall clock                 1283.1s -> 611.5s
+
+         2. The al-language corpus (586 AL files, 2361 tests), cold cache, 12-core Linux.
+            Instructions retired (user mode) rather than wall clock, because wall clock on a
+            shared box moves for reasons unrelated to the change:
+
+              Workstation  707.8 700.4 679.8 701.8 699.9 714.8  G instructions
+              Server       658.1 645.2 658.9 657.2 656.1        G instructions
+
+            6.2% fewer and no overlap between the sets. A warm single-bundle run moved the same
+            way (38.10 -> 36.16 G, 5.1%), so the small common case does not pay for the large one.
+
+         The cost is peak resident memory, and this is where the two measurements disagree. The
+         NP Retail run reported Server GC as SMALLER resident (2.86 -> 2.39 GB); on 12 cores it
+         more than doubles, because Server GC scales heap count with core count:
+
+              Workstation                      2.11-2.24 GB   698-715 G instructions
+              Server, default heap count (12)  4.74-4.95 GB   656-659 G
+              Server, DOTNET_GCHeapCount=4     3.10-3.15 GB   655, 668 G
+              Server + DATAS                   2.50-2.52 GB   700, 702 G
+
+         Neither knob is set here. Capping heap count keeps the throughput and gives back most
+         of the memory, but the right cap depends on the machine, and .NET already caps the heap
+         under a container memory limit — which is the case where running out actually matters.
+         DATAS gives back the memory and loses the whole throughput win, landing at Workstation's
+         instruction count, so it is not a middle ground on this workload.
+
+         Concurrent (background) GC stays at its default (on): untested here, and this allocation
+         profile is throughput-bound, not pause-bound.
+         Regression cover: AlRunner.Tests/ServerGcConfigTests, and
+         AlRunner.Tests/PhaseLogIntegrationTests.TheRunnerProcess_RunsUnderServerGc. -->
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+
     <!-- dotnet tool packaging -->
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>al-runner</ToolCommandName>

--- a/AlRunner/Infrastructure/PhaseLog.cs
+++ b/AlRunner/Infrastructure/PhaseLog.cs
@@ -99,6 +99,16 @@ public sealed class PhaseLogRecord
     public long PeakRssBytes { get; set; }
     public int ExitCode { get; set; }
 
+    /// <summary>
+    /// Whether this process ran under Server GC. A cold AL compile is GC-throughput-bound
+    /// (see AlRunner.csproj's ServerGarbageCollection note for the measurement), so "which GC
+    /// was this" is the first question to ask of a phase log reporting an implausibly slow
+    /// emit — and it cannot be answered from outside the process, because the setting can come
+    /// from the shipped runtimeconfig, a DOTNET_gcServer environment variable, or a host that
+    /// embeds its own config.
+    /// </summary>
+    public bool ServerGc { get; set; }
+
     // ── Bundle-row and app-row only. Named slices of the row's turn that are NOT
     // already reported elsewhere on it — for a bundle row, the block #1828 exists to
     // attribute (work outside every app group); for an app row, the block #1861
@@ -145,6 +155,7 @@ public sealed class PhaseLogRecord
             Num(sb, "patches_ms", PatchesMs);
             Num(sb, "peak_rss_bytes", PeakRssBytes);
             Num(sb, "exit_code", ExitCode);
+            Bool(sb, "server_gc", ServerGc);
         }
         // Bundle and app rows only, and only when something was measured: a process
         // row's once-per-process costs already have their own named fields, and an
@@ -174,6 +185,11 @@ public sealed class PhaseLogRecord
         {
             Sep(b);
             b.Append('"').Append(k).Append("\":").Append(v.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+        static void Bool(StringBuilder b, string k, bool v)
+        {
+            Sep(b);
+            b.Append('"').Append(k).Append("\":").Append(v ? "true" : "false");
         }
     }
 }
@@ -505,6 +521,7 @@ public static class PhaseLog
             row = Process_;
             row.ExitCode = Environment.ExitCode;
             row.PeakRssBytes = PeakRssBytes();
+            row.ServerGc = System.Runtime.GCSettings.IsServerGC;
             // Measured from OS process start, so it includes host startup and the
             // full-opt JIT that <TieredCompilation>false</TieredCompilation> forces —
             // exactly the residual #1825 wants to size.


### PR DESCRIPTION
The runner shipped with no GC mode declared, so every user ran under Workstation GC. A cold AL compile is GC-throughput-bound. This sets `<ServerGarbageCollection>true</ServerGarbageCollection>`.

Found and measured by Mikkel Mansa Vilhelmsen (@vhn) on a fork. His numbers, NP Retail corpus (7,053 AL files / 6,949 objects), 6-core / 12 GB, same binary, `DOTNET_gcServer` the only variable:

| phase | Workstation | Server |
|---|---|---|
| BC AL emit | 837.7s | 331.3s |
| Roslyn bind + IL gen | 293.9s | 103.8s |
| whole emit+compile+load | 1173.6s | 483.0s |
| run wall clock | 1283.1s | 611.5s |

## My own measurement

I could not reproduce that workload — the largest AL compile available here is the al-language corpus at 586 files, about 12x smaller, where the AL emit phase is 3-6s rather than 837s. So this measures a much smaller version of the same effect.

12-core / 31 GB Linux box, shared with several other agents, so instructions retired (user mode, `perf stat`) is the primary signal and wall clock is reported only for the quiet repetitions. Same Release binary throughout, `DOTNET_gcServer` the only variable.

Cold al-language corpus (2361 tests), cache deleted before each run:

| config | instructions (G) | peak RSS |
|---|---|---|
| Workstation | 707.8, 700.4, 679.8, 701.8, 699.9, 714.8 | 2.11-2.24 GB |
| Server | 658.1, 645.2, 658.9, 657.2, 656.1 | 4.74-4.95 GB |

6.2% fewer instructions, and the two sets do not overlap. Wall clock on the quiet repetitions went 76-84s to 69-77s; I do not put weight on that number, the box was contended for most of the session.

Warm small bundle (`tests/runner-extras/install-trigger-text-constant`, shared warm cache, 4 repetitions each, interleaved):

| config | instructions (G) |
|---|---|
| Workstation | 37.65, 38.08, 38.34, 38.31 |
| Server | 36.08, 36.14, 35.83, 36.59 |

5.1% fewer, again no overlap. The small warm case is the common one for a user with one project, and it does not regress.

## Where my measurement disagrees with the fork's

Peak resident memory. The fork reports Server GC as *smaller* resident (2.86 GB to 2.39 GB). Here it more than doubles. The cause is heap count, which Server GC scales with core count — the fork measured on 6 cores, I measured on 12:

| config | instructions (G) | peak RSS |
|---|---|---|
| Workstation | 698-715 | 2.11-2.24 GB |
| Server, default heap count (12) | 656-659 | 4.74-4.95 GB |
| Server, `DOTNET_GCHeapCount=4` | 655, 668 | 3.10-3.15 GB |
| Server + DATAS | 700, 702 | 2.50-2.52 GB |

Capping heap count keeps the throughput and returns most of the memory. DATAS returns the memory and loses the throughput entirely, landing at Workstation's instruction count — it is not a middle ground on this workload.

I still think plain Server GC is right to ship: the memory growth is a bounded property of Server GC, .NET already caps the heap under a container memory limit (which is the case where running out actually matters), and GitHub's 4-vCPU runners land near the 3.1 GB row. But the "faster and smaller resident" claim does not hold on a machine with more cores, so the csproj comment records both measurements including the disagreement.

## Tests

Two, because they fail for different reasons:

- `ServerGcConfigTests.ShippedRuntimeConfig_EnablesServerGc` — the shipped `al-runner.runtimeconfig.json` declares `System.GC.Server: true`. Needed because a box with `DOTNET_gcServer=1` already exported makes the behavioral test pass with the csproj property deleted, and absent is a different regression from present-and-false.
- `PhaseLogIntegrationTests.TheRunnerProcess_RunsUnderServerGc` — a real runner process reports `GCSettings.IsServerGC` true, through a new `server_gc` field on the phase log's process row. This is what proves the declaration reaches the process.

Both confirmed RED before the csproj change (`System.GC.Server is absent...` and `KeyNotFoundException` on `server_gc`) and GREEN after.

Closes #2577

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf