### PR TITLE
perf(roslyn): parse in parallel and share metadata references across compiles

### DIFF
--- a/AlRunner.Tests/BcAssemblerParsePipelineTests.cs
+++ b/AlRunner.Tests/BcAssemblerParsePipelineTests.cs
@@ -1,0 +1,208 @@
+// BcAssemblerParsePipelineTests — the two Roslyn-side passes BcAssembler.CompileCore now shares
+// or parallelises (issue #2589).
+//
+// Neither change may alter what the compiler sees. Parallel parsing is only safe because results
+// land in fixed array slots, so the tree ORDER handed to CSharpCompilation.Create is the
+// sequential order whatever order the workers finish in — and Roslyn folds tree order into member
+// ordering and diagnostic ordering, so that is the property to pin, not merely "every source was
+// parsed". Sharing a MetadataReference is only safe because the cache key carries the file's
+// stamp: a --bc-version switch or a rebuilt al-runner.dll points the same path at different bytes.
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class BcAssemblerParsePipelineTests
+{
+    /// <summary>Enough sources to exceed BcAssembler's serial threshold and use every worker.</summary>
+    private const int ManySources = 400;
+
+    private static List<EmittedSource> NumberedSources(int count) =>
+        Enumerable.Range(0, count)
+            .Select(i => new EmittedSource($"Object{i}", $"class C{i} {{ int F() => {i}; }}"))
+            .ToList();
+
+    // ---- parallel parse ---------------------------------------------------------
+
+    /// <summary>
+    /// The claim the whole change rests on: parsing in parallel yields the same trees, in the
+    /// same positions, as parsing in order. Repeated, because a race that reorders results does
+    /// not have to lose on the first attempt.
+    /// </summary>
+    [Fact]
+    public void ParseInParallel_PlacesEveryTreeAtItsOwnSourceIndex()
+    {
+        var sources = NumberedSources(ManySources);
+
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            var trees = BcAssembler.ParseInParallel(sources);
+
+            Assert.Equal(sources.Count, trees.Length);
+            for (var i = 0; i < sources.Count; i++)
+            {
+                Assert.NotNull(trees[i]);
+                Assert.Equal($"Object{i}.cs", trees[i].FilePath);
+                Assert.Equal(sources[i].Code, trees[i].GetText().ToString());
+            }
+        }
+    }
+
+    /// <summary>
+    /// Same trees as the sequential form, compared as text so a difference in parse options or in
+    /// which source landed where shows up as an inequality rather than a reference mismatch.
+    /// </summary>
+    [Fact]
+    public void ParseInParallel_MatchesSequentialParsingSourceForSource()
+    {
+        var sources = NumberedSources(ManySources);
+        var sequential = sources
+            .Select(s => CSharpSyntaxTree.ParseText(
+                s.Code, BcAssembler.GeneratedParseOptionsForTests, path: s.Name + ".cs"))
+            .ToList();
+
+        var parallel = BcAssembler.ParseInParallel(sources);
+
+        Assert.Equal(sequential.Count, parallel.Length);
+        for (var i = 0; i < sequential.Count; i++)
+            Assert.True(sequential[i].IsEquivalentTo(parallel[i]),
+                $"tree {i} differs between the sequential and parallel parse");
+    }
+
+    /// <summary>
+    /// The redirect pass is part of parsing, not a separate step a caller could forget: a source
+    /// naming a service-tier member the skeleton runtime cannot serve must come back pointing at
+    /// the shim. Uses the real redirect table's first entry so this cannot pass against a
+    /// hand-written key that no longer exists.
+    /// </summary>
+    [Fact]
+    public void ParseInParallel_AppliesThePolyfillRedirects()
+    {
+        var sources = NumberedSources(ManySources);
+        sources[7] = new EmittedSource(
+            "Redirected", "class R { void M() { NavRuntimeHelpers.ThrowIfWrongArgumentCount(1, null, \"x\"); } }");
+
+        var text = BcAssembler.ParseInParallel(sources)[7].GetText().ToString();
+
+        Assert.Contains("global::AlRunnerShim.NavRuntimeHelpersShim.ThrowIfWrongArgumentCount", text, StringComparison.Ordinal);
+        Assert.DoesNotContain(" NavRuntimeHelpers.ThrowIfWrongArgumentCount", text, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The small-input path is a different branch (serial, no threads started) and has to parse
+    /// every source too — an off-by-one there would drop objects out of a small app group with no
+    /// diagnostic, because a missing tree is simply a type the compilation never saw.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(7)]
+    [InlineData(8)]
+    public void ParseInParallel_ParsesEverySource_AtAndAroundTheSerialThreshold(int count)
+    {
+        var sources = NumberedSources(count);
+
+        var trees = BcAssembler.ParseInParallel(sources);
+
+        Assert.Equal(count, trees.Length);
+        for (var i = 0; i < count; i++)
+            Assert.Equal($"Object{i}.cs", trees[i].FilePath);
+    }
+
+    /// <summary>
+    /// Doc comments are not parsed into structured trivia, and the language version is pinned
+    /// rather than following whatever the Roslyn package's newest major happens to be. Both are
+    /// deliberate: nothing downstream reads doc comments, and C# 14 turned <c>field</c> into a
+    /// contextual keyword inside accessor bodies, which is exactly the kind of identifier an
+    /// AL-to-C# emitter produces.
+    /// </summary>
+    [Fact]
+    public void GeneratedParseOptions_PinTheLanguageVersionAndSkipDocumentationParsing()
+    {
+        var options = BcAssembler.GeneratedParseOptionsForTests;
+
+        Assert.Equal(DocumentationMode.None, options.DocumentationMode);
+        Assert.Equal(LanguageVersion.CSharp13, options.LanguageVersion);
+        Assert.NotEqual(LanguageVersion.Default, options.LanguageVersion);
+    }
+
+    // ---- shared metadata references ---------------------------------------------
+
+    private static string WriteAssembly(string dir, string name)
+    {
+        var path = Path.Combine(dir, name);
+        File.Copy(typeof(object).Assembly.Location, path, overwrite: true);
+        return path;
+    }
+
+    /// <summary>The module name recorded INSIDE the PE the reference actually indexed — not the
+    /// path it was loaded from, which is the same for both references here by construction.</summary>
+    private static string ModuleNameOf(MetadataReference reference) =>
+        ((AssemblyMetadata)((PortableExecutableReference)reference).GetMetadata()).GetModules()[0].Name;
+
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-mdref", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void SharedMetadataReferences_ReturnsTheSameInstanceForAnUnchangedFile()
+    {
+        var dir = NewTempDir();
+        var path = WriteAssembly(dir, "unchanged.dll");
+
+        var first = Assert.Single(BcAssembler.SharedMetadataReferences(new[] { path }));
+        var second = Assert.Single(BcAssembler.SharedMetadataReferences(new[] { path }));
+
+        Assert.Same(first, second);
+    }
+
+    /// <summary>
+    /// The negative direction, and the reason the key is not the path alone: a
+    /// <c>--bc-version</c> switch or a rebuilt <c>al-runner.dll</c> puts different bytes at the
+    /// same path, and serving the cached metadata would compile AL against a version that is no
+    /// longer on disk.
+    /// </summary>
+    [Fact]
+    public void SharedMetadataReferences_ReturnsADifferentInstanceWhenTheFileAtThatPathChanges()
+    {
+        var dir = NewTempDir();
+        var path = WriteAssembly(dir, "swapped.dll");
+        var first = Assert.Single(BcAssembler.SharedMetadataReferences(new[] { path }));
+
+        // A different assembly of a different length, at the same path.
+        File.Copy(typeof(Xunit.FactAttribute).Assembly.Location, path, overwrite: true);
+        File.SetLastWriteTimeUtc(path, DateTime.UtcNow.AddSeconds(1));
+
+        var second = Assert.Single(BcAssembler.SharedMetadataReferences(new[] { path }));
+
+        Assert.NotSame(first, second);
+        // NotSame alone would pass on a cache that simply never hits, so read the identity back
+        // out: the second reference must describe the bytes that are on disk NOW.
+        Assert.Equal(Path.GetFileName(typeof(object).Assembly.Location), ModuleNameOf(first));
+        Assert.Equal(Path.GetFileName(typeof(Xunit.FactAttribute).Assembly.Location), ModuleNameOf(second));
+    }
+
+    /// <summary>
+    /// Order and count are the compiler's reference-resolution order, so the cache may not
+    /// reorder or deduplicate the list it is handed.
+    /// </summary>
+    [Fact]
+    public void SharedMetadataReferences_PreservesTheOrderAndCountOfThePathsGiven()
+    {
+        var dir = NewTempDir();
+        var a = WriteAssembly(dir, "a.dll");
+        var b = WriteAssembly(dir, "b.dll");
+
+        var refs = BcAssembler.SharedMetadataReferences(new[] { a, b, a });
+
+        Assert.Equal(3, refs.Count);
+        Assert.Same(refs[0], refs[2]);
+        Assert.NotSame(refs[0], refs[1]);
+        Assert.Equal(a, ((PortableExecutableReference)refs[0]).FilePath);
+        Assert.Equal(b, ((PortableExecutableReference)refs[1]).FilePath);
+    }
+}

--- a/AlRunner/BcAssembler.cs
+++ b/AlRunner/BcAssembler.cs
@@ -29,6 +29,29 @@ public sealed class BcAssembler
     // Run the full compile pass on a thread with 64 MB stack to avoid SIGSEGV.
     private const int CompileStackSize = 64 * 1024 * 1024;
 
+    /// <summary>
+    /// Parse options for BC-generated C#. <c>CSharpParseOptions.Default</c> carries
+    /// <c>DocumentationMode.Parse</c>, so the lexer builds structured XML-doc trivia for every
+    /// <c>///</c> comment. BC's emitter writes none, and nothing downstream reads doc comments,
+    /// so both the scan and the trivia nodes it would allocate are pure overhead.
+    /// </summary>
+    /// <remarks>
+    /// The language version is pinned rather than left at <see cref="LanguageVersion.Default"/>,
+    /// which resolves to whatever the referenced Roslyn package's newest major happens to be — so
+    /// a routine package bump silently changes the language BC's generated C# is parsed as. That
+    /// is not hypothetical: C# 14 made <c>field</c> a contextual keyword inside property accessor
+    /// bodies, which is exactly the kind of identifier an AL-to-C# emitter produces. Pinned at the
+    /// version the corpus has actually been compiled under; raising it is a deliberate change that
+    /// needs a corpus run behind it.
+    /// </remarks>
+    /// <summary>Test seam: the options every generated source is parsed with.</summary>
+    internal static CSharpParseOptions GeneratedParseOptionsForTests => GeneratedParseOptions;
+
+    private static readonly CSharpParseOptions GeneratedParseOptions =
+        CSharpParseOptions.Default
+            .WithDocumentationMode(DocumentationMode.None)
+            .WithLanguageVersion(LanguageVersion.CSharp13);
+
     public CompileResult Compile(string assemblyName, IEnumerable<EmittedSource> sources)
     {
         CompileResult? result = null;
@@ -47,23 +70,48 @@ public sealed class BcAssembler
 
     private CompileResult CompileCore(string assemblyName, IEnumerable<EmittedSource> sources)
     {
+        // Same BCCOMPILER_TIMING=1 switch and [emit-timing] channel BcCompiler.Emit uses, because
+        // the two halves of a compile are only comparable when they are measured the same way.
+        // The Roslyn half used to be one opaque number; splitting it is what showed that the
+        // three costs this change addresses are 6% of it and CallSiteArgWrap's throwaway compile
+        // is 47% (see #2589 and #2590 for the table).
+        bool timing = Environment.GetEnvironmentVariable("BCCOMPILER_TIMING") == "1";
+        var timer = System.Diagnostics.Stopwatch.StartNew();
+        void Mark(string phase)
+        {
+            if (timing)
+                Console.Error.WriteLine(
+                    $"[emit-timing] {assemblyName}: {phase}: {timer.ElapsedMilliseconds}ms "
+                    + $"(heap {GC.GetTotalMemory(false) / (1024 * 1024)}MB)");
+            timer.Restart();
+        }
+
         var sourceList = sources.ToList();
         if (Environment.GetEnvironmentVariable("DUMP_CS") == "1")
             foreach (var s in sourceList)
                 File.WriteAllText(Path.Combine(Path.GetTempPath(), $"gen_{s.Name}.cs"), s.Code);
-        var trees = sourceList
-            .Select(s => CSharpSyntaxTree.ParseText(
-                ApplyPolyfillRedirects(s.Code), path: s.Name + ".cs"))
-            .ToList();
-        // Inject helpers for runtime-API mismatches between alc-emit and the
-        // service-tier DLLs. PolyfillRedirects above route callers here.
-        trees.Add(CSharpSyntaxTree.ParseText(PolyfillSource, path: "_polyfill.cs"));
 
-        var refs = ReferencePaths().Select(p => MetadataReference.CreateFromFile(p)).ToList();
+        // One tree per AL object, parsed in parallel. Parsing a file has no dependency on any
+        // other file, and a whole-module compile has thousands of them, so this is the one pass
+        // in CompileCore that fans out without changing what the compiler sees: results land in
+        // a fixed array slot, so the tree ORDER handed to CSharpCompilation.Create is identical
+        // to the sequential form, whatever order the workers finish in. Roslyn folds tree order
+        // into member ordering and diagnostic ordering, so that is not a detail.
+        var trees = new List<SyntaxTree>(ParseInParallel(sourceList))
+        {
+            // Helpers for runtime-API mismatches between alc-emit and the service-tier DLLs.
+            // PolyfillRedirects route callers here.
+            CSharpSyntaxTree.ParseText(PolyfillSource, GeneratedParseOptions, path: "_polyfill.cs"),
+        };
+        Mark($"Roslyn parse {trees.Count} sources");
+
+        var refs = SharedMetadataReferences(ReferencePaths());
+        Mark($"metadata references ({refs.Count})");
 
         // Fill BC's call-site ByRef gap. Runs a throwaway compile to find CS1503
         // 'cannot convert T to ByRef<T>' errors and rewrites only those args.
         trees = CallSiteArgWrap.Apply(trees, refs).ToList();
+        Mark("CallSiteArgWrap speculative compile");
 
         var compilation = CSharpCompilation.Create(
             assemblyName,
@@ -77,6 +125,7 @@ public sealed class BcAssembler
 
         using var ms = new MemoryStream();
         var emit = compilation.Emit(ms);
+        Mark("Roslyn bind + IL gen");
         if (!emit.Success)
         {
             var errs = emit.Diagnostics
@@ -97,6 +146,102 @@ public sealed class BcAssembler
             catch { /* best-effort */ }
         }
         return new CompileResult(bytes, Array.Empty<string>());
+    }
+
+    /// <summary>
+    /// Parses every source into its own syntax tree, applying the polyfill redirects first, with
+    /// the work spread over at most <see cref="Environment.ProcessorCount"/> threads.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately dedicated threads sized <see cref="CompileStackSize"/>, not a
+    /// <c>Parallel.For</c> over the thread pool. <see cref="Compile"/> runs this whole method on
+    /// a 64 MB-stack thread precisely because Roslyn's recursion on generated code has overflowed
+    /// the default stack here before; handing the parse to pool threads would put it back on a
+    /// default-sized stack and quietly give that guarantee up. The parse of one AL object is
+    /// shallow enough that it has never been the overflow, but "has never been" is not the same
+    /// claim as "cannot be", and a stack overflow is a SIGSEGV with no managed stack to read.
+    /// </remarks>
+    internal static SyntaxTree[] ParseInParallel(IReadOnlyList<EmittedSource> sources)
+    {
+        var parsed = new SyntaxTree[sources.Count];
+        SyntaxTree ParseOne(int i) => CSharpSyntaxTree.ParseText(
+            ApplyPolyfillRedirects(sources[i].Code), GeneratedParseOptions,
+            path: sources[i].Name + ".cs");
+
+        // Below this size the thread setup costs more than the parse it would overlap.
+        const int ParallelThreshold = 8;
+        var workers = Math.Min(Environment.ProcessorCount, sources.Count);
+        if (workers <= 1 || sources.Count < ParallelThreshold)
+        {
+            for (var i = 0; i < sources.Count; i++) parsed[i] = ParseOne(i);
+            return parsed;
+        }
+
+        var next = -1;
+        Exception? failure = null;
+        var threads = new Thread[workers];
+        for (var w = 0; w < workers; w++)
+        {
+            threads[w] = new Thread(() =>
+            {
+                try
+                {
+                    int i;
+                    while ((i = Interlocked.Increment(ref next)) < sources.Count)
+                        parsed[i] = ParseOne(i);
+                }
+                catch (Exception ex) { Interlocked.CompareExchange(ref failure, ex, null); }
+            }, CompileStackSize);
+            threads[w].Start();
+        }
+        foreach (var t in threads) t.Join();
+        if (failure != null)
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(failure).Throw();
+        return parsed;
+    }
+
+    /// <summary>
+    /// One <see cref="MetadataReference"/> per (path, last-write, length), shared by every
+    /// compile in the process.
+    ///
+    /// <para><see cref="MetadataReference.CreateFromFile(string, MetadataReferenceProperties, DocumentationProvider)"/>
+    /// reads and indexes the whole PE metadata of the file it is given, and this list is ~195
+    /// unchanging assemblies: every BC service-tier DLL plus the .NET shared framework. Recreating
+    /// them per app group meant a bundle of N app groups paid it N times, and a <c>--watch</c>
+    /// session paid it again on every cycle for files that cannot have moved. Roslyn is designed
+    /// for these to be shared — a MetadataReference is immutable and its underlying metadata is
+    /// reference-counted — so caching also keeps one copy of that metadata in memory instead of
+    /// one per live compilation.</para>
+    ///
+    /// <para>Keyed on the file's stamp as well as its path, never the path alone: a
+    /// <c>--bc-version</c> switch, or a rebuilt <c>al-runner.dll</c> (which is itself in the
+    /// list), points the same path at different bytes, and serving the old metadata would compile
+    /// AL against a version no longer on disk.</para>
+    /// </summary>
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<
+        (string Path, long Ticks, long Length), MetadataReference> _metadataReferenceCache = new();
+
+    internal static List<MetadataReference> SharedMetadataReferences(IEnumerable<string> paths)
+    {
+        var refs = new List<MetadataReference>();
+        foreach (var path in paths)
+        {
+            (string Path, long Ticks, long Length) key;
+            try
+            {
+                var info = new FileInfo(path);
+                key = (path, info.LastWriteTimeUtc.Ticks, info.Length);
+            }
+            catch (IOException)
+            {
+                // No readable stamp — take the uncached path rather than key on a guess.
+                refs.Add(MetadataReference.CreateFromFile(path));
+                continue;
+            }
+            refs.Add(_metadataReferenceCache.GetOrAdd(
+                key, static k => MetadataReference.CreateFromFile(k.Path)));
+        }
+        return refs;
     }
 
     private IEnumerable<string> ReferencePaths()


### PR DESCRIPTION
`BcAssembler.CompileCore` reported one opaque number for the whole Roslyn half of a compile. Adding the same `BCCOMPILER_TIMING=1` / `[emit-timing]` marks `BcCompiler.Emit` already uses splits it, and that split is what makes this change measurable — and what says which parts of the original fork change are worth taking.

Found and originally measured by Mikkel Mansa Vilhelmsen (@vhn) on a fork, on the NP Retail corpus (7,053 AL files).

## Measured split, before

al-language corpus, cold cache, 12-core Linux box shared with several other agents. These are phase timings from a single instrumented run, not wall clock for the whole process, so contention shows up as scale but not as a change of shape.

| compile | sources | polyfill redirects | parse | metadata refs | CallSiteArgWrap | bind + IL |
|---|---|---|---|---|---|---|
| Dep_AL_Language_Internals_Fixture | 5 | 0 ms | 53 | 56 | 1134 | 380 |
| Dep_Microsoft_Any | 1 | 0 | 12 | 37 | 393 | 161 |
| Dep_MS_System_App_Test_Library | 174 | 2 | 202 | 38 | 1996 | 2438 |
| AL Language Coverage Tests | 601 | 18 | 601 | 33 | 4516 | 4979 |
| **total** | 781 | **20 ms** | **868 ms** | **164 ms** | **8039 ms** | **7958 ms** |

## What this changes

**Parallel parse, `DocumentationMode.None`.** Parsing a source has no dependency on any other source, and `CSharpParseOptions.Default` carries `DocumentationMode.Parse`, so the lexer built structured XML-doc trivia for `///` comments BC's emitter never writes.

Results land at fixed array indices, so the tree order handed to `CSharpCompilation.Create` is the sequential order whatever order the workers finish in. Roslyn folds tree order into member ordering and diagnostic ordering, so that is the property the tests pin, not merely "every source was parsed".

Dedicated threads sized like `CompileStackSize`, not a `Parallel.For` over the thread pool. `Compile` already runs this whole method on a 64 MB-stack thread because Roslyn's recursion on generated code has overflowed the default stack here before; handing the parse to pool threads would put it back on a default-sized stack and quietly give that guarantee up. The parse of one AL object is shallow enough that it has never been the overflow, but that is not the same claim as "cannot be", and a stack overflow here is a SIGSEGV with no managed stack to read.

**One `MetadataReference` per (path, last-write, length), shared process-wide.** `MetadataReference.CreateFromFile` reads and indexes the whole PE metadata of the file, and this list is 195 unchanging assemblies: the BC service-tier DLLs plus the .NET shared framework. Every app group rebuilt all of them, and every `--watch` cycle rebuilt them again for files that cannot have moved. The stamp is in the key because a `--bc-version` switch or a rebuilt `al-runner.dll` (which is itself in the list) puts different bytes at the same path.

**`LanguageVersion` pinned.** `LanguageVersion.Default` follows the referenced Roslyn package's newest major, so a routine package bump silently changes the language BC's generated C# is parsed as. C# 14 made `field` a contextual keyword inside property accessor bodies, which is exactly the kind of identifier an AL-to-C# emitter produces.

## What I deliberately did not take from the fork

The fork also rewrites `ApplyPolyfillRedirects` from 35 `string.Replace` sweeps into one left-to-right walk over a `SearchValues` anchor table, with four structural invariants about the redirect table that a test suite has to hold in place (no key inside another key, no key inside a replacement, no key spanning either seam of a replacement, no two keys overlapping).

On the fork's app that pass scans 35 x 165 MB and the rewrite is clearly right. On this corpus the entire pass is **20 ms out of 17,049** — 0.1%. That buys nothing for a correctness surface that has to be argued rather than read, so `ApplyPolyfillRedirects` is unchanged.

## Separately

`CallSiteArgWrap`'s throwaway compile is 47% of the Roslyn half, slightly more than the compile it precedes. That is #2590, filed with the measurement; I am not fixing it here.

## Result

Same corpus and machine, after:

| phase | before | after |
|---|---|---|
| parse, 601-source compile | 601 ms | 152 ms |
| parse, 175-source compile | 202 ms | 94 ms |
| parse, all four compiles | 868 ms | 313 ms |
| metadata references, all four | 164 ms | 54 ms |

The 6-source compile stays at 53 ms because it is below the serial threshold and never starts a thread, which is the intended behavior.

2361/2361 corpus tests pass, and I ran it a second time warm: still 2361/2361, `C# compile: 0.0s`, a full cache hit.

## Tests

`BcAssemblerParsePipelineTests`, 11 tests. There were no `BcAssembler` tests before this, so the parallel-parse ones are new-API RED. The caching ones are genuinely RED against the old code — I confirmed it by replacing the cache lookup with a direct `CreateFromFile` and rerunning:

```
BcAssemblerParsePipelineTests.SharedMetadataReferences_ReturnsTheSameInstanceForAnUnchangedFile [FAIL]
BcAssemblerParsePipelineTests.SharedMetadataReferences_PreservesTheOrderAndCountOfThePathsGiven [FAIL]
   Assert.Same() Failure: Values are not the same instance
```

Both directions are covered: the cache returns the same instance for an unchanged file, and a *different* instance when the bytes at that path change — asserted by reading the module name back out of the reference, so a cache that simply never hits cannot pass it.

Closes #2589

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
