### PR TITLE
Give each runner process its own sibling-symbols directory

### DIFF
--- a/AlRunner.Tests/SiblingSymbolsDirectoryTests.cs
+++ b/AlRunner.Tests/SiblingSymbolsDirectoryTests.cs
@@ -1,0 +1,124 @@
+// SiblingSymbolsDirectoryTests — issue #2586.
+//
+// The old sibling-symbols path was Path.GetTempPath()/al-runner-sibling-symbols/<bundle leaf
+// name>, and EmitSiblingSymbols opens by deleting that directory recursively. Nothing in the
+// path identified the bundle beyond its leaf name and nothing identified the process, so two
+// concurrent runners over bundles both called "tests" deleted each other's symbols mid-compile,
+// and two unrelated projects with the same leaf name shared one directory.
+//
+// Every assertion here is about the runner's own temp-directory layout — there is no claim about
+// Business Central in this file, so nothing here belongs in the al-language corpus.
+//
+// The three path tests are the ones that would have caught the bug. Each fails against the old
+// implementation: it returned the leaf name alone, so DifferentProcesses and DifferentBundles
+// both returned equal paths.
+using System;
+using System.IO;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class SiblingSymbolsDirectoryTests
+{
+    private static string Bundle(string relative) =>
+        Path.Combine(Path.GetTempPath(), "al-runner-sibsym-tests", relative);
+
+    [Fact]
+    public void SameBundleSameProcess_IsTheSameDirectory()
+    {
+        // Stability is the property EmitSiblingSymbols relies on: it computes the path once and
+        // BcCompiler reads from it later in the same run.
+        Assert.Equal(
+            SiblingSymbolsDirectory.ForBundle(Bundle("proj-a/tests"), "process-a"),
+            SiblingSymbolsDirectory.ForBundle(Bundle("proj-a/tests"), "process-a"));
+    }
+
+    [Fact]
+    public void SameBundleDifferentProcesses_AreDifferentDirectories()
+    {
+        // The recursive delete in EmitSiblingSymbols is only safe because of this. Two runners
+        // on the same bundle must not be able to reach each other's files at all.
+        Assert.NotEqual(
+            SiblingSymbolsDirectory.ForBundle(Bundle("proj-a/tests"), "process-a"),
+            SiblingSymbolsDirectory.ForBundle(Bundle("proj-a/tests"), "process-b"));
+    }
+
+    [Fact]
+    public void DifferentBundlesWithTheSameLeafName_AreDifferentDirectories()
+    {
+        // The exact collision the old path had: two checkouts whose bundle folder is called
+        // "tests" resolved to one directory even within a single process.
+        var a = SiblingSymbolsDirectory.ForBundle(Bundle("proj-a/tests"), "process-a");
+        var b = SiblingSymbolsDirectory.ForBundle(Bundle("proj-b/tests"), "process-a");
+
+        Assert.NotEqual(a, b);
+        // ...and the leaf name is still there, so a temp listing is readable. This is what makes
+        // the assertion above about the HASH rather than about the names being different.
+        Assert.StartsWith("tests-", Path.GetFileName(a), StringComparison.Ordinal);
+        Assert.StartsWith("tests-", Path.GetFileName(b), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TrailingSeparatorAndRelativeSpelling_ResolveToTheSameDirectory()
+    {
+        // Normalization happens before hashing, so the same bundle named two ways is one
+        // directory. Without it a caller that passed a trailing separator would silently get a
+        // second, empty symbols directory and compile against nothing.
+        var plain = Bundle("proj-a/tests");
+        Assert.Equal(
+            SiblingSymbolsDirectory.ForBundle(plain, "process-a"),
+            SiblingSymbolsDirectory.ForBundle(plain + Path.DirectorySeparatorChar, "process-a"));
+    }
+
+    [Fact]
+    public void EveryDirectory_LivesUnderTheSharedRoot()
+    {
+        // PruneStale walks Root, so a path that escaped it would never be cleaned up.
+        var dir = SiblingSymbolsDirectory.ForBundle(Bundle("proj-a/tests"), "process-a");
+        Assert.Equal(SiblingSymbolsDirectory.Root, Path.GetDirectoryName(dir));
+    }
+
+    [Fact]
+    public void PruneStale_DeletesOnlyDirectoriesOlderThanTheThreshold()
+    {
+        var root = SiblingSymbolsDirectory.Root;
+        Directory.CreateDirectory(root);
+
+        var stamp = Guid.NewGuid().ToString("N");
+        var old = Path.Combine(root, $"prunetest-old-{stamp}");
+        var fresh = Path.Combine(root, $"prunetest-fresh-{stamp}");
+        try
+        {
+            Directory.CreateDirectory(old);
+            Directory.CreateDirectory(fresh);
+            File.WriteAllText(Path.Combine(old, "a.symbols.json"), "{}");
+            File.WriteAllText(Path.Combine(fresh, "a.symbols.json"), "{}");
+
+            var now = new DateTime(2026, 1, 10, 12, 0, 0, DateTimeKind.Utc);
+            Directory.SetLastWriteTimeUtc(old, now - TimeSpan.FromDays(3));
+            Directory.SetLastWriteTimeUtc(fresh, now - TimeSpan.FromMinutes(5));
+
+            SiblingSymbolsDirectory.PruneStale(TimeSpan.FromDays(1), now);
+
+            Assert.False(Directory.Exists(old), "a directory untouched for three days must be pruned.");
+            // The half that matters: a live sibling runner's directory must survive. A prune that
+            // deleted this would be the #2586 bug arrived at from the other direction.
+            Assert.True(Directory.Exists(fresh), "a directory written five minutes ago must NOT be pruned.");
+        }
+        finally
+        {
+            try { Directory.Delete(old, recursive: true); } catch { }
+            try { Directory.Delete(fresh, recursive: true); } catch { }
+        }
+    }
+
+    [Fact]
+    public void PruneStale_OnAMissingRoot_IsANoOpAndDoesNotThrow()
+    {
+        // First run on a clean machine: the root does not exist yet, and EmitSiblingSymbols
+        // prunes before it creates anything.
+        var record = Record.Exception(() => SiblingSymbolsDirectory.PruneStale(TimeSpan.FromDays(1)));
+        Assert.Null(record);
+    }
+}

--- a/AlRunner/Infrastructure/SiblingSymbolsDirectory.cs
+++ b/AlRunner/Infrastructure/SiblingSymbolsDirectory.cs
@@ -1,0 +1,109 @@
+// SiblingSymbolsDirectory — where EmitSiblingSymbols writes a bundle's in-bundle symbol files.
+//
+// WHY THIS EXISTS (issue #2586)
+//   The path used to be Path.GetTempPath()/al-runner-sibling-symbols/<bundle leaf name>, and
+//   EmitSiblingSymbols opens by deleting it recursively. Nothing in that path distinguishes one
+//   bundle from another with the same leaf name, and nothing distinguishes one runner process
+//   from another, so two failure modes followed:
+//
+//     1. Two runners racing. One creates the directory and starts writing *.symbols.json; the
+//        other reaches the recursive delete and removes them mid-compile, and the first then
+//        compiles a sibling against symbols that are no longer there. Leaf names collide easily
+//        — "tests", "src", "app", "test-app" — and this machine runs the runner concurrently by
+//        design: the C# suite spawns it around 130 times, CI runs four lanes, and several agent
+//        worktrees run at once. Same class of defect as #2489 for the ncl-shadow root.
+//     2. Two different bundles that both end in the same folder name resolving to one directory,
+//        so one project's sibling symbols are visible to the other's compile.
+//
+//   Both come from the same missing information, so both are fixed by putting it in the path:
+//   a hash of the bundle's full normalized path, and a per-process value.
+//
+//   The process component is what makes the recursive delete safe again. A process can only ever
+//   delete its own directory, which is what that call always meant.
+using System.Security.Cryptography;
+using System.Text;
+
+namespace AlRunner.Infrastructure;
+
+internal static class SiblingSymbolsDirectory
+{
+    /// <summary>The parent holding every per-(bundle, process) directory. Also what
+    /// <see cref="PruneStale"/> walks.</summary>
+    internal static string Root => Path.Combine(Path.GetTempPath(), "al-runner-sibling-symbols");
+
+    /// <summary>
+    /// One value per runner process. A GUID rather than the PID: PIDs are reused, and a reused
+    /// PID would collide with a directory the previous owner never got to clean up — which is
+    /// the failure this exists to prevent, arrived at a different way.
+    /// </summary>
+    private static readonly string ProcessNonce = Guid.NewGuid().ToString("N");
+
+    internal static string ForBundle(string bundlePath) => ForBundle(bundlePath, ProcessNonce);
+
+    /// <summary>
+    /// The directory for <paramref name="bundlePath"/> under <paramref name="processNonce"/>.
+    /// A pure function of its two arguments, which is what makes the three properties that
+    /// matter testable without spawning processes: the same bundle in the same process always
+    /// gives the same path, the same bundle in two processes never does, and two different
+    /// bundles never do — including when their leaf names are identical.
+    /// <para>The leaf name stays in front of the hash so the directory is still recognisable to
+    /// a human reading a temp listing; the hash is what actually separates bundles.</para>
+    /// </summary>
+    internal static string ForBundle(string bundlePath, string processNonce)
+    {
+        // Normalize BEFORE hashing so the same bundle reached by two spellings ("./tests" and an
+        // absolute path, with or without a trailing separator) is one directory and not two.
+        var normalized = Path.TrimEndingDirectorySeparator(Path.GetFullPath(bundlePath));
+        // Windows paths are case-insensitive, so two spellings that differ only in case are the
+        // same bundle there and must hash the same. On Linux and macOS they are different paths
+        // and must not be folded together.
+        if (OperatingSystem.IsWindows()) normalized = normalized.ToUpperInvariant();
+
+        var hash = Convert.ToHexString(
+            SHA256.HashData(Encoding.UTF8.GetBytes(normalized)))[..12].ToLowerInvariant();
+
+        var leaf = Path.GetFileName(normalized);
+        if (string.IsNullOrEmpty(leaf)) leaf = "bundle";   // a filesystem root has no leaf name
+
+        return Path.Combine(Root, $"{leaf}-{hash}-{processNonce}");
+    }
+
+    /// <summary>
+    /// Delete directories under <see cref="Root"/> that have not been written to for
+    /// <paramref name="maxAge"/>. Making each directory private to its process means nobody else
+    /// cleans it up, so without this the temp root grows without bound.
+    ///
+    /// <para>The age threshold is deliberately far longer than any run: the whole point of the
+    /// per-process component is that one process never deletes another's live directory, and a
+    /// prune that guessed wrong would reintroduce exactly the bug being fixed. A directory
+    /// untouched for a day belongs to a process that is not coming back.</para>
+    ///
+    /// <para>Every failure is swallowed. A concurrent prune from a sibling runner, a directory
+    /// deleted between the listing and the delete, a permission error on a directory this user
+    /// does not own — none of them is a reason to fail a test run, and the only cost of skipping
+    /// one is that it is retried next time.</para>
+    /// </summary>
+    internal static void PruneStale(TimeSpan maxAge) => PruneStale(maxAge, DateTime.UtcNow);
+
+    /// <summary>Injectable clock, so the age boundary is testable without waiting.</summary>
+    internal static void PruneStale(TimeSpan maxAge, DateTime utcNow)
+    {
+        string[] entries;
+        try
+        {
+            if (!Directory.Exists(Root)) return;
+            entries = Directory.GetDirectories(Root);
+        }
+        catch (Exception) { return; }
+
+        foreach (var entry in entries)
+        {
+            try
+            {
+                if (utcNow - Directory.GetLastWriteTimeUtc(entry) < maxAge) continue;
+                Directory.Delete(entry, recursive: true);
+            }
+            catch (Exception) { /* another runner got there first, or it is not ours to delete */ }
+        }
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -7587,8 +7587,13 @@ static void EmitSiblingSymbols(
         .ToHashSet();
     if (targets.Count == 0) return;
 
-    var dir = Path.Combine(Path.GetTempPath(),
-        "al-runner-sibling-symbols", Path.GetFileName(bundleAbs.TrimEnd(Path.DirectorySeparatorChar)));
+    // Per (bundle, process), not per bundle leaf name — see
+    // Infrastructure/SiblingSymbolsDirectory.cs (#2586). The recursive delete below is only
+    // safe because of that: it can now only ever remove THIS process's own directory, where
+    // before two concurrent runners over same-leaf-named bundles deleted each other's symbols
+    // mid-compile. Nobody else cleans up a private directory, so prune old ones first.
+    AlRunner.Infrastructure.SiblingSymbolsDirectory.PruneStale(TimeSpan.FromDays(1));
+    var dir = AlRunner.Infrastructure.SiblingSymbolsDirectory.ForBundle(bundleAbs);
     try
     {
         if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);


### PR DESCRIPTION
## What was wrong

`EmitSiblingSymbols` derived the sibling-symbols directory from the bundle's leaf folder name alone, then opened by deleting it recursively:

```csharp
var dir = Path.Combine(Path.GetTempPath(),
    "al-runner-sibling-symbols", Path.GetFileName(bundleAbs.TrimEnd(Path.DirectorySeparatorChar)));
if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
```

Nothing in that path distinguished one bundle from another with the same leaf name, and nothing distinguished one runner process from another. Two failures follow:

1. **Concurrent runners delete each other's symbols.** One creates the directory and starts writing `.symbols.json`; the other reaches the recursive delete and removes them mid-compile, and the first then compiles a sibling against symbols that are gone. Leaf names collide easily — `tests`, `src`, `app`, `test-app` — and this repo runs the runner concurrently by design: the C# suite spawns it around 130 times, CI runs four lanes, and several agent worktrees run at once.
2. **Unrelated projects share a directory.** Two checkouts whose bundle folder is called `tests` resolved to the same path, so one project's symbols were visible to the other's compile.

Same class of defect as #2489 for the `ncl-shadow` root.

## What this does

Both failures come from the same missing information, so the path now carries it: a 12-character hash of the bundle's normalized full path, plus a per-process GUID. The leaf name stays in front so a temp listing is still readable.

- Normalizing before hashing means one bundle named two ways (trailing separator, relative spelling) is one directory, not two.
- Upper-casing on Windows only, because two spellings differing in case are the same path there and different paths on Linux.
- A GUID rather than the PID: PIDs are reused, and a reused PID would collide with a directory its previous owner never cleaned up — the same failure reached a different way.

The process component is what makes the recursive delete safe again. It can now only ever remove this process's own directory, which is what that call always meant.

Nobody else cleans up a private directory, so `EmitSiblingSymbols` prunes entries under the shared root that have not been written to for a day. The threshold is far longer than any run on purpose: a prune that guessed wrong would delete a live sibling's directory, which is this bug from the other direction. Prune failures are swallowed — a concurrent prune, a directory that vanished between listing and delete, a permission error — none is a reason to fail a run, and the only cost is retrying next time.

## Proof

RED → GREEN, measured by reverting `ForBundle` to the old path shape and running the new tests:

| | Result |
|---|---|
| Old path shape | 2 failed, 5 passed |
| This PR | 7 passed |

The two that fail are exactly the ones describing the bug: `SameBundleDifferentProcesses_AreDifferentDirectories` and `DifferentBundlesWithTheSameLeafName_AreDifferentDirectories`.

The prune test asserts both directions — a three-day-old directory is removed, a five-minute-old one survives. Without that second assertion a prune that deleted everything would pass.

The existing end-to-end `SiblingSymbolsAppRootManifestTests` (#2542), which spawns the runner and exercises `EmitSiblingSymbols` for real, still passes: 10 passed across both classes.

Nothing here is a claim about Business Central — it is entirely the runner's own temp-directory layout — so no corpus test applies and this PR does not touch the submodule pin or the count baseline.

## Credit

The collision was found by Mikkel Mansa Vilhelmsen (`vhn`), who hit it on his fork and added an equivalent helper there (commit `07ca7aec`). No code was copied; the pruning and the normalization rules here are written for this repo.

Closes #2586

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
