### PR TITLE
Name this bundle's provisioning gaps again in the run summary

### DIFF
--- a/AlRunner.Tests/ProvisionGapSummaryTests.cs
+++ b/AlRunner.Tests/ProvisionGapSummaryTests.cs
@@ -1,0 +1,156 @@
+// ProvisionGapSummaryTests — issue #2587.
+//
+// Two messages predict a run's failure exactly and were printed only at the point of discovery:
+// DependencyResolver's unservable dependencies, and DependencyLoader's symbol-only platform-app
+// note. On a long run they scroll thousands of lines above the summary the caller reads, so a
+// caller reading the bottom concludes their AL is broken when their package cache is
+// unprovisioned.
+//
+// This is entirely about the runner's own reporting — there is no claim about Business Central
+// anywhere in this file, so nothing here belongs in the al-language corpus.
+//
+// The negative tests are what make the positive one mean something. A summary section that
+// printed unconditionally, or a collector that never reset, would satisfy "the gap is named" and
+// still be wrong.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using AlRunner;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ProvisionGapSummaryTests
+{
+    private static BucketResult Bucket(string path, IReadOnlyList<string>? gaps) =>
+        new(path, BucketStage.Ran,
+            Array.Empty<string>(), null, Array.Empty<TestResult>(),
+            TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, 1, gaps);
+
+    private static string Summarize(params BucketResult[] buckets)
+    {
+        var w = new StringWriter();
+        Reporter.PrintSummary(buckets, w);
+        return w.ToString();
+    }
+
+    [Fact]
+    public void Summary_NamesEveryGapVerbatim_AndCountsThem()
+    {
+        const string gapA = "[deps] Microsoft_Base Application v28.1 is symbol-only — run al-runner provision";
+        const string gapB = "[deps] Contoso_Widgets v1.0 has neither a DLL nor AL source — nothing can serve it";
+
+        var summary = Summarize(Bucket("/bundle-a", new[] { gapA, gapB }));
+
+        // Verbatim, because each block is what names the app, the winning path and the fix
+        // command. A summary that paraphrased them would send the reader back up the log.
+        Assert.Contains(gapA, summary);
+        Assert.Contains(gapB, summary);
+        Assert.Contains("Provisioning gaps: 2", summary);
+    }
+
+    [Fact]
+    public void Summary_WithNoGaps_HasNoSectionAtAll()
+    {
+        // The negative that keeps a clean run's output unchanged. Printed unconditionally, this
+        // section would be noise on every run and would sit between the existing markers and the
+        // closing rule, where the integration tests assert.
+        var summary = Summarize(Bucket("/bundle-a", null));
+
+        Assert.DoesNotContain("Provisioning gaps", summary);
+    }
+
+    [Fact]
+    public void Summary_DeduplicatesTheSameGapReportedByTwoBundles()
+    {
+        // Two bundles in one run resolving the same missing platform app report it twice. The
+        // reader needs to know it is one problem, not two.
+        const string gap = "[deps] Microsoft_Base Application v28.1 is symbol-only";
+
+        var summary = Summarize(
+            Bucket("/bundle-a", new[] { gap }),
+            Bucket("/bundle-b", new[] { gap }));
+
+        Assert.Contains("Provisioning gaps: 1", summary);
+    }
+
+    [Fact]
+    public void Summary_GapInOneBundleOnly_IsStillReported()
+    {
+        // The per-bundle carrier must not lose a gap because a LATER bundle was clean.
+        const string gap = "[deps] Contoso_Widgets v1.0 has neither a DLL nor AL source";
+
+        var summary = Summarize(
+            Bucket("/bundle-a", new[] { gap }),
+            Bucket("/bundle-b", null));
+
+        Assert.Contains(gap, summary);
+        Assert.Contains("Provisioning gaps: 1", summary);
+    }
+}
+
+// Separate class: ProvisionGapLog is process-global state, so these must not interleave with
+// anything else touching it. They are pure in-memory calls, so serialising them costs nothing.
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class ProvisionGapLogTests
+{
+    [Fact]
+    public void Report_WritesToStderrAndRecords()
+    {
+        var original = Console.Error;
+        var captured = new StringWriter();
+        try
+        {
+            ProvisionGapLog.Reset();
+            Console.SetError(captured);
+            ProvisionGapLog.Report("a gap");
+        }
+        finally { Console.SetError(original); }
+
+        // Loud FIRST, recorded SECOND. .claude/rules/loud-failures.md means the summary is an
+        // addition; nothing about this may get quieter, so the stderr half is asserted too.
+        Assert.Contains("a gap", captured.ToString());
+        Assert.Equal(new[] { "a gap" }, ProvisionGapLog.Collected);
+    }
+
+    [Fact]
+    public void Reset_ForgetsThePreviousBundlesGaps()
+    {
+        var original = Console.Error;
+        try
+        {
+            Console.SetError(TextWriter.Null);
+            ProvisionGapLog.Reset();
+            ProvisionGapLog.Report("bundle one's missing package");
+            Assert.Single(ProvisionGapLog.Collected);
+
+            // Without this, bundle one's gap is attributed to every later bundle and every later
+            // --watch cycle — the run would keep reporting a problem the current bundle does not
+            // have.
+            ProvisionGapLog.Reset();
+            Assert.Empty(ProvisionGapLog.Collected);
+        }
+        finally { Console.SetError(original); }
+    }
+
+    [Fact]
+    public void Collected_IsACopy_SoALaterResetDoesNotEmptyWhatACallerAlreadyRead()
+    {
+        var original = Console.Error;
+        try
+        {
+            Console.SetError(TextWriter.Null);
+            ProvisionGapLog.Reset();
+            ProvisionGapLog.Report("a gap");
+            var read = ProvisionGapLog.Collected;
+
+            ProvisionGapLog.Reset();
+
+            // Program.cs reads Collected into the bundle's own list and the next bundle resets.
+            // Handing out the live list would empty that bundle's record from under it.
+            Assert.Equal(new[] { "a gap" }, read);
+        }
+        finally { Console.SetError(original); }
+    }
+}

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -126,7 +126,10 @@ public sealed class DependencyLoader
             if (microsoftSourceOnly && AlRunner.Infrastructure.ProvisioningCheck.IsKnownPlatformRuntimeApp(m.Name))
             {
                 var bcVer = AlRunner.Infrastructure.BcArtifacts.SelectedVersion.ToString();
-                Console.Error.WriteLine(
+                // Reported, not just printed: this block predicts the run's failure exactly, and
+                // on a long run it scrolls thousands of lines above the summary the caller reads.
+                // Still loud on stderr — see Infrastructure/ProvisionGapLog.cs (#2587).
+                AlRunner.Infrastructure.ProvisionGapLog.Report(
                     AlRunner.Infrastructure.ProvisioningCheck.BuildPlatformAppMissingR2RMessage(
                         m.Publisher, m.Name, m.Version.ToString(), path, bcVer));
                 continue;

--- a/AlRunner/Infrastructure/ProvisionGapLog.cs
+++ b/AlRunner/Infrastructure/ProvisionGapLog.cs
@@ -1,0 +1,57 @@
+// ProvisionGapLog — carries a provisioning-gap message from the dependency load that finds it
+// up to the run summary, without making it any quieter on the way.
+//
+// WHY THIS EXISTS (issue #2587)
+//   Two messages predict a run's failure exactly, and both were printed once, at the point of
+//   discovery, and never mentioned again:
+//
+//     * DependencyResolver.UnservableDependencies — a dependency no loader tier can serve.
+//       Printed in Program.cs right after resolution, where the bundle loop CAN see it.
+//     * DependencyLoader's symbol-only platform-app note — a known Microsoft platform runtime
+//       app found as a symbol-only package. Reported from inside the dependency load, several
+//       layers below the bundle loop, so it has nothing to hand the message to. That is the one
+//       this collector exists for.
+//
+//   Measured on npcore: four such blocks at about 20 seconds in, then 212 seconds of emit and
+//   compile, then "The object with ID 0 does not have a member with that ID" — precisely what
+//   those blocks predicted — with roughly 2,600 lines of log in between. A caller reading the
+//   bottom of the run concludes their AL is broken. It is not; their package cache is
+//   unprovisioned, and the runner said so, 2,600 lines earlier.
+//
+// A COLLECTOR, NOT A REPLACEMENT
+//   Report still writes to stderr exactly as before (.claude/rules/loud-failures.md — nothing
+//   here gets quieter) and only ALSO records. The summary is a second, findable statement of
+//   the same thing, not a relocation of the first.
+namespace AlRunner.Infrastructure;
+
+internal static class ProvisionGapLog
+{
+    private static readonly object _lock = new();
+    private static List<string> _gaps = new();
+
+    /// <summary>
+    /// Forget the previous bundle's gaps. Called once per bundle: a run walks bundles in
+    /// sequence and a --watch session re-runs them forever, so without this the first bundle's
+    /// missing package is attributed to every later bundle and every later cycle.
+    /// </summary>
+    internal static void Reset()
+    {
+        lock (_lock) _gaps = new List<string>();
+    }
+
+    /// <summary>Report one gap: loud on stderr (unchanged), and recorded for the summary.</summary>
+    internal static void Report(string message)
+    {
+        Console.Error.WriteLine(message);
+        lock (_lock) _gaps.Add(message);
+    }
+
+    /// <summary>
+    /// What has been reported since the last <see cref="Reset"/>. A copy, so a caller that has
+    /// already read it keeps what it read when the next bundle resets.
+    /// </summary>
+    internal static IReadOnlyList<string> Collected
+    {
+        get { lock (_lock) return _gaps.ToList(); }
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1946,6 +1946,17 @@ foreach (var bundle in bundles)
     // without deps doesn't inherit a sibling bundle's Install codeunits.
     AlRunner.InstallTriggerRunner.ResetForNewBundle();
 
+    // Everything about this bundle that says "your package cache cannot serve this run":
+    // dependencies no loader tier can implement (DependencyResolver.UnservableDependencies,
+    // added below where they are printed) plus platform runtime apps found symbol-only
+    // (reported from inside the dependency load, hence the collector). Collected as well as
+    // printed so the run summary can name them again at the end — see Reporter.PrintSummary.
+    // Declared this high because dependency resolution happens far above the bundle's other
+    // per-bucket state, and reset per bundle so one bundle's missing package is not attributed
+    // to every later bundle and every later --watch cycle.
+    var bundleProvisionGaps = new List<string>();
+    AlRunner.Infrastructure.ProvisionGapLog.Reset();
+
     // ── per-bucket dep resolution ──────────────────────────────────────────
     // Hoisted out of the try block below so EmitSiblingSymbols (called later, once
     // per bundle) can pass this bundle's resolved Microsoft-platform closure into
@@ -2036,7 +2047,10 @@ foreach (var bundle in bundles)
                 // certain object-ID-0 failure later, and #1689 is precisely the report that
                 // nothing named it. One line per app, and only for a shape that cannot work.
                 foreach (var u in resolver.UnservableDependencies)
+                {
                     Console.Error.WriteLine(u);
+                    bundleProvisionGaps.Add(u);
+                }
                 // Compiler sees only non-workspace dirs in its .app scanner; the
                 // synthetic workspace dirs are registered as symbols.json-only
                 // sources via SetExtraSymbolDirs (called AFTER SetResolvedDeps,
@@ -2056,6 +2070,9 @@ foreach (var bundle in bundles)
                 // as `dep-load:<Name>` (see DependencyLoader.LoadAll). Wrapping it here too
                 // would nest, and nested stages double-count — see PhaseLog.Stage.
                 var loaded = depLoader.LoadAll(ordered, depRootDir);
+                // Platform runtime apps the load found symbol-only. Read straight after the load
+                // that produces them, before anything else can reset the collector.
+                bundleProvisionGaps.AddRange(AlRunner.Infrastructure.ProvisionGapLog.Collected);
                 // Issue #2239: same as "resolved N dep(s)" above — gated behind --verbose.
                 if (AlRunner.Log.Verbose)
                     Console.WriteLine($"  [{rel}] loaded {loaded.Count} dep assembl(ies)");
@@ -3194,7 +3211,7 @@ foreach (var bundle in bundles)
     if (bundleTests.Count == 0 && bundleErrors.Count > 0) bundleStage = BucketStage.CompileFailed;
     results.Add(new BucketResult(bundleAbs, bundleStage,
         bundleErrors, null, bundleTests,
-        bundleEmit, bundleComp, bundleRun, ranGroupCount));
+        bundleEmit, bundleComp, bundleRun, ranGroupCount, bundleProvisionGaps));
     // Appended here, not buffered to process exit: a run that dies mid-way still
     // yields a row for every bundle it did finish. The row's wall clock covers this
     // whole loop turn, so wall − (emit+compile+run) is the per-bundle overhead

--- a/AlRunner/Reporter.cs
+++ b/AlRunner/Reporter.cs
@@ -20,7 +20,16 @@ public sealed record BucketResult(string BucketPath, BucketStage Stage,
                                    // signal alongside the test-count baseline — see that file's header
                                    // for why a whole-group-vanished bug can hide behind an unchanged
                                    // test count.
-                                   int RanGroupCount = 0);
+                                   int RanGroupCount = 0,
+                                   // Everything about this bundle that says the package cache
+                                   // could not serve the run: DependencyResolver's unservable
+                                   // dependencies, plus platform runtime apps the dependency load
+                                   // found symbol-only. Each is printed once at discovery time,
+                                   // ~20s into a run that then spends minutes compiling — so
+                                   // PrintSummary repeats them at the end, where a scripted caller
+                                   // and a human scrolling to the bottom actually look (#2587).
+                                   // Optional/trailing for the same reason as RanGroupCount.
+                                   IReadOnlyList<string>? ProvisionGaps = null);
 
 public static class Reporter
 {
@@ -98,6 +107,31 @@ public static class Reporter
         var testData = AlRunner.TestDataProvisioner.LastSummary;
         if (testData != null)
             w.WriteLine(testData.Describe());
+        // A dependency no loader tier can serve is reported once, per bundle, on stderr at
+        // dependency-resolution time — then the run spends minutes compiling and says nothing
+        // more about it. Measured on npcore: four such blocks at ~20s, 212s of emit and compile,
+        // and a failure whose message was exactly what those blocks predicted, with ~2,600 lines
+        // of log in between. This is the part a scripted caller and a human scrolling to the
+        // bottom actually read, so it repeats them verbatim — each block is what names the app,
+        // the winning path and the fix command.
+        //
+        // Only when there ARE gaps: a section printed on every run is noise, and every
+        // integration test asserting on the markers above would then be asserting past it.
+        var gaps = buckets
+            .SelectMany(b => b.ProvisionGaps ?? Array.Empty<string>())
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+        if (gaps.Count > 0)
+        {
+            w.WriteLine("-----------------------------------------------------------------");
+            // Counts them and gets out of the way. Two sources feed this and their consequences
+            // differ — an unservable dependency really does fail every call into it, while a
+            // symbol-only platform app falls back to service-tier DLL dispatch and often works.
+            // A heading asserting either one is wrong for the other half, and each block already
+            // carries its own consequence and its own fix command.
+            w.WriteLine($"Provisioning gaps: {gaps.Count} — the package cache could not fully serve this run.");
+            foreach (var g in gaps) w.WriteLine(g);
+        }
         w.WriteLine("=================================================================");
     }
 


### PR DESCRIPTION
## What was wrong

Two messages predict a run's failure exactly, and both were printed once, at the point of discovery, and never mentioned again:

- `DependencyResolver.UnservableDependencies` — a dependency no loader tier can serve.
- `DependencyLoader`'s note that a known Microsoft platform runtime app was found as a symbol-only package.

Measured on npcore: four such blocks at about 20 seconds in, then 212 seconds of emit and compile, then `The object with ID 0 does not have a member with that ID` — precisely what those blocks predicted — with roughly 2,600 lines of log in between. A caller reading the bottom of the run concludes their AL is broken. It is not; their package cache is unprovisioned, and the runner said so, 2,600 lines earlier.

## What this does

Collects them per bundle and restates them in `Reporter.PrintSummary`. Four things it deliberately keeps:

- **The discovery-time stderr write is unchanged.** This adds a second, findable statement; it does not move the first (`.claude/rules/loud-failures.md`).
- **The collection resets per bundle.** A run walks bundles in sequence and `--watch` re-runs them, so without a reset the first bundle's missing package is attributed to every later bundle and every later cycle.
- **The section prints only when there is something to print.** A section on every run is noise, and every integration test asserting on the existing summary markers would then be asserting past it.
- **The heading counts and gets out of the way.** The two sources have different consequences — an unservable dependency fails every call into it, while a symbol-only platform app falls back to service-tier DLL dispatch and often works — so a heading asserting either one is wrong for the other half. Each block already names the app, the winning path and the fix command, and is repeated verbatim so the reader is not sent back up the log.

`ProvisionGapLog` exists for the one report that originates inside the dependency load, several layers below the bundle loop, with no return path to thread it through. The unservable-dependency list is collected where it is already printed, in `Program.cs`, which can see the bundle directly.

## Proof

RED → GREEN, measured by removing the summary section and re-running:

| | Result |
|---|---|
| Without the summary section | 3 failed, 4 passed |
| This PR | 7 passed |

The four that pass in both directions are the negatives, and they are the point: a clean run's summary contains no section at all, `Collected` hands out a copy so a later `Reset` cannot empty what a caller already read, and `Reset` really forgets. A section printed unconditionally, or a collector that never reset, would satisfy "the gap is named" and still be wrong.

Nothing here is a claim about Business Central — it is entirely the runner's own reporting — so no corpus test applies and this PR does not touch the submodule pin or the count baseline.

## Credit

Found by Mikkel Mansa Vilhelmsen (`vhn`), who hit exactly this on npcore and implemented an equivalent on his fork (commit `c7590d28`). The npcore measurement above is his. No code was copied.

Closes #2587

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
