### PR TITLE
Report a real peak RSS on macOS instead of a silent zero

### DIFF
--- a/AlRunner.Tests/PhaseLogTests.cs
+++ b/AlRunner.Tests/PhaseLogTests.cs
@@ -424,4 +424,32 @@ public sealed class PhaseLogTests : IDisposable
         var rss = PhaseLog.PeakRssBytes();
         Assert.True(rss > 8 * 1024 * 1024, $"peak RSS looks stubbed: {rss} bytes");
     }
+
+    /// <summary>
+    /// Peak RSS must be in BYTES on every platform, and the floor above cannot check that.
+    /// The live hazard is a units error, not a wrong number: the field this reads is bytes
+    /// on Darwin and kilobytes on Linux, so reading one convention on the other platform
+    /// produces a value about 1024x off — and a value 1024x too small still clears an
+    /// "8 MB" floor on a process using several GB.
+    ///
+    /// A high-water mark can never be below the current working set, and the current
+    /// working set of this test process is a real number in real bytes from a source this
+    /// code does not touch. So that comparison pins the units from below on all three
+    /// platforms at once, without an upper bound: a ratio ceiling would be a flake on a
+    /// loaded CI machine, where the suite spawns runner subprocesses and does heavy AL
+    /// compiles, peaks high, and then releases.
+    /// </summary>
+    [Fact]
+    public void PeakRssBytes_IsInBytes_AndNotBelowTheCurrentWorkingSet()
+    {
+        using var self = System.Diagnostics.Process.GetCurrentProcess();
+        var live = self.WorkingSet64;
+        var peak = PhaseLog.PeakRssBytes();
+
+        Assert.True(live > 0, $"the test's own working set should be readable, got {live}");
+        Assert.True(peak >= live,
+            $"peak RSS {peak} is below this process's current working set {live}; "
+            + "a high-water mark cannot be, so the value is in the wrong units or read "
+            + "from the wrong field");
+    }
 }

--- a/AlRunner/Infrastructure/PhaseLog.cs
+++ b/AlRunner/Infrastructure/PhaseLog.cs
@@ -547,8 +547,11 @@ public static class PhaseLog
     /// <summary>
     /// This process's resident-set high-water mark in bytes. Linux reads VmHWM from
     /// /proc/self/status — the kernel's own high-water mark, which .NET's
-    /// PeakWorkingSet64 does not surface on Unix. Falls back to the framework
-    /// property elsewhere.
+    /// PeakWorkingSet64 does not surface on Unix. macOS reads getrusage's ru_maxrss,
+    /// because .NET does not implement PeakWorkingSet64 there at all: it returns 0,
+    /// and a silent zero is worse than a missing field, since the aggregate built on
+    /// top presents it as a measurement of a run that used no memory. Falls back to
+    /// the framework property elsewhere.
     /// </summary>
     public static long PeakRssBytes()
     {
@@ -563,7 +566,25 @@ public static class PhaseLog
                     if (long.TryParse(kb, out var v)) return v * 1024;
                 }
             }
+
             using var self = System.Diagnostics.Process.GetCurrentProcess();
+
+            if (OperatingSystem.IsMacOS())
+            {
+                var maxRss = DarwinPeakRssBytes();
+                // A high-water mark cannot be below the current working set. That check is
+                // what catches the live hazard, which is a units error rather than a wrong
+                // number: ru_maxrss is BYTES on Darwin and KILOBYTES on Linux, so reading
+                // the Linux convention on a Mac produces a value about 1024x too small —
+                // one that sails past any "greater than a few MB" floor while being wrong.
+                // It also catches a wrong field offset, which would read some other member
+                // of struct rusage. On either failure, fall back to the current working
+                // set: a real measurement and a valid lower bound on the peak, rather than
+                // a made-up number or a zero.
+                if (maxRss >= self.WorkingSet64) return maxRss;
+                return self.WorkingSet64;
+            }
+
             return self.PeakWorkingSet64;
         }
         catch
@@ -571,6 +592,47 @@ public static class PhaseLog
             return 0;
         }
     }
+
+    /// <summary>
+    /// <c>getrusage(RUSAGE_SELF).ru_maxrss</c> on Darwin, already in bytes there.
+    ///
+    /// The P/Invoke declares the WHOLE <c>struct rusage</c> and reads one explicit offset.
+    /// That is not tidiness: getrusage writes the entire structure, so a declaration
+    /// carrying only the field being read would let the kernel write past the buffer.
+    ///
+    /// The layout is the same on both Darwin ABIs. Darwin's <c>timeval</c> is an 8-byte
+    /// <c>tv_sec</c> plus a 4-byte <c>tv_usec</c> plus 4 bytes of padding = 16; <c>ru_utime</c>
+    /// and <c>ru_stime</c> take the first 32 bytes, putting <c>ru_maxrss</c> at offset 32;
+    /// fourteen more <c>long</c>s follow, for 144 in total, on x86_64 and arm64 alike.
+    /// <c>RUSAGE_SELF</c> is 0.
+    /// </summary>
+    private static long DarwinPeakRssBytes()
+    {
+        try
+        {
+            var usage = default(DarwinRusage);
+            return getrusage(RusageSelf, ref usage) == 0 ? usage.MaxRss : 0;
+        }
+        catch
+        {
+            // DllNotFoundException / EntryPointNotFoundException on anything that is not
+            // the Darwin libc. The caller falls back rather than reporting a zero.
+            return 0;
+        }
+    }
+
+    private const int RusageSelf = 0;
+
+    [System.Runtime.InteropServices.StructLayout(
+        System.Runtime.InteropServices.LayoutKind.Explicit, Size = 144)]
+    private struct DarwinRusage
+    {
+        [System.Runtime.InteropServices.FieldOffset(32)]
+        public long MaxRss;
+    }
+
+    [System.Runtime.InteropServices.DllImport("libc", SetLastError = true)]
+    private static extern int getrusage(int who, ref DarwinRusage usage);
 
     /// <summary>
     /// Appends one complete record under an exclusive open, so concurrent writers in


### PR DESCRIPTION
`PhaseLog.PeakRssBytes()` read the kernel's high-water mark from `VmHWM` on Linux and otherwise fell back to `Process.PeakWorkingSet64`, which .NET does not implement on macOS — it returns 0. So every phase log written on a Mac reported `peak_rss_bytes: 0`, and the aggregate built on top presented that zero as a measurement of a run that used no memory.

Per `loud-failures.md` a silent default is exactly the shape to avoid. This one also made three existing assertions permanently red on macOS while green on CI.

## The fix

Darwin's `getrusage` carries the same high-water mark, so the macOS branch reads `ru_maxrss` — already **bytes** there, unlike Linux's `getrusage` where the identical field is kilobytes.

The P/Invoke declares the whole `struct rusage` (`Size = 144`) and reads one explicit offset, because `getrusage` writes the entire structure: a declaration carrying only the field being read would let the kernel write past the buffer. The layout is the same on both Darwin ABIs — `timeval` is an 8-byte `tv_sec` plus a 4-byte `tv_usec` plus 4 bytes of padding = 16, so `ru_utime` and `ru_stime` take the first 32 bytes, `ru_maxrss` sits at offset 32, and fourteen more `long`s follow, for 144 in total on x86_64 and arm64 alike.

## What I could not verify, and what I did instead

**I have no Mac, and CI has no macOS runner** — `runs-on` is `ubuntu-latest` everywhere except one `windows-latest` job. So no leg of this repo's CI executes the new branch, and I could not run it myself. The layout above comes from the Darwin headers, not from a measurement on the platform.

Rather than trust it, the value is sanity-checked at runtime: a high-water mark cannot be below the current working set, and if it is, the code falls back to the working set — a real measurement and a valid lower bound on the peak, rather than a made-up number or a zero. That check also catches a wrong field offset, which would read some other member of the struct.

## The test

The existing `> 8 MB` floor cannot catch the live hazard, which is a units error rather than a wrong number: a value 1024x too small still clears an 8 MB floor on a process using several GB.

The new test compares against the test process's own working set instead, which pins the units from below on all three platforms at once. No upper bound: a ratio ceiling would be a flake on a loaded CI leg, where the suite spawns runner subprocesses and does heavy AL compiles, peaks high, and then releases.

**Verified RED.** Dropping the `* 1024` from the Linux branch — the same units error, on the platform I can run — makes it fail with:

```
peak RSS 161508 is below this process's current working set 165347328;
a high-water mark cannot be, so the value is in the wrong units or read from the wrong field
```

Restoring it makes all 23 PhaseLog tests pass.

## Credit

Found by Mikkel Mansa Vilhelmsen (@vhn-mmv), commit `e8d81026` on his fork, which includes a clang `static_assert` probe for the struct layout on both Darwin ABIs.

Closes #2553

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf