### PR TITLE
fix(testpage): TestPage.<part> adopts the host's own subpage instance

### DIFF
--- a/AlRunner.Tests/TestPagePartAdoptedFromHostTests.cs
+++ b/AlRunner.Tests/TestPagePartAdoptedFromHostTests.cs
@@ -1,0 +1,220 @@
+// TestPagePartAdoptedFromHostTests — issue #2201 (TestPage.<part> and the host's own
+// CurrPage.<part>.Page used to be two DIFFERENT NavForm instances for the same subpage
+// control).
+//
+// This is a RUNNER-MECHANISM test, not a claim about what real BC does: it proves that OUR
+// OWN dispatch path — MockTestPage.GetPart via RunnerPageInstance.AdoptFromHost — reaches the
+// SAME NavForm the host's own compiled AL gets back from CurrPage.<part>, rather than building
+// a second, disconnected instance the way TestPageFactory.TryBuild/TryBuildRecordless alone
+// used to. The BEHAVIORAL claim ("a SourceTableTemporary part's rows, pushed from the host's
+// own OnOpenPage, must be visible to both the host's own AL and the TestPage that later reads
+// it, on real BC") is proven upstream against a live BC service tier — see
+// StefanMaron/BusinessCentral.AL.Language.Tests, "TP SrcTemp Tests" (codeunit 60807), per
+// .claude/rules/bc-behavior-tests-go-upstream.md. This test exists so a regression in OUR OWN
+// instance-adoption mechanism fails loudly here, without needing the corpus's al-language
+// submodule pin bumped first.
+//
+// RED/GREEN proof: reverting RunnerPageInstance.AdoptFromHost to always return null (the
+// pre-fix shape, where MockTestPage.GetPart falls straight through to
+// TestPageFactory.TryBuild/TryBuildRecordless) makes
+// HostSeededTemporaryPart_TestPageSeesTheSameRow fail: TestPage.Lines.First() finds no row,
+// because the disconnected instance TryBuild constructs never received the row the host's
+// OnOpenPage pushed into the ADOPTED instance's own temporary Rec.
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPagePartAdoptedFromHostTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly string _root;
+
+    public TestPagePartAdoptedFromHostTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-testpage-part-adopted-from-host", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private static string[] ExtraPackageCacheArgs()
+    {
+        var platformApps = TestArtifacts.PlatformAppsDir();
+        return Directory.Exists(platformApps)
+            ? new[] { "--package-cache", platformApps }
+            : Array.Empty<string>();
+    }
+
+    /// <summary>
+    /// A ListPart declaring SourceTableTemporary, hosted on a Card page that pushes one row
+    /// into it from OnOpenPage — before the TestPage side ever touches the part. The part's
+    /// own temporary Rec only exists on whichever instance the host wrote through; a
+    /// disconnected second instance has an EMPTY table, not merely a stale value.
+    /// </summary>
+    private void WriteBundle()
+    {
+        Directory.CreateDirectory(_root);
+        File.WriteAllText(Path.Combine(_root, "app.json"), """
+        {
+          "id": "d2e3f4a5-6b7c-4890-9d0e-1f2a3b4c5d02",
+          "name": "Runner Mechanism - TestPage Part Adopted From Host",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62410, "to": 62412 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "TpahRow.Table.al"), """
+        table 62410 "Tpah Row"
+        {
+            DataClassification = CustomerContent;
+
+            fields
+            {
+                field(1; "Entry No."; Integer) { }
+                field(2; Name; Text[50]) { }
+            }
+
+            keys
+            {
+                key(PK; "Entry No.") { Clustered = true; }
+            }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "TpahPart.Page.al"), """
+        page 62411 "Tpah Part"
+        {
+            PageType = ListPart;
+            SourceTable = "Tpah Row";
+            SourceTableTemporary = true;
+            ApplicationArea = All;
+
+            layout
+            {
+                area(Content)
+                {
+                    repeater(Rows)
+                    {
+                        field(Name; Rec.Name)
+                        {
+                            ApplicationArea = All;
+                        }
+                    }
+                }
+            }
+
+            internal procedure SetRows(var TempRow: Record "Tpah Row" temporary)
+            begin
+                Rec.DeleteAll();
+                if TempRow.FindSet() then
+                    repeat
+                        Rec := TempRow;
+                        Rec.Insert();
+                    until TempRow.Next() = 0;
+            end;
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "TpahHost.Page.al"), """
+        page 62412 "Tpah Host"
+        {
+            PageType = Card;
+            ApplicationArea = All;
+
+            layout
+            {
+                area(Content)
+                {
+                    part(Lines; "Tpah Part")
+                    {
+                        ApplicationArea = All;
+                    }
+                }
+            }
+
+            trigger OnOpenPage()
+            var
+                TempRow: Record "Tpah Row" temporary;
+            begin
+                TempRow."Entry No." := 1;
+                TempRow.Name := 'FROM-HOST';
+                TempRow.Insert();
+                CurrPage.Lines.Page.SetRows(TempRow);
+            end;
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "TpahTests.Codeunit.al"), """
+        codeunit 62409 "Tpah Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure HostSeededTemporaryPart_TestPageSeesTheSameRow()
+            var
+                Host: TestPage "Tpah Host";
+            begin
+                Host.OpenEdit();
+
+                if not Host.Lines.First() then
+                    Error('TestPage.Lines must show the row the host inserted from OnOpenPage — the part page instance must be the SAME one the host wrote through');
+                if Host.Lines.Name.Value() <> 'FROM-HOST' then
+                    Error('the row value must be what the host wrote, got: ' + Host.Lines.Name.Value());
+
+                Host.Close();
+            end;
+        }
+        """);
+    }
+
+    private (string output, int exit) RunBundled()
+    {
+        var args = new StringBuilder(
+            TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg + $" \"{_root}\"");
+        foreach (var a in ExtraPackageCacheArgs()) args.Append($" \"{a}\"");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(600_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>
+    /// Positive: the TestPage's own read must see the row through the SAME part page instance
+    /// the host's OnOpenPage wrote through, not a disconnected second one seeded from nothing.
+    /// </summary>
+    [SkippableFact]
+    public void HostSeededTemporaryPart_TestPageSeesTheSameRow()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        WriteBundle();
+        var (output, exit) = RunBundled();
+
+        Assert.True(exit == 0, $"Expected the bundle to pass; exit={exit}\n{output}");
+        Assert.Contains("PASS  Codeunit62409.HostSeededTemporaryPart_TestPageSeesTheSameRow", output);
+        Assert.DoesNotContain("FAIL", output);
+    }
+}

--- a/AlRunner.Tests/TestPagePartAdoptedFromHostTests.cs
+++ b/AlRunner.Tests/TestPagePartAdoptedFromHostTests.cs
@@ -3,23 +3,39 @@
 // control).
 //
 // This is a RUNNER-MECHANISM test, not a claim about what real BC does: it proves that OUR
-// OWN dispatch path — MockTestPage.GetPart via RunnerPageInstance.AdoptFromHost — reaches the
-// SAME NavForm the host's own compiled AL gets back from CurrPage.<part>, rather than building
-// a second, disconnected instance the way TestPageFactory.TryBuild/TryBuildRecordless alone
-// used to. The BEHAVIORAL claim ("a SourceTableTemporary part's rows, pushed from the host's
-// own OnOpenPage, must be visible to both the host's own AL and the TestPage that later reads
-// it, on real BC") is proven upstream against a live BC service tier — see
-// StefanMaron/BusinessCentral.AL.Language.Tests, "TP SrcTemp Tests" (codeunit 60807), per
-// .claude/rules/bc-behavior-tests-go-upstream.md. This test exists so a regression in OUR OWN
-// instance-adoption mechanism fails loudly here, without needing the corpus's al-language
-// submodule pin bumped first.
+// OWN dispatch path reaches the SAME NavForm the host's own compiled AL gets back from
+// CurrPage.<part>, rather than building a second, disconnected instance the way
+// TestPageFactory.TryBuild/TryBuildRecordless alone used to. Two mechanisms, one per test:
 //
-// RED/GREEN proof: reverting RunnerPageInstance.AdoptFromHost to always return null (the
-// pre-fix shape, where MockTestPage.GetPart falls straight through to
-// TestPageFactory.TryBuild/TryBuildRecordless) makes
-// HostSeededTemporaryPart_TestPageSeesTheSameRow fail: TestPage.Lines.First() finds no row,
-// because the disconnected instance TryBuild constructs never received the row the host's
-// OnOpenPage pushed into the ADOPTED instance's own temporary Rec.
+//   - HostSeededTemporaryPart_TestPageSeesTheSameRow: RunnerPageInstance.AdoptFromHost
+//     reaches the host's own live subpage object via NavForm.GetPart(int) and reifies it in
+//     place, reusing an already-bound record instead of rebinding a fresh empty one.
+//   - HostWriteBeforeTestPageTouch_TestPageSeesTheHostWrite: RunnerFormInit
+//     .OnSubpagePartResolved, a Cecil-injected call appended to NavForm.GetPart(int) itself,
+//     reifies a page-globals part (running its OnOpenPage) the FIRST time EITHER side reaches
+//     it through GetPart — needed because a page-globals part's host write is a plain
+//     procedure call that never touches EnsureMetadataLoaded, so AdoptFromHost's own
+//     "already touched" check (which the first mechanism relies on) has nothing to observe.
+//
+// The BEHAVIORAL claims ("a SourceTableTemporary part's rows, pushed from the host's own
+// OnOpenPage, must be visible to both sides"; "a page-globals part's host write must be
+// visible to the TestPage side, even when the host writes before the TestPage side ever
+// touches the part") are proven upstream against a live BC service tier — see
+// StefanMaron/BusinessCentral.AL.Language.Tests, "TP SrcTemp Tests" (codeunit 60807) and
+// "Test Page NoSrc Part Tests" (codeunit 60803), per
+// .claude/rules/bc-behavior-tests-go-upstream.md. These tests exist so a regression in OUR
+// OWN instance-adoption mechanisms fails loudly here, without needing the corpus's
+// al-language submodule pin bumped first.
+//
+// RED/GREEN proof (both confirmed by temporarily disabling the fix and rebuilding):
+//   - Reverting RunnerPageInstance.AdoptFromHost to always return null makes
+//     HostSeededTemporaryPart_TestPageSeesTheSameRow fail: TestPage.Lines.First() finds no
+//     row, because the disconnected instance TryBuild constructs never received the row the
+//     host's OnOpenPage pushed into the ADOPTED instance's own temporary Rec.
+//   - Emptying RunnerFormInit.OnSubpagePartResolved's body makes
+//     HostWriteBeforeTestPageTouch_TestPageSeesTheHostWrite fail: TestPage.Info.Tag.Value()
+//     reads 'Hello' (the part's own OnOpenPage, run LATE once the TestPage side finally asks)
+//     instead of 'FROM-HOST' (what the host already wrote).
 using System.Diagnostics;
 using System.Text;
 using Xunit;
@@ -70,7 +86,7 @@ public sealed class TestPagePartAdoptedFromHostTests : IDisposable
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "idRanges": [ { "from": 62410, "to": 62412 } ],
+          "idRanges": [ { "from": 62410, "to": 62413 } ],
           "runtime": "14.0"
         }
         """);
@@ -157,7 +173,7 @@ public sealed class TestPagePartAdoptedFromHostTests : IDisposable
         """);
 
         File.WriteAllText(Path.Combine(_root, "TpahTests.Codeunit.al"), """
-        codeunit 62409 "Tpah Tests"
+        codeunit 62413 "Tpah Tests"
         {
             Subtype = Test;
 
@@ -172,6 +188,121 @@ public sealed class TestPagePartAdoptedFromHostTests : IDisposable
                     Error('TestPage.Lines must show the row the host inserted from OnOpenPage — the part page instance must be the SAME one the host wrote through');
                 if Host.Lines.Name.Value() <> 'FROM-HOST' then
                     Error('the row value must be what the host wrote, got: ' + Host.Lines.Name.Value());
+
+                Host.Close();
+            end;
+        }
+        """);
+    }
+
+    /// <summary>
+    /// A CardPart whose OWN page declares no SourceTable at all — every control is bound to
+    /// a page global, and the page's own AL is the only thing that ever writes one. The host
+    /// writes through it (a plain procedure call, <c>CurrPage.Info.Page.SetTag(...)</c>) from
+    /// its OWN field's OnValidate, driven from the TESTPAGE side BEFORE the TestPage side
+    /// ever reads <c>Host.Info</c> — the exact ordering issue #2201's own repro used, and the
+    /// one AdoptFromHost alone could not fix (a plain procedure call never touches
+    /// EnsureMetadataLoaded, so there is no signal AdoptFromHost's own "already touched"
+    /// check can observe). RunnerFormInit.OnSubpagePartResolved (the Cecil hook appended to
+    /// NavForm.GetPart(int)) is what fixes this: it reifies a page-globals part — including
+    /// running its own OnOpenPage — the FIRST time EITHER side reaches it through GetPart,
+    /// before returning the object to whichever side asked.
+    /// </summary>
+    private void WriteGlobalsRaceBundle()
+    {
+        Directory.CreateDirectory(_root);
+        File.WriteAllText(Path.Combine(_root, "app.json"), """
+        {
+          "id": "e3f4a5b6-7c8d-4901-ae1f-2a3b4c5d6e03",
+          "name": "Runner Mechanism - TestPage Part Globals Race",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62420, "to": 62429 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "TpgrInfo.Page.al"), """
+        page 62420 "Tpgr Info"
+        {
+            PageType = CardPart;
+            ApplicationArea = All;
+
+            layout
+            {
+                area(Content)
+                {
+                    field(Tag; TagValue)
+                    {
+                        ApplicationArea = All;
+                    }
+                }
+            }
+
+            trigger OnOpenPage()
+            begin
+                TagValue := 'Hello';
+            end;
+
+            var
+                TagValue: Text;
+
+            internal procedure SetTag(NewTag: Text)
+            begin
+                TagValue := NewTag;
+            end;
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "TpgrHost.Page.al"), """
+        page 62421 "Tpgr Host"
+        {
+            PageType = Card;
+            ApplicationArea = All;
+
+            layout
+            {
+                area(Content)
+                {
+                    field(Mode; SelectedMode)
+                    {
+                        ApplicationArea = All;
+
+                        trigger OnValidate()
+                        begin
+                            CurrPage.Info.Page.SetTag(SelectedMode);
+                        end;
+                    }
+
+                    part(Info; "Tpgr Info")
+                    {
+                        ApplicationArea = All;
+                    }
+                }
+            }
+
+            var
+                SelectedMode: Text;
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "TpgrTests.Codeunit.al"), """
+        codeunit 62422 "Tpgr Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure HostWriteBeforeTestPageTouch_TestPageSeesTheHostWrite()
+            var
+                Host: TestPage "Tpgr Host";
+            begin
+                Host.OpenEdit();
+                Host.Mode.SetValue('FROM-HOST');
+
+                if Host.Info.Tag.Value() <> 'FROM-HOST' then
+                    Error('TestPage.Info must be the SAME instance the host already wrote through; got: ' + Host.Info.Tag.Value());
 
                 Host.Close();
             end;
@@ -214,7 +345,33 @@ public sealed class TestPagePartAdoptedFromHostTests : IDisposable
         var (output, exit) = RunBundled();
 
         Assert.True(exit == 0, $"Expected the bundle to pass; exit={exit}\n{output}");
-        Assert.Contains("PASS  Codeunit62409.HostSeededTemporaryPart_TestPageSeesTheSameRow", output);
+        Assert.Contains("PASS  Codeunit62413.HostSeededTemporaryPart_TestPageSeesTheSameRow", output);
+        Assert.DoesNotContain("FAIL", output);
+    }
+
+    /// <summary>
+    /// Positive: a page-globals part the host already wrote through (via a plain procedure
+    /// call, never touching EnsureMetadataLoaded) must still read the host's write from the
+    /// TestPage side — proving the Cecil hook on NavForm.GetPart(int) reifies the part (and
+    /// runs its OnOpenPage) before either side's first real touch, not just before the
+    /// runner's own AdoptFromHost call.
+    ///
+    /// RED/GREEN proof: with RunnerFormInit.OnSubpagePartResolved's body emptied (the
+    /// pre-fix shape — GetPart(int) still gets hooked, but the hook does nothing), this
+    /// fails: TestPage.Info.Tag.Value() reads 'Hello' (the part's own OnOpenPage, run LATE by
+    /// AdoptFromHost when the TestPage side finally asks) instead of 'FROM-HOST' (what the
+    /// host already wrote).
+    /// </summary>
+    [SkippableFact]
+    public void HostWriteBeforeTestPageTouch_TestPageSeesTheHostWrite()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        WriteGlobalsRaceBundle();
+        var (output, exit) = RunBundled();
+
+        Assert.True(exit == 0, $"Expected the bundle to pass; exit={exit}\n{output}");
+        Assert.Contains("PASS  Codeunit62422.HostWriteBeforeTestPageTouch_TestPageSeesTheHostWrite", output);
         Assert.DoesNotContain("FAIL", output);
     }
 }

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -6277,6 +6277,58 @@ public static class NclCecilRewrite
             }
         }
 
+        // NavForm.GetPart(int) — issue #2201's page-globals shape. GetPart(int) is the one
+        // door BOTH the host's own compiled AL (CurrPage.<part> compiles to
+        // base.Parent.CurrPage.GetPart(controlId) — see MockTestPage.cs's GetPart doc
+        // comment) and the runner's own AdoptFromHost go through to reach a subpage part
+        // object. Appending a call to RunnerFormInit.OnSubpagePartResolved right before every
+        // `ret` — after the original body has already computed its return value, which stays
+        // on the stack for the `ret` untouched — gives the runner a hook at the EARLIEST
+        // point common to both callers, so a page-globals part's OnOpenPage can run before
+        // EITHER side's first real touch, not just before the runner's own.
+        //
+        // Appending after (not guarding before, unlike the block above) is deliberate:
+        // GetPart(int)'s own body must always run for real — it is BC's un-guarded lookup
+        // machinery, used by every page whether the runner is driving it or not — this only
+        // adds an observer, it does not gate anything.
+        //
+        // `dup; call OnSubpagePartResolved; ret` before EVERY ret in a non-void method is
+        // correct regardless of how many return points the JIT/compiler emits: IL
+        // well-formedness guarantees exactly one value is on the evaluation stack
+        // immediately before any `ret` in a non-void method, so this needs no assumption
+        // about a single-return-point shape.
+        {
+            var navFormT = asm.MainModule.Types
+                .FirstOrDefault(t => t.FullName == "Microsoft.Dynamics.Nav.Runtime.NavForm");
+            var getPartM = navFormT?.Methods.FirstOrDefault(m =>
+                m.Name == "GetPart" && m.HasBody && m.Parameters.Count == 1
+                && m.Parameters[0].ParameterType.FullName == "System.Int32"
+                && m.ReturnType.FullName == "Microsoft.Dynamics.Nav.Runtime.NavForm");
+            if (getPartM != null)
+            {
+                var hookRef = asm.MainModule.ImportReference(
+                    typeof(AlRunner.Patches.RunnerFormInit).GetMethod(
+                        nameof(AlRunner.Patches.RunnerFormInit.OnSubpagePartResolved),
+                        BindingFlags.Public | BindingFlags.Static)
+                    ?? throw new InvalidOperationException(
+                        "RunnerFormInit.OnSubpagePartResolved not found — do not commit"));
+
+                var il = getPartM.Body.GetILProcessor();
+                var rets = getPartM.Body.Instructions.Where(i => i.OpCode == OpCodes.Ret).ToList();
+                foreach (var ret in rets)
+                {
+                    il.InsertBefore(ret, il.Create(OpCodes.Dup));
+                    il.InsertBefore(ret, il.Create(OpCodes.Call, hookRef));
+                }
+                getPartM.Body.MaxStackSize = Math.Max(getPartM.Body.MaxStackSize, 3);
+                Console.Error.WriteLine($"[Cecil] Hooked NavForm.GetPart(int) → RunnerFormInit.OnSubpagePartResolved at {rets.Count} return point(s)");
+            }
+            else
+            {
+                Console.Error.WriteLine("[Cecil] WARN: NavForm.GetPart(int) not found — page-globals subpage OnOpenPage ordering (issue #2201) may be wrong");
+            }
+        }
+
         // Diagnostic prepend (gated by env AL_RUNNER_DIAG_IC=1): print marker at
         // entry of each Ncl method called by Report{N}.InitializeComponent.
         {

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -194,6 +194,9 @@ internal class LiveNavTestPage : MockITestPage
     {
         if (_parts.TryGetValue(controlId, out var cached)) return cached;
 
+        if (Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_PAGE_METADATA") == "1")
+            Console.Out.WriteLine($"[MockTestPage.GetPart] controlId={controlId} pageId={_pageId} _page={(_page == null ? "null" : "set")} _page.Form={( _page?.Form == null ? "null" : _page.Form.GetType().FullName)}");
+
         var definition = _page?.TryGetPartDefinition(controlId)
             ?? throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
                 $"TestPage part {controlId} (page {_pageId})",
@@ -242,38 +245,63 @@ internal class LiveNavTestPage : MockITestPage
         // (StefanMaron/BusinessCentral.AL.Language.Tests commit ef52b7e9, PR #80), all eight
         // arms green on BC 27.5 and BC 28.3.
         //
-        // CAVEAT worth knowing before extending this: the part page object built here is a
-        // FRESH RunnerPageInstance, not the subpage object the host's own NavForm owns, so
-        // TestPage.<part> and the host AL's CurrPage.<part>.Page are different instances.
-        // Invisible for a Rec-bound part (its state lives in the record); visible for a
-        // globals-bound one. Tracked as issue 2201.
+        // FIXED (issue #2201): the part page object is now, where possible, the SAME
+        // RunnerPageInstance the host's own AL reaches through CurrPage.<part> —
+        // RunnerPageInstance.AdoptFromHost goes through BC's own NavForm.GetPart(int) on
+        // the host, exactly the door the host's compiled AL uses. Only when that cannot
+        // produce a live object (the host has no NavForm, the control names no part there,
+        // or reifying the adopted object throws) does this fall back to the disconnected
+        // instance TryBuild/TryBuildRecordless constructs, which is the ENTIRE previous
+        // behaviour and stays exactly as faithful as it always was.
         NavRecord? partRecord;
         RunnerPageInstance? partPage;
-        switch (TestPageClientConstructionRule.Resolve(
-                    recordBuilt: built != null,
-                    pageShapeKnown: RecordPatches.IsPageShapeKnown(partPageId),
-                    pageDeclaresSourceTable: RecordPatches.ResolvePageDeclaresSourceTableForAnyPage(partPageId)))
+        // Whether partPage came from AdoptFromHost — that path already raised the part's
+        // OnOpenPage itself (once, at reification — see AdoptFromHost), so the fallback
+        // raise below must not run a second time on an adopted instance.
+        bool adopted;
+        var partKind = TestPageClientConstructionRule.Resolve(
+            recordBuilt: built != null,
+            pageShapeKnown: RecordPatches.IsPageShapeKnown(partPageId),
+            pageDeclaresSourceTable: RecordPatches.ResolvePageDeclaresSourceTableForAnyPage(partPageId));
+
+        if (partKind == TestPageClientKind.LiveOverRecord)
         {
-            case TestPageClientKind.LiveOverRecord:
-                partRecord = built!.Record;
-                partPage = built.Page;
-                break;
-
-            // No record and none needed. TryBuildRecordless answering null is a different
-            // failure — the runner has no metadata to build the part page object from, so
-            // there would be no control tree either — and falls through to the refusal.
-            case TestPageClientKind.LiveRecordless
-                when TestPageFactory.TryBuildRecordless(_owner, partPageId) is { } recordless:
-                partRecord = null;
-                partPage = recordless;
-                break;
-
-            default:
+            partRecord = built!.Record;
+            var fromHost = RunnerPageInstance.AdoptFromHost(_page?.Form, controlId, partPageId, partRecord, recordless: false);
+            adopted = fromHost != null;
+            partPage = fromHost ?? built.Page;
+            // AdoptFromHost may have reused a record ALREADY bound on the adopted instance
+            // (a SourceTableTemporary part the host already populated — see AdoptFromHost's
+            // "alreadyLive" branch) instead of the fresh one just built above. This part's
+            // OWN record must follow whichever one the live page object actually ended up
+            // bound to, or navigation/Insert/Delete would act on an empty record nobody else
+            // can see while the control tree reads the real one.
+            if (adopted && fromHost!.Record is { } liveRecord) partRecord = liveRecord;
+        }
+        else if (partKind == TestPageClientKind.LiveRecordless)
+        {
+            partRecord = null;
+            // No record and none needed. Both AdoptFromHost and TryBuildRecordless answering
+            // null is a different failure — the runner has no metadata to build the part page
+            // object from, so there would be no control tree either — and falls through to
+            // the refusal below.
+            var fromHost = RunnerPageInstance.AdoptFromHost(_page?.Form, controlId, partPageId, recordToBind: null, recordless: true);
+            adopted = fromHost != null;
+            partPage = fromHost ?? TestPageFactory.TryBuildRecordless(_owner, partPageId);
+            if (partPage == null)
                 throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
                     $"TestPage part {controlId} → page {partPageId}",
                     "testpage-part — the part's own page could not be driven live"
                     + (why == null ? string.Empty : $" ({why})")
                     + ". See docs/scope.md");
+        }
+        else
+        {
+            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                $"TestPage part {controlId} → page {partPageId}",
+                "testpage-part — the part's own page could not be driven live"
+                + (why == null ? string.Empty : $" ({why})")
+                + ". See docs/scope.md");
         }
 
         // The parent record is only needed to evaluate SubPageLink pairs (issue #2053). A
@@ -325,7 +353,12 @@ internal class LiveNavTestPage : MockITestPage
         // Raised BEFORE the part is cached so a re-entrant GetPart during the trigger cannot
         // observe a half-built part; raised after MarkPartOf so the trigger sees the
         // editability the host resolved.
-        part.RaiseOnOpenPage();
+        //
+        // NOT raised again when `adopted` is true: AdoptFromHost already raised it, exactly
+        // once, at the moment it reified the host's own shared instance (issue #2201) —
+        // raising it a second time here would clobber whatever the host's own AL (or an
+        // earlier TestPage touch) already wrote through that same instance.
+        if (!adopted) part.RaiseOnOpenPage();
 
         _parts[controlId] = part;
         return part;

--- a/AlRunner/Patches/RunnerFormInit.cs
+++ b/AlRunner/Patches/RunnerFormInit.cs
@@ -172,4 +172,18 @@ public static class RunnerFormInit
         try { return form != null && _sourceExpressionForms.TryGetValue(form, out _); }
         catch { return false; }
     }
+
+    /// <summary>
+    /// Cecil-injected call appended to <c>NavForm.GetPart(int)</c> (see NclCecilRewrite.cs),
+    /// right before it returns — the one door BOTH the host's own compiled AL
+    /// (<c>CurrPage.&lt;part&gt;</c>) and the runner's own <c>AdoptFromHost</c> go through to
+    /// reach a subpage part object. Public because Cecil-injected IL calls it across an
+    /// assembly boundary from the (rewritten) Ncl.dll; the actual logic lives on
+    /// <c>RunnerPageInstance</c>, an internal type, so it is reached through this public
+    /// forwarder rather than made public itself. See
+    /// <c>RunnerPageInstance.EnsureRecordlessPartReifiedEagerly</c> for the full rationale
+    /// (issue #2201's page-globals shape).
+    /// </summary>
+    public static void OnSubpagePartResolved(object? form)
+        => AlRunner.Patches.RunnerPageInstance.EnsureRecordlessPartReifiedEagerly(form);
 }

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -423,6 +423,86 @@ internal sealed class RunnerPageInstance
     }
 
     /// <summary>
+    /// Cecil-injected hook on <c>NavForm.GetPart(int)</c> (see NclCecilRewrite.cs) — called
+    /// with the resolved subpage NavForm on EVERY successful <c>GetPart</c>, from EITHER
+    /// caller: the host's own compiled AL touching <c>CurrPage.&lt;part&gt;</c> (that is
+    /// exactly what <c>GetPart(int)</c> compiles to — see MockTestPage.cs's GetPart doc), or
+    /// <see cref="AdoptFromHost"/> reaching the same object on the TestPage's behalf.
+    ///
+    /// WHY THIS EXISTS (issue #2201's page-globals shape, the part AdoptFromHost alone could
+    /// not fix). A plain field write inside a part's own procedure —
+    /// <c>CurrPage.&lt;part&gt;.Page.SetTag(...)</c> — compiles to
+    /// <c>NavApplicationObjectBase.Invoke(methodId, args)</c>, which never touches
+    /// <c>EnsureMetadataLoaded</c> at all (measured: no call chain from <c>Invoke</c> reaches
+    /// it). So when the HOST's own <c>OnOpenPage</c> writes through a page-globals part
+    /// before the TestPage side ever asks for it, there is no signal AdoptFromHost's own
+    /// "already touched" check (used successfully for the Rec-bound/temporary shapes) can
+    /// observe — and running the part's OWN <c>OnOpenPage</c> later, when the TestPage side
+    /// finally does ask, clobbers whatever the host already wrote.
+    ///
+    /// <c>GetPart(int)</c> is the one call BOTH sides are guaranteed to go through to reach
+    /// the object AT ALL (it is what <c>TryGetUIPart</c>/<c>RegisterUIPart</c> caches one
+    /// instance per control against), which makes it the earliest point common to both
+    /// callers — running the part's OnOpenPage here, before returning the object to
+    /// EITHER caller, is what makes "the subpage opens with its host" (the architectural
+    /// invariant the corpus's own subpages-overview doc describes) hold regardless of which
+    /// side asks first.
+    ///
+    /// DELIBERATELY NARROW to a page that declares NO SourceTable. A Rec-bound or
+    /// SourceTableTemporary part already reifies correctly and lazily via
+    /// <see cref="AdoptFromHost"/> — the object's OWN record binding IS the "has this been
+    /// used" signal there, verified against real BC (StefanMaron/BusinessCentral.AL.Language.Tests
+    /// codeunit 60807). Eagerly running <c>EnsureMetadataLoaded</c>/<c>SetSourceTable</c> for
+    /// those from inside a hook fired deep in arbitrary NAV internals would need a
+    /// caller-supplied record this hook has no safe way to build (record construction needs
+    /// the full <c>TestPageFactory</c> machinery, table-id resolution, tableextension
+    /// registration — heavy, TestPage-construction-time-only machinery, not something to run
+    /// from an arbitrary re-entrant call site), so this does not attempt it — those shapes
+    /// keep going through the existing, already-correct path unchanged.
+    ///
+    /// Never throws: this runs inside BC's own IL, on a call path the AL author's trigger
+    /// code did not ask to be re-entered from. A failure here silently leaves the object
+    /// un-reified early; AdoptFromHost's own lazy path is still there as a fallback.
+    /// </summary>
+    internal static void EnsureRecordlessPartReifiedEagerly(object? formObj)
+    {
+        try
+        {
+            if (formObj is not Microsoft.Dynamics.Nav.Runtime.NavForm form) return;
+            if (_reifiedSubpages.TryGetValue(form, out _)) return;
+
+            var pageId = form.FormId;
+
+            // Only the page-globals shape — see the doc comment above.
+            if (RecordPatches.ResolvePageDeclaresSourceTableForAnyPage(pageId)) return;
+
+            // No metadata this runner can build a control tree from at all (neither a
+            // source-compiled page nor a precompiled dependency's page) — EnsureMetadataLoaded
+            // would just no-op (ShouldResolveMasterPage refuses) and SourceExpressions would
+            // stay permanently empty. Nothing to gain from marking it "reified" here; leave it
+            // for the existing refusal path (TryGetPartDefinition / TryBuildRecordless) to
+            // answer with its usual named OOS reason instead of a silent early exit.
+            if (!AlPageMetadataRegistry.TryGet(pageId, out _) && !RecordPatches.HasDependencyPageMetadata(pageId))
+                return;
+
+            RunnerFormInit.MarkRealInit(form);
+            Invoke(form, "EnsureMetadataLoaded", Array.Empty<object?>());
+
+            var expressions = ReadProperty(form, "SourceExpressions") as System.Collections.IDictionary;
+            if (expressions == null) return;
+
+            var instance = new RunnerPageInstance(form, form, null, pageId, expressions);
+            if (_reifiedSubpages.TryGetValue(form, out _)) return; // lost a race with itself — never observed re-entrantly in practice, but cheap to guard
+            _reifiedSubpages.Add(form, instance);
+            instance.RaiseOnOpenPage();
+        }
+        catch
+        {
+            // Never let a hook running deep inside NAV internals throw — see doc comment.
+        }
+    }
+
+    /// <summary>
     /// Wrap a NavForm BC already built and initialised — a page opened from AL with
     /// RunModal, which the runner never constructed and so cannot have marked or driven.
     ///

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -76,6 +76,16 @@ internal sealed class RunnerPageInstance
     internal object Form => _form;
 
     /// <summary>
+    /// The record this instance is actually bound to — null for a record-less page. Needed
+    /// by callers of <see cref="AdoptFromHost"/>: when adoption reuses an ALREADY-bound
+    /// record (a SourceTableTemporary part the host already populated), that record can
+    /// differ from whatever the caller was about to bind, and the caller's OWN record
+    /// variable must follow this one rather than the one it almost passed in — see
+    /// MockTestPage.GetPart, issue #2201.
+    /// </summary>
+    internal NavRecord? Record => _record;
+
+    /// <summary>
     /// Whether the AL opened this page as a LOOKUP (<c>Picker.LookupMode(true)</c>), which
     /// decides whether its closing built-in actions are OK/Cancel or LookupOK/LookupCancel.
     /// Read off BC's own NavForm.LookupMode, so it reflects whatever the AL actually set.
@@ -283,6 +293,133 @@ internal sealed class RunnerPageInstance
                 Console.Out.WriteLine(inner.StackTrace);
             return null;
         }
+    }
+
+    // Subpage NavForm objects AdoptFromHost has already run BC's own metadata-load
+    // machinery against, so a second touch (another TestPage access, or the host's own AL
+    // reaching CurrPage.<part> after this ran) reuses the SAME reified wrapper instead of
+    // re-registering every source expression ("An item with the same key has already been
+    // added"). Weak and instance-keyed for the same reason RunnerFormInit's tables are: a
+    // form that goes out of scope must not be kept alive by this cache.
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<object, RunnerPageInstance> _reifiedSubpages = new();
+
+    /// <summary>
+    /// The subpage object the HOST's own AL owns for <paramref name="controlId"/> — the
+    /// same NavForm the host's compiled AL reaches through <c>CurrPage.&lt;part&gt;</c>, via
+    /// BC's own <c>NavForm.GetPart(int)</c> (backed by <c>RegisterUIPart</c>/<c>uiParts</c>:
+    /// one NavForm per control, lazily built and cached the first time EITHER side asks for
+    /// it). Building a second, disconnected page object for the same control — which
+    /// TestPageFactory.TryBuild/TryBuildRecordless still do — is issue #2201: TestPage.&lt;part&gt;
+    /// and the host AL's own CurrPage.&lt;part&gt;.Page were two different instances, invisible
+    /// for a Rec-bound part (its state lives in the shared record) but not for one bound to
+    /// page globals.
+    ///
+    /// The object <c>NavForm.GetPart(int)</c> hands back may never have been through a real
+    /// metadata load: nothing in Ncl.dll drives <c>SetSourceTable</c>/<c>EnsureMetadataLoaded</c>
+    /// on a subpage part on the caller's behalf — SubFormLink application is client/NST-side,
+    /// which the runner reimplements itself (see <c>LiveNavTestPart</c>'s SubPageLink handling
+    /// in MockTestPage.cs). This method brings the object up to the same live state
+    /// <see cref="TryCreate"/> gives a freshly built page, but only the FIRST time this method
+    /// reifies a given form — <see cref="_reifiedSubpages"/> remembers which ones it already
+    /// drove, so a later call gets the cached wrapper instead of double-registering.
+    ///
+    /// Returns null — the caller falls back to TryBuild/TryBuildRecordless exactly as it did
+    /// before this existed — when the host has no NavForm at all (a top-level page the
+    /// runner never built as a compiled AL object), the control names no part on that host
+    /// (BC's own uiParts lookup fails), or reifying the adopted object throws.
+    /// </summary>
+    internal static RunnerPageInstance? AdoptFromHost(
+        object? hostForm, int controlId, int partPageId, NavRecord? recordToBind, bool recordless)
+    {
+        var trace = Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_PAGE_METADATA") == "1";
+        if (hostForm is not Microsoft.Dynamics.Nav.Runtime.NavForm host)
+        {
+            if (trace) Console.Out.WriteLine($"[RunnerPageInstance] AdoptFromHost control {controlId}: hostForm is {hostForm?.GetType().FullName ?? "null"}, not a NavForm");
+            return null;
+        }
+
+        Microsoft.Dynamics.Nav.Runtime.NavForm subForm;
+        try { subForm = host.GetPart(controlId); }
+        catch (Exception ex)
+        {
+            if (trace) Console.Out.WriteLine($"[RunnerPageInstance] AdoptFromHost control {controlId} on host page {host.FormId}: GetPart threw {ex.GetType().Name}: {ex.Message}");
+            return null;
+        }
+        if (subForm == null)
+        {
+            if (trace) Console.Out.WriteLine($"[RunnerPageInstance] AdoptFromHost control {controlId} on host page {host.FormId}: GetPart returned null");
+            return null;
+        }
+
+        if (_reifiedSubpages.TryGetValue(subForm, out var cached))
+        {
+            if (trace) Console.Out.WriteLine($"[RunnerPageInstance] AdoptFromHost control {controlId}: reused cached reified subpage");
+            return cached;
+        }
+        if (trace) Console.Out.WriteLine($"[RunnerPageInstance] AdoptFromHost control {controlId}: adopted subpage {subForm.GetType().FullName}, reifying (recordless={recordless})");
+
+        // A SourceTableTemporary part's own record is NOT something SetSourceTable hands it
+        // — the compiled Page{partPageId} class binds its OWN temporary Rec at construction,
+        // independent of any caller-supplied record (that is what let the host's own AL push
+        // rows into it via CurrPage.<part>.Page.SetRows BEFORE this method ever ran — the
+        // SourceTableTemporary shape in issue #2201's report). Calling SetSourceTable with a
+        // freshly built EMPTY record here would silently discard every row the host already
+        // wrote. So: if the object already carries a bound record — from its own
+        // construction, or because a previous caller (host or runner) already reified it —
+        // reuse it as-is and skip SetSourceTable/EnsureMetadataLoaded entirely, exactly the
+        // way Adopt() below already does for a modal page BC built itself.
+        // NavForm.SourceTable's GETTER lazily calls EnsureMetadataLoaded() itself when unset
+        // — reading it here to CHECK whether the form is already bound would trigger exactly
+        // the metadata load (with a freshly built, empty record) this whole check exists to
+        // avoid. SourceTableWithoutLoadingMetadata reads the same backing field with no such
+        // side effect.
+        var existingRecord = recordless ? null : ReadProperty(subForm, "SourceTableWithoutLoadingMetadata") as NavRecord;
+        var alreadyLive = existingRecord != null;
+        if (trace) Console.Out.WriteLine($"[RunnerPageInstance] AdoptFromHost control {controlId}: existingRecord={(existingRecord == null ? "null" : existingRecord.GetType().FullName)} alreadyLive={alreadyLive}");
+        if (!alreadyLive)
+        {
+            try
+            {
+                // Must precede the calls below: the guarded NavForm bodies check this and
+                // no-op for anyone else (RunnerFormInit.cs). Mirrors TryCreate/
+                // TryCreateRecordless, which mark a form they just constructed themselves —
+                // here the form was constructed by BC's own NavForm.GetPart instead, so it
+                // was never marked.
+                RunnerFormInit.MarkRealInit(subForm);
+                if (recordless)
+                    Invoke(subForm, "EnsureMetadataLoaded", Array.Empty<object?>());
+                else
+                    Invoke(subForm, "SetSourceTable", new object?[] { recordToBind, false });
+            }
+            catch (Exception ex)
+            {
+                var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
+                // stdout on purpose — see TryCreate's identical reasoning above.
+                Console.Out.WriteLine(
+                    $"[RunnerPageInstance] part page {partPageId} (control {controlId}): could not reify "
+                    + $"the host's own subpage object ({inner.GetType().Name}: {inner.Message}); falling "
+                    + "back to a freshly constructed part page");
+                if (Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_PAGE_METADATA") == "1")
+                    Console.Out.WriteLine(inner.StackTrace);
+                return null;
+            }
+        }
+
+        var expressions = ReadProperty(subForm, "SourceExpressions") as System.Collections.IDictionary;
+        if (expressions == null) return null;
+
+        var record = recordless ? null : (existingRecord ?? ReadProperty(subForm, "SourceTableWithoutLoadingMetadata") as NavRecord);
+        var instance = new RunnerPageInstance(subForm, subForm, record, partPageId, expressions);
+        _reifiedSubpages.Add(subForm, instance);
+
+        // Raise the part's own OnOpenPage exactly once — the FIRST time ANY caller (the
+        // host's own AL touching CurrPage.<part>, or the runner adopting on the TestPage's
+        // behalf) reifies this instance — not once per TestPage-side touch. Issue #2201's
+        // report: with the object now SHARED, running it again on a later touch would
+        // clobber whatever the host's AL already wrote through the same instance.
+        if (!alreadyLive) instance.RaiseOnOpenPage();
+
+        return instance;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #2201
Closes #2598

## Mechanism

`MockTestPage.GetPart` used to always build a brand-new, disconnected `Page<partId>`
object for a subpage part. The host's own compiled AL, for `CurrPage.<part>`, goes
through a completely different door: BC's own `NavForm.GetPart(int)` (backed by
`RegisterUIPart`/`uiParts` — one `NavForm` per control, lazily built and CACHED the
first time either side asks for it). Two different objects, same control.

Two complementary fixes, both needed:

1. **`RunnerPageInstance.AdoptFromHost`** reaches through the host's own
   `NavForm.GetPart(int)` instead of constructing a second instance, and brings the
   returned object up to the same live state `TryCreate` gives a freshly built page
   (`SetSourceTable`/`EnsureMetadataLoaded`) — but only the first time, and only when the
   object isn't ALREADY bound (a `SourceTableTemporary` part's own `Rec` binds itself
   lazily, independent of our `SetSourceTable` call, the first time ANYTHING touches it —
   including a plain field access from the host's own procedure — so blindly rebinding a
   fresh empty record would silently discard rows the host already pushed via
   `CurrPage.<part>.Page.SetRows(...)`). Detected via `SourceTableWithoutLoadingMetadata`,
   which — unlike the public `SourceTable` getter — doesn't itself trigger a metadata load.

2. **`RunnerFormInit.OnSubpagePartResolved`**, a Cecil-injected call appended to
   `NavForm.GetPart(int)` right before it returns, fixes the remaining page-globals
   (`SourceTable`-less) shape AdoptFromHost alone could not: a plain procedure call
   (`CurrPage.<part>.Page.SetTag(...)`) never touches `EnsureMetadataLoaded` at all, so
   there is no signal AdoptFromHost's own "already touched" check can observe when the
   host writes through the part BEFORE the TestPage side ever asks for it. `GetPart(int)`
   is the one call BOTH sides are guaranteed to go through to reach the object at all, which
   makes it the earliest point common to both callers — reifying a page-globals part there
   (running its `OnOpenPage`) before returning it to EITHER caller is what makes "the
   subpage opens with its host" hold regardless of which side asks first. Deliberately
   narrow to a page declaring no `SourceTable`: a Rec-bound/temporary part already reifies
   correctly and lazily via (1), and eagerly running `SetSourceTable` from inside a hook
   fired deep in arbitrary NAV internals would need a caller-supplied record this hook has
   no safe way to build.

`GetPart` falls back to the pre-existing disconnected-construction behaviour exactly when
adoption can't produce a live object: the host has no NavForm at all, the control names no
part there, or reifying the adopted object throws.

## Verified against a real BC service tier

StefanMaron/BusinessCentral.AL.Language.Tests#130 (pending merge, 8 legs running):
- Codeunit 60807 "TP SrcTemp Tests" — a `SourceTableTemporary` part sharing one instance
  with its host, including the host pushing rows from its own `OnOpenPage` before the
  TestPage side ever touches the part, deleting the row the TestPage navigated to, and the
  modal-handler shape.
- Codeunit 60803 "Test Page NoSrc Part Tests" — the original 8 arms (#2195) plus two new
  ones proving a page-globals part's host write is visible through the SAME instance from
  the TestPage side, direct-open and modal-handler.

## Wider blast radius (per the workflow's "fix the shape, not just the reported line")

- Checked every other `GetPart`/subpage-part call site in the runner
  (`RunnerTestClientSession.GetPage`, `RunnerPageInstance.Adopt`) — those already adopt a
  host-owned live form for the TOP-LEVEL page case; this PR extends the same pattern one
  level down, to PARTS, for both the record-bound/temporary and page-globals shapes.
- Checked the sibling `TestPageFactory.TryBuildRecordless` path (used when adoption isn't
  possible) — unchanged, still the pre-existing behaviour, still faithful for the cases it
  already covered.

## Test plan

- [x] Corpus (StefanMaron/BusinessCentral.AL.Language.Tests#130): all restored/added arms
      pass locally against this build; RED before the respective fix, GREEN after
      (verified for both mechanisms independently, by reverting each and rebuilding).
- [x] Two new runner-mechanism tests in `AlRunner.Tests/TestPagePartAdoptedFromHostTests.cs`
      — one per mechanism — each independently RED without its fix, GREEN with it, per
      `.claude/rules/bc-behavior-tests-go-upstream.md`.
- [x] Full corpus run against this build: 2377/2382 pass; the 5 failures (codeunit 60300,
      60624, 60831) reproduce identically against the unmodified baseline build — confirmed
      pre-existing, unrelated to this change.
- [x] Filtered `AlRunner.Tests` run (`--filter FullyQualifiedName~TestPage`): 65/65 pass.

Pin bump to the corpus (once #130 merges) will follow in a separate PR per
`.claude/rules/al-language-submodule.md`.