### PR TITLE
fix(rad): make a namespace clone field-complete instead of naming three properties

### DIFF
--- a/AlRunner.Tests/BcCompilerIncrementalContainerCloneTests.cs
+++ b/AlRunner.Tests/BcCompilerIncrementalContainerCloneTests.cs
@@ -1,0 +1,165 @@
+// BcCompilerIncrementalContainerCloneTests — issue #2567. The structural half of #2531.
+//
+// #2531 fixed the instance: `ExcludeObjectsRecursive` skipped `prop.SetValue` on a cloned
+// NamespaceDefinition whenever nothing of that kind was being excluded, and
+// `CloneContainerShallow`'s hand-rolled NamespaceDefinition branch had left every mergeable array
+// at its CLR default (null). BC's binder resolved a reference into that null array far enough to
+// bind a symbol without a real NavTypeKind, and codegen died inside EmitFieldInitializer with
+// "Unexpected value 'None' of type NavTypeKind".
+//
+// What #2531 could not fix is the invariant it left behind: "every caller of CloneContainerShallow
+// must explicitly set every mergeable property, for every kind, not just the kinds it is touching",
+// enforced by nothing but a doc comment. The same shape reappears whenever a new caller is added,
+// and — worse — whenever Microsoft adds a property to NamespaceDefinition, because the hand-rolled
+// branch names its properties one by one.
+//
+// This test states the invariant the clone itself must satisfy, and it is deliberately written
+// against the TYPE rather than against a list of property names: it fabricates a distinguishable
+// value for every public read/write property BC declares on NamespaceDefinition, clones, and
+// requires every one of them to survive. A property added to BC's type next version is covered the
+// day it appears, with no edit here.
+//
+// The "unknown container implementation throws" arm is not pinned here; see the note at the
+// bottom of this file for why.
+//
+// Credit: vhn's fork does not have the #2531 shape at all, because
+// AlRunner/Rad/ModuleDefinitionOps.ShallowCopy is exactly this generic reflective copy rather than
+// a per-type switch. The fix below is that idea applied to our own clone.
+using System.Reflection;
+using Xunit;
+using AlRunner;
+using NavSymRef = Microsoft.Dynamics.Nav.CodeAnalysis.SymbolReference;
+
+namespace AlRunner.Tests;
+
+public sealed class BcCompilerIncrementalContainerCloneTests
+{
+    /// <summary>
+    /// Every public instance property BC declares on <paramref name="type"/> that this test can
+    /// both write and compare.
+    /// </summary>
+    private static PropertyInfo[] WritableProperties(Type type) => type
+        .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+        .Where(p => p.CanRead && p.CanWrite && p.GetIndexParameters().Length == 0)
+        .OrderBy(p => p.Name, StringComparer.Ordinal)
+        .ToArray();
+
+    /// <summary>
+    /// A value distinguishable from the CLR default for <paramref name="type"/>, or null when this
+    /// test cannot fabricate one. Arrays are created with one (null) element: what matters is that
+    /// the array reference itself is non-null, since "left at null" is the whole defect.
+    /// </summary>
+    private static object? Fabricate(Type type)
+    {
+        var underlying = Nullable.GetUnderlyingType(type) ?? type;
+        if (underlying == typeof(string)) return "clone-probe";
+        if (underlying == typeof(int)) return 4242;
+        if (underlying == typeof(bool)) return true;
+        if (underlying == typeof(Guid)) return Guid.Parse("b515c0de-0000-4000-8000-00000000dead");
+        if (underlying.IsArray) return Array.CreateInstance(underlying.GetElementType()!, 1);
+        if (underlying.IsEnum) return Enum.GetValues(underlying).Cast<object>().LastOrDefault();
+        return null;
+    }
+
+    /// <summary>
+    /// A namespace clone must carry EVERY property forward, not the three the old hand-rolled
+    /// branch happened to name.
+    ///
+    /// <para>RED on main: only <c>Id</c>, <c>Name</c> and <c>Namespaces</c> survive, so every kind
+    /// array and anything else BC declares comes back null on the clone.</para>
+    /// </summary>
+    [Fact]
+    public void CloneContainerShallow_NamespaceDefinition_CarriesEveryProperty()
+    {
+        var type = typeof(NavSymRef.NamespaceDefinition);
+        var source = new NavSymRef.NamespaceDefinition();
+
+        var populated = new List<PropertyInfo>();
+        foreach (var property in WritableProperties(type))
+        {
+            var value = Fabricate(property.PropertyType);
+            if (value == null) continue;
+            property.SetValue(source, value);
+            populated.Add(property);
+        }
+
+        // Guard against a vacuous pass: BcCompiler's own mergeable-kind list is 18 array
+        // properties, and Id/Name/Namespaces are three more. If the fabricator ever stops
+        // covering them the assertions below would hold trivially.
+        Assert.True(populated.Count >= 20,
+            $"the fabricator only populated {populated.Count} propert(ies) on "
+            + $"{type.Name} ({string.Join(", ", populated.Select(p => p.Name))}). It must cover "
+            + "essentially the whole type, or this test proves nothing about what a clone drops.");
+        Assert.Contains(populated, p => p.Name == "Tables");
+        Assert.Contains(populated, p => p.Name == "Codeunits");
+        Assert.Contains(populated, p => p.Name == "Reports");
+        Assert.Contains(populated, p => p.Name == "Namespaces");
+
+        var clone = BcCompiler.CloneContainerShallowForTests(source);
+
+        Assert.IsType<NavSymRef.NamespaceDefinition>(clone);
+        Assert.NotSame(source, clone);
+
+        var dropped = populated
+            .Where(p => !Equals(p.GetValue(source), p.GetValue(clone)))
+            .Select(p => $"{p.Name} ({p.PropertyType.Name}): source={Describe(p.GetValue(source))} clone={Describe(p.GetValue(clone))}")
+            .ToArray();
+
+        Assert.True(dropped.Length == 0,
+            "cloning a NamespaceDefinition dropped propert(ies) the caller never named. A caller "
+            + "that excludes only Codeunits leaves every OTHER kind's array null on the clone, and "
+            + "BC's binder resolves a reference into a null array far enough to bind a symbol "
+            + "without a real NavTypeKind — Compilation.Emit then dies inside EmitFieldInitializer "
+            + "with \"Unexpected value 'None' of type NavTypeKind\" (#2531). Dropped:"
+            + Environment.NewLine + string.Join(Environment.NewLine, dropped));
+    }
+
+    /// <summary>
+    /// The module side of the same claim. BC's own <c>ModuleDefinition.Clone()</c> is a
+    /// MemberwiseClone and already carries everything; this pins that we did not regress it while
+    /// making the namespace branch generic, and that both branches now answer the same way.
+    /// </summary>
+    [Fact]
+    public void CloneContainerShallow_ModuleDefinition_CarriesEveryProperty()
+    {
+        var type = typeof(NavSymRef.ModuleDefinition);
+        var source = new NavSymRef.ModuleDefinition();
+
+        var populated = new List<PropertyInfo>();
+        foreach (var property in WritableProperties(type))
+        {
+            var value = Fabricate(property.PropertyType);
+            if (value == null) continue;
+            property.SetValue(source, value);
+            populated.Add(property);
+        }
+        Assert.True(populated.Count >= 20,
+            $"the fabricator only populated {populated.Count} propert(ies) on {type.Name}.");
+
+        var clone = BcCompiler.CloneContainerShallowForTests(source);
+
+        Assert.IsType<NavSymRef.ModuleDefinition>(clone);
+        Assert.NotSame(source, clone);
+        var dropped = populated
+            .Where(p => !Equals(p.GetValue(source), p.GetValue(clone)))
+            .Select(p => $"{p.Name} ({p.PropertyType.Name})")
+            .ToArray();
+        Assert.True(dropped.Length == 0,
+            "cloning a ModuleDefinition dropped: " + string.Join(", ", dropped));
+    }
+
+    // NOTE: the "unknown IObjectContainerDefinition implementation throws" arm is deliberately
+    // NOT pinned by a test. Implementing that interface from the test assembly means writing out
+    // all 20 of its members by hand against BC's own definition types, which is a maintenance
+    // burden that buys very little: the arm exists so that a future BC model change is loud rather
+    // than silently mis-cloned, and BC ships exactly two implementations. The generic copy below
+    // keeps the arm rather than accepting anything, which is the part that matters.
+
+    private static string Describe(object? value) => value switch
+    {
+        null => "<null>",
+        Array a => $"{a.GetType().Name}[{a.Length}]",
+        _ => value.ToString() ?? "<null>",
+    };
+
+}

--- a/AlRunner/BcCompiler.Incremental.cs
+++ b/AlRunner/BcCompiler.Incremental.cs
@@ -1208,37 +1208,63 @@ public sealed partial class BcCompiler
             .GetMethod("Clone", BindingFlags.NonPublic | BindingFlags.Instance)!.Invoke(module, null)!;
 
     /// <summary>
+    /// <c>MemberwiseClone</c>, reached by reflection because it is <c>protected</c> on
+    /// <see cref="object"/>. Used for <c>NamespaceDefinition</c>, which BC gives no <c>Clone()</c>
+    /// of its own (confirmed by decompile) — see <see cref="CloneContainerShallow"/>.
+    /// </summary>
+    private static readonly MethodInfo _memberwiseClone = typeof(object)
+        .GetMethod("MemberwiseClone", BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+    /// <summary>
     /// Shallow-clones a container (ModuleDefinition OR NamespaceDefinition — both implement
     /// <see cref="NavSymRef.IObjectContainerDefinition"/>) WITHOUT sharing any mutable array
-    /// reference with the original: <see cref="CloneModuleDefinition"/>'s <c>MemberwiseClone</c>
-    /// copies every property (including every mergeable array) verbatim, but
-    /// <c>NamespaceDefinition</c> has no <c>Clone()</c> of its own (confirmed by decompile), so
-    /// this hand-rolled branch sets ONLY <c>Id</c>/<c>Name</c>/<c>Namespaces</c> — every
-    /// mergeable-array property starts out unset (CLR default, i.e. null) on a namespace clone.
+    /// reference with the original.
     ///
-    /// #2479: that means EVERY caller here MUST explicitly set every mergeable property on the
-    /// result, for every kind — not just the kinds it is actually excluding/merging — or a
-    /// namespace-nested kind the caller had no reason to touch this cycle silently loses its
-    /// entire array. <see cref="MergeContainerRecursive"/> always does
-    /// (`prop.SetValue(merged, result)` runs unconditionally for every kind in
-    /// <see cref="RadMergeablePropertiesByKind"/>). <see cref="ExcludeObjectsRecursive"/> did NOT
-    /// before this fix — it skipped `prop.SetValue` entirely whenever nothing of that kind was
-    /// being excluded, so a namespaced bundle where the touched object was a Codeunit left every
-    /// OTHER kind's array null on the clone. BC's binder resolved a reference into a null Tables/
-    /// Reports/… array far enough to bind a symbol, but never gave it a real
-    /// <c>NavTypeKind</c> — <c>Compilation.Emit</c> crashed deep inside
-    /// <c>CodeGenerator.EmitFieldInitializer</c> with "Unexpected value 'None' of type
-    /// NavTypeKind" the first time an untouched, namespace-nested, non-Codeunit sibling (Table,
-    /// Report, Page, …) was referenced from the edited object's own syntax tree. See
-    /// BcCompilerIncrementalCrossKindSiblingTests for the RED/GREEN proof — a same-kind sibling
-    /// (Codeunit referencing Codeunit) never hit this, because excluding the touched Codeunit
-    /// already forced the Codeunits property to be set.
+    /// <para><b>Both branches are now field-complete, and that is the point (#2567).</b> The
+    /// namespace branch used to be a hand-rolled object initializer naming <c>Id</c>, <c>Name</c>
+    /// and <c>Namespaces</c> — so every OTHER property came back at its CLR default (null) on a
+    /// namespace clone, and the invariant "every caller must explicitly set every mergeable
+    /// property, for every kind, not just the kinds it is touching" was enforced by nothing but a
+    /// doc comment. #2531 fixed the one caller that violated it
+    /// (<see cref="ExcludeObjectsRecursive"/>); it could not fix the next one, nor a property
+    /// Microsoft adds to <c>NamespaceDefinition</c> that nobody here thinks to add to the
+    /// initializer.</para>
+    ///
+    /// <para>Measured before this change, on the BC this runner links against: a namespace clone
+    /// dropped 16 properties, and one of them — <c>DotNetPackages</c> — is not in
+    /// <see cref="RadMergeablePropertiesByKind"/> at all, so NO caller could have restored it even
+    /// knowing to try. BcCompilerIncrementalContainerCloneTests pins the invariant against the
+    /// TYPE rather than against a property list, so a property BC adds next version is covered the
+    /// day it appears.</para>
+    ///
+    /// <para><b>Why <c>MemberwiseClone</c> rather than a property-by-property reflective copy.</b>
+    /// A property copy carries only what BC chose to expose as a property; <c>MemberwiseClone</c>
+    /// copies every instance FIELD, which is a superset and is exactly what BC's own
+    /// <c>ModuleDefinition.Clone()</c> does. Using it for the namespace branch makes the two
+    /// branches answer the same way instead of being two different notions of "shallow clone".</para>
+    ///
+    /// <para>The unknown-implementation arm stays a throw rather than a generic accept: BC ships
+    /// exactly two implementations of this interface, and a third appearing means BC's model moved
+    /// under us — which must be loud (<c>.claude/rules/loud-failures.md</c>), not silently cloned
+    /// into something with the wrong shape.</para>
+    ///
+    /// <para>Credit: vhn's fork never had the #2531 shape, because
+    /// <c>AlRunner/Rad/ModuleDefinitionOps.ShallowCopy</c> is a generic copy rather than a per-type
+    /// switch. This is that idea applied here.</para>
     /// </summary>
+    /// <summary>Test seam for <see cref="CloneContainerShallow"/> — BcCompilerIncrementalContainerCloneTests
+    /// states the "carries every property" invariant structurally, against the TYPE, rather than
+    /// through a compile that only exercises the properties one scenario happens to touch.</summary>
+    internal static NavSymRef.IObjectContainerDefinition CloneContainerShallowForTests(
+        NavSymRef.IObjectContainerDefinition container) => CloneContainerShallow(container);
+
     private static NavSymRef.IObjectContainerDefinition CloneContainerShallow(NavSymRef.IObjectContainerDefinition container)
         => container switch
         {
+            // BC's own Clone() — already a MemberwiseClone, kept because it is the vendor's own
+            // answer for this type and may one day do more than a field copy.
             NavSymRef.ModuleDefinition module => CloneModuleDefinition(module),
-            NavSymRef.NamespaceDefinition ns => new NavSymRef.NamespaceDefinition { Id = ns.Id, Name = ns.Name, Namespaces = ns.Namespaces },
+            NavSymRef.NamespaceDefinition ns => (NavSymRef.NamespaceDefinition)_memberwiseClone.Invoke(ns, null)!,
             _ => throw new InvalidOperationException($"Unexpected {nameof(NavSymRef.IObjectContainerDefinition)} implementation: {container.GetType().Name}"),
         };
 


### PR DESCRIPTION
Closes #2567

## What was wrong

`CloneContainerShallow`'s `NamespaceDefinition` branch was a hand-rolled object initializer:

```csharp
NavSymRef.NamespaceDefinition ns => new NavSymRef.NamespaceDefinition { Id = ns.Id, Name = ns.Name, Namespaces = ns.Namespaces },
```

so every other property came back at its CLR default — `null` — on a namespace clone.

#2531 fixed the one caller that then handed a null array to BC's binder. What it could not fix is
the invariant it left behind: *"every caller of `CloneContainerShallow` must explicitly set every
mergeable property, for every kind, not just the kinds it is touching"*, enforced by nothing but a
doc comment. That is the same shape as #2486 — two places that must be kept in sync, drift is
silent — and it reappears with the next caller, or with the next property Microsoft adds to
`NamespaceDefinition`.

**Measured** on the BC this runner links against: a namespace clone dropped **16** properties. One
of them — `DotNetPackages` — is not in `RadMergeablePropertiesByKind` at all, so **no caller could
have restored it even knowing to try**.

## The fix

Both branches are now field-complete:

- `ModuleDefinition` keeps BC's own `Clone()` — the vendor's own answer for that type.
- `NamespaceDefinition` uses `MemberwiseClone`, reached by reflection because it is `protected` on
  `object`. BC declares no `Clone()` for that type (already confirmed by decompile in the existing
  comment).

`MemberwiseClone` rather than a property-by-property reflective copy: it copies every instance
**field**, which is a superset of the properties, and is exactly what BC's own `Clone()` does — so
the two branches stop being two different notions of "shallow clone".

The unknown-implementation arm stays a `throw`. BC ships exactly two implementations of
`IObjectContainerDefinition`; a third appearing means BC's model moved under us, which must be loud
(`.claude/rules/loud-failures.md`), not silently cloned into something with the wrong shape.

## Tests

`AlRunner.Tests/BcCompilerIncrementalContainerCloneTests.cs`. The claim is structural, so the test
is written **against the type, not against a property list**: it fabricates a distinguishable value
for every public read/write property BC declares on the container, clones, and requires every one to
survive. A property BC adds next version is covered the day it appears, with no edit here.

Guarded against a vacuous pass — it asserts the fabricator actually populated ≥20 properties and
names four it must have covered, so it cannot go green by covering nothing.

RED before this change:

```
Codeunits (CodeunitDefinition[]): source=CodeunitDefinition[][1] clone=<null>
ControlAddIns … DotNetPackages … EnumExtensionTypes … EnumTypes … Interfaces …
PageCustomizations … PageExtensions … Pages … PermissionSetExtensions … PermissionSets …  (16 total)
```

Local: 2/2 green, and the 30 tests across `BcCompilerIncremental*`, `WatchFullRebuildReason*`,
`ServerAffected*` and `WatchRadRealDependency*` stay green.

## Not pinned, deliberately

The "unknown `IObjectContainerDefinition` implementation throws" arm has no test. Implementing that
interface from the test assembly means writing out all 20 of its members by hand against BC's own
definition types, for an arm that exists only so a future BC model change is loud. Noted in the test
file rather than left unexplained.

## Credit

vhn's fork never had this shape, because `AlRunner/Rad/ModuleDefinitionOps.ShallowCopy` is a generic
copy rather than a per-type switch. This is that idea applied to our clone.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
