### PR TITLE
Print the build's own version, and stop overselling --print-cache-key

### DIFF
--- a/AlRunner.Tests/CacheKeyDependencyClosureTests.cs
+++ b/AlRunner.Tests/CacheKeyDependencyClosureTests.cs
@@ -93,7 +93,9 @@ public sealed class CacheKeyDependencyClosureTests : IDisposable
 
     /// <summary>
     /// Fast path: runs the fixture in `--print-cache-key` mode, which reaches the exact same
-    /// ComputeAlCacheKey call a real run would (see Program.cs) and exits before Emit+Compile.
+    /// ComputeAlCacheKey call a real run would (see Program.cs) and exits without emitting or
+    /// compiling that app group. It is not free — the layered dependency pre-pass has already
+    /// run by then; see PrintCacheKeyHelp_DoesNotClaimItRunsBeforeThePrePass.
     /// This is what the two behavioural tests below use — they only ever assert a property of
     /// the key string, so there is nothing lost by not paying for the compile.
     /// </summary>

--- a/AlRunner.Tests/CliDocumentationTests.cs
+++ b/AlRunner.Tests/CliDocumentationTests.cs
@@ -318,6 +318,19 @@ public sealed class CliDocumentationTests
         Assert.True(baseExit == 0, $"--version must exit 0. exit={baseExit}\n{baseErr}");
         Assert.Matches(new Regex(@"^al-runner v\S+"), baseOut.Trim());
 
+        // The version must carry the build's own version string, not the numeric quad that
+        // drops a prerelease suffix (#2552). AlRunner.csproj is at a prerelease version, so
+        // the printed line has to differ from what Assembly.GetName().Version would give.
+        var numericOnly = new Regex(@"^al-runner v\d+\.\d+\.\d+\.\d+$");
+        Assert.False(numericOnly.IsMatch(baseOut.Trim()),
+            "--version printed a bare numeric quad: "
+            + $"'{baseOut.Trim()}'. AlRunner.csproj declares a prerelease <Version>, so the "
+            + "suffix that says WHICH build this is has been dropped. See RunnerVersion.");
+
+        // And it must never carry SemVer build metadata: publish.yml packs the release with
+        // the commit sha appended, and that must not reach this line.
+        Assert.DoesNotContain("+", baseOut.Trim(), StringComparison.Ordinal);
+
         foreach (var spelling in new[] { "-v", "-V", "version" })
         {
             var (exit, stdout, stderr) = RunCli(spelling);
@@ -573,5 +586,55 @@ public sealed class CliDocumentationTests
             Assert.NotEmpty(paths); // the surfaces DO cite paths; an empty scrape is a broken test
             foreach (var p in paths) yield return (flag, p);
         }
+    }
+
+    /// <summary>
+    /// --print-cache-key's help said it exits "before Emit+Compile starts", which reads as
+    /// "this is cheap". It is not: the short-circuit sits inside the per-app-group loop, so
+    /// RunLayeredPrePass has already built every dependency implementation bundle from source
+    /// by the time a key is printed. That cost cannot be skipped either, because the key
+    /// covers the resolved dependency set — a run that skipped the pre-pass would print a
+    /// different key than the run it stands in for.
+    ///
+    /// This asserts the ordering against Program.cs rather than trusting the prose, so the
+    /// claim and the code cannot drift apart again. It reads source text, which is brittle by
+    /// nature; the failure message names both anchors so a rename is a two-minute fix rather
+    /// than a puzzle.
+    /// </summary>
+    [Fact]
+    public void PrintCacheKeyHelp_DoesNotClaimItRunsBeforeThePrePass()
+    {
+        var source = File.ReadAllText(Path.Combine(RepoRoot, "AlRunner", "Program.cs"));
+
+        const string prePass = "packageCacheDirs = RunLayeredPrePass(bundles";
+        const string shortCircuit = "if (printCacheKeyOnly)";
+
+        var prePassAt = source.IndexOf(prePass, StringComparison.Ordinal);
+        var shortCircuitAt = source.IndexOf(shortCircuit, StringComparison.Ordinal);
+
+        Assert.True(prePassAt >= 0,
+            $"could not find '{prePass}' in Program.cs — if RunLayeredPrePass was renamed, "
+            + "update this test and re-check what --print-cache-key's help claims.");
+        Assert.True(shortCircuitAt >= 0,
+            $"could not find '{shortCircuit}' in Program.cs — if the short-circuit moved, "
+            + "update this test and re-check what --print-cache-key's help claims.");
+        Assert.True(prePassAt < shortCircuitAt,
+            "the --print-cache-key short-circuit now runs BEFORE the layered pre-pass. That "
+            + "would make the flag genuinely cheap, so the help text should be rewritten to "
+            + "say so — this test exists to make that a deliberate edit.");
+    }
+
+    /// <summary>
+    /// The help must not tell a caller the flag exits before Emit+Compile "starts", which is
+    /// the specific wording that made it sound free.
+    /// </summary>
+    [Fact]
+    public void PrintCacheKeyHelp_SaysItIsNotFree()
+    {
+        var (_, stdout, _) = RunCli("--help");
+
+        Assert.Contains("--print-cache-key", stdout, StringComparison.Ordinal);
+        Assert.DoesNotContain("before Emit+Compile starts", stdout, StringComparison.Ordinal);
+        Assert.Contains("NOT free", stdout, StringComparison.Ordinal);
     }
 }

--- a/AlRunner.Tests/RunnerVersionTests.cs
+++ b/AlRunner.Tests/RunnerVersionTests.cs
@@ -1,0 +1,92 @@
+// What al-runner reports about its own version, and why it is not what the assembly's
+// numeric version says.
+//
+// These are unit tests over AlRunner.Infrastructure.RunnerVersion with a supplied assembly,
+// not over the running one: the running assembly carries whatever <Version> the repo happens
+// to be at, so asserting against it would pin a moving number and prove nothing about the
+// rule. Constructing assemblies with each attribute combination is what states the rule.
+
+using System.Reflection;
+using System.Reflection.Emit;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class RunnerVersionTests
+{
+    /// <summary>
+    /// An in-memory assembly carrying exactly the version attributes named, so each test can
+    /// state one rule without depending on how this repo is currently versioned.
+    /// </summary>
+    private static Assembly Build(string name, string? numeric, string? informational)
+    {
+        var asmName = new AssemblyName(name);
+        if (numeric != null) asmName.Version = Version.Parse(numeric);
+
+        var builder = AssemblyBuilder.DefineDynamicAssembly(asmName, AssemblyBuilderAccess.Run);
+        if (informational != null)
+            builder.SetCustomAttribute(new CustomAttributeBuilder(
+                typeof(AssemblyInformationalVersionAttribute).GetConstructor(new[] { typeof(string) })!,
+                new object[] { informational }));
+        return builder;
+    }
+
+    // The defect: AssemblyVersion is a numeric quad and .NET drops a prerelease suffix from
+    // it, so a 2.0.0-preview.1 build reported "2.0.0.0" and a fork build stamped
+    // 2.1.2-performance reported the same thing. The suffix is the part that says which
+    // build someone is holding.
+    [Fact]
+    public void InformationalVersion_KeepsThePrereleaseSuffix()
+        => Assert.Equal(
+            "2.0.0-preview.1",
+            RunnerVersion.Informational(Build("V1", "2.0.0.0", "2.0.0-preview.1")));
+
+    [Fact]
+    public void InformationalVersion_KeepsANonNumericSuffix()
+        => Assert.Equal(
+            "2.1.2-performance",
+            RunnerVersion.Informational(Build("V2", "2.1.0.0", "2.1.2-performance")));
+
+    // SemVer build metadata is dropped. publish.yml packs the release with
+    // IncludeSourceRevisionInInformationalVersion=true, which appends the 40-character commit
+    // sha; a released version number already identifies its build, and --guide asks coding
+    // agents to paste this line into gap reports.
+    [Fact]
+    public void BuildMetadata_IsStripped()
+        => Assert.Equal(
+            "2.11.0",
+            RunnerVersion.Informational(
+                Build("V3", "2.11.0.0", "2.11.0+0123456789abcdef0123456789abcdef01234567")));
+
+    // The same source must report the same string whether it was built here or packed for
+    // release. That is the whole reason for stripping rather than printing the sha.
+    [Fact]
+    public void ThePackedAndUnpackedFormsOfOneVersion_ReportTheSameString()
+    {
+        var packed = RunnerVersion.Informational(
+            Build("V4", "2.11.0.0", "2.11.0-rc.1+0123456789abcdef0123456789abcdef01234567"));
+        var unpacked = RunnerVersion.Informational(Build("V5", "2.11.0.0", "2.11.0-rc.1"));
+
+        Assert.Equal("2.11.0-rc.1", packed);
+        Assert.Equal(packed, unpacked);
+    }
+
+    // Negative: no informational attribute at all falls back to the numeric version rather
+    // than reporting nothing.
+    [Fact]
+    public void NoInformationalAttribute_FallsBackToTheNumericVersion()
+        => Assert.Equal("3.4.5.6", RunnerVersion.Informational(Build("V6", "3.4.5.6", null)));
+
+    // Negative: an informational attribute that is present but blank must not win over the
+    // numeric version, and must not produce an empty version line.
+    [Fact]
+    public void BlankInformationalAttribute_FallsBackToTheNumericVersion()
+        => Assert.Equal("3.4.5.6", RunnerVersion.Informational(Build("V7", "3.4.5.6", "   ")));
+
+    // Negative: an informational version that is nothing but build metadata has no version in
+    // it, so it must fall back rather than report an empty string.
+    [Fact]
+    public void InformationalVersionThatIsOnlyBuildMetadata_FallsBackToTheNumericVersion()
+        => Assert.Equal("3.4.5.6", RunnerVersion.Informational(Build("V8", "3.4.5.6", "+abcdef")));
+}

--- a/AlRunner/Infrastructure/RunnerVersion.cs
+++ b/AlRunner/Infrastructure/RunnerVersion.cs
@@ -1,0 +1,42 @@
+using System.Reflection;
+
+namespace AlRunner.Infrastructure;
+
+/// <summary>
+/// The version string al-runner reports about itself.
+/// </summary>
+internal static class RunnerVersion
+{
+    /// <summary>
+    /// The build's own version, prerelease suffix included.
+    ///
+    /// <c>Assembly.GetName().Version</c> is a numeric quad and cannot carry a prerelease
+    /// suffix — .NET drops it — so reading it printed "2.0.0.0" for a build whose
+    /// <c>&lt;Version&gt;</c> is 2.0.0-preview.1, throwing away exactly the part that says which
+    /// build someone is holding. <c>AssemblyInformationalVersion</c> keeps it.
+    ///
+    /// SemVer build metadata — everything after a '+' — is stripped. The released package is
+    /// packed with <c>IncludeSourceRevisionInInformationalVersion=true</c>
+    /// (<c>publish.yml</c>), which appends the 40-character commit sha, and a released
+    /// version number already identifies its build. Keeping the sha would put 40 characters
+    /// of noise into a line that <c>--guide</c> asks coding agents to paste into gap reports,
+    /// and would make the same source print differently depending on how it was packed.
+    ///
+    /// Falls back to the numeric version for an assembly carrying no informational attribute,
+    /// and to "unknown" for one carrying neither.
+    /// </summary>
+    internal static string Informational(Assembly assembly)
+    {
+        var informational = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+
+        if (!string.IsNullOrWhiteSpace(informational))
+        {
+            var plus = informational.IndexOf('+');
+            var trimmed = plus >= 0 ? informational[..plus] : informational;
+            if (!string.IsNullOrWhiteSpace(trimmed)) return trimmed;
+        }
+
+        return assembly.GetName().Version?.ToString() ?? "unknown";
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -270,11 +270,17 @@ catch (InvalidOperationException ex)
 string? cacheRootOverride = null;
 // --print-cache-key (issue #1851): a diagnostic/test-support mode. Reaches the SAME
 // ComputeAlCacheKey call, with the SAME arguments, that a real run would use for the
-// first app group it processes — then prints it and exits, before Emit+Compile even
-// starts. Exists so callers that only need to assert a property of the KEY (not of a
-// compiled DLL) don't have to pay for a full cold AL compile to get one. There is no
+// first app group it processes — then prints it and exits, without emitting or compiling
+// that app group. Exists so callers that only need to assert a property of the KEY (not
+// of a compiled DLL) don't have to pay for a full cold AL compile to get one. There is no
 // second/parallel key computation — see the call site below, unchanged from the normal
 // path up to and including the ComputeAlCacheKey call itself.
+//
+// It is NOT free, and the help text must not imply it is. The short-circuit sits inside
+// the per-app-group loop, so RunLayeredPrePass has already built every dependency
+// implementation bundle from source by the time a key is printed. That cost cannot be
+// skipped: the key covers the resolved dependency set, so a run that skipped the pre-pass
+// would print a different key than the run it stands in for.
 bool printCacheKeyOnly = false;
 // Test isolation mode — default matches BC's "Test Runner - Isol. Codeunit" (130450).
 var isolation = AlRunner.TestIsolation.Codeunit;
@@ -5580,10 +5586,7 @@ static string SanitiseFilename(string name)
 // Shared by --version/-v/-V/version and --help's first line, so a build's
 // self-reported version can never drift between the two surfaces (#2072).
 static string VersionString()
-{
-    var asmVer = typeof(Program).Assembly.GetName().Version?.ToString() ?? "unknown";
-    return $"al-runner v{asmVer}";
-}
+    => $"al-runner v{AlRunner.Infrastructure.RunnerVersion.Informational(typeof(Program).Assembly)}";
 
 static void PrintGuide(TextWriter w)
 {
@@ -6038,9 +6041,12 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("  --print-cache-key       Diagnostic/test-support mode: compute the AL-output cache");
     w.WriteLine("                          key for the first app group of the first bundle exactly as");
     w.WriteLine("                          a real run would, print \"[cache] KEY key=<hash>\", and exit");
-    w.WriteLine("                          before Emit+Compile starts. Requires the cache to be");
-    w.WriteLine("                          enabled (default; not --no-cache). Exit code 2 if no key");
-    w.WriteLine("                          could be computed.");
+    w.WriteLine("                          without emitting or compiling that app group. NOT free: the");
+    w.WriteLine("                          layered dependency pre-pass has already built every");
+    w.WriteLine("                          dependency bundle from source by then, and it cannot be");
+    w.WriteLine("                          skipped, because the key covers the resolved dependency set.");
+    w.WriteLine("                          Requires the cache to be enabled (default; not --no-cache).");
+    w.WriteLine("                          Exit code 2 if no key could be computed.");
     w.WriteLine("  --watch                 Stay resident with warm dependencies and re-run IN-PROCESS");
     w.WriteLine("                          on every .al change (deps loaded once → ~seconds/save, not");
     w.WriteLine("                          a cold re-run). Ctrl+C to quit.");

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,9 +25,15 @@
     Both properties are required together — disabling only #1 still leaves the SourceLink
     auto-import changing the DLL's debug-directory bytes across commits.
 
-    Nothing in this repo reads the informational version at runtime: al-runner's version
-    flag reports Assembly.GetName().Version (AssemblyVersion, e.g. "2.0.0.0"), not the
-    informational version.
+    al-runner's version flag DOES read the informational version at runtime, since #2552.
+    AssemblyVersion is a numeric quad that cannot carry a prerelease suffix, so reading it
+    printed "2.0.0.0" for a 2.0.0-preview.1 build. AlRunner.Infrastructure.RunnerVersion
+    strips SemVer build metadata (everything after '+'), so the commit sha the pack-time
+    override below appends does not reach that line, and the version flag prints the same
+    string whether the assembly was built here or packed for release.
+
+    That is a version STRING read at runtime, not the DLL's bytes. It has no bearing on the
+    two properties below, which exist to keep those bytes stable across commits.
 
     DO NOT DELETE THESE AS "REDUNDANT" IF YOU SEE THEM OVERRIDDEN ELSEWHERE. The published
     NuGet package (publish.yml's `dotnet pack AlRunner/`, PackAsTool=true, pushed to


### PR DESCRIPTION
Two CLI-surface claims that were not true of the build behind them.

## 1. `--version` dropped the prerelease suffix

`VersionString()` read `Assembly.GetName().Version`, a numeric quad that cannot carry a prerelease suffix — .NET drops it. So `--version` printed `al-runner v2.0.0.0` for a build whose `<Version>` is `2.0.0-preview.1`, and a fork build stamped `2.1.2-performance` printed the same thing. That is exactly the part that says which build someone is holding.

It now reads `AssemblyInformationalVersion`, and falls back to the numeric version for an assembly carrying no informational attribute.

**SemVer build metadata is stripped.** `publish.yml` packs the release with `IncludeSourceRevisionInInformationalVersion=true`, which appends the 40-character commit sha. A released version number already identifies its build, and `--guide` asks coding agents to paste this line into gap reports, so 40 characters of noise there costs something and buys nothing. Stripping also means the same source prints the same string whether it was built here or packed for release, which a raw informational version would not.

`VersionString()` also feeds the first line of `--help` (#2072), so both surfaces move together.

## 2. `--print-cache-key`'s help understated what it runs first

The help said the flag exits "before Emit+Compile starts", which reads as "this is cheap". `RunLayeredPrePass` is called at `Program.cs:1736`; the `if (printCacheKeyOnly)` short-circuit is at `Program.cs:2410`. So by the time a key is printed, the pre-pass has already built every dependency implementation bundle from source.

That cost cannot be skipped: the key covers the resolved dependency set, so a run that skipped the pre-pass would print a different key than the run it stands in for. The help now says so, and a test asserts the ordering against `Program.cs` rather than trusting the prose.

The stale source comment at `Program.cs:271` is corrected too.

## The `+sha` decision

`Directory.Build.props:47` turns `IncludeSourceRevisionInInformationalVersion` off for cache-key reproducibility (#1881), and `publish.yml` turns it back on at pack time for commit provenance. So reading the informational version raw would make a *released* binary print a sha that a dev or CI build does not. I chose to strip it rather than print it, for the reasons above; that is a deliberate call, not an oversight. Existing assertions (`^al-runner v\S+`, `Contains("al-runner v")`) hold either way.

`Directory.Build.props` carried a comment saying nothing in the repo reads the informational version at runtime. That is now false, so it says what changed and why it does not affect the two properties it sits above — those keep the DLL's *bytes* stable across commits, which a version string does not touch.

## Tests

Seven unit tests over `RunnerVersion` with **constructed** assemblies rather than the running one, so each states a rule instead of pinning whatever version the repo happens to be at. Three are negatives — no attribute, a blank attribute, an attribute that is only build metadata — and all must fall back rather than print an empty version.

Plus a `--version` assertion that the printed line is not a bare numeric quad and carries no `+`, and two for the cache-key help: one reads `--help` and one pins the ordering in `Program.cs`. The source-text one is brittle by nature, so its failure message names both anchors.

## Credit

Found by Mikkel Mansa Vilhelmsen (@vhn-mmv), commit `94a3d105` on his fork.

Closes #2552

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf