### PR TITLE
Carry the SourceObject flags the symbol file states for a precompiled dependency page

### DIFF
--- a/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
+++ b/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
@@ -48,6 +48,8 @@ public class DependencyPageMetadataXmlTests
     private const int ListPageId = 88123401;
     private const int UnknownPageId = 88123409;
     private const int NavigatePageId = 88123402;
+    private const int SplitKeyPageId = 88123403;
+    private const int PlainLinesPageId = 88123404;
 
     private const string SymbolReference = """
         {
@@ -69,6 +71,25 @@ public class DependencyPageMetadataXmlTests
               "Properties": [
                 { "Name": "Caption", "Value": "DPX Wizard Caption" },
                 { "Name": "PageType", "Value": "NavigatePage" }
+              ]
+            },
+            {
+              "Id": 88123403,
+              "Name": "DPX Test Split Key Lines",
+              "Properties": [
+                { "Name": "PageType", "Value": "ListPart" },
+                { "Name": "SourceTable", "Value": "701" },
+                { "Name": "AutoSplitKey", "Value": "1" },
+                { "Name": "MultipleNewLines", "Value": "1" },
+                { "Name": "DelayedInsert", "Value": "1" }
+              ]
+            },
+            {
+              "Id": 88123404,
+              "Name": "DPX Test Plain Lines",
+              "Properties": [
+                { "Name": "PageType", "Value": "ListPart" },
+                { "Name": "SourceTable", "Value": "701" }
               ]
             }
           ]
@@ -483,5 +504,89 @@ public class DependencyPageMetadataXmlTests
         {
             Directory.Delete(dir, recursive: true);
         }
+    }
+
+    /// <summary>
+    /// #2550: the three flags the AL compiler writes on &lt;SourceObject&gt; alongside
+    /// SourceTable were dropped, so a page shipping precompiled in a dependency .app answered
+    /// as if it declared none of them.
+    ///
+    /// <para>AutoSplitKey is the one with consequences. <c>RunnerPageInstance.NeedsAutoSplitKey</c>
+    /// reads <c>form.MasterPage.PageProperties.SourceObject.AutoSplitKey</c>, so a missing
+    /// attribute read false, BC's client half of AutoSplitKey silently did not run, and per the
+    /// note in <c>MockTestPage</c> the first new row then lands at line no. 0 and the second
+    /// fails on a duplicate primary key.</para>
+    ///
+    /// <para>The attribute names and value spelling are measured, not guessed: compiling a page
+    /// that declares all three and reading back the metadata the BC 28.1 compiler captured for
+    /// it gives
+    /// <c>&lt;SourceObject AutoSplitKey="1" DelayedInsert="1" MultipleNewLines="1" SourceTable="65940" /&gt;</c>.
+    /// Base Application 28.1's own SymbolReference.json states AutoSplitKey on 234 of its 2610
+    /// pages, MultipleNewLines on 116 and DelayedInsert on 303.</para>
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_CarriesTheSourceObjectFlagsTheSymbolFileStates()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SymbolReference));
+
+            var sourceObject = ReadSourceObject(SplitKeyPageId);
+
+            Assert.Equal("1", sourceObject.GetAttribute("AutoSplitKey"));
+            Assert.Equal("1", sourceObject.GetAttribute("MultipleNewLines"));
+            Assert.Equal("1", sourceObject.GetAttribute("DelayedInsert"));
+            // The flags must not have displaced what was already there.
+            Assert.Equal("701", sourceObject.GetAttribute("SourceTable"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The other direction, and the one that makes the test above mean something: all three
+    /// default to FALSE in AL, so a page whose symbol file states none of them must carry no
+    /// such attribute at all. Writing them unconditionally — as "0", or worse as "1" — would
+    /// make every dependency page claim AutoSplitKey, which is a different wrong answer from
+    /// the one being fixed.
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_OmitsTheSourceObjectFlagsAPageDoesNotDeclare()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SymbolReference));
+
+            var sourceObject = ReadSourceObject(PlainLinesPageId);
+
+            Assert.False(sourceObject.HasAttribute("AutoSplitKey"), "AutoSplitKey must be absent, not \"0\"");
+            Assert.False(sourceObject.HasAttribute("MultipleNewLines"), "MultipleNewLines must be absent");
+            Assert.False(sourceObject.HasAttribute("DelayedInsert"), "DelayedInsert must be absent");
+            Assert.Equal("701", sourceObject.GetAttribute("SourceTable"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    private static XmlElement ReadSourceObject(int pageId)
+    {
+        var xml = RecordPatches.TryBuildDependencyPageMetadata(pageId);
+        Assert.NotNull(xml);
+
+        var doc = new XmlDocument();
+        doc.LoadXml(xml!);
+        var ns = new XmlNamespaceManager(doc.NameTable);
+        ns.AddNamespace("m", "urn:schemas-microsoft-com:dynamics:NAV:MetaObjects");
+
+        var properties = (XmlElement)doc.DocumentElement!.SelectSingleNode("m:Properties", ns)!;
+        return (XmlElement)properties.SelectSingleNode("m:SourceObject", ns)!;
     }
 }

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -106,7 +106,14 @@ internal static partial class BcAppSymbolCache
     // deserialises with all three at their defaults, which reads as "every dependency codeunit
     // declares no TableNo, is not SingleInstance, and is Subtype Normal" — a silent wrong
     // answer for Base Application codeunits rather than a cache miss.
-    private const int CacheVersion = 22;
+    // v23: PageSymbol gained AutoSplitKey / MultipleNewLines / DelayedInsert — the three
+    // <SourceObject> flags the AL compiler writes alongside SourceTable, which
+    // DependencyPageMetadataXml was dropping (issue #2550). A v22 payload deserialises with
+    // all three false, which reads as "no dependency page uses AutoSplitKey" — and BC's
+    // client half of AutoSplitKey then silently does not run, so the first new row on such a
+    // page lands at line no. 0 and the second fails on a duplicate primary key. A wrong
+    // answer replayed from cache rather than a cache miss, which is why this needs the bump.
+    private const int CacheVersion = 23;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
     // Issue #1820 — path -> content-hash memo. ComputeAppContentHash needs to read the
     // WHOLE .app to hash it (unlike the FileInfo.Length/LastWriteTimeUtc stat it replaced,
@@ -219,6 +226,11 @@ internal static partial class BcAppSymbolCache
         // CardPageID = "Customer Card", not a numeric id) — resolved against the run's page
         // inventory at Page Metadata row-build time, same as the source-parsed path.
         string? CardPageName = null,
+        // The three <SourceObject> flags the AL compiler writes alongside SourceTable, all
+        // three defaulting to false in AL. Measured on Base Application 28.1's
+        // SymbolReference.json: of its 2610 pages, 234 state AutoSplitKey, 116 state
+        // MultipleNewLines and 303 state DelayedInsert, as "1"/"0" property values.
+        bool AutoSplitKey = false, bool MultipleNewLines = false, bool DelayedInsert = false,
         // Subpage PART controls (issue #2467), feeding DependencyPageMetadataXml's
         // reconstructed <Content>. Unlike Controls above, a part's binding is resolved
         // entirely from THIS XML (RunnerPageInstance.TryGetPartDefinition reads
@@ -780,6 +792,11 @@ internal static partial class BcAppSymbolCache
         bool insertAllowed = !SymbolBoolFalse(props, "InsertAllowed");
         bool modifyAllowed = !SymbolBoolFalse(props, "ModifyAllowed");
         bool deleteAllowed = !SymbolBoolFalse(props, "DeleteAllowed");
+        // These three default to FALSE in AL, so only an explicit "1"/"true" sets them —
+        // SymbolBool, not the SymbolBoolFalse the four above use.
+        bool autoSplitKey = SymbolBool(props, "AutoSplitKey");
+        bool multipleNewLines = SymbolBool(props, "MultipleNewLines");
+        bool delayedInsert = SymbolBool(props, "DelayedInsert");
 
         var controls = new List<PageControlSymbol>();
         var parts = new List<PagePartSymbol>();
@@ -794,7 +811,8 @@ internal static partial class BcAppSymbolCache
         return new PageSymbol(pageId, name!, sourceTableId, sourceTableTemporary,
             string.IsNullOrWhiteSpace(pageType) ? "Card" : pageType!, caption,
             editable, insertAllowed, modifyAllowed, deleteAllowed, controls,
-            string.IsNullOrWhiteSpace(cardPageName) ? null : cardPageName, parts);
+            string.IsNullOrWhiteSpace(cardPageName) ? null : cardPageName,
+            autoSplitKey, multipleNewLines, delayedInsert, parts);
     }
 
     /// <summary>

--- a/AlRunner/Patches/DependencyPageMetadataXml.cs
+++ b/AlRunner/Patches/DependencyPageMetadataXml.cs
@@ -146,6 +146,24 @@ public static partial class RecordPatches
                 if (!page.InsertAllowed) w.WriteAttributeString("InsertAllowed", "0");
                 if (!page.ModifyAllowed) w.WriteAttributeString("ModifyAllowed", "0");
                 if (!page.DeleteAllowed) w.WriteAttributeString("DeleteAllowed", "0");
+                // The three flags the AL compiler writes here alongside SourceTable, all
+                // three defaulting to false, so only a true one is written — the same
+                // "state what the symbol file states, default the rest" rule as above.
+                //
+                // Measured by compiling a page declaring all three and reading back the
+                // metadata the compiler captured for it, on BC 28.1:
+                //     <SourceObject AutoSplitKey="1" DelayedInsert="1"
+                //                   MultipleNewLines="1" SourceTable="65940" />
+                //
+                // AutoSplitKey is the one with teeth. RunnerPageInstance.NeedsAutoSplitKey
+                // reads form.MasterPage.PageProperties.SourceObject.AutoSplitKey, so
+                // omitting it here read false for every page shipping precompiled in a
+                // dependency .app, BC's client half of AutoSplitKey silently did not run,
+                // and per the note in MockTestPage the first new row then lands at line
+                // no. 0 and the second fails on a duplicate primary key.
+                if (page.AutoSplitKey) w.WriteAttributeString("AutoSplitKey", "1");
+                if (page.MultipleNewLines) w.WriteAttributeString("MultipleNewLines", "1");
+                if (page.DelayedInsert) w.WriteAttributeString("DelayedInsert", "1");
             }
             // The attributes above only mean anything alongside a SourceTable, so a page
             // without one gets the bare element the compiler itself emits — not


### PR DESCRIPTION
`DependencyPageMetadataXml` wrote `<SourceObject>` without `AutoSplitKey`, `MultipleNewLines` or `DelayedInsert`, because `BcAppSymbolCache.PageSymbol` did not carry them. So every page shipping precompiled in a dependency `.app` answered as if it declared none of the three.

**AutoSplitKey is the one with consequences.** `RunnerPageInstance.NeedsAutoSplitKey` reads `form.MasterPage.PageProperties.SourceObject.AutoSplitKey`, so a missing attribute read false and BC's client half of AutoSplitKey silently did not run. Per the note already in `MockTestPage`, the first new row on such a page then lands at line no. 0 and the second fails on a duplicate primary key — a silent wrong answer, not an error.

## Nothing here is inferred

The attribute names and value spelling come from compiling a page that declares all three and reading back the metadata the BC 28.1 compiler captured for it:

```xml
<SourceObject AutoSplitKey="1" DelayedInsert="1" MultipleNewLines="1" SourceTable="65940" />
```

And the data is stated by the symbol file. Of Base Application 28.1's 2610 pages:

| Property | Pages stating it |
|---|---|
| `AutoSplitKey` | 234 |
| `MultipleNewLines` | 116 |
| `DelayedInsert` | 303 |

So this is reconstruction of stated data, which is the rule `DependencyPageMetadataXml`'s own header sets.

## Details

All three default to **false** in AL, so the parser uses `SymbolBool` — only an explicit `"1"`/`"true"` sets them — not the `SymbolBoolFalse` that `Editable`/`InsertAllowed`/`ModifyAllowed`/`DeleteAllowed` use. The writer omits an attribute a page does not declare rather than writing `"0"`.

`DelayedInsert` is included because it is the same property, on the same element, from the same symbol data, dropped by the same line; leaving it out would have been arbitrary. Nothing in the runner reads it yet.

`CacheVersion` 22 → 23: a v22 payload deserialises with all three false, which reads as "no dependency page uses AutoSplitKey" — a wrong answer replayed from cache rather than a cache miss.

## Tests

Both directions, and the second is what makes the first mean something:

- a page stating all three carries all three, and keeps its `SourceTable`;
- a page stating none carries no such attribute **at all** — writing them unconditionally would make every dependency page claim AutoSplitKey, which is a different wrong answer from the one being fixed.

Verified RED by commenting out the `AutoSplitKey` write: the first test fails, the second stays green.

These are runner-only claims — how this runner reconstructs metadata from a symbol file — so they are C# tests, not corpus tests.

## Credit

Found by Mikkel Mansa Vilhelmsen (@vhn-mmv), part of commit `3debc81c` on his fork, which carried a test for exactly this reconstruction.

Closes #2550

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf