### PR TITLE
fix(server): stop a consuming bundle replaying stale C# after a sibling re-emits

### DIFF
--- a/AlRunner.Tests/ServerCrossAppOverloadRebindTests.cs
+++ b/AlRunner.Tests/ServerCrossAppOverloadRebindTests.cs
@@ -1,0 +1,200 @@
+// ServerCrossAppOverloadRebindTests — issue #2603, the CROSS-APP half of the silent overload hazard #2548
+// fixed within one app.
+//
+// #2548 / #2561 stopped the incremental fast path shipping a caller bound to the old overload
+// when caller and callee live in the SAME module: the module's own delta detects that a changed
+// object gained a member under a name it already declared, and falls back to a full compile.
+//
+// That fix cannot reach the cross-app case, and the reason is structural. Each app group gets its
+// OWN RadBaseline and its own TryEmitIncremental call. When app A's callee is edited and app B's
+// caller is not, B's file hashes are all identical, so B takes the "every file hashes identical to
+// the last cycle — genuinely zero work: replay the last cycle's result verbatim" short-circuit and
+// never enters the delta path at all. B's cached C# therefore still bakes the member id A's
+// PREVIOUS surface resolved to.
+//
+// As with the same-app case, the failure is silent exactly when the old id survives:
+//   * `MethodSymbol.CalculateMethodIdForNewVersions` is method-local, so adding `Which(Integer)`
+//     beside `Which(Decimal)` leaves the Decimal overload's id and its `case` label untouched.
+//   * What moves is the id the CALLER bakes — an Integer argument used to widen to the Decimal
+//     overload and now binds to the Integer one.
+//   * B dispatches a member that still exists and gets the previous overload's answer. No
+//     NavNCLMissingMethodException, no diagnostic, no log line — the run is green and wrong.
+//
+// This is the shape the whole cross-app reference graph (#2571) exists to make fixable. The test
+// is written to state the requirement, not the mechanism: a warm --server request must answer the
+// same as a from-scratch run of the same sources. Any fix that achieves that satisfies it.
+//
+// Request 1's expectation is deliberately the POST-edit one, so the test app's own source can stay
+// byte-identical across both requests — that is the whole point, since a modified caller would get
+// a fresh call-site id anyway and there would be nothing to measure.
+//
+// Credit: the hazard and the compiler contract underneath it were found and pinned by Mikkel Mansa
+// Vilhelmsen (vhn) in his AL Runner fork (RadDeltaWatchTests
+// .Watch_AddingAnOverloadInOneApp_RebindsItsCrossAppCaller).
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class ServerCrossAppOverloadRebindTests
+{
+    private const string AppId = "a1b2c3d4-6051-4a11-9111-111111111111";
+    private const string TestAppId = "a1b2c3d4-6052-4a11-9222-222222222222";
+
+    /// <summary>The dependency app, with one Decimal overload of `Which`.</summary>
+    private const string LibBefore = """
+        codeunit 60510 "XApp Ovl Lib"
+        {
+            procedure Which(Seed: Decimal): Integer
+            begin
+                exit(1);
+            end;
+        }
+        """;
+
+    /// <summary>The edit: a second overload of the SAME name taking Integer. Nothing else moves,
+    /// and no existing member's id moves either.</summary>
+    private const string LibAfter = """
+        codeunit 60510 "XApp Ovl Lib"
+        {
+            procedure Which(Seed: Decimal): Integer
+            begin
+                exit(1);
+            end;
+
+            procedure Which(Seed: Integer): Integer
+            begin
+                exit(2);
+            end;
+        }
+        """;
+
+    private static string MakeAppBundle(string root, string lib)
+    {
+        var dir = Path.Combine(root, "app");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{AppId}}",
+          "name": "XApp Ovl App",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 60510, "to": 60519 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Lib.al"), lib);
+        return dir;
+    }
+
+    /// <summary>
+    /// The consuming app. Byte-identical across both requests, and it passes an INTEGER — so what
+    /// it binds to is decided entirely by which overloads the dependency declares.
+    /// </summary>
+    private static string MakeTestAppBundle(string root)
+    {
+        var dir = Path.Combine(root, "test-app");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{TestAppId}}",
+          "name": "XApp Ovl Test App",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{AppId}}", "name": "XApp Ovl App",
+              "publisher": "AL Runner", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 60520, "to": 60529 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Tests.al"), """
+        codeunit 60520 "XApp Ovl Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure BindsTheIntegerOverload()
+            var
+                Lib: Codeunit "XApp Ovl Lib";
+                Seed: Integer;
+                Bound: Integer;
+            begin
+                Seed := 7;
+                Bound := Lib.Which(Seed);
+                // Deliberately the POST-edit expectation. Before the dependency gains an Integer
+                // overload the argument widens to the Decimal one and this reports 1; after, a
+                // correctly rebound caller reports 2. The value is in the message so a wrong
+                // answer names itself instead of only failing.
+                if Bound <> 2 then
+                    Error('BOUND-TO=' + Format(Bound));
+            end;
+        }
+        """);
+        return dir;
+    }
+
+    private static string RunTestsRequest(string appDir, string testAppDir)
+        => JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            sourcePaths = new[] { appDir, testAppDir },
+            packagePaths = Array.Empty<string>(),
+            // Without these the server takes the ordinary full Emit() on every request
+            // (RunBundleForServer only calls TryEmitIncremental when useIncrementalChangeModel is
+            // set, which is what affectedOnly turns on), and the incremental path this test is
+            // about is never entered at all.
+            affectedOnly = true,
+            perTestCoverage = true,
+        });
+
+    /// <summary>
+    /// A warm <c>--server</c> request whose DEPENDENCY app gained an overload must answer the same
+    /// as a from-scratch run of the same sources.
+    /// </summary>
+    [SkippableFact]
+    public async Task WarmRequest_AfterADependencyGainsAnOverload_RebindsTheConsumingApp()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-xapp-overload", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var appDir = MakeAppBundle(root, LibBefore);
+        var testAppDir = MakeTestAppBundle(root);
+
+        await using var server = await CliServer.StartAsync(new[] { "--no-cache" });
+
+        // Request 1 — pre-edit. The Integer argument widens to Which(Decimal), so the test reports
+        // BOUND-TO=1 and fails. Asserted, not tolerated: it is the measurement that the fixture
+        // really does bind the Decimal overload to begin with, so request 2's pass cannot be
+        // "it was always 2".
+        var lines1 = await server.SendRequestStreamingAsync(RunTestsRequest(appDir, testAppDir));
+        var (events1, _) = ProtocolV2Streaming.Split(lines1);
+        Assert.Single(events1);
+        Assert.Equal("fail", events1[0].GetProperty("status").GetString());
+        Assert.Contains("BOUND-TO=1", string.Join(" | ", lines1), StringComparison.Ordinal);
+
+        // Edit ONLY the dependency app. The test app's files are not touched.
+        File.WriteAllText(Path.Combine(appDir, "Lib.al"), LibAfter);
+
+        // Request 2 — same warm process. A from-scratch run of these sources binds
+        // Which(Integer) and returns 2.
+        var lines2 = await server.SendRequestStreamingAsync(RunTestsRequest(appDir, testAppDir));
+        var (events2, _) = ProtocolV2Streaming.Split(lines2);
+        Assert.Single(events2);
+
+        var status2 = events2[0].GetProperty("status").GetString();
+        Assert.True(status2 == "pass",
+            "the consuming app was not rebound after its dependency gained an overload. Its own "
+            + "files did not change, so its module took the \"replay the last cycle's result "
+            + "verbatim\" short-circuit and never entered the delta path — leaving its cached C# "
+            + "dispatching the member id that Which(Decimal) resolved to. That member still exists "
+            + "in the re-emitted dependency, so the call succeeded and returned the PREVIOUS "
+            + "overload's answer with no exception and no diagnostic. Expected BOUND-TO=2 "
+            + $"(what a cold run of these exact sources gives); got: {string.Join(" | ", lines2)}");
+    }
+}

--- a/AlRunner.Tests/ServerCrossAppOverloadRebindTests.cs
+++ b/AlRunner.Tests/ServerCrossAppOverloadRebindTests.cs
@@ -38,12 +38,15 @@ namespace AlRunner.Tests;
 
 public class ServerCrossAppOverloadRebindTests
 {
-    private const string AppId = "a1b2c3d4-6051-4a11-9111-111111111111";
-    private const string TestAppId = "a1b2c3d4-6052-4a11-9222-222222222222";
+    // One id set per ordering case, so the two cases cannot share on-disk or in-process state.
+    private static string AppId(int c) => $"a1b2c3d4-605{c}-4a11-9111-111111111111";
+    private static string TestAppId(int c) => $"a1b2c3d4-606{c}-4a11-9222-222222222222";
+    private static int LibId(int c) => 60510 + c * 20;
+    private static int TestsId(int c) => 60520 + c * 20;
 
     /// <summary>The dependency app, with one Decimal overload of `Which`.</summary>
-    private const string LibBefore = """
-        codeunit 60510 "XApp Ovl Lib"
+    private static string LibBefore(int c) => $$"""
+        codeunit {{LibId(c)}} "XApp Ovl Lib {{c}}"
         {
             procedure Which(Seed: Decimal): Integer
             begin
@@ -54,8 +57,8 @@ public class ServerCrossAppOverloadRebindTests
 
     /// <summary>The edit: a second overload of the SAME name taking Integer. Nothing else moves,
     /// and no existing member's id moves either.</summary>
-    private const string LibAfter = """
-        codeunit 60510 "XApp Ovl Lib"
+    private static string LibAfter(int c) => $$"""
+        codeunit {{LibId(c)}} "XApp Ovl Lib {{c}}"
         {
             procedure Which(Seed: Decimal): Integer
             begin
@@ -69,19 +72,19 @@ public class ServerCrossAppOverloadRebindTests
         }
         """;
 
-    private static string MakeAppBundle(string root, string lib)
+    private static string MakeAppBundle(string root, int c, string lib)
     {
         var dir = Path.Combine(root, "app");
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
         {
-          "id": "{{AppId}}",
-          "name": "XApp Ovl App",
+          "id": "{{AppId(c)}}",
+          "name": "XApp Ovl App {{c}}",
           "publisher": "AL Runner",
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "idRanges": [ { "from": 60510, "to": 60519 } ],
+          "idRanges": [ { "from": {{LibId(c)}}, "to": {{LibId(c) + 9}} } ],
           "runtime": "14.0"
         }
         """);
@@ -93,34 +96,34 @@ public class ServerCrossAppOverloadRebindTests
     /// The consuming app. Byte-identical across both requests, and it passes an INTEGER — so what
     /// it binds to is decided entirely by which overloads the dependency declares.
     /// </summary>
-    private static string MakeTestAppBundle(string root)
+    private static string MakeTestAppBundle(string root, int c)
     {
         var dir = Path.Combine(root, "test-app");
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
         {
-          "id": "{{TestAppId}}",
-          "name": "XApp Ovl Test App",
+          "id": "{{TestAppId(c)}}",
+          "name": "XApp Ovl Test App {{c}}",
           "publisher": "AL Runner",
           "version": "1.0.0.0",
           "dependencies": [
-            { "id": "{{AppId}}", "name": "XApp Ovl App",
+            { "id": "{{AppId(c)}}", "name": "XApp Ovl App {{c}}",
               "publisher": "AL Runner", "version": "1.0.0.0" }
           ],
           "platform": "1.0.0.0",
-          "idRanges": [ { "from": 60520, "to": 60529 } ],
+          "idRanges": [ { "from": {{TestsId(c)}}, "to": {{TestsId(c) + 9}} } ],
           "runtime": "14.0"
         }
         """);
-        File.WriteAllText(Path.Combine(dir, "Tests.al"), """
-        codeunit 60520 "XApp Ovl Tests"
+        File.WriteAllText(Path.Combine(dir, "Tests.al"), $$"""
+        codeunit {{TestsId(c)}} "XApp Ovl Tests {{c}}"
         {
             Subtype = Test;
 
             [Test]
             procedure BindsTheIntegerOverload()
             var
-                Lib: Codeunit "XApp Ovl Lib";
+                Lib: Codeunit "XApp Ovl Lib {{c}}";
                 Seed: Integer;
                 Bound: Integer;
             begin
@@ -138,11 +141,11 @@ public class ServerCrossAppOverloadRebindTests
         return dir;
     }
 
-    private static string RunTestsRequest(string appDir, string testAppDir)
+    private static string RunTestsRequest(string[] sourcePaths)
         => JsonSerializer.Serialize(new
         {
             command = "runTests",
-            sourcePaths = new[] { appDir, testAppDir },
+            sourcePaths,
             packagePaths = Array.Empty<string>(),
             // Without these the server takes the ordinary full Emit() on every request
             // (RunBundleForServer only calls TryEmitIncremental when useIncrementalChangeModel is
@@ -153,48 +156,84 @@ public class ServerCrossAppOverloadRebindTests
         });
 
     /// <summary>
-    /// A warm <c>--server</c> request whose DEPENDENCY app gained an overload must answer the same
-    /// as a from-scratch run of the same sources.
+    /// A warm <c>--server</c> request whose DEPENDENCY app gained an overload must never answer
+    /// with the overload the consuming app used to bind to.
+    ///
+    /// <para><b>The two orders have different bars, and the difference is measured, not assumed.</b></para>
+    ///
+    /// <para><c>dependencyFirst: true</c> — the order the README documents. Must PASS: the request
+    /// answers exactly as a from-scratch run of the same sources does.</para>
+    ///
+    /// <para><c>dependencyFirst: false</c> — an order nothing documents but the runner accepts.
+    /// Before this change it returned <c>BOUND-TO=1</c>: a green-looking, silently wrong answer,
+    /// because the consuming bundle is processed before the fallback signal the forward
+    /// propagation reads even exists. <c>ChangedLaterDependencyBundles</c> now forces that bundle
+    /// to compile in full, and what remains is a LOUD failure —
+    /// <c>NavNCLCompilationException: Function ID … was called. The object with ID … does not have
+    /// a member with that ID</c> — because in this order the dependency's runtime assembly is not
+    /// reloaded until after the consuming bundle's tests have already run. That residual is #2614; the bar asserted here is the one
+    /// <c>.claude/rules/loud-failures.md</c> sets: pass, or fail in a way somebody can see.
+    /// <b>Never <c>BOUND-TO=1</c>.</b></para>
     /// </summary>
-    [SkippableFact]
-    public async Task WarmRequest_AfterADependencyGainsAnOverload_RebindsTheConsumingApp()
+    [SkippableTheory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task WarmRequest_AfterADependencyGainsAnOverload_NeverAnswersWithTheOldOverload(bool dependencyFirst)
     {
         TestArtifacts.SkipIfMissing();
 
+        var c = dependencyFirst ? 1 : 2;
         var root = Path.Combine(Path.GetTempPath(), "al-runner-xapp-overload", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(root);
-        var appDir = MakeAppBundle(root, LibBefore);
-        var testAppDir = MakeTestAppBundle(root);
+        var appDir = MakeAppBundle(root, c, LibBefore(c));
+        var testAppDir = MakeTestAppBundle(root, c);
+        var sourcePaths = dependencyFirst
+            ? new[] { appDir, testAppDir }
+            : new[] { testAppDir, appDir };
 
         await using var server = await CliServer.StartAsync(new[] { "--no-cache" });
 
         // Request 1 — pre-edit. The Integer argument widens to Which(Decimal), so the test reports
         // BOUND-TO=1 and fails. Asserted, not tolerated: it is the measurement that the fixture
-        // really does bind the Decimal overload to begin with, so request 2's pass cannot be
-        // "it was always 2".
-        var lines1 = await server.SendRequestStreamingAsync(RunTestsRequest(appDir, testAppDir));
+        // really does bind the Decimal overload to begin with, so request 2 cannot pass by the
+        // answer having been 2 all along.
+        var lines1 = await server.SendRequestStreamingAsync(RunTestsRequest(sourcePaths));
         var (events1, _) = ProtocolV2Streaming.Split(lines1);
         Assert.Single(events1);
         Assert.Equal("fail", events1[0].GetProperty("status").GetString());
         Assert.Contains("BOUND-TO=1", string.Join(" | ", lines1), StringComparison.Ordinal);
 
-        // Edit ONLY the dependency app. The test app's files are not touched.
-        File.WriteAllText(Path.Combine(appDir, "Lib.al"), LibAfter);
+        // Edit ONLY the dependency app. The test app's files are not touched — which is the whole
+        // point, since a modified caller would get a fresh call-site id anyway.
+        File.WriteAllText(Path.Combine(appDir, "Lib.al"), LibAfter(c));
 
         // Request 2 — same warm process. A from-scratch run of these sources binds
         // Which(Integer) and returns 2.
-        var lines2 = await server.SendRequestStreamingAsync(RunTestsRequest(appDir, testAppDir));
+        var lines2 = await server.SendRequestStreamingAsync(RunTestsRequest(sourcePaths));
         var (events2, _) = ProtocolV2Streaming.Split(lines2);
         Assert.Single(events2);
-
+        var joined2 = string.Join(" | ", lines2);
         var status2 = events2[0].GetProperty("status").GetString();
+
+        // The floor, asserted for BOTH orders: the previous overload's answer must never come back
+        // reported as a result. This is the silent failure the whole change exists to remove.
+        Assert.False(joined2.Contains("BOUND-TO=1", StringComparison.Ordinal),
+            "the consuming app returned the PREVIOUS overload's answer after its dependency gained "
+            + $"an overload (dependencyFirst: {dependencyFirst}). Its own files did not change, so "
+            + "its module took the \"replay the last cycle's result verbatim\" short-circuit and "
+            + "never entered the delta path — leaving its cached C# dispatching the member id that "
+            + "Which(Decimal) resolved to. That member still exists in the re-emitted dependency, so "
+            + "the call succeeded with no exception and no diagnostic. Got: " + joined2);
+
+        if (!dependencyFirst)
+        {
+            // The undocumented order: loud is the bar. Passing is fine too — assert only that the
+            // answer is not silently wrong, which the check above has already established.
+            return;
+        }
+
         Assert.True(status2 == "pass",
-            "the consuming app was not rebound after its dependency gained an overload. Its own "
-            + "files did not change, so its module took the \"replay the last cycle's result "
-            + "verbatim\" short-circuit and never entered the delta path — leaving its cached C# "
-            + "dispatching the member id that Which(Decimal) resolved to. That member still exists "
-            + "in the re-emitted dependency, so the call succeeded and returned the PREVIOUS "
-            + "overload's answer with no exception and no diagnostic. Expected BOUND-TO=2 "
-            + $"(what a cold run of these exact sources gives); got: {string.Join(" | ", lines2)}");
+            "the documented dependency-first order must answer exactly as a cold run of these "
+            + $"sources does (BOUND-TO=2). Got: {joined2}");
     }
 }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3638,6 +3638,9 @@ return strictExitCode ? computedExitCode : 0;
         // changes that happened in a sibling bundle. Gated on affectedOnly and more than one
         // bundle — a single-bundle request already sees its own full change set.
         List<AffectedObjectId>? requestWideChangedObjects = null;
+        // Per bundle: how many objects its own peek saw change, or null when the peek could not
+        // answer for it. See ChangedDependencyForcesFullCompile below.
+        var peekedChangedCountByBundle = new Dictionary<string, int?>(StringComparer.OrdinalIgnoreCase);
         if (useIncrementalChangeModel && sourcePaths.Length > 1)
         {
             requestWideChangedObjects = new List<AffectedObjectId>();
@@ -3652,6 +3655,10 @@ return strictExitCode ? computedExitCode : 0;
                 peekPaths = peekPaths.Distinct().ToList();
 
                 var peeked = emitter.PeekChangedObjects(peekPaths, peekModuleName, peekBucketRoot);
+                // #2603: the same peek answers a second question — "did THIS bundle change this
+                // cycle?" — which is what lets a bundle listed BEFORE its own dependency decide
+                // safely. Recorded per bundle, not folded into the union.
+                peekedChangedCountByBundle[peekAbs] = peeked?.Count;
                 if (peeked == null)
                 {
                     // Unknown for at least one bundle (no baseline yet, app.json changed, an
@@ -3722,6 +3729,26 @@ return strictExitCode ? computedExitCode : 0;
             };
         }
 
+        // #2603, the order-independent half. The forward propagation above is only sound while a
+        // bundle's in-request dependencies are compiled BEFORE it — the `sourcePaths` order the
+        // README documents. Measured with that order reversed, the defect returns in full: the
+        // consuming bundle is processed first, `sawFallbackReason` is still null, it replays its
+        // previous C# verbatim, and the run reports BOUND-TO=1 where a cold run gives 2. An
+        // undocumented argument order is still an accepted one, and answering it wrongly in
+        // silence is the thing this whole change exists to stop.
+        //
+        // The request already knows enough to decide this without compiling anything and without
+        // reordering execution (which would change the order test events stream out):
+        //   * which bundles this one declares a dependency on — the same app.json identity read
+        //     RunLayeredPrePass already does to decide which bundles are "impls";
+        //   * whether each of those changed this cycle — the per-bundle peek above.
+        //
+        // The rule: a bundle may use the incremental change model only if every in-request bundle
+        // it depends on either comes BEFORE it (the forward propagation covers it) or is
+        // known-unchanged this cycle. In the documented order the first clause always holds, so
+        // this costs nothing and changes no behaviour there.
+        var forcedFullBundles = ChangedLaterDependencyBundles(sourcePaths, peekedChangedCountByBundle);
+
         var bundleIndex = 0;
         foreach (var bundleDir in sourcePaths)
         {
@@ -3730,16 +3757,91 @@ return strictExitCode ? computedExitCode : 0;
             var relBundle = Path.GetRelativePath(
                 Environment.CurrentDirectory, Path.GetFullPath(bundleDir));
             AlRunner.Infrastructure.PhaseLog.BeginBundle(relBundle, bundleIndex);
-            // #2603: see the comment above `sawFallbackReason`. An earlier bundle fell back, so
-            // this one must not serve its C# from a baseline recorded before that bundle moved.
+            // #2603: see the two comments above. An earlier bundle fell back, or a dependency of
+            // this bundle is listed after it and changed this cycle — either way this bundle must
+            // not serve its C# from a baseline recorded before that other bundle moved.
             var result = RunBundleForServer(bundleDir, requestPackagePaths, runStep,
-                useIncrementalChangeModel && sawFallbackReason == null,
+                useIncrementalChangeModel && sawFallbackReason == null
+                    && !forcedFullBundles.Contains(Path.GetFullPath(bundleDir)),
                 effectiveBeforeRun,
                 out var emitElapsed, out var compileElapsed, out var runElapsed);
             AlRunner.Infrastructure.PhaseLog.EndBundle(emitElapsed, compileElapsed, runElapsed);
             results.Add(result);
         }
         return results;
+    }
+
+    /// <summary>
+    /// The bundles in this request that must NOT use the incremental change model because a bundle
+    /// they depend on is listed AFTER them in <paramref name="sourcePaths"/> and changed this cycle.
+    ///
+    /// <para>Issue #2603. A bundle whose own files all hash identical replays its previous
+    /// generated C# verbatim, which bakes the member ids its dependencies' PREVIOUS surfaces
+    /// resolved to. The forward fallback propagation in <c>RunAllBundlesForServer</c> covers a
+    /// dependency compiled earlier in the same request; it cannot cover one compiled later,
+    /// because the signal it reads does not exist yet.</para>
+    ///
+    /// <para>Both inputs are already paid for: the dependency relation is the same app.json
+    /// identity read <see cref="RunLayeredPrePass"/> does, and "did it change" is the per-bundle
+    /// result of the peek <c>RunAllBundlesForServer</c> already performs for #2492's union.
+    /// Nothing here compiles anything, and execution order is deliberately left alone — reordering
+    /// would change the order test events stream out.</para>
+    ///
+    /// <para><b>Fail-closed on an unreadable answer.</b> A dependency whose peek could not answer
+    /// (no baseline yet, app.json changed, an unclassifiable file — <c>PeekChangedObjects</c>
+    /// returns null) counts as changed, and so does one that was never peeked at all. "I do not
+    /// know whether it moved" and "it moved" have the same safe handling; only a positive
+    /// zero-changes answer earns the fast path.</para>
+    ///
+    /// <para>Matching is by declared <c>AppId</c>, falling back to Name+Publisher — the same pair
+    /// <see cref="RunLayeredPrePass"/> uses, and for the same reason: a bundle without a declared
+    /// id still has to be recognisable as somebody's dependency.</para>
+    /// </summary>
+    static HashSet<string> ChangedLaterDependencyBundles(
+        string[] sourcePaths, Dictionary<string, int?> peekedChangedCountByBundle)
+    {
+        var forced = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (sourcePaths.Length < 2 || peekedChangedCountByBundle.Count == 0) return forced;
+
+        var order = new List<string>();
+        var identities = new Dictionary<string, AlRunner.Infrastructure.BundleIdentity>(StringComparer.OrdinalIgnoreCase);
+        foreach (var bundle in sourcePaths)
+        {
+            var abs = Path.GetFullPath(bundle);
+            order.Add(abs);
+            var appJson = Path.Combine(abs, "app.json");
+            if (!File.Exists(appJson))
+            {
+                var root = FindBucketRoot(abs);
+                if (root != null) appJson = Path.Combine(root, "app.json");
+            }
+            if (!File.Exists(appJson)) continue;
+            var id = AlRunner.Infrastructure.InProcessAppPackager.ReadIdentity(appJson);
+            if (id != null) identities[abs] = id;
+        }
+        if (identities.Count < 2) return forced;
+
+        bool ChangedOrUnknown(string abs) =>
+            !peekedChangedCountByBundle.TryGetValue(abs, out var count) || count is not 0;
+
+        for (int i = 0; i < order.Count; i++)
+        {
+            if (!identities.TryGetValue(order[i], out var mine)) continue;
+            for (int j = i + 1; j < order.Count; j++)
+            {
+                if (!identities.TryGetValue(order[j], out var later)) continue;
+                bool dependsOnLater = mine.Dependencies.Any(dep =>
+                    (dep.AppId != Guid.Empty && dep.AppId == later.AppId)
+                    || (string.Equals(dep.Name, later.Name, StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(dep.Publisher, later.Publisher, StringComparison.OrdinalIgnoreCase)));
+                if (dependsOnLater && ChangedOrUnknown(order[j]))
+                {
+                    forced.Add(order[i]);
+                    break;
+                }
+            }
+        }
+        return forced;
     }
 
     // True when `path` is `root` itself or nested somewhere under it. Both are

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3684,11 +3684,31 @@ return strictExitCode ? computedExitCode : 0;
         // processed in `sourcePaths` order — the one documented/supported shape is dependency
         // app before test app (see README), which is exactly the order this needs to see the
         // dependency's fallback before deciding the test app's selection.
+        //
+        // #2603: the SAME signal has to gate this request's later bundles' COMPILATION too, not
+        // only their test selection. A bundle whose own files all hash identical to the last cycle
+        // takes TryEmitIncremental's "genuinely zero work: replay the last cycle's result verbatim"
+        // short-circuit — which is correct in isolation and wrong when a DEPENDENCY bundle in the
+        // same request just re-emitted a surface this bundle's generated C# baked member ids
+        // against. Measured: a dependency app that gains an overload correctly falls back to a full
+        // compile (#2548), and the consuming test app, whose own sources did not move, replayed its
+        // previous C# and dispatched the PREVIOUS overload — a green-looking run returning the wrong
+        // answer, visible only because the AL test happened to assert the value.
+        //
+        // So `sawFallbackReason` is hoisted out of the closure below and read by the bundle loop:
+        // once any bundle in this request has fallen back, every later bundle compiles in full
+        // instead of replaying. Conservative on purpose — without an object-reference graph
+        // (#2571) there is no way to ask whether THIS bundle actually binds to what that one
+        // re-emitted, and the failure this prevents is silent while the cost is one full compile of
+        // a bundle whose dependency just changed anyway.
+        //
+        // Same forward-only, `sourcePaths`-order limitation as the selection half above, and for
+        // the same reason. #2571 tracks the order-independent version.
+        string? sawFallbackReason = null;
         var effectiveBeforeRun = beforeRun;
         if (beforeRun != null)
         {
             var union = requestWideChangedObjects;
-            string? sawFallbackReason = null;
             effectiveBeforeRun = (bundlePath, moduleName, selectionEnvironmentKey, changedObjects, changeModelFallbackReason) =>
             {
                 var merged = union == null || changedObjects == null ? changedObjects : changedObjects.Concat(union).ToList();
@@ -3710,8 +3730,10 @@ return strictExitCode ? computedExitCode : 0;
             var relBundle = Path.GetRelativePath(
                 Environment.CurrentDirectory, Path.GetFullPath(bundleDir));
             AlRunner.Infrastructure.PhaseLog.BeginBundle(relBundle, bundleIndex);
+            // #2603: see the comment above `sawFallbackReason`. An earlier bundle fell back, so
+            // this one must not serve its C# from a baseline recorded before that bundle moved.
             var result = RunBundleForServer(bundleDir, requestPackagePaths, runStep,
-                useIncrementalChangeModel,
+                useIncrementalChangeModel && sawFallbackReason == null,
                 effectiveBeforeRun,
                 out var emitElapsed, out var compileElapsed, out var runElapsed);
             AlRunner.Infrastructure.PhaseLog.EndBundle(emitElapsed, compileElapsed, runElapsed);


### PR DESCRIPTION
Closes #2603

## Problem

With `affectedOnly` on, a warm `--server` request can return a **green run with the wrong answer**
when a dependency bundle's callable surface moves and the consuming bundle's own sources do not.

Reproduced against `main` (see the RED test in the PR). Two bundles in one request, dependency app
first:

```al
// app/Lib.al                       // test-app/Tests.al  (byte-identical across both requests)
codeunit 60510 "XApp Ovl Lib"       Seed := 7;
{                                   Bound := Lib.Which(Seed);   // Integer argument
    procedure Which(Seed: Decimal): Integer  begin exit(1); end;
}
```

Request 1: the Integer argument widens to `Which(Decimal)` → `BOUND-TO=1`.
Then add `procedure Which(Seed: Integer): Integer begin exit(2); end;` to the dependency **only**.
Request 2, same warm process: still `BOUND-TO=1`. A from-scratch run of those exact sources gives 2.

## Mechanism

Each bundle gets its own `RadBaseline` and its own `TryEmitIncremental` call.

- The dependency app's module correctly falls back to a full compile — #2548/#2561's guard fires and
  says so in the selection reason.
- The consuming app's own files all hash identical, so its module takes
  `TryEmitIncremental`'s *"every file hashes identical to the last cycle — genuinely zero work:
  replay the last cycle's result verbatim"* short-circuit and **never enters the delta path at all**.
  Its cached C# still bakes the member id `Which(Decimal)` resolved to.

That member still exists in the re-emitted dependency, so the call succeeds and returns the previous
overload's answer. No `NavNCLMissingMethodException`, no diagnostic, no log line.

Confirmed from the request-2 summary: `forcedFull: true` with the #2548 reason for `V2_app` plus
"an earlier bundle in this request fell back this cycle", and the test still reports `BOUND-TO=1`.

## Not present without `affectedOnly`

`RunBundleForServer` only calls `TryEmitIncremental` when `useIncrementalChangeModel` is set, which
is what `affectedOnly` turns on. Without the flag every request full-compiles and answers correctly.
So this is a defect **introduced by the narrowing feature**, not a pre-existing one — worth stating,
because it means the blast radius is "runs that opted into `affectedOnly`".

I first wrote this test *without* `affectedOnly` and it passed. That near-miss is the reason the
test now carries a comment explaining why the flags are load-bearing.

## The fix

`RunAllBundlesForServer` already computes "an earlier bundle in this request fell back this cycle"
and propagates it forward to disable later bundles' **test selection** (#2492/#2508). The same signal
now also gates later bundles' **compilation**: once any bundle has fallen back, every later bundle
compiles in full instead of replaying its previous output.

Conservative on purpose. Without an object-reference graph (#2571) there is no way to ask whether a
given bundle actually binds to what the other one re-emitted, and the failure being prevented is
silent while the cost is one full compile of a bundle whose dependency just changed anyway.

## The order-independent half (second commit)

The forward propagation is only sound while a bundle's in-request dependencies compile **before** it.
I measured the reversed `sourcePaths` order and the defect came back in full — `BOUND-TO=1`, same
silent wrong answer — because the consuming bundle is processed before the signal exists.

Rather than ship that as a known limitation, `ChangedLaterDependencyBundles` decides it from
information the request already has, with no compile and no reordering of execution:

- which bundles this one declares a dependency on — the same app.json identity read
  `RunLayeredPrePass` already does;
- whether each of those changed this cycle — the per-bundle result of the peek already performed for
  #2492's union.

**The rule:** a bundle may use the incremental change model only if every in-request bundle it
depends on either comes before it, or is known-unchanged this cycle. Fail-closed — a dependency
whose peek could not answer, or that was never peeked, counts as changed. In the documented order
the first clause always holds, so this costs nothing and changes no behaviour there.

### What is left in the reversed order, and why it is acceptable

A **loud** failure, not a silent one:

```
NavNCLCompilationException: Function ID -53549305 was called.
The object with ID 60550 does not have a member with that ID.
```

The consuming bundle now compiles in full and correctly bakes the new member id — but bundles
*execute* in `sourcePaths` order, so its tests run before the dependency's assembly is reloaded in
that same request, and the new id dispatches into last request's assembly. Filed as **#2614** with
both candidate fixes (topologically order the bundle loop, or refuse the order); it needs a
maintainer call on whether changing test-event order is acceptable.

The bar asserted here is the one `.claude/rules/loud-failures.md` sets: pass, or fail where somebody
can see it — never the previous overload's answer.

## Also not covered

An edit that changes a callee's return **subtype** or a parameter **name** moves no member id
either, so a consuming bundle keeps binding and the incremental cycle compiles clean where a cold
build would raise a diagnostic in the caller. That is a missed *diagnostic*, not a wrong *dispatch*,
and needs its own reproducer.

## Credit

The cross-app half of this hazard, and the compiler contract underneath it, were found and pinned by
**Mikkel Mansa Vilhelmsen (vhn)** in his AL Runner fork
(`RadDeltaWatchTests.Watch_AddingAnOverloadInOneApp_RebindsItsCrossAppCaller`).

## Tests

`AlRunner.Tests/ServerCrossAppOverloadRebindTests.cs` — a theory over **both** `sourcePaths` orders,
RED on `main` in both, written to state the requirement rather than the mechanism. The floor
(*never* the previous overload's answer) is asserted for both; full correctness (*answers as a cold
run does*) only for the documented order, with the reason written out. When #2614 lands, the test's
`if (!dependencyFirst) return;` branch is what should be deleted.

Request 1's expectation is deliberately the post-edit one, and its failure is **asserted**
(`BOUND-TO=1`), not tolerated — that is the measurement that the fixture really does bind the
Decimal overload to begin with, so request 2's pass cannot be "it was always 2". The consuming app's
source is byte-identical across both requests, which is the whole point: a modified caller would get
a fresh call-site id anyway and there would be nothing to measure.

Local: 16 green across `ServerAffected*`, `CrossBundle*`, `SharedCliServer*` and this suite — including
`AffectedOnly_DependencyEditBetweenRequests_StillNarrows`, which asserts `forcedFull: false` and
therefore proves this change does not disable narrowing for an ordinary body edit.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
