### PR TITLE
Populate the Time Zone (2000000164) virtual table from the host

### DIFF
--- a/AlRunner.Tests/Fixtures/TimeZoneVirtualTable/Assert.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/TimeZoneVirtualTable/Assert.Codeunit.al
@@ -1,0 +1,22 @@
+// Standalone Assert codeunit — this fixture must stand alone, it does not import from
+// tests/al-language or tests/runner-extras.
+codeunit 60780 "TZV Assert"
+{
+    procedure AreEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if Format(Expected) <> Format(Actual) then
+            Error('Expected %1 but got %2: %3', Format(Expected), Format(Actual), Msg);
+    end;
+
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error('Expected true: %1', Msg);
+    end;
+
+    procedure IsFalse(Condition: Boolean; Msg: Text)
+    begin
+        if Condition then
+            Error('Expected false: %1', Msg);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/TimeZoneVirtualTable/TzvFixtureTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/TimeZoneVirtualTable/TzvFixtureTests.Codeunit.al
@@ -1,0 +1,86 @@
+// Fixture suite for TimeZoneVirtualTableTests.cs (#2584).
+//
+// Every assertion is about SHAPE, never about a specific time zone id. The row set is
+// whatever the host operating system reports — that is what BC's own TimeZoneDataProvider
+// does, and asserting a Windows id here would fail on this Linux host for a reason that is
+// documented behavior, not a bug.
+codeunit 60781 "TZV Fixture Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "TZV Assert";
+
+    [Test]
+    procedure TimeZone_IsNotEmpty()
+    var
+        TimeZone: Record "Time Zone";
+    begin
+        // Before the fix this raised "There is no Time Zone within the filter."
+        Assert.IsTrue(TimeZone.FindSet(), 'Time Zone must answer at least one row.');
+        Assert.IsTrue(TimeZone.Count() > 1, 'A host reports more than one time zone.');
+    end;
+
+    [Test]
+    procedure TimeZone_NumbersStartAtOneAndIncrementWithNoGaps()
+    var
+        TimeZone: Record "Time Zone";
+        Expected: Integer;
+    begin
+        // "No." is a sequence over the host's list, so a provider that inserted rows without
+        // numbering them, or numbered them from 0, fails here.
+        Expected := 0;
+        Assert.IsTrue(TimeZone.FindSet(), 'Time Zone must answer at least one row.');
+        repeat
+            Expected += 1;
+            Assert.AreEqual(Expected, TimeZone."No.", 'Time Zone "No." must be 1..N with no gaps.');
+        until TimeZone.Next() = 0;
+    end;
+
+    [Test]
+    procedure TimeZone_EveryRowHasANonBlankId()
+    var
+        TimeZone: Record "Time Zone";
+    begin
+        // The negative control for a provider that inserted N blank rows: the count and the
+        // numbering above would both pass, and this would not.
+        Assert.IsTrue(TimeZone.FindSet(), 'Time Zone must answer at least one row.');
+        repeat
+            Assert.IsFalse(TimeZone.ID = '', 'Every Time Zone row must carry a non-blank ID.');
+        until TimeZone.Next() = 0;
+    end;
+
+    [Test]
+    procedure TimeZone_GetOne_AgreesWithTheFirstRowOfFindSet()
+    var
+        ByGet: Record "Time Zone";
+        ByFind: Record "Time Zone";
+    begin
+        Assert.IsTrue(ByFind.FindSet(), 'Time Zone must answer at least one row.');
+        Assert.IsTrue(ByGet.Get(1), 'Get(1) must find the first time zone.');
+        Assert.AreEqual(ByFind.ID, ByGet.ID, 'Get(1) and the first FindSet row must be the same zone.');
+        Assert.AreEqual(ByFind."Display Name", ByGet."Display Name", 'Get(1) must carry the same Display Name.');
+    end;
+
+    [Test]
+    procedure TimeZone_GetOnANumberPastTheEnd_ReturnsFalse()
+    var
+        TimeZone: Record "Time Zone";
+    begin
+        // A provider answering every Get with a row would pass everything above.
+        Assert.IsFalse(TimeZone.Get(999999), 'Time Zone must not have a row numbered 999999.');
+    end;
+
+    [Test]
+    procedure TimeZone_FilterOnNumber_DiscriminatesBetweenRows()
+    var
+        TimeZone: Record "Time Zone";
+    begin
+        TimeZone.SetRange("No.", 1);
+        Assert.AreEqual(1, TimeZone.Count(), 'A filter on one existing number must select one row.');
+
+        TimeZone.SetRange("No.", 999999);
+        Assert.AreEqual(0, TimeZone.Count(), 'A filter on an unused number must select no rows.');
+        Assert.IsTrue(TimeZone.IsEmpty(), 'IsEmpty must be true for a filter naming no time zone.');
+    end;
+}

--- a/AlRunner.Tests/Fixtures/TimeZoneVirtualTable/app.json
+++ b/AlRunner.Tests/Fixtures/TimeZoneVirtualTable/app.json
@@ -1,0 +1,24 @@
+{
+  "id": "a1b2c3d4-e5f6-4708-9a1b-2c3d4e5f6164",
+  "name": "Runner Tests Fixture - Time Zone Virtual Table",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Regression test: the Time Zone virtual table (2000000164) must be populated from the host (#2584).",
+  "description": "Proves Record \"Time Zone\" answers rows numbered 1..N with non-blank ids, on whatever host the runner is on. Asserts SHAPE only, never a specific zone id: the row set is a property of the host OS, which is exactly the documented divergence. See CodeunitMetadataVirtualTableTests.cs's sibling, TimeZoneVirtualTableTests.cs, for the runner-mechanism claim this pins.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "idRanges": [
+    {
+      "from": 60780,
+      "to": 60799
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner.Tests/TimeZoneVirtualTableTests.cs
+++ b/AlRunner.Tests/TimeZoneVirtualTableTests.cs
@@ -1,0 +1,110 @@
+// TimeZoneVirtualTableTests — issue #2584.
+//
+// A RUNNER-MECHANISM test, not a claim about what real BC does: it proves that OUR OWN
+// population of the "Time Zone" system virtual table (2000000164) answers rows at all, and
+// that they are numbered and identified rather than blank.
+//
+// Before the fix, table 2000000164 had no managed provider, so GetDataAccessForTableCore fell
+// through to the plain in-memory temp store and every read answered zero rows: Get() silently
+// returned false and FindSet() raised.
+//
+// EVERY ASSERTION IS ABOUT SHAPE, NEVER A SPECIFIC ZONE ID, and that is deliberate. BC's own
+// TimeZoneDataProvider enumerates the HOST's TimeZoneInfo.GetSystemTimeZones(), so the row set
+// is a property of the machine: Windows ids on a Windows-hosted SaaS tier, IANA ids on this
+// Linux host. Asserting "W. Europe Standard Time" would fail here for a reason that is
+// documented behavior, not a bug — see docs/limitations.md, "Time Zone ids follow the host".
+//
+// The fixture is shaped so a provider inserting N BLANK rows would fail: the count and the
+// 1..N numbering would both pass, and the non-blank-ID assertion would not. The two negative
+// tests (a number past the end, and a filter selecting nothing) close the rest.
+//
+// The BEHAVIORAL claim is proven upstream against a live BC service tier by
+// "Test Time Zone Virtual Table" in StefanMaron/BusinessCentral.AL.Language.Tests, per
+// .claude/rules/bc-behavior-tests-go-upstream.md — asserting the same shape, for the same
+// reason: no host-specific id can be asserted in a corpus that runs on more than one host.
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TimeZoneVirtualTableTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static readonly string FixtureDir =
+        Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", "TimeZoneVirtualTable");
+
+    private static (int ExitCode, string StdOut, string StdErr) Run(string cacheDir)
+    {
+        var sb = new StringBuilder(TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner")));
+        sb.Append(' ').Append($"\"{FixtureDir}\"");
+        sb.Append(' ').Append($"--cache \"{cacheDir}\"");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = sb.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+
+        var outSb = new StringBuilder();
+        var errSb = new StringBuilder();
+        using var proc = Process.Start(psi)!;
+        proc.OutputDataReceived += (_, e) => { if (e.Data != null) lock (outSb) outSb.AppendLine(e.Data); };
+        proc.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (errSb) errSb.AppendLine(e.Data); };
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+        if (!proc.WaitForExit(120_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException("al-runner did not exit within 120s.");
+        }
+        // WaitForExit(int) returns as soon as the process exits and does NOT wait for the
+        // async BeginOutputReadLine/BeginErrorReadLine callbacks to drain — only the
+        // parameterless overload does. Without this the last stdout lines can still be in
+        // flight when we read outSb, and an Assert.Contains on a line the runner definitely
+        // printed fails intermittently, the more so the more loaded the machine is (#2496).
+        proc.WaitForExit();
+        return (proc.ExitCode, outSb.ToString(), errSb.ToString());
+    }
+
+    [Fact]
+    public void TimeZone_HostZones_AllFixtureTestsPass()
+    {
+        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-tzv-tests", "cache-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var (exit, stdout, stderr) = Run(cacheDir);
+
+            Assert.True(exit == 0,
+                $"expected a clean run (every fixture test must pass). exit={exit}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            // The table answers rows at all — this is the direct RED this fixes.
+            Assert.Contains("PASS  Codeunit60781.TimeZone_IsNotEmpty", stdout);
+            // "No." is a sequence over the host's list, so a provider that inserted rows
+            // without numbering them, or numbered from 0, fails here.
+            Assert.Contains("PASS  Codeunit60781.TimeZone_NumbersStartAtOneAndIncrementWithNoGaps", stdout);
+            // The one that rules out N blank rows, which would satisfy both assertions above.
+            Assert.Contains("PASS  Codeunit60781.TimeZone_EveryRowHasANonBlankId", stdout);
+            // Get and FindSet must agree, so the row Get returns is a real row and not a
+            // separately-built one.
+            Assert.Contains("PASS  Codeunit60781.TimeZone_GetOne_AgreesWithTheFirstRowOfFindSet", stdout);
+            // Negative: a number past the end still answers false. Passes against an EMPTY
+            // table too, which is exactly why it is not sufficient on its own.
+            Assert.Contains("PASS  Codeunit60781.TimeZone_GetOnANumberPastTheEnd_ReturnsFalse", stdout);
+            // Negative: filtering discriminates.
+            Assert.Contains("PASS  Codeunit60781.TimeZone_FilterOnNumber_DiscriminatesBetweenRows", stdout);
+            Assert.DoesNotContain("FAIL", stdout);
+        }
+        finally
+        {
+            try { Directory.Delete(cacheDir, recursive: true); } catch { /* best-effort cleanup */ }
+        }
+    }
+}

--- a/AlRunner/Patches/RecordPatches.TimeZoneVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.TimeZoneVirtualTable.cs
@@ -1,0 +1,146 @@
+// RecordPatches.TimeZoneVirtualTable — managed provider for the "Time Zone" (2000000164)
+// system virtual table.
+//
+// WHY THIS EXISTS (issue #2584)
+//   Time Zone is virtual on the service tier: its rows are computed on demand from the host's
+//   installed time zones. It routed to the same empty in-memory store as every other table
+//   here, so every read answered zero rows — Get() silently returned false and FindSet()
+//   raised "There is no Time Zone within the filter."
+//
+// WHAT REAL BC ANSWERS
+//   Microsoft.Dynamics.Nav.Runtime.TimeZoneDataProvider (Ncl.dll, BC 28.4.53241.53989)
+//   declares TableId => 2000000164, and its whole body is:
+//
+//       int timeZoneNo = 1;
+//       foreach (TimeZoneInfo systemTimeZone in TimeZoneInfo.GetSystemTimeZones())
+//       {
+//           buffer[0] = NavInteger.Create(timeZoneNo);
+//           buffer[1] = NavText.CreateTruncated(maxIdLength, systemTimeZone.Id);
+//           buffer[2] = NavText.CreateTruncated(maxDisplayNameLength, systemTimeZone.DisplayName);
+//           timeZoneNo++;
+//       }
+//
+//   Three columns, and the row set is whatever the HOST OPERATING SYSTEM reports, numbered
+//   1..N in enumeration order. That is the entire specification.
+//
+// ── THE DIVERGENCE THIS CREATES, AND WHY IT IS THE RIGHT ANSWER ──────────────────────────
+//   BC in the cloud runs on Windows, so GetSystemTimeZones() there returns Windows ids
+//   ("W. Europe Standard Time"). The runner runs on Linux, where the same call returns IANA
+//   ids ("Europe/Berlin"). "No." is a sequence number over that list, so the two hosts
+//   disagree about the ids AND about the numbering.
+//
+//   This provider enumerates the host, exactly as BC's own code does. The alternative — a
+//   hardcoded Windows id list, so the answers match a Windows-hosted tier — was considered
+//   and rejected: fabricating Windows time zone ids on a Linux host is a silent fake of the
+//   kind .claude/rules/loud-failures.md bars, it would be wrong in a way no test on this host
+//   could catch, and the list goes stale every time Microsoft revises it. Being faithful to
+//   BC's CODE is the honest option when BC's own answer is a property of the machine.
+//
+//   Consequence, recorded so a future reader hits a decision and not a mystery: on Linux the
+//   runner reports IANA ids where a Windows-hosted SaaS tier reports Windows ids. This is a
+//   deliberate, permanent divergence — see docs/limitations.md, "Time Zone ids follow the
+//   host". Nothing reads this table today (measured: no corpus test, no runner-extras test,
+//   and the two Microsoft bucket codeunits that grep-match are false positives —
+//   ERMUserPersonalization reads UserPersonalization."Time Zone", a field on a different
+//   table, and UTContactTable only carries [FEATURE] [Time Zone] tags), so nothing breaks
+//   now; the point of writing it down is the test somebody writes later.
+//
+// FIELD NAMES ARE MEASURED, NOT ASSUMED
+//   Resolved by compiling AL against real BC symbols and dumping the metatable through
+//   RecordRef (BC 28.1): field 3 = "No." (Integer), field 1 = "ID" (Text), field 2 =
+//   "Display Name" (Text). Matched here BY NAME off the live metatable, so a BC metadata
+//   change says so instead of writing a value into the wrong column.
+//
+// PRECOMPILED-DLL RESPECT
+//   Runtime-engine types only (NCLMetaTable, NCLMetaField, NavValue, ReadOnlyRecordBuffer,
+//   TempTableDataProvider), reached through the same helpers the AllObj / Date / Page
+//   Metadata providers resolve. No AL business-logic body is touched.
+
+using System.Runtime.CompilerServices;
+using AlRunner.Infrastructure;
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    internal const int TimeZoneVirtualTableId = 2000000164;
+
+    // One-shot per provider, unlike AllObj's per-id memo: the host's time zone list cannot
+    // change during a run, and "No." is a sequence over the whole list — topping up later
+    // would renumber rows AL had already read.
+    private static readonly ConditionalWeakTable<object, object> _tzPopulatedProviders = new();
+
+    private static bool IsTimeZoneVirtualTable(NCLMetaTable? table)
+        => table != null && table.TableId == TimeZoneVirtualTableId;
+
+    /// <summary>
+    /// Populate the in-memory store behind Time Zone (2000000164) with one row per time zone
+    /// the HOST reports, numbered 1..N in enumeration order — the same order and numbering
+    /// BC's own TimeZoneDataProvider produces from the same call.
+    /// </summary>
+    private static void PopulateTimeZoneVirtualTable(object dataAccess, NCLMetaTable metaTable)
+    {
+        EnsureAllObjReflection(metaTable);
+        EnsureDataAccessProviderReflection(dataAccess);
+
+        var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
+            ?? throw new RunnerOutOfScopeException(
+                "Time Zone (virtual table 2000000164)",
+                "time-zone-virtual-table — data access has no in-memory provider; see docs/scope.md");
+
+        if (_tzPopulatedProviders.TryGetValue(provider, out _)) return;
+
+        // Read once and materialise, so the numbering cannot shift if the host's list were
+        // enumerated twice. Failure here is loud: an empty Time Zone table is the bug being
+        // fixed, and answering with no rows would put it straight back.
+        IReadOnlyList<TimeZoneInfo> zones;
+        try
+        {
+            zones = TimeZoneInfo.GetSystemTimeZones().ToList();
+        }
+        catch (Exception ex)
+        {
+            throw new RunnerOutOfScopeException(
+                "Time Zone (virtual table 2000000164)",
+                "time-zone-virtual-table — the host reports no usable time zone database "
+                + $"({ex.GetType().Name}: {ex.Message}). BC's own TimeZoneDataProvider reads the "
+                + "same TimeZoneInfo.GetSystemTimeZones(), so there is no other source to answer "
+                + "from, and an empty table would be a wrong answer rather than a missing one. "
+                + "See docs/scope.md");
+        }
+
+        for (var i = 0; i < zones.Count; i++)
+        {
+            var number = i + 1;   // BC starts at 1, not 0
+            var zone = zones[i];
+            InsertVirtualRow(provider, metaTable,
+                new object[] { TimeZoneVirtualTableId, number, 0, 0 },
+                field => BuildTimeZoneValue(field, number, zone));
+        }
+
+        _tzPopulatedProviders.Add(provider, new object());
+    }
+
+    /// <summary>
+    /// One column of a Time Zone row, matched by the metatable's own FIELD NAME. Text columns
+    /// are truncated to the column's declared length through BC's own NavText.CreateTruncated,
+    /// exactly as TimeZoneDataProvider does — an IANA id is shorter than the column, but a
+    /// display name on some hosts is not.
+    /// </summary>
+    private static object? BuildTimeZoneValue(NCLMetaField field, int number, TimeZoneInfo zone)
+    {
+        object? Text(string s) => _aovNavTextCreateTruncated!.Invoke(
+            null, new object?[] { field.FieldDefinedLength, s ?? string.Empty });
+
+        return NormalizeObjectTypeName(field.FieldName ?? string.Empty) switch
+        {
+            // "No." normalizes with its trailing dot intact; "no" is accepted too so a BC
+            // version that drops the dot still matches rather than silently defaulting.
+            "no." or "no" => _aovNavIntegerCreate!.Invoke(null, new object?[] { number }),
+            "id" => Text(zone.Id),
+            "displayname" => Text(zone.DisplayName),
+            _ => _aovGetDefaultNavValue!.Invoke(null, new object?[] { field, false }),
+        };
+    }
+}

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -1730,6 +1730,24 @@ public static partial class RecordPatches
                 return pageMetaDa;
             }
 
+            // ── Time Zone (2000000164) ───────────────────────────────────────────────────
+            // Virtual on the service tier too (TimeZoneDataProvider enumerates the HOST's
+            // TimeZoneInfo.GetSystemTimeZones() and numbers them 1..N). An empty store made
+            // every read answer "no such time zone" silently. The runner enumerates the same
+            // host call BC does, which on Linux means IANA ids where a Windows-hosted tier
+            // reports Windows ids — a deliberate, permanent divergence recorded in
+            // docs/limitations.md. See RecordPatches.TimeZoneVirtualTable.cs (#2584).
+            if (IsTimeZoneVirtualTable(table))
+            {
+                if (!perTable.TryGetValue(tableId, out var timeZoneDa))
+                {
+                    var createdTimeZone = _mCreateTempDataAccess!.Invoke(self, new object[] { table })!;
+                    timeZoneDa = perTable.GetOrAdd(tableId, createdTimeZone);
+                }
+                PopulateTimeZoneVirtualTable(timeZoneDa, table);
+                return timeZoneDa;
+            }
+
             // ── CodeUnit Metadata (2000000137) ───────────────────────────────────────────
             // Virtual on the service tier too (CodeUnitDataProvider computes one row per
             // codeunit from NCLMetadata). An empty store makes every lookup answer "no such

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -374,6 +374,46 @@ the exact value will see different results.
 | `Commit()` | Commits current transaction | Establishes a rollback commit-point — see "Transaction semantics" above; not a no-op |
 | `FilterGroup(n)` | Scoped filter groups | Not tracked — `FilterGroup()` is a no-op; all filters apply to group 0 |
 
+### `Record "Time Zone"` — ids follow the HOST, so they are IANA ids on Linux
+
+<a id="time-zone-virtual-table"></a>
+
+The `Time Zone` system virtual table (2000000164) is computed on demand, and BC's own
+`TimeZoneDataProvider` computes it by enumerating the host's
+`TimeZoneInfo.GetSystemTimeZones()` and numbering the results 1..N. That is the whole of
+its implementation — the row set is a property of the machine, not of Business Central.
+
+The runner enumerates the same call. BC in the cloud runs on Windows, so a SaaS tier
+reports Windows ids (`W. Europe Standard Time`); the runner runs on Linux, where the same
+call reports IANA ids (`Europe/Berlin`). `"No."` is a sequence number over that list, so
+the two hosts disagree about the ids **and** about the numbering.
+
+| | Real BC (Windows-hosted) | al-runner (Linux) |
+|---|---|---|
+| `TimeZone.ID` | `W. Europe Standard Time` | `Europe/Berlin` |
+| `TimeZone."No."` | position in the Windows list | position in the IANA list |
+| `TimeZone."Display Name"` | Windows display name | the host's display name |
+
+**This is deliberate and permanent.** The alternative — shipping a hardcoded Windows id
+list so the answers match a Windows tier — was considered and rejected: fabricating
+Windows time zone ids on a Linux host is a silent fake (see
+`.claude/rules/loud-failures.md`), it is wrong in a way no test running on this host could
+catch, and the list goes stale every time Microsoft revises it. When BC's own answer is a
+property of the machine, being faithful to BC's *code* is the honest option.
+
+What this means for a test: assert the **shape** — that `FindSet()` succeeds, that `"No."`
+starts at 1 and increments with no gaps, that every row has a non-blank `ID`, and that
+`Get(1)` agrees with the first row of `FindSet()`. All of that holds on any host. A test
+that asserts a specific zone id is asserting a property of the machine it happens to run
+on, and will not hold across hosts in either direction.
+
+Nothing in the corpus or in `tests/runner-extras/` reads this table today, which is why
+there is no `expect-divergence` entry for it in `tests/expectations/`: that mode declares
+a corpus test that **fails** on the runner, and no such test exists yet. This section is
+the record until one does.
+
+---
+
 ### `Record Date` — an open-ended `Period Start` filter is answered from a materialised window
 
 <a id="date-virtual-table"></a>


### PR DESCRIPTION
## What was wrong

`Time Zone` (2000000164) had no managed provider, so `RecordPatches.GetDataAccessForTableCore` fell through to the plain in-memory temp store and every read answered zero rows — `Get()` silently returned false, `FindSet()` raised.

## What this does

BC's own `TimeZoneDataProvider` is three lines of substance: enumerate `TimeZoneInfo.GetSystemTimeZones()`, number the results 1..N, fill `ID` and `Display Name`. The row set is a property of the **host machine**, not of Business Central. This provider makes the same call.

Field names were measured, not assumed — compiled against real BC symbols and dumped through `RecordRef` on BC 28.1: field 3 `"No."` (Integer), field 1 `ID` (Text), field 2 `"Display Name"` (Text). Matched by name off the live metatable, so a BC metadata change says so instead of writing a value into the wrong column.

## The divergence, and why this is the right answer

BC in the cloud runs on Windows, so a SaaS tier reports Windows ids (`W. Europe Standard Time`). The runner runs on Linux, where the same call reports IANA ids (`Europe/Berlin`), and `"No."` is a sequence over whichever list the host gives. The two hosts disagree about the ids and about the numbering.

The alternative — a hardcoded Windows id list so the answers match a Windows tier — was considered and rejected. Fabricating Windows time zone ids on a Linux host is a silent fake (`.claude/rules/loud-failures.md`), it is wrong in a way no test running on this host could catch, and the list goes stale every time Microsoft revises it. When BC's own answer is a property of the machine, being faithful to BC's *code* is the honest option.

`docs/limitations.md` gets a section under "Behavioural differences" with a side-by-side table and a statement of what a test may therefore assert.

## One deviation from the brief, and why

**No `expect-divergence` entry is included.** That mode declares a corpus test which *fails* on the runner (`docs/expectations.md`: "Failed with no OOS signal → `expect-divergence` → pass-divergence"), and manifest drift is loud in both directions — a test that passes despite an entry fails the run with "remove the entry".

Nothing reads this table today, so there is no failing test to attach an entry to. The corpus test added alongside asserts shape only and passes on any host by construction, so an entry naming it would trip the drift check immediately. `docs/limitations.md` is the record until a diverging test exists; the provider header and the dispatch comment both point at it. Say the word if you would rather have a placeholder entry and I will add one, but as the manifest is specified today it would be red.

## Proof

RED → GREEN, measured by removing only the dispatch block:

| | Result |
|---|---|
| Without the dispatch block | 1 passed, 5 failed |
| This PR | 6 passed |

The one that passes in both directions is `Get` on a number past the end — an empty table also answers false, which is exactly why it is not sufficient on its own. The fixture is shaped so a provider inserting N *blank* rows would also fail: the count and the 1..N numbering would pass, and the non-blank-`ID` assertion would not.

**The behavioral test is upstream**: StefanMaron/BusinessCentral.AL.Language.Tests#131 (`Test Time Zone Virtual Table`, codeunit 60960), asserting the same shape for the same reason — no host-specific id can be asserted in a corpus that runs on more than one host. This PR does not bump the submodule pin or touch the count baseline.

## Credit

The gap was found by Mikkel Mansa Vilhelmsen (`vhn`), whose fork implements the hardcoded-Windows-list approach (commit `07ca7aec`); his work is what surfaced the ordering problem. No code was copied, and the approach here is deliberately the opposite one.

Closes #2584

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
