### PR TITLE
perf(packages): answer both .app metadata questions from one read, and cache both

### DIFF
--- a/AlRunner.Tests/AppLoaderPackageMetaTests.cs
+++ b/AlRunner.Tests/AppLoaderPackageMetaTests.cs
@@ -1,0 +1,310 @@
+// AppLoaderPackageMetaTests — AppLoader.ReadPackageMeta answers both metadata questions about a
+// .app from one read, and records the answer in the same on-disk index ReadManifest uses
+// (issue #2607).
+//
+// Two things have to be true and they pull in opposite directions.
+//
+// Equivalence: the pair it returns must be exactly what a separate ReadManifest plus
+// HasSymbolReference used to return, for every package shape — flat, R2R-nested, and the awkward
+// one where the outer archive carries NavxManifest.xml while only the NESTED archive carries
+// SymbolReference.json. Getting that last one wrong reports false, false drops the package from
+// the compile's scan set, and the resulting AL1023 is attributed to the whole compilation rather
+// than to the package.
+//
+// Compatibility: an index entry written before the flag existed has no flag, and "no flag" must
+// mean "go and look", never false — otherwise the first run after an upgrade drops packages on
+// exactly the machines that have a warm cache.
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(CacheRootsSerialCollection.Name)]
+public sealed class AppLoaderPackageMetaTests
+{
+    private static string NewTempDir(string suffix)
+    {
+        var dir = Path.Combine(Path.GetTempPath(),
+            "app-loader-package-meta-tests-" + suffix + "-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static string ManifestXml(Guid appId, string name) => $"""
+        <?xml version="1.0" encoding="utf-8"?>
+        <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+          <App Id="{appId}" Name="{name}" Publisher="Pub" Version="1.0.0.0"
+               Application="27.0.0.0" Platform="27.0.0.0"/>
+          <Dependencies/>
+        </Package>
+        """;
+
+    /// <summary>NAVX wrapper: magic "NAVX" + little-endian uint32 ZIP offset (8) + ZIP bytes.</summary>
+    private static byte[] Navx(byte[] zipBytes)
+    {
+        var result = new byte[8 + zipBytes.Length];
+        result[0] = (byte)'N'; result[1] = (byte)'A'; result[2] = (byte)'V'; result[3] = (byte)'X';
+        BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
+        zipBytes.CopyTo(result, 8);
+        return result;
+    }
+
+    private static byte[] ZipWith(params (string Name, byte[] Content)[] entries)
+    {
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+            foreach (var (name, content) in entries)
+            {
+                var e = zip.CreateEntry(name);
+                using var s = e.Open();
+                s.Write(content);
+            }
+        return ms.ToArray();
+    }
+
+    private static byte[] Utf8(string s) => Encoding.UTF8.GetBytes(s);
+
+    /// <summary>A flat package: manifest at the top level, symbol reference present or not.</summary>
+    private static string WriteFlatApp(string dir, string fileName, Guid appId, string name, bool withSymbolReference)
+    {
+        var entries = new List<(string, byte[])> { ("NavxManifest.xml", Utf8(ManifestXml(appId, name))) };
+        if (withSymbolReference) entries.Add(("SymbolReference.json", Utf8("{}")));
+        var path = Path.Combine(dir, fileName);
+        File.WriteAllBytes(path, Navx(ZipWith(entries.ToArray())));
+        return path;
+    }
+
+    /// <summary>
+    /// An R2R-shaped package: an outer archive holding a nested <c>.app</c>, plus whatever the
+    /// caller wants at the outer level. Microsoft ships this shape, and it is the reason the two
+    /// questions used to cost two reads of the same package.
+    /// </summary>
+    private static string WriteNestedApp(
+        string dir, string fileName, Guid appId, string name,
+        bool outerManifest, bool outerSymbolReference, bool innerSymbolReference)
+    {
+        var innerEntries = new List<(string, byte[])> { ("NavxManifest.xml", Utf8(ManifestXml(appId, name))) };
+        if (innerSymbolReference) innerEntries.Add(("SymbolReference.json", Utf8("{}")));
+        var inner = Navx(ZipWith(innerEntries.ToArray()));
+
+        var outerEntries = new List<(string, byte[])> { ("Inner.app", inner) };
+        if (outerManifest) outerEntries.Add(("NavxManifest.xml", Utf8(ManifestXml(appId, name))));
+        if (outerSymbolReference) outerEntries.Add(("SymbolReference.json", Utf8("{}")));
+
+        var path = Path.Combine(dir, fileName);
+        File.WriteAllBytes(path, Navx(ZipWith(outerEntries.ToArray())));
+        return path;
+    }
+
+    // ---- equivalence, shape by shape --------------------------------------------
+
+    public static TheoryData<string, bool> PackageShapes => new()
+    {
+        { "flat-with", true },
+        { "flat-without", false },
+        { "nested-inner-symref", true },
+        { "nested-outer-manifest-inner-symref", true },
+        { "nested-no-symref", false },
+    };
+
+    private static string WriteShape(string dir, string shape, Guid appId) => shape switch
+    {
+        "flat-with" => WriteFlatApp(dir, "a.app", appId, "Flat With", withSymbolReference: true),
+        "flat-without" => WriteFlatApp(dir, "a.app", appId, "Flat Without", withSymbolReference: false),
+        "nested-inner-symref" => WriteNestedApp(dir, "a.app", appId, "Nested",
+            outerManifest: false, outerSymbolReference: false, innerSymbolReference: true),
+        // The dangerous one: everything the outer archive can answer says "no symbol reference",
+        // and the truth is one level down.
+        "nested-outer-manifest-inner-symref" => WriteNestedApp(dir, "a.app", appId, "Nested Outer Manifest",
+            outerManifest: true, outerSymbolReference: false, innerSymbolReference: true),
+        "nested-no-symref" => WriteNestedApp(dir, "a.app", appId, "Nested No Symref",
+            outerManifest: false, outerSymbolReference: false, innerSymbolReference: false),
+        _ => throw new ArgumentOutOfRangeException(nameof(shape), shape, null),
+    };
+
+    [Theory]
+    [MemberData(nameof(PackageShapes))]
+    public void ReadPackageMeta_AnswersBothQuestions_ForEveryPackageShape(string shape, bool expectedSymbolReference)
+    {
+        var cacheRoot = NewTempDir("cache");
+        var srcDir = NewTempDir("src");
+        CacheRoots.SetOverride(cacheRoot);
+        try
+        {
+            AppLoader.ResetManifestMemoForTests();
+            var appId = Guid.NewGuid();
+            var appPath = WriteShape(srcDir, shape, appId);
+
+            var (manifest, hasSymbolReference) = AppLoader.ReadPackageMeta(appPath);
+
+            Assert.NotNull(manifest);
+            Assert.Equal(appId, manifest!.AppId);
+            Assert.Equal("Pub", manifest.Publisher);
+            Assert.Equal(new Version(1, 0, 0, 0), manifest.Version);
+            Assert.Equal(expectedSymbolReference, hasSymbolReference);
+
+            // And the single-question entry points, which now route through the same read, agree.
+            AppLoader.ResetManifestMemoForTests();
+            Assert.Equal(expectedSymbolReference, AppLoader.HasSymbolReference(appPath));
+            AppLoader.ResetManifestMemoForTests();
+            Assert.Equal(appId, AppLoader.ReadManifest(appPath)!.AppId);
+        }
+        finally
+        {
+            CacheRoots.ResetForTests();
+            try { Directory.Delete(cacheRoot, true); Directory.Delete(srcDir, true); } catch { }
+        }
+    }
+
+    /// <summary>A path that does not exist answers "no manifest, no symbol reference" rather
+    /// than throwing — the contract every caller of the old pair relied on.</summary>
+    [Fact]
+    public void ReadPackageMeta_MissingFile_AnswersNullAndFalse()
+    {
+        var srcDir = NewTempDir("src");
+        try
+        {
+            var (manifest, hasSymbolReference) =
+                AppLoader.ReadPackageMeta(Path.Combine(srcDir, "does-not-exist.app"));
+
+            Assert.Null(manifest);
+            Assert.False(hasSymbolReference);
+        }
+        finally { try { Directory.Delete(srcDir, true); } catch { } }
+    }
+
+    /// <summary>A file that is not a NAVX package at all answers the same way.</summary>
+    [Fact]
+    public void ReadPackageMeta_GarbageFile_AnswersNullAndFalse()
+    {
+        var srcDir = NewTempDir("src");
+        try
+        {
+            var path = Path.Combine(srcDir, "garbage.app");
+            File.WriteAllBytes(path, Encoding.UTF8.GetBytes("this is not a package"));
+
+            var (manifest, hasSymbolReference) = AppLoader.ReadPackageMeta(path);
+
+            Assert.Null(manifest);
+            Assert.False(hasSymbolReference);
+        }
+        finally { try { Directory.Delete(srcDir, true); } catch { } }
+    }
+
+    // ---- the cache the change exists for ----------------------------------------
+
+    /// <summary>
+    /// The point of the change: the second PROCESS to ask does not open the package. Simulated by
+    /// clearing only the in-process memo, so the answer can only come from the on-disk index —
+    /// and proven with the parse counter, because an implementation that reparses to the same
+    /// answer is correct and is not the fix.
+    /// </summary>
+    [Fact]
+    public void ReadPackageMeta_SecondProcess_IsServedFromTheIndexWithoutReopeningThePackage()
+    {
+        var cacheRoot = NewTempDir("cache");
+        var srcDir = NewTempDir("src");
+        CacheRoots.SetOverride(cacheRoot);
+        try
+        {
+            AppLoader.ResetManifestMemoForTests();
+            var appId = Guid.NewGuid();
+            var appPath = WriteFlatApp(srcDir, "a.app", appId, "Cached", withSymbolReference: true);
+
+            var cold = AppLoader.ReadPackageMeta(appPath);
+            Assert.Equal(1, AppLoader.ManifestParseInvocationCountForTests(appPath));
+
+            AppLoader.ResetManifestMemoForTests();
+            var fromIndex = AppLoader.ReadPackageMeta(appPath);
+
+            Assert.Equal(1, AppLoader.ManifestParseInvocationCountForTests(appPath));
+            Assert.Equal(cold.HasSymbolReference, fromIndex.HasSymbolReference);
+            Assert.True(fromIndex.HasSymbolReference);
+            Assert.Equal(appId, fromIndex.Manifest!.AppId);
+        }
+        finally
+        {
+            CacheRoots.ResetForTests();
+            try { Directory.Delete(cacheRoot, true); Directory.Delete(srcDir, true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// The compatibility case. A machine upgrading to this build has an index full of entries
+    /// written by ReadManifest alone, which record no flag. Absent must mean "go and look": read
+    /// as false, every such package would be dropped as unserveable and the compile would fail
+    /// with AL1023 for reasons entirely outside the AL being compiled.
+    /// </summary>
+    [Fact]
+    public void ReadPackageMeta_IndexEntryWithoutTheFlag_IsRecomputedRatherThanReadAsFalse()
+    {
+        var cacheRoot = NewTempDir("cache");
+        var srcDir = NewTempDir("src");
+        CacheRoots.SetOverride(cacheRoot);
+        try
+        {
+            AppLoader.ResetManifestMemoForTests();
+            var appId = Guid.NewGuid();
+            var appPath = WriteFlatApp(srcDir, "a.app", appId, "Legacy Entry", withSymbolReference: true);
+
+            // ReadManifest writes an entry carrying the manifest and no flag — exactly the shape
+            // every entry on disk has today.
+            Assert.NotNull(AppLoader.ReadManifest(appPath));
+            AppLoader.ResetManifestMemoForTests();
+
+            var (manifest, hasSymbolReference) = AppLoader.ReadPackageMeta(appPath);
+
+            Assert.True(hasSymbolReference,
+                "a pre-existing index entry with no recorded flag must be recomputed, not answered false");
+            Assert.Equal(appId, manifest!.AppId);
+
+            // And the entry is upgraded, so only that one recomputation is paid.
+            var parsesSoFar = AppLoader.ManifestParseInvocationCountForTests(appPath);
+            AppLoader.ResetManifestMemoForTests();
+            Assert.True(AppLoader.ReadPackageMeta(appPath).HasSymbolReference);
+            Assert.Equal(parsesSoFar, AppLoader.ManifestParseInvocationCountForTests(appPath));
+        }
+        finally
+        {
+            CacheRoots.ResetForTests();
+            try { Directory.Delete(cacheRoot, true); Directory.Delete(srcDir, true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// The other direction of the same key: a package rewritten in place — a `--bc-version`
+    /// switch, a re-downloaded artifact, InProcessAppPackager rebuilding a synthetic .app — must
+    /// be re-read, not served from the entry describing the bytes that used to be there.
+    /// </summary>
+    [Fact]
+    public void ReadPackageMeta_RewrittenPackage_IsReReadRatherThanServedStale()
+    {
+        var cacheRoot = NewTempDir("cache");
+        var srcDir = NewTempDir("src");
+        CacheRoots.SetOverride(cacheRoot);
+        try
+        {
+            AppLoader.ResetManifestMemoForTests();
+            var firstId = Guid.NewGuid();
+            var appPath = WriteFlatApp(srcDir, "a.app", firstId, "Before", withSymbolReference: false);
+            Assert.False(AppLoader.ReadPackageMeta(appPath).HasSymbolReference);
+
+            var secondId = Guid.NewGuid();
+            WriteFlatApp(srcDir, "a.app", secondId, "After", withSymbolReference: true);
+            File.SetLastWriteTimeUtc(appPath, DateTime.UtcNow.AddSeconds(5));
+            AppLoader.ResetManifestMemoForTests();
+
+            var (manifest, hasSymbolReference) = AppLoader.ReadPackageMeta(appPath);
+
+            Assert.True(hasSymbolReference);
+            Assert.Equal(secondId, manifest!.AppId);
+        }
+        finally
+        {
+            CacheRoots.ResetForTests();
+            try { Directory.Delete(cacheRoot, true); Directory.Delete(srcDir, true); } catch { }
+        }
+    }
+}

--- a/AlRunner/AppLoader.cs
+++ b/AlRunner/AppLoader.cs
@@ -52,7 +52,11 @@ public static class AppLoader
     private static readonly ConcurrentDictionary<string, AppManifest?> _manifestMemo = new(StringComparer.Ordinal);
 
     /// <summary>Test-only: clears the in-process memo so a test can simulate a fresh process.</summary>
-    internal static void ResetManifestMemoForTests() => _manifestMemo.Clear();
+    internal static void ResetManifestMemoForTests()
+    {
+        _manifestMemo.Clear();
+        _symbolReferenceMemo.Clear();
+    }
 
     // Test-only: counts genuine ReadManifestUncached invocations (i.e. BOTH the memo AND
     // the disk index missed) per full .app path — mirrors BcAppSymbolCache
@@ -155,6 +159,11 @@ public static class AppLoader
     }
 
     private static AppManifest? TryReadManifestIndex(string memoKey)
+        => TryReadIndexPayload(memoKey) is { } hit ? hit.Manifest : null;
+
+    /// <summary>The whole index entry, so a caller that needs the symbol-reference flag can see
+    /// whether it was recorded at all rather than inferring false from its absence.</summary>
+    private static (AppManifest Manifest, bool? HasSymbolReference)? TryReadIndexPayload(string memoKey)
     {
         var path = ManifestIndexPath(memoKey);
         if (!File.Exists(path)) return null;
@@ -163,8 +172,11 @@ public static class AppLoader
             var payload = JsonSerializer.Deserialize<ManifestCachePayload>(File.ReadAllText(path));
             var manifest = payload == null ? null : FromPayload(payload);
             if (manifest == null)
+            {
                 PerfTrace.Log($"app-manifests index entry unusable {Path.GetFileName(path)}: payload malformed — reparsing");
-            return manifest;
+                return null;
+            }
+            return (manifest, payload!.HasSymbolReference);
         }
         catch (Exception ex)
         {
@@ -175,13 +187,13 @@ public static class AppLoader
         }
     }
 
-    private static void TryWriteManifestIndex(string memoKey, AppManifest manifest)
+    private static void TryWriteManifestIndex(string memoKey, AppManifest manifest, bool? hasSymbolReference = null)
     {
         try
         {
             var path = ManifestIndexPath(memoKey);
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
-            var payload = ToPayload(manifest);
+            var payload = ToPayload(manifest, hasSymbolReference);
             // Atomic (temp file + rename) — 4 CI processes can race a write to the SAME
             // key for the SAME shared package cache; a torn write must never be visible.
             AlCacheWriter.AtomicPublish(path, tmp => File.WriteAllText(tmp, JsonSerializer.Serialize(payload)));
@@ -195,19 +207,25 @@ public static class AppLoader
     // JSON-serializable mirror of AppManifest/DependencyRef — Version/Guid round-trip as
     // strings (System.Text.Json has no default converter for System.Version, and keeping
     // Guid as text sidesteps ever depending on that assumption changing).
+    // HasSymbolReference is NULLABLE on purpose. An index entry written before the flag
+    // existed deserializes it as null, and null must mean "not recorded, go and look" — never
+    // false. False is the answer that drops a package from the scan set as unserveable and
+    // produces AL1023 against the whole compilation, so reading an absent field as false would
+    // break exactly the machines carrying a warm cache from an older build.
     private sealed record ManifestCachePayload(
         string Publisher, string Name, string Version, string AppId,
         List<DependencyCachePayload> Dependencies,
-        string? Application, string? Platform);
+        string? Application, string? Platform,
+        bool? HasSymbolReference = null);
 
     private sealed record DependencyCachePayload(
         string AppId, string Name, string Publisher, string Version, bool Optional);
 
-    private static ManifestCachePayload ToPayload(AppManifest m) => new(
+    private static ManifestCachePayload ToPayload(AppManifest m, bool? hasSymbolReference = null) => new(
         m.Publisher, m.Name, m.Version.ToString(), m.AppId.ToString("D"),
         m.Dependencies.Select(d => new DependencyCachePayload(
             d.AppId.ToString("D"), d.Name, d.Publisher, d.Version.ToString(), d.Optional)).ToList(),
-        m.Application?.ToString(), m.Platform?.ToString());
+        m.Application?.ToString(), m.Platform?.ToString(), hasSymbolReference);
 
     private static AppManifest? FromPayload(ManifestCachePayload p)
     {
@@ -233,25 +251,159 @@ public static class AppLoader
     /// source-only .app emitted by InProcessAppPackager returns false here.
     /// Returns false on any read/format error.
     /// </summary>
-    public static bool HasSymbolReference(string appPath)
+    public static bool HasSymbolReference(string appPath) => ReadPackageMeta(appPath).HasSymbolReference;
+
+    // Process-wide memo for the symbol-reference flag, keyed exactly like _manifestMemo. Separate
+    // from it rather than widening its value type, so a ReadManifest-only caller keeps its
+    // current shape and cannot be made to pay for a question it did not ask.
+    private static readonly ConcurrentDictionary<string, bool> _symbolReferenceMemo = new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Both metadata questions about one <c>.app</c> — its manifest and whether it carries a
+    /// <c>SymbolReference.json</c> — answered from a single open, and cached together in the
+    /// process memo and the on-disk index.
+    ///
+    /// <para>They look independent and are not: both are answered by the package's central
+    /// directory, and for the R2R packages Microsoft ships, by the same buffered nested
+    /// <c>.app</c>. Asking them separately opened every package twice.</para>
+    ///
+    /// <para>Measured on the al-language corpus with two package caches (459 <c>.app</c> files,
+    /// 117 MB, Microsoft_Base Application 98 MB of it), first uncached
+    /// <c>DeduplicateAppPackageDirs</c> scan of a process: 835 ms, of which
+    /// <see cref="ReadManifest"/> was 0 ms — its on-disk index already answers — and the
+    /// symbol-reference question was 766 ms, because it read the whole package into a
+    /// <c>byte[]</c> to check for one entry name. Streaming it alone took the scan to ~660 ms;
+    /// recording the answer in the index alongside the manifest is what takes it to ~2 ms on
+    /// every process after the first. See issue #2607.</para>
+    /// </summary>
+    public static (AppManifest? Manifest, bool HasSymbolReference) ReadPackageMeta(string appPath)
+    {
+        string fullPath;
+        long length;
+        long mtimeTicks;
+        try
+        {
+            fullPath = Path.GetFullPath(appPath);
+            var fi = new FileInfo(fullPath);
+            if (!fi.Exists) return (null, false);
+            length = fi.Length;
+            mtimeTicks = fi.LastWriteTimeUtc.Ticks;
+        }
+        catch
+        {
+            // Cannot even stat the path — take the uncached read, matching ReadManifest's own
+            // fallback contract (any failure yields a null manifest, never a throw).
+            return ReadPackageMetaUncached(appPath);
+        }
+
+        var memoKey = $"{fullPath}|{length}|{mtimeTicks}";
+        if (_symbolReferenceMemo.TryGetValue(memoKey, out var memoFlag)
+            && _manifestMemo.TryGetValue(memoKey, out var memoManifest))
+            return (memoManifest, memoFlag);
+
+        // Only a FULL index entry can serve this: an entry written before the flag existed has
+        // HasSymbolReference null, and null means "go and look", never false.
+        if (TryReadIndexPayload(memoKey) is { HasSymbolReference: { } storedFlag } hit)
+        {
+            PerfTrace.Log($"app-manifests HIT+symref {Path.GetFileName(fullPath)}");
+            _manifestMemo[memoKey] = hit.Manifest;
+            _symbolReferenceMemo[memoKey] = storedFlag;
+            return (hit.Manifest, storedFlag);
+        }
+
+        _manifestParseInvocationCountByPath.AddOrUpdate(fullPath, 1, static (_, c) => c + 1);
+        var read = ReadPackageMetaUncached(fullPath);
+        PerfTrace.Log($"app-manifests MISS {Path.GetFileName(fullPath)}");
+        _manifestMemo[memoKey] = read.Manifest;
+        _symbolReferenceMemo[memoKey] = read.HasSymbolReference;
+        if (read.Manifest != null)
+            TryWriteManifestIndex(memoKey, read.Manifest, read.HasSymbolReference);
+        return read;
+    }
+
+    /// <summary>Both answers off one <see cref="OpenAppZip"/>, with no caching.</summary>
+    private static (AppManifest? Manifest, bool HasSymbolReference) ReadPackageMetaUncached(string appPath)
     {
         try
         {
-            var bytes = File.ReadAllBytes(appPath);
-            using var zip = OpenZipFromNavx(bytes);
-            if (zip.Entries.Any(e => e.FullName.Equals("SymbolReference.json", StringComparison.OrdinalIgnoreCase)))
-                return true;
-            // R2R nested case: the inner .app carries the SymbolReference.json.
-            var nested = zip.Entries.FirstOrDefault(e =>
-                e.FullName.EndsWith(".app", StringComparison.OrdinalIgnoreCase) && !e.FullName.Contains('/'));
-            if (nested == null) return false;
-            using var ns = nested.Open();
-            using var nms = new MemoryStream();
-            ns.CopyTo(nms);
-            using var innerZip = OpenZipFromNavx(nms.ToArray());
-            return innerZip.Entries.Any(e => e.FullName.Equals("SymbolReference.json", StringComparison.OrdinalIgnoreCase));
+            using var zip = OpenAppZip(appPath);
+            return ReadPackageMetaFromZip(zip);
         }
-        catch { return false; }
+        catch { return (null, false); }
+    }
+
+    /// <summary>
+    /// Manifest and symbol-reference flag off one archive, buffering an R2R package's nested
+    /// <c>.app</c> at most once.
+    ///
+    /// <para>Calling <see cref="ReadManifestFromZip"/> and <see cref="HasSymbolReferenceInZip"/>
+    /// in turn is correct but costs twice: each recurses into the nested <c>.app</c> on its own,
+    /// and a zip ENTRY's stream is forward-only, so each has to copy the inner package out to
+    /// something seekable. Measured, that made the whole package scan SLOWER than asking the two
+    /// questions separately had been.</para>
+    ///
+    /// <para>The two early exits below are the ones that preserve the previous answers exactly.
+    /// A manifest found at the outer level does NOT license skipping the nested archive, because
+    /// the symbol-reference question has its own answer down there; skipping it would report
+    /// false for a package that carries one, and false is what drops a package from the scan set
+    /// and produces AL1023 against the whole compilation.</para>
+    /// </summary>
+    private static (AppManifest? Manifest, bool HasSymbolReference) ReadPackageMetaFromZip(ZipArchive zip)
+    {
+        var symbolReferenceHere = zip.Entries.Any(e =>
+            e.FullName.Equals("SymbolReference.json", StringComparison.OrdinalIgnoreCase));
+        var manifestEntry = zip.Entries.FirstOrDefault(e =>
+            e.FullName.Equals("NavxManifest.xml", StringComparison.OrdinalIgnoreCase));
+
+        AppManifest? ManifestHere()
+        {
+            if (manifestEntry == null) return null;
+            using var s = manifestEntry.Open();
+            return ParseManifestXml(s);
+        }
+
+        // Everything answered at this level — no reason to touch a nested package.
+        if (symbolReferenceHere && manifestEntry != null) return (ManifestHere(), true);
+
+        var nested = zip.Entries.FirstOrDefault(e =>
+            e.FullName.EndsWith(".app", StringComparison.OrdinalIgnoreCase) && !e.FullName.Contains('/'));
+        if (nested == null) return (ManifestHere(), symbolReferenceHere);
+
+        using var nestedStream = nested.Open();
+        using var nms = new MemoryStream();
+        nestedStream.CopyTo(nms);
+        using var innerZip = OpenZipFromNavx(nms.ToArray());
+        var inner = ReadPackageMetaFromZip(innerZip);
+
+        // An outer manifest wins over the nested one, matching ReadManifestFromZip, which only
+        // recurses when the outer archive has no NavxManifest.xml.
+        return (manifestEntry != null ? ManifestHere() : inner.Manifest,
+                symbolReferenceHere || inner.HasSymbolReference);
+    }
+
+    /// <summary>
+    /// One .app's central directory answered for a <c>SymbolReference.json</c> part, following
+    /// exactly one level of R2R nesting — the same shape <see cref="ReadManifestFromZip"/> uses,
+    /// and no deeper, because that is the nesting Microsoft's R2R packaging produces.
+    ///
+    /// <para>The nested .app's bytes are still buffered: a zip ENTRY's stream is
+    /// forward-only, and ZipArchive needs its central directory readable from the end of a
+    /// seekable stream. That copy is bounded by the inner package, which carries no
+    /// <c>publishedartifacts/*.dll</c> — those live only in the outer zip this path no longer
+    /// reads whole.</para>
+    /// </summary>
+    private static bool HasSymbolReferenceInZip(ZipArchive zip)
+    {
+        if (zip.Entries.Any(e => e.FullName.Equals("SymbolReference.json", StringComparison.OrdinalIgnoreCase)))
+            return true;
+        var nested = zip.Entries.FirstOrDefault(e =>
+            e.FullName.EndsWith(".app", StringComparison.OrdinalIgnoreCase) && !e.FullName.Contains('/'));
+        if (nested == null) return false;
+        using var ns = nested.Open();
+        using var nms = new MemoryStream();
+        ns.CopyTo(nms);
+        using var innerZip = OpenZipFromNavx(nms.ToArray());
+        return innerZip.Entries.Any(e => e.FullName.Equals("SymbolReference.json", StringComparison.OrdinalIgnoreCase));
     }
 
     /// <summary>

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -774,13 +774,15 @@ public sealed partial class BcCompiler
         return null;
     }
 
-    // Per-file cache of the two zip reads DeduplicateAppPackageDirs performs on every .app
-    // it scans (ReadManifest + HasSymbolReference). Both re-read the WHOLE package from
-    // disk and unzip it — for a 113-package, 138 MB platform-apps dir that is ~1–2.5 s per
-    // scan, and the scan runs on EVERY GetSharedReferences call (it has to: its output is
-    // what the loader signature is computed from). Keyed by path + length + last-write
-    // ticks, so a package rewritten in place (InProcessAppPackager's synthetic .apps, a
-    // --watch rebuild) invalidates its own entry.
+    // Per-file cache of the package read DeduplicateAppPackageDirs performs on every .app it
+    // scans, and the scan runs on EVERY GetSharedReferences call (it has to: its output is what
+    // the loader signature is computed from). Keyed by path + length + last-write ticks, so a
+    // package rewritten in place (InProcessAppPackager's synthetic .apps, a --watch rebuild)
+    // invalidates its own entry.
+    //
+    // AppLoader.ReadPackageMeta keeps the same key across PROCESSES in its on-disk index and
+    // answers both questions off one open; this is the in-process layer in front of it, and the
+    // one ResetSharedReferencesForTests clears so a test can force the scan to re-read.
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<
         string, (long Length, long Ticks, AppManifest? Manifest, bool HasSymbolReference)> _appMetaCache = new();
 
@@ -789,13 +791,13 @@ public sealed partial class BcCompiler
         var path = fi.FullName;
         long len, ticks;
         try { len = fi.Length; ticks = fi.LastWriteTimeUtc.Ticks; }
-        catch { return (AppLoader.ReadManifest(path), AppLoader.HasSymbolReference(path)); }
+        catch { return AppLoader.ReadPackageMeta(path); }
 
         if (_appMetaCache.TryGetValue(path, out var hit) && hit.Length == len && hit.Ticks == ticks)
             return (hit.Manifest, hit.HasSymbolReference);
 
-        var meta = (AppLoader.ReadManifest(path), AppLoader.HasSymbolReference(path));
-        _appMetaCache[path] = (len, ticks, meta.Item1, meta.Item2);
+        var meta = AppLoader.ReadPackageMeta(path);
+        _appMetaCache[path] = (len, ticks, meta.Manifest, meta.HasSymbolReference);
         return meta;
     }
 
@@ -912,6 +914,11 @@ public sealed partial class BcCompiler
         // thing the reader needs told. See DescribeStagedSearchSet.
         var unstaged = new List<UnstagedPackage>();
         var changed = false;
+        // Same BCCOMPILER_TIMING=1 switch and [emit-timing] channel Emit() uses. This scan runs
+        // on every GetSharedReferences call and its cost is invisible from the outside, so it
+        // gets a mark of its own.
+        var scanClock = System.Diagnostics.Stopwatch.StartNew();
+        var scanned = 0;
         foreach (var dir in packageDirs)
         {
             // This one already materialised INSIDE the try (the .ToList()), so unlike its five
@@ -923,6 +930,7 @@ public sealed partial class BcCompiler
             foreach (var appInfo in apps)
             {
                 var app = appInfo.FullName;
+                scanned++;
                 var (m, hasSymbolReference) = ReadAppMeta(appInfo);
                 if (m == null) continue;
                 if (excludeAppId != null && m.AppId == excludeAppId.Value) { changed = true; continue; }
@@ -970,6 +978,9 @@ public sealed partial class BcCompiler
                 inventory.Add(new PackageScanEntry(full, m.AppId, m.Publisher, m.Name, m.Version));
             }
         }
+        if (Environment.GetEnvironmentVariable("BCCOMPILER_TIMING") == "1")
+            Console.Error.WriteLine(
+                $"[emit-timing] package scan: {scanned} apps: {scanClock.ElapsedMilliseconds}ms");
         if (!changed) return packageDirs; // common case — leave the hot path untouched
 
         // Build (or reuse) a staging dir keyed by the exact picked-app set so concurrent /


### PR DESCRIPTION
`DeduplicateAppPackageDirs` runs on every `GetSharedReferences` call and asks two questions about every `.app`: `ReadManifest` and `HasSymbolReference`. The first is cached in a process memo and an on-disk index. The second was cached in neither, and answered by `File.ReadAllBytes(appPath)` plus an unzip, to look for one entry name — 98 MB of I/O and allocation for `Microsoft_Base Application`, on every invocation.

Found and originally measured by Mikkel Mansa Vilhelmsen (@vhn) on a fork.

## Measurement

al-language corpus with both package caches: 459 `.app` files, 117 MB. 12-core Linux box hosting several other agents, so these are in-process phase timings from the `[emit-timing]` channel rather than process wall clock. Two conditions, because they behave differently — cold manifest index is the first run on a machine, warm is every run after that.

| | cold index | warm index |
|---|---|---|
| baseline | 995, 1014 ms | 1199, 1546, 1950 ms |
| after | 779 ms | 30, 30, 54 ms |

The warm-index row is the one that matters. The baseline does not improve there at all, because the manifest index is already hitting and the entire cost is the symbol-reference read that nothing caches. Splitting the two inside a baseline run confirms the attribution: of an 835 ms scan, `ReadManifest` measured 0 ms and `HasSymbolReference` measured 766 ms.

## Two halves, and one of them is a trap

**Streaming alone is not enough.** Making `HasSymbolReference` use `OpenAppZip` the way `ReadManifest` already does took the scan from 835 ms to about 660 ms and no further. What remains is opening 459 packages and materializing each central directory, and only caching removes that.

**Combining the two reads carelessly is worse than not combining them.** My first attempt called `ReadManifestFromZip` and then `HasSymbolReferenceInZip` on the same archive, and the scan went to **1359 ms** — because for an R2R package each of those recurses into the nested `.app` on its own, and a zip entry's stream is forward-only, so each has to copy the inner package out to something seekable. `ReadPackageMetaFromZip` does one walk and buffers the nested archive at most once.

## Two ways to get this wrong, both covered by RED probes

**An outer `NavxManifest.xml` does not license skipping the nested archive.** The symbol-reference question has its own answer down there. Reporting `false` for a package that carries one drops it from the compile's scan set, and the resulting AL1023 is attributed to the whole compilation rather than to the package. I confirmed the test catches it by writing the naive early return:

```
AppLoaderPackageMetaTests.ReadPackageMeta_AnswersBothQuestions_ForEveryPackageShape
  (shape: "nested-outer-manifest-inner-symref", expectedSymbolReference: True) [FAIL]
```

**An index entry with no recorded flag must mean "go and look", never false.** Every entry on disk today was written by `ReadManifest` and records no flag, so reading absent as `false` would produce the same AL1023 on exactly the machines that have a warm cache. Confirmed the same way:

```
AppLoaderPackageMetaTests.ReadPackageMeta_IndexEntryWithoutTheFlag_IsRecomputedRatherThanReadAsFalse [FAIL]
```

## Deliberately not ported

The fork also parallelizes the scan with a `Parallel.For` over `ProcessorCount`. That was right there, because the reads were the cost. Once the answers are cached the scan is 30 ms, so fanning it out buys nothing, and it would put concurrency into a loop whose `seen` / `picked` / `inventory` decisions all encode first-occurrence-in-scan-order rules.

## Tests

`AppLoaderPackageMetaTests`, 10 tests. Equivalence across five package shapes (flat with and without a symbol reference, R2R with the flag only in the nested archive, R2R with an outer manifest and the flag only in the nested archive, R2R with no flag anywhere), plus a missing file and a garbage file answering null/false rather than throwing. Then the cache itself, proved with `ManifestParseInvocationCountForTests` so "served from the index" is distinguishable from "reparsed to the same answer", and a rewritten package being re-read rather than served stale.

`AppLoaderManifestCacheTests` and the package-scan/dedup suites still pass (57 tests). The corpus is 2361/2361 cold and 2361/2361 again warm.

Closes #2607

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
