### PR TITLE
Key the TestPage field cache by control id, not by table field number

### DIFF
--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -1057,8 +1057,24 @@ internal class LiveNavTestPage : MockITestPage
         // for a page that declares a SourceTable, so a hit here implies _record is set.
         if (_controlIdToFieldNo.TryGetValue(id, out var tableFieldNo))
         {
-            if (!_fields.TryGetValue(tableFieldNo, out var field))
-                _fields[tableFieldNo] = field =
+            // Keyed by CONTROL id, not by table field number. A page may show one field
+            // through more than one control -- twice under different conditions, or once in
+            // each of two groups with different visibility -- and each of those controls
+            // carries its own Visible / Editable / Enabled. Keying by field number handed the
+            // second control the instance built for the first, which holds the FIRST
+            // control's id, so every property read answered for the wrong control.
+            //
+            // Real BC keeps them apart: corpus test "TPSF Tests" (codeunit 60263) opens a
+            // card with two controls over one Text field, the second declaring
+            // Editable = false, and reads them independently on all 8 BC versions.
+            //
+            // Sharing the instance bought nothing. LiveNavTestField holds only readonly
+            // state -- the record, the field number, the page, the control id and the
+            // edited callback -- and every value it reads or writes goes to the record, so
+            // two instances over one field see each other's writes exactly as one did.
+            // _pageVariableFields beside it is already keyed this way.
+            if (!_fields.TryGetValue(id, out var field))
+                _fields[id] = field =
                     new LiveNavTestField(_record!, tableFieldNo, _page, id, MarkEdited);
             return field;
         }

--- a/tests/expectations/known-gaps-testpage-part-instance-pin-bump.json
+++ b/tests/expectations/known-gaps-testpage-part-instance-pin-bump.json
@@ -14,13 +14,5 @@
     "Mode": "expect-fail-known-gap",
     "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2636",
     "Note": "Feature Key rows ARE materialised now -- PR 2615 routed the table to BC's own FeatureKeyDataProvider and closed issue 2585, and the two sibling entries for FindSet and Get round-tripping were removed when that landed. What remains is only the WRITE path: real BC's Modify writes new feature state through to table 2000000210, which is not implemented here, so a Modify lands in the temp store and goes nowhere instead of raising. Measured at pin 040fbdd. The linked issue's title still says the table answers no rows; that half is fixed and only the write path is open. Passes on real BC on all eight corpus versions -- StefanMaron/BusinessCentral.AL.Language.Tests#132."
-  },
-  {
-    "codeunitId": 60263,
-    "CodeunitName": "TPSF Tests",
-    "Method": "TwoControlsOverOneField_AnswerIndependently",
-    "Mode": "expect-fail-known-gap",
-    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2637",
-    "Note": "Surfaced by the al-language pin bump landing alongside issue #2201's fix (StefanMaron/BusinessCentral.AL.Language.Tests commit 66a2e2d, #128) -- unrelated to #2201's own claim. Two TestPage controls bound to the same source field do not answer independently. Not investigated further; tracked as #2637."
   }
 ]


### PR DESCRIPTION
Two page controls over the same source-table field were not individually addressable. `LiveNavTestPage.GetField` cached its `LiveNavTestField` by **table field number**, so the second control got the instance built for the first — which holds the *first* control's id. Every property read (`Visible`, `Editable`, `Enabled`) then answered for the wrong control.

A page showing one field twice under different conditions is ordinary AL, and it is also how a page shows one field in two groups with different visibility.

## What real BC does

Corpus test `"TPSF Tests"` (codeunit 60263), opened as [corpus PR #128](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/128) and **merged green on all 8 BC versions**, opens a card with two controls over one `Text` field, the second declaring `Editable = false`, and reads them independently. BC keeps them apart.

## Why sharing the instance bought nothing

`LiveNavTestField` holds only readonly state — the record, the field number, the page, the control id and the edited callback — and every value it reads or writes goes to the record. So two instances over one field see each other's writes exactly as one did. The `_pageVariableFields` cache sitting beside it is already keyed by control id.

## How it was found

I built a page with eleven controls over one `Text` field, each with a different `Visible` expression, and traced which control id each TestPage read resolved to. Every read landed on the first control's element id and evaluated that control's expression. The one read that resolved correctly was the only control bound to a different field.

It also cost a wrong measurement: a corpus test I wrote to find out what BC answers for control property expressions bound most of its controls to one field, so every runner-side reading of that page was the first control's answer repeated.

## Verification

RED then GREEN against the corpus shape compiled locally on BC 28.1:

- old key → `TwoControlsOverOneField_AnswerIndependently` fails on "second over the shared field is not";
- new key → it passes.

The two controls that were already right stay right: a control over its own field, and both controls showing the same value. The first of those is the discrimination corpus #128 was built for — it passes either way, so only the shared-field assertion catches this.

Corpus and runner-extras stay green.

## Proving test

The BC-behavior claim is corpus codeunit 60263, already merged upstream. It is not runnable here yet because this PR deliberately does not move the submodule pin (per #2485 the orchestrator does one catch-up bump for the wave), so this change is proven locally against that same page shape rather than by the corpus run. There is no C# seam that can construct a live `LiveNavTestPage` without a built BC page, so a unit test could only restate the cache key rather than observe the behavior.

Closes #2583

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf