### PR TITLE
fix(layered): decide prebuilt-shadow staleness on content, not mtime

### DIFF
--- a/AlRunner.Tests/PrebuiltShadowCheckTests.cs
+++ b/AlRunner.Tests/PrebuiltShadowCheckTests.cs
@@ -121,3 +121,225 @@ public class PrebuiltShadowCheckTests
             PrebuiltShadowCheck.NewestAlSourceUtc(Path.Combine(Path.GetTempPath(), "definitely-not-here-" + Guid.NewGuid().ToString("N"))));
     }
 }
+
+/// <summary>
+/// The staleness verdict moved from mtime to CONTENT (issue #2610).
+///
+/// Mtime answers a different question: git writes mtimes at checkout, so their ordering says
+/// which file was last touched on this machine, not which bytes are current. It is wrong in both
+/// directions, and the two directions cost different things — a false STALE is a needless full
+/// compile, a false FRESH is a developer testing bytes they never wrote. Both are pinned below.
+/// </summary>
+public class PrebuiltShadowContentCheckTests
+{
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "prebuilt-shadow-content", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private const string CodeunitA = "codeunit 50100 \"A\"\n{\n    procedure P(): Integer begin exit(1); end;\n}\n";
+    private const string CodeunitB = "codeunit 50101 \"B\"\n{\n    procedure Q(): Integer begin exit(2); end;\n}\n";
+
+    /// <summary>A bundle directory holding the given AL sources, in nested folders, because a real
+    /// bundle has a directory layout and a package does not.</summary>
+    private static string WriteBundle(params string[] sources)
+    {
+        var dir = NewTempDir();
+        for (var i = 0; i < sources.Length; i++)
+        {
+            var sub = Path.Combine(dir, "src", "group" + i);
+            Directory.CreateDirectory(sub);
+            File.WriteAllText(Path.Combine(sub, $"Object{i}.al"), sources[i]);
+        }
+        return dir;
+    }
+
+    /// <summary>A NAVX .app carrying the given AL under flat src/*.al entries, the way alc packages it.</summary>
+    private static string WriteAppWithAl(params string[] sources)
+    {
+        var dir = NewTempDir();
+        using var ms = new MemoryStream();
+        using (var zip = new System.IO.Compression.ZipArchive(ms, System.IO.Compression.ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var manifest = zip.CreateEntry("NavxManifest.xml");
+            using (var s = manifest.Open())
+                s.Write(System.Text.Encoding.UTF8.GetBytes(
+                    "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                    + "<Package xmlns=\"http://schemas.microsoft.com/navx/2015/manifest\">"
+                    + $"<App Id=\"{Guid.NewGuid()}\" Name=\"N\" Publisher=\"P\" Version=\"1.0.0.0\"/>"
+                    + "<Dependencies/></Package>"));
+            for (var i = 0; i < sources.Length; i++)
+            {
+                var e = zip.CreateEntry($"src/Packaged{i}.al");
+                using var es = e.Open();
+                es.Write(System.Text.Encoding.UTF8.GetBytes(sources[i]));
+            }
+        }
+        var zipBytes = ms.ToArray();
+        var bytes = new byte[8 + zipBytes.Length];
+        bytes[0] = (byte)'N'; bytes[1] = (byte)'A'; bytes[2] = (byte)'V'; bytes[3] = (byte)'X';
+        BitConverter.TryWriteBytes(bytes.AsSpan(4, 4), (uint)8);
+        zipBytes.CopyTo(bytes, 8);
+        var path = Path.Combine(dir, "prebuilt.app");
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    // ---- content decides, and it beats mtime in both directions ------------------
+
+    /// <summary>
+    /// The defect that motivated this. The package's mtime is NEWER than every source file, which
+    /// the old check read as "package is current" — and its AL differs, so the run compiled bytes
+    /// the developer never wrote.
+    /// </summary>
+    [Fact]
+    public void PackageNewerThanSourceButDifferentContent_IsStale()
+    {
+        var bundle = WriteBundle(CodeunitA, CodeunitB);
+        var app = WriteAppWithAl(CodeunitA, CodeunitB.Replace("exit(2)", "exit(999)"));
+        File.SetLastWriteTimeUtc(app, DateTime.UtcNow.AddDays(1));
+
+        var verdict = PrebuiltShadowCheck.Evaluate(app, bundle);
+
+        Assert.True(verdict.Stale, "content differs, so the package must not shadow the source");
+        Assert.Contains("differs", verdict.Reason, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The other direction, which costs a needless full compile: a fresh clone or worktree switch
+    /// rewrites every source mtime to now, so a package built from exactly this source reads as
+    /// stale under mtime ordering. Its content is identical, so it is not.
+    /// </summary>
+    [Fact]
+    public void PackageOlderThanSourceButIdenticalContent_IsNotStale()
+    {
+        var bundle = WriteBundle(CodeunitA, CodeunitB);
+        var app = WriteAppWithAl(CodeunitA, CodeunitB);
+        File.SetLastWriteTimeUtc(app, DateTime.UtcNow.AddDays(-30));
+
+        var verdict = PrebuiltShadowCheck.Evaluate(app, bundle);
+
+        Assert.False(verdict.Stale, "the package ships exactly this AL, so it is current whatever the mtimes say");
+        Assert.Contains("identical", verdict.Reason, StringComparison.Ordinal);
+    }
+
+    /// <summary>Line endings and a leading BOM are rewritten by git and editors with no AL change,
+    /// and BC compiles either identically, so they must not read as drift.</summary>
+    [Fact]
+    public void CrlfAndBomDifferences_AreNotContentDrift()
+    {
+        var bundle = WriteBundle(CodeunitA, CodeunitB);
+        var app = WriteAppWithAl("﻿" + CodeunitA.Replace("\n", "\r\n"), CodeunitB.Replace("\n", "\r\n"));
+
+        Assert.False(PrebuiltShadowCheck.Evaluate(app, bundle).Stale);
+    }
+
+    /// <summary>Layout is excluded on purpose: a package flattens sources to src/&lt;name&gt;.al
+    /// while the bundle keeps its folders, and AL object identity is in the source text, never in
+    /// the filename. So a pure rename compiles to the same output and is not drift.</summary>
+    [Fact]
+    public void FileNamesAndFolders_DoNotAffectTheVerdict()
+    {
+        var bundle = NewTempDir();
+        Directory.CreateDirectory(Path.Combine(bundle, "deeply", "nested"));
+        File.WriteAllText(Path.Combine(bundle, "deeply", "nested", "TotallyDifferentName.al"), CodeunitA);
+        File.WriteAllText(Path.Combine(bundle, "Another.al"), CodeunitB);
+
+        Assert.False(PrebuiltShadowCheck.Evaluate(WriteAppWithAl(CodeunitB, CodeunitA), bundle).Stale);
+    }
+
+    /// <summary>An object added to the bundle and missing from the package is drift, and this is
+    /// the case a hash over only the package's own files would miss.</summary>
+    [Fact]
+    public void AnObjectPresentInTheBundleAndMissingFromThePackage_IsStale()
+    {
+        var bundle = WriteBundle(CodeunitA, CodeunitB);
+        var app = WriteAppWithAl(CodeunitA);
+        File.SetLastWriteTimeUtc(app, DateTime.UtcNow.AddDays(1));
+
+        Assert.True(PrebuiltShadowCheck.Evaluate(app, bundle).Stale);
+    }
+
+    /// <summary>And the mirror: an object deleted from the bundle but still shipped in the package.</summary>
+    [Fact]
+    public void AnObjectDeletedFromTheBundleButStillInThePackage_IsStale()
+    {
+        var bundle = WriteBundle(CodeunitA);
+        var app = WriteAppWithAl(CodeunitA, CodeunitB);
+        File.SetLastWriteTimeUtc(app, DateTime.UtcNow.AddDays(1));
+
+        Assert.True(PrebuiltShadowCheck.Evaluate(app, bundle).Stale);
+    }
+
+    // ---- the mtime fallback, for the shape with nothing to compare ---------------
+
+    /// <summary>
+    /// A symbols-only package ships no src/*.al, so there is nothing to compare and mtime is all
+    /// that is left. Both directions, so the fallback is not just "returns something".
+    /// </summary>
+    [Theory]
+    // A package written 30 days ago against source written now: source is newer, so stale.
+    [InlineData(-30, true)]
+    // A package written after the source: not stale, and the prebuilt keeps winning.
+    [InlineData(30, false)]
+    public void PackageWithNoAlSource_FallsBackToMtimeOrdering(int packageAgeDays, bool expectedStale)
+    {
+        var bundle = WriteBundle(CodeunitA);
+        var app = WriteAppWithAl(); // manifest only
+        File.SetLastWriteTimeUtc(app, DateTime.UtcNow.AddDays(packageAgeDays));
+
+        var verdict = PrebuiltShadowCheck.Evaluate(app, bundle);
+
+        Assert.Equal(expectedStale, verdict.Stale);
+        Assert.Contains("no AL source in the package", verdict.Reason, StringComparison.Ordinal);
+    }
+
+    /// <summary>A bundle with no AL at all cannot be compared either, and nothing can be newer
+    /// than the package, so the package keeps winning — the pre-existing contract.</summary>
+    [Fact]
+    public void BundleWithNoAlSource_FallsBackToMtimeAndKeepsThePrebuilt()
+    {
+        var bundle = NewTempDir();
+        var app = WriteAppWithAl(CodeunitA);
+
+        var verdict = PrebuiltShadowCheck.Evaluate(app, bundle);
+
+        Assert.False(verdict.Stale);
+        Assert.Contains("no AL source in the package", verdict.Reason, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A damaged package in some unrelated package cache must not end the run. It has no
+    /// comparable content, so the verdict falls back to mtime — and with source newer, to "stale",
+    /// which means "compile from source", the safe direction.
+    /// </summary>
+    [Fact]
+    public void UnreadablePackage_FallsBackToMtimeRatherThanThrowing()
+    {
+        var bundle = WriteBundle(CodeunitA);
+        var dir = NewTempDir();
+        var app = Path.Combine(dir, "corrupt.app");
+        File.WriteAllBytes(app, System.Text.Encoding.UTF8.GetBytes("NAVX not really a package at all"));
+        File.SetLastWriteTimeUtc(app, DateTime.UtcNow.AddDays(-30));
+
+        var verdict = PrebuiltShadowCheck.Evaluate(app, bundle);
+
+        Assert.True(verdict.Stale);
+        Assert.Contains("no AL source in the package", verdict.Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PrebuiltAlContentHash_IsNullForAPackageWithNoAlSource()
+        => Assert.Null(PrebuiltShadowCheck.PrebuiltAlContentHash(WriteAppWithAl()));
+
+    [Fact]
+    public void SourceAlContentHash_IsNullForADirectoryWithNoAlSource()
+        => Assert.Null(PrebuiltShadowCheck.SourceAlContentHash(NewTempDir()));
+
+    [Fact]
+    public void SourceAlContentHash_IsNullForAMissingDirectory()
+        => Assert.Null(PrebuiltShadowCheck.SourceAlContentHash(
+            Path.Combine(Path.GetTempPath(), "no-such-dir-" + Guid.NewGuid().ToString("N"))));
+}

--- a/AlRunner/Infrastructure/PrebuiltShadowCheck.cs
+++ b/AlRunner/Infrastructure/PrebuiltShadowCheck.cs
@@ -12,6 +12,32 @@
 // 136 bogus "namespace 'Copilot' is unknown" / "Codeunit '...' is missing" errors, because the
 // cached package predates that source. Deleting the .app made the same run compile and execute
 // 1076 tests.
+//
+// The first version of this check compared MTIMES. That answers a different question. Git writes
+// mtimes at CHECKOUT, so their ordering says which file was last touched on this machine, never
+// which bytes are current — and it is wrong in both directions.
+//
+// False fresh: a `NaviPartner_NP_Retail_9999.9999.9999.9999.app` was newer than every .al in the
+// sibling Application bundle, so the run compiled that package instead of the working tree and
+// dropped 322 Pages/ControlAddins through `EMIT-FAIL … excluding and retrying` — a developer
+// silently testing bytes they never wrote. False stale: a fresh clone, a worktree switch or a CI
+// checkout rewrites every source mtime to "now", so a current package reads as stale and costs a
+// full needless compile.
+//
+// So the verdict comes from CONTENT: the AL text the package ships under src/*.al against the AL
+// text in the bundle. Mtime survives as the fallback for packages that carry no AL source at all,
+// where there is nothing to compare.
+//
+// That only works because alc packages source verbatim, which was measured rather than assumed:
+// a real alc-built NP_Retail package ships 7,058 src/*.al entries against 7,058 .al files in the
+// bundle, and 7,057 are byte-identical once CRLF and a BOM are normalised away. The single
+// differing file is a genuine edit — and it is the whole defect: one file of drift in a
+// 7,058-file tree, which mtime scored as "package is current" and which cost 322 dropped objects.
+// If alc ever started reformatting what it packages, every real package would mismatch, this
+// check would answer "stale" for all of them, and the symptom would be a needless full compile
+// (safe, slow) rather than a wrong answer.
+
+using System.Text;
 
 namespace AlRunner.Infrastructure;
 
@@ -53,4 +79,130 @@ internal static class PrebuiltShadowCheck
     /// </summary>
     public static bool SourceIsNewer(DateTime prebuiltUtc, DateTime newestSourceUtc)
         => newestSourceUtc > prebuiltUtc;
+
+    /// <summary>Whether the prebuilt is stale, and why — the text goes straight into the log line.</summary>
+    public readonly record struct Verdict(bool Stale, string Reason);
+
+    /// <summary>
+    /// Content fingerprint of every <c>*.al</c> under <paramref name="bundleDir"/>, recursively,
+    /// or null when there is no readable AL source — which means "nothing to compare", not
+    /// "empty", and routes <see cref="Evaluate(string?, string?, DateTime, DateTime)"/> to the
+    /// mtime fallback.
+    ///
+    /// <para>Hashes the MULTISET of file texts, not paths: a package flattens its sources to
+    /// <c>src/&lt;filename&gt;.al</c> while the bundle keeps its directory layout, so the two
+    /// sides are only comparable if layout is excluded. AL object identity lives in the source
+    /// text (<c>codeunit 50100 "Foo"</c>), never in the filename, so this is the right
+    /// granularity — a pure rename compiles to the same output and is correctly read as
+    /// unchanged.</para>
+    ///
+    /// <para>Line endings and a leading BOM are normalised away, because git's autocrlf and
+    /// editors rewrite both with no AL change and BC compiles either identically. Nothing beyond
+    /// that is touched, so a genuine edit always registers.</para>
+    /// </summary>
+    public static string? SourceAlContentHash(string bundleDir)
+    {
+        try
+        {
+            if (!Directory.Exists(bundleDir)) return null;
+            var perFile = new List<string>();
+            foreach (var file in AlRunner.Infrastructure.SafeDirectoryScan.Files(bundleDir, "*.al"))
+                perFile.Add(HashAl(File.ReadAllText(file)));
+            return Combine(perFile);
+        }
+        catch (IOException) { return null; }
+        catch (UnauthorizedAccessException) { return null; }
+    }
+
+    /// <summary>
+    /// The same fingerprint over the AL a prebuilt <c>.app</c> ships under <c>src/*.al</c>, so it
+    /// is directly comparable with <see cref="SourceAlContentHash"/>. Null for a package that
+    /// carries no AL source (a symbols-only download) or that cannot be read as a package at all.
+    /// </summary>
+    public static string? PrebuiltAlContentHash(string appPath)
+    {
+        try
+        {
+            var packaged = AlRunner.AppLoader.ExtractAl(appPath);
+            if (packaged.Count == 0) return null;
+            return Combine(packaged.Select(s => HashAl(s.Source)).ToList());
+        }
+        // ExtractAl reads and unzips a third-party file, and a corrupt one can surface as almost
+        // anything: a bad NAVX offset reaches the MemoryStream constructor as
+        // ArgumentOutOfRangeException, a truncated zip as InvalidDataException, a bad byte
+        // sequence as a decoder failure. All of them mean "no comparable content", i.e. the mtime
+        // fallback, and none justifies ending a run because an unrelated .app in a package cache
+        // is damaged. OutOfMemoryException is excluded deliberately: that is a resource failure,
+        // not a malformed package, and reading it as "no content" would hide it behind a silently
+        // different compile decision.
+        catch (Exception ex) when (ex is not OutOfMemoryException) { return null; }
+    }
+
+    /// <summary>
+    /// The staleness verdict for a prebuilt <c>.app</c> against the bundle it would shadow.
+    /// </summary>
+    public static Verdict Evaluate(string prebuiltAppPath, string bundleDir)
+    {
+        DateTime prebuiltUtc;
+        try { prebuiltUtc = File.GetLastWriteTimeUtc(prebuiltAppPath); }
+        catch (IOException) { prebuiltUtc = DateTime.MinValue; }
+        catch (UnauthorizedAccessException) { prebuiltUtc = DateTime.MinValue; }
+
+        // Source side first, and the package is only unzipped when there is something to compare
+        // it against: with no AL under the bundle the verdict is the mtime fallback either way,
+        // and reading the package would be waste. It is the expensive half — measured 389 ms for
+        // a real 22 MB / 7,058-source ISV package — paid once per impl bundle that has a prebuilt
+        // candidate, against an AL emit whose correctness it decides.
+        var sourceHash = SourceAlContentHash(bundleDir);
+        var prebuiltHash = sourceHash == null ? null : PrebuiltAlContentHash(prebuiltAppPath);
+
+        return Evaluate(prebuiltHash, sourceHash, prebuiltUtc, NewestAlSourceUtc(bundleDir));
+    }
+
+    /// <summary>
+    /// Content decides whenever both sides have content. Mtime is the fallback only for the shape
+    /// where there is nothing to compare — a package carrying no AL source at all.
+    /// </summary>
+    public static Verdict Evaluate(string? prebuiltAlContentHash, string? sourceAlContentHash,
+                                   DateTime prebuiltUtc, DateTime newestSourceUtc)
+    {
+        if (prebuiltAlContentHash != null && sourceAlContentHash != null)
+        {
+            var identical = string.Equals(prebuiltAlContentHash, sourceAlContentHash, StringComparison.Ordinal);
+            return new Verdict(!identical,
+                identical
+                    ? "package src/*.al content is identical to the bundle's AL source"
+                    : "package src/*.al content differs from the bundle's AL source");
+        }
+
+        var stale = SourceIsNewer(prebuiltUtc, newestSourceUtc);
+        return new Verdict(stale,
+            stale
+                ? $"no AL source in the package to compare; source modified {newestSourceUtc:u} > package {prebuiltUtc:u}"
+                : $"no AL source in the package to compare; package {prebuiltUtc:u} is at least as new as source");
+    }
+
+    // Spelled as an escape, not a literal: a raw U+FEFF in source is invisible in every editor and
+    // the next reader cannot tell it from a stray keystroke.
+    private const char Bom = '\uFEFF';
+
+    private static string HashAl(string text)
+    {
+        var normalized = text.TrimStart(Bom).Replace("\r\n", "\n").Replace('\r', '\n');
+        return Convert.ToHexString(
+            System.Security.Cryptography.SHA256.HashData(Encoding.UTF8.GetBytes(normalized)));
+    }
+
+    /// <summary>
+    /// One hash over the per-file hashes, sorted so neither directory-walk order nor the
+    /// package's entry order can change the answer.
+    /// </summary>
+    private static string? Combine(List<string> perFileHashes)
+    {
+        if (perFileHashes.Count == 0) return null;
+        perFileHashes.Sort(StringComparer.Ordinal);
+        return Convert.ToHexString(
+            System.Security.Cryptography.SHA256.HashData(
+                Encoding.UTF8.GetBytes(string.Join('\n', perFileHashes))));
+    }
 }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -6660,13 +6660,14 @@ static List<string> RunLayeredPrePass(List<string> bundles, List<string> package
             // directory the user passed on the command line — surfacing as a wall of bogus
             // AL0791 / AL0185 diagnostics against source that is perfectly valid, with only
             // the "[layered] ... skipping in-process synthesis" line above to explain it.
-            var prebuiltUtc = File.GetLastWriteTimeUtc(prebuilt);
-            var newestSourceUtc = AlRunner.Infrastructure.PrebuiltShadowCheck.NewestAlSourceUtc(implPath);
-            if (AlRunner.Infrastructure.PrebuiltShadowCheck.SourceIsNewer(prebuiltUtc, newestSourceUtc))
+            // The verdict is on CONTENT, not mtime — see PrebuiltShadowCheck's header for why
+            // mtime ordering answers a different question, and gets it wrong in both directions.
+            var shadow = AlRunner.Infrastructure.PrebuiltShadowCheck.Evaluate(prebuilt, implPath);
+            if (shadow.Stale)
             {
                 Console.WriteLine($"[layered] {implId.Name} {implId.Version} has a prebuilt symbol package " +
-                    $"({Path.GetFileName(prebuilt)}) but it is STALE (source modified {newestSourceUtc:u} > " +
-                    $"package {prebuiltUtc:u}) — synthesizing from source instead.");
+                    $"({Path.GetFileName(prebuilt)}) but it is STALE ({shadow.Reason}) — " +
+                    $"synthesizing from source instead.");
                 continue; // keep implPath: build it from source
             }
 


### PR DESCRIPTION
`RunLayeredPrePass` decides whether a prebuilt `.app` may shadow the source bundle by comparing mtimes. That answers a different question: git writes mtimes at checkout, so their ordering says which file was last touched on this machine, never which bytes are current — and it is wrong in both directions.

Found and originally measured by Mikkel Mansa Vilhelmsen (@vhn) on a fork.

- **False fresh.** A `NaviPartner_NP_Retail_9999.9999.9999.9999.app` was newer than every `.al` in the sibling Application bundle, so the run compiled that package instead of the working tree and dropped 322 Pages and ControlAddins through `EMIT-FAIL … excluding and retrying`. The developer was testing bytes they never wrote, and the only line explaining it said the prebuilt was being used.
- **False stale.** A fresh clone, worktree switch or CI checkout rewrites every source mtime to "now", so a package built from exactly that source reads as stale and costs a full needless compile.

## The change

The verdict comes from content: the AL text the package ships under `src/*.al` against the AL text in the bundle. Mtime stays as the fallback for a package that carries no AL source, where there is nothing to compare.

This rests on alc packaging source verbatim, which @vhn measured rather than assumed: the real NP_Retail package ships 7,058 `src/*.al` entries against 7,058 `.al` files in the bundle, 7,057 byte-identical once CRLF and a BOM are normalized away. The single differing file is a genuine edit — and it is the whole defect: one file of drift in a 7,058-file tree, which mtime scored as "package is current" and which cost 322 dropped objects.

If alc ever started reformatting what it packages, every real package would mismatch, this check would answer "stale" for all of them, and the symptom would be a needless full compile. That is the safe direction to fail in.

Two details that decide whether the comparison is meaningful at all:

- The fingerprint is over the multiset of file **texts**, not paths. A package flattens its sources to `src/<filename>.al` while the bundle keeps its directory layout, so the two sides are only comparable with layout excluded. AL object identity lives in the source text (`codeunit 50100 "Foo"`), never in the filename, so a pure rename compiles to the same output and is correctly read as unchanged.
- Line endings and a leading BOM are normalized away, because git's autocrlf and editors rewrite both with no AL change and BC compiles either identically. Nothing beyond that, so a genuine edit always registers.

## What I measured, and what I did not

I did not reproduce @vhn's 389 ms package-read timing. This repo has no ISV package near 22 MB / 7,058 sources, and `RunLayeredPrePass` only runs for multi-bundle runs with inter-bundle dependencies, where the packages are small enough that the read does not register against the emit it decides the correctness of. The source side is checked first, so a bundle with no AL never unzips the package at all.

What I did verify is the decision, in both directions.

## Tests

`PrebuiltShadowContentCheckTests`, 12 tests. The two central ones are red against the mtime rule by construction, because each asserts the opposite of what mtime ordering says:

- `PackageNewerThanSourceButDifferentContent_IsStale` — the package's mtime is a day ahead of every source file, which the old rule read as "current". Its AL differs, so it is stale.
- `PackageOlderThanSourceButIdenticalContent_IsNotStale` — the package is 30 days older than the source, which the old rule read as "stale". Its AL is identical, so it is not.

Then: an object added to the bundle and missing from the package, an object deleted from the bundle and still in the package, CRLF and BOM differences not counting as drift, file names and folder nesting not affecting the verdict, the mtime fallback in **both** directions for a symbols-only package, a bundle with no AL, and a corrupt package falling back to mtime rather than ending the run because some unrelated `.app` in a package cache is damaged.

The 8 existing `PrebuiltShadowCheckTests` still pass — `NewestAlSourceUtc` and `SourceIsNewer` are unchanged and are what the fallback uses.

Closes #2610

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
