### PR TITLE
fix(diagnostics): name the app group in an EXEC-FAIL, not the bundle marker

### DIFF
--- a/AlRunner.Tests/ExecFailureTests.cs
+++ b/AlRunner.Tests/ExecFailureTests.cs
@@ -1,0 +1,109 @@
+// ExecFailureTests — the suite-error line for an app group whose test run threw (issue #2612).
+//
+// The claim is small and precise: the line names the APP GROUP. It used to start with the
+// literal "<bundled>", the marker every bundle-level failure uses, which is wrong here — this
+// failure happens inside the loop over a bundle's app groups, so it means one app contributed
+// zero results while its siblings ran normally. Reading such a line told you an app's tests had
+// vanished and not whose.
+using System.Reflection;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ExecFailureTests
+{
+    [Fact]
+    public void Describe_NamesTheAppGroupAndTheCause()
+    {
+        var line = ExecFailure.Describe("Contoso_Sales_1_0_0_0", new InvalidOperationException("session is not open"));
+
+        Assert.Equal("Contoso_Sales_1_0_0_0: EXEC-FAIL: session is not open", line);
+    }
+
+    /// <summary>The negative direction of the same claim, and the actual regression this guards:
+    /// the bundle-level marker must not appear, because it is what made the line useless.</summary>
+    [Fact]
+    public void Describe_DoesNotUseTheBundleLevelMarker()
+    {
+        var line = ExecFailure.Describe("Contoso_Sales_1_0_0_0", new InvalidOperationException("boom"));
+
+        Assert.DoesNotContain("<bundled>", line, StringComparison.Ordinal);
+        Assert.StartsWith("Contoso_Sales_1_0_0_0:", line, StringComparison.Ordinal);
+    }
+
+    /// <summary>Only the first line of the message: these go into a one-line-per-error summary,
+    /// and a multi-line exception message would break the shape of every consumer downstream.</summary>
+    [Fact]
+    public void Describe_KeepsOnlyTheFirstLineOfAMultiLineMessage()
+    {
+        var line = ExecFailure.Describe("App", new InvalidOperationException("first line\nsecond line\nthird"));
+
+        Assert.Equal("App: EXEC-FAIL: first line", line);
+        Assert.DoesNotContain("second line", line, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A ReflectionTypeLoadException's own message names nothing ("Unable to load one or more of
+    /// the requested types"). The concrete reasons underneath are the whole diagnosis — almost
+    /// always a dependency whose runtime DLL was never built.
+    /// </summary>
+    [Fact]
+    public void Describe_UnwrapsLoaderExceptionsSoTheRealCauseIsVisible()
+    {
+        var ex = new ReflectionTypeLoadException(
+            new Type?[] { null },
+            new Exception?[] { new FileNotFoundException("Could not load Contoso.Base"), null },
+            "Unable to load one or more of the requested types.");
+
+        var line = ExecFailure.Describe("Contoso_Sales", ex);
+
+        Assert.Contains("Contoso_Sales: EXEC-FAIL: Unable to load one or more of the requested types.", line, StringComparison.Ordinal);
+        Assert.Contains("Could not load Contoso.Base", line, StringComparison.Ordinal);
+    }
+
+    /// <summary>The same unwrapping when the loader failure arrives WRAPPED, which is how it
+    /// usually arrives — through a TargetInvocationException from a reflected call.</summary>
+    [Fact]
+    public void Describe_UnwrapsAWrappedLoaderException()
+    {
+        var inner = new ReflectionTypeLoadException(
+            new Type?[] { null },
+            new Exception?[] { new FileNotFoundException("Could not load Contoso.Base") },
+            "Unable to load one or more of the requested types.");
+
+        var line = ExecFailure.Describe("Contoso_Sales", new TargetInvocationException("wrapper", inner));
+
+        Assert.Contains("Could not load Contoso.Base", line, StringComparison.Ordinal);
+    }
+
+    /// <summary>Repeated loader reasons are one cause reported many times; quoting each once
+    /// keeps the line readable, and the cap keeps it a line.</summary>
+    [Fact]
+    public void Describe_DeduplicatesAndCapsLoaderReasons()
+    {
+        var reasons = Enumerable.Range(0, 9)
+            .Select(i => (Exception?)new FileNotFoundException($"missing dep {i % 2}"))
+            .ToArray();
+        var ex = new ReflectionTypeLoadException(new Type?[reasons.Length], reasons, "Unable to load.");
+
+        var line = ExecFailure.Describe("App", ex);
+
+        Assert.Equal(2, line.Split(" | ").Length);
+        Assert.Contains("missing dep 0", line, StringComparison.Ordinal);
+        Assert.Contains("missing dep 1", line, StringComparison.Ordinal);
+    }
+
+    /// <summary>A loader exception carrying no readable reasons still produces a usable line
+    /// rather than one ending in a dangling separator.</summary>
+    [Fact]
+    public void Describe_LoaderExceptionWithNoReasons_StillNamesTheAppGroup()
+    {
+        var ex = new ReflectionTypeLoadException(new Type?[] { null }, new Exception?[] { null }, "Unable to load.");
+
+        var line = ExecFailure.Describe("App", ex);
+
+        Assert.Equal("App: EXEC-FAIL: Unable to load.", line);
+        Assert.DoesNotContain("—", line, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner/Infrastructure/ExecFailure.cs
+++ b/AlRunner/Infrastructure/ExecFailure.cs
@@ -1,0 +1,50 @@
+// ExecFailure — the one-line description of an app group that threw during its test run.
+//
+// The message used to start with the literal "<bundled>", which is the marker every
+// BUNDLE-level failure uses (EMIT-FAIL, COMPILE-FAIL, EMIT-ZERO). This failure is not
+// bundle-level: it happens inside a loop over the bundle's app groups, and it means THIS app
+// group contributed zero results while its siblings ran normally. With the marker in place of
+// the name, an app's entire test set can disappear from a run and the only line about it does
+// not say whose. The sibling line in the same block already names the app group
+// ("{rel}: TEST-TIMEOUT-ABORT: …"), so this was also inconsistent within one catch.
+//
+// A ReflectionTypeLoadException is unwrapped for the same reason it always was: its top line
+// ("Unable to load one or more of the requested types") names nothing, and the LoaderExceptions
+// underneath are where the real cause is — almost always a dependency whose runtime DLL was
+// never built.
+
+using System.Reflection;
+
+namespace AlRunner.Infrastructure;
+
+internal static class ExecFailure
+{
+    /// <summary>How many distinct loader reasons to quote. More than a handful is a wall of
+    /// repetitions of the same missing dependency, and the message is one line in a summary.</summary>
+    private const int MaxLoaderReasons = 5;
+
+    /// <summary>
+    /// The suite-error line for an app group whose test run threw.
+    /// </summary>
+    /// <param name="appGroup">The app group's assembly name — what the reader needs in order to
+    /// know whose tests are missing from the run.</param>
+    public static string Describe(string appGroup, Exception ex)
+    {
+        var headline = ex.Message.Split('\n')[0];
+
+        var rtle = ex as ReflectionTypeLoadException
+            ?? ex.InnerException as ReflectionTypeLoadException;
+        if (rtle == null) return $"{appGroup}: EXEC-FAIL: {headline}";
+
+        var reasons = rtle.LoaderExceptions
+            .Where(e => e != null)
+            .Select(e => e!.Message)
+            .Distinct(StringComparer.Ordinal)
+            .Take(MaxLoaderReasons)
+            .ToList();
+
+        return reasons.Count == 0
+            ? $"{appGroup}: EXEC-FAIL: {headline}"
+            : $"{appGroup}: EXEC-FAIL: {headline} — {string.Join(" | ", reasons)}";
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3029,20 +3029,13 @@ foreach (var bundle in bundles)
                 // hiding WHICH type/dependency could not load. Dig out the concrete
                 // LoaderExceptions (per .claude/rules/loud-failures.md) so the developer sees
                 // the real cause — almost always a dependency whose runtime DLL was not built.
-                var rtle = ex as ReflectionTypeLoadException
-                    ?? ex.InnerException as ReflectionTypeLoadException;
-                if (rtle != null)
-                {
-                    var reasons = rtle.LoaderExceptions
-                        .Where(e => e != null).Select(e => e!.Message).Distinct().Take(5).ToList();
-                    bundleErrors.Add(
-                        $"<bundled>: EXEC-FAIL: {ex.Message.Split('\n')[0]} — " +
-                        string.Join(" | ", reasons));
-                }
-                else
-                {
-                    bundleErrors.Add($"<bundled>: EXEC-FAIL: {ex.Message.Split('\n')[0]}");
-                }
+                // Named after the APP GROUP, not the bundle: this catch sits inside the loop
+                // over the bundle's app groups, so it means THIS app contributed zero results
+                // while its siblings ran normally. With "<bundled>" here instead, an app's whole
+                // test set could disappear from a run and no line said whose — and the
+                // TEST-TIMEOUT-ABORT line a few lines up already names its app group.
+                bundleErrors.Add(AlRunner.Infrastructure.ExecFailure.Describe(
+                    asm.GetName().Name ?? $"<asm {runIdx}>", ex));
                 tests = Array.Empty<TestResult>();
             }
             finally


### PR DESCRIPTION
An app group whose test run threw was reported as `<bundled>: EXEC-FAIL: …`. `<bundled>` is the marker every *bundle*-level failure uses (EMIT-FAIL, COMPILE-FAIL, EMIT-ZERO), and this is not one: the `catch` sits inside the loop over the bundle's app groups, so it means one app contributed zero results while its siblings ran normally. The line said an app's whole test set had vanished and did not say whose — and the `TEST-TIMEOUT-ABORT` line a few lines above it, in the same `catch`, already names its app group.

Found by Mikkel Mansa Vilhelmsen (@vhn), on a witness where an install-seed failure removed all three of one app's tests on every warm `--watch` cycle and the only visible trace was the run total dropping from 2317 to 2314.

## What changed

The message construction moved into `Infrastructure/ExecFailure` so a test can reach it. The `ReflectionTypeLoadException` handling in that block had four behaviors and no cover at all:

- only the first line of the exception message (the bundle reporter keeps line 1, so a multi-line message reached the user truncated at an arbitrary point);
- unwrapping a loader exception that arrives wrapped in a `TargetInvocationException`, which is how it usually arrives;
- deduplicating repeated loader reasons, which are one missing dependency reported many times;
- capping the list, so the line stays a line.

A loader exception carrying no readable reasons used to produce a line ending in a dangling `—`. It no longer does.

## Deliberately not ported

The fork's version also writes the failure to stderr with a stack trace. That was needed on that branch because nothing else surfaced it. Here the entry already goes through `bundleErrors`, is counted in the per-bundle `N suite errors` line, marks the bucket `CompileFailed` when the bundle produced no tests at all, and reaches the exit code through `computedExitCode`'s `CompileErrors` check. Only the name was missing, so only the name changed.

## Tests

`ExecFailureTests`, 7 tests. The central pair is the claim itself in both directions: the line starts with the app group name, and it does not contain `<bundled>` — which is exactly what the previous inline code produced, so both are red against it. Then the four unwrapping behaviors above and the empty-reasons case.

No existing test asserted the `<bundled>` prefix for EXEC-FAIL, so nothing else moves.

Closes #2612

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
