### PR TITLE
fix(tests): let the silent-skip guard see the two-line form of the shape it forbids

### DIFF
--- a/AlRunner.Tests/TestArtifactsGateTests.cs
+++ b/AlRunner.Tests/TestArtifactsGateTests.cs
@@ -271,6 +271,84 @@ public class TestArtifactsGateTests
     }
 
     /// <summary>
+    /// The source shapes that mean "this test returned early and reported Passed without
+    /// asserting anything". Extracted from
+    /// <see cref="NoTestSilentlyReturnsWhenItsEnvironmentIsUnavailable"/> so the guard's own
+    /// matching can be tested directly — a guard nobody can exercise is a guard nobody notices
+    /// has stopped matching.
+    ///
+    /// <para><b>The first shape is deliberately <see cref="RegexOptions.Singleline"/> with a
+    /// bounded gap, and must not be narrowed back.</b> It used to be
+    /// <c>@"\[skip\][^\n]*\breturn;"</c> with <see cref="RegexOptions.None"/>, and
+    /// <c>[^\n]*</c> cannot cross the newline between the <c>Console.Error.WriteLine($"[skip] …")</c>
+    /// and the <c>return;</c> on the NEXT line — which is how the shape is actually written. The
+    /// guard therefore could not see the common form of the thing it exists to forbid. vhn hit
+    /// exactly this in his AL Runner fork, where seven suites had gated the BC engine that way and
+    /// 30 tests reported Passed having executed nothing (<c>646d6002</c>).</para>
+    ///
+    /// <para>The gap is bounded at 400 characters rather than left open so the match stays local to
+    /// one gate rather than pairing a <c>[skip]</c> in one method with a <c>return;</c> far below
+    /// it. A false positive here is a loud build failure somebody reads; a false negative is
+    /// silence, which is the failure mode this guard exists for — so the bound errs wide.</para>
+    /// </summary>
+    internal static readonly Regex[] SilentSkipShapes =
+    {
+        new Regex(@"\[skip\].{0,400}?\breturn;", RegexOptions.Singleline),
+        new Regex(@"\breturn;\s*//[^\n]*\b(skip|not provisioned|no artifacts|nothing to assert|nothing to prove)\b",
+            RegexOptions.IgnoreCase),
+    };
+
+    /// <summary>
+    /// The guard must see the TWO-LINE form, which is how the shape is really written. RED before
+    /// the Singleline widening: <c>[^\n]*</c> stops at the newline and this text matched nothing.
+    /// </summary>
+    [Fact]
+    public void SilentSkipShapes_MatchTheTwoLineWriteLineThenReturnForm()
+    {
+        const string twoLine = """
+            if (!engine.Ready)
+            {
+                Console.Error.WriteLine($"[skip] BC engine not ready: {engine.SkipReason}");
+                return;
+            }
+            """;
+        Assert.True(SilentSkipShapes.Any(s => s.IsMatch(twoLine)),
+            "the silent-skip guard does not match a `[skip]` line followed by `return;` on the NEXT "
+            + "line — the form the shape is actually written in. A guard that cannot see the thing "
+            + "it forbids is worse than no guard, because it reads as coverage.");
+
+        // …and the single-line form it always caught still matches, so widening did not trade one
+        // shape for the other.
+        Assert.True(
+            SilentSkipShapes.Any(s => s.IsMatch("""if (!ready) { Console.Error.WriteLine("[skip] no artifacts"); return; }""")),
+            "the single-line form is no longer matched.");
+    }
+
+    /// <summary>
+    /// Negative direction, and the reason the bound above matters: the CORRECT way to skip must not
+    /// trip the guard, and neither must an ordinary early return that has nothing to do with
+    /// skipping. Without this, widening the regex to `.*` would "pass" by flagging everything.
+    /// </summary>
+    [Fact]
+    public void SilentSkipShapes_DoNotMatchALegitimateSkipOrAnOrdinaryReturn()
+    {
+        const string properSkip = """
+            TestArtifacts.SkipIf(!engine.Ready, engine.SkipReason ?? "BC engine not ready");
+            var compiler = new BcCompiler();
+            return;
+            """;
+        Assert.DoesNotMatch(SilentSkipShapes[0], properSkip);
+        Assert.DoesNotMatch(SilentSkipShapes[1], properSkip);
+
+        const string ordinaryReturn = """
+            if (found == null)
+                return;
+            """;
+        Assert.DoesNotMatch(SilentSkipShapes[0], ordinaryReturn);
+        Assert.DoesNotMatch(SilentSkipShapes[1], ordinaryReturn);
+    }
+
+    /// <summary>
     /// A test that returns early because its environment is unavailable is recorded
     /// Passed — a green tick meaning "asserted nothing". Nothing in this assembly may
     /// do that; the unavailable branch must raise a visible skip.
@@ -278,21 +356,11 @@ public class TestArtifactsGateTests
     [Fact]
     public void NoTestSilentlyReturnsWhenItsEnvironmentIsUnavailable()
     {
-        // Both shapes the suite used: a "[skip] …" line followed by return, and a
-        // bare `return;` whose trailing comment admits it is skipping / has nothing
-        // to assert.
-        var shapes = new[]
-        {
-            new Regex(@"\[skip\][^\n]*\breturn;", RegexOptions.None),
-            new Regex(@"\breturn;\s*//[^\n]*\b(skip|not provisioned|no artifacts|nothing to assert|nothing to prove)\b",
-                RegexOptions.IgnoreCase),
-        };
-
         var offenders = new List<string>();
         foreach (var (file, text) in TestSources())
         {
             if (file == "TestArtifactsGateTests.cs") continue; // the regexes above are literals here
-            foreach (var shape in shapes)
+            foreach (var shape in SilentSkipShapes)
                 foreach (Match m in shape.Matches(text))
                     offenders.Add($"{file}: {m.Value.Split('\n')[0].Trim()}");
         }


### PR DESCRIPTION
> **Closed as superseded by #2621.** That PR merged first and lands the identical fix: the same
> two regex shapes, including `@"\[skip\].{0,400}?\breturn;"` with `RegexOptions.Singleline`,
> which is the whole point of both. It goes further by extracting `FindSilentSkipReturns` as an
> internal helper and adding `SilentSkipDetectorTests` to feed it synthetic offenders, so the
> detector is itself tested rather than only exercised. Nothing here is additive over it.
>
> The overlap is a briefing error on my side, not duplicated effort by the author: two agents
> were pointed at the same fork commit without cross-referencing. Same cause as #2597/#2619.

---

Closes #2572

## The hole

`AlRunner.Tests/TestArtifactsGateTests.cs` exists to forbid a test that gates the BC engine with

```csharp
if (!engine.Ready) { Console.Error.WriteLine($"[skip] …"); return; }
```

because xUnit records that as **Passed**, not Skipped — a green tick meaning "asserted nothing".

Its first shape was `@"\[skip\][^\n]*\breturn;"` with `RegexOptions.None`. `[^\n]*` cannot cross the
newline between the `WriteLine` and the `return;` on the next line — which is how the shape is
actually written. **The guard could not see the common form of the thing it forbids.**

## Current impact: latent, not a live false green

Measured before changing anything: I ran the guard's own regex over every `.cs` file in
`AlRunner.Tests` with the newline restriction lifted. The only additional match in the entire suite
is this file's own regex literal, which the scan already excludes. So no existing test is lying —
this closes a hole in a guard, it does not fix a live defect. Worth stating plainly rather than
letting the PR imply otherwise.

## The fix

- Widened to a **bounded `Singleline`** match: `@"\[skip\].{0,400}?\breturn;"`.
- The gap is bounded rather than open so a match stays local to one gate instead of pairing a
  `[skip]` in one method with a `return;` far below it. A false positive is a loud build failure
  somebody reads; a false negative is silence, which is the failure mode this guard exists for — so
  the bound errs wide.
- The reason the old regex failed is recorded on the field, so it does not get narrowed back.
- Shapes extracted to an internal field, so the guard's matching can be exercised directly. A guard
  nobody can test is a guard nobody notices has stopped matching — which is exactly what happened.

## Tests

| test | direction |
|---|---|
| `SilentSkipShapes_MatchTheTwoLineWriteLineThenReturnForm` | RED before the change — the two-line fixture matched nothing. Also asserts the single-line form still matches, so the widening did not trade one shape for the other. |
| `SilentSkipShapes_DoNotMatchALegitimateSkipOrAnOrdinaryReturn` | The negative direction, and the reason the bound matters: a proper `TestArtifacts.SkipIf` call and an ordinary early return must both stay unmatched. Without it, widening to `.*` would "pass" by flagging everything. |

RED proven by reverting the regex in place and re-running: 1 failed, 1 passed. Restored: 26/26 green
across the whole gate suite, including `NoTestSilentlyReturnsWhenItsEnvironmentIsUnavailable` running
with the widened shape over the real sources.

## Credit

vhn found the same regex bug in his AL Runner fork, where seven suites had gated the BC engine that
way and **30 tests reported Passed having executed nothing** (`646d6002`). We were one badly-written
gate away from the same thing.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
