### PR TITLE
ci: stop superseded runs from holding job slots

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -28,13 +28,23 @@ on:
 # ~11 were superseded duplicates (one branch had 3 PR Checks and 2 Test Matrices queued at
 # once, and `main` had SEVEN matrices queued, one per merge).
 #
-# cancel-in-progress is deliberately TRUE for pull_request and FALSE for a push to main.
-# A superseded commit's PR verdict is worthless, and cancelling it also makes the stale-verdict
-# trap in ci-verdicts.md harder to hit. A push to main is different: each main commit keeps its
-# own verdict, so a bad commit cannot be masked by a later merge cancelling its run.
+# cancel-in-progress is TRUE for both pull_request and a push to main.
+#
+# For a PR this is obvious: a superseded commit's verdict is worthless, and cancelling it also
+# makes the stale-verdict trap in ci-verdicts.md harder to hit, since no older completed run is
+# left to misread as the current one.
+#
+# For main it was initially set to FALSE, on the reasoning that each merged commit should keep
+# its own verdict so a bad commit cannot be masked by a later merge. Measured on 2026-09-03,
+# that safety net does not exist in the state where it would matter: with the queue 40 deep,
+# six main runs were queued behind hours of backlog and would have reported on commits already
+# six merges stale. A verdict that late cannot gate anything, and every one of those commits
+# was already gated by this same matrix on its own PR before merge. So the net keeps the
+# newest main run -- the only one whose answer is about the tree anybody has -- and drops the
+# rest instead of holding job slots for them.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 jobs:
   require-tests:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -21,6 +21,21 @@ on:
     # below) fails CI if it disappears.
     types: [opened, synchronize, reopened, labeled, unlabeled, edited]
 
+
+# Two agents pushing to the same branch used to leave BOTH runs holding job slots: every
+# push queued a fresh 8-leg matrix while the superseded one kept running. Measured on
+# 2026-09-03 with several agents active -- 33 runs queued against 4 in progress, of which
+# ~11 were superseded duplicates (one branch had 3 PR Checks and 2 Test Matrices queued at
+# once, and `main` had SEVEN matrices queued, one per merge).
+#
+# cancel-in-progress is deliberately TRUE for pull_request and FALSE for a push to main.
+# A superseded commit's PR verdict is worthless, and cancelling it also makes the stale-verdict
+# trap in ci-verdicts.md harder to hit. A push to main is different: each main commit keeps its
+# own verdict, so a bad commit cannot be masked by a later merge cancelling its run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   require-tests:
     name: Tests updated

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -6,6 +6,21 @@ on:
   pull_request:
     branches: [main]
 
+
+# Two agents pushing to the same branch used to leave BOTH runs holding job slots: every
+# push queued a fresh 8-leg matrix while the superseded one kept running. Measured on
+# 2026-09-03 with several agents active -- 33 runs queued against 4 in progress, of which
+# ~11 were superseded duplicates (one branch had 3 PR Checks and 2 Test Matrices queued at
+# once, and `main` had SEVEN matrices queued, one per merge).
+#
+# cancel-in-progress is deliberately TRUE for pull_request and FALSE for a push to main.
+# A superseded commit's PR verdict is worthless, and cancelling it also makes the stale-verdict
+# trap in ci-verdicts.md harder to hit. A push to main is different: each main commit keeps its
+# own verdict, so a bad commit cannot be masked by a later merge cancelling its run.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   bc-tests:
     # The matrix itself lives in bc-tests.yml so the release path (publish.yml)

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -13,13 +13,23 @@ on:
 # ~11 were superseded duplicates (one branch had 3 PR Checks and 2 Test Matrices queued at
 # once, and `main` had SEVEN matrices queued, one per merge).
 #
-# cancel-in-progress is deliberately TRUE for pull_request and FALSE for a push to main.
-# A superseded commit's PR verdict is worthless, and cancelling it also makes the stale-verdict
-# trap in ci-verdicts.md harder to hit. A push to main is different: each main commit keeps its
-# own verdict, so a bad commit cannot be masked by a later merge cancelling its run.
+# cancel-in-progress is TRUE for both pull_request and a push to main.
+#
+# For a PR this is obvious: a superseded commit's verdict is worthless, and cancelling it also
+# makes the stale-verdict trap in ci-verdicts.md harder to hit, since no older completed run is
+# left to misread as the current one.
+#
+# For main it was initially set to FALSE, on the reasoning that each merged commit should keep
+# its own verdict so a bad commit cannot be masked by a later merge. Measured on 2026-09-03,
+# that safety net does not exist in the state where it would matter: with the queue 40 deep,
+# six main runs were queued behind hours of backlog and would have reported on commits already
+# six merges stale. A verdict that late cannot gate anything, and every one of those commits
+# was already gated by this same matrix on its own PR before merge. So the net keeps the
+# newest main run -- the only one whose answer is about the tree anybody has -- and drops the
+# rest instead of holding job slots for them.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 jobs:
   bc-tests:


### PR DESCRIPTION
Neither caller workflow declared a `concurrency` group, so every push queued a fresh run while the superseded one kept its slot.

## Measured

With several agents active, 2026-09-03 19:50 UTC — **33 runs queued against 4 in progress**, of which about **11 were superseded duplicates**:

```
  7x  main                          | Test Matrix
  3x  agent/fork-rad/issue-2603     | PR Check
  2x  agent/fork-rad/issue-2603     | Test Matrix
  2x  agent/fork-ui/issue-2546      | Test Matrix
  2x  agent/fbk-3/issue-2201        | PR Check
```

Roughly a third of the queue was verifying commits nobody would read. It compounds when several agents push freely instead of waiting on a verdict.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

## Why `main` is cancelled too, having first decided otherwise

This originally kept `main` runs, on the reasoning that each merged commit should keep its own verdict so a bad commit could not be masked by a later merge cancelling its run.

That reasoning assumed `main` runs report promptly. Measured with the queue 40 deep, they do not: six `main` Test Matrix runs were queued behind hours of backlog and would have reported on commits already **six merges stale**. A verdict that late cannot gate anything, and every one of those commits was already gated by this same matrix on its own PR before merge. Holding six job slots to produce six answers nobody can act on was not a safety net — it was what starved the PRs whose verdicts still mattered.

So the group keeps the newest `main` run, which is the only one whose answer is about a tree anybody has.

## `bc-tests.yml` is untouched, deliberately

It is a reusable workflow called by `test-matrix`, `pr-check` and `publish` alike. A concurrency group there would let a release run and a PR run cancel each other, which is the opposite of what anyone wants during a release.

## Scope

This is one half of the CI cost. The other half — `Run unit tests (AlRunner.Tests)` taking 689s of a 992s leg and running eight times per PR — is being measured separately and is not addressed here.

No linked issue: CI throughput change found while diagnosing a queue backlog.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
