### PR TITLE
test(reporter): pin ProvisionGapLog's discovery order, the one property #2597 left uncovered

### DIFF
--- a/AlRunner.Tests/ProvisionGapSummaryTests.cs
+++ b/AlRunner.Tests/ProvisionGapSummaryTests.cs
@@ -135,6 +135,42 @@ public sealed class ProvisionGapLogTests
     }
 
     [Fact]
+    public void Report_KeepsDiscoveryOrder()
+    {
+        var original = Console.Error;
+        try
+        {
+            Console.SetError(TextWriter.Null);
+            ProvisionGapLog.Reset();
+
+            // Deliberately NOT in alphabetical order. Written the obvious way — "first",
+            // "second", "third" — the three strings sort into the order they were added, so the
+            // assertion passes against an implementation that sorts and proves only that three
+            // things came back. Measured: with sorted inputs, replacing the getter with
+            // OrderBy(...) still passed.
+            ProvisionGapLog.Report("zeta app resolved symbol-only");
+            ProvisionGapLog.Report("alpha app has neither a DLL nor AL source");
+            ProvisionGapLog.Report("mid app resolved symbol-only");
+
+            // The fourth property of this collector, alongside "records", "reset clears" and
+            // "Collected is a copy" below. It is observable end to end: PrintSummary dedupes with
+            // Enumerable.Distinct, which keeps first-occurrence order, so the summary lists gaps
+            // in the same order as the stderr blocks thousands of lines above it — which is what
+            // lets a reader match the two up. Every other assertion in this class uses a single
+            // entry, so nothing else here would notice a reordering.
+            Assert.Equal(
+                new[]
+                {
+                    "zeta app resolved symbol-only",
+                    "alpha app has neither a DLL nor AL source",
+                    "mid app resolved symbol-only",
+                },
+                ProvisionGapLog.Collected);
+        }
+        finally { Console.SetError(original); }
+    }
+
+    [Fact]
     public void Collected_IsACopy_SoALaterResetDoesNotEmptyWhatACallerAlreadyRead()
     {
         var original = Console.Error;


### PR DESCRIPTION
Reduced to a single test. This branch originally implemented the provisioning-gap summary, which #2597 landed first — a briefing overlap rather than a duplicated effort on my part, recorded in #2617. Everything of mine that duplicated #2597 is gone: `ProvisionGapLog.cs`, `DependencyLoader.cs`, `Program.cs`, `Reporter.cs`, and my `ProvisionGapSummaryTests.cs`.

## What is left, and why only this

I compared my ten tests against what #2597 landed. Note that #2597's `ProvisionGapSummaryTests.cs` contains **two** classes — `ProvisionGapSummaryTests` and `ProvisionGapLogTests` — so the collector was already covered too.

Eight of my ten duplicated it outright: report-and-record, reset, `Collected` being a copy, verbatim restatement with a count, no section when there are no gaps, an absent list behaving as no gaps, and dedup across bundles.

A ninth, `Summary_PlacesTheGapSectionAtTheEnd`, I dropped on inspection. I had justified it as protecting integration tests that read the summary — but those use `Contains`, so they are position-independent, and nothing downstream depends on where the section sits. It pinned formatting for its own sake, which is the kind of test I would flag in review.

That leaves one. `ProvisionGapLog` has four properties visible to its callers: it records, `Reset` clears, `Collected` is a copy, and it preserves discovery order. #2597 pins the first three. Nothing pinned the fourth, and nothing else in that class could notice a reordering, because every other test there reports a single entry.

Order is observable end to end: `PrintSummary` dedupes with `Enumerable.Distinct`, which keeps first-occurrence order, so the summary lists gaps in the same order as the stderr blocks thousands of lines above it — which is what lets a reader match the two up.

## The test data is deliberately not alphabetical

Written the obvious way — "first", "second", "third" — the three strings sort into the order they were added, so the assertion passes against an implementation that sorts and proves only that three things came back.

That is not hypothetical. I wrote it that way first and measured it: replacing the getter with `OrderBy(...)` still passed. With unsorted data:

| getter | result |
|---|---|
| `_gaps.ToList()` (as merged) | passes |
| `_gaps.OrderBy(...).ToList()` | **fails** |
| `Enumerable.Reverse(_gaps).ToList()` | **fails** |
| `new HashSet<string>(_gaps).ToList()` | passes |

The HashSet row is worth stating plainly: this test does **not** guard that refactor. An earlier draft of my comment claimed it did; I measured it and it is wrong, because `HashSet<string>` preserves insertion order for a small add-only set.

## Placement

Appended to #2597's own `ProvisionGapLogTests` rather than shipped as a second file. A separate file would have collided on the class name and split one small class's contract across two places.

All 8 tests in that file pass, and the change is test-only.

Refs #2587. No closing reference — #2617 is closed as a duplicate of #2587.

No linked issue: the issue this branch started from, 2617, was already delivered by PR 2597, which shipped the provisioning-gap summary. What is left here is one added test pinning ProvisionGapLog's discovery order, which that PR did not cover. (Issue and PR numbers are written without a leading hash next to any keyword on purpose: GitHub's parser fires on that pattern regardless of the surrounding words.)
