### PR TITLE
test(guard): the silent-skip guard could not see the multi-line shape

### DIFF
--- a/AlRunner.Tests/SilentSkipDetectorTests.cs
+++ b/AlRunner.Tests/SilentSkipDetectorTests.cs
@@ -1,0 +1,139 @@
+// SilentSkipDetectorTests — the drift guard that forbids a test returning early because its
+// environment is unavailable (issue #2620).
+//
+// A test that returns instead of skipping is recorded Passed: a green tick meaning "asserted
+// nothing". TestArtifactsGateTests.NoTestSilentlyReturnsWhenItsEnvironmentIsUnavailable exists to
+// forbid that, and it could only ever be exercised by the suite's own contents — so a hole in it
+// stayed invisible for as long as nobody happened to write the shape it missed.
+//
+// It missed one. The first pattern was `\[skip\][^\n]*\breturn;` with RegexOptions.None, and
+// `[^\n]*` cannot cross a newline, so it only matched the one-line form and was blind to the same
+// defect written over two lines — which is how anyone would actually write it.
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class SilentSkipDetectorTests
+{
+    private static int Offences(string source) =>
+        TestArtifactsGateTests.FindSilentSkipReturns(source).Count();
+
+    // ---- the shape the old pattern could not see --------------------------------
+
+    /// <summary>
+    /// The multi-line form: a "[skip]" report on one line, the return on the next. Red against
+    /// `[^\n]*`, which cannot cross the newline between them.
+    /// </summary>
+    [Fact]
+    public void DetectsASkipReportAndReturnOnSeparateLines()
+    {
+        var source = """
+            [Fact]
+            public void SomeTest()
+            {
+                if (!engine.Ready)
+                {
+                    Console.Error.WriteLine($"[skip] BC engine not available");
+                    return;
+                }
+                Assert.Equal(1, 1);
+            }
+            """;
+
+        Assert.Equal(1, Offences(source));
+    }
+
+    /// <summary>The one-line form the old pattern did catch, so widening it did not lose anything.</summary>
+    [Fact]
+    public void StillDetectsASkipReportAndReturnOnOneLine()
+    {
+        Assert.Equal(1, Offences("if (!ready) { Console.Error.WriteLine(\"[skip] no engine\"); return; }"));
+    }
+
+    /// <summary>The second shape, unchanged: a bare return whose comment admits what it is doing.</summary>
+    [Theory]
+    [InlineData("return; // skip: no artifacts here")]
+    [InlineData("return; // not provisioned")]
+    [InlineData("return; // nothing to assert")]
+    [InlineData("return; // nothing to prove without the engine")]
+    public void DetectsABareReturnWhoseCommentAdmitsIt(string line)
+    {
+        Assert.Equal(1, Offences(line));
+    }
+
+    // ---- and does not fire on things that are fine ------------------------------
+
+    /// <summary>The correct spelling must not be reported. This is the whole point of the guard:
+    /// it exists to push people to SkipIf, so flagging SkipIf would be self-defeating.</summary>
+    [Fact]
+    public void DoesNotFlagAVisibleSkip()
+    {
+        var source = """
+            [SkippableFact]
+            public void SomeTest()
+            {
+                TestArtifacts.SkipIf(!engine.Ready, "BC engine not available");
+                Assert.Equal(1, 1);
+            }
+            """;
+
+        Assert.Equal(0, Offences(source));
+    }
+
+    /// <summary>An ordinary early return in a helper is not a silent skip, and must not be
+    /// reported — a guard that fires on ordinary code gets suppressed and then protects nothing.</summary>
+    [Fact]
+    public void DoesNotFlagAnOrdinaryEarlyReturn()
+    {
+        var source = """
+            private static void Helper(string? value)
+            {
+                if (value == null) return;
+                Console.WriteLine(value);
+            }
+            """;
+
+        Assert.Equal(0, Offences(source));
+    }
+
+    /// <summary>
+    /// The bound is what keeps Singleline from over-matching: a "[skip]" mentioned in one method
+    /// and an unrelated `return;` far below it are two different pieces of code, and reporting
+    /// them as one offence would send the reader to the wrong place.
+    /// </summary>
+    [Fact]
+    public void DoesNotJoinASkipMentionToAReturnFarBelowIt()
+    {
+        var source = "Console.WriteLine(\"[skip] historical note\");\n"
+            + string.Join("\n", Enumerable.Repeat("    DoSomething();", 60))
+            + "\n    return;";
+
+        Assert.Equal(0, Offences(source));
+    }
+
+    [Fact]
+    public void ReportsNothingForSourceWithNeitherShape()
+        => Assert.Equal(0, Offences("public void T() { Assert.True(true); }"));
+
+    /// <summary>Every offence is reported, not just the first — a class that drifted usually
+    /// drifted in several places at once, and a guard naming one of them costs a round trip
+    /// for each of the others.</summary>
+    [Fact]
+    public void ReportsEveryOffenceInAFile()
+    {
+        var source = """
+            void A()
+            {
+                Console.Error.WriteLine("[skip] one");
+                return;
+            }
+            void B()
+            {
+                Console.Error.WriteLine("[skip] two");
+                return;
+            }
+            """;
+
+        Assert.Equal(2, Offences(source));
+    }
+}

--- a/AlRunner.Tests/TestArtifactsGateTests.cs
+++ b/AlRunner.Tests/TestArtifactsGateTests.cs
@@ -275,26 +275,56 @@ public class TestArtifactsGateTests
     /// Passed — a green tick meaning "asserted nothing". Nothing in this assembly may
     /// do that; the unavailable branch must raise a visible skip.
     /// </summary>
+    /// <summary>
+    /// The shapes a silent skip takes in C# source. Exposed as a function over TEXT so the
+    /// detector itself can be tested against synthetic inputs — see
+    /// <see cref="SilentSkipDetectorTests"/>. As inline regexes it could only ever be tested by
+    /// the suite's own contents, which means a hole in it stays invisible for exactly as long as
+    /// nobody happens to write the shape it misses.
+    /// </summary>
+    internal static IEnumerable<string> FindSilentSkipReturns(string sourceText)
+    {
+        foreach (var shape in SilentSkipShapes)
+            foreach (Match m in shape.Matches(sourceText))
+                yield return m.Value.Split('\n')[0].Trim();
+    }
+
+    /// <summary>
+    /// Two shapes: a "[skip] …" report followed by a return, and a bare <c>return;</c> whose
+    /// trailing comment admits it is skipping or has nothing to assert.
+    ///
+    /// <para>The first one used to be <c>\[skip\][^\n]*\breturn;</c> with
+    /// <see cref="RegexOptions.None"/>, and <c>[^\n]*</c> cannot cross the newline between the
+    /// report and the return — so it only ever matched the one-line form
+    /// <c>{ WriteLine("[skip] …"); return; }</c> and was blind to the far more common
+    ///
+    /// <code>
+    /// Console.Error.WriteLine($"[skip] …");
+    /// return;
+    /// </code>
+    ///
+    /// which is the same defect written over two lines. Widened to a bounded
+    /// <see cref="RegexOptions.Singleline"/> match: bounded, so a "[skip]" string and an
+    /// unrelated <c>return;</c> hundreds of lines apart are not reported as one offence.</para>
+    /// </summary>
+    private static readonly Regex[] SilentSkipShapes =
+    {
+        new(@"\[skip\].{0,400}?\breturn;", RegexOptions.Singleline),
+        new(@"\breturn;\s*//[^\n]*\b(skip|not provisioned|no artifacts|nothing to assert|nothing to prove)\b",
+            RegexOptions.IgnoreCase),
+    };
+
     [Fact]
     public void NoTestSilentlyReturnsWhenItsEnvironmentIsUnavailable()
     {
-        // Both shapes the suite used: a "[skip] …" line followed by return, and a
-        // bare `return;` whose trailing comment admits it is skipping / has nothing
-        // to assert.
-        var shapes = new[]
-        {
-            new Regex(@"\[skip\][^\n]*\breturn;", RegexOptions.None),
-            new Regex(@"\breturn;\s*//[^\n]*\b(skip|not provisioned|no artifacts|nothing to assert|nothing to prove)\b",
-                RegexOptions.IgnoreCase),
-        };
-
         var offenders = new List<string>();
         foreach (var (file, text) in TestSources())
         {
-            if (file == "TestArtifactsGateTests.cs") continue; // the regexes above are literals here
-            foreach (var shape in shapes)
-                foreach (Match m in shape.Matches(text))
-                    offenders.Add($"{file}: {m.Value.Split('\n')[0].Trim()}");
+            // The regexes above, and the synthetic offenders SilentSkipDetectorTests feeds them,
+            // are literals in these two files.
+            if (file is "TestArtifactsGateTests.cs" or "SilentSkipDetectorTests.cs") continue;
+            foreach (var hit in FindSilentSkipReturns(text))
+                offenders.Add($"{file}: {hit}");
         }
 
         Assert.True(offenders.Count == 0,


### PR DESCRIPTION
`TestArtifactsGateTests.NoTestSilentlyReturnsWhenItsEnvironmentIsUnavailable` forbids a test returning early because its environment is unavailable, since xUnit records that as **Passed** — a green tick meaning "asserted nothing". One of its two patterns could not match the shape anyone would actually write:

```csharp
new Regex(@"\[skip\][^\n]*\breturn;", RegexOptions.None)
```

`[^\n]*` cannot cross a newline, so it only matched `{ WriteLine("[skip] …"); return; }` on one line and was blind to the same defect over two:

```csharp
Console.Error.WriteLine($"[skip] BC engine not available");
return;
```

Found by Mikkel Mansa Vilhelmsen (@vhn), on a fork where seven suites used the multi-line form and 30 tests reported Passed having executed nothing.

## What changed

The pattern is now a bounded `RegexOptions.Singleline` match. Bounded, so a `[skip]` string and an unrelated `return;` hundreds of lines apart are not reported as one offence and the reader is not sent to the wrong place.

The detector is now a function over text. As inline regexes its only input was the suite's own contents, so a hole in it stayed invisible for exactly as long as nobody happened to write the shape it missed — which is how this one survived. `SilentSkipDetectorTests` feeds it synthetic sources instead.

## No live failure

I checked before and after: no file in `AlRunner.Tests` matches the widened pattern. This closes a hole rather than fixing a current offence, and the fork's 30 offending tests are not in this repo.

## Tests

`SilentSkipDetectorTests`, 11 assertions across 8 tests. Two are red against the old pattern, which I confirmed by putting it back:

```
SilentSkipDetectorTests.DetectsASkipReportAndReturnOnSeparateLines [FAIL]
SilentSkipDetectorTests.ReportsEveryOffenceInAFile [FAIL]
```

Both directions are covered. It must catch: the multi-line shape, the one-line shape it already caught, and the four comment forms of the second pattern. It must **not** flag: a correct `TestArtifacts.SkipIf`, an ordinary early return in a helper, or a `[skip]` mention 60 lines above an unrelated `return;`. A guard that fires on ordinary code gets suppressed, and then it protects nothing.

The 27 existing `TestArtifactsGateTests` still pass.

Closes #2620

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
