### PR TITLE
fix(scripts): parse VSTest timestamps on Python 3.9, hold the FIFO portably, and run the script tests

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -287,6 +287,48 @@ jobs:
       - name: Check every agent definition allowlists the MCP tools it documents
         run: python3 .github/scripts/check_agent_mcp_tools.py
 
+  scripts-tests:
+    name: scripts/ unit tests
+    runs-on: ubuntu-latest
+    # scripts/tests/*.test.py existed and nothing ran them, so every assertion in them
+    # was decoration: the CHANGELOG/pe-signing/release-ref suites above are all wired up
+    # and this family was not. Gated inside the job on whether scripts/ changed, like its
+    # siblings -- plain Python unrelated to most PRs.
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check whether scripts/ changed
+        id: changed
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+          if git diff --name-only "$BASE"..."$HEAD" | grep -qE '^scripts/'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run every scripts/tests/*.test.py
+        if: steps.changed.outputs.run == 'true'
+        run: |
+          # Fails the job if any suite fails AND if the glob matched nothing -- an empty
+          # run reporting success is the same "green tick meaning nothing ran" this job
+          # exists to prevent.
+          shopt -s nullglob
+          suites=(scripts/tests/*.test.py)
+          if [ ${#suites[@]} -eq 0 ]; then
+            echo "::error::no scripts/tests/*.test.py found"
+            exit 1
+          fi
+          rc=0
+          for s in "${suites[@]}"; do
+            echo "=== $s"
+            python3 "$s" || rc=1
+          done
+          exit $rc
+
   # validate-coverage (docs/coverage.yaml) removed at the v1->v2 cutover: v1 tracked
   # AL-language coverage in a hand-curated YAML the orchestrator validated on every PR.
   # v2's spec is the tests/al-language/ corpus itself -- every AL surface that needs

--- a/scripts/check-collection-weights.py
+++ b/scripts/check-collection-weights.py
@@ -40,8 +40,13 @@ import re
 import sys
 import xml.etree.ElementTree as ET
 from collections import defaultdict
-from datetime import datetime
 from pathlib import Path
+
+# Sibling module, imported by path so this works both when the script is run
+# directly and when a test loads it through importlib.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from trxtime import parse_trx_time  # noqa: E402
+
 
 NS = {"t": "http://microsoft.com/schemas/VisualStudio/TeamTest/2010"}
 
@@ -67,7 +72,7 @@ def load_trx_per_collection_seconds(path):
         if not start or not end:
             continue
         cls = names.get(r.get("testId"), "?").rsplit(".", 1)[-1]
-        per_class[cls] += (datetime.fromisoformat(end) - datetime.fromisoformat(start)).total_seconds()
+        per_class[cls] += (parse_trx_time(end) - parse_trx_time(start)).total_seconds()
     return dict(per_class)
 
 

--- a/scripts/tests/server-mode-test.sh
+++ b/scripts/tests/server-mode-test.sh
@@ -71,7 +71,14 @@ mkfifo "$FIFO"
 # shellcheck disable=SC2086
 $RUNNER --server --cache "$WORK/al-out" "${EXTRA_ARGS[@]}" < "$FIFO" > "$OUT" 2> "$LOG" &
 SERVER_PID=$!
-sleep infinity > "$FIFO" &
+# Hold the FIFO's write end open for the whole session: without a holder each
+# `printf > "$FIFO"` closes it again, the server reads EOF on stdin and shuts down
+# after one request. `sleep infinity` is a GNU extension — BSD/macOS sleep rejects
+# the argument outright, so the holder died immediately, the server shut down after
+# printing `ready`, and the first request then blocked forever writing to a FIFO
+# with no reader: a hang, not an error. `tail -f /dev/null` holds the same way on
+# both platforms.
+tail -f /dev/null > "$FIFO" &
 HOLDER_PID=$!
 
 echo "waiting for server readiness (timeout ${READY_TIMEOUT}s)..."

--- a/scripts/tests/server-reload-test.sh
+++ b/scripts/tests/server-reload-test.sh
@@ -79,7 +79,10 @@ mkfifo "$FIFO"
 # shellcheck disable=SC2086
 $RUNNER --server --cache "$WORK/al-out" "${EXTRA_ARGS[@]}" < "$FIFO" > "$OUT" 2> "$LOG" &
 SERVER_PID=$!
-sleep infinity > "$FIFO" &
+# Hold the FIFO's write end open for the whole session — see server-mode-test.sh for
+# why `sleep infinity` cannot do this job: it is a GNU extension, BSD/macOS sleep
+# rejects it, and the resulting dead holder hands the server EOF on stdin.
+tail -f /dev/null > "$FIFO" &
 HOLDER_PID=$!
 
 echo "waiting for server readiness (timeout ${READY_TIMEOUT}s)..."

--- a/scripts/tests/trxtime.test.py
+++ b/scripts/tests/trxtime.test.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/trxtime.py.
+
+VSTest writes .NET's round-trip timestamp format: seven fractional digits, and `Z` for a
+UTC clock. `datetime.fromisoformat` only became liberal in Python 3.11 — before that it
+accepts a fraction of exactly 3 or 6 digits and rejects `Z` outright — so both TRX gates
+crashed with `Invalid isoformat string` on any locally produced file under an older
+interpreter (macOS ships 3.9) while CI's 3.12 parsed the identical file.
+
+I could not run 3.9 here, so these do not measure that interpreter. They pin the two things
+that make the claim checkable without it: every timestamp shape a TRX can contain parses,
+and the NORMALISED string matches the grammar a pre-3.11 fromisoformat accepts, spelled out
+as a regex rather than left to whatever the current interpreter happens to tolerate.
+
+Run: python3 scripts/tests/trxtime.test.py
+"""
+import importlib.util
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "trxtime.py"
+_spec = importlib.util.spec_from_file_location("trxtime", SCRIPT_PATH)
+trxtime = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(trxtime)
+
+
+# Every shape a TRX startTime/endTime is known to take, and the exact instant each denotes.
+SHAPES = [
+    # .NET round-trip: seven fractional digits with an offset. The one that crashed 3.9.
+    ("2026-09-03T19:56:06.1234567+02:00", datetime(2026, 9, 3, 19, 56, 6, 123456,
+                                                   timezone(timedelta(hours=2)))),
+    # Seven digits with a Z suffix — the other half of the same crash.
+    ("2026-09-03T19:56:06.1234567Z", datetime(2026, 9, 3, 19, 56, 6, 123456, timezone.utc)),
+    # Seven digits, no zone at all.
+    ("2026-09-03T19:56:06.1234567", datetime(2026, 9, 3, 19, 56, 6, 123456)),
+    # Exactly six: already legal everywhere, and must not be altered.
+    ("2026-09-03T19:56:06.123456+02:00", datetime(2026, 9, 3, 19, 56, 6, 123456,
+                                                  timezone(timedelta(hours=2)))),
+    # Five: padded, not truncated. Five is as unparseable on 3.9 as eight.
+    ("2026-09-03T19:56:06.12345Z", datetime(2026, 9, 3, 19, 56, 6, 123450, timezone.utc)),
+    # Three: legal on 3.9 too, and must keep its value.
+    ("2026-09-03T19:56:06.123Z", datetime(2026, 9, 3, 19, 56, 6, 123000, timezone.utc)),
+    # No fraction at all.
+    ("2026-09-03T19:56:06Z", datetime(2026, 9, 3, 19, 56, 6, tzinfo=timezone.utc)),
+    ("2026-09-03T19:56:06", datetime(2026, 9, 3, 19, 56, 6)),
+]
+
+
+class ParseTests(unittest.TestCase):
+    def test_every_trx_timestamp_shape_parses_to_the_right_instant(self):
+        for raw, expected in SHAPES:
+            with self.subTest(raw=raw):
+                self.assertEqual(trxtime.parse_trx_time(raw), expected)
+
+    def test_z_and_explicit_utc_offset_are_the_same_instant(self):
+        self.assertEqual(trxtime.parse_trx_time("2026-09-03T19:56:06.1234567Z"),
+                         trxtime.parse_trx_time("2026-09-03T19:56:06.1234567+00:00"))
+
+    def test_a_duration_between_two_stamps_survives_the_normalisation(self):
+        start = trxtime.parse_trx_time("2026-09-03T19:56:06.0000000Z")
+        end = trxtime.parse_trx_time("2026-09-03T19:56:08.5000000Z")
+        self.assertEqual((end - start).total_seconds(), 2.5)
+
+
+class NormalizeTests(unittest.TestCase):
+    def test_normalised_form_matches_the_grammar_a_pre_311_parser_accepts(self):
+        """The claim this whole module rests on, stated as a grammar rather than as
+        'the interpreter I happen to be running did not complain'."""
+        for raw, _ in SHAPES:
+            with self.subTest(raw=raw):
+                normalized = trxtime.normalize_trx_time(raw)
+                self.assertRegex(normalized, trxtime.LEGACY_ISO)
+
+    def test_a_seven_digit_fraction_is_truncated_to_six(self):
+        self.assertEqual(trxtime.normalize_trx_time("2026-09-03T19:56:06.1234567"),
+                         "2026-09-03T19:56:06.123456")
+
+    def test_a_short_fraction_is_padded_to_six(self):
+        self.assertEqual(trxtime.normalize_trx_time("2026-09-03T19:56:06.12"),
+                         "2026-09-03T19:56:06.120000")
+
+    def test_a_trailing_z_becomes_an_explicit_utc_offset(self):
+        self.assertTrue(trxtime.normalize_trx_time("2026-09-03T19:56:06Z").endswith("+00:00"))
+
+    def test_an_explicit_offset_is_left_alone(self):
+        self.assertTrue(trxtime.normalize_trx_time("2026-09-03T19:56:06-05:00").endswith("-05:00"))
+
+    def test_the_grammar_rejects_what_a_pre_311_parser_rejects(self):
+        """The negative direction: LEGACY_ISO is only useful as a check if it actually
+        excludes the two forms that crashed."""
+        self.assertNotRegex("2026-09-03T19:56:06.1234567+02:00", trxtime.LEGACY_ISO)
+        self.assertNotRegex("2026-09-03T19:56:06Z", trxtime.LEGACY_ISO)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/trx-occupancy.py
+++ b/scripts/trx-occupancy.py
@@ -32,7 +32,13 @@ import statistics
 import sys
 import xml.etree.ElementTree as ET
 from collections import defaultdict
-from datetime import datetime
+from pathlib import Path
+
+# Sibling module, imported by path so this works both when the script is run
+# directly and when a test loads it through importlib.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from trxtime import parse_trx_time  # noqa: E402
+
 
 NS = {"t": "http://microsoft.com/schemas/VisualStudio/TeamTest/2010"}
 
@@ -50,7 +56,7 @@ def load(path):
         if not start or not end:
             continue
         cls, name = names.get(r.get("testId"), ("?", r.get("testName") or "?"))
-        rows.append((datetime.fromisoformat(start), datetime.fromisoformat(end),
+        rows.append((parse_trx_time(start), parse_trx_time(end),
                      cls.rsplit(".", 1)[-1], name))
     return rows
 

--- a/scripts/trxtime.py
+++ b/scripts/trxtime.py
@@ -1,0 +1,38 @@
+"""Parse a VSTest TRX timestamp on any Python >= 3.9.
+
+`datetime.fromisoformat` only became liberal in 3.11. Before that it accepts a fractional
+second of EXACTLY 3 or 6 digits and rejects a `Z` suffix outright. VSTest writes .NET's
+round-trip format, which is SEVEN digits, and writes `Z` for a UTC clock — so every gate
+here that reads a TRX crashed with `Invalid isoformat string` on any locally produced file
+under an older interpreter (macOS ships 3.9), while CI's 3.12 parsed the identical file.
+
+Normalising before handing the string over costs nothing on a new interpreter and makes the
+old one work. The reports that use this sum whole seconds and bucket in tenths, so the
+discarded 100-nanosecond tick cannot change an answer.
+"""
+import re
+from datetime import datetime
+
+# .NET's round-trip format: 2026-09-03T19:56:06.1234567+02:00, or with `Z`, or with no zone.
+_FRACTION = re.compile(r"\.(\d+)")
+_TRAILING_Z = re.compile(r"Z$")
+
+# Exactly what a pre-3.11 `fromisoformat` accepts, so a test can assert the normalised form
+# rather than only that the current interpreter happens to parse it.
+LEGACY_ISO = re.compile(
+    r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(\.\d{6})?([+-]\d{2}:\d{2})?$")
+
+
+def normalize_trx_time(value):
+    """The same instant, spelled the way every Python >= 3.9 accepts.
+
+    The fraction is padded or truncated to exactly six digits rather than only truncated: a
+    five-digit fraction is as unparseable on 3.9 as an eight-digit one.
+    """
+    value = _TRAILING_Z.sub("+00:00", value.strip())
+    return _FRACTION.sub(lambda m: "." + m.group(1)[:6].ljust(6, "0"), value, count=1)
+
+
+def parse_trx_time(value):
+    """Parse a VSTest TRX timestamp into a datetime."""
+    return datetime.fromisoformat(normalize_trx_time(value))


### PR DESCRIPTION
Four gates could not run on a machine with a Python older than 3.11 or a non-GNU `sleep`, and one of them failed as a hang. Found by Mikkel Mansa Vilhelmsen (@vhn), who hit both on macOS.

## `datetime.fromisoformat` before 3.11

`fromisoformat` only became liberal in 3.11. Before that it accepts a fractional second of exactly 3 or 6 digits and rejects a `Z` suffix outright. VSTest writes .NET's round-trip format — seven digits, and `Z` for a UTC clock — so `trx-occupancy.py` and `check-collection-weights.py` died with `Invalid isoformat string` on any locally produced TRX under an older interpreter (macOS ships 3.9) while CI's 3.12 parsed the identical file.

`scripts/trxtime.py` normalizes the fraction to exactly six digits and rewrites a trailing `Z` before parsing. Both reports sum whole seconds and bucket in tenths, so the discarded 100-nanosecond tick cannot change an answer. One module rather than a copy in each script, because two copies drift.

## `sleep infinity`

A GNU extension. BSD/macOS `sleep` rejects the argument outright, so the holder that keeps the server-mode FIFO's write end open died instantly, the server read EOF on stdin and shut down after printing `ready`, and the first request then blocked forever writing to a FIFO with no reader — a hang, not an error, which is the worse of the two to debug. `tail -f /dev/null` holds the same way on both platforms.

## Third: the reason the first two could sit here

`scripts/tests/*.test.py` was run by no workflow. `check-collection-weights.test.py` exists, passes, and gates nothing, while the CHANGELOG-generator, pe-signing and release-ref suites beside it in `pr-check.yml` are all wired up.

A proving test for the parsing fix would have been decoration, so `pr-check.yml` now runs the family — gated on `scripts/` changing, like its siblings, and failing if the glob matches nothing, because an empty run reporting success is the same false green the job exists to prevent.

## What the tests do and do not measure

I could not run 3.9 here, so they do not measure that interpreter. Saying "it parsed on my 3.14" would prove nothing about the version that crashed. Instead they pin the two things that make the claim checkable without it:

- All eight TRX timestamp shapes parse to the right instant: seven digits with an offset, with `Z`, and with no zone; exactly six; five; three; none at all; and `Z` and `+00:00` agreeing on the instant.
- The **normalized** string matches the grammar a pre-3.11 `fromisoformat` accepts, written out as a regex rather than left to whatever the current interpreter tolerates — with the negative direction asserting that grammar really does reject the two forms that crashed.

Plus the normalizer itself in both directions: a seven-digit fraction truncated to six, a short one padded to six (five digits is as unparseable on 3.9 as eight, so truncating alone would not be enough), `Z` becoming an explicit offset, and an existing offset left alone.

9 tests, and the existing `check-collection-weights.test.py` (8 tests) still passes. Both shell scripts pass `bash -n`.

Closes #2622

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
