### PR TITLE
perf(tests): drop the unused Base Application floor from the most-spawned test fixture

### DIFF
--- a/.claude/rules/no-base-app-in-csharp-tests.md
+++ b/.claude/rules/no-base-app-in-csharp-tests.md
@@ -43,6 +43,17 @@ times, so this is the single largest cost in the C# suite.
 None is a precedent to cite. Do not add a fifth. When #2364 lands, this section shrinks to
 the one legitimate case.
 
+**A fifth arrived anyway, because this list had no enforcement.** Not as a class -- as a
+checked-in fixture, which the paragraph above never mentioned:
+`AlRunner.Tests/Fixtures/RecordTriggerXRec/app.json`, a bundle with `"dependencies": []`
+and its own private Assert codeunit that needs nothing from Microsoft. It was also the
+most-spawned fixture in the suite (28 spawns per BC leg, 313-472 s of subprocess wall),
+so the property nobody noticed was costing about a quarter of all subprocess time in the
+unit-test step. `AlRunner.Tests/BaseAppFloorFixtureGuardTests.cs` now enforces both halves
+-- generated manifests AND checked-in fixture manifests -- against a named allowlist, and
+fails when an allowlist entry goes stale. Add to the allowlist only with the reason the
+floor is genuinely the subject.
+
 **How these four were identified, and how they were nearly missed.** The property was
 removed from all 49 classes and the full suite run. A *partial* local run reported three
 classes; reading it before it finished produced a wrong list, and CI — running to completion

--- a/.claude/rules/no-base-app-in-csharp-tests.md
+++ b/.claude/rules/no-base-app-in-csharp-tests.md
@@ -54,13 +54,29 @@ unit-test step. `AlRunner.Tests/BaseAppFloorFixtureGuardTests.cs` now enforces b
 fails when an allowlist entry goes stale. Add to the allowlist only with the reason the
 floor is genuinely the subject.
 
-**How these four were identified, and how they were nearly missed.** The property was
+**A sixth turned out to be legitimate, and stays on the fixture allowlist: `Fixtures/
+SubscriberScanAudit`.** Dropping the floor from `RecordTriggerXRec` broke
+`EventSubscriberScanEquivalenceTests`, which drives the runner with
+`AL_RUNNER_SUBSCRIBER_SCAN_AUDIT=1` and asserts over 3,000 real `[NavEventSubscriber]`
+methods across Base Application + System Application -- a count with nothing to count
+without the platform closure loaded. That test never declared its own need for the floor;
+it rode along on a fixture another 13 test classes shared. Its whole claim is a count of
+subscribers in real BC assemblies, so without the floor it asserts against nothing --
+the same shape as `PlaceholderFloorProvisioningTests` above, not a #2364-style violation.
+The fix is not to restore the floor to `RecordTriggerXRec` (that un-does the entire point
+of this PR for its other 13 users) but to give the one test that needs it a fixture of its
+own, so the floor is paid once per CI leg instead of 28 times.
+
+**How these six were identified, and how they were nearly missed twice.** The property was
 removed from all 49 classes and the full suite run. A *partial* local run reported three
 classes; reading it before it finished produced a wrong list, and CI — running to completion
-on all eight legs — found five failures in two further classes. **Do not conclude a set of
-failures from a run that has not finished.** The bar for adding to this list is a completed
-run showing the class fails without the floor, not a reading of what the test looks like it
-needs.
+on all eight legs — found five failures in two further classes. Later, removing the floor
+from the checked-in `RecordTriggerXRec` fixture (rather than a class-generated manifest)
+found a sixth failure the same way: only a completed eight-leg CI run surfaced
+`EventSubscriberScanEquivalenceTests` failing with `found 0` subscribers, on multiple BC
+legs at once. **Do not conclude a set of failures from a run that has not finished.** The
+bar for adding to either allowlist is a completed run showing the class or fixture fails
+without the floor, not a reading of what the test looks like it needs.
 
 ## Sister rules
 

--- a/AlRunner.Tests/AssemblyTypeIndexTests.cs
+++ b/AlRunner.Tests/AssemblyTypeIndexTests.cs
@@ -326,8 +326,15 @@ public sealed class EventSubscriberScanEquivalenceTests
     private static readonly string RepoRoot = Path.GetFullPath(
         Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
     private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    // This is the ONLY user of this fixture, and deliberately so: it is the one place in
+    // the suite where the "application" floor is the actual subject (real BC assemblies to
+    // scan), not an accident carried by a shared fixture. See
+    // Fixtures/SubscriberScanAudit/app.json and .claude/rules/no-base-app-in-csharp-tests.md.
+    // Do not repoint this at RecordTriggerXRec or any other floor-less fixture -- the
+    // magnitude assertions below (>3000 subscribers) need the real closure to be loaded.
     private static readonly string Fixture = Path.Combine(
-        RepoRoot, "AlRunner.Tests", "Fixtures", "RecordTriggerXRec");
+        RepoRoot, "AlRunner.Tests", "Fixtures", "SubscriberScanAudit");
 
     private static readonly Regex AuditLine = new(
         @"scan-audit (?<asm>\S+): metadata=(?<md>\d+) reflection=(?<rf>\d+) identical=(?<same>true|false)",

--- a/AlRunner.Tests/BaseAppFloorFixtureGuardTests.cs
+++ b/AlRunner.Tests/BaseAppFloorFixtureGuardTests.cs
@@ -24,6 +24,17 @@ namespace AlRunner.Tests;
 /// 4.65 s to 1.92 s locally, and this file's 14 dependent test classes from 4 m 20 s to
 /// 1 m 54 s.
 ///
+/// Removing the floor from RecordTriggerXRec broke one of its 14 dependent test classes:
+/// EventSubscriberScanEquivalenceTests (in AssemblyTypeIndexTests.cs) drives the runner with
+/// AL_RUNNER_SUBSCRIBER_SCAN_AUDIT=1 and asserts over 3,000 real [NavEventSubscriber]
+/// methods across Base Application + System Application -- those assemblies only load
+/// because the fixture used to declare the floor, and the test never declared its own need
+/// for it. Rather than restore the floor to all 28-spawns-per-leg of RecordTriggerXRec, it
+/// now has its own dedicated fixture, Fixtures/SubscriberScanAudit, whose entire purpose is
+/// to carry the floor -- so it is paid once per leg instead of 28 times. Found by a
+/// completed eight-leg CI run, not a partial local one -- see the note below on why that
+/// distinction matters.
+///
 /// So the count is enforced here rather than asked for in prose. Anything not on the
 /// allowlist below fails, in the C#-written manifests the rule already covered AND in the
 /// checked-in fixture manifests it did not.
@@ -58,6 +69,10 @@ public sealed class BaseAppFloorFixtureGuardTests
             "BcVersionFloorSkipTests — a floor no artifact can satisfy; the fixture IS the floor",
         ["Fixtures/CrossMajorNote/app.json"] =
             "CrossMajorNoteTests (#2210) — declares a BC major no shipped engine matches",
+        ["Fixtures/SubscriberScanAudit/app.json"] =
+            "EventSubscriberScanEquivalenceTests — needs the real Base App + System App " +
+            "closure loaded so the metadata-vs-reflection subscriber scan has >3000 real " +
+            "[NavEventSubscriber] methods to compare; the floor IS the subject",
     };
 
     /// <summary>
@@ -80,7 +95,7 @@ public sealed class BaseAppFloorFixtureGuardTests
     };
 
     [Fact]
-    public void NoFixtureManifest_DeclaresTheBaseApplicationFloor_ExceptTheAllowlistedThree()
+    public void NoFixtureManifest_DeclaresTheBaseApplicationFloor_ExceptTheAllowlistedFour()
     {
         var offenders = new List<string>();
         foreach (var path in Directory.EnumerateFiles(

--- a/AlRunner.Tests/BaseAppFloorFixtureGuardTests.cs
+++ b/AlRunner.Tests/BaseAppFloorFixtureGuardTests.cs
@@ -1,0 +1,149 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Guards <c>.claude/rules/no-base-app-in-csharp-tests.md</c>: a fixture manifest written
+/// by a test in AlRunner.Tests must not carry an <c>"application"</c> property.
+///
+/// The rule is measured, not stylistic. <c>"application"</c> is the Base Application
+/// dependency, and it is not declared through <c>dependencies</c>, which is why it is easy
+/// to add without noticing what it pulls in: from #2205 on, ReadDependencies synthesises
+/// implicit Microsoft/Application + Microsoft/System roots from it, so every runner
+/// subprocess spawned against that bundle resolves and loads the platform closure.
+///
+/// The rule listed four classes that still carried the floor and asked for no fifth. It
+/// had no enforcement, and a fifth arrived anyway — not as a class, as a static fixture:
+/// AlRunner.Tests/Fixtures/RecordTriggerXRec/app.json, a bundle with
+/// <c>"dependencies": []</c> and its own private Assert codeunit, which needs nothing from
+/// Microsoft at all. It is also the most-spawned fixture in the suite: the CI phase log for
+/// run 33791744880 records 28 spawns of it per BC leg, 313 s of subprocess wall on the
+/// 28.1 leg and 472 s on 28.2 — about a quarter of all subprocess time in the unit-test
+/// step, for a property that bought nothing. Removing it took a warm invocation from
+/// 4.65 s to 1.92 s locally, and this file's 14 dependent test classes from 4 m 20 s to
+/// 1 m 54 s.
+///
+/// So the count is enforced here rather than asked for in prose. Anything not on the
+/// allowlist below fails, in the C#-written manifests the rule already covered AND in the
+/// checked-in fixture manifests it did not.
+///
+/// Matching is on the JSON PROPERTY (<c>"application"</c> followed by a colon), never the
+/// bare word: several files quote <c>"application"</c> in a comment explaining that they
+/// deliberately do NOT declare it, and flagging those would train readers to ignore this
+/// test.
+/// </summary>
+public sealed class BaseAppFloorFixtureGuardTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static string TestsDir => Path.Combine(RepoRoot, "AlRunner.Tests");
+
+    // A JSON "application" property, in a .json file or embedded in a C# string —
+    // including the escaped \"application\" form used in concatenated manifests.
+    private static readonly Regex ApplicationProperty = new(
+        @"\\?""application\\?""\s*:", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Checked-in fixture manifests permitted to declare the floor, with the reason. Each
+    /// one has the FLOOR ITSELF as its subject: remove it and the fixture stops testing
+    /// anything. Paths are relative to AlRunner.Tests/, with '/' separators.
+    /// </summary>
+    private static readonly Dictionary<string, string> AllowedFixtures = new()
+    {
+        ["Fixtures/BcFloorSkip/healthy-suite/app.json"] =
+            "BcVersionFloorSkipTests — a floor every supported BC satisfies; the fixture IS the floor",
+        ["Fixtures/BcFloorSkip/future-suite/app.json"] =
+            "BcVersionFloorSkipTests — a floor no artifact can satisfy; the fixture IS the floor",
+        ["Fixtures/CrossMajorNote/app.json"] =
+            "CrossMajorNoteTests (#2210) — declares a BC major no shipped engine matches",
+    };
+
+    /// <summary>
+    /// C# test classes permitted to write the floor into a manifest they generate. Three
+    /// are debt tracked in #2364, not permission; two are legitimate. Keep the reasons —
+    /// the rule was ignored once already because it read as advice.
+    /// </summary>
+    private static readonly Dictionary<string, string> AllowedSources = new()
+    {
+        ["InstallBaselineDiskCacheTests.cs"] =
+            "#2364 debt — #1867 install-baseline caching needs a closure whose install writes rows",
+        ["InstallSeedDepCompanyCacheTests.cs"] =
+            "#2364 debt — same install-baseline closure requirement",
+        ["MissingTestDataDiagnosisTests.cs"] =
+            "#2364 debt — resolves 'Source Code Setup' (table 242) against real metadata",
+        ["PlaceholderFloorProvisioningTests.cs"] =
+            "legitimate — the placeholder 1.0.0.0 floor IS the subject",
+        ["ProvisionExplicitModesTests.cs"] =
+            "legitimate — asserts provisioning against a bundle declaring an older major",
+    };
+
+    [Fact]
+    public void NoFixtureManifest_DeclaresTheBaseApplicationFloor_ExceptTheAllowlistedThree()
+    {
+        var offenders = new List<string>();
+        foreach (var path in Directory.EnumerateFiles(
+                     Path.Combine(TestsDir, "Fixtures"), "app.json", SearchOption.AllDirectories))
+        {
+            if (!ApplicationProperty.IsMatch(File.ReadAllText(path))) continue;
+            var rel = Path.GetRelativePath(TestsDir, path).Replace(Path.DirectorySeparatorChar, '/');
+            if (!AllowedFixtures.ContainsKey(rel)) offenders.Add(rel);
+        }
+
+        Assert.True(offenders.Count == 0,
+            "These fixture app.json files declare \"application\" (the Base Application floor) " +
+            "without being on the allowlist in this file:\n  " + string.Join("\n  ", offenders) +
+            "\n\nSee .claude/rules/no-base-app-in-csharp-tests.md. Declaring it makes every runner " +
+            "subprocess spawned against the bundle resolve and load the platform closure. Drop the " +
+            "property, or add the fixture here WITH the reason the floor is its subject.");
+    }
+
+    [Fact]
+    public void NoTestSource_WritesTheBaseApplicationFloor_ExceptTheAllowlistedFive()
+    {
+        var offenders = new List<string>();
+        foreach (var path in Directory.EnumerateFiles(TestsDir, "*.cs", SearchOption.TopDirectoryOnly))
+        {
+            if (!ApplicationProperty.IsMatch(File.ReadAllText(path))) continue;
+            var name = Path.GetFileName(path);
+            if (!AllowedSources.ContainsKey(name)) offenders.Add(name);
+        }
+
+        Assert.True(offenders.Count == 0,
+            "These test sources write \"application\" into a manifest without being on the " +
+            "allowlist in this file:\n  " + string.Join("\n  ", offenders) +
+            "\n\nSee .claude/rules/no-base-app-in-csharp-tests.md, and #2364 for the three " +
+            "outstanding violations that are debt rather than precedent.");
+    }
+
+    /// <summary>
+    /// The negative direction: an allowlist entry naming something that no longer declares
+    /// the floor is stale, and a stale entry silently re-permits the next one that does.
+    /// This is what turns the lists above into a shrinking budget rather than decoration.
+    /// </summary>
+    [Fact]
+    public void EveryAllowlistEntry_StillDeclaresTheFloor_SoTheListCannotGoStale()
+    {
+        var stale = new List<string>();
+
+        foreach (var (rel, why) in AllowedFixtures)
+        {
+            var path = Path.Combine(TestsDir, rel.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(path) || !ApplicationProperty.IsMatch(File.ReadAllText(path)))
+                stale.Add($"{rel} ({why})");
+        }
+
+        foreach (var (name, why) in AllowedSources)
+        {
+            var path = Path.Combine(TestsDir, name);
+            if (!File.Exists(path) || !ApplicationProperty.IsMatch(File.ReadAllText(path)))
+                stale.Add($"{name} ({why})");
+        }
+
+        Assert.True(stale.Count == 0,
+            "These allowlist entries no longer declare \"application\" (or no longer exist). " +
+            "Delete them — a stale entry silently permits the next fixture that takes the name:\n  "
+            + string.Join("\n  ", stale));
+    }
+}

--- a/AlRunner.Tests/Fixtures/RecordTriggerXRec/app.json
+++ b/AlRunner.Tests/Fixtures/RecordTriggerXRec/app.json
@@ -13,7 +13,6 @@
   "dependencies": [],
   "screenshots": [],
   "platform": "1.0.0.0",
-  "application": "1.0.0.0",
   "idRanges": [
     {
       "from": 60100,

--- a/AlRunner.Tests/Fixtures/SubscriberScanAudit/Assert.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/SubscriberScanAudit/Assert.Codeunit.al
@@ -1,0 +1,12 @@
+/// <summary>
+/// Minimal assertion helper for this fixture app (own ID range so it
+/// stands alone from the corpus Assert).
+/// </summary>
+codeunit 61200 "SSA Assert"
+{
+    procedure AreEqual(Expected: Integer; Actual: Integer; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqual failed. Expected:<%1>. Actual:<%2>. %3', Expected, Actual, Msg);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/SubscriberScanAudit/ScanProbe.Table.al
+++ b/AlRunner.Tests/Fixtures/SubscriberScanAudit/ScanProbe.Table.al
@@ -1,0 +1,19 @@
+/// <summary>
+/// Trivial table so this fixture has something to compile and run against, beyond the
+/// app.json floor that is the actual point of this fixture. See app.json's description.
+/// </summary>
+table 61200 "SSA Scan Probe"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; "Value"; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/AlRunner.Tests/Fixtures/SubscriberScanAudit/ScanProbeTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/SubscriberScanAudit/ScanProbeTests.Codeunit.al
@@ -1,0 +1,32 @@
+/// <summary>
+/// One trivial passing test, so the runner invocation this fixture exists for
+/// (AlRunner.Tests' EventSubscriberScanEquivalenceTests) has a real test run to complete
+/// and exit 0. The AL-observable claim here is not the point of the fixture -- the
+/// app.json "application" floor is. See app.json's description and
+/// .claude/rules/no-base-app-in-csharp-tests.md.
+/// </summary>
+codeunit 61201 "SSA Scan Probe Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "SSA Assert";
+
+    [Test]
+    procedure Insert_ThenGet_ReadsBackTheStoredValue()
+    var
+        Rec: Record "SSA Scan Probe";
+    begin
+        // [GIVEN] a fresh record
+        Rec.Init();
+        Rec."No." := 'A1';
+        Rec."Value" := 42;
+
+        // [WHEN] it is inserted
+        Rec.Insert(false);
+
+        // [THEN] reading it back returns the stored value
+        Rec.Get('A1');
+        Assert.AreEqual(42, Rec."Value", 'expected the stored Value to round-trip through Insert/Get');
+    end;
+}

--- a/AlRunner.Tests/Fixtures/SubscriberScanAudit/app.json
+++ b/AlRunner.Tests/Fixtures/SubscriberScanAudit/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "84f8029d-6a84-4fdc-a80e-54c661121b95",
+  "name": "Runner Tests Fixture - Subscriber Scan Audit",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Declares the Base Application / System Application floor on purpose, so AL_RUNNER_SUBSCRIBER_SCAN_AUDIT has real BC assemblies to scan.",
+  "description": "Used only by AlRunner.Tests' EventSubscriberScanEquivalenceTests to spawn the runner against a bundle that resolves Microsoft/Application + Microsoft/System, so the metadata-vs-reflection subscriber scan audit has real R2R assemblies (Base App + System App, ~3,400 [NavEventSubscriber] methods) to compare. This is the one fixture in the suite where the floor is genuinely the subject under test -- see .claude/rules/no-base-app-in-csharp-tests.md. Do not point any other test at this fixture; it is deliberately the single most expensive one to spawn.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "application": "1.0.0.0",
+  "idRanges": [
+    {
+      "from": 61200,
+      "to": 61299
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.99.0
Closes #2624

`AlRunner.Tests/Fixtures/RecordTriggerXRec/app.json` declared `"application": "1.0.0.0"`
while carrying `"dependencies": []` and its own private Assert codeunit. It needs nothing
from Microsoft. `.claude/rules/no-base-app-in-csharp-tests.md` already forbids the
property, but the rule only listed the four C# classes that generate a manifest, and
nothing enforced it, so a checked-in fixture was never counted.

It is the most-spawned fixture in the suite. The phase log from test-matrix run
33791744880 records 28 spawns per BC leg: 313 s of subprocess wall on the 28.1 leg out of
1277 s total, 472 s out of 1943 s on 28.2, 436 s out of 1780 s on 27.0. Since #2205,
`ReadDependencies` synthesizes implicit `Microsoft/Application` and `Microsoft/System`
roots from `"application"`, so every one of those spawns resolved and loaded the platform
closure for no reason.

## Measurements

Warm, interleaved, six iterations each, on a machine under load from other work, so read
the ratio and not the absolute times. A single invocation: 4.65 s to 1.92 s. The 14 test
classes that use the fixture, 183 tests: 4 m 20 s to 1 m 54 s, all passing in both
directions.

## The guard test

`BaseAppFloorFixtureGuardTests` replaces the rule's prose with enforcement. It fails on an
`"application"` JSON property in a generated manifest or a checked-in fixture manifest
outside a named allowlist, and it fails again when an allowlist entry stops declaring the
floor, because a stale entry would silently permit the next fixture that takes that name.
It matches the property name followed by a colon, never the bare word, so the several
comments that quote `"application"` to say they deliberately do not declare it stay clean.

RED against the fixture as it was on `main`, GREEN with the property removed.

The allowlist keeps the three classes tracked in #2364 as debt and the two legitimate
cases, with the reason recorded against each. It grants nothing new.

## CI found one dependent I missed

`AssemblyTypeIndexTests.cs`'s `EventSubscriberScanEquivalenceTests` also used
`RecordTriggerXRec`, and it needed the floor for a reason none of the other 13 users
had. It drives the runner with `AL_RUNNER_SUBSCRIBER_SCAN_AUDIT=1` and asserts over
3,000 real `[NavEventSubscriber]` methods across Base Application + System Application,
comparing the new metadata scan against the old reflection scan. Those assemblies only
load because the fixture used to carry the floor, and the test never declared that need
itself. Dropping the floor broke it on every BC leg with "expected >3000 subscribers ...
found 0".

I did not restore the floor to `RecordTriggerXRec` -- that would undo this PR's point for
its other 13 users. Instead `EventSubscriberScanEquivalenceTests` now points at its own
fixture, `Fixtures/SubscriberScanAudit`, whose entire purpose is to carry the floor, so
the cost lands once per CI leg instead of 28 times.

Confirmed locally: RED ("found 0") with the fixture pointer reverted to the prior commit,
GREEN (3,450 subscribers, matching the ~3,447 the file's own comment already cited for BC
28.1) with the new fixture in place. `BaseAppFloorFixtureGuardTests`' allowlist grows by
one entry for it -- the same legitimate shape as `PlaceholderFloorProvisioningTests`, not
#2364 debt, since the test's whole claim is a count of subscribers in real BC assemblies
and it has nothing to count without the closure loaded.

This only showed up on a completed eight-leg CI run, not a partial local one -- the rule
doc already warns that a partial run produces a wrong list, and this is another instance
of exactly that.

## What this does not change

No test stops running and no assertion changes. `CollectionCostOrderer`'s measured weight
table is deliberately untouched: several of the affected collections are now much faster,
but `scripts/check-collection-weights.py` only fails on a heavy collection being absent
from the table, not on a weight being too high, and re-measuring properly needs a fresh
eight-leg TRX from this branch. That is worth a follow-up, not a guess in this PR.

## Context

I started from a different question: how much of `AlRunner.Tests` genuinely depends on the
BC version, and how much runs eight times for one answer. The measurement said the
duplication is not where the time is. Classifying all 279 test classes against the TRX
timings from run 33791744880, the tests that never touch the BC runtime are 439 of 1702
tests but only 14.2 s of 2444 test-seconds, 0.6%. The tests that spawn the runner are 98.2%
of the time, and each one executes real BC code at that leg's version. Deduplicating the
version-independent tests would save about four seconds per leg. The waste is in fixtures
loading a dependency closure they never use, which is what this PR removes.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf

