### PR TITLE
perf(compile): run CallSiteArgWrap only when the real emit needs it

### DIFF
--- a/AlRunner.Tests/BcAssemblerCallSiteArgWrapTests.cs
+++ b/AlRunner.Tests/BcAssemblerCallSiteArgWrapTests.cs
@@ -1,0 +1,125 @@
+// BcAssemblerCallSiteArgWrapTests — RED/GREEN proof for issue #2590 at the level that
+// actually matters: BcAssembler.CompileCore's own retry loop, against the REAL
+// Microsoft.Dynamics.Nav.Runtime.ByRef<T> from the BC service tier. CallSiteArgWrapTests
+// proves the rewrite mechanics in isolation against a stand-in shape; this class proves
+// the loop that decides WHEN CallSiteArgWrap.TryRewrite runs, and that the decision is
+// correct — not merely fast.
+//
+// Needs the real service-tier DLLs on disk (Microsoft.Dynamics.Nav.Ncl.dll, which is
+// where ByRef<T> lives) so BcAssembler can reference them, but NOT the in-process BC
+// engine bootstrap: BcAssembler.Compile is a pure Roslyn metadata-reference compile, it
+// never loads those DLLs into the CLR. TestArtifacts.SkipIf is the right gate; unlike the
+// BcEngineCollection tests, this class does not need [Collection(BcEngineCollection.Name)].
+//
+// What each test proves (tdd.md: must prove, not just pass):
+//   - Genuine gap: a call site BC's emitter under-wraps compiles successfully via the
+//     on-demand rewrite retry, and the resulting assembly is loaded and RUN, not merely
+//     reported Success — a rewrite that produced syntactically valid but semantically
+//     wrong code (e.g. wrapping the wrong argument) would still "compile".
+//   - Genuine error preserved: a real CS1503 that is NOT a ByRef-shape conversion must
+//     come back as ITS OWN diagnostic text, unmodified by ever having passed through the
+//     rewrite attempt. This is the exact correctness risk #2590 calls out: "Any
+//     reordering has to keep a real CS1503 that is not a ByRef gap reporting the
+//     original diagnostic."
+//   - No-gap fast path: an ordinary module with no ByRef gap still compiles successfully
+//     — the common case the whole change exists to speed up must still work at all.
+using System.Reflection;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class BcAssemblerCallSiteArgWrapTests
+{
+    private const string ByRefGapSource = """
+        public class Holder { public int Field; }
+        public static class Caller
+        {
+            public static int Take(Microsoft.Dynamics.Nav.Runtime.ByRef<int> x)
+            {
+                x.Value = x.Value + 1;
+                return x.Value;
+            }
+            public static int Go(Holder h)
+            {
+                // The under-wrapped call site: h.Field is 'int', Take wants ByRef<int>.
+                return Take(h.Field);
+            }
+        }
+        """;
+
+    private const string GenuineErrorSource = """
+        public static class Caller
+        {
+            public static void Take(int x) { }
+            // Ordinary CS1503 — a string where an int is expected. Shares the diagnostic
+            // ID with the ByRef-gap case but not its message shape.
+            public static void Go() { Take("not an int"); }
+        }
+        """;
+
+    private const string NoGapSource = """
+        public static class Plain
+        {
+            public static int Add(int a, int b) => a + b;
+        }
+        """;
+
+    [SkippableFact]
+    public void Compile_RewritesAGenuineByRefGap_AndTheAssemblyRunsCorrectly()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var result = new BcAssembler().Compile(
+            "ByRefGapAssembly", new[] { new EmittedSource("Gap", ByRefGapSource) });
+
+        Assert.True(result.Success, string.Join("\n", result.Errors));
+
+        // Not just "compiled" — load it and run it. A rewrite that wrapped the wrong
+        // expression, or built a getter/setter pair that didn't round-trip, would still
+        // produce a loadable assembly; only running it proves the semantics are right.
+        var asm = Assembly.Load(result.AssemblyBytes!);
+        var caller = asm.GetType("Caller")!;
+        var holderType = asm.GetType("Holder")!;
+        var holder = Activator.CreateInstance(holderType)!;
+        holderType.GetField("Field")!.SetValue(holder, 41);
+
+        var returned = (int)caller.GetMethod("Go")!.Invoke(null, new[] { holder })!;
+
+        Assert.Equal(42, returned);
+        // The setter half of the ByRef wrap must have written back through to the field —
+        // proves the wrap is the real get/set pair, not a one-way snapshot.
+        Assert.Equal(42, (int)holderType.GetField("Field")!.GetValue(holder)!);
+    }
+
+    [SkippableFact]
+    public void Compile_ReportsAGenuineCompileError_UnmodifiedByTheRewriteAttempt()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var result = new BcAssembler().Compile(
+            "GenuineErrorAssembly", new[] { new EmittedSource("Bad", GenuineErrorSource) });
+
+        Assert.False(result.Success);
+        // The ORIGINAL diagnostic — not swallowed, not replaced by a rewrite-loop failure,
+        // not turned into "no output" with no explanation.
+        Assert.Contains(result.Errors, e =>
+            e.Contains("CS1503", StringComparison.Ordinal) &&
+            e.Contains("string", StringComparison.Ordinal) &&
+            e.Contains("int", StringComparison.Ordinal));
+    }
+
+    [SkippableFact]
+    public void Compile_WithNoByRefGap_StillCompilesSuccessfully()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var result = new BcAssembler().Compile(
+            "NoGapAssembly", new[] { new EmittedSource("Plain", NoGapSource) });
+
+        Assert.True(result.Success, string.Join("\n", result.Errors));
+        var asm = Assembly.Load(result.AssemblyBytes!);
+        var plain = asm.GetType("Plain")!;
+        Assert.Equal(7, (int)plain.GetMethod("Add")!.Invoke(null, new object[] { 3, 4 })!);
+    }
+}

--- a/AlRunner.Tests/CallSiteArgWrapTests.cs
+++ b/AlRunner.Tests/CallSiteArgWrapTests.cs
@@ -1,0 +1,138 @@
+// CallSiteArgWrapTests — proves CallSiteArgWrap.TryRewrite (issue #2590) against a
+// self-contained ByRef<T>-shaped stand-in type, so this suite needs no BC service-tier
+// artifacts. BcAssemblerCallSiteArgWrapTests repeats the same shape against the REAL
+// Microsoft.Dynamics.Nav.Runtime.ByRef<T>, and additionally proves the retry loop inside
+// BcAssembler.CompileCore that decides WHEN TryRewrite runs.
+//
+// Before #2590, BcAssembler ran a throwaway full Roslyn compile before EVERY real one —
+// speculatively, whether or not the module had a ByRef gap — purely to collect these
+// diagnostics. TryRewrite takes the diagnostics of a compile that already happened
+// (the real one), so the pass only costs anything on the rare module that actually needs
+// it. What TryRewrite computes did not change; only when it is invoked did.
+//
+// What each test proves (tdd.md: must prove, not just pass):
+//   - Positive: a genuine 'cannot convert T to ByRef<T>' diagnostic is rewritten to the
+//     exact wrap expression, and the REWRITTEN trees actually recompile clean — not just
+//     "text changed", the fix is semantically correct.
+//   - Negative #1: diagnostics with no CS1503 at all return null — nothing to rewrite,
+//     caller must report its own (non-existent) errors, not loop forever.
+//   - Negative #2: a genuine CS1503 that is NOT a ByRef-shape conversion error (an
+//     ordinary type mismatch) also returns null. This is the correctness risk the issue
+//     names explicitly: a real compile error that happens to share the diagnostic ID must
+//     surface as itself, never get silently swallowed as "nothing to rewrite, try again".
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using AlRunner.Rewriters;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class CallSiteArgWrapTests
+{
+    // Shaped like Microsoft.Dynamics.Nav.Runtime.ByRef<T> exactly where it matters to
+    // CallSiteArgWrap: a generic class named ByRef<T>, constructed from a getter/setter
+    // delegate pair — see BcAssemblerCallSiteArgWrapTests for the proof this shape matches
+    // the real type's constructor.
+    private const string ByRefShim = """
+        namespace Some.Namespace
+        {
+            public sealed class ByRef<T>
+            {
+                public ByRef(System.Func<T> getter, System.Action<T> setter) { }
+            }
+        }
+        """;
+
+    private static readonly System.Lazy<System.Collections.Generic.List<MetadataReference>> _refs = new(() =>
+    {
+        var tpa = ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!).Split(Path.PathSeparator);
+        var wanted = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "mscorlib.dll", "System.Runtime.dll", "System.Private.CoreLib.dll", "netstandard.dll",
+        };
+        return tpa.Where(p => wanted.Contains(Path.GetFileName(p)))
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+    });
+
+    private static CSharpCompilation Compile(System.Collections.Generic.List<SyntaxTree> trees, string name) =>
+        CSharpCompilation.Create(name, trees, _refs.Value,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));
+
+    private const string GapSrc = """
+        public class Holder { public int Field; }
+        public static class Caller
+        {
+            public static void Take(Some.Namespace.ByRef<int> x) { }
+            public static void Go(Holder h) { Take(h.Field); }
+        }
+        """;
+
+    [Fact]
+    public void TryRewrite_WrapsTheByRefGapArgument_AndTheResultRecompilesClean()
+    {
+        var shimTree = CSharpSyntaxTree.ParseText(ByRefShim, path: "_shim.cs");
+        var gapTree = CSharpSyntaxTree.ParseText(GapSrc, path: "Gap.cs");
+        var trees = new System.Collections.Generic.List<SyntaxTree> { shimTree, gapTree };
+
+        var failing = Compile(trees, "gap_before");
+        var diagnostics = failing.GetDiagnostics();
+        Assert.Contains(diagnostics, d => d.Id == "CS1503" && d.Severity == DiagnosticSeverity.Error);
+
+        var rewritten = CallSiteArgWrap.TryRewrite(trees, diagnostics);
+
+        Assert.NotNull(rewritten);
+        var gapText = rewritten!.Single(t => t.FilePath == "Gap.cs").GetText().ToString();
+        Assert.Contains(
+            "new Some.Namespace.ByRef<int>(() => h.Field, v => h.Field = v)",
+            gapText, StringComparison.Ordinal);
+        // The gap expression itself must be GONE — a rewriter that appended the wrap
+        // instead of replacing the argument would leave both and still "contain" the text.
+        Assert.DoesNotContain("Take(h.Field)", gapText, StringComparison.Ordinal);
+
+        // Correct, not just textually different: the rewritten trees must actually compile.
+        var after = Compile(rewritten!.ToList(), "gap_after");
+        Assert.Empty(after.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error));
+    }
+
+    [Fact]
+    public void TryRewrite_ReturnsNull_WhenNoDiagnosticsAreErrors()
+    {
+        var cleanTree = CSharpSyntaxTree.ParseText(
+            "public class Clean { public int F() => 1; }", path: "Clean.cs");
+        var trees = new System.Collections.Generic.List<SyntaxTree> { cleanTree };
+        var compilation = Compile(trees, "clean");
+
+        var rewritten = CallSiteArgWrap.TryRewrite(trees, compilation.GetDiagnostics());
+
+        Assert.Null(rewritten);
+    }
+
+    /// <summary>
+    /// The correctness risk the issue names explicitly: a real CS1503 that is NOT a
+    /// ByRef-shape conversion (here: string literal passed where int is expected) must be
+    /// left alone — TryRewrite must not mistake it for a rewritable gap, and the caller's
+    /// retry loop must go on to report ITS diagnostic text unmodified.
+    /// </summary>
+    [Fact]
+    public void TryRewrite_ReturnsNull_WhenTheOnlyCS1503IsNotAByRefShapeConversion()
+    {
+        const string ordinaryMismatch = """
+            public static class Caller
+            {
+                public static void Take(int x) { }
+                public static void Go() { Take("not an int"); }
+            }
+            """;
+        var tree = CSharpSyntaxTree.ParseText(ordinaryMismatch, path: "Ordinary.cs");
+        var trees = new System.Collections.Generic.List<SyntaxTree> { tree };
+        var compilation = Compile(trees, "ordinary");
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.Contains(diagnostics, d => d.Id == "CS1503" && d.Severity == DiagnosticSeverity.Error);
+
+        var rewritten = CallSiteArgWrap.TryRewrite(trees, diagnostics);
+
+        Assert.Null(rewritten);
+    }
+}

--- a/AlRunner/BcAssembler.cs
+++ b/AlRunner/BcAssembler.cs
@@ -4,11 +4,14 @@
 //   1. ApplyPolyfillRedirects — string substitutions routing AL-compiler-emitted
 //      references for APIs that don't exist on the real service-tier DLLs to
 //      small in-process polyfill shims (defined inline as PolyfillSource).
+//
+// Post-compile pass (runs only when the real emit needs it):
 //   2. CallSiteArgWrap — fixes the residual call-site ByRef gap BC's emitter
 //      doesn't cover (e.g. `dict.ALGet(K, fieldOfHandleT)` → wraps the field arg
 //      as `new ByRef<T>(() => expr, v => expr = v)`). BC's emitter handles
 //      parameter-declaration ByRef wraps natively at codeanalysis.cs:342854 —
-//      no syntax rewriter needed for those.
+//      no syntax rewriter needed for those. Runs only when an emit reports the
+//      gap (see #2590), so a module without one never pays for it.
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using AlRunner.Rewriters;
@@ -108,33 +111,47 @@ public sealed class BcAssembler
         var refs = SharedMetadataReferences(ReferencePaths());
         Mark($"metadata references ({refs.Count})");
 
-        // Fill BC's call-site ByRef gap. Runs a throwaway compile to find CS1503
-        // 'cannot convert T to ByRef<T>' errors and rewrites only those args.
-        trees = CallSiteArgWrap.Apply(trees, refs).ToList();
-        Mark("CallSiteArgWrap speculative compile");
+        var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
+            allowUnsafe: true,
+            concurrentBuild: false,
+            checkOverflow: true,
+            optimizationLevel: OptimizationLevel.Release);
 
-        var compilation = CSharpCompilation.Create(
-            assemblyName,
-            trees,
-            refs,
-            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
-                allowUnsafe: true,
-                concurrentBuild: false,
-                checkOverflow: true,
-                optimizationLevel: OptimizationLevel.Release));
-
-        using var ms = new MemoryStream();
-        var emit = compilation.Emit(ms);
-        Mark("Roslyn bind + IL gen");
-        if (!emit.Success)
+        // Emit first, then fill BC's call-site ByRef gap only when the emit actually
+        // reports one — see CallSiteArgWrap's header for why this pass is no longer
+        // speculative (#2590). Bounded at 6 emits total (an initial attempt plus up to 5
+        // rewrite-and-retry cycles), mirroring the round budget the old speculative
+        // diagnose-and-rewrite loop used before every real compile.
+        const int MaxAttempts = 6;
+        byte[]? bytes = null;
+        IReadOnlyList<string> errors = Array.Empty<string>();
+        for (var attempt = 0; attempt < MaxAttempts; attempt++)
         {
-            var errs = emit.Diagnostics
+            var compilation = CSharpCompilation.Create(assemblyName, trees, refs, options);
+            using var ms = new MemoryStream();
+            var emit = compilation.Emit(ms);
+            if (emit.Success)
+            {
+                bytes = ms.ToArray();
+                errors = Array.Empty<string>();
+                break;
+            }
+
+            errors = emit.Diagnostics
                 .Where(d => d.Severity == DiagnosticSeverity.Error)
                 .Select(d => d.ToString())
                 .ToList();
-            return new CompileResult(null, errs);
+
+            if (attempt == MaxAttempts - 1) break;
+            var rewritten = CallSiteArgWrap.TryRewrite(trees, emit.Diagnostics);
+            // Null means the failure is NOT a ByRef gap — a genuine compile error, which
+            // must be reported as itself rather than retried into a misleading message.
+            if (rewritten == null) break;
+            trees = rewritten.ToList();
         }
-        var bytes = ms.ToArray();
+        Mark("Roslyn bind + IL gen (+ CallSiteArgWrap on demand)");
+        if (bytes == null)
+            return new CompileResult(null, errors);
         if (Environment.GetEnvironmentVariable("AL_RUNNER_DUMP_BC_ASM") == "1")
         {
             try

--- a/AlRunner/Rewriters/CallSiteArgWrap.cs
+++ b/AlRunner/Rewriters/CallSiteArgWrap.cs
@@ -7,11 +7,28 @@
 // static type is `T` (a Handle subclass) and the callee expects `ByRef<T>`.
 //
 // Strategy:
-//   1. Run a throw-away Roslyn compile to surface CS1503 diagnostics.
+//   1. Take the CS1503 diagnostics of a compile that ALREADY RAN (see below).
 //   2. Filter to "cannot convert from 'T' to 'ByRef<T>'" shape.
 //   3. Rewrite the offending argument expression `expr` to
 //      `new ByRef<T>(() => expr, v => expr = v)`.
-//   4. Return the rewritten trees so BcAssembler.Compile can emit cleanly.
+//   4. Return the rewritten trees so the caller can retry the emit.
+//
+// Why the diagnostics come from a compile that already ran (#2590)
+// ------------------------------------------------------------------
+// Earlier, this pass built its OWN throwaway CSharpCompilation and asked it for
+// diagnostics purely to find a ByRef gap, before every real compile — a full Roslyn
+// bind, thrown away, whether or not the module had a gap at all. Measured on the
+// al-language corpus (781 sources, cold cache): 8039ms in this speculative pass vs
+// 7958ms in the real bind + IL gen that followed it — the pre-pass cost slightly MORE
+// than the compile it preceded, 47% of the whole Roslyn half. On the two small
+// dependency compiles in that corpus it was 3x and 2.4x the real compile, because a
+// nearly-empty module still pays a full bind against all ~195 references.
+//
+// TryRewrite instead takes the diagnostics of the REAL compile's own (failed) emit.
+// The caller (BcAssembler.CompileCore) emits first; only when that emit fails does it
+// hand this method the diagnostics it already has, and only then does rewriting cost
+// anything. A module with no ByRef gap — the overwhelming majority — now pays for
+// exactly one bind, not two.
 //
 // This adds NO type renames or identifier rewrites — only argument expressions
 // are wrapped, so the resulting IL stays binary-compatible with Microsoft's
@@ -31,55 +48,48 @@ public static class CallSiteArgWrap
         RegexOptions.Compiled);
 
     /// <summary>
-    /// Iteratively diagnoses + rewrites until either no CS1503/ByRef diagnostics remain
-    /// or no further rewrites land (loop guard). Returns the (possibly new) trees.
+    /// Rewrites the ByRef argument gaps named by <paramref name="diagnostics"/> — the
+    /// diagnostics of a compile that already ran over <paramref name="trees"/>. Returns the
+    /// rewritten tree list, or <c>null</c> when there was nothing to rewrite: either no
+    /// CS1503 in the ByRef-gap shape was present at all, or every one that was present
+    /// resolved to a span the rewriter could not locate an argument at. <c>null</c> tells the
+    /// caller "these are genuine compile errors, not a ByRef gap — report them as themselves,"
+    /// which is the property #2590 calls out explicitly: a real CS1503 that happens to share
+    /// the diagnostic ID but not the message shape must never be swallowed as "try again".
     /// </summary>
-    public static IReadOnlyList<SyntaxTree> Apply(
+    public static IReadOnlyList<SyntaxTree>? TryRewrite(
         IReadOnlyList<SyntaxTree> trees,
-        IReadOnlyList<MetadataReference> refs)
+        IEnumerable<Diagnostic> diagnostics)
     {
-        var current = trees.ToList();
-        for (int iter = 0; iter < 5; iter++)
+        var targets = new List<(SyntaxTree Tree, TextSpan Span, string ByRefType)>();
+        foreach (var d in diagnostics)
         {
-            var comp = CSharpCompilation.Create(
-                $"_argwrap_{iter}",
-                current,
-                refs,
-                new CSharpCompilationOptions(
-                    OutputKind.DynamicallyLinkedLibrary,
-                    allowUnsafe: true,
-                    concurrentBuild: false));
-
-            var targets = new List<(SyntaxTree Tree, TextSpan Span, string ByRefType)>();
-            foreach (var d in comp.GetDiagnostics())
-            {
-                if (d.Severity != DiagnosticSeverity.Error) continue;
-                if (d.Id != "CS1503") continue;
-                var m = _byRefMessage.Match(d.GetMessage());
-                if (!m.Success) continue;
-                if (d.Location.SourceTree == null) continue;
-                targets.Add((d.Location.SourceTree, d.Location.SourceSpan, m.Groups["to"].Value));
-            }
-            if (targets.Count == 0) return current;
-
-            var byTree = targets
-                .GroupBy(t => t.Tree)
-                .ToDictionary(g => g.Key, g => g.ToList());
-
-            bool changed = false;
-            for (int i = 0; i < current.Count; i++)
-            {
-                if (!byTree.TryGetValue(current[i], out var spans)) continue;
-                var oldRoot = current[i].GetRoot();
-                var rewriter = new ArgRewriter(spans);
-                var newRoot = rewriter.Visit(oldRoot);
-                if (rewriter.Rewrote == 0) continue;
-                current[i] = current[i].WithRootAndOptions(newRoot, current[i].Options);
-                changed = true;
-            }
-            if (!changed) return current;
+            if (d.Severity != DiagnosticSeverity.Error) continue;
+            if (d.Id != "CS1503") continue;
+            var m = _byRefMessage.Match(d.GetMessage());
+            if (!m.Success) continue;
+            if (d.Location.SourceTree == null) continue;
+            targets.Add((d.Location.SourceTree, d.Location.SourceSpan, m.Groups["to"].Value));
         }
-        return current;
+        if (targets.Count == 0) return null;
+
+        var byTree = targets
+            .GroupBy(t => t.Tree)
+            .ToDictionary(g => g.Key, g => g.ToList());
+
+        var current = trees.ToList();
+        var changed = false;
+        for (int i = 0; i < current.Count; i++)
+        {
+            if (!byTree.TryGetValue(current[i], out var spans)) continue;
+            var oldRoot = current[i].GetRoot();
+            var rewriter = new ArgRewriter(spans);
+            var newRoot = rewriter.Visit(oldRoot);
+            if (rewriter.Rewrote == 0) continue;
+            current[i] = current[i].WithRootAndOptions(newRoot, current[i].Options);
+            changed = true;
+        }
+        return changed ? current : null;
     }
 
     private sealed class ArgRewriter : CSharpSyntaxRewriter


### PR DESCRIPTION
Closes #2590

## What CallSiteArgWrap computes, and why it needed a compile

`CallSiteArgWrap` fills a residual gap in BC's own C# emitter: BC wraps most call-site
arguments that need `Microsoft.Dynamics.Nav.Runtime.ByRef<T>` automatically, but misses
some (e.g. a `Dictionary` accessor called with a field whose static type is a `Handle`
subclass). Finding those spots needs semantic information — Roslyn has to bind the whole
module and ask for `CS1503 "cannot convert from 'T' to 'ByRef<T>'"` diagnostics — so *some*
compile is unavoidable. The question was never "can this be eliminated", only "does it need
to be a second, throwaway one."

Before this change, `BcAssembler.CompileCore` ran `CallSiteArgWrap.Apply` — its own full
`CSharpCompilation` built and diagnosed purely to find that shape — **before every real
compile**, whether or not the module had a gap at all.

## What changed

`CallSiteArgWrap.TryRewrite(trees, diagnostics)` now takes the diagnostics of a compile
that **already ran** — the real one. `BcAssembler.CompileCore` emits first; only when that
emit fails does it hand `TryRewrite` the diagnostics it already has. `TryRewrite` returns
`null` when nothing in those diagnostics matches the ByRef-gap shape, and the caller reports
its own (real) errors unmodified rather than looping. When it does return rewritten trees,
the caller retries the emit, bounded at 6 total attempts (an initial one plus up to 5
rewrite-and-retry cycles), mirroring the round budget the old speculative loop used.

Reference implementation: [Mikkel Mansa Vilhelmsen's (vhn) fork](https://github.com/vhn/BusinessCentral.AL.Runner),
commit `34c4367a`, where this fix arrived bundled inside unrelated RAD/`--watch` work. Per
the task brief I reimplemented it against current `main` rather than porting that commit —
credited in the commit message and here.

## Correctness evidence (not just speed)

- `AlRunner.Tests/CallSiteArgWrapTests.cs` — pure-Roslyn unit tests against a self-contained
  `ByRef<T>`-shaped stand-in (no BC artifacts needed):
  - the genuine gap is rewritten to the **exact** expected wrap expression
    (`new Some.Namespace.ByRef<int>(() => h.Field, v => h.Field = v)`), and the rewritten
    trees **actually recompile clean** — not just "text changed"
  - `TryRewrite` returns `null` when there are no error diagnostics at all
  - `TryRewrite` returns `null` when a genuine `CS1503` is present but is **not** a
    ByRef-shape conversion (an ordinary type mismatch) — the correctness risk the issue
    calls out explicitly: a real compile error must never be swallowed as "try again"
- `AlRunner.Tests/BcAssemblerCallSiteArgWrapTests.cs` — integration tests against the
  **real** `Microsoft.Dynamics.Nav.Runtime.ByRef<T>` from the BC service tier (gated on
  `TestArtifacts.SkipIfMissing()`, no in-process engine bootstrap needed since
  `BcAssembler.Compile` is a pure metadata-reference compile):
  - a genuine ByRef gap compiles via the on-demand retry, and the assembly is **loaded and
    run** (not just "Success") — proves the wrap is a real get/set round-trip, not just
    syntactically valid
  - a genuine, unrelated `CS1503` compiles to failure with **its own original diagnostic
    text**, unmodified by ever having passed through the rewrite attempt
  - the ordinary no-gap module still compiles and runs correctly (the common-case baseline)

I additionally checked, by hand, that these three integration tests pass identically against
the **old** speculative implementation (temporarily restored, verified byte-for-byte back to
the committed fix afterward via `git diff HEAD`) — i.e. they assert behavioral equivalence,
not "new code ran." DLL-byte comparison between the two implementations is not a valid
equivalence check on its own: Roslyn's `Emit` embeds a fresh MVID per compile even for
*identical* source recompiled twice in a row with the same code (confirmed locally — two
back-to-back runs of the same fixed implementation produced different DLL hashes). The
`CallSiteArgWrapTests` C#-text comparison is the actual byte-identical proof.

## Measurement — my own, on this machine, not the fork's

Corpus: `tests/al-language/tests/al-language`, 581 AL files, cold `--cache`,
`--package-cache ~/.al-runner/platform-apps`, BC 28.1. This box runs several agents plus CI
concurrently, so wall-clock is contended; I ran each side twice.

Whole-process `perf stat -e instructions:u` (load-independent, the only number I'd treat as
solid on this box):

| | instructions retired | wall (contended) |
|---|---|---|
| old (speculative pre-pass) | 654,537,047,369 | 71.5s |
| new (on-demand) | 657,115,916,587 | 70.2s |

Essentially flat — **on this corpus specifically, the net win is small to nil**, not the 47%
of the Roslyn half the issue measured on a different (much larger, quieter) machine. I traced
why, with `BCCOMPILER_TIMING=1` per-module marks and a temporary attempt counter: **every
module in this corpus has zero real ByRef gaps** (confirmed — `attempts=1` for all 4
compiles, every run), and the per-module timing shows the first Roslyn compile in a fresh
process always eats a large, roughly fixed JIT/tiering warm-up cost (~190-240ms per source
for the first module) regardless of whether that first compile is the old speculative pass
or the new real one. Old code's speculative pass paid that warm-up cost and made its
*following* real bind look artificially cheap; new code's single real compile now pays it
directly. So a meaningful slice of the "47%" was warm-up cost moving, not disappearing — real
savings on a gap-free corpus come only from skipping the strictly-cheaper `GetDiagnostics()`
pass, not from skipping a second full bind. On a corpus with a much larger fixed body of work
(the fork's witness was 7,053 files) that warm-up cost amortizes to near-zero and the
remaining savings would look much closer to the original number; on this one it doesn't.

None of this changes the fix's validity — it's still strictly less work in the common
gap-free case (one bind instead of a diagnose-pass-plus-bind), and strictly correct in the
gap-triggering case (proven above). It's just a smaller, noisier win on this particular
corpus than the headline figure, and worth being honest about per the maintainer's steer
that correctness matters more here than the number.

## Same-shape check (`file-issues-for-gaps.md` / the "fix the shape" step)

1. **Same wrong pattern elsewhere?** `CallSiteArgWrap` was the only place in `AlRunner/`
   doing a full throwaway `CSharpCompilation` purely to pre-diagnose before a real one — the
   sibling passes `BcCompiler.Emit`'s "GetSharedReferences" step and the AL-side incremental
   compile (`BcCompiler.Incremental.cs`) both already compile once and use the result. No
   other speculative-compile-then-real-compile pattern found.
2. **Sibling function, same assumption?** `BcAssembler.ParseInParallel` and
   `SharedMetadataReferences` (both touched by #2589, sitting right next to this code) don't
   run any redundant compile — nothing to fix there.
3. **Two paths, same invariant?** N/A here — there's exactly one code path that decides
   whether a call site needs the ByRef wrap now, not two that could drift apart.

## Tests run locally

- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~CallSiteArgWrap|FullyQualifiedName~BcAssemblerParsePipelineTests"` — 17/17 pass
- Full corpus (`tests/al-language/tests/al-language`, 581 files): 2361/2361 pass, exit 0

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf