### PR TITLE
fix(server): select at PROCEDURE granularity for affectedOnly, not whole-object

### DIFF
--- a/AlRunner.Tests/ServerAffectedSelectionTests.cs
+++ b/AlRunner.Tests/ServerAffectedSelectionTests.cs
@@ -180,4 +180,153 @@ public class ServerAffectedSelectionTests
         Assert.Equal(1, ran + skipped);
         Assert.Equal(1, summary.GetProperty("total").GetInt32());
     }
+
+    // #2539: procedure granularity. Two tests cover the SAME object but call DIFFERENT
+    // procedures of it — before #2539, affectedOnly's coverage keys are whole-object, so
+    // editing EITHER procedure reran BOTH tests (AffectedOnly_ChangedObjectRunsOnlyIntersectingTests
+    // above already proves object-level narrowing works across DIFFERENT objects; this proves
+    // narrowing works WITHIN one object, across its procedures).
+    private static string MakeMultiProcBundle()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-server-affected-scope", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "c357c8d5-5f6a-4f52-9e06-6f42ca7e9999",
+          "name": "Server Affected Scope Probe",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 60260, "to": 60269 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Multi.Codeunit.al"), """
+        codeunit 60260 "Affected Multi Proc SX"
+        {
+            procedure ValueA(): Integer
+            begin
+                exit(1);
+            end;
+
+            procedure ValueB(): Integer
+            begin
+                exit(2);
+            end;
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Tests.Codeunit.al"), """
+        codeunit 60261 "Affected Multi Proc Tests SX"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure OnlyA()
+            var
+                H: Codeunit "Affected Multi Proc SX";
+            begin
+                if H.ValueA() <> 1 then
+                    Error('OnlyA failed');
+            end;
+
+            [Test]
+            procedure OnlyB()
+            var
+                H: Codeunit "Affected Multi Proc SX";
+            begin
+                if H.ValueB() <> 2 then
+                    Error('OnlyB failed');
+            end;
+        }
+        """);
+        return dir;
+    }
+
+    [SkippableFact]
+    public async Task AffectedOnly_ProcedureGranularity_EditingOneProcedureRunsOnlyItsTest()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = MakeMultiProcBundle();
+        await using var server = await CliServer.StartAsync(new[] { "--no-cache" });
+
+        await server.SendRequestStreamingAsync(RunTestsRequest(bundle, affectedOnly: true));
+
+        // Edit ONLY ValueA's begin..end body — a genuine, executable statement change, still
+        // returning 1 so OnlyA keeps passing. Deliberately does NOT touch ValueA's own local
+        // `var` section: a local declaration sits outside the procedure's BodyRange exactly
+        // like an object-level one, so it widens too (a MORE conservative posture than the
+        // issue's rule 2 strictly requires, but a safe one) — this test isolates the
+        // executable-statement case specifically.
+        File.WriteAllText(Path.Combine(bundle, "Multi.Codeunit.al"), """
+        codeunit 60260 "Affected Multi Proc SX"
+        {
+            procedure ValueA(): Integer
+            begin
+                if 1 = 1 then;
+                exit(1);
+            end;
+
+            procedure ValueB(): Integer
+            begin
+                exit(2);
+            end;
+        }
+        """);
+
+        var lines = await server.SendRequestStreamingAsync(RunTestsRequest(bundle, affectedOnly: true));
+        var (events, summary) = ProtocolV2Streaming.Split(lines);
+
+        Assert.True(summary.TryGetProperty("selection", out var selection), string.Join(" | ", lines));
+        Assert.False(selection.GetProperty("forcedFull").GetBoolean());
+        // [THEN] only the test that calls ValueA reruns, even though both tests cover the
+        // SAME object — object-level attribution alone (pre-#2539) cannot tell ValueA from
+        // ValueB and reruns both.
+        Assert.Equal(1, selection.GetProperty("ran").GetInt32());
+        Assert.Equal(1, selection.GetProperty("skipped").GetInt32());
+        Assert.Single(events);
+        Assert.EndsWith(".OnlyA", events[0].GetProperty("name").GetString(), StringComparison.Ordinal);
+        Assert.Equal("pass", events[0].GetProperty("status").GetString());
+    }
+
+    [SkippableFact]
+    public async Task AffectedOnly_ProcedureGranularity_NonStatementEditWidensToWholeObject()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = MakeMultiProcBundle();
+        await using var server = await CliServer.StartAsync(new[] { "--no-cache" });
+
+        await server.SendRequestStreamingAsync(RunTestsRequest(bundle, affectedOnly: true));
+
+        // A NON-STATEMENT edit: an object-level variable declaration, which sits OUTSIDE
+        // every procedure's begin..end and carries no StmtHit. This MUST widen to the whole
+        // object — the safety-net rule #2539's issue calls out explicitly — so BOTH tests
+        // rerun, not just neither or an arbitrary one.
+        File.WriteAllText(Path.Combine(bundle, "Multi.Codeunit.al"), """
+        codeunit 60260 "Affected Multi Proc SX"
+        {
+            var
+                Dummy: Integer;
+
+            procedure ValueA(): Integer
+            begin
+                exit(1);
+            end;
+
+            procedure ValueB(): Integer
+            begin
+                exit(2);
+            end;
+        }
+        """);
+
+        var lines = await server.SendRequestStreamingAsync(RunTestsRequest(bundle, affectedOnly: true));
+        var (events, summary) = ProtocolV2Streaming.Split(lines);
+
+        Assert.True(summary.TryGetProperty("selection", out var selection), string.Join(" | ", lines));
+        Assert.False(selection.GetProperty("forcedFull").GetBoolean());
+        Assert.Equal(2, selection.GetProperty("ran").GetInt32());
+        Assert.Equal(0, selection.GetProperty("skipped").GetInt32());
+        Assert.Equal(2, events.Count);
+    }
 }

--- a/AlRunner/AffectedObjectId.cs
+++ b/AlRunner/AffectedObjectId.cs
@@ -22,3 +22,12 @@ namespace AlRunner;
 /// Keep Kind a plain string. Every consumer only ever formats it.
 /// </summary>
 internal readonly record struct AffectedObjectId(string Kind, int? Id, string Name);
+
+/// <summary>
+/// #2539: one changed AL PROCEDURE (or, when <see cref="ScopeName"/> is null, one changed
+/// whole OBJECT — the widened fallback for a non-statement edit, an added/removed file, or
+/// any case <c>PeekChangedScopes</c> cannot attribute with confidence). Carries no NavCA
+/// type for the exact same reason <see cref="AffectedObjectId"/> does not — see that type's
+/// doc comment.
+/// </summary>
+internal readonly record struct AffectedScopeId(AffectedObjectId Object, string? ScopeName);

--- a/AlRunner/BcCompiler.Incremental.cs
+++ b/AlRunner/BcCompiler.Incremental.cs
@@ -190,6 +190,14 @@ internal sealed class RadBaseline
     public required string SharedRefsFingerprint;
     public required NavSymRef.ModuleDefinition ModuleDef;
     public required Dictionary<string, string> FileHashByPath;
+    // #2539: the raw AL source text at the same cycle FileHashByPath's hash was taken,
+    // so a later PeekChangedScopes call can line-diff a modified file against what it
+    // looked like last cycle without re-compiling. Mirrors FileHashByPath's own
+    // path set exactly (populated/pruned together everywhere FileHashByPath is).
+    // Bounded cost: one extra copy of the bundle's own AL source text, proportional to
+    // source size only (not test count) — unlike per-test coverage sets, this does not
+    // grow with the suite.
+    public required Dictionary<string, string> FileContentByPath;
     public required Dictionary<string, RadObjectIdentity> ObjectByPath;
     public required Dictionary<string, EmittedSource> SourceByKey;
     public required BcEmitOutput LastOutput;
@@ -250,6 +258,18 @@ public sealed partial class BcCompiler
     {
         using var stream = File.OpenRead(path);
         return Convert.ToHexString(SHA256.HashData(stream));
+    }
+
+    // #2539: text form of a baseline'd file, for PeekChangedScopes' line-diff. Null (mapped
+    // to "" by callers) rather than throwing on a transient read failure — the baseline
+    // still records the path/hash either way, and a missing/wrong content cache entry only
+    // ever costs a widen (PeekChangedScopes' TryNarrowToChangedScopes treats "no old text"
+    // as "can't diff"), never a silent test loss.
+    private static string? ReadFileTextSafe(string path)
+    {
+        try { return File.ReadAllText(path); }
+        catch (IOException) { return null; }
+        catch (UnauthorizedAccessException) { return null; }
     }
 
     /// <summary>
@@ -672,6 +692,11 @@ public sealed partial class BcCompiler
         foreach (var path in addedPaths.Concat(modifiedPaths)) newFileHashByPath[path] = currentHashes[path];
         foreach (var path in removedPaths) newFileHashByPath.Remove(path);
 
+        var newFileContentByPath = new Dictionary<string, string>(baseline.FileContentByPath, StringComparer.Ordinal);
+        foreach (var path in addedPaths.Concat(modifiedPaths))
+            newFileContentByPath[path] = ReadFileTextSafe(path) ?? "";
+        foreach (var path in removedPaths) newFileContentByPath.Remove(path);
+
         // Rebuilt purely from the final classified buckets (vacated/renamePairs/appeared) —
         // these already cover every path-level change: `vacated` holds both originally-removed
         // files AND in-place-modified files whose old identity never found a rename partner,
@@ -699,6 +724,7 @@ public sealed partial class BcCompiler
             ManifestFingerprint = manifestFingerprint, SharedRefsFingerprint = sharedRefsFingerprint,
             ModuleDef = mergedModuleDef,
             FileHashByPath = newFileHashByPath,
+            FileContentByPath = newFileContentByPath,
             ObjectByPath = newObjectByPath,
             SourceByKey = newSourceByKey,
             LastOutput = output,
@@ -828,6 +854,197 @@ public sealed partial class BcCompiler
         => new(id.Kind.ToString(), id.Id, id.Name);
 
     /// <summary>
+    /// #2539: <see cref="PeekChangedObjects"/> at PROCEDURE granularity. Same side-effect-free
+    /// contract (no <c>CreateForRad</c>, no <c>Emit</c>, no baseline mutation) and the same
+    /// over-inclusive-by-design posture: every entry returned is either a specific changed
+    /// procedure/trigger (<see cref="AffectedScopeId.ScopeName"/> set) or a WHOLE-OBJECT widen
+    /// (<c>ScopeName</c> null) — the caller may safely treat a null-scope entry exactly like a
+    /// <see cref="PeekChangedObjects"/> entry, and null-scope is always the fallback when this
+    /// method is not confident.
+    ///
+    /// Procedure granularity is sound because an added/modified line has NO prior coverage
+    /// record only within the enclosing procedure it lands in — widening a narrowed-down
+    /// change to that whole procedure (never to a single statement/line) means a test that
+    /// executed the procedure at all is always a candidate, so a genuinely-affected test is
+    /// never silently dropped. Three cases MUST widen to the whole OBJECT instead, matching
+    /// #2539's issue body exactly:
+    ///   1. Added/removed files — every procedure in a wholly new file is "new"; no per-
+    ///      procedure record can exist for any of it.
+    ///   2. Non-statement edits — variable declarations, procedure SIGNATURES (a changed
+    ///      return type or parameter list touches the declaration line, which sits OUTSIDE
+    ///      <see cref="AlRunner.Infrastructure.AlMemberSyntax.BodyRange"/>, so it never
+    ///      matches any member and this method widens automatically), table fields, page
+    ///      properties, attributes — none carry a StmtHit.
+    ///   3. Any uncertainty at all: the changed line range spans more than one procedure,
+    ///      falls in neither, this file's old text was never cached (no
+    ///      <c>RadBaseline.FileContentByPath</c> entry), or an in-place rename (the file now
+    ///      declares a DIFFERENT object than baseline recorded at that path).
+    ///
+    /// Returns null under the exact same conditions <see cref="PeekChangedObjects"/> does
+    /// (no baseline yet, an untracked removal, an unclassifiable touched file) — the caller
+    /// MUST treat null as "unknown, do not narrow", never as "nothing changed".
+    /// </summary>
+    internal IReadOnlyList<AffectedScopeId>? PeekChangedScopes(
+        IEnumerable<string> alFolders, string moduleName, string? appRootDir)
+    {
+        if (!_radBaselines.TryGetValue(moduleName, out var baseline))
+            return null;
+
+        var dirs = alFolders.Where(Directory.Exists).Distinct().ToList();
+        var alFiles = dirs.SelectMany(d => AlRunner.Infrastructure.SafeDirectoryScan.Files(d, "*.al")).Distinct().ToList();
+
+        var manifestAppJsonPath = (appRootDir != null && File.Exists(Path.Combine(appRootDir, "app.json")))
+            ? Path.Combine(appRootDir, "app.json")
+            : dirs.Select(d => Path.Combine(d, "app.json")).FirstOrDefault(File.Exists);
+        var manifestInputs = ReadManifestCompilerInputs(manifestAppJsonPath);
+
+        var currentHashes = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var f in alFiles) currentHashes[f] = HashFile(f);
+
+        var addedPaths = new List<string>();
+        var removedPaths = new List<string>();
+        var modifiedPaths = new List<string>();
+        foreach (var kv in currentHashes)
+        {
+            if (!baseline.FileHashByPath.TryGetValue(kv.Key, out var oldHash)) addedPaths.Add(kv.Key);
+            else if (!string.Equals(oldHash, kv.Value, StringComparison.Ordinal)) modifiedPaths.Add(kv.Key);
+        }
+        foreach (var oldPath in baseline.FileHashByPath.Keys)
+            if (!currentHashes.ContainsKey(oldPath)) removedPaths.Add(oldPath);
+
+        if (addedPaths.Count == 0 && removedPaths.Count == 0 && modifiedPaths.Count == 0)
+            return Array.Empty<AffectedScopeId>();
+
+        var parseOpts = RadParseOptions(manifestInputs);
+        var compOpts = RadCompilationOptions(manifestInputs);
+        var changed = new List<AffectedScopeId>();
+        var seenWhole = new HashSet<RadObjectIdentity>();
+        void AddWhole(RadObjectIdentity id)
+        {
+            if (seenWhole.Add(id)) changed.Add(new AffectedScopeId(ToAffectedObjectId(id), null));
+        }
+
+        foreach (var path in removedPaths)
+        {
+            if (!baseline.ObjectByPath.TryGetValue(path, out var oldIdentity))
+                return null; // untracked removal — only the real compile path can adjudicate this
+            AddWhole(oldIdentity);
+        }
+
+        // Rule 1: a wholly new file — every procedure in it is new, no prior record exists.
+        foreach (var path in addedPaths)
+        {
+            NavSyntax.SyntaxTree tree;
+            try
+            {
+                var src = File.ReadAllText(path);
+                tree = NavSyntax.SyntaxTree.ParseObjectText(src, path: path, encoding: null!, parseOpts, default);
+            }
+            catch { return null; }
+            var (identity, _) = ClassifyDeclaredObject(tree, compOpts);
+            if (identity == null) return null;
+            AddWhole(identity.Value);
+        }
+
+        foreach (var path in modifiedPaths)
+        {
+            NavSyntax.SyntaxTree tree;
+            string newSrc;
+            try
+            {
+                newSrc = File.ReadAllText(path);
+                tree = NavSyntax.SyntaxTree.ParseObjectText(newSrc, path: path, encoding: null!, parseOpts, default);
+            }
+            catch { return null; }
+
+            var (identity, _) = ClassifyDeclaredObject(tree, compOpts);
+            if (identity == null) return null;
+
+            // An in-place rename (this path now declares a DIFFERENT identity than baseline
+            // recorded there) — same over-inclusive treatment as PeekChangedObjects: report
+            // BOTH the vacated old identity and the new one, whole-object, no attempt to narrow.
+            if (baseline.ObjectByPath.TryGetValue(path, out var oldIdentityAtSamePath)
+                && IdentityKey(oldIdentityAtSamePath) != IdentityKey(identity.Value))
+            {
+                AddWhole(oldIdentityAtSamePath);
+                AddWhole(identity.Value);
+                continue;
+            }
+
+            if (!baseline.FileContentByPath.TryGetValue(path, out var oldSrc))
+            {
+                AddWhole(identity.Value); // rule 3: no cached old text to diff against
+                continue;
+            }
+
+            var scopeName = TryNarrowToChangedScope(oldSrc, newSrc, path);
+            if (scopeName == null)
+            {
+                AddWhole(identity.Value); // rules 2/3: signature/non-statement edit, or uncertain
+                continue;
+            }
+            changed.Add(new AffectedScopeId(ToAffectedObjectId(identity.Value), scopeName));
+        }
+
+        return changed
+            .OrderBy(c => c.Object.Kind, StringComparer.Ordinal)
+            .ThenBy(c => c.Object.Id ?? int.MaxValue)
+            .ThenBy(c => c.Object.Name, StringComparer.Ordinal)
+            .ThenBy(c => c.ScopeName ?? "", StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    /// <summary>
+    /// The single procedure/trigger a MODIFIED file's changed lines fall entirely within, or
+    /// null when the change cannot be attributed to exactly one (multiple members, no member
+    /// at all — a signature/declaration/property edit — or the change window could not be
+    /// computed). Uses a plain common-prefix/common-suffix line trim, not a full diff: it is
+    /// deliberately over-inclusive when a file has more than one disjoint edit (the trim then
+    /// reports one span covering from the first to the last differing line, which can include
+    /// unchanged lines in between) — safe, because a wider window can only make this method
+    /// find MORE than one containing member and widen to the whole object, never attribute to
+    /// the WRONG single procedure.
+    /// </summary>
+    private static string? TryNarrowToChangedScope(string oldSrc, string newSrc, string path)
+    {
+        var oldLines = SplitLines(oldSrc);
+        var newLines = SplitLines(newSrc);
+        var minLen = Math.Min(oldLines.Length, newLines.Length);
+
+        var prefix = 0;
+        while (prefix < minLen && string.Equals(oldLines[prefix], newLines[prefix], StringComparison.Ordinal))
+            prefix++;
+
+        var suffix = 0;
+        while (suffix < minLen - prefix
+               && string.Equals(oldLines[oldLines.Length - 1 - suffix], newLines[newLines.Length - 1 - suffix], StringComparison.Ordinal))
+            suffix++;
+
+        var changeStartLine = prefix; // 0-based, inclusive
+        var changeEndLineExclusive = newLines.Length - suffix;
+        if (changeEndLineExclusive <= changeStartLine)
+            return null; // nothing left in the NEW file to attribute (e.g. a pure deletion at the boundary)
+        var changeEndLine = changeEndLineExclusive - 1; // 0-based, inclusive
+
+        IReadOnlyList<AlRunner.Infrastructure.AlMemberSyntax> members;
+        try { members = AlRunner.Infrastructure.AlMemberSyntaxIndex.Parse(newSrc, path); }
+        catch { return null; }
+
+        // Membership by LINE only (not column) — the diff above is already line-granular, so
+        // comparing at line granularity introduces no additional imprecision.
+        string? found = null;
+        foreach (var m in members)
+        {
+            if (m.BodyRange.Start.Line > changeStartLine || changeEndLine > m.BodyRange.End.Line) continue;
+            if (found != null) return null; // spans/touches more than one member — widen
+            found = m.QualifiedName;
+        }
+        return found;
+    }
+
+    private static string[] SplitLines(string text) => text.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+
+    /// <summary>
     /// Called by <see cref="Emit"/> after a clean success, when its caller passed
     /// <c>trackIncrementalBaseline: true</c>. Builds the (Kind,Id-or-Name)-keyed state
     /// <see cref="TryEmitIncremental"/> needs for the NEXT cycle, for every object kind (see
@@ -938,6 +1155,8 @@ public sealed partial class BcCompiler
 
         var fileHashByPath = new Dictionary<string, string>(StringComparer.Ordinal);
         foreach (var f in alFiles) fileHashByPath[f] = HashFile(f);
+        var fileContentByPath = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var f in alFiles) fileContentByPath[f] = ReadFileTextSafe(f) ?? "";
 
         var manifestFingerprint = RadManifestFingerprint(appId, publisher, version, manifestInputs, manifestAppJsonPath);
         var sharedRefsFingerprint = string.Join(",", specs.Select(s => $"{s.AppId}:{s.Version}").OrderBy(s => s, StringComparer.Ordinal));
@@ -948,6 +1167,7 @@ public sealed partial class BcCompiler
             ManifestFingerprint = manifestFingerprint, SharedRefsFingerprint = sharedRefsFingerprint,
             ModuleDef = moduleDef,
             FileHashByPath = fileHashByPath,
+            FileContentByPath = fileContentByPath,
             ObjectByPath = objectByPath,
             SourceByKey = sourceByKey,
             LastOutput = fullOutput,

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3558,7 +3558,11 @@ return strictExitCode ? computedExitCode : 0;
         Func<Assembly, IReadOnlyList<TestResult>> runStep,
         System.Threading.CancellationToken cancellationToken = default,
         bool useIncrementalChangeModel = false,
-        Action<string, string, string, IReadOnlyList<AffectedObjectId>?, string?>? beforeRun = null)
+        // #2539: 6th arg is the REQUEST-WIDE procedure-granular peek (PeekChangedScopes,
+        // unioned across every bundle — see requestWideChangedScopes), appended by the
+        // effectiveBeforeRun wrap below. RunBundleForServer's own (5-arg) beforeRun delegate
+        // is unchanged, since it has no access to that request-wide list.
+        Action<string, string, string, IReadOnlyList<AffectedObjectId>?, string?, IReadOnlyList<AffectedScopeId>?>? beforeRun = null)
     {
         // Server requests share a process, so give each request the same fresh
         // NumberSequence lifetime as a standalone CLI/watch execution.
@@ -3657,9 +3661,25 @@ return strictExitCode ? computedExitCode : 0;
         // Per bundle: how many objects its own peek saw change, or null when the peek could not
         // answer for it. See ChangedDependencyForcesFullCompile below.
         var peekedChangedCountByBundle = new Dictionary<string, int?>(StringComparer.OrdinalIgnoreCase);
-        if (useIncrementalChangeModel && sourcePaths.Length > 1)
+        // #2539: procedure-granular peek, unioned across EVERY bundle in the request — the
+        // scope-level mirror of requestWideChangedObjects above, and for the same reason:
+        // Pageworks/Pageworks.Test is a real repro where the edited procedure lives in the
+        // DEPENDENCY bundle and the tests that could narrow live in the SEPARATE test bundle,
+        // so restricting this signal to "a bundle's own peek only" would leave the #2535-fixed
+        // multi-bundle shape with zero additional narrowing from #2539. Unlike
+        // requestWideChangedObjects, a single uncertain/null bundle does NOT null the whole
+        // list — this signal is a pure OPTIMIZATION on top of the object-level keys
+        // BuildAffectedChangedKeys always falls back to, so one bundle's peek failing only
+        // costs that bundle's own refinement, never anyone's correctness. Also unlike
+        // requestWideChangedObjects, populated even for a single-bundle request — procedure
+        // narrowing is useful there too, so it is not gated on sourcePaths.Length > 1.
+        // peekedChangedCountByBundle stays only populated where requestWideChangedObjects is
+        // non-null (i.e. sourcePaths.Length > 1) below — its only consumer,
+        // ChangedLaterDependencyBundles, already no-ops on fewer than two bundles.
+        var requestWideChangedScopes = new List<AffectedScopeId>();
+        if (useIncrementalChangeModel)
         {
-            requestWideChangedObjects = new List<AffectedObjectId>();
+            if (sourcePaths.Length > 1) requestWideChangedObjects = new List<AffectedObjectId>();
             foreach (var peekBundleDir in sourcePaths)
             {
                 var peekAbs = Path.GetFullPath(peekBundleDir);
@@ -3669,6 +3689,11 @@ return strictExitCode ? computedExitCode : 0;
                 foreach (var suite in EnumerateSuites(peekAbs))
                     peekPaths.AddRange(CollectSuitePaths(suite, peekBucketRoot));
                 peekPaths = peekPaths.Distinct().ToList();
+
+                var peekedScopes = emitter.PeekChangedScopes(peekPaths, peekModuleName, peekBucketRoot);
+                if (peekedScopes != null) requestWideChangedScopes.AddRange(peekedScopes);
+
+                if (requestWideChangedObjects == null) continue; // single-bundle request: no cross-bundle union needed
 
                 var peeked = emitter.PeekChangedObjects(peekPaths, peekModuleName, peekBucketRoot);
                 // #2603: the same peek answers a second question — "did THIS bundle change this
@@ -3682,9 +3707,10 @@ return strictExitCode ? computedExitCode : 0;
                     // Null the whole union: every bundle below then merges nothing new in and
                     // keeps whatever its OWN cycle already decided, same as before this fix —
                     // never worse than the pre-#2492 behaviour, only better when every bundle's
-                    // own change set peeks clean.
+                    // own change set peeks clean. #2539: keep peeking later bundles' OWN scopes
+                    // above regardless — that signal is independent of this union.
                     requestWideChangedObjects = null;
-                    break;
+                    continue;
                 }
                 requestWideChangedObjects.AddRange(peeked);
             }
@@ -3728,7 +3754,11 @@ return strictExitCode ? computedExitCode : 0;
         // Same forward-only, `sourcePaths`-order limitation as the selection half above, and for
         // the same reason. #2571 tracks the order-independent version.
         string? sawFallbackReason = null;
-        var effectiveBeforeRun = beforeRun;
+        // #2539: explicitly typed as the 5-arg shape RunBundleForServer actually calls (see
+        // its own beforeRun parameter below) — `beforeRun` itself is now 6-arg (carries the
+        // ownChangedScopes lookup), so `var effectiveBeforeRun = beforeRun` would infer the
+        // wrong delegate type here.
+        Action<string, string, string, IReadOnlyList<AffectedObjectId>?, string?>? effectiveBeforeRun = null;
         if (beforeRun != null)
         {
             var union = requestWideChangedObjects;
@@ -3741,7 +3771,11 @@ return strictExitCode ? computedExitCode : 0;
                         : null);
                 if (changeModelFallbackReason != null)
                     sawFallbackReason ??= $"{moduleName}: {changeModelFallbackReason}";
-                beforeRun(bundlePath, moduleName, selectionEnvironmentKey, merged, effectiveFallbackReason);
+                // #2539: the SAME request-wide scope list for every bundle — narrowing an
+                // object changed in bundle A is legitimate for a test in bundle B exactly
+                // when A's change is legitimate for B's overlap check at all (i.e. it is
+                // already present in `merged` above, via the object-level union).
+                beforeRun(bundlePath, moduleName, selectionEnvironmentKey, merged, effectiveFallbackReason, requestWideChangedScopes);
             };
         }
 
@@ -4876,6 +4910,61 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
             ? $"{id.Kind} {id.Id.Value} {id.Name}"
             : $"{id.Kind} {id.Name}";
 
+    // #2539: the SAME compound key both the changed side (below) and the coverage-attribution
+    // side (the collectPerTestForSelection loop) must build for a specific changed procedure —
+    // an object-level key plus its scope name, separated so it can never collide with a bare
+    // ToAffectedObjectKey result (no AL identifier can contain "::").
+    static string ToAffectedScopeKey(string objectKey, string scopeName) => $"{objectKey}::proc:{scopeName}";
+
+    /// <summary>
+    /// Builds the set affectedOnly's overlap check compares a test's coveredObjects against —
+    /// object-level keys by default (identical to pre-#2539 behaviour), REFINED to a
+    /// procedure-level compound key wherever <paramref name="requestWideChangedScopes"/> (the
+    /// REQUEST-WIDE <c>PeekChangedScopes</c> union — every bundle in the request, not just
+    /// this one, mirroring #2492's own object-level union) confidently narrowed that SAME
+    /// object this cycle. An object <paramref name="requestWideChangedScopes"/> explicitly
+    /// widened (a null-ScopeName entry) is NEVER narrowed, even if some other entry for the
+    /// same object looks narrow — the widen always wins. An object with NO entry in
+    /// <paramref name="requestWideChangedScopes"/> at all (its own bundle's peek was
+    /// uncertain, or #2539's scope-level peek simply hasn't run for it) falls back to the
+    /// plain object-level key — the same safe default as pre-#2539.
+    /// </summary>
+    static HashSet<string>? BuildAffectedChangedKeys(
+        IReadOnlyList<AffectedObjectId>? changedObjects, IReadOnlyList<AffectedScopeId>? requestWideChangedScopes)
+    {
+        if (changedObjects == null) return null;
+
+        var widenedObjectKeys = new HashSet<string>(StringComparer.Ordinal);
+        var scopesByObjectKey = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        if (requestWideChangedScopes != null)
+        {
+            foreach (var sc in requestWideChangedScopes)
+            {
+                var objKey = ToAffectedObjectKey(sc.Object);
+                if (sc.ScopeName == null) { widenedObjectKeys.Add(objKey); continue; }
+                if (!scopesByObjectKey.TryGetValue(objKey, out var list))
+                    scopesByObjectKey[objKey] = list = new List<string>();
+                list.Add(sc.ScopeName);
+            }
+        }
+
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var id in changedObjects)
+        {
+            var objKey = ToAffectedObjectKey(id);
+            if (!widenedObjectKeys.Contains(objKey)
+                && scopesByObjectKey.TryGetValue(objKey, out var scopes) && scopes.Count > 0)
+            {
+                foreach (var s in scopes) keys.Add(ToAffectedScopeKey(objKey, s));
+            }
+            else
+            {
+                keys.Add(objKey);
+            }
+        }
+        return keys;
+    }
+
     // Sets executor.Isolation from req.TestIsolation (see #1616), falling back to
     // defaultServerIsolation when the request doesn't specify one. Returns an
     // error response string on an unrecognised mode, else null.
@@ -5051,13 +5140,12 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                 },
                 cts.Token,
                 affectedOnly,
-                (bundlePath, moduleName, selectionEnvironmentKey, changedObjects, changeModelFallbackReason) =>
+                (bundlePath, moduleName, selectionEnvironmentKey, changedObjects, changeModelFallbackReason, ownChangedScopes) =>
                 {
                     activeBundleKey = bundlePath;
                     requestModuleByBundle[bundlePath] = moduleName;
                     requestEnvironmentByBundle[bundlePath] = selectionEnvironmentKey;
-                    activeChangedObjectKeys = changedObjects?.Select(ToAffectedObjectKey)
-                        .ToHashSet(StringComparer.Ordinal);
+                    activeChangedObjectKeys = BuildAffectedChangedKeys(changedObjects, ownChangedScopes);
                     activeChangedObjectDisplay = (changedObjects ?? Array.Empty<AffectedObjectId>())
                         .Select(ToAffectedObjectDisplay)
                         .Distinct(StringComparer.Ordinal)
@@ -5227,7 +5315,17 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                                 unmappable = true;
                                 break;
                             }
-                            coveredObjects.Add(ToAffectedObjectKey(identity));
+                            var objKey = ToAffectedObjectKey(identity);
+                            coveredObjects.Add(objKey);
+                            // #2539: ALSO record the procedure-level compound key for this
+                            // statement's scope, so a test whose coverage never leaves the one
+                            // procedure that changed can be selected WITHOUT the plain
+                            // object-level key matching every other test that merely touched a
+                            // DIFFERENT procedure of the same object. The plain object-level key
+                            // stays too — it is what makes a WIDENED (whole-object) changed
+                            // entry still match every test that covered the object at all.
+                            if (!string.IsNullOrEmpty(s.ScopeName))
+                                coveredObjects.Add(ToAffectedScopeKey(objKey, s.ScopeName));
                         }
 
                         if (unmappable || coveredObjects.Count == 0)


### PR DESCRIPTION
No linked issue: this PR implements only the procedure-granularity half the maintainer scoped on issue 2539; statement granularity is deferred and that issue stays open for the follow-up. (Written without a closing keyword next to the issue number on purpose — GitHub's parser fires on the pattern regardless of the surrounding prose, so a sentence saying the PR does NOT close it would close it anyway. See PR #2127.)

## What this does

Coverage already carries per-statement `ScopeName` (`AlCoverageTracker.AlStatementRecord`); the selection loop in `Program.cs` threw it away and kept only a whole-object key, so editing any one procedure of a multi-procedure object reran every test that touched that object anywhere — regardless of which procedure it actually called.

Adds a compound `"object::proc:scope"` key alongside the existing whole-object key on both sides of the overlap check:

- **Coverage side**: the attribution loop now records both keys per touched scope, so a test's `coveredObjects` can match either a whole-object widen or a specific-procedure narrow.
- **Changed side**: new `BcCompiler.PeekChangedScopes` (side-effect-free, mirrors `PeekChangedObjects`'s contract exactly) line-diffs a modified file against its cached previous text (`RadBaseline.FileContentByPath`, new) and maps the changed line range to the one enclosing procedure via `AlMemberSyntaxIndex`'s existing `BodyRange` data — no new parsing/instrumentation needed.

Widens to the whole object whenever attribution isn't confident: added/removed files, an in-place rename, no cached previous text, the changed range touching more than one procedure, or (the common real case) a variable declaration/procedure signature/property that sits outside any procedure's `begin..end` and carries no `StmtHit`.

Unioned across the **whole request** (not just a bundle's own peek), same as #2492/#2535's own changed-object union — otherwise the Pageworks/Pageworks.Test shape (edited procedure in the dependency bundle, narrowing tests live in the separate test bundle) would see zero benefit from this fix.

## Measurement — real corpus, before/after

Pageworks + Pageworks.Test (1012 tests), same repro as #2535:

| edit | object-level narrowing (#2535 alone) | + procedure granularity (this PR) |
|---|---|---|
| `Descent` (one procedure of `PageworksFontMetrics`) | 119 ran | **107 ran** — a further ~10% reduction from procedure attribution |
| `RunLengthAt` (a low-level helper hit by nearly every decode-path test) | 110 ran | 110 ran — no further narrowing |

The second row is an honest result, not a defect — I confirmed via instrumentation (not left in this diff) that the compound key resolves correctly to `Codeunit|id:71179699::proc:RunLengthAt` in both requests; all 110 tests whose coverage overlaps that codeunit at all genuinely execute that specific helper too, since it's a shared inner-loop routine nearly every decode test reaches.

## Cost measurement (the issue asked for this explicitly)

On the same corpus, cycle-1 coverage-set size: **avg 114 entries/test (min 2, max 794)** across 906 tests with a coverage entry that cycle — up from ~1 entry/test (object-only) before request-wide attribution. That's about 8.6MB of key-string content, roughly 13–14MB including `HashSet`/string object overhead, held for the life of a warm `--server` process (proportional to corpus size and call-graph breadth, not to wall-clock).

The per-test `HashSet<string>.Overlaps` comparison cost is negligible — microseconds per test, dwarfed by actual test execution time. **String keys are not too expensive at this scale; I'm not introducing a more compact representation (hashed ids/bitsets).**

## Fix the shape, not just the line

- **Same wrong pattern elsewhere?** `TryGetTrackedObjectsByPath`/`PeekChangedObjects` had exactly one real call site each (both already fixed/extended here and in #2535) — no sibling instance of "per-module instead of request-wide" left.
- **Sibling function, same assumption?** `TryEmitIncremental`'s own real per-bundle change detection stays whole-object-only — deliberately not touched here; `PeekChangedScopes` is a side-effect-free ADDITIONAL signal layered on top, not a replacement, to keep this change contained. Flagged as a legitimate scope boundary, not an oversight.
- **Two paths, same invariant?** Yes — coverage side and changed side both support scope-level keys uniformly now; before this PR only the coverage side had `ScopeName` data available, and it was discarded.

## Tests

`AlRunner.Tests/ServerAffectedSelectionTests.cs`, two new tests:

- `AffectedOnly_ProcedureGranularity_EditingOneProcedureRunsOnlyItsTest` — two tests cover the SAME object via DIFFERENT procedures; editing one procedure's body reruns only the test that calls it.
  - RED confirmed against the pre-#2539 code (`git checkout HEAD~1 -- <paths>`, restored byte-for-byte afterward and diffed to confirm): `ran: 2` (both reran — object-level attribution can't tell the procedures apart).
  - GREEN with the fix: `ran: 1, skipped: 1`.
- `AffectedOnly_ProcedureGranularity_NonStatementEditWidensToWholeObject` — an object-level `var` declaration (outside any procedure body) correctly widens to the whole object; both tests rerun. This passed even pre-fix (everything was already whole-object then) — it's the regression guard for the widening safety net once narrowing is live.

Regression check: `Server*`/`Incremental*`/`Affected*` AlRunner.Tests surface — 125 passed, 18 skipped (missing artifacts), 0 failed.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
