### PR TITLE
fix(streams): implement ALCompiler.DotNetToNavInStream (.NET Stream -> AL InStream)

### DIFF
--- a/AlRunner.Tests/AlCompilerDotNetInStreamCecilBindingTests.cs
+++ b/AlRunner.Tests/AlCompilerDotNetInStreamCecilBindingTests.cs
@@ -1,0 +1,113 @@
+// AlCompilerDotNetInStreamCecilBindingTests — proves the #2576 fix: ALCompiler's REAL
+// DotNetToNavInStream(ITreeObject, NavDotNet) — after NclCecilRewrite has run — is a real,
+// working Cecil-owned rewrite, not a body that still NREs/ArgumentNullExceptions on the
+// headless skeleton's null Session.Company.SharedObjects chain.
+//
+// This is deliberately a RUNNER-INTERNAL claim, not a BC-behaviour one: it asserts that OUR
+// Cecil rewrite pipeline actually reaches ALCompiler.DotNetToNavInStream (registered in
+// NclCecilRewrite.CecilOwned) and that the helper it delegates to
+// (BcRuntime.ALCompiler_DotNetToNavInStream / AlCompilerStreamPatches.cs) produces a real,
+// readable NavInStream over the given .NET stream, refuses null and non-Stream values the
+// same way the real body does. Whether AL source code that assigns a DotNet MemoryStream to
+// an InStream variable reads back the exact content is a plain BC-behaviour claim and
+// belongs upstream — see StefanMaron/BusinessCentral.AL.Language.Tests#137
+// (tests/al-language/streams/TestDotNetInStream.al), and the equivalent end-to-end proof
+// run locally against that corpus branch (RED before this fix, GREEN after — see the PR
+// description for #2576).
+using System.Reflection;
+using AlRunner.Infrastructure;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Loads Ncl types in-process (must share the serial bc-engine collection — see
+// BcEngineCollection.cs comment header).
+[Collection(BcEngineCollection.Name)]
+public sealed class AlCompilerDotNetInStreamCecilBindingTests
+{
+    private readonly BcEngineFixture _engine;
+
+    public AlCompilerDotNetInStreamCecilBindingTests(BcEngineFixture engine) => _engine = engine;
+
+    [Fact]
+    public void DotNetToNavInStream_KeyIsCecilOwned()
+    {
+        Assert.Contains(
+            "Microsoft.Dynamics.Nav.Runtime.ALCompiler::DotNetToNavInStream/2",
+            NclCecilRewrite.CecilOwned);
+    }
+
+    private static (Type AlCompiler, MethodInfo DotNetToNavInStream, Type NavDotNet, ConstructorInfo NavDotNetCtor)
+        ResolveNclSurface()
+    {
+        var nclAsm = typeof(ITreeObject).Assembly;
+        var alCompiler = nclAsm.GetType("Microsoft.Dynamics.Nav.Runtime.ALCompiler")!;
+        var tITreeObject = nclAsm.GetType("Microsoft.Dynamics.Nav.Runtime.ITreeObject")!;
+        var tNavDotNet = nclAsm.GetType("Microsoft.Dynamics.Nav.Runtime.NavDotNet")!;
+        var method = alCompiler.GetMethod("DotNetToNavInStream",
+            BindingFlags.Public | BindingFlags.Static, null, new[] { tITreeObject, tNavDotNet }, null)!;
+        // Public .ctor(ITreeObject parent, Object dotNetValue, Boolean runOnClient, Boolean suppressDispose).
+        var ctor = tNavDotNet.GetConstructor(new[] { tITreeObject, typeof(object), typeof(bool), typeof(bool) })!;
+        return (alCompiler, method, tNavDotNet, ctor);
+    }
+
+    [SkippableFact]
+    public void DotNetToNavInStream_NullObj_ReturnsDefaultInStream_NotNRE()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var (_, method, _, _) = ResolveNclSurface();
+
+        var result = method.Invoke(null, new object?[] { BcRuntime.RootTreeStub, null });
+
+        Assert.NotNull(result);
+        Assert.Equal("Microsoft.Dynamics.Nav.Runtime.NavInStream", result!.GetType().FullName);
+    }
+
+    [SkippableFact]
+    public void DotNetToNavInStream_WrappedMemoryStream_ProducesAReadableNavInStream()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var (_, method, _, navDotNetCtor) = ResolveNclSurface();
+
+        var payload = System.Text.Encoding.UTF8.GetBytes("mechanism test payload");
+        var mem = new MemoryStream(payload);
+        var navDotNet = navDotNetCtor.Invoke(new object?[] { BcRuntime.RootTreeStub, mem, false, true });
+
+        var navInStream = method.Invoke(null, new object?[] { BcRuntime.RootTreeStub, navDotNet });
+
+        Assert.NotNull(navInStream);
+        Assert.Equal("Microsoft.Dynamics.Nav.Runtime.NavInStream", navInStream!.GetType().FullName);
+
+        // Prove it is genuinely readable and reads OUR bytes — not just an object of the
+        // right type — via the real INavStreamReader.ReadByte() (single-byte reads, the
+        // narrowest surface NavInStream exposes without pulling in AL's own ReadText
+        // plumbing, which is a separate compiler-emitted mechanism this test has no
+        // reason to reach through).
+        var reader = (INavStreamReader)navInStream;
+        Assert.Equal(payload[0], reader.ReadByte());
+        Assert.Equal(payload[1], reader.ReadByte());
+    }
+
+    [SkippableFact]
+    public void DotNetToNavInStream_NonStreamValue_ThrowsConversionException()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var (_, method, _, navDotNetCtor) = ResolveNclSurface();
+
+        var navDotNet = navDotNetCtor.Invoke(new object?[] { BcRuntime.RootTreeStub, "not a stream", false, true });
+
+        var ex = Assert.Throws<TargetInvocationException>(
+            () => method.Invoke(null, new object?[] { BcRuntime.RootTreeStub, navDotNet }));
+
+        Assert.Equal(
+            "Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLConversionException",
+            ex.InnerException!.GetType().FullName);
+    }
+}

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -409,6 +409,11 @@ public static class NclCecilRewrite
         "Microsoft.Dynamics.Nav.Runtime.ALTaskScheduler::ALCanCreateTask/1",
         "Microsoft.Dynamics.Nav.Runtime.ALTaskScheduler::CanCreateTask/1",
         "Microsoft.Dynamics.Nav.Runtime.ALTaskScheduler::CheckCodeUnit/2",
+        // ALCompiler.DotNetToNavInStream — mirror of the DotNetToNavOutStream fallback
+        // above (#2576): same skeleton SharedObjects issue, structurally identical real
+        // body (three branches: null → Default, Stream → NavStreamProvider-backed
+        // instance, else → NavNCLConversionException), just the InStream direction.
+        "Microsoft.Dynamics.Nav.Runtime.ALCompiler::DotNetToNavInStream/2",
     };
 
     /// <summary>
@@ -2443,6 +2448,29 @@ public static class NclCecilRewrite
             ReplaceBodyWithHelper(asm.MainModule, dotNetToNavOutStream,
                 nameof(AlRunner.BcRuntime.ALCompiler_DotNetToNavOutStream));
             Console.Error.WriteLine("[Cecil] Rewrote ALCompiler.DotNetToNavOutStream → BcRuntime helper (skeleton SharedObjects fallback)");
+        }
+
+        // ALCompiler.DotNetToNavInStream (#2576) — same fix as DotNetToNavOutStream just
+        // above, InStream direction. Decompiling both methods off the same cached Ncl
+        // (bc281, Microsoft.Dynamics.Nav.Runtime.ALCompiler.DotNetToNavInStream /
+        // .DotNetToNavOutStream) shows they are STRUCTURALLY IDENTICAL — same three
+        // branches (null → Default, Stream → NavStreamProvider-backed instance, else →
+        // NavNCLConversionException), only the NavInStream/NavOutStream type differs —
+        // so this is the same skeleton-SharedObjects gap the OutStream side already
+        // fixed, not a new investigation. RED→GREEN:
+        // tests/runner-extras/standalone-suites/dotnet-instream (added in this PR); the
+        // upstream BC-behaviour claim is pinned in
+        // StefanMaron/BusinessCentral.AL.Language.Tests#137
+        // (tests/al-language/streams/TestDotNetInStream.al).
+        {
+            var alCompilerType = asm.MainModule.GetType("Microsoft.Dynamics.Nav.Runtime.ALCompiler")
+                ?? throw new InvalidOperationException("ALCompiler not found in Ncl — shape changed");
+            var dotNetToNavInStream = alCompilerType.Methods.FirstOrDefault(m =>
+                m.Name == "DotNetToNavInStream" && m.Parameters.Count == 2)
+                ?? throw new InvalidOperationException("ALCompiler.DotNetToNavInStream/2 not found — shape changed");
+            ReplaceBodyWithHelper(asm.MainModule, dotNetToNavInStream,
+                nameof(AlRunner.BcRuntime.ALCompiler_DotNetToNavInStream));
+            Console.Error.WriteLine("[Cecil] Rewrote ALCompiler.DotNetToNavInStream → BcRuntime helper (skeleton SharedObjects fallback)");
         }
 
         // NavHttpClient egress (ALGet/ALPost/ALPut/ALDelete/ALPatch + their *Async and

--- a/AlRunner/Patches/AlCompilerStreamPatches.cs
+++ b/AlRunner/Patches/AlCompilerStreamPatches.cs
@@ -1,6 +1,9 @@
-// AlCompilerStreamPatches — replacement for ALCompiler.DotNetToNavOutStream.
+// AlCompilerStreamPatches — replacement for ALCompiler.DotNetToNavOutStream AND
+// ALCompiler.DotNetToNavInStream (#2576 — the InStream direction).
 //
-// The real body (Ncl.dll, runtime engine — ours to patch) is:
+// The real bodies (Ncl.dll, runtime engine — ours to patch) are structurally identical,
+// confirmed by decompiling both off the same cached Ncl assembly — only the
+// NavOutStream/NavInStream type differs:
 //
 //     public static NavOutStream DotNetToNavOutStream(ITreeObject parentOfResult, NavDotNet obj)
 //     {
@@ -11,19 +14,30 @@
 //         throw new NavNCLConversionException(obj.GetType(), typeof(NavOutStream));
 //     }
 //
-// On the headless skeleton `Session.Company` / `Company.SharedObjects` is null, so any
-// AL code that marshals a .NET Stream into an OutStream dies with an NRE (or an
-// ArgumentNullException from the TreeObject base ctor when Company exists but
-// SharedObjects is null). The hottest consumer is System Application CU 1279
-// "Cryptography Management Impl." GenerateHash(InStream, HashAlgorithmType), which wraps
-// a .NET MemoryStream in a NavDotNet and calls this method before hashing.
+//     public static NavInStream DotNetToNavInStream(ITreeObject parentOfResult, NavDotNet obj)
+//     {
+//         if (obj == null) return NavInStream.Default(parentOfResult);
+//         if (obj.Value is Stream stream)
+//             return new NavInStream(parentOfResult,
+//                 new NavStreamProvider(stream, parentOfResult.Tree.Session.Company.SharedObjects));
+//         throw new NavNCLConversionException(obj.GetType(), typeof(NavInStream));
+//     }
 //
-// SCOPE AUDIT (loud-failures rule): this replacement is observably equivalent to the
-// real BC behaviour for in-scope test code. It reproduces the real body's three branches
-// exactly (null → Default, Stream → NavOutStream over a NavStreamProvider, anything else
-// → NavNCLConversionException with the same argument types). The ONLY divergence is the
-// shared-object container the NavStreamProvider is parented to: the real session
-// container when present, otherwise the same process-wide skeleton
+// On the headless skeleton `Session.Company` / `Company.SharedObjects` is null, so any
+// AL code that marshals a .NET Stream into an OutStream OR an InStream dies with an NRE
+// (or an ArgumentNullException from the TreeObject base ctor when Company exists but
+// SharedObjects is null). The hottest OutStream consumer is System Application CU 1279
+// "Cryptography Management Impl." GenerateHash(InStream, HashAlgorithmType), which wraps
+// a .NET MemoryStream in a NavDotNet and calls DotNetToNavOutStream before hashing; the
+// InStream direction is the natural shape after any in-process .NET interop that hands
+// back a stream AL code then wants to read from.
+//
+// SCOPE AUDIT (loud-failures rule): both replacements are observably equivalent to the
+// real BC behaviour for in-scope test code. Each reproduces its real body's three
+// branches exactly (null → Default, Stream → an instance over a NavStreamProvider,
+// anything else → NavNCLConversionException with the same argument types). The ONLY
+// divergence is the shared-object container the NavStreamProvider is parented to: the
+// real session container when present, otherwise the same process-wide skeleton
 // TreeSharedObjectContainer every other stream/record Target patch in this runner uses
 // (NavRecordRef.get_Target, NavStream.get_Target, ...). The container only governs
 // tree-disposal bookkeeping, never stream content — the AL-observable bytes are the
@@ -37,8 +51,10 @@ public static partial class BcRuntime
 {
     private static PropertyInfo? _pNavDotNetValue;
     private static MethodInfo? _mNavOutStreamDefault;
+    private static MethodInfo? _mNavInStreamDefault;
     private static ConstructorInfo? _ctorNavStreamProviderFromStream;
     private static ConstructorInfo? _ctorNavOutStream;
+    private static ConstructorInfo? _ctorNavInStream;
     private static ConstructorInfo? _ctorNavNclConversionException;
 
     private static Assembly NclAssembly()
@@ -94,6 +110,65 @@ public static partial class BcRuntime
             _ctorNavNclConversionException = tEx.GetConstructor(new[] { typeof(Type), typeof(Type) })!;
         }
         throw (Exception)_ctorNavNclConversionException.Invoke(new object[] { obj.GetType(), tNavOutStream });
+    }
+
+    /// <summary>
+    /// #2576 — mirror of <see cref="ALCompiler_DotNetToNavOutStream"/>, InStream direction.
+    /// Same three branches, same NavStreamProvider/shared-object-container plumbing; only
+    /// the target type (NavInStream vs NavOutStream) differs. See the file header for the
+    /// side-by-side decompiled bodies that make this a mechanical mirror, not a new design.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static object ALCompiler_DotNetToNavInStream(object parentOfResult, object? obj)
+    {
+        var navNcl = NclAssembly();
+        var tNavInStream = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.NavInStream")!;
+        var tITreeObject = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.ITreeObject")!;
+
+        if (obj == null)
+        {
+            _mNavInStreamDefault ??= tNavInStream.GetMethod("Default",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static,
+                null, new[] { tITreeObject }, null)!;
+            return _mNavInStreamDefault.Invoke(null, new[] { parentOfResult })!;
+        }
+
+        _pNavDotNetValue ??= obj.GetType().GetProperty("Value",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var value = _pNavDotNetValue.GetValue(obj);
+        if (value is System.IO.Stream stream)
+        {
+            var container = ResolveSharedObjectContainer(parentOfResult);
+            if (_ctorNavStreamProviderFromStream == null)
+            {
+                var tProvider = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.NavStreamProvider")!;
+                var tIContainer = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.ITreeSharedObjectContainer")!;
+                _ctorNavStreamProviderFromStream = tProvider.GetConstructor(
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                    null, new[] { typeof(System.IO.Stream), tIContainer }, null)!;
+            }
+            // Same NavStreamProvider type the OutStream direction uses above — it is
+            // shared infrastructure, not tied to In vs Out.
+            var provider = _ctorNavStreamProviderFromStream.Invoke(new object[] { stream, container });
+            if (_ctorNavInStream == null)
+            {
+                var tINavStreamProvider = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.INavStreamProvider")!;
+                _ctorNavInStream = tNavInStream.GetConstructor(
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                    null, new[] { tITreeObject, tINavStreamProvider }, null)!;
+            }
+            return _ctorNavInStream.Invoke(new[] { parentOfResult, provider })!;
+        }
+
+        // Faithful to the real body: unsupported inner value → NavNCLConversionException.
+        if (_ctorNavNclConversionException == null)
+        {
+            var tEx = AppDomain.CurrentDomain.GetAssemblies()
+                .Select(a => a.GetType("Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLConversionException"))
+                .First(t => t != null)!;
+            _ctorNavNclConversionException = tEx.GetConstructor(new[] { typeof(Type), typeof(Type) })!;
+        }
+        throw (Exception)_ctorNavNclConversionException.Invoke(new object[] { obj.GetType(), tNavInStream });
     }
 
     // Resolve the ITreeSharedObjectContainer the real body reads from


### PR DESCRIPTION
Closes #2576

## Summary

AL can already assign a .NET `Stream` to an `OutStream` (`ALCompiler.DotNetToNavOutStream`,
used by CU 1279 "Cryptography Management Impl." `GenerateHash(InStream, ...)`) but had no
counterpart for the InStream direction — the natural shape after any in-process .NET
interop that hands back a stream AL code then wants to read from.

Decompiled both methods off the same cached Ncl assembly
(`Microsoft.Dynamics.Nav.Runtime.ALCompiler.DotNetToNavInStream` /
`.DotNetToNavOutStream`) and they are **structurally identical** — same three branches
(null -> `Default`, `Stream` -> a `NavStreamProvider`-backed instance, else ->
`NavNCLConversionException`), only the `NavInStream`/`NavOutStream` type differs. So this
is the same skeleton-`SharedObjects` gap the OutStream side already fixed, applied by
mirror rather than by new investigation — a reviewer should not have to re-derive that.

`BcRuntime.ALCompiler_DotNetToNavInStream` (`AlRunner/Patches/AlCompilerStreamPatches.cs`)
reproduces the real body's three branches exactly, reusing the shared
`NavStreamProvider`/shared-object-container plumbing the OutStream helper already
established. Registered **additively** in `NclCecilRewrite.cs` — a new `CecilOwned` entry
and a new rewrite block, neither touching an existing entry, per the file-ownership
correction: this file is the only registration point for the only live Ncl-patching
mechanism, so new Cecil rewrites are added there, not routed around it. Per
`precompiled-dll-respect.md`'s token-safety rule, the helper lives in our own assembly
(`BcRuntime`), so no new typeRefs/memberRefs are added to Ncl itself.

## RED -> GREEN

Ran locally against the corpus branch backing the upstream PR (see below), before and
after the fix:

**RED:**
```
FAIL  Codeunit60118.DotNetMemoryStream_AssignedToInStream_ReadsExactContent
      ArgumentNullException: Value cannot be null. (Parameter 'parent')
      at Microsoft.Dynamics.Nav.Runtime.Utility.ValidationHelper.ThrowIfNull(...)
      at Microsoft.Dynamics.Nav.Runtime.TreeObject..ctor(ITreeObject parent)
      at Microsoft.Dynamics.Nav.Runtime.NavStreamProvider..ctor(...)
      at Microsoft.Dynamics.Nav.Runtime.ALCompiler.DotNetToNavInStream(...)
```
All 3 new corpus tests failed this way.

**GREEN:**
```
PASS  Codeunit60118.DotNetMemoryStream_AssignedToInStream_ReadsExactContent (8ms)
PASS  Codeunit60118.DotNetMemoryStream_RoundTripsAgainstOutStreamDirection (3ms)
PASS  Codeunit60118.DotNetMemoryStream_ReadPastEnd_SetsEOS_ReturnsEmptyText (1ms)
```
Full corpus re-run (2411 tests): 0 regressions — the only failures are the pre-existing,
unrelated 16-test TestPage cluster (owned by #2600/#2628, not touched here).

## Proving tests

- **Upstream (plain BC-behaviour claim, per `bc-behavior-tests-go-upstream.md`):**
  StefanMaron/BusinessCentral.AL.Language.Tests#137
  (`tests/al-language/streams/TestDotNetInStream.al`) — open, corpus CI running against
  real BC 27.5/28.3, not yet merged. Not blocking this PR per the documented workflow;
  the orchestrator merges it once both legs are green, and the submodule pin bump folds
  into a follow-up.
- **Runner-internal mechanism** (since the corpus PR hasn't merged yet, so the submodule
  pin isn't bumped in this PR): `AlRunner.Tests/AlCompilerDotNetInStreamCecilBindingTests.cs`.
  Pins that the real, Cecil-rewritten `ALCompiler.DotNetToNavInStream` is Cecil-owned,
  produces a working, readable `NavInStream` over a wrapped .NET stream (verified via
  `INavStreamReader.ReadByte()`), returns `Default` for a null `NavDotNet`, and raises
  `NavNCLConversionException` for a non-`Stream` value. The 3 tests that need the
  in-process BC engine are `[SkippableFact]`s gated the same way ~10 other classes in this
  suite already are (`BcEngineCollection`/`BcEngineFixture`) — they skip in a bare local
  `dotnet test` without the CI-only `DOTNET_STARTUP_HOOKS` wiring, and run for real on CI.

## Same-shape audit (per the PR workflow's "fix the shape, not just the reported line")

1. **Same wrong pattern elsewhere?** Grepped for other `DotNetToNav*` conversions in
   Ncl — `DotNetToNavOutStream` and `DotNetToNavInStream` are the only two; both are now
   Cecil-owned.
2. **Sibling method, same assumption?** `NavDotNet`'s other conversion-adjacent members
   (`ALByValue`, `Clone`, the various `.ctor` overloads) don't touch
   `Session.Company.SharedObjects` — confirmed by reading their decompiled bodies — so
   they aren't affected by this gap.
3. **Two paths, one invariant?** The OutStream and InStream directions now share the
   exact same shared-object-container resolution helper (`ResolveSharedObjectContainer`),
   so there is no divergence between them to fix.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf