### PR TITLE
fix(media): let a structurally valid PNG import into a Media field

### DIFF
--- a/AlRunner.Tests/MediaFactoryProcessMediaObjectPngPrependTests.cs
+++ b/AlRunner.Tests/MediaFactoryProcessMediaObjectPngPrependTests.cs
@@ -1,0 +1,159 @@
+// MediaFactoryProcessMediaObjectPngPrependTests — proves the #2570 fix: the mechanism
+// MediaPatches.TryClassifyStructuralPng() drives, prepended to
+// NavMediaFactory.ProcessMediaObject(Stream, bool, string) via Cecil (see
+// NclCecilRewrite.cs), classifies a structurally valid PNG as "image/png" without decoding
+// it, leaves an explicit mimeType or non-PNG content untouched, and raises BC's own
+// "not a valid image" shape for a PNG whose chunk structure is corrupt.
+//
+// This is deliberately a RUNNER-INTERNAL claim, not a BC-behaviour one: it asserts that OUR
+// C# structural-PNG classifier — the thing the Cecil prepend calls — returns the right
+// answer for each input shape. Whether AL code that imports a PNG into a Media field
+// actually stores it as image/png on real BC is a plain BC-behaviour claim and belongs
+// upstream — see StefanMaron/BusinessCentral.AL.Language.Tests#138
+// (tests/al-language/media/TestMediaPngImport.al), and the equivalent end-to-end proof run
+// locally against that corpus branch (RED before this fix, GREEN after — see the PR
+// description for #2570).
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class MediaFactoryProcessMediaObjectPngPrependTests
+{
+    [Fact]
+    public void ProcessMediaObject_KeyIsCecilOwned()
+    {
+        Assert.Contains(
+            "Microsoft.Dynamics.Nav.Runtime.Media.NavMediaFactory::ProcessMediaObject/3",
+            NclCecilRewrite.CecilOwned);
+    }
+
+    // A minimal valid 1x1-pixel PNG (68 bytes): signature + IHDR(13) + IDAT(11) + IEND(0),
+    // every chunk CRC verified independently with Python's zlib.crc32 — the same fixture
+    // used in the upstream corpus PR (TestMediaPngImport.al).
+    private static readonly byte[] ValidPng = Convert.FromBase64String(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=");
+
+    // Same bytes with one byte of the IHDR chunk's CRC field flipped.
+    private static readonly byte[] CorruptIhdrCrcPng = Convert.FromBase64String(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAADFfptVAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=");
+
+    private static readonly byte[] JpegSoi = { 0xFF, 0xD8, 0xFF };
+
+    [Fact]
+    public void ValidPng_EmptyMimeType_ClassifiesAsImagePng()
+    {
+        using var stream = new MemoryStream(ValidPng);
+
+        var result = MediaPatches.TryClassifyStructuralPng(stream, "");
+
+        Assert.Equal("image/png", result);
+    }
+
+    [Fact]
+    public void ValidPng_NullMimeType_ClassifiesAsImagePng()
+    {
+        using var stream = new MemoryStream(ValidPng);
+
+        var result = MediaPatches.TryClassifyStructuralPng(stream, null);
+
+        Assert.Equal("image/png", result);
+    }
+
+    [Fact]
+    public void ValidPng_RestoresStreamPositionAfterSniffing()
+    {
+        using var stream = new MemoryStream(ValidPng);
+        stream.Position = 0;
+
+        MediaPatches.TryClassifyStructuralPng(stream, null);
+
+        // A "peek" must leave the stream exactly where the caller left it — the real
+        // ProcessMediaObject body still needs to read this stream from the start.
+        Assert.Equal(0, stream.Position);
+    }
+
+    [Fact]
+    public void ExplicitMimeType_ReturnsNull_EvenForValidPng()
+    {
+        // Mirrors ProcessMediaObject's own guard (string.IsNullOrEmpty(mimeType)) — a
+        // caller-supplied mimeType must never be overridden.
+        using var stream = new MemoryStream(ValidPng);
+
+        var result = MediaPatches.TryClassifyStructuralPng(stream, "application/pdf");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void NonPngContent_ReturnsNull_NotMisclassified()
+    {
+        using var stream = new MemoryStream(JpegSoi);
+
+        var result = MediaPatches.TryClassifyStructuralPng(stream, null);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void NonSeekableStream_ReturnsNull_DefersToExistingPath()
+    {
+        using var inner = new MemoryStream(ValidPng);
+        using var nonSeekable = new NonSeekableWrapperStream(inner);
+
+        var result = MediaPatches.TryClassifyStructuralPng(nonSeekable, null);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void CorruptIhdrCrc_ThrowsWithSpecificDiagnostic()
+    {
+        using var stream = new MemoryStream(CorruptIhdrCrcPng);
+
+        var ex = Assert.ThrowsAny<Exception>(() => MediaPatches.TryClassifyStructuralPng(stream, null));
+
+        // Whichever exception shape NotAnImage() ends up constructing (NavImageLoadErrorException
+        // wrapping ArgumentException in-process, or a bare ArgumentException if
+        // Microsoft.Dynamics.Nav.Types has not been loaded yet in an isolated test run), the
+        // specific diagnostic must be findable somewhere in the exception chain — proving
+        // this fires for the CRC mismatch specifically, not any old exception.
+        Assert.True(
+            (ex.Message + " " + ex.InnerException?.Message).Contains("IHDR chunk CRC mismatch"),
+            $"expected 'IHDR chunk CRC mismatch' somewhere in the exception chain, got: {ex}");
+    }
+
+    [Fact]
+    public void Truncated_AfterSignature_ThrowsWithSpecificDiagnostic()
+    {
+        // The PNG signature alone (no chunks at all) — the shape
+        // tests/runner-extras/standalone-suites/media-non-image-content used to use for its
+        // "image content is refused by name" fixture before #2570 gave PNG its own path
+        // (that test now uses a JPEG signature instead; see MncTests.Codeunit.al).
+        using var stream = new MemoryStream(ValidPng.AsSpan(0, 8).ToArray());
+
+        var ex = Assert.ThrowsAny<Exception>(() => MediaPatches.TryClassifyStructuralPng(stream, null));
+
+        Assert.True(
+            (ex.Message + " " + ex.InnerException?.Message).Contains("unexpected end of data after signature"),
+            $"expected 'unexpected end of data after signature' somewhere in the exception chain, got: {ex}");
+    }
+
+    /// <summary>Wraps a seekable stream to report CanSeek=false, for the non-seekable test above.</summary>
+    private sealed class NonSeekableWrapperStream : Stream
+    {
+        private readonly Stream _inner;
+        public NonSeekableWrapperStream(Stream inner) => _inner = inner;
+        public override bool CanRead => _inner.CanRead;
+        public override bool CanSeek => false;
+        public override bool CanWrite => _inner.CanWrite;
+        public override long Length => _inner.Length;
+        public override long Position { get => _inner.Position; set => throw new NotSupportedException(); }
+        public override void Flush() => _inner.Flush();
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => _inner.Write(buffer, offset, count);
+    }
+}

--- a/AlRunner.Tests/MediaFactoryProcessMediaObjectPngPrependTests.cs
+++ b/AlRunner.Tests/MediaFactoryProcessMediaObjectPngPrependTests.cs
@@ -1,15 +1,23 @@
 // MediaFactoryProcessMediaObjectPngPrependTests — proves the #2570 fix: the mechanism
-// MediaPatches.TryClassifyStructuralPng() drives, prepended to
+// MediaPatches.TryClassifyPngBySignature() drives, prepended to
 // NavMediaFactory.ProcessMediaObject(Stream, bool, string) via Cecil (see
-// NclCecilRewrite.cs), classifies a structurally valid PNG as "image/png" without decoding
-// it, leaves an explicit mimeType or non-PNG content untouched, and raises BC's own
-// "not a valid image" shape for a PNG whose chunk structure is corrupt.
+// NclCecilRewrite.cs), classifies any PNG-signature-prefixed stream as "image/png" without
+// decoding it, and leaves an explicit mimeType or non-PNG content untouched.
+//
+// Signature-only, deliberately: an earlier version of this classifier additionally
+// validated every PNG chunk's CRC32 and IHDR's declared width/height. Two full rounds of
+// upstream corpus CI (StefanMaron/BusinessCentral.AL.Language.Tests#138, 27.0-28.4, all 8
+// legs each) measured that real BC accepts a PNG with a wrong IHDR chunk CRC, a stream that
+// is nothing but the 8-byte signature, a stream truncated mid-IHDR-chunk, and a
+// structurally complete PNG with IHDR width=0 — identically, both rounds. Matching BC
+// exactly (rather than being stricter, which would make the runner reject a PNG BC
+// accepts) is why this file's classifier — and these tests — only check the signature.
 //
 // This is deliberately a RUNNER-INTERNAL claim, not a BC-behaviour one: it asserts that OUR
-// C# structural-PNG classifier — the thing the Cecil prepend calls — returns the right
-// answer for each input shape. Whether AL code that imports a PNG into a Media field
-// actually stores it as image/png on real BC is a plain BC-behaviour claim and belongs
-// upstream — see StefanMaron/BusinessCentral.AL.Language.Tests#138
+// C# classifier — the thing the Cecil prepend calls — returns the right answer for each
+// input shape. Whether AL code that imports a PNG into a Media field actually stores it as
+// image/png on real BC is a plain BC-behaviour claim and belongs upstream — see
+// StefanMaron/BusinessCentral.AL.Language.Tests#138
 // (tests/al-language/media/TestMediaPngImport.al), and the equivalent end-to-end proof run
 // locally against that corpus branch (RED before this fix, GREEN after — see the PR
 // description for #2570).
@@ -29,15 +37,18 @@ public sealed class MediaFactoryProcessMediaObjectPngPrependTests
             NclCecilRewrite.CecilOwned);
     }
 
-    // A minimal valid 1x1-pixel PNG (68 bytes): signature + IHDR(13) + IDAT(11) + IEND(0),
-    // every chunk CRC verified independently with Python's zlib.crc32 — the same fixture
-    // used in the upstream corpus PR (TestMediaPngImport.al).
+    // A minimal valid 1x1-pixel PNG (68 bytes): signature + IHDR(13) + IDAT(11) + IEND(0).
     private static readonly byte[] ValidPng = Convert.FromBase64String(
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=");
 
-    // Same bytes with one byte of the IHDR chunk's CRC field flipped.
+    // Same bytes with one byte of the IHDR chunk's CRC field flipped — BC accepts this
+    // (measured, corpus #138 round 1); still just the signature that matters here.
     private static readonly byte[] CorruptIhdrCrcPng = Convert.FromBase64String(
         "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAADFfptVAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=");
+
+    // Just the 8-byte PNG signature, nothing else — BC accepts this too (measured, corpus
+    // #138 round 2).
+    private static readonly byte[] SignatureOnlyPng = ValidPng.AsSpan(0, 8).ToArray();
 
     private static readonly byte[] JpegSoi = { 0xFF, 0xD8, 0xFF };
 
@@ -46,7 +57,7 @@ public sealed class MediaFactoryProcessMediaObjectPngPrependTests
     {
         using var stream = new MemoryStream(ValidPng);
 
-        var result = MediaPatches.TryClassifyStructuralPng(stream, "");
+        var result = MediaPatches.TryClassifyPngBySignature(stream, "");
 
         Assert.Equal("image/png", result);
     }
@@ -56,7 +67,7 @@ public sealed class MediaFactoryProcessMediaObjectPngPrependTests
     {
         using var stream = new MemoryStream(ValidPng);
 
-        var result = MediaPatches.TryClassifyStructuralPng(stream, null);
+        var result = MediaPatches.TryClassifyPngBySignature(stream, null);
 
         Assert.Equal("image/png", result);
     }
@@ -67,7 +78,7 @@ public sealed class MediaFactoryProcessMediaObjectPngPrependTests
         using var stream = new MemoryStream(ValidPng);
         stream.Position = 0;
 
-        MediaPatches.TryClassifyStructuralPng(stream, null);
+        MediaPatches.TryClassifyPngBySignature(stream, null);
 
         // A "peek" must leave the stream exactly where the caller left it — the real
         // ProcessMediaObject body still needs to read this stream from the start.
@@ -81,7 +92,7 @@ public sealed class MediaFactoryProcessMediaObjectPngPrependTests
         // caller-supplied mimeType must never be overridden.
         using var stream = new MemoryStream(ValidPng);
 
-        var result = MediaPatches.TryClassifyStructuralPng(stream, "application/pdf");
+        var result = MediaPatches.TryClassifyPngBySignature(stream, "application/pdf");
 
         Assert.Null(result);
     }
@@ -91,7 +102,7 @@ public sealed class MediaFactoryProcessMediaObjectPngPrependTests
     {
         using var stream = new MemoryStream(JpegSoi);
 
-        var result = MediaPatches.TryClassifyStructuralPng(stream, null);
+        var result = MediaPatches.TryClassifyPngBySignature(stream, null);
 
         Assert.Null(result);
     }
@@ -102,42 +113,34 @@ public sealed class MediaFactoryProcessMediaObjectPngPrependTests
         using var inner = new MemoryStream(ValidPng);
         using var nonSeekable = new NonSeekableWrapperStream(inner);
 
-        var result = MediaPatches.TryClassifyStructuralPng(nonSeekable, null);
+        var result = MediaPatches.TryClassifyPngBySignature(nonSeekable, null);
 
         Assert.Null(result);
     }
 
     [Fact]
-    public void CorruptIhdrCrc_ThrowsWithSpecificDiagnostic()
+    public void CorruptIhdrCrc_StillClassifiesAsImagePng()
     {
+        // MEASURED (corpus #138 round 1): real BC accepts this. The classifier must not
+        // reject it either — rejecting a PNG BC accepts is the exact defect this file's
+        // simplification exists to avoid.
         using var stream = new MemoryStream(CorruptIhdrCrcPng);
 
-        var ex = Assert.ThrowsAny<Exception>(() => MediaPatches.TryClassifyStructuralPng(stream, null));
+        var result = MediaPatches.TryClassifyPngBySignature(stream, null);
 
-        // Whichever exception shape NotAnImage() ends up constructing (NavImageLoadErrorException
-        // wrapping ArgumentException in-process, or a bare ArgumentException if
-        // Microsoft.Dynamics.Nav.Types has not been loaded yet in an isolated test run), the
-        // specific diagnostic must be findable somewhere in the exception chain — proving
-        // this fires for the CRC mismatch specifically, not any old exception.
-        Assert.True(
-            (ex.Message + " " + ex.InnerException?.Message).Contains("IHDR chunk CRC mismatch"),
-            $"expected 'IHDR chunk CRC mismatch' somewhere in the exception chain, got: {ex}");
+        Assert.Equal("image/png", result);
     }
 
     [Fact]
-    public void Truncated_AfterSignature_ThrowsWithSpecificDiagnostic()
+    public void SignatureOnly_StillClassifiesAsImagePng()
     {
-        // The PNG signature alone (no chunks at all) — the shape
-        // tests/runner-extras/standalone-suites/media-non-image-content used to use for its
-        // "image content is refused by name" fixture before #2570 gave PNG its own path
-        // (that test now uses a JPEG signature instead; see MncTests.Codeunit.al).
-        using var stream = new MemoryStream(ValidPng.AsSpan(0, 8).ToArray());
+        // MEASURED (corpus #138 round 2): real BC accepts a stream that is nothing but the
+        // 8-byte PNG signature. Same reasoning as CorruptIhdrCrc_StillClassifiesAsImagePng.
+        using var stream = new MemoryStream(SignatureOnlyPng);
 
-        var ex = Assert.ThrowsAny<Exception>(() => MediaPatches.TryClassifyStructuralPng(stream, null));
+        var result = MediaPatches.TryClassifyPngBySignature(stream, null);
 
-        Assert.True(
-            (ex.Message + " " + ex.InnerException?.Message).Contains("unexpected end of data after signature"),
-            $"expected 'unexpected end of data after signature' somewhere in the exception chain, got: {ex}");
+        Assert.Equal("image/png", result);
     }
 
     /// <summary>Wraps a seekable stream to report CanSeek=false, for the non-seekable test above.</summary>

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -415,8 +415,8 @@ public static class NclCecilRewrite
         // instance, else → NavNCLConversionException), just the InStream direction.
         "Microsoft.Dynamics.Nav.Runtime.ALCompiler::DotNetToNavInStream/2",
         // NavMediaFactory.ProcessMediaObject(Stream,bool,string) — surgical prepend so a
-        // structurally valid PNG classifies as image/png without decoding (#2570). See
-        // the RewriteNcl block below for the detail. Additive: does not touch
+        // PNG-signature-prefixed stream classifies as image/png without decoding (#2570).
+        // See the RewriteNcl block below for the detail. Additive: does not touch
         // NavForm.GetPart (#2600) or the page-background-task routing (#2628).
         "Microsoft.Dynamics.Nav.Runtime.Media.NavMediaFactory::ProcessMediaObject/3",
     };
@@ -8218,20 +8218,23 @@ public static class NclCecilRewrite
 
             // NavMediaFactory.ProcessMediaObject(Stream,bool,string) — #2570. Surgical
             // PREPEND (original body untouched, same shape as PrependFieldFindGuard below),
-            // not a body replacement: MediaPatches.TryClassifyStructuralPng sniffs+validates
-            // the stream as a PNG BEFORE the real body decides anything. When it returns
-            // "image/png" we `starg` the mimeType PARAMETER to that value and fall through
-            // into the real, unmodified body — which (mimeType now non-empty) skips
-            // GetImageWithContentHeaderValidation entirely, and — because
-            // NavMediaImage.IsSupportedMimeType is rewritten to always return false just
-            // above — cascades past every image/document branch straight to BC's own
+            // not a body replacement: MediaPatches.TryClassifyPngBySignature sniffs the
+            // stream's first 8 bytes for the PNG signature BEFORE the real body decides
+            // anything. When it returns "image/png" we `starg` the mimeType PARAMETER to
+            // that value and fall through into the real, unmodified body — which (mimeType
+            // now non-empty) skips GetImageWithContentHeaderValidation entirely, and —
+            // because NavMediaImage.IsSupportedMimeType is rewritten to always return false
+            // just above — cascades past every image/document branch straight to BC's own
             // `new NavMediaBinaryFile(mediaStream, mimeType)` fallback, unmodified. When it
             // returns null, nothing changes (falls straight through to the original first
             // instruction) — every other mimeType/content shape, including every
-            // already-working non-PNG-image / non-image classification, is untouched. When
-            // it THROWS (PNG signature present but chunk structure corrupt), the exception
-            // propagates before the original try/catch exists to catch it — a real error,
-            // not a silent accept. RED→GREEN: AlRunner.Tests
+            // already-working non-PNG-image / non-image classification, is untouched.
+            // Signature-only (no chunk/CRC/IHDR validation) is deliberate: two full rounds
+            // of upstream corpus CI (StefanMaron/BusinessCentral.AL.Language.Tests#138, all
+            // 8 BC legs both times) measured that real BC accepts a PNG-signature-prefixed
+            // stream regardless of chunk CRCs, IHDR presence, or declared width/height — so
+            // anything stricter here would make the runner reject content BC accepts (the
+            // same class of defect as #2641, opposite direction). RED→GREEN: AlRunner.Tests
             // MediaFactoryProcessMediaObjectPngPrependTests.cs (mechanism) +
             // tests/runner-extras/standalone-suites/media-non-image-content (unchanged,
             // pins the JPEG-still-refuses claim so this cannot silently widen back) + the
@@ -8240,7 +8243,7 @@ public static class NclCecilRewrite
             {
                 var processMediaObject = FindNclMethod(nclMod, Rt + "Media.NavMediaFactory", "ProcessMediaObject", 3);
                 var helperMi = typeof(AlRunner.Patches.MediaPatches).GetMethod(
-                    nameof(AlRunner.Patches.MediaPatches.TryClassifyStructuralPng),
+                    nameof(AlRunner.Patches.MediaPatches.TryClassifyPngBySignature),
                     BindingFlags.Public | BindingFlags.Static)!;
                 var helperRef = nclMod.ImportReference(helperMi);
 
@@ -8273,7 +8276,7 @@ public static class NclCecilRewrite
                 il.InsertBefore(first, starg);
 
                 body.MaxStackSize = Math.Max(body.MaxStackSize, 2);
-                Console.Error.WriteLine("[Cecil] Prepended structural-PNG mimeType classification to NavMediaFactory.ProcessMediaObject");
+                Console.Error.WriteLine("[Cecil] Prepended PNG-signature mimeType classification to NavMediaFactory.ProcessMediaObject");
             }
 
             // ── NavRecordRef cluster (Batch 8) — get_Target + open-gates + ALOpen ─

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -414,6 +414,11 @@ public static class NclCecilRewrite
         // body (three branches: null → Default, Stream → NavStreamProvider-backed
         // instance, else → NavNCLConversionException), just the InStream direction.
         "Microsoft.Dynamics.Nav.Runtime.ALCompiler::DotNetToNavInStream/2",
+        // NavMediaFactory.ProcessMediaObject(Stream,bool,string) — surgical prepend so a
+        // structurally valid PNG classifies as image/png without decoding (#2570). See
+        // the RewriteNcl block below for the detail. Additive: does not touch
+        // NavForm.GetPart (#2600) or the page-background-task routing (#2628).
+        "Microsoft.Dynamics.Nav.Runtime.Media.NavMediaFactory::ProcessMediaObject/3",
     };
 
     /// <summary>
@@ -8210,6 +8215,66 @@ public static class NclCecilRewrite
             ReplaceBodyWithHelper(nclMod,
                 FindNclMethod(nclMod, Rt + "Media.NavMediaImage", "IsSupportedMimeType", 1),
                 H(helperShims, "ReturnFalse_1Arg"));
+
+            // NavMediaFactory.ProcessMediaObject(Stream,bool,string) — #2570. Surgical
+            // PREPEND (original body untouched, same shape as PrependFieldFindGuard below),
+            // not a body replacement: MediaPatches.TryClassifyStructuralPng sniffs+validates
+            // the stream as a PNG BEFORE the real body decides anything. When it returns
+            // "image/png" we `starg` the mimeType PARAMETER to that value and fall through
+            // into the real, unmodified body — which (mimeType now non-empty) skips
+            // GetImageWithContentHeaderValidation entirely, and — because
+            // NavMediaImage.IsSupportedMimeType is rewritten to always return false just
+            // above — cascades past every image/document branch straight to BC's own
+            // `new NavMediaBinaryFile(mediaStream, mimeType)` fallback, unmodified. When it
+            // returns null, nothing changes (falls straight through to the original first
+            // instruction) — every other mimeType/content shape, including every
+            // already-working non-PNG-image / non-image classification, is untouched. When
+            // it THROWS (PNG signature present but chunk structure corrupt), the exception
+            // propagates before the original try/catch exists to catch it — a real error,
+            // not a silent accept. RED→GREEN: AlRunner.Tests
+            // MediaFactoryProcessMediaObjectPngPrependTests.cs (mechanism) +
+            // tests/runner-extras/standalone-suites/media-non-image-content (unchanged,
+            // pins the JPEG-still-refuses claim so this cannot silently widen back) + the
+            // upstream BC-behaviour claim, StefanMaron/BusinessCentral.AL.Language.Tests#138
+            // (tests/al-language/media/TestMediaPngImport.al).
+            {
+                var processMediaObject = FindNclMethod(nclMod, Rt + "Media.NavMediaFactory", "ProcessMediaObject", 3);
+                var helperMi = typeof(AlRunner.Patches.MediaPatches).GetMethod(
+                    nameof(AlRunner.Patches.MediaPatches.TryClassifyStructuralPng),
+                    BindingFlags.Public | BindingFlags.Static)!;
+                var helperRef = nclMod.ImportReference(helperMi);
+
+                var body = processMediaObject.Body;
+                var il = body.GetILProcessor();
+                var first = body.Instructions[0];
+
+                var newMimeTypeLocal = new VariableDefinition(nclMod.ImportReference(typeof(string)));
+                body.Variables.Add(newMimeTypeLocal);
+
+                // ldarg.0 (mediaStream); ldarg.2 (mimeType); call helper -> string?
+                // stloc newMimeTypeLocal; ldloc; brfalse <first>; ldloc; starg.s mimeType;
+                // <first> (original body, unchanged, falls through here in both cases)
+                var ldStream = il.Create(OpCodes.Ldarg_0);
+                var ldMime = il.Create(OpCodes.Ldarg_2);
+                var callHelper = il.Create(OpCodes.Call, helperRef);
+                var stloc = il.Create(OpCodes.Stloc, newMimeTypeLocal);
+                var ldlocCheck = il.Create(OpCodes.Ldloc, newMimeTypeLocal);
+                var brFalse = il.Create(OpCodes.Brfalse, first);
+                var ldlocApply = il.Create(OpCodes.Ldloc, newMimeTypeLocal);
+                var starg = il.Create(OpCodes.Starg, processMediaObject.Parameters[2]);
+
+                il.InsertBefore(first, ldStream);
+                il.InsertBefore(first, ldMime);
+                il.InsertBefore(first, callHelper);
+                il.InsertBefore(first, stloc);
+                il.InsertBefore(first, ldlocCheck);
+                il.InsertBefore(first, brFalse);
+                il.InsertBefore(first, ldlocApply);
+                il.InsertBefore(first, starg);
+
+                body.MaxStackSize = Math.Max(body.MaxStackSize, 2);
+                Console.Error.WriteLine("[Cecil] Prepended structural-PNG mimeType classification to NavMediaFactory.ProcessMediaObject");
+            }
 
             // ── NavRecordRef cluster (Batch 8) — get_Target + open-gates + ALOpen ─
             // get_Target's real body NREs on base.Tree.Session.Company.SharedObjects

--- a/AlRunner/Patches/MediaPatches.cs
+++ b/AlRunner/Patches/MediaPatches.cs
@@ -31,7 +31,40 @@
 //   Sniffing rather than decoding is faithful for the first case: BC only needs to know
 //   "is this an image", and a file whose header is not one of the image signatures is not
 //   one, on any platform.
+//
+// #2570 — PNG IMPORT WITHOUT A DECODER
+//   The refusal above is the right answer for a format whose validity genuinely depends on
+//   decoding — but PNG's validity is checkable STRUCTURALLY: the 8-byte signature, chunk
+//   ordering, a per-chunk CRC32, and a well-formed IHDR. TryClassifyStructuralPng() below is
+//   prepended (Cecil, see NclCecilRewrite.cs) to the START of
+//   NavMediaFactory.ProcessMediaObject(Stream, bool, string) — BEFORE it decides whether to
+//   call GetImageWithContentHeaderValidation at all. For content that is a structurally valid
+//   PNG and the caller passed no explicit mimeType, it OVERWRITES the mimeType argument to
+//   "image/png" and lets the REST OF THE REAL, UNMODIFIED ProcessMediaObject body run: with a
+//   non-empty mimeType it skips the whole GetImageWithContentHeaderValidation try/catch, and
+//   NavMediaImage.IsSupportedMimeType is separately rewritten (elsewhere in
+//   NclCecilRewrite.cs) to always answer false on this platform (its own System.Drawing-backed
+//   statics are unavailable) — so "image/png" cascades straight past every
+//   image/pdf/word/excel/powerpoint/onenote/text branch to BC's own generic fallback,
+//   `new NavMediaBinaryFile(mediaStream, mimeType)`, unmodified. No decoded image is
+//   fabricated: the bytes BC stores are exactly the bytes AL supplied, and
+//   NavMediaBinaryFile's own ValidateContentHeader → NavMediaContentValidator.VerifyStreamData
+//   is a pure managed byte-pattern check (PE/COFF/archive-executable guard) — no native
+//   dependency, confirmed by reading its decompiled body.
+//
+//   This narrows the refusal for PNG only. Content whose first 8 bytes are not the PNG
+//   signature is untouched — it still reaches GetImageWithContentHeaderValidation exactly as
+//   before. Content that looks like a PNG but fails structural validation (a bad chunk CRC, a
+//   malformed IHDR, truncated data) raises BC's own "not a valid image" error
+//   (NavImageLoadErrorException wrapping ArgumentException, thrown via the same NotAnImage()
+//   helper below) INSTEAD of silently storing invalid bytes as image/png.
+//
+//   Not a claim of byte-for-byte equivalence with a real GDI+ decoder: a PNG that passes this
+//   structural check but that GDI+ would reject for some decoder-specific reason would be
+//   accepted here and refused on a real tier. See docs/scope.md.
+using System.Buffers.Binary;
 using System.Reflection;
+using System.Text;
 
 namespace AlRunner.Patches;
 
@@ -94,10 +127,26 @@ public static class MediaPatches
     private static ConstructorInfo? _navImageLoadErrorCtor;
 
     /// <summary>
+    /// BC's own message for this exact shape (real service tier's <c>Lang.MediaImageLoadError</c>
+    /// resource string — this is the literal text a real tier shows, quoted from empirical
+    /// observation: pre-#1... the Linux PlatformNotSupportedException path let this exact
+    /// NavImageLoadErrorException(ArgumentException) propagate out UNCAUGHT for every media
+    /// write, image or not, which is how the text was captured). Every caller of NotAnImage()
+    /// must use this as the OUTER exception's message — `because` below is diagnostic detail
+    /// for the (usually swallowed) INNER exception only, never a substitute for BC's own text.
+    /// </summary>
+    internal const string MediaImageLoadErrorMessage =
+        "The media object could not be loaded because it is not a valid image type, such as JPEG, GIF, or PNG";
+
+    /// <summary>
     /// BC's own <c>NavImageLoadErrorException</c> wrapping an <c>ArgumentException</c> — the
     /// exact shape NavMediaFactory.ProcessMediaObject's `when (ex.InnerException is
     /// ArgumentException)` filter looks for. Any other type or inner type means the media
-    /// write fails instead of falling back to application/octet-stream.
+    /// write fails instead of falling back to application/octet-stream. The OUTER exception's
+    /// message is always <see cref="MediaImageLoadErrorMessage"/> — BC's own text, and the one
+    /// callers actually see when this propagates uncaught (e.g. #2570's corrupt-PNG path,
+    /// which throws this OUTSIDE ProcessMediaObject's catch). <paramref name="because"/> is a
+    /// diagnostic detail carried on the INNER ArgumentException only.
     /// </summary>
     private static Exception NotAnImage(string because)
     {
@@ -114,7 +163,7 @@ public static class MediaPatches
                     binder: null, types: new[] { typeof(string), typeof(Exception) }, modifiers: null);
             }
             if (_navImageLoadErrorCtor != null)
-                return (Exception)_navImageLoadErrorCtor.Invoke(new object[] { because, inner });
+                return (Exception)_navImageLoadErrorCtor.Invoke(new object[] { MediaImageLoadErrorMessage, inner });
         }
         catch (Exception ex)
         {
@@ -123,5 +172,151 @@ public static class MediaPatches
                 + "non-image media will fail to store rather than falling back to octet-stream");
         }
         return inner;
+    }
+
+    private static readonly byte[] PngSignature = { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+
+    /// <summary>
+    /// #2570 — prepended to the START of NavMediaFactory.ProcessMediaObject(Stream, bool,
+    /// string) via Cecil (see NclCecilRewrite.cs). Returns:
+    ///   <list type="bullet">
+    ///   <item>null — no change; the original body runs exactly as before. Covers: an
+    ///   explicit mimeType was already given (mirrors the real body's own
+    ///   <c>string.IsNullOrEmpty(mimeType)</c> guard), the stream cannot be sniffed, or the
+    ///   first 8 bytes are not the PNG signature at all.</item>
+    ///   <item>"image/png" — the content IS a structurally valid PNG; the caller overwrites
+    ///   the mimeType argument with this and falls through to the real body.</item>
+    ///   </list>
+    /// Throws BC's own "not a valid image" shape (see NotAnImage() above) when the PNG
+    /// signature is present but the chunk structure is corrupt — raised here, BEFORE the
+    /// original body's own try/catch exists, so it propagates as a real error rather than
+    /// being caught by anything.
+    /// </summary>
+    [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
+    public static string? TryClassifyStructuralPng(object? mediaStreamObj, object? mimeTypeObj)
+    {
+        if (mimeTypeObj is string existingMimeType && existingMimeType.Length > 0)
+            return null;
+        if (mediaStreamObj is not Stream stream || !stream.CanSeek)
+            return null;
+
+        var origin = stream.Position;
+        try
+        {
+            Span<byte> signature = stackalloc byte[8];
+            if (!TryReadFully(stream, signature) || !signature.SequenceEqual(PngSignature))
+                return null;
+
+            string? reason = ValidatePngChunkStructure(stream);
+            if (reason != null)
+                throw NotAnImage($"the PNG content is structurally invalid: {reason}");
+
+            return "image/png";
+        }
+        finally
+        {
+            stream.Position = origin;
+        }
+    }
+
+    private static bool TryReadFully(Stream stream, Span<byte> buffer)
+    {
+        int read = 0;
+        while (read < buffer.Length)
+        {
+            int n = stream.Read(buffer.Slice(read));
+            if (n <= 0) return false;
+            read += n;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Validates every PNG chunk following the 8-byte signature (already consumed by the
+    /// caller): 4-byte big-endian length, 4-byte ASCII type, `length` bytes of chunk data,
+    /// then a 4-byte big-endian CRC32 over (type+data) — the exact algorithm the PNG
+    /// specification requires (ISO-HDLC / zlib polynomial, the same CRC32 gzip and zip use).
+    /// Requires the first chunk to be IHDR (length 13, positive width and height) and an
+    /// IEND chunk (length 0) to terminate. Returns null when every chunk validates,
+    /// otherwise a short human-readable reason.
+    /// </summary>
+    private static string? ValidatePngChunkStructure(Stream stream)
+    {
+        bool sawIhdr = false;
+        bool sawIend = false;
+        const int maxChunks = 4096; // guards a maliciously/accidentally unbounded chunk count
+        // Allocated ONCE outside the loop (CA2014): a stackalloc's lifetime is the whole
+        // method, not just the loop iteration that created it, so allocating fresh spans
+        // per iteration would accumulate stack usage across up to maxChunks iterations.
+        Span<byte> lengthBuf = stackalloc byte[4];
+        Span<byte> typeBuf = stackalloc byte[4];
+        Span<byte> crcBuf = stackalloc byte[4];
+        for (int i = 0; i < maxChunks && !sawIend; i++)
+        {
+            if (!TryReadFully(stream, lengthBuf))
+                return sawIhdr ? "unexpected end of data before IEND" : "unexpected end of data after signature";
+            uint length = BinaryPrimitives.ReadUInt32BigEndian(lengthBuf);
+            if (length > 0x7FFFFFFF)
+                return "chunk length out of range";
+
+            if (!TryReadFully(stream, typeBuf))
+                return "unexpected end of data reading chunk type";
+            string type = Encoding.ASCII.GetString(typeBuf);
+
+            if (!sawIhdr && type != "IHDR")
+                return "first chunk is not IHDR";
+
+            byte[] data = length == 0 ? Array.Empty<byte>() : new byte[length];
+            if (length > 0 && !TryReadFully(stream, data))
+                return $"unexpected end of data reading {type} chunk body";
+
+            if (!TryReadFully(stream, crcBuf))
+                return $"unexpected end of data reading {type} chunk CRC";
+            uint storedCrc = BinaryPrimitives.ReadUInt32BigEndian(crcBuf);
+            uint computedCrc = Crc32(typeBuf, data);
+            if (computedCrc != storedCrc)
+                return $"{type} chunk CRC mismatch";
+
+            if (type == "IHDR")
+            {
+                if (length != 13) return "IHDR chunk has the wrong length";
+                uint width = BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(0, 4));
+                uint height = BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(4, 4));
+                if (width == 0 || height == 0) return "IHDR declares zero width or height";
+                sawIhdr = true;
+            }
+            else if (type == "IEND")
+            {
+                sawIend = true;
+            }
+        }
+
+        if (!sawIhdr) return "no IHDR chunk found";
+        if (!sawIend) return "no IEND chunk found";
+        return null;
+    }
+
+    private static readonly uint[] Crc32Table = BuildCrc32Table();
+
+    private static uint[] BuildCrc32Table()
+    {
+        var table = new uint[256];
+        for (uint n = 0; n < 256; n++)
+        {
+            uint c = n;
+            for (int k = 0; k < 8; k++)
+                c = (c & 1) != 0 ? 0xEDB88320 ^ (c >> 1) : c >> 1;
+            table[n] = c;
+        }
+        return table;
+    }
+
+    /// <summary>PNG's CRC32 (ISO-HDLC / zlib polynomial) over the concatenation of two spans.</summary>
+    private static uint Crc32(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
+    {
+        uint c = 0xFFFFFFFF;
+        foreach (byte by in a) c = Crc32Table[(c ^ by) & 0xFF] ^ (c >> 8);
+        foreach (byte by in b) c = Crc32Table[(c ^ by) & 0xFF] ^ (c >> 8);
+        return c ^ 0xFFFFFFFF;
     }
 }

--- a/AlRunner/Patches/MediaPatches.cs
+++ b/AlRunner/Patches/MediaPatches.cs
@@ -34,15 +34,14 @@
 //
 // #2570 — PNG IMPORT WITHOUT A DECODER
 //   The refusal above is the right answer for a format whose validity genuinely depends on
-//   decoding — but PNG's validity is checkable STRUCTURALLY: the 8-byte signature, chunk
-//   ordering, a per-chunk CRC32, and a well-formed IHDR. TryClassifyStructuralPng() below is
-//   prepended (Cecil, see NclCecilRewrite.cs) to the START of
+//   decoding. PNG turned out not to be one of those, on real BC: TryClassifyPngBySignature()
+//   below is prepended (Cecil, see NclCecilRewrite.cs) to the START of
 //   NavMediaFactory.ProcessMediaObject(Stream, bool, string) — BEFORE it decides whether to
-//   call GetImageWithContentHeaderValidation at all. For content that is a structurally valid
-//   PNG and the caller passed no explicit mimeType, it OVERWRITES the mimeType argument to
-//   "image/png" and lets the REST OF THE REAL, UNMODIFIED ProcessMediaObject body run: with a
-//   non-empty mimeType it skips the whole GetImageWithContentHeaderValidation try/catch, and
-//   NavMediaImage.IsSupportedMimeType is separately rewritten (elsewhere in
+//   call GetImageWithContentHeaderValidation at all. For content whose first 8 bytes are the
+//   PNG signature and the caller passed no explicit mimeType, it OVERWRITES the mimeType
+//   argument to "image/png" and lets the REST OF THE REAL, UNMODIFIED ProcessMediaObject body
+//   run: with a non-empty mimeType it skips the whole GetImageWithContentHeaderValidation
+//   try/catch, and NavMediaImage.IsSupportedMimeType is separately rewritten (elsewhere in
 //   NclCecilRewrite.cs) to always answer false on this platform (its own System.Drawing-backed
 //   statics are unavailable) — so "image/png" cascades straight past every
 //   image/pdf/word/excel/powerpoint/onenote/text branch to BC's own generic fallback,
@@ -52,19 +51,20 @@
 //   is a pure managed byte-pattern check (PE/COFF/archive-executable guard) — no native
 //   dependency, confirmed by reading its decompiled body.
 //
-//   This narrows the refusal for PNG only. Content whose first 8 bytes are not the PNG
-//   signature is untouched — it still reaches GetImageWithContentHeaderValidation exactly as
-//   before. Content that looks like a PNG but fails structural validation (a bad chunk CRC, a
-//   malformed IHDR, truncated data) raises BC's own "not a valid image" error
-//   (NavImageLoadErrorException wrapping ArgumentException, thrown via the same NotAnImage()
-//   helper below) INSTEAD of silently storing invalid bytes as image/png.
-//
-//   Not a claim of byte-for-byte equivalence with a real GDI+ decoder: a PNG that passes this
-//   structural check but that GDI+ would reject for some decoder-specific reason would be
-//   accepted here and refused on a real tier. See docs/scope.md.
-using System.Buffers.Binary;
+//   MEASURED, not assumed: an earlier version of this file additionally validated every PNG
+//   chunk's CRC32 and IHDR's declared width/height, reasoning that PNG validity is checkable
+//   "structurally". Two full rounds of upstream corpus CI (27.0-28.4, all 8 legs each — see
+//   StefanMaron/BusinessCentral.AL.Language.Tests#138) falsified that: BC accepts a PNG with a
+//   wrong IHDR chunk CRC, a stream that is nothing but the 8-byte signature, a stream
+//   truncated in the middle of the IHDR chunk, and a structurally complete PNG whose IHDR
+//   declares width=0 — identically, all 8 legs, both rounds. BC's own PNG acceptance for a
+//   Media field is the 8-byte signature match and NOTHING MORE: no chunk CRC check, no IHDR
+//   presence/shape check, no dimension sanity-check. Matching that exactly (rather than being
+//   STRICTER than BC, which would make the runner reject a PNG BC accepts — a defect in the
+//   opposite direction from #2641) is why this file's classifier does only the signature
+//   check. Content whose first 8 bytes are not the PNG signature is untouched — it still
+//   reaches GetImageWithContentHeaderValidation exactly as before.
 using System.Reflection;
-using System.Text;
 
 namespace AlRunner.Patches;
 
@@ -183,17 +183,17 @@ public static class MediaPatches
     ///   <item>null — no change; the original body runs exactly as before. Covers: an
     ///   explicit mimeType was already given (mirrors the real body's own
     ///   <c>string.IsNullOrEmpty(mimeType)</c> guard), the stream cannot be sniffed, or the
-    ///   first 8 bytes are not the PNG signature at all.</item>
-    ///   <item>"image/png" — the content IS a structurally valid PNG; the caller overwrites
-    ///   the mimeType argument with this and falls through to the real body.</item>
+    ///   first 8 bytes are not the PNG signature.</item>
+    ///   <item>"image/png" — the content's first 8 bytes ARE the PNG signature; the caller
+    ///   overwrites the mimeType argument with this and falls through to the real body.</item>
     ///   </list>
-    /// Throws BC's own "not a valid image" shape (see NotAnImage() above) when the PNG
-    /// signature is present but the chunk structure is corrupt — raised here, BEFORE the
-    /// original body's own try/catch exists, so it propagates as a real error rather than
-    /// being caught by anything.
+    /// Deliberately signature-only — see the file header for the corpus measurement
+    /// (StefanMaron/BusinessCentral.AL.Language.Tests#138) that settled this: real BC
+    /// accepts any signature-prefixed stream, valid PNG or not, so anything stricter here
+    /// would make the runner reject content BC accepts.
     /// </summary>
     [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-    public static string? TryClassifyStructuralPng(object? mediaStreamObj, object? mimeTypeObj)
+    public static string? TryClassifyPngBySignature(object? mediaStreamObj, object? mimeTypeObj)
     {
         if (mimeTypeObj is string existingMimeType && existingMimeType.Length > 0)
             return null;
@@ -204,12 +204,15 @@ public static class MediaPatches
         try
         {
             Span<byte> signature = stackalloc byte[8];
-            if (!TryReadFully(stream, signature) || !signature.SequenceEqual(PngSignature))
+            int read = 0;
+            while (read < signature.Length)
+            {
+                int n = stream.Read(signature.Slice(read));
+                if (n <= 0) break;
+                read += n;
+            }
+            if (read < signature.Length || !signature.SequenceEqual(PngSignature))
                 return null;
-
-            string? reason = ValidatePngChunkStructure(stream);
-            if (reason != null)
-                throw NotAnImage($"the PNG content is structurally invalid: {reason}");
 
             return "image/png";
         }
@@ -217,106 +220,5 @@ public static class MediaPatches
         {
             stream.Position = origin;
         }
-    }
-
-    private static bool TryReadFully(Stream stream, Span<byte> buffer)
-    {
-        int read = 0;
-        while (read < buffer.Length)
-        {
-            int n = stream.Read(buffer.Slice(read));
-            if (n <= 0) return false;
-            read += n;
-        }
-        return true;
-    }
-
-    /// <summary>
-    /// Validates every PNG chunk following the 8-byte signature (already consumed by the
-    /// caller): 4-byte big-endian length, 4-byte ASCII type, `length` bytes of chunk data,
-    /// then a 4-byte big-endian CRC32 over (type+data) — the exact algorithm the PNG
-    /// specification requires (ISO-HDLC / zlib polynomial, the same CRC32 gzip and zip use).
-    /// Requires the first chunk to be IHDR (length 13, positive width and height) and an
-    /// IEND chunk (length 0) to terminate. Returns null when every chunk validates,
-    /// otherwise a short human-readable reason.
-    /// </summary>
-    private static string? ValidatePngChunkStructure(Stream stream)
-    {
-        bool sawIhdr = false;
-        bool sawIend = false;
-        const int maxChunks = 4096; // guards a maliciously/accidentally unbounded chunk count
-        // Allocated ONCE outside the loop (CA2014): a stackalloc's lifetime is the whole
-        // method, not just the loop iteration that created it, so allocating fresh spans
-        // per iteration would accumulate stack usage across up to maxChunks iterations.
-        Span<byte> lengthBuf = stackalloc byte[4];
-        Span<byte> typeBuf = stackalloc byte[4];
-        Span<byte> crcBuf = stackalloc byte[4];
-        for (int i = 0; i < maxChunks && !sawIend; i++)
-        {
-            if (!TryReadFully(stream, lengthBuf))
-                return sawIhdr ? "unexpected end of data before IEND" : "unexpected end of data after signature";
-            uint length = BinaryPrimitives.ReadUInt32BigEndian(lengthBuf);
-            if (length > 0x7FFFFFFF)
-                return "chunk length out of range";
-
-            if (!TryReadFully(stream, typeBuf))
-                return "unexpected end of data reading chunk type";
-            string type = Encoding.ASCII.GetString(typeBuf);
-
-            if (!sawIhdr && type != "IHDR")
-                return "first chunk is not IHDR";
-
-            byte[] data = length == 0 ? Array.Empty<byte>() : new byte[length];
-            if (length > 0 && !TryReadFully(stream, data))
-                return $"unexpected end of data reading {type} chunk body";
-
-            if (!TryReadFully(stream, crcBuf))
-                return $"unexpected end of data reading {type} chunk CRC";
-            uint storedCrc = BinaryPrimitives.ReadUInt32BigEndian(crcBuf);
-            uint computedCrc = Crc32(typeBuf, data);
-            if (computedCrc != storedCrc)
-                return $"{type} chunk CRC mismatch";
-
-            if (type == "IHDR")
-            {
-                if (length != 13) return "IHDR chunk has the wrong length";
-                uint width = BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(0, 4));
-                uint height = BinaryPrimitives.ReadUInt32BigEndian(data.AsSpan(4, 4));
-                if (width == 0 || height == 0) return "IHDR declares zero width or height";
-                sawIhdr = true;
-            }
-            else if (type == "IEND")
-            {
-                sawIend = true;
-            }
-        }
-
-        if (!sawIhdr) return "no IHDR chunk found";
-        if (!sawIend) return "no IEND chunk found";
-        return null;
-    }
-
-    private static readonly uint[] Crc32Table = BuildCrc32Table();
-
-    private static uint[] BuildCrc32Table()
-    {
-        var table = new uint[256];
-        for (uint n = 0; n < 256; n++)
-        {
-            uint c = n;
-            for (int k = 0; k < 8; k++)
-                c = (c & 1) != 0 ? 0xEDB88320 ^ (c >> 1) : c >> 1;
-            table[n] = c;
-        }
-        return table;
-    }
-
-    /// <summary>PNG's CRC32 (ISO-HDLC / zlib polynomial) over the concatenation of two spans.</summary>
-    private static uint Crc32(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b)
-    {
-        uint c = 0xFFFFFFFF;
-        foreach (byte by in a) c = Crc32Table[(c ^ by) & 0xFF] ^ (c >> 8);
-        foreach (byte by in b) c = Crc32Table[(c ^ by) & 0xFF] ^ (c >> 8);
-        return c ^ 0xFFFFFFFF;
     }
 }

--- a/tests/runner-extras/standalone-suites/media-non-image-content/MncTests.Codeunit.al
+++ b/tests/runner-extras/standalone-suites/media-non-image-content/MncTests.Codeunit.al
@@ -78,13 +78,22 @@ codeunit 62042 "MNC Tests"
         Asset."No." := 'IMG-1';
         Asset.Insert();
 
-        // 'iVBORw0KGgo=' decodes to the 8-byte PNG signature 89 50 4E 47 0D 0A 1A 0A. Written
-        // through Base64Convert because AL's OutStream.Write is typed — it cannot emit single
-        // raw bytes. Real image content, so the runner must say plainly that it cannot decode
-        // one here rather than storing it as a blob a caller would read back as an image that
-        // never decoded.
+        // '/9j/' decodes to the 3-byte JPEG SOI marker FF D8 FF. Written through
+        // Base64Convert because AL's OutStream.Write is typed — it cannot emit single raw
+        // bytes. Real (if truncated) image content of a format the runner still cannot
+        // decode, so it must say plainly that it cannot decode one here rather than storing
+        // it as a blob a caller would read back as an image that never decoded.
+        //
+        // Deliberately NOT the PNG signature anymore (#2570): PNG got its own narrower,
+        // structural-validation-based path (see MediaPatches.TryClassifyStructuralPng and
+        // tests/al-language/media/TestMediaPngImport.al upstream) which — correctly —
+        // does NOT refuse a mere PNG-signature-only truncated stream as "this platform
+        // cannot decode PNG"; it reports the more specific "not a valid image" (the
+        // signature is present but there is no valid chunk data behind it). JPEG has no
+        // such carve-out, so it stays the fixture for "an image format this platform
+        // genuinely cannot decode."
         TempBlob.CreateOutStream(ContentOutStream);
-        Base64Convert.FromBase64('iVBORw0KGgo=', ContentOutStream);
+        Base64Convert.FromBase64('/9j/', ContentOutStream);
         TempBlob.CreateInStream(ContentInStream);
 
         asserterror Asset.Content.ImportStream(ContentInStream, 'MNC image');


### PR DESCRIPTION
Closes #2570

## Summary

`MediaPatches.NavMediaImage_GetImageWithContentHeaderValidation` sniffs the media
content's header, recognizes an image by magic bytes, and refuses with a named
`RunnerOutOfScopeException` (`media-image-decode`) because decoding needs
`System.Drawing`, unavailable on this platform (no libgdiplus). That refusal is
correct for a format whose validity genuinely depends on decoding — PNG turned out not to
be one of those, on real BC.

## Why `NavMediaImage` itself can't be the fix

`GetImageWithContentHeaderValidation`'s declared return type is `System.Drawing.Image`,
and the caller (`NavMediaFactory.ProcessMediaObject`) immediately constructs `new
NavMediaImage(image, stream)` from a successful return — there is no path through
`NavMediaImage` that avoids needing a real `Image` instance. Confirmed by decompiling every
constructor in the chain and by directly testing whether `System.Drawing.Common` can be
subclassed to fake one:

```csharp
public class FakeImage : Image { public FakeImage() { } }
// error CS0122: 'Image.Image()' is inaccessible due to its protection level
```

`System.Drawing.Common` forbids external subclassing entirely. **Bypassing
`NavMediaImage` for PNG is forced, not chosen.**

## The fix

`MediaPatches.TryClassifyPngBySignature` is **prepended** (not a body replacement — the
original body is untouched and still runs) to the start of
`NavMediaFactory.ProcessMediaObject(Stream, bool, string)` via Cecil. For content whose
first 8 bytes are the PNG signature and the caller passed no explicit mimeType, it
overwrites the mimeType **parameter** (via `starg`) to `"image/png"` and falls through into
the real, unmodified body: with mimeType now non-empty it skips
`GetImageWithContentHeaderValidation` entirely, and because `NavMediaImage.IsSupportedMimeType`
is separately rewritten elsewhere in this file to always answer `false` on this platform,
`"image/png"` cascades straight past every image/pdf/word/excel/powerpoint/onenote/text
branch to BC's own generic fallback, `new NavMediaBinaryFile(mediaStream, mimeType)` —
unmodified BC code, confirmed to be a pure managed byte-pattern check by decompiling its
constructor chain, no native dependency. No decoded image is fabricated: the bytes BC
stores are exactly the bytes AL supplied.

## Measured, not assumed: BC does no structural PNG validation beyond the signature

The first version of this PR additionally validated every PNG chunk's CRC32 and IHDR's
declared width/height, reasoning that PNG validity is checkable "structurally". **Real BC
disagreed, twice.** Two full rounds of corpus CI
(StefanMaron/BusinessCentral.AL.Language.Tests#138, 27.0-28.4, all 8 legs each):

- Round 1: a PNG with a valid signature but a corrupted IHDR chunk CRC — asserted rejected,
  **BC accepted it.**
- Round 2, to separate "BC skips CRC checks" from "BC validates structure at all": a
  signature-only stream (no IHDR), a stream truncated mid-IHDR-chunk (no CRC, no
  IDAT/IEND), a structurally complete PNG with IHDR width=0, and non-PNG content — **BC
  accepted every PNG-signature-prefixed case**, identically across all 8 legs both times.

Conclusion: BC's PNG acceptance for a Media field is the 8-byte signature match and
nothing more. Being stricter than that (the original CRC/IHDR-validating implementation)
made the runner reject PNGs real BC accepts — the same class of defect as #2641 (runner
accepting AL that BC refuses), pointed the other way. Simplified
`TryClassifyStructuralPng` → `TryClassifyPngBySignature`, dropped the CRC32 table, the
chunk-walking loop, and the "structurally invalid" throw path entirely — there is no
rejection case left for PNG-signature-prefixed content.

## Same-shape audit

`tests/runner-extras/standalone-suites/media-non-image-content`'s
`ImageContent_IsRefusedByName` fixture used a PNG-signature-only (8-byte) stream to
exercise the "real image, refused by name" path. Since BC (and now the runner) accepts a
signature-only PNG, that fixture moved to a JPEG SOI marker — still refused by name,
unaffected by this change.

## RED -> GREEN

Re-verified in a fresh, independent worktree, rebased onto current `main`:

**RED (before this PR at all):**
```
FAIL  Media_ImportStream_ValidPng_HasValueTrue
      Unexpected out-of-scope: NavMediaImage.GetImageWithContentHeaderValidation
      (reason: media-image-decode ...)
```

**GREEN (current, matching the measured corpus expectations):**
```
PASS  Media_ImportStream_ValidPng_HasValueTrue
PASS  Media_ExportStream_ValidPng_SameByteLengthAsImported
PASS  Media_ImportStream_PngWithCorruptIhdrCrc_Succeeds
PASS  Media_ImportStream_SignatureOnly_Succeeds
PASS  Media_ImportStream_TruncatedMidIhdr_Succeeds
PASS  Media_ImportStream_ZeroWidthIhdr_Succeeds
PASS  Media_ImportStream_NonPngContent_StillFallsBackToOctetStream
```

`tests/runner-extras/standalone-suites` (107 tests, including the updated
`media-non-image-content` fixture): 0 failures. `AlRunner.Tests` `Media*` filter: 31/31.

## Proving tests

- **Upstream:** StefanMaron/BusinessCentral.AL.Language.Tests#138
  (`tests/al-language/media/TestMediaPngImport.al`) — open, corpus CI green on the current
  (corrected) assertions across all 8 legs, not yet merged.
- **Runner-internal mechanism:** `AlRunner.Tests/MediaFactoryProcessMediaObjectPngPrependTests.cs`
  — pins the `ProcessMediaObject` Cecil registration and `TryClassifyPngBySignature`'s
  classification for: a valid PNG, a corrupt-CRC PNG (still `image/png`, matching BC), a
  signature-only stream (still `image/png`), an explicit-mimeType override, non-PNG
  content, and a non-seekable stream.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf