### PR TITLE
ci: stop the changelog sync losing a race it cannot win

### DIFF
--- a/.github/workflows/sync-changelog-unreleased.yml
+++ b/.github/workflows/sync-changelog-unreleased.yml
@@ -40,6 +40,15 @@ name: Sync CHANGELOG [Unreleased]
 # documented way publish.yml's release job does — via RELEASE_DEPLOY_KEY, a
 # deploy key with "Always allow" set for it.
 
+# Only one sync may be in flight at a time. Without this, a merge wave starts one
+# run per merged PR, they queue behind the account-wide Actions pool, and each one
+# wakes up holding a CHANGELOG computed against a commit that is no longer the tip.
+# The newest run is always the correct one -- this job's whole purpose is to reflect
+# CURRENT main -- so superseded runs should be cancelled, not merely lose the race.
+concurrency:
+  group: sync-changelog-unreleased
+  cancel-in-progress: true
+
 on:
   push:
     branches: [main]
@@ -77,9 +86,38 @@ jobs:
         id: sync
         run: python3 .github/scripts/generate_changelog.py --unreleased >> "$GITHUB_OUTPUT"
 
+      # #2630: this used to be `git add && git commit && git push origin HEAD:main`, a
+      # plain fast-forward from the commit that triggered the run. Under a merge wave the
+      # run waits minutes in the account-wide Actions queue, main moves, and the push is
+      # rejected with "cannot lock ref refs/heads/main: is at X but expected Y". Measured
+      # on 24 consecutive runs: 11 failed exactly this way. The CHANGELOG content was
+      # never lost -- the next run recomputes it -- but main carried a failed run for a
+      # reason unrelated to the commit under it, and a red main is not announced anywhere.
+      #
+      # Recompute against origin/main rather than rebasing the commit: the section is
+      # derived from `git describe --tags`..HEAD, so what it should say depends on which
+      # commits are on main NOW, not on which were there when this run was scheduled.
       - name: Commit and push if it changed
         if: steps.sync.outputs.changed == 'true'
         run: |
-          git add CHANGELOG.md
-          git commit -m "chore: update changelog [skip ci]"
-          git push origin HEAD:main
+          for attempt in 1 2 3 4 5; do
+            git fetch origin main
+            git checkout -B sync-retry origin/main
+            out=$(python3 .github/scripts/generate_changelog.py --unreleased)
+            echo "$out"
+            case "$out" in
+              *changed=true*) ;;
+              *)
+                echo "nothing left to write against $(git rev-parse --short origin/main) — another run got there first"
+                exit 0
+                ;;
+            esac
+            git add CHANGELOG.md
+            git commit -m "chore: update changelog [skip ci]"
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "main moved while pushing; recomputing (attempt $attempt of 5)"
+          done
+          echo "::error::main moved under this job 5 times running — something is pushing to main continuously"
+          exit 1


### PR DESCRIPTION
Closes #2630

## What was wrong

The sync job computed `CHANGELOG.md` against the commit that triggered it, then pushed to `main` as a plain fast-forward. Actions concurrency is shared across the whole account, so under a merge wave the run waits minutes in the queue, `main` moves, and the push is rejected:

```
! [remote rejected] HEAD -> main (cannot lock ref 'refs/heads/main':
  is at 3002c19d but expected 63256caf)
```

Run `33802284475` was created at 20:26:41 and reached its push step at 20:38:14. Two PRs merged in those twelve minutes.

## How often

Over the last 24 runs on `main`: **11 failed this way**, 9 succeeded, 4 were cancelled as superseded.

## Why it matters even though nothing is lost

The content is never lost — the next run recomputes the section from scratch, so this is self-correcting. The cost is that `main` carries a failed run for a reason that has nothing to do with the commit under it. Nothing announces a red `main`; the last time it went red it was found only because a contributor's PR inherited the failure and someone traced it.

## The change

**A concurrency group.** A merge wave no longer starts one queued run per merged PR. The newest run is always the correct one, because the job exists to reflect current `main`, so superseded runs are cancelled rather than left to lose the race minutes later.

**A fetch, recompute and retry around the push**, up to five attempts. It recomputes rather than rebasing the commit, and that distinction is the point: the section is derived from the `git describe --tags`..HEAD range, so what it should say depends on which commits are on `main` now, not on which were there when the run was scheduled. Rebasing would carry forward a section computed against a tip that no longer exists.

If the recomputation finds nothing left to write, another run got there first and this one exits 0 rather than failing.

## Why not a wider change

The release job in `publish.yml` also pushes to `main` as a fast-forward and also fails when `main` moves. That one is correct as it stands and is deliberately left alone: a release must pin an exact commit, so failing and being re-dispatched is the right behavior. This job has no such requirement.

## Test plan

The workflow has no unit-testable extraction, so this is reviewed as configuration:

- [x] `yaml.safe_load` parses the file; `concurrency` resolves to `{group: sync-changelog-unreleased, cancel-in-progress: True}` and the `sync` job still has 4 steps.
- [x] The retry loop's success path is `exit 0` on a successful push and on a no-op recomputation, and the only non-zero exit is after five consecutive losses, which would mean something is pushing to `main` continuously.
- [ ] Real behavior is observable on the next merge wave: failed sync runs on `main` should stop appearing.

The commit message the job writes is unchanged, including its CI-skip marker, so the existing self-retrigger reasoning in the file's header comment still holds.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
