### PR TITLE
fix(expectations): drop two Feature Key known-gap entries that main already passes

### DIFF
--- a/tests/expectations/known-gaps-testpage-part-instance-pin-bump.json
+++ b/tests/expectations/known-gaps-testpage-part-instance-pin-bump.json
@@ -26,26 +26,10 @@
   {
     "codeunitId": 60958,
     "CodeunitName": "Test Feature Key Table",
-    "Method": "Record_FeatureKey_FindSet_AnswersRows",
-    "Mode": "expect-fail-known-gap",
-    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2636",
-    "Note": "Surfaced by the al-language pin bump landing alongside issue #2201's fix (StefanMaron/BusinessCentral.AL.Language.Tests commit 63d94fd, #132) -- unrelated to #2201's own claim. The runner has no materialisation for the Feature Key virtual table (2000000211) yet, so it answers zero rows. Tracked as #2636."
-  },
-  {
-    "codeunitId": 60958,
-    "CodeunitName": "Test Feature Key Table",
-    "Method": "Record_FeatureKey_EveryRowHasAnIdThatGetRoundTrips",
-    "Mode": "expect-fail-known-gap",
-    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2636",
-    "Note": "Same gap as Record_FeatureKey_FindSet_AnswersRows in this file -- no rows to round-trip an id from. Tracked as #2636."
-  },
-  {
-    "codeunitId": 60958,
-    "CodeunitName": "Test Feature Key Table",
     "Method": "Record_FeatureKey_ModifyingAReadOnlyColumn_RaisesNamingTheField",
     "Mode": "expect-fail-known-gap",
     "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2636",
-    "Note": "Same gap as Record_FeatureKey_FindSet_AnswersRows in this file -- no row to attempt the modify against. Tracked as #2636."
+    "Note": "Feature Key rows ARE materialised now -- PR 2615 routed the table to BC's own FeatureKeyDataProvider and closed issue 2585, and the two sibling entries for FindSet and Get round-tripping were removed when that landed. What remains is only the WRITE path: real BC's Modify writes new feature state through to table 2000000210, which is not implemented here, so a Modify lands in the temp store and goes nowhere instead of raising. Measured at pin 040fbdd. The linked issue's title still says the table answers no rows; that half is fixed and only the write path is open. Passes on real BC on all eight corpus versions -- StefanMaron/BusinessCentral.AL.Language.Tests#132."
   },
   {
     "codeunitId": 60263,


### PR DESCRIPTION
No linked issue: this repairs a red `main` caused by two PRs merging in an order neither could see. It is not a tracked defect.

## `main` is red

PR 2642's pin bump declared three Feature Key tests as `expect-fail-known-gap`. PR 2615 — which routes the Feature Key virtual table to BC's own `FeatureKeyDataProvider` — had already merged, so two of those three now pass, and the manifest drift check fails them in the other direction:

```
Codeunit60958.Record_FeatureKey_FindSet_AnswersRows
Codeunit60958.Record_FeatureKey_EveryRowHasAnIdThatGetRoundTrips
  Test passed cleanly but manifest declares expect-fail-known-gap
  (issue 2636). Remove the entry.
```

## Measured, not predicted

Full corpus run at pin `040fbdd`, on `main` as it stands:

| | tests | pass | fail |
|---|---|---|---|
| `main` now | 2417 | 2415 | 2 |
| with this change | 2417 | 2417 | 0 |

Both failures are the drift above and nothing else.

## The third entry stays

`Record_FeatureKey_ModifyingAReadOnlyColumn_RaisesNamingTheField` still fails, and legitimately: real BC's `Modify` writes new feature state through to table 2000000210, which is not implemented here, so the write lands in the temp store and goes nowhere instead of raising. Only the read half was fixed.

Its `Note` now says exactly that, and records that issue 2636's title still describes the whole table as answering no rows — that half is fixed, and only the write path remains open. Worth retitling or closing that issue, which I have left to its author.

## Nobody made a mistake here

Both PRs were green when their own CI ran, and 2642 was textually clean against `main`. Its verdict simply predated 2615's merge. `ci-verdicts.md` names this case directly: `mergeStateStatus: CLEAN` only checks textual conflicts and says nothing about `main` moving underneath a PR semantically. The manifest drift check is what caught it, working exactly as designed and in the direction that is easy to forget it covers.

## Test plan

- [x] Corpus at `040fbdd` before the change: 2415 pass, 2 fail, both the drift.
- [x] After: 2417/2417, 0 fail, 0 error, `--strict --count-baseline`, exit 0.
- [x] `pass-known-gap` drops from 6 to 6 with one fewer entry consumed, and the count baseline is untouched at 2417.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
