### PR TITLE
fix(install): arm event-subscriber injection before the first Install trigger

### DIFF
--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -380,6 +380,23 @@ public sealed class TestExecutor
         }
         using (AlRunner.Infrastructure.PhaseLog.AppStage("install-seed-set-test-assembly"))
             InstallTriggerRunner.SetTestAssembly(assembly);
+        // #2592: arm subscriber injection before ANY Install trigger below —
+        // RunDependenciesOnly() a few lines down (on a dep-company-baseline cache
+        // MISS) and RunTestAssemblyOnly() unconditionally after it. Both dep
+        // assemblies (registered via SetDependencyAssemblies before this method
+        // runs) and this bundle's own assembly (just set above) are already loaded
+        // in AppDomain by this point, so their [EventSubscriber] codeunits are
+        // visible to reflection — but PopulateNclMetadataCache's initial InjectAll
+        // ran earlier, at Register() time, before either was loaded. Without this
+        // call an Install trigger that raises an integration event dispatches to
+        // no subscribers: the publisher's static <Event>_Scope is still empty, so
+        // BC's own publisher code takes its "no subscribers" early exit. The
+        // per-test-codeunit loop below re-arms the same idempotent call for
+        // subscribers whose class is discovered only later (e.g. a [Test]
+        // codeunit's own containing type), so this does not replace that call —
+        // it just closes the window before the FIRST Install trigger runs.
+        using (AlRunner.Infrastructure.PhaseLog.AppStage("install-seed-arm-event-subscribers"))
+            AlRunner.Patches.EventSubscriberPatches.InjectAllUsingStoredLookup();
         // #1867: install-seed-run-install-triggers + install-seed-ensure-company-initialized
         // were 62.4% + 20.1% = 82.5% of run_ms (#1866's own APP STAGES measurement), and both
         // are re-executing the SAME dependency assemblies' Install triggers / the SAME

--- a/tests/expectations/known-gaps-testpage-part-instance-pin-bump.json
+++ b/tests/expectations/known-gaps-testpage-part-instance-pin-bump.json
@@ -8,22 +8,6 @@
     "Note": "Surfaced by the al-language pin bump landing alongside issue #2201's fix (StefanMaron/BusinessCentral.AL.Language.Tests commit 3661f1d, #121) -- unrelated to #2201's own claim. Real BC formats the Integer virtual table's Number field as '10.00' on the first row of a self-loaded SourceTable Integer ListPart; the runner answers '10'. Not investigated further; tracked as #2634."
   },
   {
-    "codeunitId": 60835,
-    "CodeunitName": "Test Install Event Dispatch",
-    "Method": "TestInstallEvent_SubscriberRanDuringInstall",
-    "Mode": "expect-fail-known-gap",
-    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2635",
-    "Note": "Surfaced by the al-language pin bump landing alongside issue #2201's fix (StefanMaron/BusinessCentral.AL.Language.Tests commit d5f3f4f, #129) -- unrelated to #2201's own claim. A subscriber to an integration event raised from OnInstallAppPerCompany never runs during the runner's install-trigger dispatch. Not investigated further; tracked as #2635."
-  },
-  {
-    "codeunitId": 60835,
-    "CodeunitName": "Test Install Event Dispatch",
-    "Method": "TestInstallEvent_SeededExactlyOneRow",
-    "Mode": "expect-fail-known-gap",
-    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2635",
-    "Note": "Same gap as TestInstallEvent_SubscriberRanDuringInstall in this file -- the unrun subscriber seeds zero rows instead of one. Tracked as #2635."
-  },
-  {
     "codeunitId": 60958,
     "CodeunitName": "Test Feature Key Table",
     "Method": "Record_FeatureKey_ModifyingAReadOnlyColumn_RaisesNamingTheField",


### PR DESCRIPTION
Closes #2592

## Mechanism found

Registered-but-not-fired, not never-registered. `EventSubscriberPatches.InjectAllUsingStoredLookup()` was armed for the *first* time inside `TestExecutor`'s per-test-codeunit loop, strictly after both `InstallTriggerRunner.RunDependenciesOnly()` and `RunTestAssemblyOnly()` run. `PopulateNclMetadataCache`'s initial `InjectAll` call happens once, earlier, at `Register()` time -- before either the bundle's dependency assemblies or its own test assembly are loaded into the AppDomain. So any `[EventSubscriber]` codeunit living in either of those assemblies was invisible to the publisher's static `<Event>_Scope` for the entire install-seed phase: BC's own publisher code took its "no subscribers" early exit when an Install trigger raised the event, exactly as the issue's reproducer showed.

Evidence distinguishing this from a registration gap: the loop's own re-arm call (`AL_RUNNER_HOOK_AUDIT` isn't needed here -- this isn't a JmpHook) already exists and already works for tests that run *after* the loop starts; the corpus test's own third case, `TestInstallEvent_UnseededRowRaisesExpectedError`, was passing before this fix (a plain negative-path assertion that the row is absent), confirming the subscriber method itself compiles and is discoverable -- it just never got wired into the publisher's scope before the Install trigger fired.

## Fix

One call, placed once, right after `InstallTriggerRunner.SetTestAssembly(assembly)` and before either Install-trigger call: `AlRunner.Patches.EventSubscriberPatches.InjectAllUsingStoredLookup()`. It's idempotent, so this doesn't duplicate or reorder anything the per-codeunit loop already does -- it just closes the window before the *first* Install trigger, wherever it comes from.

## Fixing the shape, not just the reported line

The issue's own reproducer only exercises the bundle's own Install codeunit (`RunTestAssemblyOnly`). `RunDependenciesOnly()` -- a dependency app's Install trigger raising an event a subscriber (in that dep, or another loaded dep) needs -- shares the exact same root cause and was equally broken, just not what the corpus test happened to cover. Placing the injection call once, ahead of *both* call sites, fixes both instead of papering over only the reported one.

## Corpus

The proving test already exists upstream and is already merged at the current pin (`040fbdd`, `tests/al-language/tests/al-language/install/TestInstallEventDispatch_Tests.al`, codeunit 60835, StefanMaron/BusinessCentral.AL.Language.Tests#129) -- no pin bump needed for this PR.

RED (baseline, with the two `known-gaps` entries temporarily removed to surface the raw result):
```
FAIL  Codeunit60835.TestInstallEvent_SubscriberRanDuringInstall
      Assert.IsTrue failed. a subscriber to an integration event raised from OnInstallAppPerCompany must have run during install
FAIL  Codeunit60835.TestInstallEvent_SeededExactlyOneRow
      Assert.AreEqual failed. Expected:<1> (Integer). Actual:<0> (Integer).
```

GREEN (same two tests, after the fix, ran twice -- cold and warm -- for cache-sensitivity):
```
PASS  Codeunit60835.TestInstallEvent_SubscriberRanDuringInstall
PASS  Codeunit60835.TestInstallEvent_SeededExactlyOneRow
PASS  Codeunit60835.TestInstallEvent_UnseededRowRaisesExpectedError
```

Full corpus (`--strict --count-baseline`), local run at the current pin: **2417/2417 pass**, 0 fail, 0 error, no count-baseline drift. `runner-extras`: **218/218 pass**. Targeted `AlRunner.Tests` (`InstallBaselineDiskCacheTests`, `InstallSeedDepCompanyCacheTests`, `ObjectEventSubscriberRegistrationMechanismTests`, `AlCallStackCaptureNoFallbackTests` -- the classes closest to this pipeline): 16/16 pass.

This PR removes the two `expect-fail-known-gap` entries in `tests/expectations/known-gaps-testpage-part-instance-pin-bump.json` for `Codeunit60835.TestInstallEvent_SubscriberRanDuringInstall` and `TestInstallEvent_SeededExactlyOneRow` -- they now pass for real, so the manifest-drift check requires removing them. The other three entries in that file are unrelated gaps and are untouched.

## Note on #2635

Issue #2635 tracks the same gap as this issue's own corpus-pin-bump discovery and duplicates #2592, which this PR closes. It can be closed as a duplicate once this lands -- not closing it myself per the workflow contract.

## Not done here (out of scope for this fix, noted per the issue body)

The issue also names a `--watch` divergence (a warm cycle dispatches correctly off a surviving static, a cold cycle didn't) as a legitimate `tests/runner-extras/` claim. This fix structurally removes the divergence too, since the cold cycle now arms injection before its first Install trigger just like every later cycle -- but I did not add a dedicated `--watch` regression test for it in this PR, since the corpus test already proves the underlying mechanism and the existing `AlRunner.Tests/Watch*.cs` pattern for a two-cycle subprocess-driven test is substantial additional surface for a claim this fix already settles. Flagging it here rather than silently dropping it.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf