### PR TITLE
fix(watch): clear page/xmlport metadata registries on reload without regressing #1957

### DIFF
--- a/AlRunner.Tests/Fixtures/WatchPageMetadataReloadDelete/RPRGone.Page.al
+++ b/AlRunner.Tests/Fixtures/WatchPageMetadataReloadDelete/RPRGone.Page.al
@@ -1,0 +1,26 @@
+/// <summary>
+/// The DELETED page — WatchPageMetadataReloadDeleteTests removes this file between cycle 1
+/// and cycle 2. Nothing else in this fixture references "RPR Gone" (deliberately: it only
+/// needs to exist long enough to register once, so deleting it never breaks a compile
+/// reference elsewhere). Its cycle-2 AL_RUNNER_TRACE_PAGE_METADATA output must be silent for
+/// this page id — proving BcRuntime.ResetForNewBundleReload()'s AlPageMetadataRegistry.Clear()
+/// actually took effect and nothing resurrects a page the bundle no longer declares.
+/// </summary>
+page 70202 "RPR Gone"
+{
+    PageType = List;
+    SourceTable = "RPR Row";
+    ApplicationArea = All;
+    UsageCategory = Lists;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Entries)
+            {
+                field("Code"; Rec."Code") { ApplicationArea = All; }
+            }
+        }
+    }
+}

--- a/AlRunner.Tests/Fixtures/WatchPageMetadataReloadDelete/RPRKeep.Page.al
+++ b/AlRunner.Tests/Fixtures/WatchPageMetadataReloadDelete/RPRKeep.Page.al
@@ -1,0 +1,27 @@
+/// <summary>
+/// The SURVIVING page — untouched by the edit WatchPageMetadataReloadDeleteTests makes
+/// between cycles. Its cycle-2 AL_RUNNER_TRACE_PAGE_METADATA re-registration line proves
+/// the shadow-snapshot replay in BcCompiler.Incremental.cs (see _radPageMetadataByModule):
+/// this app group's own files are otherwise unchanged this cycle (RPR Gone.Page.al was
+/// deleted, which IS a change to the bundle, but not to THIS file), so nothing but that
+/// replay re-registers this page's metadata after BcRuntime.ResetForNewBundleReload()
+/// cleared it at the top of the cycle.
+/// </summary>
+page 70201 "RPR Keep"
+{
+    PageType = List;
+    SourceTable = "RPR Row";
+    ApplicationArea = All;
+    UsageCategory = Lists;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Entries)
+            {
+                field("Code"; Rec."Code") { ApplicationArea = All; }
+            }
+        }
+    }
+}

--- a/AlRunner.Tests/Fixtures/WatchPageMetadataReloadDelete/RPRRow.Table.al
+++ b/AlRunner.Tests/Fixtures/WatchPageMetadataReloadDelete/RPRRow.Table.al
@@ -1,0 +1,15 @@
+/// <summary>Shared source table for both pages in this fixture. See WatchPageMetadataReloadDeleteTests.</summary>
+table 70200 "RPR Row"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Code"; Code[20]) { }
+    }
+
+    keys
+    {
+        key(PK; "Code") { Clustered = true; }
+    }
+}

--- a/AlRunner.Tests/Fixtures/WatchPageMetadataReloadDelete/RPRTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/WatchPageMetadataReloadDelete/RPRTests.Codeunit.al
@@ -1,0 +1,16 @@
+/// <summary>
+/// Never edited between cycles — its own PASS on both cycles is only used to confirm each
+/// --watch cycle actually finished; the real claim WatchPageMetadataReloadDeleteTests checks
+/// is the AL_RUNNER_TRACE_PAGE_METADATA=1 stderr trace, not this test's result.
+/// </summary>
+codeunit 70203 "RPR Tests"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure CycleCompletes()
+    begin
+        // Deliberately empty — an AL [Test] with no body always passes; see this codeunit's
+        // header comment for what this is actually standing in for.
+    end;
+}

--- a/AlRunner.Tests/Fixtures/WatchPageMetadataReloadDelete/app.json
+++ b/AlRunner.Tests/Fixtures/WatchPageMetadataReloadDelete/app.json
@@ -1,0 +1,23 @@
+{
+  "id": "a3000000-0000-4000-8000-000000000021",
+  "name": "Runner Tests Fixture - Watch Page Metadata Reload Delete",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "#2593/#2579: a deleted page's metadata must stop answering after the next --watch reload, while a page that survives unchanged must keep answering.",
+  "description": "Used by AlRunner.Tests' WatchPageMetadataReloadDeleteTests. Cycle 1 declares both 'RPR Keep' and 'RPR Gone'; between cycles the test deletes RPR Gone's .al file (nothing else references it, so the bundle still compiles) and asserts AL_RUNNER_TRACE_PAGE_METADATA=1 output on cycle 2: RPR Keep's page id is re-registered (the shadow-snapshot replay this fix adds), RPR Gone's is not (BcRuntime.ResetForNewBundleReload() cleared it and nothing re-registers a page the bundle no longer declares).",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "idRanges": [
+    {
+      "from": 70200,
+      "to": 70219
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner.Tests/WatchPageMetadataReloadDeleteTests.cs
+++ b/AlRunner.Tests/WatchPageMetadataReloadDeleteTests.cs
@@ -1,0 +1,199 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #2593/#2579: a deleted page's metadata must stop answering after the next --watch
+/// reload, while a page that survives unchanged must keep answering.
+///
+/// Root cause (verified empirically, not assumed — see the PR body for the full trace):
+/// AlPageMetadataRegistry/AlXmlPortMetadataRegistry are populated ONLY as a side effect of
+/// BC's own Compilation.Emit (BcCompiler.CaptureOutputter.AddApplicationObject). Before this
+/// fix, BcRuntime.ResetForNewBundleReload() never cleared either registry — issue #2593's own
+/// finding, AlPageMetadataRegistry.Clear()/AlXmlPortMetadataRegistry.Clear() existed with zero
+/// callers anywhere in the repo. Naively adding those Clear() calls regressed #1957
+/// (WatchPageMetadataReloadTests) — a page whose own .al file is UNCHANGED between two
+/// --watch cycles never runs a full Emit again on the second cycle:
+///   - "genuinely zero work" (BcCompiler.Incremental.cs's TryEmitIncremental): this app
+///     group's files hash identical to the last cycle, so it replays the previous cycle's
+///     BcEmitOutput verbatim WITHOUT calling Emit at all.
+///   - a real RAD delta only runs Emit for the objects that actually changed this cycle —
+///     an unrelated file being deleted does not re-register a page that was not touched.
+/// So clearing without also restoring what an unaffected object's metadata used to be wipes
+/// out surviving pages just as thoroughly as deleted ones. The fix threads a per-app-group
+/// shadow snapshot through BcCompiler.Incremental.cs (see its own header comment on
+/// _radPageMetadataByModule) that survives the reset and is replayed on every RAD fast path,
+/// dropping only the ids an app genuinely no longer declares.
+///
+/// This fixture is a single, standalone app (deliberately NOT the R3Pages/R3Driver
+/// cross-app dependency shape WatchPageMetadataReloadTests uses) so the claim here is
+/// specifically about ONE app group's own RAD delta path — DependencyLoader's separate
+/// AppId-reuse cache (the mechanism WatchPageMetadataReloadTests exercises) is a different
+/// code path with its own fix (DependencyLoader.ReplayDependencyMetadataSidecars).
+///
+/// Observed via AL_RUNNER_TRACE_PAGE_METADATA=1's "[page-metadata] registered page N" stderr
+/// line — a real AL-level "does the deleted page still answer" flow is not constructible: the
+/// page's OWN CLR type is dropped from the compiled module the instant its .al file is
+/// deleted (BcCompiler.Incremental.cs's own vacated-object handling — proven separately,
+/// unconditionally, and not this fix's concern), so nothing in AL could ever again construct
+/// an instance to query. The registry's own id-keyed lifecycle — "does a query for THIS id
+/// still find something" — is the actual, narrower claim #2593 makes, and the trace line is
+/// its direct, unmediated signal.
+///
+/// Spawns the real runner in --watch mode; needs the BC artifact cache. Skips (no-op) when
+/// absent.
+/// </summary>
+public class WatchPageMetadataReloadDeleteTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string FixtureRoot = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "WatchPageMetadataReloadDelete"));
+
+    private const int KeepPageId = 70201;
+    private const int GonePageId = 70202;
+
+    private static void CopyDir(string src, string dst)
+    {
+        Directory.CreateDirectory(dst);
+        foreach (var f in Directory.GetFiles(src))
+            File.Copy(f, Path.Combine(dst, Path.GetFileName(f)));
+    }
+
+    // Same conditional-existence pattern as WatchPageMetadataReloadTests.ExtraPackageCacheArgs.
+    private static string[] ExtraPackageCacheArgs()
+    {
+        var platformApps = TestArtifacts.PlatformAppsDir();
+        return Directory.Exists(platformApps)
+            ? new[] { "--package-cache", platformApps }
+            : Array.Empty<string>();
+    }
+
+    [SkippableFact]
+    public async Task Watch_PageDeletedBetweenCycles_StopsAnswering_SurvivingPageStillDoes()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var bundle = Path.Combine(Path.GetTempPath(), "al-runner-watch-pagemeta-delete", Guid.NewGuid().ToString("N"));
+        CopyDir(FixtureRoot, bundle);
+        var gonePagePath = Path.Combine(bundle, "RPRGone.Page.al");
+        Assert.True(File.Exists(gonePagePath));
+
+        var lines = new List<CapturedLine>();
+        var argsBuilder = new StringBuilder(
+            TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg
+            + $" \"{bundle}\" --watch --no-cache");
+        foreach (var a in ExtraPackageCacheArgs()) argsBuilder.Append($" \"{a}\"");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = argsBuilder.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        // The claim this test proves lives on stderr (AL_RUNNER_TRACE_PAGE_METADATA), not
+        // stdout — set on the child process only, same isolation shape WatchTests.cs uses
+        // for its own env-var-gated diagnostics.
+        psi.EnvironmentVariables["AL_RUNNER_TRACE_PAGE_METADATA"] = "1";
+        using var p = Process.Start(psi)!;
+        void Pump(StreamReader r, OutputStream stream) => Task.Run(async () =>
+        {
+            string? l;
+            while ((l = await r.ReadLineAsync()) != null) lock (lines) lines.Add(new CapturedLine(stream, l));
+        });
+        Pump(p.StandardOutput, OutputStream.Stdout);
+        Pump(p.StandardError, OutputStream.Stderr);
+
+        string ProcessLiveness() => p.HasExited ? $"process alive=false exit={p.ExitCode}" : "process alive=true";
+        string DumpAll() { lock (lines) return string.Join("\n", lines.Select(l => $"[{l.Stream}] {l.Text}")); }
+
+        async Task<int> WaitForMarkerAfter(int fromIndex, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                List<int> found;
+                lock (lines)
+                    found = WatchOutputSlicing.FindStdoutMarkerIndices(
+                        lines, WatchOutputSlicing.WaitingForSourceMarker, fromIndex);
+                if (found.Count > 0) return found[0];
+                if (p.HasExited)
+                {
+                    await Task.Delay(500);
+                    throw new TimeoutException(
+                        $"watch marker not seen — subprocess exited early ({ProcessLiveness()}).\n" +
+                        $"--- full subprocess output ---\n{DumpAll()}");
+                }
+                await Task.Delay(200);
+            }
+            if (p.HasExited) await Task.Delay(500);
+            throw new TimeoutException(
+                $"watch marker not seen. {ProcessLiveness()}\n--- full subprocess output ---\n{DumpAll()}");
+        }
+
+        string Segment(int from, int to) { lock (lines) return WatchOutputSlicing.MergedJoin(lines, from, to); }
+
+        void CheckCycle(string label, Action check)
+        {
+            try { check(); }
+            catch (Exception ex)
+            {
+                throw new Exception(
+                    $"{label}: {ex.Message}\n--- full subprocess output ({lines.Count} lines) ---\n{DumpAll()}", ex);
+            }
+        }
+
+        try
+        {
+            // Cycle 1 (cold): the test passes, and both pages register their metadata — the
+            // baseline every later assertion is relative to.
+            int m1 = await WaitForMarkerAfter(0, TimeSpan.FromSeconds(150));
+            var cycle1 = Segment(0, m1);
+            CheckCycle("cycle 1", () =>
+            {
+                Assert.Contains("PASS  Codeunit70203.CycleCompletes", cycle1);
+                Assert.Contains($"[page-metadata] registered page {KeepPageId}", cycle1);
+                Assert.Contains($"[page-metadata] registered page {GonePageId}", cycle1);
+            });
+
+            // Delete "RPR Gone" between cycles. Nothing else in the fixture references it, so
+            // the bundle still compiles — this is a genuine object removal, not a broken edit.
+            File.Delete(gonePagePath);
+            Assert.False(File.Exists(gonePagePath));
+
+            int m2 = await WaitForMarkerAfter(m1 + 1, TimeSpan.FromSeconds(240));
+            var cycle2 = Segment(m1 + 1, m2);
+
+            CheckCycle("cycle 2", () =>
+            {
+                // The cycle actually ran and its (untouched, always-passing) test still passes —
+                // this alone proves nothing about the metadata claim, but rules out "the whole
+                // cycle silently failed" as an alternative explanation for either direction below.
+                Assert.Contains("PASS  Codeunit70203.CycleCompletes", cycle2);
+
+                // POSITIVE direction (surviving object): "RPR Keep" was not touched this cycle
+                // — no full Emit ran for it (RAD delta only covers the objects that changed,
+                // "RPR Gone" here) — yet its metadata is re-registered, because the shadow
+                // snapshot this fix adds replays it. Without the fix this line is simply
+                // absent: BcRuntime.ResetForNewBundleReload() cleared the registry and nothing
+                // else touches "RPR Keep" this cycle.
+                Assert.Contains($"[page-metadata] registered page {KeepPageId}", cycle2);
+
+                // NEGATIVE direction (deleted object): "RPR Gone" no longer exists in the
+                // bundle's own source, so nothing registers its id this cycle, and the shadow
+                // snapshot's vacated-id removal (UpdateRadMetadataSnapshotDelta) makes sure the
+                // replay does not resurrect it either. Before BcRuntime.ResetForNewBundleReload
+                // cleared the registry at all (#2593's own finding), this id would have kept
+                // answering forever, for the life of the --watch process.
+                Assert.DoesNotContain($"[page-metadata] registered page {GonePageId}", cycle2);
+            });
+        }
+        finally
+        {
+            try { p.Kill(true); } catch { }
+        }
+    }
+}

--- a/AlRunner/BcCompiler.Incremental.cs
+++ b/AlRunner/BcCompiler.Incremental.cs
@@ -207,6 +207,86 @@ public sealed partial class BcCompiler
 {
     private readonly Dictionary<string, RadBaseline> _radBaselines = new();
 
+    // #2593/#2579: AlPageMetadataRegistry/AlXmlPortMetadataRegistry are populated ONLY as a
+    // side effect of BC's own Compilation.Emit (CaptureOutputter.AddApplicationObject), and
+    // BcRuntime.ResetForNewBundleReload() clears both at the top of every --watch/--server
+    // reload cycle. Both RAD fast paths below can return WITHOUT running a full Emit for
+    // every object this app declares:
+    //   - the "genuinely zero work" fast path (this app's files hash identical to the last
+    //     cycle) never calls Emit at all;
+    //   - a real delta's own `radComp.Emit(...)` (below) only covers the objects that
+    //     actually changed this cycle, not the rest of the app's unchanged objects.
+    // Either way, an object this app still declares but did not touch this cycle would
+    // otherwise silently lose its metadata the moment THIS reload's Reset already ran —
+    // see WatchPageMetadataReloadTests (R3Pages, unchanged, resolved as R3Driver's
+    // dependency), which regresses without this. These two dictionaries are a shadow copy
+    // that lives on THIS BcCompiler instance rather than the process-wide registry, so they
+    // survive the reset; <see cref="ReplayRadMetadataSnapshot"/> restores exactly what a
+    // from-scratch Emit of this app would have (re-)registered, every time a RAD fast path
+    // is about to hand a result back to the caller.
+    private readonly Dictionary<string, Dictionary<int, string>> _radPageMetadataByModule =
+        new(StringComparer.Ordinal);
+    private readonly Dictionary<string, Dictionary<int, string>> _radXmlPortMetadataByModule =
+        new(StringComparer.Ordinal);
+
+    /// <summary>Full (re)capture — called after a clean full Emit, when every object this app
+    /// declares is known and the live registries already hold its current metadata.</summary>
+    private void CaptureRadMetadataSnapshotFull(
+        string moduleName, IEnumerable<NavCA.IApplicationObjectTypeSymbol> declared)
+    {
+        var pages = new Dictionary<int, string>();
+        var xmlPorts = new Dictionary<int, string>();
+        foreach (var sym in declared)
+        {
+            var id = (sym as NavCA.ISymbolWithId)?.Id;
+            if (id == null) continue;
+            if (sym.Kind == NavCA.SymbolKind.Page && AlPageMetadataRegistry.TryGet(id.Value, out var pageXml))
+                pages[id.Value] = pageXml;
+            else if (sym.Kind == NavCA.SymbolKind.XmlPort && AlXmlPortMetadataRegistry.TryGet(id.Value, out var xpXml))
+                xmlPorts[id.Value] = xpXml;
+        }
+        _radPageMetadataByModule[moduleName] = pages;
+        _radXmlPortMetadataByModule[moduleName] = xmlPorts;
+    }
+
+    /// <summary>Incremental update — called after a successful RAD delta. Drops vacated
+    /// (deleted/renamed-away) ids, then refreshes every changed id's metadata from the live
+    /// registry (the delta's own Emit call, immediately above the caller, already populated
+    /// it for exactly these ids).</summary>
+    private void UpdateRadMetadataSnapshotDelta(
+        string moduleName, IEnumerable<RadObjectIdentity> vacatedIds, IEnumerable<RadObjectIdentity> changedIds)
+    {
+        if (!_radPageMetadataByModule.TryGetValue(moduleName, out var pages))
+            _radPageMetadataByModule[moduleName] = pages = new Dictionary<int, string>();
+        if (!_radXmlPortMetadataByModule.TryGetValue(moduleName, out var xmlPorts))
+            _radXmlPortMetadataByModule[moduleName] = xmlPorts = new Dictionary<int, string>();
+
+        foreach (var v in vacatedIds)
+        {
+            if (v.Id is not { } id) continue;
+            if (v.Kind == NavCA.SymbolKind.Page) pages.Remove(id);
+            else if (v.Kind == NavCA.SymbolKind.XmlPort) xmlPorts.Remove(id);
+        }
+        foreach (var c in changedIds)
+        {
+            if (c.Id is not { } id) continue;
+            if (c.Kind == NavCA.SymbolKind.Page && AlPageMetadataRegistry.TryGet(id, out var pageXml))
+                pages[id] = pageXml;
+            else if (c.Kind == NavCA.SymbolKind.XmlPort && AlXmlPortMetadataRegistry.TryGet(id, out var xpXml))
+                xmlPorts[id] = xpXml;
+        }
+    }
+
+    /// <summary>Replays this app's shadow snapshot into the live process-wide registries.
+    /// Idempotent (Register overwrites by id) — safe to call even when nothing has drifted.</summary>
+    private void ReplayRadMetadataSnapshot(string moduleName)
+    {
+        if (_radPageMetadataByModule.TryGetValue(moduleName, out var pages))
+            foreach (var (id, xml) in pages) AlPageMetadataRegistry.Register(id, xml);
+        if (_radXmlPortMetadataByModule.TryGetValue(moduleName, out var xmlPorts))
+            foreach (var (id, xml) in xmlPorts) AlXmlPortMetadataRegistry.Register(id, xml);
+    }
+
     /// <summary>
     /// Object kinds with no numeric Id. Matches issue #1902's own enumeration. Five of the six
     /// (everything but entitlement) ARE represented in SymbolReference.ModuleDefinition and are
@@ -438,6 +518,11 @@ public sealed partial class BcCompiler
         {
             // Every file hashes identical to the last cycle — including a touch-with-identical-
             // bytes. Genuinely zero work: replay the last cycle's result verbatim.
+            //
+            // #2593/#2579: also replay this app's page/xmlport metadata shadow snapshot — see
+            // this class's own header comment on _radPageMetadataByModule for why a "genuinely
+            // zero work" cycle must still restore it even though nothing here calls Emit.
+            ReplayRadMetadataSnapshot(moduleName);
             changedObjects = Array.Empty<AffectedObjectId>();
             return baseline.LastOutput;
         }
@@ -729,6 +814,17 @@ public sealed partial class BcCompiler
             SourceByKey = newSourceByKey,
             LastOutput = output,
         };
+
+        // #2593/#2579: this delta's own radComp.Emit(...) above already refreshed the live
+        // registry for every CHANGED page/xmlport id — update the shadow snapshot to match
+        // (dropping vacated ids, refreshing changed ones from what Emit just wrote), then
+        // replay the FULL snapshot so an id this app still declares but did NOT touch this
+        // cycle — cleared by this reload's Reset, never re-registered by a delta that only
+        // covers the objects it actually changed — is restored too. See this class's own
+        // header comment on _radPageMetadataByModule for the full "why".
+        UpdateRadMetadataSnapshotDelta(
+            moduleName, vacated.Values.Select(v => v.Identity), allChangedIdentities);
+        ReplayRadMetadataSnapshot(moduleName);
 
         return output;
     }
@@ -1172,6 +1268,13 @@ public sealed partial class BcCompiler
             SourceByKey = sourceByKey,
             LastOutput = fullOutput,
         };
+
+        // #2593/#2579: this Emit already ran for real (that is how `captured`/the live
+        // registries got populated), so snapshot every page/xmlport id it declares NOW —
+        // the shadow copy TryEmitIncremental's fast paths replay on every later cycle that
+        // does NOT run a full Emit for this app. See _radPageMetadataByModule's header
+        // comment.
+        CaptureRadMetadataSnapshotFull(moduleName, declared);
     }
 
     /// <summary>Drops the current baseline for a bundle — used when a caller knows the next cycle must be a full rebuild regardless (e.g. a watched suite set changed).</summary>

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -524,6 +524,8 @@ public static partial class BcRuntime
         AlEnumMetadataRegistry.Clear();
         AlReportMetadataRegistry.Clear();
         AlReportLayoutRegistry.Clear();
+        AlPageMetadataRegistry.Clear();
+        AlXmlPortMetadataRegistry.Clear();
         NavReportSync.ResetMetadataCache();
         // Sibling patch classes with their own bundle-derived state.
         AlRunner.Patches.RecordPatches.ResetForReload();

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -29,8 +29,18 @@ public sealed class DependencyLoader
     // already read off app.json / the dependency manifest for every app that
     // reaches this cache, so the comparison costs nothing extra — no content hash,
     // no re-reading source.
+    // Tier3CacheKey is null for every Tier-1 (precompiled DLL) / Tier-2 (R2R) / symbol-only
+    // entry — the overwhelming majority (Base Application, System Application, most real
+    // ISV .apps) — and is set ONLY when LoadOne actually took the Tier-3 source-compile
+    // path (see its own return points). #2593/#2579: this is what lets the LoadAll
+    // cache-hit fast path replay a Tier-3 dependency's metadata sidecars on every reuse
+    // WITHOUT re-hashing the .app file (ComputeSourceDependencyCacheKey reads and
+    // SHA256's the whole file — cheap for a small test-library .app, NOT cheap for a
+    // ~100MB Base Application .app, which would otherwise pay that cost on every single
+    // reload cycle purely to discover "this one has no sidecars anyway").
     private readonly record struct LoadedAppEntry(
-        Assembly Asm, string Name, string Publisher, string Version, string SourcePath);
+        Assembly Asm, string Name, string Publisher, string Version, string SourcePath,
+        string? Tier3CacheKey = null);
 
     private static readonly ConcurrentDictionary<Guid, LoadedAppEntry> _cache = new();
     private static readonly ConcurrentDictionary<string, Assembly> _byName =
@@ -94,6 +104,22 @@ public sealed class DependencyLoader
                         m.AppId,
                         existing.Name, existing.Publisher, existing.Version, existing.SourcePath,
                         m.Name, m.Publisher, newVersion, path);
+                // #2593/#2579: this dependency's Assembly is being reused without calling
+                // LoadOne again — but LoadOne is the ONLY place that replays this dependency's
+                // Tier-3 metadata sidecars (report/report-layout/page/xmlport/enum) into the
+                // process-wide registries. Those registries get reset every reload cycle
+                // (BcRuntime.ResetForNewBundleReload), so on the SECOND and every later
+                // --watch/--server cycle that resolves this same AppId as a dependency, skipping
+                // this replay would silently drop the dependency's metadata forever — the exact
+                // regression this call prevents (see WatchPageMetadataReloadTests, R3Pages
+                // resolved as R3Driver's dependency). Gated on the stored Tier3CacheKey, not a
+                // File.Exists probe recomputed from scratch — a Tier-1/Tier-2 entry (the
+                // overwhelming majority: Base Application, System Application, most real ISV
+                // .apps) never went through Tier 3 and has no sidecars to replay, and
+                // ComputeSourceDependencyCacheKey hashes the WHOLE .app file, which would be a
+                // real cost paid every cycle for a ~100MB Base Application package for no reason.
+                if (existing.Tier3CacheKey != null)
+                    ReplayDependencyMetadataSidecars(m, existing.Tier3CacheKey);
                 list.Add(existing.Asm);
                 continue;
             }
@@ -153,9 +179,10 @@ public sealed class DependencyLoader
             }
 
             Assembly? asm;
+            string? tier3CacheKey;
             try
             {
-                asm = LoadOne(m, path, bucketRoot);
+                (asm, tier3CacheKey) = LoadOne(m, path, bucketRoot);
             }
             // #2131: this guard USED to be bare `when (microsoftSourceOnly)` — it caught
             // and silently swallowed EVERY Microsoft-source-only Tier-3 failure, including
@@ -181,7 +208,7 @@ public sealed class DependencyLoader
             }
             if (asm != null)
             {
-                _cache[m.AppId] = new LoadedAppEntry(asm, m.Name, m.Publisher, m.Version.ToString(), path);
+                _cache[m.AppId] = new LoadedAppEntry(asm, m.Name, m.Publisher, m.Version.ToString(), path, tier3CacheKey);
                 _byName[asm.GetName().Name ?? ""] = asm;
                 // Register app metadata so AlCallStackCapture can decorate frames.
                 AlCallStackCapture.RegisterAssemblyInfo(asm, m.Name, m.Publisher, m.Version.ToString());
@@ -220,7 +247,7 @@ public sealed class DependencyLoader
         }
     }
 
-    private Assembly? LoadOne(AppManifest m, string appPath, string bucketRoot)
+    private (Assembly? Asm, string? Tier3CacheKey) LoadOne(AppManifest m, string appPath, string bucketRoot)
     {
         // Tier 1: precompiled DLL.
         var fileName = SanitizeFileName($"{m.Publisher}_{m.Name}_{m.Version}.dll");
@@ -246,7 +273,7 @@ public sealed class DependencyLoader
                 // asm.GetTypes() on this assembly (asm.Location is empty for a byte[]-loaded
                 // assembly, so it couldn't cheaply re-derive this later on its own).
                 AlRunner.Patches.RecordPatches.SeedCompiledReportIdsFromPEBytes(asm, bytes);
-                return asm;
+                return (asm, null);
             }
             catch (Exception ex)
             {
@@ -299,7 +326,7 @@ public sealed class DependencyLoader
                 }
                 if (loaded > 1)
                     Console.Error.WriteLine($"[deps] tier-2 R2R: {m.Name} loaded {loaded} DLL chunk(s)");
-                return primary;
+                return (primary, null);
             }
         }
 
@@ -321,7 +348,7 @@ public sealed class DependencyLoader
                 Console.Error.WriteLine(
                     $"[deps] DLL-first: {m.Publisher}_{m.Name} v{m.Version} — {codeunitIds.Count} codeunit(s) " +
                     $"served from extracted service-tier DLLs; skipping source compile");
-                return null; // lazy dispatch via ServiceTierDllIndex
+                return (null, null); // lazy dispatch via ServiceTierDllIndex
             }
         }
 
@@ -332,7 +359,7 @@ public sealed class DependencyLoader
             Console.Error.WriteLine(
                 $"[deps] NOTE: {m.Publisher}_{m.Name} v{m.Version} is symbol-only " +
                 $"(no runtime code in package); relying on service-tier/already-loaded assembly");
-            return null;
+            return (null, null);
         }
 
         var cacheKey = ComputeSourceDependencyCacheKey(m, appPath);
@@ -380,7 +407,7 @@ public sealed class DependencyLoader
                     replayedEnums = AlEnumMetadataRegistry.LoadSidecar(enumRegistrySidecar);
                 Console.Error.WriteLine(
                     $"[deps] source-cache HIT: {m.Name} v{m.Version} key={cacheKey[..12]} ({cachedBytes.Length} bytes, {replayedReports} report-metadata entries, {replayedEnums} enum-registry entries)");
-                return Assembly.Load(cachedBytes);
+                return (Assembly.Load(cachedBytes), cacheKey);
             }
             catch (Exception ex)
             {
@@ -490,7 +517,7 @@ public sealed class DependencyLoader
         {
             Console.Error.WriteLine($"[deps] source-cache write failed for {m.Name}: {ex.Message}");
         }
-        try { return Assembly.Load(compile.AssemblyBytes!); }
+        try { return (Assembly.Load(compile.AssemblyBytes!), cacheKey); }
         catch (Exception ex)
         {
             // LOAD-FAIL: the compiled bytes could not be loaded into the ALC.
@@ -556,6 +583,47 @@ public sealed class DependencyLoader
         onSidecarsPublishedBeforeDll?.Invoke();
         AlCacheWriter.AtomicPublish(cachedDll, tmp => File.WriteAllBytes(tmp, assemblyBytes));
         return (sidecarCount, enumSidecarCount);
+    }
+
+    /// <summary>
+    /// Replay this dependency's Tier-3 source-compile-cache metadata sidecars (report,
+    /// report-layout, page, xmlport, enum) into the process-wide registries. Called from
+    /// the <c>LoadAll</c> cache-hit fast path (see its call site for the full "why"), ONLY
+    /// when the reused <see cref="LoadedAppEntry"/> carries a non-null
+    /// <c>Tier3CacheKey</c> — that gate is the caller's job (it also decides "is there
+    /// anything to do at all"), so this method trusts <paramref name="cacheKey"/> rather
+    /// than re-deriving or re-checking it. This keeps a dependency's metadata answering
+    /// after every <c>BcRuntime.ResetForNewBundleReload()</c>, not just the first time this
+    /// AppId is resolved in the process — WITHOUT re-hashing the .app file on every reuse
+    /// (see <see cref="LoadedAppEntry"/>'s own header comment on Tier3CacheKey for the cost
+    /// that would otherwise be paid every single cycle).
+    /// </summary>
+    private void ReplayDependencyMetadataSidecars(AppManifest m, string cacheKey)
+    {
+        var cacheDir = AlRunner.Infrastructure.CacheRoots.Resolve("compiled-deps");
+        var reportSidecar = Path.Combine(cacheDir, cacheKey + ".report-metadata.json");
+        var reportLayoutSidecar = Path.Combine(cacheDir, cacheKey + ".report-layouts.json");
+        var pageMetadataSidecar = Path.Combine(cacheDir, cacheKey + ".page-metadata.json");
+        var xmlPortMetadataSidecar = Path.Combine(cacheDir, cacheKey + ".xmlport-metadata.json");
+        var enumRegistrySidecar = Path.Combine(cacheDir, cacheKey + ".enum-registry.json");
+        try
+        {
+            int replayedReports = File.Exists(reportSidecar) ? AlReportMetadataRegistry.LoadSidecar(reportSidecar) : 0;
+            if (File.Exists(reportLayoutSidecar))
+                AlReportLayoutRegistry.LoadSidecar(reportLayoutSidecar);
+            int replayedPages = File.Exists(pageMetadataSidecar) ? AlPageMetadataRegistry.LoadSidecar(pageMetadataSidecar) : 0;
+            int replayedXmlPorts = File.Exists(xmlPortMetadataSidecar) ? AlXmlPortMetadataRegistry.LoadSidecar(xmlPortMetadataSidecar) : 0;
+            int replayedEnums = File.Exists(enumRegistrySidecar) ? AlEnumMetadataRegistry.LoadSidecar(enumRegistrySidecar) : 0;
+            if (replayedReports + replayedPages + replayedXmlPorts + replayedEnums > 0)
+                Console.Error.WriteLine(
+                    $"[deps] metadata sidecar replay (reused module): {m.Name} v{m.Version} — " +
+                    $"{replayedReports} report, {replayedPages} page, {replayedXmlPorts} xmlport, {replayedEnums} enum entries");
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(
+                $"[deps] metadata sidecar replay failed for {m.Name} v{m.Version} (reused module): {ex.Message}");
+        }
     }
 
     private static string ComputeSourceDependencyCacheKey(AppManifest manifest, string appPath)


### PR DESCRIPTION
Closes #2593

## Summary

`BcRuntime.ResetForNewBundleReload()` clears `AlEnumMetadataRegistry`, `AlReportMetadataRegistry`
and `AlReportLayoutRegistry` every `--watch`/`--server` reload cycle, but `AlPageMetadataRegistry`
and `AlXmlPortMetadataRegistry` had `Clear()` methods with zero callers anywhere in the repo
(#2579, #2593). A page or xmlport deleted or renumbered between two cycles kept its stale
metadata XML answering for the rest of the process.

**#2579 and #2593 are the same defect for this half.** #2593 is the fuller, more careful writeup
(including the exact caution this PR had to solve); #2579's "asymmetry" table describes the same
gap, plus a second, separate, explicitly-unverified claim (enum-extension accumulation across a
discarded RAD delta) that this PR does **not** address — see "What this PR does not fix" below.

## Why a naive fix regresses #1957

Adding the missing `Clear()` calls alone breaks `WatchPageMetadataReloadTests` (#1957's own
regression guard): a page whose `.al` file is unchanged between two `--watch` cycles never runs
BC's `Compilation.Emit` again on the second cycle —

- `TryEmitIncremental`'s "genuinely zero work" fast path (`BcCompiler.Incremental.cs`) replays the
  previous cycle's `BcEmitOutput` verbatim when every file hashes identical to last cycle, without
  calling `Emit` at all.
- A real RAD delta's own `radComp.Emit(...)` only covers the objects that actually changed that
  cycle — an unrelated deleted file does not re-register a page nobody touched.

Either way, nothing re-registers an object's metadata that this reload's `Reset` just cleared. I
reproduced this empirically before landing the real fix: with only the two `Clear()` calls added,
`WatchPageMetadataReloadTests` fails on cycle 2 with `OnOpenPage did not run — the page opened as
a record-only fallback`.

## The fix

1. **`BcCompiler.Incremental.cs`** — a per-app-group shadow snapshot
   (`_radPageMetadataByModule`/`_radXmlPortMetadataByModule`) that survives the reset (it lives on
   the `BcCompiler` instance, not the process-wide registry) and is replayed into the live registry
   on every RAD fast-path return — both the "genuinely zero work" path and a real delta's success
   path (which also updates the snapshot: drops vacated ids, refreshes changed ones from what the
   delta's own `Emit` just wrote). This restores exactly what a from-scratch `Emit` of the app would
   have (re-)registered, while correctly dropping ids the app no longer declares.
2. **`BcRuntime.cs`** — the two missing `Clear()` calls, now safe with (1) in place.
3. **`DependencyLoader.cs`** — a related, separate gap in the same family: `LoadAll`'s process-wide
   module-identity cache (the same `_cache` `TryGetByAppId`/`RegisterLoaded` read and write, #2594's
   subject) skips `LoadOne` entirely once an `AppId` is already resolved in the process — but
   `LoadOne` is the *only* place that replays a Tier-3 source-compiled dependency's metadata
   sidecars (report/report-layout/page/xmlport/enum). `LoadAll`'s cache-hit path now replays those
   sidecars on every reuse too, gated on a `Tier3CacheKey` carried on the cache entry (not a
   recomputed `File.Exists` probe) so a Tier-1/Tier-2 dependency — Base Application, System
   Application, most real ISV `.app`s, the overwhelming majority — never pays the cost of SHA256-
   hashing its `.app` file (Base Application alone is ~100MB) just to discover it has no sidecars.

## Fix the shape, not just the reported line

1. **Same wrong pattern elsewhere?** Yes — `AlReportMetadataRegistry`/`AlReportLayoutRegistry`/
   `AlEnumMetadataRegistry` are *already* cleared unconditionally today, by the exact same
   `TryEmitIncremental` fast paths this PR had to account for. I did not extend the shadow-snapshot
   fix to those three registries in this PR (scope/risk reasons below) — filing a follow-up issue
   documenting this as a distinct, reasoned-but-unverified finding, since I could not build an
   isolated reproducer for it in this session's environment (see "What this PR does not fix").
2. **Sibling function, same blind spot?** Yes — `DependencyLoader.LoadAll`'s cache-hit fast path had
   the identical "assembly reused, side-effect registries never repopulated" shape as the RAD fast
   path; fixed in (3) above.
3. **Two paths, same invariant?** `LoadOne`'s Tier-3 cache-hit branch and `LoadAll`'s process-wide
   reuse branch both need to leave the metadata registries in the same state after returning an
   Assembly for the same AppId — before this PR only the first did.

## What this PR does not fix (and why)

- **The report/report-layout/enum registries' analogous gap for an *own-bundle* app group unchanged
  across `--watch` cycles.** I'm confident by code-reading (identical `TryEmitIncremental` mechanism)
  this is real and currently unfixed on `main`, but I have not built an isolated reproducer for it —
  the in-process white-box tests that could exercise it (`BcCompilerIncrementalTests` and neighbors)
  fail to bootstrap the BC engine on this machine (confirmed pre-existing on unmodified `main`, not a
  regression from this change), and building a fresh subprocess-based reproducer for report/enum
  specifically was out of this PR's budget. Filing a follow-up issue with this exact framing.
- **#2579's second, narrower leak** (`AlEnumMetadataRegistry.RegisterExtension` accumulating
  duplicate entries when `TryEmitIncremental` returns null *after* a partial RAD emit already
  succeeded). That issue's own text already flags it as unverified and separate from the asymmetry
  table; this PR does not touch it. Recommend keeping #2579 open, scoped to just that second claim
  (or retitled), since its first claim is now covered by #2593's closure here.
- **#2594** (`--watch` skipping the AppId module dedup) needs changes in `AlRunner/Program.cs`, which
  is owned by an in-flight PR (#2629) I was told not to edit. Left untouched; flagging for the
  orchestrator to sequence after #2629 lands.

## Testing

Both new/changed assertions are proven end-to-end via real `--watch` subprocesses (not a single
cold run — a second cycle is the whole point), using `AL_RUNNER_TRACE_PAGE_METADATA=1`'s
`[page-metadata] registered page N` stderr line as the observable signal. A real AL-level "does a
deleted page still answer" flow isn't constructible: the page's own CLR type is dropped from the
compiled module the instant its `.al` file is deleted, so nothing in AL could ever again construct
an instance to query — the registry's own id-keyed lifecycle is the actual, narrower claim #2593
makes, and the trace line is its direct, unmediated signal.

- `WatchPageMetadataReloadTests` (existing, #1957's regression guard) — proves the **surviving**
  direction for a genuine cross-app dependency (R3Pages, unchanged, resolved as R3Driver's
  dependency): RED without the `BcCompiler.Incremental.cs` shadow-snapshot fix (empirically
  reproduced), GREEN with it.
- `WatchPageMetadataReloadDeleteTests` (new) — a single standalone app-group with two pages;
  deletes one between cycles. Proves **both directions** in one run: the deleted page's id stops
  registering on cycle 2, the untouched surviving page's id keeps registering. RED without the
  `BcRuntime.cs` `Clear()` calls (empirically reproduced — the deleted page's stale entry still
  answers), GREEN with the full fix.
- Ran both classes twice each (cache-sensitivity rule) — stable.
- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~Watch"` — all 37 pass.
- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~DependencyLoader|FullyQualifiedName~AlCacheWriter"` — all 12 pass.
- Entry point tested: `--watch` (per the task brief — incremental compile engages under `--watch`,
  not under `--server`, and this fix lives entirely in the mechanism `--watch` exercises).

## Object IDs

New fixture `AlRunner.Tests/Fixtures/WatchPageMetadataReloadDelete/` — own `app.json`, own AppId,
idRange 70200-70219, no collision risk with any other fixture's own app.json.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf