### PR TITLE
fix(cache): --no-cache now disables every on-disk cache, not just al-out

### DIFF
--- a/AlRunner.Tests/CacheRootsDisableForRunTests.cs
+++ b/AlRunner.Tests/CacheRootsDisableForRunTests.cs
@@ -1,0 +1,183 @@
+// CacheRootsDisableForRunTests — unit-level coverage of
+// AlRunner.Infrastructure.CacheRoots.DisableForRun/CleanupThrowawayRoot (issue #2555).
+//
+// #2555's bug: --no-cache only ever disabled the AL-output cache (Program.cs's
+// alCacheDir); every OTHER cache resolved through CacheRoots.Resolve — compiled-deps,
+// workspace-deps, ncl-cecil, bc-symbols, and (since #1821 shipped) ncl-shadow,
+// app-manifests, r2r-chunks, install-baseline — stayed pointed at the real, shared,
+// unscoped ~/.cache/al-runner/<name> regardless, so a run reached for specifically to
+// reproduce or measure a cold compile still got most of what "cold" is supposed to cost.
+//
+// This file proves the MECHANISM directly: DisableForRun() must make Resolve() return
+// paths under an actual, freshly-created directory (not just compute a different
+// string), a file written into it must really land on disk, CleanupThrowawayRoot()
+// must really delete it, and the AL_RUNNER_NO_CACHE_ROOT env var must make a SECOND
+// call (simulating a re-exec'd child adopting the parent's choice) resolve to the
+// SAME directory rather than minting a new one — the exact hazard the issue calls
+// out ("handing the child a new throwaway root would make it miss, rewrite again,
+// and take the exact load path the re-exec exists to avoid").
+//
+// The real Program.cs WIRING (does --no-cache actually call DisableForRun, does
+// --cache/--no-cache last-wins hold both directions, is the wiring reachable across a
+// real re-exec) is proved separately, end-to-end via a spawned subprocess, in
+// NoCacheLastWinsIntegrationTests.cs — that is the "not just a computed path string"
+// half this class does not attempt, mirroring how CacheRootsTests.cs (unit) and
+// CacheRootsIsolationTests.cs (integration) split #1821's proof.
+
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(CacheRootsSerialCollection.Name)]
+public sealed class CacheRootsDisableForRunTests
+{
+    private static void ClearEnvVar() =>
+        Environment.SetEnvironmentVariable(CacheRoots.NoCacheRootEnvVar, null);
+
+    [Fact]
+    public void DisableForRun_MintsAFreshDirectoryUnderTempRoot_AndResolveUsesIt()
+    {
+        CacheRoots.ResetForTests();
+        ClearEnvVar();
+        try
+        {
+            var root = CacheRoots.DisableForRun();
+
+            Assert.StartsWith(Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar), root);
+            Assert.Equal(Path.Combine(root, "ncl-cecil"), CacheRoots.Resolve("ncl-cecil"));
+            Assert.Equal(Path.Combine(root, "compiled-deps"), CacheRoots.Resolve("compiled-deps"));
+
+            // Not just a string: real I/O against the resolved path must actually land
+            // in this directory — the decisive claim of "genuinely redirected".
+            var target = CacheRoots.Resolve("ncl-cecil");
+            Directory.CreateDirectory(target);
+            var probeFile = Path.Combine(target, "probe.txt");
+            File.WriteAllText(probeFile, "hello");
+            Assert.True(File.Exists(probeFile));
+        }
+        finally { CacheRoots.ResetForTests(); ClearEnvVar(); }
+    }
+
+    [Fact]
+    public void DisableForRun_PublishesTheDirectory_ToTheEnvVar()
+    {
+        CacheRoots.ResetForTests();
+        ClearEnvVar();
+        try
+        {
+            var root = CacheRoots.DisableForRun();
+            Assert.Equal(root, Environment.GetEnvironmentVariable(CacheRoots.NoCacheRootEnvVar));
+        }
+        finally { CacheRoots.ResetForTests(); ClearEnvVar(); }
+    }
+
+    [Fact]
+    public void DisableForRun_WithEnvVarAlreadySet_AdoptsThatDirectory_NeverMintsASecondOne()
+    {
+        // Simulates a re-exec'd child: the parent already published a throwaway root
+        // before handing off, and the child's own DisableForRun() call must land on the
+        // EXACT SAME directory, not a fresh GUID — otherwise a key written by the
+        // parent (e.g. ncl-cecil, written before the Cecil-rewrite re-exec) would be
+        // invisible to the child and get redone, the exact cost the re-exec exists to
+        // avoid paying twice.
+        CacheRoots.ResetForTests();
+        var preExisting = Path.Combine(Path.GetTempPath(), "al-runner-no-cache-test-" + Guid.NewGuid().ToString("N"));
+        Environment.SetEnvironmentVariable(CacheRoots.NoCacheRootEnvVar, preExisting);
+        try
+        {
+            var root = CacheRoots.DisableForRun();
+            Assert.Equal(preExisting, root);
+            Assert.Equal(Path.Combine(preExisting, "bc-symbols"), CacheRoots.Resolve("bc-symbols"));
+        }
+        finally { CacheRoots.ResetForTests(); ClearEnvVar(); if (Directory.Exists(preExisting)) Directory.Delete(preExisting, true); }
+    }
+
+    [Fact]
+    public void DisableForRun_CalledTwiceInTheSameProcess_ReturnsTheSameDirectoryBothTimes()
+    {
+        // Program.cs's own two re-exec decision points can each observe noCacheRequested
+        // before either one actually hands off to a child — both calls, from the SAME
+        // process, must agree on one directory.
+        CacheRoots.ResetForTests();
+        ClearEnvVar();
+        try
+        {
+            var first = CacheRoots.DisableForRun();
+            var second = CacheRoots.DisableForRun();
+            Assert.Equal(first, second);
+        }
+        finally { CacheRoots.ResetForTests(); ClearEnvVar(); }
+    }
+
+    [Fact]
+    public void CleanupThrowawayRoot_DeletesTheMintedDirectory_IncludingWhateverWasWrittenIntoIt()
+    {
+        CacheRoots.ResetForTests();
+        ClearEnvVar();
+        try
+        {
+            var root = CacheRoots.DisableForRun();
+            var target = CacheRoots.Resolve("workspace-deps");
+            Directory.CreateDirectory(target);
+            File.WriteAllText(Path.Combine(target, "app.bin"), "not a real app");
+            Assert.True(Directory.Exists(root));
+
+            CacheRoots.CleanupThrowawayRoot();
+
+            Assert.False(Directory.Exists(root), $"expected {root} to be gone after cleanup");
+        }
+        finally { CacheRoots.ResetForTests(); ClearEnvVar(); }
+    }
+
+    [Fact]
+    public void CleanupThrowawayRoot_WithoutDisableForRunHavingBeenCalled_IsANoOp_DoesNotThrow()
+    {
+        CacheRoots.ResetForTests();
+        ClearEnvVar();
+        try
+        {
+            CacheRoots.CleanupThrowawayRoot(); // must not throw
+        }
+        finally { CacheRoots.ResetForTests(); ClearEnvVar(); }
+    }
+
+    [Fact]
+    public void CleanupThrowawayRoot_WhenDirectoryWasNeverActuallyCreated_IsANoOp_DoesNotThrow()
+    {
+        // DisableForRun() mints a NAME but nothing necessarily calls
+        // Directory.CreateDirectory against it before cleanup runs (e.g. a run that
+        // exits before touching any of these caches). Cleanup must tolerate that.
+        CacheRoots.ResetForTests();
+        ClearEnvVar();
+        try
+        {
+            var root = CacheRoots.DisableForRun();
+            Assert.False(Directory.Exists(root));
+
+            CacheRoots.CleanupThrowawayRoot(); // must not throw even though nothing was ever created
+        }
+        finally { CacheRoots.ResetForTests(); ClearEnvVar(); }
+    }
+
+    [Fact]
+    public void SetOverride_AfterDisableForRun_ReplacesTheThrowawayRedirect()
+    {
+        // Mirrors Program.cs's own last-wins handling: a --cache flag appearing AFTER a
+        // --no-cache flag on the same command line must fully replace the throwaway
+        // redirect, for every cache resolved here — not layer underneath it.
+        CacheRoots.ResetForTests();
+        ClearEnvVar();
+        try
+        {
+            var throwaway = CacheRoots.DisableForRun();
+            var explicitDir = Path.Combine(Path.GetTempPath(), "al-runner-cacheroots-explicit", Guid.NewGuid().ToString("N"));
+
+            CacheRoots.SetOverride(explicitDir);
+
+            Assert.Equal(Path.Combine(explicitDir, "ncl-cecil"), CacheRoots.Resolve("ncl-cecil"));
+            Assert.NotEqual(Path.Combine(throwaway, "ncl-cecil"), CacheRoots.Resolve("ncl-cecil"));
+        }
+        finally { CacheRoots.ResetForTests(); ClearEnvVar(); }
+    }
+}

--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -246,13 +246,6 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
             // (BC engine cold-start + AL emit/compile once). Measured 63.9s in CI.
             ["TestPageBooleanRecBoundDispatchTests"] = 63,
             ["ServerTestIsolationTests"] = 69,
-            // #2555: absent from this table before, fell back to UnmeasuredWeightSeconds;
-            // measured 63.0s on the BC 28.3 leg of the PR that added two more
-            // subprocess-spawning test classes to this suite (CacheRootsDisableForRunTests,
-            // NoCacheLastWinsIntegrationTests) — the added 4-way-parallel contention was
-            // enough to tip this collection over the 60s freshness threshold and trip
-            // check-collection-weights.py, the same #1887 pattern as the entries around it.
-            ["ServerAffectedSelectionTests"] = 63,
             ["ServerStreamingTests"] = 50,
             ["ExpectationManifestWiringTests"] = 47,
             ["LayeredCacheTests"] = 46,

--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -246,6 +246,13 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
             // (BC engine cold-start + AL emit/compile once). Measured 63.9s in CI.
             ["TestPageBooleanRecBoundDispatchTests"] = 63,
             ["ServerTestIsolationTests"] = 69,
+            // #2555: absent from this table before, fell back to UnmeasuredWeightSeconds;
+            // measured 63.0s on the BC 28.3 leg of the PR that added two more
+            // subprocess-spawning test classes to this suite (CacheRootsDisableForRunTests,
+            // NoCacheLastWinsIntegrationTests) — the added 4-way-parallel contention was
+            // enough to tip this collection over the 60s freshness threshold and trip
+            // check-collection-weights.py, the same #1887 pattern as the entries around it.
+            ["ServerAffectedSelectionTests"] = 63,
             ["ServerStreamingTests"] = 50,
             ["ExpectationManifestWiringTests"] = 47,
             ["LayeredCacheTests"] = 46,

--- a/AlRunner.Tests/NoCacheLastWinsIntegrationTests.cs
+++ b/AlRunner.Tests/NoCacheLastWinsIntegrationTests.cs
@@ -1,0 +1,187 @@
+// NoCacheLastWinsIntegrationTests — end-to-end proof of issue #2555's fix, spawning the
+// real runner as a subprocess (mirroring CacheRootsIsolationTests.cs's #1821 proof).
+//
+// #2555's bug: --no-cache only ever disabled the AL-output cache (Program.cs's
+// alCacheDir). Every other cache resolved through CacheRoots.Resolve — this file uses
+// ncl-cecil, which (per CacheRootsIsolationTests.cs's own note) is populated on EVERY
+// invocation unconditionally, so a single bundle run is enough to exercise it without
+// needing a dependency — stayed pointed at whatever --cache DIR the caller last gave,
+// so `--cache DIR --no-cache` silently left the other caches warm under DIR while only
+// al-out went cold. `--no-cache --cache DIR` happened to already work by accident (a
+// later --cache unconditionally overwrote both alCacheDir and cacheRootOverride).
+//
+// CacheRootsDisableForRunTests.cs proves the CacheRoots-level mechanism directly (a
+// throwaway directory really gets created, really receives files, and really gets
+// deleted). This file proves the WIRING: that Program.cs's --no-cache parsing actually
+// reaches CacheRoots.DisableForRun(), that --cache/--no-cache are last-wins against
+// each other in BOTH orders, and that the redirect survives the real Cecil-rewrite
+// re-exec (this bundle triggers one on a cold ncl-cecil cache, so a wiring bug that only
+// set the throwaway root in the PARENT generation and let the re-exec'd CHILD mint a
+// second one would show up here as a MISS against the parent's directory that this test
+// cannot directly observe, but WOULD show up as cacheDirA gaining an entry it should
+// not have — the redirect failing over to whatever cacheDirA still names once the
+// parsing loop is re-run in the child with the forwarded --no-cache argument).
+//
+// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
+
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class NoCacheLastWinsIntegrationTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(string bundleDir, string absentPackageCache, params string[] extraArgs)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" \"{bundleDir}\"");
+        args.Append($" --package-cache \"{absentPackageCache}\"");
+        args.Append(" --verbose");
+        foreach (var a in extraArgs) args.Append($" {a}");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    [SkippableFact]
+    public void CacheThenNoCache_RedirectsAwayFromTheExplicitDir_NoCacheThenCache_UsesIt_BothLastWins()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var scratchRoot = Path.Combine(Path.GetTempPath(), "al-runner-nocache-lastwins", Guid.NewGuid().ToString("N"));
+        var bundleDir = Path.Combine(scratchRoot, "tests-app");
+        var cacheDirA = Path.Combine(scratchRoot, "cache-a");
+        var absentPackageCache = Path.Combine(scratchRoot, "no-such-package-cache");
+        Directory.CreateDirectory(bundleDir);
+
+        var testsId = Guid.NewGuid();
+        File.WriteAllText(Path.Combine(bundleDir, "app.json"), $$"""
+        {
+          "id": "{{testsId}}",
+          "name": "Repro2555 Tests",
+          "publisher": "Repro2555",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 61940, "to": 61949 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(bundleDir, "Repro2555Tests.al"), """
+        codeunit 61940 "Repro2555 Poison Test"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure TrivialPass()
+            begin
+                if 1 + 1 <> 2 then
+                    Error('arithmetic is broken');
+            end;
+        }
+        """);
+
+        // Run 1: plain `--cache cacheDirA` (no --no-cache at all) populates
+        // cacheDirA/ncl-cecil with a real cache entry — establishes a baseline set of
+        // files this test can prove is UNCHANGED by a later redirected run.
+        var (output1, exit1) = RunRunner(bundleDir, absentPackageCache, $"--cache \"{cacheDirA}\"");
+        Assert.True(exit1 == 0 && output1.Contains("1P/0F/0E"), $"run 1 must pass:\n{output1}");
+        var nclCecilA = Path.Combine(cacheDirA, "ncl-cecil");
+        Assert.True(Directory.Exists(nclCecilA) && Directory.GetFiles(nclCecilA, "*.dll").Length > 0,
+            $"expected run 1 to populate {nclCecilA}:\n{output1}");
+        var filesAfterRun1 = Directory.GetFiles(nclCecilA, "*.dll").Select(Path.GetFileName).OrderBy(x => x).ToArray();
+
+        // Run 2: `--cache cacheDirA --no-cache` — --no-cache is LAST, so per #2555 it
+        // must win for cacheDirA too: this run must NOT touch cacheDirA/ncl-cecil at
+        // all (no new file) because ncl-cecil is redirected to a throwaway root
+        // instead. Before the fix, cacheRootOverride stayed cacheDirA regardless of
+        // the trailing --no-cache, so this run would resolve ncl-cecil (and every
+        // other CacheRoots-backed cache) straight into cacheDirA — this run's log
+        // would then mention cacheDirA's path (it legitimately says "[Cecil] Cecil
+        // cache HIT" even on a REDIRECTED run, since one run reads its own
+        // freshly-written ncl-cecil entry again across the shadow/Cecil re-exec — see
+        // CacheRoots.NoCacheRootEnvVar's doc — so a HIT alone does not distinguish a
+        // fix from a bug; which DIRECTORY it hit does).
+        var (output2, exit2) = RunRunner(bundleDir, absentPackageCache, $"--cache \"{cacheDirA}\" --no-cache");
+        Assert.True(exit2 == 0 && output2.Contains("1P/0F/0E"), $"run 2 must pass:\n{output2}");
+        var filesAfterRun2 = Directory.GetFiles(nclCecilA, "*.dll").Select(Path.GetFileName).OrderBy(x => x).ToArray();
+        Assert.Equal(filesAfterRun1, filesAfterRun2);
+        Assert.DoesNotContain(cacheDirA, output2);
+
+        // Run 3: `--no-cache --cache cacheDirA` — --cache is LAST, so it must win and
+        // restore normal isolated-cache behaviour: cacheDirA already holds the exact
+        // key from run 1 (same runner build, same BC artifact), so this is a HIT
+        // against cacheDirA again — the mirror-image proof that the SAME flag pair in
+        // the OPPOSITE order does NOT redirect away from cacheDirA.
+        var (output3, exit3) = RunRunner(bundleDir, absentPackageCache, $"--no-cache --cache \"{cacheDirA}\"");
+        Assert.True(exit3 == 0 && output3.Contains("1P/0F/0E"), $"run 3 must pass:\n{output3}");
+        Assert.Contains("[Cecil] Cecil cache HIT", output3);
+        var filesAfterRun3 = Directory.GetFiles(nclCecilA, "*.dll").Select(Path.GetFileName).OrderBy(x => x).ToArray();
+        Assert.Equal(filesAfterRun1, filesAfterRun3);
+    }
+
+    [SkippableFact]
+    public void NoCacheAlone_DoesNotLeakItsThrowawayTempDirectory()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var scratchRoot = Path.Combine(Path.GetTempPath(), "al-runner-nocache-noleak", Guid.NewGuid().ToString("N"));
+        var bundleDir = Path.Combine(scratchRoot, "tests-app");
+        var absentPackageCache = Path.Combine(scratchRoot, "no-such-package-cache");
+        Directory.CreateDirectory(bundleDir);
+
+        var testsId = Guid.NewGuid();
+        File.WriteAllText(Path.Combine(bundleDir, "app.json"), $$"""
+        {
+          "id": "{{testsId}}",
+          "name": "Repro2555 NoLeak Tests",
+          "publisher": "Repro2555",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 61950, "to": 61959 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(bundleDir, "Repro2555NoLeakTests.al"), """
+        codeunit 61950 "Repro2555 NoLeak Test"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure TrivialPass()
+            begin
+                if 1 + 1 <> 2 then
+                    Error('arithmetic is broken');
+            end;
+        }
+        """);
+
+        var tempRoot = Path.GetTempPath();
+        var before = Directory.GetDirectories(tempRoot, "al-runner-no-cache-*").Length;
+
+        var (output, exit) = RunRunner(bundleDir, absentPackageCache, "--no-cache");
+        Assert.True(exit == 0 && output.Contains("1P/0F/0E"), $"run must pass:\n{output}");
+
+        var after = Directory.GetDirectories(tempRoot, "al-runner-no-cache-*").Length;
+        Assert.Equal(before, after);
+    }
+}

--- a/AlRunner/Infrastructure/CacheRoots.cs
+++ b/AlRunner/Infrastructure/CacheRoots.cs
@@ -1,61 +1,146 @@
 namespace AlRunner.Infrastructure;
 
 /// <summary>
-/// Process-global override for where the four caches that used to hardcode
-/// <c>~/.cache/al-runner/&lt;name&gt;</c> actually write (issue #1821):
-/// <c>compiled-deps</c> (<see cref="AlRunner.DependencyLoader"/>), <c>workspace-deps</c>
-/// (<c>Program.cs</c>'s layered-workspace synthesis, two call sites), <c>ncl-cecil</c>
-/// (<see cref="NclCecilRewrite"/>), and <c>bc-symbols</c>
-/// (<see cref="AlRunner.Patches.BcAppSymbolCache"/>).
+/// Process-global override for where every cache resolved through <see cref="Resolve"/>
+/// actually writes (issue #1821). At the time #1821 was fixed there were four such
+/// caches: <c>compiled-deps</c> (<see cref="AlRunner.DependencyLoader"/>),
+/// <c>workspace-deps</c> (<c>Program.cs</c>'s layered-workspace synthesis, two call
+/// sites), <c>ncl-cecil</c> (<see cref="NclCecilRewrite"/>), and <c>bc-symbols</c>
+/// (<see cref="AlRunner.Patches.BcAppSymbolCache"/>). More have been added since
+/// (<c>ncl-shadow</c>, <c>app-manifests</c>, <c>r2r-chunks</c>, <c>install-baseline</c>)
+/// — this class does not enumerate them because <see cref="Resolve"/> is the single
+/// choke point every one of them already goes through; a new named cache gets this
+/// class's behaviour for free just by calling <see cref="Resolve"/> instead of
+/// hardcoding <c>~/.cache/al-runner/&lt;name&gt;</c> itself.
 ///
-/// Only the AL-output cache (<c>Program.cs</c>'s <c>alCacheDir</c>, driven by
-/// <c>--cache</c>/<c>--no-cache</c>) ever respected the <c>--cache</c> flag. The other
-/// four always wrote to the real, shared, unscoped
-/// <c>~/.cache/al-runner/&lt;name&gt;</c> regardless — so a caller that passes
-/// <c>--cache &lt;isolated-dir&gt;</c> expecting per-invocation isolation (e.g. a test
-/// using a fresh temp dir so each run starts from a clean slate) only actually got
-/// isolation for AL output; the other four caches were silently shared, process-wide,
-/// with every other <c>al-runner</c> invocation on the machine.
+/// Originally only the AL-output cache (<c>Program.cs</c>'s <c>alCacheDir</c>, driven by
+/// <c>--cache</c>/<c>--no-cache</c>) respected the <c>--cache</c> flag; every cache
+/// resolved here wrote to the real, shared, unscoped <c>~/.cache/al-runner/&lt;name&gt;</c>
+/// regardless — so a caller that passed <c>--cache &lt;isolated-dir&gt;</c> expecting
+/// per-invocation isolation (e.g. a test using a fresh temp dir so each run starts from a
+/// clean slate) only actually got isolation for AL output. #1821 fixed that for
+/// <c>--cache</c>. #2555 does the equivalent for <c>--no-cache</c>: see
+/// <see cref="DisableForRun"/>.
 ///
 /// <para><b>Deliberately NOT wired into <c>alCacheDir</c> itself.</b> <c>alCacheDir</c>
 /// keeps its pre-existing exact-directory semantics — writing straight into whatever
 /// directory <c>--cache</c> names, no subfolder — because existing callers (tests,
 /// <c>--watch</c>) already pass <c>&lt;root&gt;/al-out</c> as that value specifically for
-/// AL-output isolation. This class instead resolves the OTHER four caches as named
-/// subdirectories of that same <c>--cache</c> value (<c>&lt;dir&gt;/compiled-deps</c>,
-/// etc.), so passing <c>--cache &lt;dir&gt;</c> isolates all five caches under one root
-/// without changing what <c>al-out</c> alone has always done with that same value.</para>
+/// AL-output isolation. This class instead resolves every OTHER cache as a named
+/// subdirectory of that same <c>--cache</c> value (<c>&lt;dir&gt;/compiled-deps</c>,
+/// etc.), so passing <c>--cache &lt;dir&gt;</c> isolates all of them under one root
+/// without changing what <c>al-out</c> alone has always done with that same value. The
+/// same split applies to <c>--no-cache</c>: it disables <c>alCacheDir</c> outright (no
+/// disk cache consulted at all for AL output, not even a throwaway one — see
+/// <c>Program.cs</c>'s own comment on why that is stronger than a redirect), while
+/// <see cref="DisableForRun"/> redirects every cache resolved here to a fresh,
+/// throwaway directory instead.</para>
 ///
 /// <para>Set once at startup from the same value Program.cs assigns to <c>alCacheDir</c>
-/// on a <c>--cache &lt;dir&gt;</c> flag (not on <c>--no-cache</c> — that flag has never
-/// touched these four caches and doesn't start now; only <c>--cache</c> is in scope for
-/// this issue). No flag at all (or <c>--no-cache</c>, or a bare-default run) means
-/// <see cref="Resolve"/> falls back to exactly the same
-/// <c>~/.cache/al-runner/&lt;name&gt;</c> path every one of these four caches already
-/// used before this issue was fixed — the default behaviour, including CI's own
-/// caching (e.g. the <c>smoke</c> job's <c>rm -rf ~/.cache/al-runner/ncl-cecil/</c>,
-/// which never passes <c>--cache</c>), is unchanged.</para>
+/// on a <c>--cache &lt;dir&gt;</c> flag, or via <see cref="DisableForRun"/> on
+/// <c>--no-cache</c>. No flag at all (a bare-default run) means <see cref="Resolve"/>
+/// falls back to exactly the same <c>~/.cache/al-runner/&lt;name&gt;</c> path every one
+/// of these caches used before #1821 — the default behaviour, including CI's own caching
+/// (e.g. the <c>smoke</c> job's <c>rm -rf ~/.cache/al-runner/ncl-cecil/</c>, which never
+/// passes <c>--cache</c>), is unchanged.</para>
 /// </summary>
 public static class CacheRoots
 {
     private static string? _override;
+    private static string? _throwawayRoot;
+
+    /// <summary>
+    /// Environment variable that carries a <c>--no-cache</c> run's throwaway root across
+    /// a re-exec (a fresh Cecil rewrite, or a shadow-dir hop for a missing Ncl.dll / a
+    /// different BC-minor engine variant — both hand off to a child process mid-run).
+    /// <see cref="DisableForRun"/> sets this in the CURRENT process's environment (not
+    /// just on a specific child's <c>ProcessStartInfo</c>) the first time it mints a
+    /// directory, so any child launched afterwards inherits it automatically and a call
+    /// to <see cref="DisableForRun"/> in that child adopts the SAME directory instead of
+    /// minting a second one. One throwaway root per RUN, not per PROCESS — the whole
+    /// point of a throwaway root is that a key written earlier in the run (e.g.
+    /// <c>ncl-cecil</c>, written once and then read by several app groups) is still a HIT
+    /// later in the SAME run; a re-exec'd child that instead minted its own empty
+    /// directory would treat that as a miss and redo the work the re-exec exists to avoid.
+    /// </summary>
+    public const string NoCacheRootEnvVar = "AL_RUNNER_NO_CACHE_ROOT";
 
     /// <summary>
     /// Sets the process-global cache-root override for this run. Pass the exact value
     /// Program.cs's <c>--cache &lt;dir&gt;</c> parsing assigned to <c>alCacheDir</c>, or
-    /// <c>null</c> when <c>--cache</c> was not given (including <c>--no-cache</c> runs —
-    /// see class remarks). Idempotent to call more than once; the last call wins, mirroring
-    /// how <c>alCacheDir</c> itself is just a plain mutable local reassigned by whichever
-    /// <c>--cache</c>/<c>--no-cache</c> argument appears last on the command line.
+    /// <c>null</c> for the bare-default (no <c>--cache</c>, no <c>--no-cache</c>) case.
+    /// Idempotent to call more than once; the last call wins, mirroring how
+    /// <c>alCacheDir</c> itself is just a plain mutable local reassigned by whichever
+    /// <c>--cache</c>/<c>--no-cache</c> argument appears last on the command line. Prefer
+    /// <see cref="DisableForRun"/> for the <c>--no-cache</c> case — it also arranges
+    /// cleanup and re-exec continuity that calling this directly with an ad hoc directory
+    /// would not get.
     /// </summary>
     public static void SetOverride(string? cacheDir) => _override = cacheDir;
 
     /// <summary>
+    /// <c>--no-cache</c> (#2555): redirects every cache resolved through <see cref="Resolve"/>
+    /// to a throwaway per-run directory under the OS temp root, so a run reached for
+    /// specifically to reproduce or measure a cold compile does not silently get these
+    /// caches warm. Redirects rather than deletes anything under the real
+    /// <c>~/.cache/al-runner</c> tree — erasing that tree would be a destructive side
+    /// effect of a read-only-sounding flag, and would break any OTHER <c>al-runner</c>
+    /// process sharing the machine (e.g. concurrent CI legs).
+    ///
+    /// Reuses the directory named by <see cref="NoCacheRootEnvVar"/> if that variable is
+    /// already set in the environment (the re-exec-continuity case documented on that
+    /// constant); otherwise mints a fresh one and publishes it there for any child this
+    /// process goes on to launch. Calling this repeatedly within one process (e.g. both
+    /// re-exec decision points in <c>Program.cs</c> run before any cache is actually
+    /// touched) is safe and returns the same directory each time.
+    /// </summary>
+    public static string DisableForRun()
+    {
+        var existing = Environment.GetEnvironmentVariable(NoCacheRootEnvVar);
+        string root;
+        if (!string.IsNullOrEmpty(existing))
+        {
+            root = existing;
+        }
+        else
+        {
+            root = Path.Combine(Path.GetTempPath(), "al-runner-no-cache-" + Guid.NewGuid().ToString("N"));
+            Environment.SetEnvironmentVariable(NoCacheRootEnvVar, root);
+        }
+        _override = root;
+        _throwawayRoot = root;
+        return root;
+    }
+
+    /// <summary>
+    /// Best-effort delete of the directory <see cref="DisableForRun"/> minted (a no-op if
+    /// <see cref="DisableForRun"/> was never called, or the directory was never actually
+    /// created by anything writing into it). Program.cs registers this on
+    /// <c>AppDomain.ProcessExit</c> right after a <c>--no-cache</c> run calls
+    /// <see cref="DisableForRun"/>, so it runs from whichever generation is the terminal
+    /// one for this invocation — an intermediate generation that hands off to a re-exec'd
+    /// child reaches its own <c>ProcessExit</c> only after <c>WaitForExit</c> on that
+    /// child returns, i.e. after the child (which inherited the same directory via
+    /// <see cref="NoCacheRootEnvVar"/>) is completely done with it. Swallows IO errors —
+    /// cleanup failing should never fail the run whose results it is cleaning up after.
+    /// </summary>
+    public static void CleanupThrowawayRoot()
+    {
+        if (_throwawayRoot == null) return;
+        try
+        {
+            if (Directory.Exists(_throwawayRoot)) Directory.Delete(_throwawayRoot, recursive: true);
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+    }
+
+    /// <summary>
     /// Resolves the on-disk directory for the named cache (e.g. <c>"compiled-deps"</c>).
-    /// Returns <c>&lt;override&gt;/&lt;name&gt;</c> when <see cref="SetOverride"/> was
-    /// last called with a non-null directory; otherwise falls back to
-    /// <c>~/.cache/al-runner/&lt;name&gt;</c>, the pre-#1821 hardcoded default every one
-    /// of these four caches used unconditionally.
+    /// Returns <c>&lt;override&gt;/&lt;name&gt;</c> when <see cref="SetOverride"/> or
+    /// <see cref="DisableForRun"/> was last called with a non-null directory; otherwise
+    /// falls back to <c>~/.cache/al-runner/&lt;name&gt;</c>, the pre-#1821 hardcoded
+    /// default every one of these caches used unconditionally.
     /// </summary>
     public static string Resolve(string name)
     {
@@ -69,5 +154,9 @@ public static class CacheRoots
     /// static (e.g. in-process unit tests, as opposed to the spawned-subprocess
     /// integration tests that get natural per-process isolation) don't leak state
     /// between cases.</summary>
-    internal static void ResetForTests() => _override = null;
+    internal static void ResetForTests()
+    {
+        _override = null;
+        _throwawayRoot = null;
+    }
 }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -264,10 +264,19 @@ catch (InvalidOperationException ex)
     Console.Error.WriteLine(ex.Message);
     return 2;
 }
-// #1821: mirrors alCacheDir, but only ever set by an explicit --cache flag (never by
-// the default init above, never by --no-cache) — see the --cache parsing branch below
-// and AlRunner.Infrastructure.CacheRoots for what this drives.
+// #1821/#2555: mirrors alCacheDir for the OTHER caches CacheRoots redirects — set by an
+// explicit --cache flag directly, or by --no-cache indirectly via noCacheRequested below
+// (CacheRoots.DisableForRun() mints the actual throwaway directory once both flags have
+// been read — see the --cache/--no-cache parsing branch below and
+// AlRunner.Infrastructure.CacheRoots for what this drives).
 string? cacheRootOverride = null;
+// #2555: --cache and --no-cache are last-wins against each other for ALL of alCacheDir,
+// cacheRootOverride and this flag — whichever appears last on the command line decides
+// both "is the AL-output cache on" (alCacheDir) and "are the other CacheRoots caches
+// redirected to a throwaway root" (cacheRootOverride, resolved from this flag right
+// before either re-exec decision point, so a re-exec'd child inherits the SAME throwaway
+// directory rather than minting its own — see CacheRoots.NoCacheRootEnvVar).
+bool noCacheRequested = false;
 // --print-cache-key (issue #1851): a diagnostic/test-support mode. Reaches the SAME
 // ComputeAlCacheKey call, with the SAME arguments, that a real run would use for the
 // first app group it processes — then prints it and exits, without emitting or compiling
@@ -417,13 +426,24 @@ for (int i = 0; i < args.Length; i++)
     if (args[i] == "--bundled") { bundledMode = true; continue; }
     if (args[i] == "--expectations" && i + 1 < args.Length) { expectationsDirArg = args[++i]; continue; }
     if (args[i] == "--count-baseline" && i + 1 < args.Length) { countBaselinePath = args[++i]; continue; }
-    // #1821: the SAME --cache value also becomes the isolation root for the four
-    // caches (compiled-deps/workspace-deps/ncl-cecil/bc-symbols) that used to ignore
-    // it — see AlRunner.Infrastructure.CacheRoots for why al-out itself is unaffected.
-    // --no-cache intentionally does NOT touch cacheRootOverride: it has only ever
-    // disabled the AL-output cache, and this issue doesn't expand that scope.
-    if (args[i] == "--cache" && i + 1 < args.Length) { alCacheDir = args[++i]; cacheRootOverride = alCacheDir; continue; }
-    if (args[i] == "--no-cache") { alCacheDir = null; continue; }
+    // #1821: the SAME --cache value also becomes the isolation root for every other
+    // cache CacheRoots redirects (compiled-deps/workspace-deps/ncl-cecil/bc-symbols/
+    // ncl-shadow/app-manifests/r2r-chunks/install-baseline) — see
+    // AlRunner.Infrastructure.CacheRoots for why al-out itself is unaffected.
+    // #2555: --cache and --no-cache are last-wins against each other for BOTH
+    // alCacheDir and cacheRootOverride — an explicit --cache re-enables everything
+    // a preceding --no-cache turned off, including the other caches' redirect.
+    if (args[i] == "--cache" && i + 1 < args.Length) { alCacheDir = args[++i]; cacheRootOverride = alCacheDir; noCacheRequested = false; continue; }
+    // #2555: previously only disabled the AL-output cache (alCacheDir); the other
+    // caches CacheRoots redirects stayed warm, so a run reached for specifically to
+    // reproduce/measure a cold compile still got most of what "cold" is supposed to
+    // cost. noCacheRequested is resolved to an actual throwaway directory (via
+    // CacheRoots.DisableForRun()) right before either re-exec decision point below —
+    // resolving it here instead would mint a fresh directory per --no-cache token
+    // even when --cache later overrides it, and more importantly a --no-cache/--cache
+    // combination earlier on the command line would already have committed to a
+    // directory that a LATER flag on the same line should be able to undo.
+    if (args[i] == "--no-cache") { alCacheDir = null; noCacheRequested = true; continue; }
     if (args[i] == "--print-cache-key") { printCacheKeyOnly = true; continue; }
     if (args[i] == "--watch") { watchMode = true; continue; }
     if (args[i] == "--tdd") { tddMode = true; continue; }
@@ -1236,10 +1256,25 @@ string? variantSwapDir = null;
 }
 
 if (alCacheDir != null) Directory.CreateDirectory(alCacheDir);
-// #1821: must run before the Cecil rewrite below (first ncl-cecil consumer) and well
-// before any DependencyLoader/BcAppSymbolCache/workspace-deps call — all four read
-// CacheRoots.Resolve for their cache directory.
-AlRunner.Infrastructure.CacheRoots.SetOverride(cacheRootOverride);
+// #1821/#2555: must run before the Cecil rewrite below (first ncl-cecil consumer), the
+// shadow-hop re-exec decision right after it (first ncl-shadow consumer), and well
+// before any DependencyLoader/BcAppSymbolCache/workspace-deps/AppLoader call — every one
+// of those reads CacheRoots.Resolve for its cache directory. --no-cache resolves to an
+// actual throwaway directory HERE (not at parse time) so a later --cache on the same
+// command line can still override it (last-wins, see the parsing branch above), and the
+// directory is minted (or, on a re-exec'd child, adopted from CacheRoots.NoCacheRootEnvVar
+// — see that constant's doc) before either re-exec decision point can hand off to a child
+// that would otherwise mint its own.
+if (noCacheRequested)
+{
+    AlRunner.Infrastructure.CacheRoots.DisableForRun();
+    AppDomain.CurrentDomain.ProcessExit += (_, _) =>
+        AlRunner.Infrastructure.CacheRoots.CleanupThrowawayRoot();
+}
+else
+{
+    AlRunner.Infrastructure.CacheRoots.SetOverride(cacheRootOverride);
+}
 // #2041/#2066: deferred — see `deferredStartupLines`' declaration above. This generation
 // may still hand off via either re-exec decision below, and touches no bundle work at all
 // before doing so — the flush after both decisions is what makes this print exactly once,
@@ -6278,11 +6313,19 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("  --package-cache PATH    Extra directory to scan for .app dependencies");
     w.WriteLine("                          (repeatable). Default scan: ~/.bcartifacts.cache,");
     w.WriteLine("                          ~/.local/share/al-runner/artifacts, and bundle .alpackages/.");
-    w.WriteLine("  --cache DIR             AL-output cache directory. Default:");
-    w.WriteLine("                          ~/.cache/al-runner/al-out. Compiled test DLLs are");
-    w.WriteLine("                          re-used on subsequent runs if inputs are unchanged");
-    w.WriteLine("                          (key = hash of .al sources, resolved deps, runner mtime).");
-    w.WriteLine("  --no-cache              Disable the AL-output cache for this run.");
+    w.WriteLine("  --cache DIR             Isolation root for every on-disk cache the runner uses:");
+    w.WriteLine("                          the AL-output cache (default ~/.cache/al-runner/al-out,");
+    w.WriteLine("                          compiled test DLLs re-used on subsequent runs if inputs");
+    w.WriteLine("                          are unchanged) AND every other named cache normally under");
+    w.WriteLine("                          ~/.cache/al-runner/<name> (compiled-deps, workspace-deps,");
+    w.WriteLine("                          ncl-cecil, bc-symbols, and more) as <DIR>/<name>.");
+    w.WriteLine("  --no-cache              Disable every on-disk cache for this run, not just the");
+    w.WriteLine("                          AL-output cache: the other named caches above are");
+    w.WriteLine("                          redirected to a throwaway per-run directory (removed on");
+    w.WriteLine("                          exit) instead of the real, shared ~/.cache/al-runner tree,");
+    w.WriteLine("                          so a run reached for to reproduce/measure a cold compile");
+    w.WriteLine("                          does not silently reuse them. --cache/--no-cache are");
+    w.WriteLine("                          last-wins against each other on the command line.");
     w.WriteLine("  --print-cache-key       Diagnostic/test-support mode: compute the AL-output cache");
     w.WriteLine("                          key for the first app group of the first bundle exactly as");
     w.WriteLine("                          a real run would, print \"[cache] KEY key=<hash>\", and exit");


### PR DESCRIPTION
Closes #2555

## Problem

`--no-cache` only ever disabled the AL-output cache (`Program.cs`'s `alCacheDir`).
The other caches resolved through `CacheRoots.Resolve` — `compiled-deps`,
`workspace-deps`, `ncl-cecil`, `bc-symbols`, and (added since #1821 shipped)
`ncl-shadow`, `app-manifests`, `r2r-chunks`, `install-baseline` — stayed pointed at
the real, shared, unscoped `~/.cache/al-runner/<name>` regardless. A run reached
for specifically to reproduce or measure a cold compile still got most of what
"cold" is supposed to cost.

`--cache DIR --no-cache` was the sharper case: `cacheRootOverride` stayed `DIR`
(only `alCacheDir` was nulled), so the other caches silently kept reading/writing
an isolated directory the caller thought they had just turned off.

## Fix

`CacheRoots.DisableForRun()` redirects every cache resolved through
`CacheRoots.Resolve` to a throwaway per-run directory under the OS temp root.
Redirects, never deletes anything under the real `~/.cache/al-runner` tree — that
would be a destructive side effect of a read-only-sounding flag, and would break
any other `al-runner` process sharing the machine (e.g. concurrent CI legs).

Two details the issue called out, both handled:

- **One root per run, not per process.** The chosen directory is published via the
  `AL_RUNNER_NO_CACHE_ROOT` environment variable, so a re-exec'd child (a fresh
  Cecil rewrite, or a shadow-dir hop for a missing `Ncl.dll`/BC-minor variant)
  adopts the SAME directory instead of minting its own — verified end-to-end: this
  bundle always triggers the shadow-dir hop on this machine, and the log shows the
  child reading the parent's `ncl-cecil` entry as a HIT against the shared
  throwaway directory, not a MISS against a freshly-minted one.
- **Within-run consistency.** Because it's a redirect (not per-call disablement), a
  key written earlier in the run and read again later (e.g. `ncl-cecil`, read again
  across the shadow/Cecil re-exec) is still a same-run HIT.

`Program.cs` registers cleanup on `AppDomain.ProcessExit` right after calling
`DisableForRun()`, so the directory is removed once the terminal generation of the
run is done with it.

`--cache` and `--no-cache` are now last-wins against each other for **every**
cache, not just al-out, in both orders — verified with a real subprocess run in
both directions (see test below).

## What `--no-cache` means now (the decision the issue asked me to make explicit)

"Disable every cache" is the reading I went with — it's the obvious reading of the
flag name, and it's what a caller reaching for a genuinely cold repro needs. The
AL-output cache itself keeps its existing, *stronger* semantics: no disk cache
consulted at all, not even a throwaway one (Program.cs already explains why — a
`--tdd`-style HIT there could silently drop synthetic-FAILED-test detail that
isn't baked into the cached DLL). The other caches get the throwaway-redirect
treatment instead, because they're always-on (not gated on a flag the way al-out
is), so "disable" for them has to mean "start genuinely cold" rather than "stop
reading/writing at all" — the latter isn't expressible for a cache the compile
pipeline unconditionally needs an answer from mid-run.

I did not find any of the four (now eight) caches expensive enough to warrant a
separate opt-out from `--no-cache` itself — `ncl-cecil` (the Cecil rewrite) is the
priciest of the bunch, and it's exactly the one a genuinely cold-repro run should
be paying for, not skipping.

## Fix the shape, not just the reported line

- **Same wrong pattern elsewhere?** No other call site duplicates the bug —
  `CacheRoots.Resolve` is the single choke point every one of these caches already
  goes through (that's what made a class-level fix here cover all eight instead of
  just the four the issue named).
- **Sibling function, same assumption?** `--tdd` also forces `alCacheDir` off
  ("same effect as `--no-cache`" per its own comment) but for an unrelated reason
  (freshness of its synthetic FAILED-test detail, not cold-run reproduction), and
  does not call `DisableForRun()`. Left alone deliberately — its own caches were
  never part of this issue, and folding it in would be answering a different
  question than the one filed. `--precompile` has never parsed `--cache`/
  `--no-cache` at all, so there's no regression to fix there under this issue —
  giving it cache-flag support is a separate feature request.
- **Same-state invariant?** `CacheRoots.Resolve`'s single `_override` field is the
  only state either `SetOverride` or `DisableForRun` writes, so there's exactly one
  invariant (whatever was set last wins) and both paths maintain it the same way —
  confirmed by the last-wins integration test in both directions.

## Tests

Runner-only claims (CLI flag semantics, cache-root scope, re-exec continuity) —
`AlRunner.Tests/`, not the AL corpus, per `bc-behavior-tests-go-upstream.md`.

- `AlRunner.Tests/CacheRootsDisableForRunTests.cs` — unit-level, no BC artifacts
  needed: `DisableForRun()` really creates a directory real I/O lands in, publishes
  it to `AL_RUNNER_NO_CACHE_ROOT`, a second call (same or different process) adopts
  an already-published directory rather than minting a new one, `CleanupThrowawayRoot()`
  really deletes it (including whatever was written into it), and is a safe no-op
  when nothing was ever created. 8 tests.
- `AlRunner.Tests/NoCacheLastWinsIntegrationTests.cs` — spawns the real runner
  (skips without BC artifacts): `--cache DIR --no-cache` leaves `DIR`'s `ncl-cecil`
  untouched (same file set before/after, no mention of `DIR` anywhere in verbose
  output) while `--no-cache --cache DIR` uses `DIR` normally (a real cache HIT
  against it); a plain `--no-cache` run leaves no `al-runner-no-cache-*` directory
  behind afterward. 2 tests.

RED confirmed both times using the documented revert-then-restore recipe (copy the
fixed files out, `git checkout HEAD -- <path>` to go back to the pre-fix code,
confirm failure, restore from the copies) rather than `git stash`: the unit tests
fail to compile against the old `CacheRoots` (the new members don't exist yet), and
the integration test reproduces the exact bug — `--cache DIR --no-cache` still logs
`DIR`'s path for the shadow/Cecil-cache work.

No `tests/expectations/count-baseline` update needed — this only touches
`AlRunner.Tests/`, no AL suite's test/app-group count changed.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf