### PR TITLE
fix(tests): stop bounding the FULL REBUILD search at the cycle-2 marker

### DIFF
--- a/AlRunner.Tests/WatchFullRebuildReasonTests.cs
+++ b/AlRunner.Tests/WatchFullRebuildReasonTests.cs
@@ -69,6 +69,11 @@ public class WatchFullRebuildReasonTests
         string ProcessLiveness() =>
             p.HasExited ? $"process alive=false exit={p.ExitCode}" : "process alive=true";
         string DumpTail() { lock (lines) return string.Join("\n", lines.TakeLast(40).Select(l => $"[{l.Stream}] {l.Text}")); }
+        // #2653: on ANY assertion failure below, dump every captured line with its list
+        // index so the next occurrence answers "was the race index-vs-program-order (#1843
+        // shape) or did the runner genuinely not report it" instead of requiring a fresh
+        // reproduction — see WatchOutputSlicing.cs's header for the mechanism.
+        string DumpAllIndexed() { lock (lines) return string.Join("\n", lines.Select((l, idx) => $"[{idx}][{l.Stream}] {l.Text}")); }
 
         async Task<int> WaitForMarkerAfter(int fromIndex, TimeSpan timeout)
         {
@@ -93,6 +98,36 @@ public class WatchFullRebuildReasonTests
 
         string Segment(int from, int to) { lock (lines) return WatchOutputSlicing.MergedJoin(lines, from, to); }
 
+        // #2653: the FULL REBUILD reason line is written to STDERR, early in the cycle —
+        // well before Emit/dispatch/test-execution/reporting run, all of which happen before
+        // the cycle's OWN closing "waiting for AL source" marker on stdout (m2). Bounding the
+        // search at m2 (the old `Segment(m1 + 1, m2)` shape) reproduces the exact #1843 race
+        // for this marker: `lines`' index order is PUMP SCHEDULING order, not program order,
+        // so a starved stderr pump can still land this line's list index past m2 even though
+        // it was written, chronologically, long before it. Search unbounded forward from
+        // fromIndex instead (mirrors LastWarmTimingMs/ContainsAfter — see
+        // WatchOutputSlicing.cs), and POLL for it: m2 having appeared says nothing about
+        // whether the stderr pump's continuation for THIS line has run yet (the #1843 "mode
+        // 2" race — the line can simply not be in `lines` yet at all).
+        async Task<string> WaitForTextAfter(int fromIndex, string text, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (true)
+            {
+                string snapshot;
+                lock (lines) snapshot = WatchOutputSlicing.MergedJoin(lines, fromIndex, lines.Count);
+                if (snapshot.Contains(text)) return snapshot;
+                if (DateTime.UtcNow >= deadline)
+                {
+                    if (p.HasExited) await Task.Delay(500);
+                    throw new TimeoutException(
+                        $"'{text}' not seen at/after index {fromIndex}. {ProcessLiveness()}\n" +
+                        $"--- last output ---\n{DumpTail()}\n--- all lines ---\n{DumpAllIndexed()}");
+                }
+                await Task.Delay(200);
+            }
+        }
+
         try
         {
             // Cycle 0 (cold): the fixture always falls back here too ("no incremental
@@ -100,7 +135,9 @@ public class WatchFullRebuildReasonTests
             // rebuild" alarm, since every single --watch invocation hits it.
             int m1 = await WaitForMarkerAfter(0, TimeSpan.FromSeconds(150));
             var cycle1 = Segment(0, m1);
-            Assert.DoesNotContain("FULL REBUILD", cycle1);
+            Assert.True(!cycle1.Contains("FULL REBUILD"),
+                $"cycle1 (0..{m1}) unexpectedly contained FULL REBUILD.\n" +
+                $"--- cycle1 ---\n{cycle1}\n--- all lines ---\n{DumpAllIndexed()}");
 
             // Force a genuine fallback on cycle 1 via an ACTUAL .al edit (app.json isn't
             // watched at all — WatchSource.cs filters strictly to "*.al", so an app.json-only
@@ -113,14 +150,25 @@ public class WatchFullRebuildReasonTests
             await File.WriteAllTextAsync(testsCodeunitPath, edited);
 
             int m2 = await WaitForMarkerAfter(m1 + 1, TimeSpan.FromSeconds(240));
-            var cycle2 = Segment(m1 + 1, m2);
+
+            // #2653: NOT `Segment(m1 + 1, m2)` — that upper bound reproduces the #1843 race
+            // for this (stderr) line. Poll unbounded forward from m1 + 1 instead; `cycle2`
+            // below is therefore "everything captured from the start of cycle 2 onward" (m2
+            // itself, plus whatever arrived after it), not a window that closes at m2.
+            var cycle2 = await WaitForTextAfter(m1 + 1, "FULL REBUILD", TimeSpan.FromSeconds(30));
 
             // The reason reached the console WITHOUT --verbose (the defect) and names
             // the specific cause, not a generic "something changed" — a reader must be
             // able to tell WHY the cycle cost minutes instead of milliseconds.
-            Assert.Contains("FULL REBUILD", cycle2);
-            Assert.Contains("XRecProbeTests.Codeunit.al", cycle2);
-            Assert.Contains("declares 2 object(s)", cycle2);
+            Assert.True(cycle2.Contains("FULL REBUILD"),
+                $"cycle2 (m1={m1} m2={m2}) did not contain FULL REBUILD.\n" +
+                $"--- cycle2 (from {m1 + 1}) ---\n{cycle2}\n--- all lines ---\n{DumpAllIndexed()}");
+            Assert.True(cycle2.Contains("XRecProbeTests.Codeunit.al"),
+                $"cycle2 (m1={m1} m2={m2}) did not contain the touched file name.\n" +
+                $"--- cycle2 (from {m1 + 1}) ---\n{cycle2}\n--- all lines ---\n{DumpAllIndexed()}");
+            Assert.True(cycle2.Contains("declares 2 object(s)"),
+                $"cycle2 (m1={m1} m2={m2}) did not contain the object-count reason.\n" +
+                $"--- cycle2 (from {m1 + 1}) ---\n{cycle2}\n--- all lines ---\n{DumpAllIndexed()}");
         }
         finally
         {

--- a/AlRunner.Tests/WatchOutputSlicing.cs
+++ b/AlRunner.Tests/WatchOutputSlicing.cs
@@ -192,4 +192,28 @@ public static class WatchOutputSlicing
     /// </summary>
     public static bool HasAtLeastWarmTimingMatches(IReadOnlyList<CapturedLine> lines, int minCount) =>
         CountWarmTimingMatches(lines) >= minCount;
+
+    /// <summary>
+    /// True when any captured line at index &gt;= <paramref name="fromIndex"/> — across
+    /// EITHER stream — contains <paramref name="text"/>. Unbounded above, for the identical
+    /// reason <see cref="LastWarmTimingMs"/> is: a line's position in `lines` reflects PUMP
+    /// SCHEDULING, not program order (see this file's header comment), so a window bounded
+    /// above by the next stdout marker can miss content that was written, in real time, well
+    /// before that marker.
+    ///
+    /// #2653: WatchFullRebuildReasonTests' cycle-2 "FULL REBUILD" assertions used to bound
+    /// their search at m2 (`Segment(m1 + 1, m2)` then `Assert.Contains`) — exactly the #1843
+    /// shape, just against a different marker. The "FULL REBUILD…" line
+    /// (Program.cs's watch loop, around line 2559) is written to STDERR, early in the cycle —
+    /// well before Emit/dispatch/test-execution/reporting even run, all of which happen
+    /// before the cycle's own closing "waiting for AL source" marker on STDOUT. Under load, a
+    /// starved stderr pump can still land that line's LIST index after m2, even though it was
+    /// written, chronologically, long before it.
+    /// </summary>
+    public static bool ContainsAfter(IReadOnlyList<CapturedLine> lines, string text, int fromIndex)
+    {
+        for (int i = fromIndex; i < lines.Count; i++)
+            if (lines[i].Text.Contains(text)) return true;
+        return false;
+    }
 }

--- a/AlRunner.Tests/WatchOutputSlicingTests.cs
+++ b/AlRunner.Tests/WatchOutputSlicingTests.cs
@@ -304,4 +304,104 @@ public sealed class WatchOutputSlicingTests
         Assert.Throws<ArgumentOutOfRangeException>(
             () => WatchOutputSlicing.FinalCycleStart(new List<int>(), 0));
     }
+
+    // ── #2653: the SAME #1843 race, for the "FULL REBUILD" reason line ─────────────────
+    //
+    // WatchFullRebuildReasonTests's cycle-2 assertions used `Segment(m1 + 1, m2)` then
+    // `Assert.Contains("FULL REBUILD", cycle2)` — an index-windowed search bounded above by
+    // the SAME m2 stdout marker the #1843 fix already proved unsafe for a stderr line. The
+    // "FULL REBUILD…" line (Program.cs, around line 2559) is written to stderr, and a starved
+    // stderr pump can land it at a list index past m2 even though it was written, in program
+    // order, well before m2 — Emit/dispatch/test-execution/reporting all still have to run
+    // between the reason line and the cycle's own closing marker.
+
+    /// <summary>
+    /// Builds the exact list shape a starved stderr pump produces for the FULL REBUILD
+    /// reason line: it was written during cycle 2, strictly before m2 in program order, but
+    /// its pump continuation only gets appended to the shared list AFTER m2.
+    /// </summary>
+    private static (List<CapturedLine> lines, int m1, int m2) FullRebuildStarvedPastM2Scenario()
+    {
+        var lines = new List<CapturedLine>
+        {
+            new(OutputStream.Stdout, "[1/1] xrec-probe-rxt — 1 suites"),
+        };
+        int m1 = lines.Count;
+        lines.Add(new(OutputStream.Stdout, WatchOutputSlicing.WaitingForSourceMarker + "… (Ctrl+C to quit)"));
+
+        lines.Add(new(OutputStream.Stdout, "[watch] change detected — re-running…"));
+        lines.Add(new(OutputStream.Stdout, "[1/1] xrec-probe-rxt — 1 suites"));
+        int m2 = lines.Count;
+        lines.Add(new(OutputStream.Stdout, WatchOutputSlicing.WaitingForSourceMarker + "… (Ctrl+C to quit)"));
+
+        // Written during cycle 2, strictly before m2 in program order (Program.cs prints this
+        // long before Emit even starts) — but its pump continuation lost the race and only
+        // got appended to the shared list here, after m2.
+        lines.Add(new(OutputStream.Stderr,
+            "[watch] xrec-probe-rxt: FULL REBUILD this cycle (whole module — expect the " +
+            "cold-cycle order of magnitude, not a proportional edit) — XRecProbeTests.Codeunit.al " +
+            "declares 2 object(s) (fast path requires exactly 1 per file)"));
+
+        return (lines, m1, m2);
+    }
+
+    /// <summary>
+    /// THE OLD (buggy) SHAPE: an index-windowed `Segment(m1+1, m2)` + `Assert.Contains` misses
+    /// the FULL REBUILD line entirely when the stderr pump is starved past m2 — this is the
+    /// RED half of the #2653 proof, over the OLD assertion shape WatchFullRebuildReasonTests
+    /// used before the fix.
+    /// </summary>
+    [Fact]
+    public void MergedJoin_BoundedAtM2_MissesFullRebuildLine_WhenStderrPumpIsStarvedPastM2()
+    {
+        var (lines, m1, m2) = FullRebuildStarvedPastM2Scenario();
+
+        var cycle2 = WatchOutputSlicing.MergedJoin(lines, m1 + 1, m2);
+
+        Assert.DoesNotContain("FULL REBUILD", cycle2); // the bug: the line is genuinely missing from this window
+    }
+
+    /// <summary>
+    /// THE FIX: an unbounded-forward search from m1 + 1 finds the FULL REBUILD line
+    /// regardless of whether its list index landed past m2 — because it was written, in
+    /// program order, strictly before m2 (stderr has exactly one pump, so cycle 2's own
+    /// stderr writes are always after cycle 1's and always after m1, the same guarantee
+    /// LastWarmTimingMs already relies on for the timing line).
+    /// </summary>
+    [Fact]
+    public void ContainsAfter_FindsFullRebuildLine_EvenWhenStderrPumpIsStarvedPastM2()
+    {
+        var (lines, m1, _) = FullRebuildStarvedPastM2Scenario();
+
+        Assert.True(WatchOutputSlicing.ContainsAfter(lines, "FULL REBUILD", m1 + 1));
+        Assert.True(WatchOutputSlicing.ContainsAfter(lines, "XRecProbeTests.Codeunit.al", m1 + 1));
+        Assert.True(WatchOutputSlicing.ContainsAfter(lines, "declares 2 object(s)", m1 + 1));
+    }
+
+    /// <summary>
+    /// Negative/mutation companion: ContainsAfter must not degenerate into "always true".
+    /// Nothing at or after m1 + 1 mentions a reason that was never written.
+    /// </summary>
+    [Fact]
+    public void ContainsAfter_ReturnsFalse_WhenTheTextWasNeverWritten()
+    {
+        var (lines, m1, _) = FullRebuildStarvedPastM2Scenario();
+
+        Assert.False(WatchOutputSlicing.ContainsAfter(lines, "SOMETHING NEVER WRITTEN", m1 + 1));
+    }
+
+    /// <summary>
+    /// fromIndex must be respected: cycle 1's own window (before m1) must not leak a cycle-2
+    /// reason forward, matching FindStdoutMarkerIndices' existing fromIndex contract.
+    /// </summary>
+    [Fact]
+    public void ContainsAfter_RespectsFromIndex_CannotSeeTextOnlyPresentBeforeIt()
+    {
+        var (lines, m1, m2) = FullRebuildStarvedPastM2Scenario();
+
+        // Searching from AFTER the reason line's own (post-m2) index must not find it.
+        Assert.False(WatchOutputSlicing.ContainsAfter(lines, "FULL REBUILD", lines.Count));
+        // But from m1 + 1 (cycle 2's start), it is found — this is the shape the fixed test uses.
+        Assert.True(WatchOutputSlicing.ContainsAfter(lines, "FULL REBUILD", m1 + 1));
+    }
 }


### PR DESCRIPTION
Closes #2653

## Which explanation

Static analysis, not a live reproduction: **explanation 1** — the test's slice is wrong, not a runner defect.

- `Program.cs`'s `[watch] ... FULL REBUILD this cycle ...` line (around line 2559) is written to **stderr**, `Console.Error.WriteLine`'d before the emit task even starts — well before Emit/dispatch/test-execution/reporting run.
- The cycle-closing `[watch] waiting for AL source changes…` marker the test slices against is on **stdout**, `Console.WriteLine`'d exactly once, only from the non-interactive branch's `onArmed` callback, at the very end of the cycle (confirmed: `Console.IsOutputRedirected` is true for this test's redirected subprocess, so the interactive-dashboard branch — which has a different print path — never runs; there is exactly one print site).
- `WatchOutputSlicing.cs`'s own header comment documents this exact race class (#1843) for a *sibling* stderr line (`GetSharedReferences` timing): list order is pump-scheduling order, not program order, so a starved stderr pump can append a line at a list index *past* a later stdout marker even though it was written well before it in real time. That bug was found and fixed with `LastWarmTimingMs`/`HasAtLeastWarmTimingMatches` (unbounded search + poll-for-arrival).
- `WatchFullRebuildReasonTests.cs` (added in #1994) still used the old bounded shape — `Segment(m1 + 1, m2)` then `Assert.Contains` — for the FULL REBUILD line, which is the identical shape of stderr-vs-stdout-marker line the #1843 fix already proved unsafe. Git history confirms #1994 landed *after* #1843/#1865/#1951, so this is the same bug arriving at a second call site that was never updated, not a new mechanism.
- Explanation 2 (runner genuinely didn't report it) is implausible: the fallback trigger (`ClassifyDeclaredObject` in `BcCompiler.Incremental.cs`, "fast path requires exactly 1 object per file") is a pure static-parse classification with no timing dependency — the test's edit (appending a second `codeunit` declaration to an already-tracked file) deterministically triggers the fallback every time.

## Reproduction

**Did not reproduce live**, despite a genuine attempt: 12 iterations of the unfixed test under 10 parallel `yes` CPU stressors plus two concurrent `dotnet build` loops (~4 minutes), all passed. This is consistent with the failure needing more load/contention than a single dev machine reliably produces (it has shown up on 4 different CI legs across 6 different runs).

## What's in this PR

1. **Diagnostics** (the part worth landing even without a fix): every assertion in the live test now reports `m1`, `m2`, the captured `cycle2` text, and the complete indexed line list on failure.
2. **The fix**: `WatchOutputSlicing.ContainsAfter` — an unbounded-forward substring search mirroring `LastWarmTimingMs` — replaces the bounded `Segment(m1+1, m2)` + `Assert.Contains` shape. The live test now polls (`WaitForTextAfter`) for the FULL REBUILD text unbounded-forward from `m1 + 1`, closing both the "mode 1" (line lands past m2) and "mode 2" (line hasn't arrived at all yet) races `WatchOutputSlicing.cs` already documents for the sibling timing line.
3. **A deterministic synthetic RED/GREEN proof** in `WatchOutputSlicingTests.cs`, built the same way this file already proves #1843: `MergedJoin_BoundedAtM2_MissesFullRebuildLine_WhenStderrPumpIsStarvedPastM2` reproduces the old bug's exact failure shape without needing a live scheduling race, and `ContainsAfter_FindsFullRebuildLine_EvenWhenStderrPumpIsStarvedPastM2` proves the fix. Plus negative/fromIndex-boundary companions.

## Same-shape check

Grepped the rest of `AlRunner.Tests` for any other `Segment(m1 ... m2)`/index-bounded `Assert.Contains` pairs against output crossing the stdout/stderr boundary — `WatchTests.cs` already uses the unbounded `LastWarmTimingMs`/`HasAtLeastWarmTimingMatches` shape (the original #1843 fix site) and `WatchBurstSwitchTests.cs` uses `FinalCycleStart` (the #1936 fix, a different but related bound). `WatchFullRebuildReasonTests.cs` was the only remaining call site still using the pre-#1843 bounded shape.

## Testing

- `dotnet test AlRunner.Tests --filter FullyQualifiedName~WatchOutputSlicingTests` — 16/16 pass (11 existing + 5 new).
- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~WatchOutputSlicing|FullyQualifiedName~WatchFullRebuildReasonTests|FullyQualifiedName~WatchTests|FullyQualifiedName~WatchDashboardTests|FullyQualifiedName~WatchBurstSwitchTests"` — 30/30 pass.
- Live `WatchFullRebuildReasonTests` ran 8/8 times under the same load setup (10 `yes` + `dotnet build` loop) with the fix — no failures.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf