### PR TITLE
fix(provision): verify the test toolkit really landed instead of trusting a glob or an exit code

### DIFF
--- a/AlRunner.Tests/EnsureTestToolkitProvisionedTests.cs
+++ b/AlRunner.Tests/EnsureTestToolkitProvisionedTests.cs
@@ -1,0 +1,199 @@
+// EnsureTestToolkitProvisionedTests — issue #2558.
+//
+// `al-runner provision --test-apps` (Program.cs's EnsureTestToolkitProvisioned, now a
+// thin wrapper over AlRunner.Infrastructure.ProvisioningCheck.EnsureTestToolkitProvisioned)
+// had two silent-degradation bugs:
+//
+// 1. The entry guard accepted ANY single .app file in the destination directory as proof
+//    of a complete toolkit. An interrupted extraction that landed one country test app but
+//    not "Business Foundation Test Libraries" (the real, well-known sentinel — see
+//    ProvisioningCheck.TestToolkitSentinelApp) read as present forever; re-running never
+//    re-attempted the download.
+// 2. The post-download check only inspected the download delegate's exit code.
+//    ArtifactDownloader.TestApps reports success (rc == 0) as soon as ANY file extracted
+//    and skips entries it could not fetch silently — so rc == 0 does not mean the sentinel
+//    app actually landed. `provision --test-apps` could exit 0 over a partial toolkit.
+//
+// Both are exercised here via a FAKE download delegate rather than a real network call
+// (ProvisionExplicitModesTests.cs already covers the real end-to-end download path) —
+// this is what lets the "reports success without landing the sentinel" shape be proven
+// deterministically instead of depending on a real, flaky partial download.
+
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class EnsureTestToolkitProvisionedTests : IDisposable
+{
+    private readonly string _dir;
+
+    public EnsureTestToolkitProvisionedTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "al-runner-ensure-toolkit", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    // ── minimal NAVX .app writer (mirrors ProvisioningCheckTests.cs's own helpers) ────────
+
+    private static byte[] MakeMinimalNavxApp(string appId, string name, string publisher, string version)
+    {
+        var xml = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{appId}" Name="{name}" Publisher="{publisher}" Version="{version}"/>
+            </Package>
+            """;
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = zip.CreateEntry("NavxManifest.xml");
+            using var es = entry.Open();
+            es.Write(Encoding.UTF8.GetBytes(xml));
+        }
+        var zipBytes = ms.ToArray();
+        var result = new byte[8 + zipBytes.Length];
+        result[0] = (byte)'N'; result[1] = (byte)'A'; result[2] = (byte)'V'; result[3] = (byte)'X';
+        BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
+        zipBytes.CopyTo(result, 8);
+        return result;
+    }
+
+    private void WriteApp(string fileName, string appId, string name, string publisher, string version)
+        => File.WriteAllBytes(Path.Combine(_dir, fileName), MakeMinimalNavxApp(appId, name, publisher, version));
+
+    private void WriteSentinel() =>
+        WriteApp("microsoft_business foundation test libraries_28.1.0.0.app",
+            "bee8cf2f-494a-42f4-aabd-650e87934d39", ProvisioningCheck.TestToolkitSentinelApp, "Microsoft", "28.1.0.0");
+
+    private void WriteUnrelatedApp() =>
+        WriteApp("nl_some country test app_28.1.0.0.app",
+            "00000000-0000-0000-0000-0000000000aa", "NL Some Country Test App", "Microsoft", "28.1.0.0");
+
+    // ── entry guard ─────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SentinelAlreadyPresent_ReportsAlreadyPresent_NeverCallsDownload()
+    {
+        WriteSentinel();
+        var downloadCalled = false;
+        var logs = new List<string>();
+
+        var ok = ProvisioningCheck.EnsureTestToolkitProvisioned(
+            "28.1.49838.53910", _dir,
+            (v, d, l) => { downloadCalled = true; return 0; },
+            logs.Add);
+
+        Assert.True(ok);
+        Assert.False(downloadCalled, "already-complete toolkit must not trigger a download");
+        Assert.Contains(logs, l => l.Contains("already present") && l.Contains(_dir));
+    }
+
+    [Fact]
+    public void OnlyUnrelatedAppPresent_DoesNotReportAlreadyPresent_CallsDownload()
+    {
+        // The bug: a directory holding ONE .app that is NOT the sentinel (e.g. left behind
+        // by an earlier interrupted extraction) used to satisfy the old "any .app exists"
+        // guard forever.
+        WriteUnrelatedApp();
+        var downloadCalled = false;
+        var logs = new List<string>();
+
+        var ok = ProvisioningCheck.EnsureTestToolkitProvisioned(
+            "28.1.49838.53910", _dir,
+            (v, d, l) =>
+            {
+                downloadCalled = true;
+                // Simulate a successful, COMPLETE download this time: land the sentinel.
+                File.WriteAllBytes(Path.Combine(d, "microsoft_business foundation test libraries_28.1.0.0.app"),
+                    MakeMinimalNavxApp("bee8cf2f-494a-42f4-aabd-650e87934d39",
+                        ProvisioningCheck.TestToolkitSentinelApp, "Microsoft", "28.1.0.0"));
+                return 0;
+            },
+            logs.Add);
+
+        Assert.True(ok);
+        Assert.True(downloadCalled, "an unrelated leftover .app must not short-circuit the download");
+        Assert.DoesNotContain(logs, l => l.Contains("already present"));
+        Assert.Contains(logs, l => l.Contains("fetching"));
+    }
+
+    // ── post-download re-check ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DownloadReturnsZero_ButSentinelNeverLands_FailsLoudly_NamesTheSentinel()
+    {
+        // The exact silent-skip shape #2558 reports: ArtifactDownloader.TestApps returns 0
+        // (something extracted) but the specific sentinel app never made it to disk.
+        var logs = new List<string>();
+
+        var ok = ProvisioningCheck.EnsureTestToolkitProvisioned(
+            "28.1.49838.53910", _dir,
+            (v, d, l) =>
+            {
+                // Simulate a partial extraction: writes an unrelated file, "succeeds" (rc=0),
+                // but never writes the sentinel.
+                File.WriteAllText(Path.Combine(d, "some-other-file.app"), "not a real app");
+                return 0;
+            },
+            logs.Add);
+
+        Assert.False(ok, "rc == 0 without the sentinel landing must NOT be treated as success");
+        Assert.Contains(logs, l => l.Contains("still missing") && l.Contains(ProvisioningCheck.TestToolkitSentinelApp) && l.Contains(_dir));
+    }
+
+    [Fact]
+    public void DownloadReturnsNonZero_FailsLoudly_NamesTheVersion()
+    {
+        var logs = new List<string>();
+
+        var ok = ProvisioningCheck.EnsureTestToolkitProvisioned(
+            "28.1.49838.53910", _dir,
+            (v, d, l) => 1,
+            logs.Add);
+
+        Assert.False(ok);
+        Assert.Contains(logs, l => l.Contains("warning") && l.Contains("could not fetch") && l.Contains("28.1.49838.53910"));
+    }
+
+    [Fact]
+    public void DownloadThrows_FailsLoudly_DoesNotPropagateTheException()
+    {
+        var logs = new List<string>();
+
+        var ok = ProvisioningCheck.EnsureTestToolkitProvisioned(
+            "28.1.49838.53910", _dir,
+            (v, d, l) => throw new InvalidOperationException("network exploded"),
+            logs.Add);
+
+        Assert.False(ok);
+        Assert.Contains(logs, l => l.Contains("download failed") && l.Contains("network exploded"));
+    }
+
+    [Fact]
+    public void DownloadReturnsZero_AndSentinelLands_Succeeds()
+    {
+        var logs = new List<string>();
+
+        var ok = ProvisioningCheck.EnsureTestToolkitProvisioned(
+            "28.1.49838.53910", _dir,
+            (v, d, l) =>
+            {
+                File.WriteAllBytes(Path.Combine(d, "microsoft_business foundation test libraries_28.1.0.0.app"),
+                    MakeMinimalNavxApp("bee8cf2f-494a-42f4-aabd-650e87934d39",
+                        ProvisioningCheck.TestToolkitSentinelApp, "Microsoft", "28.1.0.0"));
+                return 0;
+            },
+            logs.Add);
+
+        Assert.True(ok);
+        Assert.DoesNotContain(logs, l => l.Contains("still missing"));
+    }
+}

--- a/AlRunner.Tests/ProvisionExplicitModesTests.cs
+++ b/AlRunner.Tests/ProvisionExplicitModesTests.cs
@@ -171,6 +171,44 @@ public sealed class ProvisionExplicitModesTests
     }
 
     /// <summary>
+    /// Issue #2558's exact reported command: `provision --test-apps` used to accept ANY
+    /// single .app file as proof of a complete toolkit — a directory left holding one
+    /// unrelated .app by, e.g., an earlier interrupted extraction read as "already present"
+    /// forever, and a re-run never attempted the real download. The entry guard now uses
+    /// ProvisioningCheck.TestToolkitPresent (a real manifest parse for the specific,
+    /// well-known sentinel app "Business Foundation Test Libraries"), not "does any .app
+    /// file exist". Proven end-to-end against the real CDN: seed the canonical directory
+    /// with one unrelated .app, run without --force, and the run must NOT say "already
+    /// present" — it must actually fetch the real set, landing the sentinel.
+    /// </summary>
+    [Fact]
+    public void TestApps_OnlyUnrelatedAppPresent_DoesNotShortCircuit_DownloadsTheRealSet()
+    {
+        var home = NewIsolatedHome();
+        try
+        {
+            var testAppsDir = TestAppsDirFor(home);
+            Directory.CreateDirectory(testAppsDir);
+            // A single, deliberately UNRELATED .app — not the real sentinel — mimicking an
+            // interrupted extraction that landed one country test app and nothing else.
+            File.WriteAllText(Path.Combine(testAppsDir, "leftover.app"), "not a real NAVX package");
+
+            var (exit, stderr) = Run(home, "provision", "--test-apps", "--bc-version", RealVersion);
+
+            Assert.True(exit == 0, $"provision --test-apps must exit 0 once the real download completes. stderr:\n{stderr}");
+            Assert.DoesNotContain("already present", stderr, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("fetching", stderr, StringComparison.OrdinalIgnoreCase);
+            var apps = Directory.GetFiles(testAppsDir, "*.app");
+            Assert.Contains(apps, a => Path.GetFileName(a).Contains("Library Assert", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(apps, a => Path.GetFileName(a).Contains("Business Foundation Test Libraries", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { Directory.Delete(home, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
     /// `--force` is the escape hatch from the skip above: it must re-run the download even
     /// though the directory already looks populated. Proven the same way as the negative
     /// test above, inverted — the marker's write time MUST move.

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -401,6 +401,88 @@ public static class ProvisioningCheck
     }
 
     /// <summary>
+    /// #2558: <c>al-runner provision --test-apps</c>'s own logic, extracted out of
+    /// <c>Program.cs</c> so it is unit-testable without a real network download —
+    /// <paramref name="download"/> stands in for
+    /// <see cref="AlRunner.Provisioning.ArtifactDownloader.TestApps"/>, which a test can
+    /// replace with a fake that returns 0 without writing the sentinel app, the exact
+    /// silent-skip shape this method exists to catch.
+    ///
+    /// Both the entry guard AND the post-download check use <see cref="TestToolkitPresent"/>
+    /// (a real manifest parse for the specific, well-known sentinel app), not "does any
+    /// <c>.app</c> file exist in <paramref name="dir"/>" — the entry guard used to accept
+    /// any single file, so a directory left holding one country test app by an earlier
+    /// interrupted extraction (but missing <see cref="TestToolkitSentinelApp"/>) read as a
+    /// complete toolkit forever, and re-running never re-attempted the download.
+    ///
+    /// <paramref name="download"/> can report <c>rc == 0</c> ("success") after extracting
+    /// ANY file, silently skipping entries it could not fetch — so a successful-looking
+    /// return code alone does not mean the sentinel app actually landed on disk. This
+    /// method re-checks the same real predicate after the download returns 0, rather than
+    /// trusting the exit code, and returns <c>false</c> (with a named, actionable log line)
+    /// on either kind of failure — a caller that used to warn-and-continue on <c>rc != 0</c>
+    /// can now fail loudly instead, per <c>.claude/rules/loud-failures.md</c>.
+    /// </summary>
+    /// <param name="fullVersion">The full BC artifact version being provisioned for.</param>
+    /// <param name="dir">The test-apps destination directory for that version.</param>
+    /// <param name="download">
+    /// (version, outputDir, log) → exit code, matching
+    /// <see cref="AlRunner.Provisioning.ArtifactDownloader.TestApps"/>'s own signature.
+    /// </param>
+    /// <param name="log">Receives one line per step, already carrying the caller's own prefix
+    /// convention (e.g. Program.cs passes a delegate that prepends "[provision] ") — this
+    /// method does not prepend anything of its own.</param>
+    /// <returns>
+    /// <c>true</c> if the toolkit was already present, or was downloaded and the sentinel
+    /// app is confirmed present afterward; <c>false</c> on any failure (download itself
+    /// failed, threw, or reported success without the sentinel actually landing).
+    /// </returns>
+    public static bool EnsureTestToolkitProvisioned(
+        string fullVersion,
+        string dir,
+        Func<string, string, Action<string>?, int> download,
+        Action<string> log)
+    {
+        if (TestToolkitPresent(new[] { dir }))
+        {
+            log($"test toolkit already present at {dir}.");
+            return true;
+        }
+
+        log($"fetching the MS test toolkit for BC {fullVersion} → {dir}");
+        int rc;
+        try
+        {
+            rc = download(fullVersion, dir, log);
+        }
+        catch (Exception ex)
+        {
+            log($"warning: test-toolkit download failed: {ex.Message}");
+            return false;
+        }
+
+        if (rc != 0)
+        {
+            log($"warning: could not fetch the test toolkit for BC {fullVersion}. " +
+                "Test bundles depending on Library Assert / Test Runner / Any will need " +
+                "--package-cache <dir-with-those-apps>.");
+            return false;
+        }
+
+        // rc == 0 does not mean the sentinel app landed -- ArtifactDownloader.TestApps
+        // reports success on any non-zero extraction and skips entries it could not fetch
+        // silently. Re-check the real predicate instead of trusting the exit code.
+        if (!TestToolkitPresent(new[] { dir }))
+        {
+            log($"test toolkit download reported success but the sentinel app " +
+                $"'{TestToolkitSentinelApp}' is still missing from {dir}.");
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
     /// The BC major.minor a Microsoft "Base Application"/"System Application" .app already
     /// present in <paramref name="packageCacheDirs"/> would suggest for auto-provisioning.
     /// Falls back to <paramref name="fallbackVersion"/>'s major.minor when no such app is

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -8153,35 +8153,53 @@ static int RunExplicitProvisionModes(string? bcVersionArg, List<string> bundles,
     if (serviceTier)
     {
         var dir = AlRunner.Infrastructure.BcArtifacts.ArtifactDirFor(full);
-        anyFailed |= ForceProvisionMode("BC service-tier engine DLLs", dir, full, force, "*.dll",
+        anyFailed |= ForceProvisionMode("BC service-tier engine DLLs", dir, full, force,
+            d => Directory.Exists(d) && Directory.EnumerateFiles(d, "*.dll").Any(),
             (v, d, log) => AlRunner.Provisioning.ArtifactDownloader.ServiceTier(v, d, log)) != 0;
     }
     if (platformApps)
     {
         var dir = AlRunner.Infrastructure.ProvisioningCheck.PlatformAppsDirFor(
             AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, full);
-        anyFailed |= ForceProvisionMode("Microsoft platform apps", dir, full, force, "*.app",
+        anyFailed |= ForceProvisionMode("Microsoft platform apps", dir, full, force,
+            d => Directory.Exists(d) && Directory.EnumerateFiles(d, "*.app").Any(),
             (v, d, log) => AlRunner.Provisioning.ArtifactDownloader.PlatformApps(
                 v, d, AlRunner.Infrastructure.BcArtifacts.SelectedCountry, log)) != 0;
     }
     if (testApps)
     {
         var dir = TestAppsDirFor(full);
-        anyFailed |= ForceProvisionMode("Microsoft test-toolkit apps", dir, full, force, "*.app",
+        // #2558: this is the exact command the issue reports ("al-runner provision
+        // --test-apps can exit 0 over a partial extraction") — unlike the other two
+        // modes above, "any *.app file exists" is not a faithful completeness check for
+        // the test toolkit specifically: an interrupted extraction that landed one
+        // country test app but not the real sentinel (TestToolkitPresent /
+        // TestToolkitSentinelApp) used to read as complete forever, and a download that
+        // reports rc == 0 without the sentinel landing used to be treated as success.
+        anyFailed |= ForceProvisionMode("Microsoft test-toolkit apps", dir, full, force,
+            d => AlRunner.Infrastructure.ProvisioningCheck.TestToolkitPresent(new[] { d }),
             (v, d, log) => AlRunner.Provisioning.ArtifactDownloader.TestApps(v, d, log)) != 0;
     }
     return anyFailed ? 2 : 0;
 }
 
-// Shared by every explicit provision mode: skip the download when the canonical directory
-// already contains at least one file matching <paramref name="expectedGlob"/> (unless
-// --force), otherwise run <paramref name="download"/> and report success/failure. Named
-// per-mode so the log lines read like the rest of `[provision]` output, not a generic
-// "done"/"failed".
+// Shared by every explicit provision mode: skip the download when <paramref name="isPresent"/>
+// says the canonical directory already looks complete (unless --force), otherwise run
+// <paramref name="download"/> and report success/failure. Named per-mode so the log lines
+// read like the rest of `[provision]` output, not a generic "done"/"failed".
+//
+// #2558: <paramref name="isPresent"/> is also re-checked AFTER a download that reports
+// rc == 0 — a download delegate can report success as soon as it wrote ANYTHING, silently
+// skipping entries it could not fetch, so rc == 0 alone does not mean the expected content
+// actually landed. This was `al-runner provision --test-apps`'s exact reported bug: its
+// predicate used to be "does any *.app file exist in the directory", so a partial
+// extraction (e.g. one leftover country test app but not the toolkit's real sentinel) read
+// as complete forever, and a download that "succeeded" without the sentinel landing was
+// never caught.
 static int ForceProvisionMode(string label, string outputDir, string fullVersion, bool force,
-    string expectedGlob, Func<string, string, Action<string>, int> download)
+    Func<string, bool> isPresent, Func<string, string, Action<string>, int> download)
 {
-    if (!force && Directory.Exists(outputDir) && Directory.EnumerateFiles(outputDir, expectedGlob).Any())
+    if (!force && isPresent(outputDir))
     {
         Console.Error.WriteLine($"[provision] {label} already present at {outputDir} for BC {fullVersion} — skipping (pass --force to re-download).");
         return 0;
@@ -8191,8 +8209,18 @@ static int ForceProvisionMode(string label, string outputDir, string fullVersion
     {
         var rc = download(fullVersion, outputDir, m => Console.Error.WriteLine($"[provision] {m}"));
         if (rc != 0)
+        {
             Console.Error.WriteLine($"[provision] warning: {label} download failed for BC {fullVersion}.");
-        return rc;
+            return rc;
+        }
+        if (!isPresent(outputDir))
+        {
+            Console.Error.WriteLine(
+                $"[provision] {label} download reported success but the expected content is " +
+                $"still missing from {outputDir} for BC {fullVersion}.");
+            return 1;
+        }
+        return 0;
     }
     catch (Exception ex)
     {
@@ -8427,7 +8455,11 @@ static int RunProvisioning(string? bcVersionArg, string? artifactPathArg,
         // edges live in the test-toolkit packages' own NavxManifest.xml. Fetch that set
         // first and EnsurePlatformAppsProvisioned can read the answer instead of guessing it
         // from a hand-written table that was only ever right for one BC version.
-        EnsureTestToolkitProvisioned(full);
+        // #2558: fail loudly (exit 2) rather than warn-and-continue over a partial toolkit
+        // — mirrors the --auto-provision path's own post-download re-check a few hundred
+        // lines up (`toolkitPresent = ...; if (!toolkitPresent) { ...; return 2; }`).
+        if (!EnsureTestToolkitProvisioned(full))
+            return 2;
         EnsurePlatformAppsProvisioned(full, bundles);
     }
     provisionedVersion = full;
@@ -8570,29 +8602,20 @@ static void EnsurePlatformAppsProvisioned(string engineVersion, List<string> bun
 // had to hand-assemble a package dir with no command that could produce one.
 // Provisioned into <artifacts>/<version>/test-apps/, which DefaultPackageCacheDirs scans,
 // so a provisioned machine needs no --package-cache for the toolkit at all.
-static void EnsureTestToolkitProvisioned(string fullVersion)
+// #2558: thin wrapper over ProvisioningCheck.EnsureTestToolkitProvisioned — the real logic
+// lives there so it is unit-testable with a fake download delegate (no real network call).
+// Returns false (rather than only warning) on either kind of provisioning failure — a
+// download that failed outright, or one that reported success (rc == 0) without the
+// sentinel app actually landing — so RunExplicitProvisionModes can fail the whole
+// `provision --test-apps` invocation loudly instead of exiting 0 over a partial toolkit.
+static bool EnsureTestToolkitProvisioned(string fullVersion)
 {
     var dir = TestAppsDirFor(fullVersion);
-    if (Directory.Exists(dir) && Directory.EnumerateFiles(dir, "*.app").Any())
-    {
-        Console.Error.WriteLine($"[provision] test toolkit already present at {dir}.");
-        return;
-    }
-    Console.Error.WriteLine($"[provision] fetching the MS test toolkit for BC {fullVersion} → {dir}");
-    try
-    {
-        var rc = AlRunner.Provisioning.ArtifactDownloader.TestApps(
-            fullVersion, dir, m => Console.Error.WriteLine($"[provision] {m}"));
-        if (rc != 0)
-            Console.Error.WriteLine(
-                $"[provision] warning: could not fetch the test toolkit for BC {fullVersion}. " +
-                $"Test bundles depending on Library Assert / Test Runner / Any will need " +
-                $"--package-cache <dir-with-those-apps>.");
-    }
-    catch (Exception ex)
-    {
-        Console.Error.WriteLine($"[provision] warning: test-toolkit download failed: {ex.Message}");
-    }
+    return AlRunner.Infrastructure.ProvisioningCheck.EnsureTestToolkitProvisioned(
+        fullVersion,
+        dir,
+        (v, d, l) => AlRunner.Provisioning.ArtifactDownloader.TestApps(v, d, l),
+        m => Console.Error.WriteLine($"[provision] {m}"));
 }
 
 static string TestAppsDirFor(string fullVersion)


### PR DESCRIPTION
Closes #2558

## Problem

`EnsureTestToolkitProvisioned` (the bare `al-runner provision` auto-detect path) treated ANY
single `.app` file in the destination directory as proof of a complete test toolkit, and only
inspected the download's exit code afterward. An interrupted extraction that landed one
country test app but not the real sentinel (`Business Foundation Test Libraries`) read as
"already present" forever, and a download reporting success (`rc == 0`) without the sentinel
actually landing was silently accepted.

## Fix

Both the entry guard and the post-download check now go through
`ProvisioningCheck.TestToolkitPresent` — a real manifest parse for the specific, well-known
sentinel app — via a new `ProvisioningCheck.EnsureTestToolkitProvisioned(fullVersion, dir,
download, log)` that takes the download as a delegate so it's unit-testable without a real
network call. A failure of either kind (download failed, or reported success without the
sentinel landing) now returns `false`, which `RunExplicitProvisionModes`... actually the
`provisionManifestApps` caller (`RunProvisioning`) now propagates it to a loud `exit 2`
instead of warning and continuing, per `.claude/rules/loud-failures.md`.

## Fix the shape, not just the reported line

**Does the same wrong pattern appear at another call site?** Yes — and it's the literal
command the issue reports. `al-runner provision --test-apps` does **not** reach
`EnsureTestToolkitProvisioned` at all: I verified this empirically (ran both code paths
against a real, isolated `$HOME` and compared the distinct log wording each one prints).
`--test-apps` dispatches through `RunExplicitProvisionModes` → `ForceProvisionMode`, a
separate helper with the identical two-bug shape: a glob-based entry guard
(`Directory.EnumerateFiles(dir, "*.app").Any()`) and an exit-code-only post-download check.
`ForceProvisionMode` now takes an `isPresent: Func<string, bool>` predicate instead of a bare
glob string, and re-checks it after a download reports success — for **all three** explicit
modes (`--platform-apps`/`--service-tier`/`--test-apps`), since the post-download re-check
generalizes cleanly regardless of what the predicate itself checks.

**Sibling function, same assumption?** Only the `--test-apps` branch gets the *precise*
`TestToolkitPresent` predicate in this PR, matching the issue's own scope.
`--platform-apps`/`--service-tier` keep their existing (less precise, but now still
re-checked-after-download) glob-based guard — building an equivalent completeness predicate
for the R2R platform set and the ~55-DLL service-tier closure is materially more work than
reusing `TestToolkitPresent`, which already existed. Filed as
[#2661](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2661) rather than
silently left as-is.

**Same-state invariant?** `ForceProvisionMode`'s generalization means the entry guard and the
post-download re-check for a given mode always use the SAME predicate — there's no way for
them to drift apart the way the two originally-separate check shapes (`EnsureTestToolkitProvisioned`'s
own guard/recheck pair vs. `ForceProvisionMode`'s) could.

## Tests

Runner-only claims (CLI behavior, provisioning lifecycle) — `AlRunner.Tests/`, not the AL
corpus, per `bc-behavior-tests-go-upstream.md`.

- `AlRunner.Tests/EnsureTestToolkitProvisionedTests.cs` — unit-level, fake download delegate,
  no network: entry guard short-circuits correctly when the sentinel is present and does NOT
  when only an unrelated `.app` is present (and calls the delegate in that case); post-download
  re-check fails loudly (named message) when the delegate returns `rc == 0` without landing the
  sentinel, when it returns non-zero, and when it throws; succeeds when the sentinel genuinely
  lands. 6 tests.
- `AlRunner.Tests/ProvisionExplicitModesTests.cs` — added
  `TestApps_OnlyUnrelatedAppPresent_DoesNotShortCircuit_DownloadsTheRealSet`: spawns the real
  runner against a real, isolated `$HOME` and the real BC artifact CDN (same style as the
  existing tests in this file) — seeds the canonical directory with one unrelated `.app`
  and confirms `provision --test-apps` does NOT report "already present", instead fetches
  and lands the real sentinel. This is the test that caught the wrong-call-site finding above:
  it failed RED against the *old* `ForceProvisionMode` even though `EnsureTestToolkitProvisioned`
  was already fixed, because that command never reached it.

RED confirmed for both files using the documented revert-then-restore recipe (copy the fixed
files out, `git checkout HEAD -- <path>`, confirm failure, restore from the copies) rather than
`git stash`. Also manually verified end-to-end against the real BC artifact CDN, before and
after the `ForceProvisionMode` fix, with a seeded partial `test-apps` directory.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf