### PR TITLE
test(perf): give ServerAffectedSelectionTests its measured weight

### DIFF
--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -226,6 +226,14 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
             ["DapStdioServerTests"] = 101,
             ["CacheRootsIsolationTests"] = 83,
             ["ServerDuplicateSourcePathTests"] = 73,
+            // #2653-adjacent: tripped check-collection-weights.py on PR 2659, absent from
+            // this table while costing over 60s. Measured across all six legs of that run:
+            // 61.3s (27.3), 67.3s (27.5), 69.4s (28.0), 71.2s (28.1), 61.4s (28.2),
+            // 63.0s (28.3). Carries the observed MAXIMUM, not the minimum, for the reason
+            // InstallBaselineVirtualTableExclusionTests above spells out: a value at the low
+            // end of an observed range sits on the 60s freshness threshold, which satisfies
+            // the gate while leaving dispatch order at the fallback and the tail in place.
+            ["ServerAffectedSelectionTests"] = 71,
             ["ProvisionExplicitModesTests"] = 80,
             // #1940/#1941/#1943: 4 tests, each spawning a real runner subprocess (two
             // single-bundle, two layered two-bundle dep compiles) — needed because


### PR DESCRIPTION
No linked issue: this is the table maintenance `check-collection-weights.py` asks for by name when a collection crosses its threshold, not a tracked defect.

## What failed

All six running legs of PR 2659 failed on the #1887 guard, not on a test:

```
STALE CollectionCostOrderer.MeasuredWeightSeconds TABLE (issue #1887)
The following collection(s) cost >= 60s this run but are absent
from the table in AlRunner.Tests/CollectionCostOrderer.cs. Each falls back to
UnmeasuredWeightSeconds (30s) and can be scheduled as a
single-threaded tail late in the run — exactly the failure issue #1887 found.

     61.3s  ServerAffectedSelectionTests
```

## Measured across every leg, not one sample

| leg | cost |
|---|---|
| 27.3 | 61.3s |
| 27.5 | 67.3s |
| 28.0 | 69.4s |
| 28.1 | 71.2s |
| 28.2 | 61.4s |
| 28.3 | 63.0s |

## Why 71 and not 61

The entry carries the observed **maximum**. That is the reasoning already written into this file next to `InstallBaselineVirtualTableExclusionTests`: a value at the low end of an observed range sits right on the 60s freshness threshold, so it satisfies the gate while leaving dispatch order at the fallback and the tail exactly where it was. The script's own message says "round down", which is right for a single measurement; with a range in hand, rounding down the *minimum* would defeat the purpose.

Six legs rather than one, because a single measurement of a load-sensitive number is how a stale entry gets written in the first place.

## Why this is its own PR

The gate tripped on 2659, whose `--no-cache` change makes more work cache-miss and pushed this collection over the line. But the entry is correct for `main` regardless — the collection genuinely costs more than 60s now — and every other PR is one unlucky run away from the same failure. Landing it separately unblocks 2659 without coupling it to whatever else that PR still needs.

## Test plan

- [x] `dotnet test --filter "FullyQualifiedName~CollectionCost"` — 8/8 pass.
- [x] Build clean.
- [ ] The guard itself only runs in CI against a real `trx`, so this leg's own run is the proof.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
