### PR TITLE
fix(provision): stop --force/--resolve-version from silently doing less than they say

### DIFF
--- a/AlRunner.Tests/DependencyManifestNonStringFieldTests.cs
+++ b/AlRunner.Tests/DependencyManifestNonStringFieldTests.cs
@@ -1,0 +1,157 @@
+// DependencyManifestNonStringFieldTests — issue #2560, defect 3.
+//
+// Program.cs's ReadDependencies read each `dependencies[]` entry's id/name/publisher/
+// version via an unguarded JsonElement.GetString(), so a hand-edited/malformed app.json
+// with a non-string field (e.g. `"name": 123`) raised InvalidOperationException straight
+// out of the resolution path. TryReadManifestDependencyRoots's own catch-all (a pre-scan,
+// ProvisioningCheck.cs) protects ONE caller; ReadDependencies is also called directly
+// (the per-suite dependency-resolve path, and EnsurePlatformAppsProvisioned's manifest
+// scan) with no such wrapper, so the exception was unhandled there.
+//
+// The fix must do neither of the two easy-but-wrong things: crash (the original bug), or
+// silently `continue` past the whole malformed entry (which drops a real dependency edge
+// just as silently, the same class of problem the other way — see the issue's own "Test"
+// section). It must print a diagnostic naming the file and the specific entry.
+//
+// Spawns the real runner; needs the BC artifact cache to get far enough to reach app.json
+// dependency resolution at all (BC version selection happens first). Skips when absent.
+
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class DependencyManifestNonStringFieldTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(string bundleDir, string absentPackageCache)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" \"{bundleDir}\"");
+        args.Append($" --package-cache \"{absentPackageCache}\"");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(120_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    [SkippableFact]
+    public void NumericDependencyName_DoesNotThrow_NamesTheFileAndEntry_StillResolvesOtherDeps()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var scratchRoot = Path.Combine(Path.GetTempPath(), "al-runner-nonstring-dep", Guid.NewGuid().ToString("N"));
+        var depDir = Path.Combine(scratchRoot, "dep-app");
+        var testsDir = Path.Combine(scratchRoot, "tests-app");
+        var absentPackageCache = Path.Combine(scratchRoot, "no-such-package-cache");
+        Directory.CreateDirectory(depDir);
+        Directory.CreateDirectory(testsDir);
+
+        var depId = Guid.NewGuid();
+        var testsId = Guid.NewGuid();
+
+        // A real, resolvable dependency alongside the malformed entry — proves the
+        // malformed entry degrades on its OWN field rather than dropping the whole
+        // dependencies array (a bug that would also silently break every OTHER entry).
+        File.WriteAllText(Path.Combine(depDir, "app.json"), $$"""
+        {
+          "id": "{{depId}}",
+          "name": "Repro2560 Dep App",
+          "publisher": "Repro2560",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 61960, "to": 61969 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(depDir, "Repro2560Dep.al"), """
+        codeunit 61960 "Repro2560 Greeter"
+        {
+            procedure Greet(): Text
+            begin
+                exit('hello');
+            end;
+        }
+        """);
+
+        // The `dependencies` array has TWO entries: a real, resolvable one (the dep app
+        // above) and one with a numeric `name` field — the exact malformed shape #2560
+        // reports. Also a numeric `id`, to prove both string-typed fields degrade
+        // independently rather than one bad field taking down parsing of the others.
+        File.WriteAllText(Path.Combine(testsDir, "app.json"), $$"""
+        {
+          "id": "{{testsId}}",
+          "name": "Repro2560 Tests",
+          "publisher": "Repro2560",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{depId}}", "name": "Repro2560 Dep App", "publisher": "Repro2560", "version": "1.0.0.0" },
+            { "id": 999, "name": 123, "publisher": "Repro2560", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 61970, "to": 61979 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(testsDir, "Repro2560Tests.al"), """
+        codeunit 61970 "Repro2560 Poison Test"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure GreeterWorks()
+            var
+                Greeter: Codeunit "Repro2560 Greeter";
+                Result: Text;
+            begin
+                Result := Greeter.Greet();
+                if Result <> 'hello' then
+                    Error('Expected hello, got ''%1''', Result);
+            end;
+        }
+        """);
+
+        var (output, exit) = RunRunner(testsDir, absentPackageCache);
+
+        // The decisive negative claim: no UNHANDLED exception took the process down — the
+        // .NET runtime's own marker for that ("Unhandled exception. <type>: ...", followed
+        // by a raw CLR stack trace) must not appear. Not asserting the exception TYPE/
+        // MESSAGE never appears anywhere in the log: a separate, already-caught reader
+        // (InProcessAppPackager, a redundant app.json read elsewhere in the pipeline) hits
+        // the identical JsonElement type mismatch and logs it as "failed to read ...",
+        // which is a legitimate, non-crashing occurrence of the same .NET exception text —
+        // this test's claim is about ReadDependencies specifically, proven by the
+        // named-diagnostic and still-resolves assertions below, not by banning a substring
+        // that a DIFFERENT, already-safe code path also produces.
+        Assert.DoesNotContain("Unhandled exception", output);
+
+        // Named diagnostic: which file, which entry (index 1, the second dependencies[]
+        // element), which property.
+        var appJsonPath = Path.Combine(testsDir, "app.json");
+        Assert.Contains(appJsonPath, output);
+        Assert.Contains("dependencies[1]", output);
+        Assert.Contains("name", output);
+
+        // Not a silent drop of the WHOLE dependencies array over one bad entry: the real,
+        // resolvable dependency (entry 0) still resolves and the test that calls into it
+        // still passes.
+        Assert.True(exit == 0 && output.Contains("1P/0F/0E"), $"the real dependency must still resolve and the test must still pass:\n{output}");
+    }
+}

--- a/AlRunner.Tests/ProvisionExplicitModesTests.cs
+++ b/AlRunner.Tests/ProvisionExplicitModesTests.cs
@@ -376,4 +376,77 @@ public sealed class ProvisionExplicitModesTests
         Assert.NotEqual(0, proc.ExitCode);
         Assert.Contains("only valid with the `provision` subcommand", stderr, StringComparison.Ordinal);
     }
+
+    /// <summary>
+    /// Issue #2560, defect 1: `provision --force` alone (the `provision` subcommand IS
+    /// present, so the sibling "--force without `provision`" guard above does not fire, but
+    /// none of --platform-apps/--test-apps/--service-tier is given either) used to match
+    /// neither rejection guard and fall through into the ordinary auto-detect run path with
+    /// --force silently discarded — no message, no error, nothing forced. No network/BC
+    /// artifacts needed: this must be rejected before either is ever touched.
+    /// </summary>
+    [Fact]
+    public void Force_AloneWithNoModeFlag_IsRejected()
+    {
+        var argLine = TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner")) + " provision --force";
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = argLine,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        psi.Environment["HOME"] = NewIsolatedHome();
+        using var proc = Process.Start(psi)!;
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(30_000));
+        Assert.Equal(2, proc.ExitCode);
+        Assert.Contains("--force is only valid with", stderr, StringComparison.Ordinal);
+        Assert.Contains("--platform-apps", stderr, StringComparison.Ordinal);
+        Assert.Contains("--test-apps", stderr, StringComparison.Ordinal);
+        Assert.Contains("--service-tier", stderr, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Issue #2560, defect 2: `provision --resolve-version PREFIX --test-apps` used to print
+    /// the resolved version and return 0 UNCONDITIONALLY, before ever reaching the named
+    /// sub-step — silently discarding the --test-apps half of the command with no
+    /// indication anything was skipped ("either honor the combination or reject it with
+    /// exit 2... silently dropping it is the one option that should be off the table" per
+    /// the issue). This proves the combination is now HONORED: the resolved version is
+    /// printed to stdout (unchanged, still needed for script/agent consumption) AND the
+    /// named sub-step actually runs, landing real content — not merely "exit 0".
+    /// --test-apps chosen over --platform-apps/--service-tier for the same ~20MB-vs-100+MB
+    /// reason the rest of this file already prefers it (see file header).
+    /// </summary>
+    [Fact]
+    public void ResolveVersion_CombinedWithTestApps_PrintsVersionAndDownloads()
+    {
+        var home = NewIsolatedHome();
+        try
+        {
+            var (exit, stderr) = Run(home, "provision", "--resolve-version", "28.1", "--test-apps");
+
+            Assert.True(exit == 0, $"must exit 0 once both the resolve and the download succeed. stderr:\n{stderr}");
+            // The resolved version is whatever's currently latest under the 28.1 prefix —
+            // find the actual directory the download landed in rather than hardcoding one.
+            var artifactsRoot = TestArtifacts.StandardCacheDir(home);
+            Assert.True(Directory.Exists(artifactsRoot), $"expected {artifactsRoot} to exist. stderr:\n{stderr}");
+            var versionDirs = Directory.GetDirectories(artifactsRoot);
+            Assert.Single(versionDirs);
+            var landedTestAppsDir = Path.Combine(versionDirs[0], "test-apps");
+            Assert.True(Directory.Exists(landedTestAppsDir),
+                $"expected a test-apps dir under the resolved version {versionDirs[0]}. stderr:\n{stderr}");
+            var apps = Directory.GetFiles(landedTestAppsDir, "*.app");
+            Assert.True(apps.Length > 10,
+                $"expected more than 10 .app files (a real download, not an empty dir), got {apps.Length}. stderr:\n{stderr}");
+        }
+        finally
+        {
+            try { Directory.Delete(home, recursive: true); } catch { }
+        }
+    }
 }

--- a/AlRunner/Infrastructure/InProcessAppPackager.cs
+++ b/AlRunner/Infrastructure/InProcessAppPackager.cs
@@ -81,12 +81,26 @@ public static class InProcessAppPackager
             if (root.TryGetProperty("dependencies", out var depsEl)
                 && depsEl.ValueKind == JsonValueKind.Array)
             {
+                // #2560: a dependencies[] entry with a non-string field (e.g. `"name": 123`)
+                // used to blow up the ENTIRE ReadIdentity call via an unguarded
+                // JsonElement.GetString() a few lines below (the try/catch around this
+                // whole method turns that into a caught, non-crashing "failed to read"
+                // log line -- but the returned identity is null for the WHOLE bundle, not
+                // just the malformed entry). That silently broke sibling first-party
+                // source-dependency discovery for every OTHER, perfectly valid dependency
+                // in the same manifest -- worse than Program.cs's ReadDependencies having
+                // the same bug (that one only lost the one malformed entry's own fields).
+                // TryGetDepString mirrors ReadDependencies' own fix: degrade the one bad
+                // field to null/default and keep going, rather than letting one typo take
+                // the whole manifest's identity down.
+                int depIndex = 0;
                 foreach (var d in depsEl.EnumerateArray())
                 {
-                    var dIdStr = d.TryGetProperty("id", out var di) ? di.GetString() : null;
-                    var dName = d.TryGetProperty("name", out var dn) ? dn.GetString() ?? "" : "";
-                    var dPub = d.TryGetProperty("publisher", out var dp) ? dp.GetString() ?? "" : "";
-                    var dVerStr = d.TryGetProperty("version", out var dv) ? dv.GetString() ?? "0.0.0.0" : "0.0.0.0";
+                    var dIdStr = TryGetDepString(d, "id", appJsonPath, depIndex);
+                    var dName = TryGetDepString(d, "name", appJsonPath, depIndex) ?? "";
+                    var dPub = TryGetDepString(d, "publisher", appJsonPath, depIndex) ?? "";
+                    var dVerStr = TryGetDepString(d, "version", appJsonPath, depIndex) ?? "0.0.0.0";
+                    depIndex++;
                     Guid dId = Guid.Empty;
                     if (!string.IsNullOrEmpty(dIdStr)) Guid.TryParse(dIdStr, out dId);
                     if (!Version.TryParse(dVerStr, out var dVer)) dVer = new Version(0, 0, 0, 0);
@@ -113,6 +127,19 @@ public static class InProcessAppPackager
             Console.Error.WriteLine($"[layered] InProcessAppPackager: failed to read {appJsonPath}: {ex.Message}");
             return null;
         }
+    }
+
+    // #2560: mirrors Program.cs's own TryGetDepString — reads one dependencies[] entry's
+    // string-typed property, tolerating a non-string value instead of letting
+    // JsonElement.GetString() throw and take the WHOLE ReadIdentity call down with it.
+    private static string? TryGetDepString(JsonElement dep, string propertyName, string appJsonPath, int depIndex)
+    {
+        if (!dep.TryGetProperty(propertyName, out var v)) return null;
+        if (v.ValueKind == JsonValueKind.String) return v.GetString();
+        Console.Error.WriteLine(
+            $"[layered] warning: '{appJsonPath}' dependencies[{depIndex}].{propertyName} is not a " +
+            $"string (found {v.ValueKind}) — ignoring that field for this dependency entry.");
+        return null;
     }
 
     /// <summary>

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -526,6 +526,19 @@ if (!provisionSubcommand && provisionForce)
     Console.Error.WriteLine("--force is only valid with `provision --platform-apps` / `--test-apps` / `--service-tier`.");
     return 2;
 }
+// #2560: `provision --force` alone (subcommand present, --force present, but none of
+// --platform-apps/--test-apps/--service-tier) matched neither guard above -- it fell
+// through into the ordinary auto-detect run path with --force silently discarded and no
+// message. Same failure mode as the two guards above, just the missing THIRD combination:
+// deliberately excludes --resolve-version (that flag never reaches a download step at
+// all -- see RunExplicitProvisionModes -- so pairing it with --force is equally
+// meaningless, but is its own, differently-worded misuse if ever rejected).
+if (provisionSubcommand && provisionForce
+    && !(provisionPlatformApps || provisionTestApps || provisionServiceTier))
+{
+    Console.Error.WriteLine("--force is only valid with `provision --platform-apps` / `--test-apps` / `--service-tier`.");
+    return 2;
+}
 // `al-runner provision --help`: subcommands must accept --help like everything else —
 // previously this fell through to the generic arg-parser and answered "Unknown option
 // '--help'. Run with --help for the supported flags.", which tells the caller to run the
@@ -8108,6 +8121,7 @@ static int RunExplicitProvisionModes(string? bcVersionArg, List<string> bundles,
     // failed or errored" — would be a lie about what happened here; 2 is what every other
     // "couldn't get to a run at all" path in this file already uses (e.g. "BC version
     // selection failed: ..." further up).
+    string? full;
     if (resolveVersionPrefix != null)
     {
         var resolved = AlRunner.Provisioning.ArtifactDownloader.ResolveVersion(
@@ -8118,12 +8132,22 @@ static int RunExplicitProvisionModes(string? bcVersionArg, List<string> bundles,
             return 2;
         }
         Console.WriteLine(resolved); // stdout for script/agent consumption, mirrors tools/DownloadArtifacts
-        return 0;
+        // #2560: used to return 0 here unconditionally, even when the caller ALSO passed
+        // --platform-apps/--test-apps/--service-tier -- `provision --resolve-version 28.1
+        // --platform-apps` printed a version and downloaded nothing, silently discarding
+        // half the command with no indication anything was skipped. Honor the combination
+        // instead of discarding it: a resolved version stands in for --bc-version and the
+        // named sub-steps still run against it.
+        if (!platformApps && !testApps && !serviceTier)
+            return 0;
+        full = resolved;
     }
-
-    var full = ResolveFullVersionForExplicitProvision(bcVersionArg, bundles);
-    if (full == null)
-        return 2; // the resolver already printed a loud, named reason
+    else
+    {
+        full = ResolveFullVersionForExplicitProvision(bcVersionArg, bundles);
+        if (full == null)
+            return 2; // the resolver already printed a loud, named reason
+    }
 
     bool anyFailed = false;
     if (serviceTier)
@@ -8606,12 +8630,25 @@ static IEnumerable<DependencyRef> ReadDependencies(string appJsonPath)
     if (root.TryGetProperty("dependencies", out var deps)
         && deps.ValueKind == System.Text.Json.JsonValueKind.Array)
     {
+        int depIndex = 0;
         foreach (var d in deps.EnumerateArray())
         {
-            var idStr = d.TryGetProperty("id", out var pid) ? pid.GetString() : null;
-            var name = d.TryGetProperty("name", out var pn) ? pn.GetString() ?? "" : "";
-            var pub = d.TryGetProperty("publisher", out var pp) ? pp.GetString() ?? "" : "";
-            var ver = d.TryGetProperty("version", out var pv) ? pv.GetString() ?? "0.0.0.0" : "0.0.0.0";
+            // #2560: a `dependencies` entry with a non-string field (e.g. `"name": 123`,
+            // a plain typo a hand-edited app.json can carry) used to call .GetString()
+            // unguarded, raising InvalidOperationException out of the resolution path —
+            // TryReadManifestDependencyRoots's pre-scan catches that (its own catch-all
+            // around a DIFFERENT reader call), but ReadDependencies itself is also called
+            // directly (ScanManifestDependencyRoots, the per-suite dep-resolve path), with
+            // no such wrapper, so the exception was unhandled there. TryGetDepString names
+            // the file, the entry's position, and the property instead of either crashing
+            // OR silently `continue`-ing past the whole entry (which would just as
+            // silently drop a real dependency edge) — one malformed field degrades to its
+            // own default, the rest of the entry is still read and yielded normally.
+            var idStr = TryGetDepString(d, "id", appJsonPath, depIndex);
+            var name = TryGetDepString(d, "name", appJsonPath, depIndex) ?? "";
+            var pub = TryGetDepString(d, "publisher", appJsonPath, depIndex) ?? "";
+            var ver = TryGetDepString(d, "version", appJsonPath, depIndex) ?? "0.0.0.0";
+            depIndex++;
             Guid id = Guid.Empty;
             if (!string.IsNullOrEmpty(idStr)) Guid.TryParse(idStr, out id);
             if (!Version.TryParse(ver, out var v)) v = new Version(0, 0, 0, 0);
@@ -8624,7 +8661,18 @@ static IEnumerable<DependencyRef> ReadDependencies(string appJsonPath)
             // findable .app (e.g. on CI, where packageCacheDirs is empty) instead of failing
             // the whole bundle — matching how the implicit roots below are already Optional.
             bool isMsPlatform = AlRunner.DependencyResolver.IsMicrosoftPlatformApp(name, pub);
-            yield return new DependencyRef(id, name, pub, v, Optional: isMsPlatform);
+            // #2560: an entry whose id AND name both degraded to nothing (malformed fields
+            // — see TryGetDepString above) names no findable package at all; the loud
+            // warning already printed for the field is the whole diagnostic value this
+            // entry can offer. Requiring resolution to find "a package named ''" turns one
+            // malformed field into a hard failure for the WHOLE bundle over information we
+            // already know is unusable, which is worse than the drop the issue itself says
+            // to avoid — it still fails LOUDLY (the resolver's normal missing-dependency
+            // message, just naming nothing useful) rather than either silently vanishing or
+            // silently succeeding, but a genuinely unresolvable phantom entry blocking every
+            // OTHER valid dependency in the same manifest is not a fix worth shipping.
+            bool isUnresolvable = id == Guid.Empty && string.IsNullOrEmpty(name);
+            yield return new DependencyRef(id, name, pub, v, Optional: isMsPlatform || isUnresolvable);
         }
     }
 
@@ -8648,6 +8696,21 @@ static IEnumerable<DependencyRef> ReadDependencies(string appJsonPath)
     }
 }
 
+// #2560: reads one `dependencies[]` entry's string-typed property, tolerating a
+// non-string value (e.g. a numeric `"name": 123` in a hand-edited/malformed app.json)
+// instead of letting JsonElement.GetString() throw InvalidOperationException. Prints a
+// diagnostic naming the manifest file, the entry's zero-based position, and the property
+// so a malformed manifest is visible rather than either crashing the whole resolution
+// path or silently dropping the entry — see ReadDependencies' own call site comment.
+static string? TryGetDepString(System.Text.Json.JsonElement dep, string propertyName, string appJsonPath, int depIndex)
+{
+    if (!dep.TryGetProperty(propertyName, out var v)) return null;
+    if (v.ValueKind == System.Text.Json.JsonValueKind.String) return v.GetString();
+    Console.Error.WriteLine(
+        $"[provision] warning: '{appJsonPath}' dependencies[{depIndex}].{propertyName} is not a " +
+        $"string (found {v.ValueKind}) — ignoring that field for this dependency entry.");
+    return null;
+}
 
 // Collect this single suite's src/test/app* dirs for emit. Per-suite isolation
 // avoids the cross-suite object-id collisions that silently zeroed-out bundled emit.


### PR DESCRIPTION
Closes #2560

## Problem

Three small `provision` CLI defects, all the same shape: an argument combination is
accepted and then silently does less than it says.

1. `provision --force` alone (subcommand present, `--force` present, but none of
   `--platform-apps`/`--test-apps`/`--service-tier`) matched neither existing rejection
   guard and fell through into the ordinary auto-detect run path with `--force` silently
   discarded.
2. `provision --resolve-version PREFIX` combined with a sub-step printed the resolved
   version and returned 0 unconditionally, before ever reaching the named sub-step —
   silently discarding half the command.
3. `ReadDependencies` called `JsonElement.GetString()` unguarded on each `dependencies[]`
   entry's fields, so a hand-edited `app.json` with a non-string field (e.g. `"name": 123`)
   raised `InvalidOperationException` out of the resolution path.

## Fix

1. Rejected with exit 2, naming the flags `--force` needs to accompany — the same message
   the two existing guards already use.
2. The combination is now honored: the resolved version stands in for `--bc-version` and
   the named sub-steps still run against it. `--help` already documented this as the
   intended behavior ("`--platform-apps`/`--test-apps`/`--service-tier`/`--resolve-version`
   may be combined in one invocation... `--force` applies to all of them") — the code just
   didn't do it.
3. `TryGetDepString` now names the file, the entry's position, and the property, and
   degrades the one bad field to a default instead of either crashing or silently dropping
   the whole entry. An entry left with no usable id or name (everything about it was
   malformed) is marked `Optional` — searching for "a package named ''" would otherwise turn
   one typo into a hard failure for the whole bundle, which is a worse outcome than the drop
   the issue itself says to avoid.

## Fix the shape, not just the reported line

**Does the same wrong pattern appear at another call site?** Yes, and it was worse than the
reported one. `InProcessAppPackager.ReadIdentity` reads the identical `dependencies[]` shape
with the identical unguarded `GetString()` calls. Its surrounding `try`/`catch` means it
doesn't crash the process, but the caught failure returns a `null` `BundleIdentity` for the
**whole manifest** — silently breaking sibling first-party source-dependency discovery for
every OTHER, perfectly valid dependency in the same bundle. I verified this directly: a
bundle with one real, resolvable sibling dependency and one malformed entry failed to find
the real dependency (`A required dependency package is missing`) until this reader got the
same guard. Fixed identically, in `AlRunner/Infrastructure/InProcessAppPackager.cs`.

**Sibling function, same assumption?** `InProcessAppPackager.ReadIdentity` also reads its
OWN top-level `id`/`name`/`publisher`/`version`/`runtime` fields unguarded (lines above the
`dependencies[]` loop). Left alone: the surrounding `catch` already prevents a crash there
(returns `null` identity for that one bundle, doesn't cascade to siblings the way the
dependency-array bug did), and the issue's own scope is specifically "a non-string
*dependency* field", not the manifest's own top-level fields.

**Same-state invariant?** Both readers now use the identical `TryGetDepString` shape
(same diagnostic wording, same degrade-one-field behavior) for the identical JSON shape —
there's no way for them to drift into disagreeing about what a malformed `dependencies[]`
entry means.

## Tests

Runner-only claims (CLI dispatch, provisioning-manifest resolution) — `AlRunner.Tests/`, not
the AL corpus, per `bc-behavior-tests-go-upstream.md`.

- `AlRunner.Tests/ProvisionExplicitModesTests.cs` — two new facts, following this file's
  existing conventions (real subprocess, real isolated `$HOME`):
  - `Force_AloneWithNoModeFlag_IsRejected` — no network/BC artifacts needed (rejected before
    either is touched): exit 2, message names all three valid flags.
  - `ResolveVersion_CombinedWithTestApps_PrintsVersionAndDownloads` — real CDN download
    (`--test-apps`, ~20MB, matching this file's existing size-conscious convention over
    `--platform-apps`'s ~100+MB): the resolved version prints to stdout AND the real test
    toolkit lands under that resolved version's canonical directory.
- `AlRunner.Tests/DependencyManifestNonStringFieldTests.cs` — spawns the real runner: a
  bundle with one real, resolvable sibling source dependency plus one malformed
  `dependencies[]` entry (numeric `id` and `name`) proves no unhandled exception (no
  "Unhandled exception" marker), a diagnostic naming the file, entry index, and property, and
  — the assertion that caught the `InProcessAppPackager` finding above — that the real
  sibling dependency still resolves and the test still passes (`1P/0F/0E`), not just "didn't
  crash".

RED confirmed for all three defects together using the documented revert-then-restore
recipe (copy the fixed files out, `git checkout HEAD -- <path>`, confirm failure, restore
from the copies) rather than `git stash`.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf