### PR TITLE
perf(compiler): route source-dependency symbol synthesis through the RAD incremental path

### DIFF
--- a/AlRunner.Tests/BcCompilerEmitDepSymbolsIncrementalTests.cs
+++ b/AlRunner.Tests/BcCompilerEmitDepSymbolsIncrementalTests.cs
@@ -1,0 +1,250 @@
+// BcCompilerEmitDepSymbolsIncrementalTests — RED/GREEN proof for issue #2669.
+//
+// #2669: `RunLayeredPrePass`/`BuildSiblingSourceDeps` synthesize a source dependency's
+// compile-time symbols (`*.symbols.json`) via `BcCompiler.EmitDepSymbols`, BC's whole-module
+// `Compilation.Create` entry point — never `TryEmitIncremental`/`Compilation.CreateForRad`, the
+// fast path `--watch`/`--server`'s own per-bundle compile already uses for exactly this class of
+// problem. Every re-synthesis of a dependency's symbols therefore cost the same whole-module
+// compile as the FIRST, however small the edit — measured 22.25s on Pageworks for one added
+// no-op procedure.
+//
+// `BcCompiler.EmitDepSymbolsIncremental` is the fix: try `TryEmitIncremental` against THIS
+// instance's own RAD baseline first (recorded by the previous call, via `EmitDepSymbols`'s new
+// `trackIncrementalBaseline` parameter), and only fall back to the full compile when
+// `TryEmitIncremental` cannot prove the fast path safe — including #2548's guard against an added
+// overload silently moving which member id an untouched sibling resolves to, which matters here
+// exactly as much as it does for the main per-bundle loop (see #2603's cross-app extension of that
+// hazard).
+//
+// What each test proves (tdd.md: must prove, not just pass):
+//   - The FIRST call on a fresh instance always falls back (no baseline yet) — proving the
+//     mechanism cannot silently claim a speedup it did not earn.
+//   - The SECOND call on the SAME instance, after a genuine content edit that adds a brand new
+//     procedure, takes the fast path AND writes symbols that actually contain the new procedure —
+//     not a stale replay of the pre-edit shape. Proven by feeding the SAME symbols.json to a real
+//     downstream compile that calls the new procedure: a stale symbol table would fail that
+//     compile with AL0132/AL0185, not just "look different" in a text diff.
+//   - An edit that ADDS AN OVERLOAD of an existing procedure name — the #2548/#2603 hazard this
+//     mechanism inherits by construction from TryEmitIncremental — still falls back to a full
+//     compile, with a fallback reason naming the hazard. A version of this method that always took
+//     the fast path would satisfy every other assertion here and still be wrong; this is the test
+//     that catches it.
+using System.Text.Json;
+using Xunit;
+using AlRunner;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class BcCompilerEmitDepSymbolsIncrementalTests : IDisposable
+{
+    private readonly string _root;
+    private readonly BcEngineFixture _engine;
+
+    public BcCompilerEmitDepSymbolsIncrementalTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-depsym-incr-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private void WriteAl(string fileName, string content) => File.WriteAllText(Path.Combine(_root, fileName), content);
+
+    private static readonly Guid AppId = new("b2c3d4e5-9001-4a11-9111-111111111111");
+
+    private const string DepBefore = """
+        codeunit 90340 "DepSym Incr Lib"
+        {
+            procedure Ping(): Integer
+            begin
+                exit(1);
+            end;
+        }
+        """;
+
+    /// <summary>Content edit to the SAME file: a brand new procedure added, nothing renamed or
+    /// removed — the ordinary shape TryEmitIncremental's ordinary content-edit path covers.</summary>
+    private const string DepWithNewProcedure = """
+        codeunit 90340 "DepSym Incr Lib"
+        {
+            procedure Ping(): Integer
+            begin
+                exit(1);
+            end;
+
+            procedure Pong(): Integer
+            begin
+                exit(42);
+            end;
+        }
+        """;
+
+    /// <summary>The #2548/#2603 hazard: a SECOND overload of `Ping`, not a new procedure name.
+    /// `MethodSymbol.CalculateMethodIdForNewVersions` is method-local, so the existing
+    /// `Ping()` keeps its member id — an untouched caller passing an argument that used to widen
+    /// to a different overload would silently rebind. See BcCompilerIncrementalOverloadRebindTests
+    /// for the full mechanism; this test only needs that TryEmitIncremental's existing guard is
+    /// still reached through EmitDepSymbolsIncremental, not that it fires correctly in general.</summary>
+    private const string DepWithOverload = """
+        codeunit 90340 "DepSym Incr Lib"
+        {
+            procedure Ping(): Integer
+            begin
+                exit(1);
+            end;
+
+            procedure Ping(Seed: Integer): Integer
+            begin
+                exit(Seed);
+            end;
+        }
+        """;
+
+    [SkippableFact]
+    public void EmitDepSymbolsIncremental_FirstCall_AlwaysFallsBack_NoBaselineYet()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+        // #2669: TryEmitIncremental reads the current app identity from static state
+        // (BcCompiler.SetCurrentAppIdentity/ScopeCurrentAppIdentity), never from the explicit
+        // appId/publisher/version arguments passed to EmitDepSymbolsIncremental itself (those only
+        // feed the FALLBACK EmitDepSymbols compile) — exactly mirroring how RunLayeredPrePass and
+        // BuildSiblingSourceDeps already scope every real call. Omitting this scope here would
+        // compare the baseline recorded under one identity against a DIFFERENT default identity on
+        // the second call, forcing a spurious fallback that has nothing to do with what this test
+        // is proving.
+        using var identityScope = BcCompiler.ScopeCurrentAppIdentity(AppId, "AL Runner", new Version(1, 0, 0, 0));
+
+
+        WriteAl("Lib.al", DepBefore);
+        var symbolsPath = Path.Combine(_root, "out.symbols.json");
+        var compiler = new BcCompiler();
+
+        compiler.EmitDepSymbolsIncremental(
+            new[] { _root }, "DepSymIncrModule", AppId, "AL Runner", new Version(1, 0, 0, 0),
+            symbolsPath, appRootDir: null, out var tookFastPath, out var fallbackReason);
+
+        Assert.False(tookFastPath, "the first call on a fresh instance has no baseline to diff against and must fall back");
+        Assert.Contains("no incremental baseline yet", fallbackReason, StringComparison.OrdinalIgnoreCase);
+        Assert.True(File.Exists(symbolsPath));
+        Assert.Contains("Ping", File.ReadAllText(symbolsPath), StringComparison.Ordinal);
+    }
+
+    [SkippableFact]
+    public void EmitDepSymbolsIncremental_ContentEditAddingAProcedure_TakesFastPath_AndMatchesAFreshFullCompile()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+        // #2669: TryEmitIncremental reads the current app identity from static state
+        // (BcCompiler.SetCurrentAppIdentity/ScopeCurrentAppIdentity), never from the explicit
+        // appId/publisher/version arguments passed to EmitDepSymbolsIncremental itself (those only
+        // feed the FALLBACK EmitDepSymbols compile) — exactly mirroring how RunLayeredPrePass and
+        // BuildSiblingSourceDeps already scope every real call. Omitting this scope here would
+        // compare the baseline recorded under one identity against a DIFFERENT default identity on
+        // the second call, forcing a spurious fallback that has nothing to do with what this test
+        // is proving.
+        using var identityScope = BcCompiler.ScopeCurrentAppIdentity(AppId, "AL Runner", new Version(1, 0, 0, 0));
+
+
+        WriteAl("Lib.al", DepBefore);
+        var symbolsPath = Path.Combine(_root, "out.symbols.json");
+        var compiler = new BcCompiler();
+
+        compiler.EmitDepSymbolsIncremental(
+            new[] { _root }, "DepSymIncrModule2", AppId, "AL Runner", new Version(1, 0, 0, 0),
+            symbolsPath, appRootDir: null, out var firstFast, out _);
+        Assert.False(firstFast);
+
+        // Genuine content edit: same file, same object, one new procedure added.
+        WriteAl("Lib.al", DepWithNewProcedure);
+
+        compiler.EmitDepSymbolsIncremental(
+            new[] { _root }, "DepSymIncrModule2", AppId, "AL Runner", new Version(1, 0, 0, 0),
+            symbolsPath, appRootDir: null, out var secondFast, out var secondReason);
+
+        Assert.True(secondFast, $"expected the RAD fast path on the second call; fell back instead: {secondReason}");
+        Assert.True(File.Exists(symbolsPath));
+
+        var fastProcedureNames = ProcedureNamesOf(symbolsPath, "DepSym Incr Lib");
+        Assert.Equal(new[] { "Ping", "Pong" }, fastProcedureNames.OrderBy(n => n, StringComparer.Ordinal));
+
+        // Correct, not just "changed": an INDEPENDENT fresh instance's full compile of the SAME
+        // post-edit source (never touched by the incremental machinery at all) must describe the
+        // identical procedure set. A fast path that shipped a stale or partially-merged module
+        // definition would still satisfy the assertion above (Pong is present) while disagreeing
+        // with this one if it ALSO dropped or duplicated something else in the merge.
+        var freshSymbolsPath = Path.Combine(_root, "fresh.symbols.json");
+        new BcCompiler().EmitDepSymbols(
+            new[] { _root }, "DepSymIncrModule2Fresh", AppId, "AL Runner", new Version(1, 0, 0, 0),
+            freshSymbolsPath, appRootDir: null);
+        var freshProcedureNames = ProcedureNamesOf(freshSymbolsPath, "DepSym Incr Lib");
+        Assert.Equal(freshProcedureNames.OrderBy(n => n, StringComparer.Ordinal), fastProcedureNames.OrderBy(n => n, StringComparer.Ordinal));
+    }
+
+    /// <summary>Procedure names of the named codeunit in a written <c>*.symbols.json</c>, read
+    /// structurally (not a raw text search) so a false positive from an unrelated string match
+    /// cannot pass this test.</summary>
+    private static List<string> ProcedureNamesOf(string symbolsJsonPath, string codeunitName)
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(symbolsJsonPath));
+        var root = doc.RootElement;
+        if (!root.TryGetProperty("Codeunits", out var codeunits))
+            throw new InvalidOperationException($"'{symbolsJsonPath}' has no top-level Codeunits array.");
+        foreach (var cu in codeunits.EnumerateArray())
+        {
+            if (!cu.TryGetProperty("Name", out var nameEl) || nameEl.GetString() != codeunitName) continue;
+            if (!cu.TryGetProperty("Methods", out var methods))
+                return new List<string>();
+            return methods.EnumerateArray()
+                .Select(m => m.TryGetProperty("Name", out var mn) ? mn.GetString() ?? "" : "")
+                .Where(n => n.Length > 0)
+                .ToList();
+        }
+        throw new InvalidOperationException($"'{symbolsJsonPath}' has no codeunit named '{codeunitName}'.");
+    }
+
+    [SkippableFact]
+    public void EmitDepSymbolsIncremental_AddingAnOverload_FallsBackInsteadOfShippingStaleSymbols()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+        // #2669: TryEmitIncremental reads the current app identity from static state
+        // (BcCompiler.SetCurrentAppIdentity/ScopeCurrentAppIdentity), never from the explicit
+        // appId/publisher/version arguments passed to EmitDepSymbolsIncremental itself (those only
+        // feed the FALLBACK EmitDepSymbols compile) — exactly mirroring how RunLayeredPrePass and
+        // BuildSiblingSourceDeps already scope every real call. Omitting this scope here would
+        // compare the baseline recorded under one identity against a DIFFERENT default identity on
+        // the second call, forcing a spurious fallback that has nothing to do with what this test
+        // is proving.
+        using var identityScope = BcCompiler.ScopeCurrentAppIdentity(AppId, "AL Runner", new Version(1, 0, 0, 0));
+
+
+        WriteAl("Lib.al", DepBefore);
+        var symbolsPath = Path.Combine(_root, "out.symbols.json");
+        var compiler = new BcCompiler();
+
+        compiler.EmitDepSymbolsIncremental(
+            new[] { _root }, "DepSymIncrModule3", AppId, "AL Runner", new Version(1, 0, 0, 0),
+            symbolsPath, appRootDir: null, out var firstFast, out _);
+        Assert.False(firstFast);
+
+        WriteAl("Lib.al", DepWithOverload);
+
+        compiler.EmitDepSymbolsIncremental(
+            new[] { _root }, "DepSymIncrModule3", AppId, "AL Runner", new Version(1, 0, 0, 0),
+            symbolsPath, appRootDir: null, out var secondFast, out var secondReason);
+
+        Assert.False(secondFast,
+            "an added overload must fall back to a full compile (#2548's guard) — taking the fast " +
+            "path here risks shipping symbols an unmodified caller elsewhere would silently misbind " +
+            "against, exactly the #2603 hazard this mechanism must not reintroduce");
+        Assert.Contains("overload", secondReason, StringComparison.OrdinalIgnoreCase);
+
+        // Still correct, just via the (slower) full-compile fallback: the new overload is present.
+        var json = File.ReadAllText(symbolsPath);
+        using var doc = JsonDocument.Parse(json);
+        Assert.Contains("Ping", json, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner.Tests/LayeredDepSymbolsIncrementalServerTests.cs
+++ b/AlRunner.Tests/LayeredDepSymbolsIncrementalServerTests.cs
@@ -1,0 +1,270 @@
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// End-to-end proof for issue #2669, through the REAL <c>RunLayeredPrePass</c> pipeline under
+/// <c>--server</c> — not just the underlying <c>BcCompiler.EmitDepSymbolsIncremental</c> mechanism
+/// (see <c>BcCompilerEmitDepSymbolsIncrementalTests</c> for that layer).
+///
+/// Setup: a dependency app ("Layered RAD Lib") + a separate test app ("Layered RAD Tests") that
+/// declares a dependency on it and calls into it — the standard AL-Go app + test-app shape #2669
+/// describes, and the exact shape <c>RunLayeredPrePass</c> engages for (the test app becomes an
+/// "impl" target the pre-pass must synthesize symbols for).
+///
+/// <see cref="EditingOneCodeunitInTheDependency_TakesTheRadFastPath_AndTheDependentCompilesAgainstTheNewProcedure"/>
+/// edits ONLY the dependency between two warm requests and asserts the pre-pass reports
+/// "RAD incremental (fast path)" on the SECOND request (not just "faster" — the actual mechanism
+/// engaging), and that the dependent app's test, which calls the NEWLY ADDED procedure, passes —
+/// proof the fast-path symbols are not a stale replay, because a stale/incomplete symbol table
+/// would fail that compile outright (AL0132/AL0185), not silently disagree.
+///
+/// <see cref="AddingAnOverloadInTheDependency_StillFallsBackToAFullCompile"/> is this class's
+/// negative control and the one #2669's own "Contention" section calls out by name: an edit that
+/// ADDS AN OVERLOAD must still force a full compile even through the new fast path, because
+/// TryEmitIncremental's own #2548 guard is what stops this mechanism from reintroducing the
+/// #2603 cross-app silent-rebind hazard. <see cref="ServerCrossAppOverloadRebindTests"/> is the
+/// existing #2603 regression test for the CONSUMING bundle's own fallback gating (untouched by
+/// this change); this test is the complementary check that the DEPENDENCY's own re-synthesis
+/// still refuses to ship stale symbols for the identical edit shape.
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
+/// </summary>
+public class LayeredDepSymbolsIncrementalServerTests : IClassFixture<SharedCliServer>
+{
+    private readonly SharedCliServer _shared;
+
+    private static readonly string CacheDir = Path.Combine(
+        Path.GetTempPath(), "al-runner-layered-rad", Guid.NewGuid().ToString("N"), "al-out");
+
+    /// <summary>Same synchronisation anchor <see cref="LayeredCacheTests"/> uses — emitted by the
+    /// pre-pass AFTER every per-impl line, so it is sound to slice on for both a positive
+    /// ("RAD incremental" is present) and a negative ("full compile" is NOT present) assertion.</summary>
+    private const string PrePassTrailer = "[layered] pre-built";
+
+    public LayeredDepSymbolsIncrementalServerTests(SharedCliServer shared) => _shared = shared;
+
+    private const string LibAppId = "d3e4f5a6-7001-4a11-9111-111111111111";
+    private const string TestAppId = "d3e4f5a6-7002-4a11-9222-222222222222";
+
+    private static string LibBefore(int libId) => $$"""
+        codeunit {{libId}} "Layered RAD Lib"
+        {
+            procedure Ping(): Integer
+            begin
+                exit(1);
+            end;
+        }
+        """;
+
+    /// <summary>Content edit to the SAME file/object: one brand new procedure added.</summary>
+    private static string LibWithNewProcedure(int libId) => $$"""
+        codeunit {{libId}} "Layered RAD Lib"
+        {
+            procedure Ping(): Integer
+            begin
+                exit(1);
+            end;
+
+            procedure Pong(): Integer
+            begin
+                exit(41);
+            end;
+        }
+        """;
+
+    /// <summary>The #2548/#2603 hazard shape: a SECOND overload of `Ping`, not a new name.</summary>
+    private static string LibWithOverload(int libId) => $$"""
+        codeunit {{libId}} "Layered RAD Lib"
+        {
+            procedure Ping(): Integer
+            begin
+                exit(1);
+            end;
+
+            procedure Ping(Seed: Integer): Integer
+            begin
+                exit(Seed);
+            end;
+        }
+        """;
+
+    private static string MakeLibBundle(string root, int libId, string lib)
+    {
+        var dir = Path.Combine(root, "lib");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{LibAppId}}",
+          "name": "Layered RAD Lib",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": {{libId}}, "to": {{libId + 9}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Lib.al"), lib);
+        return dir;
+    }
+
+    private static string MakeTestBundle(string root, int libId, int testId, string testCodeunit)
+    {
+        var dir = Path.Combine(root, "test-app");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{TestAppId}}",
+          "name": "Layered RAD Tests",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{LibAppId}}", "name": "Layered RAD Lib",
+              "publisher": "AL Runner", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": {{testId}}, "to": {{testId + 9}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Tests.al"), testCodeunit);
+        return dir;
+    }
+
+    private static string Req(params string[] bundles)
+        => JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            sourcePaths = bundles,
+            packagePaths = Array.Empty<string>(),
+        });
+
+    [SkippableFact]
+    public async Task EditingOneCodeunitInTheDependency_TakesTheRadFastPath_AndTheDependentCompilesAgainstTheNewProcedure()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var server = await _shared.GetAsync(new[] { "--cache", CacheDir });
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-layered-rad", Guid.NewGuid().ToString("N"));
+        const int libId = 60560;
+        const int testId = 60570;
+        var libDir = MakeLibBundle(root, libId, LibBefore(libId));
+
+        // Request 1's test app calls only Ping — Pong does not exist in the dependency yet.
+        var testDirBefore = MakeTestBundle(root, libId, testId, $$"""
+            codeunit {{testId}} "Layered RAD Tests Cu"
+            {
+                Subtype = Test;
+                [Test]
+                procedure PingOnly()
+                var
+                    Lib: Codeunit "Layered RAD Lib";
+                begin
+                    if Lib.Ping() <> 1 then
+                        Error('WRONG');
+                end;
+            }
+            """);
+
+        var mark1 = server.StdErrMark;
+        var lines1 = await server.SendRequestStreamingAsync(Req(libDir, testDirBefore), TimeSpan.FromSeconds(300));
+        var (_, summary1) = ProtocolV2Streaming.Split(lines1);
+        Assert.Equal(0, summary1.GetProperty("exitCode").GetInt32());
+        var out1 = await server.StdErrSinceAsync(mark1, PrePassTrailer);
+        // First synthesis of this dependency in this warm process: no baseline yet, so the
+        // pre-pass must report a full compile — the SAME message a developer sees today.
+        Assert.Contains("[layered] Layered RAD Lib 1.0.0.0: full compile (", out1);
+        Assert.DoesNotContain("[layered] Layered RAD Lib 1.0.0.0: RAD incremental", out1);
+
+        // Edit ONLY the dependency: same file, same object, a genuinely new procedure. The test
+        // app's OWN source also changes here (to call the new procedure) — that is deliberate:
+        // this test is about whether the DEPENDENCY's fast-path symbols are correct enough for a
+        // REAL downstream compile to bind against, not about the separate #2603 "consumer's own
+        // files are untouched" hazard (covered by AddingAnOverloadInTheDependency_... below and by
+        // ServerCrossAppOverloadRebindTests).
+        await File.WriteAllTextAsync(Path.Combine(libDir, "Lib.al"), LibWithNewProcedure(libId));
+        var testDirAfter = MakeTestBundle(root, libId, testId, $$"""
+            codeunit {{testId}} "Layered RAD Tests Cu"
+            {
+                Subtype = Test;
+                [Test]
+                procedure PingAndPong()
+                var
+                    Lib: Codeunit "Layered RAD Lib";
+                begin
+                    if Lib.Ping() + Lib.Pong() <> 42 then
+                        Error('WRONG-SUM=' + Format(Lib.Ping() + Lib.Pong()));
+                end;
+            }
+            """);
+
+        var mark2 = server.StdErrMark;
+        var lines2 = await server.SendRequestStreamingAsync(Req(libDir, testDirAfter), TimeSpan.FromSeconds(300));
+        var (events2, summary2) = ProtocolV2Streaming.Split(lines2);
+        var out2 = await server.StdErrSinceAsync(mark2, PrePassTrailer);
+
+        // The RED->GREEN proof: the second synthesis of the SAME dependency in this warm process
+        // takes the RAD fast path, not a repeat full compile.
+        Assert.Contains("[layered] Layered RAD Lib 1.0.0.0: RAD incremental (fast path)", out2);
+        Assert.DoesNotContain("[layered] Layered RAD Lib 1.0.0.0: full compile (", out2);
+
+        // Correctness, not just "took the fast path": the dependent app's test — which only
+        // compiles and passes if the fast-path symbols genuinely describe Pong — must succeed
+        // with the CORRECT summed value. A stale/incomplete symbol table fails AL0132/AL0185 at
+        // compile time (exitCode != 0) or, if it somehow compiled, would not know about Pong at
+        // all — either way this assertion catches it.
+        Assert.Equal(0, summary2.GetProperty("exitCode").GetInt32());
+        var joined2 = string.Join(" | ", lines2);
+        Assert.DoesNotContain("WRONG-SUM", joined2, StringComparison.Ordinal);
+        var status2 = events2.Count > 0 ? events2[^1].GetProperty("status").GetString() : null;
+        Assert.True(status2 == "pass", $"expected the dependent app's test to pass. Got: {joined2}");
+    }
+
+    [SkippableFact]
+    public async Task AddingAnOverloadInTheDependency_StillFallsBackToAFullCompile()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var server = await _shared.GetAsync(new[] { "--cache", CacheDir });
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-layered-rad", Guid.NewGuid().ToString("N"));
+        const int libId = 60580;
+        const int testId = 60590;
+        var libDir = MakeLibBundle(root, libId, LibBefore(libId));
+        var testDir = MakeTestBundle(root, libId, testId, $$"""
+            codeunit {{testId}} "Layered RAD Ovl Tests Cu"
+            {
+                Subtype = Test;
+                [Test]
+                procedure Trivial()
+                begin
+                end;
+            }
+            """);
+
+        var mark1 = server.StdErrMark;
+        var lines1 = await server.SendRequestStreamingAsync(Req(libDir, testDir), TimeSpan.FromSeconds(300));
+        var (_, summary1) = ProtocolV2Streaming.Split(lines1);
+        Assert.Equal(0, summary1.GetProperty("exitCode").GetInt32());
+        await server.StdErrSinceAsync(mark1, PrePassTrailer);
+
+        // Edit ONLY the dependency: an ADDED OVERLOAD, the one shape TryEmitIncremental itself
+        // refuses to fast-path (#2548) because an unmodified caller elsewhere could silently
+        // rebind to it. The test app's own source is UNCHANGED here — deliberately, so nothing
+        // about this request forces a full compile except the hazard itself.
+        await File.WriteAllTextAsync(Path.Combine(libDir, "Lib.al"), LibWithOverload(libId));
+
+        var mark2 = server.StdErrMark;
+        var lines2 = await server.SendRequestStreamingAsync(Req(libDir, testDir), TimeSpan.FromSeconds(300));
+        var (_, summary2) = ProtocolV2Streaming.Split(lines2);
+        Assert.Equal(0, summary2.GetProperty("exitCode").GetInt32());
+        var out2 = await server.StdErrSinceAsync(mark2, PrePassTrailer);
+
+        Assert.Contains("[layered] Layered RAD Lib 1.0.0.0: full compile (", out2);
+        Assert.DoesNotContain("[layered] Layered RAD Lib 1.0.0.0: RAD incremental", out2);
+        Assert.Contains("overload", out2, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -2276,10 +2276,20 @@ public sealed partial class BcCompiler
     /// <paramref name="alFolders"/> carries an app.json, and never searches parent
     /// directories — a neighbouring app's manifest is worse than none (#1948).
     /// </param>
+    /// <param name="trackIncrementalBaseline">
+    /// #2669: when true, records a RAD incremental baseline for <paramref name="moduleName"/>
+    /// on THIS instance after a successful compile — the same mechanism <see cref="Emit"/>'s
+    /// own identically-named parameter uses — so a LATER call to
+    /// <see cref="EmitDepSymbolsIncremental"/> for the same (instance, moduleName) can take
+    /// <see cref="TryEmitIncremental"/>'s fast path instead of repeating this whole-module
+    /// compile. False by default: an ordinary <see cref="EmitDepSymbols"/> call (a fresh
+    /// instance, or a caller that never revisits this dependency) has no use for a baseline
+    /// nobody will read.
+    /// </param>
     public void EmitDepSymbols(
         IEnumerable<string> alFolders, string moduleName,
         Guid appId, string publisher, Version version, string symbolsJsonPath,
-        string? appRootDir = null)
+        string? appRootDir = null, bool trackIncrementalBaseline = false)
     {
         var dirs = alFolders.Where(Directory.Exists).Distinct().ToList();
         var alFiles = dirs
@@ -2426,8 +2436,68 @@ public sealed partial class BcCompiler
         }
 
         Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(symbolsJsonPath))!);
-        using var fs = new FileStream(symbolsJsonPath, FileMode.Create, FileAccess.Write, FileShare.None);
-        SymbolJsonWriter.WriteSymbolJson(compilation, fs);
+        using (var fs = new FileStream(symbolsJsonPath, FileMode.Create, FileAccess.Write, FileShare.None))
+            SymbolJsonWriter.WriteSymbolJson(compilation, fs);
+
+        // #2669: record a RAD baseline from THIS full compile so a later call to
+        // EmitDepSymbolsIncremental on the SAME instance can take the fast path. `captured`
+        // (runtime C#) is intentionally empty — EmitDepSymbols never generates or needs
+        // runtime C# (that half of a source dependency is served by the DependencyLoader's own
+        // separate compile, see RunLayeredPrePass's Step 2 comment); only ModuleDef (the
+        // compile-time symbol picture TryEmitIncremental keeps merged every cycle) is ever read
+        // back from this baseline.
+        if (trackIncrementalBaseline)
+        {
+            RecordIncrementalBaseline(
+                moduleName, compilation, alFiles, Array.Empty<EmittedSource>(), specs,
+                manifestInputs, foundAppJson, appId, publisher, version, effectiveAppRoot,
+                new BcEmitOutput(Array.Empty<EmittedSource>(), Array.Empty<string>(), Array.Empty<string>()));
+        }
+    }
+
+    /// <summary>
+    /// Incremental-aware synthesis of a dependency's compile-time symbols (<c>*.symbols.json</c>)
+    /// — issue #2669. Tries <see cref="TryEmitIncremental"/> against THIS INSTANCE's RAD baseline
+    /// for <paramref name="moduleName"/> first: cost proportional to what changed since the LAST
+    /// call to this method on the SAME instance, not the whole dependency. Falls back to the
+    /// existing whole-module <see cref="EmitDepSymbols"/> compile for every condition
+    /// <see cref="TryEmitIncremental"/> already falls back for — no baseline yet (always true on
+    /// the first call for a given instance/moduleName pair), an app.json/dependency-set change, a
+    /// file declaring more than one object, a duplicate declaration only the compiler can
+    /// adjudicate, any diagnostic/exception the delta compile raises, or (#2548's guard) an edit
+    /// that could change which overload an UNTOUCHED sibling resolves to — and records a fresh
+    /// baseline afterward so the NEXT call on this instance can take the fast path.
+    ///
+    /// Callers that want the speedup must reuse ONE instance per dependency directory across
+    /// calls — a fresh <c>new BcCompiler()</c> every call (RunLayeredPrePass's and
+    /// BuildSiblingSourceDeps's shape before this fix) always falls back, correctly: there is no
+    /// baseline to diff against on an instance that has never compiled this module before.
+    ///
+    /// On the fast path the written module definition is the SAME merged <c>ModuleDef</c> the RAD
+    /// delta path itself just verified and recorded (via <see cref="TryEmitIncremental"/>'s own
+    /// correctness machinery) — never a naive replay of old bytes, and never stale: an edit this
+    /// path cannot prove safe falls back to a full compile instead of guessing.
+    /// </summary>
+    public void EmitDepSymbolsIncremental(
+        IEnumerable<string> alFolders, string moduleName,
+        Guid appId, string publisher, Version version, string symbolsJsonPath,
+        string? appRootDir, out bool tookFastPath, out string fallbackReason)
+    {
+        var folders = (alFolders as IReadOnlyCollection<string>) ?? alFolders.ToList();
+        var incrementalOutput = TryEmitIncremental(folders, moduleName, appRootDir, out fallbackReason, out _);
+        if (incrementalOutput != null && _radBaselines.TryGetValue(moduleName, out var baseline))
+        {
+            tookFastPath = true;
+            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(symbolsJsonPath))!);
+            using var fs = new FileStream(symbolsJsonPath, FileMode.Create, FileAccess.Write, FileShare.None);
+            NavSymRef.SymbolReferenceJsonWriter.WriteModule(fs, baseline.ModuleDef);
+            return;
+        }
+
+        tookFastPath = false;
+        EmitDepSymbols(
+            folders, moduleName, appId, publisher, version, symbolsJsonPath, appRootDir,
+            trackIncrementalBaseline: true);
     }
 
     /// <summary>

--- a/AlRunner/Infrastructure/DepSymbolCompilerCache.cs
+++ b/AlRunner/Infrastructure/DepSymbolCompilerCache.cs
@@ -1,0 +1,44 @@
+namespace AlRunner.Infrastructure;
+
+/// <summary>
+/// Issue #2669. One <see cref="BcCompiler"/> INSTANCE per source-dependency directory, kept
+/// warm across repeated dependency-symbol synthesis calls within the SAME process
+/// (<c>--watch</c>, <c>--server</c>).
+///
+/// A RAD incremental baseline (<c>BcCompiler.Incremental.cs</c>'s <c>_radBaselines</c>) lives on
+/// the compiler INSTANCE, not anywhere process-wide. Before this fix, every call site that
+/// synthesizes a dependency's <c>*.symbols.json</c> — <c>RunLayeredPrePass</c> and
+/// <c>BuildSiblingSourceDeps</c> in Program.cs — constructed a brand new <c>BcCompiler()</c> on
+/// every call, so nothing was ever warm: the SECOND-and-later re-synthesis of an unchanged (or
+/// barely-changed) dependency app paid the exact same whole-module compile as the FIRST.
+/// Measured: 22.25s to re-synthesize Pageworks's symbols after adding one no-op procedure, under
+/// <c>--server</c>, on the second of two <c>runTests</c> requests in the same warm process.
+///
+/// Keyed by the dependency's own source directory rather than by AppId/moduleName/version,
+/// because the directory is the only stable identity available BEFORE app.json is (re-)read on
+/// this call — the caller has to look the directory up to learn those. This is a looser key than
+/// "the app's true identity", but that costs nothing beyond an occasional avoidable fallback,
+/// never a wrong answer: <c>TryEmitIncremental</c>'s own <c>ManifestFingerprint</c> /
+/// <c>SharedRefsFingerprint</c> checks (see <c>BcCompiler.Incremental.cs</c>'s header) already
+/// refuse to reuse a baseline the moment the app's identity, version, resolved dependency set, or
+/// manifest-derived compiler inputs genuinely changed underneath this path — they just force a
+/// fresh full compile for that one cycle instead of silently answering wrong.
+///
+/// Deliberately never evicted, for the same reason <c>RunLayeredPrePass</c>'s own
+/// <c>workspace-deps</c> cache directory list is never pruned (see its #1821 comment): a long
+/// server session holds at most one compiler per DISTINCT dependency app actually touched in that
+/// session, each proportional to that one app's own compiled surface — not to how many times it
+/// was re-synthesized, and not to the corpus's overall size.
+/// </summary>
+internal static class DepSymbolCompilerCache
+{
+    private static readonly Dictionary<string, BcCompiler> _byDir = new(StringComparer.OrdinalIgnoreCase);
+
+    public static BcCompiler GetOrCreate(string dir)
+    {
+        var key = Path.GetFullPath(dir);
+        if (!_byDir.TryGetValue(key, out var compiler))
+            _byDir[key] = compiler = new BcCompiler();
+        return compiler;
+    }
+}

--- a/AlRunner/ProgramSupport/SiblingCompile.cs
+++ b/AlRunner/ProgramSupport/SiblingCompile.cs
@@ -297,6 +297,11 @@ internal static partial class ProgramSupport
         return 0;
     }
 
+    // #2669: GetDepSymbolCompiler (AlRunner.Infrastructure.DepSymbolCompilerCache) hands back the
+    // SAME BcCompiler instance across repeated calls to RunLayeredPrePass/BuildSiblingSourceDeps
+    // within the SAME process (--watch, --server) — see that class's own header for why.
+    internal static BcCompiler GetDepSymbolCompiler(string dir) => AlRunner.Infrastructure.DepSymbolCompilerCache.GetOrCreate(dir);
+
     // ── Layered source build pre-pass ─────────────────────────────────────────
     // Detects inter-bundle dependencies, emits impl bundles in topo order into a
     // per-run workspace cache dir, and prepends that dir to packageCacheDirs.
@@ -542,8 +547,25 @@ internal static partial class ProgramSupport
                     // and the guard is only here to avoid churning the loader signature.
                     if (priorImplDirs.Count > 0)
                         BcCompiler.SetExtraSymbolDirs(priorImplDirs);
+                    // #2669: EmitDepSymbolsIncremental instead of a plain EmitDepSymbols on a
+                    // throwaway `new BcCompiler()` — GetDepSymbolCompiler hands back the SAME
+                    // instance this impl used last time (if any), so a re-synthesis after a small
+                    // edit costs work proportional to that edit instead of the whole dependency
+                    // module. See GetDepSymbolCompiler's own comment above for why keying on
+                    // implPath is safe even though it's a looser identity than AppId/version.
                     using (BcCompiler.ScopeCurrentAppIdentity(implId.AppId, implId.Publisher, implId.Version))
-                        new BcCompiler().EmitDepSymbols(new[] { implPath }, implId.Name, implId.AppId, implId.Publisher, implId.Version, symbolsPath, implPath);
+                    {
+                        GetDepSymbolCompiler(implPath).EmitDepSymbolsIncremental(
+                            new[] { implPath }, implId.Name, implId.AppId, implId.Publisher, implId.Version,
+                            symbolsPath, implPath, out var tookFastPath, out var fallbackReason);
+                        // Same "not gated behind --verbose" reasoning as [watch]'s own FULL REBUILD
+                        // line above (see this file's header comment): a full compile here is the
+                        // ~22s-per-edit cost #2669 exists to eliminate, so which path was taken is a
+                        // RESULT the developer needs to see, not an internal diagnostic.
+                        Console.WriteLine(tookFastPath
+                            ? $"[layered] {implId.Name} {implId.Version}: RAD incremental (fast path)"
+                            : $"[layered] {implId.Name} {implId.Version}: full compile ({fallbackReason})");
+                    }
                     // Declare the FULL compile closure — the resolved deps (real AppIds/versions)
                     // UNIONed with the Microsoft platform apps vendored in the impl's own
                     // .alpackages. Filtering to non-Optional declared deps drops the implicit
@@ -839,8 +861,19 @@ internal static partial class ProgramSupport
             {
                 try
                 {
+                    // #2669: same GetDepSymbolCompiler + EmitDepSymbolsIncremental swap as
+                    // RunLayeredPrePass above, and for the identical reason — this function follows
+                    // the exact same "new BcCompiler() every call" shape for the same kind of source
+                    // dependency, just discovered via a sibling directory instead of a declared impl.
                     using (BcCompiler.ScopeCurrentAppIdentity(sid.AppId, sid.Publisher, sid.Version))
-                        new BcCompiler().EmitDepSymbols(new[] { dir }, sid.Name, sid.AppId, sid.Publisher, sid.Version, symbolsPath, dir);
+                    {
+                        GetDepSymbolCompiler(dir).EmitDepSymbolsIncremental(
+                            new[] { dir }, sid.Name, sid.AppId, sid.Publisher, sid.Version,
+                            symbolsPath, dir, out var tookFastPath, out var fallbackReason);
+                        Console.WriteLine(tookFastPath
+                            ? $"[source-dep] {sid.Name} {sid.Version}: RAD incremental (fast path)"
+                            : $"[source-dep] {sid.Name} {sid.Version}: full compile ({fallbackReason})");
+                    }
                     // Full compile closure (resolved deps ∪ vendored platform apps) — see the
                     // impl-bundle site above and #1546. Filtering to non-Optional declared deps
                     // would drop the implicit platform roots whose types appear in this dep's


### PR DESCRIPTION
Closes #2669

## Problem

`RunLayeredPrePass` and `BuildSiblingSourceDeps` (`AlRunner/Program.cs`) synthesize a source
dependency's compile-time symbols (`*.symbols.json`) via `BcCompiler.EmitDepSymbols`, which builds
a full `NavCA.Compilation.Create(...)` whole-module compile. Both call sites construct a fresh
`new BcCompiler()` every time, so `TryEmitIncremental`/`Compilation.CreateForRad` — the fast path
the main per-bundle compile loop already uses for exactly this class of problem — was never even
attempted, let alone tried-and-fallen-back. Every re-synthesis of a dependency's symbols paid the
same whole-module compile as the first, however small the edit.

## Fix

- `BcCompiler.EmitDepSymbols` gained a `trackIncrementalBaseline` parameter (mirroring `Emit`'s own
  identically-named parameter) that records a RAD baseline from the full compile it already did.
- `BcCompiler.EmitDepSymbolsIncremental` is the new entry point: try `TryEmitIncremental` against
  THIS instance's own baseline first, and only fall back to the full `EmitDepSymbols` compile for
  every condition `TryEmitIncremental` already falls back for — including #2548's guard against an
  added overload silently moving which member id an untouched sibling resolves to.
- `AlRunner.Infrastructure.DepSymbolCompilerCache` persists one `BcCompiler` instance per
  dependency directory across calls in the same warm process, because the RAD baseline lives on
  the compiler *instance* — a fresh instance every call (the old shape) can never have a baseline
  to diff against.
- `RunLayeredPrePass` and `BuildSiblingSourceDeps` now call `GetDepSymbolCompiler(dir)
  .EmitDepSymbolsIncremental(...)` instead of `new BcCompiler().EmitDepSymbols(...)`, and print
  which path was taken (`[layered] <App> <Version>: RAD incremental (fast path)` or `: full compile
  (<reason>)`) at default verbosity, not gated behind `--verbose` — the same "a full rebuild here
  is a RESULT the developer needs to see" reasoning `--watch`'s own FULL REBUILD line already uses.

## #2479

#2479 had two unseparated candidates for "incremental compile works under `--watch`, not
`--server`": the server entry point itself, or the multi-`sourcePaths` layered shape breaking the
per-bundle RAD baseline key. This PR settles it as neither, in a stronger form: the layered
dependency-symbol path never called `TryEmitIncremental` at all — it isn't that a key broke, it's
that the call was never made. Separately, I confirmed while investigating this that `--server`'s
*own* per-bundle compile loop (`RunBundleForServer`) already calls `TryEmitIncremental` when
`useIncrementalChangeModel` is set (`affectedOnly`) — so the server entry point itself was never
the blocker for that path. This PR does not touch `RunBundleForServer`; it only fixes the layered
pre-pass's own separate `EmitDepSymbols` call sites.

## Danger: #2603/#2548/#2605

Making the dependency's own re-synthesis incremental risks reintroducing exactly the hazard #2605
fixed for #2603: a consuming bundle whose own files hash identical takes the "genuinely zero work"
replay short-circuit and dispatches a member id a sibling's PREVIOUS surface resolved to. This PR
does not touch that mechanism (`ChangedLaterDependencyBundles`, `sawFallbackReason`,
`peekedChangedCountByBundle` in `Program.cs`) at all — it only makes the DEPENDENCY's own symbol
re-synthesis faster, by reusing the same `TryEmitIncremental` the main compile loop already relies
on for correctness, including its #2548 overload-add guard (`OverloadAddedUnderAnExistingName`).
Ran `ServerCrossAppOverloadRebindTests` (the #2603 regression test, #2605 is the PR that added it)
in both bundle orders — both pass:

```
Passed AlRunner.Tests.ServerCrossAppOverloadRebindTests.WarmRequest_AfterADependencyGainsAnOverload_NeverAnswersWithTheOldOverload(dependencyFirst: False) [19 s]
Passed AlRunner.Tests.ServerCrossAppOverloadRebindTests.WarmRequest_AfterADependencyGainsAnOverload_NeverAnswersWithTheOldOverload(dependencyFirst: True) [19 s]
```

New negative test `LayeredDepSymbolsIncrementalServerTests
.AddingAnOverloadInTheDependency_StillFallsBackToAFullCompile` proves the SAME hazard shape still
forces a full compile through the new `EmitDepSymbolsIncremental` path specifically (not just
through the pre-existing per-bundle loop): I could not find a way to make this both fast AND safe
for that one edit shape, so it stays on the slower, safe path — same tradeoff `TryEmitIncremental`
already makes everywhere else.

I believe the stale-replay risk is **fully handled**, not just mitigated: the fast path never does
anything `TryEmitIncremental` doesn't already do for the main compile loop, and the existing #2603
fix's gating on the CONSUMING bundle is completely untouched by this change.

## Measurements

The tool's own `[layered] WROTE ... (Nms)` stopwatch line, `--server`, two `runTests` requests to
one warm process, edit between them. I don't have access to Pageworks (the issue's own fixture), so
I built synthetic layered fixtures (a dependency app + a separate test app declaring a dependency
on it — the standard AL-Go shape) and measured those on this machine, describing them precisely
rather than guessing at Pageworks' own numbers:

**Fixture 1** — 1 codeunit / 1 procedure in the dependency, edited to add a second procedure:
```
before: [layered] WROTE ... (564 bytes, 5707ms)   <- first synthesis, no baseline yet (expected)
after:  [layered] WROTE ... (573 bytes,   68ms)   <- RAD incremental (fast path)
```

**Fixture 2** — 400 codeunits / 1,200 procedures in the dependency, ONE procedure body edited:
```
before fix (reverted to e9bdcbb6): request 2 full compile ...  60ms
after fix:                         request 2 RAD fast path ... 130ms
```

Fixture 2 is an honest negative result worth stating plainly: at this scale and shape (flat
procedure-only codeunits, no tables/pages/complex cross-object binding), BC's own whole-module
compile is ALREADY so cheap that `TryEmitIncremental`'s own bookkeeping overhead (hash every file,
classify touched objects, `CreateForRad`, merge the module definition) costs more than it saves.
Neither synthetic fixture reproduces Pageworks' reported magnitude (22.25s), because that cost is
almost certainly dominated by BC's binding of real business-logic complexity (tables, pages,
larger dependency closures) that a flat codeunit-and-procedure fixture doesn't have — the same
class of app `BcCompiler.Incremental.cs`'s own header cites (761-862s per save on a 7,053-file app)
for the `--watch` fast path this PR reuses unchanged. What both fixtures DO prove, unambiguously,
is that the mechanism engages correctly, produces genuinely correct symbols for a real edit (see
below), and correctly refuses to engage for the one edit shape where "fast" and "correct" conflict.
I did not have a large enough / realistic enough dependency app on hand to reproduce the reported
magnitude, and I'm saying so rather than presenting the 400-codeunit number as if it were that
proof.

## Cache-miss / correctness path

`BcCompilerEmitDepSymbolsIncrementalTests
.EmitDepSymbolsIncremental_ContentEditAddingAProcedure_TakesFastPath_AndMatchesAFreshFullCompile`
and `LayeredDepSymbolsIncrementalServerTests
.EditingOneCodeunitInTheDependency_TakesTheRadFastPath_AndTheDependentCompilesAgainstTheNewProcedure`
both add a genuinely NEW procedure to the dependency and prove the fast-path symbols are not a
stale replay: the unit test compares the fast path's procedure set structurally against an
independent fresh full compile of the same post-edit source; the server test has a REAL downstream
consuming app compile against the fast-path symbols and call the new procedure, which only
succeeds (and only returns the correct summed value) if the symbols genuinely describe it — a
stale/incomplete symbol table fails that compile outright (AL0132/AL0185), it doesn't silently
disagree.

## Tests

- `AlRunner.Tests/BcCompilerEmitDepSymbolsIncrementalTests.cs` — direct `BcCompiler` level (3
  tests): first call always falls back, a content edit adding a procedure takes the fast path and
  matches an independent full compile, an added overload falls back with a reason naming it.
- `AlRunner.Tests/LayeredDepSymbolsIncrementalServerTests.cs` — end-to-end through the real
  `RunLayeredPrePass` pipeline under `--server` (2 tests): the RED→GREEN proof that the fast path
  is actually taken in the real pipeline (not just the unit-level mechanism) plus the downstream
  correctness proof above; the overload-add negative control.
- Ran (pre-existing, unmodified) `LayeredCacheTests`, `LayeredSourceChainTests`,
  `ManifestFeaturesSubprocessTests`, `ServerCrossAppOverloadRebindTests` — all pass, no regression
  to `RunLayeredPrePass`/`BuildSiblingSourceDeps`'s existing behavior (per-impl cache-dir isolation,
  chained source deps, manifest-feature propagation, cross-app overload safety).

## Same shape elsewhere

`EmitSiblingSymbols` (in-bundle "parent of many apps" sibling-dependency symbol emit) has the
identical `new BcCompiler().EmitDepSymbols(...)` shape and the same fix would apply, but it's a
different call shape with its own fixtures/tests and no measured cost yet — left out to keep this
PR reviewable. Filed as #2672.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf