### PR TITLE
fix(diagnostics): stop a passing corpus run printing 618 header-less stack-frame lines

### DIFF
--- a/AlRunner.Tests/Fixtures/FlowFieldRecursionDiagnostics/Assert.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/FlowFieldRecursionDiagnostics/Assert.Codeunit.al
@@ -1,0 +1,18 @@
+/// <summary>
+/// Minimal assertion helper for this fixture app (own ID range so it stands
+/// alone from the corpus Assert).
+/// </summary>
+codeunit 60840 "FFR Assert"
+{
+    procedure AreEqual(Expected: Text; Actual: Text; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqual failed. Expected:<%1>. Actual:<%2>. %3', Expected, Actual, Msg);
+    end;
+
+    procedure ExpectedError(Expected: Text; Actual: Text)
+    begin
+        if StrPos(Actual, Expected) = 0 then
+            Error('Assert.ExpectedError failed. Expected to find:<%1>. Actual:<%2>.', Expected, Actual);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/FlowFieldRecursionDiagnostics/FFRHeader.Table.al
+++ b/AlRunner.Tests/Fixtures/FlowFieldRecursionDiagnostics/FFRHeader.Table.al
@@ -1,0 +1,54 @@
+/// <summary>
+/// "Self Ref Amount" is a FlowField whose where-condition names ITSELF, so calculating
+/// it could only be done by calculating it. BC refuses such a formula outright with its
+/// recursion error rather than recursing until the stack is exhausted, and the runner
+/// reproduces that refusal in FlowFieldPatches' recursion guards. That refusal is the
+/// EXPECTED result here — the fixture's test traps it with asserterror.
+/// </summary>
+table 60842 "FFR Header"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+
+        /// A plain, terminating parent-link FlowField — the control that proves a refused
+        /// self-referencing formula does not disturb the rest of the table.
+        field(10; "Total Amount"; Decimal)
+        {
+            FieldClass = FlowField;
+            CalcFormula = sum("FFR Line".Amount where("Doc No." = field("No.")));
+        }
+
+        /// The self-referencing formula.
+        field(11; "Self Ref Amount"; Decimal)
+        {
+            FieldClass = FlowField;
+            CalcFormula = sum("FFR Line".Amount where("Doc No." = field("No."),
+                                                     "Ref Amount" = field("Self Ref Amount")));
+        }
+
+        /// A pair of FlowFields whose where-conditions reference EACH OTHER. Neither names
+        /// itself, so the cycle is only caught by the depth bound — which makes the runner's
+        /// diagnostic trace hundreds of frames long instead of two.
+        field(12; "Cycle A"; Decimal)
+        {
+            FieldClass = FlowField;
+            CalcFormula = sum("FFR Line".Amount where("Doc No." = field("No."),
+                                                     "Ref Amount" = field("Cycle B")));
+        }
+
+        field(13; "Cycle B"; Decimal)
+        {
+            FieldClass = FlowField;
+            CalcFormula = sum("FFR Line".Amount where("Doc No." = field("No."),
+                                                     "Ref Amount" = field("Cycle A")));
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/AlRunner.Tests/Fixtures/FlowFieldRecursionDiagnostics/FFRLine.Table.al
+++ b/AlRunner.Tests/Fixtures/FlowFieldRecursionDiagnostics/FFRLine.Table.al
@@ -1,0 +1,18 @@
+/// <summary>The source rows the header's FlowFields aggregate.</summary>
+table 60841 "FFR Line"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; "Doc No."; Code[20]) { }
+        field(3; Amount; Decimal) { }
+        field(4; "Ref Amount"; Decimal) { }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.") { Clustered = true; }
+    }
+}

--- a/AlRunner.Tests/Fixtures/FlowFieldRecursionDiagnostics/FFRTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/FlowFieldRecursionDiagnostics/FFRTests.Codeunit.al
@@ -1,0 +1,79 @@
+/// <summary>
+/// A PASSING run that drives the runner's FlowField recursion guard. The AL here asserts
+/// only what the al-language corpus already asserts against a real service tier
+/// (TestCalcFormulaFlowFieldValueTests.Record_CalcFields_SelfReferencingFormula_RaisesTheRecursionError);
+/// it is duplicated as a runner fixture purely because FlowFieldDiagnosticNoiseTests needs
+/// a small, base-app-free bundle it can spawn and read stderr from.
+/// </summary>
+codeunit 60843 "FFR Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "FFR Assert";
+
+    local procedure Initialize()
+    var
+        Header: Record "FFR Header";
+        Line: Record "FFR Line";
+    begin
+        Header.DeleteAll();
+        Line.DeleteAll();
+
+        Header.Init();
+        Header."No." := 'D1';
+        Header.Insert();
+
+        Line.Init();
+        Line."Entry No." := 1;
+        Line."Doc No." := 'D1';
+        Line.Amount := 100;
+        Line."Ref Amount" := 100;
+        Line.Insert();
+    end;
+
+    [Test]
+    procedure CalcFields_SelfReferencingFormula_RaisesTheRecursionError()
+    var
+        Header: Record "FFR Header";
+    begin
+        // [GIVEN] a seeded document
+        Initialize();
+        Header.Get('D1');
+
+        // [WHEN] [THEN] the self-referencing formula is refused, not recursed
+        asserterror Header.CalcFields("Self Ref Amount");
+        Assert.ExpectedError('This can be caused by recursive function calls', GetLastErrorText());
+
+        // [THEN] the refusal is specific to that one formula
+        Initialize();
+        Clear(Header);
+        Header.Get('D1');
+        Header.CalcFields("Total Amount");
+        Assert.AreEqual('100', Format(Header."Total Amount"),
+            'a refused self-referencing formula must not disturb the other FlowFields');
+    end;
+
+    [Test]
+    procedure CalcFields_MutuallyReferencingFormulas_RaiseTheRecursionError()
+    var
+        Header: Record "FFR Header";
+    begin
+        // [GIVEN] "Cycle A" reads "Cycle B" and "Cycle B" reads "Cycle A"
+        Initialize();
+        Header.Get('D1');
+
+        // [WHEN] [THEN] the cycle is bounded and reported, not run until the stack dies.
+        // This is the deep path: the guard only bites 50 levels down, so the runner's
+        // internal diagnostic for it is a 300-frame stack trace.
+        asserterror Header.CalcFields("Cycle A");
+        Assert.ExpectedError('This can be caused by recursive function calls', GetLastErrorText());
+
+        Initialize();
+        Clear(Header);
+        Header.Get('D1');
+        Header.CalcFields("Total Amount");
+        Assert.AreEqual('100', Format(Header."Total Amount"),
+            'a refused cyclic formula must not disturb the other FlowFields');
+    end;
+}

--- a/AlRunner.Tests/Fixtures/FlowFieldRecursionDiagnostics/app.json
+++ b/AlRunner.Tests/Fixtures/FlowFieldRecursionDiagnostics/app.json
@@ -1,0 +1,24 @@
+{
+  "id": "c7f1a2b3-4d5e-4f60-8a71-9b2c3d4e5f80",
+  "name": "Runner Tests Fixture - FlowField Recursion Diagnostics",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Regression test: a trapped FlowField recursion error must not dump a bare .NET stack trace on stderr.",
+  "description": "Drives the runner's FlowField recursion guard (a FlowField whose where-condition names itself) from an AL asserterror, which is the expected, passing outcome. Used by FlowFieldDiagnosticNoiseTests to prove the runner's internal [FlowFieldPatches] diagnostic — header AND stack trace — is suppressed at default verbosity and restored under --verbose.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "idRanges": [
+    {
+      "from": 60840,
+      "to": 60859
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner.Tests/FlowFieldDiagnosticNoiseTests.cs
+++ b/AlRunner.Tests/FlowFieldDiagnosticNoiseTests.cs
@@ -1,0 +1,187 @@
+// FlowFieldDiagnosticNoiseTests — a PASSING run must not dump bare .NET stack traces.
+//
+// A green al-language corpus run (exit 0, every test passing) printed 184 KB of stderr:
+// 618 stack-frame lines across 102 `--- End of stack trace from previous location ---`
+// markers, with no header line anywhere to say what they belonged to. Every CI job log on
+// every PR carried it, and a green run read as broken.
+//
+// The whole 618 lines came from three calls to ONE statement —
+// FlowFieldPatches' `catch (Exception ex)` in RecordImpl_CalcFieldsAsync_3, which wrote
+// `ex.StackTrace` as its own separate Console.Error line. Two of those three traces are
+// ~308 frames each, because the exception is BC's own NavNCLStackOverflowException
+// ("...can be caused by recursive function calls...") raised by FlowFieldPatches' depth
+// guard 50 levels into a cyclic FlowField formula, rethrown with ExceptionDispatchInfo at
+// every level on the way out.
+//
+// Nothing is wrong on that path. The AL that reaches it is
+// `asserterror <Record>.CalcFields(<self-referencing FlowField>)` — the refusal IS the
+// expected result, asserted on real BC by the corpus
+// (TestCalcFormulaFlowFieldValueTests.Record_CalcFields_SelfReferencingFormula_RaisesTheRecursionError)
+// and by this file's fixture here. The exception is still rethrown to AL exactly as before;
+// only the printing changed, so .claude/rules/loud-failures.md is untouched — nothing is
+// swallowed, and no default value is returned in place of a real answer.
+//
+// The bug was a printing one, and specifically a HALF-suppressed diagnostic. The header
+// line was `[FlowFieldPatches] ex: ...`, which Log.FilteredWriter drops at default
+// verbosity by design — it is an internal diagnostic. The trace went out as a SECOND
+// Console.Error.WriteLine whose text is a bare `   at ...` block with no `[Component]`
+// prefix, so the same filter could not recognise it and let all 618 lines through. The fix
+// folds header and trace into one tagged write, so the filter sees the tag and handles both
+// together: silent by default, complete under --verbose. That is why the verbose arm below
+// is not optional — it is what separates "gated" from "deleted", the exact distinction
+// #2210/#2239 were about.
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class FlowFieldDiagnosticNoiseTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string Fixture = Path.Combine(
+        RepoRoot, "AlRunner.Tests", "Fixtures", "FlowFieldRecursionDiagnostics");
+
+    /// <summary>A .NET stack-frame line: leading whitespace, `at `, then a managed name.</summary>
+    private static readonly Regex StackFrameLine =
+        new(@"^\s+at [A-Za-z_<]", RegexOptions.Compiled);
+
+    private static (string Stdout, string Stderr, int Exit) Run(string alCacheDir, params string[] extraArgs)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(' ').Append(TestBuildConfig.BcVersionArg);
+        foreach (var a in extraArgs) args.Append(' ').Append(a);
+        args.Append($" --cache \"{alCacheDir}\"");
+        args.Append($" \"{Fixture}\"");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = args.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        // The two arms differ ONLY by the --verbose flag, so an ambient AL_RUNNER_VERBOSE
+        // would make the default arm assert against a verbose run and pass for the wrong
+        // reason (or fail for one).
+        psi.Environment.Remove("AL_RUNNER_VERBOSE");
+
+        var so = new StringBuilder();
+        var se = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (so) so.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (se) se.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        // Parameterless WaitForExit() — the int overload does NOT drain the async readers,
+        // so without this the captured text is racy and truncated.
+        p.WaitForExit();
+        lock (so) lock (se) return (so.ToString(), se.ToString(), p.ExitCode);
+    }
+
+    private static string NewCacheDir([System.Runtime.CompilerServices.CallerMemberName] string name = "") =>
+        Path.Combine(Path.GetTempPath(), "al-runner-flowfield-noise", name, Guid.NewGuid().ToString("N"));
+
+    private static void AssertFixturePassed(string stdout, string stderr, int exit)
+    {
+        Assert.True(exit == 0 && stdout.Contains("pass:        2") && stdout.Contains("fail:        0"),
+            $"fixture must compile and pass cleanly (exit {exit}):\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}");
+    }
+
+    private static string[] FrameLines(string stderr) =>
+        stderr.Split('\n').Where(l => StackFrameLine.IsMatch(l.TrimEnd('\r'))).ToArray();
+
+    /// <summary>
+    /// RED (pre-fix): 310 frame lines and 51 rethrow markers on stderr for a run that
+    /// passed both its tests. GREEN: not one frame line, and no marker.
+    /// </summary>
+    [SkippableFact]
+    public void DefaultRun_PassingFlowFieldRecursion_PrintsNoBareStackTrace()
+    {
+        TestArtifacts.SkipIfMissing();
+        var alCacheDir = NewCacheDir();
+        try
+        {
+            var (stdout, stderr, exit) = Run(alCacheDir);
+            AssertFixturePassed(stdout, stderr, exit);
+
+            var frames = FrameLines(stderr);
+            Assert.True(frames.Length == 0,
+                $"a passing run must not print bare .NET stack frames on stderr; found "
+                + $"{frames.Length}, first: {(frames.Length > 0 ? frames[0].Trim() : "")}");
+            Assert.DoesNotContain("End of stack trace from previous location", stderr);
+        }
+        finally
+        {
+            try { Directory.Delete(alCacheDir, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// The other direction, and the reason the fix is a gate rather than a deletion: under
+    /// --verbose the SAME run must still carry the full diagnostic — the `[FlowFieldPatches]`
+    /// header, the exception BC actually raised, and the frames behind it. A fix that merely
+    /// deleted the write would pass the arm above and fail this one.
+    /// </summary>
+    [SkippableFact]
+    public void VerboseRun_PassingFlowFieldRecursion_StillPrintsTheDiagnosticWithItsTrace()
+    {
+        TestArtifacts.SkipIfMissing();
+        var alCacheDir = NewCacheDir();
+        try
+        {
+            var (stdout, stderr, exit) = Run(alCacheDir, "--verbose");
+            AssertFixturePassed(stdout, stderr, exit);
+
+            Assert.Contains("[FlowFieldPatches] ex: NavNCLStackOverflowException", stderr);
+            Assert.Contains("This can be caused by recursive function calls", stderr);
+            Assert.Contains("AlRunner.Patches.FlowFieldPatches.CalcFlowFieldValuesCore", stderr);
+            Assert.True(FrameLines(stderr).Length > 0,
+                $"--verbose must still carry the frames behind the diagnostic:\n{stderr}");
+        }
+        finally
+        {
+            try { Directory.Delete(alCacheDir, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// The defect was structural, not local to one call site: a `[Component]`-tagged header
+    /// written by one Console.Error call followed by a bare `ex.StackTrace` written by the
+    /// NEXT one is always half-suppressed, because Log's filter matches per write and a
+    /// stack trace carries no tag. Pin every site that had the shape, so a future edit that
+    /// splits one back into two writes fails here rather than in a CI log six months later.
+    /// </summary>
+    [Fact]
+    public void NoPatchWritesABareStackTraceAsItsOwnConsoleErrorCall()
+    {
+        var patchesDir = Path.Combine(RepoRoot, "AlRunner", "Patches");
+        var offenders = new List<string>();
+
+        foreach (var file in Directory.EnumerateFiles(patchesDir, "*.cs", SearchOption.AllDirectories))
+        {
+            var lines = File.ReadAllLines(file);
+            for (int i = 0; i < lines.Length; i++)
+            {
+                var t = lines[i].TrimStart();
+                if (!t.StartsWith("Console.Error.WriteLine(", StringComparison.Ordinal)) continue;
+                // A write whose ENTIRE argument is a stack trace has no `[Component]` tag for
+                // Log.FilteredWriter to match, so it escapes suppression on its own.
+                if (Regex.IsMatch(t, @"^Console\.Error\.WriteLine\(\s*[A-Za-z_][A-Za-z0-9_.]*\.StackTrace\b"))
+                    offenders.Add($"{Path.GetRelativePath(RepoRoot, file)}:{i + 1}: {t}");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "a bare `.StackTrace` written as its own Console.Error call escapes Log's "
+            + "[Component] filter and prints at default verbosity; fold it into the tagged "
+            + "header line instead:\n  " + string.Join("\n  ", offenders));
+    }
+}

--- a/AlRunner/Patches/FlowFieldPatches.cs
+++ b/AlRunner/Patches/FlowFieldPatches.cs
@@ -473,8 +473,15 @@ public static class FlowFieldPatches
         }
         catch (TargetInvocationException tie) when (tie.InnerException != null)
         {
-            Console.Error.WriteLine($"[FlowFieldPatches] inner ex: {tie.InnerException.GetType().Name}: {tie.InnerException.Message}");
-            Console.Error.WriteLine(tie.InnerException.StackTrace ?? "");
+            // Header AND trace in ONE tagged write. Log.FilteredWriter matches its
+            // `[Component]` pattern per write, and a stack trace carries no tag — split
+            // across two calls the header is dropped at default verbosity and the frames
+            // are not, which is how a green corpus run came to print 618 header-less
+            // frame lines into every CI log (this is a trapped, expected AL error path,
+            // not a failure). One write means the filter suppresses or keeps both together.
+            Console.Error.WriteLine(
+                $"[FlowFieldPatches] inner ex: {tie.InnerException.GetType().Name}: "
+                + $"{tie.InnerException.Message}\n{tie.InnerException.StackTrace}");
             // Rethrow honoring DataError contract
             if (errorLevel == DataError.TrapError)
                 return new System.Threading.Tasks.ValueTask<bool>(false);
@@ -483,8 +490,14 @@ public static class FlowFieldPatches
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"[FlowFieldPatches] ex: {ex.GetType().Name}: {ex.Message}");
-            Console.Error.WriteLine(ex.StackTrace ?? "");
+            // One tagged write, header + trace — see the sibling catch above for why
+            // splitting them leaks the frames past Log's filter. This catch is on the
+            // ordinary AL error path (BC's own NavNCLStackOverflowException for a cyclic
+            // CalcFormula, trapped by `asserterror` in a passing test), so the trace is
+            // diagnostic detail, not evidence of a fault. The exception itself is still
+            // rethrown / converted per BC's DataError contract below — unchanged.
+            Console.Error.WriteLine(
+                $"[FlowFieldPatches] ex: {ex.GetType().Name}: {ex.Message}\n{ex.StackTrace}");
             if (errorLevel == DataError.TrapError)
                 return new System.Threading.Tasks.ValueTask<bool>(false);
             throw;

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -309,9 +309,13 @@ public static partial class RecordPatches
         catch (Exception ex)
         {
             var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
-            Console.Error.WriteLine($"[RecordPatches] BuildNCLMetaTable({tableId}) failed: {inner.GetType().Name}: {inner.Message}");
-            if (inner.StackTrace != null)
-                Console.Error.WriteLine(inner.StackTrace.Split('\n')[0]);
+            // Header + top frame in ONE tagged write — a separate write for the frame has no
+            // `[Component]` tag for Log.FilteredWriter to match, so it would print at default
+            // verbosity under a header the filter had just dropped.
+            Console.Error.WriteLine(
+                $"[RecordPatches] BuildNCLMetaTable({tableId}) failed: {inner.GetType().Name}: "
+                + $"{inner.Message}"
+                + (inner.StackTrace != null ? "\n" + inner.StackTrace.Split('\n')[0] : ""));
             return null;
         }
     }

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -1858,8 +1858,13 @@ public static partial class RecordPatches
         catch (Exception ex)
         {
             var inner = ex is System.Reflection.TargetInvocationException tie ? tie.InnerException ?? ex : ex;
-            Console.Error.WriteLine($"[RecordPatches] GetDataAccessForTable failed for table {table?.TableName ?? "null"}: {inner.GetType().Name}: {inner.Message}");
-            Console.Error.WriteLine(inner.StackTrace ?? "");
+            // Header + trace in ONE tagged write: Log.FilteredWriter matches per write and
+            // a bare stack trace has no `[Component]` tag, so a second call would print its
+            // frames at default verbosity under a header the filter had just dropped.
+            Console.Error.WriteLine(
+                $"[RecordPatches] GetDataAccessForTable failed for table "
+                + $"{table?.TableName ?? "null"}: {inner.GetType().Name}: {inner.Message}"
+                + $"\n{inner.StackTrace}");
             throw;
         }
     }


### PR DESCRIPTION
A **passing** al-language corpus run (exit 0, 2448/2448) was writing **185 KB of stderr — 618 stack-frame lines across 102 `--- End of stack trace ---` markers** into every CI job log, on every PR.

| | before | after |
|---|---:|---:|
| `grep -cE '^ *at '` | 618 | **0** |
| `End of stack trace` markers | 102 | **0** |
| stderr bytes | 185,378 | **254** |
| corpus | 2448/2448, exit 0 | 2448/2448, exit 0 |

stderr is now the two intended lines: `[expectations] loaded 8 entries...` and `[bc] selected BC 28.1...`.

## Root cause: a diagnostic that was half-suppressed

`AlRunner/Log.cs`'s `FilteredWriter` drops lines matching `^\[Component\]` at default verbosity, **per write**. The diagnostic was two writes:

```csharp
Console.Error.WriteLine($"[FlowFieldPatches] ex: {ex.GetType().Name}: {ex.Message}");  // dropped
Console.Error.WriteLine(ex.StackTrace ?? "");                                          // no tag → passed
```

So the useful half was filtered and the noisy half went through, which is why the traces appear in the log with **no header anywhere in either stream** — and why searching for the header found nothing. Three firings produced all 618 lines: a recursion guard bites 50 levels deep and `ExceptionDispatchInfo.Throw` re-appends a marker on the way out of every level, so one firing is ~206 lines.

## Classification: an expected AL error path, not a fault

One exception behind all 102 markers:

```
NavNCLStackOverflowException: There is insufficient memory to execute this function.
This can be caused by recursive function calls. Contact your system administrator.
```

That is the runner faithfully reproducing BC's own recursion guard for a cyclic `CalcFormula`. The AL that reaches it is, in `tests/al-language/.../TestCalcFormulaFlowFieldValueTests.Codeunit.al:176` and `:201`:

```al
asserterror CfvHeader.CalcFields("Self Ref Amount");
Assert.ExpectedError('This can be caused by recursive function calls');
```

The refusal **is** the assertion. Both tests are green upstream on real BC and green here. Nothing is wrong; the runner was printing a 308-frame trace about a test passing.

## `loud-failures.md` is not weakened

Only the printing changed. The exception is still rethrown, or converted per BC's `DataError` contract, exactly as before — no catch was widened, no return value faked. Header and trace are now a **single tagged write**, so the existing filter treats them as one unit: suppressed at default verbosity, complete under `--verbose`.

Three sibling sites had the same latent split and are fixed the same way: `FlowFieldPatches.cs:476-477`, `RecordPatches.cs:1861-1862`, `RecordPatches.NclMetaTableBuilder.cs:313-314`.

## Tests

`AlRunner.Tests/FlowFieldDiagnosticNoiseTests.cs`, over a new fixture `Fixtures/FlowFieldRecursionDiagnostics` (self-referencing and mutually-referencing FlowFields, ids 60840-60859, `dependencies: []` and **no `application` property**, per `.claude/rules/no-base-app-in-csharp-tests.md`):

- `DefaultRun_...PrintsNoBareStackTrace` — RED at 310 frames, GREEN at 0.
- `VerboseRun_...StillPrintsTheDiagnosticWithItsTrace` — the negative control that separates *gated* from *deleted*. Passes before and after, and fails if anyone removes the write.
- `NoPatchWritesABareStackTraceAsItsOwnConsoleErrorCall` — structural guard over `AlRunner/Patches/**`; RED listing all four sites, GREEN at 0.

`BaseAppFloorFixtureGuardTests`, `CleanRunStartupVerbosityTests` and `BundleSuiteErrorLoudnessTests` also pass (11/11).

No linked issue: the noise was reported directly and diagnosed in-session, never filed.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf