### PR TITLE
fix(cli): report 0.0.0-main from a source build instead of a stale 2.0.0-preview.1

### DIFF
--- a/AlRunner.Tests/RunnerVersionDefaultTests.cs
+++ b/AlRunner.Tests/RunnerVersionDefaultTests.cs
@@ -1,0 +1,58 @@
+using System.IO;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #2681. AlRunner.csproj's <c>&lt;Version&gt;</c> is the version EVERY build that is not
+/// a release reports — a local build, a dev build, a CI matrix build, a clone. Only
+/// publish.yml overrides it (<c>-p:Version=</c>), so the default is what a contributor,
+/// and every gap report they paste <c>--help</c> into, actually sees.
+///
+/// It sat at <c>2.0.0-preview.1</c> through ten releases (latest tag v2.10.0 when this was
+/// found), because nothing exercises the default path during a release and nothing failed
+/// when it drifted. That is the same shape as #2010's hardcoded <c>_BCVersion</c> pin,
+/// which rotted unnoticed and took a release down after the tag was already pushed.
+///
+/// The fix is NOT to keep it current — a real version number here would need updating every
+/// release and would conflict between every concurrent PR that touched it. It is to make the
+/// default say "this is a build off main", naming nothing specific, so it never rots and
+/// never needs a bump. <c>0.0.0-</c> is already this repo's marker for a non-release build:
+/// bc-tests.yml's pack mirror packs with <c>-p:Version=0.0.0-ci</c>.
+/// </summary>
+public class RunnerVersionDefaultTests
+{
+    private static string CsprojVersion()
+    {
+        var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "AlRunner", "AlRunner.csproj")))
+            dir = dir.Parent;
+        Assert.True(dir != null, "could not locate AlRunner/AlRunner.csproj from the test working directory");
+        var text = File.ReadAllText(Path.Combine(dir!.FullName, "AlRunner", "AlRunner.csproj"));
+        var m = Regex.Match(text, @"<Version>([^<]+)</Version>");
+        Assert.True(m.Success, "AlRunner.csproj carries no <Version> element");
+        return m.Groups[1].Value.Trim();
+    }
+
+    [Fact]
+    public void CsprojVersion_IsANonReleaseMarker_NotSomethingThatLooksLikeAShippedRelease()
+    {
+        var version = CsprojVersion();
+        Assert.True(
+            version.StartsWith("0.0.0-", System.StringComparison.Ordinal),
+            $"AlRunner.csproj <Version> is '{version}'. Every non-release build reports this, and "
+            + "--help pastes it into gap reports, so it must not look like a shipped release. Use a "
+            + "'0.0.0-<marker>' form (the repo already packs CI mirrors as 0.0.0-ci). Do NOT set it to "
+            + "the current release number: that has to be bumped every release, conflicts between "
+            + "concurrent PRs, and silently rots the moment someone forgets — see #2681 and #2010.");
+    }
+
+    [Fact]
+    public void CsprojVersion_NamesNoSpecificReleaseOrDate_SoItNeverNeedsBumping()
+    {
+        var version = CsprojVersion();
+        Assert.DoesNotMatch(new Regex(@"\d+\.\d+\.\d+(?!\-)"), version.Replace("0.0.0-", ""));
+        Assert.DoesNotMatch(new Regex(@"20\d\d"), version);
+    }
+}

--- a/AlRunner/AlRunner.csproj
+++ b/AlRunner/AlRunner.csproj
@@ -89,7 +89,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>al-runner</ToolCommandName>
     <PackageId>MSDyn365BC.AL.Runner</PackageId>
-    <Version>2.0.0-preview.1</Version>
+    <Version>0.0.0-main</Version>
     <Description>Run Business Central AL unit tests in milliseconds — no BC service tier, no Docker, no SQL Server, no license.</Description>
     <Authors>Stefan Maron</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
```console
$ al-runner -v          # before
al-runner v2.0.0-preview.1
$ git tag --sort=-v:refname | head -1
v2.10.0
```

`AlRunner.csproj`'s `<Version>` is what **every build that is not a release** reports — a local build, a dev build, a CI matrix build, a clone. Only `publish.yml` overrides it with `-p:Version=`. It sat at `2.0.0-preview.1` through ten releases, because nothing exercises the default path during a release and nothing fails when it drifts.

## Why it is not cosmetic

`CliText` prints the version as the **first line of `--help`**, deliberately, so a build carries its own version wherever that output gets pasted into a gap report (#2072) — and reporting gaps is the workflow `--guide` exists to drive (#2071). Gap reports from anyone building from source therefore arrive stamped ten releases stale, and triage cannot tell what the reporter is actually running.

Same shape as #2010: a hardcoded pin in a path nobody exercises except during a release, with nothing to make the drift visible.

## The fix is not "bump it"

A real version number here would have to be bumped every release, would conflict between every concurrent PR that touched it, and would rot again the first time someone forgot. The default now names **no specific version at all**:

| build | reports |
|---|---|
| `dotnet build` (default) | `al-runner v0.0.0-main` |
| `-p:Version=2.11.0` (publish.yml) | `al-runner v2.11.0` |

`0.0.0-` is already this repo's marker for a non-release build — `bc-tests.yml`'s pack mirror packs with `-p:Version=0.0.0-ci`.

## Tests

New `AlRunner.Tests/RunnerVersionDefaultTests`:

- `CsprojVersion_IsANonReleaseMarker_NotSomethingThatLooksLikeAShippedRelease` — **RED** naming `2.0.0-preview.1`, **GREEN** on `0.0.0-main`. Its failure message says why bumping is the wrong fix, so the next person to hit it does not "fix" it by setting the current release number.
- `CsprojVersion_NamesNoSpecificReleaseOrDate_SoItNeverNeedsBumping` — refuses any default carrying a version triple or a year, so it cannot drift back into needing maintenance.

The release direction is verified too, since that is the thing that must not break: a build with `-p:Version=2.11.0` still prints exactly `al-runner v2.11.0`.

The 27 existing `RunnerVersionTests` + `CliDocumentationTests` cases pass unchanged — the `al-runner v<something>` shape they assert is preserved, including the "not purely numeric" guard.

Closes #2681

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf