### PR TITLE
fix(testpage): a subpage part linked via SubPageLink never fired OnAfterGetRecord

### DIFF
--- a/AlRunner.Tests/TestPagePartLinkedRowLoadTests.cs
+++ b/AlRunner.Tests/TestPagePartLinkedRowLoadTests.cs
@@ -1,0 +1,280 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Runner-mechanism test for issue #2677: a subpage part bound via SubPageLink never got its
+/// own row positioned or its own OnAfterGetRecord/OnAfterGetCurrRecord run at all —
+/// TestPageFactory.TryBuild hands GetPart a BLANK, unfetched record, and nothing ever made an
+/// explicit MoveXxx/GoToBookmark call on the part's behalf.
+///
+/// AlRunner/Patches/MockTestPage.cs's LiveNavTestPage.EagerlyBuildParts (called from
+/// RunnerTestPageState.MarkOpened right after the host's own OnOpenPage, before the host's
+/// first row is found) reaches every declared part control eagerly, and
+/// LiveNavTestPage.Loaded refreshes every linked part in _parts (via the new, deliberately
+/// UN-guarded LiveNavTestPart.ReloadLinkedRow) on every subsequent host row load — which is
+/// what makes a GoToRecord on the host refresh the part too.
+///
+/// The BEHAVIORAL claim ("a subpage part linked via SubPageLink fires OnOpenPage/
+/// OnAfterGetRecord/OnAfterGetCurrRecord eagerly when the host opens, with nothing ever
+/// touching CurrPage.&lt;part&gt;/TestPage.&lt;part&gt;, and re-fires for a new row on
+/// GoToRecord") is a plain-BC-behaviour claim and belongs upstream — see
+/// StefanMaron/BusinessCentral.AL.Language.Tests codeunit 60815 "Test Page Part Agcr Tests"
+/// (corpus PR #141, all 8 BC legs green, independently confirmed against a local BC 28.4
+/// container), per .claude/rules/bc-behavior-tests-go-upstream.md. This test exists so a
+/// regression in OUR OWN eager-build/refresh-on-load mechanism fails loudly here, spawning
+/// the real runner against a synthetic bundle, without depending on the submodule pin having
+/// moved yet.
+///
+/// No Library Assert dependency (no "application" in the fixture's app.json — see
+/// .claude/rules/no-base-app-in-csharp-tests.md): each test raises its own Error() with the
+/// observed value, so the runner's own PASS/FAIL output is the assertion surface.
+/// </summary>
+public class TestPagePartLinkedRowLoadTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(string bundle)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" \"").Append(bundle).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private static string WriteBundle()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-testpage-part-linked-row-load-2677", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        File.WriteAllText(Path.Combine(root, "app.json"), """
+        {
+          "id": "c2677000-0000-4000-8000-000000002677",
+          "name": "TestPagePartLinkedRowLoad2677",
+          "publisher": "Repro2677",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62525, "to": 62535 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(root, "TplrRow.Table.al"), """
+        table 62525 "Tplr Row"
+        {
+            DataClassification = CustomerContent;
+            fields
+            {
+                field(1; "No."; Code[20]) { }
+                field(2; Name; Text[50]) { }
+            }
+            keys { key(PK; "No.") { Clustered = true; } }
+        }
+        """);
+
+        // Fire counter lives in its OWN table, one row per key, incremented via Insert-then-
+        // Delete-if-exists (never Modify — Modify on the SAME row does not re-run
+        // OnAfterGetRecord, so accumulating there could not double-count even if the part
+        // fired twice; a fresh row per fire, keyed by an ever-growing counter, sidesteps that
+        // question entirely and just counts Insert calls).
+        File.WriteAllText(Path.Combine(root, "TplrFire.Table.al"), """
+        table 62529 "Tplr Fire"
+        {
+            DataClassification = CustomerContent;
+            fields
+            {
+                field(1; "Entry No."; Integer) { AutoIncrement = true; }
+                field(2; "No."; Code[20]) { }
+            }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(root, "TplrPart.Page.al"), """
+        page 62526 "Tplr Part"
+        {
+            PageType = CardPart;
+            SourceTable = "Tplr Row";
+            ApplicationArea = All;
+
+            layout
+            {
+                area(Content)
+                {
+                    field("No."; Rec."No.") { ApplicationArea = All; }
+                }
+            }
+
+            trigger OnAfterGetCurrRecord()
+            var
+                Fire: Record "Tplr Fire";
+            begin
+                Fire.Init();
+                Fire."No." := Rec."No.";
+                Fire.Insert(true);
+            end;
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(root, "TplrHost.Page.al"), """
+        page 62527 "Tplr Host"
+        {
+            PageType = Card;
+            SourceTable = "Tplr Row";
+            ApplicationArea = All;
+            UsageCategory = None;
+
+            layout
+            {
+                area(Content)
+                {
+                    field("No."; Rec."No.") { ApplicationArea = All; }
+                }
+                area(FactBoxes)
+                {
+                    part(TplrPart; "Tplr Part")
+                    {
+                        ApplicationArea = All;
+                        SubPageLink = "No." = field("No.");
+                    }
+                }
+            }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(root, "TplrTests.Codeunit.al"), """
+        codeunit 62528 "Tplr Tests"
+        {
+            Subtype = Test;
+
+            local procedure Initialize()
+            var
+                Row: Record "Tplr Row";
+                Fire: Record "Tplr Fire";
+            begin
+                Row.DeleteAll();
+                Fire.DeleteAll();
+            end;
+
+            local procedure SeedRow(No: Code[20]; Name: Text[50])
+            var
+                Row: Record "Tplr Row";
+            begin
+                Row.Init();
+                Row."No." := No;
+                Row.Name := Name;
+                Row.Insert();
+            end;
+
+            local procedure FireCountFor(No: Code[20]): Integer
+            var
+                Fire: Record "Tplr Fire";
+            begin
+                Fire.SetRange("No.", No);
+                exit(Fire.Count());
+            end;
+
+            // Positive: the part's OnAfterGetCurrRecord must have fired for the FIRST row,
+            // WITHOUT the test ever touching CurrPage.TplrPart/Host.TplrPart.
+            [Test]
+            procedure NoTouch_PartFiresOnOpenView()
+            var
+                Host: TestPage "Tplr Host";
+                FireCount: Integer;
+            begin
+                Initialize();
+                SeedRow('X', 'Alpha');
+
+                Host.OpenView();
+                Host.Close();
+
+                FireCount := FireCountFor('X');
+                if FireCount = 0 then
+                    Error('expected the part''s OnAfterGetCurrRecord to have fired at least once with nothing touching the part, got %1', FireCount);
+            end;
+
+            // Positive: GoToRecord to a DIFFERENT row must re-fire the part's own trigger for
+            // the new row, and must NOT fire again for the row just left.
+            [Test]
+            procedure GoToRecord_PartRefires()
+            var
+                Row2: Record "Tplr Row";
+                Host: TestPage "Tplr Host";
+                FireCountXAfterOpen: Integer;
+                FireCountYAfterGoTo: Integer;
+                FireCountXAfterGoTo: Integer;
+                PartNo: Code[20];
+            begin
+                Initialize();
+                SeedRow('X', 'Alpha');
+                SeedRow('Y', 'Bravo');
+                Row2.Get('Y');
+
+                Host.OpenView();
+                FireCountXAfterOpen := FireCountFor('X');
+                if not Host.GoToRecord(Row2) then
+                    Error('GoToRecord must find the seeded row Y');
+                PartNo := Host.TplrPart."No.".Value();
+                Host.Close();
+
+                FireCountYAfterGoTo := FireCountFor('Y');
+                FireCountXAfterGoTo := FireCountFor('X');
+
+                if FireCountXAfterOpen = 0 then
+                    Error('expected at least one fire for X after OpenView, got %1', FireCountXAfterOpen);
+                if FireCountYAfterGoTo = 0 then
+                    Error('expected the part to have fired for the NEW row Y after GoToRecord, got %1', FireCountYAfterGoTo);
+                if FireCountXAfterGoTo <> FireCountXAfterOpen then
+                    Error('expected the part to NOT re-fire for the row just left (X); before=%1 after=%2', FireCountXAfterOpen, FireCountXAfterGoTo);
+                if PartNo <> 'Y' then
+                    Error('expected the part''s control to reflect the NEW row Y, got %1', PartNo);
+            end;
+        }
+        """);
+
+        return root;
+    }
+
+    [SkippableFact]
+    public void NoTouch_PartFiresOnOpenView()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, exit) = RunRunner(WriteBundle());
+
+        Assert.True(exit == 0, $"Expected the bundle to pass; exit={exit}\n{output}");
+        Assert.Contains("PASS  Codeunit62528.NoTouch_PartFiresOnOpenView", output);
+        Assert.DoesNotContain("FAIL", output);
+    }
+
+    [SkippableFact]
+    public void GoToRecord_PartRefires()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, exit) = RunRunner(WriteBundle());
+
+        Assert.True(exit == 0, $"Expected the bundle to pass; exit={exit}\n{output}");
+        Assert.Contains("PASS  Codeunit62528.GoToRecord_PartRefires", output);
+        Assert.DoesNotContain("FAIL", output);
+    }
+}

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -360,6 +360,21 @@ internal class LiveNavTestPage : MockITestPage
         // earlier TestPage touch) already wrote through that same instance.
         if (!adopted) part.RaiseOnOpenPage();
 
+        // Position the part on its SubPageLink-matched row and run OnAfterGetRecord/
+        // OnAfterGetCurrRecord — issue #2677, measured against real BC (corpus PR
+        // StefanMaron/BusinessCentral.AL.Language.Tests#141): a linked part loads on EVERY
+        // GetPart touch this method reaches (see ReloadLinkedRow's doc comment for why this
+        // is deliberately NOT once-guarded — a GetPart touch normally happens only once per
+        // part per TestPage anyway, since the `_parts` cache at the top of this method
+        // short-circuits repeats; what actually keeps a linked part in sync across host
+        // navigation is <see cref="LiveNavTestPage.Loaded"/> calling this again on every
+        // parent row load — see that method).
+        //
+        // A recordless part (LiveRecordless branch) has no cursor — ReloadLinkedRow no-ops
+        // on a null Record — so its OnOpenPage (just raised, or raised inside AdoptFromHost)
+        // is the only trigger such a part gets, exactly as before.
+        part.ReloadLinkedRow();
+
         _parts[controlId] = part;
         return part;
     }
@@ -580,6 +595,39 @@ internal class LiveNavTestPage : MockITestPage
 
     /// <summary>Run the page's OnOpenPage — see RunnerTestPageState.MarkOpened.</summary>
     internal void RaiseOnOpenPage() => _page?.RaiseOnOpenPage();
+
+    /// <summary>
+    /// Reach every subpage PART this page declares, the way <see cref="RunnerTestPageState.MarkOpened"/>
+    /// calls it: right after the host's own OnOpenPage, before the host's first row is found.
+    /// Issue #2677, corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#141 — real BC
+    /// materialises a page's declared FactBoxes as part of opening, with nothing in the
+    /// host's own AL ever referencing <c>CurrPage.&lt;part&gt;</c>. <c>GetPart</c> raises the
+    /// part's OWN OnOpenPage and, via <c>ReloadLinkedRow</c>, attempts its initial row load —
+    /// which finds nothing yet (the host's own record is not positioned until MoveFirst runs
+    /// right after this returns), so the part's OnAfterGetRecord/OnAfterGetCurrRecord fires
+    /// for the first time from <see cref="Loaded"/>'s own refresh once the host DOES have a
+    /// row, not from here.
+    ///
+    /// Each control is isolated in its own try/catch: a part the runner cannot build (a
+    /// precompiled Base App page the runner has no metadata for, an unsupported shape) must
+    /// not prevent the HOST from opening, or every card carrying one unbuildable FactBox
+    /// would refuse OpenView entirely. An AL test that genuinely touches such a part still
+    /// gets the normal named refusal through <see cref="GetPart"/> — this only skips the
+    /// EAGER attempt, it does not swallow the refusal a real touch would raise.
+    /// </summary>
+    internal void EagerlyBuildParts()
+    {
+        if (_page == null) return;
+        foreach (var controlId in _page.AllPartControlIds())
+        {
+            try { GetPart(controlId); }
+            catch (Exception ex)
+            {
+                if (Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_PAGE_METADATA") == "1")
+                    Console.Out.WriteLine($"[MockTestPage.EagerlyBuildParts] control {controlId} on page {_pageId}: {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+    }
 
     public override bool IsOpened() => _opened;
 
@@ -1207,6 +1255,18 @@ internal class LiveNavTestPage : MockITestPage
     private bool _onNewRowLine;
     private string? _newRowLineReturnPosition;
 
+    // Set while FindRowFromTableFieldValues (GoToRecord's underlying mechanism) is scanning
+    // candidate rows one at a time via repeated MoveFirst/MoveNextDataRow calls — issue
+    // #2677. Each intermediate stop DOES run this page's own OnAfterGetRecord (matching real
+    // BC, measured: a GoToRecord that has to search fires the host's OnAfterGetCurrRecord for
+    // every row the scan lands on before the target). A linked subpage part's refresh must
+    // NOT piggyback on every one of those intermediate stops the same way — measured
+    // (corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#141): the part re-fires ONLY
+    // for the row the scan actually SETTLES on, never for a row merely passed through while
+    // searching. See Loaded's own guard and FindRowFromTableFieldValues's explicit refresh
+    // once a match is confirmed.
+    private bool _suppressPartRefreshDuringScan;
+
     /// <summary>
     /// Park the cursor on the new-row line: blank the record buffer so every control reads
     /// empty, having first saved the position of the data row being left.
@@ -1267,15 +1327,42 @@ internal class LiveNavTestPage : MockITestPage
     /// as BC does after every load. That trigger is where a page derives its per-row state
     /// (the variable behind <c>Editable = …</c>, <c>CurrPage.Editable(…)</c>), so skipping it
     /// froze every page at whatever state its first row left behind.
+    ///
+    /// <c>protected</c> (not <c>private</c>) so <see cref="LiveNavTestPart"/> can drive its
+    /// own SubPageLink-matched row through the identical path a top-level page's
+    /// MoveFirst/MoveNext/GoToBookmark already use — see issue #2677's
+    /// <c>ReloadLinkedRow</c>.
     /// </summary>
-    private bool Loaded(bool found)
+    protected bool Loaded(bool found)
     {
         if (found)
         {
             _page?.RaiseOnAfterGetRecord();
             SnapshotBeforeImage();
+            // Issue #2677: NOT during a FindRowFromTableFieldValues scan — see
+            // _suppressPartRefreshDuringScan's doc comment and that method's own explicit
+            // refresh once a match is confirmed.
+            if (!_suppressPartRefreshDuringScan)
+                RefreshLinkedParts();
         }
         return found;
+    }
+
+    /// <summary>
+    /// Refresh every linked subpage part to THIS page's current row — issue #2677, measured
+    /// on real BC (corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#141): a linked
+    /// subpage part (FactBox-style, SubPageLink to this page's key) refreshes to the NEW
+    /// current row every time this page's own row changes — GoToRecord on the host re-fires
+    /// the part's OnAfterGetRecord/OnAfterGetCurrRecord for the row just arrived at, and does
+    /// NOT re-fire it for the row just left. Only linked parts refresh here: an unlinked part
+    /// shows its own table's full rowset, independent of this page's current row, and BC's
+    /// own re-sync behaviour for that shape is unmeasured — see LiveNavTestPart.HasLinks.
+    /// </summary>
+    private void RefreshLinkedParts()
+    {
+        foreach (var part in _parts.Values)
+            if (part is LiveNavTestPart { HasLinks: true } linkedPart)
+                linkedPart.ReloadLinkedRow();
     }
 
     /// <summary>
@@ -1367,31 +1454,54 @@ internal class LiveNavTestPage : MockITestPage
         // row anywhere in the rowset. Starting at the current row silently failed to find
         // any row BEHIND the cursor, so navigating C -> A returned false even though A is
         // on the page (tests/runner-extras/testpage-gotorecord GoToRecord_MovesBetweenRows).
-        var hasRow = forward ? MoveFirst() : MoveLast();
-
-        while (hasRow)
+        //
+        // Issue #2677: the scan below runs Loaded(true) — and so this page's own
+        // OnAfterGetRecord — for every intermediate row it passes through before landing on
+        // the target, matching BC's own measured behaviour. A linked subpage part must NOT
+        // piggyback on those intermediate stops; _suppressPartRefreshDuringScan holds that
+        // off, and the one explicit RefreshLinkedParts() call below — once a match is
+        // confirmed, for that row only — is what a linked part actually re-fires for.
+        _suppressPartRefreshDuringScan = true;
+        try
         {
-            if (Matches(fieldNos, values)) return true;
-            // MoveNextDataRow, not MoveNext: a search wants rows that EXIST. Walking the
-            // scan onto the new-row line would let any request for an empty value "find"
-            // the blank line and report a row that is not in the table.
-            hasRow = forward ? MoveNextDataRow() : MovePrevious();
-        }
+            var hasRow = forward ? MoveFirst() : MoveLast();
 
-        if (originalKeyFieldNos != null)
-        {
-            // Re-find the original row by its own primary key, walking forward from the top
-            // exactly like the search above — this goes through a real MoveFirst/
-            // MoveNextDataRow load, refreshing every field (not just the key) from the row's
-            // own stored values, instead of a raw key-only ALSetPosition.
-            hasRow = MoveFirst();
             while (hasRow)
             {
-                if (Matches(originalKeyFieldNos, originalKeyValues!)) break;
-                hasRow = MoveNextDataRow();
+                if (Matches(fieldNos, values))
+                {
+                    _suppressPartRefreshDuringScan = false;
+                    RefreshLinkedParts();
+                    return true;
+                }
+                // MoveNextDataRow, not MoveNext: a search wants rows that EXIST. Walking the
+                // scan onto the new-row line would let any request for an empty value "find"
+                // the blank line and report a row that is not in the table.
+                hasRow = forward ? MoveNextDataRow() : MovePrevious();
             }
+
+            if (originalKeyFieldNos != null)
+            {
+                // Re-find the original row by its own primary key, walking forward from the
+                // top exactly like the search above — this goes through a real MoveFirst/
+                // MoveNextDataRow load, refreshing every field (not just the key) from the
+                // row's own stored values, instead of a raw key-only ALSetPosition. Still
+                // suppressed: this restores the SAME row the page (and its parts) were
+                // already showing before the failed search started, so there is nothing new
+                // for a linked part to refresh to.
+                hasRow = MoveFirst();
+                while (hasRow)
+                {
+                    if (Matches(originalKeyFieldNos, originalKeyValues!)) break;
+                    hasRow = MoveNextDataRow();
+                }
+            }
+            return false;
         }
-        return false;
+        finally
+        {
+            _suppressPartRefreshDuringScan = false;
+        }
     }
 
     // ITestFilter.SetFilter/GetFilter are handed a TABLE FIELD NUMBER, not a control id:
@@ -2404,6 +2514,58 @@ internal sealed class LiveNavTestPart : LiveNavTestPage, ITestPart
     public override bool MoveLast() { ApplyLink(); return base.MoveLast(); }
     public override bool MoveNext() { ApplyLink(); return base.MoveNext(); }
     public override bool MovePrevious() { ApplyLink(); return base.MovePrevious(); }
+
+    /// <summary>True when this part carries a FIELD SubPageLink at all — the signal
+    /// <see cref="LiveNavTestPage.Loaded"/> uses to decide whether a parent row-load should
+    /// refresh this part too (issue #2677). An unlinked part shows its own table's full
+    /// rowset and is never re-positioned by a parent's cursor move.</summary>
+    internal bool HasLinks => _links.Length > 0;
+
+    /// <summary>
+    /// Position this part on the row matching its SubPageLink and, if one exists, run its
+    /// OnAfterGetRecord/OnAfterGetCurrRecord — the row-load a real BC FactBox/subpage part
+    /// gets automatically, both when its host opens AND every time the host's own cursor
+    /// moves to a different row. Issue #2677, corpus PR
+    /// StefanMaron/BusinessCentral.AL.Language.Tests#141 (8 BC legs, OBS probes measuring a
+    /// SubPageLink-bound CardPart): with NOTHING ever touching <c>CurrPage.&lt;part&gt;</c> or
+    /// <c>TestPage.&lt;part&gt;</c>, opening the host alone produces
+    /// <c>HostOpen;PartOpen;HostAGCR;PartAGCR</c> — the part's OnOpenPage runs right after the
+    /// host's, and its OnAfterGetRecord/OnAfterGetCurrRecord runs right after the host's own,
+    /// entirely unprompted. A later touch adds nothing (already loaded). Navigating the HOST
+    /// to a different row (GoToRecord) re-fires the part's trigger for the NEW row and does
+    /// NOT re-fire it for the row just left. Before this fix nothing EVER positioned a part's
+    /// own cursor at all — <c>TestPageFactory.TryBuild</c> hands back a BLANK, unfetched
+    /// record, and only an explicit MoveXxx/GoToBookmark call on the PART ITSELF (which
+    /// nothing makes on its behalf) ever reached <see cref="LiveNavTestPage.Loaded"/> — so a
+    /// part whose entire per-row state comes from that trigger (the common FactBox-summary
+    /// shape) stayed at its field defaults for the page's whole life.
+    ///
+    /// Deliberately reuses <c>Loaded(bool)</c> rather than <c>MoveFirst()</c>: MoveFirst()
+    /// also flushes pending parts/rows and, on a not-found part, enters the insertable
+    /// new-row line (<c>EnterNewRowLine</c>) — state changes appropriate to an AL-driven
+    /// cursor move, not to a parent row simply becoming current. A part with no matching row
+    /// here shows empty, exactly as it did before this method existed; this only adds the
+    /// FOUND case BC already runs.
+    ///
+    /// NOT once-guarded: every call re-applies the link filter and re-finds, which is exactly
+    /// what makes a GoToRecord-driven refresh work. A repeat call for the SAME still-current
+    /// row (a second control read with no intervening parent move) re-runs
+    /// OnAfterGetRecord/OnAfterGetCurrRecord too — unmeasured against BC for that specific
+    /// case (probe 2 only read a control, which triggers a fresh <c>GetPart</c> lookup that
+    /// the `_parts` cache already short-circuits before reaching here at all, so it never
+    /// re-entered this method a second time for the SAME touch).
+    ///
+    /// A record-less part (<see cref="LiveNavTestPage.Record"/> null, the page-globals-only
+    /// CardPart shape from #2195) has no cursor to position and nothing here to do — its
+    /// OnOpenPage is the only trigger such a part gets.
+    /// </summary>
+    internal void ReloadLinkedRow()
+    {
+        if (Record is not { } record) return;
+        ApplyLink();
+        var found = record.ALFindFirstAsync(DataError.TrapError).GetAwaiter().GetResult();
+        Loaded(found);
+    }
 
     public override bool FindRowFromTableFieldValues(int[] fieldNos, object[] values, bool forward)
     {

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -933,6 +933,26 @@ internal sealed class RunnerPageInstance
         return null;
     }
 
+    /// <summary>
+    /// Every subpage PART control id this page declares — issue #2677's eager-build list.
+    /// Real BC materialises a page's declared parts (FactBoxes above all) as part of the
+    /// host opening, without the host's own AL ever referencing <c>CurrPage.&lt;part&gt;</c>
+    /// (corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#141, all 8 BC legs: with
+    /// nothing touching the part, opening the host alone still fires the part's own
+    /// OnOpenPage and OnAfterGetRecord/OnAfterGetCurrRecord). <see cref="TryGetPartDefinition"/>
+    /// answers "is THIS control a part"; this answers "what are ALL of them" so the caller
+    /// can eagerly reach every one the same way.
+    /// </summary>
+    internal IReadOnlyList<int> AllPartControlIds()
+    {
+        if (_form is not NavForm form) return Array.Empty<int>();
+        var ids = new List<int>();
+        foreach (var definition in form.MetadataHelper.InfoPartDefinitions)
+            if (definition is Microsoft.Dynamics.Nav.Types.Metadata.InfopartPageDefinition part)
+                ids.Add(part.ID);
+        return ids;
+    }
+
     /// <summary>BC's key convention for a control's source expression.</summary>
     internal static string SourceExpressionKey(int controlId) => "Control" + controlId;
 

--- a/AlRunner/Patches/RunnerTestPageState.cs
+++ b/AlRunner/Patches/RunnerTestPageState.cs
@@ -28,6 +28,7 @@
 //   after a Close works.
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using Microsoft.Dynamics.Nav.Types.Exceptions;
 
 namespace AlRunner.Patches;
 
@@ -67,6 +68,14 @@ public static class RunnerTestPageState
             // it is looking at — the singleton buffer it fetches or creates for the current
             // user, the filter it narrows to its caller's context.
             live.RaiseOnOpenPage();
+            // Issue #2677: reach every declared subpage PART eagerly, here — right after the
+            // host's own OnOpenPage, before the host's first row is found below. This is
+            // what makes a FactBox nobody's AL ever references still get its own OnOpenPage
+            // (and, once the host's row is found, its OnAfterGetRecord/OnAfterGetCurrRecord
+            // via LiveNavTestPage.Loaded's refresh) — matching corpus PR
+            // StefanMaron/BusinessCentral.AL.Language.Tests#141's measured order
+            // (HostOpen;PartOpen;HostAGCR;PartAGCR) on all 8 BC legs.
+            live.EagerlyBuildParts();
             if (viewMode == Microsoft.Dynamics.Nav.Types.Metadata.ViewMode.Create)
                 live.InsertEmptyRow(beforeCurrent: true);
             else if (live.Record != null && AlRunner.Patches.RunnerTestClientSession.IsUnpositioned(live.Record))
@@ -88,7 +97,20 @@ public static class RunnerTestPageState
                 // table's own first row.
                 live.MoveFirst();
         }
-        catch { /* a page that cannot be marked simply behaves as it did before */ }
+        // Issue #2677: EagerlyBuildParts + Loaded's own part-refresh can now run AL trigger
+        // code (a subpage part's OnAfterGetRecord/OnAfterGetCurrRecord, and whatever that
+        // enqueues) as part of MoveFirst — code that previously never ran this early, so a
+        // genuine AL error raised in it (NavBaseException, BC's own AL-error hierarchy —
+        // e.g. the read-only-session write refusal issue #2514/#2650 raises) never had a
+        // path to this catch before. A real AL error belongs on the caller's stack, exactly
+        // as it would be on a real service tier's Open() — swallowing it here would be
+        // precisely the silent-default `.claude/rules/loud-failures.md` forbids. Only a
+        // NON-NavBaseException (a runner-internal/reflection failure — the ORIGINAL reason
+        // this catch exists, per the type comment above) still means "a page that cannot be
+        // marked simply behaves as it did before".
+        catch (Exception ex) when (ex is not NavBaseException)
+        {
+        }
     }
 
     private static FieldInfo? FindTestPageField(Type type)


### PR DESCRIPTION
Closes #2677

A subpage part bound via SubPageLink to its host's current row (the FactBox/summary shape)
never got its own row positioned or its own OnAfterGetRecord/OnAfterGetCurrRecord run at
all: `TestPageFactory.TryBuild` hands `GetPart` a blank, unfetched record, and nothing ever
made an explicit MoveXxx/GoToBookmark call on the part's behalf.

## What was measured

Corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#141 (all 8 BC legs green), plus an
independently run local BC 28.4 onprem container:

- Opening the host ALONE -- nothing ever touches `CurrPage.<part>` or `TestPage.<part>` --
  already fires the part's `OnOpenPage` right after the host's own, and the part's own
  `OnAfterGetRecord`/`OnAfterGetCurrRecord` right after the host's own, for the row the host
  landed on. Order: `HostOpen < PartOpen < HostAGCR < PartAGCR`.
- A later touch of a control on the part reads the value the eager fire already computed --
  it does not compute anything new.
- `GoToRecord` to a different row on the host re-fires the part's own trigger for the NEW
  row, and does NOT re-fire it for the row just left.

## The fix

- `LiveNavTestPage.EagerlyBuildParts` reaches every declared part control right after the
  host's own `OnOpenPage`, before the host's first row is found
  (`RunnerTestPageState.MarkOpened`).
- `LiveNavTestPage.Loaded` refreshes every linked part in `_parts` on every subsequent host
  row load, via a new, deliberately un-guarded `LiveNavTestPart.ReloadLinkedRow` -- not
  once-guarded is what makes the `GoToRecord` refresh work.
- `FindRowFromTableFieldValues` (`GoToRecord`'s underlying search) suppresses that refresh
  for rows merely passed through while scanning, and fires it once, explicitly, for the row
  the scan actually lands on -- matching BC's measured "no re-fire for the row just left".
- `RunnerTestPageState.MarkOpened`'s catch-all is narrowed to `ex is not NavBaseException`:
  eager part materialisation can now run real AL trigger code (a subpage part's own workers,
  including the read-only-session write refusal issue #2514/#2650 raises) as part of
  `MoveFirst`, and a genuine AL error belongs on the caller's stack -- silently swallowing it
  is exactly what `.claude/rules/loud-failures.md` forbids.

## Lineage

Surfaced while investigating #2514/#2650's follow-up (closed by #2628): the theorised
write-refusal regression there did not reproduce -- confirmed by decompiling BC's own
unmodified `PageBackgroundChildSessionTask.RunTaskInChildSessionAsync` (sets and clears
`NavSession.PageBackgroundTask` in its own try/finally, so the marker cannot leak) and by 8
write-after-PBT arms all passing locally against current `main`. This FactBox-part gap is a
more plausible root cause for a project's "FactBox usage counts stay blank" symptom than the
refuted marker theory.

## Corpus pin

Not bumped in this PR: corpus PR #141 (proving test) is green on all 8 legs but not yet
merged upstream -- a pin bump can't be its own PR and would be red by construction until
that merges (`.claude/rules/al-language-submodule.md`). This PR carries a runner-mechanism
test instead (`AlRunner.Tests/TestPagePartLinkedRowLoadTests.cs`), proving the SAME
mechanism without depending on the pin having moved. Once #141 merges, a follow-up PR bumps
the pin, adds the count-baseline update, and shows corpus codeunit 60815 going green against
this fix.

## Tests

- `AlRunner.Tests/TestPagePartLinkedRowLoadTests.cs` -- new, 2 tests, RED against
  `2c2e4833` (pre-fix), GREEN after.
- Full corpus (2441 tests) and `tests/runner-extras` (219 tests): unchanged, all pass.
- Targeted regression sweep (`LiveNavTestPartRecordlessTests`,
  `TestPageExtensionActionWithPartDispatchTests`, `TestPagePartAdoptedFromHostTests`,
  `DependencyPageMetadataXmlTests`, `PageBackgroundTaskInlineTests`,
  `TestPagePartLinkedRowLoadTests`): 24/24 pass.