### PR TITLE
fix(deps): let a source-built package supersede a packaged copy of the same app

### DIFF
--- a/AlRunner.Tests/DependencyResolverTests.cs
+++ b/AlRunner.Tests/DependencyResolverTests.cs
@@ -889,4 +889,115 @@ public sealed class DependencyResolverTests : IDisposable
         Assert.Single(result);
         Assert.Equal("Lib_v28_sym.app", Path.GetFileName(result[0].AppPath));
     }
+
+    // ── Part N+1: a source-built package supersedes a packaged copy of the same app ──
+    //
+    // Root cause (#2688): when a bundle passed on the command line provides an app that a
+    // package cache ALSO ships compiled, SiblingCompile correctly notices the packaged copy
+    // is stale and rebuilds from source into a workspace dir, then prepends that dir to the
+    // caches — its own comment says this makes the source build "win over a stale cached
+    // .app". It does not. SelectBestVersion ranks on executability then version and ignores
+    // directory order entirely, so the packaged copy (a real BC artifact carries a full
+    // four-part build number, e.g. 28.4.53241.53989) outranks the source build's app.json
+    // version (28.4.0.0) every time. Both copies then load under one app id and the run dies
+    // on AppIdCollisionException.
+    //
+    // Measured against microsoft/BCApps releases/28.4: `System Application Test Library`
+    // declares GetLastContextInfoRequestUri in source, the shipped 28.4.53241.53989 .app
+    // predates it, and SharePointClientTest.Codeunit drops out with three AL0132 errors —
+    // a branch head is never the same commit as a cut artifact, so this is the normal case,
+    // not an edge case.
+
+    /// <summary>
+    /// Same AppId in two dirs: a source-built package at the app.json version (28.4.0.0)
+    /// and a packaged copy at a higher artifact build (28.4.53241.53989). With the source
+    /// dir declared as source-superseding, the resolver must bind to the SOURCE build even
+    /// though it loses on version.
+    /// </summary>
+    [Fact]
+    public void SourceBuiltPackage_Wins_OverHigherVersionedPackagedCopy()
+    {
+        var appId = "dddddddd-0000-0000-0000-000000000001";
+        var artifactDir = MakeDir("artifact-test-apps");
+        var sourceDir = MakeDir("workspace-deps");
+
+        WriteApp(artifactDir, "Microsoft_System Application Test Library.app", appId,
+            "System Application Test Library", "Microsoft", "28.4.53241.53989");
+        WriteApp(sourceDir, "Microsoft_System_Application_Test_Library_28_4_0_0.app", appId,
+            "System Application Test Library", "Microsoft", "28.4.0.0");
+
+        var resolver = new DependencyResolver(
+            new[] { artifactDir, sourceDir },
+            sourceSupersedingDirs: new[] { sourceDir });
+        var dep = new DependencyRef(Guid.Parse(appId), "System Application Test Library",
+            "Microsoft", new Version(28, 4, 0, 0));
+
+        var result = resolver.Resolve(new[] { dep });
+
+        Assert.Single(result);
+        Assert.Equal("28.4.0.0", result[0].Manifest.Version.ToString());
+        Assert.Equal(sourceDir, Path.GetDirectoryName(result[0].AppPath));
+    }
+
+    /// <summary>
+    /// Negative: declaring a source-superseding dir must not change resolution for an app
+    /// that dir does NOT provide. Without this, the fix could degrade into "the first dir
+    /// always wins", silently undoing the highest-satisfying-version contract every other
+    /// test in this file pins.
+    /// </summary>
+    [Fact]
+    public void SourceSupersedingDir_LeavesOtherAppsOnHighestVersion()
+    {
+        var otherId = "dddddddd-0000-0000-0000-000000000002";
+        var providedId = "dddddddd-0000-0000-0000-000000000003";
+        var cacheDir = MakeDir("cache-untouched");
+        var sourceDir = MakeDir("workspace-untouched");
+
+        // The source dir provides ONE app, and it is not the one being resolved.
+        WriteApp(sourceDir, "Provided_1_0_0_0.app", providedId, "Provided", "Microsoft", "1.0.0.0");
+        WriteApp(cacheDir, "Other_v17.app", otherId, "Other", "Microsoft", "17.0.0.0");
+        WriteApp(cacheDir, "Other_v28.app", otherId, "Other", "Microsoft", "28.4.53241.53989");
+
+        var resolver = new DependencyResolver(
+            new[] { sourceDir, cacheDir },
+            sourceSupersedingDirs: new[] { sourceDir });
+        var dep = new DependencyRef(Guid.Parse(otherId), "Other", "Microsoft",
+            new Version(17, 0, 0, 0));
+
+        var result = resolver.Resolve(new[] { dep });
+
+        Assert.Single(result);
+        Assert.Equal("28.4.53241.53989", result[0].Manifest.Version.ToString());
+    }
+
+    /// <summary>
+    /// Negative: a Microsoft PLATFORM app is deliberately exempt. Those ship one package per
+    /// exact BC build and their real runtime lives in the extracted service-tier DLLs, so the
+    /// engine-matching R2R artifact must keep winning — that is issue #2251, whose corpus
+    /// incident PlatformApp_BelowMinimumR2R_Beats_AboveMinimumSymbolOnly pins. Superseding
+    /// those from source would hand every codeunit in them to a package that cannot execute.
+    /// </summary>
+    [Fact]
+    public void SourceBuiltPlatformApp_DoesNotSupersede_TheEngineMatchingR2RArtifact()
+    {
+        var appId = "dddddddd-0000-0000-0000-000000000004";
+        var artifactDir = MakeDir("platform-artifact");
+        var sourceDir = MakeDir("platform-source");
+
+        WriteApp(artifactDir, "Microsoft_System Application.app", appId,
+            "System Application", "Microsoft", "28.4.53241.53989", r2r: true);
+        WriteApp(sourceDir, "Microsoft_System_Application_28_4_0_0.app", appId,
+            "System Application", "Microsoft", "28.4.0.0", r2r: false);
+
+        var resolver = new DependencyResolver(
+            new[] { sourceDir, artifactDir },
+            sourceSupersedingDirs: new[] { sourceDir });
+        var dep = new DependencyRef(Guid.Parse(appId), "System Application", "Microsoft",
+            new Version(28, 4, 0, 0));
+
+        var result = resolver.Resolve(new[] { dep });
+
+        Assert.Single(result);
+        Assert.Equal("28.4.53241.53989", result[0].Manifest.Version.ToString());
+    }
 }

--- a/AlRunner/DependencyResolver.cs
+++ b/AlRunner/DependencyResolver.cs
@@ -50,9 +50,22 @@ public sealed class DependencyResolver
     /// </summary>
     public IReadOnlyList<string> UnservableDependencies => _unservable;
 
+    // Dirs holding packages this run built FROM SOURCE (SiblingCompile's synthesized
+    // workspace dirs). A candidate under one of these outranks any packaged copy of the
+    // same app — see FromSource in SelectBestVersion for why version cannot decide it.
+    private readonly IReadOnlyList<string> _sourceSupersedingDirs;
+
     public DependencyResolver(IReadOnlyList<string> cacheDirs)
+        : this(cacheDirs, Array.Empty<string>())
+    {
+    }
+
+    public DependencyResolver(
+        IReadOnlyList<string> cacheDirs,
+        IReadOnlyList<string> sourceSupersedingDirs)
     {
         _cacheDirs = cacheDirs;
+        _sourceSupersedingDirs = sourceSupersedingDirs;
     }
 
     /// <summary>
@@ -236,6 +249,37 @@ public sealed class DependencyResolver
         var isPlatformApp = IsMicrosoftPlatformApp(dep.Name, dep.Publisher);
         (AppManifest Manifest, string Path) bestExecutableAnyVersion = default;
 
+        // A package this run built FROM SOURCE outranks a packaged copy of the same app —
+        // above executability, above version (#2688). Version cannot decide it and directory
+        // order does not either: a real BC artifact ships a four-part build number
+        // (28.4.53241.53989) while a source build carries its app.json version (28.4.0.0), so
+        // the artifact wins on version every time no matter which dir was scanned first.
+        // SiblingCompile only puts a package here after PrebuiltShadowCheck has ruled the
+        // packaged copy STALE against that same source, so by the time a candidate is in one
+        // of these dirs the question "which of these two is current" is already settled — and
+        // settled on CONTENT, not on the version string or an mtime.
+        //
+        // Microsoft PLATFORM apps are exempt. Those ship one package per exact BC build and
+        // their procedure bodies are external/native, implemented by the extracted
+        // service-tier DLLs rather than by the AL they ship; superseding one from source hands
+        // every codeunit in it to a package that cannot execute, which is the #2251 corpus
+        // incident PlatformApp_BelowMinimumR2R_Beats_AboveMinimumSymbolOnly pins. Running
+        // Microsoft's own platform-app SOURCE (microsoft/BCApps src/System Application/App)
+        // as the live implementation is a separate question this ranking deliberately does not
+        // answer — see SourceBuiltPlatformApp_DoesNotSupersede_TheEngineMatchingR2RArtifact.
+        bool FromSource(string path)
+        {
+            if (isPlatformApp || _sourceSupersedingDirs.Count == 0) return false;
+            var full = Path.GetFullPath(path);
+            foreach (var d in _sourceSupersedingDirs)
+            {
+                var dir = Path.GetFullPath(d).TrimEnd(Path.DirectorySeparatorChar);
+                if (full.StartsWith(dir + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+                    return true;
+            }
+            return false;
+        }
+
         foreach (var c in candidates)
         {
             if (isPlatformApp && Executable(c.Path)
@@ -246,6 +290,13 @@ public sealed class DependencyResolver
 
             if (c.Manifest.Version < dep.Version) continue;
             if (best.Manifest == null) { best = c; continue; }
+
+            var candidateFromSource = FromSource(c.Path);
+            if (candidateFromSource != FromSource(best.Path))
+            {
+                if (candidateFromSource) best = c;
+                continue;
+            }
 
             var candidateExecutable = Executable(c.Path);
             if (candidateExecutable != Executable(best.Path))

--- a/AlRunner/Infrastructure/CacheRoots.cs
+++ b/AlRunner/Infrastructure/CacheRoots.cs
@@ -159,4 +159,17 @@ public static class CacheRoots
         _override = null;
         _throwawayRoot = null;
     }
+
+    /// <summary>
+    /// The roots under which this run writes packages it built FROM SOURCE — SiblingCompile's
+    /// synthesized workspace dirs (both <c>RunLayeredPrePass</c> and
+    /// <c>BuildSiblingSourceDeps</c> write under "workspace-deps"). Handed to
+    /// <see cref="AlRunner.DependencyResolver"/> so a source build outranks a packaged copy of
+    /// the same app instead of losing to it on version (#2688). A root rather than the
+    /// per-request list of dirs: the resolver matches by path prefix, and a per-request list
+    /// leaves a PRIOR request's dirs unmarked in a warm --server/--watch session, which is the
+    /// same scoping mistake Program.cs's selectionEnvironmentKey comment records.
+    /// </summary>
+    public static IReadOnlyList<string> SourceBuiltPackageDirs()
+        => new[] { Resolve("workspace-deps") };
 }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2054,7 +2054,7 @@ foreach (var bundle in bundles)
                     bundlePkgDirs = AlRunner.Infrastructure.SafeDirectoryScan.Directories(depRootDir, ".alpackages")
                         .ToList();
                 var resolverDirs = bundlePkgDirs.Concat(packageCacheDirs).Distinct().ToList();
-                var resolver = new DependencyResolver(resolverDirs);
+                var resolver = new DependencyResolver(resolverDirs, AlRunner.Infrastructure.CacheRoots.SourceBuiltPackageDirs());
                 IReadOnlyList<(AlRunner.AppManifest Manifest, string AppPath)> ordered;
                 using (AlRunner.Infrastructure.PhaseLog.Stage("dep-resolve"))
                     ordered = resolver.Resolve(roots);
@@ -4029,7 +4029,7 @@ return strictExitCode ? computedExitCode : 0;
                 var bundlePkgDirs = AlRunner.Infrastructure.SafeDirectoryScan.Directories(bucketRoot, ".alpackages")
                     .ToList();
                 var resolverDirs = bundlePkgDirs.Concat(effectivePkgDirs).Distinct().ToList();
-                var resolver = new DependencyResolver(resolverDirs);
+                var resolver = new DependencyResolver(resolverDirs, AlRunner.Infrastructure.CacheRoots.SourceBuiltPackageDirs());
                 ordered = resolver.Resolve(roots);
                 AlRunner.Infrastructure.PhaseLog.NoteDepsResolved(ordered.Count);
                 BcCompiler.SetResolvedDeps(ordered, resolverDirs);

--- a/AlRunner/ProgramSupport/SiblingCompile.cs
+++ b/AlRunner/ProgramSupport/SiblingCompile.cs
@@ -538,7 +538,7 @@ internal static partial class ProgramSupport
                         .Concat(implAlpackagesDirs)
                         .Distinct(StringComparer.OrdinalIgnoreCase)
                         .ToList();
-                    var implResolver = new DependencyResolver(implResolveDirs);
+                    var implResolver = new DependencyResolver(implResolveDirs, AlRunner.Infrastructure.CacheRoots.SourceBuiltPackageDirs());
                     var implDeps = implResolver.Resolve(implId.Dependencies);
                     BcCompiler.SetResolvedDeps(implDeps, implSymbolDirs);
                     // AFTER SetResolvedDeps, which resets _extraSymbolDirs. Passing an empty
@@ -847,7 +847,7 @@ internal static partial class ProgramSupport
                 .Concat(priorDepDirs)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();
-            var depResolver = new DependencyResolver(depResolveDirs);
+            var depResolver = new DependencyResolver(depResolveDirs, AlRunner.Infrastructure.CacheRoots.SourceBuiltPackageDirs());
             var resolvedDepDeps = depResolver.Resolve(sid.Dependencies);
             BcCompiler.SetResolvedDeps(resolvedDepDeps, resolveDirs);
             // AFTER SetResolvedDeps, which resets _extraSymbolDirs.


### PR DESCRIPTION
Closes #2688

## Problem

`SiblingCompile` already detects that a packaged `.app` is STALE against the source bundle it
was asked to run, rebuilds it from source into a workspace dir, and prepends that dir to the
package caches. Its own comment says this makes the source build "win over a stale cached
`.app`".

It did not. `SelectBestVersion` ranks candidates on executability, then version, and ignores
directory order entirely. A BC artifact carries a four-part build number
(`28.4.53241.53989`); a source build carries its `app.json` version (`28.4.0.0`). The artifact
therefore won on version every time, no matter which dir was scanned first. Both copies then
loaded under one app id and the run aborted:

```
FATAL: duplicate app id 9856ae4f-d1a7-46ef-89bb-6ef056398228:
  v28.4.0.0          (bcapps/src/System Application/Test Library)   <- built from source
  v28.4.53241.53989  (artifacts/.../test-apps/...app)               <- shipped in the artifact
```

## Fix

Rank a candidate built from source above executability and above version. That follows the
precedent immediately above it in the same function, where executability was promoted over
version for the same class of reason: version is not the question being asked.

The signal is the `workspace-deps` cache root rather than a per-request list of dirs. Both
`RunLayeredPrePass` and `BuildSiblingSourceDeps` write under it, and a per-request list would
leave a *prior* request's dirs unmarked in a warm `--server`/`--watch` session — the same
scoping mistake `Program.cs`'s own `selectionEnvironmentKey` comment records having made once.

By the time a package is in one of those dirs, `PrebuiltShadowCheck` has already ruled the
packaged copy stale **on content**, so "which of these two is current" is settled before this
ranking runs.

**Microsoft platform apps are exempt.** They ship one package per exact BC build and their
procedure bodies are external, implemented by the extracted service-tier DLLs rather than by
the AL they ship. Superseding one from source would hand every codeunit in it to a package
that cannot execute — the #2251 corpus incident. Running Microsoft's own platform-app source
as the live implementation is a separate question this deliberately does not answer.

## Tests

RED → GREEN on `SourceBuiltPackage_Wins_OverHigherVersionedPackagedCopy`: before the fix it
failed with `Expected: "28.4.0.0" / Actual: "28.4.53241.53989"` — the defect exactly.

Two negative controls, both of which already passed before the fix and still pass, so they pin
what must NOT change:

- `SourceSupersedingDir_LeavesOtherAppsOnHighestVersion` — declaring a source dir must not
  degrade into "the first dir always wins", which would silently undo the
  highest-satisfying-version contract the rest of this file exists to pin.
- `SourceBuiltPlatformApp_DoesNotSupersede_TheEngineMatchingR2RArtifact` — the #2251 exemption.

Targeted suites green: `DependencyResolverTests`, `LayeredSourceChainTests`,
`AppIdCollisionLoudFailureTests` — 42/42.

## End-to-end

The command from the issue, against a `microsoft/BCApps` `releases/28.4` clone with the engine
built for `28.4.53241.53989`:

| | before | after |
|---|---|---|
| outcome | `FATAL: duplicate app id` | ran |
| compile-fail | 1 | **0** |
| tests run | **0** | **1915** (1288 pass / 617 fail / 10 error) |
| wall | — | 127 s |

`SharePointClientTest.Codeunit` no longer drops out, so the `EMIT-EXCLUDED` line is gone too.

The 617 failures are not this PR's subject — they are the first honest measurement of
Microsoft's System Application test suite through the runner, and what a follow-up scoreboard
would track. Nothing about them is asserted here.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
