### PR TITLE
fix(testpage): format Decimal-typed TestPage controls with decimal places

### DIFF
--- a/AlRunner.Tests/TestPageSourceTableTemporaryIntegerTests.cs
+++ b/AlRunner.Tests/TestPageSourceTableTemporaryIntegerTests.cs
@@ -171,8 +171,8 @@ public sealed class TestPageSourceTableTemporaryIntegerTests : IDisposable
                     Error('part must have rows after its own OnOpenPage runs');
                 if Part.Number.Value() <> '1' then
                     Error('first row Number expected 1, got %1', Part.Number.Value());
-                if Part.ValueAtNumber.Value() <> '10' then
-                    Error('first row Values[Number] expected 10, got %1', Part.ValueAtNumber.Value());
+                if Part.ValueAtNumber.Value() <> '10.00' then
+                    Error('first row Values[Number] expected 10.00, got %1', Part.ValueAtNumber.Value());
                 Part.Close();
             end;
         }

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -1915,6 +1915,39 @@ internal static class TestPageMinMaxValue
     }
 }
 
+/// <summary>
+/// A Decimal-typed control always renders with the field's decimal places -- default 2,
+/// the same convention #2490 measured against real BC and <see cref="TestPageMinMaxValue.FormatValue"/>
+/// already codifies for the error-message text -- regardless of how many decimal digits the
+/// underlying .NET <c>decimal</c>'s own <c>Scale</c> happens to carry (issues #2634 / #2534).
+///
+/// A record field reaches its stored value through <see cref="Microsoft.Dynamics.Nav.Runtime.NavRecord"/>'s
+/// own Validate/Insert path, which is BC's own precompiled code and out of this runner's
+/// control -- so a Rec-bound Decimal control can format correctly today by construction, if
+/// BC's own write path already normalises the stored scale. A page-GLOBAL <c>Decimal</c>
+/// (<c>Values: array[20] of Decimal;</c>) gets no such round trip at all: a plain assignment
+/// like <c>Values[i] := i * 10;</c> stores a .NET decimal with Scale 0, and
+/// <c>Convert.ToString(10m)</c> answers "10" where real BC's page layer answers "10.00". Both
+/// <see cref="LiveNavTestField.Value"/> and <see cref="PageVariableTestField.Value"/> read
+/// through this helper so neither binding shape can silently regress relative to the other --
+/// exactly the LiveNavTestField/PageVariableTestField pairing pattern <see cref="TestPageBooleanValue"/>
+/// and <see cref="TestPageOptionValue"/> already use.
+///
+/// Only <see cref="NavDecimal"/> needs special handling: <see cref="NavInteger"/> and
+/// <see cref="NavBigInteger"/> already round-trip correctly through
+/// <c>Convert.ToString</c> because an integral CLR type never carries a fractional Scale to
+/// lose in the first place -- matching the "0" (no decimals) half of
+/// <see cref="TestPageMinMaxValue.FormatValue"/>'s own convention without any code needed here.
+/// </summary>
+internal static class TestPageNumericValue
+{
+    internal static string? Format(NavValue? navValue)
+        => navValue is NavDecimal d
+            ? Convert.ToDecimal(d.ClientObject, CultureInfo.InvariantCulture)
+                .ToString("0.00", CultureInfo.InvariantCulture)
+            : null;
+}
+
 internal static class TestPageBooleanValue
 {
     internal static NavValue Resolve(string value, string context)
@@ -2000,6 +2033,7 @@ internal sealed class LiveNavTestField : ITestField
         get => (CurrentOption() is { } option
                    ? TestPageOptionValue.Display(option, OptionCaptions())
                    : null)
+               ?? TestPageNumericValue.Format(_record.GetFieldValue(_fieldNo) as NavValue)
                ?? Convert.ToString(ObjectValue, CultureInfo.InvariantCulture)
                ?? string.Empty;
         set
@@ -2201,6 +2235,7 @@ internal sealed class PageVariableTestField : ITestField
         get => (CurrentOption() is { } option
                    ? TestPageOptionValue.Display(option, _page.TryGetOptionCaptions(_controlId, option))
                    : null)
+               ?? TestPageNumericValue.Format(RunnerPageInstance.GetValue(_expression))
                ?? Convert.ToString(ObjectValue, CultureInfo.InvariantCulture)
                ?? string.Empty;
         set
@@ -2275,6 +2310,13 @@ internal sealed class PageVariableTestField : ITestField
         NavBoolean => NavType.Boolean,
         NavCode => NavType.Code,
         NavDate => NavType.Date,
+        // #2634/#2534's fix: a Decimal-typed page-global control has to answer NavType.Decimal
+        // here too, the same as an Option/Boolean/Code/Date global already does above -- this
+        // FieldType is what NavTestField.ALSetValue (BC's own precompiled dispatch) uses to pick
+        // a NavValueMetadata before round-tripping through ValueToString, so leaving Decimal out
+        // would have kept a Decimal-typed page variable dispatching as plain Text on the WRITE
+        // side even after the READ side (Value, above) started formatting it correctly.
+        NavDecimal => NavType.Decimal,
         _ => NavType.Text,
     };
     public int ValidationErrorCount => 0;

--- a/tests/expectations/known-gaps-testpage-part-instance-pin-bump.json
+++ b/tests/expectations/known-gaps-testpage-part-instance-pin-bump.json
@@ -1,13 +1,5 @@
 [
   {
-    "codeunitId": 60624,
-    "CodeunitName": "Test TmpInt ListPart",
-    "Method": "TempIntegerPart_SelfLoaded_FirstRowIsNumberOne",
-    "Mode": "expect-fail-known-gap",
-    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2634",
-    "Note": "Surfaced by the al-language pin bump landing alongside issue #2201's fix (StefanMaron/BusinessCentral.AL.Language.Tests commit 3661f1d, #121) -- unrelated to #2201's own claim. Real BC formats the Integer virtual table's Number field as '10.00' on the first row of a self-loaded SourceTable Integer ListPart; the runner answers '10'. Not investigated further; tracked as #2634."
-  },
-  {
     "codeunitId": 60958,
     "CodeunitName": "Test Feature Key Table",
     "Method": "Record_FeatureKey_ModifyingAReadOnlyColumn_RaisesNamingTheField",


### PR DESCRIPTION
Closes #2634
Closes #2534

A TestPage control bound to a Decimal-typed expression rendered its raw .NET
`decimal` Scale instead of BC's own display convention (2 decimal places by
default). `Values[i] := i * 10;` on a page-global `array[20] of Decimal`
stored a .NET decimal with Scale 0, so `Convert.ToString` answered "10"
where real BC's page layer answers "10.00".

Both #2634 and #2534 describe the exact same page-global-array-bound Decimal
repro shape (`Values[Rec.Number]` on `array[20] of Decimal`) and the exact
same failing assertion (`Expected:<10.00>. Actual:<10>.`), so one fix and one
PR closes both.

`AlRunner/Patches/MockTestPage.cs`:
- Adds `TestPageNumericValue.Format`, a shared helper checking whether the
  raw `NavValue` is a `NavDecimal` and, if so, formatting it fixed to two
  decimal places — the same convention `TestPageMinMaxValue.FormatValue`
  already established for the error-message text path (#2490).
- Wires it into both `LiveNavTestField.Value` (record-bound controls) and
  `PageVariableTestField.Value` (page-global-bound controls) so neither
  binding shape can silently regress relative to the other — matching the
  existing pairing pattern `TestPageBooleanValue`/`TestPageOptionValue`
  already use for their own shapes.
- Teaches `PageVariableTestField.FieldType` to answer `NavType.Decimal` for
  a Decimal-bound page variable (it previously fell through to `NavType.Text`
  for every non-Option/Boolean/Code/Date global), so `SetValue` on a Decimal
  page-global control dispatches correctly too, not just `Value()`.

## Fix the shape, not just the reported line

- **Same wrong pattern at another call site?** Yes — `LiveNavTestField.Value`
  (record-bound controls) had the identical `Convert.ToString(ObjectValue)`
  gap; fixed alongside the page-variable path via the shared helper rather
  than only touching the one the corpus test exercises.
- **Sibling function, same assumption?** `PageVariableTestField.FieldType`
  made the same blind assumption (no `NavDecimal` case), which would have
  kept a Decimal-bound page-global control dispatching a `SetValue` write as
  plain Text even after reads started formatting correctly — fixed in the
  same commit.
- **Two paths, same invariant?** Yes — `Integer`/`BigInteger` values need no
  change (an integral CLR type carries no fractional Scale to lose), which
  keeps `TestPageMinMaxValue.FormatValue`'s existing "0 decimals for
  Integer/BigInteger, 2 for Decimal" convention consistent across both the
  error-message path and this read path instead of diverging.

## Testing

- **RED**: pre-fix commit (`aa2d0643`), running the corpus test in isolation
  via `--test TempIntegerPart_SelfLoaded_FirstRowIsNumberOne` against
  `tests/al-language` classifies as `pass-known-gap` (1 total, 1
  pass-known-gap) — i.e. it genuinely fails and only counts as a pass because
  of the `tests/expectations/known-gaps-testpage-part-instance-pin-bump.json`
  entry this PR deletes.
- **GREEN**: same test at this PR's head — `1P/0F/0E`, plain `pass`, no
  known-gap entry needed.
- **`AlRunner.Tests --filter FullyQualifiedName~TestPage`**: 67 passed, 0
  failed. One pre-existing mechanism test
  (`TestPageSourceTableTemporaryIntegerTests`) had encoded the pre-fix bug
  ("10") as its expected value; corrected to "10.00" to match the
  now-fixed, real-BC-verified behavior, in the same PR (not a separate
  cleanup — the test would otherwise flip to red the moment this fix
  landed).

No new corpus test needed — the corpus test proving this (`TestTempIntegerListPart.al`,
`StefanMaron/BusinessCentral.AL.Language.Tests`, merged upstream) already covers the
exact page-global-Decimal-array shape both issues describe.