### PR TITLE
fix(diagnostics): unwrap TargetInvocationException so EXEC-FAIL names the real cause

### DIFF
--- a/AlRunner.Tests/ExecFailureTests.cs
+++ b/AlRunner.Tests/ExecFailureTests.cs
@@ -106,4 +106,65 @@ public sealed class ExecFailureTests
         Assert.Equal("App: EXEC-FAIL: Unable to load.", line);
         Assert.DoesNotContain("—", line, StringComparison.Ordinal);
     }
+
+    // ── TargetInvocationException: the wrapper that names nothing ──────────────
+    //
+    // Reflection-invoked test entry points surface every failure as
+    // TargetInvocationException, whose own message is the fixed string "Exception has been
+    // thrown by the target of an invocation." — it names no app, no API and no cause, and the
+    // real exception is on InnerException. Describe unwrapped ReflectionTypeLoadException for
+    // exactly this reason and stopped there, so a whole bucket could report one useless line.
+    //
+    // Measured on Microsoft's Tests-SINGLESERVER bucket (BC 28.1): the entire bucket's only
+    // diagnostic was "Tests-SINGLESERVER: EXEC-FAIL: Exception has been thrown by the target of
+    // an invocation.", with nothing more under --verbose.
+
+    /// <summary>The wrapper's fixed message must be replaced by the inner cause, not printed.</summary>
+    [Fact]
+    public void Describe_UnwrapsTargetInvocationException_AndReportsTheRealCause()
+    {
+        var line = ExecFailure.Describe("Tests-SINGLESERVER",
+            new TargetInvocationException(new InvalidOperationException("Company 'CRONUS' does not exist")));
+
+        Assert.Equal("Tests-SINGLESERVER: EXEC-FAIL: Company 'CRONUS' does not exist", line);
+        Assert.DoesNotContain("target of an invocation", line, StringComparison.Ordinal);
+    }
+
+    /// <summary>Nested wrappers unwrap all the way down — reflection over reflection is common
+    /// on the test-invocation path, and stopping at the first level just prints a second
+    /// wrapper's equally contentless message.</summary>
+    [Fact]
+    public void Describe_UnwrapsNestedTargetInvocationExceptions()
+    {
+        var line = ExecFailure.Describe("App",
+            new TargetInvocationException(new TargetInvocationException(new DivideByZeroException("real cause"))));
+
+        Assert.Equal("App: EXEC-FAIL: real cause", line);
+    }
+
+    /// <summary>Negative: a TargetInvocationException with NO inner exception has nothing better
+    /// to say, so its own message must still be reported rather than producing an empty line.</summary>
+    [Fact]
+    public void Describe_KeepsTheWrapperMessage_WhenThereIsNoInnerException()
+    {
+        var line = ExecFailure.Describe("App", new TargetInvocationException(null));
+
+        Assert.StartsWith("App: EXEC-FAIL: ", line, StringComparison.Ordinal);
+        Assert.True(line.Length > "App: EXEC-FAIL: ".Length, "the line must still carry a message");
+    }
+
+    /// <summary>Negative: unwrapping must not lose the ReflectionTypeLoadException handling that
+    /// already worked — a RTLE reached THROUGH a TargetInvocationException must still have its
+    /// LoaderExceptions quoted, which is the whole diagnosis in that case.</summary>
+    [Fact]
+    public void Describe_StillQuotesLoaderExceptions_WhenReachedThroughATargetInvocationException()
+    {
+        var rtle = new ReflectionTypeLoadException(
+            new Type[] { null! },
+            new Exception?[] { new FileNotFoundException("Contoso.Dep.dll not found") });
+
+        var line = ExecFailure.Describe("App", new TargetInvocationException(rtle));
+
+        Assert.Contains("Contoso.Dep.dll not found", line, StringComparison.Ordinal);
+    }
 }

--- a/AlRunner/Infrastructure/ExecFailure.cs
+++ b/AlRunner/Infrastructure/ExecFailure.cs
@@ -19,6 +19,28 @@ namespace AlRunner.Infrastructure;
 
 internal static class ExecFailure
 {
+    /// <summary>
+    /// Strip TargetInvocationException wrappers. Every test entry point is reached by
+    /// reflection, so any failure inside one arrives wrapped, and the wrapper's message is the
+    /// fixed, contentless string "Exception has been thrown by the target of an invocation." —
+    /// it names no app, no API and no cause. Reporting that discards the only diagnosis there
+    /// is: measured on Microsoft's Tests-SINGLESERVER bucket, the bucket's entire output was
+    /// that one sentence, unchanged by --verbose.
+    ///
+    /// Loops, because reflection over reflection is ordinary on this path and stopping at the
+    /// first level just prints a second wrapper's equally contentless message. A wrapper with
+    /// no InnerException keeps its own message rather than producing an empty line.
+    ///
+    /// Deliberately NOT ExceptionDispatchInfo/rethrow: this only formats a summary line and
+    /// never re-throws, so there is no stack trace to preserve here.
+    /// </summary>
+    private static Exception Unwrap(Exception ex)
+    {
+        while (ex is TargetInvocationException tie && tie.InnerException != null)
+            ex = tie.InnerException;
+        return ex;
+    }
+
     /// <summary>How many distinct loader reasons to quote. More than a handful is a wall of
     /// repetitions of the same missing dependency, and the message is one line in a summary.</summary>
     private const int MaxLoaderReasons = 5;
@@ -30,6 +52,7 @@ internal static class ExecFailure
     /// know whose tests are missing from the run.</param>
     public static string Describe(string appGroup, Exception ex)
     {
+        ex = Unwrap(ex);
         var headline = ex.Message.Split('\n')[0];
 
         var rtle = ex as ReflectionTypeLoadException


### PR DESCRIPTION
Closes #2692

`ExecFailure.Describe` already unwraps `ReflectionTypeLoadException` and its header says why —
the wrapper "names nothing" and the diagnosis is underneath. `TargetInvocationException` has
exactly the same property and was not handled, so the real exception was thrown away.

## Measured

Microsoft's `Tests-SINGLESERVER` bucket (BC 28.1, 879 tests). Whole run, `--verbose`, zero
`AL####` diagnostics:

| | output |
|---|---|
| before | `Tests-SINGLESERVER: EXEC-FAIL: Exception has been thrown by the target of an invocation.` |
| after | `Tests-SINGLESERVER: EXEC-FAIL: There is already a record in table User Setup that has the same values in a unique index for the following fields: SystemId=7a6207a6-…` |

The second is a defect someone can chase. The first is what the runner printed.

## Tests

RED → GREEN on `Describe_UnwrapsTargetInvocationException_AndReportsTheRealCause` and
`Describe_UnwrapsNestedTargetInvocationExceptions`.

Two controls that passed **before** the change and still pass, so they pin what must not break:

- `Describe_KeepsTheWrapperMessage_WhenThereIsNoInnerException` — no inner exception must not
  yield an empty line.
- `Describe_StillQuotesLoaderExceptions_WhenReachedThroughATargetInvocationException` — the
  existing `ReflectionTypeLoadException` handling must survive unwrapping.

11/11 in `ExecFailureTests`.

Not `ExceptionDispatchInfo`: this only formats a summary line and never re-throws, so there is
no stack trace to preserve.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf