### PR TITLE
fix(deps): extract a dependency's AL source per process, not into a shared dir

### DIFF
--- a/AlRunner.Tests/DepExtractionDirTests.cs
+++ b/AlRunner.Tests/DepExtractionDirTests.cs
@@ -75,4 +75,14 @@ public sealed class DepExtractionDirTests
     [Fact]
     public void Root_IsUnderTheSharedAlRunnerDepsParent()
         => Assert.Contains("al-runner-deps", DepExtractionDir.Root, StringComparison.Ordinal);
+
+    /// <summary>The claim that actually matters, stated directly: two processes get different
+    /// roots. Asserting only that the live path contains the current pid would still pass if the
+    /// id were folded in somewhere that collided.</summary>
+    [Fact]
+    public void Root_DiffersBetweenProcesses()
+    {
+        Assert.NotEqual(DepExtractionDir.RootForProcess(1001), DepExtractionDir.RootForProcess(1002));
+        Assert.Equal(DepExtractionDir.RootForProcess(1001), DepExtractionDir.RootForProcess(1001));
+    }
 }

--- a/AlRunner.Tests/DepExtractionDirTests.cs
+++ b/AlRunner.Tests/DepExtractionDirTests.cs
@@ -1,0 +1,78 @@
+// DepExtractionDirTests — dependency source extraction must not be shared across processes
+// (issue #2696).
+//
+// The directory a dependency's AL source is extracted into used to be keyed only by app
+// identity, under the machine-wide temp dir, and the extraction DELETES the .al files already
+// there before rewriting them. Two runners resolving the same dependency at the same moment
+// therefore raced: one deleted the files the other was compiling from.
+//
+// Measured under `--jobs 6` on Microsoft's BaseApp buckets: `Tests-TestLibraries` is a
+// dependency of nearly every bucket, all six workers extracted it at once, and one worker died
+// with `FileNotFoundException: .../BackupManagement.Codeunit.al` before starting ANY of its
+// bundles — taking Tests-SCM (8,526 tests) and two more buckets out of a run that still printed
+// a confident aggregate.
+//
+// This is not specific to --jobs. Two terminals, a --watch session beside a CLI run, or two CI
+// jobs on one self-hosted runner share a TMPDIR too; --jobs only makes it near-certain.
+//
+// Sharing bought nothing: the real cache is the compiled DLL, which returns before this point
+// on a hit, so this directory is scratch space that is fully rewritten on every miss.
+
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class DepExtractionDirTests
+{
+    /// <summary>The defect: the path must not be the bare identity-only directory that every
+    /// process on the machine computes identically.</summary>
+    [Fact]
+    public void Path_IsNotSharedAcrossProcesses()
+    {
+        var dir = DepExtractionDir.For("Microsoft", "Tests-TestLibraries", "28.1.49838.53910");
+
+        Assert.Contains(Environment.ProcessId.ToString(), dir, StringComparison.Ordinal);
+    }
+
+    /// <summary>Stable within one process: a dependency resolved twice (ordinary under --watch)
+    /// must reuse its directory rather than leaking a new one per call.</summary>
+    [Fact]
+    public void Path_IsStableWithinOneProcess()
+    {
+        var a = DepExtractionDir.For("Microsoft", "Tests-TestLibraries", "28.1.49838.53910");
+        var b = DepExtractionDir.For("Microsoft", "Tests-TestLibraries", "28.1.49838.53910");
+
+        Assert.Equal(a, b);
+    }
+
+    /// <summary>Different dependencies stay separate — sharing one directory between two apps
+    /// would let one app's delete-then-rewrite wipe the other's sources.</summary>
+    [Fact]
+    public void Path_DiffersPerDependency()
+    {
+        var a = DepExtractionDir.For("Microsoft", "Tests-TestLibraries", "28.1.49838.53910");
+        var b = DepExtractionDir.For("Microsoft", "Tests-ERM", "28.1.49838.53910");
+        var c = DepExtractionDir.For("Microsoft", "Tests-TestLibraries", "28.2.0.0");
+
+        Assert.NotEqual(a, b);
+        Assert.NotEqual(a, c);
+    }
+
+    /// <summary>Names that are not safe as a path segment must not escape the root — a
+    /// publisher or app name is attacker-influenced only in the sense that it comes from a
+    /// third-party .app manifest, but a '/' or '..' in one should still land inside the root.</summary>
+    [Fact]
+    public void Path_StaysInsideTheRoot_ForAwkwardNames()
+    {
+        var dir = DepExtractionDir.For("Ev/il", "..\\..\\escape", "1.0.0.0");
+
+        Assert.StartsWith(DepExtractionDir.Root, System.IO.Path.GetFullPath(dir), StringComparison.Ordinal);
+    }
+
+    /// <summary>The per-process root sits under the shared parent, so the old cleanup habits and
+    /// anything that clears al-runner-deps still finds it.</summary>
+    [Fact]
+    public void Root_IsUnderTheSharedAlRunnerDepsParent()
+        => Assert.Contains("al-runner-deps", DepExtractionDir.Root, StringComparison.Ordinal);
+}

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -415,8 +415,12 @@ public sealed class DependencyLoader
             }
         }
 
-        var tempDir = Path.Combine(Path.GetTempPath(),
-            "al-runner-deps", SanitizeFileName($"{m.Publisher}_{m.Name}_{m.Version}"));
+        // Per-process, NOT the machine-wide identity-only path this used to be (#2696): the
+        // delete-then-rewrite below raced two runners resolving the same dependency, and one
+        // deleted the .al files the other was compiling from. Isolating costs nothing — the
+        // real cache is `cachedDll` above, which returns before this point on a hit, so this
+        // directory is scratch that is fully rewritten on every miss.
+        var tempDir = AlRunner.Infrastructure.DepExtractionDir.For(m.Publisher, m.Name, m.Version.ToString());
         Directory.CreateDirectory(tempDir);
         // Clean previously emitted .al files so a stale one doesn't pollute the compile.
         foreach (var existing in Directory.EnumerateFiles(tempDir, "*.al"))

--- a/AlRunner/Infrastructure/DepExtractionDir.cs
+++ b/AlRunner/Infrastructure/DepExtractionDir.cs
@@ -1,0 +1,69 @@
+// DepExtractionDir — where a dependency's AL source is extracted for compilation (issue #2696).
+//
+// This used to be Path.GetTempPath()/al-runner-deps/<Publisher>_<Name>_<Version>: identical for
+// every process on the machine. The extraction DELETES the .al files already there before
+// rewriting them, so two runners resolving the same dependency at the same moment raced — one
+// deleted the files the other was compiling from.
+//
+// Measured under `--jobs 6` on Microsoft's BaseApp buckets: Tests-TestLibraries is a dependency
+// of nearly every bucket, so all six workers extracted it at once. One died with
+// `FileNotFoundException: .../BackupManagement.Codeunit.al` before starting ANY of its bundles,
+// removing Tests-SCM (8,526 tests), Tests-Cost Accounting and Tests-Monitor Sensitive Fields
+// from a run that still printed a confident aggregate.
+//
+// Not specific to --jobs: two terminals, a --watch session beside a CLI run, or two CI jobs on
+// one self-hosted runner share a TMPDIR too. --jobs only makes it near-certain.
+//
+// Isolating per process costs nothing, which is why this is the fix rather than locking or an
+// atomic publish. The real cache is the compiled DLL (DependencyLoader returns on a
+// source-cache HIT before reaching here), so this directory is scratch space that is fully
+// rewritten on every miss — there was never any cross-process reuse to preserve.
+//
+// The per-process root stays UNDER the shared al-runner-deps parent so anything that cleans
+// that parent still finds it, and it is removed on normal process exit. A killed process leaves
+// its root behind, exactly as the previous shared directory was left behind forever.
+
+namespace AlRunner.Infrastructure;
+
+internal static class DepExtractionDir
+{
+    private static readonly Lazy<string> _root = new(() =>
+    {
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-deps", $"p{Environment.ProcessId}");
+        Directory.CreateDirectory(root);
+        AppDomain.CurrentDomain.ProcessExit += (_, _) =>
+        {
+            try { Directory.Delete(root, recursive: true); } catch { }
+        };
+        return root;
+    });
+
+    /// <summary>This process's extraction root, under the shared al-runner-deps parent.</summary>
+    public static string Root => _root.Value;
+
+    /// <summary>
+    /// The directory for one dependency. Stable within a process — a dependency resolved twice
+    /// (ordinary under --watch) reuses it rather than leaking a directory per call — and never
+    /// shared with another process.
+    /// </summary>
+    public static string For(string publisher, string name, string version)
+    {
+        var leaf = Sanitize($"{publisher}_{name}_{version}");
+        return Path.Combine(Root, leaf);
+    }
+
+    /// <summary>
+    /// Reduce a manifest-supplied identity to one safe path segment. A '/' or '..' from a
+    /// third-party .app must land inside the root, not above it.
+    /// </summary>
+    private static string Sanitize(string s)
+    {
+        var chars = s.ToCharArray();
+        for (var i = 0; i < chars.Length; i++)
+            if (Array.IndexOf(Path.GetInvalidFileNameChars(), chars[i]) >= 0
+                || chars[i] == '/' || chars[i] == '\\' || chars[i] == '.')
+                chars[i] = '_';
+        var leaf = new string(chars).Trim('_');
+        return leaf.Length == 0 ? "dep" : leaf;
+    }
+}

--- a/AlRunner/Infrastructure/DepExtractionDir.cs
+++ b/AlRunner/Infrastructure/DepExtractionDir.cs
@@ -27,9 +27,17 @@ namespace AlRunner.Infrastructure;
 
 internal static class DepExtractionDir
 {
+    /// <summary>
+    /// The root a process with this id would use. Exposed so a test can prove two processes get
+    /// DIFFERENT roots — asserting only that the live path contains the current pid would still
+    /// pass if the pid were, say, appended to a shared constant in a way that collided.
+    /// </summary>
+    public static string RootForProcess(int processId)
+        => Path.Combine(Path.GetTempPath(), "al-runner-deps", $"p{processId}");
+
     private static readonly Lazy<string> _root = new(() =>
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-deps", $"p{Environment.ProcessId}");
+        var root = RootForProcess(Environment.ProcessId);
         Directory.CreateDirectory(root);
         AppDomain.CurrentDomain.ProcessExit += (_, _) =>
         {


### PR DESCRIPTION
Closes #2696

## The defect

`DependencyLoader` extracted a dependency's AL source into
`Path.GetTempPath()/al-runner-deps/<Publisher>_<Name>_<Version>` — a path every process on the
machine computes identically — and **deletes** the `.al` files already there before rewriting
them. Two runners resolving the same dependency at the same moment race: one deletes the files
the other is compiling from.

## Measured

Full 32-bucket run of Microsoft's BaseApp tests under `--jobs 6`. `Tests-TestLibraries` is a
dependency of nearly every bucket, so all six workers extracted it within the same second:

```
[dep-load-fail] Microsoft_Tests-TestLibraries v28.1.49838.53910: EMIT-FAIL —
  FileNotFoundException: .../Microsoft_Tests-TestLibraries_28.1.49838.53910/BackupManagement.Codeunit.al
FATAL: dependency compile failed — cannot continue.
```

That worker started **0 of its 3 bundles** and exited, removing **Tests-SCM (8,526 tests)**,
Tests-Cost Accounting (565) and Tests-Monitor Sensitive Fields (19) — 9,110 tests, **22% of the
run** — from an aggregate that still printed a confident total. A second worker hit the same
error.

**Not specific to `--jobs`.** Any two `al-runner` processes sharing a `TMPDIR` can hit this: two
terminals, a `--watch` session beside a CLI run, or two CI jobs on one self-hosted runner.
`--jobs` only makes it near-certain rather than occasional.

## Why per-process isolation rather than a lock or an atomic publish

Sharing bought nothing. The real cache is the compiled DLL: `DependencyLoader` returns on a
source-cache HIT *before* reaching this code, so the directory is scratch space that is fully
rewritten on every miss. There was never cross-process reuse to preserve, which makes isolation
free — no lock contention, no partially-published directory to reason about.

The per-process root stays **under** the shared `al-runner-deps` parent, so anything that cleans
that parent still finds it, and it is removed on normal process exit. A killed process leaves
its root behind — exactly as the previous shared directory was left behind forever.

## Tests

`DepExtractionDirTests` (5): the path is not shared across processes (the defect); it is stable
*within* a process, so a dependency resolved twice under `--watch` reuses it rather than leaking
a directory per call; different dependencies and different versions stay separate; an awkward
manifest-supplied name containing `/` or `..` lands inside the root rather than above it; and the
root stays under the shared parent.

## Ordering

#2695 (`--jobs`) should not merge before this one — `--jobs` is what turns an occasional race
into a near-certain one.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf