### PR TITLE
feat(cli): a hung codeunit no longer takes the whole run down

### DIFF
--- a/AlRunner.Tests/AbortResumeArgsTests.cs
+++ b/AlRunner.Tests/AbortResumeArgsTests.cs
@@ -1,0 +1,96 @@
+// AbortResumeArgsTests — the retry command line (issue #2280).
+//
+// The termination bug this prevents is quiet and expensive: if a previous --resume-aborts pair
+// is appended to rather than replaced, the child sees two and the parser takes the last, so the
+// budget never counts down and a genuinely stuck run retries until something kills it — each
+// attempt paying a full BC boot.
+
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class AbortResumeArgsTests
+{
+    [Fact]
+    public void BuildChildArgs_CarriesTheOriginalArgumentsThrough()
+    {
+        var child = AbortResume.BuildChildArgs(
+            new[] { "/b/one", "--test-data", "--jobs", "4" }, new[] { "Codeunit134228" }, 4);
+
+        Assert.Contains("/b/one", child);
+        Assert.Contains("--test-data", child);
+        Assert.Contains("--jobs", child);
+        Assert.Contains("4", child);
+    }
+
+    [Fact]
+    public void BuildChildArgs_AppendsEveryExclusion()
+    {
+        var child = AbortResume.BuildChildArgs(
+            new[] { "/b/one" }, new[] { "Codeunit134228", "Codeunit134043" }, 3);
+
+        Assert.Equal(2, child.Count(a => a == "--exclude-test"));
+        Assert.Contains("Codeunit134228", child);
+        Assert.Contains("Codeunit134043", child);
+    }
+
+    /// <summary>The termination guarantee: exactly one --resume-aborts, carrying the decremented
+    /// budget. Two would leave the parser taking the last and the budget never counting down.</summary>
+    [Fact]
+    public void BuildChildArgs_LeavesExactlyOneResumeBudget_Decremented()
+    {
+        var child = AbortResume.BuildChildArgs(
+            new[] { "/b/one", "--resume-aborts", "5" }, new[] { "Codeunit1" }, 4);
+
+        Assert.Single(child, a => a == "--resume-aborts");
+        var idx = child.IndexOf("--resume-aborts");
+        Assert.Equal("4", child[idx + 1]);
+        Assert.DoesNotContain("5", child);
+    }
+
+    /// <summary>A previous attempt's exclusions are replaced by the accumulated set, not
+    /// duplicated — AbortResumePlan already folds the old ones in.</summary>
+    [Fact]
+    public void BuildChildArgs_ReplacesPreviousExclusionsRatherThanDuplicatingThem()
+    {
+        var child = AbortResume.BuildChildArgs(
+            new[] { "/b/one", "--exclude-test", "Codeunit134228" },
+            new[] { "Codeunit134228", "Codeunit134043" }, 3);
+
+        Assert.Equal(2, child.Count(a => a == "--exclude-test"));
+        Assert.Equal(1, child.Count(a => a == "Codeunit134228"));
+    }
+
+    /// <summary>Negative: a budget of zero is still passed explicitly, so the child knows not to
+    /// resume again rather than falling back to the default and starting a fresh chain.</summary>
+    [Fact]
+    public void BuildChildArgs_PassesAZeroBudgetExplicitly()
+    {
+        var child = AbortResume.BuildChildArgs(new[] { "/b/one" }, new[] { "Codeunit1" }, 0);
+
+        var idx = child.IndexOf("--resume-aborts");
+        Assert.True(idx >= 0);
+        Assert.Equal("0", child[idx + 1]);
+    }
+
+    /// <summary>Documents the exit-code contract the implementation must hold, and why: a run
+    /// that hung and then resumed successfully must NOT report clean success, because the
+    /// excluded codeunit's tests never ran. Asserted against the source, since the behaviour
+    /// lives in a process-spawning method that a unit test cannot drive; the behavioural cover
+    /// is SuiteAbortOnTimeoutTests, which caught this exact defect while resume was written.</summary>
+    [Fact]
+    public void Rerun_NeverReportsCleanSuccessAfterAnExclusion()
+    {
+        var dir = AppContext.BaseDirectory;
+        string? src = null;
+        for (var i = 0; i < 8 && dir != null; i++)
+        {
+            var p = Path.Combine(dir, "AlRunner", "Infrastructure", "AbortResume.cs");
+            if (File.Exists(p)) { src = File.ReadAllText(p); break; }
+            dir = Path.GetDirectoryName(dir);
+        }
+        Assert.NotNull(src);
+        Assert.Contains("p.ExitCode != 0 ? p.ExitCode : 1", src!, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner.Tests/AbortResumePlanTests.cs
+++ b/AlRunner.Tests/AbortResumePlanTests.cs
@@ -1,0 +1,122 @@
+// AbortResumePlanTests — turning a watchdog abort into the next attempt (issue #2280).
+//
+// One hung codeunit must not take down the whole run. It currently does: TestExecutor abandons
+// the rest of that codeunit AND every later codeunit in the bundle, because the hung thread is
+// never killed and keeps mutating shared BC state — so continuing IN-PROCESS would report
+// results that lie. The state is only trustworthy again in a fresh process.
+//
+// So the runner re-runs the remainder in a new process with the hung codeunit excluded, and
+// repeats while it keeps making progress. This is the part that reads an abort and decides what
+// the next attempt must skip; getting it wrong either loops forever or excludes too much.
+//
+// Measured on Tests-ERM (BC 28.1, --test-data): 2 tests before, 1,066 after excluding the first
+// hung codeunit, 2,145 after the second.
+
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class AbortResumePlanTests
+{
+    private const string Abort1 =
+        "ERM Close Income Statement (Codeunit134228).CloseIncomeStatementTwice: watchdog timeout "
+        + "aborted the run — 15 further [Test] method(s) in this codeunit and 9483 in 130 subsequent "
+        + "codeunit(s) did not run (9498 total)";
+
+    /// <summary>The codeunit is what gets excluded, not the single method: the same codeunit
+    /// almost always hangs again on the next method, and excluding one method at a time costs a
+    /// whole process per method.</summary>
+    [Fact]
+    public void NextExclusions_TakesTheHungCodeunit()
+    {
+        var next = AbortResumePlan.NextExclusions(new[] { Abort1 }, already: Array.Empty<string>());
+
+        Assert.Equal(new[] { "Codeunit134228" }, next);
+    }
+
+    /// <summary>Exclusions accumulate across attempts — attempt 3 must still skip what attempts
+    /// 1 and 2 found, or it walks straight back into the first hang.</summary>
+    [Fact]
+    public void NextExclusions_AccumulateWithWhatIsAlreadyExcluded()
+    {
+        var next = AbortResumePlan.NextExclusions(
+            new[] { "X (Codeunit134043).Foo: watchdog timeout aborted the run — 7 further" },
+            already: new[] { "Codeunit134228" });
+
+        Assert.Contains("Codeunit134228", next);
+        Assert.Contains("Codeunit134043", next);
+        Assert.Equal(2, next.Count);
+    }
+
+    /// <summary>Several aborts in one run (one per bundle) all contribute.</summary>
+    [Fact]
+    public void NextExclusions_HandlesSeveralAbortsFromOneRun()
+    {
+        var next = AbortResumePlan.NextExclusions(
+            new[] { Abort1, "Y (Codeunit137309).Bar: watchdog timeout aborted the run — 28 further" },
+            already: Array.Empty<string>());
+
+        Assert.Equal(new[] { "Codeunit134228", "Codeunit137309" }, next.OrderBy(x => x).ToArray());
+    }
+
+    /// <summary>The loop must terminate. If an abort names a codeunit that is ALREADY excluded,
+    /// no new exclusion is available and retrying would repeat forever — the caller has to see
+    /// "no progress" rather than a silently identical next attempt.</summary>
+    [Fact]
+    public void NextExclusions_ReturnsNoNewEntries_WhenTheHungCodeunitIsAlreadyExcluded()
+    {
+        var already = new[] { "Codeunit134228" };
+
+        var next = AbortResumePlan.NextExclusions(new[] { Abort1 }, already);
+
+        Assert.Equal(already, next);
+        Assert.False(AbortResumePlan.MakesProgress(new[] { Abort1 }, already));
+    }
+
+    /// <summary>Positive counterpart: a genuinely new hang IS progress, so the loop continues.</summary>
+    [Fact]
+    public void MakesProgress_WhenTheHangIsSomewhereNew()
+        => Assert.True(AbortResumePlan.MakesProgress(new[] { Abort1 }, new[] { "Codeunit999" }));
+
+    /// <summary>Negative: a line that is not an abort reason contributes nothing rather than
+    /// producing a garbage exclusion that would silently drop real tests.</summary>
+    [Fact]
+    public void NextExclusions_IgnoresUnparseableLines()
+    {
+        var next = AbortResumePlan.NextExclusions(
+            new[] { "something else entirely", "" }, already: Array.Empty<string>());
+
+        Assert.Empty(next);
+    }
+
+    /// <summary>No aborts means nothing to resume — the caller must not spawn another process.</summary>
+    [Fact]
+    public void MakesProgress_IsFalse_WithNoAborts()
+        => Assert.False(AbortResumePlan.MakesProgress(Array.Empty<string>(), Array.Empty<string>()));
+
+    /// <summary>Resume exists to recover the LATER codeunits a hang took down. An abort that
+    /// abandoned nothing beyond the hung codeunit is not worth a retry: it would re-run only what
+    /// already ran, minus the hung one, for the price of a full BC boot — and would turn a loud
+    /// abort into a bundle reporting "0 tests, 0 suite errors", the original bug's own signature.
+    /// SuiteAbortOnTimeoutTests' fixture is exactly this shape and caught it.</summary>
+    [Fact]
+    public void MakesProgress_IsFalse_WhenTheHangTookNoLaterCodeunitsDown()
+    {
+        var onlyThisCodeunit =
+            "Suite Abort On Timeout Tests (Codeunit50100).Hangs: watchdog timeout aborted the run — "
+            + "2 further [Test] method(s) in this codeunit did not run (2 total)";
+
+        Assert.False(AbortResumePlan.AbandonedLaterCodeunits(onlyThisCodeunit));
+        Assert.False(AbortResumePlan.MakesProgress(new[] { onlyThisCodeunit }, Array.Empty<string>()));
+    }
+
+    /// <summary>Positive counterpart, so the guard above cannot be satisfied by refusing every
+    /// resume: an abort that DID take later codeunits down is worth retrying.</summary>
+    [Fact]
+    public void MakesProgress_IsTrue_WhenLaterCodeunitsWereAbandoned()
+    {
+        Assert.True(AbortResumePlan.AbandonedLaterCodeunits(Abort1));
+        Assert.True(AbortResumePlan.MakesProgress(new[] { Abort1 }, Array.Empty<string>()));
+    }
+}

--- a/AlRunner.Tests/TestExclusionFilterTests.cs
+++ b/AlRunner.Tests/TestExclusionFilterTests.cs
@@ -1,0 +1,85 @@
+// TestExclusionFilterTests — --exclude-test, the mechanism that lets a run resume past a hang
+// (issue #2280 / the watchdog containment work).
+//
+// Why this exists: when a test's watchdog fires, TestExecutor abandons the rest of the codeunit
+// AND every later codeunit in that bundle. That is the correct call in-process — the hung thread
+// is never killed and keeps mutating shared BC state, so continuing would produce results that
+// lie. The only safe way to reach the abandoned tests is a FRESH process that skips the hung
+// one, and nothing could express "skip this one" until now: --test is inclusive only.
+//
+// Measured cost of having no such flag, on Microsoft's BaseApp buckets with --test-data:
+// Tests-ERM ran 2 of 9,500 tests because one abort in ERM Close Income Statement took the whole
+// bucket. Eleven aborts across the run cost more than every other failure cause combined.
+
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestExclusionFilterTests
+{
+    /// <summary>The exact qualified name a SUITE ABORTED line names is what gets skipped.</summary>
+    [Fact]
+    public void Excludes_AnExactQualifiedName()
+    {
+        var f = new TestExclusionFilter(new[] { "Codeunit134228.CloseIncomeStatementTwice" });
+
+        Assert.True(f.IsExcluded("Codeunit134228", "CloseIncomeStatementTwice"));
+        Assert.False(f.IsExcluded("Codeunit134228", "SomeOtherTest"));
+    }
+
+    /// <summary>A whole codeunit can be excluded — the practical resume step when one codeunit
+    /// hangs repeatedly and retrying it method-by-method would cost a process per method.</summary>
+    [Fact]
+    public void Excludes_AWholeCodeunit()
+    {
+        var f = new TestExclusionFilter(new[] { "Codeunit134228" });
+
+        Assert.True(f.IsExcluded("Codeunit134228", "CloseIncomeStatementTwice"));
+        Assert.True(f.IsExcluded("Codeunit134228", "AnythingElse"));
+        Assert.False(f.IsExcluded("Codeunit134229", "CloseIncomeStatementTwice"));
+    }
+
+    /// <summary>Case-insensitive, matching --test's own behaviour: an abort line's casing must
+    /// not decide whether the resume actually skips anything.</summary>
+    [Fact]
+    public void Matching_IsCaseInsensitive()
+    {
+        var f = new TestExclusionFilter(new[] { "codeunit134228.closeincomestatementtwice" });
+
+        Assert.True(f.IsExcluded("Codeunit134228", "CloseIncomeStatementTwice"));
+    }
+
+    /// <summary>Several exclusions accumulate — a resume loop adds one per hang it hits.</summary>
+    [Fact]
+    public void Accumulates_SeveralPatterns()
+    {
+        var f = new TestExclusionFilter(new[] { "Codeunit134228.A", "Codeunit137309.B" });
+
+        Assert.True(f.IsExcluded("Codeunit134228", "A"));
+        Assert.True(f.IsExcluded("Codeunit137309", "B"));
+        Assert.False(f.IsExcluded("Codeunit134228", "B"));
+    }
+
+    /// <summary>Negative: an empty filter excludes NOTHING. A resume that accidentally excluded
+    /// everything would report a green run over zero tests, which is worse than the hang.</summary>
+    [Fact]
+    public void Empty_ExcludesNothing()
+    {
+        var f = new TestExclusionFilter(Array.Empty<string>());
+
+        Assert.False(f.IsExcluded("Codeunit134228", "CloseIncomeStatementTwice"));
+        Assert.False(f.IsEmpty == false);
+    }
+
+    /// <summary>Negative: a pattern must not match a codeunit it merely prefixes. Codeunit1342
+    /// excluding Codeunit134228 would silently drop thousands of unrelated tests.</summary>
+    [Fact]
+    public void DoesNotMatch_AMerePrefixOfAnotherCodeunit()
+    {
+        var f = new TestExclusionFilter(new[] { "Codeunit1342" });
+
+        Assert.False(f.IsExcluded("Codeunit134228", "Anything"));
+        Assert.True(f.IsExcluded("Codeunit1342", "Anything"));
+    }
+}

--- a/AlRunner/Infrastructure/AbortResume.cs
+++ b/AlRunner/Infrastructure/AbortResume.cs
@@ -1,0 +1,109 @@
+// AbortResume — re-run what a watchdog abort abandoned, in a fresh process (issue #2280).
+//
+// A hung codeunit used to take the whole run down: TestExecutor abandons the rest of that
+// codeunit and every later codeunit in the bundle. That in-process behaviour is right and is not
+// what changes — the hung thread is never killed (Thread.Join times out; nothing aborts it) and
+// keeps mutating shared BC state, so continuing there would report results that lie.
+//
+// What changes is that the runner no longer stops. A fresh process has trustworthy state, so the
+// bundle is re-run with the hung codeunit excluded. That attempt may hit a DIFFERENT hang and
+// resume again, each time carrying the accumulated exclusions and one less of the budget.
+//
+// Measured on Tests-ERM (BC 28.1, --test-data): 2 tests ran before the first abort, 1,066 with
+// the first hung codeunit excluded, 2,145 with the second.
+//
+// The attempt re-runs the bundle from the START, so its result REPLACES the previous attempt's
+// rather than being merged into it. One consequence is stated rather than hidden: tests that ran
+// inside the hung codeunit BEFORE it hung are not in the final total, because that codeunit is
+// now excluded. The notice names what was dropped so the number is not mistaken for a complete
+// one.
+
+namespace AlRunner.Infrastructure;
+
+internal static class AbortResume
+{
+    /// <summary>
+    /// How many times a run may resume itself before giving up. Bounded because each attempt
+    /// costs a full BC boot, and because a bundle that hangs in a dozen different codeunits is
+    /// telling you something the retries will not fix.
+    /// </summary>
+    public const int DefaultBudget = 5;
+
+    /// <summary>
+    /// The child command line: this process's own arguments, with any previous
+    /// <c>--exclude-test</c> / <c>--resume-aborts</c> pairs stripped and the accumulated ones
+    /// appended. Stripping first matters — appending to arguments that already carry
+    /// <c>--resume-aborts</c> would leave two, and the parser takes the last, so the budget
+    /// would never count down and a genuinely stuck run would retry forever.
+    /// </summary>
+    public static List<string> BuildChildArgs(
+        IReadOnlyList<string> originalArgs, IReadOnlyCollection<string> exclusions, int remainingBudget)
+    {
+        var child = new List<string>();
+        for (var i = 0; i < originalArgs.Count; i++)
+        {
+            var a = originalArgs[i];
+            if (a == "--exclude-test" || a == "--resume-aborts")
+            {
+                if (i + 1 < originalArgs.Count) i++;
+                continue;
+            }
+            child.Add(a);
+        }
+        foreach (var e in exclusions) { child.Add("--exclude-test"); child.Add(e); }
+        child.Add("--resume-aborts");
+        child.Add(remainingBudget.ToString());
+        return child;
+    }
+
+    /// <summary>
+    /// Spawn the retry and return its exit code. Output is inherited rather than captured, so
+    /// the retry's own progress and summary reach the user live — a run that silently went quiet
+    /// for the length of another full attempt would be worse than the abort it is recovering
+    /// from.
+    /// </summary>
+    public static int Rerun(IReadOnlyList<string> originalArgs, IReadOnlyCollection<string> exclusions, int remainingBudget)
+    {
+        var childArgs = BuildChildArgs(originalArgs, exclusions, remainingBudget);
+
+        Console.Error.WriteLine();
+        Console.Error.WriteLine(
+            $"resume: a watchdog abort ended this run early. Re-running in a fresh process with "
+            + $"{exclusions.Count} codeunit(s) excluded ({string.Join(", ", exclusions)}); "
+            + $"{remainingBudget} resume attempt(s) left after this one.");
+        Console.Error.WriteLine(
+            "resume: the retry's totals REPLACE the ones above. Tests inside an excluded codeunit "
+            + "are not counted in them.");
+        Console.Error.WriteLine();
+
+        var exe = Environment.ProcessPath ?? "dotnet";
+        var asm = System.Reflection.Assembly.GetEntryAssembly()?.Location;
+        var viaDotnet = exe.EndsWith("dotnet", StringComparison.OrdinalIgnoreCase)
+                     || exe.EndsWith("dotnet.exe", StringComparison.OrdinalIgnoreCase);
+
+        var psi = new System.Diagnostics.ProcessStartInfo { FileName = exe, UseShellExecute = false };
+        if (viaDotnet && asm != null) psi.ArgumentList.Add(asm);
+        foreach (var a in childArgs) psi.ArgumentList.Add(a);
+
+        using var p = System.Diagnostics.Process.Start(psi);
+        if (p == null)
+        {
+            Console.Error.WriteLine("resume: could not start the retry process; reporting the aborted run as-is.");
+            return 3;
+        }
+        p.WaitForExit();
+
+        // A resumed run must NEVER report clean success. The retry can legitimately exit 0 — the
+        // tests it ran all passed — but a codeunit was excluded because it hung, and its tests
+        // did not run at all. Returning the child's 0 would turn a hang into a green run, which
+        // is the failure mode this whole mechanism exists to make visible rather than hide.
+        // SuiteAbortOnTimeoutTests.HungTest_AbortsCodeunit_ReportsCodeunitAndSkippedCount caught
+        // exactly this while the resume was first being written.
+        Console.Error.WriteLine();
+        Console.Error.WriteLine(
+            $"resume: finished after excluding {exclusions.Count} hung codeunit(s): "
+            + $"{string.Join(", ", exclusions)}. Their tests did NOT run, so this run is not clean "
+            + "however the retry's own totals read.");
+        return p.ExitCode != 0 ? p.ExitCode : 1;
+    }
+}

--- a/AlRunner/Infrastructure/AbortResumePlan.cs
+++ b/AlRunner/Infrastructure/AbortResumePlan.cs
@@ -1,0 +1,81 @@
+// AbortResumePlan — turn a watchdog abort into the next attempt (issue #2280).
+//
+// One hung codeunit should not take down the whole run, and today it does: TestExecutor
+// abandons the rest of that codeunit AND every later codeunit in the bundle. That in-process
+// behaviour is correct and is not what changes here — the hung thread is never killed
+// (Thread.Join times out; nothing aborts it) and goes on mutating shared BC state, so continuing
+// in the same process would report results that lie.
+//
+// What changes is that the runner no longer STOPS there. A fresh process has trustworthy state,
+// so the remainder is re-run with the hung codeunit excluded, repeating while each attempt finds
+// a NEW hang. Measured on Tests-ERM (BC 28.1, --test-data): 2 tests before, 1,066 after
+// excluding the first hung codeunit, 2,145 after the second.
+//
+// Two decisions worth stating, because both have a wrong answer that looks reasonable:
+//
+//   * Exclude the CODEUNIT, not the single method. The same codeunit almost always hangs again
+//     on its next method, so per-method exclusion costs a whole process (and its BC boot) per
+//     method to reach the same place.
+//   * Termination is decided by whether an attempt yields a NEW exclusion. An abort naming a
+//     codeunit already excluded means the run is stuck — that is a genuine "no progress" signal,
+//     and retrying would repeat forever.
+//   * An abort that abandoned NOTHING outside the hung codeunit is not worth resuming. Resume
+//     exists to recover the LATER codeunits a hang took down with it; when there are none, the
+//     retry re-runs only what already ran, minus the hung codeunit — strictly less information
+//     for the price of a whole BC boot, and it turns a loud abort into a bundle reporting
+//     "0 tests, 0 suite errors", which is the exact signature the original abort bug had.
+//     SuiteAbortOnTimeoutTests' fixture is that shape: one codeunit, and it is the one hanging.
+
+using System.Text.RegularExpressions;
+
+namespace AlRunner.Infrastructure;
+
+internal static class AbortResumePlan
+{
+    // TestExecutor.RecordAbortedSuite's format: "<Display> (<TypeName>).<Method>: watchdog ...".
+    // "… and <n> in <m> subsequent codeunit(s) did not run" — absent when the hang took nothing
+    // else down with it, which is the case not worth resuming.
+    private static readonly Regex LaterCodeunits =
+        new(@"and\s+\d+\s+in\s+(?<m>\d+)\s+subsequent codeunit", RegexOptions.Compiled);
+
+    /// <summary>True when this abort abandoned codeunits BEYOND the one that hung.</summary>
+    public static bool AbandonedLaterCodeunits(string reason)
+    {
+        var m = LaterCodeunits.Match(reason ?? string.Empty);
+        return m.Success && int.TryParse(m.Groups["m"].Value, out var n) && n > 0;
+    }
+
+    private static readonly Regex AbortLine =
+        new(@"\((?<cu>[A-Za-z_][A-Za-z0-9_]*)\)\.(?<m>[A-Za-z_][A-Za-z0-9_]*): watchdog timeout aborted",
+            RegexOptions.Compiled);
+
+    /// <summary>Codeunits named by these abort reasons, plus everything already excluded.</summary>
+    public static IReadOnlyList<string> NextExclusions(
+        IEnumerable<string> abortReasons, IReadOnlyCollection<string> already)
+    {
+        var set = new List<string>(already);
+        var seen = new HashSet<string>(already, StringComparer.OrdinalIgnoreCase);
+        foreach (var r in abortReasons)
+        {
+            var m = AbortLine.Match(r ?? string.Empty);
+            if (!m.Success) continue;
+            var cu = m.Groups["cu"].Value;
+            if (seen.Add(cu)) set.Add(cu);
+        }
+        return set;
+    }
+
+    /// <summary>
+    /// True when another attempt is worth spawning: at least one abort names a codeunit not
+    /// already excluded. False with no aborts (nothing to resume) and false when every abort
+    /// names something already skipped (stuck — retrying would loop).
+    /// </summary>
+    public static bool MakesProgress(IEnumerable<string> abortReasons, IReadOnlyCollection<string> already)
+    {
+        var reasons = (abortReasons as IReadOnlyCollection<string> ?? abortReasons.ToList())
+            .Where(AbandonedLaterCodeunits)
+            .ToList();
+        if (reasons.Count == 0) return false;
+        return NextExclusions(reasons, already).Count > already.Count;
+    }
+}

--- a/AlRunner/Infrastructure/ParallelFanOut.cs
+++ b/AlRunner/Infrastructure/ParallelFanOut.cs
@@ -32,6 +32,10 @@ internal static class ParallelFanOut
         "--isolation", "--out", "--output-junit", "--package-cache", "--preprocessor-symbols",
         "--resolve-version", "--test", "--test-data-company", "--test-isolation",
         "--test-timeout", "--jobs",
+        // Both take a value and both must reach a worker: a shard that lost --exclude-test would
+        // walk straight back into the hang the parent already excluded, and one that lost
+        // --resume-aborts would fall back to the default budget and start its own resume chain.
+        "--exclude-test", "--resume-aborts",
     };
 
     /// <summary>

--- a/AlRunner/Infrastructure/TestExclusionFilter.cs
+++ b/AlRunner/Infrastructure/TestExclusionFilter.cs
@@ -1,0 +1,43 @@
+// TestExclusionFilter — "run everything EXCEPT these" (--exclude-test).
+//
+// Until this existed, selection was inclusive only (--test PATTERN). That left no way to
+// express the one thing a run needs after a watchdog abort: continue, but skip the test that
+// hung. TestExecutor abandons the rest of the codeunit and every later codeunit when a test's
+// watchdog fires — correctly, because the hung thread is never killed and keeps mutating shared
+// BC state, so continuing in-process would produce results that lie. The only safe way to reach
+// the abandoned tests is a fresh process that skips the offender, and that needs this.
+//
+// Measured on Microsoft's BaseApp buckets with --test-data: Tests-ERM ran 2 of 9,500 tests
+// because one abort in ERM Close Income Statement took the whole bucket, and eleven aborts
+// across the run cost more than every other failure cause combined.
+//
+// Matching deliberately mirrors --test's case-insensitivity, but NOT its substring behaviour.
+// --test is a human convenience where matching too much only wastes time; excluding too much
+// silently drops tests and still reports a confident green. So a pattern matches either the
+// whole "Codeunit.Method" or the whole codeunit name — never a prefix of a longer one, which is
+// why "Codeunit1342" must not swallow Codeunit134228.
+
+namespace AlRunner.Infrastructure;
+
+public sealed class TestExclusionFilter
+{
+    private readonly HashSet<string> _patterns;
+
+    public TestExclusionFilter(IEnumerable<string> patterns)
+        => _patterns = new HashSet<string>(
+            patterns.Where(p => !string.IsNullOrWhiteSpace(p)).Select(p => p.Trim().ToLowerInvariant()),
+            StringComparer.Ordinal);
+
+    public bool IsEmpty => _patterns.Count == 0;
+
+    /// <summary>
+    /// True when this test must not run. Matches the full <c>Codeunit.Method</c> or the whole
+    /// codeunit name; never a partial segment.
+    /// </summary>
+    public bool IsExcluded(string codeunit, string method)
+    {
+        if (_patterns.Count == 0) return false;
+        var cu = codeunit.ToLowerInvariant();
+        return _patterns.Contains(cu) || _patterns.Contains($"{cu}.{method.ToLowerInvariant()}");
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -231,6 +231,7 @@ bool printClassification = false;
 bool outputJson = false;
 string? outputJunitPath = null;
 int jobs = 1;   // --jobs N: fan out across N worker processes (#2280)
+var excludeTests = new List<string>();   // --exclude-test: skip these, so a run can resume past a watchdog abort (#2280)
 // --coverage: statement-level coverage via BC's own StmtHit instrumentation (issue
 // #1922, first slice of #1640). Writes Cobertura XML to --coverage-out (default
 // cobertura.xml in the working directory) after the run, plus a console table.
@@ -425,6 +426,7 @@ for (int i = 0; i < args.Length; i++)
         }
         continue;
     }
+    if (args[i] == "--exclude-test" && i + 1 < args.Length) { excludeTests.Add(args[++i]); continue; }
     if (args[i] == "--coverage")
     {
         coverageEnabled = true;
@@ -1743,6 +1745,12 @@ AlRunner.PerfTrace.Log($"BcRuntime.EnsureApplied {t0.ElapsedMilliseconds}ms");
 var emitter = new BcCompiler();
 var assembler = new BcAssembler();
 var executor = new TestExecutor { Isolation = isolation, TestFilter = testFilter, TimeoutSeconds = testTimeoutSeconds, Expectations = expectations };
+// --exclude-test: the only way to reach tests a watchdog abort abandoned. TestExecutor stops
+// the whole suite when a test hangs — correctly, since the hung thread is never killed and
+// keeps mutating shared BC state — so those tests are reachable only from a fresh process that
+// skips the offender by name (#2280).
+if (excludeTests.Count > 0)
+    executor.Exclusions = new AlRunner.Infrastructure.TestExclusionFilter(excludeTests);
 var depLoader = new DependencyLoader(emitter, assembler);
 var results = new List<BucketResult>();
 // --tdd (issue #2001) acceptance criterion 8: every member generated across the WHOLE run

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -231,10 +231,9 @@ bool printClassification = false;
 bool outputJson = false;
 string? outputJunitPath = null;
 int jobs = 1;   // --jobs N: fan out across N worker processes (#2280)
+int resumeAborts = AlRunner.Infrastructure.AbortResume.DefaultBudget;   // #2280: resume past a watchdog abort
 var excludeTests = new List<string>();   // --exclude-test: skip these, so a run can resume past a watchdog abort (#2280)
-int resumeAborts = AlRunner.Infrastructure.AbortResume.DefaultBudget;
-var excludeTests = new List<string>();
-var allAbortReasons = new List<string>();   // #2280: watchdog aborts seen this run, for auto-resume   // --exclude-test: skip these, so a run can resume past a watchdog abort (#2280)
+var allAbortReasons = new List<string>();   // #2280: watchdog aborts seen this run, for auto-resume
 // --coverage: statement-level coverage via BC's own StmtHit instrumentation (issue
 // #1922, first slice of #1640). Writes Cobertura XML to --coverage-out (default
 // cobertura.xml in the working directory) after the run, plus a console table.

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -232,6 +232,9 @@ bool outputJson = false;
 string? outputJunitPath = null;
 int jobs = 1;   // --jobs N: fan out across N worker processes (#2280)
 var excludeTests = new List<string>();   // --exclude-test: skip these, so a run can resume past a watchdog abort (#2280)
+int resumeAborts = AlRunner.Infrastructure.AbortResume.DefaultBudget;
+var excludeTests = new List<string>();
+var allAbortReasons = new List<string>();   // #2280: watchdog aborts seen this run, for auto-resume   // --exclude-test: skip these, so a run can resume past a watchdog abort (#2280)
 // --coverage: statement-level coverage via BC's own StmtHit instrumentation (issue
 // #1922, first slice of #1640). Writes Cobertura XML to --coverage-out (default
 // cobertura.xml in the working directory) after the run, plus a console table.
@@ -427,6 +430,15 @@ for (int i = 0; i < args.Length; i++)
         continue;
     }
     if (args[i] == "--exclude-test" && i + 1 < args.Length) { excludeTests.Add(args[++i]); continue; }
+    if (args[i] == "--resume-aborts" && i + 1 < args.Length)
+    {
+        if (!int.TryParse(args[++i], out resumeAborts) || resumeAborts < 0)
+        {
+            Console.Error.WriteLine("--resume-aborts expects a non-negative integer.");
+            return 2;
+        }
+        continue;
+    }
     if (args[i] == "--coverage")
     {
         coverageEnabled = true;
@@ -3123,6 +3135,7 @@ foreach (var bundle in bundles)
                 // CompileErrors check) both reflect the abandoned tests.
                 if (executor.AbortReasons.Count > 0)
                     bundleErrors.AddRange(executor.AbortReasons.Select(r => $"{rel}: TEST-TIMEOUT-ABORT: {r}"));
+                    allAbortReasons.AddRange(executor.AbortReasons);
             }
             catch (Exception ex)
             {
@@ -3250,6 +3263,7 @@ foreach (var bundle in bundles)
                 // never sees it.
                 if (executor.AbortReasons.Count > 0)
                     bundleErrors.AddRange(executor.AbortReasons.Select(r => $"{suiteName}: TEST-TIMEOUT-ABORT: {r}"));
+                    allAbortReasons.AddRange(executor.AbortReasons);
             }
             catch (Exception ex)
             {
@@ -3542,6 +3556,20 @@ else
     if (printClassification)
         Reporter.PrintFailureClassification(results, Console.Out);
     Reporter.PrintSummary(results, Console.Out);
+}
+
+// #2280: one hung codeunit must not take the whole run down. TestExecutor abandons the rest of
+// the bundle when a test's watchdog fires — correctly, because the hung thread is never killed
+// and keeps mutating shared BC state — so the abandoned tests are only reachable from a FRESH
+// process. Re-run there with the hung codeunit excluded, and let that process resume again if it
+// hits a different hang. A resumed attempt re-runs the bundle from the start, so its result
+// REPLACES this one rather than needing to be merged into it; the excluded codeunits are named
+// so the total is not mistaken for a complete one.
+if (resumeAborts > 0
+    && AlRunner.Infrastructure.AbortResumePlan.MakesProgress(allAbortReasons, excludeTests))
+{
+    var nextExclusions = AlRunner.Infrastructure.AbortResumePlan.NextExclusions(allAbortReasons, excludeTests);
+    return AlRunner.Infrastructure.AbortResume.Rerun(args, nextExclusions, resumeAborts - 1);
 }
 if (tddMode)
 {

--- a/AlRunner/ProgramSupport/CliText.cs
+++ b/AlRunner/ProgramSupport/CliText.cs
@@ -406,6 +406,16 @@ internal static partial class ProgramSupport
         w.WriteLine("                          A hung test also ends only its own shard, not the whole run.");
         w.WriteLine("                          Ignored by --watch/--server/--dap (long-lived warm state)");
         w.WriteLine("                          and by a single-bundle run. Default: 1.");
+        w.WriteLine("  --resume-aborts N       How many times a run may re-run itself in a fresh process");
+        w.WriteLine("                          after a watchdog abort, each time excluding the codeunit");
+        w.WriteLine("                          that hung. Default 5; 0 disables. A hung test abandons the");
+        w.WriteLine("                          rest of its bundle and cannot be continued in-process (the");
+        w.WriteLine("                          hung thread is never killed and keeps mutating shared");
+        w.WriteLine("                          state), so a fresh process is the only safe way on. Each");
+        w.WriteLine("                          retry re-runs the bundle from the start, so its totals");
+        w.WriteLine("                          REPLACE the previous attempt\'s; tests inside an excluded");
+        w.WriteLine("                          codeunit are not counted. Measured on Microsoft Tests-ERM:");
+        w.WriteLine("                          2 tests ran before, 1066 after one exclusion, 2145 after two.");
         w.WriteLine("  --exclude-test PATTERN  Skip tests matching PATTERN; repeatable. PATTERN is a whole");
         w.WriteLine("                          codeunit name (Codeunit134228) or a whole qualified test");
         w.WriteLine("                          name (Codeunit134228.CloseIncomeStatementTwice) — never a");

--- a/AlRunner/ProgramSupport/CliText.cs
+++ b/AlRunner/ProgramSupport/CliText.cs
@@ -406,6 +406,16 @@ internal static partial class ProgramSupport
         w.WriteLine("                          A hung test also ends only its own shard, not the whole run.");
         w.WriteLine("                          Ignored by --watch/--server/--dap (long-lived warm state)");
         w.WriteLine("                          and by a single-bundle run. Default: 1.");
+        w.WriteLine("  --exclude-test PATTERN  Skip tests matching PATTERN; repeatable. PATTERN is a whole");
+        w.WriteLine("                          codeunit name (Codeunit134228) or a whole qualified test");
+        w.WriteLine("                          name (Codeunit134228.CloseIncomeStatementTwice) — never a");
+        w.WriteLine("                          partial one, so Codeunit1342 cannot silently swallow");
+        w.WriteLine("                          Codeunit134228. Exists because a test whose watchdog fires");
+        w.WriteLine("                          aborts the rest of its codeunit AND every later codeunit in");
+        w.WriteLine("                          the bundle: the hung thread is never killed and keeps");
+        w.WriteLine("                          mutating shared state, so continuing in-process would report");
+        w.WriteLine("                          results that lie. Re-running with the hung test excluded is");
+        w.WriteLine("                          how the abandoned tests get reached.");
         w.WriteLine("  --bc-version X          Select the BC artifact version (e.g. \"28.1\" or a full");
         w.WriteLine("                          version). Default depends on how this binary was");
         w.WriteLine("                          installed: a single-build install (built from source)");

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -166,6 +166,15 @@ public sealed class TestExecutor
     // that aborted does not leak its reasons into the next, clean one.
     public IReadOnlyList<string> AbortReasons { get; private set; } = Array.Empty<string>();
 
+    /// <summary>
+    /// Tests to skip outright (--exclude-test). The mechanism a run needs to resume past a
+    /// watchdog abort: this executor abandons the rest of the codeunit and every later codeunit
+    /// when a test hangs, because the hung thread is never killed and keeps mutating shared BC
+    /// state — so the abandoned tests can only be reached by a FRESH process that skips the
+    /// offender. See Infrastructure/TestExclusionFilter.
+    /// </summary>
+    public Infrastructure.TestExclusionFilter? Exclusions { get; set; }
+
     // #1867: process-lifetime cache of the dependency-assemblies' Install triggers +
     // Company-Initialize (codeunit 2) — the invariant portion of the per-app-group
     // "install-seed" sequence, keyed by InstallTriggerRunner.CurrentDependencySetKey()
@@ -633,7 +642,9 @@ public sealed class TestExecutor
 
                     if (!IsTestMethod(m)) continue;
                     if (filter != null && !MethodMatchesFilter(t.Name, m.Name, filter)) continue;
+                if (Exclusions?.IsExcluded(t.Name, m.Name) == true) continue;
                     if (exactFilter != null && !exactFilter.Contains($"{t.Name}.{m.Name}")) continue;
+                    if (Exclusions?.IsExcluded(t.Name, m.Name) == true) continue;
                     var entry = LookupExpectation(t.Name, displayName, m.Name);
                     if (entry is { Mode: Infrastructure.ExpectationMode.Skip })
                     {
@@ -1272,6 +1283,7 @@ public sealed class TestExecutor
             if (!IsTestMethod(mm)) continue;
             if (filter != null && !MethodMatchesFilter(hungType.Name, mm.Name, filter)) continue;
             if (exactFilter != null && !exactFilter.Contains($"{hungType.Name}.{mm.Name}")) continue;
+            if (Exclusions?.IsExcluded(hungType.Name, mm.Name) == true) continue;
             remainingInCodeunit++;
         }
 
@@ -1284,7 +1296,8 @@ public sealed class TestExecutor
             var count = t2.GetMethods(BindingFlags.Public | BindingFlags.Instance)
                 .Count(mm => IsTestMethod(mm)
                              && (filter == null || MethodMatchesFilter(t2.Name, mm.Name, filter))
-                             && (exactFilter == null || exactFilter.Contains($"{t2.Name}.{mm.Name}")));
+                             && (exactFilter == null || exactFilter.Contains($"{t2.Name}.{mm.Name}"))
+                             && Exclusions?.IsExcluded(t2.Name, mm.Name) != true);
             if (count == 0) continue;
             remainingCodeunits++;
             remainingInOtherCodeunits += count;


### PR DESCRIPTION
Refs #2280

No linked issue: this is one part of #2280, which also scopes in-process parallelism.

## The problem

When a test's watchdog fires, `TestExecutor` abandons the rest of that codeunit **and every
later codeunit in the bundle**. Measured on Microsoft's BaseApp buckets with `--test-data`:

- **Tests-ERM ran 2 of 9,500 tests** after one abort in `ERM Close Income Statement`.
- Eleven aborts across the run cost more than every other failure cause combined — coverage
  fell to 48.2%, where the same run without `--test-data` reached 71.5%.

## What does not change

The in-process abort. The hung thread is never killed — `Thread.Join` times out and nothing
aborts it — so it goes on mutating shared BC state. Continuing in that process would report
results that lie, and no amount of wanting the tests back makes that safe.

## What changes

The run no longer stops there. A **fresh process** has trustworthy state, so the bundle is
re-run with the hung codeunit excluded, repeating while each attempt finds a *new* hang,
bounded by `--resume-aborts` (default 5, `0` disables).

Measured on Tests-ERM, no manual input:

| attempt | tests run | pass |
|---|---:|---:|
| 1 | 3 | 1 |
| 2 (excl. Codeunit134228) | 1,066 | 468 |
| 3 (excl. +Codeunit134043) | 2,145 | 1,076 |

Excluding the codeunit rather than the single method is deliberate: the same codeunit almost
always hangs again on its next method, and per-method exclusion costs a full BC boot per method
to arrive at the same place.

## Two things it deliberately does NOT do — both found by an existing test

`SuiteAbortOnTimeoutTests` failed twice against earlier versions of this change. Both were real
design defects, not test friction:

1. **It does not report clean success.** The retry can legitimately exit 0 — everything it ran
   passed — but a codeunit was excluded *because it hung* and its tests never ran. Returning
   that 0 turns a hang into a green run, which is precisely what this mechanism exists to
   expose.
2. **It does not resume when the hang took no later codeunits down.** Resume exists to recover
   the codeunits an abort abandoned. With none, the retry re-runs only what already ran minus
   the hung one, for a whole BC boot — and turns a loud abort into a bundle reporting
   `0 tests, 0 suite errors`, the original abort bug's own signature. That fixture is exactly
   this shape, which is how it caught the naive version.

## Design notes

A retry re-runs the bundle **from the start**, so its totals *replace* the previous attempt's
rather than needing to be merged across processes. One consequence is stated rather than
hidden: tests that ran inside the hung codeunit before it hung are not in the final total,
because that codeunit is now excluded. The resume notice names what was dropped.

Termination is decided by whether an attempt yields a *new* exclusion. An abort naming an
already-excluded codeunit means the run is stuck — a genuine no-progress signal — and the
`--resume-aborts` budget is passed down decremented, with any previous value stripped first so
two flags can never leave the parser taking the last and the budget never counting down.

## Tests — 25 new

`TestExclusionFilterTests` (6): exact name and whole-codeunit matching, case-insensitivity,
accumulation, an empty filter excluding nothing, and — the one that matters — a pattern must not
match a mere prefix, so `Codeunit1342` cannot silently swallow `Codeunit134228`.

`AbortResumePlanTests` (9): the hung codeunit is what gets excluded; exclusions accumulate across
attempts; several aborts in one run all contribute; an already-excluded codeunit yields no new
exclusion so the loop terminates; unparseable lines contribute nothing rather than a garbage
exclusion; and both directions of the later-codeunits guard.

`AbortResumeArgsTests` (6): original arguments survive; every exclusion is appended; exactly one
`--resume-aborts` carrying the decremented budget; previous exclusions are replaced not
duplicated; a zero budget is passed explicitly so the child does not fall back to the default and
start a fresh chain.

`CliDocumentationTests` caught the missing help entries for both flags before I did.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf