### PR TITLE
fix(record): a snapshot replay is not an AL Insert — don't refuse its SystemIds

### DIFF
--- a/AlRunner.Tests/SystemIdRestoreSuppressionTests.cs
+++ b/AlRunner.Tests/SystemIdRestoreSuppressionTests.cs
@@ -1,0 +1,92 @@
+// SystemIdRestoreSuppressionTests — a snapshot replay is not an AL Insert (issue #2694).
+//
+// #2639 made TempTableDataProvider.Insert refuse a duplicate SystemId, modelling the clustered
+// unique constraint real SQL Server puts on $systemId. That is right for an AL `Insert()`
+// statement. It is a category error for the runner's OWN transaction rollback, which restores a
+// table by clearing it and re-inserting the snapshot rows through that same provider method.
+// Real BC's rollback is a transaction abort; it never issues an INSERT, so there is no
+// constraint for a replay to violate.
+//
+// The consequence was total. Measured on Microsoft's Tests-SINGLESERVER (BC 28.1), traced to
+// RecordPatches.RollbackToCommitPoint -> InsertRows -> the guard:
+//
+//     EXEC-FAIL: There is already a record in table User Setup that has the same values in a
+//     unique index for the following fields: SystemId=4ca8d6ba-...
+//
+// 0 of 878 tests ran, on `main`, with the corpus green throughout. Bisected to #2639's commit:
+// its parent d9f01ca1 runs all 878.
+//
+// A restore that throws half way is worse than either outcome it chooses between: the table is
+// left holding some of the snapshot and none of the rest.
+//
+// NOTE the underlying data problem this exposed is NOT fixed here and is tracked separately:
+// the snapshot legitimately contained two User Setup rows carrying the same SystemId, so
+// something seeded them that way. Suppressing the check during a replay restores the run; it
+// does not make those rows correct.
+
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class SystemIdRestoreSuppressionTests
+{
+    [Fact]
+    public void NotSuppressed_ByDefault()
+        => Assert.False(RowVersionPatches.IsSystemIdUniquenessSuppressed);
+
+    [Fact]
+    public void Suppressed_InsideTheScope()
+    {
+        using (RowVersionPatches.SuppressSystemIdUniqueness())
+            Assert.True(RowVersionPatches.IsSystemIdUniquenessSuppressed);
+    }
+
+    /// <summary>Restored on the way out, including when the restore throws — a leaked
+    /// suppression would disable a real AL-visible integrity check for the rest of the process,
+    /// turning #2639's fix into a no-op nobody would notice.</summary>
+    [Fact]
+    public void Restored_AfterTheScope_EvenOnAnException()
+    {
+        try
+        {
+            using (RowVersionPatches.SuppressSystemIdUniqueness())
+                throw new InvalidOperationException("restore blew up");
+        }
+        catch (InvalidOperationException) { }
+
+        Assert.False(RowVersionPatches.IsSystemIdUniquenessSuppressed);
+    }
+
+    /// <summary>Nesting restores to the enclosing state, not unconditionally to false: a
+    /// rollback inside a rollback must not re-arm the check for the outer replay's remaining
+    /// rows.</summary>
+    [Fact]
+    public void Nesting_RestoresTheEnclosingState()
+    {
+        using (RowVersionPatches.SuppressSystemIdUniqueness())
+        {
+            using (RowVersionPatches.SuppressSystemIdUniqueness())
+                Assert.True(RowVersionPatches.IsSystemIdUniquenessSuppressed);
+
+            Assert.True(RowVersionPatches.IsSystemIdUniquenessSuppressed);
+        }
+        Assert.False(RowVersionPatches.IsSystemIdUniquenessSuppressed);
+    }
+
+    /// <summary>The suppression is per-thread. AL test bodies run on their own thread (see
+    /// TestExecutor.InvokeWithTimeout), and a process-wide flag would let one thread's restore
+    /// silently disable the check for another's genuine AL Insert.</summary>
+    [Fact]
+    public void Suppression_DoesNotLeakToAnotherThread()
+    {
+        bool? seenOnOtherThread = null;
+        using (RowVersionPatches.SuppressSystemIdUniqueness())
+        {
+            var t = new Thread(() => seenOnOtherThread = RowVersionPatches.IsSystemIdUniquenessSuppressed);
+            t.Start();
+            t.Join();
+        }
+        Assert.False(seenOnOtherThread);
+    }
+}

--- a/AlRunner/Patches/RecordPatches.TransactionSnapshot.cs
+++ b/AlRunner/Patches/RecordPatches.TransactionSnapshot.cs
@@ -314,10 +314,19 @@ public static partial class RecordPatches
             AlRunner.Infrastructure.FieldPoke.SetInstance(RequiredField(t, name), provider, null);
     }
 
-    /// <summary>Put saved rows back, deep-copying so the snapshot stays reusable.</summary>
+    /// <summary>
+    /// Put saved rows back, deep-copying so the snapshot stays reusable.
+    ///
+    /// Runs inside RowVersionPatches.SuppressSystemIdUniqueness (#2694): every restored row
+    /// carries the SystemId it already had, and #2639's duplicate-SystemId refusal models an AL
+    /// `Insert()` hitting SQL's clustered unique constraint on $systemId. Real BC's rollback is a
+    /// transaction abort that issues no INSERT at all, so a replay has no constraint to violate.
+    /// Without the scope the guard fired mid-restore and Tests-SINGLESERVER ran 0 of 878 tests.
+    /// </summary>
     private static void InsertRows(object provider, object metaTable, NavValue[][] rows)
     {
         if (rows.Length == 0) return;
+        using var _ = AlRunner.Patches.RowVersionPatches.SuppressSystemIdUniqueness();
         var insert = provider.GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance)
             .First(m => m.Name == "Insert" && m.GetParameters().Length == 4
                      && m.GetParameters()[0].ParameterType == typeof(int));

--- a/AlRunner/Patches/RowVersionPatches.SystemIdIntegrity.cs
+++ b/AlRunner/Patches/RowVersionPatches.SystemIdIntegrity.cs
@@ -171,8 +171,48 @@ public static partial class RowVersionPatches
     /// explicit SystemId already exists on this database-backed table, matching real
     /// BC's SQL unique-constraint violation on $systemId.
     /// </summary>
+    // ── The runner's own snapshot replay is not an AL Insert (issue #2694) ──────────
+    //
+    // RecordPatches.RollbackToCommitPoint restores a table by clearing it and re-inserting the
+    // snapshot rows THROUGH THIS SAME provider method, so every restored row arrives here
+    // carrying the SystemId it already had. Real BC's rollback is a transaction abort — it never
+    // issues an INSERT — so there is no unique constraint for a replay to violate, and applying
+    // the guard there is a category error rather than a stricter reading of it.
+    //
+    // It was also total: on Microsoft's Tests-SINGLESERVER (BC 28.1) the restore threw and the
+    // bucket ran 0 of 878 tests, bisected to #2639's commit against its parent d9f01ca1. A
+    // restore that throws part way is worse than either outcome it chooses between — the table
+    // keeps some of the snapshot and none of the rest.
+    //
+    // Scoped and per-thread rather than a global off switch: AL test bodies run on their own
+    // thread (TestExecutor.InvokeWithTimeout), and a process-wide flag would let one thread's
+    // restore disable a genuine AL Insert's check on another.
+    [ThreadStatic] private static bool _suppressSystemIdUniqueness;
+
+    /// <summary>True while this thread is replaying a snapshot rather than running AL Insert.</summary>
+    public static bool IsSystemIdUniquenessSuppressed => _suppressSystemIdUniqueness;
+
+    /// <summary>
+    /// Suppress the duplicate-SystemId refusal for the duration of a snapshot replay. Restores
+    /// the ENCLOSING state on dispose, not unconditionally false, so a rollback nested inside a
+    /// rollback cannot re-arm the check for the outer replay's remaining rows.
+    /// </summary>
+    public static IDisposable SuppressSystemIdUniqueness() => new SystemIdSuppressionScope();
+
+    private sealed class SystemIdSuppressionScope : IDisposable
+    {
+        private readonly bool _previous;
+        public SystemIdSuppressionScope()
+        {
+            _previous = _suppressSystemIdUniqueness;
+            _suppressSystemIdUniqueness = true;
+        }
+        public void Dispose() => _suppressSystemIdUniqueness = _previous;
+    }
+
     private static void CheckNoDuplicateSystemId(object? provider, object? recordBuffer)
     {
+        if (_suppressSystemIdUniqueness) return;
         if (recordBuffer == null || !BlobStoreIsolationPatches.IsDatabaseBacked(provider)) return;
 
         var bufferType = recordBuffer.GetType();


### PR DESCRIPTION
Closes #2694

## What was happening

#2639 made `TempTableDataProvider.Insert` refuse a duplicate SystemId, modelling the clustered
unique constraint real SQL Server puts on `$systemId`. That is correct for an AL `Insert()`
statement and is unchanged here.

But `RecordPatches.RollbackToCommitPoint` restores a table by **clearing it and re-inserting the
snapshot rows through that same provider method**, so every restored row arrives at the guard
carrying the SystemId it already had. Real BC's rollback is a transaction abort — it issues no
INSERT at all — so a replay has no constraint to violate. Policing it is a category error, not a
stricter reading of the rule.

Traced with a stack dump at the throw:

```
RowVersionPatches.CheckNoDuplicateSystemId
RowVersionPatches.OnBeforeInsert
TempTableDataProvider.Insert
RecordPatches.InsertRows
RecordPatches.RollbackToCommitPoint          <- a snapshot replay, not AL
TestExecutor.ApplyTestTransactionModel
```

## Measured

Microsoft's Tests-SINGLESERVER, BC 28.1, same machine and command:

| build | tests run | pass |
|---|---:|---:|
| `main` | **0** of 878 | — (`EXEC-FAIL: … same values in a unique index … SystemId=4ca8d6ba-…`) |
| `d9f01ca1` (#2639's parent) | 878 | 195 |
| **this fix** | **878** | **196** |

A restore that throws part way is worse than either outcome it chooses between: the table keeps
some of the snapshot and none of the rest.

## The fix

A scoped, `[ThreadStatic]` suppression around the replay. Per-thread rather than a global off
switch because AL test bodies run on their own thread (`TestExecutor.InvokeWithTimeout`), and a
process-wide flag would let one thread's restore disable a genuine AL `Insert`'s check on
another. Dispose restores the **enclosing** state, so a rollback nested inside a rollback cannot
re-arm the check for the outer replay's remaining rows.

## Tests

`SystemIdRestoreSuppressionTests` (5): off by default; on inside the scope; restored on the way
out **including when the restore throws** — a leaked suppression would silently turn #2639's fix
into a no-op for the rest of the process; nesting restores the enclosing state rather than
unconditionally false; and the suppression does not leak to another thread.

`RowVersionPatchesTests` — #2639's own suite — still passes in full, so the guard still refuses a
genuine AL duplicate. 20/20 together.

## What this does NOT fix

The snapshot legitimately contained **two User Setup rows carrying the same SystemId**, which is
why the replay collided at all. Restoring them faithfully is correct — real BC restores what was
there — but those rows should not exist on a database-backed table. Something seeds them that
way, and that is a separate defect I have filed rather than folded in here; suppressing the check
during a replay makes the run work, it does not make those rows right.

## Why CI never caught this

The corpus stayed green throughout. Nothing in the gating suite exercises a rollback over a table
that already holds duplicate SystemIds, and the MS BaseApp buckets that do are not in CI — the
same blind spot #2694 was filed from.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf