### PR TITLE
fix(enum): keep compiled-deps enum sidecar base/extension entries separate

### DIFF
--- a/AlRunner.Tests/EnumExtensionSidecarRoundTripTests.cs
+++ b/AlRunner.Tests/EnumExtensionSidecarRoundTripTests.cs
@@ -1,0 +1,189 @@
+// EnumExtensionSidecarRoundTripTests — issue #2709.
+//
+// This is a RUNNER-MECHANISM test, not a claim about what real BC does: it proves that
+// AlEnumMetadataRegistry's compiled-deps/AL-output sidecar round-trip (SnapshotRaw /
+// SaveSidecar / LoadSidecar) keeps a base enum registration and an enumextension's own
+// values SEPARATE across a save+reload cycle, regardless of which one registers first
+// in the process. The BC-side claim ("an enumextension of a Base App enum still casts
+// to its interface and keeps the base's own values") is Base App behaviour, already
+// covered by the corpus per docs/rules/bc-behavior-tests-go-upstream.md — see the issue
+// body's acceptance-criteria note. This test exists so a regression in OUR OWN sidecar
+// mechanism fails loudly here, in milliseconds, without needing the BC engine or Base
+// App loaded at all.
+//
+// Root cause (see AlEnumMetadataRegistry.SnapshotRaw's doc comment): the OLD sidecar
+// persisted TryGet's MERGED base+extension view, flattened under the base id, with no
+// way to say "this came from an extension". Replaying that through plain Register()
+// then went wrong in one of two directions depending on registration order:
+//   - extension-sidecar replayed AFTER the real base registers -> clobbers the base
+//     (multi-bundle: Base App enum lost, "Unable to cast enum '' value '...'").
+//   - extension-sidecar replayed BEFORE the real base registers -> the later base
+//     registration overwrites the replayed (extension-only) entry, so the extension's
+//     value is gone (single-bundle: "Unable to cast enum '<base options only>' value
+//     '<extension ordinal>'").
+//
+// RED (pre-fix, i.e. AlEnumMetadataRegistry.SaveSidecar/LoadSidecar without the
+// `extends` marker and without routing extension-only entries through
+// RegisterExtension): MultiBundleOrder_ExtensionReplayAfterBase_DoesNotClobberBase and
+// SingleBundleOrder_ExtensionReplayBeforeBase_KeepsExtensionValue both fail.
+// GREEN (post-fix): both pass, and the merged view always carries base name + all base
+// values + all extension values.
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class EnumExtensionSidecarRoundTripTests : IDisposable
+{
+    private readonly string _root;
+
+    public EnumExtensionSidecarRoundTripTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-enum-ext-sidecar-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        AlEnumMetadataRegistry.Clear();
+    }
+
+    public void Dispose()
+    {
+        AlEnumMetadataRegistry.Clear();
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    // Mirrors the issue's real numbers: Base App enum 7011 "Price Calculation Handler"
+    // (0 "Not Defined", 7002 "Business Central (Version 16.0)", 7003 "Business Central
+    // (Version 15.0)") extended by enumextension 130515 "Price Calc. Handler - Test"
+    // (130514 "Test"). The exact ids don't matter to the mechanism; keeping them makes
+    // the test legible against the issue.
+    private const int BaseId = 7011;
+    private const string BaseName = "Price Calculation Handler";
+    private static readonly string[] BaseOptions = { "Not Defined", "Business Central (Version 16.0)", "Business Central (Version 15.0)" };
+    private static readonly int[] BaseIndexes = { 0, 7002, 7003 };
+
+    private const string ExtName = "Price Calc. Handler - Test";
+    private static readonly string[] ExtOptions = { "Test" };
+    private static readonly int[] ExtIndexes = { 130514 };
+
+    /// <summary>Simulates a source-compiled dependency's OWN sidecar write: the
+    /// enumextension compiles while the base enum is not yet in the registry (the
+    /// exact condition #1731's "own entries this dep's emit contributed" scoping
+    /// produces for Tests-TestLibraries extending Base App's 7011). Returns the path
+    /// written.</summary>
+    private string WriteDependencySidecarWithExtensionOnly()
+    {
+        AlEnumMetadataRegistry.Clear();
+        AlEnumMetadataRegistry.RegisterExtension(BaseId, ExtName, ExtOptions, ExtIndexes);
+        var path = Path.Combine(_root, "dep.enum-registry.json");
+        var count = AlEnumMetadataRegistry.SaveSidecar(path, new[] { BaseId });
+        Assert.Equal(1, count);
+        AlEnumMetadataRegistry.Clear();
+        return path;
+    }
+
+    [Fact]
+    public void SaveSidecar_ExtensionOnlyEntry_CarriesExtendsMarker_NotFlattenedUnderBaseName()
+    {
+        var path = WriteDependencySidecarWithExtensionOnly();
+        var json = File.ReadAllText(path);
+
+        // Positive: the persisted entry says "I am an extension of 7011", not "I am
+        // enum 7011 named 'Price Calc. Handler - Test'" (the pre-fix flattening the
+        // issue quotes verbatim).
+        Assert.Contains("\"extends\":7011", json);
+        Assert.Contains("\"options\":[\"Test\"]", json);
+
+        // Negative: the base enum's own name must NOT appear as if it were this
+        // entry's name — the whole defect was the extension's name overwriting it.
+        Assert.DoesNotContain($"\"name\":\"{BaseName}\"", json);
+    }
+
+    [Fact]
+    public void MultiBundleOrder_ExtensionReplayAfterBase_DoesNotClobberBase()
+    {
+        var depSidecar = WriteDependencySidecarWithExtensionOnly();
+
+        // Bundle 1: the real Base App registration (AddBcAppPath / RegisterFromAppPath
+        // in production) lands first and is never re-run for bundle 2 in the same
+        // process (the `_bcAppPaths.Contains` guard the issue names).
+        AlEnumMetadataRegistry.Register(BaseId, BaseName, BaseOptions, BaseIndexes);
+
+        // Bundle 2: dependency is a compiled-deps cache HIT, so its sidecar replays
+        // instead of re-emitting.
+        var replayed = AlEnumMetadataRegistry.LoadSidecar(depSidecar);
+        Assert.Equal(1, replayed);
+
+        Assert.True(AlEnumMetadataRegistry.TryGet(BaseId, out var merged),
+            "enum 7011 must still be registered after the dependency replay");
+
+        // Positive: the base's own name and every base value survive — this is
+        // literally "FixupEnumFieldOptionMetadata resolves 'Price Calculation Handler'
+        // by name" from the issue; a clobbered base has no such name at all.
+        Assert.Equal(BaseName, merged.Name);
+        foreach (var (opt, idx) in BaseOptions.Zip(BaseIndexes))
+        {
+            var i = Array.IndexOf(merged.Options, opt);
+            Assert.True(i >= 0, $"expected base option '{opt}' to survive; got [{string.Join(", ", merged.Options)}]");
+            Assert.Equal(idx, merged.Indexes[i]);
+        }
+
+        // Positive: the extension's value is ALSO present — replay must merge, not
+        // just "not clobber".
+        var extIdx = Array.IndexOf(merged.Options, "Test");
+        Assert.True(extIdx >= 0, $"expected extension option 'Test' to be merged in; got [{string.Join(", ", merged.Options)}]");
+        Assert.Equal(130514, merged.Indexes[extIdx]);
+
+        // Negative: this is exactly the value ALCompiler_ToInterfaceFromOption casts
+        // through Price Calculation Mgt.FindSetup's default (7003) — must resolve to a
+        // real base option, not the empty-name entry the bug produced.
+        Assert.NotEqual(string.Empty, merged.Name);
+    }
+
+    [Fact]
+    public void SingleBundleOrder_ExtensionReplayBeforeBase_KeepsExtensionValue()
+    {
+        var depSidecar = WriteDependencySidecarWithExtensionOnly();
+
+        // Single-bundle order per the issue: DependencyLoader.LoadAll (and its sidecar
+        // replay) runs BEFORE AddBcAppPath registers the base.
+        var replayed = AlEnumMetadataRegistry.LoadSidecar(depSidecar);
+        Assert.Equal(1, replayed);
+
+        // The base registers AFTER the replay.
+        AlEnumMetadataRegistry.Register(BaseId, BaseName, BaseOptions, BaseIndexes);
+
+        Assert.True(AlEnumMetadataRegistry.TryGet(BaseId, out var merged),
+            "enum 7011 must still be registered after the base registers over the replay");
+
+        Assert.Equal(BaseName, merged.Name);
+
+        // Positive: base values intact.
+        foreach (var opt in BaseOptions)
+            Assert.Contains(opt, merged.Options);
+
+        // Positive: the extension's value ('Test' / 130514, the exact repro's arm B —
+        // Codeunit79900.B_Literal_ExtensionValue_CastsToInterface) must NOT have been
+        // dropped by the base registering over it.
+        var extIdx = Array.IndexOf(merged.Options, "Test");
+        Assert.True(extIdx >= 0,
+            $"expected extension option 'Test' to survive the base registering afterwards; got [{string.Join(", ", merged.Options)}]");
+        Assert.Equal(130514, merged.Indexes[extIdx]);
+    }
+
+    [Fact]
+    public void LoadSidecar_LegacyEntryWithoutExtendsMarker_StillReplaysAsBaseRegistration()
+    {
+        // Negative/back-compat: a sidecar entry with no "extends" property at all
+        // (the pre-#2709 shape, and any plain base entry written by this build) must
+        // keep behaving as a base registration — never silently accumulate as an
+        // "extension of itself" or throw.
+        var path = Path.Combine(_root, "legacy.enum-registry.json");
+        File.WriteAllText(path,
+            "{\"enums\":[{\"id\":90300,\"name\":\"Legacy Enum\",\"options\":[\"A\",\"B\"],\"indexes\":[0,1],\"implementations\":[[],[]],\"captions\":[null,null]}]}");
+
+        var replayed = AlEnumMetadataRegistry.LoadSidecar(path);
+        Assert.Equal(1, replayed);
+
+        Assert.True(AlEnumMetadataRegistry.TryGet(90300, out var entry));
+        Assert.Equal("Legacy Enum", entry.Name);
+        Assert.Equal(new[] { "A", "B" }, entry.Options);
+    }
+}

--- a/AlRunner/Patches/EnumMetadataPatches.cs
+++ b/AlRunner/Patches/EnumMetadataPatches.cs
@@ -242,45 +242,88 @@ public static class AlEnumMetadataRegistry
     }
 
     /// <summary>
-    /// Serialize the given enum ids' MERGED entries (base + enumextension values
-    /// already flattened by <see cref="TryGet"/>) to a sidecar file. Mirrors
-    /// Program.cs's bundle-level <c>SaveEnumRegistrySidecar</c> (schema v3), but
-    /// scoped to <paramref name="onlyIds"/> so the dependency-loader's per-dep
-    /// cache sidecar does not leak sibling-app/bundle entries into its own file —
-    /// same convention as <see cref="AlReportMetadataRegistry.SaveSidecar(string, IEnumerable{int})"/>.
+    /// Raw (unmerged) entries for serialization: each base registration paired with
+    /// <c>ExtendsTargetId = null</c>, and each enumextension's OWN values (never
+    /// merged with the base) paired with <c>ExtendsTargetId = &lt;the base id it
+    /// targets&gt;</c>.
+    ///
+    /// Deliberately NOT <see cref="TryGet"/>/<see cref="Snapshot"/>'s merged view: a
+    /// sidecar built from the merged view cannot round-trip through
+    /// <see cref="Register"/> alone without one of two failures (issue #2709) —
+    /// replayed AFTER the target's real base registration, it clobbers the base
+    /// (multi-bundle: Base App enum 7011 lost); replayed BEFORE and then the real
+    /// base registers over it, the extension's values are lost (single-bundle:
+    /// enumextension value no longer casts). Keeping base and extension identities
+    /// distinct in the sidecar — exactly as <see cref="_byId"/>/<see cref="_extByTargetId"/>
+    /// already keep them distinct in memory — lets replay use
+    /// <see cref="Register"/>/<see cref="RegisterExtension"/> the same way emit does,
+    /// so a later real base (or extension) registration always merges instead of
+    /// overwriting.
+    /// </summary>
+    public static IEnumerable<(Entry Entry, int? ExtendsTargetId)> SnapshotRaw(IEnumerable<int>? onlyIds = null)
+    {
+        IEnumerable<int> ids;
+        if (onlyIds != null)
+            ids = new HashSet<int>(onlyIds);
+        else
+        {
+            var all = new HashSet<int>(_byId.Keys);
+            all.UnionWith(_extByTargetId.Keys);
+            ids = all;
+        }
+        foreach (var id in ids.OrderBy(i => i))
+        {
+            if (_byId.TryGetValue(id, out var baseEntry))
+                yield return (baseEntry, null);
+            if (_extByTargetId.TryGetValue(id, out var exts))
+                foreach (var ext in exts)
+                    yield return (ext, id);
+        }
+    }
+
+    /// <summary>
+    /// Serialize the given enum ids' RAW (unmerged) entries — see
+    /// <see cref="SnapshotRaw"/> for why raw, not merged — to a sidecar file (schema
+    /// v2: adds the <c>extends</c> marker; see #2709). Mirrors Program.cs's
+    /// bundle-level <c>SaveEnumRegistrySidecar</c>, but scoped to
+    /// <paramref name="onlyIds"/> so the dependency-loader's per-dep cache sidecar
+    /// does not leak sibling-app/bundle entries into its own file — same convention
+    /// as <see cref="AlReportMetadataRegistry.SaveSidecar(string, IEnumerable{int})"/>.
     /// Returns the number of entries written.
     /// </summary>
     public static int SaveSidecar(string path, IEnumerable<int> onlyIds)
     {
-        var idSet = new HashSet<int>(onlyIds);
-        var entries = new List<Entry>(idSet.Count);
-        foreach (var id in idSet)
-            if (TryGet(id, out var merged))
-                entries.Add(merged);
-        entries = entries.OrderBy(e => e.Id).ToList();
+        var raw = SnapshotRaw(onlyIds).ToList();
 
         var dto = new
         {
-            enums = entries.Select(e => new
+            enums = raw.Select(r => new
             {
-                id = e.Id,
-                name = e.Name,
-                options = e.Options,
-                indexes = e.Indexes,
-                implementations = e.Implementations,
-                captions = e.Captions,
+                id = r.Entry.Id,
+                name = r.Entry.Name,
+                options = r.Entry.Options,
+                indexes = r.Entry.Indexes,
+                implementations = r.Entry.Implementations,
+                captions = r.Entry.Captions,
                 // #2306 — the enum-level Default/UnknownValue implementation fallbacks. Absent
                 // from a sidecar written before this and read back as null, which means
                 // "declares none" and is the pre-#2306 behaviour; the AL-output cache key
                 // hashes the runner assembly's own content, so such a sidecar is unreachable
                 // from this build anyway.
-                defaultImplementations = e.DefaultImplementations,
-                unknownImplementations = e.UnknownImplementations,
+                defaultImplementations = r.Entry.DefaultImplementations,
+                unknownImplementations = r.Entry.UnknownImplementations,
+                // #2709 — null for a base registration; the base enum id it extends for an
+                // enumextension's own (unmerged) entry. Absent/null on replay means "plain
+                // Register", exactly like a pre-#2709 sidecar (which never carried this
+                // property) — but the cache key already hashes the runner assembly's own
+                // content, so a pre-#2709 sidecar is unreachable from this build anyway; the
+                // fallback is defensive, not load-bearing.
+                extends = r.ExtendsTargetId,
             }).ToArray(),
         };
         var json = System.Text.Json.JsonSerializer.Serialize(dto);
         File.WriteAllText(path, json);
-        return entries.Count;
+        return raw.Count;
     }
 
     /// <summary>
@@ -353,8 +396,22 @@ public static class AlEnumMetadataRegistry
                 foreach (var c in capEl.EnumerateArray())
                     captions[ci++] = c.ValueKind == System.Text.Json.JsonValueKind.Null ? null : c.GetString();
             }
-            Register(id, name, opts, idxs, implementations, captions,
-                ReadIdList(e, "defaultImplementations"), ReadIdList(e, "unknownImplementations"));
+            // #2709 — a present, non-null `extends` marks this entry as an
+            // enumextension's own (unmerged) values, targeting the base enum id it
+            // names; replay through RegisterExtension so it accumulates alongside
+            // whatever base/other-extension entries this process already holds,
+            // instead of overwriting the base enum's own _byId slot. Absent (older
+            // sidecar written before #2709, or a plain base entry) replays through
+            // Register exactly as before.
+            int? extendsTargetId = null;
+            if (e.TryGetProperty("extends", out var extEl) && extEl.ValueKind == System.Text.Json.JsonValueKind.Number)
+                extendsTargetId = extEl.GetInt32();
+
+            if (extendsTargetId.HasValue)
+                RegisterExtension(extendsTargetId.Value, name, opts, idxs, implementations, captions);
+            else
+                Register(id, name, opts, idxs, implementations, captions,
+                    ReadIdList(e, "defaultImplementations"), ReadIdList(e, "unknownImplementations"));
             count++;
         }
         return count;

--- a/AlRunner/ProgramSupport/Suites.cs
+++ b/AlRunner/ProgramSupport/Suites.cs
@@ -8,25 +8,32 @@ internal static partial class ProgramSupport
 
     // Sidecar: serialize AlEnumMetadataRegistry to <key>.enum-registry.json so
     // cache HIT can replay the side-effect that emit would have populated.
-    // Schema (v9): { "enums": [ { "id": int, "name": string, "options": [string], "indexes": [int], "implementations": [[int]], "captions": [string?] }, ... ] }
+    // Schema (v10, #2709): { "enums": [ { "id": int, "name": string, "options": [string], "indexes": [int], "implementations": [[int]], "captions": [string?], "extends": int? }, ... ] }
+    // v10 switched from AlEnumMetadataRegistry.Snapshot()'s MERGED base+extension view to
+    // SnapshotRaw()'s unmerged one — a merged entry replayed through Register alone
+    // clobbers whichever of base/extension registers for real later in the process (#2709;
+    // see SnapshotRaw's doc comment for the two failure shapes this caused).
     internal static int SaveEnumRegistrySidecar(string path)
     {
-        var entries = AlEnumMetadataRegistry.Snapshot();
+        var raw = AlEnumMetadataRegistry.SnapshotRaw().ToList();
         var dto = new
         {
-            enums = entries.Select(e => new
+            enums = raw.Select(r => new
             {
-                id = e.Id,
-                name = e.Name,
-                options = e.Options,
-                indexes = e.Indexes,
-                implementations = e.Implementations,
-                captions = e.Captions,
+                id = r.Entry.Id,
+                name = r.Entry.Name,
+                options = r.Entry.Options,
+                indexes = r.Entry.Indexes,
+                implementations = r.Entry.Implementations,
+                captions = r.Entry.Captions,
                 // #2306 — the enum-level DefaultImplementation / UnknownValueImplementation
                 // fallbacks, without which an enum that names no per-value Implementation cannot
                 // be cast to its interface on a cache HIT.
-                defaultImplementations = e.DefaultImplementations,
-                unknownImplementations = e.UnknownImplementations,
+                defaultImplementations = r.Entry.DefaultImplementations,
+                unknownImplementations = r.Entry.UnknownImplementations,
+                // #2709 — null for a base registration; the base enum id an enumextension's
+                // own (unmerged) entry targets otherwise. See SnapshotRaw.
+                extends = r.ExtendsTargetId,
             }).ToArray(),
             // v4: per-report runtime metadata XML captured from emit — replayed on
             // cache HIT so NavReportSync builds real MetaReport instances.
@@ -68,7 +75,7 @@ internal static partial class ProgramSupport
             WriteIndented = false,
         });
         File.WriteAllText(path, json);
-        return entries.Count;
+        return raw.Count;
     }
 
     // Replay AlEnumMetadataRegistry from <key>.enum-registry.json. Throws on
@@ -138,8 +145,19 @@ internal static partial class ProgramSupport
                 foreach (var c in capEl.EnumerateArray())
                     captions[ci++] = c.ValueKind == System.Text.Json.JsonValueKind.Null ? null : c.GetString();
             }
-            AlEnumMetadataRegistry.Register(id, name, opts, idxs, implementations, captions,
-                ReadIdList(e, "defaultImplementations"), ReadIdList(e, "unknownImplementations"));
+            // #2709 — see AlEnumMetadataRegistry.LoadSidecar's matching comment: a present
+            // `extends` marks this entry as an enumextension's own (unmerged) values, so
+            // replay it through RegisterExtension, never Register, or it clobbers the base
+            // enum's _byId slot instead of accumulating alongside it.
+            int? extendsTargetId = null;
+            if (e.TryGetProperty("extends", out var extEl) && extEl.ValueKind == System.Text.Json.JsonValueKind.Number)
+                extendsTargetId = extEl.GetInt32();
+
+            if (extendsTargetId.HasValue)
+                AlEnumMetadataRegistry.RegisterExtension(extendsTargetId.Value, name, opts, idxs, implementations, captions);
+            else
+                AlEnumMetadataRegistry.Register(id, name, opts, idxs, implementations, captions,
+                    ReadIdList(e, "defaultImplementations"), ReadIdList(e, "unknownImplementations"));
             count++;
         }
         // v4: replay per-report metadata XML (absent in pre-v4 sidecars — fine,


### PR DESCRIPTION
Closes #2709

The compiled-deps enum-registry sidecar (and its bundle-level AL-output cache sibling) persisted `AlEnumMetadataRegistry`'s MERGED base+enumextension view (`TryGet`/`Snapshot`), flattened under the base enum's own id with no way to say "this entry came from an extension". Replaying that through plain `Register()` then clobbered whichever of base/extension registered for real later in the process:

- Multi-bundle (`app tests`, dependency compiled-deps cache HIT): bundle 2's replay overwrote bundle 1's real Base App registration, losing enum 7011 "Price Calculation Handler" entirely — casts to interface failed with `Unable to cast enum '' value '7003' to interface`.
- Single-bundle (dependency replay runs before `AddBcAppPath`): the base registering afterwards overwrote the replayed entry, dropping the enumextension's own value — `Unable to cast enum 'Not Defined,...' value '130514' to interface`.

`AlEnumMetadataRegistry.SnapshotRaw` (new) keeps base and extension entries distinct in the sidecar via an `extends` marker. `SaveSidecar`/`LoadSidecar` (dependency-loader per-dep cache) and `ProgramSupport.SaveEnumRegistrySidecar`/`LoadEnumRegistrySidecar` (bundle-level AL-output cache — same defect shape, same fix) now replay through `Register`/`RegisterExtension` the same way emit does, so a later real registration always merges instead of overwriting. Old sidecars are unreachable regardless (the cache key already hashes the runner assembly's own content), so no explicit schema-version bump was needed.

## Fix the shape, not just the reported line

1. **Same wrong pattern elsewhere?** Yes — `ProgramSupport.SaveEnumRegistrySidecar`/`LoadEnumRegistrySidecar` in `AlRunner/ProgramSupport/Suites.cs` (the bundle-level AL-output cache sidecar) had the identical merged-snapshot-then-plain-Register defect. Fixed in the same PR.
2. **Sibling function, same assumption?** `AlEnumMetadataRegistry.Snapshot()` (the merged view) is still correct and unchanged — it's consumed by `RecordPatches.AllObjVirtualTable` and `NclMetaTableBuilder` for read-only display/lookup, which is fine since nothing replays it through `Register` alone. Only the two *persist-then-replay* call sites needed the raw/unmerged view.
3. **Two paths, same invariant?** Both sidecar read/write pairs (dependency-loader and bundle-level) now carry the same `extends` marker and the same replay logic — checked so one couldn't silently regress while the other was fixed.

## Testing

- `AlRunner.Tests/EnumExtensionSidecarRoundTripTests.cs` — new runner-mechanism test (4 cases) directly exercising `SnapshotRaw`/`SaveSidecar`/`LoadSidecar`, reproducing both failure directions plus a legacy-sidecar back-compat case. RED confirmed against the pre-fix registry (3/4 failed, matching both described failure shapes byte-for-byte); GREEN after the fix (4/4 pass).
- End-to-end verification against the issue's own repro (app+tests bundles depending on the real `Tests-TestLibraries`/Base App `Price Calculation Handler` enum 7011), run locally through the actual three-run cache sequence:

  | Run | Before this fix (issue) | After this fix |
  |---|---|---|
  | `tests` (fresh cache) | 5P/0F/0E | 5P/0F/0E |
  | `app tests2` (dep HIT, tests MISS) | 2P/3F/0E | 5P/0F/0E |
  | `tests3` (single bundle, same cache) | 4P/1F/0E | 5P/0F/0E |

This is a runner-mechanism fix with no new BC-behavior claim — the acceptance criteria in #2709 note the BC-side claim (enumextension of a Base App enum casts to its interface) is already covered by Base App behaviour; nothing new needed upstream in the al-language corpus for this fix.