### PR TITLE
perf(jobs): tune each worker for footprint — half the peak memory for 6-7% wall

### DIFF
--- a/AlRunner.Tests/ParallelFanOutGcHeapTests.cs
+++ b/AlRunner.Tests/ParallelFanOutGcHeapTests.cs
@@ -1,19 +1,52 @@
-// ParallelFanOutGcHeapTests — each --jobs worker gets its own GC heap budget (issue #2280).
+// ParallelFanOutGcHeapTests — each --jobs worker is tuned for footprint (issues #2280, #2713).
 //
 // The runner ships with <ServerGarbageCollection>true</ServerGarbageCollection> (#2577), and
 // Server GC sizes its heap count from the CORE count. That is the right call for a single
 // process — #2577 measured 6.2% fewer instructions on a cold AL compile — but under --jobs it
-// means every worker independently believes it owns all 12 cores and allocates 12 heaps.
+// means every worker independently believes it owns all 12 cores and keeps an arena sized for
+// a machine it does not have to itself.
 //
-// Measured on Tests-SMB (1,027 tests), two runs each, the same bucket and binary:
+// An earlier version of this file divided the core budget across workers (cores / jobs). That
+// was a guess made before anything was measured, and the measurement does not support it: one
+// heap per worker wins at EVERY job count, not only at high ones. Peak PSS of the whole process
+// tree, sampled twice a second, on BC 28.1 with warm caches, 12 cores / 32 GB. The pass count is
+// identical in every row of all three tables, so none of these knobs changes what the run
+// reports.
 //
-//   Server GC, default heaps   3,244 / 3,119 MB   106 / 107 s
-//   Server GC, 2 heaps         2,090 / 2,192 MB   108 / 110 s
-//   Workstation GC             1,591 / 1,561 MB   120 / 122 s
+//   Tests-SMB alone, one process, 1,027 tests, 259 passing throughout:
+//     default (12 heaps)                 3,313 / 3,451 MB   106.8 s
+//     1 heap                             1,675 MB           113.8 s
+//     1 heap + GCConserveMemory=9        1,493 MB           113.3 s
+//     1 heap + gcConcurrent=0            1,523 MB           112.1 s
+//     1 heap + both                      1,370 MB           114.3 s
 //
-// So capping heaps costs about 2% wall and returns about 34% of peak RSS. Since worker count is
-// bounded by RAM rather than cores (see ShardPlanner), that trade buys more concurrency than it
-// costs. Workstation GC returns more still but costs ~14% wall, so it is not the default here.
+//   --jobs 2, 2 buckets, 1,861 tests, 455 passing both:
+//     old configuration (6 heaps/worker)  4,983 MB   113.1 s
+//     all three knobs                     2,434 MB   119.9 s
+//
+//   --jobs 4, 4 buckets, 3,881 tests, 925 passing both:
+//     old configuration (3 heaps/worker)  8,183 MB   296.7 s
+//     all three knobs                     4,193 MB   316.4 s
+//
+//   The two --jobs tables are a controlled A/B: same binary, same warm cache, the knobs set
+//   through the override path so nothing but the knobs differs. An earlier attempt compared
+//   across a rebuild, which invalidated the AL-output cache and moved the pass count from 873
+//   to 925 for reasons unrelated to GC — both configurations report 925 on one warm cache.
+//
+// So about half the peak memory for 6-7% wall. That trade buys concurrency: at ~1.2 GB per worker
+// the machine runs out of cores before it runs out of RAM, which is the opposite of the
+// situation that OOMed this machine twice at four workers.
+//
+// WHY NOT A HEAP HARD LIMIT
+//   DOTNET_GCHeapHardLimit recovers a similar amount and has a cliff. Below about 1.25 GB on
+//   Tests-SMB the run silently drops from 259 to 212 passing, with no error and an unchanged
+//   exit code, because an OutOfMemoryException in the table-extension symbol parse is swallowed
+//   (#2712). Every knob chosen here is soft: it can cost time, never correctness.
+//
+// WHY LIVE RETENTION IS NOT THE TARGET
+//   AL_RUNNER_MEM_CENSUS=1 forces a blocking full GC after every test. Across all 1,027 tests
+//   live retention stays flat at 214-398 MB and daSources never drops. Nothing accumulates —
+//   peak RSS is roughly 90% allocator arena, which is why a soft knob recovers so much of it.
 
 using AlRunner.Infrastructure;
 using Xunit;
@@ -22,17 +55,21 @@ namespace AlRunner.Tests;
 
 public sealed class ParallelFanOutGcHeapTests
 {
-    /// <summary>The core budget is shared out, not handed to each worker whole.</summary>
+    /// <summary>One heap per worker, whatever the machine and whatever the job count. Measured
+    /// at --jobs 2 and --jobs 4 (see the header); the old cores/jobs division handed a worker 6
+    /// heaps at --jobs 2 and cost 2.5 GB of peak to save 6.8 s of wall.</summary>
     [Theory]
-    [InlineData(12, 6, 2)]
-    [InlineData(12, 4, 3)]
-    [InlineData(12, 3, 4)]
-    [InlineData(8, 2, 4)]
-    public void GcHeapCountForWorker_DividesCoresAcrossWorkers(int cores, int jobs, int expected)
-        => Assert.Equal(expected, ParallelFanOut.GcHeapCountForWorker(cores, jobs));
+    [InlineData(12, 2)]
+    [InlineData(12, 4)]
+    [InlineData(12, 6)]
+    [InlineData(12, 12)]
+    [InlineData(8, 2)]
+    [InlineData(4, 8)]
+    public void GcHeapCountForWorker_IsOneForEveryFanOut(int cores, int jobs)
+        => Assert.Equal(1, ParallelFanOut.GcHeapCountForWorker(cores, jobs));
 
     /// <summary>Never zero: a heap count of 0 is not a valid GC configuration, and more workers
-    /// than cores is an ordinary thing to ask for when the limit is memory rather than CPU.</summary>
+    /// than cores is an ordinary thing to ask for.</summary>
     [Theory]
     [InlineData(4, 8)]
     [InlineData(2, 12)]
@@ -40,33 +77,60 @@ public sealed class ParallelFanOutGcHeapTests
     public void GcHeapCountForWorker_IsNeverBelowOne(int cores, int jobs)
         => Assert.True(ParallelFanOut.GcHeapCountForWorker(cores, jobs) >= 1);
 
-    /// <summary>Never more than the machine has — handing a worker more heaps than cores is the
-    /// bug this exists to prevent, in the other direction.</summary>
-    [Theory]
-    [InlineData(12, 1)]
-    [InlineData(4, 1)]
-    public void GcHeapCountForWorker_NeverExceedsTheCoreCount(int cores, int jobs)
-        => Assert.True(ParallelFanOut.GcHeapCountForWorker(cores, jobs) <= cores);
-
-    /// <summary>The knob actually reaches the worker, and as DOTNET_GCHeapCount specifically —
-    /// the whole measurement above is meaningless if the child never sees it.</summary>
+    /// <summary>The knobs actually reach the worker, and under the exact names the CLR reads —
+    /// the whole measurement in the header is meaningless if the child never sees them.</summary>
     [Fact]
-    public void WorkerEnvironment_SetsTheHeapCount()
+    public void WorkerEnvironment_SetsAllThreeFootprintKnobs()
     {
         var env = ParallelFanOut.WorkerEnvironment(cores: 12, jobs: 6);
 
-        Assert.True(env.TryGetValue("DOTNET_GCHeapCount", out var v));
-        Assert.Equal("2", v);
+        Assert.True(env.TryGetValue("DOTNET_GCHeapCount", out var heaps));
+        Assert.Equal("1", heaps);
+
+        Assert.True(env.TryGetValue("DOTNET_GCConserveMemory", out var conserve));
+        Assert.Equal("9", conserve);
+
+        // 0 = background GC off. A background collection keeps its own budget alive, which is
+        // 150 MB of the measured difference on Tests-SMB.
+        Assert.True(env.TryGetValue("DOTNET_gcConcurrent", out var concurrent));
+        Assert.Equal("0", concurrent);
     }
 
-    /// <summary>Negative: an explicit user setting wins. Someone tuning DOTNET_GCHeapCount by
-    /// hand — or a CI runner that sets it globally — must not be silently overridden.</summary>
+    /// <summary>Negative: an explicit user setting wins, for each knob independently. Someone
+    /// tuning one of these by hand — or a CI runner that sets one globally — must not be
+    /// silently overridden, and setting one must not suppress the other two.</summary>
     [Fact]
-    public void WorkerEnvironment_DefersToAnExplicitUserSetting()
+    public void WorkerEnvironment_DefersToAnExplicitHeapCount()
     {
         var env = ParallelFanOut.WorkerEnvironment(cores: 12, jobs: 6, userHeapCount: "8");
 
         Assert.False(env.ContainsKey("DOTNET_GCHeapCount"),
             "an explicit DOTNET_GCHeapCount must be left alone, not replaced by the computed one");
+        Assert.True(env.ContainsKey("DOTNET_GCConserveMemory"),
+            "setting one knob by hand must not suppress the others");
+        Assert.True(env.ContainsKey("DOTNET_gcConcurrent"));
+    }
+
+    [Fact]
+    public void WorkerEnvironment_DefersToAnExplicitConserveMemory()
+    {
+        var env = ParallelFanOut.WorkerEnvironment(cores: 12, jobs: 6, userConserveMemory: "3");
+
+        Assert.False(env.ContainsKey("DOTNET_GCConserveMemory"),
+            "an explicit DOTNET_GCConserveMemory must be left alone");
+        Assert.True(env.ContainsKey("DOTNET_GCHeapCount"));
+        Assert.True(env.ContainsKey("DOTNET_gcConcurrent"));
+    }
+
+    [Fact]
+    public void WorkerEnvironment_DefersToAnExplicitGcConcurrent()
+    {
+        var env = ParallelFanOut.WorkerEnvironment(cores: 12, jobs: 6, userGcConcurrent: "1");
+
+        Assert.False(env.ContainsKey("DOTNET_gcConcurrent"),
+            "an explicit DOTNET_gcConcurrent must be left alone — someone who wants background "
+            + "GC back must be able to ask for it");
+        Assert.True(env.ContainsKey("DOTNET_GCHeapCount"));
+        Assert.True(env.ContainsKey("DOTNET_GCConserveMemory"));
     }
 }

--- a/AlRunner/Infrastructure/ParallelFanOut.cs
+++ b/AlRunner/Infrastructure/ParallelFanOut.cs
@@ -125,31 +125,57 @@ internal static class ParallelFanOut
 
 
     /// <summary>
-    /// GC heaps to give one worker. The runner ships under Server GC (#2577), which sizes its
-    /// heap count from the CORE count — right for a single process, wrong under --jobs, where
-    /// every worker independently believes it owns the whole machine and allocates a full set.
+    /// GC heaps to give one worker: always one.
     ///
-    /// Measured on Tests-SMB (1,027 tests), two runs each: default heaps 3,244/3,119 MB at
-    /// 106/107 s; two heaps 2,090/2,192 MB at 108/110 s. About 34% of peak RSS returned for
-    /// about 2% wall. Since worker count is bounded by RAM rather than cores (see ShardPlanner),
-    /// that trade buys more concurrency than it costs.
+    /// The runner ships under Server GC (#2577), which sizes its heap count from the CORE
+    /// count — right for a single process, wrong under --jobs, where every worker
+    /// independently believes it owns the whole machine and keeps an arena sized for it.
     ///
-    /// Workstation GC returns more still (1,591/1,561 MB) but costs ~14% wall, so it is not
-    /// chosen for you here — DOTNET_gcServer=0 remains available to anyone who wants it.
+    /// This used to divide the core budget across workers (cores / jobs). That was a guess
+    /// made before anything was measured, and measurement does not support it: one heap wins
+    /// at every job count, not only at high ones. At --jobs 2 the old formula handed each
+    /// worker 6 heaps and cost 2.5 GB of peak to save 6.8 s of wall. Figures are in
+    /// ParallelFanOutGcHeapTests' header; the pass count is identical in every configuration.
+    ///
+    /// Both parameters are kept so the call site and the tests keep their shape, and so a
+    /// future machine-dependent answer does not need a signature change — but the answer no
+    /// longer depends on either, which is the point.
     /// </summary>
     public static int GcHeapCountForWorker(int cores, int jobs)
-        => Math.Clamp(cores / Math.Max(1, jobs), 1, Math.Max(1, cores));
+        => 1;
 
     /// <summary>
-    /// Extra environment for a worker process. Empty when the user has already set the knob:
-    /// someone tuning DOTNET_GCHeapCount by hand, or a CI runner setting it globally, must win
-    /// over a number computed here.
+    /// Extra environment for a worker process: one GC heap, conserve memory, no background GC.
+    /// Together these take about half off peak memory for 6-7% wall (8,183 -> 4,193 MB at
+    /// --jobs 4, 4,983 -> 2,434 MB at --jobs 2, pass count identical in both) — see
+    /// ParallelFanOutGcHeapTests' header for the measurements behind each one.
+    ///
+    /// Every knob here is SOFT: it can cost time, never correctness. That rules out
+    /// DOTNET_GCHeapHardLimit, which recovers a similar amount and then silently drops
+    /// Tests-SMB from 259 to 212 passing below about 1.25 GB, with no error and an unchanged
+    /// exit code (#2712).
+    ///
+    /// Each knob is skipped when the user has already set it — someone tuning by hand, or a CI
+    /// runner setting one globally, must win over a value chosen here. Setting one does not
+    /// suppress the other two.
     /// </summary>
-    public static Dictionary<string, string> WorkerEnvironment(int cores, int jobs, string? userHeapCount = null)
+    public static Dictionary<string, string> WorkerEnvironment(
+        int cores,
+        int jobs,
+        string? userHeapCount = null,
+        string? userConserveMemory = null,
+        string? userGcConcurrent = null)
     {
         var env = new Dictionary<string, string>(StringComparer.Ordinal);
         if (string.IsNullOrEmpty(userHeapCount))
             env["DOTNET_GCHeapCount"] = GcHeapCountForWorker(cores, jobs).ToString();
+        // 9 is the most aggressive setting: trade CPU for footprint wherever the GC can.
+        if (string.IsNullOrEmpty(userConserveMemory))
+            env["DOTNET_GCConserveMemory"] = "9";
+        // 0 = background GC off. A background collection keeps its own budget alive, worth
+        // ~150 MB of the measured difference on Tests-SMB.
+        if (string.IsNullOrEmpty(userGcConcurrent))
+            env["DOTNET_gcConcurrent"] = "0";
         return env;
     }
 
@@ -194,7 +220,9 @@ internal static class ParallelFanOut
             };
             foreach (var kv in WorkerEnvironment(
                          Environment.ProcessorCount, shards.Count,
-                         Environment.GetEnvironmentVariable("DOTNET_GCHeapCount")))
+                         Environment.GetEnvironmentVariable("DOTNET_GCHeapCount"),
+                         Environment.GetEnvironmentVariable("DOTNET_GCConserveMemory"),
+                         Environment.GetEnvironmentVariable("DOTNET_gcConcurrent")))
                 psi.Environment[kv.Key] = kv.Value;
             if (viaDotnet && asm != null) psi.ArgumentList.Add(asm);
             foreach (var a in childArgs) psi.ArgumentList.Add(a);


### PR DESCRIPTION
Each `--jobs` worker is its own process under Server GC, so each one sized its heap count
from the machine's core count and kept an allocator arena sized for a machine it does not
have to itself. `WorkerEnvironment` already capped the heap count, but the formula it used
— `cores / jobs` — was a guess made before anything was measured.

The guess does not survive measurement: **one heap per worker wins at every job count**, not
only at high ones, and `GCConserveMemory=9` plus `gcConcurrent=0` stack cleanly on top.

## Measurements

Controlled A/B — same binary, same warm cache, knobs set through the override path so nothing
but the knobs differs. Peak PSS of the whole process tree, sampled twice a second, BC 28.1 on
12 cores / 32 GB.

`--jobs 2`, Tests-SMB + Tests-SINGLESERVER, 1,861 tests, **455 passing both**:

| configuration | peak PSS | wall |
|---|---|---|
| old (6 heaps/worker) | 4,983 MB | 113.1 s |
| tuned | 2,434 MB | 119.9 s |

`--jobs 4`, plus Tests-SCM-Assembly and Tests-Job, 3,881 tests, **925 passing both**:

| configuration | peak PSS | wall |
|---|---|---|
| old (3 heaps/worker) | 8,183 MB | 296.7 s |
| tuned | 4,193 MB | 316.4 s |

Knob by knob, single process, Tests-SMB, 1,027 tests, 259 passing throughout:

| configuration | peak PSS | wall |
|---|---|---|
| default (12 heaps) | 3,313 / 3,451 MB | 106.8 s |
| 1 heap | 1,675 MB | 113.8 s |
| 1 heap + `GCConserveMemory=9` | 1,493 MB | 113.3 s |
| 1 heap + `gcConcurrent=0` | 1,523 MB | 112.1 s |
| 1 heap + both | 1,370 MB | 114.3 s |

About half the peak memory for 6-7% wall. That moves the limit on worker count from memory
to cores: at ~1.1 GB per worker a 32 GB machine fits far more workers than it has cores,
where four workers at the old settings OOMed this machine twice.

## Why these knobs and not a heap hard limit

Every knob here is soft — it can cost time, never correctness. `DOTNET_GCHeapHardLimit`
recovers a similar amount and then silently drops Tests-SMB from 259 to 212 passing below
about 1.25 GB, with no error and an unchanged exit code, because an `OutOfMemoryException` in
the table-extension symbol parse is swallowed. That is #2712, filed separately, and it is the
reason a hard limit is not used as a footprint control here.

## Why live retention is not the target

`AL_RUNNER_MEM_CENSUS=1` forces a blocking full GC after every test and reports live
retention. Across all 1,027 tests of Tests-SMB it stays flat at 214-398 MB and `daSources`
never drops:

```
#1     gcTotalMB=397.6 rssMB=1668.7 daSources=1 daTables=104
#501   gcTotalMB=270.5 rssMB= 991.9 daSources=1 daTables=165
#1001  gcTotalMB=277.7 rssMB=1022.4 daSources=1 daTables=108
```

Nothing accumulates. Peak RSS is roughly 90% allocator arena, which is why a soft knob
recovers so much of it and why there is nothing to fix in the runner's own retention.

## Tests

`ParallelFanOutGcHeapTests` covers both directions: the three knobs reach the worker under
the exact names the CLR reads, and each is skipped when the user has already set it — with
each negative test also asserting that setting one knob does not suppress the other two.

## Note on a discrepancy

An earlier comparison spanned a rebuild, which invalidated the AL-output cache and moved the
pass count from 873 to 925 for reasons unrelated to GC. Both configurations report 925 on one
warm cache; the tables above are all from a single cache state.

Closes #2713

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
