### PR TITLE
fix(shutdown): make BC's ExecutionScheduler thread background so a one-shot run exits; bound --jobs worker wait

### DIFF
--- a/AlRunner.Tests/ExecutionSchedulerBackgroundThreadTests.cs
+++ b/AlRunner.Tests/ExecutionSchedulerBackgroundThreadTests.cs
@@ -1,0 +1,64 @@
+// ExecutionSchedulerBackgroundThreadTests — issue #2704.
+//
+// BC's `ExecutionScheduler` constructor starts a real OS thread ("BC Execution Scheduler",
+// SchedulerLoop) that is FOREGROUND by default and only ever stops when `Dispose()` is
+// called — which nothing in Ncl or the runner does. `NavEnvironment.Instance.ExecutionScheduler`
+// is a process-lifetime lazy that roughly ten Ncl call sites realize as a side effect (the
+// captured trigger for #2704 was Base App's Feature Telemetry disposing a helper NavSession),
+// so a one-shot runner process that realizes it even once prints its summary and never exits.
+//
+// The fix is a Cecil rewrite of the constructor (NclCecilRewrite.Runtime.cs) that marks the
+// thread background before `Start()`. This test proves the rewrite landed on the Ncl the
+// engine actually loaded: construct a scheduler the way NavEnvironment's lazy does, read the
+// thread it started, and assert `IsBackground`. Without the rewrite the thread is foreground
+// (RED); the `finally` disposes it either way so a RED run does not leave the xunit host
+// hanging on exactly the thread this issue is about.
+
+using System.Reflection;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class ExecutionSchedulerBackgroundThreadTests
+{
+    private readonly BcEngineFixture _engine;
+
+    public ExecutionSchedulerBackgroundThreadTests(BcEngineFixture engine) => _engine = engine;
+
+    [SkippableFact]
+    public void SchedulerThread_IsBackground_SoItCannotOutliveMain()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var ncl = typeof(ITreeObject).Assembly;
+        var schedulerType = ncl.GetType("Microsoft.Dynamics.Nav.Runtime.ExecutionScheduler")!;
+        var queueType = ncl.GetType("Microsoft.Dynamics.Nav.Runtime.RoundRobinSchedulingQueue")!;
+        var ctor = Assert.Single(schedulerType.GetConstructors(BindingFlags.Public | BindingFlags.Instance));
+        Assert.Equal(6, ctor.GetParameters().Length);
+
+        var queue = Activator.CreateInstance(queueType)!;
+        // Same shape as NavEnvironment's lazy factory: createDisposed=false is the arm that
+        // starts the thread; sliceLength >= MinimumSliceLength(16); sampling period > 0.
+        var scheduler = (IDisposable)ctor.Invoke(new object?[] { 1, 16L, queue, false, 1000UL, null });
+        try
+        {
+            var threadField = schedulerType.GetField("schedulerThread",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(threadField);
+            var thread = Assert.IsType<Thread>(threadField!.GetValue(scheduler));
+            Assert.Equal("BC Execution Scheduler", thread.Name);
+            Assert.True(thread.IsAlive, "the constructor should have started SchedulerLoop");
+            Assert.True(thread.IsBackground,
+                "ExecutionScheduler's SchedulerLoop thread is FOREGROUND — the Cecil rewrite " +
+                "(NclCecilRewrite.Runtime.cs, #2704) did not land, so a one-shot run that realizes " +
+                "NavEnvironment.ExecutionScheduler will print its summary and never exit.");
+        }
+        finally
+        {
+            scheduler.Dispose();
+        }
+    }
+}

--- a/AlRunner.Tests/ExecutionSchedulerShutdownTests.cs
+++ b/AlRunner.Tests/ExecutionSchedulerShutdownTests.cs
@@ -1,0 +1,106 @@
+// ExecutionSchedulerShutdownTests — issue #2704, second layer.
+//
+// Exercises ExecutionSchedulerShutdown against a REAL Microsoft.Dynamics.Nav.Types.LazyEx of
+// a real ExecutionScheduler, built the same way NavEnvironment's field is — but a private
+// one, so no test here disposes the engine fixture's shared NavEnvironment scheduler under
+// the other engine tests. The three claims: an unrealized lazy is left unrealized (the helper
+// must never read .Value), a realized one is disposed and its thread leaves SchedulerLoop, and
+// a null field (the skeleton NavEnvironment) is a no-op.
+
+using System.Linq.Expressions;
+using System.Reflection;
+using AlRunner.Infrastructure;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class ExecutionSchedulerShutdownTests
+{
+    private readonly BcEngineFixture _engine;
+
+    public ExecutionSchedulerShutdownTests(BcEngineFixture engine) => _engine = engine;
+
+    private static Type SchedulerType => typeof(ITreeObject).Assembly
+        .GetType("Microsoft.Dynamics.Nav.Runtime.ExecutionScheduler")!;
+
+    /// <summary>A LazyEx&lt;ExecutionScheduler&gt; whose factory builds a live (createDisposed=false) scheduler.</summary>
+    private static object NewLazyScheduler()
+    {
+        var ncl = typeof(ITreeObject).Assembly;
+        var queueType = ncl.GetType("Microsoft.Dynamics.Nav.Runtime.RoundRobinSchedulingQueue")!;
+        var ctor = SchedulerType.GetConstructors(BindingFlags.Public | BindingFlags.Instance).Single();
+        var diagType = ctor.GetParameters()[5].ParameterType;
+
+        var body = Expression.New(ctor,
+            Expression.Constant(1), Expression.Constant(16L),
+            Expression.Convert(Expression.New(queueType), ctor.GetParameters()[2].ParameterType),
+            Expression.Constant(false), Expression.Constant(1000UL),
+            Expression.Constant(null, diagType));
+        var funcType = typeof(Func<>).MakeGenericType(SchedulerType);
+        var factory = Expression.Lambda(funcType, body).Compile();
+
+        // The exact closed type NavEnvironment's field uses (Microsoft.Dynamics.Nav.Types.LazyEx<ExecutionScheduler>).
+        var lazyType = ncl.GetType("Microsoft.Dynamics.Nav.Runtime.NavEnvironment")!
+            .GetField("executionScheduler", BindingFlags.NonPublic | BindingFlags.Instance)!.FieldType;
+        Assert.Equal("LazyEx`1", lazyType.Name);
+        return Activator.CreateInstance(lazyType, factory)!;
+    }
+
+    private static bool IsValueCreated(object lazy) =>
+        (bool)lazy.GetType().GetProperty("IsValueCreated")!.GetValue(lazy)!;
+
+    [Fact]
+    public void NullField_IsNoEnvironment()
+    {
+        Assert.Equal(ExecutionSchedulerShutdown.Outcome.NoEnvironment,
+            ExecutionSchedulerShutdown.DisposeIfRealized((object?)null));
+    }
+
+    [SkippableFact]
+    public void UnrealizedLazy_IsLeftUnrealized()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var lazy = NewLazyScheduler();
+        Assert.False(IsValueCreated(lazy));
+
+        Assert.Equal(ExecutionSchedulerShutdown.Outcome.NotRealized,
+            ExecutionSchedulerShutdown.DisposeIfRealized(lazy));
+
+        // The whole point: a shutdown helper that reads .Value would START the thread here.
+        Assert.False(IsValueCreated(lazy),
+            "DisposeIfRealized realized the lazy — it must decide on IsValueCreated only");
+    }
+
+    [SkippableFact]
+    public void RealizedLazy_IsDisposed_AndItsThreadExits()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var lazy = NewLazyScheduler();
+        var scheduler = lazy.GetType().GetProperty("Value")!.GetValue(lazy)!;
+        var thread = (Thread)SchedulerType.GetField("schedulerThread",
+            BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(scheduler)!;
+        Assert.True(thread.IsAlive);
+        try
+        {
+            Assert.Equal(ExecutionSchedulerShutdown.Outcome.Disposed,
+                ExecutionSchedulerShutdown.DisposeIfRealized(lazy));
+
+            var disposed = (bool)SchedulerType.GetField("disposed",
+                BindingFlags.NonPublic | BindingFlags.Instance)!.GetValue(scheduler)!;
+            Assert.True(disposed, "ExecutionScheduler.Dispose() did not run");
+            // SchedulerLoop waits at most sliceLength (16ms) per round, then sees `disposed`.
+            Assert.True(thread.Join(TimeSpan.FromSeconds(10)),
+                "SchedulerLoop thread is still running 10s after Dispose()");
+        }
+        finally
+        {
+            ((IDisposable)scheduler).Dispose();
+        }
+    }
+}

--- a/AlRunner.Tests/ParallelFanOutWorkerExitTests.cs
+++ b/AlRunner.Tests/ParallelFanOutWorkerExitTests.cs
@@ -1,0 +1,85 @@
+// ParallelFanOutWorkerExitTests — issue #2704, the --jobs half.
+//
+// ParallelFanOut.Run used to wait on each worker with a bare `p.WaitForExit()`. One worker
+// that finished its run but never exited (#2704: a foreground BC thread outliving Main) hung
+// the whole aggregate — no diagnostic, no partial results, even though every other worker's
+// output was already sitting in the parent. The kill decision is a pure function so this can
+// assert the policy without spawning processes: a worker gets a bounded grace period AFTER
+// its JUnit file appears (that file is written after the summary, so it is the "work is done"
+// signal — stdout EOF cannot be, since a hung child never closes its pipes), and an unbounded
+// wait BEFORE it (a genuinely long shard is --test-timeout's business, not this one's).
+
+using System.Text.RegularExpressions;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ParallelFanOutWorkerExitTests
+{
+    private static readonly TimeSpan Grace = TimeSpan.FromSeconds(60);
+
+    [Fact]
+    public void BeforeTheJUnitFileExists_NeverKills()
+    {
+        Assert.False(ParallelFanOut.ShouldKillWorker(junitWritten: false, TimeSpan.Zero, Grace));
+        Assert.False(ParallelFanOut.ShouldKillWorker(junitWritten: false, TimeSpan.FromHours(3), Grace));
+    }
+
+    [Fact]
+    public void AfterTheJUnitFileExists_KillsOnlyOnceGraceIsUsedUp()
+    {
+        Assert.False(ParallelFanOut.ShouldKillWorker(junitWritten: true, TimeSpan.Zero, Grace));
+        Assert.False(ParallelFanOut.ShouldKillWorker(junitWritten: true, Grace - TimeSpan.FromMilliseconds(1), Grace));
+        Assert.True(ParallelFanOut.ShouldKillWorker(junitWritten: true, Grace, Grace));
+        Assert.True(ParallelFanOut.ShouldKillWorker(junitWritten: true, Grace + TimeSpan.FromMinutes(5), Grace));
+    }
+
+    /// <summary>
+    /// A killed worker's Process.ExitCode is the kill signal (-1 / 137), not a verdict. Its
+    /// verdict is derivable from the JUnit file it already wrote: any failure or error → 1,
+    /// otherwise 0 — the same mapping Program.cs applies to its own results.
+    /// </summary>
+    [Fact]
+    public void KilledWorkerExitCode_ComesFromItsJUnitCounts()
+    {
+        Assert.Equal(0, ParallelFanOut.ExitCodeForKilledWorker(new JUnitTotals(12, 0, 0, 2)));
+        Assert.Equal(1, ParallelFanOut.ExitCodeForKilledWorker(new JUnitTotals(12, 1, 0, 0)));
+        Assert.Equal(1, ParallelFanOut.ExitCodeForKilledWorker(new JUnitTotals(12, 0, 1, 0)));
+    }
+
+    [Fact]
+    public void WorkerExitGrace_IsLongerThanAnyRealShutdown()
+    {
+        // JUnit write → coverage/classification output → return is well under a second;
+        // the grace only has to be long enough that no healthy worker is ever killed.
+        Assert.InRange(ParallelFanOut.WorkerExitGrace, TimeSpan.FromSeconds(30), TimeSpan.FromMinutes(5));
+    }
+
+    /// <summary>
+    /// Asserted against the source, the same way ParallelFanOutVisibilityTests does: the
+    /// regression is a specific call shape, and spawning real workers to observe a hang would
+    /// make the test itself hang on failure.
+    /// </summary>
+    [Fact]
+    public void RunNeverWaitsOnAWorkerWithoutABound()
+    {
+        var src = Source();
+        var bare = Regex.Matches(src, @"\.WaitForExit\(\s*\)").Select(m => m.Value).ToList();
+        Assert.True(bare.Count == 0,
+            "ParallelFanOut.cs waits on a worker with a bare WaitForExit() — one worker that " +
+            "finishes but never exits (#2704) hangs the whole --jobs run:\n  " + string.Join("\n  ", bare));
+    }
+
+    private static string Source()
+    {
+        var dir = AppContext.BaseDirectory;
+        for (var i = 0; i < 8 && dir != null; i++)
+        {
+            var p = Path.Combine(dir, "AlRunner", "Infrastructure", "ParallelFanOut.cs");
+            if (File.Exists(p)) return File.ReadAllText(p);
+            dir = Path.GetDirectoryName(dir);
+        }
+        throw new InvalidOperationException("could not locate AlRunner/Infrastructure/ParallelFanOut.cs");
+    }
+}

--- a/AlRunner/Infrastructure/ExecutionSchedulerShutdown.cs
+++ b/AlRunner/Infrastructure/ExecutionSchedulerShutdown.cs
@@ -1,0 +1,70 @@
+// ExecutionSchedulerShutdown — issue #2704, second layer.
+//
+// The primary fix for #2704 is the Cecil rewrite in NclCecilRewrite.Runtime.cs that marks
+// BC's "BC Execution Scheduler" thread background, so a realized scheduler can no longer keep
+// the process alive after Main returns. This is the tidy-shutdown layer on top of it: at the
+// end of a one-shot run, if some BC-internal path realized NavEnvironment's lazy scheduler,
+// dispose it so the thread leaves SchedulerLoop on its own instead of being torn down by
+// process exit. It is deliberately NOT the thing correctness rests on — disposal has to be
+// reached on every exit path, and the constructor rewrite does not.
+//
+// The one rule here: never READ `NavEnvironment.ExecutionScheduler`. The getter is
+// `executionScheduler.Value`, which realizes the lazy — a shutdown helper that touched it
+// would start the very thread it exists to stop. Everything below goes through the private
+// LazyEx field and its IsValueCreated flag.
+
+using System.Reflection;
+
+namespace AlRunner.Infrastructure;
+
+public static class ExecutionSchedulerShutdown
+{
+    public enum Outcome
+    {
+        /// <summary>Ncl was never loaded, or NavEnvironment has no instance / no lazy field (skeleton).</summary>
+        NoEnvironment,
+        /// <summary>The lazy exists but nothing realized it this run — nothing to dispose, nothing touched.</summary>
+        NotRealized,
+        /// <summary>The scheduler had been realized; its Dispose() ran.</summary>
+        Disposed,
+    }
+
+    /// <summary>
+    /// Dispose <c>NavEnvironment.Instance.ExecutionScheduler</c> if — and only if — it was
+    /// realized during this process. Safe to call when Ncl was never loaded (compile-only
+    /// runs): it looks the assembly up among those already loaded and never forces a load.
+    /// </summary>
+    public static Outcome DisposeIfRealized()
+    {
+        var ncl = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(a => string.Equals(a.GetName().Name, "Microsoft.Dynamics.Nav.Ncl", StringComparison.Ordinal));
+        var envType = ncl?.GetType("Microsoft.Dynamics.Nav.Runtime.NavEnvironment");
+        if (envType == null) return Outcome.NoEnvironment;
+
+        // The static backing field, not the Instance property: the runner hooks get_Instance
+        // and the skeleton fallback is an uninitialized object whose lazy field is null.
+        var instance = envType.GetField("instance", BindingFlags.NonPublic | BindingFlags.Static)?.GetValue(null);
+        if (instance == null) return Outcome.NoEnvironment;
+
+        var lazy = envType.GetField("executionScheduler", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(instance);
+        return DisposeIfRealized(lazy);
+    }
+
+    /// <summary>
+    /// Testable core: <paramref name="lazyScheduler"/> is a
+    /// <c>Microsoft.Dynamics.Nav.Types.LazyEx&lt;ExecutionScheduler&gt;</c> (or null). Reads
+    /// only <c>IsValueCreated</c> before deciding, so an unrealized lazy stays unrealized.
+    /// </summary>
+    public static Outcome DisposeIfRealized(object? lazyScheduler)
+    {
+        if (lazyScheduler == null) return Outcome.NoEnvironment;
+        var lazyType = lazyScheduler.GetType();
+        var isCreated = lazyType.GetProperty("IsValueCreated", BindingFlags.Public | BindingFlags.Instance)
+            ?? throw new InvalidOperationException($"{lazyType.FullName} has no IsValueCreated — BC LazyEx shape changed");
+        if (!(bool)isCreated.GetValue(lazyScheduler)!) return Outcome.NotRealized;
+
+        var value = lazyType.GetProperty("Value", BindingFlags.Public | BindingFlags.Instance)!.GetValue(lazyScheduler);
+        if (value is IDisposable disposable) disposable.Dispose();
+        return Outcome.Disposed;
+    }
+}

--- a/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
@@ -1699,7 +1699,76 @@ public static partial class NclCecilRewrite
             //    single-mechanism. No rewrite here — the body replace is upstream.
         }
 
+        RewriteExecutionSchedulerThreadToBackground(asm.MainModule);
+    }
 
+    /// <summary>
+    /// #2704 — ExecutionScheduler..ctor starts a FOREGROUND OS thread ("BC Execution
+    /// Scheduler", SchedulerLoop) that only ever stops when <c>Dispose()</c> is called, and
+    /// nothing in Ncl or the runner calls it. <c>NavEnvironment.Instance.ExecutionScheduler</c>
+    /// is a process-lifetime lazy that roughly ten Ncl call sites realize as a side effect
+    /// (the captured #2704 trigger was Base App's Feature Telemetry disposing a helper
+    /// NavSession — <c>NavSession.InnerDispose</c> reads the lazy). On a service tier the
+    /// process never exits anyway; in a one-shot CLI process the thread keeps the CLR alive
+    /// after Main returns — the summary prints and the process hangs (#2650 was the same
+    /// defect through the PBT-enqueue trigger; #2628 removed that trigger, not the defect).
+    ///
+    /// Fix at the constructor, so every trigger — enumerated or not — is covered: insert
+    /// <c>dup; ldc.i4.1; callvirt Thread::set_IsBackground</c> before the single
+    /// <c>callvirt Thread::Start()</c>. The thread is parked in <c>Monitor.Wait</c>, so
+    /// tearing it down at process exit is harmless; during a run nothing changes, and
+    /// --server/--watch keep the process alive via the main thread regardless.
+    ///
+    /// Token-safe: <c>Thread::set_IsBackground(bool)</c> is ALREADY a memberRef in Ncl
+    /// (NavEnvironment's CollectAndCompactHeap thread sets it), and that existing
+    /// <see cref="MethodReference"/> is reused verbatim — no new typeRef/memberRef, so R2R
+    /// callers' token offsets are untouched. If either shape is missing this throws rather
+    /// than importing a fresh reference, per the token-shift rule.
+    /// </summary>
+    private static void RewriteExecutionSchedulerThreadToBackground(ModuleDefinition nclMod)
+    {
+        const string ThreadFullName = "System.Threading.Thread";
+
+        var navEnvT = nclMod.GetType("Microsoft.Dynamics.Nav.Runtime.NavEnvironment")
+            ?? throw new InvalidOperationException(
+                "[Cecil] NavEnvironment not found — Ncl shape changed; do not commit");
+        var setIsBackground = navEnvT.Methods
+            .Where(m => m.HasBody)
+            .SelectMany(m => m.Body.Instructions)
+            .Where(i => i.OpCode == OpCodes.Callvirt
+                && i.Operand is MethodReference mr
+                && mr.DeclaringType.FullName == ThreadFullName
+                && mr.Name == "set_IsBackground"
+                && mr.Parameters.Count == 1)
+            .Select(i => (MethodReference)i.Operand)
+            .FirstOrDefault()
+            ?? throw new InvalidOperationException(
+                "[Cecil] no existing Thread::set_IsBackground memberRef in NavEnvironment — " +
+                "cannot make ExecutionScheduler's thread background without adding a memberRef " +
+                "(R2R token-shift rule); Ncl shape changed; do not commit");
+
+        var ctor = FindNclMethod(nclMod,
+            "Microsoft.Dynamics.Nav.Runtime.ExecutionScheduler", ".ctor", 6);
+        var starts = ctor.Body.Instructions
+            .Where(i => i.OpCode == OpCodes.Callvirt
+                && i.Operand is MethodReference mr
+                && mr.DeclaringType.FullName == ThreadFullName
+                && mr.Name == "Start"
+                && mr.Parameters.Count == 0)
+            .ToList();
+        if (starts.Count != 1)
+            throw new InvalidOperationException(
+                $"[Cecil] expected exactly 1 Thread::Start() in ExecutionScheduler..ctor, found {starts.Count} — Ncl shape changed; do not commit");
+
+        // Stack at Start(): [thread]. dup → [thread, thread]; ldc.i4.1 → [thread, thread, 1];
+        // callvirt set_IsBackground → [thread]; then the original Start() consumes it.
+        var il = ctor.Body.GetILProcessor();
+        var start = starts[0];
+        il.InsertBefore(start, il.Create(OpCodes.Dup));
+        il.InsertBefore(start, il.Create(OpCodes.Ldc_I4_1));
+        il.InsertBefore(start, il.Create(OpCodes.Callvirt, setIsBackground));
+        ctor.Body.MaxStackSize += 2;
+        Console.Error.WriteLine("[Cecil] ExecutionScheduler..ctor: SchedulerLoop thread → IsBackground=true before Start() (#2704: foreground thread outlived Main)");
     }
 
     private static void AddRuntimeOwned(HashSet<string> set)

--- a/AlRunner/Infrastructure/ParallelFanOut.cs
+++ b/AlRunner/Infrastructure/ParallelFanOut.cs
@@ -240,18 +240,20 @@ internal static class ParallelFanOut
         for (var i = 0; i < procs.Count; i++)
         {
             var (p, junit, so, se) = procs[i];
-            p.WaitForExit();
+            var killed = WaitForWorkerExit(p, junit, i);
             var stdout = so.GetAwaiter().GetResult();
             var stderr = se.GetAwaiter().GetResult();
-            if (p.ExitCode > worst) worst = p.ExitCode;
 
             Console.WriteLine();
-            Console.WriteLine($"───── shard {i} (exit {p.ExitCode}) ─────");
+            Console.WriteLine($"───── shard {i} (exit {(killed ? "killed" : p.ExitCode.ToString())}) ─────");
             if (!string.IsNullOrWhiteSpace(stdout)) Console.WriteLine(stdout.TrimEnd());
             if (!string.IsNullOrWhiteSpace(stderr)) Console.Error.WriteLine(stderr.TrimEnd());
 
             var c = JUnitCounts.Read(junit);
             tests += c.Tests; failures += c.Failures; errors += c.Errors; skipped += c.Skipped;
+
+            var exit = killed ? ExitCodeForKilledWorker(c) : p.ExitCode;
+            if (exit > worst) worst = exit;
         }
 
         Console.WriteLine();
@@ -267,6 +269,61 @@ internal static class ParallelFanOut
 
         try { Directory.Delete(tempDir, recursive: true); } catch { }
         return worst;
+    }
+
+    /// <summary>
+    /// How long a worker may stay alive AFTER it has written its JUnit file before the parent
+    /// kills it (#2704). The file is written after the summary, so once it exists the worker's
+    /// work is done and all that remains is process exit — well under a second when healthy.
+    /// Before the file exists the wait is unbounded: a long shard is --test-timeout's business.
+    /// Not a CLI flag on purpose; nothing legitimate takes this long to exit.
+    /// </summary>
+    public static readonly TimeSpan WorkerExitGrace = TimeSpan.FromSeconds(60);
+
+    /// <summary>Pure kill policy — see <see cref="WorkerExitGrace"/>.</summary>
+    public static bool ShouldKillWorker(bool junitWritten, TimeSpan sinceJunitWritten, TimeSpan grace)
+        => junitWritten && sinceJunitWritten >= grace;
+
+    /// <summary>
+    /// A killed worker's Process.ExitCode is the kill signal, not its verdict. It had already
+    /// written its results, so derive the verdict the way Program.cs does: any failure or
+    /// error → 1, otherwise 0.
+    /// </summary>
+    public static int ExitCodeForKilledWorker(JUnitTotals counts)
+        => counts.Failures + counts.Errors > 0 ? 1 : 0;
+
+    /// <summary>
+    /// Wait for a worker, bounded once its JUnit file has appeared. Returns true when the
+    /// worker had to be killed. #2704: a worker whose BC-internal foreground thread outlived
+    /// Main printed its summary and never exited; a bare WaitForExit() here then hung the
+    /// whole --jobs run with no diagnostic and no partial results, even though every other
+    /// worker's output was already in hand. Stdout EOF cannot be the "done" signal — a hung
+    /// child never closes its pipes — the JUnit file is.
+    /// </summary>
+    private static bool WaitForWorkerExit(System.Diagnostics.Process p, string junitPath, int shard)
+    {
+        var junitSeen = System.Diagnostics.Stopwatch.StartNew();
+        var junitWritten = false;
+        while (!p.WaitForExit(500))
+        {
+            if (!junitWritten && File.Exists(junitPath))
+            {
+                junitWritten = true;
+                junitSeen.Restart();
+            }
+            if (!ShouldKillWorker(junitWritten, junitSeen.Elapsed, WorkerExitGrace)) continue;
+
+            // Not "[jobs]"-tagged: FilteredWriter would drop it, and this is the one line that
+            // tells the reader why the exit column says "killed".
+            Console.Error.WriteLine(
+                $"jobs: shard {shard} (pid {p.Id}) wrote its results but did not exit within " +
+                $"{WorkerExitGrace.TotalSeconds:F0}s — killing its process tree and reporting the " +
+                "results it wrote (a foreground thread outliving Main; see issue #2704)");
+            try { p.Kill(entireProcessTree: true); } catch { }
+            p.WaitForExit(10_000);
+            return true;
+        }
+        return false;
     }
 
     private static string Normalize(string p)

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3660,6 +3660,16 @@ if (Environment.GetEnvironmentVariable("AL_RUNNER_DUMP_INSTRUMENTATION_COUNTERS"
         $"dap.WorkPerformedCount={AlRunner.Infrastructure.AlDapSession.WorkPerformedCount}");
 }
 
+// #2704 second layer: if a BC-internal path realized NavEnvironment's lazy ExecutionScheduler
+// during this run (captured trigger: Feature Telemetry disposing a helper NavSession), dispose
+// it so its SchedulerLoop thread leaves on its own. The Cecil rewrite that marks that thread
+// background (NclCecilRewrite.Runtime.cs) is what guarantees exit; this is the tidy shutdown.
+// One-shot runs only — --server/--watch/--dap keep the process, and the scheduler, alive.
+if (!serverMode && !watchMode && !dapMode
+    && AlRunner.Infrastructure.ExecutionSchedulerShutdown.DisposeIfRealized()
+        == AlRunner.Infrastructure.ExecutionSchedulerShutdown.Outcome.Disposed)
+    Console.Error.WriteLine("[shutdown] disposed BC ExecutionScheduler that a BC-internal path realized during the run (#2704)");
+
 // Exit non-zero if anything failed — the default since the v2 cut, matching main/v1.
 // --no-strict-exit restores the old always-0 behaviour for JSON-only consumers.
 return strictExitCode ? computedExitCode : 0;


### PR DESCRIPTION
## Summary

A one-shot run could print its summary and never exit: BC's `ExecutionScheduler` constructor starts a foreground thread (`SchedulerLoop`) that only stops on `Dispose()`, and `NavEnvironment.Instance.ExecutionScheduler` is a process-lifetime lazy that roughly ten Ncl call sites realize as a side effect — the captured trigger was Base App's Feature Telemetry disposing a helper `NavSession`. Same defect as #2650, different trigger.

Three parts, in the order the issue discussion settled on:

1. **Primary — Cecil rewrite of `ExecutionScheduler..ctor`** (`NclCecilRewrite.Runtime.cs`): insert `dup; ldc.i4.1; callvirt Thread::set_IsBackground` before the single `Thread::Start()`. Token-safe: the `set_IsBackground` memberRef already exists in Ncl (NavEnvironment's CollectAndCompactHeap thread) and that `MethodReference` is reused verbatim; the rewrite throws rather than importing if either shape is missing. Checked the memberRef is present in Ncl for 27.0.38460.53934, 28.1, 28.2 and 28.4 artifacts on disk. Covers every trigger, enumerated or not.
2. **Second layer — tidy shutdown** (`ExecutionSchedulerShutdown.cs`, Program.cs tail): if something realized the lazy during a one-shot run, dispose it. Decides on `LazyEx.IsValueCreated` via the private field, never reading the getter (which would realize it). Skipped for `--server`/`--watch`/`--dap`.
3. **`--jobs` hardening** (`ParallelFanOut.cs`): the bare `p.WaitForExit()` is gone. A worker gets an unbounded wait until its JUnit file appears (that is written after the summary, so it is the "done" signal — stdout EOF cannot be, a hung child never closes its pipes), then a 60 s grace, then its process tree is killed with a stderr line saying why, and its already-written results are aggregated. A killed worker's verdict comes from its JUnit counts, not the kill signal.

## Evidence

Cold-cache `audit-2515` repro (the issue's bundle, `.cache` wiped before each run), 60 s bound after the `wall:` line:

| build | result |
|---|---|
| main (05508c92) | HUNG — summary at +48 s, still alive 60 s later, killed |
| this branch, run 1 | EXITED 0, post-summary 0 s |
| this branch, run 2 (fresh cache again) | EXITED 0, post-summary 2 s |

C# tests (RED → GREEN, run under the engine startup hooks):

- `ExecutionSchedulerBackgroundThreadTests` — constructs a scheduler the way NavEnvironment's lazy does and asserts the started thread `IsBackground`. Fails on unmodified Ncl ("thread is FOREGROUND"), passes with the rewrite.
- `ExecutionSchedulerShutdownTests` — unrealized lazy stays unrealized; realized lazy is disposed and its thread leaves `SchedulerLoop`; null field is a no-op.
- `ParallelFanOutWorkerExitTests` — kill policy (never before the JUnit file, only after grace), killed-worker exit code from counts, grace bounds, and a source assertion that no bare `WaitForExit()` remains.

`--jobs 2` smoke over two fixtures still aggregates and exits normally.

Closes #2704

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjXxeLNh8APsc1XZNpV6NJ
