### PR TITLE
fix(jobs): write a resumed run's carried cases into its JUnit so the --jobs aggregate is the whole run

### DIFF
--- a/AlRunner.Tests/JUnitReportCarriedCasesTests.cs
+++ b/AlRunner.Tests/JUnitReportCarriedCasesTests.cs
@@ -1,0 +1,159 @@
+// JUnitReportCarriedCasesTests — the JUnit a resumed run writes is the WHOLE run (issue #2716).
+//
+// A watchdog resume (#2280) re-runs a bundle in a fresh process with every attempted codeunit
+// excluded, so the final attempt's own results are a slice. Its printed summary folded the
+// earlier attempts' totals in (--merge-counts); its JUnit did not. Under --jobs the parent reads
+// only that JUnit, so the aggregate silently lost everything the earlier attempts ran — 26% of
+// the tests on the full BaseApp surface at --jobs 12. SuiteAbortOnTimeoutTests proves the
+// end-to-end shape with a real hang and a real resume; these pin the writer's mechanism in
+// milliseconds: carried suites are copied once, in attempt order, with their detail intact, and
+// a run with nothing carried writes byte-identical XML to before.
+
+using System.Xml.Linq;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class JUnitReportCarriedCasesTests : IDisposable
+{
+    private readonly string _dir = Path.Combine(Path.GetTempPath(), "junit-carried-" + Guid.NewGuid().ToString("N"));
+
+    public JUnitReportCarriedCasesTests() => Directory.CreateDirectory(_dir);
+    public void Dispose() { try { Directory.Delete(_dir, true); } catch { } }
+
+    private string P(string name) => Path.Combine(_dir, name);
+
+    private static TestResult T(string cu, string method, TestOutcome outcome, string? message = null, double secs = 0.5)
+        => new(cu, method, outcome, message, outcome == TestOutcome.Pass ? null : "at " + cu + "." + method,
+               TimeSpan.FromSeconds(secs));
+
+    private static BucketResult Bucket(params TestResult[] tests)
+        => new("/bundle", BucketStage.Ran, Array.Empty<string>(), null, tests,
+               TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero);
+
+    private static List<(string Suite, string Name)> Cases(string path)
+        => XDocument.Load(path).Descendants("testcase")
+            .Select(tc => ((string?)tc.Attribute("classname") ?? "", (string?)tc.Attribute("name") ?? ""))
+            .ToList();
+
+    /// <summary>
+    /// Positive: a chain of two earlier attempts plus this process's own results. Every case
+    /// appears exactly once, earlier attempts first, root totals cover all of it, and the parent's
+    /// reader (JUnitCounts.Read — what ParallelFanOut.Run aggregates with) sees the whole worker.
+    /// </summary>
+    [Fact]
+    public void WriteJUnit_FoldsEachCarriedAttemptOnce_InAttemptOrder()
+    {
+        var attempt1 = P("attempt1.xml");
+        JUnitReport.WriteJUnit(attempt1, new[] { Bucket(
+            T("CuA", "a1", TestOutcome.Pass),
+            T("CuA", "a2", TestOutcome.Fail, "boom: expected 1, got 2")) });
+        var attempt2 = P("attempt2.xml");
+        JUnitReport.WriteJUnit(attempt2, new[] { Bucket(
+            T("CuB", "b1", TestOutcome.Error, "Test exceeded 2s timeout."),
+            T("CuB", "b2", TestOutcome.Skipped, "manifest")) });
+
+        var final = P("final.xml");
+        JUnitReport.WriteJUnit(final, new[] { Bucket(T("CuC", "c1", TestOutcome.Pass, secs: 2.0)) },
+            new[] { attempt1, attempt2 });
+
+        var doc = XDocument.Load(final);
+        var root = doc.Root!;
+        Assert.Equal("testsuites", root.Name.LocalName);
+        Assert.Equal("5", (string?)root.Attribute("tests"));
+        Assert.Equal("1", (string?)root.Attribute("failures"));
+        Assert.Equal("1", (string?)root.Attribute("errors"));
+        Assert.Equal("1", (string?)root.Attribute("skipped"));
+        // 4 x 0.5s carried + 2.0s own.
+        Assert.Equal("4.000", (string?)root.Attribute("time"));
+
+        Assert.Equal(new[] { "CuA", "CuB", "CuC" },
+            root.Elements("testsuite").Select(s => (string?)s.Attribute("name")).ToArray());
+        Assert.Equal(new[] { ("CuA", "a1"), ("CuA", "a2"), ("CuB", "b1"), ("CuB", "b2"), ("CuC", "c1") },
+            Cases(final).ToArray());
+
+        // Detail survives the copy — a CI dashboard groups failures by this message.
+        var a2 = doc.Descendants("testcase").Single(tc => (string?)tc.Attribute("name") == "a2");
+        Assert.Equal("boom: expected 1, got 2", (string?)a2.Element("failure")!.Attribute("message"));
+        Assert.Contains("at CuA.a2", a2.Element("failure")!.Value);
+
+        // Each carried block is announced, so a reader can tell a resumed record from a clean one.
+        var comments = root.Nodes().OfType<XComment>().Select(c => c.Value).ToList();
+        Assert.Equal(2, comments.Count);
+        Assert.Contains(attempt1, comments[0]);
+        Assert.Contains(attempt2, comments[1]);
+
+        var totals = JUnitCounts.Read(final);
+        Assert.Equal(5, totals.Tests);
+        Assert.Equal(1, totals.Failures);
+        Assert.Equal(1, totals.Errors);
+        Assert.Equal(1, totals.Skipped);
+    }
+
+    /// <summary>
+    /// Negative: nothing carried, nothing added. The two-argument overload and an empty list
+    /// write byte-identical XML, with only this process's case in it — a run that never resumed
+    /// (every --jobs worker that did not hang, every ordinary run) is unchanged.
+    /// </summary>
+    [Fact]
+    public void WriteJUnit_WithNothingCarried_IsByteIdenticalToBefore()
+    {
+        var buckets = new[] { Bucket(T("CuC", "c1", TestOutcome.Pass), T("CuC", "c2", TestOutcome.Fail, "x")) };
+        JUnitReport.WriteJUnit(P("plain.xml"), buckets);
+        JUnitReport.WriteJUnit(P("empty-carry.xml"), buckets, Array.Empty<string>());
+
+        Assert.Equal(File.ReadAllText(P("plain.xml")), File.ReadAllText(P("empty-carry.xml")));
+        Assert.Equal(new[] { ("CuC", "c1"), ("CuC", "c2") }, Cases(P("plain.xml")).ToArray());
+        Assert.Equal("2", (string?)XDocument.Load(P("plain.xml")).Root!.Attribute("tests"));
+        Assert.Empty(XDocument.Load(P("plain.xml")).Root!.Nodes().OfType<XComment>());
+    }
+
+    /// <summary>
+    /// Negative: a missing or truncated carried file — what an attempt killed mid-write leaves —
+    /// contributes nothing and does not take this process's own results down with it. Same
+    /// stance as JUnitCounts.Read and CarriedFromEarlierAttempts, so the XML and the printed
+    /// summary agree on such a file.
+    /// </summary>
+    [Fact]
+    public void WriteJUnit_UnreadableCarriedFile_ContributesNothing_KeepsOwnResults()
+    {
+        var truncated = P("truncated.xml");
+        File.WriteAllText(truncated, "<testsuites><testsuite name=\"Gone\" tests=\"9\"");
+        var good = P("good.xml");
+        JUnitReport.WriteJUnit(good, new[] { Bucket(T("CuA", "a1", TestOutcome.Pass)) });
+
+        var final = P("final.xml");
+        JUnitReport.WriteJUnit(final, new[] { Bucket(T("CuC", "c1", TestOutcome.Pass)) },
+            new[] { P("does-not-exist.xml"), truncated, good });
+
+        Assert.Equal(new[] { ("CuA", "a1"), ("CuC", "c1") }, Cases(final).ToArray());
+        Assert.Equal(2, JUnitCounts.Read(final).Tests);
+        Assert.Single(XDocument.Load(final).Root!.Nodes().OfType<XComment>());
+    }
+
+    /// <summary>
+    /// A carried file whose root is a bare testsuite (no testsuites wrapper) is still one suite,
+    /// copied once — the same shape JUnitCounts.Read accepts, so the two never disagree on it.
+    /// </summary>
+    [Fact]
+    public void WriteJUnit_CarriedBareTestsuiteRoot_IsCopiedOnce()
+    {
+        var bare = P("bare.xml");
+        File.WriteAllText(bare, """
+            <testsuite name="Only" tests="2" failures="1" errors="0" skipped="0" time="1.5">
+              <testcase name="t1" classname="Only" time="1.0"/>
+              <testcase name="t2" classname="Only" time="0.5"><failure message="f"/></testcase>
+            </testsuite>
+            """);
+
+        var final = P("final.xml");
+        JUnitReport.WriteJUnit(final, Array.Empty<BucketResult>(), new[] { bare });
+
+        var root = XDocument.Load(final).Root!;
+        Assert.Equal("2", (string?)root.Attribute("tests"));
+        Assert.Equal("1", (string?)root.Attribute("failures"));
+        Assert.Equal("1.500", (string?)root.Attribute("time"));
+        Assert.Equal(new[] { ("Only", "t1"), ("Only", "t2") }, Cases(final).ToArray());
+    }
+}

--- a/AlRunner.Tests/SuiteAbortOnTimeoutTests.cs
+++ b/AlRunner.Tests/SuiteAbortOnTimeoutTests.cs
@@ -21,8 +21,15 @@
 // left in place, or a fix that merely changes the return value's shape without
 // surfacing anything) makes the assertions below fail because the output carries
 // neither the codeunit name, nor the count "2", nor a non-zero exit code.
+//
+// #2716 extends this file with a RESUME fixture (two codeunits, the first hangs): the JUnit a
+// resumed run writes must be the whole run — the earlier attempt's cases as well as the final
+// attempt's — because under --jobs the parent aggregates ONLY that XML. Measured on the full
+// BaseApp surface at --jobs 12, the aggregate was missing 26% of the tests the shards had run.
 using System.Diagnostics;
 using System.Text;
+using System.Xml.Linq;
+using AlRunner.Infrastructure;
 using Xunit;
 
 namespace AlRunner.Tests;
@@ -34,17 +41,22 @@ public sealed class SuiteAbortOnTimeoutTests : IDisposable
     private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
 
     private readonly string _root;
+    private readonly string _resumeRoot;
 
     public SuiteAbortOnTimeoutTests()
     {
         _root = Path.Combine(Path.GetTempPath(), "al-runner-suite-abort-on-timeout", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(_root);
         WriteFixture(_root);
+        _resumeRoot = Path.Combine(Path.GetTempPath(), "al-runner-suite-abort-resume", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_resumeRoot);
+        WriteResumeFixture(_resumeRoot);
     }
 
     public void Dispose()
     {
         try { Directory.Delete(_root, recursive: true); } catch { }
+        try { Directory.Delete(_resumeRoot, recursive: true); } catch { }
     }
 
     /// <summary>
@@ -92,11 +104,77 @@ public sealed class SuiteAbortOnTimeoutTests : IDisposable
         """);
     }
 
+    /// <summary>
+    /// The shape a watchdog RESUME needs (#2280): two codeunits, the FIRST hangs part-way, so
+    /// the abort abandons a later codeunit and AbortResumePlan judges a retry worthwhile.
+    ///   attempt 1 runs First:  RanBeforeHang passes, Hangs errors, AbandonedInFirst never runs.
+    ///   attempt 2 runs Second: SecondA and SecondB pass (First is excluded as attempted+hung).
+    /// The whole run is therefore 4 tests / 1 error; each attempt on its own is 2.
+    /// </summary>
+    private static void WriteResumeFixture(string dir)
+    {
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "d4e5f6a7-b8c9-0123-4567-890abcdef123",
+          "name": "Suite Abort Resume Test Fixture",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62210, "to": 62219 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(dir, "First.Codeunit.al"), """
+        codeunit 62212 "Suite Abort Resume First"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure RanBeforeHang()
+            begin
+            end;
+
+            [Test]
+            procedure Hangs()
+            begin
+                while true do;
+            end;
+
+            [Test]
+            procedure AbandonedInFirst()
+            begin
+            end;
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(dir, "Second.Codeunit.al"), """
+        codeunit 62213 "Suite Abort Resume Second"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure SecondA()
+            begin
+            end;
+
+            [Test]
+            procedure SecondB()
+            begin
+            end;
+        }
+        """);
+    }
+
     private (string output, int exit) RunRunner(params string[] extraArgs)
+        => RunRunner(_root, 120_000, extraArgs);
+
+    private (string output, int exit) RunRunner(string bundle, int waitMs, params string[] extraArgs)
     {
         var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
         args.Append(TestBuildConfig.BcVersionArg);
-        args.Append($" \"{_root}\"");
+        args.Append($" \"{bundle}\"");
         foreach (var a in extraArgs) args.Append($" {a}");
         var psi = new ProcessStartInfo
         {
@@ -113,7 +191,7 @@ public sealed class SuiteAbortOnTimeoutTests : IDisposable
         // The fixture's first [Test] never returns on its own; give the runner
         // subprocess enough headroom above the (short) --test-timeout to finish the
         // whole run, but well under a genuine hang.
-        if (!p.WaitForExit(120_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        if (!p.WaitForExit(waitMs)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
         p.WaitForExit();
         lock (sb) return (sb.ToString(), p.ExitCode);
     }
@@ -157,5 +235,77 @@ public sealed class SuiteAbortOnTimeoutTests : IDisposable
 
         Assert.Contains("Hangs", output);
         Assert.Contains("Test exceeded 2s timeout.", output);
+    }
+
+    private static List<(string ClassName, string Name)> TestCases(string junitPath)
+        => XDocument.Load(junitPath).Descendants("testcase")
+            .Select(tc => ((string?)tc.Attribute("classname") ?? "", (string?)tc.Attribute("name") ?? ""))
+            .ToList();
+
+    /// <summary>
+    /// #2716 positive: after a watchdog resume, --output-junit must hold the WHOLE run — the
+    /// earlier attempt's cases (RanBeforeHang, Hangs) as well as the final attempt's (SecondA,
+    /// SecondB). The worker's own printed summary already said "4 total (carried: 2)"; the XML
+    /// said 2, and under --jobs the parent reads only the XML, so the aggregate lost the 2.
+    /// </summary>
+    [SkippableFact]
+    public void ResumedRun_JUnitContainsEarlierAttemptsCases()
+    {
+        TestArtifacts.SkipIfMissing();
+        var junit = Path.Combine(_resumeRoot, "out", "resumed.xml");
+        Directory.CreateDirectory(Path.GetDirectoryName(junit)!);
+
+        // Two attempts, each a full BC boot: generous wait, still far below a real hang.
+        var (output, exit) = RunRunner(_resumeRoot, 300_000,
+            "--test-timeout 2", "--resume-aborts 1", $"--output-junit \"{junit}\"");
+
+        Assert.NotEqual(0, exit);
+        // Sanity: the resume really happened, and the printed summary already carried attempt 1.
+        Assert.Contains("resume: a watchdog abort ended this attempt early", output);
+        Assert.Contains("carried from earlier attempt(s): 2 tests", output);
+        Assert.True(File.Exists(junit), $"JUnit not written: {junit}\n{output}");
+
+        var cases = TestCases(junit);
+        var names = cases.Select(c => c.Name).OrderBy(n => n).ToList();
+        Assert.Equal(new[] { "Hangs", "RanBeforeHang", "SecondA", "SecondB" }, names);
+        // Once each: the carried suites and the final attempt's suites are disjoint by
+        // construction (the resume excludes every attempted codeunit), and the XML must reflect
+        // that rather than, say, the whole earlier file being appended twice down a chain.
+        Assert.Equal(cases.Count, cases.Distinct().Count());
+        // A test inside the HUNG codeunit that never ran is not invented into the record.
+        Assert.DoesNotContain("AbandonedInFirst", names);
+
+        // The parent's own aggregation path (ParallelFanOut.Run -> JUnitCounts.Read) now sees
+        // the whole worker, not its last slice.
+        var totals = JUnitCounts.Read(junit);
+        Assert.Equal(4, totals.Tests);
+        Assert.Equal(1, totals.Errors);
+        Assert.Equal(0, totals.Failures);
+        Assert.Equal(0, totals.Skipped);
+    }
+
+    /// <summary>
+    /// #2716 negative: with resume disabled the same fixture writes exactly attempt 1's two
+    /// cases — nothing is carried in from nowhere, and the count is not inflated.
+    /// </summary>
+    [SkippableFact]
+    public void NonResumedRun_JUnitHoldsOnlyWhatThisProcessRan()
+    {
+        TestArtifacts.SkipIfMissing();
+        var junit = Path.Combine(_resumeRoot, "out", "single.xml");
+        Directory.CreateDirectory(Path.GetDirectoryName(junit)!);
+
+        var (output, exit) = RunRunner(_resumeRoot, 180_000,
+            "--test-timeout 2", "--resume-aborts 0", $"--output-junit \"{junit}\"");
+
+        Assert.NotEqual(0, exit);
+        Assert.DoesNotContain("resume: a watchdog abort ended this attempt early", output);
+        Assert.DoesNotContain("carried from earlier attempt(s)", output);
+
+        var names = TestCases(junit).Select(c => c.Name).OrderBy(n => n).ToList();
+        Assert.Equal(new[] { "Hangs", "RanBeforeHang" }, names);
+        var totals = JUnitCounts.Read(junit);
+        Assert.Equal(2, totals.Tests);
+        Assert.Equal(1, totals.Errors);
     }
 }

--- a/AlRunner/Infrastructure/AbortResume.cs
+++ b/AlRunner/Infrastructure/AbortResume.cs
@@ -87,8 +87,9 @@ internal static class AbortResume
             + $"skipping {exclusions.Count} codeunit(s) already attempted or hung; "
             + $"{remainingBudget} resume attempt(s) left after this one.");
         Console.Error.WriteLine(
-            "resume: this attempt's totals are carried forward, so the next summary covers the "
-            + "whole run. Tests inside a HUNG codeunit still never ran and are not counted.");
+            "resume: this attempt's results are carried forward, so the next summary and its "
+            + "--output-junit cover the whole run. Tests inside a HUNG codeunit still never ran "
+            + "and are not counted.");
         Console.Error.WriteLine();
 
         var exe = Environment.ProcessPath ?? "dotnet";

--- a/AlRunner/Infrastructure/ParallelFanOut.cs
+++ b/AlRunner/Infrastructure/ParallelFanOut.cs
@@ -81,6 +81,11 @@ internal static class ParallelFanOut
             // same earlier-attempt totals six times and report a number larger than the tests
             // that exist. Listed in ValueTakingFlags above so its value is still recognised as a
             // value rather than read as a bundle path; dropped here so it reaches no worker.
+            //
+            // The OTHER direction is not this code's job and is not affected by the strip: a
+            // worker that resumes itself builds its own --merge-counts chain (AbortResume) and
+            // writes the carried cases into the JUnit it hands back (#2716), so Run() reading
+            // that one file per shard sees everything the worker's attempts ran.
             if (a == "--merge-counts")
             {
                 if (i + 1 < originalArgs.Count) i++;

--- a/AlRunner/JUnitReport.cs
+++ b/AlRunner/JUnitReport.cs
@@ -2,8 +2,10 @@
 // Actions, Azure DevOps, and GitLab CI natively render as test annotations,
 // summaries, and trend graphs. Ported from v1 (AlRunner/JUnitReport.cs) onto
 // v2's BucketResult/TestResult shape.
+using System.Globalization;
 using System.Text;
 using System.Xml;
+using System.Xml.Linq;
 
 namespace AlRunner;
 
@@ -11,6 +13,37 @@ public static class JUnitReport
 {
     /// <summary>Write a JUnit XML report to <paramref name="outputPath"/>.</summary>
     public static void WriteJUnit(string outputPath, IReadOnlyList<BucketResult> buckets)
+        => WriteJUnit(outputPath, buckets, Array.Empty<string>());
+
+    /// <summary>
+    /// Write a JUnit XML report to <paramref name="outputPath"/> holding this process's
+    /// <paramref name="buckets"/> AND every <c>testsuite</c> from <paramref name="carriedJUnitFiles"/>
+    /// — the JUnit files earlier attempts of this same run left behind before a watchdog abort
+    /// forced a resume (#2280, passed in as <c>--merge-counts</c>).
+    ///
+    /// Why the XML must carry them and not only the printed summary (#2716): under <c>--jobs</c>
+    /// the parent learns what a worker ran from this file alone (<c>JUnitCounts.Read</c>), and a
+    /// resumed worker's final attempt runs only the codeunits no earlier attempt reached. With the
+    /// carried cases missing here, the aggregate silently dropped everything the earlier attempts
+    /// ran — 26% of the tests on the full BaseApp surface at --jobs 12 — while each worker's own
+    /// summary was right. Folding them in makes the XML a complete record of the run, so the
+    /// parent needs no knowledge of resume at all, and a single-process <c>--output-junit</c>
+    /// after a resume is complete for the same reason.
+    ///
+    /// No double counting by construction: a resume excludes every codeunit an earlier attempt
+    /// ran (AbortResumePlan.NextExclusions), so the carried suites and <paramref name="buckets"/>
+    /// are disjoint; and each carried file holds exactly ONE attempt's own results — Program.cs
+    /// writes the carry file for an attempt from that attempt's results alone, never through this
+    /// overload — so a chain of N resumes contributes each attempt once. Carried suites are copied
+    /// verbatim (their failure messages and bodies survive), in attempt order, ahead of this
+    /// process's own, each block preceded by an XML comment naming the file it came from.
+    ///
+    /// An unreadable carried file contributes nothing rather than failing the write, matching
+    /// JUnitCounts.Read and ProgramSupport.CarriedFromEarlierAttempts, which already treat such a
+    /// file as zero for the printed summary — the two stay in agreement either way.
+    /// </summary>
+    public static void WriteJUnit(string outputPath, IReadOnlyList<BucketResult> buckets,
+        IReadOnlyList<string> carriedJUnitFiles)
     {
         var tests = buckets
             .Where(b => b.Stage == BucketStage.Ran)
@@ -23,10 +56,21 @@ public static class JUnitReport
             .ToList();
 
         double totalSeconds = tests.Sum(t => t.Duration.TotalSeconds);
-        int totalTests = tests.Count;
-        int totalFailures = tests.Count(t => t.Outcome == TestOutcome.Fail);
-        int totalErrors = tests.Count(t => t.Outcome == TestOutcome.Error);
-        int totalSkipped = tests.Count(t => t.Outcome == TestOutcome.Skipped);
+        long totalTests = tests.Count;
+        long totalFailures = tests.Count(t => t.Outcome == TestOutcome.Fail);
+        long totalErrors = tests.Count(t => t.Outcome == TestOutcome.Error);
+        long totalSkipped = tests.Count(t => t.Outcome == TestOutcome.Skipped);
+
+        var carried = LoadCarriedSuites(carriedJUnitFiles);
+        foreach (var (_, carriedSuites) in carried)
+            foreach (var cs in carriedSuites)
+            {
+                totalTests += Attr(cs, "tests");
+                totalFailures += Attr(cs, "failures");
+                totalErrors += Attr(cs, "errors");
+                totalSkipped += Attr(cs, "skipped");
+                totalSeconds += Seconds(cs);
+            }
 
         using var writer = XmlWriter.Create(outputPath, new XmlWriterSettings
         {
@@ -40,7 +84,17 @@ public static class JUnitReport
         writer.WriteAttributeString("failures", totalFailures.ToString());
         writer.WriteAttributeString("errors", totalErrors.ToString());
         writer.WriteAttributeString("skipped", totalSkipped.ToString());
-        writer.WriteAttributeString("time", totalSeconds.ToString("F3", System.Globalization.CultureInfo.InvariantCulture));
+        writer.WriteAttributeString("time", totalSeconds.ToString("F3", CultureInfo.InvariantCulture));
+
+        foreach (var (file, carriedSuites) in carried)
+        {
+            // An XML comment rather than a non-standard attribute: every JUnit consumer tolerates
+            // a comment, not every one tolerates an attribute its schema does not name. "--" is
+            // illegal inside a comment, so a path containing it is softened.
+            writer.WriteComment(" carried from an earlier attempt of this run (watchdog resume, #2280): "
+                + file.Replace("--", "- -") + " ");
+            foreach (var cs in carriedSuites) cs.WriteTo(writer);
+        }
 
         foreach (var suite in suites)
         {
@@ -56,14 +110,14 @@ public static class JUnitReport
             writer.WriteAttributeString("failures", suiteFailures.ToString());
             writer.WriteAttributeString("errors", suiteErrors.ToString());
             writer.WriteAttributeString("skipped", suiteSkipped.ToString());
-            writer.WriteAttributeString("time", suiteSeconds.ToString("F3", System.Globalization.CultureInfo.InvariantCulture));
+            writer.WriteAttributeString("time", suiteSeconds.ToString("F3", CultureInfo.InvariantCulture));
 
             foreach (var test in suiteTests)
             {
                 writer.WriteStartElement("testcase");
                 writer.WriteAttributeString("name", test.Method);
                 writer.WriteAttributeString("classname", suite.Key);
-                writer.WriteAttributeString("time", test.Duration.TotalSeconds.ToString("F3", System.Globalization.CultureInfo.InvariantCulture));
+                writer.WriteAttributeString("time", test.Duration.TotalSeconds.ToString("F3", CultureInfo.InvariantCulture));
 
                 if (test.Outcome == TestOutcome.Fail)
                 {
@@ -94,6 +148,44 @@ public static class JUnitReport
 
         writer.WriteEndElement(); // testsuites
     }
+
+    /// <summary>
+    /// The <c>testsuite</c> elements of each carried file, in the order the files were given
+    /// (attempt order). A file that is missing, truncated — what an attempt killed mid-write
+    /// leaves behind — or not JUnit-shaped yields no suites. Only DIRECT children of a
+    /// <c>testsuites</c> root (or a bare <c>testsuite</c> root) count: a nested suite would be
+    /// written twice, once inside its parent and once on its own.
+    /// </summary>
+    private static List<(string File, List<XElement> Suites)> LoadCarriedSuites(IReadOnlyList<string> files)
+    {
+        var result = new List<(string, List<XElement>)>();
+        foreach (var f in files)
+        {
+            if (string.IsNullOrEmpty(f)) continue;
+            try
+            {
+                if (!File.Exists(f)) continue;
+                var root = XDocument.Load(f).Root;
+                if (root == null) continue;
+                var suites = root.Name.LocalName == "testsuite"
+                    ? new List<XElement> { root }
+                    : root.Elements("testsuite").ToList();
+                if (suites.Count > 0) result.Add((f, suites));
+            }
+            catch
+            {
+                // Not a verdict on the run — the attempt's exit code and its own printed summary
+                // are. Same stance as JUnitCounts.Read.
+            }
+        }
+        return result;
+    }
+
+    private static long Attr(XElement el, string name)
+        => long.TryParse(el.Attribute(name)?.Value, out var v) ? v : 0;
+
+    private static double Seconds(XElement el)
+        => double.TryParse(el.Attribute("time")?.Value, NumberStyles.Float, CultureInfo.InvariantCulture, out var v) ? v : 0;
 
     private static string BuildBody(TestResult test)
     {

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3600,6 +3600,10 @@ if (resumeAborts > 0
     var carryDir = Path.Combine(Path.GetTempPath(), "al-runner-resume-" + Guid.NewGuid().ToString("N"));
     Directory.CreateDirectory(carryDir);
     var carryPath = Path.Combine(carryDir, "attempt.xml");
+    // THIS attempt's results only — deliberately not the carried-files overload. Each carry file
+    // must hold exactly one attempt, because the final attempt folds the whole list into its
+    // --output-junit (#2716); a carry file that already contained the earlier files would put
+    // every attempt into the final XML once per later resume.
     try { JUnitReport.WriteJUnit(carryPath, results); } catch { carryPath = null!; }
     var carry = new List<string>(mergeCountsFiles);
     if (carryPath != null) carry.Add(carryPath);
@@ -3639,7 +3643,12 @@ if (outPath != null)
 }
 if (outputJunitPath != null)
 {
-    JUnitReport.WriteJUnit(outputJunitPath, results);
+    // #2716: after a watchdog resume this process ran only the codeunits no earlier attempt
+    // reached, so `results` is a slice. The earlier attempts' cases arrive as --merge-counts
+    // files and go into the XML too — the printed summary above already folded their totals in,
+    // and under --jobs the parent reads ONLY this file, so a slice here silently shrank the
+    // aggregate by everything the earlier attempts ran. Empty list on a run that never resumed.
+    JUnitReport.WriteJUnit(outputJunitPath, results, mergeCountsFiles);
     if (!outputJson) Console.WriteLine($"JUnit XML → {outputJunitPath}");
 }
 if (coverageEnabled)

--- a/AlRunner/ProgramSupport/CliText.cs
+++ b/AlRunner/ProgramSupport/CliText.cs
@@ -411,10 +411,11 @@ internal static partial class ProgramSupport
         w.WriteLine("                          a bundle's emit phase roughly N times slower in wall time,");
         w.WriteLine("                          so the wall-clock timeout is scaled to match. An explicit");
         w.WriteLine("                          AL_RUNNER_EMIT_TIMEOUT_SEC set before the run is left alone.");
-        w.WriteLine("  --merge-counts PATH     Fold a JUnit file's totals into this run's summary;");
-        w.WriteLine("                          repeatable. Set automatically by --resume-aborts to carry");
-        w.WriteLine("                          earlier attempts forward, and reported on its own line so a");
-        w.WriteLine("                          resumed total is never mistaken for one clean run's.");
+        w.WriteLine("  --merge-counts PATH     Fold a JUnit file's totals into this run's summary, and its");
+        w.WriteLine("                          test cases into this run's --output-junit; repeatable. Set");
+        w.WriteLine("                          automatically by --resume-aborts to carry earlier attempts");
+        w.WriteLine("                          forward, and reported on its own summary line so a resumed");
+        w.WriteLine("                          total is never mistaken for one clean run's.");
         w.WriteLine("  --resume-aborts N       How many times a run may re-run itself in a fresh process");
         w.WriteLine("                          after a watchdog abort, each time excluding the codeunit");
         w.WriteLine("                          that hung, and every codeunit already attempted, so the");


### PR DESCRIPTION
Closes #2716

## What was wrong

When a run resumes after a watchdog abort (#2280), the final attempt runs only the codeunits no earlier attempt reached. Its printed summary folds the earlier attempts' totals in through `--merge-counts`, but the JUnit written by `--output-junit` held only the final attempt's own cases. Under `--jobs`, `ParallelFanOut.Run` learns what a worker ran from that XML alone, so the aggregate dropped everything the earlier attempts ran: 10,399 of 39,190 tests on the full BaseApp surface at `--jobs 12`.

## What I changed

I took the issue's preferred direction: the XML becomes a complete record of the worker, so the parent does not need to know about resume at all.

- `JUnitReport.WriteJUnit` gains an overload taking the carried JUnit files. It copies their `testsuite` elements verbatim (failure messages and bodies survive), in attempt order, ahead of this process's own suites, and folds their counts into the root `testsuites` totals. Each carried block is preceded by an XML comment naming its source file, so a resumed record is distinguishable from a clean one without a non-standard attribute that a strict consumer might reject.
- `Program.cs` passes `mergeCountsFiles` at the final `--output-junit` write. The per-attempt carry file is still written from that attempt's results alone, with a comment saying why: each carry file must hold exactly one attempt so a chain of N resumes contributes each attempt once.
- `ParallelFanOut.BuildChildArgs` still strips `--merge-counts` from worker command lines. That direction was correct and is unchanged; I added a comment describing the other direction so the two are not confused later.
- Help text for `--merge-counts` and the resume notice now say the JUnit is covered too.

No double counting by construction: a resume excludes every codeunit an earlier attempt ran (`AbortResumePlan.NextExclusions`), and excluded tests are dropped from `results`, not emitted as Skipped, so the carried suites and the final attempt's suites are disjoint.

## Tests (RED then GREEN)

- `SuiteAbortOnTimeoutTests.ResumedRun_JUnitContainsEarlierAttemptsCases` — a two-codeunit fixture where the first codeunit hangs part-way. With `--test-timeout 2 --resume-aborts 1 --output-junit`, the XML must hold all four cases (`RanBeforeHang`, `Hangs`, `SecondA`, `SecondB`), each once, with `JUnitCounts.Read` (the parent's path) reporting 4 tests / 1 error, and no `AbandonedInFirst` invented into the record. **RED before the fix:** `Actual: ["SecondA", "SecondB"]` while the printed summary in the same output already said `carried from earlier attempt(s): 2 tests`. GREEN after.
- `SuiteAbortOnTimeoutTests.NonResumedRun_JUnitHoldsOnlyWhatThisProcessRan` — same fixture with `--resume-aborts 0`: exactly the two cases attempt 1 ran, nothing carried.
- `JUnitReportCarriedCasesTests` (4 fast unit tests) — once-each in attempt order across a two-file chain with detail intact and root totals summed; byte-identical output when nothing is carried; missing/truncated carry files contribute nothing without dropping own results; a bare `testsuite` root is one suite.

## Fix the shape

1. **Same wrong pattern elsewhere?** The other readers of `results` after a resume: `--output-json`, `--out` classification, and `--count-baseline` all see the final slice too. Not fixed here: those are built from `TestResult` records, and a carried JUnit case does not round-trip to one (`Expectation`, `Diagnosis`, display name are not in the XML), so the carry channel needs a design decision. Filed as #2719.
2. **Sibling functions with the same assumption?** `JUnitCounts.Read`, `ProgramSupport.CarriedFromEarlierAttempts`, and the new `LoadCarriedSuites` all treat an unreadable carry file as zero. They agree with each other, so the printed summary and the XML cannot disagree on such a file. `LoadCarriedSuites` takes only direct children of the root (or a bare `testsuite` root), never `Descendants`, so a nested suite could not be written twice.
3. **Two paths writing the same state?** Two call sites write JUnit in `Program.cs`: the carry file (must stay one-attempt-only) and the final output (must fold all carried files). Both now carry a comment stating the invariant the other depends on.

## How this composes with #2717 (bounded worker wait)

#2717 replaces the parent's bare `WaitForExit()` with a wait that treats the appearance of the worker's JUnit file as the done-signal, kills the process tree after a 60 s grace, and aggregates whatever the worker wrote. I read its diff against this branch:

- **Textually independent.** #2717 edits `Run` and adds `WaitForWorkerExit` / `ExitCodeForKilledWorker`; my only touch in `ParallelFanOut.cs` is a comment in `BuildChildArgs`. `git merge-tree --write-tree HEAD pr-2717` reports a clean merge in either order.
- **The done-signal is not fooled by a resume.** Intermediate attempts return from the resume branch before the `--output-junit` block runs, and write their carry files under `al-runner-resume-<guid>/attempt.xml`, never to the worker's `junitPath`. So the file the parent watches appears only once the final attempt has written it, carried cases included; the kill-after-grace cannot truncate a resumed worker's record.
- **It makes #2717's killed-worker verdict right for resumed workers.** `ExitCodeForKilledWorker` derives the verdict from the JUnit counts. Attempt 1's suite carries the hung test as an Error, so with this change a resumed-then-killed worker reads as 1, which keeps `AbortResume.Rerun`'s rule that a resumed run never reports clean. Without this change, a killed worker whose final slice was all-pass would have read as 0.

## What I ran locally

- `dotnet test AlRunner.Tests --filter FullyQualifiedName~SuiteAbortOnTimeoutTests`: 4/4 (30 s; the resume test spawns two runner processes).
- `--filter "JUnitReportCarriedCasesTests|JUnitCountsTests|ParallelFanOutArgsTests|AbortResume"`: 30/30.
- `--filter "CliDocumentationTests|OutputFormatTests"` (help text changed): 22/22.

Not run: the full `AlRunner.Tests` suite or the AL corpus; the change is confined to the JUnit writer and the two call sites above.

Note for the orchestrator: I was handed the identity `impl-3`, outside the fixed `impl-1`/`impl-2` pool. This session's commit is unsigned because the 1Password signing agent was unreachable (SSH to GitHub was refused for the same reason; I pushed over https).

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
