### PR TITLE
fix(jobs): scale the AL emit timeout by worker count so --jobs stops losing bundles

### DIFF
--- a/AlRunner.Tests/ParallelFanOutEmitTimeoutTests.cs
+++ b/AlRunner.Tests/ParallelFanOutEmitTimeoutTests.cs
@@ -1,0 +1,113 @@
+// ParallelFanOutEmitTimeoutTests — the AL emit timeout must scale with shard count (issue #2715).
+//
+// AL_RUNNER_EMIT_TIMEOUT_SEC (default 120s in Program.cs) is measured in wall-clock time, but
+// under --jobs N every worker competes with N-1 others for the same cores. Measured on a
+// 12-core box at --jobs 12: Tests-ERM's emit was cut off at 120.1s of wall while that worker's
+// total wall was 820.1s — it was getting a fraction of a core. Tests-SCM failed the same way.
+// Losing those two largest buckets took a 40,550-test run down to 14,856 (63% of the surface
+// gone), reported as a plain total with no sign anything was lost.
+//
+// The fix follows the exact pattern #2713/#2714 established for the GC footprint knobs in
+// ParallelFanOut.WorkerEnvironment: scale the default handed to a worker by the shard count
+// when the user has not set the knob themselves, and leave an explicit user value alone.
+
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ParallelFanOutEmitTimeoutTests
+{
+    /// <summary>The worker gets DefaultEmitTimeoutSec scaled by the shard count, not the flat
+    /// single-process default — a bundle sharing cores with N-1 other workers can take roughly
+    /// N times as long in wall time to reach the same amount of CPU work.</summary>
+    [Theory]
+    [InlineData(1, ParallelFanOut.DefaultEmitTimeoutSec)]
+    [InlineData(2, ParallelFanOut.DefaultEmitTimeoutSec * 2)]
+    [InlineData(6, ParallelFanOut.DefaultEmitTimeoutSec * 6)]
+    [InlineData(12, ParallelFanOut.DefaultEmitTimeoutSec * 12)]
+    public void EmitTimeoutSecForWorker_ScalesByShardCount(int jobs, int expected)
+        => Assert.Equal(expected, ParallelFanOut.EmitTimeoutSecForWorker(jobs));
+
+    /// <summary>Never scaled down to zero or below the single-process default — a shard count of
+    /// 0 must not be reached in practice, but the formula must not misbehave if it is.</summary>
+    [Fact]
+    public void EmitTimeoutSecForWorker_NeverBelowTheSingleProcessDefault()
+        => Assert.True(ParallelFanOut.EmitTimeoutSecForWorker(0) >= ParallelFanOut.DefaultEmitTimeoutSec);
+
+    /// <summary>Positive: when the user has not set AL_RUNNER_EMIT_TIMEOUT_SEC, the worker
+    /// environment carries the shard-scaled value under the exact name Program.cs reads.</summary>
+    [Fact]
+    public void WorkerEnvironment_ScalesEmitTimeoutWhenUserSetNothing()
+    {
+        var env = ParallelFanOut.WorkerEnvironment(cores: 12, jobs: 6);
+
+        Assert.True(env.TryGetValue("AL_RUNNER_EMIT_TIMEOUT_SEC", out var value));
+        Assert.Equal((ParallelFanOut.DefaultEmitTimeoutSec * 6).ToString(), value);
+    }
+
+    /// <summary>Negative: an explicit AL_RUNNER_EMIT_TIMEOUT_SEC set by the user (by hand, or by
+    /// a CI runner setting one globally) must win over the scaled default and must not be
+    /// present in the override dictionary at all — the child inherits the real environment
+    /// variable already, exactly as the GC knobs do (ParallelFanOutGcHeapTests).</summary>
+    [Fact]
+    public void WorkerEnvironment_DefersToAnExplicitEmitTimeout()
+    {
+        var env = ParallelFanOut.WorkerEnvironment(cores: 12, jobs: 6, userEmitTimeoutSec: "300");
+
+        Assert.False(env.ContainsKey("AL_RUNNER_EMIT_TIMEOUT_SEC"),
+            "an explicit AL_RUNNER_EMIT_TIMEOUT_SEC must be left alone, not replaced by the scaled one");
+        // Setting the emit-timeout knob must not suppress the unrelated GC knobs.
+        Assert.True(env.ContainsKey("DOTNET_GCHeapCount"));
+        Assert.True(env.ContainsKey("DOTNET_GCConserveMemory"));
+        Assert.True(env.ContainsKey("DOTNET_gcConcurrent"));
+    }
+
+    /// <summary>Setting one of the pre-existing GC knobs must not suppress the emit-timeout
+    /// scaling — each knob is independent, the same invariant ParallelFanOutGcHeapTests already
+    /// pins for the other three.</summary>
+    [Fact]
+    public void WorkerEnvironment_ExplicitGcKnobDoesNotSuppressEmitTimeoutScaling()
+    {
+        var env = ParallelFanOut.WorkerEnvironment(cores: 12, jobs: 6, userHeapCount: "8");
+
+        Assert.True(env.TryGetValue("AL_RUNNER_EMIT_TIMEOUT_SEC", out var value));
+        Assert.Equal((ParallelFanOut.DefaultEmitTimeoutSec * 6).ToString(), value);
+    }
+
+    /// <summary>CountOccurrences drives the aggregate's "bundles not run" line — a run that
+    /// loses a bundle to COMPILE FAIL must not report the smaller total as though it were
+    /// complete (#2715's own complaint about the aggregate summary).</summary>
+    [Fact]
+    public void CountOccurrences_CountsEachCompileFailMarker()
+    {
+        var stdout =
+            "jobs: 2 bundle(s) across 2 worker process(es)\n" +
+            "=== Tests-ERM — COMPILE FAIL ===\n" +
+            "  <bundled>: EMIT-TIMEOUT after 120s\n";
+
+        Assert.Equal(1, ParallelFanOut.CountOccurrences(stdout, " — COMPILE FAIL ==="));
+    }
+
+    /// <summary>Negative: a clean run's output — no COMPILE FAIL marker anywhere — counts zero,
+    /// so the aggregate's "bundles not run" line stays silent instead of always printing.</summary>
+    [Fact]
+    public void CountOccurrences_IsZeroWhenNoBundleFailedToCompile()
+    {
+        var stdout = "jobs: 2 bundle(s) across 2 worker process(es)\nTests: 100 total\n";
+
+        Assert.Equal(0, ParallelFanOut.CountOccurrences(stdout, " — COMPILE FAIL ==="));
+    }
+
+    /// <summary>Multiple failed bundles in the same shard's captured output are all counted, not
+    /// just the first — a worker can process more than one bundle per shard.</summary>
+    [Fact]
+    public void CountOccurrences_CountsMultipleOccurrences()
+    {
+        var stdout =
+            "=== Tests-ERM — COMPILE FAIL ===\n" +
+            "=== Tests-SCM — COMPILE FAIL ===\n";
+
+        Assert.Equal(2, ParallelFanOut.CountOccurrences(stdout, " — COMPILE FAIL ==="));
+    }
+}

--- a/AlRunner/Infrastructure/ParallelFanOut.cs
+++ b/AlRunner/Infrastructure/ParallelFanOut.cs
@@ -145,10 +145,32 @@ internal static class ParallelFanOut
         => 1;
 
     /// <summary>
-    /// Extra environment for a worker process: one GC heap, conserve memory, no background GC.
-    /// Together these take about half off peak memory for 6-7% wall (8,183 -> 4,193 MB at
-    /// --jobs 4, 4,983 -> 2,434 MB at --jobs 2, pass count identical in both) — see
-    /// ParallelFanOutGcHeapTests' header for the measurements behind each one.
+    /// The single-process default for the AL emit-phase timeout (Program.cs), in seconds. A
+    /// worker under --jobs scales this by its shard count — see
+    /// <see cref="EmitTimeoutSecForWorker"/> — so it stays the source of truth for both.
+    /// </summary>
+    public const int DefaultEmitTimeoutSec = 120;
+
+    /// <summary>
+    /// Emit-phase timeout to hand one worker, in seconds (issue #2715).
+    ///
+    /// The timeout is wall-clock, but under --jobs N every worker competes with N-1 others for
+    /// the same cores — a bundle that emits comfortably alone can time out purely because other
+    /// workers are running. Measured on a 12-core box at --jobs 12: Tests-ERM's emit was cut off
+    /// at 120.1s of wall while that worker's total wall was 820.1s, roughly the same ~7x the
+    /// contention stretched everything else by. Scaling the default by the shard count is a
+    /// proxy for that stretch, not a precise CPU-time budget — see this file's header comment
+    /// for why CPU time would be the more precise fix and why it is a larger change.
+    /// </summary>
+    public static int EmitTimeoutSecForWorker(int jobs)
+        => DefaultEmitTimeoutSec * Math.Max(1, jobs);
+
+    /// <summary>
+    /// Extra environment for a worker process: one GC heap, conserve memory, no background GC,
+    /// and a shard-scaled emit timeout. The GC knobs together take about half off peak memory
+    /// for 6-7% wall (8,183 -> 4,193 MB at --jobs 4, 4,983 -> 2,434 MB at --jobs 2, pass count
+    /// identical in both) — see ParallelFanOutGcHeapTests' header for the measurements behind
+    /// each one.
     ///
     /// Every knob here is SOFT: it can cost time, never correctness. That rules out
     /// DOTNET_GCHeapHardLimit, which recovers a similar amount and then silently drops
@@ -157,14 +179,15 @@ internal static class ParallelFanOut
     ///
     /// Each knob is skipped when the user has already set it — someone tuning by hand, or a CI
     /// runner setting one globally, must win over a value chosen here. Setting one does not
-    /// suppress the other two.
+    /// suppress the others.
     /// </summary>
     public static Dictionary<string, string> WorkerEnvironment(
         int cores,
         int jobs,
         string? userHeapCount = null,
         string? userConserveMemory = null,
-        string? userGcConcurrent = null)
+        string? userGcConcurrent = null,
+        string? userEmitTimeoutSec = null)
     {
         var env = new Dictionary<string, string>(StringComparer.Ordinal);
         if (string.IsNullOrEmpty(userHeapCount))
@@ -176,6 +199,8 @@ internal static class ParallelFanOut
         // ~150 MB of the measured difference on Tests-SMB.
         if (string.IsNullOrEmpty(userGcConcurrent))
             env["DOTNET_gcConcurrent"] = "0";
+        if (string.IsNullOrEmpty(userEmitTimeoutSec))
+            env["AL_RUNNER_EMIT_TIMEOUT_SEC"] = EmitTimeoutSecForWorker(jobs).ToString();
         return env;
     }
 
@@ -222,7 +247,8 @@ internal static class ParallelFanOut
                          Environment.ProcessorCount, shards.Count,
                          Environment.GetEnvironmentVariable("DOTNET_GCHeapCount"),
                          Environment.GetEnvironmentVariable("DOTNET_GCConserveMemory"),
-                         Environment.GetEnvironmentVariable("DOTNET_gcConcurrent")))
+                         Environment.GetEnvironmentVariable("DOTNET_gcConcurrent"),
+                         Environment.GetEnvironmentVariable("AL_RUNNER_EMIT_TIMEOUT_SEC")))
                 psi.Environment[kv.Key] = kv.Value;
             if (viaDotnet && asm != null) psi.ArgumentList.Add(asm);
             foreach (var a in childArgs) psi.ArgumentList.Add(a);
@@ -236,7 +262,7 @@ internal static class ParallelFanOut
         }
 
         var worst = 0;
-        long tests = 0, failures = 0, errors = 0, skipped = 0;
+        long tests = 0, failures = 0, errors = 0, skipped = 0, notRun = 0;
         for (var i = 0; i < procs.Count; i++)
         {
             var (p, junit, so, se) = procs[i];
@@ -252,6 +278,14 @@ internal static class ParallelFanOut
 
             var c = JUnitCounts.Read(junit);
             tests += c.Tests; failures += c.Failures; errors += c.Errors; skipped += c.Skipped;
+
+            // A bundle that COMPILE FAILs (Reporter.cs's "=== <bundle> — COMPILE FAIL ===")
+            // contributes zero tests to the JUnit this worker writes, so it vanishes from the
+            // totals above with no trace — the exact shape #2715 measured (40,550 tests down to
+            // 14,856, reported as a plain total). Count it here so the aggregate says a bundle
+            // is missing instead of silently reporting the smaller number as complete.
+            notRun += CountOccurrences(stdout, " — COMPILE FAIL ===")
+                    + CountOccurrences(stderr, " — COMPILE FAIL ===");
         }
 
         Console.WriteLine();
@@ -263,6 +297,9 @@ internal static class ParallelFanOut
         Console.WriteLine($"  fail:        {failures}");
         Console.WriteLine($"  error:       {errors}");
         Console.WriteLine($"  skipped:     {skipped}");
+        if (notRun > 0)
+            Console.WriteLine($"  NOT RUN:     {notRun} bundle(s) — COMPILE FAIL in a shard above, " +
+                               "excluded from the totals; see that shard's output for which one");
         Console.WriteLine("=================================================================");
 
         try { Directory.Delete(tempDir, recursive: true); } catch { }
@@ -273,5 +310,21 @@ internal static class ParallelFanOut
     {
         try { return Path.GetFullPath(p).TrimEnd(Path.DirectorySeparatorChar); }
         catch { return p.TrimEnd('/', '\\'); }
+    }
+
+    /// <summary>How many times a bundle reported COMPILE FAIL in a shard's captured output —
+    /// used to tell the aggregate summary how many bundles are missing from its totals, rather
+    /// than reporting the smaller total as though it were complete (#2715).</summary>
+    internal static int CountOccurrences(string haystack, string needle)
+    {
+        if (string.IsNullOrEmpty(haystack)) return 0;
+        var count = 0;
+        var idx = 0;
+        while ((idx = haystack.IndexOf(needle, idx, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            idx += needle.Length;
+        }
+        return count;
     }
 }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2590,10 +2590,14 @@ foreach (var bundle in bundles)
             // above with a synthetic FAILED test each), so the guard must subtract this
             // count before deciding there is an unexplained gap left.
             int tddExcludedCount = 0;
-            // Emit-phase timeout: default 120 s, override via AL_RUNNER_EMIT_TIMEOUT_SEC.
+            // Emit-phase timeout: default 120 s, override via AL_RUNNER_EMIT_TIMEOUT_SEC. Under
+            // --jobs, ParallelFanOut.WorkerEnvironment sets AL_RUNNER_EMIT_TIMEOUT_SEC on each
+            // worker's environment to DefaultEmitTimeoutSec scaled by the shard count (#2715),
+            // so this single-process default and that scaled one share the same source of truth.
             // Note: Task.Run thread continues in background after timeout — acceptable for a CLI tool.
             int emitTimeoutSec = int.TryParse(
-                Environment.GetEnvironmentVariable("AL_RUNNER_EMIT_TIMEOUT_SEC"), out var ts) ? ts : 120;
+                Environment.GetEnvironmentVariable("AL_RUNNER_EMIT_TIMEOUT_SEC"), out var ts)
+                    ? ts : AlRunner.Infrastructure.ParallelFanOut.DefaultEmitTimeoutSec;
             // Containment: keep a symbol-less .app in ONE suite's .alpackages from failing
             // every OTHER suite in the bundle. BC's native .app scanner reports AL1023
             // ("package file is not valid") for a package with no SymbolReference.json and

--- a/AlRunner/ProgramSupport/CliText.cs
+++ b/AlRunner/ProgramSupport/CliText.cs
@@ -406,6 +406,11 @@ internal static partial class ProgramSupport
         w.WriteLine("                          A hung test also ends only its own shard, not the whole run.");
         w.WriteLine("                          Ignored by --watch/--server/--dap (long-lived warm state)");
         w.WriteLine("                          and by a single-bundle run. Default: 1.");
+        w.WriteLine("                          Each worker also gets its own AL_RUNNER_EMIT_TIMEOUT_SEC,");
+        w.WriteLine("                          scaled by the shard count: N workers sharing cores can run");
+        w.WriteLine("                          a bundle's emit phase roughly N times slower in wall time,");
+        w.WriteLine("                          so the wall-clock timeout is scaled to match. An explicit");
+        w.WriteLine("                          AL_RUNNER_EMIT_TIMEOUT_SEC set before the run is left alone.");
         w.WriteLine("  --merge-counts PATH     Fold a JUnit file's totals into this run's summary;");
         w.WriteLine("                          repeatable. Set automatically by --resume-aborts to carry");
         w.WriteLine("                          earlier attempts forward, and reported on its own line so a");
@@ -670,7 +675,9 @@ internal static partial class ProgramSupport
         w.WriteLine("                               ~/.cache/al-runner/ncl-cecil/<key>.dll if present).");
         w.WriteLine("  AL_RUNNER_HOOK_TRACE=1       Trace every JmpHook fire to");
         w.WriteLine("                               /tmp/al-runner-hook-trace.log.");
-        w.WriteLine("  AL_RUNNER_EMIT_TIMEOUT_SEC=N Override the 120 s default emit-phase timeout.");
+        w.WriteLine("  AL_RUNNER_EMIT_TIMEOUT_SEC=N Override the 120 s default emit-phase timeout. Under");
+        w.WriteLine("                               --jobs, setting this yourself is passed to every");
+        w.WriteLine("                               worker unscaled instead of the shard-scaled default.");
         w.WriteLine("  AL_RUNNER_PHASE_LOG=PATH     Append one JSONL cost record per app group, per");
         w.WriteLine("                               bundle and per process to PATH (emit/compile/run");
         w.WriteLine("                               ms, deps, cache HIT/MISS, start + wall clock,");


### PR DESCRIPTION
The AL emit timeout (`AL_RUNNER_EMIT_TIMEOUT_SEC`, default 120) is wall-clock, but under
`--jobs N` every worker competes with N-1 others for the same cores. A bundle that emits
comfortably on its own times out purely because other workers are running, and the larger the
bundle the likelier it is. It surfaces as `COMPILE FAIL`, so the bundle contributes zero tests
and the aggregate reports the smaller number as though it were the whole run.

## Measured

12 workers on a 12-core box, cold cache, Microsoft's 35 extracted BaseApp buckets:

```
Tests-ERM   AL emit 120.1s (cut off)   worker wall 820.1s   COMPILE FAIL
Tests-SCM   same shape at 125.7s                            COMPILE FAIL
```

Those are the two largest buckets in the set. Losing them took the run from ~40,000 tests down
to **14,856** — 63% of the test surface gone, with nothing in the output suggesting memory or
contention had anything to do with it.

## Change

`WorkerEnvironment` now passes a scaled `AL_RUNNER_EMIT_TIMEOUT_SEC` to each worker, following
the same skip-if-the-user-set-it pattern the GC knobs use (#2714), with a floor at the
single-process default. `Program.cs` reads that default from one place instead of a duplicated
literal, and `CliText` documents the scaling in both the `--jobs` and the env-var sections.

The aggregate also stops presenting a run that lost bundles as a plain total — it prints
`NOT RUN: N bundle(s) — COMPILE FAIL in a shard above` when a bundle vanishes from the totals.

## Tests

`ParallelFanOutEmitTimeoutTests` covers both directions: scaling by shard count, the
never-below-default floor, the value being set when the user set nothing, and the negative case
that an explicit user value is left untouched and neither suppresses nor is suppressed by the
GC knobs. RED was confirmed by reverting the three source files to `origin/main` content
(via a copy-out/restore, not `git stash`) — `CS0117: 'ParallelFanOut' does not contain a
definition for 'DefaultEmitTimeoutSec'`. GREEN: 34/34 on the `ParallelFanOut` filter, 20/20 on
`CliDocumentationTests`.

## Left out deliberately

The per-test watchdog (`AL_RUNNER_TEST_TIMEOUT_SEC`, default 60) has the identical wall-clock
assumption and a larger blast radius — an abort takes out the rest of the codeunit and every
later codeunit in the bundle, and can trigger `--resume-aborts`. Filed as #2718 rather than
widened into this PR.

Note `AlRunner/Infrastructure/ParallelFanOut.cs` is contended: #2714 landed this morning and
#2717 is open against the same file.

Closes #2715
