### PR TITLE
fix(symbols): a table-extension parse that fails part-way is fatal, never a cached partial

### DIFF
--- a/AlRunner.Tests/BcAppSymbolCachePartialParseTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCachePartialParseTests.cs
@@ -1,0 +1,133 @@
+// BcAppSymbolCachePartialParseTests — proves #2712 at the parse layer: a table-extension
+// parse that fails part-way through must THROW, never return (and cache) the partial list
+// it had collected so far.
+//
+// What went wrong
+// ---------------
+// BcAppSymbolCache.ParseTableExtensions caught every exception, logged it only to PerfTrace
+// (off unless AL_RUNNER_PERF=1) and returned `result.Values.ToList()` — whatever it had
+// parsed before the failure. GetTableExtensions then stored that partial list in
+// TableExtensionCache, so one failure permanently poisoned the process with an incomplete
+// extension index. Reported with an OutOfMemoryException while parsing Base Application's
+// SymbolReference.json: 90 of 96 table extensions dropped, 47 tests flipped, exit code
+// unchanged.
+//
+// Reproducer used here (deterministic, no memory pressure needed)
+// ----------------------------------------------------------------
+// A SymbolReference.json whose TableExtensions[] holds one valid entry followed by one with a
+// field whose "Id" is a string. JsonElement.TryGetInt32 THROWS InvalidOperationException when
+// the element is not a number (it does not return false), so the second entry fails after the
+// first has already been collected — exactly the partial-then-fail shape of the OOM case.
+// BcAppSymbolCache.Parse (behind Get) reads an extension's Id/Name/Properties for the object
+// list but never its Fields, so the same file reads fine through Get; only the extension
+// parse is affected, which is what makes the partial invisible everywhere else.
+
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Same collection as BcAppSymbolCacheTableExtTests (#1821): GetTableExtensions consults the
+// process-global CacheRoots override, so it must not race CacheRootsTests's SetOverride calls.
+[Collection(CacheRootsSerialCollection.Name)]
+public sealed class BcAppSymbolCachePartialParseTests : IDisposable
+{
+    private readonly string _dir;
+
+    public BcAppSymbolCachePartialParseTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "al-runner-2712-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private string WriteApp(string symbolReferenceJson)
+    {
+        var appPath = Path.Combine(_dir, Guid.NewGuid().ToString("N") + ".app");
+        using var zip = new FileStream(appPath, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+        return appPath;
+    }
+
+    private const string ValidExtension = """
+        {
+          "TargetObject": "#f3552374a1f24356848e196002525837#Source Code Setup",
+          "Fields": [
+            { "TypeDefinition": { "Name": "Code[10]" }, "Properties": [], "Id": 2, "Name": "Sales" }
+          ],
+          "Id": 243,
+          "Name": "SourceCodeSetupExt"
+        }
+        """;
+
+    // The FIELD's "Id" is a string: TryGetInt32 throws InvalidOperationException on a
+    // non-Number element. The poison sits inside Fields[] on purpose — BcAppSymbolCache.Parse
+    // reads an extension entry's Id/Name/Properties for the object list but never its Fields,
+    // so Get() succeeds on this file and only the extension parse fails.
+    private const string PoisonExtension = """
+        {
+          "TargetObject": "Customer",
+          "Fields": [
+            { "TypeDefinition": { "Name": "Code[10]" }, "Properties": [], "Id": "not-a-number", "Name": "PoisonField" }
+          ],
+          "Id": 244,
+          "Name": "PoisonExt"
+        }
+        """;
+
+    [Fact]
+    public void GetTableExtensions_FailureAfterFirstEntry_ThrowsAndCachesNothing()
+    {
+        var appPath = WriteApp($$"""
+            {
+              "RuntimeVersion": "15.1",
+              "Namespaces": [],
+              "TableExtensions": [ {{ValidExtension}}, {{PoisonExtension}} ]
+            }
+            """);
+
+        // [WHEN] the parse fails on the second entry
+        // [THEN] it throws — it must NOT hand back the one extension it had already collected.
+        var ex = Assert.Throws<BcAppSymbolReadException>(() => BcAppSymbolCache.GetTableExtensions(appPath));
+        Assert.Equal(appPath, ex.AppPath);
+        Assert.Contains(Path.GetFileName(appPath), ex.Message);
+        Assert.Contains("table extensions", ex.Message);
+        Assert.IsType<InvalidOperationException>(ex.InnerException);
+
+        // [THEN] nothing was cached for that key: a second call re-parses and fails the same
+        // way. Before the fix the second call returned the cached partial list (one entry).
+        Assert.Throws<BcAppSymbolReadException>(() => BcAppSymbolCache.GetTableExtensions(appPath));
+    }
+
+    [Fact]
+    public void GetTableExtensions_CompleteParse_ReturnsAllAndCachesOneInstance()
+    {
+        var appPath = WriteApp($$"""
+            {
+              "RuntimeVersion": "15.1",
+              "Namespaces": [],
+              "TableExtensions": [ {{ValidExtension}} ]
+            }
+            """);
+
+        var first = BcAppSymbolCache.GetTableExtensions(appPath);
+        var ext = Assert.Single(first);
+        Assert.Equal(243, ext.ExtensionId);
+        Assert.Equal("Source Code Setup", ext.TargetTableName);
+        Assert.Equal(2, Assert.Single(ext.Fields).FieldId);
+
+        // A COMPLETE parse is still cached: the second call is served the same instance.
+        var second = BcAppSymbolCache.GetTableExtensions(appPath);
+        Assert.Same(first, second);
+    }
+}

--- a/AlRunner.Tests/RecordPatchesBcAppSymbolReadFailureTests.cs
+++ b/AlRunner.Tests/RecordPatchesBcAppSymbolReadFailureTests.cs
@@ -1,0 +1,164 @@
+// RecordPatchesBcAppSymbolReadFailureTests — proves #2712 at the caller: a registered
+// dependency .app whose table extensions cannot be parsed to completion is a loud, typed
+// failure at BOTH points RecordPatches reads it — never a shorter extension list.
+//
+// The two read points
+// -------------------
+// 1. Registration (RecordPatches.AddBcAppPath, called from Program.cs for every resolved
+//    dependency): reads the .app's symbols eagerly. A parse failure here throws
+//    BcAppSymbolReadException, which Program.cs turns into `FATAL: ... exit 1` before any
+//    test runs, and the .app is NOT left registered.
+// 2. The lazy index rebuild (EnsureBcSymbolTableIndex -> EnsureBcSymbolExtensionIndex), which
+//    re-parses when the file changed on disk after registration — the --watch / --server
+//    shape, where a dependency .app is rebuilt between iterations. Before the fix this path
+//    set _bcSymbolExtensionIndexBuilt = true FIRST, swallowed the failure into a
+//    `[RecordPatches]`-tagged stderr line (dropped by Log's default-verbosity filter), and
+//    merged whatever partial list the parse had returned.
+//
+// Fixture: a synthetic .app whose SymbolReference.json has a real Tables[] entry (so the
+// table-symbol read succeeds) plus a TableExtensions[] entry with a FIELD whose "Id" is a
+// string, which makes JsonElement.TryGetInt32 throw after the earlier entry was collected — see
+// BcAppSymbolCachePartialParseTests for why this reproduces the reported OOM shape exactly.
+// Same synthetic-.app technique as RecordPatchesWarmReloadExtensionIndexTests (#2478); no
+// Base Application floor (.claude/rules/no-base-app-in-csharp-tests.md).
+
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// RecordPatchesSerialCollection: this class calls RecordPatches.ResetForReload() directly,
+// which ParserStaticsIsolationGuardTests requires to be in this collection (#1696) — see
+// RecordPatchesWarmReloadExtensionIndexTests's header for the full reasoning.
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class RecordPatchesBcAppSymbolReadFailureTests : IDisposable
+{
+    private readonly string _root;
+
+    public RecordPatchesBcAppSymbolReadFailureTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-2712-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private static void WriteApp(string path, string symbolReferenceJson)
+    {
+        using var zip = new FileStream(path, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+    }
+
+    // Object ids process-wide unique among AlRunner.Tests statics (shared _parsedTables):
+    // 939xx is used by RecordPatchesPrecompiledTableExtEvictionTests (93900-93902),
+    // RecordPatchesWarmReloadExtensionIndexTests (93910-93912) and
+    // RecordPatchesWarmReloadInstallBaselineTests (93920-93921); this file uses 93930-93935.
+    private static string SymbolReference(int tableId, string tableName, int extId, bool poison)
+    {
+        var extensions = poison
+            ? $$"""
+              { "TargetObject": "{{tableName}}", "Fields": [ { "TypeDefinition": { "Name": "Code[10]" }, "Properties": [], "Id": 50, "Name": "ExtField2712" } ], "Id": {{extId}}, "Name": "Bug2712Ext" },
+              { "TargetObject": "{{tableName}}", "Fields": [ { "TypeDefinition": { "Name": "Code[10]" }, "Properties": [], "Id": "not-a-number", "Name": "PoisonField" } ], "Id": {{extId + 1}}, "Name": "Bug2712Poison" }
+              """
+            : $$"""
+              { "TargetObject": "{{tableName}}", "Fields": [ { "TypeDefinition": { "Name": "Code[10]" }, "Properties": [], "Id": 50, "Name": "ExtField2712" } ], "Id": {{extId}}, "Name": "Bug2712Ext" }
+              """;
+        return $$"""
+            {
+              "RuntimeVersion": "15.1",
+              "Namespaces": [],
+              "Tables": [
+                {
+                  "Id": {{tableId}},
+                  "Name": "{{tableName}}",
+                  "Fields": [ { "TypeDefinition": { "Name": "Code[20]" }, "Properties": [], "Id": 1, "Name": "No." } ],
+                  "Keys": [ { "Name": "PK", "FieldNames": [ "No." ] } ]
+                }
+              ],
+              "TableExtensions": [ {{extensions}} ]
+            }
+            """;
+    }
+
+    [Fact]
+    public void AddBcAppPath_TableExtensionParseFailure_ThrowsAndDoesNotRegister()
+    {
+        const int tableId = 93930;
+        const string tableName = "Bug2712 Unregistered";
+        var appPath = Path.Combine(_root, "poison.app");
+        WriteApp(appPath, SymbolReference(tableId, tableName, extId: 93931, poison: true));
+
+        // [WHEN] Program.cs registers the dependency
+        // [THEN] registration fails loudly with the typed exception naming the .app ...
+        var ex = Assert.Throws<BcAppSymbolReadException>(() => RecordPatches.AddBcAppPath(appPath));
+        Assert.Equal(appPath, ex.AppPath);
+        Assert.Contains("poison.app", ex.Message);
+        Assert.Contains("table extensions", ex.Message);
+
+        // ... and the .app was NOT left registered: its table is unknown to the symbol index.
+        // (Had it been registered, this lookup would build the index over it and find the id.)
+        Assert.Equal(-1, RecordPatches.ResolveTableIdByName(tableName));
+    }
+
+    [Fact]
+    public void AddBcAppPath_CompleteParse_RegistersAndResolves()
+    {
+        const int tableId = 93932;
+        const string tableName = "Bug2712 Registered";
+        var appPath = Path.Combine(_root, "good.app");
+        WriteApp(appPath, SymbolReference(tableId, tableName, extId: 93933, poison: false));
+
+        RecordPatches.AddBcAppPath(appPath);
+
+        // Positive control: the eager read does not get in the way of a healthy .app.
+        Assert.Equal(tableId, RecordPatches.ResolveTableIdByName(tableName));
+    }
+
+    [Fact]
+    public void LazyRebuild_AppChangedToUnparseableOnDisk_ThrowsInsteadOfMergingPartial()
+    {
+        const int tableId = 93934;
+        const string tableName = "Bug2712 Rebuilt";
+        const int extId = 93935;
+        var appPath = Path.Combine(_root, "rebuilt.app");
+        WriteApp(appPath, SymbolReference(tableId, tableName, extId, poison: false));
+
+        // [GIVEN] a healthy registration whose indexes have been built once
+        RecordPatches.AddBcAppPath(appPath);
+        Assert.Equal(tableId, RecordPatches.ResolveTableIdByName(tableName));
+
+        // [WHEN] the .app is rebuilt on disk into a shape whose extension parse fails part-way,
+        // and the per-request reset drops the indexes (exactly what --server/--watch do).
+        // A different length + a bumped mtime give both BcAppSymbolCache caches a new key,
+        // so the next index build re-parses rather than serving the earlier good result.
+        WriteApp(appPath, SymbolReference(tableId, tableName, extId, poison: true));
+        File.SetLastWriteTimeUtc(appPath, File.GetLastWriteTimeUtc(appPath).AddSeconds(5));
+        RecordPatches.ResetForReload();
+
+        // [THEN] the rebuild throws — before the fix it merged the one good extension, flagged
+        // the index as built, printed a filtered-out stderr line and returned the id.
+        var ex = Assert.Throws<BcAppSymbolReadException>(() => RecordPatches.ResolveTableIdByName(tableName));
+        Assert.Contains("rebuilt.app", ex.Message);
+
+        // [THEN] the failure is not turned into "built, nothing merged" either: asking again
+        // re-attempts the build and fails the same loud way (the table index was not published
+        // with the extension flag left false — the #2478 short-circuit shape).
+        Assert.Throws<BcAppSymbolReadException>(() => RecordPatches.ResolveTableIdByName(tableName));
+
+        // Cleanup for later tests in this collection: restore a parseable file so the still-
+        // registered path does not fail every subsequent index rebuild in this process.
+        WriteApp(appPath, SymbolReference(tableId, tableName, extId, poison: false));
+        File.SetLastWriteTimeUtc(appPath, File.GetLastWriteTimeUtc(appPath).AddSeconds(10));
+        RecordPatches.ResetForReload();
+        Assert.Equal(tableId, RecordPatches.ResolveTableIdByName(tableName));
+    }
+}

--- a/AlRunner/Infrastructure/BcAppSymbolReadException.cs
+++ b/AlRunner/Infrastructure/BcAppSymbolReadException.cs
@@ -1,0 +1,41 @@
+// BcAppSymbolReadException — loud failure when a registered dependency .app's
+// SymbolReference.json cannot be read or parsed to completion.
+//
+// Why this is fatal rather than a skipped .app (#2712): the runner answers "which fields
+// does table X have" from these symbols. An .app whose table extensions failed to parse
+// part-way through used to be presented as a shorter list of extensions, and the run then
+// reported ordinary-looking test failures ("field 5912 cannot be found in the 'Customer'
+// table") with an unchanged exit code. A run that cannot see a dependency's symbols cannot
+// produce meaningful results, so it stops here instead — the same posture as
+// DependencyLoadException for a dependency that fails to compile.
+//
+// See: .claude/rules/loud-failures.md.
+
+namespace AlRunner.Infrastructure;
+
+/// <summary>
+/// Thrown when a dependency .app registered with <c>RecordPatches.AddBcAppPath</c> has a
+/// SymbolReference.json the runner could not read to completion. Carries the .app path and
+/// which symbol surface failed ("table symbols" / "table extensions"); the inner exception
+/// is the original failure (an <see cref="OutOfMemoryException"/> in the reported case).
+/// </summary>
+public sealed class BcAppSymbolReadException : Exception
+{
+    public string AppPath { get; }
+    public string Surface { get; }
+
+    public BcAppSymbolReadException(string appPath, string surface, Exception inner)
+        : base(BuildMessage(appPath, surface, inner), inner)
+    {
+        AppPath = appPath;
+        Surface = surface;
+    }
+
+    // No leading `[tag]`: Log's default-verbosity filter drops lines that START with a
+    // bracketed component tag, and this message must survive being printed on its own.
+    private static string BuildMessage(string appPath, string surface, Exception inner)
+        => $"symbol-read-fail {Path.GetFileName(appPath)}: could not read its {surface} from " +
+           $"SymbolReference.json — {inner.GetType().Name}: {inner.Message}. Continuing would " +
+           $"silently report wrong test results (the runner would treat every object this .app " +
+           $"contributes as absent), so the run is aborted. Path: {appPath}";
+}

--- a/AlRunner/Patches/BcAppSymbolCache.TableExtensions.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.TableExtensions.cs
@@ -37,7 +37,12 @@ internal static partial class BcAppSymbolCache
     /// Returns the parsed TableExtension objects for the given .app file.
     /// Uses a separate cache (TableExtensionCache) so that AppSymbols is never modified —
     /// changing AppSymbols also causes SIGSEGV via the same token-shift mechanism.
-    /// Called from <c>RecordPatches.BcAppFallback.EnsureBcSymbolExtensionIndex</c>.
+    /// Called eagerly from <c>RecordPatches.AddBcAppPath</c> at registration and again from
+    /// <c>RecordPatches.BcAppFallback.EnsureBcSymbolExtensionIndex</c> (a cache hit by then,
+    /// unless the file changed on disk).
+    /// <para>Either the parse completes and its result is cached, or it throws
+    /// <see cref="AlRunner.Infrastructure.BcAppSymbolReadException"/> and nothing is stored —
+    /// the store below is only reached on a complete parse (#2712).</para>
     /// </summary>
     internal static IReadOnlyList<TableExtensionSymbol> GetTableExtensions(string appPath)
     {
@@ -50,6 +55,16 @@ internal static partial class BcAppSymbolCache
         return parsed;
     }
 
+    /// <summary>
+    /// Parse every tableextension the .app's SymbolReference.json declares — all of them or
+    /// none. This used to catch every exception, log it only to PerfTrace (off unless
+    /// AL_RUNNER_PERF=1) and return the PARTIAL dictionary collected so far, which
+    /// <see cref="GetTableExtensions"/> then cached for the life of the process. Reported as
+    /// #2712: an OutOfMemoryException part-way through Base Application's symbols dropped
+    /// 90 of 96 extensions, and the run reported 47 extra ordinary-looking test failures
+    /// ("field 5912 cannot be found in the 'Customer' table") with an unchanged exit code.
+    /// Mirrors <see cref="Parse"/>, which has never caught here either.
+    /// </summary>
     private static IReadOnlyList<TableExtensionSymbol> ParseTableExtensions(string appPath)
     {
         var result = new Dictionary<int, TableExtensionSymbol>();
@@ -63,7 +78,11 @@ internal static partial class BcAppSymbolCache
         }
         catch (Exception ex)
         {
-            PerfTrace.Log($"bc-tableext parse failed {System.IO.Path.GetFileName(appPath)}: {ex.Message}");
+            // Typed and loud: the caller (RecordPatches.AddBcAppPath at registration, or the
+            // lazy index rebuild) lets this propagate, and Program.cs turns it into a FATAL
+            // exit — a run that cannot see a dependency's table extensions cannot produce
+            // meaningful results (.claude/rules/loud-failures.md).
+            throw new AlRunner.Infrastructure.BcAppSymbolReadException(appPath, "table extensions", ex);
         }
         return result.Values.ToList();
     }

--- a/AlRunner/Patches/RecordPatches.BcAppFallback.cs
+++ b/AlRunner/Patches/RecordPatches.BcAppFallback.cs
@@ -101,30 +101,50 @@ public static partial class RecordPatches
         if (string.IsNullOrEmpty(appPath) || !File.Exists(appPath)) return;
         lock (_bcTableIndexLock)
         {
-            if (!_bcAppPaths.Contains(appPath, StringComparer.OrdinalIgnoreCase))
+            if (_bcAppPaths.Contains(appPath, StringComparer.OrdinalIgnoreCase)) return;
+
+            // #2712: read BOTH symbol surfaces to completion BEFORE the path is registered.
+            // Registration happens in Program.cs before any test runs, so a failure here is
+            // fatal to the run (Program.cs catches BcAppSymbolReadException and exits 1)
+            // instead of surfacing later as "this table has no extensions" — which is how an
+            // OutOfMemoryException parsing Base Application's SymbolReference.json under a
+            // 1 GB heap limit turned into 47 plausible-looking test failures and exit 0.
+            // Reading first also means a failed .app is never left in _bcAppPaths, so a warm
+            // --server process is not poisoned for every later request. The table-extension
+            // read doubles as a cache warm-up: EnsureBcSymbolExtensionIndex's later call is a
+            // process-cache hit, so this costs nothing the first index build would not have.
+            BcAppSymbolCache.AppSymbols symbols;
+            try
             {
-                _bcAppPaths.Add(appPath);
-                // This is the ONLY live path by which a precompiled dependency's enums reach
-                // AlEnumMetadataRegistry (AlEnumMetadataRegistry.RegisterFromAppPath, which
-                // looks like it does the same job, has no callers). Every field the symbol
-                // carries has to be passed here or it is simply absent at runtime: the
-                // per-value Captions (#1775) and the enum-level DefaultImplementation /
-                // UnknownValueImplementation fallbacks (#2306) were both being dropped,
-                // which is why Base App enum 205 "Alt. Cust VAT Reg. Doc." could not be cast
-                // to its interface.
-                foreach (var enumSymbol in BcAppSymbolCache.Get(appPath).Enums)
-                    AlRunner.AlEnumMetadataRegistry.Register(
-                        enumSymbol.Id,
-                        enumSymbol.Name,
-                        enumSymbol.Options.ToArray(),
-                        enumSymbol.Indexes.ToArray(),
-                        enumSymbol.Implementations.Select(i => i.ToArray()).ToArray(),
-                        enumSymbol.Captions?.ToArray(),
-                        enumSymbol.DefaultImplementations?.ToArray(),
-                        enumSymbol.UnknownImplementations?.ToArray());
-                // Invalidate the indexes so newly-added .app gets picked up on next miss.
-                InvalidateBcAppIndexes();
+                symbols = BcAppSymbolCache.Get(appPath);
+                BcAppSymbolCache.GetTableExtensions(appPath);
             }
+            catch (Exception ex) when (ex is not AlRunner.Infrastructure.BcAppSymbolReadException)
+            {
+                throw new AlRunner.Infrastructure.BcAppSymbolReadException(appPath, "table symbols", ex);
+            }
+
+            _bcAppPaths.Add(appPath);
+            // This is the ONLY live path by which a precompiled dependency's enums reach
+            // AlEnumMetadataRegistry (AlEnumMetadataRegistry.RegisterFromAppPath, which
+            // looks like it does the same job, has no callers). Every field the symbol
+            // carries has to be passed here or it is simply absent at runtime: the
+            // per-value Captions (#1775) and the enum-level DefaultImplementation /
+            // UnknownValueImplementation fallbacks (#2306) were both being dropped,
+            // which is why Base App enum 205 "Alt. Cust VAT Reg. Doc." could not be cast
+            // to its interface.
+            foreach (var enumSymbol in symbols.Enums)
+                AlRunner.AlEnumMetadataRegistry.Register(
+                    enumSymbol.Id,
+                    enumSymbol.Name,
+                    enumSymbol.Options.ToArray(),
+                    enumSymbol.Indexes.ToArray(),
+                    enumSymbol.Implementations.Select(i => i.ToArray()).ToArray(),
+                    enumSymbol.Captions?.ToArray(),
+                    enumSymbol.DefaultImplementations?.ToArray(),
+                    enumSymbol.UnknownImplementations?.ToArray());
+            // Invalidate the indexes so newly-added .app gets picked up on next miss.
+            InvalidateBcAppIndexes();
         }
     }
 
@@ -145,7 +165,17 @@ public static partial class RecordPatches
             foreach (var app in Directory.EnumerateFiles(bundleRoot, "*.app", SearchOption.TopDirectoryOnly))
             {
                 try { if (AlRunner.AppLoader.HasSymbolReference(app)) AddBcAppPath(app); }
-                catch { /* unreadable .app — skip */ }
+                catch (Exception ex)
+                {
+                    // A bundle-root .app is optional (a source-only bundle has none), so an
+                    // unreadable one is skipped as a WHOLE — AddBcAppPath reads to completion
+                    // or throws, so there is no partial to skip with (#2712). `[warn]` is
+                    // exempt from Log's default-verbosity filter; the previous bare catch
+                    // said nothing at all.
+                    Console.Error.WriteLine(
+                        $"[warn] BcAppFallback: skipping bundle-root .app {Path.GetFileName(app)} — " +
+                        $"its symbols could not be read: {ex.Message}");
+                }
             }
         }
         catch (Exception ex)
@@ -493,32 +523,59 @@ public static partial class RecordPatches
         var captions = new Dictionary<int, string?>();
         foreach (var appPath in _bcAppPaths)
         {
-            try
+            // #2712: every path here passed AddBcAppPath's eager read, so the only way this
+            // read can fail is the file having changed or vanished on disk since (a --watch
+            // dependency rebuilt or removed between iterations; a test fixture's temp dir
+            // deleted). Vanished: skip the .app as a WHOLE and say so on a channel that is on
+            // by default. Present but unreadable: a typed failure that propagates — the
+            // previous catch wrote a `[RecordPatches]`-tagged line that Log's default filter
+            // dropped, and published a table index missing that .app's tables.
+            if (!File.Exists(appPath))
             {
-                var symbols = BcAppSymbolCache.Get(appPath);
-                foreach (var table in symbols.Tables)
-                    if (!idx.ContainsKey(table.TableId))
-                        idx[table.TableId] = (appPath, table);
-                // Same first-app-wins rule as the table index above, so the two dictionaries
-                // cannot disagree about which .app a given table id came from. TryAdd rather
-                // than an indexer assignment: the value may legitimately be null (the table
-                // declares no Caption), and null must still claim the id so a later .app's
-                // same-id caption does not overwrite it.
-                foreach (var obj in symbols.Objects)
-                    if (string.Equals(obj.Kind, "Table", StringComparison.OrdinalIgnoreCase))
-                        captions.TryAdd(obj.Id, obj.Caption);
+                Console.Error.WriteLine(
+                    $"[warn] BcAppFallback: registered dependency .app is no longer on disk; its tables " +
+                    $"and table extensions are not available to this run: {appPath}");
+                continue;
             }
-            catch (Exception ex)
+            BcAppSymbolCache.AppSymbols symbols;
+            try { symbols = BcAppSymbolCache.Get(appPath); }
+            catch (Exception ex) when (ex is not AlRunner.Infrastructure.BcAppSymbolReadException)
             {
-                Console.Error.WriteLine($"[RecordPatches] BcAppFallback: SymbolReference read failed for {Path.GetFileName(appPath)}: {ex.Message}");
+                throw new AlRunner.Infrastructure.BcAppSymbolReadException(appPath, "table symbols", ex);
             }
+            foreach (var table in symbols.Tables)
+                if (!idx.ContainsKey(table.TableId))
+                    idx[table.TableId] = (appPath, table);
+            // Same first-app-wins rule as the table index above, so the two dictionaries
+            // cannot disagree about which .app a given table id came from. TryAdd rather
+            // than an indexer assignment: the value may legitimately be null (the table
+            // declares no Caption), and null must still claim the id so a later .app's
+            // same-id caption does not overwrite it.
+            foreach (var obj in symbols.Objects)
+                if (string.Equals(obj.Kind, "Table", StringComparison.OrdinalIgnoreCase))
+                    captions.TryAdd(obj.Id, obj.Caption);
         }
         _bcSymbolTableIndex = idx;
         _bcSymbolTableCaptions = captions;
         if (idx.Count > 0)
             Console.Error.WriteLine($"[RecordPatches] BcAppFallback: indexed {idx.Count} symbol table id(s) across {_bcAppPaths.Count} BC .app file(s)");
-        // Co-build the extension index whenever the table index is (re)built.
-        EnsureBcSymbolExtensionIndex();
+        // Co-build the extension index whenever the table index is (re)built. If that fails,
+        // unpublish the table index again: EnsureBcSymbolExtensionIndex's only call site is
+        // this one, gated by `_bcSymbolTableIndex != null`, so a published table index with
+        // the extension flag still false would short-circuit every later call and serve
+        // tables with no extensions for the rest of the process — the #2478 shape, reached
+        // through a failure instead of a reset. Unpublished, the next lookup retries and
+        // fails the same loud way.
+        try
+        {
+            EnsureBcSymbolExtensionIndex();
+        }
+        catch
+        {
+            _bcSymbolTableIndex = null;
+            _bcSymbolTableCaptions = null;
+            throw;
+        }
     }
 
     /// <summary>
@@ -543,26 +600,34 @@ public static partial class RecordPatches
     private static void EnsureBcSymbolExtensionIndex()
     {
         if (_bcSymbolExtensionIndexBuilt) return;
-        _bcSymbolExtensionIndexBuilt = true;
 
         int merged = 0;
         foreach (var appPath in _bcAppPaths)
         {
-            try
-            {
-                foreach (var ext in BcAppSymbolCache.GetTableExtensions(appPath))
-                {
-                    if (string.IsNullOrEmpty(ext.TargetTableName)) continue;
+            // Vanished from disk since registration: EnsureBcSymbolTableIndex (the only
+            // caller, same pass) already warned and skipped this .app's tables; skip its
+            // extensions the same way so the two indexes agree.
+            if (!File.Exists(appPath)) continue;
 
-                    MergeExtensionFields(ext.TargetTableName, ext.ExtensionId, ext.Fields);
-                    merged++;
-                }
-            }
-            catch (Exception ex)
+            // No catch here (#2712). This used to swallow any failure into a
+            // `[RecordPatches]`-tagged stderr line — dropped by Log's default-verbosity
+            // filter — AFTER having already flagged the index as built, so a partial merge
+            // was presented as the complete answer for the rest of the process.
+            // GetTableExtensions either returns the complete list or throws
+            // BcAppSymbolReadException; MergeExtensionFields de-duplicates by field id, so
+            // a retried merge after a failure is safe.
+            foreach (var ext in BcAppSymbolCache.GetTableExtensions(appPath))
             {
-                Console.Error.WriteLine($"[RecordPatches] BcAppFallback: extension index failed for {Path.GetFileName(appPath)}: {ex.Message}");
+                if (string.IsNullOrEmpty(ext.TargetTableName)) continue;
+
+                MergeExtensionFields(ext.TargetTableName, ext.ExtensionId, ext.Fields);
+                merged++;
             }
         }
+
+        // Only once every registered .app merged to completion. Setting this FIRST was half of
+        // the bug: a failure part-way through left the flag true and the merge never re-ran.
+        _bcSymbolExtensionIndexBuilt = true;
 
         if (merged > 0)
             Console.Error.WriteLine($"[RecordPatches] BcAppFallback: merged {merged} precompiled tableextension(s) into _parsedExtensionFields across {_bcAppPaths.Count} BC .app file(s)");

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2226,6 +2226,20 @@ foreach (var bundle in bundles)
                     $"FATAL: dependency compile failed — cannot continue. {ex.Message}");
                 return 1;
             }
+            catch (AlRunner.Infrastructure.BcAppSymbolReadException ex)
+            {
+                // #2712: a resolved dependency .app's SymbolReference.json could not be read
+                // to completion (reported: OutOfMemoryException parsing Base Application's
+                // under a 1 GB heap limit). Before this handler that failure fell through to
+                // the generic DEP-RESOLVE-FAIL catch below, which prints one line and keeps
+                // going — and the run then reported 212 instead of 259 passing with exit 0.
+                // Same posture as DependencyLoadException above: abort with exit 1 rather
+                // than produce plausible-looking wrong results.
+                if (stdoutSilenced) { Console.SetOut(savedOut); Console.SetError(savedErr); }
+                Console.Error.WriteLine(
+                    $"FATAL: dependency symbols unreadable — cannot continue. {ex.Message}");
+                return 1;
+            }
             catch (AlRunner.Infrastructure.MissingDependencyException ex)
             {
                 // A declared dependency is completely absent from every package-cache directory.


### PR DESCRIPTION
Closes #2712

## What was wrong

`BcAppSymbolCache.ParseTableExtensions` caught every exception, logged it only to `PerfTrace` (off unless `AL_RUNNER_PERF=1`), and returned the partial list it had collected before the failure. `GetTableExtensions` then cached that partial list for the life of the process. The caller, `RecordPatches.EnsureBcSymbolExtensionIndex`, set `_bcSymbolExtensionIndexBuilt = true` before its loop and turned any failure into a `[RecordPatches]`-tagged stderr line, which `Log`'s default filter drops. So an `OutOfMemoryException` while parsing Base Application's `SymbolReference.json` under a 1 GB heap limit dropped 90 of 96 table extensions, and the Tests-SMB run reported 212 instead of 259 passing with exit code 0.

## What I changed

- `AlRunner/Patches/BcAppSymbolCache.TableExtensions.cs`: `ParseTableExtensions` throws a typed `BcAppSymbolReadException` (new, `AlRunner/Infrastructure/BcAppSymbolReadException.cs`) naming the `.app` and the surface. The cache store in `GetTableExtensions` is only reached on a complete parse. This matches `Parse` (behind `Get`), which never caught.
- `RecordPatches.AddBcAppPath`: reads both symbol surfaces (`Get` and `GetTableExtensions`) to completion before adding the path to `_bcAppPaths`. Registration runs in `Program.cs` before any test, so the failure is fatal to the run, and a failed `.app` is never left registered (a warm `--server` process would otherwise fail every later request). The table-extension read also fills the process cache, so the later index build is a cache hit: this is the same parse the first index build already did, moved earlier.
- `AlRunner/Program.cs`: catches `BcAppSymbolReadException` next to `DependencyLoadException`, restores the streams, prints `FATAL: dependency symbols unreadable — cannot continue. <message>` and returns 1. Before, it fell into the generic `DEP-RESOLVE-FAIL` catch, which prints one line and continues. In server mode the existing generic catch already returns a failure for the request.
- `EnsureBcSymbolExtensionIndex`: no catch; the built flag is set only after every registered `.app` merged. `EnsureBcSymbolTableIndex`: if the extension merge throws, it unpublishes the table index before rethrowing, so a table index with the extension flag still false cannot short-circuit every later call (the same shape as #2478, reached through a failure instead of a reset). A registered `.app` that is no longer on disk is skipped as a whole with a `[warn]` line, which is exempt from the default filter.
- `RegisterBundleSymbolApps`: the bare `catch {}` now prints a `[warn]` line naming the bundle-root `.app` it skipped and why. It still skips: a bundle-root `.app` is optional, and after this change an unreadable one contributes nothing at all, since no partial is possible.

## RED -> GREEN

Both new classes were RED on `main` with "No exception was thrown" and are GREEN with the fix:

- `AlRunner.Tests/BcAppSymbolCachePartialParseTests.cs` (parse layer). Fixture: a `TableExtensions[]` with one valid entry followed by an entry whose field `Id` is a string. `JsonElement.TryGetInt32` throws `InvalidOperationException` on a non-number, so the second entry fails after the first was collected: the same partial-then-fail shape as the OOM case, with no memory pressure. `Parse` reads an extension's `Id`/`Name`/`Properties` for the object list but never its `Fields`, so `Get` succeeds on the same file and only the extension parse fails.
  - Negative: `GetTableExtensions` throws `BcAppSymbolReadException` (app path, file name, "table extensions", inner `InvalidOperationException`), and throws again on the second call, so nothing was cached. Before the fix both calls returned the one-entry partial.
  - Positive: a complete parse returns the extension with its field, and the second call returns the same instance.
- `AlRunner.Tests/RecordPatchesBcAppSymbolReadFailureTests.cs` (caller).
  - `AddBcAppPath` on the broken `.app` throws the typed exception and the `.app` is not registered (`ResolveTableIdByName` for its table returns -1).
  - A healthy `.app` still registers and resolves.
  - Lazy rebuild: a healthy registration, then the file is rewritten on disk into the broken shape, mtime bumped, `ResetForReload()` (what `--server`/`--watch` do). The next lookup throws, and throws again on retry. Before the fix it merged the one good extension, flagged the index built, printed a filtered line and returned the id.

## Reproducer from the issue

Same Tests-SMB bundle, BC 28.1, this branch's Release build:

```
DOTNET_GCHeapHardLimit=0x40000000 al-runner <Tests-SMB>
FATAL: dependency symbols unreadable — cannot continue. symbol-read-fail Microsoft_Base Application_28.1.49838.54169.app: could not read its table extensions from SymbolReference.json — OutOfMemoryException: Exception of type 'System.OutOfMemoryException' was thrown.. Continuing would silently report wrong test results (...), so the run is aborted. Path: .../platform-apps/Microsoft_Base Application_28.1.49838.54169.app
exit=1   (1m38s wall)
```

Before this change the same command reported 212 passing with exit 0.

## What I ran

- The two new classes: 5 passed.
- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~BcAppSymbolCache|~RecordPatches|~DependencyPage|~DependencyReport|~CacheRoots|~PageExtensionParser|~QueryAggregationProjection"`: 76 passed, 0 failed, 11 skipped (the engine-gated ones).
- The reproducer above.
- I did not run the full `AlRunner.Tests` suite or the corpus locally.

## The wider shape

1. **Same wrong pattern at another call site?** `ParseTableExtensions` was the only parse that returned a partial result; `Parse` (behind `Get`) has no catch, so `Get` cannot yield one. The caller-side catch-and-continue existed in two places in `RecordPatches.BcAppFallback.cs`: `EnsureBcSymbolExtensionIndex` (was line 561, fixed) and `EnsureBcSymbolTableIndex` (was line 511, fixed the same way).
2. **Sibling functions with the same assumption?** Eleven more lazy loops over `_bcAppPaths` call `BcAppSymbolCache.Get(appPath)` inside a `catch (Exception)` that writes a `[RecordPatches]`-tagged line (dropped at default verbosity) and continues: `RecordPatches.BcAppFallback.cs` (query index, and the AL-source table index), `RecordPatches.AllObjVirtualTable.cs`, `RecordPatches.AllProfileVirtualTable.cs`, `RecordPatches.CodeunitMetadataVirtualTable.cs`, `RecordPatches.DependencyPageMetadata.cs`, `RecordPatches.MetadataPermissionSetVirtualTable.cs`, `RecordPatches.PageMetadataVirtualTable.cs`, `RecordPatches.ReportMetadataVirtualTable.cs`, `RecordPatches.TableMetadataVirtualTable.cs`, `DependencyReportMetadata.cs`. I left these as they are. Every path in `_bcAppPaths` has now passed the eager read in `AddBcAppPath`, and `Get` is served from the process cache after that, so the only failure those catches can still see is a file changed or removed on disk after registration. That is a whole-app skip, not a partial answer, but it is still silent at default verbosity. If that should also be loud or fatal, I can file a follow-up issue.
3. **Two code paths writing the same state with different invariants?** Yes, and that was the bug: `AddBcAppPath` (registration) and `ResetForReload` (per-request reset) both drive the same index rebuild; the rebuild trusted the parse to be complete while the parse did not guarantee it. Both now use the same read-to-completion contract, and the rebuild unpublishes on failure.

Not done: the issue's item 4 (checking the merged count against the number of registered `.app` files). With the parse either complete or throwing, the count can no longer be silently short, so I did not add a second check. No documentation change: the new `FATAL:` line follows the existing `DependencyLoadException` format, which is not documented separately either.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
