### PR TITLE
ci: manual-dispatch workflow to run one Microsoft BaseApp bucket with --test-data

### DIFF
--- a/.github/actions/provision-bc/action.yml
+++ b/.github/actions/provision-bc/action.yml
@@ -1,0 +1,84 @@
+name: Provision BC for a runner build
+description: >-
+  Build the solution against one BC version (auto-downloading its service-tier DLLs) and
+  populate the two package caches every runner invocation in CI needs — the R2R platform
+  apps and the Microsoft test toolkit. ONE definition with two consumers: bc-tests.yml (the
+  matrix) and ms-bucket.yml (the manual Microsoft-bucket run, #2724). bc-tests.yml's header
+  records what a second hand-maintained copy of these steps cost (#1976: four drifts, two
+  broken releases); AlRunner.Tests/MsBucketWorkflowTests.cs keeps both consumers on this
+  action instead of re-inlining it.
+
+inputs:
+  bc-version:
+    description: Full four-part BC build to provision, e.g. 28.4.53241.54318
+    required: true
+
+runs:
+  using: composite
+  steps:
+    # BC 28.1 is a .NET 8 product (Server.runtimeconfig.json tfm=net8.0); the runner
+    # targets net8.0 and runs it on its real runtime. (BC's Types.dll binds
+    # System.Text.Json 10, which the runner deploys app-local via deps.json — see
+    # AlRunner.csproj.) net8 SDK builds the runner and tools/DownloadArtifacts.
+    - uses: actions/setup-dotnet@v5
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Build (auto-downloads BC ${{ inputs.bc-version }} DLLs)
+      shell: bash
+      run: |
+        # AllowBcArtifactDownload=true is what actually permits the in-build fetch
+        # (AlRunner.csproj target EnsureBCServiceTierDlls). Without it the sibling
+        # FailIfBCServiceTierDllsMissing target hard-errors, and this step failed
+        # before a single test ran — despite its name promising the download.
+        dotnet build AlRunner.slnx \
+          -p:_BCVersion=${{ inputs.bc-version }} \
+          -p:AllowBcArtifactDownload=true \
+          -c Release
+
+    - name: Download R2R platform apps (Base/System Application, …)
+      shell: bash
+      run: |
+        # The corpus ships a SYMBOL-ONLY Base Application in its .alpackages, which is
+        # enough to COMPILE but carries no runtime DLL — so cross-app tableextension tests
+        # that instantiate a Base App record (e.g. Item Journal Batch / Record233) fail at
+        # runtime ("no loaded type Record233"). Fetch the R2R platform apps (with DLLs) at
+        # this BC version into a package cache so DependencyLoader can load the real types.
+        # They're a higher version than the .alpackages symbols, so the resolver prefers them.
+        dotnet run --project tools/DownloadArtifacts -- \
+          platform-apps ${{ inputs.bc-version }} "$HOME/.al-runner/platform-apps"
+
+        # Issue #2205: the same apps, also at the location the runner scans BY DEFAULT
+        # (ProvisioningCheck.PlatformAppsDirFor — <artifacts-root>/<version>/platform-apps),
+        # which is where `provision`/--auto-provision put them on a real machine.
+        #
+        # Every AlRunner.Tests case that spawns the runner as a subprocess runs without
+        # --package-cache, so it only ever sees the default caches. Now that an ordinary
+        # app.json's `application`/`platform` fields are recognised as a real Microsoft
+        # dependency, each of those subprocesses would otherwise decide it needs the
+        # platform set and fetch 116 MB from the CDN — dozens of times, four in parallel,
+        # into the same directory. Hardlinking the already-downloaded set is instant and
+        # makes CI match a developer machine that has provisioned once.
+        DEFAULT_PLATFORM_APPS="$HOME/.local/share/al-runner/artifacts/${{ inputs.bc-version }}/platform-apps"
+        mkdir -p "$DEFAULT_PLATFORM_APPS"
+        cp -al "$HOME/.al-runner/platform-apps/." "$DEFAULT_PLATFORM_APPS/" \
+          || cp -a "$HOME/.al-runner/platform-apps/." "$DEFAULT_PLATFORM_APPS/"
+        ls -la "$DEFAULT_PLATFORM_APPS"
+
+    - name: Download the Microsoft test toolkit (Any, Library Assert, Test Runner, …)
+      shell: bash
+      run: |
+        # tests/runner-extras/microsoft-dependencies depends on Application Test Library
+        # (w1/Extensions, fetched above), which in turn needs the toolkit apps that ship
+        # in the PLATFORM artifact — two different artifacts, two commands. Without these
+        # the leg aborted on a provisioning gap before running a test; it only passed
+        # locally because a full multi-GB BC sandbox artifact happened to be cached.
+        #
+        # Deliberately a SEPARATE directory, not merged into platform-apps: the toolkit is
+        # 107 apps, and CacheKeyDependencyClosureTests builds a "different closure" by
+        # dropping the ordinally-first .app from that directory. Merged, that drops an
+        # unrelated toolkit app the fixture never resolves, both closures come out
+        # identical, and the test fails for a reason that has nothing to do with the
+        # cache key. --package-cache is repeatable; pass both.
+        dotnet run --project tools/DownloadArtifacts -- \
+          test-apps ${{ inputs.bc-version }} "$HOME/.al-runner/test-apps"

--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -178,69 +178,15 @@ jobs:
           ref: ${{ inputs.ref }}
           submodules: true
 
-      # BC 28.1 is a .NET 8 product (Server.runtimeconfig.json tfm=net8.0); the runner
-      # targets net8.0 and runs it on its real runtime. (BC's Types.dll binds
-      # System.Text.Json 10, which the runner deploys app-local via deps.json — see
-      # AlRunner.csproj.) net8 SDK builds the runner and tools/DownloadArtifacts.
-      - uses: actions/setup-dotnet@v5
+      # setup-dotnet, the Release build against this BC version, the R2R platform apps
+      # and the Microsoft test toolkit — moved, comments and all, into ONE composite
+      # action (#2724) because ms-bucket.yml needs the identical provisioning and this
+      # file's own header is the record of what a second hand-maintained copy of these
+      # steps costs (#1976). MsBucketWorkflowTests keeps both consumers on the action;
+      # ReleaseTestParityTests still keeps publish.yml/test-matrix.yml delegating here.
+      - uses: ./.github/actions/provision-bc
         with:
-          dotnet-version: '8.0.x'
-
-      - name: Build (auto-downloads BC ${{ matrix.target.bc-version }} DLLs)
-        run: |
-          # AllowBcArtifactDownload=true is what actually permits the in-build fetch
-          # (AlRunner.csproj target EnsureBCServiceTierDlls). Without it the sibling
-          # FailIfBCServiceTierDllsMissing target hard-errors, and this step failed
-          # before a single test ran — despite its name promising the download.
-          dotnet build AlRunner.slnx \
-            -p:_BCVersion=${{ matrix.target.bc-version }} \
-            -p:AllowBcArtifactDownload=true \
-            -c Release
-
-      - name: Download R2R platform apps (Base/System Application, …)
-        run: |
-          # The corpus ships a SYMBOL-ONLY Base Application in its .alpackages, which is
-          # enough to COMPILE but carries no runtime DLL — so cross-app tableextension tests
-          # that instantiate a Base App record (e.g. Item Journal Batch / Record233) fail at
-          # runtime ("no loaded type Record233"). Fetch the R2R platform apps (with DLLs) at
-          # this BC version into a package cache so DependencyLoader can load the real types.
-          # They're a higher version than the .alpackages symbols, so the resolver prefers them.
-          dotnet run --project tools/DownloadArtifacts -- \
-            platform-apps ${{ matrix.target.bc-version }} "$HOME/.al-runner/platform-apps"
-
-          # Issue #2205: the same apps, also at the location the runner scans BY DEFAULT
-          # (ProvisioningCheck.PlatformAppsDirFor — <artifacts-root>/<version>/platform-apps),
-          # which is where `provision`/--auto-provision put them on a real machine.
-          #
-          # Every AlRunner.Tests case that spawns the runner as a subprocess runs without
-          # --package-cache, so it only ever sees the default caches. Now that an ordinary
-          # app.json's `application`/`platform` fields are recognised as a real Microsoft
-          # dependency, each of those subprocesses would otherwise decide it needs the
-          # platform set and fetch 116 MB from the CDN — dozens of times, four in parallel,
-          # into the same directory. Hardlinking the already-downloaded set is instant and
-          # makes CI match a developer machine that has provisioned once.
-          DEFAULT_PLATFORM_APPS="$HOME/.local/share/al-runner/artifacts/${{ matrix.target.bc-version }}/platform-apps"
-          mkdir -p "$DEFAULT_PLATFORM_APPS"
-          cp -al "$HOME/.al-runner/platform-apps/." "$DEFAULT_PLATFORM_APPS/" \
-            || cp -a "$HOME/.al-runner/platform-apps/." "$DEFAULT_PLATFORM_APPS/"
-          ls -la "$DEFAULT_PLATFORM_APPS"
-
-      - name: Download the Microsoft test toolkit (Any, Library Assert, Test Runner, …)
-        run: |
-          # tests/runner-extras/microsoft-dependencies depends on Application Test Library
-          # (w1/Extensions, fetched above), which in turn needs the toolkit apps that ship
-          # in the PLATFORM artifact — two different artifacts, two commands. Without these
-          # the leg aborted on a provisioning gap before running a test; it only passed
-          # locally because a full multi-GB BC sandbox artifact happened to be cached.
-          #
-          # Deliberately a SEPARATE directory, not merged into platform-apps: the toolkit is
-          # 107 apps, and CacheKeyDependencyClosureTests builds a "different closure" by
-          # dropping the ordinally-first .app from that directory. Merged, that drops an
-          # unrelated toolkit app the fixture never resolves, both closures come out
-          # identical, and the test fails for a reason that has nothing to do with the
-          # cache key. --package-cache is repeatable; pass both.
-          dotnet run --project tools/DownloadArtifacts -- \
-            test-apps ${{ matrix.target.bc-version }} "$HOME/.al-runner/test-apps"
+          bc-version: ${{ matrix.target.bc-version }}
 
       - name: Warm the Ncl Cecil rewrite cache
         run: |

--- a/.github/workflows/ms-bucket.yml
+++ b/.github/workflows/ms-bucket.yml
@@ -1,0 +1,255 @@
+name: MS bucket (manual)
+
+# Runs ONE Microsoft BaseApp test bucket (default Tests-ERM, 9,496 tests) through AL Runner
+# in the full configuration — including --test-data — and reports total / pass / fail /
+# error and wall time in the job summary. Issue #2724.
+#
+# This is a VERIFICATION NET, not a gate:
+#   * `on: workflow_dispatch` only. No push, no pull_request, no schedule. A 9,500-test
+#     bucket is a multi-hour job and must never land on a PR.
+#   * Not a required check and not in any branch ruleset. Nothing about `main`'s gate
+#     ("All BC versions passed", test-matrix.yml) changes.
+#   * It measures; it does not try to make the suite green. The job is GREEN when it
+#     produced a number (runner exit 0 or 1 plus a JUnit file) and RED only when it did not
+#     (compile fail, exec fail, crash, or no JUnit) — thousands of failing tests are the
+#     expected outcome and are reported, not failed on.
+#
+# Why it exists: running the Microsoft surface on a developer desktop competes with the
+# implementation agents for memory and has OOMed the machine twice. A hosted runner gives a
+# trustworthy number without that contention.
+#
+# What it reuses (see the composite action's description and bc-tests.yml's header for why
+# these steps are never hand-copied): .github/actions/provision-bc builds the runner against
+# the BC version and fills BOTH package caches. Everything the matrix does NOT provision is
+# fetched here through the same ranged-ZIP read tools/DownloadArtifacts already uses:
+#   * `test-sources` — the bucket's Source.zip, from the platform artifact (2.4 MB for ERM);
+#   * `test-data`    — BusinessCentral-W1.bak from the sandbox w1 artifact (~977 MB), streamed
+#                      to disk and cached across runs with actions/cache keyed on the build;
+#   * the backup reader `bcbak` — StefanMaron/BusinessCentral.BakReader's Native AOT
+#                      `bcdb-linux-x64` release asset, checksum-verified, installed under the
+#                      old name the runner probes (BackupReaderTool.cs).
+#
+# Configuration recorded from working local runs — wrong values do not fail the run, they
+# make its number meaningless (AlRunner.Tests/MsBucketWorkflowTests.cs pins them):
+#   * company `CRONUS International Ltd_` — SQL form, TRAILING UNDERSCORE, not a period;
+#   * both --package-cache directories;
+#   * AL_RUNNER_EMIT_TIMEOUT_SEC far above the 120 s default (Tests-ERM's emit alone is
+#     minutes);
+#   * a private --cache root, never the shared default.
+#
+# Reading the number — two known ways it can be wrong until their fixes land, both surfaced
+# verbatim in the summary by scripts/ms-bucket-summary.py:
+#   * a bundle lost to COMPILE FAIL silently vanishes from the totals (#2715; #2721 adds a
+#     "NOT RUN: N bundle(s)" line);
+#   * a run resumed after a watchdog abort (--resume-aborts, default 5) carries earlier
+#     attempts forward via --merge-counts; #2716 / #2720 cover the JUnit under-reporting that
+#     came with it. The "resume:" and "(carried from earlier attempt(s): …)" lines tell you it
+#     happened.
+# Always state whether a number was measured WITH or WITHOUT --test-data: the two differ by
+# 3x on Tests-SINGLESERVER and are not comparable.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bucket:
+        description: >-
+          Microsoft BaseApp test bucket — the <name> in Applications/BaseApp/Test/<name>.Source.zip
+          (Tests-ERM, Tests-SCM, Tests-Misc, Tests-Cash Flow, …). A wrong name fails fast and
+          lists what the artifact ships.
+        type: string
+        required: true
+        default: Tests-ERM
+      bc-version:
+        description: >-
+          BC build: a full four-part build (28.4.53241.54318) or a prefix (28.4) resolved to
+          its newest published build. Empty = the newest prefix in .github/bc-versions.txt,
+          the one the matrix marks required.
+        type: string
+        required: false
+        default: ''
+      test-data:
+        description: >-
+          Hydrate CRONUS International Ltd_ from the sandbox backup (--test-data). Off measures
+          the empty-database number, which is a different number.
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  contents: read
+
+# One run per bucket at a time. A second dispatch of the same bucket queues behind the first
+# rather than cancelling a multi-hour measurement in flight.
+concurrency:
+  group: ms-bucket-${{ inputs.bucket }}
+  cancel-in-progress: false
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  run:
+    name: ${{ inputs.bucket }} on BC ${{ inputs.bc-version || 'newest' }}
+    runs-on: ubuntu-latest
+    # The hosted maximum. Tests-SINGLESERVER (834 tests) takes ~4 minutes warm; Tests-ERM is
+    # 11x the tests plus a cold build, provisioning and a cold emit.
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v6
+
+      # The provisioning action sets up .NET too; this earlier copy is for the version
+      # resolution below, which has to run BEFORE the action can be given a version.
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Resolve the BC build
+        id: bc
+        env:
+          REQUESTED: ${{ inputs.bc-version }}
+        run: |
+          # Same resolver bc-tests.yml uses (tools/DownloadArtifacts resolve-version), never a
+          # second implementation of it — re-resolving differently is the drift #2010 was.
+          req="${REQUESTED// /}"
+          if [ -z "$req" ]; then
+            req=$(grep -v '^#' .github/bc-versions.txt | tr ' ' '\n' | grep . | sort -V | tail -1)
+            echo "No version given; using the newest prefix in .github/bc-versions.txt: $req"
+          fi
+          dots=$(printf '%s' "$req" | tr -dc . | wc -c)
+          if [ "$dots" -eq 3 ]; then
+            full="$req"
+          else
+            full=$(dotnet run --project tools/DownloadArtifacts -- resolve-version "$req" 2>/dev/null || true)
+            if [ -z "$full" ]; then
+              echo "::error::could not resolve BC '$req' to a published build"
+              exit 1
+            fi
+          fi
+          echo "version=$full" >> "$GITHUB_OUTPUT"
+          echo "BC build: $full"
+
+      - uses: ./.github/actions/provision-bc
+        with:
+          bc-version: ${{ steps.bc.outputs.version }}
+
+      - name: Fetch the bucket sources
+        env:
+          BUCKET: ${{ inputs.bucket }}
+        run: |
+          dotnet run --project tools/DownloadArtifacts -- \
+            test-sources ${{ steps.bc.outputs.version }} "$RUNNER_TEMP/ms-buckets" "$BUCKET"
+          bundle="$RUNNER_TEMP/ms-buckets/$BUCKET"
+          echo "AL files in $bundle: $(find "$bundle" -name '*.al' | wc -l)"
+          test -f "$bundle/app.json"
+
+      - name: Install the backup reader (bcbak)
+        if: ${{ inputs.test-data }}
+        id: reader
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # bcbak is StefanMaron/BusinessCentral.BakReader's `bcdb`, consumed as the latest
+          # release's Native AOT asset rather than built here: a source build needs the .NET 10
+          # SDK plus clang and adds minutes, and the release binary is the one that repo's own
+          # hermetic test suite gated before publishing. The runner probes the OLD name at
+          # ~/.cache/al-runner/bcbak/bcbak (BackupReaderTool.CandidateExecutables), so the
+          # asset is installed under that name. The tag lands in the summary: the reader's
+          # identity keys the install-baseline cache and a reader fix changes decoded values.
+          tag=$(gh release view --repo StefanMaron/BusinessCentral.BakReader --json tagName --jq .tagName)
+          mkdir -p "$RUNNER_TEMP/reader"
+          cd "$RUNNER_TEMP/reader"
+          gh release download "$tag" --repo StefanMaron/BusinessCentral.BakReader \
+            --pattern bcdb-linux-x64 --pattern SHA256SUMS
+          grep 'bcdb-linux-x64$' SHA256SUMS | sha256sum -c -
+          install -D -m 0755 bcdb-linux-x64 "$HOME/.cache/al-runner/bcbak/bcbak"
+          "$HOME/.cache/al-runner/bcbak/bcbak" --version
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Restore the cached backup
+        if: ${{ inputs.test-data }}
+        id: bak-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.al-runner/test-data/${{ steps.bc.outputs.version }}
+          key: bc-test-data-w1-${{ steps.bc.outputs.version }}
+
+      - name: Fetch the backup (BusinessCentral-W1.bak)
+        if: ${{ inputs.test-data && steps.bak-cache.outputs.cache-hit != 'true' }}
+        run: |
+          dotnet run --project tools/DownloadArtifacts -- \
+            test-data ${{ steps.bc.outputs.version }} "$HOME/.al-runner/test-data/${{ steps.bc.outputs.version }}" w1
+
+      # Explicit restore/save pair rather than actions/cache: its implicit save runs only
+      # when the job succeeds, and a multi-hour bucket run can legitimately end red (no
+      # number) for reasons that have nothing to do with the backup. The 1 GB download is
+      # worth keeping either way.
+      - name: Save the backup to the cache
+        if: ${{ inputs.test-data && steps.bak-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.al-runner/test-data/${{ steps.bc.outputs.version }}
+          key: bc-test-data-w1-${{ steps.bc.outputs.version }}
+
+      - name: Run the bucket
+        id: run
+        env:
+          # The 120 s default is sized for a corpus app, not a 9,500-test bucket whose emit
+          # alone is minutes. #2721 scales the default by --jobs worker count; this is a single
+          # process, so the base value is what applies.
+          AL_RUNNER_EMIT_TIMEOUT_SEC: "3600"
+          BUCKET: ${{ inputs.bucket }}
+          BC_VERSION: ${{ steps.bc.outputs.version }}
+          WITH_TEST_DATA: ${{ inputs.test-data }}
+        run: |
+          set +e
+          bundle="$RUNNER_TEMP/ms-buckets/$BUCKET"
+          bak="$HOME/.al-runner/test-data/$BC_VERSION/BusinessCentral-W1.bak"
+          args=( "$bundle"
+                 --package-cache "$HOME/.al-runner/platform-apps"
+                 --package-cache "$HOME/.al-runner/test-apps"
+                 --cache "$RUNNER_TEMP/al-runner-cache"
+                 --output-junit "$GITHUB_WORKSPACE/junit.xml"
+                 --out "$GITHUB_WORKSPACE/results.json"
+                 --quiet )
+          if [ "$WITH_TEST_DATA" = "true" ]; then
+            # SQL form of the company name: trailing underscore. With a period the run fails
+            # loudly and lists both companies.
+            args+=( "--test-data=$bak" --test-data-company "CRONUS International Ltd_" )
+          fi
+          # cwd OUTSIDE the checkout: the runner auto-probes ./tests/expectations from cwd as
+          # a fallback (ExpectationsDirectoryResolution.cs), and the corpus manifest has no
+          # business reclassifying a Microsoft bucket.
+          cd "$RUNNER_TEMP"
+          start=$SECONDS
+          "$GITHUB_WORKSPACE/AlRunner/bin/Release/net8.0/al-runner" "${args[@]}" 2>&1 \
+            | tee "$GITHUB_WORKSPACE/run.log"
+          rc=${PIPESTATUS[0]}
+          echo "rc=$rc" >> "$GITHUB_OUTPUT"
+          echo "elapsed=$(( SECONDS - start ))" >> "$GITHUB_OUTPUT"
+          echo "runner exit code: $rc (1 = tests failed, the expected outcome; the summary step decides the verdict)"
+
+      - name: Job summary
+        if: always()
+        run: |
+          # Exit 0 = a number was produced (runner exit 0/1 + JUnit); 1 = no measurement.
+          python3 scripts/ms-bucket-summary.py \
+            --log run.log --junit junit.xml \
+            --rc "${{ steps.run.outputs.rc || 2 }}" \
+            --elapsed "${{ steps.run.outputs.elapsed || 0 }}" \
+            --bucket "${{ inputs.bucket }}" \
+            --bc-version "${{ steps.bc.outputs.version }}" \
+            --test-data "${{ inputs.test-data }}" \
+            --reader "${{ steps.reader.outputs.tag }}" \
+            --step-summary "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload results (JUnit for clustering, classification JSON, full log)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ms-bucket-${{ inputs.bucket }}-${{ steps.bc.outputs.version }}
+          path: |
+            junit.xml
+            results.json
+            run.log
+          if-no-files-found: ignore

--- a/AlRunner.Provisioning/ArtifactDownloader.cs
+++ b/AlRunner.Provisioning/ArtifactDownloader.cs
@@ -222,6 +222,346 @@ public static class ArtifactDownloader
     }
 
     // -----------------------------------------------------------------------
+    // Test Sources (issue #2724): ONE Microsoft BaseApp test bucket's AL source. The
+    // 33 `Tests-*.Source.zip` files ship in the SAME platform artifact TestApps reads,
+    // under Applications/BaseApp/Test/ beside the compiled .app files — TestApps' filter
+    // simply excluded them by extension. Each zip is flat (app.json at the root beside
+    // the .al files, measured on 28.4.53241.54318: Tests-ERM = 297 files, 2.4 MB
+    // deflated) and needs no edits, so it is unpacked straight into <outputDir>/<bucket>/
+    // and that directory is a runnable bundle.
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Whether a ZIP central-directory entry is <paramref name="bucket"/>'s Source.zip.
+    /// Pure over the entry name so the rule — the BaseApp Test/ folder AND an exact
+    /// basename match — is unit-testable without a central directory or a network round
+    /// trip. Exact, not prefix: <c>Tests-ERM</c> must not match a hypothetical
+    /// <c>Tests-ERM-Extra</c>, and the compiled <c>Microsoft_Tests-ERM_….app</c> beside it
+    /// is a different file for a different mode.
+    /// </summary>
+    internal static bool IsBaseAppTestSourceEntry(string entryName, string bucket)
+    {
+        if (string.IsNullOrWhiteSpace(entryName) || string.IsNullOrWhiteSpace(bucket)) return false;
+        const string folder = "applications/baseapp/test/";
+        var lower = entryName.Replace('\\', '/').ToLowerInvariant();
+        if (!lower.StartsWith(folder, StringComparison.Ordinal)) return false;
+        // Equality on the remainder also rejects anything nested deeper than the folder.
+        return lower[folder.Length..] == bucket.Trim().ToLowerInvariant() + ".source.zip";
+    }
+
+    public static int TestSources(string version, string outputDir, string bucket, Action<string>? log = null)
+    {
+        var logf = L(log);
+        if (string.IsNullOrWhiteSpace(bucket))
+        {
+            logf("Error: test-sources needs a bucket name, e.g. Tests-ERM");
+            return 1;
+        }
+        bucket = bucket.Trim();
+        var artifactUrl = BuildArtifactUrl(version, "platform");
+        Directory.CreateDirectory(outputDir);
+
+        using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(10) };
+
+        logf($"Resolving artifact size for BC {version} (platform)...");
+        if (!TryHeadContentLength(http, artifactUrl, version, "platform", logf, out long totalSize)) return 1;
+        if (totalSize == 0) { logf("Error: unknown size"); return 1; }
+
+        logf("Downloading ZIP directory...");
+        if (!TryReadCentralDirectory(http, artifactUrl, totalSize, logf, out var cdData, out var cdStart, out var entryCount))
+            return 1;
+
+        (string Name, int Method, long CompSize, long Offset)? found = null;
+        var shipped = new List<string>();
+        int pos = cdStart;
+        for (int i = 0; i < entryCount && pos + 46 <= cdData.Length; i++)
+        {
+            if (!IsCentralHeader(cdData, pos)) break;
+            var (cm, cs, nl, el, cl, lo, name) = ReadCentralEntry(cdData, pos);
+            pos += 46 + nl + el + cl;
+            if (cs == 0) continue;
+            if (IsBaseAppTestSourceEntry(name, bucket)) { found = (name, cm, cs, lo); break; }
+            var lower = name.ToLowerInvariant();
+            if (lower.StartsWith("applications/baseapp/test/", StringComparison.Ordinal)
+                && lower.EndsWith(".source.zip", StringComparison.Ordinal))
+                shipped.Add(Path.GetFileName(name)[..^".Source.zip".Length]);
+        }
+
+        if (found == null)
+        {
+            // Name what IS there: a typo'd bucket ("Tests-Erm", "Tests-CashFlow") is the
+            // likely cause, and the list is the only way to fix it without a second run.
+            logf($"Error: no Applications/BaseApp/Test/{bucket}.Source.zip in the BC {version} platform artifact.");
+            shipped.Sort(StringComparer.OrdinalIgnoreCase);
+            logf($"       Buckets that artifact ships ({shipped.Count}): {string.Join(", ", shipped)}");
+            return 1;
+        }
+
+        var (entryName, method, compSize, offset) = found.Value;
+        logf($"  Downloading {Path.GetFileName(entryName)} ({compSize / 1024} KB compressed)...");
+        var zipBytes = ExtractEntry(http, artifactUrl, totalSize, entryName, method, compSize, offset, logf);
+        if (zipBytes == null) return 1;
+
+        // A fresh directory every time: a previous partial or older-version unpack must not
+        // merge with this one and leave stray .al files the compiler then picks up.
+        var bundleDir = Path.Combine(outputDir, bucket);
+        if (Directory.Exists(bundleDir)) Directory.Delete(bundleDir, recursive: true);
+        Directory.CreateDirectory(bundleDir);
+
+        int files;
+        try
+        {
+            using var ms = new MemoryStream(zipBytes);
+            files = UnpackSourceZip(ms, bundleDir);
+        }
+        catch (InvalidDataException ex)
+        {
+            logf($"Error: {Path.GetFileName(entryName)}: {ex.Message}");
+            return 1;
+        }
+
+        logf($"Unpacked {files} file(s) from {Path.GetFileName(entryName)} to {bundleDir}");
+        return 0;
+    }
+
+    /// <summary>
+    /// Unpacks a bucket Source.zip into <paramref name="destDir"/>. Validates EVERY entry
+    /// before writing ANY: an entry that would land outside the destination
+    /// (<c>../</c>, an absolute path) or a zip with no root <c>app.json</c> throws
+    /// <see cref="InvalidDataException"/> with nothing on disk — a half-unpacked bundle
+    /// would otherwise compile and run a subset while looking complete. Returns the number
+    /// of files written.
+    /// </summary>
+    internal static int UnpackSourceZip(Stream sourceZip, string destDir)
+    {
+        using var zip = new ZipArchive(sourceZip, ZipArchiveMode.Read, leaveOpen: true);
+        var destRoot = Path.GetFullPath(destDir);
+        var destRootWithSep = destRoot.EndsWith(Path.DirectorySeparatorChar) ? destRoot : destRoot + Path.DirectorySeparatorChar;
+
+        var plan = new List<(ZipArchiveEntry Entry, string Target)>();
+        var hasRootAppJson = false;
+        foreach (var entry in zip.Entries)
+        {
+            var name = entry.FullName.Replace('\\', '/');
+            if (name.Length == 0 || name.EndsWith('/')) continue; // directory entry
+            var target = Path.GetFullPath(Path.Combine(destRoot, name));
+            if (!target.StartsWith(destRootWithSep, StringComparison.Ordinal))
+                throw new InvalidDataException(
+                    $"entry '{entry.FullName}' escapes the destination directory '{destRoot}' — refusing to unpack any of it");
+            if (string.Equals(name, "app.json", StringComparison.OrdinalIgnoreCase)) hasRootAppJson = true;
+            plan.Add((entry, target));
+        }
+
+        if (!hasRootAppJson)
+            throw new InvalidDataException(
+                "no app.json at the root of the zip, so the runner would see no bundle at all (first entries: "
+                + string.Join(", ", zip.Entries.Take(5).Select(e => e.FullName)) + ")");
+
+        foreach (var (entry, target) in plan)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(target)!);
+            using var input = entry.Open();
+            using var output = File.Create(target);
+            input.CopyTo(output);
+        }
+        return plan.Count;
+    }
+
+    // -----------------------------------------------------------------------
+    // Test Data (issue #2724): the sandbox demo-database backup `--test-data` hydrates
+    // from. It sits at the ROOT of the country artifact (w1: BusinessCentral-W1.bak,
+    // measured 610 MB deflated / 977 MB uncompressed on 28.4.53241.54318 — the whole
+    // artifact is 955 MB, so this one entry is most of it). ExtractEntry buffers an entry
+    // in memory twice over and cannot hold this one; the .bak is streamed to disk instead
+    // (ExtractEntryToFile / CopyZipEntryData) and landed atomically, so a partial download
+    // never sits at the path TestDataOptions would open and trust.
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Whether a ZIP central-directory entry is the demo backup for <paramref name="country"/>.
+    /// Root-level only: the artifact ships exactly one, at the root, and anchoring there is the
+    /// same defence <see cref="IsWantedPlatformAppEntry"/> uses against a same-basename file in
+    /// another folder. Pure over the entry name so it is testable without a network round trip.
+    /// </summary>
+    internal static bool IsTestDataBackupEntry(string entryName, string country)
+    {
+        if (string.IsNullOrWhiteSpace(entryName)) return false;
+        var lower = entryName.Replace('\\', '/').ToLowerInvariant();
+        return lower == $"businesscentral-{NormalizeCountry(country)}.bak";
+    }
+
+    public static int TestData(string version, string outputDir, string country = "w1", Action<string>? log = null)
+    {
+        var logf = L(log);
+        var countryLower = NormalizeCountry(country);
+        var artifactUrl = BuildArtifactUrl(version, countryLower);
+        Directory.CreateDirectory(outputDir);
+
+        // Generous: this client streams the whole ~600 MB entry through one response.
+        using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(30) };
+
+        logf($"Resolving artifact size for BC {version} ({countryLower})...");
+        if (!TryHeadContentLength(http, artifactUrl, version, countryLower, logf, out long totalSize)) return 1;
+        if (totalSize == 0) { logf("Error: unknown size"); return 1; }
+        logf($"{countryLower} artifact: {totalSize / 1048576} MB");
+
+        logf("Downloading ZIP directory...");
+        if (!TryReadCentralDirectory(http, artifactUrl, totalSize, logf, out var cdData, out var cdStart, out var entryCount))
+            return 1;
+
+        (string Name, int Method, long CompSize, long UncompSize, long Offset)? found = null;
+        int pos = cdStart;
+        for (int i = 0; i < entryCount && pos + 46 <= cdData.Length; i++)
+        {
+            if (!IsCentralHeader(cdData, pos)) break;
+            var (cm, cs, nl, el, cl, lo, name) = ReadCentralEntry(cdData, pos);
+            if (cs > 0 && IsTestDataBackupEntry(name, countryLower))
+            {
+                found = (name, cm, cs, ReadCentralUncompressedSize(cdData, pos), lo);
+                break;
+            }
+            pos += 46 + nl + el + cl;
+        }
+
+        var expectedName = $"BusinessCentral-{countryLower.ToUpperInvariant()}.bak";
+        if (found == null)
+        {
+            logf($"Error: no {expectedName} at the root of the BC {version} ({countryLower}) artifact.");
+            return 1;
+        }
+
+        var (entryName, method, compSize, uncompSize, offset) = found.Value;
+        if (uncompSize == uint.MaxValue)
+        {
+            // ZIP64 sizes live in the extra field; nothing here reads them, and guessing the
+            // length would defeat the truncation check that makes the download trustworthy.
+            logf($"Error: {entryName} is a ZIP64 entry (uncompressed size not in the central directory); not supported.");
+            return 1;
+        }
+
+        var destPath = Path.Combine(outputDir, Path.GetFileName(entryName));
+        logf($"  Downloading {entryName} ({compSize / 1048576} MB compressed, {uncompSize / 1048576} MB uncompressed), streaming to disk...");
+        if (!ExtractEntryToFile(http, artifactUrl, totalSize, entryName, method, compSize, uncompSize, offset, destPath, logf))
+            return 1;
+
+        logf($"Written {destPath} ({new FileInfo(destPath).Length / 1048576} MB)");
+        return 0;
+    }
+
+    /// <summary>
+    /// Copies one ZIP entry's data from <paramref name="compressedSource"/> to
+    /// <paramref name="destination"/>, inflating deflate (method 8) or copying stored
+    /// (method 0) bytes, and returns the byte count written. Throws
+    /// <see cref="NotSupportedException"/> for any other method and
+    /// <see cref="InvalidDataException"/> when the count differs from
+    /// <paramref name="expectedUncompressedLength"/> — a stream that stopped short must
+    /// surface as an error, never as a shorter file. Pure over streams so it is testable
+    /// against an in-memory deflate buffer.
+    /// </summary>
+    internal static long CopyZipEntryData(Stream compressedSource, int method, long expectedUncompressedLength, Stream destination)
+    {
+        Stream data = method switch
+        {
+            0 => compressedSource,
+            8 => new DeflateStream(compressedSource, CompressionMode.Decompress, leaveOpen: true),
+            _ => throw new NotSupportedException(
+                $"unsupported ZIP compression method {method} (only stored = 0 and deflate = 8 are handled)"),
+        };
+
+        long copied = 0;
+        try
+        {
+            var buffer = new byte[1 << 20];
+            int n;
+            while ((n = data.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                destination.Write(buffer, 0, n);
+                copied += n;
+            }
+        }
+        catch (InvalidDataException ex)
+        {
+            throw new InvalidDataException(
+                $"corrupt deflate stream after {copied} of the expected {expectedUncompressedLength} bytes: {ex.Message}", ex);
+        }
+        finally
+        {
+            if (method == 8) data.Dispose();
+        }
+
+        if (copied != expectedUncompressedLength)
+            throw new InvalidDataException(
+                $"truncated entry: expected {expectedUncompressedLength} bytes, got {copied}");
+        return copied;
+    }
+
+    // Streamed sibling of ExtractEntry for entries too large to buffer (the .bak). Reads the
+    // local header with a small ranged request exactly as ExtractEntry does, then streams the
+    // compressed data range through CopyZipEntryData into <dest>.partial and moves it into
+    // place only after the length check passed. One retry from scratch, like DownloadRange.
+    private static bool ExtractEntryToFile(
+        HttpClient http, string url, long totalSize,
+        string name, int method, long compSize, long uncompSize, long offset,
+        string destPath, Action<string> logf)
+    {
+        long headerEnd = Math.Min(offset + 30 + name.Length + 4096, totalSize - 1);
+        var header = DownloadRange(http, url, offset, headerEnd);
+        if (header.Length < 30 || header[0] != 0x50 || header[1] != 0x4b || header[2] != 0x03 || header[3] != 0x04)
+        {
+            logf($"  WARNING: bad local header for {Path.GetFileName(name)} — skipping");
+            return false;
+        }
+        int nl2 = BitConverter.ToUInt16(header, 26);
+        int el2 = BitConverter.ToUInt16(header, 28);
+        long dataStart = offset + 30 + nl2 + el2;
+        long dataEnd = dataStart + compSize - 1;
+        if (dataEnd > totalSize - 1)
+        {
+            logf($"  WARNING: truncated data for {Path.GetFileName(name)} — skipping");
+            return false;
+        }
+
+        var partial = destPath + ".partial";
+        for (int attempt = 0; attempt < 2; attempt++)
+        {
+            try
+            {
+                var req = new HttpRequestMessage(HttpMethod.Get, url);
+                req.Headers.Range = new RangeHeaderValue(dataStart, dataEnd);
+                using var resp = http.Send(req, HttpCompletionOption.ResponseHeadersRead);
+                resp.EnsureSuccessStatusCode();
+                using (var body = resp.Content.ReadAsStream())
+                using (var file = new FileStream(partial, FileMode.Create, FileAccess.Write, FileShare.None, 1 << 20))
+                    CopyZipEntryData(body, method, uncompSize, file);
+                File.Move(partial, destPath, overwrite: true);
+                return true;
+            }
+            catch (NotSupportedException ex)
+            {
+                logf($"  WARNING: {Path.GetFileName(name)}: {ex.Message} — skipping");
+                TryDelete(partial);
+                return false;
+            }
+            catch (Exception ex) when (attempt == 0)
+            {
+                logf($"  Retrying download of {Path.GetFileName(name)} ({ex.Message})...");
+            }
+            catch (Exception ex)
+            {
+                logf($"  WARNING: {Path.GetFileName(name)}: {ex.Message} — skipping");
+                TryDelete(partial);
+                return false;
+            }
+        }
+        return false;
+    }
+
+    private static void TryDelete(string path)
+    {
+        try { if (File.Exists(path)) File.Delete(path); } catch { /* best effort */ }
+    }
+
+    // -----------------------------------------------------------------------
     // Platform Apps: Microsoft Base/System/BusinessFoundation/Application .app files
     // from the w1 (or, since #2236, a country-localized) artifact's Extensions/ folder.
     // -----------------------------------------------------------------------
@@ -569,6 +909,11 @@ public static class ArtifactDownloader
 
     private static bool IsCentralHeader(byte[] cd, int pos)
         => cd[pos] == 0x50 && cd[pos + 1] == 0x4b && cd[pos + 2] == 0x01 && cd[pos + 3] == 0x02;
+
+    // Central-directory uncompressed size (offset 24). Kept out of ReadCentralEntry's tuple so
+    // its five existing deconstruction sites stay untouched; only the streamed path needs it.
+    private static long ReadCentralUncompressedSize(byte[] cd, int pos)
+        => BitConverter.ToUInt32(cd, pos + 24);
 
     private static (int Method, uint CompSize, int NameLen, int ExtraLen, int CommentLen, uint LocalOffset, string Name)
         ReadCentralEntry(byte[] cd, int pos)

--- a/AlRunner.Tests/ArtifactDownloaderMsBucketTests.cs
+++ b/AlRunner.Tests/ArtifactDownloaderMsBucketTests.cs
@@ -1,0 +1,243 @@
+// Issue #2724: a manual-dispatch workflow that runs one Microsoft BaseApp test bucket with
+// --test-data needs three things the existing provisioning did not fetch — the bucket's
+// `<bucket>.Source.zip` (platform artifact, Applications/BaseApp/Test/), the sandbox
+// `BusinessCentral-<CC>.bak` (country artifact root, ~1 GB), and the `bcbak` reader. The first
+// two ride on ArtifactDownloader's ranged-ZIP read; these tests pin the pure, no-network
+// pieces of that: the two entry selectors, the Source.zip unpack, and the streaming entry
+// copy the .bak needs because it does not fit the byte[]-returning ExtractEntry (977 MB
+// uncompressed on BC 28.4, measured against the live CDN — see the PR).
+//
+// Both directions on every piece, per .claude/rules/tdd.md: the selector that accepts the
+// real entry names also rejects the .app beside them, a prefix-collision bucket, and the
+// Source/ (not Test/) sibling; the unpack that lands app.json also refuses a traversal
+// entry BEFORE writing anything and a zip with no root app.json; the streaming copy that
+// inflates a deflate entry byte-for-byte also names a truncated stream and an unsupported
+// method instead of writing a short file that a later --test-data run would open and trust.
+using System.IO.Compression;
+using AlRunner.Provisioning;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ArtifactDownloaderMsBucketTests
+{
+    // ---- Source.zip selection -------------------------------------------------------
+
+    [Theory]
+    [InlineData("Applications/BaseApp/Test/Tests-ERM.Source.zip", "Tests-ERM")]
+    [InlineData("applications/baseapp/test/tests-erm.source.zip", "Tests-ERM")]
+    [InlineData("Applications\\BaseApp\\Test\\Tests-ERM.Source.zip", "tests-erm")]
+    // Bucket names with spaces are real: Tests-Cash Flow, Tests-Cost Accounting, ...
+    [InlineData("Applications/BaseApp/Test/Tests-Cash Flow.Source.zip", "Tests-Cash Flow")]
+    public void IsBaseAppTestSourceEntry_MatchesTheBucketsSourceZip(string entryName, string bucket)
+        => Assert.True(ArtifactDownloader.IsBaseAppTestSourceEntry(entryName, bucket));
+
+    [Theory]
+    // A different bucket in the same folder.
+    [InlineData("Applications/BaseApp/Test/Tests-Bank.Source.zip", "Tests-ERM")]
+    // The compiled .app that sits beside the Source.zip — the thing `test-apps` fetches.
+    [InlineData("Applications/BaseApp/Test/Microsoft_Tests-ERM_28.4.53241.54318.app", "Tests-ERM")]
+    // Prefix collision: the basename must match EXACTLY, not start with the bucket.
+    [InlineData("Applications/BaseApp/Test/Tests-ERM-Extra.Source.zip", "Tests-ERM")]
+    [InlineData("Applications/BaseApp/Test/Tests-ERM.Source.zip", "Tests-ER")]
+    // Source/, not Test/: the Base Application's own source, not a test bucket.
+    [InlineData("Applications/BaseApp/Source/Base Application.Source.zip", "Base Application")]
+    // Another app's Test/ folder — same layout, different app; the mode is BaseApp buckets.
+    [InlineData("Applications/APIV1/Test/_Exclude_APIV1_ Tests.Source.zip", "_Exclude_APIV1_ Tests")]
+    [InlineData("", "Tests-ERM")]
+    public void IsBaseAppTestSourceEntry_RejectsEverythingElse(string entryName, string bucket)
+        => Assert.False(ArtifactDownloader.IsBaseAppTestSourceEntry(entryName, bucket));
+
+    // ---- .bak selection -----------------------------------------------------------------
+
+    [Theory]
+    [InlineData("BusinessCentral-W1.bak", "w1")]
+    [InlineData("businesscentral-w1.bak", "W1")]
+    [InlineData("BusinessCentral-US.bak", "us")]
+    public void IsTestDataBackupEntry_MatchesTheRootLevelBackupForTheCountry(string entryName, string country)
+        => Assert.True(ArtifactDownloader.IsTestDataBackupEntry(entryName, country));
+
+    [Theory]
+    // Wrong country.
+    [InlineData("BusinessCentral-W1.bak", "us")]
+    // Not at the artifact root: the measured w1 artifact ships exactly one, at the root.
+    // Anchoring there is the same defence IsWantedPlatformAppEntry uses against a
+    // same-basename lookalike in another folder.
+    [InlineData("Backups/BusinessCentral-W1.bak", "w1")]
+    [InlineData("Extensions/Microsoft_Base Application_28.4.53241.54318.app", "w1")]
+    [InlineData("BusinessCentral-W1.bak.txt", "w1")]
+    [InlineData("", "w1")]
+    public void IsTestDataBackupEntry_RejectsOtherCountriesFoldersAndFiles(string entryName, string country)
+        => Assert.False(ArtifactDownloader.IsTestDataBackupEntry(entryName, country));
+
+    // ---- Source.zip unpack -----------------------------------------------------------------
+
+    private static MemoryStream BuildZip(params (string Name, string Content)[] entries)
+    {
+        var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            foreach (var (name, content) in entries)
+            {
+                var e = zip.CreateEntry(name);
+                using var w = new StreamWriter(e.Open());
+                w.Write(content);
+            }
+        }
+        ms.Position = 0;
+        return ms;
+    }
+
+    private static string TempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-ms-bucket-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void UnpackSourceZip_WritesAppJsonAndEveryAlFile_FlatLikeTheRealBucket()
+    {
+        // The real Tests-ERM.Source.zip is FLAT: app.json at the root beside 297 .al files
+        // (measured on BC 28.4.53241.54318). Nothing to strip, nothing to rename.
+        var dest = TempDir();
+        try
+        {
+            using var zip = BuildZip(
+                ("app.json", "{ \"name\": \"Tests-ERM\" }"),
+                ("ERMTest.Codeunit.al", "codeunit 134000 \"ERM Test\" { }"),
+                ("Sub/Helper.Codeunit.al", "codeunit 134001 Helper { }"));
+
+            var written = ArtifactDownloader.UnpackSourceZip(zip, dest);
+
+            Assert.Equal(3, written);
+            Assert.Equal("{ \"name\": \"Tests-ERM\" }", File.ReadAllText(Path.Combine(dest, "app.json")));
+            Assert.Equal("codeunit 134000 \"ERM Test\" { }", File.ReadAllText(Path.Combine(dest, "ERMTest.Codeunit.al")));
+            Assert.True(File.Exists(Path.Combine(dest, "Sub", "Helper.Codeunit.al")));
+        }
+        finally { Directory.Delete(dest, recursive: true); }
+    }
+
+    [Fact]
+    public void UnpackSourceZip_RefusesAPathTraversalEntry_BeforeWritingAnything()
+    {
+        var dest = TempDir();
+        var outside = Path.Combine(Path.GetDirectoryName(dest)!, "escaped-" + Path.GetFileName(dest) + ".al");
+        try
+        {
+            using var zip = BuildZip(
+                ("app.json", "{}"),
+                ("Good.Codeunit.al", "codeunit 1 G { }"),
+                ("../" + Path.GetFileName(outside), "codeunit 2 Evil { }"));
+
+            var ex = Assert.Throws<InvalidDataException>(() => ArtifactDownloader.UnpackSourceZip(zip, dest));
+
+            Assert.Contains("escapes", ex.Message, StringComparison.Ordinal);
+            Assert.False(File.Exists(outside), "the traversal entry must not land outside the destination");
+            // Validation runs over the whole directory first: not even the benign entries
+            // before the bad one are written, so a half-unpacked bundle never looks complete.
+            Assert.False(File.Exists(Path.Combine(dest, "app.json")));
+            Assert.False(File.Exists(Path.Combine(dest, "Good.Codeunit.al")));
+        }
+        finally
+        {
+            Directory.Delete(dest, recursive: true);
+            if (File.Exists(outside)) File.Delete(outside);
+        }
+    }
+
+    [Fact]
+    public void UnpackSourceZip_RefusesAZipWithNoRootAppJson()
+    {
+        // Without app.json at the root the runner would not see a bundle at all — it would
+        // report zero tests, which is exactly the silent "green tick meaning nothing ran"
+        // shape this workflow exists to avoid. Fail here, with the reason named.
+        var dest = TempDir();
+        try
+        {
+            using var zip = BuildZip(
+                ("Tests-ERM/app.json", "{}"),
+                ("Tests-ERM/A.Codeunit.al", "codeunit 1 A { }"));
+
+            var ex = Assert.Throws<InvalidDataException>(() => ArtifactDownloader.UnpackSourceZip(zip, dest));
+
+            Assert.Contains("app.json", ex.Message, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dest, recursive: true); }
+    }
+
+    // ---- streaming entry copy (the .bak path) ----------------------------------------------
+
+    private static byte[] RandomBytes(int count)
+    {
+        var rng = new Random(2724);
+        var buf = new byte[count];
+        rng.NextBytes(buf);
+        return buf;
+    }
+
+    private static byte[] Deflate(byte[] raw)
+    {
+        using var ms = new MemoryStream();
+        using (var ds = new DeflateStream(ms, CompressionLevel.Fastest, leaveOpen: true))
+            ds.Write(raw, 0, raw.Length);
+        return ms.ToArray();
+    }
+
+    [Fact]
+    public void CopyZipEntryData_Deflate_InflatesByteForByte_AndReturnsTheLength()
+    {
+        var raw = RandomBytes(1_500_000);
+        using var source = new MemoryStream(Deflate(raw));
+        using var dest = new MemoryStream();
+
+        var copied = ArtifactDownloader.CopyZipEntryData(source, method: 8, expectedUncompressedLength: raw.Length, dest);
+
+        Assert.Equal(raw.Length, copied);
+        Assert.Equal(raw, dest.ToArray());
+    }
+
+    [Fact]
+    public void CopyZipEntryData_Stored_CopiesVerbatim()
+    {
+        var raw = RandomBytes(4096);
+        using var source = new MemoryStream(raw);
+        using var dest = new MemoryStream();
+
+        var copied = ArtifactDownloader.CopyZipEntryData(source, method: 0, expectedUncompressedLength: raw.Length, dest);
+
+        Assert.Equal(raw.Length, copied);
+        Assert.Equal(raw, dest.ToArray());
+    }
+
+    [Fact]
+    public void CopyZipEntryData_TruncatedSource_ThrowsNamingExpectedAndActual()
+    {
+        // A .bak that stopped short must never be reported as fetched: TestDataOptions keys
+        // its baseline cache on (path, length, mtime) and would open a truncated file
+        // without complaint. The length check is the guard.
+        var raw = RandomBytes(200_000);
+        var deflated = Deflate(raw);
+        using var source = new MemoryStream(deflated, 0, deflated.Length / 2);
+        using var dest = new MemoryStream();
+
+        var ex = Assert.Throws<InvalidDataException>(() =>
+            ArtifactDownloader.CopyZipEntryData(source, method: 8, expectedUncompressedLength: raw.Length, dest));
+
+        Assert.Contains(raw.Length.ToString(), ex.Message, StringComparison.Ordinal);
+        Assert.Contains("expected", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CopyZipEntryData_UnsupportedMethod_ThrowsNamingTheMethod()
+    {
+        using var source = new MemoryStream(new byte[16]);
+        using var dest = new MemoryStream();
+
+        var ex = Assert.Throws<NotSupportedException>(() =>
+            ArtifactDownloader.CopyZipEntryData(source, method: 12, expectedUncompressedLength: 16, dest));
+
+        Assert.Contains("12", ex.Message, StringComparison.Ordinal);
+        Assert.Equal(0, dest.Length);
+    }
+}

--- a/AlRunner.Tests/MsBucketWorkflowTests.cs
+++ b/AlRunner.Tests/MsBucketWorkflowTests.cs
@@ -1,0 +1,167 @@
+// Issue #2724: .github/workflows/ms-bucket.yml runs one Microsoft BaseApp test bucket with
+// --test-data as a MANUAL verification net. A YAML workflow cannot be unit-tested the way
+// the C# behind it can, so this file pins the properties that are load-bearing and cheap
+// to lose in an edit:
+//
+//   1. It is manual-dispatch ONLY. A push/pull_request/schedule trigger would put a
+//      multi-hour, 9,500-test job on every PR — the issue rules that out explicitly.
+//   2. Its BC provisioning is the SAME definition bc-tests.yml uses — a composite action —
+//      not a hand-maintained copy. bc-tests.yml's own header records a copy of those steps
+//      drifting four times and failing two releases (#1976); ReleaseTestParityTests guards
+//      the matrix callers, this guards the provisioning action's two consumers.
+//   3. The configuration values recorded from working local runs are present verbatim.
+//      Wrong values do not fail the run — they make its number meaningless (the company
+//      name with a trailing underscore, both package caches, a raised emit timeout, a
+//      private --cache).
+//
+// Split like ReleaseTestParityTests: WorkflowTriggers.TriggersOf is a pure function proven
+// on constructed text; the rest wires it (and the marker checks) to the real files on disk.
+using Xunit;
+
+namespace AlRunner.Tests;
+
+internal static class WorkflowTriggers
+{
+    /// <summary>
+    /// The event names declared under a workflow's top-level <c>on:</c> key, in order. Only
+    /// the two-space-indented keys directly under <c>on:</c> count — <c>branches:</c> and
+    /// <c>inputs:</c> sit deeper. Empty when there is no <c>on:</c> block.
+    /// </summary>
+    internal static IReadOnlyList<string> TriggersOf(string workflowText)
+    {
+        var lines = workflowText.Replace("\r\n", "\n").Split('\n');
+        var triggers = new List<string>();
+        var inOn = false;
+        foreach (var raw in lines)
+        {
+            var line = raw.TrimEnd();
+            if (line.TrimStart().StartsWith('#') || line.Length == 0) continue;
+            if (!line.StartsWith(' '))
+            {
+                inOn = line.StartsWith("on:", StringComparison.Ordinal);
+                continue;
+            }
+            if (!inOn) continue;
+            if (line.StartsWith("  ") && !line.StartsWith("   "))
+            {
+                var key = line.Trim();
+                var colon = key.IndexOf(':');
+                if (colon > 0) triggers.Add(key[..colon]);
+            }
+        }
+        return triggers;
+    }
+}
+
+public sealed class MsBucketWorkflowTests
+{
+    private static readonly string GithubDir = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".github"));
+
+    private const string Workflow = "ms-bucket.yml";
+    private const string SharedMatrix = "bc-tests.yml";
+    private const string ProvisionAction = "actions/provision-bc/action.yml";
+    private const string ProvisionMarker = "uses: ./.github/actions/provision-bc";
+
+    private static string Read(string relative)
+    {
+        var path = Path.Combine(GithubDir, relative);
+        Assert.True(File.Exists(path), $"expected {relative} at {path}");
+        return File.ReadAllText(path);
+    }
+
+    private static string CodeOnly(string text) =>
+        string.Join('\n', text.Split('\n').Where(l => !l.TrimStart().StartsWith('#')));
+
+    // ---- the pure function, proven on constructed text ------------------------------
+
+    [Fact]
+    public void TriggersOf_ListsEveryTopLevelEventAndNothingDeeper()
+    {
+        const string wf = """
+            name: X
+            on:
+              push:
+                branches: [main]
+              pull_request:
+                branches: [main]
+              workflow_dispatch:
+                inputs:
+                  bucket:
+                    default: Tests-ERM
+            jobs:
+              run:
+                runs-on: ubuntu-latest
+            """;
+
+        Assert.Equal(new[] { "push", "pull_request", "workflow_dispatch" }, WorkflowTriggers.TriggersOf(wf));
+    }
+
+    [Fact]
+    public void TriggersOf_IsEmptyWithoutAnOnBlock_AndIgnoresComments()
+    {
+        Assert.Empty(WorkflowTriggers.TriggersOf("name: X\njobs:\n  run:\n    runs-on: ubuntu-latest\n"));
+        Assert.Equal(new[] { "workflow_dispatch" },
+            WorkflowTriggers.TriggersOf("on:\n  # push: would be wrong here\n  workflow_dispatch:\n"));
+    }
+
+    // ---- wired to the real files ------------------------------------------------------
+
+    [Fact]
+    public void MsBucketWorkflow_IsManualDispatchOnly()
+    {
+        var triggers = WorkflowTriggers.TriggersOf(Read(Path.Combine("workflows", Workflow)));
+
+        Assert.Equal(new[] { "workflow_dispatch" }, triggers);
+    }
+
+    [Fact]
+    public void MsBucketWorkflow_CarriesTheRecordedConfigurationVerbatim()
+    {
+        var code = CodeOnly(Read(Path.Combine("workflows", Workflow)));
+
+        // The SQL-form company name, trailing underscore — the run fails loudly with a period.
+        Assert.Contains("CRONUS International Ltd_", code, StringComparison.Ordinal);
+        Assert.DoesNotContain("CRONUS International Ltd.", code, StringComparison.Ordinal);
+        // Both package caches, repeatable flag.
+        Assert.Contains("--package-cache \"$HOME/.al-runner/platform-apps\"", code, StringComparison.Ordinal);
+        Assert.Contains("--package-cache \"$HOME/.al-runner/test-apps\"", code, StringComparison.Ordinal);
+        // The 120 s default emit timeout is far too short for a 9,500-test bucket.
+        Assert.Contains("AL_RUNNER_EMIT_TIMEOUT_SEC", code, StringComparison.Ordinal);
+        // A private cache root, not the shared default.
+        Assert.Contains("--cache \"", code, StringComparison.Ordinal);
+        // The pieces the issue lists as missing: bucket sources, the backup, the reader.
+        Assert.Contains("test-sources", code, StringComparison.Ordinal);
+        Assert.Contains("--test-data=", code, StringComparison.Ordinal);
+        Assert.Contains("--test-data-company", code, StringComparison.Ordinal);
+        Assert.Contains("BusinessCentral.BakReader", code, StringComparison.Ordinal);
+        Assert.Contains(".cache/al-runner/bcbak/bcbak", code, StringComparison.Ordinal);
+        // The deliverable: a job summary plus the JUnit for clustering.
+        Assert.Contains("GITHUB_STEP_SUMMARY", code, StringComparison.Ordinal);
+        Assert.Contains("--output-junit", code, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ProvisioningAction_CarriesTheBuildAndBothAppDownloads()
+    {
+        var code = CodeOnly(Read(ProvisionAction));
+
+        Assert.Contains("AllowBcArtifactDownload=true", code, StringComparison.Ordinal);
+        Assert.Contains("platform-apps ${{", code, StringComparison.Ordinal);
+        Assert.Contains("test-apps ${{", code, StringComparison.Ordinal);
+        Assert.Contains("$HOME/.al-runner/platform-apps", code, StringComparison.Ordinal);
+        Assert.Contains("$HOME/.al-runner/test-apps", code, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("workflows/" + Workflow)]
+    [InlineData("workflows/" + SharedMatrix)]
+    public void ProvisioningConsumers_UseTheSharedAction_AndInlineNeitherDownload(string relative)
+    {
+        var code = CodeOnly(Read(relative));
+
+        Assert.Contains(ProvisionMarker, code, StringComparison.Ordinal);
+        Assert.DoesNotContain("platform-apps ${{", code, StringComparison.Ordinal);
+        Assert.DoesNotContain("test-apps ${{", code, StringComparison.Ordinal);
+    }
+}

--- a/scripts/ms-bucket-summary.py
+++ b/scripts/ms-bucket-summary.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Job summary for .github/workflows/ms-bucket.yml (issue #2724).
+
+The manual Microsoft-bucket run's deliverable is one readable block: total / pass / fail /
+error, wall time, and every line of the runner's output that means the number is not what
+it looks like. Two of those are known at the time of writing:
+
+  * a bundle lost to COMPILE FAIL vanishes from the totals (#2715 — #2721 adds a
+    "NOT RUN: N bundle(s)" line to the aggregate);
+  * a run resumed after a watchdog abort under-reports unless the earlier attempts are
+    carried forward (#2716 — #2720), which the runner announces with "resume:" lines and a
+    "(carried from earlier attempt(s): …)" line in the summary.
+
+So the caveat scan is deliberately broad and verbatim: any line matching one of the
+markers below is copied into the summary as-is. A reader must never have to open the log
+to learn that 9,496 became 7,000 because a codeunit hung.
+
+Exit code: 0 when the run produced a number (runner exit 0 or 1 AND a JUnit file), 1
+otherwise — so the workflow step goes red exactly when there is no measurement, and stays
+green for the expected outcome of a bucket with thousands of failing tests.
+
+Usage:
+  ms-bucket-summary.py --log run.log --rc N --elapsed SECONDS --bucket B --bc-version V
+                       --test-data true|false [--reader TAG] [--junit junit.xml] [--out FILE]
+                       [--step-summary FILE]
+Appends the same markdown to --step-summary, defaulting to $GITHUB_STEP_SUMMARY when set.
+"""
+import argparse
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+# Every line matching one of these is a caveat, copied verbatim. Anchored where the runner's
+# own text is stable (Reporter.cs summary block, AbortResume.cs messages, the per-bundle
+# status lines), tolerant of leading whitespace.
+CAVEAT_PATTERNS = (
+    re.compile(r"^\s*COMPILE FAIL\b"),
+    re.compile(r"^\s*EXEC FAIL\b"),
+    re.compile(r"^\s*NOT RUN:"),
+    re.compile(r"^\s*resume:"),
+    re.compile(r"carried from earlier attempt"),
+    re.compile(r"^\s*compile-fail:\s*[1-9]"),
+    re.compile(r"^\s*exec-fail:\s*[1-9]"),
+)
+
+SUMMARY_START = "al-runner — test run summary"
+
+RC_MEANING = {
+    0: "all tests passed",
+    1: "at least one test failed or errored (the expected outcome for a Microsoft bucket)",
+    2: "a bundle could not execute (process-level error)",
+    3: "a bundle could not compile",
+    4: "count-baseline mismatch",
+    134: "crash (SIGABRT)",
+    139: "crash (SIGSEGV)",
+}
+
+
+def parse_junit_totals(xml_text):
+    """Totals from the JUnit root: tests/failures/errors/skipped, plus derived passed."""
+    root = ET.fromstring(xml_text)
+    if root.tag != "testsuites":
+        raise ValueError(f"expected a <testsuites> root, got <{root.tag}>")
+    totals = {k: int(root.attrib.get(k, "0")) for k in ("tests", "failures", "errors", "skipped")}
+    totals["passed"] = totals["tests"] - totals["failures"] - totals["errors"] - totals["skipped"]
+    return totals
+
+
+def scan_log(log_text):
+    """Caveat lines (verbatim) and the runner's own summary block, if it printed one."""
+    lines = log_text.splitlines()
+    caveats = [l.rstrip() for l in lines if any(p.search(l) for p in CAVEAT_PATTERNS)]
+    summary_block = ""
+    for i, line in enumerate(lines):
+        if line.startswith(SUMMARY_START):
+            block = []
+            for l in lines[i:]:
+                if block and not l.strip():
+                    break
+                block.append(l.rstrip())
+            summary_block = "\n".join(block)
+    return {"caveats": caveats, "summary_block": summary_block}
+
+
+def measured(rc, have_junit):
+    """A run produced a number only if the runner finished normally and wrote JUnit."""
+    return have_junit and rc in (0, 1)
+
+
+def fmt_elapsed(seconds):
+    seconds = int(seconds)
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    return f"{h}h {m}m {s}s" if h else f"{m}m {s}s"
+
+
+def compose(meta, totals, scan, rc, elapsed_s):
+    with_td = "with --test-data" if meta.get("test_data") else "without --test-data"
+    out = [f"## Microsoft bucket `{meta['bucket']}` on BC {meta['bc_version']} ({with_td})", ""]
+    rc_text = RC_MEANING.get(rc, "unexpected exit code")
+    out.append(f"Runner exit code {rc} — {rc_text}. Wall time {fmt_elapsed(elapsed_s)} for the runner step.")
+    if meta.get("reader"):
+        out.append(f"Backup reader: BusinessCentral.BakReader {meta['reader']}.")
+    out.append("")
+    if totals is None:
+        out += ["**No number: no JUnit file was produced.** The runner did not get as far as running tests"
+                " — read the log artifact (`run.log`) and the caveats below.", ""]
+    else:
+        out += ["| total | pass | fail | error | skipped |",
+                "|---|---|---|---|---|",
+                f"| {totals['tests']} | {totals['passed']} | {totals['failures']} | {totals['errors']} | {totals['skipped']} |",
+                ""]
+        if not measured(rc, True):
+            out += [f"**Treat the table with suspicion:** exit code {rc} means the run did not finish normally;"
+                    " the JUnit covers only what ran before that.", ""]
+    if scan["caveats"]:
+        out += ["### Caveats (verbatim from the runner)", "",
+                "Each line below means the table is not one clean run's number:", "", "```"]
+        out += scan["caveats"]
+        out += ["```", ""]
+    else:
+        out += ["No caveats: no COMPILE FAIL / EXEC FAIL / NOT RUN / resume lines in the runner output.", ""]
+    if scan["summary_block"]:
+        out += ["<details><summary>Runner summary block</summary>", "", "```"]
+        out.append(scan["summary_block"])
+        out += ["```", "", "</details>", ""]
+    return "\n".join(out)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--log", required=True)
+    ap.add_argument("--rc", type=int, required=True)
+    ap.add_argument("--elapsed", type=int, required=True)
+    ap.add_argument("--bucket", required=True)
+    ap.add_argument("--bc-version", required=True)
+    ap.add_argument("--test-data", required=True, help="true|false")
+    ap.add_argument("--reader", default="")
+    ap.add_argument("--junit", default=None)
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--step-summary", default=None,
+                    help="also append the markdown here; defaults to $GITHUB_STEP_SUMMARY when set")
+    a = ap.parse_args(argv)
+
+    with open(a.log, encoding="utf-8", errors="replace") as f:
+        scan = scan_log(f.read())
+
+    totals = None
+    if a.junit and os.path.exists(a.junit):
+        with open(a.junit, encoding="utf-8") as f:
+            totals = parse_junit_totals(f.read())
+
+    meta = {"bucket": a.bucket, "bc_version": a.bc_version,
+            "test_data": a.test_data.strip().lower() == "true", "reader": a.reader}
+    md = compose(meta, totals, scan, a.rc, a.elapsed)
+
+    print(md)
+    if a.out:
+        with open(a.out, "w", encoding="utf-8") as f:
+            f.write(md + "\n")
+    step = a.step_summary or os.environ.get("GITHUB_STEP_SUMMARY")
+    if step:
+        with open(step, "a", encoding="utf-8") as f:
+            f.write(md + "\n")
+
+    return 0 if measured(a.rc, totals is not None) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/ms-bucket-summary.test.py
+++ b/scripts/tests/ms-bucket-summary.test.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/ms-bucket-summary.py (issue #2724).
+
+The manual MS-bucket workflow's deliverable is the job summary: total / pass / fail /
+error and wall time, plus every line of the runner's output that means the number is
+not what it looks like — a bundle lost to COMPILE FAIL, a resume that carried earlier
+attempts forward, a "not run" count. RED before #2724: the script did not exist. GREEN
+proves both directions: a JUnit file yields exact numbers and a "measured" verdict
+(positive); a missing JUnit, a crash exit code, or a caveat line in the log each change
+the verdict or the summary in a way the reader cannot miss (negative).
+
+Run: python3 scripts/tests/ms-bucket-summary.test.py
+"""
+import importlib.util
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "ms-bucket-summary.py"
+_spec = importlib.util.spec_from_file_location("ms_bucket_summary", SCRIPT_PATH)
+mbs = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mbs)
+
+
+JUNIT = """<?xml version="1.0" encoding="utf-8"?>
+<testsuites tests="9496" failures="7000" errors="120" skipped="3" time="4321.500">
+  <testsuite name="Codeunit134000" tests="2" failures="1" errors="0" skipped="0" time="1.0">
+    <testcase name="A" classname="Codeunit134000" time="0.5" />
+    <testcase name="B" classname="Codeunit134000" time="0.5"><failure message="x" /></testcase>
+  </testsuite>
+</testsuites>
+"""
+
+CLEAN_LOG = """al-runner — test run summary
+=================================================================
+Buckets:       1 total
+  ran:         1
+  compile-fail:0
+  exec-fail:   0
+Tests:         9496 total
+  pass:        2373
+  fail:        7000
+  error:       120
+  skipped:     3
+Time:
+  AL emit:     412.0s
+  C# compile:  88.1s
+  test run:    3821.4s
+  total:       4321.5s
+"""
+
+META = {"bucket": "Tests-ERM", "bc_version": "28.4.53241.54318", "test_data": True, "reader": "v0.1.1"}
+
+
+class ParseJunitTotalsTests(unittest.TestCase):
+    def test_reads_the_root_attributes_and_derives_pass(self):
+        totals = mbs.parse_junit_totals(JUNIT)
+        self.assertEqual(totals, {"tests": 9496, "failures": 7000, "errors": 120, "skipped": 3, "passed": 2373})
+
+    def test_rejects_a_document_without_a_testsuites_root(self):
+        with self.assertRaises(ValueError):
+            mbs.parse_junit_totals("<testsuite tests='1' failures='0' errors='0' skipped='0' />")
+
+
+class ScanLogTests(unittest.TestCase):
+    def test_a_clean_log_has_no_caveats_and_keeps_the_summary_block(self):
+        scan = mbs.scan_log(CLEAN_LOG)
+        self.assertEqual(scan["caveats"], [])
+        self.assertIn("Tests:         9496 total", scan["summary_block"])
+        self.assertIn("  total:       4321.5s", scan["summary_block"])
+
+    def test_lost_bundles_resumes_and_not_run_lines_are_caveats(self):
+        log = (
+            "COMPILE FAIL  /tmp/ms-buckets/Tests-ERM: AL0185 ...\n"
+            "resume: a watchdog abort ended this attempt early. Continuing in a fresh process, "
+            "skipping 3 codeunit(s) already attempted or hung; 4 resume attempt(s) left after this one.\n"
+            "NOT RUN: 1 bundle(s)\n"
+            "  (carried from earlier attempt(s): 400 tests, 100 pass, 300 fail, 0 error)\n"
+            "  compile-fail:1\n"
+            + CLEAN_LOG
+        )
+        caveats = mbs.scan_log(log)["caveats"]
+        self.assertTrue(any(c.startswith("COMPILE FAIL") for c in caveats), caveats)
+        self.assertTrue(any(c.startswith("resume:") for c in caveats), caveats)
+        self.assertTrue(any(c.startswith("NOT RUN:") for c in caveats), caveats)
+        self.assertTrue(any("carried from earlier attempt" in c for c in caveats), caveats)
+        self.assertTrue(any(c.strip() == "compile-fail:1" for c in caveats), caveats)
+        # The zero-count summary lines are NOT caveats.
+        self.assertFalse(any("compile-fail:0" in c for c in caveats), caveats)
+        self.assertFalse(any("exec-fail:   0" in c for c in caveats), caveats)
+
+
+class ComposeTests(unittest.TestCase):
+    def test_measured_run_renders_exact_numbers_and_wall_time(self):
+        md = mbs.compose(META, mbs.parse_junit_totals(JUNIT), mbs.scan_log(CLEAN_LOG), rc=1, elapsed_s=4500)
+        for needle in ("Tests-ERM", "28.4.53241.54318", "| 9496 |", "| 2373 |", "| 7000 |", "| 120 |", "| 3 |",
+                       "1h 15m 0s", "with --test-data", "v0.1.1", "exit code 1"):
+            self.assertIn(needle, md, needle)
+        self.assertIn("No caveats", md)
+
+    def test_caveats_are_listed_verbatim_so_a_wrong_number_cannot_hide(self):
+        scan = mbs.scan_log("NOT RUN: 1 bundle(s)\n" + CLEAN_LOG)
+        md = mbs.compose(META, mbs.parse_junit_totals(JUNIT), scan, rc=1, elapsed_s=10)
+        self.assertIn("NOT RUN: 1 bundle(s)", md)
+        self.assertNotIn("No caveats", md)
+
+    def test_missing_junit_is_reported_as_no_number(self):
+        md = mbs.compose(dict(META, test_data=False), None, mbs.scan_log(""), rc=3, elapsed_s=61)
+        self.assertIn("no JUnit", md)
+        self.assertIn("exit code 3", md)
+        self.assertIn("compile", md.lower())
+        self.assertIn("without --test-data", md)
+        self.assertIn("1m 1s", md)
+
+
+class VerdictTests(unittest.TestCase):
+    def test_zero_and_one_with_junit_are_measured(self):
+        self.assertTrue(mbs.measured(rc=0, have_junit=True))
+        self.assertTrue(mbs.measured(rc=1, have_junit=True))
+
+    def test_anything_else_is_not(self):
+        self.assertFalse(mbs.measured(rc=1, have_junit=False))
+        self.assertFalse(mbs.measured(rc=2, have_junit=True))
+        self.assertFalse(mbs.measured(rc=3, have_junit=True))
+        self.assertFalse(mbs.measured(rc=139, have_junit=True))
+
+
+class MainTests(unittest.TestCase):
+    def _run(self, junit_text, log_text, rc):
+        with tempfile.TemporaryDirectory() as d:
+            log = Path(d, "run.log"); log.write_text(log_text)
+            summary = Path(d, "summary.md")
+            args = ["--log", str(log), "--rc", str(rc), "--elapsed", "12", "--bucket", "Tests-ERM",
+                    "--bc-version", "28.4.1.2", "--test-data", "true", "--reader", "v0.1.1", "--out", str(summary)]
+            if junit_text is not None:
+                junit = Path(d, "junit.xml"); junit.write_text(junit_text)
+                args += ["--junit", str(junit)]
+            code = mbs.main(args)
+            return code, summary.read_text()
+
+    def test_measured_run_exits_zero_and_writes_the_summary(self):
+        code, md = self._run(JUNIT, CLEAN_LOG, rc=1)
+        self.assertEqual(code, 0)
+        self.assertIn("| 9496 |", md)
+
+    def test_missing_junit_exits_nonzero_but_still_writes_a_summary(self):
+        code, md = self._run(None, "COMPILE FAIL x\n", rc=3)
+        self.assertEqual(code, 1)
+        self.assertIn("no JUnit", md)
+        self.assertIn("COMPILE FAIL x", md)
+
+    def test_explicit_step_summary_path_is_appended_to(self):
+        with tempfile.TemporaryDirectory() as d:
+            step = Path(d, "step.md"); step.write_text("existing\n")
+            log = Path(d, "run.log"); log.write_text(CLEAN_LOG)
+            junit = Path(d, "junit.xml"); junit.write_text(JUNIT)
+            code = mbs.main(["--log", str(log), "--junit", str(junit), "--rc", "1", "--elapsed", "5",
+                             "--bucket", "Tests-ERM", "--bc-version", "28.4.1.2", "--test-data", "true",
+                             "--step-summary", str(step)])
+            self.assertEqual(code, 0)
+            text = step.read_text()
+            self.assertTrue(text.startswith("existing\n"))
+            self.assertIn("| 9496 |", text)
+
+    def test_appends_to_github_step_summary_when_set(self):
+        with tempfile.TemporaryDirectory() as d:
+            step = Path(d, "step.md"); step.write_text("existing\n")
+            old = os.environ.get("GITHUB_STEP_SUMMARY")
+            os.environ["GITHUB_STEP_SUMMARY"] = str(step)
+            try:
+                code, _ = self._run(JUNIT, CLEAN_LOG, rc=0)
+            finally:
+                if old is None:
+                    del os.environ["GITHUB_STEP_SUMMARY"]
+                else:
+                    os.environ["GITHUB_STEP_SUMMARY"] = old
+            self.assertEqual(code, 0)
+            text = step.read_text()
+            self.assertTrue(text.startswith("existing\n"))
+            self.assertIn("| 9496 |", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/DownloadArtifacts/Program.cs
+++ b/tools/DownloadArtifacts/Program.cs
@@ -14,6 +14,14 @@
 //                                                            the stable 3-arg CI invocation is
 //                                                            unaffected.
 //   test-apps       <bc-version> <output-dir>              test-toolkit .app files
+//   test-sources    <bc-version> <output-dir> <bucket>     ONE Microsoft BaseApp test bucket's AL
+//                                                            source (issue #2724), e.g. Tests-ERM,
+//                                                            unpacked to <output-dir>/<bucket>/ as
+//                                                            a runnable bundle. Same platform
+//                                                            artifact as test-apps.
+//   test-data       <bc-version> <output-dir> [country]     BusinessCentral-<CC>.bak, the demo
+//                                                            backup --test-data hydrates from
+//                                                            (issue #2724). ~1 GB, streamed.
 //   al-compiler     <tool-version> <output-dir>             AL compiler DLLs (RID-aware NuGet pkg)
 //   resolve-version <bc-prefix>                             latest full version → stdout
 
@@ -22,8 +30,10 @@ using AlRunner.Provisioning;
 if (args.Length < 2)
 {
     Console.Error.WriteLine("Usage: DownloadArtifacts service-tier <bc-version> <output-dir>");
-    Console.Error.WriteLine("       DownloadArtifacts platform-apps <bc-version> <output-dir>");
+    Console.Error.WriteLine("       DownloadArtifacts platform-apps <bc-version> <output-dir> [country]");
     Console.Error.WriteLine("       DownloadArtifacts test-apps <bc-version> <output-dir>");
+    Console.Error.WriteLine("       DownloadArtifacts test-sources <bc-version> <output-dir> <bucket>");
+    Console.Error.WriteLine("       DownloadArtifacts test-data <bc-version> <output-dir> [country]");
     Console.Error.WriteLine("       DownloadArtifacts al-compiler <tool-version> <output-dir>");
     Console.Error.WriteLine("       DownloadArtifacts resolve-version <bc-prefix>");
     return 1;
@@ -42,6 +52,15 @@ switch (mode)
         var country = args.Length >= 4 ? args[3] : "w1";
         return ArtifactDownloader.PlatformApps(version, outputDir, country);
     case "test-apps": return ArtifactDownloader.TestApps(version, outputDir);
+    case "test-sources":
+        if (args.Length < 4)
+        {
+            Console.Error.WriteLine("Error: test-sources needs a bucket name: DownloadArtifacts test-sources <bc-version> <output-dir> <bucket>");
+            return 1;
+        }
+        return ArtifactDownloader.TestSources(version, outputDir, args[3]);
+    case "test-data":
+        return ArtifactDownloader.TestData(version, outputDir, args.Length >= 4 ? args[3] : "w1");
     case "al-compiler": return ArtifactDownloader.AlCompiler(version, outputDir);
     case "resolve-version":
         var resolved = ArtifactDownloader.ResolveVersion(version);


### PR DESCRIPTION
Closes #2724

## What this adds

**`.github/workflows/ms-bucket.yml`** — `on: workflow_dispatch` only. No push, pull_request, or schedule trigger; not a required check; not in any ruleset. Inputs: `bucket` (default `Tests-ERM`), `bc-version` (full build, a prefix, or empty for the newest prefix in `bc-versions.txt`), `test-data` (boolean, default true). It runs the bucket as a single process and writes total / pass / fail / error and wall time to the job summary, then uploads `junit.xml`, `results.json`, and `run.log`. The job is green when it produced a number (runner exit 0 or 1 plus a JUnit file) and red only when it did not (compile fail, exec fail, crash). Thousands of failing tests are the expected outcome and are reported, not failed on.

**The three missing pieces**, all through the ranged-ZIP read `ArtifactDownloader` already uses:

- `tools/DownloadArtifacts test-sources <ver> <dir> <bucket>` — pulls `Applications/BaseApp/Test/<bucket>.Source.zip` from the platform artifact (the same artifact `test-apps` reads; the entries were only filtered out by extension) and unpacks it into `<dir>/<bucket>/` as a runnable bundle. The zip is flat: `app.json` at the root beside the `.al` files, no edits needed. A wrong bucket name fails and lists the 35 buckets the artifact ships.
- `tools/DownloadArtifacts test-data <ver> <dir> [country]` — pulls `BusinessCentral-<CC>.bak` from the root of the country artifact. On 28.4.53241.54318 that entry is 582 MB compressed / 932 MB uncompressed, which does not fit the existing `ExtractEntry` (it buffers an entry in memory twice). A new streaming path (`ExtractEntryToFile` / `CopyZipEntryData`) writes it to `<name>.partial` and moves it into place only after the byte count matches the central directory, so a truncated download never sits at a path `--test-data` would open and trust. The workflow caches it with explicit `actions/cache/restore` + `save` keyed on the BC build, so the 1 GB is fetched once per build and kept even when the test run later goes red.
- `bcbak` — **consumed as the `bcdb-linux-x64` release asset from `StefanMaron/BusinessCentral.BakReader`, not built.** Reasons: a source build needs the .NET 10 SDK plus clang and adds minutes to every run; the release binary is the one that repo's own hermetic test suite gated before publishing; and the asset ships with `SHA256SUMS`, which the workflow verifies. The runner probes the old name at `~/.cache/al-runner/bcbak/bcbak`, so the asset is installed under that name. The release tag is printed in the summary because the reader's identity keys the install-baseline cache.

**`.github/actions/provision-bc/action.yml`** — the setup-dotnet, build, platform-apps, and test-apps steps moved out of `bc-tests.yml` (comments included, verbatim) into a composite action that both workflows use. This is the "reuse rather than hand-copy" the file's own header asks for. `ReleaseTestParityTests` still passes: the markers it checks (`tools/DownloadArtifacts`, both `$HOME/.al-runner/*` paths) remain in `bc-tests.yml` through the resolve step and the corpus run.

**`scripts/ms-bucket-summary.py`** — composes the summary from the JUnit root attributes and the runner log. Every log line matching `COMPILE FAIL`, `EXEC FAIL`, `NOT RUN:`, `resume:`, `carried from earlier attempt`, or a non-zero `compile-fail:` / `exec-fail:` count is copied into the summary verbatim under "Caveats".

## Configuration, exact

- `--test-data-company "CRONUS International Ltd_"` (trailing underscore)
- `--package-cache "$HOME/.al-runner/platform-apps" --package-cache "$HOME/.al-runner/test-apps"`
- `AL_RUNNER_EMIT_TIMEOUT_SEC=3600`
- `--cache "$RUNNER_TEMP/al-runner-cache"`
- The runner is invoked from `$RUNNER_TEMP` with absolute paths, so the repo's `tests/expectations` manifest (probed from cwd as a fallback) does not reclassify a Microsoft bucket.

## Interaction with #2721 and #2720

Until #2721 (emit timeout scaling plus the `NOT RUN: N bundle(s)` aggregate line) and #2720 (a resumed worker's JUnit carrying earlier attempts) land, this workflow's first number can be wrong in two ways that are hard to notice: a bundle lost to compile failure vanishes from the totals, and a resumed run under-reports. The summary surfaces every line the runner prints about either case, and once #2721 lands its `NOT RUN:` line is picked up by the same scan with no change here. The workflow header says the same.

## What the RED → GREEN proved

C# (`AlRunner.Tests/ArtifactDownloaderMsBucketTests.cs`, 19 cases; RED was CS0117 on the four new members):
- `IsBaseAppTestSourceEntry` accepts the real entry names (including `Tests-Cash Flow`, and either slash style) and rejects a different bucket, the `.app` beside the zip, a prefix collision (`Tests-ERM-Extra`, `Tests-ER`), the `Source/` sibling, and another app's `Test/` folder.
- `IsTestDataBackupEntry` accepts the root-level `.bak` for the country and rejects another country, a nested copy, and a `.bak.txt`.
- `UnpackSourceZip` writes `app.json` and every `.al` file with exact content; refuses a `../` entry before writing anything (not even the benign entries before it land); refuses a zip with no root `app.json`.
- `CopyZipEntryData` inflates a 1.5 MB deflate buffer byte-for-byte; copies a stored entry; throws naming expected vs actual on a truncated stream; throws naming the method on an unsupported one, with nothing written.

C# (`AlRunner.Tests/MsBucketWorkflowTests.cs`, 7 cases; RED was 5 failures on missing files, then 1 on a missing marker): `ms-bucket.yml` has exactly one trigger, `workflow_dispatch`; it carries every configuration value above verbatim; the composite action carries the build and both downloads; both `bc-tests.yml` and `ms-bucket.yml` use the action and neither inlines a `platform-apps ${{` / `test-apps ${{` download.

Python (`scripts/tests/ms-bucket-summary.test.py`, 13 cases; RED was FileNotFoundError): exact numbers from the JUnit root; caveat lines copied verbatim and zero-count lines not treated as caveats; a missing JUnit or exit code 2/3/139 yields "no number" and a non-zero exit; explicit `--step-summary` and the `GITHUB_STEP_SUMMARY` fallback both append.

Live-CDN checks of the new modes (not unit tests, run once against 28.4.53241.54318):
- `test-sources … Tests-Local` unpacked 3 files; `… Tests-ERM` unpacked 296 files; `… Tests-Nope` exited 1 listing the 35 shipped buckets.
- `test-data 28.4.53241.54318` streamed the 932 MB `.bak` in 16 s at a **peak RSS of 134 MB**; the file's CRC-32 (`0xf4f13cea`) and length (977,391,616) match the ZIP central directory; no `.partial` left behind.
- `test-data 27.5.46862.48827` (a build Microsoft has withdrawn) exited 1 with the existing "no BC artifact published" message.

## What is NOT covered by a test

- The workflow has not been dispatched. Its YAML parses (pyyaml) and the structure tests above pin what an edit could lose, but the step wiring — `actions/cache/restore`/`save`, `gh release download` under `github.token`, `bcbak --version`, output passing between steps — is exercised only by a real dispatch. The first dispatch is the test.
- Whether a 9,496-test single-bundle run fits a hosted runner's 16 GB and the 360-minute cap. Measured locally, one bundle of ~1,000 tests peaks around 3.7 GB and Tests-SINGLESERVER (834 tests) takes ~4 minutes warm; Tests-ERM is 11x the tests plus a cold build and emit.
- The `bcdb` release asset's behavior on the runner's Ubuntu (glibc) — it is the same asset the reader's own CI produced on `ubuntu-latest`.

## Shape check

1. Same wrong pattern elsewhere: `ExtractEntry`'s in-memory buffering is shared by every existing mode; the largest entry any of them fetches is the ~100 MB Base Application, which works today, so only the `.bak` moved to the streaming path. The `.EndsWith(".app")` filter that excluded the Source.zips exists only in `TestApps`.
2. Sibling assumptions: `TestDataOptions.CandidateBackupPaths` expects `<artifactsRoot>/<version>/<country>/`; the workflow passes an explicit `--test-data=PATH`, so it does not rely on that layout. `al-runner provision` has no `--test-sources` / `--test-data` counterpart; left out deliberately (below).
3. Two writers of the same state: `bc-tests.yml` and `ms-bucket.yml` both provision the same two package caches. They now do it through one action, and `MsBucketWorkflowTests` fails if either re-inlines the downloads.

## Deliberately left out

- No scheduled or automatic trigger; nothing added to any ruleset.
- No `al-runner provision --test-sources` / `--test-data`; the CLI wrapper `tools/DownloadArtifacts` is what CI uses, and the issue scopes the workflow.
- No `--jobs`: the bucket is one bundle and `--jobs` shards by bundle.
- No attempt to make the suite green. The `.bak` stays in the GitHub cache, not in the repo.

## Tests I ran locally

`dotnet test AlRunner.Tests --filter` over `ArtifactDownloaderMsBucketTests|MsBucketWorkflowTests|ArtifactDownloaderCountryTests|ArtifactDownloader404Tests|ReleaseTestParityTests|CliDocumentationTests` — 86 passed. `python3 scripts/tests/ms-bucket-summary.test.py` — 13 passed. I did not run the full `AlRunner.Tests` suite, the corpus, or Tests-ERM locally.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
