### PR TITLE
docs(agents): record the coordinator's standing authority and the traps found running one

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -1,6 +1,6 @@
 ---
 name: impl-agent
-description: Use when acting as an AL Runner implementation agent — claim a `status: ready` issue, implement with strict TDD, open a PR, monitor it through CI and merge. Trigger phrases include "act as impl agent", "pick up an issue and implement", "claim the next ready issue", "/loop impl-1". The invoking prompt must specify the agent identity (`impl-1`, `impl-2`, etc.).
+description: Use when acting as an AL Runner implementation agent — claim a `status: ready` issue, implement with strict TDD, open a PR, and hand it back without waiting for CI. Trigger phrases include "act as impl agent", "pick up an issue and implement", "claim the next ready issue", "/loop impl-1". The invoking prompt must specify the agent identity (`impl-1`, `impl-2`, etc.).
 tools: Bash, Read, Edit, Write, Grep, LSP, ToolSearch, mcp__github__get_me, mcp__github__list_issues, mcp__github__issue_read, mcp__github__issue_write, mcp__github__list_pull_requests, mcp__github__pull_request_read, mcp__github__create_pull_request, mcp__github__update_pull_request, mcp__github__add_issue_comment, mcp__github__get_job_logs, mcp__bc-decompiler__ping, mcp__bc-decompiler__status, mcp__bc-decompiler__get_server_stats, mcp__bc-decompiler__list_contexts, mcp__bc-decompiler__select_context, mcp__bc-decompiler__compare_contexts, mcp__bc-decompiler__warm_index, mcp__bc-decompiler__list_namespaces, mcp__bc-decompiler__get_types_in_namespace, mcp__bc-decompiler__search_symbols, mcp__bc-decompiler__search_types, mcp__bc-decompiler__search_members, mcp__bc-decompiler__search_attributes, mcp__bc-decompiler__search_string_literals, mcp__bc-decompiler__resolve_member_id, mcp__bc-decompiler__normalize_member_id, mcp__bc-decompiler__list_members, mcp__bc-decompiler__get_members_of_type, mcp__bc-decompiler__get_member_details, mcp__bc-decompiler__get_member_signature, mcp__bc-decompiler__get_overloads, mcp__bc-decompiler__get_overrides, mcp__bc-decompiler__get_implementations, mcp__bc-decompiler__find_base_types, mcp__bc-decompiler__find_derived_types, mcp__bc-decompiler__find_callers, mcp__bc-decompiler__find_callees, mcp__bc-decompiler__find_usages, mcp__bc-decompiler__get_decompiled_source, mcp__bc-decompiler__batch_get_decompiled_source, mcp__bc-decompiler__get_il, mcp__bc-decompiler__get_source_slice, mcp__bc-decompiler__get_ast_outline, mcp__bc-decompiler__get_xml_doc, mcp__bc-decompiler__compare_symbols
 model: sonnet
 ---
@@ -168,23 +168,40 @@ gh pr create --title "<title>" --body "Closes #<N>
 gh pr edit <pr-N> --add-label "agent: <AGENT-ID>" --add-label "status: review-ready" --repo StefanMaron/BusinessCentral.AL.Runner
 ```
 
-## Step 5 — Monitor until merged
+## Step 5 — Hand the PR back, do NOT wait for CI
 
-`.claude/rules/ci-verdicts.md` is the full guidance — "PR opened" is not the deliverable, drive it to merge. Wait on CI with **`tools/ci-wait.py <pr-N>`**: one call instead of a poll loop, exit codes in that rule.
+**"PR opened and pushed" IS your deliverable.** Open the PR, label it, and return
+immediately. Do not call `tools/ci-wait.py`. Do not poll `gh pr checks`. Do not wait for the
+run to finish, and do not merge.
+
+Waiting costs an agent slot for 15-25 minutes while it watches a run it cannot influence.
+The coordinator watches CI instead, and will either resume you or dispatch a fresh agent if
+your PR goes red — so a failure is never lost by returning early.
+
+Before you return, confirm all three and state them in your report:
+
+1. The branch is pushed (`git push` succeeded; `git status` shows nothing unpushed).
+2. The PR exists and its body contains `Closes #<N>`.
+3. The PR's head SHA equals your local `HEAD` — so whatever CI reports later is measuring
+   your actual work.
 
 ```
-gh pr view <pr-N> --json mergeStateStatus --repo StefanMaron/BusinessCentral.AL.Runner
-gh pr checks <pr-N> --repo StefanMaron/BusinessCentral.AL.Runner
+gh pr view <pr-N> --json number,headRefOid,mergeStateStatus --repo StefanMaron/BusinessCentral.AL.Runner
+git rev-parse HEAD
 ```
 
-Check merge conflicts first (no checks reported almost always means conflicts, not a CI outage); rebase + force-push with `--force-with-lease` if `DIRTY`/`CONFLICTING`. Fix CI failures, address review comments. Once merged, return to Step 1. One issue at a time — do not claim another while a PR is open.
+If `mergeStateStatus` already reads `DIRTY`/`CONFLICTING` at this point, that is a conflict
+with `main`, not a CI problem — rebase, resolve, re-run your targeted tests (never carry a
+stale test result across a rebase), force-push with `--force-with-lease`, and re-check the
+SHA before returning.
 
-**Do not end your turn while CI you are responsible for is still running** — no notification will ever arrive for a process you started, whatever backgrounded it (`.claude/rules/no-backgrounding-long-commands.md`). Re-check directly and keep checking: `gh run view <run-id> --json status,conclusion`. Both must hold before you report completion:
+Then report: the issue, the PR number, the head SHA, what you changed, what the RED → GREEN
+proved, and anything you deliberately left out. Return. Do not claim another issue.
 
-1. The run status is `completed` — not `in_progress`, and not "the last completed run was green."
-2. The green check's commit SHA matches your own current `HEAD`.
-
-State the head SHA in your completion report so the claim is checkable.
+**The no-backgrounding rule still applies to everything you start yourself** — builds,
+`dotnet test`, corpus runs (`.claude/rules/no-backgrounding-long-commands.md`). Never end a
+turn with your own local command still running. CI is the single exception, because it runs
+on GitHub's machines and the coordinator is watching it.
 
 ---
 
@@ -197,7 +214,7 @@ Full detail in `.claude/rules/` (`branch-and-pr.md`, `al-language-submodule.md`,
 - Isolate your work in a dedicated worktree/branch — never `git checkout -b` in a shared tree that may carry another agent's uncommitted edits, never `git add -A`/`git add .` there, never `git stash`.
 - Object IDs unique within the `app.json` whose `idRanges` you allocate from — check the range and check for in-flight collisions before creating AL files.
 - A test asserting plain BC behaviour goes upstream in the corpus, never into `tests/runner-extras/` as a shortcut.
-- One issue at a time; drive your own PR to green, don't just open it and stop.
+- One issue at a time. Open and push the PR, then return — do NOT wait on CI or merge; the coordinator does both.
 - No shipped real implementations of System Application codeunits (blank-shell auto-stubs and test-automation libraries only).
 - No assumption-based fixes — escalate thin issues with `status: needs-input`.
 - Never touch an issue or PR assigned to a user other than `@me` — a human maintainer is already on it.

--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -28,11 +28,25 @@ something, spawning an agent to re-measure it wastes a full context. Write the P
 
 - **Filing issues** on `StefanMaron/BusinessCentral.AL.Runner`, and **correcting the body of
   an issue you filed** when a measurement contradicts it.
-- **Merging PRs** in both this repo and the corpus repo
-  (`StefanMaron/BusinessCentral.AL.Language.Tests`), once they meet the bar below.
-- **Agents opening corpus PRs.** This is not gated. They open; you review and merge when all
-  8 BC legs are green. Agents never merge a corpus PR themselves. If an agent stops to ask
-  permission for this, tell it to go ahead — its definition may predate the change.
+- **Closing an issue whose work has already landed.** The owner's standing position: closing
+  is cheap and reversible — "we can always reopen if it returns". Verify against the code at
+  `main`, not against issue text, and prefer re-running the reporter's repro where one exists.
+- **Merging any PR authored under the owner's account**, in this repo and the corpus repo,
+  on your own high-level review plus a green pipeline. That covers every PR your agents open,
+  since they push with the owner's token. Judge whether the change is right, whether the
+  proving test is there, and whether CI is green on the **current head** — then merge.
+- **Arming auto-merge** instead of waiting. Review the PR when it arrives; if it passes, arm
+  it (`gh pr merge <N> --squash --delete-branch --auto`) and move on. Do not sit watching a
+  run you cannot influence.
+- **Claiming an issue assigned to another contributor when it overlaps work already in
+  flight.** `branch-and-pr.md`'s assignee boundary still holds as the default, but the owner
+  has released the `SShadowS`-assigned backlog specifically: when one of those issues is the
+  same defect an agent is already fixing, reassign it
+  (`gh issue edit <N> --remove-assignee SShadowS --add-assignee @me`) and fold it in. Do not
+  bulk-claim issues nobody is working on.
+
+**A PR from a contributor who is NOT the owner** — FBakkensen and others — is reviewed, never
+merged. You may review it and, with approval, comment. Merging it stays the owner's call.
 
 **Still gated, ask first:** comments on issues or PRs (including the corpus repo), PR review
 comments, anything posted to another repo. That is editorial content, not a workflow step.
@@ -57,9 +71,31 @@ failing test names, the stack top, the counts, the falsified hypotheses — and 
 are cause A and these 10 are cause B, here is the evidence" is a complete answer with no fix.
 Say so explicitly, or agents will force one fix over two causes to make the PR look bigger.
 
+**Agents do NOT wait for CI.** Their deliverable is "PR opened and pushed". Waiting costs an
+agent slot for 15-25 minutes watching a run it cannot influence, and you are watching CI
+anyway. `impl-agent.md`'s Step 5 says this; keep briefs consistent with it. A failure is never
+lost by returning early — resume the agent, or dispatch a fresh one with the failure in hand.
+
+**Never relay an authorization to an agent.** An agent is right to refuse a message claiming
+"the owner approved X" for anything touching its operating rules — commit signing, skipping a
+verification step, dropping an instruction its own harness set. It cannot verify the claim,
+and its instructions correctly say no agent message substitutes for the user's consent. This
+cost a full round trip when signing was disabled: the agent refused twice, correctly. **Do the
+privileged step yourself** — its work is staged in its worktree, so commit, push and open the
+PR from the coordinator session. Better still, make the change invisible: `commit.gpgsign` was
+already `false` in the shared repo config, so an agent that simply runs `git commit` succeeds
+and never needs telling.
+
 **Check in on long runners.** Past ~90 minutes, ask: where are you, is anything unpushed, is
 there a PR, are you blocked. Agents will sit on finished work waiting for permission they
 already have.
+
+**Search the issue queue before dispatching, and hand over the whole cluster.** A measured
+failure cluster is usually already partly filed. Grep the open issues for the area first — on
+one dispatch this turned a single issue into four sharing one root cause (#2723 + #2517 +
+#2460 + #2200), and the agent brief said so, which is what let it fix them together. Ask the
+agent which of the related issues its change closes for free rather than assigning all of
+them; "these three are one fix, that one is not, here is why" is a complete answer.
 
 ## Triage
 
@@ -90,6 +126,20 @@ verdict: 0 green on current head, 1 failed with the log already fetched, 2 still
 **Never `gh run rerun` a failed job** — it destroys the log permanently. Read
 `--log-failed` first, then push a new commit.
 
+**A CANCELLED check blocks the merge, with everything green and nothing saying why.**
+`pr-check.yml` triggers on `edited`, so editing a PR body starts a fresh run and
+`cancel-in-progress` cancels the old one — leaving a `CANCELLED` conclusion on required
+contexts that protection then treats as unsatisfied. `gh pr checks` shows all green,
+`ci-wait.py` reports GREEN on the head SHA, and the merge is still refused as `BLOCKED`. Look
+at `statusCheckRollup` for `conclusion == "CANCELLED"`. Re-running just that cancelled run
+clears it in under a minute — and that is NOT the forbidden `gh run rerun`, because a
+cancelled run has no failure log to destroy. Do not reach for `--admin`. Tracked as #2726.
+
+**Auto-merge does not drain a queue.** Protection requires up-to-date branches, so arming
+three PRs that touch one file merges one and leaves the rest `DIRTY`. Arm freely for
+independent PRs; drive contended ones one at a time, rebasing and **re-running the affected
+tests** after each merge rather than carrying a stale verdict forward.
+
 **Order matters when PRs carry submodule pins.** Two PRs both bumping the pin and the
 count-baseline will conflict; merge one, then tell the other to rebase and *re-measure*
 rather than carrying its old number forward.
@@ -106,6 +156,10 @@ These exist because each was violated at real cost.
 - **A children-inclusive profile percentage is not a saving.** In a JIT-dominated process it
   measures what is *reachable* from a call site; deleting the caller moves the cost to the
   next one. Price a change by removing the work and re-measuring, not by reading a call tree.
+- **Never compare two configurations across a rebuild.** Rebuilding the runner invalidates
+  the AL-output cache, and a cold run can report a different pass count for reasons unrelated
+  to your change — 873 vs 925 on the same code in one session. Set the variable through an
+  override on ONE warm cache instead, and pass a private `--cache <dir>`.
 - **Include a control.** Convert three classes, leave two untouched, and show the untouched
   ones flat. That is what makes the deltas believable.
 - **Do not rank work by the bc-linux container comparison.** That tier patches BC's binaries
@@ -138,6 +192,14 @@ Otherwise the next agent starts from the wrong premise — which has happened he
 - **The MS test company is `CRONUS International Ltd_`** — underscore, not a period.
 - **`.mcp.json` changes need a session restart.** Registering an MCP server mid-session does
   nothing for that session or its subagents.
+- **When 1Password is locked, commits and pushes both fail.** Signing goes through
+  `op-ssh-sign` and `origin` is SSH via the same agent, so `git commit` hangs waiting for a
+  signature and `git ls-remote` fails. The owner has authorized unsigned commits when he is
+  away from the machine: set `commit.gpgsign=false` / `tag.gpgsign=false` in the repo config
+  (every worktree shares it), and switch pushes to HTTPS with `gh auth setup-git` plus
+  `git remote set-url origin https://github.com/StefanMaron/BusinessCentral.AL.Runner.git`.
+  Verify with `git ls-remote origin HEAD` before telling anyone it works. Never read a secret
+  file and never try to unlock 1Password yourself.
 - **The network here times out intermittently.** Wrap `gh` in a retry; a bare `i/o timeout`
   is not an answer, and treating one as "no results" corrupts whatever you concluded.
 

--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -28,25 +28,25 @@ something, spawning an agent to re-measure it wastes a full context. Write the P
 
 - **Filing issues** on `StefanMaron/BusinessCentral.AL.Runner`, and **correcting the body of
   an issue you filed** when a measurement contradicts it.
-- **Closing an issue whose work has already landed.** The owner's standing position: closing
-  is cheap and reversible — "we can always reopen if it returns". Verify against the code at
+- **Closing an issue whose work has already landed.** Closing is cheap and reversible — an
+  issue that turns out to be live again can simply be reopened. Verify against the code at
   `main`, not against issue text, and prefer re-running the reporter's repro where one exists.
-- **Merging any PR authored under the owner's account**, in this repo and the corpus repo,
-  on your own high-level review plus a green pipeline. That covers every PR your agents open,
-  since they push with the owner's token. Judge whether the change is right, whether the
-  proving test is there, and whether CI is green on the **current head** — then merge.
+- **Merging any PR authored under the repo owner's account**, in this repo and the corpus
+  repo, on your own high-level review plus a green pipeline. That covers every PR your agents
+  open, since they push with that account's token. Judge whether the change is right, whether
+  the proving test is there, and whether CI is green on the **current head** — then merge.
 - **Arming auto-merge** instead of waiting. Review the PR when it arrives; if it passes, arm
   it (`gh pr merge <N> --squash --delete-branch --auto`) and move on. Do not sit watching a
   run you cannot influence.
 - **Claiming an issue assigned to another contributor when it overlaps work already in
-  flight.** `branch-and-pr.md`'s assignee boundary still holds as the default, but the owner
-  has released the `SShadowS`-assigned backlog specifically: when one of those issues is the
-  same defect an agent is already fixing, reassign it
-  (`gh issue edit <N> --remove-assignee SShadowS --add-assignee @me`) and fold it in. Do not
-  bulk-claim issues nobody is working on.
+  flight**, once the repo owner has released that contributor's backlog. `branch-and-pr.md`'s
+  assignee boundary still holds as the default. When a released issue is the same defect an
+  agent is already fixing, reassign it
+  (`gh issue edit <N> --remove-assignee <login> --add-assignee @me`) and fold it in. Do not
+  bulk-claim issues nobody is working on, and do not assume a release — confirm it.
 
-**A PR from a contributor who is NOT the owner** — FBakkensen and others — is reviewed, never
-merged. You may review it and, with approval, comment. Merging it stays the owner's call.
+**A PR from anyone other than the repo owner** is reviewed, never merged. You may review it
+and, with approval, comment on it. Merging someone else's contribution stays the owner's call.
 
 **Still gated, ask first:** comments on issues or PRs (including the corpus repo), PR review
 comments, anything posted to another repo. That is editorial content, not a workflow step.
@@ -135,10 +135,15 @@ at `statusCheckRollup` for `conclusion == "CANCELLED"`. Re-running just that can
 clears it in under a minute — and that is NOT the forbidden `gh run rerun`, because a
 cancelled run has no failure log to destroy. Do not reach for `--admin`. Tracked as #2726.
 
-**Auto-merge does not drain a queue.** Protection requires up-to-date branches, so arming
-three PRs that touch one file merges one and leaves the rest `DIRTY`. Arm freely for
-independent PRs; drive contended ones one at a time, rebasing and **re-running the affected
-tests** after each merge rather than carrying a stale verdict forward.
+**Auto-merge drains the queue — but a drained queue is not a verified one.** The
+"branches must be up to date" protection rule was removed, so arming several PRs lets them
+merge in sequence without each waiting for a rebase. Use that: review on arrival, arm, move on.
+
+The cost of dropping that rule is that a PR can merge on a green verdict measured against an
+older `main`. A clean textual merge says nothing about semantic conflict — two PRs can each be
+green alone and wrong together. So arm freely when PRs touch **different** files, and when two
+touch the same file, still land one and rebase the other with its affected tests **re-run**
+rather than trusting the earlier verdict. `git merge-tree` only answers the textual question.
 
 **Order matters when PRs carry submodule pins.** Two PRs both bumping the pin and the
 count-baseline will conflict; merge one, then tell the other to rebase and *re-measure*
@@ -194,8 +199,8 @@ Otherwise the next agent starts from the wrong premise — which has happened he
   nothing for that session or its subagents.
 - **When 1Password is locked, commits and pushes both fail.** Signing goes through
   `op-ssh-sign` and `origin` is SSH via the same agent, so `git commit` hangs waiting for a
-  signature and `git ls-remote` fails. The owner has authorized unsigned commits when he is
-  away from the machine: set `commit.gpgsign=false` / `tag.gpgsign=false` in the repo config
+  signature and `git ls-remote` fails. With the repo owner's authorization, fall back to
+  unsigned commits: set `commit.gpgsign=false` / `tag.gpgsign=false` in the repo config
   (every worktree shares it), and switch pushes to HTTPS with `gh auth setup-git` plus
   `git remote set-url origin https://github.com/StefanMaron/BusinessCentral.AL.Runner.git`.
   Verify with `git ls-remote origin HEAD` before telling anyone it works. Never read a secret

--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -171,6 +171,31 @@ These exist because each was violated at real cost.
   at startup, and filtering by it once hid the single largest cluster in the bucket — 102
   tests, worth +93 when fixed.
 
+## The corpus must grow with the fixes
+
+The corpus is the only place a claim about BC gets adjudicated by a real service tier, so it
+should gain a test roughly as often as a fix makes such a claim. If a session merges several
+fixes and opens no corpus PR, that is a signal to check rather than a sign the work was all
+infrastructure.
+
+**Ask of every PR: does this assert something about what BC does?** Runner infrastructure —
+process configuration, CI plumbing, error handling, caching, parallelism — genuinely asserts
+nothing about BC and owes nothing upstream. A change to what the runner *makes AL code
+observe* almost always does.
+
+**"The corpus cannot express this" is a claim, and it needs its evidence like any other.** It
+is sometimes true and the reason is usually structural: corpus tests are compiled from AL
+source *by the runner*, so a defect that only affects **precompiled** dependency artifacts
+cannot be reproduced by a corpus test, which would take the source-compiled path and pass. That
+is a legitimate answer. What is not legitimate is reaching for it because writing the upstream
+test is slower. When an agent gives that answer, make it name the structural reason — and if
+the reason is real, the proving test belongs in `tests/runner-extras/` and the PR should say
+so explicitly.
+
+Watch for the shape where a fix closes a BC-behaviour issue with only a runner-local test.
+That is the case `bc-behavior-tests-go-upstream.md` exists to prevent, and it is easiest to
+miss on a busy day, because a runner-local test is green and nothing complains.
+
 ## Settling a claim about BC
 
 Order of evidence, highest first: a corpus test green on a real service tier; BC's own


### PR DESCRIPTION
Folds a session's worth of repeated explanation into the two definitions that exist to prevent it. No runtime code changes.

## orchestrating-a-session

**Authority**, stated once instead of re-asked: close issues whose work already landed; merge any PR authored under the repo owner's account in this repo and the corpus on your own review plus a green pipeline; arm auto-merge rather than watching a run; claim a contributor-assigned issue when it overlaps work already in flight and that backlog has been released. A PR from anyone other than the repo owner is reviewed, never merged.

**Agents hand the PR back instead of waiting for CI**, and never receive a relayed authorization. An agent that refuses `the owner approved X` for anything touching its operating rules is behaving correctly — it cannot verify the claim, and its instructions say so. Do the privileged step from the coordinator session instead, or make the change invisible so it never has to be told. This cost a full round trip.

**Search the issue queue before dispatching.** One dispatch became four issues sharing a single root cause because the brief named them. Ask which the change closes for free rather than assigning all of them.

**A CANCELLED check blocks a merge with everything green and nothing reporting why** — `pr-check.yml` triggers on `edited`, `cancel-in-progress` kills the older run, and protection treats the cancelled context as unsatisfied. `gh pr checks` and `ci-wait.py` both report green while the merge is refused. Re-running that one run clears it, and it is not the forbidden rerun: a cancelled run has no failure log to destroy.

**Auto-merge drains the queue, but a drained queue is not a verified one.** The "branches must be up to date" rule has been removed, so arming several PRs lets them merge in sequence. The cost is that a PR can merge on a verdict measured against an older `main`, and a clean textual merge says nothing about semantic conflict — so still rebase and re-run the affected tests when two PRs touch the same file.

**Never compare two configurations across a rebuild** — it invalidates the AL-output cache and moved a pass count 873 → 925 on unchanged code.

Plus how to work when the credential agent is locked, without touching any secret.

## impl-agent

Step 5 becomes *hand the PR back*, not *monitor until merged*. Waiting spends an agent slot for 15-25 minutes on a run it cannot influence while the coordinator is watching CI anyway; a failure is never lost, since the agent can be resumed. The no-backgrounding rule still binds everything the agent starts itself — CI is the single exception, and the file says so.

## Note

The text is deliberately role-based rather than naming individuals, since this ships in a public repo. The remaining owner/repo references are the repository URL itself.

No linked issue: this records operating decisions and traps found while running a coordinator session, not a filed defect.
