### PR TITLE
fix(temp): give every runner-written scratch dir an owner, and sweep dead owners' leftovers at startup

### DIFF
--- a/AlRunner.Tests/AlCacheWriterDependencyCacheOrderingTests.cs
+++ b/AlRunner.Tests/AlCacheWriterDependencyCacheOrderingTests.cs
@@ -31,7 +31,7 @@ public sealed class AlCacheWriterDependencyCacheOrderingTests
 {
     private static string NewTempDir()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-cache-writer-dep-order-tests-" + Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.FlatDir("al-cache-writer-dep-order-tests-");
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/AlRunner.Tests/AlCacheWriterTests.cs
+++ b/AlRunner.Tests/AlCacheWriterTests.cs
@@ -20,7 +20,7 @@ public sealed class AlCacheWriterTests
 {
     private static string NewTempDir()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-cache-writer-tests-" + Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.FlatDir("al-cache-writer-tests-");
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/AlRunner.Tests/AlPerTestCoverageTests.cs
+++ b/AlRunner.Tests/AlPerTestCoverageTests.cs
@@ -37,7 +37,7 @@ public class AlPerTestCoverageTests : IClassFixture<SharedCliServer>
     // module cache.
     private static string MakeRunTestsBundle(string sourceFile)
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-per-test-coverage-tests", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-per-test-coverage-tests");
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "app.json"), """
         {

--- a/AlRunner.Tests/AlStatementTableTests.cs
+++ b/AlRunner.Tests/AlStatementTableTests.cs
@@ -43,7 +43,7 @@ public class AlStatementTableTests : IClassFixture<SharedCliServer>
     // this class never collides with another suite's compiled-module cache).
     private static string MakeRunTestsBundle(string sourceFile)
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-stmt-table-tests", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-stmt-table-tests");
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "app.json"), """
         {

--- a/AlRunner.Tests/AppIdCollisionLoudFailureTests.cs
+++ b/AlRunner.Tests/AppIdCollisionLoudFailureTests.cs
@@ -68,7 +68,7 @@ public class AppIdCollisionLoudFailureTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-appid-collision-1850", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-appid-collision-1850");
         var suiteADir = Path.Combine(root, "collide-a");
         var suiteBDir = Path.Combine(root, "collide-b");
         Directory.CreateDirectory(suiteADir);

--- a/AlRunner.Tests/AppLoaderR2rChunkCacheTests.cs
+++ b/AlRunner.Tests/AppLoaderR2rChunkCacheTests.cs
@@ -83,7 +83,7 @@ public sealed class AppLoaderR2rChunkCacheTests
         TestArtifacts.SkipIf(appPath == null,
             $"No R2R 'Business Foundation' .app found under '{platformDir}' — provision platform apps first.");
 
-        var cacheRoot = Path.Combine(Path.GetTempPath(), "app-loader-r2r-chunk-cache-tests-" + Guid.NewGuid().ToString("N"));
+        var cacheRoot = TestScratch.FlatDir("app-loader-r2r-chunk-cache-tests-");
         CacheRoots.SetOverride(cacheRoot);
         try
         {
@@ -126,7 +126,7 @@ public sealed class AppLoaderR2rChunkCacheTests
     [SkippableFact]
     public void ExtractAllDllPaths_UnknownOrNonR2RFile_ReturnsEmpty()
     {
-        var cacheRoot = Path.Combine(Path.GetTempPath(), "app-loader-r2r-chunk-cache-tests-" + Guid.NewGuid().ToString("N"));
+        var cacheRoot = TestScratch.FlatDir("app-loader-r2r-chunk-cache-tests-");
         CacheRoots.SetOverride(cacheRoot);
         try
         {

--- a/AlRunner.Tests/AssertErrorRollbackNestedTransactionTests.cs
+++ b/AlRunner.Tests/AssertErrorRollbackNestedTransactionTests.cs
@@ -62,7 +62,7 @@ public class AssertErrorRollbackNestedTransactionTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-assert-error-rollback-ntx-2413", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-assert-error-rollback-ntx-2413");
         Directory.CreateDirectory(root);
 
         File.WriteAllText(Path.Combine(root, "app.json"), """

--- a/AlRunner.Tests/AssertErrorRollbackScopeTests.cs
+++ b/AlRunner.Tests/AssertErrorRollbackScopeTests.cs
@@ -61,7 +61,7 @@ public class AssertErrorRollbackScopeTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-assert-error-rollback-2191", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-assert-error-rollback-2191");
         Directory.CreateDirectory(root);
 
         File.WriteAllText(Path.Combine(root, "app.json"), """
@@ -251,7 +251,7 @@ public class AssertErrorRollbackScopeTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-assert-error-rollback-2431", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-assert-error-rollback-2431");
         Directory.CreateDirectory(root);
 
         File.WriteAllText(Path.Combine(root, "app.json"), """

--- a/AlRunner.Tests/AutoProvisionCleanupTests.cs
+++ b/AlRunner.Tests/AutoProvisionCleanupTests.cs
@@ -30,7 +30,7 @@ public sealed class AutoProvisionCleanupTests : IDisposable
 
     public AutoProvisionCleanupTests()
     {
-        _artifactsRoot = Path.Combine(Path.GetTempPath(), "al-runner-autoprov", Guid.NewGuid().ToString("N"));
+        _artifactsRoot = TestScratch.Dir("al-runner-autoprov");
         Directory.CreateDirectory(_artifactsRoot);
     }
 

--- a/AlRunner.Tests/AutoProvisionDefaultTests.cs
+++ b/AlRunner.Tests/AutoProvisionDefaultTests.cs
@@ -79,7 +79,7 @@ public sealed class AutoProvisionDefaultTests
 
     private static string NewIsolatedHome()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-auto-provision-default", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-auto-provision-default");
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/AlRunner.Tests/BatchAppIdentityTests.cs
+++ b/AlRunner.Tests/BatchAppIdentityTests.cs
@@ -38,7 +38,7 @@ public sealed class BatchAppIdentityTests : IDisposable
 
     public BatchAppIdentityTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-batch-ident", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-batch-ident");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/BcAppSymbolCacheAtomicWriteTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCacheAtomicWriteTests.cs
@@ -45,7 +45,7 @@ public sealed class BcAppSymbolCacheAtomicWriteTests
 {
     private static string NewTempDir()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "bc-symbol-cache-atomic-tests-" + Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.FlatDir("bc-symbol-cache-atomic-tests-");
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/AlRunner.Tests/BcAppSymbolCacheContentAddressedKeyTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCacheContentAddressedKeyTests.cs
@@ -41,7 +41,7 @@ public sealed class BcAppSymbolCacheContentAddressedKeyTests
 {
     private static string NewTempDir()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "bc-symbol-cache-content-key-tests-" + Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.FlatDir("bc-symbol-cache-content-key-tests-");
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/AlRunner.Tests/BcAppSymbolCachePartialParseTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCachePartialParseTests.cs
@@ -39,7 +39,7 @@ public sealed class BcAppSymbolCachePartialParseTests : IDisposable
 
     public BcAppSymbolCachePartialParseTests()
     {
-        _dir = Path.Combine(Path.GetTempPath(), "al-runner-2712-tests", Guid.NewGuid().ToString("N"));
+        _dir = TestScratch.Dir("al-runner-2712-tests");
         Directory.CreateDirectory(_dir);
     }
 

--- a/AlRunner.Tests/BcAppSymbolCacheQueryMethodVersionTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCacheQueryMethodVersionTests.cs
@@ -62,7 +62,7 @@ public sealed class BcAppSymbolCacheQueryMethodVersionTests
 {
     private static string NewTempDir()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "bc-symbol-cache-query-method-version-tests-" + Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.FlatDir("bc-symbol-cache-query-method-version-tests-");
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/AlRunner.Tests/BcAppSymbolCacheQueryModuleQualifierTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCacheQueryModuleQualifierTests.cs
@@ -38,7 +38,7 @@ public sealed class BcAppSymbolCacheQueryModuleQualifierTests
 {
     private static string NewTempDir()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "bc-symbol-cache-query-module-qualifier-tests-" + Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.FlatDir("bc-symbol-cache-query-module-qualifier-tests-");
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/AlRunner.Tests/BcArtifactSelectionTests.cs
+++ b/AlRunner.Tests/BcArtifactSelectionTests.cs
@@ -19,7 +19,7 @@ public sealed class BcArtifactSelectionTests : IDisposable
 
     public BcArtifactSelectionTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-artifact-sel", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-artifact-sel");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/BcAssemblerParsePipelineTests.cs
+++ b/AlRunner.Tests/BcAssemblerParsePipelineTests.cs
@@ -143,7 +143,7 @@ public sealed class BcAssemblerParsePipelineTests
 
     private static string NewTempDir()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-mdref", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-mdref");
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/AlRunner.Tests/BcCompilerEmitDepSymbolsIncrementalTests.cs
+++ b/AlRunner.Tests/BcCompilerEmitDepSymbolsIncrementalTests.cs
@@ -44,7 +44,7 @@ public sealed class BcCompilerEmitDepSymbolsIncrementalTests : IDisposable
     public BcCompilerEmitDepSymbolsIncrementalTests(BcEngineFixture engine)
     {
         _engine = engine;
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-depsym-incr-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-depsym-incr-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/BcCompilerEmitRetryTests.cs
+++ b/AlRunner.Tests/BcCompilerEmitRetryTests.cs
@@ -55,7 +55,7 @@ public sealed class BcCompilerEmitRetryTests : IDisposable
     public BcCompilerEmitRetryTests(BcEngineFixture engine)
     {
         _engine = engine;
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-emit-retry-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-emit-retry-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/BcCompilerIncrementalCrossKindSiblingTests.cs
+++ b/AlRunner.Tests/BcCompilerIncrementalCrossKindSiblingTests.cs
@@ -43,7 +43,7 @@ public sealed class BcCompilerIncrementalCrossKindSiblingTests : IDisposable
     public BcCompilerIncrementalCrossKindSiblingTests(BcEngineFixture engine)
     {
         _engine = engine;
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-incremental-crosskind-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-incremental-crosskind-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/BcCompilerIncrementalNamespaceTests.cs
+++ b/AlRunner.Tests/BcCompilerIncrementalNamespaceTests.cs
@@ -42,7 +42,7 @@ public sealed class BcCompilerIncrementalNamespaceTests : IDisposable
     public BcCompilerIncrementalNamespaceTests(BcEngineFixture engine)
     {
         _engine = engine;
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-incremental-ns-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-incremental-ns-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/BcCompilerIncrementalOverloadRebindTests.cs
+++ b/AlRunner.Tests/BcCompilerIncrementalOverloadRebindTests.cs
@@ -45,7 +45,7 @@ public sealed class BcCompilerIncrementalOverloadRebindTests : IDisposable
     public BcCompilerIncrementalOverloadRebindTests(BcEngineFixture engine)
     {
         _engine = engine;
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-incremental-overload-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-incremental-overload-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/BcCompilerIncrementalTests.cs
+++ b/AlRunner.Tests/BcCompilerIncrementalTests.cs
@@ -43,7 +43,7 @@ public sealed class BcCompilerIncrementalTests : IDisposable
     public BcCompilerIncrementalTests(BcEngineFixture engine)
     {
         _engine = engine;
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-incremental-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-incremental-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/BcCompilerLoaderSelfExclusionTests.cs
+++ b/AlRunner.Tests/BcCompilerLoaderSelfExclusionTests.cs
@@ -62,7 +62,7 @@ public sealed class BcCompilerLoaderSelfExclusionTests : IDisposable
 
     public BcCompilerLoaderSelfExclusionTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-loader-selfexclusion-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-loader-selfexclusion-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/BcCompilerPkgDedupRelativePathTests.cs
+++ b/AlRunner.Tests/BcCompilerPkgDedupRelativePathTests.cs
@@ -60,7 +60,7 @@ public sealed class BcCompilerPkgDedupRelativePathTests : IDisposable
 
     public BcCompilerPkgDedupRelativePathTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-pkgdedup-relpath-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-pkgdedup-relpath-tests");
         Directory.CreateDirectory(_root);
         _savedCwd = Directory.GetCurrentDirectory();
     }

--- a/AlRunner.Tests/BcCompilerProfileEmitCrashTests.cs
+++ b/AlRunner.Tests/BcCompilerProfileEmitCrashTests.cs
@@ -41,7 +41,7 @@ public sealed class BcCompilerProfileEmitCrashTests : IDisposable
     public BcCompilerProfileEmitCrashTests(BcEngineFixture engine)
     {
         _engine = engine;
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-profile-emit-crash-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-profile-emit-crash-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/BcCompilerSharedReferenceMemoTests.cs
+++ b/AlRunner.Tests/BcCompilerSharedReferenceMemoTests.cs
@@ -53,7 +53,7 @@ public sealed class BcCompilerSharedReferenceMemoTests : IDisposable
 
     public BcCompilerSharedReferenceMemoTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-sharedref-memo-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-sharedref-memo-tests");
         Directory.CreateDirectory(_root);
         BcCompiler.ResetSharedReferencesForTests();
     }

--- a/AlRunner.Tests/BcCompilerWarmLoaderReuseTests.cs
+++ b/AlRunner.Tests/BcCompilerWarmLoaderReuseTests.cs
@@ -73,7 +73,7 @@ public sealed class BcCompilerWarmLoaderReuseTests : IDisposable
 
     public BcCompilerWarmLoaderReuseTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-warm-reuse-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-warm-reuse-tests");
         Directory.CreateDirectory(_root);
         BcCompiler.ResetSharedReferencesForTests();
     }

--- a/AlRunner.Tests/BcVersionDefaultDocumentationTests.cs
+++ b/AlRunner.Tests/BcVersionDefaultDocumentationTests.cs
@@ -87,7 +87,7 @@ public sealed class BcVersionDefaultDocumentationTests
         var realEngineDir = Path.Combine(TestArtifacts.StandardCacheDir(realHome), engineVersion.ToString());
         TestArtifacts.SkipIfDirectoryMissing(realEngineDir, $"BC {engineVersion} artifacts");
 
-        var isolatedHome = Path.Combine(Path.GetTempPath(), "al-runner-bcversion-default-doc", Guid.NewGuid().ToString("N"));
+        var isolatedHome = TestScratch.Dir("al-runner-bcversion-default-doc");
         var isolatedArtifacts = TestArtifacts.StandardCacheDir(isolatedHome);
         Directory.CreateDirectory(isolatedArtifacts);
         Directory.CreateSymbolicLink(Path.Combine(isolatedArtifacts, engineVersion.ToString()), realEngineDir);

--- a/AlRunner.Tests/BundleRootDeduplicationTests.cs
+++ b/AlRunner.Tests/BundleRootDeduplicationTests.cs
@@ -40,7 +40,7 @@ public sealed class BundleRootDeduplicationTests : IDisposable
 
     public BundleRootDeduplicationTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-bundle-dedup", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-bundle-dedup");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/BundleRootValidationTests.cs
+++ b/AlRunner.Tests/BundleRootValidationTests.cs
@@ -40,7 +40,7 @@ public sealed class BundleRootValidationTests : IDisposable
 
     public BundleRootValidationTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-bundle-root", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-bundle-root");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/CacheKeyDependencyClosureTests.cs
+++ b/AlRunner.Tests/CacheKeyDependencyClosureTests.cs
@@ -53,7 +53,7 @@ public sealed class CacheKeyDependencyClosureTests : IDisposable
 
     public CacheKeyDependencyClosureTests()
     {
-        _scratch = Path.Combine(Path.GetTempPath(), "al-runner-cachekey", Guid.NewGuid().ToString("N"));
+        _scratch = TestScratch.Dir("al-runner-cachekey");
         Directory.CreateDirectory(_scratch);
     }
 

--- a/AlRunner.Tests/CacheRootsDisableForRunTests.cs
+++ b/AlRunner.Tests/CacheRootsDisableForRunTests.cs
@@ -82,7 +82,7 @@ public sealed class CacheRootsDisableForRunTests
         // invisible to the child and get redone, the exact cost the re-exec exists to
         // avoid paying twice.
         CacheRoots.ResetForTests();
-        var preExisting = Path.Combine(Path.GetTempPath(), "al-runner-no-cache-test-" + Guid.NewGuid().ToString("N"));
+        var preExisting = TestScratch.FlatDir("al-runner-no-cache-test-");
         Environment.SetEnvironmentVariable(CacheRoots.NoCacheRootEnvVar, preExisting);
         try
         {
@@ -122,10 +122,16 @@ public sealed class CacheRootsDisableForRunTests
             Directory.CreateDirectory(target);
             File.WriteAllText(Path.Combine(target, "app.bin"), "not a real app");
             Assert.True(Directory.Exists(root));
+            // #2706: the minted root is owned through ScratchDirs, so a --no-cache run that is
+            // killed before this cleanup runs is reclaimed by the next runner start.
+            Assert.True(File.Exists(AlRunner.Infrastructure.ScratchDirs.MarkerPathFor(root)),
+                "the --no-cache throwaway root has no .owner sidecar");
 
             CacheRoots.CleanupThrowawayRoot();
 
             Assert.False(Directory.Exists(root), $"expected {root} to be gone after cleanup");
+            Assert.False(File.Exists(AlRunner.Infrastructure.ScratchDirs.MarkerPathFor(root)),
+                "cleanup left the .owner sidecar behind");
         }
         finally { CacheRoots.ResetForTests(); ClearEnvVar(); }
     }
@@ -171,7 +177,7 @@ public sealed class CacheRootsDisableForRunTests
         try
         {
             var throwaway = CacheRoots.DisableForRun();
-            var explicitDir = Path.Combine(Path.GetTempPath(), "al-runner-cacheroots-explicit", Guid.NewGuid().ToString("N"));
+            var explicitDir = TestScratch.Dir("al-runner-cacheroots-explicit");
 
             CacheRoots.SetOverride(explicitDir);
 

--- a/AlRunner.Tests/CacheRootsIsolationTests.cs
+++ b/AlRunner.Tests/CacheRootsIsolationTests.cs
@@ -73,7 +73,7 @@ public class CacheRootsIsolationTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var scratchRoot = Path.Combine(Path.GetTempPath(), "al-runner-cacheroots-isolation", Guid.NewGuid().ToString("N"));
+        var scratchRoot = TestScratch.Dir("al-runner-cacheroots-isolation");
         var depDir = Path.Combine(scratchRoot, "dep-app");
         var testsDir = Path.Combine(scratchRoot, "tests-app");
         var cacheDirA = Path.Combine(scratchRoot, "cache-a");

--- a/AlRunner.Tests/CacheRootsTests.cs
+++ b/AlRunner.Tests/CacheRootsTests.cs
@@ -41,7 +41,7 @@ public sealed class CacheRootsTests
     [Fact]
     public void Resolve_WithOverride_NestsEachCacheUnderTheGivenDir()
     {
-        var overrideDir = Path.Combine(Path.GetTempPath(), "al-runner-cacheroots-unit", Guid.NewGuid().ToString("N"));
+        var overrideDir = TestScratch.Dir("al-runner-cacheroots-unit");
         CacheRoots.SetOverride(overrideDir);
         try
         {
@@ -56,8 +56,8 @@ public sealed class CacheRootsTests
     [Fact]
     public void Resolve_TwoDifferentOverrides_NeverCollide()
     {
-        var dirA = Path.Combine(Path.GetTempPath(), "al-runner-cacheroots-unit", Guid.NewGuid().ToString("N"));
-        var dirB = Path.Combine(Path.GetTempPath(), "al-runner-cacheroots-unit", Guid.NewGuid().ToString("N"));
+        var dirA = TestScratch.Dir("al-runner-cacheroots-unit");
+        var dirB = TestScratch.Dir("al-runner-cacheroots-unit");
         try
         {
             CacheRoots.SetOverride(dirA);
@@ -76,7 +76,7 @@ public sealed class CacheRootsTests
     [Fact]
     public void Resolve_SetOverrideNull_RevertsToDefault()
     {
-        var overrideDir = Path.Combine(Path.GetTempPath(), "al-runner-cacheroots-unit", Guid.NewGuid().ToString("N"));
+        var overrideDir = TestScratch.Dir("al-runner-cacheroots-unit");
         try
         {
             CacheRoots.SetOverride(overrideDir);

--- a/AlRunner.Tests/CodeunitRunGuardRollbackTests.cs
+++ b/AlRunner.Tests/CodeunitRunGuardRollbackTests.cs
@@ -69,7 +69,7 @@ public class CodeunitRunGuardRollbackTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-codeunit-run-guard-2334", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-codeunit-run-guard-2334");
         Directory.CreateDirectory(root);
 
         File.WriteAllText(Path.Combine(root, "app.json"), """

--- a/AlRunner.Tests/ControlAddInFileSystemTests.cs
+++ b/AlRunner.Tests/ControlAddInFileSystemTests.cs
@@ -48,7 +48,7 @@ public sealed class ControlAddInFileSystemTests : IDisposable
     public ControlAddInFileSystemTests(BcEngineFixture engine)
     {
         _engine = engine;
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-controladdin-fs-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-controladdin-fs-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/CountBaselineIntegrationTests.cs
+++ b/AlRunner.Tests/CountBaselineIntegrationTests.cs
@@ -45,7 +45,7 @@ public sealed class CountBaselineIntegrationTests : IDisposable
 
     public CountBaselineIntegrationTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-count-baseline", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-count-baseline");
         Directory.CreateDirectory(_root);
         _suiteKey = Path.GetFileName(_root);
         _baselinePath = Path.Combine(Path.GetTempPath(), "al-runner-count-baseline",

--- a/AlRunner.Tests/CoverageTests.cs
+++ b/AlRunner.Tests/CoverageTests.cs
@@ -30,7 +30,7 @@ public sealed class CoverageTests : IDisposable
 
     public CoverageTests()
     {
-        _scratch = Path.Combine(Path.GetTempPath(), "al-runner-coverage-tests", Guid.NewGuid().ToString("N"));
+        _scratch = TestScratch.Dir("al-runner-coverage-tests");
         Directory.CreateDirectory(_scratch);
     }
 

--- a/AlRunner.Tests/CrossBundleModuleIdentityDedupTests.cs
+++ b/AlRunner.Tests/CrossBundleModuleIdentityDedupTests.cs
@@ -62,7 +62,7 @@ public class CrossBundleModuleIdentityDedupTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-xbundle-dedup", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-xbundle-dedup");
         var depDir = Path.Combine(root, "dep-app");
         var testDir = Path.Combine(root, "test-app");
         Directory.CreateDirectory(depDir);

--- a/AlRunner.Tests/DefaultProvisionTargetMessagingTests.cs
+++ b/AlRunner.Tests/DefaultProvisionTargetMessagingTests.cs
@@ -62,7 +62,7 @@ public sealed class DefaultProvisionTargetMessagingTests
 
     private static string NewIsolatedHome()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-provision-target-msg", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-provision-target-msg");
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/AlRunner.Tests/DefaultProvisionTargetTests.cs
+++ b/AlRunner.Tests/DefaultProvisionTargetTests.cs
@@ -28,7 +28,7 @@ public sealed class DefaultProvisionTargetTests : IDisposable
 
     public DefaultProvisionTargetTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-provision-target", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-provision-target");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/DefineFlagIntegrationTests.cs
+++ b/AlRunner.Tests/DefineFlagIntegrationTests.cs
@@ -63,7 +63,7 @@ public sealed class DefineFlagIntegrationTests : IDisposable
 
     public DefineFlagIntegrationTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-define-flag", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-define-flag");
         Directory.CreateDirectory(_root);
         WriteFixture(_root);
     }

--- a/AlRunner.Tests/DependencyManifestNonStringFieldTests.cs
+++ b/AlRunner.Tests/DependencyManifestNonStringFieldTests.cs
@@ -56,7 +56,7 @@ public class DependencyManifestNonStringFieldTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var scratchRoot = Path.Combine(Path.GetTempPath(), "al-runner-nonstring-dep", Guid.NewGuid().ToString("N"));
+        var scratchRoot = TestScratch.Dir("al-runner-nonstring-dep");
         var depDir = Path.Combine(scratchRoot, "dep-app");
         var testsDir = Path.Combine(scratchRoot, "tests-app");
         var absentPackageCache = Path.Combine(scratchRoot, "no-such-package-cache");

--- a/AlRunner.Tests/DependencyResolverTests.cs
+++ b/AlRunner.Tests/DependencyResolverTests.cs
@@ -32,7 +32,7 @@ public sealed class DependencyResolverTests : IDisposable
 
     public DependencyResolverTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-resolver-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-resolver-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/DependencyShadowDiagnosticTests.cs
+++ b/AlRunner.Tests/DependencyShadowDiagnosticTests.cs
@@ -37,8 +37,7 @@ namespace AlRunner.Tests;
 
 public sealed class DependencyShadowDiagnosticTests : IDisposable
 {
-    private readonly string _dir = Path.Combine(Path.GetTempPath(),
-        "al-runner-shadow-" + Guid.NewGuid().ToString("N"));
+    private readonly string _dir = TestScratch.FlatDir("al-runner-shadow-");
 
     public DependencyShadowDiagnosticTests() => Directory.CreateDirectory(_dir);
 

--- a/AlRunner.Tests/EmitExclusionLoudnessTests.cs
+++ b/AlRunner.Tests/EmitExclusionLoudnessTests.cs
@@ -145,7 +145,7 @@ public sealed class EmitExclusionLoudnessTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var tmp = Path.Combine(Path.GetTempPath(), "al-runner-emit-excl", Guid.NewGuid().ToString("N"));
+        var tmp = TestScratch.Dir("al-runner-emit-excl");
         Directory.CreateDirectory(tmp);
         try
         {

--- a/AlRunner.Tests/EnsureTestToolkitProvisionedTests.cs
+++ b/AlRunner.Tests/EnsureTestToolkitProvisionedTests.cs
@@ -32,7 +32,7 @@ public sealed class EnsureTestToolkitProvisionedTests : IDisposable
 
     public EnsureTestToolkitProvisionedTests()
     {
-        _dir = Path.Combine(Path.GetTempPath(), "al-runner-ensure-toolkit", Guid.NewGuid().ToString("N"));
+        _dir = TestScratch.Dir("al-runner-ensure-toolkit");
         Directory.CreateDirectory(_dir);
     }
 

--- a/AlRunner.Tests/EnumCaptionCaptureTests.cs
+++ b/AlRunner.Tests/EnumCaptionCaptureTests.cs
@@ -30,7 +30,7 @@ public sealed class EnumCaptionCaptureTests : IDisposable
     public EnumCaptionCaptureTests(BcEngineFixture engine)
     {
         _engine = engine;
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-enum-caption-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-enum-caption-tests");
         Directory.CreateDirectory(_root);
         AlEnumMetadataRegistry.Clear();
     }

--- a/AlRunner.Tests/EnumExtensionSidecarRoundTripTests.cs
+++ b/AlRunner.Tests/EnumExtensionSidecarRoundTripTests.cs
@@ -38,7 +38,7 @@ public sealed class EnumExtensionSidecarRoundTripTests : IDisposable
 
     public EnumExtensionSidecarRoundTripTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-enum-ext-sidecar-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-enum-ext-sidecar-tests");
         Directory.CreateDirectory(_root);
         AlEnumMetadataRegistry.Clear();
     }

--- a/AlRunner.Tests/ExpectationManifestSchemaTests.cs
+++ b/AlRunner.Tests/ExpectationManifestSchemaTests.cs
@@ -13,8 +13,7 @@ namespace AlRunner.Tests;
 
 public class ExpectationManifestSchemaTests : IDisposable
 {
-    private readonly string _dir = Path.Combine(
-        Path.GetTempPath(), "al-runner-manifest-" + Guid.NewGuid().ToString("N"));
+    private readonly string _dir = TestScratch.FlatDir("al-runner-manifest-");
 
     public ExpectationManifestSchemaTests() => Directory.CreateDirectory(_dir);
 

--- a/AlRunner.Tests/ExpectationManifestWiringTests.cs
+++ b/AlRunner.Tests/ExpectationManifestWiringTests.cs
@@ -55,8 +55,7 @@ public sealed class ExpectationManifestWiringTests : IDisposable
     // #1984: scratch root for tests that need fixture copies living OUTSIDE this
     // repo's working tree, so no ancestor of the copy accidentally carries this
     // repo's own tests/expectations/. Torn down in Dispose.
-    private readonly string _scratchRoot = Path.Combine(
-        Path.GetTempPath(), "al-runner-expectations-wiring", Guid.NewGuid().ToString("N"));
+    private readonly string _scratchRoot = TestScratch.Dir("al-runner-expectations-wiring");
 
     public void Dispose()
     {

--- a/AlRunner.Tests/ExpectationsDirectoryResolutionTests.cs
+++ b/AlRunner.Tests/ExpectationsDirectoryResolutionTests.cs
@@ -24,7 +24,7 @@ public sealed class ExpectationsDirectoryResolutionTests : IDisposable
 
     public ExpectationsDirectoryResolutionTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-expectations-resolve", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-expectations-resolve");
         Directory.CreateDirectory(_root);
     }
 
@@ -84,7 +84,7 @@ public sealed class ExpectationsDirectoryResolutionTests : IDisposable
     {
         var manifestDir = Path.Combine(_root, "tests", "expectations");
         Directory.CreateDirectory(manifestDir);
-        var bundleOutsideRoot = Path.Combine(Path.GetTempPath(), "al-runner-expectations-resolve-elsewhere", Guid.NewGuid().ToString("N"));
+        var bundleOutsideRoot = TestScratch.Dir("al-runner-expectations-resolve-elsewhere");
         Directory.CreateDirectory(bundleOutsideRoot);
         try
         {

--- a/AlRunner.Tests/FindBucketRootDedupeTests.cs
+++ b/AlRunner.Tests/FindBucketRootDedupeTests.cs
@@ -40,7 +40,7 @@ public sealed class FindBucketRootDedupeTests
 {
     private static string NewTempDir()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-findbucketroot-dedupe-tests", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-findbucketroot-dedupe-tests");
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/AlRunner.Tests/HomeDirectoryMissingLoudFailureTests.cs
+++ b/AlRunner.Tests/HomeDirectoryMissingLoudFailureTests.cs
@@ -91,7 +91,7 @@ public sealed class HomeDirectoryMissingLoudFailureTests
     [Fact]
     public void MissingHomeDirectory_FailsLoud_NamingHomeValue_NeverCrashesWithRawStack()
     {
-        var missingHome = Path.Combine(Path.GetTempPath(), "al-runner-2114-missing-home", Guid.NewGuid().ToString("N"));
+        var missingHome = TestScratch.Dir("al-runner-2114-missing-home");
         Assert.False(Directory.Exists(missingHome)); // never created — the exact trigger
 
         var (exit, stderr) = RunWithHome(missingHome);
@@ -126,7 +126,7 @@ public sealed class HomeDirectoryMissingLoudFailureTests
     [Fact]
     public void ExistingEmptyHomeDirectory_BehaviourUnchanged_GenericArtifactRootMessage()
     {
-        var existingHome = Path.Combine(Path.GetTempPath(), "al-runner-2114-existing-home", Guid.NewGuid().ToString("N"));
+        var existingHome = TestScratch.Dir("al-runner-2114-existing-home");
         Directory.CreateDirectory(existingHome);
         try
         {

--- a/AlRunner.Tests/InaccessibleDirectoryScanTests.cs
+++ b/AlRunner.Tests/InaccessibleDirectoryScanTests.cs
@@ -45,7 +45,7 @@ public sealed class InaccessibleDirectoryScanTests : IDisposable
 
     public InaccessibleDirectoryScanTests()
     {
-        _dir = Path.Combine(Path.GetTempPath(), "al-runner-inaccessible", Guid.NewGuid().ToString("N"));
+        _dir = TestScratch.Dir("al-runner-inaccessible");
         Directory.CreateDirectory(_dir);
     }
 

--- a/AlRunner.Tests/InstallBaselineDiskCacheTests.cs
+++ b/AlRunner.Tests/InstallBaselineDiskCacheTests.cs
@@ -205,7 +205,7 @@ public class InstallBaselineDiskCacheTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-ib-disk-roundtrip", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-ib-disk-roundtrip");
         try
         {
             var (dep, main) = WriteUniqueClosure(root, 62000, "rt");
@@ -259,7 +259,7 @@ public class InstallBaselineDiskCacheTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-ib-disk-killswitch", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-ib-disk-killswitch");
         try
         {
             var (dep, main) = WriteUniqueClosure(root, 62020, "ks");
@@ -304,7 +304,7 @@ public class InstallBaselineDiskCacheTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-ib-disk-corrupt", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-ib-disk-corrupt");
         try
         {
             var (dep, main) = WriteUniqueClosure(root, 62040, "cx");
@@ -365,7 +365,7 @@ public class InstallBaselineDiskCacheTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-ib-disk-scope", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-ib-disk-scope");
         try
         {
             var (depA, mainA) = WriteUniqueClosure(root, 62060, "sa");

--- a/AlRunner.Tests/InstallBaselineVirtualTableExclusionTests.cs
+++ b/AlRunner.Tests/InstallBaselineVirtualTableExclusionTests.cs
@@ -371,7 +371,7 @@ public class InstallBaselineVirtualTableExclusionTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-2272-codeunit", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-2272-codeunit");
         try
         {
             var app = Path.Combine(root, "app");
@@ -394,7 +394,7 @@ public class InstallBaselineVirtualTableExclusionTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-2272-test", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-2272-test");
         try
         {
             var app = Path.Combine(root, "app");
@@ -437,7 +437,7 @@ public class InstallBaselineVirtualTableExclusionTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-2272-appgroup", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-2272-appgroup");
         try
         {
             var appA = Path.Combine(root, "app-a");

--- a/AlRunner.Tests/InstallSeedDepCompanyCacheTests.cs
+++ b/AlRunner.Tests/InstallSeedDepCompanyCacheTests.cs
@@ -128,7 +128,7 @@ public class InstallSeedDepCompanyCacheTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-depcompany-cache", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-depcompany-cache");
         try
         {
             var appA = Path.Combine(root, "app-a");
@@ -181,7 +181,7 @@ public class InstallSeedDepCompanyCacheTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-depcompany-cache-killswitch", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-depcompany-cache-killswitch");
         try
         {
             var appA = Path.Combine(root, "app-a");
@@ -224,7 +224,7 @@ public class InstallSeedDepCompanyCacheTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-depcompany-cache-neg", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-depcompany-cache-neg");
         try
         {
         var appA = Path.Combine(root, "app-a");

--- a/AlRunner.Tests/JUnitCountsTests.cs
+++ b/AlRunner.Tests/JUnitCountsTests.cs
@@ -7,7 +7,7 @@ namespace AlRunner.Tests;
 
 public sealed class JUnitCountsTests : IDisposable
 {
-    private readonly string _dir = Path.Combine(Path.GetTempPath(), "junitcounts-" + Guid.NewGuid().ToString("N"));
+    private readonly string _dir = TestScratch.FlatDir("junitcounts-");
 
     public JUnitCountsTests() => Directory.CreateDirectory(_dir);
     public void Dispose() { try { Directory.Delete(_dir, true); } catch { } }

--- a/AlRunner.Tests/LayeredCacheTests.cs
+++ b/AlRunner.Tests/LayeredCacheTests.cs
@@ -86,7 +86,7 @@ public class LayeredCacheTests : IClassFixture<SharedCliServer>
 
         var server = await _shared.GetAsync(new[] { "--cache", CacheDir });
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-layered-cache", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-layered-cache");
         var aDir = Path.Combine(root, "A");
         var bDir = Path.Combine(root, "B");
         var cDir = Path.Combine(root, "C");

--- a/AlRunner.Tests/LayeredDepManifestTests.cs
+++ b/AlRunner.Tests/LayeredDepManifestTests.cs
@@ -165,7 +165,7 @@ public class LayeredDepManifestTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-layered-ctxhelp-pos", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-layered-ctxhelp-pos");
         var depDir = Path.Combine(root, "dep");
         var mainDir = Path.Combine(root, "main");
         var depId = "c1a20000-0000-4000-8000-0000000000a1";
@@ -191,7 +191,7 @@ public class LayeredDepManifestTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-layered-ctxhelp-neg", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-layered-ctxhelp-neg");
         var depDir = Path.Combine(root, "dep");
         var mainDir = Path.Combine(root, "main");
         var depId = "c1a20000-0000-4000-8000-0000000000b1";

--- a/AlRunner.Tests/LayeredDepSymbolsIncrementalServerTests.cs
+++ b/AlRunner.Tests/LayeredDepSymbolsIncrementalServerTests.cs
@@ -148,7 +148,7 @@ public class LayeredDepSymbolsIncrementalServerTests : IClassFixture<SharedCliSe
 
         var server = await _shared.GetAsync(new[] { "--cache", CacheDir });
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-layered-rad", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-layered-rad");
         const int libId = 60560;
         const int testId = 60570;
         var libDir = MakeLibBundle(root, libId, LibBefore(libId));
@@ -230,7 +230,7 @@ public class LayeredDepSymbolsIncrementalServerTests : IClassFixture<SharedCliSe
 
         var server = await _shared.GetAsync(new[] { "--cache", CacheDir });
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-layered-rad", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-layered-rad");
         const int libId = 60580;
         const int testId = 60590;
         var libDir = MakeLibBundle(root, libId, LibBefore(libId));

--- a/AlRunner.Tests/ManifestCompilerInputsTests.cs
+++ b/AlRunner.Tests/ManifestCompilerInputsTests.cs
@@ -43,7 +43,7 @@ public sealed class ManifestCompilerInputsTests : IDisposable
     public ManifestCompilerInputsTests(BcEngineFixture engine)
     {
         _engine = engine;
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-manifest-compiler-inputs", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-manifest-compiler-inputs");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/ManifestDependencyEdgeScanTests.cs
+++ b/AlRunner.Tests/ManifestDependencyEdgeScanTests.cs
@@ -39,7 +39,7 @@ public sealed class ManifestDependencyEdgeScanTests : IDisposable
 
     public ManifestDependencyEdgeScanTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-edges", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-edges");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/ManifestFeaturesSubprocessTests.cs
+++ b/AlRunner.Tests/ManifestFeaturesSubprocessTests.cs
@@ -41,14 +41,13 @@ public sealed class ManifestFeaturesSubprocessTests : IClassFixture<SharedCliSer
     public ManifestFeaturesSubprocessTests(SharedCliServer shared)
     {
         _shared = shared;
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-manifest-features-subprocess", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-manifest-features-subprocess");
         Directory.CreateDirectory(_root);
     }
 
     /// <summary>#2377: the one `--cache` dir this class's shared server is started with,
     /// fresh per test run so nothing an earlier invocation cached can answer here.</summary>
-    private static readonly string CacheDir = Path.Combine(
-        Path.GetTempPath(), "al-runner-manifest-features-cache", Guid.NewGuid().ToString("N"));
+    private static readonly string CacheDir = TestScratch.Dir("al-runner-manifest-features-cache");
 
     private static IEnumerable<string> ServerArgs()
     {

--- a/AlRunner.Tests/MissingTestDataDiagnosisTests.cs
+++ b/AlRunner.Tests/MissingTestDataDiagnosisTests.cs
@@ -48,7 +48,7 @@ public sealed class MissingTestDataDiagnosisTests : IDisposable
 
     public MissingTestDataDiagnosisTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-missing-test-data", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-missing-test-data");
         Directory.CreateDirectory(_root);
         WriteFixture(_root);
     }

--- a/AlRunner.Tests/NavRecordTestFieldNavigationPatchesTests.cs
+++ b/AlRunner.Tests/NavRecordTestFieldNavigationPatchesTests.cs
@@ -31,7 +31,7 @@ public sealed class NavRecordTestFieldNavigationPatchesTests : IDisposable
     public NavRecordTestFieldNavigationPatchesTests(BcEngineFixture engine)
     {
         _engine = engine;
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-testfield-nav-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-testfield-nav-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/NclCecilRewriteCacheKeyTests.cs
+++ b/AlRunner.Tests/NclCecilRewriteCacheKeyTests.cs
@@ -24,7 +24,7 @@ public sealed class NclCecilRewriteCacheKeyTests
 {
     private static string NewTempDir()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "ncl-cecil-cachekey-tests-" + Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.FlatDir("ncl-cecil-cachekey-tests-");
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/AlRunner.Tests/NclShadowConcurrentStartupTests.cs
+++ b/AlRunner.Tests/NclShadowConcurrentStartupTests.cs
@@ -186,7 +186,7 @@ public sealed class NclShadowConcurrentStartupTests
     [Fact]
     public void IsShadowDirComplete_DirDoesNotExist_ReturnsFalse()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "ncl-shadow-race-does-not-exist-" + Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.FlatDir("ncl-shadow-race-does-not-exist-");
         Assert.False(NclShadowRuntime.IsShadowDirComplete(dir, @"C:\install\any"));
     }
 

--- a/AlRunner.Tests/NoCacheLastWinsIntegrationTests.cs
+++ b/AlRunner.Tests/NoCacheLastWinsIntegrationTests.cs
@@ -66,7 +66,7 @@ public class NoCacheLastWinsIntegrationTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var scratchRoot = Path.Combine(Path.GetTempPath(), "al-runner-nocache-lastwins", Guid.NewGuid().ToString("N"));
+        var scratchRoot = TestScratch.Dir("al-runner-nocache-lastwins");
         var bundleDir = Path.Combine(scratchRoot, "tests-app");
         var cacheDirA = Path.Combine(scratchRoot, "cache-a");
         var absentPackageCache = Path.Combine(scratchRoot, "no-such-package-cache");
@@ -143,7 +143,7 @@ public class NoCacheLastWinsIntegrationTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var scratchRoot = Path.Combine(Path.GetTempPath(), "al-runner-nocache-noleak", Guid.NewGuid().ToString("N"));
+        var scratchRoot = TestScratch.Dir("al-runner-nocache-noleak");
         var bundleDir = Path.Combine(scratchRoot, "tests-app");
         var absentPackageCache = Path.Combine(scratchRoot, "no-such-package-cache");
         Directory.CreateDirectory(bundleDir);
@@ -175,13 +175,17 @@ public class NoCacheLastWinsIntegrationTests
         }
         """);
 
+        // Set difference, not a count (#2706): the spawned runner sweeps stale al-runner-*
+        // directories of DEAD processes at startup, so the count can legitimately go DOWN
+        // across the run on a machine with leftovers. The claim here is only that this run
+        // left no NEW directory behind.
         var tempRoot = Path.GetTempPath();
-        var before = Directory.GetDirectories(tempRoot, "al-runner-no-cache-*").Length;
+        var before = Directory.GetDirectories(tempRoot, "al-runner-no-cache-*").ToHashSet(StringComparer.Ordinal);
 
         var (output, exit) = RunRunner(bundleDir, absentPackageCache, "--no-cache");
         Assert.True(exit == 0 && output.Contains("1P/0F/0E"), $"run must pass:\n{output}");
 
-        var after = Directory.GetDirectories(tempRoot, "al-runner-no-cache-*").Length;
-        Assert.Equal(before, after);
+        var leaked = Directory.GetDirectories(tempRoot, "al-runner-no-cache-*").Where(d => !before.Contains(d)).ToList();
+        Assert.True(leaked.Count == 0, "the --no-cache run left its throwaway root behind: " + string.Join(", ", leaked));
     }
 }

--- a/AlRunner.Tests/NumberSequenceServerResetTests.cs
+++ b/AlRunner.Tests/NumberSequenceServerResetTests.cs
@@ -33,8 +33,7 @@ public sealed class NumberSequenceServerResetTests
 
     private static string CreateProbeBundle()
     {
-        var directory = Path.Combine(
-            Path.GetTempPath(), "al-runner-number-sequence-server", Guid.NewGuid().ToString("N"));
+        var directory = TestScratch.Dir("al-runner-number-sequence-server");
         Directory.CreateDirectory(directory);
         File.WriteAllText(Path.Combine(directory, "app.json"), """
         {

--- a/AlRunner.Tests/OutputFormatTests.cs
+++ b/AlRunner.Tests/OutputFormatTests.cs
@@ -28,7 +28,7 @@ public sealed class OutputFormatTests : IDisposable
 
     public OutputFormatTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-output-format", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-output-format");
         Directory.CreateDirectory(_root);
         WriteFixture(_root);
     }

--- a/AlRunner.Tests/PackageCacheFinalSearchSetTests.cs
+++ b/AlRunner.Tests/PackageCacheFinalSearchSetTests.cs
@@ -192,8 +192,7 @@ public sealed class PackageCacheFinalSearchSetTests
     public void FinalSearchSet_ReflectsRunnerOwnedFoldIn()
     {
         TestArtifacts.SkipIfMissing();
-        var scratchRoot = Path.Combine(
-            Path.GetTempPath(), "al-runner-pkgcache-final", Guid.NewGuid().ToString("N"));
+        var scratchRoot = TestScratch.Dir("al-runner-pkgcache-final");
         var testsDir = WriteFixture(scratchRoot);
         var isolatedHome = Path.Combine(scratchRoot, "home");
         Directory.CreateDirectory(isolatedHome);
@@ -221,8 +220,7 @@ public sealed class PackageCacheFinalSearchSetTests
     public void FinalSearchSet_UnchangedWhenNothingFolds()
     {
         TestArtifacts.SkipIfMissing();
-        var scratchRoot = Path.Combine(
-            Path.GetTempPath(), "al-runner-pkgcache-final-plain", Guid.NewGuid().ToString("N"));
+        var scratchRoot = TestScratch.Dir("al-runner-pkgcache-final-plain");
         var testsDir = WriteFixture(scratchRoot);
         var isolatedHome = Path.Combine(scratchRoot, "home");
         Directory.CreateDirectory(isolatedHome);

--- a/AlRunner.Tests/PageBackgroundTaskInlineTests.cs
+++ b/AlRunner.Tests/PageBackgroundTaskInlineTests.cs
@@ -73,7 +73,7 @@ public class PageBackgroundTaskInlineTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-pbt-inline-2514", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-pbt-inline-2514");
         Directory.CreateDirectory(root);
 
         File.WriteAllText(Path.Combine(root, "app.json"), """
@@ -366,7 +366,7 @@ public class PageBackgroundTaskInlineTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-pbt-shutdown-2650", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-pbt-shutdown-2650");
         Directory.CreateDirectory(root);
 
         File.WriteAllText(Path.Combine(root, "app.json"), """

--- a/AlRunner.Tests/PhaseLogIntegrationTests.cs
+++ b/AlRunner.Tests/PhaseLogIntegrationTests.cs
@@ -34,7 +34,7 @@ public sealed class PhaseLogIntegrationTests : IDisposable
 
     public PhaseLogIntegrationTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-phaselog-e2e", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-phaselog-e2e");
         _noDeps = Path.Combine(_root, "nodeps");
         _withDeps = Path.Combine(_root, "withdeps");
         _logPath = Path.Combine(_root, "logs", "phases.jsonl");

--- a/AlRunner.Tests/PhaseLogServerKillTests.cs
+++ b/AlRunner.Tests/PhaseLogServerKillTests.cs
@@ -36,7 +36,7 @@ public sealed class PhaseLogServerKillTests : IDisposable
 
     public PhaseLogServerKillTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-phaselog-server-kill", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-phaselog-server-kill");
         _logPath = Path.Combine(_root, "logs", "phases.jsonl");
         Directory.CreateDirectory(_root);
     }

--- a/AlRunner.Tests/PhaseLogTests.cs
+++ b/AlRunner.Tests/PhaseLogTests.cs
@@ -22,8 +22,7 @@ namespace AlRunner.Tests;
 
 public sealed class PhaseLogTests : IDisposable
 {
-    private readonly string _dir = Path.Combine(
-        Path.GetTempPath(), "al-runner-phaselog-" + Guid.NewGuid().ToString("N"));
+    private readonly string _dir = TestScratch.FlatDir("al-runner-phaselog-");
 
     public PhaseLogTests() => Directory.CreateDirectory(_dir);
 

--- a/AlRunner.Tests/PkgDedupSearchSetProvenanceTests.cs
+++ b/AlRunner.Tests/PkgDedupSearchSetProvenanceTests.cs
@@ -28,7 +28,7 @@ public sealed class PkgDedupSearchSetProvenanceTests : IDisposable
 
     public PkgDedupSearchSetProvenanceTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-pkgdedup-provenance", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-pkgdedup-provenance");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/PkgDedupStagingPublishTests.cs
+++ b/AlRunner.Tests/PkgDedupStagingPublishTests.cs
@@ -26,8 +26,7 @@ public class PkgDedupStagingPublishTests : IDisposable
 
     public PkgDedupStagingPublishTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-pkgdedup-tests",
-                             Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-pkgdedup-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/PlaceholderFloorProvisioningTests.cs
+++ b/AlRunner.Tests/PlaceholderFloorProvisioningTests.cs
@@ -165,8 +165,7 @@ public sealed class PlaceholderFloorProvisioningTests
     public void PlaceholderFloorWithGenuineMicrosoftUsage_ColdCache_NoAutoProvision_StillRefuses()
     {
         TestArtifacts.SkipIfMissing();
-        var scratchRoot = Path.Combine(
-            Path.GetTempPath(), "al-runner-placeholder-floor-msuse", Guid.NewGuid().ToString("N"));
+        var scratchRoot = TestScratch.Dir("al-runner-placeholder-floor-msuse");
         var bundleDir = WritePlaceholderFloorWithMicrosoftUsageFixture(Path.Combine(scratchRoot, "bundle"));
         var isolatedHome = Path.Combine(scratchRoot, "home");
         Directory.CreateDirectory(isolatedHome);
@@ -203,8 +202,7 @@ public sealed class PlaceholderFloorProvisioningTests
         var bundleDir = Path.Combine(RepoRoot, "tests", "runner-extras", "microsoft-dependencies");
         TestArtifacts.SkipIf(!Directory.Exists(bundleDir), $"fixture not found: '{bundleDir}'.");
 
-        var scratchRoot = Path.Combine(
-            Path.GetTempPath(), "al-runner-genuine-msdep", Guid.NewGuid().ToString("N"));
+        var scratchRoot = TestScratch.Dir("al-runner-genuine-msdep");
         var isolatedHome = Path.Combine(scratchRoot, "home");
         Directory.CreateDirectory(isolatedHome);
         var alCacheDir = Path.Combine(scratchRoot, "al-out");

--- a/AlRunner.Tests/PlainRunInstrumentationGateTests.cs
+++ b/AlRunner.Tests/PlainRunInstrumentationGateTests.cs
@@ -43,7 +43,7 @@ public sealed class PlainRunInstrumentationGateTests : IDisposable
 
     public PlainRunInstrumentationGateTests()
     {
-        _scratch = Path.Combine(Path.GetTempPath(), "al-runner-plainrun-gate-tests", Guid.NewGuid().ToString("N"));
+        _scratch = TestScratch.Dir("al-runner-plainrun-gate-tests");
         Directory.CreateDirectory(_scratch);
     }
 

--- a/AlRunner.Tests/PrebuiltShadowCheckTests.cs
+++ b/AlRunner.Tests/PrebuiltShadowCheckTests.cs
@@ -21,7 +21,7 @@ public class PrebuiltShadowCheckTests
 {
     private static string NewTempDir()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-shadow-" + Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.FlatDir("al-runner-shadow-");
         Directory.CreateDirectory(dir);
         return dir;
     }
@@ -118,7 +118,7 @@ public class PrebuiltShadowCheckTests
     public void NewestAlSourceUtc_MissingDirectory_ReturnsMinValue()
     {
         Assert.Equal(DateTime.MinValue,
-            PrebuiltShadowCheck.NewestAlSourceUtc(Path.Combine(Path.GetTempPath(), "definitely-not-here-" + Guid.NewGuid().ToString("N"))));
+            PrebuiltShadowCheck.NewestAlSourceUtc(TestScratch.FlatDir("definitely-not-here-")));
     }
 }
 
@@ -134,7 +134,7 @@ public class PrebuiltShadowContentCheckTests
 {
     private static string NewTempDir()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "prebuilt-shadow-content", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("prebuilt-shadow-content");
         Directory.CreateDirectory(dir);
         return dir;
     }
@@ -341,5 +341,5 @@ public class PrebuiltShadowContentCheckTests
     [Fact]
     public void SourceAlContentHash_IsNullForAMissingDirectory()
         => Assert.Null(PrebuiltShadowCheck.SourceAlContentHash(
-            Path.Combine(Path.GetTempPath(), "no-such-dir-" + Guid.NewGuid().ToString("N"))));
+            TestScratch.FlatDir("no-such-dir-")));
 }

--- a/AlRunner.Tests/PrecompileAlDiagnosticFailureTests.cs
+++ b/AlRunner.Tests/PrecompileAlDiagnosticFailureTests.cs
@@ -115,7 +115,7 @@ public sealed class PrecompileAlDiagnosticFailureTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-precompile-al0353-bad", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-precompile-al0353-bad");
         var appPath = WriteAppPackage(dir, "f6666666-6666-6666-6666-666666666666",
             "PrecompileAl0353Bad", "Repro2152",
             ("Order.Table.al", """
@@ -167,7 +167,7 @@ public sealed class PrecompileAlDiagnosticFailureTests
         // The corrected form real BC accepts — proves the precompile gate does not
         // also reject valid AL. Required alongside the negative test above: a guard
         // that always failed would pass that test too.
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-precompile-al0353-good", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-precompile-al0353-good");
         var appPath = WriteAppPackage(dir, "f7777777-7777-7777-7777-777777777777",
             "PrecompileAl0353Good", "Repro2152",
             ("Order.Table.al", """

--- a/AlRunner.Tests/PrecompileSupportTests.cs
+++ b/AlRunner.Tests/PrecompileSupportTests.cs
@@ -14,7 +14,7 @@ public sealed class PrecompileSupportTests
 {
     private static string NewTempArtifactsRoot()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "precompile-support-tests-" + Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.FlatDir("precompile-support-tests-");
         Directory.CreateDirectory(dir);
         return dir;
     }
@@ -58,7 +58,7 @@ public sealed class PrecompileSupportTests
         // never provisioned must not conjure a phantom search-path entry the caller can
         // silently rely on (Directory.EnumerateFiles over a missing dir already throws
         // elsewhere in this codebase's .app scanners if this ever regressed).
-        var artifactsRoot = Path.Combine(Path.GetTempPath(), "precompile-support-tests-missing-" + Guid.NewGuid().ToString("N"));
+        var artifactsRoot = TestScratch.FlatDir("precompile-support-tests-missing-");
         const string version = "28.1.49838.50794";
 
         var widened = PrecompileSupport.WidenPackageCacheDirs(Array.Empty<string>(), artifactsRoot, version);

--- a/AlRunner.Tests/ProvisionExplicitModesTests.cs
+++ b/AlRunner.Tests/ProvisionExplicitModesTests.cs
@@ -88,7 +88,7 @@ public sealed class ProvisionExplicitModesTests
 
     private static string NewIsolatedHome()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-provision-explicit", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-provision-explicit");
         Directory.CreateDirectory(dir);
         return dir;
     }
@@ -361,7 +361,7 @@ public sealed class ProvisionExplicitModesTests
         var engineMajor = Version.Parse(ThisBuildsEngineVersion).Major;
         var bundleMajor = engineMajor - 1;
         var home = NewIsolatedHome();
-        var bundleDir = Path.Combine(Path.GetTempPath(), "al-runner-provision-explicit-bundle", Guid.NewGuid().ToString("N"));
+        var bundleDir = TestScratch.Dir("al-runner-provision-explicit-bundle");
         Directory.CreateDirectory(bundleDir);
         File.WriteAllText(Path.Combine(bundleDir, "app.json"),
             "{ \"id\": \"11111111-1111-1111-1111-111111111111\", \"name\": \"Fixture\", " +

--- a/AlRunner.Tests/ProvisioningCheckTests.cs
+++ b/AlRunner.Tests/ProvisioningCheckTests.cs
@@ -16,7 +16,7 @@ public sealed class ProvisioningCheckTests : IDisposable
 
     public ProvisioningCheckTests()
     {
-        _dir = Path.Combine(Path.GetTempPath(), "al-runner-prov", Guid.NewGuid().ToString("N"));
+        _dir = TestScratch.Dir("al-runner-prov");
         Directory.CreateDirectory(_dir);
     }
 

--- a/AlRunner.Tests/QueryAggregationProjectionTests.cs
+++ b/AlRunner.Tests/QueryAggregationProjectionTests.cs
@@ -62,7 +62,7 @@ public class QueryAggregationProjectionTests
 
     private static string WriteBundle()
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-query-agg-2137", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-query-agg-2137");
         Directory.CreateDirectory(root);
 
         File.WriteAllText(Path.Combine(root, "app.json"), """

--- a/AlRunner.Tests/QueryColumnFilterProjectionTests.cs
+++ b/AlRunner.Tests/QueryColumnFilterProjectionTests.cs
@@ -74,7 +74,7 @@ public class QueryColumnFilterProjectionTests
 
     private static string WriteBundle()
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-query-columnfilter-2418", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-query-columnfilter-2418");
         Directory.CreateDirectory(root);
 
         File.WriteAllText(Path.Combine(root, "app.json"), """

--- a/AlRunner.Tests/QueryFlowFieldColumnProjectionTests.cs
+++ b/AlRunner.Tests/QueryFlowFieldColumnProjectionTests.cs
@@ -83,7 +83,7 @@ public class QueryFlowFieldColumnProjectionTests
 
     private static string WriteBundle()
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-query-flowfield-2300", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-query-flowfield-2300");
         Directory.CreateDirectory(root);
 
         File.WriteAllText(Path.Combine(root, "app.json"), """

--- a/AlRunner.Tests/QueryHavingAndJoinAggregationProjectionTests.cs
+++ b/AlRunner.Tests/QueryHavingAndJoinAggregationProjectionTests.cs
@@ -78,7 +78,7 @@ public class QueryHavingAndJoinAggregationProjectionTests
 
     private static string WriteBundle()
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-query-having-join-2146", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-query-having-join-2146");
         Directory.CreateDirectory(root);
 
         File.WriteAllText(Path.Combine(root, "app.json"), """

--- a/AlRunner.Tests/QueryJoinColumnFilterProjectionTests.cs
+++ b/AlRunner.Tests/QueryJoinColumnFilterProjectionTests.cs
@@ -74,7 +74,7 @@ public class QueryJoinColumnFilterProjectionTests
 
     private static string WriteBundle()
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-query-join-columnfilter-2444", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-query-join-columnfilter-2444");
         Directory.CreateDirectory(root);
 
         File.WriteAllText(Path.Combine(root, "app.json"), """

--- a/AlRunner.Tests/QueryJoinFlowFieldColumnOosTests.cs
+++ b/AlRunner.Tests/QueryJoinFlowFieldColumnOosTests.cs
@@ -57,7 +57,7 @@ public class QueryJoinFlowFieldColumnOosTests
 
     private static string WriteBundle(string appJsonName, string idRangeFrom, string idRangeTo, string extraFiles)
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-query-join-flowfield-2423", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-query-join-flowfield-2423");
         Directory.CreateDirectory(root);
 
         File.WriteAllText(Path.Combine(root, "app.json"), $$"""

--- a/AlRunner.Tests/QueryReverseSignProjectionTests.cs
+++ b/AlRunner.Tests/QueryReverseSignProjectionTests.cs
@@ -64,7 +64,7 @@ public class QueryReverseSignProjectionTests
 
     private static string WriteBundle()
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-query-reversesign-2575", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-query-reversesign-2575");
         Directory.CreateDirectory(root);
 
         File.WriteAllText(Path.Combine(root, "app.json"), """

--- a/AlRunner.Tests/QueryWildcardFilterProjectionTests.cs
+++ b/AlRunner.Tests/QueryWildcardFilterProjectionTests.cs
@@ -64,7 +64,7 @@ public class QueryWildcardFilterProjectionTests
 
     private static string WriteBundle()
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-query-wildcard-2299", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-query-wildcard-2299");
         Directory.CreateDirectory(root);
 
         File.WriteAllText(Path.Combine(root, "app.json"), """

--- a/AlRunner.Tests/RecordPatchesAddSourceDirsParseOnceTests.cs
+++ b/AlRunner.Tests/RecordPatchesAddSourceDirsParseOnceTests.cs
@@ -29,7 +29,7 @@ public sealed class RecordPatchesAddSourceDirsParseOnceTests : IDisposable
     public RecordPatchesAddSourceDirsParseOnceTests(BcEngineFixture engine)
     {
         _engine = engine;
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-parse-once-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-parse-once-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/RecordPatchesBcAppSymbolReadFailureTests.cs
+++ b/AlRunner.Tests/RecordPatchesBcAppSymbolReadFailureTests.cs
@@ -40,7 +40,7 @@ public sealed class RecordPatchesBcAppSymbolReadFailureTests : IDisposable
 
     public RecordPatchesBcAppSymbolReadFailureTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-2712-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-2712-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/RecordPatchesPrecompiledTableExtEvictionTests.cs
+++ b/AlRunner.Tests/RecordPatchesPrecompiledTableExtEvictionTests.cs
@@ -54,7 +54,7 @@ public sealed class RecordPatchesPrecompiledTableExtEvictionTests : IDisposable
     public RecordPatchesPrecompiledTableExtEvictionTests(BcEngineFixture engine)
     {
         _engine = engine;
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-2126-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-2126-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/RecordPatchesSourceDirBatchTests.cs
+++ b/AlRunner.Tests/RecordPatchesSourceDirBatchTests.cs
@@ -53,7 +53,7 @@ public sealed class RecordPatchesSourceDirBatchTests : IDisposable
     public RecordPatchesSourceDirBatchTests(BcEngineFixture engine)
     {
         _engine = engine;
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-source-dir-batch-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-source-dir-batch-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/RecordPatchesWarmReloadExtensionIndexTests.cs
+++ b/AlRunner.Tests/RecordPatchesWarmReloadExtensionIndexTests.cs
@@ -58,7 +58,7 @@ public sealed class RecordPatchesWarmReloadExtensionIndexTests : IDisposable
 
     public RecordPatchesWarmReloadExtensionIndexTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-2478-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-2478-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/RecordPatchesWarmReloadInstallBaselineTests.cs
+++ b/AlRunner.Tests/RecordPatchesWarmReloadInstallBaselineTests.cs
@@ -67,7 +67,7 @@ public sealed class RecordPatchesWarmReloadInstallBaselineTests : IDisposable
 
     public RecordPatchesWarmReloadInstallBaselineTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-2480-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-2480-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/RunnerFingerprintTests.cs
+++ b/AlRunner.Tests/RunnerFingerprintTests.cs
@@ -20,7 +20,7 @@ public sealed class RunnerFingerprintTests
 {
     private static string NewTempDir()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "runner-fingerprint-tests-" + Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.FlatDir("runner-fingerprint-tests-");
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/AlRunner.Tests/ScratchDirsRunnerStartupTests.cs
+++ b/AlRunner.Tests/ScratchDirsRunnerStartupTests.cs
@@ -1,0 +1,146 @@
+// ScratchDirsRunnerStartupTests — the runner sweeps stale scratch directories out of the OS
+// temp root when it starts (issue #2706).
+//
+// Every per-process / per-run scratch directory the runner writes under Path.GetTempPath()
+// (dependency extraction, the report engine's per-session temp folder, --jobs shard reports,
+// --no-cache throwaway roots, resume carry files, ...) used to be removed only by the process
+// that created it, at its own clean exit — so a run that was killed, OOM'd, or hit the
+// watchdog left its directory behind forever. Measured on the reporting machine:
+// al-runner-navserver/user/ alone held 212 per-pid folders, 211 of them for dead processes,
+// 7.5 GB. On a stock Linux desktop /tmp is a tmpfs, so that is RAM, charged to no process.
+//
+// The runner cannot know at exit time that it is about to be killed, so the only place the
+// leftovers of a dead process can be reclaimed is the start of the NEXT process. This class
+// plants the shapes that leak, spawns the real runner once, and asserts which ones survive:
+//
+//   - a directory whose `.owner` sidecar names a process that no longer exists -> removed
+//   - the legacy pid-named leaves (al-runner-deps/p<pid>, al-runner-navserver/user/<pid>)
+//     whose pid is dead -> removed
+//   - a directory whose owner is THIS test host (alive) -> kept, untouched
+//   - an unmarked directory with no pid in its name -> kept: the sweep never guesses by age,
+//     because several runners share one TMPDIR on a busy machine and an age heuristic is the
+//     only rule that can delete a live process's directory out from under it
+//
+// The spawned run needs no BC artifacts: --bc-version 1.2.3.4 --no-auto-provision fails at
+// artifact selection, which is after the sweep and before any BC type loads. The planted
+// directories are all created by this test and named with a fresh GUID, so the test never
+// touches another process's scratch space.
+
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class ScratchDirsRunnerStartupTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    /// <summary>The sidecar format the runner's sweep reads. Written by hand here (rather than
+    /// through the runner's own helper) so the format itself is pinned as a contract — a
+    /// leftover from a killed run must still be recognised by a later build.</summary>
+    private static void WriteOwnerMarker(string dir, int pid, long startTicks)
+        => File.WriteAllText(dir + ".owner", $"pid={pid}\nstart={startTicks}\n");
+
+    /// <summary>A pid that no process on this machine has. Linux pid_max tops out at
+    /// 4,194,304 and Windows pids are far smaller in practice, so counting down from two
+    /// billion finds one on the first try; the loop is only there so the claim is checked
+    /// rather than assumed.</summary>
+    internal static int FindDeadPid()
+    {
+        for (var pid = 2_000_000_000; pid > 1_000_000_000; pid -= 7919)
+        {
+            try { using var _ = Process.GetProcessById(pid); }
+            catch (ArgumentException) { return pid; }
+            catch (InvalidOperationException) { return pid; }
+        }
+        throw new InvalidOperationException("could not find a free pid");
+    }
+
+    private static (int Exit, string Output) RunRunnerWithoutArtifacts()
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(" --bc-version 1.2.3.4 --no-auto-provision");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(120_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (p.ExitCode, sb.ToString());
+    }
+
+    [Fact]
+    public void RunnerStartup_RemovesDeadOwnersLeftovers_AndLeavesLiveAndUnmarkedOnesAlone()
+    {
+        var temp = Path.GetTempPath();
+        var deadPid = FindDeadPid();
+        var me = Process.GetCurrentProcess();
+        var myStart = me.StartTime.ToUniversalTime().Ticks;
+        var tag = Guid.NewGuid().ToString("N");
+
+        // Shapes that must be reclaimed.
+        var deadMarked = Path.Combine(temp, "al-runner-startup-sweep-tests", tag + "-dead");
+        Directory.CreateDirectory(deadMarked);
+        File.WriteAllText(Path.Combine(deadMarked, "payload.bin"), "x");
+        WriteOwnerMarker(deadMarked, deadPid, 1);
+
+        var deadFlatMarked = Path.Combine(temp, "al-runner-startup-sweep-flat-" + tag);
+        Directory.CreateDirectory(deadFlatMarked);
+        WriteOwnerMarker(deadFlatMarked, deadPid, 1);
+
+        var legacyDeps = Path.Combine(temp, "al-runner-deps", "p" + deadPid);
+        Directory.CreateDirectory(Path.Combine(legacyDeps, "Microsoft_Tests-TestLibraries_1_0"));
+        File.WriteAllText(Path.Combine(legacyDeps, "Microsoft_Tests-TestLibraries_1_0", "X.al"), "codeunit 1 X {}");
+
+        var legacyNavUser = Path.Combine(temp, "al-runner-navserver", "user", deadPid.ToString());
+        Directory.CreateDirectory(Path.Combine(legacyNavUser, "TEMP"));
+        File.WriteAllText(Path.Combine(legacyNavUser, "TEMP", "GU00000001.xlsx"), "x");
+
+        // Shapes that must survive.
+        var liveMarked = Path.Combine(temp, "al-runner-startup-sweep-tests", tag + "-live");
+        Directory.CreateDirectory(liveMarked);
+        File.WriteAllText(Path.Combine(liveMarked, "payload.bin"), "x");
+        WriteOwnerMarker(liveMarked, me.Id, myStart);
+
+        var unmarked = Path.Combine(temp, "al-runner-startup-sweep-tests", tag + "-unmarked");
+        Directory.CreateDirectory(unmarked);
+        File.WriteAllText(Path.Combine(unmarked, "payload.bin"), "x");
+        // Old by any age heuristic — and still not the sweep's to delete.
+        Directory.SetLastWriteTimeUtc(unmarked, DateTime.UtcNow.AddDays(-30));
+
+        try
+        {
+            var (exit, output) = RunRunnerWithoutArtifacts();
+            Assert.True(exit != 0, "a run pinned to a version that cannot exist must not report success:\n" + output);
+
+            Assert.False(Directory.Exists(deadMarked), $"dead-owner scratch dir survived the runner's startup sweep: {deadMarked}\n{output}");
+            Assert.False(File.Exists(deadMarked + ".owner"), "dead-owner marker survived");
+            Assert.False(Directory.Exists(deadFlatMarked), $"dead-owner flat scratch dir survived: {deadFlatMarked}");
+            Assert.False(Directory.Exists(legacyDeps), $"legacy al-runner-deps/p<deadpid> survived: {legacyDeps}");
+            Assert.False(Directory.Exists(legacyNavUser), $"legacy al-runner-navserver/user/<deadpid> survived: {legacyNavUser}");
+
+            Assert.True(File.Exists(Path.Combine(liveMarked, "payload.bin")), "a LIVE owner's scratch dir was deleted");
+            Assert.True(File.Exists(liveMarked + ".owner"), "a LIVE owner's marker was deleted");
+            Assert.True(File.Exists(Path.Combine(unmarked, "payload.bin")), "an unmarked directory was deleted — the sweep must not guess by age");
+        }
+        finally
+        {
+            foreach (var d in new[] { deadMarked, deadFlatMarked, legacyDeps, legacyNavUser, liveMarked, unmarked })
+            {
+                try { if (Directory.Exists(d)) Directory.Delete(d, recursive: true); } catch { }
+                try { File.Delete(d + ".owner"); } catch { }
+            }
+        }
+    }
+}

--- a/AlRunner.Tests/ScratchDirsRunnerStartupTests.cs
+++ b/AlRunner.Tests/ScratchDirsRunnerStartupTests.cs
@@ -16,7 +16,10 @@
 //   - a directory whose `.owner` sidecar names a process that no longer exists -> removed
 //   - the legacy pid-named leaves (al-runner-deps/p<pid>, al-runner-navserver/user/<pid>)
 //     whose pid is dead -> removed
-//   - a directory whose owner is THIS test host (alive) -> kept, untouched
+//   - a directory whose owner is THIS test host (alive) -> kept, untouched, INCLUDING when the
+//     recorded wall-clock start time has drifted from the one the runner computes for this pid
+//     (see the ScratchDirs header: that drift is real, grows with the owner's age, and jumps for
+//     every sidecar at once on a clock step)
 //   - an unmarked directory with no pid in its name -> kept: the sweep never guesses by age,
 //     because several runners share one TMPDIR on a busy machine and an age heuristic is the
 //     only rule that can delete a live process's directory out from under it
@@ -28,6 +31,7 @@
 
 using System.Diagnostics;
 using System.Text;
+using AlRunner.Infrastructure;
 using Xunit;
 
 namespace AlRunner.Tests;
@@ -41,8 +45,9 @@ public class ScratchDirsRunnerStartupTests
     /// <summary>The sidecar format the runner's sweep reads. Written by hand here (rather than
     /// through the runner's own helper) so the format itself is pinned as a contract — a
     /// leftover from a killed run must still be recognised by a later build.</summary>
-    private static void WriteOwnerMarker(string dir, int pid, long startTicks)
-        => File.WriteAllText(dir + ".owner", $"pid={pid}\nstart={startTicks}\n");
+    private static void WriteOwnerMarker(string dir, int pid, long startTicks, long? startJiffies = null)
+        => File.WriteAllText(dir + ".owner",
+            $"pid={pid}\nstart={startTicks}\n" + (startJiffies is long j ? $"startjiffies={j}\n" : ""));
 
     /// <summary>A pid that no process on this machine has. Linux pid_max tops out at
     /// 4,194,304 and Windows pids are far smaller in practice, so counting down from two
@@ -113,6 +118,15 @@ public class ScratchDirsRunnerStartupTests
         File.WriteAllText(Path.Combine(liveMarked, "payload.bin"), "x");
         WriteOwnerMarker(liveMarked, me.Id, myStart);
 
+        // Same live owner, but with a wall-clock start time ten seconds off what the runner will
+        // compute for this pid — days of ordinary drift, or one clock step. The boot-relative value
+        // it also carries is what makes this survivable.
+        var liveSkewed = Path.Combine(temp, "al-runner-startup-sweep-tests", tag + "-live-skewed");
+        Directory.CreateDirectory(liveSkewed);
+        File.WriteAllText(Path.Combine(liveSkewed, "payload.bin"), "x");
+        WriteOwnerMarker(liveSkewed, me.Id, myStart + 10 * TimeSpan.TicksPerSecond,
+            ScratchDirs.TryReadStartJiffies(me.Id));
+
         var unmarked = Path.Combine(temp, "al-runner-startup-sweep-tests", tag + "-unmarked");
         Directory.CreateDirectory(unmarked);
         File.WriteAllText(Path.Combine(unmarked, "payload.bin"), "x");
@@ -132,11 +146,13 @@ public class ScratchDirsRunnerStartupTests
 
             Assert.True(File.Exists(Path.Combine(liveMarked, "payload.bin")), "a LIVE owner's scratch dir was deleted");
             Assert.True(File.Exists(liveMarked + ".owner"), "a LIVE owner's marker was deleted");
+            Assert.True(File.Exists(Path.Combine(liveSkewed, "payload.bin")),
+                "a LIVE owner's scratch dir was deleted because its recorded wall-clock start time had drifted");
             Assert.True(File.Exists(Path.Combine(unmarked, "payload.bin")), "an unmarked directory was deleted — the sweep must not guess by age");
         }
         finally
         {
-            foreach (var d in new[] { deadMarked, deadFlatMarked, legacyDeps, legacyNavUser, liveMarked, unmarked })
+            foreach (var d in new[] { deadMarked, deadFlatMarked, legacyDeps, legacyNavUser, liveMarked, liveSkewed, unmarked })
             {
                 try { if (Directory.Exists(d)) Directory.Delete(d, recursive: true); } catch { }
                 try { File.Delete(d + ".owner"); } catch { }

--- a/AlRunner.Tests/ScratchDirsTests.cs
+++ b/AlRunner.Tests/ScratchDirsTests.cs
@@ -1,0 +1,275 @@
+// ScratchDirsTests — the ownership rules behind the runner's temp-directory sweep (#2706).
+//
+// Every test here sweeps a PRIVATE root (the `tempRoot` parameter), never the real temp dir,
+// so the suite can run beside live runners on the same machine without touching their
+// scratch space. ScratchDirsRunnerStartupTests covers the real temp root end to end.
+//
+// The claims, both directions:
+//   - a directory whose recorded owner is dead (no such pid, or pid reused by a process with a
+//     different start time) is removed, sidecar included;
+//   - a directory whose owner is alive is never touched;
+//   - the two legacy pid-named shapes are swept by pid liveness;
+//   - an unmarked directory — however old — and anything not named al-runner-*/alrunner-* is
+//     never touched: the sweep does not guess by age.
+
+using System.Diagnostics;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ScratchDirsTests : IDisposable
+{
+    private readonly string _root;
+
+    public ScratchDirsTests()
+    {
+        // The private root is itself an owned scratch dir, so a killed test host leaves nothing.
+        _root = TestScratch.Dir("al-runner-scratchdirs-unit");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose() => ScratchDirs.Release(_root);
+
+    private static void WriteMarker(string dir, int pid, long startTicks)
+        => File.WriteAllText(ScratchDirs.MarkerPathFor(dir), $"pid={pid}\nstart={startTicks}\n");
+
+    private static string MakeDir(string path, string? payload = "payload")
+    {
+        Directory.CreateDirectory(path);
+        if (payload != null) File.WriteAllText(Path.Combine(path, "f.bin"), payload);
+        return path;
+    }
+
+    private static int DeadPid => ScratchDirsRunnerStartupTests.FindDeadPid();
+    private static int LivePid => Environment.ProcessId;
+    private static long LiveStartTicks
+    {
+        get { using var me = Process.GetCurrentProcess(); return me.StartTime.ToUniversalTime().Ticks; }
+    }
+
+    // ── Reserve / Create / Release ──────────────────────────────────────────────
+
+    [Fact]
+    public void Create_WritesSidecarNamingThisProcessAndItsStartTime()
+    {
+        var dir = ScratchDirs.Create(Path.Combine(_root, "al-runner-x", "a"));
+
+        Assert.True(Directory.Exists(dir));
+        var marker = ScratchDirs.MarkerPathFor(dir);
+        Assert.True(File.Exists(marker), "sidecar missing: " + marker);
+        Assert.True(ScratchDirs.TryReadOwner(marker, out var pid, out var start));
+        Assert.Equal(Environment.ProcessId, pid);
+        Assert.InRange(Math.Abs(start - LiveStartTicks), 0, 2 * TimeSpan.TicksPerSecond);
+        Assert.True(ScratchDirs.IsOwnedByThisProcess(dir));
+    }
+
+    [Fact]
+    public void Reserve_WritesSidecarButDoesNotCreateTheDirectory()
+    {
+        var dir = ScratchDirs.Reserve(Path.Combine(_root, "al-runner-y", "b"));
+
+        Assert.False(Directory.Exists(dir), "Reserve must not create the leaf — callers rely on 'never written into' staying observable");
+        Assert.True(File.Exists(ScratchDirs.MarkerPathFor(dir)));
+    }
+
+    [Fact]
+    public void Release_DeletesDirectoryAndSidecarNow()
+    {
+        var dir = ScratchDirs.Create(Path.Combine(_root, "al-runner-z", "c"));
+        File.WriteAllText(Path.Combine(dir, "f.bin"), "x");
+
+        ScratchDirs.Release(dir);
+
+        Assert.False(Directory.Exists(dir));
+        Assert.False(File.Exists(ScratchDirs.MarkerPathFor(dir)));
+        Assert.False(ScratchDirs.IsOwnedByThisProcess(dir));
+    }
+
+    // ── Sweep: sidecar-owned directories ────────────────────────────────────────
+
+    [Fact]
+    public void Sweep_KeepsDirectoryOwnedByLiveProcess()
+    {
+        var dir = ScratchDirs.Create(Path.Combine(_root, "al-runner-live", "d"));
+        File.WriteAllText(Path.Combine(dir, "f.bin"), "x");
+
+        var r = ScratchDirs.SweepStale(_root);
+
+        Assert.True(File.Exists(Path.Combine(dir, "f.bin")), "live owner's directory was deleted");
+        Assert.True(File.Exists(ScratchDirs.MarkerPathFor(dir)));
+        Assert.Empty(r.Removed);
+        Assert.Equal(1, r.Kept);
+    }
+
+    [Fact]
+    public void Sweep_RemovesDirectoryWhoseOwnerNoLongerExists_NestedAndFlat()
+    {
+        var nested = MakeDir(Path.Combine(_root, "al-runner-dead", "e"));
+        WriteMarker(nested, DeadPid, 1);
+        var flat = MakeDir(Path.Combine(_root, "al-runner-dead-flat-e"));
+        WriteMarker(flat, DeadPid, 1);
+
+        var r = ScratchDirs.SweepStale(_root);
+
+        Assert.False(Directory.Exists(nested));
+        Assert.False(File.Exists(ScratchDirs.MarkerPathFor(nested)));
+        Assert.False(Directory.Exists(flat));
+        Assert.False(File.Exists(ScratchDirs.MarkerPathFor(flat)));
+        Assert.Equal(2, r.Removed.Count);
+        Assert.Equal(0, r.Failed);
+    }
+
+    [Fact]
+    public void Sweep_TreatsReusedPidAsDeadOwner()
+    {
+        // Same pid as this (live) process, but a start time no process alive now can have.
+        var dir = MakeDir(Path.Combine(_root, "al-runner-reused", "f"));
+        WriteMarker(dir, LivePid, 1);
+
+        var r = ScratchDirs.SweepStale(_root);
+
+        Assert.False(Directory.Exists(dir), "pid reuse must not keep a dead owner's directory alive");
+        Assert.Single(r.Removed);
+    }
+
+    [Fact]
+    public void Sweep_MarkerWithoutStartTime_DecidesByPidLivenessAlone()
+    {
+        var dead = MakeDir(Path.Combine(_root, "al-runner-nostart", "dead"));
+        File.WriteAllText(ScratchDirs.MarkerPathFor(dead), $"pid={DeadPid}\n");
+        var live = MakeDir(Path.Combine(_root, "al-runner-nostart", "live"));
+        File.WriteAllText(ScratchDirs.MarkerPathFor(live), $"pid={LivePid}\n");
+
+        ScratchDirs.SweepStale(_root);
+
+        Assert.False(Directory.Exists(dead));
+        Assert.True(Directory.Exists(live));
+    }
+
+    [Fact]
+    public void Sweep_RemovesOrphanSidecarOfDeadOwner_KeepsLiveOnes()
+    {
+        var deadTarget = Path.Combine(_root, "al-runner-orphan", "gone");
+        Directory.CreateDirectory(Path.GetDirectoryName(deadTarget)!);
+        WriteMarker(deadTarget, DeadPid, 1);
+        var liveTarget = Path.Combine(_root, "al-runner-orphan", "reserved");
+        WriteMarker(liveTarget, LivePid, LiveStartTicks);
+
+        var r = ScratchDirs.SweepStale(_root);
+
+        Assert.False(File.Exists(ScratchDirs.MarkerPathFor(deadTarget)));
+        Assert.True(File.Exists(ScratchDirs.MarkerPathFor(liveTarget)), "a live Reserve()'d path's sidecar was removed");
+        Assert.Single(r.Removed);
+        Assert.Equal(1, r.Kept);
+    }
+
+    [Fact]
+    public void Sweep_UnparseableSidecar_LeavesBothSidecarAndDirectoryAlone()
+    {
+        var dir = MakeDir(Path.Combine(_root, "al-runner-weird", "g"));
+        File.WriteAllText(ScratchDirs.MarkerPathFor(dir), "not a marker\n");
+
+        var r = ScratchDirs.SweepStale(_root);
+
+        Assert.True(Directory.Exists(dir));
+        Assert.True(File.Exists(ScratchDirs.MarkerPathFor(dir)));
+        Assert.Empty(r.Removed);
+    }
+
+    // ── Sweep: legacy pid-named leaves ─────────────────────────────────────────
+
+    [Fact]
+    public void Sweep_LegacyPidNamedLeaves_RemovedWhenPidDead_KeptWhenAlive()
+    {
+        var dead = DeadPid;
+        var depsDead = MakeDir(Path.Combine(_root, "al-runner-deps", "p" + dead));
+        var depsLive = MakeDir(Path.Combine(_root, "al-runner-deps", "p" + LivePid));
+        var navDead = MakeDir(Path.Combine(_root, "al-runner-navserver", dead.ToString()));
+        var navLive = MakeDir(Path.Combine(_root, "al-runner-navserver", LivePid.ToString()));
+        var userDead = MakeDir(Path.Combine(_root, "al-runner-navserver", "user", dead.ToString()));
+        var userLive = MakeDir(Path.Combine(_root, "al-runner-navserver", "user", LivePid.ToString()));
+        // Same digits, wrong container: not a legacy leaf, so not the sweep's to delete.
+        var elsewhere = MakeDir(Path.Combine(_root, "al-runner-other", dead.ToString()));
+
+        var r = ScratchDirs.SweepStale(_root);
+
+        Assert.False(Directory.Exists(depsDead));
+        Assert.False(Directory.Exists(navDead));
+        Assert.False(Directory.Exists(userDead));
+        Assert.True(Directory.Exists(depsLive), "live pid's al-runner-deps leaf was deleted");
+        Assert.True(Directory.Exists(navLive), "live pid's al-runner-navserver leaf was deleted");
+        Assert.True(Directory.Exists(userLive), "live pid's al-runner-navserver/user leaf was deleted");
+        Assert.True(Directory.Exists(elsewhere), "a pid-looking name outside the legacy containers was deleted");
+        Assert.Equal(3, r.Removed.Count);
+        Assert.Equal(3, r.Kept);
+    }
+
+    // ── Sweep: what it must never touch ────────────────────────────────────────
+
+    [Fact]
+    public void Sweep_NeverDeletesUnmarkedDirectories_HoweverOld()
+    {
+        var old = MakeDir(Path.Combine(_root, "al-runner-legacy-fixture", Guid.NewGuid().ToString("N")));
+        Directory.SetLastWriteTimeUtc(old, DateTime.UtcNow.AddDays(-90));
+        Directory.SetLastWriteTimeUtc(Path.GetDirectoryName(old)!, DateTime.UtcNow.AddDays(-90));
+        var oldFlat = MakeDir(Path.Combine(_root, "al-runner-jobs-" + Guid.NewGuid().ToString("N")));
+        Directory.SetLastWriteTimeUtc(oldFlat, DateTime.UtcNow.AddDays(-90));
+
+        var r = ScratchDirs.SweepStale(_root);
+
+        Assert.True(File.Exists(Path.Combine(old, "f.bin")));
+        Assert.True(File.Exists(Path.Combine(oldFlat, "f.bin")));
+        Assert.Empty(r.Removed);
+    }
+
+    [Fact]
+    public void Sweep_IgnoresForeignNamesAndPlainFiles()
+    {
+        var foreign = MakeDir(Path.Combine(_root, "someone-elses-" + Guid.NewGuid().ToString("N")));
+        WriteMarker(foreign, DeadPid, 1);   // even with a dead-owner sidecar: wrong prefix, not ours
+        var file = Path.Combine(_root, "al-runner-systemapp-abc.app");
+        File.WriteAllText(file, "x");
+        var log = Path.Combine(_root, "al-runner-startup.log");
+        File.WriteAllText(log, "x");
+
+        var r = ScratchDirs.SweepStale(_root);
+
+        Assert.True(Directory.Exists(foreign));
+        Assert.True(File.Exists(ScratchDirs.MarkerPathFor(foreign)));
+        Assert.True(File.Exists(file));
+        Assert.True(File.Exists(log));
+        Assert.Empty(r.Removed);
+    }
+
+    [Fact]
+    public void Sweep_MissingRoot_IsNoOp()
+    {
+        var r = ScratchDirs.SweepStale(Path.Combine(_root, "does-not-exist"));
+        Assert.Empty(r.Removed);
+        Assert.Equal(0, r.Kept);
+    }
+
+    // ── Liveness primitive ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void IsOwnerAlive_CurrentProcess_True_DeadPid_False_ReusedPid_False()
+    {
+        Assert.True(ScratchDirs.IsOwnerAlive(LivePid, LiveStartTicks));
+        Assert.True(ScratchDirs.IsOwnerAlive(LivePid, 0));
+        Assert.False(ScratchDirs.IsOwnerAlive(DeadPid, 0));
+        Assert.False(ScratchDirs.IsOwnerAlive(LivePid, 1));
+    }
+
+    // ── The runner's own writers go through it ─────────────────────────────────
+
+    [Fact]
+    public void DepExtractionDir_Root_CarriesAnOwnerSidecar()
+    {
+        var root = DepExtractionDir.Root;
+        Assert.True(Directory.Exists(root));
+        Assert.True(File.Exists(ScratchDirs.MarkerPathFor(root)), "DepExtractionDir.Root has no .owner sidecar — a killed run's extraction dir could never be reclaimed");
+        Assert.True(ScratchDirs.TryReadOwner(ScratchDirs.MarkerPathFor(root), out var pid, out _));
+        Assert.Equal(Environment.ProcessId, pid);
+    }
+}

--- a/AlRunner.Tests/ScratchDirsTests.cs
+++ b/AlRunner.Tests/ScratchDirsTests.cs
@@ -10,7 +10,10 @@
 //   - a directory whose owner is alive is never touched;
 //   - the two legacy pid-named shapes are swept by pid liveness;
 //   - an unmarked directory — however old — and anything not named al-runner-*/alrunner-* is
-//     never touched: the sweep does not guess by age.
+//     never touched: the sweep does not guess by age;
+//   - a live owner whose recorded WALL-CLOCK start time has drifted from the one this process
+//     computes for it is still alive (the drift is real and unbounded — see the ScratchDirs
+//     header), while a mismatched BOOT-RELATIVE start time is still a dead owner.
 
 using System.Diagnostics;
 using AlRunner.Infrastructure;
@@ -31,8 +34,9 @@ public sealed class ScratchDirsTests : IDisposable
 
     public void Dispose() => ScratchDirs.Release(_root);
 
-    private static void WriteMarker(string dir, int pid, long startTicks)
-        => File.WriteAllText(ScratchDirs.MarkerPathFor(dir), $"pid={pid}\nstart={startTicks}\n");
+    private static void WriteMarker(string dir, int pid, long startTicks, long? startJiffies = null)
+        => File.WriteAllText(ScratchDirs.MarkerPathFor(dir),
+            $"pid={pid}\nstart={startTicks}\n" + (startJiffies is long j ? $"startjiffies={j}\n" : ""));
 
     private static string MakeDir(string path, string? payload = "payload")
     {
@@ -47,6 +51,9 @@ public sealed class ScratchDirsTests : IDisposable
     {
         get { using var me = Process.GetCurrentProcess(); return me.StartTime.ToUniversalTime().Ticks; }
     }
+    /// <summary>/proc/self/stat field 22. 0 off Linux, where it is not recorded.</summary>
+    private static long LiveStartJiffies => ScratchDirs.TryReadStartJiffies(Environment.ProcessId) ?? 0;
+    private const long TenSeconds = 10 * TimeSpan.TicksPerSecond;
 
     // ── Reserve / Create / Release ──────────────────────────────────────────────
 
@@ -131,6 +138,61 @@ public sealed class ScratchDirsTests : IDisposable
 
         Assert.False(Directory.Exists(dir), "pid reuse must not keep a dead owner's directory alive");
         Assert.Single(r.Removed);
+    }
+
+    [Fact]
+    public void Sweep_KeepsLiveOwner_WhenItsRecordedWallClockStartTimeHasDrifted()
+    {
+        // Process.StartTime on Linux is derived per process from (realtime now - /proc/uptime), so
+        // the value an owner records and the value a later sweeper computes for that same owner
+        // drift apart with the owner's age, and jump together on any clock step. Ten seconds is
+        // days of ordinary drift, or one chrony makestep. Both shapes must survive: with the
+        // boot-relative value recorded (the fix), and without it (a sidecar from an older build).
+        var bootRelative = MakeDir(Path.Combine(_root, "al-runner-drift", "boot-relative"));
+        WriteMarker(bootRelative, LivePid, LiveStartTicks + TenSeconds, LiveStartJiffies);
+        var wallClockOnly = MakeDir(Path.Combine(_root, "al-runner-drift", "wall-clock-only"));
+        WriteMarker(wallClockOnly, LivePid, LiveStartTicks + TenSeconds);
+
+        var r = ScratchDirs.SweepStale(_root);
+
+        Assert.True(File.Exists(Path.Combine(bootRelative, "f.bin")),
+            "a LIVE owner's directory was deleted because its recorded wall-clock start time had drifted");
+        Assert.True(File.Exists(Path.Combine(wallClockOnly, "f.bin")),
+            "a LIVE owner's directory with a pre-#2706 sidecar was deleted over wall-clock drift");
+        Assert.Empty(r.Removed);
+        Assert.Equal(2, r.Kept);
+    }
+
+    [Fact]
+    public void Sweep_BootRelativeStartTime_IsAuthoritative_SoPidReuseIsStillDetected()
+    {
+        // /proc/<pid>/stat field 22 is a Linux fact; off Linux there is nothing to be authoritative.
+        if (!OperatingSystem.IsLinux()) return;
+
+        // The wall-clock start time matches exactly — under the widened tolerance alone this would
+        // read as "same process". The boot-relative value says otherwise and wins, so the wider
+        // tolerance is a fallback, not a hole in pid-reuse detection.
+        var dir = MakeDir(Path.Combine(_root, "al-runner-jiffies", "reused"));
+        WriteMarker(dir, LivePid, LiveStartTicks, LiveStartJiffies + 1);
+
+        var r = ScratchDirs.SweepStale(_root);
+
+        Assert.False(Directory.Exists(dir),
+            "a mismatched boot-relative start time must be treated as a reused pid, i.e. a dead owner");
+        Assert.Single(r.Removed);
+    }
+
+    [Fact]
+    public void Create_RecordsTheBootRelativeStartTimeToo()
+    {
+        if (!OperatingSystem.IsLinux()) return;
+
+        var dir = ScratchDirs.Create(Path.Combine(_root, "al-runner-jf", "a"));
+
+        Assert.True(ScratchDirs.TryReadOwner(ScratchDirs.MarkerPathFor(dir), out var pid, out _, out var jiffies));
+        Assert.Equal(Environment.ProcessId, pid);
+        Assert.True(jiffies > 0, "sidecar carries no startjiffies= — the sweep would fall back to the drifting wall clock");
+        Assert.Equal(LiveStartJiffies, jiffies);
     }
 
     [Fact]

--- a/AlRunner.Tests/ServerAffectedSelectionCrossBundleFallbackTests.cs
+++ b/AlRunner.Tests/ServerAffectedSelectionCrossBundleFallbackTests.cs
@@ -125,7 +125,7 @@ public class ServerAffectedSelectionCrossBundleFallbackTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-server-affected-crossfallback", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-server-affected-crossfallback");
         Directory.CreateDirectory(root);
         var appDir = MakeAppBundle(root, "1.0.0.0");
         var testAppDir = MakeTestAppBundle(root);

--- a/AlRunner.Tests/ServerAffectedSelectionMultiSourcePathsTests.cs
+++ b/AlRunner.Tests/ServerAffectedSelectionMultiSourcePathsTests.cs
@@ -103,7 +103,7 @@ public class ServerAffectedSelectionMultiSourcePathsTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-server-affected-multi", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-server-affected-multi");
         Directory.CreateDirectory(root);
         var appDir = MakeAppBundle(root, """
         codeunit 60360 "Multi Affected Helper SX"
@@ -279,7 +279,7 @@ public class ServerAffectedSelectionMultiSourcePathsTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-server-affected-crossbundle", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-server-affected-crossbundle");
         Directory.CreateDirectory(root);
         var appDir = MakeAppBundleTwoHelpers(root);
         var testAppDir = MakeTestApp2Bundle(root);

--- a/AlRunner.Tests/ServerAffectedSelectionTests.cs
+++ b/AlRunner.Tests/ServerAffectedSelectionTests.cs
@@ -7,7 +7,7 @@ public class ServerAffectedSelectionTests
 {
     private static string MakeBundle(string helperABody)
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-server-affected", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-server-affected");
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "app.json"), """
         {
@@ -188,7 +188,7 @@ public class ServerAffectedSelectionTests
     // narrowing works WITHIN one object, across its procedures).
     private static string MakeMultiProcBundle()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-server-affected-scope", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-server-affected-scope");
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "app.json"), """
         {

--- a/AlRunner.Tests/ServerCancelTests.cs
+++ b/AlRunner.Tests/ServerCancelTests.cs
@@ -76,7 +76,7 @@ public class ServerCancelTests : IClassFixture<SharedCliServer>
     /// </summary>
     private static string MakeFastBundle(int variant)
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-server-cancel-fast", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-server-cancel-fast");
         Directory.CreateDirectory(dir);
         var baseId = 60310 + variant * 10;
         File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
@@ -130,7 +130,7 @@ public class ServerCancelTests : IClassFixture<SharedCliServer>
     /// </summary>
     private static string MakeBarrierBundle(int testCount = 2)
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-server-cancel-barrier", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-server-cancel-barrier");
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
         {
@@ -317,7 +317,7 @@ public class ServerCancelTests : IClassFixture<SharedCliServer>
         // cannot affect any other concurrently-running test's server. The server
         // blocks in TestBarrier.WaitForRelease() right after emitting each `test`
         // event; nothing releases it until this test explicitly does so below.
-        var barrierDir = Path.Combine(Path.GetTempPath(), "al-runner-cancel-barrier", Guid.NewGuid().ToString("N"));
+        var barrierDir = TestScratch.Dir("al-runner-cancel-barrier");
         Directory.CreateDirectory(barrierDir);
         var releaseFile = Path.Combine(barrierDir, "release");
 

--- a/AlRunner.Tests/ServerCrossAppOverloadRebindTests.cs
+++ b/AlRunner.Tests/ServerCrossAppOverloadRebindTests.cs
@@ -183,7 +183,7 @@ public class ServerCrossAppOverloadRebindTests
         TestArtifacts.SkipIfMissing();
 
         var c = dependencyFirst ? 1 : 2;
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-xapp-overload", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-xapp-overload");
         Directory.CreateDirectory(root);
         var appDir = MakeAppBundle(root, c, LibBefore(c));
         var testAppDir = MakeTestAppBundle(root, c);

--- a/AlRunner.Tests/ServerCrossAppStaleGenerationTests.cs
+++ b/AlRunner.Tests/ServerCrossAppStaleGenerationTests.cs
@@ -70,8 +70,7 @@ public class ServerCrossAppStaleGenerationTests : IClassFixture<SharedCliServer>
     /// cannot collide inside it because <see cref="MakeLibTestPair"/> now gives each
     /// variant its own app ids, object ids and object names (see below).
     /// </summary>
-    private static readonly string CacheDir = Path.Combine(
-        Path.GetTempPath(), "al-runner-xapp-stale-gen-cache", Guid.NewGuid().ToString("N"));
+    private static readonly string CacheDir = TestScratch.Dir("al-runner-xapp-stale-gen-cache");
 
     /// <param name="variant">
     /// #2377: which fact is asking. Not cosmetic — it is what makes sharing one server

--- a/AlRunner.Tests/ServerCrossBundleModuleIdentityDedupTests.cs
+++ b/AlRunner.Tests/ServerCrossBundleModuleIdentityDedupTests.cs
@@ -42,7 +42,7 @@ public class ServerCrossBundleModuleIdentityDedupTests
 {
     private static (string appDir, string testDir) MakeAppTestPair()
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-server-xbundle-dedup", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-server-xbundle-dedup");
         var appDir = Path.Combine(root, "app");
         var testDir = Path.Combine(root, "tests");
         Directory.CreateDirectory(appDir);
@@ -160,7 +160,7 @@ public class ServerCrossBundleModuleIdentityDedupTests
         TestArtifacts.SkipIfMissing();
 
         var (appDir, testDir) = MakeAppTestPair();
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-xbundle-dedup-cache", Guid.NewGuid().ToString("N"));
+        var cacheDir = TestScratch.Dir("al-runner-server-xbundle-dedup-cache");
         await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
 
         // Same order as the issue's Leg 2 (`sourcePaths [app, tests]`) — the exact

--- a/AlRunner.Tests/ServerDuplicateSourcePathTests.cs
+++ b/AlRunner.Tests/ServerDuplicateSourcePathTests.cs
@@ -25,7 +25,7 @@ public class ServerDuplicateSourcePathTests
 {
     private static string MakeBundle(string dirName, string appId, int idFrom, int codeunitId)
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-server-dup-2136", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-server-dup-2136");
         var dir = Path.Combine(root, dirName);
         Directory.CreateDirectory(dir);
 
@@ -72,7 +72,7 @@ public class ServerDuplicateSourcePathTests
         TestArtifacts.SkipIfMissing();
 
         var dir = MakeBundle("only", "d4e5f6a7-2136-4a1b-9c3d-000000000001", 62410, 62410);
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-dup-2136-cache", Guid.NewGuid().ToString("N"));
+        var cacheDir = TestScratch.Dir("al-runner-server-dup-2136-cache");
         await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
 
         var req = JsonSerializer.Serialize(new
@@ -101,7 +101,7 @@ public class ServerDuplicateSourcePathTests
 
         var a = MakeBundle("first", "d4e5f6a7-2136-4a1b-9c3d-000000000002", 62420, 62420);
         var b = MakeBundle("second", "d4e5f6a7-2136-4a1b-9c3d-000000000003", 62425, 62425);
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-dup-2136-cache", Guid.NewGuid().ToString("N"));
+        var cacheDir = TestScratch.Dir("al-runner-server-dup-2136-cache");
         await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
 
         var req = JsonSerializer.Serialize(new

--- a/AlRunner.Tests/ServerEmitExclusionDiagnosticTests.cs
+++ b/AlRunner.Tests/ServerEmitExclusionDiagnosticTests.cs
@@ -20,7 +20,7 @@ public sealed class ServerEmitExclusionDiagnosticTests
 {
     private static string WriteBundle()
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-server-emitexcl-2207", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-server-emitexcl-2207");
         Directory.CreateDirectory(root);
         File.WriteAllText(Path.Combine(root, "app.json"), """
         {

--- a/AlRunner.Tests/ServerExecuteIterationsTests.cs
+++ b/AlRunner.Tests/ServerExecuteIterationsTests.cs
@@ -688,7 +688,7 @@ public class ServerExecuteIterationsTests : IClassFixture<SharedCliServer>
     public async Task Execute_RecordDrivenRepeat_EveryPassCarriesTheRecordPosition()
     {
         TestArtifacts.SkipIfMissing();
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-iter-record", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-iter-record");
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "LoopRows.Table.al"), """
         table 60328 "Iter Loop Rows SX"
@@ -767,7 +767,7 @@ public class ServerExecuteIterationsTests : IClassFixture<SharedCliServer>
     public async Task Execute_LoopInATableTrigger_IsTrackedUnderItsQualifiedScopeName()
     {
         TestArtifacts.SkipIfMissing();
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-iter-trigger", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-iter-trigger");
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "Trig.Table.al"), """
         table 60331 "Iter Trigger SX"
@@ -840,7 +840,7 @@ public class ServerExecuteIterationsTests : IClassFixture<SharedCliServer>
     public async Task Execute_TwoBundles_LoopIdsUniquePerResponse_AndMessageTagsResolve()
     {
         TestArtifacts.SkipIfMissing();
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-iter-multi", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-iter-multi");
         var a = Path.Combine(root, "a"); var b = Path.Combine(root, "b");
         Directory.CreateDirectory(a); Directory.CreateDirectory(b);
         File.WriteAllText(Path.Combine(a, "A.al"),

--- a/AlRunner.Tests/ServerExecuteMessagesTests.cs
+++ b/AlRunner.Tests/ServerExecuteMessagesTests.cs
@@ -159,7 +159,7 @@ public class ServerExecuteMessagesTests : IClassFixture<SharedCliServer>
     public async Task RunTests_MessageWithoutHandler_StillRaisesUnhandledUI()
     {
         TestArtifacts.SkipIfMissing();
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-msg-unhandled-ui-tests", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-msg-unhandled-ui-tests");
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "app.json"), """
         {

--- a/AlRunner.Tests/ServerStreamingTests.cs
+++ b/AlRunner.Tests/ServerStreamingTests.cs
@@ -43,7 +43,7 @@ public class ServerStreamingTests : IClassFixture<SharedCliServer>
     // ID (offset by variant*10 from 60200) — see the class doc comment.
     private static string MakeMixedBundle(int variant)
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-server-streaming", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-server-streaming");
         Directory.CreateDirectory(dir);
         var baseId = 60200 + variant * 10;
         File.WriteAllText(Path.Combine(dir, "app.json"), $$"""

--- a/AlRunner.Tests/ServerTestIsolationTests.cs
+++ b/AlRunner.Tests/ServerTestIsolationTests.cs
@@ -52,7 +52,7 @@ public class ServerTestIsolationTests : IClassFixture<SharedCliServer>
     // share a server process.
     private static string MakeIsolationBundle(int variant)
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-server-isolation", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-server-isolation");
         Directory.CreateDirectory(dir);
         var baseId = 60170 + variant * 10;
         File.WriteAllText(Path.Combine(dir, "app.json"), $$"""

--- a/AlRunner.Tests/ServerTests.cs
+++ b/AlRunner.Tests/ServerTests.cs
@@ -54,7 +54,7 @@ public class ServerTests : IClassFixture<SharedCliServer>
 
     private static string MakeTempBundle()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-server-tests", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-server-tests");
         Directory.CreateDirectory(dir);
         foreach (var f in Directory.GetFiles(FixtureSrc))
             File.Copy(f, Path.Combine(dir, Path.GetFileName(f)));
@@ -138,7 +138,7 @@ public class ServerTests : IClassFixture<SharedCliServer>
     // execute must actually invoke OnRun, so the AL Error text surfaces as a Fail.
     private static string MakeExecuteBundle()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-server-exec", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-server-exec");
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "app.json"), """
         {
@@ -535,7 +535,7 @@ public class ServerTests : IClassFixture<SharedCliServer>
     // idRange in this file (60100-60199, 60120-60129, 60160-60169).
     private static string MakeAppTestPair(out string appDir, out string testDir)
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-server-multi", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-server-multi");
         appDir = Path.Combine(root, "App");
         testDir = Path.Combine(root, "Test");
         Directory.CreateDirectory(appDir);

--- a/AlRunner.Tests/SharedCliServerTests.cs
+++ b/AlRunner.Tests/SharedCliServerTests.cs
@@ -49,7 +49,7 @@ public class SharedCliServerTests
     // to avoid it).
     private static string MakeIsolationProbeBundle()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-shared-server-isolation", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-shared-server-isolation");
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "app.json"), """
         {

--- a/AlRunner.Tests/SiblingSourceDepProvisioningReportingTests.cs
+++ b/AlRunner.Tests/SiblingSourceDepProvisioningReportingTests.cs
@@ -216,7 +216,7 @@ public class SiblingSourceDepProvisioningReportingTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-ssd-missing", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-ssd-missing");
         var mainDir = Path.Combine(root, "main");
         var sidekickDir = Path.Combine(root, "sidekick");
         var emptyCacheDir = Path.Combine(root, "empty-cache");
@@ -245,7 +245,7 @@ public class SiblingSourceDepProvisioningReportingTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-ssd-oldver", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-ssd-oldver");
         var mainDir = Path.Combine(root, "main");
         var sidekickDir = Path.Combine(root, "sidekick");
         var cacheDir = Path.Combine(root, "cache");
@@ -274,7 +274,7 @@ public class SiblingSourceDepProvisioningReportingTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-ssd-badmanifest", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-ssd-badmanifest");
         var mainDir = Path.Combine(root, "main");
         var sidekickDir = Path.Combine(root, "sidekick");
         var mainId = "5cd30000-0000-4000-8000-0000000000e1";

--- a/AlRunner.Tests/SourceDepCacheEnumMetadataTests.cs
+++ b/AlRunner.Tests/SourceDepCacheEnumMetadataTests.cs
@@ -99,7 +99,7 @@ public class SourceDepCacheEnumMetadataTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var scratchRoot = Path.Combine(Path.GetTempPath(), "al-runner-depcache-enum", Guid.NewGuid().ToString("N"));
+        var scratchRoot = TestScratch.Dir("al-runner-depcache-enum");
         var depDir = Path.Combine(scratchRoot, "dep-app");
         var testsDir = Path.Combine(scratchRoot, "tests-app");
         var alCacheDir = Path.Combine(scratchRoot, "al-out");

--- a/AlRunner.Tests/SourceDepSymbolsWithoutPackageCacheTests.cs
+++ b/AlRunner.Tests/SourceDepSymbolsWithoutPackageCacheTests.cs
@@ -72,8 +72,7 @@ public class SourceDepSymbolsWithoutPackageCacheTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var scratchRoot = Path.Combine(
-            Path.GetTempPath(), "al-runner-srcdep-nopkgcache", Guid.NewGuid().ToString("N"));
+        var scratchRoot = TestScratch.Dir("al-runner-srcdep-nopkgcache");
         var depDir = Path.Combine(scratchRoot, "dep-app");
         var testsDir = Path.Combine(scratchRoot, "tests-app");
         var alCacheDir = Path.Combine(scratchRoot, "al-out");

--- a/AlRunner.Tests/StartupJitModeTests.cs
+++ b/AlRunner.Tests/StartupJitModeTests.cs
@@ -39,7 +39,7 @@ public sealed class StartupJitModeTests : IDisposable
 
     public StartupJitModeTests()
     {
-        _scratch = Path.Combine(Path.GetTempPath(), "al-runner-jitmode", Guid.NewGuid().ToString("N"));
+        _scratch = TestScratch.Dir("al-runner-jitmode");
         Directory.CreateDirectory(_scratch);
     }
 

--- a/AlRunner.Tests/SuiteAbortOnTimeoutTests.cs
+++ b/AlRunner.Tests/SuiteAbortOnTimeoutTests.cs
@@ -45,7 +45,7 @@ public sealed class SuiteAbortOnTimeoutTests : IDisposable
 
     public SuiteAbortOnTimeoutTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-suite-abort-on-timeout", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-suite-abort-on-timeout");
         Directory.CreateDirectory(_root);
         WriteFixture(_root);
         _resumeRoot = Path.Combine(Path.GetTempPath(), "al-runner-suite-abort-resume", Guid.NewGuid().ToString("N"));

--- a/AlRunner.Tests/SuiteEnumerationTests.cs
+++ b/AlRunner.Tests/SuiteEnumerationTests.cs
@@ -39,7 +39,7 @@ public sealed class SuiteEnumerationTests : IDisposable
 
     public SuiteEnumerationTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-suite-enum", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-suite-enum");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/TddModeTests.cs
+++ b/AlRunner.Tests/TddModeTests.cs
@@ -32,7 +32,7 @@ public sealed class TddModeTests : IDisposable
 
     public TddModeTests()
     {
-        _scratch = Path.Combine(Path.GetTempPath(), "al-runner-tdd", Guid.NewGuid().ToString("N"));
+        _scratch = TestScratch.Dir("al-runner-tdd");
         Directory.CreateDirectory(_scratch);
     }
 

--- a/AlRunner.Tests/TddWatchTests.cs
+++ b/AlRunner.Tests/TddWatchTests.cs
@@ -62,7 +62,7 @@ public class TddWatchTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var bundle = Path.Combine(Path.GetTempPath(), "al-runner-tdd-watch", Guid.NewGuid().ToString("N"));
+        var bundle = TestScratch.Dir("al-runner-tdd-watch");
         Directory.CreateDirectory(bundle);
         foreach (var f in Directory.GetFiles(FixtureSrc))
             File.Copy(f, Path.Combine(bundle, Path.GetFileName(f)));

--- a/AlRunner.Tests/TestArtifactsGateTests.cs
+++ b/AlRunner.Tests/TestArtifactsGateTests.cs
@@ -29,7 +29,7 @@ public class TestArtifactsGateTests
 
     private static string NewTempHome()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-artifacts-gate", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-artifacts-gate");
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/AlRunner.Tests/TestBuildConfigRunArgsTests.cs
+++ b/AlRunner.Tests/TestBuildConfigRunArgsTests.cs
@@ -44,8 +44,7 @@ public sealed class TestBuildConfigRunArgsTests
     [Fact]
     public void RunArgs_MissingBuildOutput_ThrowsNamingSearchedPath()
     {
-        var missingProjectDir = Path.Combine(
-            Path.GetTempPath(), "al-runner-issue-1808-" + Guid.NewGuid().ToString("N"));
+        var missingProjectDir = TestScratch.FlatDir("al-runner-issue-1808-");
 
         var ex = Assert.Throws<FileNotFoundException>(
             () => TestBuildConfig.RunArgs(missingProjectDir));

--- a/AlRunner.Tests/TestFilterFlagTests.cs
+++ b/AlRunner.Tests/TestFilterFlagTests.cs
@@ -44,7 +44,7 @@ public sealed class TestFilterFlagTests : IDisposable
 
     public TestFilterFlagTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-test-filter-flag", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-test-filter-flag");
         Directory.CreateDirectory(_root);
         WriteFixture(_root);
     }

--- a/AlRunner.Tests/TestIsolationCodeunitVariableSharingTests.cs
+++ b/AlRunner.Tests/TestIsolationCodeunitVariableSharingTests.cs
@@ -39,7 +39,7 @@ public sealed class TestIsolationCodeunitVariableSharingTests : IDisposable
 
     public TestIsolationCodeunitVariableSharingTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-isolation-variable-sharing", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-isolation-variable-sharing");
         Directory.CreateDirectory(_root);
         WriteFixture(_root);
     }

--- a/AlRunner.Tests/TestIsolationMethodAliasTests.cs
+++ b/AlRunner.Tests/TestIsolationMethodAliasTests.cs
@@ -33,7 +33,7 @@ public sealed class TestIsolationMethodAliasTests : IDisposable
 
     public TestIsolationMethodAliasTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-isolation-method-alias", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-isolation-method-alias");
         Directory.CreateDirectory(_root);
         WriteFixture(_root);
     }

--- a/AlRunner.Tests/TestPageBooleanRecBoundDispatchTests.cs
+++ b/AlRunner.Tests/TestPageBooleanRecBoundDispatchTests.cs
@@ -39,7 +39,7 @@ public sealed class TestPageBooleanRecBoundDispatchTests : IDisposable
 
     public TestPageBooleanRecBoundDispatchTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-bool-recbound-dispatch", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-bool-recbound-dispatch");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/TestPageCurrFieldNoDispatchTests.cs
+++ b/AlRunner.Tests/TestPageCurrFieldNoDispatchTests.cs
@@ -37,7 +37,7 @@ public sealed class TestPageCurrFieldNoDispatchTests : IDisposable
 
     public TestPageCurrFieldNoDispatchTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-currfieldno-dispatch", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-currfieldno-dispatch");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/TestPageDrillDownDispatchTests.cs
+++ b/AlRunner.Tests/TestPageDrillDownDispatchTests.cs
@@ -47,7 +47,7 @@ public sealed class TestPageDrillDownDispatchTests : IDisposable
 
     public TestPageDrillDownDispatchTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-drilldown-dispatch", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-drilldown-dispatch");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/TestPageExtensionActionWithPartDispatchTests.cs
+++ b/AlRunner.Tests/TestPageExtensionActionWithPartDispatchTests.cs
@@ -52,7 +52,7 @@ public sealed class TestPageExtensionActionWithPartDispatchTests : IDisposable
 
     public TestPageExtensionActionWithPartDispatchTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-pageext-part-action-dispatch", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-pageext-part-action-dispatch");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/TestPageFieldCaptionCaptureTests.cs
+++ b/AlRunner.Tests/TestPageFieldCaptionCaptureTests.cs
@@ -39,7 +39,7 @@ public sealed class TestPageFieldCaptionCaptureTests : IDisposable
     public TestPageFieldCaptionCaptureTests(BcEngineFixture engine)
     {
         _engine = engine;
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-field-caption-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-field-caption-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/TestPageMinMaxValueDispatchTests.cs
+++ b/AlRunner.Tests/TestPageMinMaxValueDispatchTests.cs
@@ -34,7 +34,7 @@ public sealed class TestPageMinMaxValueDispatchTests : IDisposable
 
     public TestPageMinMaxValueDispatchTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-minmax-dispatch", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-minmax-dispatch");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/TestPagePartAdoptedFromHostTests.cs
+++ b/AlRunner.Tests/TestPagePartAdoptedFromHostTests.cs
@@ -52,7 +52,7 @@ public sealed class TestPagePartAdoptedFromHostTests : IDisposable
 
     public TestPagePartAdoptedFromHostTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-testpage-part-adopted-from-host", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-testpage-part-adopted-from-host");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/TestPagePartLinkedRowLoadTests.cs
+++ b/AlRunner.Tests/TestPagePartLinkedRowLoadTests.cs
@@ -62,7 +62,7 @@ public class TestPagePartLinkedRowLoadTests
 
     private static string WriteBundle()
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-testpage-part-linked-row-load-2677", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-testpage-part-linked-row-load-2677");
         Directory.CreateDirectory(root);
 
         File.WriteAllText(Path.Combine(root, "app.json"), """

--- a/AlRunner.Tests/TestPageSourceTableTemporaryIntegerTests.cs
+++ b/AlRunner.Tests/TestPageSourceTableTemporaryIntegerTests.cs
@@ -32,7 +32,7 @@ public sealed class TestPageSourceTableTemporaryIntegerTests : IDisposable
 
     public TestPageSourceTableTemporaryIntegerTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-temp-integer-testpage", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-temp-integer-testpage");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/TestScratch.cs
+++ b/AlRunner.Tests/TestScratch.cs
@@ -1,0 +1,30 @@
+// TestScratch — per-run scratch directories for tests, owned and reclaimable (#2706).
+//
+// Tests in this project hand the runner fresh GUID-named directories under Path.GetTempPath()
+// as bundles and — the expensive case — as `--cache` roots, into which the runner then builds a
+// complete BC cache (~273 MB: r2r-chunks, bc-symbols, the Cecil-rewritten Ncl, ...). Written as
+// `Path.Combine(Path.GetTempPath(), "<name>", Guid.NewGuid().ToString("N"))` and never deleted,
+// those had accumulated 126 GB on one machine; and on a stock Linux desktop /tmp is a tmpfs,
+// so a contributor without a TMPDIR redirect pays that in RAM.
+//
+// Both helpers return exactly the path shape the hand-written expression produced, so a call
+// site's semantics are unchanged (the leaf is NOT created here — some tests rely on observing
+// whether the runner created it). What changes is ownership: ScratchDirs writes a `.owner`
+// sidecar naming this test host, deletes every reserved directory at the host's ProcessExit,
+// and the next runner start reclaims whatever a KILLED host left behind. A test that also
+// deletes its directory itself keeps doing so; the sidecar is a second net, not a replacement.
+
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Tests;
+
+internal static class TestScratch
+{
+    /// <summary><c>&lt;temp&gt;/&lt;prefix&gt;/&lt;guid&gt;</c> — the nested shape, one container per fixture kind.</summary>
+    public static string Dir(string prefix)
+        => ScratchDirs.Reserve(Path.Combine(Path.GetTempPath(), prefix, Guid.NewGuid().ToString("N")));
+
+    /// <summary><c>&lt;temp&gt;/&lt;prefix&gt;&lt;guid&gt;</c> — the flat shape (prefix usually ends in '-').</summary>
+    public static string FlatDir(string prefix)
+        => ScratchDirs.Reserve(Path.Combine(Path.GetTempPath(), prefix + Guid.NewGuid().ToString("N")));
+}

--- a/AlRunner.Tests/TestTimeoutFlagTests.cs
+++ b/AlRunner.Tests/TestTimeoutFlagTests.cs
@@ -32,7 +32,7 @@ public sealed class TestTimeoutFlagTests : IDisposable
 
     public TestTimeoutFlagTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-test-timeout-flag", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-test-timeout-flag");
         Directory.CreateDirectory(_root);
         WriteFixture(_root);
     }

--- a/AlRunner.Tests/VirtualTableBitClearingTests.cs
+++ b/AlRunner.Tests/VirtualTableBitClearingTests.cs
@@ -58,7 +58,7 @@ public sealed class VirtualTableBitClearingTests : IDisposable
     public VirtualTableBitClearingTests(BcEngineFixture engine)
     {
         _engine = engine;
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-2543-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-2543-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/WatchBurstSwitchTests.cs
+++ b/AlRunner.Tests/WatchBurstSwitchTests.cs
@@ -128,7 +128,7 @@ public class WatchBurstSwitchTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var bundle = Path.Combine(Path.GetTempPath(), "al-runner-watch-burst", Guid.NewGuid().ToString("N"));
+        var bundle = TestScratch.Dir("al-runner-watch-burst");
         Directory.CreateDirectory(bundle);
         File.Copy(Path.Combine(FixtureRoot, "app.json"), Path.Combine(bundle, "app.json"));
         File.Copy(Path.Combine(FixtureRoot, "Assert.Codeunit.al"), Path.Combine(bundle, "Assert.Codeunit.al"));

--- a/AlRunner.Tests/WatchFullRebuildReasonTests.cs
+++ b/AlRunner.Tests/WatchFullRebuildReasonTests.cs
@@ -39,7 +39,7 @@ public class WatchFullRebuildReasonTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var bundle = Path.Combine(Path.GetTempPath(), "al-runner-watch-fullrebuild", Guid.NewGuid().ToString("N"));
+        var bundle = TestScratch.Dir("al-runner-watch-fullrebuild");
         Directory.CreateDirectory(bundle);
         foreach (var f in Directory.GetFiles(FixtureSrc))
             File.Copy(f, Path.Combine(bundle, Path.GetFileName(f)));

--- a/AlRunner.Tests/WatchPageMetadataReloadDeleteTests.cs
+++ b/AlRunner.Tests/WatchPageMetadataReloadDeleteTests.cs
@@ -77,7 +77,7 @@ public class WatchPageMetadataReloadDeleteTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var bundle = Path.Combine(Path.GetTempPath(), "al-runner-watch-pagemeta-delete", Guid.NewGuid().ToString("N"));
+        var bundle = TestScratch.Dir("al-runner-watch-pagemeta-delete");
         CopyDir(FixtureRoot, bundle);
         var gonePagePath = Path.Combine(bundle, "RPRGone.Page.al");
         Assert.True(File.Exists(gonePagePath));

--- a/AlRunner.Tests/WatchPageMetadataReloadTests.cs
+++ b/AlRunner.Tests/WatchPageMetadataReloadTests.cs
@@ -84,7 +84,7 @@ public class WatchPageMetadataReloadTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var bundle = Path.Combine(Path.GetTempPath(), "al-runner-watch-pagemeta", Guid.NewGuid().ToString("N"));
+        var bundle = TestScratch.Dir("al-runner-watch-pagemeta");
         CopyDir(Path.Combine(FixtureRoot, "R3Pages"), Path.Combine(bundle, "R3Pages"));
         CopyDir(Path.Combine(FixtureRoot, "R3Driver"), Path.Combine(bundle, "R3Driver"));
         var driverTestsPath = Path.Combine(bundle, "R3Driver", "WPMRTests.Codeunit.al");

--- a/AlRunner.Tests/WatchRadRealDependencyTests.cs
+++ b/AlRunner.Tests/WatchRadRealDependencyTests.cs
@@ -45,7 +45,7 @@ public class WatchRadRealDependencyTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var bundle = Path.Combine(Path.GetTempPath(), "al-runner-watch-rad-msdep", Guid.NewGuid().ToString("N"));
+        var bundle = TestScratch.Dir("al-runner-watch-rad-msdep");
         Directory.CreateDirectory(bundle);
         foreach (var f in Directory.GetFiles(FixtureSrc))
             File.Copy(f, Path.Combine(bundle, Path.GetFileName(f)));

--- a/AlRunner.Tests/WatchSourceTests.cs
+++ b/AlRunner.Tests/WatchSourceTests.cs
@@ -16,7 +16,7 @@ public sealed class WatchSourceTests
 {
     private static string NewTempDir()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-watchsource-tests", Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-watchsource-tests");
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/AlRunner.Tests/WatchTests.cs
+++ b/AlRunner.Tests/WatchTests.cs
@@ -34,7 +34,7 @@ public class WatchTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var bundle = Path.Combine(Path.GetTempPath(), "al-runner-watch", Guid.NewGuid().ToString("N"));
+        var bundle = TestScratch.Dir("al-runner-watch");
         Directory.CreateDirectory(bundle);
         foreach (var f in Directory.GetFiles(FixtureSrc))
             File.Copy(f, Path.Combine(bundle, Path.GetFileName(f)));

--- a/AlRunner/AppLoader.cs
+++ b/AlRunner/AppLoader.cs
@@ -730,8 +730,10 @@ public static class AppLoader
 
     private static List<string> WriteDllsToTempFallback(IReadOnlyList<byte[]> dlls)
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-r2r-chunks-fallback", Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(dir);
+        // Per-process scratch, owned via ScratchDirs (#2706): removed at exit, reclaimed by the
+        // next start if this process is killed. Previously never deleted at all.
+        var dir = AlRunner.Infrastructure.ScratchDirs.Create(
+            Path.Combine(Path.GetTempPath(), "al-runner-r2r-chunks-fallback", Guid.NewGuid().ToString("N")));
         var paths = new List<string>(dlls.Count);
         for (int i = 0; i < dlls.Count; i++)
         {

--- a/AlRunner/Infrastructure/CacheRoots.cs
+++ b/AlRunner/Infrastructure/CacheRoots.cs
@@ -104,7 +104,11 @@ public static class CacheRoots
         }
         else
         {
-            root = Path.Combine(Path.GetTempPath(), "al-runner-no-cache-" + Guid.NewGuid().ToString("N"));
+            // Reserved (not created — nothing may ever write into it) through ScratchDirs
+            // (#2706) so a run killed before CleanupThrowawayRoot fires is reclaimed by the
+            // next runner start instead of leaking a full cache per killed --no-cache run.
+            root = ScratchDirs.Reserve(
+                Path.Combine(Path.GetTempPath(), "al-runner-no-cache-" + Guid.NewGuid().ToString("N")));
             Environment.SetEnvironmentVariable(NoCacheRootEnvVar, root);
         }
         _override = root;
@@ -127,12 +131,7 @@ public static class CacheRoots
     public static void CleanupThrowawayRoot()
     {
         if (_throwawayRoot == null) return;
-        try
-        {
-            if (Directory.Exists(_throwawayRoot)) Directory.Delete(_throwawayRoot, recursive: true);
-        }
-        catch (IOException) { }
-        catch (UnauthorizedAccessException) { }
+        ScratchDirs.Release(_throwawayRoot);   // best-effort: deletes the root and its .owner sidecar
     }
 
     /// <summary>

--- a/AlRunner/Infrastructure/DepExtractionDir.cs
+++ b/AlRunner/Infrastructure/DepExtractionDir.cs
@@ -20,8 +20,9 @@
 // rewritten on every miss — there was never any cross-process reuse to preserve.
 //
 // The per-process root stays UNDER the shared al-runner-deps parent so anything that cleans
-// that parent still finds it, and it is removed on normal process exit. A killed process leaves
-// its root behind, exactly as the previous shared directory was left behind forever.
+// that parent still finds it. It is created through ScratchDirs (#2706), which removes it on
+// normal process exit and — because the sidecar records the owning pid + start time — lets the
+// next runner start reclaim it when this process was killed instead.
 
 namespace AlRunner.Infrastructure;
 
@@ -37,13 +38,7 @@ internal static class DepExtractionDir
 
     private static readonly Lazy<string> _root = new(() =>
     {
-        var root = RootForProcess(Environment.ProcessId);
-        Directory.CreateDirectory(root);
-        AppDomain.CurrentDomain.ProcessExit += (_, _) =>
-        {
-            try { Directory.Delete(root, recursive: true); } catch { }
-        };
-        return root;
+        return ScratchDirs.Create(RootForProcess(Environment.ProcessId));
     });
 
     /// <summary>This process's extraction root, under the shared al-runner-deps parent.</summary>

--- a/AlRunner/Infrastructure/ParallelFanOut.cs
+++ b/AlRunner/Infrastructure/ParallelFanOut.cs
@@ -219,8 +219,10 @@ internal static class ParallelFanOut
         var weighted = bundles.Select(b => (Name: b, Weight: WeighBundle(b))).ToList();
         var shards = ShardPlanner.Plan(weighted, jobs);
 
-        var tempDir = Path.Combine(Path.GetTempPath(), "al-runner-jobs-" + Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(tempDir);
+        // ScratchDirs (#2706): the delete at the end of this method only runs on a clean exit,
+        // and a --jobs run is exactly the kind that gets killed; the sidecar lets the next
+        // runner start reclaim it.
+        var tempDir = ScratchDirs.Create(Path.Combine(Path.GetTempPath(), "al-runner-jobs-" + Guid.NewGuid().ToString("N")));
 
         var exe = Environment.ProcessPath ?? "dotnet";
         var asm = System.Reflection.Assembly.GetEntryAssembly()?.Location;
@@ -307,7 +309,7 @@ internal static class ParallelFanOut
                                "excluded from the totals; see that shard's output for which one");
         Console.WriteLine("=================================================================");
 
-        try { Directory.Delete(tempDir, recursive: true); } catch { }
+        ScratchDirs.Release(tempDir);
         return worst;
     }
 

--- a/AlRunner/Infrastructure/ScratchDirs.cs
+++ b/AlRunner/Infrastructure/ScratchDirs.cs
@@ -36,6 +36,24 @@
 // unmarked litter is either legacy (a one-time manual `rm`) or from an old build; neither is
 // worth the risk of pulling a directory out from under a live run.
 //
+// The liveness test compares a BOOT-RELATIVE start time, not a wall-clock one. Process.StartTime
+// on Linux is not anchored to the kernel's /proc/stat btime: each process derives its own base as
+// (realtime now - /proc/uptime) the first time it asks, so two processes asking at different
+// moments get bases that differ by the realtime-against-boottime skew accumulated in between.
+// Measured on the reporting machine: .NET puts pid 1's StartTime at unix 1788245948.07 while
+// btime + /proc/<pid>/stat field 22 gives 1788245947.13 — 0.95 s apart after 4.2 days of uptime,
+// about 2.6 ppm. Under the old 2-second tolerance a --watch or --server session crossed it after
+// roughly nine days and had its scratch directory deleted while still using it; a clock STEP
+// (chrony makestep, a VM snapshot restore, suspend/resume) crossed it instantly and for EVERY
+// sidecar on the machine at once, so one runner start could delete every live owner's directory,
+// including a test host's in-use --cache root — a wrong test result rather than a visible failure.
+// So the sidecar also records /proc/<pid>/stat field 22 (`startjiffies=`), which both the writer
+// and the sweeper compute identically because it has no wall-clock anchor at all, and that value
+// decides whenever it is present on both sides. The wall-clock comparison remains only as the
+// fallback for a sidecar written without it (a pre-#2706 build, or a non-Linux host where
+// StartTime is a fixed creation FILETIME and does not drift), with a 60 s tolerance so ordinary
+// drift cannot reach it either.
+//
 // The sweep is synchronous and cheap in steady state: one directory enumeration (plus one per
 // al-runner-* container) when there is nothing stale. It only costs real time when there IS
 // garbage — which is precisely the situation the issue is about — and the first sweep on a
@@ -76,6 +94,13 @@ public static class ScratchDirs
     private static readonly HashSet<string> Owned = new(StringComparer.Ordinal);
     private static bool _exitHooked;
     private static long? _ownStartTicks;
+    private static long? _ownStartJiffies;
+
+    /// <summary>Tolerance for the FALLBACK wall-clock start-time comparison (see the file header).
+    /// Only reached when no boot-relative value is available on both sides. Generous on purpose:
+    /// a false "alive" costs one stale directory, a false "dead" costs a live run's data, and the
+    /// pid-reuse case this guards against needs the pid space to wrap pid_max first.</summary>
+    private const long WallClockStartToleranceTicks = 60 * TimeSpan.TicksPerSecond;
 
     /// <summary>The sidecar path for <paramref name="dir"/>.</summary>
     public static string MarkerPathFor(string dir)
@@ -97,7 +122,7 @@ public static class ScratchDirs
             var parent = Path.GetDirectoryName(full);
             if (!string.IsNullOrEmpty(parent)) Directory.CreateDirectory(parent);
             File.WriteAllText(MarkerPathFor(full),
-                $"pid={Environment.ProcessId}\nstart={OwnStartTicks}\ncreated={DateTime.UtcNow:O}\n");
+                $"pid={Environment.ProcessId}\nstart={OwnStartTicks}\nstartjiffies={OwnStartJiffies}\ncreated={DateTime.UtcNow:O}\n");
         }
         catch (IOException) { }
         catch (UnauthorizedAccessException) { }
@@ -170,6 +195,36 @@ public static class ScratchDirs
         }
     }
 
+    /// <summary>This process's boot-relative start time, or 0 where it cannot be read (non-Linux).
+    /// 0 in a sidecar means "not recorded" and sends the reader to the wall-clock fallback.</summary>
+    private static long OwnStartJiffies
+        => _ownStartJiffies ??= TryReadStartJiffies(Environment.ProcessId) ?? 0;
+
+    /// <summary>
+    /// The boot-relative start time of <paramref name="pid"/> in kernel clock ticks —
+    /// <c>/proc/&lt;pid&gt;/stat</c> field 22 (<c>starttime</c>). Null when /proc is unavailable or
+    /// the entry cannot be parsed. Unlike <see cref="Process.StartTime"/> this number is a property
+    /// of the process rather than of the reader's clock, so the writer and a later sweeper always
+    /// compute the same value for the same process.
+    /// </summary>
+    internal static long? TryReadStartJiffies(int pid)
+    {
+        if (!OperatingSystem.IsLinux() || pid <= 0) return null;
+        string text;
+        try { text = File.ReadAllText("/proc/" + pid.ToString(CultureInfo.InvariantCulture) + "/stat"); }
+        catch { return null; }
+
+        // Field 2 (comm) is the executable name in parentheses and may itself contain spaces and
+        // parentheses, so the only safe split point is the LAST ')'.
+        var close = text.LastIndexOf(')');
+        if (close < 0 || close + 1 >= text.Length) return null;
+        var fields = text.Substring(close + 1).Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        // fields[0] is field 3 (state), so field 22 (starttime) is fields[19].
+        if (fields.Length <= 19) return null;
+        return long.TryParse(fields[19], NumberStyles.None, CultureInfo.InvariantCulture, out var t) && t > 0
+            ? t : null;
+    }
+
     // ── Sweep ─────────────────────────────────────────────────────────────────────────────
 
     /// <summary>What one <see cref="SweepStale"/> pass did. <see cref="Removed"/> lists the
@@ -239,10 +294,10 @@ public static class ScratchDirs
 
     private static void HandleSidecar(string markerPath, SweepResult result)
     {
-        if (!TryReadOwner(markerPath, out var pid, out var startTicks))
+        if (!TryReadOwner(markerPath, out var pid, out var startTicks, out var startJiffies))
             return;   // not ours to interpret; leave it and whatever it points at
         var target = markerPath.Substring(0, markerPath.Length - OwnerMarkerSuffix.Length);
-        if (IsOwnerAlive(pid, startTicks)) { result.Kept++; return; }
+        if (IsOwnerAlive(pid, startTicks, startJiffies)) { result.Kept++; return; }
         if (DeleteTreeAndMarker(target)) result.Removed.Add(target);
         else result.Failed++;
     }
@@ -270,10 +325,15 @@ public static class ScratchDirs
         return false;
     }
 
-    /// <summary>Parse a sidecar. <c>start</c> is optional (0 = unknown, pid liveness alone decides).</summary>
+    /// <summary>Parse a sidecar. Both start values are optional (0 = not recorded); with neither,
+    /// pid liveness alone decides.</summary>
     internal static bool TryReadOwner(string markerPath, out int pid, out long startTicks)
+        => TryReadOwner(markerPath, out pid, out startTicks, out _);
+
+    /// <inheritdoc cref="TryReadOwner(string, out int, out long)"/>
+    internal static bool TryReadOwner(string markerPath, out int pid, out long startTicks, out long startJiffies)
     {
-        pid = 0; startTicks = 0;
+        pid = 0; startTicks = 0; startJiffies = 0;
         string[] lines;
         try { lines = File.ReadAllLines(markerPath); } catch { return false; }
         var havePid = false;
@@ -282,6 +342,8 @@ public static class ScratchDirs
             var line = raw.Trim();
             if (line.StartsWith("pid=", StringComparison.Ordinal))
                 havePid = int.TryParse(line.AsSpan(4), NumberStyles.None, CultureInfo.InvariantCulture, out pid);
+            else if (line.StartsWith("startjiffies=", StringComparison.Ordinal))
+                long.TryParse(line.AsSpan(13), NumberStyles.None, CultureInfo.InvariantCulture, out startJiffies);
             else if (line.StartsWith("start=", StringComparison.Ordinal))
                 long.TryParse(line.AsSpan(6), NumberStyles.None, CultureInfo.InvariantCulture, out startTicks);
         }
@@ -292,21 +354,36 @@ public static class ScratchDirs
     /// Is the recorded owner still running? "Alive" needs the pid to exist AND, when a start
     /// time was recorded, the live process's start time to match it — a pid that has been
     /// reused by an unrelated process is a dead owner. Anything that cannot be determined
-    /// (a process we are not allowed to inspect) counts as alive: the sweep's failure mode
-    /// must be "left a stale directory behind", never "deleted a live one".
+    /// (a process we are not allowed to inspect, a /proc entry that will not parse) counts as
+    /// alive: the sweep's failure mode must be "left a stale directory behind", never "deleted
+    /// a live one".
+    ///
+    /// <paramref name="startJiffies"/> — <c>/proc/&lt;pid&gt;/stat</c> field 22 — decides whenever
+    /// it was recorded and can still be read, because it is the only one of the two the writer and
+    /// this reader are guaranteed to compute identically. See the file header for why
+    /// <see cref="Process.StartTime"/> alone is not safe to compare here.
     /// </summary>
-    internal static bool IsOwnerAlive(int pid, long startTicks)
+    internal static bool IsOwnerAlive(int pid, long startTicks, long startJiffies = 0)
     {
         if (pid <= 0) return true;
         try
         {
             using var p = Process.GetProcessById(pid);
             if (p.HasExited) return false;
+
+            if (startJiffies > 0)
+            {
+                // Both sides read the same kernel field; a mismatch really is a different process.
+                var liveJiffies = TryReadStartJiffies(pid);
+                if (liveJiffies is not long lj) return true;   // cannot compare -> assume alive
+                return lj == startJiffies;
+            }
+
             if (startTicks <= 0) return true;
             long live;
             try { live = p.StartTime.ToUniversalTime().Ticks; }
             catch { return true; }
-            return Math.Abs(live - startTicks) <= 2 * TimeSpan.TicksPerSecond;
+            return Math.Abs(live - startTicks) <= WallClockStartToleranceTicks;
         }
         catch (ArgumentException) { return false; }         // no process with that id
         catch (InvalidOperationException) { return false; } // exited between lookup and use

--- a/AlRunner/Infrastructure/ScratchDirs.cs
+++ b/AlRunner/Infrastructure/ScratchDirs.cs
@@ -1,0 +1,317 @@
+// ScratchDirs — ownership-tracked scratch directories under the OS temp root (issue #2706).
+//
+// The runner writes several per-process / per-run scratch directories under
+// Path.GetTempPath(): dependency source extraction (DepExtractionDir), the report engine's
+// per-session temp folder (NavReportSync / MetadataPatches), --jobs shard reports
+// (ParallelFanOut), --no-cache throwaway cache roots (CacheRoots), watchdog-resume carry
+// files and --server inline-code bundles (Program.cs), the r2r-chunks write fallback
+// (AppLoader). The test suite adds ~190 more sites of the same shape. Every one of them used
+// to rely on the CREATING process deleting the directory at its own clean exit — or on
+// nothing at all — so a run that was killed, OOM'd, or hit the watchdog left its directory
+// behind forever. Measured on the reporting machine: 126 GB across the test fixtures'
+// --cache roots, and al-runner-navserver/user/ alone regrew to 7.5 GB (212 per-pid folders,
+// 211 of them for dead processes) within hours of being cleared. On a stock Linux desktop
+// /tmp is a tmpfs, so that is RAM, charged to no process.
+//
+// A process cannot clean up after itself when it is killed, so the leftovers of a dead
+// process can only be reclaimed by a LATER process. That needs an ownership record that
+// outlives the owner, which is what this class adds:
+//
+//   * Reserve/Create write a sidecar file `<dir>.owner` beside the directory, naming the
+//     owning pid AND its start time (a pid alone is reused; pid + start time is not).
+//   * The owner deletes its directories and sidecars at ProcessExit (clean exit, SIGTERM,
+//     Ctrl+C). Release does the same on demand.
+//   * SweepStale — run once at every runner start — enumerates the temp root's al-runner-*
+//     entries and deletes exactly those whose recorded owner is provably gone: no such pid,
+//     or the pid now belongs to a process with a different start time. A live owner's
+//     directory is never touched, so any number of runners (and test hosts) can share one
+//     TMPDIR. Two legacy shapes that predate the sidecar are recognised by the pid in their
+//     name (al-runner-deps/p<pid>, al-runner-navserver/[user/]<pid>) and swept by pid
+//     liveness alone.
+//
+// Deliberately NO age-based rule for unmarked directories. An age heuristic is the only rule
+// that can delete a directory a live process is still using — a --watch or --server session,
+// or a test host from a build that predates this file — and this machine routinely runs
+// several of those at once. Everything the runner itself writes is marked after #2706, so
+// unmarked litter is either legacy (a one-time manual `rm`) or from an old build; neither is
+// worth the risk of pulling a directory out from under a live run.
+//
+// The sweep is synchronous and cheap in steady state: one directory enumeration (plus one per
+// al-runner-* container) when there is nothing stale. It only costs real time when there IS
+// garbage — which is precisely the situation the issue is about — and the first sweep on a
+// littered machine paying a few seconds once is the intended trade.
+
+using System.Diagnostics;
+using System.Globalization;
+
+namespace AlRunner.Infrastructure;
+
+public static class ScratchDirs
+{
+    /// <summary>Sidecar suffix: <c>&lt;dir&gt;.owner</c>, beside the directory, never inside it — so
+    /// reserving a path does not have to create it, and a reader can decide a directory's fate
+    /// without opening it.</summary>
+    public const string OwnerMarkerSuffix = ".owner";
+
+    /// <summary>Only names with one of these prefixes are ever examined by the sweep. Anything
+    /// else in the temp root belongs to someone else.</summary>
+    internal static readonly string[] ScannedPrefixes = { "al-runner-", "alrunner-" };
+
+    /// <summary>How far below the temp root the sweep looks for sidecars and legacy pid-named
+    /// leaves: <c>&lt;temp&gt;/X.owner</c> (0), <c>&lt;temp&gt;/al-runner-foo/X.owner</c> (1),
+    /// <c>&lt;temp&gt;/al-runner-navserver/user/&lt;pid&gt;</c> (2).</summary>
+    private const int MaxDepth = 2;
+
+    /// <summary>Legacy per-process shapes written before the sidecar existed, keyed by the
+    /// container path (relative to the temp root, '/'-joined) whose immediate children are named
+    /// by pid with the given prefix.</summary>
+    private static readonly (string Container, string LeafPrefix)[] LegacyPidLeaves =
+    {
+        ("al-runner-deps", "p"),
+        ("al-runner-navserver", ""),
+        ("al-runner-navserver/user", ""),
+    };
+
+    private static readonly object Gate = new();
+    private static readonly HashSet<string> Owned = new(StringComparer.Ordinal);
+    private static bool _exitHooked;
+    private static long? _ownStartTicks;
+
+    /// <summary>The sidecar path for <paramref name="dir"/>.</summary>
+    public static string MarkerPathFor(string dir)
+        => dir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + OwnerMarkerSuffix;
+
+    /// <summary>
+    /// Claim <paramref name="dir"/> for this process WITHOUT creating it: writes the sidecar
+    /// (creating the parent directory if needed) and schedules the directory and sidecar for
+    /// deletion at ProcessExit. For callers that only hand the path on (e.g. a --no-cache root
+    /// that the caches may or may not ever write into). Returns <paramref name="dir"/>.
+    /// A sidecar that cannot be written is not fatal — the directory simply falls back to the
+    /// pre-#2706 behaviour of relying on its owner's clean exit.
+    /// </summary>
+    public static string Reserve(string dir)
+    {
+        var full = Path.GetFullPath(dir);
+        try
+        {
+            var parent = Path.GetDirectoryName(full);
+            if (!string.IsNullOrEmpty(parent)) Directory.CreateDirectory(parent);
+            File.WriteAllText(MarkerPathFor(full),
+                $"pid={Environment.ProcessId}\nstart={OwnStartTicks}\ncreated={DateTime.UtcNow:O}\n");
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+
+        lock (Gate)
+        {
+            Owned.Add(full);
+            if (!_exitHooked)
+            {
+                _exitHooked = true;
+                AppDomain.CurrentDomain.ProcessExit += (_, _) => ReleaseAll();
+            }
+        }
+        return dir;
+    }
+
+    /// <summary><see cref="Reserve"/> plus <c>Directory.CreateDirectory</c>. Returns <paramref name="dir"/>.</summary>
+    public static string Create(string dir)
+    {
+        Reserve(dir);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    /// <summary>Delete <paramref name="dir"/> and its sidecar now, and forget it. Best-effort:
+    /// cleanup failing must never fail the run it is cleaning up after.</summary>
+    public static void Release(string dir)
+    {
+        var full = Path.GetFullPath(dir);
+        lock (Gate) Owned.Remove(full);
+        DeleteTreeAndMarker(full);
+    }
+
+    /// <summary>True when <paramref name="dir"/> was reserved by THIS process and not yet released.</summary>
+    internal static bool IsOwnedByThisProcess(string dir)
+    {
+        var full = Path.GetFullPath(dir);
+        lock (Gate) return Owned.Contains(full);
+    }
+
+    private static void ReleaseAll()
+    {
+        string[] snapshot;
+        lock (Gate) { snapshot = Owned.ToArray(); Owned.Clear(); }
+        foreach (var d in snapshot) DeleteTreeAndMarker(d);
+    }
+
+    private static bool DeleteTreeAndMarker(string full)
+    {
+        var ok = true;
+        try { if (Directory.Exists(full)) Directory.Delete(full, recursive: true); }
+        catch (IOException) { ok = false; }
+        catch (UnauthorizedAccessException) { ok = false; }
+        try { File.Delete(MarkerPathFor(full)); }
+        catch (IOException) { ok = false; }
+        catch (UnauthorizedAccessException) { ok = false; }
+        return ok;
+    }
+
+    private static long OwnStartTicks
+    {
+        get
+        {
+            if (_ownStartTicks is long t) return t;
+            long v;
+            try { using var me = Process.GetCurrentProcess(); v = me.StartTime.ToUniversalTime().Ticks; }
+            catch { v = 0; }
+            _ownStartTicks = v;
+            return v;
+        }
+    }
+
+    // ── Sweep ─────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>What one <see cref="SweepStale"/> pass did. <see cref="Removed"/> lists the
+    /// directories (or orphan sidecars) deleted; <see cref="Kept"/> counts entries examined and
+    /// left alone because their owner is alive; <see cref="Failed"/> counts deletions that
+    /// threw (a file in use, a permission problem) and will be retried by the next sweep.</summary>
+    public sealed class SweepResult
+    {
+        public List<string> Removed { get; } = new();
+        public int Kept { get; set; }
+        public int Failed { get; set; }
+    }
+
+    /// <summary>
+    /// Reclaim the scratch directories of processes that no longer exist. Examines only
+    /// <see cref="ScannedPrefixes"/>-named entries under <paramref name="tempRoot"/> (default:
+    /// <c>Path.GetTempPath()</c>), down to <see cref="MaxDepth"/>. Never throws — a sweep that
+    /// cannot read some entry skips it. Safe to run from any number of processes concurrently:
+    /// each decision is made per directory from that directory's own sidecar (or pid-named
+    /// leaf), and only dead owners' directories are removed.
+    /// </summary>
+    public static SweepResult SweepStale(string? tempRoot = null)
+    {
+        var result = new SweepResult();
+        string root;
+        try { root = Path.GetFullPath(tempRoot ?? Path.GetTempPath()); }
+        catch { return result; }
+        if (!Directory.Exists(root)) return result;
+        Scan(root, root, 0, result);
+        return result;
+    }
+
+    private static void Scan(string root, string dir, int depth, SweepResult result)
+    {
+        IEnumerable<string> entries;
+        try { entries = Directory.EnumerateFileSystemEntries(dir).ToList(); }
+        catch { return; }
+
+        foreach (var entry in entries)
+        {
+            var name = Path.GetFileName(entry);
+            if (depth == 0 && !HasScannedPrefix(name)) continue;
+
+            try
+            {
+                if (name.EndsWith(OwnerMarkerSuffix, StringComparison.Ordinal) && File.Exists(entry))
+                {
+                    HandleSidecar(entry, result);
+                    continue;
+                }
+                if (!Directory.Exists(entry)) continue;   // a plain file: never the sweep's business
+                if (File.Exists(MarkerPathFor(entry))) continue;   // decided by its sidecar, above or later in this loop
+
+                if (depth >= 1 && TryLegacyPid(root, entry, name, out var legacyPid))
+                {
+                    if (ProcessExists(legacyPid)) { result.Kept++; }
+                    else if (DeleteTreeAndMarker(entry)) result.Removed.Add(entry);
+                    else result.Failed++;
+                    continue;
+                }
+
+                if (depth < MaxDepth) Scan(root, entry, depth + 1, result);
+            }
+            catch { /* one unreadable entry must not stop the sweep */ }
+        }
+    }
+
+    private static void HandleSidecar(string markerPath, SweepResult result)
+    {
+        if (!TryReadOwner(markerPath, out var pid, out var startTicks))
+            return;   // not ours to interpret; leave it and whatever it points at
+        var target = markerPath.Substring(0, markerPath.Length - OwnerMarkerSuffix.Length);
+        if (IsOwnerAlive(pid, startTicks)) { result.Kept++; return; }
+        if (DeleteTreeAndMarker(target)) result.Removed.Add(target);
+        else result.Failed++;
+    }
+
+    private static bool HasScannedPrefix(string name)
+    {
+        foreach (var p in ScannedPrefixes)
+            if (name.StartsWith(p, StringComparison.OrdinalIgnoreCase)) return true;
+        return false;
+    }
+
+    private static bool TryLegacyPid(string root, string entry, string name, out int pid)
+    {
+        pid = 0;
+        var parent = Path.GetDirectoryName(entry);
+        if (parent == null) return false;
+        var rel = Path.GetRelativePath(root, parent).Replace('\\', '/');
+        foreach (var (container, leafPrefix) in LegacyPidLeaves)
+        {
+            if (!string.Equals(rel, container, StringComparison.OrdinalIgnoreCase)) continue;
+            if (!name.StartsWith(leafPrefix, StringComparison.Ordinal)) continue;
+            var digits = name.Substring(leafPrefix.Length);
+            return digits.Length > 0 && int.TryParse(digits, NumberStyles.None, CultureInfo.InvariantCulture, out pid);
+        }
+        return false;
+    }
+
+    /// <summary>Parse a sidecar. <c>start</c> is optional (0 = unknown, pid liveness alone decides).</summary>
+    internal static bool TryReadOwner(string markerPath, out int pid, out long startTicks)
+    {
+        pid = 0; startTicks = 0;
+        string[] lines;
+        try { lines = File.ReadAllLines(markerPath); } catch { return false; }
+        var havePid = false;
+        foreach (var raw in lines)
+        {
+            var line = raw.Trim();
+            if (line.StartsWith("pid=", StringComparison.Ordinal))
+                havePid = int.TryParse(line.AsSpan(4), NumberStyles.None, CultureInfo.InvariantCulture, out pid);
+            else if (line.StartsWith("start=", StringComparison.Ordinal))
+                long.TryParse(line.AsSpan(6), NumberStyles.None, CultureInfo.InvariantCulture, out startTicks);
+        }
+        return havePid && pid > 0;
+    }
+
+    /// <summary>
+    /// Is the recorded owner still running? "Alive" needs the pid to exist AND, when a start
+    /// time was recorded, the live process's start time to match it — a pid that has been
+    /// reused by an unrelated process is a dead owner. Anything that cannot be determined
+    /// (a process we are not allowed to inspect) counts as alive: the sweep's failure mode
+    /// must be "left a stale directory behind", never "deleted a live one".
+    /// </summary>
+    internal static bool IsOwnerAlive(int pid, long startTicks)
+    {
+        if (pid <= 0) return true;
+        try
+        {
+            using var p = Process.GetProcessById(pid);
+            if (p.HasExited) return false;
+            if (startTicks <= 0) return true;
+            long live;
+            try { live = p.StartTime.ToUniversalTime().Ticks; }
+            catch { return true; }
+            return Math.Abs(live - startTicks) <= 2 * TimeSpan.TicksPerSecond;
+        }
+        catch (ArgumentException) { return false; }         // no process with that id
+        catch (InvalidOperationException) { return false; } // exited between lookup and use
+        catch { return true; }
+    }
+
+    private static bool ProcessExists(int pid) => IsOwnerAlive(pid, 0);
+}

--- a/AlRunner/Patches/MetadataPatches.cs
+++ b/AlRunner/Patches/MetadataPatches.cs
@@ -624,9 +624,12 @@ public static partial class BcRuntime
                 BindingFlags.NonPublic | BindingFlags.Instance);
             if (userFolderBacking != null && string.IsNullOrEmpty(userFolderBacking.GetValue(_skeletonSession) as string))
             {
-                var userFolder = System.IO.Path.Combine(
-                    System.IO.Path.GetTempPath(), "al-runner-navserver", "user", Environment.ProcessId.ToString());
-                System.IO.Directory.CreateDirectory(userFolder);
+                // Owned via ScratchDirs (#2706): the report processors buffer whole datasets
+                // here (measured: up to 2 GB per process), and this folder was never deleted —
+                // 212 dead-pid copies on one machine. Removed at exit; reclaimed by the next
+                // runner start when this process is killed.
+                var userFolder = ScratchDirs.Create(System.IO.Path.Combine(
+                    System.IO.Path.GetTempPath(), "al-runner-navserver", "user", Environment.ProcessId.ToString()));
                 FieldPoke.SetInstance(userFolderBacking, _skeletonSession, userFolder);
                 Console.Error.WriteLine($"[BcRuntime] InjectSkeletonSystemTenant: session.UserFolder wired to {userFolder}");
             }

--- a/AlRunner/Patches/NavReportSync.cs
+++ b/AlRunner/Patches/NavReportSync.cs
@@ -1450,7 +1450,14 @@ public static partial class NavReportSync
             ? Environment.ProcessId.ToString()
             : string.Concat(folderName.Where(c => !System.IO.Path.GetInvalidFileNameChars().Contains(c)));
         string basePath = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "al-runner-navserver", name);
-        System.IO.Directory.CreateDirectory(basePath);
+        // The per-process (pid-named) folder is owned via ScratchDirs (#2706): deleted at exit,
+        // reclaimed by the next runner start if this process is killed. It used to be left
+        // behind unconditionally — hundreds of dead-pid folders holding report temp files. A
+        // caller-named folder is shared across processes and is left as it was.
+        if (string.IsNullOrEmpty(folderName))
+            AlRunner.Infrastructure.ScratchDirs.Create(basePath);
+        else
+            System.IO.Directory.CreateDirectory(basePath);
 
         void Set(string field, object? value)
         {

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -228,6 +228,12 @@ if (args[0] == "--emit-app")
 try
 {
     var swept = AlRunner.Infrastructure.ScratchDirs.SweepStale();
+    // Deleting other processes' directories is the only destructive thing the runner does on
+    // its own initiative, so say so UNCONDITIONALLY — not behind AL_RUNNER_PERF. On a clean
+    // machine this never prints; if the liveness test ever misjudges a live owner, this line is
+    // the only evidence that would exist. Detail stays behind PerfTrace.
+    if (swept.Removed.Count > 0)
+        Console.Error.WriteLine($"scratch sweep: reclaimed {swept.Removed.Count} stale dir(s) from dead runners under {Path.GetTempPath()}");
     if (swept.Removed.Count > 0 || swept.Failed > 0)
         PerfTrace.Log($"scratch sweep: removed {swept.Removed.Count} stale dir(s), kept {swept.Kept}, failed {swept.Failed} under {Path.GetTempPath()}");
 }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -220,6 +220,22 @@ if (args[0] == "--emit-app")
     return RunEmitApp(args.Skip(1).ToArray());
 }
 
+// #2706: reclaim the scratch directories of runner / test-host processes that no longer exist
+// (killed, OOM'd, watchdog-aborted — they cannot clean up after themselves). Runs before
+// argument parsing so it does not depend on which mode this invocation is in, and before any
+// BC type loads so it costs one directory enumeration on a clean machine. Only directories
+// whose recorded owner is provably dead are removed; see ScratchDirs for the rules.
+try
+{
+    var swept = AlRunner.Infrastructure.ScratchDirs.SweepStale();
+    if (swept.Removed.Count > 0 || swept.Failed > 0)
+        PerfTrace.Log($"scratch sweep: removed {swept.Removed.Count} stale dir(s), kept {swept.Kept}, failed {swept.Failed} under {Path.GetTempPath()}");
+}
+catch (Exception ex)
+{
+    PerfTrace.Log($"scratch sweep skipped: {ex.GetType().Name}: {ex.Message}");
+}
+
 // Failure classification (the FAILURE CLASSIFICATION block + v2-classification.json)
 // is a runner-development diagnostic, not something end users care about. Default off.
 // Enable by passing --out PATH (which sets the JSON output path) or --classify (which
@@ -3597,8 +3613,10 @@ if (resumeAborts > 0
 
     // This attempt's results are a partial view; carry them forward so the final summary is the
     // whole run rather than the last slice of it.
-    var carryDir = Path.Combine(Path.GetTempPath(), "al-runner-resume-" + Guid.NewGuid().ToString("N"));
-    Directory.CreateDirectory(carryDir);
+    // Owned by THIS generation (ScratchDirs, #2706): the re-exec'd child reads it while we
+    // wait on it, and it is deleted when we exit — or, if we are killed, by the next start.
+    var carryDir = AlRunner.Infrastructure.ScratchDirs.Create(
+        Path.Combine(Path.GetTempPath(), "al-runner-resume-" + Guid.NewGuid().ToString("N")));
     var carryPath = Path.Combine(carryDir, "attempt.xml");
     // THIS attempt's results only — deliberately not the carried-files overload. Each carry file
     // must hold exactly one attempt, because the final attempt folds the whole list into its
@@ -5714,8 +5732,11 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
             ? code
             : $"codeunit 50100 \"AL Runner Inline Execute\" {{ trigger OnRun() begin {code} end; }}";
 
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-server-inline", Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(dir);
+        // One scratch bundle per request, owned by this server process (ScratchDirs, #2706)
+        // so a long --server session's inline requests are all removed when it exits and a
+        // killed session's are reclaimed by the next runner start.
+        var dir = AlRunner.Infrastructure.ScratchDirs.Create(
+            Path.Combine(Path.GetTempPath(), "al-runner-server-inline", Guid.NewGuid().ToString("N")));
         File.WriteAllText(Path.Combine(dir, "Scratch.al"), source);
         return dir;
     }

--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ single-fixture run). `--cache <dir>` relocates it with the other caches; set
 `AL_RUNNER_NO_DEP_COMPANY_CACHE=1` to bypass it entirely (no read, no write) and force the
 full computation.
 
+The runner also writes short-lived scratch directories under the OS temp directory
+(`Path.GetTempPath()` — `$TMPDIR`, or `/tmp`, which is a tmpfs, i.e. RAM, on most Linux
+desktops): `al-runner-deps/p<pid>` (dependency source extraction), `al-runner-navserver/`
+(the report engine's per-session temp files), `al-runner-jobs-*`, `al-runner-no-cache-*`,
+`al-runner-resume-*`, `al-runner-server-inline/`. Each carries a `<dir>.owner` sidecar naming
+the process that created it; the owner deletes its directories at exit, and every runner
+start sweeps the ones whose owner no longer exists (killed, OOM'd, watchdog-aborted). The
+sweep never deletes a live process's directory and never guesses by age, so any number of
+runners can share one `TMPDIR`; directories from builds before this mechanism (no sidecar,
+no pid in the name) are left alone and can be removed by hand. See
+`AlRunner/Infrastructure/ScratchDirs.cs`.
+
 ### Watch mode (live dashboard)
 
 ```bash


### PR DESCRIPTION
Closes #2706

Every per-process scratch directory the runner writes under `Path.GetTempPath()` used to be removed only by the process that created it, at its own clean exit — or by nothing at all. A run that was killed, OOM'd, or hit the watchdog left its directory behind forever. This PR gives each of them an ownership record that outlives the owner, and reclaims dead owners' directories at the next runner start.

## What leaks, and when

| writer | before | leaked when |
|---|---|---|
| `al-runner-navserver/user/<pid>` (MetadataPatches), `al-runner-navserver/<pid>` (NavReportSync) | never deleted | always — 212 pid dirs on the reporting machine, 211 dead, 7.5 GB, regrown within hours of the reporter's cleanup |
| `al-runner-resume-<guid>` (Program.cs), `al-runner-server-inline/<guid>`, `al-runner-r2r-chunks-fallback/<guid>` (AppLoader) | never deleted | always (40 resume dirs there) |
| `al-runner-deps/p<pid>` (DepExtractionDir), `al-runner-no-cache-<guid>` (CacheRoots), `al-runner-jobs-<guid>` (ParallelFanOut) | ProcessExit / end-of-method delete | on kill, OOM, watchdog abort |
| 190 test sites (`Path.Combine(GetTempPath(), "<name>", Guid)`, 149 files; 19 classes pass such a dir as `--cache`) | never deleted | always — ~273 MB per `--cache` root |

On a stock Linux desktop `/tmp` is a tmpfs, so that is RAM, charged to no process.

Persistent-by-design entries that must stay: `al-runner-pkgdedup`, `al-runner-sibling-symbols`, `al-runner-query-symbols`, `alrunner-v2-win32-stubs`, `al-runner-systemapp-*.app`, `al-runner-startup.log`.

## The mechanism (`AlRunner/Infrastructure/ScratchDirs.cs`)

- `Reserve`/`Create` write a `<dir>.owner` sidecar naming the owning **pid and its start time** (a pid alone is reused; pid + start time is not). `Reserve` does not create the leaf, so tests that observe "did the runner create it" keep working.
- The owner deletes its directories and sidecars at ProcessExit; `Release` does it on demand.
- `SweepStale()` runs synchronously at every runner start, before argument parsing and before any BC type loads. It removes exactly: directories whose sidecar owner is dead, plus the two legacy pid-named shapes (`al-runner-deps/p<pid>`, `al-runner-navserver/[user/]<pid>`) by pid liveness. Live owners are never touched, so concurrent runners and test hosts share one TMPDIR safely. Cost on a clean machine: one directory enumeration.
- **No age rule, deliberately.** An age heuristic is the only rule that can delete a live process's directory (a `--watch`/`--server` session, or a test host from an older build). Legacy unmarked litter is a one-time manual `rm`; the README says so.

All seven runner writers go through it. Test side: `AlRunner.Tests/TestScratch.cs` (`Dir`/`FlatDir`, same path shapes) and a scripted conversion of 190 canonical/flat sites. `NoCacheLastWinsIntegrationTests` asserts a set difference instead of a count, because the spawned runner's sweep can legitimately lower the count.

## Review round (impl-5): the liveness test compared the wrong clock

The review found the one place in the file that traded in the wrong direction — a **live** owner could be judged dead, and that deletes data rather than leaving litter.

`Process.StartTime` on Linux is not anchored to the kernel's `/proc/stat btime`. Each process derives its own base as `(realtime now - /proc/uptime)`, lazily, the first time it asks. So the value an owner records in its sidecar and the value a later sweeper computes for that same owner drift apart by the realtime-against-boottime skew accumulated in between. Measured on this machine, and it matches the review's number exactly:

```
btime + /proc/1/stat field 22   ->  1788245947.13
.NET Process.StartTime (pid 1)  ->  1788245948.07
(now - btime) - /proc/uptime    ->  0.947 s   after 4.2 days of uptime, ~2.6 ppm
```

Under the old `<= 2 s` tolerance that had two consequences. Ordinary drift: a `--watch` or `--server` session crossed into "reused pid, owner dead" after roughly nine days and had its scratch directory deleted while still using it. A clock **step** (chrony `makestep`, a VM snapshot restore, suspend/resume): crossed instantly, and for every sidecar on the machine at once, so one runner start could delete every live owner's directory — including a running test host's in-use `--cache` root, which is a wrong test result rather than a visible failure.

**Fix: compare something both processes compute identically.** The sidecar now also records `/proc/<pid>/stat` field 22 as `startjiffies=`. That number is a property of the process, not of the reader's clock, so writer and sweeper always get the same value for the same process — and it is exactly what pid-reuse detection needs. It decides whenever both sides have it.

I took the boot-relative route rather than just widening the tolerance, as the review preferred: widening removes the ordinary-drift class but not the clock-step class, and the clock-step class is the one that deletes everything at once. The wall-clock comparison survives only as the fallback for a sidecar written without the new key (a pre-#2706 build) and for non-Linux hosts, where `StartTime` is a fixed creation FILETIME and does not drift — at 60 s, so ordinary drift cannot reach that path either. An unreadable `/proc` entry counts as alive, keeping the asymmetry the file's header states: a false "alive" costs one stale directory, a false "dead" costs a live run's data.

**Also from the review: the sweep is now audible.** Deleting other processes' directories is the only destructive thing the runner does on its own initiative, and it reported only through `PerfTrace.Log` — i.e. nothing at all unless `AL_RUNNER_PERF=1`. It now prints one unconditional stderr line when it removed anything (`scratch sweep: reclaimed N stale dir(s) from dead runners under <root>`), with `Kept`/`Failed` detail still behind `PerfTrace`. Verified against the real runner on a private TMPDIR containing one dead-owner directory; it prints on a default run and prints nothing on a clean root. It costs nothing on a clean machine and is the only evidence that would exist if the liveness test ever misjudged a live owner.

## RED → GREEN

Reverting **only** the decision logic in `IsOwnerAlive` to its pre-fix form (wall clock, 2 s) while keeping the signatures, so the new tests compile and it is the semantics being measured:

```
Failed  ScratchDirsTests.Sweep_KeepsLiveOwner_WhenItsRecordedWallClockStartTimeHasDrifted
          a LIVE owner's directory was deleted because its recorded wall-clock start time had drifted
Failed  ScratchDirsTests.Sweep_BootRelativeStartTime_IsAuthoritative_SoPidReuseIsStillDetected
Failed  ScratchDirsRunnerStartupTests.RunnerStartup_RemovesDeadOwnersLeftovers_AndLeavesLiveAndUnmarkedOnesAlone
          a LIVE owner's scratch dir was deleted because its recorded wall-clock start time had drifted
Failed: 3, Passed: 16
```

GREEN after restoring the fix: `Failed: 0, Passed: 29` over `ScratchDirsTests`, `ScratchDirsRunnerStartupTests`, `CacheRootsDisableForRunTests`, `NoCacheLastWinsIntegrationTests`.

The second failure is the one that stops this being "widen the tolerance in disguise": it plants a sidecar whose wall-clock `start=` matches the live process **exactly** and whose boot-relative value does not, and asserts the directory is removed. Under a wall-clock-only rule at any tolerance that directory survives, so the test can only pass if the boot-relative value is genuinely authoritative — pid reuse is still detected, and the wider fallback tolerance is not a hole.

The third runs the whole thing through the real runner binary: a directory owned by the live test host, with its recorded wall-clock start offset by 10 s, must still be there after the runner has swept the temp root.

Earlier RED → GREEN for the mechanism itself is unchanged: `ScratchDirsRunnerStartupTests` plants a dead-owner marked dir (nested and flat), legacy `al-runner-deps/p<deadpid>` and `al-runner-navserver/user/<deadpid>`, a dir owned by the live test host, and an unmarked 30-day-old dir; RED on main is the dead-owner dir surviving, GREEN is the four dead shapes removed and the live-owned and unmarked dirs untouched. `ScratchDirsTests` now has 16 facts on a private root.

## Measured: space left behind by one run of three spawning test classes

| | left in TMPDIR after the test host exited |
|---|---:|
| `origin/main` | **195.3 MB** (13 entries) |
| this branch, default `dotnet test` | 3 dirs + sidecars, reclaimed by the *next* runner start |
| this branch, `VSTEST_TESTHOST_SHUTDOWN_TIMEOUT=30000` | **0 bytes**, 0 entries |

vstest kills the test host about 100 ms after it begins shutting down. A probe confirmed ProcessExit handlers do fire and `ScratchDirs`' handler does delete, but deleting three 273 MB cache roots does not finish inside that budget. So the test host's own litter is reclaimed at the next runner start (which the suite spawns constantly) rather than at session end — bounded to one session's worth instead of unbounded.

## Scope: what is deliberately not here

- **Retitled.** The previous title said "every scratch dir under the OS temp root", which is not what shipped: about 50 `GetTempPath` sites in `AlRunner.Tests/` did not match the two textual shapes the conversion script targeted, five of them `--cache` roots that delete in a `finally` and so leak on exactly the killed-host case the sidecar exists for. Filed separately as #2743; this PR is not expanded to cover them.
- **The three "planned next" items from the first round were considered and dropped.** The detached double-fork exit sweep is a lot of machinery on the exit path of every invocation, for litter already bounded to one session; setting `VSTEST_TESTHOST_SHUTDOWN_TIMEOUT` in `bc-tests.yml` buys nothing in CI, where each job gets a fresh `/tmp`; and a test-host startup sweep only helps a session that spawns no runner, while the suite spawns about 130. Nothing in this PR depends on any of them, and no CLI flag was added.

## Shape check

- Same wrong pattern elsewhere: yes — all seven runner writers and 190 test sites, listed above, converted.
- Sibling assumption: `al-runner-precompile/<identity>` is shared by app identity across processes (the #2696 delete-then-rewrite race shape); left as-is, a different problem.
- Same-state invariant: `IsOwnerAlive` was the only comparison in the file trading toward "delete a live one"; every other unreadable input already returns "alive" (empty or unparseable sidecar, a process we cannot inspect). The new `/proc` read follows that rule too.
- Separate bug noticed, not fixed: the report engine writes `TEMP\GU00000032.xlsx` — the `TEMP\` becomes part of the *file name* on Linux because BC does `Path.Combine(UserFolder, "TEMP\\")`. Worth its own issue.

Rebased onto `origin/main` at 55429e38, and the targeted tests above were re-run after the rebase rather than carried across it.

Review round by agent impl-5.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
