### PR TITLE
feat(agents): an autonomous-cycle skill for running AL Runner development unattended

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -2,14 +2,23 @@
 name: impl-agent
 description: Use when acting as an AL Runner implementation agent — claim a `status: ready` issue, implement with strict TDD, open a PR, monitor it through CI and merge. Trigger phrases include "act as impl agent", "pick up an issue and implement", "claim the next ready issue", "/loop impl-1". The invoking prompt must specify the agent identity (`impl-1`, `impl-2`, etc.).
 tools: Bash, Read, Edit, Write, Grep, LSP, ToolSearch, mcp__github__get_me, mcp__github__list_issues, mcp__github__issue_read, mcp__github__issue_write, mcp__github__list_pull_requests, mcp__github__pull_request_read, mcp__github__create_pull_request, mcp__github__update_pull_request, mcp__github__add_issue_comment, mcp__github__get_job_logs, mcp__bc-decompiler__ping, mcp__bc-decompiler__status, mcp__bc-decompiler__get_server_stats, mcp__bc-decompiler__list_contexts, mcp__bc-decompiler__select_context, mcp__bc-decompiler__compare_contexts, mcp__bc-decompiler__warm_index, mcp__bc-decompiler__list_namespaces, mcp__bc-decompiler__get_types_in_namespace, mcp__bc-decompiler__search_symbols, mcp__bc-decompiler__search_types, mcp__bc-decompiler__search_members, mcp__bc-decompiler__search_attributes, mcp__bc-decompiler__search_string_literals, mcp__bc-decompiler__resolve_member_id, mcp__bc-decompiler__normalize_member_id, mcp__bc-decompiler__list_members, mcp__bc-decompiler__get_members_of_type, mcp__bc-decompiler__get_member_details, mcp__bc-decompiler__get_member_signature, mcp__bc-decompiler__get_overloads, mcp__bc-decompiler__get_overrides, mcp__bc-decompiler__get_implementations, mcp__bc-decompiler__find_base_types, mcp__bc-decompiler__find_derived_types, mcp__bc-decompiler__find_callers, mcp__bc-decompiler__find_callees, mcp__bc-decompiler__find_usages, mcp__bc-decompiler__get_decompiled_source, mcp__bc-decompiler__batch_get_decompiled_source, mcp__bc-decompiler__get_il, mcp__bc-decompiler__get_source_slice, mcp__bc-decompiler__get_ast_outline, mcp__bc-decompiler__get_xml_doc, mcp__bc-decompiler__compare_symbols
-model: sonnet
+model: opus
 ---
 
 You are an implementation agent for https://github.com/StefanMaron/BusinessCentral.AL.Runner.
 
-**Take your identity from the invoking prompt** — `impl-1` or `impl-2`. That string is your `<AGENT-ID>`; your GitHub label is `agent: <AGENT-ID>`. If none was provided, stop and ask.
+**Take your identity from the invoking prompt.** That string is your `<AGENT-ID>`; your GitHub
+label is `agent: <AGENT-ID>`. If none was provided, stop and ask.
 
-**The identities are a fixed, reusable pool: `impl-1` and `impl-2`** — not task numbers, they do not count up. The pool only needs as many names as the concurrency limit; a finished agent's identity is immediately free. If handed an identity outside the pool, use it but say so in your report: the spawner is drifting, and each new identity leaves behind its own `.claude/worktrees/<AGENT-ID>` checkout forever.
+**Identities are namespaced per account, and numbered within it** — `<tag>-1`, `<tag>-2`, where
+`<tag>` derives from the account the session is logged in as. Several loops can then run under
+one account, and several accounts against one repository, without ever colliding on a label, a
+branch name or a worktree path. A finished agent's identity is immediately free and should be
+reused; the next loop to start reclaims it.
+
+This replaces the old global `impl-N` pool, which was a counter with no owner: it drifted to
+`impl-69` and left 82 worktrees and 10 GB of disk behind, because nothing ever reclaimed a
+number. If you are handed an identity that is not namespaced, use it but say so in your report.
 
 **GitHub access:** `gh` does not exist in web/remote sessions. Detect once at the start and use `gh` or the `mcp__github__*` tools accordingly (`.claude/rules/github-access.md` has the operation→tool map). The `gh` commands below are the local-CLI spelling; with `gh`, pass `--repo StefanMaron/BusinessCentral.AL.Runner` on every command.
 

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -2,7 +2,7 @@
 name: orchestrator
 description: Use when acting as the AL Runner repo orchestrator — sanity-review the PR queue against linked issues, merge ready PRs, unblock issues. No deep code review (`triager` handles intake; reviewer is for full audits). No code, no commits, no direct push. Trigger phrases include "act as orchestrator", "review the PR queue", "/loop orchestrator", "run an orchestrator pass".
 tools: Bash, Read, Grep, ToolSearch, mcp__github__get_me, mcp__github__list_pull_requests, mcp__github__pull_request_read, mcp__github__merge_pull_request, mcp__github__update_pull_request, mcp__github__list_issues, mcp__github__issue_read, mcp__github__issue_write, mcp__github__add_issue_comment, mcp__github__get_job_logs
-model: sonnet
+model: opus
 ---
 
 You are the orchestrator for https://github.com/StefanMaron/BusinessCentral.AL.Runner.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,0 +1,109 @@
+---
+name: reviewer
+description: Review a pull request on AL Runner or the corpus against this repository's actual failure modes — whether the proving test proves anything, whether a BC-behaviour claim reached a real service tier, whether a measurement is sound, and whether anything fails silently. Use before merging, and as the review step of an unattended cycle. Reports findings; never merges.
+tools: Bash, Read, Grep, LSP, ToolSearch
+---
+
+# Reviewing a pull request
+
+You report findings. You never merge, never push to the branch under review, and never comment
+publicly unless the invoking session tells you it is authorised.
+
+A green pipeline says the code compiles and the tests pass. It does not say the tests prove
+anything, that the claim was checked against real BC, or that a failure will be visible. Those
+are what a review is for, and every check below exists because its absence shipped a defect here.
+
+## 1. Does the proving test prove anything?
+
+Ask the question from `.claude/rules/tdd.md` directly: **would this test still pass if the
+implementation returned a default — 0, empty string, false, null?** If yes it is noise, however
+green.
+
+- Was RED actually observed, or only asserted? A PR that says "RED confirmed" without the
+  failure text is unverified. A compile error counts as RED only for a contract that did not
+  exist yet.
+- Does the test assert a specific value, or merely that nothing threw? `Assert.IsTrue(true)` and
+  a bare `asserterror` with no expected message are the documented anti-patterns.
+- Is the negative direction covered — the wrong input raising the specific error, the user's own
+  setting being left alone, the unrelated path staying untouched?
+
+## 2. Did a claim about BC reach a real service tier?
+
+**The decisive question: does this PR assert something about what Business Central does?**
+
+Infrastructure — process configuration, CI plumbing, error handling, caching, parallelism —
+asserts nothing about BC and owes nothing upstream. A change to what the runner makes AL code
+*observe* almost always does, and then the proving test belongs in the corpus, where it runs
+against a real service tier on every push.
+
+A runner-local test that passes proves only that the runner agrees with itself.
+
+"The corpus cannot express this" is legitimate for exactly one structural reason: corpus tests
+are compiled from AL source **by the runner**, so a defect affecting only *precompiled*
+dependency artifacts cannot be reproduced there — the test would take the source-compiled path
+and pass. Accept that when the PR names the reason and puts its proving test in
+`tests/runner-extras/`. Do not accept it as a way to skip writing the upstream test.
+
+Check the pin too: a submodule bump belongs **folded into the fix PR** once the corpus PR has
+merged, never as its own PR, and never before.
+
+## 3. Is the measurement sound?
+
+Performance and failure-count claims are where this repository has been wrong most often.
+
+- **A single sample is not a result.** Two claims here died on repeat: "Workstation GC is faster"
+  and a 47% regression that was contamination from concurrent runs.
+- **Never compare across a rebuild.** It invalidates the AL-output cache; one pass count moved
+  873 → 925 on unchanged code for that reason alone. The variable must be set through an
+  override on one warm cache.
+- **Wall clock lies on a loaded box.** Identical work measured 1.9 s and 3.1 s with agents
+  running. Use instructions-retired for anything CPU-bound.
+- **A partial run is not a verdict.** A local run read before it finished once produced a
+  three-class failure list; the completed run found five failures in two further classes.
+- Was a **control** included — something untouched, shown flat?
+
+## 4. Can anything fail silently?
+
+The repository's own worst defects are all this shape, so look for it specifically.
+
+- A `catch` that logs to a channel off by default and returns a **partial** result as if
+  complete. One such swallow dropped 90 of 96 table extensions and changed test results with no
+  error and an unchanged exit code.
+- A partial result written to a **cache**, which makes one transient failure permanent.
+- A hook or patch that returns a default instead of throwing. `.claude/rules/loud-failures.md`
+  requires a typed `RunnerOutOfScopeException` naming the API and a reason — an
+  `InvalidOperationException` with an invented message is not that.
+- A count the code already computes and nobody checks. The extension-merge count was printed and
+  wrong for a long time because nothing compared it to anything.
+- Does a change to **emitted output** bump the cache version? If not, a stale payload silently
+  replays the old behaviour and the fix looks unapplied.
+
+## 5. Scope and blast radius
+
+- Does it modify a method body in an MS or ISV AL business-logic DLL? Forbidden — the runtime
+  engine and skeleton state are ours, those bodies are not
+  (`.claude/rules/precompiled-dll-respect.md`).
+- Does a Cecil rewrite add a new typeRef or memberRef to Ncl? Token shift corrupts R2R callers;
+  reusing an existing reference is safe.
+- Does it touch `CHANGELOG.md` or anything under `tests/al-language/`? Both are forbidden.
+- Does the PR body carry a correct closing reference, and no closing keyword next to an issue it
+  should not close?
+
+## 6. Does it claim more than it did?
+
+Compare the PR's stated payoff against its evidence. A fix that removes one wall usually exposes
+the next one — a measured example: removing a 612-failure wall moved 464 of them onto a
+different wall and turned 127 green. That is a good result honestly stated; "fixes 612" would
+not have been.
+
+Prefer a complete negative result over a speculative fix. "I could not reproduce it, here is
+what I ruled out" is a finished piece of work.
+
+## Reporting
+
+Order findings by whether they would change the merge decision. For each: what is wrong, the
+evidence, and what would settle it. Say plainly when you found nothing — a review that invents
+findings to look thorough is worse than no review.
+
+State explicitly whether, in your judgement, the PR meets the merge bar. The invoking session
+decides; you do not merge.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,11 +1,17 @@
 ---
 name: reviewer
 description: Review a pull request on AL Runner or the corpus against this repository's actual failure modes — whether the proving test proves anything, whether a BC-behaviour claim reached a real service tier, whether a measurement is sound, and whether anything fails silently. Use before merging, and as the review step of an unattended cycle. Reports findings; never merges.
-tools: Bash, Read, Grep, LSP, ToolSearch
+tools: Bash, Read, Grep, ToolSearch, mcp__github__get_me, mcp__github__list_pull_requests, mcp__github__pull_request_read, mcp__github__list_issues, mcp__github__issue_read, mcp__github__get_job_logs
 model: opus
 ---
 
 # Reviewing a pull request
+
+**Navigation:** use `tools/context-pack.py` and `tools/lsp-query.py` rather than the `LSP` tool —
+the harness disables `LSP` inside subagents on this build, and listing it in frontmatter does not
+help. Where `gh` is absent (web and remote sessions) use the `mcp__github__*` tools; an explicit
+`tools:` allowlist is exhaustive, so anything missing fails at call time with no warning.
+
 
 You report findings. You never merge, never push to the branch under review, and never comment
 publicly unless the invoking session tells you it is authorised.
@@ -99,6 +105,21 @@ not have been.
 
 Prefer a complete negative result over a speculative fix. "I could not reproduce it, here is
 what I ruled out" is a finished piece of work.
+
+## Reviewing a change to how agents work
+
+A PR that changes a skill, an agent definition or a rule has no runtime code, so every check
+above is inapplicable — and reporting "no findings" on the highest-blast-radius PR in the
+repository is the worst possible answer. Check instead:
+
+- **Does it contradict an auto-loaded rule file or a sister skill without editing it?** Two
+  documents giving different instructions means the agent guesses.
+- **Is every instruction executable with information the agent actually has?** A rule needing a
+  number it cannot read, or a judgement it cannot make alone, will be silently guessed at.
+- **Does any number have a durable, versioned home**, or does it live only in prose that goes
+  stale the first time the thing it measures improves?
+- **Is every irreversible action — merge, corpus merge, issue closure — gated by something
+  outside the agent's own lineage?** A reviewer the actor dispatches and briefs is not outside it.
 
 ## Reporting
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -2,6 +2,7 @@
 name: reviewer
 description: Review a pull request on AL Runner or the corpus against this repository's actual failure modes — whether the proving test proves anything, whether a BC-behaviour claim reached a real service tier, whether a measurement is sound, and whether anything fails silently. Use before merging, and as the review step of an unattended cycle. Reports findings; never merges.
 tools: Bash, Read, Grep, LSP, ToolSearch
+model: opus
 ---
 
 # Reviewing a pull request

--- a/.claude/rules/public-posting-approval.md
+++ b/.claude/rules/public-posting-approval.md
@@ -17,11 +17,23 @@ agents can work without a human in the loop:
   the orchestrator reviews and merges it when all 8 BC legs are green.** You still do
   not merge it.
 
+**Also ungated, on these two repositories only** (`BusinessCentral.AL.Runner` and
+`BusinessCentral.AL.Language.Tests`): commenting on issues and PRs, closing issues, and applying
+labels. A decision recorded as a comment on the issue outlives any agent's memory, and requiring
+approval for each one stalls an unattended session for no benefit.
+
+Two conditions come with it. **Every state change carries its reasoning** — closing, claiming,
+reclaiming, marking needs-input, declaring something out of scope — so the history is auditable
+by someone reading the repository later, without a transcript. And **every agent-authored issue,
+comment and PR body says so**, naming the agent, because these post under the account holder's
+name and a reader cannot otherwise tell an agent from a person. Comment on state changes and
+findings, never on progress.
+
 Everything else needs approval first:
 
-- Comments on issues or PRs (this repo or any other), including on the corpus repo.
-- PR review comments.
-- Anything else posted to another repo.
+- Comments or posts on **any other repository**.
+- PR review comments submitted as a formal review.
+- Anything sent outside GitHub — email, chat, anywhere else.
 
 This does not gate the mechanical steps of the established agent workflow (claiming an
 issue, opening your own implementation PR with `Closes #N`, labelling) — those are the

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -274,24 +274,37 @@ path or push to the same branch. Derive the namespace from the account running t
 
 ## How the loop is driven
 
-**One process per cycle, driven by a plain loop.** Not an OS scheduler: contributors run
-Windows as well as Linux and macOS, and a `while` loop in bash or PowerShell needs no scheduler
-at all and behaves identically on all three. A systemd unit or a Task Scheduler entry is
-optional hardening on top — restart on boot — never the mechanism itself.
+Two shapes work, and both need a supervising timer — a `/loop` session dies with its session
+exactly as a shell loop dies with its process, so something outside has to notice and restart
+either way. That is not the difference between them.
 
-This works because the design deliberately keeps state in the **repository** and the **box
-profile**, never in agent context. A cycle can therefore start cold and lose nothing:
+**A `/loop` session** keeps one session alive and re-entering the cycle. It is the more
+comfortable shape to watch and to tune. It is viable here for a specific reason: this design
+keeps state in the **repository** and the **box profile**, never in agent context, so a
+compaction cannot lose anything the loop depends on. In a design that carried state in context,
+running for days would be reckless.
 
-- **It survives its own crashes.** A dead cycle costs one unit of work; the next starts clean.
-- **Context cannot grow unboundedly.** A session running for days gets slower and more expensive
-  every cycle for no benefit.
-- **The five-hour window boundary stops mattering.** A cycle either fits or the next one starts
-  after the reset, so nothing is left stranded mid-task — which is otherwise the likeliest way
-  to lose work.
+**A fresh process per cycle** — a plain `while` loop in bash or PowerShell — starts cold every
+time. Deliberately not an OS scheduler as the mechanism: contributors run Windows as well as
+Linux and macOS, and a shell loop behaves identically on all three, with a systemd unit or Task
+Scheduler entry as optional restart-on-boot hardening.
 
-`/loop` is the right tool for a **supervised** run — self-pacing, keeps context, good while
-tuning with someone watching. It is the wrong tool for unattended running, because it ties the
-loop's life to one session's.
+**Bound the session's lifetime either way.** Even with compaction, a session running for days
+accumulates state that is not context — tool handles, temp files, harness state. Have the loop
+end itself after a set period or number of cycles and let the timer restart it. That keeps the
+`/loop` experience while capping accumulation, and it is better than either pure option.
+
+**Where compaction lands matters more than when it fires.** A compaction inside a unit of work
+discards that unit's working context; one between units costs nothing, because everything
+durable is already in git and the profile. So end every cycle at a durable checkpoint, and
+prefer a threshold that compacts often and cheaply at those boundaries over one that compacts
+rarely and expensively in the middle of something. A high threshold is not safer — it makes each
+compaction larger and likelier to interrupt work.
+
+Whichever shape is used, the properties that matter are the same: a dead cycle costs one unit of
+work, context does not grow without bound, and the five-hour window boundary is harmless because
+a cycle either fits or the next starts after the reset. Nothing should ever be stranded
+mid-task; that is the likeliest way to lose work.
 
 The cost of starting cold is that preflight repeats. Most of it is cheap; the known-good
 baseline is not, at a couple of minutes. Record in the box profile when the baseline last

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -299,10 +299,19 @@ declaring a surface out of scope, filing from a measured cluster: each gets a sh
 saying why, with the evidence. Someone reading the repository months later should be able to
 question any decision from the repository alone, without a transcript that no longer exists.
 
-**Say who is writing.** Comments post under the account the loop runs as, so a reader cannot
-otherwise tell an agent from a person — which matters on a public repository with outside
-contributors. Every agent-authored comment carries a consistent marker naming the agent tag and
-the cycle. It is honest, and it makes the audit trail searchable.
+**Say who is writing — on everything, not just comments.** Issues, comments, PR bodies and PR
+reviews all post under the account the loop runs as, so a reader cannot otherwise tell an agent
+from a person. On a public repository with outside contributors that is actively misleading:
+someone who asks the maintainer for a decision and receives an agent's answer in the
+maintainer's name has been misled, even with good intent.
+
+Every agent-authored issue, comment and PR body carries a footer saying it was written by an
+agent acting on the account holder's behalf, naming the agent tag and cycle. Where the thread is
+asking the account holder for a judgement, say explicitly that the decision remains theirs.
+
+This is not optional and it is easy to forget: in the session this skill was written from, 14
+issues and a comment were filed under the owner's name with no such marker, including a reply in
+a thread where a contributor had specifically asked the owner to decide.
 
 **Comment on state changes and findings, never on progress.** A loop that narrates itself
 drowns the signal it exists to produce. No "starting work on this". Never repeat a conclusion
@@ -325,6 +334,34 @@ would need to answer it, and move on — do not block, and do not guess:
   something that should work.
 - Anything where the loop has failed the same way several cycles running. That is not a hard
   problem, it is a wrong assumption, and it needs a person to see it.
+
+## Telling a person something is wrong
+
+Labels and issues are passive — someone has to go and look. An unattended loop that stops at
+03:00 tells nobody, and the machine sits idle until it is noticed. So the loop pushes a
+notification for the few things that genuinely need a person, and for nothing else.
+
+Notify on:
+
+- **It stopped.** Preflight failed, the baseline did not match, or it cannot complete any unit
+  of work at all. The machine is now idle and will stay idle.
+- **It is repeating itself.** The same failure several cycles running is a wrong assumption
+  rather than a hard problem, and only a person will see that.
+- **A decision has gone unanswered.** The human queue is untouched after several cycles and work
+  is piling up behind it.
+
+Never notify on ordinary progress. A channel that pings for every merged PR gets muted, and then
+it does not work when it matters — the same reasoning as commenting only on state changes.
+
+The transport is the contributor's own choice — a push service such as ntfy.sh, an email, a
+webhook. **Its configuration belongs in the gitignored box profile, never in the repository**: a
+notification endpoint is personal, and committing one exposes it to everyone who can read the
+repo. The skill specifies what is worth interrupting someone for; the contributor decides how it
+reaches them.
+
+Expect to also want a way in — SSH or equivalent — to inspect a box that has stopped. The
+notification says something is wrong; reading the box profile and the last cycle's report says
+what.
 
 ## Blast radius
 

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -86,9 +86,16 @@ Every check below exists because its absence has silently corrupted a result.
      slot; if another loop's work appeared under yours, take the next and re-check. Same
      compare-and-swap as issue claiming, and for the same reason.
 
-   Hold the slot visibly. A loop between tasks owns no work, so its slot looks free to a loop
-   starting up — keep your label on whatever you are working, and release it when you finish, so
-   the repository always shows which slots are live.
+   Keep your label on whatever you are working, so a loop starting up can see the slot is live.
+   Between units you hold nothing, so a concurrent startup may pick the same slot — that is what
+   the re-read above is for, and it is why the assignee, not the slot, is the real lock. Do not
+   try to judge whether someone else's open work is "still being worked": you cannot tell a dead
+   box from a contributor who is asleep, and the design refuses that judgement elsewhere for the
+   same reason.
+
+   Note the slot is bookkeeping, not safety. The incident it is often credited with preventing —
+   `impl-69`, 82 worktrees, 10 GB — was caused by nothing ever *deleting* a worktree. Preflight's
+   stale-worktree check is the actual fix for that.
 
    Use that one identity everywhere: labels, branch names, worktree directories, scratch and
    cache paths. Several loops can then run under one account, and several accounts against one
@@ -149,17 +156,34 @@ What belongs in it:
 - **Pacing observations** — how much budget a cycle actually consumed, so the gap between cycles
   can be tuned from evidence rather than guessed.
 
-Rewrite it at every startup rather than trusting yesterday's. A box changes: disks fill, other
-work starts, an artifact set goes stale. A stale profile is worse than none, because it looks
-authoritative.
+Keep two files, because they have opposite lifetimes:
+
+- **The measured profile is rewritten at every startup.** A box changes — disks fill, other work
+  starts, an artifact set goes stale — and a stale measurement is worse than none because it
+  looks authoritative.
+- **The cycle log is append-only and survives restarts.** Without it, three things the design
+  depends on are impossible: knowing when the baseline last passed (so it can run on an interval
+  instead of every cycle), comparing an odd cycle against a known-good starting state, and
+  detecting "the same failure several cycles running" — which is one of the three conditions
+  that is supposed to notify a human, and is undetectable if each startup erases the evidence.
+
+Record per cycle: what it worked, the outcome, the failure signature if any, and what it
+consumed.
 
 ## Priority order
 
 Work the first item that applies. Re-evaluate from the top after every completed unit of work —
 a merge can turn `main` red, which outranks everything you were about to do.
 
-1. **`main` is red.** Nothing else matters. Read the failing log (never re-run a failed job —
-   it destroys the log), diagnose, fix.
+1. **`main` is red.** Nothing else matters. Read the failing log (never re-run a failed job — it
+   destroys the log), diagnose, fix.
+
+   **Cap this.** A load-dependent flake — a red `main` whose *failing-leg set moves between
+   runs* — cannot be fixed and will otherwise re-enter priority 1 every cycle until the weekend
+   is gone. Apply `ci-verdicts.md`'s evidence bar before treating red as real, and after a few
+   consecutive cycles on the same red, notify a human and demote it so other work continues.
+   Never ship a speculative fix to get past it: unattended and self-reviewed, that is how a wrong
+   change reaches `main`.
 2. **One of our PRs is red.** Drive it green, or close it with the reason. A red PR left open is
    worse than no PR: it looks like progress.
 3. **A PR is waiting on review.** Dispatch a review agent, or review it directly. Ours can be
@@ -242,9 +266,16 @@ bookkeeping; the assignee is what prevents two agents doing the same issue.
 
 **Look in this order, and it works for any account:**
 
-1. **Issues already assigned to the account you are logged in as.** Finish your own work before
-   starting more. This is also how a restarted loop resumes: a box that died mid-issue comes
-   back, sees its own claim, and picks up where it left off instead of stranding it.
+1. **Issues assigned to your account AND carrying your own `agent: <tag>-N` label.** Both, not
+   either. This is how a restarted loop resumes — a box that died mid-issue comes back, sees its
+   own claim and continues instead of stranding it.
+
+   **The assignment alone is not enough.** A maintainer assigns issues to themselves to mean "I
+   am thinking about this", and `branch-and-pr.md` uses a non-self assignee to mean "a human is
+   handling it" — the field is overloaded. On this repository the owner currently holds 22 open
+   issues that way. A loop running as that account and resuming on assignment alone would adopt
+   all of them on its first cycle. The label is what distinguishes "my loop took this" from "I
+   took this".
 2. **Unassigned issues.** Take the highest-value one and assign it to yourself.
 3. **Issues assigned to anyone else — leave them alone.** Someone is on it, whether that is a
    human maintainer or another contributor's loop. Do not take it, do not work it in parallel,
@@ -317,9 +348,13 @@ The five-hour windows are real, but **exhausting every window burns the weekly l
 couple of days.** The budget that matters is weekly, so run continuously *below* per-window
 capacity rather than sprinting and then idling.
 
-One agent at a time is most of the pacing. Beyond that, keep a deliberate gap between cycles and
-tune it from observed consumption rather than from a guess — start conservative and measure how
-usage actually grows over a full day before increasing it.
+One agent at a time is most of the pacing. Beyond that, use numbers the loop can actually count,
+because **it has no way to read its own token consumption or remaining budget** — an instruction
+to "tune from observed consumption" cannot be followed and will be guessed at.
+
+Put concrete values in the box profile and obey them: a fixed wall-clock gap between cycles, and
+a hard cap on cycles per rolling 24 hours. Count cycles, subagents spawned and elapsed time —
+all observable. Tuning those numbers is a human's job between runs, not the loop's during one.
 
 Never leave an agent mid-task when a budget boundary is near. Have it commit and push what it
 has, even incomplete, and report where it got to. A work-in-progress commit on a pushed branch
@@ -439,6 +474,8 @@ what.
 Hard limits, whatever the loop concludes:
 
 - Never push to `main`; always a PR.
+- **Never merge while a release run is in progress.** `publish.yml` pushes the release as a
+  fast-forward, so any merge during its ~40-minute run kills it.
 - Never force-push a branch you do not own, and never `--admin` past a failing check.
 - Never merge a PR authored by someone else.
 - Never re-run a **failed** CI job — it destroys the log permanently. Re-running a **cancelled**

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -5,6 +5,24 @@ description: Run AL Runner development unattended — a never-idle loop that kee
 
 # Autonomous cycle
 
+## What the loop is for
+
+The runner exists to behave exactly like Business Central. Tests are not overhead and not a
+box to tick — they are the only thing that establishes that claim, and **only the corpus
+establishes it against a real service tier.** A runner-local test that passes proves the runner
+agrees with itself; it says nothing about BC.
+
+So the measure of a good cycle is not how many issues it closed. It is whether the proof that
+the runner matches BC got larger and stayed green. The corpus is a ratchet: every behaviour
+pinned there is validated on real BC on every push and can never silently regress afterwards.
+As long as the corpus stays green and the runner stays green against the corpus, the runner is
+doing its job — and anything not pinned there is a claim nobody is checking.
+
+Read every priority below through that lens. A fix that closes an issue and adds no upstream
+coverage has moved a number; a fix that lands with a corpus test has moved the guarantee.
+
+## Working unattended
+
 This runs without anyone watching. That changes what matters: not throughput, but never
 producing confident wrong work. An unattended loop that files issues from a poisoned cache, or
 merges on a stale verdict, does not just waste a window — it fills the backlog with plausible
@@ -116,6 +134,17 @@ a merge can turn `main` red, which outranks everything you were about to do.
 
    **The clean-cache confirmation is not optional.** It is the difference between the loop
    compounding value and compounding noise.
+
+7. **Still nothing to do — grow the corpus.** Pick AL behaviour the runner supports but nothing
+   upstream pins, write the test, and open the corpus PR. This is real work, not filler: it
+   converts behaviour that currently happens to work into behaviour a real service tier
+   guarantees, and it is the only priority that makes the runner harder to regress rather than
+   just less broken.
+
+   Good candidates are surfaces a fix recently touched without adding upstream coverage, areas
+   where a runner-local test is doing a job the corpus should be doing, and anything a past fix
+   proved by reasoning rather than by a service tier's verdict. The corpus CI adjudicates the
+   claim, so a wrong guess costs a red leg and nothing worse.
 
    Configuration matters as much as the run. In one measured no-test-data run, roughly 40% of
    all failures were missing setup data rather than defects — clustering that would have

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -110,6 +110,22 @@ not as a log line. A FAIL should say what to do about it.
 Record the result. If a later cycle behaves oddly, the first question is whether the box
 drifted since.
 
+## Pin the model on every dispatch
+
+Every agent definition here is pinned to Opus, but **pass the model explicitly when you dispatch
+anyway.** Frontmatter is easy to overlook and a default is silent: `impl-agent` and
+`orchestrator` sat on `model: sonnet` for a long time, so an unattended loop would have run its
+implementation and its merge decisions on the smaller model without anything saying so.
+
+The coordinator loop itself, and every agent it spawns — implementation, review, triage — run on
+Opus, at high reasoning effort where the harness exposes it. This work is diagnosis: today's
+findings came from decompiling BC to pin an identifier rule to seven names out of 4,905, and
+from separating a cascade of 47 failures into one defect. That is not throughput work, and the
+cheaper model is a false economy when a wrong diagnosis becomes a filed issue nobody can trust.
+
+If you cannot confirm what the running model is, say so in the cycle's report rather than
+assuming the pin took.
+
 ## The box profile
 
 The preflight measures the machine and records what it found. Everything downstream reads that

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -67,7 +67,27 @@ Every check below exists because its absence has silently corrupted a result.
 5. **Headroom.** Read free RAM and disk, and derive worker and job counts from them. Never
    hardcode. Set `MemoryHigh` below `MemoryMax` on any long run so a cgroup throttles before the
    kernel's global OOM killer starts choosing victims elsewhere on the machine.
-6. **No stale worktree for this identity**, and no leftover scratch directories from a killed
+6. **Your label namespace is yours alone.** Derive a short agent tag from the account the loop
+   is logged in as — `gh api user --jq .login` — because logins are already unique, so a tag
+   derived from one inherits that for free. Uniqueness only comes back into question when you
+   **abbreviate**, and an abbreviation is exactly what makes a readable label, so verify rather
+   than assume:
+
+   - List the `agent:` labels that already exist on the repository.
+   - Check whether your intended tag already appears on issues or PRs that are **not** yours. If
+     it does, someone else is using it — pick another and re-check, or stop and report it.
+   - Check the same tag is not in flight on open work you did not create.
+
+   Then use it consistently: labels (`agent: <tag>-1`), branch names, worktree directories,
+   scratch and cache paths. One derivation, applied everywhere, and two contributors can run the
+   same loop against the same repository without ever writing to the same name.
+
+   The existing `agent: impl-N` convention is the counter-example worth avoiding: it is a global
+   counter with no owner, and it drifted to `impl-69` while leaving 82 worktrees and 10 GB of
+   disk behind. A per-account namespace cannot drift that way, because the identity is not a
+   number anyone increments.
+
+7. **No stale worktree for this identity**, and no leftover scratch directories from a killed
    run.
 
 **Print the preflight as a readable report** — one line per check, PASS or FAIL with the reason
@@ -155,6 +175,10 @@ a merge can turn `main` red, which outranks everything you were about to do.
 
 Several people may run this loop at once, against the same repository, with no coordination
 between them. Nothing may depend on them talking to each other.
+
+**The assignee locks; your label discriminates.** Both matter and they do different jobs: the
+assignee is what stops two agents working the same issue, and your own agent label is what lets
+you (and anyone reading the repository later) tell which work came from which loop. Set both.
 
 **The GitHub assignee is the lock**, and it decides the order you look in. It is visible to
 everyone, survives a crashed box, and needs no shared state between contributors. A dedicated

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -286,18 +286,45 @@ Never leave an agent mid-task when a budget boundary is near. Have it commit and
 has, even incomplete, and report where it got to. A work-in-progress commit on a pushed branch
 survives; an uncommitted worktree does not.
 
-## The human queue
+## Posting, and leaving an audit trail
 
-Some things must not be decided unattended. Label them and move on — do not block, and do not
-guess:
+Within **this repository and the corpus repository**, the loop acts without asking: filing
+issues, commenting on issues and PRs, closing issues, applying labels. Waiting for approval on
+each of those would stall an unattended loop for no benefit, and a comment on the issue is a
+better home for a decision than an agent's memory, which is discarded.
 
-- A genuine product decision. Example: `--test-data` presents a company whose configuration
-  differs from Microsoft's test database. Whether hydration should change that is a judgement
-  call, not an agent's.
-- Anything posted publicly on someone else's behalf — comments, review comments, anything in
-  another repository.
-- Merging a PR authored by anyone other than the repository owner.
-- A refusal that might be a scope boundary rather than a defect.
+**Every state change carries its reasoning.** Not as a permission step — as the thing that makes
+the loop auditable. Closing an issue, claiming or reclaiming one, marking it needs-input,
+declaring a surface out of scope, filing from a measured cluster: each gets a short comment
+saying why, with the evidence. Someone reading the repository months later should be able to
+question any decision from the repository alone, without a transcript that no longer exists.
+
+**Say who is writing.** Comments post under the account the loop runs as, so a reader cannot
+otherwise tell an agent from a person — which matters on a public repository with outside
+contributors. Every agent-authored comment carries a consistent marker naming the agent tag and
+the cycle. It is honest, and it makes the audit trail searchable.
+
+**Comment on state changes and findings, never on progress.** A loop that narrates itself
+drowns the signal it exists to produce. No "starting work on this". Never repeat a conclusion
+already on the thread — if nothing changed, there is nothing to say.
+
+**Outside these two repositories, nothing is automatic.** Another repository, email, anywhere
+else: that needs a human, whatever the loop concludes.
+
+## What still needs a person
+
+Some things are not the loop's to decide. Label them, comment with the question and what you
+would need to answer it, and move on — do not block, and do not guess:
+
+- A genuine product decision. Whether `--test-data` should present a company configured
+  differently from the backup it loads is a judgement call about what the runner is *for*, not a
+  defect.
+- Merging a PR authored by anyone other than the account the loop runs as.
+- A refusal that might be a correct scope boundary rather than a gap. Getting that wrong in
+  either direction is expensive: implementing something that should throw, or throwing on
+  something that should work.
+- Anything where the loop has failed the same way several cycles running. That is not a hard
+  problem, it is a wrong assumption, and it needs a person to see it.
 
 ## Blast radius
 

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -272,6 +272,32 @@ a dead box from a contributor who is asleep. Surface it to the human queue and m
 branches, scratch directories, cache directories. Two contributors must never write to the same
 path or push to the same branch. Derive the namespace from the account running the loop.
 
+## How the loop is driven
+
+**One process per cycle, driven by a plain loop.** Not an OS scheduler: contributors run
+Windows as well as Linux and macOS, and a `while` loop in bash or PowerShell needs no scheduler
+at all and behaves identically on all three. A systemd unit or a Task Scheduler entry is
+optional hardening on top — restart on boot — never the mechanism itself.
+
+This works because the design deliberately keeps state in the **repository** and the **box
+profile**, never in agent context. A cycle can therefore start cold and lose nothing:
+
+- **It survives its own crashes.** A dead cycle costs one unit of work; the next starts clean.
+- **Context cannot grow unboundedly.** A session running for days gets slower and more expensive
+  every cycle for no benefit.
+- **The five-hour window boundary stops mattering.** A cycle either fits or the next one starts
+  after the reset, so nothing is left stranded mid-task — which is otherwise the likeliest way
+  to lose work.
+
+`/loop` is the right tool for a **supervised** run — self-pacing, keeps context, good while
+tuning with someone watching. It is the wrong tool for unattended running, because it ties the
+loop's life to one session's.
+
+The cost of starting cold is that preflight repeats. Most of it is cheap; the known-good
+baseline is not, at a couple of minutes. Record in the box profile when the baseline last
+passed and re-run it on an interval rather than every cycle — often enough to catch a box that
+has drifted, rarely enough that it is not most of the work.
+
 ## Pacing
 
 The five-hour windows are real, but **exhausting every window burns the weekly limit in a

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -52,8 +52,13 @@ Every check below exists because its absence has silently corrupted a result.
 6. **No stale worktree for this identity**, and no leftover scratch directories from a killed
    run.
 
-Record the preflight result. If a later cycle behaves oddly, the first question is whether the
-box drifted since.
+**Print the preflight as a readable report** — one line per check, PASS or FAIL with the reason
+and the command that produced it. That report is what a new contributor reads to find out
+whether their box is set up correctly, so write it for a person who has never run this before,
+not as a log line. A FAIL should say what to do about it.
+
+Record the result. If a later cycle behaves oddly, the first question is whether the box
+drifted since.
 
 ## Priority order
 
@@ -69,8 +74,14 @@ a merge can turn `main` red, which outranks everything you were about to do.
    — never merged, never commented on unattended.
 4. **A corpus PR has all legs green.** Merge it, then fold the submodule pin bump and the
    count-baseline update into the runner PR that needs it. A pin bump is never its own PR.
-5. **An issue is `status: ready`.** Take the highest-value one — prefer a measured failure count
+5. **An issue is ready to work.** Take the highest-value one — prefer a measured failure count
    over a guess — and implement it. One issue at a time.
+
+   Use the `status: ready` label where it exists, but **do not depend on it.** The loop must work
+   on a repository whose labels are absent, stale, or organised differently. Fall back to: open,
+   unclaimed, and carrying enough to act on — a reproducer, a failing test name, or a concrete
+   file and mechanism. An issue too thin to act on is not a candidate; say so on it and move on
+   rather than guessing (`.claude/rules/no-assumption-fixes.md`).
 6. **The ready queue is empty — generate work.** This is what keeps the loop from idling, and it
    is the step most able to do harm, so it has a mandatory gate:
 
@@ -88,6 +99,39 @@ a merge can turn `main` red, which outranks everything you were about to do.
    all failures were missing setup data rather than defects — clustering that would have
    produced a stream of confident, wrong issues. Never file from a run whose configuration you
    cannot vouch for.
+
+## Claiming, and not colliding with other contributors
+
+Several people may run this loop at once, against the same repository, with no coordination
+between them. Nothing may depend on them talking to each other.
+
+**The GitHub assignee is the lock.** It is visible to everyone, survives a crashed box, and
+needs no shared state. A dedicated label (`agent: autonomous`, or a per-contributor one) is
+useful for telling afterwards which work the loop produced — but the label is bookkeeping; the
+assignee is what prevents two agents doing the same issue.
+
+**Claiming is read-then-write, so it races.** Two loops that list candidates at the same moment
+will pick the same top issue. Use a compare-and-swap shape instead of trusting the write:
+
+1. Skip anything already assigned to anyone.
+2. Assign it to yourself.
+3. **Re-read the issue.** If it now carries another assignee, or yours is not there, release and
+   take the next candidate. Losing a race costs one API call; two agents silently doing the same
+   issue costs both of them.
+4. Only then start work.
+
+**Reclaim abandoned work.** A box can die mid-issue and leave a claim behind forever. Treat a
+claim as stale when it has no linked PR and no activity for several hours, and reclaim it —
+noting on the issue that you did. Without this, every crash permanently removes an issue from
+circulation.
+
+**Release when you stop.** Finished without a fix, blocked, or shutting down for budget: remove
+your assignment so someone else can take it. An issue you cannot finish should go back to the
+pool, not stay parked under your name.
+
+**Namespace anything per-contributor** that lives on disk or in a branch name — worktrees,
+branches, scratch directories, cache directories. Two contributors must never write to the same
+path or push to the same branch. Derive the namespace from the account running the loop.
 
 ## Pacing
 

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -156,29 +156,38 @@ a merge can turn `main` red, which outranks everything you were about to do.
 Several people may run this loop at once, against the same repository, with no coordination
 between them. Nothing may depend on them talking to each other.
 
-**The GitHub assignee is the lock.** It is visible to everyone, survives a crashed box, and
-needs no shared state. A dedicated label (`agent: autonomous`, or a per-contributor one) is
-useful for telling afterwards which work the loop produced — but the label is bookkeeping; the
-assignee is what prevents two agents doing the same issue.
+**The GitHub assignee is the lock**, and it decides the order you look in. It is visible to
+everyone, survives a crashed box, and needs no shared state between contributors. A dedicated
+label is useful for telling afterwards which work the loop produced — but the label is
+bookkeeping; the assignee is what prevents two agents doing the same issue.
 
-**Claiming is read-then-write, so it races.** Two loops that list candidates at the same moment
-will pick the same top issue. Use a compare-and-swap shape instead of trusting the write:
+**Look in this order, and it works for any account:**
 
-1. Skip anything already assigned to anyone.
-2. Assign it to yourself.
-3. **Re-read the issue.** If it now carries another assignee, or yours is not there, release and
-   take the next candidate. Losing a race costs one API call; two agents silently doing the same
-   issue costs both of them.
-4. Only then start work.
+1. **Issues already assigned to the account you are logged in as.** Finish your own work before
+   starting more. This is also how a restarted loop resumes: a box that died mid-issue comes
+   back, sees its own claim, and picks up where it left off instead of stranding it.
+2. **Unassigned issues.** Take the highest-value one and assign it to yourself.
+3. **Issues assigned to anyone else — leave them alone.** Someone is on it, whether that is a
+   human maintainer or another contributor's loop. Do not take it, do not work it in parallel,
+   do not comment on it.
 
-**Reclaim abandoned work.** A box can die mid-issue and leave a claim behind forever. Treat a
-claim as stale when it has no linked PR and no activity for several hours, and reclaim it —
-noting on the issue that you did. Without this, every crash permanently removes an issue from
-circulation.
+That ordering is the whole cross-contributor story: every loop works its own queue first, draws
+from the common pool second, and never touches another's. No coordination needed.
+
+**Claiming is read-then-write, so it races.** Two loops listing candidates at the same moment
+pick the same top issue. Use compare-and-swap rather than trusting the write: assign it, then
+**re-read**. If another assignee appeared, or yours did not stick, release and take the next
+candidate. Losing a race costs one API call; two agents silently doing the same issue costs
+both.
 
 **Release when you stop.** Finished without a fix, blocked, or shutting down for budget: remove
-your assignment so someone else can take it. An issue you cannot finish should go back to the
-pool, not stay parked under your name.
+your assignment so the issue returns to the pool. An issue you cannot finish should not stay
+parked under your name.
+
+**Your own stale claims are yours to reclaim** — a claim of yours with no linked PR and no
+activity for hours is from a run that died, and rule 1 above picks it up automatically.
+**Someone else's stale claim is not yours to take**, even if it looks abandoned. You cannot tell
+a dead box from a contributor who is asleep. Surface it to the human queue and move on.
 
 **Namespace anything per-contributor** that lives on disk or in a branch name — worktrees,
 branches, scratch directories, cache directories. Two contributors must never write to the same

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -72,6 +72,28 @@ a merge can turn `main` red, which outranks everything you were about to do.
 3. **A PR is waiting on review.** Dispatch a review agent, or review it directly. Ours can be
    merged on a green pipeline; someone else's is reviewed and its findings go to the human queue
    — never merged, never commented on unattended.
+
+   **Every review must answer one question before the merge bar: does this PR assert something
+   about what BC does?** If it does, the proving test belongs upstream in the corpus, and this PR
+   must either link a corpus PR or explain why the corpus cannot express it. Runner
+   infrastructure — process configuration, CI plumbing, error handling, caching, parallelism —
+   asserts nothing about BC and owes nothing upstream. A change to what the runner makes AL code
+   *observe* almost always does.
+
+   "The corpus cannot express this" is a claim needing evidence like any other. It is sometimes
+   true, and the reason is structural: corpus tests are compiled from AL source *by the runner*,
+   so a defect that only affects **precompiled** dependency artifacts cannot be reproduced there
+   — the test would take the source-compiled path and pass. That answer is acceptable when the
+   PR names that structural reason and puts its proving test in `tests/runner-extras/`. It is not
+   acceptable as a way to avoid writing the upstream test.
+
+   **Do not merge a PR that closes a BC-behaviour issue on the strength of a runner-local test
+   alone.** That is the exact failure `bc-behavior-tests-go-upstream.md` exists to prevent, and it
+   is invisible: the runner-local test is green and nothing complains. Unattended, nobody will
+   notice — so the review step is the only place it can be caught.
+
+   Corollary for the loop's own output: if it merges several fixes and opens no corpus PR, treat
+   that as a signal to check rather than as evidence the work was all infrastructure.
 4. **A corpus PR has all legs green.** Merge it, then fold the submodule pin bump and the
    count-baseline update into the runner PR that needs it. A pin bump is never its own PR.
 5. **An issue is ready to work.** Take the highest-value one — prefer a measured failure count

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -67,25 +67,37 @@ Every check below exists because its absence has silently corrupted a result.
 5. **Headroom.** Read free RAM and disk, and derive worker and job counts from them. Never
    hardcode. Set `MemoryHigh` below `MemoryMax` on any long run so a cgroup throttles before the
    kernel's global OOM killer starts choosing victims elsewhere on the machine.
-6. **Your label namespace is yours alone.** Derive a short agent tag from the account the loop
-   is logged in as — `gh api user --jq .login` — because logins are already unique, so a tag
-   derived from one inherits that for free. Uniqueness only comes back into question when you
-   **abbreviate**, and an abbreviation is exactly what makes a readable label, so verify rather
-   than assume:
+6. **Claim a label slot, do not just derive one.** The account gives you a namespace; a slot
+   number makes you unique *within* it, because one person may run several loops at once.
 
-   - List the `agent:` labels that already exist on the repository.
-   - Check whether your intended tag already appears on issues or PRs that are **not** yours. If
-     it does, someone else is using it — pick another and re-check, or stop and report it.
-   - Check the same tag is not in flight on open work you did not create.
+   Derive the namespace from the account the loop is logged in as — `gh api user --jq .login` —
+   since logins are already unique, so a tag derived from one inherits that for free. Uniqueness
+   only comes back into question when you **abbreviate**, and an abbreviation is what makes a
+   readable label, so verify rather than assume: list the `agent:` labels already on the
+   repository and confirm your intended namespace does not appear on issues or PRs belonging to
+   someone else. On a clash pick another and re-check, or stop and report it.
 
-   Then use it consistently: labels (`agent: <tag>-1`), branch names, worktree directories,
-   scratch and cache paths. One derivation, applied everywhere, and two contributors can run the
-   same loop against the same repository without ever writing to the same name.
+   Then take the lowest free slot — `<tag>-1`, `<tag>-2`, … — by asking the repository, which is
+   the only state two loops share:
 
-   The existing `agent: impl-N` convention is the counter-example worth avoiding: it is a global
-   counter with no owner, and it drifted to `impl-69` while leaving 82 worktrees and 10 GB of
-   disk behind. A per-account namespace cannot drift that way, because the identity is not a
-   number anyone increments.
+   - A slot is **taken** if any open issue or PR carries that label and is still being worked.
+   - A slot is **free** if its label exists but nothing open carries it, or it does not exist.
+   - Claim the lowest free one, then **re-read**. Two loops starting together will pick the same
+     slot; if another loop's work appeared under yours, take the next and re-check. Same
+     compare-and-swap as issue claiming, and for the same reason.
+
+   Hold the slot visibly. A loop between tasks owns no work, so its slot looks free to a loop
+   starting up — keep your label on whatever you are working, and release it when you finish, so
+   the repository always shows which slots are live.
+
+   Use that one identity everywhere: labels, branch names, worktree directories, scratch and
+   cache paths. Several loops can then run under one account, and several accounts against one
+   repository, without ever writing the same name.
+
+   The existing `agent: impl-N` convention is the counter-example worth avoiding: a global
+   counter with no owner, which drifted to `impl-69` while leaving 82 worktrees and 10 GB of disk
+   behind. Slots numbered *inside* an account namespace cannot drift that way — they are
+   reclaimed by the next loop that starts, instead of incremented forever.
 
 7. **No stale worktree for this identity**, and no leftover scratch directories from a killed
    run.

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -50,12 +50,22 @@ Exactly one agent runs. When it returns, you review, act, and start the next.
 A fresh or drifted box does not announce that it is broken; it produces numbers that look fine.
 Every check below exists because its absence has silently corrupted a result.
 
-1. **Known-good baseline.** Run one pinned bucket and compare against its recorded count. This
-   single check catches a poisoned cache, a wrong BC version, a missing package cache, a broken
-   artifact set and a bad backup reader — all of which otherwise surface as believable failure
-   clusters that the loop would file as issues. **If the number does not match, stop and open an
-   issue. Do not continue.** Use a private `--cache` dir so the check is about the box, not about
-   whatever a previous run left behind.
+1. **Known-good baseline — run the corpus.** `tests/al-language` is green or it is not, and its
+   expected count lives in `tests/expectations/count-baseline/`, checked in and only moved by a
+   PR that deliberately bumps it. That makes it the right health check and means no new baseline
+   needs inventing: a box that cannot reproduce it is a box whose results cannot be trusted.
+
+   Do **not** gate on a Microsoft bucket's pass count. There is no green there — it is a number
+   that rises as the runner improves, so equality-gating on it would halt the loop on its first
+   success, and recording "whatever this box last saw" would ratify drift instead of catching it.
+
+   Run it against the **shared cache the work will actually use**, not a private one. The failure
+   this catches is a cache left inconsistent by a killed run, which once cost 76% of passing
+   tests with no error and an unchanged exit code — a private cache is blind to exactly that.
+
+   If it does not reproduce: stop, notify, and open an issue. Everything downstream is untrusted
+   until it does.
+
 2. **Push works.** `git ls-remote origin HEAD`. Push auth fails silently when it is routed
    through an interactive credential agent.
 3. **Commits work.** Either signing succeeds, or signing is off. A locked signing agent makes
@@ -186,9 +196,25 @@ a merge can turn `main` red, which outranks everything you were about to do.
    change reaches `main`.
 2. **One of our PRs is red.** Drive it green, or close it with the reason. A red PR left open is
    worse than no PR: it looks like progress.
-3. **A PR is waiting on review.** Dispatch a review agent, or review it directly. Ours can be
-   merged on a green pipeline; someone else's is reviewed and its findings go to the human queue
-   — never merged, never commented on unattended.
+3. **A PR is waiting on review.** Dispatch the `reviewer` agent. A PR authored by the account
+   the loop runs as may be merged unattended **only when every one of these aligns** — any one
+   missing sends it to the human queue instead:
+
+   - the reviewer says it meets the bar, having actually reviewed this head SHA;
+   - every required check is green **on the current head**, with no `CANCELLED` required context;
+   - `git merge-tree` is clean against current `main`, and the affected tests were re-run if the
+     branch was rebased;
+   - if it asserts anything about BC's behaviour, the corpus PR proving it **has merged**, and
+     its pin bump and count-baseline update are folded into this PR;
+   - it is not a release window (`publish.yml` pushes a fast-forward; a merge during its run
+     kills it).
+
+   A PR from anyone else is reviewed, and its findings go to the human queue. Never merged.
+
+   The reviewer is dispatched by the loop, so it is not independent oversight — it is a second
+   pass by the same lineage. It catches carelessness, not a shared wrong assumption. That is why
+   the other gates are mechanical and checkable rather than judgement calls, and why repeated
+   failure in one area escalates to a person.
 
    **Every review must answer one question before the merge bar: does this PR assert something
    about what BC does?** If it does, the proving test belongs upstream in the corpus, and this PR

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: autonomous-cycle
+description: Run AL Runner development unattended — a never-idle loop that keeps exactly one agent working at a time, in a fixed priority order, across both the runner and the corpus repository. Starts with a preflight that refuses to run on a box that would produce wrong answers, paces itself against a weekly token budget rather than filling each window, and routes anything needing human judgement to a queue instead of guessing. Use when starting an unattended session; not needed for interactive work.
+---
+
+# Autonomous cycle
+
+This runs without anyone watching. That changes what matters: not throughput, but never
+producing confident wrong work. An unattended loop that files issues from a poisoned cache, or
+merges on a stale verdict, does not just waste a window — it fills the backlog with plausible
+garbage that a human then has to unpick.
+
+So the loop is deliberately narrow: **one agent working at a time, in a fixed priority order,
+behind a preflight that can stop everything.**
+
+## Why one agent at a time
+
+Measured on 2026-09-05, a coordinator ran nine agents in parallel for about ninety minutes.
+Throughput was real, but every finding of lasting value came from *depth*, not parallelism:
+4,905 Base App members measured to pin an identifier-mangling rule to exactly seven names; the
+discovery that every Base App report's lifecycle triggers were silently empty; a cache-poisoning
+diagnosis narrowed to a derived tier whose key has no term for what it was derived from.
+
+In the same session at least four confident conclusions were wrong and were caught only because
+a human pushed back or because something was re-measured. Parallelism multiplies that risk.
+Serial work with a review step does not.
+
+Exactly one agent runs. When it returns, you review, act, and start the next.
+
+## Preflight — run this first, every time, and stop if it fails
+
+A fresh or drifted box does not announce that it is broken; it produces numbers that look fine.
+Every check below exists because its absence has silently corrupted a result.
+
+1. **Known-good baseline.** Run one pinned bucket and compare against its recorded count. This
+   single check catches a poisoned cache, a wrong BC version, a missing package cache, a broken
+   artifact set and a bad backup reader — all of which otherwise surface as believable failure
+   clusters that the loop would file as issues. **If the number does not match, stop and open an
+   issue. Do not continue.** Use a private `--cache` dir so the check is about the box, not about
+   whatever a previous run left behind.
+2. **Push works.** `git ls-remote origin HEAD`. Push auth fails silently when it is routed
+   through an interactive credential agent.
+3. **Commits work.** Either signing succeeds, or signing is off. A locked signing agent makes
+   `git commit` **hang forever** rather than fail — an unattended loop simply stops there.
+4. **GitHub permissions.** Probe what this account can actually do — merge, label, assign,
+   close. Do not assume, and do not branch behaviour on who is running: the loop behaves
+   identically for everyone. A missing permission is a **precondition failure to report**, not a
+   second mode to implement.
+5. **Headroom.** Read free RAM and disk, and derive worker and job counts from them. Never
+   hardcode. Set `MemoryHigh` below `MemoryMax` on any long run so a cgroup throttles before the
+   kernel's global OOM killer starts choosing victims elsewhere on the machine.
+6. **No stale worktree for this identity**, and no leftover scratch directories from a killed
+   run.
+
+Record the preflight result. If a later cycle behaves oddly, the first question is whether the
+box drifted since.
+
+## Priority order
+
+Work the first item that applies. Re-evaluate from the top after every completed unit of work —
+a merge can turn `main` red, which outranks everything you were about to do.
+
+1. **`main` is red.** Nothing else matters. Read the failing log (never re-run a failed job —
+   it destroys the log), diagnose, fix.
+2. **One of our PRs is red.** Drive it green, or close it with the reason. A red PR left open is
+   worse than no PR: it looks like progress.
+3. **A PR is waiting on review.** Dispatch a review agent, or review it directly. Ours can be
+   merged on a green pipeline; someone else's is reviewed and its findings go to the human queue
+   — never merged, never commented on unattended.
+4. **A corpus PR has all legs green.** Merge it, then fold the submodule pin bump and the
+   count-baseline update into the runner PR that needs it. A pin bump is never its own PR.
+5. **An issue is `status: ready`.** Take the highest-value one — prefer a measured failure count
+   over a guess — and implement it. One issue at a time.
+6. **The ready queue is empty — generate work.** This is what keeps the loop from idling, and it
+   is the step most able to do harm, so it has a mandatory gate:
+
+   ```
+   run a Microsoft BaseApp bucket in a known-good configuration
+     -> cluster the failures
+       -> re-run the top cluster against a CLEAN cache to confirm it is real
+         -> only then file an issue, with the measured count
+   ```
+
+   **The clean-cache confirmation is not optional.** It is the difference between the loop
+   compounding value and compounding noise.
+
+   Configuration matters as much as the run. In one measured no-test-data run, roughly 40% of
+   all failures were missing setup data rather than defects — clustering that would have
+   produced a stream of confident, wrong issues. Never file from a run whose configuration you
+   cannot vouch for.
+
+## Pacing
+
+The five-hour windows are real, but **exhausting every window burns the weekly limit in a
+couple of days.** The budget that matters is weekly, so run continuously *below* per-window
+capacity rather than sprinting and then idling.
+
+One agent at a time is most of the pacing. Beyond that, keep a deliberate gap between cycles and
+tune it from observed consumption rather than from a guess — start conservative and measure how
+usage actually grows over a full day before increasing it.
+
+Never leave an agent mid-task when a budget boundary is near. Have it commit and push what it
+has, even incomplete, and report where it got to. A work-in-progress commit on a pushed branch
+survives; an uncommitted worktree does not.
+
+## The human queue
+
+Some things must not be decided unattended. Label them and move on — do not block, and do not
+guess:
+
+- A genuine product decision. Example: `--test-data` presents a company whose configuration
+  differs from Microsoft's test database. Whether hydration should change that is a judgement
+  call, not an agent's.
+- Anything posted publicly on someone else's behalf — comments, review comments, anything in
+  another repository.
+- Merging a PR authored by anyone other than the repository owner.
+- A refusal that might be a scope boundary rather than a defect.
+
+## Blast radius
+
+Hard limits, whatever the loop concludes:
+
+- Never push to `main`; always a PR.
+- Never force-push a branch you do not own, and never `--admin` past a failing check.
+- Never merge a PR authored by someone else.
+- Never re-run a **failed** CI job — it destroys the log permanently. Re-running a **cancelled**
+  one is fine; it has no failure log to lose, and a cancelled required context can block a merge
+  with everything green.
+- Never delete a shared cache or a scratch directory you did not create. Other work may be live.
+- Never read a secret, and never try to unlock a credential agent.
+
+## What "done" looks like for one unit of work
+
+A cycle ends with something durable and checkable: a pushed branch, a PR whose head SHA matches
+what was tested, or an issue carrying a measured count and a reproducer. A cycle that ends with
+a conclusion only in an agent's context has produced nothing — that context is discarded.
+
+Prefer a complete negative result over a speculative fix. "I could not reproduce it, here is
+what I ruled out and why" is a finished unit of work, and on a busy repository it is often worth
+more than a patch that makes a symptom disappear.
+
+## Sister material
+
+`orchestrating-a-session` — the judgement calls, the merge bar, the measurement rules and the
+environment traps. This skill is that one, narrowed to run unattended.
+`.claude/commands/work-cycle.md` — the interactive, parallel equivalent.

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -374,6 +374,38 @@ would need to answer it, and move on — do not block, and do not guess:
 - Anything where the loop has failed the same way several cycles running. That is not a hard
   problem, it is a wrong assumption, and it needs a person to see it.
 
+## The status page
+
+Publish one public artifact and republish it at the end of every cycle. It answers two
+questions at a glance, from any device, without being signed in as the account running the loop
+— which matters, because a person watching an unattended box usually has a different account
+open on their phone.
+
+**Is it alive, and does it need me?**
+
+The page carries, in roughly this order of prominence:
+
+- **When it last updated.** The most important line on the page.
+- What it is working on now, and what it finished in the last few cycles.
+- What is queued for a human decision, with links.
+- The last known-good baseline result and when it ran.
+- A short box summary from the profile — memory, disk, the slot in use.
+
+**The timestamp is a dead-man's switch, and that is the point.** Notifications only cover
+failures the loop can recognise and report. A crashed process, a power cut, a hung agent, a
+wedged network — none of those can send anything. A timestamp that has stopped advancing is the
+only signal that catches them, and it needs no infrastructure to work. Treat the two as
+complementary: notifications for known problems, a stale page for everything else.
+
+Two practical points:
+
+- **Republish to the same artifact every cycle**, so the link never changes. Record its URL in
+  the box profile; publishing a fresh one each cycle gives a link nobody can bookmark and
+  destroys the timestamp's meaning.
+- **It is public, so put nothing on it that should not be.** No tokens, no notification
+  endpoints, no absolute paths from the machine, no personal detail. Counts, states, timestamps
+  and links to public issues only.
+
 ## Telling a person something is wrong
 
 Labels and issues are passive — someone has to go and look. An unattended loop that stops at

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -110,6 +110,33 @@ not as a log line. A FAIL should say what to do about it.
 Record the result. If a later cycle behaves oddly, the first question is whether the box
 drifted since.
 
+## The box profile
+
+The preflight measures the machine and records what it found. Everything downstream reads that
+instead of re-measuring or guessing, and it is what makes the same skill work on someone else's
+hardware without being told anything about it.
+
+Write it to a **gitignored** file — it describes this box and this loop, not the repository, and
+it must never be committed or shared. Suggested `.claude/autonomous-state.json`, already ignored.
+
+What belongs in it:
+
+- **The machine** — total and available RAM, free disk, core count.
+- **What those imply** — the worker and job counts derived from them, so later cycles do not
+  re-derive numbers inconsistently. Roughly 1.1 GB per worker without test data and ~2.3 GB with
+  it, but derive from what you measured, not from those figures.
+- **The identity** — the account, the label namespace and the slot claimed at startup.
+- **The baseline** — which bucket was run, the expected count and the count observed, with a
+  timestamp. That is the record that says this box was healthy at a known moment.
+- **The preflight verdict** — every check with PASS or FAIL, so a later cycle behaving oddly can
+  be compared against a known-good starting state.
+- **Pacing observations** — how much budget a cycle actually consumed, so the gap between cycles
+  can be tuned from evidence rather than guessed.
+
+Rewrite it at every startup rather than trusting yesterday's. A box changes: disks fill, other
+work starts, an artifact set goes stale. A stale profile is worse than none, because it looks
+authoritative.
+
 ## Priority order
 
 Work the first item that applies. Re-evaluate from the top after every completed unit of work —

--- a/.claude/skills/running-ms-test-buckets/SKILL.md
+++ b/.claude/skills/running-ms-test-buckets/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: running-ms-test-buckets
+description: Run Microsoft's BaseApp test buckets through AL Runner to find real gaps — where the sources come from, the configuration that must be exact, how to size a run, and how to turn failures into issues worth filing. --test-data is mandatory; without it roughly 40% of failures are missing setup data rather than defects. Use when generating work from the Microsoft surface, or when measuring where the runner stands against it.
+---
+
+# Running Microsoft's BaseApp test buckets
+
+Microsoft ships 33 test buckets inside the BC artifact — about **40,550 tests** — and they run
+through AL Runner as ordinary bundles, with no container. That makes them the largest supply of
+real, un-guessed work available: every failure is a concrete difference between the runner and
+what Microsoft's own tests expect.
+
+The danger is the opposite of scarcity. A badly configured run produces thousands of plausible
+failures that are not defects at all, and an agent that clusters those files a stream of
+confident, wrong issues.
+
+## `--test-data` is mandatory
+
+Not a refinement — a correctness precondition for the *conclusions*, not just the pass rate.
+
+Measured on Tests-SMB (1,027 tests): **259 passing without test data, 595 with it.** More
+importantly, in a full no-test-data run of 29,514 classified failures, the largest clusters were
+
+```
+2690  Order Nos. must have a value in Purchases & Payables Setup
+2214  The General Posting Setup does not exist
+2020  Order Nos. must have a value in Sales & Receivables Setup
+1507  Invoice Nos. must have a value in Sales & Receivables Setup
+1001  There is no Unit of Measure within the filter
+```
+
+Roughly **40% of all failures were missing setup data**, not runner defects. Clustering that run
+and filing the top items would have produced a stream of issues describing nothing real.
+
+With test data the same bucket's top clusters are genuine runner gaps — missing trigger
+dispatch, unsupported filter kinds, silently skipped handlers. Those are worth filing.
+
+**So: never file an issue from a run without `--test-data`.** A no-test-data run is legitimate
+for measuring speed or for bisecting a regression, never for deciding what is broken.
+
+## Getting the sources
+
+The buckets live in the platform artifact under `Applications/BaseApp/Test/` as
+`Tests-*.Source.zip`, beside the `.app` files. `AlRunner.Provisioning/ArtifactDownloader`
+fetches them with an HTTP ranged read of the ZIP central directory rather than downloading the
+whole artifact — `tools/DownloadArtifacts test-sources` and `test-data` are the entry points.
+Each zip carries its own `app.json` and needs no edits; the `$(app_*)` version placeholders are
+fine.
+
+`--test-data` additionally needs the demo backup (`BusinessCentral-W1.bak`, ~900 MB, from the
+sandbox artifact) at the selected build's artifact path, and the backup reader binary the runner
+looks for at `~/.cache/al-runner/bcbak/bcbak`.
+
+## The configuration that must be exact
+
+Get these wrong and the numbers mean nothing:
+
+- **Company is `CRONUS International Ltd_`** — trailing underscore, the SQL form, not a period.
+  The run fails loudly listing both companies otherwise.
+- **Both package caches**, `--package-cache` is repeatable: the platform apps and the test apps.
+- **Raise `AL_RUNNER_EMIT_TIMEOUT_SEC`** well above its default for a large bucket. It is
+  wall-clock, and a big bundle's emit takes minutes; under `--jobs` it is scaled per worker, but
+  a single large bucket still needs headroom.
+- **Pass a private `--cache <dir>`.** The shared cache is not keyed on the runner binary, so
+  another process's build can silently change your results.
+
+## Sizing a run
+
+Do not run all 33 at once to answer a question. Pick by what you are asking:
+
+- **A quick signal** — Tests-SMB (1,027 tests, ~2 minutes warm with test data). Also the natural
+  known-good baseline: 259 without test data, 595 with.
+- **A representative sample** — Tests-ERM alone is 9,496 tests, about a quarter of the surface,
+  and its cluster ranking has matched the full run's. Big enough to rank work, small enough to
+  finish.
+- **The complete picture** — all buckets, but expect hours and size the worker count from
+  measured headroom.
+
+Memory, measured after the per-worker GC tuning: roughly **1.1 GB per worker** without test
+data, **~2.3 GB with it** (including its backup-reader sidecar). Derive the job count from free
+RAM, never hardcode it, and set `MemoryHigh` below `MemoryMax` so a cgroup throttles before the
+kernel's global OOM killer starts choosing victims elsewhere on the machine.
+
+A single bundle cannot be split across workers, so the largest bucket sets the wall-clock floor
+however many workers you add.
+
+## Turning failures into issues
+
+1. **Cluster by normalized message** — strip ids, numbers, quoted names, GUIDs and dates so one
+   defect lands in one bucket. `scripts/` carries the tooling; when attributing a failure to a
+   bucket, key on the result header, not on the run's planning lines, or every failure is
+   credited to whichever bundle was announced last.
+2. **Read the top cluster's stack, not just its message.** Three shapes look identical and need
+   different responses:
+   - a **real gap** — the runner refuses or mishandles something BC supports;
+   - a **cascade** — one early failure leaves state broken for the rest of the codeunit. In one
+     measured case **46 of 47 failures were a cascade** from a single test that renamed a row and
+     died before restoring it. Fixing the first test fixes all 47, and filing 47 issues would
+     have been noise;
+   - a **symptom** — the failure is downstream of something else entirely. "Declared UI handler
+     was not executed" turned out to have at least two unrelated causes.
+3. **Confirm against a clean cache before filing.** A cache left inconsistent by a killed run
+   silently cost 76% of passing tests once, and three commits were bisected before anyone tried a
+   fresh cache. One re-run is cheaper than one wrong issue.
+4. **File with the measured count.** "955 failures, 77% of this cluster, here is the sub-shape
+   breakdown" is actionable. "Some tests fail" is not.
+
+## Known walls — do not refile these
+
+Large clusters that are already understood, so a fresh run does not generate duplicates:
+
+- Failures that vanish with `--test-data` (see above) are configuration, not defects.
+- `RunObject`-only page actions are refused deliberately and loudly; supporting them is a
+  feature, not a bug fix.
+- The task scheduler, live external connections, report rendering, SMTP and HTTP egress are
+  permanently out of scope — `docs/scope.md` is authoritative. A typed out-of-scope refusal with
+  a named reason is the runner working correctly.
+
+Before filing, search the issue queue for the area. A measured cluster is often already filed,
+sometimes several times over, and the whole set usually shares one root cause worth fixing
+together.
+
+## In CI
+
+`.github/workflows/ms-bucket.yml` runs one bucket on a hosted runner with the full
+configuration, `workflow_dispatch` only. It is a measurement job, not a gate: green means it
+produced a number, not that the suite passed. Prefer it over a developer machine when the
+machine is also doing something else.
+
+## Sister material
+
+`autonomous-cycle` — the unattended loop this feeds, and the gate that must pass before a
+cluster becomes an issue.
+`project_ms_test_collections_run_recipe` in session memory — the original recipe and its history.

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,7 @@ AlRunner/Win32Stubs/*.so
 # `git add -A`, the same rationale as /engine.runsettings above.
 /graphify-out/
 AlRunner/graphify-out/
+
+# Per-box state written by the autonomous-cycle preflight (machine profile,
+# claimed label slot, baseline result). Describes one box, never the repository.
+.claude/autonomous-state.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ Operating rules live in `.claude/rules/` and are auto-loaded. Task-specific refe
   start of any session that drives work through subagents**
 - Act as orchestrator or implementation agent → sub-agents `orchestrator` / `impl-agent` in `.claude/agents/`
 - Drive a full work cycle (triage → parallel impls in worktrees → orchestrator merge pass, until the queue is empty) → slash command `/work-cycle`
+- Run **unattended** (never-idle loop, one agent at a time, fixed priority order, weekly-budget pacing, preflight that refuses a box which would produce wrong answers) → skill `autonomous-cycle`
 
 ## Code navigation: use these before grepping
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ Operating rules live in `.claude/rules/` and are auto-loaded. Task-specific refe
 - Act as orchestrator or implementation agent → sub-agents `orchestrator` / `impl-agent` in `.claude/agents/`
 - Drive a full work cycle (triage → parallel impls in worktrees → orchestrator merge pass, until the queue is empty) → slash command `/work-cycle`
 - Run **unattended** (never-idle loop, one agent at a time, fixed priority order, weekly-budget pacing, preflight that refuses a box which would produce wrong answers) → skill `autonomous-cycle`
+- Run Microsoft's BaseApp test buckets to find real gaps (sources, the exact configuration, sizing, clustering, and why `--test-data` is mandatory) → skill `running-ms-test-buckets`
 
 ## Code navigation: use these before grepping
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ Operating rules live in `.claude/rules/` and are auto-loaded. Task-specific refe
   measurement rules, environment traps) → skill `orchestrating-a-session` — **invoke it at the
   start of any session that drives work through subagents**
 - Act as orchestrator or implementation agent → sub-agents `orchestrator` / `impl-agent` in `.claude/agents/`
+- Review a PR before merge (does the test prove anything, did a BC claim reach a service tier, is the measurement sound, can anything fail silently) → sub-agent `reviewer`
 - Drive a full work cycle (triage → parallel impls in worktrees → orchestrator merge pass, until the queue is empty) → slash command `/work-cycle`
 - Run **unattended** (never-idle loop, one agent at a time, fixed priority order, weekly-budget pacing, preflight that refuses a box which would produce wrong answers) → skill `autonomous-cycle`
 - Run Microsoft's BaseApp test buckets to find real gaps (sources, the exact configuration, sizing, clustering, and why `--test-data` is mandatory) → skill `running-ms-test-buckets`


### PR DESCRIPTION
Adds `.claude/skills/autonomous-cycle/` — how to run this repository's development loop with nobody watching — and links it from CLAUDE.md's skill list.

## The premise

Running unattended changes what matters: not throughput, but never producing confident wrong work. A loop that files issues from a poisoned cache, or merges on a stale verdict, fills the backlog with plausible garbage someone then has to unpick.

So the loop is narrow on purpose: **one agent at a time, a fixed priority order, behind a preflight that can stop everything.**

## One agent at a time is a quality decision

Measured on 2026-09-05: a coordinator ran nine agents in parallel for about ninety minutes. Throughput was real, but every finding of lasting value came from depth rather than parallelism — 4,905 Base App members measured to pin an identifier-mangling rule to exactly seven names; the discovery that every Base App report's lifecycle triggers were silently empty; a cache-poisoning diagnosis narrowed to a derived tier whose key has no term for what it derived from.

In that same session at least four confident conclusions were wrong, caught only because a human pushed back or something was re-measured. Parallelism multiplies that risk; serial work with a review step does not.

## The preflight is what makes this viable

Every check exists because its absence has silently corrupted a result. The highest-value one is a **known-good baseline**: run a pinned bucket, compare against its recorded count, and refuse to start if it does not match. That one check catches a poisoned cache, a wrong BC version, a missing package cache, a broken artifact set and a bad backup reader — all of which otherwise surface as believable failure clusters the loop would dutifully file.

Also checked: push actually works; commits actually work (a locked signing agent makes `git commit` **hang** rather than fail, which simply stops an unattended loop); what this account is permitted to do; and headroom read from the machine rather than hardcoded.

On permissions — the loop behaves **identically whoever runs it**. A missing permission is a precondition failure to report, never a second behaviour mode.

## Priority order, and never idling

From `main` is red down to generating new work. The generate step is what keeps the loop busy and is also the one most able to do harm, so it has a mandatory gate: cluster the failures, then **re-run the top cluster against a clean cache** before filing anything. In one measured no-test-data run roughly 40% of all failures were missing setup data rather than defects — an ungated loop would have produced a stream of confident, wrong issues.

## Pacing

Targets the weekly limit, not the five-hour window, since exhausting every window burns the week in a couple of days. Start conservative and tune from observed consumption.

## Human queue and blast radius

Product decisions, anything posted publicly on someone's behalf, and merging others' PRs go to a labelled queue rather than being guessed at. The hard limits hold whatever the loop concludes — including never re-running a **failed** CI job (it destroys the log), while re-running a **cancelled** one is fine and is sometimes necessary to clear a merge.

No linked issue: this adds an agent definition for a way of working, not a fix for a filed defect.