### PR TITLE
docs(patches): correct a transaction-snapshot comment that still says two fixed tests fail

### DIFF
--- a/AlRunner/Patches/RecordPatches.TransactionSnapshot.cs
+++ b/AlRunner/Patches/RecordPatches.TransactionSnapshot.cs
@@ -49,9 +49,12 @@
 //   Record_Insert_UnrelatedAssertError_NoCommit_RowIsRolledBack for what looks like the
 //   identical shape (an uncommitted, untriggered Insert() then a later, unrelated Error()).
 //   Real BC passes all three (confirmed against CI run 33273501078, BC 27.5 and 28.3) — they
-//   are NOT contradictory. This runner currently does NOT special-case that shape at all —
-//   Test04 and Error_After_Insert_Before_Commit_RecordPersists both fail here, openly, with no
-//   known-gaps entry masking it, exactly as on unmodified main.
+//   are NOT contradictory. Both Test04 and Error_After_Insert_Before_Commit_RecordPersists now
+//   PASS here, fixed by cc9e1615 (PR #2405), which also deleted the
+//   known-gaps-transaction-rollback-boundary.json entries that had masked them. Nothing masks
+//   them today: bc-tests.yml runs the corpus with --strict, so either would fail its leg.
+//   (This paragraph previously said both still failed openly — that was true when 90579baf
+//   wrote it and stopped being true two weeks later. AlRunner#2167 tracked it and is closed.)
 //
 //   Without any of this the runner either never rolled anything back (silently wrong for a
 //   test that checks the table afterwards) or rolled back to the wrong boundary.


### PR DESCRIPTION
The comment at `AlRunner/Patches/RecordPatches.TransactionSnapshot.cs:53` says two corpus tests fail in this runner. They pass.

It was written by `90579baf` (PR #2437) and was accurate then. `cc9e1615` (PR #2405, merged 2026-09-02) fixed both `TestScopeIsolationContracts.Test04` and `TestTransactionContracts.Error_After_Insert_Before_Commit_RecordPersists`, and deleted `tests/expectations/known-gaps-transaction-rollback-boundary.json` — the file that had held their entries. The comment was never updated.

Green `--strict` corpus CI on `abdac823` confirms they pass today: `bc-tests.yml` runs the corpus with `--strict`, so a failing corpus test fails its leg, and both tests are present and unmasked at main's corpus pin (`1725c51b`).

## Why this is worth a PR of its own

A comment that describes the runner as broken where it is not is worse than no comment. It sits in the file an agent opens when working on transaction-rollback boundaries, and it reads as a deliberate statement of current behavior. The correction also records that the paragraph went stale, so the next reader can see the shape of the mistake rather than only its fix.

Found during a triage pass while closing issue #2167, which tracked the same two tests.

No linked issue: this corrects a code comment, and the issue that covered the underlying defect is already closed.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
