### PR TITLE
fix(deps): count the Tier-1 sidecar DLL as an implementation, so the provisioning-gap notice stops firing on healthy runs

### DIFF
--- a/AlRunner.Tests/DependencyResolverTests.cs
+++ b/AlRunner.Tests/DependencyResolverTests.cs
@@ -715,6 +715,95 @@ public sealed class DependencyResolverTests : IDisposable
     }
 
     /// <summary>
+    /// NEGATIVE — #2739: a symbols-only package paired with a committed Tier-1 sidecar DLL
+    /// under <c>&lt;bundle&gt;/.deps-bin/</c> is fully servable, because DependencyLoader
+    /// prefers that DLL over every other tier. Reporting it as "NO IMPLEMENTATION … no other
+    /// copy was found" fired on every green CI leg and, on 2026-09-05, produced a wrong
+    /// diagnosis of a red PR whose actual cause was several lines further down.
+    /// </summary>
+    [Fact]
+    public void SymbolsOnlyButHasPrecompiledSidecarDll_IsNotReported()
+    {
+        var appId = "c7a1b2d3-4e5f-4a6b-8c9d-0e1f2a3b4c5d";
+        var bundleRoot = MakeDir("sidecar-bundle");
+        var pkgDir = Directory.CreateDirectory(Path.Combine(bundleRoot, ".alpackages")).FullName;
+        WriteApp(pkgDir, "AL_Runner_Fixtures_Sidecar_Dep_1.0.0.0.app", appId,
+            "Sidecar Dep", "AL Runner Fixtures", "1.0.0.0", r2r: false);
+
+        // Exactly the name DependencyLoader.LoadOne builds: <Publisher>_<Name>_<Version>.dll.
+        var depsBin = Directory.CreateDirectory(Path.Combine(bundleRoot, ".deps-bin")).FullName;
+        File.WriteAllBytes(
+            Path.Combine(depsBin, "AL_Runner_Fixtures_Sidecar_Dep_1.0.0.0.dll"), new byte[] { 0x4D, 0x5A });
+
+        var resolver = new DependencyResolver(
+            new[] { pkgDir }, Array.Empty<string>(), bundleRoot);
+        var result = resolver.Resolve(new[]
+        {
+            new DependencyRef(Guid.Parse(appId), "Sidecar Dep", "AL Runner Fixtures", new Version(1, 0, 0, 0))
+        });
+        Assert.Single(result);
+
+        Assert.Empty(resolver.UnservableDependencies);
+    }
+
+    /// <summary>
+    /// POSITIVE control for the test above — the SAME symbols-only package with NO sidecar
+    /// DLL beside it must still be reported. Without this, an implementation that simply
+    /// stopped reporting unservable dependencies altogether would pass the negative test,
+    /// and the real #1689 diagnostic would be silently lost.
+    /// </summary>
+    [Fact]
+    public void SymbolsOnlyWithoutSidecarDll_IsStillReported()
+    {
+        var appId = "c7a1b2d3-4e5f-4a6b-8c9d-0e1f2a3b4c5e";
+        var bundleRoot = MakeDir("no-sidecar-bundle");
+        var pkgDir = Directory.CreateDirectory(Path.Combine(bundleRoot, ".alpackages")).FullName;
+        WriteApp(pkgDir, "AL_Runner_Fixtures_Sidecar_Dep_1.0.0.0.app", appId,
+            "Sidecar Dep", "AL Runner Fixtures", "1.0.0.0", r2r: false);
+        // No .deps-bin directory at all.
+
+        var resolver = new DependencyResolver(
+            new[] { pkgDir }, Array.Empty<string>(), bundleRoot);
+        resolver.Resolve(new[]
+        {
+            new DependencyRef(Guid.Parse(appId), "Sidecar Dep", "AL Runner Fixtures", new Version(1, 0, 0, 0))
+        });
+
+        var report = Assert.Single(resolver.UnservableDependencies);
+        Assert.Contains("AL Runner Fixtures/Sidecar Dep", report);
+        Assert.Contains("NO IMPLEMENTATION", report);
+    }
+
+    /// <summary>
+    /// #2739 — a sidecar DLL for a DIFFERENT version must not satisfy the probe. The loader
+    /// builds the file name from the resolved manifest's exact version, so a v2 DLL cannot
+    /// serve a v1 resolution, and claiming otherwise would suppress a real gap.
+    /// </summary>
+    [Fact]
+    public void SidecarDllForAnotherVersion_DoesNotSuppressTheReport()
+    {
+        var appId = "c7a1b2d3-4e5f-4a6b-8c9d-0e1f2a3b4c5f";
+        var bundleRoot = MakeDir("wrong-version-sidecar");
+        var pkgDir = Directory.CreateDirectory(Path.Combine(bundleRoot, ".alpackages")).FullName;
+        WriteApp(pkgDir, "AL_Runner_Fixtures_Sidecar_Dep_1.0.0.0.app", appId,
+            "Sidecar Dep", "AL Runner Fixtures", "1.0.0.0", r2r: false);
+
+        var depsBin = Directory.CreateDirectory(Path.Combine(bundleRoot, ".deps-bin")).FullName;
+        File.WriteAllBytes(
+            Path.Combine(depsBin, "AL_Runner_Fixtures_Sidecar_Dep_2.0.0.0.dll"), new byte[] { 0x4D, 0x5A });
+
+        var resolver = new DependencyResolver(
+            new[] { pkgDir }, Array.Empty<string>(), bundleRoot);
+        resolver.Resolve(new[]
+        {
+            new DependencyRef(Guid.Parse(appId), "Sidecar Dep", "AL Runner Fixtures", new Version(1, 0, 0, 0))
+        });
+
+        var report = Assert.Single(resolver.UnservableDependencies);
+        Assert.Contains("NO IMPLEMENTATION", report);
+    }
+
+    /// <summary>
     /// NEGATIVE — Microsoft platform apps are legitimately symbols-only; their runtime comes
     /// from the service tier. The existing carve-out must survive.
     /// </summary>

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -247,22 +247,38 @@ public sealed class DependencyLoader
         }
     }
 
+    /// <summary>
+    /// The Tier-1 precompiled sidecar DLL for <paramref name="m"/> under
+    /// <paramref name="bucketRoot"/>, or <c>null</c> when there is none.
+    /// </summary>
+    /// <remarks>
+    /// Shared with <see cref="DependencyResolver"/> on purpose. The resolver has to decide
+    /// whether ANY loader tier can serve a symbols-only package, and it used to answer that
+    /// question with its own list of tiers that did not include this one — so a dependency
+    /// this method serves perfectly well was reported as "no other copy was found in the
+    /// package caches" on every healthy run (#2739). One method, so the two cannot disagree
+    /// about what Tier 1 covers.
+    /// </remarks>
+    internal static string? FindPrecompiledSidecar(AppManifest m, string bucketRoot)
+    {
+        var fileName = SanitizeFileName($"{m.Publisher}_{m.Name}_{m.Version}.dll");
+        var precompiled = Path.Combine(bucketRoot, ".deps-bin", fileName);
+        if (File.Exists(precompiled)) return precompiled;
+
+        // A bundle that is a PARENT of many apps has no .deps-bin of its own — the one
+        // that matters belongs to the suite that declares the dependency, one level
+        // down. Without this the Tier-1 DLL was simply not found when the same suite ran
+        // as part of the parent bundle (it loads fine standalone, where bucketRoot IS
+        // the suite), and the dep silently fell through to a lower tier — for a
+        // source-less fixture .app that means its objects never exist at all.
+        return SafeEnumerateFiles(bucketRoot, fileName).FirstOrDefault();
+    }
+
     private (Assembly? Asm, string? Tier3CacheKey) LoadOne(AppManifest m, string appPath, string bucketRoot)
     {
         // Tier 1: precompiled DLL.
-        var fileName = SanitizeFileName($"{m.Publisher}_{m.Name}_{m.Version}.dll");
-        var precompiled = Path.Combine(bucketRoot, ".deps-bin", fileName);
-        if (!File.Exists(precompiled))
-        {
-            // A bundle that is a PARENT of many apps has no .deps-bin of its own — the one
-            // that matters belongs to the suite that declares the dependency, one level
-            // down. Without this the Tier-1 DLL was simply not found when the same suite ran
-            // as part of the parent bundle (it loads fine standalone, where bucketRoot IS
-            // the suite), and the dep silently fell through to a lower tier — for a
-            // source-less fixture .app that means its objects never exist at all.
-            precompiled = SafeEnumerateFiles(bucketRoot, fileName).FirstOrDefault() ?? precompiled;
-        }
-        if (File.Exists(precompiled))
+        var precompiled = FindPrecompiledSidecar(m, bucketRoot);
+        if (precompiled != null)
         {
             try
             {

--- a/AlRunner/DependencyResolver.cs
+++ b/AlRunner/DependencyResolver.cs
@@ -55,6 +55,11 @@ public sealed class DependencyResolver
     // same app — see FromSource in SelectBestVersion for why version cannot decide it.
     private readonly IReadOnlyList<string> _sourceSupersedingDirs;
 
+    // Bundle root to probe for DependencyLoader's Tier-1 precompiled sidecar DLLs
+    // (<root>/**/.deps-bin/<Publisher>_<Name>_<Version>.dll). Null means "not supplied",
+    // which suppresses nothing — the unservable check then behaves exactly as before.
+    private readonly string? _precompiledSidecarRoot;
+
     public DependencyResolver(IReadOnlyList<string> cacheDirs)
         : this(cacheDirs, Array.Empty<string>())
     {
@@ -62,10 +67,12 @@ public sealed class DependencyResolver
 
     public DependencyResolver(
         IReadOnlyList<string> cacheDirs,
-        IReadOnlyList<string> sourceSupersedingDirs)
+        IReadOnlyList<string> sourceSupersedingDirs,
+        string? precompiledSidecarRoot = null)
     {
         _cacheDirs = cacheDirs;
         _sourceSupersedingDirs = sourceSupersedingDirs;
+        _precompiledSidecarRoot = precompiledSidecarRoot;
     }
 
     /// <summary>
@@ -90,6 +97,16 @@ public sealed class DependencyResolver
     // Microsoft platform apps the runner provides via precompiled service-tier DLLs +
     // bundle .alpackages symbols, never by loading a resolved .app — so a missing .app is
     // expected and non-fatal. Kept in sync with Program.IsMicrosoftPlatformApp.
+    /// <summary>
+    /// Whether DependencyLoader's Tier-1 precompiled sidecar DLL exists for this manifest.
+    /// Answered by the loader's own lookup rather than a copy of it, so the resolver cannot
+    /// drift from what the loader will actually do at run time — the drift was the defect
+    /// in #2739.
+    /// </summary>
+    private bool HasPrecompiledSidecar(AppManifest m)
+        => _precompiledSidecarRoot != null
+           && DependencyLoader.FindPrecompiledSidecar(m, _precompiledSidecarRoot) != null;
+
     internal static bool IsMicrosoftPlatformApp(string name, string publisher)
     {
         if (!string.Equals(publisher, "Microsoft", StringComparison.OrdinalIgnoreCase)) return false;
@@ -366,8 +383,15 @@ public sealed class DependencyResolver
             // and nothing else, as produced by a symbol-only package download. No loader tier
             // can implement it, so every call into it ends at
             // "The object with ID 0 does not have a member with that ID".
+            // Tier 1 counts too. A committed sidecar DLL under <bundle>/**/.deps-bin/ is a
+            // complete implementation that DependencyLoader.LoadOne prefers over every other
+            // tier, so a package paired with one is fully servable no matter what the .app
+            // itself carries. Leaving it out of this list is what made the notice fire on
+            // every green CI leg for tests/runner-extras/testpage-precompiled-dep-control,
+            // whose fixture ships exactly that pairing on purpose (#2739).
             if (!Executable(best.Path)
                 && !AppLoader.HasAlSource(best.Path)
+                && !HasPrecompiledSidecar(best.Manifest)
                 && !IsMicrosoftPlatformApp(best.Manifest.Name, best.Manifest.Publisher))
             {
                 var tooOld = candidates

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2099,7 +2099,12 @@ foreach (var bundle in bundles)
                     bundlePkgDirs = AlRunner.Infrastructure.SafeDirectoryScan.Directories(depRootDir, ".alpackages")
                         .ToList();
                 var resolverDirs = bundlePkgDirs.Concat(packageCacheDirs).Distinct().ToList();
-                var resolver = new DependencyResolver(resolverDirs, AlRunner.Infrastructure.CacheRoots.SourceBuiltPackageDirs());
+                // depRootDir is the same root DependencyLoader.LoadAll gets, so the resolver's
+                // "no loader tier can serve this" verdict is answered against the Tier-1
+                // sidecar DLLs that will actually be loaded, not against a subset of the
+                // tiers (#2739).
+                var resolver = new DependencyResolver(
+                    resolverDirs, AlRunner.Infrastructure.CacheRoots.SourceBuiltPackageDirs(), depRootDir);
                 IReadOnlyList<(AlRunner.AppManifest Manifest, string AppPath)> ordered;
                 using (AlRunner.Infrastructure.PhaseLog.Stage("dep-resolve"))
                     ordered = resolver.Resolve(roots);


### PR DESCRIPTION
## What this fixes

`DependencyResolver` decided "no loader tier can serve this dependency" from its own list of
tiers — R2R payload, `src/*.al`, Microsoft platform app — which omitted `DependencyLoader`'s
**Tier 1**: a committed sidecar DLL at `<bundle>/**/.deps-bin/<Publisher>_<Name>_<Version>.dll`.
That is the tier the loader *prefers over all others*, so a dependency it serves perfectly well
was reported as `NO IMPLEMENTATION … and no other copy was found in the package caches` on every
green CI leg.

## The open question in the issue, answered

The issue asked which of two things was true. It is **case 2**: the tests do reach the
dependency's code, a `.deps-bin/` sidecar DLL serves those calls through a path the gap reporter
did not check, and the reporter's "no other copy was found" was false.

`tests/runner-extras/testpage-precompiled-dep-control` ships that pairing deliberately — a
symbol-only `.app` plus a committed `.deps-bin` DLL, so page 65601 exists as pure compiled code
with no AL source reachable at runtime. Its own `app.json` documents the arrangement. So the
tests are not weakened and need no strengthening; the reporter had the blind spot.

## Measured, on one box, same command

| | notice | tests | exit |
|---|---|---|---|
| pre-fix resolver | `Provisioning gaps: 1` + `NO IMPLEMENTATION` | 232/232 pass | 0 |
| this branch | *(silent)* | 232/232 pass | 0 |

The "before" row is the resolver with only the new tier check removed, so nothing else differs.

## Why a shared helper rather than a second lookup

The probe is `DependencyLoader.FindPrecompiledSidecar`, extracted from `LoadOne` and called by
both sides. The resolver and the loader disagreeing about what Tier 1 covers *is* the defect, so
a copied lookup would just re-arm it later.

The bundle root reaches the resolver only at the call site that reports the notice; it is `null`
everywhere else, where the check behaves exactly as before.

## Tests

Three added to `DependencyResolverTests`, and the RED was verified by removing only the new
condition:

- `SymbolsOnlyButHasPrecompiledSidecarDll_IsNotReported` — **fails without the fix**, the
  regression itself.
- `SymbolsOnlyWithoutSidecarDll_IsStillReported` — positive control. Passes in both states, so an
  implementation that simply stopped reporting unservable dependencies (losing #1689's
  diagnostic) cannot sneak through.
- `SidecarDllForAnotherVersion_DoesNotSuppressTheReport` — a v2 DLL must not satisfy a v1
  resolution.

`DependencyResolverTests`: 32 pre-existing plus the 3 new, 35/35 green. `tests/runner-extras`: 232/232, exit 0.

## Verified by review, not just claimed

The review settled the issue's open question with the counterfactual this PR did not run: with
`.deps-bin/` removed, both tests in the bundle fail with `no loaded type Record65600 found` and
the notice correctly fires. The tests execute the dependency's compiled code and are not vacuous.

## Not done here

Step 4 of the issue — rewording so a gap that does not set the exit code reads differently from
one that does — is left alone deliberately. With the false positive gone, the notice now fires
only on genuine gaps, and I would rather not reword a diagnostic while there is no longer a
healthy run that prints it to check the wording against. Say the word if you want it folded in.

Closes #2739

---

Opened by the autonomous cycle agent (`stma-auto-1`) acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
