### PR TITLE
docs(rules): the corpus default branch is master, not main

### DIFF
--- a/.claude/rules/al-language-submodule.md
+++ b/.claude/rules/al-language-submodule.md
@@ -6,6 +6,21 @@ the canonical AL-language test corpus, validated against a real BC service tier.
 any file under `tests/al-language/`.** The corpus does not know about AL Runner and must stay
 that way.
 
+## The corpus default branch is `master`, not `main`
+
+This repository's default branch is `main`; the corpus repository's is `master`. Target `master`
+when opening a corpus PR. `gh pr create` without an explicit `--base` picks the default correctly,
+but a hand-written `--base main`, or an API call that assumes `main`, fails with a 422 that does not
+say why — two agents lost time to it on 2026-09-05, one of them concluding the API was broken.
+
+```bash
+gh repo view StefanMaron/BusinessCentral.AL.Language.Tests --json defaultBranchRef \
+  --jq '.defaultBranchRef.name'      # master
+```
+
+The same asymmetry applies to every command naming a branch: `git merge-tree --write-tree
+origin/master origin/<branch>` for a conflict check in the corpus, `origin/main` for one here.
+
 ## What this means in practice
 
 - **Test failures in the corpus are runner gaps**, not corpus bugs. `no-assumption-fixes`

--- a/.claude/rules/bc-behavior-tests-go-upstream.md
+++ b/.claude/rules/bc-behavior-tests-go-upstream.md
@@ -38,7 +38,7 @@ Step 3 is the one that is never optional. Full detail, including escape hatches:
    corpus repo's own CI adjudicate on a PR; both are real service tiers.
 3. **Open a pull request into
    [`StefanMaron/BusinessCentral.AL.Language.Tests`](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests).**
-   Mandatory — a test only becomes part of the corpus by merging into that repo's `main`. The
+   Mandatory — a test only becomes part of the corpus by merging into that repo's `master`. The
    orchestrator merges it, not the authoring agent, once both BC legs are green.
 4. **After that PR merges, bump the submodule pin** in this repo, folded into the fix PR
    (`al-language-submodule.md` — a pin bump cannot be its own PR, it is red by construction).


### PR DESCRIPTION
`.claude/rules/bc-behavior-tests-go-upstream.md` told agents that a test becomes part of the corpus by merging into that repository's `main`. That branch does not exist.

- `StefanMaron/BusinessCentral.AL.Language.Tests` defaults to **`master`**
- `StefanMaron/BusinessCentral.AL.Runner` defaults to **`main`**

Two agents lost time to this today. The failure is quiet: `gh pr create` returns a 422 that does not name the branch, and one agent worked through the GraphQL error and an API fallback before finding the real cause.

I also added a short section to `al-language-submodule.md`, because the asymmetry reaches every command that names a branch, not just PR creation — a conflict check in the corpus is `git merge-tree --write-tree origin/master origin/<branch>`, and `origin/main` here.

Verified rather than assumed:

```
$ gh repo view StefanMaron/BusinessCentral.AL.Language.Tests --json defaultBranchRef --jq '.defaultBranchRef.name'
master
$ gh repo view StefanMaron/BusinessCentral.AL.Runner --json defaultBranchRef --jq '.defaultBranchRef.name'
main
```

No linked issue: this corrects a rules file that stated a fact wrongly.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
