### PR TITLE
fix(cache): key the install-baseline on the BC symbol state it was derived from

### DIFF
--- a/AlRunner.Tests/InstallBaselineKeySymbolStateTests.cs
+++ b/AlRunner.Tests/InstallBaselineKeySymbolStateTests.cs
@@ -1,0 +1,270 @@
+// InstallBaselineKeySymbolStateTests — #2710.
+//
+// What went wrong
+// ---------------
+// The install-baseline cache (in-memory _depCompanyBaselineCache, and its cross-process disk
+// tier InstallBaselineDiskCache) stores the rows the Install triggers and Company-Initialize
+// wrote. RecordPatches.InstallBaselineDisk's own header claimed that snapshot is "deterministic
+// given (dependency assembly set, runner build, BC version)", and TestExecutor
+// .CurrentInstallBaselineCacheKey built the key from exactly those (plus #2258's --test-data
+// identity).
+//
+// It is not. The triggers write through table metadata the runner builds from the BC .app
+// symbol sources REGISTERED IN THIS PROCESS — RecordPatches._bcAppPaths, which
+// EnsureBcSymbolTableIndex / EnsureBcSymbolExtensionIndex walk to build the table and
+// table-extension indexes. That set is an input to the snapshot, and the key never named it,
+// so a run whose registered set differed wrote its snapshot under the identical key another
+// run then read back. Nothing at read time could tell: every entry passes its own validity
+// check, which is why #2710's field report found that removing any ONE cache subdirectory left
+// the bad result unchanged and only a full wipe restored it.
+//
+// The set varies between two runs whose (deps, runner, BC version) are identical:
+//
+//   * --server / --watch ACCUMULATE it. _bcAppPaths is process-global and nothing clears it —
+//     RecordPatches.ResetForReload (the per-bundle reload path) calls InvalidateBcAppIndexes,
+//     which drops the DERIVED indexes precisely so they rebuild FROM that list. Meanwhile the
+//     key's only per-bundle term IS reset per bundle: InstallTriggerRunner.ResetForNewBundle
+//     clears _depAssemblies. Two writers of the same per-bundle state, one holding the
+//     invariant and one not.
+//   * RegisterBundleSymbolApps SKIPS what it cannot read — an unreadable bundle-root .app is
+//     dropped with a [warn] and the run continues, which silently removes a symbol source
+//     without moving any other key term. Pinned below.
+//
+// What the difference is worth: #2712 measured a partial table-extension index (90 of 96 Base
+// Application extensions dropped) flipping 47 Tests-SMB tests with an unchanged exit code.
+//
+// The fix is a key term, not a detector: RegisteredBcAppSymbolStateKey() names the input, so a
+// run with a different symbol state simply MISSES instead of reading someone else's snapshot.
+//
+// Note on isolation: _bcAppPaths has no unregister, so these tests assert that registering
+// something CHANGES the key rather than asserting an absolute key value — correct regardless of
+// what an earlier test in the same process already registered.
+
+using System.IO.Compression;
+using System.Text;
+using AlRunner;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// RecordPatchesSerialCollection: this class registers .app paths into the process-global
+// RecordPatches registry (AddBcAppPath / RegisterBundleSymbolApps), the same shared state
+// RecordPatchesBcAppSymbolReadFailureTests mutates.
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class InstallBaselineKeySymbolStateTests : IDisposable
+{
+    private readonly string _root;
+
+    public InstallBaselineKeySymbolStateTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-2710-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    // A minimal but COMPLETE .app: AddBcAppPath reads both symbol surfaces to completion
+    // (#2712) and throws if either fails, so the file has to parse all the way through.
+    // tableName varies the bytes, which is how the content-hash half of the key is exercised.
+    private string WriteApp(string fileName, string tableName)
+    {
+        var path = Path.Combine(_root, fileName);
+        using var fs = new FileStream(path, FileMode.Create);
+        using var za = new ZipArchive(fs, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write($$"""
+            {
+              "RuntimeVersion": "15.1",
+              "Namespaces": [],
+              "Tables": [
+                {
+                  "Id": 60900,
+                  "Name": "{{tableName}}",
+                  "Properties": [],
+                  "Fields": [
+                    { "TypeDefinition": { "Name": "Code[10]" }, "Properties": [], "Id": 1, "Name": "Code" }
+                  ]
+                }
+              ],
+              "TableExtensions": []
+            }
+            """);
+        return path;
+    }
+
+    private static string WriteCorruptApp(string path)
+    {
+        // Not a zip at all: OpenAppZip fails, so AddBcAppPath throws and
+        // RegisterBundleSymbolApps takes its per-file skip branch.
+        File.WriteAllBytes(path, new byte[] { 0x50, 0x4B, 0x03, 0x04, 0xFF, 0xFF, 0xFF, 0xFF });
+        return path;
+    }
+
+    // ── the key ───────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void InstallBaselineKey_ChangesWhenAnotherBcAppIsRegistered()
+    {
+        var before = TestExecutor.CurrentInstallBaselineCacheKey();
+
+        RecordPatches.AddBcAppPath(WriteApp("Extra_1.0.0.0.app", "Two Sixty Nine"));
+
+        var after = TestExecutor.CurrentInstallBaselineCacheKey();
+
+        // [THEN] the key MOVED. Before the fix these were byte-identical: the registered .app
+        // set was invisible to the key, so the snapshot captured with this app's tables in
+        // scope was stored under the key a run without them would look up.
+        Assert.NotEqual(before, after);
+        Assert.Contains("|bcapps:", after);
+
+        // [AND] it is the bcapps term that moved, not the dependency-set term — the two runs
+        // have the same loaded dependency assemblies.
+        Assert.Equal(
+            before[..before.IndexOf("|bcapps:", StringComparison.Ordinal)],
+            after[..after.IndexOf("|bcapps:", StringComparison.Ordinal)]);
+    }
+
+    [Fact]
+    public void InstallBaselineKey_IsStableWhenNothingWasRegistered()
+    {
+        // Negative direction: the term must not be a nonce. Two consecutive reads with no
+        // registration in between have to agree, or every run would MISS and the cache would
+        // be dead weight rather than fixed.
+        var first = TestExecutor.CurrentInstallBaselineCacheKey();
+        var second = TestExecutor.CurrentInstallBaselineCacheKey();
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public void InstallBaselineKey_IsUnchangedByReRegisteringTheSameApp()
+    {
+        var app = WriteApp("Idempotent_1.0.0.0.app", "Idempotent Table");
+        RecordPatches.AddBcAppPath(app);
+        var after1 = TestExecutor.CurrentInstallBaselineCacheKey();
+
+        RecordPatches.AddBcAppPath(app);
+        var after2 = TestExecutor.CurrentInstallBaselineCacheKey();
+
+        Assert.Equal(after1, after2);
+        Assert.Single(RecordPatches.RegisteredBcAppPathsForTests(), p =>
+            string.Equals(p, app, StringComparison.OrdinalIgnoreCase));
+    }
+
+    // ── the reachable path: a bundle-root .app that cannot be read is silently dropped ─────
+
+    [Fact]
+    public void RegisterBundleSymbolApps_SkippingAnUnreadableApp_LeavesADifferentKeyThanReadingIt()
+    {
+        // Two bundle roots that differ ONLY in whether their bundle-root .app is readable.
+        // RegisterBundleSymbolApps skips the unreadable one with a [warn] and the run
+        // continues — the right call for an optional input, but it removes a symbol source
+        // that install triggers would otherwise have seen.
+        var healthyRoot = Path.Combine(_root, "healthy");
+        var brokenRoot = Path.Combine(_root, "broken");
+        Directory.CreateDirectory(healthyRoot);
+        Directory.CreateDirectory(brokenRoot);
+        WriteCorruptApp(Path.Combine(brokenRoot, "Bundle_1.0.0.0.app"));
+
+        var baseline = TestExecutor.CurrentInstallBaselineCacheKey();
+
+        RecordPatches.RegisterBundleSymbolApps(brokenRoot);
+        var afterSkip = TestExecutor.CurrentInstallBaselineCacheKey();
+
+        // [THEN] the skipped .app contributed nothing — no registration, so no key movement.
+        // That is the honest answer; the defect was that the HEALTHY case did not move it
+        // either, so the two were indistinguishable.
+        Assert.Equal(baseline, afterSkip);
+
+        // Now the same bundle root with a readable .app.
+        var healthyApp = Path.Combine(healthyRoot, "Bundle_1.0.0.0.app");
+        using (var fs = new FileStream(healthyApp, FileMode.Create))
+        using (var za = new ZipArchive(fs, ZipArchiveMode.Create))
+        {
+            var entry = za.CreateEntry("SymbolReference.json");
+            using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+            w.Write("""
+                { "RuntimeVersion": "15.1", "Namespaces": [], "Tables": [], "TableExtensions": [] }
+                """);
+        }
+        RecordPatches.RegisterBundleSymbolApps(healthyRoot);
+        var afterHealthy = TestExecutor.CurrentInstallBaselineCacheKey();
+
+        // [THEN] reading it DOES move the key, so "this run saw the bundle's symbols" and
+        // "this run did not" are now different cache entries instead of the same one.
+        Assert.NotEqual(afterSkip, afterHealthy);
+    }
+
+    // ── the digest itself ─────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SymbolStateKey_IsOrderIndependent()
+    {
+        // Registration order follows dependency-resolution order, which is not part of what
+        // was registered. Two orderings of the same set must be one cache entry, not two.
+        var a = ("/pkg/A_1.0.0.0.app", "aaaa");
+        var b = ("/pkg/B_1.0.0.0.app", "bbbb");
+        Assert.Equal(
+            RecordPatches.ComputeBcAppSymbolStateKey(new[] { a, b }, Array.Empty<string>()),
+            RecordPatches.ComputeBcAppSymbolStateKey(new[] { b, a }, Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void SymbolStateKey_ChangesWhenAnAppsContentChangesUnderTheSamePath()
+    {
+        // The #2710 field scenario in one line: same path, different bytes. Keying on the
+        // path alone would have served the snapshot captured against the old package.
+        var before = RecordPatches.ComputeBcAppSymbolStateKey(
+            new[] { ("/pkg/Base Application_28.1.49838.53910.app", "hash-one") }, Array.Empty<string>());
+        var after = RecordPatches.ComputeBcAppSymbolStateKey(
+            new[] { ("/pkg/Base Application_28.1.49838.53910.app", "hash-two") }, Array.Empty<string>());
+        Assert.NotEqual(before, after);
+    }
+
+    [Fact]
+    public void SymbolStateKey_ChangesWhenAnAppIsDropped()
+    {
+        var two = RecordPatches.ComputeBcAppSymbolStateKey(
+            new[] { ("/pkg/A.app", "aaaa"), ("/pkg/B.app", "bbbb") }, Array.Empty<string>());
+        var one = RecordPatches.ComputeBcAppSymbolStateKey(
+            new[] { ("/pkg/A.app", "aaaa") }, Array.Empty<string>());
+        Assert.NotEqual(two, one);
+    }
+
+    [Fact]
+    public void SymbolStateKey_ChangesWhenAQuerySymbolJsonIsRegistered()
+    {
+        var without = RecordPatches.ComputeBcAppSymbolStateKey(
+            new[] { ("/pkg/A.app", "aaaa") }, Array.Empty<string>());
+        var with = RecordPatches.ComputeBcAppSymbolStateKey(
+            new[] { ("/pkg/A.app", "aaaa") }, new[] { "/out/SymbolReference.json" });
+        Assert.NotEqual(without, with);
+    }
+
+    [Fact]
+    public void SymbolStateKey_EmptyRegistry_IsTheNamedNoneSentinel()
+    {
+        // A named sentinel rather than the SHA-256 of nothing, so a key read by a human says
+        // "no symbol sources were registered" instead of an opaque constant that looks like a
+        // hash of something.
+        Assert.Equal("|bcapps:none",
+            RecordPatches.ComputeBcAppSymbolStateKey(
+                Array.Empty<(string, string)>(), Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void SymbolStateKey_DoesNotConfuseAnAppPathWithAQueryJsonPath()
+    {
+        // Framing check: without the per-entry "app"/"qjson" tags a path moving from one list
+        // to the other would hash identically, and the two are not the same registration.
+        var asApp = RecordPatches.ComputeBcAppSymbolStateKey(
+            new[] { ("/x/thing", "") }, Array.Empty<string>());
+        var asJson = RecordPatches.ComputeBcAppSymbolStateKey(
+            Array.Empty<(string, string)>(), new[] { "/x/thing" });
+        Assert.NotEqual(asApp, asJson);
+    }
+}

--- a/AlRunner/Patches/RecordPatches.BcAppFallback.cs
+++ b/AlRunner/Patches/RecordPatches.BcAppFallback.cs
@@ -92,6 +92,107 @@ public static partial class RecordPatches
     }
 
     /// <summary>
+    /// A stable digest of the BC symbol sources registered in THIS process — the
+    /// <see cref="_bcAppPaths"/> set with each entry's content hash, plus the paths of the
+    /// loose query-symbol JSON files. Folded into the install-baseline cache key
+    /// (<c>TestExecutor.CurrentInstallBaselineCacheKey</c>); see that method for why.
+    ///
+    /// <para>Why this exists (#2710). The install-baseline snapshot is the rows the Install
+    /// triggers and Company-Initialize wrote, and they write them through table metadata
+    /// built from exactly these registrations — <see cref="EnsureBcSymbolTableIndex"/> /
+    /// <see cref="EnsureBcSymbolExtensionIndex"/> rebuild the table and table-extension
+    /// indexes by walking <see cref="_bcAppPaths"/>. So the registered set is an INPUT to the
+    /// snapshot, and until this line existed the key never named it. #2712 measured what the
+    /// difference is worth: dropping 90 of 96 Base Application table extensions flipped 47
+    /// Tests-SMB tests ("field 5912 cannot be found in the 'Customer' table") with an
+    /// unchanged exit code.</para>
+    ///
+    /// <para>The set genuinely varies between two runs whose (dependency assemblies, runner
+    /// build, BC version) are identical — the three terms the key did name:</para>
+    /// <list type="bullet">
+    /// <item><description><b>--server / --watch accumulate it.</b> <see cref="_bcAppPaths"/>
+    /// is process-global and nothing ever clears it: <see cref="InvalidateBcAppIndexes"/>
+    /// drops the DERIVED indexes so they rebuild FROM this list, and <c>ResetForReload</c>
+    /// (the per-bundle reload path) calls exactly that. Meanwhile the key's only per-bundle
+    /// term is reset per bundle — <c>InstallTriggerRunner.ResetForNewBundle</c> clears
+    /// <c>_depAssemblies</c>. Two writers of the same per-bundle state, one keeping the
+    /// invariant and one not: the second bundle in a server process computes its snapshot
+    /// against its own apps UNION every earlier bundle's, then persists it under the key a
+    /// fresh single-bundle process will look up.</description></item>
+    /// <item><description><b><see cref="RegisterBundleSymbolApps"/> skips what it cannot
+    /// read.</b> An unreadable bundle-root .app is skipped as a whole with a <c>[warn]</c>
+    /// line and the run continues — which is the right call for an optional input, but it
+    /// means a transiently unreadable file (a concurrent write, a package left half-written
+    /// by a killed run) silently removes a symbol source without changing any other key
+    /// term.</description></item>
+    /// </list>
+    ///
+    /// <para>Order-independent (paths are sorted) because registration order is an artifact
+    /// of dependency-resolution order, not of what was registered. Content-hashed for .app
+    /// entries because two packages can share a path across runs and differ in bytes;
+    /// PATH-only for the query-symbol JSONs, which are this run's own compiler output — their
+    /// content is already determined by the bundle sources the AL-output key hashes, so
+    /// hashing them here would only add churn. <c>ComputeAppContentHash</c> is memoized per
+    /// path and every registered .app was already hashed by <see cref="AddBcAppPath"/>'s own
+    /// <c>BcAppSymbolCache.Get</c> call, so this costs a dictionary lookup per entry.</para>
+    /// </summary>
+    internal static string RegisteredBcAppSymbolStateKey()
+    {
+        string[] apps;
+        string[] queryJson;
+        lock (_bcTableIndexLock)
+        {
+            apps = _bcAppPaths.ToArray();
+            queryJson = _bcQuerySymbolJsonPaths.ToArray();
+        }
+        return ComputeBcAppSymbolStateKey(
+            apps.Select(p => (p, BcAppSymbolCache.ComputeAppContentHash(p))), queryJson);
+    }
+
+    /// <summary>
+    /// Testable core of <see cref="RegisteredBcAppSymbolStateKey"/>: takes the registered
+    /// entries explicitly so a test can vary the set, the order and the content hashes
+    /// without having to drive the process-global registry (which has no unregister).
+    /// Mirrors the same core/wrapper split <c>RunnerFingerprint.WriteKeyLines</c> and
+    /// <c>NclCecilRewrite.ComputeCacheKeyCore</c> use.
+    /// </summary>
+    internal static string ComputeBcAppSymbolStateKey(
+        IEnumerable<(string Path, string ContentHash)> apps, IEnumerable<string> querySymbolJsonPaths)
+    {
+        var appList = apps.ToList();
+        var jsonList = querySymbolJsonPaths.ToList();
+        if (appList.Count == 0 && jsonList.Count == 0) return "|bcapps:none";
+        appList.Sort(static (a, b) => string.CompareOrdinal(a.Path, b.Path));
+        jsonList.Sort(StringComparer.Ordinal);
+        using var hash = System.Security.Cryptography.IncrementalHash.CreateHash(
+            System.Security.Cryptography.HashAlgorithmName.SHA256);
+        void Feed(string s) => hash.AppendData(System.Text.Encoding.UTF8.GetBytes(s));
+        foreach (var (path, contentHash) in appList)
+        {
+            Feed("app\n");
+            Feed(path);
+            Feed("\n");
+            Feed(contentHash);
+            Feed("\n");
+        }
+        foreach (var p in jsonList)
+        {
+            Feed("qjson\n");
+            Feed(p);
+            Feed("\n");
+        }
+        return "|bcapps:" + Convert.ToHexString(hash.GetHashAndReset()).ToLowerInvariant();
+    }
+
+    /// <summary>Test seam: the registered .app paths, so a test can assert what
+    /// <see cref="RegisteredBcAppSymbolStateKey"/> is digesting rather than inferring it
+    /// from the hash alone.</summary>
+    internal static IReadOnlyList<string> RegisteredBcAppPathsForTests()
+    {
+        lock (_bcTableIndexLock) return _bcAppPaths.ToArray();
+    }
+
+    /// <summary>
     /// Register a BC dependency .app path so its AL table sources can be used
     /// as a fallback when a test's own src/ doesn't define a referenced table.
     /// Called from Program.cs after DependencyLoader.LoadAll.

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -293,9 +293,39 @@ public sealed class TestExecutor
     /// directly assertable — see TestDataProvisioningTests.
     /// CacheIdentity() returns the empty string when --test-data is off, so a default run's
     /// key is byte-identical to what it was before #2258.
+    ///
+    /// #2710: the same omission, one input further out. The snapshot is the rows the Install
+    /// triggers and Company-Initialize wrote, and they write them through table metadata the
+    /// runner builds from the BC .app symbol sources REGISTERED IN THIS PROCESS
+    /// (RecordPatches._bcAppPaths). That registered set is an input to the snapshot and it
+    /// varies independently of all three terms this key used to carry — --server/--watch
+    /// accumulate it across bundles while ResetForNewBundle resets the dependency-assembly
+    /// term, and RegisterBundleSymbolApps drops an unreadable bundle-root .app with only a
+    /// [warn]. So a run with a degraded or merely different symbol state persisted a snapshot
+    /// under the identical key a healthy run then read back, with nothing at read time able to
+    /// tell: the file header's claim that this is "a pure function of (dependency assembly
+    /// set, runner build, BC version)" was false. RegisteredBcAppSymbolStateKey() names the
+    /// missing input; see its doc comment for the two reachable paths and the measured cost
+    /// (#2712: 90 of 96 table extensions dropped, 47 Tests-SMB tests flipped, exit code
+    /// unchanged).
+    ///
+    /// This is a KEY change, not a payload change: entries written under the old key simply
+    /// hash elsewhere and are never found again, so no schema version needs bumping. It can
+    /// cost reuse — a --server process's second bundle no longer shares an entry with a fresh
+    /// single-bundle process — which is correct, because those two runs did not compute the
+    /// same thing.
     /// </summary>
+    /// <remarks>
+    /// Term ORDER is load-bearing, not cosmetic: TestDataProvisioningTests
+    /// .TestDataRun_AndPlainRun_DoNotShareAnInstallBaselineCacheKey asserts that a
+    /// --test-data key STARTS WITH the plain key, i.e. that #2258's identity is purely
+    /// additive. So the #2710 term goes BEFORE CacheIdentity(), keeping that invariant
+    /// intact; appending it instead breaks the prefix relation while changing nothing about
+    /// what either term discriminates.
+    /// </remarks>
     internal static string CurrentInstallBaselineCacheKey()
         => InstallTriggerRunner.CurrentDependencySetKey()
+         + AlRunner.Patches.RecordPatches.RegisteredBcAppSymbolStateKey()
          + AlRunner.Infrastructure.TestDataOptions.CacheIdentity();
 
     /// <summary>
@@ -441,7 +471,17 @@ public sealed class TestExecutor
             else
                 lock (_depCompanyBaselineCacheLock)
                     _depCompanyBaselineCache.TryGetValue(depKey, out cached);
-            var shortKey = depKey[..Math.Min(8, depKey.Length)];
+            // #2710: this log token has to be an IDENTITY, and it was not. It used to be
+            // depKey[..8] — and depKey opens with InstallTriggerRunner.CurrentDependencySetKey(),
+            // whose first characters are the first dependency assembly's MVID, so every app
+            // group sharing a first dependency printed the SAME "key" however different their
+            // real keys were. Measured on InstallBaselineDiskCacheTests's own four-bundle run:
+            // two app groups wrote to 589cefc3….bin and a3401318….bin — provably different
+            // keys — and both logged "b13a7122", so a reader (or a test) comparing these
+            // tokens sees one entry where there are two. SHA-256 of the WHOLE depKey instead,
+            // via the same helper the on-disk filename uses, so distinct keys are distinct
+            // tokens. Same token shape, so the AL_RUNNER_PERF marker format is unchanged.
+            var shortKey = AlRunner.Infrastructure.InstallBaselineDiskCache.HashKey(depKey)[..8];
             if (cached != null)
             {
                 AlRunner.Patches.RecordPatches.RestoreInstallBaselineSnapshot(cached);


### PR DESCRIPTION
Closes #2710

Written by an agent (impl-1) on Stefan's behalf.

## What the report's signature actually means

#2710 measured a cache that a killed run left mutually inconsistent: Tests-SMB dropped 259 to 63 passing on the same binary, removing any ONE cache subdirectory left it at 63, and only a full wipe restored it. Every entry passed its own validity check.

That shape — individually valid entries, no single entry invalidatable — is what a derived cache tier looks like when its key omits an input. I went looking for the omitted input rather than for a torn write.

## The omitted input

The install-baseline snapshot is the rows the Install triggers and Company-Initialize wrote. They write them through table metadata the runner builds from the BC `.app` symbol sources **registered in this process** — `RecordPatches._bcAppPaths`, which `EnsureBcSymbolTableIndex` and `EnsureBcSymbolExtensionIndex` walk to build the table and table-extension indexes.

The key was `(dependency assembly set, runner build, BC version)` plus #2258's `--test-data` identity. `RecordPatches.InstallBaselineDisk`'s own header asserted that set was complete — "deterministic given (dependency assembly set, runner build, BC version)". It is not, and the registered set varies independently of all four:

- **`--server` / `--watch` accumulate it.** `_bcAppPaths` is process-global and nothing clears it. `ResetForReload` calls `InvalidateBcAppIndexes`, which drops the *derived* indexes precisely so they rebuild **from** that list. Meanwhile the key's only per-bundle term **is** reset per bundle: `InstallTriggerRunner.ResetForNewBundle` clears `_depAssemblies`. Two writers of the same per-bundle state, one holding the invariant and one not — so a server process's second bundle computes its snapshot against its own apps union every earlier bundle's, then persists it under the key a fresh single-bundle process will look up.
- **`RegisterBundleSymbolApps` skips what it cannot read.** An unreadable bundle-root `.app` is dropped with a `[warn]` and the run continues. Right call for an optional input, but it silently removes a symbol source without moving any other key term — exactly what a killed or concurrent run produces.

What the difference is worth was already measured by #2712: a partial table-extension index (90 of 96 Base Application extensions dropped) flipped 47 Tests-SMB tests with an unchanged exit code.

## The fix

`RecordPatches.RegisteredBcAppSymbolStateKey()` digests the registered `.app` set — path plus content hash, order-independent — together with the query-symbol JSON paths, and `CurrentInstallBaselineCacheKey` folds it in. A run with a different symbol state now **misses** instead of reading another run's snapshot. Prevention by key, not detection after the fact, which is the same remedy #2258 applied to `--test-data`.

Term order is load-bearing: the new term goes **before** `TestDataOptions.CacheIdentity()`, because `TestDataProvisioningTests` asserts a `--test-data` key starts with the plain key. Appending instead broke that and I caught it locally.

This is a key change, not a payload change, so no schema version moves: old entries hash elsewhere and are never found again.

## A second defect, same shape one level down

Found because it broke a neighbouring test. The `AL_RUNNER_PERF` marker's key token was `depKey[..8]`, and `depKey` opens with the first dependency assembly's MVID — so every app group sharing a first dependency printed the **same** token. Measured on `InstallBaselineDiskCacheTests`'s own four-bundle run: two app groups wrote `589cefc3….bin` and `a3401318….bin`, provably different keys, and both logged `b13a7122`. A diagnostic that names a cache entry has to name it, and a test keying on that token was intersecting two entries as one. Now SHA-256 of the whole `depKey`, via the same helper the on-disk filename uses. Marker format unchanged, so the other parsers are unaffected.

## RED to GREEN

`AlRunner.Tests/InstallBaselineKeySymbolStateTests.cs`, 10 tests. With the fold reverted to `origin/main`'s `TestExecutor.cs`:

```
InstallBaselineKey_ChangesWhenAnotherBcAppIsRegistered                          [FAIL]
RegisterBundleSymbolApps_SkippingAnUnreadableApp_LeavesADifferentKeyThanReadingIt [FAIL]
  Assert.NotEqual() Failure: Strings are equal
Failed! - Failed: 2, Passed: 8
```

With the fix: `Passed! - Failed: 0, Passed: 10`. The other eight pin the digest itself — order independence, content sensitivity under an unchanged path, a dropped app, the app-versus-query-json framing, and the named empty sentinel.

## What I verified locally, and with what

| check | command | result |
|---|---|---|
| RED baseline | revert `TestExecutor.cs` to `origin/main`, `dotnet test AlRunner.Tests --filter ~InstallBaselineKeySymbolStateTests` | 2 failed / 8 passed |
| GREEN | same filter, fix restored | 10/10 |
| neighbours | `--filter` over `InstallBaselineDiskCacheTests`, `InstallSeedDepCompanyCacheTests`, `TestDataProvisioningTests`, `RecordPatchesBcAppSymbolReadFailureTests`, `BcAppSymbolCachePartialParseTests`, `RecordPatchesWarmReload{InstallBaseline,ExtensionIndex}Tests` | 58 passed / 0 failed / 3 skipped |
| the cache still works across processes | two runs of `tests/runner-extras/install-trigger-seed` with `AL_RUNNER_PERF=1` and a private `--cache` | run 1 `MISS 221f9556` + `DISK-WRITE`, run 2 `DISK-HIT 221f9556` |
| no behaviour regression | Microsoft's `Tests-SMB`, 1027 tests, private `--cache` | 237 passing before and after |

Every runner invocation used a private `--cache` outside the repository.

## What I did NOT verify, and what could still be wrong

- **The exact field sequence in #2710 is not reproduced.** I probed a clean `SIGKILL` at six points — 10 s, 30 s, 50 s, 65 s, 74 s single-process, and a `--jobs 3` multi-bucket run at 45 s — each followed by a full Tests-SMB run against the same cache. **None poisoned anything**: every tier self-healed and the result stayed at 237. So this PR does not fix a reproduction; it fixes the structural blindness that makes such a poisoning undetectable, plus the log token that made it hard to see. If the coordinator wants the reproduction itself, the remaining candidate is an out-of-memory survival path rather than a kill, which #2722 has partly closed.
- **I did not run the full `AlRunner.Tests` suite, the corpus, or `runner-extras`.** The install-baseline path runs on every app group of every run, so the blast radius is real even though the neighbouring suites are green. The most likely CI-only failure is another test that parses the `DepCompanyCache <token>` marker and happens to depend on its old value; I checked `InstallSeedDepCompanyCacheTests` (counts occurrences only) and `InstallBaselineDiskCacheTests` (now green), but I did not grep every consumer.
- **Cache reuse in `--server` mode will drop.** The second bundle in a server process no longer shares an install-baseline entry with a fresh single-bundle process. That is correct — those two runs did not compute the same thing — but it is a real cost, and I have not measured it.
- **I hashed the query-symbol JSON paths but not their content**, on the argument that they are this run's own compiler output and their content is already determined by the bundle sources the AL-output key hashes. If that argument is wrong, the term under-captures for those files.

## Things I found and did not fix

Filed separately rather than folded in: the AL-output cache key's dependency term is `id+version` strings rather than content hashes, so two packages with the same declared identity and different bytes collide; and `_bcAppPaths` accumulating across bundles in one server process is now key-visible but is arguably wrong in itself.

No `README`, `--help`, `docs/limitations.md` or `docs/scope.md` change: this is an internal cache key with no CLI surface.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
