### PR TITLE
docs(rules): resolve the never-rerun vs flake-evidence contradiction in ci-verdicts.md

### DIFF
--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -62,12 +62,15 @@ while CI you are responsible for is still running (`no-backgrounding-long-comman
 Re-check with `gh run view <id> --json status,conclusion` and treat anything other than
 `completed` as "not yet reported".
 
-## 3. Never re-run a failed job
+## 3. Never re-run a failed job — not even to gather evidence
 
 `gh run rerun` and the web "Re-run" button overwrite the failed run's logs permanently. Read
 the log first (`gh run view <id> --log-failed`, or `mcp__github__get_job_logs` with
-`failed_only: true, return_content: true`), save what you need, then push a new commit for a
-fresh run. A re-run is never a diagnostic step — it destroys the evidence a diagnosis needs.
+`failed_only: true, return_content: true`), save what you need. **Then do not re-run that same
+run — not even after saving the log.** A re-run is never a diagnostic step — it destroys the
+evidence a diagnosis needs, and section 5's flake-evidence standard needs a second, independent
+run, not the same one overwritten in place. See "Getting a second run of the same commit"
+under section 5 for how to get one without this.
 
 ## 4. Diagnose from the log, not from a theory
 
@@ -81,9 +84,77 @@ Dismissed twice without checking; both times it was real and both blocked a rele
 one of:
 
 - the same failure reproducing on `origin/main` at a commit predating the branch;
-- a *changing failing-leg set* across repeated runs of the same commit (load-dependent, not
-  the commit);
+- a *changing failing-leg set* across two **independent** runs of the same code (load-dependent,
+  not the commit) — see below for how to get the second run without `gh run rerun`;
 - an existing issue describing that exact failure.
+
+**"Same code" means the same tree, not the same commit SHA.** An empty commit
+(`git commit --allow-empty`) changes no tree content, only commit metadata, so its CI run is a
+legitimate second data point for this standard even though the SHA differs from the original.
+Two commits with different trees are not the same code no matter how closely related they look
+— reading a leg-set change between two *different* head SHAs as a flake signal proved nothing
+and cost real time on corpus PR 2639. Confirm the trees actually match before trusting a
+comparison across commits:
+
+```bash
+[ "$(git rev-parse <sha1>^{tree})" = "$(git rev-parse <sha2>^{tree})" ] && echo "same tree"
+```
+
+### Getting a second run of the same commit without `gh run rerun`
+
+Both options below create a brand-new, separate workflow run. Neither touches the original
+failed run or its log — that run and its log stay exactly as they were, so a diagnosis made
+from the original log is never at risk.
+
+**When the workflow exposes `workflow_dispatch` with a way to target one leg** — dispatch that
+leg directly against the failing ref, which still points at the same commit as long as nobody
+has pushed since:
+
+```bash
+gh workflow run ci.yml --repo <owner>/<repo> --ref <branch> -f bc_version=28.4
+```
+
+`StefanMaron/BusinessCentral.AL.Language.Tests`' `.github/workflows/ci.yml` supports exactly
+this (`bc_version` input). It is how impl-4 got a second, independent verdict on corpus PR
+#144's BC 28.4 leg without disturbing the original: run 33962643816, dispatched against the
+same SHA that had just failed, came back 2495/2495 clean. **This repository's own
+`test-matrix.yml` / `bc-tests.yml` do not currently expose `workflow_dispatch`** — this exact
+recipe is not available here today (see "Not done here" below).
+
+**When there is no per-leg dispatch (the case here, today)** — push an empty commit:
+
+```bash
+git commit --allow-empty -m "chore: re-run CI to check a leg-set flake (no content change)"
+git push
+```
+
+This is the AL Runner recipe until `test-matrix.yml` gains a `workflow_dispatch` trigger, if it
+ever does.
+
+### What neither of these is
+
+Neither is a way to make a red required check pass without fixing anything, and neither
+overrides a human's call about what to do with the result — their only legitimate use is
+deciding whether "pre-existing unrelated flake" is actually true, evidence a person can act on.
+If the failing-leg set repeats identically on the second run, that is the code, not the
+environment — stop calling it a flake and go fix it.
+
+Re-rolling CI *hoping* the same failure won't recur, as a way to get past a red required check,
+is separately and explicitly not sanctioned, by any mechanism — tried for real with a genuine
+content-changing push on corpus PR #145, it moved the failing leg from BC 28.2 to BC 28.0
+without fixing anything, at roughly 8 minutes of the whole account's shared Actions queue per
+attempt. GitHub Actions concurrency is scoped per account, not per repository, so that cost is
+shared with every other repo and agent using the same account, not just this one. Nobody
+bypasses a red required check. The two recipes above are for finding out whether a failure is
+real, not for making it go away.
+
+### Not done here: teaching a tool to dispatch this
+
+`tools/ci-wait.py` answers "has this PR's required check reported a verdict on its current
+head" — a different question from "get me an independent second run of this exact commit."
+Folding the dispatch recipe into it would conflate two different operations behind one tool, so
+it stays out for now. If this recipe gets used often enough to be worth automating, that is a
+new, narrowly-scoped tool, not an addition to `ci-wait.py`.
 
 ## Sister rules
 


### PR DESCRIPTION
Closes #2649

## The contradiction

Section 3 banned `gh run rerun` unconditionally — it destroys a failed run's log permanently, and the logs from four separate corpus leg aborts investigated today (issue tracked in `StefanMaron/BusinessCentral.AL.Language.Tests` #39) were the entire evidence base for that investigation; a re-run would have destroyed them.

Section 5 required, as one of three acceptable forms of flake evidence, "a changing failing-leg set across repeated runs of the same commit." Getting that evidence needs a second run of the identical commit, and section 3 gave no legitimate way to get one. An agent hit this for real on PR 2625: saved the failing log first, then did the one thing section 3 forbids anyway, because the rule didn't say what else to do.

## The fix

Keep the ban on `gh run rerun` with no exception — not even "I already saved the log." That run's own log is still destroyed regardless of what's saved elsewhere.

Add a documented way to get a second, independent run instead — a new run, not the same one overwritten in place:

1. **When the workflow exposes `workflow_dispatch` with a per-leg input** — dispatch that leg directly against the failing ref. `StefanMaron/BusinessCentral.AL.Language.Tests`' `ci.yml` supports this today (`bc_version` input). Verified against a real instance rather than assumed: impl-4 used exactly this on corpus PR #144's BC 28.4 leg, run 33962643816, and got 2495/2495 clean on the identical SHA that had just failed.
2. **When there is no per-leg dispatch** — an empty commit (`git commit --allow-empty`). I checked: this repository's own `test-matrix.yml` and `bc-tests.yml` have no `workflow_dispatch` trigger at all (grepped both files), so option 1 isn't available here today, and the rule says so plainly instead of describing a recipe that doesn't work in its own repo.

Both are scoped explicitly to evidence-gathering, not to making a red required check pass. The rule now separately and explicitly rules out re-rolling CI *hoping* a failure won't recur, citing what actually happened on corpus PR #145: a genuine content-changing push moved the failing leg from BC 28.2 to BC 28.0 without fixing anything, at roughly 8 minutes of the whole GitHub account's shared Actions queue per attempt (Actions concurrency is per-account, not per-repository). Nobody bypasses a red required check that way either.

## A second, related fix folded in

Section 5's "changing failing-leg set across repeated runs of the same commit" language actually meant "the same tree," not "the same commit SHA" — an empty commit is a different SHA with identical content, and that's exactly the case the evidence standard needs to accept. I tightened the wording to say "same tree" explicitly, gave the exact check (`git rev-parse <sha>^{tree}`), and named the mistake this prevents: comparing failing-leg sets across genuinely *different* commits proved nothing and cost real time on corpus PR 2639, which the issue's own author flagged as a mistake made the same night.

## `tools/ci-wait.py` — considered, decided against

I looked at whether the dispatch recipe belongs in `ci-wait.py`. It doesn't: `ci-wait.py` answers "has this PR's required check reported a verdict on its current head," which is a different question from "get me an independent second run of this exact commit for flake evidence." The two dispatch recipes above aren't about a specific PR's check state at all — the corpus recipe targets an arbitrary ref via `workflow_dispatch`, not a PR. Folding them into `ci-wait.py` would conflate two different operations behind one tool. If this recipe gets used often enough to be worth automating, that's a new, narrowly-scoped tool, not an addition to this one.

---
Written by Claude Code agent impl-7. Off the (impl-1, impl-2) identity pool for this session — flagging per the workflow contract so the drift is visible; this leaves behind its own `.claude/worktrees/impl-7` checkout going forward.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
