### PR TITLE
fix(ci): pe_signing verify must fail on a scan that classified no PE files

### DIFF
--- a/.github/scripts/pe_signing.py
+++ b/.github/scripts/pe_signing.py
@@ -33,6 +33,21 @@ Used two ways from publish.yml (#2248):
       root(s); exits 0 otherwise. This is the release-path verification gate:
       it must find zero unsigned PE files in the packed nupkg contents.
 
+BOTH subcommands exit 1 when a root does not exist, and when the walk
+classified ZERO PE files -- an empty directory, a tree whose only .dll/.exe
+files are unparseable, or one whose only PE files sit in an excluded
+ref/refint directory (#2298). verify used to print
+"OK: all 0 .dll/.exe file(s) checked are Authenticode-signed." and exit 0 for
+all of those, which is the failure class #2284 fixed one layer up: a check
+that cannot distinguish "I looked and everything was signed" from "I did not
+look at anything". An empty scan is a hard failure, not a lenient pass and
+not a warning -- every caller of this script is a release gate, and the one
+in publish.yml that builds the signing catalog already refuses to "succeed at
+signing nothing" for the same reason. Note what is NOT affected: zero
+*unsigned* files in a tree that really was scanned remains a normal success
+for list-unsigned (an already-signed tree writes a legitimately empty
+catalog); it is zero *scanned* files that fails.
+
 Both subcommands share the same walk: recurse into `.dll`/`.exe` files,
 skipping any path with a `ref` or `refint` directory component (MSBuild's
 compile-only reference-assembly output -- never copied into a publish/pack
@@ -154,16 +169,100 @@ def scan(roots: list[Path], exclude_dirs: frozenset[str] = DEFAULT_EXCLUDE_DIRS)
                     yield Path(dirpath) / name
 
 
+def _missing_roots(roots: list[Path]) -> list[Path]:
+    """Roots that do not exist on disk. os.walk() yields nothing and raises
+    nothing for a missing directory, so without this check a typo'd or
+    never-created root produces an empty scan that reads exactly like a clean
+    one (#2298)."""
+    return [root for root in roots if not root.exists()]
+
+
+def _report_missing_roots(roots: list[Path]) -> bool:
+    """Print a ::error:: line per missing root and return True if any were
+    missing (the caller then exits non-zero without scanning)."""
+    missing = _missing_roots(roots)
+    for root in missing:
+        print(
+            f"::error::scan root does not exist: {root}. Nothing would be "
+            "scanned under it, and an empty scan must not be reported as a "
+            "clean one (#2298).",
+            file=sys.stderr,
+        )
+    return bool(missing)
+
+
+def _classify(roots: list[Path], exclude_dirs: frozenset[str] = DEFAULT_EXCLUDE_DIRS):
+    """Walk the roots once and return (candidates, classified):
+
+      candidates  -- every .dll/.exe path scan() yielded, sorted
+      classified  -- the (path, is_signed) pairs among them that actually
+                     parse as a PE image (is_signed() returned a bool)
+
+    Keeping both counts is what lets the callers below tell "the directory
+    held nothing at all" apart from "it held .dll files that are not PE
+    images" -- different causes, different fixes, and both of them used to
+    print the same "all 0 ... checked" success line."""
+    candidates = sorted(scan(roots, exclude_dirs))
+    classified = []
+    for path in candidates:
+        signed = is_signed(path)
+        if signed is not None:
+            classified.append((path, signed))
+    return candidates, classified
+
+
+def _report_empty_scan(roots: list[Path], candidates: list[Path], consequence: str) -> None:
+    """Print the ::error:: line for a scan that classified zero PE files.
+
+    #2298: `verify` printed "OK: all 0 .dll/.exe file(s) checked are
+    Authenticode-signed." and exited 0 in this situation -- hit for real
+    while verifying the v2.10.0 release, where a failed `dotnet tool install`
+    had left the target directory empty. "Nothing to check" is not
+    "everything checked out"; a gate that cannot distinguish 0 files from 40
+    is not a gate. Same reasoning as the catalog step in publish.yml, which
+    already refuses to "succeed at signing nothing"."""
+    roots_text = ", ".join(str(root) for root in roots)
+    if not candidates:
+        detail = (
+            f"no .dll/.exe files found under {roots_text} "
+            f"(ref/refint directories are excluded from the scan)"
+        )
+    else:
+        detail = (
+            f"found {len(candidates)} .dll/.exe file(s) under {roots_text}, "
+            f"but none of them parsed as a PE image"
+        )
+    print(
+        f"::error::{detail}. Nothing was classified as signed or unsigned, so "
+        f"{consequence} Failing loudly instead of reporting success over an "
+        "empty scan (#2298).",
+        file=sys.stderr,
+    )
+
+
 def _cmd_list_unsigned(args: argparse.Namespace) -> int:
     exclude_dirs = DEFAULT_EXCLUDE_DIRS | set(args.exclude_dir)
     roots = [Path(r) for r in args.roots]
     relative_to = Path(args.relative_to).resolve()
 
-    unsigned_paths = []
-    for path in sorted(scan(roots, exclude_dirs)):
-        signed = is_signed(path)
-        if signed is False:
-            unsigned_paths.append(path)
+    if _report_missing_roots(roots):
+        return 1
+
+    candidates, classified = _classify(roots, exclude_dirs)
+    if not classified:
+        # Note the distinction this does NOT break: zero *unsigned* files in
+        # a tree that really was scanned stays a successful, empty catalog
+        # (an already-signed tree). What fails here is zero *scanned* files --
+        # a catalog built from a scan that saw nothing signable.
+        _report_empty_scan(
+            roots,
+            candidates,
+            "the signing catalog would be built from a scan that examined "
+            "nothing, and the signing step would have no files to sign.",
+        )
+        return 1
+
+    unsigned_paths = [path for path, signed in classified if not signed]
 
     lines = []
     for path in unsigned_paths:
@@ -203,15 +302,21 @@ def _cmd_list_unsigned(args: argparse.Namespace) -> int:
 
 def _cmd_verify(args: argparse.Namespace) -> int:
     roots = [Path(r) for r in args.roots]
-    unsigned = []
-    total_pe = 0
-    for path in sorted(scan(roots)):
-        signed = is_signed(path)
-        if signed is None:
-            continue
-        total_pe += 1
-        if not signed:
-            unsigned.append(path)
+
+    if _report_missing_roots(roots):
+        return 1
+
+    candidates, classified = _classify(roots)
+    if not classified:
+        _report_empty_scan(
+            roots,
+            candidates,
+            "this gate verified nothing at all.",
+        )
+        return 1
+
+    total_pe = len(classified)
+    unsigned = [path for path, signed in classified if not signed]
 
     if unsigned:
         print(

--- a/.github/scripts/test_pe_signing.py
+++ b/.github/scripts/test_pe_signing.py
@@ -304,6 +304,187 @@ class ListUnsignedCliTests(unittest.TestCase):
             self.assertIn("OK", result.stdout)
 
 
+class EmptyScanTests(unittest.TestCase):
+    """#2298: a scan that classified NOTHING must not report success.
+
+    `verify` used to print "OK: all 0 .dll/.exe file(s) checked are
+    Authenticode-signed." and exit 0 for a directory holding no PE files at
+    all -- hit for real while verifying the v2.10.0 release, where a failed
+    `dotnet tool install` had left the target directory empty and the gate
+    reported OK against nothing. A verifier that cannot tell "0 files, all
+    good" from "40 files, all good" is not a gate. Same for `list-unsigned`:
+    a catalog built from a scan that saw no PE files is not "nothing needed
+    signing", it is "nothing was looked at".
+
+    Both directions are covered here -- the empty/unclassifiable cases must
+    fail, and the populated cases in the same class must still succeed, so a
+    fix that simply always fails is caught.
+    """
+
+    def _verify(self, *roots):
+        return subprocess.run(
+            [sys.executable, SCRIPT_PATH, "verify", *[str(r) for r in roots]],
+            capture_output=True, text=True,
+        )
+
+    def _list_unsigned(self, root, catalog=None):
+        argv = [sys.executable, SCRIPT_PATH, "list-unsigned", str(root),
+                "--relative-to", str(root)]
+        if catalog is not None:
+            argv += ["--catalog", str(catalog)]
+        return subprocess.run(argv, capture_output=True, text=True)
+
+    # --- verify: the vacuous passes that must now fail -------------------
+
+    def test_verify_fails_on_directory_with_no_pe_files_at_all(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = self._verify(tmp)
+
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertNotIn("OK", result.stdout)
+            # The directory has to be named, so a caller can tell "nothing to
+            # check" apart from "everything checked out".
+            self.assertIn(tmp, result.stderr)
+            self.assertIn("no .dll/.exe files", result.stderr)
+
+    def test_verify_fails_when_every_candidate_is_not_a_pe_image(self):
+        # 3 files matching the extension, none of them a PE image: the old
+        # code counted only classifiable files, so this also printed
+        # "all 0 ... checked". The message must distinguish this case from
+        # the empty-directory one, because the fix is different (a broken
+        # build output vs. a missing one).
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            for name in ("a.dll", "b.dll", "c.exe"):
+                (root / name).write_bytes(b"not a PE image at all, just text")
+
+            result = self._verify(root)
+
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertNotIn("OK", result.stdout)
+            self.assertIn("3 .dll/.exe file(s)", result.stderr)
+            self.assertIn("none of them parsed as a PE image", result.stderr)
+
+    def test_verify_fails_when_the_only_pe_files_are_in_an_excluded_dir(self):
+        # ref/ and refint/ are skipped by scan(), so a tree whose ONLY PE
+        # files live there is verified against nothing -- same vacuous pass.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "obj" / "ref").mkdir(parents=True)
+            (root / "obj" / "ref" / "app.dll").write_bytes(
+                build_fake_pe(0x20B, cert_table_size=4096))
+
+            result = self._verify(root)
+
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn("no .dll/.exe files", result.stderr)
+
+    def test_verify_fails_on_a_root_that_does_not_exist(self):
+        # os.walk() on a missing path yields nothing and raises nothing, so
+        # a typo'd or never-created root verified clean before this fix.
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "never-created"
+
+            result = self._verify(missing)
+
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertNotIn("OK", result.stdout)
+            self.assertIn(str(missing), result.stderr)
+            self.assertIn("does not exist", result.stderr)
+
+    def test_verify_fails_when_one_of_several_roots_does_not_exist(self):
+        # publish.yml passes four roots. A single missing one must not be
+        # masked by the others having content.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            good = root / "good"
+            good.mkdir()
+            (good / "signed.dll").write_bytes(build_fake_pe(0x20B, cert_table_size=999))
+            missing = root / "variants-staging"
+
+            result = self._verify(good, missing)
+
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn(str(missing), result.stderr)
+            self.assertIn("does not exist", result.stderr)
+
+    # --- verify: the control cases that must still pass ------------------
+
+    def test_verify_still_reports_ok_and_the_real_count_for_signed_pes(self):
+        # The other direction: a fix that just always fails is caught here,
+        # and the reported count must be the real one (2), not a constant --
+        # "all 0" is exactly the string this issue is about.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "signed-a.dll").write_bytes(build_fake_pe(0x20B, cert_table_size=999))
+            (root / "signed-b.exe").write_bytes(build_fake_pe(0x10B, cert_table_size=1))
+            # Unclassifiable and excluded files alongside them must not stop
+            # the OK, since two real PE files WERE checked.
+            (root / "not-a-pe.dll").write_bytes(b"plain text")
+            (root / "obj" / "ref").mkdir(parents=True)
+            (root / "obj" / "ref" / "skipped.dll").write_bytes(build_fake_pe(0x20B, 0))
+
+            result = self._verify(root)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("OK: all 2 .dll/.exe file(s)", result.stdout)
+
+    def test_verify_of_a_single_signed_file_root_still_passes(self):
+        # scan() accepts a file path directly; that path must not be caught
+        # by the emptiness guard.
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "signed.dll"
+            path.write_bytes(build_fake_pe(0x20B, cert_table_size=7))
+
+            result = self._verify(path)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("OK: all 1 .dll/.exe file(s)", result.stdout)
+
+    # --- list-unsigned: same distinction ---------------------------------
+
+    def test_list_unsigned_fails_on_directory_with_no_pe_files_and_writes_no_catalog(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            catalog = root / "catalog.txt"
+
+            result = self._list_unsigned(root, catalog)
+
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn(str(root), result.stderr)
+            self.assertIn("no .dll/.exe files", result.stderr)
+            # An empty catalog must not be left behind for the signing action
+            # to consume -- the failure has to be the only outcome.
+            self.assertFalse(catalog.exists(), "an empty catalog was written anyway")
+
+    def test_list_unsigned_fails_on_a_root_that_does_not_exist(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "never-created"
+
+            result = self._list_unsigned(missing)
+
+            self.assertEqual(result.returncode, 1, result.stdout + result.stderr)
+            self.assertIn(str(missing), result.stderr)
+            self.assertIn("does not exist", result.stderr)
+
+    def test_list_unsigned_still_succeeds_with_an_empty_listing_when_all_are_signed(self):
+        # The distinction that makes this fix correct rather than merely
+        # strict: zero UNSIGNED files in a tree that really was scanned is a
+        # legitimate, successful outcome (an already-signed tree), and stays
+        # exit 0 with an empty catalog.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "signed.dll").write_bytes(build_fake_pe(0x20B, cert_table_size=4096))
+            catalog = root / "catalog.txt"
+
+            result = self._list_unsigned(root, catalog)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.stdout.strip(), "")
+            self.assertTrue(catalog.exists())
+            self.assertEqual(catalog.read_text().strip(), "")
+
+
 class ListUnsignedCrossDriveTests(unittest.TestCase):
     """#2286: when a path can't be made relative to --relative-to (the
     Windows cross-drive case), _cmd_list_unsigned must fail loudly instead


### PR DESCRIPTION
Closes #2298

## What the verify path actually did

`_cmd_verify` counted only files that *parse* as a PE image (`is_signed()` returning a bool),
then printed `OK: all {total_pe} .dll/.exe file(s) checked are Authenticode-signed.` and
returned 0 whenever `unsigned` was empty. `total_pe == 0` took that same branch, so four
distinct "I did not look at anything" situations all reported success:

- an empty directory (the case in the issue — a failed `dotnet tool install` during the
  v2.10.0 release left the target directory empty and the gate said OK);
- a root that does not exist at all — `os.walk()` on a missing path yields nothing and
  raises nothing, so a typo'd or never-created root verified clean;
- a tree whose `.dll`/`.exe` files are all unparseable as PE images (40 files in, "all 0"
  out);
- a tree whose only PE files sit in a `ref`/`refint` directory, which `scan()` excludes.

## Semantics chosen for the empty case: hard failure (exit 1), naming the root(s)

Not a warning, and not a distinct lenient exit code. Every caller of this script is a
release gate whose steps treat any non-zero exit as failure, and publish.yml's catalog step
already fails explicitly rather than "silently 'succeeding' at signing nothing" — this makes
the tool itself hold the invariant its callers were holding for it. I deliberately did not
add an `--allow-empty` opt-out: it would have no caller today, and a flag that exists only
in case someone wants the old vacuous pass back is how the hole gets reopened.

The message distinguishes the two causes, because the fix differs:

```
::error::no .dll/.exe files found under <root> (ref/refint directories are excluded from
the scan). Nothing was classified as signed or unsigned, so this gate verified nothing at
all. Failing loudly instead of reporting success over an empty scan (#2298).

::error::found 3 .dll/.exe file(s) under <root>, but none of them parsed as a PE image. ...

::error::scan root does not exist: <root>. Nothing would be scanned under it, and an empty
scan must not be reported as a clean one (#2298).
```

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — `list-unsigned`, which the issue asks
   about. It now fails on the same two conditions (missing root, zero *scanned* PE files)
   and does **not** write the catalog file in that case, so an empty catalog is never left
   behind for the signing action to consume. The distinction that keeps this correct rather
   than merely strict: zero *unsigned* files in a tree that really was scanned is still a
   normal success (an already-signed tree writes a legitimately empty catalog) — there is a
   dedicated test for that direction.
2. **Sibling function making the same assumption?** `scan()` — silently returning nothing for
   a nonexistent root is the root cause of the missing-root variant, and it is shared by both
   subcommands. Both now check via one helper (`_report_missing_roots`).
3. **Two code paths maintaining the same invariant?** They do now: `verify` and
   `list-unsigned` share `_report_missing_roots` / `_classify` / `_report_empty_scan`
   instead of each doing its own walk-and-tally, so the guard cannot be present in one and
   missing in the other.

Also checked and **not** a defect: `.github/scripts/check-nupkg-contents.sh`, the other
release-gate script. It runs under `set -euo pipefail` and `stat`/`unzip -l` fail on a
missing or non-zip input, so it cannot pass over nothing the way this one could.

`publish.yml` needs no change and is not touched. Its four roots
(`AlRunner`, `AlRunner.QueryJoin`, `AlRunner.Provisioning`, `variants-staging`) are all
unconditionally created by the `build` job (`mkdir -p ./variants-staging` plus
`if-no-files-found: error` on the artifact upload), so the new missing-root and empty-scan
checks cannot fail a healthy release.

## RED → GREEN

New `EmptyScanTests` class in `.github/scripts/test_pe_signing.py`, following the existing
subprocess-CLI convention in that file (no signing certificate needed; PE fixtures are the
synthetic ones already built there).

- **RED**, before the fix: `Ran 25 tests ... FAILED (failures=7)` — all seven new negative
  cases, each failing with `AssertionError: 0 != 1 : OK: all 0 .dll/.exe file(s) checked are
  Authenticode-signed.` (and `all 1` for the one-good-root/one-missing-root case).
- **GREEN**, after: `Ran 25 tests in 0.55s / OK`.

The three positive-direction tests in the same class already passed before the fix and still
pass, which is what catches a fix that just always fails:

- `verify` on two signed PE files still exits 0 and reports the **real** count
  (`OK: all 2 .dll/.exe file(s)`), with an unclassifiable file and a `ref/` file alongside
  them — `all 0` is precisely the string this issue is about, so the count is asserted, not
  just the `OK`;
- `verify` on a single signed file passed as the root still exits 0 (`scan()` accepts a file
  path directly; the emptiness guard must not catch it);
- `list-unsigned` on an all-signed tree still exits 0 with empty stdout and an empty catalog
  file written;
- the 15 pre-existing tests in the file are unchanged and pass.

Reproduced the issue's exact command against the fix: exit 1 with the named directory.

## No upstream corpus test

This is runner/CI tooling — a Python PE-header presence check used by `publish.yml`. It
asserts nothing about Business Central behaviour, so there is nothing for a BC service tier
to adjudicate and no `tests/al-language` change is owed. The diff touches no `AlRunner/`
file, so the `require-tests` gate does not apply; `pr-check.yml`'s `pe-signing-tests` job
runs `test_pe_signing.py` on this PR because the diff touches both of its trigger paths.

---
Filed by agent `stma-auto-3` acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
