### PR TITLE
fix(watch): stop serving a dependent bundle the previous compile of its dependency

### DIFF
--- a/AlRunner.Tests/WatchLayeredDependencyStaleTests.cs
+++ b/AlRunner.Tests/WatchLayeredDependencyStaleTests.cs
@@ -1,0 +1,245 @@
+// WatchLayeredDependencyStaleTests — issue #2683: under `--watch`, a dependent bundle is
+// served from cache after its DEPENDENCY changes, so its tests run against the previous
+// compile and report a confident green for code that is no longer on disk.
+//
+// Mechanism (read off Program.cs, then confirmed by this test)
+// -----------------------------------------------------------
+// `RunLayeredPrePass` — the pass that synthesises each depended-upon bundle into a
+// content-keyed workspace dir as a source `.app` plus a `*.symbols.json` sidecar — is called
+// ONCE, before the `while (true)` watch loop, and never again. Every later cycle therefore
+// reuses the `packageCacheDirs` and workspace dirs computed from the FIRST cycle's dependency
+// sources.
+//
+// Two things go stale together, and either alone would be enough to produce a wrong green:
+//
+//   * COMPILE-TIME. The dependent resolves the dependency's symbols from the frozen
+//     `*.symbols.json`, so it compiles against the previous public surface — a procedure the
+//     edit deleted still resolves.
+//   * RUNTIME. `DependencyLoader` extracts and compiles the dependency's source out of the
+//     frozen `.app`, so even a fresh compile of the dependent would EXECUTE the previous
+//     dependency code.
+//
+// And the cache key cannot notice. `GetOrderedDepIds` deliberately stamps each resolved
+// dependency `.app` with `mtime:length` precisely so a sibling source app's changing content
+// invalidates the dependent (see its own comment) — but nothing rewrites that `.app` after
+// cycle 1, so the stamp is frozen and `ComputeAlCacheKey` returns the same key. The dependent
+// re-emits in 0.0s, links against the old symbols, and runs the old code.
+//
+// That is why the fix is to re-run the pre-pass per cycle rather than to add another input to
+// the cache key: invalidating the key alone would recompile the dependent against symbols and
+// runtime code that are still the previous cycle's.
+//
+// The two arms
+// ------------
+// POSITIVE — edit the dependency so its OBSERVABLE ANSWER changes (42 -> 99) while everything
+// still compiles. A test asserting 42 must start FAILING on the next cycle. Choosing a value
+// change over deleting the procedure isolates this defect from the separate EMIT-EXCLUDED /
+// compile-fail reporting concerns in the same issue: nothing here fails to compile, so a green
+// cycle 2 can only mean the previous compile ran.
+//
+// NEGATIVE — edit ONLY the test bundle. The dependency's content is unchanged, so the pre-pass
+// must report `cache HIT` for it rather than re-synthesising. Without this arm the positive one
+// is satisfied by simply rebuilding the world every cycle, which is what `--watch` exists not
+// to do.
+using System.Diagnostics;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class WatchLayeredDependencyStaleTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private const string DepAppId = "b7c1d2e3-2683-4a11-9111-111111111111";
+    private const string TestAppId = "b7c1d2e3-2683-4a11-9222-222222222222";
+
+    private static string WriteDepBundle(string root, int answer)
+    {
+        var dir = Path.Combine(root, "dep-app");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{DepAppId}}",
+          "name": "Watch Layered Dep WLD",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 60420, "to": 60429 } ],
+          "runtime": "14.0"
+        }
+        """);
+        WriteDepSource(dir, answer);
+        return dir;
+    }
+
+    // The single file the positive arm edits. Exactly one object, one procedure, one literal —
+    // nothing that could make the dependency's own recompile take a path other than the normal
+    // one.
+    private static void WriteDepSource(string dir, int answer) =>
+        File.WriteAllText(Path.Combine(dir, "Answer.Codeunit.al"), $$"""
+        codeunit 60420 "WLD Answer"
+        {
+            procedure Value(): Integer
+            begin
+                exit({{answer}});
+            end;
+        }
+        """);
+
+    private static string WriteTestBundle(string root, string extraComment)
+    {
+        var dir = Path.Combine(root, "test-app");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{TestAppId}}",
+          "name": "Watch Layered Dep Tests WLD",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{DepAppId}}", "name": "Watch Layered Dep WLD",
+              "publisher": "AL Runner", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 60430, "to": 60439 } ],
+          "runtime": "14.0"
+        }
+        """);
+        WriteTestSource(dir, extraComment);
+        return dir;
+    }
+
+    // Asserts the dependency's answer is 42 and names the value it actually saw, so a failure
+    // says WHICH compile ran rather than only that one did.
+    private static void WriteTestSource(string dir, string extraComment) =>
+        File.WriteAllText(Path.Combine(dir, "AnswerTests.Codeunit.al"), $$"""
+        // {{extraComment}}
+        codeunit 60430 "WLD Answer Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure DependencyAnswerIs42()
+            var
+                Answer: Codeunit "WLD Answer";
+            begin
+                if Answer.Value() <> 42 then
+                    Error('WLD dependency answered %1, expected 42', Answer.Value());
+            end;
+        }
+        """);
+
+    [SkippableFact]
+    public async Task Watch_DependencyEditedAfterCycleOne_IsNotServedFromThePreviousCompile()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-watch-layered-stale", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        var depDir = WriteDepBundle(root, answer: 42);
+        var testDir = WriteTestBundle(root, extraComment: "cycle 1");
+        var cacheDir = Path.Combine(root, ".cache");
+
+        var lines = new List<CapturedLine>();
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg
+                + $" \"{depDir}\" \"{testDir}\" --watch --cache \"{cacheDir}\"",
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        using var p = Process.Start(psi)!;
+        void Pump(StreamReader r, OutputStream stream) => Task.Run(async () =>
+        {
+            string? l;
+            while ((l = await r.ReadLineAsync()) != null) lock (lines) lines.Add(new CapturedLine(stream, l));
+        });
+        Pump(p.StandardOutput, OutputStream.Stdout);
+        Pump(p.StandardError, OutputStream.Stderr);
+
+        string DumpTail() { lock (lines) return string.Join("\n", lines.TakeLast(60).Select(l => $"[{l.Stream}] {l.Text}")); }
+
+        async Task<int> WaitForMarkerAfter(int fromIndex, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                List<int> found;
+                lock (lines)
+                    found = WatchOutputSlicing.FindStdoutMarkerIndices(lines, WatchOutputSlicing.WaitingForSourceMarker, fromIndex);
+                if (found.Count > 0) return found[0];
+                if (p.HasExited)
+                {
+                    await Task.Delay(500);
+                    throw new TimeoutException(
+                        $"watch marker not seen — subprocess exited early (exit={p.ExitCode}).\n--- last output ---\n{DumpTail()}");
+                }
+                await Task.Delay(200);
+            }
+            if (p.HasExited) await Task.Delay(500);
+            throw new TimeoutException($"watch marker not seen.\n--- last output ---\n{DumpTail()}");
+        }
+
+        string Segment(int from, int to) { lock (lines) return WatchOutputSlicing.MergedJoin(lines, from, to); }
+
+        try
+        {
+            // ── Cycle 1: the baseline. The dependency answers 42 and the test passes.
+            int m1 = await WaitForMarkerAfter(0, TimeSpan.FromSeconds(240));
+            var cycle1 = Segment(0, m1);
+            Assert.True(cycle1.Contains("PASS"), "cycle 1 did not pass:\n" + cycle1);
+            Assert.DoesNotContain("FAIL", cycle1);
+
+            // ── Cycle 2 (POSITIVE): the dependency now answers 99. Nothing fails to compile;
+            // the only way the test can still pass is by running the previous compile.
+            WriteDepSource(depDir, answer: 99);
+            int m2 = await WaitForMarkerAfter(m1 + 1, TimeSpan.FromSeconds(240));
+            var cycle2 = Segment(m1 + 1, m2);
+
+            // Assert.True with the whole cycle as the message: when this regresses, the
+            // question is always "which compile ran", and that is only answerable from the
+            // cycle's own output.
+            Assert.True(cycle2.Contains("FAIL"), "cycle 2 reported no FAIL:\n" + cycle2);
+            Assert.True(cycle2.Contains("WLD dependency answered 99"),
+                "cycle 2 did not run the edited dependency:\n" + cycle2);
+
+            // ── Cycle 3 (NEGATIVE): only the TEST bundle changes. The dependency's content is
+            // identical to cycle 2's, so the pre-pass must serve it from its content-keyed
+            // workspace dir instead of synthesising it again — otherwise the fix has replaced a
+            // stale cache with a full rebuild on every keystroke.
+            WriteTestSource(testDir, extraComment: "cycle 3");
+            int m3 = await WaitForMarkerAfter(m2 + 1, TimeSpan.FromSeconds(240));
+            var cycle3 = Segment(m2 + 1, m3);
+
+            Assert.True(cycle3.Contains("[layered] cache HIT Watch Layered Dep WLD"),
+                "cycle 3 re-synthesised an unchanged dependency:\n" + cycle3);
+            Assert.DoesNotContain("[layered] WROTE Watch Layered Dep WLD", cycle3);
+            // Still failing, and still for the right reason: cycle 3 did not revert to 42.
+            Assert.True(cycle3.Contains("WLD dependency answered 99"),
+                "cycle 3 did not run the edited dependency:\n" + cycle3);
+
+            // ── Cycle 4 (WARM): put the dependency back to 42. Its content is one this
+            // process has already compiled, so both the layered workspace dir and the Tier-3
+            // compiled-deps entry are HITS — and this is where a fix that only ever moved
+            // FORWARD would show: serving the cached 99 module for 42 source is the same
+            // defect pointing the other way, and a cache HIT is exactly the path that gets
+            // it wrong. See .claude/rules/local-test-scope.md on running cache-sensitive
+            // changes warm as well as cold.
+            WriteDepSource(depDir, answer: 42);
+            int m4 = await WaitForMarkerAfter(m3 + 1, TimeSpan.FromSeconds(240));
+            var cycle4 = Segment(m3 + 1, m4);
+
+            Assert.True(cycle4.Contains("PASS"), "cycle 4 did not go back to passing:\n" + cycle4);
+            Assert.DoesNotContain("FAIL", cycle4);
+        }
+        finally
+        {
+            try { if (!p.HasExited) p.Kill(entireProcessTree: true); } catch { }
+            try { Directory.Delete(root, recursive: true); } catch { }
+        }
+    }
+}

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -335,7 +335,15 @@ public static partial class BcRuntime
     /// sibling in a multi-bundle invocation), so the registry stays accurate for apps
     /// that are not currently executing too — see <see cref="_latestGenerationByAssemblyName"/>.
     /// </summary>
-    private static void RegisterAssemblyGeneration(Assembly asm)
+    /// <para>#2683: also called from <see cref="DependencyLoader"/> for a Tier-3
+    /// source-compiled dependency. Before that, only bundle assemblies were registered here,
+    /// so <see cref="IsStaleBundleAssembly"/> returned false for EVERY generation of a
+    /// dependency module — its simple name was never in the registry — and the AL type
+    /// finders happily resolved an object from a previous cycle's copy. That is #1901's own
+    /// failure mode, one app-kind short of being fixed: the comment above describes a call
+    /// from app B into an edited app A, and a source dependency compiled by
+    /// DependencyLoader is exactly that shape.</para>
+    internal static void RegisterAssemblyGeneration(Assembly asm)
     {
         var name = asm.GetName().Name;
         if (name != null) _latestGenerationByAssemblyName[name] = asm;

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -68,6 +68,43 @@ public sealed class DependencyLoader
     /// a source suite) omits `publisher` — both paths, both fields missing at once. If you
     /// change either default, keep the other in sync or this comparison silently drifts.
     /// </summary>
+    /// <summary>
+    /// Forget the cached module for each of <paramref name="appIds"/>, so the next
+    /// <see cref="LoadAll"/> for that AppId compiles and loads it again instead of handing back
+    /// the module from a previous reload cycle.
+    ///
+    /// <para>#2683. <see cref="_cache"/> is keyed on AppId and its reuse gate compares
+    /// Name/Publisher/Version — none of which move when a developer edits a dependency's AL
+    /// under <c>--watch</c>, since app.json keeps saying 1.0.0.0 all through development. So a
+    /// dependent bundle went on EXECUTING the dependency module compiled in cycle 1 for the rest
+    /// of the process's life, however many times the dependency was recompiled afterwards. With
+    /// the AL-output cache and the incremental replay path both fixed to notice the change, this
+    /// was the last layer still answering from the previous compile — and the only one visible
+    /// purely at runtime, where a passing test is the only symptom.</para>
+    ///
+    /// <para>Deliberately NOT a blanket flush, and deliberately not a content check inside
+    /// <see cref="LoadAll"/>. Two sibling bundles resolving the same app from two different
+    /// directories in one run must keep sharing one module — that is <see cref="RegisterLoaded"/>'s
+    /// "an earlier module wins" contract (#1892), and a SourcePath comparison in the reuse gate
+    /// would break it by handing each bundle its own copy. The caller here passes exactly the
+    /// apps whose layered workspace package the pre-pass resolved to a DIFFERENT path than it did
+    /// last cycle, which is a positive statement that their content moved, not an inference from
+    /// where they happen to live.</para>
+    /// </summary>
+    internal static void InvalidateApps(IEnumerable<Guid> appIds)
+    {
+        foreach (var appId in appIds)
+        {
+            if (!_cache.TryRemove(appId, out var removed)) continue;
+            // The by-name map is what AssemblyResolve answers from (see EnsureResolverInstalled).
+            // Leaving the stale module there would let a type load resolve to the assembly this
+            // call just evicted, which is the same wrong answer one indirection further away.
+            var simpleName = removed.Asm.GetName().Name;
+            if (!string.IsNullOrEmpty(simpleName))
+                _byName.TryRemove(simpleName!, out _);
+        }
+    }
+
     private static bool IdentityMatches(LoadedAppEntry entry, string name, string publisher, string version)
         => string.Equals(entry.Name, name, StringComparison.OrdinalIgnoreCase)
         && string.Equals(entry.Publisher, publisher, StringComparison.OrdinalIgnoreCase)
@@ -210,6 +247,15 @@ public sealed class DependencyLoader
             {
                 _cache[m.AppId] = new LoadedAppEntry(asm, m.Name, m.Publisher, m.Version.ToString(), path, tier3CacheKey);
                 _byName[asm.GetName().Name ?? ""] = asm;
+                // #2683: this assembly is now the CURRENT generation for its simple name.
+                // Without this, BcRuntime.IsStaleBundleAssembly answered false for every
+                // generation of a dependency module — the registry only ever held bundle
+                // assemblies — so the AL type finders (Codeunit/Record/Page…) enumerated the
+                // previous cycle's copy and, per #1901, in practice found it FIRST, because
+                // AppDomain.CurrentDomain.GetAssemblies() tends to return the oldest first.
+                // A --watch edit to a dependency then recompiled and reloaded everything
+                // correctly and still executed the previous cycle's bodies.
+                BcRuntime.RegisterAssemblyGeneration(asm);
                 // Register app metadata so AlCallStackCapture can decorate frames.
                 AlCallStackCapture.RegisterAssemblyInfo(asm, m.Name, m.Publisher, m.Version.ToString());
                 // Register the assembly's app package so NavApp.GetResource can serve

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1829,11 +1829,82 @@ var layeredWorkspaceDirs = new List<string>();
 // ladder) matches the ProvisioningCheck gap report a few hundred lines up (Program.cs,
 // the "Completeness gate" block) — same shape (bare ToDetailedMessage, no compile even
 // attempted yet) and the same exit code.
-if (bundles.Count > 1)
+// The package caches AS THE USER GAVE THEM, before either pre-pass prepends its synthetic
+// workspace dirs. RunLayeredPrePass is re-run once per --watch cycle (see the call inside
+// the watch loop), and it must be fed this list every time rather than its own previous
+// output: feeding the extended list back in would leave the PREVIOUS cycle's workspace dir
+// still at the front of the search order, where it wins resolution over the one this cycle
+// just wrote — the same stale-dependency answer the re-run exists to prevent, only harder
+// to see.
+var basePackageCacheDirs = packageCacheDirs.ToList();
+
+// The workspace package each depended-upon bundle resolved to, as of the most recent
+// RunDependencyPrePasses call, and the AppIds whose package CHANGED between the previous call
+// and that one. Under --watch this is what tells a dependent bundle that the ground moved
+// underneath it even though its own files did not (#2683).
+//
+// A path comparison rather than a "did the pre-pass rewrite it" flag, because each impl's
+// workspace directory is keyed on its source content: reverting an edit resolves straight back
+// to a package written cycles ago, writes nothing, and still has to invalidate everything the
+// EDITED module was serving in between.
+var previousImplAppPaths = new Dictionary<Guid, string>();
+var changedImplAppIds = new HashSet<Guid>();
+
+// Dirs the COMPILE-time .app scanner may safely enumerate: everything except the
+// synthetic workspace dirs (whose source-only .apps would trip AL1023).
+var compilerPackageDirs = new List<string>();
+
+// Both dependency pre-passes, from the untouched base list, with compilerPackageDirs
+// recomputed to match. Returns null on success, or the exit code the caller should return.
+//
+// #2683: this used to be straight-line code that ran ONCE, before the `while (true)` watch
+// loop below. Every later cycle therefore reused the workspace dirs synthesised from the
+// FIRST cycle's dependency sources, and a dependent bundle went on compiling against the
+// frozen *.symbols.json and EXECUTING the frozen .app's source — reporting a confident green
+// for a dependency whose code had changed underneath it. Its AL-output cache could not catch
+// that either: GetOrderedDepIds stamps each resolved .app with mtime:length precisely so a
+// sibling source app's content invalidates the dependent, but nothing rewrote that .app after
+// cycle 1, so the stamp never moved and the key HIT.
+//
+// Re-running is cheap when nothing changed. Each impl's workspace dir is keyed on its own
+// source content (ComputeSourceWorkspaceKey), so an unchanged dependency finds its .app and
+// sidecar already on disk and short-circuits both compiles, printing "[layered] cache HIT".
+int? RunDependencyPrePasses()
 {
+    packageCacheDirs = basePackageCacheDirs.ToList();
+    layeredWorkspaceDirs.Clear();
+    changedImplAppIds.Clear();
+    var implAppPaths = new Dictionary<Guid, string>();
+
+    if (bundles.Count > 1)
+    {
+        try
+        {
+            packageCacheDirs = RunLayeredPrePass(bundles, packageCacheDirs, layeredWorkspaceDirs, implAppPaths);
+        }
+        catch (Exception ex) when (ex is AlRunner.Infrastructure.IDependencyProvisioningDiagnostic diag)
+        {
+            var bcVer = AlRunner.Infrastructure.BcArtifacts.SelectedVersion.ToString();
+            Console.Error.WriteLine();
+            Console.Error.WriteLine(diag.ToDetailedMessage(bcVer));
+            Console.Error.WriteLine();
+            return 2;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"<layered-deps>: COMPILE-FAIL — {ex.Message}");
+            return 3;
+        }
+    }
+    // Discover + compile sibling source-only dependency apps. Some apps declare a
+    // dependency that ships ONLY as AL source in a sibling directory (not a compiled
+    // .app in any cache) — e.g. the corpus internalsVisibleTo fixture next to the
+    // main test app. Inert when no declared dep matches a sibling source app.
+    // Same unhandled-exception exposure as RunLayeredPrePass above (#1898) — same fix.
+    // Same #2095 provisioning/version-gap special-case as RunLayeredPrePass above.
     try
     {
-        packageCacheDirs = RunLayeredPrePass(bundles, packageCacheDirs, layeredWorkspaceDirs);
+        packageCacheDirs = BuildSiblingSourceDeps(bundles, packageCacheDirs, layeredWorkspaceDirs);
     }
     catch (Exception ex) when (ex is AlRunner.Infrastructure.IDependencyProvisioningDiagnostic diag)
     {
@@ -1845,39 +1916,37 @@ if (bundles.Count > 1)
     }
     catch (Exception ex)
     {
-        Console.Error.WriteLine($"<layered-deps>: COMPILE-FAIL — {ex.Message}");
+        Console.Error.WriteLine($"<sibling-source-deps>: COMPILE-FAIL — {ex.Message}");
         return 3;
     }
-}
-// Discover + compile sibling source-only dependency apps. Some apps declare a
-// dependency that ships ONLY as AL source in a sibling directory (not a compiled
-// .app in any cache) — e.g. the corpus internalsVisibleTo fixture next to the
-// main test app. Inert when no declared dep matches a sibling source app.
-// Same unhandled-exception exposure as RunLayeredPrePass above (#1898) — same fix.
-// Same #2095 provisioning/version-gap special-case as RunLayeredPrePass above.
-try
-{
-    packageCacheDirs = BuildSiblingSourceDeps(bundles, packageCacheDirs, layeredWorkspaceDirs);
-}
-catch (Exception ex) when (ex is AlRunner.Infrastructure.IDependencyProvisioningDiagnostic diag)
-{
-    var bcVer = AlRunner.Infrastructure.BcArtifacts.SelectedVersion.ToString();
-    Console.Error.WriteLine();
-    Console.Error.WriteLine(diag.ToDetailedMessage(bcVer));
-    Console.Error.WriteLine();
-    return 2;
-}
-catch (Exception ex)
-{
-    Console.Error.WriteLine($"<sibling-source-deps>: COMPILE-FAIL — {ex.Message}");
-    return 3;
+
+    compilerPackageDirs.Clear();
+    compilerPackageDirs.AddRange(packageCacheDirs
+        .Where(d => !layeredWorkspaceDirs.Contains(d, StringComparer.OrdinalIgnoreCase)));
+
+    // An impl counts as changed only if it was ALSO present last time: on the very first call
+    // nothing has been compiled or loaded against it yet, so there is nothing to invalidate and
+    // reporting every impl as "changed" would force a pointless full rebuild of cycle 1.
+    foreach (var (appId, appPath) in implAppPaths)
+        if (previousImplAppPaths.TryGetValue(appId, out var before)
+            && !string.Equals(before, appPath, StringComparison.OrdinalIgnoreCase))
+            changedImplAppIds.Add(appId);
+    previousImplAppPaths = implAppPaths;
+
+    // #2683, the runtime half. A dependency that was re-synthesised has new CODE, and
+    // DependencyLoader caches the compiled module per AppId with a reuse gate that compares
+    // Name/Publisher/Version — none of which move during development. Recompiling the dependent
+    // against fresh symbols is not enough on its own: without this, the fresh compile still
+    // EXECUTES the module built in the first cycle, and the only symptom is a test that keeps
+    // passing.
+    DependencyLoader.InvalidateApps(changedImplAppIds);
+    return null;
 }
 
-// Dirs the COMPILE-time .app scanner may safely enumerate: everything except the
-// synthetic workspace dirs (whose source-only .apps would trip AL1023).
-var compilerPackageDirs = packageCacheDirs
-    .Where(d => !layeredWorkspaceDirs.Contains(d, StringComparer.OrdinalIgnoreCase))
-    .ToList();
+{
+    var prePassExit = RunDependencyPrePasses();
+    if (prePassExit != null) return prePassExit.Value;
+}
 
 // ── --server: stay resident. Warm state (BC patches + the dep symbol loader) is
 // now established; each request re-emits the requested bundle (warm) and runs it
@@ -2002,6 +2071,33 @@ while (true)
 AlRunner.Patches.NumberSequencePatches.ResetForNewExecution();
 results.Clear();
 watchFullRebuildReasons.Clear();
+
+// #2683: re-synthesise the dependency workspace before re-running. The pre-passes above
+// ran against the sources as they were when the process started; a --watch edit to a
+// bundle that another bundle DEPENDS ON changes both halves of that handoff — the
+// *.symbols.json the dependent compiles against, and the .app whose source
+// DependencyLoader executes — and without this, both stay frozen at cycle 1. The
+// dependent then re-emits from its AL-output cache in 0.0s and reports the previous
+// compile's results as this cycle's, which is worse than a wrong answer because a
+// developer in a tight edit loop trusts --watch more than a CI run.
+//
+// Skipped on the first cycle: the call above already did it, and repeating it would pay
+// the pre-pass twice before the first test runs.
+//
+// A pre-pass failure does NOT exit the process here the way it does at startup. Watch mode
+// exists to survive a broken intermediate edit, and the next keystroke may well fix it. The
+// failure is printed and the cycle continues with the base caches and NO workspace dirs, so
+// the dependent bundle fails its own compile naming the dependency it cannot resolve —
+// loud and true — rather than quietly resolving the previous cycle's copy.
+if (watchMode && watchCycleIndex > 0)
+{
+    var prePassExit = RunDependencyPrePasses();
+    if (prePassExit != null)
+        Console.Error.WriteLine(
+            "[watch] dependency pre-pass FAILED this cycle (see the diagnostic above). Bundles that " +
+            "depend on another bundle will fail to resolve it until the next edit fixes the build; " +
+            "no result below is carried over from the previous cycle.");
+}
 // Clean loading (#5): the interactive dashboard owns the whole screen, but the
 // run-cycle body emits diagnostic Console.WriteLine noise ("[bundle] resolved N
 // dep(s)", "loaded N assembl(ies)", "[i/N] … suites", …) that would scroll over
@@ -2640,7 +2736,32 @@ foreach (var bundle in bundles)
             // other mode (one-shot, --server) is untouched — normal-mode Emit() never tracks a
             // baseline and never calls TryEmitIncremental, so its cost profile is unchanged.
             BcEmitOutput? incrementalOutput = null;
-            if (watchMode)
+            // #2683: the incremental path decides from THIS bundle's own AL files alone. A bundle
+            // whose files are byte-identical replays its previous generated C# verbatim — which
+            // was compiled against, and baked member ids resolved from, its dependencies'
+            // PREVIOUS surfaces. So when a bundle this one depends on was re-synthesised by the
+            // pre-pass this cycle, "nothing of mine changed" is not a safe answer and the
+            // incremental path is skipped outright. This is the --watch counterpart of the
+            // forward fallback propagation #2603 added to RunAllBundlesForServer; --server got
+            // that fix and --watch never did.
+            //
+            // The signal comes from the pre-pass rather than from the sibling bundle's own emit,
+            // and that is deliberate: the pre-pass runs before ANY bundle compiles, so it answers
+            // correctly whether the dependency is listed before or after this bundle in the
+            // command line — the ordering hole ChangedLaterDependencyBundles exists to plug on
+            // the server side.
+            var changedDependency = changedImplAppIds.Count == 0
+                ? null
+                : DeclaredDependencyOn(appGroup.SuiteDir, changedImplAppIds);
+            if (watchMode && changedDependency != null && watchCycleIndex > 0)
+            {
+                watchFullRebuildReasons.Add((moduleName, $"dependency '{changedDependency}' changed this cycle"));
+                Console.Error.WriteLine(
+                    $"[watch] {moduleName}: FULL REBUILD this cycle — the bundle it depends on " +
+                    $"('{changedDependency}') changed, so replaying this bundle's previous output " +
+                    "would test it against the previous compile of that dependency.");
+            }
+            if (watchMode && changedDependency == null)
             {
                 incrementalOutput = emitter.TryEmitIncremental(
                     allPaths, moduleName, appGroup.SuiteDir,

--- a/AlRunner/ProgramSupport/Dependencies.cs
+++ b/AlRunner/ProgramSupport/Dependencies.cs
@@ -504,6 +504,41 @@ internal static partial class ProgramSupport
     // 67c4f8c4622a928aae07bf1857af515bb37fc5df4ac16eb047855f5dd2f9bba8 — a warm cache then
     // serves a DLL compiled against a different dependency closure. Same defect family as
     // the --define symbols that were missing from this key.
+    /// <summary>
+    /// The name of the first dependency <paramref name="appRootDir"/>'s own app.json declares
+    /// whose AppId is in <paramref name="changedAppIds"/>, or null when it declares none of them.
+    ///
+    /// <para>#2683. Used under <c>--watch</c> to decide whether a bundle may replay its previous
+    /// generated C#: a bundle whose own AL files are byte-identical still cannot, if a bundle it
+    /// depends on was re-synthesised this cycle, because the replayed output was compiled against
+    /// that dependency's previous surface.</para>
+    ///
+    /// <para>Matched on AppId only. Unlike RunLayeredPrePass, which also falls back to
+    /// Name+Publisher so a bundle without a declared id is still recognisable as somebody's
+    /// dependency, the ids here come from that same pre-pass and are therefore always real —
+    /// and the answer feeds a "may I take the fast path" decision, where a false NEGATIVE is
+    /// the dangerous direction. A dependency that the pre-pass matched by name and this method
+    /// cannot match by id would be one whose AppId is empty, which the pre-pass never adds.</para>
+    ///
+    /// <para>An unreadable or absent app.json answers null: a bundle whose manifest cannot be
+    /// read has no declared dependencies to speak of, and its own compile will fail on that
+    /// separately and loudly.</para>
+    /// </summary>
+    internal static string? DeclaredDependencyOn(string? appRootDir, IReadOnlyCollection<Guid> changedAppIds)
+    {
+        if (appRootDir == null || changedAppIds.Count == 0) return null;
+        var appJson = Path.Combine(appRootDir, "app.json");
+        if (!File.Exists(appJson)) return null;
+        AlRunner.Infrastructure.BundleIdentity? id;
+        try { id = AlRunner.Infrastructure.InProcessAppPackager.ReadIdentity(appJson); }
+        catch { return null; }
+        if (id == null) return null;
+        foreach (var dep in id.Dependencies)
+            if (dep.AppId != Guid.Empty && changedAppIds.Contains(dep.AppId))
+                return string.IsNullOrEmpty(dep.Name) ? dep.AppId.ToString() : dep.Name;
+        return null;
+    }
+
     internal static IReadOnlyList<string> GetOrderedDepIds(
         string? bucketRoot, IReadOnlyList<string> packageCacheDirs, string? bundleAbs = null)
     {

--- a/AlRunner/ProgramSupport/SiblingCompile.cs
+++ b/AlRunner/ProgramSupport/SiblingCompile.cs
@@ -306,7 +306,19 @@ internal static partial class ProgramSupport
     // Detects inter-bundle dependencies, emits impl bundles in topo order into a
     // per-run workspace cache dir, and prepends that dir to packageCacheDirs.
     // Completely inert when bundles.Count <= 1 or no inter-bundle dep edges exist.
-    internal static List<string> RunLayeredPrePass(List<string> bundles, List<string> packageCacheDirs, List<string> workspaceDirsOut)
+    /// <param name="implAppPathsOut">Optional. Receives, for every impl this call handled, the
+    /// path of the workspace package a dependent bundle will resolve it from — whether this call
+    /// wrote that package or served it from its content-keyed directory.
+    ///
+    /// <para>Comparing this map between two <c>--watch</c> cycles is how a dependent bundle
+    /// learns that its dependency moved (#2683). Deliberately NOT "did this call re-synthesise
+    /// it": each impl's directory is keyed on its source content, so reverting an edit resolves
+    /// back to a package written cycles ago and re-synthesises nothing — and the dependent, which
+    /// has been running the EDITED module in between, still has to be told. A test that only ever
+    /// moved forward would pass while the revert kept executing the code the developer just
+    /// undid.</para></param>
+    internal static List<string> RunLayeredPrePass(List<string> bundles, List<string> packageCacheDirs, List<string> workspaceDirsOut,
+        IDictionary<Guid, string>? implAppPathsOut = null)
     {
         // Read identity of every bundle.
         var identities = new Dictionary<string, AlRunner.Infrastructure.BundleIdentity>(StringComparer.OrdinalIgnoreCase);
@@ -620,6 +632,10 @@ internal static partial class ProgramSupport
 
             sw.Stop();
             var info = new FileInfo(outPath);
+            // Recorded for HIT and WROTE alike — the caller compares paths across cycles, and a
+            // HIT that resolves a DIFFERENT package than last cycle (an edit reverted) is exactly
+            // the case a "was it written" flag would miss.
+            if (implAppPathsOut != null) implAppPathsOut[implId.AppId] = outPath;
             var cacheVerb = hadApp && hadSymbols ? "cache HIT" : "WROTE";
             Console.WriteLine($"[layered] {cacheVerb} {implId.Name} {implId.Version} → {appFileName} (src .app + sidecar symbols, {info.Length} bytes, {sw.ElapsedMilliseconds}ms)");
             emitted++;


### PR DESCRIPTION
Closes #2683

Written by agent impl-3.

## What was wrong

Editing a bundle that another bundle depends on, under `--watch`, left the dependent testing code that was no longer on disk. It re-emitted, reported PASS, and executed the previous cycle's dependency.

**Four independent layers each served something stale, and every one had to be fixed before the reproduction changed its answer.** Each was measured, not inferred — the fixture is two bundles where the dependency's `Value()` goes `42` -> `99` between cycles, and the test asserts the value it actually observed.

1. **`RunLayeredPrePass` ran once, before the `while (true)` watch loop** (`Program.cs:1836` against a loop opening at `1998`). Every later cycle reused the workspace synthesised from cycle 1's dependency sources, so the dependent compiled against a frozen `*.symbols.json` and `DependencyLoader` executed a frozen `.app`. The AL-output cache could not catch it either: `GetOrderedDepIds` stamps each resolved `.app` with `mtime:length` precisely so a sibling source app's content invalidates the dependent, but nothing rewrote that `.app` after cycle 1, so the stamp never moved.

2. **The dependent replayed its previous generated C#.** `--watch`'s incremental path decides from a bundle's own AL files alone, and a bundle whose files are byte-identical replays output that baked the member ids its dependencies' *previous* surfaces resolved to. That is exactly what #2603 fixed for `--server` via `RunAllBundlesForServer`'s forward fallback propagation; `--watch` never got the counterpart.

3. **`DependencyLoader` caches the compiled module per AppId**, and its reuse gate compares Name/Publisher/Version — none of which move while `app.json` says `1.0.0.0` all through development. Probed directly: cycle 2 reused the cycle-1 assembly while the two `.app` paths already differed.

4. **Even once reloaded, the fresh module was ignored.** The AL type finders skip previous-cycle assemblies via `BcRuntime.IsStaleBundleAssembly`, but `_latestGenerationByAssemblyName` only ever held *bundle* assemblies. It therefore answered `false` for every generation of a *dependency* module, and `AppDomain.CurrentDomain.GetAssemblies()` resolved `Codeunit60420` from the oldest copy — which is #1901's own documented failure mode, one app-kind short of being fixed. Confirmed by extracting both synthesized packages: cycle 2's contained `exit(99)`, `DependencyLoader` compiled and loaded it, and the test still observed `42`.

## The signal, and why it is not "did the pre-pass rewrite it"

Layers 2 and 3 need to know that a dependency moved. The first version of this fix used "the pre-pass re-synthesised it this cycle". That is wrong, and the test caught it.

Each impl's workspace directory is keyed on its **source content**. Reverting an edit resolves straight back to a package written cycles ago and rewrites nothing — while the dependent has been running the *edited* module in between and still has to be told. So `RunLayeredPrePass` now reports the package path each impl **resolves to**, HIT or WROTE, and the caller compares that map across cycles. Cycle 4 of the test (revert `99` -> `42`) failed against the rewritten-flag version and passes against this one.

## Tests

`AlRunner.Tests/WatchLayeredDependencyStaleTests` drives a real `--watch` session over two bundles for four cycles:

| cycle | edit | claim |
|---|---|---|
| 1 | — | baseline passes |
| 2 | dependency `42` -> `99` | must start FAILING, naming the value it saw |
| 3 | test bundle only | the dependency must report `[layered] cache HIT`, so the fix has not simply disabled incremental compilation |
| 4 | dependency back to `42` | must go back to passing — the warm-cache direction |

Cycle 3 is the negative arm the issue asks for. Cycle 4 is the "run cache-sensitive changes warm as well as cold" rule, and it earned its place by failing.

The value change is deliberate rather than deleting the procedure the issue's reproduction removed: nothing fails to compile, so a green cycle 2 can only mean the previous compile ran. That isolates this defect from the separate `EMIT-EXCLUDED` and summary-reporting concerns in the same issue (see "left out").

**RED -> GREEN, run locally:**

- RED, before any change: cycle 2 reported no FAIL — `Assert.Contains("FAIL", cycle2)` failed in 21 s.
- Intermediate states are in the commit message; each layer moved the failure one step further down without fixing it, which is why all four are here.
- GREEN: `dotnet test AlRunner.Tests --filter FullyQualifiedName~WatchLayeredDependencyStaleTests` — 1 passed, 30 s.

**Targeted regressions, run locally:**

- `--filter "FullyQualifiedName~Watch|FullyQualifiedName~Layered|FullyQualifiedName~SiblingSource|FullyQualifiedName~DependencyLoader"` — 60 passed, 1 m 32 s.
- `--filter "FullyQualifiedName~Server|FullyQualifiedName~Dependencies|FullyQualifiedName~AppId|FullyQualifiedName~Precompile"` — 162 passed, 2 skipped (pre-existing environment skips), 3 m 29 s.

I did not run the full `AlRunner.Tests` suite locally; CI runs it on the two legs that carry it.

## Shape questions

1. **Same wrong pattern at another call site?** Yes — `--server` has the same four-layer exposure in principle, and layer 2 is already fixed there (#2603). Layers 3 and 4 are fixed in shared code (`DependencyLoader`, `BcRuntime`), so `--server` gets them for free. Layer 1's server-path pre-pass is a separate call site (`Program.cs:3759`) that runs per request already.
2. **Sibling assumption?** `BuildSiblingSourceDeps` sits beside `RunLayeredPrePass` and had the same once-only exposure; both moved into the re-runnable `RunDependencyPrePasses` together.
3. **Two writers, one invariant?** `_latestGenerationByAssemblyName` was written by `SetTestAssembly` only, while `IsStaleBundleAssembly` was read on behalf of *every* AL assembly including dependency modules. One writer, two classes of reader, and only one class maintained the invariant. Now both writers register.

## Left out, deliberately

- **The issue's other two points are not fixed here.** `EMIT-EXCLUDED` shedding 23 objects and continuing (point 1), and a `compile-fail: 1` cycle printing a test summary indistinguishable from a clean run (point 3), are reporting defects in a different part of the pipeline. They deserve their own change and their own test; folding them in would have made this diff unreviewable. Happy to file them as a follow-up.
- **A pre-pass failure inside the watch loop does not exit the process** the way it does at startup. Watch mode exists to survive a broken intermediate edit. The failure is printed and the cycle continues with the base caches and no workspace dirs, so the dependent fails its own compile naming the dependency it cannot resolve, rather than quietly resolving the previous cycle's copy.

## One correction to the issue body

`re-emitted ... (0.0s)` is not by itself evidence of a cache hit. On this fixture the test bundle re-emits in `0.0s` on a full `[cache] MISS` too — it is one small codeunit. The real evidence is the `[cache] HIT`/`MISS` line under `--verbose`, and the value the test observes.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
