### PR TITLE
fix(capture-values): unwrap ByRef<T> so a var parameter renders its value, not its wrapper type name

### DIFF
--- a/AlRunner.Tests/AlValueWireFormatByRefTests.cs
+++ b/AlRunner.Tests/AlValueWireFormatByRefTests.cs
@@ -1,0 +1,201 @@
+// Issue #2488: --capture-values (#1640) and --dap's live variable inspection (#1642)
+// rendered an AL `var` (by-reference) parameter as the CLR type name of its wrapper —
+// `Microsoft.Dynamics.Nav.Runtime.ByRef`1[System.Int32]` — instead of the value the
+// wrapper points at, with `captureError` null so a consumer could not tell the type name
+// apart from a real value.
+//
+// BC materialises a `var` parameter on the generated `*_Scope` class as
+// `Microsoft.Dynamics.Nav.Runtime.ByRef<T>`, a getter/setter pair over the caller's slot.
+// It declares no ToString() override (decompiled from Ncl.dll), so object.ToString() runs
+// and yields the type name — which is exactly what AlValueWireFormat's default arm took.
+// The wrapper does implement `IByRef` with a non-generic `ObjectValue` accessor, so the
+// inner value is reachable without reflection and without reimplementing anything BC owns
+// (.claude/rules/precompiled-dll-respect.md).
+//
+// These are pure C# unit tests: `ByRef<T>` is constructible directly (AlRunner.Tests
+// already references Ncl.dll), so a getter over a plain local reproduces the exact shape a
+// `var` parameter has at runtime. Nothing here is a claim about Business Central's
+// behaviour — the wire format of --capture-values is a runner surface — so this does not
+// belong in the upstream corpus (.claude/rules/bc-behavior-tests-go-upstream.md).
+using AlRunner.Infrastructure;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class AlValueWireFormatByRefTests
+{
+    // --- the reported bug: a by-ref parameter must render its VALUE ---------------------
+
+    [Fact]
+    public void ToWireValue_ByRefInteger_RendersInnerNumber_NotWrapperTypeName()
+    {
+        int slot = 5;
+        var value = AlValueWireFormat.ToWireValue(
+            new ByRef<int>(() => slot, v => slot = v), out var captureError);
+
+        // A real JSON number, not a string: the AL local is an Integer and an Integer
+        // is a CLR int, so the wire value must stay one (same contract as a by-value
+        // Integer local, asserted below).
+        Assert.Equal(5, value);
+        Assert.IsType<int>(value);
+        Assert.Null(captureError);
+    }
+
+    [Fact]
+    public void ToWireValue_ByRefNavText_RendersInnerText_NotWrapperTypeName()
+    {
+        var slot = new NavText("y");
+        var value = AlValueWireFormat.ToWireValue(
+            new ByRef<NavText>(() => slot, v => slot = v), out var captureError);
+
+        Assert.Equal("y", value);
+        Assert.Null(captureError);
+    }
+
+    [Fact]
+    public void ToWireValue_ByRef_ReadsThroughToTheCurrentSlotValue_NotACopy()
+    {
+        int slot = 5;
+        var byRef = new ByRef<int>(() => slot, v => slot = v);
+        Assert.Equal(5, AlValueWireFormat.ToWireValue(byRef));
+
+        slot = 6; // what `v := v + 1` inside the callee does to the caller's local
+        Assert.Equal(6, AlValueWireFormat.ToWireValue(byRef));
+    }
+
+    // --- the other direction: by-value locals must be untouched ------------------------
+    // A fix that unwrapped indiscriminately, or that stringified everything, fails here.
+
+    [Fact]
+    public void ToWireValue_PlainInteger_StillRendersAsNumber()
+    {
+        var value = AlValueWireFormat.ToWireValue(6, out var captureError);
+        Assert.Equal(6, value);
+        Assert.IsType<int>(value);
+        Assert.Null(captureError);
+    }
+
+    [Fact]
+    public void ToWireValue_PlainNavText_StillRendersViaItsOwnToString()
+    {
+        var value = AlValueWireFormat.ToWireValue(new NavText("x"), out var captureError);
+        Assert.Equal("x", value);
+        Assert.Null(captureError);
+    }
+
+    // --- an unreadable wrapper still surfaces a captureError, never a wrapper name -----
+
+    [Fact]
+    public void ToWireValue_ByRefWhoseGetterThrows_ReportsCaptureErrorNamingExceptionType()
+    {
+        var value = AlValueWireFormat.ToWireValue(
+            new ByRef<int>(() => throw new InvalidOperationException("slot is gone"), _ => { }),
+            out var captureError);
+
+        Assert.Null(value);
+        Assert.NotNull(captureError);
+        Assert.Contains(nameof(InvalidOperationException), captureError);
+    }
+
+    [Fact]
+    public void ToWireValue_ByRefWithNoGetterInstalled_ReportsCaptureError_NotWrapperName()
+    {
+        // ByRef<T>'s parameterless ctor leaves `getter` null, so ObjectValue NREs.
+        var value = AlValueWireFormat.ToWireValue(new ByRef<int>(), out var captureError);
+
+        Assert.Null(value);
+        Assert.NotNull(captureError);
+        Assert.Contains(nameof(NullReferenceException), captureError);
+    }
+
+    [Fact]
+    public void ToWireValue_ByRefOverNullInner_IsANullValueWithNoCaptureError()
+    {
+        // A `var` parameter of a reference-typed AL value that is genuinely null must be
+        // indistinguishable from a genuinely null by-value local — and distinguishable
+        // from an unreadable one (issue #2043's contract, preserved through the unwrap).
+        var value = AlValueWireFormat.ToWireValue(
+            new ByRef<NavText>(() => null!, _ => { }), out var captureError);
+
+        Assert.Null(value);
+        Assert.Null(captureError);
+    }
+
+    // --- the unwrap must terminate ------------------------------------------------------
+
+    [Fact]
+    public void ToWireValue_NestedByRef_UnwrapsToTheInnermostValue()
+    {
+        int slot = 7;
+        var inner = new ByRef<int>(() => slot, v => slot = v);
+        var outer = new ByRef<ByRef<int>>(() => inner, v => inner = v);
+
+        Assert.Equal(7, AlValueWireFormat.ToWireValue(outer, out var captureError));
+        Assert.Null(captureError);
+    }
+
+    [Fact]
+    public void ToWireValue_SelfReferentialByRef_TerminatesWithCaptureError()
+    {
+        ByRef<object>? self = null;
+        self = new ByRef<object>(() => self!, _ => { });
+
+        var value = AlValueWireFormat.ToWireValue(self, out var captureError);
+
+        Assert.Null(value);
+        Assert.NotNull(captureError);
+    }
+
+    // --- both consumers of the shared renderer -----------------------------------------
+
+    [Fact]
+    public void CaptureField_ByRefInteger_CapturesInnerNumber_NotWrapperTypeName()
+    {
+        int slot = 5;
+        var byRef = new ByRef<int>(() => slot, v => slot = v);
+        var captured = AlValueCapture.CaptureField("Bump", "v", statementId: 1, readField: () => byRef);
+
+        Assert.Equal(5, captured.Value);
+        Assert.Null(captured.CaptureError);
+    }
+
+    [Fact]
+    public void ScopeInspector_ReadField_ByRefInteger_ReportsInnerNumberAsReadable()
+    {
+        int slot = 5;
+        var byRef = new ByRef<int>(() => slot, v => slot = v);
+        var local = AlScopeInspector.ReadField("v", () => byRef);
+
+        Assert.Equal("v", local.Name);
+        Assert.Equal(5, local.Value);
+        Assert.True(local.Readable);
+    }
+
+    // --- the symptom that was actually reported ----------------------------------------
+    // A `var grand: Integer` accumulator threaded through a per-iteration procedure was
+    // reported as the wrapper name in EVERY iteration. Two failures in one: each record
+    // rendered the type name, and — because that name never changes — DiffAndUpdate saw
+    // no change and suppressed every observation after the first. Both must be gone.
+
+    [Fact]
+    public void DiffAndUpdate_ByRefAccumulator_EmitsEachIterationsRealValue()
+    {
+        int slot = 5;
+        var byRef = new ByRef<int>(() => slot, v => slot = v);
+        var fields = new (string Name, Func<object?> ReadField)[] { ("grand", () => byRef) };
+        var lastKnown = new Dictionary<string, (object? Value, string? Error)>();
+
+        var first = AlValueCapture.DiffAndUpdate("Subtotal", 1, fields, lastKnown, isBaseline: false);
+        Assert.Equal(5, Assert.Single(first).Value);
+
+        slot = 6; // the callee's `grand := grand + 1`
+        var second = AlValueCapture.DiffAndUpdate("Subtotal", 2, fields, lastKnown, isBaseline: false);
+        Assert.Equal(6, Assert.Single(second).Value);
+
+        // Unchanged between observations is still suppressed — the unwrap must not turn
+        // every by-ref local into a record on every statement.
+        var third = AlValueCapture.DiffAndUpdate("Subtotal", 3, fields, lastKnown, isBaseline: false);
+        Assert.Empty(third);
+    }
+}

--- a/AlRunner.Tests/ServerExecuteCapturedValuesByRefTests.cs
+++ b/AlRunner.Tests/ServerExecuteCapturedValuesByRefTests.cs
@@ -1,0 +1,116 @@
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #2488 — end-to-end proof, on the wire, that a `var` (by-reference) AL parameter
+/// reports its VALUE under `--capture-values`, not the CLR type name of the
+/// `Microsoft.Dynamics.Nav.Runtime.ByRef&lt;T&gt;` wrapper BC materialises it as.
+///
+/// The mechanism tests in AlValueWireFormatByRefTests construct a `ByRef&lt;T&gt;` by hand;
+/// this one compiles and runs the reporter's own reproducer through BC's real emitter, so
+/// it also pins the premise — that a `var` parameter really does land on the generated
+/// `*_Scope` class as a wrapper — rather than assuming it.
+///
+/// Ghost-test guard: the assertions name concrete values (5 then 6 for the integer, "y"
+/// for the text) AND the JSON kind they must arrive as. A renderer that stringified
+/// everything fails on <c>ValueKind.Number</c>; one that emitted the wrapper name fails on
+/// the values; one that unwrapped nothing fails both. The by-value control in the same
+/// response (`total`, `name` in OnRun) fails if a fix unwrapped indiscriminately.
+/// </summary>
+public class ServerExecuteCapturedValuesByRefTests : IClassFixture<SharedCliServer>
+{
+    private readonly SharedCliServer _fixture;
+
+    public ServerExecuteCapturedValuesByRefTests(SharedCliServer fixture) => _fixture = fixture;
+
+    // The reproducer from issue #2488: an Integer and a Text threaded through `var`
+    // parameters and mutated by the callee, plus the same-typed by-value locals in OnRun
+    // that already rendered correctly and must keep doing so. `Bump` mutates TWICE, so
+    // the by-ref parameter produces a real series (6 then 16) rather than a single
+    // end-of-scope reading — the wrapper's type name is constant, so before the fix
+    // AlValueCapture.DiffAndUpdate also saw every observation after the first as
+    // "unchanged" and suppressed it. One mutation could not tell those two bugs apart.
+    // (The first observation of any scope is a baseline and is never emitted — see
+    // AlValueCapture's file header — so `v`'s incoming 5 is legitimately absent.)
+    private const string ByRefParamsCode =
+        "codeunit 60212 \"CV ByRef Params SX\"\n" +
+        "{\n" +
+        "    trigger OnRun()\n" +
+        "    var\n" +
+        "        total: Integer;\n" +
+        "        name: Text;\n" +
+        "    begin\n" +
+        "        total := 5;\n" +
+        "        name := 'x';\n" +
+        "        Bump(total);\n" +
+        "        Rename(name);\n" +
+        "    end;\n" +
+        "\n" +
+        "    local procedure Bump(var v: Integer)\n" +
+        "    begin\n" +
+        "        v := v + 1;\n" +
+        "        v := v + 10;\n" +
+        "    end;\n" +
+        "\n" +
+        "    local procedure Rename(var t: Text)\n" +
+        "    begin\n" +
+        "        t := 'y';\n" +
+        "    end;\n" +
+        "}\n";
+
+    [SkippableFact]
+    public async Task Execute_CaptureValues_VarParameter_ReportsValue_NotByRefWrapperTypeName()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            captureValues = true,
+            code = ByRefParamsCode,
+        }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        Assert.Equal(0, d.GetProperty("exitCode").GetInt32());
+
+        var captured = d.GetProperty("tests")[0].GetProperty("capturedValues").EnumerateArray().ToList();
+
+        // Nothing anywhere in the series may be a wrapper type name — the whole symptom,
+        // stated once over the entire response so a new leak cannot hide in another scope.
+        foreach (var e in captured)
+        {
+            var rendered = e.GetProperty("value").ToString();
+            Assert.DoesNotContain("ByRef", rendered);
+        }
+
+        // `var v: Integer` — a real JSON number, and the value the callee actually saw.
+        var v = captured.Where(e => e.GetProperty("variableName").GetString() == "v").ToList();
+        Assert.NotEmpty(v);
+        foreach (var e in v)
+        {
+            Assert.Equal(JsonValueKind.Number, e.GetProperty("value").ValueKind);
+            Assert.Null(e.TryGetProperty("captureError", out var ce) ? ce.GetString() : null);
+        }
+        // Bump receives 5 and mutates it twice: 6, then 16. Both readings must be in the
+        // series, in that order — each one read through the wrapper to the caller's slot
+        // as it stood at that statement, which is the whole point of a by-ref parameter.
+        var vNumbers = v.Select(e => e.GetProperty("value").GetInt32()).ToList();
+        Assert.Equal(new[] { 6, 16 }, vNumbers.ToArray());
+
+        // `var t: Text` — the inner NavText's own text, not the wrapper.
+        var t = captured.Where(e => e.GetProperty("variableName").GetString() == "t").ToList();
+        Assert.NotEmpty(t);
+        Assert.Contains("y", t.Select(e => e.GetProperty("value").GetString()));
+
+        // Control, the other direction: the by-value locals in OnRun never went through a
+        // wrapper and must render exactly as they always did.
+        var total = captured.Where(e => e.GetProperty("variableName").GetString() == "total").ToList();
+        Assert.NotEmpty(total);
+        Assert.Contains(5, total.Select(e => e.GetProperty("value").GetInt32()));
+        var name = captured.Where(e => e.GetProperty("variableName").GetString() == "name").ToList();
+        Assert.NotEmpty(name);
+        Assert.Contains("x", name.Select(e => e.GetProperty("value").GetString()));
+    }
+}

--- a/AlRunner/Infrastructure/AlValueWireFormat.cs
+++ b/AlRunner/Infrastructure/AlValueWireFormat.cs
@@ -2,10 +2,41 @@
 // representation. Extracted from AlValueCapture (issue #1640) so both it and
 // AlScopeInspector's live variable reads (issue #1642, --dap) render the same value
 // the same way, rather than two independently-drifting copies.
+//
+// #2488 — BY-REFERENCE PARAMETERS ARRIVE WRAPPED:
+//
+// BC's emitter materialises an AL `var` (by-reference) parameter on the generated
+// `*_Scope` class as `Microsoft.Dynamics.Nav.Runtime.ByRef<T>` — a getter/setter pair
+// over the CALLER's slot, not a copy of the value (BcCompiler's header: the
+// [NavByReferenceAttribute] T -> ByRef<T> wrap happens natively at parameter emission).
+// The [NavName] field scan in AlValueCapture/AlScopeInspector therefore reads the
+// WRAPPER, and `ByRef<T>` declares no ToString() override (decompiled from Ncl.dll:
+// getter/setter/Value/ObjectValue/ObjectType and an implicit conversion, nothing else),
+// so object.ToString() ran and the default arm below rendered the CLR type name —
+// `Microsoft.Dynamics.Nav.Runtime.ByRef`1[System.Int32]` — with captureError null, i.e.
+// indistinguishable to the consumer from a real value. Worse, the type name never
+// changes, so AlValueCapture.DiffAndUpdate saw every observation of a by-ref local as
+// "unchanged" and suppressed all but the first.
+//
+// The unwrap reads BC's own `IByRef.ObjectValue` (the non-generic accessor on the same
+// type), so nothing BC owns is reimplemented — .claude/rules/precompiled-dll-respect.md
+// — and the inner value then goes through the SAME rendering rules as a by-value local:
+// an AL Integer inner is a CLR int and stays a JSON number; a NavText inner renders via
+// its own ToString(). A wrapper whose getter throws is reported through captureError
+// exactly like any other unreadable value, never as a wrapper name
+// (.claude/rules/loud-failures.md).
+using Microsoft.Dynamics.Nav.Runtime;
+
 namespace AlRunner.Infrastructure;
 
 public static class AlValueWireFormat
 {
+    /// <summary>Bound on the ByRef unwrap loop. Real AL never nests these — BC passes an
+    /// existing wrapper straight through when a `var` argument feeds another `var`
+    /// parameter — so any depth beyond a couple means a cycle, and a cycle must end in a
+    /// reported failure rather than a hang.</summary>
+    private const int MaxByRefUnwrapDepth = 8;
+
     /// <summary>
     /// CLR primitives (AL Integer/Boolean/BigInteger/... map straight to these —
     /// confirmed via DUMP_CS=1 on a probe fixture) pass through as-is so a JSON writer
@@ -31,6 +62,33 @@ public static class AlValueWireFormat
     {
         captureError = null;
         if (raw == null) return null;
+
+        // Unwrap the by-reference wrapper(s) first, then apply the ordinary rules to the
+        // value inside (see the file header). A loop rather than a single unwrap because
+        // ObjectValue's static type is `object`: nothing in the type system stops a
+        // wrapper resolving to another wrapper, and a self-referential one would spin
+        // forever — hence the depth bound, which reports rather than silently returning
+        // the wrapper's type name.
+        for (int depth = 0; raw is IByRef byRef; depth++)
+        {
+            if (depth >= MaxByRefUnwrapDepth)
+            {
+                captureError = $"by-ref value still wrapped after {MaxByRefUnwrapDepth} unwraps";
+                return null;
+            }
+            try { raw = byRef.ObjectValue; }
+            catch (Exception ex)
+            {
+                // The slot the wrapper points at could not be read. Same contract as a
+                // throwing ToString() below: no value is faked, and the reason is visible.
+                captureError = $"ByRef.ObjectValue threw {ex.GetType().Name}";
+                return null;
+            }
+            // A `var` parameter over a genuinely null value is a genuinely null value —
+            // captureError stays null so it reads exactly like a null by-value local.
+            if (raw == null) return null;
+        }
+
         switch (raw)
         {
             case bool or byte or sbyte or short or ushort or int or uint or long or ulong


### PR DESCRIPTION
Closes #2488

## Root cause

BC's emitter materialises an AL `var` (by-reference) parameter on the generated
`*_Scope` class as `Microsoft.Dynamics.Nav.Runtime.ByRef<T>` — a getter/setter pair
over the caller's slot, not a copy. The `[NavName]` field scan that both
`--capture-values` and `--dap` use therefore reads the **wrapper**, and `ByRef<T>`
declares no `ToString()` override (decompiled from `Ncl.dll`: `getter`, `setter`,
`Value`, `ObjectValue`, `ObjectType` and an implicit conversion — and, load-bearingly, no `ToString()` override). So
`AlValueWireFormat.ToWireValue`'s default arm ran `object.ToString()` and returned the
CLR type name, with `captureError` null — indistinguishable from a real value.

The report was actually **two** bugs sharing one cause. The wrapper's type name is
constant, so `AlValueCapture.DiffAndUpdate` also saw every observation of a by-ref
local as "unchanged" and suppressed all but the first. That is why the reporter saw
the wrapper name "in every iteration" and never a series.

## Fix

`ToWireValue` unwraps through BC's own non-generic `IByRef.ObjectValue` accessor
before applying the existing rules, so the inner value is rendered exactly like a
by-value local of the same type: an AL `Integer` inner is a CLR `int` and stays a JSON
number, a `NavText` inner renders via its own `ToString()`. Nothing BC owns is
reimplemented (`precompiled-dll-respect.md`). A wrapper whose getter throws reports a
`captureError` naming the exception type instead of a wrapper name
(`loud-failures.md`), and the unwrap loop is depth-bounded so a self-referential
wrapper ends in a reported failure rather than a hang.

## RED → GREEN

**Mechanism tests** — `AlRunner.Tests/AlValueWireFormatByRefTests.cs`, 13 tests, no BC
artifact needed (`ByRef<T>` is constructible directly; `AlRunner.Tests` already
references `Ncl.dll`).

- RED: `Failed: 11, Passed: 2`. Sample failure:
  `Expected: 5 / Actual: Microsoft.Dynamics.Nav.Runtime.ByRef`1[System.Int32]`.
  The 2 that passed are the by-value controls — exactly the ones that must stay green.
- GREEN: `Failed: 0, Passed: 13`.

**End-to-end test** — `AlRunner.Tests/ServerExecuteCapturedValuesByRefTests.cs`, the
issue's own reproducer compiled and executed through BC's real emitter, so it pins the
premise (that a `var` parameter really does land as a wrapper) rather than assuming it.

- RED, with only `AlValueWireFormat.cs` reverted to `origin/main`:
  `Assert.DoesNotContain() Failure: Sub-string found ... "ynamics.Nav.Runtime.ByRef`1[System.Int32]"`.
- GREEN: passes. `Bump` mutates its `var v: Integer` twice, so the assertion is
  `Assert.Equal(new[] { 6, 16 }, vNumbers)` — an exact ordered series, which a fix that
  only stopped printing the type name (leaving the diff suppression) would still fail.

**Both directions**, so neither "unwrap everything" nor "unwrap nothing" passes:

- by-ref `Integer` → `5` as `IsType<int>`; by-ref `Text` → `"y"`; reading twice through
  the same wrapper after the slot moves → `5` then `6`.
- by-value `Integer` still `6` as a number; by-value `NavText` still renders via its own
  `ToString()`; the end-to-end control asserts OnRun's by-value `total`/`name` are
  untouched.
- a wrapper whose getter throws, and one with no getter installed, both report a
  `captureError` naming the exception type and a null value — never a wrapper name.
- a `var` over a genuinely null value stays `(value: null, captureError: null)`, keeping
  #2043's "null is distinguishable from unreadable" contract through the unwrap.
- an unchanged by-ref local across two observations is still suppressed, so the unwrap
  does not turn every by-ref local into a record on every statement.

**Regression scope run:** `dotnet test AlRunner.Tests --filter "FullyQualifiedName~ByRef|
FullyQualifiedName~AlValueCapture|FullyQualifiedName~AlScopeInspector|
FullyQualifiedName~CapturedValues|FullyQualifiedName~Dap"` → `Failed: 0, Passed: 114,
Skipped: 2` (both skips pre-existing and unrelated). Full `AlRunner.Tests` not run
locally — CI runs it on all 8 legs.

## Where the test lives

The wire format of `--capture-values` is a **runner** surface: none of these assertions
is a claim about what Business Central does, so `bc-behavior-tests-go-upstream.md` does
not apply and no upstream corpus test is owed. The one BC-behaviour input here — the
shape of `ByRef<T>` — is read from BC's own shipped `Ncl.dll` and exercised through BC's
own emitter by the end-to-end test, not asserted about.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** `ToWireValue` has exactly two callers —
   `AlValueCapture.CaptureField` (`--capture-values`) and `AlScopeInspector.ReadField`
   (`--dap`). The issue only reported the first; the second had the identical bug, and
   the shared renderer fixes both at once. There is a test pinning each
   (`CaptureField_ByRefInteger_...`, `ScopeInspector_ReadField_ByRefInteger_...`) so a
   future split of the renderer cannot silently regress one of them.
2. **Sibling function making the same assumption?** The other two `[NavName]` field
   scanners (`AlCoverageTracker`, `RunnerClientCallback`) read scope *names*, not values,
   so they are unaffected. `CodeunitEventDispatcher.CoerceArg` is the one other place
   that meets a `ByRef<T>` — it already unwraps correctly (via reflection on the generic
   `Value` property, #1816), so it does **not** have this bug. Deliberately left alone:
   it sits on the hot dispatch path and switching it to `IByRef` would be unrelated churn.
3. **Two paths, same invariant?** `CaptureField` and `ReadField` each translate a
   `captureError` into their own failure representation. Both now inherit the unwrap
   identically because it lives in the one shared renderer rather than being duplicated —
   which is the drift `AlValueWireFormat` was extracted to prevent in the first place.

## Deliberately out of scope

- `CodeunitEventDispatcher.CoerceArg`'s reflective unwrap, per (2) above.
- No DAP `setVariable` / write-back path exists, so the unwrap is read-only; nothing
  writes through `ObjectValue`.

Opened by agent `stma-auto-2` on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE

