### PR TITLE
fix(testpage): run a precompiled page's async trigger override, not NavForm's empty sync one

### DIFF
--- a/AlRunner.Tests/RunnerPageInstanceAsyncTriggerResolutionTests.cs
+++ b/AlRunner.Tests/RunnerPageInstanceAsyncTriggerResolutionTests.cs
@@ -1,0 +1,131 @@
+// Issue #2522 — which of NavForm's two declarations of a page trigger the runner invokes.
+//
+// NavForm declares every page trigger TWICE: a synchronous virtual with an EMPTY body
+// (`protected virtual void OnOpenPage() {}`) and an async twin
+// (`protected virtual ValueTask OnOpenPageAsync() => default`). The runner's own emit
+// pipeline overrides the synchronous one; Microsoft's AL compiler overrides the async one.
+// BC's own dispatcher picks between them off the page object's `__IsAsync`, verbatim from
+// NavForm.RaiseOnOpenPageAsync in BC 28.1's Ncl.dll:
+//
+//     if (__IsAsync) await OnOpenPageAsync(); else OnOpenPage();
+//
+// Resolving the synchronous name only bound NavForm's own empty body for every precompiled
+// page, invoked it, and reported success having run nothing — Base Application page 973
+// "Time Sheet Card" never applied its default owner filter and never raised its
+// OnBefore/OnAfterOnOpenPage integration events.
+//
+// This pins the resolution rule itself. It stands in for the BC-behaviour claim, which is
+// not expressible upstream: the corpus compiles its own pages through the runner's pipeline,
+// so a corpus page is async-compiled only if Microsoft's compiler produced it.
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class RunnerPageInstanceAsyncTriggerResolutionTests
+{
+    /// <summary>Stands in for NavForm: both declarations, both empty.</summary>
+    private class FakeNavForm
+    {
+        protected virtual void OnOpenPage() { }
+        protected virtual ValueTask OnOpenPageAsync() => default;
+        protected virtual bool OnInsertRecord(bool belowXRec) => true;
+        protected virtual ValueTask<bool> OnInsertRecordAsync(bool belowXRec) => new(true);
+    }
+
+    /// <summary>A page Microsoft's AL compiler emitted: overrides the ASYNC twin only.</summary>
+    private sealed class AsyncCompiledPage : FakeNavForm
+    {
+        protected override ValueTask OnOpenPageAsync() => default;
+        protected override ValueTask<bool> OnInsertRecordAsync(bool belowXRec) => new(false);
+    }
+
+    /// <summary>A page the runner compiled itself: overrides the SYNCHRONOUS one only.</summary>
+    private sealed class SyncCompiledPage : FakeNavForm
+    {
+        protected override void OnOpenPage() { }
+        protected override bool OnInsertRecord(bool belowXRec) => false;
+    }
+
+    /// <summary>A page declaring neither trigger — it inherits both empty bases.</summary>
+    private sealed class NoTriggerPage : FakeNavForm { }
+
+    [Theory]
+    [InlineData("OnOpenPage")]
+    public void AsyncCompiledPage_ResolvesTheAsyncOverride_NotTheEmptySyncBase(string trigger)
+    {
+        var resolved = RunnerPageInstance.ResolveRecordTriggerOn(
+            typeof(AsyncCompiledPage), isAsyncCompiled: true, trigger, Type.EmptyTypes);
+
+        Assert.NotNull(resolved);
+        Assert.Equal(trigger + "Async", resolved!.Name);
+        Assert.Equal(typeof(AsyncCompiledPage), resolved.DeclaringType);
+        Assert.Equal(typeof(ValueTask), resolved.ReturnType);
+    }
+
+    [Fact]
+    public void AsyncCompiledPage_ArgumentTakingTrigger_ResolvesTheAsyncOverride()
+    {
+        var resolved = RunnerPageInstance.ResolveRecordTriggerOn(
+            typeof(AsyncCompiledPage), isAsyncCompiled: true, "OnInsertRecord", new[] { typeof(bool) });
+
+        Assert.NotNull(resolved);
+        Assert.Equal("OnInsertRecordAsync", resolved!.Name);
+        Assert.Equal(typeof(AsyncCompiledPage), resolved.DeclaringType);
+        Assert.Equal(typeof(ValueTask<bool>), resolved.ReturnType);
+    }
+
+    [Fact]
+    public void SyncCompiledPage_KeepsResolvingTheSynchronousOverride()
+    {
+        var resolved = RunnerPageInstance.ResolveRecordTriggerOn(
+            typeof(SyncCompiledPage), isAsyncCompiled: false, "OnOpenPage", Type.EmptyTypes);
+
+        Assert.NotNull(resolved);
+        Assert.Equal("OnOpenPage", resolved!.Name);
+        Assert.Equal(typeof(SyncCompiledPage), resolved.DeclaringType);
+        Assert.Equal(typeof(void), resolved.ReturnType);
+    }
+
+    [Fact]
+    public void SyncCompiledPage_ArgumentTakingTrigger_KeepsResolvingTheSynchronousOverride()
+    {
+        var resolved = RunnerPageInstance.ResolveRecordTriggerOn(
+            typeof(SyncCompiledPage), isAsyncCompiled: false, "OnInsertRecord", new[] { typeof(bool) });
+
+        Assert.NotNull(resolved);
+        Assert.Equal("OnInsertRecord", resolved!.Name);
+        Assert.Equal(typeof(SyncCompiledPage), resolved.DeclaringType);
+        Assert.Equal(typeof(bool), resolved.ReturnType);
+    }
+
+    /// <summary>
+    /// The negative direction of the same rule: an async-compiled page that declares NO
+    /// override still resolves to the base — invoking a base no-op is correct there, and is
+    /// exactly the outcome that was wrong for AsyncCompiledPage above.
+    /// </summary>
+    [Fact]
+    public void PageDeclaringNoTrigger_FallsBackToTheBaseDeclaration()
+    {
+        var resolvedAsync = RunnerPageInstance.ResolveRecordTriggerOn(
+            typeof(NoTriggerPage), isAsyncCompiled: true, "OnOpenPage", Type.EmptyTypes);
+        var resolvedSync = RunnerPageInstance.ResolveRecordTriggerOn(
+            typeof(NoTriggerPage), isAsyncCompiled: false, "OnOpenPage", Type.EmptyTypes);
+
+        Assert.Equal(typeof(FakeNavForm), resolvedAsync!.DeclaringType);
+        Assert.Equal("OnOpenPageAsync", resolvedAsync.Name);
+        Assert.Equal(typeof(FakeNavForm), resolvedSync!.DeclaringType);
+        Assert.Equal("OnOpenPage", resolvedSync.Name);
+    }
+
+    /// <summary>A trigger the page does not declare at all stays null, not a wrong method.</summary>
+    [Fact]
+    public void UnknownTriggerName_ResolvesToNull()
+    {
+        Assert.Null(RunnerPageInstance.ResolveRecordTriggerOn(
+            typeof(AsyncCompiledPage), isAsyncCompiled: true, "OnNotATrigger", Type.EmptyTypes));
+    }
+}

--- a/AlRunner/Patches/RecordPatches.AllObjWithCaptionVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AllObjWithCaptionVirtualTable.cs
@@ -104,10 +104,21 @@ public static partial class RecordPatches
     /// <summary>
     /// One column of an AllObjWithCaption row, matched by the metatable's own FIELD NAME so
     /// the mapping tracks whatever the System package in the resolved artifact declares
-    /// rather than a hardcoded field-number table. Every other column (App Package ID, App
-    /// Runtime Package ID, Object Subtype, Object Namespace, …) gets BC's own default,
-    /// which is exactly what AllObjWithCaptionDataProvider emits for a base object with no
-    /// app package and no namespace.
+    /// rather than a hardcoded field-number table. Every remaining column (App Package ID,
+    /// App Runtime Package ID, Object Namespace, …) gets BC's own default, which is exactly
+    /// what AllObjWithCaptionDataProvider emits for a base object with no app package and no
+    /// namespace.
+    ///
+    /// <para><c>Object Subtype</c> is answered for PAGES, from the same PageType the "Page
+    /// Metadata" (2000000138) virtual table reports — one source, so a page's subtype here
+    /// and its PageType there cannot disagree. Base Application page 9170 "Profile Card"
+    /// reads exactly this column: its <c>ValidateRoleCenterIdExists</c> does
+    /// <c>AllObjWithCaption.TestField("Object Subtype", 'RoleCenter')</c> on the profile's
+    /// Role Center ID, so a blank column made every profile insert refuse a legitimate role
+    /// center. Other object kinds carry a subtype on a real tier too (a codeunit's
+    /// Normal/Test/Install/Upgrade, a table's Normal/Temporary, …); those are NOT answered
+    /// here and keep BC's default, because the runner has no equally-single source for them
+    /// yet — see the issue linked from the PR that added this.</para>
     /// </summary>
     private static object? BuildAllObjWithCaptionValue(
         NCLMetaField field, int typeOrdinal, int objectId, string objectName, string objectCaption)
@@ -122,9 +133,33 @@ public static partial class RecordPatches
                 return _aovNavTextCreateTruncated!.Invoke(null, new object?[] { field.FieldDefinedLength, objectName ?? string.Empty });
             case "objectcaption":
                 return _aovNavTextCreateTruncated!.Invoke(null, new object?[] { field.FieldDefinedLength, objectCaption ?? string.Empty });
+            case "objectsubtype":
+            {
+                var subtype = SubtypeForObject(typeOrdinal, objectId);
+                if (subtype == null) break;
+                return _aovNavTextCreateTruncated!.Invoke(null, new object?[] { field.FieldDefinedLength, subtype });
+            }
             default:
-                return _aovGetDefaultNavValue!.Invoke(null, new object?[] { field, false });
+                break;
         }
+        return _aovGetDefaultNavValue!.Invoke(null, new object?[] { field, false });
+    }
+
+    /// <summary>
+    /// The AL subtype of one object in the shared inventory, or null when the runner has no
+    /// single authoritative source for that kind's subtype and BC's own default must stand.
+    ///
+    /// Pages only, deliberately — see <see cref="BuildAllObjWithCaptionValue"/>. The page's
+    /// type ordinal is compared against the ordinal AllObjWithCaption's OWN "Object Type"
+    /// option set gives "Page" in this artifact, never a hardcoded number.
+    /// </summary>
+    private static string? SubtypeForObject(int typeOrdinal, int objectId)
+    {
+        if (_awcObjectTypeOrdinals == null) return null;
+        if (!_awcObjectTypeOrdinals.TryGetValue("page", out var pageOrdinal) || typeOrdinal != pageOrdinal)
+            return null;
+        var pageType = TryGetPageMetadataPageType(objectId);
+        return string.IsNullOrEmpty(pageType) ? null : pageType;
     }
 
     private static Dictionary<string, int>? _awcObjectTypeOrdinals;

--- a/AlRunner/Patches/RecordPatches.PageMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.PageMetadataVirtualTable.cs
@@ -165,6 +165,19 @@ public static partial class RecordPatches
     /// test and of any source-compiled dependency first, then pages declared by the
     /// SymbolReference.json of every registered precompiled dependency .app.
     /// </summary>
+    /// <summary>
+    /// The declared <c>PageType</c> of one page, from the SAME inventory the "Page Metadata"
+    /// (2000000138) virtual table reports — so AllObjWithCaption's "Object Subtype" and Page
+    /// Metadata's "PageType" cannot disagree for the same page. Null when this run knows of
+    /// no such page.
+    /// </summary>
+    internal static string? TryGetPageMetadataPageType(int pageId)
+    {
+        foreach (var row in EnumerateKnownPageMetadata())
+            if (row.Id == pageId) return row.PageType;
+        return null;
+    }
+
     private static List<PageMetaRow> EnumerateKnownPageMetadata()
     {
         var generation = (_bcAppPaths.Count, _parsedPages.Count);

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -1511,9 +1511,7 @@ internal sealed class RunnerPageInstance
     /// </summary>
     private object? InvokeRecordTrigger(string name, Type[] parameterTypes, object[] arguments)
     {
-        var trigger = _form.GetType().GetMethod(name,
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
-            binder: null, types: parameterTypes, modifiers: null);
+        var trigger = ResolveRecordTrigger(name, parameterTypes);
         if (trigger == null) return null;
         try { return AwaitTriggerResult(trigger.Invoke(_form, arguments)); }
         catch (TargetInvocationException tie) when (tie.InnerException != null)
@@ -1524,6 +1522,59 @@ internal sealed class RunnerPageInstance
             throw; // unreachable
         }
     }
+
+    /// <summary>
+    /// The method carrying page trigger <paramref name="name"/> on this page's compiled type —
+    /// its ASYNC override when the page was compiled async, its synchronous one otherwise.
+    ///
+    /// Issue #2522. <c>NavForm</c> declares every page trigger TWICE: a synchronous virtual
+    /// with an empty body (<c>protected virtual void OnOpenPage() {}</c>) and an async twin
+    /// (<c>protected virtual ValueTask OnOpenPageAsync() =&gt; default</c>). Which one a page
+    /// overrides is decided by the compiler that produced it, and BC's own dispatcher picks
+    /// between them off the page's own <c>__IsAsync</c> — verbatim from
+    /// <c>NavForm.RaiseOnOpenPageAsync</c> in BC 28.1's Ncl.dll:
+    ///
+    /// <code>
+    ///   if (__IsAsync) await OnOpenPageAsync(); else OnOpenPage();
+    /// </code>
+    ///
+    /// The runner's own emit pipeline overrides the SYNCHRONOUS virtual, so a bare
+    /// <c>GetMethod("OnOpenPage")</c> was right for every page the runner compiled itself and
+    /// silently wrong for every PRECOMPILED one: Microsoft's AL compiler overrides
+    /// <c>OnOpenPageAsync</c> instead, so the lookup bound <c>NavForm</c>'s own EMPTY body,
+    /// invoked it, and returned success having run nothing. Measured on Base Application page
+    /// 973 "Time Sheet Card" (BC 28.1.49838.53910): <c>Page973.OnOpenPageAsync()</c> exists,
+    /// the resolved method was <c>NavForm.OnOpenPage</c>, and consequently the page's default
+    /// owner filter never landed, its <c>OnBeforeOnOpenPage</c>/<c>OnAfterOnOpenPage</c>
+    /// integration events never fired, and neither did the <c>OnBeforeFilterTimeSheets</c>
+    /// codeunit event its body reaches — while that same codeunit event fires normally when
+    /// <c>TimeSheetMgt.FilterTimeSheets</c> is called directly. Same shape on page 9807 "User
+    /// Card", whose <c>OnAfterGetRecordAsync</c> is where <c>WebServiceExpiryDate</c> is
+    /// assigned (issue #2361's populated-value arm).
+    ///
+    /// <c>__IsAsync</c> is BC's own discriminator, not a heuristic:
+    /// <c>NavApplicationObjectBase.__IsAsync =&gt; false</c>, and an async-compiled object
+    /// overrides it to true. Falling back to whichever twin exists keeps a page that declares
+    /// only one of them working either way.
+    /// </summary>
+    private MethodInfo? ResolveRecordTrigger(string name, Type[] parameterTypes)
+    {
+        const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+        var type = _form.GetType();
+        var sync = type.GetMethod(name, flags, binder: null, types: parameterTypes, modifiers: null);
+        if (!IsAsyncCompiled) return sync ?? type.GetMethod(name + "Async", flags, binder: null, types: parameterTypes, modifiers: null);
+        return type.GetMethod(name + "Async", flags, binder: null, types: parameterTypes, modifiers: null) ?? sync;
+    }
+
+    /// <summary>
+    /// BC's own <c>NavApplicationObjectBase.__IsAsync</c> for this page — false on the base,
+    /// overridden to true by an object Microsoft's AL compiler emitted in its async shape.
+    /// See <see cref="ResolveRecordTrigger"/>.
+    /// </summary>
+    private bool IsAsyncCompiled
+        => _form.GetType()
+            .GetProperty("__IsAsync", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?
+            .GetValue(_form) is true;
 
     /// <summary>
     /// A resolved trigger method plus the OBJECT to invoke it on. Before issue #1923 every

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -1558,12 +1558,20 @@ internal sealed class RunnerPageInstance
     /// only one of them working either way.
     /// </summary>
     private MethodInfo? ResolveRecordTrigger(string name, Type[] parameterTypes)
+        => ResolveRecordTriggerOn(_form.GetType(), IsAsyncCompiled, name, parameterTypes);
+
+    /// <summary>
+    /// <see cref="ResolveRecordTrigger"/>'s rule, as a pure function of the page's compiled
+    /// TYPE and its <c>__IsAsync</c>, so it can be pinned without a BC runtime — see
+    /// AlRunner.Tests/RunnerPageInstanceAsyncTriggerResolutionTests.cs.
+    /// </summary>
+    internal static MethodInfo? ResolveRecordTriggerOn(
+        Type type, bool isAsyncCompiled, string name, Type[] parameterTypes)
     {
         const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
-        var type = _form.GetType();
         var sync = type.GetMethod(name, flags, binder: null, types: parameterTypes, modifiers: null);
-        if (!IsAsyncCompiled) return sync ?? type.GetMethod(name + "Async", flags, binder: null, types: parameterTypes, modifiers: null);
-        return type.GetMethod(name + "Async", flags, binder: null, types: parameterTypes, modifiers: null) ?? sync;
+        var async = type.GetMethod(name + "Async", flags, binder: null, types: parameterTypes, modifiers: null);
+        return isAsyncCompiled ? (async ?? sync) : (sync ?? async);
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #2522

Filed by agent impl-6.

## Mechanism

`NavForm` declares **every page trigger twice**. From BC 28.1's shipped `Ncl.dll`:

```csharp
protected virtual void OnOpenPage() { }                        // empty
protected virtual ValueTask OnOpenPageAsync() => default;      // empty
```

and its own dispatcher, `NavForm.RaiseOnOpenPageAsync`, chooses between them off the page
object's `__IsAsync` (`NavApplicationObjectBase.__IsAsync => false`, overridden to `true` by an
object Microsoft's AL compiler emitted):

```csharp
if (__IsAsync) await OnOpenPageAsync(); else OnOpenPage();
```

The runner's own emit pipeline overrides the **synchronous** virtual. Microsoft's AL compiler
overrides the **async** one. `RunnerPageInstance.InvokeRecordTrigger` looked up the synchronous
name only, so for every **precompiled** page it bound `NavForm`'s own empty body, invoked it, and
returned success having run nothing. No error, no trace — the page's whole trigger simply did
not happen.

Measured on Base Application page 973 "Time Sheet Card", BC 28.1.49838.53910: the type carries
`Page973.OnOpenPageAsync() -> ValueTask`, and the method the runner resolved was
`NavForm.OnOpenPage`. Behaviourally, with a `Time Sheet Header` owned by the current user and
one owned by someone else:

| probe | before | after |
|---|---|---|
| rows the `TestPage` shows | `I6MINE + I6OTHER` | `I6MINE` |
| page event `OnBeforeOnOpenPage` fired | no | yes |
| page event `OnAfterOnOpenPage` fired, filter captured | no, `?` | yes, `TESTUSER` |
| codeunit event `OnBeforeFilterTimeSheets` fired | no | yes |

The codeunit event is the control that rules out "event dispatch is broken": calling
`TimeSheetMgt.FilterTimeSheets` directly fires it in both builds, and applies the same
`TESTUSER` filter. The trigger was the only thing not running.

This is not specific to `OnOpenPage`. Every trigger `InvokeRecordTrigger` drives has an async
twin on `NavForm` — `OnAfterGetRecordAsync`, `OnAfterGetCurrRecordAsync`,
`OnQueryClosePageAsync`, `OnClosePageAsync`, `OnNewRecordAsync`, `OnInsertRecordAsync`,
`OnModifyRecordAsync` — and on Base Application page 9807 "User Card" the runner was resolving
`NavForm` for both `OnOpenPage` and `OnAfterGetRecord` while `Page9807.OnOpenPageAsync` and
`Page9807.OnAfterGetRecordAsync` sat unused. That is the "populated `WebServiceExpiryDate` never
reaches the control" arm of #2361 (its blank-value arm is a separate defect and this PR does not
close it).

## The second commit

Landing the first commit alone turns the corpus red on
`Codeunit60820.ControlOnValidate_AcceptsAValueItDoesNotRefuse`, and correctly so: page 9170
"Profile Card"'s `OnInsertRecord` now actually runs, and its `ValidateRoleCenterIdExists` does

```al
AllObjWithCaption.Get(AllObjWithCaption."Object Type"::Page, Rec."Role Center ID");
AllObjWithCaption.TestField("Object Subtype", 'RoleCenter');
```

against a column the runner left blank. The second commit answers `Object Subtype` for pages
from the same `PageType` the "Page Metadata" (2000000138) virtual table reports, so the two
cannot disagree. Other object kinds carry a subtype on a real tier too (a codeunit's
Normal/Test/Install/Upgrade, a table's Normal/Temporary); those still get BC's default and are
filed separately rather than guessed at.

## Fixing the shape, not the reported line

- **Another call site with the same wrong pattern?** Yes, and it is the same method — all eight
  page-level triggers funnel through `InvokeRecordTrigger`, so all eight were affected and all
  eight are fixed. The member-trigger path (`FindTrigger`, used for control `OnValidate` /
  `OnAction` / `OnLookup`) matches on a suffix and was already reaching MS-compiled pages, which
  is why a control `OnValidate` fired on page 9807 while the page's own `OnOpenPage` did not.
- **A sibling function making the same assumption?** `RunnerPageInstance.Invoke` /
  `AwaitTriggerResult` already handle a `ValueTask` return (#2359); the gap was purely in *which
  method got resolved*, so awaiting needed no change.
- **Two paths writing the same state?** `Object Subtype` and Page Metadata's `PageType` are now
  one source, deliberately, so they cannot drift.

## Verification

All on BC 28.1 unless noted.

- `AlRunner.Tests/RunnerPageInstanceAsyncTriggerResolutionTests.cs` — RED 3/6 with the pre-fix
  resolution rule, GREEN 6/6 with it. It pins the rule as a pure function of the compiled type
  and `__IsAsync`, including the negative direction (a page declaring neither override still
  resolves to the base, and an unknown trigger name still resolves to null).
- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~RunnerPageInstance|~AllObj|~PageMetadata"` — 37/37.
- al-language corpus — 2456/2456 (2456/2456 on `main` too; the intermediate 2455 is what the
  second commit repairs).
- runner-extras — 232/232.
- Microsoft `Tests-SINGLESERVER`, 839 tests, BC 28.1.49838.53910, `--test-data`, company
  `CRONUS International Ltd_`: **510 → 541 passing**, 34 tests gained, 3 lost. All five tests
  named in #2522 pass.

The three losses are all the same shape — a trigger that used to do nothing now runs and reaches
a genuinely unsupported surface, so a silent wrong pass became a loud failure:

- `Codeunit134201.ApprovalCommentFromIncomingDoc` and `Codeunit136506.OpenActiveTimeSheet` —
  `IsAvailable()` on a `[RunOnClient]` DotNet variable (Camera, PageNotifier) raises
  `NavNCLCallbackNotAllowedException` where a real tier with no client answers `false`. Filed
  separately.
- `Codeunit139004.TestApplicationAreaReadonly` — `LibraryVariableStorage` is left non-empty by
  `TestChangeCustomExperienceTierOnCompanyInfoFail`, which this PR moves from failing to
  passing, in the same codeunit. A cascade from the newly-passing neighbour; I did not chase it
  further and say so rather than claim it is unrelated.

## What I did not verify

The BC-behaviour claim here ("a precompiled page's `OnOpenPage` runs") is not expressible in the
upstream corpus: the corpus compiles its own pages through the runner's pipeline, so a corpus
page is only async-compiled if Microsoft's compiler produced it. The evidence is BC's own shipped
IL (`NavForm.RaiseOnOpenPageAsync`) plus the measured before/after above, and the proving test is
the runner-side mechanism test. `AllObjWithCaption."Object Subtype"` for pages **is** expressible
upstream and a corpus test for it is worth adding; it is not in this PR.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
