### PR TITLE
feat(artifacts): relocate the BC artifacts root with AL_RUNNER_ARTIFACTS_ROOT

### DIFF
--- a/AlRunner.Tests/AlRunner.Tests.csproj
+++ b/AlRunner.Tests/AlRunner.Tests.csproj
@@ -91,9 +91,10 @@
          Carrying its OWN default value on top of that Condition is what caused #2102: it
          disagreed with AlRunner.csproj's separate default on a bare local build with no
          override at all. -->
-    <_CacheBase Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(USERPROFILE)/.local/share/al-runner</_CacheBase>
-    <_CacheBase Condition="!$([MSBuild]::IsOSPlatform('Windows'))">$(HOME)/.local/share/al-runner</_CacheBase>
-    <ServiceTierPath Condition="'$(ServiceTierPath)' == ''">$(_CacheBase)/artifacts/$(_BCVersion)</ServiceTierPath>
+    <!-- Same artifacts root the runtime and AlRunner.csproj resolve, AL_RUNNER_ARTIFACTS_ROOT
+         included (#2578). $(_ArtifactsRoot) is declared once in the repo-root
+         Directory.Build.props, trailing separator included. -->
+    <ServiceTierPath Condition="'$(ServiceTierPath)' == ''">$(_ArtifactsRoot)$(_BCVersion)</ServiceTierPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Dynamics.Nav.CodeAnalysis">

--- a/AlRunner.Tests/ArtifactsRootEnvOverrideTests.cs
+++ b/AlRunner.Tests/ArtifactsRootEnvOverrideTests.cs
@@ -1,0 +1,352 @@
+// ArtifactsRootEnvOverrideTests — issue #2578.
+//
+// BcArtifacts.ArtifactsRoot was Path.Combine(AlRunnerPaths.UserHome, ArtifactsRoot_Rel),
+// so the ONLY way to move the BC artifact cache off the home directory was to move $HOME
+// itself — which relocates every other home-rooted path (~/.cache/al-runner,
+// ~/.bcartifacts.cache, ~/.local/share/al-runner/symbols) at the same time and forces the
+// caller to hand-spell the version-directory layout BcArtifacts owns. AL_RUNNER_ARTIFACTS_ROOT
+// names that root directly.
+//
+// Not the same knob as --artifact-path: that pins ONE version's engine directory (and
+// bypasses version selection entirely); this names the root those version directories live
+// under, so --bc-version / latest-in-cache selection and provisioning keep working.
+//
+// Per .claude/rules/bc-behavior-tests-go-upstream.md this is a runner-configuration claim
+// (where the CLI and the BUILD resolve their own artifact cache) and asserts nothing about
+// Business Central, so it belongs here and owes no al-language corpus test.
+//
+// Three layers, because a variable honoured by only one of them is a half-feature:
+//   1. the pure resolver (absolutization, trailing-separator canonicalization, fallback),
+//   2. the real CLI, spawned as a subprocess so nothing in-process mutates the shared
+//      environment other parallel test classes read,
+//   3. the MSBuild evaluation of both csprojs that <Reference> the service-tier DLLs —
+//      AlRunner.csproj hard-ERRORS (FailIfBCServiceTierDllsMissing) when they are absent,
+//      so a runtime-only override would leave the build unable to find a relocated cache.
+
+using System.Diagnostics;
+using System.Text;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ArtifactsRootEnvOverrideTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    // Never on the CDN and never in a cache: the process must fail at artifact-root
+    // resolution, long before "does this version exist" is asked (same reason
+    // HomeDirectoryMissingLoudFailureTests uses 1.2.3.4).
+    private const string NonexistentVersion = "1.2.3.4";
+
+    private static string Norm(string p) => p.Replace('\\', '/');
+
+    // ---------------------------------------------------------------- 1. pure resolver
+
+    [Fact]
+    public void NoOverride_FallsBackToTheHomeRootedDefault()
+    {
+        var resolved = BcArtifacts.ResolveArtifactsRoot(null, () => "/home/someone");
+
+        Assert.Equal("/home/someone/.local/share/al-runner/artifacts", Norm(resolved));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BlankOverride_FallsBackToTheHomeRootedDefault(string blank)
+    {
+        // `export AL_RUNNER_ARTIFACTS_ROOT=` in a shell profile must not silently route the
+        // whole cache at the current working directory.
+        var resolved = BcArtifacts.ResolveArtifactsRoot(blank, () => "/home/someone");
+
+        Assert.Equal("/home/someone/.local/share/al-runner/artifacts", Norm(resolved));
+    }
+
+    [Fact]
+    public void AbsoluteOverride_IsUsedVerbatim_AndTheHomeDirectoryIsNeverConsulted()
+    {
+        var custom = Path.Combine(Path.GetTempPath(), "al-runner-2578-abs");
+
+        // The home provider throws: this resolution must not be coupled to a $HOME resolution
+        // that can fail for an unrelated reason (#2114). Scoped to the resolver — Program.cs's
+        // AL-output cache resolves UserHome independently, so a broken $HOME still ends the
+        // run; what this pins is that the override itself never depends on it.
+        var resolved = BcArtifacts.ResolveArtifactsRoot(
+            custom, () => throw new InvalidOperationException("UserHome must not be consulted"));
+
+        Assert.Equal(Norm(custom), Norm(resolved));
+        Assert.DoesNotContain(".local/share/al-runner", Norm(resolved));
+    }
+
+    [Fact]
+    public void RelativeOverride_IsAbsolutized_ResolvingTheSameWayAnAbsoluteValueDoes()
+    {
+        // A relative root never matches TryTranslateArtifactPathToVersion's ordinal compare
+        // against Path.Combine(ArtifactsRoot, version), so it would silently route every
+        // --artifact-path onto the explicit-root branch instead of normal version selection.
+        var resolved = BcArtifacts.ResolveArtifactsRoot("rel-arts", () => "/home/someone");
+
+        Assert.True(Path.IsPathRooted(resolved), $"expected a rooted path, got '{resolved}'");
+        Assert.Equal(Norm(Path.GetFullPath("rel-arts")), Norm(resolved));
+
+        // "Resolves the same way an absolute one does": the absolute spelling of the same
+        // directory produces the identical string.
+        Assert.Equal(
+            Norm(BcArtifacts.ResolveArtifactsRoot(Path.GetFullPath("rel-arts"), () => "/home/someone")),
+            Norm(resolved));
+    }
+
+    [Fact]
+    public void TrailingSeparatorIsTrimmed_SoTheArtifactPathOrdinalCompareStillMatches()
+    {
+        var custom = Path.Combine(Path.GetTempPath(), "al-runner-2578-trail");
+
+        var resolved = BcArtifacts.ResolveArtifactsRoot(
+            custom + Path.DirectorySeparatorChar, () => "/home/someone");
+
+        Assert.Equal(Norm(custom), Norm(resolved));
+    }
+
+    [Fact]
+    public void ArtifactDirForAndArtifactsRootDir_AgreeWithTheResolver()
+    {
+        // Both public entry points must be derived from the same resolution, not from a
+        // second hand-spelled Path.Combine(UserHome, ...) that would ignore the override.
+        var root = BcArtifacts.ArtifactsRootDir;
+
+        Assert.Equal(
+            Norm(Path.Combine(root, "28.1.49838.53910")),
+            Norm(BcArtifacts.ArtifactDirFor("28.1.49838.53910")));
+    }
+
+    // ------------------------------------------------------- 2. the real CLI, subprocess
+
+    private static (int ExitCode, string StdErr) RunCli(
+        string? artifactsRootEnv, string? homeOverride = null, string? workingDir = null)
+        => RunRunner(artifactsRootEnv, homeOverride, workingDir,
+                     $"--bc-version {NonexistentVersion} --no-auto-provision");
+
+    private static (int ExitCode, string Output) RunRunner(
+        string? artifactsRootEnv, string? homeOverride, string? workingDir, string runnerArgs)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner")));
+        args.Append(' ').Append(runnerArgs);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = args.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = workingDir ?? RepoRoot,
+        };
+        // Set on the CHILD only. Mutating this process's environment would leak into every
+        // other test class spawning a runner concurrently (maxParallelThreads = 4).
+        if (artifactsRootEnv == null) psi.Environment.Remove("AL_RUNNER_ARTIFACTS_ROOT");
+        else psi.Environment["AL_RUNNER_ARTIFACTS_ROOT"] = artifactsRootEnv;
+        if (homeOverride != null)
+        {
+            psi.Environment["HOME"] = homeOverride;
+            psi.Environment["USERPROFILE"] = homeOverride; // SpecialFolder.UserProfile on Windows
+        }
+
+        // Both pipes into one buffer, drained concurrently: the runner writes its
+        // "[bc] selected BC <ver> (<dir>)" line and its diagnostics to stderr and its run
+        // summary to stdout, and reading one to the end before the other deadlocks once the
+        // 64K buffer of the unread pipe fills (see CliDocumentationTests' note).
+        var errSb = new StringBuilder();
+        using var proc = Process.Start(psi)!;
+        proc.OutputDataReceived += (_, e) => { if (e.Data != null) lock (errSb) errSb.AppendLine(e.Data); };
+        proc.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (errSb) errSb.AppendLine(e.Data); };
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+        if (!proc.WaitForExit(120_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException("al-runner did not exit within 120s.");
+        }
+        proc.WaitForExit();
+        lock (errSb) return (proc.ExitCode, errSb.ToString());
+    }
+
+    [Fact]
+    public void Cli_WithTheEnvVarSet_ResolvesUnderThatRoot_AndNotUnderHome()
+    {
+        // An isolated (existing, empty) home, so "did it use the override" is decidable:
+        // the diagnostic must name the override and must NOT name this home's own tree.
+        var isolatedHome = TestScratch.Dir("al-runner-2578-home");
+        Directory.CreateDirectory(isolatedHome);
+        var custom = TestScratch.Dir("al-runner-2578-root"); // deliberately never created
+        try
+        {
+            var (exit, stderr) = RunCli(custom, isolatedHome);
+
+            Assert.Equal(2, exit);
+            Assert.Contains($"BC artifact root not found: {custom}", Norm(stderr));
+            Assert.DoesNotContain(Norm(TestArtifacts.StandardCacheDir(isolatedHome)), Norm(stderr));
+        }
+        finally { try { Directory.Delete(isolatedHome, recursive: true); } catch { } }
+    }
+
+    [Fact]
+    public void Cli_WithoutTheEnvVar_StillUsesTheHomeRootedDefault()
+    {
+        // The regression direction: a fix that broke this would break every existing box.
+        var isolatedHome = TestScratch.Dir("al-runner-2578-home-default");
+        Directory.CreateDirectory(isolatedHome);
+        try
+        {
+            var (exit, stderr) = RunCli(artifactsRootEnv: null, homeOverride: isolatedHome);
+
+            Assert.Equal(2, exit);
+            Assert.Contains(
+                $"BC artifact root not found: {Norm(TestArtifacts.StandardCacheDir(isolatedHome))}",
+                Norm(stderr));
+        }
+        finally { try { Directory.Delete(isolatedHome, recursive: true); } catch { } }
+    }
+
+    [Fact]
+    public void Cli_WithARelativeEnvValue_ReportsAnAbsolutePath()
+    {
+        var isolatedHome = TestScratch.Dir("al-runner-2578-home-rel");
+        Directory.CreateDirectory(isolatedHome);
+        var cwd = TestScratch.Dir("al-runner-2578-cwd");
+        Directory.CreateDirectory(cwd);
+        try
+        {
+            var (exit, stderr) = RunCli("rel-arts", isolatedHome, workingDir: cwd);
+
+            Assert.Equal(2, exit);
+            // Absolutized against the child's own working directory — never reported (or
+            // probed) as the bare relative string.
+            Assert.Contains($"BC artifact root not found: {Norm(Path.Combine(cwd, "rel-arts"))}",
+                            Norm(stderr));
+            Assert.DoesNotContain("BC artifact root not found: rel-arts", Norm(stderr));
+        }
+        finally
+        {
+            try { Directory.Delete(isolatedHome, recursive: true); } catch { }
+            try { Directory.Delete(cwd, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// The positive end-to-end half: a real run, real BC engine, tests actually executing —
+    /// out of a root that is NOT the home-rooted default. The three cases above prove the
+    /// resolution by reading a failure message; this one proves version SELECTION and the
+    /// default package-cache/provisioning probes (both derived from ArtifactsRootDir) really
+    /// follow the variable, which a message-only assertion cannot show.
+    ///
+    /// The relocated root is a SYMLINK to the provisioned one, so the test costs no copy of a
+    /// multi-hundred-MB artifact tree. Path.GetFullPath does not resolve symlinks, so the
+    /// runner's own selection line still names the relocated path — if it named the link
+    /// target instead, that would mean the root came from somewhere other than the variable.
+    /// </summary>
+    [SkippableFact]
+    public void Cli_RunsARealSuite_OutOfARelocatedArtifactsRoot()
+    {
+        TestArtifacts.SkipIfMissing();
+        var provisioned = TestArtifacts.StandardCacheDir(TestArtifacts.HomeDir()!);
+        // The gate is also satisfied by the legacy BcContainerHelper layout, which is not the
+        // tree this test relocates — so require the runner-owned one specifically.
+        TestArtifacts.SkipIf(!Directory.Exists(provisioned),
+            $"'{provisioned}' is what this test relocates, and it is not present.");
+
+        var relocatedParent = TestScratch.Dir("al-runner-2578-relocated");
+        Directory.CreateDirectory(relocatedParent);
+        var relocated = Path.Combine(relocatedParent, "artifacts");
+        try
+        {
+            Directory.CreateSymbolicLink(relocated, provisioned);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            // Windows needs Developer Mode or elevation to create a directory symlink.
+            throw new SkipException($"cannot create a directory symlink here: {ex.Message}");
+        }
+
+        try
+        {
+            // RecordTriggerXRec: the suite's most-spawned fixture, declares no Microsoft
+            // dependency (see no-base-app-in-csharp-tests.md), so it needs nothing but the
+            // engine — which is exactly what the relocated root has to supply.
+            var (exit, output) = RunRunner(
+                relocated, homeOverride: null, workingDir: null,
+                runnerArgs: "--no-auto-provision \"" +
+                            Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", "RecordTriggerXRec") + "\"");
+
+            Assert.True(exit == 0, $"a run out of the relocated root must succeed. exit={exit}\n{output}");
+
+            // The engine was loaded from the relocated root, named by the runner itself.
+            Assert.Contains($"({Norm(relocated)}/", Norm(output));
+            Assert.Contains("selected BC", output, StringComparison.Ordinal);
+
+            // And tests really ran — a run that selected the right root but executed nothing
+            // would otherwise satisfy every assertion above.
+            Assert.Contains("1P/0F/0E", output, StringComparison.Ordinal);
+        }
+        finally { try { Directory.Delete(relocatedParent, recursive: true); } catch { } }
+    }
+
+    // -------------------------------------------------------------- 3. the build (MSBuild)
+
+    private static string EvaluateServiceTierPath(string projectRelPath, string? artifactsRootEnv)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = $"msbuild \"{Path.Combine(RepoRoot, projectRelPath)}\" " +
+                        "-getProperty:ServiceTierPath -nologo",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        if (artifactsRootEnv == null) psi.Environment.Remove("AL_RUNNER_ARTIFACTS_ROOT");
+        else psi.Environment["AL_RUNNER_ARTIFACTS_ROOT"] = artifactsRootEnv;
+
+        using var proc = Process.Start(psi)!;
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        if (!proc.WaitForExit(120_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException("dotnet msbuild -getProperty did not finish within 120s.");
+        }
+        proc.WaitForExit();
+        Assert.True(proc.ExitCode == 0, $"msbuild evaluation failed ({proc.ExitCode}):\n{stdout}\n{stderr}");
+        return stdout.Trim();
+    }
+
+    [Theory]
+    [InlineData("AlRunner/AlRunner.csproj")]
+    [InlineData("AlRunner.Tests/AlRunner.Tests.csproj")]
+    public void Build_WithTheEnvVarSet_ReferencesTheServiceTierDllsUnderThatRoot(string projectRelPath)
+    {
+        // AlRunner.csproj's FailIfBCServiceTierDllsMissing target hard-errors when the
+        // service-tier DLLs are absent from ServiceTierPath, so a runtime-only override
+        // would leave a relocated cache unbuildable on a box with nothing under $HOME.
+        var custom = Path.Combine(Path.GetTempPath(), "al-runner-2578-build-root");
+
+        var resolved = Norm(EvaluateServiceTierPath(projectRelPath, custom));
+
+        Assert.StartsWith(Norm(custom) + "/", resolved);
+        Assert.DoesNotContain(".local/share/al-runner", resolved);
+    }
+
+    [Theory]
+    [InlineData("AlRunner/AlRunner.csproj")]
+    [InlineData("AlRunner.Tests/AlRunner.Tests.csproj")]
+    public void Build_WithoutTheEnvVar_KeepsTheHomeRootedDefault(string projectRelPath)
+    {
+        var resolved = Norm(EvaluateServiceTierPath(projectRelPath, artifactsRootEnv: null));
+
+        Assert.Contains(".local/share/al-runner/artifacts/", resolved);
+    }
+}

--- a/AlRunner/AlRunner.csproj
+++ b/AlRunner/AlRunner.csproj
@@ -284,12 +284,11 @@
          If a future BC version needs the same treatment, restore the pattern from 0983df71
          rather than reinventing it: a constant per FEATURE (not a bare BCnn) keeps each #if
          site self-explaining. -->
-    <!-- Cross-platform cache directory for the build-time BC service tier. MUST match the
-         runtime artifacts root (BcArtifacts.ArtifactsRoot = UserProfile/.local/share/al-runner/
-         artifacts on every OS) so a dev's downloaded artifacts serve both the build and the
-         run. USERPROFILE is the Windows equivalent of $HOME (SpecialFolder.UserProfile). -->
-    <_CacheBase Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(USERPROFILE)/.local/share/al-runner</_CacheBase>
-    <_CacheBase Condition="!$([MSBuild]::IsOSPlatform('Windows'))">$(HOME)/.local/share/al-runner</_CacheBase>
+    <!-- The build-time BC service tier comes out of the SAME artifacts root the runtime
+         resolves (BcArtifacts.ArtifactsRootDir), so a dev's downloaded artifacts serve both
+         the build and the run — including when AL_RUNNER_ARTIFACTS_ROOT relocates that root
+         (#2578). $(_ArtifactsRoot) is declared once in the repo-root Directory.Build.props,
+         trailing separator included; see the comment there for why it is not per-project. -->
   </PropertyGroup>
 
   <!-- BC service tier: local artifacts first, then cache directory.
@@ -297,8 +296,11 @@
        AL compiler-and-emit infrastructure ships in BC service tier so no separate
        AL compiler tool is required. -->
   <PropertyGroup Condition="'$(ServiceTierPath)' == ''">
-    <ServiceTierPath Condition="Exists('$(RepoRoot)/artifacts/sandbox/$(_BCVersion)/platform/ServiceTier/PFiles64/Microsoft Dynamics NAV/270/Service')">$(RepoRoot)/artifacts/sandbox/$(_BCVersion)/platform/ServiceTier/PFiles64/Microsoft Dynamics NAV/270/Service</ServiceTierPath>
-    <ServiceTierPath Condition="'$(ServiceTierPath)' == ''">$(_CacheBase)/artifacts/$(_BCVersion)</ServiceTierPath>
+    <!-- An explicit AL_RUNNER_ARTIFACTS_ROOT outranks the incidental in-repo sandbox tree:
+         relocating the cache is a deliberate act, a leftover artifacts/sandbox/ directory in
+         the checkout is not, and the runtime gives the variable the same precedence. -->
+    <ServiceTierPath Condition="'$(AL_RUNNER_ARTIFACTS_ROOT)' == '' AND Exists('$(RepoRoot)/artifacts/sandbox/$(_BCVersion)/platform/ServiceTier/PFiles64/Microsoft Dynamics NAV/270/Service')">$(RepoRoot)/artifacts/sandbox/$(_BCVersion)/platform/ServiceTier/PFiles64/Microsoft Dynamics NAV/270/Service</ServiceTierPath>
+    <ServiceTierPath Condition="'$(ServiceTierPath)' == ''">$(_ArtifactsRoot)$(_BCVersion)</ServiceTierPath>
   </PropertyGroup>
 
   <!-- Common packages on every TFM -->

--- a/AlRunner/Infrastructure/BcArtifacts.cs
+++ b/AlRunner/Infrastructure/BcArtifacts.cs
@@ -5,7 +5,8 @@ namespace AlRunner.Infrastructure;
 /// process-global selected BC version.
 ///
 /// The runner downloads BC platform DLLs (Ncl/Types/Common/Language/CodeAnalysis +
-/// their runtime closure) to <c>~/.local/share/al-runner/artifacts/&lt;bc-version&gt;/</c>.
+/// their runtime closure) to <c>~/.local/share/al-runner/artifacts/&lt;bc-version&gt;/</c>,
+/// or under whatever root <see cref="ArtifactsRootEnvVar"/> names (issue #2578).
 /// The exact version is pinned by <c>AlRunner.csproj</c>'s <c>_BCVersion</c> at build
 /// time (those 5 DLLs are <c>&lt;Reference&gt;</c>d and CopyLocal'd into bin/), so the
 /// *engine* a given binary runs is fixed at build time. But the runtime artifact /
@@ -102,13 +103,77 @@ public static class BcArtifacts
 
     private static readonly object _lock = new();
 
-    // AlRunnerPaths.UserHome throws loudly (issue #2114) rather than silently handing back
-    // a relative path when $HOME names a directory that does not exist.
-    private static string ArtifactsRoot => Path.Combine(AlRunnerPaths.UserHome, ArtifactsRoot_Rel);
+    /// <summary>
+    /// Environment variable that relocates the artifacts root (issue #2578) — the directory
+    /// the per-version subdirectories live under, NOT one version's engine directory.
+    ///
+    /// <para>Before this existed the root was <c>Path.Combine(UserHome, ArtifactsRoot_Rel)</c>
+    /// and nothing else, so the only way to move the artifact cache off the home directory
+    /// was to move <c>$HOME</c> — which relocates every OTHER home-rooted path
+    /// (<c>~/.cache/al-runner</c>, <c>~/.bcartifacts.cache</c>,
+    /// <c>~/.local/share/al-runner/symbols</c>) at the same time. Useful when the cache has
+    /// to sit on a different volume from the home directory, and for CI runners that want it
+    /// on a mounted path.</para>
+    ///
+    /// <para>Distinct from <c>--artifact-path</c>, which pins ONE version's engine directory
+    /// and bypasses version selection entirely. This names the root that selection scans, so
+    /// <c>--bc-version</c>, latest-in-cache defaulting and provisioning all keep working —
+    /// they resolve through <see cref="ArtifactsRootDir"/> / <see cref="ArtifactDirFor"/>.</para>
+    ///
+    /// <para>Also read by <c>AlRunner.csproj</c> and <c>AlRunner.Tests.csproj</c> (MSBuild
+    /// surfaces environment variables as properties), which <c>&lt;Reference&gt;</c> the
+    /// service-tier DLLs out of the same root and hard-error when they are missing
+    /// (<c>FailIfBCServiceTierDllsMissing</c>). A variable the runtime honoured but the build
+    /// did not would leave a relocated cache unbuildable.</para>
+    /// </summary>
+    public const string ArtifactsRootEnvVar = "AL_RUNNER_ARTIFACTS_ROOT";
 
-    /// <summary>The per-user artifacts root (<c>~/.local/share/al-runner/artifacts</c>),
-    /// where each BC version lives in a version-named subdir. Public for the provisioning
-    /// flow, which downloads into <see cref="ArtifactDirFor"/> before selection runs.</summary>
+    private static string ArtifactsRoot =>
+        ResolveArtifactsRoot(
+            Environment.GetEnvironmentVariable(ArtifactsRootEnvVar),
+            static () => AlRunnerPaths.UserHome);
+
+    /// <summary>
+    /// Pure core of <see cref="ArtifactsRootDir"/>: <paramref name="envOverride"/> wins when
+    /// it is set to something non-blank, otherwise the historical
+    /// <c>&lt;home&gt;/.local/share/al-runner/artifacts</c>. Split out from the property (the
+    /// same shape <see cref="AlRunnerPaths.Validate"/> uses) so the resolution is unit-testable
+    /// without mutating the process-wide environment, which every parallel test in this repo
+    /// shares. Internal + <c>InternalsVisibleTo("AlRunner.Tests")</c>.
+    ///
+    /// <para><paramref name="userHome"/> is a callback, not a value, on purpose: an explicitly
+    /// named artifacts root must not be coupled to an unrelated resolution that can throw.
+    /// <see cref="AlRunnerPaths.UserHome"/> fails loudly when <c>$HOME</c> names a directory
+    /// that does not exist (issue #2114), and evaluating it eagerly would make THIS resolution
+    /// fail for a reason it does not depend on. (It does not follow that the whole run
+    /// survives a broken <c>$HOME</c> — <c>Program.cs</c>'s AL-output cache resolves
+    /// <see cref="AlRunnerPaths.UserHome"/> independently and still exits 2 there. The claim is
+    /// scoped to this resolution.)</para>
+    ///
+    /// <para>The override is absolutized. A relative root would never equal
+    /// <c>Path.Combine(ArtifactsRoot, version)</c> under
+    /// <see cref="TryTranslateArtifactPathToVersion"/>'s ordinal comparison, so every
+    /// <c>--artifact-path</c> naming a directory inside the (relocated) cache would silently
+    /// route onto the explicit-root branch instead of normal version selection. The trailing
+    /// separator is trimmed for the same comparison — <c>Path.GetFullPath</c> preserves one
+    /// when the caller typed it.</para>
+    /// </summary>
+    internal static string ResolveArtifactsRoot(string? envOverride, Func<string> userHome)
+    {
+        if (string.IsNullOrWhiteSpace(envOverride))
+            // AlRunnerPaths.UserHome throws loudly (issue #2114) rather than silently handing
+            // back a relative path when $HOME names a directory that does not exist.
+            return Path.Combine(userHome(), ArtifactsRoot_Rel);
+
+        // TrimEndingDirectorySeparator leaves a filesystem ROOT ("/", a drive root) alone,
+        // unlike a bare TrimEnd, which turns "/" into "" and hands back a relative path.
+        return Path.TrimEndingDirectorySeparator(Path.GetFullPath(envOverride.Trim()));
+    }
+
+    /// <summary>The per-user artifacts root (<c>~/.local/share/al-runner/artifacts</c>, or
+    /// <see cref="ArtifactsRootEnvVar"/> when set), where each BC version lives in a
+    /// version-named subdir. Public for the provisioning flow, which downloads into
+    /// <see cref="ArtifactDirFor"/> before selection runs.</summary>
     public static string ArtifactsRootDir => ArtifactsRoot;
 
     /// <summary>The artifact directory for a specific full version string.</summary>

--- a/AlRunner/ProgramSupport/CliText.cs
+++ b/AlRunner/ProgramSupport/CliText.cs
@@ -75,7 +75,8 @@ internal static partial class ProgramSupport
         w.WriteLine("    1. every --package-cache DIR you pass (repeatable)");
         w.WriteLine("    2. the bundle's own .alpackages/");
         w.WriteLine("    3. ~/.bcartifacts.cache");
-        w.WriteLine("    4. ~/.local/share/al-runner/artifacts   (the BC artifact cache)");
+        w.WriteLine("    4. ~/.local/share/al-runner/artifacts   (the BC artifact cache; set");
+        w.WriteLine("       AL_RUNNER_ARTIFACTS_ROOT to put it somewhere else)");
         w.WriteLine();
         w.WriteLine("  THE TRAP: a .app package may carry SYMBOLS ONLY (type/method signatures, no");
         w.WriteLine("  compiled bodies) or it may be CODE-BEARING. The AL compiler needs only symbols,");
@@ -668,6 +669,18 @@ internal static partial class ProgramSupport
         w.WriteLine("                          in-process, without running tests.");
         w.WriteLine();
         w.WriteLine("ENVIRONMENT");
+        w.WriteLine("  AL_RUNNER_ARTIFACTS_ROOT=DIR");
+        w.WriteLine("                               Put the BC artifact cache somewhere other than");
+        w.WriteLine("                               ~/.local/share/al-runner/artifacts, without moving");
+        w.WriteLine("                               $HOME (which would relocate every other cache too).");
+        w.WriteLine("                               DIR is the root the per-version subdirectories live");
+        w.WriteLine("                               under, so --bc-version, latest-in-cache defaulting");
+        w.WriteLine("                               and provisioning all still work — unlike");
+        w.WriteLine("                               --artifact-path, which pins ONE version's engine");
+        w.WriteLine("                               directory and skips version selection. A relative");
+        w.WriteLine("                               value is resolved against the current directory.");
+        w.WriteLine("                               Read by the build too, so a relocated cache stays");
+        w.WriteLine("                               buildable from source.");
         w.WriteLine("  AL_RUNNER_VERBOSE=1          Same as --verbose.");
         w.WriteLine("  AL_RUNNER_FAILURES_ONLY=1    Same as --failures-only.");
         w.WriteLine("  AL_RUNNER_TRACE_NRE=1        Log every first-chance NullReferenceException with");

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,9 @@ The version is `_BCVersion` in `AlRunner/AlRunner.csproj`, and the default artif
 `<user-home>/.local/share/al-runner/artifacts/<version>` (that same layout on Windows, under
 `%USERPROFILE%`). You do not have to look either up — the failing build prints the whole
 command, filled in, ready to paste. Set `-p:ServiceTierPath=...` to point at an artifact dir
-you already have instead.
+you already have instead, or `AL_RUNNER_ARTIFACTS_ROOT=<dir>` to move the whole cache (the
+root the per-version subdirectories live under) somewhere else — the build and the runner
+both read it, so the two never disagree about where the artifacts are.
 
 Once the DLLs are present neither provisioning target runs, and the plain build is all
 you need from then on:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -83,4 +83,39 @@
     <_BCVersion Condition="'$(_BCVersion)' == ''">28.1.49838.53910</_BCVersion>
   </PropertyGroup>
 
+  <!--
+    #2578: the BC artifacts root — the directory the per-version artifact subdirectories
+    live under — resolved ONCE here for every project in the tree.
+
+    Why the build cares at all: AlRunner.csproj and AlRunner.Tests.csproj both <Reference>
+    the BC service-tier DLLs straight out of <root>/<_BCVersion>/, and AlRunner.csproj's
+    FailIfBCServiceTierDllsMissing target hard-ERRORS when they are not there. An
+    AL_RUNNER_ARTIFACTS_ROOT that only the RUNTIME honoured would be a half-feature: a
+    developer or CI runner who relocated the cache onto another volume could run the
+    already-built runner but could not build it.
+
+    Declared here rather than per-project for the same reason _BCVersion above is — the two
+    projects carried byte-identical _CacheBase blocks and #2102 records what a second
+    hand-maintained copy of a BC path cost when the copies drifted.
+
+    MSBuild surfaces environment variables as properties, so AL_RUNNER_ARTIFACTS_ROOT needs
+    no plumbing to be visible here; -p:AL_RUNNER_ARTIFACTS_ROOT=<dir> works too. GetFullPath
+    mirrors BcArtifacts.ResolveArtifactsRoot's absolutization (a relative root would resolve
+    against whatever directory the build was launched from and silently disagree with the
+    runtime); EnsureTrailingSlash lets the version be appended without a second separator
+    whether or not the caller typed one.
+
+    ServiceTierPath itself is NOT set here: AlRunner.csproj layers an in-repo
+    artifacts/sandbox/ location on top of this default, and a caller-supplied
+    -p:ServiceTierPath must still win in both projects.
+  -->
+  <PropertyGroup>
+    <_ArtifactsRoot Condition="'$(AL_RUNNER_ARTIFACTS_ROOT)' != ''">$([System.IO.Path]::GetFullPath('$(AL_RUNNER_ARTIFACTS_ROOT)'))</_ArtifactsRoot>
+    <!-- USERPROFILE is the Windows equivalent of $HOME (SpecialFolder.UserProfile), which is
+         what AlRunnerPaths.UserHome resolves at runtime on each OS. -->
+    <_ArtifactsRoot Condition="'$(_ArtifactsRoot)' == '' AND $([MSBuild]::IsOSPlatform('Windows'))">$(USERPROFILE)/.local/share/al-runner/artifacts</_ArtifactsRoot>
+    <_ArtifactsRoot Condition="'$(_ArtifactsRoot)' == ''">$(HOME)/.local/share/al-runner/artifacts</_ArtifactsRoot>
+    <_ArtifactsRoot>$([MSBuild]::EnsureTrailingSlash('$(_ArtifactsRoot)'))</_ArtifactsRoot>
+  </PropertyGroup>
+
 </Project>

--- a/README.md
+++ b/README.md
@@ -212,7 +212,9 @@ that table is measurably empty, so a genuine bug against a populated table is ne
 as missing data. With `--test-data` already on, the line says instead why the table is still
 empty (refused, not in this backup, or empty in it).
 
-Environment variables: `AL_RUNNER_VERBOSE=1`, `AL_RUNNER_SHOW_PASS=1`, `AL_RUNNER_TRACE_NRE=1` (logs every first-chance NRE before AL `asserterror` swallows it), `AL_RUNNER_BCBAK` (path to the `bcbak` backup reader used by `--test-data`).
+Environment variables: `AL_RUNNER_VERBOSE=1`, `AL_RUNNER_SHOW_PASS=1`, `AL_RUNNER_TRACE_NRE=1` (logs every first-chance NRE before AL `asserterror` swallows it), `AL_RUNNER_BCBAK` (path to the `bcbak` backup reader used by `--test-data`), `AL_RUNNER_ARTIFACTS_ROOT` (see below).
+
+`AL_RUNNER_ARTIFACTS_ROOT=DIR` moves the BC artifact cache off the home directory — useful when it has to sit on a different volume, or on a mounted path on a CI runner. `DIR` is the root the per-version subdirectories live under (default `~/.local/share/al-runner/artifacts`), so `--bc-version`, latest-in-cache defaulting and provisioning keep working. That is what makes it different from `--artifact-path`, which pins one version's engine directory and skips version selection entirely. A relative value is resolved against the current directory. The build reads it too, so a relocated cache stays buildable from source. Moving `$HOME` instead would relocate every other runner path (`~/.cache/al-runner`, `~/.bcartifacts.cache`, `~/.local/share/al-runner/symbols`) along with it.
 
 ## Test Corpus
 


### PR DESCRIPTION
Closes #2578

## What changed

`BcArtifacts.ArtifactsRoot` was `Path.Combine(AlRunnerPaths.UserHome, ".local/share/al-runner/artifacts")` and nothing else, so the only way to move the BC artifact cache off the home directory was to move `$HOME` — which relocates every other home-rooted path (`~/.cache/al-runner`, `~/.bcartifacts.cache`, `~/.local/share/al-runner/symbols`) at the same time, and forces the caller to hand-spell the version-directory layout `BcArtifacts` owns.

`AL_RUNNER_ARTIFACTS_ROOT=DIR` names that root directly. `DIR` is the directory the per-version subdirectories live under, so `--bc-version`, latest-in-cache defaulting and provisioning all keep working — which is what makes it a different knob from `--artifact-path`, which pins one version's engine directory and skips version selection entirely.

**Where the root is resolved:** `AlRunner/Infrastructure/BcArtifacts.cs`. Everything downstream already went through it — `ArtifactsRootDir` / `ArtifactDirFor`, `SelectVersion`, `DefaultVersionPrefix`, `ProvisioningCheck.PlatformAppsDirFor`/`TestAppsDirFor` (which take the root as a parameter), and the ~15 `BcArtifacts.ArtifactsRootDir` call sites in `Program.cs` and `ProgramSupport/Provisioning.cs` — so one resolution change reaches all of them.

**Name:** `AL_RUNNER_ARTIFACTS_ROOT`, as the issue proposed. 47 existing variables use the `AL_RUNNER_` prefix; no new prefix invented.

**Absolutization** (`Path.GetFullPath`) plus a trailing-separator trim. The issue calls out the first half; the second is the same defect one character later. A relative or slash-suffixed root never equals `Path.Combine(ArtifactsRoot, version)` under `TryTranslateArtifactPathToVersion`'s ordinal comparison, so every `--artifact-path` naming a directory inside a relocated cache would silently route onto the explicit-root branch instead of normal version selection. `Path.TrimEndingDirectorySeparator` is used rather than a bare `TrimEnd`, which would turn `/` into `""` and hand every consumer a relative path.

## The build needed it too — it is not a runtime-only knob

`AlRunner.csproj` **and** `AlRunner.Tests.csproj` both `<Reference>` the six BC service-tier DLLs straight out of `<root>/<_BCVersion>/`, and `AlRunner.csproj`'s `FailIfBCServiceTierDllsMissing` target hard-**errors** when they are absent. A variable the runtime honoured but the build did not would be a half-feature: a developer or CI runner who relocated the cache onto another volume could run the already-built runner but could not build it, and the failing build's own remediation text would name a directory they had deliberately stopped using.

MSBuild surfaces environment variables as properties, so no plumbing was needed — but the two projects carried byte-identical `_CacheBase` blocks, and patching both is exactly the shape `#2102` records the cost of. `$(_ArtifactsRoot)` is now declared once in the repo-root `Directory.Build.props`, next to `_BCVersion`, for the same stated reason; both csprojs consume it. An explicitly set `AL_RUNNER_ARTIFACTS_ROOT` also outranks the incidental in-repo `artifacts/sandbox/` tree, matching the runtime's precedence — relocating the cache is a deliberate act, a leftover directory in a checkout is not.

## RED → GREEN

RED baseline was taken with `ResolveArtifactsRoot` present as a pure refactor of the old behaviour (home-rooted, override ignored), so every test ran for real instead of failing to compile:

```
Failed: 6, Passed: 9, Total: 15 (runtime-half revert). NOTE: an earlier draft of this body quoted 7/7/14, taken against an earlier version of the test file; the shipped file has 15 tests and that number is not reproducible against it. The build half reverts separately: both `Build_WithTheEnvVarSet_*` fail, both `Build_WithoutTheEnvVar_*` pass.
```

The 7 that passed in RED are the fallback direction — a fix that broke every existing box would have been caught there, which is the point of including them.

GREEN, after the change:

```
Passed!  - Failed: 0, Passed: 15, Skipped: 0, Total: 15, Duration: 1 s
```

`AlRunner.Tests/ArtifactsRootEnvOverrideTests.cs`, three layers:

1. **Pure resolver** — absolute value used verbatim, relative value absolutized and equal to the absolute spelling of the same directory, trailing separator trimmed, unset **and** blank (`export AL_RUNNER_ARTIFACTS_ROOT=`) falling back to `<home>/.local/share/al-runner/artifacts`, and the home provider never consulted when an override is set. Concrete expected strings, no `IsTrue(true)`.
2. **The real CLI, spawned as a subprocess** — three cases asserting the exact resolved path the runner reports (`BC artifact root not found: <dir>`): the variable set to a custom root resolves there and *not* under `$HOME`; unset still resolves under `$HOME`; a relative value reports the rooted path and never the bare relative string. The variable is set on the child's `ProcessStartInfo` only — mutating this process's environment would leak into every other test class spawning a runner concurrently (`maxParallelThreads: 4`).
3. **A positive end-to-end run** (`[SkippableFact]`, gated through `TestArtifacts`): the provisioned artifacts root is symlinked into a temp directory, and a real suite runs out of it — `1P/0F/0E`, exit 0, with the runner's own `[bc] selected BC 28.1.49838.53910 (/tmp/.../artifacts/28.1.49838.53910)` line naming the relocated path. `Path.GetFullPath` does not resolve symlinks, so the link target appearing there instead would mean the root came from somewhere other than the variable. This is the half a message-only assertion cannot show: version selection and the default package-cache/provisioning probes really follow the variable.
4. **The build** — `dotnet msbuild -getProperty:ServiceTierPath` on both csprojs (~1 s each, evaluation only), with and without the variable.

Also run: `CliDocumentationTests`, `HomeDirectoryMissingLoudFailureTests`, `AlRunnerPathsTests`, `TestArtifactsGateTests`, `BuildDeterminismTests`, `SilentSkipDetectorTests` (54 + 50 passed), and `BCVersionDefaultTests`, `PublishReleaseOrderingTests`, `RunnerVersionDefaultTests`, `ProvisionExplicitModesTests`, `MsBucketWorkflowTests` (32 passed) for the build-configuration surface. `dotnet build AlRunner.slnx -c Release` clean. The full `AlRunner.Tests` suite was **not** run locally; CI runs it on all 8 legs.

Manual confirmation of the whole pipeline, outside the suite:

```
$ AL_RUNNER_ARTIFACTS_ROOT=/tmp/relocated-artifacts-2578 al-runner --no-auto-provision tests/runner-extras/page-enum-control-modal
[bc] selected BC 28.1.49838.53910 (/tmp/relocated-artifacts-2578/28.1.49838.53910)
  -> 4P/0F/0E across 4 tests, 0 suite errors
```

## No upstream corpus test

This is runner configuration — where the CLI and the build resolve their own artifact cache. It asserts nothing about Business Central, so per `.claude/rules/bc-behavior-tests-go-upstream.md` it owes no `BusinessCentral.AL.Language.Tests` test and none was written.

## Documentation

- `--help` / `--guide` `ENVIRONMENT` section (`AlRunner/ProgramSupport/CliText.cs`), plus the `DEPENDENCIES` search-order list, which named the artifact cache without saying it could move.
- `README.md` environment-variables paragraph.
- `CONTRIBUTING.md`, next to the existing `-p:ServiceTierPath=...` advice, since that is where a contributor meets the build-time half.

## Fixing the shape, not just the reported line

- **Same wrong pattern at another call site?** Yes. `AlRunner.Tests.csproj` carried a byte-identical copy of `AlRunner.csproj`'s `_CacheBase` block, so patching only the one the issue points at would have left the test project's own BC `<Reference>` items pinned to the home-rooted path. Both now read one `$(_ArtifactsRoot)`.
- **Does a sibling function make the same assumption?** Yes, three, and they are **not** fixed here — filed as #2768: the curated symbols cache (`Provisioning.cs:199`, read again in `BcCompiler.ResolveSymbolDirs`), `CacheRoots.Resolve`'s `~/.cache/al-runner` fallback (which already has `--cache`/`--no-cache`), and `AlRunner.Tests/TestArtifacts.cs`, whose provisioning gate probes the home-rooted layout and would skip locally / fail a CI leg if the variable were ever set for a test run. None is the root the issue asks about, and widening into the test harness would have made this PR about something else.
- **Two paths writing the same state with different invariants?** That was the build-vs-runtime split, and it is the reason the csproj change is in this PR rather than a follow-up. Both now derive from one variable; `-p:ServiceTierPath=...` still wins over both, unchanged.

## Deliberately left out

- The `#2114` loud `$HOME` failure still offers only `--artifact-path` as its "bypass this resolution" escape hatch. Adding `AL_RUNNER_ARTIFACTS_ROOT` there would be **false**: `Program.cs` resolves `AlRunnerPaths.UserHome` independently for the AL-output cache and exits 2 before artifact selection, so setting the variable does not rescue a broken `$HOME`. The resolver's own doc comment scopes the claim explicitly rather than overstating it.
- No `--artifacts-root` CLI flag. The issue asks for an environment variable, and only an environment variable is visible to MSBuild without extra plumbing.

---

Implemented by agent `stma-auto-4` on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
