### PR TITLE
ci: add a single-leg diagnostic re-run, so the flake-evidence recipe works in this repo too

### DIFF
--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -54,8 +54,12 @@ reporting green from a stale run has happened at least four times. Confirm the c
 SHA matches local `HEAD` — a mismatch means "not yet reported," not "green." Never report a
 PR as done while its CI is still running.
 
-The one required check on `main` is **`All BC versions passed`**
-(`.github/workflows/test-matrix.yml`); matrix legs report as `bc-tests / BC <ver> (required)`.
+`main`'s ruleset requires exactly two contexts: **`All BC versions passed`**
+(`.github/workflows/test-matrix.yml`) and **`Tests updated`** (`pr-check.yml`). The matrix legs
+report as `bc-tests / BC <ver> (required)` — the `(required)` there is part of the job's own
+name and does NOT make the leg a required context; only the aggregate gates. That is why a
+single-leg diagnostic run cannot clear the gate, and why a red leg still blocks through the
+aggregate.
 
 Wait in the **foreground** — `tools/ci-wait.py`, or `gh run watch <run-id>`. Never end a turn
 while CI you are responsible for is still running (`no-backgrounding-long-commands.md`).
@@ -106,30 +110,57 @@ Both options below create a brand-new, separate workflow run. Neither touches th
 failed run or its log — that run and its log stay exactly as they were, so a diagnosis made
 from the original log is never at risk.
 
-**When the workflow exposes `workflow_dispatch` with a way to target one leg** — dispatch that
-leg directly against the failing ref, which still points at the same commit as long as nobody
-has pushed since:
+**Preferred — dispatch the one leg.** Cheapest by far: one leg instead of eight, against the
+ref that already carries the verdict (still the same commit as long as nobody has pushed
+since).
+
+In this repository, `.github/workflows/bc-leg-rerun.yml`:
 
 ```bash
-gh workflow run ci.yml --repo <owner>/<repo> --ref <branch> -f bc_version=28.4
+gh workflow run bc-leg-rerun.yml --repo StefanMaron/BusinessCentral.AL.Runner \
+  --ref <branch> -f bc-version=28.4
 ```
 
-`StefanMaron/BusinessCentral.AL.Language.Tests`' `.github/workflows/ci.yml` supports exactly
-this (`bc_version` input). It is how impl-4 got a second, independent verdict on corpus PR
-#144's BC 28.4 leg without disturbing the original: run 33962643816, dispatched against the
-same SHA that had just failed, came back 2495/2495 clean. **This repository's own
-`test-matrix.yml` / `bc-tests.yml` do not currently expose `workflow_dispatch`** — this exact
-recipe is not available here today (see "Not done here" below).
+`bc-version` is a prefix from `.github/bc-versions.txt`; an unknown one fails the run rather
+than resolving to an empty matrix. The leg does exactly the work that leg does on a normal
+run — `required` and `unit-tests` are still computed from the full version list, so a
+dispatched 28.0 leg does not suddenly run `AlRunner.Tests` that the real 28.0 leg skips.
 
-**When there is no per-leg dispatch (the case here, today)** — push an empty commit:
+In the AL-language corpus, `.github/workflows/ci.yml` (`bc_version` input):
+
+```bash
+gh workflow run ci.yml --repo StefanMaron/BusinessCentral.AL.Language.Tests \
+  --ref <branch> -f bc_version=28.4
+```
+
+That is how impl-4 got a second, independent verdict on corpus PR #144's BC 28.4 leg without
+disturbing the original: run 33962643816, dispatched against the same SHA that had just
+failed, came back 2495/2495 clean.
+
+**A single-leg dispatch cannot satisfy this repository's required check**, by construction:
+`All BC versions passed` is declared in `test-matrix.yml`, and `bc-leg-rerun.yml` does not
+contain that job at all, so there is no conclusion — not success, not `skipped` — for it to
+report. `AlRunner.Tests/BcLegRerunWorkflowTests.cs` holds that property in place. Treat the
+result as evidence for a human, never as a gate that has been cleared.
+
+**The corpus has no equivalent guarantee** — there the eight `BC <ver> / test` legs ARE the
+required contexts, so a dispatched leg reports a check run with the same name as the one that
+gated. Measured once, on corpus PR #144: the dispatch produced a second `BC 28.4 / test` check
+run with conclusion `success` on the same head SHA as the original `failure`, and the PR stayed
+`BLOCKED` with `gh pr checks --required` still reporting the failing one. So it did not clear
+the gate — but that is one observation of undocumented GitHub behaviour, not a rule. Never
+dispatch a corpus leg expecting it to turn a PR green, and check `gh pr checks --required`
+rather than assuming either way.
+
+**Fallback, when a workflow has no per-leg dispatch** — push an empty commit:
 
 ```bash
 git commit --allow-empty -m "chore: re-run CI to check a leg-set flake (no content change)"
 git push
 ```
 
-This is the AL Runner recipe until `test-matrix.yml` gains a `workflow_dispatch` trigger, if it
-ever does.
+Same tree, so it is still "the same code" by the rule above, but it spends a full eight-leg
+run in a queue shared across the whole account. Prefer the dispatch.
 
 ### What neither of these is
 
@@ -145,16 +176,16 @@ content-changing push on corpus PR #145, it moved the failing leg from BC 28.2 t
 without fixing anything, at roughly 8 minutes of the whole account's shared Actions queue per
 attempt. GitHub Actions concurrency is scoped per account, not per repository, so that cost is
 shared with every other repo and agent using the same account, not just this one. Nobody
-bypasses a red required check. The two recipes above are for finding out whether a failure is
+bypasses a red required check. The recipes above are for finding out whether a failure is
 real, not for making it go away.
 
-### Not done here: teaching a tool to dispatch this
+### Deliberately not in `tools/ci-wait.py`
 
 `tools/ci-wait.py` answers "has this PR's required check reported a verdict on its current
 head" — a different question from "get me an independent second run of this exact commit."
 Folding the dispatch recipe into it would conflate two different operations behind one tool, so
-it stays out for now. If this recipe gets used often enough to be worth automating, that is a
-new, narrowly-scoped tool, not an addition to `ci-wait.py`.
+it stays out. If this gets used often enough to be worth automating, that is a new,
+narrowly-scoped tool, not an addition to `ci-wait.py`.
 
 ## Sister rules
 

--- a/.github/workflows/bc-leg-rerun.yml
+++ b/.github/workflows/bc-leg-rerun.yml
@@ -1,0 +1,64 @@
+name: BC single-leg re-run (diagnostic)
+
+# One BC leg, on demand, against a ref that already has a verdict — the second
+# measurement `.claude/rules/ci-verdicts.md` section 5 requires before anyone may call a
+# failure a "pre-existing unrelated flake".
+#
+#   gh workflow run bc-leg-rerun.yml --repo StefanMaron/BusinessCentral.AL.Runner \
+#     --ref <branch> -f bc-version=28.4
+#
+# It exists because section 3 bans `gh run rerun` outright — a re-run overwrites the failed
+# run's log in place, and those logs have been the entire evidence base for real
+# investigations. This gives the same repeat measurement while leaving the original run and
+# its log untouched: a separate workflow run, its own log, nothing overwritten.
+#
+# ---------------------------------------------------------------------------------------
+# WHY THIS IS A SEPARATE FILE AND NOT A `workflow_dispatch:` ON test-matrix.yml
+# ---------------------------------------------------------------------------------------
+# `All BC versions passed` is the ONE required status check in main's branch ruleset (the
+# other is `Tests updated`; the individual `bc-tests / BC <ver>` legs are NOT required
+# contexts — verified against the live ruleset, not assumed). If a single-leg run could
+# report that context, one leg's green would satisfy a gate that means "all eight passed".
+# That is far worse than the flake it would be diagnosing.
+#
+# Adding `workflow_dispatch:` to test-matrix.yml could not be made safe by condition alone:
+# gating its `all-tests` job with an `if:` makes the job report `skipped` rather than not
+# report, and GitHub has historically treated a skipped check run as satisfying a required
+# check. The only durable guarantee is structural — this workflow does not contain the job
+# at all, so there is no conclusion, skipped or otherwise, for it to report. A test asserts
+# the string stays absent from this file.
+#
+# It also means a dispatch cannot disturb a normal run: no `push` or `pull_request` trigger
+# here, a distinct workflow name (so a distinct default concurrency group from
+# test-matrix.yml's `${{ github.workflow }}-${{ github.ref }}`), and `cancel-in-progress:
+# false` so two diagnostic runs of different legs on one branch do not cancel each other.
+#
+# The calling job is named `single-leg`, not `bc-tests`, so its legs report as
+# `single-leg / BC <ver> (required)` — visibly distinct from the pull-request path's
+# `bc-tests / BC <ver> (required)` in `gh pr checks` output. Measured on the corpus repo,
+# a dispatched run's check runs did not replace the pull-request run's verdict for the
+# same context name on the same SHA; but that is one observation of undocumented GitHub
+# behaviour, so nothing here relies on it.
+
+on:
+  workflow_dispatch:
+    inputs:
+      bc-version:
+        description: 'BC version prefix from .github/bc-versions.txt, e.g. 28.4'
+        required: true
+        type: string
+
+concurrency:
+  # Per leg, not per ref: re-running 28.4 must not cancel a 27.3 diagnostic on the same
+  # branch. cancel-in-progress is false because each run IS the measurement — cancelling
+  # one to start another would throw away the data point this workflow exists to collect.
+  group: bc-leg-rerun-${{ github.ref }}-${{ inputs.bc-version }}
+  cancel-in-progress: false
+
+jobs:
+  single-leg:
+    # Delegates to the same shared definition test-matrix.yml and publish.yml call, so a
+    # diagnostic leg runs the real leg and not a copy of it that can drift (#1976).
+    uses: ./.github/workflows/bc-tests.yml
+    with:
+      bc-version-filter: ${{ inputs.bc-version }}

--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -30,6 +30,31 @@ on:
         type: string
         required: false
         default: ''
+      bc-version-filter:
+        description: >-
+          Run ONE leg instead of the whole matrix: a prefix from
+          .github/bc-versions.txt, e.g. "28.4". Empty (the default) is the full
+          matrix, which is what BOTH gating callers use — test-matrix.yml and
+          publish.yml never set this, so the push / pull-request / release paths
+          resolve exactly the list they resolved before this input existed.
+
+          The only caller that sets it is bc-leg-rerun.yml, the diagnostic
+          single-leg re-run that `.claude/rules/ci-verdicts.md` section 5 points
+          at for flake evidence. That workflow deliberately does NOT contain the
+          aggregate job that reports main's required status check, so a
+          single-leg run cannot satisfy that gate with one leg's result. (The
+          check's name is spelled out in test-matrix.yml and deliberately not
+          here — ReleaseTestParityTests asserts this file never names it, so
+          that the job cannot quietly migrate into the reusable workflow and
+          change the context's name.)
+
+          A non-empty value narrows the matrix ONLY. Every per-leg attribute
+          (`required`, `unit-tests`) is still computed from the FULL list below,
+          so a dispatched leg does exactly the work that same leg does on a
+          normal run rather than a subtly different job.
+        type: string
+        required: false
+        default: ''
     outputs:
       required-version:
         description: >-
@@ -78,6 +103,12 @@ jobs:
           dotnet-version: '8.0.x'
       - name: Resolve BC versions
         id: resolve
+        # Via env, never interpolated straight into the script body: a `${{ }}` expansion
+        # inside `run:` is textual substitution before bash ever sees it, so a crafted
+        # dispatch input would run as shell. Only users with write access can dispatch,
+        # but the mitigation costs one line.
+        env:
+          BC_VERSION_FILTER: ${{ inputs.bc-version-filter }}
         run: |
           # Each prefix in bc-versions.txt → one matrix entry {bc-version, required}.
           #
@@ -119,6 +150,31 @@ jobs:
                             printf '%s\n' $BC_PREFIXES | grep "^${major}\." | sort -V | tail -1
                           done | tr '\n' ' ')
           echo "Primary prefix: $PRIMARY_PREFIX | unit-test prefixes: $UNIT_PREFIXES"
+
+          # Single-leg narrowing for the diagnostic dispatch (bc-leg-rerun.yml). Applied
+          # HERE, after PRIMARY_PREFIX and UNIT_PREFIXES are derived from the FULL list
+          # above and before the resolve loop below — so a dispatched leg carries the same
+          # `required` and `unit-tests` flags it carries on a normal 8-leg run. Narrowing
+          # before those two were computed would silently hand a single-leg run a different
+          # job than the leg it is supposed to be reproducing, which would make it useless
+          # as flake evidence: AlRunner.Tests runs on 2 of the 8 legs, not all 8 (#2674).
+          #
+          # Unknown prefixes fail the run rather than resolving to an empty matrix. An empty
+          # matrix means the `test` job never runs, and a workflow whose only real job never
+          # ran still reports success — the silent-no-op shape this repo has been bitten by
+          # repeatedly (#1976, #2065).
+          if [ -n "${BC_VERSION_FILTER:-}" ]; then
+            case " $BC_PREFIXES " in
+              *" $BC_VERSION_FILTER "*)
+                echo "Single-leg run: narrowing to '$BC_VERSION_FILTER' (was: $BC_PREFIXES)"
+                BC_PREFIXES="$BC_VERSION_FILTER"
+                ;;
+              *)
+                echo "::error::bc-version-filter '$BC_VERSION_FILTER' is not a prefix in .github/bc-versions.txt ($BC_PREFIXES)"
+                exit 1
+                ;;
+            esac
+          fi
 
           ENTRIES="[]"
           for prefix in $BC_PREFIXES; do
@@ -507,6 +563,16 @@ jobs:
   smoke:
     name: Smoke ${{ matrix.tfm }}
     needs: resolve-versions
+    # Skipped only on a single-leg diagnostic dispatch (bc-version-filter set). Two
+    # reasons, and the first is correctness rather than cost: `required-version` is
+    # emitted by the resolve loop only for the PRIMARY prefix, and a filtered run that
+    # narrowed to any OTHER prefix never reaches that branch, so this job would build
+    # against an empty version. The second is that a single-leg re-run exists to repeat
+    # ONE leg's measurement cheaply; smoke and pack are not that leg.
+    #
+    # Both gating callers (test-matrix.yml, publish.yml) leave the filter empty, so this
+    # condition is true on every push, pull request and release exactly as before.
+    if: inputs.bc-version-filter == ''
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -577,6 +643,11 @@ jobs:
   pack:
     name: Release pack (dry, no publish)
     needs: resolve-versions
+    # Same reasoning as `smoke` above: this job reads
+    # needs.resolve-versions.outputs.required-version and versions-json, both of which a
+    # single-leg run narrows or leaves empty. Empty on every gating path, so unchanged
+    # for push / pull request / release.
+    if: inputs.bc-version-filter == ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/AlRunner.Tests/BcLegRerunWorkflowTests.cs
+++ b/AlRunner.Tests/BcLegRerunWorkflowTests.cs
@@ -1,0 +1,137 @@
+// Issue #2649 follow-up: .github/workflows/bc-leg-rerun.yml re-runs ONE BC leg on demand,
+// so `.claude/rules/ci-verdicts.md` section 5's flake-evidence standard ("a changing
+// failing-leg set across two independent runs of the same code") can be satisfied without
+// `gh run rerun`, which section 3 bans because it overwrites the failed run's log in place.
+//
+// The reason this needs a guard rather than a comment: `All BC versions passed` is the ONE
+// required status check in main's branch ruleset (verified against the live ruleset — the
+// other required context is `Tests updated`, and the individual `bc-tests / BC <ver>` legs
+// are NOT required). If a SINGLE-leg run could report that context, one leg's green would
+// satisfy a gate whose entire meaning is "all eight passed". That is a false green on the
+// one check protecting main, and it is strictly worse than the flake it would be helping
+// diagnose.
+//
+// The protection is structural, not conditional, and that distinction is the point:
+// gating the aggregate job with an `if:` inside a dispatch-capable test-matrix.yml would
+// make it report `skipped`, and GitHub has historically treated a skipped check run as
+// SATISFYING a required check. So the aggregate job must not exist in the dispatch path at
+// all — which is only true as long as the single-leg workflow stays a separate file that
+// never declares it. That is what these tests hold in place.
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class BcLegRerunWorkflowTests
+{
+    private static readonly string WorkflowDir = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".github", "workflows"));
+
+    private const string Workflow = "bc-leg-rerun.yml";
+    private const string RequiredCheckJobName = "All BC versions passed";
+
+    private static string Read(string name)
+    {
+        var path = Path.Combine(WorkflowDir, name);
+        Assert.True(File.Exists(path), $"expected workflow {name} at {path}");
+        return File.ReadAllText(path);
+    }
+
+    private static string CodeOnly(string text) =>
+        string.Join('\n', text.Split('\n').Where(l => !l.TrimStart().StartsWith('#')));
+
+    [Fact]
+    public void SingleLegRerun_IsManualDispatchOnly()
+    {
+        // A `push` or `pull_request` trigger here would run a SECOND matrix on every commit,
+        // doubling the account-wide Actions queue this repo already contends for, and would
+        // put a single-leg run on the same events the real gate uses.
+        Assert.Equal(new[] { "workflow_dispatch" }, WorkflowTriggers.TriggersOf(Read(Workflow)));
+    }
+
+    [Fact]
+    public void SingleLegRerun_NeverDeclaresTheRequiredAggregateCheck()
+    {
+        // The load-bearing assertion. Matches the job-name FORM (`name: <context>`) rather
+        // than the bare string, so the file's own comments may explain the constraint
+        // without tripping the guard that enforces it.
+        var code = CodeOnly(Read(Workflow));
+
+        Assert.DoesNotMatch(new Regex(@"name:\s*" + Regex.Escape(RequiredCheckJobName)), code);
+    }
+
+    [Fact]
+    public void RequiredAggregateCheck_IsStillDeclaredExactlyOnce_InTestMatrixOnly()
+    {
+        // The mirror image: the guard above is worthless if the aggregate job stops existing
+        // on the gating path, which would leave main's ruleset requiring a context that never
+        // reports — a permanently pending check that blocks every pull request.
+        Assert.Matches(new Regex(@"name:\s*" + Regex.Escape(RequiredCheckJobName)),
+            CodeOnly(Read("test-matrix.yml")));
+    }
+
+    [Fact]
+    public void SingleLegRerun_DelegatesToTheSharedMatrix_AndNarrowsItByVersion()
+    {
+        // Delegation, not a copy: a diagnostic leg has to run the REAL leg or its verdict
+        // says nothing about the leg that failed (#1976 is the record of what a second
+        // hand-maintained copy of these steps costs).
+        var code = CodeOnly(Read(Workflow));
+
+        Assert.Contains(WorkflowParity.DelegationMarker, code, StringComparison.Ordinal);
+        Assert.Contains("bc-version-filter:", code, StringComparison.Ordinal);
+        Assert.Empty(WorkflowParity.FindInlinedBcTestSteps(code));
+    }
+
+    [Fact]
+    public void SingleLegRerun_UsesADistinctCallingJobName_SoItsLegContextsDoNotCollide()
+    {
+        // A check's context is the leg name qualified by the CALLING job. Naming this job
+        // `bc-tests` would make a diagnostic leg report the identical context to the
+        // pull-request path's (`bc-tests / BC <ver> (required)`) on the same head SHA.
+        // Those legs are not required contexts, so that would not block a merge — but it
+        // would make `gh pr checks` ambiguous about which run a verdict came from, which is
+        // the stale-verdict trap ci-verdicts.md section 2 already exists for.
+        var jobs = WorkflowParity.SplitJobs(CodeOnly(Read(Workflow)));
+
+        Assert.DoesNotContain("bc-tests", jobs.Keys);
+        Assert.Single(jobs);
+    }
+
+    [Fact]
+    public void SingleLegRerun_DoesNotCancelInProgressRuns()
+    {
+        // Each run IS the measurement. `cancel-in-progress: true` would let a second
+        // diagnostic dispatch destroy the data point the first one was collecting — the
+        // same evidence-destruction this whole mechanism exists to avoid.
+        var code = CodeOnly(Read(Workflow));
+
+        Assert.Matches(new Regex(@"cancel-in-progress:\s*false"), code);
+    }
+
+    [Fact]
+    public void SharedMatrix_DefaultsTheVersionFilterToEmpty_SoGatingCallersAreUnchanged()
+    {
+        // The filter narrows the matrix, so its default is what keeps every gating path
+        // resolving all eight legs. A non-empty default would silently reduce main's gate
+        // to one version.
+        var shared = Read(WorkflowParity.SharedWorkflow);
+        var filterBlock = Regex.Match(
+            shared, @"bc-version-filter:.*?default:\s*''", RegexOptions.Singleline);
+
+        Assert.True(filterBlock.Success,
+            "bc-tests.yml must declare bc-version-filter with an empty default — a non-empty "
+            + "default would narrow the required matrix for push, pull_request and release.");
+    }
+
+    [Fact]
+    public void GatingCallers_NeverSetTheVersionFilter()
+    {
+        // test-matrix.yml gates main; publish.yml gates a release. Either one passing a
+        // filter would mean the eight-leg promise is not what actually ran.
+        foreach (var caller in new[] { "test-matrix.yml", "publish.yml" })
+        {
+            Assert.DoesNotContain("bc-version-filter", CodeOnly(Read(caller)), StringComparison.Ordinal);
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #2649 / #2759. Not a `Closes` — #2759 already closes that issue; this finishes the job it exposed.

## Stacking note

Based on `agent/impl-7/issue-2649` (PR #2759), not `main`, so the diff here is only this change. #2759 is armed for auto-merge and edits the same rule file; basing on `main` would have shown its diff a second time. When #2759 merges and its branch is deleted, GitHub retargets this PR to `main`.

## Why

#2759 documented a per-leg dispatch as the way to get a second independent run of the same commit without `gh run rerun` — but it only worked in the AL-language corpus. This repository had no `workflow_dispatch` anywhere in `test-matrix.yml` or `bc-tests.yml`, so the rule pointed at a good recipe that does not work here and a worse one (an empty commit, a full eight-leg run in an account-wide queue) that does.

## The safety analysis, which changed the design

I checked the live ruleset rather than assuming. `main` requires exactly **two** contexts:

```
[{"context":"All BC versions passed"},{"context":"Tests updated"}]
```

The matrix legs are **not** required contexts — the `(required)` inside `bc-tests / BC <ver> (required)` is part of the job's own name, not a status. So the only thing that could turn a one-leg run into a false green on `main` is the aggregate context, and the whole design is arranged so a single-leg run cannot report it.

**Adding `workflow_dispatch:` to `test-matrix.yml` could not be made safe by condition alone.** Gating its `all-tests` job with an `if:` makes the job report `skipped` rather than not report, and GitHub has historically treated a skipped check run as *satisfying* a required check — so the obvious "safe" version of that approach is the dangerous one. The only durable guarantee is structural: a separate workflow that does not contain the aggregate job at all, so there is no conclusion of any kind for it to report.

## What changed

**`.github/workflows/bc-leg-rerun.yml`** (new) — `workflow_dispatch` only, one `bc-version` input, delegating to `bc-tests.yml`. No `push`/`pull_request` trigger, so it never runs on ordinary events. Own concurrency group with `cancel-in-progress: false`, so a diagnostic dispatch can neither cancel a PR's in-flight matrix nor cancel a diagnostic for another leg. Calling job named `single-leg`, not `bc-tests`, so its legs report a visibly distinct context.

**`.github/workflows/bc-tests.yml`** — one new `workflow_call` input, `bc-version-filter`, default `''`. Empty is today's behaviour exactly, and neither gating caller sets it.

- Narrowing is applied **after** `PRIMARY_PREFIX`/`UNIT_PREFIXES` are derived from the full list, so a dispatched leg carries the same `required` and `unit-tests` flags as on a normal run. This matters concretely: I simulated the real selection logic against `.github/bc-versions.txt`, and a filtered `28.0` correctly keeps `unit-tests=False`. Narrowing earlier would have flipped it to `True` and made the diagnostic a different job from the leg it is meant to reproduce — useless as evidence, and silently so.
- An unknown prefix exits 1 rather than resolving to an empty matrix. A workflow whose only real job never ran still reports success, which is the silent-no-op shape this repo has been bitten by before (#1976, #2065).
- `smoke` and `pack` are skipped on a filtered run. Both read `required-version`, which the resolve loop emits only for the primary prefix — the same simulation shows a `27.5` filter produces no `required-version` at all, so those jobs would build against an empty version. This is a real coupling, not a precaution.
- The input is read through `env:` rather than interpolated into the `run:` body, so a dispatch input cannot become shell.

**`AlRunner.Tests/BcLegRerunWorkflowTests.cs`** (new) — 8 guards over the properties above.

**`.claude/rules/ci-verdicts.md`** — per-leg dispatch is now the primary recipe with the command for this repo; the empty commit is documented as the fallback. Section 2 is also corrected: it claimed the legs were required contexts, which the ruleset says they are not.

## RED → GREEN

Each guard was checked against the mutation it exists to catch, not just observed passing:

| mutation | result |
|---|---|
| inject an `All BC versions passed` job into `bc-leg-rerun.yml` | **2 guards fail** (`NeverDeclaresTheRequiredAggregateCheck`, `UsesADistinctCallingJobName`) |
| add a `pull_request:` trigger to `bc-leg-rerun.yml` | **1 guard fails** (`IsManualDispatchOnly`) |
| change `bc-version-filter`'s default to `'28.4'` | **1 guard fails** (`DefaultsTheVersionFilterToEmpty`) |
| none (as committed) | **8/8 pass** |

Existing workflow guards still pass — `ReleaseTestParityTests`, `PublishReleaseOrderingTests`, `MsBucketWorkflowTests` and the new class together: **37 passed, 0 failed**.

Worth recording: an earlier draft of the `bc-tests.yml` comment spelled out the required check's name, which broke `ReleaseTestParityTests`' existing assertion that the reusable workflow never names it (so the job cannot quietly migrate and rename the context). Caught by running that suite, not by reading it.

## One thing deliberately not claimed

In the corpus the legs **are** the required contexts, so a dispatched leg there reports a check run with the same name as the one that gated. Measured once, on corpus PR #144: the dispatch produced a `success` check run alongside the original `failure` on the same head SHA, and the PR stayed `BLOCKED` with `gh pr checks --required` still reporting the failing one. So it did not clear the gate — but that is one observation of undocumented GitHub behaviour. The rule now says exactly that rather than presenting it as a guarantee, and nothing in this repository's design depends on it.

## What I could not verify

I have not dispatched this workflow, because it does not exist until this merges — `workflow_dispatch` is only offered for workflows present on the default branch. The first real dispatch is the remaining unknown. Everything checkable without running it has been checked: YAML parses, the selection logic simulated across all eight prefixes plus an invalid one, and the guards RED→GREEN.

---
Written by Claude Code agent impl-7. Off the (impl-1, impl-2) identity pool for this session — flagging per the workflow contract so the drift is visible.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
