### PR TITLE
fix(testpage): fall back to the source table field's OnLookup trigger

### DIFF
--- a/AlRunner.Tests/TestPageFieldTableLookupTests.cs
+++ b/AlRunner.Tests/TestPageFieldTableLookupTests.cs
@@ -1,0 +1,223 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Runner-mechanism test for issue #2549: <c>TestPage.Field.Lookup()</c> refused
+/// <c>testpage-lookup</c> for any field whose PAGE CONTROL declared no OnLookup, even when the
+/// field's own TABLE declared one.
+///
+/// <para>AL spells OnLookup two unrelated ways — <c>trigger OnLookup(var Text: Text): Boolean</c>
+/// on a page control, and a parameterless <c>trigger OnLookup()</c> on a table field that writes
+/// into <c>Rec</c> itself. Real BC tries the control first, then the table field, then the
+/// TableRelation lookup UI. <c>RunnerPageInstance.RaiseOnLookup</c> implemented only the first
+/// and refused as soon as it missed, so a field whose table carries the lookup was refused as if
+/// it had no lookup at all — even though the handler was already wired onto the metafield by
+/// <c>RecordPatches.NclMetaTableBuilder</c> and nothing ever dispatched it.</para>
+///
+/// <para>Only the third case is genuinely out of scope: a field with neither trigger gets its
+/// lookup from a TableRelation, which on real BC opens the related table's list page. That one
+/// must keep refusing, and the last test here is what stops a fix for the first two from
+/// quietly turning the refusal into a no-op — which is the failure mode
+/// <c>.claude/rules/loud-failures.md</c> exists for.</para>
+///
+/// <para>The BC-behaviour half of this claim — that BC runs the table field's trigger, and that
+/// a control trigger wins over it — is adjudicated upstream in the al-language corpus per
+/// <c>.claude/rules/bc-behavior-tests-go-upstream.md</c>. This test exists so a regression in
+/// the runner's own dispatch fails here too, without waiting on the submodule pin.</para>
+///
+/// <para>No <c>"application"</c> in the fixture manifest (see
+/// <c>.claude/rules/no-base-app-in-csharp-tests.md</c>): each AL test raises its own Error() with
+/// the value it observed, so the runner's PASS/FAIL output is the assertion surface.</para>
+/// </summary>
+public class TestPageFieldTableLookupTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(string bundle)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" \"").Append(bundle).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private static string WriteBundle()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-testpage-field-table-lookup-2549", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        File.WriteAllText(Path.Combine(root, "app.json"), """
+        {
+          "id": "c2549000-0000-4000-8000-000000002549",
+          "name": "TestPageFieldTableLookup2549",
+          "publisher": "Repro2549",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62560, "to": 62569 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        // Three fields, one per case the dispatch has to tell apart. Each trigger writes a
+        // value that names WHERE it ran, so a failure reports which handler fired rather than
+        // only that the wrong one did.
+        File.WriteAllText(Path.Combine(root, "TftlRow.Table.al"), """
+        table 62560 "Tftl Row"
+        {
+            DataClassification = CustomerContent;
+            fields
+            {
+                field(1; "No."; Code[20]) { }
+                // Table trigger only: the page control over this field declares nothing.
+                field(2; "Table Only"; Code[20])
+                {
+                    trigger OnLookup()
+                    begin
+                        "Table Only" := 'FROM-TABLE';
+                    end;
+                }
+                // BOTH: the control also declares one, and the control must win.
+                field(3; Both; Code[20])
+                {
+                    trigger OnLookup()
+                    begin
+                        Both := 'FROM-TABLE';
+                    end;
+                }
+                // Neither: the lookup would come from the TableRelation, i.e. from a list page
+                // the runner cannot stand up. Must keep refusing.
+                field(4; "Relation Only"; Code[20])
+                {
+                    TableRelation = "Tftl Row"."No.";
+                }
+            }
+            keys { key(PK; "No.") { Clustered = true; } }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(root, "TftlCard.Page.al"), """
+        page 62561 "Tftl Card"
+        {
+            PageType = Card;
+            SourceTable = "Tftl Row";
+            ApplicationArea = All;
+            UsageCategory = None;
+
+            layout
+            {
+                area(Content)
+                {
+                    field("No."; Rec."No.") { ApplicationArea = All; }
+                    field("Table Only"; Rec."Table Only") { ApplicationArea = All; }
+                    field(Both; Rec.Both)
+                    {
+                        ApplicationArea = All;
+                        trigger OnLookup(var Text: Text): Boolean
+                        begin
+                            Text := 'FROM-CONTROL';
+                            exit(true);
+                        end;
+                    }
+                    field("Relation Only"; Rec."Relation Only") { ApplicationArea = All; }
+                }
+            }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(root, "TftlTests.Codeunit.al"), """
+        codeunit 62562 "Tftl Tests"
+        {
+            Subtype = Test;
+
+            local procedure OpenOn(var Card: TestPage "Tftl Card")
+            var
+                Row: Record "Tftl Row";
+            begin
+                Row.DeleteAll();
+                Row.Init();
+                Row."No." := 'R1';
+                Row.Insert();
+                Card.OpenEdit();
+                Card.GoToRecord(Row);
+            end;
+
+            [Test]
+            procedure TableFieldOnLookupRunsWhenTheControlDeclaresNone()
+            var
+                Card: TestPage "Tftl Card";
+            begin
+                OpenOn(Card);
+                Card."Table Only".Lookup();
+                if Card."Table Only".Value <> 'FROM-TABLE' then
+                    Error('table field OnLookup did not run: field reads %1', Card."Table Only".Value);
+                Card.Close();
+            end;
+
+            [Test]
+            procedure ControlOnLookupWinsOverTheTableFieldTrigger()
+            var
+                Card: TestPage "Tftl Card";
+            begin
+                OpenOn(Card);
+                Card.Both.Lookup();
+                if Card.Both.Value <> 'FROM-CONTROL' then
+                    Error('the control trigger must win over the table field trigger, field reads %1', Card.Both.Value);
+                Card.Close();
+            end;
+
+            [Test]
+            procedure FieldWithNeitherTriggerStillRefuses()
+            var
+                Card: TestPage "Tftl Card";
+            begin
+                OpenOn(Card);
+                asserterror Card."Relation Only".Lookup();
+                if StrPos(GetLastErrorText(), 'testpage-lookup') = 0 then
+                    Error('a TableRelation-only lookup must still refuse by name, got: %1', GetLastErrorText());
+                Card.Close();
+            end;
+        }
+        """);
+
+        return root;
+    }
+
+    /// <summary>
+    /// All three cases on one bundle. Splitting them would let a fix that dispatches the table
+    /// trigger for EVERY field — turning the third case's loud refusal into a silent no-op —
+    /// pass two tests out of three and look like progress.
+    /// </summary>
+    [SkippableFact]
+    public void FieldLookup_FallsBackToTheTableFieldTrigger_ButOnlyWhenOneExists()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, exit) = RunRunner(WriteBundle());
+
+        Assert.True(exit == 0, $"Expected the bundle to pass; exit={exit}\n{output}");
+        Assert.Contains("PASS  Codeunit62562.TableFieldOnLookupRunsWhenTheControlDeclaresNone", output);
+        Assert.Contains("PASS  Codeunit62562.ControlOnLookupWinsOverTheTableFieldTrigger", output);
+        Assert.Contains("PASS  Codeunit62562.FieldWithNeitherTriggerStillRefuses", output);
+        Assert.DoesNotContain("FAIL", output);
+    }
+}

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -2299,7 +2299,12 @@ internal sealed class LiveNavTestField : ITestField
 
         // BC's contract: the trigger writes the selection back and returns true; a false
         // return means the user cancelled and the field keeps its value.
-        var picked = _page.RaiseOnLookup(_controlId, NavText.Create(Value));
+        // The record and field number go with the call so RaiseOnLookup can fall back to the
+        // SOURCE TABLE FIELD's own OnLookup when the control declares none (#2549). A table
+        // trigger writes into Rec rather than handing a value back, which is why the null it
+        // returns for that path needs no special handling here: the Value getter reads the
+        // record, where the trigger already wrote.
+        var picked = _page.RaiseOnLookup(_controlId, NavText.Create(Value), _record, _fieldNo);
         if (picked != null) Value = picked.ToString();
     }
 

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -1134,6 +1134,51 @@ public static partial class RecordPatches
     private static PropertyInfo? _pOnAfterValidateHandlers;
     private static Type? _tFieldTriggerHandlerListClosed;
 
+    /// <summary>
+    /// Whether the table field <paramref name="fieldNo"/> declares an <c>OnLookup</c> trigger:
+    /// true when one is wired onto its metafield, false when none is, and <b>null when this
+    /// cannot be determined</b> against the BC build in use.
+    ///
+    /// <para>#2549. The three-valued answer is the point. A caller that refuses when this says
+    /// false is telling the developer "neither your control nor your table declares an OnLookup",
+    /// which is a statement about their AL — and it would be a lie if the real reason were that
+    /// reflection could not find BC's backing field on a build whose shape moved. Those two
+    /// outcomes need different messages, so they get different values rather than a bool that
+    /// collapses them.</para>
+    ///
+    /// <para>Existence only. Running the trigger goes through BC's own public
+    /// <c>NavRecord.LookupAsync(int)</c>, which resolves the handler again via
+    /// <c>GetFieldTriggerHandler</c> — and that method returns null for an untyped
+    /// <c>NavRecord</c> (BC will not fire a field trigger on one) and calls
+    /// <c>EnsureGlobalVariablesInitialized()</c> before handing a handler back. Invoking the
+    /// handler read here directly would skip both, so a table <c>OnLookup</c> that touches a
+    /// global would run against uninitialized ones. Decompiled from BC 28.1; the method body is
+    /// byte-identical on 27.0 through 28.4 (compare_symbols, bodyChanged=false).</para>
+    ///
+    /// <para>Reads the backing fields rather than the internal <c>NCLMetaField.LookupHandler</c>
+    /// property so the probe cannot itself construct an <c>EventTriggerData</c> as a side effect
+    /// of asking whether one exists — a null backing field means no handler was ever set, which
+    /// is exactly the question.</para>
+    /// </summary>
+    internal static bool? TryHasFieldLookupTrigger(NavRecord record, int fieldNo)
+    {
+        try
+        {
+            EnsureFieldTriggerReflection();
+            if (_fEventTriggerDataValueBacking == null || _fLookupHandlerBacking == null) return null;
+            if (!record.MetaTable.TryGetFieldByNo(fieldNo, out var metaField)) return false;
+            var etd = _fEventTriggerDataValueBacking.GetValue(metaField);
+            if (etd == null) return false;
+            return _fLookupHandlerBacking.GetValue(etd) != null;
+        }
+        catch (Exception)
+        {
+            // Any reflection failure is "cannot determine", never "no trigger" — see the
+            // three-valued note above.
+            return null;
+        }
+    }
+
     private static void EnsureFieldTriggerReflection()
     {
         if (_tFieldTriggerHandlerAttr != null) return;

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -1180,14 +1180,13 @@ internal sealed class RunnerPageInstance
     /// name rather than doing nothing — doing nothing let a test invoke a lookup, observe no
     /// change, and compare two empty strings successfully.
     /// </summary>
-    internal NavText? RaiseOnLookup(int controlId, NavText current)
+    internal NavText? RaiseOnLookup(int controlId, NavText current,
+        NavRecord? sourceRecord = null, int sourceFieldNo = 0)
     {
-        var trigger = FindTrigger(controlId, "_OnLookup", "OnLookup", arity: 1)
-            ?? throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                $"TestPage lookup on control {controlId} (page {_pageId})",
-                "testpage-lookup — the control declares no OnLookup trigger, so its lookup comes "
-                + "from a TableRelation and would open the related table's list page, which the "
-                + "runner cannot stand up. See docs/scope.md");
+        var found = FindTrigger(controlId, "_OnLookup", "OnLookup", arity: 1);
+        if (found == null)
+            return RaiseSourceFieldOnLookup(controlId, sourceRecord, sourceFieldNo);
+        var trigger = found.Value;
 
         var value = current;
         var byRef = new ByRef<NavText>(() => value, v => value = v);
@@ -1204,6 +1203,69 @@ internal sealed class RunnerPageInstance
         }
 
         return result is true ? value : null;
+    }
+
+    /// <summary>
+    /// The second of the three places AL can put a lookup, tried when the page control has no
+    /// OnLookup trigger of its own: the SOURCE TABLE FIELD's <c>trigger OnLookup()</c>.
+    ///
+    /// <para>#2549. These are two unrelated triggers that share a name. The control's takes
+    /// <c>var Text: Text</c> and returns Boolean — the return value is how "the user cancelled"
+    /// is expressed, and the text it wrote back is what replaces the field's value. The table
+    /// field's is parameterless and writes into <c>Rec</c> itself, so there is nothing to hand
+    /// back and nothing to gate on: this returns null, and the caller reads the field's value
+    /// off the record, where the trigger already put it. Returning null is not "cancelled" here,
+    /// it is "no client-side write-back applies" — which produces the same caller behaviour.</para>
+    ///
+    /// <para>Run through BC's own public <c>NavRecord.LookupAsync(int)</c>, not by invoking the
+    /// handler this probe found. That method re-resolves the handler through
+    /// <c>GetFieldTriggerHandler</c>, which refuses to fire a trigger on an untyped NavRecord and
+    /// calls <c>EnsureGlobalVariablesInitialized()</c> first; its
+    /// <c>InvokeFieldTriggerHandlerAsync</c> also dispatches to the right tableextension instance
+    /// when the trigger came from one. Invoking the handler directly skips all three.</para>
+    ///
+    /// <para>A field with NEITHER trigger keeps refusing: its lookup comes from a TableRelation,
+    /// which on real BC opens the related table's list page, and the runner cannot stand that up.
+    /// Doing nothing there is what let a test invoke a lookup, observe no change, and compare two
+    /// empty strings successfully. A control not bound to a source-table field at all — a page
+    /// global — has no table field to fall back to and lands in the same refusal.</para>
+    /// </summary>
+    private NavText? RaiseSourceFieldOnLookup(int controlId, NavRecord? sourceRecord, int sourceFieldNo)
+    {
+        // A control bound to a page GLOBAL rather than to a source-table field has no table
+        // field to fall back to, and saying "nor its source table field declares one" about a
+        // field that does not exist points the reader at the wrong thing.
+        if (sourceRecord == null || sourceFieldNo <= 0)
+            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                $"TestPage lookup on control {controlId} (page {_pageId})",
+                "testpage-lookup — the control declares no OnLookup trigger and is not bound to a "
+                + "source-table field, so there is no table-field OnLookup to fall back to and its "
+                + "lookup would come from a TableRelation, which the runner cannot stand up. "
+                + "See docs/scope.md");
+
+        var has = AlRunner.Patches.RecordPatches.TryHasFieldLookupTrigger(sourceRecord, sourceFieldNo);
+
+        // Undeterminable is its own outcome, with its own message. Saying "neither declares an
+        // OnLookup trigger" when the real reason is that BC's metafield shape moved under our
+        // reflection would send the reader to look at their AL, where there is nothing to find.
+        if (has == null)
+            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                $"TestPage lookup on control {controlId} (page {_pageId})",
+                $"testpage-lookup — the control declares no OnLookup trigger, and whether field "
+                + $"{sourceFieldNo} of its source table declares one could not be determined on this "
+                + "BC build (RecordPatches.TryHasFieldLookupTrigger could not read BC's field-trigger "
+                + "metadata). This is a runner/BC-shape problem, not a problem with the AL under test. "
+                + "See docs/scope.md");
+
+        if (has != true)
+            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                $"TestPage lookup on control {controlId} (page {_pageId})",
+                "testpage-lookup — neither the control nor its source table field declares an "
+                + "OnLookup trigger, so the lookup comes from a TableRelation and would open the "
+                + "related table's list page, which the runner cannot stand up. See docs/scope.md");
+
+        sourceRecord.LookupAsync(sourceFieldNo).GetAwaiter().GetResult();
+        return null;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #2549

Written by agent impl-3. Credit for the diagnosis and the fix's shape: Mikkel Mansa Vilhelmsen (@vhn-mmv), commit `24228324` on his fork.

## Was this even in scope?

Yes, and it is worth answering first, because a loud refusal is the *correct* answer for a surface that genuinely cannot run here (`.claude/rules/loud-failures.md`).

A table field's `trigger OnLookup()` is ordinary in-process AL business logic. BC runs it through `NavRecord.LookupAsync(int)`, which touches no UI, no service and no external process. What is genuinely out of scope is the *third* fallback — a field with no trigger at all, whose lookup comes from a `TableRelation` and on real BC opens the related table's list page. **That one keeps refusing**, and the fix narrows the refusal rather than softening it.

## What was wrong

AL spells `OnLookup` two unrelated ways:

- on a **page control**: `trigger OnLookup(var Text: Text): Boolean`
- on a **table field**: `trigger OnLookup()`, parameterless, writing into `Rec` itself

Real BC tries the control, then the table field, then the `TableRelation` UI. `RunnerPageInstance.RaiseOnLookup` implemented only the first and threw `testpage-lookup` the moment it missed — so a `TestPage` field whose *table* carries the lookup was refused as if it had no lookup at all.

The handler was **already wired onto the metafield** by `RecordPatches.NclMetaTableBuilder` and nothing ever read it back. One writer, no reader.

## How it runs the trigger, and why not the obvious way

Through BC's own public `NavRecord.LookupAsync(int fieldNo)`, not by invoking the handler the probe found. Decompiled from BC 28.1:

```csharp
public ValueTask LookupAsync(int fieldNo)
{
    ThrowIfRecordStaleOrNotOpen();
    NCLMetaField fieldByNo = metaTable.GetFieldByNo(fieldNo);
    FieldTriggerHandler<NavApplicationObjectBase> h = GetFieldTriggerHandler(FieldTriggerType.OnLookup, fieldByNo);
    return InvokeFieldTriggerHandlerAsync(h);
}
```

That path does three things a direct invoke skips:

- `GetFieldTriggerHandler` returns `null` when `GetType() == typeof(NavRecord)` — BC will not fire a field trigger on an untyped record;
- it calls `EnsureGlobalVariablesInitialized()` before handing a handler back, so a table `OnLookup` that reads a global does not run against uninitialized ones;
- `InvokeFieldTriggerHandlerAsync` dispatches to the matching `NavRecordExtension` instance when the trigger came from a tableextension.

`LookupAsync` is **byte-identical on BC 27.0 through 28.4** (`compare_symbols`, `signatureChanged: false`, `bodyChanged: false`), so this is safe across the supported matrix rather than pinned to the build I read.

`RecordPatches.TryHasFieldLookupTrigger` is used only to answer *does a handler exist*, and reads the backing fields rather than the internal `NCLMetaField.LookupHandler` property so the probe cannot construct an `EventTriggerData` as a side effect of asking whether one exists.

## The refusal got more specific, not quieter

It returns `bool?`, and the caller now distinguishes three cases:

| situation | message |
|---|---|
| control not bound to a source-table field (a page global) | "…declares no OnLookup trigger and is not bound to a source-table field…" |
| neither control nor field declares one | "…neither the control nor its source table field declares an OnLookup trigger…" |
| reflection could not read BC's field-trigger metadata | "…could not be determined on this BC build… This is a runner/BC-shape problem, not a problem with the AL under test." |

The third exists because reporting "your AL declares no trigger" when the real cause is that BC's metafield shape moved sends the reader to look in the wrong place. That was called out in the issue and it is the reason for `bool?` rather than `bool`.

## Tests

**RED -> GREEN, run locally.**

- `AlRunner.Tests/TestPageFieldTableLookupTests` spawns the real runner on a synthetic bundle carrying **all three cases on one page**. RED: `TableFieldOnLookupRunsWhenTheControlDeclaresNone` failed with `Unexpected out-of-scope: TestPage lookup on control 167300721 (page 62561) … testpage-lookup`, while the other two already passed. GREEN: all three pass, 12 s.
- The three cases are deliberately **not** split across tests. A fix that dispatched the table trigger for *every* field — turning the TableRelation case's loud refusal into a silent no-op — would pass two out of three and look like progress.

**Upstream, where the BC-behaviour claim belongs** (`.claude/rules/bc-behavior-tests-go-upstream.md`): StefanMaron/BusinessCentral.AL.Language.Tests#152, codeunit 60316 "TFL Tests". Proven RED -> GREEN against that branch with a private `--cache`:

- released runner: `FAIL Lookup_ControlWithoutTrigger_RunsTheTableFieldsOnLookup`, `PASS Lookup_ControlWithTrigger_WinsOverTheTableFieldsOnLookup` — 1 pass / 1 fail;
- this build: both PASS, `compile-fail: 0`.

The submodule pin bump follows once #152 merges; it cannot be part of this PR (`al-language-submodule.md`).

**Targeted regressions, run locally:**

- `--filter "FullyQualifiedName~TestPage|~Lookup|~FieldTrigger|~NclMetaTable"` — 96 passed, 5 skipped, 38 s.
- `--filter "FullyQualifiedName~RecordPatches|~Validate|~RunnerPage"` — 40 passed, 11 skipped, 3 s.

I did not run the full `AlRunner.Tests` suite locally; CI runs it on the two legs that carry it.

## Shape questions

1. **Same wrong pattern at another call site?** Checked, and no. `FieldTriggerType` has exactly `OnLookup` and `OnValidate` (BC's own `GetFieldTriggerHandler` switch), so there is no table-field `OnDrillDown` to have the same gap — `RaiseOnDrillDown`'s no-trigger answer is a genuine BC error, not a missing fallback.
2. **Sibling assumption?** The **validate** half of the same pair was already correct: `LiveNavTestField` routes `SetValue` through `_record.ALValidateAsync(_fieldNo, …)`, BC's own entry point, which runs the table field's `OnValidate`. Lookup was the one of the two that never got its entry point. The var-bound (page-global) control's `Lookup()` is left refusing on purpose — it has no source-table field to fall back to, and now says so.
3. **Two writers, one invariant?** This *was* the defect, in one sentence: `RecordPatches.NclMetaTableBuilder` wrote `LookupHandler` onto the metafield (including the tableextension path at `:1449`) and no reader existed.

## Left out

- **The `TableRelation` lookup page itself** stays out of scope — it needs a list page and a user selection the runner cannot stand up.
- **A `tests/runner-extras/` bundle for the TableRelation refusal.** The issue suggests one; the same claim is covered by the third case of the mechanism test above, and adding a bundle moves `tests/expectations/count-baseline/test-count-baseline.json` in four places (`default` plus the three per-BC-version overrides) for one test. That baseline is already a conflict magnet and moves anyway in the pin-bump PR, which is where I would rather fold it. Say the word if you want it here instead.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
