### PR TITLE
fix(ci): stop a same-commit cancellation blocking the merge with everything green

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -158,7 +158,7 @@ Full decision tree: `.claude/rules/bc-behavior-tests-go-upstream.md` plus the `a
 
 ### The "Tests updated" CI gate
 
-`.github/workflows/pr-check.yml`'s `require-tests` job triggers only when your diff touches `AlRunner/` (excluding `.md` files); when it does, it requires the diff to also touch something under `tests/` or `AlRunner.Tests/`. Two things agents got wrong:
+`.github/workflows/require-tests.yml`'s `require-tests` job triggers only when your diff touches `AlRunner/` (excluding `.md` files); when it does, it requires the diff to also touch something under `tests/` or `AlRunner.Tests/`. Two things agents got wrong:
 
 - The gate's grep (`^(tests/|AlRunner\.Tests/)`) accepts the gitlink line a pin bump produces in `git diff --name-only` — legitimate *only* when this PR is the fix PR the bump is folded into (above). You may still never edit a file *inside* the read-only submodule. If your proving test lives upstream and the pin isn't being bumped here (its corpus PR hasn't merged yet), add a **runner-side mechanism test** under `AlRunner.Tests/` instead — see `AlRunner.Tests/EnumCaptionCaptureTests.cs` or `AlRunner.Tests/MediaSetPatchesTests.cs` for the shape — pinning the runner's own C# behavior, not duplicating the BC-behaviour claim.
 - The `no-tests-needed` label bypasses the gate but is **not** a substitute for a real test when runtime behavior changed — use it only when the diff genuinely needs none (pure comment/doc changes inside `AlRunner/`). The `docs-only` label is for PRs that don't touch `AlRunner/` at all; those never trip the gate.

--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -20,6 +20,7 @@ tools/ci-wait.py 2379 --timeout 2400
 | 1 | a required check failed; **the failing log is already printed** |
 | 2 | timed out while still running — **not a verdict**, call again |
 | 3 | could not determine (auth, network, no checks) |
+| 4 | **blocked, not failing** — every check passed but a *required* context is `cancelled` on this commit, so the merge is refused and nothing else says why (#2726). The one case where `gh run rerun` is correct: re-run the cancelled run, it has no failure log to destroy. Never reach for `--admin`. |
 
 It enforces the two rules agents keep getting wrong: checks are matched against the PR's
 **current head SHA**, so a newer completed run for an older push is never reported as this

--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -121,19 +121,29 @@ Merge when **all of**:
 
 **Use `tools/ci-wait.py <PR>`** rather than a poll loop. It polls internally and returns one
 verdict: 0 green on current head, 1 failed with the log already fetched, 2 still running
-(*not* a verdict), 3 undetermined.
+(*not* a verdict), 3 undetermined, 4 blocked by a cancelled required context (below).
 
 **Never `gh run rerun` a failed job** — it destroys the log permanently. Read
 `--log-failed` first, then push a new commit.
 
 **A CANCELLED check blocks the merge, with everything green and nothing saying why.**
-`pr-check.yml` triggers on `edited`, so editing a PR body starts a fresh run and
-`cancel-in-progress` cancels the old one — leaving a `CANCELLED` conclusion on required
-contexts that protection then treats as unsatisfied. `gh pr checks` shows all green,
-`ci-wait.py` reports GREEN on the head SHA, and the merge is still refused as `BLOCKED`. Look
-at `statusCheckRollup` for `conclusion == "CANCELLED"`. Re-running just that cancelled run
-clears it in under a minute — and that is NOT the forbidden `gh run rerun`, because a
-cancelled run has no failure log to destroy. Do not reach for `--admin`. Tracked as #2726.
+A ruleset satisfies a required check from the *newest* check run carrying that context name on
+the head commit, and `cancelled` does not satisfy it. `cancel-in-progress` produces that
+conclusion whenever a `pull_request` event fires *without* moving the head SHA — `edited`,
+`labeled`, `unlabeled` — because the cancelled run's checks then land on the very commit the
+ruleset is reading. `gh pr checks` still shows all green and the merge is still refused as
+`BLOCKED`.
+
+#2726 fixed both halves. The required `Tests updated` job moved out of `pr-check.yml` into
+`require-tests.yml`, which has no `concurrency` block and does not trigger on `edited`, so no
+required context is cancellable on its own commit any more; `check_required_contexts.py` fails
+CI if one becomes so again. And `ci-wait.py` now returns **exit 4** naming the cancelled
+context instead of reporting GREEN.
+
+If you still land in this state, re-run just the cancelled run — it clears in under a minute,
+and that is NOT the forbidden `gh run rerun`, because a cancelled run has no failure log to
+destroy. Do not reach for `--admin`: protection is working, the context genuinely is not
+satisfied.
 
 **Auto-merge drains the queue — but a drained queue is not a verified one.** The
 "branches must be up to date" protection rule was removed, so arming several PRs lets them

--- a/.github/scripts/check_pr_check_triggers.sh
+++ b/.github/scripts/check_pr_check_triggers.sh
@@ -24,8 +24,15 @@
 # the workflow keeps that trigger on one line; a workflow that reformats it
 # across multiple lines needs a corresponding update here.
 #
-# Usage: check_pr_check_triggers.sh [path-to-workflow-yaml]
-# Defaults to .github/workflows/pr-check.yml relative to this script.
+# Usage: check_pr_check_triggers.sh [path-to-workflow-yaml] [required,types]
+# Defaults to .github/workflows/pr-check.yml relative to this script, and to
+# the historical six-type list below.
+#
+# The second argument exists because #2726 moved the require-tests job ("Tests
+# updated", a REQUIRED status-check context) out of pr-check.yml and into
+# require-tests.yml. 'labeled'/'unlabeled' are load-bearing in the file that job
+# now lives in, and 'edited' is deliberately absent there -- so the two files
+# need different required-type lists, guarded separately.
 # Exits 0 and prints a confirmation when all required types are present.
 # Exits 1 with an ::error:: line naming what's missing otherwise.
 # Exits 2 if the file or the types line can't be found at all (a distinct
@@ -54,7 +61,15 @@ fi
 # reasons documented inline in pr-check.yml itself; this check also catches
 # one of them being dropped by accident while editing the trigger line for
 # something unrelated.
-REQUIRED_TYPES=(opened synchronize reopened labeled unlabeled edited)
+DEFAULT_REQUIRED_TYPES="opened,synchronize,reopened,labeled,unlabeled,edited"
+# IFS of ", " so "a, b,c" and "a,b,c" both split cleanly -- a stray space would
+# otherwise end up inside a type name and never match.
+IFS=', ' read -r -a REQUIRED_TYPES <<< "${2:-$DEFAULT_REQUIRED_TYPES}"
+
+if [ "${#REQUIRED_TYPES[@]}" -eq 0 ]; then
+  echo "::error::no required types given" >&2
+  exit 2
+fi
 
 MISSING=()
 for t in "${REQUIRED_TYPES[@]}"; do

--- a/.github/scripts/check_required_contexts.py
+++ b/.github/scripts/check_required_contexts.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Fail when a REQUIRED status-check context can be left `cancelled` on the head commit.
+
+The gap this guards (#2726)
+---------------------------
+A branch ruleset satisfies a required status check by looking at the newest
+check run carrying that context name on the PR's head commit. A check run whose
+conclusion is `cancelled` does not satisfy it — and unlike a failure, nothing in
+the UI or in `gh pr checks` points at it as the reason the merge is refused.
+
+`concurrency.cancel-in-progress: true` produces exactly that conclusion whenever
+a second run of the same workflow enters the group. For a new PUSH that is
+correct and deliberate: the superseded run is testing a commit nobody has any
+more, and its check runs hang off that older SHA where no ruleset will read
+them. The whole comment block at the top of pr-check.yml and test-matrix.yml
+argues for it, and this guard does not touch it.
+
+The damage comes from the `pull_request` event types that fire WITHOUT changing
+the head SHA — `edited`, `labeled`, `unlabeled` and friends. Those start a second
+run against the SAME commit, so the cancelled conclusion lands on the very SHA
+the ruleset is evaluating. Observed live on PR #2722 at head d5c334c1: the
+required `Tests updated` context existed three times, twice `success` and once
+`cancelled`, `gh pr checks` reported every context SUCCESS, `tools/ci-wait.py`
+correctly reported GREEN, and the merge was refused with nothing saying why.
+
+So the rule is narrow and only about required contexts:
+
+    A workflow that produces a REQUIRED status-check context may not combine
+    `cancel-in-progress: true` with a `pull_request` trigger type that fires
+    without changing the head SHA.
+
+Either drop the same-SHA trigger types from that workflow (move the jobs that
+need them to a workflow producing no required context), or drop
+`cancel-in-progress`. Both are fine; leaving them together is not.
+
+It also fails when a required context is produced by NO workflow at all, which
+is the mirror-image outage: every PR blocks forever on a check that can never
+report. That is the failure mode the comment above test-matrix.yml's `all-tests`
+job warns about, and nothing enforced it until now.
+
+Usage
+-----
+    check_required_contexts.py [workflows-dir]
+
+`workflows-dir` defaults to .github/workflows next to this script. The required
+context list can be overridden with the REQUIRED_CONTEXTS environment variable
+(newline- or comma-separated) — that exists so the unit tests can drive synthetic
+fixtures, not as a production knob.
+
+Exit codes
+----------
+    0  every required context is safe
+    1  at least one required context is cancellable, or is produced by nothing
+    2  the check could not run at all (no workflows dir, unparseable YAML)
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import yaml
+
+# The contexts the `main` branch ruleset requires. Re-derive with:
+#   gh api repos/StefanMaron/BusinessCentral.AL.Runner/rulesets/15001420 \
+#     --jq '.rules[] | select(.type=="required_status_checks")
+#           | .parameters.required_status_checks[].context'
+# Measured 2026-09-05: exactly these two, matched by context NAME only (the
+# ruleset entries carry no integration_id), which is why a required job may move
+# between workflow files as long as its `name:` is unchanged.
+DEFAULT_REQUIRED_CONTEXTS = ["All BC versions passed", "Tests updated"]
+
+# `pull_request` types that fire while the head SHA stays put, so a run they
+# start collides with runs already reporting on that same SHA.
+#
+# Deliberately NOT in this set:
+#   opened      - fires once, nothing to collide with
+#   synchronize - this is what a new push is; the superseded run reports on the
+#                 OLD sha, which no ruleset reads. Cancelling it is the point.
+#   reopened    - same-SHA in principle, but it requires closing a PR and
+#                 reopening it inside the lifetime of one run. Listing it would
+#                 fail test-matrix.yml (default types, cancel-in-progress: true)
+#                 for a case never observed, so this guard does not claim it.
+#   closed      - no checks are gating a closed PR.
+SAME_SHA_TYPES = {
+    "edited",
+    "labeled",
+    "unlabeled",
+    "assigned",
+    "unassigned",
+    "review_requested",
+    "review_request_removed",
+    "ready_for_review",
+    "converted_to_draft",
+    "locked",
+    "unlocked",
+    "milestoned",
+    "demilestoned",
+    "auto_merge_enabled",
+    "auto_merge_disabled",
+    "enqueued",
+    "dequeued",
+}
+
+# GitHub's default when `on.pull_request` lists no `types:`.
+DEFAULT_PR_TYPES = ["opened", "synchronize", "reopened"]
+
+
+def required_contexts() -> list[str]:
+    raw = os.environ.get("REQUIRED_CONTEXTS")
+    if not raw:
+        return list(DEFAULT_REQUIRED_CONTEXTS)
+    parts = [p.strip() for chunk in raw.split("\n") for p in chunk.split(",")]
+    return [p for p in parts if p]
+
+
+def load(path: str) -> dict:
+    with open(path, encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh)
+    return doc if isinstance(doc, dict) else {}
+
+
+def triggers(wf: dict) -> dict:
+    """`on:` from a workflow. PyYAML resolves the bare key `on` to True."""
+    on = wf.get("on", wf.get(True))
+    if isinstance(on, dict):
+        return on
+    if isinstance(on, str):
+        return {on: None}
+    if isinstance(on, list):
+        return {k: None for k in on}
+    return {}
+
+
+def pull_request_types(wf: dict) -> list[str]:
+    """The pull_request types this workflow reacts to, [] if it has no such trigger."""
+    on = triggers(wf)
+    if "pull_request" not in on:
+        return []
+    spec = on["pull_request"]
+    if not isinstance(spec, dict) or "types" not in spec:
+        return list(DEFAULT_PR_TYPES)
+    types = spec["types"]
+    if isinstance(types, str):
+        return [types]
+    return [str(t) for t in (types or [])]
+
+
+def cancels_in_progress(scope: dict) -> bool:
+    """True unless `concurrency` is absent or cancel-in-progress is literally false.
+
+    An expression like ${{ github.ref != 'refs/heads/main' }} cannot be evaluated
+    here, so it counts as cancelling — a guard that assumed the safe branch of an
+    expression it cannot read would be worse than no guard.
+    """
+    conc = scope.get("concurrency")
+    if conc is None:
+        return False
+    if not isinstance(conc, dict):
+        # `concurrency: some-group` — a group with no cancel-in-progress queues.
+        return False
+    flag = conc.get("cancel-in-progress", False)
+    if isinstance(flag, bool):
+        return flag
+    if isinstance(flag, str):
+        return flag.strip().lower() not in ("", "false")
+    return bool(flag)
+
+
+def contexts_of(wf: dict, wf_dir: str) -> dict[str, dict]:
+    """context name -> the job dict that produces it.
+
+    A top-level job reports under its `name:` (falling back to the job id). A job
+    that calls a reusable workflow reports each of the called workflow's jobs
+    qualified as "<calling job id> / <called job name>" — the mechanism the
+    comment above test-matrix.yml's `all-tests` job describes.
+    """
+    out: dict[str, dict] = {}
+    jobs = wf.get("jobs") or {}
+    if not isinstance(jobs, dict):
+        return out
+    for job_id, job in jobs.items():
+        if not isinstance(job, dict):
+            continue
+        uses = job.get("uses")
+        if isinstance(uses, str) and uses.startswith("./"):
+            called_path = os.path.join(wf_dir, os.path.basename(uses))
+            if os.path.isfile(called_path):
+                called = load(called_path)
+                for inner, inner_job in (called.get("jobs") or {}).items():
+                    inner_name = inner
+                    if isinstance(inner_job, dict) and inner_job.get("name"):
+                        inner_name = str(inner_job["name"])
+                    out[f"{job_id} / {inner_name}"] = job
+                continue
+        out[str(job.get("name") or job_id)] = job
+    return out
+
+
+def main(argv: list[str]) -> int:
+    here = os.path.dirname(os.path.abspath(__file__))
+    wf_dir = argv[1] if len(argv) > 1 else os.path.join(here, "..", "workflows")
+    wf_dir = os.path.abspath(wf_dir)
+    if not os.path.isdir(wf_dir):
+        print(f"::error::workflows directory not found: {wf_dir}", file=sys.stderr)
+        return 2
+
+    files = sorted(
+        os.path.join(wf_dir, f)
+        for f in os.listdir(wf_dir)
+        if f.endswith((".yml", ".yaml"))
+    )
+    if not files:
+        print(f"::error::no workflow files in {wf_dir}", file=sys.stderr)
+        return 2
+
+    # context -> list of (workflow path, workflow dict, job dict)
+    produced: dict[str, list[tuple[str, dict, dict]]] = {}
+    for path in files:
+        try:
+            wf = load(path)
+        except yaml.YAMLError as exc:
+            print(f"::error::could not parse {path}: {exc}", file=sys.stderr)
+            return 2
+        if not pull_request_types(wf):
+            continue
+        for ctx, job in contexts_of(wf, wf_dir).items():
+            produced.setdefault(ctx, []).append((path, wf, job))
+
+    problems: list[str] = []
+    for ctx in required_contexts():
+        sources = produced.get(ctx)
+        if not sources:
+            problems.append(
+                f"required context {ctx!r} is produced by NO workflow reacting to "
+                f"pull_request — every PR blocks forever on a check that never reports"
+            )
+            continue
+        for path, wf, job in sources:
+            risky = sorted(set(pull_request_types(wf)) & SAME_SHA_TYPES)
+            if not risky:
+                continue
+            if cancels_in_progress(wf) or cancels_in_progress(job):
+                problems.append(
+                    f"required context {ctx!r} in {os.path.basename(path)} combines "
+                    f"cancel-in-progress with same-SHA pull_request type(s) "
+                    f"{', '.join(risky)} — a second run on the SAME commit cancels the "
+                    f"first and leaves {ctx!r} 'cancelled', which blocks the merge with "
+                    f"nothing reporting why (#2726)"
+                )
+
+    if problems:
+        for p in problems:
+            print(f"::error::{p}", file=sys.stderr)
+        print(
+            "\nFix: move the jobs that need the same-SHA trigger types into a workflow "
+            "that produces no required context, or drop cancel-in-progress from the "
+            "workflow that produces this one.",
+            file=sys.stderr,
+        )
+        return 1
+
+    names = ", ".join(required_contexts())
+    print(f"required contexts cannot be left cancelled on the head commit: {names}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/scripts/test_check_pr_check_triggers.sh
+++ b/.github/scripts/test_check_pr_check_triggers.sh
@@ -48,6 +48,20 @@ assert_exit() {
   fi
 }
 
+assert_exit_types() {
+  local desc="$1" expected_rc="$2" fixture_path="$3" types="$4"
+  local rc
+  "$SCRIPT" "$fixture_path" "$types" >/dev/null 2>&1
+  rc=$?
+  if [ "$rc" = "$expected_rc" ]; then
+    echo "ok   - $desc"
+    pass=$((pass + 1))
+  else
+    echo "FAIL - $desc: expected exit $expected_rc, got $rc"
+    fail=$((fail + 1))
+  fi
+}
+
 write_fixture() {
   local name="$1" types="$2"
   local path="$TMPDIR_FIXTURES/$name"
@@ -120,6 +134,31 @@ assert_exit "'label' does not satisfy the requirement for 'labeled'" 1 "$label_n
 
 assert_exit "the actual .github/workflows/pr-check.yml satisfies the check" 0 \
   "$REPO_ROOT/.github/workflows/pr-check.yml"
+
+# --- #2726: an explicit required-type list, so pr-check.yml and ------------
+# --- require-tests.yml can be guarded with the different lists each needs ---
+
+# require-tests.yml deliberately has NO 'edited' (nothing in it reads the PR
+# title or body, and including it is what caused #2726), so the default
+# six-type list must NOT be what guards it.
+rt_shape=$(write_fixture "require-tests-shape.yml" "opened, synchronize, reopened, labeled, unlabeled")
+assert_exit "the require-tests trigger shape fails the DEFAULT list" 1 "$rt_shape"
+assert_exit_types "...and passes its own explicit list" 0 "$rt_shape" \
+  "opened,synchronize,reopened,labeled,unlabeled"
+
+# The explicit list still has to actually check: drop a type it names.
+assert_exit_types "an explicit list still fails on a missing type" 1 "$rt_shape" \
+  "opened,synchronize,reopened,labeled,unlabeled,ready_for_review"
+
+# Spaces around the commas must not smuggle a space into a type name.
+assert_exit_types "an explicit list tolerates spaces after commas" 0 "$rt_shape" \
+  "opened, synchronize, reopened, labeled, unlabeled"
+
+# --- The real require-tests.yml, guarded with the list it actually needs -----
+
+assert_exit_types "the actual .github/workflows/require-tests.yml keeps labeled/unlabeled" 0 \
+  "$REPO_ROOT/.github/workflows/require-tests.yml" \
+  "opened,synchronize,reopened,labeled,unlabeled"
 
 echo ""
 echo "$pass passed, $fail failed"

--- a/.github/scripts/test_check_required_contexts.py
+++ b/.github/scripts/test_check_required_contexts.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Unit tests for check_required_contexts.py, against synthetic workflow fixtures.
+
+Same pattern as test_check_pr_check_triggers.sh: the guard is provable here
+rather than only by opening a real PR, editing its body at the wrong moment and
+watching a merge get refused.
+
+Run: python3 .github/scripts/test_check_required_contexts.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "check_required_contexts", os.path.join(HERE, "check_required_contexts.py")
+)
+crc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(crc)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+def run(files: dict[str, str], required: str) -> tuple[int, str]:
+    """Write fixture workflows to a temp dir, run the guard, return (rc, stderr)."""
+    import contextlib
+    import io
+
+    with tempfile.TemporaryDirectory() as d:
+        for fname, body in files.items():
+            with open(os.path.join(d, fname), "w", encoding="utf-8") as fh:
+                fh.write(body)
+        old = os.environ.get("REQUIRED_CONTEXTS")
+        os.environ["REQUIRED_CONTEXTS"] = required
+        err = io.StringIO()
+        out = io.StringIO()
+        try:
+            with contextlib.redirect_stderr(err), contextlib.redirect_stdout(out):
+                rc = crc.main(["check_required_contexts.py", d])
+        finally:
+            if old is None:
+                os.environ.pop("REQUIRED_CONTEXTS", None)
+            else:
+                os.environ["REQUIRED_CONTEXTS"] = old
+        return rc, err.getvalue() + out.getvalue()
+
+
+CANCELLABLE_EDITED = """
+name: PR Check
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  require-tests:
+    name: Tests updated
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'true'
+"""
+
+SAFE_NO_SAME_SHA_TYPES = """
+name: PR Check
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  require-tests:
+    name: Tests updated
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'true'
+"""
+
+SAFE_NO_CONCURRENCY = """
+name: Require Tests
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+jobs:
+  require-tests:
+    name: Tests updated
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'true'
+"""
+
+DEFAULT_TYPES_CANCELLING = """
+name: Test Matrix
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  all-tests:
+    name: All BC versions passed
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'true'
+"""
+
+JOB_LEVEL_CANCEL = """
+name: Require Tests
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, edited]
+jobs:
+  require-tests:
+    name: Tests updated
+    runs-on: ubuntu-latest
+    concurrency:
+      group: rt-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - run: 'true'
+"""
+
+EXPLICIT_FALSE = """
+name: Require Tests
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, edited]
+concurrency:
+  group: rt-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  require-tests:
+    name: Tests updated
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'true'
+"""
+
+REUSABLE_CALLER = """
+name: Test Matrix
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, edited]
+concurrency:
+  group: tm-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  bc-tests:
+    uses: ./.github/workflows/called.yml
+"""
+
+REUSABLE_CALLED = """
+name: BC Tests
+on:
+  workflow_call:
+jobs:
+  matrix-leg:
+    name: BC 28.3 (required)
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'true'
+"""
+
+PUSH_ONLY = """
+name: Publish
+on:
+  push:
+    tags: ['v*']
+jobs:
+  ship:
+    name: Tests updated
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'true'
+"""
+
+
+print("check_required_contexts.py")
+
+# --- the bug: cancel-in-progress + a same-SHA trigger type on a required context
+rc, msg = run({"pr-check.yml": CANCELLABLE_EDITED}, "Tests updated")
+check("edited + cancel-in-progress on a required context fails", rc == 1, f"(rc={rc})")
+check("...and names the offending trigger type", "edited" in msg, msg)
+check("...and names the context", "Tests updated" in msg, msg)
+check("...and names the workflow file", "pr-check.yml" in msg, msg)
+
+# --- the other direction: safe shapes must stay green, or the guard is noise
+rc, msg = run({"pr-check.yml": SAFE_NO_SAME_SHA_TYPES}, "Tests updated")
+check("cancel-in-progress with no same-SHA type is fine", rc == 0, f"(rc={rc}) {msg}")
+
+rc, msg = run({"require-tests.yml": SAFE_NO_CONCURRENCY}, "Tests updated")
+check("same-SHA types with no concurrency block is fine", rc == 0, f"(rc={rc}) {msg}")
+
+rc, msg = run({"test-matrix.yml": DEFAULT_TYPES_CANCELLING}, "All BC versions passed")
+check("default pull_request types + cancel-in-progress is fine",
+      rc == 0, f"(rc={rc}) {msg}")
+
+rc, msg = run({"require-tests.yml": EXPLICIT_FALSE}, "Tests updated")
+check("cancel-in-progress: false with edited is fine", rc == 0, f"(rc={rc}) {msg}")
+
+# --- job-level concurrency is the same defect one level down
+rc, msg = run({"require-tests.yml": JOB_LEVEL_CANCEL}, "Tests updated")
+check("job-level cancel-in-progress is caught too", rc == 1, f"(rc={rc}) {msg}")
+
+# --- a required context nothing produces is the mirror-image outage
+rc, msg = run({"pr-check.yml": SAFE_NO_CONCURRENCY}, "No Such Context")
+check("a required context no workflow produces fails", rc == 1, f"(rc={rc})")
+check("...and says so distinctly, not as a cancellation",
+      "produced by NO workflow" in msg, msg)
+
+rc, msg = run({"publish.yml": PUSH_ONLY}, "Tests updated")
+check("a context produced only on push does not count as produced",
+      rc == 1, f"(rc={rc}) {msg}")
+
+# --- reusable-workflow contexts are qualified by the calling job id
+rc, msg = run({"test-matrix.yml": REUSABLE_CALLER, "called.yml": REUSABLE_CALLED},
+              "bc-tests / BC 28.3 (required)")
+check("a reusable workflow's job resolves to '<caller> / <name>'",
+      rc == 1 and "bc-tests / BC 28.3 (required)" in msg, f"(rc={rc}) {msg}")
+
+# --- multiple required contexts: one bad is enough, and both get reported
+rc, msg = run({"pr-check.yml": CANCELLABLE_EDITED, "test-matrix.yml": DEFAULT_TYPES_CANCELLING},
+              "Tests updated,All BC versions passed")
+check("a mixed set fails on the bad one only", rc == 1, f"(rc={rc})")
+check("...and does not accuse the safe one",
+      "All BC versions passed" not in msg.split("Fix:")[0], msg)
+
+# --- unreadable input is exit 2, distinct from 'check failed'
+rc, msg = run({}, "Tests updated")
+check("an empty workflows directory is exit 2, not a failure verdict",
+      rc == 2, f"(rc={rc}) {msg}")
+
+print()
+if FAILURES:
+    print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")
+    sys.exit(1)
+print("all checks passed")

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -4,11 +4,17 @@ on:
   pull_request:
     branches: [main]
     # 'labeled'/'unlabeled' are not in the default event set (opened, synchronize,
-    # reopened), so without them applying the bypass label below triggers no new
-    # run and the stale red X stays -- re-running the failed job just replays the
-    # pre-label payload. 'unlabeled' re-asserts the guard when the label is
-    # removed, so the bypass cannot be applied and then silently withdrawn while
-    # the check still reads green.
+    # reopened). They were added for the require-tests job's docs-only /
+    # no-tests-needed bypass, which #2726 moved to require-tests.yml -- the
+    # reasoning now lives there, along with the guard that keeps them.
+    #
+    # Nothing left in THIS file reads labels, so these two are no longer
+    # load-bearing here. They are kept rather than trimmed because trimming them
+    # is cosmetic: since require-tests moved out, this workflow produces no
+    # REQUIRED status-check context, so a same-SHA re-trigger cancelling a run
+    # here can no longer block a merge (see check_required_contexts.py). What it
+    # can still do is leave grey 'cancelled' entries in the checks list, which is
+    # noise, not a block -- tools/ci-wait.py now names them for what they are.
     #
     # 'edited' is also required (#2159), and for the same underlying reason:
     # reject-ci-skip-directives and reject-bad-closing-references both read
@@ -47,58 +53,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  require-tests:
-    name: Tests updated
-    runs-on: ubuntu-latest
-    # Skip this check when the PR carries the 'docs-only' or 'no-tests-needed' label
-    if: |
-      !contains(github.event.pull_request.labels.*.name, 'docs-only') &&
-      !contains(github.event.pull_request.labels.*.name, 'no-tests-needed')
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Check that tests/ or AlRunner.Tests/ was updated when AlRunner/ changed
-        run: |
-          BASE=${{ github.event.pull_request.base.sha }}
-          HEAD=${{ github.event.pull_request.head.sha }}
-
-          # Files changed in this PR
-          CHANGED=$(git diff --name-only "$BASE"..."$HEAD")
-
-          # Did any runtime or rewriter source change?
-          SOURCE_CHANGED=$(echo "$CHANGED" | grep -E '^AlRunner/' | grep -vE '\.(md)$' || true)
-
-          if [ -z "$SOURCE_CHANGED" ]; then
-            echo "No AlRunner/ source changes — test check skipped."
-            exit 0
-          fi
-
-          echo "AlRunner/ changes detected:"
-          echo "$SOURCE_CHANGED"
-
-          # Did any test file also change?
-          TESTS_CHANGED=$(echo "$CHANGED" | grep -E '^(tests/|AlRunner\.Tests/)' || true)
-
-          if [ -z "$TESTS_CHANGED" ]; then
-            echo ""
-            echo "ERROR: AlRunner/ was modified but no files under tests/ or AlRunner.Tests/ were updated."
-            echo ""
-            echo "Every change that affects behavior, mocks, or rewriter rules must include"
-            echo "a test. See CONTRIBUTING.md for the requirements."
-            echo ""
-            echo "If this PR genuinely needs no tests (e.g. docs-only or CI infra change),"
-            echo "add the 'docs-only' or 'no-tests-needed' label to bypass this check."
-            exit 1
-          fi
-
-          echo ""
-          echo "Test files updated:"
-          echo "$TESTS_CHANGED"
-          echo ""
-          echo "Test presence check passed. Copilot review will assess test quality."
-
   release-workflow-script-tests:
     name: Release workflow script tests
     runs-on: ubuntu-latest
@@ -263,7 +217,7 @@ jobs:
         run: bash .github/scripts/check_closing_reference.sh
 
   verify-trigger-list:
-    name: pr-check.yml's own pull_request trigger must include 'edited'
+    name: pull_request trigger lists must keep their load-bearing event types
     runs-on: ubuntu-latest
     # #2159: reject-ci-skip-directives and reject-bad-closing-references
     # above both read PR_TITLE/PR_BODY, but this workflow's `pull_request`
@@ -288,6 +242,73 @@ jobs:
 
       - name: Check this workflow's own pull_request trigger list
         run: bash .github/scripts/check_pr_check_triggers.sh
+
+      # #2726: require-tests.yml is where the 'Tests updated' REQUIRED context
+      # lives now, and 'labeled'/'unlabeled' are load-bearing THERE -- dropping
+      # them would silently break the docs-only / no-tests-needed bypass. It
+      # must NOT gain 'edited': that is the trigger that produced #2726, and
+      # nothing in that file reads the PR title or body.
+      - name: Check require-tests.yml keeps the trigger types its bypass needs
+        run: |
+          bash .github/scripts/check_pr_check_triggers.sh \
+            .github/workflows/require-tests.yml \
+            opened,synchronize,reopened,labeled,unlabeled
+          if grep -qE '(\[|,)[[:space:]]*edited[[:space:]]*(,|\])' \
+              <(grep -E '^[[:space:]]*types:[[:space:]]*\[' .github/workflows/require-tests.yml | head -n1); then
+            echo "::error::require-tests.yml must not trigger on 'edited' -- it produces the"
+            echo "::error::required 'Tests updated' context, and a same-SHA re-trigger there"
+            echo "::error::is exactly what blocked the merge in #2726."
+            exit 1
+          fi
+          echo "require-tests.yml does not trigger on 'edited'."
+
+  required-context-cancellation:
+    name: Required contexts must not be cancellable on the same commit
+    runs-on: ubuntu-latest
+    # #2726: a branch ruleset satisfies a required status check from the newest
+    # check run carrying that context name on the PR's head commit, and a
+    # `cancelled` conclusion does not satisfy it. Unlike a failure, nothing
+    # surfaces it: on PR #2722 at head d5c334c1 `gh pr checks` reported every
+    # context SUCCESS, tools/ci-wait.py correctly reported GREEN, all 8 BC legs
+    # passed, and the merge was still refused, because a superseded PR Check run
+    # had left the required "Tests updated" context cancelled on that same SHA.
+    #
+    # cancel-in-progress produces that conclusion whenever a second run enters
+    # the group. For a new PUSH that is correct -- the superseded run's checks
+    # hang off an older SHA nothing reads. The damage is from the pull_request
+    # types that fire WITHOUT moving the head SHA ('edited', 'labeled',
+    # 'unlabeled'), which agents trigger on nearly every PR.
+    #
+    # The guard is narrow: a workflow producing a REQUIRED context may not
+    # combine cancel-in-progress with one of those trigger types. It also fails
+    # when a required context is produced by no workflow at all -- the
+    # mirror-image outage the comment above test-matrix.yml's `all-tests` job
+    # warns about and nothing enforced.
+    #
+    # Logic in check_required_contexts.py, extracted so it is unit-tested
+    # against synthetic fixture workflows rather than provable only by opening a
+    # real PR, editing its body at the wrong moment and watching a merge get
+    # refused for no stated reason.
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run check_required_contexts.py's own unit tests
+        run: python3 .github/scripts/test_check_required_contexts.py
+
+      - name: Check no required context can be left cancelled
+        run: python3 .github/scripts/check_required_contexts.py
+
+  ci-wait-tests:
+    name: ci-wait.py unit tests
+    runs-on: ubuntu-latest
+    # tools/ci-wait.py is the tool every agent uses to decide a PR is ready, so
+    # its verdict logic gets unit tests rather than being provable only by
+    # pointing it at a live PR. Ungated -- it is plain Python and takes seconds.
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run tools/test_ci_wait.py
+        run: python3 tools/test_ci_wait.py
 
   agent-mcp-tools:
     name: Agent definitions must allowlist the MCP tools they document

--- a/.github/workflows/require-tests.yml
+++ b/.github/workflows/require-tests.yml
@@ -1,0 +1,110 @@
+name: Require Tests
+
+# This job used to live in pr-check.yml. It was moved out for #2726, and the move
+# is the whole fix -- the job body below is unchanged.
+#
+# "Tests updated" is one of the two contexts the `main` branch ruleset requires
+# (the other is "All BC versions passed", from test-matrix.yml). pr-check.yml
+# triggers on 'edited', 'labeled' and 'unlabeled' -- event types that fire
+# WITHOUT changing the head SHA -- while also declaring cancel-in-progress: true.
+# Editing a PR body, or labelling a PR right after opening it (both routine, both
+# things agents do on nearly every PR), therefore started a second PR Check run
+# against the SAME commit and cancelled the first. The loser left a `cancelled`
+# conclusion on "Tests updated", attached to the exact SHA the ruleset reads, and
+# a cancelled required context blocks the merge.
+#
+# Nothing reported that. Observed on PR #2722 at head d5c334c1: `gh pr checks`
+# showed every context SUCCESS, tools/ci-wait.py correctly reported GREEN, all 8
+# BC legs passed, and the merge was refused anyway. The natural next step from
+# there is to assume branch protection is broken and reach for --admin, which
+# bypasses the ruleset to work around a phantom.
+#
+# There is deliberately NO `concurrency` block here.
+#
+#   - Cancelling is pointless for this job. It is a checkout plus a `git diff`;
+#     letting a superseded one run to the end costs seconds of a free runner,
+#     which is not remotely worth risking a `cancelled` conclusion on a required
+#     context.
+#   - Cancelling is not what makes the label bypass work. The 'labeled' trigger
+#     was added so that applying 'docs-only'/'no-tests-needed' starts a NEW run
+#     whose skipped-and-green conclusion supersedes the stale red one. That is
+#     supersession by a newer check run; it never depended on the older run being
+#     cancelled, and it still works with the older run allowed to finish.
+#
+# pr-check.yml keeps its own concurrency group and its cancel-in-progress: true,
+# which is correct and well argued in the comment block at the top of that file:
+# for a new PUSH the superseded run is testing a commit nobody has any more, and
+# its check runs hang off that older SHA where no ruleset will ever read them.
+# Now that no required context is produced there, a same-SHA cancellation in
+# pr-check.yml is cosmetic rather than merge-blocking.
+#
+# check_required_contexts.py (run by pr-check.yml) fails CI if any required
+# context ever ends up in a workflow that can cancel it on the same commit again,
+# including this one.
+on:
+  pull_request:
+    branches: [main]
+    # 'labeled'/'unlabeled' are not in the default event set (opened,
+    # synchronize, reopened), so without them applying the bypass label below
+    # triggers no new run and the stale red X stays -- re-running the failed job
+    # just replays the pre-label payload. 'unlabeled' re-asserts the guard when
+    # the label is removed, so the bypass cannot be applied and then silently
+    # withdrawn while the check still reads green.
+    #
+    # 'edited' is deliberately absent: nothing in this job reads the PR title or
+    # body, so a body edit has no reason to re-run it -- and including it is
+    # precisely what caused #2726.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  require-tests:
+    name: Tests updated
+    runs-on: ubuntu-latest
+    # Skip this check when the PR carries the 'docs-only' or 'no-tests-needed' label
+    if: |
+      !contains(github.event.pull_request.labels.*.name, 'docs-only') &&
+      !contains(github.event.pull_request.labels.*.name, 'no-tests-needed')
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check that tests/ or AlRunner.Tests/ was updated when AlRunner/ changed
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+
+          # Files changed in this PR
+          CHANGED=$(git diff --name-only "$BASE"..."$HEAD")
+
+          # Did any runtime or rewriter source change?
+          SOURCE_CHANGED=$(echo "$CHANGED" | grep -E '^AlRunner/' | grep -vE '\.(md)$' || true)
+
+          if [ -z "$SOURCE_CHANGED" ]; then
+            echo "No AlRunner/ source changes — test check skipped."
+            exit 0
+          fi
+
+          echo "AlRunner/ changes detected:"
+          echo "$SOURCE_CHANGED"
+
+          # Did any test file also change?
+          TESTS_CHANGED=$(echo "$CHANGED" | grep -E '^(tests/|AlRunner\.Tests/)' || true)
+
+          if [ -z "$TESTS_CHANGED" ]; then
+            echo ""
+            echo "ERROR: AlRunner/ was modified but no files under tests/ or AlRunner.Tests/ were updated."
+            echo ""
+            echo "Every change that affects behavior, mocks, or rewriter rules must include"
+            echo "a test. See CONTRIBUTING.md for the requirements."
+            echo ""
+            echo "If this PR genuinely needs no tests (e.g. docs-only or CI infra change),"
+            echo "add the 'docs-only' or 'no-tests-needed' label to bypass this check."
+            exit 1
+          fi
+
+          echo ""
+          echo "Test files updated:"
+          echo "$TESTS_CHANGED"
+          echo ""
+          echo "Test presence check passed. Copilot review will assess test quality."

--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -122,7 +122,14 @@ def required_checks(sha: str) -> list[dict] | None:
 
 
 # The contexts the `main` branch ruleset requires, verbatim. Re-derive with:
-#   gh api repos/StefanMaron/BusinessCentral.AL.Runner/rulesets/15039643 ...
+#   gh api repos/StefanMaron/BusinessCentral.AL.Runner/rulesets/15001420 \
+#     --jq '[.rules[]|select(.type=="required_status_checks")
+#            |.parameters.required_status_checks[].context]'
+# 15001420 is the ACTIVE "main" ruleset and the only one carrying a
+# required_status_checks rule. Do NOT query 15039643 ("Copilot review for
+# default branch"): it is disabled and has no such rule, so it answers with an
+# empty list, and emptying this list on the strength of that would restore the
+# exact false-green this module exists to prevent.
 # (see .github/scripts/check_required_contexts.py, which carries the exact query
 # and is the CI guard for the same list).
 #

--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -40,6 +40,26 @@ Exit codes
     1  at least one required check failed; the failing log is printed
     2  timed out while still running -- NOT a verdict, call again
     3  could not determine state (auth, network, no checks reported)
+    4  everything green, but a REQUIRED context is `cancelled` on this commit --
+       the merge is blocked and nothing else reports why (#2726)
+
+Exit 4, and why it is not exit 0
+--------------------------------
+A branch ruleset satisfies a required status check from the newest check run
+carrying that context name on the head commit. `cancelled` does not satisfy it,
+and unlike a failure nothing surfaces it -- `gh pr checks` prints the rollup's
+summarised state and reads SUCCESS. Observed on PR #2722 at head d5c334c1: every
+context SUCCESS, all 8 BC legs passed, this script reported GREEN, and the merge
+was refused, because a superseded PR Check run had left the required
+"Tests updated" context cancelled on that same SHA. The natural next move from a
+green tool and a refused merge is to assume branch protection is broken and
+reach for --admin, which bypasses the ruleset to work around a phantom.
+
+This is the one case in this repository where `gh run rerun` is the right call:
+a cancelled run has no failure log to overwrite, so re-running it destroys no
+evidence, and it re-reports the context as success within a minute. The workflow
+side of #2726 stops required contexts being cancellable in the first place; this
+verdict exists for anything that still gets there.
 """
 from __future__ import annotations
 
@@ -101,6 +121,144 @@ def required_checks(sha: str) -> list[dict] | None:
         return None
 
 
+# The contexts the `main` branch ruleset requires, verbatim. Re-derive with:
+#   gh api repos/StefanMaron/BusinessCentral.AL.Runner/rulesets/15039643 ...
+# (see .github/scripts/check_required_contexts.py, which carries the exact query
+# and is the CI guard for the same list).
+#
+# Names containing "(required)" are the bc-tests matrix legs. They are not
+# ruleset contexts themselves, but "All BC versions passed" fails when any of
+# them does, so a cancelled leg blocks just as surely.
+RULESET_CONTEXTS = ("All BC versions passed", "Tests updated")
+
+NOT_FAILURES = ("success", "neutral", "skipped")
+
+
+def is_required(name: str | None) -> bool:
+    name = name or ""
+    return "required" in name or name in RULESET_CONTEXTS
+
+
+class Verdict:
+    """One decision about one commit.
+
+    `code` is None while no verdict is available yet -- deliberately distinct
+    from 2 (timed out), because "still running" only becomes a reportable answer
+    once the caller's deadline passes.
+    """
+
+    def __init__(self, code, lines=None, log_target=None, progress=""):
+        self.code = code
+        self.lines = lines or []
+        self.log_target = log_target
+        self.progress = progress
+
+
+def newest_per_name(runs: list[dict]) -> dict[str, dict]:
+    """The check run a ruleset would read for each context name.
+
+    Check-run ids on a commit increase with creation, so the highest id for a
+    name is the newest attempt at that context. This is what makes a superseded
+    cancellation (harmless) distinguishable from a cancellation that is still the
+    latest word on its context (merge-blocking).
+    """
+    newest: dict[str, dict] = {}
+    for r in runs:
+        name = r.get("name") or ""
+        cur = newest.get(name)
+        if cur is None or (r.get("id") or 0) > (cur.get("id") or 0):
+            newest[name] = r
+    return newest
+
+
+def classify(runs: list[dict]) -> Verdict:
+    """Turn a commit's check runs into one verdict. Pure -- see tools/test_ci_wait.py.
+
+    The pool used to be "every check whose name contains 'required'", which is
+    the 8 bc-tests legs and nothing else. That silently excluded BOTH ruleset
+    contexts: a failing "Tests updated" was reported GREEN. Ruleset contexts are
+    now judged too, but only once they have actually appeared in the rollup --
+    a docs-only PR skips "Tests updated" at job level, and waiting for a context
+    that will never report would turn a green PR into a timeout.
+    """
+    if not runs:
+        return Verdict(None)
+
+    # Judge the NEWEST run per context name and nothing else -- that is what a
+    # ruleset reads, and a commit routinely carries several attempts at the same
+    # context. Measured against PR #2740's head 6b95477f: "Tests updated" is
+    # present twice, `failure` and then `skipped` after a no-tests-needed label
+    # was applied. GitHub took the newer `skipped` and the PR merged; scanning
+    # every entry instead would report that merged PR as FAILED.
+    newest = newest_per_name(runs)
+    pool = [r for n, r in newest.items() if is_required(n)] or list(newest.values())
+    done = [r for r in pool if r.get("status") == "completed"]
+    bad = [r for r in done if r.get("conclusion") not in NOT_FAILURES
+           and r.get("conclusion") != "cancelled"]
+    progress = f"{len(done)}/{len(pool)} complete, {len(bad)} failing"
+
+    if bad:
+        lines = [f"{len(bad)} of {len(pool)} required checks failed:"]
+        lines += [f"  {r['name']}: {r.get('conclusion')}" for r in bad]
+        return Verdict(1, lines, log_target=bad[0], progress=progress)
+
+    if len(done) != len(pool):
+        # A cancellation seen mid-run is usually a run being superseded while its
+        # replacement is still queued; the replacement outranks it as soon as it
+        # reports. Calling that a block here would cry wolf on every push.
+        return Verdict(None, progress=progress)
+
+    blocking = sorted(
+        (r for r in newest.values()
+         if r.get("conclusion") == "cancelled" and is_required(r.get("name"))),
+        key=lambda r: r.get("name") or "",
+    )
+    superseded = sorted(
+        {(r.get("name") or "") for r in runs
+         if r.get("conclusion") == "cancelled"
+         and newest.get(r.get("name") or "", {}).get("id") != r.get("id")}
+    )
+    cosmetic = sorted(
+        {(r.get("name") or "") for r in newest.values()
+         if r.get("conclusion") == "cancelled" and not is_required(r.get("name"))}
+    )
+
+    if blocking:
+        lines = [
+            f"BLOCKED, not failing -- {len(blocking)} REQUIRED context(s) are "
+            f"'cancelled' on this commit and nothing else reports it:",
+        ]
+        lines += [f"  {r['name']}: cancelled" for r in blocking]
+        lines += [
+            "",
+            "Every other check passed. A ruleset reads the NEWEST check run per",
+            "context name, and 'cancelled' does not satisfy a required check, so the",
+            "merge is refused while `gh pr checks` still reads SUCCESS (#2726).",
+            "",
+            "Re-run the cancelled run -- this is the ONE case where `gh run rerun` is",
+            "correct: a cancelled run has no failure log to overwrite. Do NOT reach",
+            "for --admin; branch protection is working, the context genuinely is not",
+            "satisfied.",
+        ]
+        for r in blocking:
+            if r.get("details_url"):
+                lines.append(f"  {r['details_url']}")
+        return Verdict(4, lines, progress=progress)
+
+    lines = [f"all {len(pool)} required checks passed."]
+    if cosmetic:
+        lines.append("")
+        lines.append("Cosmetic: these NON-required contexts are 'cancelled' on this "
+                     "commit and do not block a merge:")
+        lines += [f"  {n}" for n in cosmetic]
+    if superseded:
+        lines.append("")
+        lines.append("Superseded: these contexts have a 'cancelled' entry on this "
+                     "commit that a newer run already re-reported. Harmless.")
+        lines += [f"  {n}" for n in superseded]
+    return Verdict(0, lines, progress=progress)
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -124,25 +282,19 @@ def main() -> int:
         if runs is None:
             time.sleep(args.interval)
             continue
-        req = [r for r in runs if "required" in (r.get("name") or "")]
-        pool = req or runs
-        if not pool:
-            time.sleep(args.interval)
-            continue
-        done = [r for r in pool if r.get("status") == "completed"]
-        bad = [r for r in done if r.get("conclusion") not in ("success", "neutral", "skipped")]
-        state = f"{len(done)}/{len(pool)} complete, {len(bad)} failing"
-        if state != last:
-            last = state  # only reported at the end; keeps the transcript to one block
-        if bad:
-            print(f"\nFAILED on {sha[:8]} -- {len(bad)} of {len(pool)} required checks:")
-            for r in bad:
-                print(f"  {r['name']}: {r.get('conclusion')}")
+        v = classify(runs)
+        if v.progress:
+            last = v.progress  # only reported at the end; keeps the transcript to one block
+
+        if v.code == 1:
+            print(f"\nFAILED on {sha[:8]} -- " + v.lines[0])
+            for line in v.lines[1:]:
+                print(line)
             if not args.no_log:
                 # The check-run `id` is NOT the Actions job id that `gh run view --job`
                 # wants; passing it fails with "could not find job". The job id is the
                 # trailing path segment of details_url (.../actions/runs/<run>/job/<job>).
-                job = job_id_from(bad[0].get("details_url"))
+                job = job_id_from((v.log_target or {}).get("details_url"))
                 rc, out = (gh(["run", "view", "--repo", REPO, "--log-failed", "--job", job])
                            if job else (1, ""))
                 if rc == 0 and out:
@@ -153,15 +305,25 @@ def main() -> int:
                     where = job or "<job id>"
                     print("\n(could not fetch the failing log; read it with "
                           f"`gh run view --repo {REPO} --log-failed --job {where}`)")
-                    if bad[0].get("details_url"):
-                        print(f" or open {bad[0]['details_url']}")
+                    if (v.log_target or {}).get("details_url"):
+                        print(f" or open {v.log_target['details_url']}")
             print("\nNEVER `gh run rerun` -- it overwrites this log permanently. "
                   "Push a new commit for a fresh run.")
             return 1
-        if len(done) == len(pool):
-            print(f"\nGREEN on {sha[:8]} -- all {len(pool)} required checks passed.")
+
+        if v.code == 4:
+            print(f"\nBLOCKED on {sha[:8]} -- " + v.lines[0].split(" -- ", 1)[1])
+            for line in v.lines[1:]:
+                print(line)
+            return 4
+
+        if v.code == 0:
+            print(f"\nGREEN on {sha[:8]} -- " + v.lines[0])
+            for line in v.lines[1:]:
+                print(line)
             print("Confirm this SHA is still the PR head before reporting it.")
             return 0
+
         time.sleep(args.interval)
 
     print(f"\nSTILL RUNNING after {args.timeout}s ({last}). "

--- a/tools/test_ci_wait.py
+++ b/tools/test_ci_wait.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/ci-wait.py's verdict logic.
+
+ci-wait.py is the tool every agent uses to decide a PR is ready, so its verdict
+is worth proving against synthetic check-run payloads rather than only against a
+live PR. The payloads below are the shape
+`GET /repos/{o}/{r}/commits/{sha}/check-runs` returns.
+
+Run: python3 tools/test_ci_wait.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location("ci_wait", os.path.join(HERE, "ci-wait.py"))
+cw = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cw)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+_next_id = [1000]
+
+
+def run(name: str, conclusion: str | None, status: str = "completed", cid: int | None = None):
+    if cid is None:
+        _next_id[0] += 1
+        cid = _next_id[0]
+    return {"name": name, "status": status, "conclusion": conclusion, "id": cid,
+            "details_url": f"https://x/actions/runs/1/job/{cid}"}
+
+
+LEGS = ["bc-tests / BC 27.0 (required)", "bc-tests / BC 28.3 (required)"]
+
+
+def green_set(**kw):
+    runs = [run(n, "success") for n in LEGS]
+    runs.append(run("All BC versions passed", "success"))
+    runs.append(run("Tests updated", "success"))
+    runs.append(run("scripts/ unit tests", "success"))
+    return runs
+
+
+print("ci-wait.py verdict logic")
+
+# --- the plain green case must stay green, or a fix that flags everything wins
+v = cw.classify(green_set())
+check("an all-success rollup is GREEN", v.code == 0, f"(code={v.code}) {v.lines}")
+check("...and says nothing about cancellations",
+      not any("cancel" in l.lower() for l in v.lines), v.lines)
+
+# --- a real failure still outranks everything, and still gets its log fetched
+runs = green_set()
+runs[0] = run(LEGS[0], "failure")
+v = cw.classify(runs)
+check("a failing required leg is FAILED", v.code == 1, f"(code={v.code})")
+check("...and the failing run is offered for the log fetch",
+      v.log_target is not None and v.log_target["name"] == LEGS[0], str(v.log_target))
+
+# --- #2726: a cancelled REQUIRED context, newest for its name, blocks the merge
+runs = green_set()
+runs.append(run("Tests updated", "cancelled", cid=9999))
+v = cw.classify(runs)
+check("a cancelled required context is NOT reported green", v.code != 0, f"(code={v.code})")
+check("...and gets its own verdict code, distinct from failure and timeout",
+      v.code == 4, f"(code={v.code})")
+check("...and names the context", any("Tests updated" in l for l in v.lines), v.lines)
+check("...and does not claim anything failed",
+      not any("FAILED on" in l for l in v.lines), v.lines)
+
+# --- the other direction: a cancelled entry SUPERSEDED by a later success is
+# --- cosmetic, and must not be reported as a block
+runs = green_set()
+runs.append(run("Tests updated", "cancelled", cid=500))  # older than the success above
+v = cw.classify(runs)
+check("a cancelled entry superseded by a newer success stays GREEN",
+      v.code == 0, f"(code={v.code}) {v.lines}")
+check("...but is still mentioned, so the grey entries are explained",
+      any("cancelled" in l.lower() for l in v.lines), v.lines)
+
+# --- a cancelled NON-required context does not block a merge, so it must not
+# --- produce a blocking verdict either
+runs = green_set()
+runs.append(run("scripts/ unit tests", "cancelled", cid=9999))
+v = cw.classify(runs)
+check("a cancelled non-required context stays GREEN", v.code == 0, f"(code={v.code}) {v.lines}")
+check("...and is named as cosmetic",
+      any("scripts/ unit tests" in l for l in v.lines), v.lines)
+
+# --- a cancelled required LEG is a required context too
+runs = green_set()
+runs.append(run(LEGS[1], "cancelled", cid=9999))
+v = cw.classify(runs)
+check("a cancelled '(required)' matrix leg blocks", v.code == 4, f"(code={v.code})")
+
+# --- nothing is decided while checks are still running
+runs = green_set()
+runs[0] = run(LEGS[0], None, status="in_progress")
+v = cw.classify(runs)
+check("an in-flight leg is still pending, not a verdict", v.code is None, f"(code={v.code})")
+
+runs = green_set()
+runs[0] = run(LEGS[0], None, status="in_progress")
+runs.append(run("Tests updated", "cancelled", cid=9999))
+v = cw.classify(runs)
+check("a cancellation mid-run is not called a block yet", v.code is None, f"(code={v.code})")
+
+# --- the required contexts that are NOT named '(required)' must be waited on
+# --- and judged: reporting GREEN while 'Tests updated' is red was possible
+runs = [run(n, "success") for n in LEGS]
+runs.append(run("All BC versions passed", "success"))
+runs.append(run("Tests updated", "failure"))
+v = cw.classify(runs)
+check("a failing 'Tests updated' is not reported green", v.code == 1, f"(code={v.code})")
+
+runs = [run(n, "success") for n in LEGS]
+runs.append(run("All BC versions passed", None, status="queued"))
+v = cw.classify(runs)
+check("a queued 'All BC versions passed' keeps the verdict pending",
+      v.code is None, f"(code={v.code})")
+
+# --- a required context that never reports at all must not hang the tool: a
+# --- docs-only PR skips 'Tests updated' entirely
+runs = [run(n, "success") for n in LEGS]
+runs.append(run("All BC versions passed", "success"))
+v = cw.classify(runs)
+check("a required context absent from the rollup does not block the verdict",
+      v.code == 0, f"(code={v.code}) {v.lines}")
+
+# --- neutral/skipped are not failures
+runs = [run(n, "success") for n in LEGS]
+runs.append(run("All BC versions passed", "success"))
+runs.append(run("Tests updated", "skipped"))
+v = cw.classify(runs)
+check("a skipped required context is not a failure", v.code == 0, f"(code={v.code}) {v.lines}")
+
+# --- real data, PR #2740 head 6b95477f: 'Tests updated' failed, then a
+# --- no-tests-needed label produced a newer 'skipped'. GitHub read the newer
+# --- one and the PR merged. Scanning every entry instead of the newest per
+# --- name reported that merged PR as FAILED.
+runs = [run(n, "success") for n in LEGS]
+runs.append(run("All BC versions passed", "success"))
+runs.append(run("Tests updated", "failure", cid=101297899468))
+runs.append(run("Tests updated", "skipped", cid=101297995090))
+v = cw.classify(runs)
+check("a failure superseded by a newer skipped run is GREEN, not FAILED",
+      v.code == 0, f"(code={v.code}) {v.lines}")
+
+# ...and the reverse ordering is still a failure, so this is not just ignoring
+# every failure that shares a name with something.
+runs = [run(n, "success") for n in LEGS]
+runs.append(run("All BC versions passed", "success"))
+runs.append(run("Tests updated", "skipped", cid=101297899468))
+runs.append(run("Tests updated", "failure", cid=101297995090))
+v = cw.classify(runs)
+check("...but a failure that IS the newest entry still fails", v.code == 1, f"(code={v.code})")
+
+# --- an older cancelled entry must not hold the pool 'incomplete' forever
+runs = [run(n, "success") for n in LEGS]
+runs.append(run("All BC versions passed", "success"))
+runs.append(run("Tests updated", "cancelled", cid=10))
+runs.append(run("Tests updated", "success", cid=20))
+v = cw.classify(runs)
+check("an older cancelled entry does not stall the verdict", v.code == 0, f"(code={v.code})")
+
+# --- an empty rollup is not a verdict
+v = cw.classify([])
+check("an empty rollup is pending, not green", v.code is None, f"(code={v.code})")
+
+print()
+if FAILURES:
+    print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")
+    sys.exit(1)
+print("all checks passed")


### PR DESCRIPTION
Closes #2726

## Mechanism

A branch ruleset satisfies a required status check from the **newest check run carrying that
context name on the head commit**, and a `cancelled` conclusion does not satisfy it. Unlike a
failure, nothing surfaces it: `gh pr checks` prints the rollup's summarised state and reads
SUCCESS.

`concurrency.cancel-in-progress` produces that conclusion whenever a second run enters the
group. Which cause of cancellation matters, and they are not the same:

| cause | verdict |
|---|---|
| a new **push** supersedes an older run (`synchronize`) | correct, unchanged. The superseded run's checks hang off the older SHA, which no ruleset reads. The argument for it at the top of `pr-check.yml` and `test-matrix.yml` stands. |
| a merge to `main` supersedes an older `main` run | correct, unchanged, same reason. The brief's `e517869d` example is this one — and its check runs are in fact all `success`; only the *run-level* conclusion is `cancelled`. Rulesets read check runs, not run conclusions, so it never blocked anything. |
| a **same-commit** re-trigger — `edited`, `labeled`, `unlabeled` | **the bug.** The cancelled run's checks land on the very commit the ruleset is evaluating. |
| a job cancelled because a sibling failed | not applicable — `bc-tests` sets `fail-fast: false`, and a failure is already reported as a failure. |

Only the third row is addressed. Measured, not assumed:

- The `main` ruleset (id `15001420`) requires exactly two contexts: `All BC versions passed`
  and `Tests updated`. The entries carry **no `integration_id`**, so they match by context name
  only — which is what makes moving a required job between workflow files safe.
- `Tests updated` comes from `pr-check.yml`, which triggers on all three same-SHA types. It was
  the only exposed required context. `All BC versions passed` was never exposed: `test-matrix.yml`
  uses the default trigger types.
- On #2722's head `d5c334c1`, the cancelled run `33955335305` is confirmed to have produced the
  `Tests updated` check run (`gh api .../check-runs/101279804998` → `.../runs/33955335305/job/...`).
  That is the required context that blocked, and it is not in the issue body's list of eight,
  which is why the list looked like it consisted only of non-required checks.

This is not routine at all. On PR #2753's head, `Tests updated` carries a cancelled entry today;
it merged only because a newer run happened to re-report it.

## What I changed, and why the alternatives are worse

**Chosen: make the run not cancel the required context in the first place.** `require-tests`
moves to a new `require-tests.yml` with **no `concurrency` block** and **no `edited` trigger**.
The job body is byte-identical to the one removed (verified by diff). Cancelling this job was
never worth anything — it is a checkout plus a `git diff` — and the `labeled` bypass never
depended on cancelling: it works by a *newer* check run superseding the stale one, which still
happens with the older run allowed to finish.

- **Rejected: report a clear reason on the required context.** Nothing can. The cancelled check
  run belongs to a run that no longer exists to write output, and the ruleset reads a
  conclusion, not a message.
- **Insufficient alone: fix only `tools/ci-wait.py`.** It diagnoses the phantom but leaves every
  merge still blocked, requiring a manual re-run each time. Done as well, not instead.
- **Rejected: the issue body's direction 1** (head SHA in the concurrency group) — the issue's
  own follow-up comment already falsified it: a body edit does not change the SHA, so both runs
  land in the same group either way.
- **Not done: the fuller three-job split** proposed in that comment (moving the two body-linting
  jobs out too, so `pr-check.yml` drops `edited` entirely). Its stated blocker was "whether the
  required contexts survive the split", and the ruleset query above answers it: the body-linting
  contexts are **not required**, so cancelling them cannot block a merge. That split addresses
  grey UI noise, not the merge block, and it would require reworking the #2159 trigger guard for
  a cosmetic gain. Deliberately left out; the leftover noise is now explained by `ci-wait.py`
  instead, and `pr-check.yml`'s comment records the reasoning.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — `labeled`/`unlabeled` are same-SHA
   triggers too, and every impl agent labels a PR immediately after opening it, while the first
   run is in flight. The issue only names `edited`. Removing `require-tests` from that workflow
   covers all three at once, which a narrower "drop `edited`" fix would not have.
2. **Sibling making the same assumption?** Yes, two in `ci-wait.py`'s verdict path (below).
3. **Two paths writing the same state with different invariants?** Yes — nothing enforced that a
   required context lives in a cancellation-safe workflow. `check_required_contexts.py` now
   does, and also fails when a required context is produced by **no** workflow, the mirror-image
   outage the comment above `test-matrix.yml`'s `all-tests` job warns about and which nothing
   checked.

`check_pr_check_triggers.sh` gains an explicit required-type argument, because the move creates
a new silent-regression path: `labeled`/`unlabeled` are now load-bearing in `require-tests.yml`,
and dropping them would quietly break the docs-only bypass. The default list is unchanged, so
every pre-existing assertion still holds.

## Two further defects found in `ci-wait.py`, same shape

- Its pool was "every check whose name contains `required`" — the 8 `bc-tests` legs and nothing
  else. **Both** ruleset contexts were excluded, so a *failing* `Tests updated` was reported
  GREEN. Ruleset contexts are now judged, but only once they have actually appeared, so a
  docs-only PR that skips the job does not turn into a timeout.
- It judged *every* check run rather than the newest per name. Measured against PR #2740's head
  `6b95477f`, where `Tests updated` is `failure` and then `skipped` after a `no-tests-needed`
  label: GitHub read the newer entry and the PR merged, while that logic reports a merged PR as
  FAILED. Found by running the new code over real data, and fixed.

## RED to GREEN (all run, nothing quoted unrun)

**Workflow half.** `check_required_contexts.py` written first, run against the real tree:

```
::error::required context 'Tests updated' in pr-check.yml combines cancel-in-progress with
same-SHA pull_request type(s) edited, labeled, unlabeled -- ...
exit=1
```

It flagged the one context the incident hit and cleared `All BC versions passed`. After the
extraction: `required contexts cannot be left cancelled on the head commit: All BC versions
passed, Tests updated`, exit 0. Its own 16 fixture tests cover both directions, including
`cancel-in-progress` with only default types (fine), same-SHA types with no concurrency (fine),
`cancel-in-progress: false` (fine), job-level concurrency (caught), and reusable-workflow
context naming.

The `edited` guard was proved in both directions on a real copy of `require-tests.yml`: passes
as committed, exits 1 with the error when `edited` is added.

**`ci-wait.py` half.** `tools/test_ci_wait.py` written first — `AttributeError: module 'ci_wait'
has no attribute 'classify'`. After implementing, 23 checks pass, covering the cancelled-required
case (exit 4, names the context, does not claim a failure) and the negatives that catch a fix
which flags everything: a plain green rollup stays green and says nothing about cancellations; a
cancelled entry superseded by a newer success stays green; a cancelled *non-required* context
stays green; a cancellation seen mid-run is not called a block.

**Against real data**, 40 recent PR head commits classified: 34 green stayed green, the genuine
failures stayed failures, in-flight stayed pending, zero false exit 4. That scan is what caught
the #2740 false positive; re-run after the fix, #2740 correctly reports green. End-to-end runs
of the actual script against PRs #2753 and #2722 both return exit 0.

Also ran, unchanged and passing: `test_check_pr_check_triggers.sh` (13), the CI-skip guard, the
closing-reference guard, and the agent-MCP guard plus its real-tree check. All nine workflow
files parse.

## Scope notes for the reviewer

- **This is CI plumbing and asserts nothing about Business Central**, so no upstream corpus test
  is owed and none was written.
- No `AlRunner/` file is touched, so the `Tests updated` gate does not fire and no bypass label
  is needed. The gate's own job is what moved; it will report from `require-tests.yml` on this
  PR, which is the migration proving itself.
- `CHANGELOG.md` untouched; nothing under `tests/al-language/` touched.

---

Filed by agent `stma-auto-3` on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
