### PR TITLE
fix(report): an execution failure must not be reported as a compile failure

### DIFF
--- a/.github/workflows/ms-bucket.yml
+++ b/.github/workflows/ms-bucket.yml
@@ -47,6 +47,24 @@ name: MS bucket (manual)
 #     happened.
 # Always state whether a number was measured WITH or WITHOUT --test-data: the two differ by
 # 3x on Tests-SINGLESERVER and are not comparable.
+#
+# WHICH BC BUILDS --test-data CAN ACTUALLY BE MEASURED ON, as of reader v0.1.1 (#2779, #2780)
+#   The pinned reader opens the W1 demo backup for some builds and refuses others. Measured
+#   directly, one `bcdb companies` per backup, same binary:
+#
+#     28.0.46665.54310  OK      28.2.50931.54319  refused
+#     28.1.49838.54308  OK      28.3.52162.54309  refused
+#     27.5.46862.48827  OK      28.4.53241.54318  refused
+#
+#   The refusal is "block N of MSDA region is neither mapped by the derived extent list nor
+#   padding filler — backup layout differs from the derived model, refusing to guess", from
+#   BcDb.Core's PageFile. It is NOT a regression: reader v0.1.0, v0.1.1 and the source build
+#   before both fail identically, so the reader has never read a 28.2+ backup. Tracked in
+#   #2780; the fix is in StefanMaron/BusinessCentral.BakReader, not here.
+#
+#   Consequence for THIS workflow: the default bc-version (the newest prefix in
+#   .github/bc-versions.txt, currently 28.4) cannot produce a --test-data number. Pass
+#   `bc-version: 28.1` for one, or run with test-data off and say so.
 
 on:
   workflow_dispatch:
@@ -147,16 +165,32 @@ jobs:
         if: ${{ inputs.test-data }}
         id: reader
         env:
+          # PINNED, deliberately (#2779). This used to resolve the LATEST release at run time
+          # (`gh release view … --jq .tagName`), which made this workflow's result depend on
+          # when another repository last published — a change here could not explain a change
+          # in the answer, and the first run's failure was investigated as a reader regression
+          # partly because the tag had moved between the working local baseline and CI. It had
+          # not regressed; but the workflow's own comment already said the reader's identity
+          # keys the install-baseline cache and that a reader fix changes DECODED VALUES, which
+          # is an argument for pinning it, not for floating it.
+          #
+          # To move it: pick the new tag from
+          # https://github.com/StefanMaron/BusinessCentral.BakReader/releases, run this
+          # workflow once on the new pin, and compare the pass/fail totals against the previous
+          # pin's run before merging the bump. A reader upgrade that changes decoded values
+          # changes this measurement, so the bump belongs in its own PR with both numbers in
+          # the body.
+          READER_TAG: v0.1.1
           GH_TOKEN: ${{ github.token }}
         run: |
-          # bcbak is StefanMaron/BusinessCentral.BakReader's `bcdb`, consumed as the latest
+          # bcbak is StefanMaron/BusinessCentral.BakReader's `bcdb`, consumed as a pinned
           # release's Native AOT asset rather than built here: a source build needs the .NET 10
           # SDK plus clang and adds minutes, and the release binary is the one that repo's own
           # hermetic test suite gated before publishing. The runner probes the OLD name at
           # ~/.cache/al-runner/bcbak/bcbak (BackupReaderTool.CandidateExecutables), so the
           # asset is installed under that name. The tag lands in the summary: the reader's
           # identity keys the install-baseline cache and a reader fix changes decoded values.
-          tag=$(gh release view --repo StefanMaron/BusinessCentral.BakReader --json tagName --jq .tagName)
+          tag="$READER_TAG"
           mkdir -p "$RUNNER_TEMP/reader"
           cd "$RUNNER_TEMP/reader"
           gh release download "$tag" --repo StefanMaron/BusinessCentral.BakReader \

--- a/AlRunner.Tests/BackupReaderFailureReportingTests.cs
+++ b/AlRunner.Tests/BackupReaderFailureReportingTests.cs
@@ -1,0 +1,214 @@
+// BackupReaderFailureReportingTests — issue #2779.
+//
+// WHAT WENT WRONG, MEASURED
+//   The ms-bucket workflow's first run (Actions run 33967273260, Tests-ERM on BC
+//   28.4.53241.54318) produced 0 tests, and the only thing the report said was:
+//
+//     Tests-ERM: EXEC-FAIL: the backup reader failed (exit 1) for:
+//       /home/runner/.cache/al-runner/bcbak/bcbak companies …/BusinessCentral-W1.bak
+//
+//   under a "=== Tests-ERM — COMPILE FAIL ===" header, with `compile-fail: 1`, `exec-fail: 0`
+//   and `"classification": "compile/other"` in results.json.
+//
+//   The reader had in fact printed its reason to stderr:
+//
+//     error: block 116504 of MSDA region is neither mapped by the derived extent list nor
+//     padding filler — backup layout differs from the derived model, refusing to guess
+//
+//   That text was appended as line 2 of the exception message, and every bundle-level reporter
+//   keeps only line 1 (ExecFailure.Describe — a deliberate one-line contract that
+//   ExecFailureTests pins). So the one sentence that diagnoses the failure was discarded, and
+//   the label on what remained said "compile" about a run with zero AL compile errors.
+//   Reproducing it took a manual download of the 932 MB backup and a hand-run of the reader.
+//
+// WHAT IS PROVED HERE
+//   The unit tests below pin the message shape: the reader's own text on the FIRST line, for
+//   both transports (spawn and serve). The end-to-end test spawns the real runner against a
+//   fake reader that fails exactly the way the real one did, and asserts on what a reader of
+//   the report actually sees — the header, the counters and results.json. Asserting on the
+//   printed report rather than on an internal value is the point: an internal assertion cannot
+//   see a diagnosis that never reaches the page, which is the whole defect.
+using System.Diagnostics;
+using System.Text;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class BackupReaderFailureReportingTests
+{
+    /// <summary>The real reader's real message for this failure, used verbatim so the test
+    /// fails if the shape that actually occurred stops surviving.</summary>
+    private const string RealReaderStderr =
+        "error: block 116504 of MSDA region is neither mapped by the derived extent list nor "
+        + "padding filler — backup layout differs from the derived model, refusing to guess";
+
+    // ───────────────────────────────────────────── the message shape ──
+
+    [Fact]
+    public void Condense_PutsTheReadersDiagnosisOnOneLine()
+    {
+        var condensed = BackupReaderTool.Condense(RealReaderStderr + "\n");
+
+        Assert.Equal(RealReaderStderr, condensed);
+        Assert.DoesNotContain("\n", condensed, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Condense_JoinsMultipleLinesRatherThanKeepingOnlyTheFirst()
+    {
+        var condensed = BackupReaderTool.Condense("first thing\nsecond thing\n\nthird thing");
+
+        Assert.Contains("first thing", condensed, StringComparison.Ordinal);
+        Assert.Contains("second thing", condensed, StringComparison.Ordinal);
+        Assert.Contains("third thing", condensed, StringComparison.Ordinal);
+        Assert.DoesNotContain("\n", condensed, StringComparison.Ordinal);
+    }
+
+    /// <summary>Negative: a reader that says nothing must be reported as saying nothing, not as
+    /// a message with a hole in it. "The binary died silently" is a different diagnosis from
+    /// "the reader refused", and the report has to be able to tell them apart.</summary>
+    [Fact]
+    public void Condense_SaysSoWhenTheReaderPrintedNothing()
+    {
+        Assert.Contains("printed nothing", BackupReaderTool.Condense(""), StringComparison.Ordinal);
+        Assert.Contains("printed nothing", BackupReaderTool.Condense(null), StringComparison.Ordinal);
+        Assert.Contains("printed nothing", BackupReaderTool.Condense("   \n \n"), StringComparison.Ordinal);
+    }
+
+    /// <summary>A pathological reader must not turn one suite-error line into a wall of text.</summary>
+    [Fact]
+    public void Condense_CapsRunawayOutput_AndSaysHowMuchItDropped()
+    {
+        var condensed = BackupReaderTool.Condense(
+            string.Join("\n", Enumerable.Range(0, 40).Select(i => $"line {i}")));
+
+        Assert.Contains("line 0", condensed, StringComparison.Ordinal);
+        Assert.Contains("(+35 more line(s))", condensed, StringComparison.Ordinal);
+        Assert.DoesNotContain("line 39", condensed, StringComparison.Ordinal);
+    }
+
+    /// <summary>The sibling transport: a serve-mode refusal carried the reader's text on line 2
+    /// for exactly the same reason, so it was discarded exactly the same way.</summary>
+    [Fact]
+    public void AServeRefusalCarriesTheReadersTextOnTheFirstLine()
+    {
+        var ex = Assert.Throws<BackupReaderException>(() => BackupReaderServe.TranslateReadResponse(
+            """{"id":2,"ok":false,"error":"no table matches 'No Such Table'"}""",
+            "read No Such Table"));
+
+        var firstLine = ex.Message.Split('\n')[0];
+        Assert.Contains("no table matches 'No Such Table'", firstLine, StringComparison.Ordinal);
+        Assert.Contains("read No Such Table", firstLine, StringComparison.Ordinal);
+    }
+
+    // ─────────────────────────────────────────────────── end to end ──
+
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    /// <summary>
+    /// The whole failure, end to end, against a fake reader that fails the way the real one did:
+    /// non-zero exit from `companies`, with the diagnosis on stderr.
+    ///
+    /// RED (pre-fix): stdout carries "COMPILE FAIL" and `compile-fail:1` / `exec-fail:   0`, and
+    /// the reader's sentence appears nowhere in the output or in results.json.
+    /// GREEN: "EXEC FAIL", `exec-fail:   1`, and the sentence in both.
+    /// </summary>
+    [SkippableFact]
+    public void AReaderFailureIsReportedAsAnExecutionFailure_WithTheReadersOwnReason()
+    {
+        TestArtifacts.SkipIfMissing();
+        Skip.IfNot(OperatingSystem.IsLinux(), "the fake reader is a shell script");
+
+        var root = TestScratch.Dir("al-runner-2779-reader-failure");
+        var bundle = Path.Combine(root, "reader-failure-suite");
+        Directory.CreateDirectory(bundle);
+
+        File.WriteAllText(Path.Combine(bundle, "app.json"), $$"""
+        {
+          "id": "{{Guid.NewGuid()}}",
+          "name": "Reader Failure Reporting 2779",
+          "publisher": "Repro2779",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62700, "to": 62709 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(bundle, "ReaderFailure.al"), """
+        codeunit 62700 "Reader Failure Tests 2779"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure NeverReached()
+            begin
+                if 1 <> 1 then
+                    Error('unreachable');
+            end;
+        }
+        """);
+
+        // A reader that fails the way the real one did. `--version` still answers, so the
+        // failure is a refusal of THIS backup and not a broken install.
+        var fakeReader = Path.Combine(root, "bcbak");
+        File.WriteAllText(fakeReader, $"""
+        #!/bin/sh
+        if [ "$1" = "--version" ]; then echo "bcdb 0.0.0-fake"; exit 0; fi
+        echo "{RealReaderStderr}" >&2
+        exit 1
+        """);
+        File.SetUnixFileMode(fakeReader,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute
+            | UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+            | UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+
+        // Only its existence matters: the run never gets past `companies`.
+        var backup = Path.Combine(root, "BusinessCentral-W1.bak");
+        File.WriteAllBytes(backup, new byte[] { 0x54, 0x41, 0x50, 0x45 });
+
+        var resultsJson = Path.Combine(root, "results.json");
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" \"").Append(bundle).Append('"');
+        args.Append(" \"--test-data=").Append(backup).Append('"');
+        args.Append(" --test-data-company \"CRONUS International Ltd_\"");
+        args.Append(" --out \"").Append(resultsJson).Append('"');
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        psi.Environment[BackupReaderTool.ExecutableEnvVar] = fakeReader;
+
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(600_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        string output; lock (sb) output = sb.ToString();
+
+        // The reader really was reached — without this the rest could pass for the wrong reason.
+        Assert.Contains("block 116504 of MSDA region", output, StringComparison.Ordinal);
+
+        // The label. This is the half that sent a human hunting for AL compile errors.
+        Assert.Contains("— EXEC FAIL ===", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("— COMPILE FAIL ===", output, StringComparison.Ordinal);
+        Assert.Contains("exec-fail:   1", output, StringComparison.Ordinal);
+        Assert.Contains("compile-fail:0", output, StringComparison.Ordinal);
+
+        // …and the same two claims in the machine-readable report the workflow uploads.
+        var json = File.ReadAllText(resultsJson);
+        Assert.Contains("\"kind\": \"execute\"", json, StringComparison.Ordinal);
+        Assert.Contains("block 116504 of MSDA region", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"kind\": \"compile\"", json, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner.Tests/BundleFailureStageTests.cs
+++ b/AlRunner.Tests/BundleFailureStageTests.cs
@@ -1,0 +1,243 @@
+// BundleFailureStageTests — issue #2779.
+//
+// THE DEFECT THESE PIN
+//   A bundle that produced zero tests was reported as COMPILE FAIL unconditionally, whatever
+//   actually failed. Measured on the ms-bucket workflow's first run (Actions run 33967273260):
+//   every AL object in Microsoft's Tests-ERM bucket compiled cleanly, the BC backup reader then
+//   refused the backup at run time, and the report said `compile-fail: 1`, `exec-fail: 0`,
+//   printed "=== Tests-ERM — COMPILE FAIL ===" and classified the failure `compile/other` in
+//   --out's JSON. Reading that report sends you hunting for AL compile errors that do not
+//   exist, which is exactly what happened.
+//
+//   Two halves have to hold together, and the second is what makes the first safe:
+//     1. the STAGE is decided by what failed (BundleFailureStage), and
+//     2. every consumer of BucketStage.ExecuteFailed actually PRINTS the reason. `ProcessError`
+//        is set only by the out-of-process fan-out path, so before this change an in-process
+//        execution failure would have rendered as a bare "EXEC FAIL" header with no text under
+//        it — trading a wrong report for an empty one.
+//
+//   The drift guard at the bottom is the third: it reads Program.cs's own error literals, so a
+//   new marker that nothing classifies fails the build instead of silently defaulting.
+using System.Text.RegularExpressions;
+using AlRunner;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class BundleFailureStageTests
+{
+    // ───────────────────────────────────────────────── marker parsing ──
+
+    [Theory]
+    [InlineData("Tests-ERM: EXEC-FAIL: the backup reader failed (exit 1)", "EXEC-FAIL")]
+    [InlineData("<bundled>: EMIT-TIMEOUT after 3600s", "EMIT-TIMEOUT")]
+    [InlineData("<bundled>: COMPILE-FAIL (3): CS0246 …", "COMPILE-FAIL")]
+    [InlineData("Contoso_Sales_1_0_0_0: TEST-TIMEOUT-ABORT: codeunit 50000 abandoned", "TEST-TIMEOUT-ABORT")]
+    [InlineData("<bundled>: PARTIAL-EMIT-DROP for M: 4 object(s) declared", "PARTIAL-EMIT-DROP")]
+    public void MarkerOf_ReadsTheMarkerOffTheRealLineShapes(string line, string expected)
+        => Assert.Equal(expected, BundleFailureStage.MarkerOf(line));
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("no separator at all")]
+    [InlineData("name: lowercase text with no marker")]
+    public void MarkerOf_ReturnsNullWhenThereIsNoMarker(string line)
+        => Assert.Null(BundleFailureStage.MarkerOf(line));
+
+    // ───────────────────────────────────────────────── stage decision ──
+
+    /// <summary>The CI failure this issue is about, at the level the stage is decided.</summary>
+    [Fact]
+    public void AReaderFailureAtRunTimeIsAnExecutionFailure_NotACompileFailure()
+    {
+        var errors = new[]
+        {
+            "Tests-ERM: EXEC-FAIL: the backup reader failed (exit 1): block 116504 of MSDA region "
+            + "is neither mapped by the derived extent list nor padding filler",
+        };
+
+        Assert.Equal(BucketStage.ExecuteFailed, BundleFailureStage.Classify(errors));
+    }
+
+    [Fact]
+    public void CodeunitsAbandonedByTheWatchdogAreAnExecutionFailure()
+        => Assert.Equal(BucketStage.ExecuteFailed,
+            BundleFailureStage.Classify(new[] { "App: TEST-TIMEOUT-ABORT: codeunit 50000 abandoned" }));
+
+    /// <summary>The negative direction, and the one that keeps this from being a rename: a real
+    /// compile failure must still read as one.</summary>
+    [Theory]
+    [InlineData("<bundled>: COMPILE-FAIL (3): CS0246 The type or namespace 'X' could not be found")]
+    [InlineData("<bundled>: EMIT-FAIL: BC's compiler threw")]
+    [InlineData("<bundled>: EMIT-ZERO (7 AL error(s))")]
+    [InlineData("Suite: AL-DIAGNOSTIC-FAIL (2): AL0118 …")]
+    [InlineData("<bundled>: EMIT-TIMEOUT after 120s")]
+    [InlineData("<bundled>: EMIT-EXCLUDED for M: 2 object(s) dropped from the module")]
+    [InlineData("<bundled>: PARTIAL-EMIT-DROP for M: 9 object(s) declared, only 4 emitted")]
+    public void EveryPreExecutionMarkerStillReadsAsACompileFailure(string error)
+        => Assert.Equal(BucketStage.CompileFailed, BundleFailureStage.Classify(new[] { error }));
+
+    /// <summary>A bundle where one app group failed to compile and another threw at run time is
+    /// a compile failure: something genuinely did not compile, and reporting "exec fail" would
+    /// be the same wrong-report defect pointing the other way.</summary>
+    [Fact]
+    public void AMixOfCompileAndExecutionErrorsStaysACompileFailure()
+    {
+        var errors = new[]
+        {
+            "AppA: COMPILE-FAIL (1): CS0103 The name 'x' does not exist",
+            "AppB: EXEC-FAIL: session is not open",
+        };
+
+        Assert.Equal(BucketStage.CompileFailed, BundleFailureStage.Classify(errors));
+    }
+
+    /// <summary>An unrecognised marker is conservative, not optimistic — the CompileFailed path
+    /// is the one that prints the whole error list, so a line nobody classified is still read.</summary>
+    [Fact]
+    public void AnUnrecognisedMarkerFallsBackToCompileFailed()
+        => Assert.Equal(BucketStage.CompileFailed,
+            BundleFailureStage.Classify(new[] { "App: SOME-NEW-MARKER: whatever" }));
+
+    [Fact]
+    public void NoErrorsAtAllIsNotAnExecutionFailure()
+        => Assert.Equal(BucketStage.CompileFailed, BundleFailureStage.Classify(Array.Empty<string>()));
+
+    // ─────────────────────────────────── the reason must be printed ──
+
+    private static BucketResult ExecFailedBucket(params string[] errors)
+        => new("/tmp/ms-buckets/Tests-ERM", BucketStage.ExecuteFailed, errors, null,
+               Array.Empty<TestResult>(), TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero);
+
+    /// <summary>
+    /// The half that makes the stage split safe. `ProcessError` is null for an in-process
+    /// failure, and the EXEC FAIL branch used to print only that — so switching the stage
+    /// without this would have replaced a wrong header with an empty block.
+    /// </summary>
+    [Fact]
+    public void PrintPerTest_PrintsTheReasonUnderTheExecFailHeader()
+    {
+        var w = new StringWriter();
+        Reporter.PrintPerTest(new[] { ExecFailedBucket(
+            "Tests-ERM: EXEC-FAIL: the backup reader failed (exit 1): block 116504 of MSDA region") },
+            w, showPass: false);
+
+        var text = w.ToString();
+        Assert.Contains("— EXEC FAIL ===", text, StringComparison.Ordinal);
+        Assert.Contains("block 116504 of MSDA region", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("COMPILE FAIL", text, StringComparison.Ordinal);
+    }
+
+    /// <summary>Same claim for the JSON `--out` writes: results.json carried
+    /// `"kind": "compile"` and `"classification": "compile/other"` for this exact failure.</summary>
+    [Fact]
+    public void WriteClassification_NamesItAnExecutionFailureAndCarriesTheReason()
+    {
+        var dir = TestScratch.Dir("al-runner-2779-classification");
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "results.json");
+        Reporter.WriteClassification(new[] { ExecFailedBucket(
+            "Tests-ERM: EXEC-FAIL: the backup reader failed (exit 1): block 116504 of MSDA region") },
+            path);
+
+        var json = File.ReadAllText(path);
+        Assert.Contains("\"kind\": \"execute\"", json, StringComparison.Ordinal);
+        Assert.Contains("execute/exec-fail", json, StringComparison.Ordinal);
+        Assert.Contains("block 116504 of MSDA region", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("compile/other", json, StringComparison.Ordinal);
+    }
+
+    /// <summary>An ExecuteFailed bucket used to appear NOWHERE in --json: not in `tests` (it has
+    /// none) and not in `compilationErrors` (it is not compile-failed). A whole bundle vanished
+    /// from the document with nothing saying so.</summary>
+    [Fact]
+    public void SerializeJsonOutput_DoesNotDropAnExecutionFailedBundle()
+    {
+        var json = Reporter.SerializeJsonOutput(
+            new[] { ExecFailedBucket("Tests-ERM: EXEC-FAIL: the backup reader failed (exit 1): block 116504") }, 2);
+
+        Assert.Contains("executionErrors", json, StringComparison.Ordinal);
+        Assert.Contains("block 116504", json, StringComparison.Ordinal);
+    }
+
+    /// <summary>Negative: a run with no execution failure serialises exactly as before, so the
+    /// new field is additive rather than a schema change every consumer has to absorb.</summary>
+    [Fact]
+    public void SerializeJsonOutput_OmitsTheFieldWhenNothingFailedToExecute()
+    {
+        var ran = new BucketResult("/tmp/ok", BucketStage.Ran, Array.Empty<string>(), null,
+            Array.Empty<TestResult>(), TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero);
+
+        Assert.DoesNotContain("executionErrors", Reporter.SerializeJsonOutput(new[] { ran }, 0),
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The interaction the stage split would otherwise have broken. `--jobs` fan-out counts the
+    /// per-bundle headers in each shard's captured output to report "NOT RUN: N bundle(s)"
+    /// (#2715 / #2721) — a bundle with zero tests is absent from that shard's JUnit, so without
+    /// the count the aggregate reports a smaller total as though it were complete. It looked for
+    /// the COMPILE FAIL header only; moving execution failures to their own header would have
+    /// re-introduced exactly that silent loss.
+    ///
+    /// The counter is fed the REAL printer's output here, so the two cannot drift apart by
+    /// someone spelling the header twice.
+    /// </summary>
+    [Fact]
+    public void FanOutCountsAnExecutionFailedBundleAsNotRun_JustLikeACompileFailedOne()
+    {
+        var w = new StringWriter();
+        Reporter.PrintPerTest(new[] { ExecFailedBucket("Tests-ERM: EXEC-FAIL: the reader failed") },
+            w, showPass: false);
+        var shardOutput = w.ToString();
+
+        var counted = Infrastructure.ParallelFanOut.NotRunHeaders
+            .Sum(h => Infrastructure.ParallelFanOut.CountOccurrences(shardOutput, h));
+        Assert.Equal(1, counted);
+
+        // The pre-fix behaviour, stated as a fact: looking only for the compile header scores
+        // this bundle 0 — absent from the aggregate with nothing saying so.
+        Assert.Equal(0, Infrastructure.ParallelFanOut.CountOccurrences(shardOutput, " — COMPILE FAIL ==="));
+    }
+
+    // ────────────────────────────────────────────────── drift guard ──
+
+    /// <summary>
+    /// Every marker Program.cs and ExecFailure.cs actually write must be classified here. Without
+    /// this, adding a marker and forgetting to classify it produces a silently mislabelled report
+    /// — the same class of defect as the one being fixed, and invisible until someone reads a
+    /// summary and believes it.
+    /// </summary>
+    [Fact]
+    public void EveryMarkerTheRunnerWritesIsClassified()
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var token = new Regex(@"\b[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)+\b");
+
+        var found = new SortedSet<string>(StringComparer.Ordinal);
+
+        // Program.cs: the `bundleErrors.Add(...)` call and the three lines that may continue it.
+        var program = File.ReadAllLines(Path.Combine(repoRoot, "AlRunner", "Program.cs"));
+        for (var i = 0; i < program.Length; i++)
+        {
+            if (!program[i].Contains("bundleErrors.Add", StringComparison.Ordinal)) continue;
+            for (var w = i; w < Math.Min(i + 4, program.Length); w++)
+                foreach (Match m in token.Matches(program[w]))
+                    found.Add(m.Value);
+        }
+
+        // ExecFailure.cs composes the EXEC-FAIL line for the bundled path, so its literal is not
+        // in Program.cs at all.
+        foreach (Match m in token.Matches(
+                     File.ReadAllText(Path.Combine(repoRoot, "AlRunner", "Infrastructure", "ExecFailure.cs"))))
+            found.Add(m.Value);
+
+        Assert.NotEmpty(found);
+        var unclassified = found.Except(BundleFailureStage.KnownMarkers, StringComparer.Ordinal).ToList();
+        Assert.True(unclassified.Count == 0,
+            $"BundleFailureStage does not classify: {string.Join(", ", unclassified)}. "
+            + "Add each to PreExecutionMarkers or ExecutionMarkers — an unclassified marker is "
+            + "reported as a compile failure whatever it actually was.");
+    }
+}

--- a/AlRunner.Tests/MsBucketWorkflowTests.cs
+++ b/AlRunner.Tests/MsBucketWorkflowTests.cs
@@ -141,6 +141,26 @@ public sealed class MsBucketWorkflowTests
         Assert.Contains("--output-junit", code, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// #2779: the backup reader is PINNED to a tag, not resolved to whatever is newest at run
+    /// time. `gh release view … --jq .tagName` made this workflow's result depend on when a
+    /// different repository last published — the measurement could change with no change here,
+    /// and the reader's identity keys the install-baseline cache, so a reader upgrade changes
+    /// decoded values. Both halves are asserted: the pin is present, and the run-time
+    /// resolution is gone.
+    /// </summary>
+    [Fact]
+    public void MsBucketWorkflow_PinsTheBackupReaderRelease_RatherThanResolvingLatest()
+    {
+        var code = CodeOnly(Read(Path.Combine("workflows", Workflow)));
+
+        Assert.Contains("READER_TAG: v", code, StringComparison.Ordinal);
+        Assert.Contains("tag=\"$READER_TAG\"", code, StringComparison.Ordinal);
+        Assert.DoesNotContain("gh release view", code, StringComparison.Ordinal);
+        // The download still uses the tag, so pinning cannot silently stop pinning.
+        Assert.Contains("gh release download \"$tag\"", code, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void ProvisioningAction_CarriesTheBuildAndBothAppDownloads()
     {

--- a/AlRunner/Infrastructure/BackupReaderServe.cs
+++ b/AlRunner/Infrastructure/BackupReaderServe.cs
@@ -169,8 +169,13 @@ internal static class BackupReaderServe
             if (!root.TryGetProperty("ok", out var ok) || ok.ValueKind != JsonValueKind.True)
             {
                 var error = root.TryGetProperty("error", out var e) ? e.GetString() : null;
+                // #2779: the reader's own text on line 1, not line 2. Same defect as the
+                // spawning transport's non-zero-exit message had — every bundle-level reporter
+                // keeps only line 1 of an EXEC-FAIL message, so a refusal reason placed under
+                // the request description was discarded before anyone read it.
                 throw new BackupReaderException(
-                    $"the backup reader refused: {describeRequest}\n  {error ?? responseLine}");
+                    $"the backup reader refused: {BackupReaderTool.Condense(error ?? responseLine)} "
+                    + $"— request: {describeRequest}");
             }
             if (!root.TryGetProperty("headers", out var headers) || headers.ValueKind != JsonValueKind.Array)
                 throw new BackupReaderException(

--- a/AlRunner/Infrastructure/BackupReaderTool.cs
+++ b/AlRunner/Infrastructure/BackupReaderTool.cs
@@ -84,11 +84,16 @@ internal static class BackupReaderTool
         var onPath = TryFindOnPath(ExecutableName);
         if (onPath != null) return _resolved = onPath;
 
-        var probed = string.Join("\n    ", CandidateExecutables(env, home).Append($"<each PATH entry>/{ExecutableName}"));
+        // Everything actionable on the FIRST line (#2779), for the same reason TestDataOptions.
+        // ResolveBackupPath does it: the bundle reporter keeps only line 1 of an EXEC-FAIL
+        // message, so a "Probed:" list on line 3 never reached anyone. This message's whole
+        // value is the list of places that were looked in and the env var that overrides them.
+        var probed = string.Join(", ",
+            CandidateExecutables(env, home).Append($"<each PATH entry>/{ExecutableName}").Select(c => $"'{c}'"));
         throw new BackupReaderException(
-            $"--test-data needs the BC backup reader '{ExecutableName}', which was not found.\n"
-            + $"  Probed:\n    {probed}\n"
-            + $"  Set {ExecutableEnvVar} to the executable (or to the directory containing it).");
+            $"--test-data needs the BC backup reader '{ExecutableName}', which was not found — "
+            + $"probed {probed}. Set {ExecutableEnvVar} to the executable "
+            + "(or to the directory containing it).");
     }
 
     /// <summary>Reset the memoised resolution/identity. Test-only seam: the resolution reads
@@ -191,8 +196,43 @@ internal static class BackupReaderTool
         var errText = stderr.GetAwaiter().GetResult();
         if (proc.ExitCode != 0)
             throw new BackupReaderException(
-                $"the backup reader failed (exit {proc.ExitCode}) for: {exe} {string.Join(' ', args)}\n"
-                + $"  {errText.Trim()}");
+                $"the backup reader failed (exit {proc.ExitCode}): {Condense(errText)} "
+                + $"— command: {exe} {string.Join(' ', args)}");
         return outText;
+    }
+
+    /// <summary>
+    /// Collapse a reader diagnostic onto ONE line, because that is the only line that survives
+    /// (#2779).
+    ///
+    /// The reader's stderr IS the diagnosis. It used to be appended as line 2 of the exception
+    /// message, and every bundle-level reporter keeps only line 1 of an EXEC-FAIL message
+    /// (ExecFailure.Describe, and ExecFailureTests pins that one-line contract deliberately —
+    /// a multi-line suite-error line would break every consumer downstream). Measured on the
+    /// ms-bucket workflow's first run (Actions run 33967273260): all that reached results.json
+    /// was "the backup reader failed (exit 1) for: … BusinessCentral-W1.bak", while the reader
+    /// had printed "block 116504 of MSDA region is neither mapped by the derived extent list
+    /// nor padding filler — backup layout differs from the derived model, refusing to guess",
+    /// which names the cause outright. Diagnosing it took a manual re-run against the same
+    /// backup. See .claude/rules/loud-failures.md: a tool that fails with a reason must not be
+    /// reduced to an exit code.
+    ///
+    /// Empty input is reported as such rather than producing a message with a hole in it —
+    /// "the reader said nothing" is itself a fact worth reading, and distinguishes a crashed
+    /// binary from a refusal.
+    /// </summary>
+    internal static string Condense(string? text, int maxLines = 5, int maxChars = 600)
+    {
+        var lines = (text ?? "")
+            .Split('\n')
+            .Select(l => l.Trim())
+            .Where(l => l.Length > 0)
+            .ToList();
+        if (lines.Count == 0) return "(the reader printed nothing to stderr)";
+
+        var kept = string.Join(" | ", lines.Take(maxLines));
+        if (lines.Count > maxLines) kept += $" | (+{lines.Count - maxLines} more line(s))";
+        if (kept.Length > maxChars) kept = kept[..maxChars] + "… (truncated)";
+        return kept;
     }
 }

--- a/AlRunner/Infrastructure/BundleFailureStage.cs
+++ b/AlRunner/Infrastructure/BundleFailureStage.cs
@@ -1,0 +1,92 @@
+// BundleFailureStage — which pipeline stage a bundle's suite-error lines describe.
+//
+// WHY THIS EXISTS (issue #2779)
+//   A bundle that produced zero tests used to be reported as COMPILE FAIL unconditionally:
+//
+//       if (bundleTests.Count == 0 && bundleErrors.Count > 0) stage = BucketStage.CompileFailed;
+//
+//   The stage is not a cosmetic label. It decides the "=== <bundle> — COMPILE FAIL ===" header,
+//   the `compile-fail:` / `exec-fail:` counters in the summary, and `"kind": "compile"` plus a
+//   `compile/*` classification in --out's JSON. Measured on the ms-bucket workflow's first run
+//   (Actions run 33967273260): the BC backup reader refused the backup, every AL object had
+//   compiled cleanly, and the run reported `compile-fail: 1`, `exec-fail: 0` and
+//   `"classification": "compile/other"`. The reader of that report goes looking for AL compile
+//   errors that do not exist.
+//
+//   BucketStage.ExecuteFailed already existed and was reachable only from the out-of-process
+//   (fan-out) path, never from the in-process run loop that produces these lines.
+//
+// HOW THE STAGE IS DECIDED
+//   Every line Program.cs appends to `bundleErrors` starts with `<name>: <MARKER>`, and the
+//   marker says which stage failed. Classification is by marker, and the marker set is CLOSED:
+//   an unrecognised marker is treated as pre-execution, and BundleFailureStageTests scans
+//   Program.cs's own `bundleErrors.Add` literals and fails if one appears that this file does
+//   not know about — so adding a marker without classifying it is a build failure, not a
+//   silently mislabelled report.
+//
+//   A bundle is ExecuteFailed only when EVERY error is an execution-stage failure. A mix means
+//   something genuinely failed to compile, and hiding that behind "exec fail" would be the same
+//   wrong-report defect pointing the other way.
+namespace AlRunner.Infrastructure;
+
+internal static class BundleFailureStage
+{
+    /// <summary>The marker on a line reporting a failure of the test RUN itself — the module
+    /// compiled and loaded, and then something threw or was abandoned.</summary>
+    internal const string ExecFail = "EXEC-FAIL";
+
+    /// <summary>The marker on a line reporting codeunits abandoned by the per-test watchdog.
+    /// Execution-stage for the same reason: the module ran.</summary>
+    internal const string TestTimeoutAbort = "TEST-TIMEOUT-ABORT";
+
+    /// <summary>Markers for a failure BEFORE anything could run — AL emit, BC's own AL
+    /// diagnostics, or the C# compile of the emitted sources.</summary>
+    internal static readonly IReadOnlyList<string> PreExecutionMarkers = new[]
+    {
+        "EMIT-TIMEOUT", "EMIT-FAIL", "EMIT-EXCLUDED", "EMIT-ZERO",
+        "PARTIAL-EMIT-DROP", "AL-DIAGNOSTIC-FAIL", "COMPILE-FAIL",
+    };
+
+    /// <summary>Markers for a failure AFTER the module compiled and loaded.</summary>
+    internal static readonly IReadOnlyList<string> ExecutionMarkers = new[] { ExecFail, TestTimeoutAbort };
+
+    /// <summary>Every marker this file classifies. The drift guard compares Program.cs's
+    /// literals against this set.</summary>
+    internal static IEnumerable<string> KnownMarkers => PreExecutionMarkers.Concat(ExecutionMarkers);
+
+    /// <summary>
+    /// The marker of one bundle-error line, or null when the line carries none. The lines are
+    /// `&lt;name&gt;: &lt;MARKER&gt;…`, where the name is an app-group assembly name, a suite
+    /// name or the literal `&lt;bundled&gt;`, so the marker is the first upper-case token after
+    /// the first ": " separator.
+    /// </summary>
+    internal static string? MarkerOf(string error)
+    {
+        if (string.IsNullOrEmpty(error)) return null;
+        var sep = error.IndexOf(": ", StringComparison.Ordinal);
+        if (sep < 0) return null;
+        var rest = error.AsSpan(sep + 2);
+        var end = 0;
+        while (end < rest.Length && (char.IsAsciiLetterUpper(rest[end]) || rest[end] == '-')) end++;
+        if (end == 0) return null;
+        var token = rest[..end].ToString().TrimEnd('-');
+        return token.Length == 0 ? null : token;
+    }
+
+    internal static bool IsExecutionFailure(string error)
+    {
+        var marker = MarkerOf(error);
+        return marker != null && ExecutionMarkers.Contains(marker, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// The stage to report for a bundle that produced no tests. ExecuteFailed only when every
+    /// error is an execution-stage failure; anything else — including an unrecognised marker —
+    /// stays CompileFailed, which is the conservative direction because that path prints the
+    /// error list in full.
+    /// </summary>
+    internal static BucketStage Classify(IReadOnlyList<string> errors)
+        => errors.Count > 0 && errors.All(IsExecutionFailure)
+            ? BucketStage.ExecuteFailed
+            : BucketStage.CompileFailed;
+}

--- a/AlRunner/Infrastructure/ParallelFanOut.cs
+++ b/AlRunner/Infrastructure/ParallelFanOut.cs
@@ -291,8 +291,13 @@ internal static class ParallelFanOut
             // totals above with no trace — the exact shape #2715 measured (40,550 tests down to
             // 14,856, reported as a plain total). Count it here so the aggregate says a bundle
             // is missing instead of silently reporting the smaller number as complete.
-            notRun += CountOccurrences(stdout, " — COMPILE FAIL ===")
-                    + CountOccurrences(stderr, " — COMPILE FAIL ===");
+            //
+            // BOTH headers, since #2779: a bundle that compiled and then failed at RUN time now
+            // reports "— EXEC FAIL ===" instead. It contributes zero tests for exactly the same
+            // reason, so counting only the compile header would have re-introduced #2715's
+            // silent loss for every execution failure.
+            foreach (var header in NotRunHeaders)
+                notRun += CountOccurrences(stdout, header) + CountOccurrences(stderr, header);
         }
 
         Console.WriteLine();
@@ -305,8 +310,8 @@ internal static class ParallelFanOut
         Console.WriteLine($"  error:       {errors}");
         Console.WriteLine($"  skipped:     {skipped}");
         if (notRun > 0)
-            Console.WriteLine($"  NOT RUN:     {notRun} bundle(s) — COMPILE FAIL in a shard above, " +
-                               "excluded from the totals; see that shard's output for which one");
+            Console.WriteLine($"  NOT RUN:     {notRun} bundle(s) — COMPILE FAIL or EXEC FAIL in a " +
+                               "shard above, excluded from the totals; see that shard's output for which one");
         Console.WriteLine("=================================================================");
 
         ScratchDirs.Release(tempDir);
@@ -319,9 +324,15 @@ internal static class ParallelFanOut
         catch { return p.TrimEnd('/', '\\'); }
     }
 
-    /// <summary>How many times a bundle reported COMPILE FAIL in a shard's captured output —
-    /// used to tell the aggregate summary how many bundles are missing from its totals, rather
-    /// than reporting the smaller total as though it were complete (#2715).</summary>
+    /// <summary>The per-bundle headers Reporter.PrintPerTest writes for a bundle that produced
+    /// no tests. Both mean "this bundle is absent from the JUnit totals"; which one appears
+    /// depends only on WHAT failed (#2779).</summary>
+    internal static readonly IReadOnlyList<string> NotRunHeaders =
+        new[] { " — COMPILE FAIL ===", " — EXEC FAIL ===" };
+
+    /// <summary>How many times a bundle reported COMPILE FAIL or EXEC FAIL in a shard's captured
+    /// output — used to tell the aggregate summary how many bundles are missing from its totals,
+    /// rather than reporting the smaller total as though it were complete (#2715).</summary>
     internal static int CountOccurrences(string haystack, string needle)
     {
         if (string.IsNullOrEmpty(haystack)) return 0;

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3343,12 +3343,20 @@ foreach (var bundle in bundles)
         else
             Console.WriteLine($"  → {sP}P/{sF}F/{sE}E across {bundleTests.Count} tests, {bundleErrors.Count} suite errors ({(bundleEmit + bundleComp + bundleRun).TotalSeconds:F1}s)");
     }
-    // Deliberately still gated on an EMPTY bundle. CompileFailed suppresses the bucket's
+    // Deliberately still gated on an EMPTY bundle. A non-Ran stage suppresses the bucket's
     // per-test reporting (Reporter treats it as "nothing ran"), so widening it to any suite
     // error would hide the tests that DID pass — trading one silent inaccuracy for another.
     // Partial suite loss reaches the exit code via computedExitCode's CompileErrors check
     // instead, which keeps the surviving results in the report and the JSON.
-    if (bundleTests.Count == 0 && bundleErrors.Count > 0) bundleStage = BucketStage.CompileFailed;
+    //
+    // #2779: WHICH non-Ran stage is decided by the errors' own markers, not assumed. This used
+    // to hardcode CompileFailed, so a bundle whose AL compiled cleanly and then failed at RUN
+    // time — the BC backup reader refusing the backup, on the ms-bucket workflow's first run —
+    // was reported as `compile-fail: 1` under a "COMPILE FAIL" header and classified
+    // `compile/other` in --out's JSON, sending the reader hunting for AL errors that never
+    // existed.
+    if (bundleTests.Count == 0 && bundleErrors.Count > 0)
+        bundleStage = AlRunner.Infrastructure.BundleFailureStage.Classify(bundleErrors);
     results.Add(new BucketResult(bundleAbs, bundleStage,
         bundleErrors, null, bundleTests,
         bundleEmit, bundleComp, bundleRun, ranGroupCount, bundleProvisionGaps));

--- a/AlRunner/Reporter.cs
+++ b/AlRunner/Reporter.cs
@@ -181,6 +181,14 @@ public static class Reporter
                 w.WriteLine();
                 w.WriteLine($"=== {Path.GetFileName(b.BucketPath)} — EXEC FAIL ===");
                 if (b.ProcessError != null) w.WriteLine($"  {b.ProcessError}");
+                // #2779: an in-process bundle that failed at RUN time has no ProcessError — its
+                // diagnosis is in the suite-error list, the same list the COMPILE FAIL branch
+                // above prints. Without this the header was the ONLY thing printed and the
+                // reason vanished entirely, which is the defect this stage split would
+                // otherwise have introduced while fixing the wrong header.
+                foreach (var e in b.CompileErrors.Take(20)) w.WriteLine($"  {e}");
+                if (b.CompileErrors.Count > 20)
+                    w.WriteLine($"  ... and {b.CompileErrors.Count - 20} more errors");
                 continue;
             }
             // Skip silent buckets — only emit a per-bucket header if there's anything to show.
@@ -310,6 +318,21 @@ public static class Reporter
             .Select(b => new { file = b.BucketPath, errors = b.CompileErrors.ToList() })
             .ToList();
 
+        // #2779: an ExecuteFailed bucket used to appear NOWHERE in this document — not in
+        // `tests` (it has none), not in `compilationErrors` (it is not compile-failed). A
+        // consumer reading `--json` saw a run that silently lost a whole bundle. Additive and
+        // null-omitted, so a run with no execution failure serialises byte-identically.
+        var executionErrors = buckets
+            .Where(b => b.Stage == BucketStage.ExecuteFailed)
+            .Select(b => new
+            {
+                file = b.BucketPath,
+                errors = b.ProcessError is { } pe
+                    ? b.CompileErrors.Prepend(pe).ToList()
+                    : b.CompileErrors.ToList(),
+            })
+            .ToList();
+
         var output = new
         {
             tests = tests.Select(t => new
@@ -343,6 +366,7 @@ public static class Reporter
             total = tests.Count,
             exitCode,
             compilationErrors = compileErrors.Count > 0 ? compileErrors : null,
+            executionErrors = executionErrors.Count > 0 ? executionErrors : null,
             // #1936: same "real wall clock, not just the measured phases" gap as the
             // `wall:` line in PrintSummary — see that comment. Additive field, so
             // existing consumers reading this JSON are unaffected.
@@ -373,12 +397,19 @@ public static class Reporter
             }
             else if (b.Stage == BucketStage.ExecuteFailed)
             {
+                // #2779: `ProcessError` is set only by the out-of-process fan-out path. An
+                // in-process bundle that failed at RUN time carries its diagnosis in the same
+                // suite-error list a compile failure uses, so emitting only `error` here would
+                // have written `"error": null` — a failure record naming nothing. Both fields
+                // are emitted, and the classification comes from the errors' own markers rather
+                // than asserting a child process died when none did.
                 failures.Add(new
                 {
                     bucket = b.BucketPath,
                     kind = "execute",
                     error = b.ProcessError,
-                    classification = "process-error",
+                    errors = b.CompileErrors.Take(10).ToList(),
+                    classification = ClassifyExecute(b),
                 });
             }
             else
@@ -425,6 +456,20 @@ public static class Reporter
             .Take(15)  // more frames for diagnosis
             .Select(l => l.Trim())
             .ToArray();
+    }
+
+    /// <summary>
+    /// The classification for a bucket that failed at RUN time (#2779). `process-error` is kept
+    /// for the out-of-process fan-out path, where a child process really did fail; an in-process
+    /// bundle is named by its own error marker instead, so a reader can tell a thrown exception
+    /// from codeunits abandoned by the per-test watchdog without parsing the message.
+    /// </summary>
+    private static string ClassifyExecute(BucketResult b)
+    {
+        if (b.ProcessError != null) return "process-error";
+        var first = b.CompileErrors.FirstOrDefault();
+        var marker = first == null ? null : Infrastructure.BundleFailureStage.MarkerOf(first);
+        return marker == null ? "execute/other" : $"execute/{marker.ToLowerInvariant()}";
     }
 
     // Hand-tuned classification heuristics — purely descriptive, not authoritative.

--- a/AlRunner/WatchDashboard.cs
+++ b/AlRunner/WatchDashboard.cs
@@ -127,7 +127,15 @@ public static class WatchDashboard
                 any = true;
                 var bucketLabel = Markup.Escape(Path.GetFileName(b.BucketPath));
                 var node = tree.AddNode($"[blue]{bucketLabel}[/]  [red]EXEC FAILED[/]");
-                node.AddNode($"[red]{Markup.Escape(b.ProcessError ?? "execution failed")}[/]");
+                // #2779: same sibling gap as Reporter.PrintPerTest's EXEC FAIL branch — an
+                // in-process bundle that failed at run time has no ProcessError, and its
+                // diagnosis is in the suite-error list. Without this the dashboard printed the
+                // placeholder "execution failed" and nothing else.
+                if (b.ProcessError != null) node.AddNode($"[red]{Markup.Escape(b.ProcessError)}[/]");
+                foreach (var err in b.CompileErrors)
+                    node.AddNode($"[red]{Markup.Escape(err)}[/]");
+                if (b.ProcessError == null && b.CompileErrors.Count == 0)
+                    node.AddNode("[red]execution failed[/]");
                 continue;
             }
 

--- a/scripts/ms-bucket-summary.py
+++ b/scripts/ms-bucket-summary.py
@@ -34,9 +34,24 @@ import xml.etree.ElementTree as ET
 # Every line matching one of these is a caveat, copied verbatim. Anchored where the runner's
 # own text is stable (Reporter.cs summary block, AbortResume.cs messages, the per-bundle
 # status lines), tolerant of leading whitespace.
+# The markers Program.cs puts on a bundle-level suite-error line; kept in step with
+# AlRunner/Infrastructure/BundleFailureStage.cs, which classifies the same set.
+BUNDLE_ERROR_MARKERS = (
+    "EMIT-TIMEOUT", "EMIT-FAIL", "EMIT-EXCLUDED", "EMIT-ZERO", "PARTIAL-EMIT-DROP",
+    "AL-DIAGNOSTIC-FAIL", "COMPILE-FAIL", "EXEC-FAIL", "TEST-TIMEOUT-ABORT",
+)
+
 CAVEAT_PATTERNS = (
-    re.compile(r"^\s*COMPILE FAIL\b"),
-    re.compile(r"^\s*EXEC FAIL\b"),
+    # Reporter.PrintPerTest's per-bundle header: "=== <bundle> — COMPILE FAIL ===" (em dash).
+    # This used to be anchored as r"^\s*COMPILE FAIL\b", which matches nothing the runner
+    # actually prints — the bundle's NAME never reached the summary (#2779). The test that
+    # covered it fed a hand-written line in a shape the runner does not emit.
+    re.compile(r"^\s*=== .* (?:COMPILE|EXEC) FAIL ==="),
+    # The suite-error lines under that header — the actual diagnosis, e.g.
+    # "Tests-ERM: EXEC-FAIL: the backup reader failed (exit 1): block 116504 …". Without
+    # these the summary said a bundle failed and never said why, which is what made the
+    # first ms-bucket run take several steps to diagnose.
+    re.compile(r"^\s*\S.*?: (?:" + "|".join(BUNDLE_ERROR_MARKERS) + r")\b"),
     re.compile(r"^\s*NOT RUN:"),
     re.compile(r"^\s*resume:"),
     re.compile(r"carried from earlier attempt"),

--- a/scripts/tests/ms-bucket-summary.test.py
+++ b/scripts/tests/ms-bucket-summary.test.py
@@ -71,8 +71,13 @@ class ScanLogTests(unittest.TestCase):
         self.assertIn("  total:       4321.5s", scan["summary_block"])
 
     def test_lost_bundles_resumes_and_not_run_lines_are_caveats(self):
+        # The per-bundle header is written the way Reporter.PrintPerTest actually writes it —
+        # "=== <bundle> \u2014 COMPILE FAIL ===". This test used to feed "COMPILE FAIL  /tmp/..."
+        # instead, a shape the runner never emits, so it passed while the pattern it covered
+        # matched nothing in a real log (#2779).
         log = (
-            "COMPILE FAIL  /tmp/ms-buckets/Tests-ERM: AL0185 ...\n"
+            "\n=== Tests-ERM \u2014 COMPILE FAIL ===\n"
+            "  Tests-ERM: COMPILE-FAIL (3): CS0246 The type or namespace 'X' could not be found\n"
             "resume: a watchdog abort ended this attempt early. Continuing in a fresh process, "
             "skipping 3 codeunit(s) already attempted or hung; 4 resume attempt(s) left after this one.\n"
             "NOT RUN: 1 bundle(s)\n"
@@ -81,7 +86,8 @@ class ScanLogTests(unittest.TestCase):
             + CLEAN_LOG
         )
         caveats = mbs.scan_log(log)["caveats"]
-        self.assertTrue(any(c.startswith("COMPILE FAIL") for c in caveats), caveats)
+        self.assertTrue(any("COMPILE FAIL ===" in c for c in caveats), caveats)
+        self.assertTrue(any("Tests-ERM" in c for c in caveats), caveats)
         self.assertTrue(any(c.startswith("resume:") for c in caveats), caveats)
         self.assertTrue(any(c.startswith("NOT RUN:") for c in caveats), caveats)
         self.assertTrue(any("carried from earlier attempt" in c for c in caveats), caveats)
@@ -89,6 +95,34 @@ class ScanLogTests(unittest.TestCase):
         # The zero-count summary lines are NOT caveats.
         self.assertFalse(any("compile-fail:0" in c for c in caveats), caveats)
         self.assertFalse(any("exec-fail:   0" in c for c in caveats), caveats)
+
+    def test_the_reason_a_bundle_failed_reaches_the_caveats(self):
+        """Actions run 33967273260, verbatim. The summary named a failure and never its cause:
+        the reader's own sentence is the one thing that diagnoses it, and it has to survive."""
+        log = (
+            "[1/1] ms-buckets/Tests-ERM \u2014 1 suites\n"
+            "  \u2192 0P/0F/0E across 0 tests, 1 suite errors (59.9s)\n"
+            "\n=== Tests-ERM \u2014 EXEC FAIL ===\n"
+            "  Tests-ERM: EXEC-FAIL: the backup reader failed (exit 1): block 116504 of MSDA "
+            "region is neither mapped by the derived extent list nor padding filler\n"
+            "  exec-fail:   1\n"
+            + CLEAN_LOG
+        )
+        caveats = mbs.scan_log(log)["caveats"]
+        self.assertTrue(any("EXEC FAIL ===" in c for c in caveats), caveats)
+        self.assertTrue(any("block 116504 of MSDA region" in c for c in caveats), caveats)
+        self.assertTrue(any(c.strip() == "exec-fail:   1" for c in caveats), caveats)
+
+    def test_ordinary_test_output_is_not_mistaken_for_a_bundle_error(self):
+        """The negative: per-test FAIL lines and passing output must not become caveats, or
+        every Microsoft bucket run drowns the real ones in thousands of lines."""
+        log = (
+            "  FAIL  Codeunit 134000.\"Sales Invoice\" (12ms)\n"
+            "        Assert.AreEqual failed: expected 3, got 4\n"
+            "  compile-fail:0\n"
+            + CLEAN_LOG
+        )
+        self.assertEqual(mbs.scan_log(log)["caveats"], [])
 
 
 class ComposeTests(unittest.TestCase):
@@ -145,10 +179,12 @@ class MainTests(unittest.TestCase):
         self.assertIn("| 9496 |", md)
 
     def test_missing_junit_exits_nonzero_but_still_writes_a_summary(self):
-        code, md = self._run(None, "COMPILE FAIL x\n", rc=3)
+        # The header shape Reporter.PrintPerTest really writes (#2779) — the previous
+        # "COMPILE FAIL x" is not a line the runner emits.
+        code, md = self._run(None, "=== Tests-ERM \u2014 COMPILE FAIL ===\n", rc=3)
         self.assertEqual(code, 1)
         self.assertIn("no JUnit", md)
-        self.assertIn("COMPILE FAIL x", md)
+        self.assertIn("COMPILE FAIL ===", md)
 
     def test_explicit_step_summary_path_is_appended_to(self):
         with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
Closes #2779

Opened by agent impl-8.

The manual-dispatch MS bucket workflow ran for the first time (Actions run 33967273260, `Tests-ERM` on BC 28.4.53241.54318) and failed. Diagnosing it took several steps, and every one of them was the report's fault, not the failure's.

## What actually failed, measured

The backup reader refused the backup. I reproduced it locally against the same 932 MB file, and the reader prints the reason:

```
error: block 116504 of MSDA region is neither mapped by the derived extent list nor padding filler
       — backup layout differs from the derived model, refusing to guess
```

**The "reader v0.1.1 regressed" hypothesis is dead.** Three reader builds against the same BC 28.4 backup — release v0.1.0 (`b6371f12`), release v0.1.1 (`9aecc82c`), and the local source build that is the known-good MS-bucket baseline (`f191ad44`) — all refuse it with the identical message. `f191ad44` is an ancestor of v0.1.1's tag and the three commits between are release plumbing only, so the two releases are functionally identical for reading.

The boundary is the backup, not the binary. One `bcdb companies` per file:

| BC build | result |
|---|---|
| 27.5.46862.48827 | OK |
| 28.0.46665.54310 | OK |
| 28.1.49838.54308, 28.1.49838.53910 | OK |
| 28.2.50931.54319 | refused (block 116296) |
| 28.3.52162.54309 | refused (block 116288) |
| 28.4.53241.54318 | refused (block 116504) |

The reader has never read a 28.2+ backup. That fix belongs in `StefanMaron/BusinessCentral.BakReader`, which is outside what I may push to — filed as #2780, which stays open, and recorded in this workflow's header comment with the consequence: the workflow's default `bc-version` cannot produce a `--test-data` number today, and `bc-version: 28.1` can.

## What this PR fixes

**1. An execution failure was counted as a compile failure.** `Program.cs` set `BucketStage.CompileFailed` for any bundle that produced zero tests, whatever failed. `ExecuteFailed` existed but was only reachable from the fan-out path. New `BundleFailureStage` classifies from the error's own marker, with a drift guard that scans `Program.cs`'s and `ExecFailure.cs`'s literals and fails the build if a marker appears that nothing classifies. A mix of compile and execution errors stays `CompileFailed` — something genuinely did not compile, and the mirror-image wrong report is not an improvement.

The exit code for this case changes from 3 to 2. Both are already documented; 2 is the correct one.

**2. Every `ExecuteFailed` consumer now prints the reason.** `ProcessError` is null for an in-process failure, so flipping the stage alone would have replaced a wrong header with an empty one. Fixed in `Reporter.PrintPerTest`, `Reporter.WriteClassification` (which also gets a marker-derived classification instead of asserting `process-error` when no child process died) and `WatchDashboard`. `Reporter.SerializeJsonOutput` gains `executionErrors`: an `ExecuteFailed` bucket previously appeared **nowhere** in that document — not in `tests`, not in `compilationErrors` — so a whole bundle vanished silently. The field is null-omitted, so a run with no execution failure serialises byte-identically.

**3. The reader's own stderr reaches the report.** It was on line 2 of the exception message, and every bundle-level reporter keeps only line 1 (`ExecFailure.Describe` — a one-line contract `ExecFailureTests` pins deliberately, so the fix is to put the actionable text on line 1, which `TestDataOptions.ResolveBackupPath` already does). `loud-failures.md`: a tool that fails with a reason must not be reduced to an exit code.

**4. The reader release is pinned.** `gh release view … --jq .tagName` meant an unrelated repository publishing a release changed this workflow's result with no change here. Pinned to `v0.1.1` with a comment on how to move it deliberately, and a test asserting both that the pin is there and that the run-time resolution is gone.

## Answering the three shape questions

1. **Same wrong pattern at another call site?** Yes — `ParallelFanOut`'s "NOT RUN: N bundle(s)" counter (#2715 / #2721) counted `— COMPILE FAIL ===` headers only. Moving execution failures to their own header would have re-introduced #2715's silent loss for every one of them. It now counts both, and the coupling test feeds the real printer's output into the counter so the two cannot drift.

2. **Sibling functions making the same assumption?** Three, all fixed: `BackupReaderServe.TranslateReadResponse` put a serve-mode refusal's text on line 2; `BackupReaderTool.Resolve` put its "Probed:" list on lines 2-3; `WatchDashboard`'s EXEC FAILED node printed only `ProcessError`.

3. **Two code paths writing the same state with different invariants?** Yes. `ExecuteFailed` is now reachable from two places — the fan-out path (sets `ProcessError`, empty error list) and the in-process path (empty `ProcessError`, populated error list). Every renderer now handles both rather than the one it was written for.

Cross-referencing #2746, which the brief flagged as possibly sharing a cause: it does not share this root cause (that is a suite error counted but never printed; this is a suite error printed under the wrong label), but the summary-script half here is adjacent. `scripts/ms-bucket-summary.py`'s caveat patterns were anchored `^\s*COMPILE FAIL\b` / `^\s*EXEC FAIL\b`, which match nothing the runner writes — the real line is `=== <bundle> — COMPILE FAIL ===` with an em dash — so the bundle's name never reached the job summary, and neither did the suite-error lines carrying the reason. The unit test covering them fed a hand-written line in a shape the runner does not emit, so it passed while the pattern was dead. Both are fixed, and a new negative test keeps per-test FAIL lines from becoming caveats.

## RED → GREEN

Reverting the five behavioural files to the branch base (the `Condense` helper kept as scaffold so the tests still compile):

- **RED:** 5 failures of 31 — `AServeRefusalCarriesTheReadersTextOnTheFirstLine`, `PrintPerTest_PrintsTheReasonUnderTheExecFailHeader`, `WriteClassification_NamesItAnExecutionFailureAndCarriesTheReason`, `SerializeJsonOutput_DoesNotDropAnExecutionFailedBundle`, and the end-to-end `AReaderFailureIsReportedAsAnExecutionFailure_WithTheReadersOwnReason` (which spawns the real runner against a fake reader that fails exactly as the real one did, and asserts on the printed report, the summary counters and `results.json`).
- **GREEN:** 31 of 31.

The summary script separately: **RED** 3 failures of 15 with `ms-bucket-summary.py` at the base, **GREEN** 15 of 15.

## What I ran

- `dotnet test AlRunner.Tests --filter` over `BundleFailureStage`, `BackupReaderFailureReporting`, `MsBucketWorkflow`, `ExecFailure`, `BackupReaderServe`, `Reporter`, `TestDataProvisioning`, `WatchDashboard` — **114 passed, 0 failed**. An earlier, wider filter including `JUnit` and `Classification` ran 135 passed, 0 failed.
- `python3 scripts/tests/ms-bucket-summary.test.py` — **15 passed**.
- One `tests/runner-extras` bundle end to end for the happy path (`date-virtual-table-window`, private `--cache`): 3P/0F/0E, `compile-fail:0`, `exec-fail: 0`.

I did not run the full `AlRunner.Tests` suite or the corpus locally; CI covers both.

## Deliberately left out

- The BakReader fix itself (#2780) — wrong repository, and outside what I may push to.
- Changing the workflow's default `bc-version` away from 28.4. That is a decision about which BC version the measurement should target, not a defect fix; the header comment now states the constraint and how to work around it.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
