### PR TITLE
fix(virtual-tables): do not apply the Field-table find bypass to a temporary record

### DIFF
--- a/AlRunner.Tests/FieldFindBypassTemporaryGateTests.cs
+++ b/AlRunner.Tests/FieldFindBypassTemporaryGateTests.cs
@@ -1,0 +1,86 @@
+// Issue #2524 — when the managed find bypass for the virtual Field table (2000000041) may fire.
+//
+// The bypass exists because BC's native InnerFindAsync prologue AVs on a find whose
+// MetaApplicationObject is the 2000000041 metatable, and it serves the table's REAL field
+// metadata rows. Applying it to an AL `Record "Field" temporary` was wrong twice over: the
+// temporary table's own rows were hidden behind the metadata rows, and the bypass's populate
+// step wrote those metadata rows INTO the AL programmer's temporary table. Base Application
+// report 8621 "Config. Package - Process" keys its transformation rules off
+// `Format(TempField."No.")` and read back '0' for every one of them.
+//
+// The BC-behaviour claim underneath ("a temporary Record \"Field\" round-trips what AL wrote,
+// and the non-temporary half still reports real metadata") is not pinned here — it belongs
+// upstream, and is StefanMaron/BusinessCentral.AL.Language.Tests codeunit 60663. What is pinned
+// here is the runner's own gate rule, which has no BC counterpart because BC has no bypass.
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class FieldFindBypassTemporaryGateTests
+{
+    private const int FieldTableId = 2000000041;
+
+    [Fact]
+    public void FieldTable_DatabaseBacked_TakesTheBypass()
+    {
+        Assert.True(RecordPatches.ShouldTakeFieldFindBypass(FieldTableId, isDatabaseBacked: true));
+    }
+
+    [Fact]
+    public void FieldTable_TemporaryRecord_DoesNotTakeTheBypass()
+    {
+        // The whole of #2524. A temporary record's DataAccess is never marked database-backed
+        // (NavDataAccessSource_GetDataAccessForTable marks only when isTemporary is false), so
+        // this is the case that must fall through to BC's own find.
+        Assert.False(RecordPatches.ShouldTakeFieldFindBypass(FieldTableId, isDatabaseBacked: false));
+    }
+
+    [Theory]
+    [InlineData(2000000038)] // AllObj
+    [InlineData(2000000136)] // Table Metadata
+    [InlineData(2000000026)] // Integer
+    [InlineData(18)]         // an ordinary application table
+    [InlineData(0)]
+    [InlineData(-1)]         // FindRequestTableId's "could not read" answer
+    public void AnyOtherTable_NeverTakesTheBypass_WhicheverBackingItHas(int tableId)
+    {
+        // The other conjunct, and it is not academic: dropping it would route every find in the
+        // run through a bypass built for one table's rows.
+        Assert.False(RecordPatches.ShouldTakeFieldFindBypass(tableId, isDatabaseBacked: true));
+        Assert.False(RecordPatches.ShouldTakeFieldFindBypass(tableId, isDatabaseBacked: false));
+    }
+
+    /// <summary>
+    /// The marker the gate reads. An unmarked provider — which is what a temporary record's
+    /// DataAccess carries — must answer false, and null must not throw: the gate calls this on
+    /// every Field find and a throw there would take down an ordinary metadata read.
+    /// </summary>
+    [Fact]
+    public void UnmarkedProvider_IsNotDatabaseBacked()
+    {
+        var provider = new object();
+        Assert.False(BlobStoreIsolationPatches.IsDatabaseBacked(provider));
+        Assert.False(BlobStoreIsolationPatches.IsDatabaseBacked(null));
+    }
+
+    [Fact]
+    public void MarkedProvider_IsDatabaseBacked_AndTheMarkIsPerProvider()
+    {
+        var marked = new FakeDataAccess();
+        var unmarked = new FakeDataAccess();
+        BlobStoreIsolationPatches.MarkDatabaseBacked(marked);
+
+        Assert.True(BlobStoreIsolationPatches.IsDatabaseBacked(marked.DataProvider));
+        Assert.False(BlobStoreIsolationPatches.IsDatabaseBacked(unmarked.DataProvider));
+    }
+
+    /// <summary>
+    /// Stands in for BC's DataAccess: MarkDatabaseBacked reads a `DataProvider` property off it
+    /// and marks the PROVIDER, not the DataAccess, which is the object the gate then asks about.
+    /// </summary>
+    private sealed class FakeDataAccess
+    {
+        public object DataProvider { get; } = new();
+    }
+}

--- a/AlRunner/Patches/RecordPatches.FieldFindIntercept.cs
+++ b/AlRunner/Patches/RecordPatches.FieldFindIntercept.cs
@@ -175,8 +175,20 @@ public static partial class RecordPatches
         // sit AFTER GetDataAccessForTableCore's `if (isTemporary) return` early exit, so a
         // temporary instance of those never sees injected rows. This gate is what gives the
         // Field table the same property.
-        return IsDatabaseBackedFindTarget(self);
+        return ShouldTakeFieldFindBypass(tableId, IsDatabaseBackedFindTarget(self));
     }
+
+    /// <summary>
+    /// The gate rule of <see cref="DataAccess_IsManagedFindRequest"/>, as a pure function of the
+    /// two facts it turns on, so it can be pinned without a BC runtime — see
+    /// AlRunner.Tests/FieldFindBypassTemporaryGateTests.cs.
+    ///
+    /// Take the managed Field bypass only for the virtual Field table AND only when the find's
+    /// DataAccess stands in for SQL. Both conjuncts matter and each has its own failure: dropping
+    /// the first sends every table through the bypass; dropping the second is issue #2524.
+    /// </summary>
+    internal static bool ShouldTakeFieldFindBypass(int tableId, bool isDatabaseBacked)
+        => tableId == FieldFindTableId && isDatabaseBacked;
 
     /// <summary>
     /// Whether this find's DataAccess stands in for SQL (a non-temporary table) rather than

--- a/AlRunner/Patches/RecordPatches.FieldFindIntercept.cs
+++ b/AlRunner/Patches/RecordPatches.FieldFindIntercept.cs
@@ -151,7 +151,57 @@ public static partial class RecordPatches
             RedriveAggregatePermissionSetForRequest(self, request);
             return false;
         }
-        return tableId == FieldFindTableId;
+        if (tableId != FieldFindTableId) return false;
+
+        // Issue #2524: a `Record "Field" temporary` is an ordinary in-memory table that happens
+        // to have the Field table's SHAPE, holding exactly the rows AL put in it. It must not
+        // take this bypass — the bypass exists to serve the virtual Field table's REAL metadata
+        // rows, and taking it for a temporary record both hid AL's own rows behind 178 metadata
+        // rows and, worse, wrote those metadata rows INTO the AL programmer's temporary table
+        // (EnsureFilteredFieldTablePopulated below inserts into whatever provider the DataAccess
+        // carries). Base Application report 8621 "Config. Package - Process" keys its
+        // transformation rules off `TempField."No."` and read back 0 for every one of them.
+        //
+        // The discriminator is NOT anything on the request or the metatable — both are identical
+        // for the two cases, and both DataAccesses are built by the same CreateTempDataAccess,
+        // because the runner serves every table from a TempTableDataProvider. The one place that
+        // still knows is where the DataAccess was handed out:
+        // NavDataAccessSource_GetDataAccessForTable marks the provider database-backed exactly
+        // when isTemporary is false, and BlobStoreIsolationPatches already exposes that fact for
+        // the same reason (a `temporary` record's BLOB and rowversion semantics differ too).
+        //
+        // Every other virtual table the runner populates — AllObj, Table Metadata, Page
+        // Metadata, Integer — is already correct here by construction: their populate call sites
+        // sit AFTER GetDataAccessForTableCore's `if (isTemporary) return` early exit, so a
+        // temporary instance of those never sees injected rows. This gate is what gives the
+        // Field table the same property.
+        return IsDatabaseBackedFindTarget(self);
+    }
+
+    /// <summary>
+    /// Whether this find's DataAccess stands in for SQL (a non-temporary table) rather than
+    /// serving an AL `temporary` record. Reads the same marker
+    /// <see cref="BlobStoreIsolationPatches.MarkDatabaseBacked"/> stamps at DataAccess hand-out.
+    ///
+    /// Answering TRUE when the marker cannot be read is deliberate: that is the behaviour this
+    /// gate had before #2524, so a reflection failure degrades to the old path rather than
+    /// silently turning the virtual Field table into an empty one, which would make real field
+    /// metadata disappear across the whole run.
+    /// </summary>
+    private static bool IsDatabaseBackedFindTarget(object dataAccess)
+    {
+        try
+        {
+            var provider = dataAccess.GetType()
+                .GetProperty("DataProvider", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                ?.GetValue(dataAccess);
+            if (provider == null) return true;
+            return BlobStoreIsolationPatches.IsDatabaseBacked(provider);
+        }
+        catch
+        {
+            return true;
+        }
     }
 
     private static bool IsFieldFindRequest(object request)


### PR DESCRIPTION
Closes #2524

Filed by agent impl-6.

## Mechanism

The runner serves the virtual `Field` table (2000000041) through a **managed find bypass**: a
guard prepended to `DataAccess.InnerFindAsync` that, for that one table, skips BC's native SQL
transactional-cache prologue (which AVs on it) and runs the find in managed code. Its populate
step builds the table's real field rows and inserts them into whatever provider the find's
`DataAccess` carries.

The gate turned on the table id alone:

```csharp
return tableId == FieldFindTableId;
```

A `Record "Field" temporary` has the same table id, so it took the bypass too. That is wrong in
both directions at once, and the second is the damaging one:

1. the temporary table's own rows were hidden behind the metadata rows, and
2. **the populate step wrote 178 real metadata rows into the AL programmer's temporary table.**

Base Application report 8621 "Config. Package - Process" builds its rule set in a temporary
`Field` record and keys its transformation rules off `Format(TempField."No.")` — which read `'0'`
for every rule, so each was stored *and* looked up under `'0'`. A silently wrong answer, not an
error.

Measured on `main` @ 0b649744, BC 28.1, a hermetic probe with no RapidStart involved:

| | before | after |
|---|---|---|
| `TempField."No."` immediately after `Insert()`, no find | 7 | 7 |
| after `SetRange(TableNo, 18); FindSet()` | **`TableNo=18 No.=0 FieldName=<timestamp> count=178`** | `TableNo=18 No.=7 FieldName=<> count=1` |
| after `Reset(); FindFirst()` with three columns written | **`TableNo=7 No.=0 FieldName=<timestamp>`** — the first row of the *entire* Field metadata set | `TableNo=18 No.=7 FieldName=<MYNAME> Caption=<MYCAPTION>` |
| non-temporary `Field`, table 18 field 1 | `FieldName=<No.>` | `FieldName=<No.>` (unchanged) |

The write itself was never broken — the value survives until the first find, which is what makes
this the confidently-wrong-answer shape rather than a visible failure.

## Checking the caller, not just the method

The discriminator is **not** on the find request or the metatable. I dumped both: for a temporary
and a non-temporary `Field` find they are byte-identical (`TableType=Normal`,
`SqlHasSystemId=True`, the same `NCLMetaTable` instance, `TempDataAccessVersionTokens` in both
cases), and both `DataAccess` objects are built by the same `CreateTempDataAccess` — the runner
serves *every* table from a `TempTableDataProvider`, so the provider type says nothing either.

The one place that still knows is one level up, where the `DataAccess` is handed out:
`NavDataAccessSource_GetDataAccessForTable` marks the provider database-backed exactly when
`isTemporary` is false, and `BlobStoreIsolationPatches` already exposes that fact for the same
underlying reason — a `temporary` record's BLOB and rowversion semantics differ too, and its
comment says so verbatim: *"Both branches below land on a TempTableDataProvider, so the provider
alone cannot say whether it is standing in for SQL or genuinely serving a `temporary` record …
This is the one place that still knows, so record it here."* The gate now reads that marker.

## Fixing the shape, not the reported line

- **Does the same wrong pattern appear at another call site?** The Field table has a *second*
  populate call site, in `GetDataAccessForTableCore`. It is already correct — it sits after that
  method's `if (isTemporary) return` early exit, so it never runs for a temporary record. Only
  the find gate was missing the distinction.
- **Do sibling functions make the same assumption?** No, and I measured rather than assumed:
  a temporary `Record AllObj`, `Record "Table Metadata"`, `Record "Page Metadata"`,
  `Record Integer` and a temporary ordinary table all round-trip correctly on unpatched `main`
  (`count=1`, AL's own values). They are correct **by construction** — their populate call sites
  are all after the same early exit. `Field` is the only virtual table that takes over the find
  itself, and so the only one that needed the gate. This fix gives it the property the others
  already had.
- **Do two paths maintain the same invariant?** They do now: "a temporary record sees only AL's
  rows" holds for every virtual table the runner populates, by one rule per path rather than one
  path having a guard the other lacks.

## Was letting a temporary Field find through safe?

Not assumed — this was the open question. The bypass exists because BC's native prologue AVs on
2000000041, and the file's banner records that the crash reproduced even with zero rows. That
evidence is about the **database-backed** Field `DataAccess`, which still takes the bypass. A
temporary one falling through to BC's own `InnerFindAsync` was measured, not reasoned about:
exit 0, no SIGSEGV, correct rows.

## Verification

BC 28.1 throughout.

- **Corpus test upstream** — StefanMaron/BusinessCentral.AL.Language.Tests#156, codeunit 60663,
  8 tests. "A temporary `Record \"Field\"` holds only AL's rows, and the non-temporary half still
  reports real metadata" is plain BC behaviour, so it goes there rather than into
  `runner-extras`. Against this branch: **RED 4/8 before, GREEN 8/8 after**. The pre-fix failures
  show contamination rather than absence — `"No." must round-trip. Expected:<7> Actual:<0>`, and
  `DeleteAll` raising `The Field does not exist … TableNo='15',No.='6'` on rows the test never
  inserted. When #156 merges, the pin bump and count-baseline update belong in the same PR as
  whatever still needs them, not on their own.
- **`AlRunner.Tests/FieldFindBypassTemporaryGateTests.cs`** — 10 tests, RED 1/10 with the pre-fix
  rule, GREEN 10/10 with it. Pins the gate rule as a pure function of its two inputs (both
  conjuncts, each with its own failure mode), plus the marker it reads, including that an
  unmarked provider and `null` both answer false without throwing.
- `dotnet test AlRunner.Tests --filter "~Field|~BlobStore|~VirtualTable|~DataAccess"` — 121/121
  passed, 10 skipped.
- al-language corpus — **2464/2464**. runner-extras — **237/237**. Both run at this PR's head
  commit.
- Microsoft `Tests-SINGLESERVER` `Codeunit136608` "ERM RS Validate and Apply", BC
  28.1.49838.53910, `--test-data`, company `CRONUS International Ltd_`: **40 → 42 passing**. The
  per-test diff is exactly the two tests #2524 names,
  `PackageDataProcessing_RunTransformOnSingleDataRecord` and `…OnMultipleDataRecord`, and
  nothing else moved.

## What I did not establish

I tried a full 839-test `Tests-SINGLESERVER` before/after pair for blast radius. **The baseline
run was truncated by a watchdog abort** — a hung codeunit sent it into resume, 26 codeunits were
skipped and it reported 626 tests against the after-run's 839, so the totals are not comparable
and I am not quoting them as a gain. What that pair *does* support is the negative: across the
626 tests both runs covered, **0 gained and 0 lost** — no regression anywhere in the bucket.
Codeunit 136608 was one of the skipped ones, which is why the gain is quoted from its own
isolated before/after above instead. I did not re-run the baseline to get a clean pair; the fix
only changes the code path when `tableId == 2000000041 && !isDatabaseBacked`, so nothing outside
temporary `Field` records can be affected by construction.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
