### PR TITLE
fix(reporter): name the suites a bundle lost instead of printing a clean summary

### DIFF
--- a/AlRunner.Tests/Fixtures/EmitExcludedPartialBundle/excluded-suite/Assert.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/EmitExcludedPartialBundle/excluded-suite/Assert.Codeunit.al
@@ -1,0 +1,12 @@
+/// <summary>
+/// Minimal assert for this fixture. Deliberately private to the fixture: nothing here
+/// needs the Base Application floor (.claude/rules/no-base-app-in-csharp-tests.md).
+/// </summary>
+codeunit 61300 "Emit Excl Part Assert"
+{
+    procedure AreEqual(Expected: Integer; Actual: Integer; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('%1: expected %2, got %3', Msg, Expected, Actual);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/EmitExcludedPartialBundle/excluded-suite/BrokenObject.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/EmitExcludedPartialBundle/excluded-suite/BrokenObject.Codeunit.al
@@ -1,0 +1,17 @@
+/// <summary>
+/// References a codeunit that exists nowhere in the module or its dependencies, so it
+/// cannot bind. BC's Compilation.Emit is atomic per module, so the runner's retry loop
+/// excludes THIS object and recompiles the survivors — the EMIT-EXCLUDED path of #2762.
+/// </summary>
+codeunit 61320 "Emit Excl Part Broken"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure ExcludedSuiteBroken_NeverRuns()
+    var
+        Missing: Codeunit "This Partial Codeunit Does Not Exist At All";
+    begin
+        Missing.DoSomething();
+    end;
+}

--- a/AlRunner.Tests/Fixtures/EmitExcludedPartialBundle/excluded-suite/HealthyTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/EmitExcludedPartialBundle/excluded-suite/HealthyTests.Codeunit.al
@@ -1,0 +1,19 @@
+/// <summary>
+/// Binds and compiles cleanly, yet NEVER RUNS: its sibling object in the same module is
+/// EMIT-EXCLUDED, and a module missing objects must not run at all, so Program.cs empties
+/// the module's sources. That is why the loss is bigger than the excluded-object count —
+/// the excluded set names 1 object, and 2 [Test] procedures go missing.
+/// </summary>
+codeunit 61310 "Emit Excl Part Healthy"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Emit Excl Part Assert";
+
+    [Test]
+    procedure ExcludedSuiteHealthy_NeverRuns()
+    begin
+        Assert.AreEqual(3, 1 + 2, 'this test is dropped with its module, not executed');
+    end;
+}

--- a/AlRunner.Tests/Fixtures/EmitExcludedPartialBundle/excluded-suite/app.json
+++ b/AlRunner.Tests/Fixtures/EmitExcludedPartialBundle/excluded-suite/app.json
@@ -1,0 +1,23 @@
+{
+  "id": "e4f5a6b7-8c9d-4e0f-a1b2-c3d4e5f60718",
+  "name": "Runner Tests Fixture - Emit Excluded Partial",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "A suite where ONE object is EMIT-EXCLUDED, so the whole module is dropped and the tests its healthy siblings declare go missing too.",
+  "description": "Issue #2762. One object cannot bind, so BC's emit-retry loop excludes it and Program.cs empties this module's sources — the healthy test codeunit next to it never runs either. Paired with a healthy sibling SUITE (same bundle) the bucket still reports Stage=Ran, which is the shape in which the loss used to be absent from every report surface.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "idRanges": [
+    {
+      "from": 61300,
+      "to": 61349
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner.Tests/Fixtures/EmitExcludedPartialBundle/healthy-suite/Assert.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/EmitExcludedPartialBundle/healthy-suite/Assert.Codeunit.al
@@ -1,0 +1,8 @@
+codeunit 61350 "Emit Excl Part H Assert"
+{
+    procedure AreEqual(Expected: Integer; Actual: Integer; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('%1: expected %2, got %3', Msg, Expected, Actual);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/EmitExcludedPartialBundle/healthy-suite/HealthyTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/EmitExcludedPartialBundle/healthy-suite/HealthyTests.Codeunit.al
@@ -1,0 +1,16 @@
+/// <summary>
+/// Runs and passes, keeping the bucket's Stage at Ran while its sibling suite is dropped.
+/// </summary>
+codeunit 61360 "Emit Excl Part H Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Emit Excl Part H Assert";
+
+    [Test]
+    procedure PartialBundleHealthy_StillRuns()
+    begin
+        Assert.AreEqual(3, 1 + 2, 'the healthy sibling suite must compile and run');
+    end;
+}

--- a/AlRunner.Tests/Fixtures/EmitExcludedPartialBundle/healthy-suite/app.json
+++ b/AlRunner.Tests/Fixtures/EmitExcludedPartialBundle/healthy-suite/app.json
@@ -1,0 +1,23 @@
+{
+  "id": "f5a6b7c8-9d0e-4f1a-b2c3-d4e5f6071829",
+  "name": "Runner Tests Fixture - Emit Excluded Partial Healthy",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "The healthy sibling suite that keeps the bucket non-empty, so its Stage stays Ran.",
+  "description": "Its surviving PASS is what kept the excluded sibling's loss out of every report surface: a bucket only reports CompileErrors when Stage is CompileFailed, and Stage is CompileFailed only when the bucket produced zero tests.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "idRanges": [
+    {
+      "from": 61350,
+      "to": 61399
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner.Tests/PartialSuiteLossReportingTests.cs
+++ b/AlRunner.Tests/PartialSuiteLossReportingTests.cs
@@ -320,6 +320,85 @@ public sealed class PartialSuiteLossReportingTests
         Assert.Equal(1, total);
     }
 
+    // ── --watch dashboard TREE (rendered) ────────────────────────────────────────────
+
+    /// <summary>
+    /// Renders the real dashboard through Spectre's TestConsole, the harness
+    /// WatchDashboardTests already uses. Wide profile so the node text under test is never
+    /// wrapped or truncated away — an assertion that passes only because a line was cut is
+    /// worse than no assertion.
+    /// </summary>
+    private static string RenderWatch(params BucketResult[] results)
+    {
+        var console = new Spectre.Console.Testing.TestConsole();
+        console.Profile.Width = 200;
+        console.Write(WatchDashboard.Build(results, "my-bundle", WatchStatus.Idle,
+            new DateTime(2026, 9, 5, 12, 0, 0, DateTimeKind.Local), TimeSpan.FromSeconds(1)));
+        return console.Output;
+    }
+
+    /// <summary>
+    /// Tally counts a lost suite, but the count alone is a number with no name attached — under
+    /// --watch the tree is where the developer finds out WHICH suite went missing and why, and
+    /// there is no exit code to send them looking. Asserts the concrete node text, not merely
+    /// that something rendered.
+    /// </summary>
+    [Fact]
+    public void WatchTree_RanBucketThatLostASuite_RendersANamedSuiteErrorsNode()
+    {
+        var output = RenderWatch(PartialLossBucket("/tmp/my-bundle"));
+
+        // The node header, carrying the bucket name and how many suites it lost.
+        Assert.Contains("my-bundle", output, StringComparison.Ordinal);
+        Assert.Contains("SUITE ERRORS (1)", output, StringComparison.Ordinal);
+
+        // The message itself, so the reader learns the surface (EMIT-EXCLUDED) and the module
+        // from the tree rather than from a stderr line the dashboard has already overpainted.
+        Assert.Contains("EMIT-EXCLUDED for Contoso Widgets", output, StringComparison.Ordinal);
+        Assert.Contains("23 object(s) dropped from the module", output, StringComparison.Ordinal);
+
+        // And the consequence spelled out, because a cycle has no exit code to state it.
+        Assert.Contains("MISSING from this cycle, not passing", output, StringComparison.Ordinal);
+
+        // The surviving test is still in the tree — a node that replaced the bucket's results
+        // would satisfy everything above and hide the run.
+        Assert.Contains("PartialBundleHealthy_StillRuns", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The negative control. Without it every assertion above is satisfied by an implementation
+    /// that emits the node unconditionally, which would put a red SUITE ERRORS banner on every
+    /// clean --watch cycle.
+    /// </summary>
+    [Fact]
+    public void WatchTree_CleanBucket_RendersNoSuiteErrorsNode()
+    {
+        var output = RenderWatch(CleanBucket("/tmp/my-bundle"));
+
+        Assert.DoesNotContain("SUITE ERRORS", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("MISSING from this cycle", output, StringComparison.Ordinal);
+        // …and the cycle's real results are untouched.
+        Assert.Contains("PartialBundleHealthy_StillRuns", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A bucket that lost EVERYTHING already rendered as COMPILE FAILED. It must keep doing so
+    /// rather than acquiring a second, contradictory node — the new branch is for buckets that
+    /// ran, and Stage is the thing that separates them.
+    /// </summary>
+    [Fact]
+    public void WatchTree_FullyCompileFailedBucket_StillRendersCompileFailedNotSuiteErrors()
+    {
+        var bucket = new BucketResult("/tmp/my-bundle", BucketStage.CompileFailed,
+            new[] { SuiteError }, null, Array.Empty<TestResult>(),
+            TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, 0, null);
+
+        var output = RenderWatch(bucket);
+
+        Assert.Contains("COMPILE FAILED", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("SUITE ERRORS", output, StringComparison.Ordinal);
+    }
+
     // ── --jobs aggregate ─────────────────────────────────────────────────────────────
 
     /// <summary>

--- a/AlRunner.Tests/PartialSuiteLossReportingTests.cs
+++ b/AlRunner.Tests/PartialSuiteLossReportingTests.cs
@@ -1,0 +1,461 @@
+// PartialSuiteLossReportingTests — issue #2762.
+//
+// A bundle whose AL fails to compile sheds the objects that did not compile and carries on.
+// Program.cs already routes that into `bundleErrors` and into the exit code: computedExitCode
+// counts `b.CompileErrors.Count > 0` on a bucket whose Stage is still `Ran` (the fix
+// BundleSuiteErrorLoudnessTests pins). So the VERDICT is correct — exit 3.
+//
+// What no surface reported is the REASON. Every reporting path branches on `Stage` and reads
+// `CompileErrors` only for a CompileFailed / ExecuteFailed bucket, and a bucket whose sibling
+// suite still produced one passing test has Stage == Ran. Measured on the real runner before
+// this change, against Fixtures/EmitExcludedPartialBundle (1 object EMIT-EXCLUDED, 2 [Test]
+// procedures dropped with its module, 1 healthy sibling suite):
+//
+//     Buckets:       1 total
+//       ran:         1
+//       compile-fail:0
+//       exec-fail:   0
+//     Tests:         1 total
+//       pass:        1
+//       fail:        0
+//       error:       0
+//
+// — byte-identical to a clean one-test run. The only disagreement was the exit code, and
+// `--watch` has no exit code at all, so there the loss was completely silent.
+//
+// This file is entirely about the RUNNER's own reporting. There is no claim about Business
+// Central anywhere in it — "what does al-runner's summary block print when it cannot emit an
+// object" is not a question a service tier can adjudicate — so nothing here belongs in the
+// al-language corpus (.claude/rules/bc-behavior-tests-go-upstream.md).
+//
+// The negatives are what make the positives mean something: a section printed unconditionally,
+// or a count that folded lost suites into the test totals, would satisfy "the loss is named"
+// and still be wrong.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PartialSuiteLossReportingTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string PartialBundle = Path.Combine(
+        RepoRoot, "AlRunner.Tests", "Fixtures", "EmitExcludedPartialBundle");
+
+    private const string SuiteError =
+        "<bundled>: EMIT-EXCLUDED for Contoso Widgets: 23 object(s) dropped from the module "
+        + "— tests they declare are missing: [Codeunit \"Widget Tests\"].";
+
+    private static TestResult Pass(string codeunit, string method) =>
+        new(codeunit, method, TestOutcome.Pass, null, null, TimeSpan.FromMilliseconds(3));
+
+    /// <summary>A bucket that RAN — one surviving pass — but lost a suite to a compile error.</summary>
+    private static BucketResult PartialLossBucket(string path = "/bundle-a") =>
+        new(path, BucketStage.Ran,
+            new[] { SuiteError }, null, new[] { Pass("Codeunit61360", "PartialBundleHealthy_StillRuns") },
+            TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, 1, null);
+
+    /// <summary>The same bucket with nothing lost — the control for every negative below.</summary>
+    private static BucketResult CleanBucket(string path = "/bundle-a") =>
+        new(path, BucketStage.Ran,
+            Array.Empty<string>(), null, new[] { Pass("Codeunit61360", "PartialBundleHealthy_StillRuns") },
+            TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, 1, null);
+
+    private static string Summarize(params BucketResult[] buckets)
+    {
+        var w = new StringWriter();
+        Reporter.PrintSummary(buckets, w);
+        return w.ToString();
+    }
+
+    private static string PerTest(bool showPass, params BucketResult[] buckets)
+    {
+        var w = new StringWriter();
+        Reporter.PrintPerTest(buckets, w, showPass);
+        return w.ToString();
+    }
+
+    // ── Summary ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The summary is where a human scrolling to the bottom and a scripted caller both look.
+    /// It must name the lost suite VERBATIM — the message already names the API (EMIT-EXCLUDED),
+    /// the module and the dropped objects, and paraphrasing it sends the reader back up the log
+    /// (.claude/rules/loud-failures.md).
+    /// </summary>
+    [Fact]
+    public void Summary_RanBucketThatLostASuite_NamesItAndCountsIt()
+    {
+        var summary = Summarize(PartialLossBucket());
+
+        Assert.Contains("Suite errors: 1", summary, StringComparison.Ordinal);
+        Assert.Contains(SuiteError, summary, StringComparison.Ordinal);
+        // The bucket it happened in, so a multi-bundle run is actionable.
+        Assert.Contains("/bundle-a", summary, StringComparison.Ordinal);
+        // And the consequence stated in the summary itself, not inferred from the exit code.
+        Assert.Contains("MISSING", summary, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// "ran: 1 / compile-fail: 0" on its own is what made the loss invisible. The bucket really
+    /// did run, so it is not a compile-fail — it gets its own line instead.
+    /// </summary>
+    [Fact]
+    public void Summary_RanBucketThatLostASuite_IsCountedAsPartialNotAsCompileFail()
+    {
+        var summary = Summarize(PartialLossBucket());
+
+        Assert.Contains("partial:     1", summary, StringComparison.Ordinal);
+        Assert.Contains("compile-fail:0", summary, StringComparison.Ordinal);
+        Assert.Contains("ran:         1", summary, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// No inflation. The test counts must keep meaning "tests that actually ran" — a fix that
+    /// synthesised the missing tests into the totals would make every count in the summary a
+    /// number nobody measured.
+    /// </summary>
+    [Fact]
+    public void Summary_RanBucketThatLostASuite_DoesNotInflateTheTestCounts()
+    {
+        var summary = Summarize(PartialLossBucket());
+
+        Assert.Contains("Tests:         1 total", summary, StringComparison.Ordinal);
+        Assert.Contains("pass:        1", summary, StringComparison.Ordinal);
+        Assert.Contains("fail:        0", summary, StringComparison.Ordinal);
+        Assert.Contains("error:       0", summary, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The negative that keeps a clean run's output unchanged. Printed unconditionally, this
+    /// section would be noise on every run, and every integration test asserting on the
+    /// summary's existing markers would be asserting past it.
+    /// </summary>
+    [Fact]
+    public void Summary_CleanRun_HasNoSuiteErrorSectionAndNoPartialLine()
+    {
+        var summary = Summarize(CleanBucket());
+
+        Assert.DoesNotContain("Suite errors", summary, StringComparison.Ordinal);
+        Assert.DoesNotContain("partial:", summary, StringComparison.Ordinal);
+        Assert.Contains("Tests:         1 total", summary, StringComparison.Ordinal);
+        Assert.Contains("pass:        1", summary, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A CompileFailed bucket already had its errors printed by PrintPerTest's COMPILE FAIL
+    /// block. Counting it as "partial" too would double-report it and misstate what happened:
+    /// nothing in that bucket ran.
+    /// </summary>
+    [Fact]
+    public void Summary_FullyCompileFailedBucket_IsNotCountedAsPartial()
+    {
+        var bucket = new BucketResult("/bundle-b", BucketStage.CompileFailed,
+            new[] { SuiteError }, null, Array.Empty<TestResult>(),
+            TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, 0, null);
+
+        var summary = Summarize(bucket);
+
+        Assert.Contains("compile-fail:1", summary, StringComparison.Ordinal);
+        Assert.DoesNotContain("partial:", summary, StringComparison.Ordinal);
+    }
+
+    // ── Per-test report ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The per-bucket report showed the surviving PASS lines and nothing else. The suite that
+    /// never ran belongs next to them, or the reader concludes the bucket is complete.
+    /// </summary>
+    [Fact]
+    public void PerTest_RanBucketThatLostASuite_PrintsTheErrorVerbatim()
+    {
+        var report = PerTest(showPass: true, PartialLossBucket());
+
+        Assert.Contains("SUITE ERRORS (1)", report, StringComparison.Ordinal);
+        Assert.Contains(SuiteError, report, StringComparison.Ordinal);
+        // The survivors are still reported — a fix that replaced the bucket's output with the
+        // error would trade one silent inaccuracy for another.
+        Assert.Contains("PartialBundleHealthy_StillRuns", report, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The sibling gap, and the reason the default output was completely empty: PrintPerTest
+    /// skips a bucket with no VISIBLE tests, and at default verbosity a bucket whose survivors
+    /// all passed has none. Without this the section exists but never prints on the runs that
+    /// matter most — every all-green run that quietly lost a suite.
+    /// </summary>
+    [Fact]
+    public void PerTest_AllSurvivorsPassedAtDefaultVerbosity_StillPrintsTheSuiteError()
+    {
+        var report = PerTest(showPass: false, PartialLossBucket());
+
+        Assert.Contains("SUITE ERRORS (1)", report, StringComparison.Ordinal);
+        Assert.Contains(SuiteError, report, StringComparison.Ordinal);
+    }
+
+    /// <summary>Negative: a clean bucket with only passes still prints nothing at all.</summary>
+    [Fact]
+    public void PerTest_CleanBucketAtDefaultVerbosity_PrintsNothing()
+    {
+        var report = PerTest(showPass: false, CleanBucket());
+
+        Assert.DoesNotContain("SUITE ERRORS", report, StringComparison.Ordinal);
+        Assert.Equal("", report);
+    }
+
+    // ── --output-json ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Same defect one layer down, and the same fix #2779 applied to ExecuteFailed buckets: a
+    /// consumer reading --output-json saw `compilationErrors: null` and a fully passing test
+    /// list. The exitCode field said 3 and the document explained nothing.
+    /// </summary>
+    [Fact]
+    public void Json_RanBucketThatLostASuite_CarriesItAsSuiteErrors()
+    {
+        var json = Reporter.SerializeJsonOutput(new[] { PartialLossBucket() }, exitCode: 3);
+        using var doc = JsonDocument.Parse(json);
+
+        var suiteErrors = doc.RootElement.GetProperty("suiteErrors");
+        Assert.Equal(1, suiteErrors.GetArrayLength());
+        var entry = suiteErrors[0];
+        Assert.Equal("/bundle-a", entry.GetProperty("file").GetString());
+        Assert.Equal(SuiteError, entry.GetProperty("errors")[0].GetString());
+
+        // The surviving test is still in `tests`, and the totals still count only what ran.
+        Assert.Equal(1, doc.RootElement.GetProperty("total").GetInt32());
+        Assert.Equal(1, doc.RootElement.GetProperty("passed").GetInt32());
+        Assert.Equal(3, doc.RootElement.GetProperty("exitCode").GetInt32());
+    }
+
+    /// <summary>
+    /// Negative: null-omitted, so a run that lost nothing serialises exactly as before and no
+    /// existing consumer sees a new empty array.
+    /// </summary>
+    [Fact]
+    public void Json_CleanRun_OmitsSuiteErrorsEntirely()
+    {
+        var json = Reporter.SerializeJsonOutput(new[] { CleanBucket() }, exitCode: 0);
+        using var doc = JsonDocument.Parse(json);
+
+        Assert.False(doc.RootElement.TryGetProperty("suiteErrors", out _));
+    }
+
+    // ── --out classification file ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// WriteClassification's `else` branch (the Ran bucket) walked only failing TESTS, so a
+    /// bucket that lost a whole suite contributed zero failure records — the file a triage
+    /// pass reads said the run had nothing wrong with it.
+    /// </summary>
+    [Fact]
+    public void Classification_RanBucketThatLostASuite_RecordsIt()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"al-runner-cls-{Guid.NewGuid():N}.json");
+        try
+        {
+            Reporter.WriteClassification(new[] { PartialLossBucket() }, path);
+            using var doc = JsonDocument.Parse(File.ReadAllText(path));
+
+            Assert.Equal(1, doc.RootElement.GetProperty("total_failures").GetInt32());
+            var failure = doc.RootElement.GetProperty("all_failures")[0];
+            Assert.Equal("suite", failure.GetProperty("kind").GetString());
+            Assert.Equal("/bundle-a", failure.GetProperty("bucket").GetString());
+            Assert.Equal(SuiteError, failure.GetProperty("errors")[0].GetString());
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    /// <summary>Negative: a clean run still writes an empty failure list.</summary>
+    [Fact]
+    public void Classification_CleanRun_RecordsNoFailures()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"al-runner-cls-{Guid.NewGuid():N}.json");
+        try
+        {
+            Reporter.WriteClassification(new[] { CleanBucket() }, path);
+            using var doc = JsonDocument.Parse(File.ReadAllText(path));
+            Assert.Equal(0, doc.RootElement.GetProperty("total_failures").GetInt32());
+        }
+        finally { if (File.Exists(path)) File.Delete(path); }
+    }
+
+    // ── --watch dashboard ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// `--watch` has no exit code, so the dashboard IS the verdict. Its roll-up already counts
+    /// a whole compile-failed bucket as one error; a suite lost from a bucket that otherwise
+    /// ran got no such treatment and the footer read a clean 1P/0F/0E.
+    /// </summary>
+    [Fact]
+    public void WatchTally_RanBucketThatLostASuite_CountsAsAnError()
+    {
+        var (pass, fail, err, total) = WatchDashboard.Tally(new[] { PartialLossBucket() });
+
+        Assert.Equal(1, pass);
+        Assert.Equal(0, fail);
+        Assert.Equal(1, err);
+        Assert.Equal(2, total);
+    }
+
+    /// <summary>Negative: a clean bucket's roll-up is untouched.</summary>
+    [Fact]
+    public void WatchTally_CleanBucket_IsUnchanged()
+    {
+        var (pass, fail, err, total) = WatchDashboard.Tally(new[] { CleanBucket() });
+
+        Assert.Equal(1, pass);
+        Assert.Equal(0, fail);
+        Assert.Equal(0, err);
+        Assert.Equal(1, total);
+    }
+
+    // ── --jobs aggregate ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Under --jobs the parent reprints each shard's output and then its OWN aggregate, and
+    /// that aggregate is the only complete summary a caller reads. It learns what a shard lost
+    /// by counting Reporter's per-bundle headers in the captured text (#2715's mechanism). The
+    /// SUITE ERRORS header was not one of them, so a shard that lost suites folded into the
+    /// aggregate as a clean smaller total — #2715's own defect, one Stage over.
+    /// </summary>
+    [Fact]
+    public void FanOut_CountsTheSuiteErrorHeaderInAShardsOutput()
+    {
+        const string shardOutput =
+            "=== bundle-a — SUITE ERRORS (2) ===\n"
+            + "  <bundled>: EMIT-EXCLUDED for X: 2 object(s) dropped\n"
+            + "=== bundle-a ===\n"
+            + "PASS  Codeunit1.T (1ms)\n"
+            + "=== bundle-b — SUITE ERRORS (1) ===\n"
+            + "  <bundled>: EMIT-ZERO (3 AL error(s))\n";
+
+        Assert.Equal(2, Infrastructure.ParallelFanOut.CountOccurrences(
+            shardOutput, Infrastructure.ParallelFanOut.PartialLossHeader));
+    }
+
+    /// <summary>
+    /// The load-bearing negative. A bundle that lost suites still contributes its SURVIVING
+    /// tests to the shard's JUnit, so counting it as "not run" would tell the caller a bundle
+    /// is absent from totals it is actually in — a wrong number stated confidently, which is
+    /// the failure mode this whole issue is about.
+    /// </summary>
+    [Fact]
+    public void FanOut_SuiteErrorHeaderIsNotCountedAsANotRunBundle()
+    {
+        const string shardOutput =
+            "=== bundle-a — SUITE ERRORS (1) ===\n"
+            + "  <bundled>: EMIT-EXCLUDED for X: 1 object(s) dropped\n"
+            + "=== bundle-a ===\n"
+            + "PASS  Codeunit1.T (1ms)\n";
+
+        var notRun = Infrastructure.ParallelFanOut.NotRunHeaders
+            .Sum(h => Infrastructure.ParallelFanOut.CountOccurrences(shardOutput, h));
+
+        Assert.Equal(0, notRun);
+    }
+
+    /// <summary>Negative: a clean shard's output contains neither marker.</summary>
+    [Fact]
+    public void FanOut_CleanShardOutput_CountsNothing()
+    {
+        const string shardOutput = "=== bundle-a ===\nPASS  Codeunit1.T (1ms)\n";
+
+        Assert.Equal(0, Infrastructure.ParallelFanOut.CountOccurrences(
+            shardOutput, Infrastructure.ParallelFanOut.PartialLossHeader));
+        Assert.Equal(0, Infrastructure.ParallelFanOut.NotRunHeaders
+            .Sum(h => Infrastructure.ParallelFanOut.CountOccurrences(shardOutput, h)));
+    }
+
+    // ── End to end, against the real runner ──────────────────────────────────────────
+
+    private static (string Output, int Exit) RunRunner(params string[] extraArgs)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        foreach (var a in extraArgs) args.Append(' ').Append(a);
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(240_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>
+    /// The literal #2762 reproduction. One object in `excluded-suite` cannot bind, so the whole
+    /// module is dropped and BOTH its [Test] procedures vanish — the loss is larger than the
+    /// excluded-object count, which is exactly why the count alone is not the story. The
+    /// healthy sibling suite keeps the bucket at Stage=Ran.
+    ///
+    /// Before this change the run printed the EMIT-EXCLUDED line ~10 lines up and then a
+    /// summary block identical to a clean 1-test run.
+    /// </summary>
+    [SkippableFact]
+    public void EmitExcludedBundle_SummaryNamesTheLossBelowTheSummaryHeader()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, exit) = RunRunner($"\"{PartialBundle}\"");
+
+        // The sibling really ran — without this a runner that died on the whole bundle would
+        // satisfy everything below while proving nothing.
+        Assert.Contains("PartialBundleHealthy_StillRuns", output, StringComparison.Ordinal);
+        Assert.Equal(3, exit);
+
+        // The exclusion happened, and it is the EMIT-EXCLUDED path (not EMIT-ZERO).
+        Assert.Contains("EMIT-EXCLUDED", output, StringComparison.Ordinal);
+
+        // ...and the actual defect: it is stated in the summary, at the bottom, where the
+        // reader is — not only on a stderr line above the results.
+        var summaryStart = output.IndexOf("al-runner — test run summary", StringComparison.Ordinal);
+        Assert.True(summaryStart >= 0, $"no summary block in output:\n{output}");
+        var summary = output[summaryStart..];
+        Assert.Contains("Suite errors: 1", summary, StringComparison.Ordinal);
+        Assert.Contains("EMIT-EXCLUDED", summary, StringComparison.Ordinal);
+        Assert.Contains("partial:     1", summary, StringComparison.Ordinal);
+
+        // The counts still say what they measured.
+        Assert.Contains("Tests:         1 total", summary, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Negative, end to end: the healthy suite alone exits 0 and its output gains nothing. A
+    /// fix that failed every bundle, or that printed the new section unconditionally, would
+    /// pass the test above and fail here.
+    /// </summary>
+    [SkippableFact]
+    public void HealthySuiteAlone_ExitsZeroWithNoSuiteErrorSection()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var target = Path.Combine(PartialBundle, "healthy-suite");
+        var (output, exit) = RunRunner($"\"{target}\"");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("PartialBundleHealthy_StillRuns", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("EMIT-EXCLUDED", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("Suite errors", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("partial:", output, StringComparison.Ordinal);
+        Assert.Contains("Tests:         1 total", output, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner/Infrastructure/ParallelFanOut.cs
+++ b/AlRunner/Infrastructure/ParallelFanOut.cs
@@ -269,7 +269,7 @@ internal static class ParallelFanOut
         }
 
         var worst = 0;
-        long tests = 0, failures = 0, errors = 0, skipped = 0, notRun = 0;
+        long tests = 0, failures = 0, errors = 0, skipped = 0, notRun = 0, partial = 0;
         for (var i = 0; i < procs.Count; i++)
         {
             var (p, junit, so, se) = procs[i];
@@ -300,6 +300,14 @@ internal static class ParallelFanOut
             // silent loss for every execution failure.
             foreach (var header in NotRunHeaders)
                 notRun += CountOccurrences(stdout, header) + CountOccurrences(stderr, header);
+
+            // #2762: the sibling shape. A bundle that lost SOME suites and still produced tests
+            // is not "not run" — its survivors ARE in the totals above, so counting it as
+            // missing would overstate the loss. But it covers less than it declares, and the
+            // aggregate is the only summary a --jobs caller reads; without this the parent
+            // reprints a clean total for a run in which whole suites never compiled.
+            partial += CountOccurrences(stdout, PartialLossHeader)
+                     + CountOccurrences(stderr, PartialLossHeader);
         }
 
         Console.WriteLine();
@@ -314,6 +322,9 @@ internal static class ParallelFanOut
         if (notRun > 0)
             Console.WriteLine($"  NOT RUN:     {notRun} bundle(s) — COMPILE FAIL or EXEC FAIL in a " +
                                "shard above, excluded from the totals; see that shard's output for which one");
+        if (partial > 0)
+            Console.WriteLine($"  PARTIAL:     {partial} bundle(s) — SUITE ERRORS in a shard above: they " +
+                               "ran, but the tests the lost suites declare are MISSING from the totals");
         Console.WriteLine("=================================================================");
 
         ScratchDirs.Release(tempDir);
@@ -386,6 +397,12 @@ internal static class ParallelFanOut
     /// depends only on WHAT failed (#2779).</summary>
     internal static readonly IReadOnlyList<string> NotRunHeaders =
         new[] { " — COMPILE FAIL ===", " — EXEC FAIL ===" };
+
+    /// <summary>The per-bundle header Reporter.PrintPerTest writes for a bundle that RAN but
+    /// lost one or more suites (#2762). Deliberately NOT in <see cref="NotRunHeaders"/>: such a
+    /// bundle's surviving tests are counted in the JUnit totals, so it is under-reported, not
+    /// absent. Matched without the count so any number of lost suites is found.</summary>
+    internal const string PartialLossHeader = " — SUITE ERRORS (";
 
     /// <summary>How many times a bundle reported COMPILE FAIL or EXEC FAIL in a shard's captured
     /// output — used to tell the aggregate summary how many bundles are missing from its totals,

--- a/AlRunner/Reporter.cs
+++ b/AlRunner/Reporter.cs
@@ -54,12 +54,24 @@ public static class Reporter
         int totalTests = 0, pass = 0, fail = 0, err = 0, skipped = 0;
         int passOos = 0, passKnownGap = 0, passDivergence = 0;
         int compileFailed = 0, execFailed = 0;
+        // #2762: buckets that RAN but lost one or more suites on the way. Their Stage stays
+        // `Ran` — one surviving sibling suite is enough — so neither counter above sees them,
+        // and every number printed below describes only what survived. computedExitCode in
+        // Program.cs already fails the run for exactly this condition; without these the
+        // summary contradicted it in silence.
+        var partialBuckets = new List<BucketResult>();
+        int lostSuites = 0;
         TimeSpan emit = TimeSpan.Zero, comp = TimeSpan.Zero, run = TimeSpan.Zero;
         foreach (var b in buckets)
         {
             emit += b.EmitTime; comp += b.CompileTime; run += b.RunTime;
             if (b.Stage == BucketStage.CompileFailed) { compileFailed++; continue; }
             if (b.Stage == BucketStage.ExecuteFailed) { execFailed++; continue; }
+            if (b.CompileErrors.Count > 0)
+            {
+                partialBuckets.Add(b);
+                lostSuites += b.CompileErrors.Count;
+            }
             foreach (var t in b.Tests)
             {
                 totalTests++;
@@ -83,6 +95,13 @@ public static class Reporter
         w.WriteLine($"  ran:         {buckets.Count - compileFailed - execFailed}");
         w.WriteLine($"  compile-fail:{compileFailed}");
         w.WriteLine($"  exec-fail:   {execFailed}");
+        // Deliberately NOT folded into `compile-fail`: these buckets really did run and their
+        // surviving results are real, so calling them compile failures would misstate the run
+        // in the other direction. Omitted entirely when there is nothing to say, so a clean
+        // run's summary is byte-identical to before.
+        if (partialBuckets.Count > 0)
+            w.WriteLine($"  partial:     {partialBuckets.Count}  (ran, but {lostSuites} suite(s) "
+                + "did not — see \"Suite errors\" below)");
         if (!carried.IsEmpty)
         {
             // Named rather than folded in silently: these tests ran in an EARLIER process of this
@@ -142,6 +161,25 @@ public static class Reporter
         //
         // Only when there ARE gaps: a section printed on every run is noise, and every
         // integration test asserting on the markers above would then be asserting past it.
+        // #2762: the same argument as the provisioning-gap block below, for a louder failure.
+        // The EMIT-EXCLUDED / EMIT-ZERO / COMPILE-FAIL line that explains a lost suite is
+        // written on stderr at the moment it happens — tens to thousands of lines above this
+        // point on a real run — and the numbers printed just above it read as a clean pass.
+        // Repeat each message VERBATIM: it is what names the surface (EMIT-EXCLUDED), the
+        // module and the objects that were dropped, and a paraphrase would send the reader
+        // back up the log (.claude/rules/loud-failures.md).
+        if (partialBuckets.Count > 0)
+        {
+            w.WriteLine("-----------------------------------------------------------------");
+            w.WriteLine($"Suite errors: {lostSuites} — in {partialBuckets.Count} bucket(s) that "
+                + "otherwise ran. Every test these suites declare is MISSING from the counts "
+                + "above, so this run covers less than it discovered.");
+            foreach (var b in partialBuckets)
+            {
+                w.WriteLine(b.BucketPath);
+                foreach (var e in b.CompileErrors) w.WriteLine($"  {e}");
+            }
+        }
         var gaps = buckets
             .SelectMany(b => b.ProvisionGaps ?? Array.Empty<string>())
             .Distinct(StringComparer.Ordinal)
@@ -190,6 +228,19 @@ public static class Reporter
                 if (b.CompileErrors.Count > 20)
                     w.WriteLine($"  ... and {b.CompileErrors.Count - 20} more errors");
                 continue;
+            }
+            // #2762: a bucket that ran but lost suites. This MUST come before the
+            // `visible.Count == 0` skip below: at default verbosity a bucket whose survivors
+            // all passed has nothing visible, which is precisely the all-green run where a
+            // silently missing suite does the most damage.
+            if (b.CompileErrors.Count > 0)
+            {
+                w.WriteLine();
+                w.WriteLine($"=== {Path.GetFileName(b.BucketPath)} — SUITE ERRORS ({b.CompileErrors.Count}) ===");
+                foreach (var e in b.CompileErrors.Take(20)) w.WriteLine($"  {e}");
+                if (b.CompileErrors.Count > 20)
+                    w.WriteLine($"  ... and {b.CompileErrors.Count - 20} more suite errors");
+                w.WriteLine("  → the tests these suites declare are MISSING from this run, not passing.");
             }
             // Skip silent buckets — only emit a per-bucket header if there's anything to show.
             var visible = b.Tests.Where(t => showPass || t.Outcome != TestOutcome.Pass).ToList();
@@ -333,6 +384,16 @@ public static class Reporter
             })
             .ToList();
 
+        // #2762: exactly the gap #2779 closed for ExecuteFailed buckets, one Stage over. A
+        // bucket that ran but lost a suite is not compile-failed, so it appeared in neither
+        // `compilationErrors` nor `tests` — a consumer read a fully passing document next to
+        // `exitCode: 3` and had nothing to explain it. Additive and null-omitted, so a run
+        // that lost nothing serialises byte-identically.
+        var suiteErrors = buckets
+            .Where(b => b.Stage == BucketStage.Ran && b.CompileErrors.Count > 0)
+            .Select(b => new { file = b.BucketPath, errors = b.CompileErrors.ToList() })
+            .ToList();
+
         var output = new
         {
             tests = tests.Select(t => new
@@ -367,6 +428,7 @@ public static class Reporter
             exitCode,
             compilationErrors = compileErrors.Count > 0 ? compileErrors : null,
             executionErrors = executionErrors.Count > 0 ? executionErrors : null,
+            suiteErrors = suiteErrors.Count > 0 ? suiteErrors : null,
             // #1936: same "real wall clock, not just the measured phases" gap as the
             // `wall:` line in PrintSummary — see that comment. Additive field, so
             // existing consumers reading this JSON are unaffected.
@@ -414,6 +476,20 @@ public static class Reporter
             }
             else
             {
+                // #2762: this branch walked only failing TESTS, so a bucket that lost a whole
+                // suite contributed zero records and the triage file said the run had nothing
+                // wrong with it. Its own kind, not "compile": the bucket ran, and the records
+                // below it are still that bucket's real test failures.
+                if (b.CompileErrors.Count > 0)
+                {
+                    failures.Add(new
+                    {
+                        bucket = b.BucketPath,
+                        kind = "suite",
+                        errors = b.CompileErrors.Take(10).ToList(),
+                        classification = ClassifyCompile(b.CompileErrors),
+                    });
+                }
                 foreach (var t in b.Tests.Where(t => t.Outcome is TestOutcome.Fail or TestOutcome.Error))
                 {
                     failures.Add(new

--- a/AlRunner/WatchDashboard.cs
+++ b/AlRunner/WatchDashboard.cs
@@ -139,6 +139,22 @@ public static class WatchDashboard
                 continue;
             }
 
+            // #2762: a bucket that RAN but lost one or more suites. --watch has no exit code,
+            // so this tree and the footer below ARE the verdict — a lost suite that appears in
+            // neither reads as a clean cycle. Rendered as its own node rather than folded into
+            // COMPILE FAILED, because the bucket's surviving tests are real and still listed.
+            if (b.CompileErrors.Count > 0)
+            {
+                any = true;
+                var lostLabel = Markup.Escape(Path.GetFileName(b.BucketPath));
+                var lostNode = tree.AddNode(
+                    $"[blue]{lostLabel}[/]  [red]SUITE ERRORS ({b.CompileErrors.Count})[/]");
+                foreach (var err in b.CompileErrors)
+                    lostNode.AddNode($"[red]{Markup.Escape(err)}[/]");
+                lostNode.AddNode(
+                    "[red]the tests these suites declare are MISSING from this cycle, not passing[/]");
+            }
+
             // Group this bucket's tests by codeunit so each codeunit is one parent node.
             // (A bucket normally maps to one bundle but may contain several codeunits.)
             var byCodeunit = b.Tests
@@ -220,6 +236,11 @@ public static class WatchDashboard
     /// <summary>
     /// Roll-up counts. A compile- or exec-failed bucket has no per-test rows, so it
     /// counts as one error in the footer (consistent with the COMPILE/EXEC tree node).
+    /// #2762 extends the same convention to a bucket that RAN but lost suites: one error per
+    /// lost suite, matching its SUITE ERRORS tree node. Without it the footer of a cycle that
+    /// dropped a whole app read a clean `1P / 0F / 0E`, and under --watch there is no exit
+    /// code to disagree with it. This roll-up is dashboard-only — it never feeds the exit code
+    /// or Reporter's `Tests:` totals, which keep counting only tests that actually ran.
     /// </summary>
     internal static (int Pass, int Fail, int Err, int Total) Tally(IReadOnlyList<BucketResult> results)
     {
@@ -231,6 +252,7 @@ public static class WatchDashboard
                 err++;
                 continue;
             }
+            err += b.CompileErrors.Count;
             foreach (var t in b.Tests)
             {
                 switch (t.Outcome)


### PR DESCRIPTION
Closes #2762

## The mechanism

`EMIT-EXCLUDED` is produced in `AlRunner/Program.cs` (bundled CLI run loop) when BC's emit-retry loop drops one or more AL objects it could not compile. That branch does three things: it prints the message on stderr, it empties the module's `sources` ("do not run a module that is missing objects"), and it adds an entry to `bundleErrors`.

The verdict was already correct. `computedExitCode` counts `b.CompileErrors.Count > 0` on a bucket whose `Stage` is still `Ran` — the fix `BundleSuiteErrorLoudnessTests` pins — so the run exits 3. **Nothing else agreed with it.**

Every reporting path branches on `Stage` and reads `CompileErrors` only for a `CompileFailed` or `ExecuteFailed` bucket. `Stage` becomes `CompileFailed` only when `bundleTests.Count == 0`, and one surviving sibling suite is enough to prevent that. Measured on `main` against a new fixture reproducing the issue's exact shape (1 object `EMIT-EXCLUDED`, 2 `[Test]` procedures dropped with its module, 1 healthy sibling suite):

```
<bundled>: EMIT-EXCLUDED — Runner Tests Fixture - Emit Excluded Partial: 1 object(s) could not be
           compiled and were dropped from the module, so any tests they declare are MISSING ...
  → 1P/0F/0E across 1 tests, 1 suite errors (1.6s)

=== EmitExcludedPartialBundle ===
PASS  Codeunit61360.PartialBundleHealthy_StillRuns (7ms)

=================================================================
al-runner — test run summary
=================================================================
Buckets:       1 total
  ran:         1
  compile-fail:0
  exec-fail:   0
Tests:         1 total
  pass:        1
  fail:        0
  error:       0
```

Byte-identical to a clean one-test run, with two tests gone. The exclusion line is ~10 lines up here and thousands of lines up on a real bundle. Under `--watch` there is no exit code at all, so there the loss was completely silent.

## Which remedy, and why not the others

The issue offered three. They are not equivalent, and the first two are already answered:

**"Fail the run loudly (exit non-zero)" — already true, and not the gap.** The CLI bundled path exits 3, `--server` returns `exitCode: 3` with `compilationErrors` populated and never reaches a partial state (it returns immediately on exclusion). Re-doing this would have shipped a no-op wearing a fix's commit message. The gap is that *the exit code was the only surface that knew*, and `--watch` has no exit code.

**"Report the lost tests as FAILURES rather than as absent" — this already exists as `--tdd`, and is wrong as a default.** `TDD-EXCLUDED` synthesises a FAILED `TestResult` per `[Test]` the excluded objects declared. It is opt-in for two reasons that still hold. The runner only knows which procedures a *non-compiling* object declares because `--tdd` makes `BcCompiler` collect `TddExcludedDetails` specifically for that purpose; there is no general enumeration. And it converts a compile failure into a test failure — exit 3 becomes exit 1 — which erases the distinction real BC makes: a module carrying an error diagnostic is never published at all, regardless of how many objects compiled clean (the reasoning already written into the `AL-DIAGNOSTIC-FAIL` guard). It would also inflate `Tests:` with numbers nobody measured.

**"Make the count gate catch it" — `--count-baseline` does catch it, and is the wrong instrument.** A dropped app group reduces both `tests` and `appGroups`, so an exact-match baseline fails with exit 4. But it is opt-in, it only exists where a baseline file has been recorded, exit 3 already outranks 4, and — decisively — it is a *regression* gate, not a per-run verdict: it compares this run against a recorded number, so it cannot see a loss introduced in the same change that bumps the baseline, and it tells a developer running one bundle locally nothing at all. Routing through it would have made the answer depend on a file most invocations do not pass.

**What this PR does instead: the verdict already existed, so make every surface that reports the run agree with it, except the JUnit XML artifact (tracked as #2791).** The asymmetry *was* the defect — `computedExitCode` reads `CompileErrors` on a `Ran` bucket and every display path does not, so the process said 3 while the report said clean. That is question 3 of "fix the shape": two code paths reading the same state, one maintaining an invariant the other does not.

## Fixing the shape, not the reported line

The reported line was the summary. The same wrong pattern — branch on `Stage`, drop `CompileErrors` when it is `Ran` — appeared at five more call sites, all fixed here:

1. **`Reporter.PrintSummary`** — a `partial:` bucket line, and a `Suite errors:` section repeating each message verbatim. Same argument as the provisioning-gap block right below it (#2587): the message that explains the loss is written where it happens and the reader is at the bottom. Deliberately not folded into `compile-fail`, which would misstate the run in the other direction — these buckets did run and their results are real.
2. **`Reporter.PrintPerTest`** — a `SUITE ERRORS (n)` block, placed **before** the existing `if (visible.Count == 0) continue;` skip. That skip is the sibling gap: at default verbosity a bucket whose survivors all passed has nothing visible, which is exactly the all-green run where a missing suite does the most damage.
3. **`Reporter.SerializeJsonOutput`** — a `suiteErrors` array. Precisely the gap #2779 closed for `ExecuteFailed` buckets, one `Stage` over: a consumer read `compilationErrors: null` and a fully passing test list next to `exitCode: 3`.
4. **`Reporter.WriteClassification`** — the `Ran` branch walked only failing *tests*, so a bucket that lost a whole suite contributed zero records and the triage file said the run had nothing wrong with it.
5. **`WatchDashboard`** — a `SUITE ERRORS` tree node, and one `Tally` error per lost suite. `--watch` has no exit code, so the tree and footer **are** the verdict; the footer read a clean `1P / 0F / 0E`. `Tally` already counts a compile-failed bucket as one error, so this extends an existing convention rather than inventing one. It is dashboard-only and never feeds the exit code or `Tests:`.
6. **`ParallelFanOut`** — the `--jobs` aggregate learns what a shard lost by counting Reporter's per-bundle headers in the captured text (#2715's mechanism), and only counted bundles that produced **zero** tests. A shard that lost suites folded in as a clean smaller total — #2715's own defect, one `Stage` over. Counted as `PARTIAL:`, deliberately **not** added to `NotRunHeaders`: such a bundle's survivors *are* in the JUnit totals, so calling it absent would be a different wrong number.

Test counts are never inflated anywhere. `Tests:` still means tests that ran.

## Where the proving test goes

`AlRunner.Tests/`, and the structural reason is that the claim has no BC in it. "What does al-runner print in its summary block when BC's `Compilation.Emit` could not emit an object" is a statement about this runner's reporting contract — the strings `Suite errors:`, `SUITE ERRORS (n)`, the `suiteErrors` JSON key, `BucketStage`, `WatchDashboard.Tally`. Applying the test in `bc-behavior-tests-go-upstream.md`: if AL Runner did not exist, not one assertion in this file would still be a meaningful statement about AL or BC, and there is no configuration in which a service tier could adjudicate any of them — a service tier refuses to publish a module with an error diagnostic and never reaches the state this PR is about. Nothing here belongs in the al-language corpus, and no part of it is a mixed suite needing a split.

## RED → GREEN, actually run

`AlRunner.Tests/PartialSuiteLossReportingTests.cs`, 19 tests, plus `AlRunner.Tests/Fixtures/EmitExcludedPartialBundle/` (ids 61300-61399, a free range).

**RED** — built at `origin/main` + tests only, `dotnet test --filter FullyQualifiedName~PartialSuiteLossReportingTests`:

```
Failed!  - Failed: 8, Passed: 8, Skipped: 0, Total: 16
```

All 8 positives failed; all 8 negatives passed, which is what makes them controls rather than decoration. The failures were the real thing, not absence of a helper: `Not found: "SUITE ERRORS (1)"`, `Not found: "partial:     1"`, `Expected: 1 / Actual: 0` for the watch tally and the classification file.

Two of the passing 8 are worth naming because they pass in **both** states by design and would catch a fix that overshot: `Summary_RanBucketThatLostASuite_DoesNotInflateTheTestCounts` (the totals must keep meaning "tests that ran") and `HealthySuiteAlone_ExitsZeroWithNoSuiteErrorSection` (a fix that failed every bundle, or printed the section unconditionally, fails here).

**GREEN** — same filter after the fix:

```
Passed!  - Failed: 0, Passed: 19, Skipped: 0, Total: 19
```

The three `FanOut_*` tests were added with the `PartialLossHeader` constant, so their RED was a compile error rather than a failed assertion — stated plainly rather than dressed up. Their behavioural claim is still load-bearing: `FanOut_SuiteErrorHeaderIsNotCountedAsANotRunBundle` pins that the new header does **not** enter `NotRunHeaders`.

End to end against the real runner, `EmitExcludedPartialBundle`, exit 3 both before and after — the summary is the difference:

```
=== EmitExcludedPartialBundle — SUITE ERRORS (1) ===
  <bundled>: EMIT-EXCLUDED for Runner Tests Fixture - Emit Excluded Partial: 1 object(s) dropped
             from the module — tests they declare are missing: [Codeunit ."Emit Excl Part Broken"].
  → the tests these suites declare are MISSING from this run, not passing.
...
  partial:     1  (ran, but 1 suite(s) did not — see "Suite errors" below)
...
Suite errors: 1 — in 1 bucket(s) that otherwise ran. Every test these suites declare is MISSING
from the counts above, so this run covers less than it discovered.
```

## Other tests run locally

Filtered `AlRunner.Tests` over the changed surfaces, all green:

- `PartialSuiteLoss | BundleSuiteErrorLoudness | EmitExclusionLoudness | ProvisionGapSummary | SummaryWallClock | ReporterDuplicateBucketName | BundleFailureStage | ParallelFanOutEmitTimeout | OutputFormat | TddMode` → **79/79 passed** (52s)
- `WatchDashboard | WatchFullRebuildReason | AbortResumePlan | BackupReaderFailureReporting | TddWatch | ManifestFeaturesSubprocess` → all green

`SuiteAbortOnTimeoutTests` fails 2 of 4 (`NonResumedRun_JUnitHoldsOnlyWhatThisProcessRan`, `ResumedRun_JUnitContainsEarlierAttemptsCases`). **Pre-existing, verified not inferred:** built and run in a clean detached worktree at `origin/main` (`6fa0fc2a`, this PR's base), same two failures, same assertions. It is a `--test-timeout` watchdog test on a machine running several agents; my change touches no JUnit or watchdog code.

I did not run the full `AlRunner.Tests` suite or the AL corpus locally — CI runs both on all 8 legs.

## Deliberately left out

**JUnit XML.** `JUnitReport.WriteJUnit` reads only `Stage == Ran` buckets' tests and never `CompileErrors`, so the artifact GitHub/ADO/GitLab render still shows a clean pass for a bundle that lost suites — and, pre-existing and symmetric, shows nothing at all for one that lost everything. Fixing it is a design decision the other six surfaces did not need (synthetic `<testcase>` entries require enumerating tests of an object that did not compile, which only `--tdd` can do, and would inflate the counts CI trends on). #2715 chose text-header counting around exactly this for the compile-failed case and this PR followed that precedent. Filed as **#2791** rather than fixed silently.

**`--watch`'s per-cycle verdict as a whole** (the issue's open question 3). This PR gives a `--watch` cycle a visible statement that it lost suites, in both the interactive dashboard and the piped fallback. It does not introduce a per-cycle exit code or status line, which is #2764's subject — that issue stays open and this PR does not close it.

---

Opened by agent `stma-auto-3` acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE

