### PR TITLE
fix(reports): run BC's whole pre-report step, not just the OnPreReport trigger

### DIFF
--- a/AlRunner.Tests/ReportPreTriggerStepTests.cs
+++ b/AlRunner.Tests/ReportPreTriggerStepTests.cs
@@ -1,0 +1,147 @@
+// Issue #2526 — the runner ran only the FIRST of the three things BC's pre-report step does.
+//
+// NavReport.OnPreTriggerAsync, verbatim from BC 28.1's Ncl.dll:
+//
+//     await DataItemIterator.ExecuteTriggerAsync(Session, null, OnPreReportInternalAsync, "OnPreReport", this);
+//     await InitializeReportLabelsAsync();
+//     AddDefaultParameters();
+//
+// NavReportSync called only OnPreReportInternalAsync (through RunLifecycleTrigger). So the AL
+// trigger ran and the other two silently did not: InitializeReportLabelsAsync is what walks
+// Metadata.Labels and adds every non-PerRow label to reportDatasetParameters — the collection
+// NavReport.GetParameters() returns and ReportSaveAsXmlRenderer.SerializeReportParameters
+// writes into the parameters file. A column with IncludeCaption = true contributes a label
+// named {ColumnName}Caption; a report's `labels` section contributes one per entry. With the
+// step skipped the parameters document came out as a bare <ArrayOfReportParameter />.
+//
+// These are RUNNER-MECHANISM tests. The BC-behaviour claim — what a report's parameters
+// document contains — is NOT expressible in the upstream corpus: the document is only
+// reachable through TestRequestPage.SaveAsXml(parametersFile, dataSetFile), which takes file
+// PATHS (NavTestPage.ALSaveAsXml has no stream overload), and reading a file back needs File,
+// which the AL compiler rejects for Target = Cloud (AL0296) — the corpus's target. The
+// end-to-end proof is therefore a measured before/after on a hermetic bundle, recorded in the
+// PR, not a corpus test.
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using AlRunner;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ReportPreTriggerStepTests
+{
+    /// <summary>Stands in for NavReport: the whole-step method plus the bare trigger.</summary>
+    public abstract class FakeReportBase
+    {
+        public virtual bool __IsAsync => false;
+        public int WholeStepHits;
+        public int BareTriggerHits;
+        protected virtual ValueTask OnPreTriggerAsync() { WholeStepHits++; return default; }
+        protected virtual ValueTask OnPreReportInternalAsync() { BareTriggerHits++; return default; }
+        protected virtual void OnPreReport() { }
+        protected virtual ValueTask OnPreReportAsync() => default;
+    }
+
+    public sealed class NormalReport : FakeReportBase { }
+
+    /// <summary>An Ncl build without the whole-step method — the fallback path.</summary>
+    public abstract class LegacyReportBase
+    {
+        public virtual bool __IsAsync => false;
+        public int BareTriggerHits;
+        protected virtual ValueTask OnPreReportInternalAsync() { BareTriggerHits++; return default; }
+        protected virtual void OnPreReport() { }
+        protected virtual ValueTask OnPreReportAsync() => default;
+    }
+
+    public sealed class LegacyReport : LegacyReportBase { }
+
+    [Fact]
+    public void WhenBcDeclaresTheWholeStep_ItIsSelected_NotTheBareTrigger()
+    {
+        var pick = NavReportSync.SelectPreTriggerMethod(typeof(FakeReportBase));
+
+        Assert.NotNull(pick);
+        Assert.Equal("OnPreTriggerAsync", pick!.Name);
+        Assert.Equal(typeof(ValueTask), pick.ReturnType);
+    }
+
+    [Fact]
+    public void WhenBcDeclaresTheWholeStep_RunningIt_HitsItExactlyOnce_AndNotTheBareTriggerDirectly()
+    {
+        var r = new NormalReport();
+
+        NavReportSync.RunOnPreTrigger(r, typeof(FakeReportBase));
+
+        // Exactly once: a double-dispatch would run the AL OnPreReport trigger twice, and a
+        // report trigger is not idempotent.
+        Assert.Equal(1, r.WholeStepHits);
+        // Zero, not one: BC's own OnPreTriggerAsync is what reaches the trigger, so the runner
+        // must not also call it. This is the assertion that fails if someone "helpfully" adds
+        // the old RunLifecycleTrigger call back alongside the new one.
+        Assert.Equal(0, r.BareTriggerHits);
+    }
+
+    /// <summary>
+    /// The negative direction: an Ncl build with no OnPreTriggerAsync must still run the
+    /// trigger. Degrading to the pre-#2526 behaviour is correct there; degrading to nothing
+    /// would stop every report's OnPreReport.
+    /// </summary>
+    [Fact]
+    public void WhenBcHasNoWholeStep_ItFallsBackToTheBareTrigger()
+    {
+        Assert.Null(NavReportSync.SelectPreTriggerMethod(typeof(LegacyReportBase)));
+
+        var r = new LegacyReport();
+        NavReportSync.RunOnPreTrigger(r, typeof(LegacyReportBase));
+
+        Assert.Equal(1, r.BareTriggerHits);
+    }
+}
+
+/// <summary>
+/// Rot guard, run on every BC leg. The fix calls BC's private
+/// <c>NavReport.OnPreTriggerAsync</c> and depends on it still doing all three of its steps.
+/// A BC build that renames it makes <see cref="NavReportSync.SelectPreTriggerMethod"/> answer
+/// null and the runner fall back SILENTLY to running only the trigger — which is exactly the
+/// defect #2526 reported, reappearing with no failing test to announce it. So the members are
+/// asserted here rather than rediscovered from an empty parameters document.
+/// </summary>
+[Collection(BcEngineCollection.Name)]
+public sealed class ReportPreTriggerBcMembersTests
+{
+    private readonly BcEngineFixture _engine;
+    public ReportPreTriggerBcMembersTests(BcEngineFixture engine) => _engine = engine;
+
+    [SkippableFact]
+    public void Ncl_StillDeclares_TheWholeStepAndItsThreeParts()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var ncl = typeof(ITreeObject).Assembly;
+        var navReport = ncl.GetType("Microsoft.Dynamics.Nav.Runtime.NavReport")!;
+        const BindingFlags F = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+        var wholeStep = navReport.GetMethod("OnPreTriggerAsync", F, null, Type.EmptyTypes, null);
+        Assert.True(wholeStep != null,
+            "NavReport.OnPreTriggerAsync() is gone from this Ncl build — RunOnPreTrigger falls back to "
+            + "running only the OnPreReport trigger, so report labels and default parameters silently "
+            + "stop reaching the parameters document (#2526).");
+        Assert.Equal(typeof(ValueTask), wholeStep!.ReturnType);
+
+        // Its three steps. If any is renamed the whole-step method above is still called, so the
+        // runner would not notice — but the parameters document would change shape.
+        Assert.NotNull(navReport.GetMethod("OnPreReportInternalAsync", F, null, Type.EmptyTypes, null));
+        Assert.NotNull(navReport.GetMethod("InitializeReportLabelsAsync", F, null, Type.EmptyTypes, null));
+        Assert.NotNull(navReport.GetMethod("AddDefaultParameters", F, null, Type.EmptyTypes, null));
+
+        // AddDefaultParameters reads ResultSetProcessor.RequireDataColumnEval and NREs on a null
+        // one — which is why the processor install moved ahead of the pre-report step. If this
+        // property disappears the ordering constraint changes with it.
+        var dataItemIterator = ncl.GetType("Microsoft.Dynamics.Nav.Runtime.DataItemIterator")!;
+        Assert.NotNull(dataItemIterator.GetProperty("ResultSetProcessor", F));
+    }
+}

--- a/AlRunner/Patches/NavReportSync.cs
+++ b/AlRunner/Patches/NavReportSync.cs
@@ -947,8 +947,7 @@ public static partial class NavReportSync
     /// </summary>
     internal static void RunOnPreTrigger(object navReport, Type navReportBase)
     {
-        var onPreTrigger = navReportBase.GetMethod("OnPreTriggerAsync", LifecycleTriggerFlags,
-            null, Type.EmptyTypes, null);
+        var onPreTrigger = SelectPreTriggerMethod(navReportBase);
         if (onPreTrigger == null)
         {
             RunLifecycleTrigger(navReport, navReportBase, "OnPreReport");
@@ -956,6 +955,16 @@ public static partial class NavReportSync
         }
         BcRuntime.AwaitIfTask(Invoke(onPreTrigger, navReport, Array.Empty<object?>()));
     }
+
+    /// <summary>
+    /// BC's whole-pre-report method when this Ncl build has one, else null so
+    /// <see cref="RunOnPreTrigger"/> falls back to the bare trigger. Split out as a pure
+    /// function of the base type so it can be pinned without a BC runtime — see
+    /// AlRunner.Tests/ReportPreTriggerStepTests.cs.
+    /// </summary>
+    internal static MethodInfo? SelectPreTriggerMethod(Type navReportBase)
+        => navReportBase.GetMethod("OnPreTriggerAsync", LifecycleTriggerFlags,
+            null, Type.EmptyTypes, null);
 
     internal static void RunLifecycleTrigger(object navReport, Type navReportBase, string trigger)
     {

--- a/AlRunner/Patches/NavReportSync.cs
+++ b/AlRunner/Patches/NavReportSync.cs
@@ -672,8 +672,15 @@ public static partial class NavReportSync
             // to a data item the loop re-seeds, both went missing.
             StoreCallerTableViewBeforeLoop(navReport);
 
-            RunLifecycleTrigger(navReport, navReportBase, "OnPreReport");
-            bool datasetWritten = InvokeDataItems(navReport);
+            // BC's RunReportInternalCoreAsync installs the result-set processor HERE — after
+            // the request page has run (which is what parks the SaveAsXml file names on
+            // TestExecution) and BEFORE the pre-report step. The order is load-bearing rather
+            // than cosmetic: OnPreTriggerAsync's third step, AddDefaultParameters, reads
+            // ResultSetProcessor.RequireDataColumnEval and NREs on a null one. Installing it
+            // inside InvokeDataItems, as this used to, put it one step too late.
+            var datasetProcessor = EnsureResultSetProcessor(navReport, FindDataItemIteratorType(navReport));
+            RunOnPreTrigger(navReport, navReportBase);
+            bool datasetWritten = InvokeDataItems(navReport, datasetProcessor);
             RunLifecycleTrigger(navReport, navReportBase, "OnPostReport");
 
             // Strict AL semantics: when the report declares `ProcessingOnly =
@@ -897,6 +904,59 @@ public static partial class NavReportSync
     /// <c>__IsAsync</c> rule for the one that does not (Init). Either way the AL trigger runs
     /// exactly once, in the flavour the compiler emitted it in.
     /// </summary>
+    /// <summary>
+    /// BC's own pre-report step, whole. Issue #2526.
+    ///
+    /// <c>NavReport.OnPreTriggerAsync</c> does THREE things, in this order (verbatim from BC
+    /// 28.1's Ncl.dll):
+    ///
+    /// <code>
+    ///   await DataItemIterator.ExecuteTriggerAsync(Session, null, OnPreReportInternalAsync, "OnPreReport", this);
+    ///   await InitializeReportLabelsAsync();
+    ///   AddDefaultParameters();
+    /// </code>
+    ///
+    /// The runner called only the first of them — <see cref="RunLifecycleTrigger"/> with
+    /// "OnPreReport", which resolves to that same <c>OnPreReportInternalAsync</c>. So the AL
+    /// trigger ran and the other two steps silently did not:
+    ///
+    /// <list type="bullet">
+    /// <item><c>InitializeReportLabelsAsync</c> walks <c>Metadata.Labels</c> and adds every
+    /// NON-PerRow label to <c>reportDatasetParameters</c> — which is exactly what
+    /// <c>NavReport.GetParameters()</c> returns and what
+    /// <c>ReportSaveAsXmlRenderer.SerializeReportParameters</c> writes into the parameters
+    /// file. A column declaring <c>IncludeCaption = true</c> contributes a label named
+    /// <c>{ColumnName}Caption</c>, and a report's <c>labels</c> section contributes one per
+    /// entry. With the step skipped the parameters document came out as a bare
+    /// <c>&lt;ArrayOfReportParameter /&gt;</c>, so Microsoft's
+    /// <c>LibraryReportDataset.AssertParameterValueExists</c> found no row at all.</item>
+    /// <item><c>AddDefaultParameters</c> appends BC's own default parameters (user id, the
+    /// client-local timestamp) when the result-set processor requires data-column
+    /// evaluation.</item>
+    /// </list>
+    ///
+    /// Calling BC's method rather than re-deriving its three steps is the same choice
+    /// <see cref="RunLifecycleTrigger"/> already makes for the trigger itself: the ordering,
+    /// the error context <c>ExecuteTriggerAsync</c> establishes, and whatever a future BC
+    /// build adds here all come from BC. The fallback to the bare trigger keeps a Ncl without
+    /// that method working exactly as it did.
+    ///
+    /// Placement is unchanged and matches BC: after the request page has run and the
+    /// result-set processor is installed (<c>AddDefaultParameters</c> reads it), before the
+    /// data-item loop.
+    /// </summary>
+    internal static void RunOnPreTrigger(object navReport, Type navReportBase)
+    {
+        var onPreTrigger = navReportBase.GetMethod("OnPreTriggerAsync", LifecycleTriggerFlags,
+            null, Type.EmptyTypes, null);
+        if (onPreTrigger == null)
+        {
+            RunLifecycleTrigger(navReport, navReportBase, "OnPreReport");
+            return;
+        }
+        BcRuntime.AwaitIfTask(Invoke(onPreTrigger, navReport, Array.Empty<object?>()));
+    }
+
     internal static void RunLifecycleTrigger(object navReport, Type navReportBase, string trigger)
     {
         var bcDispatcher = navReportBase.GetMethod(trigger + "InternalAsync", LifecycleTriggerFlags,
@@ -962,13 +1022,10 @@ public static partial class NavReportSync
     /// BC's own <c>ReportSaveAsXmlRenderer</c> produced the file. The caller uses this to
     /// decide whether a layout still has to be resolved — a dataset run resolves none.
     /// </returns>
-    private static bool InvokeDataItems(object navReport)
+    private static bool InvokeDataItems(object navReport, object? datasetProcessor)
     {
-        Type? iter = navReport.GetType();
-        while (iter != null && iter.Name != "DataItemIterator") iter = iter.BaseType;
+        var iter = FindDataItemIteratorType(navReport);
         if (iter == null) return false;
-
-        var datasetProcessor = EnsureResultSetProcessor(navReport, iter);
 
         _applyDataItemTableView ??= iter.GetMethod("ApplyDataItemTableViewAndRequestFormFilters",
             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
@@ -1005,8 +1062,21 @@ public static partial class NavReportSync
     /// what its factory returns for a report with no layout, so neither is a runner stand-in.
     /// </summary>
     /// <returns>The dataset renderer when one was installed, else null.</returns>
-    private static object? EnsureResultSetProcessor(object navReport, Type dataItemIteratorType)
+    /// <summary>
+    /// The <c>DataItemIterator</c> base of a compiled report, or null when the object is not
+    /// one. Both the processor install and the data-item loop need it, and since #2526 they
+    /// happen at two different points in the lifecycle rather than one.
+    /// </summary>
+    private static Type? FindDataItemIteratorType(object navReport)
     {
+        Type? iter = navReport.GetType();
+        while (iter != null && iter.Name != "DataItemIterator") iter = iter.BaseType;
+        return iter;
+    }
+
+    private static object? EnsureResultSetProcessor(object navReport, Type? dataItemIteratorType)
+    {
+        if (dataItemIteratorType == null) return null;
         _resultSetProcessorProp ??= dataItemIteratorType.GetProperty("ResultSetProcessor",
             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
         if (_resultSetProcessorProp == null) return null;


### PR DESCRIPTION
Closes #2796

Filed by agent impl-6, from investigating #2526. **This PR does not close #2526** — see "What
this does not fix" below.

## Mechanism

BC's pre-report step is one method that does three things. Verbatim from BC 28.1's shipped
`Ncl.dll`, `NavReport.OnPreTriggerAsync`:

```csharp
await DataItemIterator.ExecuteTriggerAsync(Session, null, OnPreReportInternalAsync, "OnPreReport", this);
await InitializeReportLabelsAsync();
AddDefaultParameters();
```

`NavReportSync.TryRunOrControlFlow` called `RunLifecycleTrigger(navReport, navReportBase,
"OnPreReport")`, which resolves to that same `OnPreReportInternalAsync` — the **first** step
only. The AL trigger ran; the other two silently did not.

`InitializeReportLabelsAsync` is the one that matters: it walks `Metadata.Labels` and adds every
non-`PerRow` label to `reportDatasetParameters`, which is exactly what `NavReport.GetParameters()`
returns and what `ReportSaveAsXmlRenderer.SerializeReportParameters` writes into the parameters
file. A column declaring `IncludeCaption = true` contributes a label named `{ColumnName}Caption`;
a report's `labels` section contributes one per entry.

## Measured, on a hermetic bundle with no Base Application

A report with two `IncludeCaption = true` columns, one column deliberately without it, and a
one-entry `labels` section, driven through a `[RequestPageHandler]` calling
`SaveAsXml(parametersFile, dataSetFile)`.

**Before** — the entire document:

```xml
<?xml version="1.0" encoding="utf-8"?>
<ArrayOfReportParameter xmlns:xsi="..." xmlns:xsd="..." />
```

**After** — five `<ReportParameter>` entries:

| Name | Values/string | where it comes from |
|---|---|---|
| `EntryNo_RowCaption` | `Entry No.` | `IncludeCaption = true`, caption taken from the field |
| `CaptionedAmount_RowCaption` | `Captioned Amount` | same |
| `MyOwnLabel` | `My Own Label` | the report's `labels` section |
| `NavUserId…` | `TESTUSER` | `AddDefaultParameters` |
| `ExecutionTime…` | `2026-09-05T16:09:59.608…` | `AddDefaultParameters` |

The negative direction holds in the same run: `PlainName_Row`, which declares no
`IncludeCaption`, produces no `PlainName_RowCaption`. And captions are parameters, not dataset
columns — the dataset document is unchanged by this PR, which is why Microsoft's own test reads
the *parameters* file.

## The ordering change, and why it is not incidental

`AddDefaultParameters` reads `ResultSetProcessor.RequireDataColumnEval`. The runner installed the
processor inside `InvokeDataItems`, i.e. one step *after* the pre-report step, so calling BC's
method straight away NRE'd inside `AddDefaultParameters`. BC installs it earlier — after the
request page has run (which is what parks the `SaveAsXml` file names on `TestExecution`) and
before `OnPreTriggerAsync`. The install moves to match, and `InvokeDataItems` now receives the
processor rather than creating it.

## Fixing the shape, not the reported line

- **Same wrong pattern at another call site?** No. `OnPostReport` is the only sibling with a
  BC whole-step wrapper of the same kind, and `NavReport.OnPostTriggerAsync` does not exist —
  the post half has no extra steps to skip. `OnInitReport` likewise.
- **Sibling functions with the same assumption?** `RunLifecycleTrigger` itself is correct and
  unchanged: it already prefers BC's `On{Pre,Post}ReportInternalAsync` dispatcher and mirrors
  `__IsAsync` for `OnInitReport` (#2732/#2734). The defect was one level up — *which* BC method
  the lifecycle calls, not how it dispatches the trigger.
- **Two paths, same invariant?** The result-set processor is now installed in exactly one place
  for both the dataset and the no-dataset path, rather than lazily inside the data-item loop.

## Verification

BC 28.1 unless noted.

- `AlRunner.Tests/ReportPreTriggerStepTests.cs` — RED 1/3 with the pre-fix rule, GREEN 3/3 with
  it. Pins that the whole-step method is selected, that it runs **exactly once and the bare
  trigger not at all** (a double-dispatch would run an AL `OnPreReport` twice), and the negative
  direction: an Ncl without `OnPreTriggerAsync` must still run the trigger.
- `ReportPreTriggerBcMembersTests` — a rot guard on every BC leg. If a BC build renames
  `OnPreTriggerAsync`, the runner falls back **silently** to running only the trigger, which is
  this defect reappearing with nothing to announce it. The guard asserts the whole-step method,
  its three parts, and `DataItemIterator.ResultSetProcessor` (the ordering constraint).
- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~Report"` — 155/155 passed, 22 skipped.
- al-language corpus — **2464/2464**. runner-extras — **243/243**. Both at this PR's head.

## What this does not fix, and what I did not verify

**Microsoft's `Codeunit134335.VendorDetailTrialBalance_EntryNoCaption` (#2526) still fails, and
this PR does not close it.** Measured, not assumed: codeunit 134335 is **38 → 38** passing with
no per-test movement. Report 304 is a *precompiled* Base Application report, and its
reconstructed `MetaReport.Labels` is empty — instrumented: `Labels=0 DataItems=5`, against
`Labels=3` for the runner-compiled probe. So there is a second, independent layer, which I have
written up on #2526 with the symbol data and XML shape needed for it. I deliberately did not
fold it in: it lives in a different subsystem (dependency symbol parsing plus report-metadata
synthesis), needs its own RED → GREEN, and bundling it would make this two unrelated changes.

**The BC-behaviour half has no upstream test, and cannot have one.** The parameters document is
reachable only through `TestRequestPage.SaveAsXml(parametersFile, dataSetFile)`, which takes file
PATHS — `NavTestPage.ALSaveAsXml` has no stream overload, confirmed against the shipped IL — and
reading a file back needs `File`, which the AL compiler rejects for `Target = Cloud` (AL0296),
the corpus's target. Per `bc-behavior-tests-go-upstream.md` I have not substituted a runner-local
BC-behaviour test to paper over that; the coverage here is runner-mechanism tests plus the
measured before/after above, and the gap is stated on #2796.

I also did not run the full 839-test `Tests-SINGLESERVER` bucket for this change. The isolated
134335 pair showed no movement in either direction, and corpus + runner-extras are green.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
