### PR TITLE
perf(systemid): index the duplicate-SystemId check instead of scanning every row

### DIFF
--- a/AlRunner.Tests/StoredSystemIdIndexTests.cs
+++ b/AlRunner.Tests/StoredSystemIdIndexTests.cs
@@ -1,0 +1,171 @@
+// StoredSystemIdIndexTests — the invalidation rules behind #2667's duplicate-SystemId index.
+//
+// The index replaces a walk of every stored row on every insert. Its only real risk is going
+// stale, and the two directions are NOT equally bad:
+//
+//   * an index that LOST an entry misses a duplicate real BC would refuse — a wrong answer, but
+//     the same wrong answer the runner gave before #2639 existed;
+//   * an index holding a STALE entry refuses an insert real BC would ACCEPT — it fails a correct
+//     test with a database error that has nothing to do with the AL under test.
+//
+// The second is the one to design against, and every test below is about a mutation the index
+// does not observe: an insert that threw, a delete, a DeleteAll, a snapshot replay. In each case
+// the store's row count no longer matches what the index last agreed with, and the index must
+// rebuild rather than answer from memory.
+//
+// These drive the class directly with a fake store, so they pin the rule rather than a
+// particular BC build's tree; the wiring into TempTableDataProvider.Insert is exercised
+// end-to-end by the corpus's own SystemId contracts (codeunit 60061).
+
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class StoredSystemIdIndexTests
+{
+    private static readonly Guid A = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid B = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private static readonly Guid C = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+    /// <summary>A stand-in for the store, counting how often the O(rows) rebuild walk is taken.</summary>
+    private sealed class FakeStore
+    {
+        internal readonly List<Guid> Rows = new();
+        internal int Walks;
+        internal IEnumerable<Guid> Enumerate() { Walks++; return Rows.ToList(); }
+        internal int Count => Rows.Count;
+    }
+
+    [Fact]
+    public void FirstSync_Rebuilds_AndAnswersFromTheStore()
+    {
+        var store = new FakeStore(); store.Rows.AddRange(new[] { A, B });
+        var idx = new StoredSystemIdIndex();
+
+        Assert.Equal(StoredSystemIdIndex.Unsynced, idx.SyncedRowCount);
+        Assert.True(idx.SyncTo(store.Count, store.Enumerate), "an unsynced index must rebuild");
+
+        Assert.Equal(1, store.Walks);
+        Assert.True(idx.Contains(A));
+        Assert.True(idx.Contains(B));
+        Assert.False(idx.Contains(C));
+        Assert.Equal(2, idx.SyncedRowCount);
+    }
+
+    [Fact]
+    public void SecondSync_AtTheSameCount_DoesNotWalkTheStore()
+    {
+        // This is the whole point of the change: the common path must not be O(rows).
+        var store = new FakeStore(); store.Rows.AddRange(new[] { A, B });
+        var idx = new StoredSystemIdIndex();
+        idx.SyncTo(store.Count, store.Enumerate);
+
+        Assert.False(idx.SyncTo(store.Count, store.Enumerate), "a count that has not moved must not rebuild");
+        Assert.Equal(1, store.Walks);
+    }
+
+    [Fact]
+    public void NoteInserting_AnticipatesTheRowTheCallerIsAboutToLetThrough()
+    {
+        // The check runs AHEAD of the insert, so the index moves to one more than the store
+        // holds right now. When the insert lands, the counts agree and the next check is O(1).
+        var store = new FakeStore(); store.Rows.Add(A);
+        var idx = new StoredSystemIdIndex();
+        idx.SyncTo(store.Count, store.Enumerate);
+
+        idx.NoteInserting(B, store.Count);
+        store.Rows.Add(B);   // the insert lands
+
+        Assert.Equal(store.Count, idx.SyncedRowCount);
+        Assert.False(idx.SyncTo(store.Count, store.Enumerate), "a landed insert must not force a rebuild");
+        Assert.Equal(1, store.Walks);
+        Assert.True(idx.Contains(B));
+    }
+
+    [Fact]
+    public void AnInsertThatThrew_IsCorrectedOnTheNextSync()
+    {
+        // The dangerous direction: the index noted a row that never landed. If it kept believing
+        // that, it would refuse a later insert of the same id that real BC would accept.
+        var store = new FakeStore(); store.Rows.Add(A);
+        var idx = new StoredSystemIdIndex();
+        idx.SyncTo(store.Count, store.Enumerate);
+
+        idx.NoteInserting(B, store.Count);   // cleared to insert...
+        // ...and the insert threw, so the store still holds one row.
+        Assert.True(idx.Contains(B), "precondition: the phantom entry is present before the next sync");
+
+        Assert.True(idx.SyncTo(store.Count, store.Enumerate), "a count one short must rebuild");
+        Assert.False(idx.Contains(B), "a row that never landed must not survive as a phantom duplicate");
+        Assert.True(idx.Contains(A));
+    }
+
+    [Fact]
+    public void ADeletedRow_StopsCountingAsADuplicate()
+    {
+        var store = new FakeStore(); store.Rows.AddRange(new[] { A, B });
+        var idx = new StoredSystemIdIndex();
+        idx.SyncTo(store.Count, store.Enumerate);
+        Assert.True(idx.Contains(A));
+
+        store.Rows.Remove(A);   // a delete this index never saw
+
+        Assert.True(idx.SyncTo(store.Count, store.Enumerate), "a dropped count must rebuild");
+        Assert.False(idx.Contains(A), "re-inserting a deleted row's SystemId must be allowed");
+        Assert.True(idx.Contains(B));
+    }
+
+    [Fact]
+    public void DeleteAll_ClearsTheIndex()
+    {
+        var store = new FakeStore(); store.Rows.AddRange(new[] { A, B, C });
+        var idx = new StoredSystemIdIndex();
+        idx.SyncTo(store.Count, store.Enumerate);
+
+        store.Rows.Clear();
+
+        Assert.True(idx.SyncTo(store.Count, store.Enumerate));
+        Assert.False(idx.Contains(A));
+        Assert.False(idx.Contains(B));
+        Assert.False(idx.Contains(C));
+        Assert.Equal(0, idx.IndexedCount);
+    }
+
+    [Fact]
+    public void Invalidate_ForcesARebuild_EvenWhenTheCountIsUnchanged()
+    {
+        // A snapshot replay (#2694) writes rows straight past the check under
+        // SuppressSystemIdUniqueness, so the count can land back on its old value with entirely
+        // different ids behind it. Nothing but an explicit invalidation catches that.
+        var store = new FakeStore(); store.Rows.AddRange(new[] { A, B });
+        var idx = new StoredSystemIdIndex();
+        idx.SyncTo(store.Count, store.Enumerate);
+
+        store.Rows.Clear();
+        store.Rows.AddRange(new[] { B, C });   // same count, different rows
+        Assert.False(idx.SyncTo(store.Count, store.Enumerate), "precondition: the count alone cannot see this");
+        Assert.True(idx.Contains(A), "precondition: the index still believes the replaced row");
+
+        idx.Invalidate();
+
+        Assert.True(idx.SyncTo(store.Count, store.Enumerate), "an invalidated index must rebuild");
+        Assert.False(idx.Contains(A));
+        Assert.True(idx.Contains(C));
+    }
+
+    [Fact]
+    public void RebuildIsLazy_TheCallbackIsNotInvokedWhenNothingDrifted()
+    {
+        // The callback is what costs O(rows). It must not be called on the common path — a
+        // regression here would silently restore the quadratic this change exists to remove.
+        var store = new FakeStore(); store.Rows.Add(A);
+        var idx = new StoredSystemIdIndex();
+        idx.SyncTo(store.Count, store.Enumerate);
+        var walksAfterFirstSync = store.Walks;
+
+        for (var i = 0; i < 100; i++) idx.SyncTo(store.Count, store.Enumerate);
+
+        Assert.Equal(walksAfterFirstSync, store.Walks);
+    }
+}

--- a/AlRunner/Patches/RowVersionPatches.SystemIdIndex.cs
+++ b/AlRunner/Patches/RowVersionPatches.SystemIdIndex.cs
@@ -1,0 +1,85 @@
+// StoredSystemIdIndex — the duplicate-SystemId check's index (issue #2667).
+//
+// #2639's guard answered "is this SystemId already stored?" by walking every stored row of the
+// table on every insert. That is O(stored rows) per insert and O(rows^2) over a bulk load, and
+// measured on a plain 3-field table it is not a rounding error: it was 93-97% of ALL the work a
+// bulk insert did, and it grew quadratically (3.38x for a 2x row increase, 2.18x for a 1.5x
+// one, against 4.00x/2.25x for a textbook quadratic and 2.00x/1.50x for a linear one).
+//
+// Real BC does not scan. It puts a clustered unique index on $systemId and lets SQL Server
+// answer in constant time. The faithful analogue is an index, which is what this is.
+//
+// The whole difficulty is INVALIDATION, and the failure mode is asymmetric: an index that has
+// LOST an entry misses a duplicate real BC would refuse, while an index holding a STALE entry
+// refuses an insert real BC would accept. The second is worse -- it fails a correct test with
+// a database error that has nothing to do with the AL under test -- so this class never trusts
+// itself. It carries the store's row count as of its last sync and rebuilds whenever the store
+// disagrees, which makes it self-correcting for every mutation it does not see:
+//
+//   * an insert that succeeds        -> count matches the anticipated one, no rebuild
+//   * an insert that throws          -> count is one short, rebuild
+//   * a delete, a DeleteAll          -> count dropped, rebuild
+//   * a snapshot restore (rollback)  -> those inserts run under SuppressSystemIdUniqueness and
+//                                       are not seen here at all, so the caller invalidates
+//                                       explicitly AND the count check catches it
+//
+// A rebuild is one O(rows) walk, i.e. exactly what the old code did on EVERY insert, so the
+// worst case is no worse than the behaviour this replaces.
+
+namespace AlRunner.Patches;
+
+/// <summary>
+/// The set of SystemIds a single table store currently holds, kept in step with that store by
+/// row count. Not thread-safe by itself: the caller holds the lock, because the decision to
+/// rebuild, the lookup and the note-the-pending-insert have to be one atomic step.
+/// </summary>
+internal sealed class StoredSystemIdIndex
+{
+    /// <summary>Row count meaning "never synced, or known stale" — forces the next sync to rebuild.
+    /// Negative so it can never equal a real count.</summary>
+    internal const int Unsynced = -1;
+
+    private readonly HashSet<Guid> _ids = new();
+    private int _syncedRowCount = Unsynced;
+
+    /// <summary>The store row count this index last agreed with. <see cref="Unsynced"/> until a sync.</summary>
+    internal int SyncedRowCount => _syncedRowCount;
+
+    /// <summary>How many ids are indexed — for tests; not a substitute for the row count, because
+    /// two stored rows could in principle carry the same id (that is the bug being guarded against).</summary>
+    internal int IndexedCount => _ids.Count;
+
+    /// <summary>Force the next <see cref="SyncTo"/> to rebuild. Used when rows were written by a
+    /// path this index does not observe.</summary>
+    internal void Invalidate() => _syncedRowCount = Unsynced;
+
+    /// <summary>
+    /// Make the index agree with a store currently holding <paramref name="storedRowCount"/> rows,
+    /// rebuilding from <paramref name="storedIds"/> only when the count says it drifted.
+    /// <paramref name="storedIds"/> is a callback rather than a collection so the O(rows) walk is
+    /// not paid on the common path where nothing drifted. Returns true when a rebuild happened.
+    /// </summary>
+    internal bool SyncTo(int storedRowCount, Func<IEnumerable<Guid>> storedIds)
+    {
+        if (_syncedRowCount == storedRowCount) return false;
+        _ids.Clear();
+        foreach (var id in storedIds()) _ids.Add(id);
+        _syncedRowCount = storedRowCount;
+        return true;
+    }
+
+    /// <summary>Is this id already stored? Only meaningful straight after a <see cref="SyncTo"/>.</summary>
+    internal bool Contains(Guid id) => _ids.Contains(id);
+
+    /// <summary>
+    /// Record the row the caller is about to let through. The count moves to one MORE than the
+    /// store holds right now, because this runs ahead of the insert it is clearing: if that
+    /// insert lands the counts agree and the next check is O(1), and if it throws the store stays
+    /// one short and the next check rebuilds.
+    /// </summary>
+    internal void NoteInserting(Guid id, int storedRowCountBeforeInsert)
+    {
+        _ids.Add(id);
+        _syncedRowCount = storedRowCountBeforeInsert + 1;
+    }
+}

--- a/AlRunner/Patches/RowVersionPatches.SystemIdIntegrity.cs
+++ b/AlRunner/Patches/RowVersionPatches.SystemIdIntegrity.cs
@@ -210,9 +210,45 @@ public static partial class RowVersionPatches
         public void Dispose() => _suppressSystemIdUniqueness = _previous;
     }
 
+    /// <summary>Per-store SystemId indexes (#2667). Keyed on the provider so an index dies with
+    /// the store it describes; a table the run never touches again costs nothing.</summary>
+    private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<object, StoredSystemIdIndex>
+        _systemIdIndexes = new();
+
+    /// <summary>The AvlTree row count, in O(1), or -1 when the tree cannot answer cheaply.
+    /// BC's own <c>AvlTree&lt;T&gt;.CountIfBounded</c> returns the node count for an unbounded
+    /// tree (which <c>primaryTree</c> always is) and -1 for a bounded view.</summary>
+    private static int TryGetStoredRowCount(object storedRows)
+    {
+        var getter = _treeCountGetters.GetOrAdd(storedRows.GetType(), static t =>
+        {
+            var prop = t.GetProperty("CountIfBounded",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var getMethod = prop?.GetGetMethod(nonPublic: true);
+            if (getMethod == null || prop!.PropertyType != typeof(int)) return null;
+            var instance = System.Linq.Expressions.Expression.Parameter(typeof(object), "tree");
+            var body = System.Linq.Expressions.Expression.Call(
+                System.Linq.Expressions.Expression.Convert(instance, t), getMethod);
+            return System.Linq.Expressions.Expression.Lambda<Func<object, int>>(body, instance).Compile();
+        });
+        // No such property on this BC build: fall back to the scan rather than guess a count.
+        return getter == null ? -1 : getter(storedRows);
+    }
+
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, Func<object, int>?>
+        _treeCountGetters = new();
+
     private static void CheckNoDuplicateSystemId(object? provider, object? recordBuffer)
     {
-        if (_suppressSystemIdUniqueness) return;
+        if (_suppressSystemIdUniqueness)
+        {
+            // A snapshot replay writes rows straight past this check (#2694), so anything this
+            // index believes about that store is now guesswork. Drop it; the next real insert
+            // rebuilds. See StoredSystemIdIndex for why a stale entry is the dangerous direction.
+            if (provider != null && _systemIdIndexes.TryGetValue(provider, out var replayed))
+                lock (replayed) replayed.Invalidate();
+            return;
+        }
         if (recordBuffer == null || !BlobStoreIsolationPatches.IsDatabaseBacked(provider)) return;
 
         var bufferType = recordBuffer.GetType();
@@ -262,21 +298,46 @@ public static partial class RowVersionPatches
         // nothing to collide with.
         if (_fPrimaryTree.GetValue(provider) is not System.Collections.IEnumerable storedRows) return;
 
-        // Read each stored row's SystemId through a delegate compiled once per row type
-        // rather than PropertyInfo.GetValue per row. This loop runs on EVERY insert into a
-        // database-backed table that carries an explicit SystemId, so it is O(rows) per
-        // insert and O(rows^2) over a bulk materialisation. Measured before this was
-        // compiled: the Date virtual table's on-demand window materialisation
-        // (tests/runner-extras/date-virtual-table-window, Codeunit64561) went from 908 ms
-        // on main to a 60 s timeout — reflection per row, not the comparison, was the cost.
-        foreach (var rowObj in storedRows)
+        // #2667: answer from a per-store index instead of walking every stored row. The walk
+        // ran on EVERY insert into a database-backed table — note that the zero-SystemId early
+        // return above does NOT spare the common case, because the id is already assigned by the
+        // time this runs — making it O(rows) per insert and O(rows^2) over a bulk load. Measured
+        // on a 3-field table with the guard bypassed as the control, it was 93-97% of all the
+        // work an insert did. See StoredSystemIdIndex for the invalidation rules.
+        var storedRowCount = TryGetStoredRowCount(storedRows);
+        if (storedRowCount < 0)
         {
-            var storedSystemId = ReadRowSystemId(rowObj);
-            if (storedSystemId.Value != incomingSystemId.Value) continue;
-
-            var tableCaption = ResolveTableCaptionSafe(metaTable);
-            throw BuildDuplicateSystemIdException(tableCaption, $"SystemId={incomingSystemId.Value}");
+            // The store cannot give a cheap, trustworthy count, so an index built from it could
+            // not be verified. Fall back to exactly the pre-#2667 walk rather than risk a stale
+            // entry refusing an insert real BC would accept.
+            foreach (var rowObj in storedRows)
+            {
+                if (ReadRowSystemId(rowObj).Value != incomingSystemId.Value) continue;
+                throw BuildDuplicateSystemIdException(
+                    ResolveTableCaptionSafe(metaTable), $"SystemId={incomingSystemId.Value}");
+            }
+            return;
         }
+
+        var index = _systemIdIndexes.GetOrCreateValue(provider);
+        lock (index)
+        {
+            // Deciding to rebuild, looking the id up, and noting the row this call is about to
+            // clear have to be one atomic step: two threads inserting into the same store must
+            // not both see "not present" for the same id.
+            index.SyncTo(storedRowCount, () => EnumerateStoredSystemIds(storedRows));
+            if (index.Contains(incomingSystemId.Value))
+                throw BuildDuplicateSystemIdException(
+                    ResolveTableCaptionSafe(metaTable), $"SystemId={incomingSystemId.Value}");
+            index.NoteInserting(incomingSystemId.Value, storedRowCount);
+        }
+    }
+
+    /// <summary>Every stored row's SystemId, read through the same compiled per-row-type getter
+    /// the pre-#2667 walk used. Lazy, so a sync that does not rebuild never touches a row.</summary>
+    private static IEnumerable<Guid> EnumerateStoredSystemIds(System.Collections.IEnumerable storedRows)
+    {
+        foreach (var rowObj in storedRows) yield return ReadRowSystemId(rowObj).Value;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #2667

The duplicate-SystemId guard from #2639 walked every stored row of the table before every insert. It now consults a per-store index of the SystemIds currently held — which is what real BC does: a clustered unique index on `$systemId`, answered by SQL Server in constant time.

## Measured, with a control

Wall clock is useless on this box — seven agents on twelve cores, and identical work measured 2.3 s and 3.1 s. Every number below is **instructions retired** (`perf stat`), medians of three, where the per-measurement spread was 0.02–0.7%.

The control is **the same binary with the guard bypassed**, so the difference is the guard and nothing else:

| rows | guard on | guard bypassed (control) | guard's share |
|---:|---:|---:|---:|
| 12,000 | 33.1e9 | 2.5e9 | **92.6%** |
| 24,000 | 107.5e9 | 3.9e9 | **96.4%** |
| 36,000 | 231.9e9 | 6.1e9 | **97.4%** |

Growth of the guard's own cost: **3.38x** for a 2x row increase and **2.18x** for a 1.5x one — against 4.00x/2.25x for a textbook quadratic and 2.00x/1.50x for a linear one. The control over the same row counts grew 1.57x and 1.59x, flat by comparison. So the shape is quadratic, and the guard is essentially all of it.

**After this change**, at the same row counts: 2.9e9, 4.4e9, 6.3e9 instructions, growing **1.51x and 1.44x** — indistinguishable from the control. The quadratic is gone, not reduced:

| rows | before | after | speedup |
|---:|---:|---:|---:|
| 12,000 | 33.1e9 | 2.9e9 | 11.4x |
| 24,000 | 107.5e9 | 4.4e9 | 24.6x |
| 36,000 | 231.9e9 | 6.3e9 | 36.9x |

The factor keeps growing with row count, which is what removing an O(n²) looks like.

## The issue understated the blast radius

#2667 framed this as costing bulk loads that carry **explicit** SystemIds. Instrumenting the guard showed the zero-SystemId early return **never fires at all** — `zeroId=0` over a 12,000-row load — because the id is already assigned by the time the guard runs. Every insert into every database-backed table was paying the full scan: **71,994,000 rows walked for a 12,000-row load**, whether or not the AL set `SystemId`.

That also caught a mistake of mine. My first control was "insert without setting SystemId", on the assumption it would take the early return. It doesn't, so both arms scanned and the measurement showed nothing. The counters are what exposed it; the bypass control replaced it.

## Invalidation, and why it fails safe

The two directions are not symmetric:

- an index that **lost** an entry misses a duplicate real BC would refuse — the same wrong answer the runner gave before #2639;
- an index holding a **stale** entry refuses an insert real BC would **accept**, failing a correct test with a database error that has nothing to do with the AL under test.

The second is worse, and #2667 says so. So the index never trusts itself: it carries the store's row count as of its last sync and rebuilds whenever the store disagrees. Self-correcting for every mutation it cannot see:

| mutation | how it is caught |
|---|---|
| insert that landed | count matches the anticipated one — no rebuild, O(1) |
| insert that threw | store is one short → rebuild |
| delete / `DeleteAll` | count dropped → rebuild |
| snapshot replay (#2694) | writes past the check under `SuppressSystemIdUniqueness`, so it **also invalidates explicitly** — a replay can land back on the same count with different rows behind it |

A rebuild is one O(rows) walk — exactly what the old code did on *every* insert — so the worst case is no worse than what this replaces. Where the store cannot give a cheap trustworthy count (`AvlTree.CountIfBounded` returns -1 for a bounded view, and a future BC build might not have the property), it falls back to the original walk rather than risk a stale entry.

## Tests

`StoredSystemIdIndexTests` drives the index directly, one test per mutation it cannot observe, plus one asserting the common path does **not** walk the store — a regression there would silently restore the quadratic.

Mutating `SyncTo` to trust itself after the first sync fails exactly the three staleness tests and none of the others:

```
Failed  AnInsertThatThrew_IsCorrectedOnTheNextSync
Failed  ADeletedRow_StopsCountingAsADuplicate
Failed  DeleteAll_ClearsTheIndex
Failed: 3, Passed: 5
```

End to end: **full corpus 2464/2464, zero failures**, and `tests/runner-extras/date-virtual-table-window` — the suite whose 60 s watchdog timeout motivated #2639's virtual-table exclusion — still passes in 1.1 s. Targeted C# suites (`StoredSystemIdIndexTests`, `SystemIdRestoreSuppressionTests`, `RowVersionPatchesTests`): 28 passed.

## Shape check

- **Same wrong pattern elsewhere?** `PreserveSystemIdOnModify`, the sibling in this file, reads one field off the record buffer and does not scan — it is O(1) already.
- **Sibling assumption?** The zero-SystemId early return is now known to be dead on this path. Left in place (it is still correct, and cheap), but the comment above it no longer claims it spares the common case.
- **Same-state invariant?** The suppression path previously just returned; it now also invalidates, so the two writers of the index agree about what a replay means.
- **Not fixed here:** the BC-behaviour claim "delete a row, then re-insert its SystemId — this must succeed" has no upstream corpus test. I proved it against the runner while validating this change, but per `bc-behavior-tests-go-upstream.md` it belongs in the corpus; `TestRecordSystemId.al` (codeunit 60061) is the right home and my PR #147 is already open on that file. Worth folding in there rather than a fourth corpus PR.

Written by agent impl-5.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
