### PR TITLE
fix(ci): scan commit messages, not just the PR body, for closing and skip directives

### DIFF
--- a/.claude/rules/branch-and-pr.md
+++ b/.claude/rules/branch-and-pr.md
@@ -8,13 +8,37 @@
 - **Concurrency with human maintainers.** This is a public repo. When claiming an issue, also assign it to `@me` (`gh issue edit <N> --add-assignee @me`, or `mcp__github__issue_write` with `method: update` and your login in `assignees`). Skip any issue or PR whose assignee is a user other than `@me` — a human maintainer is already on it. The assignee field is the boundary between "agent-owned" and "human-owned" work. A repo owner can waive this for a specific PR, but an agent never waives it on its own.
 - **GitHub access:** never assume the `gh` CLI exists — it is absent in web/remote sessions. See `.claude/rules/github-access.md`.
 
-## This repo squash-merges: the PR title + body become the commit message
+## This repo squash-merges: your COMMIT MESSAGES become the merge commit, and the PR body links issues separately
 
-Anything GitHub parses out of a commit message fires when written in a PR body,
-regardless of the author's intent or the surrounding prose. Refer to issues and
-directives without their trigger keywords/forms unless the effect is intended. Three
-real bugs share this one root cause:
+This section used to say "the PR title + body become the commit message". That is not
+what this repository is configured to do, and the wrong version is why the guards below
+were built to scan only the title and body (#2491). Measured, not assumed:
+
+```bash
+gh api repos/StefanMaron/BusinessCentral.AL.Runner \
+  --jq '{squash_merge_commit_title, squash_merge_commit_message}'
+# {"squash_merge_commit_title":"COMMIT_OR_PR_TITLE","squash_merge_commit_message":"COMMIT_MESSAGES"}
+```
+
+So text reaches the merged result by **two independent routes**, and both fire:
+
+| route | source text | what acts on it |
+|---|---|---|
+| the merge commit | your branch's **commit messages**, concatenated (subject: a commit subject, or the PR title) | GitHub parses the commit landing on `main` — closing references, CI-skip directives |
+| the pull request | the PR **title and body** | GitHub's `closingIssuesReferences`, which closes those issues when the PR merges |
+
+Practical consequence: a closing keyword or a skip directive written in a **commit
+message** fires even though it never appears in the PR body, and editing the body will
+not remove it — the commit has to be reworded and force-pushed. `Closes #N` belongs in
+the PR **body**, where the declaration is visible to a reviewer; `pr-check.yml` reads
+the title, the body and every commit message and holds the body to being the place a
+target is declared.
+
+Anything GitHub parses out of a commit message fires regardless of the author's intent or
+the surrounding prose. Refer to issues and directives without their trigger keywords/forms
+unless the effect is intended. Four real bugs share this one root cause:
 
 - A trailing `(#N)` already in the title survives into the merge commit and gets a second one appended by the squash itself (`generate_changelog.py` strips both, see #2109). **No automated guard for this one** — watch for it when a squash-merge default message already carries a PR-title `(#N)` and GitHub is about to append its own.
 - GitHub matches several CI-skip spellings (`[skip ci]`, `[ci skip]`, `[no ci]`, `[skip actions]`, `[actions skip]`, `***NO_CI***`) ANYWHERE in a commit message, so writing one in a PR body — even just to document it — silently skips every workflow on the resulting merge commit, including the one required check on `main` (this happened for real on #2115's merge, see #2116). `pr-check.yml`'s `reject-ci-skip-directives` job catches it before merge.
+- The same parser fires on a **commit message**, which the PR-body guard could not see: PR #2486 declared exactly two closing references (`closingIssuesReferences` confirmed #2478 and #2480), a commit message said "It does not close #2479", and merge commit `28cdcf65` closed #2479 anyway. The issue had to be reopened by hand. `reject-bad-closing-references` and `reject-ci-skip-directives` now scan the commit messages too (#2491).
 - GitHub's closing-reference parser (`Closes`/`Fixes`/`Resolves` + `#N`) fires on that pattern anywhere in the message and does not understand negation or qualifying prose: PR #2127's body said "This does not close #2125" and merge commit `fe789a13` closed #2125 regardless. The mirror bug is the parser missing entirely — a PR with no closing reference merges fine but leaves its linked issue open and labeled in-progress forever (real instances: #2046, #1642, #1640). `pr-check.yml`'s `reject-bad-closing-references` job catches both directions.

--- a/.github/scripts/check_ci_skip_directives.sh
+++ b/.github/scripts/check_ci_skip_directives.sh
@@ -4,20 +4,30 @@
 # Extracted into its own script (out of pr-check.yml's inline `run:` block) so
 # this can be unit-tested directly -- pr-check.yml's job just calls it.
 #
-# This repo squash-merges, and GitHub's default squash commit message is
-# "<title> (#N)" followed by the PR body (see .claude/rules/branch-and-pr.md).
-# GitHub matches several CI-skip spellings ANYWHERE in a commit message, not
-# just in a dedicated trailer -- so a directive in EITHER the title or the
-# body, even just describing it in prose, lands in the merge commit and
-# silently skips every workflow on that commit. This happened for real:
+# This repo squash-merges. Measured rather than assumed (#2491):
+# `squash_merge_commit_message` is COMMIT_MESSAGES and
+# `squash_merge_commit_title` is COMMIT_OR_PR_TITLE
+# (`gh api repos/StefanMaron/BusinessCentral.AL.Runner`), so the merge
+# commit's body is the concatenated BRANCH COMMIT MESSAGES and its subject is
+# a commit subject or the PR title. GitHub matches several CI-skip spellings
+# ANYWHERE in a commit message, not just in a dedicated trailer -- so a
+# directive in a commit message, the title, or the body, even just describing
+# it in prose, can land in the merge commit and silently skip every workflow
+# on that commit. The commit-message route is the one that most reliably
+# reaches it, and it was unchecked until #2491; title and body stay checked
+# because the squash title is drawn from them and because a directive there
+# is never intentional. This happened for real:
 # #2115's own PR body explained sync-changelog-unreleased.yml's use of
 # "[skip ci]" in its own commit, and that explanation -- once squashed into
 # 7a3c3535's commit message -- skipped the one required check on main, along
 # with the sync workflow's own first run.
 #
 # Inputs (environment variables, both required, may be empty strings):
-#   PR_TITLE - the pull request's title
-#   PR_BODY  - the pull request's body/description
+#   PR_TITLE   - the pull request's title
+#   PR_BODY    - the pull request's body/description
+#   PR_COMMITS - every commit message on the branch, concatenated (optional;
+#                defaults to empty so the script stays callable with just a
+#                title and body)
 #
 # Exits non-zero with a message on stderr (via ::error::) explaining the
 # mechanism and how to write the directive anyway (escaped) if a PR
@@ -27,6 +37,8 @@ set -uo pipefail
 
 : "${PR_TITLE?PR_TITLE is required (may be empty)}"
 : "${PR_BODY?PR_BODY is required (may be empty)}"
+# Optional and additive: callers that predate #2491 pass only a title and body.
+PR_COMMITS="${PR_COMMITS-}"
 
 # Every spelling GitHub honors, case-insensitively:
 # https://docs.github.com/actions/managing-workflow-runs/skipping-workflow-runs
@@ -39,10 +51,13 @@ fi
 if printf '%s' "$PR_BODY" | grep -qiE "$PATTERN"; then
   FOUND="${FOUND:+$FOUND and }body"
 fi
+if printf '%s' "$PR_COMMITS" | grep -qiE "$PATTERN"; then
+  FOUND="${FOUND:+$FOUND and }commit message"
+fi
 
 if [ -n "$FOUND" ]; then
-  echo "::error::This PR's $FOUND contains a CI-skip directive (one of [skip ci], [ci skip], [no ci], [skip actions], [actions skip], ***NO_CI***). This repo squash-merges, and GitHub folds the PR title + body into the squash commit message -- a directive anywhere in either one skips EVERY workflow on the resulting merge commit, including the one required check on main (this happened for real: #2116). If you genuinely need to WRITE ABOUT the directive (e.g. documenting this exact mechanism, as this script's own PR had to), break the literal match so it survives the squash without triggering it: insert a zero-width space (U+200B) inside the brackets -- '[skip' + U+200B + 'ci]' -- or describe it in prose without the literal bracketed form (e.g. \"a skip-ci directive\") instead." >&2
+  echo "::error::This PR's $FOUND contains a CI-skip directive (one of [skip ci], [ci skip], [no ci], [skip actions], [actions skip], ***NO_CI***). This repo squash-merges with squash_merge_commit_message=COMMIT_MESSAGES, so the branch's commit messages become the merge commit body and a commit subject or the PR title becomes its subject -- a directive in any of them skips EVERY workflow on the resulting merge commit, including the one required check on main (this happened for real: #2116). A directive in a COMMIT MESSAGE has to be fixed there (git commit --amend, or an interactive reword, then force-push); editing the PR body will not remove it. If you genuinely need to WRITE ABOUT the directive (e.g. documenting this exact mechanism, as this script's own PR had to), break the literal match so it survives the squash without triggering it: insert a zero-width space (U+200B) inside the brackets -- '[skip' + U+200B + 'ci]' -- or describe it in prose without the literal bracketed form (e.g. \"a skip-ci directive\") instead." >&2
   exit 1
 fi
 
-echo "No CI-skip directive found in the PR title or body."
+echo "No CI-skip directive found in the PR title, body or commit messages."

--- a/.github/scripts/check_closing_reference.sh
+++ b/.github/scripts/check_closing_reference.sh
@@ -2,9 +2,29 @@
 # Validates that a PR body's closing references are correct in BOTH directions.
 # See #2121 (missing direction) and #2128 (unintended direction).
 #
-# This repo squash-merges, and GitHub folds the PR title + body into the
-# squash commit message (see .claude/rules/branch-and-pr.md). GitHub's
-# closing-reference parser (Closes/Fixes/Resolves + one of "#N",
+# This repo squash-merges, and a closing reference reaches the merged result
+# by TWO independent routes (#2491). Both are live; covering one is not
+# covering the bug:
+#
+#   Route A -- the PULL REQUEST's own linkage. GitHub parses the PR title and
+#     body into `closingIssuesReferences` and closes those issues when the PR
+#     merges, whatever the squash message ends up being.
+#   Route B -- the MERGE COMMIT's message. Measured on this repository:
+#     `squash_merge_commit_message` is COMMIT_MESSAGES and
+#     `squash_merge_commit_title` is COMMIT_OR_PR_TITLE
+#     (`gh api repos/StefanMaron/BusinessCentral.AL.Runner`), so the squash
+#     body is the concatenated BRANCH COMMIT MESSAGES -- not the PR body.
+#     GitHub then closes whatever that commit message references when it
+#     lands on the default branch.
+#
+# So a closing keyword written in a commit message closes an issue even
+# though it never appears in the PR body. That is exactly what happened to
+# PR #2486: `closingIssuesReferences` listed only #2478 and #2480, a commit
+# message said "It does not close #2479", and merge commit 28cdcf65 closed
+# #2479 anyway. This script therefore scans the PR title, the PR body AND
+# every commit message on the branch.
+#
+# GitHub's closing-reference parser (Closes/Fixes/Resolves + one of "#N",
 # "owner/repo#N", or a full issue/PR URL, case-insensitive) matches ANYWHERE
 # in that message and does not understand surrounding prose -- negation,
 # qualification, "not", none of it changes what fires on merge. A bare
@@ -41,11 +61,19 @@
 # defeating the point of documenting why there's nothing to link.
 #
 # Inputs (environment variables, both required, may be empty strings):
-#   PR_TITLE - the pull request's title (checked only for the escape hatch
-#              being irrelevant here; closing references in the title are
-#              treated the same as stray body text, since GitHub honors them
-#              there too)
-#   PR_BODY  - the pull request's body/description
+#   PR_TITLE   - the pull request's title (checked only for the escape hatch
+#                being irrelevant here; closing references in the title are
+#                treated the same as stray body text, since GitHub honors
+#                them there too)
+#   PR_BODY    - the pull request's body/description
+#   PR_COMMITS - every commit message on the branch, concatenated (optional;
+#                defaults to empty so the script stays callable with just a
+#                title and body). Scanned for STRAY references only: a
+#                canonical "Closes #N" trailer must appear in the PR BODY,
+#                which is the convention .claude/rules/branch-and-pr.md asks
+#                for and the only place a reviewer reliably reads. A commit
+#                message that names an already-declared target is a harmless
+#                restatement and passes.
 #
 # Exits non-zero with a message on stderr (via ::error::) naming the problem
 # and how to fix it.
@@ -54,6 +82,8 @@ set -uo pipefail
 
 : "${PR_TITLE?PR_TITLE is required (may be empty)}"
 : "${PR_BODY?PR_BODY is required (may be empty)}"
+# Optional and additive: callers that predate #2491 pass only a title and body.
+PR_COMMITS="${PR_COMMITS-}"
 
 KEYWORDS='close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved'
 
@@ -120,11 +150,21 @@ done <<< "$PR_BODY"
 stray_number=""
 stray_source=""
 
+# skip_canonical=1 (the default, used for the PR body and title): a standalone
+# "Closes #N" line is a DECLARATION, not a stray, so it is exempt.
+#
+# skip_canonical=0 (used for commit messages): a commit message cannot declare
+# anything. A standalone "Fixes #456" line in a commit message closes #456 on
+# merge exactly as an inline one does, and the PR body -- where the convention
+# says the declaration belongs, and where a reviewer actually reads it -- never
+# mentioned it. Exempting those lines here is how this whole class stays
+# invisible, so commit messages get no exemption. A commit line naming an
+# ALREADY-DECLARED target still passes, via the is_declared check below.
 check_stray_in_text() {
-  local text="$1" source="$2" line
+  local text="$1" source="$2" skip_canonical="${3:-1}" line
   while IFS= read -r line; do
     [ -z "$line" ] && continue
-    if printf '%s' "$line" | command grep -qiP "$CANONICAL_LINE_RE"; then
+    if [ "$skip_canonical" = "1" ] && printf '%s' "$line" | command grep -qiP "$CANONICAL_LINE_RE"; then
       continue
     fi
     if printf '%s' "$line" | command grep -qiP "$STRAY_MATCH_RE"; then
@@ -143,9 +183,19 @@ check_stray_in_text() {
   return 1
 }
 
-check_stray_in_text "$PR_BODY" "body" || check_stray_in_text "$PR_TITLE" "title"
+check_stray_in_text "$PR_BODY" "body" \
+  || check_stray_in_text "$PR_TITLE" "title" \
+  || check_stray_in_text "$PR_COMMITS" "commit message" 0
 
 if [ -n "$stray_number" ]; then
+  # The remedy differs by source: a title or body is edited in place, a commit
+  # message has to be reworded and force-pushed. Saying "edit the body" to
+  # someone whose problem is in a commit message sends them looking in the
+  # wrong file.
+  if [ "$stray_source" = "commit message" ]; then
+    echo "::error::A COMMIT MESSAGE on this branch contains a closing keyword (one of Close/Closes/Closed/Fix/Fixes/Fixed/Resolve/Resolves/Resolved, case-insensitive) next to issue number $stray_number, which is not one of this PR's declared canonical targets. This repository's squash setting is squash_merge_commit_message=COMMIT_MESSAGES, so the branch's commit messages ARE the merge commit's body -- GitHub's closing-reference parser fires on that text and does not understand negation or surrounding qualification. This happened for real: PR #2486's commit message said 'It does not close #2479' and merge commit 28cdcf65 closed #2479 anyway. Fix it in the commit message (git commit --amend, or an interactive reword, then force-push): refer to the issue WITHOUT a closing keyword, e.g. 'see #$stray_number'. If it IS meant to close, add a standalone 'Closes #$stray_number' line to the PR BODY so the intent is declared where a reviewer reads it." >&2
+    exit 1
+  fi
   echo "::error::This PR's $stray_source contains a closing keyword (one of Close/Closes/Closed/Fix/Fixes/Fixed/Resolve/Resolves/Resolved, case-insensitive) next to issue number $stray_number, written inline in a sentence rather than as its own standalone 'Closes #N' trailer line. This repo squash-merges the PR title + body into the merge commit message, and GitHub's closing-reference parser fires on that pattern ANYWHERE in the message -- it does not understand negation or surrounding qualification. Whatever the sentence says, this will close issue $stray_number on merge (this happened for real: PR #2127's body said a sentence did NOT close an issue, and merge commit fe789a13 closed it anyway). If issue $stray_number is not one of this PR's declared canonical targets, refer to it WITHOUT a closing keyword instead, e.g. 'see #$stray_number' or 'its investigation found ...', which still creates the cross-reference on merge without the closing behavior. If it IS meant to close, add its own standalone 'Closes #$stray_number' line." >&2
   exit 1
 fi

--- a/.github/scripts/test_check_ci_skip_directives.sh
+++ b/.github/scripts/test_check_ci_skip_directives.sh
@@ -62,6 +62,42 @@ assert_exit "prose mention without literal brackets does not trip the check" 0 \
   "fix: document the skip mechanism" \
   "This describes a skip-ci directive without using the literal bracketed form."
 
+# --- #2491: the commit-message route -----------------------------------------
+#
+# This repository's squash setting is squash_merge_commit_message=COMMIT_MESSAGES,
+# so the branch's commit messages become the merge commit's body. A skip
+# directive there skips every workflow on main, and the title/body-only check
+# could not see it.
+
+assert_exit_commits() {
+  local desc="$1" expected_rc="$2" title="$3" body="$4" commits="$5"
+  local rc
+  PR_TITLE="$title" PR_BODY="$body" PR_COMMITS="$commits" "$SCRIPT" >/dev/null 2>&1
+  rc=$?
+  if [ "$rc" = "$expected_rc" ]; then
+    echo "ok   - $desc"
+    pass=$((pass + 1))
+  else
+    echo "FAIL - $desc: expected exit $expected_rc, got $rc"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_exit_commits "a skip directive in a commit message fails" 1 \
+  "fix: something" "Closes #123" "fix: something
+
+[skip ci]"
+assert_exit_commits "an alternate spelling in a commit message fails" 1 \
+  "fix: something" "Closes #123" "chore: release plumbing ***NO_CI***"
+assert_exit_commits "a clean multi-commit branch passes" 0 \
+  "fix: something" "Closes #123" "fix: first commit
+
+test: add coverage"
+assert_exit_commits "prose about a skip directive in a commit message, without the literal brackets, passes" 0 \
+  "fix: something" "Closes #123" "docs: explain why a skip-ci directive is dangerous here"
+
+assert_exit "PR_COMMITS unset still passes a clean PR" 0 "fix: something" "Closes #123"
+
 echo ""
 echo "$pass passed, $fail failed"
 if [ "$fail" -ne 0 ]; then

--- a/.github/scripts/test_check_closing_reference.sh
+++ b/.github/scripts/test_check_closing_reference.sh
@@ -198,6 +198,71 @@ assert_exit "ordinary PR with a clean Closes line and unrelated prose passes" 0 
 
 This adds a script and a test. See CONTRIBUTING.md for details."
 
+# --- #2491: the commit-message route -----------------------------------------
+#
+# The PR body is not the only text GitHub reads. This repository's squash
+# setting is squash_merge_commit_message=COMMIT_MESSAGES, so the branch's
+# commit messages ARE the merge commit's body. PR #2486 proved it: its
+# declared closing references (via closingIssuesReferences) were #2478 and
+# #2480, a COMMIT MESSAGE said "It does not close #2479", and merge commit
+# 28cdcf65 closed #2479. The body-only check passed that PR.
+
+assert_exit_commits() {
+  local desc="$1" expected_rc="$2" title="$3" body="$4" commits="$5"
+  local rc
+  PR_TITLE="$title" PR_BODY="$body" PR_COMMITS="$commits" "$SCRIPT" >/dev/null 2>&1
+  rc=$?
+  if [ "$rc" = "$expected_rc" ]; then
+    echo "ok   - $desc"
+    pass=$((pass + 1))
+  else
+    echo "FAIL - $desc: expected exit $expected_rc, got $rc"
+    fail=$((fail + 1))
+  fi
+}
+
+# The reproducer, in the shape it actually occurred.
+assert_exit_commits "the #2486 shape: a commit message saying it does NOT close an undeclared issue fails" 1 \
+  "fix: something" \
+  "Closes #2478
+Closes #2480" \
+  "fix: the environment-key half
+
+Scope note: this addresses the environment-key half of #2479. It does not close #2479
+ -- the issue's own repro still shows the baseline going missing."
+
+assert_exit_commits "a bare closing keyword in a commit message for an undeclared issue fails" 1 \
+  "fix: something" "Closes #123" "fix: something else
+
+Fixes #456"
+
+# Negative direction, and the one that keeps this from being a blanket ban on
+# the word: a commit message may restate a target the body already declared.
+assert_exit_commits "a commit message restating a DECLARED target passes" 0 \
+  "fix: something" "Closes #123" "fix: something
+
+Closes #123"
+
+assert_exit_commits "a commit message referring to an issue WITHOUT a closing keyword passes" 0 \
+  "fix: something" "Closes #123" "fix: something
+
+Investigated alongside #456; see that issue for the remaining half."
+
+assert_exit_commits "an ordinary multi-commit branch with clean messages passes" 0 \
+  "fix: something" "Closes #123" "fix: first commit
+
+test: add coverage for the first commit
+
+docs: note the behaviour change"
+
+# Additive: the script must behave identically when PR_COMMITS is unset, so a
+# caller that predates this change is not broken by it.
+assert_exit "PR_COMMITS unset still passes a clean body" 0 "fix: something" "Closes #123"
+assert_exit "PR_COMMITS unset still fails a stray body reference" 1 "fix: something" \
+  "Closes #123
+
+This does not close #456."
+
 echo ""
 echo "$pass passed, $fail failed"
 if [ "$fail" -ne 0 ]; then

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -147,6 +147,9 @@ jobs:
 
   reject-ci-skip-directives:
     name: PR title/body must not contain a CI-skip directive
+    permissions:
+      contents: read
+      pull-requests: read   # gh pr view --json commits (#2491)
     runs-on: ubuntu-latest
     # #2116: this repo squash-merges, and GitHub's default squash commit
     # message is "<title> (#N)" followed by the PR body (see
@@ -175,14 +178,46 @@ jobs:
       - name: Run check_ci_skip_directives.sh's own unit tests
         run: bash .github/scripts/test_check_ci_skip_directives.sh
 
-      - name: Check PR title and body for CI-skip directives
+      # #2491: the branch's commit messages are the merge commit's BODY here
+      # (squash_merge_commit_message=COMMIT_MESSAGES, measured with
+      # `gh api repos/StefanMaron/BusinessCentral.AL.Runner`), so they are part
+      # of the text GitHub parses on merge and have to be checked with the
+      # title and body. Asked of the API rather than reconstructed from git:
+      # this returns exactly the commit list GitHub will concatenate, with no
+      # dependence on fetch-depth or on where the base branch has moved to.
+      # A PR always has at least one commit, so empty output means the fetch
+      # failed and the job must say so rather than pass on no evidence.
+      - name: Collect the branch's commit messages
+        id: commits
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          msgs=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+                   --json commits --jq '.commits[] | .messageHeadline, .messageBody')
+          if [ -z "${msgs//[[:space:]]/}" ]; then
+            echo "::error::Could not read any commit message for PR #$PR_NUMBER. Every PR has at least one commit, so this is a failure to fetch, not an empty branch -- refusing to report a pass without having read the text that becomes the merge commit." >&2
+            exit 1
+          fi
+          {
+            echo "messages<<PR_COMMITS_EOF"
+            printf '%s\n' "$msgs"
+            echo "PR_COMMITS_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check PR title, body and commit messages for CI-skip directives
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_COMMITS: ${{ steps.commits.outputs.messages }}
         run: bash .github/scripts/check_ci_skip_directives.sh
 
   reject-bad-closing-references:
     name: PR body closing references must be correct, both directions
+    permissions:
+      contents: read
+      pull-requests: read   # gh pr view --json commits (#2491)
     runs-on: ubuntu-latest
     # #2121 (missing) and #2128 (unintended): this repo squash-merges, and
     # GitHub folds the PR title + body into the squash commit message (see
@@ -210,10 +245,39 @@ jobs:
       - name: Run check_closing_reference.sh's own unit tests
         run: bash .github/scripts/test_check_closing_reference.sh
 
-      - name: Check PR body for a correct closing reference
+      # #2491: the branch's commit messages are the merge commit's BODY here
+      # (squash_merge_commit_message=COMMIT_MESSAGES, measured with
+      # `gh api repos/StefanMaron/BusinessCentral.AL.Runner`), so they are part
+      # of the text GitHub parses on merge and have to be checked with the
+      # title and body. Asked of the API rather than reconstructed from git:
+      # this returns exactly the commit list GitHub will concatenate, with no
+      # dependence on fetch-depth or on where the base branch has moved to.
+      # A PR always has at least one commit, so empty output means the fetch
+      # failed and the job must say so rather than pass on no evidence.
+      - name: Collect the branch's commit messages
+        id: commits
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          msgs=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+                   --json commits --jq '.commits[] | .messageHeadline, .messageBody')
+          if [ -z "${msgs//[[:space:]]/}" ]; then
+            echo "::error::Could not read any commit message for PR #$PR_NUMBER. Every PR has at least one commit, so this is a failure to fetch, not an empty branch -- refusing to report a pass without having read the text that becomes the merge commit." >&2
+            exit 1
+          fi
+          {
+            echo "messages<<PR_COMMITS_EOF"
+            printf '%s\n' "$msgs"
+            echo "PR_COMMITS_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check PR body and commit messages for correct closing references
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
+          PR_COMMITS: ${{ steps.commits.outputs.messages }}
         run: bash .github/scripts/check_closing_reference.sh
 
   verify-trigger-list:


### PR DESCRIPTION
Closes #2491

Opened by agent impl-8.

`pr-check.yml`'s `reject-bad-closing-references` and `reject-ci-skip-directives` read `PR_TITLE` and `PR_BODY` only. That is not the text GitHub acts on here.

## The measurement that reframes the issue

I checked the repository's merge settings rather than assuming them:

```bash
gh api repos/StefanMaron/BusinessCentral.AL.Runner \
  --jq '{squash_merge_commit_title, squash_merge_commit_message}'
# {"squash_merge_commit_title":"COMMIT_OR_PR_TITLE","squash_merge_commit_message":"COMMIT_MESSAGES"}
```

So the merge commit's **body is the concatenated branch commit messages** — not the PR body. Text reaches the merged result by two independent routes, and both fire:

| route | source text | what acts on it |
|---|---|---|
| the merge commit | the branch's **commit messages** | GitHub parsing the commit that lands on `main` |
| the pull request | the PR **title and body** | `closingIssuesReferences`, closed when the PR merges |

The guards covered the second only. The first was never read by anything.

That is why PR #2486 got through: its declared references were #2478 and #2480 (confirmed by `closingIssuesReferences`), a commit message carried a scope note saying it was **not** closing #2479, GitHub's parser does not read negation, and merge commit `28cdcf65` shut that issue anyway. It had to be reopened by hand.

## What changed

- **Both scripts take an optional `PR_COMMITS`** and scan it. Optional and defaulted to empty, so every existing caller and test keeps working unchanged.
- **Commit messages get no canonical-trailer exemption.** In the PR body a standalone `Closes #N` line *is* the declaration, so it is exempt from the stray check. A commit message cannot declare anything — the body is where the convention puts it and where a reviewer reads it — so a standalone trailer in a commit message is checked like any other reference, and passes only when the body already declared that target. Without this the check misses the most likely spelling of all: a plain closing trailer on its own line at the end of a commit message.
- **`pr-check.yml` fetches the commit list from the API** (`gh pr view --json commits`) rather than reconstructing it from git. That returns exactly the list GitHub will concatenate, with no dependence on `fetch-depth` or on where the base branch has moved to. It **fails loudly** when it reads nothing: every PR has at least one commit, so empty output is a failed fetch, and a guard that passed there would be reporting a verdict on evidence it never had.
- **Explicit minimal `permissions`** (`contents: read`, `pull-requests: read`) on the two jobs that now call the API. The repository's default workflow permission is already `read`, so this narrows rather than grants.
- **`.claude/rules/branch-and-pr.md` corrected.** It said "the PR title + body become the commit message". They do not, and that sentence is the reason the guards were built to scan them alone. It now carries the measurement, both routes, and the #2486 instance.

## RED → GREEN

Reverting only the two check scripts and keeping the new tests:

- `test_check_closing_reference.sh` — RED **38 passed, 2 failed**; GREEN **40 passed, 0 failed**.
- `test_check_ci_skip_directives.sh` — RED **17 passed, 2 failed**; GREEN **19 passed, 0 failed**.

Every pre-existing case stayed green in both directions, which is the evidence that the change is additive rather than a re-specification.

New cases cover the acceptance criteria in the issue, in both directions:

- the #2486 shape verbatim — a commit message saying it does not close an undeclared issue → fails;
- a bare closing trailer in a commit message (the keyword `Fixes` followed by an undeclared issue number) → fails;
- a skip directive in a commit message, and an alternate spelling → fail;
- a commit message restating an **already-declared** target → passes;
- a commit message naming an issue without a closing keyword → passes;
- an ordinary multi-commit branch → passes;
- `PR_COMMITS` unset behaves exactly as before, in both the passing and failing direction.

## This PR is its own test case

The `pull_request` event runs the workflow from the merge ref, so this PR is checked by the code it adds. That mattered: my **first** commit message described what happened to issue 2479 by putting a closing keyword directly in front of its number, and the new guard rejected it —

```
::error::A COMMIT MESSAGE on this branch contains a closing keyword ... next to issue
number 2479, which is not one of this PR's declared canonical targets.
```

It was right. That message would have shut #2479 a second time on merge. I reworded it. The failure message is deliberately different for the commit-message source, because the remedy is different — you cannot fix it by editing the PR body, the commit has to be reworded and force-pushed.

## Scope

The issue asked for both jobs in one change, since they scan the same text; both are done. I did not touch `generate_changelog.py`'s trailing-`(#N)` handling — that is the third bug listed in `branch-and-pr.md`, it has no automated guard, and it is a separate mechanism from the text these two jobs read.

The `require-tests` gate does not apply: this diff touches nothing under `AlRunner/`.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
