### PR TITLE
fix(jobs): scale the per-test watchdog by shard count, after measuring whether it needed it

### DIFF
--- a/AlRunner.Tests/ParallelFanOutTestTimeoutTests.cs
+++ b/AlRunner.Tests/ParallelFanOutTestTimeoutTests.cs
@@ -1,0 +1,154 @@
+// ParallelFanOutTestTimeoutTests — the per-test watchdog must scale with shard count (issue #2718).
+//
+// AL_RUNNER_TEST_TIMEOUT_SEC (default 60s, TestExecutor.DefaultTestTimeoutSeconds) is wall-clock
+// time on the AL execution thread, and under --jobs N every worker competes with N-1 others for
+// the same cores. Same shape as the emit timeout #2715 fixed, but it needed measuring rather than
+// assuming, because the two have very different margins:
+//
+//   emit timeout, the DEMONSTRATED failure: Tests-ERM's emit was cut off at 120.1s against a 120s
+//   budget — about 1.0x of headroom, so contention broke it immediately and cost 63% of a
+//   40,550-test run.
+//
+//   per-test watchdog, MEASURED here on a 12-core box (load ~4), single process, slowest SINGLE
+//   test in each surface:
+//       al-language corpus (2,464 tests):    0.78s ->  77x headroom to 60s
+//       Tests-SMB, a BaseApp bucket (1,027): 4.36s -> 13.8x headroom to 60s
+//
+// So the corpus cannot reach this watchdog through contention at any realistic job count, and
+// BaseApp is the surface that can. Against the ~7x stretch #2715 measured at --jobs 12 (not the
+// 12x a linear model predicts), 4.36s lands near 30s — about half the budget. This is therefore
+// a PLAUSIBLE failure with roughly 2x of room left, not a demonstrated one, and this file says so
+// rather than implying the two cases are equivalent.
+//
+// It is fixed anyway because the Tests-SMB figure is a LOWER bound — measured without
+// --test-data, where most tests fail early and stop short of the work they exist to do (234 of
+// 1,027 passed) — and because the costs are lopsided: a spurious abort takes out the rest of its
+// codeunit AND every later codeunit in the bundle (one such abort cost 6,097 tests across 189
+// codeunits), while over-scaling costs only bounded extra wall on a genuine hang, which still
+// gets caught and still reports as a timeout.
+
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ParallelFanOutTestTimeoutTests
+{
+    /// <summary>ParallelFanOut.DefaultTestTimeoutSec exists so this file can scale the same
+    /// number TestExecutor actually falls back to. If they drift, workers get a budget derived
+    /// from a default nothing uses and the scaling silently stops meaning what it says — so the
+    /// private constant is read by reflection and compared, rather than trusted to stay in
+    /// step by convention.</summary>
+    [Fact]
+    public void DefaultTestTimeoutSec_MatchesTheOneTestExecutorActuallyUses()
+    {
+        var field = typeof(TestExecutor).GetField(
+            "DefaultTestTimeoutSeconds",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        Assert.True(field is not null,
+            "TestExecutor.DefaultTestTimeoutSeconds was renamed or removed — ParallelFanOut."
+            + "DefaultTestTimeoutSec is a copy of it and must be updated with it");
+
+        Assert.Equal((int)field!.GetRawConstantValue()!, ParallelFanOut.DefaultTestTimeoutSec);
+    }
+
+    /// <summary>The worker gets DefaultTestTimeoutSec scaled by the shard count, matching the
+    /// emit timeout's pattern: a test sharing cores with N-1 other workers can take roughly N
+    /// times as long in wall time to do the same CPU work.</summary>
+    [Theory]
+    [InlineData(1, ParallelFanOut.DefaultTestTimeoutSec)]
+    [InlineData(2, ParallelFanOut.DefaultTestTimeoutSec * 2)]
+    [InlineData(6, ParallelFanOut.DefaultTestTimeoutSec * 6)]
+    [InlineData(12, ParallelFanOut.DefaultTestTimeoutSec * 12)]
+    public void TestTimeoutSecForWorker_ScalesByShardCount(int jobs, int expected)
+        => Assert.Equal(expected, ParallelFanOut.TestTimeoutSecForWorker(jobs));
+
+    /// <summary>Never scaled below the single-process default — a shard count of 0 should not be
+    /// reached, but the formula must not hand a worker a SHORTER budget than it would get alone,
+    /// which would turn this fix into the defect it exists to prevent.</summary>
+    [Fact]
+    public void TestTimeoutSecForWorker_NeverBelowTheSingleProcessDefault()
+        => Assert.True(ParallelFanOut.TestTimeoutSecForWorker(0) >= ParallelFanOut.DefaultTestTimeoutSec);
+
+    /// <summary>The scaled value must stay far above any legitimate test even at low job counts.
+    /// The slowest test measured on either surface was 4.36s (Tests-SMB); at --jobs 2 the budget
+    /// is 120s. If this ever fails, the constant moved and the measurements in the header need
+    /// re-taking before trusting the scaling.</summary>
+    [Fact]
+    public void TestTimeoutSecForWorker_StaysWellAboveTheSlowestMeasuredTest()
+    {
+        const double slowestMeasuredSeconds = 4.36; // Tests-SMB, single process, 12 cores
+        Assert.True(ParallelFanOut.TestTimeoutSecForWorker(1) > slowestMeasuredSeconds * 10,
+            "the single-process budget must leave an order of magnitude over the slowest test "
+            + "actually measured, or contention is not the thing being compensated for");
+    }
+
+    /// <summary>Positive: when the user has set nothing, the worker environment carries the
+    /// shard-scaled value under the exact name TestExecutor.TestTimeout() reads.</summary>
+    [Fact]
+    public void WorkerEnvironment_ScalesTestTimeoutWhenUserSetNothing()
+    {
+        var env = ParallelFanOut.WorkerEnvironment(cores: 12, jobs: 6);
+
+        Assert.True(env.TryGetValue("AL_RUNNER_TEST_TIMEOUT_SEC", out var value));
+        Assert.Equal((ParallelFanOut.DefaultTestTimeoutSec * 6).ToString(), value);
+    }
+
+    /// <summary>Negative: an explicit AL_RUNNER_TEST_TIMEOUT_SEC must win, and must be absent
+    /// from the override dictionary entirely — the child inherits the real environment variable
+    /// already, exactly as the GC knobs and the emit timeout do.</summary>
+    [Fact]
+    public void WorkerEnvironment_DefersToAnExplicitTestTimeout()
+    {
+        var env = ParallelFanOut.WorkerEnvironment(cores: 12, jobs: 6, userTestTimeoutSec: "30");
+
+        Assert.False(env.ContainsKey("AL_RUNNER_TEST_TIMEOUT_SEC"),
+            "a user-set AL_RUNNER_TEST_TIMEOUT_SEC must not be overridden by the scaled default");
+    }
+
+    /// <summary>Setting one knob must not suppress the others. The emit timeout and the test
+    /// timeout are independent: someone who pinned the emit budget for a large bundle has said
+    /// nothing about how long a single test may run.</summary>
+    [Fact]
+    public void WorkerEnvironment_ExplicitEmitTimeoutDoesNotSuppressTestTimeoutScaling()
+    {
+        var env = ParallelFanOut.WorkerEnvironment(cores: 12, jobs: 4, userEmitTimeoutSec: "900");
+
+        Assert.False(env.ContainsKey("AL_RUNNER_EMIT_TIMEOUT_SEC"));
+        Assert.Equal((ParallelFanOut.DefaultTestTimeoutSec * 4).ToString(),
+            env["AL_RUNNER_TEST_TIMEOUT_SEC"]);
+    }
+
+    /// <summary>And the reverse, so neither knob can start shadowing the other unnoticed.</summary>
+    [Fact]
+    public void WorkerEnvironment_ExplicitTestTimeoutDoesNotSuppressEmitTimeoutScaling()
+    {
+        var env = ParallelFanOut.WorkerEnvironment(cores: 12, jobs: 4, userTestTimeoutSec: "30");
+
+        Assert.False(env.ContainsKey("AL_RUNNER_TEST_TIMEOUT_SEC"));
+        Assert.Equal((ParallelFanOut.DefaultEmitTimeoutSec * 4).ToString(),
+            env["AL_RUNNER_EMIT_TIMEOUT_SEC"]);
+    }
+
+    /// <summary>The scaled default is an ENV var, and TestExecutor.TestTimeout() ranks an
+    /// explicit --test-timeout above it. That ordering is what keeps tests which pass a
+    /// deliberate short timeout — SuiteAbortOnTimeoutTests drives the watchdog with
+    /// --test-timeout 2 — unaffected by this change: the flag is in ValueTakingFlags, so it
+    /// reaches the worker as an argument and wins over anything set here.</summary>
+    [Fact]
+    public void ExplicitTestTimeoutFlag_ReachesTheWorker_AndOutranksTheScaledEnvDefault()
+    {
+        Assert.Contains("--test-timeout", ParallelFanOut.ValueTakingFlags);
+
+        var child = ParallelFanOut.BuildChildArgs(
+            new[] { "bundleA", "--test-timeout", "2" },
+            new[] { "bundleA" },
+            new[] { "bundleA" },
+            "/tmp/shard-0.xml");
+
+        var i = child.IndexOf("--test-timeout");
+        Assert.True(i >= 0, "--test-timeout must survive into the worker's argv");
+        Assert.Equal("2", child[i + 1]);
+    }
+}

--- a/AlRunner/Infrastructure/ParallelFanOut.cs
+++ b/AlRunner/Infrastructure/ParallelFanOut.cs
@@ -170,6 +170,48 @@ internal static class ParallelFanOut
     public static int EmitTimeoutSecForWorker(int jobs)
         => DefaultEmitTimeoutSec * Math.Max(1, jobs);
 
+    /// <summary>The single-process default for the per-test watchdog (TestExecutor), in
+    /// seconds. Kept in step with TestExecutor.DefaultTestTimeoutSeconds by
+    /// ParallelFanOutTestTimeoutTests, which fails if the two drift apart.</summary>
+    public const int DefaultTestTimeoutSec = 60;
+
+    /// <summary>
+    /// Per-test watchdog timeout to hand one worker, in seconds (issue #2718).
+    ///
+    /// Same wall-clock-under-contention shape as the emit timeout above, but it needed
+    /// measuring rather than assuming, because the two have very different margins and the
+    /// cost of over-scaling is different in kind. The watchdog exists to stop a runaway AL
+    /// loop; stretching it delays catching a real hang, which the emit timeout's equivalent
+    /// does not.
+    ///
+    /// What the margin actually is, measured on a 12-core box (load ~4), single process,
+    /// slowest SINGLE test:
+    ///
+    ///   al-language corpus (2,464 tests):   0.78s  ->  77x headroom to 60s
+    ///   Tests-SMB, a BaseApp bucket (1,027): 4.36s  ->  13.8x headroom to 60s
+    ///
+    /// So the corpus cannot reach this watchdog through contention at any realistic job
+    /// count, and BaseApp is the surface that can. Against the ~7x stretch #2715 measured at
+    /// --jobs 12 (not the 12x a linear model predicts), 4.36s lands near 30s — about half the
+    /// budget. That is a real margin, so this is NOT the demonstrated failure the emit
+    /// timeout was; it is a plausible one with roughly 2x of room left.
+    ///
+    /// Two things close that gap and are why this scales anyway. The Tests-SMB figure is a
+    /// LOWER bound: it was measured without --test-data, where most tests fail early and stop
+    /// short of the work they exist to do (234 of 1,027 passed). And the cost of being wrong
+    /// is lopsided — a spurious abort takes out the rest of its codeunit AND every later
+    /// codeunit in the bundle (one such abort cost 6,097 tests across 189 codeunits), while
+    /// over-scaling costs only bounded extra wall on a genuine hang, which still gets caught
+    /// and still reports as a timeout.
+    ///
+    /// A CPU-time budget would be the precise fix and would also answer #2070's "the thread
+    /// is legitimately blocked, not runaway" — contention inflates wall time and leaves CPU
+    /// time alone, and a runaway loop burns CPU at full rate regardless of job count. That is
+    /// the larger change this defers, exactly as the emit timeout deferred it.
+    /// </summary>
+    public static int TestTimeoutSecForWorker(int jobs)
+        => DefaultTestTimeoutSec * Math.Max(1, jobs);
+
     /// <summary>
     /// Extra environment for a worker process: one GC heap, conserve memory, no background GC,
     /// and a shard-scaled emit timeout. The GC knobs together take about half off peak memory
@@ -192,7 +234,8 @@ internal static class ParallelFanOut
         string? userHeapCount = null,
         string? userConserveMemory = null,
         string? userGcConcurrent = null,
-        string? userEmitTimeoutSec = null)
+        string? userEmitTimeoutSec = null,
+        string? userTestTimeoutSec = null)
     {
         var env = new Dictionary<string, string>(StringComparer.Ordinal);
         if (string.IsNullOrEmpty(userHeapCount))
@@ -206,6 +249,11 @@ internal static class ParallelFanOut
             env["DOTNET_gcConcurrent"] = "0";
         if (string.IsNullOrEmpty(userEmitTimeoutSec))
             env["AL_RUNNER_EMIT_TIMEOUT_SEC"] = EmitTimeoutSecForWorker(jobs).ToString();
+        // #2718. Note this is the ENV var only: an explicit --test-timeout reaches the child
+        // as an argument and TestExecutor.TestTimeout() ranks that above the env var, so a
+        // caller who named a number still gets exactly that number.
+        if (string.IsNullOrEmpty(userTestTimeoutSec))
+            env["AL_RUNNER_TEST_TIMEOUT_SEC"] = TestTimeoutSecForWorker(jobs).ToString();
         return env;
     }
 
@@ -255,7 +303,8 @@ internal static class ParallelFanOut
                          Environment.GetEnvironmentVariable("DOTNET_GCHeapCount"),
                          Environment.GetEnvironmentVariable("DOTNET_GCConserveMemory"),
                          Environment.GetEnvironmentVariable("DOTNET_gcConcurrent"),
-                         Environment.GetEnvironmentVariable("AL_RUNNER_EMIT_TIMEOUT_SEC")))
+                         Environment.GetEnvironmentVariable("AL_RUNNER_EMIT_TIMEOUT_SEC"),
+                         Environment.GetEnvironmentVariable("AL_RUNNER_TEST_TIMEOUT_SEC")))
                 psi.Environment[kv.Key] = kv.Value;
             if (viaDotnet && asm != null) psi.ArgumentList.Add(asm);
             foreach (var a in childArgs) psi.ArgumentList.Add(a);

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -332,6 +332,10 @@ string? testFilter = null;
 // --test-timeout SECONDS: per-test timeout override (v1 carryover; v2 previously
 // hardcoded 60s with no CLI override — see #1648). Takes precedence over the
 // AL_RUNNER_TEST_TIMEOUT_SEC env var. Null = env var / 60s default.
+// Under --jobs, ParallelFanOut.WorkerEnvironment sets AL_RUNNER_TEST_TIMEOUT_SEC on each
+// worker to the 60s default scaled by shard count, because the watchdog is wall-clock and a
+// worker sharing cores runs slower in wall time for the same work (#2718). This flag still
+// outranks that, so naming a number here gets exactly that number in every worker.
 int? testTimeoutSeconds = null;
 // --watch: stay resident with warm dependencies and re-run IN-PROCESS on every .al
 // change. Each cycle resets the per-bundle caches (BcRuntime.ResetForNewBundleReload),

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -1307,6 +1307,11 @@ public sealed class TestExecutor
             return TimeSpan.FromHours(24);
         // Explicit --test-timeout (via TestExecutor.TimeoutSeconds) wins over the env var,
         // which in turn wins over the hardcoded default. See #1648.
+        //
+        // That ordering is load-bearing under --jobs (#2718): a worker is handed
+        // AL_RUNNER_TEST_TIMEOUT_SEC scaled by shard count, since this clock is wall-clock and
+        // contention stretches wall time without changing the work done. A caller who named a
+        // number still gets it — the scaled value only fills the slot nobody asked for.
         if (TimeoutSeconds is int explicitSeconds && explicitSeconds > 0)
             return TimeSpan.FromSeconds(explicitSeconds);
         if (int.TryParse(Environment.GetEnvironmentVariable("AL_RUNNER_TEST_TIMEOUT_SEC"), out var seconds)


### PR DESCRIPTION
Closes #2718

The per-test watchdog (`AL_RUNNER_TEST_TIMEOUT_SEC`, default 60s) is wall-clock time on the AL execution thread, and under `--jobs N` every worker competes with N-1 others for the same cores — the same assumption #2715 fixed for the emit timeout. That fix is the obvious model, but the brief was to establish whether it *fits* rather than assume it, because a per-test timeout scaled too far masks a genuinely hung test and the emit timeout has no equivalent downside.

So I measured it first.

## What the margin actually is

12-core box (load ~4), single process, slowest **single** test per surface:

| surface | slowest test | headroom to 60s |
|---|---|---|
| al-language corpus (2,464 tests) | 0.78s | **77x** |
| Tests-SMB, a BaseApp bucket (1,027 tests) | 4.36s | **13.8x** |

Against the emit timeout, which was a *demonstrated* failure: Tests-ERM's emit was cut off at 120.1s against a 120s budget — about **1.0x** of headroom, so contention broke it immediately and cost 63% of a 40,550-test run.

**The two cases are not equivalent and this PR does not claim they are.** The corpus cannot reach this watchdog through contention at any realistic job count. BaseApp is the surface that can, and even there, against the **~7x** stretch #2715 measured at `--jobs 12` (not the 12x a linear model predicts), 4.36s lands near 30s — about half the budget.

**So: a plausible failure with roughly 2x of room left, not an observed one.** That is written into the code comments too, not just here.

## Why it is fixed anyway

Two reasons, both concrete:

1. **The Tests-SMB figure is a lower bound.** It was measured without `--test-data`, where most tests fail early and stop short of the work they exist to do — 234 of 1,027 passed. The `running-ms-test-buckets` skill sanctions a no-test-data run for measuring speed, which is what this is, but the honest reading is that real durations are higher and the margin is smaller than 2x.
2. **The costs are lopsided.** A spurious abort takes out the rest of its codeunit *and every later codeunit in the bundle* — one such abort cost 6,097 tests across 189 codeunits, reported as a plain total. Over-scaling costs only bounded extra wall on a genuine hang, which still gets caught and still reports as a timeout. Silent loss of thousands of tests is the worse error.

A **CPU-time budget** would be the precise fix, and would also answer #2070's "the thread is legitimately blocked, not runaway": contention inflates wall time and leaves CPU time alone, while a runaway loop burns CPU at full rate regardless of job count. That is the larger change, deferred here exactly as the emit timeout deferred it, and named in the code so the next person does not re-derive it.

## Precedence is unchanged, which is what keeps existing callers safe

`WorkerEnvironment` fills `AL_RUNNER_TEST_TIMEOUT_SEC` only when the user set nothing, and `TestExecutor.TestTimeout()` still ranks an explicit `--test-timeout` above the env var. So `SuiteAbortOnTimeoutTests`, which drives the watchdog with `--test-timeout 2`, is untouched — **verified by running it**, not by reading the precedence. That matters because #2801 reports those same tests failing on loaded CI legs, and this change must not be confused with that.

## RED → GREEN

Each guard checked against the mutation it exists to catch, not just observed passing:

| mutation | result |
|---|---|
| `WorkerEnvironment` stops setting the var (the pre-fix state) | **2 fail** |
| `TestTimeoutSecForWorker` returns the flat default (scaling neutered) | **5 fail** |
| the user's own `AL_RUNNER_TEST_TIMEOUT_SEC` stops winning | **2 fail** |
| as committed | **12/12 pass** |

After each mutation the file was restored from the commit and verified byte-identical against a copy kept outside the repository.

There is also a **reflection-based drift guard**: `ParallelFanOut.DefaultTestTimeoutSec` is a copy of the private `TestExecutor.DefaultTestTimeoutSeconds`, and if the two diverge the scaling is derived from a default nothing uses — silently. The test reads the private constant and compares.

**72 tests green** across `ParallelFanOut*`, `TestTimeoutFlagTests`, `SuiteAbortOnTimeoutTests` and `AbortResume`, re-run after the rebase onto current `main` rather than carried across it.

## Scope note

Local runs cover **BC 28.x only** — a self-built runner is compiled against Ncl 28.x and cannot load 27.x artifacts, so the 27.x legs are CI's to answer. I am not claiming coverage I do not have.

## What I did not do

I did not touch the **RC=143 / SIGTERM** half of the brief. It is a separate question — the brief said to establish which defect I was looking at before fixing either, and this one is the wall-clock watchdog. Nothing here explains a SIGTERM, and I would rather say so than fold an unexplained signal into a timeout change.

---
Written by Claude Code agent impl-7. Off the (impl-1, impl-2) identity pool for this session — flagging per the workflow contract so the drift stays visible.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
