### PR TITLE
perf(cache-gate): stop resolving dep ids into a dead variable, and gate both whole-tree probes

### DIFF
--- a/AlRunner.Tests/CacheGateProbeScopeTests.cs
+++ b/AlRunner.Tests/CacheGateProbeScopeTests.cs
@@ -1,0 +1,238 @@
+// CacheGateProbeScopeTests — issue #2557.
+//
+// Two whole-tree scans used to run on every bundle whether or not their answer could be used,
+// and one of them was dead outright:
+//
+//   * `orderedDepIds` was assigned before the app loop and read NOWHERE. The loop went on
+//     calling GetOrderedDepIds again inside the cache gate, so a run paid for both. Each call
+//     builds its own DependencyResolver and EnsureIndexed is an instance field, so the second
+//     resolver re-walked every package-cache directory and re-read every .app manifest out of
+//     its zip, carrying nothing over from the first.
+//
+//   * `BcCompiler.BundleDeclaresQuery` ran ahead of the gate that is its only reason to exist.
+//     A bundle that declares a query answers on its first file; one that does not — the common
+//     case — reads the whole tree to prove the negative. `--no-cache` skips the gate and paid
+//     for it anyway.
+//
+// The instrument is the phase log, which the runner already emits. Both probes now run inside
+// the `alCacheDir != null` gate and record a stage when they do, so "did this run pay for the
+// scan" is directly observable rather than inferred from wall clock. That matters for how this
+// is tested: wall clock on a loaded machine cannot tell a skipped scan from a fast one, and
+// this box runs several agents at once.
+//
+// The needles are the stage NAMES, and each fails independently:
+//
+//   with --cache     both `ordered-dep-ids` and `query-decl-probe` appear
+//   with --no-cache  NEITHER appears
+//
+// Before the change, `ordered-dep-ids` appeared in both runs (it was emitted unconditionally,
+// as a bundle stage) and `query-decl-probe` did not exist at all. So the --no-cache assertion
+// is what carries the claim, and it is asserted per stage rather than as one combined check so
+// a half-fix cannot pass.
+//
+// The phase log also enforces a rule this change had to respect: a stage must not overlap an
+// app group, or #1828's stage sum double-counts app time and eats the report's "unattributed"
+// line. Both stages are AppStages, because PhaseLog.BeginApp is already open where they run.
+// The last test asserts that directly — they must appear on an app row, never the bundle row.
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class CacheGateProbeScopeTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private const string DepIdsStage = "ordered-dep-ids";
+    private const string QueryProbeStage = "query-decl-probe";
+
+    private readonly string _root;
+    private readonly string _bundle;
+
+    public CacheGateProbeScopeTests()
+    {
+        _root = TestScratch.Dir("al-runner-cache-gate-probes");
+        _bundle = Path.Combine(_root, "bundle");
+        Directory.CreateDirectory(_bundle);
+        // A nonce keeps the AL source unique per run so a --cache run always MISSes. A HIT
+        // would still enter the gate and still record both stages, so the assertions hold
+        // either way — but a MISS is the path that actually computes a cache key, which is
+        // what consumes orderedDepIds.
+        WriteFixture(_bundle, Guid.NewGuid().ToString("N"));
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private static void WriteFixture(string dir, string nonce)
+    {
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "5c1e93a7-84d2-4b60-9f37-2a6e0d18b45c",
+          "name": "Cache Gate Probe Fixture",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "idRanges": [ { "from": 62310, "to": 62319 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Tests.Codeunit.al"), $$"""
+        codeunit 62311 "CGP Tests"
+        {
+            Subtype = Test;
+
+            var
+                Nonce: Label '{{nonce}}';
+
+            [Test]
+            procedure Arithmetic()
+            begin
+                if 3 + 4 <> 7 then
+                    Error('sum');
+                if StrLen(Nonce) <> {{nonce.Length}} then
+                    Error('nonce');
+            end;
+        }
+        """);
+    }
+
+    /// <summary>Every stage name recorded anywhere in the phase log, with the row kind it sat on.</summary>
+    private static List<(string Kind, string Stage)> StagesFrom(string logPath)
+    {
+        var found = new List<(string, string)>();
+        if (!File.Exists(logPath)) return found;
+        foreach (var line in File.ReadAllLines(logPath))
+        {
+            if (string.IsNullOrWhiteSpace(line)) continue;
+            using var doc = JsonDocument.Parse(line);
+            if (!doc.RootElement.TryGetProperty("stages", out var stages)) continue;
+            var kind = doc.RootElement.TryGetProperty("kind", out var k) ? k.GetString() ?? "?" : "?";
+            foreach (var st in stages.EnumerateObject())
+                found.Add((kind, st.Name));
+        }
+        return found;
+    }
+
+    private (string Output, int Exit, string LogPath) Run(bool noCache, string tag)
+    {
+        var logPath = Path.Combine(_root, $"phases-{tag}.jsonl");
+        var cacheDir = Path.Combine(_root, $"cache-{tag}");
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        var platformApps = Path.Combine(TestArtifacts.HomeDir() ?? "", ".al-runner", "platform-apps");
+        if (Directory.Exists(platformApps)) args.Append($" --package-cache \"{platformApps}\"");
+        args.Append($" \"{_bundle}\"");
+        args.Append(noCache ? " --no-cache" : $" --cache \"{cacheDir}\"");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = args.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        psi.Environment["AL_RUNNER_PHASE_LOG"] = logPath;
+
+        var sb = new StringBuilder();
+        using var proc = Process.Start(psi)!;
+        proc.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        proc.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+        if (!proc.WaitForExit(300_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException("al-runner did not exit within 300s.");
+        }
+        // WaitForExit(int) does not drain the async output callbacks; the parameterless
+        // overload does. See #2496.
+        proc.WaitForExit();
+        return (sb.ToString(), proc.ExitCode, logPath);
+    }
+
+    [Fact]
+    public void WithCache_BothGateProbesRun()
+    {
+        var (output, exit, logPath) = Run(noCache: false, tag: "cached");
+        Assert.True(exit == 0, $"the fixture must pass. exit={exit}\n{output}");
+
+        var stages = StagesFrom(logPath);
+        Assert.True(stages.Count > 0, $"the phase log recorded no stages at all — the instrument is broken, so the "
+            + $"--no-cache assertions below would pass vacuously.\nlog: {logPath}\n{output}");
+
+        Assert.True(stages.Any(s => s.Stage == DepIdsStage),
+            $"a --cache run enters the gate and must resolve ordered dep ids, recording '{DepIdsStage}'. "
+            + $"saw: {string.Join(", ", stages.Select(s => $"{s.Kind}/{s.Stage}"))}");
+        Assert.True(stages.Any(s => s.Stage == QueryProbeStage),
+            $"a --cache run enters the gate and must probe for a query declaration, recording "
+            + $"'{QueryProbeStage}'. saw: {string.Join(", ", stages.Select(s => $"{s.Kind}/{s.Stage}"))}");
+    }
+
+    [Fact]
+    public void WithNoCache_NeitherGateProbeRuns()
+    {
+        var (output, exit, logPath) = Run(noCache: true, tag: "nocache");
+        Assert.True(exit == 0, $"the fixture must pass. exit={exit}\n{output}");
+
+        var stages = StagesFrom(logPath);
+        // Guard against a vacuous pass: if the log had no stages at all, both absence
+        // assertions below would hold for the wrong reason.
+        Assert.True(stages.Count > 0, $"the phase log recorded no stages at all — a vacuous pass.\nlog: {logPath}\n{output}");
+
+        // Asserted separately so a half-fix cannot pass. Before #2557 the first of these
+        // failed: ordered-dep-ids was emitted unconditionally, ahead of the gate.
+        Assert.False(stages.Any(s => s.Stage == DepIdsStage),
+            $"--no-cache never reaches the cache-key computation, so resolving ordered dep ids is "
+            + $"pure waste and '{DepIdsStage}' must not appear. saw: "
+            + string.Join(", ", stages.Select(s => $"{s.Kind}/{s.Stage}")));
+        Assert.False(stages.Any(s => s.Stage == QueryProbeStage),
+            $"--no-cache never consults the query sidecar, so reading the whole tree to answer "
+            + $"'does this bundle declare a query' is pure waste and '{QueryProbeStage}' must not "
+            + $"appear. saw: " + string.Join(", ", stages.Select(s => $"{s.Kind}/{s.Stage}")));
+    }
+
+    [Fact]
+    public void GateProbeStages_AreRecordedOnAnAppRow_NotTheBundleRow()
+    {
+        // PhaseLog's own rule: a stage must not overlap an app group, or #1828's stage sum
+        // double-counts app time and manufactures overhead in the report. Both probes run after
+        // BeginApp, so both must be AppStages. This is the assertion that would catch someone
+        // "simplifying" either back to PhaseLog.Stage.
+        var (output, exit, logPath) = Run(noCache: false, tag: "approw");
+        Assert.True(exit == 0, $"the fixture must pass. exit={exit}\n{output}");
+
+        var stages = StagesFrom(logPath);
+        foreach (var name in new[] { DepIdsStage, QueryProbeStage })
+        {
+            var rows = stages.Where(s => s.Stage == name).ToList();
+            Assert.True(rows.Count > 0, $"'{name}' must be recorded somewhere. saw: "
+                + string.Join(", ", stages.Select(s => $"{s.Kind}/{s.Stage}")));
+            Assert.DoesNotContain(rows, r => r.Kind == "bundle");
+        }
+    }
+
+    [Fact]
+    public void OrderedDepIds_IsResolvedAtMostOncePerRun()
+    {
+        // The hoist existed to stop the resolve happening once per app group; it never did,
+        // because the hoisted value was read nowhere. The Lazy is what finally delivers it, and
+        // recording the stage inside the Lazy's factory is what makes "at most once" visible.
+        var (output, exit, logPath) = Run(noCache: false, tag: "once");
+        Assert.True(exit == 0, $"the fixture must pass. exit={exit}\n{output}");
+
+        var count = StagesFrom(logPath).Count(s => s.Stage == DepIdsStage);
+        Assert.True(count == 1,
+            $"ordered dep ids must be resolved at most once per run, so '{DepIdsStage}' must be "
+            + $"recorded exactly once; saw {count}.\n{output}");
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2525,12 +2525,30 @@ foreach (var bundle in bundles)
         // SetTestAssembly.
         var suiteDirByAssembly = new Dictionary<Assembly, string>();
 
-        // Ordered dep ids feed every app's cache key but depend only on the bucket root
-        // and the package caches — both loop-invariant. Resolving them inside the loop
-        // re-scanned the package caches once per app.
-        IReadOnlyList<string> orderedDepIds;
-        using (AlRunner.Infrastructure.PhaseLog.Stage("ordered-dep-ids"))
-            orderedDepIds = GetOrderedDepIds(bucketRoot, packageCacheDirs, bundleAbs);
+        // Ordered dep ids feed every app's cache key but depend only on the bucket root and
+        // the package caches — both loop-invariant, so resolving them inside the loop
+        // re-scanned the package caches once per app. That was the intent of hoisting them;
+        // the hoist was never wired up (#2557) — the value was assigned here and read
+        // nowhere, while the loop went on calling GetOrderedDepIds again, so the run paid for
+        // BOTH. GetOrderedDepIds builds its own DependencyResolver and EnsureIndexed is an
+        // instance field, so the second resolver re-walked every package-cache directory and
+        // re-read every .app manifest out of its zip, carrying nothing over.
+        //
+        // Lazy, not eager: the only consumer is inside the `needCompile && alCacheDir != null`
+        // cache gate, so a --no-cache run (or one where nothing needs compiling) must not pay
+        // for it at all. Evaluated at most once per bundle, which is what the hoist was for.
+        //
+        // The stage is an AppStage and lives INSIDE the factory deliberately. PhaseLog.BeginApp
+        // is called above, so the first evaluation happens inside an app group, and a bundle
+        // Stage there would overlap it — which #1828's stage sum reports as manufactured
+        // overhead, eating the "unattributed" line. Inside the factory it is also recorded
+        // exactly once, on the app that actually opens the gate, instead of a zero-length row
+        // on every later app.
+        var orderedDepIds = new Lazy<IReadOnlyList<string>>(() =>
+        {
+            using (AlRunner.Infrastructure.PhaseLog.AppStage("ordered-dep-ids"))
+                return GetOrderedDepIds(bucketRoot, packageCacheDirs, bundleAbs);
+        });
 
         int agIdx = 0;
         foreach (var appGroup in appGroups)
@@ -2615,14 +2633,31 @@ foreach (var bundle in bundles)
         string? cachePath = null;
         string? sidecarPath = null;
         string? querySidecarPath = null;
-        // A bundle declaring an AL query also needs its query-symbols sidecar: the
-        // MetaQuery design is built from the compilation's SymbolReference, which only
-        // emit produces. Serving a HIT without it leaves NCLMetaQuery null and every
-        // query Find NREs inside BC's NavQuery.ValidateTablesNotVirtual.
-        bool bundleDeclaresQuery = BcCompiler.BundleDeclaresQuery(allPaths);
+        // A bundle declaring an AL query also needs its query-symbols sidecar: the MetaQuery
+        // design is built from the compilation's SymbolReference, which only emit produces.
+        // Serving a HIT without it leaves NCLMetaQuery null and every query Find NREs inside
+        // BC's NavQuery.ValidateTablesNotVirtual.
+        //
+        // Declared here but PROBED only inside the gate below (#2557). The probe reads AL text
+        // to answer: a bundle that declares a query answers on its first file, but one that
+        // does not — the common case — reads the whole tree to prove the negative. Probing
+        // unconditionally meant --no-cache runs and needCompile == false app groups paid for a
+        // whole-tree scan and then discarded the answer.
+        //
+        // It cannot simply MOVE into the gate: the second consumer is in the separate
+        // `needCompile && cachedBytes != null` block further down, outside the gate's braces.
+        // Defaulting to false is safe there because cachedBytes is only ever assigned non-null
+        // inside the gate, so reaching that consumer implies the gate ran and assigned this.
+        bool bundleDeclaresQuery = false;
         if (needCompile && alCacheDir != null)
         {
-            cacheKey = ComputeAlCacheKey(allPaths, moduleName, ordered: GetOrderedDepIds(bucketRoot, packageCacheDirs, bundleAbs), appRootDir: appGroup.SuiteDir);
+            // Instrumented because it was invisible: a whole-tree read that only showed up as
+            // the report's "unattributed" remainder. An AppStage, not a Stage — BeginApp is
+            // already open here, and a bundle stage overlapping an app group is what #1828's
+            // stage sum reports as manufactured overhead.
+            using (AlRunner.Infrastructure.PhaseLog.AppStage("query-decl-probe"))
+                bundleDeclaresQuery = BcCompiler.BundleDeclaresQuery(allPaths);
+            cacheKey = ComputeAlCacheKey(allPaths, moduleName, ordered: orderedDepIds.Value, appRootDir: appGroup.SuiteDir);
             cachePath = Path.Combine(alCacheDir, cacheKey + ".dll");
             sidecarPath = Path.Combine(alCacheDir, cacheKey + AlRunner.Infrastructure.AlCacheSidecars.EnumRegistrySuffix);
             querySidecarPath = Path.Combine(alCacheDir, cacheKey + AlRunner.Infrastructure.AlCacheSidecars.QuerySymbolsSuffix);
@@ -4410,10 +4445,17 @@ return strictExitCode ? computedExitCode : 0;
             // the request, exactly like an AL-output cache hit.
             bool cached = reusedAsm != null;
             string? cacheKey = null, cachePath = null, sidecarPath = null, querySidecarPath = null;
-            // See AlCacheSidecars: a query bundle without its query-symbols sidecar must MISS.
-            bool bundleDeclaresQuery = BcCompiler.BundleDeclaresQuery(allPaths);
             if (reusedAsm == null && alCacheDir != null)
             {
+                // See AlCacheSidecars: a query bundle without its query-symbols sidecar must
+                // MISS. Computed INSIDE the gate (#2557), same reasoning as the CLI path: both
+                // consumers are in here, and the probe reads every .al file in the tree to
+                // answer "no". Outside the gate, a cross-bundle module reuse (reusedAsm != null)
+                // — the case --server exists to make fast — paid for a whole-tree scan whose
+                // answer it then threw away.
+                bool bundleDeclaresQuery;
+                using (AlRunner.Infrastructure.PhaseLog.AppStage("query-decl-probe"))
+                    bundleDeclaresQuery = BcCompiler.BundleDeclaresQuery(allPaths);
                 cacheKey = ComputeAlCacheKey(allPaths, moduleName,
                     ordered: GetOrderedDepIds(bucketRoot, effectivePkgDirs), appRootDir: bucketRoot);
                 cachePath = Path.Combine(alCacheDir, cacheKey + ".dll");


### PR DESCRIPTION
Closes #2557

## What was wrong

Two whole-tree scans ran on every bundle whether or not their answer could be used, and one was dead outright.

**`orderedDepIds` was assigned and read nowhere.** The app loop went on calling `GetOrderedDepIds` again inside the cache gate, so a run paid for both. Each call builds its own `DependencyResolver`, and `EnsureIndexed` is an instance field, so the second resolver re-walked every package-cache directory and re-read every `.app` manifest out of its zip, carrying nothing over. The hoist's comment describes the intent — resolve once, not once per app — and the hoist was simply never wired up.

**`BcCompiler.BundleDeclaresQuery` ran ahead of the gate that is its only reason to exist.** A bundle declaring a query answers on its first file; one that does not — the common case — reads the whole tree to prove the negative. `--no-cache` and cross-bundle module reuse skip the gate and paid for the scan anyway.

## What changed

- `orderedDepIds` is now a `Lazy<>` that the in-gate call site consumes, so it resolves **at most once per bundle** and not at all when nothing opens the gate.
- `BundleDeclaresQuery` is probed inside the gate, in both the CLI and `--server` paths.
- Both probes now record a phase-log stage. They were invisible before — whole-tree work that showed up only in the report's "unattributed" remainder — and the stage is also what makes this testable without wall clock.

### A correction to the issue's reading

The issue says both `bundleDeclaresQuery` consumers are inside the gate. **For the CLI path that is wrong.** The second consumer is in the separate `needCompile && cachedBytes != null` block below the gate's closing brace, so the variable cannot simply move — it is declared `false` and assigned inside the gate. That is safe because `cachedBytes` is only ever assigned non-null inside the gate (checked: line 2659 is its only non-null assignment), so reaching the second consumer implies the gate ran.

The compiler caught this. My own first pass was a brace-depth reading that said "depth 6, inside the gate", and it was wrong — the block just happens to be nested at the same depth further down. Worth recording as the shape of a near-miss: depth is not scope.

### The phase-log trap

Both stages are `AppStage`, not `Stage`. `PhaseLog.BeginApp` is already open where they run, and a bundle stage overlapping an app group is what #1828's stage sum reports as manufactured overhead, eating the report's "unattributed" line. The `ordered-dep-ids` stage sits **inside the `Lazy`'s factory** so it is recorded exactly once, on the app that opens the gate, rather than as a zero-length row on every later app. `GateProbeStages_AreRecordedOnAnAppRow_NotTheBundleRow` pins this, and it is the test that would catch someone simplifying either back to `Stage`.

## Verification

RED measured against this PR's own merge base (`c8ca948c`) by copying the new test file onto a worktree of it — **3 of 4 fail there, independently**:

| test | on `main` | with fix |
|---|---|---|
| `WithCache_BothGateProbesRun` | FAIL | PASS |
| `WithNoCache_NeitherGateProbeRuns` | FAIL | PASS |
| `GateProbeStages_AreRecordedOnAnAppRow_NotTheBundleRow` | FAIL | PASS |
| `OrderedDepIds_IsResolvedAtMostOncePerRun` | **PASS** | PASS |

The fourth passes on `main` too and I am not calling it a needle — before the change the stage was emitted once as a *bundle* stage, so the count was also 1. It is a regression guard against the resolve going back to once-per-app, which is the thing the original hoist was for.

The `--no-cache` RED output is the diagnosis stated as data: on `main` the phase log for a `--no-cache` run contains `bundle/ordered-dep-ids`, a full dependency resolve on a run that can never use it.

Gates, all on this branch:

- `AlRunner.Tests --filter` over `CacheGateProbeScopeTests|PhaseLog|AlCacheSidecars|CacheKeyDependencyClosure|WatchLayeredDependencyStale`: **39 passed, 0 failed.**
- `tests/runner-extras` `--strict --count-baseline`: **246/246, 0 suite errors, exit 0.**
- `tests/al-language` at the current pin: **2464/2464, exit 0.**

## On the performance claim: I am not making one

#2371 measured an adjacent "stop re-reading manifests" change and found it saved nothing, because `BcCompiler`'s own package scan reads the same manifests moments later. That warning applies here, so what follows is a count of work removed, **not** a claim about end-to-end time. I did not measure instructions-retired, and nothing here should be read as a wall-clock win.

Measured from the phase log on a `tests/runner-extras` run (47 app groups):

```
ordered-dep-ids:    1 occurrence,  32 ms   (app row)
query-decl-probe:  47 occurrences, 24 ms   (app rows)
```

The `1` is the point. Structurally, before this change the same run performed **48** full dependency resolutions — one dead hoist plus one per app group inside the gate — where it now performs **1**. That is a property of the code (the in-gate call sat inside `foreach (var appGroup in appGroups)`), not a timing, which is why I am willing to state it. Whether removing 47 resolves shows up in the total is exactly what #2371 says not to assume, and I have not measured it.

## Fix the shape

1. **Same pattern elsewhere?** These were the only two probes computed ahead of the cache gate. `GetOrderedDepIds` has one other call site, in the `--server` path, and it was already inside its gate.
2. **Sibling assumption?** The `--server` path had the identical `BundleDeclaresQuery`-ahead-of-gate shape and is fixed in the same way. Its second consumer *is* genuinely inside its gate — checked, not assumed, after the CLI one proved otherwise.
3. **Two writers, same invariant?** The CLI and `--server` paths both compute a cache key from the same two probes; they now gate them identically, where before they differed only by which gate condition they ignored.

## Credit

Found independently by Mikkel Mansa Vilhelmsen (@vhn) in his fork (`89e751e2`), per the issue. His tree had diverged and the dead `orderedDepIds` assignment is specific to `origin/main`; no code was copied.

Written by an agent (impl-2).

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
