### PR TITLE
fix(server): run a request's bundles in dependency order, not sourcePaths order

### DIFF
--- a/AlRunner.Tests/BundleDependencyOrderTests.cs
+++ b/AlRunner.Tests/BundleDependencyOrderTests.cs
@@ -1,0 +1,206 @@
+// BundleDependencyOrderTests — the graph half of #2614.
+//
+// A --server request's pre-passes publish every dependency's NEW symbols before the per-bundle
+// loop, but a bundle's runtime ASSEMBLY is only reloaded during its own iteration of that loop.
+// List the dependency last and the consuming bundle dispatches freshly baked member ids into the
+// assembly still resident from the previous request:
+//
+//     NavNCLCompilationException: Function ID -53549305 was called.
+//     The object with ID 60550 does not have a member with that ID.
+//
+// Loud rather than wrong (#2603 removed the silent half), but red in an order a cold run of the
+// same sources handles fine. Running dependencies first is the fix.
+//
+// ServerCrossAppOverloadRebindTests proves the end-to-end effect against a real server process,
+// which is the measurement that matters — but it costs ~20s per case and cannot construct a
+// dependency cycle at all. These pin the three properties that decide whether the sort is safe to
+// apply to EVERY request rather than only the broken one: it moves what must move, it moves
+// nothing else, and it never loses or duplicates a bundle.
+
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class BundleDependencyOrderTests
+{
+    private static BundleIdentity App(string name, params string[] dependsOnNames)
+        => new(
+            AppId: Guid.NewGuid(),
+            Name: name,
+            Publisher: "AL Runner Fixtures",
+            Version: new Version(1, 0, 0, 0),
+            RuntimeVersion: new Version(13, 0),
+            Dependencies: dependsOnNames
+                .Select(n => new DependencyRef(Guid.Empty, n, "AL Runner Fixtures", new Version(1, 0, 0, 0), false))
+                .ToList());
+
+    private static IReadOnlyList<string> Sort(
+        IReadOnlyList<string> paths, Dictionary<string, BundleIdentity?> identities)
+        => BundleDependencyOrder.Sort(paths, p => identities.TryGetValue(p, out var id) ? id : null);
+
+    // ── it moves what must move ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ADependencyListedAfterItsConsumer_IsMovedBeforeIt()
+    {
+        // The exact #2614 shape: sourcePaths = [test-app, app], app being test-app's dependency.
+        var ids = new Dictionary<string, BundleIdentity?>
+        {
+            ["test-app"] = App("XApp Ovl Test App", "XApp Ovl App"),
+            ["app"] = App("XApp Ovl App"),
+        };
+
+        Assert.Equal(new[] { "app", "test-app" }, Sort(new[] { "test-app", "app" }, ids));
+    }
+
+    [Fact]
+    public void AThreeLevelChain_IsFullyOrdered_FromTheMostReversedInput()
+    {
+        // c depends on b depends on a, listed exactly backwards.
+        var ids = new Dictionary<string, BundleIdentity?>
+        {
+            ["c"] = App("C", "B"),
+            ["b"] = App("B", "A"),
+            ["a"] = App("A"),
+        };
+
+        Assert.Equal(new[] { "a", "b", "c" }, Sort(new[] { "c", "b", "a" }, ids));
+    }
+
+    [Fact]
+    public void MatchingFallsBackToNamePlusPublisher_WhenTheDependencyDeclaresNoAppId()
+    {
+        // DependencyRef carries Guid.Empty above on purpose: an app.json dependency entry that
+        // names its target without an id must still be recognised, which is the same fallback
+        // RunLayeredPrePass uses. Negative direction: a name that matches nothing does not order.
+        var ids = new Dictionary<string, BundleIdentity?>
+        {
+            ["consumer"] = App("Consumer", "Nothing By This Name"),
+            ["other"] = App("Other"),
+        };
+
+        Assert.Equal(new[] { "consumer", "other" }, Sort(new[] { "consumer", "other" }, ids));
+    }
+
+    // ── it moves nothing else ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TheDocumentedDependencyFirstOrder_IsReturnedByReference()
+    {
+        // Reference equality is the contract Program.cs reads to decide whether to reorder the
+        // RESULTS as well: a request already in the documented order must pay nothing and must not
+        // have its streamed test-line order perturbed. This caught a real defect — the first
+        // version early-returned on "no edges at all", and the documented order HAS an edge (the
+        // consumer's indegree is 1), so it built a new list and made every well-formed request pay
+        // a result remap. The check is now on whether the sequence actually moved.
+        var ids = new Dictionary<string, BundleIdentity?>
+        {
+            ["app"] = App("App"),
+            ["test-app"] = App("Test App", "App"),
+        };
+        var input = new[] { "app", "test-app" };
+
+        Assert.Same(input, Sort(input, ids));
+    }
+
+    [Fact]
+    public void AWaitingBundle_IsEmittedWhenItsDependencyLands_NotSoonerToPreserveOrder()
+    {
+        // The precise disturbance guarantee, written down because the loose version ("unrelated
+        // bundles keep their order") is FALSE and I asserted it before measuring. 'y' waits on 'z';
+        // 'm' is unrelated to everything and becomes ready first, so it is emitted before both.
+        // y and m have no relation and still swap.
+        //
+        // That is inherent: y cannot precede z, and deferring a ready node to preserve a relative
+        // order that the dependency has already broken buys nothing. What IS guaranteed is that the
+        // result is a deterministic function of the input, and that 'a' — ready from the start and
+        // listed first — stays first.
+        var ids = new Dictionary<string, BundleIdentity?>
+        {
+            ["a"] = App("A"),
+            ["y"] = App("Y", "Z"),
+            ["m"] = App("M"),
+            ["z"] = App("Z"),
+        };
+
+        var sorted = Sort(new[] { "a", "y", "m", "z" }, ids);
+
+        Assert.Equal(new[] { "a", "m", "z", "y" }, sorted);
+        Assert.True(sorted.ToList().IndexOf("z") < sorted.ToList().IndexOf("y"),
+            "the dependency must precede its consumer, which is the only ordering that was required");
+    }
+
+    [Fact]
+    public void APathWithNoIdentity_HoldsItsPlaceAndOrdersNothing()
+    {
+        // A bundle with no readable app.json cannot depend on anything and cannot be depended
+        // upon. It must not be treated as related to the other identity-less bundle either.
+        var ids = new Dictionary<string, BundleIdentity?>
+        {
+            ["loose-1"] = null,
+            ["loose-2"] = null,
+            ["app"] = App("App"),
+        };
+        var input = new[] { "loose-1", "loose-2", "app" };
+
+        Assert.Same(input, Sort(input, ids));
+    }
+
+    [Fact]
+    public void FewerThanTwoIdentities_IsLeftAlone()
+    {
+        var ids = new Dictionary<string, BundleIdentity?> { ["only"] = App("Only"), ["loose"] = null };
+        var input = new[] { "only", "loose" };
+
+        Assert.Same(input, Sort(input, ids));
+    }
+
+    // ── it never loses or duplicates a bundle ──────────────────────────────────────────────────
+
+    [Fact]
+    public void ADependencyCycle_KeepsEveryBundle_InTheCallersOrder()
+    {
+        // Two bundles declaring each other. This sort does not get to adjudicate a cycle, and it
+        // must not throw or drop one: Program.cs's ChangedLaterDependencyBundles guard still
+        // applies to whatever ordering comes out, which is why that guard was kept rather than
+        // deleted as #2614 suggested it could be.
+        var ids = new Dictionary<string, BundleIdentity?>
+        {
+            ["p"] = App("P", "Q"),
+            ["q"] = App("Q", "P"),
+        };
+
+        Assert.Equal(new[] { "p", "q" }, Sort(new[] { "p", "q" }, ids));
+    }
+
+    [Fact]
+    public void ACycleAlongsideAnOrderablePair_StillOrdersTheOrderablePartAndKeepsTheRest()
+    {
+        // The drainable part is ordered; the cyclic remainder is appended in the caller's order.
+        // Asserted as a set-plus-constraint rather than one exact sequence, because what matters
+        // is that nothing is lost and the orderable relation is honoured.
+        var ids = new Dictionary<string, BundleIdentity?>
+        {
+            ["consumer"] = App("Consumer", "Dep"),
+            ["p"] = App("P", "Q"),
+            ["q"] = App("Q", "P"),
+            ["dep"] = App("Dep"),
+        };
+
+        var sorted = Sort(new[] { "consumer", "p", "q", "dep" }, ids).ToList();
+
+        Assert.Equal(4, sorted.Count);
+        Assert.Equal(new[] { "consumer", "dep", "p", "q" }.OrderBy(x => x), sorted.OrderBy(x => x));
+        Assert.True(sorted.IndexOf("dep") < sorted.IndexOf("consumer"),
+            "the orderable dependency must still precede its consumer despite an unrelated cycle in "
+            + "the same request; got: " + string.Join(", ", sorted));
+    }
+
+    [Fact]
+    public void ASingleBundle_IsReturnedByReference()
+    {
+        var input = new[] { "only" };
+        Assert.Same(input, Sort(input, new Dictionary<string, BundleIdentity?>()));
+    }
+}

--- a/AlRunner.Tests/ServerCrossAppOverloadRebindTests.cs
+++ b/AlRunner.Tests/ServerCrossAppOverloadRebindTests.cs
@@ -165,15 +165,21 @@ public class ServerCrossAppOverloadRebindTests
     /// answers exactly as a from-scratch run of the same sources does.</para>
     ///
     /// <para><c>dependencyFirst: false</c> — an order nothing documents but the runner accepts.
-    /// Before this change it returned <c>BOUND-TO=1</c>: a green-looking, silently wrong answer,
-    /// because the consuming bundle is processed before the fallback signal the forward
-    /// propagation reads even exists. <c>ChangedLaterDependencyBundles</c> now forces that bundle
-    /// to compile in full, and what remains is a LOUD failure —
-    /// <c>NavNCLCompilationException: Function ID … was called. The object with ID … does not have
-    /// a member with that ID</c> — because in this order the dependency's runtime assembly is not
-    /// reloaded until after the consuming bundle's tests have already run. That residual is #2614; the bar asserted here is the one
-    /// <c>.claude/rules/loud-failures.md</c> sets: pass, or fail in a way somebody can see.
-    /// <b>Never <c>BOUND-TO=1</c>.</b></para>
+    /// It has been wrong twice, in two different ways, and now must simply pass.</para>
+    ///
+    /// <para>Originally it returned <c>BOUND-TO=1</c>: a green-looking, silently wrong answer,
+    /// because the consuming bundle is processed before the fallback signal the forward propagation
+    /// reads even exists. #2603 made <c>ChangedLaterDependencyBundles</c> force that bundle to
+    /// compile in full, which left a LOUD failure instead — <c>NavNCLCompilationException: Function
+    /// ID … was called. The object with ID … does not have a member with that ID</c> — because the
+    /// dependency's runtime ASSEMBLY was still not reloaded until after the consuming bundle's
+    /// tests had run. #2614 closed that by executing dependencies first
+    /// (<see cref="AlRunner.Infrastructure.BundleDependencyOrder"/>), so both orders now answer
+    /// exactly as a cold run of the same sources does.</para>
+    ///
+    /// <para><b>Never <c>BOUND-TO=1</c></b> remains asserted for both orders separately from the
+    /// pass/fail bar: it is the specific silently-wrong answer, and a future regression that made
+    /// the request red again must not be able to satisfy this test by failing differently.</para>
     /// </summary>
     [SkippableTheory]
     [InlineData(true)]
@@ -225,15 +231,8 @@ public class ServerCrossAppOverloadRebindTests
             + "Which(Decimal) resolved to. That member still exists in the re-emitted dependency, so "
             + "the call succeeded with no exception and no diagnostic. Got: " + joined2);
 
-        if (!dependencyFirst)
-        {
-            // The undocumented order: loud is the bar. Passing is fine too — assert only that the
-            // answer is not silently wrong, which the check above has already established.
-            return;
-        }
-
         Assert.True(status2 == "pass",
-            "the documented dependency-first order must answer exactly as a cold run of these "
-            + $"sources does (BOUND-TO=2). Got: {joined2}");
+            $"a warm request must answer exactly as a cold run of these sources does (BOUND-TO=2), "
+            + $"in EITHER order (dependencyFirst: {dependencyFirst}). Got: {joined2}");
     }
 }

--- a/AlRunner/Infrastructure/BundleDependencyOrder.cs
+++ b/AlRunner/Infrastructure/BundleDependencyOrder.cs
@@ -1,0 +1,142 @@
+// BundleDependencyOrder — orders the bundles of one request so a dependency runs BEFORE the
+// bundles that consume it, whatever order the caller listed them in (#2614).
+//
+// THE BUG. A --server request's pre-passes (RunLayeredPrePass / BuildSiblingSourceDeps) run before
+// the per-bundle loop and publish every dependency's NEW symbols, so a consuming bundle compiles
+// against the post-edit surface and bakes member ids from it. A bundle's runtime ASSEMBLY, though,
+// is only reloaded during its own iteration of that loop. List the dependency last — an order
+// nothing documents but the runner accepts — and the consumer dispatches its freshly baked ids
+// into the assembly still resident from the PREVIOUS request, which does not carry them:
+//
+//     NavNCLCompilationException: Function ID -53549305 was called.
+//     The object with ID 60550 does not have a member with that ID.
+//
+// #2603 had already removed the silent half of this (the consumer answering with its previous
+// binding). What was left was loud but still red, in an order a cold run of the very same sources
+// handles fine — so the symbols a bundle compiled against and the assembly it dispatched into came
+// from two different points in one request. Running dependencies first restores that invariant.
+//
+// WHY A SEPARATE FILE. The graph half is pure — given "which bundles are there" and "what does each
+// declare", the answer needs no filesystem — while the identity read that feeds it does not. Split
+// that way it is directly testable for the three properties that actually matter (dependencies
+// ordered, nothing else disturbed, cycle safety), which the end-to-end server test cannot cheaply cover: it costs ~20s
+// per case and cannot construct a dependency cycle at all. Same reason BundleRootDeduplication
+// (#2136) sits beside this rather than inside Program.cs.
+//
+// DETERMINISM AND MINIMAL DISTURBANCE, stated precisely because the loose version is wrong. Kahn's
+// algorithm here always takes the lowest remaining ORIGINAL index, so the output is a deterministic
+// function of the input, and a request whose order already satisfies every dependency comes back as
+// the input array itself (by reference — the caller reads that to skip its paired result remap).
+//
+// What it does NOT promise is that two bundles with no dependency between them keep their relative
+// order in every case. A bundle waiting on a dependency is emitted when that dependency lands, and
+// unrelated bundles listed after it can become ready first: [a, y, m, z] with y depending on z
+// comes back [a, m, z, y], not [a, z, y, m]. y and m are unrelated and still swapped. That is
+// inherent to any topological sort — y cannot precede z — and the alternative (deferring ready
+// nodes to preserve a doomed relative order) buys nothing. The streamed `test` line order is
+// user-visible (docs/server-mode.md), so this is documented there rather than glossed here.
+//
+// CYCLES ARE NOT ADJUDICATED HERE. A cycle (or any remainder Kahn cannot drain) is appended in the
+// caller's original order rather than throwing. Program.cs's ChangedLaterDependencyBundles guard
+// still applies to whatever ordering comes out, which is why #2614's suggestion that this sort
+// could REPLACE that guard was not taken: for every acyclic request the guard is now a no-op, and
+// for the ones this cannot fully order it is the backstop.
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Infrastructure;
+
+internal static class BundleDependencyOrder
+{
+    /// <summary>
+    /// True when <paramref name="consumer"/> declares a dependency on <paramref name="dependency"/>:
+    /// by declared AppId, falling back to Name+Publisher.
+    ///
+    /// <para>The same pair <c>RunLayeredPrePass</c> matches on, and for the same reason — a bundle
+    /// that declares no id of its own still has to be recognisable as somebody's dependency. An
+    /// empty AppId never matches by id, so two identity-less bundles do not become each other's
+    /// dependency by both being blank.</para>
+    /// </summary>
+    internal static bool DependsOn(BundleIdentity consumer, BundleIdentity dependency)
+    {
+        foreach (var dep in consumer.Dependencies)
+        {
+            if (dep.AppId != Guid.Empty && dep.AppId == dependency.AppId) return true;
+            if (string.Equals(dep.Name, dependency.Name, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(dep.Publisher, dependency.Publisher, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// <paramref name="paths"/> reordered so every in-request dependency precedes its consumers.
+    /// </summary>
+    /// <param name="identityOf">
+    /// The declared identity of one path, or null when it has none (no readable app.json). A path
+    /// with no identity is never related to anything: it cannot depend on a bundle and cannot be
+    /// depended upon, so it simply holds its place.
+    /// </param>
+    /// <returns>
+    /// A new list in execution order, or <paramref name="paths"/> itself when nothing needs to
+    /// move — callers use reference equality to skip the result-reordering that pairs with this.
+    /// </returns>
+    internal static IReadOnlyList<string> Sort(
+        IReadOnlyList<string> paths, Func<string, BundleIdentity?> identityOf)
+    {
+        if (paths.Count < 2) return paths;
+
+        var identities = new BundleIdentity?[paths.Count];
+        var known = 0;
+        for (var i = 0; i < paths.Count; i++)
+            if ((identities[i] = identityOf(paths[i])) != null) known++;
+        if (known < 2) return paths;
+
+        var n = paths.Count;
+        // dependents[i] = indices that must come AFTER i. indegree[j] = how many in-request
+        // dependencies j is still waiting on.
+        var dependents = new List<int>[n];
+        var indegree = new int[n];
+        for (var i = 0; i < n; i++) dependents[i] = new List<int>();
+
+        for (var consumer = 0; consumer < n; consumer++)
+        {
+            var mine = identities[consumer];
+            if (mine == null) continue;
+            for (var dependency = 0; dependency < n; dependency++)
+            {
+                if (dependency == consumer) continue;
+                var other = identities[dependency];
+                if (other == null || !DependsOn(mine, other)) continue;
+                dependents[dependency].Add(consumer);
+                indegree[consumer]++;
+            }
+        }
+
+        var ordered = new List<string>(n);
+        var emitted = new bool[n];
+        var emittedCount = 0;
+        while (emittedCount < n)
+        {
+            var next = -1;
+            for (var i = 0; i < n; i++)
+                if (!emitted[i] && indegree[i] == 0) { next = i; break; }   // lowest original index
+            if (next < 0) break;                                            // cycle: stop draining
+            emitted[next] = true;
+            emittedCount++;
+            ordered.Add(paths[next]);
+            foreach (var dependent in dependents[next]) indegree[dependent]--;
+        }
+        for (var i = 0; i < n; i++)
+            if (!emitted[i]) ordered.Add(paths[i]);      // cyclic remainder, in the caller's order
+
+        // Return the INPUT when the sort changed nothing. Checked on the resulting sequence rather
+        // than on "were there any edges at all": a request already in the documented
+        // dependency-first order has edges — the consumer's indegree is 1 — and an edge-count test
+        // would report it as reordered and make the caller pay a result remap for an order that
+        // never moved. The caller reads this by reference, so it has to mean "nothing moved".
+        for (var i = 0; i < n; i++)
+            if (!ReferenceEquals(ordered[i], paths[i]) && !string.Equals(ordered[i], paths[i], StringComparison.Ordinal))
+                return ordered;
+        return paths;
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3918,6 +3918,18 @@ return strictExitCode ? computedExitCode : 0;
             }
         }
 
+        // #2614: run dependencies before the bundles that consume them, whatever order the caller
+        // listed. Everything downstream — the pre-passes, the per-bundle peek, and the execution
+        // loop — uses this one order, so the symbols a bundle compiles against and the assembly it
+        // dispatches into come from the same point in the request. See
+        // SortBundlesInDependencyOrder for why the compile-time pre-pass alone did not close this.
+        //
+        // requestOrder keeps the caller's listing so the RESULTS come back in it (below), leaving
+        // the streamed `test` line order as the only visible change — documented in
+        // docs/server-mode.md.
+        var requestOrder = sourcePaths;
+        sourcePaths = SortBundlesInDependencyOrder(sourcePaths);
+
         var bundleList = sourcePaths.ToList();
         var workspaceScratch = new List<string>();
         if (sourcePaths.Length > 1)
@@ -4139,7 +4151,75 @@ return strictExitCode ? computedExitCode : 0;
             AlRunner.Infrastructure.PhaseLog.EndBundle(emitElapsed, compileElapsed, runElapsed);
             results.Add(result);
         }
+
+        // #2614: execution ran in dependency order; hand the results back in the order the caller
+        // listed the paths. A ServerRunResult carries no bundle path, so the mapping is positional
+        // — sourcePaths[k] produced results[k], and requestOrder says where that belongs. Only
+        // reached when the sort actually moved something, so the documented order pays nothing.
+        if (!ReferenceEquals(sourcePaths, requestOrder) && results.Count == sourcePaths.Length)
+        {
+            var byPath = new Dictionary<string, ServerRunResult>(StringComparer.OrdinalIgnoreCase);
+            for (var k = 0; k < sourcePaths.Length; k++) byPath[Path.GetFullPath(sourcePaths[k])] = results[k];
+            var reordered = new List<ServerRunResult>(results.Count);
+            foreach (var path in requestOrder)
+                if (byPath.TryGetValue(Path.GetFullPath(path), out var r)) reordered.Add(r);
+            // Only adopt a complete remapping: a duplicate or unresolvable path must not silently
+            // drop a bundle's results from the response.
+            if (reordered.Count == results.Count) return reordered;
+        }
         return results;
+    }
+
+    /// <summary>
+    /// Each bundle's declared identity, keyed by its full path, reading <c>app.json</c> from the
+    /// bundle root and falling back to its bucket root — the same read
+    /// <see cref="RunLayeredPrePass"/> does to decide which bundles are "impls". A bundle with no
+    /// readable <c>app.json</c> is simply absent from the result; every caller treats "no identity"
+    /// as "cannot be related to anything", never as an error.
+    ///
+    /// <para>Extracted so <see cref="ChangedLaterDependencyBundles"/> and
+    /// <see cref="SortBundlesInDependencyOrder"/> cannot drift on what counts as a bundle's
+    /// identity — they answer two halves of one question and a second copy of this loop is exactly
+    /// the shape #2478 turned into a silent divergence.</para>
+    /// </summary>
+    static Dictionary<string, AlRunner.Infrastructure.BundleIdentity> ReadBundleIdentities(
+        IEnumerable<string> sourcePaths)
+    {
+        var identities = new Dictionary<string, AlRunner.Infrastructure.BundleIdentity>(StringComparer.OrdinalIgnoreCase);
+        foreach (var bundle in sourcePaths)
+        {
+            var abs = Path.GetFullPath(bundle);
+            var appJson = Path.Combine(abs, "app.json");
+            if (!File.Exists(appJson))
+            {
+                var root = FindBucketRoot(abs);
+                if (root != null) appJson = Path.Combine(root, "app.json");
+            }
+            if (!File.Exists(appJson)) continue;
+            var id = AlRunner.Infrastructure.InProcessAppPackager.ReadIdentity(appJson);
+            if (id != null) identities[abs] = id;
+        }
+        return identities;
+    }
+
+    /// <summary>
+    /// <paramref name="sourcePaths"/> reordered so every bundle an in-request bundle depends on is
+    /// executed BEFORE it, whatever order the caller listed them in (#2614). The graph work — and
+    /// the reasoning, the stability contract and the cycle handling — lives in
+    /// <see cref="AlRunner.Infrastructure.BundleDependencyOrder"/>, which is unit-tested directly;
+    /// this is only the filesystem half that reads each bundle's declared identity.
+    ///
+    /// <para>Returns the input array itself when nothing needs to move, which the caller relies on
+    /// (by reference) to skip the paired result-reordering.</para>
+    /// </summary>
+    static string[] SortBundlesInDependencyOrder(string[] sourcePaths)
+    {
+        if (sourcePaths.Length < 2) return sourcePaths;
+        var identities = ReadBundleIdentities(sourcePaths);
+        var sorted = AlRunner.Infrastructure.BundleDependencyOrder.Sort(
+            sourcePaths,
+            path => identities.TryGetValue(Path.GetFullPath(path), out var id) ? id : null);
+        return ReferenceEquals(sorted, sourcePaths) ? sourcePaths : sorted.ToArray();
     }
 
     /// <summary>
@@ -4155,8 +4235,13 @@ return strictExitCode ? computedExitCode : 0;
     /// <para>Both inputs are already paid for: the dependency relation is the same app.json
     /// identity read <see cref="RunLayeredPrePass"/> does, and "did it change" is the per-bundle
     /// result of the peek <c>RunAllBundlesForServer</c> already performs for #2492's union.
-    /// Nothing here compiles anything, and execution order is deliberately left alone — reordering
-    /// would change the order test events stream out.</para>
+    /// Nothing here compiles anything.</para>
+    ///
+    /// <para>#2614 has since made execution order itself dependency-ordered
+    /// (<see cref="AlRunner.Infrastructure.BundleDependencyOrder"/>), so for any request this sort
+    /// can fully order, no dependency is listed later and this returns empty. It is kept rather
+    /// than deleted because that sort cannot order a dependency CYCLE, and this guard still
+    /// applies to whatever ordering comes out of one.</para>
     ///
     /// <para><b>Fail-closed on an unreadable answer.</b> A dependency whose peek could not answer
     /// (no baseline yet, app.json changed, an unclassifiable file — <c>PeekChangedObjects</c>
@@ -4174,22 +4259,8 @@ return strictExitCode ? computedExitCode : 0;
         var forced = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         if (sourcePaths.Length < 2 || peekedChangedCountByBundle.Count == 0) return forced;
 
-        var order = new List<string>();
-        var identities = new Dictionary<string, AlRunner.Infrastructure.BundleIdentity>(StringComparer.OrdinalIgnoreCase);
-        foreach (var bundle in sourcePaths)
-        {
-            var abs = Path.GetFullPath(bundle);
-            order.Add(abs);
-            var appJson = Path.Combine(abs, "app.json");
-            if (!File.Exists(appJson))
-            {
-                var root = FindBucketRoot(abs);
-                if (root != null) appJson = Path.Combine(root, "app.json");
-            }
-            if (!File.Exists(appJson)) continue;
-            var id = AlRunner.Infrastructure.InProcessAppPackager.ReadIdentity(appJson);
-            if (id != null) identities[abs] = id;
-        }
+        var order = sourcePaths.Select(Path.GetFullPath).ToList();
+        var identities = ReadBundleIdentities(order);
         if (identities.Count < 2) return forced;
 
         bool ChangedOrUnknown(string abs) =>
@@ -4201,11 +4272,8 @@ return strictExitCode ? computedExitCode : 0;
             for (int j = i + 1; j < order.Count; j++)
             {
                 if (!identities.TryGetValue(order[j], out var later)) continue;
-                bool dependsOnLater = mine.Dependencies.Any(dep =>
-                    (dep.AppId != Guid.Empty && dep.AppId == later.AppId)
-                    || (string.Equals(dep.Name, later.Name, StringComparison.OrdinalIgnoreCase)
-                        && string.Equals(dep.Publisher, later.Publisher, StringComparison.OrdinalIgnoreCase)));
-                if (dependsOnLater && ChangedOrUnknown(order[j]))
+                if (AlRunner.Infrastructure.BundleDependencyOrder.DependsOn(mine, later)
+                    && ChangedOrUnknown(order[j]))
                 {
                     forced.Add(order[i]);
                     break;

--- a/docs/server-mode.md
+++ b/docs/server-mode.md
@@ -60,8 +60,24 @@ Unlike every other command, `runTests` is **not** a single response line. It
 emits zero or more `test` lines — one per completed test, in the order each
 test finishes, flushed immediately so a client sees results as they happen
 instead of waiting for the whole bundle — followed by exactly one terminal
-`summary` line. A request naming multiple `sourcePaths` runs them in order and
+`summary` line. A request naming multiple `sourcePaths` runs all of them and
 streams `test` lines across all of them before the one final `summary`.
+
+Bundles execute in **dependency order**, not the order they were listed: if one
+bundle in the request declares a dependency on another, the dependency runs
+first (#2614). Without that, a dependency listed last was compiled against —
+the pre-pass publishes its new symbols before any bundle runs — but its runtime
+assembly was not reloaded until after its consumer's tests had already run, so
+the consumer dispatched freshly resolved member ids into the previous request's
+assembly and the request failed where a cold run of the same sources passed.
+
+A request whose listed order already satisfies its dependencies is unchanged,
+and bundles with no dependency between them are not deliberately reordered — but
+a bundle waiting on a dependency is emitted when that dependency lands, which
+can put an unrelated bundle listed after it ahead of it. **Do not depend on
+`test` lines arriving in `sourcePaths` order.** The `summary` totals and the
+per-bundle results are unaffected: results are returned in the order the caller
+listed the paths.
 
 ```jsonc
 {"type":"test","name":"Codeunit60110.MyTest","status":"pass","durationMs":12}


### PR DESCRIPTION
Closes #2614

Written by an agent (impl-1).

## The defect

A `--server` request's pre-passes (`RunLayeredPrePass` / `BuildSiblingSourceDeps`) run before the per-bundle loop and publish every dependency's **new** symbols, so a consuming bundle compiles against the post-edit surface and bakes member ids from it. A bundle's runtime **assembly**, though, is only reloaded during its own iteration of that loop.

List the dependency last — an order nothing documents but the runner accepts — and the consumer dispatches its freshly baked ids into the assembly still resident from the previous request:

```
NavNCLCompilationException: Function ID -53549305 was called.
The object with ID 60550 does not have a member with that ID.
```

#2603 had already removed the silent half. What was left was loud but still red, in an order a cold run of the very same sources handles fine — because the symbols a bundle compiled against and the assembly it dispatched into came from two different points in one request. This is #2614's **option 1**: run dependencies first, which restores that invariant.

## What changed

- **`AlRunner/Infrastructure/BundleDependencyOrder.cs`** (new) — the graph half, pure and directly unit-tested. Kahn's algorithm always taking the lowest remaining original index, so the output is a deterministic function of the input and a request that already satisfies its dependencies comes back as the input array itself, by reference. Split out for the same reason `BundleRootDeduplication` (#2136) is: the end-to-end server test costs ~20s per case and cannot construct a dependency cycle at all.
- **`Program.cs`** sorts once, before the pre-passes, so the pre-passes, the per-bundle peek and the execution loop all agree on one order. Results are handed back in the order the caller listed the paths, leaving the streamed `test` line order as the only visible change.
- **`ReadBundleIdentities` extracted** so this and `ChangedLaterDependencyBundles` cannot drift on what a bundle's identity is — the shape #2478 turned into a silent divergence.

**`ChangedLaterDependencyBundles` is kept, not deleted** as #2614 suggested it could be. For any request this sort can fully order it now returns empty, but the sort cannot order a dependency **cycle**, and the guard still applies to whatever ordering comes out of one. Its doc comment's claim that "execution order is deliberately left alone" is corrected rather than left to rot.

## RED to GREEN

Exactly as #2614 predicted — deleting `ServerCrossAppOverloadRebindTests`'s `if (!dependencyFirst) return;` branch:

```
[FAIL] WarmRequest_AfterADependencyGainsAnOverload_NeverAnswersWithTheOldOverload(dependencyFirst: False)
       NavNCLCompilationException: Function ID -53549305 was called.
       The object with ID 60550 does not have a member with that ID.
Failed! - Failed: 1, Passed: 1
```

After: `Passed! - Failed: 0, Passed: 2`. Both orders now answer `BOUND-TO=2`, as a cold run does. "Never `BOUND-TO=1`" stays asserted separately for both orders, so a future regression cannot satisfy the test by failing differently instead of silently.

## Two defects in my own first version

Both caught by the new unit tests, not by review — which is the argument for them existing:

1. The fast path early-returned on "no edges at all", but the **documented** order has an edge (the consumer's indegree is 1), so every well-formed request built a new list and paid a result remap for an order that never moved. Now checked on whether the sequence actually changed.
2. I asserted "unrelated bundles keep the caller's order" and it is **false**: a bundle waiting on a dependency is emitted when that dependency lands, so an unrelated bundle listed after it can become ready first. `[a, y, m, z]` with `y` depending on `z` gives `[a, m, z, y]`. The test and both doc comments now state the accurate, weaker guarantee.

## Docs

`docs/server-mode.md` said "runs them in order" — a contract this changes. It now documents dependency order, that results are unaffected, and that clients must not depend on `test` lines arriving in `sourcePaths` order.

## Verified locally

**28.x only — a self-built runner is compiled against Ncl 28.x and cannot run 27.x artifacts.**

| check | result |
|---|---|
| `BundleDependencyOrderTests` | 10/10 |
| `ServerCrossAppOverloadRebind`, `ServerAffectedSelectionMultiSourcePaths`, `ServerAffectedSelectionCrossBundleFallback`, `ServerDuplicateSourcePath`, `LayeredSourceChain`, `LayeredDepSymbolsIncrementalServer`, `ServerStreaming` | 27/27 |
| the same sweep a second time, warm | 27/27, identical |

Run twice because this touches the incremental-change path, where a warm second run has caught real defects here that a cold one cannot.

## Scope, and what I did not verify

- **`--server` only.** The CLI and `--watch` loops are untouched. A cold CLI run is green by construction (#2614 says so). `--watch` resets per **bundle** (`BcRuntime.ResetForNewBundleReload` inside the loop) rather than per **request** as the server does — a different reload discipline — and `--watch` is not restricted to a single bundle, so the same shape *may* exist there. I did not reproduce it and did not extend the fix on a guess; filed separately.
- I did not run the full `AlRunner.Tests` suite or the AL corpus. The change is confined to `RunAllBundlesForServer` plus one new Infrastructure file, but the multi-bundle server surface is wide and CI covers what I did not.
- I did not verify the streamed-order change against any real consumer. If something outside this repo keys on `test` lines arriving in `sourcePaths` order, this breaks it — which is why the docs now say not to.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
