### PR TITLE
fix(dotnet): answer IsAvailable() on a [RunOnClient] variable instead of refusing the callback

### DIFF
--- a/AlRunner.Tests/ClientCapabilityProbeTests.cs
+++ b/AlRunner.Tests/ClientCapabilityProbeTests.cs
@@ -1,0 +1,211 @@
+// ClientCapabilityProbeTests — issue #2772.
+//
+// `IsAvailable()` on a [RunOnClient] DotNet variable raised
+// NavNCLCallbackNotAllowedException ("Callback functions are not allowed") instead of
+// answering false. AL emits that probe as
+//     navDotNet.InvokeStaticPropertyGet<bool>("IsAvailable", methodIndex)
+// whose first act is NavDotNet.CheckTypeIsLoaded() → Session.ClientCallback.
+// CreateDotNetHandle(...), and `NavSession.ClientCallback` is
+// `ClientCallbackOrNull ?? throw new NavNCLCallbackNotAllowedException()`. With no client
+// attached the probe raised before it could ever produce a value, so page 9042 "Team Member
+// Activities".OnOpenPage and page 189 "Incoming Document".OnOpenPage (via System App
+// codeunit 1907 "Camera") failed instead of skipping their guarded block.
+//
+// WHAT THIS SUITE IS FOR
+//   The BEHAVIOURAL claim — "real BC answers false rather than raising" — is a statement
+//   about Business Central, so it is proven upstream against a live service tier in the
+//   corpus repo (StefanMaron/BusinessCentral.AL.Language.Tests), per
+//   .claude/rules/bc-behavior-tests-go-upstream.md. Since that PR has not merged and this
+//   PR deliberately does not move the submodule pin, the runner-side guard lives here: a
+//   MECHANISM suite pinning where the runner draws the line between a client-capability
+//   PROBE (answered) and a client-capability USE (still refused, loudly).
+//
+//   Both halves matter. Answering `false` for everything a [RunOnClient] variable is asked
+//   would pass a one-sided test while quietly making genuine client-side calls succeed —
+//   exactly the silent fake .claude/rules/loud-failures.md forbids. So the AL fixture below
+//   asserts the probe answers false AND that `Create()` and a NON-IsAvailable static
+//   property get on the same kind of variable still raise "Callback functions are not
+//   allowed".
+//
+// The fixture declares NO application floor (no-base-app-in-csharp-tests.md): the
+// `dotnet` block resolves Microsoft.Dynamics.Nav.ClientExtensions off the service-tier
+// probing path, which is independent of the app's dependency closure. Measured cold: ~3s.
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class ClientCapabilityProbeTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(string bundle)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" \"").Append(bundle).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    // PageNotifier and OfficeHost both derive from ClientExtension<T> in the service tier's
+    // own Microsoft.Dynamics.Nav.ClientExtensions.dll, and both are declared [RunOnClient]
+    // by the shipped Base Application (pages 9060/9062/9068 and the Office host pages), so
+    // the assembly and both type names resolve on every supported BC version. No Version /
+    // Culture / PublicKeyToken is pinned in the `assembly(...)` block precisely so the
+    // fixture is not tied to one BC major.
+    private const string Fixture = """
+    dotnet
+    {
+        assembly("Microsoft.Dynamics.Nav.ClientExtensions")
+        {
+            type("Microsoft.Dynamics.Nav.Client.PageNotifier"; "PageNotifier") { }
+            type("Microsoft.Dynamics.Nav.Client.Hosts.OfficeHost"; "OfficeHost") { }
+        }
+    }
+
+    codeunit 62770 "Client Capability Probe 2772"
+    {
+        Subtype = Test;
+
+        var
+            [RunOnClient]
+            PageNotifier: DotNet PageNotifier;
+            [RunOnClient]
+            OfficeHost: DotNet OfficeHost;
+
+        // The #2772 regression itself: this raised NavNCLCallbackNotAllowedException.
+        [Test]
+        procedure Probe_IsAvailable_AnswersFalseInsteadOfRaising()
+        begin
+            if PageNotifier.IsAvailable() then
+                Error('PageNotifier.IsAvailable() answered TRUE; expected FALSE.');
+        end;
+
+        // Same answer for a second, unrelated client-extension type, so the fix is not
+        // pinned to one type name.
+        [Test]
+        procedure Probe_IsAvailable_AnswersFalseForASecondClientType()
+        begin
+            if OfficeHost.IsAvailable() then
+                Error('OfficeHost.IsAvailable() answered TRUE; expected FALSE.');
+        end;
+
+        // The other direction: a genuine client-side USE past the guard must still refuse.
+        // A fix that answered every [RunOnClient] member with a default would pass the two
+        // tests above and fail this one.
+        [Test]
+        procedure Use_StaticCreate_StillRefusesLoudly()
+        begin
+            asserterror PageNotifier := PageNotifier.Create();
+            if StrPos(GetLastErrorText(), 'Callback functions are not allowed') = 0 then
+                Error('PageNotifier.Create() raised the wrong error: %1', GetLastErrorText());
+        end;
+
+        // And the guard is scoped to the availability probe by NAME, not to "any static
+        // property get on a client type": OfficeHost.HostName is a static string property
+        // on a [RunOnClient] type and must still refuse.
+        [Test]
+        procedure Use_OtherStaticProperty_StillRefusesLoudly()
+        var
+            HostName: Text;
+        begin
+            asserterror HostName := OfficeHost.HostName;
+            if StrPos(GetLastErrorText(), 'Callback functions are not allowed') = 0 then
+                Error('OfficeHost.HostName raised the wrong error: %1', GetLastErrorText());
+        end;
+    }
+    """;
+
+    private static string WriteBundle()
+    {
+        var root = TestScratch.Dir("al-runner-client-capability-probe-2772");
+        Directory.CreateDirectory(root);
+        File.WriteAllText(Path.Combine(root, "app.json"), """
+        {
+          "id": "c7d1e4f2-2772-4a1b-9c3d-000000002772",
+          "name": "Client Capability Probe 2772",
+          "publisher": "Repro2772",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62770, "to": 62779 } ],
+          "runtime": "14.0",
+          "target": "OnPrem"
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "probe.al"), Fixture);
+        return root;
+    }
+
+    [SkippableFact]
+    public void IsAvailableProbeAnswersFalse_WhileGenuineClientUseStillRefuses()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, _) = RunRunner(WriteBundle());
+
+        Assert.DoesNotContain("EMIT-EXCLUDED", output);
+        Assert.DoesNotContain("COMPILE FAIL", output);
+        // Named individually so a failure log says WHICH half broke rather than only "3P/1F".
+        Assert.Contains("PASS  Codeunit62770.Probe_IsAvailable_AnswersFalseInsteadOfRaising", output);
+        Assert.Contains("PASS  Codeunit62770.Probe_IsAvailable_AnswersFalseForASecondClientType", output);
+        Assert.Contains("PASS  Codeunit62770.Use_StaticCreate_StillRefusesLoudly", output);
+        Assert.Contains("PASS  Codeunit62770.Use_OtherStaticProperty_StillRefusesLoudly", output);
+        Assert.Contains("4P/0F/0E", output);
+    }
+
+    // ── The predicate the Cecil prologue calls, pinned directly ────────────────────────
+    // Cheap (no subprocess) and states the scoping as a truth table: every "false" row is a
+    // call that must still run BC's own body unchanged.
+
+    [Fact]
+    public void Predicate_AnswersOnly_TheBooleanIsAvailableProbe_OnAClientVariable()
+    {
+        // The one case that is answered.
+        Assert.True(AlRunner.Patches.NavDotNetPatches.IsUnavailableClientCapabilityProbe(
+            runOnClient: true, "IsAvailable", typeof(bool)));
+
+        // A SERVER-side DotNet variable over the very same type is a different mechanism
+        // (CreateNavServerHandle against the real assembly) and is deliberately untouched.
+        Assert.False(AlRunner.Patches.NavDotNetPatches.IsUnavailableClientCapabilityProbe(
+            runOnClient: false, "IsAvailable", typeof(bool)));
+
+        // Any other member on a client variable stays on BC's path — and therefore still
+        // raises "Callback functions are not allowed".
+        Assert.False(AlRunner.Patches.NavDotNetPatches.IsUnavailableClientCapabilityProbe(
+            runOnClient: true, "HostName", typeof(bool)));
+        Assert.False(AlRunner.Patches.NavDotNetPatches.IsUnavailableClientCapabilityProbe(
+            runOnClient: true, null, typeof(bool)));
+
+        // Ordinal, case-sensitive: AL emits the member name exactly as the .NET property is
+        // spelled, so a differently-cased name is a DIFFERENT member, not this probe.
+        Assert.False(AlRunner.Patches.NavDotNetPatches.IsUnavailableClientCapabilityProbe(
+            runOnClient: true, "isavailable", typeof(bool)));
+
+        // Non-boolean instantiations must never be answered: the Cecil prologue's
+        // `unbox.any !!T` of a boxed `false` is only well-typed when T is bool.
+        Assert.False(AlRunner.Patches.NavDotNetPatches.IsUnavailableClientCapabilityProbe(
+            runOnClient: true, "IsAvailable", typeof(string)));
+        Assert.False(AlRunner.Patches.NavDotNetPatches.IsUnavailableClientCapabilityProbe(
+            runOnClient: true, "IsAvailable", typeof(int)));
+        Assert.False(AlRunner.Patches.NavDotNetPatches.IsUnavailableClientCapabilityProbe(
+            runOnClient: true, "IsAvailable", null));
+    }
+}

--- a/AlRunner/Infrastructure/NclCecilRewrite.Dispatch.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Dispatch.cs
@@ -715,6 +715,89 @@ public static partial class NclCecilRewrite
             }
         }
 
+        // ── NavDotNet.InvokeStaticPropertyGet<T>: answer the [RunOnClient] IsAvailable probe ──
+        // #2772. AL `SomeClientVar.IsAvailable()` on a [RunOnClient] DotNet variable compiles
+        // to `navDotNet.InvokeStaticPropertyGet<bool>("IsAvailable", methodIndex)`, whose first
+        // act is CheckTypeIsLoaded() → Session.ClientCallback.CreateDotNetHandle(...) →
+        // NavNCLCallbackNotAllowedException on a session with no client. The probe exists so AL
+        // can ask "can I use this here?" WITHOUT raising, and all 17 shipped call sites use it
+        // as the condition of an `if` — so raising turns "no client here" into a test failure
+        // (page 9042 "Team Member Activities".OnOpenPage, page 189 "Incoming Document".OnOpenPage
+        // via System App codeunit 1907 "Camera"). Full faithfulness argument, and the list of
+        // client-side surfaces that deliberately keep raising, in
+        // NavDotNetPatches.IsUnavailableClientCapabilityProbe's doc comment.
+        //
+        // Prepended as a guarded early return; BC's original body and every branch target in it
+        // are untouched, so any call that is not the boolean `IsAvailable` probe on a
+        // [RunOnClient] variable behaves exactly as before:
+        //     ldarg.0                                  // this
+        //     ldfld  bool NavDotNet::runOnClient
+        //     ldarg.1                                  // propertyName
+        //     ldtoken !!T ; call Type::GetTypeFromHandle
+        //     call   bool NavDotNetPatches::IsUnavailableClientCapabilityProbe(bool,string,Type)
+        //     brfalse <original first instruction>
+        //     ldc.i4.0 ; box bool ; unbox.any !!T ; ret
+        // The box/unbox.any round trip is what makes the constant well-typed inside a generic
+        // method; the predicate returns true only when T is bool, so unbox.any never sees
+        // another instantiation.
+        {
+            var navDotNetType = asm.MainModule.GetType("Microsoft.Dynamics.Nav.Runtime.NavDotNet")
+                ?? throw new InvalidOperationException(
+                    "[Cecil] type NavDotNet not found — Ncl shape changed; do not commit (#2772)");
+            // The 2-parameter overload is the parameterless property get. The 3-parameter
+            // (params object[] dimensions) overload is for INDEXED properties and can never be
+            // the IsAvailable probe, so it is deliberately left alone.
+            var mProbe = navDotNetType.Methods.FirstOrDefault(x =>
+                    x.Name == "InvokeStaticPropertyGet"
+                    && x.HasGenericParameters && x.GenericParameters.Count == 1
+                    && x.Parameters.Count == 2
+                    && x.Parameters[0].ParameterType.FullName == "System.String"
+                    && x.Parameters[1].ParameterType.FullName == "System.UInt32")
+                ?? throw new InvalidOperationException(
+                    "[Cecil] NavDotNet.InvokeStaticPropertyGet<T>(string, uint) not found — "
+                    + "Ncl shape changed; do not commit (#2772)");
+            var runOnClientField = navDotNetType.Fields.FirstOrDefault(
+                    f => f.Name == "runOnClient" && f.FieldType.FullName == "System.Boolean")
+                ?? throw new InvalidOperationException(
+                    "[Cecil] NavDotNet.runOnClient (bool) not found — Ncl shape changed; "
+                    + "do not commit (#2772)");
+
+            var probeMi = typeof(AlRunner.Patches.NavDotNetPatches).GetMethod(
+                    nameof(AlRunner.Patches.NavDotNetPatches.IsUnavailableClientCapabilityProbe),
+                    BindingFlags.Public | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "[Cecil] NavDotNetPatches.IsUnavailableClientCapabilityProbe not found — do not commit");
+            var probeRef = asm.MainModule.ImportReference(probeMi);
+            var getTypeFromHandleRef = asm.MainModule.ImportReference(
+                typeof(Type).GetMethod(nameof(Type.GetTypeFromHandle),
+                    BindingFlags.Public | BindingFlags.Static)!);
+            var boolTypeRef = asm.MainModule.TypeSystem.Boolean;
+            var tRef = mProbe.GenericParameters[0];
+
+            var body = mProbe.Body;
+            var il = body.GetILProcessor();
+            var first = body.Instructions[0];
+            foreach (var instr in new[]
+            {
+                il.Create(OpCodes.Ldarg_0),
+                il.Create(OpCodes.Ldfld, runOnClientField),
+                il.Create(OpCodes.Ldarg_1),
+                il.Create(OpCodes.Ldtoken, tRef),
+                il.Create(OpCodes.Call, getTypeFromHandleRef),
+                il.Create(OpCodes.Call, probeRef),
+                il.Create(OpCodes.Brfalse, first),
+                il.Create(OpCodes.Ldc_I4_0),
+                il.Create(OpCodes.Box, boolTypeRef),
+                il.Create(OpCodes.Unbox_Any, tRef),
+                il.Create(OpCodes.Ret),
+            })
+                il.InsertBefore(first, instr);
+            body.MaxStackSize = Math.Max(body.MaxStackSize, 3);
+            Console.Error.WriteLine(
+                "[Cecil] Prepended IsAvailable client-probe guard to "
+                + "NavDotNet.InvokeStaticPropertyGet<T>(string, uint)");
+        }
+
         // ALNumberSequence — runner-emitted AL calls the synchronous entry points, while
         // precompiled Microsoft apps call the async entry points directly. Rewrite both
         // public surfaces so neither can reach SQL and both observe the same store.
@@ -889,6 +972,11 @@ public static partial class NclCecilRewrite
         // NavNCLDotNetCreateException (which is trappable and would be silently swallowed
         // by TryInvokeAsync → TryInitializeFromCurrentApp returns false with no OOS signal).
         set.Add("Microsoft.Dynamics.Nav.Runtime.NavDotNet::CreateDotNet/1");
+        // NavDotNet.InvokeStaticPropertyGet<T>(string, uint) — guarded early return so the
+        // `IsAvailable` probe on a [RunOnClient] DotNet variable answers false instead of
+        // raising NavNCLCallbackNotAllowedException out of CheckTypeIsLoaded (#2772). Every
+        // other call runs BC's original body; every other client-side surface still raises.
+        set.Add("Microsoft.Dynamics.Nav.Runtime.NavDotNet::InvokeStaticPropertyGet/2");
         // ALTaskScheduler cluster (scope.md §3.6, #1733) — CanCreateTask/ALCanCreateTask
         // rewritten to return false (no scheduler headlessly) and CheckCodeUnit no-op'd so
         // ALCreateTaskAsync's real body reaches that CanCreateTask gate instead of throwing

--- a/AlRunner/Patches/NavDotNetPatches.cs
+++ b/AlRunner/Patches/NavDotNetPatches.cs
@@ -18,6 +18,9 @@
 // plain System.Exception, so it gets wrapped — losing the OOS signal.  The surgical
 // RethrowIfRunnerOOS check (inserted at the start of CreateDotNet's catch block by
 // NclCecilRewrite.cs) rethrows OOS before the wrapping logic runs.
+//
+// ADDITIONAL (#2772): the `IsAvailable` probe on a [RunOnClient] DotNet variable.
+// See IsUnavailableClientCapabilityProbe below for the full argument.
 
 namespace AlRunner.Patches;
 
@@ -42,4 +45,67 @@ public static class NavDotNetPatches
         if (ex is AlRunner.Infrastructure.RunnerOutOfScopeException oos)
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(oos).Throw();
     }
+
+    /// <summary>
+    /// #2772 — predicate for the Cecil guard prepended to
+    /// <c>NavDotNet.InvokeStaticPropertyGet&lt;T&gt;(string, uint)</c>. True means "this call
+    /// is the client-capability availability PROBE, answer <c>false</c> and do not enter BC's
+    /// body"; false means "run BC's original body unchanged".
+    ///
+    /// WHAT AL EMITS
+    ///   AL `SomeClientVar.IsAvailable()` on a <c>[RunOnClient] DotNet</c> variable compiles to
+    ///       navDotNet.InvokeStaticPropertyGet&lt;bool&gt;("IsAvailable", methodIndex)
+    ///   — verified by decompiling the shipped 28.1 System Application and Base Application:
+    ///   17 call sites, every one of them this exact shape — System Application codeunits
+    ///   1908/1909/3726/7569 and pages 1990/8886/9451, Base Application pages
+    ///   1310/1600/9060/9062/9068. There is no other emit shape for the probe, so this one
+    ///   seam covers all of them.
+    ///
+    /// WHY BC RAISES HERE ON THE RUNNER
+    ///   InvokeStaticPropertyGet calls NavDotNet.CheckTypeIsLoaded, whose RunOnClient branch is
+    ///       remoteHandle = new NavClientHandle(
+    ///           NavCurrentThread.Session.ClientCallback.CreateDotNetHandle(...), …)
+    ///   and `NavSession.ClientCallback` is `ClientCallbackOrNull ?? throw new
+    ///   NavNCLCallbackNotAllowedException()`. With no client attached the probe raises before
+    ///   it can ever produce a value — which turns "no client here" into a test failure.
+    ///
+    /// WHY `false` IS THE FAITHFUL ANSWER, NOT A SILENT FAKE
+    ///   Microsoft ships the server-side half of these types in the service tier itself,
+    ///   `Microsoft.Dynamics.Nav.ClientExtensions.dll`, and every client capability type in it
+    ///   (PageNotifier, CameraProvider, LocationProvider, AppSource, UserTours, Tour, Designer,
+    ///   BarcodeScannerProvider, CameraBarcodeScannerProvider, DeviceContactProvider, OfficeHost)
+    ///   derives from
+    ///       public abstract class ClientExtension&lt;T&gt; { public static bool IsAvailable =&gt; false; }
+    ///   `false` is therefore Microsoft's own answer, in Microsoft's own binary, for exactly
+    ///   these types when no client is providing the capability. It is also what the AL contract
+    ///   asks for: `IsAvailable` exists so AL can ask "can I use this here?" WITHOUT raising, and
+    ///   every one of the 17 call sites uses it as the guard on an `if`.
+    ///
+    /// WHAT STILL RAISES (the other half of .claude/rules/loud-failures.md)
+    ///   Only the probe is answered. Everything past the guard is a real USE of a client that is
+    ///   not there, and still raises NavNCLCallbackNotAllowedException exactly as before:
+    ///     • `PageNotifier.Create()`   → InvokeStaticMethod&lt;NavDotNet&gt;("Create", …)
+    ///     • `PageNotifier.NotifyPageReady()` → InvokeMethod&lt;NavVoidType&gt;("NotifyPageReady", …)
+    ///     • any other static property get on a client type (OfficeHost.HostName, …)
+    ///     • every [RunOnClient] path that does not go through this one method
+    ///   Nothing here can make a client-side call succeed: the guard returns `true` only for a
+    ///   BOOLEAN result and the literal property name `IsAvailable`, and the only value it ever
+    ///   produces is `false`.
+    ///
+    /// NOT AFFECTED: a DotNet variable declared WITHOUT [RunOnClient] over the same type. That
+    /// resolves server-side through CreateNavServerHandle against the real
+    /// Microsoft.Dynamics.Nav.ClientExtensions assembly and answers from Microsoft's own code
+    /// (or raises RunnerOutOfScopeException naming the assembly if it is not on the probing
+    /// path) — a different mechanism, deliberately left alone.
+    /// </summary>
+    /// <param name="runOnClient">NavDotNet's own <c>runOnClient</c> field, loaded directly by
+    /// the Cecil prologue — no reflection, and false for every server-side DotNet variable.</param>
+    /// <param name="propertyName">The property name BC was about to ask the client for.</param>
+    /// <param name="resultType">The call's <c>typeof(T)</c>. Guarding on it keeps the generic
+    /// early-return well-typed: a non-bool instantiation always runs BC's original body.</param>
+    public static bool IsUnavailableClientCapabilityProbe(
+        bool runOnClient, string? propertyName, Type? resultType)
+        => runOnClient
+           && resultType == typeof(bool)
+           && string.Equals(propertyName, "IsAvailable", StringComparison.Ordinal);
 }


### PR DESCRIPTION
Closes #2772

## The mechanism

AL `SomeClientVar.IsAvailable()` on a `[RunOnClient] DotNet` variable compiles to a single shape. Decompiled from the shipped 28.1 System Application, `Camera Impl.` (codeunit 1909):

```csharp
val.Target.Item2 = val.Target.Item1.InvokeStaticPropertyGet<bool>("IsAvailable", 268435455u);
```

`NavDotNet.InvokeStaticPropertyGet<T>(string, uint)`'s first act is `CheckTypeIsLoaded()`, whose `RunOnClient` branch is:

```csharp
remoteHandle = new NavClientHandle(
    NavCurrentThread.Session.ClientCallback.CreateDotNetHandle(assemblyFullName, typeName, ...), suppressDispose);
```

and `NavSession.ClientCallback` is `ClientCallbackOrNull ?? throw new NavNCLCallbackNotAllowedException()`. With no client attached, the probe raised before it could produce a value — the reported `Callback functions are not allowed.`

**Should the probe and the call path diverge? Yes, and the shipped code says so directly.** All 17 call sites of this shape in the Base Application and the System Application (System App codeunits 1908/1909/3726/7569 and pages 1990/8886/9451; Base App pages 1310/1600/9060/9062/9068) use `IsAvailable()` as the condition of an `if`, never as a use:

```al
if PageNotifier.IsAvailable() then begin
    PageNotifier := PageNotifier.Create();   // <- the USE
    PageNotifier.NotifyPageReady();          // <- the USE
end;
```

The probe asks whether the use is possible. Refusing the question is not the same as refusing the use.

**Why `false` is faithful rather than a silent default.** Microsoft ships the server-side half of these types in the service tier itself, `Microsoft.Dynamics.Nav.ClientExtensions.dll`, and every capability type in it — PageNotifier, CameraProvider, LocationProvider, AppSource, UserTours, Tour, Designer, BarcodeScannerProvider, CameraBarcodeScannerProvider, DeviceContactProvider, OfficeHost — derives from:

```csharp
public abstract class ClientExtension<T> where T : ClientExtension<T>
{
    public static bool IsAvailable => false;
    public static T Create() => null;
}
```

`false` is Microsoft's own answer, in Microsoft's own binary, for these exact types when no client provides the capability.

## The fix

A Cecil-prepended guarded early return on `NavDotNet.InvokeStaticPropertyGet<T>(string, uint)`. It fires only when **all three** hold — the variable is `runOnClient`, the property name is exactly `IsAvailable` (ordinal), and `T` is `bool` — and returns `false`. Every other call falls through to BC's original body, untouched, with every branch target intact.

### Which surfaces now answer instead of raising, and why each is faithful

| surface | before | after | why |
|---|---|---|---|
| `InvokeStaticPropertyGet<bool>("IsAvailable")` on a `[RunOnClient]` variable | raised `NavNCLCallbackNotAllowedException` | returns `false` | the AL contract of the probe, and the literal value Microsoft's shipped `ClientExtension<T>` stub returns server-side |

That is the whole list — one method, one property name, one result type. Everything below still raises exactly as before, and the suite proves it rather than asserting it:

- `PageNotifier.Create()` → `InvokeStaticMethod<NavDotNet>("Create", ...)`
- `PageNotifier.NotifyPageReady()` → `InvokeMethod<NavVoidType>("NotifyPageReady", ...)`
- `OfficeHost.HostName` — a **non-`IsAvailable`** static property get on the same kind of variable
- the indexed `InvokeStaticPropertyGet<T>(string, uint, params object[])` overload, deliberately not patched: it serves indexed properties and can never be this probe
- a **server-side** (non-`[RunOnClient]`) DotNet variable over the very same type — a different mechanism (`CreateNavServerHandle` against the real assembly), untouched

## RED → GREEN, actually run

Against the exact fixture in `AlRunner.Tests/ClientCapabilityProbeTests.cs`, on this machine, BC 28.1.49838.53910.

**RED** (this commit's test file present, the Cecil block reverted to `origin/main`):

```
FAIL  Codeunit62770.Probe_IsAvailable_AnswersFalseInsteadOfRaising (13ms)
      NavNCLCallbackNotAllowedException: Callback functions are not allowed.
FAIL  Codeunit62770.Probe_IsAvailable_AnswersFalseForASecondClientType (1ms)
      NavNCLCallbackNotAllowedException: Callback functions are not allowed.
PASS  Codeunit62770.Use_StaticCreate_StillRefusesLoudly (2ms)
PASS  Codeunit62770.Use_OtherStaticProperty_StillRefusesLoudly (1ms)
```

The two `PASS` lines in the RED state are the point: they already held, so they constrain the fix instead of being satisfied by it. A change that answered every `[RunOnClient]` member with a default would turn all four green in RED and fail both of them here.

**GREEN**: `4P/0F/0E`; `dotnet test AlRunner.Tests --filter FullyQualifiedName~ClientCapabilityProbeTests` → 2 passed.

The issue's own reproducer was confirmed first, before any test was written — a `Camera.IsAvailable()` call in a throwaway bundle reproduced the reported trace verbatim (`"Camera Page Impl."(CodeUnit 1908).IsAvailable` → `"Camera"(CodeUnit 1907).IsAvailable`) and passes after the fix.

## Wider regression runs (this head, this machine)

- corpus: `2464P/0F/0E` — exactly the count baseline
- `tests/runner-extras`: `246P/0F/0E`, three consecutive runs — exactly the count baseline
- `dotnet test AlRunner.Tests --filter FullyQualifiedName~ClientCapabilityProbeTests`: 2/2

One thing worth flagging rather than burying: an earlier build of this branch failed `PrecompiledCodeunit_StartSession_RunsTheWorkersOnRunBody` and `...RunsTheWorkerItWasGiven_AndNoOther` (both new in #2752) three times, while the same suite passed at the branch's base commit. A/B-ing the guard behind an env var **inside one binary** showed no difference — 24/24 both ways — and after a rebuild from identical source the Cecil cache key changed from `c85e03fb` to `450ed2ce` and the failures never returned across five subsequent runs. So the failing state was tied to a particular cached rewritten Ncl, not to the guard's answer. I could not reproduce it again to diagnose it further; recording it here because the next person to see those two tests flap should know it has happened once, on a `~/.cache/al-runner/ncl-cecil` hit.

## Where the tests live

The behavioural claim — *real BC answers rather than raising* — is a statement about Business Central, so it is upstream at **StefanMaron/BusinessCentral.AL.Language.Tests#162**, where a real service tier adjudicates it on 8 BC legs. **That verdict is still pending, and this PR does not depend on it.** The corpus PR covers both routes to the answer (Camera, client-resolved; Geolocation, server-resolved), the guard shape itself, and pins `GuiAllowed()` true in the same session so `false` means the capability is absent rather than the session being headless.

Per this task's instruction, **the submodule pin is deliberately not moved here** (it is contended between two other open PRs) and `tests/expectations/count-baseline/test-count-baseline.json` is untouched. The runner-side proving suite is therefore in `AlRunner.Tests/`, which the count baseline does not cover — the `require-tests` shape the workflow prescribes when the corpus PR has not merged yet.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** All 17 shipped `IsAvailable` probes funnel through this one `NavDotNet` method, so one seam covers every one of them — including the second reported failure (page 189 via codeunit 1907 "Camera"), which is now proven fixed rather than assumed.
2. **Does a sibling function make the same assumption?** `InvokeStaticMethod`, `InvokeStaticField`, the instance `InvokePropertyGet`, and the indexed `InvokeStaticPropertyGet` overload all call `CheckTypeIsLoaded()` the same way. They are deliberately **not** changed: each is a real use of a client that is not there, and refusing them is correct. Two of them are pinned as still-refusing by this PR's tests.
3. **Two paths writing the same state with different invariants?** Not applicable — this is a read path. The nearest analogue is the client-resolved vs server-resolved form of the same capability type; both are covered, by different mechanisms, in the corpus PR.

Left out on purpose: a `tests/runner-extras/` suite. It would have needed a `dotnet` block plus an edit to the contended count baseline, and the `AlRunner.Tests` fixture proves the same four things.

Authored by agent `stma-auto-1` on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE