### PR TITLE
fix(resume): carry full results so --output-json, --out and --count-baseline describe the run

### DIFF
--- a/AlRunner.Tests/ResumeCarryTests.cs
+++ b/AlRunner.Tests/ResumeCarryTests.cs
@@ -1,0 +1,141 @@
+// ResumeCarryTests — what a watchdog-resume attempt hands to the next process (#2719).
+//
+// The point of carrying full results rather than rebuilding them from the JUnit the summary
+// already carries is that a JUnit <testcase> has a name and a status and nothing else. These
+// tests pin the fields that make that difference — above all Expectation, which is what decides
+// whether a failure is a real `fail` or a pass-known-gap / pass-oos / pass-divergence. A carried
+// case that lost it would be classified as an UNEXPECTED failure by --out, turning a silently
+// missing error into a confidently wrong one.
+//
+// They also pin what deliberately does NOT cross: a live Exception object, and CapturedValues
+// (server `execute` only). Being explicit about the crossing set is the reason this DTO exists
+// instead of making TestResult serialisable, where both would have ridden along unnoticed.
+
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ResumeCarryTests : IDisposable
+{
+    private readonly string _dir = TestScratch.Dir("al-runner-resume-carry-tests");
+
+    public ResumeCarryTests() => Directory.CreateDirectory(_dir);
+    public void Dispose() => ScratchDirs.Release(_dir);
+
+    private static BucketResult Bucket(params TestResult[] tests)
+        => new("/bundle/x", BucketStage.Ran, new[] { "compile note" }, null, tests,
+               TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3),
+               RanGroupCount: 7, ProvisionGaps: new[] { "gap" });
+
+    [Fact]
+    public void RoundTrip_KeepsTheFieldsAJUnitCaseCannotCarry()
+    {
+        var path = Path.Combine(_dir, "attempt.json");
+        var original = Bucket(
+            new TestResult("Codeunit1", "KnownGap", TestOutcome.Fail, "boom", "full-ex",
+                TimeSpan.FromMilliseconds(1234), AlCallStack: "al-stack",
+                CodeunitDisplayName: "Nice Name", Exception: new InvalidOperationException("live"),
+                Expectation: ExpectationResult.PassKnownGap, InsideTestProc: false, TimedOut: true,
+                CapturedValues: null, Diagnosis: "no rows in table X"));
+
+        ResumeCarry.Write(path, new[] { original });
+        var back = ResumeCarry.Read(new[] { path }, out var unreadable);
+
+        Assert.Equal(0, unreadable);
+        var t = Assert.Single(Assert.Single(back).Tests);
+        // The three the issue named as unavailable from JUnit:
+        Assert.Equal(ExpectationResult.PassKnownGap, t.Expectation);
+        Assert.Equal("no rows in table X", t.Diagnosis);
+        Assert.Equal("Nice Name", t.CodeunitDisplayName);
+        // And the rest of what a consumer reads.
+        Assert.Equal("Codeunit1", t.Codeunit);
+        Assert.Equal("KnownGap", t.Method);
+        Assert.Equal(TestOutcome.Fail, t.Outcome);
+        Assert.Equal("boom", t.Message);
+        Assert.Equal("full-ex", t.FullException);
+        Assert.Equal("al-stack", t.AlCallStack);
+        Assert.Equal(TimeSpan.FromMilliseconds(1234), t.Duration);
+        Assert.False(t.InsideTestProc);
+        Assert.True(t.TimedOut);
+    }
+
+    [Fact]
+    public void RoundTrip_DoesNotResurrectTheLiveException_NorCapturedValues()
+    {
+        // FullException already carries the text, which is everything a later process can use.
+        // Serialising an exception graph to rebuild an object in another process would be a
+        // fiction dressed as fidelity.
+        var path = Path.Combine(_dir, "attempt.json");
+        ResumeCarry.Write(path, new[] { Bucket(
+            new TestResult("Codeunit1", "Boom", TestOutcome.Error, "m", "the text",
+                TimeSpan.Zero, Exception: new InvalidOperationException("live"))) });
+
+        var t = Assert.Single(Assert.Single(ResumeCarry.Read(new[] { path }, out _)).Tests);
+
+        Assert.Null(t.Exception);
+        Assert.Null(t.CapturedValues);
+        Assert.Equal("the text", t.FullException);
+    }
+
+    [Fact]
+    public void RoundTrip_KeepsBucketLevelFacts()
+    {
+        // The bucket's own CompileErrors are how a watchdog abort is recorded, and they are what
+        // makes a resumed run's exit code describe the run rather than the last slice.
+        var path = Path.Combine(_dir, "attempt.json");
+        ResumeCarry.Write(path, new[] { Bucket() });
+
+        var b = Assert.Single(ResumeCarry.Read(new[] { path }, out _));
+
+        Assert.Equal("/bundle/x", b.BucketPath);
+        Assert.Equal(BucketStage.Ran, b.Stage);
+        Assert.Equal(new[] { "compile note" }, b.CompileErrors);
+        Assert.Equal(7, b.RanGroupCount);
+        Assert.Equal(new[] { "gap" }, b.ProvisionGaps);
+        Assert.Equal(TimeSpan.FromSeconds(1), b.EmitTime);
+        Assert.Equal(TimeSpan.FromSeconds(2), b.CompileTime);
+        Assert.Equal(TimeSpan.FromSeconds(3), b.RunTime);
+    }
+
+    [Fact]
+    public void ManyFiles_AreConcatenatedInOrder()
+    {
+        // One file per attempt, so a chain of resumes reads back as the chain — never with an
+        // earlier attempt folded in twice, which is the rule the JUnit carry file follows too.
+        var a = Path.Combine(_dir, "a.json");
+        var b = Path.Combine(_dir, "b.json");
+        ResumeCarry.Write(a, new[] { Bucket(new TestResult("C1", "First", TestOutcome.Pass, null, null, TimeSpan.Zero)) });
+        ResumeCarry.Write(b, new[] { Bucket(new TestResult("C2", "Second", TestOutcome.Pass, null, null, TimeSpan.Zero)) });
+
+        var back = ResumeCarry.Read(new[] { a, b }, out var unreadable);
+
+        Assert.Equal(0, unreadable);
+        Assert.Equal(new[] { "First", "Second" }, back.SelectMany(x => x.Tests).Select(t => t.Method).ToArray());
+    }
+
+    [Fact]
+    public void AMissingOrCorruptFile_ContributesNothing_AndIsCounted()
+    {
+        // Counted, not swallowed: the caller prints the count, because the difference between
+        // "the run had one error" and "the run was clean" must never turn on a scratch file
+        // quietly going missing (#2747 is the lifetime hazard that makes this reachable).
+        var good = Path.Combine(_dir, "good.json");
+        var corrupt = Path.Combine(_dir, "corrupt.json");
+        ResumeCarry.Write(good, new[] { Bucket(new TestResult("C1", "Kept", TestOutcome.Pass, null, null, TimeSpan.Zero)) });
+        File.WriteAllText(corrupt, "{ not json at all");
+
+        var back = ResumeCarry.Read(
+            new[] { good, corrupt, Path.Combine(_dir, "does-not-exist.json") }, out var unreadable);
+
+        Assert.Equal(2, unreadable);
+        Assert.Equal(new[] { "Kept" }, back.SelectMany(x => x.Tests).Select(t => t.Method).ToArray());
+    }
+
+    [Fact]
+    public void NoFiles_ReadsEmpty_SoANonResumedRunIsUnchanged()
+    {
+        Assert.Empty(ResumeCarry.Read(Array.Empty<string>(), out var unreadable));
+        Assert.Equal(0, unreadable);
+    }
+}

--- a/AlRunner.Tests/SuiteAbortOnTimeoutTests.cs
+++ b/AlRunner.Tests/SuiteAbortOnTimeoutTests.cs
@@ -28,6 +28,7 @@
 // BaseApp surface at --jobs 12, the aggregate was missing 26% of the tests the shards had run.
 using System.Diagnostics;
 using System.Text;
+using System.Text.Json;
 using System.Xml.Linq;
 using AlRunner.Infrastructure;
 using Xunit;
@@ -197,6 +198,37 @@ public sealed class SuiteAbortOnTimeoutTests : IDisposable
     }
 
     /// <summary>
+    /// Same spawn, but keeping stdout and stderr APART. Every other test here reads them merged,
+    /// which is fine when it is looking for a message — but --output-json's whole contract is
+    /// about what lands on stdout ALONE, and a merged capture cannot tell a second JSON document
+    /// from an ordinary stderr line following the first (#2719).
+    /// </summary>
+    private (string stdout, string stderr, int exit) RunRunnerSplit(
+        string bundle, int waitMs, params string[] extraArgs)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" \"{bundle}\"");
+        foreach (var a in extraArgs) args.Append($" {a}");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var so = new StringBuilder();
+        var se = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (so) so.AppendLine(e.Data); };
+        p.ErrorDataReceived  += (_, e) => { if (e.Data != null) lock (se) se.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(waitMs)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (so) lock (se) return (so.ToString(), se.ToString(), p.ExitCode);
+    }
+
+    /// <summary>
     /// Positive: a hang must be reported loudly. The codeunit name and the exact
     /// count of [Test] methods it never got to (2 — NeverRuns1 and NeverRuns2) must
     /// both appear in the output, alongside a non-zero "suite errors" tally.
@@ -282,6 +314,89 @@ public sealed class SuiteAbortOnTimeoutTests : IDisposable
         Assert.Equal(1, totals.Errors);
         Assert.Equal(0, totals.Failures);
         Assert.Equal(0, totals.Skipped);
+    }
+
+    /// <summary>
+    /// #2719: --output-json, --out and --count-baseline must describe the RUN after a resume,
+    /// not the final attempt's slice. Before this the same command produced, all at once:
+    /// TWO JSON documents concatenated on stdout (so json.loads failed outright); a final
+    /// document reading total=2 passed=2 errors=0 exitCode=0 — a completely clean run — while
+    /// the process exited non-zero; a classification file claiming total_failures=0; and a
+    /// count-baseline DROP reported in the same log as "4 total".
+    ///
+    /// One spawn, all four outputs, because they have to AGREE — that is the actual claim.
+    /// </summary>
+    [SkippableFact]
+    public void ResumedRun_JsonClassificationAndBaseline_DescribeTheWholeRun()
+    {
+        TestArtifacts.SkipIfMissing();
+        var dir = Path.Combine(_resumeRoot, "out2");
+        Directory.CreateDirectory(dir);
+        var jsonPath = Path.Combine(dir, "stdout.json");
+        var clsPath = Path.Combine(dir, "cls.json");
+        var junitPath = Path.Combine(dir, "r.xml");
+        var baselinePath = Path.Combine(dir, "baseline.json");
+        // The whole run is 4 tests; a baseline of 4 must be MET, not reported as a drop.
+        File.WriteAllText(baselinePath,
+            $$"""{ "suites": { "{{Path.GetFileName(_resumeRoot)}}": { "tests": { "default": 4 } } } }""");
+
+        var (stdout, stderr, exit) = RunRunnerSplit(_resumeRoot, 300_000,
+            "--test-timeout 2", "--resume-aborts 1", "--output-json",
+            $"--out \"{clsPath}\"", $"--output-junit \"{junitPath}\"",
+            $"--count-baseline \"{baselinePath}\"");
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("resume: a watchdog abort ended this attempt early", stderr);
+
+        // stdout is ONE json document. A second one is not "the wrong half" — it is unparseable.
+        var stdoutJson = StdoutJson(stdout);
+        using var doc = JsonDocument.Parse(stdoutJson);
+        var root = doc.RootElement;
+
+        Assert.Equal(4, root.GetProperty("total").GetInt32());
+        Assert.Equal(3, root.GetProperty("passed").GetInt32());
+        Assert.Equal(1, root.GetProperty("errors").GetInt32());
+        // The field a consumer trusts INSTEAD of the exit code. It said 0 for a failed run.
+        Assert.Equal(exit, root.GetProperty("exitCode").GetInt32());
+
+        var names = root.GetProperty("tests").EnumerateArray()
+            .Select(t => t.GetProperty("name").GetString()!.Split('.').Last())
+            .OrderBy(n => n).ToArray();
+        Assert.Equal(new[] { "Hangs", "RanBeforeHang", "SecondA", "SecondB" }, names);
+
+        // The carried error reaches the classification file, which reported zero failures.
+        var cls = JsonDocument.Parse(File.ReadAllText(clsPath)).RootElement;
+        Assert.True(cls.GetProperty("total_failures").GetInt32() > 0,
+            "the classification file must not report a resumed run with an error as having no failures");
+
+        // The baseline the whole run meets is met, and the phantom DROP is gone.
+        Assert.DoesNotContain("[count-baseline] DROP", stderr);
+        Assert.Contains("[count-baseline] skipped: this attempt is resuming", stderr);
+
+        // And --output-junit is untouched by all of this: still 4 cases, not 8. The carried
+        // attempt must not be counted once per output shape.
+        Assert.Equal(4, TestCases(junitPath).Count);
+    }
+
+    /// <summary>The single JSON document the runner prints on stdout. Fails loudly, naming what
+    /// it saw, rather than letting a test read the first of two concatenated documents.</summary>
+    private static string StdoutJson(string stdout)
+    {
+        var start = stdout.IndexOf('{');
+        Assert.True(start >= 0, "no JSON found on stdout:\n" + stdout);
+        var text = stdout.Substring(start).Trim();
+        var reader = new Utf8JsonReader(System.Text.Encoding.UTF8.GetBytes(text), isFinalBlock: true,
+            state: default);
+        Assert.True(JsonDocument.TryParseValue(ref reader, out _),
+            "stdout did not hold ONE parseable JSON document:\n" + text);
+        var consumed = (int)reader.BytesConsumed;
+        var trailing = System.Text.Encoding.UTF8.GetString(
+            System.Text.Encoding.UTF8.GetBytes(text), consumed,
+            System.Text.Encoding.UTF8.GetByteCount(text) - consumed).Trim();
+        Assert.True(trailing.Length == 0,
+            "stdout held MORE than one JSON document — a consumer's json.loads fails outright. "
+            + "Trailing:\n" + trailing);
+        return text;
     }
 
     /// <summary>

--- a/AlRunner/Infrastructure/AbortResume.cs
+++ b/AlRunner/Infrastructure/AbortResume.cs
@@ -50,12 +50,25 @@ internal static class AbortResume
     public static List<string> BuildChildArgs(
         IReadOnlyList<string> originalArgs, IReadOnlyCollection<string> exclusions,
         int remainingBudget, IReadOnlyCollection<string> carryFiles)
+        => BuildChildArgs(originalArgs, exclusions, remainingBudget, carryFiles, Array.Empty<string>());
+
+    /// <summary>
+    /// As above, plus <paramref name="carryResultFiles"/> — the per-attempt JSON sidecars
+    /// (#2719). The JUnit carry files answer the printed summary and --output-junit; these
+    /// answer --output-json, --out and --count-baseline, which need the full TestResult and
+    /// cannot be rebuilt from a JUnit testcase (see Infrastructure.ResumeCarry).
+    /// </summary>
+    public static List<string> BuildChildArgs(
+        IReadOnlyList<string> originalArgs, IReadOnlyCollection<string> exclusions,
+        int remainingBudget, IReadOnlyCollection<string> carryFiles,
+        IReadOnlyCollection<string> carryResultFiles)
     {
         var child = new List<string>();
         for (var i = 0; i < originalArgs.Count; i++)
         {
             var a = originalArgs[i];
-            if (a == "--exclude-test" || a == "--resume-aborts" || a == "--merge-counts")
+            if (a == "--exclude-test" || a == "--resume-aborts"
+                || a == "--merge-counts" || a == "--merge-results")
             {
                 if (i + 1 < originalArgs.Count) i++;
                 continue;
@@ -64,6 +77,7 @@ internal static class AbortResume
         }
         foreach (var e in exclusions) { child.Add("--exclude-test"); child.Add(e); }
         foreach (var f in carryFiles) { child.Add("--merge-counts"); child.Add(f); }
+        foreach (var f in carryResultFiles) { child.Add("--merge-results"); child.Add(f); }
         child.Add("--resume-aborts");
         child.Add(remainingBudget.ToString());
         return child;
@@ -76,10 +90,11 @@ internal static class AbortResume
     /// from.
     /// </summary>
     public static int Rerun(IReadOnlyList<string> originalArgs, IReadOnlyCollection<string> exclusions,
-        int remainingBudget, IReadOnlyCollection<string>? carryFiles = null)
+        int remainingBudget, IReadOnlyCollection<string>? carryFiles = null,
+        IReadOnlyCollection<string>? carryResultFiles = null)
     {
         var childArgs = BuildChildArgs(originalArgs, exclusions, remainingBudget,
-            carryFiles ?? Array.Empty<string>());
+            carryFiles ?? Array.Empty<string>(), carryResultFiles ?? Array.Empty<string>());
 
         Console.Error.WriteLine();
         Console.Error.WriteLine(

--- a/AlRunner/Infrastructure/ParallelFanOut.cs
+++ b/AlRunner/Infrastructure/ParallelFanOut.cs
@@ -35,7 +35,7 @@ internal static class ParallelFanOut
         // Both take a value and both must reach a worker: a shard that lost --exclude-test would
         // walk straight back into the hang the parent already excluded, and one that lost
         // --resume-aborts would fall back to the default budget and start its own resume chain.
-        "--exclude-test", "--resume-aborts", "--merge-counts",
+        "--exclude-test", "--resume-aborts", "--merge-counts", "--merge-results",
     };
 
     /// <summary>

--- a/AlRunner/Infrastructure/ResumeCarry.cs
+++ b/AlRunner/Infrastructure/ResumeCarry.cs
@@ -1,0 +1,122 @@
+// ResumeCarry — the results of one watchdog-resume attempt, carried to the next process (#2719).
+//
+// A resumed run (#2280) re-execs and the final attempt runs only the codeunits no earlier
+// attempt reached, so its `results` list is a SLICE of the run. Two outputs already reassemble
+// the whole: the printed summary (totals, via --merge-counts) and --output-junit (cases copied
+// verbatim, #2716). Three did not, and reported the slice as if it were the run:
+//
+//   --output-json      the tests[] array, its counters, and its own exitCode field
+//   --out PATH         the failure-classification file
+//   --count-baseline   the count compared against the baseline
+//
+// Why this file exists rather than reconstructing from the JUnit the other two already carry.
+// A JUnit <testcase> has a name and a status. It does not have Expectation, and Expectation is
+// what decides whether a failure is a real `fail` or a `pass-known-gap` / `pass-oos` /
+// `pass-divergence` — exactly what --out and the expectations manifest exist to compute. A case
+// reconstructed from XML would arrive with a null Expectation and be classified as an
+// UNEXPECTED failure, so the classification file would go from silently missing the carried
+// error to confidently misclassifying it. Trading a silent omission for a wrong answer is not a
+// fix, so the attempt writes what it actually had.
+//
+// What deliberately does NOT cross the process boundary:
+//
+//   * TestResult.Exception — a live object. FullException already carries its text, which is
+//     everything a later process can use; serialising an exception graph to resurrect it in
+//     another process would be a fiction, not fidelity.
+//   * TestResult.CapturedValues — only ever populated by the server's `execute` with
+//     --capture-values (#1640), which is not a batch run and never resumes.
+//
+// Being explicit about the crossing set is the point. Making TestResult itself serialisable
+// would have quietly carried both of the above the first time someone added a field.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace AlRunner.Infrastructure;
+
+public static class ResumeCarry
+{
+    /// <summary>One test's result, reduced to what survives a process boundary.</summary>
+    public sealed record CarriedTest(
+        string Codeunit, string Method, AlRunner.TestOutcome Outcome, string? Message,
+        string? FullException, long DurationTicks, string? AlCallStack,
+        string? CodeunitDisplayName, ExpectationResult? Expectation,
+        bool InsideTestProc, bool TimedOut, string? Diagnosis);
+
+    /// <summary>One bundle's result. Timings are carried so a resumed run's reported wall time
+    /// is the run's, not the last attempt's.</summary>
+    public sealed record CarriedBucket(
+        string BucketPath, BucketStage Stage, List<string> CompileErrors, string? ProcessError,
+        List<CarriedTest> Tests, long EmitTicks, long CompileTicks, long RunTicks,
+        int RanGroupCount, List<string>? ProvisionGaps);
+
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        WriteIndented = false,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    /// <summary>
+    /// Write ONE attempt's results. The caller must pass only what this process ran — the same
+    /// rule the JUnit carry file follows, and for the same reason: each carry file holds exactly
+    /// one attempt, so a chain of resumes cannot fold an earlier attempt in more than once.
+    /// </summary>
+    public static void Write(string path, IReadOnlyList<BucketResult> results)
+    {
+        var payload = new List<CarriedBucket>(results.Count);
+        foreach (var b in results)
+        {
+            var tests = new List<CarriedTest>(b.Tests.Count);
+            foreach (var t in b.Tests)
+                tests.Add(new CarriedTest(
+                    t.Codeunit, t.Method, t.Outcome, t.Message, t.FullException,
+                    t.Duration.Ticks, t.AlCallStack, t.CodeunitDisplayName, t.Expectation,
+                    t.InsideTestProc, t.TimedOut, t.Diagnosis));
+            payload.Add(new CarriedBucket(
+                b.BucketPath, b.Stage, new List<string>(b.CompileErrors), b.ProcessError, tests,
+                b.EmitTime.Ticks, b.CompileTime.Ticks, b.RunTime.Ticks, b.RanGroupCount,
+                b.ProvisionGaps == null ? null : new List<string>(b.ProvisionGaps)));
+        }
+        File.WriteAllText(path, JsonSerializer.Serialize(payload, Options));
+    }
+
+    /// <summary>
+    /// Read every carry file back into BucketResults, in the order given. A file that is missing
+    /// or will not parse contributes NOTHING rather than failing the run — the same stance
+    /// JUnitReport takes for a carried JUnit, and the reason is the same: the run has already
+    /// happened, and refusing to report it because a scratch file went missing helps nobody.
+    /// It is the quiet direction, which is why the caller says so on stderr (see Program.cs).
+    /// </summary>
+    public static List<BucketResult> Read(IEnumerable<string> paths, out int unreadable)
+    {
+        unreadable = 0;
+        var all = new List<BucketResult>();
+        foreach (var p in paths)
+        {
+            List<CarriedBucket>? payload;
+            try
+            {
+                if (!File.Exists(p)) { unreadable++; continue; }
+                payload = JsonSerializer.Deserialize<List<CarriedBucket>>(File.ReadAllText(p), Options);
+            }
+            catch (Exception) { unreadable++; continue; }
+            if (payload == null) { unreadable++; continue; }
+
+            foreach (var b in payload)
+            {
+                var tests = new List<TestResult>(b.Tests.Count);
+                foreach (var t in b.Tests)
+                    tests.Add(new TestResult(
+                        t.Codeunit, t.Method, t.Outcome, t.Message, t.FullException,
+                        TimeSpan.FromTicks(t.DurationTicks), t.AlCallStack, t.CodeunitDisplayName,
+                        Exception: null, Expectation: t.Expectation, InsideTestProc: t.InsideTestProc,
+                        TimedOut: t.TimedOut, CapturedValues: null, Diagnosis: t.Diagnosis));
+                all.Add(new BucketResult(
+                    b.BucketPath, b.Stage, b.CompileErrors, b.ProcessError, tests,
+                    TimeSpan.FromTicks(b.EmitTicks), TimeSpan.FromTicks(b.CompileTicks),
+                    TimeSpan.FromTicks(b.RunTicks), b.RanGroupCount, b.ProvisionGaps));
+            }
+        }
+        return all;
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -256,6 +256,7 @@ int jobs = 1;   // --jobs N: fan out across N worker processes (#2280)
 int resumeAborts = AlRunner.Infrastructure.AbortResume.DefaultBudget;   // #2280: resume past a watchdog abort
 var excludeTests = new List<string>();   // --exclude-test: skip these, so a run can resume past a watchdog abort (#2280)
 var mergeCountsFiles = new List<string>();   // #2280: totals carried in from earlier resume attempts
+var mergeResultsFiles = new List<string>(); // #2719: full results carried in from earlier resume attempts
 var allAbortReasons = new List<string>();   // #2280: watchdog aborts seen this run, for auto-resume
 // --coverage: statement-level coverage via BC's own StmtHit instrumentation (issue
 // #1922, first slice of #1640). Writes Cobertura XML to --coverage-out (default
@@ -453,6 +454,7 @@ for (int i = 0; i < args.Length; i++)
     }
     if (args[i] == "--exclude-test" && i + 1 < args.Length) { excludeTests.Add(args[++i]); continue; }
     if (args[i] == "--merge-counts" && i + 1 < args.Length) { mergeCountsFiles.Add(args[++i]); continue; }
+    if (args[i] == "--merge-results" && i + 1 < args.Length) { mergeResultsFiles.Add(args[++i]); continue; }
     if (args[i] == "--resume-aborts" && i + 1 < args.Length)
     {
         if (!int.TryParse(args[++i], out resumeAborts) || resumeAborts < 0)
@@ -3603,6 +3605,41 @@ else
 watchCycleIndex++; // the cycle that just finished is no longer "the first cycle"
 } // end while(true) watch loop
 
+// #2719: is this attempt about to hand off to a fresh process? Decided here, ahead of every
+// output, rather than at the resume branch far below, because two outputs must not speak for an
+// attempt that is not the run's last word: --output-json (two attempts each printing one left
+// TWO documents concatenated on stdout, which is not parseable at all — json.loads fails
+// outright, it does not merely read the wrong half) and the count-baseline check (a slice can
+// never match a whole-suite baseline, so it reported a DROP on every resumed run).
+var willResume = resumeAborts > 0
+    && AlRunner.Infrastructure.AbortResumePlan.MakesProgress(allAbortReasons, excludeTests);
+
+// ── The whole run, not this attempt's slice (issue #2719) ───────────────────────────
+// After a watchdog resume this process ran only the codeunits no earlier attempt reached, so
+// `results` is a SLICE. The printed summary and --output-junit already reassemble the run
+// through their own carry channels (--merge-counts, #2280/#2716); these are the three outputs
+// that did not, and each reported the slice as if it were the run:
+//
+//   --output-json      tests[], its counters, AND its own exitCode field
+//   --out PATH         the failure-classification file
+//   --count-baseline   the number compared against the baseline
+//
+// Deliberately a SEPARATE list rather than appending onto `results`: PrintSummary and
+// JUnitReport.WriteJUnit fold the carried attempts in themselves, so a merged `results` would
+// count every carried case twice, once in each shape. Empty carry list => the same object,
+// so a run that never resumed is bit-for-bit unchanged.
+var carriedResults = AlRunner.Infrastructure.ResumeCarry.Read(mergeResultsFiles, out var carryUnreadable);
+if (carryUnreadable > 0)
+    // Never silent: this is the difference between "the run had one error" and "the run was
+    // clean", and a scratch file going missing must not be the quiet reason a run reads green.
+    Console.Error.WriteLine(
+        $"resume: {carryUnreadable} carried result file(s) could not be read, so --output-json, "
+        + "--out and --count-baseline cover only part of this run. The printed summary and "
+        + "--output-junit are unaffected.");
+var allResults = carriedResults.Count == 0
+    ? results
+    : carriedResults.Concat(results).ToList();
+
 // ── Count-baseline check (issue #1880) ──────────────────────────────────────────────
 // Runs once, after every bundle has finished, against the FULL `results` list — same
 // timing as the exit-code computation right below, which it feeds into. See
@@ -3617,7 +3654,18 @@ if (countBaseline != null)
     // runs the SAME al-language root with --test "Codeunit6020"), so a baseline sized
     // for the full suite must not fire here. Loud, not silent: anyone who passes both
     // flags together sees exactly why the guard stood down.
-    if (testFilter != null)
+    if (willResume)
+    {
+        // #2719: this attempt ran a slice and is about to hand the rest to a fresh process, so
+        // comparing it against a whole-suite baseline can only ever report a phantom DROP —
+        // "a bundle may have silently stopped being discovered" is exactly the wrong story to
+        // tell about a watchdog resume. The final attempt carries every earlier attempt's
+        // results and does the real check.
+        Console.Error.WriteLine(
+            "[count-baseline] skipped: this attempt is resuming in a fresh process; the final "
+            + "attempt checks the whole run.");
+    }
+    else if (testFilter != null)
     {
         Console.Error.WriteLine(
             $"[count-baseline] skipped: --test '{testFilter}' narrows scope intentionally.");
@@ -3625,7 +3673,7 @@ if (countBaseline != null)
     else
     {
         var actualBySuite = new Dictionary<string, AlRunner.Infrastructure.SuiteCountActual>();
-        foreach (var b in results)
+        foreach (var b in allResults)   // #2719: the run, not this attempt's slice
         {
             var suiteKey = Path.GetFileName(b.BucketPath.TrimEnd(
                 Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
@@ -3692,7 +3740,11 @@ if (countBaseline != null)
 int computedExitCode = 0;
 {
     int failed = 0, errored = 0, compileFail = 0, execFail = 0;
-    foreach (var b in results)
+    // #2719: allResults, so a resumed run's exitCode field reports the RUN. Before this the
+    // final attempt computed 0 from its own all-passing slice and printed "exitCode": 0 into
+    // --output-json, while AbortResume.Rerun forced the process to exit 1 — the shell said
+    // failed and the JSON said success, each self-consistent from its own vantage point.
+    foreach (var b in allResults)
     {
         if (b.Stage == BucketStage.CompileFailed) { compileFail++; continue; }
         if (b.Stage == BucketStage.ExecuteFailed) { execFail++; continue; }
@@ -3716,9 +3768,17 @@ int computedExitCode = 0;
         : (countBaselineMismatch ? 4 : 0));      // #1880: suite's count didn't exactly match its baseline
 }
 
-if (outputJson)
+if (outputJson && willResume)
 {
-    var json = Reporter.SerializeJsonOutput(results, computedExitCode);
+    // The final attempt prints the whole run. If Rerun then fails to START that attempt it
+    // returns non-zero having printed none, so a consumer gets NO json rather than a wrong one
+    // — louder, and the direction to fail in.
+    Console.Error.WriteLine(
+        "resume: --output-json suppressed for this attempt; the final attempt prints the whole run.");
+}
+else if (outputJson)
+{
+    var json = Reporter.SerializeJsonOutput(allResults, computedExitCode);
     // Restore the real stdout (captured above) so this is the ONLY thing ever
     // written to it — every banner/progress line up to this point went to stderr
     // instead. See the redirect right after arg parsing for why.
@@ -3740,8 +3800,7 @@ else
 // hits a different hang. A resumed attempt re-runs the bundle from the start, so its result
 // REPLACES this one rather than needing to be merged into it; the excluded codeunits are named
 // so the total is not mistaken for a complete one.
-if (resumeAborts > 0
-    && AlRunner.Infrastructure.AbortResumePlan.MakesProgress(allAbortReasons, excludeTests))
+if (willResume)
 {
     // Exclude every codeunit already ATTEMPTED, not just the hung one, so the retry runs only
     // work no attempt has reached. Re-running from the start made a bundle pay for its whole
@@ -3766,7 +3825,20 @@ if (resumeAborts > 0
     var carry = new List<string>(mergeCountsFiles);
     if (carryPath != null) carry.Add(carryPath);
 
-    return AlRunner.Infrastructure.AbortResume.Rerun(args, nextExclusions, resumeAborts - 1, carry);
+    // #2719: the same attempt, in full. A JUnit <testcase> has a name and a status; it has no
+    // Expectation, and Expectation is what decides whether a failure is a real `fail` or a
+    // pass-known-gap / pass-oos / pass-divergence. Rebuilding a carried case from the XML would
+    // hand --out a case with no Expectation, which classifies as an UNEXPECTED failure — turning
+    // a silently missing error into a confidently wrong one. So the attempt writes what it had.
+    // THIS attempt's results only, for the same reason the JUnit carry file holds one attempt.
+    var carryResultsPath = Path.Combine(carryDir, "attempt-results.json");
+    try { AlRunner.Infrastructure.ResumeCarry.Write(carryResultsPath, results); }
+    catch { carryResultsPath = null!; }
+    var carryResults = new List<string>(mergeResultsFiles);
+    if (carryResultsPath != null) carryResults.Add(carryResultsPath);
+
+    return AlRunner.Infrastructure.AbortResume.Rerun(
+        args, nextExclusions, resumeAborts - 1, carry, carryResults);
 }
 if (tddMode)
 {
@@ -3794,7 +3866,7 @@ if (tddMode)
 }
 if (outPath != null)
 {
-    Reporter.WriteClassification(results, outPath);
+    Reporter.WriteClassification(allResults, outPath);   // #2719: the run, not this attempt's slice
     // In --output-json mode this must not land on stdout (it already printed the
     // JSON above and restored the real stdout writer) — route to stderr there.
     (outputJson ? Console.Error : Console.Out).WriteLine($"Classification → {outPath}");

--- a/AlRunner/ProgramSupport/CliText.cs
+++ b/AlRunner/ProgramSupport/CliText.cs
@@ -417,6 +417,13 @@ internal static partial class ProgramSupport
         w.WriteLine("                          automatically by --resume-aborts to carry earlier attempts");
         w.WriteLine("                          forward, and reported on its own summary line so a resumed");
         w.WriteLine("                          total is never mistaken for one clean run's.");
+        w.WriteLine("  --merge-results PATH    Fold a carried attempt's FULL results into --output-json, --out");
+        w.WriteLine("                          and --count-baseline; repeatable. Set automatically by");
+        w.WriteLine("                          --resume-aborts alongside --merge-counts, which covers the");
+        w.WriteLine("                          summary and --output-junit. Separate because a JUnit test");
+        w.WriteLine("                          case has no expectation classification, so a case rebuilt");
+        w.WriteLine("                          from one would read as an unexpected failure rather than as");
+        w.WriteLine("                          the pass-known-gap / pass-oos it was.");
         w.WriteLine("  --resume-aborts N       How many times a run may re-run itself in a fresh process");
         w.WriteLine("                          after a watchdog abort, each time excluding the codeunit");
         w.WriteLine("                          that hung, and every codeunit already attempted, so the");
@@ -425,8 +432,9 @@ internal static partial class ProgramSupport
         w.WriteLine("                          rest of its bundle and cannot be continued in-process (the");
         w.WriteLine("                          hung thread is never killed and keeps mutating shared");
         w.WriteLine("                          state), so a fresh process is the only safe way on. Earlier");
-        w.WriteLine("                          attempts\' totals are carried forward via --merge-counts, so");
-        w.WriteLine("                          the final summary covers the whole run; tests inside an");
+        w.WriteLine("                          attempts\' totals are carried forward via --merge-counts and");
+        w.WriteLine("                          their full results via --merge-results, so every output");
+        w.WriteLine("                          covers the whole run; tests inside an");
         w.WriteLine("                          excluded codeunit are not counted, and the run never reports");
         w.WriteLine("                          clean success because they did not run.");
         w.WriteLine("  --exclude-test PATTERN  Skip tests matching PATTERN; repeatable. PATTERN is a whole");


### PR DESCRIPTION
Closes #2719

After a watchdog resume (#2280) the final attempt runs only the codeunits no earlier attempt reached, so its `results` list is a **slice** of the run. The printed summary and `--output-junit` already reassemble the whole through `--merge-counts` (#2280, #2716). Three outputs did not.

## The issue title understates it

Measured on the existing two-codeunit resume fixture, whose truth is **4 tests / 1 error / 3 passed**:

- **`--output-json` emitted TWO JSON documents on stdout**, one per attempt. That is not "sees only the final attempt" — `json.loads(stdout)` **fails outright**.
- The final document read `total=2 passed=2 failed=0 errors=0 exitCode=0` — a **completely clean run** — while the process exited non-zero. **The shell said failed and the JSON said success**, each self-consistent from its own vantage point, which is exactly why this survived. A consumer that trusts the JSON over the exit code — an IDE integration, a dashboard, an agent — read a green run.
- **`--out`** wrote `total_failures: 0` with empty arrays, for a run with an error.
- **`--count-baseline` contradicted itself inside one log**: `DROP: expected 4, actual 2 — a bundle may have silently stopped being discovered` a few lines above `Tests: 4 total`, and it fired on **both** attempts.

Given how many measurements get built on resumed runs, that is worth stating plainly rather than leaving in the diff.

## The fix, and why not the cheaper one

A per-attempt JSON sidecar (`Infrastructure.ResumeCarry`) written beside the JUnit carry file and forwarded as `--merge-results`, parallel to `--merge-counts`.

**Why not rebuild the carried cases from the JUnit already being carried.** A `<testcase>` has a name and a status, and no `Expectation`. `Expectation` is what decides whether a failure is a real `fail` or a `pass-known-gap` / `pass-oos` / `pass-divergence` — precisely what `--out` and the expectations manifest exist to compute. A case rebuilt from XML arrives with a null `Expectation` and classifies as an **unexpected failure**, so the classification file would go from *silently missing* the carried error to *confidently misclassifying* it. Trading a silent omission for a wrong answer is not a fix.

**An explicit DTO, not a serialisable `TestResult`.** Two things deliberately do not cross the process boundary: the live `Exception` (`FullException` already carries its text; rebuilding an exception object in another process would be fiction dressed as fidelity) and `CapturedValues` (server `execute` only, never a batch resume). Making `TestResult` itself serialisable would have carried both the first time someone added a field.

**Carried results go into a separate `allResults`,** not appended to `results` — `PrintSummary` and `JUnitReport.WriteJUnit` fold the carried attempts in through their own channels, so a merged `results` would count every carried case twice, once per output shape. An empty carry list yields the same object, so a run that never resumed is unchanged.

## Two corrections from the same `willResume` decision

Taken once, ahead of every output:

- **`--output-json` is suppressed on an attempt that is about to hand off**, so stdout carries exactly one document. If `Rerun` then fails to *start* the next attempt it returns non-zero having printed none, so a consumer gets **no** json rather than a wrong one. Louder is the right direction to fail in, and it is worth writing down.
- **the count-baseline check is skipped on such an attempt.** A slice can never match a whole-suite baseline, so it reported a phantom DROP on every resumed run — and "a bundle may have silently stopped being discovered" is the wrong story to tell about a watchdog resume.

## Behaviour change worth calling out

A resumed run's **exit code now describes the run**. Before, the final attempt computed `0` from its own all-passing slice and `AbortResume.Rerun` forced a generic `1`. Now the fixture exits **3** — the same code a **non-resumed** run of that same fixture exits, because the bucket carries the watchdog abort in `CompileErrors`. Still always non-zero (`Rerun`'s forcing remains as the backstop), and now consistent with the un-resumed run instead of compensating for a wrong number.

## After

All four outputs agree on the run: stdout is **one** document with `total=4 passed=3 errors=1` and `exitCode` equal to the process exit; `--out` reports the carried suite abort and the `Hangs` error; `--output-junit` is still 4 cases, not 8; the baseline of 4 is met with no DROP.

## Tests

`ResumeCarryTests` drives the DTO directly: round-trip keeps `Expectation`, `Diagnosis` and `CodeunitDisplayName`, drops the `Exception` and `CapturedValues`, counts unreadable files instead of swallowing them, and concatenates a chain in order.

`SuiteAbortOnTimeoutTests` gains **one** end-to-end spawn asserting all four outputs agree — that is the actual claim, so they are checked together rather than one per test. It needed a stdout/stderr-**separated** capture, because the existing merged one cannot tell a second JSON document from an ordinary stderr line following the first; that is what made my own first version of the test fail for the wrong reason.

Reverting the three behaviours fails it on the real pre-fix symptom:

```
stdout held MORE than one JSON document — a consumer's json.loads fails outright.
```

Ran after rebasing onto `main`: `SuiteAbortOnTimeoutTests`, `ResumeCarryTests`, `CliDocumentationTests`, `AbortResume`, `ParallelFanOut`, `JUnitReport`, `Reporter` — **92 passed**. `--help` documents `--merge-results`, so the `CliDocumentationTests` gate passes.

## Shape check

- **Same wrong pattern elsewhere?** `--output-junit` and the printed summary were the other two `results` consumers; both were already fixed (#2716, #2280) and are deliberately left alone here.
- **Sibling assumption?** `ParallelFanOut`'s pass-through list needed `--merge-results` too, or a shard would drop it. Added.
- **Same-state invariant?** `AbortResume.BuildChildArgs` strips and re-adds `--merge-results` exactly as it does `--merge-counts`, so a chain of resumes replaces rather than appends to itself.
- **Not changed:** `test-count-baseline.json`. This alters how `--count-baseline` *counts*, not what the corpus contains; the value read in place is still `2464` at the time of this rebase, and #2808's bump to 2523 is independent.

Written by agent impl-5.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
