### PR TITLE
fix(resume): refuse to report a run whose carried attempt files went missing

### DIFF
--- a/AlRunner.Tests/CarriedAttemptFilesTests.cs
+++ b/AlRunner.Tests/CarriedAttemptFilesTests.cs
@@ -1,0 +1,155 @@
+// CarriedAttemptFilesTests — a promised attempt that is not here must not pass quietly (#2747).
+//
+// The distinction this class exists to draw, and every test below is about which side of it a
+// given file falls on:
+//
+//   * a file NEVER NAMED — nothing was promised, nothing is missing. Every run that did not
+//     resume is in this case, and must be completely unaffected.
+//   * a file NAMED and usable — the ordinary resume. Also unaffected.
+//   * a file NAMED and not usable — a promised attempt vanished. Whatever the run reports omits
+//     it, so the run may not present itself as complete.
+//
+// The third case used to be silent: JUnitReport.LoadCarriedSuites skipped it and JUnitCounts.Read
+// returned zeros, so the child finished, found nothing, and reported a SMALLER run with exit 0.
+// The carry directory is owned by the PARENT attempt, which waits while the child runs, so
+// killing the parent alone loses the file for the child's entire run — either because SIGTERM
+// ran its ProcessExit and deleted the directory, or because SIGKILL left an owner that is dead
+// and the next runner start swept it correctly.
+
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class CarriedAttemptFilesTests : IDisposable
+{
+    private readonly string _dir = TestScratch.Dir("al-runner-carried-attempt-tests");
+
+    public CarriedAttemptFilesTests() => Directory.CreateDirectory(_dir);
+    public void Dispose() => ScratchDirs.Release(_dir);
+
+    private string Write(string name, string content)
+    {
+        var p = Path.Combine(_dir, name);
+        File.WriteAllText(p, content);
+        return p;
+    }
+
+    private string GoodJUnit(string name = "good.xml") => Write(name,
+        """<testsuites><testsuite name="s" tests="1"><testcase classname="C" name="T"/></testsuite></testsuites>""");
+
+    private string GoodResults(string name = "good.json")
+    {
+        var p = Path.Combine(_dir, name);
+        ResumeCarry.Write(p, new[]
+        {
+            new BucketResult("/b", BucketStage.Ran, Array.Empty<string>(), null,
+                new[] { new TestResult("C", "T", TestOutcome.Pass, null, null, TimeSpan.Zero) },
+                TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero),
+        });
+        return p;
+    }
+
+    [Fact]
+    public void NoFilesNamed_IsClean_SoANonResumedRunIsUntouched()
+    {
+        // The case every ordinary run is in. If this ever reported a loss, every run on the
+        // machine would start failing.
+        Assert.Empty(CarriedAttemptFiles.Audit(Array.Empty<string>(), Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void UsableFiles_AreClean()
+    {
+        Assert.Empty(CarriedAttemptFiles.Audit(new[] { GoodJUnit() }, new[] { GoodResults() }));
+    }
+
+    [Fact]
+    public void AMissingJUnit_IsReported_NotSkipped()
+    {
+        // The defect verbatim: this is what the child sees after the parent's scratch directory
+        // went away, and it used to contribute nothing in silence.
+        var missing = Path.Combine(_dir, "gone.xml");
+
+        var bad = CarriedAttemptFiles.Audit(new[] { missing }, Array.Empty<string>());
+
+        var one = Assert.Single(bad);
+        Assert.Equal(missing, one.Path);
+        Assert.Contains("gone", one.Reason);
+    }
+
+    [Fact]
+    public void AMissingResultsSidecar_IsReported_Too()
+    {
+        // Both channels or neither: a report is complete or it is not, and #2719's sidecar can
+        // vanish exactly the same way the JUnit can — same directory, same owner, same kill.
+        var missing = Path.Combine(_dir, "gone.json");
+
+        var one = Assert.Single(CarriedAttemptFiles.Audit(Array.Empty<string>(), new[] { missing }));
+
+        Assert.Equal(missing, one.Path);
+        Assert.Contains("gone", one.Reason);
+    }
+
+    [Fact]
+    public void ATruncatedJUnit_IsReported()
+    {
+        // What a kill mid-write leaves: well-formed enough to load, no suites in it. Reported,
+        // because an attempt only ever writes a carry file when it HAS results — "no suites"
+        // cannot be an honest attempt.
+        var truncated = Write("truncated.xml", "<testsuites></testsuites>");
+
+        var one = Assert.Single(CarriedAttemptFiles.Audit(new[] { truncated }, Array.Empty<string>()));
+
+        Assert.Contains("no testsuite", one.Reason);
+    }
+
+    [Fact]
+    public void ACorruptJUnit_IsReported()
+    {
+        var corrupt = Write("corrupt.xml", "<testsuites><not closed");
+
+        var one = Assert.Single(CarriedAttemptFiles.Audit(new[] { corrupt }, Array.Empty<string>()));
+
+        Assert.Contains("will not parse", one.Reason);
+    }
+
+    [Fact]
+    public void ACorruptResultsSidecar_IsReported()
+    {
+        var corrupt = Write("corrupt.json", "{ not json");
+
+        var one = Assert.Single(CarriedAttemptFiles.Audit(Array.Empty<string>(), new[] { corrupt }));
+
+        Assert.Contains("will not parse", one.Reason);
+    }
+
+    [Fact]
+    public void EveryLostFileIsNamed_NotJustCounted()
+    {
+        // Which attempt was lost is the first thing anyone asks, so the message lists each path
+        // with its own reason rather than reporting a count.
+        var missingXml = Path.Combine(_dir, "a.xml");
+        var corruptJson = Write("b.json", "nope");
+
+        var bad = CarriedAttemptFiles.Audit(new[] { missingXml, GoodJUnit() }, new[] { corruptJson });
+        var text = CarriedAttemptFiles.Describe(bad);
+
+        Assert.Equal(2, bad.Count);
+        Assert.Contains(missingXml, text);
+        Assert.Contains(corruptJson, text);
+        Assert.DoesNotContain(GoodJUnit("good.xml"), text.Replace(missingXml, "").Replace(corruptJson, ""));
+        Assert.Contains("#2747", text);
+        // The run's own results are still valid; it is the TOTAL that cannot be trusted. Saying
+        // so stops the next reader discarding a run that mostly worked.
+        Assert.Contains("still printed above", text);
+    }
+
+    [Fact]
+    public void AnEmptyPathEntry_IsNotAPromise()
+    {
+        // Program.cs can carry an empty string when writing a carry file failed outright; that
+        // is not a vanished attempt, it is an attempt that never wrote one.
+        Assert.Empty(CarriedAttemptFiles.Audit(new[] { "" }, new[] { "" }));
+    }
+}

--- a/AlRunner.Tests/SuiteAbortOnTimeoutTests.cs
+++ b/AlRunner.Tests/SuiteAbortOnTimeoutTests.cs
@@ -400,6 +400,57 @@ public sealed class SuiteAbortOnTimeoutTests : IDisposable
     }
 
     /// <summary>
+    /// #2747: a carried attempt that was PROMISED and is not there must fail the run loudly,
+    /// not shrink the report in silence.
+    ///
+    /// Reproduced deterministically by naming a carry file that does not exist, rather than by
+    /// racing a kill: how the file goes missing (SIGTERM running the parent's ProcessExit and
+    /// deleting the scratch directory it owns, or SIGKILL leaving a dead owner for the next
+    /// runner start to sweep correctly) does not change what the child then does with it, and
+    /// the silence was unconditional on the cause.
+    ///
+    /// Before this the same command exited 0 with a JUnit holding only the final attempt.
+    /// </summary>
+    [SkippableFact]
+    public void CarriedAttemptFileGone_FailsLoudly_InsteadOfShrinkingTheReport()
+    {
+        TestArtifacts.SkipIfMissing();
+        var dir = Path.Combine(_resumeRoot, "out3");
+        Directory.CreateDirectory(dir);
+        var missingJUnit = Path.Combine(dir, "attempt-that-vanished.xml");
+        var junit = Path.Combine(dir, "final.xml");
+
+        var (output, exit) = RunRunner(_resumeRoot, 180_000,
+            "--test-timeout 2", "--resume-aborts 0",
+            $"--merge-counts \"{missingJUnit}\"", $"--output-junit \"{junit}\"");
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("#2747", output);
+        // The lost attempt is named, because "which one?" is the first question.
+        Assert.Contains(missingJUnit, output);
+        // And the run's own results are not thrown away with it — only the total is untrusted.
+        Assert.Contains("still printed above", output);
+    }
+
+    /// <summary>
+    /// #2747 negative, and the one that matters most: a run handed NO carry files is untouched.
+    /// Every run that never resumed is in this case, so a false positive here would fail every
+    /// run on the machine.
+    /// </summary>
+    [SkippableFact]
+    public void NoCarriedAttemptFiles_IsNotTreatedAsALoss()
+    {
+        TestArtifacts.SkipIfMissing();
+        var junit = Path.Combine(_resumeRoot, "out4", "final.xml");
+        Directory.CreateDirectory(Path.GetDirectoryName(junit)!);
+
+        var (output, _) = RunRunner(_resumeRoot, 180_000,
+            "--test-timeout 2", "--resume-aborts 0", $"--output-junit \"{junit}\"");
+
+        Assert.DoesNotContain("#2747", output);
+    }
+
+    /// <summary>
     /// #2716 negative: with resume disabled the same fixture writes exactly attempt 1's two
     /// cases — nothing is carried in from nowhere, and the count is not inflated.
     /// </summary>

--- a/AlRunner/Infrastructure/CarriedAttemptFiles.cs
+++ b/AlRunner/Infrastructure/CarriedAttemptFiles.cs
@@ -1,0 +1,106 @@
+// CarriedAttemptFiles — is every attempt this run was PROMISED actually here? (issue #2747)
+//
+// A watchdog resume (#2280) hands the next process one file per earlier attempt: a JUnit for the
+// summary and --output-junit (--merge-counts), and since #2719 a JSON sidecar for --output-json,
+// --out and --count-baseline (--merge-results). Both readers were written to shrug at a file
+// they cannot use — JUnitReport.LoadCarriedSuites skips it, JUnitCounts.Read returns zero
+// totals — and for a CORRUPT file that is the right instinct: the run already happened, and one
+// unreadable scratch file is not a verdict on it.
+//
+// It is the wrong instinct for a file that is simply GONE, because of how it goes gone. The
+// carry directory is owned by the attempt that wrote it (ScratchDirs, #2706), and that attempt
+// is the PARENT, which then sits waiting while the child runs. The child does not read the
+// carry files until it writes its own outputs, at the very end — so the window is the child's
+// entire run, not an instant. Two ways the parent's death takes the file with it:
+//
+//   * SIGTERM to the parent alone — its ProcessExit handler runs and deletes the directory it
+//     owns, while the child is still running;
+//   * SIGKILL to the parent alone — nothing runs, but the owner is now dead, so the next runner
+//     start anywhere on the machine sweeps the directory correctly and legitimately.
+//
+// On a busy machine under --jobs the second is the more likely one. In both cases the child
+// finishes, finds the file absent, silently omits every earlier attempt, and reports a SMALLER
+// run as a clean one. That is the failure mode this repository treats as the worst kind: a
+// result that shrank without saying so, wearing exit code 0.
+//
+// So this class draws the line the readers could not: a file NAMED on the command line and not
+// usable is a promised input that vanished, and the run may not report as if it never existed.
+// A missing carry file is not a reason to discard the run's own results — the summary and the
+// exit code still describe what this process ran — it is a reason to refuse to present the
+// report as complete.
+
+using System.Xml.Linq;
+
+namespace AlRunner.Infrastructure;
+
+public static class CarriedAttemptFiles
+{
+    /// <summary>Why one named carry file could not contribute.</summary>
+    public sealed record Unusable(string Path, string Reason);
+
+    /// <summary>
+    /// Every file named by <c>--merge-counts</c> / <c>--merge-results</c> that cannot contribute.
+    /// Empty for a run that was handed none, which is every run that never resumed.
+    /// </summary>
+    public static List<Unusable> Audit(
+        IEnumerable<string> junitFiles, IEnumerable<string> resultFiles)
+    {
+        var bad = new List<Unusable>();
+        foreach (var f in junitFiles) { var r = JUnitProblem(f); if (r != null) bad.Add(new Unusable(f, r)); }
+        foreach (var f in resultFiles) { var r = ResultsProblem(f); if (r != null) bad.Add(new Unusable(f, r)); }
+        return bad;
+    }
+
+    private static string? JUnitProblem(string path)
+    {
+        if (string.IsNullOrEmpty(path)) return null;   // never named; nothing was promised
+        if (!File.Exists(path))
+            return "the file is gone — most likely deleted with the scratch directory of the "
+                 + "attempt that wrote it (see this file's header)";
+        try
+        {
+            var root = XDocument.Load(path).Root;
+            if (root == null) return "the file is empty";
+            var suites = root.Name.LocalName == "testsuite"
+                ? 1
+                : root.Elements("testsuite").Count();
+            // Zero suites is what an attempt killed mid-write leaves behind, and it is
+            // indistinguishable from an attempt that genuinely ran nothing — which cannot
+            // happen, because an attempt only writes a carry file when it HAS results.
+            return suites > 0 ? null : "the file holds no testsuite elements (truncated?)";
+        }
+        catch (Exception ex) { return $"the file will not parse as JUnit ({ex.GetType().Name})"; }
+    }
+
+    private static string? ResultsProblem(string path)
+    {
+        if (string.IsNullOrEmpty(path)) return null;
+        if (!File.Exists(path))
+            return "the file is gone — most likely deleted with the scratch directory of the "
+                 + "attempt that wrote it (see this file's header)";
+        try
+        {
+            var back = ResumeCarry.Read(new[] { path }, out var unreadable);
+            if (unreadable > 0) return "the file will not parse as carried results";
+            return back.Count > 0 ? null : "the file holds no buckets (truncated?)";
+        }
+        catch (Exception ex) { return $"the file will not parse as carried results ({ex.GetType().Name})"; }
+    }
+
+    /// <summary>The message a run prints before refusing to report as complete. One line per
+    /// file, because which attempt was lost is the first thing anyone will ask.</summary>
+    public static string Describe(IReadOnlyList<Unusable> bad)
+    {
+        var lines = new List<string>
+        {
+            $"resume: {bad.Count} carried attempt file(s) named on the command line could not be "
+            + "used, so this run's report would silently omit whole attempts. Refusing to report "
+            + "it as complete (issue #2747):",
+        };
+        foreach (var b in bad) lines.Add($"  {b.Path}: {b.Reason}");
+        lines.Add(
+            "The results THIS process produced are still printed above and are unaffected; what "
+            + "cannot be trusted is the total, so treat this run as incomplete and re-run it.");
+        return string.Join(Environment.NewLine, lines);
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3667,14 +3667,19 @@ var willResume = resumeAborts > 0
 // JUnitReport.WriteJUnit fold the carried attempts in themselves, so a merged `results` would
 // count every carried case twice, once in each shape. Empty carry list => the same object,
 // so a run that never resumed is bit-for-bit unchanged.
-var carriedResults = AlRunner.Infrastructure.ResumeCarry.Read(mergeResultsFiles, out var carryUnreadable);
-if (carryUnreadable > 0)
-    // Never silent: this is the difference between "the run had one error" and "the run was
-    // clean", and a scratch file going missing must not be the quiet reason a run reads green.
-    Console.Error.WriteLine(
-        $"resume: {carryUnreadable} carried result file(s) could not be read, so --output-json, "
-        + "--out and --count-baseline cover only part of this run. The printed summary and "
-        + "--output-junit are unaffected.");
+var carriedResults = AlRunner.Infrastructure.ResumeCarry.Read(mergeResultsFiles, out _);
+
+// #2747: every attempt this run was PROMISED must actually be here. Both carry readers shrug at
+// a file they cannot use — right for a corrupt one, wrong for a file that is simply GONE,
+// because the carry directory is owned by the PARENT attempt, which then waits while the child
+// runs. Kill the parent alone (SIGTERM runs its ProcessExit and deletes the directory; SIGKILL
+// leaves an owner that is dead, so the next runner start sweeps it correctly) and the child
+// finishes, finds nothing, and reports a SMALLER run as a clean one. Audited in ONE place for
+// BOTH channels, because a report is complete or it is not — it cannot be half-trusted.
+var carryLosses = AlRunner.Infrastructure.CarriedAttemptFiles.Audit(mergeCountsFiles, mergeResultsFiles);
+var carryIncomplete = carryLosses.Count > 0;
+if (carryIncomplete)
+    Console.Error.WriteLine(AlRunner.Infrastructure.CarriedAttemptFiles.Describe(carryLosses));
 var allResults = carriedResults.Count == 0
     ? results
     : carriedResults.Concat(results).ToList();
@@ -3802,7 +3807,11 @@ int computedExitCode = 0;
         }
     }
     computedExitCode = compileFail > 0 ? 3       // compile errors
-        : execFail > 0 ? 2                       // bucket-level execution error
+        // #2747: a carried attempt was promised and is not here, so whatever this run reports
+        // omits it. Ranked above a plain test failure because it is not a statement about the
+        // AL at all — it says the REPORT cannot be trusted, which a consumer must not read as
+        // "some tests failed". Below a compile failure, which is the more fundamental problem.
+        : (execFail > 0 || carryIncomplete) ? 2  // bucket-level execution error, or a lost attempt
         : (failed + errored > 0 ? 1               // at least one test failed
         : (countBaselineMismatch ? 4 : 0));      // #1880: suite's count didn't exactly match its baseline
 }


### PR DESCRIPTION
Closes #2747

A watchdog resume hands the next process one file per earlier attempt: a JUnit for the summary and `--output-junit` (`--merge-counts`), and since #2719 a JSON sidecar for `--output-json`, `--out` and `--count-baseline` (`--merge-results`). Both readers shrug at a file they cannot use — `LoadCarriedSuites` skips it, `JUnitCounts.Read` returns zeros. For a **corrupt** file that is the right instinct: the run already happened, and one unreadable scratch file is not a verdict on it.

It is the wrong instinct for a file that is simply **gone**, because of how it goes gone.

## The mechanism

The carry directory is owned by the attempt that wrote it (`ScratchDirs`, #2706), and that attempt is the **parent**, which then sits waiting while the child runs. The child does not read the carry files until it writes its own outputs, at the very end — so the window is the child's **entire run**, not an instant. Two ways the parent's death takes the file with it:

- **SIGTERM to the parent alone** — its `ProcessExit` handler runs and deletes the directory it owns, while the child is still running.
- **SIGKILL to the parent alone** — nothing runs, but the owner is now dead, so the next runner start anywhere on the machine sweeps the directory correctly and legitimately.

On a busy box under `--jobs`, the second is the likelier one. Either way the child finishes, finds the file absent, silently omits every earlier attempt, and reports a **smaller** run as a clean one with exit 0.

## Reproduced deterministically — and not by racing a kill

I did not reproduce the race, and did not need to: **how** the file goes missing does not change what the child then does with it, and the silence is unconditional on the cause. Naming a carry file that does not exist produces the identical defect on demand.

Measured before this change, with both channels named and absent:

| | before |
|---|---|
| `--merge-results` loss | printed the #2719 warning |
| `--merge-counts` loss | **printed nothing at all** |
| `--output-junit` | 1 testcase instead of the run |
| exit code | **0** |

## The fix

Draw the line the readers could not. A file **named on the command line** and not usable is a promised input that vanished, and the run may not report as if it never existed.

`CarriedAttemptFiles.Audit` checks **both** channels in one place — a report is complete or it is not, it cannot be half-trusted — names every lost file with its own reason, and forces **exit 2**.

## The three directions, evaluated

The issue sketched three and evaluated none. This is the only one that removes the silence:

- **"Keep the file, not just the totals"** — cannot work as written. The parent writes the carry file *before* the child exists, so there is no child scratch space to write it into.
- **"Hand ownership to the child"** — this does work. After `Process.Start` the parent knows the child's pid and could rewrite the `.owner` sidecar and disown the directory, which would remove the dominant *cause*. But it lowers the **probability** of loss without removing the **silence** when loss still happens — a `/tmp` cleaner, a full disk, an operator `rm`. So it cannot substitute for this fix, and it deserves judging on its own merits rather than being folded in. Filing separately.
- **"Make the loss loud"** — this PR. A JUnit that silently omits attempts is worse than a run that refuses to present one.

## Exit 2, not 1

This is not a statement about the AL at all. It says the **report** cannot be trusted, which a consumer must not read as "some tests failed". Ranked below a compile failure, which is the more fundamental problem.

The run's own results are still printed and still valid, and the message says so explicitly — so nobody discards a run that mostly worked:

```
resume: 2 carried attempt file(s) named on the command line could not be used, so this run's
report would silently omit whole attempts. Refusing to report it as complete (issue #2747):
  /…/gone.xml: the file is gone — most likely deleted with the scratch directory of the attempt that wrote it
  /…/gone.json: the file is gone — most likely deleted with the scratch directory of the attempt that wrote it
The results THIS process produced are still printed above and are unaffected; what cannot be
trusted is the total, so treat this run as incomplete and re-run it.
```

## Tests

`CarriedAttemptFilesTests` pins which side of the line each case falls on: never named (every non-resumed run), named and usable, named and missing, truncated, corrupt, both channels, and that every lost file is **named** rather than counted.

`SuiteAbortOnTimeoutTests` gains the end-to-end pair — a named-but-missing carry file fails loudly and names the file, and **a run handed no carry files is unaffected**. That negative control matters most: a false positive there would fail every run on the machine.

Reverting the check fails the positive test and leaves the negative passing.

Verified by hand as well: an ordinary run exits 0 with no message, and a **real** resume with its carry files present still exits as before with all attempts in the JUnit.

Ran after rebasing onto `main`: `SuiteAbortOnTimeoutTests`, `CarriedAttemptFilesTests`, `ResumeCarryTests`, `JUnitReport`, `AbortResume`, `ParallelFanOut`, `Reporter`, `CliDocumentationTests` — **115 passed**. No new CLI flag, so nothing to document in `--help`. `test-count-baseline.json` untouched; read in place at `2496` after the rebase.

Written by agent impl-5.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
