### PR TITLE
fix(session): refuse StartSession inside a test codeunit, as BC does

### DIFF
--- a/AlRunner.Tests/StartSessionIsolationGuardTests.cs
+++ b/AlRunner.Tests/StartSessionIsolationGuardTests.cs
@@ -1,0 +1,119 @@
+// StartSessionIsolationGuardTests — the plumbing behind #2805's StartSession guard.
+//
+// BC refuses StartSession called from inside a test codeunit unless the TestRunner declares
+// TestIsolation = Disabled. It is the FIRST statement of ALSession.ALStartSessionAsyncImpl,
+// before the timeout check and before a session id is assigned:
+//
+//     if (session.TestExecution != null
+//         && (!session.TestExecution.CommitTestCodeunits
+//             || !session.TestExecution.CommitTestFunctions))
+//         throw new NavTestStartSessionNotAllowedException();
+//
+// BcRuntime.AlRunnerStartSession now mirrors it, reading two ambient facts: whether a [Test]
+// body is executing (BcRuntime.InTestExecutionScope, off BC's own executingTestCodeUnit field)
+// and this run's isolation mode (TestExecutor.ActiveIsolation).
+//
+// The REFUSAL itself is proved end-to-end by the corpus — codeunit 60397 in
+// session/TestStartSessionRecord.al, green on all eight BC versions and adjudicated by a real
+// service tier, which is the only thing that can settle what BC does. These tests pin the half
+// the corpus cannot see: that ActiveIsolation actually tracks the executor, and that the
+// message text is the one the corpus matches on.
+//
+// Why that matters rather than being a tautology: the guard is CONDITIONAL. If ActiveIsolation
+// silently stopped following the executor's Isolation property, the guard would keep reading
+// whatever it last saw — refusing under Disabled, or permitting under Codeunit — and every
+// symptom would look like a test-authoring mistake rather than a stale global. Nothing else
+// covers that, because the corpus only ever runs under Codeunit isolation.
+
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class StartSessionIsolationGuardTests
+{
+    // The exact substring the corpus asserts (Assert.ExpectedError is a StrPos match), and the
+    // one the adapted runner-extras tests assert too. Duplicated here deliberately: if the
+    // runner's wording drifts, this fails fast in the unit suite instead of only surfacing on
+    // an eight-leg corpus run.
+    private const string CorpusPinnedSubstring =
+        "can only be started in tests that are run by a TestRunner that has TestIsolation set to Disabled";
+
+    [Fact]
+    public void TheRefusalMessage_ContainsTheSubstringTheCorpusPins()
+    {
+        var ex = BcRuntime.MakeStartSessionNotAllowedInTestException();
+
+        Assert.Contains(CorpusPinnedSubstring, ex.Message, StringComparison.Ordinal);
+        // BC's full sentence, so a reader of the runner's output sees what BC would have said.
+        Assert.Equal(
+            "Sessions can only be started in tests that are run by a TestRunner that has "
+            + "TestIsolation set to Disabled.",
+            ex.Message);
+    }
+
+    [Theory]
+    [InlineData(TestIsolation.Codeunit)]
+    [InlineData(TestIsolation.Test)]
+    [InlineData(TestIsolation.Disabled)]
+    public void ActiveIsolation_FollowsTheExecutorThatWasConfigured(TestIsolation mode)
+    {
+        var previous = TestExecutor.ActiveIsolation;
+        try
+        {
+            var executor = new TestExecutor { Isolation = mode };
+
+            Assert.Equal(mode, executor.Isolation);
+            Assert.Equal(mode, TestExecutor.ActiveIsolation);
+        }
+        finally
+        {
+            new TestExecutor { Isolation = previous };
+        }
+    }
+
+    [Fact]
+    public void ActiveIsolation_ReflectsTheMostRecentlyConfiguredExecutor()
+    {
+        // The guard reads a static because it is called from a BC seam with no executor in
+        // hand. This pins the consequence: the LAST executor configured wins, which is correct
+        // for the runner's one-executor-at-a-time model and is exactly the assumption that
+        // would break silently if that model ever changed.
+        var previous = TestExecutor.ActiveIsolation;
+        try
+        {
+            new TestExecutor { Isolation = TestIsolation.Codeunit };
+            Assert.Equal(TestIsolation.Codeunit, TestExecutor.ActiveIsolation);
+
+            new TestExecutor { Isolation = TestIsolation.Disabled };
+            Assert.Equal(TestIsolation.Disabled, TestExecutor.ActiveIsolation);
+
+            // And back, so this is not passing on a one-way latch.
+            new TestExecutor { Isolation = TestIsolation.Codeunit };
+            Assert.Equal(TestIsolation.Codeunit, TestExecutor.ActiveIsolation);
+        }
+        finally
+        {
+            new TestExecutor { Isolation = previous };
+        }
+    }
+
+    [Fact]
+    public void ADefaultExecutor_IsCodeunitIsolation_SoTheGuardIsArmedUnlessAskedOtherwise()
+    {
+        // Negative direction for the whole feature: if the default were Disabled, the guard
+        // would be inert for every ordinary run and #2805 would still be open while looking
+        // fixed.
+        var previous = TestExecutor.ActiveIsolation;
+        try
+        {
+            var executor = new TestExecutor();
+            Assert.Equal(TestIsolation.Codeunit, executor.Isolation);
+            Assert.NotEqual(TestIsolation.Disabled, TestExecutor.ActiveIsolation);
+        }
+        finally
+        {
+            new TestExecutor { Isolation = previous };
+        }
+    }
+}

--- a/AlRunner/Patches/MetadataPatches.cs
+++ b/AlRunner/Patches/MetadataPatches.cs
@@ -94,6 +94,30 @@ public static partial class BcRuntime
     /// only the per-test flag is undone; the process-lifetime SetTestTenantEnvironmentType(true)
     /// tuple set by EnterTestExecutionScope's first call is intentionally left in place.
     /// </summary>
+    /// <summary>
+    /// True while a <c>[Test]</c> method is executing — the runner's answer to BC's own
+    /// <c>session.TestExecution != null</c>.
+    ///
+    /// <para>Read straight off BC's <c>NavTestExecution.executingTestCodeUnit</c>, the very field
+    /// <see cref="EnterTestExecutionScope(object, MethodInfo?)"/> pokes and
+    /// <see cref="LeaveTestExecutionScope"/> clears, rather than from a parallel bool of our own.
+    /// A second copy of "are we in a test" would be one more thing that can drift out of step with
+    /// the state BC's own bodies read (<c>InTest</c>, and through it <c>IsSandbox()</c>).</para>
+    ///
+    /// <para>False when the seam never resolved (<c>_testExecutionInstance</c> null), which is the
+    /// safe direction: the #2805 guard that consults this refuses StartSession, so failing to know
+    /// must mean "not in a test" and let the call through, never a refusal nobody can explain.</para>
+    /// </summary>
+    public static bool InTestExecutionScope
+    {
+        get
+        {
+            if (_testExecutionInstance == null || _fExecutingTestCodeUnit == null) return false;
+            try { return _fExecutingTestCodeUnit.GetValue(_testExecutionInstance) != null; }
+            catch { return false; }
+        }
+    }
+
     public static void LeaveTestExecutionScope()
     {
         if (_testExecutionInstance == null || _fExecutingTestCodeUnit == null) return;

--- a/AlRunner/Patches/SessionPatches.cs
+++ b/AlRunner/Patches/SessionPatches.cs
@@ -339,6 +339,37 @@ public static partial class BcRuntime
     /// where a trapped StartSession returns false without rethrowing).
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
+    /// <summary>
+    /// BC's refusal for <c>StartSession</c> called inside a test codeunit under any isolation mode
+    /// other than <c>Disabled</c> (#2805), carried as <c>NavNCLDialogException</c> — the AL
+    /// <c>Error()</c> carrier, so AL <c>asserterror</c> traps it and <c>GetLastErrorText</c>
+    /// returns the message, which is what the corpus test does.
+    ///
+    /// <para>Deliberately NOT <c>RunnerOutOfScopeException</c>: that type is a plain
+    /// <c>System.Exception</c> specifically so <c>asserterror</c> CANNOT swallow it
+    /// (loud-failures.md), and it announces a runner limitation. This is the opposite on both
+    /// counts — it is real BC behaviour faithfully reproduced, and AL is entitled to trap it.
+    /// Same shape and reasoning as <c>MakeDataTransferException</c>.</para>
+    ///
+    /// <para>The text is BC's own, measured byte-identical on all eight corpus legs (27.0, 27.3,
+    /// 27.5, 28.0, 28.1, 28.2, 28.3, 28.4). <c>Assert.ExpectedError</c> is a substring match and
+    /// the corpus pins the middle of this sentence, so the wording is not free to drift.</para>
+    /// </summary>
+    internal static System.Exception MakeStartSessionNotAllowedInTestException()
+    {
+        const string msg =
+            "Sessions can only be started in tests that are run by a TestRunner that has "
+            + "TestIsolation set to Disabled.";
+        var t = System.Type.GetType(
+            "Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLDialogException, Microsoft.Dynamics.Nav.Types");
+        if (t != null)
+        {
+            var ctor = t.GetConstructor(new[] { typeof(string) });
+            if (ctor != null) return (System.Exception)ctor.Invoke(new object[] { msg });
+        }
+        return new System.InvalidOperationException(msg);
+    }
+
     public static bool AlRunnerStartSession(
         Microsoft.Dynamics.Nav.Types.DataError errorLevel,
         Microsoft.Dynamics.Nav.Runtime.ByRef<int> sessionId,
@@ -346,6 +377,39 @@ public static partial class BcRuntime
         string? companyName,
         Microsoft.Dynamics.Nav.Runtime.NavRecord? record)
     {
+        // #2805 — BC's TestIsolation guard, and it goes FIRST, outside the try, exactly where BC
+        // puts it. Decompiled from ALSession.ALStartSessionAsyncImpl (bc281):
+        //
+        //     if (session.TestExecution != null
+        //         && (!session.TestExecution.CommitTestCodeunits
+        //             || !session.TestExecution.CommitTestFunctions))
+        //     {
+        //         throw new NavTestStartSessionNotAllowedException();
+        //     }
+        //
+        // Three things about that placement are load-bearing, and all three are why this is not
+        // simply folded into the try below:
+        //
+        //   * It precedes the session-id assignment. BC assigns sessionId.ObjectValue about forty
+        //     lines later, after the new session is opened, so a refused call leaves the caller's
+        //     by-ref untouched. The corpus pins that directly (SessionId = 0 after the refusal),
+        //     and the runner's own "allocate the id up front so SessionId > 0 holds even if
+        //     dispatch throws" ordering — right for a dispatch failure — is wrong for this one.
+        //   * TrapError does NOT swallow it. BC's guard throws BEFORE its try block, so the catch
+        //     that returns false for a trapped NavBaseException never sees this exception. Whether
+        //     NavTestStartSessionNotAllowedException derives from NavBaseException is therefore
+        //     irrelevant — settled by control flow, not by the type hierarchy, which is worth
+        //     stating because #2805 asked for the derivation to be checked against the DLL and the
+        //     answer is that it cannot matter. `trap` is deliberately not consulted here.
+        //   * It is CONDITIONAL. Under TestIsolation = Disabled both commit flags are true and BC
+        //     runs the session normally, so an unconditional refusal would be a different bug.
+        //
+        // The two conditions map to: InTestExecutionScope (BC's session.TestExecution != null,
+        // read off BC's own executingTestCodeUnit field) and the run's isolation mode. Outside a
+        // [Test] body — `execute` mode, an install trigger, a report — nothing is refused.
+        if (InTestExecutionScope && TestExecutor.ActiveIsolation != TestIsolation.Disabled)
+            throw MakeStartSessionNotAllowedInTestException();
+
         bool trap = errorLevel == Microsoft.Dynamics.Nav.Types.DataError.TrapError;
         try
         {

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -118,7 +118,29 @@ public sealed class TestExecutor
 {
     private const int DefaultTestTimeoutSeconds = 60;
 
-    public TestIsolation Isolation { get; set; } = TestIsolation.Codeunit;
+    private static TestIsolation _activeIsolation = TestIsolation.Codeunit;
+
+    /// <summary>
+    /// The isolation mode of the executor currently running tests in this process.
+    ///
+    /// <para>Static because the consumer is a static patch on a BC seam:
+    /// <c>BcRuntime.AlRunnerStartSession</c> has to answer BC's guard "is this session's
+    /// TestIsolation anything other than Disabled" (#2805) and has no executor instance to ask.
+    /// BC reads the equivalent off <c>session.TestExecution</c>, which is likewise ambient rather
+    /// than passed down the call chain.</para>
+    ///
+    /// <para>Only meaningful together with <see cref="BcRuntime.InTestExecutionScope"/>: outside a
+    /// test this holds whatever the last executor set, which is exactly why the guard checks both
+    /// and why this is not a "are we isolated right now" flag on its own.</para>
+    /// </summary>
+    public static TestIsolation ActiveIsolation => _activeIsolation;
+
+    public TestIsolation Isolation
+    {
+        get => _isolation;
+        set { _isolation = value; _activeIsolation = value; }
+    }
+    private TestIsolation _isolation = TestIsolation.Codeunit;
 
     /// <summary>
     /// Optional substring filter applied to "Codeunit.Method" and "Codeunit" before

--- a/tests/runner-extras/microsoft-dependencies/MicrosoftDependencyTests.Codeunit.al
+++ b/tests/runner-extras/microsoft-dependencies/MicrosoftDependencyTests.Codeunit.al
@@ -542,90 +542,74 @@ codeunit 61001 "Microsoft Dependency Tests"
         SetupPage.OK().Invoke();
     end;
 
-    // Precompiled dependency CODEUNITS reached through StartSession (AlRunner#2733).
+    // StartSession from inside a [Test] — REFUSED, and that is real BC, not a runner limit.
     //
-    // BC's compiler emits a codeunit's `trigger OnRun()` as an async `OnRunAsync` on the
-    // concrete type for the dependency-compile path, and as a synchronous `OnRun` override
-    // for the runner's own emit. Both are virtuals on NavCodeunit with an EMPTY base body, so
-    // a sync-name-only reflection lookup always resolves — it binds and runs the empty base.
-    // SessionPatches.AlRunnerStartSession did exactly that, so StartSession on any Base
-    // Application / System Application / ISV worker returned true having executed nothing.
+    // These three tests used to assert that StartSession dispatched a precompiled worker
+    // (AlRunner#2733). They were green only because the runner did not implement BC's
+    // TestIsolation guard. It does now (#2805), and the corpus pins the refusal on all eight
+    // BC versions — StefanMaron/BusinessCentral.AL.Language.Tests session/TestStartSessionRecord.al,
+    // codeunit 60397, merged as PR #149.
     //
-    // The worker has to be genuinely precompiled. A source-compiled sibling app is NOT
-    // enough: measured, a `-dep` fixture bundle compiled from .al alongside the test bundle
-    // carries the SYNC flavour and passes against the unfixed runner, so it proves nothing.
-    // The same distinction is recorded in tests/runner-extras/depapp-dictionary-main.
+    // BC's guard is the FIRST statement of ALSession.ALStartSessionAsyncImpl, before the
+    // timeout check and before a session id is assigned:
     //
-    // Base Application codeunit 7002 "Price Calculation - V16" is the smallest precompiled
-    // worker with an OnRun whose effect is observable and needs no setup: it rewrites its own
-    // rows in "Price Calculation Setup". Codeunit 7003 "Price Calculation - V15" is its twin,
-    // which makes the pair differential.
+    //     if (session.TestExecution != null
+    //         && (!session.TestExecution.CommitTestCodeunits
+    //             || !session.TestExecution.CommitTestFunctions))
+    //         throw new NavTestStartSessionNotAllowedException();
     //
-    // Every assertion reads a row the worker's body writes. None asserts that StartSession
-    // returned or did not throw — the broken behaviour satisfies both.
+    // So on a real service tier a [Test] running under TestIsolation = Codeunit (this suite's
+    // mode, and BC's shipped runner 130450) can never reach StartSession's dispatch at all.
+    // Asserting that it does was asserting something no service tier would agree with.
+    //
+    // WHAT THIS COSTS, recorded rather than glossed: the #2733/#2752 dispatch path inside
+    // AlRunnerStartSession — construct the worker, resolve OnRun vs OnRunAsync, await the
+    // ValueTask — no longer has AL-level coverage here, because from AL it is now only
+    // reachable under --isolation disabled, which this suite does not run under. The shared
+    // resolver it calls (CodeunitPatches.ResolveOnRunTrigger) keeps its other call site's
+    // coverage through Codeunit.Run. Re-covering the StartSession-specific half is AlRunner#2816.
     [Test]
-    procedure PrecompiledCodeunit_StartSession_RunsTheWorkersOnRunBody()
+    procedure PrecompiledCodeunit_StartSession_FromATestIsRefusedUnderCodeunitIsolation()
     var
-        PriceCalculationSetup: Record "Price Calculation Setup";
-        SessionId: Integer;
-        Started: Boolean;
-    begin
-        PriceCalculationSetup.DeleteAll();
-
-        Started := StartSession(SessionId, Codeunit::"Price Calculation - V16");
-
-        Assert.IsTrue(Started, 'StartSession must report that it started the session.');
-        Assert.IsTrue(SessionId > 0,
-            StrSubstNo('BC guarantees a non-zero session id after StartSession; got %1.', SessionId));
-
-        PriceCalculationSetup.SetRange(
-            Implementation, PriceCalculationSetup.Implementation::"Business Central (Version 16.0)");
-        Assert.AreEqual(2, PriceCalculationSetup.Count(),
-            'Codeunit 7002''s OnRun body inserts its Purchase and Sale setup rows. The empty inherited ' +
-            'NavCodeunit.OnRun returns just as quietly and writes nothing.');
-        Assert.IsTrue(PriceCalculationSetup.FindFirst(), 'the rows the worker wrote must be readable');
-        Assert.IsTrue(PriceCalculationSetup.Default,
-            'OnRun ends in ModifyAll(Default, true), so the rows it wrote must carry Default = true.');
-    end;
-
-    // Differential: starting the V15 worker must run THAT worker, not the V16 one. Together
-    // with the test above this rules out "some codeunit ran" as the explanation.
-    [Test]
-    procedure PrecompiledCodeunit_StartSession_RunsTheWorkerItWasGiven_AndNoOther()
-    var
-        PriceCalculationSetup: Record "Price Calculation Setup";
         SessionId: Integer;
     begin
-        PriceCalculationSetup.DeleteAll();
+        asserterror StartSession(SessionId, Codeunit::"Price Calculation - V16");
 
-        Assert.IsTrue(StartSession(SessionId, Codeunit::"Price Calculation - V15"),
-            'StartSession must report that it started the session.');
-
-        PriceCalculationSetup.SetRange(
-            Implementation, PriceCalculationSetup.Implementation::"Business Central (Version 15.0)");
-        Assert.AreEqual(2, PriceCalculationSetup.Count(),
-            'Codeunit 7003''s OnRun body must have inserted its two setup rows.');
-
-        PriceCalculationSetup.SetRange(
-            Implementation, PriceCalculationSetup.Implementation::"Business Central (Version 16.0)");
-        Assert.AreEqual(0, PriceCalculationSetup.Count(),
-            'Starting the V15 worker must not have run the V16 worker''s body.');
+        Assert.Contains(GetLastErrorText(),
+            'can only be started in tests that are run by a TestRunner that has TestIsolation set to Disabled',
+            'StartSession inside a [Test] under Codeunit isolation must be refused with BC''s own message.');
     end;
 
-    // Negative: an object id with no codeunit behind it must fail LOUDLY rather than return
-    // true having done nothing — the exact failure mode this whole area is about.
-    // Deliberately asserts only the error text: an error rolls the write transaction back to
-    // the last commit point, so any table read placed after this asserterror would report the
-    // state before the test began (see tests/al-language error-handling/TestAssertErrorRollback.al).
+    // The refusal precedes the session-id assignment. BC assigns sessionId.ObjectValue about
+    // forty lines after the guard, so a refused call leaves the caller's by-ref untouched —
+    // the same claim corpus codeunit 60397 makes, asserted here against a Base Application
+    // worker rather than a fixture one.
     [Test]
-    procedure PrecompiledCodeunit_StartSession_OnAnIdWithNoCodeunit_FailsLoudly()
+    procedure PrecompiledCodeunit_StartSession_RefusedBeforeASessionIdIsAssigned()
+    var
+        SessionId: Integer;
+    begin
+        SessionId := 0;
+        asserterror StartSession(SessionId, Codeunit::"Price Calculation - V15");
+
+        Assert.AreEqual(0, SessionId,
+            'a refused StartSession must not have assigned a session id.');
+    end;
+
+    // The refusal is checked BEFORE the object id is resolved, so a nonexistent codeunit id
+    // reports the isolation refusal rather than "no codeunit behind this id" — matching BC,
+    // whose guard runs before any codeunit lookup. Keeps the negative direction of the test
+    // this replaces: StartSession still fails loudly here, just for the earlier reason.
+    [Test]
+    procedure PrecompiledCodeunit_StartSession_OnAnIdWithNoCodeunit_IsRefusedByIsolationFirst()
     var
         SessionId: Integer;
     begin
         asserterror StartSession(SessionId, 1999999);
 
-        Assert.Contains(GetLastErrorText(), '1999999',
-            'A StartSession naming an object id with no codeunit behind it must fail and name that id.');
+        Assert.Contains(GetLastErrorText(),
+            'can only be started in tests that are run by a TestRunner that has TestIsolation set to Disabled',
+            'the isolation guard runs before the codeunit lookup, so it reports first.');
     end;
 
     local procedure EnsureGeneralLedgerSetupExists()

--- a/tests/runner-extras/microsoft-dependencies/MicrosoftDependencyTests.Codeunit.al
+++ b/tests/runner-extras/microsoft-dependencies/MicrosoftDependencyTests.Codeunit.al
@@ -567,7 +567,7 @@ codeunit 61001 "Microsoft Dependency Tests"
     // ValueTask — no longer has AL-level coverage here, because from AL it is now only
     // reachable under --isolation disabled, which this suite does not run under. The shared
     // resolver it calls (CodeunitPatches.ResolveOnRunTrigger) keeps its other call site's
-    // coverage through Codeunit.Run. Re-covering the StartSession-specific half is AlRunner#2816.
+    // coverage through Codeunit.Run. Re-covering the StartSession-specific half is AlRunner#2826.
     [Test]
     procedure PrecompiledCodeunit_StartSession_FromATestIsRefusedUnderCodeunitIsolation()
     var


### PR DESCRIPTION
Closes #2805

Written by an agent (impl-1).

## The defect

Real BC refuses `StartSession` from a test codeunit unless the TestRunner declares `TestIsolation = Disabled`. The runner did not implement that guard at all — `AlRunnerStartSession` ran the worker inline and returned `true` whatever the isolation mode. **AL that a real service tier refuses to run passed here silently**, which is the failure direction that produces confidently wrong results rather than visible ones.

BC's guard is the **first** statement of `ALSession.ALStartSessionAsyncImpl` (decompiled, `bc281`), before the timeout check and before a session id is assigned.

## The three constraints #2805 named, and how each is met

- **Conditional, not unconditional.** Under `TestIsolation = Disabled` BC runs the session normally, so the guard reads `TestExecutor.ActiveIsolation` together with `BcRuntime.InTestExecutionScope`. Outside a `[Test]` body — `execute` mode, an install trigger, a report — nothing is refused.
- **Before the session id is assigned.** The corpus asserts `SessionId = 0` after the refusal because BC assigns `sessionId.ObjectValue` about forty lines later. The runner's "allocate the id up front so `SessionId > 0` holds even if dispatch throws" ordering is right for a *dispatch* failure and wrong for this one, so the guard sits ahead of it.
- **`TrapError` does not swallow it — and the `NavBaseException` question cannot matter.** #2805 asked for the derivation to be checked against the DLL before copying the existing swallow path. I could not find the type in the indexed `Ncl.dll` (it lives in `Types.dll`), but the answer is settled by control flow instead: BC's guard throws **before** its `try`, so the catch that returns `false` for a trapped `NavBaseException` never sees this exception. `trap` is deliberately not consulted.

`InTestExecutionScope` reads BC's own `NavTestExecution.executingTestCodeUnit` — the field `EnterTestExecutionScope` already pokes — rather than a parallel bool, so it cannot drift from the state BC's own bodies read through `InTest`.

Carried as `NavNCLDialogException`, the AL `Error()` carrier, so `asserterror` traps it and `GetLastErrorText` returns the message. Deliberately **not** `RunnerOutOfScopeException`: that type is a plain `System.Exception` precisely so `asserterror` cannot swallow it, and it announces a runner limitation. This is the opposite on both counts.

## RED to GREEN — against the service-tier-adjudicated corpus

Corpus codeunit 60397, merged as corpus PR #149, green on all eight BC versions:

```
before: NavNCLAssertErrorException: An error was expected inside an ASSERTERROR statement.
        Assert.ExpectedError failed. Expected: can only be started in tests that are run by
        a TestRunner that has TestIsolation set to Disabled.
        Actual: Exception has been thrown by the target of an invocation.
after:  PASS StartSession_FromATestCodeunit_IsRefusedUnderCodeunitIsolation
        PASS StartSession_RecordOverload_IsRefusedTheSameWay
```

## Three runner-extras tests were asserting the opposite

`microsoft-dependencies` had three tests asserting that `StartSession` dispatches a precompiled worker from inside a `[Test]`. They were green **only because this guard was missing** — a real service tier contradicts them. They are rewritten to assert the refusal, the session id staying 0, and the guard preceding the codeunit lookup. **Test count is unchanged (3 replaced by 3), so no count-baseline edit.**

That costs coverage, and I recorded it in the AL rather than glossing it: the #2733/#2752 dispatch path inside `AlRunnerStartSession` is now only reachable from AL under `--isolation disabled`, which no suite runs under. The shared resolver it calls (`CodeunitPatches.ResolveOnRunTrigger`) keeps its other call site's coverage through `Codeunit.Run`. Re-covering the StartSession-specific half is filed as **#2826**.

## The #2808 interaction — read this before merging

**#2808 has not merged.** `tests/expectations/known-gaps-start-session-isolation.json` does not exist on `main`, so there is nothing for this PR to delete and I have deleted nothing.

- **If #2808 merges first**, whoever merges this must remove that entry — the manifest fails loudly in both directions, so leaving it will fail the run with "remove the entry" once these tests start passing.
- **If this merges first**, #2808 must land without that entry (or with it already removed), for the same reason.

The current pin (`bce7c87`) predates corpus #149, so the proving tests are not in this repo's submodule yet — I ran them against a checkout of corpus `master`, as the workflow prescribes when the pin has not caught up.

## Verified locally

**28.x only — a self-built runner is compiled against Ncl 28.x and cannot run 27.x artifacts.**

| check | result |
|---|---|
| corpus codeunit 60397, against corpus `master` | 2/2 (0/2 before) |
| `tests/runner-extras` | 256/256, run twice cold and warm |
| `StartSessionIsolationGuardTests` | 6/6 |
| isolation + session neighbours (`SessionPatches`, `TestIsolation`, `InstallSeedDepCompanyCache`) | 19/19 |

## What I did not verify

- **No AL-level coverage that the guard stays inert under `--isolation disabled`.** The new C# tests pin that `ActiveIsolation` tracks the executor and does not latch, which is the plumbing that would silently break the conditionality — but nothing runs a real bundle under Disabled isolation to prove `StartSession` still dispatches there. That is the same gap #2826 covers.
- **No coverage that `StartSession` outside a `[Test]` is unaffected.** The guard is inert when `InTestExecutionScope` is false, by construction, but I did not exercise `execute` mode.
- I did not run the full `AlRunner.Tests` suite or the corpus.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
