### PR TITLE
ci(#2819): capture a core dump when the runner is killed by a signal

### DIFF
--- a/.claude/skills/al-runner-tests/SKILL.md
+++ b/.claude/skills/al-runner-tests/SKILL.md
@@ -94,6 +94,41 @@ Today the reporter prints raw PASS / FAIL / ERROR per test plus aggregate counts
 
 Drift is loud in every direction: a test passing despite an entry fails with "remove the entry"; a test raising an OOS signal without an entry fails with "add an entry"; a wrong or near-miss `Reason` still fails. See `docs/expectations.md`.
 
+## If a run dies with no output (exit 139 / 134)
+
+An exit of 139 is SIGSEGV and 134 is SIGABRT — the process was killed by a signal, so there
+is no managed stack, no test result and usually nothing in the log but the missing output.
+#2819 is one such corpus run: it died seconds in, before any test reported, and four further
+runs of the same tree finished 2523/2523.
+
+**Do not re-run hoping to see it again.** A rare crash re-run without dump capture produces
+another sighting and no evidence, and on a shared box it costs everyone else queue time.
+
+Capture a dump instead. Set these before the run and the next fault leaves something to read:
+
+```bash
+export DOTNET_DbgEnableMiniDump=1
+export DOTNET_DbgMiniDumpType=2          # heap; see below on why not 4
+export DOTNET_DbgMiniDumpName="$PWD/crash-dumps/coredump.%p"
+mkdir -p crash-dumps                     # createdump does NOT create this itself
+```
+
+Verified locally on .NET 8: a real `SIGSEGV` (`signal 11`) is caught and written, not only a
+managed `AccessViolationException`. `createdump` prints `Writing minidump with heap to file
+…` on the dying process's stderr, so its absence tells you the settings did not take.
+
+`DOTNET_DbgMiniDumpType=4` is full memory. Measured: type 2 on a trivial hello-world process
+is already ~127 MB, and it scales with committed memory — a runner with BC loaded is measured
+in GB. Type 2 carries the faulting native stack, the module list and the managed heap, which
+is what the first read of an unexplained crash needs. Reach for 4 only when 2 has been read
+and found wanting.
+
+CI sets all three at job level in `.github/workflows/bc-tests.yml` and uploads anything
+produced as `crash-dumps-<bc-version>`, so a crash on any leg leaves an artifact rather than
+an exit code.
+
+Read one with `dotnet-dump analyze <file>` (`clrstack`, `clrmodules`, `eeversion`).
+
 ## Proving-test rules
 
 A skeptic must be able to read any test and say: "yes, if this passes, feature X works correctly." Every test satisfies all four:

--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -228,11 +228,39 @@ jobs:
     continue-on-error: ${{ !matrix.target.required }}
     env:
       BC_VERSION: ${{ matrix.target.bc-version }}
+      # #2819: a corpus run died with SIGSEGV (exit 139) seconds in, before any test
+      # reported — no stack, no managed exception, nothing to read. One occurrence, not
+      # reproduced in four further runs of the same tree. Without this, every future
+      # sighting is another paragraph describing an exit code.
+      #
+      # Set at JOB level, not on the corpus step, because the same runner binary is
+      # invoked by six steps in this leg (corpus, xmlport isolation, runner-extras, two
+      # server-mode integrations, the unit tests) and a crash in any of them has the same
+      # nothing-to-read problem. These variables cost nothing until a process actually
+      # faults.
+      #
+      # Type 2 (MiniDumpWithPrivateReadWriteMemory) rather than the 4 the issue suggests.
+      # 4 is MiniDumpWithFullMemory, whose size tracks the process's committed memory —
+      # a runner with BC loaded is measured in GB, and a hosted runner has roughly 14 GB
+      # free. Filling the disk would convert a rare crash into a reliable infrastructure
+      # failure, which is a worse trade than a slightly smaller dump. Type 2 still carries
+      # the faulting native stack, the module list and the managed heap, which is what the
+      # first read of an unexplained SIGSEGV actually needs. Override the variable on a
+      # dispatch if a full dump is ever genuinely required.
+      DOTNET_DbgEnableMiniDump: '1'
+      DOTNET_DbgMiniDumpType: '2'
+      DOTNET_DbgMiniDumpName: ${{ github.workspace }}/crash-dumps/coredump.%p
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
           submodules: true
+
+      # createdump does NOT create the directory in DOTNET_DbgMiniDumpName's path — it
+      # fails to write and says so on stderr of a process that is already dying, which
+      # nobody would see. Created before anything can crash.
+      - name: Create the crash-dump directory (#2819)
+        run: mkdir -p "${{ github.workspace }}/crash-dumps"
 
       # setup-dotnet, the Release build against this BC version, the R2R platform apps
       # and the Microsoft test toolkit — moved, comments and all, into ONE composite
@@ -545,6 +573,18 @@ jobs:
           scripts/tests/server-reload-test.sh \
               --package-cache "$HOME/.al-runner/platform-apps" \
               --package-cache "$HOME/.al-runner/test-apps"
+
+      # Separate from the results artifact below so a multi-hundred-MB dump never rides
+      # along with the small JSON every green run uploads. if-no-files-found: ignore is
+      # what keeps this a no-op on the overwhelming majority of runs that do not crash.
+      - name: Upload crash dumps (#2819)
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: crash-dumps-${{ matrix.target.bc-version }}
+          path: crash-dumps/
+          if-no-files-found: ignore
+          retention-days: 14
 
       - name: Upload result artifacts
         if: always()

--- a/AlRunner.Tests/CrashDumpCaptureWiringTests.cs
+++ b/AlRunner.Tests/CrashDumpCaptureWiringTests.cs
@@ -1,0 +1,115 @@
+// CrashDumpCaptureWiringTests — issue #2819: a corpus run died with SIGSEGV (exit 139) seconds
+// in, before any test reported. No stack, no managed exception, nothing to read. One occurrence,
+// not reproduced in four further runs of the same tree.
+//
+// The wiring this guards is worth a test for the same reason the workflow guards already here
+// are: it is invisible until the rare moment it matters, and by then a silent regression has
+// already cost the one occurrence it existed to capture. Every assertion below corresponds to a
+// way the capture can be present-but-useless.
+//
+// Verified by hand on .NET 8 before writing this, rather than assumed from documentation:
+//
+//   * a REAL SIGSEGV (kill -SEGV against a live dotnet process) is caught — createdump reports
+//     `Crashing thread ... signal 11 (000b)` and writes the file. That is the exact signal
+//     #2819 reports; a managed AccessViolationException arrives as signal 6 instead, so testing
+//     only that shape would have proven the wrong thing.
+//   * createdump does NOT create the directory in DOTNET_DbgMiniDumpName's path. Without the
+//     mkdir it fails to write, and says so only on the stderr of a process that is already
+//     dying.
+//   * type 2 on a trivial hello-world process is already ~127 MB, and it scales with committed
+//     memory. Type 4 (full memory) against a runner with BC loaded is a multi-GB file on a
+//     hosted runner with roughly 14 GB free — which would convert a rare crash into a reliable
+//     out-of-disk failure. That is why this asserts 2 and not the 4 the issue suggested.
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class CrashDumpCaptureWiringTests
+{
+    private static readonly string WorkflowDir = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".github", "workflows"));
+
+    private static string Read(string name)
+    {
+        var path = Path.Combine(WorkflowDir, name);
+        Assert.True(File.Exists(path), $"expected workflow {name} at {path}");
+        return File.ReadAllText(path);
+    }
+
+    private static string CodeOnly(string text) =>
+        string.Join('\n', text.Split('\n').Where(l => !l.TrimStart().StartsWith('#')));
+
+    [Fact]
+    public void BcTests_EnablesMiniDumpCapture()
+    {
+        var code = CodeOnly(Read("bc-tests.yml"));
+
+        Assert.Matches(new Regex(@"DOTNET_DbgEnableMiniDump:\s*'?1'?"), code);
+        Assert.Matches(new Regex(@"DOTNET_DbgMiniDumpName:.*crash-dumps"), code);
+    }
+
+    /// <summary>Type 2, not 4. A full-memory dump of a runner with BC loaded is measured in GB
+    /// against roughly 14 GB of free disk on a hosted runner, so 4 would trade a rare crash for
+    /// a reliable infrastructure failure. Asserted as an exact value because "some dump type is
+    /// configured" is precisely the check that would let 4 back in unnoticed.</summary>
+    [Fact]
+    public void BcTests_UsesTheHeapDumpType_NotFullMemory()
+    {
+        var code = CodeOnly(Read("bc-tests.yml"));
+
+        Assert.Matches(new Regex(@"DOTNET_DbgMiniDumpType:\s*'?2'?"), code);
+        Assert.DoesNotMatch(new Regex(@"DOTNET_DbgMiniDumpType:\s*'?4'?"), code);
+    }
+
+    /// <summary>createdump does not create the directory it is told to write into. Without this
+    /// step the dump is silently never written, and the only sign is a line on the stderr of an
+    /// already-dying process — which is the same nothing-to-read situation #2819 is about.</summary>
+    [Fact]
+    public void BcTests_CreatesTheDumpDirectoryBeforeAnythingCanCrash()
+    {
+        var code = CodeOnly(Read("bc-tests.yml"));
+
+        Assert.Matches(new Regex(@"mkdir -p .*crash-dumps"), code);
+
+        // Ordering matters as much as presence: a mkdir after the runner has already been
+        // invoked cannot help the invocation that crashed.
+        var mkdirAt = code.IndexOf("mkdir -p", StringComparison.Ordinal);
+        var firstRunnerAt = code.IndexOf("dotnet run --no-build --project AlRunner", StringComparison.Ordinal);
+        Assert.True(mkdirAt >= 0 && firstRunnerAt >= 0 && mkdirAt < firstRunnerAt,
+            "the crash-dump directory must be created before the first runner invocation, or the "
+            + "first crash — the one worth capturing — writes nothing");
+    }
+
+    /// <summary>A dump written into the workspace and never uploaded is discarded when the runner
+    /// is torn down, which is indistinguishable from never having captured it.</summary>
+    [Fact]
+    public void BcTests_UploadsAnyDumpItProduces()
+    {
+        var code = CodeOnly(Read("bc-tests.yml"));
+
+        Assert.Matches(new Regex(@"name:\s*crash-dumps-\$\{\{\s*matrix\.target\.bc-version\s*\}\}"), code);
+        Assert.Matches(new Regex(@"path:\s*crash-dumps/"), code);
+
+        // Without this the step FAILS on every green run, since no dump exists — turning a
+        // diagnostic aid into a permanent red leg.
+        Assert.Matches(new Regex(@"if-no-files-found:\s*ignore"), code);
+    }
+
+    /// <summary>The upload must not be conditional on the runner step's success in a way that
+    /// skips it on the crash — `always()` is the only condition that fires when a step died.</summary>
+    [Fact]
+    public void BcTests_UploadsDumpsEvenWhenTheLegFailed()
+    {
+        var code = CodeOnly(Read("bc-tests.yml"));
+        var uploadAt = code.IndexOf("crash-dumps-${{ matrix.target.bc-version }}", StringComparison.Ordinal);
+        Assert.True(uploadAt > 0, "the crash-dump upload step is missing");
+
+        // The `if:` governing that step is the nearest one above it.
+        var before = code[..uploadAt];
+        var lastIf = before.LastIndexOf("if:", StringComparison.Ordinal);
+        Assert.True(lastIf > 0, "the crash-dump upload step has no `if:` condition");
+        var condition = before[lastIf..];
+        Assert.Contains("always()", condition, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
Closes #2819

This is the issue's own first ask and **deliberately only that**: it makes the next occurrence diagnosable. It does not diagnose this one, and it attributes nothing.

## Verified, not assumed

The whole change is worthless if `createdump` does not fire for the signal in question, so I measured both facts on .NET 8 locally before wiring anything:

- **A real SIGSEGV is caught.** `kill -SEGV` against a live `dotnet` process produced `Crashing thread ... signal 11 (000b)` and a written dump. That is exactly #2819's signal (139 = 128+11). Testing only a managed `AccessViolationException` would have proven the wrong thing — that arrives as **signal 6**, and my first attempt did precisely that before I noticed.
- **`createdump` does not create the directory** in `DOTNET_DbgMiniDumpName`'s path. Without a `mkdir` it fails to write and says so only on the stderr of an already-dying process — the same nothing-to-read situation this exists to end. Hence an explicit step, ordered before the first runner invocation.

## Type 2, not the 4 the issue suggested

Type 4 is `MiniDumpWithFullMemory` and its size tracks committed memory. **Measured: type 2 on a trivial hello-world process is already ~127 MB**, and a runner with BC loaded is measured in GB against roughly 14 GB free on a hosted runner. Filling the disk would convert a rare crash into a reliable infrastructure failure — a worse trade than a smaller dump.

Type 2 still carries the faulting native stack, the module list and the managed heap, which is what the first read of an unexplained SIGSEGV needs. Reach for 4 only once 2 has been read and found wanting.

I am flagging this as a deliberate deviation from the issue text rather than quietly implementing something different.

## Scope

Set at **job** level, not on the corpus step: the same runner binary is invoked by six steps in this leg (corpus, xmlport isolation, runner-extras, two server-mode integrations, unit tests) and a crash in any of them has the identical nothing-to-read problem. The variables cost nothing until a process actually faults.

Dumps upload as `crash-dumps-<bc-version>`, separate from the results artifact so a large dump never rides along with the small JSON every green run produces, with `if-no-files-found: ignore` so the step is a no-op on runs that do not crash.

## The observed crash was local, and CI has not seen it

Worth stating plainly, because it bounds what this change buys: the one occurrence was on a developer box, so the CI wiring only helps **if CI ever sees it**. I checked whether it has — scanned the six most recent failed Test Matrix runs for `exit 139`, `exit 134` and `Segmentation fault`, and found **none**.

So the `al-runner-tests` skill gains the same recipe for local runs, which is where the crash actually happened, together with the instruction **not to re-run hoping to reproduce it** — that burns a shared queue to produce another sighting with no dump attached.

## What this does not claim

- **Not attributed.** impl-9's stale-cache/rebuild boundary is a hypothesis with one observation behind it. If a dump lands and says something else, that is the answer.
- **A SIGSEGV here has precedent that was not a runner memory-safety bug.** Multi-dataitem query joins segfaulted under R2R from layout perturbation and the fix was elsewhere entirely, so "the runner has a memory-safety bug" is one hypothesis among several, not the default.

## Tests

`CrashDumpCaptureWiringTests` pins the five ways this can be present but useless — enabled, correct type, directory created *before* the first runner invocation, uploaded, and uploaded on failure rather than only on success.

RED-checked against three mutations, each caught by its own guard:

| mutation | result |
|---|---|
| raise the dump type to 4 | `UsesTheHeapDumpType_NotFullMemory` fails |
| drop the `mkdir` step | `CreatesTheDumpDirectoryBeforeAnythingCanCrash` fails |
| make the upload `if: success()` | `UploadsDumpsEvenWhenTheLegFailed` fails |

33 green across `CrashDumpCaptureWiringTests`, `ReleaseTestParityTests`, `BcLegRerunWorkflowTests` and `MsBucketWorkflowTests`, re-run on the final base rather than carried across the rebase.

---
Written by Claude Code agent impl-7.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
