### PR TITLE
fix(summary): name the bundles that did not compile, in the block that gets read

### DIFF
--- a/AlRunner.Tests/CompileFailedBucketReportingTests.cs
+++ b/AlRunner.Tests/CompileFailedBucketReportingTests.cs
@@ -1,0 +1,154 @@
+// CompileFailedBucketReportingTests — issue #2764.
+//
+// #2762/#2793 gave a bucket that RAN but LOST a suite a "Suite errors" section in the summary,
+// because every number above it described only what survived. A bucket that failed to compile
+// ENTIRELY has the same problem one step further along, and one channel fewer to solve it.
+//
+// Its tests are simply absent from the totals, so `Tests: / pass: / fail:` read exactly as a
+// clean run of whatever else ran. `compile-fail:1` does move, but the line that says WHICH
+// bundle and WHY is written when it happens — tens to thousands of lines above the block a
+// developer actually reads — and `PrintPerTest`'s `=== X — COMPILE FAIL ===` sits up there
+// with it.
+//
+// In a one-shot run the exit code still catches it. Under `--watch` there is no exit code at
+// all: the summary IS the interface, nobody scrolls a live session, and the faster the loop
+// the more it is trusted. That is why this one is worth fixing rather than filing.
+//
+// The fix is deliberately the SAME mechanism #2793 introduced rather than a second spelling of
+// it: name the buckets in the summary and repeat their errors verbatim, printed only when
+// there are any.
+//
+// This is entirely about the runner's own reporting — "what does al-runner print when a bundle
+// does not compile" is not a question a service tier can adjudicate — so nothing here belongs
+// in the al-language corpus (.claude/rules/bc-behavior-tests-go-upstream.md).
+//
+// The negatives carry as much weight as the positives: a section printed unconditionally, or
+// one that folded compile-failed buckets into the test totals or into #2793's `partial:`
+// counter, would satisfy "the failure is named" and still misstate the run.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class CompileFailedBucketReportingTests
+{
+    private const string CompileError =
+        "<bundled>: COMPILE-FAIL (8): error AL0118: The name 'Widgetz' does not exist.";
+
+    private static TestResult Pass(string codeunit, string method) =>
+        new(codeunit, method, TestOutcome.Pass, null, null, TimeSpan.FromMilliseconds(3));
+
+    /// <summary>A bucket that did not compile at all: no tests, its errors on the record.</summary>
+    private static BucketResult CompileFailedBucket(string path = "/bundle-broken") =>
+        new(path, BucketStage.CompileFailed,
+            new[] { CompileError }, null, Array.Empty<TestResult>(),
+            TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, 0, null);
+
+    /// <summary>A healthy sibling, so the run has something to report that looks clean.</summary>
+    private static BucketResult CleanBucket(string path = "/bundle-ok") =>
+        new(path, BucketStage.Ran,
+            Array.Empty<string>(), null, new[] { Pass("Codeunit50100", "Healthy") },
+            TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero, 1, null);
+
+    private static string Summarise(params BucketResult[] buckets)
+    {
+        var w = new StringWriter();
+        Reporter.PrintSummary(buckets, w);
+        return w.ToString();
+    }
+
+    /// <summary>
+    /// The claim: a cycle that lost a whole bundle must not print a summary a reader can mistake
+    /// for a clean one. It has to name the bundle and say why, in the block being read.
+    /// </summary>
+    [Fact]
+    public void CompileFailedBucket_IsNamedInTheSummary_WithItsErrorVerbatim()
+    {
+        var output = Summarise(CleanBucket(), CompileFailedBucket());
+
+        Assert.Contains("/bundle-broken", output, StringComparison.Ordinal);
+        // Verbatim, not paraphrased: this text is what names the surface and the diagnostic,
+        // and a summary of it would send the reader back up the log.
+        Assert.Contains(CompileError, output, StringComparison.Ordinal);
+    }
+
+    /// <summary>The Tests block — every line from "Tests:" to the timings.</summary>
+    private static string TestsBlock(string summary)
+    {
+        var lines = summary.Replace("\r\n", "\n").Split('\n');
+        var sb = new System.Text.StringBuilder();
+        bool inBlock = false;
+        foreach (var line in lines)
+        {
+            if (line.StartsWith("Tests:", StringComparison.Ordinal)) inBlock = true;
+            else if (inBlock && line.StartsWith("Time:", StringComparison.Ordinal)) break;
+            if (inBlock) sb.Append(line).Append('\n');
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// The heart of #2764, stated as the thing that makes the fix necessary rather than as a
+    /// difference any change would satisfy: adding a bundle that did not compile leaves the
+    /// TEST TOTALS byte-identical. Those are the numbers a developer glances at, so they cannot
+    /// carry the signal and something else has to.
+    /// </summary>
+    [Fact]
+    public void ACompileFailure_LeavesTheTestTotalsIdentical_SoTheNamingMustCarryIt()
+    {
+        var clean = Summarise(CleanBucket());
+        var broken = Summarise(CleanBucket(), CompileFailedBucket());
+
+        Assert.Equal(TestsBlock(clean), TestsBlock(broken));
+        // ...which is exactly why the bundle has to be named somewhere the totals are not.
+        Assert.DoesNotContain("/bundle-broken", clean, StringComparison.Ordinal);
+        Assert.Contains("/bundle-broken", broken, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Negative: a clean run must be byte-identical to what it printed before. A section that
+    /// appears unconditionally is noise, and every integration test asserting on the markers
+    /// around it would be asserting past it.
+    /// </summary>
+    [Fact]
+    public void CleanRun_PrintsNoCompileFailureSection()
+    {
+        var output = Summarise(CleanBucket());
+
+        Assert.DoesNotContain("Compile failures", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("COMPILE-FAIL", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Negative: a compile-failed bucket is not a #2793 "partial" one. Folding it into that
+    /// counter would claim the bundle ran and lost a suite, which is a different and milder
+    /// thing than never having compiled.
+    /// </summary>
+    [Fact]
+    public void CompileFailedBucket_IsNotCountedAsPartial()
+    {
+        var output = Summarise(CleanBucket(), CompileFailedBucket());
+
+        Assert.Contains("  compile-fail:1", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("partial:", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("Suite errors:", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Negative: its (absent) tests must not reach the totals. The bundle contributed nothing,
+    /// and inventing a count for it would be a different lie than the one being fixed.
+    /// </summary>
+    [Fact]
+    public void CompileFailedBucket_ContributesNoTestsToTheTotals()
+    {
+        var output = Summarise(CleanBucket(), CompileFailedBucket());
+
+        Assert.Contains("Tests:         1 total", output, StringComparison.Ordinal);
+        Assert.Contains("  pass:        1", output, StringComparison.Ordinal);
+        Assert.Contains("  fail:        0", output, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner/Reporter.cs
+++ b/AlRunner/Reporter.cs
@@ -180,6 +180,33 @@ public static class Reporter
                 foreach (var e in b.CompileErrors) w.WriteLine($"  {e}");
             }
         }
+        // #2764, and the same argument as the "Suite errors" block directly above, for the case
+        // one step further along: a bucket that did not compile AT ALL contributes no tests, so
+        // every number in the Tests block is byte-identical to a clean run of whatever else ran.
+        // `compile-fail:` does move, but the line naming WHICH bundle and WHY was written when it
+        // happened — tens to thousands of lines above this point — and PrintPerTest's
+        // "=== X — COMPILE FAIL ===" block sits up there with it.
+        //
+        // In a one-shot run the exit code still catches it. Under --watch there is no exit code
+        // at all: this summary IS the interface, nobody scrolls a live session, and the faster
+        // the loop the more it is trusted. Deliberately the same shape as the block above rather
+        // than a second spelling of it — name the bucket, repeat its errors VERBATIM (a
+        // paraphrase sends the reader back up the log), and print nothing at all when there is
+        // nothing to say, so a clean run's summary is unchanged.
+        var failedBuckets = buckets.Where(b => b.Stage == BucketStage.CompileFailed).ToList();
+        if (failedBuckets.Count > 0)
+        {
+            w.WriteLine("-----------------------------------------------------------------");
+            w.WriteLine($"Compile failures: {failedBuckets.Count} bucket(s) did not compile, so "
+                + "NONE of the tests they declare appear in the counts above — this run covers "
+                + "less than it discovered.");
+            foreach (var b in failedBuckets)
+            {
+                w.WriteLine(b.BucketPath);
+                foreach (var e in b.CompileErrors) w.WriteLine($"  {e}");
+                if (b.ProcessError != null) w.WriteLine($"  {b.ProcessError}");
+            }
+        }
         var gaps = buckets
             .SelectMany(b => b.ProvisionGaps ?? Array.Empty<string>())
             .Distinct(StringComparer.Ordinal)


### PR DESCRIPTION
Closes #2764

Written by agent impl-3, who also filed it.

## What was wrong

A bucket that failed to compile contributes no tests, so **every number in the summary's Tests block is byte-identical to a clean run** of whatever else ran:

```
Buckets:       2 total
  ran:         1
  compile-fail:1
  exec-fail:   0
Tests:         1 total
  pass:        1
  fail:        0
  error:       0
```

`compile-fail:` does move. But the line saying *which* bundle and *why* was written when it happened — tens to thousands of lines above the block a developer actually reads — and `PrintPerTest`'s `=== X — COMPILE FAIL ===` sits up there with it.

In a one-shot run the exit code still catches it. **Under `--watch` there is no exit code at all**: the summary is the interface, nobody scrolls a live session, and the faster the loop the more it is trusted. That is the gap the neighbouring work stops short of — #2793 named lost suites and impl-8 established the exit-code half was already correct, and **neither reaches a mode that has no exit code**.

## The fix

`PrintSummary` now prints a `Compile failures` section naming each bucket and repeating its errors verbatim, **deliberately the same shape #2793 introduced** for buckets that ran but lost a suite rather than a second spelling of it. Printed only when there are any, so a clean run's summary is unchanged.

End to end on a two-bundle run where one does not compile:

```
-----------------------------------------------------------------
Compile failures: 1 bucket(s) did not compile, so NONE of the tests they declare appear in
the counts above — this run covers less than it discovered.
/…/cf2764/broken
  <bundled>: EMIT-ZERO (2 AL error(s))
```

## Scoped to the plain-line path, on purpose

The interactive dashboard was **already correct** and I did not touch it: `WatchDashboard` renders a `COMPILE FAILED` tree node carrying the errors, and `Tally` counts the bucket as one error so the footer never reads a clean `1P / 0F / 0E`. The plain-line path is where the issue's transcript came from, and it is what a TUI front-end or a test harness consumes.

## Tests

`AlRunner.Tests/CompileFailedBucketReportingTests`, five cases. **RED** on the naming claim before the change (`Not found: "/bundle-broken"`), **GREEN** after.

The negatives carry the weight here:

- a clean run must print **no** such section — one that appears unconditionally is noise, and every integration test asserting on the surrounding markers would be asserting past it;
- a compile-failed bucket must **not** be folded into #2793's `partial:` counter — it never ran, which is a different and worse thing than losing a suite;
- its absent tests must **not** reach the totals — inventing a count would be a different lie than the one being fixed.

One test is deliberately documentary rather than proving: `ACompileFailure_LeavesTheTestTotalsIdentical_SoTheNamingMustCarryIt` asserts the Tests block is identical with and without the failed bundle. It would pass against any change — its job is to record *why* the naming is necessary, and it is labelled as such rather than left to look like coverage.

**Run locally:** `--filter "FullyQualifiedName~CompileFailedBucketReportingTests"` — 5 passed. `--filter "~Summary|~Reporter|~PartialSuiteLoss|~ProvisionGap|~CompileFail|~Watch|~Output"` — 128 passed, 3 skipped, 1 m 16 s. I did not run the full `AlRunner.Tests` suite locally; CI runs it on the two legs that carry it.

## Shape questions

1. **Same wrong pattern elsewhere?** `exec-fail` has the identical shape — a bucket that failed to execute also contributes no tests. It is not covered here because I have no reproduction of it and did not want to add an untested branch; worth a follow-up if you want it, and the section is written so adding that case is a two-line change.
2. **Sibling assumption?** The dashboard path was checked rather than assumed, and found already correct.
3. **Two writers, one invariant?** `PrintSummary` and `WatchDashboard.Tally` both answer "did this run cover what it discovered". The dashboard already counted a compile-failed bucket as an error; the summary did not. They agree now.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
