### PR TITLE
fix(resume): hand the carry directory to the child, so a killed parent stops costing the run

### DIFF
--- a/AlRunner.Tests/ScratchDirsOwnershipTransferTests.cs
+++ b/AlRunner.Tests/ScratchDirsOwnershipTransferTests.cs
@@ -1,0 +1,187 @@
+// ScratchDirsOwnershipTransferTests — handing a scratch directory to the process that needs it
+// (issue #2824).
+//
+// The watchdog resume's carry directory is written by the PARENT attempt and read by the CHILD,
+// at the very end of a run that may take minutes. Owned by the parent it dies with the parent:
+// SIGTERM runs the parent's ProcessExit, which deletes what it owns, and SIGKILL leaves an owner
+// that is dead, so the next runner start sweeps it correctly and legitimately. #2747/#2822 made
+// that loss LOUD; this makes it rare, and the two are independent — nothing here removes the need
+// to shout when a carry file is missing for some other reason.
+//
+// As in #2747, these test the BEHAVIOUR rather than the scenario: what matters is what the sweep
+// and the exit handler do with a transferred directory, and that is decidable without racing a
+// kill against a real resume.
+//
+// The subtle half is the recorded start time. The sweep's liveness rule is boot-relative on Linux
+// (/proc/<pid>/stat field 22), because two processes disagree about Process.StartTime by
+// accumulated clock skew (#2706). A transfer that wrote the WRITER's boot-relative value, or a
+// wall-clock one, would hand the child a sidecar the sweeper reads as a dead owner — reintroducing
+// the drift on the one directory whose whole purpose is to outlive its writer.
+
+using System.Diagnostics;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ScratchDirsOwnershipTransferTests : IDisposable
+{
+    private readonly string _root = TestScratch.Dir("al-runner-owner-transfer-tests");
+    private readonly List<Process> _spawned = new();
+
+    public ScratchDirsOwnershipTransferTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        foreach (var p in _spawned) { try { if (!p.HasExited) p.Kill(true); } catch { } p.Dispose(); }
+        ScratchDirs.Release(_root);
+    }
+
+    /// <summary>A real, live process to hand a directory to — the stand-in for the resumed child.</summary>
+    private Process LiveProcess()
+    {
+        var p = Process.Start(new ProcessStartInfo("sleep", "120") { UseShellExecute = false })!;
+        _spawned.Add(p);
+        return p;
+    }
+
+    private string MakeDir(string name)
+    {
+        var dir = Path.Combine(_root, "al-runner-resume-" + name);
+        ScratchDirs.Create(dir);
+        File.WriteAllText(Path.Combine(dir, "attempt.xml"), "<testsuites/>");
+        return dir;
+    }
+
+    [Fact]
+    public void Transfer_StopsThisProcessOwningIt()
+    {
+        // Half the fix: the parent's own ProcessExit must no longer delete a directory it has
+        // promised to the child. ReleaseAll works off exactly this set.
+        var dir = MakeDir("disown");
+        var child = LiveProcess();
+        Assert.True(ScratchDirs.IsOwnedByThisProcess(dir), "precondition: we own it before the handoff");
+
+        Assert.True(ScratchDirs.TransferOwnership(dir, child.Id));
+
+        Assert.False(ScratchDirs.IsOwnedByThisProcess(dir),
+            "after the handoff this process must not delete the directory at its own exit");
+    }
+
+    [Fact]
+    public void Transfer_NamesTheNewOwnerWithITSBootRelativeStartTime()
+    {
+        // The correctness point. The sidecar must carry the value the SWEEPER will compute for
+        // that pid, not one computed for us — otherwise the sweep reads a live owner as dead and
+        // deletes the directory during the child's run, which is the very failure being fixed.
+        if (!OperatingSystem.IsLinux()) return;   // /proc/<pid>/stat field 22 is a Linux fact
+
+        var dir = MakeDir("jiffies");
+        var child = LiveProcess();
+
+        ScratchDirs.TransferOwnership(dir, child.Id);
+
+        Assert.True(ScratchDirs.TryReadOwner(ScratchDirs.MarkerPathFor(dir),
+            out var pid, out _, out var jiffies));
+        Assert.Equal(child.Id, pid);
+        var childJiffies = ScratchDirs.TryReadStartJiffies(child.Id);
+        Assert.NotNull(childJiffies);
+        Assert.Equal(childJiffies!.Value, jiffies);
+        // And it is genuinely the CHILD's, not ours copied across.
+        Assert.NotEqual(ScratchDirs.TryReadStartJiffies(Environment.ProcessId), jiffies);
+    }
+
+    [Fact]
+    public void AfterTransfer_TheSweepLeavesItAloneWhileTheNewOwnerLives()
+    {
+        // The other half: a sweep by any runner on the machine must read the directory as live.
+        var dir = MakeDir("survives");
+        var child = LiveProcess();
+
+        ScratchDirs.TransferOwnership(dir, child.Id);
+        var r = ScratchDirs.SweepStale(_root);
+
+        Assert.True(Directory.Exists(dir), "a directory handed to a LIVE process was swept away");
+        Assert.Empty(r.Removed);
+    }
+
+    [Fact]
+    public void AfterTheNewOwnerDies_TheSweepReclaimsIt()
+    {
+        // The handoff must not create an immortal directory: once the child is gone nobody needs
+        // the carry files, and #2706's guarantee that nothing leaks still has to hold.
+        var dir = MakeDir("reclaimed");
+        var child = LiveProcess();
+        ScratchDirs.TransferOwnership(dir, child.Id);
+        child.Kill(true);
+        child.WaitForExit();
+
+        var r = ScratchDirs.SweepStale(_root);
+
+        Assert.False(Directory.Exists(dir), "a directory whose new owner has died must be reclaimed");
+        Assert.Single(r.Removed);
+    }
+
+    [Fact]
+    public void Transfer_ToADeadPid_IsReclaimedImmediately()
+    {
+        var dir = MakeDir("deadpid");
+        ScratchDirs.TransferOwnership(dir, ScratchDirsRunnerStartupTests.FindDeadPid());
+
+        ScratchDirs.SweepStale(_root);
+
+        Assert.False(Directory.Exists(dir));
+    }
+
+    [Fact]
+    public void Transfer_RefusesANonsensePid_AndKeepsOwnership()
+    {
+        // Failing toward "we still own it" is the safe direction: the directory is then deleted at
+        // our exit exactly as before, which is the pre-#2824 behaviour, not a leak.
+        var dir = MakeDir("nonsense");
+
+        Assert.False(ScratchDirs.TransferOwnership(dir, 0));
+
+        Assert.True(ScratchDirs.IsOwnedByThisProcess(dir));
+    }
+
+    [Fact]
+    public void Adopt_TakesADirectoryHandedToThisProcess()
+    {
+        var dir = MakeDir("adopt");
+        // Simulate a parent handing it to us: the sidecar names OUR pid.
+        ScratchDirs.TransferOwnership(dir, Environment.ProcessId);
+        Assert.False(ScratchDirs.IsOwnedByThisProcess(dir), "precondition: transfer disowns first");
+
+        Assert.True(ScratchDirs.AdoptIfHandedToThisProcess(dir));
+
+        Assert.True(ScratchDirs.IsOwnedByThisProcess(dir),
+            "an adopted directory must be deleted at this process's exit rather than leaking");
+    }
+
+    [Fact]
+    public void Adopt_RefusesADirectoryOwnedBySomeoneElse()
+    {
+        // THE safety test. --merge-counts takes an arbitrary path, so "adopt the directory of
+        // every carry file" would have this process delete a directory of the caller's at exit.
+        // Adoption is gated on the sidecar already naming us, which a hand-passed path never does.
+        var dir = MakeDir("someone-else");
+        var other = LiveProcess();
+        ScratchDirs.TransferOwnership(dir, other.Id);
+
+        Assert.False(ScratchDirs.AdoptIfHandedToThisProcess(dir));
+        Assert.False(ScratchDirs.IsOwnedByThisProcess(dir));
+    }
+
+    [Fact]
+    public void Adopt_RefusesADirectoryWithNoSidecarAtAll()
+    {
+        // A plain directory the caller pointed --merge-counts into. Nothing about it says ours.
+        var dir = Path.Combine(_root, "al-runner-resume-unmarked");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "attempt.xml"), "<testsuites/>");
+
+        Assert.False(ScratchDirs.AdoptIfHandedToThisProcess(dir));
+        Assert.False(ScratchDirs.IsOwnedByThisProcess(dir));
+    }
+}

--- a/AlRunner/Infrastructure/AbortResume.cs
+++ b/AlRunner/Infrastructure/AbortResume.cs
@@ -91,7 +91,8 @@ internal static class AbortResume
     /// </summary>
     public static int Rerun(IReadOnlyList<string> originalArgs, IReadOnlyCollection<string> exclusions,
         int remainingBudget, IReadOnlyCollection<string>? carryFiles = null,
-        IReadOnlyCollection<string>? carryResultFiles = null)
+        IReadOnlyCollection<string>? carryResultFiles = null,
+        string? carryDirectory = null)
     {
         var childArgs = BuildChildArgs(originalArgs, exclusions, remainingBudget,
             carryFiles ?? Array.Empty<string>(), carryResultFiles ?? Array.Empty<string>());
@@ -122,6 +123,20 @@ internal static class AbortResume
             Console.Error.WriteLine("resume: could not start the retry process; reporting the aborted run as-is.");
             return 3;
         }
+
+        // #2824: the carry directory is written by THIS process but READ by the child, at the very
+        // end of a run that may take minutes. Owned by us, it dies with us — SIGTERM here runs our
+        // ProcessExit and deletes it out from under a live child, and SIGKILL leaves an owner that
+        // is dead, so the next runner start on the machine sweeps it correctly. The child is the
+        // one that needs it, so the child should own it. Done HERE rather than before the spawn
+        // because the pid to name does not exist until Process.Start returns.
+        //
+        // This lowers the PROBABILITY of the loss; it does not remove the need to shout when a
+        // carry file is missing anyway (a /tmp cleaner, a full disk, an operator rm). #2747's
+        // loud refusal stays exactly as it is.
+        if (carryDirectory != null)
+            AlRunner.Infrastructure.ScratchDirs.TransferOwnership(carryDirectory, p.Id);
+
         p.WaitForExit();
 
         // A resumed run must NEVER report clean success. The retry can legitimately exit 0 — the

--- a/AlRunner/Infrastructure/ScratchDirs.cs
+++ b/AlRunner/Infrastructure/ScratchDirs.cs
@@ -156,6 +156,87 @@ public static class ScratchDirs
         DeleteTreeAndMarker(full);
     }
 
+    /// <summary>
+    /// Hand <paramref name="dir"/> to <paramref name="pid"/>: stop deleting it at this process's
+    /// exit, and rewrite the sidecar so the sweep judges it by that pid's liveness instead of
+    /// this one's (issue #2824).
+    ///
+    /// The case this exists for is the watchdog resume's carry directory. It is written by the
+    /// PARENT attempt, which then sits waiting while the child runs — and the child does not read
+    /// it until it writes its own outputs, at the very end. So the file must survive the child's
+    /// whole run under an owner that is not using it, and killing the parent alone loses it two
+    /// ways: SIGTERM runs the parent's ProcessExit, which deletes what it owns, and SIGKILL runs
+    /// nothing but leaves an owner that is dead, so the next runner start sweeps it correctly.
+    /// Naming the child instead makes both harmless.
+    ///
+    /// ORDER MATTERS. Disown first, then rewrite. Killed in between, this leaves a sidecar naming
+    /// a dead parent, which the next sweep reclaims — exactly today's behaviour, so the window is
+    /// no worse than not doing this at all. The other order has a window where the parent's own
+    /// ProcessExit deletes a directory the sidecar has already promised to the child, which is
+    /// worse than today.
+    ///
+    /// The recorded start time must be the one the SWEEP will compute for that pid, which on
+    /// Linux is boot-relative (/proc/&lt;pid&gt;/stat field 22), not Process.StartTime — see this
+    /// file's header for why the two disagree by accumulated clock skew. Writing the wall-clock
+    /// value here would reintroduce precisely the drift #2706 removed, and it would do it to a
+    /// directory whose whole point is to outlive its writer.
+    ///
+    /// Best-effort: a sidecar that cannot be rewritten leaves the directory owned as it was, which
+    /// is the pre-#2824 behaviour and still correct, just more fragile.
+    /// </summary>
+    /// <returns>True when the sidecar now names <paramref name="pid"/>.</returns>
+    public static bool TransferOwnership(string dir, int pid)
+    {
+        if (pid <= 0) return false;
+        var full = Path.GetFullPath(dir);
+
+        // Disown BEFORE rewriting — see the order note above.
+        lock (Gate) Owned.Remove(full);
+
+        long startTicks = 0;
+        try { using var p = Process.GetProcessById(pid); startTicks = p.StartTime.ToUniversalTime().Ticks; }
+        catch { /* already gone, or not inspectable: pid liveness alone will decide */ }
+        var jiffies = TryReadStartJiffies(pid) ?? 0;
+
+        try
+        {
+            File.WriteAllText(MarkerPathFor(full),
+                $"pid={pid}\nstart={startTicks}\nstartjiffies={jiffies}\ncreated={DateTime.UtcNow:O}\n");
+            return true;
+        }
+        catch (IOException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
+    }
+
+    /// <summary>
+    /// Take responsibility for a directory a previous process handed to THIS one, so it is
+    /// deleted at this process's exit rather than leaking (issue #2824).
+    ///
+    /// Adopts ONLY when the sidecar already names this process — which is true exactly when a
+    /// parent called <see cref="TransferOwnership"/> for us, and false for a path a user typed on
+    /// the command line. That condition is the whole safety argument: <c>--merge-counts</c> takes
+    /// an arbitrary path, and a rule like "adopt the directory of every carry file" would have
+    /// this process delete a directory of the caller's own at exit.
+    /// </summary>
+    /// <returns>True when this process now owns it.</returns>
+    public static bool AdoptIfHandedToThisProcess(string dir)
+    {
+        var full = Path.GetFullPath(dir);
+        if (!TryReadOwner(MarkerPathFor(full), out var pid, out _, out _)) return false;
+        if (pid != Environment.ProcessId) return false;
+
+        lock (Gate)
+        {
+            Owned.Add(full);
+            if (!_exitHooked)
+            {
+                _exitHooked = true;
+                AppDomain.CurrentDomain.ProcessExit += (_, _) => ReleaseAll();
+            }
+        }
+        return true;
+    }
+
     /// <summary>True when <paramref name="dir"/> was reserved by THIS process and not yet released.</summary>
     internal static bool IsOwnedByThisProcess(string dir)
     {

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3696,6 +3696,24 @@ var willResume = resumeAborts > 0
 // JUnitReport.WriteJUnit fold the carried attempts in themselves, so a merged `results` would
 // count every carried case twice, once in each shape. Empty carry list => the same object,
 // so a run that never resumed is bit-for-bit unchanged.
+// #2824: a parent that resumed into this process handed us its carry directory — it rewrote the
+// sidecar to name our pid so its own death could not take the files with it. Take responsibility
+// for deleting it at our exit, so the handoff does not turn into a leak. Done HERE rather than at
+// argument-parsing time because the parent rewrites the sidecar AFTER Process.Start, so at parse
+// time it may still name the parent; by the time the run is over it never does.
+//
+// AdoptIfHandedToThisProcess adopts ONLY when the sidecar already names this process, which is
+// what makes it safe to call on the directory of an arbitrary --merge-counts path: a file the
+// caller passed by hand has no such sidecar, and this process must not delete a directory of
+// theirs at exit.
+foreach (var carriedFile in mergeCountsFiles.Concat(mergeResultsFiles))
+{
+    if (string.IsNullOrEmpty(carriedFile)) continue;
+    var carriedDir = Path.GetDirectoryName(Path.GetFullPath(carriedFile));
+    if (!string.IsNullOrEmpty(carriedDir))
+        AlRunner.Infrastructure.ScratchDirs.AdoptIfHandedToThisProcess(carriedDir);
+}
+
 var carriedResults = AlRunner.Infrastructure.ResumeCarry.Read(mergeResultsFiles, out _);
 
 // #2747: every attempt this run was PROMISED must actually be here. Both carry readers shrug at
@@ -3915,7 +3933,7 @@ if (willResume)
     if (carryResultsPath != null) carryResults.Add(carryResultsPath);
 
     return AlRunner.Infrastructure.AbortResume.Rerun(
-        args, nextExclusions, resumeAborts - 1, carry, carryResults);
+        args, nextExclusions, resumeAborts - 1, carry, carryResults, carryDir);
 }
 if (tddMode)
 {


### PR DESCRIPTION
Closes #2824

The watchdog resume's carry directory is written by the **parent** attempt and read by the **child**, at the very end of a run that may take minutes. Owned by the parent (`ScratchDirs`, #2706) it dies with the parent:

- **SIGTERM** — the parent's `ProcessExit` runs and deletes what it owns, while the child is still running.
- **SIGKILL** — nothing runs, but the owner is now dead, so the next runner start anywhere on the machine sweeps the directory correctly and legitimately.

On a busy box under `--jobs`, the second is the likelier one. The child is the process that needs the files, so the child should own them. `AbortResume.Rerun` now calls `ScratchDirs.TransferOwnership` right after `Process.Start` — the earliest it can, because the pid to name does not exist until then — and the child adopts the directory once its run is over so the handoff does not become a leak.

## This does not replace #2822, and must not be read as doing so

This lowers the **probability** of the loss. It does not remove the **silence** when a carry file is missing for some other reason — a `/tmp` cleaner, a full disk, an operator `rm` — and the silence, not the race, was the defect. #2747's loud refusal remains the safety property; this is the quality-of-life change that makes it fire less often.

Please do not let this tempt anyone into deleting that check later. Verified the two are independent and merge cleanly: this touches `ScratchDirs`/`AbortResume`, #2822 touches the audit in `Program.cs`.

## Two details that are easy to get silently wrong

**Order — disown first, then rewrite.** Killed in between, that leaves a sidecar naming a dead parent, which the next sweep reclaims: exactly today's behaviour, so the window is no worse than not doing this at all. The other order has a window where the parent's own `ProcessExit` deletes a directory the sidecar has already promised to the child — worse than today.

**Start time — record the value the sweeper will compute for that pid.** The liveness rule is boot-relative on Linux (`/proc/<pid>/stat` field 22), because two processes disagree about `Process.StartTime` by accumulated clock skew (#2706). Writing the *writer's* value would reintroduce precisely the drift that fix removed, on the one directory whose entire purpose is to outlive its writer.

That one is not hypothetical. Mutating the transfer to record our own value fails two tests — and the second fails by the **consequence** rather than the field: `AfterTransfer_TheSweepLeavesItAloneWhileTheNewOwnerLives` goes red because the sweep deletes a live child's directory.

```
Failed  Transfer_NamesTheNewOwnerWithITSBootRelativeStartTime
Failed  AfterTransfer_TheSweepLeavesItAloneWhileTheNewOwnerLives
Failed: 2, Passed: 7
```

**Adoption safety.** `AdoptIfHandedToThisProcess` adopts **only** when the sidecar already names this process, which is true exactly when a parent transferred it to us. `--merge-counts` takes an arbitrary path, so a rule like "adopt the directory of every carry file" would have the runner delete a directory of the caller's own at exit. Adoption also happens after the run rather than at argument-parsing time, because the parent rewrites the sidecar *after* `Process.Start`, so at parse time it may still name the parent.

## Tested as behaviour, not by racing a kill

Same approach as #2747: what matters is what the sweep and the exit handler do with a transferred directory, and that is decidable directly. Nine tests — the transfer disowns; it names the new owner with **its** boot-relative time; the sweep leaves it alone while that owner lives and reclaims it once it dies; a nonsense pid keeps ownership here (failing toward the pre-#2824 behaviour, not toward a leak); adoption takes what was handed to us and refuses a directory owned by someone else or carrying no sidecar at all.

End to end: a real resume still carries every attempt into its JUnit (`Hangs`, `RanBeforeHang`, `SecondA`) and leaves **zero** carry directories behind, so the handoff cleans up as completely as the pre-transfer ownership did.

Ran: `ScratchDirs`, `AbortResume`, `ResumeCarry`, `SuiteAbortOnTimeout`, `CacheRoots`, `NoCacheLastWins`, `ParallelFanOut`, `JUnitReport` — **124 passed**. No new CLI flag. `test-count-baseline.json` untouched; read in place at **2500** on this base.

Written by agent impl-5.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
