### PR TITLE
test(startsession): restore AL coverage of the dispatch path behind the isolation guard

### DIFF
--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -504,6 +504,35 @@ jobs:
               --count-baseline tests/expectations/count-baseline/test-count-baseline.json \
               --out runner-extras-results.json
 
+      - name: Run runner-extras suites that need --isolation disabled
+        # A SECOND invocation because isolation is a process-global flag with no per-bundle
+        # override, and the step above runs one process under the default (Codeunit). Same
+        # shape as the al-language xmlport order-independence guard above: another `dotnet run`
+        # with different flags over a different root.
+        #
+        # What it protects (issue #2826): real BC refuses StartSession from inside a [Test]
+        # unless the TestRunner declares TestIsolation = Disabled — pinned upstream by corpus
+        # codeunit 60397 on all eight BC versions, and implemented by the runner in #2805. That
+        # left the dispatch path BEHIND the guard (#2733, #2752 — worker construction, resolving
+        # OnRun against the OnRunAsync flavour BC's compiler emits for precompiled codeunits,
+        # and awaiting the resulting ValueTask) reachable from AL only with the guard stood
+        # down. #2733 was a genuine silent no-op, so that coverage is worth a second process.
+        #
+        # always() for the same reason the xmlport guard has it: this answers a different
+        # question from the step above and its answer matters most when something is broken.
+        #
+        # Deliberately NO --count-baseline. The baseline is keyed per suite and a third key for
+        # three tests buys a number nobody reads, in a file that is already a merge-conflict
+        # magnet. --strict is what makes this a gate.
+        if: ${{ always() && hashFiles('tests/runner-extras-isolation-disabled/**/*.al') != '' }}
+        run: |
+          dotnet run --no-build --project AlRunner -c Release --framework net8.0 -- \
+              tests/runner-extras-isolation-disabled \
+              --package-cache "$HOME/.al-runner/platform-apps" \
+              --package-cache "$HOME/.al-runner/test-apps" \
+              --isolation disabled \
+              --strict
+
       - name: Phase-log report (runner-extras)
         # The step with the most to say: 25 app groups in ONE process (down from 38 —
         # see #1847, which folded 16 standalone-with-no-hazard suites into

--- a/tests/runner-extras-isolation-disabled/README.md
+++ b/tests/runner-extras-isolation-disabled/README.md
@@ -1,0 +1,25 @@
+# runner-extras-isolation-disabled
+
+Suites here need `--isolation disabled`, so they are a **sibling of** `tests/runner-extras/`
+rather than a directory inside it: the main runner-extras CI step runs one invocation under the
+default isolation mode (Codeunit) and has no per-bundle override and no exclusion mechanism.
+
+They get their own step in `.github/workflows/bc-tests.yml`, the same shape as the al-language
+xmlport order-independence guard — a second `dotnet run` with different flags over a different
+root.
+
+Deliberately **not** passed `--count-baseline`. The baseline in
+`tests/expectations/count-baseline/test-count-baseline.json` is keyed per suite, and adding a
+third key for a handful of tests buys a number nobody reads at the cost of a file that is
+already a merge-conflict magnet. `--strict` is what makes this step a gate.
+
+## Why a whole directory for this
+
+`StartSession` from inside a `[Test]` is refused by real BC unless the TestRunner declares
+`TestIsolation = Disabled` (issue #2805, corpus codeunit 60397, green on all eight BC
+versions). The runner implements that guard. So the dispatch path *behind* the guard — worker
+construction, resolving `OnRun` against the `OnRunAsync` flavour BC's compiler emits for
+precompiled codeunits, and awaiting the resulting `ValueTask` — is reachable from AL only with
+the guard stood down, and that is a process-global flag.
+
+See issue #2826.

--- a/tests/runner-extras-isolation-disabled/startsession-dispatch/SsdAssert.Codeunit.al
+++ b/tests/runner-extras-isolation-disabled/startsession-dispatch/SsdAssert.Codeunit.al
@@ -1,0 +1,22 @@
+// Standalone Assert codeunit — this suite must stand alone (tests/runner-extras/README.md),
+// it does not import from tests/al-language.
+codeunit 61103 "Ssd Assert"
+{
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error('Assert.IsTrue failed. %1', Msg);
+    end;
+
+    procedure AreEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if Format(Expected) <> Format(Actual) then
+            Error('Assert.AreEqual failed. Expected <%1>, got <%2>. %3', Format(Expected), Format(Actual), Msg);
+    end;
+
+    procedure Contains(Haystack: Text; Needle: Text; Msg: Text)
+    begin
+        if StrPos(Haystack, Needle) = 0 then
+            Error('Assert.Contains failed. ''%1'' does not contain ''%2''. %3', Haystack, Needle, Msg);
+    end;
+}

--- a/tests/runner-extras-isolation-disabled/startsession-dispatch/SsdTests.Codeunit.al
+++ b/tests/runner-extras-isolation-disabled/startsession-dispatch/SsdTests.Codeunit.al
@@ -1,0 +1,107 @@
+// Issue #2826 — AL coverage of the StartSession dispatch path (#2733, #2752), preserved after
+// #2805 made StartSession refuse from inside a [Test] under the default isolation mode.
+//
+// WHY THIS SUITE IS NOT IN tests/runner-extras
+// --------------------------------------------
+// Real BC refuses StartSession from inside a [Test] unless the TestRunner declares
+// TestIsolation = Disabled — pinned upstream by corpus codeunit 60397 on all eight BC
+// versions, and the runner implements it. Isolation is a process-global CLI flag with no
+// per-bundle override, and the runner-extras CI step is one invocation under the default. So
+// the dispatch path BEHIND the guard is reachable from AL only in a separate invocation, which
+// is what this directory and its own bc-tests.yml step exist for.
+//
+// WHY THE WORKER MUST BE PRECOMPILED
+// ----------------------------------
+// BC's compiler emits `trigger OnRun()` as an async OnRunAsync on the concrete type for the
+// dependency-compile path, and as a synchronous OnRun override for the runner's own emit. Both
+// are virtuals on NavCodeunit with an EMPTY base body, so a sync-name-only reflection lookup
+// always resolves — it binds and runs the empty base. SessionPatches.AlRunnerStartSession did
+// exactly that, so StartSession on any Base Application / System Application / ISV worker
+// returned true having executed none of its AL (#2733).
+//
+// A source-compiled sibling app is NOT enough: measured, a `-dep` fixture bundle compiled from
+// .al alongside the test bundle carries the SYNC flavour and passes against the unfixed runner,
+// so it proves nothing. The same distinction is recorded in
+// tests/runner-extras/depapp-dictionary-main.
+//
+// Base Application codeunit 7002 "Price Calculation - V16" is the smallest precompiled worker
+// with an OnRun whose effect is observable and needs no setup: it rewrites its own rows in
+// "Price Calculation Setup". Codeunit 7003 "Price Calculation - V15" is its twin, which makes
+// the pair differential.
+//
+// EVERY ASSERTION READS A ROW THE WORKER'S BODY WROTE. None asserts that StartSession returned,
+// or that it did not throw — the broken behaviour satisfied both, which is precisely why it
+// went unnoticed. A test here that only ran the path would restore the appearance of this
+// coverage without its substance.
+codeunit 61104 "Ssd StartSession Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Ssd Assert";
+
+    [Test]
+    procedure PrecompiledCodeunit_StartSession_RunsTheWorkersOnRunBody()
+    var
+        PriceCalculationSetup: Record "Price Calculation Setup";
+        SessionId: Integer;
+        Started: Boolean;
+    begin
+        PriceCalculationSetup.DeleteAll();
+
+        Started := StartSession(SessionId, Codeunit::"Price Calculation - V16");
+
+        Assert.IsTrue(Started, 'StartSession must report that it started the session.');
+        Assert.IsTrue(SessionId > 0,
+            StrSubstNo('BC guarantees a non-zero session id after StartSession; got %1.', SessionId));
+
+        PriceCalculationSetup.SetRange(
+            Implementation, PriceCalculationSetup.Implementation::"Business Central (Version 16.0)");
+        Assert.AreEqual(2, PriceCalculationSetup.Count(),
+            'Codeunit 7002''s OnRun body inserts its Purchase and Sale setup rows. The empty inherited ' +
+            'NavCodeunit.OnRun returns just as quietly and writes nothing.');
+        Assert.IsTrue(PriceCalculationSetup.FindFirst(), 'the rows the worker wrote must be readable');
+        Assert.IsTrue(PriceCalculationSetup.Default,
+            'OnRun ends in ModifyAll(Default, true), so the rows it wrote must carry Default = true.');
+    end;
+
+    // Differential: starting the V15 worker must run THAT worker, not the V16 one. Together
+    // with the test above this rules out "some codeunit ran" as the explanation.
+    [Test]
+    procedure PrecompiledCodeunit_StartSession_RunsTheWorkerItWasGiven_AndNoOther()
+    var
+        PriceCalculationSetup: Record "Price Calculation Setup";
+        SessionId: Integer;
+    begin
+        PriceCalculationSetup.DeleteAll();
+
+        Assert.IsTrue(StartSession(SessionId, Codeunit::"Price Calculation - V15"),
+            'StartSession must report that it started the session.');
+
+        PriceCalculationSetup.SetRange(
+            Implementation, PriceCalculationSetup.Implementation::"Business Central (Version 15.0)");
+        Assert.AreEqual(2, PriceCalculationSetup.Count(),
+            'Codeunit 7003''s OnRun body must have inserted its two setup rows.');
+
+        PriceCalculationSetup.SetRange(
+            Implementation, PriceCalculationSetup.Implementation::"Business Central (Version 16.0)");
+        Assert.AreEqual(0, PriceCalculationSetup.Count(),
+            'Starting the V15 worker must not have run the V16 worker''s body.');
+    end;
+
+    // Negative: an object id with no codeunit behind it must fail LOUDLY rather than return
+    // true having done nothing — the exact failure mode this whole area is about.
+    // Deliberately asserts only the error text: an error rolls the write transaction back to
+    // the last commit point, so any table read placed after this asserterror would report the
+    // state before the test began (see tests/al-language error-handling/TestAssertErrorRollback.al).
+    [Test]
+    procedure PrecompiledCodeunit_StartSession_OnAnIdWithNoCodeunit_FailsLoudly()
+    var
+        SessionId: Integer;
+    begin
+        asserterror StartSession(SessionId, 1999999);
+
+        Assert.Contains(GetLastErrorText(), '1999999',
+            'A StartSession naming an object id with no codeunit behind it must fail and name that id.');
+    end;
+}

--- a/tests/runner-extras-isolation-disabled/startsession-dispatch/app.json
+++ b/tests/runner-extras-isolation-disabled/startsession-dispatch/app.json
@@ -1,0 +1,19 @@
+{
+  "id": "a2826d51-6b47-4c8e-9a13-58f2c7b0e491",
+  "name": "Runner Extras - StartSession Dispatch (isolation disabled)",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Issue #2826: keeps AL coverage of the StartSession dispatch path (#2733, #2752) after #2805 made StartSession refuse from inside a [Test] under the default isolation mode. Runs only under --isolation disabled, which is why it is not in tests/runner-extras.",
+  "description": "The worker has to be genuinely PRECOMPILED. BC's compiler emits a codeunit's trigger OnRun() as an async OnRunAsync on the concrete type for the dependency-compile path, and as a synchronous OnRun override for the runner's own emit; both are virtuals on NavCodeunit with an EMPTY base body, so a sync-name-only reflection lookup always resolves and runs the empty base. That was #2733: StartSession on any Base Application worker returned true having executed none of its AL. A source-compiled sibling app does NOT reproduce it -- measured, and recorded in tests/runner-extras/depapp-dictionary-main -- so these tests use Base Application codeunit 7002 'Price Calculation - V16' and its twin 7003 'Price Calculation - V15', the smallest precompiled workers whose OnRun has an observable effect needing no setup. Every assertion reads a row the worker's body writes; none asserts merely that StartSession returned or did not throw, because the broken behaviour satisfied both.",
+  "dependencies": [],
+  "idRanges": [
+    {
+      "from": 61103,
+      "to": 61109
+    }
+  ],
+  "platform": "27.0.0.0",
+  "application": "27.0.0.0",
+  "runtime": "17.0",
+  "target": "Cloud"
+}


### PR DESCRIPTION
Closes #2826

Written by agent impl-3.

## What was lost

#2805 implements BC's guard: `StartSession` from inside a `[Test]` is refused unless the TestRunner declares `TestIsolation = Disabled` — pinned upstream by corpus codeunit 60397 on all eight BC versions. Three `runner-extras` tests asserted the opposite and were green only because the guard was missing; #2825 rewrites them to assert the refusal, which is the BC-faithful claim.

The cost is that **#2733/#2752's dispatch path becomes reachable from AL only under `--isolation disabled`**, which no suite runs: worker construction under the skeleton tree root, resolving `OnRun` against the `OnRunAsync` flavour BC's compiler emits for precompiled codeunits, and awaiting the resulting `ValueTask`. #2733 was a genuine silent no-op — `StartSession` on any Base App worker returned `true` having executed none of its AL — so that coverage is worth having back.

## Route taken, and why

**A sibling directory plus its own CI step** (route 1 of the two the issue costed), not an `AlRunner.Tests` spawn.

Isolation is a process-global flag with no per-bundle override, and the `runner-extras` step is one process under the default mode with no exclusion mechanism. So `tests/runner-extras-isolation-disabled/` sits beside `tests/runner-extras/` and gets a second `dotnet run` in `bc-tests.yml` — the same shape as the al-language xmlport order-independence guard, which is the existing precedent for exactly this.

I did not take the `AlRunner.Tests` route. `no-base-app-in-csharp-tests.md` has a measured cost behind it (~70 s cold per runner invocation, and `AlRunner.Tests` spawns the runner ~130 times) and an enforced allowlist with a stated bar for adding to it. Pointing a spawn at the existing bundle might have threaded the rule, but it would still have added a Base-App-loading spawn to the C# suite on the two legs that carry it, to answer a question a 23-second AL invocation answers on all eight.

**No `--count-baseline` on the new step**, deliberately. The baseline is keyed per suite; a third key for three tests buys a number nobody reads, in a file that is already a merge-conflict magnet. `--strict` is what makes the step a gate.

## The tests are carried over unchanged, on purpose

Their discriminating power is the whole point, and rewriting them would have risked it. **Every assertion reads a row the worker's `OnRun` body wrote**, and the V16/V15 pair is differential — starting V15 must run *that* worker and leave V16's rows absent. None asserts that `StartSession` returned or did not throw, because the #2733 behaviour satisfied both, which is exactly why it went unnoticed.

That is the bar for a coverage-restoration task: a test that ran the path without observing the worker's effect would restore the *appearance* of this coverage and not the substance.

## Placement verified against the guard, not just against `main`

Built PR #2825's head — where the guard actually exists — and ran the new suite both ways:

| invocation | result |
|---|---|
| `--isolation disabled` | **3 pass**, worker bodies observably ran |
| default isolation | **refused**: `Sessions can only be started in tests that are run by a TestRunner that has TestIsolation set to Disabled.` |

So the separate step is *required*, not merely tidy. The suite also passes on current `main`, where the guard is not yet present, so **this PR and #2825 are independent and can merge in either order** — neither blocks the other.

## Cost

Measured locally: **22.8 s cold, 0.8 s warm** on a per-run AL-output cache, with the Base Application package cache already warm from the steps before it. In CI the AL-output cache is per-run, so the cold figure is the one to expect, once per leg.

## Left out

**`StartSession` outside a `[Test]`** — `execute` mode or an install trigger, where the guard must stay inert. The issue lists it as "also worth covering while here". It is inert by construction (`BcRuntime.InTestExecutionScope` is false), but that is still unverified, and covering it needs a non-test entry point plus its own verification pass against the guard branch. I would rather add it deliberately than bolt it on here; say the word and I will do it as a follow-up.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
