### PR TITLE
fix(object-metadata): refuse a moved primaryTree layout instead of reading it as "no rows"

### DIFF
--- a/AlRunner.Tests/ObjectMetadataProviderRowProbeTests.cs
+++ b/AlRunner.Tests/ObjectMetadataProviderRowProbeTests.cs
@@ -1,0 +1,189 @@
+// ObjectMetadataProviderRowProbeTests — contract tests for issue #2786.
+//
+// RecordPatches.ObjectMetadataSystemTable.ProviderHasAnyRow is the guard that decides
+// whether the Object Metadata (2000000071) populator synthesises its 43 rows or leaves a
+// --test-data-restored store alone. It answers that question by reading BC's PRIVATE
+// TempTableDataProvider.primaryTree field by reflection, and it used to answer "no rows,
+// go ahead and synthesise" for TWO different reasons that mean opposite things:
+//
+//   * primaryTree is null            — BC's own representation of "no row was ever
+//                                      inserted". Synthesising is correct.
+//   * the field is not there at all  — BC renamed or restructured it. The runner has no
+//                                      idea what the store holds, and synthesising would
+//                                      silently shadow real --test-data rows, disabling the
+//                                      #2519 precedence rule with no diagnostic anywhere.
+//
+// Four sibling readers of the SAME private field already fail loud on the second case
+// (RecordPatches.StoredTableCensus.cs x2 and RecordPatches.TransactionSnapshot.cs /
+// RecordPatches.InstallBaseline.cs via RequiredField -> MissingFieldException;
+// RowVersionPatches.SystemIdIntegrity.cs via PrivateMemberLookup -> InvalidOperationException
+// naming the member). This one did not. See .claude/rules/loud-failures.md.
+//
+// WHY THESE LIVE HERE AND NOT IN THE UPSTREAM CORPUS
+//   The claim is about how the RUNNER reflects on a BC private field, not about anything AL
+//   code can observe from Business Central: on every BC version the runner supports,
+//   TempTableDataProvider.primaryTree exists, so the loud branch is unreachable from AL and a
+//   service tier has nothing to adjudicate. Runner-internal reflection-resolution behaviour
+//   belongs in AlRunner.Tests — see .claude/rules/bc-behavior-tests-go-upstream.md, and the
+//   same reasoning in RowVersionPatchesTests' header.
+//
+// The fakes below are reflected-shape POCOs, the pattern RowVersionPatchesTests uses: they
+// reproduce the exact private-instance field shape the production reader walks, without
+// needing a loaded BC runtime. ProviderHasAnyRow keeps no reflection cache, so no per-test
+// static reset is needed.
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ObjectMetadataProviderRowProbeTests
+{
+    private static bool ProviderHasAnyRow(object provider)
+    {
+        var m = typeof(RecordPatches).GetMethod(
+            "ProviderHasAnyRow", BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                "test setup: RecordPatches.ProviderHasAnyRow(object) not found");
+        try
+        {
+            return (bool)m.Invoke(null, new[] { provider })!;
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            throw tie.InnerException;   // reflection wrapper is not part of the contract
+        }
+    }
+
+    // ── The defect: a moved BC layout must not read as "no rows" ─────────────────────
+
+    [Fact]
+    public void MissingPrimaryTreeField_ThrowsNamingTheFieldAndTheTable()
+    {
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
+            () => ProviderHasAnyRow(new ProviderWithoutPrimaryTree()));
+
+        // Names the member that moved, so a BC layout change points at its own fix.
+        Assert.Contains("primaryTree", ex.Message);
+        Assert.Contains(nameof(ProviderWithoutPrimaryTree), ex.Message);
+        // Names the surface and carries the docs/scope.md reason anchor the manifest matches on.
+        Assert.Equal("Object Metadata (system table 2000000071)", ex.Api);
+        Assert.StartsWith("object-metadata-system-table", ex.Reason);
+        // Says WHY it refuses rather than guessing, so the message is actionable.
+        Assert.Contains("--test-data", ex.Message);
+    }
+
+    // primaryTree present but holding something the runner cannot enumerate is the same
+    // "layout moved" case wearing a different hat — it must not read as "no rows" either.
+    [Fact]
+    public void NonEnumerablePrimaryTree_ThrowsNamingTheFieldAndTheTable()
+    {
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
+            () => ProviderHasAnyRow(new ProviderWithNonEnumerablePrimaryTree()));
+
+        Assert.Contains("primaryTree", ex.Message);
+        Assert.Equal("Object Metadata (system table 2000000071)", ex.Api);
+        Assert.StartsWith("object-metadata-system-table", ex.Reason);
+    }
+
+    // ── The positive arms: BC's genuine answers still come back, unchanged ───────────
+    // Without these, a fix that simply threw on every input would pass the two above.
+
+    [Fact]
+    public void NullPrimaryTree_IsBcsOwnNoRowsAndAnswersFalse()
+    {
+        Assert.False(ProviderHasAnyRow(new FakeTempTableDataProvider(null)));
+    }
+
+    [Fact]
+    public void EmptyPrimaryTree_AnswersFalse()
+    {
+        Assert.False(ProviderHasAnyRow(new FakeTempTableDataProvider(new List<object>())));
+    }
+
+    [Fact]
+    public void PopulatedPrimaryTree_AnswersTrue()
+    {
+        Assert.True(ProviderHasAnyRow(new FakeTempTableDataProvider(new List<object> { new() })));
+    }
+
+    // A single row is enough — the reader must short-circuit rather than count, because a
+    // --test-data restore can put a large table here and this runs on the record-open path.
+    [Fact]
+    public void PopulatedPrimaryTree_StopsAtTheFirstRow()
+    {
+        var rows = new CountingRows(3);
+        Assert.True(ProviderHasAnyRow(new FakeTempTableDataProvider(rows)));
+        Assert.Equal(1, rows.Yielded);
+    }
+
+    // ── The derived-provider case (#2725) is "found", never "layout moved" ───────────
+    // GetField(NonPublic) on a derived type does NOT return a base class's private field,
+    // and BC's own CrmTableConnection.CrmTestDataProvider derives from TempTableDataProvider.
+    // Reading the base's field as "absent" would have turned a perfectly readable store into
+    // a hard failure once this reader started refusing.
+
+    [Fact]
+    public void DerivedProvider_ReadsTheBaseClassPrivateField_AndAnswersTrue()
+    {
+        Assert.True(ProviderHasAnyRow(new DerivedProvider(new List<object> { new() })));
+    }
+
+    [Fact]
+    public void DerivedProvider_WithNullBaseClassPrivateField_AnswersFalse()
+    {
+        Assert.False(ProviderHasAnyRow(new DerivedProvider(null)));
+    }
+
+    // ── Reflected-shape fakes ────────────────────────────────────────────────────────
+
+    private sealed class ProviderWithoutPrimaryTree
+    {
+    }
+
+#pragma warning disable CS0414   // assigned and read only by the reflection under test
+    private sealed class ProviderWithNonEnumerablePrimaryTree
+    {
+        private readonly object primaryTree = new();
+    }
+
+    // Same member name, same private-instance shape as BC's TempTableDataProvider.primaryTree.
+    private sealed class FakeTempTableDataProvider
+    {
+        private readonly IEnumerable? primaryTree;
+        public FakeTempTableDataProvider(IEnumerable? rows) => primaryTree = rows;
+    }
+
+    private class BaseDeclaresPrimaryTree
+    {
+        private readonly IEnumerable? primaryTree;
+        protected BaseDeclaresPrimaryTree(IEnumerable? rows) => primaryTree = rows;
+    }
+#pragma warning restore CS0414
+
+    private sealed class DerivedProvider : BaseDeclaresPrimaryTree
+    {
+        public DerivedProvider(IEnumerable? rows) : base(rows) { }
+    }
+
+    /// <summary>Counts how many rows the reader actually pulled.</summary>
+    private sealed class CountingRows : IEnumerable
+    {
+        private readonly int _count;
+        public CountingRows(int count) => _count = count;
+        public int Yielded { get; private set; }
+
+        public IEnumerator GetEnumerator()
+        {
+            for (var i = 0; i < _count; i++)
+            {
+                Yielded++;
+                yield return new object();
+            }
+        }
+    }
+}

--- a/AlRunner.Tests/ObjectMetadataProviderRowProbeTests.cs
+++ b/AlRunner.Tests/ObjectMetadataProviderRowProbeTests.cs
@@ -59,6 +59,22 @@ public sealed class ObjectMetadataProviderRowProbeTests
         }
     }
 
+    private static void RunObjectMetadataPopulateOnce(object provider, Action populate)
+    {
+        var m = typeof(RecordPatches).GetMethod(
+            "RunObjectMetadataPopulateOnce", BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                "test setup: RecordPatches.RunObjectMetadataPopulateOnce(object, Action) not found");
+        try
+        {
+            m.Invoke(null, new object[] { provider, populate });
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            throw tie.InnerException;
+        }
+    }
+
     // ── The defect: a moved BC layout must not read as "no rows" ─────────────────────
 
     [Fact]
@@ -137,6 +153,99 @@ public sealed class ObjectMetadataProviderRowProbeTests
     public void DerivedProvider_WithNullBaseClassPrivateField_AnswersFalse()
     {
         Assert.False(ProviderHasAnyRow(new DerivedProvider(null)));
+    }
+
+    // ── The populate memo must not record a REFUSED populate as "done" ──────────────
+    // PopulateObjectMetadataSystemTable claims the provider in _omsPopulatedByProvider
+    // BEFORE it does any of the work, so every throw after that point used to leave table
+    // 2000000071 permanently marked "populated" holding whatever rows it had at the moment
+    // it failed — usually none. And a runner refusal IS catchable from AL: asserterror is
+    // MethodScopePatches.NavMethodScope_AssertError, an unfiltered `catch (Exception ex)`.
+    // So `asserterror` around a record-open of this table would swallow the refusal and
+    // leave every later access reading an empty table with no diagnostic anywhere.
+    //
+    // Ten call sites sit after that claim, not one: ProviderHasAnyRow, plus the nine
+    // RunnerOutOfScopeException throws in EnsureObjectMetadataObjectTypeOrdinal /
+    // ReadNavEnvironmentEmitVersion / EnumerateApplicationDatabaseTableIds, plus a
+    // part-way InsertVirtualRow failure. These pin the seam all ten go through.
+
+    [Fact]
+    public void PopulateOnce_BodyThrows_SecondCallRefusesAgain_NeverSilentlyMarksItPopulated()
+    {
+        var provider = new object();
+        var calls = 0;
+        void Body()
+        {
+            calls++;
+            throw new RunnerOutOfScopeException("Object Metadata (system table 2000000071)",
+                "object-metadata-system-table — synthetic refusal; see docs/scope.md");
+        }
+
+        var first = Assert.Throws<RunnerOutOfScopeException>(
+            () => RunObjectMetadataPopulateOnce(provider, Body));
+        // The second access must NOT come back quietly with an empty table.
+        var second = Assert.Throws<RunnerOutOfScopeException>(
+            () => RunObjectMetadataPopulateOnce(provider, Body));
+
+        Assert.Equal(first.Message, second.Message);
+        Assert.Equal("object-metadata-system-table — synthetic refusal; see docs/scope.md", second.Reason);
+        // Latched, not re-derived: the refusal replays from the memo rather than re-running a
+        // populate that may have left rows behind part-way through.
+        Assert.Equal(1, calls);
+    }
+
+    // The end-to-end shape of #2786 at the seam: the body is the real ProviderHasAnyRow
+    // against a provider whose layout moved. Nothing may be synthesised, and no call may
+    // ever answer quietly.
+    [Fact]
+    public void PopulateOnce_ProviderLayoutMoved_RefusesEveryTime_AndSynthesisesNothing()
+    {
+        var provider = new ProviderWithoutPrimaryTree();
+        var rowsSynthesised = 0;
+        void Body()
+        {
+            if (ProviderHasAnyRow(provider)) return;
+            rowsSynthesised++;
+        }
+
+        Assert.Throws<RunnerOutOfScopeException>(() => RunObjectMetadataPopulateOnce(provider, Body));
+        Assert.Throws<RunnerOutOfScopeException>(() => RunObjectMetadataPopulateOnce(provider, Body));
+
+        Assert.Equal(0, rowsSynthesised);
+    }
+
+    // The positive arm: a populate that SUCCEEDS is still once-only. Without this, "poison
+    // the memo on failure" could be satisfied by never memoising at all, which would
+    // re-synthesise 43 rows on every single record-open of the table.
+    [Fact]
+    public void PopulateOnce_BodySucceeds_RunsExactlyOnce_AcrossRepeatedCalls()
+    {
+        var provider = new object();
+        var calls = 0;
+
+        RunObjectMetadataPopulateOnce(provider, () => calls++);
+        RunObjectMetadataPopulateOnce(provider, () => calls++);
+        RunObjectMetadataPopulateOnce(provider, () => calls++);
+
+        Assert.Equal(1, calls);
+    }
+
+    // Two providers are two independent stores: one refusing must not poison the other.
+    [Fact]
+    public void PopulateOnce_RefusalIsPerProvider_AndDoesNotLeakToAnother()
+    {
+        var refusing = new object();
+        var healthy = new object();
+        var healthyCalls = 0;
+
+        Assert.Throws<RunnerOutOfScopeException>(() => RunObjectMetadataPopulateOnce(
+            refusing, () => throw new RunnerOutOfScopeException("api", "reason")));
+
+        var record = Record.Exception(
+            () => RunObjectMetadataPopulateOnce(healthy, () => healthyCalls++));
+
+        Assert.Null(record);
+        Assert.Equal(1, healthyCalls);
     }
 
     // ── Reflected-shape fakes ────────────────────────────────────────────────────────

--- a/AlRunner.Tests/RowVersionPatchesTests.cs
+++ b/AlRunner.Tests/RowVersionPatchesTests.cs
@@ -322,6 +322,53 @@ public sealed class RowVersionPatchesTests
         Assert.Contains("primaryTree", ex.Message);
     }
 
+    // #2786's sibling half. "primaryTree resolved, but its value is not something we can
+    // walk" is the SAME moved-layout case as "the field is gone", and it used to collapse
+    // into the null branch below the resolution — i.e. into "no rows stored yet", silently
+    // skipping the duplicate-SystemId check on every insert. A null primaryTree is BC's own
+    // "EnsureTreeCreated has not run yet" and stays a quiet no-op (the test right below);
+    // a non-null value the runner cannot enumerate is a runner bug and now says so.
+    [Fact]
+    public void OnBeforeInsert_PrimaryTreeNotEnumerable_ExplicitSystemId_ThrowsNamingTheMember()
+    {
+        ResetReflectionCache();
+        var provider = MarkDatabaseBackedProvider(new ProviderWithNonEnumerablePrimaryTree());
+        var metaTable = new FakeMetaTable(timestampField: null, systemIdField: new FakeMetaField(0));
+        var buffer = new FakeBuffer(metaTable, slotCount: 1) { [0] = NavGuid.NewGuid() };
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => RowVersionPatches.OnBeforeInsert(provider, CompanyToken, buffer));
+
+        Assert.Contains("primaryTree", ex.Message);
+        Assert.Contains(nameof(ProviderWithNonEnumerablePrimaryTree), ex.Message);
+    }
+
+    // The positive arm that keeps the throw above from swallowing BC's genuine "no rows
+    // yet": a NULL primaryTree is what a provider looks like before the real Insert body
+    // runs EnsureTreeCreated, and it must stay a silent, exception-free no-op.
+    [Fact]
+    public void OnBeforeInsert_NullPrimaryTree_ExplicitSystemId_IsAQuietNoOp()
+    {
+        ResetReflectionCache();
+        var provider = MarkDatabaseBackedProvider(new FakeProvider(null));
+        var metaTable = new FakeMetaTable(timestampField: null, systemIdField: new FakeMetaField(0));
+        var buffer = new FakeBuffer(metaTable, slotCount: 1) { [0] = NavGuid.NewGuid() };
+
+        var record = Record.Exception(
+            () => RowVersionPatches.OnBeforeInsert(provider, CompanyToken, buffer));
+
+        Assert.Null(record);
+    }
+
+    // Same member name as BC's TempTableDataProvider.primaryTree, holding something that
+    // cannot be walked — the shape a future BC layout change would produce.
+#pragma warning disable CS0414   // assigned and read only by the reflection under test
+    private sealed class ProviderWithNonEnumerablePrimaryTree
+    {
+        private readonly object primaryTree = new();
+    }
+#pragma warning restore CS0414
+
     // ── #2573: Modify never lets an existing row's SystemId change ────────────────
 
     [Fact]

--- a/AlRunner/Patches/RecordPatches.ObjectMetadataSystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.ObjectMetadataSystemTable.cs
@@ -138,6 +138,7 @@
 using System.Collections;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
 using AlRunner.Infrastructure;
 using Microsoft.Dynamics.Nav.Runtime;
 
@@ -161,7 +162,13 @@ public static partial class RecordPatches
 
     // Populated-once guard, per in-memory provider. The row set is a fixed BC-declared list,
     // so unlike AllObj there is nothing to top up on a later handout.
+    //
+    // The value is either _omsPopulateSucceeded or the ExceptionDispatchInfo of the refusal
+    // that stopped it — see RunObjectMetadataPopulateOnce for why a failure has to be
+    // remembered rather than forgotten.
     private static readonly ConditionalWeakTable<object, object> _omsPopulatedByProvider = new();
+
+    private static readonly object _omsPopulateSucceeded = new();
 
     private static int[]? _omsApplicationDatabaseTableIds;
     private static int? _omsObjectTypeOrdinal;
@@ -188,24 +195,77 @@ public static partial class RecordPatches
                 "Object Metadata (system table 2000000071)",
                 "object-metadata-system-table — data access has no in-memory provider; see docs/scope.md");
 
+        RunObjectMetadataPopulateOnce(provider, () =>
+        {
+            // --test-data (or an install baseline) already put real rows here — leave them alone.
+            if (ProviderHasAnyRow(provider)) return;
+
+            var objectTypeOrdinal = EnsureObjectMetadataObjectTypeOrdinal(metaTable);
+            var emitVersion = ReadNavEnvironmentEmitVersion();
+
+            foreach (var tableId in EnumerateApplicationDatabaseTableIds())
+            {
+                InsertVirtualRow(provider, metaTable,
+                    new object[] { ObjectMetadataSystemTableId, objectTypeOrdinal, tableId, emitVersion },
+                    field => BuildObjectMetadataValue(field, objectTypeOrdinal, tableId, emitVersion));
+            }
+        });
+    }
+
+    /// <summary>
+    /// Run <paramref name="populate"/> at most once per provider, and never let a populate
+    /// that REFUSED be remembered as one that succeeded.
+    ///
+    /// <para>WHY THE FAILURE PATH EXISTS (#2786 review). The claim below is taken BEFORE any
+    /// of the work, which is what makes the populate once-only under the concurrent handout
+    /// in GetDataAccessForTableCore. Ten things after that claim can throw:
+    /// <see cref="ProviderHasAnyRow"/>, the nine <see cref="RunnerOutOfScopeException"/>
+    /// throws across <see cref="EnsureObjectMetadataObjectTypeOrdinal"/>,
+    /// <see cref="ReadNavEnvironmentEmitVersion"/> and
+    /// <see cref="EnumerateApplicationDatabaseTableIds"/>, and an <c>InsertVirtualRow</c> that
+    /// fails part-way through the row set. Left alone, every one of them marked table
+    /// 2000000071 "populated" holding whatever it had at the moment it failed — usually
+    /// nothing — and every later access read an empty table with no diagnostic.</para>
+    ///
+    /// <para>THAT IS REACHABLE FROM AL, not just in theory. A runner refusal IS catchable:
+    /// AL's <c>asserterror</c> is MethodScopePatches.NavMethodScope_AssertError, an unfiltered
+    /// <c>catch (Exception ex)</c>, and this populate runs on the record-open path an
+    /// <c>asserterror</c> can wrap. So the refusal gets swallowed and the empty table is what
+    /// the rest of the test sees.</para>
+    ///
+    /// <para>A REFUSAL IS REPLAYED, NOT RETRIED. Retrying looks kinder and is worse: an
+    /// <c>InsertVirtualRow</c> that failed on row 20 leaves 19 rows behind, so the retry's own
+    /// <see cref="ProviderHasAnyRow"/> answers "already populated" and returns quietly — a
+    /// silently PARTIAL table, which is the bug this method exists to prevent wearing a
+    /// different hat. None of these failures is transient anyway: BC's layout does not change
+    /// mid-run. Same principle as RowVersionPatches' "no loud-once-then-silent latch"
+    /// (#1986), in the opposite direction — there the latch made a failure go quiet, here it
+    /// is what keeps it loud.</para>
+    /// </summary>
+    private static void RunObjectMetadataPopulateOnce(object provider, Action populate)
+    {
         // One populate per provider; the row set never grows within a run.
         lock (_omsPopulatedByProvider)
         {
-            if (_omsPopulatedByProvider.TryGetValue(provider, out _)) return;
-            _omsPopulatedByProvider.Add(provider, provider);
+            if (_omsPopulatedByProvider.TryGetValue(provider, out var prior))
+            {
+                // Throw() rather than `throw`: it preserves the original refusal's stack, so
+                // the message still points at the member that actually moved.
+                if (prior is ExceptionDispatchInfo refused) refused.Throw();
+                return;
+            }
+            _omsPopulatedByProvider.Add(provider, _omsPopulateSucceeded);
         }
 
-        // --test-data (or an install baseline) already put real rows here — leave them alone.
-        if (ProviderHasAnyRow(provider)) return;
-
-        var objectTypeOrdinal = EnsureObjectMetadataObjectTypeOrdinal(metaTable);
-        var emitVersion = ReadNavEnvironmentEmitVersion();
-
-        foreach (var tableId in EnumerateApplicationDatabaseTableIds())
+        try
         {
-            InsertVirtualRow(provider, metaTable,
-                new object[] { ObjectMetadataSystemTableId, objectTypeOrdinal, tableId, emitVersion },
-                field => BuildObjectMetadataValue(field, objectTypeOrdinal, tableId, emitVersion));
+            populate();
+        }
+        catch (Exception ex)
+        {
+            lock (_omsPopulatedByProvider)
+                _omsPopulatedByProvider.AddOrUpdate(provider, ExceptionDispatchInfo.Capture(ex));
+            throw;
         }
     }
 
@@ -368,8 +428,12 @@ public static partial class RecordPatches
     /// <para>A refusal here is a BUG REPORT ABOUT THE RUNNER, not a permanent scope
     /// boundary — but <see cref="RunnerOutOfScopeException"/> is what this whole file already
     /// raises when a BC surface it reflects on is not where it expects (SystemTables,
-    /// NavEnvironment, the "Object Type" option string), it names the API and a
-    /// docs/scope.md reason, and AL <c>asserterror</c> cannot swallow it. Same choice here.</para>
+    /// NavEnvironment, the "Object Type" option string), and it carries the typed
+    /// <c>Api</c>/<c>Reason</c> pair the expectations manifest matches on. Same choice here.
+    /// It is NOT proof against AL swallowing it — <c>asserterror</c> is
+    /// MethodScopePatches.NavMethodScope_AssertError, an unfiltered <c>catch (Exception ex)</c>
+    /// — which is exactly why <see cref="RunObjectMetadataPopulateOnce"/> has to remember a
+    /// refusal instead of leaving the table marked populated and empty.</para>
     ///
     /// <para>Resolution goes through <see cref="PrivateMemberLookup"/> rather than a plain
     /// <c>GetField</c>, because <c>primaryTree</c> is PRIVATE on <c>TempTableDataProvider</c>

--- a/AlRunner/Patches/RecordPatches.ObjectMetadataSystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.ObjectMetadataSystemTable.cs
@@ -352,26 +352,56 @@ public static partial class RecordPatches
     /// <c>TempTableDataProvider.primaryTree</c> the stored-table census reads, where a null
     /// tree is BC's own representation of "no row was ever inserted".
     ///
-    /// A layout change in BC's private fields answers FALSE (i.e. "populate"), not "leave it
-    /// alone": the failure this guards against is shadowing real --test-data rows, and a run
-    /// with no test data must still get its rows. That makes an absent field indistinguishable
-    /// from BC's genuine "no row was ever inserted", where the two sibling readers of this same
-    /// private field (RecordPatches.StoredTableCensus.cs) deliberately fail loud instead —
-    /// issue #2786 tracks reconciling the three.
+    /// <para>THE TWO REASONS THIS READ CAN COME BACK EMPTY ARE NOT THE SAME REASON (#2786).
+    /// A null <c>primaryTree</c> is BC's own "no row was ever inserted", and answering FALSE —
+    /// "go ahead and synthesise" — is right. The field being ABSENT means BC renamed or
+    /// restructured it and the runner has no idea what the store holds; answering FALSE there
+    /// would silently shadow whatever --test-data restored into this table, disabling the
+    /// precedence rule in this file's header with no diagnostic anywhere. It used to do
+    /// exactly that. Now it refuses, naming the member, the way every sibling reader of this
+    /// same private field already does: RecordPatches.StoredTableCensus.cs (twice),
+    /// RecordPatches.TransactionSnapshot.cs and RecordPatches.InstallBaseline.cs all go
+    /// through <c>RequiredField</c>, which throws <see cref="MissingFieldException"/>, and
+    /// RowVersionPatches.SystemIdIntegrity.cs throws naming the member. See
+    /// .claude/rules/loud-failures.md.</para>
+    ///
+    /// <para>A refusal here is a BUG REPORT ABOUT THE RUNNER, not a permanent scope
+    /// boundary — but <see cref="RunnerOutOfScopeException"/> is what this whole file already
+    /// raises when a BC surface it reflects on is not where it expects (SystemTables,
+    /// NavEnvironment, the "Object Type" option string), it names the API and a
+    /// docs/scope.md reason, and AL <c>asserterror</c> cannot swallow it. Same choice here.</para>
+    ///
+    /// <para>Resolution goes through <see cref="PrivateMemberLookup"/> rather than a plain
+    /// <c>GetField</c>, because <c>primaryTree</c> is PRIVATE on <c>TempTableDataProvider</c>
+    /// and <c>GetField(NonPublic)</c> on a DERIVED type does not return a base class's private
+    /// fields — BC's own <c>CrmTableConnection.CrmTestDataProvider</c> derives from it (#2725).
+    /// Reading a derived provider's inherited field as "absent" would turn a perfectly readable
+    /// store into a hard failure now that absence refuses.</para>
     /// </summary>
     private static bool ProviderHasAnyRow(object provider)
     {
-        try
-        {
-            var field = provider.GetType().GetField("primaryTree",
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-            if (field?.GetValue(provider) is not IEnumerable tree) return false;
-            foreach (var _ in tree) return true;
-            return false;
-        }
-        catch (TargetInvocationException)
-        {
-            return false;
-        }
+        var field = PrivateMemberLookup.Field(provider.GetType(), "primaryTree")
+            ?? throw new RunnerOutOfScopeException(
+                "Object Metadata (system table 2000000071)",
+                $"object-metadata-system-table — {provider.GetType().Name}.primaryTree not found, so the "
+                + "runner cannot tell a store BC never inserted into from one --test-data already filled; "
+                + "synthesising rows would silently shadow the restored ones. BC's private provider layout "
+                + "moved; see docs/scope.md");
+
+        // A null tree is BC's own "no row was ever inserted": nothing to shadow, synthesise.
+        var tree = field.GetValue(provider);
+        if (tree == null) return false;
+
+        if (tree is not IEnumerable rows)
+            throw new RunnerOutOfScopeException(
+                "Object Metadata (system table 2000000071)",
+                $"object-metadata-system-table — {provider.GetType().Name}.primaryTree is a "
+                + $"{tree.GetType().Name}, which cannot be enumerated, so the runner cannot tell whether "
+                + "--test-data already filled this table. BC's private provider layout moved; see "
+                + "docs/scope.md");
+
+        // Short-circuit: one row is the whole answer, and a restored backup can be large.
+        foreach (var _ in rows) return true;
+        return false;
     }
 }

--- a/AlRunner/Patches/RowVersionPatches.SystemIdIntegrity.cs
+++ b/AlRunner/Patches/RowVersionPatches.SystemIdIntegrity.cs
@@ -293,10 +293,20 @@ public static partial class RowVersionPatches
                 ?? throw new InvalidOperationException(
                     $"[RowVersionPatches] {provider.GetType().Name}.primaryTree field not found — " +
                     "SystemId integrity check cannot resolve its reflection target");
-        // No rows stored yet for this table instance (EnsureTreeCreated has not run,
-        // which happens INSIDE the real Insert body this prepend runs ahead of) —
-        // nothing to collide with.
-        if (_fPrimaryTree.GetValue(provider) is not System.Collections.IEnumerable storedRows) return;
+        // A NULL primaryTree means no rows are stored yet for this table instance
+        // (EnsureTreeCreated has not run, which happens INSIDE the real Insert body this
+        // prepend runs ahead of) — nothing to collide with, so a quiet return is right.
+        //
+        // A NON-NULL value the runner cannot enumerate is the same "BC's private layout
+        // moved" case the resolution above already refuses, and folding it into the null
+        // branch silently skipped the duplicate-SystemId check on every insert (#2786).
+        var storedTree = _fPrimaryTree.GetValue(provider);
+        if (storedTree == null) return;
+        if (storedTree is not System.Collections.IEnumerable storedRows)
+            throw new InvalidOperationException(
+                $"[RowVersionPatches] {provider.GetType().Name}.primaryTree holds a " +
+                $"{storedTree.GetType().Name}, which cannot be enumerated — " +
+                "SystemId integrity check cannot read the stored rows");
 
         // #2667: answer from a per-store index instead of walking every stored row. The walk
         // ran on EVERY insert into a database-backed table — note that the zero-SystemId early

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -558,6 +558,17 @@ well, which is the bug (#2519) this table's support closed.
 move quietly. It deliberately uses only ids that are live table objects, so it does not encode
 the open `ObsoleteState = Removed` question as settled in either direction.
 
+**Synthesis never overwrites restored rows, and never guesses whether there are any.** Because
+2000000071 is a real SQL table, a `--test-data` backup can genuinely carry rows for it, so the
+on-demand loader runs first and the populator does nothing when the store already holds a row.
+Deciding that means reading BC's private `TempTableDataProvider.primaryTree` by reflection. A
+*null* tree is BC's own "no row was ever inserted" and synthesis proceeds; the field being
+**absent**, or holding something that cannot be enumerated, means BC's private layout moved and
+the runner cannot tell the two apart — so it refuses with an `out-of-scope:` failure naming the
+member rather than synthesising over rows it cannot see (#2786). That refusal is unreachable on
+every BC version the runner supports; it exists so a future one cannot silently disable the
+precedence rule.
+
 ---
 
 ## Per-BC-minor engine variants: granularity is per MINOR, not per exact build


### PR DESCRIPTION
Closes #2786

`RecordPatches.ObjectMetadataSystemTable.ProviderHasAnyRow` decides whether the Object Metadata (2000000071) populator synthesises its rows or leaves a `--test-data`-restored store alone. It read BC's private `TempTableDataProvider.primaryTree` by reflection and answered "no rows, go ahead and synthesise" for two reasons that mean opposite things:

* `primaryTree` is **null** — BC's own "no row was ever inserted". Synthesising is correct.
* the field is **absent** — BC renamed or restructured it. The runner has no idea what the store holds, and synthesising would silently shadow real restored rows, disabling the #2519 precedence rule with no diagnostic anywhere.

## What changed

**`AlRunner/Patches/RecordPatches.ObjectMetadataSystemTable.cs` — the reported defect**

* Field absent -> `RunnerOutOfScopeException` naming the provider type, the member, and why it refuses. Null -> still `false`, unchanged, and that is the branch every real run takes.
* `primaryTree` non-null but not enumerable -> refuses too, instead of reading as "empty".
* The `catch (TargetInvocationException) { return false; }` around the reflective read is gone.
* Resolution moved from `GetType().GetField(...)` to `PrivateMemberLookup.Field`, which walks the hierarchy. `GetField(NonPublic)` on a **derived** type does not return a base class's private field, and `CrmTableConnection.CrmTestDataProvider` derives from `TempTableDataProvider` (#2725) — reading its inherited field as "absent" would have turned a readable store into a hard failure the moment absence started refusing.

**`AlRunner/Patches/RecordPatches.ObjectMetadataSystemTable.cs` — an ordering defect the refusal exposed (found in review)**

Adding a throw to `ProviderHasAnyRow` was not safe on its own, because `PopulateObjectMetadataSystemTable` claimed the provider in `_omsPopulatedByProvider` **before** doing any of the work. Every throw after that claim left table 2000000071 permanently marked "populated", holding whatever it had when it failed — usually nothing — and every later access read an empty table silently.

That is reachable from AL, not just in theory: `asserterror` is `MethodScopePatches.NavMethodScope_AssertError`, an unfiltered `catch (Exception ex)` (`AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs:319-320` binds it), and this populate runs on the record-open path an `asserterror` can wrap. The repository's own OOS tests rely on exactly that catch — `tests/runner-extras/table-connection-live-oos` does `asserterror InsertRow('live')` then `Assert.ExpectedError('out-of-scope: …')`.

**Ten call sites sit after that claim, not one**: `ProviderHasAnyRow`, the nine `RunnerOutOfScopeException` throws across `EnsureObjectMetadataObjectTypeOrdinal` / `ReadNavEnvironmentEmitVersion` / `EnumerateApplicationDatabaseTableIds`, and an `InsertVirtualRow` that fails part-way through the row set. So the fix went at the seam all ten pass through rather than at the one that was reported: the work moved into `RunObjectMetadataPopulateOnce`, which stores the refusal against the provider and **replays** it on every later call.

Replayed rather than retried, deliberately. A retry after a part-way `InsertVirtualRow` would find 19 rows already there, so its own `ProviderHasAnyRow` would answer "already populated" and return quietly — a silently *partial* table, the same bug wearing a different hat. None of these failures is transient; BC's layout does not change mid-run.

Just moving the `ProviderHasAnyRow` call above the memo would have fixed 1 of those 10 and left the other 9 in.

**`AlRunner/Patches/RowVersionPatches.SystemIdIntegrity.cs`** — the one other reader that still had the reported shape (see the table below).

**`docs/limitations.md`** — the `--test-data` precedence rule and the new refusal were documented only in the source header.

## Corrections to the first version of this description

Three things I got wrong, corrected here rather than quietly:

* **I said six readers of `primaryTree`; there are seven.** The one I missed is `ClearProviderInPlace` (`RecordPatches.TransactionSnapshot.cs:313-317`), and it matters because `RecordPatches.AggregatePermissionSetVirtualTable.cs:176` calls it **without** the `GetType().Name != "TempTableDataProvider"` guard its two `TransactionSnapshot` callers have — the one place a derived provider could reach a `RequiredField`. It fails *loud* (`MissingFieldException`) if it ever does, so it is not the silent-failure class this PR is about, and I have not changed it.
* **I labelled the two `StoredTableCensus` readers "already loud". They are not.** They `catch (MissingFieldException) { continue; }` (lines 102, 169) — silent. They are *non-lying*, which is the property that matters: `TryCensus` returns false unless `hits.Count == 1`, and the only consumer is a diagnostic, so a skipped source can never be reported as "the table is empty". Leaving them alone is still right; the label was wrong.
* **I implied `RunnerOutOfScopeException` cannot be swallowed by AL `asserterror`. That is false**, per the unfiltered catch above. The claim is struck from the code comment. The other two reasons for choosing that exception type stand on their own: it is this file's own convention for a BC surface that is not where it expects, and it carries the typed `Api`/`Reason` pair the expectations manifest matches on. (`AlRunner/Infrastructure/RunnerOutOfScopeException.cs:8-9` carries the same false claim repo-wide; that is being filed separately rather than widened into this PR.)

**The reconciliation #2786 asked for is partial, and I want that on the record.** Three conventions remain across the seven readers — `MissingFieldException` (the four `RequiredField` sites), `InvalidOperationException` (`RowVersionPatches`), and `RunnerOutOfScopeException` (Object Metadata). Each matches its own file's surrounding style, which is defensible, but this PR did not collapse them into one.

## The reader inventory

| reader | when the field is absent | verdict |
|---|---|---|
| `StoredTableCensus.cs` (x2, lines 100/167) | `RequiredField` -> `MissingFieldException`, **caught, `continue`** | silent but non-lying — left alone |
| `TransactionSnapshot.cs:197` (capture) | `RequiredField`, uncaught | already loud |
| `TransactionSnapshot.cs:316` (`ClearProviderInPlace`) | `RequiredField`, uncaught | already loud; the one unguarded call site |
| `InstallBaseline.cs:257` | `RequiredField`, uncaught, plus an explicit throw on a non-enumerable value | already loud |
| `RowVersionPatches.SystemIdIntegrity.cs:292` | throws naming the member — **but folded non-enumerable into the null branch** | **fixed here** |
| `ObjectMetadataSystemTable.cs:366` | silently `false` | **fixed here** |

The `RowVersionPatches` one is the "sibling function makes the same assumption" answer: it already refused an absent field, then wrote `is not IEnumerable storedRows -> return`, so a moved layout would have skipped the duplicate-SystemId check on **every insert** with nothing printed anywhere. Null still returns quietly (that is what a provider looks like before the real `Insert` body runs `EnsureTreeCreated`); non-null-and-unwalkable now throws.

I deliberately did **not** move the four `RequiredField` call sites to `PrivateMemberLookup`. Three are guarded by a `GetType().Name != "TempTableDataProvider"` check a few lines earlier, so a derived provider never reaches them; the fourth (`ClearProviderInPlace` via Aggregate Permission Set) already fails loud.

## RED -> GREEN

Every GREEN below is of the pushed tree.

| | before | after |
|---|---|---|
| `ObjectMetadataProviderRowProbeTests` (new, 12 tests) | **Failed 3, Passed 5** (reader) then **Failed 2, Passed 10** (memo) | Passed 12 |
| `RowVersionPatchesTests` (+2 tests) | **Failed 1, Passed 16** | Passed 17 |
| `ObjectMetadata` + `PrivateMemberLookup` + `RowVersion` + `SystemId` + `Census` + `MethodScope` + `AssertError` | — | Passed 56 |
| `CliDocumentationTests` (docs guard) | — | Passed 20 |
| `tests/runner-extras` full, `--strict --count-baseline`, BC 28.1 | — | **260/260**, 0 fail, 0 error, exit 0 |

The memo RED is the sharp one: the **second** call to a populate whose body had already refused came back with `Assert.Throws() Failure: No exception was thrown` — the table silently marked populated and empty, exactly the reported shape.

## Pre-answering the review questions

**Does the test prove the loud failure, or just "it throws"?** It asserts the exception **type** and the typed properties, not a substring of a rendered message: `ex.Api == "Object Metadata (system table 2000000071)"` and `ex.Reason` starting with the `object-metadata-system-table` docs anchor. The message must also name `primaryTree`, the concrete provider type, and `--test-data`. The memo tests additionally assert the replayed refusal is the *same* refusal (`first.Message == second.Message`) and that the body ran **exactly once** — so a "retry and hope" implementation fails.

**Is there a positive arm proving the reader still returns the right answer?** Nine, and they are load-bearing — a fix that always threw, or one that simply stopped memoising, fails them:

* null `primaryTree` -> `false`; empty tree -> `false`; one row -> `true`
* three rows -> `true` **and only one row pulled** (`CountingRows` asserts `Yielded == 1`, pinning the short-circuit)
* derived provider, populated inherited field -> `true`; null inherited field -> `false`
* a populate that **succeeds** still runs exactly once across three calls (this is what stops "never memoise" from passing)
* a refusal on one provider does not poison a different provider
* end to end, `tests/runner-extras/object-metadata-system-table` passes 4/4 against a **real** BC `TempTableDataProvider`: the rows are still synthesised on a run with no application database.

**Can anything still fail silently on a neighbouring path?** The seven-reader table above is the audit. Two were silent and both are fixed; two are silent-but-non-lying and stay; three were already loud.

**On the non-enumerable branch being dead code:** it is dead **by declared type**, which is a better argument than the one I made first. Verified directly against the shipped metadata on all three cached builds (27.5.46862.48827, 28.1.49838.53910, 28.1.49838.54308): `TempTableDataProvider.primaryTree` is declared `private AvlTree<TempTableRecordBuffer>`, and `AvlTree<T>` implements `System.Collections.IEnumerable`. My earlier argument — that `InstallBaseline`'s equivalent throw has never fired — is weaker, because it only holds when a baseline capture actually runs, `primaryTree` is non-null, and the provider type name is exactly `TempTableDataProvider`.

## Runner-local, not corpus — and why

This is a claim about how the **runner** reflects on a BC private field, not about anything AL code can observe from Business Central. On every supported BC version the field exists and its declared type is enumerable (measured above), so the loud branch is **unreachable from AL** and a service tier has nothing to adjudicate. A C# test in `AlRunner.Tests` is the only place it can be pinned; see `.claude/rules/bc-behavior-tests-go-upstream.md` and the same reasoning in `RowVersionPatchesTests`' header.

The BC-behaviour half of this table (what rows a real tier holds) is separately blocked from the corpus, for reasons already recorded in `docs/limitations.md` and in corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#153: the corpus app targets Cloud, 2000000071 is `Scope = OnPrem`, and both the `Record` and `RecordRef` routes are refused. Unchanged by this PR, and not what this PR claims.

## Notes

* **No `test-count-baseline.json` change** (#2803) — the runner-extras count is unchanged at 260 and `--count-baseline` passed.
* No new AL objects, so no object-id allocation. No submodule pin change; `tests/al-language/` untouched. `CHANGELOG.md` untouched.
* The new C# tests need no fixture `app.json`, so `.claude/rules/no-base-app-in-csharp-tests.md` does not arise — pure in-process reflection over POCOs, 77 ms for all 12.
* #2788 (the `GetDataAccessForTableCore` populate/hydrate race in adjacent code) is **not** touched here and stays open. The memo fix does not change the concurrent-handout behaviour it describes: the claim is still taken before the work.

---

Implemented by agent `stma-auto-1` on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
