### PR TITLE
fix(cache): identify AL-output cache dependencies by content hash, not mtime+size

### DIFF
--- a/AlRunner.Tests/CacheKeyDependencyClosureTests.cs
+++ b/AlRunner.Tests/CacheKeyDependencyClosureTests.cs
@@ -148,8 +148,9 @@ public sealed class CacheKeyDependencyClosureTests : IDisposable
     /// </list>
     /// Both runs then keyed on the same closure and the test failed while the cache key was
     /// working correctly. Worse, it PASSED on a developer machine for an accidental reason:
-    /// the key stamps each winning `.app`'s mtime+size, and the freshly-copied file and the
-    /// warm provisioned one merely had different timestamps. A test whose verdict depends on
+    /// the key stamped each winning `.app`'s mtime+size (a hash of its bytes since #2754),
+    /// and the freshly-copied file and the warm provisioned one merely had different
+    /// timestamps. A test whose verdict depends on
     /// the machine's provisioning history is not measuring the cache key. This variant
     /// cannot be restored by any provisioning path, because no artifact Microsoft ships is
     /// published by "Contoso ISV".

--- a/AlRunner.Tests/CacheKeyDependencyContentIdentityTests.cs
+++ b/AlRunner.Tests/CacheKeyDependencyContentIdentityTests.cs
@@ -1,0 +1,294 @@
+// CacheKeyDependencyContentIdentityTests — issue #2754: the AL-output cache key must identify
+// each resolved dependency by its CONTENT, not by a filesystem stat of the winning package.
+//
+// The defect
+// ----------
+// `GetOrderedDepIds` (AlRunner/ProgramSupport/Dependencies.cs) used to write one term per
+// resolved dependency of the form
+//
+//     {AppId:N}:{Version}:{LastWriteTimeUtc.Ticks}:{Length}
+//
+// and `ComputeAlCacheKey` folded those terms straight into the key. That is a *stat* identity,
+// and it carries no path — so the identity of a dependency, across the whole filesystem, was
+// (declared id, declared version, size, mtime). Two `.app` packages that declare the same
+// publisher/name/version, are the same size, and carry the same mtime therefore hash to the
+// same AL-output cache key even when their bytes differ, and a warm cache serves the DLL
+// compiled against whichever one was seen first.
+//
+// Nothing about that fails: the run reports the same exit code and the same green tests, having
+// executed code compiled against a dependency it never saw. Same defect family as the two the
+// key's own comments already record — the `--define` symbols that were missing (making
+// `--define` a silent no-op on a cache hit) and the dependency closure that was missing
+// entirely (3175424 -> 3206144 bytes emitted, key unchanged).
+//
+// Reachability is not exotic. `cp -p`, `rsync -a`, `tar -x`, `unzip` and every CI cache restore
+// carry an mtime along with the bytes, so equal mtimes across two directories is the normal
+// case rather than a coincidence; a locally rebuilt ISV dependency keeps its declared version
+// while its content changes; and `Program.cs` folds
+// `ProvisioningCheck.CollectRunnerOwnedProvisionDirs(...)` into the package-cache search set,
+// so which directories are searched depends on what happens to exist on the machine.
+//
+// The two arms
+// ------------
+// NEGATIVE (the collision) — two packages with the SAME declared id+version, the SAME byte
+// length and the SAME mtime, differing only in their bytes. Every input the old stamp could
+// see is identical, so the old key collides and the new key must not.
+//
+// POSITIVE (the cache must still hit) — the SAME bytes at a DIFFERENT path with a DIFFERENT
+// mtime must produce the SAME key. Without this arm the negative one is satisfied by a key
+// that keys on something always-unique, which would pass a collision-only test while silently
+// destroying the cache's whole value. It also pins the direction the fix improves: under the
+// old stamp a re-downloaded, byte-identical package MISSed unconditionally.
+
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class CacheKeyDependencyContentIdentityTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    // Distinct from CacheKeyDependencyClosureTests' IsvDepId on purpose: these tests run in a
+    // separate collection, in parallel with that one, and both write synthetic packages under
+    // their own scratch roots. A shared AppId would still not cross directories, but a distinct
+    // one keeps a failure message unambiguous about which fixture produced it.
+    private const string DepAppId = "c40e2754-9a11-4b22-8c33-d44455566677";
+    private const string BundleAppId = "c40e2754-1122-4333-8444-555566667777";
+
+    private readonly string _scratch;
+
+    public CacheKeyDependencyContentIdentityTests()
+    {
+        _scratch = TestScratch.Dir("al-runner-cachekey-content");
+        Directory.CreateDirectory(_scratch);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_scratch, recursive: true); } catch { }
+    }
+
+    /// <summary>
+    /// Two `.app` packages that declare the same id+version, are byte-for-byte the same LENGTH
+    /// and carry the same MTIME, but hold different bytes, must not share an AL-output cache
+    /// key. Under the old `mtime:length` stamp every term the key could see was identical and
+    /// the two keys were equal — a warm cache then served the DLL compiled against the other
+    /// package, green, with an unchanged exit code.
+    /// </summary>
+    [SkippableFact]
+    public void SameVersionDifferentBytes_ProducesDifferentCacheKey()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var bundle = WriteDependentFixture(Path.Combine(_scratch, "bundle-collide"));
+        var dirA = Path.Combine(_scratch, "pkg-a");
+        var dirB = Path.Combine(_scratch, "pkg-b");
+        Directory.CreateDirectory(dirA);
+        Directory.CreateDirectory(dirB);
+
+        // Same declared identity, same payload SIZE, different payload BYTES.
+        var appA = WriteSyntheticApp(dirA, payloadFill: (byte)'A');
+        var appB = WriteSyntheticApp(dirB, payloadFill: (byte)'B');
+
+        // Same mtime, to the tick. Every filesystem-stat term the old key could observe is now
+        // provably identical across the two packages.
+        var stamp = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        File.SetLastWriteTimeUtc(appA, stamp);
+        File.SetLastWriteTimeUtc(appB, stamp);
+
+        var bytesA = File.ReadAllBytes(appA);
+        var bytesB = File.ReadAllBytes(appB);
+
+        // Preconditions, asserted rather than assumed: without all three this test would not be
+        // exercising the defect at all, and a silent drift in the synthetic-package writer
+        // (a zip timestamp, a compression-level change) would turn it into a test that passes
+        // for the wrong reason.
+        Assert.Equal(bytesA.Length, bytesB.Length);
+        Assert.Equal(
+            new FileInfo(appA).LastWriteTimeUtc.Ticks,
+            new FileInfo(appB).LastWriteTimeUtc.Ticks);
+        Assert.False(bytesA.AsSpan().SequenceEqual(bytesB),
+            "the two synthetic packages are byte-identical — the fixture is not exercising the defect");
+
+        var keyA = ReadCacheKey(bundle, dirA, Path.Combine(_scratch, "cache-a"));
+        var keyB = ReadCacheKey(bundle, dirB, Path.Combine(_scratch, "cache-b"));
+
+        Assert.NotEqual(keyA, keyB);
+    }
+
+    /// <summary>
+    /// The direction that keeps the fix honest: byte-identical dependency packages must key
+    /// IDENTICALLY even at a different path and a different mtime. A key that simply varied per
+    /// resolved file would satisfy the collision test above while destroying every cache hit.
+    ///
+    /// This is also a strict improvement over the `mtime:length` stamp, which MISSed
+    /// unconditionally for a package re-downloaded or re-copied with fresh timestamps — the
+    /// #1815/#1820 finding, one cache layer over.
+    /// </summary>
+    [SkippableFact]
+    public void SameBytesDifferentPathAndMtime_ProducesTheSameCacheKey()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var bundle = WriteDependentFixture(Path.Combine(_scratch, "bundle-stable"));
+        var dirA = Path.Combine(_scratch, "same-a");
+        var dirB = Path.Combine(_scratch, "same-b");
+        Directory.CreateDirectory(dirA);
+        Directory.CreateDirectory(dirB);
+
+        var appA = WriteSyntheticApp(dirA, payloadFill: (byte)'A');
+        var appB = WriteSyntheticApp(dirB, payloadFill: (byte)'A');
+
+        File.SetLastWriteTimeUtc(appA, new DateTime(2020, 5, 6, 7, 8, 9, DateTimeKind.Utc));
+        File.SetLastWriteTimeUtc(appB, new DateTime(2026, 5, 6, 7, 8, 9, DateTimeKind.Utc));
+
+        // Preconditions again: the packages must genuinely be byte-identical and genuinely
+        // differ in mtime, or this arm proves nothing.
+        Assert.True(File.ReadAllBytes(appA).AsSpan().SequenceEqual(File.ReadAllBytes(appB)),
+            "the two synthetic packages differ in bytes — the fixture is not exercising a cache HIT");
+        Assert.NotEqual(
+            new FileInfo(appA).LastWriteTimeUtc.Ticks,
+            new FileInfo(appB).LastWriteTimeUtc.Ticks);
+
+        var keyA = ReadCacheKey(bundle, dirA, Path.Combine(_scratch, "cache-same-a"));
+        var keyB = ReadCacheKey(bundle, dirB, Path.Combine(_scratch, "cache-same-b"));
+
+        Assert.Equal(keyA, keyB);
+    }
+
+    // ── fixture writers ───────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A one-codeunit bundle declaring exactly one third-party dependency and NO
+    /// `application`/`platform`, so its resolved closure is entirely under this test's control
+    /// and no provisioning decision (nor the runner-owned provision dirs Program.cs folds into
+    /// the package-cache search set) can contribute a package to it.
+    /// </summary>
+    private static string WriteDependentFixture(string dir)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{BundleAppId}}",
+          "name": "CacheKey Content Identity Fixture",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{DepAppId}}", "name": "Fabrikam Dep", "publisher": "Fabrikam ISV", "version": "1.0.0.0" }
+          ],
+          "idRanges": [ { "from": 60710, "to": 60719 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "CacheKeyContent.Codeunit.al"), """
+        codeunit 60710 "CacheKey Content Probe"
+        {
+            procedure Probe(): Integer
+            begin
+                exit(1);
+            end;
+        }
+        """);
+        return dir;
+    }
+
+    private const string DepName = "Fabrikam Dep";
+    private const string DepPublisher = "Fabrikam ISV";
+    private const string DepVersion = "1.0.0.0";
+
+    /// <summary>
+    /// Writes a minimal NAVX `.app` — enough for AppLoader.ReadManifest and DependencyResolver
+    /// to see the package and its version — carrying a fixed-size uncompressed payload entry
+    /// filled with <paramref name="payloadFill"/>.
+    ///
+    /// Two details are load-bearing and neither is incidental:
+    /// <list type="bullet">
+    /// <item><description>Every zip entry gets an EXPLICIT LastWriteTime. ZipArchive stamps
+    /// DateTimeOffset.Now otherwise, which would make two "identical" packages differ in bytes
+    /// and silently invert the positive arm below into a second collision test.</description></item>
+    /// <item><description>The payload entry is stored with CompressionLevel.NoCompression, so
+    /// its on-disk size is exactly the payload length regardless of how compressible the fill
+    /// byte is — which is what makes the two packages the same LENGTH while differing in
+    /// content, the precise shape the old mtime:length stamp could not tell apart.</description></item>
+    /// </list>
+    /// </summary>
+    private static string WriteSyntheticApp(string dir, byte payloadFill)
+    {
+        var xml = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{DepAppId}" Name="{DepName}" Publisher="{DepPublisher}" Version="{DepVersion}"/>
+              <Dependencies />
+            </Package>
+            """;
+        var entryStamp = new DateTimeOffset(2021, 6, 7, 8, 9, 10, TimeSpan.Zero);
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var manifest = zip.CreateEntry("NavxManifest.xml", CompressionLevel.NoCompression);
+            manifest.LastWriteTime = entryStamp;
+            using (var es = manifest.Open())
+                es.Write(Encoding.UTF8.GetBytes(xml));
+
+            var payload = zip.CreateEntry("payload.bin", CompressionLevel.NoCompression);
+            payload.LastWriteTime = entryStamp;
+            using (var ps = payload.Open())
+            {
+                var buf = new byte[4096];
+                buf.AsSpan().Fill(payloadFill);
+                ps.Write(buf);
+            }
+        }
+        var zipBytes = ms.ToArray();
+        var result = new byte[8 + zipBytes.Length];
+        result[0] = (byte)'N'; result[1] = (byte)'A'; result[2] = (byte)'V'; result[3] = (byte)'X';
+        BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
+        zipBytes.CopyTo(result, 8);
+        var path = Path.Combine(dir, $"{DepPublisher}_{DepName}_{DepVersion}.app");
+        File.WriteAllBytes(path, result);
+        return path;
+    }
+
+    // ── runner invocation ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Runs the bundle in `--print-cache-key` mode, which reaches the exact ComputeAlCacheKey
+    /// call a real run would (see Program.cs) and exits before Emit+Compile — the same cheap
+    /// path CacheKeyDependencyClosureTests uses, anchored to a real run by that class's
+    /// PrintCacheKeyOnly_MatchesFullRunKey.
+    /// </summary>
+    private static string ReadCacheKey(string bundlePath, string packageCacheDir, string alCacheDir)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" \"{bundlePath}\"");
+        args.Append($" --package-cache \"{packageCacheDir}\"");
+        args.Append($" --cache \"{alCacheDir}\"");
+        args.Append(" --print-cache-key");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(240_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        string output;
+        lock (sb) output = sb.ToString();
+        var m = Regex.Match(output, @"\[cache\]\s+KEY\s+key=([0-9a-f]{64})");
+        Assert.True(m.Success, $"could not read a cache key from --print-cache-key output:\n{output}");
+        return m.Groups[1].Value;
+    }
+}

--- a/AlRunner.Tests/CacheKeyUnhashableDependencyTests.cs
+++ b/AlRunner.Tests/CacheKeyUnhashableDependencyTests.cs
@@ -1,0 +1,326 @@
+// CacheKeyUnhashableDependencyTests — the degraded path of #2754's content-hashed dep terms:
+// what the AL-output cache key does when ONE resolved dependency package cannot be hashed.
+//
+// The defect this pins (found in review of the #2754 fix, not in the original code)
+// -------------------------------------------------------------------------------
+// The first cut of the fix threw out of the per-dependency Select when
+// ComputeAppContentHash could not answer, and let GetOrderedDepIds' outer catch key the
+// whole bundle on one string:
+//
+//     return new[] { $"unresolved:{ex.GetType().Name}:{ex.Message}" };
+//
+// That is strictly WORSE than the `mtime:length` stamp it replaced. The old code degraded
+// the single bad term to "?" and kept every other dependency's stamp; collapsing the LIST
+// discards all of them. So:
+//
+//     run 1: dep X unhashable, dep Y at content C1  ->  key = f("unresolved:<type>:<msg>")
+//     run 2: dep X unhashable, dep Y at content C2  ->  SAME string, SAME key, HIT
+//
+// and the DLL compiled against C1 is served for a closure containing C2. An exception type
+// and message are deterministic across runs, so this HITs reliably — inheriting the exact
+// property #2754 exists to remove, and the exact property the #2754 PR body criticised in
+// the old "?" term ("simply cannot HIT", which was never true).
+//
+// Constructing "resolved but unhashable"
+// -------------------------------------
+// It looks impossible from outside the process: DependencyResolver.EnsureIndexed calls
+// AppLoader.ReadManifest on every .app it finds, so a package it cannot open is a package it
+// never indexes, and the run fails at resolution instead of reaching the hash.
+//
+// But ReadManifest is backed by an on-disk index under CacheRoots.Resolve("app-manifests"),
+// keyed by (full path, length, last-write-ticks) — and `chmod 000` changes none of those. So:
+// run once with the package readable to warm that index (the same --cache root is shared
+// across all runs here, which is what makes the index visible to the next process), then make
+// it unreadable. The resolver now answers from the index WITHOUT opening the file, and
+// ComputeAppContentHash — which must read the bytes — throws.
+//
+// That construction is also the review finding's other half in concrete form: "the resolver
+// read this package's manifest moments ago" does not imply the bytes are readable, so
+// "unhashable means the compile is about to fail anyway" is an assumption, not a fact.
+//
+// The three arms
+// --------------
+// NEGATIVE (the regression) — X unhashable, Y's content CHANGES between two runs. The keys
+// must differ. This is the arm that fails against the throw-and-collapse code.
+//
+// CONTROL — X unhashable, nothing else changes. The keys must be EQUAL. Without it the
+// negative arm would be satisfied by a degraded term that simply varies per run (a nonce),
+// which would force a permanent MISS for any bundle with an unreadable dependency instead of
+// tracking what actually changed.
+//
+// LOUD — the run must SAY it keyed a dependency on something weaker than its content, naming
+// the package. A cache silently downgrading its own identity is the failure mode
+// .claude/rules/loud-failures.md exists for.
+
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class CacheKeyUnhashableDependencyTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private const string DepXId = "c4102754-aaaa-4b22-8c33-d44455566677";
+    private const string DepYId = "c4102754-bbbb-4b22-8c33-d44455566677";
+    private const string BundleAppId = "c4102754-cccc-4333-8444-555566667777";
+
+    private readonly string _scratch;
+    private readonly List<string> _lockedFiles = new();
+
+    public CacheKeyUnhashableDependencyTests()
+    {
+        _scratch = TestScratch.Dir("al-runner-cachekey-unhashable");
+        Directory.CreateDirectory(_scratch);
+    }
+
+    public void Dispose()
+    {
+        // Restore modes first or the recursive delete trips on the locked files.
+        foreach (var f in _lockedFiles)
+        {
+            try { File.SetUnixFileMode(f, UnixFileMode.UserRead | UnixFileMode.UserWrite); } catch { }
+        }
+        try { Directory.Delete(_scratch, recursive: true); } catch { }
+    }
+
+    /// <summary>
+    /// Makes <paramref name="path"/> unreadable and returns true only if that actually bites.
+    /// A CAPABILITY probe rather than a uid check, for the same reason
+    /// InaccessibleDirectoryScanTests uses one: running as root, or on a filesystem that
+    /// ignores mode bits, the mode change is accepted and then ignored, and a test that
+    /// assumed otherwise would assert against a perfectly readable file.
+    /// </summary>
+    private bool TryMakeUnreadable(string path)
+    {
+        try { File.SetUnixFileMode(path, UnixFileMode.None); }
+        catch { return false; }
+        _lockedFiles.Add(path);
+        try
+        {
+            using var _ = File.OpenRead(path);
+            return false; // the mode bits did not bite
+        }
+        catch (UnauthorizedAccessException) { return true; }
+        catch (IOException) { return true; }
+    }
+
+    /// <summary>
+    /// The shared setup all three arms use: a bundle depending on X and Y, both packages
+    /// written and resolvable, one warm-up run to populate the app-manifest index under the
+    /// shared cache root, then X made unreadable.
+    /// </summary>
+    private (string Bundle, string PkgDir, string CacheDir, string XPath, string YPath) ArrangeUnhashableX(string name)
+    {
+        var bundle = WriteTwoDepFixture(Path.Combine(_scratch, name + "-bundle"));
+        var pkgDir = Path.Combine(_scratch, name + "-pkg");
+        Directory.CreateDirectory(pkgDir);
+        var cacheDir = Path.Combine(_scratch, name + "-cache");
+
+        var xPath = WriteSyntheticApp(pkgDir, DepXId, "Fabrikam Dep X", payloadFill: (byte)'X');
+        var yPath = WriteSyntheticApp(pkgDir, DepYId, "Fabrikam Dep Y", payloadFill: (byte)'1');
+
+        // Warm-up run, with BOTH packages readable: this is what writes the app-manifests index
+        // entries the later runs resolve X from without opening it.
+        var warm = RunPrintCacheKey(bundle, pkgDir, cacheDir);
+        Assert.True(warm.Key != null, $"warm-up run produced no cache key:\n{warm.Output}");
+
+        Skip.IfNot(TryMakeUnreadable(xPath),
+            "cannot make a file unreadable here (running as root, or a filesystem that ignores "
+            + "mode bits), so 'resolved but unhashable' cannot be constructed");
+
+        return (bundle, pkgDir, cacheDir, xPath, yPath);
+    }
+
+    /// <summary>
+    /// THE REGRESSION ARM. One unhashable dependency must not erase the identity of the others:
+    /// with X unhashable throughout, changing Y's bytes must still change the key.
+    ///
+    /// Against the throw-and-collapse code both runs key on the identical
+    /// `unresolved:UnauthorizedAccessException:Access to the path '…' is denied.` string, the
+    /// keys are equal, and a warm cache serves the DLL compiled against Y's previous bytes.
+    /// </summary>
+    [SkippableFact]
+    public void UnhashableDependency_DoesNotHideAnotherDependencysContentChange()
+    {
+        TestArtifacts.SkipIfMissing();
+        var (bundle, pkgDir, cacheDir, _, yPath) = ArrangeUnhashableX("regression");
+
+        var before = RunPrintCacheKey(bundle, pkgDir, cacheDir);
+        Assert.True(before.Key != null, $"no cache key with X unreadable:\n{before.Output}");
+
+        // Y keeps its declared id/name/publisher/version and changes only its bytes — the same
+        // shape #2754 is about, now with an unhashable sibling standing next to it.
+        var yBefore = File.ReadAllBytes(yPath);
+        WriteSyntheticApp(pkgDir, DepYId, "Fabrikam Dep Y", payloadFill: (byte)'2');
+        Assert.False(yBefore.AsSpan().SequenceEqual(File.ReadAllBytes(yPath)),
+            "Y's bytes did not change — the fixture is not exercising the defect");
+
+        var after = RunPrintCacheKey(bundle, pkgDir, cacheDir);
+        Assert.True(after.Key != null, $"no cache key after rewriting Y:\n{after.Output}");
+
+        Assert.NotEqual(before.Key, after.Key);
+    }
+
+    /// <summary>
+    /// THE CONTROL. With X unhashable and nothing else touched, the key must be STABLE. This is
+    /// what forbids "fixing" the arm above with a per-run nonce: a degraded term that simply
+    /// varies would satisfy the inequality while forcing a permanent MISS on every bundle that
+    /// has an unreadable dependency, which is a different way of throwing the cache away.
+    /// </summary>
+    [SkippableFact]
+    public void UnhashableDependency_WithNothingElseChanged_KeysStably()
+    {
+        TestArtifacts.SkipIfMissing();
+        var (bundle, pkgDir, cacheDir, _, _) = ArrangeUnhashableX("control");
+
+        var first = RunPrintCacheKey(bundle, pkgDir, cacheDir);
+        var second = RunPrintCacheKey(bundle, pkgDir, cacheDir);
+
+        Assert.True(first.Key != null, $"no cache key on the first run:\n{first.Output}");
+        Assert.Equal(first.Key, second.Key);
+    }
+
+    /// <summary>
+    /// THE LOUD ARM. Downgrading a dependency's cache identity from its content to a path+stat
+    /// is exactly the kind of quiet weakening .claude/rules/loud-failures.md is about, so the
+    /// run must name the package it could not hash. Against the throw-and-collapse code the
+    /// message is the generic "dependency resolution failed" instead — which is also a false
+    /// statement, since resolution succeeded.
+    /// </summary>
+    [SkippableFact]
+    public void UnhashableDependency_IsReportedByName()
+    {
+        TestArtifacts.SkipIfMissing();
+        var (bundle, pkgDir, cacheDir, xPath, _) = ArrangeUnhashableX("loud");
+
+        var run = RunPrintCacheKey(bundle, pkgDir, cacheDir);
+
+        Assert.Contains("could not hash dependency package", run.Output);
+        Assert.Contains(Path.GetFileName(xPath), run.Output);
+    }
+
+    // ── fixture writers ───────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A one-codeunit bundle declaring TWO third-party dependencies and NO
+    /// `application`/`platform`, so its resolved closure is entirely under this test's control.
+    /// Two are required: the whole point is that a problem with one must not erase the other.
+    /// </summary>
+    private static string WriteTwoDepFixture(string dir)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{BundleAppId}}",
+          "name": "CacheKey Unhashable Dep Fixture",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{DepXId}}", "name": "Fabrikam Dep X", "publisher": "Fabrikam ISV", "version": "1.0.0.0" },
+            { "id": "{{DepYId}}", "name": "Fabrikam Dep Y", "publisher": "Fabrikam ISV", "version": "1.0.0.0" }
+          ],
+          "idRanges": [ { "from": 60730, "to": 60739 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "CacheKeyUnhashable.Codeunit.al"), """
+        codeunit 60730 "CacheKey Unhashable Probe"
+        {
+            procedure Probe(): Integer
+            begin
+                exit(1);
+            end;
+        }
+        """);
+        return dir;
+    }
+
+    private const string DepPublisher = "Fabrikam ISV";
+    private const string DepVersion = "1.0.0.0";
+
+    /// <summary>
+    /// A minimal NAVX `.app` carrying a fixed-size uncompressed payload, so two packages with
+    /// the same declared identity can differ in bytes. Every zip entry gets an explicit
+    /// LastWriteTime — ZipArchive stamps DateTimeOffset.Now otherwise, which would make even a
+    /// byte-for-byte rewrite produce different bytes and rob the control arm of its meaning.
+    /// </summary>
+    private static string WriteSyntheticApp(string dir, string appId, string name, byte payloadFill)
+    {
+        var xml = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{appId}" Name="{name}" Publisher="{DepPublisher}" Version="{DepVersion}"/>
+              <Dependencies />
+            </Package>
+            """;
+        var entryStamp = new DateTimeOffset(2021, 6, 7, 8, 9, 10, TimeSpan.Zero);
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var manifest = zip.CreateEntry("NavxManifest.xml", CompressionLevel.NoCompression);
+            manifest.LastWriteTime = entryStamp;
+            using (var es = manifest.Open())
+                es.Write(Encoding.UTF8.GetBytes(xml));
+
+            var payload = zip.CreateEntry("payload.bin", CompressionLevel.NoCompression);
+            payload.LastWriteTime = entryStamp;
+            using (var ps = payload.Open())
+            {
+                var buf = new byte[4096];
+                buf.AsSpan().Fill(payloadFill);
+                ps.Write(buf);
+            }
+        }
+        var zipBytes = ms.ToArray();
+        var result = new byte[8 + zipBytes.Length];
+        result[0] = (byte)'N'; result[1] = (byte)'A'; result[2] = (byte)'V'; result[3] = (byte)'X';
+        BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
+        zipBytes.CopyTo(result, 8);
+        var path = Path.Combine(dir, $"{DepPublisher}_{name}_{DepVersion}.app");
+        File.WriteAllBytes(path, result);
+        return path;
+    }
+
+    // ── runner invocation ─────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Runs the bundle in `--print-cache-key` mode. The SAME <paramref name="cacheDir"/> is
+    /// passed on every call in a given test on purpose: CacheRoots resolves `app-manifests`
+    /// under it, and a warm manifest index is what lets a later run resolve a package it can no
+    /// longer open. Returns the key (null if none was printed) alongside the full output, so a
+    /// failure can say what the runner actually did.
+    /// </summary>
+    private static (string? Key, string Output) RunPrintCacheKey(string bundlePath, string packageCacheDir, string cacheDir)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" \"{bundlePath}\"");
+        args.Append($" --package-cache \"{packageCacheDir}\"");
+        args.Append($" --cache \"{cacheDir}\"");
+        args.Append(" --print-cache-key");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(240_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        string output;
+        lock (sb) output = sb.ToString();
+        var m = Regex.Match(output, @"\[cache\]\s+KEY\s+key=([0-9a-f]{64})");
+        return (m.Success ? m.Groups[1].Value : null, output);
+    }
+}

--- a/AlRunner.Tests/WatchLayeredDependencyStaleTests.cs
+++ b/AlRunner.Tests/WatchLayeredDependencyStaleTests.cs
@@ -20,9 +20,10 @@
 //     dependency code.
 //
 // And the cache key cannot notice. `GetOrderedDepIds` deliberately stamps each resolved
-// dependency `.app` with `mtime:length` precisely so a sibling source app's changing content
-// invalidates the dependent (see its own comment) — but nothing rewrites that `.app` after
-// cycle 1, so the stamp is frozen and `ComputeAlCacheKey` returns the same key. The dependent
+// dependency `.app` with a hash of its bytes (`mtime:length` when this was written; #2754
+// replaced it) precisely so a sibling source app's changing content invalidates the dependent
+// (see its own comment) — but nothing rewrites that `.app` after cycle 1, so the stamp is
+// frozen and `ComputeAlCacheKey` returns the same key. The dependent
 // re-emits in 0.0s, links against the old symbols, and runs the old code.
 //
 // That is why the fix is to re-run the pre-pass per cycle rather than to add another input to

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1919,9 +1919,10 @@ var compilerPackageDirs = new List<string>();
 // FIRST cycle's dependency sources, and a dependent bundle went on compiling against the
 // frozen *.symbols.json and EXECUTING the frozen .app's source — reporting a confident green
 // for a dependency whose code had changed underneath it. Its AL-output cache could not catch
-// that either: GetOrderedDepIds stamps each resolved .app with mtime:length precisely so a
-// sibling source app's content invalidates the dependent, but nothing rewrote that .app after
-// cycle 1, so the stamp never moved and the key HIT.
+// that either: GetOrderedDepIds stamps each resolved .app with a hash of its bytes (#2754;
+// mtime:length before that) precisely so a sibling source app's content invalidates the
+// dependent, but nothing rewrote that .app after cycle 1, so the stamp never moved and the
+// key HIT.
 //
 // Re-running is cheap when nothing changed. Each impl's workspace dir is keyed on its own
 // source content (ComputeSourceWorkspaceKey), so an unchanged dependency finds its .app and

--- a/AlRunner/ProgramSupport/Dependencies.cs
+++ b/AlRunner/ProgramSupport/Dependencies.cs
@@ -601,36 +601,28 @@ internal static partial class ProgramSupport
                 // the process, and a normal run hashes these same packages anyway for the
                 // bc-symbols key — so for the packages that reach both, this is a
                 // dictionary lookup. For the rest it is one SHA-256 pass over bytes the
-                // run reads regardless (measured on this machine: 122 MB of platform .apps
-                // in ~0.08 s warm). The stat was cheaper per call and answered a different
-                // question.
+                // run reads regardless. Order of magnitude, from a standalone streaming
+                // SHA-256 over the six .app files in ~/.al-runner/platform-apps (122 MB)
+                // on a page-cache-warm dev box, best of three: ~0.07 s. That is a rough
+                // bound on the added work, not a measurement of the runner. The stat was
+                // cheaper per call and answered a different question.
                 //
                 // It also strictly IMPROVES the hit rate in the safe direction, the same
                 // finding #1815/#1820 made one cache layer over: a byte-identical package
                 // re-downloaded or re-copied with a fresh mtime used to MISS
                 // unconditionally, and now HITs.
-                .Select(d =>
-                {
-                    // ComputeAppContentHash answers "unknown" for a missing/empty path
-                    // rather than throwing. Letting that through would put every
-                    // unhashable dependency under one shared term, which is the same
-                    // collision one level down — so make it loud instead: the throw lands
-                    // in the catch below, which prints and keys on the failure so this
-                    // bundle cannot share a cache entry with a resolvable one. A package
-                    // the resolver just read a manifest out of is expected to be hashable;
-                    // if it is not, the compile is about to fail on it anyway.
-                    var hash = AlRunner.Patches.BcAppSymbolCache.ComputeAppContentHash(d.AppPath);
-                    if (hash == "unknown")
-                        throw new IOException(
-                            $"resolved dependency package '{d.AppPath}' could not be hashed for the "
-                            + "AL-output cache key (missing or unreadable at hash time)");
-                    return $"{d.Manifest.AppId:N}:{d.Manifest.Version}:sha256:{hash}";
-                })
+                .Select(d => $"{d.Manifest.AppId:N}:{d.Manifest.Version}:{DependencyContentTerm(d.AppPath)}")
                 .OrderBy(s => s, StringComparer.Ordinal)
                 .ToList();
         }
         catch (Exception ex)
         {
+            // Reached only when RESOLUTION itself failed — there is no dependency list to
+            // speak of, so collapsing to a single term costs no per-dependency information.
+            // A per-dependency problem must NEVER arrive here: DependencyContentTerm handles
+            // its own failures precisely so that one unhashable package cannot erase every
+            // other dependency's identity (see its comment).
+            //
             // Never collapse to "no deps": an empty list is indistinguishable from a bundle
             // that genuinely has none, so two different closures would share a key and the
             // cache would hand back the wrong DLL. Fold the failure itself into the key
@@ -642,6 +634,83 @@ internal static partial class ProgramSupport
                 $"bundle cannot share a cache entry with a resolvable one.");
             return new[] { $"unresolved:{ex.GetType().Name}:{ex.Message}" };
         }
+    }
+
+    /// <summary>
+    /// The content half of one resolved dependency's cache-key term: <c>sha256:&lt;hash of the
+    /// package's bytes&gt;</c>, or — when the package cannot be hashed — a degraded term naming
+    /// that ONE package.
+    ///
+    /// <para><b>Why this never throws.</b> An earlier revision of #2754 threw here, letting the
+    /// caller's catch key the whole bundle on <c>unresolved:&lt;exception&gt;</c>. That is
+    /// strictly worse than what it replaced. The pre-#2754 code degraded the single bad term to
+    /// <c>"?"</c> and kept every other dependency's stamp; collapsing the LIST discards them
+    /// all, so a run where package X is unhashable and package Y has changed content produces
+    /// the same string — an exception type and message, both deterministic across runs — as the
+    /// run before it. Identical string, identical key, HIT, and the DLL compiled against Y's
+    /// previous bytes gets served. It also inherited the exact property #2754 exists to remove:
+    /// a term whose comment claimed it "simply cannot HIT" while in fact hitting reliably.</para>
+    ///
+    /// <para><b>Why "cannot hash" is not "about to fail the compile".</b>
+    /// RunnerFingerprint.ComputeContentHash answers <c>"unknown"</c> for an empty or NON-EXISTENT
+    /// path, and the resolver read this very package's manifest moments earlier — so reaching
+    /// that branch means a time-of-check/time-of-use window, not a broken package. A package
+    /// that vanished and came back would not fail the compile at all. (The manifest read can
+    /// itself be served from AppLoader's on-disk index without opening the file, so "the
+    /// resolver saw it" does not even imply the bytes were readable.)</para>
+    ///
+    /// <para><b>The degraded term.</b> Full path plus whatever the filesystem will still say —
+    /// mtime+size when a stat succeeds, <c>absent</c> when it does not. The path is what the
+    /// pathless <c>sha256:</c> term deliberately omits (that omission is what lets byte-identical
+    /// packages in different directories share a cache entry); here it is wanted, because a
+    /// term that cannot describe content should at least move when the package moves. mtime+size
+    /// makes the degraded term no less discriminating than the pre-#2754 stamp was for EVERY
+    /// dependency.</para>
+    ///
+    /// <para><b>Residual, stated rather than papered over.</b> A package that is unhashable on
+    /// two consecutive runs AND whose content changes between them without changing path, size
+    /// or mtime is still not distinguished — the pre-#2754 exposure, now narrowed to packages
+    /// the runner could not read at all. Closing it means not claiming a cache identity for such
+    /// a run at all (a "do not cache this run" signal threaded out to the cache gate), which is
+    /// a wider change than this one and is tracked on #2846. It is not closed by anything
+    /// cheaper here: a per-run nonce would force a MISS, but it would also be a code path no
+    /// test in this repo can construct, and an untestable branch is what this method exists to
+    /// stop shipping.</para>
+    /// </summary>
+    private static string DependencyContentTerm(string appPath)
+    {
+        string failure;
+        try
+        {
+            var hash = AlRunner.Patches.BcAppSymbolCache.ComputeAppContentHash(appPath);
+            if (hash != "unknown") return $"sha256:{hash}";
+            failure = "missing or empty at hash time";
+        }
+        catch (Exception ex)
+        {
+            failure = $"{ex.GetType().Name}: {ex.Message}";
+        }
+
+        string fullPath;
+        try { fullPath = Path.GetFullPath(appPath); }
+        catch { fullPath = appPath; }
+
+        var stamp = "absent";
+        try
+        {
+            var fi = new FileInfo(fullPath);
+            if (fi.Exists) stamp = $"{fi.LastWriteTimeUtc.Ticks}:{fi.Length}";
+        }
+        catch { /* the stat failed too — "absent" is the honest answer, not a guess */ }
+
+        // Loud, because the cache is now keying this dependency on something weaker than its
+        // content and nothing else in the run would say so.
+        Console.Error.WriteLine(
+            $"  [cache] could not hash dependency package '{fullPath}' for the AL-output cache " +
+            $"key ({failure}) — keying it on path+stat instead. Every OTHER dependency keeps its "
+            + "content hash; this one is only as precise as its mtime and size.");
+
+        return $"unhashable:{fullPath}:{stamp}";
     }
 }
 

--- a/AlRunner/ProgramSupport/Dependencies.cs
+++ b/AlRunner/ProgramSupport/Dependencies.cs
@@ -349,9 +349,9 @@ internal static partial class ProgramSupport
     }
 
     // Deterministic cache key for the bundled-mode emit:
-    //   sha256( runner-asm-mtime-ticks
+    //   sha256( runner-assembly content hash + selected BC version
     //         | moduleName
-    //         | each (ordered dep id+version)
+    //         | each (ordered dep id + version + sha256 of the resolved package's bytes)
     //         | each (.al file relpath + sha256-of-contents) sorted )
     // Hashed in a single pass with line-separated framing so two different file
     // layouts can't collide. The key is hex-encoded sha256 (64 chars).
@@ -420,7 +420,17 @@ internal static partial class ProgramSupport
         //        a normal run reusing a --tdd-generated DLL, or (just as bad) a later --tdd
         //        run reusing a normal-mode DLL and reporting the excluded tests' vanished
         //        instead of failed. v11 entries never hashed this and must not be served.
-        WriteLine("schema:v12");
+        //    v13 (issue #2754): each `dep:` term now identifies its resolved package by a
+        //        SHA-256 of the package bytes instead of `{mtime.Ticks}:{Length}` (see
+        //        GetOrderedDepIds). The term carries no path, so under v12 the identity of a
+        //        dependency across the whole filesystem was (declared id, declared version,
+        //        size, mtime) — two same-version packages of the same size with the same
+        //        mtime and different bytes hashed to the same key, and a warm cache served
+        //        the DLL compiled against the other one, green and with an unchanged exit
+        //        code. A v12 entry and a v13 entry are not interchangeable in EITHER
+        //        direction (v13 HITs where v12 MISSed, for a byte-identical package with a
+        //        fresh mtime), so v12 entries must not be served under the new shape.
+        WriteLine("schema:v13");
         WriteLine($"tdd:{(AlRunner.BcCompiler.IsTddMode() ? "1" : "0")}");
 
         // 1. Runner assembly fingerprint (content hash, not mtime — see v10 note above) +
@@ -561,22 +571,60 @@ internal static partial class ProgramSupport
             return ordered
                 // Id:Version alone is NOT a content identity: a sibling source app keeps
                 // its app.json version while its schema evolves during development, so a
-                // key without the winning .app's file stamp served the test bundle a
+                // key without the winning .app's own identity served the test bundle a
                 // stale compiled assembly after e.g. a field removal — a runtime
                 // NavNCLFieldNotFoundException where a fresh compile correctly fails.
-                // mtime+size (not a content hash) keeps big platform .apps cheap to
-                // stamp; the layered pre-pass only rewrites a synthesized sibling .app
-                // when its source actually changed, so stamps are stable across runs.
+                //
+                // That identity is the package's CONTENT HASH, not a filesystem stat
+                // (#2754). This used to write `{mtime.Ticks}:{Length}`, and note what the
+                // term as a whole does NOT contain: the path. So the identity of a
+                // dependency — across the entire filesystem, not merely within one
+                // directory — was (declared id, declared version, size, mtime). Two .app
+                // packages declaring the same publisher/name/version, of the same size,
+                // carrying the same mtime therefore produced the same AL-output cache key
+                // with different bytes, and a warm cache served the DLL compiled against
+                // whichever one was seen first: same exit code, same green tests, code
+                // linked against a dependency surface the run never saw. Same defect
+                // family as the --define symbols that were missing from this key (a silent
+                // no-op on a cache hit) and the dependency closure that was missing
+                // entirely (3175424 -> 3206144 bytes emitted, key unchanged).
+                //
+                // It is not an exotic coincidence. cp -p, rsync -a, tar -x, unzip and CI
+                // cache restores all carry an mtime along with the bytes, so equal mtimes
+                // across two directories is the ordinary case; a locally rebuilt ISV
+                // dependency keeps its declared version while its content changes; and
+                // Program.cs folds ProvisioningCheck.CollectRunnerOwnedProvisionDirs(...)
+                // into the package-cache search set, so WHICH directories are searched
+                // depends on what artifact directories happen to exist on the machine.
+                //
+                // Cost: BcAppSymbolCache.ComputeAppContentHash memoizes per full path for
+                // the process, and a normal run hashes these same packages anyway for the
+                // bc-symbols key — so for the packages that reach both, this is a
+                // dictionary lookup. For the rest it is one SHA-256 pass over bytes the
+                // run reads regardless (measured on this machine: 122 MB of platform .apps
+                // in ~0.08 s warm). The stat was cheaper per call and answered a different
+                // question.
+                //
+                // It also strictly IMPROVES the hit rate in the safe direction, the same
+                // finding #1815/#1820 made one cache layer over: a byte-identical package
+                // re-downloaded or re-copied with a fresh mtime used to MISS
+                // unconditionally, and now HITs.
                 .Select(d =>
                 {
-                    string stamp = "?";
-                    try
-                    {
-                        var fi = new FileInfo(d.AppPath);
-                        if (fi.Exists) stamp = $"{fi.LastWriteTimeUtc.Ticks}:{fi.Length}";
-                    }
-                    catch { /* unreadable path keys as "?" and simply cannot HIT */ }
-                    return $"{d.Manifest.AppId:N}:{d.Manifest.Version}:{stamp}";
+                    // ComputeAppContentHash answers "unknown" for a missing/empty path
+                    // rather than throwing. Letting that through would put every
+                    // unhashable dependency under one shared term, which is the same
+                    // collision one level down — so make it loud instead: the throw lands
+                    // in the catch below, which prints and keys on the failure so this
+                    // bundle cannot share a cache entry with a resolvable one. A package
+                    // the resolver just read a manifest out of is expected to be hashable;
+                    // if it is not, the compile is about to fail on it anyway.
+                    var hash = AlRunner.Patches.BcAppSymbolCache.ComputeAppContentHash(d.AppPath);
+                    if (hash == "unknown")
+                        throw new IOException(
+                            $"resolved dependency package '{d.AppPath}' could not be hashed for the "
+                            + "AL-output cache key (missing or unreadable at hash time)");
+                    return $"{d.Manifest.AppId:N}:{d.Manifest.Version}:sha256:{hash}";
                 })
                 .OrderBy(s => s, StringComparer.Ordinal)
                 .ToList();


### PR DESCRIPTION
Closes #2754

## The defect

`GetOrderedDepIds` (`AlRunner/ProgramSupport/Dependencies.cs`) wrote one term per resolved dependency, and `ComputeAlCacheKey` folded those straight into the AL-output cache key:

```csharp
return $"{d.Manifest.AppId:N}:{d.Manifest.Version}:{fi.LastWriteTimeUtc.Ticks}:{fi.Length}";
```

Note what the term does **not** contain: the path. So the identity of a dependency — across the whole filesystem, not merely within one directory — was `(declared id, declared version, size, mtime)`. Two `.app` packages that declare the same publisher/name/version, are the same size and carry the same mtime hash to the same key with different bytes, and a warm cache serves the DLL compiled against whichever one was seen first. Nothing fails: same exit code, same green tests, code linked against a dependency surface the run never saw.

The issue body says the term was id+version only; it had since gained the `mtime:length` stamp (#2683). That narrowed the defect without removing it — a stat is not a content identity — so the reproducer here pins the stat terms equal rather than relying on them differing.

Reachability is not exotic. `cp -p`, `rsync -a`, `tar -x`, `unzip` and CI cache restores all carry an mtime along with the bytes, so equal mtimes across two directories is the ordinary case rather than a coincidence; a locally rebuilt ISV dependency keeps its declared version while its content changes; and `Program.cs` folds `ProvisioningCheck.CollectRunnerOwnedProvisionDirs(...)` into the package-cache search set, so *which* directories are searched depends on what artifact directories happen to exist on the machine — the observation in #2754's body.

## The change

Two commits: `04331545` is the fix, `e121dac9` is a correctness fix to `04331545` found in review (second section below).

- Each `dep:` term now carries `sha256:<hash of the resolved package's bytes>` instead of `{mtime.Ticks}:{Length}`, via `BcAppSymbolCache.ComputeAppContentHash` — the same helper #1820 introduced when it replaced a stat with a content hash one cache layer over.
- **The schema line goes `v12` → `v13`.** v12 and v13 entries are not interchangeable in *either* direction (v13 HITs where v12 MISSed), so v12 entries must not be served under the new shape.
- When a resolved package cannot be hashed, **that one term** degrades to `unhashable:<full path>:<mtime>:<size>` (or `:absent` when even a stat fails), with a stderr line naming the package. Every other dependency keeps its content hash.
- Four stale comments corrected: the key's own header summary still described the pre-v10 runner-mtime line and "dep id+version"; three others still described the `mtime:length` stamp.

## The review finding, and `e121dac9`

The first cut threw out of the per-dependency `Select` and let the outer `catch` key the whole bundle on one string:

```csharp
return new[] { $"unresolved:{ex.GetType().Name}:{ex.Message}" };
```

That is **strictly worse than what it replaced**. The pre-#2754 code degraded the single bad term to `"?"` and kept every other dependency's stamp; collapsing the *list* discards them all. So a run where package X is unhashable and package Y has different content produces the same string — an exception type and message, both deterministic across runs — as the run before it. Identical string, identical key, HIT, and the DLL compiled against Y's previous bytes gets served. It inherited exactly the property this PR exists to remove, and the exact property its own body criticised in the old `"?"` term.

The comment defending it was an assumption, not a measurement. `RunnerFingerprint.ComputeContentHash` returns `"unknown"` for an empty or **non-existent** path, so that branch is a time-of-check/time-of-use window rather than a broken package, and a package that vanished and came back would not fail the compile at all. Independently: the resolver's manifest read can be served from `AppLoader`'s on-disk index *without opening the file*, so "the resolver just read its manifest" does not imply the bytes are readable either — which is also how the new tests construct the state (below).

`e121dac9` moves the failure handling into `DependencyContentTerm`, which never throws. The outer `catch` is now reached only for a genuine **resolution** failure, where there is no dep list to preserve — and its comment says so, so the collapse cannot quietly become reachable from a per-dependency condition again.

**Residual, stated rather than papered over.** A package unhashable on two consecutive runs *and* whose content changes between them without changing path, size or mtime is still not distinguished — the pre-#2754 exposure, now narrowed to packages the runner could not read at all. Closing it properly means not claiming a cache identity for such a run at all (a "do not cache this run" signal threaded out to the cache gate), which is wider than this PR; noted on #2846. A per-run nonce would force the MISS in one line, and I deliberately did not add one: no test in this repo can construct the absent-at-hash-time branch, and shipping an untestable branch is the thing this section exists to stop doing. Both the code comment and the tests say this out loud.

## RED → GREEN

RED was run against the code *before* each fix; GREEN is the code pushed. Both are real `dotnet test` runs, not descriptions.

### `AlRunner.Tests/CacheKeyDependencyContentIdentityTests.cs` — the reported defect

RED: `Failed: 2, Passed: 0`, both for the right reason:

```
SameVersionDifferentBytes_ProducesDifferentCacheKey [FAIL]
  Assert.NotEqual() Failure: Strings are equal
  Expected: Not "af38b63c2436dd9ed379a4cea57a81a9dada6f51e7e2b55372"···
  Actual:       "af38b63c2436dd9ed379a4cea57a81a9dada6f51e7e2b55372"···

SameBytesDifferentPathAndMtime_ProducesTheSameCacheKey [FAIL]
  Assert.Equal() Failure: Strings differ
  Expected: "ecfae4bde511c2e22762cebf1d74b2898ab36c2b7"···
  Actual:   "20bcfadcfe797d53deeb4957815e1024249434279"···
```

GREEN: `Passed: 2`.

**Does the collision test construct two packages with the same declared id+version and different bytes?** Yes, and it asserts all three preconditions rather than assuming them, so a drift in the synthetic-package writer becomes a failure rather than a test passing for the wrong reason:

```csharp
Assert.Equal(bytesA.Length, bytesB.Length);
Assert.Equal(new FileInfo(appA).LastWriteTimeUtc.Ticks,
             new FileInfo(appB).LastWriteTimeUtc.Ticks);
Assert.False(bytesA.AsSpan().SequenceEqual(bytesB), "…the fixture is not exercising the defect");
```

Same NAVX manifest (same `Id`/`Name`/`Publisher`/`Version="1.0.0.0"`), plus a 4096-byte `payload.bin` entry stored `CompressionLevel.NoCompression` so its on-disk size is the payload length regardless of how compressible the fill byte is — `'A'` in one, `'B'` in the other. Every zip entry gets an **explicit** `LastWriteTime`; without that `ZipArchive` stamps `DateTimeOffset.Now`, two "identical" packages differ in bytes, and the positive arm silently inverts into a second collision test.

**Is there a positive arm proving the cache still hits?** `SameBytesDifferentPathAndMtime_ProducesTheSameCacheKey` — byte-identical packages at **different paths** with **deliberately different mtimes** (2020 vs 2026) must key **identically**. That is the arm a key on something always-unique would fail. It also pins the direction the fix improves: under the old stamp a byte-identical package re-downloaded with a fresh mtime MISSed unconditionally (the #1815/#1820 finding). The pre-existing `CacheKeyDependencyClosureTests` stability tests and `PrintCacheKeyOnly_MatchesFullRunKey` — the anchor holding `--print-cache-key` to what a real run keys on — still pass, so both arms are measuring the production key.

### `AlRunner.Tests/CacheKeyUnhashableDependencyTests.cs` — the review finding

Three arms, and the construction is the interesting part. "Resolved but unhashable" looks impossible from outside the process: `DependencyResolver.EnsureIndexed` calls `AppLoader.ReadManifest` on every `.app`, so a package it cannot open is one it never indexes. But `ReadManifest` is backed by an on-disk index under `CacheRoots.Resolve("app-manifests")` keyed by `(full path, length, last-write-ticks)` — and `chmod 000` changes none of those. So: run once with the package readable to warm that index (all runs share one `--cache` root, which is what makes the index visible to the next process), then make it unreadable. The resolver answers from the index without opening the file; `ComputeAppContentHash` must read the bytes, and throws. `TryMakeUnreadable` is a **capability** probe, not a uid check — same shape as `InaccessibleDirectoryScanTests` — so it skips rather than asserts against a readable file where mode bits do not bite.

RED (against `04331545`): `Failed: 2, Passed: 1`.

```
UnhashableDependency_DoesNotHideAnotherDependencysContentChange [FAIL]
  Assert.NotEqual() Failure: Strings are equal
  Expected: Not "9d887e9f7cb1a4c32dd98a3070d47cd7c55a262a7c0293b1e4"···
  Actual:       "9d887e9f7cb1a4c32dd98a3070d47cd7c55a262a7c0293b1e4"···

UnhashableDependency_IsReportedByName [FAIL]
  Assert.Contains() Failure: Sub-string not found
  Not found: "could not hash dependency package"
```

GREEN (against `e121dac9`): `Passed: 3, Skipped: 0` — the `Skipped: 0` confirms the chmod actually bit and the arms executed.

- **Regression arm** — X unhashable, Y's bytes change between two runs → keys must differ. This is the arm that fails against throw-and-collapse, above.
- **Control arm** — X unhashable, nothing else touched → keys must be **equal**. Without it the regression arm would be satisfied by a degraded term that simply varies per run, which forces a permanent MISS for any bundle with an unreadable dependency — throwing the cache away by a different route. It passed in RED too; that is its job.
- **Loud arm** — the run must name the package it could not hash. Against throw-and-collapse the message is the generic "dependency resolution failed", which is additionally a false statement, since resolution succeeded.

## Measurements, and what they are worth

**SHA-256 cost.** Method: a standalone Python `hashlib.sha256` streaming in 1 MiB chunks over the six `.app` files in `~/.al-runner/platform-apps` (122.5 MB total), three consecutive runs on a page-cache-warm dev box, wall clock per run 0.088 / 0.072 / 0.070 s. That is an order-of-magnitude bound on the *added hashing work*, measured outside the runner — it is not a measurement of the runner, and I did not A-B the runner's own wall clock before and after. In the run itself the cost is lower than that bound: `ComputeAppContentHash` memoizes per full path, and a normal run hashes these same packages anyway for the `bc-symbols` key, so for packages reaching both it is a dictionary lookup.

**End-to-end cache HIT.** A local transcript, not evidence any CI leg re-checks — I am flagging that explicitly because it reads like proof and is not. `tests/runner-extras/microsoft-dependencies` run twice into one `--cache`:

```
run 1: [cache] MISS key=796c0097…4b4cc35 — running Emit+Compile      24/24 PASS   23.0s
run 2: [cache] HIT  key=796c0097…4b4cc35 … — skipping Emit+Compile   24/24 PASS    5.9s
```

Useful as a sanity check that the full Microsoft platform closure still keys stably once content-hashed, but **the key-stability tests above are the actual evidence**, because they run on every CI leg. The one CI test asserting a real `[cache] HIT` uses a fixture with `"dependencies": []`, so it never executes the changed path at all.

## Can anything fail silently on a neighbouring path?

The `"unknown"` sentinel and the collapsing catch were the two places it could; both are addressed above and both are now tested. Beyond that, three checks per the shape rule:

1. **Same wrong pattern at another call site?** `GetOrderedDepIds` is called from `Program.cs:2585` and `Program.cs:4642`; both funnel into this one function, so one fix covers both. `ComputeAlCacheKey` is its only consumer.
2. **Sibling function making the same assumption?** `DependencyLoader.ComputeSourceDependencyCacheKey` — already content-addressed (`app-bytes:<sha256>`), no gap. `SiblingCompile.ComputeSourceWorkspaceKey` — **yes**: its `dep:` lines are declared identities, the resolved winners appear nowhere, and the directory it keys holds a `symbols.json` compiled against those winners. Filed as #2846 rather than folded in — `bc:<four-part version>` already covers the Microsoft platform case, and the residue needs a resolver threaded into a function that today takes a dir list and an identity map, changing the layered pre-pass's cache identity repo-wide.
3. **Two paths maintaining the same invariant?** `BcAppSymbolCache.Get` keys on content (`|hash:{contentHash}|`) while `BcAppSymbolCache.GetTableExtensions`, in the same class answering the same question about the same file, keys on `|{Length}|{LastWriteTimeUtc.Ticks}|`. Real asymmetry, materially narrower — the key includes the full path and the cache is in-memory with process lifetime. Also on #2846; that file carries an explicit token-shift SIGSEGV warning and deserves its own change.

**Two more, examined and deliberately not changed here** (both raised in review, both pre-existing):

- `AppContentHashCache`'s comment says content "doesn't change mid-run", which is written for a one-shot run and `--watch` is not one. Checked: the runner-owned path is safe, because the layered pre-pass writes to a source-content-keyed directory, so changed content lands at a different path.
- `AppContentHashCache` uses `StringComparer.OrdinalIgnoreCase` on a full path, conflating `/x/Foo.app` and `/x/foo.app` on a case-sensitive filesystem. Pre-existing from #1820, untouched here.

## Which side of the corpus line

**Runner side.** Cache identity asserts nothing about what Business Central does — the AL under test observes no difference, and there is no service tier that could adjudicate "should two packages share a cache entry". `bc-behavior-tests-go-upstream.md`'s test ("if AL Runner did not exist, would this still be a meaningful statement about AL/BC?") answers no. No corpus PR was opened. Both proving tests are C# in `AlRunner.Tests`, and neither needs a fixture `app.json` — they write their packages at runtime — so `no-base-app-in-csharp-tests.md` is not engaged.

## Tests run locally

All Debug, `--no-build`, on this machine, at the pushed tree unless marked RED:

| filter | result |
|---|---|
| `CacheKeyDependencyContentIdentityTests` — RED, pre-`04331545` | Failed 2, Passed 0 |
| `CacheKeyUnhashableDependencyTests` — RED, at `04331545` | Failed 2, Passed 1 |
| `CacheKey*` + `CacheKeyDependencyClosureTests` — GREEN | **Passed 9** |
| `CacheKey*` + `CacheGateProbeScope` + `WatchLayeredDependencyStale` + `BcAppSymbolCacheContentAddressedKey` + `LayeredCache` + `LayeredSourceChain` + `NoCacheLastWinsIntegration` + `SourceDepCacheEnumMetadata` + `SourceDepSymbolsWithoutPackageCache` + `TddMode` + `PackageCacheFinalSearchSet` + `SiblingSymbolsAppRootManifest` | **Passed 46, Skipped 0** (cold, 3 m 32 s) |
| the same filter, **second run** (warm — `local-test-scope.md` names cache-sensitive changes as an exception to targeted-only) | **Passed 46, Skipped 0** (3 m 10 s) |

I did not run the full `AlRunner.Tests` suite or the corpus locally; CI runs both on all 8 legs.

## Deliberately left out

- The two neighbouring keys in #2846, and the residual noted above (reasoning in each section).
- No `test-count-baseline.json` change, no submodule pin bump, no `CHANGELOG.md` edit. The v13 bump invalidates existing on-disk `al-out` entries by design — they become unreachable and the next run rebuilds, which is the documented behaviour of every previous schema bump in this key.

---

🤖 Filed by agent **stma-auto-1**. Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
