### PR TITLE
ci(ms-bucket): move the reader pin to v0.1.2 and name the repository that exists

### DIFF
--- a/.github/workflows/ms-bucket.yml
+++ b/.github/workflows/ms-bucket.yml
@@ -25,7 +25,7 @@ name: MS bucket (manual)
 #   * `test-sources` — the bucket's Source.zip, from the platform artifact (2.4 MB for ERM);
 #   * `test-data`    — BusinessCentral-W1.bak from the sandbox w1 artifact (~977 MB), streamed
 #                      to disk and cached across runs with actions/cache keyed on the build;
-#   * the backup reader `bcbak` — StefanMaron/BusinessCentral.BakReader's Native AOT
+#   * the backup reader `bcbak` — StefanMaron/BusinessCentral.DbReader's Native AOT
 #                      `bcdb-linux-x64` release asset, checksum-verified, installed under the
 #                      old name the runner probes (BackupReaderTool.cs).
 #
@@ -48,23 +48,31 @@ name: MS bucket (manual)
 # Always state whether a number was measured WITH or WITHOUT --test-data: the two differ by
 # 3x on Tests-SINGLESERVER and are not comparable.
 #
-# WHICH BC BUILDS --test-data CAN ACTUALLY BE MEASURED ON, as of reader v0.1.1 (#2779, #2780)
-#   The pinned reader opens the W1 demo backup for some builds and refuses others. Measured
-#   directly, one `bcdb companies` per backup, same binary:
+# WHICH BC BUILDS --test-data CAN ACTUALLY BE MEASURED ON, as of reader v0.1.2 (#2779, #2780)
+#   Reader v0.1.1 opened the W1 demo backup for BC 28.1 and older and REFUSED 28.2, 28.3 and
+#   28.4 with "block N of MSDA region is neither mapped by the derived extent list nor padding
+#   filler — backup layout differs from the derived model, refusing to guess" (BcDb.Core's
+#   PageFile). That was never a regression — v0.1.0, v0.1.1 and the source build before both
+#   refused identically, so the reader had never read a 28.2+ backup — and it meant this
+#   workflow's DEFAULT bc-version could not produce a --test-data number at all.
 #
-#     28.0.46665.54310  OK      28.2.50931.54319  refused
-#     28.1.49838.54308  OK      28.3.52162.54309  refused
-#     27.5.46862.48827  OK      28.4.53241.54318  refused
+#   v0.1.2 reads them. Measured directly with the pinned binary, one `bcdb companies` per
+#   backup:
 #
-#   The refusal is "block N of MSDA region is neither mapped by the derived extent list nor
-#   padding filler — backup layout differs from the derived model, refusing to guess", from
-#   BcDb.Core's PageFile. It is NOT a regression: reader v0.1.0, v0.1.1 and the source build
-#   before both fail identically, so the reader has never read a 28.2+ backup. Tracked in
-#   #2780; the fix is in StefanMaron/BusinessCentral.BakReader, not here.
+#     27.5.46862.48827  OK      28.2.50931.54319  OK
+#     28.1.49838.50621  OK      28.3.52162.54309  OK
+#     28.1.49838.54308  OK      28.4.53241.54318  OK
 #
-#   Consequence for THIS workflow: the default bc-version (the newest prefix in
-#   .github/bc-versions.txt, currently 28.4) cannot produce a --test-data number. Pass
-#   `bc-version: 28.1` for one, or run with test-data off and say so.
+#   28.0.46665.54310 was not re-measured (no local backup); v0.1.1 read it and v0.1.2 changes
+#   only the refusal path, so it is expected to keep reading it. The pin comment on READER_TAG
+#   below carries the v0.1.1-vs-v0.1.2 comparison and the decoded-value check behind the bump.
+#
+#   So the default bc-version (the newest prefix in .github/bc-versions.txt, currently 28.4)
+#   is expected to produce a --test-data number. `bcdb companies` succeeding is not the same
+#   as a whole bucket run succeeding: the first full run on 28.4 is the confirmation, and if
+#   it fails it should fail for a NEW reason, surfaced verbatim by
+#   scripts/ms-bucket-summary.py's caveat scanner (which matches the runner's
+#   "=== <bundle> — EXEC FAIL ===" header and its reason lines generically, not the MSDA text).
 
 on:
   workflow_dispatch:
@@ -175,15 +183,35 @@ jobs:
           # is an argument for pinning it, not for floating it.
           #
           # To move it: pick the new tag from
-          # https://github.com/StefanMaron/BusinessCentral.BakReader/releases, run this
+          # https://github.com/StefanMaron/BusinessCentral.DbReader/releases, run this
           # workflow once on the new pin, and compare the pass/fail totals against the previous
           # pin's run before merging the bump. A reader upgrade that changes decoded values
           # changes this measurement, so the bump belongs in its own PR with both numbers in
           # the body.
-          READER_TAG: v0.1.1
+          #
+          # v0.1.1 -> v0.1.2 (#2780). v0.1.1 could not open the W1 demo backup for BC 28.2 and
+          # newer at all -- `bcdb companies` exited 1 with "block <N> of MSDA region is neither
+          # mapped by the derived extent list nor padding filler" -- so with test-data: true the
+          # workflow's DEFAULT bc-version (the newest prefix in .github/bc-versions.txt, 28.4)
+          # could not produce a number. Measured on the real backups, one binary per row, both
+          # release assets checksum-verified against their SHA256SUMS:
+          #
+          #     BC        v0.1.1                     v0.1.2
+          #     28.1      OK                         OK
+          #     28.2      refused (block 116296)     OK
+          #     28.3      refused (block 116288)     OK
+          #     28.4      refused (block 116504)     OK
+          #
+          # The totals comparison this comment asks for cannot be done like-for-like at 28.2+,
+          # because the OLD pin produces no number there at all -- that is the bug. So the
+          # decoded-value question was answered where both readers CAN read, on 28.1: the
+          # `bcdb tables` listing is byte-identical (3,956 lines) and a `bcdb read` of
+          # "Source Code Setup" is byte-identical between the two. v0.1.2 adds versions it can
+          # open; it does not change what it decodes on the versions v0.1.1 already opened.
+          READER_TAG: v0.1.2
           GH_TOKEN: ${{ github.token }}
         run: |
-          # bcbak is StefanMaron/BusinessCentral.BakReader's `bcdb`, consumed as a pinned
+          # bcbak is StefanMaron/BusinessCentral.DbReader's `bcdb`, consumed as a pinned
           # release's Native AOT asset rather than built here: a source build needs the .NET 10
           # SDK plus clang and adds minutes, and the release binary is the one that repo's own
           # hermetic test suite gated before publishing. The runner probes the OLD name at
@@ -193,7 +221,12 @@ jobs:
           tag="$READER_TAG"
           mkdir -p "$RUNNER_TEMP/reader"
           cd "$RUNNER_TEMP/reader"
-          gh release download "$tag" --repo StefanMaron/BusinessCentral.BakReader \
+          # StefanMaron/BusinessCentral.DbReader, NOT .BakReader: that repository was renamed,
+          # and the old name only still works because GitHub redirects it. A rename redirect is
+          # not a contract -- it lasts at GitHub's discretion, and it stops the moment anyone
+          # creates a new repository at the freed-up old name, at which point this line
+          # downloads someone else's asset or 404s in a nightly nobody is watching closely.
+          gh release download "$tag" --repo StefanMaron/BusinessCentral.DbReader \
             --pattern bcdb-linux-x64 --pattern SHA256SUMS
           grep 'bcdb-linux-x64$' SHA256SUMS | sha256sum -c -
           install -D -m 0755 bcdb-linux-x64 "$HOME/.cache/al-runner/bcbak/bcbak"

--- a/AlRunner.Tests/MsBucketWorkflowTests.cs
+++ b/AlRunner.Tests/MsBucketWorkflowTests.cs
@@ -134,7 +134,15 @@ public sealed class MsBucketWorkflowTests
         Assert.Contains("test-sources", code, StringComparison.Ordinal);
         Assert.Contains("--test-data=", code, StringComparison.Ordinal);
         Assert.Contains("--test-data-company", code, StringComparison.Ordinal);
-        Assert.Contains("BusinessCentral.BakReader", code, StringComparison.Ordinal);
+        // StefanMaron/BusinessCentral.DbReader. This assertion previously named
+        // BusinessCentral.BakReader, which is the repository's OLD name and resolves only
+        // through GitHub's rename redirect -- so the test was pinning a name that is not the
+        // repository's, and it went red the moment the workflow was corrected. A redirect is
+        // not a contract: it lasts at GitHub's discretion and ends if anyone claims the freed
+        // old name. The DoesNotContain arm is the point of the pair -- without it, a revert to
+        // the redirect name passes again in silence.
+        Assert.Contains("StefanMaron/BusinessCentral.DbReader", code, StringComparison.Ordinal);
+        Assert.DoesNotContain("BusinessCentral.BakReader", code, StringComparison.Ordinal);
         Assert.Contains(".cache/al-runner/bcbak/bcbak", code, StringComparison.Ordinal);
         // The deliverable: a job summary plus the JUnit for clustering.
         Assert.Contains("GITHUB_STEP_SUMMARY", code, StringComparison.Ordinal);

--- a/scripts/ms-bucket-summary.py
+++ b/scripts/ms-bucket-summary.py
@@ -116,7 +116,11 @@ def compose(meta, totals, scan, rc, elapsed_s):
     rc_text = RC_MEANING.get(rc, "unexpected exit code")
     out.append(f"Runner exit code {rc} — {rc_text}. Wall time {fmt_elapsed(elapsed_s)} for the runner step.")
     if meta.get("reader"):
-        out.append(f"Backup reader: BusinessCentral.BakReader {meta['reader']}.")
+        # BusinessCentral.DbReader, not .BakReader: that repository was renamed and the old
+        # name survives only through GitHub's rename redirect. This line is read by a human
+        # deciding where to go look, so an old name sends them to a redirect that may not be
+        # there later.
+        out.append(f"Backup reader: BusinessCentral.DbReader {meta['reader']}.")
     out.append("")
     if totals is None:
         out += ["**No number: no JUnit file was produced.** The runner did not get as far as running tests"

--- a/scripts/tests/ms-bucket-summary.test.py
+++ b/scripts/tests/ms-bucket-summary.test.py
@@ -133,6 +133,23 @@ class ComposeTests(unittest.TestCase):
             self.assertIn(needle, md, needle)
         self.assertIn("No caveats", md)
 
+    def test_the_reader_line_names_the_repository_that_actually_exists(self):
+        """#2780. The summary's reader line is what a human follows to go look at the reader,
+        and it used to name BusinessCentral.BakReader — the repository's OLD name, which
+        resolves only through GitHub's rename redirect. A redirect is not a contract, and
+        nothing here covered this line, so the wrong name could sit indefinitely. Both
+        directions, because the positive alone would still pass with both names present."""
+        md = mbs.compose(META, mbs.parse_junit_totals(JUNIT), mbs.scan_log(CLEAN_LOG), rc=1, elapsed_s=10)
+        self.assertIn("Backup reader: BusinessCentral.DbReader v0.1.1.", md)
+        self.assertNotIn("BakReader", md)
+
+    def test_no_reader_line_at_all_when_the_run_had_no_reader(self):
+        """The negative arm for the line's existence: without --test-data there is no reader,
+        and inventing one would mislabel the run."""
+        md = mbs.compose(dict(META, test_data=False, reader=None),
+                         mbs.parse_junit_totals(JUNIT), mbs.scan_log(CLEAN_LOG), rc=1, elapsed_s=10)
+        self.assertNotIn("Backup reader:", md)
+
     def test_caveats_are_listed_verbatim_so_a_wrong_number_cannot_hide(self):
         scan = mbs.scan_log("NOT RUN: 1 bundle(s)\n" + CLEAN_LOG)
         md = mbs.compose(META, mbs.parse_junit_totals(JUNIT), scan, rc=1, elapsed_s=10)


### PR DESCRIPTION
Closes #2780

Two changes to one consumption path: move the backup reader pin to `v0.1.2`, and stop naming a repository that only exists as a redirect.

## The pin move

`v0.1.1` could not open the W1 demo backup for BC 28.2 and newer **at all**, so with `test-data: true` this workflow's default `bc-version` — the newest prefix in `.github/bc-versions.txt`, currently 28.4 — could not produce a number. Measured with both release binaries, each checksum-verified against its own `SHA256SUMS`, one `bcdb companies` per backup:

| BC | v0.1.1 | v0.1.2 |
|---|---|---|
| 27.5.46862.48827 | OK | OK |
| 28.1.49838.50621 | OK | OK |
| 28.1.49838.54308 | OK | OK |
| 28.2.50931.54319 | refused (block 116296) | **OK** |
| 28.3.52162.54309 | refused (block 116288) | **OK** |
| 28.4.53241.54318 | refused (block 116504) | **OK** |

That inverts #2780's table exactly, with 28.1 and 27.5 unchanged as controls. 28.0 was not re-measured — no local backup — and is called out as such in the workflow comment rather than presented as measured.

**The pin comment asks for a totals comparison against the previous pin before any bump. That cannot be done like-for-like at 28.2+, because the old pin produces no number there at all — that is the bug.** So I answered the question the comment is actually protecting (does a reader upgrade change decoded values?) where both readers *can* read, on 28.1: the `bcdb tables` listing is byte-identical at 3,956 lines, and a `bcdb read` of "Source Code Setup" is byte-identical. v0.1.2 adds versions it can open without changing what it decodes on the versions v0.1.1 already opened.

I verified the release independently before pinning to it: `v0.1.2`, `draft=false`, published 2026-09-05T17:54:44Z, `bcdb-linux-x64` 9,573,616 bytes plus `SHA256SUMS`, all `uploaded`. The binary reports `bcdb 0.1.2+68df0f96…`.

## The repository name

The download line named `StefanMaron/BusinessCentral.BakReader`. That repository was **renamed to `BusinessCentral.DbReader`**, and the old name works only because GitHub redirects it:

```
gh repo view StefanMaron/BusinessCentral.BakReader  ->  resolves-to: StefanMaron/BusinessCentral.DbReader
```

A rename redirect is not a contract. It lasts at GitHub's discretion and ends the moment anyone creates a repository at the freed-up old name — at which point this line downloads a stranger's asset or 404s, in a job nobody watches closely.

**A test was pinning the wrong name.** `MsBucketWorkflowTests` asserted `Contains("BusinessCentral.BakReader")`, so correcting the workflow turned it red immediately — a test asserting a name that resolves only through a redirect pins the redirect rather than the repository, and it would have quietly blocked this correction for whoever tried it next. It now asserts the real name **and** `DoesNotContain` the old one; without that second arm, a revert to the redirect name passes again in silence.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site?** Yes — four in the workflow, not one. Beyond `gh release download`, `ms-bucket.yml`'s own header comment named `.BakReader` as the asset's source, and a "which BC builds can be measured" block still told readers to pass `bc-version: 28.1` as a workaround and that "the fix is in BusinessCentral.BakReader, not here." Both are rewritten; leaving the second would have documented a workaround for a bug this PR removes.
2. **Sibling reading the same state?** `scripts/ms-bucket-summary.py` writes the reader line a human follows to go look at the reader. Same wrong name, and **nothing covered that line** — so it had no way to be noticed. Corrected, with a test.
3. **Two paths writing the same state?** The C# guard covered the workflow and nothing covered the summary script, which is why the two drifted in the first place. Both are covered now, each with a negative arm.

## What I deliberately left out

Five prose mentions of the old name survive in `AlRunner/TestDataProvisioner.cs`, `AlRunner/Patches/RecordPatches.TestDataHydration.cs` and `tests/test-data-fixture/README.md`. They are historical references of the form `BakReader#18` — an issue filed while the repo had that name — not a consumption path: nothing resolves through them. Touching `AlRunner/` would also trip the `Tests updated` gate for a comment edit with no behavior change. Left as-is on purpose, recorded here rather than silently.

## RED to GREEN

- **C#, both directions.** The pre-existing assertion failed against the corrected workflow (`Not found: "BusinessCentral.BakReader"`). With the test corrected, putting the redirect name back into the download line fails again (`Not found: "StefanMaron/BusinessCentral.DbReader"`). Green: `MsBucketWorkflowTests` 8/8, and 25/25 across every `~Workflow` guard class.
- **Python, both directions.** The new `test_the_reader_line_names_the_repository_that_actually_exists` fails against the old string and passes against the new; a second case asserts no reader line at all when a run had no reader. `scripts/tests/ms-bucket-summary.test.py`: 17 tests, OK.
- **The reader itself** was measured on real backups rather than trusted from a release note, which is the table above.

Local runs are BC 28.x plus 27.5 backups on this machine; CI reports the rest.

## What the nightly should do next

The nightly is #2838 (impl-2, `status: review-ready`) and is **not on `main` yet** — `ms-bucket.yml` is still `workflow_dispatch` only, so nothing scheduled runs until that lands. When it does, it has been red for a known and annotated reason: the reader refusing 28.4. After this pin it should either produce a Tests-SMB number or fail for a **new** reason.

`bcdb companies` succeeding is not the same as a whole bucket run succeeding, and this PR does not claim otherwise — the first full 28.4 run is the confirmation. A new failure should still be legible: `scripts/ms-bucket-summary.py`'s caveat scanner matches the runner's `=== <bundle> — EXEC FAIL ===` header and its reason lines **generically**, not the MSDA text, so a different reason reaches the summary verbatim. What nobody has confirmed is that the reader emits exactly the string the success path expects; impl-9's change alters the success path rather than the refusal path, so the scanner should be unaffected, but that is reasoning, not a measurement.

**Possible conflict:** #2838 also edits `ms-bucket.yml` (adding a schedule, and likely its header). Whichever merges second may need a rebase.

---
Written by Claude Code agent impl-7.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
