### PR TITLE
docs(limitations): correct the task-scheduler section — nothing runs, inline or otherwise

### DIFF
--- a/AlRunner.Tests/ExpectationManifestSchemaTests.cs
+++ b/AlRunner.Tests/ExpectationManifestSchemaTests.cs
@@ -112,4 +112,67 @@ public class ExpectationManifestSchemaTests : IDisposable
             }
         }
     }
+
+    /// <summary>
+    /// Every <c>Doc</c> an expect-divergence entry cites must resolve: the file has to exist, and
+    /// when the reference carries a <c>#anchor</c>, that anchor has to be defined in it.
+    ///
+    /// <para>#2565 is why this exists. A divergence entry's whole justification is "the decision
+    /// is recorded over there" — if the pointer rots, the entry becomes an assertion with nothing
+    /// behind it, and the manifest looks as authoritative as ever. The sibling check above only
+    /// asked that <c>Doc</c> starts with <c>docs/</c>, which a reference to a deleted file or a
+    /// renamed heading passes.</para>
+    ///
+    /// <para>This does not check that the prose is TRUE — nothing automated can — but it does
+    /// catch the mechanical half of the drift that has been expensive here repeatedly: three
+    /// separate cases in one day of a document asserting something the code had stopped doing.
+    /// Anchors are matched against both explicit <c>&lt;a id="..."&gt;</c> tags (what
+    /// <c>docs/scope.md</c> uses) and GitHub's heading-slug convention.</para>
+    /// </summary>
+    [Fact]
+    public void EveryDivergenceDocReference_ResolvesToARealFileAndAnchor()
+    {
+        var repoRoot = Path.GetFullPath(
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var manifest = ExpectationManifest.LoadFromDirectory(
+            Path.Combine(repoRoot, "tests", "expectations"));
+
+        var checkedAny = false;
+        foreach (var e in manifest.Entries)
+        {
+            if (e.Mode != ExpectationMode.ExpectDivergence || string.IsNullOrWhiteSpace(e.Doc)) continue;
+            checkedAny = true;
+
+            var hash = e.Doc!.IndexOf('#');
+            var relPath = hash < 0 ? e.Doc! : e.Doc![..hash];
+            var anchor = hash < 0 ? null : e.Doc![(hash + 1)..];
+
+            var full = Path.Combine(repoRoot, relPath);
+            Assert.True(File.Exists(full),
+                $"{e.SourceFile}: {e.CodeunitName}.{e.Method} cites Doc '{e.Doc}', but {relPath} does not exist.");
+
+            if (anchor == null) continue;
+            var text = File.ReadAllText(full);
+
+            // Explicit anchor tag, e.g. docs/scope.md's `<a id="jobs"></a>`.
+            if (text.Contains($"id=\"{anchor}\"", StringComparison.OrdinalIgnoreCase)) continue;
+
+            // Otherwise GitHub's heading slug: lower-cased, non-alphanumerics dropped, spaces to '-'.
+            var slugs = text.Split('\n')
+                .Where(l => l.TrimStart().StartsWith("#", StringComparison.Ordinal))
+                .Select(l => new string(l.TrimStart('#', ' ', '\t', '\r')
+                        .ToLowerInvariant()
+                        .Select(c => char.IsLetterOrDigit(c) ? c : (c == ' ' ? '-' : '\0'))
+                        .Where(c => c != '\0').ToArray()))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+            Assert.True(slugs.Contains(anchor),
+                $"{e.SourceFile}: {e.CodeunitName}.{e.Method} cites Doc '{e.Doc}', but {relPath} defines no "
+                + $"anchor '{anchor}' — neither an <a id=\"...\"> tag nor a heading that slugs to it. "
+                + "A divergence entry whose pointer has rotted is an assertion with nothing behind it.");
+        }
+
+        Assert.True(checkedAny,
+            "no expect-divergence entry carried a Doc reference — this guard would pass vacuously.");
+    }
 }

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -237,17 +237,38 @@ The runner executes in a single .NET process with no attached BC debugger. Debug
 
 `Debugger.Activate()`, `Debugger.Deactivate()`, and `Debugger.IsActive()` are supported — they are stripped or return `false`.
 
-### Task scheduler — synchronous dispatch
+### Task scheduler — no scheduler, and no inline substitute
 
-`TaskScheduler.CreateTask()` dispatches the target codeunit **synchronously, inline**,
-before returning — the same pattern as `StartSession`. The implications:
+**Tasks are never executed.** `TaskScheduler.CreateTask()` does not run the target codeunit —
+not in the background, and not inline either. [`docs/scope.md` §3.6](scope.md#jobs) is the
+authoritative description of this surface; the summary below only restates what was measured
+against it, so if the two ever disagree again, §3.6 and the Cecil layer win.
 
-- `TaskExists()` always returns `false` — the task already completed before the call returned.
-- `CancelTask()` and `SetTaskReady()` are no-ops — the task has already run.
-- `CanCreateTask()` returns `false` — there is no background job queue.
-- `NotBefore` and `CompanyName` parameters are accepted but ignored — the codeunit runs immediately in the current company context.
+The runner Cecil-rewrites `ALTaskScheduler.CanCreateTask` / `ALCanCreateTask` to return
+`false` and deliberately leaves `ALCreateTaskAsync` **unmodified**, so BC's own body raises
+BC's own exception. Measured on BC 28.1:
 
-AL that tests the *logic* around task creation (what codeunit runs, what state it produces) works here. AL that tests the *scheduling contract* (task still pending, NotBefore delay, cancellation before execution) cannot work here because there is no background scheduler.
+| AL call | What actually happens |
+|---|---|
+| `CanCreateTask()` | `false` |
+| `CreateTask()` | throws `You do not have permission to create or run scheduled tasks.` The target codeunit's `OnRun` does **not** run. |
+| `TaskExists()` | throws a `NullReferenceException` — the real body reaches for a SQL connection that does not exist here. Tracked separately; it should refuse loudly rather than NRE. |
+| `CancelTask()`, `SetTaskReady()` | complete without error, having done nothing (there is no task to act on). |
+
+So: guarded AL (`if TaskScheduler.CanCreateTask() then …`) skips task creation cleanly and is
+the pattern that works here. Unguarded AL that calls `CreateTask()` directly gets BC's loud
+refusal, which is deliberate — an earlier version of the runner rewrote `ALCreateTaskAsync` to
+return `Guid.Empty`, and that was reverted (#1733, #1739) as a silent fake suppressing BC's
+own guard.
+
+AL that tests the *scheduling contract* — a task still pending, a `NotBefore` delay,
+cancellation before execution — cannot work here, because nothing is scheduled and nothing
+runs. AL that needs the target codeunit's logic to actually execute should call it directly
+(`Codeunit.Run`) rather than through `CreateTask`.
+
+> This section previously described `CreateTask()` as dispatching the codeunit
+> "synchronously, inline". That described a design that was reverted, and it was wrong in both
+> directions: no codeunit runs, and `TaskExists()` does not return `false`. See #2565.
 
 ### No DotNet interop
 


### PR DESCRIPTION
Closes #2565

Written by an agent (impl-1).

## Which document was right — established by measurement, not by reading

`docs/scope.md` §3.6 is right; `docs/limitations.md` described a design that was **reverted**. I did not take either document's word for it, and I did not assume the newer file was correct. I ran a probe bundle that calls each API and reports what came back, on BC 28.1:

| AL call | `limitations.md` said | **Measured** |
|---|---|---|
| `CanCreateTask()` | `false` | `false` — correct |
| `CreateTask()` | dispatches the codeunit **synchronously, inline** | **throws** `You do not have permission to create or run scheduled tasks.` The target codeunit's `OnRun` does **not** run — the worker's marker table had **0 rows**, where inline dispatch would have left 1 |
| `TaskExists()` | always returns `false` | **throws `NullReferenceException`**, from `NavSqlConnectionScope.TryOpenConnection` reaching for a SQL connection that does not exist here |
| `CancelTask()` / `SetTaskReady()` | no-ops, "the task has already run" | complete having done nothing — correct outcome, **false reason** (no task ever ran) |

So it was wrong on the two substantive claims and accidentally right on three others with a rationale that does not hold.

The code agrees with `scope.md`. `NclCecilRewrite.Dispatch.cs` rewrites `ALTaskScheduler.CanCreateTask` / `ALCanCreateTask` to return `false` and deliberately leaves `ALCreateTaskAsync` **unmodified** so BC's own body raises BC's own exception; its comment records that an earlier `return Guid.Empty` rewrite was reverted as "a silent fake suppressing BC's guard" (#1733, #1739). `tests/expectations/divergence-session.json` carries the matching `expect-divergence` entry, and that corpus test passes as a divergence here.

The rewritten section names `docs/scope.md` §3.6 as authoritative and states which side wins if they drift again — the structural fix the issue asked for.

## A second stale claim, found while measuring

`TaskExists()` does not return `false` — it **NREs**. An unhandled `NullReferenceException` is not a meaningful answer to an AL caller, and `loud-failures.md` would have it either work or refuse loudly. That is a behaviour defect rather than a docs one, so it is **filed separately as #2866** and only *described* here; this PR changes no runtime behaviour.

## The guard, because this is the third case today

`ExpectationManifestSchemaTests.EveryDivergenceDocReference_ResolvesToARealFileAndAnchor` now checks that every `Doc` an `expect-divergence` entry cites actually resolves: the file exists, and a `#anchor` is genuinely defined (explicit `<a id>` tag, or a heading that slugs to it). The existing check only asserted the string starts with `docs/`, which a reference to a deleted file or a renamed heading passes happily.

**Proved it is not vacuous**: renaming `scope.md`'s `jobs` anchor makes it fail, naming the entry and the missing anchor —

```
divergence-session.json: Test TaskScheduler Behavior.TaskScheduler_CreateTask_InsideTest_ReturnsNonEmptyGuid
cites Doc 'docs/scope.md#jobs', but docs/scope.md defines no anchor 'jobs' …
```

— and pass again once restored. It also asserts it checked at least one entry, so it cannot pass by finding nothing.

It cannot check that prose is **true** — nothing automated can, and I am not claiming otherwise. It catches the mechanical half.

## What I did NOT do

The issue's "How this came up" section mentions a contributor fork that reverses the closed #1733/#1739 decision and edits `.claude/rules/loud-failures.md` to permit itself. **That is a maintainer policy call, not an agent's.** I did not act on it, did not evaluate its merits, and changed nothing about the #1733/#1739 decision or that rule. This PR only makes the documentation match the behaviour shipped today.

## Verified locally

**28.x only — a self-built runner is compiled against Ncl 28.x and cannot run 27.x artifacts.**

- `ExpectationManifestSchemaTests` + `ExpectationClassifierTests`: 28/28, and the new guard fails-then-passes against a deliberately broken anchor.
- Corpus `Codeunit60877` (`TestTaskSchedulerCloudBehavior`) still classifies as `pass-divergence`.
- The probe bundle above; it is scratch, not committed.

**Not verified:** I did not run the full `AlRunner.Tests` suite or the corpus. No runtime code changed — the diff is one docs file and one test file.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
