### PR TITLE
fix(server): clear the registered symbol .apps on bundle reload, not just their derived indexes

### DIFF
--- a/AlRunner.Tests/BcAppPathsResetTests.cs
+++ b/AlRunner.Tests/BcAppPathsResetTests.cs
@@ -1,0 +1,155 @@
+// BcAppPathsResetTests — issue #2755.
+//
+// RecordPatches._bcAppPaths is process-global and nothing ever cleared it. The per-bundle reload
+// path, ResetForReload, clears _parsedTables and every other source-derived dictionary and then
+// calls InvalidateBcAppIndexes() — which drops the DERIVED table/extension indexes precisely so
+// the next lookup rebuilds them FROM _bcAppPaths. So in --server and --watch, bundle 2 was
+// compiled and run against its own registered .app symbols UNION every earlier bundle's, while a
+// fresh single-bundle process running bundle 2 alone saw only its own.
+//
+// The neighbouring per-bundle state does reset: InstallTriggerRunner.ResetForNewBundle() clears
+// _depAssemblies, and the server path's own comment says "New bundle in the server session:
+// replace (not inherit) the install-trigger registrations". Two writers of the same per-bundle
+// notion, one holding the invariant and one not.
+//
+// ── WHY THIS TEST IS SHAPED THIS WAY, WHICH IS MOST OF THE WORK ─────────────────────────────
+//
+// impl-7 measured two things before this could be written, both AFTER a fixture that passed and
+// read like a result (see their comment on #2755):
+//
+//   * A SOURCE-ONLY bundle never touches _bcAppPaths at all. Its tables live in _parsedTables,
+//     which ResetForReload does clear. A source-only fixture cannot express this defect and goes
+//     green for an unrelated reason — they nearly reported exactly that.
+//   * A layered-synthesized .app is not registrable either: manifest plus src/, no
+//     SymbolReference.json, so RegisterBundleSymbolApps skips it. Copying one into a bundle root
+//     would have produced a second fixture that also could not express the defect.
+//
+// So the assertion is made DIRECTLY against the registered set, through
+// RecordPatches.RegisteredBcAppPathsForTests(). Inferring it from a downstream table lookup is
+// what conflates this with _parsedTables — which the reset DOES clear, so such a test would pass
+// on the broken build.
+//
+// The .app comes from SymbolAppFixture (impl-7, #2855): a registrable symbol package emitted
+// in-process in milliseconds, platform-only and never an application floor.
+using System.Reflection;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// MUST be serial. This mutates RecordPatches' process-global registration list and calls
+// ResetForReload(), which clears roughly twenty static dictionaries — running it beside another
+// test that reads any of them would corrupt that test, not this one, which is the hard kind of
+// flake to trace back.
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class BcAppPathsResetTests : IDisposable
+{
+    private readonly string _root;
+
+    public BcAppPathsResetTests() => _root = TestScratch.Dir("al-runner-bcapppaths-reset");
+
+    public void Dispose()
+    {
+        // Leave the process's registration list as it was found: this class runs inside a shared
+        // engine, and a stray registration outlives the test that made it.
+        try { RecordPatches.ResetForReload(); } catch { }
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private string RegisterOneSymbolApp(string name, int tableId)
+    {
+        var bundleDir = Path.Combine(_root, name);
+        var appPath = Path.Combine(bundleDir, $"{name}.app");
+        SymbolAppFixture.WriteBundleAndApp(
+            bundleDir, appPath, Guid.NewGuid(), name, tableId, $"{name} Table",
+            withSymbolReference: true);
+        RecordPatches.RegisterBundleSymbolApps(bundleDir);
+        return appPath;
+    }
+
+    [Fact]
+    public void ResetForReload_ClearsTheRegisteredSymbolApps()
+    {
+        RecordPatches.ResetForReload();
+        var appPath = RegisterOneSymbolApp("BcpA", 70600);
+
+        // Precondition, asserted rather than assumed: if registration silently did not happen —
+        // which is exactly what a source-only or SymbolReference-less fixture produces — the
+        // assertion below would pass for a reason that has nothing to do with the reset.
+        Assert.Contains(appPath, RecordPatches.RegisteredBcAppPathsForTests());
+
+        RecordPatches.ResetForReload();
+
+        Assert.DoesNotContain(appPath, RecordPatches.RegisteredBcAppPathsForTests());
+    }
+
+    [Fact]
+    public void ASecondBundleDoesNotInheritTheFirstBundlesSymbolApps()
+    {
+        // The defect as --server actually meets it: two bundles, one process, a reload between
+        // them. Bundle 2 must see its own registration and NOT bundle 1's.
+        RecordPatches.ResetForReload();
+        var first = RegisterOneSymbolApp("BcpFirst", 70610);
+        Assert.Contains(first, RecordPatches.RegisteredBcAppPathsForTests());
+
+        // What Program.cs does between bundles in a server session: reset, then register this
+        // bundle's own closure (Program.cs 2196/2200 then 2354/2357 on the CLI path, 4049/4529
+        // then 4533/4534 on the server path — the reset precedes registration in both, which is
+        // what makes clearing here safe).
+        RecordPatches.ResetForReload();
+        var second = RegisterOneSymbolApp("BcpSecond", 70620);
+
+        var registered = RecordPatches.RegisteredBcAppPathsForTests();
+        Assert.Contains(second, registered);
+        Assert.DoesNotContain(first, registered);
+    }
+
+    [Fact]
+    public void AfterTheReset_ReRegisteringTheSameAppStillWorks()
+    {
+        // The other direction, and the one that stops the fix from being "break registration".
+        // Every bundle re-registers its FULL resolved closure — platform apps included — right
+        // after the reset, so clearing is only safe if a cleared path can be registered again.
+        // AddBcAppPath early-returns on a path already present, so a clear that did not really
+        // clear would show up here as a missing re-registration.
+        RecordPatches.ResetForReload();
+        var appPath = RegisterOneSymbolApp("BcpAgain", 70630);
+        Assert.Contains(appPath, RecordPatches.RegisteredBcAppPathsForTests());
+
+        RecordPatches.ResetForReload();
+        Assert.DoesNotContain(appPath, RecordPatches.RegisteredBcAppPathsForTests());
+
+        RecordPatches.RegisterBundleSymbolApps(Path.GetDirectoryName(appPath)!);
+        Assert.Contains(appPath, RecordPatches.RegisteredBcAppPathsForTests());
+    }
+
+    [Fact]
+    public void TheRegisteredSetIsAnInputToTheInstallBaselineKey_SoClearingItMovesTheKey()
+    {
+        // #2710/#2753 folded the registered set into the install-baseline cache key precisely
+        // because it varies between runs, and named --server accumulation as one of the two ways
+        // it varies. This asserts the two facts stay connected: if the key ever stopped reading
+        // the registered set, the accumulation would go silent again and this fix would be
+        // load-bearing for nothing.
+        RecordPatches.ResetForReload();
+        var empty = InvokeStateKey();
+
+        RegisterOneSymbolApp("BcpKeyed", 70640);
+        var withApp = InvokeStateKey();
+        Assert.NotEqual(empty, withApp);
+
+        RecordPatches.ResetForReload();
+        Assert.Equal(empty, InvokeStateKey());
+    }
+
+    private static string InvokeStateKey()
+    {
+        var m = typeof(RecordPatches).GetMethod(
+            "RegisteredBcAppSymbolStateKey", BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                "RegisteredBcAppSymbolStateKey is gone — the install-baseline key may no longer "
+                + "name the registered symbol set (#2710), which is what makes this accumulation "
+                + "observable at all");
+        return (string)m.Invoke(null, null)!;
+    }
+}

--- a/AlRunner.Tests/BcAppPathsResetTests.cs
+++ b/AlRunner.Tests/BcAppPathsResetTests.cs
@@ -123,6 +123,44 @@ public sealed class BcAppPathsResetTests : IDisposable
         Assert.Contains(appPath, RecordPatches.RegisteredBcAppPathsForTests());
     }
 
+    [SkippableFact]
+    public void ResetForReload_KeepsTheProcessLifetimeSystemAppRegistration()
+    {
+        TestArtifacts.SkipIf(!BcEngineBootstrap.Ready,
+            BcEngineBootstrap.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // The one entry in _bcAppPaths that NOTHING re-adds. RegisterSystemAppPackage() runs
+        // once per process, from RecordPatches.Register() at engine bootstrap — it is not part
+        // of Program.cs's per-bundle dep-register stage, so a flat _bcAppPaths.Clear() here
+        // unregistered it for the rest of a --server/--watch process. That matters because
+        // ResetForReload also clears _parsedTables and _metaTableCache: the registered .app is
+        // the only source left for the NCL-internal system tables (RecordLink 2000000068,
+        // Field 2000000041, Object 2000000038, ...) that BC's own NCL code constructs directly
+        // via `new NavRecord(parent, id)`. The first draft of #2755 did exactly that and two
+        // AlRunner.Tests classes failed with "no NCLMetaTable for table N (dependency source
+        // not parsed)" on the 27.5 and 28.4 legs — the two that run AlRunner.Tests.
+        var systemApp = RecordPatches.SystemAppPackagePathForTests;
+        Assert.NotNull(systemApp);
+        Assert.Contains(systemApp!, RecordPatches.RegisteredBcAppPathsForTests());
+
+        // A per-bundle registration alongside it, so the assertion below is a statement about
+        // WHICH entries go rather than about the reset doing nothing.
+        var bundleApp = RegisterOneSymbolApp("BcpAlongsideSystemApp", 70650);
+        Assert.Contains(bundleApp, RecordPatches.RegisteredBcAppPathsForTests());
+
+        RecordPatches.ResetForReload();
+
+        var registered = RecordPatches.RegisteredBcAppPathsForTests();
+        Assert.Contains(systemApp!, registered);      // kept: nothing re-adds it
+        Assert.DoesNotContain(bundleApp, registered); // dropped: Program.cs re-adds it
+
+        // And it is still usable, not merely still listed: a system table the SystemApp package
+        // is the only source for still resolves after the reset. Table 2000000068 (Record Link)
+        // is not in any test bundle's src/ and _parsedTables was just cleared, so the ONLY way
+        // this can answer is by re-reading the registration kept above.
+        Assert.Equal(2000000068, RecordPatches.ResolveTableIdByName("Record Link"));
+    }
+
     [Fact]
     public void TheRegisteredSetIsAnInputToTheInstallBaselineKey_SoClearingItMovesTheKey()
     {

--- a/AlRunner.Tests/RecordPatchesBcAppSymbolReadFailureTests.cs
+++ b/AlRunner.Tests/RecordPatchesBcAppSymbolReadFailureTests.cs
@@ -136,13 +136,21 @@ public sealed class RecordPatchesBcAppSymbolReadFailureTests : IDisposable
         RecordPatches.AddBcAppPath(appPath);
         Assert.Equal(tableId, RecordPatches.ResolveTableIdByName(tableName));
 
+        // The per-request reset, then the re-registration Program.cs performs right after it
+        // (#2755 clears the per-bundle .app registrations, so the reset alone would leave
+        // nothing for the rebuild below to read and this test would pass vacuously). Both
+        // happen while the file on disk is still healthy, so AddBcAppPath's own eager read
+        // succeeds — the subject here is the LAZY index build, not registration.
+        RecordPatches.ResetForReload();
+        RecordPatches.AddBcAppPath(appPath);
+
         // [WHEN] the .app is rebuilt on disk into a shape whose extension parse fails part-way,
-        // and the per-request reset drops the indexes (exactly what --server/--watch do).
-        // A different length + a bumped mtime give both BcAppSymbolCache caches a new key,
-        // so the next index build re-parses rather than serving the earlier good result.
+        // AFTER registration and before the first lookup rebuilds the indexes — the --watch
+        // window where a recompile lands between the two. A different length + a bumped mtime
+        // give both BcAppSymbolCache caches a new key, so the index build re-parses rather than
+        // serving the earlier good result.
         WriteApp(appPath, SymbolReference(tableId, tableName, extId, poison: true));
         File.SetLastWriteTimeUtc(appPath, File.GetLastWriteTimeUtc(appPath).AddSeconds(5));
-        RecordPatches.ResetForReload();
 
         // [THEN] the rebuild throws — before the fix it merged the one good extension, flagged
         // the index as built, printed a filtered-out stderr line and returned the id.
@@ -154,11 +162,14 @@ public sealed class RecordPatchesBcAppSymbolReadFailureTests : IDisposable
         // with the extension flag left false — the #2478 short-circuit shape).
         Assert.Throws<BcAppSymbolReadException>(() => RecordPatches.ResolveTableIdByName(tableName));
 
-        // Cleanup for later tests in this collection: restore a parseable file so the still-
-        // registered path does not fail every subsequent index rebuild in this process.
+        // Cleanup for later tests in this collection, and the positive control: restore a
+        // parseable file, reset, re-register the way a next request would, and the id resolves
+        // again. A reset that did not really clear would show up here as AddBcAppPath's
+        // already-present early return leaving the poisoned index in place.
         WriteApp(appPath, SymbolReference(tableId, tableName, extId, poison: false));
         File.SetLastWriteTimeUtc(appPath, File.GetLastWriteTimeUtc(appPath).AddSeconds(10));
         RecordPatches.ResetForReload();
+        RecordPatches.AddBcAppPath(appPath);
         Assert.Equal(tableId, RecordPatches.ResolveTableIdByName(tableName));
     }
 }

--- a/AlRunner.Tests/RecordPatchesWarmReloadExtensionIndexTests.cs
+++ b/AlRunner.Tests/RecordPatchesWarmReloadExtensionIndexTests.cs
@@ -28,11 +28,27 @@
 //   1. Reference an unrelated table so the symbol table + extension indexes get built once
 //      ("request 1"), and confirm the base table's extension field resolves.
 //   2. Call RecordPatches.ResetForReload() directly — the exact method the server calls
-//      between requests — then re-register the SAME source dir (the server re-registers a
-//      bundle's own source on every request; _bcAppPaths is registered once at startup and
-//      is deliberately NOT re-added here, matching production).
+//      between requests — then re-register the SAME source dir AND the SAME .app, which is
+//      what Program.cs does (2196 then 2354/2357 on the CLI path, 4049 then 4533/4534 on the
+//      server path: the reset precedes the bundle's own dep registration in both).
 //   3. Reference the unrelated table again ("request 2") and confirm the extension field
 //      STILL resolves. Without the fix this throws "extension field 50 ... not found".
+//
+// #2755 CORRECTION. Step 2 used to skip the AddBcAppPath call, on the stated grounds that
+// "_bcAppPaths is registered once at startup and is deliberately NOT re-added, matching
+// production". That was wrong about production — Program.cs registers a bundle's resolved dep
+// closure inside the per-bundle loop, AFTER the reset, on both paths — and #2755 made the
+// error visible by clearing the per-bundle registrations in ResetForReload: this test then
+// failed with "no NCLMetaTable for table 93911 (dependency source not parsed)" on CI legs 27.5
+// and 28.4, the two that run AlRunner.Tests.
+//
+// Re-registering is production-faithful, but AddBcAppPath invalidates the indexes itself, so
+// the end-to-end half below would now survive a reintroduced #2478 for the wrong reason. The
+// #2478 claim is therefore ALSO asserted directly, against the reset's own post-state:
+// ResetForReload must leave BOTH _bcSymbolTableIndex null AND _bcSymbolExtensionIndexBuilt
+// false. That pair IS #2478 — the extension merge's only call site is inside
+// EnsureBcSymbolTableIndex, behind its `_bcSymbolTableIndex != null` guard, so a reset that
+// drops the flag but keeps the index short-circuits the merge forever.
 using System.IO.Compression;
 using System.Text;
 using AlRunner.Patches;
@@ -157,11 +173,24 @@ public sealed class RecordPatchesWarmReloadExtensionIndexTests : IDisposable
         Assert.Equal(extFieldName, field1.FieldName);
 
         // ── SIMULATE THE --server / --watch PER-REQUEST RESET ──────────────────────────
-        // Exactly BcRuntime.ResetForNewBundleReload()'s delegate target. _bcAppPaths is
-        // registered once by Program.cs at startup, never per-request, so AddBcAppPath is
-        // deliberately NOT called again here — matching production.
+        // Exactly BcRuntime.ResetForNewBundleReload()'s delegate target.
         RecordPatches.ResetForReload();
+
+        // [THEN, #2478 asserted at the mechanism] the reset dropped the built table index as
+        // well as the extension-built flag. Before #2478's fix _bcSymbolTableIndex survived,
+        // and because EnsureBcSymbolExtensionIndex is only ever called from inside
+        // EnsureBcSymbolTableIndex — after its `if (_bcSymbolTableIndex != null) return;` —
+        // the merge never ran again for the life of the process. Asserted here rather than
+        // only end-to-end below, because the production-faithful re-registration on the next
+        // line invalidates the indexes on its own and would mask a reintroduced #2478.
+        Assert.Null(PrivateStatic("_bcSymbolTableIndex"));
+        Assert.Equal(false, PrivateStatic("_bcSymbolExtensionIndexBuilt"));
+
+        // What Program.cs does next: re-register this bundle's own source AND its resolved dep
+        // closure. #2755 clears the per-bundle .app registrations in the reset above, so the
+        // .app has to be re-added here exactly as production re-adds it.
         RecordPatches.AddSourceDir(baseDir);
+        RecordPatches.AddBcAppPath(appPath);
 
         // ── REQUEST 2 ────────────────────────────────────────────────────────────────
         var trigger2 = RecordPatches.NCLMetadata_GetMetaTableById(skeleton!, triggerTableId, false, 0);
@@ -183,5 +212,21 @@ public sealed class RecordPatchesWarmReloadExtensionIndexTests : IDisposable
             RecordPatches.NCLMetaTable_GetFieldByNoExt(base2!, extId, nonExistentFieldId));
         Assert.Contains($"extension field {nonExistentFieldId}", ex.Message);
         Assert.Contains("not found", ex.Message);
+    }
+
+    /// <summary>
+    /// Read one of RecordPatches' private static index fields. Reflection rather than a
+    /// production accessor: these are the internals #2478 is about, and a named accessor would
+    /// invite callers. Throws with the field name if it is ever renamed, so the test reports
+    /// "the probe is stale" instead of silently asserting null against a field that is gone.
+    /// </summary>
+    private static object? PrivateStatic(string field)
+    {
+        var f = typeof(RecordPatches).GetField(field,
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                $"RecordPatches.{field} is gone — this probe asserts #2478's reset invariant "
+                + "directly and cannot do so against a renamed field. Re-point it, do not delete it.");
+        return f.GetValue(null);
     }
 }

--- a/AlRunner.Tests/SymbolAppFixtureTests.cs
+++ b/AlRunner.Tests/SymbolAppFixtureTests.cs
@@ -19,6 +19,11 @@ using Xunit;
 
 namespace AlRunner.Tests;
 
+// Serial: RegisterBundleSymbolApps below mutates RecordPatches' process-global _bcAppPaths, and
+// AlRunner.Tests runs collections in parallel (xunit.runner.json, maxParallelThreads 4). A stray
+// registration made beside a test that reads the registered set corrupts THAT test, which is the
+// hard direction to trace. Added by impl-2 while building on this fixture for #2755.
+[Collection(RecordPatchesSerialCollection.Name)]
 public sealed class SymbolAppFixtureTests
 {
     private static readonly Guid WithSymbolsId = new("f6a7b8c9-2755-4a11-9111-111111111111");

--- a/AlRunner/Patches/RecordPatches.BcAppFallback.cs
+++ b/AlRunner/Patches/RecordPatches.BcAppFallback.cs
@@ -63,6 +63,40 @@ public static partial class RecordPatches
     private static readonly HashSet<int> _bcMissCache = new();
 
     /// <summary>
+    /// Drop the PER-BUNDLE .app registrations and every index derived from them, so the next
+    /// lookup rebuilds against what the incoming bundle registers and nothing else (#2755).
+    /// Called only from <c>ResetForReload</c> (RecordPatches.cs); see the comment at that call
+    /// site for why clearing the registered set is safe there and what it fixes.
+    ///
+    /// <para>The process-lifetime SystemApp registration is deliberately kept — see the inline
+    /// comment. It is the one entry in <see cref="_bcAppPaths"/> that nothing re-adds.</para>
+    /// Must be called while holding <see cref="_bcTableIndexLock"/>.
+    /// </summary>
+    private static void ClearPerBundleBcAppPaths()
+    {
+        // The SystemApp package is registered ONCE per process, by RegisterSystemAppPackage()
+        // from RecordPatches.Register() (the engine bootstrap) — never by Program.cs's per-bundle
+        // dep-register stage, and never again after a reload. Dropping it here would unregister
+        // the AL source for every NCL-internal system table (RecordLink 2000000068, Field
+        // 2000000041, Object 2000000038, ...) for the whole remaining life of a --server /
+        // --watch process: ResetForReload also clears _parsedTables and _metaTableCache, so the
+        // registered .app IS the only thing those tables can be rebuilt from on request 2.
+        //
+        // Everything else in the list is a per-bundle registration that Program.cs re-adds
+        // immediately after the reset, so it goes.
+        _bcAppPaths.RemoveAll(p =>
+            !string.Equals(p, _systemAppTempPath, StringComparison.OrdinalIgnoreCase));
+        InvalidateBcAppIndexes();
+    }
+
+    /// <summary>The process-lifetime SystemApp .app <see cref="ClearPerBundleBcAppPaths"/> keeps,
+    /// or null when <see cref="RegisterSystemAppPackage"/> has not run or could not extract it.</summary>
+    internal static string? SystemAppPackagePathForTests
+    {
+        get { lock (_bcTableIndexLock) return _systemAppTempPath; }
+    }
+
+    /// <summary>
     /// Drop every lazily-built BC .app index so the next lookup rebuilds them from
     /// <see cref="_bcAppPaths"/> from scratch — including <see cref="_bcSymbolExtensionIndexBuilt"/>,
     /// which is what actually re-triggers <see cref="EnsureBcSymbolExtensionIndex"/> (its only
@@ -70,7 +104,8 @@ public static partial class RecordPatches
     /// <c>_bcSymbolTableIndex != null</c> — so nulling the table index without ALSO resetting
     /// the extension-built flag would still short-circuit the merge).
     ///
-    /// Two callers, and #2478 was exactly this pair being out of sync: <see cref="AddBcAppPath"/>
+    /// Two callers (<see cref="AddBcAppPath"/> and <see cref="ClearPerBundleBcAppPaths"/>), and
+    /// #2478 was exactly this pair being out of sync: <see cref="AddBcAppPath"/>
     /// already invalidated all four fields inline when a NEW .app was registered; <c>ResetForReload</c>
     /// (RecordPatches.cs) independently reset only <c>_bcSymbolExtensionIndexBuilt</c>, leaving
     /// <c>_bcSymbolTableIndex</c> populated — so on a warm --server/--watch reload,
@@ -110,15 +145,19 @@ public static partial class RecordPatches
     /// <para>The set genuinely varies between two runs whose (dependency assemblies, runner
     /// build, BC version) are identical — the three terms the key did name:</para>
     /// <list type="bullet">
-    /// <item><description><b>--server / --watch accumulate it.</b> <see cref="_bcAppPaths"/>
-    /// is process-global and nothing ever clears it: <see cref="InvalidateBcAppIndexes"/>
-    /// drops the DERIVED indexes so they rebuild FROM this list, and <c>ResetForReload</c>
-    /// (the per-bundle reload path) calls exactly that. Meanwhile the key's only per-bundle
-    /// term is reset per bundle — <c>InstallTriggerRunner.ResetForNewBundle</c> clears
-    /// <c>_depAssemblies</c>. Two writers of the same per-bundle state, one keeping the
-    /// invariant and one not: the second bundle in a server process computes its snapshot
-    /// against its own apps UNION every earlier bundle's, then persists it under the key a
-    /// fresh single-bundle process will look up.</description></item>
+    /// <item><description><b>--server / --watch USED to accumulate it, and no longer do
+    /// (#2755).</b> <see cref="_bcAppPaths"/> is process-global and nothing cleared it:
+    /// <see cref="InvalidateBcAppIndexes"/> drops the DERIVED indexes so they rebuild FROM
+    /// this list, and <c>ResetForReload</c> (the per-bundle reload path) called exactly that
+    /// and nothing more. Meanwhile the key's only per-bundle term IS reset per bundle —
+    /// <c>InstallTriggerRunner.ResetForNewBundle</c> clears <c>_depAssemblies</c>. Two writers
+    /// of the same per-bundle state, one keeping the invariant and one not: the second bundle
+    /// in a server process computed its snapshot against its own apps UNION every earlier
+    /// bundle's, then persisted it under the key a fresh single-bundle process would look up.
+    /// <c>ResetForReload</c> now calls <see cref="ClearPerBundleBcAppPaths"/>, so the two
+    /// writers agree. This term stays load-bearing regardless: it is what made the divergence
+    /// observable rather than silent, it still separates a bundle whose deps differ from
+    /// another's, and it still catches the second bullet below.</description></item>
     /// <item><description><b><see cref="RegisterBundleSymbolApps"/> skips what it cannot
     /// read.</b> An unreadable bundle-root .app is skipped as a whole with a <c>[warn]</c>
     /// line and the run continues — which is the right call for an optional input, but it

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -254,19 +254,33 @@ public static partial class RecordPatches
             // path's own comment states the intent: "New bundle in the server session: replace
             // (not inherit) the install-trigger registrations".
             //
-            // Safe because every caller re-registers immediately afterwards, and registers the
-            // FULL resolved closure rather than a delta — platform and Base Application .apps
-            // included. ResetForNewBundleReload (BcRuntime.cs, the single caller of this method)
-            // runs at Program.cs 2196 on the CLI path and 4049 on the server path; the matching
-            // registrations are at 2354/2357 and 4533/4534, both AFTER. A clear here therefore
-            // removes nothing the current bundle does not immediately put back.
+            // Safe for the PER-BUNDLE registrations because every caller re-registers
+            // immediately afterwards, and registers the FULL resolved closure rather than a
+            // delta — platform and Base Application .apps included. ResetForNewBundleReload
+            // (BcRuntime.cs, the single caller of this method) runs at Program.cs 2196 on the
+            // CLI path and 4049 on the server path; the matching registrations are at 2354/2357
+            // and 4533/4534, both AFTER. A clear therefore removes nothing the current bundle
+            // does not immediately put back.
+            //
+            // NOT safe for all of them, which is why this is ClearPerBundleBcAppPaths and not
+            // _bcAppPaths.Clear(): the SystemApp package is registered once per PROCESS, by
+            // RegisterSystemAppPackage() from Register(), and no per-bundle path re-adds it. A
+            // flat clear unregistered the AL source for every NCL-internal system table for the
+            // rest of a --server/--watch process — and since this method also clears
+            // _parsedTables and _metaTableCache, that registration is the only thing they can
+            // be rebuilt from. Two AlRunner.Tests classes caught it as
+            // "no NCLMetaTable for table N (dependency source not parsed)".
             //
             // #2478 is the reason this is spelled out rather than done quietly: the last defect
             // in this same reset path was an index reset that did not reset ENOUGH, and it made
             // precompiled tableextension fields vanish from every metatable from the second
             // server request on. That failure was silent; this one was too.
-            _bcAppPaths.Clear();
-            InvalidateBcAppIndexes();
+            //
+            // Still accumulating, same shape, deliberately NOT changed here: the sibling list
+            // _bcQuerySymbolJsonPaths (RecordPatches.BcAppFallback.cs). Tracked separately —
+            // see the PR discussion; #2755 scoped itself to _bcAppPaths and called the blast
+            // radius out explicitly.
+            ClearPerBundleBcAppPaths();
         }
         _fieldTriggersWiredTables.Clear();
         _parsedPages.Clear();

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -277,9 +277,11 @@ public static partial class RecordPatches
             // server request on. That failure was silent; this one was too.
             //
             // Still accumulating, same shape, deliberately NOT changed here: the sibling list
-            // _bcQuerySymbolJsonPaths (RecordPatches.BcAppFallback.cs). Tracked separately —
-            // see the PR discussion; #2755 scoped itself to _bcAppPaths and called the blast
-            // radius out explicitly.
+            // _bcQuerySymbolJsonPaths (RecordPatches.BcAppFallback.cs), tracked in #2939. It
+            // feeds _bcSymbolQueryIndex through the same derived/registered split and is the
+            // other input to RegisteredBcAppSymbolStateKey. Left alone because #2755 scoped
+            // itself to _bcAppPaths and called the blast radius out explicitly — and the
+            // SystemApp regression above is what that caution was warning about.
             ClearPerBundleBcAppPaths();
         }
         _fieldTriggersWiredTables.Clear();

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -243,7 +243,31 @@ public static partial class RecordPatches
         // Shares InvalidateBcAppIndexes with AddBcAppPath (RecordPatches.BcAppFallback.cs) so the
         // two call sites can't drift apart again the way they did here.
         lock (_bcTableIndexLock)
+        {
+            // #2755: the REGISTERED set goes too, not just the indexes derived from it.
+            // InvalidateBcAppIndexes drops the derived table/extension indexes so the next lookup
+            // rebuilds them FROM _bcAppPaths — so leaving that list populated meant bundle 2 in a
+            // --server/--watch process rebuilt against its own registrations UNION every earlier
+            // bundle's, while a fresh single-bundle process running bundle 2 alone saw only its
+            // own. The neighbouring per-bundle state already held this invariant
+            // (InstallTriggerRunner.ResetForNewBundle clears _depAssemblies), and the server
+            // path's own comment states the intent: "New bundle in the server session: replace
+            // (not inherit) the install-trigger registrations".
+            //
+            // Safe because every caller re-registers immediately afterwards, and registers the
+            // FULL resolved closure rather than a delta — platform and Base Application .apps
+            // included. ResetForNewBundleReload (BcRuntime.cs, the single caller of this method)
+            // runs at Program.cs 2196 on the CLI path and 4049 on the server path; the matching
+            // registrations are at 2354/2357 and 4533/4534, both AFTER. A clear here therefore
+            // removes nothing the current bundle does not immediately put back.
+            //
+            // #2478 is the reason this is spelled out rather than done quietly: the last defect
+            // in this same reset path was an index reset that did not reset ENOUGH, and it made
+            // precompiled tableextension fields vanish from every metatable from the second
+            // server request on. That failure was silent; this one was too.
+            _bcAppPaths.Clear();
             InvalidateBcAppIndexes();
+        }
         _fieldTriggersWiredTables.Clear();
         _parsedPages.Clear();
         _parsedPageExtensions.Clear();


### PR DESCRIPTION
Closes #2755

## The defect

`RecordPatches._bcAppPaths` is process-global and nothing ever cleared it. `ResetForReload` clears every source-derived dictionary and then calls `InvalidateBcAppIndexes()` — which drops the **derived** table/extension indexes precisely so the next lookup rebuilds them **from `_bcAppPaths`**. Leaving that list populated meant bundle 2 in a `--server`/`--watch` process was compiled and run against its own registered `.app` symbols **union every earlier bundle's**, while a fresh single-bundle process running bundle 2 alone saw only its own.

The invariant was already stated twice in code, and `_bcAppPaths` simply never got it:

- `InstallTriggerRunner.ResetForNewBundle()` clears `_depAssemblies`.
- The server path's own comment: *"New bundle in the server session: replace (not inherit) the install-trigger registrations."*

`RegisteredBcAppSymbolStateKey`'s doc comment already described the asymmetry as "two writers of the same per-bundle state, one keeping the invariant and one not" — documented as a hazard the install-baseline key had to account for (#2710/#2753), never as intended behaviour. That bullet is corrected here, since the change makes it false.

## What changed since the first version of this PR (impl-5 picking it up)

The first version cleared `_bcAppPaths` outright, with a code comment asserting *"every caller re-registers immediately afterwards"*. That is true of the per-bundle registrations and **false of exactly one entry**, which is the interesting part of this PR now:

**The SystemApp package is registered once per PROCESS**, by `RegisterSystemAppPackage()` from `RecordPatches.Register()` at engine bootstrap. It is not part of Program.cs's per-bundle dep-register stage, and nothing re-adds it. Since `ResetForReload` also clears `_parsedTables` and `_metaTableCache`, that registration is the **only** remaining source for the NCL-internal system tables (`Record Link` 2000000068, `Field` 2000000041, `Object` 2000000038, …) that BC's own NCL code constructs directly via `new NavRecord(parent, id)`. A flat clear unregistered them for the rest of a `--server`/`--watch` process.

It was not hypothetical. CI legs **27.5 and 28.4** — the two that run `AlRunner.Tests`, which is why a 2-of-8 red set here is a C# failure and not a leg-set flake — failed with:

```
System.InvalidOperationException : NCLMetadata.GetMetaTableById: no NCLMetaTable for
table 93911 (dependency source not parsed)
```

So the clear is now `ClearPerBundleBcAppPaths()`, which drops everything except that one registration, and says why at the call site.

## Two existing tests had encoded a wrong model of production, and are corrected rather than deleted

**`RecordPatchesWarmReloadExtensionIndexTests`** stated: *"`_bcAppPaths` is registered once by Program.cs at startup, never per-request, so `AddBcAppPath` is deliberately NOT called again here — matching production."* Program.cs registers a bundle's resolved dep closure **inside the per-bundle loop, after the reset**, on both paths (2196 → 2354/2357 CLI, 4049 → 4533/4534 server). The test now re-registers the way production does.

That alone would have weakened it, because `AddBcAppPath` invalidates the indexes itself — so the end-to-end half would survive a reintroduced #2478 for the wrong reason. The #2478 claim is therefore **also asserted directly** against the reset's own post-state: `_bcSymbolTableIndex` null **and** `_bcSymbolExtensionIndexBuilt` false. That pair *is* #2478 (the extension merge's only call site sits inside `EnsureBcSymbolTableIndex`, behind its `_bcSymbolTableIndex != null` guard).

**`RecordPatchesBcAppSymbolReadFailureTests.LazyRebuild_AppChangedToUnparseableOnDisk_ThrowsInsteadOfMergingPartial`** relied on the registration surviving the reset. It now resets, re-registers **while the file is still healthy**, and poisons the file after that — the `--watch` window where a recompile lands between registration and first lookup, which is the sequence the claim was always about. Its final restore step is now a positive control rather than only cleanup.

## Verification

Local, on this head, with the BC engine actually bootstrapped (`SkippableFact`s executed, **0 skipped**):

| run | result |
|---|---|
| `BcAppPathsResetTests \| RecordPatchesWarmReloadExtensionIndexTests \| RecordPatchesBcAppSymbolReadFailureTests \| SymbolAppFixtureTests` | **11 passed, 0 failed, 0 skipped** |
| `RecordPatches \| Watch \| Server \| InstallBaseline \| InstallSeedDep \| CacheKeyDependencyClosure \| VirtualTable` | **246 passed, 0 failed, 0 skipped** (6 m 5 s) |

RED measured by reverting the production line and re-running, not assumed:

- **Flat `_bcAppPaths.Clear()`** → `ResetForReload_KeepsTheProcessLifetimeSystemAppRegistration` fails: `Assert.Contains() Failure … Collection: []`. The two corrected tests **pass** in this state, which is the point — their claims are no longer coupled to which registrations survive.
- **#2478 reintroduced** (reset drops the extension flag but keeps the table index) → the new mechanism assertion fails: `Assert.Null() Failure: Value is not null … [2000000069] = Tuple(…al-runner-systemapp…)`. So #2478 coverage is genuinely preserved, not traded away.

**Not run on this head, stated rather than implied:** the AL corpus and `runner-extras` suites. This branch does not touch the count-baseline — it takes `main`'s current 264 default / 253 on 27.0/27.3/27.5 — and CI runs both on all eight legs.

## New test

`ResetForReload_KeepsTheProcessLifetimeSystemAppRegistration` asserts both directions in one test: the SystemApp entry is **kept**, a per-bundle entry registered alongside it is **dropped**. Then it resolves table `2000000068` to prove the kept entry is still *usable* rather than merely still listed — `_parsedTables` was just cleared and no test bundle's `src/` defines that table, so the registration is the only thing that can answer.

The four tests from the original version stay, including the two that keep this honest in the other direction: `AfterTheReset_ReRegisteringTheSameAppStillWorks` (a clear that did not really clear shows up as a missing re-registration, because `AddBcAppPath` early-returns on a path already present) and `TheRegisteredSetIsAnInputToTheInstallBaselineKey_SoClearingItMovesTheKey` (ties the registered set back to #2710/#2753 so the accumulation cannot go silent again).

## Fixture provenance and the rebase

`SymbolAppFixture` came from impl-7 (#2855) and is most of what makes this issue testable — a source-only bundle never touches `_bcAppPaths` at all, and a layered-synthesized `.app` is not registrable, so both obvious fixtures go green for unrelated reasons. #2855 has since merged, so the rebase onto current `main` dropped that commit as already-applied; the add/add conflict on `AlRunner.Tests/SymbolAppFixtureTests.cs` was two byte-identical files, and no coverage was lost from either side. What remains of that file here is one `[Collection(RecordPatchesSerialCollection.Name)]` attribute: it mutates the same process-global `_bcAppPaths`, and `AlRunner.Tests` runs collections in parallel, so a stray registration beside a test that reads the registered set corrupts *that* test.

## Fix the shape

1. **Same pattern at another call site?** Yes, and it is the reason this PR grew: `RegisterSystemAppPackage` is a *second* writer of `_bcAppPaths` with a completely different lifetime, and the first fix treated the list as if it had only one. Found by reading every writer after the CI failure, not by the failure itself — the failure only said a table was missing.
2. **Sibling function with the same assumption?** `RegisteredBcAppSymbolStateKey`'s doc comment asserted "nothing ever clears it" as a load-bearing premise of the #2710 cache-key term. Corrected in place, with why the term stays load-bearing anyway.
3. **Two writers, same invariant?** `_bcQuerySymbolJsonPaths` is the same registered/derived split, feeds the same lazily-rebuilt index, and is the other input to the same cache key — **still accumulating, deliberately not changed here**, and filed as **#2939** with the measurement that has to happen first. #2755 called this blast radius out explicitly and the SystemApp regression is what that caution was warning about; doing the same thing to a second list in the same PR without its own measurement is how that gets repeated.

Written by an agent (impl-5, continuing impl-2's PR, on impl-7's fixture).

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
