### PR TITLE
docs(scope): document-service providers are out of scope, and guard the decision

### DIFF
--- a/AlRunner.Tests/DocumentServiceProviderScopeGuardTests.cs
+++ b/AlRunner.Tests/DocumentServiceProviderScopeGuardTests.cs
@@ -1,0 +1,155 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Guards the scope decision recorded in <c>docs/limitations.md</c> ("Document-service
+/// providers"): the runner must never ship an <c>IDocumentServiceHandler</c> implementation,
+/// and in particular never one answering to <c>DOCUMENTSERVICEMOCK</c>.
+///
+/// The mechanism, read out of <c>Microsoft.Dynamics.Nav.DocumentService.dll</c> (28.1):
+/// <c>DocumentServiceFactory.Create</c> composes a MEF <c>DirectoryCatalog</c> over
+/// <c>Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)</c> with the pattern
+/// <c>*.nav.*DocumentService*.dll</c>, then picks the export whose
+/// <c>IDocumentServiceMetadata.ServiceType</c> matches the requested type, case-insensitively.
+/// So a provider is discoverable only if BOTH halves line up: an assembly FILE NAME matching
+/// that glob, and an exported type carrying the metadata attribute. This guard checks both,
+/// which is why it can be exact rather than approximate.
+///
+/// Why a guard and not just the paragraph in the doc: this exact category of violation has
+/// already happened once and had to be reverted (#1502, MockImage), and issue #2493 proposed
+/// doing it again as its first option. Measured on 25 cached BC artifacts spanning 26.0
+/// through 28.4, <c>DOCUMENTSERVICEMOCK</c> appears in no shipped DLL and the only provider
+/// present is <c>Microsoft.Dynamics.Nav.SharePointOnlineDocumentService.dll</c> — the mock is
+/// a Microsoft-internal test binary, not something missing from provisioning that the runner
+/// could legitimately supply.
+///
+/// The harm is specific, not stylistic. Of the 11 failures in Microsoft's
+/// <c>Codeunit139101</c>, five assert that the handler SUCCEEDS and five assert an exact error
+/// literal that Microsoft's own AL marks <c>Comment = 'Text is copied from Mock assembly.'</c>.
+/// A runner-authored handler would therefore be graded against strings copied out of the test
+/// that grades it — green would mean the runner agrees with itself, which is precisely what
+/// <c>.claude/rules/loud-failures.md</c> and the SA scope policy exist to prevent. BC's own
+/// "provider could not be found" exception is the correct, already-tested outcome; it is pinned
+/// from the AL side by <c>tests/runner-extras/document-service-session-seed</c>.
+///
+/// This file is excluded from its own scans: it necessarily quotes the very identifiers and
+/// literals it forbids, and flagging itself would train readers to ignore the result.
+/// </summary>
+public sealed class DocumentServiceProviderScopeGuardTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private const string SelfFileName = "DocumentServiceProviderScopeGuardTests.cs";
+
+    /// <summary>MEF's discovery glob, as a regex over a bare file name.</summary>
+    private static readonly Regex MefProviderFileName = new(
+        @"^.*\.nav\..*DocumentService.*\.dll$",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// The two halves of the MEF export contract a provider must declare to be discoverable.
+    /// </summary>
+    private static readonly Regex HandlerContract = new(
+        @"IDocumentServiceHandler|DocumentServiceMetadata",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// The literal prefix of every error string Microsoft's mock produces, which the test
+    /// codeunit copies verbatim into its expectations. Reproducing it in runner code is the
+    /// sharpest form of the harm this guard exists to prevent.
+    /// </summary>
+    private static readonly Regex CopiedMockLiteral = new(
+        @"DocumentServiceMock says",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static IEnumerable<string> RunnerSourceFiles()
+    {
+        foreach (var dir in Directory.EnumerateDirectories(RepoRoot, "AlRunner*"))
+        {
+            foreach (var path in Directory.EnumerateFiles(dir, "*.cs", SearchOption.AllDirectories))
+            {
+                // Build intermediates are copies of the sources already scanned.
+                var rel = Path.GetRelativePath(RepoRoot, path)
+                    .Replace(Path.DirectorySeparatorChar, '/');
+                if (rel.Contains("/bin/") || rel.Contains("/obj/")) continue;
+                if (Path.GetFileName(path) == SelfFileName) continue;
+                yield return path;
+            }
+        }
+    }
+
+    [Fact]
+    public void NoRunnerSource_DeclaresADocumentServiceHandler()
+    {
+        var scanned = 0;
+        var offenders = new List<string>();
+
+        foreach (var path in RunnerSourceFiles())
+        {
+            scanned++;
+            if (HandlerContract.IsMatch(File.ReadAllText(path)))
+                offenders.Add(Path.GetRelativePath(RepoRoot, path)
+                    .Replace(Path.DirectorySeparatorChar, '/'));
+        }
+
+        // Non-vacuity: a scan that found no files would pass while proving nothing.
+        Assert.True(scanned > 100,
+            $"expected to scan the runner's C# sources, but only {scanned} file(s) were found " +
+            $"under {RepoRoot} — the guard is not looking at anything.");
+
+        Assert.True(offenders.Count == 0,
+            "These files reference the document-service handler contract, which means the runner " +
+            "is shipping (or preparing to ship) its own provider. That is out of scope — see the " +
+            "\"Document-service providers\" entry in docs/limitations.md and issue #2493. The " +
+            "supported path is for the user to supply their own assembly; the runner must let " +
+            "BC's own \"provider could not be found\" exception surface:\n  " +
+            string.Join("\n  ", offenders));
+    }
+
+    [Fact]
+    public void NoRunnerSource_CopiesTheMockErrorLiterals()
+    {
+        var offenders = new List<string>();
+
+        foreach (var path in RunnerSourceFiles())
+        {
+            if (CopiedMockLiteral.IsMatch(File.ReadAllText(path)))
+                offenders.Add(Path.GetRelativePath(RepoRoot, path)
+                    .Replace(Path.DirectorySeparatorChar, '/'));
+        }
+
+        Assert.True(offenders.Count == 0,
+            "These files reproduce error text from Microsoft's internal DocumentServiceMock " +
+            "assembly. Microsoft's own test codeunit marks those labels 'Text is copied from " +
+            "Mock assembly', so any runner code carrying them is being graded against strings " +
+            "copied from the test that grades it:\n  " + string.Join("\n  ", offenders));
+    }
+
+    [Fact]
+    public void NoBuildOutput_ShipsAnAssemblyMatchingTheMefDiscoveryGlob()
+    {
+        // The runner's own build output is the directory a shipped provider would have to
+        // land in to be discovered alongside the runner's assemblies.
+        var outputDir = AppContext.BaseDirectory;
+        var dlls = Directory.GetFiles(outputDir, "*.dll", SearchOption.TopDirectoryOnly);
+
+        // Non-vacuity: the runner's output always contains its own assemblies.
+        Assert.True(dlls.Length > 0,
+            $"expected assemblies in the build output at {outputDir}, found none — " +
+            "the guard is not looking at anything.");
+
+        var offenders = dlls
+            .Select(Path.GetFileName)
+            .Where(name => name is not null && MefProviderFileName.IsMatch(name))
+            .ToList();
+
+        Assert.True(offenders.Count == 0,
+            "These assemblies in the runner's build output match MEF's document-service " +
+            "discovery glob (*.nav.*DocumentService*.dll), so BC's DocumentServiceFactory would " +
+            "load them as providers. The runner must not ship one — see docs/limitations.md " +
+            "and issue #2493:\n  " + string.Join("\n  ", offenders));
+    }
+}

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -358,6 +358,52 @@ If your AL under test depends on real SA behaviour to mean anything, the support
 
 Concrete example — `Image` codeunit (System Application). A test that asserts on image dimensions cannot rely on the runner's blank-shell `Image.GetWidth()` (which returns `0`). The fix is to write a small stub in your test project that parses a known fixture image, not to ask the runner to ship an `Image` implementation. If the AL pattern under test is widespread enough that everyone needs the same stub, file a runner-gap issue and we can discuss whether a shared stub belongs in `AlRunner/stubs/` (the bar is high — it must be test-automation infrastructure, not business logic).
 
+### Document-service providers (`DOCUMENTSERVICEMOCK`)
+
+Base Application codeunit 9510 `"Document Service Management"` resolves a provider through
+`Microsoft.Dynamics.Nav.DocumentService.DocumentServiceFactory.CreateService`. That factory
+composes a MEF `DirectoryCatalog` over the directory holding
+`Microsoft.Dynamics.Nav.DocumentService.dll`, using the file pattern
+`*.nav.*DocumentService*.dll`, and picks the export whose `IDocumentServiceMetadata.ServiceType`
+matches the requested type, compared case-insensitively.
+
+The only provider Microsoft ships in the public platform artifacts is
+`Microsoft.Dynamics.Nav.SharePointOnlineDocumentService.dll`. The two types Microsoft's own test
+codeunit 139101 `"Document Service Mgmt Test"` asks for — `DOCUMENTSERVICEMOCK` and
+`EMPTYDOCUMENTSERVICEMOCK` — live in internal test binaries. Measured across 25 cached artifacts
+from BC 26.0 through 28.4, the string `DOCUMENTSERVICEMOCK` appears in no shipped DLL.
+
+A test that requests one of those service types therefore fails, with BC's own message:
+
+```
+NavNCLDotNetInvokeException: A call to ...DocumentServiceFactory.CreateService failed with this
+message: <install-dir> The following document service provider could not be found: 'DOCUMENTSERVICEMOCK'.
+```
+
+That is the correct result, and the runner keeps it. It names the API, the missing provider and
+the directory that was searched. `tests/runner-extras/document-service-session-seed` checks it
+from AL, and `AlRunner.Tests/DocumentServiceProviderScopeGuardTests.cs` checks that the runner
+ships no provider of its own.
+
+**The runner will not supply a `DOCUMENTSERVICEMOCK` implementation.** Ten of the eleven failing
+tests in codeunit 139101 need one, and they divide into two halves: five need the handler to
+return a result the test then asserts on, and five assert an exact error string that Microsoft's
+AL marks `Comment = 'Text is copied from Mock assembly.'`. A runner-written handler would have to
+reproduce those strings out of the test codeunit that checks them, so those five would pass
+because the runner matched its own copy, not because it behaved the way Microsoft's mock behaves.
+That is the same problem that caused MockImage to be reverted in #1502.
+
+**Bring your own provider.** The extension point is public, so this needs no runner change:
+
+1. Build a .NET assembly whose file name matches `*.nav.*DocumentService*.dll`.
+2. Export a type implementing `IDocumentServiceHandler`, decorated
+   `[DocumentServiceMetadata("YOURTYPE")]`.
+3. Put it in the artifact directory alongside `Microsoft.Dynamics.Nav.DocumentService.dll`.
+4. Call `SetServiceType('YOURTYPE')` from your AL.
+
+The factory rescans that directory on every `CreateService` call, so the assembly is picked up
+without any further setup.
+
 ---
 
 ## Behavioural differences — same API, different semantics


### PR DESCRIPTION
Closes #2493

Filed by the impl-2 agent.

## What I found

The issue's premise holds — `DOCUMENTSERVICEMOCK` really is absent — but three of its
specifics do not, and its first proposed option should be rejected.

**The runner behavior is already correct, and already tested.** #2487 landed
`tests/runner-extras/document-service-session-seed`, whose second test
(`UnresolvableHandler_FailsWithNamedBcException_NotNRE`) already asserts that when the
handler cannot be resolved, BC's own named exception surfaces instead of an NRE. There is
nothing to implement. What was missing is a written scope decision, so this comes back as
a documentation change plus enforcement.

**Corrections to the issue body** (I have posted these on the issue as well):

| Issue says | Measured |
|---|---|
| 10 tests fail | 11 fail in `Codeunit139101`. `TestPermissionExistsInDemoData` also fails, for an unrelated reason. |
| One failure mode | Two, split 5/5. |
| One mock is needed | Two: `DOCUMENTSERVICEMOCK` and `EMPTYDOCUMENTSERVICEMOCK`. `TestChangingServiceType` needs both. |

The 5/5 split matters because it decides the disposition:

- 5 tests (`TestSuccessfulTestConnection`, `TestSaveSuccess`, `TestSaveSuccessfulOverwrite`,
  `TestIsServiceUriReturnsTrueWithValidDocumentAddress`,
  `TestIsServiceUriReturnsFalseWithInvalidDocumentAddress`) need the handler to return a
  result the test then asserts on.
- 5 tests (`TestFailedTestConnection`, `TestSaveConnectionError`, `TestSaveExistingFile`,
  `TestChangingServiceType`, `TestMultipleOperationsWithSameServiceType`) assert an exact
  error string, and Microsoft's own AL marks each of those labels
  `Comment = 'Text is copied from Mock assembly.'`.

## Why option 1 is rejected

Writing a runner-owned `IDocumentServiceHandler` means copying those five strings out of
the test codeunit that checks them. Those five tests would then pass because the runner
matched its own copy, not because it behaved the way Microsoft's mock behaves. The other
five would pass because the runner decided to succeed. This is the same problem that
caused MockImage to be reverted in #1502, and it is what the existing
"Always out of scope — SA business-logic implementations" policy already rules out.

It is also unnecessary. Reading
`Microsoft.Dynamics.Nav.DocumentService.DocumentServiceFactory.Create` (28.1), discovery is
a public MEF extension point: a `DirectoryCatalog` over
`Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)` with pattern
`*.nav.*DocumentService*.dll`, selecting the export whose
`IDocumentServiceMetadata.ServiceType` matches. Anyone who needs this can supply their own
assembly with no runner change, and the doc now gives the four steps.

## Measurements

- `DOCUMENTSERVICEMOCK` appears in no DLL of any of the 25 cached BC artifacts, spanning
  26.0 through 28.4. The only provider present is
  `Microsoft.Dynamics.Nav.SharePointOnlineDocumentService.dll`.
- BC's failure already names the API, the missing provider and the directory searched, so
  it satisfies `loud-failures.md` without any runner change.

## Fix the shape

1. **Same pattern at another call site?** Nothing found. No runner source references
   `IDocumentServiceHandler` or `DocumentServiceMetadata`, and no runner source carries the
   copied `DocumentServiceMock says` literals. The new guard now keeps it that way.
2. **Sibling making the same assumption?** Nothing found.
   `Microsoft.Dynamics.Nav.DocumentService.dll` is the only assembly in the platform
   artifact that uses MEF for pluggable providers, so document service is the only
   extension point of this shape.
3. **Two paths writing the same state?** Not applicable — there is one resolution path.

## What this changes

- `docs/limitations.md` — a "Document-service providers" subsection under the existing
  System Application scope policy, recording the mechanism, the decision, and the steps to
  supply your own provider.
- `AlRunner.Tests/DocumentServiceProviderScopeGuardTests.cs` — three regression guards, so
  the decision is enforced and not only written down. They are guards, not proof of a
  feature: they fail if someone later ships a provider.

## RED to GREEN

These are guards, so I proved them by planting a violation of each and confirming each one
detects it, then removing the violations.

RED (probe file declaring the contract and copying the mock literal, plus a
`Microsoft.Dynamics.Nav.MockDocumentService.dll` dropped into the build output) — all three
failed, each naming the exact offending file:

```
Failed  NoBuildOutput_ShipsAnAssemblyMatchingTheMefDiscoveryGlob
Failed  NoRunnerSource_DeclaresADocumentServiceHandler
Failed  NoRunnerSource_CopiesTheMockErrorLiterals
Failed!  - Failed: 3, Passed: 0, Total: 3
```

GREEN (probes removed):

```
Passed!  - Failed: 0, Passed: 3, Total: 3, Duration: 73 ms
```

Both source scans assert they saw more than 100 files before passing, so they cannot pass
by scanning nothing; the actual count is 644. The build-output scan asserts it saw at least
one assembly.

## Also run locally

- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~DocumentServiceProviderScopeGuardTests|FullyQualifiedName~CliDocumentationTests"` — 23 passed. `CliDocumentationTests` is included because it reads `docs/limitations.md`.
- `tests/runner-extras/document-service-session-seed` against BC 28.1 — 2/2 passed, confirming the behavior I documented is what the runner actually does.

I did not run the full `AlRunner.Tests` suite or the corpus: this change touches no runner
code, only a doc and a new test class.

## Left out

- `TestPermissionExistsInDemoData` is a separate gap and I have filed it separately rather
  than folding it in here. It reads the `Permission` system table (2000000005) looking for a
  read-only grant on `Document Service` (2000000114) in demo data, and finds no row. It has
  nothing to do with document-service providers.
- No `tests/expectations/` entry. Microsoft's `Tests-SINGLESERVER` bucket is not part of the
  al-language corpus or `tests/runner-extras`, so there is no manifest slot for it. The
  issue raised that same point as its option 2; tracking ad hoc MS-bucket results still
  needs its own decision.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
