### PR TITLE
fix(compile): sort AL source discovery, so test execution order stops depending on readdir

### DIFF
--- a/AlRunner.Tests/AlObjectEmitOrderDeterminismTests.cs
+++ b/AlRunner.Tests/AlObjectEmitOrderDeterminismTests.cs
@@ -1,0 +1,181 @@
+// AlObjectEmitOrderDeterminismTests — the end-to-end half of #2872.
+//
+// SafeDirectoryScanOrderTests pins the unit-level contract (SafeDirectoryScan returns paths in
+// ordinal order). This pins what that contract is FOR: two bundles holding byte-identical AL
+// sources must run the same tests in the same order, whatever order their files happened to be
+// created in.
+//
+// The chain the bug ran down: SafeDirectoryScan.Files -> BcCompiler.Emit's `alFiles` -> the
+// syntax-tree array handed to the AL compiler -> the emitted assembly's TypeDef order ->
+// Assembly.GetTypes() -> the `for (int ti = 0; ti < types.Length; ti++)` loop in
+// TestExecutor.Run. Nothing sorts anywhere along it, and readdir on Linux is creation order for
+// a small directory, so creating Second.Codeunit.al before First.Codeunit.al ran the second
+// codeunit first.
+//
+// Measured before the fix, same runner build, same machine, identical AL bytes:
+//   files created First-then-Second -> Codeunit62241 ... then Codeunit62242
+//   files created Second-then-First -> Codeunit62242 ... then Codeunit62241
+//
+// Harmless-looking until something ends the run early. On BC 27.5 in run 33984312053 a
+// watchdog abort ended the run at the hung codeunit (TestExecutor's `return results`), so the
+// flipped order decided WHICH tests had already run, and SuiteAbortOnTimeoutTests' three
+// order-sensitive assertions failed on `main` — with `AL emit: 0.0s`, i.e. every one of them
+// served the same wrongly-ordered assembly out of one cache entry.
+//
+// The file names here are deliberately anti-correlated with the object IDs: Alpha.Codeunit.al
+// declares the HIGHER id (62242) and Zeta.Codeunit.al the lower (62241). So a fix that
+// accidentally sorted by object id, or one that left creation order in place, produces a
+// different answer than the one asserted — the test cannot pass by coincidence.
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class AlObjectEmitOrderDeterminismTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly string _root;
+
+    public AlObjectEmitOrderDeterminismTests()
+    {
+        _root = TestScratch.Dir("al-runner-emit-order");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private const string AppJson = """
+    {
+      "id": "b1c2d3e4-f5a6-4708-9901-2233445566aa",
+      "name": "AL Emit Order Determinism Fixture",
+      "publisher": "AL Runner",
+      "version": "1.0.0.0",
+      "dependencies": [],
+      "platform": "1.0.0.0",
+      "idRanges": [ { "from": 62240, "to": 62249 } ],
+      "runtime": "14.0"
+    }
+    """;
+
+    private const string ZetaAl = """
+    codeunit 62241 "Emit Order Zeta"
+    {
+        Subtype = Test;
+
+        [Test]
+        procedure ZetaOnly()
+        begin
+        end;
+    }
+    """;
+
+    private const string AlphaAl = """
+    codeunit 62242 "Emit Order Alpha"
+    {
+        Subtype = Test;
+
+        [Test]
+        procedure AlphaOnly()
+        begin
+        end;
+    }
+    """;
+
+    /// <summary>
+    /// Writes the fixture into a fresh subdirectory, creating the two .al files in the
+    /// requested order. On ext4/tmpfs a directory this small lists in creation order, which is
+    /// exactly the lever the bug turned.
+    /// </summary>
+    private string WriteBundle(string name, bool zetaFirst)
+    {
+        var dir = Path.Combine(_root, name);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), AppJson);
+        if (zetaFirst)
+        {
+            File.WriteAllText(Path.Combine(dir, "Zeta.Codeunit.al"), ZetaAl);
+            File.WriteAllText(Path.Combine(dir, "Alpha.Codeunit.al"), AlphaAl);
+        }
+        else
+        {
+            File.WriteAllText(Path.Combine(dir, "Alpha.Codeunit.al"), AlphaAl);
+            File.WriteAllText(Path.Combine(dir, "Zeta.Codeunit.al"), ZetaAl);
+        }
+        return dir;
+    }
+
+    private static (string output, int exit) RunRunner(string bundle)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" \"{bundle}\"");
+        // --no-cache so the AL output is really re-emitted for each bundle. A cache HIT would
+        // serve one assembly to both and hide the very difference under test — which is how
+        // this reached `main`: the CI failure's own log reads "AL emit: 0.0s".
+        args.Append(" --no-cache");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(300_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>The executed test names, in the order the runner reported them.</summary>
+    private static List<string> ExecutionOrder(string output)
+        => Regex.Matches(output, @"^PASS\s+(\S+)", RegexOptions.Multiline)
+            .Select(m => m.Groups[1].Value).ToList();
+
+    /// <summary>
+    /// Positive: identical AL content, opposite file-creation order, one execution order —
+    /// and it is the ordinal order of the source file paths (Alpha before Zeta), not the
+    /// order the files were created in and not the order of the object ids.
+    /// </summary>
+    [SkippableFact]
+    public void SameSources_DifferentFileCreationOrder_RunInTheSameOrder()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var zetaFirst = WriteBundle("zeta-first", zetaFirst: true);
+        var alphaFirst = WriteBundle("alpha-first", zetaFirst: false);
+
+        var (outA, exitA) = RunRunner(zetaFirst);
+        var (outB, exitB) = RunRunner(alphaFirst);
+
+        Assert.Equal(0, exitA);
+        Assert.Equal(0, exitB);
+
+        var orderA = ExecutionOrder(outA);
+        var orderB = ExecutionOrder(outB);
+
+        // Both tests actually ran in both bundles — otherwise "same order" is trivially true.
+        Assert.Equal(2, orderA.Count);
+        Assert.Equal(2, orderB.Count);
+
+        var expected = new[] { "Codeunit62242.AlphaOnly", "Codeunit62241.ZetaOnly" };
+        Assert.True(orderA.SequenceEqual(expected),
+            "the bundle whose Zeta.Codeunit.al was created FIRST must still run Alpha's codeunit "
+            + "first — source-path ordinal order, not creation order. Got: ["
+            + string.Join(", ", orderA) + "]\n--- runner output ---\n" + outA);
+        Assert.True(orderB.SequenceEqual(expected),
+            "the bundle whose Alpha.Codeunit.al was created FIRST must run in the same order as "
+            + "the other one. Got: [" + string.Join(", ", orderB) + "]\n--- runner output ---\n" + outB);
+    }
+}

--- a/AlRunner.Tests/SafeDirectoryScanOrderTests.cs
+++ b/AlRunner.Tests/SafeDirectoryScanOrderTests.cs
@@ -1,0 +1,140 @@
+// SafeDirectoryScanOrderTests — the ordering half of SafeDirectoryScan's contract (#2872).
+//
+// SafeDirectoryScan.Files is how every AL compile in this runner collects its *.al inputs
+// (BcCompiler.Emit, EmitDepSymbols, the three incremental paths, InProcessAppPackager, ...).
+// It returned whatever order the filesystem's readdir happened to produce, and its own walk
+// popped subdirectories off a Stack, so the order was reversed relative to
+// Directory.GetDirectories on top of that.
+//
+// That order is not cosmetic. It is the order of the syntax trees handed to the AL compiler,
+// therefore the TypeDef order of the emitted assembly, therefore the order Assembly.GetTypes()
+// returns, therefore the order TestExecutor runs test codeunits in. Two directories holding
+// byte-identical AL sources, differing only in the order their files were created, produced
+// assemblies that ran the same tests in different orders — measured on this machine, and it is
+// what turned `main` red on the BC 27.5 leg (run 33984312053): a watchdog abort ends the run,
+// so which codeunit had already run decided what the JUnit contained.
+//
+// The mirror image of the bug is the reason it has to be fixed HERE rather than at one call
+// site: ComputeAlCacheKey (ProgramSupport/Dependencies.cs) already sorts the very same file
+// list — "Enumerate every .al file in stable order" — before hashing it. So the KEY was
+// order-independent while the COMPILE was not: two bundles with identical content hash to one
+// cache entry and can legitimately want two different assemblies out of it. A cache HIT then
+// serves whichever order was emitted first, for every later run.
+//
+// Ordinal, not culture: the whole point is an order that does not move between machines.
+using Xunit;
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Tests;
+
+public sealed class SafeDirectoryScanOrderTests : IDisposable
+{
+    private readonly string _root;
+
+    public SafeDirectoryScanOrderTests()
+    {
+        _root = TestScratch.Dir("al-runner-scan-order");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    /// <summary>
+    /// Positive, flat: files created in reverse-alphabetical order come back in ORDINAL
+    /// order, not creation order. On ext4/tmpfs a small directory's readdir is creation
+    /// order, so pre-fix this returned [c, b, a] — the exact shape that flipped the two
+    /// fixture codeunits on CI.
+    /// </summary>
+    [Fact]
+    public void Files_AreReturnedInOrdinalOrder_NotCreationOrder()
+    {
+        foreach (var n in new[] { "ccc.al", "bbb.al", "aaa.al" })
+            File.WriteAllText(Path.Combine(_root, n), "x");
+        // Not a *.al file: it must not appear at all, so a "sorted" result cannot be
+        // achieved by returning everything and letting the caller filter.
+        File.WriteAllText(Path.Combine(_root, "app.json"), "{}");
+
+        var hits = SafeDirectoryScan.Files(_root, "*.al");
+
+        Assert.Equal(
+            new[] { "aaa.al", "bbb.al", "ccc.al" },
+            hits.Select(Path.GetFileName).ToArray());
+    }
+
+    /// <summary>
+    /// Positive, nested: the walk's Stack popped subdirectories in reverse, so this failed
+    /// independently of how readdir ordered anything. Full paths, ordinal — which puts a
+    /// parent's own files before its subdirectories' and keeps sibling directories in name
+    /// order.
+    /// </summary>
+    [Fact]
+    public void Files_AcrossSubdirectories_AreReturnedInOrdinalPathOrder()
+    {
+        foreach (var sub in new[] { "alpha", "beta", "gamma" })
+        {
+            Directory.CreateDirectory(Path.Combine(_root, sub));
+            File.WriteAllText(Path.Combine(_root, sub, "One.al"), "x");
+            File.WriteAllText(Path.Combine(_root, sub, "Two.al"), "x");
+        }
+        File.WriteAllText(Path.Combine(_root, "Root.al"), "x");
+
+        var hits = SafeDirectoryScan.Files(_root, "*.al");
+
+        Assert.Equal(
+            hits.OrderBy(p => p, StringComparer.Ordinal).ToArray(),
+            hits.ToArray());
+        Assert.Equal(
+            new[]
+            {
+                "Root.al",
+                Path.Combine("alpha", "One.al"), Path.Combine("alpha", "Two.al"),
+                Path.Combine("beta", "One.al"), Path.Combine("beta", "Two.al"),
+                Path.Combine("gamma", "One.al"), Path.Combine("gamma", "Two.al"),
+            },
+            hits.Select(p => Path.GetRelativePath(_root, p)).ToArray());
+    }
+
+    /// <summary>
+    /// The same guarantee for the directory overload — <c>.alpackages</c> discovery feeds
+    /// dependency resolution, where "the first one found" decides which package wins.
+    /// </summary>
+    [Fact]
+    public void Directories_AreReturnedInOrdinalPathOrder()
+    {
+        foreach (var sub in new[] { "zeta", "delta", "alpha" })
+            Directory.CreateDirectory(Path.Combine(_root, sub, ".alpackages"));
+
+        var hits = SafeDirectoryScan.Directories(_root, ".alpackages");
+
+        Assert.Equal(
+            new[]
+            {
+                Path.Combine("alpha", ".alpackages"),
+                Path.Combine("delta", ".alpackages"),
+                Path.Combine("zeta", ".alpackages"),
+            },
+            hits.Select(p => Path.GetRelativePath(_root, p)).ToArray());
+    }
+
+    /// <summary>
+    /// Negative: sorting must not change WHAT is found. An empty result stays empty, and a
+    /// pattern that matches nothing does not start matching something because the list is
+    /// now sorted.
+    /// </summary>
+    [Fact]
+    public void Sorting_DoesNotChangeWhatIsFound()
+    {
+        Directory.CreateDirectory(Path.Combine(_root, "sub"));
+        File.WriteAllText(Path.Combine(_root, "sub", "only.al"), "x");
+
+        Assert.Empty(SafeDirectoryScan.Files(_root, "*.xlf"));
+        Assert.Empty(SafeDirectoryScan.Directories(_root, ".alpackages"));
+        Assert.Single(SafeDirectoryScan.Files(_root, "*.al"));
+        Assert.Equal(
+            Path.Combine("sub", "only.al"),
+            Path.GetRelativePath(_root, SafeDirectoryScan.Files(_root, "*.al")[0]));
+    }
+}

--- a/AlRunner/Infrastructure/SafeDirectoryScan.cs
+++ b/AlRunner/Infrastructure/SafeDirectoryScan.cs
@@ -47,6 +47,34 @@ namespace AlRunner.Infrastructure;
 /// platform-default casing, which is exactly what <c>EnumerationOptions.Compatible</c>
 /// (<c>MatchType.Win32</c>, <c>MatchCasing.PlatformDefault</c>) uses — so results are
 /// identical to the <c>SearchOption.AllDirectories</c> calls this replaces.</para>
+///
+/// <para><b>Results are ordinal-sorted by full path (issue #2872).</b> They did not used to
+/// be, and the order is load-bearing: <see cref="Files"/> is how every AL compile collects
+/// its <c>*.al</c> inputs (<c>BcCompiler.Emit</c>, <c>EmitDepSymbols</c>, the three
+/// incremental paths, <c>InProcessAppPackager</c>, …), and that list becomes the syntax-tree
+/// order handed to the AL compiler, hence the TypeDef order of the emitted assembly, hence
+/// the order <c>Assembly.GetTypes()</c> returns, hence the order <c>TestExecutor.Run</c>
+/// executes test codeunits in. <c>Directory.GetFiles</c> and <c>Directory.GetDirectories</c>
+/// return readdir order, which on Linux is creation order for a small directory, and the walk
+/// below pops subdirectories off a <see cref="Stack{T}"/>, reversing them on top of that.
+/// Measured: two bundles holding byte-identical AL sources, differing only in which file was
+/// written first, ran the same two test codeunits in opposite orders.</para>
+///
+/// <para>That was invisible until something ended a run early. It turned <c>main</c> red on
+/// the BC 27.5 leg (run 33984312053): a per-test watchdog abort ends the run at the hung
+/// codeunit, so the flipped order decided which tests had already executed and what the JUnit
+/// contained. And the mirror image is why the sort belongs here rather than at one call site
+/// — <c>ComputeAlCacheKey</c> (<c>ProgramSupport/Dependencies.cs</c>) already sorted the same
+/// file list before hashing it ("Enumerate every .al file in stable order"), so the cache KEY
+/// was order-independent while the COMPILE was not: identical sources hash to one entry that
+/// can hold either assembly, and every later run is served whichever was emitted first.
+/// Three call sites (<c>Dependencies</c>, <c>InProcessAppPackager</c>,
+/// <c>ProvisioningCheck</c>) had each added their own <c>OrderBy</c> for the same reason;
+/// <c>BcCompiler.Emit</c>, the one whose order decides execution, had not.</para>
+///
+/// <para>Ordinal, not culture-aware or case-insensitive: the point is an order that does not
+/// move between machines or locales. Cost is a single sort of the materialised result — on
+/// this repository's 94,740-directory checkout, milliseconds against a 787 ms walk.</para>
 /// </summary>
 public static class SafeDirectoryScan
 {
@@ -84,6 +112,7 @@ public static class SafeDirectoryScan
         Walk(root, searchPattern, hits, denied, matchFiles: false,
              recurse: searchOption == SearchOption.AllDirectories);
         inaccessible = denied;
+        hits.Sort(StringComparer.Ordinal);
         return hits;
     }
 
@@ -106,6 +135,11 @@ public static class SafeDirectoryScan
         Walk(root, searchPattern, hits, denied, matchFiles: true,
              recurse: searchOption == SearchOption.AllDirectories);
         inaccessible = denied;
+        // See the class remarks: this order is the AL compiler's syntax-tree order and
+        // therefore the test-execution order. Sorting the materialised result is enough —
+        // it makes the answer independent of readdir order AND of the Stack-driven
+        // traversal order below, so neither has to be reasoned about again.
+        hits.Sort(StringComparer.Ordinal);
         return hits;
     }
 


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.100.0
Closes #2801

`main` was red on the BC 27.5 leg (run 33984312053) with three failures in
`AlRunner.Tests.SuiteAbortOnTimeoutTests`. This is the root cause of #2801, and it is not
what #2801 guessed.

## Which of the two diagnoses is right

The brief asked whether the defect is in the abort (it should end the run and only ends the
codeunit) or in the test (it asserts run scope where the contract is codeunit scope).

**Neither. The abort is run-scoped and correct, and the test is correct.** `TestExecutor.Run`
does `if (IsTimeout(raw)) { RecordAbortedSuite(...); return results; }` — a `return` out of the
codeunit loop, which ends the whole `Run` call. The message adapts to what it abandons and, run
locally, reads `1 further [Test] method(s) in this codeunit and 2 in 1 subsequent codeunit(s)
did not run (3 total)`.

The CI message read `1 further [Test] method(s) in this codeunit did not run (1 total)` — no
"subsequent codeunit(s)" clause at all — and the PASS lines listed `Codeunit62213` before
`Codeunit62212`. Both say the same thing: **the second codeunit had already run when the abort
fired.** The abort did not fail to end the run; there was nothing left to end.

## Why the order flipped

`SafeDirectoryScan.Files` is how every AL compile collects its `*.al` inputs. It returned
`Directory.GetFiles` order — readdir order, which on Linux is creation order for a small
directory — and its walk pops subdirectories off a `Stack`, reversing them on top of that.
Nothing sorted anywhere along the chain:

`SafeDirectoryScan.Files` → `BcCompiler.Emit`'s `alFiles` → the syntax-tree array handed to
the AL compiler → the emitted assembly's TypeDef order → `Assembly.GetTypes()` →
`for (int ti = 0; ti < types.Length; ti++)` in `TestExecutor.Run`.

Reproduced deterministically on this machine, same runner build, byte-identical AL sources,
one bundle written `First` then `Second` and the other `Second` then `First`:

| bundle | readdir order | result |
|---|---|---|
| `b1` | `First.Codeunit.al`, `Second.Codeunit.al` | abort reports `(3 total)`, only 62212's tests ran |
| `b2` | `Second.Codeunit.al`, `First.Codeunit.al` | abort reports `(1 total)`, `Codeunit62213.SecondA/SecondB` had already run |

`b2` is the CI failure, exactly. The `--no-cache` flag matters here: without it both bundles
hash to one cache entry and are served the same assembly, which hides the difference.

## Why one cache entry can hold either assembly

`ComputeAlCacheKey` (`ProgramSupport/Dependencies.cs`) already sorted the same file list before
hashing it — its comment says "Enumerate every .al file in stable order". So the **key** was
order-independent while the **compile** was not: two directories with identical AL content hash
to one entry that can legitimately want two different assemblies out of it, and a HIT serves
whichever order happened to be emitted first, to every later run.

That is visible in the CI log: all three failures report `AL emit: 0.0s` / `C# compile: 0.0s`.
One wrongly-ordered assembly was emitted once and then served to every test in the class, which
is why exactly three order-sensitive tests failed together and the two order-insensitive ones
passed.

## The fix

Sort the materialised result in `SafeDirectoryScan`, ordinal by full path — one place, so the
answer is independent of both readdir order and the `Stack`-driven traversal order, and neither
has to be reasoned about again. Cost is one sort of the result: milliseconds against the 787 ms
walk the class doc measures on this repository's 94,740-directory checkout.

## RED → GREEN

- `AlRunner.Tests/SafeDirectoryScanOrderTests.cs` — the unit contract. RED before: `Files`
  returned `[ccc.al, bbb.al, aaa.al]` for files created in that order, and nested results came
  back in `Stack`-pop order. 4 passed after.
- `AlRunner.Tests/AlObjectEmitOrderDeterminismTests.cs` — the end-to-end claim. Two bundles,
  identical AL, opposite creation order, `--no-cache`. RED before: the `Zeta`-first bundle ran
  `Codeunit62241.ZetaOnly` first. GREEN after: both run
  `[Codeunit62242.AlphaOnly, Codeunit62241.ZetaOnly]`. The file names are deliberately
  anti-correlated with the object IDs (`Alpha.Codeunit.al` holds the *higher* ID), so a fix that
  accidentally sorted by object ID, or one that left creation order alone, gives a different
  answer — the test cannot pass by coincidence.
- The original reproduction re-run after the fix: both `b1` and `b2` now report
  `(3 total)` and run only `Codeunit62212.RanBeforeHang` / `Hangs`.

## What #2801 said, and what it turns out to be

#2801's stated hypothesis was that `Hangs` failed to report `TimedOut` under load, so no abort
happened. impl-4's instrumentation on that issue — `AssertHangEscalatedToAbort`, already on
`main` — is what falsifies it: in run 33984312053 that precondition **passed**. `Test exceeded
2s timeout.` and `SUITE ABORTED` were both present, and the failure was the name list. The
watchdog fired exactly as designed. Nothing here is timing-dependent, which is also why the
failure is 1-of-2 legs rather than intermittent on one: it is whatever order that machine's
filesystem produced when the assembly was first emitted.

I did not re-run the failed job.

## Fixing the shape, not the line

1. **Same wrong pattern at another call site?** Every `SafeDirectoryScan.Files`/`Directories`
   call site shared it — 18 of them, including `BcCompiler.Emit`, `EmitDepSymbols`, the three
   `BcCompiler.Incremental` paths, `InProcessAppPackager`, `Suites`, `Dependencies`,
   `ServerSupport`, `RecordPatches`, `AlMemberSyntaxIndex`, `PrebuiltShadowCheck`. The central
   fix covers all of them. The two raw `Directory.EnumerateFiles(tempDir, "*.al")` calls
   (`DependencyLoader.cs:488`, `SiblingCompile.cs:162`) are stale-file deletion loops where
   order cannot matter; checked, left alone.
2. **Does a sibling function make the same assumption?** Yes — `Directories()` had it too, and
   it is how `.alpackages` discovery works, where "the first one found" decides which package
   wins. Fixed in the same place and pinned by a test.
3. **Two paths writing the same state, one with a guard the other lacks?** That is the defect:
   `ComputeAlCacheKey` sorted, `BcCompiler.Emit` did not. Three call sites
   (`Dependencies.cs:457`, `InProcessAppPackager.cs:201`, `ProvisioningCheck.cs:822`) had each
   added their own local `OrderBy` for the same reason; the one whose order decides execution
   never did. Their now-redundant sorts are left in place — harmless, and removing them is
   unrelated churn.

## Deliberately left out

I did not add a second, independent ordering rule in `TestExecutor` (sorting `types` by name or
object ID). Compile-input order is the single source of truth for this, the end-to-end test
pins it, and two competing determinism rules would make the next reader guess which one is
authoritative.

## Local verification

- `dotnet test AlRunner.Tests --filter FullyQualifiedName~SafeDirectoryScanOrderTests` — 4/4.
- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~AlObjectEmitOrderDeterminismTests|FullyQualifiedName~InaccessibleDirectoryScanTests"` — 11/11, including the existing
  `SafeDirectoryScan` behaviour tests.
- The `b1`/`b2` runner reproduction, before and after.

Authored by agent impl-1.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf

---

## On "load-dependent": what the leg set does and does not tell us

The coordinator gathered a moving failing-leg set across seven independent runs of essentially
`main`'s tree — five passes on 27.5, and the same test failing on 28.4 for #2870 while 27.5
passed there. That meets `ci-verdicts.md` §5 for "not the commit". It does not follow that the
mechanism is a timing race, and the failing run's own output rules that out.

`RecordAbortedSuite` counts what the abort abandons in two parts: the rest of the hung codeunit,
and every later test codeunit in `types[ti+1..]`. On the failing leg it printed `1 further
[Test] method(s) in this codeunit did not run (1 total)` — the "and N in M subsequent
codeunit(s)" clause is absent, so `remainingCodeunits` was **zero**, so `Codeunit62213` was
already *behind* `Codeunit62212` in the type array. A race in which the abort fires and the loop
continues anyway would have printed `and 2 in 1 subsequent codeunit(s)` and then run them. It
did not. The codeunit loop is a plain sequential `for` over `types` with no concurrency, and the
abort is a `return`, not a flag anything polls.

So the run's outcome varies because the **input order** varied, not because the abort lost a
race. That is still load-dependent in effect, and it is still a real defect — it is just located
at compile time rather than in the watchdog.

What I could not establish: which mechanism flipped the enumeration order on those particular
runners. I did not reproduce a spontaneous flip — 12 consecutive `--no-cache` emits on this
machine gave the same order every time, and 5 concurrent emits with all 12 cores saturated by
spinners also gave the same order every time (a 6th was killed by my own cleanup and produced no
verdict). What I could do is flip the input deliberately, by writing the two `.al` files in the
other order, and that reproduces the CI failure exactly — same `(1 total)` message, same
`Codeunit62213` first.

That is enough. The enumeration was unsorted and therefore not guaranteed in the first place;
the fix removes the dependence rather than the trigger, so it does not matter which trigger
fired.

## What a convincing verification looks like

Not a green CI leg. Two observed failures across roughly nine `AlRunner.Tests` leg-runs puts the
pre-fix failure rate near 20%, so a single dispatched 27.5 leg passes about 80% of the time even
with nothing fixed, and both legs together about 64%. At that sample size CI cannot distinguish
this fix from luck, and treating a green leg as proof would be the same mistake in the other
direction.

The load-bearing evidence is that the failure is now reproducible on demand and then provably
gone:

1. `AlObjectEmitOrderDeterminismTests` inverts the input CI could only flip by chance. Before the
   fix it fails deterministically; after, both orderings agree. That converts "did not happen
   this time" into "cannot happen".
2. The original `b1`/`b2` reproduction, which produced the CI message byte-for-byte before and
   the correct `(3 total)` after.
3. `SafeDirectoryScanOrderTests` pins the contract at the unit level so a future refactor cannot
   quietly drop the sort.

If a CI leg is dispatched anyway, dispatch **both** `AlRunner.Tests` legs — 27.5 and 28.4 —
since the observed failures split across them, and read the result as a smoke check rather than
a verdict.

## Relationship to the other two

- #2801 is this failure; the PR closes it, and the reasoning is above.
- #2819 (the 1-in-5 SIGSEGV) is unrelated on the evidence I have: nothing here crashes, and this
  mechanism cannot produce a segfault. I did not investigate it.

## Not verified locally

I could not run the al-language corpus locally to check for order-dependent tests — the
submodule fetch failed on a network timeout in this environment. Execution order across the
corpus does change with this fix (it becomes ordinal source-path order), so that is the one
thing worth watching on the full matrix.
