### PR TITLE
test(compile): pin the DotNet/compilation-target matrix end to end

### DIFF
--- a/AlRunner.Tests/DotNetCompilationTargetScopeTests.cs
+++ b/AlRunner.Tests/DotNetCompilationTargetScopeTests.cs
@@ -1,0 +1,178 @@
+// DotNetCompilationTargetScopeTests — issue #2641.
+//
+// RUNNER-MECHANISM test, end to end. ManifestCompilationTargetTests (#2725) pins that
+// app.json's `target` reaches NavCA.CompilationOptions. It does not pin that anything
+// OBSERVABLE follows from it, and that is the half #2641 is about: the runner used to
+// compile every bundle as CompilationTarget.OnPrem regardless of its manifest, so a
+// Cloud-target app declaring a `dotnet` block compiled and ran here while a real service
+// tier refuses it. Runner-green then meant nothing for that file.
+//
+// The rejection is NOT re-implemented here. The runner hands BC's own AL compiler the
+// declared target and the compiler applies its own rule, so these diagnostics are
+// Microsoft's, not the runner's — which is why this can be a runner-mechanism test rather
+// than a BC-behaviour claim needing a service tier. It also could not be a corpus test even
+// if we wanted one: the corpus adjudicates by COMPILING its apps and running them, so an app
+// that deliberately fails to compile cannot express a passing test there.
+//
+// The four cells, measured on BC 28.1 before this file existed. `target` and the presence of
+// a `dotnet` declaration block are independent, and each is load-bearing:
+//
+//   target   dotnet block   result
+//   Cloud    present        error AL0296 — 'DotNet' has scope 'OnPrem', not usable for Cloud
+//   Cloud    absent         error AL0185 — DotNet '<Type>' is missing
+//   OnPrem   absent         error AL0185 — DotNet '<Type>' is missing
+//   OnPrem   present        compiles, and the test runs and passes
+//
+// The last row is why the other three prove something. Without it every assertion here would
+// still pass if the runner simply refused all DotNet everywhere, which is a different bug
+// with the same green.
+//
+// Historical note, because it decides what this test is worth: at the commit #2641 reports
+// (7744ab12) only the FIRST row was wrong — Cloud + a dotnet block compiled and the test
+// passed. The AL0185 rows already behaved correctly there, on both targets. The AL0185
+// output quoted in that issue therefore does not demonstrate the defect it is attached to;
+// it is the no-declaration diagnostic, which was never broken. #2737 fixed the real cell by
+// making the manifest target reach the compiler.
+
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class DotNetCompilationTargetScopeTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    /// <summary>
+    /// A `dotnet` declaration block naming one mscorlib type. Its presence is one of the two
+    /// independent variables in the table above.
+    /// </summary>
+    private const string DotNetDeclaration = """
+    dotnet
+    {
+        assembly("mscorlib")
+        {
+            type("System.Text.Encoding"; "Encoding")
+            {
+            }
+        }
+    }
+    """;
+
+    /// <summary>
+    /// Declares a DotNet variable and nothing else. Declaring it is enough — the diagnostics
+    /// under test are the compiler's, raised before anything runs.
+    /// </summary>
+    private const string ProbeCodeunit = """
+    codeunit 62260 "DotNet Target Probe"
+    {
+        Subtype = Test;
+
+        [Test]
+        procedure DeclaresADotNetVariable()
+        var
+            Enc: DotNet Encoding;
+        begin
+            Clear(Enc);
+        end;
+    }
+    """;
+
+    private static string WriteBundle(string label, string target, bool withDeclaration)
+    {
+        var root = Path.Combine(
+            Path.GetTempPath(), "al-runner-dotnet-target-" + label, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        // No "application" property: the Base Application floor is not the subject here and
+        // costs ~70 s cold per invocation (.claude/rules/no-base-app-in-csharp-tests.md).
+        File.WriteAllText(Path.Combine(root, "app.json"), $$"""
+        {
+          "id": "{{Guid.NewGuid()}}",
+          "name": "DotNet Target Scope {{label}}",
+          "publisher": "Repro2641",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62260, "to": 62269 } ],
+          "runtime": "15.0",
+          "target": "{{target}}"
+        }
+        """);
+
+        if (withDeclaration)
+            File.WriteAllText(Path.Combine(root, "Declaration.DotNet.al"), DotNetDeclaration);
+
+        File.WriteAllText(Path.Combine(root, "Probe.Codeunit.al"), ProbeCodeunit);
+        return root;
+    }
+
+    private static string RunRunner(string bundle)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" \"").Append(bundle).Append('"');
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(300_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return sb.ToString();
+    }
+
+    [Fact]
+    public void CloudTarget_DeclaringADotNetBlock_IsRefusedByTheCompiler()
+    {
+        var output = RunRunner(WriteBundle("cloud-decl", "Cloud", withDeclaration: true));
+
+        // The cell #2641 is actually about. Before #2737 this compiled and the test PASSED.
+        Assert.Contains("error AL0296", output, StringComparison.Ordinal);
+        Assert.Contains("cannot be used for 'Cloud' development", output, StringComparison.Ordinal);
+        Assert.Contains("COMPILE FAIL", output, StringComparison.Ordinal);
+
+        // It must not have run: a compile-refused bundle that still reports a passing test
+        // would mean the diagnostic was raised and then ignored.
+        Assert.DoesNotContain("PASS  Codeunit62260", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OnPremTarget_DeclaringADotNetBlock_CompilesAndRuns()
+    {
+        var output = RunRunner(WriteBundle("onprem-decl", "OnPrem", withDeclaration: true));
+
+        // The positive control. Without it, a runner that refused DotNet unconditionally
+        // would satisfy every other assertion in this file.
+        Assert.Contains("PASS  Codeunit62260.DeclaresADotNetVariable", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("error AL0296", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("error AL0185", output, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("Cloud")]
+    [InlineData("OnPrem")]
+    public void EitherTarget_WithoutADotNetBlock_IsRefusedAsMissing(string target)
+    {
+        var output = RunRunner(WriteBundle("no-decl-" + target, target, withDeclaration: false));
+
+        // A DotNet variable with no declaration is missing on BOTH targets, which is why the
+        // AL0185 output quoted in #2641 does not demonstrate a target defect. Asserting the
+        // type name too, so this cannot pass on some unrelated AL0185.
+        Assert.Contains("error AL0185: DotNet 'Encoding' is missing", output, StringComparison.Ordinal);
+        Assert.Contains("COMPILE FAIL", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("PASS  Codeunit62260", output, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
Closes #2641

Filed by the impl-2 agent.

## What I measured

The issue's headline is correct in substance but **the defect is already fixed**, and the
evidence quoted in the issue does not demonstrate it. I measured four cells at the commit the
issue names (`7744ab12`) and on current `main`, treating `target` and the presence of a
`dotnet` declaration block as independent variables.

| target | `dotnet` block | at `7744ab12` | on current `main` |
|---|---|---|---|
| Cloud | present | **compiled, test PASSED** | `error AL0296` — 'DotNet' has scope 'OnPrem', not usable for Cloud |
| Cloud | absent | `error AL0185` | `error AL0185` |
| OnPrem | absent | `error AL0185` | `error AL0185` |
| OnPrem | present | compiles and runs | compiles and runs |

Three corrections follow:

1. **Only one cell was ever wrong** — Cloud *with* a declaration block. #2737 fixed it by
   making the manifest's target reach the compiler.
2. **The AL0185 output quoted in the issue is the missing-declaration diagnostic**, not a
   target defect. It appears on both targets and at both commits. The corpus file that
   produced it (`TestDotNetInStream.al`) declares no `dotnet` block at all, so AL0185 is what
   any target would give.
3. **The issue's second claim is false.** It says the runner "does not fail on a `dotnet`
   declaration block being absent". It does fail, with AL0185, on both targets and at both
   commits.

## What this PR adds

A regression test for the whole matrix. `ManifestCompilationTargetTests` (#2725) pins that
`target` reaches `NavCA.CompilationOptions`; nothing pinned that anything observable follows
from it, which is the half that let this ship. The new test drives the runner end to end over
all four cells.

The RED proof reproduces the original defect rather than relying on history: forcing the
generated manifest to `OnPrem` regardless of the requested target — exactly what the runner
did before #2737 — makes `CloudTarget_DeclaringADotNetBlock_IsRefusedByTheCompiler` fail with
`error AL0296` not found, while the other three still pass. That the other three stay green
under the mutation is itself the evidence that only one cell was broken.

## Why the proving test is not upstream

I was asked to put this in the corpus and I think that is the wrong home, for two reasons I
can show rather than assert:

- **A compile refusal cannot be expressed there.** The corpus adjudicates by compiling its
  apps and running their tests. An app that deliberately fails to compile does not produce a
  failing assertion, it breaks the run for everything in that app. There is no
  "expect-does-not-compile" mode upstream.
- **There is no runner re-implementation for a service tier to check.** The runner hands BC's
  own AL compiler the declared target and the compiler applies its own rule, so AL0296 and
  AL0185 are Microsoft's diagnostics verbatim. What is runner-specific is only whether the
  target reaches the compiler, which is what this test pins.

The BC fact is already recorded upstream structurally: corpus PR
StefanMaron/BusinessCentral.AL.Language.Tests#137 created a separate **OnPrem-target** app
precisely because a Cloud app cannot declare `dotnet`. That split is the upstream expression
of the claim.

## Fix the shape

1. **Same pattern at another call site?** The mechanism is one place — `target:
   manifestInputs.EffectiveTarget`, on both compile paths, already covered by #2725's unit
   test. What was missing was an outcome test, which this adds.
2. **Sibling making the same assumption?** The positive control is the sibling check: without
   the OnPrem-with-declaration cell, a runner that refused DotNet unconditionally would pass
   every other assertion here.
3. **Two paths writing the same state?** Both compile paths read `EffectiveTarget` from the
   same struct, so they cannot diverge.

## Deliberately not claimed

The issue asks whether the rest of the Cloud-target restriction family is enforced. I checked
one neighbour and am **not** drawing a conclusion from it: a `File` variable declaration, and
an `File.Open` call, both compile under `target: Cloud` as well as `OnPrem`. I have no
service-tier verdict on whether real BC rejects either, and the corpus exercises neither
`File` nor `DotNet`, so there is no upstream evidence to read. Calling that a gap would be a
guess, so I have left it alone rather than file an issue asserting something I did not
establish. It is a real open question and separable from this one.

## Run locally

- `dotnet test AlRunner.Tests --filter FullyQualifiedName~DotNetCompilationTargetScopeTests` — 4 passed (30 s), on the rebased head.
- `dotnet test AlRunner.Tests --filter FullyQualifiedName~ManifestCompilationTargetTests` — 6 passed, the sibling this builds on.

Rebased onto current `main` and re-run after the rebase; the numbers above are from the
rebased head, not from before it.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
