### PR TITLE
fix(testpage): opening a TestPage is not a commit point

### DIFF
--- a/AlRunner.Tests/TestPageMinMaxValueDispatchTests.cs
+++ b/AlRunner.Tests/TestPageMinMaxValueDispatchTests.cs
@@ -121,6 +121,15 @@ public sealed class TestPageMinMaxValueDispatchTests : IDisposable
                 Row.Init();
                 Row.PK := 'R1';
                 Row.Insert();
+                // Commit the seed explicitly. SetValue_BelowMin_Decimal_RaisesFromTestPageOnly
+                // reads R1 back AFTER an asserterror, and an AL error unwinds the database to
+                // the last commit — so without this the seed is part of what gets rolled back
+                // and the read fails on a row that never should have been the subject of this
+                // test. It used to survive by accident: opening a TestPage marked a commit
+                // point in the runner, which real BC does not do (issue #2400). This test is
+                // about MinValue/MaxValue dispatch, so it says where its own commit boundary
+                // is instead of inheriting one from the page.
+                Commit();
             end;
 
             [Test]

--- a/AlRunner.Tests/TestPageOpenIsNotACommitPointTests.cs
+++ b/AlRunner.Tests/TestPageOpenIsNotACommitPointTests.cs
@@ -1,0 +1,172 @@
+// TestPageOpenIsNotACommitPointTests — the rot guard for #2400.
+//
+// RunnerTestPageState.MarkOpened used to call RecordPatches.MarkCommitPoint() on every
+// TestPage open, on the reading that "opening a page enters a new TRANSACTION WORLD, and
+// TransactionManager.BeginTransactionWorld commits the active transaction on entering one".
+// MarkCommitPoint() DISCARDS the snapshot a rollback restores from, so a [Test] that wrote
+// rows and then opened a TestPage had nothing left to roll back to: its writes outlived the
+// test, past [TransactionModel(TransactionModel::AutoRollback)] and past a later asserterror.
+// In Microsoft's Tests-SINGLESERVER codeunit 134614 that is one test's InitializeData()
+// leaving its "Security Group" rows for the next test to fail on with "The group SG1 already
+// exists" — 13 of 15 tests in that codeunit, all cascading from the one root.
+//
+// The reading was half right, and the half that matters is wrong. A page CAN reach a commit:
+// SessionTransactionExtensions.BeginTransactionWorld commits when the transaction-world count
+// is zero. But in BC 28.1's Ncl it has exactly two callers, NavForm.RunModalAsync and
+// NavReport.RunReportCoreAsync — Page.RunModal and Report.Run enter a transaction world, and
+// a TestPage does not. NavTestPage.Open is base.Open(mode), then
+// TestClientProxy<ITestPage>.Proxy(session.TestExecution.ClientSession.CreatePage(...)), then
+// Attach(value). No transaction world anywhere on that path.
+//
+// These are deliberately RUNNER-INTERNAL and BC-SHAPE claims: that the runner's own
+// MarkOpened no longer discards the commit point, and that the BC shape the removal rests on
+// still holds. Whether a write made before a TestPage opens is still rolled back at the end
+// of the test is a plain BC-behaviour claim and lives upstream, where a real service tier
+// adjudicates it — corpus codeunit 60900 "Test TxModel Page Open"
+// (StefanMaron/BusinessCentral.AL.Language.Tests), which writes a row, opens and closes a
+// TestPage, and asserts the write is undone both by AutoRollback and by a later asserterror.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Dynamics.Nav.Runtime;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Reads the Ncl image this process actually loaded, which BcEngineBootstrap has already
+// Cecil-rewritten in place — so it must share the serial bc-engine collection.
+[Collection(BcEngineCollection.Name)]
+public sealed class TestPageOpenIsNotACommitPointTests
+{
+    private readonly BcEngineFixture _engine;
+
+    public TestPageOpenIsNotACommitPointTests(BcEngineFixture engine) => _engine = engine;
+
+    private const string BeginTransactionWorld = "BeginTransactionWorld";
+    private const string BeginTransactionWorldAndTransaction = "BeginTransactionWorldAndTransaction";
+
+    /// <summary>
+    /// Every method body declared by <paramref name="typeFullName"/> or by any type nested
+    /// inside it — the compiler-generated async state machines live in nested types, and
+    /// NavForm.RunModalAsync's call to BeginTransactionWorld is inside one of them, so a scan
+    /// of the outer type alone would report "does not call it" for the one case that does.
+    /// </summary>
+    private static IEnumerable<MethodDefinition> BodiesOf(ModuleDefinition module, string typeFullName)
+    {
+        var root = module.GetType(typeFullName);
+        Assert.True(root != null,
+            $"{typeFullName} not found in the loaded Ncl image — Ncl shape changed; do not commit.");
+
+        var stack = new Stack<TypeDefinition>();
+        stack.Push(root!);
+        while (stack.Count > 0)
+        {
+            var t = stack.Pop();
+            foreach (var nested in t.NestedTypes) stack.Push(nested);
+            foreach (var m in t.Methods)
+                if (m.HasBody) yield return m;
+        }
+    }
+
+    private static List<string> CallSitesOf(
+        ModuleDefinition module, string typeFullName, params string[] calleeNames)
+        => BodiesOf(module, typeFullName)
+            .Where(m => m.Body.Instructions.Any(i =>
+                (i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt)
+                && i.Operand is MethodReference mr
+                && calleeNames.Contains(mr.Name, StringComparer.Ordinal)))
+            .Select(m => m.DeclaringType.FullName + "::" + m.Name)
+            .ToList();
+
+    private static ModuleDefinition Ncl()
+        => AssemblyDefinition.ReadAssembly(typeof(ITreeObject).Assembly.Location).MainModule;
+
+    /// <summary>
+    /// Positive control: the transaction world a page CAN enter is real, and it is the MODAL
+    /// path. Without this, the negative below would pass just as happily against a Cecil scan
+    /// that had stopped finding anything at all — a rename of BeginTransactionWorld would turn
+    /// the guard into a test that cannot fail.
+    /// </summary>
+    [SkippableFact]
+    public void NavForm_ModalRun_DoesEnterATransactionWorld()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var sites = CallSitesOf(Ncl(), "Microsoft.Dynamics.Nav.Runtime.NavForm",
+            BeginTransactionWorld, BeginTransactionWorldAndTransaction);
+
+        Assert.True(sites.Count > 0,
+            "NavForm (or one of its nested async state machines) must still call "
+            + $"{BeginTransactionWorld} — that is the modal-page commit this guard's negative "
+            + "half is defined against. If BC moved it, re-derive where a page commits before "
+            + "trusting the negative below.");
+    }
+
+    /// <summary>
+    /// The BC shape the fix rests on: opening a TestPage does not enter a transaction world,
+    /// so it does not commit. If a BC service update ever routes NavTestPage.Open through one,
+    /// the runner's rollback boundary genuinely would need to move and this fails loudly rather
+    /// than the corpus quietly disagreeing on one leg.
+    /// </summary>
+    [SkippableTheory]
+    [InlineData("Microsoft.Dynamics.Nav.Runtime.NavTestPage")]
+    [InlineData("Microsoft.Dynamics.Nav.Runtime.NavTestPageBase")]
+    public void TestPageOpen_DoesNotEnterATransactionWorld(string typeFullName)
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var sites = CallSitesOf(Ncl(), typeFullName,
+            BeginTransactionWorld, BeginTransactionWorldAndTransaction);
+
+        Assert.True(sites.Count == 0,
+            $"{typeFullName} must not enter a transaction world — a TestPage attaches through "
+            + "the test client session, and entering a transaction world is what commits the "
+            + "caller's active transaction. Found: " + string.Join(", ", sites));
+    }
+
+    /// <summary>
+    /// The runner-side half, and the one that actually regressed: MarkOpened must not discard
+    /// the transaction snapshot. Read off the runner's own compiled IL rather than its source,
+    /// so a call reintroduced through a helper is caught too.
+    /// </summary>
+    [Fact]
+    public void MarkOpened_DoesNotDiscardTheTransactionSnapshot()
+    {
+        var module = AssemblyDefinition
+            .ReadAssembly(typeof(AlRunner.Patches.RunnerTestPageState).Assembly.Location)
+            .MainModule;
+
+        var sites = CallSitesOf(module, "AlRunner.Patches.RunnerTestPageState",
+            nameof(AlRunner.Patches.RecordPatches.MarkCommitPoint));
+
+        Assert.True(sites.Count == 0,
+            "RunnerTestPageState must not call RecordPatches.MarkCommitPoint — that clears the "
+            + "snapshot RollbackToCommitPoint restores from, so every write a [Test] made before "
+            + "it opened a TestPage becomes permanent: AutoRollback cannot undo it and neither "
+            + "can a later asserterror (issue #2400). Found: " + string.Join(", ", sites));
+    }
+
+    /// <summary>
+    /// Negative control for the test above: the same scan DOES find the commit points that are
+    /// meant to be there, so "found none" in MarkOpened means the call is absent rather than
+    /// the scan being blind. ALDatabase_ALCommit is AL's own <c>Commit()</c> and
+    /// ResetWriteTransactionState is the per-test isolation boundary; both must keep marking.
+    /// </summary>
+    [Fact]
+    public void TheRealCommitPointsAreStillMarked()
+    {
+        var module = AssemblyDefinition
+            .ReadAssembly(typeof(AlRunner.Patches.RunnerTestPageState).Assembly.Location)
+            .MainModule;
+
+        var sites = CallSitesOf(module, "AlRunner.Patches.ALDatabasePatches",
+            nameof(AlRunner.Patches.RecordPatches.MarkCommitPoint));
+
+        Assert.Contains("AlRunner.Patches.ALDatabasePatches::ALDatabase_ALCommit", sites);
+        Assert.Contains("AlRunner.Patches.ALDatabasePatches::ResetWriteTransactionState", sites);
+    }
+}

--- a/AlRunner/Patches/RunnerTestPageState.cs
+++ b/AlRunner/Patches/RunnerTestPageState.cs
@@ -56,13 +56,35 @@ public static class RunnerTestPageState
             if (navTestPage == null) return;
             _testPageField ??= FindTestPageField(navTestPage.GetType());
             if (_testPageField?.GetValue(navTestPage) is not LiveNavTestPage live) return;
-            // Opening a page is a commit point. BC reaches one because the page opens inside a
-            // new TRANSACTION WORLD, and TransactionManager.BeginTransactionWorld commits the
-            // active transaction on entering one (CommitImpl(commit: true)). The runner opens
-            // the page in-process without that machinery, so the commit has to be made here —
-            // otherwise an asserterror on a page operation rolls back the test's own setup,
-            // which real BC has already committed by then.
-            AlRunner.Patches.RecordPatches.MarkCommitPoint();
+            // NOT a commit point. This used to call RecordPatches.MarkCommitPoint() here, on
+            // the reading that "opening a page enters a new TRANSACTION WORLD, and
+            // TransactionManager.BeginTransactionWorld commits the active transaction on
+            // entering one". Half of that is true and the half that matters is not (#2400).
+            //
+            // BeginTransactionWorld does commit — but only when
+            // `logicalTransaction.TransactionWorldCount == 0`, and it calls
+            // ThrowIfWriteTransactionStarted() first, so with an AL write transaction already
+            // open it RAISES rather than committing. More decisive: in BC 28.1's Ncl,
+            // SessionTransactionExtensions.BeginTransactionWorld has exactly two callers —
+            // NavForm.RunModalAsync and NavReport.RunReportCoreAsync. Page.RunModal and
+            // Report.Run enter a transaction world. A TestPage does not: NavTestPage.Open is
+            // `base.Open(mode)` followed by
+            // `TestClientProxy<ITestPage>.Proxy(session.TestExecution.ClientSession.CreatePage(...))`
+            // and `Attach(value)` — no transaction world anywhere on that path. The runner
+            // already marks the modal/report commit through BC's own machinery, via
+            // RecordPatches.NoteTransactionEnd prepended to EndTransactionWorldAndTransaction.
+            //
+            // What the wrong commit point cost: MarkCommitPoint() DISCARDS the pre-write
+            // snapshot, so a [Test] that wrote rows and then opened a TestPage had nothing left
+            // to roll back to. Its writes then outlived the test —
+            // [TransactionModel(TransactionModel::AutoRollback)] could not undo them, and
+            // neither could a later asserterror. In Microsoft's Tests-SINGLESERVER codeunit
+            // 134614 that is exactly one test's InitializeData() leaving its "Security Group"
+            // rows behind for the next test to fail on with "The group SG1 already exists."
+            //
+            // Pinned upstream by corpus codeunit 60900 "Test TxModel Page Open", which writes a
+            // row, opens and closes a TestPage, and asserts the write is still rolled back both
+            // by AutoRollback and by a later asserterror.
             live.MarkOpened(viewMode);
             // Before anything else reads the page: OnOpenPage is where a page establishes what
             // it is looking at — the singleton buffer it fetches or creates for the current


### PR DESCRIPTION
Closes #2400

Opening a TestPage marked a commit point in the runner. Real BC does not do that, and the difference is why one test's setup outlived it and failed the next test in the same codeunit.

## Root cause

`RunnerTestPageState.MarkOpened` called `RecordPatches.MarkCommitPoint()` on every TestPage open. `MarkCommitPoint()` clears `_txCommitPoint`, the snapshot `RollbackToCommitPoint` restores from, so a `[Test]` that wrote rows and then opened a TestPage had nothing left to roll back to. Its writes became permanent: `[TransactionModel(TransactionModel::AutoRollback)]` could not undo them and neither could a later `asserterror`.

The comment justifying it said a page opens inside a new transaction world, and entering one commits the active transaction. Half of that holds:

- `SessionTransactionExtensions.BeginTransactionWorld` does commit, but only when `logicalTransaction.TransactionWorldCount == 0`, and it calls `ThrowIfWriteTransactionStarted()` first — with an AL write transaction open it raises rather than committing.
- In BC 28.1's Ncl it has exactly two callers: `NavForm.RunModalAsync` and `NavReport.RunReportCoreAsync`. `Page.RunModal` and `Report.Run` enter a transaction world. A TestPage does not.
- `NavTestPage.Open` is `base.Open(mode)`, then `TestClientProxy<ITestPage>.Proxy(session.TestExecution.ClientSession.CreatePage(...))`, then `Attach(value)`. No transaction world on that path.

Nothing that should commit stops committing: the runner already marks the modal and report commit through BC's own machinery, via `RecordPatches.NoteTransactionEnd` prepended to `EndTransactionWorldAndTransaction`.

## Where the proving test lives

Whether a write made before a TestPage opens is still rolled back at the end of the test is a plain BC-behavior claim, so it is upstream: **corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#168**, codeunit 60900 "Test TxModel Page Open". Test01 (`AutoRollback`) writes a row, opens and closes a TestPage, and confirms the row is readable inside the test that wrote it. Test02 confirms it did not survive into the next test. Test03 writes a row, opens and closes the page, traps an unrelated error, and confirms the pre-page-open write went back with it.

**This PR does not bump the submodule pin** — the pin bump folds into whichever PR lands after #168 merges. RED → GREEN was measured against the corpus branch directly instead:

| | tests | failures |
|---|---|---|
| corpus `master` + codeunit 60900, pre-fix build | 2555 | 13 |
| same tree, post-fix build | 2555 | 11 |

The two that moved are Test02 and Test03. The other 11 are unrelated failures already present at corpus `master`, unchanged in both runs — `Codeunit60403`, five in `Codeunit60482`, `Codeunit60653`, four in `Codeunit60822` — all from corpus commits newer than the current pin.

## What it recovers

Microsoft's Tests-SINGLESERVER `Codeunit134614 "Test App Permissions"`, run on its own against BC 28.1:

| | pass | fail |
|---|---|---|
| before | 2 | 13 |
| after | 11 | 4 |

The first failing root was `TestViewAggregatePermissionsSetsByUser` dying in `InitializeData` with `The group SG1 already exists.` — the previous test's `Security Group` rows, kept alive by the TestPage that test opened — and the 12 behind it were the "already bound" cascade from it. Both are gone. The 4 that remain have a different root, `TestRemoveSUPERPermissionsByUserAll`'s `asserterror` not raising, filed separately as #2900.

## Fixing the shape, not just the reported line

- **Same wrong pattern at another call site?** `MarkCommitPoint()` has three other callers and all three are correct: `ALDatabasePatches.ALDatabase_ALCommit` is AL's own `Commit()`, `ALDatabasePatches.ResetWriteTransactionState` is the per-test isolation boundary, and `RecordPatches.NoteTransactionEnd` is BC's real transaction-world completion. `MarkOpened` was the only one asserting a commit BC does not make.
- **Does a sibling make the same assumption?** No. `RunnerModalDispatch.FormRunModal` / `FormRun` open a form through `TryOpenForm`, not through `NavTestPage.Open`, and neither marks a commit point of its own.
- **Do two paths that write the same state keep the same invariant?** They do now. The only remaining writers of the commit point are AL's `Commit()`, the test boundary, and BC's own transaction-world completion — all three are real commits.

I flagged the neighbouring modal boundary as unmeasured in the first version of this body, and have since settled it. **The runner already matches BC on `Page.RunModal`, and there is nothing to fix.** In `NavForm.<RunModalAsync>d__5`, `BeginTransactionWorld()` sits on the `else` of `if (Tree.Session.TestExecution.TestHandleModalForm(...))` — under a test the handler answers and the transaction world is never entered. With no `[ModalPageHandler]` declared, `FindHandler` raises `NavNCLMissingUIHandlerException` first, which the runner reproduces through the `8d` rewrite in `NclCecilRewrite.Forms.cs`. So the committing branch is unreachable under test execution in BC and in the runner alike: `Page.RunModal` in a test neither commits nor raises the write-transaction refusal. The Cecil rewrite replaces only the client-callback call inside `TestHandleModalForm`, leaving BC's own return-value logic intact, so the runner takes the same branch BC takes.

Pinned upstream by corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#169, codeunit 60903 "Test TxModel RunModal". Measured: all three of its tests pass on this branch **and** on `origin/main` at `d044fba2` without this fix, while 60900's Test02/Test03 fail there — so the modal path was never affected, and 60903 is an independent boundary rather than coverage of this change. That is exactly why it is worth having: this PR moves the plain-TestPage commit boundary, and the modal boundary next to it is the obvious thing to move by accident.

The report path is genuinely different and I have filed it rather than touched it: `NavReport.RunReportCoreAsync` CAN enter a transaction world inside a test, and its guard exempts `AutoRollback` tests explicitly. The runner matches BC on the exempted branch, measured. The committing branch needs a request page or a non-default `TransactionType` and I have not reached it on either side — #2904 records the condition, what was measured, and what was not.

## Is #2503 the same thing?

No, and it is correctly closed. #2503 was that `[TransactionModel(AutoRollback)]` had no effect at all, because `TestExecutor.RunOne` invoked the method directly and never reached BC's `NavTestCodeunit.ExecuteTestMethodAsync`; #2513 implemented `ApplyTestTransactionModel` and its corpus test, codeunit 60899, passes both before and after this change. That codeunit does not open a page, which is exactly the case it left uncovered — the rollback was being applied, it just had nothing to roll back to. Corpus 60900 is 60899 with a page open added, and it is the case that was missing.

## Tests

- **Upstream:** corpus PR #168 above — the BC-behavior claim, for a real service tier to adjudicate on all 8 legs.
- **`AlRunner.Tests/TestPageOpenIsNotACommitPointTests.cs`** — the rot guard, four tests. The runner-side half reads `RunnerTestPageState`'s compiled IL and asserts it no longer calls `MarkCommitPoint`, with a negative control proving the same scan still finds `ALDatabase_ALCommit`'s and `ResetWriteTransactionState`'s, so "found none" means absent rather than blind. The BC half asserts `NavForm` still enters a transaction world and `NavTestPage`/`NavTestPageBase` still do not, so a service update that moves the boundary fails here instead of on one corpus leg.
- **`AlRunner.Tests/TestPageMinMaxValueDispatchTests.cs`** — one existing fixture had encoded the old boundary as correct. `SetValue_BelowMin_Decimal_RaisesFromTestPageOnly` seeds row R1, opens a TestPage, traps a rejected `SetValue`, then reads R1 back; that read only worked because the page open committed the seed. Its subject is MinValue/MaxValue dispatch, so `Seed()` now commits explicitly rather than inheriting a boundary from the page. Same assertion, no longer resting on the bug.

## What I ran

| suite | result |
|---|---|
| corpus `master` + codeunit 60900 | RED 13 fail → GREEN 11 fail (see table above) |
| pinned corpus, `--strict --count-baseline` | 2523 tests, 1 fail — the pre-existing `Codeunit60653.BooleanFieldControl_ReadsAsYesOrNo` known-gap drift (#2795, `agent: impl-6`), which also fails on the pre-fix build |
| `tests/runner-extras`, `--strict --count-baseline` | 260/260, exit 0 |
| Microsoft Tests-SINGLESERVER `Codeunit134614` | 2P/13F → 11P/4F |
| full `AlRunner.Tests` | 2383 tests. Two complete runs of the same tree failed 3 and then 4, all in `ProvisionExplicitModesTests`, all `[provision] Error fetching index: ... A task was canceled` against Microsoft's artifact index. Network, not this change — the failing set changed between two runs of identical code. |

The three engine-gated cases in the new rot guard skip locally, because `BcEngineFixture` cannot bootstrap on this machine — the pre-existing `NonModalPageRunDispatchBindingTests` skips identically, so it is the environment and not the new test. I verified their claims another way rather than pushing them unmeasured: `find_callers` over BC 28.1's Ncl gives `BeginTransactionWorld` exactly two callers (`NavForm.<RunModalAsync>d__5`, `NavReport.<RunReportCoreAsync>d__194`) and `BeginTransactionWorldAndTransaction` three (`NavXmlPort`, `NavEventScope`, `NavCodeunit.<DoRunAsync>d__9`), with no `NavTestPage` or `NavTestPageBase` among them. CI runs them for real.

Written by agent impl-8.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
