### PR TITLE
fix(deps): ask same-SourcePath before identity, so a version bump is not a self-collision

### DIFF
--- a/AlRunner.Tests/ServerAppVersionBumpTests.cs
+++ b/AlRunner.Tests/ServerAppVersionBumpTests.cs
@@ -31,12 +31,13 @@ public sealed class ServerAppVersionBumpTests
 
     private static string WriteBundle(string suffix, string version, string appName, string appId = AppId, int idBase = 62280)
     {
-        var root = Path.Combine(
-            Path.GetTempPath(), "al-runner-server-versionbump-" + suffix, Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-server-versionbump-" + suffix);
         Directory.CreateDirectory(root);
 
-        // No "application": the Base Application floor is not the subject and costs ~70 s
-        // cold per invocation (.claude/rules/no-base-app-in-csharp-tests.md).
+        // No Base Application floor is declared below: it is not the subject here and costs
+        // ~70 s cold per invocation (.claude/rules/no-base-app-in-csharp-tests.md). Written
+        // without the literal property spelling because BaseAppFloorFixtureGuardTests scans
+        // this file as raw text and cannot tell a comment from a manifest key (see #3064).
         File.WriteAllText(Path.Combine(root, "app.json"), $$"""
         {
           "id": "{{appId}}",

--- a/AlRunner.Tests/ServerAppVersionBumpTests.cs
+++ b/AlRunner.Tests/ServerAppVersionBumpTests.cs
@@ -1,0 +1,292 @@
+// ServerAppVersionBumpTests — issue #2556.
+//
+// A warm --server session compiles the SAME bundle directory across requests. Editing that
+// bundle's app.json `version` between two requests aborted the run with an
+// AppIdCollisionException naming the same directory as BOTH sides of the collision. One
+// directory cannot collide with itself.
+//
+// The cause is ordering. DependencyLoader compares identity (Name + Publisher + VERSION)
+// before it compares SourcePath, so a version bump on one tree matched #1850's
+// "two apps, one id" guard and never reached the same-SourcePath branch that exists
+// precisely for server mode's edit-and-rerun contract. The message it produced was written
+// for two DIFFERENT paths ("one of these is a stale build ... (pathA) and (pathB)"), so with
+// one path it read as nonsense on top of being wrong.
+//
+// Dedicated server, not SharedCliServer: ServerTests documents that every fact sharing that
+// process must present a distinct AppId, and the negative fact below deliberately presents
+// ONE AppId at TWO SourcePaths. Running it on the shared server would poison the AppId cache
+// for every other fact in that class.
+//
+// Credit: found and fixed independently by Mikkel Mansa Vilhelmsen (@vhn) in his fork
+// (commit 831080ea). The code here is not copied from it.
+
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ServerAppVersionBumpTests
+{
+    private const string AppId = "b5555555-5555-5555-5555-555555555555";
+
+    private static string WriteBundle(string suffix, string version, string appName, string appId = AppId, int idBase = 62280)
+    {
+        var root = Path.Combine(
+            Path.GetTempPath(), "al-runner-server-versionbump-" + suffix, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        // No "application": the Base Application floor is not the subject and costs ~70 s
+        // cold per invocation (.claude/rules/no-base-app-in-csharp-tests.md).
+        File.WriteAllText(Path.Combine(root, "app.json"), $$"""
+        {
+          "id": "{{appId}}",
+          "name": "{{appName}}",
+          "publisher": "Repro2556",
+          "version": "{{version}}",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": {{idBase}}, "to": {{idBase + 9}} } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(root, "Probe.Codeunit.al"), $$"""
+        codeunit {{idBase}} "Version Bump Probe {{idBase}}"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure APassingTest()
+            begin
+                if 1 <> 1 then
+                    Error('unreachable');
+            end;
+        }
+        """);
+        return root;
+    }
+
+    private static string Req(string bundle) => JsonSerializer.Serialize(new
+    {
+        command = "runTests",
+        sourcePaths = new[] { bundle },
+        packagePaths = Array.Empty<string>(),
+    });
+
+    private static void SetVersion(string bundle, string version)
+    {
+        var path = Path.Combine(bundle, "app.json");
+        var text = File.ReadAllText(path);
+        var edited = text.Replace("\"version\": \"1.0.0.0\"", $"\"version\": \"{version}\"");
+        Assert.NotEqual(text, edited); // guard: the substitution actually applied
+        File.WriteAllText(path, edited);
+    }
+
+    [SkippableFact]
+    public async Task BumpingTheVersionOfTheSameBundle_DoesNotCollideWithItself()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = WriteBundle("bump", "1.0.0.0", "Version Bump Probe");
+        try
+        {
+            await using var server = await CliServer.StartAsync();
+
+            // ── Request 1: baseline. Registers AppId -> (v1.0.0.0, this directory). ──
+            var lines1 = await server.SendRequestStreamingAsync(Req(bundle), TimeSpan.FromSeconds(180));
+            var (_, d1) = ProtocolV2Streaming.Split(lines1);
+            Assert.Equal(0, d1.GetProperty("exitCode").GetInt32());
+            Assert.Equal(1, d1.GetProperty("passed").GetInt32());
+
+            // ── Request 2: same directory, version bumped. This is the whole issue. ──
+            SetVersion(bundle, "1.0.0.1");
+            var lines2 = await server.SendRequestStreamingAsync(Req(bundle), TimeSpan.FromSeconds(180));
+            var joined2 = string.Join(" | ", lines2);
+
+            // Named explicitly so a future regression says WHY it failed rather than just
+            // reporting a non-zero exit code.
+            Assert.DoesNotContain("duplicate app id", joined2, StringComparison.OrdinalIgnoreCase);
+
+            var (_, d2) = ProtocolV2Streaming.Split(lines2);
+            Assert.Equal(0, d2.GetProperty("exitCode").GetInt32());
+            Assert.Equal(1, d2.GetProperty("passed").GetInt32());
+            Assert.Equal(0, d2.GetProperty("failed").GetInt32());
+
+            // ── Request 3: bump again, to prove the first bump did not merely get away
+            //    with it once by overwriting a single stale entry. ──
+            var path = Path.Combine(bundle, "app.json");
+            File.WriteAllText(path, File.ReadAllText(path).Replace("1.0.0.1", "2.0.0.0"));
+            var lines3 = await server.SendRequestStreamingAsync(Req(bundle), TimeSpan.FromSeconds(180));
+            Assert.DoesNotContain("duplicate app id", string.Join(" | ", lines3), StringComparison.OrdinalIgnoreCase);
+            var (_, d3) = ProtocolV2Streaming.Split(lines3);
+            Assert.Equal(0, d3.GetProperty("exitCode").GetInt32());
+            Assert.Equal(1, d3.GetProperty("passed").GetInt32());
+        }
+        finally
+        {
+            try { Directory.Delete(bundle, recursive: true); } catch { }
+        }
+    }
+
+    private static (string appDir, string testDir) MakeAppTestPair()
+    {
+        var root = TestScratch.Dir("al-runner-server-versionbump-dep");
+        var appDir = Path.Combine(root, "app");
+        var testDir = Path.Combine(root, "tests");
+        Directory.CreateDirectory(appDir);
+        Directory.CreateDirectory(testDir);
+
+        const string depAppId = "c6666666-6666-6666-6666-666666666666";
+
+        File.WriteAllText(Path.Combine(appDir, "app.json"), $$"""
+        {
+          "id": "{{depAppId}}",
+          "name": "VB2556 Dep App",
+          "publisher": "Repro2556",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62300, "to": 62309 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(appDir, "DepApp.al"), """
+        codeunit 62300 "VB2556 Dep Helper"
+        {
+            procedure Answer(): Integer
+            begin
+                exit(42);
+            end;
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(testDir, "app.json"), $$"""
+        {
+          "id": "d7777777-7777-7777-7777-777777777777",
+          "name": "VB2556 Dep Tests",
+          "publisher": "Repro2556",
+          "version": "1.0.0.0",
+          "dependencies": [
+            {
+              "id": "{{depAppId}}",
+              "name": "VB2556 Dep App",
+              "publisher": "Repro2556",
+              "version": "1.0.0.0"
+            }
+          ],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62310, "to": 62319 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(testDir, "DepTests.al"), """
+        codeunit 62310 "VB2556 Dep Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure DependencyStillAnswers()
+            var
+                Helper: Codeunit "VB2556 Dep Helper";
+            begin
+                if Helper.Answer() <> 42 then
+                    Error('the dependency module answered %1, not 42', Helper.Answer());
+            end;
+        }
+        """);
+        return (appDir, testDir);
+    }
+
+    private static string ReqBoth(string appDir, string testDir) => JsonSerializer.Serialize(new
+    {
+        command = "runTests",
+        sourcePaths = new[] { appDir, testDir },
+        packagePaths = Array.Empty<string>(),
+    });
+
+    [SkippableFact]
+    public async Task BumpingADependencysVersion_DoesNotCollideWithItself()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        // A version bump across a dependency PAIR, which is the shape that motivated looking
+        // at DependencyLoader.LoadAll's own cache check — the third site with the same
+        // identity-before-path ordering, which #2556 does not name.
+        //
+        // Measured, and stated because it bounds what this test proves: this exercises the
+        // TryGetByAppId/RegisterLoaded path, NOT LoadAll's branch. Reverting the LoadAll half
+        // of the fix leaves this test green, in either bundle order (dependent first and app
+        // first were both tried). #1892's cross-bundle dedup registers the app's own compile
+        // before its dependent resolves it, so LoadAll finds an entry whose identity already
+        // matches. The LoadAll change is kept as a consistency fix for a provably identical
+        // ordering, not because this test covers it.
+        var (appDir, testDir) = MakeAppTestPair();
+        try
+        {
+            await using var server = await CliServer.StartAsync();
+
+            var lines1 = await server.SendRequestStreamingAsync(ReqBoth(appDir, testDir), TimeSpan.FromSeconds(240));
+            var (_, d1) = ProtocolV2Streaming.Split(lines1);
+            Assert.Equal(0, d1.GetProperty("exitCode").GetInt32());
+            Assert.Equal(1, d1.GetProperty("passed").GetInt32());
+
+            // Bump the dependency's own version AND the dependent's declaration of it, which
+            // is what a caller bumping a version actually does.
+            foreach (var manifest in new[] { Path.Combine(appDir, "app.json"), Path.Combine(testDir, "app.json") })
+            {
+                var text = File.ReadAllText(manifest);
+                var edited = text.Replace("\"version\": \"1.0.0.0\"", "\"version\": \"1.0.0.1\"");
+                Assert.NotEqual(text, edited);
+                File.WriteAllText(manifest, edited);
+            }
+
+            var lines2 = await server.SendRequestStreamingAsync(ReqBoth(appDir, testDir), TimeSpan.FromSeconds(240));
+            var joined2 = string.Join(" | ", lines2);
+            Assert.DoesNotContain("duplicate app id", joined2, StringComparison.OrdinalIgnoreCase);
+
+            var (_, d2) = ProtocolV2Streaming.Split(lines2);
+            Assert.Equal(0, d2.GetProperty("exitCode").GetInt32());
+            // The dependency still resolves and its body still answers 42 — so the fall-through
+            // recompiled it rather than dropping it.
+            Assert.Equal(1, d2.GetProperty("passed").GetInt32());
+            Assert.Equal(0, d2.GetProperty("failed").GetInt32());
+        }
+        finally
+        {
+            try { Directory.Delete(Path.GetDirectoryName(appDir)!, recursive: true); } catch { }
+        }
+    }
+
+    [SkippableFact]
+    public async Task TwoDifferentDirectoriesSharingOneAppId_StillCollide()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        // The negative direction, and the reason the fix is a REORDER rather than a
+        // deletion: #1850's guard must keep firing for what it was written for. Without
+        // this, "never throw" would satisfy the fact above.
+        var first = WriteBundle("collide-a", "1.0.0.0", "Collide App A", idBase: 62280);
+        var second = WriteBundle("collide-b", "1.0.0.0", "Collide App B", idBase: 62290);
+        try
+        {
+            await using var server = await CliServer.StartAsync();
+
+            var lines1 = await server.SendRequestStreamingAsync(Req(first), TimeSpan.FromSeconds(180));
+            var (_, d1) = ProtocolV2Streaming.Split(lines1);
+            Assert.Equal(0, d1.GetProperty("exitCode").GetInt32());
+
+            var lines2 = await server.SendRequestStreamingAsync(Req(second), TimeSpan.FromSeconds(180));
+            var joined2 = string.Join(" | ", lines2);
+
+            // Both directories named, which is what makes the message actionable — and
+            // what the self-collision message could never be.
+            Assert.Contains("duplicate app id", joined2, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains(first, joined2, StringComparison.Ordinal);
+            Assert.Contains(second, joined2, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { Directory.Delete(first, recursive: true); } catch { }
+            try { Directory.Delete(second, recursive: true); } catch { }
+        }
+    }
+}

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -136,29 +136,47 @@ public sealed class DependencyLoader
             if (_cache.TryGetValue(m.AppId, out var existing))
             {
                 var newVersion = m.Version.ToString();
-                if (!IdentityMatches(existing, m.Name, m.Publisher, newVersion))
+                var identityMatches = IdentityMatches(existing, m.Name, m.Publisher, newVersion);
+                var sameDirectory = string.Equals(
+                    existing.SourcePath, path, StringComparison.OrdinalIgnoreCase);
+
+                // #2556: the third site with this ordering, and the one the issue does not
+                // name. A dependency's app.json version can be bumped mid-session exactly as
+                // a bundle's own can — and in a multi-bundle run one bundle's own app IS
+                // another bundle's dependency — so this threw naming the same directory on
+                // both sides. Only a DIFFERENT directory can be a collision.
+                if (!identityMatches && !sameDirectory)
                     throw new AlRunner.Infrastructure.AppIdCollisionException(
                         m.AppId,
                         existing.Name, existing.Publisher, existing.Version, existing.SourcePath,
                         m.Name, m.Publisher, newVersion, path);
-                // #2593/#2579: this dependency's Assembly is being reused without calling
-                // LoadOne again — but LoadOne is the ONLY place that replays this dependency's
-                // Tier-3 metadata sidecars (report/report-layout/page/xmlport/enum) into the
-                // process-wide registries. Those registries get reset every reload cycle
-                // (BcRuntime.ResetForNewBundleReload), so on the SECOND and every later
-                // --watch/--server cycle that resolves this same AppId as a dependency, skipping
-                // this replay would silently drop the dependency's metadata forever — the exact
-                // regression this call prevents (see WatchPageMetadataReloadTests, R3Pages
-                // resolved as R3Driver's dependency). Gated on the stored Tier3CacheKey, not a
-                // File.Exists probe recomputed from scratch — a Tier-1/Tier-2 entry (the
-                // overwhelming majority: Base Application, System Application, most real ISV
-                // .apps) never went through Tier 3 and has no sidecars to replay, and
-                // ComputeSourceDependencyCacheKey hashes the WHOLE .app file, which would be a
-                // real cost paid every cycle for a ~100MB Base Application package for no reason.
-                if (existing.Tier3CacheKey != null)
-                    ReplayDependencyMetadataSidecars(m, existing.Tier3CacheKey);
-                list.Add(existing.Asm);
-                continue;
+
+                // Same directory with a changed identity falls through to a recompile rather
+                // than into the reuse below: serving `existing.Asm` would run the PREVIOUS
+                // version's compiled module for the new one's tests — the silent wrong answer
+                // #1850 exists to prevent, reached from the other side. The cache entry is
+                // overwritten further down, when this app is loaded afresh.
+                if (identityMatches)
+                {
+                    // #2593/#2579: this dependency's Assembly is being reused without calling
+                    // LoadOne again — but LoadOne is the ONLY place that replays this dependency's
+                    // Tier-3 metadata sidecars (report/report-layout/page/xmlport/enum) into the
+                    // process-wide registries. Those registries get reset every reload cycle
+                    // (BcRuntime.ResetForNewBundleReload), so on the SECOND and every later
+                    // --watch/--server cycle that resolves this same AppId as a dependency, skipping
+                    // this replay would silently drop the dependency's metadata forever — the exact
+                    // regression this call prevents (see WatchPageMetadataReloadTests, R3Pages
+                    // resolved as R3Driver's dependency). Gated on the stored Tier3CacheKey, not a
+                    // File.Exists probe recomputed from scratch — a Tier-1/Tier-2 entry (the
+                    // overwhelming majority: Base Application, System Application, most real ISV
+                    // .apps) never went through Tier 3 and has no sidecars to replay, and
+                    // ComputeSourceDependencyCacheKey hashes the WHOLE .app file, which would be a
+                    // real cost paid every cycle for a ~100MB Base Application package for no reason.
+                    if (existing.Tier3CacheKey != null)
+                        ReplayDependencyMetadataSidecars(m, existing.Tier3CacheKey);
+                    list.Add(existing.Asm);
+                    continue;
+                }
             }
             // A source-only Microsoft app carries compile-time symbols, not a runtime DLL.
             // Two sub-cases, and we can only tell them apart by trying to compile:
@@ -900,12 +918,18 @@ public sealed class DependencyLoader
     public static Assembly? TryGetByAppId(Guid appId, string name, string publisher, string version, string sourcePath)
     {
         if (!_cache.TryGetValue(appId, out var entry)) return null;
+        // #2556: SourcePath is asked FIRST. A collision is by definition between two
+        // DIFFERENT directories, so comparing identity first meant a version bump on this
+        // one tree — an ordinary thing to do between two requests of a warm session — was
+        // read as #1850's two-apps-one-id case and aborted the run, naming this same
+        // directory as both sides. Identity is now only ever compared across two genuinely
+        // distinct directories, which is the only situation #1850's guard was written for.
+        if (string.Equals(entry.SourcePath, sourcePath, StringComparison.OrdinalIgnoreCase))
+            return null;
         if (!IdentityMatches(entry, name, publisher, version))
             throw new AlRunner.Infrastructure.AppIdCollisionException(
                 appId, entry.Name, entry.Publisher, entry.Version, entry.SourcePath,
                 name, publisher, version, sourcePath);
-        if (string.Equals(entry.SourcePath, sourcePath, StringComparison.OrdinalIgnoreCase))
-            return null;
         return entry.Asm;
     }
 
@@ -940,11 +964,19 @@ public sealed class DependencyLoader
         var newEntry = new LoadedAppEntry(asm, name, publisher, version, sourcePath);
         if (_cache.TryAdd(appId, newEntry)) return;
         var existing = _cache[appId];
+        // #2556: SourcePath first, for the same reason as TryGetByAppId above — this is the
+        // same bundle re-registering itself after a fresh compile, which is not a collision
+        // whatever its version now says. Overwriting is what server mode's edit-and-rerun
+        // contract needs: a later sibling bundle must resolve to THIS compile, not the one
+        // that happened to run first.
+        if (string.Equals(existing.SourcePath, sourcePath, StringComparison.OrdinalIgnoreCase))
+        {
+            _cache[appId] = newEntry;
+            return;
+        }
         if (!IdentityMatches(existing, name, publisher, version))
             throw new AlRunner.Infrastructure.AppIdCollisionException(
                 appId, existing.Name, existing.Publisher, existing.Version, existing.SourcePath,
                 name, publisher, version, sourcePath);
-        if (string.Equals(existing.SourcePath, sourcePath, StringComparison.OrdinalIgnoreCase))
-            _cache[appId] = newEntry;
     }
 }


### PR DESCRIPTION
Closes #2556

Filed by the impl-2 agent.

## The defect

`DependencyLoader` compared identity (Name + Publisher + **Version**) before it compared
`SourcePath`. So editing a bundle's `app.json` version between two requests of a warm
`--server` session matched #1850's two-apps-one-id guard and aborted the run:

```
FATAL: duplicate app id b5555555-... : "Repro2556_Version Bump Probe" is loaded at two
different versions in this process under the SAME id — v1.0.0.0 (/tmp/...) and v1.0.0.1 (/tmp/...)
```

Same directory on both sides. One directory cannot collide with itself, and the message was
written for two *different* paths ("one of these is a stale build"), so it read as nonsense on
top of being wrong.

## The fix

Ask `SourcePath` first, in **all three** places that compare identity against the AppId cache.
The issue names two; `DependencyLoader.LoadAll`'s own cache check is a third with the identical
ordering, and it is reachable for the same reason — a dependency's `app.json` version can be
bumped mid-session, and in a multi-bundle run one bundle's own app *is* another's dependency.

Identity is now only ever compared across two genuinely distinct directories, which is the only
situation #1850's guard was ever about. That guard is unchanged for what it was written for.

In `LoadAll` the same-directory case falls through to a **recompile** rather than into the reuse
branch. Serving the cached assembly there would run the previous version's compiled module for
the new version's tests — #1850's silent wrong answer, reached from the other side.

## RED → GREEN

RED, before the fix, on the second request after the bump:

```
Assert.DoesNotContain() Failure: Sub-string found
String: ···"","errors":["FATAL: duplicate app id b555"···
```

GREEN after: 3 passed. The negative test **already passed before the fix** and still does,
which is the point — the fix is a reorder, not a deletion, so two different directories sharing
one app id still abort, still naming both.

## Coverage, stated plainly

The two sites the issue names are covered. **The `LoadAll` change is not**, and I could not
construct a reproducer for it:

- Reverting only the `LoadAll` half leaves all three tests green.
- I tried both bundle orders (dependent first, app first). Neither reaches it.
- The reason is #1892's cross-bundle dedup: an app's own compile is registered via
  `RegisterLoaded` before its dependent resolves it, so `LoadAll` finds an entry whose identity
  already matches and never reaches the mismatch branch.

I kept it as a consistency fix for a provably identical ordering rather than leave one of three
instances behind, but it is not a tested one and the test file and commit message both say so.
If you would rather it were reverted and filed separately, say so and I will.

## Fix the shape

1. **Same pattern at another call site?** Yes — `LoadAll`, which the issue does not name. Found
   by grepping for `IdentityMatches` rather than following the two line numbers given.
2. **Sibling making the same assumption?** `IdentityMatches` itself is unchanged and remains the
   right comparison for two distinct directories; only its ordering relative to the path check
   was wrong.
3. **Two paths writing the same state?** `TryGetByAppId` (read) and `RegisterLoaded` (write) are
   the pair, and they now agree: neither treats one directory as colliding with itself.

## Run locally, on the rebased head

Cache-sensitive, so the new tests were run twice — both runs green:

- `ServerAppVersionBumpTests` — 3 passed (cold 31 s, warm 18 s)
- `AppIdCollisionLoudFailureTests` — 5 passed (the guard this must preserve)
- `ServerTests` — 30 passed (the edit-and-rerun contract this sits next to)
- `ServerCrossBundleModuleIdentityDedupTests` — 1 passed
- `ServerCrossAppStaleGenerationTests` — 2 passed
- `DependencyResolverTests` — 35 passed

Mode note: this is `--server`, not `--watch`. Incremental compile works under `--watch` and not
under `--server`, so the two are not interchangeable evidence; the tests here drive the server
protocol directly.

## Credit

Found and fixed independently by Mikkel Mansa Vilhelmsen (@vhn) in his fork, commit `831080ea`.
The code here is not copied from it.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
