### PR TITLE
docs(reviewer): post the review on the PR, and stop contradicting the posting rule

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: reviewer
 description: Review a pull request on AL Runner or the corpus against this repository's actual failure modes — whether the proving test proves anything, whether a BC-behaviour claim reached a real service tier, whether a measurement is sound, and whether anything fails silently. Use before merging, and as the review step of an unattended cycle. Reports findings; never merges.
-tools: Bash, Read, Grep, ToolSearch, mcp__github__get_me, mcp__github__list_pull_requests, mcp__github__pull_request_read, mcp__github__list_issues, mcp__github__issue_read, mcp__github__get_job_logs
+tools: Bash, Read, Grep, ToolSearch, mcp__github__add_issue_comment, mcp__github__get_me, mcp__github__list_pull_requests, mcp__github__pull_request_read, mcp__github__list_issues, mcp__github__issue_read, mcp__github__get_job_logs
 model: opus
 ---
 
@@ -13,8 +13,15 @@ help. Where `gh` is absent (web and remote sessions) use the `mcp__github__*` to
 `tools:` allowlist is exhaustive, so anything missing fails at call time with no warning.
 
 
-You report findings. You never merge, never push to the branch under review, and never comment
-publicly unless the invoking session tells you it is authorised.
+**Post your review as a comment on the PR under review**, on this repository and on the corpus
+repository. That needs no approval — `public-posting-approval.md` makes commenting on issues and
+PRs here ungated precisely so an unattended session is not stalled waiting for it. A review that
+reaches only the session that dispatched you has produced nothing: that context is discarded, and
+the reader who needs the review most is whoever opens the PR next.
+
+You still never merge, never push to the branch under review, and never submit a **formal** PR
+review — that one is gated, and a plain comment carries the same information without the approval
+semantics. Outside these two repositories, post nothing without the invoking session's say-so.
 
 A green pipeline says the code compiles and the tests pass. It does not say the tests prove
 anything, that the claim was checked against real BC, or that a failure will be visible. Those
@@ -129,3 +136,9 @@ findings to look thorough is worse than no review.
 
 State explicitly whether, in your judgement, the PR meets the merge bar. The invoking session
 decides; you do not merge.
+
+That verdict goes **on the PR**, not only into your reply. Post it as a comment before you
+return, and say in your reply that you did. Where `gh` exists, `gh pr comment <N> --repo <owner>/<repo>
+--body-file <file>` is the shortest route; where it does not (web and remote sessions — see
+`github-access.md`), use `mcp__github__add_issue_comment`, which serves PRs too. Sign it as an
+agent review, since it posts under the account holder's name.


### PR DESCRIPTION
`.claude/agents/reviewer.md:16-17` told reviewers to "never comment publicly unless the invoking session tells you it is authorised". `.claude/rules/public-posting-approval.md` says the opposite for these two repositories: commenting on issues and PRs is **ungated**, "because requiring approval for each one stalls an unattended session for no benefit".

Closes #2907

## What the wrong default cost

Twelve reviewer agents ran against twelve open PRs tonight. All twelve returned substantial reports to the invoking session and **none posted anything to the PR**, because the definition said not to and nobody thought to authorise it. Findings that existed nowhere but in one agent's context:

- **#2881** — the materialisation gate's latch is write-once and `ResetPerTestState` never clears it, so the race fix closes its window exactly once per (source, table) per process. Reproduced deterministically: 5 runs, 5 failures, carrying the original defect's own `Expected: 1 / Actual: 0`.
- **#2874** — reverting both `DependencyLoader.cs` hunks leaves the whole suite green; nothing binds the fix to the emit site.
- **#2882** — a residual false-green shape that the test suite asserts as *correct* at `tools/test_ci_wait.py:294-297`.

The `autonomous-cycle` skill names this exactly: *"A cycle that ends with a conclusion only in an agent's context has produced nothing — that context is discarded."* A review is the clearest case, because the reader who needs it most is whoever opens the PR next, not the session that dispatched the reviewer.

It is also the reviewer's own listed check turned on itself: *"Does it contradict an auto-loaded rule file or a sister skill without editing it? Two documents giving different instructions means the agent guesses."*

## The change

- **Invert the default.** The review goes on the PR as a comment, on these two repositories, without asking.
- **Keep every other prohibition exactly as it was** — never merge, never push to the branch under review, never submit a *formal* PR review (that one **is** gated by `public-posting-approval.md`, and a plain comment carries the same information without the approval semantics), and nothing outside these two repos.
- **Say where the review lands.** The `## Reporting` section ended "the invoking session decides", which describes the audience as that session alone. It now says the verdict goes on the PR, names the `gh pr comment` route, names the MCP route for sessions without `gh`, and requires the comment to be signed as an agent review since it posts under the account holder's name.
- **Add `mcp__github__add_issue_comment` to the `tools:` allowlist.** The allowlist is exhaustive, and `github-access.md` records that web and remote sessions have no `gh` — so without this a reviewer there would be told to post and be unable to.

## Scope

One file, +16/−3. No runner code, no AL, no CHANGELOG, nothing under `tests/al-language/`. `require-tests` does not trigger (`^AlRunner/` only).

Deliberately not proposed: whether a reviewer should be able to submit a **formal** PR review. `public-posting-approval.md` gates that separately and on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE

*Opened by an automated agent (`stma-auto-1`) acting on the account holder's behalf, at their request.*
