### PR TITLE
docs(agents): the loop can measure its own budget, and the assignee is not the lock

### DIFF
--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -98,9 +98,11 @@ Every check below exists because its absence has silently corrupted a result.
 
    Keep your label on whatever you are working, so a loop starting up can see the slot is live.
    Between units you hold nothing, so a concurrent startup may pick the same slot — that is what
-   the re-read above is for, and it is why the assignee, not the slot, is the real lock. Do not
-   try to judge whether someone else's open work is "still being worked": you cannot tell a dead
-   box from a contributor who is asleep, and the design refuses that judgement elsewhere for the
+   the re-read above is for. Do not read the assignee as the lock that makes up for it: where
+   every loop pushes as one account, the assignee cannot say *which* loop holds an issue, and an
+   **open PR carrying `Closes #N`** is the signal that decides it (#2891). Do not try to judge
+   whether someone else's open work is "still being worked" either: you cannot tell a dead box
+   from a contributor who is asleep, and the design refuses that judgement elsewhere for the
    same reason.
 
    Note the slot is bookkeeping, not safety. The incident it is often credited with preventing —
@@ -374,9 +376,41 @@ The five-hour windows are real, but **exhausting every window burns the weekly l
 couple of days.** The budget that matters is weekly, so run continuously *below* per-window
 capacity rather than sprinting and then idling.
 
-One agent at a time is most of the pacing. Beyond that, use numbers the loop can actually count,
-because **it has no way to read its own token consumption or remaining budget** — an instruction
-to "tune from observed consumption" cannot be followed and will be guessed at.
+One agent at a time is most of the pacing. Beyond that, **the loop can measure both its own
+consumption and its remaining budget**, where the tooling for it is installed. Check for these
+two sources during preflight and record in the box profile which ones this machine has:
+
+- **Consumption, on any machine:** `npx ccusage@latest claude` for daily totals and
+  `npx ccusage@latest blocks` for per-5-hour-block ones, read from Claude Code's own local
+  JSONL. Absolute tokens and cost only — see the two misreadings below.
+- **Remaining budget, where the Omarchy agents panel is installed:**
+  `/usr/share/omarchy/bin/omarchy-agent-usage-claude --limits-only`, or read its state file
+  `~/.local/state/omarchy/agents/usage/claude.json` directly. It carries the authoritative
+  limits from Anthropic's OAuth usage endpoint — a `percent` and a `resetsAt` for the 5-hour
+  and the 7-day window. `percent` is a 0..1 fraction, so `0.47` means 47%. `--limits-only`
+  re-probes the limits while reusing a recent transcript scan; it does not narrow the output.
+
+**A missing limits source leaves the loop half-sighted, not blind.** Measure absolute tokens and
+cost with ccusage, ask the human for the cap percentage, and record any snapshot they give you
+so a burn rate can be derived. One sample for calibration, taken from a panel screenshot:
+35% → 37% of a session across 8 minutes at 9–12 concurrent agents, roughly 15 percentage points
+per hour. Where the limits source *is* present, measure the rate directly rather than
+extrapolating from that figure.
+
+Two ways to misread these numbers, both of which cost real time on 2026-09-05:
+
+- **ccusage's block `%` is not your cap.** It is measured against a *guessed* limit — the largest
+  block ccusage has ever seen. A coordinator read it as "at the cap" and concluded there was no
+  headroom while the authoritative figure was 37%. Take absolute tokens and cost from ccusage;
+  take the percentage from the limits source, or from the human.
+- **ccusage counts the whole machine.** It reads all local Claude Code data, so its totals cover
+  every loop running on the box, not only yours.
+
+**Cost is almost entirely cache reads, so the lever is round trips, not agent count.** Of
+738,650,170 tokens in one measured day, 723,088,774 (97.9%) were cache reads and 8,761 were
+input. Cache reads scale with tool round-trips × context size, so fewer round trips per agent
+and tighter briefs cut cost far more than running fewer agents does — the same finding
+`CLAUDE.md`'s code-navigation section reaches about grep round-trips, and it applies here too.
 
 Put concrete values in the box profile and obey them: a fixed wall-clock gap between cycles, and
 a hard cap on cycles per rolling 24 hours. Count cycles, subagents spawned and elapsed time —


### PR DESCRIPTION
Closes #2918

Two statements in `.claude/skills/autonomous-cycle/SKILL.md` were false. Both are load-bearing — a fresh unattended session reads the skill as fact and follows them.

Documentation only, no policy changed, and the edits are deliberately surgical: this file is shared with several loops running right now, so a reflowing diff would collide with all of them.

## 1. Pacing: the loop *can* measure its own consumption and its remaining budget

The old text was:

> use numbers the loop can actually count, because **it has no way to read its own token consumption or remaining budget** — an instruction to "tune from observed consumption" cannot be followed and will be guessed at.

Both halves are wrong, and the whole "obey fixed values in the box profile" design rests on them.

**Consumption** — `npx ccusage@latest claude` (daily) and `npx ccusage@latest blocks` (per 5-hour block), read from Claude Code's own local JSONL. Measured 2026-09-05: 738,650,170 tokens / $482.55 for the day.

**Remaining budget** — verified on this box:

```
$ /usr/share/omarchy/bin/omarchy-agent-usage-claude --limits-only
"limits":[{"label":"Session (5-hour)","percent":0.47,"resetsAt":"2026-09-05T21:29:59+00:00"},
          {"label":"Weekly (7-day)","percent":0.16,"resetsAt":"2026-09-07T18:59:59+00:00"}],
"tierLabel":"Max 20x","todayTotalTokens":813800459
```

The producer's own docstring says it collects "the authoritative rate limits from Anthropic's OAuth usage endpoint", state cached at `~/.local/state/omarchy/agents/usage/claude.json`.

Details I checked rather than took on trust, because the skill will be read literally:

- **`percent` is a 0..1 fraction**, so `0.47` is 47%. Confirmed in `normalize_utilization`, which divides percent-scaled payloads by 100.
- **`--limits-only` does not narrow the output.** Per `--help` it means "reuse any recent transcript scan; only the limits probe must be fresh". The skill says so, so nobody wastes a cycle wondering why the full record came back.

**Written as conditional on the tooling being present.** The skill is explicitly meant to work on someone else's hardware, and a contributor without Omarchy needs the fallback spelled out rather than being left believing a missing binary means the loop is blind.

Also recorded: the two ways these numbers get misread (ccusage's block `%` is measured against a *guessed* limit — the largest block it has seen — and is not the plan cap; and ccusage counts every loop on the machine), and the finding that matters more than the totals — cost is 97.9% cache reads against 8,761 input tokens for a whole day, so the lever is round trips per agent, not agent count. That is the same conclusion `CLAUDE.md`'s code-navigation section reaches about grep round-trips, now cross-referenced.

## 2. "The assignee is the lock" — the instance a sibling PR leaves standing

The skill asserts this in two places. PR #2916 (issue #2891) corrects the one in the claiming section and adds the rule file. Line 101, in the identity/slot section, says:

> it is why the assignee, not the slot, is the real lock

That is outside #2916's hunks and would have been left standing — the same false claim, in a section that PR does not touch. Corrected here to point at the open-PR signal and #2891.

**Coordinated by reading, not by editing the same lines.** I did not touch `.claude/rules/branch-and-pr.md` and created no rule file; those are #2916's. Merge checked against its head `f6250394`:

```
git merge-tree --write-tree --messages f6250394 HEAD   ->  CLEAN
```

Both branches share merge base `6287bedf`. If #2916 lands first this still applies cleanly, and vice versa.

## Question for the maintainer — raised, not answered

**Now that remaining budget is readable on this box, should pacing become closed-loop against it?**

The Pacing section tells the loop to obey fixed wall-clock gaps and a fixed cycle cap *precisely because* it could not read its budget. That premise is gone where the limits source exists. I deliberately left the policy unchanged — the "Put concrete values in the box profile and obey them" paragraph is byte-identical, including "Tuning those numbers is a human's job between runs, not the loop's during one" — because deciding that is your call, not mine. The commands above are the evidence that closed-loop pacing is newly possible.

A related sub-question, if you do want it closed-loop: a shared box means several loops draw on one budget, and `omarchy-agent-usage-claude` reports the account, not the caller. Two loops each pacing against the same account-wide percentage would each think they had the whole headroom.

## Verification

- `require-tests` gate simulated against its real condition (`git diff --name-only | grep -E '^AlRunner/' | grep -vE '\.(md)$'`): empty, so the job skips. Only `.claude/skills/autonomous-cycle/SKILL.md` changed. Expect `docs-only`.
- `.github/scripts/check_closing_reference.sh` run over the real title, body and branch commit messages — see below.
- No `CHANGELOG.md`, nothing under `tests/al-language/`.

---

*Written by an automated agent (`stma-auto-1`) acting on the account holder's behalf. The pacing-policy question above is the account holder's decision, not the agent's.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
