### PR TITLE
feat(tools): preflight.py — the autonomous-cycle preflight as an executable check with a real exit code

### DIFF
--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -64,6 +64,15 @@ Exactly one agent runs. When it returns, you review, act, and start the next.
 A fresh or drifted box does not announce that it is broken; it produces numbers that look fine.
 Every check below exists because its absence has silently corrupted a result.
 
+**Run `tools/preflight.py`.** It is this section, executable, with a real exit code — 0 all
+passed, 1 something failed and this box would produce untrustworthy results, 2 warnings under
+`--strict`, 3 it could not complete. `--json` for a box profile, `--reap` to remove worktrees
+whose PR is merged and whose tree is clean, `--with-corpus` to include step 1. The prose below
+stays as the specification and the reasoning; the script is how it actually gets run, because a
+check a busy coordinator can decline is not a check — one skipped step 5 across an evening of
+~20 agents and filled a 7.7 GB tmpfs, after which every shell on the box failed without naming
+the cause.
+
 1. **Known-good baseline — run the corpus.** `tests/al-language` is green or it is not, and its
    expected count lives in `tests/expectations/count-baseline/`, checked in and only moved by a
    PR that deliberately bumps it. That makes it the right health check and means no new baseline

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -374,6 +374,23 @@ jobs:
       - name: Run tools/test_ci_wait.py
         run: python3 tools/test_ci_wait.py
 
+  preflight-tests:
+    name: preflight.py unit tests
+    runs-on: ubuntu-latest
+    # tools/preflight.py decides whether a box is fit to run an autonomous
+    # cycle, so its thresholds and its merged-worktree test are unit-tested
+    # against captured df / git worktree output rather than against whatever the
+    # runner happens to look like. Two of its cases build a real throwaway git
+    # repository: the squash-merge trap (this repo squash-merges, so
+    # `git merge-base --is-ancestor` calls every merged branch unmerged) and the
+    # submodule refusal `git worktree remove` raises. Ungated -- plain Python
+    # plus git, and it takes seconds.
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run tools/test_preflight.py
+        run: python3 tools/test_preflight.py
+
   agent-mcp-tools:
     name: Agent definitions must allowlist the MCP tools they document
     runs-on: ubuntu-latest

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -1,0 +1,1314 @@
+#!/usr/bin/env python3
+"""Check that this box can be trusted to run an autonomous AL Runner cycle.
+
+This is `.claude/skills/autonomous-cycle/SKILL.md`'s "Preflight" section as an
+executable check with a real exit code, rather than prose. It implements what
+that skill already specifies; it does not add policy of its own.
+
+It exists because the prose version failed, measurably. A coordinator ran ~20
+agents across an evening without ever performing step 5 ("Headroom. Read free
+RAM and disk, and derive worker and job counts from them.") and filled `/tmp`,
+which on that box is a 7.7 GB **tmpfs** rather than the 400 GB `/` that "check
+disk" brings to mind. Every shell on the machine then failed without naming the
+cause: `echo` exited 1, `ls` exited 2, `python3 -c "print(1)"` exited 120 with
+"error flushing std streams", and a redirect produced a zero-byte file because
+the shell died between open() and write(). Three agents diagnosed it as a broken
+shell before a fourth surfaced the real errno, EDQUOT. About 40 minutes lost.
+
+So the report below always names the **mount point and filesystem type** behind
+every number. "Disk is fine" was true of `/` and false of `/tmp` at the same
+moment, and that ambiguity is the whole incident.
+
+A check a busy coordinator can decline is not a check.
+
+Usage:
+    tools/preflight.py                 # human-readable report
+    tools/preflight.py --json          # machine-readable, same verdicts
+    tools/preflight.py --strict        # warnings are also non-zero
+    tools/preflight.py --reap          # remove worktrees of MERGED PRs, if clean
+    tools/preflight.py --with-corpus   # also run the corpus baseline (minutes)
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Optional
+
+GIB = 1024 ** 3
+
+# The skill offers these as a *starting point* and says explicitly to derive from
+# measurement rather than hardcode a worker count. They are the per-worker
+# footprint, not a worker count: the count is computed from them and from what
+# this box actually has free, in suggest_workers() below.
+PER_WORKER_BYTES_NO_TEST_DATA = int(1.1 * GIB)
+PER_WORKER_BYTES_WITH_TEST_DATA = int(2.3 * GIB)
+
+# Percentage-full alone never hard-fails: a 500 GB disk at 99% still has 5 GB
+# free, which is room for several workers, whereas a 7.7 GB tmpfs at 99% has 77
+# MB and is the state that broke the box. Absolute free space is what decides;
+# the percentage is a heads-up. (The brief's "a box at 60% disk is not the same
+# as one at 99%" is exactly this split.)
+SPACE_WARN_USED_PCT = 90
+
+# A budget window this far consumed is worth saying out loud. It never hard-fails
+# -- an exhausted budget produces *no* answers, which is visible, rather than
+# wrong answers, which are not. See classify_budget().
+BUDGET_WARN_FRACTION = 0.85
+BUDGET_STALE_MINUTES = 60
+
+OMARCHY_USAGE_BIN = "/usr/share/omarchy/bin/omarchy-agent-usage-claude"
+
+EXIT_MEANING = {
+    0: "every check passed (warnings may be present; see --strict)",
+    1: "at least one check FAILED - this box would produce untrustworthy results",
+    2: "--strict was given and at least one check WARNED (nothing failed)",
+    3: "preflight could not complete - bad usage, or no checks ran",
+}
+
+
+# --------------------------------------------------------------------------
+# process helpers
+# --------------------------------------------------------------------------
+@dataclass
+class Ran:
+    rc: int
+    out: str
+    err: str
+    timed_out: bool = False
+
+    @property
+    def ok(self) -> bool:
+        return self.rc == 0 and not self.timed_out
+
+
+def run(argv: list[str], *, cwd: Optional[str] = None, timeout: float = 30,
+        env: Optional[dict] = None, stdin: bytes = b"") -> Ran:
+    """Run a command, never raise, and treat a timeout as its own outcome.
+
+    A timeout is distinct from a failure on purpose: a locked signing agent makes
+    `git commit` hang forever rather than fail, and an unattended loop simply
+    stops there. That is the difference between "signing is broken" and "signing
+    will silently eat your cycle", and the report says which.
+    """
+    try:
+        p = subprocess.run(argv, cwd=cwd, env=env, input=stdin,
+                           stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                           timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return Ran(rc=124, out="", err="", timed_out=True)
+    except (FileNotFoundError, PermissionError, OSError) as exc:
+        return Ran(rc=127, out="", err=str(exc))
+    return Ran(rc=p.returncode,
+               out=p.stdout.decode("utf-8", "replace"),
+               err=p.stderr.decode("utf-8", "replace"))
+
+
+def run_retry(argv: list[str], *, attempts: int = 3, **kw) -> Ran:
+    """Retry a network-touching command. This box's network times out
+    intermittently, and a single timeout read as a FAIL would halt a healthy
+    loop."""
+    last = Ran(rc=127, out="", err="never ran")
+    for _ in range(attempts):
+        last = run(argv, **kw)
+        if last.ok:
+            return last
+    return last
+
+
+def human(n: Optional[float]) -> str:
+    if n is None:
+        return "?"
+    n = float(n)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if abs(n) < 1024 or unit == "TiB":
+            return f"{n:.1f} {unit}" if unit != "B" else f"{int(n)} B"
+        n /= 1024
+    return f"{n:.1f} TiB"
+
+
+# --------------------------------------------------------------------------
+# data
+# --------------------------------------------------------------------------
+@dataclass
+class Mount:
+    device: str
+    fstype: str
+    total: int
+    used: int
+    free: int
+    used_pct: int
+    mountpoint: str
+
+
+@dataclass
+class Worktree:
+    path: str
+    head: str
+    branch: Optional[str]
+    detached: bool = False
+    is_main: bool = False
+    size_bytes: Optional[int] = None
+
+
+@dataclass
+class Disposition:
+    reapable: bool
+    reason: str
+
+
+@dataclass
+class Suggestion:
+    workers: int
+    limited_by: str
+    detail: dict
+
+
+@dataclass
+class BudgetWindow:
+    label: str
+    fraction: float             # 0..1, share of the window already consumed
+    resets_at: Optional[dt.datetime]
+
+    def minutes_left(self, now: dt.datetime) -> Optional[float]:
+        if self.resets_at is None:
+            return None
+        return (self.resets_at - now).total_seconds() / 60.0
+
+
+@dataclass
+class CheckResult:
+    name: str
+    status: str                 # PASS | WARN | FAIL | SKIP
+    summary: str
+    command: str = ""
+    detail: list = field(default_factory=list)
+    remedy: str = ""
+    data: dict = field(default_factory=dict)
+
+
+# --------------------------------------------------------------------------
+# pure parsing
+# --------------------------------------------------------------------------
+def parse_df(text: str) -> list[Mount]:
+    """Parse `df -PT -B1 <paths>`.
+
+    -P guarantees one line per filesystem (without it a long device name wraps
+    and every field shifts), -T adds the filesystem type -- the column this whole
+    tool exists to print -- and -B1 gives exact bytes rather than a rounded
+    human figure that cannot be compared against a per-worker budget.
+
+    The mount point is the last field and may contain spaces, so the split is
+    bounded at 6 rather than done greedily.
+    """
+    mounts: list[Mount] = []
+    for line in text.splitlines():
+        line = line.rstrip("\n")
+        if not line.strip() or line.startswith("Filesystem"):
+            continue
+        parts = line.split(None, 6)
+        if len(parts) < 7:
+            continue
+        device, fstype, total, used, free, capacity, mountpoint = parts
+        try:
+            total_i, used_i, free_i = int(total), int(used), int(free)
+            pct = int(capacity.rstrip("%"))
+        except ValueError:
+            continue
+        mounts.append(Mount(device=device, fstype=fstype, total=total_i, used=used_i,
+                            free=free_i, used_pct=pct, mountpoint=mountpoint))
+    return mounts
+
+
+def mount_for_path(path: str, mounts: Iterable[Mount]) -> Optional[Mount]:
+    """Longest-prefix match, so /tmp/x resolves to the tmpfs and not to /.
+
+    Getting this wrong is the incident: "/" had 400 GB free at the exact moment
+    /tmp had none, and a check that resolved a /tmp path to "/" would have
+    reported the box healthy.
+    """
+    if not os.path.isabs(path):
+        return None
+    path = os.path.abspath(path)
+    best: Optional[Mount] = None
+    for m in mounts:
+        prefix = m.mountpoint.rstrip("/") + "/"
+        if path == m.mountpoint or path.startswith(prefix):
+            if best is None or len(m.mountpoint) > len(best.mountpoint):
+                best = m
+    return best
+
+
+def parse_meminfo(text: str) -> dict:
+    """/proc/meminfo, converted to bytes.
+
+    MemAvailable, not MemFree: MemFree excludes reclaimable page cache and so
+    understates what a new worker can actually get, which would suppress the
+    worker count for no reason.
+    """
+    out: dict = {}
+    for line in text.splitlines():
+        m = re.match(r"^(\w+):\s+(\d+)(?:\s+(\w+))?", line)
+        if not m:
+            continue
+        value = int(m.group(2))
+        if (m.group(3) or "").lower() == "kb":
+            value *= 1024
+        out[m.group(1)] = value
+    return out
+
+
+def parse_worktree_porcelain(text: str) -> list[Worktree]:
+    """Parse `git worktree list --porcelain`. The first record is the main
+    checkout; git guarantees that ordering."""
+    out: list[Worktree] = []
+    cur: dict = {}
+
+    def flush():
+        if cur.get("path"):
+            branch = cur.get("branch")
+            if branch and branch.startswith("refs/heads/"):
+                branch = branch[len("refs/heads/"):]
+            out.append(Worktree(path=cur["path"], head=cur.get("head", ""),
+                                branch=branch, detached=bool(cur.get("detached")),
+                                is_main=not out))
+        cur.clear()
+
+    for line in text.splitlines():
+        if not line.strip():
+            flush()
+            continue
+        key, _, value = line.partition(" ")
+        if key == "worktree":
+            flush()
+            cur["path"] = value
+        elif key == "HEAD":
+            cur["head"] = value
+        elif key == "branch":
+            cur["branch"] = value
+        elif key == "detached":
+            cur["detached"] = True
+    flush()
+    return out
+
+
+def _iso(value: Any) -> Optional[dt.datetime]:
+    raw = str(value or "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = dt.datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed
+
+
+def parse_omarchy_limits(text: str) -> tuple[list[BudgetWindow], dict]:
+    """Parse `omarchy-agent-usage-claude --limits-only`.
+
+    Its `percent` field is a **fraction in 0..1**, not a number of percent. That
+    is not a guess: the producer's normalize_utilization() divides by 100 when
+    the upstream payload is percent-scaled and clamps to 1.0, and the reading is
+    confirmed by measurement -- the session window read 0.43, then 0.48 twenty
+    minutes later under 9-12 concurrent agents, i.e. 15 percentage points/hour,
+    matching the burn measured independently.
+
+    A value above 1.0 would mean the producer changed its convention, so it is
+    treated as already being a percentage rather than silently rendered as
+    4800%.
+    """
+    try:
+        payload = json.loads(text)
+    except (ValueError, TypeError):
+        return [], {}
+    windows: list[BudgetWindow] = []
+    for entry in payload.get("limits") or []:
+        if not isinstance(entry, dict):
+            continue
+        label = str(entry.get("label") or "").strip()
+        raw = entry.get("percent")
+        if label == "" or raw is None:
+            continue
+        try:
+            fraction = float(raw)
+        except (TypeError, ValueError):
+            continue
+        if fraction > 1.0:
+            fraction = fraction / 100.0
+        windows.append(BudgetWindow(label=label, fraction=max(0.0, min(1.0, fraction)),
+                                    resets_at=_iso(entry.get("resetsAt"))))
+    meta = {k: payload.get(k) for k in
+            ("tierLabel", "todayTotalTokens", "todayPrompts", "todaySessions", "updatedAt")
+            if k in payload}
+    return windows, meta
+
+
+def parse_ccusage_blocks(text: str) -> Optional[dict]:
+    """Parse `ccusage blocks --json` and return the ACTIVE 5-hour block.
+
+    Deliberately the `--json` form. ccusage's table rendering has a `%` column
+    that is a guess -- it is measured against the largest block ccusage has ever
+    seen, not against the plan cap -- and reading it as the cap once led a
+    coordinator to conclude there was no headroom when the real figure was 37%.
+    The JSON has no such field at all, so parsing it cannot make that mistake:
+    absolute tokens and cost only.
+    """
+    try:
+        payload = json.loads(text)
+    except (ValueError, TypeError):
+        return None
+    blocks = payload.get("blocks")
+    if not isinstance(blocks, list):
+        return None
+    for block in blocks:
+        if isinstance(block, dict) and block.get("isActive") and not block.get("isGap"):
+            projection = block.get("projection") or {}
+            burn = block.get("burnRate") or {}
+            return {
+                "startTime": block.get("startTime"),
+                "endTime": block.get("endTime"),
+                "totalTokens": block.get("totalTokens"),
+                "costUSD": block.get("costUSD"),
+                "remainingMinutes": projection.get("remainingMinutes"),
+                "tokensPerMinute": burn.get("tokensPerMinute"),
+            }
+    return None
+
+
+# --------------------------------------------------------------------------
+# pure policy
+# --------------------------------------------------------------------------
+def classify_space(free: int, used_pct: int, per_worker: int) -> tuple[str, str]:
+    """Absolute free space decides; percent-full only warns.
+
+    Returns (status, reason). The reason is written to be read by someone who has
+    never run this before, so it says how many workers fit rather than only how
+    many bytes are free.
+    """
+    workers = int(free // per_worker) if per_worker > 0 else 0
+    per = human(per_worker)
+    if workers < 1:
+        return ("FAIL", f"{human(free)} free is not enough for even one worker "
+                        f"({per} each) - work started here will run out of space mid-run")
+    if workers < 2:
+        return ("WARN", f"{human(free)} free leaves room for {workers} worker "
+                        f"({per} each)")
+    if used_pct >= SPACE_WARN_USED_PCT:
+        return ("WARN", f"{used_pct}% used, though {human(free)} free is still room for "
+                        f"{workers} workers ({per} each)")
+    return ("PASS", f"{human(free)} free is room for {workers} workers ({per} each)")
+
+
+def suggest_workers(*, tmp_free: int, repo_free: int, mem_available: int, cpus: int,
+                    per_worker: int) -> Suggestion:
+    """Derive a concurrent-agent count from what this box actually has.
+
+    Nothing here is a constant except the per-worker footprint the caller passes
+    in, which is itself the skill's starting figure. Each resource is divided by
+    that footprint independently and the smallest wins, so the report can name
+    the resource that is actually limiting rather than printing one number with
+    no cause.
+    """
+    candidates = {
+        "/tmp free space": int(tmp_free // per_worker) if per_worker else 0,
+        "repo filesystem free space": int(repo_free // per_worker) if per_worker else 0,
+        "available RAM": int(mem_available // per_worker) if per_worker else 0,
+        "CPU count": int(cpus),
+    }
+    limited_by = min(candidates, key=lambda k: (candidates[k], k))
+    return Suggestion(workers=max(0, candidates[limited_by]), limited_by=limited_by,
+                      detail=candidates)
+
+
+def unpushed_against_pr(head: str, pr: Optional[dict]) -> Optional[int]:
+    """How many local commits the remote has never seen, judged by the PR.
+
+    After a squash merge GitHub deletes the head branch, so `git log @{u}..HEAD`
+    has no upstream left to resolve and reports nothing rather than reporting
+    zero. The PR's headRefOid is the surviving record of what was actually
+    pushed. Returns None when there is no PR, because "cannot prove anything was
+    pushed" must not be rendered as "nothing is unpushed".
+    """
+    if not pr or not pr.get("headRefOid"):
+        return None
+    return 0 if head == pr["headRefOid"] else 1
+
+
+def disposition(wt: Worktree, *, pr: Optional[dict], dirty: bool,
+                unpushed: Optional[int], is_current: bool = False) -> Disposition:
+    """Decide whether a worktree may be removed.
+
+    The merged test asks the **pull request**, never `git merge-base
+    --is-ancestor`. This repository squash-merges, so the branch head of a merged
+    PR is not an ancestor of main and never becomes one: measured here against
+    three merged branches, ancestry reported all three as unmerged. Built on
+    ancestry, a reaper reaps nothing and calls every worktree live -- safe by
+    luck. The mirror of the same mistake, on a repo that merges with a merge
+    commit, deletes unmerged work.
+    """
+    if wt.is_main:
+        return Disposition(False, "the main checkout is never removed")
+    if is_current:
+        return Disposition(False, "you are standing in this worktree")
+    if wt.detached or not wt.branch:
+        return Disposition(False, "detached HEAD - no branch, so no pull request to consult")
+    if pr is None:
+        return Disposition(False, f"no pull request found for {wt.branch} - merged state "
+                                  f"unknown, so it is kept")
+    state = str(pr.get("state") or "").upper()
+    if state != "MERGED":
+        return Disposition(False, f"PR #{pr.get('number')} is {state or 'in an unknown state'}, "
+                                  f"not MERGED")
+    if dirty:
+        return Disposition(False, f"PR #{pr.get('number')} is merged, but the tree has "
+                                  f"uncommitted changes - reported, not removed")
+    if unpushed is None:
+        return Disposition(False, f"PR #{pr.get('number')} is merged, but nothing proves the "
+                                  f"local commits were pushed - reported, not removed")
+    if unpushed > 0:
+        return Disposition(False, f"PR #{pr.get('number')} is merged, but {unpushed} local "
+                                  f"commit(s) were never pushed - reported, not removed")
+    return Disposition(True, f"PR #{pr.get('number')} is MERGED, tree is clean and fully "
+                             f"pushed")
+
+
+def classify_budget(windows: list[BudgetWindow], now: dt.datetime) -> tuple[str, str, list]:
+    """Report remaining budget, and derive a sustainable burn from it.
+
+    Never a hard FAIL. An exhausted budget produces *no* answers, which is
+    visible the moment it happens; the checks that hard-fail are the ones where
+    work proceeds and produces *wrong* answers. That split is the brief's, and
+    the skill's.
+
+    The derived number is the share of the window still available divided by the
+    hours until it resets: the rate the loop can sustain from here to the reset
+    without exhausting it. The alternative -- printing a percentage and letting
+    the reader guess -- is what left a coordinator unable to tell 43%-with-an-hour
+    -left from 43%-with-four-hours-left.
+    """
+    if not windows:
+        return ("WARN", "budget headroom UNKNOWN - no usage source answered", [])
+    detail: list[str] = []
+    worst = "PASS"
+    for w in windows:
+        pct = w.fraction * 100.0
+        mins = w.minutes_left(now)
+        remaining = max(0.0, 1.0 - w.fraction) * 100.0
+        line = f"{w.label}: {pct:.1f}% used, {remaining:.1f}% left"
+        if mins is None:
+            line += " (no reset time reported)"
+        elif mins <= 0:
+            line += " (its window has already reset; this figure describes a period that is over)"
+        else:
+            hours = mins / 60.0
+            line += (f", resets in {mins:.0f} min"
+                     f" - sustainable from here: {remaining / max(hours, 1e-6):.1f}%/hour")
+        detail.append(line)
+        if w.fraction >= BUDGET_WARN_FRACTION:
+            worst = "WARN"
+    if worst == "WARN":
+        hot = ", ".join(f"{w.label} at {w.fraction * 100:.0f}%"
+                        for w in windows if w.fraction >= BUDGET_WARN_FRACTION)
+        return ("WARN", f"budget nearly consumed: {hot}", detail)
+    top = max(windows, key=lambda w: w.fraction)
+    return ("PASS", f"budget has headroom (highest window: {top.label} at "
+                    f"{top.fraction * 100:.0f}% used)", detail)
+
+
+def overall_exit(results: list[CheckResult], strict: bool = False) -> int:
+    if not results:
+        return 3
+    statuses = {r.status for r in results}
+    if "FAIL" in statuses:
+        return 1
+    if strict and "WARN" in statuses:
+        return 2
+    return 0
+
+
+# --------------------------------------------------------------------------
+# rendering
+# --------------------------------------------------------------------------
+_ORDER = {"FAIL": 0, "WARN": 1, "SKIP": 2, "PASS": 3}
+
+
+def render_report(results: list[CheckResult], *, strict: bool, header: str = "") -> str:
+    lines: list[str] = []
+    if header:
+        lines.append(header)
+        lines.append("")
+    width = max([len(r.name) for r in results], default=10)
+    for r in results:
+        lines.append(f"{r.status:<4}  {r.name:<{width}}  {r.summary}")
+        for d in r.detail:
+            lines.append(f"{'':<6}{'':<{width}}  {d}")
+        if r.command:
+            lines.append(f"{'':<6}{'':<{width}}  $ {r.command}")
+        if r.remedy:
+            for i, chunk in enumerate(r.remedy.split("\n")):
+                prefix = "-> what to do: " if i == 0 else "               "
+                lines.append(f"{'':<6}{'':<{width}}  {prefix}{chunk}")
+        lines.append("")
+    code = overall_exit(results, strict)
+    counts = {s: sum(1 for r in results if r.status == s) for s in ("PASS", "WARN", "FAIL", "SKIP")}
+    lines.append(f"{counts['PASS']} passed, {counts['WARN']} warned, "
+                 f"{counts['FAIL']} failed, {counts['SKIP']} skipped")
+    lines.append(f"exit {code}: {EXIT_MEANING[code]}")
+    return "\n".join(lines)
+
+
+def build_json(results: list[CheckResult], *, strict: bool, extra: Optional[dict] = None) -> dict:
+    code = overall_exit(results, strict)
+    out = {
+        "exit_code": code,
+        "exit_code_meaning": EXIT_MEANING[code],
+        "exit_codes": {str(k): v for k, v in EXIT_MEANING.items()},
+        "strict": strict,
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "checks": [
+            {"name": r.name, "status": r.status, "summary": r.summary,
+             "command": r.command, "detail": list(r.detail), "remedy": r.remedy,
+             "data": r.data}
+            for r in results
+        ],
+    }
+    if extra:
+        out.update(extra)
+    return out
+
+
+# --------------------------------------------------------------------------
+# measuring this box
+# --------------------------------------------------------------------------
+def dir_size(path: str, budget: int = 400_000) -> tuple[int, bool]:
+    """Disk usage of a directory tree, in bytes, with an entry budget.
+
+    st_blocks * 512 rather than st_size, so sparse files and small-file overhead
+    are counted the way df counts them -- the point is to compare against a
+    filesystem's free space, not to sum logical file lengths. Returns
+    (bytes, complete); complete is False when the budget ran out, so the report
+    can say "at least" instead of printing a number that quietly undercounts.
+    """
+    total = 0
+    seen = 0
+    stack = [path]
+    while stack:
+        current = stack.pop()
+        try:
+            with os.scandir(current) as it:
+                for entry in it:
+                    seen += 1
+                    if seen > budget:
+                        return total, False
+                    try:
+                        st = entry.stat(follow_symlinks=False)
+                    except OSError:
+                        continue
+                    if entry.is_dir(follow_symlinks=False):
+                        stack.append(entry.path)
+                    total += getattr(st, "st_blocks", 0) * 512
+        except OSError:
+            continue
+    return total, True
+
+
+def git_repo_root(start: str) -> Optional[str]:
+    r = run(["git", "-C", start, "rev-parse", "--show-toplevel"])
+    return r.out.strip() if r.ok else None
+
+
+def repo_slug(repo: str) -> Optional[str]:
+    r = run(["git", "-C", repo, "remote", "get-url", "origin"])
+    if not r.ok:
+        return None
+    m = re.search(r"github\.com[:/]+([^/]+)/(.+?)(?:\.git)?/?$", r.out.strip())
+    return f"{m.group(1)}/{m.group(2)}" if m else None
+
+
+def check_space(label: str, path: str, mounts: list[Mount], per_worker: int) -> CheckResult:
+    mount = mount_for_path(path, mounts)
+    if mount is None:
+        return CheckResult(name=label, status="FAIL",
+                           summary=f"could not determine the filesystem holding {path}",
+                           command=f"df -PT -B1 {path}",
+                           remedy="Run `df -PT` by hand and check the path exists.")
+    status, reason = classify_space(mount.free, mount.used_pct, per_worker)
+    detail = [f"filesystem {mount.device} ({mount.fstype}), mounted on {mount.mountpoint}, "
+              f"{human(mount.total)} total, {mount.used_pct}% used"]
+    if mount.fstype == "tmpfs":
+        detail.append("this mount is a tmpfs: it lives in RAM, it is NOT the filesystem "
+                      "holding the repository, and filling it breaks every process on the "
+                      "box with EDQUOT rather than a clear error.")
+    remedy = ""
+    if status != "PASS":
+        remedy = (f"Free space on {mount.mountpoint}. Agent scratch and per-agent --cache "
+                  f"roots are the usual occupants; `tools/preflight.py --reap` removes "
+                  f"worktrees whose PR is merged. Check the biggest consumers with "
+                  f"`du -xh -d1 {mount.mountpoint} | sort -h | tail -20`.")
+    return CheckResult(name=label, status=status, summary=f"{path} -> {mount.mountpoint}: {reason}",
+                       command=f"df -PT -B1 {path}", detail=detail, remedy=remedy,
+                       data={"mountpoint": mount.mountpoint, "fstype": mount.fstype,
+                             "free_bytes": mount.free, "total_bytes": mount.total,
+                             "used_pct": mount.used_pct, "path": path})
+
+
+def check_memory(mem: dict, per_worker: int) -> CheckResult:
+    available = mem.get("MemAvailable", 0)
+    total = mem.get("MemTotal", 0)
+    status, reason = classify_space(available, 0, per_worker)
+    detail = [f"MemTotal {human(total)}, MemAvailable {human(available)}, "
+              f"SwapFree {human(mem.get('SwapFree'))}",
+              "MemAvailable, not MemFree: MemFree ignores reclaimable page cache and "
+              "would understate what a new worker can get."]
+    remedy = ""
+    if status != "PASS":
+        remedy = ("Reduce concurrency, or stop idle agents. On any long run set MemoryHigh "
+                  "below MemoryMax so a cgroup throttles before the kernel's global OOM "
+                  "killer starts choosing victims elsewhere on the machine.")
+    return CheckResult(name="memory", status=status, summary=reason,
+                       command="cat /proc/meminfo", detail=detail, remedy=remedy,
+                       data={"mem_available_bytes": available, "mem_total_bytes": total})
+
+
+def check_headroom(tmp_dir: str, repo: str, mounts: list[Mount], mem: dict,
+                   per_worker: int, per_worker_label: str) -> CheckResult:
+    tmp_mount = mount_for_path(tmp_dir, mounts)
+    repo_mount = mount_for_path(repo, mounts)
+    cpus = os.cpu_count() or 1
+    sug = suggest_workers(tmp_free=tmp_mount.free if tmp_mount else 0,
+                          repo_free=repo_mount.free if repo_mount else 0,
+                          mem_available=mem.get("MemAvailable", 0), cpus=cpus,
+                          per_worker=per_worker)
+    detail = [f"per-worker footprint assumed: {human(per_worker)} ({per_worker_label})",
+              "each resource divided by that footprint: "
+              + ", ".join(f"{k} -> {v}" for k, v in sorted(sug.detail.items()))]
+    if sug.workers == 0:
+        return CheckResult(name="headroom", status="FAIL",
+                           summary=f"this box has room for 0 concurrent agents "
+                                   f"(limited by {sug.limited_by})",
+                           command="df -PT -B1 + /proc/meminfo + nproc",
+                           detail=detail,
+                           remedy="Do not start a cycle. Free the limiting resource first "
+                                  "and re-run this preflight.",
+                           data={"workers": 0, "limited_by": sug.limited_by,
+                                 "candidates": sug.detail})
+    return CheckResult(name="headroom", status="PASS",
+                       summary=f"run at most {sug.workers} concurrent agents "
+                               f"(limited by {sug.limited_by})",
+                       command="df -PT -B1 + /proc/meminfo + nproc", detail=detail,
+                       data={"workers": sug.workers, "limited_by": sug.limited_by,
+                             "candidates": sug.detail, "per_worker_bytes": per_worker})
+
+
+def pr_map(slug: Optional[str]) -> tuple[dict, str]:
+    """branch -> newest PR record. One API call, not one per branch."""
+    if not slug or not shutil.which("gh"):
+        return {}, "unavailable"
+    r = run_retry(["gh", "pr", "list", "--repo", slug, "--state", "all", "--limit", "300",
+                   "--json", "number,headRefName,state,headRefOid,mergedAt"], timeout=90)
+    if not r.ok:
+        return {}, f"gh pr list failed: {(r.err or r.out).strip()[:200]}"
+    try:
+        prs = json.loads(r.out)
+    except ValueError:
+        return {}, "gh pr list returned unparseable JSON"
+    out: dict = {}
+    for pr in prs:
+        branch = pr.get("headRefName")
+        if branch and branch not in out:
+            out[branch] = pr
+    return out, "ok"
+
+
+def collect_worktrees(repo: str, prs: dict, measure: bool = True) -> list[tuple]:
+    r = run(["git", "-C", repo, "worktree", "list", "--porcelain"])
+    if not r.ok:
+        return []
+    cwd = os.path.realpath(os.getcwd())
+    rows = []
+    for wt in parse_worktree_porcelain(r.out):
+        exists = os.path.isdir(wt.path)
+        real = os.path.realpath(wt.path) if exists else wt.path
+        is_current = exists and (cwd == real or cwd.startswith(real.rstrip("/") + "/"))
+        pr = prs.get(wt.branch) if wt.branch else None
+        dirty = False
+        unpushed: Optional[int] = None
+        if exists:
+            st = run(["git", "-C", wt.path, "status", "--porcelain"], timeout=60)
+            dirty = bool(st.out.strip()) if st.ok else True
+            up = run(["git", "-C", wt.path, "rev-list", "--count", "@{u}..HEAD"], timeout=60)
+            if up.ok and up.out.strip().isdigit():
+                unpushed = int(up.out.strip())
+            else:
+                # No upstream left to resolve -- GitHub deletes the head branch on
+                # merge. The PR's headRefOid is what still records what was pushed.
+                unpushed = unpushed_against_pr(wt.head, pr)
+            if measure:
+                size, complete = dir_size(wt.path)
+                wt.size_bytes = size
+        d = disposition(wt, pr=pr, dirty=dirty, unpushed=unpushed, is_current=is_current)
+        rows.append((wt, pr, dirty, unpushed, d, exists))
+    return rows
+
+
+def check_worktrees(rows: list[tuple], repo: str, pr_status: str) -> CheckResult:
+    agents = [r for r in rows if not r[0].is_main]
+    reapable = [r for r in agents if r[4].reapable]
+    missing = [r for r in agents if not r[5]]
+    dirty = [r for r in agents if r[5] and r[2]]
+    total = sum((r[0].size_bytes or 0) for r in agents)
+    detail = [f"{len(agents)} agent worktree(s), {human(total)} on disk in total"]
+    for wt, pr, is_dirty, unpushed, d, exists in sorted(
+            agents, key=lambda r: -(r[0].size_bytes or 0)):
+        mark = "REAP " if d.reapable else "keep "
+        detail.append(f"{mark}{human(wt.size_bytes):>9}  {os.path.basename(wt.path)}  "
+                      f"[{wt.branch or 'detached'}] - {d.reason}")
+    if pr_status != "ok":
+        detail.append(f"pull-request states could not be read ({pr_status}); every worktree "
+                      f"is therefore reported as merged-state unknown and kept.")
+    if missing:
+        detail.append(f"{len(missing)} registration(s) point at a directory that no longer "
+                      f"exists")
+    status = "PASS"
+    remedy = ""
+    if pr_status != "ok":
+        status = "WARN"
+        remedy = ("Authenticate gh (`gh auth status`) so merged worktrees can be identified; "
+                  "until then nothing is reapable.")
+    elif reapable:
+        status = "WARN"
+        remedy = (f"{len(reapable)} worktree(s) belong to MERGED pull requests and are clean. "
+                  f"Remove them with `tools/preflight.py --reap` (add --dry-run first). "
+                  f"Nothing ever deleting these is what left 82 worktrees and 10 GB behind "
+                  f"in the impl-69 incident.")
+    elif missing:
+        status = "WARN"
+        remedy = "Run `git worktree prune` to drop registrations for directories that are gone."
+    summary = (f"{len(agents)} agent worktree(s), {human(total)}; {len(reapable)} reapable, "
+               f"{len(dirty)} with uncommitted work")
+    return CheckResult(name="worktrees", status=status, summary=summary,
+                       command="git worktree list --porcelain + gh pr list --state all",
+                       detail=detail, remedy=remedy,
+                       data={"count": len(agents), "total_bytes": total,
+                             "reapable": [r[0].path for r in reapable],
+                             "dirty": [r[0].path for r in dirty],
+                             "missing": [r[0].path for r in missing]})
+
+
+def check_stale_scratch(tmp_dir: str, rows: list[tuple], stale_hours: float) -> CheckResult:
+    now = dt.datetime.now().timestamp()
+    entries = []
+    try:
+        with os.scandir(tmp_dir) as it:
+            for entry in it:
+                try:
+                    st = entry.stat(follow_symlinks=False)
+                except OSError:
+                    continue
+                if st.st_uid != os.getuid() or not entry.is_dir(follow_symlinks=False):
+                    continue
+                size, complete = dir_size(entry.path, budget=200_000)
+                entries.append((size, complete, (now - st.st_mtime) / 3600.0, entry.path))
+    except OSError as exc:
+        return CheckResult(name="stale-scratch", status="WARN",
+                           summary=f"could not scan {tmp_dir}: {exc}",
+                           command=f"scan of {tmp_dir}",
+                           remedy=f"Check {tmp_dir} exists and is readable.")
+    entries.sort(reverse=True)
+    stale = [e for e in entries if e[2] >= stale_hours and e[0] > 256 * 1024 * 1024]
+    orphan = [r for r in rows if not r[5]]
+    total = sum(e[0] for e in entries)
+    detail = [f"{len(entries)} directory(ies) owned by this user under {tmp_dir}, "
+              f"{human(total)} in total"]
+    for size, complete, age_h, path in entries[:8]:
+        detail.append(f"{human(size):>9}{'+' if not complete else ' '}  {age_h:6.1f}h old  {path}")
+    if orphan:
+        detail.append(f"{len(orphan)} git worktree registration(s) point at directories that "
+                      f"are gone (a killed run leaves these)")
+    status = "PASS"
+    remedy = ""
+    if stale or orphan:
+        status = "WARN"
+        bits = []
+        if stale:
+            bits.append(f"{len(stale)} scratch director(ies) over 256 MiB and idle for "
+                        f"{stale_hours:g}h+ ({human(sum(e[0] for e in stale))} total). "
+                        f"Confirm no agent owns them, then delete.")
+        if orphan:
+            bits.append("Run `git worktree prune` to clear dead registrations.")
+        remedy = "\n".join(bits)
+    return CheckResult(name="stale-scratch", status=status,
+                       summary=f"{human(total)} of scratch under {tmp_dir}; "
+                               f"{len(stale)} stale, {len(orphan)} dead worktree registration(s)",
+                       command=f"stat + recursive size of {tmp_dir}/*", detail=detail,
+                       remedy=remedy,
+                       data={"scratch_root": tmp_dir, "total_bytes": total,
+                             "stale": [e[3] for e in stale],
+                             "orphan_registrations": [r[0].path for r in orphan]})
+
+
+def check_push(repo: str, identity: str) -> CheckResult:
+    """`git ls-remote` proves READ. Only a push proves push.
+
+    The skill says push auth fails silently when it is routed through an
+    interactive credential agent, and a false PASS here has happened. --dry-run
+    performs the full negotiation, including authentication, and transfers
+    nothing, so the probe ref is never created.
+    """
+    ref = f"refs/heads/preflight-probe-{identity}"
+    cmd = f"git push --dry-run origin HEAD:{ref}"
+    r = run_retry(["git", "-C", repo, "push", "--dry-run", "--porcelain", "origin",
+                   f"HEAD:{ref}"], timeout=120, attempts=2)
+    if r.timed_out:
+        return CheckResult(name="push", status="FAIL",
+                           summary="the push probe timed out - credentials are probably "
+                                   "waiting on an interactive prompt nobody will answer",
+                           command=cmd,
+                           remedy="Configure a non-interactive credential helper, or "
+                                  "`gh auth setup-git`, then re-run.")
+    if not r.ok:
+        return CheckResult(name="push", status="FAIL",
+                           summary=f"push was refused: {(r.err or r.out).strip().splitlines()[-1] if (r.err or r.out).strip() else 'no message'}",
+                           command=cmd,
+                           detail=[(r.err or r.out).strip()[:600]],
+                           remedy="Re-authenticate (`gh auth login`, then `gh auth setup-git`) "
+                                  "and confirm the account has push permission on origin.")
+    return CheckResult(name="push", status="PASS",
+                       summary="push works (dry-run negotiated with origin; nothing was written)",
+                       command=cmd,
+                       detail=["git ls-remote would only have proven read access."])
+
+
+def check_commit(repo: str) -> CheckResult:
+    """Either signing succeeds, or signing is off.
+
+    A locked signing agent makes `git commit` hang forever rather than fail, so
+    an unattended loop stops there with no error to report. The probe is given a
+    timeout precisely so that "hangs" becomes a verdict instead of a symptom.
+
+    Objects are written to a throwaway GIT_OBJECT_DIRECTORY, so the probe leaves
+    nothing in the repository's object store.
+    """
+    ident = run(["git", "-C", repo, "var", "GIT_COMMITTER_IDENT"])
+    if not ident.ok:
+        return CheckResult(name="commit", status="FAIL",
+                           summary="git has no committer identity, so every commit will fail",
+                           command="git var GIT_COMMITTER_IDENT",
+                           detail=[(ident.err or "").strip()[:300]],
+                           remedy="Set `git config --global user.name` and `user.email`.")
+    signing = run(["git", "-C", repo, "config", "--get", "commit.gpgsign"]).out.strip().lower()
+    if signing not in ("true", "1", "yes", "on"):
+        return CheckResult(name="commit", status="PASS",
+                           summary=f"commits work; signing is off, so no agent can lock "
+                                   f"(committer: {ident.out.strip().split(' 1')[0]})",
+                           command="git var GIT_COMMITTER_IDENT; git config --get commit.gpgsign")
+    import tempfile
+    objdir = tempfile.mkdtemp(prefix="preflight-objects-")
+    try:
+        env = dict(os.environ, GIT_OBJECT_DIRECTORY=objdir)
+        tree = run(["git", "-C", repo, "hash-object", "-t", "tree", "-w", "--stdin"],
+                   env=env, stdin=b"")
+        if not tree.ok:
+            return CheckResult(name="commit", status="FAIL",
+                               summary="could not write a probe object to test signing",
+                               command="git hash-object -t tree -w --stdin",
+                               detail=[(tree.err or "").strip()[:300]],
+                               remedy="Check the repository is writable.")
+        probe = run(["git", "-C", repo, "commit-tree", "-S", "-m", "preflight signing probe",
+                     tree.out.strip()], env=env, timeout=25)
+        if probe.timed_out:
+            return CheckResult(name="commit", status="FAIL",
+                               summary="signing HUNG - `git commit` will hang forever and an "
+                                       "unattended loop will simply stop there",
+                               command="git commit-tree -S -m 'preflight signing probe' <tree>",
+                               remedy="Unlock the signing key (`gpg-connect-agent updatestartuptty "
+                                      "/bye`), or turn signing off for the loop with "
+                                      "`git config commit.gpgsign false`.")
+        if not probe.ok:
+            return CheckResult(name="commit", status="FAIL",
+                               summary="commit signing is enabled but fails",
+                               command="git commit-tree -S -m 'preflight signing probe' <tree>",
+                               detail=[(probe.err or probe.out).strip()[:400]],
+                               remedy="Fix the signing key, or set `commit.gpgsign false`.")
+        return CheckResult(name="commit", status="PASS",
+                           summary="commits work and signing succeeds without prompting",
+                           command="git commit-tree -S -m 'preflight signing probe' <tree>",
+                           detail=["Probe objects were written to a throwaway "
+                                   "GIT_OBJECT_DIRECTORY, not to the repository."])
+    finally:
+        shutil.rmtree(objdir, ignore_errors=True)
+
+
+def check_github(slug: Optional[str]) -> CheckResult:
+    """Report what this account can do. Do not branch on it.
+
+    The skill is explicit: a missing permission is a precondition failure to
+    report, not a second mode to implement. The loop behaves identically for
+    everyone; it just refuses to start when it cannot do its job.
+    """
+    if not shutil.which("gh"):
+        return CheckResult(name="github", status="WARN",
+                           summary="the gh CLI is not installed on this box",
+                           command="command -v gh",
+                           detail=["Web and remote Claude Code sessions have no gh at all; "
+                                   "there the mcp__github__* tools are the interface "
+                                   "(.claude/rules/github-access.md). On a local box that "
+                                   "runs the unattended loop, gh is expected."],
+                           remedy="Install and authenticate gh, or run the loop from a session "
+                                  "that has the GitHub MCP tools.")
+    auth = run_retry(["gh", "auth", "status"], timeout=45)
+    if not auth.ok:
+        return CheckResult(name="github", status="FAIL",
+                           summary="gh is installed but not authenticated",
+                           command="gh auth status",
+                           detail=[(auth.err or auth.out).strip()[:400]],
+                           remedy="Run `gh auth login`.")
+    login = run_retry(["gh", "api", "user", "--jq", ".login"], timeout=45).out.strip()
+    if not slug:
+        return CheckResult(name="github", status="WARN",
+                           summary=f"authenticated as {login or '?'}, but origin is not a "
+                                   f"recognisable GitHub remote",
+                           command="git remote get-url origin",
+                           remedy="Point origin at the GitHub repository.")
+    perm = run_retry(["gh", "api", f"repos/{slug}", "--jq", ".permissions"], timeout=45)
+    if not perm.ok:
+        return CheckResult(name="github", status="FAIL",
+                           summary=f"could not read permissions on {slug}",
+                           command=f"gh api repos/{slug} --jq .permissions",
+                           detail=[(perm.err or perm.out).strip()[:400]],
+                           remedy="Check network access and that the token has repo scope.")
+    try:
+        perms = json.loads(perm.out)
+    except ValueError:
+        perms = {}
+    can_push = bool(perms.get("push") or perms.get("maintain") or perms.get("admin"))
+    detail = [f"account: {login or 'unknown'}; repository: {slug}",
+              "permissions: " + ", ".join(f"{k}={v}" for k, v in sorted(perms.items())),
+              f"merge a PR: {'yes' if can_push else 'no'}; label and assign: "
+              f"{'yes' if (can_push or perms.get('triage')) else 'no'} (both need push or triage)"]
+    if not can_push:
+        return CheckResult(name="github", status="FAIL",
+                           summary=f"{login or 'this account'} cannot push to {slug}, so the "
+                                   f"loop cannot open or merge anything",
+                           command=f"gh api repos/{slug} --jq .permissions", detail=detail,
+                           remedy="Grant push access, or run the loop as an account that has it. "
+                                  "This is a precondition to report, not a second mode to "
+                                  "implement.")
+    return CheckResult(name="github", status="PASS",
+                       summary=f"authenticated as {login} with push access to {slug}",
+                       command=f"gh auth status; gh api repos/{slug} --jq .permissions",
+                       detail=detail, data={"login": login, "permissions": perms})
+
+
+def check_budget(skip_fallback: bool = False) -> CheckResult:
+    """Budget headroom: a resource that, exhausted, strands work mid-task.
+
+    Layered, and a missing tool is never read as "no constraint":
+      1. omarchy-agent-usage-claude --limits-only - the authoritative percent and
+         reset time, straight from Anthropic's OAuth usage endpoint.
+      2. ccusage blocks --json - absolute tokens and cost for the active 5-hour
+         block. Never its table's % column, which is measured against the largest
+         block ccusage has seen rather than the plan cap.
+      3. UNKNOWN, reported as a precondition.
+
+    Omarchy-specific, so the binary is probed rather than assumed.
+    """
+    now = dt.datetime.now(dt.timezone.utc)
+    binary = OMARCHY_USAGE_BIN if os.path.exists(OMARCHY_USAGE_BIN) \
+        else shutil.which("omarchy-agent-usage-claude")
+    if binary:
+        r = run([binary, "--limits-only"], timeout=60)
+        if r.ok:
+            windows, meta = parse_omarchy_limits(r.out)
+            status, summary, detail = classify_budget(windows, now)
+            detail = list(detail)
+            if meta.get("tierLabel"):
+                detail.append(f"plan: {meta['tierLabel']}; today: "
+                              f"{meta.get('todayTotalTokens', '?')} tokens across "
+                              f"{meta.get('todayPrompts', '?')} prompts, "
+                              f"{meta.get('todaySessions', '?')} session(s)")
+            updated = _iso(meta.get("updatedAt"))
+            if updated is not None:
+                age_min = (now - updated).total_seconds() / 60.0
+                detail.append(f"figures measured {age_min:.0f} min ago (updatedAt "
+                              f"{meta['updatedAt']})")
+                if age_min > BUDGET_STALE_MINUTES and status == "PASS":
+                    status = "WARN"
+                    summary += f" - but the reading is {age_min:.0f} min old"
+            remedy = ""
+            if status == "WARN":
+                remedy = ("Pace the cycle, or wait for the window to reset before starting a "
+                          "long unit of work. Never leave an agent mid-task when a budget "
+                          "boundary is near.")
+            return CheckResult(name="budget", status=status, summary=summary,
+                               command=f"{binary} --limits-only", detail=detail, remedy=remedy,
+                               data={"source": "omarchy",
+                                     "limits": [{"label": w.label, "fraction": w.fraction,
+                                                 "percent_used": round(w.fraction * 100, 2),
+                                                 "resets_at": w.resets_at.isoformat()
+                                                 if w.resets_at else None,
+                                                 "minutes_left": w.minutes_left(now)}
+                                                for w in windows],
+                                     "meta": meta})
+    fallback_note = ("omarchy-agent-usage-claude is not on this box, so the authoritative "
+                     "percent-of-cap is unavailable.")
+    if not skip_fallback and shutil.which("npx"):
+        r = run(["npx", "--yes", "ccusage@latest", "blocks", "--json"], timeout=180)
+        block = parse_ccusage_blocks(r.out) if r.ok else None
+        if block:
+            detail = [fallback_note,
+                      f"active 5-hour block started {block['startTime']}, "
+                      f"{block.get('remainingMinutes', '?')} min remaining",
+                      f"{block.get('totalTokens', '?')} tokens, "
+                      f"${block.get('costUSD', 0):.2f} so far, "
+                      f"{block.get('tokensPerMinute') or 0:.0f} tokens/min",
+                      "ccusage reports absolute usage, not a share of the plan cap. Its "
+                      "table's % column is measured against the largest block ccusage has "
+                      "ever seen, so it is not a cap and is deliberately not read here."]
+            return CheckResult(name="budget", status="WARN",
+                               summary="budget headroom UNKNOWN as a share of the cap; "
+                                       "absolute usage measured instead",
+                               command="npx --yes ccusage@latest blocks --json",
+                               detail=detail,
+                               remedy="Install the omarchy usage plugin for an authoritative "
+                                      "percent, or pace from the absolute figures above.",
+                               data={"source": "ccusage", "active_block": block})
+    return CheckResult(name="budget", status="WARN",
+                       summary="budget headroom UNKNOWN - no usage source answered",
+                       command=f"{OMARCHY_USAGE_BIN} --limits-only; npx ccusage@latest blocks --json",
+                       detail=[fallback_note,
+                               "A missing tool is not the same as no constraint: the budget "
+                               "still exists, it just cannot be read here."],
+                       remedy="Install the omarchy Claude usage plugin, or ccusage, so a cycle "
+                              "can be paced against a measured figure rather than a guess.")
+
+
+def check_corpus(repo: str, enabled: bool) -> CheckResult:
+    """The skill's step 1: the corpus is the known-good baseline, and its expected
+    count is checked in at tests/expectations/count-baseline/.
+
+    Off by default because it is a multi-minute run and this script is meant to be
+    run before every cycle; --with-corpus turns it on. A SKIP is reported as a
+    SKIP, never folded into the passing count, so nobody reads a green preflight
+    as "the baseline reproduced".
+    """
+    baseline = os.path.join(repo, "tests/expectations/count-baseline/test-count-baseline.json")
+    if not enabled:
+        return CheckResult(name="corpus-baseline", status="SKIP",
+                           summary="not run (multi-minute); pass --with-corpus to run it",
+                           command="tools/preflight.py --with-corpus",
+                           detail=[f"expected counts live in {os.path.relpath(baseline, repo)}",
+                                   "A box that cannot reproduce the corpus baseline produces "
+                                   "results that cannot be trusted - notably a shared cache "
+                                   "left inconsistent by a killed run, which once cost 76% of "
+                                   "passing tests with no error and an unchanged exit code."],
+                           remedy="Run it at least once on a fresh or drifted box, against the "
+                                  "SHARED cache the work will actually use - a private cache is "
+                                  "blind to exactly the failure this catches.")
+    if not os.path.exists(baseline):
+        return CheckResult(name="corpus-baseline", status="FAIL",
+                           summary=f"no baseline file at {baseline}",
+                           command=f"ls {baseline}",
+                           remedy="Check out the repository fully, including tests/expectations.")
+    r = run(["dotnet", "run", "--project", "AlRunner", "--", "test",
+             "--bundle", "tests/al-language", "--package-cache",
+             os.path.expanduser("~/.al-runner/platform-apps")],
+            cwd=repo, timeout=3600)
+    if r.ok:
+        return CheckResult(name="corpus-baseline", status="PASS",
+                           summary="the corpus baseline reproduced on this box",
+                           command="dotnet run --project AlRunner -- test --bundle "
+                                   "tests/al-language --package-cache ~/.al-runner/platform-apps")
+    tail = "\n".join((r.out + r.err).strip().splitlines()[-15:])
+    return CheckResult(name="corpus-baseline", status="FAIL",
+                       summary="the corpus baseline did NOT reproduce - everything downstream "
+                               "is untrusted until it does",
+                       command="dotnet run --project AlRunner -- test --bundle tests/al-language",
+                       detail=[tail],
+                       remedy="Stop, notify, and open an issue. Do not start a cycle on a box "
+                              "whose baseline does not reproduce.")
+
+
+# --------------------------------------------------------------------------
+# the reaper
+# --------------------------------------------------------------------------
+def reap(repo: str, rows: list[tuple], dry_run: bool) -> list[str]:
+    """Remove worktrees whose PR is MERGED and whose tree is clean.
+
+    Two traps, both hit for real:
+
+    1. `git worktree remove` refuses with "working trees containing submodules
+       cannot be moved or removed" once anyone has run `git submodule update
+       --init` inside it. The fix is NOT `git submodule deinit`: that rewrites
+       submodule.*.url in the SHARED .git/config and would disturb the main
+       checkout and every other live worktree. Deleting the submodule directory
+       and then --force is what works, and it touches only this worktree.
+    2. Never remove a worktree carrying uncommitted work or unpushed commits.
+       disposition() has already refused those; this re-checks immediately before
+       deleting, because the census may be minutes old by now.
+    """
+    log: list[str] = []
+    for wt, pr, dirty, unpushed, d, exists in rows:
+        if not d.reapable:
+            continue
+        st = run(["git", "-C", wt.path, "status", "--porcelain"], timeout=60)
+        if not st.ok or st.out.strip():
+            log.append(f"SKIP  {wt.path} - it became dirty since the census")
+            continue
+        if dry_run:
+            log.append(f"WOULD REMOVE  {wt.path}  [{wt.branch}]  {d.reason}")
+            continue
+        r = run(["git", "-C", repo, "worktree", "remove", wt.path], timeout=120)
+        if r.ok:
+            log.append(f"REMOVED  {wt.path}  [{wt.branch}]")
+            continue
+        if "submodule" in (r.err + r.out).lower():
+            removed_any = False
+            for sub in submodule_paths(wt.path):
+                target = os.path.join(wt.path, sub)
+                if os.path.isdir(target):
+                    shutil.rmtree(target, ignore_errors=True)
+                    removed_any = True
+            r2 = run(["git", "-C", repo, "worktree", "remove", "--force", wt.path], timeout=120)
+            if r2.ok:
+                log.append(f"REMOVED  {wt.path}  [{wt.branch}] (after clearing "
+                           f"{'submodule directories' if removed_any else 'nothing'}; "
+                           f"submodule deinit deliberately NOT used - it edits the shared "
+                           f".git/config)")
+            else:
+                log.append(f"FAILED   {wt.path} - {(r2.err or r2.out).strip()[:200]}")
+        else:
+            log.append(f"FAILED   {wt.path} - {(r.err or r.out).strip()[:200]}")
+    if not log:
+        log.append("nothing to reap")
+    return log
+
+
+def submodule_paths(worktree: str) -> list[str]:
+    gitmodules = os.path.join(worktree, ".gitmodules")
+    if not os.path.exists(gitmodules):
+        return []
+    r = run(["git", "config", "--file", gitmodules, "--get-regexp", r"^submodule\..*\.path$"])
+    if not r.ok:
+        return []
+    return [line.split(" ", 1)[1].strip() for line in r.out.splitlines() if " " in line]
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+def default_identity() -> str:
+    r = run(["gh", "api", "user", "--jq", ".login"], timeout=20) if shutil.which("gh") \
+        else Ran(rc=1, out="", err="")
+    login = r.out.strip() if r.ok else ""
+    return re.sub(r"[^A-Za-z0-9._-]", "-", login or os.environ.get("USER", "unknown"))
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    epilog = "exit codes:\n" + "\n".join(f"  {k}  {v}" for k, v in sorted(EXIT_MEANING.items()))
+    ap = argparse.ArgumentParser(
+        description=__doc__.split("\n\n")[0],
+        epilog=epilog, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    ap.add_argument("--strict", action="store_true",
+                    help="exit 2 when a check WARNs, even if nothing failed")
+    ap.add_argument("--with-test-data", action="store_true",
+                    help="size workers for runs that use --test-data (a larger per-worker "
+                         "footprint, so a smaller suggested worker count)")
+    ap.add_argument("--with-corpus", action="store_true",
+                    help="also run the corpus baseline (minutes, not seconds)")
+    ap.add_argument("--reap", action="store_true",
+                    help="remove worktrees whose PR is MERGED and whose tree is clean")
+    ap.add_argument("--dry-run", action="store_true", help="with --reap, only say what it would do")
+    ap.add_argument("--identity", default=None, help="agent identity used for the push probe ref")
+    ap.add_argument("--scratch-root", default=None,
+                    help="directory to scan for stale scratch (default: the system temp dir)")
+    ap.add_argument("--stale-hours", type=float, default=6.0,
+                    help="idle hours before a large scratch directory is called stale "
+                         "(default: 6)")
+    ap.add_argument("--skip-budget-fallback", action="store_true",
+                    help="do not fall back to `npx ccusage` when the omarchy usage tool "
+                         "is missing (it needs the network)")
+    ap.add_argument("--no-sizes", action="store_true",
+                    help="skip recursive size measurement (faster, less useful)")
+    args = ap.parse_args(argv)
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    repo = git_repo_root(here)
+    if not repo:
+        print("preflight: not inside a git repository", file=sys.stderr)
+        return 3
+    # The MAIN checkout, not whichever worktree this copy of the script lives in:
+    # the worktree census and the reaper both have to see every worktree.
+    common = run(["git", "-C", repo, "rev-parse", "--path-format=absolute",
+                  "--git-common-dir"]).out.strip()
+    if common.endswith("/.git"):
+        repo = common[:-len("/.git")]
+
+    import tempfile
+    scratch_root = args.scratch_root or tempfile.gettempdir()
+    identity = args.identity or default_identity()
+    per_worker = (PER_WORKER_BYTES_WITH_TEST_DATA if args.with_test_data
+                  else PER_WORKER_BYTES_NO_TEST_DATA)
+    per_worker_label = ("with --test-data" if args.with_test_data else "without test data")
+
+    df = run(["df", "-PT", "-B1", scratch_root, repo])
+    mounts = parse_df(df.out)
+    try:
+        with open("/proc/meminfo") as fh:
+            mem = parse_meminfo(fh.read())
+    except OSError:
+        mem = {}
+
+    slug = repo_slug(repo)
+    prs, pr_status = pr_map(slug)
+    rows = collect_worktrees(repo, prs, measure=not args.no_sizes)
+
+    results = [
+        check_space("disk-scratch", scratch_root, mounts, per_worker),
+        check_space("disk-repo", repo, mounts, per_worker),
+        check_memory(mem, per_worker),
+        check_headroom(scratch_root, repo, mounts, mem, per_worker, per_worker_label),
+        check_budget(skip_fallback=args.skip_budget_fallback),
+        check_worktrees(rows, repo, pr_status),
+        check_stale_scratch(scratch_root, rows, args.stale_hours),
+        check_push(repo, identity),
+        check_commit(repo),
+        check_github(slug),
+        check_corpus(repo, args.with_corpus),
+    ]
+    results.sort(key=lambda r: _ORDER.get(r.status, 9))
+
+    reap_log: list[str] = []
+    if args.reap:
+        reap_log = reap(repo, rows, args.dry_run)
+
+    if args.json:
+        extra = {"repo": repo, "identity": identity, "scratch_root": scratch_root,
+                 "per_worker_bytes": per_worker}
+        if args.reap:
+            extra["reap"] = reap_log
+        print(json.dumps(build_json(results, strict=args.strict, extra=extra), indent=2))
+    else:
+        now = dt.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        header = (f"AL Runner preflight - is this box fit to run an autonomous cycle?\n"
+                  f"{now}   repo {repo}   identity {identity}   scratch {scratch_root}")
+        print(render_report(results, strict=args.strict, header=header))
+        if args.reap:
+            print()
+            print("--reap:" + (" (dry run)" if args.dry_run else ""))
+            for line in reap_log:
+                print(f"  {line}")
+    return overall_exit(results, args.strict)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -408,7 +408,7 @@ def classify_space(free: int, used_pct: int, per_worker: int) -> tuple[str, str]
 
 
 def suggest_workers(*, tmp_free: int, repo_free: int, mem_available: int, cpus: int,
-                    per_worker: int) -> Suggestion:
+                    per_worker: int, scratch_label: str = "/tmp") -> Suggestion:
     """Derive a concurrent-agent count from what this box actually has.
 
     Nothing here is a constant except the per-worker footprint the caller passes
@@ -418,7 +418,11 @@ def suggest_workers(*, tmp_free: int, repo_free: int, mem_available: int, cpus: 
     no cause.
     """
     candidates = {
-        "/tmp free space": int(tmp_free // per_worker) if per_worker else 0,
+        # Named after the scratch root actually measured, not a hardcoded /tmp:
+        # a report that says "limited by /tmp free space" while measuring
+        # somewhere else sends the reader to the wrong filesystem, which is the
+        # same class of mistake as not naming the mount at all.
+        f"{scratch_label} free space": int(tmp_free // per_worker) if per_worker else 0,
         "repo filesystem free space": int(repo_free // per_worker) if per_worker else 0,
         "available RAM": int(mem_available // per_worker) if per_worker else 0,
         "CPU count": int(cpus),
@@ -686,7 +690,7 @@ def check_headroom(tmp_dir: str, repo: str, mounts: list[Mount], mem: dict,
     sug = suggest_workers(tmp_free=tmp_mount.free if tmp_mount else 0,
                           repo_free=repo_mount.free if repo_mount else 0,
                           mem_available=mem.get("MemAvailable", 0), cpus=cpus,
-                          per_worker=per_worker)
+                          per_worker=per_worker, scratch_label=tmp_dir)
     detail = [f"per-worker footprint assumed: {human(per_worker)} ({per_worker_label})",
               "each resource divided by that footprint: "
               + ", ".join(f"{k} -> {v}" for k, v in sorted(sug.detail.items()))]
@@ -769,8 +773,17 @@ def check_worktrees(rows: list[tuple], repo: str, pr_status: str) -> CheckResult
     for wt, pr, is_dirty, unpushed, d, exists in sorted(
             agents, key=lambda r: -(r[0].size_bytes or 0)):
         mark = "REAP " if d.reapable else "keep "
+        flags = []
+        if is_dirty:
+            flags.append("UNCOMMITTED CHANGES")
+        if unpushed:
+            flags.append(f"{unpushed} UNPUSHED COMMIT(S)")
+        # Shown even when the worktree is kept for an unrelated reason: unsaved
+        # work is the thing a person most needs to see in this census, and
+        # disposition() stops at the first reason it finds.
+        suffix = (" -- " + ", ".join(flags)) if flags else ""
         detail.append(f"{mark}{human(wt.size_bytes):>9}  {os.path.basename(wt.path)}  "
-                      f"[{wt.branch or 'detached'}] - {d.reason}")
+                      f"[{wt.branch or 'detached'}] - {d.reason}{suffix}")
     if pr_status != "ok":
         detail.append(f"pull-request states could not be read ({pr_status}); every worktree "
                       f"is therefore reported as merged-state unknown and kept.")
@@ -1021,11 +1034,14 @@ def check_budget(skip_fallback: bool = False) -> CheckResult:
 
     Omarchy-specific, so the binary is probed rather than assumed.
     """
-    now = dt.datetime.now(dt.timezone.utc)
     binary = OMARCHY_USAGE_BIN if os.path.exists(OMARCHY_USAGE_BIN) \
         else shutil.which("omarchy-agent-usage-claude")
     if binary:
         r = run([binary, "--limits-only"], timeout=60)
+        # `now` is taken AFTER the probe: the probe refreshes the reading, so a
+        # clock read before it makes updatedAt look like it is in the future and
+        # prints an age of "-0 min ago".
+        now = dt.datetime.now(dt.timezone.utc)
         if r.ok:
             windows, meta = parse_omarchy_limits(r.out)
             status, summary, detail = classify_budget(windows, now)
@@ -1037,7 +1053,7 @@ def check_budget(skip_fallback: bool = False) -> CheckResult:
                               f"{meta.get('todaySessions', '?')} session(s)")
             updated = _iso(meta.get("updatedAt"))
             if updated is not None:
-                age_min = (now - updated).total_seconds() / 60.0
+                age_min = max(0.0, (now - updated).total_seconds() / 60.0)
                 detail.append(f"figures measured {age_min:.0f} min ago (updatedAt "
                               f"{meta['updatedAt']})")
                 if age_min > BUDGET_STALE_MINUTES and status == "PASS":
@@ -1081,6 +1097,7 @@ def check_budget(skip_fallback: bool = False) -> CheckResult:
                                remedy="Install the omarchy usage plugin for an authoritative "
                                       "percent, or pace from the absolute figures above.",
                                data={"source": "ccusage", "active_block": block})
+    now = dt.datetime.now(dt.timezone.utc)  # noqa: F841 - kept for symmetry of the branches
     return CheckResult(name="budget", status="WARN",
                        summary="budget headroom UNKNOWN - no usage source answered",
                        command=f"{OMARCHY_USAGE_BIN} --limits-only; npx ccusage@latest blocks --json",

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -168,6 +168,15 @@ sug_none = pf.suggest_workers(tmp_free=full["/tmp"].free, repo_free=by_mp["/"].f
                               mem_available=mem["MemAvailable"], cpus=12, per_worker=PW)
 check("a box with no room for one worker suggests zero", sug_none.workers == 0, str(sug_none))
 
+# The limiting resource is named after the scratch root actually measured. A
+# report that says "/tmp" while measuring somewhere else points the reader at the
+# wrong filesystem -- the same mistake as not naming the mount at all.
+sug_named = pf.suggest_workers(tmp_free=1 * GIB, repo_free=900 * GIB,
+                               mem_available=900 * GIB, cpus=64, per_worker=PW,
+                               scratch_label="/mnt/agent-scratch")
+check("the scratch mount is named, not hardcoded as /tmp",
+      sug_named.limited_by == "/mnt/agent-scratch free space", sug_named.limited_by)
+
 # --------------------------------------------------- worktree list parsing
 print()
 print("preflight.py -- git worktree list parsing")
@@ -419,6 +428,145 @@ check("no active block returns None rather than a fabricated zero",
 check("unparseable ccusage output returns None", pf.parse_ccusage_blocks("not json") is None)
 check("unparseable omarchy output yields no windows, not a fake zero-usage one",
       pf.parse_omarchy_limits("not json") == ([], {}))
+
+# ------------------------------------------------- the census a person reads
+print()
+print("preflight.py -- the worktree census")
+
+
+def row(path, branch, pr, dirty=False, unpushed=0, size=100 * 1024 * 1024,
+        is_main=False, exists=True, is_current=False):
+    w = pf.Worktree(path=path, head="a" * 40, branch=branch, detached=branch is None,
+                    is_main=is_main, size_bytes=size)
+    d = pf.disposition(w, pr=pr, dirty=dirty, unpushed=unpushed, is_current=is_current)
+    return (w, pr, dirty, unpushed, d, exists)
+
+
+rows = [
+    row("/r", "main", None, is_main=True),
+    row("/r/.claude/worktrees/a", "agent/x/issue-1", MERGED),
+    row("/r/.claude/worktrees/b", "agent/x/issue-2", OPEN, dirty=True),
+    row("/r/.claude/worktrees/c", "agent/x/issue-3", MERGED, unpushed=2),
+]
+r = pf.check_worktrees(rows, "/r", "ok")
+body = "\n".join([r.summary] + r.detail + [r.remedy])
+check("the main checkout is excluded from the agent count", "3 agent worktree" in r.summary,
+      r.summary)
+check("a reapable worktree is counted", "1 reapable" in r.summary, r.summary)
+check("uncommitted work is counted in the summary", "1 with uncommitted work" in r.summary,
+      r.summary)
+check("the reapable one is marked REAP", "REAP" in body, body)
+# A worktree kept for an unrelated reason (its PR is open) must still show that
+# it holds unsaved work: disposition() stops at the first reason it finds, and
+# unsaved work is what a person most needs out of this census.
+check("uncommitted work is visible even when the worktree is kept for another reason",
+      "UNCOMMITTED CHANGES" in body, body)
+check("unpushed commits are visible on their own line", "UNPUSHED COMMIT" in body, body)
+check("having something to reap is a WARN, not silence", r.status == "WARN", r.status)
+check("...and the remedy names the reaper", "--reap" in r.remedy, r.remedy)
+check("...and cites why nothing ever deleting these matters", "82 worktrees" in r.remedy,
+      r.remedy)
+
+r = pf.check_worktrees(rows, "/r", "gh pr list failed: boom")
+check("unreadable PR states make the census WARN rather than silently reap",
+      r.status == "WARN", r.status)
+check("...and say the merged state is unknown",
+      any("could not be read" in d for d in r.detail), str(r.detail))
+
+r = pf.check_worktrees([row("/r", "main", None, is_main=True),
+                        row("/r/.claude/worktrees/b", "agent/x/issue-2", OPEN)], "/r", "ok")
+check("a tidy box with only live worktrees passes", r.status == "PASS", r.status)
+
+# ------------------------------------------------------ the reaper (real git)
+print()
+print("preflight.py -- the reaper (real git, including the submodule refusal)")
+
+tmp = tempfile.mkdtemp(prefix="preflight-reap-")
+try:
+    env = dict(os.environ,
+               GIT_AUTHOR_NAME="t", GIT_AUTHOR_EMAIL="t@e",
+               GIT_COMMITTER_NAME="t", GIT_COMMITTER_EMAIL="t@e",
+               GIT_CONFIG_GLOBAL=os.path.join(tmp, "nogitconfig"),
+               GIT_CONFIG_SYSTEM=os.path.join(tmp, "nogitconfig"))
+
+    sub = os.path.join(tmp, "sub")
+    os.makedirs(sub)
+    git("init", "-q", "-b", "master", cwd=sub, env=env)
+    open(os.path.join(sub, "s.txt"), "w").write("sub\n")
+    git("add", "s.txt", cwd=sub, env=env)
+    git("commit", "-qm", "sub", cwd=sub, env=env)
+
+    repo = os.path.join(tmp, "main")
+    os.makedirs(repo)
+    git("init", "-q", "-b", "main", cwd=repo, env=env)
+    open(os.path.join(repo, "a.txt"), "w").write("one\n")
+    git("add", "a.txt", cwd=repo, env=env)
+    git("commit", "-qm", "base", cwd=repo, env=env)
+    # file:// submodules are refused by default since the CVE-2022-39253 fix.
+    git("-c", "protocol.file.allow=always", "submodule", "add", "-q", sub, "tests/al-language",
+        cwd=repo, env=env)
+    git("commit", "-qm", "add submodule", cwd=repo, env=env)
+
+    git("branch", "feature", cwd=repo, env=env)
+    wt_path = os.path.join(tmp, "wt")
+    git("worktree", "add", "-q", wt_path, "feature", cwd=repo, env=env)
+    head = git("rev-parse", "HEAD", cwd=wt_path, env=env).stdout.strip()
+    # This is the step that makes the worktree unremovable.
+    git("-c", "protocol.file.allow=always", "submodule", "update", "--init", "-q",
+        cwd=wt_path, env=env)
+
+    refusal = subprocess.run(["git", "worktree", "remove", wt_path], cwd=repo, env=env,
+                             capture_output=True, text=True)
+    check("plain `git worktree remove` refuses a worktree with an initialised submodule",
+          refusal.returncode != 0 and "submodule" in (refusal.stderr + refusal.stdout).lower(),
+          f"rc={refusal.returncode} {refusal.stderr.strip()[:200]}")
+
+    check("submodule_paths reads .gitmodules",
+          pf.submodule_paths(wt_path) == ["tests/al-language"], str(pf.submodule_paths(wt_path)))
+
+    w = pf.Worktree(path=wt_path, head=head, branch="feature", detached=False, is_main=False)
+    pr = {"number": 7, "state": "MERGED", "headRefOid": head}
+    d = pf.disposition(w, pr=pr, dirty=False, unpushed=0)
+    rows = [(w, pr, False, 0, d, True)]
+
+    dry = pf.reap(repo, rows, dry_run=True)
+    check("--dry-run removes nothing", os.path.isdir(wt_path), "the worktree is gone")
+    check("...and says what it would do", any("WOULD REMOVE" in l for l in dry), str(dry))
+
+    # The shared .git/config must be untouched: `git submodule deinit` rewrites
+    # submodule.*.url there, which would disturb the main checkout and every
+    # other live worktree of the same repository.
+    shared_config = open(os.path.join(repo, ".git", "config")).read()
+
+    log = pf.reap(repo, rows, dry_run=False)
+    check("the reaper removes it anyway, working around the submodule refusal",
+          not os.path.isdir(wt_path), str(log))
+    check("...and says so", any("REMOVED" in l for l in log), str(log))
+    check("...and records that submodule deinit was deliberately not used",
+          any("deinit" in l for l in log), str(log))
+    check("the SHARED .git/config is byte-for-byte unchanged",
+          open(os.path.join(repo, ".git", "config")).read() == shared_config,
+          "the reaper edited config other worktrees share")
+    check("the submodule source repository is untouched",
+          os.path.exists(os.path.join(sub, "s.txt")))
+
+    # And it must refuse work that appeared since the census was taken.
+    wt2 = os.path.join(tmp, "wt2")
+    git("branch", "feature2", cwd=repo, env=env)
+    git("worktree", "add", "-q", wt2, "feature2", cwd=repo, env=env)
+    w2 = pf.Worktree(path=wt2, head=head, branch="feature2", detached=False, is_main=False)
+    pr2 = {"number": 8, "state": "MERGED", "headRefOid": head}
+    rows2 = [(w2, pr2, False, 0, pf.disposition(w2, pr=pr2, dirty=False, unpushed=0), True)]
+    open(os.path.join(wt2, "scratch.txt"), "w").write("work done after the census\n")
+    log2 = pf.reap(repo, rows2, dry_run=False)
+    check("a worktree that became dirty since the census is NOT removed",
+          os.path.isdir(wt2), str(log2))
+    check("...and the reason says why", any("became dirty" in l for l in log2), str(log2))
+
+    check("nothing to reap says so rather than printing an empty list",
+          pf.reap(repo, [], dry_run=False) == ["nothing to reap"])
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
 
 # ---------------------------------------------------------------- exit codes
 print()

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/preflight.py's parsing, threshold and disposition logic.
+
+preflight.py decides whether a box is fit to run an autonomous cycle, so its
+verdicts are proven here against *captured* `df` / `/proc/meminfo` /
+`git worktree list --porcelain` output rather than against whatever the machine
+running the tests happens to look like. A threshold suite that reads the live box
+passes for the wrong reason on a healthy one and cannot be made to fail on demand.
+
+The one test that does touch a real git repository builds its own throwaway one:
+`test_squash_merge_trap` squash-merges a branch and proves that
+`git merge-base --is-ancestor` -- the merged-test a reaper reaches for first --
+reports the merged branch as unmerged. That has to be real git, because the whole
+point is that the trap is invisible in a hand-written fixture.
+
+Run: python3 tools/test_preflight.py
+"""
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location("preflight", os.path.join(HERE, "preflight.py"))
+pf = importlib.util.module_from_spec(_spec)
+# Registered before exec: @dataclass resolves its own module through
+# sys.modules[cls.__module__], and on Python 3.14 an unregistered module makes
+# that lookup return None and the decorator raise.
+sys.modules["preflight"] = pf
+_spec.loader.exec_module(pf)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+GIB = 1024 ** 3
+
+# ---------------------------------------------------------------- df parsing
+# Captured verbatim from the box the incident happened on:
+#   df -PT -B1 /tmp /home/stefan/Documents/Repos/Comunity/BusinessCentral.AL.Runner
+DF_HEALTHY = """\
+Filesystem       Type      1-blocks         Used    Available Capacity Mounted on
+tmpfs            tmpfs    8222150656   1179975680   7042174976      15% /tmp
+/dev/mapper/root btrfs  509943480320  82476822528 426615525376      17% /
+"""
+
+# The same box mid-incident: /tmp at 80% before cleanup, and then the state that
+# actually broke every shell on the machine (EDQUOT on a full tmpfs).
+DF_FULL_TMP = """\
+Filesystem       Type      1-blocks         Used    Available Capacity Mounted on
+tmpfs            tmpfs    8222150656   8140000000     82150656      99% /tmp
+/dev/mapper/root btrfs  509943480320  82476822528 426615525376      17% /
+"""
+
+print("preflight.py -- df parsing")
+
+mounts = pf.parse_df(DF_HEALTHY)
+by_mp = {m.mountpoint: m for m in mounts}
+check("both mounts parsed", set(by_mp) == {"/tmp", "/"}, str(sorted(by_mp)))
+check("/tmp is recognised as tmpfs", by_mp["/tmp"].fstype == "tmpfs", by_mp["/tmp"].fstype)
+check("/tmp free bytes are exact", by_mp["/tmp"].free == 7042174976, str(by_mp["/tmp"].free))
+check("/tmp total bytes are exact", by_mp["/tmp"].total == 8222150656, str(by_mp["/tmp"].total))
+check("/tmp used percent is exact", by_mp["/tmp"].used_pct == 15, str(by_mp["/tmp"].used_pct))
+check("the repo filesystem is not tmpfs", by_mp["/"].fstype == "btrfs", by_mp["/"].fstype)
+check("a device name with a slash does not break the split",
+      by_mp["/"].device == "/dev/mapper/root", by_mp["/"].device)
+
+# A df line for a mountpoint containing a space must keep the whole path.
+spaced = pf.parse_df(
+    "Filesystem Type 1-blocks Used Available Capacity Mounted on\n"
+    "tmpfs tmpfs 100 10 90 10% /mnt/my disk\n")
+check("a mountpoint containing a space survives parsing",
+      spaced[0].mountpoint == "/mnt/my disk", spaced[0].mountpoint)
+
+# ------------------------------------------------------- mount for a path
+print()
+print("preflight.py -- which filesystem holds a path")
+check("/tmp/x resolves to the tmpfs, not to /",
+      pf.mount_for_path("/tmp/x/y", mounts).mountpoint == "/tmp")
+check("a repo path under /home resolves to /",
+      pf.mount_for_path("/home/stefan/repo", mounts).mountpoint == "/")
+check("the longest matching mountpoint wins, not the first",
+      pf.mount_for_path("/tmp", mounts).mountpoint == "/tmp")
+check("a path on no known mount returns None", pf.mount_for_path("relative/path", []) is None)
+
+# ------------------------------------------------------------ disk thresholds
+print()
+print("preflight.py -- disk thresholds")
+PW = pf.PER_WORKER_BYTES_NO_TEST_DATA
+
+check("a 7 GiB-free tmpfs at 15% passes",
+      pf.classify_space(by_mp["/tmp"].free, by_mp["/tmp"].used_pct, PW)[0] == "PASS")
+check("a 400 GiB-free root at 17% passes",
+      pf.classify_space(by_mp["/"].free, by_mp["/"].used_pct, PW)[0] == "PASS")
+
+full = {m.mountpoint: m for m in pf.parse_df(DF_FULL_TMP)}
+st, why = pf.classify_space(full["/tmp"].free, full["/tmp"].used_pct, PW)
+check("the tmpfs that broke the box FAILs", st == "FAIL", f"{st} {why}")
+check("...and the reason names the shortfall, not just a percentage",
+      "worker" in why.lower(), why)
+
+# A big disk at 99% still has room for many workers: percentage alone must not
+# hard-fail, or every large half-full-of-something disk halts the loop.
+st, why = pf.classify_space(free=50 * GIB, used_pct=99, per_worker=PW)
+check("a 99%-used disk with 50 GiB free WARNs rather than FAILs", st == "WARN", f"{st} {why}")
+check("...and says why the percentage alone is not fatal", "50" in why or "GiB" in why, why)
+
+st, _ = pf.classify_space(free=int(1.5 * PW), used_pct=40, per_worker=PW)
+check("room for only one worker WARNs", st == "WARN", st)
+st, _ = pf.classify_space(free=int(0.9 * PW), used_pct=40, per_worker=PW)
+check("room for less than one worker FAILs", st == "FAIL", st)
+st, _ = pf.classify_space(free=int(4 * PW), used_pct=60, per_worker=PW)
+check("60% used with room for four workers passes -- 60% is not 99%", st == "PASS", st)
+
+# ---------------------------------------------------------------- meminfo
+print()
+print("preflight.py -- meminfo parsing")
+MEMINFO = """\
+MemTotal:       16058888 kB
+MemFree:         2573664 kB
+MemAvailable:    7364856 kB
+SwapTotal:      16058364 kB
+SwapFree:       14297236 kB
+"""
+mem = pf.parse_meminfo(MEMINFO)
+check("MemAvailable is converted from kB to bytes",
+      mem["MemAvailable"] == 7364856 * 1024, str(mem.get("MemAvailable")))
+check("MemTotal is converted from kB to bytes", mem["MemTotal"] == 16058888 * 1024)
+check("MemFree is not mistaken for MemAvailable", mem["MemFree"] != mem["MemAvailable"])
+
+# ------------------------------------------------------- derived worker count
+print()
+print("preflight.py -- derived worker count")
+sug = pf.suggest_workers(tmp_free=by_mp["/tmp"].free, repo_free=by_mp["/"].free,
+                         mem_available=mem["MemAvailable"], cpus=12, per_worker=PW)
+check("the suggestion is derived, not hardcoded", sug.workers == min(
+    int(by_mp["/tmp"].free // PW), int(by_mp["/"].free // PW),
+    int(mem["MemAvailable"] // PW), 12), str(sug.workers))
+check("the smallest resource is named as the limit", sug.limited_by == "/tmp free space",
+      sug.limited_by)
+
+# Same box, but with test data: the per-worker cost roughly doubles, so the
+# suggestion must fall. A hardcoded number would not move.
+sug_td = pf.suggest_workers(tmp_free=by_mp["/tmp"].free, repo_free=by_mp["/"].free,
+                            mem_available=mem["MemAvailable"], cpus=12,
+                            per_worker=pf.PER_WORKER_BYTES_WITH_TEST_DATA)
+check("a bigger per-worker footprint yields fewer workers", sug_td.workers < sug.workers,
+      f"{sug_td.workers} vs {sug.workers}")
+
+sug_cpu = pf.suggest_workers(tmp_free=900 * GIB, repo_free=900 * GIB,
+                             mem_available=900 * GIB, cpus=4, per_worker=PW)
+check("with unlimited disk and RAM the CPU count is the limit",
+      sug_cpu.workers == 4 and sug_cpu.limited_by == "CPU count", str(sug_cpu))
+
+sug_none = pf.suggest_workers(tmp_free=full["/tmp"].free, repo_free=by_mp["/"].free,
+                              mem_available=mem["MemAvailable"], cpus=12, per_worker=PW)
+check("a box with no room for one worker suggests zero", sug_none.workers == 0, str(sug_none))
+
+# --------------------------------------------------- worktree list parsing
+print()
+print("preflight.py -- git worktree list parsing")
+WORKTREES = """\
+worktree /home/stefan/repo
+HEAD 1a60f505ef03ae56b8172b0563c22fd0b4ab7356
+branch refs/heads/main
+
+worktree /home/stefan/repo/.claude/worktrees/stma-auto-1-issue-2858
+HEAD c4a6fa86a6c750952af9dd0d61935124dda5a5b4
+branch refs/heads/agent/stma-auto-1/issue-2858
+
+worktree /home/stefan/repo/.claude/worktrees/stma-auto-1-issue-2907
+HEAD 55a16035000000000000000000000000000000aa
+branch refs/heads/agent/stma-auto-1/issue-2907
+
+worktree /tmp/scratch/rev-a
+HEAD ec02626700000000000000000000000000000bbb
+detached
+
+"""
+wts = pf.parse_worktree_porcelain(WORKTREES)
+check("every worktree is parsed", len(wts) == 4, str(len(wts)))
+check("the first entry is the main checkout", wts[0].is_main and wts[0].branch == "main")
+check("agent worktrees are not main", not any(w.is_main for w in wts[1:]))
+check("a detached worktree has no branch", wts[3].branch is None and wts[3].detached)
+check("branch refs are shortened",
+      wts[1].branch == "agent/stma-auto-1/issue-2858", str(wts[1].branch))
+check("HEAD sha is captured", wts[1].head == "c4a6fa86a6c750952af9dd0d61935124dda5a5b4")
+
+# ------------------------------------------------- worktree disposition
+print()
+print("preflight.py -- worktree disposition (what may be reaped)")
+
+
+def wt(path="/w/x", branch="agent/a/issue-1", head="a" * 40, is_main=False):
+    return pf.Worktree(path=path, head=head, branch=branch, detached=False, is_main=is_main)
+
+
+MERGED = {"number": 2859, "state": "MERGED", "headRefOid": "a" * 40}
+OPEN = {"number": 2860, "state": "OPEN", "headRefOid": "a" * 40}
+CLOSED = {"number": 2861, "state": "CLOSED", "headRefOid": "a" * 40}
+
+d = pf.disposition(wt(), pr=MERGED, dirty=False, unpushed=0)
+check("merged PR + clean tree is reapable", d.reapable, d.reason)
+check("...and the reason names the PR", "2859" in d.reason, d.reason)
+
+d = pf.disposition(wt(), pr=OPEN, dirty=False, unpushed=0)
+check("an open PR is never reaped", not d.reapable, d.reason)
+
+d = pf.disposition(wt(), pr=CLOSED, dirty=False, unpushed=0)
+check("a closed-unmerged PR is never reaped", not d.reapable, d.reason)
+
+d = pf.disposition(wt(), pr=None, dirty=False, unpushed=0)
+check("no PR at all is never reaped", not d.reapable, d.reason)
+check("...and says the PR is unknown rather than implying it is unmerged",
+      "no pull request" in d.reason.lower() or "unknown" in d.reason.lower(), d.reason)
+
+d = pf.disposition(wt(), pr=MERGED, dirty=True, unpushed=0)
+check("uncommitted work blocks the reap even on a merged PR", not d.reapable, d.reason)
+check("...and the reason says uncommitted", "uncommitted" in d.reason.lower(), d.reason)
+
+d = pf.disposition(wt(), pr=MERGED, dirty=False, unpushed=3)
+check("unpushed commits block the reap even on a merged PR", not d.reapable, d.reason)
+check("...and the reason counts them", "3" in d.reason, d.reason)
+
+d = pf.disposition(wt(is_main=True, branch="main"), pr=MERGED, dirty=False, unpushed=0)
+check("the main checkout is never reapable", not d.reapable, d.reason)
+
+d = pf.disposition(wt(), pr=MERGED, dirty=False, unpushed=0, is_current=True)
+check("the worktree you are standing in is never reapable", not d.reapable, d.reason)
+
+d = pf.disposition(pf.Worktree(path="/w/d", head="b" * 40, branch=None, detached=True,
+                               is_main=False), pr=None, dirty=False, unpushed=0)
+check("a detached worktree has no PR to consult and is kept", not d.reapable, d.reason)
+
+# --------------------------------------------- the squash-merge trap, for real
+print()
+print("preflight.py -- the squash-merge trap (real git)")
+
+
+def git(*args, cwd, **kw):
+    return subprocess.run(["git", *args], cwd=cwd, check=True,
+                          capture_output=True, text=True, **kw)
+
+
+tmp = tempfile.mkdtemp(prefix="preflight-squash-")
+try:
+    env = dict(os.environ,
+               GIT_AUTHOR_NAME="t", GIT_AUTHOR_EMAIL="t@e",
+               GIT_COMMITTER_NAME="t", GIT_COMMITTER_EMAIL="t@e",
+               GIT_CONFIG_GLOBAL=os.path.join(tmp, "nogitconfig"),
+               GIT_CONFIG_SYSTEM=os.path.join(tmp, "nogitconfig"))
+    repo = os.path.join(tmp, "r")
+    os.makedirs(repo)
+    git("init", "-q", "-b", "main", cwd=repo, env=env)
+    open(os.path.join(repo, "a.txt"), "w").write("one\n")
+    git("add", "a.txt", cwd=repo, env=env)
+    git("commit", "-qm", "base", cwd=repo, env=env)
+
+    git("checkout", "-qb", "feature", cwd=repo, env=env)
+    open(os.path.join(repo, "b.txt"), "w").write("two\n")
+    git("add", "b.txt", cwd=repo, env=env)
+    git("commit", "-qm", "feature work", cwd=repo, env=env)
+    feature_head = git("rev-parse", "feature", cwd=repo, env=env).stdout.strip()
+
+    # Squash-merge, exactly as this repository is configured to merge:
+    #   squash_merge_commit_title=COMMIT_OR_PR_TITLE
+    #   squash_merge_commit_message=COMMIT_MESSAGES
+    git("checkout", "-q", "main", cwd=repo, env=env)
+    git("merge", "--squash", "feature", cwd=repo, env=env)
+    git("commit", "-qm", "feature work (#1)", cwd=repo, env=env)
+
+    ancestor = subprocess.run(["git", "merge-base", "--is-ancestor", feature_head, "main"],
+                              cwd=repo, env=env, capture_output=True)
+    check("git merge-base --is-ancestor reports a SQUASH-MERGED branch as unmerged",
+          ancestor.returncode != 0,
+          "the trap did not reproduce -- if git changed, the disposition test below is moot")
+
+    content = open(os.path.join(repo, "b.txt")).read()
+    check("...even though its content is demonstrably on main", content == "two\n", content)
+
+    d = pf.disposition(wt(branch="feature", head=feature_head),
+                       pr={"number": 1, "state": "MERGED", "headRefOid": feature_head},
+                       dirty=False, unpushed=0)
+    check("disposition() calls it merged anyway, because it asks the PR", d.reapable, d.reason)
+
+    # And the mirror: the PR is the authority in BOTH directions. A branch whose
+    # head IS an ancestor of main but whose PR is still open must not be reaped.
+    d = pf.disposition(wt(branch="main-ish", head=feature_head),
+                       pr={"number": 2, "state": "OPEN", "headRefOid": feature_head},
+                       dirty=False, unpushed=0)
+    check("an open PR is kept even when ancestry would say merged", not d.reapable, d.reason)
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
+
+# ------------------------------------------------------------ unpushed logic
+print()
+print("preflight.py -- unpushed detection without a remote-tracking branch")
+# After a squash merge GitHub deletes the head branch, so `git log @{u}..HEAD`
+# has no upstream to resolve. The PR's headRefOid is what still records what was
+# pushed.
+check("head == the PR's headRefOid means nothing is unpushed",
+      pf.unpushed_against_pr("a" * 40, {"headRefOid": "a" * 40}) == 0)
+check("a local head the PR never saw counts as unpushed",
+      pf.unpushed_against_pr("b" * 40, {"headRefOid": "a" * 40}) == 1)
+check("no PR record cannot prove anything was pushed",
+      pf.unpushed_against_pr("b" * 40, None) is None)
+
+# ------------------------------------------------------------------- budget
+print()
+print("preflight.py -- budget headroom")
+
+# Captured from `omarchy-agent-usage-claude --limits-only` on this box, trimmed
+# to the fields the check reads. `percent` is a FRACTION in 0..1: the producer's
+# normalize_utilization() divides by 100 when the upstream payload is
+# percent-scaled and clamps to 1.0. Measured confirmation: the session window
+# read 0.43 and then 0.48 twenty minutes later under 9-12 concurrent agents,
+# i.e. ~15 percentage points/hour.
+OMARCHY = """{"limits":[
+  {"label":"Session (5-hour)","percent":0.48,"resetsAt":"2026-09-05T21:30:00.037631+00:00"},
+  {"label":"Weekly (7-day)","percent":0.17,"resetsAt":"2026-09-07T19:00:00.037651+00:00"},
+  {"label":"Fable Weekly","percent":0.0,"resetsAt":""}],
+  "tierLabel":"Max 20x","todayTotalTokens":813800459,"todayPrompts":4998,"todaySessions":3,
+  "updatedAt":"2026-09-05T20:27:46Z"}"""
+
+NOW = pf._iso("2026-09-05T20:30:00+00:00")
+windows, meta = pf.parse_omarchy_limits(OMARCHY)
+by_label = {w.label: w for w in windows}
+check("every limit window is parsed", len(windows) == 3, str(len(windows)))
+check("0.48 is read as 48% used, not 0.48% and not 4800%",
+      abs(by_label["Session (5-hour)"].fraction - 0.48) < 1e-9,
+      str(by_label["Session (5-hour)"].fraction))
+check("the reset time is parsed as an aware datetime",
+      by_label["Session (5-hour)"].resets_at is not None
+      and by_label["Session (5-hour)"].resets_at.tzinfo is not None)
+check("minutes-to-reset is computed, not just the percentage",
+      abs(by_label["Session (5-hour)"].minutes_left(NOW) - 60.0) < 1.0,
+      str(by_label["Session (5-hour)"].minutes_left(NOW)))
+check("an empty resetsAt yields no reset time rather than a crash",
+      by_label["Fable Weekly"].resets_at is None)
+check("the plan tier is carried through for the box profile",
+      meta.get("tierLabel") == "Max 20x", str(meta))
+
+# If the producer ever switches to emitting 48.0 for 48%, that must not render
+# as 4800% used and trip the warning.
+alt, _ = pf.parse_omarchy_limits('{"limits":[{"label":"S","percent":48.0,"resetsAt":""}]}')
+check("a value above 1.0 is read as an already-scaled percentage",
+      abs(alt[0].fraction - 0.48) < 1e-9, str(alt[0].fraction))
+
+st, summary, detail = pf.classify_budget(windows, NOW)
+check("48% used with an hour left is not a failure", st == "PASS", f"{st} {summary}")
+check("budget is never a HARD fail -- an exhausted budget yields no answers, "
+      "not wrong ones", st != "FAIL", st)
+check("the report gives wall-clock, not only a percentage",
+      any("resets in" in d for d in detail), str(detail))
+check("...and derives a sustainable burn rate from the two together",
+      any("%/hour" in d for d in detail), str(detail))
+
+# The derivation has to move with the clock: the same 48% is a different
+# situation with four hours left than with one.
+LATER = pf._iso("2026-09-05T21:15:00+00:00")
+_, _, d_soon = pf.classify_budget([by_label["Session (5-hour)"]], LATER)
+_, _, d_far = pf.classify_budget([by_label["Session (5-hour)"]], NOW)
+
+
+def burn(lines):
+    return float(lines[0].split("sustainable from here: ")[1].split("%/hour")[0])
+
+
+check("less wall-clock left means a higher sustainable burn is required",
+      burn(d_soon) > burn(d_far), f"{burn(d_soon)} vs {burn(d_far)}")
+
+hot = [pf.BudgetWindow("Session (5-hour)", 0.93, NOW + dt.timedelta(minutes=90))]
+st, summary, detail = pf.classify_budget(hot, NOW)
+check("a nearly-consumed window WARNs", st == "WARN", f"{st} {summary}")
+check("...and names the window in the summary", "Session" in summary, summary)
+
+st, summary, _ = pf.classify_budget([], NOW)
+check("no usage source is UNKNOWN, and UNKNOWN is not PASS", st == "WARN", st)
+check("...and says so rather than implying there is no constraint",
+      "UNKNOWN" in summary, summary)
+
+# --- ccusage fallback. Captured from a real `npx ccusage@latest blocks --json`.
+# Note there is no percentage field anywhere in the JSON: the misleading `%`
+# column exists only in the table rendering, so parsing --json cannot repeat the
+# mistake of reading it as the plan cap.
+CCUSAGE = """{"blocks":[
+ {"id":"a","isActive":false,"isGap":false,"totalTokens":349104370,"costUSD":227.018,
+  "startTime":"2026-09-05T11:00:00.000Z","endTime":"2026-09-05T16:00:00.000Z",
+  "projection":null,"burnRate":null},
+ {"id":"b","isActive":true,"isGap":false,"totalTokens":513488037,"costUSD":332.137,
+  "startTime":"2026-09-05T16:00:00.000Z","endTime":"2026-09-05T21:00:00.000Z",
+  "projection":{"remainingMinutes":28,"totalCost":366.4,"totalTokens":566459665},
+  "burnRate":{"costPerHour":73.42,"tokensPerMinute":1891847.4}}]}"""
+
+block = pf.parse_ccusage_blocks(CCUSAGE)
+check("the ACTIVE block is selected, not the first", block["totalTokens"] == 513488037, str(block))
+check("absolute tokens are read", block["totalTokens"] == 513488037)
+check("cost is read", abs(block["costUSD"] - 332.137) < 1e-6)
+check("remaining minutes come from the projection", block["remainingMinutes"] == 28)
+check("no percentage is extracted from ccusage at all -- its %% column is a guess",
+      not any("percent" in k.lower() or k == "%" for k in block), str(list(block)))
+
+check("a gap block is never treated as the active block",
+      pf.parse_ccusage_blocks('{"blocks":[{"isActive":true,"isGap":true}]}') is None)
+check("no active block returns None rather than a fabricated zero",
+      pf.parse_ccusage_blocks('{"blocks":[{"isActive":false}]}') is None)
+check("unparseable ccusage output returns None", pf.parse_ccusage_blocks("not json") is None)
+check("unparseable omarchy output yields no windows, not a fake zero-usage one",
+      pf.parse_omarchy_limits("not json") == ([], {}))
+
+# ---------------------------------------------------------------- exit codes
+print()
+print("preflight.py -- exit codes")
+
+
+def res(status, name="x"):
+    return pf.CheckResult(name=name, status=status, summary="s", command="c")
+
+
+check("all PASS exits 0", pf.overall_exit([res("PASS"), res("PASS")]) == 0)
+check("a SKIP does not fail the run", pf.overall_exit([res("PASS"), res("SKIP")]) == 0)
+check("a WARN alone exits 0 by default", pf.overall_exit([res("PASS"), res("WARN")]) == 0)
+check("a WARN alone exits 2 under --strict",
+      pf.overall_exit([res("PASS"), res("WARN")], strict=True) == 2)
+check("any FAIL exits 1", pf.overall_exit([res("PASS"), res("WARN"), res("FAIL")]) == 1)
+check("FAIL outranks WARN under --strict too",
+      pf.overall_exit([res("WARN"), res("FAIL")], strict=True) == 1)
+check("an empty result set is not silently green", pf.overall_exit([]) == 3)
+
+# ---------------------------------------------------------------- the report
+print()
+print("preflight.py -- the report a person reads")
+disk = pf.CheckResult(
+    name="disk-tmp", status="PASS",
+    summary="/tmp: 6.6 GiB free of 7.7 GiB (15% used), fstype tmpfs",
+    command="df -PT -B1 /tmp",
+    detail=["/tmp is a tmpfs: it is RAM, and it is NOT the filesystem holding the repo."])
+text = pf.render_report([disk], strict=False)
+check("the report names the mount point", "/tmp" in text, text)
+check("the report names the filesystem type -- the fact the incident turned on",
+      "tmpfs" in text, text)
+check("the report shows the command that produced the number", "df -PT" in text, text)
+
+failing = pf.CheckResult(name="push", status="FAIL", summary="push was refused",
+                         command="git push --dry-run origin HEAD:refs/heads/probe",
+                         remedy="Re-authenticate: gh auth login, or fix the credential helper.")
+text = pf.render_report([failing], strict=False)
+check("a FAIL is rendered as FAIL", "FAIL" in text)
+check("a FAIL tells the reader what to do", "gh auth login" in text, text)
+check("the summary of a failure survives into the report", "refused" in text, text)
+
+check("every non-PASS result carries a remedy in the checks preflight builds",
+      all(r.remedy for r in [failing]), "")
+
+j = pf.build_json([disk, failing], strict=False)
+check("--json reports the exit code it would return", j["exit_code"] == 1, str(j))
+check("--json lists every check by name",
+      [c["name"] for c in j["checks"]] == ["disk-tmp", "push"], str(j))
+check("--json keeps the machine-readable status", j["checks"][1]["status"] == "FAIL")
+check("--json documents what the exit code means",
+      "exit_code_meaning" in j and j["exit_code_meaning"], str(j.get("exit_code_meaning")))
+
+print()
+if FAILURES:
+    print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")
+    sys.exit(1)
+print("all checks passed")


### PR DESCRIPTION
Closes #2911

`tools/preflight.py` — the `autonomous-cycle` skill's Preflight section as an executable check with a real exit code, plus `tools/test_preflight.py` and an ungated `pr-check.yml` job to run it.

It implements what the skill already specifies. No new policy: the prose stays as the specification and the reasoning, and the script is how it gets run.

## Why an exit code

The prose version failed, measurably. A coordinator ran ~20 agents across an evening without ever performing step 5 ("Headroom. Read free RAM and disk...") and filled `/tmp`, which on this box is a **7.7 GB tmpfs**, not the 400 GB `/` that "check disk" brings to mind. Every shell on the machine then failed without naming the cause — `echo` exited 1, `ls` exited 2, `python3 -c "print(1)"` exited 120 with "error flushing std streams", and a redirect produced a zero-byte file because the shell died between `open()` and `write()`. Three agents diagnosed it as a broken shell before a fourth surfaced `EDQUOT`. About 40 minutes lost.

So every disk number in the report names its **mount point and filesystem type**. "Disk is fine" was true of `/` and false of `/tmp` at the same moment, and that ambiguity is the whole incident.

## Exit codes

| exit | meaning |
|---|---|
| 0 | every check passed (warnings may be present) |
| 1 | at least one check FAILED — this box would produce untrustworthy results |
| 2 | `--strict` was given and at least one check WARNED (nothing failed) |
| 3 | preflight could not complete — bad usage, or no checks ran |

All four are printed by `--help` and carried in `--json` as `exit_code_meaning` plus the full `exit_codes` map. The warn/fail split is the brief's: a box at 60% disk is not a box at 99%, and a budget that runs out produces *no* answers (visible) rather than *wrong* ones (not).

## Checks

`disk-scratch`, `disk-repo`, `memory`, `headroom`, `budget`, `worktrees`, `stale-scratch`, `push`, `commit`, `github`, `corpus-baseline`.

Nothing is hardcoded downstream of measurement. Each resource is divided by the per-worker footprint the skill offers as a starting point (1.1 GiB, or 2.3 GiB under `--with-test-data`) and the smallest wins, so the report names the resource that is actually limiting:

```
PASS  headroom   run at most 5 concurrent agents (limited by /tmp free space)
                 per-worker footprint assumed: 1.1 GiB (without test data)
                 each resource divided by that footprint: /tmp free space -> 5,
                 CPU count -> 12, available RAM -> 5, repo filesystem free space -> 361
```

Three checks earn their place by refusing a cheaper answer:

- **`push`** runs `git push --dry-run origin HEAD:refs/heads/preflight-probe-<identity>`. `git ls-remote` proves read only, and the skill records that push auth fails silently through an interactive credential agent. A false PASS here has happened.
- **`commit`** reports PASS when signing is off, and otherwise signs a probe commit **with a timeout**, writing objects to a throwaway `GIT_OBJECT_DIRECTORY` so nothing lands in the repository. A locked signing agent makes `git commit` hang forever rather than fail; the timeout turns "hangs" into a verdict.
- **`corpus-baseline`** is `SKIP` unless `--with-corpus`, and reported as SKIP rather than folded into the passing count, so nobody reads a green preflight as "the baseline reproduced".

## Budget headroom

Layered, and a missing tool is never read as "no constraint":

1. `omarchy-agent-usage-claude --limits-only` — authoritative percent and reset time.
2. `npx ccusage@latest blocks --json` — absolute tokens and cost for the active 5-hour block.
3. `UNKNOWN`, reported as a precondition.

Two things worth flagging:

**The `percent` field is a fraction in 0..1, and the code says how that was established** rather than assuming. The producer's `normalize_utilization()` divides by 100 when the upstream payload is percent-scaled and clamps to 1.0; independently, the session window read 0.43 and then 0.48 twenty minutes later under 9–12 concurrent agents — 15 percentage points/hour, matching the burn measured separately. A value above 1.0 is treated as already-scaled, so a future convention change renders as 48%, not 4800%.

**ccusage is read as `--json`, which structurally cannot repeat the `%`-column mistake.** The warning is that its table's `%` is measured against the largest block ccusage has ever seen rather than the plan cap. Captured from a real run, the JSON has no percentage field anywhere — only `totalTokens`, `costUSD`, `projection.remainingMinutes`, `burnRate`. Parsing the JSON is therefore not discipline, it is the absence of the field.

The check **derives** rather than printing a bare number: remaining share ÷ hours to reset gives the rate sustainable from here to the reset, which is what distinguishes 43%-with-an-hour-left from 43%-with-four-hours-left. `--json` carries the raw limits so a coordinator can record them in a box profile and derive burn across cycles.

**A question for the maintainer, deliberately not implemented.** The skill's pacing section tells the loop to obey *fixed* values in the box profile **because** it is blind to its own budget. That premise does not hold on a box with this plugin. Whether pacing should become closed-loop against the live percentage is a policy decision, so this PR only reports the number.

## The squash-merge trap

This repository squash-merges, so `git merge-base --is-ancestor <branch-head> origin/main` is the **wrong** merged-test. `disposition()` asks the pull request instead, and the code comment says why.

Confirmed live while writing this. The one reapable worktree on the box:

```
$ git merge-base --is-ancestor agent/stma-auto-1/issue-2786 origin/main
NOT an ancestor of origin/main
$ gh pr view 2837 --json state,mergedAt
PR 2837 state=MERGED mergedAt=2026-09-05T20:43:37Z
```

Ancestry would have missed the only worktree there was to reap. The failure is safe by luck in that direction; its mirror, on a repo that merges with a merge commit, deletes unmerged work. `test_squash_merge_trap` builds a throwaway repo, squash-merges a branch, and asserts both halves — that ancestry calls it unmerged, and that `disposition()` calls it merged anyway. It also asserts the reverse: an OPEN PR is kept even when ancestry would say merged, so the PR is the authority in both directions.

## The reaper

`--reap` (with `--dry-run`) removes worktrees whose PR is MERGED and whose tree is clean, and handles both traps from the brief:

- `git worktree remove` refuses with *"working trees containing submodules cannot be moved or removed"* once someone has run `git submodule update --init` inside. Worked around by deleting the submodule directory and retrying with `--force`. **Not** `git submodule deinit`, which rewrites `submodule.*.url` in the **shared** `.git/config` and would disturb the main checkout and every other live worktree. A test asserts the shared `.git/config` is byte-for-byte unchanged after a reap.
- Uncommitted or unpushed work is reported, never removed — and re-checked immediately before deletion, since the census may be minutes old. Unsaved work is also shown on the worktree's own census line even when it is being kept for an unrelated reason, because `disposition()` stops at the first reason it finds.

Unpushed detection has its own wrinkle: after a squash merge GitHub deletes the head branch, so `git log @{u}..HEAD` has no upstream left to resolve and reports nothing rather than zero. The PR's `headRefOid` is the surviving record, and `unpushed_against_pr` returns `None` — not 0 — when there is no PR, so "cannot prove anything was pushed" is never rendered as "nothing is unpushed".

## Fixing the shape, not just the reported line

Three questions, answered including where the answer was "nothing":

1. **Same wrong pattern at another call site?** No other merged-test exists in the repo — `command grep -rn "is-ancestor"` across `.py`/`.md`/`.sh`/`.yml`/`.cs` returns exactly one pre-existing hit, `.claude/rules/github-access.md:48`, and it uses the command correctly for a *different* question — confirming a specific SHA landed after a merge, not classifying a branch as merged.
2. **Does a sibling function make the same assumption?** Yes, and it is fixed: `suggest_workers` originally hardcoded the string `"/tmp free space"` for its limiting-resource label. Run with `--scratch-root /elsewhere` it reported "limited by /tmp free space" while measuring something else — the same class of mistake as not naming the mount at all. It now takes the label from the root actually measured, with a test.
3. **Two code paths writing the same state with different invariants?** The census computes `dirty`/`unpushed` once and the reaper acts on it later. Only the census enforced cleanliness; the reaper now re-checks `git status --porcelain` immediately before removing, with a test that creates a file after the census and asserts the worktree survives.

Also found and fixed while running it: `budget` printed "figures measured -0 min ago", because the clock was read *before* the probe that refreshes `updatedAt`.

## Measured on this box

`10 passed, 0 warned, 0 failed, 1 skipped`, exit 0, 48 s wall (most of it recursive sizing; `--no-sizes` skips it).

- `/tmp` → tmpfs, 6.6 GiB free of 7.7 GiB, 15% used
- repo → `/home`, btrfs, 397.2 GiB free of 474.9 GiB, 17% used — a *different mount* from `/`, which the check resolved correctly
- MemAvailable 5.7 GiB of 15.3 GiB
- headroom: **5 concurrent agents, limited by /tmp free space** — not by RAM, and nowhere near the 12 CPUs
- budget: Session (5-hour) 48% used, resets in 52 min, 60%/hour sustainable; Weekly 17% used, 1.8%/hour sustainable
- worktrees: 20 agent worktrees, 2.0 GiB, 1 reapable, 5 with uncommitted work
- push, commit (signing off), github (push access) all PASS

End-to-end exit codes verified against the live box, not only in unit tests: exit 1 from an unresolvable scratch root, exit 2 from `--strict --stale-hours 0`, exit 0 normally.

## Tests

123 assertions in `tools/test_preflight.py`, run by a new ungated `preflight.py unit tests` job in `pr-check.yml`, mirroring the existing `ci-wait.py unit tests` job.

Thresholds and parsing are tested against **captured** `df -PT -B1`, `/proc/meminfo`, `git worktree list --porcelain`, omarchy and ccusage output, so they are deterministic and can be made to fail on demand — a suite that reads the live box passes for the wrong reason on a healthy one. Two cases build a real throwaway git repository, because the things they prove are invisible in a hand-written fixture: the squash-merge trap, and the submodule refusal `git worktree remove` raises.

## Not owed upstream

Nothing here asserts anything about Business Central that a service tier could adjudicate. It is repo tooling; there is no corpus test to write.

## Left out deliberately

- **The actual reap was not run** on the live box. `--reap --dry-run` identified `stma-auto-1-issue-2786` correctly; removing another agent's worktree is the coordinator's call, and the removal path is proven by the real-git test instead.
- **No policy changed in the skill.** The only edit is one paragraph at the top of Preflight pointing at the script and listing its exit codes. Everything the skill already said is still there and still governs.
- **`ccusage` is not installed on this box**, so its fallback was exercised against a real captured `npx ccusage@latest blocks --json` payload rather than end-to-end. The omarchy path is the one that runs here, and it ran.

---
*Opened by an automated agent (`stma-auto-1`) acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
