### PR TITLE
perf(compiler): stop a layered dependency republish re-warming the package reference loader

### DIFF
--- a/AlRunner.Tests/BcCompilerWarmLoaderReuseTests.cs
+++ b/AlRunner.Tests/BcCompilerWarmLoaderReuseTests.cs
@@ -167,38 +167,60 @@ public sealed class BcCompilerWarmLoaderReuseTests : IDisposable
     }
 
     /// <summary>
-    /// The `scripts/tests/server-mode-test.sh` regression in unit form. A source dependency
-    /// recompiled from edited AL keeps its AppId, Name and Version but is republished under a
-    /// NEW content-addressed path. Nothing else moves — the scanned .app dirs are unchanged,
-    /// because a synthetic source-only package carries no SymbolReference.json and is
-    /// filtered out of the .app scan set entirely. The changed dep KEY is therefore the only
-    /// signal that the cached loader's symbols are stale, and it must rebuild: otherwise the
-    /// dependent app compiles green against the OLD schema and fails at runtime instead of
-    /// failing loudly at compile time.
+    /// The `scripts/tests/server-mode-test.sh` regression in unit form, and issue #2678's
+    /// measured cost. A source dependency recompiled from edited AL keeps its AppId, Name and
+    /// Version but is republished under a NEW content-addressed path. Nothing else moves — the
+    /// scanned .app dirs are unchanged, because a synthetic source-only package carries no
+    /// SymbolReference.json and is filtered out of the .app scan set entirely, reaching the
+    /// compile through the JSON symbol loaders instead.
+    ///
+    /// Two things must both hold, and before #2678 only the first did:
+    ///
+    ///  * CORRECTNESS — the compile must see the NEWLY published symbols, not the ones the
+    ///    cached loader indexed at construction. The JSON loaders index in their constructor,
+    ///    so something has to be rebuilt.
+    ///  * COST — the something must be the JSON chain ALONE. The package loader is built from
+    ///    the .app scan set, which is byte-identical either side of a republish (the control
+    ///    below asserts exactly that), so nothing about its answers can have gone stale — and
+    ///    rebuilding it means paying <see cref="BcCompiler.WarmReferenceLoader"/> again, which
+    ///    on a real Microsoft dep set is 36-43 s. Measured on Pageworks under `--server`
+    ///    (issue #2678): every warm edit cycle republished the layered dependency at a new
+    ///    `workspace-deps/&lt;hash&gt;` path, the dep-universe key grew, and the whole loader was
+    ///    re-warmed — 36.1 s, 39.4 s and 43.0 s on three consecutive cycles of one process.
+    ///
+    /// The sidecar content differs between the two paths, so the correctness half is a real
+    /// observation of the served symbols rather than a proxy for one: a stale chain answers
+    /// "Before Edit" and fails the test.
     /// </summary>
     [Fact]
-    public void ASymbolLessDepRepublishedAtANewPath_RebuildsTheLoader_EvenThoughTheScanSetIsIdentical()
+    public void ASymbolLessDepRepublishedAtANewPath_RefreshesTheJsonSymbols_WithoutRewarmingThePackageLoader()
     {
         // A stable .app scan set the loader is really built from…
         var pkg = MakeDir("pkg");
         var platform = WriteApps(pkg, 2);
 
-        // …plus a synthetic source-only dep, symbol-less, in a content-addressed dir.
+        // …plus a synthetic source-only dep, symbol-less, in a content-addressed dir, with a
+        // dependency sidecar the JSON loader chain serves on its behalf.
         var v1 = MakeDir("workspace-deps/9c31b7ece106");
         var dep = WriteSymbolLessApp(v1, "AL_Runner_Src_Dep_1_0_0_0.app", "Src Dep");
+        WriteDepsSidecar(v1, dep, "Before Edit");
 
         BcCompiler.SetResolvedDeps(
             platform.Append(dep).Select(a => (ManifestFor(a), PathFor(a))).ToList(),
             new[] { pkg, v1 });
-        InvokeGetSharedReferences(new[] { pkg });
+        var first = InvokeGetSharedReferences(new[] { pkg });
         Assert.Equal(1, BcCompiler.ReferenceLoaderBuildCount);
+        Assert.Equal(1, BcCompiler.JsonSymbolLoaderBuildCount);
+        Assert.Equal("Before Edit", SoleSidecarDependencyName(first.Loader!, dep));
+        var warmedAfterFirst = BcCompiler.ReferenceLoaderWarmSpecCount;
 
-        // Republish the same identity under a new content-addressed dir — exactly what the
-        // layered pre-pass does when the dep's AL changes.
+        // Republish the same identity under a new content-addressed dir, with CHANGED symbols
+        // — exactly what the layered pre-pass does when the dep's AL changes.
         var v2 = MakeDir("workspace-deps/d750c87b300c");
         var republished = Path.Combine(v2, "AL_Runner_Src_Dep_1_0_0_0.app");
         File.Copy(_files[dep.AppId], republished);
         _files[dep.AppId] = republished;
+        WriteDepsSidecar(v2, dep, "After Edit");
 
         BcCompiler.SetResolvedDeps(
             platform.Append(dep).Select(a => (ManifestFor(a), PathFor(a))).ToList(),
@@ -206,13 +228,20 @@ public sealed class BcCompilerWarmLoaderReuseTests : IDisposable
 
         // Control: the .app SCAN set really is unchanged — a symbol-less package is filtered
         // out of it, so the dedup staging key (the picked-app set) is identical either side.
-        // Without the dep key in the rule, nothing here would invalidate the loader.
+        // This is what makes reusing the package loader provably safe rather than hopeful.
         Assert.Equal(
             InvokeDedupScanSet(new List<string> { pkg, v1 }),
             InvokeDedupScanSet(new List<string> { pkg, v2 }));
 
-        InvokeGetSharedReferences(new[] { pkg });
-        Assert.Equal(2, BcCompiler.ReferenceLoaderBuildCount);
+        var second = InvokeGetSharedReferences(new[] { pkg });
+
+        // CORRECTNESS: the republished symbols are what the compile sees now.
+        Assert.Equal("After Edit", SoleSidecarDependencyName(second.Loader!, dep));
+        // COST: neither the package loader nor its warm was redone to achieve that.
+        Assert.Equal(1, BcCompiler.ReferenceLoaderBuildCount);
+        Assert.Equal(warmedAfterFirst, BcCompiler.ReferenceLoaderWarmSpecCount);
+        // …and the cheap half is what moved instead.
+        Assert.Equal(2, BcCompiler.JsonSymbolLoaderBuildCount);
     }
 
     /// <summary>
@@ -375,6 +404,22 @@ public sealed class BcCompilerWarmLoaderReuseTests : IDisposable
 
 
     // ── Helpers ───────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A <c>*.symbols.deps.json</c> sidecar for <paramref name="dep"/> declaring exactly one
+    /// dependency named <paramref name="soleDependencyName"/> — a cheap, readable-back marker
+    /// for WHICH published copy of the dep's symbols a loader chain is actually serving.
+    /// </summary>
+    private static void WriteDepsSidecar(string dir, AppFixture dep, string soleDependencyName)
+        => DepsSidecarWriter.Write(
+            Path.Combine(dir, $"{dep.Publisher}_{dep.Name}_{dep.Version}.symbols.deps.json".Replace(' ', '_')),
+            dep.Publisher, dep.Name, dep.Version, dep.AppId,
+            new[] { new DepsSidecarWriter.DepEntry(
+                "Marker", soleDependencyName, new Version(1, 0, 0, 0), Guid.NewGuid()) });
+
+    /// <summary>The single dependency name the loader chain reports for <paramref name="dep"/>.</summary>
+    private static string SoleSidecarDependencyName(ISymbolReferenceLoader loader, AppFixture dep)
+        => loader.GetDependencies(SpecFor(dep), new List<Diagnostic>()).Single().Name;
 
     private sealed record AppFixture(Guid AppId, string Name, string Publisher, Version Version);
 

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -140,12 +140,33 @@ public sealed partial class BcCompiler
     // the dep list's two real jobs are both redone per call anyway: the requested SPEC array
     // is rebuilt at the bottom of GetSharedReferences (so it really does shrink), and
     // WarmReferenceLoader is a read-only cache prefill (so a superset warm subsumes a subset
-    // one). Anything that ADDS or CHANGES a key still rebuilds, exactly as before — which
-    // matters: a source dependency recompiled from edited AL is republished under a NEW
-    // content-addressed path (`~/.cache/al-runner/workspace-deps/<hash>/…`), and that new
-    // key is what makes the next compile see the new symbols instead of the cached loader's
-    // stale ones (scripts/tests/server-mode-test.sh assertions 2+3).
+    // one). Anything that ADDS or CHANGES a key still rebuilds, exactly as before.
+    //
+    // #2678: the keys are those of the deps THIS loader can actually serve — the ones that
+    // survived the .app scan (see PackageServedDepKeys). A symbol-less synthetic package is
+    // filtered out of that scan entirely and reaches the compile through the JSON symbol
+    // loaders instead, so its path can never make this loader's answers stale, and it must
+    // not be allowed to invalidate it: the layered pre-pass republishes exactly such a
+    // package under a NEW content-addressed path (`<cache>/workspace-deps/<hash>/…`) on
+    // every warm edit cycle. Keying on it re-warmed the whole Microsoft dep set once per
+    // cycle — 36.1 s / 39.4 s / 43.0 s on three consecutive Pageworks `--server` cycles.
+    // Seeing the republished symbols is still mandatory; that is _jsonLoaderSignature's job
+    // below (scripts/tests/server-mode-test.sh assertions 2+3), and re-indexing the JSON
+    // chain costs 16-38 ms against the package loader's tens of seconds.
     private static HashSet<string>? _loaderDepUniverse;
+    // Content signature of the dirs the JSON symbol loaders index (#2678). Separate from
+    // _loaderSignature because the two halves have wildly different rebuild costs and
+    // genuinely different invalidation triggers: JSON sidecars are republished under a new
+    // path on every layered edit cycle, .app scan dirs almost never move. _extraSymbolDirs
+    // belongs HERE and only here — those dirs hold *.symbols.json only and are deliberately
+    // never handed to CreateReferenceLoader, so they cannot affect the package loader.
+    private static string? _jsonLoaderSignature;
+    // How many times the CHEAP half (JsonSymbolReferenceLoader construction, which indexes
+    // its directory eagerly) has been rebuilt. The companion to _loaderBuildCount: after
+    // #2678 a layered republish moves this counter and not that one, and a test asserting
+    // the split is what stops the fix degenerating into a chain that never re-indexes.
+    private static int _jsonLoaderBuildCount;
+    internal static int JsonSymbolLoaderBuildCount { get { lock (_refSync) return _jsonLoaderBuildCount; } }
     // How many times the expensive loader (filesystem scan + CreateReferenceLoader +
     // WarmReferenceLoader) has actually been built in this process, counting both the
     // shared superset loader and any physically-excluded fallback. The whole point of
@@ -813,8 +834,10 @@ public sealed partial class BcCompiler
             _refLoader = null;
             _refPackageLoader = null;
             _loaderSignature = null;
+            _jsonLoaderSignature = null;
             _loaderDepUniverse = null;
             _warmSpecCount = 0;
+            _jsonLoaderBuildCount = 0;
             _exclPackageLoader = null;
             _exclSignature = null;
             _exclDepUniverse = null;
@@ -1144,10 +1167,46 @@ public sealed partial class BcCompiler
             var loaderScanDirs = DeduplicateAppPackageDirs(packageDirs, null, out var scanInventory);
             Mark($"dedup-scan ({scanInventory.Count} pkgs)");
 
-            var loaderSig = ComputeLoaderSignature(loaderScanDirs, _extraSymbolDirs, null);
-            var depKeys = DepUniverseKeys(_resolvedDeps);
-            if (_refLoader == null || loaderSig != _loaderSignature
-                || !depKeys.IsSubsetOf(_loaderDepUniverse ?? new HashSet<string>(StringComparer.Ordinal)))
+            // ── Two memo halves, because they cost three orders of magnitude apart (#2678) ──
+            // PACKAGE half: CreateReferenceLoader over the .app scan set plus
+            // WarmReferenceLoader — measured at 36.1 s / 39.4 s / 43.0 s on the Pageworks dep
+            // set. JSON half: one JsonSymbolReferenceLoader per dir holding *.symbols.json,
+            // each indexing its directory in its constructor — 16-38 ms for the whole chain.
+            //
+            // They were one memo slot, keyed on a signature that mixed the .app scan dirs with
+            // the *.symbols.json dirs, and on a dep universe keyed by FILE PATH. The layered
+            // pre-pass republishes its synthetic dependency package under a new
+            // content-addressed path every warm edit cycle, so that one path grew the dep
+            // universe every cycle and dragged the package loader's full re-warm with it —
+            // paid by whichever GetSharedReferences call ran first afterwards, including the
+            // one inside TryEmitIncremental, which is what made a ~130 ms RAD delta read as a
+            // tens-of-seconds "fast path" in #2678's original measurement.
+            //
+            // Splitting them is sound rather than merely cheaper: the package loader is
+            // constructed from loaderScanDirs and nothing else, and a symbol-less package is
+            // dropped from that scan (see DeduplicateAppPackageDirs) — so a republish that
+            // leaves the scan set byte-identical provably cannot change a single answer it
+            // gives. Freshness of the republished symbols is preserved by rebuilding the JSON
+            // chain, which is the half that actually serves them.
+            var loaderSig = ComputeLoaderSignature(loaderScanDirs, null, null);
+            var depKeys = PackageServedDepKeys(_resolvedDeps, scanInventory);
+
+            // _extraSymbolDirs hold *.symbols.json ONLY and must NOT reach
+            // CreateReferenceLoader: they may contain synthetic .app files with no
+            // SymbolReference.json (written by RunLayeredPrePass), and BC reports AL1023
+            // "package not valid" for every compilation that scans one.
+            var jsonScanDirs = packageDirs.ToList();
+            if (_extraSymbolDirs != null)
+                foreach (var d in _extraSymbolDirs)
+                    if (Directory.Exists(d) && !jsonScanDirs.Contains(d, StringComparer.OrdinalIgnoreCase))
+                        jsonScanDirs.Add(d);
+            var jsonSig = string.Join("\n", jsonScanDirs.OrderBy(x => x, StringComparer.Ordinal));
+
+            var rebuildPackage = _refLoader == null || loaderSig != _loaderSignature
+                || !depKeys.IsSubsetOf(_loaderDepUniverse ?? new HashSet<string>(StringComparer.Ordinal));
+            var rebuildJson = rebuildPackage || _cachedJsonLoaders == null || jsonSig != _jsonLoaderSignature;
+
+            if (rebuildPackage || rebuildJson)
             {
                 // Chain JSON-symbols loaders for any `*.symbols.json` in the package dirs
                 // (written by EmitDepSymbols for source dependencies we compiled ourselves).
@@ -1156,12 +1215,6 @@ public sealed partial class BcCompiler
                 // runtime-loadable but compile-invisible (AL0185). JSON loaders go FIRST
                 // so they answer for those deps; they return null for everything else,
                 // falling through to the package scanner.
-                //
-                // IMPORTANT: _extraSymbolDirs are scanned for *.symbols.json ONLY — they
-                // must NOT be included in packageDirs above (passed to CreateReferenceLoader)
-                // because they may contain synthetic .app files with no SymbolReference.json
-                // (written by RunLayeredPrePass). If such an .app ends up in the .app scanner,
-                // BC reports AL1023 "package not valid" for every compilation.
                 //
                 // This block is built BEFORE the .app scanner and independently of it: with
                 // no package-cache dir at all (a bundle whose only dependency is a SIBLING
@@ -1173,17 +1226,13 @@ public sealed partial class BcCompiler
                 // "Codeunit 'X' is missing", after which BC's emitter crashes on the
                 // now-unresolved local variable type ("Unexpected value 'None' of type
                 // NavTypeKind") and the whole bundle emits zero sources.
-                var jsonScanDirs = packageDirs.ToList();
-                if (_extraSymbolDirs != null)
-                    foreach (var d in _extraSymbolDirs)
-                        if (Directory.Exists(d) && !jsonScanDirs.Contains(d, StringComparer.OrdinalIgnoreCase))
-                            jsonScanDirs.Add(d);
-
-                var jsonLoaders = jsonScanDirs
-                    .Select(d => new JsonSymbolReferenceLoader(d))
-                    .Where(l => l.HasAny)
-                    .ToList();
-                Mark("json-loaders");
+                var jsonLoaders = rebuildJson
+                    ? jsonScanDirs
+                        .Select(d => new JsonSymbolReferenceLoader(d))
+                        .Where(l => l.HasAny)
+                        .ToList()
+                    : _cachedJsonLoaders!;
+                if (rebuildJson) Mark("json-loaders");
 
                 // Nothing to serve references from at all — same no-op result as before.
                 // (Deliberately leaves _refLoader / _loaderSignature untouched, as the
@@ -1191,39 +1240,56 @@ public sealed partial class BcCompiler
                 if (loaderScanDirs.Count == 0 && jsonLoaders.Count == 0)
                     return (null, Array.Empty<NavCA.SymbolReferenceSpecification>());
 
-                _cachedJsonLoaders = jsonLoaders;
-                NavCA.ISymbolReferenceLoader? packageLoader = loaderScanDirs.Count > 0
-                    ? NavSymRef.ReferenceLoaderFactory.CreateReferenceLoader(loaderScanDirs)
-                    : null;
-                _refPackageLoader = packageLoader;
+                if (rebuildJson)
+                {
+                    _cachedJsonLoaders = jsonLoaders;
+                    _jsonLoaderSignature = jsonSig;
+                    _jsonLoaderBuildCount++;
+                }
+
+                if (rebuildPackage)
+                {
+                    _refPackageLoader = loaderScanDirs.Count > 0
+                        ? NavSymRef.ReferenceLoaderFactory.CreateReferenceLoader(loaderScanDirs)
+                        : null;
+                    _loaderBuildCount++;
+                    Mark("create-loader");
+                }
+
+                var packageLoader = _refPackageLoader;
                 if (jsonLoaders.Count > 0)
                 {
                     var chain = jsonLoaders.Cast<NavCA.ISymbolReferenceLoader>().ToList();
                     if (packageLoader != null) chain.Add(packageLoader);
-                    _refLoader = new CompositeSymbolReferenceLoader(chain);
+                    _refLoader = chain.Count == 1 ? chain[0] : new CompositeSymbolReferenceLoader(chain);
                 }
                 else
                 {
                     _refLoader = packageLoader!;
                 }
-                _loaderBuildCount++;
 
-                // Pre-warm the loader's internal package caches SEQUENTIALLY before the
-                // compiler's parallel reference-loading runs. BC's ReferenceManager fans
-                // GetDependencies out across ThreadPool workers; concurrent first-reads of
-                // the same R2R .app race inside NavAppPackageReader.CreateEmbeddedReader and
-                // wedge in an unbounded Stream.CopyTo (intermittent compile hang on bundles
-                // that pull MS test-library deps — proven gone when the process is pinned to
-                // one CPU). Warming every reachable spec here makes that later parallel phase
-                // hit warm caches instead of racing on cold file reads. Best-effort: any
-                // failure just leaves the cold-read path to the compiler as before.
-                Mark("create-loader");
-                WarmReferenceLoader(_refLoader, _resolvedDeps);
-                Mark("warm");
-                _loaderSignature = loaderSig;
-                // This instance is warm for exactly these dep keys; a later call whose deps
-                // are a subset of them reuses it (#1832).
-                _loaderDepUniverse = depKeys;
+                if (rebuildPackage)
+                {
+                    // Pre-warm the loader's internal package caches SEQUENTIALLY before the
+                    // compiler's parallel reference-loading runs. BC's ReferenceManager fans
+                    // GetDependencies out across ThreadPool workers; concurrent first-reads of
+                    // the same R2R .app race inside NavAppPackageReader.CreateEmbeddedReader and
+                    // wedge in an unbounded Stream.CopyTo (intermittent compile hang on bundles
+                    // that pull MS test-library deps — proven gone when the process is pinned to
+                    // one CPU). Warming every reachable spec here makes that later parallel phase
+                    // hit warm caches instead of racing on cold file reads. Best-effort: any
+                    // failure just leaves the cold-read path to the compiler as before.
+                    //
+                    // Only on a PACKAGE rebuild: BC's MemoryCachedSymbolReferenceLoader caches in
+                    // instance fields, so a reused package-loader instance is already warm, and a
+                    // re-indexed JSON chain has nothing to warm (it indexes in its constructor).
+                    WarmReferenceLoader(_refLoader, _resolvedDeps);
+                    Mark("warm");
+                    _loaderSignature = loaderSig;
+                    // This instance is warm for exactly these dep keys; a later call whose deps
+                    // are a subset of them reuses it (#1832).
+                    _loaderDepUniverse = depKeys;
+                }
             }
 
             // ── Specs (cheap) — recompute each call with _currentAppId exclusion ──
@@ -1412,11 +1478,19 @@ public sealed partial class BcCompiler
     private static NavCA.ISymbolReferenceLoader GetPhysicallyExcludedPackageLoader(
         List<string> packageDirs, Guid excludeAppId)
     {
-        var reducedDirs = DeduplicateAppPackageDirs(packageDirs, excludeAppId);
+        var reducedDirs = DeduplicateAppPackageDirs(packageDirs, excludeAppId, out var reducedInventory);
         // Same #1832 rule as the shared loader: reducedDirs (which already encode the
         // exclusion) are compared for equality, the dep set for subset.
-        var sig = ComputeLoaderSignature(reducedDirs, _extraSymbolDirs, excludeAppId);
-        var depKeys = DepUniverseKeys(_resolvedDeps);
+        //
+        // #2678: and the same two narrowings, for the same reasons — this loader is a package
+        // loader too, built from reducedDirs alone. _extraSymbolDirs hold *.symbols.json only
+        // and never reach CreateReferenceLoader, so they cannot change its answers; and a dep
+        // the .app scan dropped is not one it can serve, so a symbol-less package republished
+        // at a new path must not throw this instance's warm away either. Without this the
+        // saving disappears on exactly the runs that reach the fallback (an app name shared
+        // with the self-excluded package).
+        var sig = ComputeLoaderSignature(reducedDirs, null, excludeAppId);
+        var depKeys = PackageServedDepKeys(_resolvedDeps, reducedInventory);
         if (_exclPackageLoader != null && sig == _exclSignature
             && depKeys.IsSubsetOf(_exclDepUniverse ?? new HashSet<string>(StringComparer.Ordinal)))
             return _exclPackageLoader;
@@ -1441,6 +1515,44 @@ public sealed partial class BcCompiler
         var keys = new HashSet<string>(StringComparer.Ordinal);
         if (deps == null) return keys;
         foreach (var d in deps) keys.Add(d.AppPath + "@" + d.Manifest.Version);
+        return keys;
+    }
+
+    /// <summary>
+    /// <see cref="DepUniverseKeys"/> restricted to the deps a PACKAGE reference loader built
+    /// over <paramref name="scanInventory"/> can actually answer for — issue #2678.
+    ///
+    /// A resolved dep absent from the inventory is one the .app scan dropped: almost always a
+    /// synthetic source-only package with no <c>SymbolReference.json</c> (the layered pre-pass
+    /// and <c>BuildSiblingSourceDeps</c> write these), whose symbols reach the compile through
+    /// the JSON symbol loaders instead. Such a dep is invisible to the package loader by
+    /// construction, so its arrival, departure or republication cannot change one answer the
+    /// package loader gives — and keying the package memo on it is not conservatism, it is a
+    /// guaranteed miss on a path that is republished under a fresh content-addressed directory
+    /// on EVERY warm edit cycle. The freshness those republications genuinely require is
+    /// served by rebuilding the JSON chain (see <c>_jsonLoaderSignature</c>), which is the half
+    /// that reads them.
+    ///
+    /// Everything the package loader does serve keeps the pre-#2678 rule exactly: added or
+    /// changed key → rebuild and re-warm; removed key → reuse (subset).
+    /// </summary>
+    private static HashSet<string> PackageServedDepKeys(
+        IReadOnlyList<(AppManifest Manifest, string AppPath)>? deps,
+        List<PackageScanEntry> scanInventory)
+    {
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        if (deps == null) return keys;
+        var served = new HashSet<string>(
+            scanInventory.Select(e => e.Path), StringComparer.OrdinalIgnoreCase);
+        foreach (var d in deps)
+        {
+            string full;
+            // A dep path that cannot be normalised is not one the scan could have matched
+            // either; fall back to the raw string so it is compared consistently rather than
+            // silently dropped from every subsequent comparison.
+            try { full = Path.GetFullPath(d.AppPath); } catch { full = d.AppPath; }
+            if (served.Contains(full)) keys.Add(full + "@" + d.Manifest.Version);
+        }
         return keys;
     }
 


### PR DESCRIPTION
Closes #2678

Filed by an agent (impl-3).

## The reported premise did not survive measurement — the mechanism behind it did

The issue title says `TryEmitIncremental`'s own fast path costs ~18.5 s on Pageworks. It does
not. Measured on the real app under `--server`, the layered RAD fast path costs **126-181 ms**:

```
[layered] Pageworks 1.0.0.0: RAD incremental (fast path)
[layered] WROTE Pageworks 1.0.0.0 → ... (650742 bytes, 181ms)
```

That matches the maintainer's own follow-up comment on the issue, which had already retracted
the headline number and narrowed what was left to "a one-time cost lands inside the timer next
to the fast-path line". So I went looking for what that one-time cost actually is, rather than
relabelling the timer.

It is not one-time. `TryEmitIncremental` calls `GetSharedReferences`, and on this workload that
call re-warmed the entire Microsoft symbol closure **on every single warm edit cycle**:

```
[shared-refs] memo DEP UNIVERSE GREW
[shared-refs]   new keys: <cache>/workspace-deps/5bba9c6f2606.../Stefan_Maron_Consulting_Pageworks_1_0_0_0.app@1.0.0.0
[shared-refs] warm: 39448ms
```

and on the next cycle the same thing under a different hash (`b14e4c5428d3...`), 43,036 ms.

**Root cause.** The layered pre-pass republishes its synthetic dependency `.app` under a fresh
content-addressed `workspace-deps/<hash>` directory every cycle. `_loaderDepUniverse` is keyed
by `AppPath@Version`, so that one path grew the dep universe every cycle, missed the memo, threw
away the warm package reference loader and re-ran `WarmReferenceLoader` over the whole dep set.
Whichever `GetSharedReferences` call ran first after the republish paid it — the one inside
`TryEmitIncremental` on the maintainer's ordering, the consuming bundle's compile on mine. Same
defect, same cost, read off two different timers.

## The fix

Split the single memo into its two halves, which cost three orders of magnitude apart:

| half | what it does | cost |
|---|---|---|
| package loader | `CreateReferenceLoader` over the `.app` scan set + `WarmReferenceLoader` | 33-43 s |
| JSON symbol chain | one `JsonSymbolReferenceLoader` per dir holding `*.symbols.json`, each indexing in its constructor | 16-38 ms |

The package loader is built from `loaderScanDirs` and nothing else, and
`DeduplicateAppPackageDirs` drops every symbol-less package from that scan — so a republish that
leaves the scan set byte-identical (the test asserts exactly that, as a control) provably cannot
change one answer it gives. The JSON chain is the half that actually reads the republished
symbols, so that is the half that gets rebuilt. Concretely:

- `_loaderDepUniverse` now holds `PackageServedDepKeys` — the deps that survived the `.app` scan.
  A symbol-less synthetic package is invisible to the package loader by construction, so it can
  no longer invalidate it. Everything the package loader does serve keeps the #1832 rule exactly:
  added/changed key rebuilds and re-warms, removed key reuses.
- `_extraSymbolDirs` moved out of the package signature and into a new `_jsonLoaderSignature`.
  Those dirs hold `*.symbols.json` only and are deliberately never handed to
  `CreateReferenceLoader`, so they never could affect the package loader.
- `WarmReferenceLoader` runs only on a package rebuild. BC's `MemoryCachedSymbolReferenceLoader`
  caches in instance fields, so a reused instance is already warm and a re-indexed JSON chain has
  nothing to warm.

## RED → GREEN

`AlRunner.Tests/BcCompilerWarmLoaderReuseTests.ASymbolLessDepRepublishedAtANewPath_RefreshesTheJsonSymbols_WithoutRewarmingThePackageLoader`
replaces the old `...RebuildsTheLoader_EvenThoughTheScanSetIsIdentical`, which encoded the
old *mechanism* (rebuild everything) as the contract. The new test pins the *contract* — fresh
symbols — and the cost separately:

- **Correctness**: the two published copies of the dep carry *different* `*.symbols.deps.json`
  content, and the test reads back which one the returned loader chain serves. A stale chain
  answers `"Before Edit"` and fails.
- **Cost**: `ReferenceLoaderBuildCount` stays 1 and `ReferenceLoaderWarmSpecCount` is unchanged
  across the republish; the new `JsonSymbolLoaderBuildCount` goes 1 → 2.
- **Control**: `InvokeDedupScanSet` is asserted identical either side of the republish, which is
  what makes reusing the package loader provably safe rather than hopeful.

RED, with only the two key expressions reverted to the pre-fix rule and everything else
(including the counter) in place:

```
ASymbolLessDepRepublishedAtANewPath_RefreshesTheJsonSymbols_WithoutRewarmingThePackageLoader [FAIL]
Assert.Equal() Failure: Values differ   Expected: 1   Actual: 2
Failed! - Failed: 1, Passed: 8
```

The correctness assertion passed in the RED run too, which is the point: the RED failure is the
cost, not a freshness regression I introduced and then papered over.

GREEN: `Failed: 0, Passed: 27` over `BcCompilerWarmLoaderReuse` + `BcCompilerSharedReferenceMemo`
+ `BcCompilerLoaderSelfExclusion` + `JsonLoaderDependencyFallthrough`.

## Measurement

Pageworks (`Pageworks` + `Pageworks.Test`, 148 + 192 `.al`), `--server`, BC 28.1, isolated
`--cache` per run, one no-op procedure appended to `PageworksRunLengthEncoder.Codeunit.al`
between requests, `BCCOMPILER_TIMING=1`. Before/after are a matched pair on the same box in the
same session at base `6287bedf`; the third column is the pushed head after rebasing onto `main`.

| warm edit cycle | before | after | pushed head |
|---|---|---|---|
| `[shared-refs] warm`, cycle 2 | **39,448 ms** | *phase does not run* | *phase does not run* |
| `[shared-refs] warm`, cycle 3 | **43,036 ms** | *phase does not run* | *phase does not run* |
| `GetSharedReferences (16 specs)`, cycle 2 | 39,490 ms | 10 ms | 6 ms |
| `GetSharedReferences (16 specs)`, cycle 3 | 43,082 ms | 11 ms | 7 ms |
| `compilation.Emit` (Pageworks.Test), cycle 2 | 24,549 ms | 1,189 ms | — |
| `compilation.Emit` (Pageworks.Test), cycle 3 | 31,244 ms | 1,151 ms | — |
| request wall, cycle 2 | 131.5 s | 72.0 s | 67.0 s |
| request wall, cycle 3 | 143.5 s | 84.2 s | 70.8 s |

This is priced by **removing the work and re-measuring**, not by reading a percentage off a call
tree: the `warm` phase either runs or it does not, and after the fix it does not appear in a warm
cycle's log at all.

The `compilation.Emit` row is a second-order saving I did not set out to get and did not predict.
The number is measured; my explanation for it is a hypothesis — BC's
`MemoryCachedSymbolReferenceLoader` caches per instance, so before the fix every cycle handed the
bind a cold loader.

**Controls, unchanged either side:**

- `[shared-refs] dedup-scan`: 2-3 ms both sides (not touched).
- `[layered] ... RAD incremental (fast path)`: still taken, still 126-181 ms (not touched) —
  the thing the issue title blamed is exactly the thing that did not move.
- `GetSharedReferences (6 specs)` for the Pageworks bundle: 2-38 ms both sides.
- Cold first cycle: 34.7 s before, 32.2 s after, 29.3 s at head — unchanged by design, the loader
  has to be built once.
- **Test outcomes byte-identical in every run, before and after: 997 passed / 15 failed / 1012.**

Wall clock on this box is noisy (several agents run concurrently), which is why the phase
attribution above carries the argument and the wall column is supporting.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — `GetPhysicallyExcludedPackageLoader`, the
   pre-#1831 fallback built when self-exclusion cannot be done by hiding, had the identical
   shape: `ComputeLoaderSignature(reducedDirs, _extraSymbolDirs, …)` plus a path-keyed
   `DepUniverseKeys`. It is fixed the same way, so the saving does not silently vanish on the
   runs that reach it. Those are the only two call sites of either helper.
2. **Sibling functions making the same assumption?** `TryEmitIncremental` and `EmitDepSymbols`
   both call `GetSharedReferences` and inherit the fix; neither needed its own change. Checked,
   nothing else reads `_loaderDepUniverse` or `_loaderSignature`.
3. **Two paths writing the same state with different invariants?** `_refLoader`,
   `_loaderSignature` and `_loaderDepUniverse` are written by the shared branch and by the
   fallback; both now use the same restricted key rule, so the invariant matches on both. The
   defect fixed here was a variant of that: `_cachedJsonLoaders` could only ever be refreshed
   from inside the *expensive* rebuild, so the cheap half's invalidation trigger was welded to
   the expensive half's price.

## What I ran

- Targeted: `BcCompilerWarmLoaderReuse|BcCompilerSharedReferenceMemo|BcCompilerLoaderSelfExclusion|JsonLoaderDependencyFallthrough` — 27 passed, 0 failed.
- Wider (shared compile path, broad blast radius): `~BcCompiler|~Layered|~JsonLoader|~Sibling|~DependencyLoader|~DepSymbol` — **99 passed, 0 failed**, 25 skipped. Re-run after the rebase, same result. The 25 skips are this box's in-process BC engine gate (cold Ncl Cecil rewrite), not related to the change.
- `LayeredDepSymbolsIncrementalServerTests` specifically, since it is the real staleness guard — it edits the dependency, adds a procedure, and asserts the dependent app *calls* it and gets the right value. **8 passed, 0 failed.** If reusing the package loader served stale symbols, this is the test that would catch it.
- al-language corpus, `--strict --count-baseline`: **2554 / 2554, exit 0**, cold and again warm (cache-sensitive re-run — no defect on a compile-cache HIT).
- `tests/runner-extras`, `--strict --count-baseline`: **264 / 264, exit 0**.
- Pageworks re-run against a warm on-disk `--cache`: `[layered] cache HIT`, 997/15/1012 — identical.

## Deliberately not in this PR

- **No change to the `[layered] WROTE ... <n>ms` timer or its wording.** The issue's remaining
  scope was a reporting question, but the number it reported was real work, and the existing
  per-phase `BCCOMPILER_TIMING=1` marks already distinguish the halves (a `json-loaders` line
  with no `warm` line after it is the cheap half). Relabelling the timer would have hidden a
  36-43 s per-cycle regression instead of removing it.
- **The cold, first-in-process warm (17-33 s) is untouched.** The loader must be built once.
- **`EmitSiblingSymbols` (#2672) is untouched.** It has the never-attempts-RAD shape #2669 fixed;
  when it is fixed the same way it now inherits a loader memo that no longer re-warms, but that
  is its own issue and its own test.
- I did not edit the issue body. The maintainer had already corrected it himself in a comment,
  and this PR records what the measurement found.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
