### PR TITLE
fix(preflight): strip mise's stdout banner, which made a healthy box read as unable to push

### DIFF
--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -106,8 +106,39 @@ def run(argv: list[str], *, cwd: Optional[str] = None, timeout: float = 30,
     except (FileNotFoundError, PermissionError, OSError) as exc:
         return Ran(rc=127, out="", err=str(exc))
     return Ran(rc=p.returncode,
-               out=p.stdout.decode("utf-8", "replace"),
+               out=strip_shim_banner(p.stdout.decode("utf-8", "replace")),
                err=p.stderr.decode("utf-8", "replace"))
+
+
+# mise prints a tool-activation banner on STDOUT, ahead of the real output, for
+# every command it shims -- gh and git among them. It is not an error and the
+# exit code stays 0, so it corrupts a capture silently.
+#
+# This is not hypothetical. On the box this was written on, `gh api user --jq
+# .login` returned "mise ~/.config/mise/config.toml tools: gh@2.100.0\nStefanMaron",
+# and `gh api repos/<slug> --jq .permissions` returned the banner followed by the
+# JSON -- so json.loads() raised, perms fell back to {}, and the github check
+# reported "StefanMaron cannot push to StefanMaron/BusinessCentral.AL.Runner".
+# A healthy box was refused. That is precisely the failure mode this tool exists
+# to prevent, arriving through the tool itself.
+#
+# Strip it here, in run(), rather than at each call site: a call site added later
+# would not know to do it, and the symptom is a wrong answer rather than an error.
+_SHIM_BANNER = re.compile(r"^mise\s+.*\btools:\s")
+
+
+def strip_shim_banner(text: str) -> str:
+    """Drop mise's activation banner from captured stdout.
+
+    Only leading banner lines are dropped, and only lines that match the banner
+    shape -- a line of real output that merely begins with "mise" is kept, or the
+    filter would eat data to fix formatting.
+    """
+    lines = text.splitlines(keepends=True)
+    i = 0
+    while i < len(lines) and _SHIM_BANNER.match(lines[i]):
+        i += 1
+    return "".join(lines[i:])
 
 
 def run_retry(argv: list[str], *, attempts: int = 3, **kw) -> Ran:

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import datetime as dt
 import importlib.util
+import json
 import os
 import shutil
 import subprocess
@@ -46,6 +47,38 @@ def check(name: str, cond: bool, detail: str = "") -> None:
 
 
 GIB = 1024 ** 3
+
+# -------------------------------------------------- shim banner on stdout
+# mise prints an activation banner on STDOUT for every command it shims. It does
+# not change the exit code, so a capture that keeps it fails later, somewhere
+# else, as a wrong answer. This is the real payload that made the github check
+# report a healthy account as unable to push.
+BANNER = "mise ~/.config/mise/config.toml tools: gh@2.100.0\n"
+
+check("the banner is stripped from a one-line capture",
+      pf.strip_shim_banner(BANNER + "StefanMaron\n") == "StefanMaron\n",
+      repr(pf.strip_shim_banner(BANNER + "StefanMaron\n")))
+
+perms = '{"admin":true,"push":true,"pull":true}'
+check("a JSON body behind the banner parses after stripping",
+      json.loads(pf.strip_shim_banner(BANNER + perms))["push"] is True)
+
+check("two banner lines are both dropped",
+      pf.strip_shim_banner(BANNER + BANNER + "x\n") == "x\n",
+      repr(pf.strip_shim_banner(BANNER + BANNER + "x\n")))
+
+check("output with no banner is returned byte-for-byte",
+      pf.strip_shim_banner(perms) == perms)
+
+check("a real line that merely starts with 'mise' is NOT eaten",
+      pf.strip_shim_banner("mise is the tool we use\n") == "mise is the tool we use\n",
+      repr(pf.strip_shim_banner("mise is the tool we use\n")))
+
+check("a banner appearing after real output is left alone -- only the leader is a banner",
+      pf.strip_shim_banner("StefanMaron\n" + BANNER) == "StefanMaron\n" + BANNER)
+
+check("an empty capture stays empty rather than becoming a false answer",
+      pf.strip_shim_banner("") == "")
 
 # ---------------------------------------------------------------- df parsing
 # Captured verbatim from the box the incident happened on:


### PR DESCRIPTION
`tools/preflight.py` refused a healthy box. It reported `StefanMaron cannot push to StefanMaron/BusinessCentral.AL.Runner, so the loop cannot open or merge anything`, with an empty permissions line right underneath it, on an account that has admin, maintain, pull, push and triage.

The cause is that mise prints a tool-activation banner on **stdout** ahead of the real output for every command it shims, `gh` and `git` among them. It is not an error and the exit code stays 0, so `run()` keeps it and the capture is corrupt with no signal:

```
$ gh api user --jq .login
mise ~/.config/mise/config.toml tools: gh@2.100.0
StefanMaron
```

`login` becomes the whole two-line string, and `gh api repos/<slug> --jq .permissions` returns the banner followed by the JSON, so `json.loads()` raises, `perms` falls back to `{}`, and `can_push` goes false.

The same corruption reached the worktree reaper: its `gh pr list` capture fails to parse, no pull request is ever found, and every worktree reads as `merged state unknown, so it is kept`. That box reported 76 worktrees holding 11.7 GiB with 0 reapable.

## The change

`strip_shim_banner()`, applied in `run()` rather than at each call site — a call site added later would not know to do it, and the symptom is a wrong answer rather than an error.

Only leading lines matching the banner shape are dropped. A line of real output that merely begins with `mise` is kept, and a banner appearing after real output is left alone; otherwise the filter would eat data to fix formatting.

## Proof

RED is the live report above. GREEN, same box, same command, after the change:

```
PASS  github    authenticated as StefanMaron with push access to StefanMaron/BusinessCentral.AL.Runner
                account: StefanMaron; repository: StefanMaron/BusinessCentral.AL.Runner
                permissions: admin=True, maintain=True, pull=True, push=True, triage=True
                merge a PR: yes; label and assign: yes (both need push or triage)
```

Seven checks in `tools/test_preflight.py` pin both directions, including the exact `gh api user` payload above and the `.permissions` JSON body. Three of them are the negative direction: output with no banner is returned byte-for-byte, a real line beginning with `mise` is not eaten, and an empty capture stays empty rather than becoming a false answer.

`python3 tools/test_preflight.py`: all checks passed.

Closes #2935

*Opened by an agent (coordinator session).*

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
