### PR TITLE
fix(server): drop the dependency page/report metadata memos when the registered .app set changes

### DIFF
--- a/AlRunner.Tests/DependencyMetadataMemoInvalidationTests.cs
+++ b/AlRunner.Tests/DependencyMetadataMemoInvalidationTests.cs
@@ -1,0 +1,287 @@
+// DependencyMetadataMemoInvalidationTests — issue #2889: the synthesized-metadata memos for
+// PRECOMPILED dependency objects must not outlive the registration set they were derived
+// from.
+//
+// The state under test
+// --------------------
+//   RecordPatches._depPageMetadataXml    (AlRunner/Patches/DependencyPageMetadataXml.cs)
+//   RecordPatches._depReportMetadataXml  (AlRunner/Patches/DependencyReportMetadata.cs)
+//
+// Two ConcurrentDictionary<int, string?> memos, each filled by a GetOrAdd whose factory
+// walks _bcAppPaths and reads each registered .app's SymbolReference.json. Both cached the
+// NEGATIVE answer as well as the positive one, and both justified it identically: "Result
+// cached per id (including the null), since the answer is a property of the loaded
+// dependency set." That premise is only sound while the loaded dependency set cannot
+// change under the memo — and it changes twice:
+//
+//   * AddBcAppPath GROWS it, on every dependency registration, and its last act is
+//     InvalidateBcAppIndexes() precisely so "newly-added .app gets picked up on next miss".
+//     Every index derived from _bcAppPaths was dropped there; these two memos were not.
+//   * ResetForReload SHRINKS it, on every --server request and every --watch cycle: since
+//     #2755 / PR #2873 it calls ClearPerBundleBcAppPaths, which REMOVES the previous
+//     bundle's registrations and then funnels through that same InvalidateBcAppIndexes().
+//     So a memo surviving a roll answers from an .app the process no longer has registered.
+//
+// Why this is a mechanism test and not a corpus test
+// -------------------------------------------------
+// The claim is about cache lifetime across a registration-set change inside ONE runner
+// process — multi-bundle / server-mode wiring, which
+// .claude/rules/bc-behavior-tests-go-upstream.md names as explicitly runner-specific. No
+// BC service tier has an opinion about it: real BC has no such memo, and the AL a test
+// would run is identical either way. What AL observes when a page's metadata IS available
+// is plain BC behaviour and is already pinned upstream; this file pins only that the
+// runner keeps answering from the currently-registered set.
+//
+// Both polarities are covered because a positive-only test passes on the broken build for
+// the half that matters most: the cached null is the one that makes an object that DOES
+// exist permanently invisible, with no error and an unchanged exit code.
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// RecordPatchesSerialCollection, not CacheRootsSerialCollection: this class calls
+// RecordPatches.ResetForReload() directly, which ParserStaticsIsolationGuardTests requires.
+// Both collections set DisableParallelization and xUnit runs every such collection serially
+// relative to every other one (CollectionCostOrderer.cs), so BcAppSymbolCache.Get()'s
+// process-global CacheRoots resolution is still uncontended here — the same reasoning
+// RecordPatchesWarmReloadExtensionIndexTests records for the same pair of collections.
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class DependencyMetadataMemoInvalidationTests : IDisposable
+{
+    private readonly string _root;
+
+    public DependencyMetadataMemoInvalidationTests()
+    {
+        _root = TestScratch.Dir("al-runner-2889-tests");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    // Ids process-wide unique among AlRunner.Tests statics (_bcAppPaths and both memos are
+    // process-global and nothing in the test host unregisters an .app), and outside every
+    // neighbouring file's block: DependencyPageMetadataXmlTests owns 881234xx and
+    // DependencyReportProcessingOnlyTests owns 881236xx, so this file uses 881235xx.
+    private const int UnrelatedPageId = 88123510;
+    private const int LatePageId = 88123511;
+    private const int ReloadPageId = 88123512;
+    private const int UnrelatedReportId = 88123550;
+    private const int LateReportId = 88123551;
+
+    private string WriteApp(string symbolReferenceJson)
+    {
+        var appPath = Path.Combine(_root, Guid.NewGuid().ToString("N") + ".app");
+        using var zip = new FileStream(appPath, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+        return appPath;
+    }
+
+    private static string PagesJson(params (int Id, string Name, string PageType)[] pages)
+    {
+        var sb = new StringBuilder();
+        sb.Append("{ \"RuntimeVersion\": \"15.1\", \"Pages\": [");
+        for (var i = 0; i < pages.Length; i++)
+        {
+            if (i > 0) sb.Append(',');
+            sb.Append($$"""
+                {
+                  "Id": {{pages[i].Id}},
+                  "Name": "{{pages[i].Name}}",
+                  "Properties": [
+                    { "Name": "PageType", "Value": "{{pages[i].PageType}}" },
+                    { "Name": "SourceTable", "Value": "700" }
+                  ]
+                }
+                """);
+        }
+        sb.Append("] }");
+        return sb.ToString();
+    }
+
+    private static string ReportsJson(params (int Id, string Name)[] reports)
+    {
+        var sb = new StringBuilder();
+        sb.Append("{ \"RuntimeVersion\": \"15.1\", \"Namespaces\": [ { \"Name\": \"DMMI\", \"Reports\": [");
+        for (var i = 0; i < reports.Length; i++)
+        {
+            if (i > 0) sb.Append(',');
+            sb.Append($$"""
+                {
+                  "Id": {{reports[i].Id}},
+                  "Name": "{{reports[i].Name}}",
+                  "Properties": [ { "Name": "Caption", "Value": "{{reports[i].Name}}" } ]
+                }
+                """);
+        }
+        sb.Append("] } ] }");
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// The cached NULL half, for pages. Bundle 1 asks about a page no registered .app
+    /// declares; bundle 2's own dependency declares it. Before the fix the memoized null
+    /// was served forever, so RunnerXmlMetadataLoader fell through to its out-of-scope
+    /// throw for a page whose metadata was sitting in a registered symbol file.
+    /// </summary>
+    [Fact]
+    public void ANullPageAnswer_DoesNotSurviveALaterAppDeclaringThatPage()
+    {
+        RecordPatches.AddBcAppPath(WriteApp(PagesJson((UnrelatedPageId, "DMMI Unrelated Page", "List"))));
+
+        // Precondition, and it memoizes the null. Asserted rather than assumed: if some
+        // other test had already registered an .app declaring this id, the "after"
+        // assertion below could pass without the fix.
+        Assert.False(RecordPatches.HasDependencyPageMetadata(LatePageId));
+        Assert.Null(RecordPatches.TryBuildDependencyPageMetadata(LatePageId));
+
+        RecordPatches.AddBcAppPath(WriteApp(PagesJson((LatePageId, "DMMI Late Page", "Card"))));
+
+        // Positive control: the live lookup never memoized anything, so it is already
+        // right. That is what pins the failure below to the memo rather than to the
+        // registration not having happened.
+        Assert.True(RecordPatches.HasDependencyPageMetadata(LatePageId),
+            "the second .app is registered and readable, so the live symbol lookup must see the page");
+
+        var xml = RecordPatches.TryBuildDependencyPageMetadata(LatePageId);
+        Assert.NotNull(xml);
+
+        var doc = new System.Xml.XmlDocument();
+        doc.LoadXml(xml!);
+        var root = doc.DocumentElement!;
+        Assert.Equal("PageDefinition", root.LocalName);
+        Assert.Equal(LatePageId.ToString(), root.GetAttribute("ID"));
+        Assert.Equal("DMMI Late Page", root.GetAttribute("Name"));
+        var ns = new System.Xml.XmlNamespaceManager(doc.NameTable);
+        ns.AddNamespace("m", "urn:schemas-microsoft-com:dynamics:NAV:MetaObjects");
+        var properties = (System.Xml.XmlElement)root.SelectSingleNode("m:Properties", ns)!;
+        Assert.Equal("Card", properties.GetAttribute("PageType"));
+    }
+
+    /// <summary>
+    /// The same cached NULL half for the sibling memo one file over, which #2889 does not
+    /// name and which is byte-for-byte the same shape — same GetOrAdd, same doc comment,
+    /// same _bcAppPaths-derived factory.
+    /// </summary>
+    [Fact]
+    public void ANullReportAnswer_DoesNotSurviveALaterAppDeclaringThatReport()
+    {
+        RecordPatches.AddBcAppPath(WriteApp(ReportsJson((UnrelatedReportId, "DMMI Unrelated Report"))));
+
+        Assert.Null(RecordPatches.TryBuildDependencyReportMetadata(LateReportId));
+
+        RecordPatches.AddBcAppPath(WriteApp(ReportsJson((LateReportId, "DMMI Late Report"))));
+
+        var xml = RecordPatches.TryBuildDependencyReportMetadata(LateReportId);
+        Assert.NotNull(xml);
+
+        var doc = new System.Xml.XmlDocument();
+        doc.LoadXml(xml!);
+        Assert.Equal("Report", doc.DocumentElement!.LocalName);
+        Assert.Equal(LateReportId.ToString(), doc.SelectSingleNode("/Report/ID")!.InnerText);
+        Assert.Equal("DMMI Late Report", doc.SelectSingleNode("/Report/Name")!.InnerText);
+    }
+
+    /// <summary>
+    /// The POSITIVE half: a synthesized document must not outlive the .app it was
+    /// synthesized from, when a bundle roll unregisters that .app.
+    ///
+    /// <para>This is live on <c>main</c> as of #2755 / PR #2873, not latent.
+    /// <c>ResetForReload</c> now calls <c>ClearPerBundleBcAppPaths</c>, which REMOVES the
+    /// previous bundle's registrations from <c>_bcAppPaths</c> before funnelling through
+    /// <see cref="RecordPatches"/>' <c>InvalidateBcAppIndexes</c>. So immediately after a
+    /// roll the only honest answer for a page declared solely by bundle 1's .app is null,
+    /// and a memo the roll did not clear answers with bundle 1's document instead — a
+    /// document synthesized from an .app that is no longer registered at all.</para>
+    ///
+    /// <para>The assertion deliberately sits BETWEEN the roll and bundle 2's registration.
+    /// Re-registering first and then asserting would prove nothing about the roll:
+    /// <c>AddBcAppPath</c> funnels through the same invalidation, and (having early-returned
+    /// on a path already in the list) it treats the re-registration as new, so it would clear
+    /// the memo itself and the test would pass on a build where only the grow path clears —
+    /// which is the half tests 1 and 2 already cover. Bundle 2 is registered afterwards, with
+    /// a DIFFERENT PageType for the same id, so the rebuild is checked to answer with bundle
+    /// 2's shape rather than bundle 1's.</para>
+    ///
+    /// <para>The no-roll arm is a control in both directions — it proves the memo really is a
+    /// memo (so the roll arm is testing something), and the "synthesized" line asserted at the
+    /// end proves stderr capture works here (so its <c>DoesNotContain</c> cannot pass by the
+    /// capture silently returning nothing).</para>
+    /// </summary>
+    [Fact]
+    public void ASynthesizedPageDocument_DoesNotSurviveTheBundleRollThatUnregistersItsApp()
+    {
+        var bundle1App = WriteApp(PagesJson((ReloadPageId, "DMMI Reload Page", "List")));
+        RecordPatches.AddBcAppPath(bundle1App);
+
+        var first = RecordPatches.TryBuildDependencyPageMetadata(ReloadPageId);
+        Assert.NotNull(first);
+        Assert.Equal("List", PageTypeOf(first!));
+
+        var withoutRoll = CaptureStderr(() => RecordPatches.TryBuildDependencyPageMetadata(ReloadPageId));
+        Assert.DoesNotContain($"synthesized Page {ReloadPageId}", withoutRoll);
+
+        // The bundle roll.
+        RecordPatches.ResetForReload();
+
+        // Precondition, asserted rather than assumed: the roll really did unregister
+        // bundle 1's .app. Without this the null below could mean the memo was cleared OR
+        // that the page was never findable, and only the first is the claim.
+        Assert.DoesNotContain(
+            RecordPatches.RegisteredBcAppPathsForTests(),
+            p => string.Equals(p, bundle1App, StringComparison.OrdinalIgnoreCase));
+        Assert.False(RecordPatches.HasDependencyPageMetadata(ReloadPageId),
+            "the live symbol walk must agree the page is gone, so null is the correct answer here");
+
+        // ...so serving the memoized document would be serving one built from an .app the
+        // process no longer has registered. Before the fix, that is exactly what happened.
+        Assert.Null(RecordPatches.TryBuildDependencyPageMetadata(ReloadPageId));
+
+        // And the roll did not leave a memoized NULL behind either: bundle 2 registers its
+        // own .app declaring the same id with a different PageType, and the answer is
+        // bundle 2's shape, freshly synthesized.
+        RecordPatches.AddBcAppPath(WriteApp(PagesJson((ReloadPageId, "DMMI Reload Page", "Card"))));
+
+        string? second = null;
+        var afterRoll = CaptureStderr(() => second = RecordPatches.TryBuildDependencyPageMetadata(ReloadPageId));
+        Assert.Contains($"synthesized Page {ReloadPageId}", afterRoll);
+        Assert.NotNull(second);
+        Assert.Equal("Card", PageTypeOf(second!));
+        Assert.NotEqual(first, second);
+    }
+
+    /// <summary>The PageType stated by a synthesized PageDefinition document.</summary>
+    private static string PageTypeOf(string pageDefinitionXml)
+    {
+        var doc = new System.Xml.XmlDocument();
+        doc.LoadXml(pageDefinitionXml);
+        var ns = new System.Xml.XmlNamespaceManager(doc.NameTable);
+        ns.AddNamespace("m", "urn:schemas-microsoft-com:dynamics:NAV:MetaObjects");
+        var properties = (System.Xml.XmlElement)doc.DocumentElement!.SelectSingleNode("m:Properties", ns)!;
+        return properties.GetAttribute("PageType");
+    }
+
+    private static string CaptureStderr(Action action)
+    {
+        var saved = Console.Error;
+        var buffer = new StringWriter();
+        try
+        {
+            Console.SetError(buffer);
+            action();
+        }
+        finally
+        {
+            Console.SetError(saved);
+        }
+        return buffer.ToString();
+    }
+}

--- a/AlRunner/Patches/DependencyPageMetadataXml.cs
+++ b/AlRunner/Patches/DependencyPageMetadataXml.cs
@@ -77,8 +77,18 @@ public static partial class RecordPatches
 
     /// <summary>
     /// Runtime PageDefinition metadata XML for a page declared by a precompiled dependency,
-    /// or null when no loaded dependency .app describes that page. Result cached per id
-    /// (including the null), since the answer is a property of the loaded dependency set.
+    /// or null when no loaded dependency .app describes that page.
+    ///
+    /// <para>Result cached per id, INCLUDING the null, because the answer is a property of
+    /// the loaded dependency set — and therefore only for as long as that set holds still.
+    /// <see cref="InvalidateBcAppIndexes"/> drops this memo alongside every other index
+    /// derived from <c>_bcAppPaths</c>, so both directions of a set change are covered:
+    /// a registration that ADDS the .app declaring this page (<see cref="AddBcAppPath"/>),
+    /// and a bundle roll that drops the previous bundle's registrations
+    /// (<c>ResetForReload</c>). Issue #2889: without that, an id asked about before its
+    /// declaring .app registered kept the memoized null for the life of the process, and
+    /// <see cref="RunnerXmlMetadataLoader"/> answered "no metadata XML for this object" for
+    /// a page whose metadata was readable in a registered symbol file.</para>
     /// </summary>
     internal static string? TryBuildDependencyPageMetadata(int pageId)
         => _depPageMetadataXml.GetOrAdd(pageId, BuildDependencyPageMetadata);

--- a/AlRunner/Patches/DependencyReportMetadata.cs
+++ b/AlRunner/Patches/DependencyReportMetadata.cs
@@ -55,8 +55,14 @@ public static partial class RecordPatches
 
     /// <summary>
     /// Runtime metadata XML for a report declared by a precompiled dependency, or null when
-    /// no dependency .app describes that report. Result cached per id (including the null),
-    /// since the answer is a property of the loaded dependency set.
+    /// no dependency .app describes that report.
+    ///
+    /// <para>Result cached per id, INCLUDING the null, and dropped by
+    /// <see cref="InvalidateBcAppIndexes"/> whenever the registered .app set changes — same
+    /// memo shape, same reasoning and the same issue (#2889) as
+    /// <see cref="TryBuildDependencyPageMetadata"/> one file over; see its doc comment for
+    /// the full argument. #2889 reported only the page memo; this one is its twin and was
+    /// fixed with it rather than left to be re-found.</para>
     /// </summary>
     internal static string? TryBuildDependencyReportMetadata(int reportId)
         => _depReportMetadataXml.GetOrAdd(reportId, BuildDependencyReportMetadata);

--- a/AlRunner/Patches/RecordPatches.BcAppFallback.cs
+++ b/AlRunner/Patches/RecordPatches.BcAppFallback.cs
@@ -97,8 +97,10 @@ public static partial class RecordPatches
     }
 
     /// <summary>
-    /// Drop every lazily-built BC .app index so the next lookup rebuilds them from
-    /// <see cref="_bcAppPaths"/> from scratch — including <see cref="_bcSymbolExtensionIndexBuilt"/>,
+    /// Drop every lazily-built piece of state derived from the registered BC .app set — the
+    /// symbol/table/query indexes AND the per-id synthesized-metadata memos (#2889) — so the
+    /// next lookup rebuilds it from <see cref="_bcAppPaths"/> from scratch. Including
+    /// <see cref="_bcSymbolExtensionIndexBuilt"/>,
     /// which is what actually re-triggers <see cref="EnsureBcSymbolExtensionIndex"/> (its only
     /// call site is inside <see cref="EnsureBcSymbolTableIndex"/>, gated by
     /// <c>_bcSymbolTableIndex != null</c> — so nulling the table index without ALSO resetting
@@ -124,6 +126,36 @@ public static partial class RecordPatches
         _bcSymbolTableCaptions = null;
         _bcSymbolQueryIndex = null;
         _bcSymbolExtensionIndexBuilt = false;
+        // #2889: the synthesized-metadata memos are derived from _bcAppPaths exactly like the
+        // indexes above — TryBuildDependencyPageMetadata / TryBuildDependencyReportMetadata
+        // GetOrAdd a document built by walking the registered .apps' SymbolReference.json —
+        // and they were the only such state this method did not drop. Both memo the NEGATIVE
+        // answer too, which is the half that bites without a fix landing anywhere else:
+        // AddBcAppPath calls this method precisely so a "newly-added .app gets picked up on
+        // next miss", so an id asked about BEFORE the .app that declares it was registered
+        // kept its memoized null for the rest of the process. RunnerXmlMetadataLoader then
+        // fell past its page branch and raised the not-yet-implemented out-of-scope throw for
+        // a page whose metadata was sitting readable in a registered symbol file — which
+        // EnsureRealPageMetadata catches, logging "falling back to the control-less skeleton"
+        // and recording the page as permanently failed. That loader's dependency-REPORT branch
+        // reached the identical throw the same way. (The report memo has a SECOND consumer the
+        // page memo does not: NavReportSync.GetRealMetaReport, which layers its own
+        // _realMetaCache on top and falls back to the legacy ProcessingOnly stub when this
+        // memo answers null — so a cached null there costs a SaveAs, not a throw. Naming one
+        // consumer as "the only" one is the same unchecked-uniqueness reasoning that let this
+        // memo's premise go unexamined in the first place, so both are named.)
+        //
+        // The positive direction needs the registered set to be able to SHRINK, and since
+        // #2755 / PR #2873 merged it can: ClearPerBundleBcAppPaths drops the previous bundle's
+        // registrations and routes through this same method. So this direction is live on main
+        // today, not latent — a document synthesized from bundle 1's symbols is not
+        // stale-but-consistent for bundle 2, it is simply wrong, and without the clears below
+        // the memo would serve it for an .app that is no longer registered at all. Clearing
+        // here covers both directions and cannot drift from the registration set, for the same
+        // reason #2478 gave for funnelling the index resets through one method rather than
+        // duplicating them at each call site.
+        _depPageMetadataXml.Clear();
+        _depReportMetadataXml.Clear();
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #2889

`_depPageMetadataXml` and `_depReportMetadataXml` are two `ConcurrentDictionary<int, string?>` memos, each filled by a `GetOrAdd` whose factory walks `_bcAppPaths` and reads each registered `.app`'s `SymbolReference.json`. Both cached the **negative** answer alongside the positive one, and both justified it with the same sentence: *"the answer is a property of the loaded dependency set."*

That premise is sound only while the set holds still, and it does not hold still. Both writers of `_bcAppPaths` already funnel through `InvalidateBcAppIndexes`, which dropped every *other* piece of `_bcAppPaths`-derived state and not these two. The fix adds the two `Clear()` calls to that funnel.

## Both directions are live on `main` today

**The cached null (the direction #2889 reports).** `AddBcAppPath` grows the set on every dependency registration, and calls `InvalidateBcAppIndexes` precisely so a "newly-added .app gets picked up on next miss". An id asked about *before* the `.app` declaring it was registered kept its memoized null for the life of the process. `RunnerXmlMetadataLoader` then fell past its page branch to the `not-yet-implemented` out-of-scope throw for a page whose metadata was sitting readable in a registered symbol file — which `EnsureRealPageMetadata` catches, logging "falling back to the control-less skeleton" and recording the page as permanently failed.

**The stale positive document.** An earlier revision of this body called this direction *latent until #2873 merges*. **#2873 has since merged**, so it is live on `main` now: `ResetForReload` calls `ClearPerBundleBcAppPaths`, which **removes** the previous bundle's registrations from `_bcAppPaths` before routing through this same method. A memo surviving the roll therefore does not answer with something stale-but-consistent — it answers with a document synthesized from an `.app` the process no longer has registered at all.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — `_depReportMetadataXml` in `DependencyReportMetadata.cs`, same `GetOrAdd`, same factory shape, same doc-comment justification. #2889 names only the page memo; the report memo is fixed here rather than left to be re-found.
2. **Sibling functions making the same assumption?** `HasDependencyPageMetadata` and `TryGetDependencyPageSymbol` do **not** — `TryGetDependencyPageSymbol` (`RecordPatches.DependencyPageMetadata.cs:82`) is a live `_bcAppPaths` walk with no per-id memo, so it was always right. That asymmetry is what makes the positive control in test 1 meaningful.
3. **Two code paths writing the same state, one invariant?** This is the defect: `AddBcAppPath` (grow) and `ClearPerBundleBcAppPaths` (shrink) are the only two callers of `InvalidateBcAppIndexes`, verified after the rebase — so putting the clears in the funnel covers both and cannot drift, for the same reason #2478 gave for funnelling the index resets in the first place.

**Deliberately left out:** `_bcMissCache` (two lines above the edited method, identical shape) and the seven `_bcAppPaths.Count`-keyed generations including `_depProcessingOnlyBuiltFrom`. Those are the scope of **#2888**, which is open and unclaimed. Not swept in here.

## RED → GREEN

`AlRunner.Tests/DependencyMetadataMemoInvalidationTests.cs`, 3 tests. RED taken by deleting only the two `Clear()` lines on this exact tree; **all three fail**, each on the assertion naming its own direction:

| test | RED failure |
|---|---|
| `ANullPageAnswer_DoesNotSurviveALaterAppDeclaringThatPage` | `Assert.NotNull() Failure: Value is null` |
| `ANullReportAnswer_DoesNotSurviveALaterAppDeclaringThatReport` | `Assert.NotNull() Failure: Value is null` |
| `ASynthesizedPageDocument_DoesNotSurviveTheBundleRollThatUnregistersItsApp` | `Assert.Null() Failure: Value is not null` |

GREEN: 3/3 pass with the clears restored.

### Test 3 was rewritten for the post-#2873 world, not just repaired

The rebase onto merged-#2873 broke test 3, because `ResetForReload` now unregisters the test's `.app` and the old test asserted on a re-synthesis log line that consequently never printed. The obvious repair — re-register the `.app` after the reset, then assert — **would have made the test pass without proving anything**: `AddBcAppPath` early-returns on a path already in the list, so post-roll it treats the re-registration as new and funnels through the same invalidation, clearing the memo itself. Test 3 would have passed on a build where only the *grow* path clears, which is exactly what tests 1 and 2 already cover.

So the assertion now sits **between** the roll and bundle 2's registration, where only `ResetForReload` can have cleared anything:

- precondition asserted, not assumed: the roll really removed bundle 1's `.app` (`RegisteredBcAppPathsForTests`), and `HasDependencyPageMetadata` agrees the page is gone — so `null` is the correct answer and cannot be confused with "never findable";
- `Assert.Null(TryBuildDependencyPageMetadata(...))` — the stale-positive claim, and the assertion that fails RED;
- bundle 2 then registers its **own** `.app` declaring the same id with a **different** `PageType`, and the rebuild is checked to answer `Card` (bundle 2) rather than `List` (bundle 1), with the "synthesized" line proving the rebuild happened — which also keeps the earlier `DoesNotContain` control from passing by the stderr capture silently returning nothing.

## Comment correction

A comment introduced by the first revision called `RunnerXmlMetadataLoader` "the report memo's only consumer". **It is not** — `NavReportSync.GetRealMetaReport` is a second one, layering its own `_realMetaCache` on top and falling back to the legacy `ProcessingOnly` stub when this memo answers null, so a cached null there costs a `SaveAs` rather than a throw. Both are now named. An unchecked uniqueness claim is the same class of error that let this memo's premise go unexamined to begin with. (The **page** memo's only reader really is `RunnerXmlMetadataLoader.cs:81`; that claim was re-verified and stands.)

## Where the test lives, and why not upstream

Runner-specific by the `bc-behavior-tests-go-upstream.md` test: the claim is about cache lifetime across a registration-set change inside one runner process — multi-bundle / server-mode wiring, which that rule names explicitly. Real BC has no such memo and the AL a corpus test would run is identical either way. What AL observes when a page's metadata *is* available is plain BC behaviour and is already pinned upstream. No corpus change, no pin bump, and therefore no `test-count-baseline.json` edit.

## Rebase

Rebased twice while under review, ending on `b186f5fd`. The #2873 conflict was in the `InvalidateBcAppIndexes` doc comment only: #2873's new `ClearPerBundleBcAppPaths` method and its "Two callers" wording are kept verbatim, and this PR's rewrite of the opening sentence applies on top. No code conflicted.

## Tests run

- `dotnet test AlRunner.Tests --filter FullyQualifiedName~DependencyMetadataMemoInvalidationTests` — 3/3 pass (RED → GREEN as above).
- Filtered sweep over the touched surface (`Reload|Metadata|Dependency|ServerMode`) — **192 passed, 0 failed**, 12 skipped (environment-gated).
- After the final rebase, re-ran the class plus #2972's new `ScratchDirOwnershipGuardTests` — 6/6 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE

<sub>Authored by agent `stma-auto-1`.</sub>
