### PR TITLE
fix(query): give a query FlowField column the query's own flow filters

### DIFF
--- a/AlRunner.QueryJoin/JoinContext.cs
+++ b/AlRunner.QueryJoin/JoinContext.cs
@@ -58,7 +58,11 @@ public sealed class JoinContext
     /// unrelated TableSlot on the FlowField's source table (which this join never reads a row
     /// buffer for at all).
     /// </summary>
-    public required Func<object /*rowBuffer*/, object /*flowFieldMeta*/, object?> CalcFlowFieldForRow;
+    /// #2925 adds the third argument: the QUERY's own flow filters (a FiltersAndMarks boxed as
+    /// object, or null when the query sets none), which BC's FlowFieldsHelper.
+    /// GetFilterFromMetaFilterCollection dereferences unguarded for any CalcFormula carrying a
+    /// FlowFilter-class where-condition.
+    public required Func<object /*rowBuffer*/, object /*flowFieldMeta*/, object? /*flowFiltersAndMarks*/, object?> CalcFlowFieldForRow;
 
     /// <summary>Diagnostic log sink (al-runner's QLog).</summary>
     public required Action<string> Log;

--- a/AlRunner.QueryJoin/JoinExecutor.cs
+++ b/AlRunner.QueryJoin/JoinExecutor.cs
@@ -198,7 +198,8 @@ public static class JoinExecutor
     /// (ReadOnlyRecordBuffers as objects). Eagerly materialised so any failure surfaces as a
     /// managed exception at the call site, never a native crash mid-enumeration.
     /// </summary>
-    public static List<object> Execute(JoinContext ctx, object nclMetaQuery, object dataAccessSource)
+    public static List<object> Execute(
+        JoinContext ctx, object nclMetaQuery, object dataAccessSource, object? flowFiltersAndMarks)
     {
         Log(ctx, "ExecuteJoinQuery start");
         EnsureReflection(nclMetaQuery);
@@ -295,7 +296,8 @@ public static class JoinExecutor
                         }
                         else
                         {
-                            fields[col.QuerySlot] = ApplyReverseSign(ctx, col.ColumnObj, ctx.CalcFlowFieldForRow(ownerBuf, col.FlowFieldMeta));
+                            fields[col.QuerySlot] = ApplyReverseSign(ctx, col.ColumnObj,
+                                ctx.CalcFlowFieldForRow(ownerBuf, col.FlowFieldMeta, flowFiltersAndMarks));
                         }
                         continue;
                     }
@@ -322,7 +324,7 @@ public static class JoinExecutor
             // computed over the JOINED rows — mirrors RecordPatches.QueryProjection.cs's
             // single-dataitem GROUP BY (#2137), just fed by `combos` (this executor's own join
             // output) instead of a plain table scan.
-            projected = BuildGroupedRows(ctx, plan, combos);
+            projected = BuildGroupedRows(ctx, plan, combos, flowFiltersAndMarks);
         }
 
         // 4. OrderBy over the projected result slots (top-level ordering).
@@ -470,13 +472,15 @@ public static class JoinExecutor
     /// buffer value at the column's TableSlot, or the child field's typed default for an
     /// unmatched LeftOuterJoin combo, or null if unsupported (ConstValue/no source field).
     /// </summary>
-    private static object? ResolveComboValue(JoinContext ctx, JoinColumn col, Dictionary<string, object?> combo)
+    private static object? ResolveComboValue(
+        JoinContext ctx, JoinColumn col, Dictionary<string, object?> combo, object? flowFiltersAndMarks)
     {
         if (col.FlowFieldMeta != null)
         {
             if (!combo.TryGetValue(col.OwnerName, out var ownerBuf) || ownerBuf == null)
                 return ctx.TypedDefaultForField(col.FlowFieldMeta);
-            return ApplyReverseSign(ctx, col.ColumnObj, ctx.CalcFlowFieldForRow(ownerBuf, col.FlowFieldMeta));
+            return ApplyReverseSign(ctx, col.ColumnObj,
+                ctx.CalcFlowFieldForRow(ownerBuf, col.FlowFieldMeta, flowFiltersAndMarks));
         }
         if (!combo.TryGetValue(col.OwnerName, out var buf) || buf == null)
             return col.SourceField != null ? ctx.TypedDefaultForField(col.SourceField) : null;
@@ -490,11 +494,12 @@ public static class JoinExecutor
     /// row per group. A query with NO non-aggregated column at all is BC's scalar-aggregate
     /// case (SQL's "GROUP BY ()"): exactly one output row always, even over zero joined combos.
     /// </summary>
-    private static List<object?[]> BuildGroupedRows(JoinContext ctx, JoinProjectionPlan plan, List<Dictionary<string, object?>> combos)
+    private static List<object?[]> BuildGroupedRows(JoinContext ctx, JoinProjectionPlan plan,
+        List<Dictionary<string, object?>> combos, object? flowFiltersAndMarks)
     {
         var groupKeyCols = plan.Columns.Where(c => c.Aggregation == "None").ToList();
         if (groupKeyCols.Count == 0)
-            return new List<object?[]> { BuildAggregateRow(ctx, plan, combos) };
+            return new List<object?[]> { BuildAggregateRow(ctx, plan, combos, flowFiltersAndMarks) };
 
         var groups = new Dictionary<JoinGroupKey, List<Dictionary<string, object?>>>();
         var order = new List<JoinGroupKey>();
@@ -502,7 +507,7 @@ public static class JoinExecutor
         {
             var keyValues = new object?[groupKeyCols.Count];
             for (int i = 0; i < groupKeyCols.Count; i++)
-                keyValues[i] = ResolveComboValue(ctx, groupKeyCols[i], combo);
+                keyValues[i] = ResolveComboValue(ctx, groupKeyCols[i], combo, flowFiltersAndMarks);
             var key = new JoinGroupKey(keyValues);
             if (!groups.TryGetValue(key, out var list))
             {
@@ -515,7 +520,7 @@ public static class JoinExecutor
 
         var result = new List<object?[]>(order.Count);
         foreach (var key in order)
-            result.Add(BuildAggregateRow(ctx, plan, groups[key]));
+            result.Add(BuildAggregateRow(ctx, plan, groups[key], flowFiltersAndMarks));
         return result;
     }
 
@@ -528,7 +533,8 @@ public static class JoinExecutor
     /// true combo count and Sum/Average/Min/Max skip exactly the missing ones) and hand them to
     /// ctx.ComputeAggregate — al-runner's own aggregation math, not re-derived here.
     /// </summary>
-    private static object?[] BuildAggregateRow(JoinContext ctx, JoinProjectionPlan plan, IReadOnlyList<Dictionary<string, object?>> groupCombos)
+    private static object?[] BuildAggregateRow(JoinContext ctx, JoinProjectionPlan plan,
+        IReadOnlyList<Dictionary<string, object?>> groupCombos, object? flowFiltersAndMarks)
     {
         var fields = new object?[plan.SlotCount];
         foreach (var col in plan.Columns)
@@ -548,7 +554,7 @@ public static class JoinExecutor
                 continue;
             }
             if (groupCombos.Count > 0)
-                fields[col.QuerySlot] = ResolveComboValue(ctx, col, groupCombos[0]);
+                fields[col.QuerySlot] = ResolveComboValue(ctx, col, groupCombos[0], flowFiltersAndMarks);
         }
         return fields;
     }

--- a/AlRunner.Tests/QueryFlowFieldFlowFilterTests.cs
+++ b/AlRunner.Tests/QueryFlowFieldFlowFilterTests.cs
@@ -1,0 +1,349 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #2925 -- a query column backed by a FlowField whose CalcFormula carries a
+/// FieldClass.FlowFilter where-condition used to throw a NullReferenceException out of BC's
+/// own FlowFieldsHelper.GetFilterFromMetaFilterCollection.
+///
+/// The null is BC's, but the fault is the runner's. Decompiling that method (bc281,
+/// Microsoft.Dynamics.Nav.Runtime.FlowFieldsHelper) shows exactly one unguarded dereference of
+/// its filtersAndMarks parameter, in the FieldClass.FlowFilter branch:
+///
+///     case FieldClass.FlowFilter:
+///         filterExpression = GetFlowFilterBasedFilter(nCLMetaFilterField, filtersAndMarks.Filters, session);
+///
+/// FlowFieldPatches.CalcOneFlowFieldForQueryRow entered the shared FlowField core with
+/// parentFiltersAndMarks hard-coded to null, so every CalcFormula with a flow-filter condition
+/// crashed on the query path while the identical formula computed fine on the Record.CalcFields
+/// path (which supplies the record's real FiltersAndMarks).
+///
+/// Two things are pinned here, and the second is why the first is not enough on its own:
+///
+///   1. The crash is gone. Passing BC's own FiltersAndMarks.Empty would do that much -- its
+///      Filters field is null (verified from the .cctor IL: `new FiltersAndMarks(null, null)`),
+///      and GetFlowFilterBasedFilter answers a null dictionary with "no constraint".
+///   2. A flow filter the QUERY actually sets still reaches the calculation. Fixing only (1)
+///      turns the crash into a silently wrong number: the runner measured 15 where the flow
+///      filter says 14, because TranslateQueryFilters was pushing the filter down as a row
+///      predicate on a FlowFilter field -- a field with no stored value to filter rows on --
+///      instead of routing it to the CalcFormula. That is the loud-failures.md silent default,
+///      one layer up.
+///
+/// The BEHAVIORAL claim (what value real BC computes in each case) is proven upstream against a
+/// real service tier -- StefanMaron/BusinessCentral.AL.Language.Tests PR #175, per
+/// .claude/rules/bc-behavior-tests-go-upstream.md. This suite pins the runner MECHANISM: that
+/// the query-projection path and the multi-dataitem JOIN path both route the query's own flow
+/// filters into FlowFieldPatches.CalcOneFlowFieldForQueryRow, and that neither crashes.
+///
+/// The join case is in the same bundle deliberately. Before this fix it failed with the SAME
+/// NRE, but reported at RecordPatches.QueryJoin.cs:204 with no BC frame at all, because
+/// ExecuteJoinQuery rethrew with `throw tie.InnerException` -- which resets the stack trace.
+/// That is why issue #2925 describes it as a possibly-unrelated second cluster. The rethrow now
+/// goes through ExceptionDispatchInfo, so the origin survives.
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
+/// </summary>
+public class QueryFlowFieldFlowFilterTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(string bundle)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" \"").Append(bundle).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = args.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private static string WriteBundle()
+    {
+        var root = TestScratch.Dir("al-runner-query-flowfilter-2925");
+        Directory.CreateDirectory(root);
+
+        File.WriteAllText(Path.Combine(root, "app.json"), """
+        {
+          "id": "c7d1e4f2-2925-4a1b-9c3d-000000002925",
+          "name": "QFF 2925 Repro",
+          "publisher": "Repro2925",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62470, "to": 62479 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(root, "Line.al"), """
+        table 62470 "QFF25 Line"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "Entry No."; Integer) { }
+                field(2; "Header No."; Code[20]) { }
+                field(3; "Posting Date"; Date) { }
+                field(4; Amount; Decimal) { }
+            }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+        """);
+
+        // "Total Amount" narrows its aggregate with the "Date Filter" flow filter -- the
+        // FieldClass.FlowFilter where-condition that reaches the unguarded dereference.
+        File.WriteAllText(Path.Combine(root, "Header.al"), """
+        table 62471 "QFF25 Header"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "No."; Code[20]) { }
+                field(2; "Date Filter"; Date) { FieldClass = FlowFilter; }
+                field(3; "Total Amount"; Decimal)
+                {
+                    FieldClass = FlowField;
+                    CalcFormula = sum("QFF25 Line".Amount where("Header No." = field("No."),
+                                                                "Posting Date" = field("Date Filter")));
+                }
+            }
+            keys { key(PK; "No.") { Clustered = true; } }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(root, "Tag.al"), """
+        table 62472 "QFF25 Tag"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "Header No."; Code[20]) { }
+                field(2; "Tag Code"; Code[20]) { }
+            }
+            keys { key(PK; "Header No.", "Tag Code") { Clustered = true; } }
+        }
+        """);
+
+        // No filter() element at all -- the query cannot set the flow filter, so BC's own
+        // "unset flow filter contributes no condition" answer must apply.
+        File.WriteAllText(Path.Combine(root, "QPlain.al"), """
+        query 62473 "QFF25 Plain"
+        {
+            QueryType = Normal;
+            elements
+            {
+                dataitem(H; "QFF25 Header")
+                {
+                    column(No; "No.") { }
+                    column(TotalAmount; "Total Amount") { }
+                }
+            }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(root, "QFiltered.al"), """
+        query 62474 "QFF25 Filtered"
+        {
+            QueryType = Normal;
+            elements
+            {
+                dataitem(H; "QFF25 Header")
+                {
+                    column(No; "No.") { }
+                    filter(DateFilter; "Date Filter") { }
+                    column(TotalAmount; "Total Amount") { }
+                }
+            }
+        }
+        """);
+
+        // Same flow-filtered FlowField column, reached through the multi-dataitem JOIN path
+        // (AlRunner.QueryJoin.JoinExecutor) rather than the single-dataitem projection path.
+        File.WriteAllText(Path.Combine(root, "QJoin.al"), """
+        query 62475 "QFF25 Join Filtered"
+        {
+            QueryType = Normal;
+            elements
+            {
+                dataitem(H; "QFF25 Header")
+                {
+                    column(No; "No.") { }
+                    filter(DateFilter; "Date Filter") { }
+                    column(TotalAmount; "Total Amount") { }
+
+                    dataitem(T; "QFF25 Tag")
+                    {
+                        DataItemLink = "Header No." = H."No.";
+                        column(TagCode; "Tag Code") { }
+                    }
+                }
+            }
+        }
+        """);
+
+        // Three lines: 10 on 2024-01-10, 4 on 2024-02-10, 1 on 2024-03-10. Whole aggregate 15;
+        // the 2024-01-01..2024-02-15 window is 14. 14 and 15 are both non-zero and different
+        // from each other, so neither a dropped filter nor a default-returning implementation
+        // can produce the expected value by accident.
+        File.WriteAllText(Path.Combine(root, "Tests.al"), """
+        codeunit 62476 "QFF25 Tests"
+        {
+            Subtype = Test;
+
+            local procedure Seed()
+            var
+                H: Record "QFF25 Header";
+                L: Record "QFF25 Line";
+                T: Record "QFF25 Tag";
+            begin
+                if not H.Get('H1') then begin
+                    H.Init(); H."No." := 'H1'; H.Insert();
+                end;
+                if T.IsEmpty() then begin
+                    T.Init(); T."Header No." := 'H1'; T."Tag Code" := 'A'; T.Insert();
+                end;
+                if L.IsEmpty() then begin
+                    L.Init(); L."Entry No." := 1; L."Header No." := 'H1'; L."Posting Date" := 20240110D; L.Amount := 10; L.Insert();
+                    L.Init(); L."Entry No." := 2; L."Header No." := 'H1'; L."Posting Date" := 20240210D; L.Amount := 4; L.Insert();
+                    L.Init(); L."Entry No." := 3; L."Header No." := 'H1'; L."Posting Date" := 20240310D; L.Amount := 1; L.Insert();
+                end;
+            end;
+
+            [Test]
+            procedure RecordCalcFields_NoFlowFilter_SumsAll()
+            var
+                H: Record "QFF25 Header";
+            begin
+                Seed();
+                H.Get('H1');
+                H.CalcFields("Total Amount");
+                if H."Total Amount" <> 15 then
+                    Error('rec-nofilter: expected 15, got %1', H."Total Amount");
+            end;
+
+            [Test]
+            procedure RecordCalcFields_WithFlowFilter_SumsRange()
+            var
+                H: Record "QFF25 Header";
+            begin
+                Seed();
+                H.Get('H1');
+                H.SetRange("Date Filter", 20240101D, 20240215D);
+                H.CalcFields("Total Amount");
+                if H."Total Amount" <> 14 then
+                    Error('rec-filter: expected 14, got %1', H."Total Amount");
+            end;
+
+            [Test]
+            procedure QueryFlowFieldColumn_NoFlowFilter_SumsAll()
+            var
+                Q: Query "QFF25 Plain";
+                T: Decimal;
+            begin
+                Seed();
+                Q.SetRange(No, 'H1');
+                Q.Open();
+                if not Q.Read() then Error('q1: expected one row');
+                T := Q.TotalAmount;
+                Q.Close();
+                if T <> 15 then Error('q1: expected 15, got %1', T);
+            end;
+
+            [Test]
+            procedure QueryFlowFieldColumn_WithFlowFilter_SumsRange()
+            var
+                Q: Query "QFF25 Filtered";
+                T: Decimal;
+            begin
+                Seed();
+                Q.SetRange(No, 'H1');
+                Q.SetFilter(DateFilter, '%1..%2', 20240101D, 20240215D);
+                Q.Open();
+                if not Q.Read() then Error('q2: expected one row');
+                T := Q.TotalAmount;
+                Q.Close();
+                if T <> 14 then Error('q2: expected 14, got %1', T);
+            end;
+
+            [Test]
+            procedure JoinQueryFlowFieldColumn_NoFlowFilter_SumsAll()
+            var
+                Q: Query "QFF25 Join Filtered";
+                T: Decimal;
+            begin
+                Seed();
+                Q.SetRange(No, 'H1');
+                Q.Open();
+                if not Q.Read() then Error('q3a: expected one row');
+                T := Q.TotalAmount;
+                if Q.TagCode <> 'A' then Error('q3a: expected tag A, got %1', Q.TagCode);
+                Q.Close();
+                if T <> 15 then Error('q3a: expected 15, got %1', T);
+            end;
+
+            [Test]
+            procedure JoinQueryFlowFieldColumn_WithFlowFilter_SumsRange()
+            var
+                Q: Query "QFF25 Join Filtered";
+                T: Decimal;
+            begin
+                Seed();
+                Q.SetRange(No, 'H1');
+                Q.SetFilter(DateFilter, '%1..%2', 20240101D, 20240215D);
+                Q.Open();
+                if not Q.Read() then Error('q3b: expected one row');
+                T := Q.TotalAmount;
+                if Q.TagCode <> 'A' then Error('q3b: expected tag A, got %1', Q.TagCode);
+                Q.Close();
+                if T <> 14 then Error('q3b: expected 14, got %1', T);
+            end;
+        }
+        """);
+
+        return root;
+    }
+
+    [SkippableFact]
+    public void QueryFlowFieldColumn_WithFlowFilterCondition_CalculatesInsteadOfCrashing()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var bundle = WriteBundle();
+        var (output, exitCode) = RunRunner(bundle);
+
+        // Never silently pass a run that never got the test codeunit compiled and executed.
+        Assert.DoesNotContain("EMIT-EXCLUDED", output);
+        Assert.DoesNotContain("COMPILE FAIL", output);
+        // The crash this issue reports, by the BC frame it appeared in.
+        Assert.DoesNotContain("GetFilterFromMetaFilterCollection", output);
+        Assert.DoesNotContain("NullReferenceException", output);
+        // 6P/0F/0E is TestExecutor's own per-bundle summary line. All six must have run: two
+        // Record.CalcFields controls (the path that always worked, so a regression there shows
+        // as a failure rather than as a silently-changed expectation), two single-dataitem
+        // query cases, and two JOIN cases.
+        Assert.Contains("6P/0F/0E", output);
+        Assert.Equal(0, exitCode);
+    }
+}

--- a/AlRunner/Patches/FlowFieldPatches.cs
+++ b/AlRunner/Patches/FlowFieldPatches.cs
@@ -917,8 +917,26 @@ public static class FlowFieldPatches
     /// <c>MutableRecordBuffer</c> does, which is what <c>GetFilterFromMetaFilterCollection</c>
     /// actually requires (its parameter type is the interface, not the concrete buffer type), so
     /// CalcFlowFieldValuesCore needs no changes to accept it.
+    ///
+    /// #2925 — <paramref name="flowFiltersAndMarks"/> carries the QUERY's own flow filters (an
+    /// AL <c>filter(Name; "Some Flow Filter")</c> element, or a static <c>ColumnFilter</c> on
+    /// one), keyed by the FlowFilter <c>NCLMetaField</c>, exactly the way a record's
+    /// <c>FiltersAndMarks</c> carries the ones <c>Record.SetRange("Date Filter", ...)</c> sets.
+    /// It is what BC's own <c>FlowFieldsHelper.GetFilterFromMetaFilterCollection</c>
+    /// dereferences UNGUARDED for a <c>FieldClass.FlowFilter</c> where-condition
+    /// (<c>GetFlowFilterBasedFilter(metaFilter, filtersAndMarks.Filters, session)</c>), so
+    /// passing null here — which this method used to do — NREs inside BC for every CalcFormula
+    /// carrying a flow-filter condition (e.g. <c>Cust. Ledger Entry."Remaining Amt. (LCY)"</c>,
+    /// whose formula reads <c>upperlimit("Date Filter")</c>).
+    ///
+    /// A null argument means "this query set no flow filter", and is answered with BC's own
+    /// <c>FiltersAndMarks.Empty</c> — whose <c>Filters</c> is itself null, which is precisely
+    /// the input <c>GetFlowFilterBasedFilter</c> reads as "flow filter unset → contributes no
+    /// constraint" (it returns null, and the caller's <c>IsNullOrConstantTrue()</c> skips it).
+    /// So the unset case is decided by BC's code, not by a runner-side assumption about it.
     /// </summary>
-    internal static NavValue? CalcOneFlowFieldForQueryRow(object rowBuffer, NCLMetaField flowFieldMeta)
+    internal static NavValue? CalcOneFlowFieldForQueryRow(
+        object rowBuffer, NCLMetaField flowFieldMeta, object? flowFiltersAndMarks = null)
     {
         // NavCurrentThread.Session must resolve on every real test run (CalcFlowFieldValuesCore
         // below is unreachable without it, and every other FlowField entry point in this file —
@@ -949,9 +967,19 @@ public static class FlowFieldPatches
         // RecordPatches.cs's companyTokens skeleton-state comment) — the same value every other
         // FlowField/query code path in this runner uses when no per-record company token is
         // available.
+        // #2925: never null — see the summary above. Resolving FiltersAndMarks.Empty is part of
+        // Register(); if THAT failed, say so instead of handing BC a null it dereferences (the
+        // NRE this parameter exists to remove) or silently answering with an unfiltered total.
+        var parentFm = flowFiltersAndMarks ?? _emptyFm
+            ?? throw new InvalidOperationException(
+                $"CalcOneFlowFieldForQueryRow('{flowFieldMeta.FieldName}' on "
+                + $"'{flowFieldMeta.Parent?.TableName}'): Microsoft.Dynamics.Nav.Runtime."
+                + "FiltersAndMarks.Empty could not be resolved on this artifact, so the "
+                + "FlowField's where-conditions cannot be evaluated against BC's own helper.");
+
         var results = new List<Tuple<INavFieldMetadata, NavValue>>();
         CalcFlowFieldValuesCore(session, companyToken: 0, rowBuffer,
-            parentFiltersAndMarks: null, securityFiltering: null, alIsolationLevel: null,
+            parentFiltersAndMarks: parentFm, securityFiltering: null, alIsolationLevel: null,
             new NCLMetaField[] { flowFieldMeta }, recursionLevel: 0, results);
         return results.Count > 0 ? results[0].Item2 : null;
     }

--- a/AlRunner/Patches/RecordPatches.QueryJoin.cs
+++ b/AlRunner/Patches/RecordPatches.QueryJoin.cs
@@ -185,7 +185,7 @@ public static partial class RecordPatches
     /// AlRunner.QueryJoin executor. Materialised eagerly inside the executor so any failure
     /// surfaces as a managed exception here, never a native crash mid-enumeration.
     /// </summary>
-    private static IEnumerable ExecuteJoinQuery(object nclMetaQuery)
+    private static IEnumerable ExecuteJoinQuery(object nclMetaQuery, object? flowFiltersAndMarks)
     {
         EnsureJoinExecutorLoaded();
         var queryDef = _tNCLMetaQuery!.GetProperty("QueryDefinition", BindingFlags.Public | BindingFlags.Instance)!
@@ -197,11 +197,19 @@ public static partial class RecordPatches
 
         try
         {
-            return (IEnumerable)_mExecute!.Invoke(null, new[] { _joinCtx, nclMetaQuery, dataAccessSource })!;
+            return (IEnumerable)_mExecute!.Invoke(null,
+                new[] { _joinCtx, nclMetaQuery, dataAccessSource, flowFiltersAndMarks })!;
         }
         catch (TargetInvocationException tie) when (tie.InnerException != null)
         {
-            throw tie.InnerException; // surface the executor's real exception (e.g. OOS)
+            // Surface the executor's real exception (e.g. OOS) — via ExceptionDispatchInfo, NOT
+            // `throw tie.InnerException`. A bare rethrow RESETS the stack trace to this frame, so
+            // every failure inside the executor was reported as originating HERE, at
+            // RecordPatches.QueryJoin.cs. That is how #2925's second cluster (4 Tests-SMB tests)
+            // looked like a different bug from its first (21 tests): the same
+            // FlowFieldsHelper.GetFilterFromMetaFilterCollection NRE, with its origin erased.
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw(tie.InnerException);
+            throw; // unreachable; satisfies definite assignment
         }
     }
 

--- a/AlRunner/Patches/RecordPatches.QueryProjection.cs
+++ b/AlRunner/Patches/RecordPatches.QueryProjection.cs
@@ -123,10 +123,10 @@ public static partial class RecordPatches
         object self, object request, Func<bool>? onlyCurrentKeyNeededForNextRow)
     {
         EnsureQueryProjectionReflection(self);
-        var execRequest = TranslateQueryFilters(request, out var havingFilters);
+        var execRequest = TranslateQueryFilters(request, out var havingFilters, out var flowFam);
         var raw = (IEnumerable<ReadOnlyRecordBuffer>)_mTtdpFindImpl!.Invoke(self, new[] { execRequest })!;
         raw = ApplyFirstOnly(request, raw);
-        return ProjectIfQuery(request, raw, havingFilters);
+        return ProjectIfQuery(request, raw, havingFilters, flowFam);
     }
 
     /// <summary>
@@ -136,10 +136,10 @@ public static partial class RecordPatches
         object self, object request, Func<bool>? onlyCurrentKeyNeededForNextRow)
     {
         EnsureQueryProjectionReflection(self);
-        var execRequest = TranslateQueryFilters(request, out var havingFilters);
+        var execRequest = TranslateQueryFilters(request, out var havingFilters, out var flowFam);
         var raw = (IEnumerable<ReadOnlyRecordBuffer>)_mTtdpFindByPositionImpl!.Invoke(self, new[] { execRequest })!;
         raw = ApplyFirstOnly(request, raw);
-        return ProjectIfQuery(request, raw, havingFilters);
+        return ProjectIfQuery(request, raw, havingFilters, flowFam);
     }
 
     private static MethodInfo? _mGetDataAccessForTable_Orig;
@@ -463,10 +463,25 @@ public static partial class RecordPatches
     /// unaggregated value instead, a different silently-wrong answer than #2137 but the same
     /// class of bug. Such filters are instead returned via <paramref name="havingFilters"/>
     /// so the caller can apply them AFTER aggregation (see ApplyHavingFilters).
+    ///
+    /// A filter whose column is backed by a <b>FlowFilter</b>-class source field (an AL
+    /// <c>filter(Name; "Date Filter")</c> element, or a static <c>ColumnFilter</c> on one) is
+    /// neither a WHERE nor a HAVING condition — it constrains the FlowField COLUMNS' own
+    /// CalcFormula the same way <c>Record.SetRange("Date Filter", ...)</c> constrains
+    /// <c>Record.CalcFields</c>. Pushing it down as a row filter would filter on a field that
+    /// has no stored value at all. Those are returned via
+    /// <paramref name="flowFiltersAndMarks"/> — a <c>FiltersAndMarks</c> keyed by the FlowFilter
+    /// <c>NCLMetaField</c>, i.e. the exact shape BC's own <c>FlowFieldsHelper.
+    /// GetFilterFromMetaFilterCollection</c> reads them out of — for the projection layer to
+    /// hand to <c>FlowFieldPatches.CalcOneFlowFieldForQueryRow</c> (#2925). Null when the query
+    /// carries no flow filter at all.
     /// </summary>
-    private static object TranslateQueryFilters(object request, out List<(object Column, object Expr)> havingFilters)
+    private static object TranslateQueryFilters(
+        object request, out List<(object Column, object Expr)> havingFilters, out object? flowFiltersAndMarks)
     {
         havingFilters = new List<(object, object)>();
+        flowFiltersAndMarks = null;
+        var flowFilterTuples = new List<object>();
         var metaAppObj = _pReqMetaAppObj!.GetValue(request);
         if (metaAppObj == null || _tNCLMetaQuery == null || !_tNCLMetaQuery.IsInstanceOfType(metaAppObj))
             return request; // ordinary table read — nothing to translate.
@@ -498,6 +513,14 @@ public static partial class RecordPatches
                 if (key != null && _tNCLMetaQueryColumn != null && _tNCLMetaQueryColumn.IsInstanceOfType(key))
                 {
                     runtimeFilteredColumnIds.Add(((NCLMetaQueryColumn)key).Id);
+                    // #2925: a filter on a FlowFilter-class field is a FLOW filter, not a row
+                    // filter — route it to the FlowField calculation and keep it out of the
+                    // WHERE push-down (the field has no stored column to filter rows on).
+                    if (expr != null && TryTakeFlowFilter((NCLMetaQueryColumn)key, expr, flowFilterTuples))
+                    {
+                        anyTranslated = true;
+                        continue;
+                    }
                     if (((NCLMetaQueryColumn)key).AggregationType != AggregationType.None)
                     {
                         // HAVING-clause filter — exclude from the WHERE-style push-down (pushing it
@@ -531,6 +554,11 @@ public static partial class RecordPatches
         foreach (var (col, expr) in staticColumnFilters)
         {
             if (runtimeFilteredColumnIds.Contains(col.Id)) continue;
+            if (TryTakeFlowFilter(col, expr, flowFilterTuples)) // #2925, as above
+            {
+                anyTranslated = true;
+                continue;
+            }
             if (col.AggregationType != AggregationType.None)
             {
                 havingFilters.Add((col, expr));
@@ -544,6 +572,14 @@ public static partial class RecordPatches
                 anyTranslated = true;
             }
         }
+
+        // #2925: hand the collected flow filters back as a real FiltersAndMarks. MarkedRecords
+        // is null — marks are a Record concept (Record.Mark/MarkedOnly) with no query
+        // equivalent, and BC's own FiltersAndMarks.Empty is itself constructed as
+        // `new FiltersAndMarks(null, null)`.
+        if (flowFilterTuples.Count > 0)
+            flowFiltersAndMarks = Activator.CreateInstance(
+                _tFiltersAndMarks!, BuildFilterFieldDictionary(flowFilterTuples), null);
 
         if (!anyTranslated) return request;
 
@@ -580,6 +616,45 @@ public static partial class RecordPatches
             if (col is NCLMetaQueryColumn c && expr != null)
                 yield return (c, expr);
         }
+    }
+
+    /// <summary>
+    /// #2925 — if <paramref name="col"/>'s source table field is a <c>FlowFilter</c>, add its
+    /// filter expression to <paramref name="flowFilterTuples"/> (retargeted to the FlowFilter
+    /// field's own expression context, exactly as a WHERE-bound filter is retargeted to its
+    /// source field's) and report true so the caller keeps it out of the row filters.
+    ///
+    /// A FlowFilter field holds no data — it is a parameter to the table's FlowField formulas —
+    /// so evaluating it as a row predicate is meaningless in either direction: pushed into the
+    /// temp provider's WHERE it filters on an unwritten slot, and evaluated post-projection
+    /// (the join path) it compares against a slot nothing ever wrote. The one place it means
+    /// something is the CalcFormula, which is where this routes it.
+    ///
+    /// <c>SourceTableField</c> throws <c>NotSupportedException</c> for a ConstValue column (no
+    /// source field at all); that is not a flow filter, so it answers false and the caller's
+    /// existing handling stands.
+    /// </summary>
+    /// <summary>#2925 — true iff this query column is backed by a FlowFilter-class table field.</summary>
+    private static bool IsFlowFilterColumn(NCLMetaQueryColumn col)
+    {
+        try
+        {
+            return col.SourceTableField?.FieldClass
+                == Microsoft.Dynamics.Nav.Types.Metadata.FieldClass.FlowFilter;
+        }
+        catch { return false; } // ConstValue column — SourceTableField throws; not a flow filter.
+    }
+
+    private static bool TryTakeFlowFilter(NCLMetaQueryColumn col, object expr, List<object> flowFilterTuples)
+    {
+        NCLMetaField? srcField;
+        try { srcField = col.SourceTableField; }
+        catch { return false; }
+        if (srcField == null
+            || srcField.FieldClass != Microsoft.Dynamics.Nav.Types.Metadata.FieldClass.FlowFilter)
+            return false;
+        flowFilterTuples.Add(MakeFieldTuple(srcField, RetargetFilterExpression(expr, srcField.ExpressionContext)));
+        return true;
     }
 
     private static object MakeFieldTuple(object field, object expr)
@@ -713,7 +788,8 @@ public static partial class RecordPatches
     }
 
     private static IEnumerable<ReadOnlyRecordBuffer> ProjectIfQuery(
-        object request, IEnumerable<ReadOnlyRecordBuffer> rows, List<(object Column, object Expr)> havingFilters)
+        object request, IEnumerable<ReadOnlyRecordBuffer> rows, List<(object Column, object Expr)> havingFilters,
+        object? flowFiltersAndMarks)
     {
         var metaAppObj = _pReqMetaAppObj!.GetValue(request);
         if (metaAppObj == null || _tNCLMetaQuery == null || !_tNCLMetaQuery.IsInstanceOfType(metaAppObj))
@@ -733,7 +809,7 @@ public static partial class RecordPatches
             // Min/Max) column, ExecuteJoinQuery performs the implicit GROUP BY over the
             // joined rows itself (mirroring ProjectQueryRows' single-dataitem GROUP BY) —
             // see AlRunner.QueryJoin.JoinExecutor.BuildGroupedRows.
-            var joined = ExecuteJoinQuery(metaAppObj).Cast<ReadOnlyRecordBuffer>();
+            var joined = ExecuteJoinQuery(metaAppObj, flowFiltersAndMarks).Cast<ReadOnlyRecordBuffer>();
             // Apply the live NavQuery's runtime filters (SetRange/SetFilter) as a POST-projection
             // pass. The single-dataitem path pushes these into the temp provider's WHERE
             // (TranslateQueryFilters); the join executor reads each dataitem's table with only its
@@ -761,7 +837,7 @@ public static partial class RecordPatches
         // a group before they're ever summed/counted/averaged.
         var top = _pReqTopNumberOfRows!.GetValue(request);
         int topN = top == null ? 0 : Convert.ToInt32(top);
-        var projected = ProjectQueryRows(metaAppObj, rows);
+        var projected = ProjectQueryRows(metaAppObj, rows, flowFiltersAndMarks);
         // #2146: HAVING-clause filters (runtime SetRange/SetFilter on an aggregated column)
         // are evaluated here, against the already-aggregated per-group result — never against
         // the raw pre-aggregation row. Applied AFTER grouping/aggregation, BEFORE Top, matching
@@ -861,6 +937,13 @@ public static partial class RecordPatches
                         "NavQuery (multi-dataitem join)",
                         "query-join-runtime-filter-on-nonprojected-column — a runtime filter is keyed by a " +
                         $"non-query-column ({key?.GetType().Name ?? "null"}); cannot evaluate post-projection; see docs/scope.md");
+                runtimeFilteredColumnIds.Add(((NCLMetaQueryColumn)key).Id);
+                // #2925: a FlowFilter-class column carries no projected value to compare against
+                // — TranslateQueryFilters has already routed it to the FlowField calculation as
+                // a flow filter. Evaluating it here against its (never-written) slot would drop
+                // every row. Checked BEFORE the slot lookup below, which would otherwise refuse
+                // the column outright for the same reason it has no value: it is not projected.
+                if (IsFlowFilterColumn((NCLMetaQueryColumn)key)) continue;
                 if (!slotMap.TryGetValue(key, out var slot))
                     // The filtered column isn't in ANY dataitem's QueryColumns of this query
                     // definition — should not occur (the filter dictionary is keyed by columns that
@@ -869,7 +952,6 @@ public static partial class RecordPatches
                         "NavQuery (multi-dataitem join)",
                         "query-join-runtime-filter-unresolved-column — a runtime filter's column could not be " +
                         "located in the query's own DataItems/QueryColumns; see docs/scope.md");
-                runtimeFilteredColumnIds.Add(((NCLMetaQueryColumn)key).Id);
                 conds.Add((slot, expr));
             }
 
@@ -883,6 +965,7 @@ public static partial class RecordPatches
         foreach (var (col, expr) in staticColumnFilters)
         {
             if (runtimeFilteredColumnIds.Contains(col.Id)) continue;
+            if (IsFlowFilterColumn(col)) continue; // #2925, as above
             if (!slotMap.TryGetValue(col, out var slot))
                 throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
                     "NavQuery (multi-dataitem join)",
@@ -975,7 +1058,8 @@ public static partial class RecordPatches
         public bool HasAggregate;
     }
 
-    private static IEnumerable<ReadOnlyRecordBuffer> ProjectQueryRows(object nclMetaQuery, IEnumerable<ReadOnlyRecordBuffer> rows)
+    private static IEnumerable<ReadOnlyRecordBuffer> ProjectQueryRows(
+        object nclMetaQuery, IEnumerable<ReadOnlyRecordBuffer> rows, object? flowFiltersAndMarks)
     {
         var plan = _projectionPlans.GetValue(nclMetaQuery, BuildProjectionPlan);
 
@@ -984,7 +1068,7 @@ public static partial class RecordPatches
             // No Method column anywhere in this query → every row projects independently,
             // exactly as before #2137 (this is the 99% case: a plain, non-aggregated query).
             foreach (var row in rows)
-                yield return BuildRow(nclMetaQuery, plan, new[] { row });
+                yield return BuildRow(nclMetaQuery, plan, new[] { row }, flowFiltersAndMarks);
             yield break;
         }
 
@@ -1000,7 +1084,7 @@ public static partial class RecordPatches
             // Scalar aggregate (no non-aggregated column at all) — SQL's "GROUP BY ()" always
             // produces exactly one group, even over zero source rows (SUM/COUNT/AVERAGE then
             // default to 0; MIN/MAX to the column's own typed default — see ComputeAggregate).
-            yield return BuildRow(nclMetaQuery, plan, sourceRows);
+            yield return BuildRow(nclMetaQuery, plan, sourceRows, flowFiltersAndMarks);
             yield break;
         }
 
@@ -1023,7 +1107,7 @@ public static partial class RecordPatches
         }
 
         foreach (var key in groupOrder)
-            yield return BuildRow(nclMetaQuery, plan, groups[key]);
+            yield return BuildRow(nclMetaQuery, plan, groups[key], flowFiltersAndMarks);
     }
 
     /// <summary>
@@ -1094,7 +1178,9 @@ public static partial class RecordPatches
         return (NavValue?)_mFlowFieldsHelperNegateValue.Invoke(null, new object?[] { value, column.NavType });
     }
 
-    private static ReadOnlyRecordBuffer BuildRow(object nclMetaQuery, ProjectionPlan plan, IReadOnlyList<ReadOnlyRecordBuffer> groupRows)
+    private static ReadOnlyRecordBuffer BuildRow(
+        object nclMetaQuery, ProjectionPlan plan, IReadOnlyList<ReadOnlyRecordBuffer> groupRows,
+        object? flowFiltersAndMarks)
     {
         var fields = new object?[plan.SlotCount];
         foreach (var c in plan.Columns)
@@ -1111,7 +1197,8 @@ public static partial class RecordPatches
             // follow-up rather than guessed at here.
             if (c.FlowFieldMeta != null && groupRows.Count > 0)
             {
-                fields[c.QuerySlot] = ApplyReverseSign(c.Column, FlowFieldPatches.CalcOneFlowFieldForQueryRow(groupRows[0], c.FlowFieldMeta));
+                fields[c.QuerySlot] = ApplyReverseSign(c.Column,
+                    FlowFieldPatches.CalcOneFlowFieldForQueryRow(groupRows[0], c.FlowFieldMeta, flowFiltersAndMarks));
                 continue;
             }
             if (c.TableSlot < 0 || groupRows.Count == 0 || c.TableSlot >= groupRows[0].FieldCount)
@@ -1237,8 +1324,8 @@ public static partial class RecordPatches
     /// same FlowFieldPatches.CalcOneFlowFieldForQueryRow the single-real-dataitem path (#2300)
     /// uses, so the aggregation/formula math is not duplicated across the assembly boundary.
     /// </summary>
-    private static object? Join_CalcFlowFieldForRow(object rowBuffer, object flowFieldMeta)
-        => FlowFieldPatches.CalcOneFlowFieldForQueryRow(rowBuffer, (NCLMetaField)flowFieldMeta);
+    private static object? Join_CalcFlowFieldForRow(object rowBuffer, object flowFieldMeta, object? flowFiltersAndMarks)
+        => FlowFieldPatches.CalcOneFlowFieldForQueryRow(rowBuffer, (NCLMetaField)flowFieldMeta, flowFiltersAndMarks);
 
     private static Type? _tNavValue;
     private static Array ToNavValueArray(object?[] values)


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.100.0
Closes #2925

BC's `FlowFieldsHelper.GetFilterFromMetaFilterCollection` dereferences its `filtersAndMarks` argument in exactly one place — the `FieldClass.FlowFilter` branch, verified by decompiling it on bc281:

```csharp
case FieldClass.FlowFilter:
    filterExpression = GetFlowFilterBasedFilter(nCLMetaFilterField, filtersAndMarks.Filters, session);
    break;
```

`FlowFieldPatches.CalcOneFlowFieldForQueryRow` entered the shared FlowField core with `parentFiltersAndMarks: null`, so every CalcFormula carrying a flow-filter condition crashed on the query path while the identical formula computed fine through `Record.CalcFields` (which supplies the record's real `FiltersAndMarks`). That settles the issue's open question: it is the `filtersAndMarks` argument, not `currentRecord` — the `ReadOnlyRecordBuffer` the query path passes is fine.

## Not just the null

Handing BC its own `FiltersAndMarks.Empty` removes the crash, and that is the correct answer when the query sets no flow filter: `Empty` is built as `new FiltersAndMarks(null, null)` (from the `.cctor` IL), and `GetFlowFilterBasedFilter` answers a null dictionary with `return null`, which the caller's `IsNullOrConstantTrue()` skips. So BC's own code decides the unset case.

But stopping there turns the crash into a wrong number. Measured on the reproducer: with the flow filter set through the query's `filter()` element, the runner reported **15** where the filter says **14**. `TranslateQueryFilters` was retargeting that filter onto the FlowFilter *table field* and pushing it into the row WHERE — a field that holds no data, so it constrained nothing and the FlowField never saw it. That is the silent default `loud-failures.md` is about, one layer up from the NRE.

So the fix routes a filter on a FlowFilter-class column out of the row filters and into the FlowField calculation, as a `FiltersAndMarks` keyed by the FlowFilter `NCLMetaField` — the shape BC's own helper reads them out of.

## Fix the shape, not just the line

**Does the same wrong pattern appear at another call site?** Yes, and it is the issue's own "neighbouring sub-shape". `ApplyJoinRuntimeFilters` evaluates a runtime filter post-projection against the column's projection slot; for a FlowFilter column that slot is never written, so it would have dropped every row. Both its loops now skip flow-filter columns, and the skip is placed *before* the slot lookup that would otherwise refuse the column outright.

**Does a sibling function make the same assumption?** Yes. `AlRunner.QueryJoin.JoinExecutor` reaches the same `CalcOneFlowFieldForQueryRow` through `JoinContext.CalcFlowFieldForRow`, and had the same null. The delegate now carries the flow filters, threaded through `Execute`, `BuildGroupedRows`, `BuildAggregateRow` and `ResolveComboValue`.

**If two code paths write the same state, do they maintain the same invariant?** They do now: the single-dataitem projection path and the join path both receive the same `FiltersAndMarks` from the same `TranslateQueryFilters` call.

One more thing that is not a behavior change but is why the issue read as two clusters. `ExecuteJoinQuery` rethrew with `throw tie.InnerException`, which **resets the stack trace** — so every failure inside the isolated executor was reported as originating at `RecordPatches.QueryJoin.cs:204` with no BC frame at all. The RED baseline reproduces exactly that: four tests NRE at line 204, four NRE inside `GetFilterFromMetaFilterCollection`, one root cause. It now goes through `ExceptionDispatchInfo`, matching what `FlowFieldPatches` already does 40 lines away.

`NavReportSync.cs` has four more instances of the same bare-rethrow shape. They are outside this issue's area and have no test to move, so I left them; filed as #2948 rather than fixed silently.

## RED to GREEN

Reproducer: `QFF25 Header."Total Amount" = sum("QFF25 Line".Amount where("Header No." = field("No."), "Posting Date" = field("Date Filter")))`. Three lines — 10 on 2024-01-10, 4 on 2024-02-10, 1 on 2024-03-10. Whole aggregate 15; the 2024-01-01..2024-02-15 window 14. Both non-zero and different, so neither a dropped filter nor a default-returning implementation lands on the expected value by accident.

RED, at `origin/main` (`git checkout HEAD~1 --` on the five files, rebuilt):

```
PASS  RecordCalcFields_NoFlowFilter_SumsAll
PASS  RecordCalcFields_WithFlowFilter_SumsRange
FAIL  QueryFlowFieldColumn_NoFlowFilter_SumsAll        NullReferenceException ... GetFilterFromMetaFilterCollection
FAIL  QueryFlowFieldColumn_WithFlowFilter_SumsRange    NullReferenceException ... GetFilterFromMetaFilterCollection
FAIL  JoinQueryFlowFieldColumn_NoFlowFilter_SumsAll    NullReferenceException at RecordPatches.QueryJoin.cs:204
FAIL  JoinQueryFlowFieldColumn_WithFlowFilter_SumsRange NullReferenceException at RecordPatches.QueryJoin.cs:204
```

The two `Record.CalcFields` controls pass in both states, which is what shows the query path is the defect rather than the formula.

GREEN: 6P/0F/0E, cold cache and again warm — the AL-query-on-a-compile-cache-hit trap is a real one here, so both were run.

## Where the tests live

The behavioral claim (what value real BC computes with the flow filter set and unset) is plain BC behavior, so it went upstream: **StefanMaron/BusinessCentral.AL.Language.Tests PR #175**, three tests extending `TestQueryFlowFieldColumn.al`, each query assertion paired with the equivalent `Record.CalcFields` assertion. All three pass against this build. That PR is the real-BC verification and is not merged yet, so no pin bump here.

`AlRunner.Tests/QueryFlowFieldFlowFilterTests.cs` pins the runner **mechanism** — that both query paths route the query's own flow filters into the calculation and neither crashes.

## What else I ran

- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~Query|FullyQualifiedName~FlowField"` — 27 passed, re-run after the rebase onto current `main`.
- Full al-language corpus: 2568 tests, 5 failures, all `Codeunit60756.TestPage_Previous_*`. Those come from corpus commit `f93060f`, merged upstream after the runner's current pin — they are not in the pinned tree and are unrelated to this change. Run against a corpus checkout carrying PR #175, which is also how the three new corpus tests were exercised.
- `tests/runner-extras/query-join-aggregation-oos` — 4/4.

Written by an agent (impl-9) on the account holder's behalf.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf

