### PR TITLE
fix(object-metadata): say the twelve 2000000071 refusals are gaps, not scope boundaries

### DIFF
--- a/AlRunner.Tests/ObjectMetadataProviderRowProbeTests.cs
+++ b/AlRunner.Tests/ObjectMetadataProviderRowProbeTests.cs
@@ -86,9 +86,13 @@ public sealed class ObjectMetadataProviderRowProbeTests
         // Names the member that moved, so a BC layout change points at its own fix.
         Assert.Contains("primaryTree", ex.Message);
         Assert.Contains(nameof(ProviderWithoutPrimaryTree), ex.Message);
-        // Names the surface and carries the docs/scope.md reason anchor the manifest matches on.
+        // Names the surface, and claims a gap rather than a scope boundary (#2894): this table
+        // IS in scope, so the anchor is "not-yet-implemented" and the doc link points at
+        // docs/limitations.md, which is where the table is written up.
         Assert.Equal("Object Metadata (system table 2000000071)", ex.Api);
-        Assert.StartsWith("object-metadata-system-table", ex.Reason);
+        Assert.StartsWith("not-yet-implemented", ex.Reason);
+        Assert.Contains("object-metadata-system-table", ex.Reason);
+        Assert.EndsWith(" — see docs/limitations.md#object-metadata-system-table", ex.Message);
         // Says WHY it refuses rather than guessing, so the message is actionable.
         Assert.Contains("--test-data", ex.Message);
     }
@@ -103,7 +107,8 @@ public sealed class ObjectMetadataProviderRowProbeTests
 
         Assert.Contains("primaryTree", ex.Message);
         Assert.Equal("Object Metadata (system table 2000000071)", ex.Api);
-        Assert.StartsWith("object-metadata-system-table", ex.Reason);
+        Assert.StartsWith("not-yet-implemented", ex.Reason);
+        Assert.Contains("object-metadata-system-table", ex.Reason);
     }
 
     // ── The positive arms: BC's genuine answers still come back, unchanged ───────────

--- a/AlRunner.Tests/ObjectMetadataSystemTableRefusalTests.cs
+++ b/AlRunner.Tests/ObjectMetadataSystemTableRefusalTests.cs
@@ -1,0 +1,204 @@
+// ObjectMetadataSystemTableRefusalTests — what the twelve refusals in
+// RecordPatches.ObjectMetadataSystemTable.cs actually claim, and where they send the reader.
+//
+// WHY THIS IS A RUNNER-SIDE MECHANISM TEST AND NOT AN AL BUNDLE
+// ------------------------------------------------------------
+// Every one of the twelve fires only when something the runner reflects on is absent or the
+// wrong shape: BC's SystemTables type, its ApplicationDatabaseTables list, NavEnvironment,
+// the "Object Type" option string, the in-memory data provider, TempTableDataProvider's
+// private primaryTree field. None of those is reachable from AL — no AL statement can make
+// SystemTables disappear — so tests/runner-extras/object-metadata-system-table cannot drive a
+// single one of them, and does not try (it asserts the rows, not the refusals). The subject
+// here is the C# refusal contract, so per .claude/rules/bc-behavior-tests-go-upstream.md this
+// is runner-specific and belongs in AlRunner.Tests, the same shape as
+// TryFunctionOutOfScopeTrapTests.
+//
+// Two of the twelve — the ProviderHasAnyRow pair — ARE drivable from C# with a fake provider,
+// and ObjectMetadataProviderRowProbeTests does exactly that. This class covers the contract
+// all twelve share; that one covers those two end to end.
+//
+// WHAT WAS WRONG (#2894)
+// ----------------------
+// All twelve pointed at docs/scope.md, which contains no object-metadata text at all, and
+// they did it twice over: the reason string ended "; see docs/scope.md" and BuildMessage
+// appended its own default link, so a developer read
+//
+//     ... has no in-memory provider; see docs/scope.md — see docs/scope.md
+//
+// The bigger defect is what "docs/scope.md" ASSERTS. That file is the permanently-out-of-scope
+// manifest — SMTP, HTTP egress, printing. Object Metadata (2000000071) is none of those: the
+// file these refusals live in IMPLEMENTS the table, and .claude/rules/loud-failures.md puts
+// AL records squarely in scope. Claiming otherwise tells the next developer to stop looking,
+// and it had a measurable runtime consequence: ApplicationObjectBasePatches.IsPermanentOutOfScope
+// traps a refusal into `false` for an AL [TryFunction] unless its reason starts
+// "not-yet-implemented". So a shape gap in this table read as a clean `if not TryX()` — the
+// silent-default failure loud-failures.md exists to prevent.
+
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+using AlRunner;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+
+namespace AlRunner.Tests;
+
+public sealed class ObjectMetadataSystemTableRefusalTests
+{
+    private const string Api = "Object Metadata (system table 2000000071)";
+    private const string DocLink = "docs/limitations.md#object-metadata-system-table";
+    private const string SourceFile = "AlRunner/Patches/RecordPatches.ObjectMetadataSystemTable.cs";
+
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static RunnerOutOfScopeException Refusal(string detail = "NavEnvironment.EmitVersion not found")
+        => RecordPatches.ObjectMetadataShapeGap(detail);
+
+    /// <summary>A genuinely permanent refusal, for the negative half of every pair below.</summary>
+    private static RunnerOutOfScopeException PermanentRefusal()
+        => new("NavEmail.Send", "email-smtp — no SMTP transport in the runner", "email");
+
+    // ── The link: one of them, and it points at the section that exists ──────────────────
+
+    [Fact]
+    public void Refusal_LinksToTheDocSectionThatActuallyDocumentsThisTable()
+    {
+        var msg = Refusal().Message;
+
+        Assert.EndsWith(" — see " + DocLink, msg, StringComparison.Ordinal);
+        Assert.DoesNotContain("docs/scope.md", msg, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Refusal_RendersExactlyOneDocLink()
+    {
+        var msg = Refusal().Message;
+
+        // Counted on "see docs/", not on the " — see " separator: the defect was a reason
+        // string that ended "; see docs/scope.md" with BuildMessage appending its own
+        // " — see docs/scope.md" after it, which leaves the separator count at 1.
+        var links = msg.Split("see docs/").Length - 1;
+        Assert.Equal(1, links);
+    }
+
+    [Fact]
+    public void TheDocAnchorTheRefusalPointsAt_Exists_AndScopeMdStillDoesNotDocumentThisTable()
+    {
+        var limitations = File.ReadAllText(Path.Combine(RepoRoot, "docs", "limitations.md"));
+        var scope = File.ReadAllText(Path.Combine(RepoRoot, "docs", "scope.md"));
+
+        // The anchor the message now names has to be a real anchor in that file.
+        Assert.Contains("<a id=\"object-metadata-system-table\"></a>", limitations, StringComparison.Ordinal);
+
+        // And the reason the old link was wrong has to stay true, or the fix is moot.
+        Assert.DoesNotContain("object-metadata", scope, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── The claim: in scope, not yet answerable for this shape ───────────────────────────
+
+    [Fact]
+    public void Refusal_ClaimsNotYetImplemented_NotAPermanentScopeBoundary()
+    {
+        var ex = Refusal();
+
+        Assert.Equal(Api, ex.Api);
+        Assert.StartsWith("not-yet-implemented", ex.Reason, StringComparison.Ordinal);
+        Assert.Contains("object-metadata-system-table", ex.Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Refusal_NamesTheFailingPrecondition_SoTheReaderKnowsWhatMoved()
+    {
+        var ex = Refusal("SystemTables.ApplicationDatabaseTables not found");
+
+        Assert.Contains("SystemTables.ApplicationDatabaseTables not found", ex.Reason, StringComparison.Ordinal);
+        Assert.Contains("SystemTables.ApplicationDatabaseTables not found", ex.Message, StringComparison.Ordinal);
+    }
+
+    // ── The consequence: an AL [TryFunction] must NOT read a runner gap as `false` ───────
+
+    [Fact]
+    public void Refusal_TearsThroughATryFunction_InsteadOfReadingAsFalse()
+    {
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
+            () => BcRuntime.NavApplicationObjectBase_TryInvoke(null, () => throw Refusal()));
+
+        Assert.Equal(Api, ex.Api);
+    }
+
+    [Fact]
+    public void PermanentRefusal_IsStillTrappedByATryFunction_SoTheTestDiscriminatesOnTheReason()
+    {
+        // Same exception TYPE, different reason: this one really is out of scope forever, and
+        // real BC answers `false` there. If this went red alongside the test above, the
+        // discrimination would be on the type rather than on the claim.
+        Assert.False(BcRuntime.NavApplicationObjectBase_TryInvoke(null, () => throw PermanentRefusal()));
+    }
+
+    // ── The wire format the expectations manifest and the reporter read ──────────────────
+
+    [Fact]
+    public void Refusal_RoundTripsThroughTheOutOfScopeMessageConvention()
+    {
+        var ex = Refusal("\"Object Type\" carries no option metadata");
+
+        var typed = OutOfScopeMessage.FromException(ex);
+        Assert.NotNull(typed);
+        Assert.True(typed!.Value.Typed);
+        Assert.Equal(Api, typed.Value.Api);
+        Assert.Equal(ex.Reason, typed.Value.Reason);
+
+        // The untyped path (message text only) has to recover the same pair — that is what a
+        // Cecil-injected throw site and the TRX reader get. The doc link must be stripped and
+        // the free-text detail must survive.
+        Assert.True(OutOfScopeMessage.TryParse(ex.Message, out var parsed));
+        Assert.Equal(Api, parsed.Api);
+        Assert.Equal(ex.Reason, parsed.Reason);
+        Assert.DoesNotContain("docs/", parsed.Reason, StringComparison.Ordinal);
+    }
+
+    // ── The shape cannot drift back: one factory, no direct construction ─────────────────
+
+    [Fact]
+    public void EveryRefusalInTheFile_GoesThroughTheOneFactory()
+    {
+        var src = File.ReadAllText(Path.Combine(RepoRoot, SourceFile));
+
+        // Comment lines are stripped first: the header explains the history of this defect and
+        // has to be able to quote the old wording. The claim under test is about the CODE.
+        var code = string.Join('\n', src.Split('\n')
+            .Where(line => !line.TrimStart().StartsWith("//", StringComparison.Ordinal)));
+
+        Assert.DoesNotContain("new RunnerOutOfScopeException(", code, StringComparison.Ordinal);
+        Assert.DoesNotContain("docs/scope.md", code, StringComparison.Ordinal);
+
+        // 12 call sites + the factory declaration. A new refusal added without the factory
+        // would fail the two assertions above; this one catches a refusal being DELETED
+        // silently, which would mean a precondition went back to being read as a default.
+        var uses = src.Split("ObjectMetadataShapeGap(").Length - 1;
+        Assert.Equal(13, uses);
+    }
+
+    // ── The mechanism: a docAnchor may name its own doc file (backward compatible) ───────
+
+    [Fact]
+    public void DocAnchorNamingItsOwnFile_IsUsedVerbatim()
+    {
+        var ex = new RunnerOutOfScopeException("Some.Api", "some-reason", "docs/limitations.md#somewhere");
+
+        Assert.EndsWith(" — see docs/limitations.md#somewhere", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("email", "docs/scope.md#email")]
+    [InlineData("#email", "docs/scope.md#email")]
+    [InlineData(null, "docs/scope.md")]
+    public void BareAnchor_StillResolvesAgainstScopeMd(string? anchor, string expectedLink)
+    {
+        var ex = new RunnerOutOfScopeException("NavEmail.Send", "email-smtp", anchor);
+
+        Assert.EndsWith(" — see " + expectedLink, ex.Message, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner/Infrastructure/RunnerOutOfScopeException.cs
+++ b/AlRunner/Infrastructure/RunnerOutOfScopeException.cs
@@ -65,9 +65,25 @@ public sealed class RunnerOutOfScopeException : Exception
     // or just 'out-of-scope:' for any-OOS. Keep the prefix + " — " separators stable.
     private static string BuildMessage(string api, string reason, string? docAnchor)
     {
-        var link = docAnchor != null
-            ? $"docs/scope.md{(docAnchor.StartsWith("#") ? docAnchor : "#" + docAnchor)}"
-            : "docs/scope.md";
+        // A docAnchor that names its own doc file is used verbatim (#2894). scope.md is the
+        // manifest of what is permanently out of scope, and it is the right target for most
+        // refusals — but not for every one. An IN-SCOPE surface the runner cannot answer for
+        // yet is written up in docs/limitations.md, and pointing that case at scope.md sends
+        // the reader to a file with no matching section AND asserts a permanence that is not
+        // true. The twelve Object Metadata (2000000071) refusals in
+        // RecordPatches.ObjectMetadataSystemTable.cs are the case that showed it.
+        //
+        // OutOfScopeMessage.TryParse strips everything from " — see " onward, so the file name
+        // here is invisible to the expectations manifest and to the reporter's bucketing —
+        // this is a reader-facing pointer only, and widening it changes no classification.
+        const string DefaultDoc = "docs/scope.md";
+        var link = docAnchor switch
+        {
+            null => DefaultDoc,
+            var a when a.StartsWith("docs/", StringComparison.Ordinal) => a,
+            var a when a.StartsWith("#", StringComparison.Ordinal) => DefaultDoc + a,
+            var a => DefaultDoc + "#" + a,
+        };
         return $"{OutOfScopeMessage.Prefix}{api} — {reason} — see {link}";
     }
 }
@@ -77,7 +93,8 @@ public sealed class RunnerOutOfScopeException : Exception
 /// </summary>
 /// <param name="Api">BC API that was touched, e.g. <c>HttpClient.Get</c>.</param>
 /// <param name="Reason">
-/// Reason as written by the throw site: a <c>docs/scope.md</c> anchor,
+/// Reason as written by the throw site: an anchor (a <c>docs/scope.md</c> section
+/// for a permanent refusal, or <c>not-yet-implemented</c> for an in-scope one),
 /// optionally followed by free-text detail after an em-dash separator.
 /// Empty when the throw site did not carry one.
 /// </param>
@@ -180,6 +197,8 @@ public static class RunnerScope
     /// <summary>
     /// Permanently-out-of-scope API. <paramref name="docAnchor"/> is the
     /// section anchor under <c>docs/scope.md</c> (e.g. "email", "external-http").
+    /// A caller documenting an in-scope refusal elsewhere may pass a full
+    /// <c>docs/&lt;file&gt;.md#anchor</c> instead — see <c>BuildMessage</c>.
     /// </summary>
     public static void ThrowOutOfScope(string api, string reason, string docAnchor)
         => throw new RunnerOutOfScopeException(api, reason, docAnchor);

--- a/AlRunner/Patches/RecordPatches.ObjectMetadataSystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.ObjectMetadataSystemTable.cs
@@ -130,6 +130,51 @@
 //   at all if the store already has any row. Real rows always win over synthesised ones; the
 //   synthesis is the fallback for the (normal) case of a run with no application database.
 //
+// ── THE REFUSALS: WHAT EACH ONE CLAIMS, AND WHY NONE OF THEM IS A SCOPE BOUNDARY (#2894) ──
+//   Every refusal in this file goes through ObjectMetadataShapeGap. All twelve used to end
+//   "; see docs/scope.md", which was wrong twice over: docs/scope.md contains no
+//   object-metadata text (the write-up is docs/limitations.md#object-metadata-system-table),
+//   and citing scope.md ASSERTS that the surface is out of scope forever. It is not. Object
+//   Metadata is an AL record on a real BC table and this file implements it;
+//   .claude/rules/loud-failures.md puts AL records squarely in scope.
+//
+//   So none of the twelve is category (1) "genuinely out of scope", and none is category (3)
+//   "implementable now" — there is nothing to build, they are preconditions that hold in every
+//   supported configuration. All twelve are category (2): IN SCOPE, and the runner cannot
+//   answer for the shape it actually found. Reason anchor "not-yet-implemented". What the
+//   anchor tracks is issue #2946: the runner has no exception that says "I could not read BC's
+//   internals here", and the three conventions in this directory disagree about which to use.
+//
+//     PopulateObjectMetadataSystemTable
+//       1. data access has no in-memory provider
+//          -> (2) the runner's own store wiring did not hand one over. Nothing to populate,
+//             and inventing a store would answer with rows nobody can read back.
+//     EnumerateApplicationDatabaseTableIds
+//       2. SystemTables type not found          -> (2) unsupported BC assembly shape
+//       3. ApplicationDatabaseTables not found  -> (2) unsupported BC assembly shape
+//       4. ApplicationDatabaseTables is empty   -> (2) BC's own list is the row set; with no
+//          list there is no row set, and a hardcoded fallback would be an invented answer.
+//     EnsureObjectMetadataObjectTypeOrdinal
+//       5. metatable has no field 3             -> (2) unsupported artifact metadata shape
+//       6. "Object Type" has no option metadata -> (2) same
+//       7. option string has no "Table" member  -> (2) same. Refusing beats guessing ordinal
+//          1: the ordinal is a primary-key value, so a wrong guess silently mis-keys 43 rows.
+//     ReadNavEnvironmentEmitVersion
+//       8. NavEnvironment type not found        -> (2) unsupported BC assembly shape
+//       9. NavEnvironment.Instance is null      -> (2) skeleton state not initialised at this
+//          point. Note the difference from a skeleton Instance whose EmitVersion READS 0: that
+//          0 is BC's own answer and is kept (see the columns section). A null Instance has no
+//          answer at all, and this is the third primary-key field.
+//      10. EmitVersion property not found       -> (2) unsupported BC assembly shape
+//     ProviderHasAnyRow (both added by #2837, same classification)
+//      11. primaryTree field not found          -> (2) BC's private provider layout moved
+//      12. primaryTree is not enumerable        -> (2) same
+//
+//   The same "; see docs/scope.md" wording sits on the equivalent provider-null guard in
+//   roughly fifteen sibling virtual-table populators in this directory (AllObj, Integer,
+//   Field, ...). Same defect, different files; issue #2945 tracks that sweep rather than
+//   widening this change past the file the issue named.
+//
 // PRECOMPILED-DLL RESPECT
 //   Runtime-engine and Types-assembly members only (SystemTables, NavEnvironment, NCLMetaTable,
 //   NCLMetaField, NavValue, ReadOnlyRecordBuffer, TempTableDataProvider), reached the same way
@@ -177,6 +222,34 @@ public static partial class RecordPatches
     private static bool IsObjectMetadataSystemTable(NCLMetaTable? table)
         => table != null && table.TableId == ObjectMetadataSystemTableId;
 
+    /// <summary>The API name every refusal in this file carries.</summary>
+    internal const string ObjectMetadataApi = "Object Metadata (system table 2000000071)";
+
+    /// <summary>
+    /// The doc section that actually documents this table. NOT <c>docs/scope.md</c>: that file
+    /// is the permanently-out-of-scope manifest and contains no object-metadata text at all
+    /// (#2894).
+    /// </summary>
+    private const string ObjectMetadataDocLink = "docs/limitations.md#object-metadata-system-table";
+
+    /// <summary>
+    /// The one place a refusal for this table is built — see the REFUSALS section of the file
+    /// header for the per-site classification, and .claude/rules/loud-failures.md for the rule.
+    ///
+    /// <para>Reason anchor <c>not-yet-implemented</c>, deliberately. Object Metadata is IN
+    /// SCOPE — this file implements it — so none of these twelve is a scope boundary; each one
+    /// says the runner cannot answer for the shape it found. That is not cosmetic: for an AL
+    /// <c>[TryFunction]</c>, ApplicationObjectBasePatches.IsPermanentOutOfScope traps a refusal
+    /// into <c>false</c> UNLESS the reason starts <c>not-yet-implemented</c>. Under the old
+    /// <c>object-metadata-system-table</c> anchor a runner gap here read as a clean
+    /// <c>if not TryX()</c>, which is the silent default loud-failures.md forbids. Now it tears
+    /// through.</para>
+    /// </summary>
+    internal static RunnerOutOfScopeException ObjectMetadataShapeGap(string detail)
+        => new(ObjectMetadataApi,
+            "not-yet-implemented — object-metadata-system-table: " + detail,
+            ObjectMetadataDocLink);
+
     /// <summary>
     /// Populate the in-memory store behind Object Metadata (2000000071) with one row per
     /// application-database system table, exactly the row set Microsoft's own
@@ -191,9 +264,7 @@ public static partial class RecordPatches
         EnsureDataAccessProviderReflection(dataAccess);
 
         var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
-            ?? throw new RunnerOutOfScopeException(
-                "Object Metadata (system table 2000000071)",
-                "object-metadata-system-table — data access has no in-memory provider; see docs/scope.md");
+            ?? throw ObjectMetadataShapeGap("data access has no in-memory provider");
 
         RunObjectMetadataPopulateOnce(provider, () =>
         {
@@ -309,16 +380,13 @@ public static partial class RecordPatches
 
         var tSystemTables = ResolveType(
             "Microsoft.Dynamics.Nav.Runtime.SystemTables", "Microsoft.Dynamics.Nav.Types.SystemTables")
-            ?? throw new RunnerOutOfScopeException(
-                "Object Metadata (system table 2000000071)",
-                "object-metadata-system-table — Microsoft.Dynamics.Nav.Types.SystemTables not found, so BC's "
-                + "own application-database table list cannot be read; see docs/scope.md");
+            ?? throw ObjectMetadataShapeGap(
+                "Microsoft.Dynamics.Nav.Types.SystemTables not found, so BC's own "
+                + "application-database table list cannot be read");
 
         var property = tSystemTables.GetProperty("ApplicationDatabaseTables",
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
-            ?? throw new RunnerOutOfScopeException(
-                "Object Metadata (system table 2000000071)",
-                "object-metadata-system-table — SystemTables.ApplicationDatabaseTables not found; see docs/scope.md");
+            ?? throw ObjectMetadataShapeGap("SystemTables.ApplicationDatabaseTables not found");
 
         var ids = new List<int>();
         if (property.GetValue(null) is IEnumerable values)
@@ -326,10 +394,8 @@ public static partial class RecordPatches
                 if (v is int id) ids.Add(id);
 
         if (ids.Count == 0)
-            throw new RunnerOutOfScopeException(
-                "Object Metadata (system table 2000000071)",
-                "object-metadata-system-table — SystemTables.ApplicationDatabaseTables is empty, so there is "
-                + "no row set to answer with; see docs/scope.md");
+            throw ObjectMetadataShapeGap(
+                "SystemTables.ApplicationDatabaseTables is empty, so there is no row set to answer with");
 
         ids.Sort();
         _omsApplicationDatabaseTableIds = ids.ToArray();
@@ -348,14 +414,10 @@ public static partial class RecordPatches
 
         var field = (GetAllFields(metaTable) ?? Enumerable.Empty<NCLMetaField>())
             .FirstOrDefault(f => f.FieldNo == ObjectMetadataFieldObjectType)
-            ?? throw new RunnerOutOfScopeException(
-                "Object Metadata (system table 2000000071)",
-                "object-metadata-system-table — metatable has no field 3 (\"Object Type\"); see docs/scope.md");
+            ?? throw ObjectMetadataShapeGap("metatable has no field 3 (\"Object Type\")");
 
         var optionString = field.FieldOptionMetadata?.OptionString
-            ?? throw new RunnerOutOfScopeException(
-                "Object Metadata (system table 2000000071)",
-                "object-metadata-system-table — \"Object Type\" carries no option metadata; see docs/scope.md");
+            ?? throw ObjectMetadataShapeGap("\"Object Type\" carries no option metadata");
 
         var wanted = NormalizeObjectTypeName(ObjectMetadataRetainedObjectType);
         var parts = optionString.Split(',');
@@ -366,11 +428,10 @@ public static partial class RecordPatches
             return i;
         }
 
-        throw new RunnerOutOfScopeException(
-            "Object Metadata (system table 2000000071)",
-            $"object-metadata-system-table — \"Object Type\" option string ('{optionString}') has no "
+        throw ObjectMetadataShapeGap(
+            $"\"Object Type\" option string ('{optionString}') has no "
             + $"'{ObjectMetadataRetainedObjectType}' member, so the ordinal every retained row carries "
-            + "cannot be resolved; see docs/scope.md");
+            + "cannot be resolved");
     }
 
     /// <summary>
@@ -384,25 +445,21 @@ public static partial class RecordPatches
     {
         var tNavEnvironment = ResolveType(
             "Microsoft.Dynamics.Nav.Runtime.NavEnvironment", "Microsoft.Dynamics.Nav.Types.NavEnvironment")
-            ?? throw new RunnerOutOfScopeException(
-                "Object Metadata (system table 2000000071)",
-                "object-metadata-system-table — NavEnvironment not found, so BC's own emit version (the third "
-                + "primary-key field) cannot be read; see docs/scope.md");
+            ?? throw ObjectMetadataShapeGap(
+                "NavEnvironment not found, so BC's own emit version (the third primary-key field) "
+                + "cannot be read");
 
         var instance = tNavEnvironment
             .GetProperty("Instance", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
             ?.GetValue(null)
-            ?? throw new RunnerOutOfScopeException(
-                "Object Metadata (system table 2000000071)",
-                "object-metadata-system-table — NavEnvironment.Instance is null, so BC's own emit version (the "
-                + "third primary-key field) cannot be read; see docs/scope.md");
+            ?? throw ObjectMetadataShapeGap(
+                "NavEnvironment.Instance is null, so BC's own emit version (the third primary-key field) "
+                + "cannot be read");
 
         var emitVersion = tNavEnvironment
             .GetProperty("EmitVersion", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
             ?.GetValue(instance)
-            ?? throw new RunnerOutOfScopeException(
-                "Object Metadata (system table 2000000071)",
-                "object-metadata-system-table — NavEnvironment.EmitVersion not found; see docs/scope.md");
+            ?? throw ObjectMetadataShapeGap("NavEnvironment.EmitVersion not found");
 
         return (int)emitVersion;
     }
@@ -445,24 +502,20 @@ public static partial class RecordPatches
     private static bool ProviderHasAnyRow(object provider)
     {
         var field = PrivateMemberLookup.Field(provider.GetType(), "primaryTree")
-            ?? throw new RunnerOutOfScopeException(
-                "Object Metadata (system table 2000000071)",
-                $"object-metadata-system-table — {provider.GetType().Name}.primaryTree not found, so the "
-                + "runner cannot tell a store BC never inserted into from one --test-data already filled; "
-                + "synthesising rows would silently shadow the restored ones. BC's private provider layout "
-                + "moved; see docs/scope.md");
+            ?? throw ObjectMetadataShapeGap(
+                $"{provider.GetType().Name}.primaryTree not found, so the runner cannot tell a store BC "
+                + "never inserted into from one --test-data already filled; synthesising rows would "
+                + "silently shadow the restored ones. BC's private provider layout moved");
 
         // A null tree is BC's own "no row was ever inserted": nothing to shadow, synthesise.
         var tree = field.GetValue(provider);
         if (tree == null) return false;
 
         if (tree is not IEnumerable rows)
-            throw new RunnerOutOfScopeException(
-                "Object Metadata (system table 2000000071)",
-                $"object-metadata-system-table — {provider.GetType().Name}.primaryTree is a "
-                + $"{tree.GetType().Name}, which cannot be enumerated, so the runner cannot tell whether "
-                + "--test-data already filled this table. BC's private provider layout moved; see "
-                + "docs/scope.md");
+            throw ObjectMetadataShapeGap(
+                $"{provider.GetType().Name}.primaryTree is a {tree.GetType().Name}, which cannot be "
+                + "enumerated, so the runner cannot tell whether --test-data already filled this table. "
+                + "BC's private provider layout moved");
 
         // Short-circuit: one row is the whole answer, and a restored backup can be large.
         foreach (var _ in rows) return true;

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -113,6 +113,14 @@ in the reason slot**, and the API name in the API slot. A message shaped
 reason where the API belongs and is undeclarable; fix the throw site rather
 than writing a prose `Reason` into the entry.
 
+The trailing ` — see …` link is **not** part of the signal. `OutOfScopeMessage`
+strips it, so a throw site may point at a file other than `docs/scope.md` when
+that is where the surface is written up — a refusal whose reason anchor is
+`not-yet-implemented` describes an IN-SCOPE surface the runner cannot answer for
+yet, and those belong in `docs/limitations.md`. Pass the full
+`docs/<file>.md#anchor` as the `docAnchor` argument; a bare anchor still resolves
+against `docs/scope.md`. Nothing about the classification changes either way.
+
 `Reason` matches on the anchor: throw sites may append free-text detail after
 an ` — ` (em-dash) separator, while the entry holds only the leading
 `docs/scope.md` anchor (e.g. a throw site's

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -629,6 +629,19 @@ well, which is the bug (#2519) this table's support closed.
 move quietly. It deliberately uses only ids that are live table objects, so it does not encode
 the open `ObsoleteState = Removed` question as settled in either direction.
 
+**When the runner cannot answer at all, it refuses and says so as a gap, not as a scope
+boundary.** Twelve preconditions guard this table — BC's `SystemTables` type and its
+`ApplicationDatabaseTables` list, `NavEnvironment.Instance.EmitVersion`, the `"Object Type"`
+option string, the in-memory data provider, and `TempTableDataProvider.primaryTree`. If one of
+them is not the shape the runner expects, it raises `RunnerOutOfScopeException` with reason
+anchor `not-yet-implemented` and a link back to this section. None of them means the surface is
+out of scope: this table is implemented, and a refusal here is a bug report about the runner
+(#2894). The anchor matters at runtime as well as on the page — an AL `[TryFunction]` traps a
+*permanent* refusal into `false` and lets a `not-yet-implemented` one tear through, so a shape
+gap can never read as a clean `if not TryX()`. `AlRunner.Tests/ObjectMetadataSystemTableRefusalTests.cs`
+pins the contract; `AlRunner.Tests/ObjectMetadataProviderRowProbeTests.cs` drives the two
+`primaryTree` cases end to end.
+
 **Synthesis never overwrites restored rows, and never guesses whether there are any.** Because
 2000000071 is a real SQL table, a `--test-data` backup can genuinely carry rows for it, so the
 on-demand loader runs first and the populator does nothing when the store already holds a row.


### PR DESCRIPTION
Closes #2894

The issue reported ten refusals in `AlRunner/Patches/RecordPatches.ObjectMetadataSystemTable.cs` pointing at `docs/scope.md`, a file with no object-metadata section, and rendering the link twice:

```
... has no in-memory provider; see docs/scope.md — see docs/scope.md
```

There are **twelve**, not ten — #2837 added two more to `ProviderHasAnyRow` after the issue was filed. All twelve are fixed.

## The claim was wrong, not just the link

`docs/scope.md` is the manifest of what is **permanently** out of scope: SMTP, HTTP egress, printing. Object Metadata (2000000071) is an AL record on a real BC table, and the file raising these refusals implements it. `.claude/rules/loud-failures.md` puts AL records squarely in scope. A refusal citing scope.md tells the next developer to stop looking.

It also had a runtime consequence. `ApplicationObjectBasePatches.IsPermanentOutOfScope`:

```csharp
return oos != null && !oos.Reason.StartsWith("not-yet-implemented", StringComparison.Ordinal);
```

Under the old `object-metadata-system-table` anchor that returned **true**, so an AL `[TryFunction]` reading this table trapped a runner shape gap into `false` — the silent default `loud-failures.md` exists to prevent. It now tears through.

## Classifying all twelve

Each is annotated in the file header. Verdict: **none is genuinely out of scope, none is implementable now, all twelve are in scope and unanswerable for the shape found.** They are preconditions that hold in every supported configuration, not unbuilt features — so the honest reason is `not-yet-implemented` with the failing precondition named.

| site | precondition | verdict |
|---|---|---|
| `PopulateObjectMetadataSystemTable` | data access has no in-memory provider | in scope; nothing to populate, and inventing a store answers with rows nobody reads back |
| `EnumerateApplicationDatabaseTableIds` | `SystemTables` type not found | in scope; unsupported BC assembly shape |
| | `ApplicationDatabaseTables` not found | in scope; unsupported BC assembly shape |
| | `ApplicationDatabaseTables` is empty | in scope; BC's list **is** the row set, a hardcoded fallback would be invented |
| `EnsureObjectMetadataObjectTypeOrdinal` | metatable has no field 3 | in scope; unsupported artifact metadata shape |
| | `"Object Type"` has no option metadata | in scope; same |
| | option string has no `Table` member | in scope; the ordinal is a primary-key value, so guessing 1 silently mis-keys 43 rows |
| `ReadNavEnvironmentEmitVersion` | `NavEnvironment` not found | in scope; unsupported BC assembly shape |
| | `NavEnvironment.Instance` is null | in scope; distinct from a skeleton `Instance` whose `EmitVersion` **reads** 0, which is BC's own answer and is kept |
| | `EmitVersion` property not found | in scope; unsupported BC assembly shape |
| `ProviderHasAnyRow` | `primaryTree` not found | in scope; BC's private provider layout moved |
| | `primaryTree` not enumerable | in scope; same |

The `not-yet-implemented` anchor tracks **#2946**, filed here: the runner has no exception that says "I could not read BC's internals", and three conventions in `AlRunner/Patches/` disagree about which to raise for exactly this. That issue stays open after this merges.

## The mechanism

`RunnerOutOfScopeException.BuildMessage` hard-coded `docs/scope.md`. It now uses a `docAnchor` verbatim when it names its own doc file; a bare anchor and a `#anchor` still resolve against scope.md. `OutOfScopeMessage.TryParse` already strips everything from `" — see "` onward, so **no classification moves** — this is a reader-facing pointer only. `docs/expectations.md` records that.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes, and it is the bulk of the finding. About seventeen sibling virtual-table populators in this directory carry the identical three-line guard — `AllObj`, `Integer`, `Field`, `CodeUnit Metadata`, `Page Metadata`, `Report Metadata`, `Table Metadata`, `All Profile`, `Feature Key`, `Time Zone`, and more — each citing `docs/scope.md` for a table it implements, each therefore trapping into `false` inside a `[TryFunction]`. Filed as **#2945** rather than swept here, since the brief scoped this PR to one file. #2766 does not cover them: it measured `command grep -c "See docs/scope.md"` (capital S) and these spell it lowercase, and it is about the doubled rendering rather than the false claim.
2. **A sibling making the same assumption?** Yes, two — the `primaryTree` pair #2837 added after the issue was written. Folded in, so the count is twelve.
3. **Two paths writing the same state with different invariants?** Yes, and it is #2946: four sites read `TempTableDataProvider.primaryTree` and raise three different exception types between them. Not resolved here; it is a convention decision, not a defect in this file.

## RED → GREEN

RED was produced against executing code, not a compile error: the twelve sites were first collapsed onto one factory that reproduced the **old** strings byte for byte, then the tests run.

```
Failed Refusal_TearsThroughATryFunction_InsteadOfReadingAsFalse
Failed Refusal_ClaimsNotYetImplemented_NotAPermanentScopeBoundary
Failed Refusal_LinksToTheDocSectionThatActuallyDocumentsThisTable
Failed Refusal_RoundTripsThroughTheOutOfScopeMessageConvention
Failed EveryRefusalInTheFile_GoesThroughTheOneFactory
Failed DocAnchorNamingItsOwnFile_IsUsedVerbatim
Failed!  - Failed: 6, Passed: 7, Total: 13
```

GREEN after correcting the factory and `BuildMessage`, re-run on the rebased tree:

```
dotnet test AlRunner.Tests -c Release --framework net8.0 --no-build --filter \
  "FullyQualifiedName~ObjectMetadataSystemTableRefusalTests|FullyQualifiedName~ObjectMetadataProviderRowProbeTests|\
FullyQualifiedName~TryFunctionOutOfScopeTrapTests|FullyQualifiedName~AssertErrorOutOfScopeCatchabilityTests|\
FullyQualifiedName~ExpectationClassifier|FullyQualifiedName~ExpectationManifest"
Passed!  - Failed: 0, Passed: 71, Skipped: 0, Total: 71, Duration: 23 s
```

And the AL bundle that covers this table, run the way CI runs it:

```
dotnet run --no-build --project AlRunner -c Release --framework net8.0 -- \
  tests/runner-extras/object-metadata-system-table \
  --package-cache "$HOME/.al-runner/platform-apps" --package-cache "$HOME/.al-runner/test-apps" --cache <private>
Tests: 4 total  pass: 4  fail: 0  error: 0
```

The seven RED-green tests are the control arms — the doc-anchor existence check, the backward-compatible `BareAnchor` theory, and `PermanentRefusal_IsStillTrappedByATryFunction`, which asserts the *same exception type* with an `email-smtp` reason **is** still trapped. Without that arm the tear-through test could pass by discriminating on the type rather than on the claim.

The two `ObjectMetadataProviderRowProbeTests` assertions that encoded the old anchor (`Assert.StartsWith("object-metadata-system-table", ex.Reason)`) are updated; that expectation was part of the defect.

## Why the tests are in `AlRunner.Tests/`, not `tests/runner-extras/`

None of the twelve is reachable from AL — no AL statement makes `SystemTables` disappear or moves a private BC field — so `tests/runner-extras/object-metadata-system-table` cannot drive one, and does not try. The subject is the C# refusal contract, which `bc-behavior-tests-go-upstream.md` classifies as runner-specific; this is the shape `TryFunctionOutOfScopeTrapTests` and `AssertErrorOutOfScopeCatchabilityTests` already use. No new AL bundle, so `tests/expectations/count-baseline/test-count-baseline.json` does not move and is untouched.

## Deliberately left out

- **The ~17 sibling populators** — #2945, above. Fixing them here would have made this a directory-wide sweep.
- **The doubled-link sweep at the other ~45 sites** — #2766's, untouched. The doubling is fixed here only for the twelve in this file, as a consequence of rewriting their reason strings.
- **Whether a BC-shape guard should raise `RunnerOutOfScopeException` at all** — #2946. It is a convention decision across `AlRunner/Patches/`, and picking one unilaterally inside this file is how the disagreement got here.
- **No expectations manifest entry**, and none is needed: no corpus or runner-extras test reaches these refusals, and none is declared today.

---
*Authored by an automated agent (`impl-16`) acting on the account holder's behalf.*

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
