### PR TITLE
fix(cache): identify the layered workspace dir and the table-extension cache by content

### DIFF
--- a/AlRunner.Tests/BcAppSymbolCacheTableExtensionKeyTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCacheTableExtensionKeyTests.cs
@@ -1,0 +1,218 @@
+// BcAppSymbolCacheTableExtensionKeyTests — issue #2846 case 2: BcAppSymbolCache answered the
+// same question about the same file two different ways.
+//
+// The asymmetry
+// -------------
+// `BcAppSymbolCache.Get` identifies a `.app` by its CONTENT — `{fullPath}|hash:{contentHash}|
+// v{CacheVersion}|shape:{...}`. That content hash replaced a `Length`/`LastWriteTimeUtc` stat
+// in #1820, for the reason #1815 recorded one layer over: CI re-downloads every platform and
+// test-toolkit `.app` on every run, so the mtime is fresh even when the bytes are byte-for-byte
+// identical to the previous run's, and an mtime-keyed entry MISSes unconditionally regardless
+// of content.
+//
+// `BcAppSymbolCache.GetTableExtensions`, in the same static class, over the same files, never
+// got the same treatment:
+//
+//     var key = $"{Path.GetFullPath(appPath)}|{info.Length}|{info.LastWriteTimeUtc.Ticks}|v{CacheVersion}";
+//
+// Two consequences, and the first is the one with a cost attached:
+//
+//   1. A touched-but-unchanged package reparses every tableextension in it. For Base
+//      Application that is the whole SymbolReference.json — the same parse #2712 measured as
+//      worth 96 table extensions and 47 test results when it went wrong.
+//   2. The two caches DISAGREE about which byte state of one file they are describing. The
+//      table index and the table-extension index are built from the same package by the same
+//      class, and nothing made them agree; one keyed on content, the other on a stat.
+//
+// What this does NOT claim
+// ------------------------
+// It does not make either cache notice a package rewritten in place mid-process.
+// `ComputeAppContentHash` memoizes per full path for the life of the process, deliberately
+// (see its comment: `Get()` is called once per virtual-table lookup, often a dozen times for
+// the same `.app`). So after this change both caches are consistently pinned to the byte state
+// first observed at that path — which is the point. Before it, `Get()` was pinned and
+// `GetTableExtensions` was not, so a mid-process rewrite made the two indexes describe
+// different byte states of one file. Agreement is the property under test here, not detection.
+
+using Xunit;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+
+namespace AlRunner.Tests;
+
+public sealed class BcAppSymbolCacheTableExtensionKeyTests : IDisposable
+{
+    private readonly string _scratch;
+
+    public BcAppSymbolCacheTableExtensionKeyTests()
+    {
+        _scratch = TestScratch.Dir("al-runner-bcappsymbol-tableext-key");
+        Directory.CreateDirectory(_scratch);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_scratch, recursive: true); } catch { }
+    }
+
+    /// <summary>
+    /// The defect. Touching a package's mtime without changing a byte must not reparse its
+    /// table extensions — exactly what #1820 established for <c>Get</c>, which shares this
+    /// class, these files and this CacheVersion.
+    ///
+    /// <para>Asserted by reference identity: a cache HIT hands back the very list instance it
+    /// stored, a MISS builds a fresh one in ParseTableExtensions. The concrete parsed values
+    /// are asserted alongside it so a cache that "hit" by handing back an empty or default
+    /// list could not pass.</para>
+    /// </summary>
+    [SkippableFact]
+    public void TouchingTheMtimeOfAnUnchangedPackage_DoesNotReparseItsTableExtensions()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var app = WriteExtensionApp("touched", extensionId: 70001, fieldId: 50001, fieldName: "Loyalty Points");
+
+        var first = BcAppSymbolCache.GetTableExtensions(app);
+        AssertOneExtension(first, 70001, 50001, "Loyalty Points");
+
+        // Content untouched; only the timestamp moves — the CI re-download shape from #1815.
+        var before = new FileInfo(app).LastWriteTimeUtc;
+        File.SetLastWriteTimeUtc(app, before.AddDays(7));
+        Assert.NotEqual(before.Ticks, new FileInfo(app).LastWriteTimeUtc.Ticks);
+
+        var second = BcAppSymbolCache.GetTableExtensions(app);
+
+        Assert.Same(first, second);
+        AssertOneExtension(second, 70001, 50001, "Loyalty Points");
+    }
+
+    /// <summary>
+    /// The invariant the two caches must share: after the same mtime touch, <c>Get</c> and
+    /// <c>GetTableExtensions</c> must BOTH still be describing the byte state they first saw.
+    /// Before the fix <c>Get</c> hit and <c>GetTableExtensions</c> missed, so the table index
+    /// and the table-extension index for one package were built from two different reads of it.
+    /// </summary>
+    [SkippableFact]
+    public void AfterAnMtimeTouch_GetAndGetTableExtensions_AgreeOnTheSameIdentity()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var app = WriteExtensionApp("agree", extensionId: 70011, fieldId: 50011, fieldName: "Agree Field");
+
+        var symbolsBefore = BcAppSymbolCache.Get(app);
+        var extsBefore = BcAppSymbolCache.GetTableExtensions(app);
+
+        File.SetLastWriteTimeUtc(app, new FileInfo(app).LastWriteTimeUtc.AddDays(3));
+
+        var symbolsAfter = BcAppSymbolCache.Get(app);
+        var extsAfter = BcAppSymbolCache.GetTableExtensions(app);
+
+        // Get already had this property (#1820). GetTableExtensions is the half that did not.
+        Assert.Same(symbolsBefore, symbolsAfter);
+        Assert.Same(extsBefore, extsAfter);
+        AssertOneExtension(extsAfter, 70011, 50011, "Agree Field");
+    }
+
+    /// <summary>
+    /// The direction that stops the fix from being "always hit": two genuinely different
+    /// packages must still get their own parses and their own answers. A content key that
+    /// over-shared — dropping the path, say — would pass the arms above and fail here.
+    /// </summary>
+    [SkippableFact]
+    public void TwoDifferentPackages_EachGetTheirOwnTableExtensions()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var appA = WriteExtensionApp("distinct-a", extensionId: 70021, fieldId: 50021, fieldName: "Alpha Field");
+        var appB = WriteExtensionApp("distinct-b", extensionId: 70022, fieldId: 50022, fieldName: "Beta Field");
+
+        var a = BcAppSymbolCache.GetTableExtensions(appA);
+        var b = BcAppSymbolCache.GetTableExtensions(appB);
+
+        Assert.NotSame(a, b);
+        AssertOneExtension(a, 70021, 50021, "Alpha Field");
+        AssertOneExtension(b, 70022, 50022, "Beta Field");
+    }
+
+    // ── fixture ───────────────────────────────────────────────────────────────────────────
+
+    private static void AssertOneExtension(
+        IReadOnlyList<TableExtensionSymbol> exts, int extensionId, int fieldId, string fieldName)
+    {
+        var ext = Assert.Single(exts);
+        Assert.Equal(extensionId, ext.ExtensionId);
+        Assert.Equal("Customer", ext.TargetTableName);
+        var field = Assert.Single(ext.Fields);
+        Assert.Equal(fieldId, field.FieldId);
+        Assert.Equal(fieldName, field.FieldName);
+        Assert.Equal("Integer", field.TypeName);
+    }
+
+    /// <summary>
+    /// A registrable `.app` whose SymbolReference.json declares exactly one tableextension on
+    /// "Customer". Written at its own directory: every arm here needs a DISTINCT path, because
+    /// ComputeAppContentHash memoizes per full path for the process.
+    /// </summary>
+    private string WriteExtensionApp(string subdir, int extensionId, int fieldId, string fieldName)
+    {
+        var bundleDir = Path.Combine(_scratch, subdir, "src");
+        var appPath = Path.Combine(_scratch, subdir, $"AL Runner_TableExt {extensionId}_1.0.0.0.app");
+        var appId = new Guid($"2846d00{extensionId % 10}-1111-4222-8333-4444555566{extensionId % 100:D2}");
+
+        Directory.CreateDirectory(bundleDir);
+        File.WriteAllText(Path.Combine(bundleDir, "app.json"), $$"""
+        {
+          "id": "{{appId}}",
+          "name": "TableExt {{extensionId}}",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": {{extensionId}}, "to": {{extensionId + 9}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(bundleDir, "Ext.al"), $$"""
+        tableextension {{extensionId}} "TableExt {{extensionId}}" extends Customer
+        {
+            fields
+            {
+                field({{fieldId}}; "{{fieldName}}"; Integer) { DataClassification = CustomerContent; }
+            }
+        }
+        """);
+
+        var json = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            AppId = appId.ToString(),
+            Name = $"TableExt {extensionId}",
+            Publisher = "AL Runner",
+            Version = "1.0.0.0",
+            Tables = Array.Empty<object>(),
+            TableExtensions = new[]
+            {
+                new
+                {
+                    Id = extensionId,
+                    Name = $"TableExt {extensionId}",
+                    TargetObject = "Customer",
+                    Fields = new object[]
+                    {
+                        new { Id = fieldId, Name = fieldName, TypeDefinition = new { Name = "Integer" } },
+                    },
+                },
+            },
+            Codeunits = Array.Empty<object>(),
+            Pages = Array.Empty<object>(),
+            EnumTypes = Array.Empty<object>(),
+            Queries = Array.Empty<object>(),
+        });
+
+        var identity = InProcessAppPackager.ReadIdentity(Path.Combine(bundleDir, "app.json"))
+            ?? throw new InvalidOperationException("could not read the identity just written");
+        Directory.CreateDirectory(Path.GetDirectoryName(appPath)!);
+        InProcessAppPackager.EmitAppPackageToFile(
+            bundleDir, identity, appPath, System.Text.Encoding.UTF8.GetBytes(json));
+        return appPath;
+    }
+}

--- a/AlRunner.Tests/SourceWorkspaceKeyDependencyContentTests.cs
+++ b/AlRunner.Tests/SourceWorkspaceKeyDependencyContentTests.cs
@@ -98,8 +98,8 @@ public sealed class SourceWorkspaceKeyDependencyContentTests : IDisposable
         Assert.False(File.ReadAllBytes(pkgA).AsSpan().SequenceEqual(File.ReadAllBytes(pkgB)),
             "the two synthetic packages are byte-identical — the fixture is not exercising the defect");
 
-        var keyA = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkgA));
-        var keyB = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkgB));
+        var keyA = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkgA), resolutionFailure: null);
+        var keyB = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkgB), resolutionFailure: null);
 
         // Concrete shape, not just "different": a 64-char lowercase hex digest. A key that
         // degraded to an empty string or a constant would satisfy an inequality-only test in
@@ -132,8 +132,8 @@ public sealed class SourceWorkspaceKeyDependencyContentTests : IDisposable
         Assert.NotEqual(new FileInfo(pkgA).LastWriteTimeUtc.Ticks, new FileInfo(pkgB).LastWriteTimeUtc.Ticks);
         Assert.NotEqual(pkgA, pkgB);
 
-        var keyA = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkgA));
-        var keyB = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkgB));
+        var keyA = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkgA), resolutionFailure: null);
+        var keyB = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkgB), resolutionFailure: null);
 
         AssertIsWorkspaceKey(keyA);
         Assert.Equal(keyA, keyB);
@@ -155,10 +155,11 @@ public sealed class SourceWorkspaceKeyDependencyContentTests : IDisposable
         var pkgA = WritePackage("closure-a", fill: (byte)'A');
         var extra = WritePackage("closure-extra", fill: (byte)'X', name: "Vendored Extra");
 
-        var one = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkgA));
+        var one = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkgA), resolutionFailure: null);
         var two = ProgramSupport.ComputeSourceWorkspaceKey(
             new[] { dir }, ids,
-            Resolved(pkgA).Concat(ResolvedNamed(extra, "Vendored Extra", new Guid("2846c003-1111-4222-8333-444455556666"))).ToList());
+            Resolved(pkgA).Concat(ResolvedNamed(extra, "Vendored Extra", new Guid("2846c003-1111-4222-8333-444455556666"))).ToList(),
+            resolutionFailure: null);
 
         AssertIsWorkspaceKey(one);
         AssertIsWorkspaceKey(two);
@@ -178,8 +179,8 @@ public sealed class SourceWorkspaceKeyDependencyContentTests : IDisposable
         var (dir, ids) = WriteSourceApp("src-edit");
         var pkg = WritePackage("edit-pkg", fill: (byte)'A');
 
-        var before = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkg));
-        var again = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkg));
+        var before = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkg), resolutionFailure: null);
+        var again = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkg), resolutionFailure: null);
         Assert.Equal(before, again);
 
         File.WriteAllText(Path.Combine(dir, "Probe.Codeunit.al"), """
@@ -192,9 +193,48 @@ public sealed class SourceWorkspaceKeyDependencyContentTests : IDisposable
         }
         """);
 
-        var after = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkg));
+        var after = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkg), resolutionFailure: null);
         AssertIsWorkspaceKey(after);
         Assert.NotEqual(before, after);
+    }
+
+    /// <summary>
+    /// A failed resolve must key on the FAILURE, never collapse to "no dependencies" — the rule
+    /// GetOrderedDepIds states for the AL-output key, and for the same reason: an empty closure
+    /// is indistinguishable from a bundle that genuinely has none, so a bundle whose dependency
+    /// is temporarily missing would otherwise share a workspace directory with one that has no
+    /// dependencies at all. It must also move when the reason moves.
+    ///
+    /// <para>RunLayeredPrePass catches the resolve so it can compute this key and rethrows from
+    /// where it threw before; this arm is what makes that catch honest rather than a swallow.</para>
+    /// </summary>
+    [SkippableFact]
+    public void AFailedResolve_KeysOnTheFailure_AndNotOnAnEmptyClosure()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dir, ids) = WriteSourceApp("src-unresolved");
+        var pkg = WritePackage("unresolved-pkg", fill: (byte)'A');
+
+        var empty = Array.Empty<(AppManifest Manifest, string AppPath)>();
+        var failedA = ProgramSupport.ComputeSourceWorkspaceKey(
+            new[] { dir }, ids, empty, "MissingDependencyException: LSC Chain Base not found");
+        var failedB = ProgramSupport.ComputeSourceWorkspaceKey(
+            new[] { dir }, ids, empty, "MissingDependencyException: a different package not found");
+        var genuinelyEmpty = ProgramSupport.ComputeSourceWorkspaceKey(
+            new[] { dir }, ids, empty, resolutionFailure: null);
+        var resolved = ProgramSupport.ComputeSourceWorkspaceKey(
+            new[] { dir }, ids, Resolved(pkg), resolutionFailure: null);
+
+        AssertIsWorkspaceKey(failedA);
+        // A failure is not "no deps", and it is not a successful resolve either.
+        Assert.NotEqual(genuinelyEmpty, failedA);
+        Assert.NotEqual(resolved, failedA);
+        // Two different reasons are two different cache identities.
+        Assert.NotEqual(failedA, failedB);
+        // ...and the same reason is stable, or the directory would never be reused.
+        Assert.Equal(failedA, ProgramSupport.ComputeSourceWorkspaceKey(
+            new[] { dir }, ids, empty, "MissingDependencyException: LSC Chain Base not found"));
     }
 
     // ── fixture ───────────────────────────────────────────────────────────────────────────

--- a/AlRunner.Tests/SourceWorkspaceKeyDependencyContentTests.cs
+++ b/AlRunner.Tests/SourceWorkspaceKeyDependencyContentTests.cs
@@ -1,0 +1,277 @@
+// SourceWorkspaceKeyDependencyContentTests — issue #2846 case 1: the layered pre-pass's
+// workspace directory key must identify the RESOLVED dependency packages by their content.
+//
+// The defect
+// ----------
+// `ProgramSupport.ComputeSourceWorkspaceKey` (AlRunner/ProgramSupport/SiblingCompile.cs) names
+// the directory `workspace-deps/<key[..12]>` that `RunLayeredPrePass` and `RunSourceDepPrePass`
+// write two artifacts into:
+//
+//   <Pub>_<Name>_<Ver>.app            — emitted by InProcessAppPackager from the SOURCE dir
+//   <Pub>_<Name>_<Ver>.symbols.json   — the output of COMPILING that app's public surface
+//   <Pub>_<Name>_<Ver>.symbols.deps.json    against the resolved package closure
+//
+// The key carried the source app's identity, its DECLARED dependencies (id/publisher/name/
+// version) and a SHA-256 per `.al`/`app.json` file. The `.app` is entirely source-derived, so
+// those terms cover it. The `*.symbols.json` is not: it is the compiler's view of the app's
+// public surface *as compiled against the resolved dependency packages' bytes*, and the bytes
+// of the winning packages appeared nowhere in the key.
+//
+// So swapping a third-party dependency `.app` for different bytes at the same declared version
+// produced a workspace HIT, and the dependent bundle compiled against the PREVIOUS public
+// surface. Nothing fails: same exit code, same green tests, code linked against a dependency
+// surface the run never saw. Identical shape to #2754 one cache layer over — see
+// CacheKeyDependencyContentIdentityTests for that one, and commit f3ca2b00 for the fix this
+// follows.
+//
+// Why the #2754 fix does not already cover it: the AL-output key's dep term for a layered
+// sibling hashes the workspace `.app`, whose content is source-derived. A stale `symbols.json`
+// sitting beside it is invisible to that hash.
+//
+// The arms
+// --------
+// NEGATIVE (the collision) — the same declared dependency resolved to packages with the same
+// byte LENGTH and the same MTIME but different BYTES must not share a workspace key.
+//
+// POSITIVE (the cache must still hit) — byte-identical packages at a different path with a
+// different mtime must produce the SAME key. Without this arm the collision test above is
+// satisfied by keying on something always-unique, which would pass while destroying every
+// workspace cache hit and re-running the ~22s-per-impl symbol compile on every invocation.
+//
+// Plus the two properties the change must not break: the key still moves when a source file
+// changes, and it still distinguishes two different resolved closures for identical source.
+//
+// A note on the fixture, because it is easy to get wrong: BcAppSymbolCache.ComputeAppContentHash
+// memoizes per FULL PATH for the life of the process (deliberately — see its comment). A test
+// that rewrote one package in place at a single path would therefore be served the first hash
+// and read as GREEN no matter what the key does. Every arm here writes its packages at
+// DISTINCT paths for that reason.
+
+using Xunit;
+using AlRunner;
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Tests;
+
+public sealed class SourceWorkspaceKeyDependencyContentTests : IDisposable
+{
+    private static readonly Guid SourceAppId = new("2846a001-1111-4222-8333-444455556666");
+    private static readonly Guid DepAppId = new("2846b002-1111-4222-8333-444455556666");
+    private const string DepName = "Fabrikam Layered Dep";
+    private const string DepPublisher = "Fabrikam ISV";
+    private static readonly Version DepVersion = new(1, 0, 0, 0);
+
+    private readonly string _scratch;
+
+    public SourceWorkspaceKeyDependencyContentTests()
+    {
+        _scratch = TestScratch.Dir("al-runner-workspace-key-depcontent");
+        Directory.CreateDirectory(_scratch);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_scratch, recursive: true); } catch { }
+    }
+
+    /// <summary>
+    /// The defect. Two resolved packages with the same declared id/publisher/name/version, the
+    /// same byte length and the same mtime, differing only in their bytes, must produce
+    /// different workspace keys — otherwise the second run reuses the first run's
+    /// <c>*.symbols.json</c>, which was compiled against the other package's public surface.
+    /// </summary>
+    [SkippableFact]
+    public void SameDeclaredDependencyDifferentPackageBytes_ProducesDifferentWorkspaceKey()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dir, ids) = WriteSourceApp("src-collide");
+
+        var pkgA = WritePackage("pkg-a", fill: (byte)'A');
+        var pkgB = WritePackage("pkg-b", fill: (byte)'B');
+        StampSameMtime(pkgA, pkgB);
+
+        // Preconditions, asserted rather than assumed: without all three this test would not
+        // be exercising the defect at all.
+        Assert.Equal(new FileInfo(pkgA).Length, new FileInfo(pkgB).Length);
+        Assert.Equal(new FileInfo(pkgA).LastWriteTimeUtc.Ticks, new FileInfo(pkgB).LastWriteTimeUtc.Ticks);
+        Assert.False(File.ReadAllBytes(pkgA).AsSpan().SequenceEqual(File.ReadAllBytes(pkgB)),
+            "the two synthetic packages are byte-identical — the fixture is not exercising the defect");
+
+        var keyA = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkgA));
+        var keyB = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkgB));
+
+        // Concrete shape, not just "different": a 64-char lowercase hex digest. A key that
+        // degraded to an empty string or a constant would satisfy an inequality-only test in
+        // one direction and this one in neither.
+        AssertIsWorkspaceKey(keyA);
+        AssertIsWorkspaceKey(keyB);
+        Assert.NotEqual(keyA, keyB);
+    }
+
+    /// <summary>
+    /// The direction that keeps the fix honest: byte-identical resolved packages at a different
+    /// path with a different mtime must key IDENTICALLY. A key that simply varied per resolved
+    /// file path (or per stat) would satisfy the collision arm while destroying the workspace
+    /// cache — and re-running the per-impl symbol compile the workspace dir exists to avoid.
+    /// </summary>
+    [SkippableFact]
+    public void ByteIdenticalPackagesAtDifferentPathsAndMtimes_ProduceTheSameWorkspaceKey()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dir, ids) = WriteSourceApp("src-stable");
+
+        var pkgA = WritePackage("same-a", fill: (byte)'A');
+        var pkgB = WritePackage("same-b", fill: (byte)'A');
+        File.SetLastWriteTimeUtc(pkgA, new DateTime(2020, 5, 6, 7, 8, 9, DateTimeKind.Utc));
+        File.SetLastWriteTimeUtc(pkgB, new DateTime(2026, 5, 6, 7, 8, 9, DateTimeKind.Utc));
+
+        Assert.True(File.ReadAllBytes(pkgA).AsSpan().SequenceEqual(File.ReadAllBytes(pkgB)),
+            "the two synthetic packages differ in bytes — this arm is not exercising a cache HIT");
+        Assert.NotEqual(new FileInfo(pkgA).LastWriteTimeUtc.Ticks, new FileInfo(pkgB).LastWriteTimeUtc.Ticks);
+        Assert.NotEqual(pkgA, pkgB);
+
+        var keyA = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkgA));
+        var keyB = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkgB));
+
+        AssertIsWorkspaceKey(keyA);
+        Assert.Equal(keyA, keyB);
+    }
+
+    /// <summary>
+    /// A resolved closure that GAINS a package must not share a key with one that does not have
+    /// it — the "dependency closure missing from the key entirely" shape #2754's own comment
+    /// records one cache layer over. Declared identity is identical in both calls here; only
+    /// what actually resolved differs.
+    /// </summary>
+    [SkippableFact]
+    public void AResolvedClosureWithAnExtraPackage_ProducesADifferentWorkspaceKey()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dir, ids) = WriteSourceApp("src-closure");
+
+        var pkgA = WritePackage("closure-a", fill: (byte)'A');
+        var extra = WritePackage("closure-extra", fill: (byte)'X', name: "Vendored Extra");
+
+        var one = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkgA));
+        var two = ProgramSupport.ComputeSourceWorkspaceKey(
+            new[] { dir }, ids,
+            Resolved(pkgA).Concat(ResolvedNamed(extra, "Vendored Extra", new Guid("2846c003-1111-4222-8333-444455556666"))).ToList());
+
+        AssertIsWorkspaceKey(one);
+        AssertIsWorkspaceKey(two);
+        Assert.NotEqual(one, two);
+    }
+
+    /// <summary>
+    /// Regression guard for what the key already did: an edited source file still moves it, and
+    /// an unchanged input still reproduces it byte for byte. A change that keyed only on the
+    /// resolved packages would pass every arm above and break this one.
+    /// </summary>
+    [SkippableFact]
+    public void SourceContentStillDecidesTheKey_AndTheKeyIsDeterministic()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (dir, ids) = WriteSourceApp("src-edit");
+        var pkg = WritePackage("edit-pkg", fill: (byte)'A');
+
+        var before = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkg));
+        var again = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkg));
+        Assert.Equal(before, again);
+
+        File.WriteAllText(Path.Combine(dir, "Probe.Codeunit.al"), """
+        codeunit 60730 "Workspace Key Probe"
+        {
+            procedure Probe(): Integer
+            begin
+                exit(2);
+            end;
+        }
+        """);
+
+        var after = ProgramSupport.ComputeSourceWorkspaceKey(new[] { dir }, ids, Resolved(pkg));
+        AssertIsWorkspaceKey(after);
+        Assert.NotEqual(before, after);
+    }
+
+    // ── fixture ───────────────────────────────────────────────────────────────────────────
+
+    private static void AssertIsWorkspaceKey(string key)
+    {
+        Assert.Equal(64, key.Length);
+        Assert.Matches("^[0-9a-f]{64}$", key);
+    }
+
+    private (string Dir, IReadOnlyDictionary<string, BundleIdentity> Ids) WriteSourceApp(string name)
+    {
+        var dir = Path.Combine(_scratch, name);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{SourceAppId}}",
+          "name": "Workspace Key Fixture",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{DepAppId}}", "name": "{{DepName}}", "publisher": "{{DepPublisher}}", "version": "1.0.0.0" }
+          ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Probe.Codeunit.al"), """
+        codeunit 60730 "Workspace Key Probe"
+        {
+            procedure Probe(): Integer
+            begin
+                exit(1);
+            end;
+        }
+        """);
+
+        var id = new BundleIdentity(
+            SourceAppId, "Workspace Key Fixture", "AL Runner",
+            new Version(1, 0, 0, 0), new Version(14, 0, 0, 0),
+            new[] { new DependencyRef(DepAppId, DepName, DepPublisher, DepVersion) });
+
+        var ids = new Dictionary<string, BundleIdentity>(StringComparer.OrdinalIgnoreCase) { [dir] = id };
+        return (dir, ids);
+    }
+
+    /// <summary>
+    /// A file of a fixed length filled with <paramref name="fill"/>, written at its OWN
+    /// directory. The content hash the key consults is a plain SHA-256 over the file's bytes
+    /// (BcAppSymbolCache.ComputeAppContentHash → RunnerFingerprint.ComputeContentHash), which
+    /// never parses the package — so the manifest is not what this fixture needs to get right.
+    /// What it does need to get right is a distinct path per package, because that hash is
+    /// memoized per path for the process.
+    /// </summary>
+    private string WritePackage(string subdir, byte fill, string name = DepName)
+    {
+        var dir = Path.Combine(_scratch, subdir);
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, $"{DepPublisher}_{name}_1.0.0.0.app");
+        var bytes = new byte[8192];
+        bytes.AsSpan().Fill(fill);
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+
+    private static void StampSameMtime(string a, string b)
+    {
+        var stamp = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        File.SetLastWriteTimeUtc(a, stamp);
+        File.SetLastWriteTimeUtc(b, stamp);
+    }
+
+    private static List<(AppManifest Manifest, string AppPath)> Resolved(string appPath)
+        => ResolvedNamed(appPath, DepName, DepAppId);
+
+    private static List<(AppManifest Manifest, string AppPath)> ResolvedNamed(string appPath, string name, Guid appId)
+        => new()
+        {
+            (new AppManifest(DepPublisher, name, DepVersion, appId, Array.Empty<DependencyRef>()), appPath),
+        };
+}

--- a/AlRunner/Patches/BcAppSymbolCache.TableExtensions.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.TableExtensions.cs
@@ -46,8 +46,27 @@ internal static partial class BcAppSymbolCache
     /// </summary>
     internal static IReadOnlyList<TableExtensionSymbol> GetTableExtensions(string appPath)
     {
-        var info = new System.IO.FileInfo(appPath);
-        var key = $"{System.IO.Path.GetFullPath(appPath)}|{info.Length}|{info.LastWriteTimeUtc.Ticks}|v{CacheVersion}";
+        // Content, not a stat — issue #2846 case 2. This key used to read
+        //     $"{fullPath}|{info.Length}|{info.LastWriteTimeUtc.Ticks}|v{CacheVersion}"
+        // while `Get` in the same class, over the same files, keyed the same question on
+        // ComputeAppContentHash. #1820 replaced the Length/LastWriteTimeUtc stat there for the
+        // reason #1815 recorded one layer over: CI re-downloads every platform and test-toolkit
+        // .app on every run, so the mtime is fresh even when the bytes are identical, and an
+        // mtime-keyed entry MISSes unconditionally regardless of content. GetTableExtensions
+        // never got that treatment, so a touched-but-unchanged package reparsed every
+        // tableextension in it — the whole of Base Application's SymbolReference.json, the same
+        // parse #2712 measured as worth 96 extensions and 47 test results when it went wrong.
+        //
+        // The second half is the invariant: two members of one class, describing one package,
+        // disagreeing about which byte state of it they had read. ComputeAppContentHash is
+        // memoized per full path (see its comment) and `Get` computes it for these same .app
+        // files anyway, so aligning costs a dictionary lookup and makes the table index and the
+        // table-extension index provably describe the same read.
+        //
+        // The full path stays in the key. It is what keeps two byte-identical packages in
+        // different directories from sharing an entry, and dropping it is not part of this
+        // change.
+        var key = $"{System.IO.Path.GetFullPath(appPath)}|hash:{ComputeAppContentHash(appPath)}|v{CacheVersion}";
         if (TableExtensionCache.TryGetValue(key, out var cached))
             return cached;
         var parsed = ParseTableExtensions(appPath);

--- a/AlRunner/ProgramSupport/Dependencies.cs
+++ b/AlRunner/ProgramSupport/Dependencies.cs
@@ -672,7 +672,8 @@ internal static partial class ProgramSupport
     /// or mtime is still not distinguished — the pre-#2754 exposure, now narrowed to packages
     /// the runner could not read at all. Closing it means not claiming a cache identity for such
     /// a run at all (a "do not cache this run" signal threaded out to the cache gate), which is
-    /// a wider change than this one and is tracked on #2846. It is not closed by anything
+    /// a wider change than this one and is tracked on #2954 (carried out of #2846 when its other
+    /// two cases were fixed). It is not closed by anything
     /// cheaper here: a per-run nonce would force a MISS, but it would also be a code path no
     /// test in this repo can construct, and an untestable branch is what this method exists to
     /// stop shipping.</para>

--- a/AlRunner/ProgramSupport/SiblingCompile.cs
+++ b/AlRunner/ProgramSupport/SiblingCompile.cs
@@ -525,9 +525,28 @@ internal static partial class ProgramSupport
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();
             var implResolver = new DependencyResolver(implResolveDirs, AlRunner.Infrastructure.CacheRoots.SourceBuiltPackageDirs());
-            var implDeps = implResolver.Resolve(implId.Dependencies);
 
-            var implKey = ComputeSourceWorkspaceKey(new[] { implPath }, idByKey, implDeps);
+            // The resolve is CAUGHT here, not allowed to escape, and rethrown below from inside
+            // the emit block's own try — where it threw before this moved. Two behaviours depend
+            // on that and neither is this change's to alter:
+            //
+            //   * a WARM workspace (hadSymbols) never resolved at all, so a dependency that has
+            //     since gone missing did not fail here; the per-bundle resolve reports it later,
+            //     with the message and exit code Program.cs's own handlers decide;
+            //   * a COLD one wrapped the failure in "[layered] Failed to emit symbols for impl
+            //     '<name>' from <path>: <reason>" (LayeredSourceChainTests pins that text).
+            //
+            // Letting a MissingDependencyException escape from here instead does produce a
+            // better message — Program.cs's #2095 handler renders ToDetailedMessage's
+            // provisioning-gap report, which the wrapper defeats — but that is an error-reporting
+            // change with its own blast radius across CLI and server mode, not part of a cache
+            // key fix. Filed separately.
+            IReadOnlyList<(AppManifest Manifest, string AppPath)> implDeps = Array.Empty<(AppManifest, string)>();
+            string? implResolveFailure = null;
+            try { implDeps = implResolver.Resolve(implId.Dependencies); }
+            catch (Exception ex) { implResolveFailure = $"{ex.GetType().Name}: {ex.Message}"; }
+
+            var implKey = ComputeSourceWorkspaceKey(new[] { implPath }, idByKey, implDeps, implResolveFailure);
             var wsDir = Path.Combine(workspaceRoot, implKey[..12]);
             Directory.CreateDirectory(wsDir);
             if (!implDirs.Contains(wsDir, StringComparer.OrdinalIgnoreCase))
@@ -574,6 +593,13 @@ internal static partial class ProgramSupport
                     // here rather than recomputed, so the cold path costs exactly what it did.
                     // ScopeCurrentAppIdentity (below) sets _currentAppId to the impl so
                     // GetSharedReferences excludes the impl from its own specs (self-ref guard).
+                    //
+                    // If the resolve failed, redo it so it throws HERE — inside this try, whose
+                    // catch produces the "[layered] Failed to emit symbols for impl …" message
+                    // this path has always produced. The retry only runs on a path that is about
+                    // to abort.
+                    if (implResolveFailure != null)
+                        implDeps = implResolver.Resolve(implId.Dependencies);
                     BcCompiler.SetResolvedDeps(implDeps, implSymbolDirs);
                     // AFTER SetResolvedDeps, which resets _extraSymbolDirs. Passing an empty
                     // list is not the same as not calling it at all — the previous impl's call
@@ -855,7 +881,9 @@ internal static partial class ProgramSupport
 
             // Per-dep cache dir keyed on THIS dep's own sources + dep identities + the CONTENT
             // of the packages that closure actually resolved to.
-            var depKey = ComputeSourceWorkspaceKey(new[] { dir }, sourceApps, resolvedDepDeps);
+            // null: this resolve is not caught — it throws past the key, exactly as it did
+            // before the move, so there is never a failure for the key to describe.
+            var depKey = ComputeSourceWorkspaceKey(new[] { dir }, sourceApps, resolvedDepDeps, resolutionFailure: null);
             var wsDir = Path.Combine(workspaceRoot, depKey[..12]);
             Directory.CreateDirectory(wsDir);
             if (!depDirs.Contains(wsDir, StringComparer.OrdinalIgnoreCase))
@@ -984,11 +1012,21 @@ internal static partial class ProgramSupport
     /// parameter rather than an optional one on purpose: the directory holds a
     /// <c>*.symbols.json</c> compiled against those packages, so a call site that could omit
     /// them would be a call site that silently reintroduces #2846.</para>
+    ///
+    /// <para><paramref name="resolutionFailure"/> is for the one caller that CATCHES a
+    /// resolution failure to compute this key and rethrows it later from where it threw before
+    /// (RunLayeredPrePass). Passing the failure keys the directory on it, following
+    /// <c>GetOrderedDepIds</c>'s rule that an unresolvable closure is its own cache identity:
+    /// an empty list is indistinguishable from a bundle that genuinely has no dependencies, so
+    /// collapsing to "no deps" would let two different closures share a directory. Non-null and
+    /// a non-empty <paramref name="resolvedDeps"/> are mutually exclusive by construction; a
+    /// caller whose resolve simply throws past this point passes null.</para>
     /// </summary>
     internal static string ComputeSourceWorkspaceKey(
         IReadOnlyList<string> sortedDirs,
         IReadOnlyDictionary<string, AlRunner.Infrastructure.BundleIdentity> sourceApps,
-        IReadOnlyList<(AppManifest Manifest, string AppPath)> resolvedDeps)
+        IReadOnlyList<(AppManifest Manifest, string AppPath)> resolvedDeps,
+        string? resolutionFailure)
     {
         using var sha = System.Security.Cryptography.SHA256.Create();
         using var ms = new MemoryStream();
@@ -1045,6 +1083,8 @@ internal static partial class ProgramSupport
         //
         // Sorted so registration/resolution order — an artifact of directory scan order — cannot
         // move the key.
+        if (resolutionFailure != null)
+            WriteLine($"depres-unresolved:{resolutionFailure}");
         foreach (var term in resolvedDeps
                      .Select(d => $"depres:{d.Manifest.AppId:N}:{d.Manifest.Publisher}:{d.Manifest.Name}:{d.Manifest.Version}:{DependencyContentTerm(d.AppPath)}")
                      .OrderBy(t => t, StringComparer.Ordinal))

--- a/AlRunner/ProgramSupport/SiblingCompile.cs
+++ b/AlRunner/ProgramSupport/SiblingCompile.cs
@@ -476,7 +476,58 @@ internal static partial class ProgramSupport
             // has no impl dependency of its own.
             var priorImplDirs = implDirs.ToList();
 
-            var implKey = ComputeSourceWorkspaceKey(new[] { implPath }, idByKey);
+            // Resolve this impl's OWN dependency closure (declared + the implicit
+            // Application/System roots from app.json) transitively, exactly like the main
+            // per-bundle compile does. This replaced the former all-.app
+            // SetPackageCacheFallback, which scanned EVERY package in the caches — 134 apps /
+            // 353MB in the RS Extensions dir → ~215s per impl. The Application closure pulls
+            // only BaseApp / System App / Business Foundation (≈5 apps), so the symbol compile
+            // is fast and identical in coverage (an app that uses BaseApp via namespace
+            // depends, implicitly, on Application — never on the whole marketplace).
+            //
+            // Computed BEFORE the workspace key, and reused for the symbol emit below. #2846: the key names a directory
+            // holding the impl's *.symbols.json, which is the compiler's view of its public
+            // surface AS COMPILED AGAINST these resolved packages' bytes — so the resolved
+            // winners are an INPUT to what lands there, and the key has to see them. Resolving
+            // here rather than inside the `!hadSymbols` branch is what makes that possible; the
+            // cold path does exactly the work it did before (the list is reused, not recomputed),
+            // and the warm path gains one DependencyResolver index build, which is a directory
+            // scan plus AppLoader.ReadManifest calls that are memoized per process AND answered
+            // from an on-disk index.
+            //
+            // ORIGINAL package cache dirs + the impl's .alpackages (NOT extendedCaches, which
+            // includes wsDir — wsDir has no valid .app yet at this point anyway). They carry the
+            // impl's vendored/declared deps (e.g. an ISV licensing app) AND the Microsoft
+            // platform `System` app whose symbols define the System.* / System.AI.* namespaces
+            // (e.g. the "Copilot Capability" enum). Without them the layered impl symbol-emit
+            // resolves against only the global --package-cache and fails where the standalone
+            // compile succeeds: "Dependency not found" for a vendored dep, or AL0185/AL0133
+            // "Copilot Capability is missing". The impl compiles fine on its own BECAUSE it uses
+            // these dirs; the layered impl-emit must too.
+            var implSymbolDirs = thisImplAlpackages.Concat(packageCacheDirs).Distinct().ToList();
+            // RESOLUTION set (#2178): the compile set above, PLUS the workspace dirs of the impls
+            // already built by this loop and their .alpackages. This is what lets an impl declare
+            // a dependency on ANOTHER impl in the same invocation — the synthetic .app the
+            // earlier iteration wrote lives only in its workspace dir, which is otherwise not
+            // visible until this whole function returns extendedCaches to the per-bundle compiles
+            // below.
+            //
+            // Deliberately kept SEPARATE from implSymbolDirs, which is what SetResolvedDeps hands
+            // to BC's own .app scanner: a synthetic workspace .app carries no
+            // SymbolReference.json and makes that scanner report AL1023 "package not valid" for
+            // the whole compilation. The compile-time half of an earlier impl travels through its
+            // *.symbols.json sidecar instead, via SetExtraSymbolDirs below — exactly the split
+            // the per-bundle compile in Main already uses (see the SetExtraSymbolDirs
+            // (layeredWorkspaceDirs) call sites).
+            var implResolveDirs = implSymbolDirs
+                .Concat(priorImplDirs)
+                .Concat(implAlpackagesDirs)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            var implResolver = new DependencyResolver(implResolveDirs, AlRunner.Infrastructure.CacheRoots.SourceBuiltPackageDirs());
+            var implDeps = implResolver.Resolve(implId.Dependencies);
+
+            var implKey = ComputeSourceWorkspaceKey(new[] { implPath }, idByKey, implDeps);
             var wsDir = Path.Combine(workspaceRoot, implKey[..12]);
             Directory.CreateDirectory(wsDir);
             if (!implDirs.Contains(wsDir, StringComparer.OrdinalIgnoreCase))
@@ -518,51 +569,11 @@ internal static partial class ProgramSupport
             {
                 try
                 {
-                    // Resolve the impl's OWN dependency closure (declared + the implicit
-                    // Application/System roots from app.json) transitively, exactly like the
-                    // main per-bundle compile does. This replaces the former all-.app
-                    // SetPackageCacheFallback, which scanned EVERY package in the caches —
-                    // 134 apps / 353MB in the RS Extensions dir → ~215s per impl. The
-                    // Application closure pulls only BaseApp / System App / Business
-                    // Foundation (≈5 apps), so the symbol compile is fast and identical in
-                    // coverage (an app that uses BaseApp via namespace depends, implicitly,
-                    // on Application — never on the whole marketplace).
-                    // ScopeCurrentAppIdentity sets _currentAppId to the impl so
+                    // implSymbolDirs / implResolveDirs / implResolver / implDeps are computed
+                    // ABOVE, before the workspace key — see the comment there (#2846). Reused
+                    // here rather than recomputed, so the cold path costs exactly what it did.
+                    // ScopeCurrentAppIdentity (below) sets _currentAppId to the impl so
                     // GetSharedReferences excludes the impl from its own specs (self-ref guard).
-                    // Include the impl bundle's OWN .alpackages in the resolver + symbol dirs —
-                    // the SAME dirs the main per-bundle compile uses (see the bundlePkgDirs path
-                    // in the compile loop). They carry the impl's vendored/declared deps (e.g.
-                    // an ISV licensing app) AND the Microsoft platform `System` app whose symbols
-                    // define the System.* / System.AI.* namespaces (e.g. the "Copilot Capability"
-                    // enum). Without them the layered impl symbol-emit resolves against only the
-                    // global --package-cache and fails where the standalone compile succeeds:
-                    // "Dependency not found" for a vendored dep, or AL0185/AL0133 "Copilot
-                    // Capability is missing". The impl compiles fine on its own BECAUSE it uses
-                    // these dirs; the layered impl-emit must too.
-                    // ORIGINAL package cache dirs + the impl's .alpackages (NOT extendedCaches,
-                    // which includes wsDir — wsDir has no valid .app yet at this point anyway).
-                    var implSymbolDirs = thisImplAlpackages.Concat(packageCacheDirs).Distinct().ToList();
-                    // RESOLUTION set (#2178): the compile set above, PLUS the workspace dirs of
-                    // the impls already built by this loop and their .alpackages. This is what
-                    // lets an impl declare a dependency on ANOTHER impl in the same invocation —
-                    // the synthetic .app the earlier iteration wrote lives only in its workspace
-                    // dir, which is otherwise not visible until this whole function returns
-                    // extendedCaches to the per-bundle compiles below.
-                    //
-                    // Deliberately kept SEPARATE from implSymbolDirs, which is what
-                    // SetResolvedDeps hands to BC's own .app scanner: a synthetic workspace .app
-                    // carries no SymbolReference.json and makes that scanner report AL1023
-                    // "package not valid" for the whole compilation. The compile-time half of an
-                    // earlier impl travels through its *.symbols.json sidecar instead, via
-                    // SetExtraSymbolDirs below — exactly the split the per-bundle compile in Main
-                    // already uses (see the SetExtraSymbolDirs(layeredWorkspaceDirs) call sites).
-                    var implResolveDirs = implSymbolDirs
-                        .Concat(priorImplDirs)
-                        .Concat(implAlpackagesDirs)
-                        .Distinct(StringComparer.OrdinalIgnoreCase)
-                        .ToList();
-                    var implResolver = new DependencyResolver(implResolveDirs, AlRunner.Infrastructure.CacheRoots.SourceBuiltPackageDirs());
-                    var implDeps = implResolver.Resolve(implId.Dependencies);
                     BcCompiler.SetResolvedDeps(implDeps, implSymbolDirs);
                     // AFTER SetResolvedDeps, which resets _extraSymbolDirs. Passing an empty
                     // list is not the same as not calling it at all — the previous impl's call
@@ -815,8 +826,36 @@ internal static partial class ProgramSupport
             // one depends on has necessarily been written by now — see the identical snapshot
             // in RunLayeredPrePass and #2178.
             var priorDepDirs = depDirs.ToList();
-            // Per-dep cache dir keyed on THIS dep's own sources + dep identities.
-            var depKey = ComputeSourceWorkspaceKey(new[] { dir }, sourceApps);
+            // Resolve THIS dep's own dependency closure (declared + transitive) against the
+            // dependent bundles' .alpackages + packageCacheDirs, then hand it to BcCompiler —
+            // exactly like RunLayeredPrePass and the main per-bundle compile. Without this, a
+            // source dep that extends a Base App object (e.g. a tableextension on "Item Journal
+            // Batch") cannot resolve its target → AL0247 → BC's converter NREs → crash. The
+            // resolver produces CONCRETE resolved manifests (real version + path) from the
+            // .alpackages closure, which is present on CI where packageCacheDirs is empty.
+            // NOT the all-packages SetPackageCacheFallback (scans every .app, hangs the corpus);
+            // Resolve pulls only this dep's declared closure (BaseApp / System App / …).
+            // #2178: resolve against the workspace dirs written for the source deps BUILT BEFORE
+            // this one as well, so a source dep may itself depend on another source dep. Those
+            // dirs are kept out of the set handed to SetResolvedDeps — BC's .app scanner reports
+            // AL1023 on a synthetic .app with no SymbolReference.json — and reach the compiler as
+            // *.symbols.json through SetExtraSymbolDirs instead.
+            //
+            // #2846: this used to run AFTER the workspace key, which meant the key never saw the
+            // resolved winners even though the *.symbols.json written into the keyed directory is
+            // the compiler's view of this dep's public surface as compiled against exactly those
+            // packages' bytes. It was already unconditional, so moving it above the key adds no
+            // work at all here.
+            var depResolveDirs = resolveDirs
+                .Concat(priorDepDirs)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+            var depResolver = new DependencyResolver(depResolveDirs, AlRunner.Infrastructure.CacheRoots.SourceBuiltPackageDirs());
+            var resolvedDepDeps = depResolver.Resolve(sid.Dependencies);
+
+            // Per-dep cache dir keyed on THIS dep's own sources + dep identities + the CONTENT
+            // of the packages that closure actually resolved to.
+            var depKey = ComputeSourceWorkspaceKey(new[] { dir }, sourceApps, resolvedDepDeps);
             var wsDir = Path.Combine(workspaceRoot, depKey[..12]);
             Directory.CreateDirectory(wsDir);
             if (!depDirs.Contains(wsDir, StringComparer.OrdinalIgnoreCase))
@@ -853,29 +892,10 @@ internal static partial class ProgramSupport
             // runtime-loadable but invisible to the compiler (AL0185). BcCompiler's
             // GetSharedReferences chains a JsonSymbolReferenceLoader over the workspace
             // dir to pick these up. Revived from main's DepCompiler / SymbolJson.
-            // Resolve THIS dep's own dependency closure (declared + transitive) against the
-            // dependent bundles' .alpackages + packageCacheDirs, then hand it to BcCompiler —
-            // exactly like RunLayeredPrePass and the main per-bundle compile. Without this, a
-            // source dep that extends a Base App object (e.g. a tableextension on "Item Journal
-            // Batch") cannot resolve its target → AL0247 → BC's converter NREs → crash. The
-            // resolver produces CONCRETE resolved manifests (real version + path) from the
-            // .alpackages closure, which is present on CI where packageCacheDirs is empty.
-            // NOT the all-packages SetPackageCacheFallback (scans every .app, hangs the corpus);
-            // Resolve pulls only this dep's declared closure (BaseApp / System App / …).
-            // ScopeCurrentAppIdentity sets _currentAppId so GetSharedReferences excludes the dep
-            // from its own specs (self-ref guard). Reset by the per-bundle SetResolvedDeps below.
-            // #2178: resolve against the workspace dirs written for the source deps BUILT
-            // BEFORE this one as well, so a source dep may itself depend on another source dep.
-            // As in RunLayeredPrePass, those dirs are kept out of the set handed to
-            // SetResolvedDeps — BC's .app scanner reports AL1023 on a synthetic .app with no
-            // SymbolReference.json — and reach the compiler as *.symbols.json through
-            // SetExtraSymbolDirs instead.
-            var depResolveDirs = resolveDirs
-                .Concat(priorDepDirs)
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToList();
-            var depResolver = new DependencyResolver(depResolveDirs, AlRunner.Infrastructure.CacheRoots.SourceBuiltPackageDirs());
-            var resolvedDepDeps = depResolver.Resolve(sid.Dependencies);
+            // depResolveDirs / depResolver / resolvedDepDeps are computed ABOVE, before the
+            // workspace key — see the comment there (#2846). ScopeCurrentAppIdentity (below)
+            // sets _currentAppId so GetSharedReferences excludes the dep from its own specs
+            // (self-ref guard). Reset by the per-bundle SetResolvedDeps below.
             BcCompiler.SetResolvedDeps(resolvedDepDeps, resolveDirs);
             // AFTER SetResolvedDeps, which resets _extraSymbolDirs.
             if (priorDepDirs.Count > 0)
@@ -954,9 +974,21 @@ internal static partial class ProgramSupport
         return false;
     }
 
+    /// <summary>
+    /// The cache identity of one source app's synthesized workspace directory
+    /// (<c>workspace-deps/&lt;key[..12]&gt;</c>).
+    ///
+    /// <para><paramref name="resolvedDeps"/> is the closure the caller's
+    /// <see cref="DependencyResolver"/> actually produced for these dirs — NOT the declared
+    /// references, which are covered separately by the <c>dep:</c> lines. It is a required
+    /// parameter rather than an optional one on purpose: the directory holds a
+    /// <c>*.symbols.json</c> compiled against those packages, so a call site that could omit
+    /// them would be a call site that silently reintroduces #2846.</para>
+    /// </summary>
     internal static string ComputeSourceWorkspaceKey(
         IReadOnlyList<string> sortedDirs,
-        IReadOnlyDictionary<string, AlRunner.Infrastructure.BundleIdentity> sourceApps)
+        IReadOnlyDictionary<string, AlRunner.Infrastructure.BundleIdentity> sourceApps,
+        IReadOnlyList<(AppManifest Manifest, string AppPath)> resolvedDeps)
     {
         using var sha = System.Security.Cryptography.SHA256.Create();
         using var ms = new MemoryStream();
@@ -971,8 +1003,52 @@ internal static partial class ProgramSupport
         // explicit bc:<version> line was added (a content hash alone is identical across
         // every BC-version CI leg building the same commit, so without it all legs would
         // collide on one cache entry). v1 entries carried neither and must not be served.
-        WriteLine("schema:v2");
+        //
+        // v3 (issue #2846): the `depres:` lines below. v2 entries were written by a key that
+        // could not see the resolved packages, so a v2 directory's *.symbols.json may have been
+        // compiled against a different dependency surface than the one this run resolved —
+        // exactly the answer v3 exists to stop serving. v2 and v3 entries are therefore not
+        // interchangeable in either direction and the schema line has to move.
+        WriteLine("schema:v3");
         AlRunner.Infrastructure.RunnerFingerprint.WriteKeyLines(WriteLine);
+
+        // The RESOLVED dependency winners, by CONTENT — issue #2846, and the same substitution
+        // #2754/f3ca2b00 made for the AL-output key one layer over.
+        //
+        // The directory this key names holds two artifacts with DIFFERENT provenance:
+        //
+        //   <Pub>_<Name>_<Ver>.app          — InProcessAppPackager output, derived from the
+        //                                     source dir and its identity alone. The app:/dep:/
+        //                                     file: lines below cover it completely.
+        //   <Pub>_<Name>_<Ver>.symbols.json — the COMPILER's view of that app's public surface,
+        //   + .symbols.deps.json              produced by compiling it against the resolved
+        //                                     package closure.
+        //
+        // Only the declared dependency REFERENCES (id/publisher/name/version) were in the key,
+        // never the packages they actually resolved to. So replacing a third-party dependency
+        // with different bytes at the same declared version produced a HIT and served the
+        // previous symbols.json: the dependent bundle compiled against a public surface this
+        // run never saw, with an unchanged exit code and no failure anywhere. `bc:<version>`
+        // already covers the Microsoft platform case (it is the full four-part version), so the
+        // residue this closes is a non-Microsoft dependency at an unchanged declared version.
+        //
+        // Content, not a stat and not a path, for the reasons DependencyContentTerm states in
+        // full: `cp -p`, `rsync -a`, `tar -x` and CI cache restores all carry an mtime with the
+        // bytes, so equal mtimes across two directories is ordinary rather than a coincidence.
+        // Sharing DependencyContentTerm with the AL-output key is deliberate — it is the one
+        // place that decides what "the identity of a resolved package" means, including how a
+        // package that cannot be hashed degrades, so the two keys cannot drift apart on it.
+        //
+        // Cost: BcAppSymbolCache.ComputeAppContentHash memoizes per full path for the process,
+        // and a normal run hashes these same packages for the AL-output and bc-symbols keys
+        // anyway — so for the packages that reach both this is a dictionary lookup.
+        //
+        // Sorted so registration/resolution order — an artifact of directory scan order — cannot
+        // move the key.
+        foreach (var term in resolvedDeps
+                     .Select(d => $"depres:{d.Manifest.AppId:N}:{d.Manifest.Publisher}:{d.Manifest.Name}:{d.Manifest.Version}:{DependencyContentTerm(d.AppPath)}")
+                     .OrderBy(t => t, StringComparer.Ordinal))
+            WriteLine(term);
 
         foreach (var dir in sortedDirs.OrderBy(d => d, StringComparer.OrdinalIgnoreCase))
         {

--- a/AlRunner/ProgramSupport/SiblingCompile.cs
+++ b/AlRunner/ProgramSupport/SiblingCompile.cs
@@ -540,7 +540,7 @@ internal static partial class ProgramSupport
             // better message — Program.cs's #2095 handler renders ToDetailedMessage's
             // provisioning-gap report, which the wrapper defeats — but that is an error-reporting
             // change with its own blast radius across CLI and server mode, not part of a cache
-            // key fix. Filed separately.
+            // key fix. Filed as #2956, with both messages measured against the same fixture.
             IReadOnlyList<(AppManifest Manifest, string AppPath)> implDeps = Array.Empty<(AppManifest, string)>();
             string? implResolveFailure = null;
             try { implDeps = implResolver.Resolve(implId.Dependencies); }


### PR DESCRIPTION
Closes #2846

Two of that issue's three cases. A cache identified a thing by something other than its content, in the two places the issue names, and both are now content-keyed the way commit `f3ca2b00` (PR #2847, issue #2754) did it one cache layer over. Case 3 is a different change with its own design and is carried to #2954 rather than left in a comment on a closed issue.

## Case 1 — `ComputeSourceWorkspaceKey`

`AlRunner/ProgramSupport/SiblingCompile.cs`. The key names `workspace-deps/<key[..12]>`, a directory holding two artifacts with different provenance:

| artifact | derived from | covered by the old key? |
|---|---|---|
| `<Pub>_<Name>_<Ver>.app` | the source dir + its identity | yes — `app:` / `dep:` / `file:` lines |
| `<Pub>_<Name>_<Ver>.symbols.json` (+ `.symbols.deps.json`) | compiling that app's public surface **against the resolved package closure** | no |

The key carried the declared dependency *references* and never the packages they resolved to. Replacing a third-party dependency with different bytes at the same declared version produced a workspace HIT and served the previous `symbols.json`, so the dependent bundle compiled against a public surface the run never saw — same exit code, same green tests. `bc:<version>` is the full four-part BC version, so the Microsoft platform case was already covered; the residue this closes is a non-Microsoft dependency at an unchanged declared version.

The #2754 fix does not cover it by accident: the AL-output key's dep term for a layered sibling hashes the workspace `.app`, whose content is source-derived, so a stale `symbols.json` beside it stays invisible.

Adds one `depres:` line per resolved dependency, built by the **same** `DependencyContentTerm` helper `f3ca2b00` introduced — so the two keys cannot drift on what "the identity of a resolved package" means, including how an unhashable one degrades. `schema:v2` → `v3`, because a v2 directory may hold symbols compiled against a different surface.

Both call sites now resolve before computing the key and reuse the list. In `RunSourceDepPrePass` the resolve was already unconditional, so that is a pure reordering with no added work. In `RunLayeredPrePass` it moves out of the `!hadSymbols` branch, so the cold path costs exactly what it did (reused, not recomputed) and the warm path gains one `DependencyResolver` index build — a directory scan plus `ReadManifest` calls that are memoized per process and answered from an on-disk index.

## Case 2 — `BcAppSymbolCache.GetTableExtensions`

`BcAppSymbolCache.Get` keys on `{fullPath}|hash:{contentHash}|…`; `GetTableExtensions`, in the same class over the same files, still keyed on `{fullPath}|{Length}|{LastWriteTimeUtc.Ticks}|…`. Two consequences:

- a touched-but-unchanged package reparsed every tableextension in it — for Base Application, the whole `SymbolReference.json`, the parse #2712 measured as worth 96 extensions and 47 test results when it went wrong. CI re-downloads every platform and test-toolkit `.app` on every run, so this is the ordinary case, not a coincidence (#1815).
- the two caches disagreed about which byte state of one file they were describing, so the table index and the table-extension index for one package could be built from two different reads of it.

The full path stays in the key. This does **not** make either cache notice a package rewritten in place mid-process — `ComputeAppContentHash` memoizes per path by design — and the tests say so in as many words. Agreement between the two members is the property under test, not detection.

Edited only `BcAppSymbolCache.TableExtensions.cs`, never `BcAppSymbolCache.cs`, per that file's token-shift SIGSEGV header. `ComputeAppContentHash` is an existing member.

## RED → GREEN

Both were driven RED first, and in both cases the arms that must keep passing were already green at RED — so neither is satisfied by a key that varies unconditionally.

**Case 1** (`AlRunner.Tests/SourceWorkspaceKeyDependencyContentTests.cs`, 5 arms). RED with the parameter accepted but not yet written into the key: 2 failed, 2 passed. Both failures were `Assert.NotEqual() Failure: Strings are equal`, on `fbac35bc104d0d0521c3470ae252c232d4c37173f982af11e0…` — the identical key for two resolved packages with the same declared identity, same length, same mtime, different bytes. GREEN: 5/5.

- different package bytes → different key (the defect)
- byte-identical packages at a different path with a different mtime → **same** key (so the workspace cache still hits, and a re-downloaded package no longer MISSes)
- a closure that gains a package → different key
- an edited source file still moves the key; an unchanged input reproduces it
- a failed resolve keys on the failure — not on "no dependencies", not on a successful resolve, different reasons give different keys, the same reason is stable

Every arm asserts the key is a concrete 64-char lowercase hex digest, so a key degrading to `""` or a constant fails rather than passing an inequality test in one direction.

**Case 2** (`AlRunner.Tests/BcAppSymbolCacheTableExtensionKeyTests.cs`, 3 arms). RED: 2 failed, 1 passed. Both failures `Assert.Same() Failure: Values are not the same instance` on `TableExtensionSymbol { ExtensionId = 70001, … }` — a fresh parse where a HIT was required. GREEN: 3/3.

- an mtime touch on unchanged bytes does not reparse (reference identity: a HIT returns the stored list, a MISS builds a new one), with the parsed extension id, target table, field id, field name and type asserted concretely so an "empty list" HIT cannot pass
- after the same touch, `Get` **and** `GetTableExtensions` both still describe the byte state they first saw — the invariant
- two genuinely different packages still get their own parses and their own answers

## What else was run

- `dotnet test AlRunner.Tests --filter` over the whole affected surface (`BcAppSymbolCache`, `CacheKey`, `Layered`, `SourceDep`, `SourceWorkspaceKey`, `SiblingSourceDep`, `WatchLayeredDependencyStale`): **72/72**, 2m39s.
- `tests/runner-extras`, cold and again warm on the same private `--cache` outside the repo, since this is a cache-sensitive change: **264P/0F/0E** both times, count baseline matched. The warm run reported `AL emit: 0.0s` / `C# compile: 0.0s` — the new key terms are stable across runs, which is the property the "byte-identical → same key" arm asserts, observed end to end.
- `tests/al-language`: **2554P/0F/0E**, count baseline matched.

Local BC was 28.1.49838.53910; CI covers the other seven legs.

## The shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes, one: `AppLoader.ExtractAllDllPaths` keys a **persisted, cross-process** `r2r-chunks/<hash>` cache on `path|length|mtime`. Worse blast radius than case 2 (on disk, survives the process, caches the DLL payloads dependency code loads from), and it needs a decision about which hashing path to use plus a before/after measurement, so it is filed as **#2955** and cross-referenced in the code rather than fixed blind. Three further stat-based identities were checked and are deliberate, documented trade-offs, not oversights: `BcAssembler._metadataReferenceCache` (in-process, re-validated per call), `TestDataOptions.BuildCacheIdentity` (explicitly rejects hashing a ~1 GB backup), `BcCompiler.ReadAppMeta` (in-process, re-validated, caches a manifest).
2. **Sibling function making the same assumption?** That is case 2 itself — `Get` and `GetTableExtensions` are siblings in one class answering one question two ways.
3. **Two paths writing the same state, same invariant?** The `depres:` terms and the AL-output key's `dep:` terms are now produced by one helper, so a future change to what "resolved package identity" means moves both.

## Deliberately left out

- **#2846 case 3** — the degraded `unhashable:` term still cannot distinguish a package unhashable on two consecutive runs whose content changes without moving path, size or mtime. Closing it means a "do not cache this run" signal threaded out to the cache gate, not a term-format change; the two cheaper options were considered and rejected in #2847's review. Carried to **#2954** with that design and those rejections recorded, so it survives this issue closing.
- **An error-reporting improvement I found and did not take.** Hoisting the resolve initially let a `MissingDependencyException` escape `RunLayeredPrePass`'s `[layered] Failed to emit symbols…` wrapper, and `Program.cs`'s #2095 handler then rendered `ToDetailedMessage`'s full provisioning-gap report — measurably better output on the same fixture, and exactly what #2095 exists to produce. It is still an error-reporting change across CLI and server mode (which do not agree about where this failure surfaces), so this PR keeps the old behaviour exactly: the resolve is caught for the key and rethrown from inside the same `try` it used to throw from, and a caught failure is keyed on rather than collapsed to "no dependencies". Both messages are recorded against the same fixture on **#2956**.
- **#2889** — I claimed it, then found `agent: stma-auto-1` had claimed it concurrently, so I dropped my label and left it with them. Consequently I did not touch `InvalidateBcAppIndexes`, which is where their fix lands.
- **#2888** — left alone. Three of its four items are defined against PR #2873's `_bcAppPaths.Clear()`, which is **not** on `main` (`RecordPatches.cs` has no `Clear()` call), and its item 2 sits in the same `InvalidateBcAppIndexes` body #2889's owner is editing.

---

🤖 PR authored by Claude Code agent `impl-2b`.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
