### PR TITLE
fix(test-data): load a table first materialised inside another table's hydration

### DIFF
--- a/AlRunner.Tests/NestedTableMaterialisationHydrationTests.cs
+++ b/AlRunner.Tests/NestedTableMaterialisationHydrationTests.cs
@@ -1,0 +1,435 @@
+// NestedTableMaterialisationHydrationTests — the proving tests for issue #2877.
+//
+// THE DEFECT
+//   Hydrating table X under --test-data runs BC's own metadata and NavValue construction, and
+//   that code can reach a Record of another table Y and land straight back in
+//   GetDataAccessForTableCore. A nested load there would recurse, so it is refused — but by the
+//   time it is refused, Y's storage has already been created and published into perTable. The
+//   design's own rule is "storage presence IS the have-we-loaded-this answer", so every later
+//   touch of Y found the entry and never loaded it: Y silently kept NONE of its backup rows for
+//   the rest of the run, and TestDataProvisioner recorded no outcome for it either, so the
+//   summary could not report it and the store afterwards looked exactly like a table nothing
+//   had ever touched.
+//
+// WHAT IS PROVED HERE
+//   1. The debt is recorded against the storage INSTANCE the nested call published, and paid by
+//      the next touch that is not itself inside a materialisation — same instance, backup rows
+//      present.
+//   2. It is paid ONCE, and a store nothing deferred is untouched by any of this.
+//   3. When the store has been written to in the meantime the debt is WRITTEN OFF rather than
+//      paid, because loading then would MIX the backup's rows with whatever put the others
+//      there — and the write-off is reported, never silent. "Cannot tell" is written off too:
+//      unknown is not empty (the same discipline RecordPatches.StoredTableCensus keeps).
+//   4. Object Metadata (2000000071) is the one table where a populate follows the
+//      materialisation, and hydration and synthesis cannot both win. Synthesis is HELD OFF
+//      while a load is owed rather than done and later withdrawn, so the backup's real rows
+//      still win — which is the precedence #2519/#2788 built that branch on.
+//
+// WHY THESE ARE RUNNER TESTS
+//   Every claim is about the runner's own materialisation order under --test-data, a flag no CI
+//   leg passes. None of it is expressible from AL: by design AL cannot tell a table materialised
+//   on first touch from one present from the start, and it cannot observe another table's
+//   hydration reaching back for its own. .claude/rules/bc-behavior-tests-go-upstream.md keeps
+//   them here.
+using System.Collections.Concurrent;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// RecordPatches.TestDataOnDemandLoader and the deferred-load notifiers are process-wide statics
+// that TestDataLazyLoadPolicyTests also writes, so these join the collection that serialises it.
+[Collection(BcCompilerSharedReferenceCollection.Name)]
+public sealed class NestedTableMaterialisationHydrationTests : IDisposable
+{
+    private const int OuterTableId = 61030;   // the table whose hydration reaches for the other
+    private const int NestedTableId = 61031;  // the one first materialised from inside it
+    private const int ObjectMetadataTableId = 2000000071;
+    private const string BackupRow = "row-from-the-backup";
+
+    private readonly Action<object, int>? _previousLoader;
+    private readonly Action<int>? _previousDeferred;
+    private readonly Action<int, string>? _previousWriteOff;
+
+    public NestedTableMaterialisationHydrationTests()
+    {
+        _previousLoader = RecordPatches.TestDataOnDemandLoader;
+        _previousDeferred = RecordPatches.TestDataDeferredLoadNotifier;
+        _previousWriteOff = RecordPatches.TestDataDeferredLoadWriteOffNotifier;
+        RecordPatches.TestDataOnDemandLoader = null;
+        RecordPatches.TestDataDeferredLoadNotifier = null;
+        RecordPatches.TestDataDeferredLoadWriteOffNotifier = null;
+    }
+
+    public void Dispose()
+    {
+        RecordPatches.TestDataOnDemandLoader = _previousLoader;
+        RecordPatches.TestDataDeferredLoadNotifier = _previousDeferred;
+        RecordPatches.TestDataDeferredLoadWriteOffNotifier = _previousWriteOff;
+    }
+
+    /// <summary>Stand-in for the in-memory store behind a DataAccess — one object per table
+    /// whose rows are visible to whoever holds it.</summary>
+    private sealed class FakeStore
+    {
+        public ConcurrentQueue<string> Rows { get; } = new();
+    }
+
+    private static bool? HasRows(object store) => !((FakeStore)store).Rows.IsEmpty;
+
+    // ── 1. The central claim ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// THE claim of #2877. The loader for the outer table reaches a Record of the nested one,
+    /// which lands back in the materialisation at depth &gt; 0 and publishes storage that cannot
+    /// be loaded there. The next touch of the nested table — outside any hydration — must come
+    /// back with the SAME storage, now carrying the backup's rows.
+    ///
+    /// Before the fix that touch returned the published-but-empty store and no load ever ran
+    /// again for the rest of the run, so `rowsOnTheNextTouch` was 0.
+    /// </summary>
+    [Fact]
+    public void ATableFirstMaterialisedInsideAnotherTablesHydration_IsHydratedOnTheNextTouch()
+    {
+        var source = new object();
+        var perTable = new ConcurrentDictionary<int, object>();
+        object? nestedGot = null;
+        var loads = 0;
+
+        RecordPatches.TestDataOnDemandLoader = (src, id) =>
+        {
+            Interlocked.Increment(ref loads);
+            if (id == OuterTableId)
+            {
+                // BC's metadata / NavValue construction reaching a Record of another table.
+                nestedGot = RecordPatches.GetOrCreateHydratedDataAccessCore(
+                    src, perTable, NestedTableId, static () => new FakeStore(), HasRows);
+                return;
+            }
+            ((FakeStore)perTable[id]).Rows.Enqueue(BackupRow);
+        };
+
+        RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, OuterTableId, static () => new FakeStore(), HasRows);
+
+        // The nested call got storage, and it was empty at that moment — nothing changes there.
+        Assert.NotNull(nestedGot);
+        Assert.Empty(((FakeStore)nestedGot!).Rows);
+        Assert.Same(perTable[NestedTableId], nestedGot);
+
+        // The next independent touch pays the debt into that same storage.
+        var later = RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, NestedTableId, static () => new FakeStore(), HasRows);
+
+        Assert.Same(nestedGot, later);
+        Assert.Equal(new[] { BackupRow }, ((FakeStore)later).Rows.ToArray());
+        Assert.Equal(2, loads);   // the outer one, then the deferred one — not a third
+    }
+
+    /// <summary>
+    /// Paid once, not on every touch. A deferred load that re-ran would duplicate every backup
+    /// row on the second access, which is a worse answer than the missing rows it replaced.
+    /// </summary>
+    [Fact]
+    public void TheDeferredLoad_IsPaidExactlyOnce_AndLaterTouchesAreFastPathHits()
+    {
+        var source = new object();
+        var perTable = new ConcurrentDictionary<int, object>();
+        var loads = 0;
+
+        RecordPatches.TestDataOnDemandLoader = (src, id) =>
+        {
+            Interlocked.Increment(ref loads);
+            if (id == OuterTableId)
+            {
+                RecordPatches.GetOrCreateHydratedDataAccessCore(
+                    src, perTable, NestedTableId, static () => new FakeStore(), HasRows);
+                return;
+            }
+            ((FakeStore)perTable[id]).Rows.Enqueue(BackupRow);
+        };
+
+        RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, OuterTableId, static () => new FakeStore(), HasRows);
+
+        var first = RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, NestedTableId, static () => new FakeStore(), HasRows);
+        var second = RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, NestedTableId, static () => new FakeStore(), HasRows);
+        var third = RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, NestedTableId, static () => new FakeStore(), HasRows);
+
+        Assert.Same(first, second);
+        Assert.Same(second, third);
+        Assert.Equal(new[] { BackupRow }, ((FakeStore)third).Rows.ToArray());
+        Assert.Equal(2, loads);
+    }
+
+    /// <summary>
+    /// The debt names the storage INSTANCE, so a table materialised normally never carries one
+    /// and the ordinary path is untouched. Without this, "always load again" would satisfy the
+    /// test above and load every table twice.
+    /// </summary>
+    [Fact]
+    public void ATableMaterialisedNormally_OwesNothing_AndIsNotLoadedTwice()
+    {
+        var source = new object();
+        var perTable = new ConcurrentDictionary<int, object>();
+        var loads = 0;
+        RecordPatches.TestDataOnDemandLoader = (_, id) =>
+        {
+            Interlocked.Increment(ref loads);
+            ((FakeStore)perTable[id]).Rows.Enqueue(BackupRow);
+        };
+
+        var first = RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, NestedTableId, static () => new FakeStore(), HasRows);
+        Assert.False(RecordPatches.IsAwaitingTestDataHydration(first));
+
+        var second = RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, NestedTableId, static () => new FakeStore(), HasRows);
+
+        Assert.Same(first, second);
+        Assert.Equal(1, loads);
+        Assert.Equal(new[] { BackupRow }, ((FakeStore)second).Rows.ToArray());
+    }
+
+    /// <summary>
+    /// The debt is observable from outside the materialisation while it stands, and gone once it
+    /// is settled. That predicate is what the Object Metadata branch consults to decide whether
+    /// synthesising now would shadow a load that is still owed.
+    /// </summary>
+    [Fact]
+    public void AwaitingHydration_IsTrueForTheNestedStore_AndFalseOnceTheDebtIsSettled()
+    {
+        var source = new object();
+        var perTable = new ConcurrentDictionary<int, object>();
+        object? nestedGot = null;
+
+        RecordPatches.TestDataOnDemandLoader = (src, id) =>
+        {
+            if (id == OuterTableId)
+            {
+                nestedGot = RecordPatches.GetOrCreateHydratedDataAccessCore(
+                    src, perTable, NestedTableId, static () => new FakeStore(), HasRows);
+                Assert.True(RecordPatches.IsAwaitingTestDataHydration(nestedGot));
+                return;
+            }
+            ((FakeStore)perTable[id]).Rows.Enqueue(BackupRow);
+        };
+
+        RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, OuterTableId, static () => new FakeStore(), HasRows);
+
+        Assert.True(RecordPatches.IsAwaitingTestDataHydration(nestedGot!));
+
+        var later = RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, NestedTableId, static () => new FakeStore(), HasRows);
+
+        Assert.Same(nestedGot, later);
+        Assert.False(RecordPatches.IsAwaitingTestDataHydration(later));
+    }
+
+    // ── 3. The write-off: never MIX, and never silently ─────────────────────────────
+
+    /// <summary>
+    /// Something wrote into the store between the nested publication and the touch that would
+    /// pay the debt. Loading now would put the backup's rows on top of those — the mixed result
+    /// #2788 exists to prevent, wearing a different hat — so the debt is written off instead,
+    /// with the table id and the reason reported. A silent skip is what produced #2877 in the
+    /// first place.
+    /// </summary>
+    [Fact]
+    public void WhenTheStoreWasWrittenToMeanwhile_TheDebtIsWrittenOffAndReported_NotPaidOnTop()
+    {
+        var source = new object();
+        var perTable = new ConcurrentDictionary<int, object>();
+        var writeOffs = new List<(int TableId, string Reason)>();
+        RecordPatches.TestDataDeferredLoadWriteOffNotifier = (id, reason) => writeOffs.Add((id, reason));
+
+        var loads = 0;
+        RecordPatches.TestDataOnDemandLoader = (src, id) =>
+        {
+            Interlocked.Increment(ref loads);
+            if (id == OuterTableId)
+            {
+                var nested = RecordPatches.GetOrCreateHydratedDataAccessCore(
+                    src, perTable, NestedTableId, static () => new FakeStore(), HasRows);
+                // The nested caller writes through the handle it was just given.
+                ((FakeStore)nested).Rows.Enqueue("written-by-the-nested-caller");
+                return;
+            }
+            ((FakeStore)perTable[id]).Rows.Enqueue(BackupRow);
+        };
+
+        RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, OuterTableId, static () => new FakeStore(), HasRows);
+
+        var later = RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, NestedTableId, static () => new FakeStore(), HasRows);
+
+        // The row that was there stays, and the backup's row is NOT stacked on top of it.
+        Assert.Equal(new[] { "written-by-the-nested-caller" }, ((FakeStore)later).Rows.ToArray());
+        Assert.Equal(1, loads);
+        // …and it is reported, naming the table and saying why.
+        var writeOff = Assert.Single(writeOffs);
+        Assert.Equal(NestedTableId, writeOff.TableId);
+        Assert.Contains("row", writeOff.Reason, StringComparison.OrdinalIgnoreCase);
+        // Settled: a later touch does not re-try and does not report twice.
+        RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, NestedTableId, static () => new FakeStore(), HasRows);
+        Assert.Single(writeOffs);
+        Assert.False(RecordPatches.IsAwaitingTestDataHydration(later));
+    }
+
+    /// <summary>
+    /// "Cannot tell" is written off too. A probe that cannot read BC's private store layout must
+    /// not be read as "empty, go ahead and load" — that is the same false-negative
+    /// RecordPatches.StoredTableCensus refuses to make, and here it would silently mix rows.
+    /// </summary>
+    [Fact]
+    public void WhenTheStoreCannotBeProbed_TheDebtIsWrittenOffRatherThanPaidBlind()
+    {
+        var source = new object();
+        var perTable = new ConcurrentDictionary<int, object>();
+        var writeOffs = new List<(int TableId, string Reason)>();
+        RecordPatches.TestDataDeferredLoadWriteOffNotifier = (id, reason) => writeOffs.Add((id, reason));
+
+        static bool? CannotTell(object _) => null;
+
+        var loads = 0;
+        RecordPatches.TestDataOnDemandLoader = (src, id) =>
+        {
+            Interlocked.Increment(ref loads);
+            if (id == OuterTableId)
+            {
+                RecordPatches.GetOrCreateHydratedDataAccessCore(
+                    src, perTable, NestedTableId, static () => new FakeStore(), CannotTell);
+                return;
+            }
+            ((FakeStore)perTable[id]).Rows.Enqueue(BackupRow);
+        };
+
+        RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, OuterTableId, static () => new FakeStore(), CannotTell);
+        var later = RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, NestedTableId, static () => new FakeStore(), CannotTell);
+
+        Assert.Empty(((FakeStore)later).Rows);
+        Assert.Equal(1, loads);
+        var writeOff = Assert.Single(writeOffs);
+        Assert.Equal(NestedTableId, writeOff.TableId);
+    }
+
+    // ── 4. Object Metadata (2000000071): hydration and synthesis cannot both win ────
+
+    /// <summary>
+    /// The one table where a populate follows the materialisation. A nested first touch used to
+    /// leave it published-and-unloaded AND let PopulateObjectMetadataSystemTable claim the
+    /// once-per-provider flag and synthesise its 43 rows into it — so the deferred load would
+    /// later land on top of synthesised rows, or (before this fix) never land at all.
+    ///
+    /// The answer: synthesis is held off while a load is owed. The nested caller sees an empty
+    /// store for that moment, the next touch hydrates first, and the populate that follows finds
+    /// rows and does nothing — which is the "real rows win, synthesis is the fallback"
+    /// precedence the branch was built on.
+    /// </summary>
+    [Fact]
+    public void ObjectMetadata_NestedFirstTouch_SynthesisesNothing_AndTheBackupsRowsStillWin()
+    {
+        var source = new object();
+        var perTable = new ConcurrentDictionary<int, object>();
+        var synthesised = 0;
+
+        void Populate(object store)
+        {
+            // The real populator's contract: synthesise only into a store nobody has filled.
+            if (!((FakeStore)store).Rows.IsEmpty) return;
+            synthesised++;
+            ((FakeStore)store).Rows.Enqueue("synthesised");
+        }
+
+        object? nestedGot = null;
+        RecordPatches.TestDataOnDemandLoader = (src, id) =>
+        {
+            if (id == OuterTableId)
+            {
+                nestedGot = RecordPatches.MaterialiseObjectMetadataStoreCore(
+                    src, perTable, ObjectMetadataTableId,
+                    static () => new FakeStore(), HasRows, Populate);
+                return;
+            }
+            ((FakeStore)perTable[id]).Rows.Enqueue(BackupRow);
+        };
+
+        RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, OuterTableId, static () => new FakeStore(), HasRows);
+
+        // Nothing was synthesised into a store that still owes a load.
+        Assert.NotNull(nestedGot);
+        Assert.Empty(((FakeStore)nestedGot!).Rows);
+        Assert.Equal(0, synthesised);
+
+        var later = RecordPatches.MaterialiseObjectMetadataStoreCore(
+            source, perTable, ObjectMetadataTableId,
+            static () => new FakeStore(), HasRows, Populate);
+
+        Assert.Same(nestedGot, later);
+        Assert.Equal(new[] { BackupRow }, ((FakeStore)later).Rows.ToArray());
+        Assert.Equal(0, synthesised);
+    }
+
+    /// <summary>
+    /// The fallback arm, and it is what stops the fix from simply disabling synthesis: with no
+    /// load owed — a backup that does not offer 2000000071, or a run whose loader inserts
+    /// nothing — the populate runs exactly as before and its rows are what the table holds.
+    /// </summary>
+    [Fact]
+    public void ObjectMetadata_WithNothingOwed_StillSynthesises_AndOnlyOnce()
+    {
+        var source = new object();
+        var perTable = new ConcurrentDictionary<int, object>();
+        var synthesised = 0;
+
+        void Populate(object store)
+        {
+            if (!((FakeStore)store).Rows.IsEmpty) return;
+            synthesised++;
+            ((FakeStore)store).Rows.Enqueue("synthesised");
+        }
+
+        // A loader that offers this table nothing — the common case for a backup without it.
+        RecordPatches.TestDataOnDemandLoader = static (_, _) => { };
+
+        var first = RecordPatches.MaterialiseObjectMetadataStoreCore(
+            source, perTable, ObjectMetadataTableId, static () => new FakeStore(), HasRows, Populate);
+        var second = RecordPatches.MaterialiseObjectMetadataStoreCore(
+            source, perTable, ObjectMetadataTableId, static () => new FakeStore(), HasRows, Populate);
+
+        Assert.Same(first, second);
+        Assert.Equal(new[] { "synthesised" }, ((FakeStore)second).Rows.ToArray());
+        Assert.Equal(1, synthesised);
+    }
+
+    /// <summary>
+    /// A run without --test-data installs no loader, so nothing can ever be owed and the
+    /// Object Metadata branch keeps its pre-#2877 shape exactly: create, populate, hand back.
+    /// This is every corpus and runner-extras leg.
+    /// </summary>
+    [Fact]
+    public void WithNoLoaderInstalled_NothingIsEverOwed_AndTheObjectMetadataPopulateStillRuns()
+    {
+        var source = new object();
+        var perTable = new ConcurrentDictionary<int, object>();
+        var synthesised = 0;
+        Assert.Null(RecordPatches.TestDataOnDemandLoader);
+
+        var store = RecordPatches.MaterialiseObjectMetadataStoreCore(
+            source, perTable, ObjectMetadataTableId, static () => new FakeStore(), HasRows,
+            s => { synthesised++; ((FakeStore)s).Rows.Enqueue("synthesised"); });
+
+        Assert.False(RecordPatches.IsAwaitingTestDataHydration(store));
+        Assert.Equal(1, synthesised);
+        Assert.Equal(new[] { "synthesised" }, ((FakeStore)store).Rows.ToArray());
+    }
+}

--- a/AlRunner.Tests/TestDataLazyHydrationTests.cs
+++ b/AlRunner.Tests/TestDataLazyHydrationTests.cs
@@ -238,8 +238,138 @@ public sealed class TestDataLazyLoadPolicyTests : IDisposable
         TestDataProvisioner.Arm();
 
         Assert.Null(RecordPatches.TestDataOnDemandLoader);
+        Assert.Null(RecordPatches.TestDataDeferredLoadNotifier);
+        Assert.Null(RecordPatches.TestDataDeferredLoadWriteOffNotifier);
         Assert.Empty(ReaderInvocations());
         Assert.Null(TestDataProvisioner.LastSummary);
+    }
+
+    /// <summary>
+    /// #2877's reporting half, end to end through the real provisioner. A table whose storage is
+    /// first created from inside ANOTHER table's hydration used to leave TableOutcome answering
+    /// null for it — and null, under the on-demand policy, means "nothing in this run ever
+    /// touched the table". So the one table that had been touched, published and silently left
+    /// unloaded was the one the run described exactly like a table nobody asked for.
+    ///
+    /// The untouched table is asserted alongside it on purpose: without that arm, a fix that
+    /// recorded something for every id in the plan would pass.
+    /// </summary>
+    [Fact]
+    public void ATableFirstCreatedInsideAnotherTablesHydration_HasARecordedOutcome_NotNull()
+    {
+        TestDataProvisioner.Arm();
+        var realLoader = RecordPatches.TestDataOnDemandLoader!;
+        var perTable = new System.Collections.Concurrent.ConcurrentDictionary<int, object>();
+        var source = new object();
+
+        // Stand in for BC's metadata / NavValue construction reaching a Record of another table
+        // while the outer table is being hydrated. Only the loader is swapped: the deferred-load
+        // notifier Arm() installed is the thing under test and stays in place.
+        RecordPatches.TestDataOnDemandLoader = (src, id) =>
+        {
+            if (id != UntouchedTableId) { realLoader(src, id); return; }
+            RecordPatches.GetOrCreateHydratedDataAccessCore(
+                src, perTable, TouchedTableId, static () => new object());
+        };
+
+        RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, UntouchedTableId, static () => new object());
+
+        var deferred = TestDataProvisioner.TableOutcome(TouchedTableId);
+        Assert.NotNull(deferred);
+        Assert.Contains("inside another table's", deferred!, StringComparison.Ordinal);
+        Assert.Contains("nothing has been loaded into it yet", deferred, StringComparison.Ordinal);
+
+        // A table nothing touched still has no outcome — "nested, not loaded" and "never
+        // touched" are two different answers, which is the whole point.
+        Assert.Null(TestDataProvisioner.TableOutcome(NotInTheBackupTableId));
+
+        // …and once the debt is paid the load's OWN outcome replaces it, so the deferred note is
+        // never left standing as the final word.
+        RecordPatches.TestDataOnDemandLoader = realLoader;
+        RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, TouchedTableId, static () => new object());
+
+        var settled = TestDataProvisioner.TableOutcome(TouchedTableId);
+        Assert.NotNull(settled);
+        Assert.DoesNotContain("nothing has been loaded into it yet", settled!, StringComparison.Ordinal);
+        Assert.Contains("Touched", settled, StringComparison.Ordinal);
+        // The debt really was paid by reading the backup, not by writing the outcome off.
+        Assert.Contains(TableLoadReads(), l => l.Contains("|Touched|", StringComparison.Ordinal));
+        Assert.Equal(0, TestDataProvisioner.DeferredLoadsWrittenOff);
+    }
+
+    /// <summary>
+    /// The write-off, reported through the real provisioner. Something wrote into the store
+    /// between the nested publication and the touch that would have loaded it, so the backup's
+    /// rows for that table are never loaded — and the run says so, per table, instead of leaving
+    /// a store that looks exactly like a table nothing touched.
+    /// </summary>
+    [Fact]
+    public void ADeferredLoadThatCannotBeRun_IsCountedAndExplained_NotSilentlyDropped()
+    {
+        TestDataProvisioner.Arm();
+        var realLoader = RecordPatches.TestDataOnDemandLoader!;
+        var perTable = new System.Collections.Concurrent.ConcurrentDictionary<int, object>();
+        var source = new object();
+        var occupied = new HashSet<object>();
+        Func<object, bool?> hasRows = store => occupied.Contains(store);
+
+        RecordPatches.TestDataOnDemandLoader = (src, id) =>
+        {
+            if (id != UntouchedTableId) { realLoader(src, id); return; }
+            var nested = RecordPatches.GetOrCreateHydratedDataAccessCore(
+                src, perTable, TouchedTableId, static () => new object(), hasRows);
+            occupied.Add(nested);   // the nested caller writes through the handle it was given
+        };
+
+        RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, UntouchedTableId, static () => new object(), hasRows);
+        RecordPatches.TestDataOnDemandLoader = realLoader;
+        RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, TouchedTableId, static () => new object(), hasRows);
+
+        Assert.Equal(1, TestDataProvisioner.DeferredLoadsWrittenOff);
+        var outcome = TestDataProvisioner.TableOutcome(TouchedTableId);
+        Assert.NotNull(outcome);
+        Assert.Contains("never loaded", outcome!, StringComparison.Ordinal);
+        Assert.Contains("mix", outcome, StringComparison.Ordinal);
+        // No reader ran for it — the write-off is the reason there are no rows, not a read that
+        // came back empty.
+        Assert.DoesNotContain(TableLoadReads(), l => l.Contains("|Touched|", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A table the backup does not offer must NOT be reported as a deferred or written-off load:
+    /// nothing was lost, and every runner test table and every table this company has no rows
+    /// for takes this path. It gets the ordinary "the plan has no table with this id" answer.
+    /// </summary>
+    [Fact]
+    public void ANestedCreationOfATableTheBackupDoesNotHave_IsNotReportedAsAMissingLoad()
+    {
+        TestDataProvisioner.Arm();
+        var realLoader = RecordPatches.TestDataOnDemandLoader!;
+        var perTable = new System.Collections.Concurrent.ConcurrentDictionary<int, object>();
+        var source = new object();
+
+        RecordPatches.TestDataOnDemandLoader = (src, id) =>
+        {
+            if (id != UntouchedTableId) { realLoader(src, id); return; }
+            RecordPatches.GetOrCreateHydratedDataAccessCore(
+                src, perTable, NotInTheBackupTableId, static () => new object());
+        };
+
+        RecordPatches.GetOrCreateHydratedDataAccessCore(
+            source, perTable, UntouchedTableId, static () => new object());
+
+        var outcome = TestDataProvisioner.TableOutcome(NotInTheBackupTableId);
+        Assert.NotNull(outcome);
+        Assert.Contains("has no table with this id", outcome!, StringComparison.Ordinal);
+        Assert.DoesNotContain("nothing has been loaded into it yet", outcome, StringComparison.Ordinal);
+        Assert.Equal(0, TestDataProvisioner.DeferredLoadsWrittenOff);
+        // The only table read was the one that really is in the plan.
+        Assert.All(TableLoadReads(),
+            l => Assert.Contains("|Untouched|", l, StringComparison.Ordinal));
     }
 }
 

--- a/AlRunner/Patches/RecordPatches.TableMaterialisation.cs
+++ b/AlRunner/Patches/RecordPatches.TableMaterialisation.cs
@@ -62,16 +62,47 @@
 //   code below is the original lock-free TryGetValue / create / GetOrAdd, with no gate object
 //   allocated and no lock taken.
 //
-// KNOWN, TRACKED, AND DELIBERATELY NOT CHANGED HERE
-//   A table whose storage was first created by a NESTED call is published without ever being
-//   hydrated, and "storage presence IS the have-we-loaded-this answer" then means no later
-//   touch loads it either — so that table silently keeps none of its backup rows for the whole
-//   run. That is a second defect of the same family, with a different fix and a different risk
-//   (hydrating into a store AL may already have written to, and, for 2000000071, into one the
-//   populator may already have synthesised into). It is filed separately rather than folded in;
-//   the behaviour below is byte-for-byte what it was.
+// THE NESTED PUBLICATION, AND THE DEBT IT LEAVES (#2877)
+//   A table whose storage is first created by a NESTED call is published without ever being
+//   hydrated, and "storage presence IS the have-we-loaded-this answer" then meant no later touch
+//   loaded it either — so that table silently kept none of its backup rows for the whole run,
+//   and TestDataProvisioner recorded no outcome for it, so the run could not report it either.
+//   The store afterwards looked exactly like a table nothing had ever touched.
+//
+//   The nested publication itself cannot be avoided: hydrating there would recurse. So it is
+//   recorded instead. _awaitingTestDataHydration names the storage INSTANCE that was published
+//   without a load, and the next touch that is NOT inside a materialisation pays the debt into
+//   that same instance, inside the gate, before handing it out. Same instance-naming discipline
+//   as the settled latch above, and for the same reason: a reset that drops or replaces the
+//   entry produces a different instance, so a stale debt can never be paid into the wrong store.
+//
+//   TWO THINGS THE DEBT MUST NOT DO, AND HOW EACH IS STOPPED
+//   * MIX ROWS. If anything wrote into the store between the nested publication and the payment
+//     — the nested caller inserting through the handle it was given is the realistic route — a
+//     load landing on top would produce a store holding the backup's rows AND somebody else's.
+//     That is the wrong-rows outcome the #2788 hand-out ordering exists to prevent. So the debt
+//     is only paid into a store that is provably EMPTY, and written off otherwise. "Cannot tell"
+//     is written off as well: unknown is not empty, the same discipline
+//     RecordPatches.StoredTableCensus keeps. A write-off is never silent — it is reported per
+//     table through TestDataDeferredLoadWriteOffNotifier, which is what makes the outcome
+//     readable rather than a store that looks untouched (.claude/rules/loud-failures.md).
+//   * LET A POPULATE SYNTHESISE FIRST. Object Metadata (2000000071) is the one table with a
+//     populate after its materialisation, and PopulateObjectMetadataSystemTable's contract is
+//     "synthesise only if nobody else put rows here". A nested first touch used to run that
+//     populate against the empty store it had just published, claim the once-per-provider flag
+//     and synthesise 43 rows — which would then be exactly the mixing case above, so the debt
+//     would be written off and the backup's real rows lost for the run. MaterialiseObjectMetadata-
+//     StoreCore holds the populate off while a load is owed instead. The nested caller sees an
+//     EMPTY Object Metadata store for that moment; that is the deliberate choice, because the
+//     alternative is synthesising rows that would have to be withdrawn, and nothing can withdraw
+//     rows a caller has already read. Nothing is lost when the backup does not offer the table:
+//     the debt is paid with zero rows, the store is still empty at the next touch, and the
+//     populate then synthesises exactly as it always did.
+using System.Collections;
 using System.Collections.Concurrent;
+using System.Reflection;
 using System.Runtime.CompilerServices;
+using AlRunner.Infrastructure;
 using Microsoft.Dynamics.Nav.Runtime;
 
 namespace AlRunner.Patches;
@@ -129,15 +160,143 @@ public static partial class RecordPatches
     private static object GetOrCreateHydratedDataAccess(
         object self, ConcurrentDictionary<int, object> perTable, NCLMetaTable table, int tableId)
         => GetOrCreateHydratedDataAccessCore(self, perTable, tableId,
-            () => _mCreateTempDataAccess!.Invoke(self, new object[] { table })!);
+            () => _mCreateTempDataAccess!.Invoke(self, new object[] { table })!,
+            // The production emptiness probe. Every real caller passes it: a deferred load
+            // settled without one would be paid BLIND, which is the row-mixing the debt exists
+            // to avoid (#2877).
+            StoredHasAnyRow);
+
+    /// <summary>
+    /// The storage for Object Metadata (2000000071): materialised like any other table, then
+    /// populated with its synthesised fallback row set — except while a --test-data load is
+    /// still owed for it, when the populate is held off so the backup's real rows still win.
+    /// See the #2877 note in this file's header for why "hold off" and not "synthesise now".
+    /// </summary>
+    private static object MaterialiseObjectMetadataStore(
+        object self, ConcurrentDictionary<int, object> perTable, NCLMetaTable table, int tableId)
+        => MaterialiseObjectMetadataStoreCore(self, perTable, tableId,
+            () => _mCreateTempDataAccess!.Invoke(self, new object[] { table })!,
+            StoredHasAnyRow,
+            store => PopulateObjectMetadataSystemTable(store, table));
+
+    /// <summary>
+    /// The ordering itself, with the two BC-specific steps behind delegates so it can be driven
+    /// without a booted engine. See AlRunner.Tests/NestedTableMaterialisationHydrationTests.cs.
+    /// </summary>
+    internal static object MaterialiseObjectMetadataStoreCore(
+        object self, ConcurrentDictionary<int, object> perTable, int tableId,
+        Func<object> createStorage, Func<object, bool?>? storeHasAnyRow, Action<object> populate)
+    {
+        var store = GetOrCreateHydratedDataAccessCore(self, perTable, tableId, createStorage, storeHasAnyRow);
+
+        // A store that still owes a --test-data load is left ALONE, empty, until the touch that
+        // pays it. Synthesising into it now would make the payment a mix of real and synthesised
+        // rows — and the payment refuses to mix, so it would be written off and the backup's real
+        // rows lost for the run instead. Only reachable under --test-data: with no loader
+        // installed nothing is ever owed and this is the pre-#2877 shape exactly.
+        if (IsAwaitingTestDataHydration(store)) return store;
+
+        populate(store);
+        return store;
+    }
+
+    /// <summary>Storage instances published by a nested materialisation and therefore never
+    /// --test-data-loaded. Keyed on the INSTANCE, so it dies with the store and no reset path
+    /// has to know it exists — the same reason the settled latch names an instance.</summary>
+    private static readonly ConditionalWeakTable<object, object> _awaitingTestDataHydration = new();
+
+    private static readonly object _awaitingTestDataHydrationSentinel = new();
+
+    /// <summary>
+    /// True while <paramref name="store"/> owes a --test-data load it could not run when it was
+    /// created, because it was created from inside another table's hydration (#2877). False for
+    /// every store on a run without --test-data, and false again the moment the debt is settled
+    /// — either paid or written off.
+    /// </summary>
+    internal static bool IsAwaitingTestDataHydration(object store)
+        => _awaitingTestDataHydration.TryGetValue(store, out _);
+
+    /// <summary>
+    /// Does <paramref name="dataAccess"/>'s in-memory store hold a row right now?
+    /// <c>true</c> / <c>false</c> / <c>null</c> = cannot tell, and cannot-tell is NOT empty:
+    /// every caller here treats it as "do not load", because loading blind is what would mix
+    /// rows. Same read, and the same three-way discipline, as
+    /// RecordPatches.StoredTableCensus.CollectCensus.
+    ///
+    /// <para>Resolution goes through <see cref="PrivateMemberLookup"/> rather than
+    /// <c>GetField</c>: <c>primaryTree</c> is private on <c>TempTableDataProvider</c> and BC's
+    /// own <c>CrmTableConnection.CrmTestDataProvider</c> derives from it, where
+    /// <c>GetField(NonPublic)</c> does not return a base class's private field (#2725).</para>
+    /// </summary>
+    private static bool? StoredHasAnyRow(object dataAccess)
+    {
+        object? primaryTree;
+        try
+        {
+            var provider = GetDataProvider(dataAccess);
+            if (provider == null) return null;
+            var field = PrivateMemberLookup.Field(provider.GetType(), "primaryTree");
+            if (field == null) return null;                  // BC's private layout moved — unknown
+            primaryTree = field.GetValue(provider);
+        }
+        catch (TargetInvocationException) { return null; }
+        catch (InvalidOperationException) { return null; }
+
+        // A null tree is BC's own "no row was ever inserted".
+        if (primaryTree == null) return false;
+        if (primaryTree is not IEnumerable rows) return null;
+        foreach (var _ in rows) return true;                 // one row is the whole answer
+        return false;
+    }
+
+    /// <summary>
+    /// Settle the debt a nested publication left against <paramref name="store"/>, from inside
+    /// the gate and before the store is handed out. Pays it — runs the load that was refused —
+    /// only when the store is provably empty; otherwise writes it off and reports why. Either
+    /// way the debt is gone afterwards, so no later touch re-tries and no table is reported
+    /// twice.
+    /// </summary>
+    private static void SettleDeferredTestDataLoad(
+        object self, int tableId, object store, Func<object, bool?>? storeHasAnyRow)
+    {
+        // No probe at all means the caller staged this storage itself and knows nothing else
+        // wrote to it — the ordering tests. Production always passes StoredHasAnyRow.
+        var occupied = storeHasAnyRow == null ? false : storeHasAnyRow(store);
+
+        if (occupied == false)
+        {
+            InvokeTestDataOnDemandLoader(self, tableId);
+            return;
+        }
+
+        TestDataDeferredLoadWriteOffNotifier?.Invoke(tableId, occupied == true
+            ? "its storage already held rows by the time a load could run, and loading on top "
+              + "of them would mix the backup's rows with those"
+            : "the runner could not read whether its storage already held rows, and loading "
+              + "blind could mix the backup's rows with rows that are already there");
+    }
 
     /// <summary>
     /// The ordering itself, with the one BC-specific step (constructing the temp DataAccess)
     /// behind <paramref name="createStorage"/> so the ordering can be driven — and raced —
     /// without a booted engine. See AlRunner.Tests/TableMaterialisationOrderingTests.cs.
     /// </summary>
+    /// <summary>
+    /// Test-only overload: no emptiness probe, because the caller stages the storage itself and
+    /// nothing else writes to it. Production never takes this route — see
+    /// <see cref="GetOrCreateHydratedDataAccess"/>, which always passes
+    /// <see cref="StoredHasAnyRow"/>.
+    /// </summary>
     internal static object GetOrCreateHydratedDataAccessCore(
         object self, ConcurrentDictionary<int, object> perTable, int tableId, Func<object> createStorage)
+        => GetOrCreateHydratedDataAccessCore(self, perTable, tableId, createStorage, storeHasAnyRow: null);
+
+    /// <param name="storeHasAnyRow">Answers "does this storage already hold a row" — true /
+    /// false / null for cannot-tell — and is consulted only when a deferred load (#2877) is
+    /// owed, to decide whether paying it would mix rows.</param>
+    internal static object GetOrCreateHydratedDataAccessCore(
+        object self, ConcurrentDictionary<int, object> perTable, int tableId, Func<object> createStorage,
+        Func<object, bool?>? storeHasAnyRow)
     {
         // No --test-data loader installed: nothing can hydrate, so there is no create → hydrate
         // window for anyone to observe. Original shape, original cost.
@@ -159,12 +318,26 @@ public static partial class RecordPatches
         // into the loader. That combination is the #2788 hand-out itself.
         if (perTable.TryGetValue(tableId, out var ready) && gate.IsSettled(ready)) return ready;
 
-        // Already inside a materialisation on this thread — must not wait on anyone. This is
-        // the pre-gate code path verbatim, and it is what a nested call did before.
+        // Already inside a materialisation on this thread — must not wait on anyone (see the
+        // wait-graph note in this file's header), and must not load either, because a nested
+        // load would recurse. So it creates and publishes lock-free, exactly as the pre-gate
+        // code did, and RECORDS that the instance it published owes a load (#2877). Without
+        // that record, "storage presence IS the have-we-loaded-this answer" made the omission
+        // permanent for the rest of the run.
         if (_materialisationDepth > 0)
         {
             if (perTable.TryGetValue(tableId, out var nested)) return nested;
-            return perTable.GetOrAdd(tableId, createStorage());
+            var createdNested = createStorage();
+            var publishedNested = perTable.GetOrAdd(tableId, createdNested);
+            if (ReferenceEquals(publishedNested, createdNested))
+            {
+                _awaitingTestDataHydration.AddOrUpdate(publishedNested, _awaitingTestDataHydrationSentinel);
+                // Recorded for the run's own reporting too, so TableOutcome can say "created
+                // during another table's hydration" instead of the null that means "nothing ever
+                // touched it" (#2240's argument, applied to this case).
+                TestDataDeferredLoadNotifier?.Invoke(tableId);
+            }
+            return publishedNested;
         }
 
         lock (gate)
@@ -176,16 +349,18 @@ public static partial class RecordPatches
             {
                 object instance;
                 var thisCallCreatedIt = false;
+                var owesADeferredLoad = false;
                 if (perTable.TryGetValue(tableId, out var existing))
                 {
                     // Published by a nested call (this thread's or another's) or by a restore.
                     // Storage presence IS the "have we loaded this" answer — see the on-demand
-                    // note in GetDataAccessForTableCore — so nothing is loaded for it here, and
-                    // nothing ever will be. It is settled below all the same: settled means "no
-                    // load is or will be running against this instance", which is true of it,
-                    // and is the only thing the fast path needs. That it holds no backup rows
-                    // is #2877, a different defect with a different fix.
+                    // note in GetDataAccessForTableCore — so a restore's instance is loaded by
+                    // construction and nothing runs for it here. A NESTED publication is the one
+                    // case where presence and loadedness came apart, and it says so: the debt
+                    // below is recorded against that exact instance, and this is the first touch
+                    // that can settle it (#2877).
                     instance = existing;
+                    owesADeferredLoad = _awaitingTestDataHydration.TryGetValue(existing, out _);
                 }
                 else
                 {
@@ -198,7 +373,13 @@ public static partial class RecordPatches
                 // throw away, and the winner's rows are already in the returned instance.
                 if (thisCallCreatedIt)
                     InvokeTestDataOnDemandLoader(self, tableId);
+                else if (owesADeferredLoad)
+                    SettleDeferredTestDataLoad(self, tableId, instance, storeHasAnyRow);
 
+                // Settled either way — paid, written off, or never owed — so no later touch
+                // re-tries and no table is reported twice. Removing before MarkSettled keeps the
+                // two facts in the right order for anything reading them from the fast path.
+                _awaitingTestDataHydration.Remove(instance);
                 gate.MarkSettled(instance);
                 return instance;
             }

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -1529,14 +1529,40 @@ public static partial class RecordPatches
     /// </summary>
     internal static Action<object, int>? TestDataOnDemandLoader;
 
+    /// <summary>
+    /// Told the id of a table whose storage was published from inside ANOTHER table's hydration
+    /// and therefore could not be loaded there (#2877). Installed by TestDataProvisioner.Arm()
+    /// alongside the loader, and null for every run without --test-data.
+    ///
+    /// The point is reporting, not mechanism: without it the provisioner has no record for that
+    /// table at all, so TableOutcome answers null — which under the on-demand policy means
+    /// "nothing in this run ever touched it", the opposite of what happened. Same argument as
+    /// #2240.
+    /// </summary>
+    internal static Action<int>? TestDataDeferredLoadNotifier;
+
+    /// <summary>
+    /// Told (table id, reason) when a deferred load could not be run after all, because the
+    /// store had rows by then or could not be read. Arriving here means the table ends the run
+    /// WITHOUT its backup rows, so it is reported rather than skipped — a silent skip is what
+    /// produced #2877. See .claude/rules/loud-failures.md.
+    /// </summary>
+    internal static Action<int, string>? TestDataDeferredLoadWriteOffNotifier;
+
     /// <summary>Re-entrancy depth for the loader — NOT a "which tables are loaded" cache,
     /// which #2262 rules out on purpose.
     ///
     /// Hydrating a table runs BC's own metadata and NavValue construction, and that code can
     /// reach a Record of ANOTHER table, which lands back in GetDataAccessForTableCore and
-    /// would recurse. Skipping the nested load is safe rather than lossy: the nested table is
-    /// left with empty storage, which is the same state it would have had a moment earlier,
-    /// so the next independent touch of it loads it normally.</summary>
+    /// would recurse.
+    ///
+    /// Skipping the nested load is only safe because the omission is RECORDED. The nested call
+    /// has already published the nested table's storage by the time the load is refused, and
+    /// "storage presence IS the have-we-loaded-this answer" then made the omission permanent:
+    /// every later touch found the entry and never loaded it, so the table silently kept none
+    /// of its backup rows for the whole run (#2877). GetOrCreateHydratedDataAccessCore's nested
+    /// branch marks that instance as owing a load, and the next touch outside a materialisation
+    /// settles it — see RecordPatches.TableMaterialisation.cs.</summary>
     [ThreadStatic] private static int _testDataLoadDepth;
 
     private static void InvokeTestDataOnDemandLoader(object source, int tableId)
@@ -1976,12 +2002,14 @@ public static partial class RecordPatches
             // is what guarantees it — see RecordPatches.TableMaterialisation.cs — so the populate
             // below always runs on a store that is either hydrated or never will be.
             // See RecordPatches.ObjectMetadataSystemTable.cs.
+            //
+            // A store published by a NESTED materialisation is the one case where the populate
+            // must NOT run yet: it owes a --test-data load that could not run there, and
+            // synthesising into it now would make that load a mix of real and synthesised rows.
+            // MaterialiseObjectMetadataStore holds the populate off until the debt is settled
+            // (#2877) — with no loader installed nothing is ever owed and this is unchanged.
             if (IsObjectMetadataSystemTable(table))
-            {
-                var objectMetadataDa = GetOrCreateHydratedDataAccess(self, perTable, table, tableId);
-                PopulateObjectMetadataSystemTable(objectMetadataDa, table);
-                return objectMetadataDa;
-            }
+                return MaterialiseObjectMetadataStore(self, perTable, table, tableId);
 
             // ── Page Control Field (2000000192) ──────────────────────────────────────────
             // Virtual on the service tier too: one row per field control declared on a

--- a/AlRunner/TestDataProvisioner.cs
+++ b/AlRunner/TestDataProvisioner.cs
@@ -171,6 +171,13 @@ internal static class TestDataProvisioner
     // Running tallies, accumulated across on-demand loads rather than known at Arm() time.
     private static int _tablesDone, _rowsDone, _refused, _readerRefused, _droppedColumns, _columnsNotInThisBuild;
 
+    /// <summary>Tables the backup offers that ended the run without their rows because the
+    /// deferred load (#2877) could not be run safely. Read by the proving test, so "written off"
+    /// is an assertable count rather than something inferred from log text.</summary>
+    private static int _deferredLoadsWrittenOff;
+
+    internal static int DeferredLoadsWrittenOff => _deferredLoadsWrittenOff;
+
     /// <summary>The most recent hydration's outcome — the assertable signal a test uses
     /// instead of re-deriving what happened from log text. Under the on-demand policy it is
     /// cumulative: it reflects every table loaded so far, and it stays null until the first
@@ -205,6 +212,71 @@ internal static class TestDataProvisioner
     internal static string? TableOutcome(int tableId)
         => _tableOutcome.TryGetValue(tableId, out var reason) ? reason : null;
 
+    // ─────────────────────────────── deferred loads, and their outcomes (#2877) ──
+
+    /// <summary>
+    /// A table's storage was created from inside ANOTHER table's --test-data hydration, where a
+    /// load would recurse, so nothing has been loaded into it yet.
+    ///
+    /// Recorded rather than skipped for one reason: without it <see cref="TableOutcome"/>
+    /// answers null for that table, and null under the on-demand policy means "nothing in this
+    /// run ever touched it" — the exact opposite of what happened, and indistinguishable from a
+    /// table nobody asked for. Replaced by the load's own outcome as soon as the debt is
+    /// settled, so it is only ever the answer while the debt actually stands.
+    /// </summary>
+    private static void NoteDeferredLoad(int tableId)
+    {
+        var armed = _armed;
+        if (armed == null) return;
+        // A table the plan does not offer owes nothing worth reporting as deferred: the honest
+        // answer is the one LoadOnDemand would give, and saying "not loaded yet" for a table
+        // this backup does not have would read as a problem where there is none. Every runner
+        // test table and every table the company has no rows for lands here.
+        if (!armed.ByTableId.ContainsKey(tableId))
+        {
+            _tableOutcome[tableId] = $"the plan built from '{Path.GetFileName(armed.Backup)}' "
+                + $"company '{armed.Company}' has no table with this id, so nothing was loaded";
+            return;
+        }
+        _tableOutcome[tableId] = "its storage was first created from inside another table's "
+            + "hydration, where loading it would have recursed, so nothing has been loaded into "
+            + $"it yet from '{Path.GetFileName(armed.Backup)}' company '{armed.Company}'; the "
+            + "next touch outside a hydration loads it";
+        PerfTrace.Log($"TestData.DeferredLoad {tableId}");
+    }
+
+    /// <summary>
+    /// The deferred load could not be run after all — the store had rows by the time one could,
+    /// or the runner could not read whether it did. The table ends the run WITHOUT its backup
+    /// rows, which is a fact about the run and is reported as one: recorded per table AND
+    /// printed, never dropped quietly (.claude/rules/loud-failures.md).
+    ///
+    /// Not a throw. The rows it would name are BC's own metadata construction reaching a Record
+    /// mid-hydration, and turning that into a hard failure would take out a --test-data run that
+    /// works today for the sake of one table — the same trade #2875 rejects for the same reason.
+    /// </summary>
+    private static void NoteDeferredLoadWrittenOff(int tableId, string reason)
+    {
+        var armed = _armed;
+        if (armed == null) return;
+        // Same reason as above: a table this backup does not offer loses nothing by not being
+        // loaded, so it must not be printed as though rows went missing.
+        if (!armed.ByTableId.ContainsKey(tableId))
+        {
+            _tableOutcome[tableId] = $"the plan built from '{Path.GetFileName(armed.Backup)}' "
+                + $"company '{armed.Company}' has no table with this id, so nothing was loaded";
+            return;
+        }
+        _deferredLoadsWrittenOff++;
+        _tableOutcome[tableId] = "its storage was first created from inside another table's "
+            + $"--test-data hydration and {reason}, so the rows "
+            + $"'{Path.GetFileName(armed.Backup)}' company '{armed.Company}' holds for it were "
+            + "never loaded";
+        Console.Error.WriteLine(
+            $"[test-data] NOT LOADED table {tableId}: {reason}. Its storage was first created "
+            + "from inside another table's hydration; see issue #2877.");
+    }
+
     /// <summary>True when a plan is armed — i.e. --test-data resolved a backup and a company
     /// and the on-demand loader is installed. Distinguishes "the flag is on and working" from
     /// "the flag is on but Arm() has not run for this app group yet".</summary>
@@ -219,8 +291,11 @@ internal static class TestDataProvisioner
         _lastSummary = null;
         _armed = null;
         _tablesDone = _rowsDone = _refused = _readerRefused = _droppedColumns = _columnsNotInThisBuild = 0;
+        _deferredLoadsWrittenOff = 0;
         _tableOutcome.Clear();
         RecordPatches.TestDataOnDemandLoader = null;
+        RecordPatches.TestDataDeferredLoadNotifier = null;
+        RecordPatches.TestDataDeferredLoadWriteOffNotifier = null;
     }
 
     /// <summary>
@@ -244,7 +319,7 @@ internal static class TestDataProvisioner
         if (_armed != null && _armed.SymbolKey == symbolKey && _armed.Backup == backup)
         {
             // The loader is a static field; re-install it in case something cleared it.
-            RecordPatches.TestDataOnDemandLoader = LoadOnDemand;
+            InstallLoader();
             return;
         }
 
@@ -278,7 +353,16 @@ internal static class TestDataProvisioner
                 byTableId[e.AlTableId.Value] = e;
 
         _armed = new ArmedPlan(backup, symbolKey, symbols, company, byTableId, plan.SkippedAmbiguous);
+        InstallLoader();
+    }
+
+    /// <summary>The three hooks the materialisation path calls back on, installed together so a
+    /// re-arm can never leave the loader in place with the reporting halves cleared.</summary>
+    private static void InstallLoader()
+    {
         RecordPatches.TestDataOnDemandLoader = LoadOnDemand;
+        RecordPatches.TestDataDeferredLoadNotifier = NoteDeferredLoad;
+        RecordPatches.TestDataDeferredLoadWriteOffNotifier = NoteDeferredLoadWrittenOff;
     }
 
     /// <summary>

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -640,6 +640,18 @@ member rather than synthesising over rows it cannot see (#2786). That refusal is
 every BC version the runner supports; it exists so a future one cannot silently disable the
 precedence rule.
 
+**Synthesis is also held off while a load is still owed.** Hydrating some other table runs BC's
+own metadata and NavValue construction, which can reach a `Record` of 2000000071 and materialise
+its storage from *inside* that hydration — where a load of its own would recurse and so is
+refused. The populator used to run against the empty store it had just been handed, claim the
+once-per-provider flag and synthesise; the backup's real rows then had nowhere to go. It now
+leaves such a store alone until the next touch outside a hydration loads it, so the precedence
+rule holds on that path too (#2877). The nested caller sees an **empty** Object Metadata store
+for that moment — deliberately, because the alternative is synthesising rows that would have to
+be withdrawn, and rows a caller has already read cannot be withdrawn. Nothing is lost when the
+backup does not offer the table: the load comes back with no rows, and the populate that follows
+synthesises exactly as it always did.
+
 ---
 
 ## Per-BC-minor engine variants: granularity is per MINOR, not per exact build
@@ -773,6 +785,15 @@ https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues.
   - A table whose AL name is declared by two installed apps in the same company is refused
     rather than guessed at —
     [#2264](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2264).
+  - A table whose storage is first created from **inside another table's hydration** cannot be
+    loaded there — a nested load would recurse — so the load is deferred to the next touch
+    outside a hydration and runs into that same storage
+    ([#2877](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2877)). It used to
+    be dropped instead, silently and for the rest of the run, because storage being present is
+    what the on-demand policy reads as "already loaded". If something wrote into that storage in
+    the meantime, the deferred load is **written off** rather than stacked on top of those rows,
+    and the table is named on stderr with the reason; `--test-data`'s per-table outcome
+    distinguishes "created during another table's hydration" from "never touched".
 
   Measured on BC 28.1's W1 CRONUS backup with the Base Application / System Application /
   Business Foundation closure: **39,231 rows across 344 tables** hydrated; 12 refused,


### PR DESCRIPTION
Closes #2877

## The defect

Hydrating table X under `--test-data` runs BC's own metadata and NavValue construction, and that
code can reach a `Record` of another table Y and land straight back in
`GetDataAccessForTableCore`. A nested load there would recurse, so `InvokeTestDataOnDemandLoader`
refuses it. The comment above `_testDataLoadDepth` claimed that was safe rather than lossy —
"the next independent touch of it loads it normally". It did not. Y's storage had already been
created and published into `perTable` by the time the loader refused, and the design's own rule
is that storage presence IS the have-we-loaded-this answer, so every later touch found the entry
and never loaded it. Y silently kept **none** of its backup rows for the rest of the run, and
`TestDataProvisioner` recorded nothing for it, so `TableOutcome(Y)` answered `null` — the value
that under the on-demand policy means "nothing in this run ever touched it". The store afterwards
looked exactly like a table nobody had asked for.

## The fix

The nested publication cannot be avoided; hydrating there would recurse. So it is **recorded**.
`_awaitingTestDataHydration` names the storage **instance** that was published without a load,
and the next touch that is not itself inside a materialisation pays the debt into that same
instance, inside the gate, before handing it out. Instance-naming rather than `(source, table)`
for the same reason #2788's settled latch uses it: a reset drops or replaces the entry, which
produces a different instance, so a stale debt can never be paid into the wrong store.

Two things the payment must not do, and how each is stopped:

* **Mix rows.** If anything wrote into the store between the nested publication and the payment
  — the nested caller inserting through the handle it was just given is the realistic route — a
  load landing on top would leave the store holding the backup's rows *and* somebody else's.
  That is the wrong-rows outcome #2788 exists to prevent, wearing a different hat. So the debt is
  paid only into a store that is provably empty, and written off otherwise. "Cannot tell" is
  written off as well: unknown is not empty, the same discipline
  `RecordPatches.StoredTableCensus` keeps. A write-off is never silent — it names the table and
  the reason on stderr and in the per-table outcome (`.claude/rules/loud-failures.md`).

* **Let a populate synthesise first.** Object Metadata (2000000071) is the one table with a
  populate after its materialisation, and `PopulateObjectMetadataSystemTable`'s contract is
  "synthesise only if nobody else put rows here". A nested first touch used to run that populate
  against the empty store it had just published, claim the once-per-provider flag and synthesise
  43 rows — which is then exactly the mixing case above, so the debt would be written off and
  the backup's real rows lost for the run. The populate is now held off while a load is owed.

## The two open questions the issue asked to answer

**"An answer for 2000000071 specifically: hydration and synthesis cannot both win."** Hydration
wins; synthesis is **held off**, not done and later withdrawn. The nested caller sees an *empty*
Object Metadata store for that moment. That is the deliberate choice, because the alternative is
synthesising rows that would have to be withdrawn, and rows a caller has already read cannot be
withdrawn. Nothing is lost when the backup does not offer the table: the debt is paid with zero
rows, the store is still empty at the next touch, and the populate then synthesises exactly as it
always did. Both arms are asserted
(`ObjectMetadata_NestedFirstTouch_SynthesisesNothing_AndTheBackupsRowsStillWin`,
`ObjectMetadata_WithNothingOwed_StillSynthesises_AndOnlyOnce`).

**"`TableOutcome` distinguishes 'nested, not loaded' from 'never touched'."** It does, and the
deferred note is replaced by the load's own outcome the moment the debt is settled, so it is only
ever the answer while the debt actually stands. A table the plan does not offer is *not* reported
as deferred or written off — it gets the ordinary "the plan has no table with this id" answer,
because nothing was lost and every runner test table takes that path.

## Not a throw

`.claude/rules/loud-failures.md` applies and is honoured as reporting, not as an exception. A
write-off names the table and the reason on stderr and in `TableOutcome`; it does not throw. The
rows it would be thrown over are BC's own metadata construction reaching a `Record`
mid-hydration, and turning that into a hard failure would take out a `--test-data` run that works
today for the sake of one table — the same trade #2875 examines and rejects for the same reason.

## RED → GREEN

RED was staged by adding the new API surface as pass-throughs that preserved the existing
behaviour exactly, so the failures are assertion failures and not compile errors:
`NestedTableMaterialisationHydrationTests` ran **6 failed / 3 passed**. The three that passed are
the no-overshoot arms — a table materialised normally is not loaded twice, a run with no loader
installed is unchanged, and the Object Metadata populate still runs when nothing is owed — so
they hold in both directions and a fix that simply always reloaded, or simply stopped
synthesising, fails them.

GREEN: **9 / 9**, plus the three provisioner-level tests added to `TestDataLazyHydrationTests`
(deferred outcome recorded and later replaced; a write-off counted and explained; a table the
backup does not have not reported as a missing load).

## What was run

| | |
|---|---|
| `NestedTableMaterialisationHydrationTests` | 9/9 |
| `TestDataLazy` + `TestDataBaselineAppend` + `TableMaterialisationOrdering` + `ObjectMetadataProviderRowProbe` + `TestDataProvisioning` + `MissingTestDataDiagnosis` (post-rebase) | 80/80 |
| The same set plus `TestDataUnmappedColumn` / `TestDataDateValue` / `TestDataLobValue` / `InstallBaseline*` / `InstallSeedDep*` / `StoredTableCensus` | 139/141, 2 skipped — see the flake note below |
| `tests/runner-extras/object-metadata-system-table`, cold then warm on a private `--cache` | 4/4 both times, before and after the rebase |
| `tests/runner-extras` (all 50 suites) | 264/264 |

Capture and restore are cache-sensitive, so the AL bundle was run twice against the same private
cache directory, cold and warm; same result both times.

**One flake observed, and it is not this change.**
`InstallBaselineDiskCacheTests.CorruptEntry_IsRejectedRecomputedAndRewrittenUsable` failed once in
the wide filtered run. A second run of the identical tree passed 139/141 with nothing failing, and
the test passes in isolation. Same code, different result, so it is load-dependent
(`.claude/rules/ci-verdicts.md` §5). That class is on `no-base-app-in-csharp-tests.md`'s
outstanding-violation list and spawns the runner as a subprocess; nothing in this change touches
what it exercises, since with no `--test-data` loader installed every path here returns at the
existing early exit.

## Fixing the shape, not just the reported line

1. **Does the same wrong pattern appear at another call site?** Yes, and it is in flight rather
   than on `main`. `GetDataAccessForTableCore` materialises storage in two shapes: through
   `GetOrCreateHydratedDataAccess` (the generic path and Object Metadata), which gets the #2788
   ordering and now the #2877 debt; or inline with the branch's own `TryGetValue` / `GetOrAdd` and
   its own `InvokeTestDataOnDemandLoader`, which gets neither. Open PR #2842 adds the `Object`
   (2000000001) branch in the second shape, on a table that is real SQL and that a backup
   genuinely has rows for — so it reintroduces both defects. It is not in this tree, so it is
   filed as **#2953** with the one-line fix (a sibling of `MaterialiseObjectMetadataStore`)
   rather than guessed at here.

2. **Does a sibling function make the same assumption?** The eighteen virtual-table branches
   materialise storage inline too, and they are safe for a different reason, not by accident: a
   `.bak` cannot carry rows for a table BC computes on the service tier, so nothing is ever loaded
   into them, there is no window and no debt. `HydrateTestDataTable` does its own
   `perTable.GetOrAdd` for the table it is loading, which always hits the entry the gate published
   before entering the loader. `Company` (2000000006) is ordinary storage and goes through the
   generic path, so it is covered.

3. **If two code paths write the same state, do they maintain the same invariant?** `perTable` is
   written by the materialisation, by each virtual-table branch and by
   `RestoreInstallBaselineSnapshot`. The invariant "an entry has had its `--test-data` load run"
   now holds for all three: gate-managed entries by construction, virtual tables vacuously, and a
   restore's entries because the restore repopulates from the snapshot it restores. The nested
   publication was the one case where presence and loadedness came apart, and it now says so
   instead of being indistinguishable.

## #2875 — read, and deliberately not folded in

They are not one root cause. #2875 is about `Object`'s `DeferToRealRows` latch being unable to
tell a backup's rows from its own projection replayed by an install-baseline restore — provider
identity across a restore. This one is a debt left by a nested materialisation. They are
independent, and #2875's code (`RecordPatches.ObjectSystemTable.cs`) is not on `main` at all yet;
it arrives with #2842. Forcing them together would have made both harder to review. What the two
*do* share is the call site, which is why #2953 exists.

## Cost when `--test-data` is off

Zero. With no loader installed `GetOrCreateHydratedDataAccessCore` returns at its existing early
exit before any of this, nothing is ever marked as owing a load, and the Object Metadata branch
is the pre-#2877 shape exactly. That is every corpus and runner-extras leg, and every default
user run.

---

*Opened by an automated agent (`impl-11`) on the account holder's behalf.*

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
