### PR TITLE
fix(watch,cli): one module per AL identity under --watch, and brace the TEST-TIMEOUT-ABORT guard

### DIFF
--- a/AlRunner.Tests/BracelessIfSecondStatementGuardTests.cs
+++ b/AlRunner.Tests/BracelessIfSecondStatementGuardTests.cs
@@ -1,0 +1,312 @@
+// BracelessIfSecondStatementGuardTests — issue #2843.
+//
+// The shape this guards against, as it stood in Program.cs at the TEST-TIMEOUT-ABORT append:
+//
+//     if (executor.AbortReasons.Count > 0)
+//         bundleErrors.AddRange(executor.AbortReasons.Select(r => $"{rel}: TEST-TIMEOUT-ABORT: {r}"));
+//         allAbortReasons.AddRange(executor.AbortReasons);
+//
+// The `if` has no braces, so it guards only the first statement. The second one — indented as
+// though it were guarded, and added by a later commit (#2698) that clearly meant it to be —
+// runs unconditionally.
+//
+// WHAT THAT SECOND STATEMENT ACTUALLY DID, MEASURED RATHER THAN ASSUMED
+// ---------------------------------------------------------------------
+// Nothing. This is the part worth writing down, because "brace-less if" reads like a live bug
+// and here it is not one:
+//
+//   * The guard is `AbortReasons.Count > 0`, so the ONLY state in which the second statement
+//     runs unguarded is `Count == 0`.
+//   * `TestExecutor.AbortReasons` is `Array.Empty<string>()` in that state — it is reset to
+//     exactly that at the top of every `Run()` call (TestExecutor.cs, the `#2415: this instance
+//     is reused across Run() calls` line) and only ever grows via `RecordAbortedSuite`.
+//   * `List<string>.AddRange` special-cases an `ICollection<T>` argument on its count, so
+//     `allAbortReasons.AddRange(Array.Empty<string>())` is a no-op — it does not even grow the
+//     list's capacity.
+//
+// So the unguarded call is provably equivalent to not making it, and there is no runtime
+// observation that can tell the two apart. A test asserting "allAbortReasons stayed empty"
+// would pass identically before and after the fix, which is the noise `.claude/rules/tdd.md`
+// forbids. The honest proving test for a fix whose only effect is structural is a structural
+// one — this file.
+//
+// WHY IT IS STILL WORTH FIXING AND GUARDING
+// -----------------------------------------
+// The indentation promises something the code does not do. The next person to add a third
+// statement under that `if` gets it wrong in a way that reads as correct — `goto fail`, and
+// there the third statement was not a no-op. Braces remove the trap; this test keeps them.
+//
+// THE DETECTOR HAS TO BE HELD HONEST TOO
+// --------------------------------------
+// A scanner that quietly stops matching passes forever and guards nothing — the silent-default
+// shape from `.claude/rules/loud-failures.md` wearing test clothing. So the detector is tested
+// in BOTH directions: `Detector_FiresOnTheShape_AndOnlyOnIt` feeds it the exact #2843 snippet
+// plus every near-miss that must NOT trip it, and only then does
+// `AlRunnerSources_HaveNoBracelessIfWhoseNextStatementIsIndentedAsIfGuarded` claim the tree is
+// clean.
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class BracelessIfSecondStatementGuardTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    /// <summary>One flagged occurrence: the `if`/loop header and the statement that only LOOKS guarded.</summary>
+    internal readonly record struct Occurrence(string File, int HeaderLine, string Header, int OrphanLine, string Orphan);
+
+    /// <summary>
+    /// Drop `//` line comments, leaving string and char literals intact, so a trailing comment
+    /// cannot change whether a line "ends with a semicolon". Block comments are deliberately not
+    /// handled: they do not occur in this position anywhere in the tree, and a half-implemented
+    /// block-comment stripper would be a worse lie than none. A `/* */` in this position would
+    /// simply fail to match and under-report, never over-report.
+    /// </summary>
+    internal static string StripLineComment(string line)
+    {
+        var sb = new StringBuilder(line.Length);
+        bool inString = false, inChar = false, inVerbatim = false, escaped = false;
+        for (int i = 0; i < line.Length; i++)
+        {
+            char c = line[i];
+            if (inVerbatim)
+            {
+                // In @"..." a doubled quote is an escaped quote; a single one ends the literal.
+                if (c == '"')
+                {
+                    if (i + 1 < line.Length && line[i + 1] == '"') { sb.Append(c).Append(line[++i]); continue; }
+                    inVerbatim = false;
+                }
+                sb.Append(c);
+                continue;
+            }
+            if (inString)
+            {
+                if (escaped) escaped = false;
+                else if (c == '\\') escaped = true;
+                else if (c == '"') inString = false;
+                sb.Append(c);
+                continue;
+            }
+            if (inChar)
+            {
+                if (escaped) escaped = false;
+                else if (c == '\\') escaped = true;
+                else if (c == '\'') inChar = false;
+                sb.Append(c);
+                continue;
+            }
+            if (c == '/' && i + 1 < line.Length && line[i + 1] == '/') break;
+            if (c == '@' && i + 1 < line.Length && line[i + 1] == '"') { inVerbatim = true; sb.Append(c).Append(line[++i]); continue; }
+            if (c == '$' && i + 2 < line.Length && line[i + 1] == '@' && line[i + 2] == '"')
+            { inVerbatim = true; sb.Append(c).Append(line[++i]).Append(line[++i]); continue; }
+            if (c == '"') inString = true;
+            else if (c == '\'') inChar = true;
+            sb.Append(c);
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    private static bool ParensBalanced(string s)
+    {
+        int depth = 0;
+        foreach (var c in s) { if (c == '(') depth++; else if (c == ')') depth--; }
+        return depth == 0;
+    }
+
+    private static int Indent(string s)
+    {
+        int n = 0;
+        while (n < s.Length && s[n] == ' ') n++;
+        return n;
+    }
+
+    private static readonly System.Text.RegularExpressions.Regex HeaderPattern = new(
+        @"^(?<ind>[ ]*)(\}[ ]*)?(else[ ]+)?(if|for|foreach|while)[ ]*\(.*\)$",
+        System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    /// <summary>
+    /// Report every place where a brace-less `if`/loop header is followed by a single-line
+    /// statement and then a SECOND statement at the same indentation — the statement that looks
+    /// guarded and is not.
+    ///
+    /// Deliberately conservative in every ambiguous case, so a hit is always real:
+    /// the header's condition must close on its own line (balanced parens), the guarded
+    /// statement must be one complete line ending in `;`, and the following line must be a
+    /// statement at exactly that indentation (not `}`, `{`, `else`, `catch`, `finally`). Under
+    /// -reporting a contrived shape is acceptable; a false positive that blocks an unrelated PR
+    /// is not.
+    /// </summary>
+    internal static IReadOnlyList<Occurrence> Scan(string file, string text)
+    {
+        var raw = text.Replace("\r\n", "\n").Split('\n');
+        var code = new string[raw.Length];
+        for (int i = 0; i < raw.Length; i++) code[i] = StripLineComment(raw[i]);
+
+        var found = new List<Occurrence>();
+        for (int i = 0; i < code.Length; i++)
+        {
+            var m = HeaderPattern.Match(code[i]);
+            if (!m.Success || !ParensBalanced(code[i])) continue;
+            int headerIndent = m.Groups["ind"].Value.Length;
+
+            int j = i + 1;
+            while (j < code.Length && code[j].Trim().Length == 0) j++;
+            if (j >= code.Length) continue;
+            var body = code[j];
+            if (body.TrimStart().StartsWith("{", StringComparison.Ordinal)) continue; // braced — fine
+            int bodyIndent = Indent(body);
+            if (bodyIndent <= headerIndent) continue;
+            if (!body.EndsWith(";", StringComparison.Ordinal)) continue;               // multi-line statement — skip
+
+            int k = j + 1;
+            while (k < code.Length && code[k].Trim().Length == 0) k++;
+            if (k >= code.Length) continue;
+            if (Indent(code[k]) != bodyIndent) continue;
+            var next = code[k].Trim();
+            if (next.Length == 0) continue;
+            if (next.StartsWith("}", StringComparison.Ordinal) || next.StartsWith("{", StringComparison.Ordinal)
+                || next.StartsWith("else", StringComparison.Ordinal) || next.StartsWith("catch", StringComparison.Ordinal)
+                || next.StartsWith("finally", StringComparison.Ordinal))
+                continue;
+
+            found.Add(new Occurrence(file, i + 1, raw[i].Trim(), k + 1, raw[k].Trim()));
+        }
+        return found;
+    }
+
+    /// <summary>
+    /// The detector's own RED→GREEN. The positive sample is the #2843 code verbatim; every
+    /// negative is a shape that must NOT be reported, including the two legitimate ways to write
+    /// the same intent (braces, or the second statement dedented to where it belongs).
+    /// </summary>
+    [Fact]
+    public void Detector_FiresOnTheShape_AndOnlyOnIt()
+    {
+        const string theDefect = """
+            void M()
+            {
+                if (executor.AbortReasons.Count > 0)
+                    bundleErrors.AddRange(executor.AbortReasons.Select(r => $"x: {r}"));
+                    allAbortReasons.AddRange(executor.AbortReasons);
+            }
+            """;
+        var hit = Assert.Single(Scan("sample.cs", theDefect));
+        Assert.Equal(3, hit.HeaderLine);
+        Assert.Equal(5, hit.OrphanLine);
+        Assert.Contains("allAbortReasons.AddRange", hit.Orphan, StringComparison.Ordinal);
+
+        // Fix A — braces. This is what the production fix does.
+        Assert.Empty(Scan("a.cs", """
+            void M()
+            {
+                if (executor.AbortReasons.Count > 0)
+                {
+                    bundleErrors.AddRange(x);
+                    allAbortReasons.AddRange(y);
+                }
+            }
+            """));
+
+        // Fix B — the second statement dedented to the level it actually executes at.
+        Assert.Empty(Scan("b.cs", """
+            void M()
+            {
+                if (executor.AbortReasons.Count > 0)
+                    bundleErrors.AddRange(x);
+                allAbortReasons.AddRange(y);
+            }
+            """));
+
+        // A brace-less if with exactly one statement is idiomatic here and must stay allowed.
+        Assert.Empty(Scan("c.cs", """
+            void M()
+            {
+                if (a > 0)
+                    Use(a);
+                Other();
+            }
+            """));
+
+        // A multi-line condition: the header does not close on its own line, so the "body" line
+        // is really the rest of the condition. Skipped rather than guessed at.
+        Assert.Empty(Scan("d.cs", """
+            void M()
+            {
+                if (a > 0
+                    && b > 0)
+                    Use(a);
+            }
+            """));
+
+        // if/else — `else` after the guarded statement is not an unguarded sibling.
+        Assert.Empty(Scan("e.cs", """
+            void M()
+            {
+                if (a > 0)
+                    Use(a);
+                else
+                    Use(b);
+            }
+            """));
+
+        // A trailing comment must not stop the body line from counting as a complete statement,
+        // and a comment line between the two statements must not hide the defect either.
+        var withComments = Scan("f.cs", """
+            void M()
+            {
+                if (a > 0)
+                    First(a);  // trailing comment
+                    Second(a);
+            }
+            """);
+        Assert.Single(withComments);
+
+        // A `//`-commented-out second statement is not code and must not be reported.
+        Assert.Empty(Scan("g.cs", """
+            void M()
+            {
+                if (a > 0)
+                    First(a);
+                    // Second(a);
+            }
+            """));
+    }
+
+    /// <summary>
+    /// #2843's actual claim: no `AlRunner/` source contains a brace-less `if`/loop whose next
+    /// statement is indented as though it were guarded.
+    ///
+    /// <para>RED on `main` before this fix: two occurrences, `Program.cs:3376` (bundled-mode run
+    /// loop) and `Program.cs:3504` (the `--isolation`-split per-suite loop). The issue reported
+    /// only the second and asked whether the first shared the pattern — it did.</para>
+    /// </summary>
+    [Fact]
+    public void AlRunnerSources_HaveNoBracelessIfWhoseNextStatementIsIndentedAsIfGuarded()
+    {
+        var runnerDir = Path.Combine(RepoRoot, "AlRunner");
+        Assert.True(Directory.Exists(runnerDir), $"AlRunner source directory not found at {runnerDir}");
+
+        var files = Directory.EnumerateFiles(runnerDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                     && !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToList();
+
+        // If the walk finds nothing, the guard is vacuous — say so instead of passing.
+        Assert.True(files.Count > 50, $"expected the AlRunner tree to hold many .cs files, found {files.Count}");
+
+        var hits = new List<Occurrence>();
+        foreach (var f in files)
+            hits.AddRange(Scan(Path.GetRelativePath(RepoRoot, f), File.ReadAllText(f)));
+
+        Assert.True(hits.Count == 0,
+            "brace-less `if`/loop whose NEXT statement is indented as though it were guarded (#2843) — "
+            + "the indentation promises a guard the code does not apply, and the next statement added "
+            + "under it will be wrong in a way that reads as correct. Add braces:\n"
+            + string.Join("\n", hits.Select(h =>
+                $"  {h.File}:{h.HeaderLine}  {h.Header}\n      unguarded -> {h.File}:{h.OrphanLine}  {h.Orphan}")));
+    }
+}

--- a/AlRunner.Tests/WatchCrossBundleModuleIdentityTests.cs
+++ b/AlRunner.Tests/WatchCrossBundleModuleIdentityTests.cs
@@ -1,0 +1,386 @@
+// WatchCrossBundleModuleIdentityTests — issue #2594.
+//
+// `al-runner <app> <app>.Test --watch` is the README's usual shape, and until this test it ran
+// a path no test covered: the cross-bundle module-identity dedup (#1683) was gated OFF under
+// `--watch`, at both ends.
+//
+//   * the READ side, `DependencyLoader.TryGetByAppId(...)` — "was this AppId already loaded?"
+//   * the WRITE side, `DependencyLoader.RegisterLoaded(...)` — "this module IS that AppId"
+//
+// With the write side skipped, bundle 1 compiled the dep app and told nobody, so bundle 2
+// resolved the SAME AL app through DependencyLoader's Tier-3 source compile into a SECOND live
+// module for one AL identity. That is exactly #1683: the event-subscription registry pairs a
+// subscriber MethodInfo discovered from one module's Type with a subscriberInstance BC's own
+// dispatcher materialized from the OTHER module's Type, and `RuntimeMethodInfo.Invoke` throws
+// `TargetException: Object does not match target type` at
+// `NavEventScope.CallEventSubscriberInternalAsync` → `ValidateInvokeTarget`.
+//
+// MEASURED, NOT INFERRED — the RED this test was written against
+// --------------------------------------------------------------
+// This exact fixture, driven under `--watch` against the pre-fix build:
+//
+//   [install-trigger] Codeunit60032.OnInstallAppPerCompany (Dep_Repro2594_…) threw:
+//       TargetException: Object does not match target type.
+//     at System.Reflection.RuntimeMethodInfo.Invoke(…)
+//     at Microsoft.Dynamics.Nav.EventSubscription.NavEventScope.CallEventSubscriberInternalAsync(…)
+//     …
+//   === test-app — EXEC FAIL ===
+//     WM Main Tests 2594: EXEC-FAIL: Object does not match target type.
+//
+//   Tests: 0 total / pass: 0 — the test bundle's tests never ran at all.
+//
+// The issue itself recorded that the duplicate module had NOT been observed under `--watch`
+// ("Not verified: I have not run a two-bundle --watch session"), and warned it might surface as
+// an EMIT-ZERO instead. On this fixture it surfaces as the dispatch failure above.
+//
+// WHY THE GATE'S OWN RATIONALE NO LONGER HELD
+// -------------------------------------------
+// The comment disabling it said reuse under `--watch` would replay iteration 1's stale pre-edit
+// assembly forever, because `RegisterLoaded` was first-wins. Both halves changed in the #1892
+// follow-up and the comment did not:
+//
+//   * `TryGetByAppId` returns null — deliberately not a reuse — when the cached entry's
+//     SourcePath equals the one being asked about. A watch cycle asking about its own SuiteDir
+//     therefore always recompiles.
+//   * `RegisterLoaded` OVERWRITES on a same-SourcePath re-registration, so a later cycle's
+//     freshly compiled module replaces the earlier one rather than losing to it.
+//
+// `--server`, which is the other warm edit-and-rerun loop and the one those two rules were
+// written for, calls both without any gate at all.
+//
+// BOTH DIRECTIONS, BECAUSE ONE ALONE WOULD BE HALF THE CLAIM
+// ----------------------------------------------------------
+// Cycle 1 proves the dedup: one module per AL identity across two bundles. Cycle 2 edits the
+// DEPENDENCY and proves the reuse is not stale. Without the second half this test would pass
+// against a "reuse whatever compiled first, forever" implementation — which is precisely the
+// hazard the removed gate claimed to prevent, so leaving it unasserted would be arguing the
+// gate was pointless rather than showing it.
+//
+// The consumer's files are never touched, following WatchCrossAppOverloadRebindTests: a cycle
+// is triggered by ONE file write, so there is no window in which the watcher can split an edit
+// across two cycles and land the assertion on a half-applied one. The cost is that
+// `DepStampIsCurrent` is EXPECTED TO FAIL in cycle 1 — asserted, because it is the measurement
+// that the fixture really does start on stamp 1, without which cycle 2 could pass by the answer
+// having been 2 all along.
+using System.Diagnostics;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class WatchCrossBundleModuleIdentityTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private const string DepAppId = "c3d4e5f6-2594-4a1b-9c3d-000000000001";
+    private const string TestAppId = "d4e5f6a7-2594-4a1b-9c3d-000000000002";
+
+    // Allocated from each fixture app.json's OWN idRanges. 60030-60049 is unused elsewhere in
+    // AlRunner.Tests.
+    private const int SetupTableId = 60030;
+    private const int SubscriberId = 60031;
+    private const int InstallId = 60032;
+    private const int StampId = 60033;
+    private const int TestsId = 60040;
+
+    /// <summary>
+    /// The dependency app. Its shape is load-bearing: a table, a subscriber ON that table, and
+    /// an install codeunit whose <c>Modify(true)</c> fires that subscriber. That is what turns
+    /// "two modules for one identity" from an invisible inefficiency into an observable failure
+    /// — the dispatcher has to pair a MethodInfo with an instance, and with two modules live
+    /// they come from different Types.
+    ///
+    /// <para><paramref name="stamp"/> is what the consumer reads back, so a module served from
+    /// an earlier cycle cannot pass.</para>
+    /// </summary>
+    private static void WriteDepSource(string dir, int stamp) =>
+        File.WriteAllText(Path.Combine(dir, "Dep.al"), $$"""
+        table {{SetupTableId}} "WM Setup 2594"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "Primary Key"; Code[10]) { }
+                field(2; "Value"; Integer) { }
+            }
+            keys { key(PK; "Primary Key") { Clustered = true; } }
+        }
+
+        codeunit {{SubscriberId}} "WM Subscriber 2594"
+        {
+            [EventSubscriber(ObjectType::Table, Database::"WM Setup 2594", 'OnAfterModifyEvent', '', false, false)]
+            local procedure OnAfterModifyWmSetup(var Rec: Record "WM Setup 2594")
+            begin
+            end;
+        }
+
+        codeunit {{InstallId}} "WM Install 2594"
+        {
+            Subtype = Install;
+            trigger OnInstallAppPerCompany()
+            var
+                Setup: Record "WM Setup 2594";
+            begin
+                if not Setup.Get('X') then begin
+                    Setup."Primary Key" := 'X';
+                    Setup.Insert();
+                end;
+                Setup.Value += 1;
+                Setup.Modify(true); // fires OnAfterModifyEvent -> "WM Subscriber 2594"
+            end;
+        }
+
+        codeunit {{StampId}} "WM Stamp 2594"
+        {
+            procedure Stamp(): Integer
+            begin
+                exit({{stamp}});
+            end;
+        }
+        """);
+
+    private static string MakeDepBundle(string root, int stamp)
+    {
+        var dir = Path.Combine(root, "dep-app");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{DepAppId}}",
+          "name": "WM Dep App 2594",
+          "publisher": "Repro2594",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": {{SetupTableId}}, "to": {{SetupTableId + 9}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        WriteDepSource(dir, stamp);
+        return dir;
+    }
+
+    /// <summary>
+    /// The consumer. Two tests, and both have to be here:
+    ///
+    /// <para><c>DepInstallTriggerRan</c> can only pass if the dependency's install trigger
+    /// completed, which it cannot while the subscriber dispatch throws — this is the #1683
+    /// half, and it must be green in BOTH cycles.</para>
+    ///
+    /// <para><c>DepStampIsCurrent</c> pins the dependency's answer to the value only its
+    /// CURRENT compile returns, and reports the value it actually got. Written once, expecting
+    /// the post-edit stamp, so the consumer is never rewritten mid-session: it fails in cycle 1
+    /// by design and must pass in cycle 2.</para>
+    /// </summary>
+    private static string MakeTestAppBundle(string root, int expectedStamp)
+    {
+        var dir = Path.Combine(root, "test-app");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{TestAppId}}",
+          "name": "WM Main Tests 2594",
+          "publisher": "Repro2594",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{DepAppId}}", "name": "WM Dep App 2594",
+              "publisher": "Repro2594", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": {{TestsId}}, "to": {{TestsId + 9}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Tests.al"), $$"""
+        codeunit {{TestsId}} "WM Main Tests 2594"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure DepInstallTriggerRan()
+            var
+                Setup: Record "WM Setup 2594";
+            begin
+                if not Setup.Get('X') then
+                    Error('WM-SETUP-MISSING: the dependency install trigger did not run');
+                if Setup.Value < 1 then
+                    Error('WM-SETUP-VALUE=%1: Modify(true) did not commit', Setup.Value);
+            end;
+
+            [Test]
+            procedure DepStampIsCurrent()
+            var
+                Stamp: Codeunit "WM Stamp 2594";
+            begin
+                if Stamp.Stamp() <> {{expectedStamp}} then
+                    Error('WM-STAMP=%1', Stamp.Stamp());
+            end;
+        }
+        """);
+        return dir;
+    }
+
+    /// <summary>
+    /// Two bundles under <c>--watch</c>, one declaring the other as a dependency, must resolve
+    /// that dependency to the module the dependency's own bundle already compiled — on cycle 1,
+    /// and to the CURRENT one after the dependency is edited.
+    /// </summary>
+    ///
+    /// <param name="dependencyFirst">
+    /// Which order the two bundles are listed in on the command line. Both are covered because
+    /// the freshness half rests on the dependency's own bundle executing FIRST, and that is not
+    /// a property of the argument order — <c>--watch</c> reorders bundles dependency-first
+    /// (#2614/#2814, Program.cs's `if (watchMode &amp;&amp; bundles.Count > 1)` sort).
+    ///
+    /// <para>It is load-bearing rather than incidental. `DependencyLoader` has TWO writers of
+    /// the cache this fix reads, and they disagree on the SourcePath they record for one AL
+    /// identity: `RegisterLoaded` from the bundle loop records the bundle's own SuiteDir, while
+    /// `LoadOne`'s Tier-3 path records the resolved `.app` package path. Only the SuiteDir
+    /// spelling makes `TryGetByAppId`/`RegisterLoaded`'s same-SourcePath rules fire, so if the
+    /// consumer ever ran first and registered the identity under the package path, every later
+    /// cycle would keep serving that first module and the edit would go unnoticed. Reversing
+    /// the argument order is how that gets exercised; if the sort is ever dropped, this case
+    /// goes red instead of the staleness shipping silently.</para>
+    /// </param>
+    [SkippableTheory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task WatchCycles_ResolveOneModulePerAlIdentity_AndAlwaysTheCurrentOne(bool dependencyFirst)
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = TestScratch.Dir("al-runner-watch-module-identity");
+        Directory.CreateDirectory(root);
+        var depDir = MakeDepBundle(root, stamp: 1);
+        var testAppDir = MakeTestAppBundle(root, expectedStamp: 2);
+
+        // Outside the repository — a --cache pointed inside a worktree has faked a whole-bundle
+        // install failure before.
+        var cacheDir = Path.Combine(root, "cache");
+        Directory.CreateDirectory(cacheDir);
+
+        var lines = new List<CapturedLine>();
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg
+                + (dependencyFirst
+                    ? $" \"{depDir}\" \"{testAppDir}\""
+                    : $" \"{testAppDir}\" \"{depDir}\"")
+                + $" --watch --cache \"{cacheDir}\"",
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        using var p = Process.Start(psi)!;
+        void Pump(StreamReader r, OutputStream stream) => _ = Task.Run(async () =>
+        {
+            string? l;
+            while ((l = await r.ReadLineAsync()) != null)
+                lock (lines) lines.Add(new CapturedLine(stream, l));
+        });
+        Pump(p.StandardOutput, OutputStream.Stdout);
+        Pump(p.StandardError, OutputStream.Stderr);
+
+        string DumpTail() { lock (lines) return string.Join("\n", lines.TakeLast(80).Select(l => $"[{l.Stream}] {l.Text}")); }
+
+        async Task<int> WaitForMarkerAfter(int fromIndex, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                List<int> found;
+                lock (lines)
+                    found = WatchOutputSlicing.FindStdoutMarkerIndices(
+                        lines, WatchOutputSlicing.WaitingForSourceMarker, fromIndex);
+                if (found.Count > 0) return found[0];
+                if (p.HasExited)
+                {
+                    await Task.Delay(500);
+                    throw new TimeoutException(
+                        $"watch marker not seen — subprocess exited early (exit={p.ExitCode}).\n"
+                        + $"--- last output ---\n{DumpTail()}");
+                }
+                await Task.Delay(200);
+            }
+            if (p.HasExited) await Task.Delay(500);
+            throw new TimeoutException($"watch marker not seen.\n--- last output ---\n{DumpTail()}");
+        }
+
+        string Segment(int from, int to) { lock (lines) return WatchOutputSlicing.MergedJoin(lines, from, to); }
+
+        // The #1683 half, asserted the same way in both cycles. Named by the defect rather than
+        // only by the outcome, so a cycle that reddens for an unrelated reason cannot be read as
+        // this claim holding, and this claim failing cannot be read as something else.
+        void AssertOneModulePerIdentity(string cycle, string label)
+        {
+            Assert.False(cycle.Contains("TargetException", StringComparison.Ordinal),
+                $"{label}: the dependency resolved to a SECOND module for an AL identity bundle 1 "
+                + "had already loaded, so the subscriber MethodInfo and the instance BC's "
+                + "dispatcher materialized came from different Types (#1683/#2594).\n" + cycle);
+            Assert.False(cycle.Contains("Object does not match target type", StringComparison.Ordinal),
+                $"{label}: the same defect, by its message.\n" + cycle);
+
+            // The install trigger is where the mismatch fires, and it is reported on its own line
+            // before any test result — asserted separately so a failed install cannot hide behind
+            // a later EXEC-FAIL, and so the EMIT-ZERO shape #2594 warned about is not silently
+            // accepted either.
+            Assert.False(cycle.Contains("[install-trigger]", StringComparison.Ordinal)
+                         && cycle.Contains("threw:", StringComparison.Ordinal),
+                $"{label}: the dependency's install trigger threw.\n" + cycle);
+            Assert.False(cycle.Contains("EXEC-FAIL", StringComparison.Ordinal),
+                $"{label}: the test bundle compiled and loaded and then failed to run, so none of "
+                + "its tests were counted.\n" + cycle);
+            Assert.False(cycle.Contains("EMIT-ZERO", StringComparison.Ordinal),
+                $"{label}: the dependency produced no objects — the other shape #2594 predicted "
+                + "for a bundle that has to Tier-3 compile a dependency already loaded.\n" + cycle);
+
+            // Not "no crash": this named test must actually have run and passed. A cycle that
+            // discovered zero tests cannot satisfy it.
+            Assert.True(cycle.Contains($"PASS  Codeunit{TestsId}.DepInstallTriggerRan", StringComparison.Ordinal),
+                $"{label}: DepInstallTriggerRan did not pass — the dependency's install trigger "
+                + "never completed, or the test never ran.\n" + cycle);
+        }
+
+        try
+        {
+            // ── Cycle 1. Bundle 1 compiles the dep app; bundle 2 must resolve THAT module rather
+            // than compiling its own copy. Pre-fix, this cycle already fails: the install trigger
+            // throws TargetException and the test bundle EXEC-FAILs with zero tests counted.
+            int m1 = await WaitForMarkerAfter(0, TimeSpan.FromSeconds(300));
+            var cycle1 = Segment(0, m1);
+            AssertOneModulePerIdentity(cycle1, $"cycle 1 (dependencyFirst: {dependencyFirst})");
+
+            // The fixture genuinely starts on stamp 1. Without this, cycle 2 could pass by the
+            // dependency having answered 2 all along, and the freshness claim would be empty.
+            Assert.True(cycle1.Contains("WM-STAMP=1", StringComparison.Ordinal),
+                "cycle 1 did not report the dependency's pre-edit stamp, so cycle 2 proves "
+                + "nothing about the module being re-resolved after the edit:\n" + cycle1);
+
+            // ── Cycle 2. Edit ONLY the dependency. The consumer's files are untouched, so reuse
+            // is correct here only if it is reuse of the module compiled THIS cycle — the exact
+            // hazard the removed --watch gate cited as its reason to exist.
+            WriteDepSource(depDir, stamp: 2);
+            int m2 = await WaitForMarkerAfter(m1 + 1, TimeSpan.FromSeconds(300));
+            var cycle2 = Segment(m1 + 1, m2);
+            AssertOneModulePerIdentity(cycle2, $"cycle 2, dependency edited (dependencyFirst: {dependencyFirst})");
+
+            // The freshness half. A stale module reports its own value, so the failure says which
+            // compile answered rather than only that something went wrong.
+            Assert.False(cycle2.Contains("WM-STAMP=1", StringComparison.Ordinal),
+                "cycle 2: a STALE module was served for the dependency — Stamp() answered with "
+                + "cycle 1's value after the dependency's source changed. This is the hazard the "
+                + "removed --watch gate named, and RegisterLoaded's same-SourcePath overwrite "
+                + "(#1892) is what is supposed to prevent it.\n" + cycle2);
+            Assert.True(cycle2.Contains($"PASS  Codeunit{TestsId}.DepStampIsCurrent", StringComparison.Ordinal),
+                "cycle 2: DepStampIsCurrent did not pass — the module resolved for the dependency "
+                + "did not return the value its current source compiles to.\n" + cycle2);
+            Assert.False(cycle2.Contains("FAIL", StringComparison.Ordinal),
+                "cycle 2: a warm --watch cycle must answer exactly as a cold run of these sources "
+                + "does.\n" + cycle2);
+        }
+        finally
+        {
+            try { if (!p.HasExited) p.Kill(entireProcessTree: true); } catch { }
+        }
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2616,14 +2616,21 @@ foreach (var bundle in bundles)
         // module's Type at CallEventSubscriberInternalAsync → ValidateInvokeTarget.
         // One AL app identity must resolve to exactly one loaded compilation.
         //
-        // Disabled under --watch: watch mode re-runs this SAME per-AppGroup loop on every
-        // edit cycle for the SAME bundle set, and its whole point is to pick up the edited
-        // source on each iteration. Reusing "the module already loaded for this AppId"
-        // there would mean iteration 2 replays iteration 1's stale pre-edit assembly
-        // forever — ResetForNewBundleReload() does not (and must not, for the unrelated
-        // deps-stay-warm reason documented there) clear DependencyLoader's cross-bundle
-        // cache, so this dedup stays scoped to genuinely distinct bundle args in one
-        // one-shot invocation, never a same-bundle reload.
+        // Applies under --watch too (#2594). It did not until now, and the comment that
+        // disabled it there described a hazard the loader has since stopped having: "watch
+        // mode re-runs this SAME per-AppGroup loop on every edit cycle, so reusing the
+        // module already loaded for this AppId would replay iteration 1's stale pre-edit
+        // assembly forever." DependencyLoader.TryGetByAppId now returns null — deliberately
+        // NOT a reuse — whenever the cached entry's SourcePath equals the one being asked
+        // about, which is exactly the same-bundle reload case (#1892 follow-up, see its doc
+        // comment). So a watch cycle asking about its own SuiteDir gets a fresh compile
+        // regardless, and the gate bought nothing while costing bundle 2 a SECOND module for
+        // an AL identity bundle 1 had already loaded — #1683's TargetException, reproduced
+        // under --watch on a dep-app + test-app pair before this line changed.
+        //
+        // --server's equivalent call site (the per-request bundle loop below) has never been
+        // gated on anything and is the warm edit-and-rerun loop the same-SourcePath rule was
+        // written for, which is the other half of why the rationale no longer held here.
         Assembly? reusedAsm;
         try
         {
@@ -2635,7 +2642,7 @@ foreach (var bundle in bundles)
             // asserts that invariant instead of silently masking a violation of it behind a
             // fallback that would disagree with AppLoader's own default (see IdentityMatches'
             // doc comment) — PR #1862 review.
-            reusedAsm = (!watchMode && appGroup.AppId is { } reuseCheckId)
+            reusedAsm = appGroup.AppId is { } reuseCheckId
                 ? DependencyLoader.TryGetByAppId(
                     reuseCheckId, appGroup.ModuleName, appGroup.Publisher!,
                     appGroup.Version!.ToString(), appGroup.SuiteDir)
@@ -3258,11 +3265,19 @@ foreach (var bundle in bundles)
                 // Register this freshly-loaded module by AppId so a LATER bundle that
                 // resolves the same app as a dependency (via DependencyLoader) reuses this
                 // exact Assembly instead of re-emitting/re-compiling a second module for the
-                // same AL identity — see the dedup comment above (issue #1683). Skipped under
-                // --watch: TryAdd is first-wins, so iteration 2's freshly-edited asm would
-                // never overwrite iteration 1's stale entry, and any sibling bundle that
-                // later resolves this AppId as a real dependency would get the stale copy.
-                if (!watchMode && appGroup.AppId is { } newlyLoadedId)
+                // same AL identity — see the dedup comment above (issue #1683).
+                //
+                // Registers under --watch too (#2594). The gate that used to skip it there
+                // said "TryAdd is first-wins, so iteration 2's freshly-edited asm would never
+                // overwrite iteration 1's stale entry, and any sibling bundle that later
+                // resolves this AppId as a real dependency would get the stale copy."
+                // RegisterLoaded stopped being first-wins in the #1892 follow-up: on a
+                // same-SourcePath re-registration it OVERWRITES, which is precisely a watch
+                // cycle re-registering its own bundle after a fresh compile. So iteration 2's
+                // module is the one a sibling bundle resolves, and skipping the registration
+                // only meant registering nothing at all — leaving the sibling to Tier-3
+                // compile a second module for the identity this one already loaded.
+                if (appGroup.AppId is { } newlyLoadedId)
                 {
                     try
                     {

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3372,8 +3372,10 @@ foreach (var bundle in bundles)
                 // "N suite errors" summary and the exit code (computedExitCode's
                 // CompileErrors check) both reflect the abandoned tests.
                 if (executor.AbortReasons.Count > 0)
+                {
                     bundleErrors.AddRange(executor.AbortReasons.Select(r => $"{rel}: TEST-TIMEOUT-ABORT: {r}"));
                     allAbortReasons.AddRange(executor.AbortReasons);
+                }
             }
             catch (Exception ex)
             {
@@ -3500,8 +3502,10 @@ foreach (var bundle in bundles)
                 // returns normally on a watchdog-timeout abort, so the catch below
                 // never sees it.
                 if (executor.AbortReasons.Count > 0)
+                {
                     bundleErrors.AddRange(executor.AbortReasons.Select(r => $"{suiteName}: TEST-TIMEOUT-ABORT: {r}"));
                     allAbortReasons.AddRange(executor.AbortReasons);
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Closes #2843
Closes #2594

Two small, independent correctness fixes. Written by an agent (impl-15).

---

## #2843 — the brace-less `if` at the TEST-TIMEOUT-ABORT append

### What the second statement does when it runs unconditionally

Nothing. I looked for a live consequence, and there is not one — stating that plainly because the issue title reads like there should be:

- The guard is `executor.AbortReasons.Count > 0`, so the only state in which the unguarded statement runs is `Count == 0`.
- In that state `AbortReasons` is `Array.Empty<string>()`. It is reset to exactly that at the top of every `TestExecutor.Run()` call (`TestExecutor.cs`, the `#2415: this instance is reused across Run() calls` line) and only ever grows through `RecordAbortedSuite`.
- `List<string>.AddRange` special-cases an `ICollection<T>` argument on its count, so `allAbortReasons.AddRange(Array.Empty<string>())` is a no-op. It does not even grow the list's capacity.

`executor` is a single instance created once at `Program.cs:1788` and reused across every app group and suite, which is the one thing that could have made this observable — and the per-`Run()` reset is what closes it.

So the unguarded call is provably equivalent to not making it, and no runtime observation can tell the two apart. The issue's own reading ("not a live defect") is right.

### The consequence that is real

The indentation promises a guard the code does not apply. The next statement added under that `if` is wrong in a way that reads as correct, and that one will not be a no-op. Braces remove the trap.

### Fix the shape

1. **Same pattern at another call site?** **Yes** — and the issue predicted the opposite. It reported the `--isolation`-split per-suite site (`Program.cs:3502`) and said the bundled-mode sibling was "worth reading at the same time to confirm it does not share the pattern". It shares it exactly, `Program.cs:3374`. Both are braced here. Had I fixed only the reported line, the guard test below would still have been red.
2. **Sibling function with the same assumption?** I scanned every `.cs` file under `AlRunner/` for the shape: a brace-less `if`/loop header whose condition closes on its own line, followed by a single-line statement, followed by a second statement at the same indentation. Those two sites are the only occurrences in the tree. Three other candidates a looser scan produced (`CompanyInitializer.cs`, `RecordPatches.InstallBaseline.cs`, `RecordPatches.BcAppFallback.cs`) are correct code that a weaker heuristic misread.
3. **Two writers of the same state?** `allAbortReasons` has exactly these two writers, and they are now identical in shape.

### The proving test

A fix whose only effect is structural cannot be proved by a runtime assertion — a test asserting "`allAbortReasons` stayed empty" passes identically before and after, which is the noise `tdd.md` forbids. So `AlRunner.Tests/BracelessIfSecondStatementGuardTests.cs` asserts the structure, in both directions:

- `Detector_FiresOnTheShape_AndOnlyOnIt` feeds the scanner the #2843 snippet verbatim and every near-miss that must not trip it: both correct spellings of the same intent (braces, or the second statement dedented), a brace-less `if` with one statement, a multi-line condition, `if`/`else`, a trailing comment, and a commented-out second statement. Without this the scanner could silently stop matching and pass forever.
- `AlRunnerSources_HaveNoBracelessIfWhoseNextStatementIsIndentedAsIfGuarded` runs it over `AlRunner/**/*.cs`.

**RED → GREEN, measured.** Against pre-fix `Program.cs`:

```
Failed AlRunner.Tests.BracelessIfSecondStatementGuardTests.AlRunnerSources_HaveNoBracelessIfWhoseNextStatementIsIndentedAsIfGuarded
  AlRunner/Program.cs:3374  if (executor.AbortReasons.Count > 0)
      unguarded -> AlRunner/Program.cs:3376  allAbortReasons.AddRange(executor.AbortReasons);
  AlRunner/Program.cs:3502  if (executor.AbortReasons.Count > 0)
      unguarded -> AlRunner/Program.cs:3504  allAbortReasons.AddRange(executor.AbortReasons);
Failed! - Failed: 1, Passed: 1
```

After: `Passed! - Failed: 0, Passed: 2`.

The scanner is deliberately conservative — a condition spanning lines, or a guarded statement spanning lines, is skipped rather than guessed at. It under-reports a contrived shape; it does not report a false one and block an unrelated PR.

---

## #2594 — `--watch` skipped the AppId module dedup

### The defect

The cross-bundle module-identity dedup (#1683) was gated off under `--watch` at both ends: the read (`DependencyLoader.TryGetByAppId`) and the write (`DependencyLoader.RegisterLoaded`). With the write skipped, bundle 1 compiled the dep app and registered nothing, so bundle 2 resolved the same AL app through `DependencyLoader`'s Tier-3 source compile into a **second live module for one AL identity**.

### Reproduced before changing the line

The issue recorded this half as unverified ("I have not run a two-bundle `--watch` session to observe the duplicate module") and warned it might surface as a hard EMIT-ZERO instead. On a dep-app + test-app pair (table, subscriber on that table, install trigger whose `Modify(true)` fires it), driven under `--watch` against the pre-fix build, it surfaces as the dispatch failure:

```
[install-trigger] Codeunit60032.OnInstallAppPerCompany (Dep_Repro2594_…) threw:
    TargetException: Object does not match target type.
  at System.Reflection.RuntimeMethodInfo.Invoke(…)
  at Microsoft.Dynamics.Nav.EventSubscription.NavEventScope.CallEventSubscriberInternalAsync(…)
  …
=== test-app — EXEC FAIL ===
  WM Main Tests 2594: EXEC-FAIL: Object does not match target type.

Tests: 0 total / pass: 0
```

The test bundle's tests never ran at all. The new test asserts against the EMIT-ZERO shape too, so the other predicted outcome cannot pass quietly.

### Why the gate's rationale no longer held

The comment disabling it said reuse under `--watch` would replay iteration 1's stale pre-edit assembly forever, because `RegisterLoaded` was first-wins. Both halves changed in the #1892 follow-up and the comment did not:

- `TryGetByAppId` returns null — deliberately not a reuse — when the cached entry's `SourcePath` equals the one being asked about. A watch cycle asking about its own `SuiteDir` therefore always recompiles.
- `RegisterLoaded` **overwrites** on a same-`SourcePath` re-registration, so a later cycle's freshly compiled module replaces the earlier one rather than losing to it.

`--server` — the other warm edit-and-rerun loop, and the one those two rules were written for — calls both with no gate at all. The fix is to drop `watchMode` from the two conditions, which makes the CLI/watch pair identical to the server pair.

I did not take the "incremental compile works under `--watch`, not `--server`" folklore as given: both modes call `ResetForNewBundleReload` per cycle, and the server call sites at `Program.cs` 4634/4876 have never carried a mode gate. That is what settled it, not the rule.

### Fix the shape

1. **Same pattern at another call site?** There are four `TryGetByAppId`/`RegisterLoaded` call sites. Two (the CLI/watch bundle loop) carried the gate and are fixed; two (the server per-request loop) never had it. After this change all four are ungated and identical.
2. **Sibling function with the same assumption?** I read the remaining `watchMode` gates in `Program.cs`. None of the others rests on the first-wins claim — they are about parallel fan-out, per-cycle resets, the incremental-emit baseline and output formatting.
3. **Two writers of the same state, same invariant?** `DependencyLoader._cache` has two writers and **they disagree on what they record as `SourcePath` for one AL identity**: `RegisterLoaded` (from the bundle loop) records the bundle's own `SuiteDir`, while `LoadOne`'s Tier-3 path records the resolved `.app` package path. Only the `SuiteDir` spelling makes the same-`SourcePath` freshness rules fire, so if the consumer bundle ever ran first and registered the identity under the package path, every later cycle would keep serving that first module and an edit would go unnoticed.

   That does not happen, because `--watch` reorders bundles dependency-first (#2614/#2814, the `if (watchMode && bundles.Count > 1)` sort). But my fix now depends on that sort, which it did not before — so the test covers **both command-line orders**, and the reversed one goes red if the sort is ever dropped instead of the staleness shipping silently. `LoadOne`'s write skips the `IdentityMatches` collision check `RegisterLoaded` performs; it is only reached on a cache miss inside a single-threaded loop, so there is no entry to collide with. Checked, holds, deliberately not changed.

### The proving test

`AlRunner.Tests/WatchCrossBundleModuleIdentityTests.cs`, both directions, both orders:

- **Cycle 1** — the dedup. `DepInstallTriggerRan` must pass, and `TargetException` / `Object does not match target type` / `[install-trigger] … threw:` / `EXEC-FAIL` / `EMIT-ZERO` must all be absent, each asserted by name so a cycle that reddens for an unrelated reason cannot be read as this claim holding.
- **Cycle 2** — freshness. Only the dependency is edited (`Stamp()` 1 → 2); the consumer's files are never touched, so a cycle is always triggered by one file write and there is no window for the watcher to split an edit across two cycles. The consumer expects the post-edit value from the start, which means `DepStampIsCurrent` **fails in cycle 1 by design** — asserted (`WM-STAMP=1` must be present in cycle 1), because that is the measurement that the fixture really starts on stamp 1. Without it, cycle 2 could pass by the answer having been 2 all along, and the freshness claim would be empty.

Without the second half this test would pass against a "reuse whatever compiled first, forever" implementation, which is exactly the hazard the removed gate named.

Object IDs 60030-60049, allocated from each fixture `app.json`'s own `idRanges`; unused elsewhere in `AlRunner.Tests`.

---

## What I ran, on this head

Rebased onto `origin/main` at `9368b0d3` (#2873, which changed `_bcAppPaths` reset behavior in the same reload path) and re-run after the rebase — no result below predates it.

| filter | result |
|---|---|
| `WatchCrossBundleModuleIdentityTests \| BracelessIfSecondStatementGuardTests` | **4 passed, 0 failed, 0 skipped** (named individually, so neither silently skipped) |
| `Watch \| CrossBundle \| DependencyLoader \| AppIdCollision \| Server \| BracelessIf \| SuiteAbortOnTimeout \| BcAppPathsReset \| RecordPatchesWarmReload` | **213 passed, 0 failed, 4 skipped** (5 m 45 s) |
| `SuiteAbortOnTimeout \| AbortResumePlan \| PartialSuiteLossReporting` | **38 passed, 0 failed, 0 skipped** — the existing watchdog coverage #2843 must not move |

RED measured for both fixes by restoring the pre-fix `Program.cs` and re-running, not assumed. Both RED outputs are quoted above.

**Not run on this head, stated rather than implied:** the AL corpus and `runner-extras`. Neither exercises `--watch`, and the `#2843` change is a no-op at runtime, so I do not expect either to move — CI runs both on all eight legs.

## Deliberately left out

- **No behavioral test for #2843**, because there is no behavior to assert. See the derivation above rather than treating the structural test as a shortcut.
- **`_bcQuerySymbolJsonPaths`** and the rest of #2873's follow-up (#2939) are untouched here.
- **No doc changes.** `--watch` and `--server` now behave the same way on this point, which is what `README.md` and `--help` already imply; nothing user-visible changed in either flag's contract.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
