### PR TITLE
test: own every scratch directory in AlRunner.Tests, and enforce it

### DIFF
--- a/AlRunner.Tests/AggregatePermissionSetVirtualTableTests.cs
+++ b/AlRunner.Tests/AggregatePermissionSetVirtualTableTests.cs
@@ -81,7 +81,7 @@ public sealed class AggregatePermissionSetVirtualTableTests
     [Fact]
     public void AggregatePermissionSet_SourceDeclaredPermissionSet_BothTestsPass()
     {
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-aps-tests", "cache-" + Guid.NewGuid().ToString("N"));
+        var cacheDir = TestScratch.Dir("al-runner-aps-tests");
         try
         {
             var (exit, stdout, stderr) = Run(cacheDir);

--- a/AlRunner.Tests/AppLoaderManifestCacheTests.cs
+++ b/AlRunner.Tests/AppLoaderManifestCacheTests.cs
@@ -28,7 +28,7 @@ public sealed class AppLoaderManifestCacheTests
 {
     private static string NewTempDir(string suffix)
     {
-        var dir = Path.Combine(Path.GetTempPath(), "app-loader-manifest-cache-tests-" + suffix + "-" + Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.FlatDir("app-loader-manifest-cache-tests-" + suffix + "-");
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/AlRunner.Tests/AppLoaderPackageMetaTests.cs
+++ b/AlRunner.Tests/AppLoaderPackageMetaTests.cs
@@ -26,8 +26,7 @@ public sealed class AppLoaderPackageMetaTests
 {
     private static string NewTempDir(string suffix)
     {
-        var dir = Path.Combine(Path.GetTempPath(),
-            "app-loader-package-meta-tests-" + suffix + "-" + Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.FlatDir("app-loader-package-meta-tests-" + suffix + "-");
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/AlRunner.Tests/ArtifactDownloaderMsBucketTests.cs
+++ b/AlRunner.Tests/ArtifactDownloaderMsBucketTests.cs
@@ -90,7 +90,7 @@ public sealed class ArtifactDownloaderMsBucketTests
 
     private static string TempDir()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-ms-bucket-" + Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.FlatDir("al-runner-ms-bucket-");
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/AlRunner.Tests/AssemblyTypeIndexTests.cs
+++ b/AlRunner.Tests/AssemblyTypeIndexTests.cs
@@ -161,7 +161,7 @@ public sealed class AssemblyTypeIndexTests
     private static (Assembly Definer, Assembly Consumer) LoadPairFromDisk()
     {
         var tag = Guid.NewGuid().ToString("N");
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-type-index", tag);
+        var dir = TestScratch.Dir("al-runner-type-index");
         Directory.CreateDirectory(dir);
         var definerBytes = Compile($"al-runner-ti-def-{tag}", DefinerSource);
         var consumerBytes = Compile($"al-runner-ti-use-{tag}", ConsumerSource, definerBytes);

--- a/AlRunner.Tests/BcAppSymbolCachePageMetadataTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCachePageMetadataTests.cs
@@ -116,7 +116,7 @@ public class BcAppSymbolCachePageMetadataTests
     [Fact]
     public void Pages_CardPage_HasPageTypeCaptionSourceTableAndOrderedControls()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-bcsym-pagemeta-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -169,7 +169,7 @@ public class BcAppSymbolCachePageMetadataTests
     [Fact]
     public void Pages_ListPage_CardPageIdIsStatedByName_NotById()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-bcsym-pagemeta-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -197,7 +197,7 @@ public class BcAppSymbolCachePageMetadataTests
     [Fact]
     public void Pages_NoPropertiesDeclared_AllDefaultsApply()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-bcsym-pagemeta-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -226,7 +226,7 @@ public class BcAppSymbolCachePageMetadataTests
     [Fact]
     public void Pages_AreEmpty_WhenTheSymbolFileDeclaresNone()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-bcsym-pagemeta-tests");
         Directory.CreateDirectory(dir);
         try
         {

--- a/AlRunner.Tests/BcAppSymbolCachePermissionSetTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCachePermissionSetTests.cs
@@ -109,7 +109,7 @@ public class BcAppSymbolCachePermissionSetTests
     [Fact]
     public void PermissionSets_NestedUnderNamespaces_AreFoundWithTheirOwningAppId()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-bcsym-permset-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -145,7 +145,7 @@ public class BcAppSymbolCachePermissionSetTests
     [Fact]
     public void PermissionSets_AssignableDefaultsToTrue_AndAnExplicitFalseIsHonored()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-bcsym-permset-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -170,7 +170,7 @@ public class BcAppSymbolCachePermissionSetTests
     [Fact]
     public void PermissionSets_NoDeclaredCaption_StaysNull()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-bcsym-permset-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -194,7 +194,7 @@ public class BcAppSymbolCachePermissionSetTests
     [Fact]
     public void PermissionSets_AppDeclaringNone_ReturnsAnEmptyList()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-bcsym-permset-tests");
         Directory.CreateDirectory(dir);
         try
         {

--- a/AlRunner.Tests/BcAppSymbolCacheReportTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCacheReportTests.cs
@@ -110,7 +110,7 @@ public class BcAppSymbolCacheReportTests
     [Fact]
     public void Reports_AreReadFromANestedNamespace_WithCaptionAndDataItemTree()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-bcsym-report-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -170,7 +170,7 @@ public class BcAppSymbolCacheReportTests
     [Fact]
     public void Reports_ApplyAlPropertyDefaults_AndStatedOverrides()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-bcsym-report-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -202,7 +202,7 @@ public class BcAppSymbolCacheReportTests
     [Fact]
     public void Reports_AreEmpty_WhenTheSymbolFileDeclaresNone()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-bcsym-report-tests");
         Directory.CreateDirectory(dir);
         try
         {

--- a/AlRunner.Tests/BcAppSymbolCacheTableExtTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCacheTableExtTests.cs
@@ -49,7 +49,7 @@ public class BcAppSymbolCacheTableExtTests
     public void GetTableExtensions_RootLevelEntry_ReturnsParsedExtension()
     {
         // ── ARRANGE ──────────────────────────────────────────────────────────────────
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-bcsym-tableext-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -116,7 +116,7 @@ public class BcAppSymbolCacheTableExtTests
     public void GetTableExtensions_NestedNamespace_ReturnsParsedExtension()
     {
         // Extension nested two namespaces deep (mirrors real BC BaseApp structure)
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-bcsym-tableext-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -174,7 +174,7 @@ public class BcAppSymbolCacheTableExtTests
     public void GetTableExtensions_PlainTargetObjectName_StripsPrefixCorrectly()
     {
         // Some apps use a plain table name without the #appId# prefix
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-bcsym-tableext-tests");
         Directory.CreateDirectory(dir);
         try
         {

--- a/AlRunner.Tests/CleanRunStartupVerbosityTests.cs
+++ b/AlRunner.Tests/CleanRunStartupVerbosityTests.cs
@@ -116,7 +116,7 @@ public sealed class CleanRunStartupVerbosityTests
     }
 
     private static string NewCacheDir([System.Runtime.CompilerServices.CallerMemberName] string name = "") =>
-        Path.Combine(Path.GetTempPath(), "al-runner-clean-run-verbosity", name, Guid.NewGuid().ToString("N"));
+        TestScratch.Dir(Path.Combine("al-runner-clean-run-verbosity", name));
 
     /// <summary>
     /// RED (pre-fix): every fragment in <see cref="ColdRunBookkeepingLineFragments"/>

--- a/AlRunner.Tests/CodeunitMetadataVirtualTableTests.cs
+++ b/AlRunner.Tests/CodeunitMetadataVirtualTableTests.cs
@@ -78,7 +78,7 @@ public sealed class CodeunitMetadataVirtualTableTests
     [Fact]
     public void CodeunitMetadata_SourceCompiledCodeunits_AllFixtureTestsPass()
     {
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-cmv-tests", "cache-" + Guid.NewGuid().ToString("N"));
+        var cacheDir = TestScratch.Dir("al-runner-cmv-tests");
         try
         {
             var (exit, stdout, stderr) = Run(cacheDir);

--- a/AlRunner.Tests/CollateralFailureReportingTests.cs
+++ b/AlRunner.Tests/CollateralFailureReportingTests.cs
@@ -301,7 +301,7 @@ public sealed class CollateralFailureReportingTests
     [Fact]
     public void Classification_FailureRecordsInAPartialBucket_AreMarkedSuspect()
     {
-        var path = Path.Combine(Path.GetTempPath(), $"al-runner-cls-{Guid.NewGuid():N}.json");
+        var path = TestScratch.FilePath("al-runner-cls", "classification.json");
         try
         {
             Reporter.WriteClassification(new[] { PartialBucketWithFailures() }, path);
@@ -333,7 +333,7 @@ public sealed class CollateralFailureReportingTests
     [Fact]
     public void Classification_CleanBucket_MarksNothingSuspect()
     {
-        var path = Path.Combine(Path.GetTempPath(), $"al-runner-cls-{Guid.NewGuid():N}.json");
+        var path = TestScratch.FilePath("al-runner-cls", "classification.json");
         try
         {
             Reporter.WriteClassification(new[] { CleanBucketWithFailures() }, path);

--- a/AlRunner.Tests/CorruptSidecarLoaderCallSiteTests.cs
+++ b/AlRunner.Tests/CorruptSidecarLoaderCallSiteTests.cs
@@ -55,8 +55,7 @@ public sealed class CorruptSidecarLoaderCallSiteTests : IDisposable
     private static readonly byte[] BogusPeBytes = { 0x4D, 0x5A, 0x90, 0x00, 0x03 };
 
     private readonly string _root =
-        Path.Combine(Path.GetTempPath(), "al-runner-corrupt-sidecar-callsite",
-                     Guid.NewGuid().ToString("N"));
+        TestScratch.Dir("al-runner-corrupt-sidecar-callsite");
 
     public void Dispose()
     {

--- a/AlRunner.Tests/CountBaselineIntegrationTests.cs
+++ b/AlRunner.Tests/CountBaselineIntegrationTests.cs
@@ -48,8 +48,7 @@ public sealed class CountBaselineIntegrationTests : IDisposable
         _root = TestScratch.Dir("al-runner-count-baseline");
         Directory.CreateDirectory(_root);
         _suiteKey = Path.GetFileName(_root);
-        _baselinePath = Path.Combine(Path.GetTempPath(), "al-runner-count-baseline",
-            "baseline-" + Guid.NewGuid().ToString("N") + ".json");
+        _baselinePath = TestScratch.FilePath("al-runner-count-baseline", "baseline.json");
         WriteFixture(_root);
     }
 

--- a/AlRunner.Tests/CountBaselineMergeShapeTests.cs
+++ b/AlRunner.Tests/CountBaselineMergeShapeTests.cs
@@ -281,7 +281,7 @@ public sealed class CountBaselineMergeShapeTests
     // ── Merge machinery ────────────────────────────────────────────────────────────────
     private (string Base, string Ours, string Theirs) ThreeCopies()
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-count-baseline-merge-" + Guid.NewGuid().ToString("N"));
+        var root = TestScratch.FlatDir("al-runner-count-baseline-merge-");
         string Copy(string name)
         {
             var dst = Path.Combine(root, name);

--- a/AlRunner.Tests/CountBaselineTests.cs
+++ b/AlRunner.Tests/CountBaselineTests.cs
@@ -10,8 +10,7 @@ namespace AlRunner.Tests;
 
 public sealed class CountBaselineManifestSchemaTests : IDisposable
 {
-    private readonly string _path = Path.Combine(
-        Path.GetTempPath(), "al-runner-count-baseline-schema-" + Guid.NewGuid().ToString("N") + ".json");
+    private readonly string _path = TestScratch.FilePath("al-runner-count-baseline-schema", "manifest.json");
 
     public void Dispose()
     {
@@ -105,7 +104,7 @@ public sealed class CountBaselineCheckTests
 {
     private static CountBaselineManifest ManifestWith(string suitesJson)
     {
-        var path = Path.Combine(Path.GetTempPath(), "al-runner-cbc-" + Guid.NewGuid().ToString("N") + ".json");
+        var path = TestScratch.FilePath("al-runner-cbc", "manifest.json");
         try
         {
             File.WriteAllText(path, $$"""{ "suites": {{{suitesJson}}} }""");
@@ -264,7 +263,7 @@ public sealed class CountBaselineGroupsFormTests
 {
     private static CountBaselineManifest Load(string json)
     {
-        var path = Path.Combine(Path.GetTempPath(), "al-runner-cb-groups-" + Guid.NewGuid().ToString("N") + ".json");
+        var path = TestScratch.FilePath("al-runner-cb-groups", "manifest.json");
         try { File.WriteAllText(path, json); return CountBaselineManifest.Load(path); }
         finally { try { File.Delete(path); } catch { } }
     }

--- a/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
+++ b/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
@@ -99,7 +99,7 @@ public class DependencyPageMetadataXmlTests
     [Fact]
     public void TryBuildDependencyPageMetadata_KnownPage_ProducesPageDefinitionWithRealPageTypeAndSourceTable()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -171,7 +171,7 @@ public class DependencyPageMetadataXmlTests
     [Fact]
     public void TryBuildDependencyPageMetadata_PageWithoutSourceTable_StillEmitsEmptySourceObjectAndExpressions()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -217,7 +217,7 @@ public class DependencyPageMetadataXmlTests
     [Fact]
     public void TryBuildDependencyPageMetadata_PageWithSourceTable_KeepsSourceTableOnTheSameElement()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -247,7 +247,7 @@ public class DependencyPageMetadataXmlTests
     [Fact]
     public void TryBuildDependencyPageMetadata_UnknownPage_ReturnsNullAndIsNotFlaggedAsHavingMetadata()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -403,7 +403,7 @@ public class DependencyPageMetadataXmlTests
     [Fact]
     public void TryBuildDependencyPageMetadata_PartWithResolvableFieldLink_EmitsNumericSubFormLink()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -453,7 +453,7 @@ public class DependencyPageMetadataXmlTests
     [Fact]
     public void TryBuildDependencyPageMetadata_PartWithUnresolvableFieldLink_EmitsNonNumericFilterValue()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -488,7 +488,7 @@ public class DependencyPageMetadataXmlTests
     [Fact]
     public void TryBuildDependencyPageMetadata_PartWithConstLink_PreservesConstFilterType()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -527,7 +527,7 @@ public class DependencyPageMetadataXmlTests
     [InlineData(88123594, "SPECIAL", "5")]       // "Part Link Field" = const('SPECIAL')                 -> the bare text
     public void TryBuildDependencyPageMetadata_ConstLink_NormalisesToCompilerRepresentation(int controlId, string expected, string partFieldId)
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -567,7 +567,7 @@ public class DependencyPageMetadataXmlTests
     [Fact]
     public void TryBuildDependencyPageMetadata_FilterLink_RequotesIdentifiersForFilterGrammar()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -600,7 +600,7 @@ public class DependencyPageMetadataXmlTests
     [Fact]
     public void TryBuildDependencyPageMetadata_PageWithoutParts_ContentHasNoContainers()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -643,7 +643,7 @@ public class DependencyPageMetadataXmlTests
     [Fact]
     public void TryBuildDependencyPageMetadata_CarriesTheSourceObjectFlagsTheSymbolFileStates()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -673,7 +673,7 @@ public class DependencyPageMetadataXmlTests
     [Fact]
     public void TryBuildDependencyPageMetadata_OmitsTheSourceObjectFlagsAPageDoesNotDeclare()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
         Directory.CreateDirectory(dir);
         try
         {

--- a/AlRunner.Tests/DependencyPageShapeResolutionTests.cs
+++ b/AlRunner.Tests/DependencyPageShapeResolutionTests.cs
@@ -75,7 +75,7 @@ public class DependencyPageShapeResolutionTests
 
     private static void WithLoadedDependency(Action body)
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-dep-pageshape-tests");
         Directory.CreateDirectory(dir);
         try
         {

--- a/AlRunner.Tests/DependencyReportDataItemLinkTests.cs
+++ b/AlRunner.Tests/DependencyReportDataItemLinkTests.cs
@@ -126,7 +126,7 @@ public class DependencyReportDataItemLinkTests
     [Fact]
     public void ReportDataItem_CarriesItsJoinBackToTheParent()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-dep-report-dataitemlink-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -168,7 +168,7 @@ public class DependencyReportDataItemLinkTests
     [Fact]
     public void ReportMetadataXml_StatesTheJoinAndOnlyDatasetColumnTypes()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-dep-report-dataitemlink-tests");
         Directory.CreateDirectory(dir);
         try
         {

--- a/AlRunner.Tests/DependencyReportProcessingOnlyTests.cs
+++ b/AlRunner.Tests/DependencyReportProcessingOnlyTests.cs
@@ -125,7 +125,7 @@ public class DependencyReportProcessingOnlyTests
     [Fact]
     public void DependencyReportDeclaringProcessingOnly_IsReportedProcessingOnly()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-dep-report-proconly-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -154,7 +154,7 @@ public class DependencyReportProcessingOnlyTests
     [Fact]
     public void ReportNoSourceAndNoDependencyDeclares_IsNotProcessingOnly()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-dep-report-proconly-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -177,7 +177,7 @@ public class DependencyReportProcessingOnlyTests
     [Fact]
     public void SourceParsedReport_KeepsItsOwnAnswer_EvenWhenADependencyDeclaresTheSameId()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-dep-report-proconly-tests");
         Directory.CreateDirectory(dir);
         try
         {

--- a/AlRunner.Tests/DotNetCompilationTargetScopeTests.cs
+++ b/AlRunner.Tests/DotNetCompilationTargetScopeTests.cs
@@ -83,8 +83,7 @@ public sealed class DotNetCompilationTargetScopeTests
 
     private static string WriteBundle(string label, string target, bool withDeclaration)
     {
-        var root = Path.Combine(
-            Path.GetTempPath(), "al-runner-dotnet-target-" + label, Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-dotnet-target-" + label);
         Directory.CreateDirectory(root);
 
         // No "application" property: the Base Application floor is not the subject here and

--- a/AlRunner.Tests/EngineVariantsTests.cs
+++ b/AlRunner.Tests/EngineVariantsTests.cs
@@ -16,7 +16,7 @@ public sealed class EngineVariantsTests
 {
     private static string NewTempDir(string label)
     {
-        var dir = Path.Combine(Path.GetTempPath(), $"engine-variants-tests-{label}-" + Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.FlatDir($"engine-variants-tests-{label}-");
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/AlRunner.Tests/FailedTestRollbackBoundaryTests.cs
+++ b/AlRunner.Tests/FailedTestRollbackBoundaryTests.cs
@@ -100,7 +100,7 @@ public sealed class FailedTestRollbackBoundaryTests
     [Fact]
     public void FailedTest_WritesAreRolledBack_PassingTestWritesAreNot()
     {
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-ftr-tests", "cache-" + Guid.NewGuid().ToString("N"));
+        var cacheDir = TestScratch.Dir("al-runner-ftr-tests");
         try
         {
             var (exit, stdout, stderr) = Run(cacheDir);

--- a/AlRunner.Tests/FeatureKeyVirtualTableTests.cs
+++ b/AlRunner.Tests/FeatureKeyVirtualTableTests.cs
@@ -77,7 +77,7 @@ public sealed class FeatureKeyVirtualTableTests
     [Fact]
     public void FeatureKey_RoutedToBcsOwnProvider_AllFixtureTestsPass()
     {
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-fkv-tests", "cache-" + Guid.NewGuid().ToString("N"));
+        var cacheDir = TestScratch.Dir("al-runner-fkv-tests");
         try
         {
             var (exit, stdout, stderr) = Run(cacheDir);

--- a/AlRunner.Tests/FlowFieldDiagnosticNoiseTests.cs
+++ b/AlRunner.Tests/FlowFieldDiagnosticNoiseTests.cs
@@ -87,7 +87,7 @@ public sealed class FlowFieldDiagnosticNoiseTests
     }
 
     private static string NewCacheDir([System.Runtime.CompilerServices.CallerMemberName] string name = "") =>
-        Path.Combine(Path.GetTempPath(), "al-runner-flowfield-noise", name, Guid.NewGuid().ToString("N"));
+        TestScratch.Dir(Path.Combine("al-runner-flowfield-noise", name));
 
     private static void AssertFixturePassed(string stdout, string stderr, int exit)
     {

--- a/AlRunner.Tests/InstallBaselineKeySymbolStateTests.cs
+++ b/AlRunner.Tests/InstallBaselineKeySymbolStateTests.cs
@@ -58,7 +58,7 @@ public sealed class InstallBaselineKeySymbolStateTests : IDisposable
 
     public InstallBaselineKeySymbolStateTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-2710-tests", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-2710-tests");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/JUnitReportCarriedCasesTests.cs
+++ b/AlRunner.Tests/JUnitReportCarriedCasesTests.cs
@@ -17,7 +17,7 @@ namespace AlRunner.Tests;
 
 public sealed class JUnitReportCarriedCasesTests : IDisposable
 {
-    private readonly string _dir = Path.Combine(Path.GetTempPath(), "junit-carried-" + Guid.NewGuid().ToString("N"));
+    private readonly string _dir = TestScratch.FlatDir("junit-carried-");
 
     public JUnitReportCarriedCasesTests() => Directory.CreateDirectory(_dir);
     public void Dispose() { try { Directory.Delete(_dir, true); } catch { } }

--- a/AlRunner.Tests/JsonLoaderDependencyFallthroughTests.cs
+++ b/AlRunner.Tests/JsonLoaderDependencyFallthroughTests.cs
@@ -35,7 +35,7 @@ public sealed class JsonLoaderDependencyFallthroughTests : IDisposable
 
     public JsonLoaderDependencyFallthroughTests()
     {
-        _emptyDir = Path.Combine(Path.GetTempPath(), "alrunner-jsonloader-test-" + Guid.NewGuid().ToString("N")[..8]);
+        _emptyDir = TestScratch.FlatDir("alrunner-jsonloader-test-");
         Directory.CreateDirectory(_emptyDir);
     }
 

--- a/AlRunner.Tests/LayeredCacheTests.cs
+++ b/AlRunner.Tests/LayeredCacheTests.cs
@@ -39,8 +39,7 @@ public class LayeredCacheTests : IClassFixture<SharedCliServer>
     /// for this one — the same guarantee the CLI version got from building its cacheDir
     /// under a fresh scratch root.
     /// </summary>
-    private static readonly string CacheDir = Path.Combine(
-        Path.GetTempPath(), "al-runner-layered-cache", Guid.NewGuid().ToString("N"), "al-out");
+    private static readonly string CacheDir = Path.Combine(TestScratch.Dir("al-runner-layered-cache"), "al-out");
 
     /// <summary>
     /// Emitted by the layered pre-pass AFTER every per-impl WROTE/HIT line, so it is a

--- a/AlRunner.Tests/LayeredDepSymbolsIncrementalServerTests.cs
+++ b/AlRunner.Tests/LayeredDepSymbolsIncrementalServerTests.cs
@@ -35,8 +35,7 @@ public class LayeredDepSymbolsIncrementalServerTests : IClassFixture<SharedCliSe
 {
     private readonly SharedCliServer _shared;
 
-    private static readonly string CacheDir = Path.Combine(
-        Path.GetTempPath(), "al-runner-layered-rad", Guid.NewGuid().ToString("N"), "al-out");
+    private static readonly string CacheDir = Path.Combine(TestScratch.Dir("al-runner-layered-rad"), "al-out");
 
     /// <summary>Same synchronisation anchor <see cref="LayeredCacheTests"/> uses — emitted by the
     /// pre-pass AFTER every per-impl line, so it is sound to slice on for both a positive

--- a/AlRunner.Tests/LayeredSourceChainTests.cs
+++ b/AlRunner.Tests/LayeredSourceChainTests.cs
@@ -248,7 +248,7 @@ public class LayeredSourceChainTests
     }
 
     private static string NewScratch(string tag) =>
-        Path.Combine(Path.GetTempPath(), "al-runner-layered-chain", tag, Guid.NewGuid().ToString("N"));
+        TestScratch.Dir(Path.Combine("al-runner-layered-chain", tag));
 
     private static string ServerReq(params string[] bundles) => JsonSerializer.Serialize(new
     {

--- a/AlRunner.Tests/ManifestCompilationTargetTests.cs
+++ b/AlRunner.Tests/ManifestCompilationTargetTests.cs
@@ -25,7 +25,7 @@ public sealed class ManifestCompilationTargetTests : IDisposable
 
     public ManifestCompilationTargetTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-manifest-target", Guid.NewGuid().ToString("N"));
+        _root = TestScratch.Dir("al-runner-manifest-target");
         Directory.CreateDirectory(_root);
     }
 

--- a/AlRunner.Tests/NclShadowConcurrentStartupTests.cs
+++ b/AlRunner.Tests/NclShadowConcurrentStartupTests.cs
@@ -16,7 +16,7 @@ public sealed class NclShadowConcurrentStartupTests
 {
     private static string NewTempDir(string label)
     {
-        var dir = Path.Combine(Path.GetTempPath(), $"ncl-shadow-race-{label}-" + Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.FlatDir($"ncl-shadow-race-{label}-");
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/AlRunner.Tests/NclShadowRuntimeTests.cs
+++ b/AlRunner.Tests/NclShadowRuntimeTests.cs
@@ -27,7 +27,7 @@ public sealed class NclShadowRuntimeTests
 {
     private static string NewTempDir(string label)
     {
-        var dir = Path.Combine(Path.GetTempPath(), $"ncl-shadow-tests-{label}-" + Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.FlatDir($"ncl-shadow-tests-{label}-");
         Directory.CreateDirectory(dir);
         return dir;
     }

--- a/AlRunner.Tests/PartialSuiteLossReportingTests.cs
+++ b/AlRunner.Tests/PartialSuiteLossReportingTests.cs
@@ -261,7 +261,7 @@ public sealed class PartialSuiteLossReportingTests
     [Fact]
     public void Classification_RanBucketThatLostASuite_RecordsIt()
     {
-        var path = Path.Combine(Path.GetTempPath(), $"al-runner-cls-{Guid.NewGuid():N}.json");
+        var path = TestScratch.FilePath("al-runner-cls", "classification.json");
         try
         {
             Reporter.WriteClassification(new[] { PartialLossBucket() }, path);
@@ -280,7 +280,7 @@ public sealed class PartialSuiteLossReportingTests
     [Fact]
     public void Classification_CleanRun_RecordsNoFailures()
     {
-        var path = Path.Combine(Path.GetTempPath(), $"al-runner-cls-{Guid.NewGuid():N}.json");
+        var path = TestScratch.FilePath("al-runner-cls", "classification.json");
         try
         {
             Reporter.WriteClassification(new[] { CleanBucket() }, path);

--- a/AlRunner.Tests/PerSuiteAlDiagnosticFailureTests.cs
+++ b/AlRunner.Tests/PerSuiteAlDiagnosticFailureTests.cs
@@ -52,7 +52,7 @@ public class PerSuiteAlDiagnosticFailureTests
     // test needs to isolate the per-suite gate from the bundled one.
     private static string WriteBundle(string suffix, string queryBody)
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-persuite-al0353-" + suffix, Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-persuite-al0353-" + suffix);
         Directory.CreateDirectory(root);
         File.WriteAllText(Path.Combine(root, "app.json"), """
         {

--- a/AlRunner.Tests/PermissionMetadataPopulationTests.cs
+++ b/AlRunner.Tests/PermissionMetadataPopulationTests.cs
@@ -44,7 +44,7 @@ public sealed class PermissionMetadataPopulationTests
     [Fact]
     public void AfterAPermissionTableIsTouched_TheAppGroupAndTheMetadataLayerBothAnswer()
     {
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-permmeta-" + Guid.NewGuid().ToString("N"));
+        var cacheDir = TestScratch.FlatDir("al-runner-permmeta-");
         try
         {
             var (exit, stdout, stderr) = Run(cacheDir);

--- a/AlRunner.Tests/PhaseLogServerKillTests.cs
+++ b/AlRunner.Tests/PhaseLogServerKillTests.cs
@@ -62,7 +62,7 @@ public sealed class PhaseLogServerKillTests : IDisposable
     private static string MakeFixtureBundle(out string dirName)
     {
         var nonce = Guid.NewGuid().ToString("N");
-        var dir = Path.Combine(Path.GetTempPath(), "al-runner-phaselog-kill-fixture", nonce);
+        var dir = TestScratch.Dir("al-runner-phaselog-kill-fixture");
         Directory.CreateDirectory(dir);
         dirName = Path.GetFileName(dir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
         File.WriteAllText(Path.Combine(dir, "app.json"), $$"""

--- a/AlRunner.Tests/PrecompiledPageMemberNameTests.cs
+++ b/AlRunner.Tests/PrecompiledPageMemberNameTests.cs
@@ -174,7 +174,7 @@ public class PrecompiledPageMemberNameTests
 
     private static void WithApp(Action<string> body)
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-precompiled-pagemember-tests");
         Directory.CreateDirectory(dir);
         try { body(WriteApp(dir, SymbolReference)); }
         finally { Directory.Delete(dir, recursive: true); }

--- a/AlRunner.Tests/QueryColumnAlDiagnosticFailureTests.cs
+++ b/AlRunner.Tests/QueryColumnAlDiagnosticFailureTests.cs
@@ -66,7 +66,7 @@ public class QueryColumnAlDiagnosticFailureTests
 
     private static string WriteBundle(string suffix, string queryBody)
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-al0353-" + suffix, Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-al0353-" + suffix);
         Directory.CreateDirectory(root);
         File.WriteAllText(Path.Combine(root, "app.json"), """
         {

--- a/AlRunner.Tests/RecordPatchesGetPageControlFieldMapDependencyTests.cs
+++ b/AlRunner.Tests/RecordPatchesGetPageControlFieldMapDependencyTests.cs
@@ -117,7 +117,7 @@ public class RecordPatchesGetPageControlFieldMapDependencyTests
     [Fact]
     public void GetPageControlFieldMap_DependencyPage_ResolvesPlainRecFieldControl()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-pagecontrol-fieldmap-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -142,7 +142,7 @@ public class RecordPatchesGetPageControlFieldMapDependencyTests
     [Fact]
     public void GetPageControlFieldMap_DependencyPage_OmitsControlWhoseFieldDoesNotExist()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-pagecontrol-fieldmap-tests");
         Directory.CreateDirectory(dir);
         try
         {

--- a/AlRunner.Tests/ReportLayoutFileResolutionTests.cs
+++ b/AlRunner.Tests/ReportLayoutFileResolutionTests.cs
@@ -65,7 +65,7 @@ public class ReportLayoutFileResolutionTests
 
     private static string WriteApp(string suffix, string appId, int baseId)
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-report-layout-resolution-" + suffix, Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-report-layout-resolution-" + suffix);
         Directory.CreateDirectory(root);
         File.WriteAllText(Path.Combine(root, "app.json"), $$"""
         {

--- a/AlRunner.Tests/ScratchDirOwnershipGuardTests.cs
+++ b/AlRunner.Tests/ScratchDirOwnershipGuardTests.cs
@@ -1,0 +1,219 @@
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Guards the invariant #2706 set up and #2743 finished: every scratch directory a test in
+/// this project hands to the runner is OWNED, so a killed test host's leftovers can be
+/// reclaimed by a later runner start instead of sitting in the temp root forever.
+///
+/// #2736 converted 190 sites by matching two textual shapes. About 50 did not match and were
+/// left behind — including fourteen <c>--cache</c> roots, the expensive kind at roughly 273 MB
+/// each, and about 30 bare <c>Path.Combine(Path.GetTempPath(), Guid)</c> directories written
+/// straight into the temp root with no <c>al-runner-</c> prefix, which
+/// <see cref="AlRunner.Infrastructure.ScratchDirs.SweepStale"/> cannot reach even in principle
+/// (it skips any depth-0 name without a scanned prefix). Nothing noticed for three weeks,
+/// because a textual conversion leaves no record of what it missed.
+///
+/// So the remainder is enforced here rather than described in a PR body. A new
+/// <c>Path.GetTempPath()</c> in AlRunner.Tests fails this test unless its file is on the
+/// allowlist below WITH the reason the site cannot be owned — and the COUNT is part of the
+/// allowlist, so adding a second, ownable site to an allowlisted file still fails.
+///
+/// The failure mode this shape exists to avoid is the one
+/// <c>.claude/rules/no-base-app-in-csharp-tests.md</c> already recorded: an allowlist written
+/// as prose with no test behind it was ignored, and the violation it asked for arrived anyway.
+///
+/// Every allowlisted site has the same property: reserving it would change what the test is
+/// testing, not just where it writes. Three kinds, and no fourth has been needed:
+///
+///   * A path that must NOT exist — <c>Reserve</c> creates the parent directory and writes a
+///     <c>.owner</c> sidecar next to a path whose entire point is that nothing is there.
+///   * A pure path-string argument to a resolver, never created on disk, so there is nothing
+///     to own and a sidecar would be litter of its own.
+///   * An assertion ABOUT the temp root — where the runner puts its own scratch, or that the
+///     sweep walks the real root.
+///
+/// Comment lines are not counted: several files quote the expression while explaining that
+/// they deliberately do not use it, and flagging those would train readers to ignore this
+/// test.
+/// </summary>
+public sealed class ScratchDirOwnershipGuardTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static string TestsDir => Path.Combine(RepoRoot, "AlRunner.Tests");
+
+    private const string Expression = "Path.GetTempPath()";
+
+    /// <summary>
+    /// File name → (how many non-comment <c>Path.GetTempPath()</c> occurrences are permitted,
+    /// why they cannot be owned). The count is deliberately exact in both directions: too many
+    /// means a new unowned site slipped into an already-allowlisted file, too few means the
+    /// entry is stale and is silently pre-approving the next one.
+    /// </summary>
+    private static readonly Dictionary<string, (int Count, string Why)> Allowed = new()
+    {
+        ["TestScratch.cs"] =
+            (3, "the helper itself — Dir, FlatDir and FilePath are what everything else calls"),
+        ["ScratchDirOwnershipGuardTests.cs"] =
+            (1, "the literal this guard scans for, in the const it scans with"),
+
+        // ── paths that must NOT exist ───────────────────────────────────────────────────
+        ["AppLoaderManifestCacheTests.cs"] =
+            (1, "a .app path that must not exist, so the loader's miss path is what runs"),
+        ["AppLoaderR2rChunkCacheTests.cs"] =
+            (1, "a .app path that must not exist"),
+        ["RunnerFingerprintTests.cs"] =
+            (1, "a .dll path that must not exist"),
+        ["TestDataProvisioningTests.cs"] =
+            (1, "a .bak path that must not exist, so the missing-backup diagnosis is what runs"),
+        ["WatchSourceTests.cs"] =
+            (1, "a bundle path that must not exist"),
+        ["Win32StubsLoudFailureTests.cs"] =
+            (1, "a .so path that must not exist; this file's three real directories ARE owned"),
+
+        // ── path strings handed to a resolver, never created ────────────────────────────
+        ["ArtifactsRootEnvOverrideTests.cs"] =
+            (3, "AL_RUNNER_ARTIFACTS_ROOT values fed to BcArtifacts.ResolveArtifactsRoot; the "
+              + "test asserts on the resolved string and never touches the filesystem"),
+        ["SiblingSymbolsDirectoryTests.cs"] =
+            (1, "a synthetic bundle path fed to SiblingSymbolsDirectory.ForBundle; the three "
+              + "facts compare returned paths and create nothing"),
+
+        // ── assertions about the temp root itself ───────────────────────────────────────
+        ["AlRunnerPathsTests.cs"] =
+            (1, "asserts an absolute path is echoed back unchanged; the temp root is just a "
+              + "conveniently absolute path"),
+        ["CacheRootsDisableForRunTests.cs"] =
+            (1, "asserts the throwaway root the RUNNER chose is under the temp root"),
+        ["NoCacheLastWinsIntegrationTests.cs"] =
+            (1, "same — asserts about a root the runner chose, not one this test creates"),
+        ["ScratchDirsRunnerStartupTests.cs"] =
+            (1, "drives SweepStale over the real temp root, which is the behaviour under test"),
+    };
+
+    /// <summary>Non-comment occurrences of the expression, per file name.</summary>
+    private static Dictionary<string, int> Occurrences()
+    {
+        var found = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var path in Directory.EnumerateFiles(TestsDir, "*.cs", SearchOption.TopDirectoryOnly))
+        {
+            var n = 0;
+            foreach (var raw in File.ReadAllLines(path))
+            {
+                var line = raw.TrimStart();
+                if (line.StartsWith("//", StringComparison.Ordinal)
+                    || line.StartsWith("*", StringComparison.Ordinal)) continue;
+
+                var i = 0;
+                while ((i = raw.IndexOf(Expression, i, StringComparison.Ordinal)) >= 0)
+                {
+                    n++;
+                    i += Expression.Length;
+                }
+            }
+            if (n > 0) found[Path.GetFileName(path)] = n;
+        }
+        return found;
+    }
+
+    /// <summary>
+    /// The forward direction: a file using <c>Path.GetTempPath()</c> without being on the
+    /// allowlist is a scratch path nothing owns.
+    /// </summary>
+    [Fact]
+    public void NoTestSource_BuildsAnUnownedTempPath_ExceptTheAllowlisted()
+    {
+        var offenders = Occurrences().Keys.Where(f => !Allowed.ContainsKey(f)).OrderBy(f => f).ToList();
+
+        Assert.True(offenders.Count == 0,
+            $"These test sources build a path under {Expression} directly, so nothing "
+            + "records an owner for it and a killed test host leaks it permanently:\n  "
+            + string.Join("\n  ", offenders)
+            + "\n\nUse TestScratch.Dir / TestScratch.FlatDir for a directory, or "
+            + "TestScratch.FilePath for a scratch file (ScratchDirs owns directories, so a "
+            + "reserved FILE path writes a marker that deletes nothing). If the path genuinely "
+            + "cannot be owned — it must not exist, or it is never created at all — add the "
+            + "file here WITH its count and the reason. See issue #2743.");
+    }
+
+    /// <summary>
+    /// The count direction: an allowlisted file may not quietly grow a new site behind its
+    /// entry, and an entry whose count has dropped is stale — a stale entry pre-approves the
+    /// next unowned site to land in that file.
+    /// </summary>
+    [Fact]
+    public void EveryAllowlistEntry_MatchesItsRecordedCount_SoTheListCannotGoStale()
+    {
+        var found = Occurrences();
+        var wrong = new List<string>();
+
+        foreach (var (name, (count, why)) in Allowed)
+        {
+            var actual = found.TryGetValue(name, out var n) ? n : 0;
+            if (actual != count)
+                wrong.Add($"{name}: allowlist says {count}, source has {actual} ({why})");
+        }
+
+        Assert.True(wrong.Count == 0,
+            "These allowlist entries no longer match the source:\n  " + string.Join("\n  ", wrong)
+            + "\n\nHigher than recorded means a NEW unowned temp path was added to an "
+            + "already-allowlisted file — route it through TestScratch. Lower means the entry is "
+            + "stale: correct the count, or delete the entry, so it stops pre-approving the next "
+            + "site that lands in that file.");
+    }
+
+    /// <summary>
+    /// The helper has to actually reserve, or every one of the ~240 converted call sites is
+    /// back to an unowned <c>Path.Combine</c> while all the source-scanning facts above stay
+    /// green. So: each shape writes the <c>.owner</c> sidecar beside the path it returns, and
+    /// this process is recorded as the owner.
+    ///
+    /// <see cref="TestScratch.FilePath"/> differs from the other two on purpose — it returns a
+    /// FILE, and ScratchDirs cleans up directories, so the thing that must be owned is the
+    /// file's parent. Asserting that distinction here is what keeps someone from "simplifying"
+    /// FilePath into a Reserve of the file path, which would write a marker that deletes
+    /// nothing.
+    /// </summary>
+    [Fact]
+    public void EveryTestScratchShape_ReallyRecordsAnOwner()
+    {
+        var dir = TestScratch.Dir("al-runner-scratch-guard-tests");
+        var flat = TestScratch.FlatDir("al-runner-scratch-guard-flat-");
+        var file = TestScratch.FilePath("al-runner-scratch-guard-file", "payload.json");
+        var parent = Path.GetDirectoryName(file)!;
+
+        try
+        {
+            foreach (var owned in new[] { dir, flat, parent })
+            {
+                Assert.True(File.Exists(ScratchDirs.MarkerPathFor(owned)),
+                    $"no .owner sidecar beside {owned} — a killed test host would leak it");
+                Assert.True(ScratchDirs.TryReadOwner(ScratchDirs.MarkerPathFor(owned), out var pid, out _),
+                    $"the sidecar beside {owned} does not parse");
+                Assert.Equal(Environment.ProcessId, pid);
+            }
+
+            // FilePath's directory is created (the caller is about to write into it) while
+            // Dir/FlatDir deliberately leave the leaf uncreated — several call sites observe
+            // whether the RUNNER created it.
+            Assert.True(Directory.Exists(parent), "TestScratch.FilePath must create the containing directory");
+            Assert.False(Directory.Exists(dir), "TestScratch.Dir must not create the leaf");
+            Assert.False(Directory.Exists(flat), "TestScratch.FlatDir must not create the leaf");
+
+            // Negative: the sidecar names the directory, never the file. A marker written for
+            // the file path itself would name something ScratchDirs' cleanup never deletes.
+            Assert.False(File.Exists(ScratchDirs.MarkerPathFor(file)),
+                "FilePath must own the containing DIRECTORY, not the file path");
+        }
+        finally
+        {
+            ScratchDirs.Release(dir);
+            ScratchDirs.Release(flat);
+            ScratchDirs.Release(parent);
+        }
+    }
+}

--- a/AlRunner.Tests/ServerAlDiagnosticFailureTests.cs
+++ b/AlRunner.Tests/ServerAlDiagnosticFailureTests.cs
@@ -19,7 +19,7 @@ public sealed class ServerAlDiagnosticFailureTests
 {
     private static string WriteBundle(string suffix, string queryBody)
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-server-al0353-" + suffix, Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-server-al0353-" + suffix);
         Directory.CreateDirectory(root);
         File.WriteAllText(Path.Combine(root, "app.json"), """
         {

--- a/AlRunner.Tests/ServerCrossAppStaleGenerationTests.cs
+++ b/AlRunner.Tests/ServerCrossAppStaleGenerationTests.cs
@@ -88,7 +88,7 @@ public class ServerCrossAppStaleGenerationTests : IClassFixture<SharedCliServer>
     private static (string libDir, string testDir, string answerFile) MakeLibTestPair(
         string rootName, int variant)
     {
-        var root = Path.Combine(Path.GetTempPath(), rootName, Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir(rootName);
         var libDir = Path.Combine(root, "Lib");
         var testDir = Path.Combine(root, "Test");
         Directory.CreateDirectory(libDir);

--- a/AlRunner.Tests/SiblingSymbolsAppRootManifestTests.cs
+++ b/AlRunner.Tests/SiblingSymbolsAppRootManifestTests.cs
@@ -210,8 +210,7 @@ public class SiblingSymbolsAppRootManifestTests
 
     private static string NewRoot(string tag)
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-sibling-approot-" + tag,
-            Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-sibling-approot-" + tag);
         Directory.CreateDirectory(root);
         return root;
     }

--- a/AlRunner.Tests/SuiteAbortOnTimeoutTests.cs
+++ b/AlRunner.Tests/SuiteAbortOnTimeoutTests.cs
@@ -49,7 +49,7 @@ public sealed class SuiteAbortOnTimeoutTests : IDisposable
         _root = TestScratch.Dir("al-runner-suite-abort-on-timeout");
         Directory.CreateDirectory(_root);
         WriteFixture(_root);
-        _resumeRoot = Path.Combine(Path.GetTempPath(), "al-runner-suite-abort-resume", Guid.NewGuid().ToString("N"));
+        _resumeRoot = TestScratch.Dir("al-runner-suite-abort-resume");
         Directory.CreateDirectory(_resumeRoot);
         WriteResumeFixture(_resumeRoot);
     }

--- a/AlRunner.Tests/TableRelationWhereFieldLinkTests.cs
+++ b/AlRunner.Tests/TableRelationWhereFieldLinkTests.cs
@@ -159,7 +159,7 @@ public class TableRelationWhereFieldLinkTests
     [Fact]
     public void WhereClauseFieldLink_IsCarried_AsAFieldFilterNamingTheReferencingField()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-table-relation-where-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -214,7 +214,7 @@ public class TableRelationWhereFieldLinkTests
     [Fact]
     public void RelationsWithoutAFieldLink_AreUnchanged()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-table-relation-where-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -249,7 +249,7 @@ public class TableRelationWhereFieldLinkTests
     [Fact]
     public void FieldLinkModeSpellings_SetTheMatchingMetaFilterFlag()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-table-relation-where-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -284,7 +284,7 @@ public class TableRelationWhereFieldLinkTests
     [Fact]
     public void ConditionalRelation_KeepsBothArms_WhenOnlyTheSecondCarriesAFieldLink()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-table-relation-where-tests");
         Directory.CreateDirectory(dir);
         try
         {
@@ -321,7 +321,7 @@ public class TableRelationWhereFieldLinkTests
     [Fact]
     public void ParentTableRelationsAreUnaffected_AndTheAppReallyLoaded()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        var dir = TestScratch.Dir("al-runner-table-relation-where-tests");
         Directory.CreateDirectory(dir);
         try
         {

--- a/AlRunner.Tests/TestPageFieldTableLookupTests.cs
+++ b/AlRunner.Tests/TestPageFieldTableLookupTests.cs
@@ -62,7 +62,7 @@ public class TestPageFieldTableLookupTests
 
     private static string WriteBundle()
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-testpage-field-table-lookup-2549", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-testpage-field-table-lookup-2549");
         Directory.CreateDirectory(root);
 
         File.WriteAllText(Path.Combine(root, "app.json"), """

--- a/AlRunner.Tests/TestPageNewRecordValidationTests.cs
+++ b/AlRunner.Tests/TestPageNewRecordValidationTests.cs
@@ -86,7 +86,7 @@ public sealed class TestPageNewRecordValidationTests
     [Fact]
     public void New_ValidatesTheStampedSet_AndOnlyTheStampedSet()
     {
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-tnv-tests", "cache-" + Guid.NewGuid().ToString("N"));
+        var cacheDir = TestScratch.Dir("al-runner-tnv-tests");
         try
         {
             var (exit, stdout, stderr) = Run(cacheDir);

--- a/AlRunner.Tests/TestPagePartConstFilterLinkTests.cs
+++ b/AlRunner.Tests/TestPagePartConstFilterLinkTests.cs
@@ -57,7 +57,7 @@ public class TestPagePartConstFilterLinkTests
 
     private static string WriteBundle()
     {
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-testpage-part-const-filter-link-2469", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-testpage-part-const-filter-link-2469");
         Directory.CreateDirectory(root);
 
         File.WriteAllText(Path.Combine(root, "app.json"), """

--- a/AlRunner.Tests/TestScratch.cs
+++ b/AlRunner.Tests/TestScratch.cs
@@ -27,4 +27,19 @@ internal static class TestScratch
     /// <summary><c>&lt;temp&gt;/&lt;prefix&gt;&lt;guid&gt;</c> — the flat shape (prefix usually ends in '-').</summary>
     public static string FlatDir(string prefix)
         => ScratchDirs.Reserve(Path.Combine(Path.GetTempPath(), prefix + Guid.NewGuid().ToString("N")));
+
+    /// <summary>
+    /// <c>&lt;temp&gt;/&lt;prefix&gt;/&lt;guid&gt;/&lt;fileName&gt;</c> — a scratch FILE with an owner.
+    ///
+    /// ScratchDirs owns DIRECTORIES: its sidecar sits beside the entry it names and its cleanup
+    /// calls Directory.Delete, so reserving a file path would write a marker that never deletes
+    /// anything. An owned scratch file therefore has to live inside an owned directory. That
+    /// directory IS created here — unlike <see cref="Dir"/>, where some callers rely on observing
+    /// whether the runner created the leaf — because a caller about to File.WriteAllText into it
+    /// has no way to create it that this helper has not already had to do.
+    /// </summary>
+    public static string FilePath(string prefix, string fileName)
+        => Path.Combine(
+            ScratchDirs.Create(Path.Combine(Path.GetTempPath(), prefix, Guid.NewGuid().ToString("N"))),
+            fileName);
 }

--- a/AlRunner.Tests/TimeZoneVirtualTableTests.cs
+++ b/AlRunner.Tests/TimeZoneVirtualTableTests.cs
@@ -77,7 +77,7 @@ public sealed class TimeZoneVirtualTableTests
     [Fact]
     public void TimeZone_HostZones_AllFixtureTestsPass()
     {
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-tzv-tests", "cache-" + Guid.NewGuid().ToString("N"));
+        var cacheDir = TestScratch.Dir("al-runner-tzv-tests");
         try
         {
             var (exit, stdout, stderr) = Run(cacheDir);

--- a/AlRunner.Tests/WatchLayeredDependencyStaleTests.cs
+++ b/AlRunner.Tests/WatchLayeredDependencyStaleTests.cs
@@ -138,7 +138,7 @@ public class WatchLayeredDependencyStaleTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var root = Path.Combine(Path.GetTempPath(), "al-runner-watch-layered-stale", Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("al-runner-watch-layered-stale");
         Directory.CreateDirectory(root);
         var depDir = WriteDepBundle(root, answer: 42);
         var testDir = WriteTestBundle(root, extraComment: "cycle 1");

--- a/AlRunner.Tests/Win32StubsLoudFailureTests.cs
+++ b/AlRunner.Tests/Win32StubsLoudFailureTests.cs
@@ -93,7 +93,7 @@ public class Win32StubsLoudFailureTests
     [SkippableFact]
     public void GetOrBuild_HonoursSoOverride_WhenFileExists()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "win32stubs-test-" + Guid.NewGuid());
+        var dir = TestScratch.FlatDir("win32stubs-test-");
         Directory.CreateDirectory(dir);
         var cFile = Path.Combine(dir, "trivial.c");
         var soFile = Path.Combine(dir, "trivial.so");
@@ -217,7 +217,7 @@ public class Win32StubsLoudFailureTests
         TestArtifacts.SkipIf(ridName is null,
             $"no prebuilt-stub convention for this RID ({System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier}) — Linux x64/arm64 only.");
 
-        var dir = Path.Combine(Path.GetTempPath(), "win32stubs-prebuilt-test-" + Guid.NewGuid());
+        var dir = TestScratch.FlatDir("win32stubs-prebuilt-test-");
         var stubDir = Path.Combine(dir, "Win32Stubs");
         Directory.CreateDirectory(stubDir);
         var cFile = Path.Combine(dir, "trivial.c");
@@ -263,7 +263,7 @@ public class Win32StubsLoudFailureTests
     [Fact]
     public void GetOrBuild_StillThrows_WhenNoPrebuiltAndNoCompiler()
     {
-        var dir = Path.Combine(Path.GetTempPath(), "win32stubs-no-prebuilt-test-" + Guid.NewGuid());
+        var dir = TestScratch.FlatDir("win32stubs-no-prebuilt-test-");
         Directory.CreateDirectory(dir); // deliberately no Win32Stubs/ subfolder inside it
 
         var savedOverride = Environment.GetEnvironmentVariable("AL_RUNNER_WIN32_STUBS_SO");

--- a/AlRunner.Tests/WindowsLanguageVirtualTableTests.cs
+++ b/AlRunner.Tests/WindowsLanguageVirtualTableTests.cs
@@ -74,7 +74,7 @@ public sealed class WindowsLanguageVirtualTableTests
     [Fact]
     public void WindowsLanguage_TruthfulColumns_AllFixtureTestsPass()
     {
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-wlv-tests", "cache-" + Guid.NewGuid().ToString("N"));
+        var cacheDir = TestScratch.Dir("al-runner-wlv-tests");
         try
         {
             var (exit, stdout, stderr) = Run(cacheDir);


### PR DESCRIPTION
Closes #2743

Finishes the conversion #2736 started, and replaces the prose invariant with a test, because a textual conversion leaves no record of what it missed and this one missed about 50 sites for three weeks.

## The `--cache` roots: 14, not 5

The issue named five. I grepped for the shape rather than the symptom and found nine more, including two written with the identical `al-runner-<tag>-tests/cache-<guid>` spelling as the five:

| test | what it handed the runner |
|---|---|
| `AggregatePermissionSetVirtualTableTests` | `al-runner-aps-tests/cache-<guid>` |
| `CodeunitMetadataVirtualTableTests` | `al-runner-cmv-tests/cache-<guid>` |
| `FeatureKeyVirtualTableTests` | `al-runner-fkv-tests/cache-<guid>` |
| `TimeZoneVirtualTableTests` | `al-runner-tzv-tests/cache-<guid>` |
| `WindowsLanguageVirtualTableTests` | `al-runner-wlv-tests/cache-<guid>` |
| `FailedTestRollbackBoundaryTests` | `al-runner-ftr-tests/cache-<guid>` — not in the issue |
| `TestPageNewRecordValidationTests` | `al-runner-tnv-tests/cache-<guid>` — not in the issue |
| `PermissionMetadataPopulationTests` | `al-runner-permmeta-<guid>` — not in the issue |
| `SiblingSymbolsAppRootManifestTests` | a per-fact cache under `al-runner-sibling-approot-<tag>/<guid>` |
| `LayeredSourceChainTests` | `al-runner-layered-chain/<tag>/<guid>/al-out` |
| `LayeredCacheTests` | `al-runner-layered-cache/<guid>/al-out` |
| `LayeredDepSymbolsIncrementalServerTests` | `al-runner-layered-rad/<guid>/al-out` |
| `FlowFieldDiagnosticNoiseTests` | `al-runner-flowfield-noise/<fact>/<guid>` |
| `CleanRunStartupVerbosityTests` | `al-runner-clean-run-verbosity/<fact>/<guid>` |

**Correction to the brief I was given, and it matters for the diagnosis.** None of these was sharing `~/.cache/al-runner` or anything else — every one already built a fresh GUID path per run, so a concurrent agent's payload could not reach them and no result was unreliable. What they lacked was an *owner*: no `.owner` sidecar, so a test host killed by the watchdog, an OOM or Ctrl-C left roughly 273 MB behind per root with no later process able to tell the owner was dead. Each also deletes in a `finally`, which covers the clean exit and nothing else. That is exactly the case the sidecar exists for.

All fourteen keep their exact path shape. The two `.../al-out` ones now reserve the parent instead of the leaf, which additionally reclaims the containing directory rather than leaving an empty shell.

## The rest: two shapes the sweep could not reach

- **30 bare `Path.Combine(Path.GetTempPath(), Guid)` directories.** `SweepStale` skips any depth-0 name without a scanned prefix, so these were unreclaimable even with a sidecar. Each file's set now shares one named container.
- **7 scratch `.json` FILES.** `ScratchDirs` owns directories — cleanup calls `Directory.Delete` — so reserving a file path writes a marker that deletes nothing. Added `TestScratch.FilePath`, which puts the file inside an owned directory. That is the only shape that actually works, and the guard asserts the distinction so nobody "simplifies" it back.

## Deliberately not converted, and why

Checked each rather than substituting mechanically. Converting these would change what the test can see:

- **Paths that must NOT exist** — `does-not-exist-*.app` / `.so` / `.dll`, `al-runner-no-such-backup-*.bak`. `Reserve` creates the parent and writes a sidecar next to a path whose whole point is that nothing is there.
- **Pure path strings fed to a resolver** — `ArtifactsRootEnvOverrideTests` asserts on `ResolveArtifactsRoot`'s returned string; `SiblingSymbolsDirectoryTests.Bundle` feeds `ForBundle` and compares paths. Neither touches the filesystem.
- **Assertions about the temp root itself** — `AlRunnerPathsTests`, `CacheRootsDisableForRunTests`, `NoCacheLastWinsIntegrationTests`, `ScratchDirsRunnerStartupTests`.

Each is on the guard's allowlist with that reason.

## The guard

`AlRunner.Tests/ScratchDirOwnershipGuardTests.cs`, modelled on `BaseAppFloorFixtureGuardTests` rather than adding a second convention. Three facts:

1. a `Path.GetTempPath()` in `AlRunner.Tests/` fails unless its file is allowlisted;
2. the allowlisted **count** must match the source in both directions — too high means a new site slipped in behind an existing entry, too low means the entry is stale and is pre-approving the next one;
3. `TestScratch` really reserves: each shape writes the sidecar naming this process, `Dir`/`FlatDir` leave the leaf uncreated (call sites observe whether the runner created it) while `FilePath` creates it, and `FilePath` owns the **parent**, never the file path.

Without fact 3 the source scanning stays green while the helper is hollowed out and every converted call site silently goes back to leaking.

## RED → GREEN

- **The guard's forward direction.** Dropped one `Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"))` into a throwaway file: `NoTestSource_BuildsAnUnownedTempPath_ExceptTheAllowlisted` **failed**, naming that file. Removed it: 3/3 pass. It also caught itself on the first run — the `const string Expression` it scans with — which is how the count came to be exact rather than a floor.
- **It caught a real drift within the hour.** Rebasing onto current `main` pulled in `TableRelationWhereFieldLinkTests.cs` from #2853, merged while this branch was open, carrying **five fresh prefix-less sites** — the exact shape the previous commit had just converted 30 of. Site 51 arrived on schedule. Converted in its own commit.
- **The refactor itself.** Every converted test still passes, which is the proof for a change of this kind.

## What I ran

All on this branch at `5e896752` (rebased onto `0f42d06f`), after a rebuild — no result is carried across the rebase.

| scope | result |
|---|---|
| `ScratchDirOwnershipGuardTests` | 3/3 |
| the 10 prefix-less-conversion classes | 44/44 |
| CountBaseline / CollateralFailure / PartialSuiteLoss / Win32Stubs / AppLoader\* / JsonLoader / ScratchDirs\* / JUnit / AssemblyTypeIndex / ManifestCompilationTarget / InstallBaselineKeySymbolState / CorruptSidecar | 177/179 — the 2 are pre-existing and environmental, see below |
| the 8 `--cache` classes, **cold** | 8/8, 55 s |
| the 8 `--cache` classes, **warm** | 8/8, 45 s |
| Layered\* / SiblingSymbols / FlowFieldNoise / CleanRunVerbosity / CountBaselineIntegration / EngineVariants / DotNetTargetScope / ArtifactDownloader / ReportLayout | 63/63 |
| Watch\* / NclShadow\* / PhaseLogServerKill / SuiteAbort / Server\* / PerSuite+QueryColumn diagnostics / TestPage\* / TestDataProvisioning | 93/93 |
| `TableRelationWhereFieldLinkTests` after conversion | 5/5 |

Ran the cache-touching set twice per `local-test-scope.md`; both passes green, and the second was faster rather than differently-behaved. Did **not** run the whole `AlRunner.Tests` sweep — CI does that on eight legs, and the diff is confined to test scratch paths.

The two failures are `CollateralFailureReportingTests.BundleProgress_*`, which compare a formatted elapsed time and so depend on the ambient locale's decimal separator (`30,9s` on this box's `en_DK.UTF-8`). Not mine — they pass under `LC_ALL=C`, and they touch none of the lines I changed in that file. Filed as #2968.

## Filed rather than silently fixed

- **#2967** — the same scan over `AlRunner/` found 8 runner-side temp sites `ScratchDirs`'s own header does not list. Two of them (`al-runner-query-symbols/<module>.json`, `al-runner-precompile/<pub>_<name>_<ver>`) key a directory on a *name* and then truncate or overwrite it, which is the shape #2586 fixed for `al-runner-sibling-symbols` after two concurrent runners deleted each other's symbols mid-compile. I did not reproduce a break; I am reporting the shape. Out of this issue's scope, and each site needs a decision rather than a mechanical conversion — `al-runner-pkgdedup` is content-addressed and deliberately shared.
- **#2968** — the locale-dependent assertions above.

Opened by the impl-20 agent (Claude) on Stefan's behalf.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
