### PR TITLE
fix(table-relation): read a namespace-qualified target instead of refusing the relation

### DIFF
--- a/AlRunner.Tests/NamespaceQualifiedRelationTargetTests.cs
+++ b/AlRunner.Tests/NamespaceQualifiedRelationTargetTests.cs
@@ -1,0 +1,362 @@
+// NamespaceQualifiedRelationTargetTests — runner-mechanism guard for #2851.
+//
+// The gap
+// -------
+// AL lets a TableRelation target, and a CalcFormula source, name their table through its
+// NAMESPACE: `Microsoft.Manufacturing.Capacity."Capacity Ledger Entry"`. The runner's parser
+// counted the dot-separated parts of that name and accepted only one (`Table`) or two
+// (`Table.Field` / `Namespace.Table`), refusing anything longer — so the WHOLE relation was
+// dropped and FieldRef.Relation answered 0, which AL cannot distinguish from "this field
+// declares no TableRelation" (#2851, the same silent zero #2518 was reported as).
+//
+// CalcFormula had the same blind spot from the other direction: it never split the name at
+// all, taking `Left.ToString()` verbatim, so a namespace-qualified source table arrived as the
+// literal string "Microsoft.Manufacturing.Forecast.\"Production Forecast Entry\"", matched no
+// table, and BuildMetaCalcFormula returned null — a FlowField that silently never computes.
+//
+// Measured on Base Application 28.1.49838.53910 by reading SymbolReference.json directly:
+// 8 of the 7,787 relation-bearing fields name a namespace-qualified target (one of the 8,
+// Item."Production Forecast Name", is a FlowFilter and is skipped a level earlier by the
+// #2781 field-class gate, which is why #2851 counts 7 reaching the parser), and 4 of the
+// 2,055 CalcFormula properties name a namespace-qualified source table:
+//
+//   Gen. Journal Line."Alloc. Acc. Modified by User"  exist(Microsoft.Finance.AllocationAccount."Alloc. Acc. Manual Override" where(...))
+//   Item."Prod. Forecast Quantity (Base)"             sum(Microsoft.Manufacturing.Forecast."Production Forecast Entry"."Forecast Quantity (Base)" where(...))
+//   Purchase Line."Alloc. Acc. Modified by User"      exist(Microsoft.Finance.AllocationAccount."Alloc. Acc. Manual Override" where(...))
+//   User Group Plan."Plan Name"                       lookup(System.Azure.Identity.Plan.Name where(...))
+//
+// What this file pins
+// -------------------
+// The runner-only C# mechanism: what BcAppSymbolCache reads back out of a PRECOMPILED
+// dependency's SymbolReference.json for a field whose TableRelation target, or whose
+// CalcFormula source, is namespace-qualified. The BC-observable claim underneath it — that a
+// namespace-qualified TableRelation still makes FieldRef.Relation answer the related table's
+// id — is plain BC behaviour and belongs upstream in the al-language corpus against a real
+// service tier, not here.
+//
+// Why the assertions are about the LAST TWO parts rather than a resolved table id
+// -------------------------------------------------------------------------------
+// Splitting `Namespace.Parts.Table` from `Namespace.Parts.Table."Field"` needs symbol
+// resolution, which the parser does not have; the id resolution happens later, in
+// BuildMetaFieldRelations, which already disambiguates a two-part name by trying `Table.Field`
+// first and falling back to reading the last part as the table. So the parser's job is to stop
+// refusing and to hand that resolver the two parts it can act on, and that is what is asserted
+// here. Verified against the real closure (Base Application + System Application + Business
+// Foundation + System.app, 28.1) that the fallback lands on the right table for all six
+// distinct shapes Base Application actually ships: `Capacity`, `Forecast`, `Identity` and
+// `Reflection` are namespace segments that are NOT table names, while `Plan`,
+// `AllObjWithCaption` and `Production Forecast Name` are real tables that really do carry the
+// field named after them.
+//
+// The .app shape below (a plain zip holding SymbolReference.json) mirrors
+// TableRelationWhereFieldLinkTests and BcAppSymbolCacheReportTests.
+
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// #1821: BcAppSymbolCache.Get() resolves its on-disk path through the process-global
+// CacheRoots override, so this joins CacheRootsSerialCollection for the same reason
+// BcAppSymbolCacheReportTests does.
+[Collection(CacheRootsSerialCollection.Name)]
+public class NamespaceQualifiedRelationTargetTests
+{
+    private const int TargetTableId = 88512701;
+    private const int ChildTableId = 88512702;
+
+    private static string WriteApp(string dir, string symbolReferenceJson)
+    {
+        var appPath = Path.Combine(dir, Guid.NewGuid().ToString("N") + ".app");
+        using var zip = new FileStream(appPath, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+        return appPath;
+    }
+
+    // The namespace segments are named so that neither can be mistaken for the table: no
+    // table is called "NqrRoot" or "NqrLeaf", and the target table's own name shares no word
+    // with them. That matters because the assertion below is about WHICH two parts survive —
+    // a fix that kept the FIRST two parts, or that kept the whole dotted string as one name,
+    // would produce a different pair and fail rather than pass.
+    //
+    // Field 2 is `Namespace.Namespace.Table` (last part IS the table); field 3 is
+    // `Namespace.Namespace.Table.Field` (last part is the FIELD). Those two shapes are the
+    // two Base Application actually ships and they disagree about what the last part means,
+    // so both are pinned. Field 4 is the two-part form that parsed before #2851 and must keep
+    // parsing. Field 5 declares no TableRelation at all. Fields 6 and 7 put a namespace-
+    // qualified target inside a where() clause and inside an if/else chain, so a fix that
+    // only handled the bare unconditional shape does not pass. Field 12 is a namespace-
+    // qualified CalcFormula source with no field part (count), field 13 the same with one
+    // (sum), and field 14 the un-namespaced control for both.
+    private const string SymbolReference = """
+        {
+          "RuntimeVersion": "15.1",
+          "Namespaces": [
+            {
+              "Name": "NQR",
+              "Tables": [
+                {
+                  "Id": 88512701,
+                  "Name": "NQR Target",
+                  "Fields": [
+                    { "Id": 1, "Name": "Code", "TypeDefinition": { "Name": "Code", "Subtype": { "Name": "20" } } },
+                    { "Id": 2, "Name": "Target Group", "TypeDefinition": { "Name": "Code", "Subtype": { "Name": "20" } } },
+                    { "Id": 3, "Name": "Name", "TypeDefinition": { "Name": "Code", "Subtype": { "Name": "50" } } },
+                    { "Id": 4, "Name": "Amount", "TypeDefinition": { "Name": "Decimal" } }
+                  ],
+                  "Keys": [ { "Name": "PK", "FieldNames": [ "Code" ] } ]
+                },
+                {
+                  "Id": 88512702,
+                  "Name": "NQR Child",
+                  "Fields": [
+                    { "Id": 1, "Name": "Entry No.", "TypeDefinition": { "Name": "Integer" } },
+                    {
+                      "Id": 2, "Name": "Ns Table Only",
+                      "TypeDefinition": { "Name": "Code", "Subtype": { "Name": "20" } },
+                      "Properties": [
+                        { "Name": "TableRelation", "Value": "NqrRoot.NqrLeaf.\"NQR Target\"" }
+                      ]
+                    },
+                    {
+                      "Id": 3, "Name": "Ns Table And Field",
+                      "TypeDefinition": { "Name": "Code", "Subtype": { "Name": "50" } },
+                      "Properties": [
+                        { "Name": "TableRelation", "Value": "NqrRoot.NqrLeaf.\"NQR Target\".Name" }
+                      ]
+                    },
+                    {
+                      "Id": 4, "Name": "Plain Ref",
+                      "TypeDefinition": { "Name": "Code", "Subtype": { "Name": "20" } },
+                      "Properties": [
+                        { "Name": "TableRelation", "Value": "\"NQR Target\".\"Code\"" }
+                      ]
+                    },
+                    { "Id": 5, "Name": "No Relation", "TypeDefinition": { "Name": "Code", "Subtype": { "Name": "20" } } },
+                    {
+                      "Id": 6, "Name": "Ns With Where",
+                      "TypeDefinition": { "Name": "Code", "Subtype": { "Name": "20" } },
+                      "Properties": [
+                        { "Name": "TableRelation", "Value": "NqrRoot.NqrLeaf.\"NQR Target\".\"Code\" where(\"Target Group\" = const('GRP'))" }
+                      ]
+                    },
+                    {
+                      "Id": 7, "Name": "Ns Conditional",
+                      "TypeDefinition": { "Name": "Code", "Subtype": { "Name": "20" } },
+                      "Properties": [
+                        { "Name": "TableRelation", "Value": "if (Kind = const(A)) NqrRoot.NqrLeaf.\"NQR Target\".\"Code\"\r\n            else\r\n            \"NQR Target\".\"Code\"" }
+                      ]
+                    },
+                    {
+                      "Id": 8, "Name": "Kind",
+                      "TypeDefinition": { "Name": "Option" },
+                      "Properties": [ { "Name": "OptionMembers", "Value": "A,B" } ]
+                    },
+                    { "Id": 9, "Name": "Child Group", "TypeDefinition": { "Name": "Code", "Subtype": { "Name": "20" } } },
+                    {
+                      "Id": 12, "Name": "Ns Count",
+                      "TypeDefinition": { "Name": "Integer" },
+                      "Properties": [
+                        { "Name": "FieldClass", "Value": "FlowField" },
+                        { "Name": "CalcFormula", "Value": "count(NqrRoot.NqrLeaf.\"NQR Target\")" }
+                      ]
+                    },
+                    {
+                      "Id": 13, "Name": "Ns Sum",
+                      "TypeDefinition": { "Name": "Decimal" },
+                      "Properties": [
+                        { "Name": "FieldClass", "Value": "FlowField" },
+                        { "Name": "CalcFormula", "Value": "sum(NqrRoot.NqrLeaf.\"NQR Target\".Amount where(\"Target Group\" = field(\"Child Group\")))" }
+                      ]
+                    },
+                    {
+                      "Id": 14, "Name": "Plain Count",
+                      "TypeDefinition": { "Name": "Integer" },
+                      "Properties": [
+                        { "Name": "FieldClass", "Value": "FlowField" },
+                        { "Name": "CalcFormula", "Value": "count(\"NQR Target\")" }
+                      ]
+                    }
+                  ],
+                  "Keys": [ { "Name": "PK", "FieldNames": [ "Entry No." ] } ]
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private static ParsedField FieldOf(string appPath, int tableId, int fieldId)
+    {
+        var table = Assert.Single(BcAppSymbolCache.Get(appPath).Tables, t => t.TableId == tableId);
+        return Assert.Single(table.Fields, f => f.FieldId == fieldId);
+    }
+
+    private static string NewDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void NamespaceQualifiedTarget_IsCarried_KeepingTheLastTwoNameParts()
+    {
+        var dir = NewDir();
+        try
+        {
+            var appPath = WriteApp(dir, SymbolReference);
+
+            // `NqrRoot.NqrLeaf."NQR Target"` — the last part IS the table, so the pair handed
+            // to BuildMetaFieldRelations reads as `NqrLeaf."NQR Target"`, which its existing
+            // Table.Field-first / Namespace.Table-fallback resolver lands on the table. Before
+            // #2851 RelationArms was null here: the whole relation refused for having three
+            // parts, which every consumer reads as "declares no TableRelation".
+            var tableOnly = FieldOf(appPath, ChildTableId, 2);
+            Assert.NotNull(tableOnly.RelationArms);
+            var tableOnlyArm = Assert.Single(tableOnly.RelationArms!);
+            Assert.Equal("NqrLeaf", tableOnlyArm.TableName);
+            Assert.Equal("NQR Target", tableOnlyArm.FieldName);
+            Assert.Empty(tableOnlyArm.Conditions);
+            Assert.Empty(tableOnlyArm.Filters);
+
+            // `NqrRoot.NqrLeaf."NQR Target".Name` — four parts, and here the last part is the
+            // FIELD. The two shapes disagree about what the last part means, so keeping the
+            // last two is the only reading that serves both; asserting them apart is what
+            // stops a fix that always treats the last part as the table.
+            var tableAndField = FieldOf(appPath, ChildTableId, 3);
+            var tableAndFieldArm = Assert.Single(tableAndField.RelationArms!);
+            Assert.Equal("NQR Target", tableAndFieldArm.TableName);
+            Assert.Equal("Name", tableAndFieldArm.FieldName);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void NamespaceQualifiedTarget_KeepsItsWhereClauseAndItsArms()
+    {
+        var dir = NewDir();
+        try
+        {
+            var appPath = WriteApp(dir, SymbolReference);
+
+            // A where() clause on a namespace-qualified target must survive with it. Dropping
+            // the filter while keeping the target would WIDEN the relation — Validate would
+            // start accepting rows outside the filter, a wrong answer rather than a missing
+            // one.
+            var withWhere = Assert.Single(FieldOf(appPath, ChildTableId, 6).RelationArms!);
+            Assert.Equal("NQR Target", withWhere.TableName);
+            Assert.Equal("Code", withWhere.FieldName);
+            var f = Assert.Single(withWhere.Filters);
+            Assert.Equal(ParsedCalcFilterKind.Const, f.Kind);
+            Assert.Equal("Target Group", f.SourceFieldName);
+            Assert.Equal("GRP", f.Value);
+
+            // An if/else chain with the qualified target in the FIRST arm only. Both arms must
+            // arrive, and in order: a fix that refused the chain the moment one arm was
+            // qualified would lose the un-qualified arm too, which is exactly how the
+            // whole-property refusal behaved.
+            var arms = FieldOf(appPath, ChildTableId, 7).RelationArms;
+            Assert.NotNull(arms);
+            Assert.Equal(2, arms!.Count);
+            Assert.Equal("NQR Target", arms[0].TableName);
+            Assert.Equal("Code", arms[0].FieldName);
+            Assert.Equal(ParsedCalcFilterKind.Const, Assert.Single(arms[0].Conditions).Kind);
+            Assert.Equal("Kind", Assert.Single(arms[0].Conditions).SourceFieldName);
+            // The else arm carries no condition of its own — BC's own shape, pinned upstream.
+            Assert.Equal("NQR Target", arms[1].TableName);
+            Assert.Equal("Code", arms[1].FieldName);
+            Assert.Empty(arms[1].Conditions);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void UnqualifiedRelations_AreUnchanged_AndAFieldWithoutOneStillHasNoArms()
+    {
+        var dir = NewDir();
+        try
+        {
+            var appPath = WriteApp(dir, SymbolReference);
+
+            // Positive control: the two-part shape that already worked must still produce the
+            // same pair, so "the parser stopped counting parts at all" is not what makes the
+            // tests above pass.
+            var plain = Assert.Single(FieldOf(appPath, ChildTableId, 4).RelationArms!);
+            Assert.Equal("NQR Target", plain.TableName);
+            Assert.Equal("Code", plain.FieldName);
+
+            // Negative direction: a field with no TableRelation must still carry no arms.
+            // Without this, "RelationArms is never null any more" would pass as a fix and
+            // FieldRef.Relation would start answering non-zero for fields that declare
+            // nothing.
+            Assert.Null(FieldOf(appPath, ChildTableId, 5).RelationArms);
+
+            // Control: the .app is genuinely readable and both tables arrived, so every
+            // "is null" assertion is an observation rather than a vacuous "nothing loaded".
+            var tables = BcAppSymbolCache.Get(appPath).Tables;
+            Assert.Contains(tables, t => t.TableId == TargetTableId);
+            Assert.Contains(tables, t => t.TableId == ChildTableId);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void NamespaceQualifiedCalcFormulaSource_ResolvesToTheTableName()
+    {
+        var dir = NewDir();
+        try
+        {
+            var appPath = WriteApp(dir, SymbolReference);
+
+            // count/exist carry a table and no field, so the last part is unambiguously the
+            // table — no fallback needed, unlike the TableRelation case. Before #2851 this was
+            // the literal string `NqrRoot.NqrLeaf."NQR Target"`, which matched no table, and
+            // BuildMetaCalcFormula returned null: the FlowField silently never computed.
+            var nsCount = FieldOf(appPath, ChildTableId, 12);
+            Assert.NotNull(nsCount.CalcFormula);
+            Assert.Equal("Count", nsCount.CalcFormula!.FormulaType, ignoreCase: true);
+            Assert.Equal("NQR Target", nsCount.CalcFormula.SourceTableName);
+            Assert.Null(nsCount.CalcFormula.SourceFieldName);
+
+            // sum/lookup carry Table.Field, so the namespace sits inside the LEFT half only —
+            // the field name must come through untouched, and the where() clause with it.
+            var nsSum = FieldOf(appPath, ChildTableId, 13);
+            Assert.NotNull(nsSum.CalcFormula);
+            Assert.Equal("Sum", nsSum.CalcFormula!.FormulaType, ignoreCase: true);
+            Assert.Equal("NQR Target", nsSum.CalcFormula.SourceTableName);
+            Assert.Equal("Amount", nsSum.CalcFormula.SourceFieldName);
+            var w = Assert.Single(nsSum.CalcFormula.Filters);
+            Assert.Equal(ParsedCalcFilterKind.Field, w.Kind);
+            Assert.Equal("Target Group", w.SourceFieldName);
+            Assert.Equal("Child Group", w.ParentFieldName);
+
+            // Positive control: the un-namespaced form must be unchanged, so a fix that
+            // mangled every CalcFormula source name equally would not pass.
+            var plainCount = FieldOf(appPath, ChildTableId, 14);
+            Assert.NotNull(plainCount.CalcFormula);
+            Assert.Equal("NQR Target", plainCount.CalcFormula!.SourceTableName);
+
+            // Negative direction: a field that is not a FlowField has no CalcFormula at all.
+            Assert.Null(FieldOf(appPath, ChildTableId, 4).CalcFormula);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -142,7 +142,13 @@ internal static partial class BcAppSymbolCache
     // RapidStart's Relation Table ID stays 0, and Validate() skips the relation check. The
     // schema did not change, so a v27 payload loads without error and replays the pre-fix
     // wrong answer instead of missing — which is precisely what the bump is for.
-    private const int CacheVersion = 28;
+    // v29: the same shape once more, one level up in the name (#2851). RelationArms and
+    // CalcFormula now carry a NAMESPACE-QUALIFIED table name, which the parser refused for
+    // having 3+ parts (relation) or never resolved at all (CalcFormula) — 8 Base Application
+    // 28.1 relations cached as RelationArms = null and 4 FlowFields with a source table that
+    // matches nothing. Same reason for the bump as v28: the schema is unchanged, so a v28
+    // payload loads WITHOUT error and replays those pre-fix wrong answers rather than missing.
+    private const int CacheVersion = 29;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
     // Issue #1820 — path -> content-hash memo. ComputeAppContentHash needs to read the
     // WHOLE .app to hash it (unlike the FileInfo.Length/LastWriteTimeUtc stat it replaced,

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -384,9 +384,11 @@ public static partial class RecordPatches
         var arms = new List<ParsedRelationArm>();
         for (var node = tr; node != null; node = node.ElseExpression?.ElseTableRelationCondition)
         {
-            var parts = NameParts(node.RelatedTableField);
-            // 1 part = table; 2 parts = table + field. A 3+-part (namespace-qualified) name
-            // is ambiguous without symbol resolution, so the relation stays uncaptured.
+            var parts = RelationTargetNameParts(node.RelatedTableField);
+            // 1 part = table; 2 parts = table + field, OR namespace + table — BuildMetaFieldRelations
+            // tries both readings and that ambiguity is already its job. RelationTargetNameParts drops
+            // any leading namespace segments (#2851), so reaching here with any other count means the
+            // name did not read as a name at all, and the relation stays uncaptured.
             if (parts.Count is not (1 or 2))
             {
                 Console.Error.WriteLine(
@@ -523,6 +525,64 @@ public static partial class RecordPatches
         }
         Walk(name);
         return parts;
+    }
+
+    /// <summary>
+    /// The parts of a TableRelation TARGET name, with any namespace qualification dropped:
+    /// at most the last two (#2851).
+    /// <para>AL lets a relation name its table through the table's namespace, and Base
+    /// Application does — <c>Microsoft.Manufacturing.Capacity."Capacity Ledger Entry"</c>,
+    /// <c>System.Azure.Identity.Plan."Plan ID"</c>, and six other shapes across 8 fields of
+    /// 28.1.49838.53910. Those used to be refused for having three or more parts, which drops
+    /// the WHOLE relation, so <c>FieldRef.Relation</c> answered 0 — the value that also means
+    /// "this field declares no TableRelation" (#2851, the silent zero #2518 was reported as).
+    /// </para>
+    /// <para>Object names are global in AL — the namespace organises source, it does not
+    /// namespace the name a relation resolves by — so the namespace segments carry no
+    /// information the runner needs and are dropped here rather than plumbed through
+    /// <see cref="ParsedRelationArm"/> and the on-disk symbol cache.</para>
+    /// <para>Keeping the last TWO, not the last one, is what makes both shipped shapes work:
+    /// the last part is the TABLE in <c>NS.NS.Table</c> but the FIELD in
+    /// <c>NS.NS.Table."Field"</c>, and nothing here can tell them apart without symbol
+    /// resolution. That ambiguity is not new and is not this method's to settle —
+    /// <c>BuildMetaFieldRelations</c> already disambiguates a two-part name by trying
+    /// <c>Table.Field</c> first and falling back to reading the last part as the table, so
+    /// handing it the last two parts routes the namespace-qualified shapes through the resolver
+    /// that already exists. Checked against the real 28.1 closure (Base Application + System
+    /// Application + Business Foundation + System.app): every namespace segment Base
+    /// Application uses in this position — <c>Capacity</c>, <c>Forecast</c>, <c>Identity</c>,
+    /// <c>Reflection</c> — is not a table name, so the fallback fires and lands on the right
+    /// table, while <c>Plan</c>, <c>AllObjWithCaption</c> and <c>Production Forecast Name</c>
+    /// are real tables that really do carry the field named after them.</para>
+    /// </summary>
+    private static List<string> RelationTargetNameParts(NavSyntax.NameSyntax? name)
+    {
+        var parts = NameParts(name);
+        return parts.Count <= 2 ? parts : parts.GetRange(parts.Count - 2, 2);
+    }
+
+    /// <summary>
+    /// The last part of a (possibly namespace-qualified) name — the table name a CalcFormula
+    /// source resolves by (#2851).
+    /// <para>Unlike a TableRelation target this is unambiguous: <c>count</c>/<c>exist</c> carry
+    /// a table and no field, and <c>sum</c>/<c>lookup</c>/<c>average</c>/<c>min</c>/<c>max</c>
+    /// carry <c>Table.Field</c> as a qualified name whose Left half is the table, so in both
+    /// positions the last part IS the table and no fallback reading is needed.</para>
+    /// <para>This read the name's whole text before #2851, so a namespace-qualified source
+    /// arrived as the literal <c>Microsoft.Manufacturing.Forecast."Production Forecast Entry"</c>,
+    /// matched no table, and <c>BuildMetaCalcFormula</c> returned null — a FlowField that
+    /// silently never computes. Four Base Application 28.1 FlowFields are that shape:
+    /// Gen. Journal Line and Purchase Line's "Alloc. Acc. Modified by User",
+    /// Item."Prod. Forecast Quantity (Base)" and User Group Plan."Plan Name".</para>
+    /// <para><paramref name="fallbackText"/> is the pre-#2851 expression, used when the node is
+    /// a NameSyntax shape <see cref="NameParts"/> does not walk. Without it an unrecognised
+    /// shape would yield the empty string, which <c>CalcFormulaFrom</c> refuses — turning a
+    /// formula that used to parse into a refused one, a regression rather than a fix.</para>
+    /// </summary>
+    private static string LastNamePart(NavSyntax.NameSyntax? name, string? fallbackText)
+    {
+        var parts = NameParts(name);
+        return parts.Count > 0 ? parts[^1] : Unquote(fallbackText?.Trim() ?? "");
     }
 
     private static void TryParseTableFile(string text)
@@ -690,14 +750,14 @@ public static partial class RecordPatches
         {
             case NavSyntax.FieldCalculationFormulaSyntax f:
                 formulaType = f.FormulaKeywordToken.ValueText;
-                sourceTableName = Unquote(f.Field?.Left?.ToString()?.Trim() ?? "");
+                sourceTableName = LastNamePart(f.Field?.Left, f.Field?.Left?.ToString());
                 sourceFieldName = f.Field?.Right == null ? null : Unquote(f.Field.Right.ToString().Trim());
                 where = f.WhereExpression;
                 signText = f.Sign.ValueText ?? "";
                 break;
             case NavSyntax.TableCalculationFormulaSyntax t:
                 formulaType = t.FormulaKeywordToken.ValueText;
-                sourceTableName = Unquote(t.Table?.ToString()?.Trim() ?? "");
+                sourceTableName = LastNamePart(t.Table, t.Table?.ToString());
                 sourceFieldName = null; // count/exist have no field part
                 where = t.WhereExpression;
                 signText = t.Sign.ValueText ?? "";

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -512,3 +512,9 @@ not computed. appGroups is unchanged: every new test joined the single existing 
 group, and al-language carries no byBcVersion override -- CI's eight legs confirm whether one is
 needed. Only the al-language number moved here; the runner-extras values are main's, taken
 unmodified through a rebase conflict in this file.
+
+The runner-extras `testpage-lookup-tablerelation-oos` group (3 tests, issue #2775) is a new app
+group, so it adds a line rather than moving a number: expected tests on every leg go up by 3 and
+expected app groups by 1, both derived from the line and neither written out anywhere. No
+`absentOn` -- the bundle declares `platform`/`application` 27.0.0.0, so it runs on all eight
+legs. The 3 is measured from an actual run of that bundle, not counted off the source.

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -50,6 +50,7 @@
         "tableext-eviction-subscriber-timing": { "tests": 2 },
         "tableext-eviction-subscriber-timing-dep": { "tests": 0 },
         "temporary-virtual-table-isolation": { "tests": 6 },
+        "testpage-lookup-tablerelation-oos": { "tests": 3 },
         "testpage-precompiled-dep-control": { "tests": 2 },
         "testpage-precompiled-member-names": { "tests": 7 },
         "testpage-promoted-actionref": { "tests": 9 },

--- a/tests/runner-extras/testpage-lookup-tablerelation-oos/TlrAssert.Codeunit.al
+++ b/tests/runner-extras/testpage-lookup-tablerelation-oos/TlrAssert.Codeunit.al
@@ -1,0 +1,16 @@
+// Standalone Assert codeunit — this suite must stand alone (README.md), it does not
+// import from tests/al-language.
+codeunit 65560 "Tlr Assert"
+{
+    procedure AreEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if Format(Expected) <> Format(Actual) then
+            Error('Expected %1 but got %2: %3', Format(Expected), Format(Actual), Msg);
+    end;
+
+    procedure ExpectedError(Fragment: Text)
+    begin
+        if StrPos(GetLastErrorText(), Fragment) = 0 then
+            Error('Expected error containing ''%1'' but got ''%2''', Fragment, GetLastErrorText());
+    end;
+}

--- a/tests/runner-extras/testpage-lookup-tablerelation-oos/TlrCard.Page.al
+++ b/tests/runner-extras/testpage-lookup-tablerelation-oos/TlrCard.Page.al
@@ -1,0 +1,29 @@
+page 65562 "Tlr Card"
+{
+    PageType = Card;
+    SourceTable = "Tlr Row";
+    ApplicationArea = All;
+    UsageCategory = None;
+
+    layout
+    {
+        area(Content)
+        {
+            field("No."; Rec."No.") { ApplicationArea = All; }
+            // No OnLookup here, and none on the table field either.
+            field("Relation Only"; Rec."Relation Only") { ApplicationArea = All; }
+            // No OnLookup here; the TABLE field has one.
+            field("Table Trigger"; Rec."Table Trigger") { ApplicationArea = All; }
+            field("Control Trigger"; Rec."Control Trigger")
+            {
+                ApplicationArea = All;
+
+                trigger OnLookup(var Text: Text): Boolean
+                begin
+                    Text := 'FROM-CONTROL';
+                    exit(true);
+                end;
+            }
+        }
+    }
+}

--- a/tests/runner-extras/testpage-lookup-tablerelation-oos/TlrRow.Table.al
+++ b/tests/runner-extras/testpage-lookup-tablerelation-oos/TlrRow.Table.al
@@ -1,0 +1,47 @@
+// Three fields, one per case RunnerPageInstance.RaiseOnLookup has to tell apart. The two
+// trigger-bearing fields write a value naming WHERE the trigger ran, so a failure reports
+// which handler fired and not only that the wrong one did.
+table 65561 "Tlr Row"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20])
+        {
+            DataClassification = CustomerContent;
+        }
+        // The subject. No trigger on either side, so on real BC the lookup comes from the
+        // TableRelation and opens table 65561's list page. The relation points back at this
+        // same table on purpose: it keeps the bundle to one table, and the refusal does not
+        // depend on which table is named.
+        field(2; "Relation Only"; Code[20])
+        {
+            DataClassification = CustomerContent;
+            TableRelation = "Tlr Row"."No.";
+        }
+        // Scoping control: the table field carries the trigger and the page control does not.
+        field(3; "Table Trigger"; Code[20])
+        {
+            DataClassification = CustomerContent;
+
+            trigger OnLookup()
+            begin
+                "Table Trigger" := 'FROM-TABLE';
+            end;
+        }
+        // Scoping control: the page control carries the trigger (see Tlr Card).
+        field(4; "Control Trigger"; Code[20])
+        {
+            DataClassification = CustomerContent;
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/runner-extras/testpage-lookup-tablerelation-oos/TlrTests.Codeunit.al
+++ b/tests/runner-extras/testpage-lookup-tablerelation-oos/TlrTests.Codeunit.al
@@ -1,0 +1,99 @@
+// Issue #2775 — runner-specific half of the TestPage OnLookup contract.
+//
+// AL spells OnLookup two unrelated ways: `trigger OnLookup(var Text: Text): Boolean` on a page
+// control, and a parameterless `trigger OnLookup()` on a table field that writes into Rec
+// itself. Real BC tries the control first, then the table field, and then falls back to the
+// field's TableRelation, which opens the related table's list page.
+//
+// The first two run here. The third cannot: standing up a list page needs a client the runner
+// does not have. So it refuses by name with RunnerOutOfScopeException and reason
+// `testpage-lookup` (docs/scope.md), instead of doing nothing — doing nothing is what let a
+// test invoke a lookup, observe no change, and compare two empty strings successfully, which is
+// the failure mode .claude/rules/loud-failures.md exists for.
+//
+// Everything that is plain BC behaviour — that BC runs the table field's trigger, and that a
+// control trigger wins over it — is proven upstream in the al-language corpus against a real
+// service tier. What is asserted here is the runner's own refusal, from inside AL through
+// asserterror and GetLastErrorText, which is the surface a consumer meets.
+codeunit 65563 "Tlr Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Tlr Assert";
+
+    local procedure OpenOn(var Card: TestPage "Tlr Card")
+    var
+        Row: Record "Tlr Row";
+    begin
+        Row.DeleteAll();
+        Row.Init();
+        Row."No." := 'R1';
+        Row.Insert();
+        Card.OpenEdit();
+        Card.GoToRecord(Row);
+    end;
+
+    [Test]
+    procedure Lookup_TableRelationOnly_IsRefusedByName()
+    var
+        Card: TestPage "Tlr Card";
+    begin
+        // The subject. Neither the control nor the table field declares an OnLookup, so the
+        // only lookup this field has is its TableRelation's list page.
+        OpenOn(Card);
+
+        asserterror Card."Relation Only".Lookup();
+
+        // Each fragment is a separate assertion because each carries a different part of the
+        // contract, and a message change that dropped any one of them would leave a consumer
+        // without it. Naming them individually also keeps this from being a bare asserterror,
+        // which would pass on any error at all — including the runner failing to open the page.
+        Assert.ExpectedError('out-of-scope:');
+        Assert.ExpectedError('testpage-lookup');
+        Assert.ExpectedError('neither the control nor its source table field declares an');
+        Assert.ExpectedError('OnLookup trigger');
+        // The reason the refusal exists, and the part a reader needs in order to know this is
+        // a scope boundary and not a bug in their AL.
+        Assert.ExpectedError('would open the related table''s list page');
+
+        Card.Close();
+    end;
+
+    [Test]
+    procedure Lookup_TableFieldTrigger_Runs()
+    var
+        Card: TestPage "Tlr Card";
+    begin
+        // Scoping control: the refusal is keyed on there being NO trigger, not on the control
+        // declaring none. Without this a runner that refused every control without its own
+        // OnLookup would pass the test above and still be wrong — which is exactly what #2549
+        // reported.
+        OpenOn(Card);
+
+        Card."Table Trigger".Lookup();
+
+        Assert.AreEqual('FROM-TABLE', Card."Table Trigger".Value,
+            'the table field''s OnLookup must run when the page control declares none');
+
+        Card.Close();
+    end;
+
+    [Test]
+    procedure Lookup_ControlTrigger_Runs()
+    var
+        Card: TestPage "Tlr Card";
+    begin
+        // The other scoping control, and the reason the three fields sit on one page: a fix
+        // that turned the refusal above into a no-op would pass this and the test above, so
+        // all three have to run together for any of them to mean anything.
+        OpenOn(Card);
+
+        Card."Control Trigger".Lookup();
+
+        Assert.AreEqual('FROM-CONTROL', Card."Control Trigger".Value,
+            'the page control''s OnLookup must run and write its text back to the field');
+
+        Card.Close();
+    end;
+}

--- a/tests/runner-extras/testpage-lookup-tablerelation-oos/app.json
+++ b/tests/runner-extras/testpage-lookup-tablerelation-oos/app.json
@@ -1,0 +1,19 @@
+{
+  "id": "7a41d0c6-3e58-4b92-9d17-6f2c85b31ae4",
+  "name": "Runner Extras - TestPage Lookup TableRelation OOS",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Issue #2775: a TestPage field whose lookup could only come from a TableRelation must keep refusing by name with reason testpage-lookup, and the two shapes that DO have a trigger must keep running.",
+  "description": "Runner-specific claim, not a claim about AL. On real BC a field with no page-control OnLookup and no table-field OnLookup still has a lookup: the TableRelation opens the related table's list page. The runner cannot stand a list page up, so it refuses by name instead of doing nothing -- doing nothing is what let a test invoke a lookup, observe no change, and compare two empty strings successfully. AlRunner.Tests/TestPageFieldTableLookupTests pins the same three cases from outside, by matching the runner's console output; this asserts them from inside AL through asserterror and GetLastErrorText, which is the surface a consumer actually meets, and it runs on all eight BC legs rather than only the two that carry AlRunner.Tests.",
+  "dependencies": [],
+  "idRanges": [
+    {
+      "from": 65560,
+      "to": 65569
+    }
+  ],
+  "platform": "27.0.0.0",
+  "application": "27.0.0.0",
+  "runtime": "15.0",
+  "target": "Cloud"
+}


### PR DESCRIPTION
Closes #2851
Closes #2775

Two independent pieces of work, one PR because they were assigned together. They are **not** two halves of one behavior — see "On #2775" below.

---

## #2851 — a namespace-qualified TableRelation target was refused

AL lets a `TableRelation` target, and a `CalcFormula` source, name its table through the table's **namespace**. Object names are global in AL; the namespace organizes source and is not part of the name a relation resolves by. So `Microsoft.Manufacturing.Capacity."Capacity Ledger Entry"` means the same table as `"Capacity Ledger Entry"`.

The parser counted the dot-separated parts of a relation target and accepted only one (`Table`) or two (`Table.Field` / `Namespace.Table`). A name with three or more parts refused the **whole** relation, so `FieldRef.Relation` answered 0 — the same value that means "this field declares no `TableRelation`", and the silent zero #2518 was originally reported as.

### The sibling function had the same blind spot (question 2)

`CalcFormulaFrom` never split the name at all. It read `Left.ToString()` verbatim, so a namespace-qualified source table arrived as the literal string `Microsoft.Manufacturing.Forecast."Production Forecast Entry"`, matched no table, and `BuildMetaCalcFormula` returned null — a FlowField that silently never computes.

### Measured, not estimated

Read directly out of `SymbolReference.json` for Base Application 28.1.49838.53910:

| | count |
|---|---|
| fields carrying a `TableRelation` | 7,787 |
| of those, namespace-qualified target | **8** |
| `CalcFormula` properties | 2,055 |
| of those, namespace-qualified source | **4** |

The 8 reconcile with the 7 in #2851: `Item."Production Forecast Name"` is a FlowFilter and is dropped one level earlier by the #2781 field-class gate, so only 7 reach the parser.

The four FlowFields are `Gen. Journal Line."Alloc. Acc. Modified by User"`, `Purchase Line."Alloc. Acc. Modified by User"`, `Item."Prod. Forecast Quantity (Base)"` and `User Group Plan."Plan Name"`.

### The fix

A relation target keeps the **last two** name parts. Keeping only the last one does not work, because the two shapes Base Application ships disagree about what the last part means: it is the table in `NS.NS.Table` and the field in `NS.NS.Table."Field"`. Nothing in the parser can tell them apart without symbol resolution — and it does not have to, because `BuildMetaFieldRelations` already disambiguates a two-part name by trying `Table.Field` first and falling back to reading the last part as the table. Handing it the last two parts routes the namespace-qualified shapes through the resolver that already exists, so this change adds no second resolution rule.

I checked that fallback against the real closure (Base Application + System Application + Business Foundation + `System.app`, 28.1) for all six distinct shapes: `Capacity`, `Forecast`, `Identity` and `Reflection` are namespace segments that are not table names, so the fallback fires and lands on the right table, while `Plan`, `AllObjWithCaption` and `Production Forecast Name` are real tables that really do carry the field named after them.

A `CalcFormula` source keeps the **last one**, which is unambiguous there: `count`/`exist` carry a table and no field, and `sum`/`lookup`/`average`/`min`/`max` carry `Table.Field` whose left half is the table.

`BcAppSymbolCache.CacheVersion` 27 to 28. No schema changed, so a v27 payload loads without error and replays the pre-fix wrong answers instead of missing — which is what the bump is for.

### Answers to the other two shape questions

1. **Same wrong pattern at another call site?** `AlPageParser` reads a page's `SourceTable` the same verbatim way, so a namespace-qualified `SourceTable` would not resolve either. It is not reachable in practice: `SourceTable` arrives from `SymbolReference.json` as a numeric table id (2,443 page properties in 28.1, zero of them dotted), and the AL-source path only sees the bundle's own AL. Left alone deliberately.
3. **Two code paths writing the same state, same invariant?** Yes, and they already share one implementation: the AL-source path (`ParseRelationArms`) and the precompiled-symbol path (`TryParseRelationArmsText`) go through the same parser, so both are fixed by the same change and cannot drift.

### RED to GREEN

**Runner mechanism test** — `AlRunner.Tests/NamespaceQualifiedRelationTargetTests.cs`, a synthetic `.app` read back through `BcAppSymbolCache.Get()`. Before: 3 of 4 fail, including `Expected: "NQR Target" / Actual: "NqrRoot.NqrLeaf.\"NQR Target\""` for the CalcFormula source. After: 4 of 4 pass. The fourth test is controls only and passes in both states on purpose.

**End to end, on Base Application's own fields.** I ran a throwaway bundle (not committed) reading `FieldRef.Relation` for the three shapes plus two controls, against a Release build of this branch and of the commit before it:

| | pre-fix | post-fix |
|---|---|---|
| `Item Register."From Capacity Entry No."` to 5832 | FAIL (0) | PASS |
| `Inventory Setup."Current Demand Forecast"` to 99000851 | FAIL (0) | PASS |
| `Requisition Line."Demand Type"` to 2000000058 | FAIL (0) | PASS |
| control: `Customer."Currency Code"` to `Currency` | PASS | PASS |
| control: `Customer.Name` to 0 | PASS | PASS |

This is the step that confirms the two-part fallback actually lands on the right table, which the mechanism test alone cannot show.

### The corpus half

`FieldRef.Relation` answering the related table id for a namespace-qualified target is plain BC behavior, so the test for it belongs upstream: **StefanMaron/BusinessCentral.AL.Language.Tests#177**, three tests added to codeunit 60482, no new objects and no new fixtures. Against this branch all three pass; against the build before it all three fail with `Actual:<0>`. I checked the three property values are identical in the Base Application symbols for BC 26.0, 27.0, 27.3, 27.5, 28.0, 28.1, 28.3 and 28.4, so they do not depend on one build.

**The submodule pin is not bumped here**, because that corpus PR has not merged. The runner-side mechanism test is what satisfies the "Tests updated" gate in the meantime.

### What I deliberately left out

The second half of #2851 — that a refused relation is indistinguishable from no relation at `FieldRef.Relation`, and that the `[TableRelation] REFUSED` line is not observable in CI. #2851 offers two answers and says to pick one: resolve the remaining shape, or record refused fields and refuse loudly when one is read. I did the first, which is what removes the Base Application instances. I did not do the second, and it should not be folded in here: on `main` the parser still refuses 1,142 relations (the `where(... = field(...))` shape that #2853 fixes), so making a refused read throw today would turn a narrow metadata gap into a hard failure across a large part of Base Application. That work belongs after #2853, and #2851's own comment says the issue stays open past it.

### Overlap with PR #2853

#2853 merged into `main` while I was working, so this branch is rebased on top of it (`0f42d06f`). The two changes touch the same two files and the outcome is the one I expected: `RecordPatches.AlSourceParser.cs` merged automatically — its hunk changes the two `RelationConditionList` calls, mine is one line above the guard plus a new method 60 lines away, with unchanged context between — and the only conflict was the one shared line, `BcAppSymbolCache.CacheVersion`. Resolved to **29**, keeping both version comments. Nothing else about the two changes interacts, and all of the measurements below were re-run after the rebase.

---

## #2775 — a runner-extras bundle for the TableRelation-only TestPage lookup refusal

`tests/runner-extras/testpage-lookup-tablerelation-oos/`, object ids 65560-65569 (65550 and 65600 are claimed by in-flight PRs #2842 and #2952).

Real BC resolves a TestPage field's lookup in three steps: the page control's `trigger OnLookup(var Text: Text): Boolean`, then the table field's parameterless `trigger OnLookup()`, then the field's `TableRelation`, which opens the related table's list page. The first two run in the runner. The third needs a client the runner does not have, so it refuses by name with reason `testpage-lookup`.

That refusal was only asserted from outside the runner, by matching console output in `AlRunner.Tests/TestPageFieldTableLookupTests`. This asserts it from inside AL through `asserterror` and `GetLastErrorText()` — the surface a consumer meets — and it runs on all eight BC legs instead of the two that carry `AlRunner.Tests`.

Three tests on one page. The two that pass are what stop the refusal from being replaced by a silent no-op: a field whose table declares the trigger must run it, a control that declares its own must run that, and the field with neither must refuse. The refusal test asserts five separate message fragments rather than a bare `asserterror`.

I checked the assertions are not vacuous: corrupting the expected strings (`testpage-lookup` to `testpage-lookup-NOPE`, `FROM-TABLE` to `FROM-NOWHERE`, `FROM-CONTROL` to `FROM-ELSEWHERE`) makes all three fail, and restoring them makes all three pass again.

Count baseline gains one group line: 264 to 267 tests and one more app group on every leg, both derived from the line. `history.md` records why.

### On #2775 being "the coverage half" of #2851

It is not. #2851 is about parsing a `TableRelation` target into metadata; #2775 is about what `TestPage.Field.Lookup()` does when no `OnLookup` trigger exists. They share the words "TableRelation" and nothing else — different files, different call paths, and neither one's fix touches the other. They ship together only because both were assigned to me and the repo allows one open PR per agent.

---

## What I ran

On the rebased tree (`origin/main` at `0f42d06f`, i.e. with #2853 merged), Release build:

- `AlRunner.Tests` filtered to `NamespaceQualifiedRelationTargetTests`, `TableRelationWhereFieldLinkTests` (#2853's, so its cache-version bump is covered too), `BcAppSymbolCache*`, `CalcFormulaSyntaxTests`, `FlowFieldDiagnosticNoiseTests`, `TestPageFieldTableLookupTests` — **56/56 pass**.
- `tests/runner-extras` in full, with `--strict --count-baseline`, as CI runs it — **267/267 pass, exit 0**.
- The pinned `al-language` corpus with `--strict --expectations --count-baseline` — **2554/2554 pass, exit 0**, no expectation drift in either direction (16 known-gap passes, down from 21 before #2853 deleted five entries). That one matters here: this change alters metadata parsing for every Base Application field, so a widened or narrowed relation would have shown up as a known-gap entry going stale.
- The three new corpus tests against my corpus branch — **3/3 pass**.

I did not run the full `AlRunner.Tests` suite.

---

*Opened by agent `impl-13`.*

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
