### PR TITLE
fix(testpage): start the row before validating a write to a part's draft line

### DIFF
--- a/AlRunner.Tests/TestPageNewRowLinePromotionTests.cs
+++ b/AlRunner.Tests/TestPageNewRowLinePromotionTests.cs
@@ -1,0 +1,179 @@
+// TestPageNewRowLinePromotionTests — issue #2923.
+//
+// Root cause: the implicit new-row line of a TestPage was turned into a pending insert AFTER
+// the write that triggered it had already validated. LiveNavTestPage.EnterNewRowLine blanks
+// the record buffer and clears every primary-key field, and the only promotion step
+// (MarkEdited) ran from LiveNavTestField's setter after ALValidateAsync — so the typed field's
+// own OnValidate saw a row with no key. On a subpage part carrying a SubPageLink that is
+// fatal: Sales Line's first OnValidate reaches TestStatusOpen -> GetSalesHeader ->
+// TestField("Document No.") and raises "Document No. must have a value". 35 tests of
+// Microsoft's Tests-SMB bucket fail on it, 27 on Sales Line and 8 on Purchase Line.
+//
+// The second half of the same defect was LiveNavTestPart.ReloadLinkedRow, which left a part
+// with no matching row on NO row at all, so a write with no New()/First() of its own had
+// nothing to land on.
+//
+// These are RUNNER-MECHANISM tests, not claims about what real BC does: they pin our own
+// wiring — that the promotion happens BEFORE the validate rather than after, that it goes
+// through the same InsertEmptyRow entry point New() uses (which is where a part stamps its
+// SubPageLink values), and that a linked part with no matching row parks on its draft line.
+//
+// The BEHAVIORAL claims are measured upstream against a live BC service tier — see
+// StefanMaron/BusinessCentral.AL.Language.Tests PR #176, codeunit 60996 "TPDL Tests" in
+// tests/al-language/handlers/TestPagePartDraftLineLink.al, per
+// .claude/rules/bc-behavior-tests-go-upstream.md. Those five tests went 2 pass / 3 fail
+// before this change and 5 pass after, run against the corpus branch.
+using System.Linq;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPageNewRowLinePromotionTests
+{
+    private static TypeDefinition LoadType(System.Type type)
+    {
+        var asm = AssemblyDefinition.ReadAssembly(type.Assembly.Location);
+        var cecilType = asm.MainModule.GetType(type.FullName);
+        Assert.NotNull(cecilType);
+        return cecilType!;
+    }
+
+    private static MethodDefinition Method(TypeDefinition type, string name)
+    {
+        var m = type.Methods.FirstOrDefault(x => x.Name == name && x.HasBody);
+        Assert.NotNull(m);
+        return m!;
+    }
+
+    // Any reference to the named method, whether it is invoked (call/callvirt) or captured as
+    // a delegate (ldftn/ldvirtftn). A method group passed as an Action compiles to ldftn, which
+    // Calls() below does not see.
+    private static bool References(MethodDefinition m, string memberName)
+        => m.Body.Instructions.Any(i =>
+            i.Operand is MethodReference mr && mr.Name == memberName);
+
+    private static bool Calls(MethodDefinition m, string memberName)
+        => m.Body.Instructions.Any(i =>
+            (i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt)
+            && i.Operand is MethodReference mr && mr.Name == memberName);
+
+    // Index of the first instruction loading the named instance field, or -1.
+    private static int IndexOfFieldLoad(MethodDefinition m, string fieldName)
+    {
+        var instructions = m.Body.Instructions;
+        for (var i = 0; i < instructions.Count; i++)
+            if (instructions[i].OpCode == OpCodes.Ldfld
+                && instructions[i].Operand is FieldReference fr && fr.Name == fieldName)
+                return i;
+        return -1;
+    }
+
+    // Index of the first call to the named method, or -1.
+    private static int IndexOfCall(MethodDefinition m, string memberName)
+    {
+        var instructions = m.Body.Instructions;
+        for (var i = 0; i < instructions.Count; i++)
+            if ((instructions[i].OpCode == OpCodes.Call || instructions[i].OpCode == OpCodes.Callvirt)
+                && instructions[i].Operand is MethodReference mr && mr.Name == memberName)
+                return i;
+        return -1;
+    }
+
+    // THE ORDERING CLAIM, and the whole point of the fix. Both callbacks are Action?.Invoke()
+    // so they are indistinguishable by call name in IL — the field loads that feed them are
+    // what tells them apart, and their positions relative to ALValidateAsync are the defect.
+    [Fact]
+    public void FieldSetter_PromotesTheNewRowLineBeforeValidatingAndFlagsTheEditAfter()
+    {
+        var type = LoadType(typeof(AlRunner.LiveNavTestPage));
+        var live = type.Module.GetType("AlRunner.LiveNavTestField");
+        Assert.NotNull(live);
+
+        var setter = Method(live!, "set_Value");
+
+        var beforeEdit = IndexOfFieldLoad(setter, "_onBeforeEdit");
+        var validate = IndexOfCall(setter, "ALValidateAsync");
+        var afterEdit = IndexOfFieldLoad(setter, "_onEdited");
+
+        Assert.True(beforeEdit >= 0,
+            "LiveNavTestField's Value setter must read _onBeforeEdit — the callback that turns "
+            + "the page's implicit new-row line into a started row before this write is validated.");
+        Assert.True(validate >= 0,
+            "LiveNavTestField's Value setter must call ALValidateAsync — setting a field on a "
+            + "page is a validate, not an assignment.");
+        Assert.True(afterEdit >= 0,
+            "LiveNavTestField's Value setter must read _onEdited — the callback that marks the "
+            + "row for persistence once the write has happened.");
+
+        Assert.True(beforeEdit < validate,
+            "the _onBeforeEdit callback must run BEFORE ALValidateAsync. Its whole job is to let "
+            + "the page start the row (keys stamped from the page's filters, OnNewRecord raised) "
+            + "while the typed field's own OnValidate can still see it — issue #2923. Invoking it "
+            + $"after the validate would be the defect itself (before={beforeEdit}, validate={validate}).");
+
+        Assert.True(validate < afterEdit,
+            "the _onEdited callback must run AFTER ALValidateAsync, as it always has: it records "
+            + "that a write happened, which is only true once the write has. It is NOT a "
+            + "substitute for _onBeforeEdit — it cannot give the row its keys in time "
+            + $"(validate={validate}, after={afterEdit}).");
+    }
+
+    // The promotion must reuse the New() entry point, because that is where the SubPageLink
+    // stamping lives (LiveNavTestPart.InsertEmptyRow overrides it). A hand-rolled promotion
+    // that only flipped the pending-insert flag would pass every other assertion here and
+    // still leave a linked part's row without its key.
+    [Fact]
+    public void PromoteNewRowLineForWrite_GoesThroughTheSameInsertEmptyRowNewUses()
+    {
+        var type = LoadType(typeof(AlRunner.LiveNavTestPage));
+        var m = Method(type, "PromoteNewRowLineForWrite");
+
+        Assert.True(Calls(m, "InsertEmptyRow"),
+            "LiveNavTestPage.PromoteNewRowLineForWrite must call InsertEmptyRow — the same entry "
+            + "point New() uses, and the one LiveNavTestPart overrides to stamp its SubPageLink "
+            + "values onto the primary-key fields. Setting _pendingNewRow directly would start "
+            + "the row without its link values, which is the bug.");
+    }
+
+    // A part with no matching row must park on its own draft line, the way a top-level page
+    // already does from MoveFirst. Without this a write with no New()/First() of its own on a
+    // linked part had no row to land on at all.
+    [Fact]
+    public void ReloadLinkedRow_ParksAnEmptyPartOnItsNewRowLine()
+    {
+        var type = LoadType(typeof(AlRunner.LiveNavTestPage));
+        var part = type.Module.GetType("AlRunner.LiveNavTestPart");
+        Assert.NotNull(part);
+
+        var m = Method(part!, "ReloadLinkedRow");
+
+        Assert.True(Calls(m, "EnterNewRowLine"),
+            "LiveNavTestPart.ReloadLinkedRow must call EnterNewRowLine when the link matches no "
+            + "row, mirroring LiveNavTestPage.MoveFirst's own empty-result fallback — otherwise "
+            + "a linked part that opens empty sits on no row and a field write targets nothing.");
+
+        Assert.True(Calls(m, "AbandonNewRowLine"),
+            "LiveNavTestPart.ReloadLinkedRow must call AbandonNewRowLine first. It is re-entered "
+            + "on every parent move and Loaded() does not clear the flag, so a part that walked "
+            + "onto its draft line and then had its parent move would sit on a real row while "
+            + "still claiming to be on the blank line — and the next write would insert instead "
+            + "of modify.");
+    }
+
+    // The wiring between the two: the page has to hand its promotion callback to the fields it
+    // builds, or the ordering proven above never runs for any real control.
+    [Fact]
+    public void GetField_HandsRecBoundControlsThePromotionCallback()
+    {
+        var type = LoadType(typeof(AlRunner.LiveNavTestPage));
+        var m = Method(type, "GetField");
+
+        Assert.True(References(m, "PromoteNewRowLineForWrite"),
+            "LiveNavTestPage.GetField must pass PromoteNewRowLineForWrite to every Rec-bound "
+            + "LiveNavTestField it constructs (as a method group, which the compiler emits as an "
+            + "ldftn) — a field built without it silently keeps the old after-the-validate "
+            + "behavior for that control.");
+    }
+}

--- a/AlRunner.Tests/TestPageNewRowLinePromotionTests.cs
+++ b/AlRunner.Tests/TestPageNewRowLinePromotionTests.cs
@@ -162,44 +162,51 @@ public sealed class TestPageNewRowLinePromotionTests
             + "of modify.");
     }
 
-    // The draft line is not blank in every column: it carries the page's own single-valued
-    // filters on the PRIMARY-KEY fields, which is BC's RecordImplementation.InitRecordFromFilters
-    // rule. EnterNewRowLine cleared the key and stopped, so the runner answered blank in a
-    // linked part's key column where real BC answers the link's value.
+    // What the draft line IS, measured on all 8 BC legs across two corpus runs (33995429394
+    // and 33997895349, codeunit 60996): BC's NavForm.NewRecord and nothing after it. The blank
+    // line reads the SubPageLink's value in the linked primary-key column, has already run the
+    // page's OnNewRecord before anyone types, still reads 0 in the AutoSplitKey column, and
+    // writes nothing while nobody types.
     //
-    // Measured on all 8 BC legs, corpus run 33995429394: the original corpus assertion said
-    // "the draft line must read blank in the column the SubPageLink constrains" and every leg
-    // returned Expected:<> Actual:<H1>. Corrected upstream to
-    // LinkedPart_DraftLine_ReadsTheLinkValueInTheLinkedKeyColumn.
-    //
-    // Reading it off the FILTER rather than off the SubPageLink is what keeps the two
-    // neighbouring corpus suites green: CU60743's standalone page has no filters and stays
-    // blank, and CU60648's link on a non-key field is never visited because the loop only walks
-    // the primary key.
+    // Both of this file's original expectations were corrected by that measurement — it had
+    // asserted the linked column reads blank, and that OnNewRecord had not run. EnterNewRowLine
+    // did a subset of NewRecord by hand (ALInit, then clear every primary-key field), which is
+    // why the runner answered blank in a linked part's key column and never raised the trigger.
     [Fact]
-    public void EnterNewRowLine_PutsThePagesSingleValuedKeyFiltersBackOnTheBlankedBuffer()
+    public void EnterNewRowLine_RunsBcsNewRecordWithoutSavingTheRow()
     {
         var type = LoadType(typeof(AlRunner.LiveNavTestPage));
         var m = Method(type, "EnterNewRowLine");
 
+        Assert.True(Calls(m, "TryNewRecord"),
+            "EnterNewRowLine must ask the page to start the record — BC's NavForm.NewRecord: "
+            + "ALInit, copy the page's single-valued filters onto the primary key "
+            + "(InitRecordFromFilters), raise OnNewRecord. Doing a subset of that by hand left a "
+            + "linked part's key column blank and its OnNewRecord unrun, and both are measured.");
+
+        // The record-only fallback, for a page the runner built no AL page object for: BC's
+        // filter step cannot run, so the two halves are done by hand.
         Assert.True(Calls(m, "ClearFieldValue"),
-            "EnterNewRowLine must still clear the primary-key fields ALInit preserves — without "
-            + "that the draft line reports the key of the row the cursor just walked off.");
-
+            "EnterNewRowLine's record-only fallback must still clear the primary-key fields "
+            + "ALInit preserves — without that the draft line reports the key of the row the "
+            + "cursor just walked off.");
         Assert.True(Calls(m, "TryGetSingleFilterValue"),
-            "EnterNewRowLine must read each primary-key field's single-valued filter — BC's "
-            + "InitRecordFromFilters rule. Clearing the key and stopping made the runner answer "
-            + "blank in a linked part's key column where real BC answers the link's value.");
-
+            "EnterNewRowLine's record-only fallback must read each primary-key field's "
+            + "single-valued filter, the same rule BC's own step applies.");
         Assert.True(Calls(m, "SetFieldValue"),
-            "EnterNewRowLine must write the filter's value back onto the blanked buffer, not "
-            + "merely read it.");
+            "EnterNewRowLine's record-only fallback must write the filter's value back onto the "
+            + "blanked buffer, not merely read it.");
 
         Assert.False(Calls(m, "ALValidateAsync"),
-            "EnterNewRowLine must NOT validate what it copies. That validate belongs to "
-            + "NavForm.NewRecordAsync — starting a row — and merely standing on the blank line "
-            + "starts nothing (corpus CU60743 NewRowLine_LeftUntouched_InsertsNothing). Running "
-            + "OnValidate here would give walking a page side effects.");
+            "EnterNewRowLine must NOT validate what the filter copy wrote. That is "
+            + "NavForm.NewRecordAsync's second half, and the promotion path "
+            + "(LiveNavTestPart.InsertEmptyRow -> ValidateStampedFields) runs it when a write "
+            + "actually starts the row.");
+
+        Assert.False(Calls(m, "ProposeAutoSplitKey"),
+            "EnterNewRowLine must NOT number the row. AutoSplitKey belongs to NavForm.SaveRecord "
+            + "— corpus CU60996 LinkedPart_DraftLine_ReadsZeroInTheAutoSplitKeyColumn measures "
+            + "the draft line still reading 0 even though OnNewRecord has run for it.");
     }
 
     // The wiring between the two: the page has to hand its promotion callback to the fields it

--- a/AlRunner.Tests/TestPageNewRowLinePromotionTests.cs
+++ b/AlRunner.Tests/TestPageNewRowLinePromotionTests.cs
@@ -162,6 +162,46 @@ public sealed class TestPageNewRowLinePromotionTests
             + "of modify.");
     }
 
+    // The draft line is not blank in every column: it carries the page's own single-valued
+    // filters on the PRIMARY-KEY fields, which is BC's RecordImplementation.InitRecordFromFilters
+    // rule. EnterNewRowLine cleared the key and stopped, so the runner answered blank in a
+    // linked part's key column where real BC answers the link's value.
+    //
+    // Measured on all 8 BC legs, corpus run 33995429394: the original corpus assertion said
+    // "the draft line must read blank in the column the SubPageLink constrains" and every leg
+    // returned Expected:<> Actual:<H1>. Corrected upstream to
+    // LinkedPart_DraftLine_ReadsTheLinkValueInTheLinkedKeyColumn.
+    //
+    // Reading it off the FILTER rather than off the SubPageLink is what keeps the two
+    // neighbouring corpus suites green: CU60743's standalone page has no filters and stays
+    // blank, and CU60648's link on a non-key field is never visited because the loop only walks
+    // the primary key.
+    [Fact]
+    public void EnterNewRowLine_PutsThePagesSingleValuedKeyFiltersBackOnTheBlankedBuffer()
+    {
+        var type = LoadType(typeof(AlRunner.LiveNavTestPage));
+        var m = Method(type, "EnterNewRowLine");
+
+        Assert.True(Calls(m, "ClearFieldValue"),
+            "EnterNewRowLine must still clear the primary-key fields ALInit preserves — without "
+            + "that the draft line reports the key of the row the cursor just walked off.");
+
+        Assert.True(Calls(m, "TryGetSingleFilterValue"),
+            "EnterNewRowLine must read each primary-key field's single-valued filter — BC's "
+            + "InitRecordFromFilters rule. Clearing the key and stopping made the runner answer "
+            + "blank in a linked part's key column where real BC answers the link's value.");
+
+        Assert.True(Calls(m, "SetFieldValue"),
+            "EnterNewRowLine must write the filter's value back onto the blanked buffer, not "
+            + "merely read it.");
+
+        Assert.False(Calls(m, "ALValidateAsync"),
+            "EnterNewRowLine must NOT validate what it copies. That validate belongs to "
+            + "NavForm.NewRecordAsync — starting a row — and merely standing on the blank line "
+            + "starts nothing (corpus CU60743 NewRowLine_LeftUntouched_InsertsNothing). Running "
+            + "OnValidate here would give walking a page side effects.");
+    }
+
     // The wiring between the two: the page has to hand its promotion callback to the fields it
     // builds, or the ordering proven above never runs for any real control.
     [Fact]

--- a/AlRunner.Tests/TestPageNewRowLinePromotionTests.cs
+++ b/AlRunner.Tests/TestPageNewRowLinePromotionTests.cs
@@ -85,26 +85,30 @@ public sealed class TestPageNewRowLinePromotionTests
     // so they are indistinguishable by call name in IL — the field loads that feed them are
     // what tells them apart, and their positions relative to ALValidateAsync are the defect.
     [Fact]
-    public void FieldSetter_PromotesTheNewRowLineBeforeValidatingAndFlagsTheEditAfter()
+    public void FieldWrite_PromotesTheNewRowLineBeforeValidatingAndFlagsTheEditAfter()
     {
         var type = LoadType(typeof(AlRunner.LiveNavTestPage));
         var live = type.Module.GetType("AlRunner.LiveNavTestField");
         Assert.NotNull(live);
 
-        var setter = Method(live!, "set_Value");
+        // NOT set_Value. Since #2900/#3007 the setter is one line —
+        // `_validationErrors.RunRecordingRefusal(() => Write(value))` — and the whole write,
+        // including the ordering this test is about, lives in Write. Reading set_Value here
+        // would find none of the three markers and the test would fail for the wrong reason.
+        var setter = Method(live!, "Write");
 
         var beforeEdit = IndexOfFieldLoad(setter, "_onBeforeEdit");
         var validate = IndexOfCall(setter, "ALValidateAsync");
         var afterEdit = IndexOfFieldLoad(setter, "_onEdited");
 
         Assert.True(beforeEdit >= 0,
-            "LiveNavTestField's Value setter must read _onBeforeEdit — the callback that turns "
+            "LiveNavTestField.Write must read _onBeforeEdit — the callback that turns "
             + "the page's implicit new-row line into a started row before this write is validated.");
         Assert.True(validate >= 0,
-            "LiveNavTestField's Value setter must call ALValidateAsync — setting a field on a "
+            "LiveNavTestField.Write must call ALValidateAsync — setting a field on a "
             + "page is a validate, not an assignment.");
         Assert.True(afterEdit >= 0,
-            "LiveNavTestField's Value setter must read _onEdited — the callback that marks the "
+            "LiveNavTestField.Write must read _onEdited — the callback that marks the "
             + "row for persistence once the write has happened.");
 
         Assert.True(beforeEdit < validate,

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -1514,49 +1514,57 @@ internal class LiveNavTestPage : MockITestPage
         // real insert later.
         CaptureInsertPosition();
 
-        // ALInit is AL's Init(), which deliberately PRESERVES the primary key — so on its own
-        // it left the key fields reading the row that was just walked off (the new-row line
-        // reported the last row's "No."). The draft line does not show the previous row's key,
-        // so the key fields are cleared.
+        // BC'S NavForm.NewRecord, MINUS THE SAVE. Measured on all 8 BC legs, corpus codeunit
+        // 60996 (runs 33995429394 and 33997895349), that the draft line of a linked part:
         //
-        // ClearFieldValue per key field rather than NavRecord.Clear(): Clear() is AL's
-        // Clear(Rec), which also drops filters and the current key — and the page's filters
-        // are what make the rowset the page's own (a part's SubPageLink above all). Blanking
-        // the buffer must not silently widen what the page is showing.
+        //   * reads the SubPageLink's value in the linked PRIMARY-KEY column, not blank
+        //     (LinkedPart_DraftLine_ReadsTheLinkValueInTheLinkedKeyColumn — the first run
+        //     answered 'H1' where this file had asserted blank);
+        //   * has ALREADY run the page's OnNewRecord before anyone types
+        //     (LinkedPart_DraftLine_HasRunTheOnNewRecordTrigger — the second run answered
+        //     'NEWREC' where this file had asserted blank);
+        //   * still reads 0 in the AutoSplitKey column
+        //     (LinkedPart_DraftLine_ReadsZeroInTheAutoSplitKeyColumn), and writes nothing while
+        //     nobody types (LinkedPart_DraftLineLeftUntouched_InsertsNothing).
         //
-        // THEN PUT THE PAGE'S OWN FILTER BACK ON, which is the half this was missing. The
-        // draft line is NOT blank in every column: it carries the page's single-valued filters
-        // on the primary-key fields — BC's RecordImplementation.InitRecordFromFilters rule,
-        // the same one a row started by New() goes through. Measured on all 8 BC legs (corpus
-        // codeunit 60996 LinkedPart_DraftLine_ReadsTheLinkValueInTheLinkedKeyColumn, corpus
-        // run 33995429394): a part linked "Header No." = field("No.") from a card on 'H1'
-        // shows 'H1' in that column on its draft line, not blank. This file previously cleared
-        // the key and stopped, so the runner answered blank there.
+        // Those four together are exactly NewRecord and nothing after it: ALInit, copy the
+        // page's single-valued filters onto the primary key
+        // (RecordImplementation.InitRecordFromFilters), raise OnNewRecord — while SplitKey,
+        // OnInsertRecord and the Insert all belong to NavForm.SaveRecord, which is where
+        // FlushPendingNewRow does them. So the client starts the record when the blank line
+        // becomes current; it just never saves it.
         //
-        // The two neighbouring measurements are what fix the rule's shape rather than just
-        // this one column:
-        //   * corpus CU60743 — a STANDALONE page's draft line reads blank in its key column.
-        //     It has no filters, so the copy finds nothing. Same rule, no special case.
-        //   * corpus CU60648 "PKFL Tests" — a part linked on a NON-key field shows that field
-        //     blank on its draft row. Key membership is the gate, which is why this loop only
-        //     visits primary-key fields.
+        // This is the SAME call InsertEmptyRow makes for New(). The runner used to do a subset
+        // of it by hand here — ALInit, then clear every primary-key field — which left a linked
+        // part's key column blank and its OnNewRecord unrun.
         //
-        // Deliberately NO ALValidateAsync on what is copied here, unlike the stamping
-        // LiveNavTestPart.InsertEmptyRow does. That validate is part of NavForm.NewRecordAsync
-        // — starting a row — and merely standing on the blank line starts nothing (corpus
-        // CU60743 NewRowLine_LeftUntouched_InsertsNothing, CU60996
-        // LinkedPart_DraftLineLeftUntouched_InsertsNothing). Running OnValidate here would let
-        // walking a page have side effects.
-        record.ALInit();
-        var primaryKey = record.MetaTable?.PrimaryKey;
-        if (primaryKey != null)
-            for (var i = 0; i < primaryKey.KeyFieldCount; i++)
-            {
-                var keyFieldNo = primaryKey.KeyFieldsList[i].FieldNo;
-                record.ClearFieldValue(keyFieldNo);
-                if (TryGetSingleFilterValue(record, keyFieldNo, out var fromFilter))
-                    record.SetFieldValue(keyFieldNo, fromFilter);
-            }
+        // Deliberately NOT _pendingNewRow (that is what makes walking a page insert nothing)
+        // and deliberately NO ALValidateAsync of what the filter copy wrote. The validate step
+        // is NavForm.NewRecordAsync's second half, which the promotion path
+        // (LiveNavTestPart.InsertEmptyRow -> ValidateStampedFields) runs when a write actually
+        // starts the row.
+        if (!(_page?.TryNewRecord(belowXRec: true) ?? false))
+        {
+            // Record-only mode: no page to ask, so BC's filter step never runs. Do the two
+            // halves by hand — ALInit is AL's Init(), which deliberately PRESERVES the primary
+            // key, so without the clear the draft line reported the key of the row just walked
+            // off; without the copy back it reads blank where the page's filter says otherwise.
+            //
+            // ClearFieldValue per key field rather than NavRecord.Clear(): Clear() is AL's
+            // Clear(Rec), which also drops filters and the current key — and the page's filters
+            // are what make the rowset the page's own (a part's SubPageLink above all).
+            // Blanking the buffer must not silently widen what the page is showing.
+            record.ALInit();
+            var primaryKey = record.MetaTable?.PrimaryKey;
+            if (primaryKey != null)
+                for (var i = 0; i < primaryKey.KeyFieldCount; i++)
+                {
+                    var keyFieldNo = primaryKey.KeyFieldsList[i].FieldNo;
+                    record.ClearFieldValue(keyFieldNo);
+                    if (TryGetSingleFilterValue(record, keyFieldNo, out var fromFilter))
+                        record.SetFieldValue(keyFieldNo, fromFilter);
+                }
+        }
 
         _onNewRowLine = true;
         return true;

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -1143,14 +1143,59 @@ internal class LiveNavTestPage : MockITestPage
     // to the table notices. Tests of the first shape were green while asserting nothing.
     private bool _pendingModify;
 
+    /// <summary>
+    /// A control is ABOUT to write to the record. Called by the field before it validates —
+    /// which is the only moment at which the implicit new-row line can still be turned into
+    /// the row BC would have started.
+    ///
+    /// <para>Typing into the draft line is what creates a record on a repeater, and the
+    /// platform step that creates it is the SAME one <c>New()</c> runs:
+    /// <c>NavForm.NewRecordAsync</c>, which resets the buffer, copies the page's single-valued
+    /// filters onto the primary-key fields (<c>RecordImplementation.InitRecordFromFilters</c>)
+    /// and raises OnNewRecord. So the promotion goes through <see cref="InsertEmptyRow"/>,
+    /// the same entry point <c>New()</c> uses — including
+    /// <see cref="LiveNavTestPart.InsertEmptyRow"/>'s SubPageLink stamping when the page is a
+    /// linked part.</para>
+    ///
+    /// <para>WHY BEFORE THE VALIDATE, NOT AFTER (issue #2923). <c>MarkEdited</c> below runs
+    /// after the control's write, and it used to be the whole promotion: it flipped
+    /// <c>_pendingNewRow</c> and left the buffer exactly as <see cref="EnterNewRowLine"/> had
+    /// blanked it — key fields cleared, link values sitting unread in the record's filters.
+    /// The typed field's own OnValidate therefore ran against a row with no key. On a linked
+    /// document part that is fatal rather than cosmetic: <c>Sales Line</c>'s first OnValidate
+    /// reaches <c>TestStatusOpen</c> → <c>GetSalesHeader</c> → <c>TestField("Document No.")</c>
+    /// and raises "Document No. must have a value" — 35 tests of Microsoft's Tests-SMB bucket,
+    /// on the commonest shape in BC test code (<c>SalesQuote.SalesLines.First()</c> on an empty
+    /// part, then <c>SetValue</c>).</para>
+    ///
+    /// <para>Reading the draft line still answers blank, including in the column a SubPageLink
+    /// constrains — nothing here runs until a WRITE arrives. Both halves are measured upstream
+    /// on real BC (corpus codeunit 60996 "TPDL Tests",
+    /// StefanMaron/BusinessCentral.AL.Language.Tests): the draft line of a linked part reads
+    /// blank in the linked column, and the row a write starts on it carries the link's value
+    /// early enough that the typed field's OnValidate already sees it.</para>
+    /// </summary>
+    internal void PromoteNewRowLineForWrite()
+    {
+        if (!_onNewRowLine) return;
+        // beforeCurrent: false — the draft line is the LAST row of the rowset, so the row it
+        // becomes is inserted after the data, which is also what BC's own TestPageProxy asks
+        // for (InsertBehavior = RowUpdateBehavior.After, whatever beforeCurrent says).
+        // Virtual on purpose: a part must reach LiveNavTestPart's override.
+        InsertEmptyRow(beforeCurrent: false);
+    }
+
     /// <summary>A control wrote to the record. Called by the field, which owns no page state.</summary>
     internal void MarkEdited()
     {
-        // Typing into the new-row line is exactly what turns it into a record — it is how a
-        // user creates a row without ever invoking New(). Promote it to the pending-insert
-        // the flush path already knows how to finish (EnterNewRowLine has already done the
-        // CaptureInsertPosition that ProposeAutoSplitKey needs). Falling through to
-        // _pendingModify instead would try to Modify a row that has no row in the table.
+        // The new-row line is normally already gone by the time this runs — the field calls
+        // PromoteNewRowLineForWrite() before validating, and that turns the draft line into a
+        // pending insert. This branch stays for any write that reaches the record without
+        // going through a LiveNavTestField setter: the row still has to become an insert
+        // rather than a Modify of a row that is not in the table. It does NOT do the
+        // link-stamping half — a write that never announced itself cannot be given one — so
+        // the two paths are not equivalent and the pre-write call above is the one that
+        // matters.
         if (_onNewRowLine)
         {
             _onNewRowLine = false;
@@ -1299,7 +1344,8 @@ internal class LiveNavTestPage : MockITestPage
             // _pageVariableFields beside it is already keyed this way.
             if (!_fields.TryGetValue(id, out var field))
                 _fields[id] = field =
-                    new LiveNavTestField(_record!, tableFieldNo, _page, id, MarkEdited);
+                    new LiveNavTestField(_record!, tableFieldNo, _page, id,
+                        MarkEdited, PromoteNewRowLineForWrite);
             return field;
         }
 
@@ -1451,9 +1497,12 @@ internal class LiveNavTestPage : MockITestPage
     /// raise and no before-image to snapshot. Deliberately NOT _pendingNewRow either — the
     /// client only turns the draft line into a record once someone types into it, so merely
     /// walking a page must not insert a blank row (corpus CU60743
-    /// NewRowLine_LeftUntouched_InsertsNothing). MarkEdited is where typing promotes it.
+    /// NewRowLine_LeftUntouched_InsertsNothing, and CU60996 for the linked-part case).
+    /// <see cref="PromoteNewRowLineForWrite"/> is where typing promotes it — BEFORE the
+    /// write's own validate, so the row the trigger sees is the one BC's NewRecord would
+    /// have handed it, link values and all (#2923).
     /// </summary>
-    private bool EnterNewRowLine(NavRecord record)
+    private protected bool EnterNewRowLine(NavRecord record)
     {
         if (!ShowsNewRowLine) return false;
 
@@ -1496,6 +1545,24 @@ internal class LiveNavTestPage : MockITestPage
         var position = _newRowLineReturnPosition;
         _newRowLineReturnPosition = null;
         if (!string.IsNullOrEmpty(position)) _record!.ALSetPosition(position);
+    }
+
+    /// <summary>
+    /// Drop the new-row line WITHOUT restoring the position it saved — for the one case where
+    /// that position is not valid to go back to: a linked part being re-pointed at a different
+    /// parent row (<see cref="LiveNavTestPart.ReloadLinkedRow"/>). The saved position names a
+    /// row of the OLD link's rowset, and the caller re-finds against the new one immediately,
+    /// so restoring it would put the buffer on a row the part no longer shows.
+    ///
+    /// Kept distinct from <see cref="LeaveNewRowLine"/> because the flag itself must still be
+    /// cleared either way: <c>Loaded()</c> does not touch it, so a part that walked onto its
+    /// draft line and then had its parent move would otherwise sit on a real row while still
+    /// claiming to be on the blank line — and the next write would insert instead of modify.
+    /// </summary>
+    private protected void AbandonNewRowLine()
+    {
+        _onNewRowLine = false;
+        _newRowLineReturnPosition = null;
     }
 
     /// <summary>
@@ -2310,17 +2377,25 @@ internal sealed class LiveNavTestField : ITestField
     // page, not to the card the test is holding.
     private readonly Action? _onEdited;
 
+    // Told BEFORE this field writes, so the page can turn its implicit new-row line into a
+    // real started row while the write's own OnValidate can still see it — see
+    // LiveNavTestPage.PromoteNewRowLineForWrite (#2923). Separate from _onEdited because the
+    // order is the whole point: _onEdited runs after the validate and is far too late to give
+    // the row its keys.
+    private readonly Action? _onBeforeEdit;
+
     public LiveNavTestField(NavRecord record, int fieldNo)
-        : this(record, fieldNo, page: null, controlId: 0, onEdited: null) { }
+        : this(record, fieldNo, page: null, controlId: 0, onEdited: null, onBeforeEdit: null) { }
 
     public LiveNavTestField(NavRecord record, int fieldNo, RunnerPageInstance? page, int controlId,
-        Action? onEdited)
+        Action? onEdited, Action? onBeforeEdit)
     {
         _record = record;
         _fieldNo = fieldNo;
         _page = page;
         _controlId = controlId;
         _onEdited = onEdited;
+        _onBeforeEdit = onBeforeEdit;
     }
 
     // The refusals this control has recorded, read back by ValidationErrorCount /
@@ -2351,6 +2426,20 @@ internal sealed class LiveNavTestField : ITestField
 
     private void Write(string value)
     {
+        // FIRST, before anything reads or writes the record: if the page is parked on its
+        // implicit new-row line, this write is what turns that line into a row the flush path
+        // will persist, and BC settles the row's key BEFORE the typed value is validated onto
+        // it. Doing it after (which is all MarkEdited below could do) handed the field's own
+        // OnValidate a row with no key: issue #2923, 35 Tests-SMB failures on Sales Line and
+        // Purchase Line. A no-op on every page not sitting on that line, which is all of them
+        // once a real row is current.
+        //
+        // Inside Write, so it is inside the RunRecordingRefusal the setter wraps this in
+        // (#3007): starting the row is part of this control write, so a refusal raised while
+        // starting it is recorded and re-raised by BC's NavTestField.CheckError exactly as a
+        // refusal of the value itself would be.
+        _onBeforeEdit?.Invoke();
+
         // Issue #1870 — the Rec-bound half of #1837 that #1869 (the page-variable half)
         // left open. FieldType (sourced from the source table field's own declared type,
         // see TryGetMetaFieldType) answers Boolean for a `field(Flag; Rec.Flag)` control
@@ -3006,11 +3095,23 @@ internal sealed class LiveNavTestPart : LiveNavTestPage, ITestPart
     /// shape) stayed at its field defaults for the page's whole life.
     ///
     /// Deliberately reuses <c>Loaded(bool)</c> rather than <c>MoveFirst()</c>: MoveFirst()
-    /// also flushes pending parts/rows and, on a not-found part, enters the insertable
-    /// new-row line (<c>EnterNewRowLine</c>) — state changes appropriate to an AL-driven
-    /// cursor move, not to a parent row simply becoming current. A part with no matching row
-    /// here shows empty, exactly as it did before this method existed; this only adds the
-    /// FOUND case BC already runs.
+    /// also flushes pending parts/rows — a state change appropriate to an AL-driven cursor
+    /// move, not to a parent row simply becoming current. Only the two steps a parent move
+    /// really does are taken: run the FOUND case's trigger, or park on the draft line.
+    ///
+    /// THE NOT-FOUND CASE IS NOT "SHOW NOTHING" (#2923). It used to be, and that was the
+    /// remaining half of #2392 applied to parts: a client renders an editable, insert-allowed
+    /// repeater with no matching rows as exactly one row — its blank new-row line — and a
+    /// write with no <c>New()</c> and no <c>First()</c> of its own lands there. Corpus
+    /// codeunit 60743 <c>EmptyEditableList_SetValueWithoutNewOrFirst_InsertsARow</c> measured
+    /// that on a real service tier for a standalone page; codeunit 60996
+    /// <c>EmptyLinkedPart_WriteWithoutFirst_ValidateSeesTheLinkedKey</c> measures it for a
+    /// LINKED part, which is the shape Microsoft's own document tests use. Leaving the part
+    /// unpositioned sent that write into a record nothing had ever positioned.
+    ///
+    /// <c>AbandonNewRowLine</c> first, because this method is re-entered on every parent move:
+    /// a draft line the part was parked on belongs to the parent being left, and
+    /// <c>Loaded()</c> would not have cleared it.
     ///
     /// NOT once-guarded: every call re-applies the link filter and re-finds, which is exactly
     /// what makes a GoToRecord-driven refresh work. A repeat call for the SAME still-current
@@ -3028,8 +3129,10 @@ internal sealed class LiveNavTestPart : LiveNavTestPage, ITestPart
     {
         if (Record is not { } record) return;
         ApplyLink();
+        AbandonNewRowLine();
         var found = record.ALFindFirstAsync(DataError.TrapError).GetAwaiter().GetResult();
         Loaded(found);
+        if (!found) EnterNewRowLine(record);
     }
 
     public override bool FindRowFromTableFieldValues(int[] fieldNos, object[] values, bool forward)

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -1516,18 +1516,47 @@ internal class LiveNavTestPage : MockITestPage
 
         // ALInit is AL's Init(), which deliberately PRESERVES the primary key — so on its own
         // it left the key fields reading the row that was just walked off (the new-row line
-        // reported the last row's "No."). The draft line is blank in every column, so the key
-        // fields are cleared too.
+        // reported the last row's "No."). The draft line does not show the previous row's key,
+        // so the key fields are cleared.
         //
         // ClearFieldValue per key field rather than NavRecord.Clear(): Clear() is AL's
         // Clear(Rec), which also drops filters and the current key — and the page's filters
         // are what make the rowset the page's own (a part's SubPageLink above all). Blanking
         // the buffer must not silently widen what the page is showing.
+        //
+        // THEN PUT THE PAGE'S OWN FILTER BACK ON, which is the half this was missing. The
+        // draft line is NOT blank in every column: it carries the page's single-valued filters
+        // on the primary-key fields — BC's RecordImplementation.InitRecordFromFilters rule,
+        // the same one a row started by New() goes through. Measured on all 8 BC legs (corpus
+        // codeunit 60996 LinkedPart_DraftLine_ReadsTheLinkValueInTheLinkedKeyColumn, corpus
+        // run 33995429394): a part linked "Header No." = field("No.") from a card on 'H1'
+        // shows 'H1' in that column on its draft line, not blank. This file previously cleared
+        // the key and stopped, so the runner answered blank there.
+        //
+        // The two neighbouring measurements are what fix the rule's shape rather than just
+        // this one column:
+        //   * corpus CU60743 — a STANDALONE page's draft line reads blank in its key column.
+        //     It has no filters, so the copy finds nothing. Same rule, no special case.
+        //   * corpus CU60648 "PKFL Tests" — a part linked on a NON-key field shows that field
+        //     blank on its draft row. Key membership is the gate, which is why this loop only
+        //     visits primary-key fields.
+        //
+        // Deliberately NO ALValidateAsync on what is copied here, unlike the stamping
+        // LiveNavTestPart.InsertEmptyRow does. That validate is part of NavForm.NewRecordAsync
+        // — starting a row — and merely standing on the blank line starts nothing (corpus
+        // CU60743 NewRowLine_LeftUntouched_InsertsNothing, CU60996
+        // LinkedPart_DraftLineLeftUntouched_InsertsNothing). Running OnValidate here would let
+        // walking a page have side effects.
         record.ALInit();
         var primaryKey = record.MetaTable?.PrimaryKey;
         if (primaryKey != null)
             for (var i = 0; i < primaryKey.KeyFieldCount; i++)
-                record.ClearFieldValue(primaryKey.KeyFieldsList[i].FieldNo);
+            {
+                var keyFieldNo = primaryKey.KeyFieldsList[i].FieldNo;
+                record.ClearFieldValue(keyFieldNo);
+                if (TryGetSingleFilterValue(record, keyFieldNo, out var fromFilter))
+                    record.SetFieldValue(keyFieldNo, fromFilter);
+            }
 
         _onNewRowLine = true;
         return true;
@@ -1563,6 +1592,33 @@ internal class LiveNavTestPage : MockITestPage
     {
         _onNewRowLine = false;
         _newRowLineReturnPosition = null;
+    }
+
+    /// <summary>The one value a field's current filter selects, or false when the filter is
+    /// not a single value (BC's <c>GetRangeMin</c>/<c>GetRangeMax</c> raise for a filter that
+    /// is not a range; a range whose ends differ is not a single value either).
+    ///
+    /// On the base class rather than on <see cref="LiveNavTestPart"/> because BOTH users of
+    /// BC's filter-copy rule need it: the part's New() stamping, and
+    /// <see cref="EnterNewRowLine"/>'s draft line. The rule is about the record's FILTERS, not
+    /// about a SubPageLink — so reading it off the filters covers const/filter/field links and
+    /// a plain filtered page with one mechanism, and answers "nothing to copy" for an
+    /// unfiltered page without needing a special case.</summary>
+    private protected static bool TryGetSingleFilterValue(NavRecord record, int fieldNo, out NavValue value)
+    {
+        try
+        {
+            var min = record.ALGetRangeMin(fieldNo);
+            var max = record.ALGetRangeMax(fieldNo);
+            if (min != null && min.Equals(max)) { value = min; return true; }
+        }
+        catch (NavBaseException)
+        {
+            // Not a range: a multi-value expression (1|2), an open-ended one (>1), or a
+            // wildcard. BC's own InitRecordFromFilters stamps nothing for these either.
+        }
+        value = null!;
+        return false;
     }
 
     /// <summary>
@@ -3266,23 +3322,4 @@ internal sealed class LiveNavTestPart : LiveNavTestPage, ITestPart
         return fieldNos;
     }
 
-    /// <summary>The one value a field's current filter selects, or false when the filter is
-    /// not a single value (BC's <c>GetRangeMin</c>/<c>GetRangeMax</c> raise for a filter that
-    /// is not a range; a range whose ends differ is not a single value either).</summary>
-    private static bool TryGetSingleFilterValue(NavRecord record, int fieldNo, out NavValue value)
-    {
-        try
-        {
-            var min = record.ALGetRangeMin(fieldNo);
-            var max = record.ALGetRangeMax(fieldNo);
-            if (min != null && min.Equals(max)) { value = min; return true; }
-        }
-        catch (NavBaseException)
-        {
-            // Not a range: a multi-value expression (1|2), an open-ended one (>1), or a
-            // wildcard. BC's own InitRecordFromFilters stamps nothing for these either.
-        }
-        value = null!;
-        return false;
-    }
 }

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -606,3 +606,25 @@ by the time this branch merged, because several other groups landed on `main` in
 final run on this branch reports **282**. The lesson, not the number, is the point: a suite-wide
 total written into this file dates the moment it was measured, while the per-group line does
 not.
+
+The al-language number moves 2599 -> 2610 with the submodule pin bump to corpus
+`9ba6f581`, which takes two corpus merges. Eight of the eleven are codeunit 60996 "TPDL
+Tests" (corpus PR #176), pinning what typing into the draft line of a subpage part that
+carries a SubPageLink creates -- the upstream half of issue #2923. The other three extend
+`TestQueryFlowFieldColumn` with how a flow filter reaches a query's FlowField column
+(corpus PR #175); their runner-side fix is already on main (#2947), which is why the bump
+does not need a second fix folded in for them.
+
+2610 is measured from an actual run against the new pin, not counted off the source.
+appGroups is unchanged at 1: every new test joined the single existing al-language app
+group, and al-language carries no byBcVersion override, so CI's eight legs are what confirm
+one is not needed. Only the al-language number moved; runner-extras and
+al-language-internals-fixture are main's values, untouched.
+
+Worth recording about codeunit 60996 specifically, because it is the reason two of its
+assertions read the way they do: a service tier refuted the test twice before it merged.
+Run 33995429394 answered `H1` where the file asserted the draft line reads blank in the
+column a SubPageLink constrains, and run 33997895349 answered `NEWREC` where it asserted
+the page's OnNewRecord had not yet run for that line. Both are now asserted at the measured
+value. The runner change in this PR follows those measurements rather than the other way
+round.

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Schema, semantics and how to bump: README.md in this directory. Per-bump rationale: history.md, never a prose line in here (#2485).",
   "suites": {
     "al-language": {
-      "tests": { "default": 2599 },
+      "tests": { "default": 2610 },
       "appGroups": { "default": 1 }
     },
     "al-language-internals-fixture": { "tests": { "default": 0 }, "appGroups": { "default": 1 } },


### PR DESCRIPTION
Closes #2923

## The defect

Two things went wrong on a TestPage's implicit new-row line, and a linked subpage part hit both.

**The row was started too late.** `LiveNavTestPage.EnterNewRowLine` blanks the record buffer and
clears every primary-key field. The only promotion step was `MarkEdited`, which the field's
setter calls *after* `ALValidateAsync` — so the typed field's own OnValidate ran against a row
with no key, while the SubPageLink's values sat unread in the record's filters. On a linked
document part that is fatal: `Sales Line`'s first OnValidate reaches `TestStatusOpen` ->
`GetSalesHeader` -> `TestField("Document No.")`:

```
NavTestFieldException: Document No. must have a value in Sales Line:
  Document Type=Quote, Document No.=, Line No.=0. It cannot be zero or empty.
```

35 tests of Microsoft's Tests-SMB bucket fail on it — 27 on `Sales Line`, 8 on `Purchase Line` —
on the commonest shape in BC test code:

```al
SalesQuote.SalesLines.First();                    // empty part, returns false
SalesQuote.SalesLines."No.".SetValue(Item."No."); // raises
```

**The draft line was not what BC shows.** `EnterNewRowLine` did a subset of BC's
`NavForm.NewRecord` by hand — `ALInit`, then clear every primary-key field. Real BC runs the
whole of `NewRecord` for that line.

## What a service tier actually says

Corpus codeunit 60996 "TPDL Tests" — merged as
StefanMaron/BusinessCentral.AL.Language.Tests#176, green on all 8 BC legs. It refuted my first
two guesses, and the corrections are what this PR encodes:

| claim | verdict |
|---|---|
| draft line reads blank in the linked column | **refuted** — run 33995429394 answered `H1` |
| draft line has not run the page's OnNewRecord | **refuted** — run 33997895349 answered `NEWREC` |
| draft line reads 0 in the AutoSplitKey column | confirmed |
| walking onto it and typing nothing writes nothing | confirmed |
| a write there carries the link's value, and the typed field's OnValidate already sees it | confirmed (3 tests) |

Together those eight say the client runs `NavForm.NewRecord` when the blank line becomes current
— init, copy the page's single-valued filters onto the primary key
(`RecordImplementation.InitRecordFromFilters`), raise OnNewRecord — and stops short of the save.
`SplitKey`, `OnInsertRecord` and the `Insert` belong to `NavForm.SaveRecord`.

After the first correction I split the four draft-line reads into one `[Test]` each. A single
procedure stops at its first failing assertion, so the first wrong expectation hid the other
three columns and cost a whole 8-leg cycle; the split meant one run then adjudicated all three
remaining columns at once, which is how the OnNewRecord answer arrived.

## The fix

Three changes in `AlRunner/Patches/MockTestPage.cs`.

**1. Promote before the validate, through the same entry point `New()` uses.**
`LiveNavTestField` gained an `_onBeforeEdit` callback, invoked at the top of `Write(...)`, wired
to a new `LiveNavTestPage.PromoteNewRowLineForWrite()`. That calls the virtual `InsertEmptyRow`,
so `LiveNavTestPart`'s override does the SubPageLink stamping and a linked part gets its key
before the typed value is validated onto it. The primary-key gate from #2735 is reused, not
duplicated — a link on a non-key field is still not stamped.

**2. A linked part with no matching row parks on its own draft line.**
`LiveNavTestPart.ReloadLinkedRow` left such a part on no row at all, so a write with no `New()`
and no `First()` had nothing to land on. It now falls onto the draft line the way `MoveFirst`
already does (#2392), and calls a new `AbandonNewRowLine()` first — it is re-entered on every
parent move and `Loaded()` does not clear the flag, so a part that walked onto its draft line and
then had its parent move would have sat on a real row while still claiming to be on the blank
line.

**3. `EnterNewRowLine` runs BC's `NewRecord` instead of a subset of it.**
The same `TryNewRecord` call `InsertEmptyRow` makes, and nothing after it. The hand-rolled
clear-then-copy survives only as the record-only fallback, where there is no page to ask and BC's
filter step cannot run.

The runner was already wrong on both halves of change 3 before this PR — `EnterNewRowLine` has
cleared the key and skipped OnNewRecord since before I touched it, and my original (wrong) corpus
assertions passed against `main`. The promotion change neither caused nor cured them; they are
fixed here because it is the same function and the same claim.

## RED -> GREEN against the new pin

Measured by reverting only `AlRunner/Patches/MockTestPage.cs` to `origin/main`, rebuilding, and
running the pinned corpus:

| | codeunit 60996 | whole corpus (2610 tests) |
|---|---|---|
| `main`'s `MockTestPage.cs` | 3 pass / 5 fail | 2605 pass / **5 fail** |
| this branch | **8 pass** | **2610 pass / 0 fail** |

The five failures on `main` are exactly my five; nothing else in the corpus fails either way.

## Submodule pin and count baseline

Folded in here, per `al-language-submodule.md`. Pin `ab6fbefa` -> `9ba6f581`, which takes two
corpus merges:

- **#176** — codeunit 60996, the 8 tests above, the upstream half of this fix.
- **#175** — 3 more `TestQueryFlowFieldColumn` tests. Their runner-side fix is already on `main`
  (#2947), which is why they pass in the RED baseline above and need nothing folded in.

`al-language` baseline 2599 -> **2610**, measured from an actual run against the new pin rather
than counted off the source. `appGroups` stays 1 — every new test joined the existing app group.
Only the `al-language` group moved; `runner-extras` and `al-language-internals-fixture` are
`main`'s values untouched. Rationale recorded in `count-baseline/history.md`, not as a prose line
in the JSON.

## Rebase onto #3007

`main` moved 22 commits, one of which (#3007, `a895d95c`) rewrote the same region of
`MockTestPage.cs`: it moved the field setter's body into a new `private void Write(string value)`
and left `set => _validationErrors.RunRecordingRefusal(() => Write(value))`.

I resolved by keeping #3007's side whole and re-applying only my one behavioural line at the top
of `Write`, rather than taking either side of the conflict. `git diff origin/main..HEAD` touches
none of `RunRecordingRefusal`, `_validationErrors`, `ValidationErrorCount`, `GetValidationError`,
`MakeError` or `MakeNotAcceptableError`.

`_onBeforeEdit?.Invoke()` sits **inside** `Write`, so it is inside the `RunRecordingRefusal` the
setter wraps: starting the row is part of this control write, so a refusal raised while starting
it is recorded and re-raised by BC's `NavTestField.CheckError` exactly as a refusal of the value
itself would be.

The ordering test in this PR had to move with it — it read `set_Value`, which after #3007
contains none of the three markers, so it now reads `Write`.

## Runner-side tests

`AlRunner.Tests/TestPageNewRowLinePromotionTests.cs` — five mechanism tests over the emitted IL,
in the shape of `TestPageImplicitPositioningBindingTests`. They pin our wiring, not BC's
behavior: `_onBeforeEdit` read before `ALValidateAsync` and `_onEdited` after it (both callbacks
are `Action?.Invoke()`, so only the field loads tell them apart); the promotion going through
`InsertEmptyRow`; `ReloadLinkedRow` calling `EnterNewRowLine` and `AbandonNewRowLine`; `GetField`
handing every Rec-bound control the promotion callback; and `EnterNewRowLine` calling
`TryNewRecord` while calling neither `ALValidateAsync` nor `ProposeAutoSplitKey` — the two
negatives being what keeps "start the row" from drifting into "save the row".

Each fails without its half of the fix, verified by reverting `MockTestPage.cs` and rebuilding.
They predate the pin bump; with the corpus now merged, codeunit 60996 is the real proof and these
guard the wiring underneath it.

## Fixing the shape, not just the reported line

**Same wrong pattern at another call site?** I audited every read and write of `_onNewRowLine`.
The field setter is the only Rec-bound write path — `Lookup()` routes through it, and
`PageVariableTestField` writes page variables, never the record. `GoToBookmark` leaves the line,
which is right for a jump to a real row.

**A sibling function with the same assumption?** Yes: `MoveLast()` has no `EnterNewRowLine`
fallback, so `Last()` then `SetValue` on an empty editable page still writes into a record nothing
positioned. Not fixed here — unmeasured, and the two plausible answers differ observably. Filed as
#2964 with the corpus tests that would settle it.

**Two paths writing the same state with different invariants?** Two, and both are changes above:
`InsertEmptyRow` stamped the link while `EnterNewRowLine` cleared the keys, and `InsertEmptyRow`
ran `NewRecord` while `EnterNewRowLine` did a subset. `MarkEdited`'s draft-line branch is kept as
a fallback for a write reaching the record outside a field setter, with a comment saying it does
not do the stamping half and is not equivalent.

**One thing this change introduces, which I filed rather than guessed at:** `EnterNewRowLine` and
the promotion now both call `TryNewRecord`, so a `First()`-then-`SetValue` sequence raises the
page's OnNewRecord **twice** for one row. That is certain from the two call sites; what real BC
does is not measured, and codeunit 60996's witness is idempotent so none of its eight tests can
see it. Filed as #3029 with the corpus test that would settle it.

I stayed out of `RaiseOnAction` and the event-subscriber injection path.

## Suites run on this exact tree, rebased onto `9ba81187`

- Pinned corpus, CI's invocation (`--strict --count-baseline`) — **2610/2610, exit 0**.
- `tests/runner-extras`, with `--count-baseline` — **287/287, exit 0**.
- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~TestPage|FullyQualifiedName~TestFieldValidationErrors|FullyQualifiedName~Scratch"` — 143 passed, 4 skipped, 0 failed. The `Scratch` filter is #2991's guard, now green on this base; the `TestFieldValidationErrors` filter is #3007's, to show the rebase left it working.

I did not run the full `AlRunner.Tests` suite locally; CI runs it on all eight legs.

Opened by an agent (`impl-10`).

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
