### PR TITLE
fix(virtual-tables): say the 55 refusals are gaps, not scope boundaries

### DIFF
--- a/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
+++ b/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
@@ -80,6 +80,22 @@ public sealed class VirtualTableRefusalClaimTests
         "RecordPatches.WindowsLanguageVirtualTable.cs",
     };
 
+    /// <summary>
+    /// Two files OUTSIDE the *VirtualTable.cs set that raise refusals for the same surfaces —
+    /// found by asking question 2 of "fix the shape, not just the reported line", not by the
+    /// issue's own grep. RecordPatches.cs's DataAccess dispatch chain refuses for Field,
+    /// Aggregate Permission Set and Feature Key; AllProfileWritePatches.cs refuses for All
+    /// Profile. Same table, same anchor, so leaving them would have left one table claiming two
+    /// different things depending on which code path reached it. They route through the same
+    /// factories now — but they legitimately carry OTHER, genuinely permanent refusals too, so
+    /// the whole-file guard below does not apply to them.
+    /// </summary>
+    private static readonly string[] SiblingFiles =
+    {
+        "RecordPatches.cs",
+        "AllProfileWritePatches.cs",
+    };
+
     /// <summary>factory name → (api, surface anchor, doc link). One row per corrected surface.</summary>
     public static IEnumerable<object[]> Surfaces() => new[]
     {
@@ -271,15 +287,48 @@ public sealed class VirtualTableRefusalClaimTests
     [Fact]
     public void AllFortyEightRefusalsStillExist_SoNoneWasDeletedRatherThanCorrected()
     {
-        var total = CoveredFiles.Sum(file =>
+        var total = CoveredFiles.Concat(SiblingFiles).Sum(file =>
         {
             var src = File.ReadAllText(Path.Combine(RepoRoot, "AlRunner", "Patches", file));
-            return Regex.Matches(src, @"throw [A-Za-z]+ShapeGap\(").Count;
+            return Regex.Matches(src, @"throw (RecordPatches\.)?[A-Za-z]+ShapeGap\(").Count;
         });
 
-        // 48 corrected sites. A refusal DELETED rather than corrected would mean a precondition
-        // went back to being read as a default, which is the failure this whole change is about.
-        Assert.Equal(48, total);
+        // 48 in the sixteen populators + 3 in RecordPatches.cs's dispatch chain + 4 in
+        // AllProfileWritePatches.cs. A refusal DELETED rather than corrected would mean a
+        // precondition went back to being read as a default, which is the failure this whole
+        // change is about, so the count is asserted exactly.
+        Assert.Equal(55, total);
+    }
+
+
+    [Fact]
+    public void EachSurfaceAnchorIsSpelledInExactlyOneFile_SoOneTableCannotClaimTwoThings()
+    {
+        // The defect this guards against is what the sibling sweep found: RecordPatches.cs
+        // spelled "field-virtual-table" itself instead of calling the Field factory, so the
+        // same table refused with one claim from the populator and another from the dispatch
+        // chain. One anchor, one file, one claim.
+        var sources = Directory
+            .EnumerateFiles(Path.Combine(RepoRoot, "AlRunner"), "*.cs", SearchOption.AllDirectories)
+            .ToDictionary(
+                path => path,
+                path => string.Join('\n', File.ReadAllLines(path)
+                    .Where(l => !l.TrimStart().StartsWith("//", StringComparison.Ordinal))));
+
+        foreach (var row in Surfaces())
+        {
+            var anchor = (string)row[2];
+            // Whole-token match: "field-virtual-table" is a SUBSTRING of
+            // "page-control-field-virtual-table", so a plain Contains reports a false collision.
+            var whole = new Regex("(?<![a-z-])" + Regex.Escape(anchor) + "(?![a-z-])");
+            var owners = sources.Where(kv => whole.IsMatch(kv.Value))
+                                .Select(kv => Path.GetFileName(kv.Key))
+                                .OrderBy(n => n, StringComparer.Ordinal)
+                                .ToList();
+
+            Assert.True(owners.Count == 1,
+                $"anchor '{anchor}' is spelled in {owners.Count} files: {string.Join(", ", owners)}");
+        }
     }
 
     // ── The mechanism: a docAnchor may name its own doc file ─────────────────────────────

--- a/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
+++ b/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
@@ -1,0 +1,298 @@
+// VirtualTableRefusalClaimTests — what the 48 refusals in the sixteen
+// RecordPatches.*VirtualTable.cs populators actually claim, and what an AL [TryFunction]
+// does with one (#2945).
+//
+// WHY THIS IS A RUNNER-SIDE MECHANISM TEST AND NOT AN AL BUNDLE
+// ------------------------------------------------------------
+// Every one of the 48 fires when something the runner reflects on is absent or the wrong
+// shape: the in-memory data provider behind a DataAccess, an option string on the artifact's
+// own metatable, Microsoft's FeatureKeyDataProvider / WindowsLanguageHelper, or the host's
+// time zone database. No AL statement can make any of those disappear, so no bundle under
+// tests/runner-extras/ can drive one, and the existing virtual-table suites do not try (they
+// assert the rows, which is the in-scope half). The subject here is the C# refusal contract,
+// which .claude/rules/bc-behavior-tests-go-upstream.md classifies as runner-specific — the
+// same shape as TryFunctionOutOfScopeTrapTests and ObjectMetadataProviderRowProbeTests.
+//
+// WHAT WAS WRONG
+// --------------
+// All 48 ended "; see docs/scope.md" (rendered twice, since BuildMessage appends its own
+// link). docs/scope.md is the manifest of what is PERMANENTLY out of scope — SMTP, HTTP
+// egress, printing — and it says nothing about any of these tables, because the files raising
+// these refusals implement them.
+//
+// The claim is load-bearing, not decorative. ApplicationObjectBasePatches.IsPermanentOutOfScope:
+//
+//     return oos != null && !oos.Reason.StartsWith("not-yet-implemented", StringComparison.Ordinal);
+//
+// Under the old anchors that returned TRUE, so an AL [TryFunction] reading any of these
+// tables trapped a runner shape gap into `false` — the silent default
+// .claude/rules/loud-failures.md exists to prevent — and a test could go green having
+// quietly done without the table.
+//
+// HOW THIS TEST AVOIDS BEING A LIST THAT ROTS
+// -------------------------------------------
+// The per-surface facts are asserted against an explicit expected table (so a factory that
+// silently changes its API name or doc link fails), AND every `*ShapeGap` factory discovered
+// by reflection on RecordPatches has to satisfy the shared invariants (so a NEW virtual-table
+// factory added later is covered without anyone remembering to add it here).
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Xunit;
+using AlRunner;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+
+namespace AlRunner.Tests;
+
+public sealed class VirtualTableRefusalClaimTests
+{
+    private const string GapDoc = "docs/limitations.md#virtual-table-shape-gaps";
+    private const string TimeZoneDoc = "docs/limitations.md#time-zone-virtual-table";
+    private const string WindowsLanguageDoc = "docs/limitations.md#windows-language-virtual-table";
+
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    /// <summary>The sixteen files this issue covers. ObjectMetadataSystemTable is #2894's and
+    /// DateVirtualTable is #2648's — both deliberately outside this change.</summary>
+    private static readonly string[] CoveredFiles =
+    {
+        "RecordPatches.AggregatePermissionSetVirtualTable.cs",
+        "RecordPatches.AllObjVirtualTable.cs",
+        "RecordPatches.AllObjWithCaptionVirtualTable.cs",
+        "RecordPatches.AllProfileVirtualTable.cs",
+        "RecordPatches.CodeunitMetadataVirtualTable.cs",
+        "RecordPatches.FeatureKeyVirtualTable.cs",
+        "RecordPatches.FieldVirtualTable.cs",
+        "RecordPatches.IntegerVirtualTable.cs",
+        "RecordPatches.MetadataPermissionSetVirtualTable.cs",
+        "RecordPatches.PageControlFieldVirtualTable.cs",
+        "RecordPatches.PageMetadataVirtualTable.cs",
+        "RecordPatches.ReportLayoutListVirtualTable.cs",
+        "RecordPatches.ReportMetadataVirtualTable.cs",
+        "RecordPatches.TableMetadataVirtualTable.cs",
+        "RecordPatches.TimeZoneVirtualTable.cs",
+        "RecordPatches.WindowsLanguageVirtualTable.cs",
+    };
+
+    /// <summary>factory name → (api, surface anchor, doc link). One row per corrected surface.</summary>
+    public static IEnumerable<object[]> Surfaces() => new[]
+    {
+        new object[] { "AggregatePermissionSetShapeGap", "Aggregate Permission Set (virtual table 2000000167)", "aggregate-permission-set-virtual-table", GapDoc },
+        new object[] { "AllObjShapeGap",                 "AllObj (virtual table 2000000038)",                   "allobj-virtual-table",                   GapDoc },
+        new object[] { "AllObjWithCaptionShapeGap",      "AllObjWithCaption (virtual table 2000000058)",        "allobjwithcaption-virtual-table",         GapDoc },
+        new object[] { "AllProfileShapeGap",             "All Profile (virtual table 2000000178)",              "all-profile-virtual-table",              GapDoc },
+        new object[] { "CodeunitMetadataShapeGap",       "CodeUnit Metadata (virtual table 2000000137)",        "codeunit-metadata-virtual-table",         GapDoc },
+        new object[] { "FeatureKeyShapeGap",             "Feature Key (system table 2000000211)",               "feature-key-virtual-table",               GapDoc },
+        new object[] { "FeatureKeyModifyShapeGap",       "Feature Key (system table 2000000211): Modify",       "feature-key-modify",                      GapDoc },
+        new object[] { "FieldVirtualShapeGap",           "Field (virtual table 2000000041)",                    "field-virtual-table",                     GapDoc },
+        new object[] { "IntegerShapeGap",                "Integer (virtual table 2000000026)",                  "integer-virtual-table",                   GapDoc },
+        new object[] { "MetadataPermissionSetShapeGap",  "Metadata Permission Set (virtual table 2000000250)",  "metadata-permission-set-virtual-table",   GapDoc },
+        new object[] { "PageControlFieldShapeGap",       "Page Control Field (virtual table 2000000192)",       "page-control-field-virtual-table",        GapDoc },
+        new object[] { "PageMetadataShapeGap",           "Page Metadata (virtual table 2000000138)",            "page-metadata-virtual-table",             GapDoc },
+        new object[] { "ReportDataItemsShapeGap",        "Report Data Items (virtual table 2000000203)",        "report-data-items-virtual-table",         GapDoc },
+        new object[] { "ReportLayoutListShapeGap",       "Report Layout List (virtual table 2000000234)",       "report-layout-list-virtual-table",        GapDoc },
+        new object[] { "ReportMetadataShapeGap",         "Report Metadata (virtual table 2000000139)",          "report-metadata-virtual-table",           GapDoc },
+        new object[] { "TableMetadataShapeGap",          "Table Metadata (virtual table 2000000136)",           "table-metadata-virtual-table",            GapDoc },
+        new object[] { "TimeZoneShapeGap",               "Time Zone (virtual table 2000000164)",                "time-zone-virtual-table",                 TimeZoneDoc },
+        new object[] { "WindowsLanguageShapeGap",        "Windows Language (virtual table 2000000045)",         "windows-language-virtual-table",          WindowsLanguageDoc },
+    };
+
+    private static RunnerOutOfScopeException Raise(string factory, string detail = "the probe detail")
+    {
+        var m = typeof(RecordPatches).GetMethod(
+            factory, BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public,
+            binder: null, types: new[] { typeof(string) }, modifiers: null);
+        Assert.True(m != null, $"RecordPatches.{factory}(string) not found — the factory was renamed or removed.");
+        return (RunnerOutOfScopeException)m!.Invoke(null, new object?[] { detail })!;
+    }
+
+    /// <summary>Every <c>*ShapeGap(string)</c> factory on RecordPatches, discovered rather than listed.</summary>
+    private static IEnumerable<MethodInfo> AllShapeGapFactories() =>
+        typeof(RecordPatches)
+            .GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)
+            .Where(m => m.Name.EndsWith("ShapeGap", StringComparison.Ordinal)
+                     && m.ReturnType == typeof(RunnerOutOfScopeException)
+                     && m.GetParameters().Length == 1
+                     && m.GetParameters()[0].ParameterType == typeof(string));
+
+    // ── The claim: in scope, not yet answerable for the shape found ──────────────────────
+
+    [Theory]
+    [MemberData(nameof(Surfaces))]
+    public void Refusal_ClaimsNotYetImplemented_NotAPermanentScopeBoundary(
+        string factory, string api, string surface, string doc)
+    {
+        _ = doc;
+        var ex = Raise(factory);
+
+        Assert.Equal(api, ex.Api);
+        // StartsWith, not Contains: IsPermanentOutOfScope reads the FIRST token, and
+        // ExpectationManifest.ReasonAnchor cuts at the first em-dash separator.
+        Assert.StartsWith("not-yet-implemented", ex.Reason, StringComparison.Ordinal);
+        // The table's own anchor survives as the second token, so the surfaces stay distinct.
+        Assert.Contains(surface + ":", ex.Reason, StringComparison.Ordinal);
+        // And the caller's detail is carried through rather than swallowed.
+        Assert.Contains("the probe detail", ex.Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EveryDiscoveredFactory_ClaimsNotYetImplemented()
+    {
+        var factories = AllShapeGapFactories().ToList();
+        Assert.True(factories.Count >= 18,
+            $"expected at least the 18 virtual-table factories, found {factories.Count}");
+
+        foreach (var m in factories)
+        {
+            var ex = (RunnerOutOfScopeException)m.Invoke(null, new object?[] { "probe" })!;
+            Assert.StartsWith("not-yet-implemented", ex.Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain("docs/scope.md", ex.Message, StringComparison.Ordinal);
+        }
+    }
+
+    // ── The consequence: an AL [TryFunction] must NOT read a runner gap as `false` ───────
+
+    [Theory]
+    [MemberData(nameof(Surfaces))]
+    public void Refusal_TearsThroughATryFunction_InsteadOfReadingAsFalse(
+        string factory, string api, string surface, string doc)
+    {
+        _ = surface; _ = doc;
+
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
+            () => BcRuntime.NavApplicationObjectBase_TryInvoke(null, () => throw Raise(factory)));
+
+        Assert.Equal(api, ex.Api);
+    }
+
+    [Fact]
+    public void PermanentRefusal_IsStillTrappedByATryFunction_SoTheTestDiscriminatesOnTheClaim()
+    {
+        // The control arm. Same exception TYPE, but a surface that really is out of scope
+        // forever — real BC in an environment that also lacks SMTP answers `false` there, so
+        // trapping it is faithful. Without this arm the theory above could pass by
+        // discriminating on the exception type rather than on what the reason claims.
+        var permanent = new RunnerOutOfScopeException(
+            "NavEmail.Send", "email-smtp — no SMTP transport in the runner", "email");
+
+        Assert.False(BcRuntime.NavApplicationObjectBase_TryInvoke(null, () => throw permanent));
+    }
+
+    // ── The link: one of them, and it points at a section that exists ────────────────────
+
+    [Theory]
+    [MemberData(nameof(Surfaces))]
+    public void Refusal_LinksToTheDocThatActuallyDocumentsTheLimit(
+        string factory, string api, string surface, string doc)
+    {
+        _ = api; _ = surface;
+        var msg = Raise(factory).Message;
+
+        Assert.EndsWith(" — see " + doc, msg, StringComparison.Ordinal);
+        Assert.DoesNotContain("docs/scope.md", msg, StringComparison.Ordinal);
+
+        // Counted on "see docs/", not on the " — see " separator: the old defect was a reason
+        // string ending "; see docs/scope.md" with BuildMessage appending its own link after
+        // it, which leaves the separator count at 1 but renders the link twice.
+        Assert.Equal(1, msg.Split("see docs/").Length - 1);
+    }
+
+    [Fact]
+    public void TheDocAnchorsThesePointAt_Exist_AndScopeMdStillDocumentsNoneOfTheseTables()
+    {
+        var limitations = File.ReadAllText(Path.Combine(RepoRoot, "docs", "limitations.md"));
+        var scope = File.ReadAllText(Path.Combine(RepoRoot, "docs", "scope.md"));
+
+        foreach (var anchor in new[]
+                 { "virtual-table-shape-gaps", "time-zone-virtual-table", "windows-language-virtual-table" })
+            Assert.Contains($"<a id=\"{anchor}\"></a>", limitations, StringComparison.Ordinal);
+
+        // The reason the old link was wrong has to stay true, or this fix is moot: scope.md is
+        // the permanent manifest and names none of these tables.
+        foreach (var table in new[]
+                 { "AllObj", "Time Zone", "Windows Language", "Feature Key", "Page Control Field" })
+            Assert.DoesNotContain(table, scope, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ── The wire format the reporter and the expectations manifest read ──────────────────
+
+    [Theory]
+    [MemberData(nameof(Surfaces))]
+    public void TypedAndUntypedRecovery_AgreeOnTheApiAndTheReason(
+        string factory, string api, string surface, string doc)
+    {
+        _ = surface; _ = doc;
+        var ex = Raise(factory);
+
+        // Typed path: what tests/expectations/ matches on when the exception object survives.
+        var typed = OutOfScopeMessage.FromException(ex);
+        Assert.NotNull(typed);
+        Assert.True(typed!.Value.Typed);
+        Assert.Equal(api, typed.Value.Api);
+        Assert.Equal(ex.Reason, typed.Value.Reason);
+
+        // Untyped path: message text only, which is all a Cecil-injected throw site and the
+        // TRX reader get. It must recover the SAME pair. It cuts the api from the reason at
+        // the first " — ", which is why no api here may contain that separator — the Feature
+        // Key Modify surface used to, and the two paths silently disagreed (#2945).
+        Assert.True(OutOfScopeMessage.TryParse(ex.Message, out var parsed));
+        Assert.Equal(api, parsed.Api);
+        Assert.Equal(ex.Reason, parsed.Reason);
+        Assert.DoesNotContain("docs/", parsed.Reason, StringComparison.Ordinal);
+    }
+
+    // ── The shape cannot drift back ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void NoCoveredFileStillConstructsTheRefusalDirectly_OrCitesScopeMd()
+    {
+        foreach (var file in CoveredFiles)
+        {
+            var path = Path.Combine(RepoRoot, "AlRunner", "Patches", file);
+            Assert.True(File.Exists(path), $"{file} not found — was it renamed?");
+
+            // Comments are stripped first: the headers explain the history of this defect and
+            // have to be able to quote the old wording. The claim under test is about CODE.
+            var code = string.Join('\n', File.ReadAllLines(path)
+                .Where(l => !l.TrimStart().StartsWith("//", StringComparison.Ordinal)));
+
+            Assert.DoesNotContain("new RunnerOutOfScopeException(", code, StringComparison.Ordinal);
+            Assert.DoesNotContain("new AlRunner.Infrastructure.RunnerOutOfScopeException(", code, StringComparison.Ordinal);
+            Assert.DoesNotContain("docs/scope.md", code, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void AllFortyEightRefusalsStillExist_SoNoneWasDeletedRatherThanCorrected()
+    {
+        var total = CoveredFiles.Sum(file =>
+        {
+            var src = File.ReadAllText(Path.Combine(RepoRoot, "AlRunner", "Patches", file));
+            return Regex.Matches(src, @"throw [A-Za-z]+ShapeGap\(").Count;
+        });
+
+        // 48 corrected sites. A refusal DELETED rather than corrected would mean a precondition
+        // went back to being read as a default, which is the failure this whole change is about.
+        Assert.Equal(48, total);
+    }
+
+    // ── The mechanism: a docAnchor may name its own doc file ─────────────────────────────
+
+    [Theory]
+    [InlineData("email", "docs/scope.md#email")]
+    [InlineData("#email", "docs/scope.md#email")]
+    [InlineData(null, "docs/scope.md")]
+    [InlineData("docs/limitations.md#virtual-table-shape-gaps", "docs/limitations.md#virtual-table-shape-gaps")]
+    public void DocAnchorResolution(string? anchor, string expectedLink)
+    {
+        var ex = new RunnerOutOfScopeException("Some.Api", "some-reason", anchor);
+
+        Assert.EndsWith(" — see " + expectedLink, ex.Message, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner/Infrastructure/RunnerOutOfScopeException.cs
+++ b/AlRunner/Infrastructure/RunnerOutOfScopeException.cs
@@ -65,9 +65,25 @@ public sealed class RunnerOutOfScopeException : Exception
     // or just 'out-of-scope:' for any-OOS. Keep the prefix + " — " separators stable.
     private static string BuildMessage(string api, string reason, string? docAnchor)
     {
-        var link = docAnchor != null
-            ? $"docs/scope.md{(docAnchor.StartsWith("#") ? docAnchor : "#" + docAnchor)}"
-            : "docs/scope.md";
+        // A docAnchor that names its own doc file is used verbatim (#2894). scope.md is the
+        // manifest of what is permanently out of scope, and it is the right target for most
+        // refusals — but not for every one. An IN-SCOPE surface the runner cannot answer for
+        // yet is written up in docs/limitations.md, and pointing that case at scope.md sends
+        // the reader to a file with no matching section AND asserts a permanence that is not
+        // true. The twelve Object Metadata (2000000071) refusals in
+        // RecordPatches.ObjectMetadataSystemTable.cs are the case that showed it.
+        //
+        // OutOfScopeMessage.TryParse strips everything from " — see " onward, so the file name
+        // here is invisible to the expectations manifest and to the reporter's bucketing —
+        // this is a reader-facing pointer only, and widening it changes no classification.
+        const string DefaultDoc = "docs/scope.md";
+        var link = docAnchor switch
+        {
+            null => DefaultDoc,
+            var a when a.StartsWith("docs/", StringComparison.Ordinal) => a,
+            var a when a.StartsWith("#", StringComparison.Ordinal) => DefaultDoc + a,
+            var a => DefaultDoc + "#" + a,
+        };
         return $"{OutOfScopeMessage.Prefix}{api} — {reason} — see {link}";
     }
 }
@@ -77,7 +93,8 @@ public sealed class RunnerOutOfScopeException : Exception
 /// </summary>
 /// <param name="Api">BC API that was touched, e.g. <c>HttpClient.Get</c>.</param>
 /// <param name="Reason">
-/// Reason as written by the throw site: a <c>docs/scope.md</c> anchor,
+/// Reason as written by the throw site: an anchor (a <c>docs/scope.md</c> section
+/// for a permanent refusal, or <c>not-yet-implemented</c> for an in-scope one),
 /// optionally followed by free-text detail after an em-dash separator.
 /// Empty when the throw site did not carry one.
 /// </param>
@@ -180,6 +197,8 @@ public static class RunnerScope
     /// <summary>
     /// Permanently-out-of-scope API. <paramref name="docAnchor"/> is the
     /// section anchor under <c>docs/scope.md</c> (e.g. "email", "external-http").
+    /// A caller documenting an in-scope refusal elsewhere may pass a full
+    /// <c>docs/&lt;file&gt;.md#anchor</c> instead — see <c>BuildMessage</c>.
     /// </summary>
     public static void ThrowOutOfScope(string api, string reason, string docAnchor)
         => throw new RunnerOutOfScopeException(api, reason, docAnchor);

--- a/AlRunner/Patches/AllProfileWritePatches.cs
+++ b/AlRunner/Patches/AllProfileWritePatches.cs
@@ -115,10 +115,8 @@ public static class AllProfileWritePatches
         foreach (var f in RecordPatches.GetAllFields(rec.MetaTable!) ?? Enumerable.Empty<NCLMetaField>())
             if (string.Equals(f.FieldName, fieldName, StringComparison.OrdinalIgnoreCase))
                 return f.FieldNo;
-        throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-            "All Profile (virtual table 2000000178)",
-            $"all-profile-virtual-table — metatable has no \"{fieldName}\" field, so BC's write rules "
-            + "cannot be applied; see docs/scope.md");
+        throw RecordPatches.AllProfileShapeGap(
+            $"metatable has no \"{fieldName}\" field, so BC's write rules cannot be applied");
     }
 
     // Ncl's own resource class (internal, resx-generated). Located by the presence of the
@@ -134,23 +132,18 @@ public static class AllProfileWritePatches
             if (_messageCache.TryGetValue(resourceName, out var cached)) return cached;
 
             _langType ??= FindLangType()
-                ?? throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                    "All Profile (virtual table 2000000178)",
-                    "all-profile-virtual-table — Ncl's profile message resources could not be located, so "
-                    + "BC's own refusal wording cannot be reproduced; see docs/scope.md");
+                ?? throw RecordPatches.AllProfileShapeGap(
+                    "Ncl's profile message resources could not be located, so BC's own refusal "
+                    + "wording cannot be reproduced");
 
             var prop = _langType.GetProperty(resourceName,
                 BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
-                ?? throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                    "All Profile (virtual table 2000000178)",
-                    $"all-profile-virtual-table — Ncl states no '{resourceName}' message resource; "
-                    + "see docs/scope.md");
+                ?? throw RecordPatches.AllProfileShapeGap(
+                    $"Ncl states no '{resourceName}' message resource");
 
             var text = prop.GetValue(null) as string
-                ?? throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                    "All Profile (virtual table 2000000178)",
-                    $"all-profile-virtual-table — Ncl's '{resourceName}' message resource is empty; "
-                    + "see docs/scope.md");
+                ?? throw RecordPatches.AllProfileShapeGap(
+                    $"Ncl's '{resourceName}' message resource is empty");
 
             _messageCache[resourceName] = text;
             return text;

--- a/AlRunner/Patches/RecordPatches.AggregatePermissionSetVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AggregatePermissionSetVirtualTable.cs
@@ -126,6 +126,19 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
+    /// <summary>
+    /// Every refusal in this file, built in one place. See
+    /// RecordPatches.VirtualTableShapeGap.cs for the three-bucket classification and for
+    /// why the anchor is "not-yet-implemented" rather than a docs/scope.md section (#2945).
+    /// </summary>
+    /// <remarks>
+    /// Category (2) for both. One is a store-wiring gap. The other is skeleton state not yet
+    /// populated (NavSession.NCLMetadata), which is squarely the runner's own to fill in --
+    /// .claude/rules/loud-failures.md lists skeleton session state as in scope.
+    /// </remarks>
+    internal static RunnerOutOfScopeException AggregatePermissionSetShapeGap(string detail)
+        => VirtualTableShapeGap("Aggregate Permission Set (virtual table 2000000167)", "aggregate-permission-set-virtual-table", detail);
+
     internal const int AggregatePermissionSetVirtualTableId = 2000000167;
 
     private static bool _apsReflectionReady;
@@ -153,9 +166,7 @@ public static partial class RecordPatches
         EnsureDataAccessProviderReflection(dataAccess);
 
         var store = _pDataAccessDataProvider!.GetValue(dataAccess)
-            ?? throw new RunnerOutOfScopeException(
-                "Aggregate Permission Set (virtual table 2000000167)",
-                "aggregate-permission-set-virtual-table — data access has no in-memory provider; see docs/scope.md");
+            ?? throw AggregatePermissionSetShapeGap("data access has no in-memory provider");
 
         // Recompute the WHOLE union fresh on every touch — on a real service tier
         // Aggregate Permission Set has no persistent state of its own; every Get()/FindSet()
@@ -183,11 +194,10 @@ public static partial class RecordPatches
         EnsurePermissionMetadataPopulated();
 
         var nclMetadata = _apsSessionNclMetadata!.GetValue(session)
-            ?? throw new RunnerOutOfScopeException(
-                "Aggregate Permission Set (virtual table 2000000167)",
-                "aggregate-permission-set-virtual-table — NavSession.NCLMetadata is null on the "
-                + "skeleton session, so BC's own AggregatePermissionSetDataProvider cannot resolve "
-                + "the System/Tenant Permission Set tables it unions; see docs/scope.md");
+            ?? throw AggregatePermissionSetShapeGap(
+                "NavSession.NCLMetadata is null on the skeleton session, so BC's own "
+                + "AggregatePermissionSetDataProvider cannot resolve the System/Tenant Permission "
+                + "Set tables it unions");
 
         object bcProvider;
         List<object> systemRecords;

--- a/AlRunner/Patches/RecordPatches.AllObjVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AllObjVirtualTable.cs
@@ -58,6 +58,20 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
+    /// <summary>
+    /// Every refusal in this file, built in one place. See
+    /// RecordPatches.VirtualTableShapeGap.cs for the three-bucket classification and for
+    /// why the anchor is "not-yet-implemented" rather than a docs/scope.md section (#2945).
+    /// </summary>
+    /// <remarks>
+    /// Category (2) for all four. One is a store-wiring gap; the other three are BC metadata
+    /// shapes this file reads rather than owns. Refusing beats guessing an option ordinal: the
+    /// ordinal is a stored column value, so a wrong guess mis-keys every row it writes and no
+    /// test can see it.
+    /// </remarks>
+    internal static RunnerOutOfScopeException AllObjShapeGap(string detail)
+        => VirtualTableShapeGap("AllObj (virtual table 2000000038)", "allobj-virtual-table", detail);
+
     internal const int AllObjVirtualTableId = 2000000038;
 
     private const int AllObjFieldObjectType = 1;
@@ -99,9 +113,7 @@ public static partial class RecordPatches
         EnsureDataAccessProviderReflection(dataAccess);
 
         var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
-            ?? throw new RunnerOutOfScopeException(
-                "AllObj (virtual table 2000000038)",
-                "allobj-virtual-table — AllObj data access has no in-memory provider; see docs/scope.md");
+            ?? throw AllObjShapeGap("AllObj data access has no in-memory provider");
 
         var ordinals = EnsureAllObjObjectTypeOrdinals(allObjMetaTable);
         var done = _aovPopulatedByProvider.GetValue(provider, static _ => new ConcurrentDictionary<(int, int), byte>());
@@ -244,18 +256,14 @@ public static partial class RecordPatches
         var allFields = GetAllFields(allObjMetaTable);
         var typeField = (allFields ?? Enumerable.Empty<NCLMetaField>())
             .FirstOrDefault(f => f.FieldNo == AllObjFieldObjectType)
-            ?? throw new RunnerOutOfScopeException(
-                "AllObj (virtual table 2000000038)",
-                "allobj-virtual-table — AllObj metatable has no field 1 (\"Object Type\") "
+            ?? throw AllObjShapeGap(
+                "AllObj metatable has no field 1 (\"Object Type\") "
                 + $"[tableId={allObjMetaTable.TableId} name='{allObjMetaTable.TableName}' "
-                + $"allFields={(allFields == null ? "null" : string.Join("/", allFields.Select(f => f.FieldNo)))}]; "
-                + "see docs/scope.md");
+                + $"allFields={(allFields == null ? "null" : string.Join("/", allFields.Select(f => f.FieldNo)))}]");
 
         var optionMetadata = typeField.FieldOptionMetadata
-            ?? throw new RunnerOutOfScopeException(
-                "AllObj (virtual table 2000000038)",
-                "allobj-virtual-table — AllObj \"Object Type\" carries no option metadata, so its ordinals "
-                + "cannot be resolved; see docs/scope.md");
+            ?? throw AllObjShapeGap(
+                "AllObj \"Object Type\" carries no option metadata, so its ordinals cannot be resolved");
 
         var optionString = optionMetadata.OptionString ?? string.Empty;
         var map = new Dictionary<string, int>(StringComparer.Ordinal);
@@ -267,10 +275,7 @@ public static partial class RecordPatches
             map.TryAdd(key, i);
         }
         if (map.Count == 0)
-            throw new RunnerOutOfScopeException(
-                "AllObj (virtual table 2000000038)",
-                $"allobj-virtual-table — AllObj \"Object Type\" option string is empty ('{optionString}'); "
-                + "see docs/scope.md");
+            throw AllObjShapeGap($"AllObj \"Object Type\" option string is empty ('{optionString}')");
 
         if (Environment.GetEnvironmentVariable("ALRUNNER_ALLOBJ_TRACE") == "1")
             Console.Error.WriteLine("[RecordPatches] AllObj Object Type OptionString = '" + optionString + "' → "

--- a/AlRunner/Patches/RecordPatches.AllObjWithCaptionVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AllObjWithCaptionVirtualTable.cs
@@ -49,6 +49,20 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
+    /// <summary>
+    /// Every refusal in this file, built in one place. See
+    /// RecordPatches.VirtualTableShapeGap.cs for the three-bucket classification and for
+    /// why the anchor is "not-yet-implemented" rather than a docs/scope.md section (#2945).
+    /// </summary>
+    /// <remarks>
+    /// Category (2) for all four. One is a store-wiring gap; the other three are BC metadata
+    /// shapes this file reads rather than owns. Refusing beats guessing an option ordinal: the
+    /// ordinal is a stored column value, so a wrong guess mis-keys every row it writes and no
+    /// test can see it.
+    /// </remarks>
+    internal static RunnerOutOfScopeException AllObjWithCaptionShapeGap(string detail)
+        => VirtualTableShapeGap("AllObjWithCaption (virtual table 2000000058)", "allobjwithcaption-virtual-table", detail);
+
     internal const int AllObjWithCaptionVirtualTableId = 2000000058;
 
     // Per in-memory-provider guard, so repeated data-access handouts within one test only
@@ -71,9 +85,7 @@ public static partial class RecordPatches
         EnsureDataAccessProviderReflection(dataAccess);
 
         var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
-            ?? throw new RunnerOutOfScopeException(
-                "AllObjWithCaption (virtual table 2000000058)",
-                "allobjwithcaption-virtual-table — data access has no in-memory provider; see docs/scope.md");
+            ?? throw AllObjWithCaptionShapeGap("data access has no in-memory provider");
 
         // The Object Type option ordinals live on AllObjWithCaption's OWN field 1, not on
         // AllObj's: the two tables declare the same option set today, but reading the
@@ -140,15 +152,11 @@ public static partial class RecordPatches
 
         var typeField = (GetAllFields(metaTable) ?? Enumerable.Empty<NCLMetaField>())
             .FirstOrDefault(f => NormalizeObjectTypeName(f.FieldName ?? string.Empty) == "objecttype")
-            ?? throw new RunnerOutOfScopeException(
-                "AllObjWithCaption (virtual table 2000000058)",
-                "allobjwithcaption-virtual-table — metatable has no \"Object Type\" field, so its "
-                + "option ordinals cannot be resolved; see docs/scope.md");
+            ?? throw AllObjWithCaptionShapeGap(
+                "metatable has no \"Object Type\" field, so its option ordinals cannot be resolved");
 
         var optionMetadata = typeField.FieldOptionMetadata
-            ?? throw new RunnerOutOfScopeException(
-                "AllObjWithCaption (virtual table 2000000058)",
-                "allobjwithcaption-virtual-table — \"Object Type\" carries no option metadata; see docs/scope.md");
+            ?? throw AllObjWithCaptionShapeGap("\"Object Type\" carries no option metadata");
 
         var optionString = optionMetadata.OptionString ?? string.Empty;
         var map = new Dictionary<string, int>(StringComparer.Ordinal);
@@ -160,10 +168,7 @@ public static partial class RecordPatches
             map.TryAdd(key, i);
         }
         if (map.Count == 0)
-            throw new RunnerOutOfScopeException(
-                "AllObjWithCaption (virtual table 2000000058)",
-                $"allobjwithcaption-virtual-table — \"Object Type\" option string is empty ('{optionString}'); "
-                + "see docs/scope.md");
+            throw AllObjWithCaptionShapeGap($"\"Object Type\" option string is empty ('{optionString}')");
 
         _awcObjectTypeOrdinals = map;
         return map;

--- a/AlRunner/Patches/RecordPatches.AllProfileVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AllProfileVirtualTable.cs
@@ -61,6 +61,20 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
+    /// <summary>
+    /// Every refusal in this file, built in one place. See
+    /// RecordPatches.VirtualTableShapeGap.cs for the three-bucket classification and for
+    /// why the anchor is "not-yet-implemented" rather than a docs/scope.md section (#2945).
+    /// </summary>
+    /// <remarks>
+    /// Category (2), in scope and not yet answerable. This file populates the table, so the
+    /// one refusal here reports that the runner's own store wiring handed over no provider —
+    /// there is nothing to populate, and standing up a private store would answer with rows
+    /// nobody can read back.
+    /// </remarks>
+    internal static RunnerOutOfScopeException AllProfileShapeGap(string detail)
+        => VirtualTableShapeGap("All Profile (virtual table 2000000178)", "all-profile-virtual-table", detail);
+
     internal const int AllProfileVirtualTableId = 2000000178;
 
     /// <summary>
@@ -112,9 +126,7 @@ public static partial class RecordPatches
         EnsureDataAccessProviderReflection(dataAccess);
 
         var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
-            ?? throw new RunnerOutOfScopeException(
-                "All Profile (virtual table 2000000178)",
-                "all-profile-virtual-table — data access has no in-memory provider; see docs/scope.md");
+            ?? throw AllProfileShapeGap("data access has no in-memory provider");
 
         if (_apvPopulatedProviders.TryGetValue(provider, out _)) return;
         _apvPopulatedProviders.Add(provider, new object());

--- a/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
@@ -59,6 +59,20 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
+    /// <summary>
+    /// Every refusal in this file, built in one place. See
+    /// RecordPatches.VirtualTableShapeGap.cs for the three-bucket classification and for
+    /// why the anchor is "not-yet-implemented" rather than a docs/scope.md section (#2945).
+    /// </summary>
+    /// <remarks>
+    /// Category (2) for all four. One is a store-wiring gap; the other three are BC metadata
+    /// shapes this file reads rather than owns. Refusing beats guessing an option ordinal: the
+    /// ordinal is a stored column value, so a wrong guess mis-keys every row it writes and no
+    /// test can see it.
+    /// </remarks>
+    internal static RunnerOutOfScopeException CodeunitMetadataShapeGap(string detail)
+        => VirtualTableShapeGap("CodeUnit Metadata (virtual table 2000000137)", "codeunit-metadata-virtual-table", detail);
+
     internal const int CodeunitMetadataVirtualTableId = 2000000137;
 
     private static readonly ConditionalWeakTable<object, ConcurrentDictionary<int, byte>>
@@ -98,9 +112,7 @@ public static partial class RecordPatches
         var subtypeOrdinals = EnsureCodeunitSubtypeOrdinals(metaTable);
 
         var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
-            ?? throw new RunnerOutOfScopeException(
-                "CodeUnit Metadata (virtual table 2000000137)",
-                "codeunit-metadata-virtual-table — data access has no in-memory provider; see docs/scope.md");
+            ?? throw CodeunitMetadataShapeGap("data access has no in-memory provider");
 
         var done = _cmvPopulatedByProvider.GetValue(provider, static _ => new ConcurrentDictionary<int, byte>());
 
@@ -250,14 +262,10 @@ public static partial class RecordPatches
 
         var field = (GetAllFields(metaTable) ?? Enumerable.Empty<NCLMetaField>())
             .FirstOrDefault(f => NormalizeObjectTypeName(f.FieldName ?? string.Empty) == "subtype")
-            ?? throw new RunnerOutOfScopeException(
-                "CodeUnit Metadata (virtual table 2000000137)",
-                "codeunit-metadata-virtual-table — metatable has no \"Subtype\" field; see docs/scope.md");
+            ?? throw CodeunitMetadataShapeGap("metatable has no \"Subtype\" field");
 
         var optionMetadata = field.FieldOptionMetadata
-            ?? throw new RunnerOutOfScopeException(
-                "CodeUnit Metadata (virtual table 2000000137)",
-                "codeunit-metadata-virtual-table — \"Subtype\" carries no option metadata; see docs/scope.md");
+            ?? throw CodeunitMetadataShapeGap("\"Subtype\" carries no option metadata");
 
         var map = new Dictionary<string, int>(StringComparer.Ordinal);
         var parts = (optionMetadata.OptionString ?? string.Empty).Split(',');
@@ -268,9 +276,7 @@ public static partial class RecordPatches
             map.TryAdd(key, i);
         }
         if (map.Count == 0)
-            throw new RunnerOutOfScopeException(
-                "CodeUnit Metadata (virtual table 2000000137)",
-                "codeunit-metadata-virtual-table — \"Subtype\" option string is empty; see docs/scope.md");
+            throw CodeunitMetadataShapeGap("\"Subtype\" option string is empty");
 
         _cmvSubtypeOrdinals = map;
         return map;

--- a/AlRunner/Patches/RecordPatches.FeatureKeyVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.FeatureKeyVirtualTable.cs
@@ -54,6 +54,40 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
+    /// <summary>
+    /// Every refusal in this file, built in one place. See
+    /// RecordPatches.VirtualTableShapeGap.cs for the three-bucket classification and for
+    /// why the anchor is "not-yet-implemented" rather than a docs/scope.md section (#2945).
+    /// </summary>
+    /// <remarks>
+    /// Category (2) for all five. One is a store-wiring gap; the other four are BC's own
+    /// FeatureKeyDataProvider missing, throwing, or answering with nothing. Every one of those
+    /// already carried a comment saying why answering empty would be WRONG rather than
+    /// incomplete -- an empty Feature Key table makes every feature read as unregistered and
+    /// silently wins the legacy code path, which is the bug #2585 fixed.
+    /// </remarks>
+    internal static RunnerOutOfScopeException FeatureKeyShapeGap(string detail)
+        => VirtualTableShapeGap("Feature Key (system table 2000000211)", "feature-key-virtual-table", detail);
+
+    /// <summary>
+    /// Every refusal in this file, built in one place. See
+    /// RecordPatches.VirtualTableShapeGap.cs for the three-bucket classification and for
+    /// why the anchor is "not-yet-implemented" rather than a docs/scope.md section (#2945).
+    /// </summary>
+    /// <remarks>
+    /// Category (2) for all seven: BC's FeatureKeyDataProvider.FeatureKeyReadOnlyFields, or
+    /// Ncl's InvalidFeatureKeyField message resource, is not where this reads it.
+    /// 
+    /// The API name is punctuated with a colon, not an em-dash. OutOfScopeMessage.TryParse cuts
+    /// the api from the reason at the FIRST " \u2014 " in the message, so the old
+    /// "... 2000000211) \u2014 Modify" spelling made the untyped recovery path read the api as
+    /// "Feature Key (system table 2000000211)" and the reason as "Modify \u2014 feature-key-modify
+    /// ..." -- disagreeing with the typed path, which is the one the manifest matches on. AL
+    /// asserterror is unaffected: Assert.ExpectedError matches a prefix.
+    /// </remarks>
+    internal static RunnerOutOfScopeException FeatureKeyModifyShapeGap(string detail)
+        => VirtualTableShapeGap("Feature Key (system table 2000000211): Modify", "feature-key-modify", detail);
+
     internal const int FeatureKeyVirtualTableId = 2000000211;
 
     private static readonly ConditionalWeakTable<object, object> _fkPopulatedProviders = new();
@@ -79,9 +113,7 @@ public static partial class RecordPatches
         EnsureFeatureKeyReflection();
 
         var store = _pDataAccessDataProvider!.GetValue(dataAccess)
-            ?? throw new RunnerOutOfScopeException(
-                "Feature Key (system table 2000000211)",
-                "feature-key-virtual-table — data access has no in-memory provider; see docs/scope.md");
+            ?? throw FeatureKeyShapeGap("data access has no in-memory provider");
 
         if (_fkPopulatedProviders.TryGetValue(store, out _)) return;
 
@@ -93,13 +125,12 @@ public static partial class RecordPatches
         catch (Exception ex)
         {
             var inner = ex is TargetInvocationException tie && tie.InnerException != null ? tie.InnerException : ex;
-            throw new RunnerOutOfScopeException(
-                "Feature Key (system table 2000000211)",
-                "feature-key-virtual-table — BC's own FeatureKeyDataProvider could not be "
+            throw FeatureKeyShapeGap(
+                "BC's own FeatureKeyDataProvider could not be "
                 + $"constructed on the skeleton session ({inner.GetType().Name}: {inner.Message}). "
                 + "Its constructor reads the table's own metatable and the session's app group; "
                 + "rebuilding the feature list here instead would be a second copy of a list BC "
-                + "owns. See docs/scope.md and AlRunner#2585");
+                + "owns. See AlRunner#2585");
         }
 
         object? rows;
@@ -111,12 +142,11 @@ public static partial class RecordPatches
         catch (Exception ex)
         {
             var inner = ex is TargetInvocationException tie && tie.InnerException != null ? tie.InnerException : ex;
-            throw new RunnerOutOfScopeException(
-                "Feature Key (system table 2000000211)",
-                "feature-key-virtual-table — BC's own FeatureKeyDataProvider.GetAllItems failed "
+            throw FeatureKeyShapeGap(
+                "BC's own FeatureKeyDataProvider.GetAllItems failed "
                 + $"({inner.GetType().Name}: {inner.Message}). Answering with no rows would make "
                 + "every feature read as unregistered and silently win the legacy code path, "
-                + "which is the bug this fixes. See docs/scope.md and AlRunner#2585");
+                + "which is the bug this fixes. See AlRunner#2585");
         }
 
         var inserted = 0;
@@ -128,14 +158,13 @@ public static partial class RecordPatches
         }
 
         if (inserted == 0)
-            throw new RunnerOutOfScopeException(
-                "Feature Key (system table 2000000211)",
-                "feature-key-virtual-table — BC's own FeatureKeyDataProvider produced no rows. "
+            throw FeatureKeyShapeGap(
+                "BC's own FeatureKeyDataProvider produced no rows. "
                 + "Its feature list is a hardcoded static in Microsoft.Dynamics.Nav.Types, so an "
                 + "empty result means a modifier filtered everything out (a tenant state read, "
                 + "the FeatureKeyOverride setting, or ECS configuration filtering) rather than "
                 + "that BC ships no features. Silently answering empty would put back exactly "
-                + "the wrong-legacy-path bug this fixes. See docs/scope.md and AlRunner#2585");
+                + "the wrong-legacy-path bug this fixes. See AlRunner#2585");
 
         _fkPopulatedProviders.Add(store, new object());
     }
@@ -182,16 +211,12 @@ public static partial class RecordPatches
     internal static void GuardFeatureKeyReadOnlyFieldsOnModify(NavRecord self)
     {
         var meta = self.MetaTable
-            ?? throw new RunnerOutOfScopeException(
-                "Feature Key (system table 2000000211) — Modify",
-                "feature-key-modify — record carries no metatable; see docs/scope.md");
+            ?? throw FeatureKeyModifyShapeGap("record carries no metatable");
 
         var readOnlyFieldNos = ReadOnlyFieldNumbers();
 
         var keyField = meta.PrimaryKey?.GetKeyFieldByIndex(0)
-            ?? throw new RunnerOutOfScopeException(
-                "Feature Key (system table 2000000211) — Modify",
-                "feature-key-modify — metatable has no primary key field; see docs/scope.md");
+            ?? throw FeatureKeyModifyShapeGap("metatable has no primary key field");
         var keyValue = self.GetFieldValue(keyField.FieldNo);
 
         var original = new NavRecord(self.ParentSession, FeatureKeyVirtualTableId);
@@ -222,15 +247,11 @@ public static partial class RecordPatches
         EnsureFeatureKeyReflection();
         _fkReadOnlyFieldsField ??= _fkProviderType!.GetField(
             "FeatureKeyReadOnlyFields", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
-            ?? throw new RunnerOutOfScopeException(
-                "Feature Key (system table 2000000211) — Modify",
-                "feature-key-modify — BC's FeatureKeyDataProvider no longer declares "
-                + "FeatureKeyReadOnlyFields; see docs/scope.md");
+            ?? throw FeatureKeyModifyShapeGap(
+                "BC's FeatureKeyDataProvider no longer declares FeatureKeyReadOnlyFields");
 
         return (int[])(_fkReadOnlyFieldsField.GetValue(null)
-            ?? throw new RunnerOutOfScopeException(
-                "Feature Key (system table 2000000211) — Modify",
-                "feature-key-modify — FeatureKeyReadOnlyFields is null; see docs/scope.md"));
+            ?? throw FeatureKeyModifyShapeGap("FeatureKeyReadOnlyFields is null"));
     }
 
     private static Exception BuildFeatureKeyReadOnlyError(string fieldCaption)
@@ -260,23 +281,17 @@ public static partial class RecordPatches
         if (_fkInvalidFieldMessage != null) return _fkInvalidFieldMessage;
 
         _fkLangType ??= FindFeatureKeyLangType()
-            ?? throw new RunnerOutOfScopeException(
-                "Feature Key (system table 2000000211) — Modify",
-                "feature-key-modify — Ncl's InvalidFeatureKeyField message resource could not be "
-                + "located; see docs/scope.md");
+            ?? throw FeatureKeyModifyShapeGap(
+                "Ncl's InvalidFeatureKeyField message resource could not be located");
 
         var prop = _fkLangType.GetProperty("InvalidFeatureKeyField",
             BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
-            ?? throw new RunnerOutOfScopeException(
-                "Feature Key (system table 2000000211) — Modify",
-                "feature-key-modify — Ncl states no InvalidFeatureKeyField message resource; "
-                + "see docs/scope.md");
+            ?? throw FeatureKeyModifyShapeGap(
+                "Ncl states no InvalidFeatureKeyField message resource");
 
         var text = prop.GetValue(null) as string
-            ?? throw new RunnerOutOfScopeException(
-                "Feature Key (system table 2000000211) — Modify",
-                "feature-key-modify — Ncl's InvalidFeatureKeyField message resource is empty; "
-                + "see docs/scope.md");
+            ?? throw FeatureKeyModifyShapeGap(
+                "Ncl's InvalidFeatureKeyField message resource is empty");
 
         _fkInvalidFieldMessage = text;
         return text;
@@ -329,13 +344,12 @@ public static partial class RecordPatches
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
 
         if (_fkProviderType == null || _fkProviderCtor == null || _fkGetAllItems == null)
-            throw new RunnerOutOfScopeException(
-                "Feature Key (system table 2000000211)",
-                "feature-key-virtual-table — BC's FeatureKeyDataProvider does not expose the "
+            throw FeatureKeyShapeGap(
+                "BC's FeatureKeyDataProvider does not expose the "
                 + $"shape this drives (type={_fkProviderType != null}, "
                 + $"ctor(NavSession)={_fkProviderCtor != null}, GetAllItems={_fkGetAllItems != null}). "
                 + "A BC shape change says so here rather than being papered over with a "
-                + "hand-built feature list. See docs/scope.md");
+                + "hand-built feature list");
 
         _fkReflectionReady = true;
     }

--- a/AlRunner/Patches/RecordPatches.FieldVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.FieldVirtualTable.cs
@@ -54,6 +54,20 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
+    /// <summary>
+    /// Every refusal in this file, built in one place. See
+    /// RecordPatches.VirtualTableShapeGap.cs for the three-bucket classification and for
+    /// why the anchor is "not-yet-implemented" rather than a docs/scope.md section (#2945).
+    /// </summary>
+    /// <remarks>
+    /// Category (2) for all four: the managed FieldDataProvider row-builder could not be bound,
+    /// the store handed over no provider, BC's own GetFieldRecordBuffer threw for one field, or
+    /// its constructor threw. A field that cannot be projected must not silently vanish -- that
+    /// is the point of the third one -- and none of the four says the table is out of scope.
+    /// </remarks>
+    internal static RunnerOutOfScopeException FieldVirtualShapeGap(string detail)
+        => VirtualTableShapeGap("Field (virtual table 2000000041)", "field-virtual-table", detail);
+
     internal const int FieldVirtualTableId = 2000000041;
 
     // Reflection handles for the managed Field-row build + insert path.
@@ -95,15 +109,11 @@ public static partial class RecordPatches
         AlRunner.BcRuntime.EnsureMetadataProviderSeeded();
         EnsureFieldVirtualTableReflection(fieldMetaTable, session);
         if (_mGetFieldRecordBuffer == null || _mTtdpInsert == null || _ctorMutableFromReadOnly == null)
-            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                "Field (virtual table 2000000041)",
-                "field-virtual-table — managed FieldDataProvider row-builder could not be bound; see docs/scope.md");
+            throw FieldVirtualShapeGap("managed FieldDataProvider row-builder could not be bound");
 
         EnsureDataAccessProviderReflection(dataAccess);
         var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
-            ?? throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                "Field (virtual table 2000000041)",
-                "field-virtual-table — Field data access has no in-memory provider; see docs/scope.md");
+            ?? throw FieldVirtualShapeGap("Field data access has no in-memory provider");
 
         // Make our 2000000041 metatable report IsVirtualTable=false so BC's RecordImplementation
         // find takes the NORMAL (temp-table) DataAccess path. IsVirtualTable for table 2000000041
@@ -170,10 +180,9 @@ public static partial class RecordPatches
             {
                 // A single field that cannot be projected must not silently vanish nor
                 // poison the whole table — surface loudly so the gap is visible.
-                throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                    "Field (virtual table 2000000041)",
-                    $"field-virtual-table — GetFieldRecordBuffer threw for table {srcMeta.TableId} field: " +
-                    $"{tie.InnerException.GetType().Name}: {tie.InnerException.Message}; see docs/scope.md");
+                throw FieldVirtualShapeGap(
+                    $"GetFieldRecordBuffer threw for table {srcMeta.TableId} field: " +
+                    $"{tie.InnerException.GetType().Name}: {tie.InnerException.Message}");
             }
 
             var mutable = _ctorMutableFromReadOnly!.Invoke(new object?[] { readOnlyBuf })!;
@@ -385,10 +394,9 @@ public static partial class RecordPatches
             var seedState = AlRunner.BcRuntime.IsMetadataProviderSeeded()
                 ? "NavGlobal.MetadataProvider IS seeded (so that is not the cause)"
                 : "NavGlobal.MetadataProvider is NOT seeded";
-            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                "Field (virtual table 2000000041)",
-                $"field-virtual-table — FieldDataProvider ctor failed ({inner.GetType().Name}: {inner.Message}); " +
-                $"{seedState}; see docs/scope.md. Inner stack trace:\n{inner.StackTrace}");
+            throw FieldVirtualShapeGap(
+                $"FieldDataProvider ctor failed ({inner.GetType().Name}: {inner.Message}); " +
+                $"{seedState}. Inner stack trace:\n{inner.StackTrace}");
         }
 
         // Bind base.metaTable to OUR 2000000041 instance so emitted rows align with the

--- a/AlRunner/Patches/RecordPatches.IntegerVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.IntegerVirtualTable.cs
@@ -52,6 +52,18 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
+    /// <summary>
+    /// Every refusal in this file, built in one place. See
+    /// RecordPatches.VirtualTableShapeGap.cs for the three-bucket classification and for
+    /// why the anchor is "not-yet-implemented" rather than a docs/scope.md section (#2945).
+    /// </summary>
+    /// <remarks>
+    /// Category (2): the runner materialises this table, so the single refusal is a store-
+    /// wiring gap and never a statement that Integer is out of scope.
+    /// </remarks>
+    internal static RunnerOutOfScopeException IntegerShapeGap(string detail)
+        => VirtualTableShapeGap("Integer (virtual table 2000000026)", "integer-virtual-table", detail);
+
     internal const int IntegerVirtualTableId = 2000000026;
 
     /// <summary>
@@ -107,9 +119,7 @@ public static partial class RecordPatches
         EnsureDataAccessProviderReflection(dataAccess);
 
         var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
-            ?? throw new RunnerOutOfScopeException(
-                "Integer (virtual table 2000000026)",
-                "integer-virtual-table — Integer data access has no in-memory provider; see docs/scope.md");
+            ?? throw IntegerShapeGap("Integer data access has no in-memory provider");
 
         // Fixed window ⇒ populate exactly once per provider.
         if (_ivtPopulatedProviders.TryGetValue(provider, out _)) return;

--- a/AlRunner/Patches/RecordPatches.MetadataPermissionSetVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.MetadataPermissionSetVirtualTable.cs
@@ -81,6 +81,17 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
+    /// <summary>
+    /// Every refusal in this file, built in one place. See
+    /// RecordPatches.VirtualTableShapeGap.cs for the three-bucket classification and for
+    /// why the anchor is "not-yet-implemented" rather than a docs/scope.md section (#2945).
+    /// </summary>
+    /// <remarks>
+    /// Category (2): one store-wiring refusal, on a table this file populates.
+    /// </remarks>
+    internal static RunnerOutOfScopeException MetadataPermissionSetShapeGap(string detail)
+        => VirtualTableShapeGap("Metadata Permission Set (virtual table 2000000250)", "metadata-permission-set-virtual-table", detail);
+
     internal const int MetadataPermissionSetVirtualTableId = 2000000250;
 
     // Per in-memory-provider guard so repeated data-access handouts only insert roles
@@ -108,9 +119,7 @@ public static partial class RecordPatches
         EnsureDataAccessProviderReflection(dataAccess);
 
         var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
-            ?? throw new RunnerOutOfScopeException(
-                "Metadata Permission Set (virtual table 2000000250)",
-                "metadata-permission-set-virtual-table — data access has no in-memory provider; see docs/scope.md");
+            ?? throw MetadataPermissionSetShapeGap("data access has no in-memory provider");
 
         var done = _mpsPopulatedByProvider.GetValue(provider, static _ => new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase));
 

--- a/AlRunner/Patches/RecordPatches.PageControlFieldVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.PageControlFieldVirtualTable.cs
@@ -54,6 +54,17 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
+    /// <summary>
+    /// Every refusal in this file, built in one place. See
+    /// RecordPatches.VirtualTableShapeGap.cs for the three-bucket classification and for
+    /// why the anchor is "not-yet-implemented" rather than a docs/scope.md section (#2945).
+    /// </summary>
+    /// <remarks>
+    /// Category (2): one store-wiring refusal, on a table this file populates.
+    /// </remarks>
+    internal static RunnerOutOfScopeException PageControlFieldShapeGap(string detail)
+        => VirtualTableShapeGap("Page Control Field (virtual table 2000000192)", "page-control-field-virtual-table", detail);
+
     internal const int PageControlFieldVirtualTableId = 2000000192;
 
     private static readonly ConditionalWeakTable<object, ConcurrentDictionary<(int PageNo, int ControlId), byte>> _pcfvPopulatedByProvider = new();
@@ -76,9 +87,7 @@ public static partial class RecordPatches
         EnsureDataAccessProviderReflection(dataAccess);
 
         var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
-            ?? throw new RunnerOutOfScopeException(
-                "Page Control Field (virtual table 2000000192)",
-                "page-control-field-virtual-table — data access has no in-memory provider; see docs/scope.md");
+            ?? throw PageControlFieldShapeGap("data access has no in-memory provider");
 
         var done = _pcfvPopulatedByProvider.GetValue(provider, static _ => new ConcurrentDictionary<(int, int), byte>());
 

--- a/AlRunner/Patches/RecordPatches.PageMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.PageMetadataVirtualTable.cs
@@ -70,6 +70,20 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
+    /// <summary>
+    /// Every refusal in this file, built in one place. See
+    /// RecordPatches.VirtualTableShapeGap.cs for the three-bucket classification and for
+    /// why the anchor is "not-yet-implemented" rather than a docs/scope.md section (#2945).
+    /// </summary>
+    /// <remarks>
+    /// Category (2) for all four. One is a store-wiring gap; the other three are BC metadata
+    /// shapes this file reads rather than owns. Refusing beats guessing an option ordinal: the
+    /// ordinal is a stored column value, so a wrong guess mis-keys every row it writes and no
+    /// test can see it.
+    /// </remarks>
+    internal static RunnerOutOfScopeException PageMetadataShapeGap(string detail)
+        => VirtualTableShapeGap("Page Metadata (virtual table 2000000138)", "page-metadata-virtual-table", detail);
+
     internal const int PageMetadataVirtualTableId = 2000000138;
 
     private static readonly ConditionalWeakTable<object, ConcurrentDictionary<int, byte>> _pmvPopulatedByProvider = new();
@@ -107,9 +121,7 @@ public static partial class RecordPatches
         var pageTypeOrdinals = EnsurePageTypeOrdinals(metaTable);
 
         var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
-            ?? throw new RunnerOutOfScopeException(
-                "Page Metadata (virtual table 2000000138)",
-                "page-metadata-virtual-table — data access has no in-memory provider; see docs/scope.md");
+            ?? throw PageMetadataShapeGap("data access has no in-memory provider");
 
         var done = _pmvPopulatedByProvider.GetValue(provider, static _ => new ConcurrentDictionary<int, byte>());
 
@@ -258,14 +270,10 @@ public static partial class RecordPatches
 
         var field = (GetAllFields(metaTable) ?? Enumerable.Empty<NCLMetaField>())
             .FirstOrDefault(f => NormalizeObjectTypeName(f.FieldName ?? string.Empty) == "pagetype")
-            ?? throw new RunnerOutOfScopeException(
-                "Page Metadata (virtual table 2000000138)",
-                "page-metadata-virtual-table — metatable has no \"PageType\" field; see docs/scope.md");
+            ?? throw PageMetadataShapeGap("metatable has no \"PageType\" field");
 
         var optionMetadata = field.FieldOptionMetadata
-            ?? throw new RunnerOutOfScopeException(
-                "Page Metadata (virtual table 2000000138)",
-                "page-metadata-virtual-table — \"PageType\" carries no option metadata; see docs/scope.md");
+            ?? throw PageMetadataShapeGap("\"PageType\" carries no option metadata");
 
         var map = new Dictionary<string, int>(StringComparer.Ordinal);
         var parts = (optionMetadata.OptionString ?? string.Empty).Split(',');
@@ -276,9 +284,7 @@ public static partial class RecordPatches
             map.TryAdd(key, i);
         }
         if (map.Count == 0)
-            throw new RunnerOutOfScopeException(
-                "Page Metadata (virtual table 2000000138)",
-                "page-metadata-virtual-table — \"PageType\" option string is empty; see docs/scope.md");
+            throw PageMetadataShapeGap("\"PageType\" option string is empty");
 
         _pmvPageTypeOrdinals = map;
         return map;

--- a/AlRunner/Patches/RecordPatches.ReportLayoutListVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.ReportLayoutListVirtualTable.cs
@@ -61,6 +61,19 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
+    /// <summary>
+    /// Every refusal in this file, built in one place. See
+    /// RecordPatches.VirtualTableShapeGap.cs for the three-bucket classification and for
+    /// why the anchor is "not-yet-implemented" rather than a docs/scope.md section (#2945).
+    /// </summary>
+    /// <remarks>
+    /// Category (2) for both. One is a store-wiring gap. The other is a layout Type this BC
+    /// version's option set does not declare: BC's own format fork keys off that ordinal, so
+    /// guessing one would silently send a layout down the wrong renderer.
+    /// </remarks>
+    internal static RunnerOutOfScopeException ReportLayoutListShapeGap(string detail)
+        => VirtualTableShapeGap("Report Layout List (virtual table 2000000234)", "report-layout-list-virtual-table", detail);
+
     internal const int ReportLayoutListVirtualTableId = 2000000234;
 
     // Per in-memory-provider guard so repeated data-access handouts only insert
@@ -81,9 +94,7 @@ public static partial class RecordPatches
         EnsureDataAccessProviderReflection(dataAccess);
 
         var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
-            ?? throw new RunnerOutOfScopeException(
-                "Report Layout List (virtual table 2000000234)",
-                "report-layout-list-virtual-table — data access has no in-memory provider; see docs/scope.md");
+            ?? throw ReportLayoutListShapeGap("data access has no in-memory provider");
 
         var done = _rllPopulatedByProvider.GetValue(provider, static _ => new ConcurrentDictionary<(int, string), byte>());
 
@@ -155,11 +166,10 @@ public static partial class RecordPatches
                     // A layout Type this BC version's option set does not know is not
                     // something we may guess at — BC's format fork keys off this value.
                     if (ordinal < 0)
-                        throw new RunnerOutOfScopeException(
-                            "Report Layout List (virtual table 2000000234)",
-                            $"report-layout-list-virtual-table — report {layout.ReportId} layout '{layout.Name}' declares "
+                        throw ReportLayoutListShapeGap(
+                            $"report {layout.ReportId} layout '{layout.Name}' declares "
                             + $"Type = '{layout.LayoutType}', which is not in this BC version's "
-                            + $"\"{field.FieldName}\" option set ('{field.FieldOptionMetadata?.OptionString}'); see docs/scope.md");
+                            + $"\"{field.FieldName}\" option set ('{field.FieldOptionMetadata?.OptionString}')");
                     return _aovNavOptionCreate!.Invoke(null, new object?[] { field.FieldOptionMetadata, ordinal });
                 }
             // Every other column — Company Name, App ID, Layout/Media GUIDs, User Defined,

--- a/AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs
@@ -61,6 +61,29 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
+    /// <summary>
+    /// Every refusal in this file, built in one place. See
+    /// RecordPatches.VirtualTableShapeGap.cs for the three-bucket classification and for
+    /// why the anchor is "not-yet-implemented" rather than a docs/scope.md section (#2945).
+    /// </summary>
+    /// <remarks>
+    /// Category (2): one store-wiring refusal, on a table this file populates.
+    /// </remarks>
+    internal static RunnerOutOfScopeException ReportMetadataShapeGap(string detail)
+        => VirtualTableShapeGap("Report Metadata (virtual table 2000000139)", "report-metadata-virtual-table", detail);
+
+    /// <summary>
+    /// Every refusal in this file, built in one place. See
+    /// RecordPatches.VirtualTableShapeGap.cs for the three-bucket classification and for
+    /// why the anchor is "not-yet-implemented" rather than a docs/scope.md section (#2945).
+    /// </summary>
+    /// <remarks>
+    /// Category (2): the sibling table populated from the same report inventory, with the
+    /// same single store-wiring refusal.
+    /// </remarks>
+    internal static RunnerOutOfScopeException ReportDataItemsShapeGap(string detail)
+        => VirtualTableShapeGap("Report Data Items (virtual table 2000000203)", "report-data-items-virtual-table", detail);
+
     internal const int ReportMetadataVirtualTableId = 2000000139;
     internal const int ReportDataItemsVirtualTableId = 2000000203;
 
@@ -109,9 +132,7 @@ public static partial class RecordPatches
         EnsureDataAccessProviderReflection(dataAccess);
 
         var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
-            ?? throw new RunnerOutOfScopeException(
-                "Report Metadata (virtual table 2000000139)",
-                "report-metadata-virtual-table — data access has no in-memory provider; see docs/scope.md");
+            ?? throw ReportMetadataShapeGap("data access has no in-memory provider");
 
         var done = _rmvPopulatedByProvider.GetValue(provider, static _ => new ConcurrentDictionary<int, byte>());
 
@@ -136,9 +157,7 @@ public static partial class RecordPatches
         EnsureDataAccessProviderReflection(dataAccess);
 
         var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
-            ?? throw new RunnerOutOfScopeException(
-                "Report Data Items (virtual table 2000000203)",
-                "report-data-items-virtual-table — data access has no in-memory provider; see docs/scope.md");
+            ?? throw ReportDataItemsShapeGap("data access has no in-memory provider");
 
         var done = _rdiPopulatedByProvider.GetValue(provider, static _ => new ConcurrentDictionary<(int, int), byte>());
 

--- a/AlRunner/Patches/RecordPatches.TableMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.TableMetadataVirtualTable.cs
@@ -61,6 +61,17 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
+    /// <summary>
+    /// Every refusal in this file, built in one place. See
+    /// RecordPatches.VirtualTableShapeGap.cs for the three-bucket classification and for
+    /// why the anchor is "not-yet-implemented" rather than a docs/scope.md section (#2945).
+    /// </summary>
+    /// <remarks>
+    /// Category (2): one store-wiring refusal, on a table this file populates.
+    /// </remarks>
+    internal static RunnerOutOfScopeException TableMetadataShapeGap(string detail)
+        => VirtualTableShapeGap("Table Metadata (virtual table 2000000136)", "table-metadata-virtual-table", detail);
+
     internal const int TableMetadataVirtualTableId = 2000000136;
 
     private static readonly ConditionalWeakTable<object, ConcurrentDictionary<int, byte>> _tmvPopulatedByProvider = new();
@@ -99,9 +110,7 @@ public static partial class RecordPatches
         EnsureDataAccessProviderReflection(dataAccess);
 
         var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
-            ?? throw new RunnerOutOfScopeException(
-                "Table Metadata (virtual table 2000000136)",
-                "table-metadata-virtual-table — data access has no in-memory provider; see docs/scope.md");
+            ?? throw TableMetadataShapeGap("data access has no in-memory provider");
 
         var done = _tmvPopulatedByProvider.GetValue(provider, static _ => new ConcurrentDictionary<int, byte>());
 

--- a/AlRunner/Patches/RecordPatches.TimeZoneVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.TimeZoneVirtualTable.cs
@@ -64,6 +64,23 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
+    /// <summary>
+    /// Every refusal in this file, built in one place. See
+    /// RecordPatches.VirtualTableShapeGap.cs for the three-bucket classification and for
+    /// why the anchor is "not-yet-implemented" rather than a docs/scope.md section (#2945).
+    /// </summary>
+    /// <remarks>
+    /// Category (2) for both, and neither is the documented Time Zone DIVERGENCE. That
+    /// divergence -- IANA ids on a Linux host where a Windows-hosted tier reports Windows ids
+    /// -- is a real answer this provider gives on purpose, and it never throws. These two
+    /// refusals are the runner failing to answer at all: no in-memory provider, or a host with
+    /// no usable time zone database. Both point at the table's own limitations.md section,
+    /// which is where a reader who hits either one needs to end up.
+    /// </remarks>
+    internal static RunnerOutOfScopeException TimeZoneShapeGap(string detail)
+        => VirtualTableShapeGap("Time Zone (virtual table 2000000164)", "time-zone-virtual-table", detail,
+            "docs/limitations.md#time-zone-virtual-table");
+
     internal const int TimeZoneVirtualTableId = 2000000164;
 
     // One-shot per provider, unlike AllObj's per-id memo: the host's time zone list cannot
@@ -85,9 +102,7 @@ public static partial class RecordPatches
         EnsureDataAccessProviderReflection(dataAccess);
 
         var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
-            ?? throw new RunnerOutOfScopeException(
-                "Time Zone (virtual table 2000000164)",
-                "time-zone-virtual-table — data access has no in-memory provider; see docs/scope.md");
+            ?? throw TimeZoneShapeGap("data access has no in-memory provider");
 
         if (_tzPopulatedProviders.TryGetValue(provider, out _)) return;
 
@@ -101,13 +116,11 @@ public static partial class RecordPatches
         }
         catch (Exception ex)
         {
-            throw new RunnerOutOfScopeException(
-                "Time Zone (virtual table 2000000164)",
-                "time-zone-virtual-table — the host reports no usable time zone database "
+            throw TimeZoneShapeGap(
+                "the host reports no usable time zone database "
                 + $"({ex.GetType().Name}: {ex.Message}). BC's own TimeZoneDataProvider reads the "
                 + "same TimeZoneInfo.GetSystemTimeZones(), so there is no other source to answer "
-                + "from, and an empty table would be a wrong answer rather than a missing one. "
-                + "See docs/scope.md");
+                + "from, and an empty table would be a wrong answer rather than a missing one");
         }
 
         for (var i = 0; i < zones.Count; i++)

--- a/AlRunner/Patches/RecordPatches.VirtualTableShapeGap.cs
+++ b/AlRunner/Patches/RecordPatches.VirtualTableShapeGap.cs
@@ -1,0 +1,110 @@
+// RecordPatches.VirtualTableShapeGap — the one place a virtual-table populator in this
+// directory builds its refusal, and the per-surface classification behind it (#2945).
+//
+// ── WHAT WAS WRONG ───────────────────────────────────────────────────────────────────────
+//   Every RecordPatches.*VirtualTable.cs populator refused the same way:
+//
+//       ?? throw new RunnerOutOfScopeException(
+//              "AllObj (virtual table 2000000038)",
+//              "allobj-virtual-table — AllObj data access has no in-memory provider; "
+//              + "see docs/scope.md");
+//
+//   docs/scope.md is the manifest of what is PERMANENTLY out of scope — SMTP, HTTP egress,
+//   printing, a real task scheduler. Not one of these tables is in it, and the files raising
+//   these refusals IMPLEMENT the tables: .claude/rules/loud-failures.md puts AL records
+//   squarely in scope. So the citation told the next developer the surface would never work
+//   and to stop looking, and it did it twice over — the reason string ended "see
+//   docs/scope.md" and RunnerOutOfScopeException.BuildMessage appended its own default link
+//   after it.
+//
+//   The claim also had a runtime consequence, which is why this is a correctness fix and not
+//   a wording one. ApplicationObjectBasePatches.IsPermanentOutOfScope:
+//
+//       return oos != null && !oos.Reason.StartsWith("not-yet-implemented", StringComparison.Ordinal);
+//
+//   Under the old anchors that returned TRUE, so an AL [TryFunction] reading any of these
+//   tables trapped a runner shape gap into `false` — the silent default loud-failures.md
+//   exists to prevent. A test could go green having quietly done without the table. With the
+//   "not-yet-implemented" anchor the refusal tears through instead.
+//
+// ── CLASSIFYING THE 48 SITES ─────────────────────────────────────────────────────────────
+//   Every site was read and put in one of three buckets before it was touched:
+//
+//     (1) genuinely out of scope        — keep the refusal, correct the reason.  0 sites.
+//     (2) in scope, not yet answerable  — "not-yet-implemented" anchor.         48 sites.
+//     (3) implementable now             — say what it would take.                0 sites.
+//
+//   Nothing landed in (1). To be in (1) a refusal has to be faithful to real BC: BC itself
+//   must be unable to answer, so an AL [TryFunction] reading `false` is the OBSERVABLE BC
+//   OUTCOME rather than a runner gap. Every one of these tables answers on a real service
+//   tier, so a refusal here is always the runner failing to keep up, never BC's answer.
+//
+//   Nothing landed in (3) either, and that is worth stating precisely rather than assuming.
+//   These are not unbuilt features waiting for someone to build them; they are preconditions
+//   that hold in every supported configuration. Three shapes, all of them:
+//
+//     a. "data access has no in-memory provider" (16 sites, one per populator plus Field's
+//        row-builder bind). The runner's own store wiring did not hand a provider over.
+//        There is nothing to populate, and standing up a private store here would answer
+//        with rows nobody can read back.
+//     b. "BC's metatable / option string / helper type is not the shape this drives"
+//        (23 sites). The artifact's own metadata is the row set or the ordinal source. A
+//        hardcoded fallback would be an invented answer, and for an option ordinal it is
+//        worse than that: the ordinal is a stored column value, so a wrong guess mis-keys
+//        every row silently. Naming the member that moved is the whole value of the refusal.
+//     c. "BC's own provider threw, or produced nothing" (9 sites). Feature Key, Field, Time
+//        Zone and Windows Language all delegate to Microsoft's provider or to the host, and
+//        each of these guards already carries a comment explaining why answering empty would
+//        be a wrong answer rather than a missing one (an empty Feature Key table silently
+//        wins every legacy code path; an empty Time Zone table is the bug #2584 fixed).
+//
+//   Two surfaces have a doc section of their own and point at it — Time Zone and Windows
+//   Language both document a real, permanent DIVERGENCE (host-derived ids; chosen license
+//   columns) that is separate from these shape gaps. Everything else points at
+//   docs/limitations.md#virtual-table-shape-gaps.
+//
+//   What the "not-yet-implemented" anchor tracks is #2946: the runner has no exception type
+//   that says "I could not read BC's internals here", and the conventions in this directory
+//   disagree about which one to raise for exactly that. That issue stays open.
+//
+// ── DELIBERATELY NOT COVERED HERE ────────────────────────────────────────────────────────
+//   RecordPatches.ObjectMetadataSystemTable.cs got the same treatment under #2894 and keeps
+//   its own ObjectMetadataShapeGap factory. RecordPatches.DateVirtualTable.cs is left alone:
+//   it is being changed concurrently under #2648, and its eight refusals are tracked
+//   separately rather than merged into a conflict. #2766 is the separate doubled-link sweep
+//   across the ~45 sites OUTSIDE this directory; the doubling is fixed here only as a
+//   consequence of rewriting these reason strings.
+
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    /// <summary>
+    /// The doc section that documents this class of refusal. NOT <c>docs/scope.md</c>: that
+    /// file is the permanently-out-of-scope manifest and says nothing about any of these
+    /// tables (#2945).
+    /// </summary>
+    internal const string VirtualTableGapDoc = "docs/limitations.md#virtual-table-shape-gaps";
+
+    /// <summary>
+    /// Build the refusal a virtual-table populator raises when BC's shape, the host, or the
+    /// runner's own store is not what the populator needs. See this file's header for the
+    /// per-site classification and for why the anchor is <c>not-yet-implemented</c> rather
+    /// than a <c>docs/scope.md</c> section.
+    ///
+    /// <para>The table's old anchor is kept as the second token of the reason, so a reader
+    /// (and any future expectations entry) can still tell the surfaces apart. No manifest
+    /// entry matches on these anchors today — <c>ExpectationManifest.ReasonAnchor</c> cuts at
+    /// the first em-dash separator, so the anchor these now report is
+    /// <c>not-yet-implemented</c>.</para>
+    /// </summary>
+    /// <param name="api">The BC surface the AL author touched, e.g. "AllObj (virtual table 2000000038)".</param>
+    /// <param name="surface">The table's own anchor, e.g. "allobj-virtual-table".</param>
+    /// <param name="detail">What was actually missing — the member that moved, the empty list.</param>
+    /// <param name="docLink">Where the reader should look; defaults to the shape-gaps section.</param>
+    internal static RunnerOutOfScopeException VirtualTableShapeGap(
+        string api, string surface, string detail, string docLink = VirtualTableGapDoc)
+        => new(api, $"not-yet-implemented — {surface}: {detail}", docLink);
+}

--- a/AlRunner/Patches/RecordPatches.VirtualTableShapeGap.cs
+++ b/AlRunner/Patches/RecordPatches.VirtualTableShapeGap.cs
@@ -69,11 +69,23 @@
 //
 // ── DELIBERATELY NOT COVERED HERE ────────────────────────────────────────────────────────
 //   RecordPatches.ObjectMetadataSystemTable.cs got the same treatment under #2894 and keeps
-//   its own ObjectMetadataShapeGap factory. RecordPatches.DateVirtualTable.cs is left alone:
-//   it is being changed concurrently under #2648, and its eight refusals are tracked
-//   separately rather than merged into a conflict. #2766 is the separate doubled-link sweep
-//   across the ~45 sites OUTSIDE this directory; the doubling is fixed here only as a
-//   consequence of rewriting these reason strings.
+//   its own ObjectMetadataShapeGap factory.
+//
+//   RecordPatches.DateVirtualTable.cs is left alone: it is being changed concurrently under
+//   #2648, so a factory edit across its eight refusals would have collided with that work.
+//   Tracked as #2965 rather than swept here, and one of its eight (the row-cap refusal, which
+//   tests/runner-extras/date-virtual-table-window pins) may not classify the same way as the
+//   other seven — that issue says so instead of assuming.
+//
+//   96 further "see docs/scope.md" citations sit in 23 files outside this directory. MOST are
+//   correct — SMTP, HTTP egress, file storage and printing really are permanent — but at least
+//   one is the same defect (RecordPatches.QueryProjection.cs's
+//   "query-join-synthesized-subquery-not-implemented", whose anchor says not-implemented in
+//   words yet does not START with "not-yet-implemented", so a [TryFunction] swallows it).
+//   Measured and tracked in #2966; classifying them is the work, not deleting the citation.
+//
+//   #2766 is the separate doubled-link sweep (it measured capital-S "See docs/scope.md"); the
+//   doubling is fixed here only as a consequence of rewriting these reason strings.
 
 using AlRunner.Infrastructure;
 

--- a/AlRunner/Patches/RecordPatches.WindowsLanguageVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.WindowsLanguageVirtualTable.cs
@@ -85,6 +85,22 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
+    /// <summary>
+    /// Every refusal in this file, built in one place. See
+    /// RecordPatches.VirtualTableShapeGap.cs for the three-bucket classification and for
+    /// why the anchor is "not-yet-implemented" rather than a docs/scope.md section (#2945).
+    /// </summary>
+    /// <remarks>
+    /// Category (2) for all three, and none of them is the documented Windows Language
+    /// DIVERGENCE. The chosen license and installed-resource column values are answers this
+    /// provider gives on purpose and never throws for. These three fire when the runner cannot
+    /// answer at all: no in-memory provider, or BC's own WindowsLanguageHelper missing or not
+    /// the shape its provider uses. All three point at the table's limitations.md section.
+    /// </remarks>
+    internal static RunnerOutOfScopeException WindowsLanguageShapeGap(string detail)
+        => VirtualTableShapeGap("Windows Language (virtual table 2000000045)", "windows-language-virtual-table", detail,
+            "docs/limitations.md#windows-language-virtual-table");
+
     internal const int WindowsLanguageVirtualTableId = 2000000045;
 
     // One-shot per provider: BC's culture list cannot change during a run.
@@ -118,9 +134,7 @@ public static partial class RecordPatches
         EnsureWindowsLanguageHelperReflection();
 
         var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
-            ?? throw new RunnerOutOfScopeException(
-                "Windows Language (virtual table 2000000045)",
-                "windows-language-virtual-table — data access has no in-memory provider; see docs/scope.md");
+            ?? throw WindowsLanguageShapeGap("data access has no in-memory provider");
 
         if (_wlPopulatedProviders.TryGetValue(provider, out _)) return;
 
@@ -206,12 +220,10 @@ public static partial class RecordPatches
         var navTypes = AppDomain.CurrentDomain.GetAssemblies()
             .FirstOrDefault(a => a.GetName().Name == "Microsoft.Dynamics.Nav.Types");
         var helper = navTypes?.GetType("Microsoft.Dynamics.Nav.Types.WindowsLanguageHelper")
-            ?? throw new RunnerOutOfScopeException(
-                "Windows Language (virtual table 2000000045)",
-                "windows-language-virtual-table — Microsoft.Dynamics.Nav.Types.WindowsLanguageHelper "
-                + "was not found, so BC's own culture list cannot be read. Reimplementing it from "
-                + "CultureInfo would answer a different row set than the service tier. "
-                + "See docs/scope.md");
+            ?? throw WindowsLanguageShapeGap(
+                "Microsoft.Dynamics.Nav.Types.WindowsLanguageHelper was not found, so BC's own "
+                + "culture list cannot be read. Reimplementing it from CultureInfo would answer a "
+                + "different row set than the service tier");
 
         const BindingFlags Statics = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
 
@@ -229,13 +241,12 @@ public static partial class RecordPatches
         var abbreviatedName = One("AbbreviatedName");
 
         if (cultures == null || languageId == null || primaryLanguageId == null || abbreviatedName == null)
-            throw new RunnerOutOfScopeException(
-                "Windows Language (virtual table 2000000045)",
-                "windows-language-virtual-table — WindowsLanguageHelper does not expose the shape "
+            throw WindowsLanguageShapeGap(
+                "WindowsLanguageHelper does not expose the shape "
                 + $"BC's own provider uses (AllCultures={cultures != null}, "
                 + $"LanguageId={languageId != null}, PrimaryLanguageId={primaryLanguageId != null}, "
                 + $"AbbreviatedName={abbreviatedName != null}). A BC shape change says so here "
-                + "rather than being papered over. See docs/scope.md");
+                + "rather than being papered over");
 
         _wlLanguageId = languageId;
         _wlPrimaryLanguageId = primaryLanguageId;

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -1646,9 +1646,7 @@ public static partial class RecordPatches
                 // on demand there. This whole path is now DEFAULT-ON (no env gate): the find
                 // interception means a populated Field table no longer crashes under R2R.
                 var session = _fDasSession?.GetValue(self)
-                    ?? throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                        "Field (virtual table 2000000041)",
-                        "field-virtual-table — DataAccessSource has no skeleton session; see docs/scope.md");
+                    ?? throw FieldVirtualShapeGap("DataAccessSource has no skeleton session");
                 PopulateFieldVirtualTable(fieldDa, table, session);
                 return fieldDa;
             }
@@ -1821,11 +1819,9 @@ public static partial class RecordPatches
                     aggPermSetDa = perTable.GetOrAdd(tableId, createdAggPermSet);
                 }
                 var aggPermSetSession = _fDasSession?.GetValue(self)
-                    ?? throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                        "Aggregate Permission Set (virtual table 2000000167)",
-                        "aggregate-permission-set-virtual-table — DataAccessSource has no skeleton "
-                        + "session, so BC's own AggregatePermissionSetDataProvider cannot be "
-                        + "constructed; see docs/scope.md");
+                    ?? throw AggregatePermissionSetShapeGap(
+                        "DataAccessSource has no skeleton session, so BC's own "
+                        + "AggregatePermissionSetDataProvider cannot be constructed");
                 PopulateAggregatePermissionSetVirtualTable(aggPermSetDa, table, aggPermSetSession);
                 return aggPermSetDa;
             }
@@ -1914,10 +1910,9 @@ public static partial class RecordPatches
                     featureKeyDa = perTable.GetOrAdd(tableId, createdFeatureKey);
                 }
                 var featureKeySession = _fDasSession?.GetValue(self)
-                    ?? throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                        "Feature Key (system table 2000000211)",
-                        "feature-key-virtual-table — DataAccessSource has no skeleton session, so "
-                        + "BC's own FeatureKeyDataProvider cannot be constructed; see docs/scope.md");
+                    ?? throw FeatureKeyShapeGap(
+                        "DataAccessSource has no skeleton session, so BC's own "
+                        + "FeatureKeyDataProvider cannot be constructed");
                 PopulateFeatureKeyVirtualTable(featureKeyDa, table, featureKeySession);
                 return featureKeyDa;
             }

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -725,6 +725,25 @@ there, so everything behind it is unmeasured.
 These are not architectural limits. They can be fixed; report them at
 https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues.
 
+<a id="virtual-table-shape-gaps"></a>
+
+- **System virtual tables — the runner refuses rather than answering a shape it cannot read.**
+  AllObj, AllObjWithCaption, All Profile, Integer, Field, Table/Page/CodeUnit/Report Metadata,
+  Report Data Items, Report Layout List, Page Control Field, Metadata and Aggregate Permission
+  Set, Feature Key, Time Zone and Windows Language are all populated in-memory by
+  `AlRunner/Patches/RecordPatches.*VirtualTable.cs`. Each populator reads something it does not
+  own — the runner's in-memory store, the artifact's own metatable and option strings, or
+  Microsoft's own data provider — and when what it finds is not the shape it drives, it raises
+  `RunnerOutOfScopeException` naming the member that moved instead of answering with rows it
+  guessed at. An option ordinal is a stored column value, so a guess there mis-keys every row
+  it writes and no test can see it.
+
+  These refusals are gaps, not scope boundaries: every one of these tables answers on a real
+  service tier. They carry the reason anchor `not-yet-implemented`, which is what stops an AL
+  `[TryFunction]` from trapping one into `false`
+  ([#2945](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2945)). Time Zone
+  and Windows Language have documented *divergences* as well — see their own sections above —
+  and those are answers the runner gives on purpose, not refusals.
 - **FilterGroup** — `Rec.FilterGroup(n)` has no effect; filters always apply to group 0.
 - **Query aggregation** — a query column with `Method = Sum`/`Count`/`Average`/`Min`/`Max`
   does not aggregate or group rows; it silently returns each row's own unaggregated value.


### PR DESCRIPTION
Closes #2945

The issue reported that ~17 sibling virtual-table populators carry the wrong out-of-scope claim that #2894 fixed for Object Metadata. There are **55** refusals, not 17, and seven of them are outside the `*VirtualTable.cs` files entirely.

## The claim was wrong, not the wording

Every one of these ended `; see docs/scope.md`, rendered twice over because `BuildMessage` appends its own link:

```
out-of-scope: AllObj (virtual table 2000000038) — allobj-virtual-table — AllObj data
access has no in-memory provider; see docs/scope.md — see docs/scope.md
```

`docs/scope.md` is the manifest of what is **permanently** out of scope: SMTP, HTTP egress, printing. It names none of these tables — the test below asserts that, so the fix cannot quietly become moot — and the files raising the refusals implement them. `.claude/rules/loud-failures.md` puts AL records squarely in scope.

The runtime consequence is why this is a correctness fix. `ApplicationObjectBasePatches.IsPermanentOutOfScope`:

```csharp
return oos != null && !oos.Reason.StartsWith("not-yet-implemented", StringComparison.Ordinal);
```

Under the old anchors that returned **true**, so an AL `[TryFunction]` reading any of these tables trapped a runner shape gap into `false` — the silent default `loud-failures.md` exists to prevent — and the test went green having quietly done without the table. It tears through now.

## Classifying all 55 before touching any of them

Three buckets, per `RecordPatches.VirtualTableShapeGap.cs`'s header and each file's own:

| bucket | count |
|---|---|
| (1) genuinely out of scope — keep the refusal, correct the reason | **0** |
| (2) in scope, not yet answerable for the shape found | **55** |
| (3) implementable now | **0** |

Nothing landed in (1), and the test for it is specific: a refusal is faithful only if **BC itself** cannot answer, so that a `[TryFunction]` reading `false` is the observable BC outcome. Every one of these tables answers on a real service tier, so a refusal here is always the runner failing to keep up.

Nothing landed in (3) either. These are not unbuilt features; they are preconditions that hold in every supported configuration. Three shapes:

- **"data access has no in-memory provider"** (17 sites). The runner's own store wiring handed nothing over. Standing up a private store answers with rows nobody reads back.
- **"BC's metatable / option string / helper type is not the shape this drives"** (25 sites). The artifact's metadata *is* the row set or the ordinal source. For an option ordinal it is worse than a fallback being wrong: the ordinal is a stored column value, so a guess mis-keys every row silently.
- **"BC's own provider threw, or produced nothing"** (13 sites). Feature Key, Field, Time Zone and Windows Language delegate to Microsoft's provider or to the host, and each guard already carried a comment saying why answering empty would be a *wrong* answer rather than a missing one — an empty Feature Key table silently wins every legacy code path (#2585); an empty Time Zone table is the bug #2584 fixed.

Two surfaces have doc sections of their own and point at them. **Time Zone and Windows Language document real, permanent divergences** — host-derived ids, chosen license columns — and those are answers the runner gives on purpose and never throws for, which is a different thing from these refusals. The per-file headers say so, so the two are not conflated later.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes, and the issue's own grep undercounted it. That grep matched `_pDataAccessDataProvider!.GetValue(dataAccess)`, which is **16** of the sites. Reading every throw site in each file found 48 across the sixteen files.
2. **A sibling making the same assumption?** Yes — seven, in two files the issue did not name. `RecordPatches.cs`'s DataAccess dispatch chain refuses for Field, Aggregate Permission Set and Feature Key, and `AllProfileWritePatches.cs` refuses for All Profile, all **spelling the same anchors themselves** instead of calling the populator's factory. So four tables each claimed one thing from the populator and another from the other path, depending on which one you reached. All seven route through the same factories now.
3. **Two paths writing the same state with different invariants?** Yes. `OutOfScopeMessage` recovers the (Api, Reason) pair two ways — typed from the exception, untyped from the message text, which is what a Cecil-injected throw site and the TRX reader get. `TryParse` cuts the api from the reason at the first `" — "`, and the Feature Key **Modify** api was spelled `"Feature Key (system table 2000000211) — Modify"`, so the untyped path read the api as `"Feature Key (system table 2000000211)"` and the reason as `"Modify — feature-key-modify …"`. The two paths disagreed. The api is punctuated with a colon now, and a test asserts the two paths agree for all 18 surfaces. AL `asserterror` is unaffected — `Assert.ExpectedError` matches a prefix.

## What is deliberately left out

- **`RecordPatches.DateVirtualTable.cs`'s eight refusals** — filed as **#2965**. It is being changed concurrently under #2648, and a factory edit across it would have collided. That issue also records that one of the eight (the row-cap refusal, which `tests/runner-extras/date-virtual-table-window` pins) may not classify the same way as the other seven, rather than assuming it does.
- **96 further `docs/scope.md` citations in 23 files outside this directory** — measured and filed as **#2966**. Most are correct; SMTP and HTTP egress really are permanent. At least one is the same defect: `RecordPatches.QueryProjection.cs`'s `query-join-synthesized-subquery-not-implemented` says "not-implemented" in words but does not *start* with `not-yet-implemented`, so a `[TryFunction]` swallows it. Classifying them is the work, not deleting the citation, and 25 of them sit in `MockTestPage.cs` / `RunnerPageInstance.cs`, which overlap in-flight TestPage work.
- **#2766's doubled-link sweep** at the other ~45 sites — untouched. The doubling is fixed here only for these 55, as a consequence of rewriting their reason strings.
- **Whether a BC-shape guard should raise `RunnerOutOfScopeException` at all** — #2946, a convention decision across `AlRunner/Patches/`. It is what the `not-yet-implemented` anchor tracks, and it stays open after this merges.

## The `BuildMessage` hunk is #2950's, taken verbatim

Pointing a refusal at `docs/limitations.md#…` needs `RunnerOutOfScopeException.BuildMessage` to use a `docAnchor` that names its own file, which #2950 (still open) adds. That hunk is applied here **byte for byte** from #2950's diff, so if #2950 lands first the three-way merge sees identical content on both sides and resolves silently; if it does not, this branch stands on its own. `OutOfScopeMessage.TryParse` strips everything from `" — see "` onward, so the doc file is invisible to the manifest and the reporter — a reader-facing pointer only.

**No classification moves.** `ExpectationManifest.ReasonAnchor` cuts at the first em-dash, so the anchor these report goes from e.g. `allobj-virtual-table` to `not-yet-implemented`. No manifest entry matches on any of them: the only three `Reason` values declared today are `task-scheduler-create-task`, `external-http` and `report-rendering-external`.

## RED → GREEN

RED was produced against executing code, not a compile error: the factory was flipped back to reproduce the old strings, and the Feature Key api back to its em-dash spelling.

```
Failed!  - Failed: 73, Passed: 8, Total: 81
```

The 8 that stayed green are the control arms — the `docAnchor` resolution theory, the doc-anchor existence check, the source-shape guards, and `PermanentRefusal_IsStillTrappedByATryFunction`, which asserts the **same exception type** with an `email-smtp` reason still reads as `false`. Without that arm the tear-through theory could pass by discriminating on the type rather than on the claim.

The sibling half has its own RED, since it is a different defect: with `RecordPatches.cs` and `AllProfileWritePatches.cs` reverted one commit,

```
anchor 'aggregate-permission-set-virtual-table' is spelled in 2 files:
  RecordPatches.AggregatePermissionSetVirtualTable.cs, RecordPatches.cs
Failed!  - Failed: 2, Passed: 80, Total: 82
```

GREEN, re-run on the rebased tree (never carried across the rebase):

```
dotnet test AlRunner.Tests -c Release --framework net8.0 --no-build --filter \
  "FullyQualifiedName~VirtualTableRefusalClaimTests|FullyQualifiedName~TryFunctionOutOfScopeTrapTests|\
FullyQualifiedName~AssertErrorOutOfScopeCatchabilityTests|FullyQualifiedName~ExpectationManifest|\
FullyQualifiedName~ExpectationClassifier|FullyQualifiedName~ObjectMetadata|FullyQualifiedName~AllProfile|\
FullyQualifiedName~FeatureKey|FullyQualifiedName~PermissionSet|FullyQualifiedName~Reporter"
Passed!  - Failed: 0, Passed: 149, Skipped: 0, Total: 149, Duration: 24 s
```

And the AL side, run the way CI runs it — wider than usual because `RecordPatches.cs`'s DataAccess dispatch chain is on the path:

```
dotnet run --no-build --project AlRunner -c Release --framework net8.0 -- tests/runner-extras \
  --package-cache "$HOME/.al-runner/platform-apps" --package-cache "$HOME/.al-runner/test-apps" \
  --strict --count-baseline tests/expectations/count-baseline/test-count-baseline.json --cache <private>
Tests: 264 total  pass: 264  fail: 0  error: 0
```

`tests/runner-extras/standalone-suites` (108/108) and `windows-language-license-stub` (4/4) were also run on their own. No new AL test and no new app group, so `tests/expectations/count-baseline/test-count-baseline.json` does not move and is untouched — the `--count-baseline` run above is what confirms that rather than an assumption.

## Why the tests are in `AlRunner.Tests/`, not `tests/runner-extras/`

None of the 55 is reachable from AL: they fire when BC's `SystemTables`-equivalent metadata, `WindowsLanguageHelper`, `FeatureKeyDataProvider`, the host's time zone database or the runner's own store is absent or the wrong shape, and no AL statement can arrange any of that. The existing virtual-table suites assert the **rows**, which is the in-scope half, and cannot drive a refusal. The subject here is the C# refusal contract, which `bc-behavior-tests-go-upstream.md` classifies as runner-specific — the shape `TryFunctionOutOfScopeTrapTests` and `ObjectMetadataProviderRowProbeTests` already use.

The new class does not hard-code only a list. Alongside the explicit 18-surface table it discovers every `*ShapeGap(string)` factory on `RecordPatches` by reflection and holds it to the same invariants, so a factory added later is covered without anyone remembering — and `EachSurfaceAnchorIsSpelledInExactlyOneFile` pins the sibling defect so one table cannot go back to claiming two different things.

---
*Authored by an automated agent (`impl-18`) acting on the account holder's behalf.*

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
