### PR TITLE
fix(provisioning): report what the network actually did instead of blaming the CDN

### DIFF
--- a/AlRunner.Provisioning/ArtifactDownloader.cs
+++ b/AlRunner.Provisioning/ArtifactDownloader.cs
@@ -867,10 +867,14 @@ public static class ArtifactDownloader
     /// Sizes a remote artifact and turns a failure into a named, actionable log message
     /// instead of letting <see cref="HttpRequestException"/> propagate as an unhandled
     /// exception with a raw .NET stack trace. A 404 (no artifact published for that exact
-    /// version) gets the <c>resolve-version</c> pointer; any other transport failure
-    /// (DNS, TLS, timeout, 5xx) gets a distinct "could not reach the CDN" message so the
-    /// caller can tell "your version is wrong" from "the network/tool is broken" — the
-    /// two categories the raw stack trace collapsed into one indistinguishable crash.
+    /// version) gets the <c>resolve-version</c> pointer; everything else goes to
+    /// <see cref="NetworkDiagnosis"/>.
+    ///
+    /// Issue #2926 split that second half apart. It used to be one "could not reach the CDN"
+    /// message covering DNS, TLS, timeouts, connect failures and 5xx alike, which let the tool
+    /// tell a user the CDN was down when the real fault was a missing IPv6 route on their own
+    /// machine. Those observations mean different things and are now reported as different
+    /// things; only a response from the server licenses a statement about the server.
     /// </summary>
     internal static bool TryHeadContentLength(
         HttpClient http, string url, string version, string channel, Action<string> logf, out long size)

--- a/AlRunner.Provisioning/ArtifactDownloader.cs
+++ b/AlRunner.Provisioning/ArtifactDownloader.cs
@@ -42,7 +42,7 @@ public static class ArtifactDownloader
         var url = $"https://api.nuget.org/v3-flatcontainer/{packageId}/{version}/{packageId}.{version}.nupkg";
 
         Directory.CreateDirectory(outputDir);
-        using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(5) };
+        using var http = ArtifactHttpClient.Create(TimeSpan.FromMinutes(5), logf);
         logf($"Downloading AL compiler {version} from NuGet ({packageId})...");
 
         byte[] nupkg;
@@ -56,7 +56,10 @@ public static class ArtifactDownloader
         }
         catch (Exception ex)
         {
-            logf($"Error downloading: {ex.Message}");
+            // Issue #2926: same shape as the CDN messages — one line for every possible
+            // failure. This one fetches from nuget.org rather than the BC CDN, so a message
+            // blaming "the CDN" would be wrong twice over.
+            NetworkDiagnosis.Describe(ex, $"the AL compiler package {packageId} {version}", url).WriteTo(logf);
             return 1;
         }
 
@@ -105,7 +108,7 @@ public static class ArtifactDownloader
         var artifactUrl = $"{CdnBase}/{version}/platform";
         Directory.CreateDirectory(outputDir);
 
-        using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(5) };
+        using var http = ArtifactHttpClient.Create(TimeSpan.FromMinutes(5), logf);
 
         logf($"Resolving artifact size for BC {version}...");
         if (!TryHeadContentLength(http, artifactUrl, version, "platform", logf, out long totalSize)) return 1;
@@ -174,7 +177,7 @@ public static class ArtifactDownloader
         var artifactUrl = $"{CdnBase}/{version}/platform";
         Directory.CreateDirectory(outputDir);
 
-        using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(10) };
+        using var http = ArtifactHttpClient.Create(TimeSpan.FromMinutes(10), logf);
 
         logf($"Resolving artifact size for BC {version} (platform)...");
         if (!TryHeadContentLength(http, artifactUrl, version, "platform", logf, out long totalSize)) return 1;
@@ -261,7 +264,7 @@ public static class ArtifactDownloader
         var artifactUrl = BuildArtifactUrl(version, "platform");
         Directory.CreateDirectory(outputDir);
 
-        using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(10) };
+        using var http = ArtifactHttpClient.Create(TimeSpan.FromMinutes(10), logf);
 
         logf($"Resolving artifact size for BC {version} (platform)...");
         if (!TryHeadContentLength(http, artifactUrl, version, "platform", logf, out long totalSize)) return 1;
@@ -398,7 +401,7 @@ public static class ArtifactDownloader
         Directory.CreateDirectory(outputDir);
 
         // Generous: this client streams the whole ~600 MB entry through one response.
-        using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(30) };
+        using var http = ArtifactHttpClient.Create(TimeSpan.FromMinutes(30), logf);
 
         logf($"Resolving artifact size for BC {version} ({countryLower})...");
         if (!TryHeadContentLength(http, artifactUrl, version, countryLower, logf, out long totalSize)) return 1;
@@ -646,7 +649,7 @@ public static class ArtifactDownloader
         var artifactUrl = BuildArtifactUrl(version, countryLower);
         Directory.CreateDirectory(outputDir);
 
-        using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(10) };
+        using var http = ArtifactHttpClient.Create(TimeSpan.FromMinutes(10), logf);
 
         logf($"Resolving artifact size for BC {version} ({countryLower})...");
         if (!TryHeadContentLength(http, artifactUrl, version, countryLower, logf, out long totalSize)) return 1;
@@ -716,7 +719,7 @@ public static class ArtifactDownloader
     private static int SystemApp(string version, string outputDir, Action<string> logf)
     {
         var artifactUrl = $"{CdnBase}/{version}/platform";
-        using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(10) };
+        using var http = ArtifactHttpClient.Create(TimeSpan.FromMinutes(10), logf);
 
         logf($"Resolving platform artifact for System.app (BC {version})...");
         if (!TryHeadContentLength(http, artifactUrl, version, "platform", logf, out long totalSize))
@@ -771,13 +774,28 @@ public static class ArtifactDownloader
         var url = $"{CdnBase}/{version}/platform";
         try
         {
-            using var http = new HttpClient();
+            using var http = ArtifactHttpClient.Create(log: logf);
             using var resp = http.Send(new HttpRequestMessage(HttpMethod.Head, url));
             return resp.IsSuccessStatusCode;
         }
-        catch (HttpRequestException ex)
+        catch (Exception ex)
         {
-            logf($"[provision] could not probe BC {version} on the CDN: {ex.Message}");
+            // Issue #2926. Two things wrong here, and the second is the one that bites.
+            //
+            // Only HttpRequestException was caught, so a timeout escaped as an unhandled
+            // exception from a method whose whole contract is "answer true or false".
+            //
+            // And `false` here does not mean what the caller reads it as.
+            // BcArtifacts.ResolveProvisionTargetCore treats false as "this exact build is not
+            // published" and walks down to the major-fallback tier, whose own comment calls
+            // that "the one genuinely degraded outcome" — so a five-second network blip gets
+            // reported to the user as Microsoft having withdrawn the build. The signature
+            // cannot carry the third state without changing that contract (tracked separately),
+            // so the log at least has to stop asserting something that was never established.
+            NetworkDiagnosis.Describe(ex, $"BC {version}", url).WriteTo(logf);
+            logf($"       Could not determine whether BC {version} is published. Treating it as " +
+                 "unavailable and falling back; that is a consequence of the failure above, not " +
+                 "evidence the build was withdrawn.");
             return false;
         }
     }
@@ -793,8 +811,16 @@ public static class ArtifactDownloader
         logf($"Resolving BC version prefix '{prefix}'...");
 
         string json;
-        try { using var http = new HttpClient(); json = http.GetStringAsync(indexUrl).Result; }
-        catch (Exception ex) { logf($"Error fetching index: {ex.Message}"); return null; }
+        try { using var http = ArtifactHttpClient.Create(log: logf); json = http.GetStringAsync(indexUrl).Result; }
+        catch (Exception ex)
+        {
+            // Issue #2926: this used to print "Error fetching index: One or more errors
+            // occurred. (A task was canceled.)" — an AggregateException's ToString, which names
+            // neither what failed nor where. NetworkDiagnosis unwraps it and reports the
+            // observation.
+            NetworkDiagnosis.Describe(ex, $"the BC version index (prefix '{prefix}')", indexUrl).WriteTo(logf);
+            return null;
+        }
 
         var searchPrefix = prefix + ".";
         var versions = new List<string>();
@@ -876,9 +902,20 @@ public static class ArtifactDownloader
             size = 0;
             return false;
         }
-        catch (HttpRequestException ex)
+        catch (Exception ex)
         {
-            logf($"Error: could not reach the BC artifact CDN for {version} ({channel}): {ex.Message}");
+            // Issue #2926, two defects in one catch block.
+            //
+            // It caught only HttpRequestException, so a client-timeout — which .NET raises as
+            // TaskCanceledException, not HttpRequestException — escaped this method as an
+            // unhandled exception with a raw stack trace: exactly the crash #1659 fixed for
+            // 404s, still live for the most common transient failure there is.
+            //
+            // And the message it did emit named a cause the observation did not support. "could
+            // not reach the BC artifact CDN" is how a host with no IPv6 route was told Azure was
+            // down. NetworkDiagnosis reports what was observed and only speaks about the CDN
+            // when the CDN actually answered.
+            NetworkDiagnosis.Describe(ex, $"BC {version} ({channel})", url).WriteTo(logf);
             size = 0;
             return false;
         }
@@ -980,6 +1017,7 @@ public static class ArtifactDownloader
 
     private static byte[] DownloadRange(HttpClient http, string url, long from, long to)
     {
+        Exception? last = null;
         for (int attempt = 0; attempt < 2; attempt++)
         {
             try
@@ -992,11 +1030,21 @@ public static class ArtifactDownloader
                 resp.Content.ReadAsStream().CopyTo(ms);
                 return ms.ToArray();
             }
-            catch when (attempt == 0)
+            catch (Exception ex) when (attempt == 0)
             {
-                Console.Error.WriteLine("  Retrying download...");
+                last = ex;
+                Console.Error.WriteLine($"  Retrying download... ({ex.Message})");
+            }
+            catch (Exception ex)
+            {
+                last = ex;
             }
         }
-        throw new Exception($"Failed to download range {from}-{to}");
+        // Issue #2926: this used to throw a bare Exception with no inner, discarding the only
+        // record of WHY both attempts failed. The caller then reported "Failed to download
+        // range 0-65535" — a message that cannot be acted on. Keep the cause attached so the
+        // diagnosis above it has something to classify.
+        throw new HttpRequestException(
+            $"Failed to download range {from}-{to} from {url} after 2 attempts", last);
     }
 }

--- a/AlRunner.Provisioning/ArtifactHttpClient.cs
+++ b/AlRunner.Provisioning/ArtifactHttpClient.cs
@@ -1,0 +1,57 @@
+// Issue #2926: the nine `new HttpClient { Timeout = ... }` sites in ArtifactDownloader each
+// got the stock connect behaviour, so a host with a broken IPv6 route failed at every one of
+// them and the tool blamed the CDN. One factory now owns connect behaviour for all of them —
+// two code paths reaching the same CDN should not be able to disagree about how to reach it.
+using System.Collections.Concurrent;
+using System.Net.Http;
+
+namespace AlRunner.Provisioning;
+
+public static class ArtifactHttpClient
+{
+    /// <summary>
+    /// Escape hatch: set to 1 to use .NET's stock connect instead of the address-walking one.
+    /// Here so a bug in the walk can be ruled out without a rebuild, not because it is expected.
+    /// </summary>
+    public const string DisableEnvVar = "AL_RUNNER_DISABLE_MULTI_ADDRESS_CONNECT";
+
+    // A host with no IPv6 route fails the first address on EVERY connection, and this pool
+    // opens many. Report the fallback once per distinct observation, or the useful line is
+    // buried under hundreds of copies of itself.
+    private static readonly ConcurrentDictionary<string, byte> Reported = new();
+
+    /// <summary>An <see cref="HttpClient"/> that tries every resolved address, the way curl does.</summary>
+    public static HttpClient Create(TimeSpan? timeout = null, Action<string>? log = null)
+    {
+        if (Environment.GetEnvironmentVariable(DisableEnvVar) == "1")
+        {
+            var stock = new HttpClient();
+            if (timeout is { } st) stock.Timeout = st;
+            return stock;
+        }
+
+        var handler = new SocketsHttpHandler
+        {
+            ConnectCallback = (context, ct) => MultiAddressConnector.ConnectAnyAsync(
+                context.DnsEndPoint.Host,
+                context.DnsEndPoint.Port,
+                MultiAddressConnector.ResolveWithDnsAsync,
+                MultiAddressConnector.ConnectWithSocketAsync,
+                MultiAddressConnector.DefaultPerAddressTimeout,
+                ct,
+                note: log is null ? null : m => NoteOnce(log, m)),
+        };
+
+        var client = new HttpClient(handler, disposeHandler: true);
+        if (timeout is { } t) client.Timeout = t;
+        return client;
+    }
+
+    private static void NoteOnce(Action<string> log, string message)
+    {
+        if (Reported.TryAdd(message, 0)) log(message);
+    }
+
+    /// <summary>Test seam: forget which fallback notes have already been reported.</summary>
+    internal static void ResetNoteDedupeForTests() => Reported.Clear();
+}

--- a/AlRunner.Provisioning/MultiAddressConnector.cs
+++ b/AlRunner.Provisioning/MultiAddressConnector.cs
@@ -22,10 +22,18 @@ public static class MultiAddressConnector
     public delegate ValueTask<Stream> ConnectDelegate(IPAddress address, int port, CancellationToken ct);
 
     /// <summary>
-    /// Per-address connect budget. A black-holed address (firewall dropping SYNs, which is the
-    /// common shape of a broken IPv6 path) never returns an error — it just goes quiet — so
-    /// without a per-address cap one dead address consumes the caller's entire timeout and the
-    /// remaining addresses are never tried. That failure looks exactly like #2926 from outside.
+    /// Connect budget for an address that still has another address behind it. A black-holed
+    /// address never returns an error — it just goes quiet — so without a cap one dead address
+    /// consumes the caller's entire timeout and the addresses behind it are never tried. That
+    /// failure looks exactly like #2926 from outside.
+    ///
+    /// Measured on the machine this was developed on, which reproduces #2926's condition: the
+    /// CDN's IPv6 address fails instantly with NetworkUnreachable on every attempt, and its
+    /// IPv4 address intermittently black-holes — 4 of 15 connects hung for ~135 s before the
+    /// kernel gave up. The stock client hit the same fault and took the full 135 s; the cap
+    /// turns that into a 10 s failure carrying the per-address record.
+    ///
+    /// Deliberately NOT applied to the last address — see <see cref="ConnectAnyAsync"/>.
     /// </summary>
     public static readonly TimeSpan DefaultPerAddressTimeout = TimeSpan.FromSeconds(10);
 
@@ -75,8 +83,14 @@ public static class MultiAddressConnector
                 break;
             }
 
+            // The cap exists to stop a dead address from starving the addresses behind it. On
+            // the LAST address there is nothing behind it to starve, so capping there can only
+            // do harm: it would abandon a merely-slow connect that the caller's own timeout was
+            // willing to wait for, turning a success into a failure. Every address the stock
+            // client would have waited on is therefore still waited on for at least as long.
+            var isLast = i == addresses.Length - 1;
             using var perAddress = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            perAddress.CancelAfter(perAddressTimeout);
+            if (!isLast) perAddress.CancelAfter(perAddressTimeout);
             try
             {
                 var stream = await connect(address, port, perAddress.Token).ConfigureAwait(false);

--- a/AlRunner.Provisioning/MultiAddressConnector.cs
+++ b/AlRunner.Provisioning/MultiAddressConnector.cs
@@ -1,0 +1,136 @@
+// Issue #2926: .NET's default connect did not do what curl does. On a host whose DNS returns
+// an AAAA record for the BC artifact CDN and which has no working IPv6 route, curl tried the
+// IPv6 address, got `Network is unreachable`, moved on to the A record and downloaded 893 MB.
+// tools/DownloadArtifacts stopped at the first address and reported a CDN outage.
+//
+// This is the "walks all resolved addresses the way curl does" half of the fix. It is a plain
+// function over an injected resolver and an injected connect, so the interesting cases (an
+// IPv6 address the kernel refuses, an address that black-holes, DNS returning nothing) are
+// unit-testable from captured outcomes instead of from whatever the live network happens to be
+// doing — a test that reads the real network passes for the wrong reason on a healthy box.
+using System.Net;
+using System.Net.Sockets;
+
+namespace AlRunner.Provisioning;
+
+public static class MultiAddressConnector
+{
+    /// <summary>Resolve a host name to candidate addresses, in the order they should be tried.</summary>
+    public delegate ValueTask<IPAddress[]> ResolveDelegate(string host, CancellationToken ct);
+
+    /// <summary>Open a stream to one specific address.</summary>
+    public delegate ValueTask<Stream> ConnectDelegate(IPAddress address, int port, CancellationToken ct);
+
+    /// <summary>
+    /// Per-address connect budget. A black-holed address (firewall dropping SYNs, which is the
+    /// common shape of a broken IPv6 path) never returns an error — it just goes quiet — so
+    /// without a per-address cap one dead address consumes the caller's entire timeout and the
+    /// remaining addresses are never tried. That failure looks exactly like #2926 from outside.
+    /// </summary>
+    public static readonly TimeSpan DefaultPerAddressTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Try every resolved address in order and return the first connection that comes up.
+    /// Throws <see cref="MultiAddressConnectException"/> carrying the per-address outcomes when
+    /// none does — the caller reports those instead of collapsing them into one message.
+    /// </summary>
+    /// <param name="note">
+    /// Called when an address fails but a later one succeeds. Without it the fallback is
+    /// invisible, and a host with a broken IPv6 route silently pays a connect timeout on every
+    /// single connection while looking perfectly healthy.
+    /// </param>
+    public static async ValueTask<Stream> ConnectAnyAsync(
+        string host, int port,
+        ResolveDelegate resolve,
+        ConnectDelegate connect,
+        TimeSpan perAddressTimeout,
+        CancellationToken ct,
+        Action<string>? note = null)
+    {
+        IPAddress[] addresses;
+        try
+        {
+            addresses = await resolve(host, ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            throw new MultiAddressConnectException(host, port, Array.Empty<AddressAttempt>(), ex,
+                $"could not resolve {host}: {ex.Message}");
+        }
+
+        if (addresses.Length == 0)
+            throw new MultiAddressConnectException(host, port, Array.Empty<AddressAttempt>(), null,
+                $"could not resolve {host}: DNS returned no addresses");
+
+        var attempts = new List<AddressAttempt>(addresses.Length);
+        for (var i = 0; i < addresses.Length; i++)
+        {
+            var address = addresses[i];
+
+            if (ct.IsCancellationRequested)
+            {
+                // Record the rest as untried rather than as failures. "not tried" and "failed"
+                // are different observations and the message must not conflate them.
+                for (var j = i; j < addresses.Length; j++) attempts.Add(AddressAttempt.NotTried(addresses[j]));
+                break;
+            }
+
+            using var perAddress = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            perAddress.CancelAfter(perAddressTimeout);
+            try
+            {
+                var stream = await connect(address, port, perAddress.Token).ConfigureAwait(false);
+                if (attempts.Count > 0 && note is not null)
+                    note($"[provision] {host}: {Describe(attempts)}; connected over {Family(address)} ({address}).");
+                return stream;
+            }
+            catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+            {
+                // The per-address budget elapsed, not the caller's token: a timed-out connect.
+                attempts.Add(new AddressAttempt(address, Attempted: true, SocketError.TimedOut,
+                    $"no response within {perAddressTimeout.TotalSeconds:0.#}s"));
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                attempts.Add(AddressAttempt.Failed(address, ex));
+            }
+        }
+
+        ct.ThrowIfCancellationRequested();
+
+        throw new MultiAddressConnectException(host, port, attempts, null,
+            $"could not connect to {host}:{port}: {Describe(attempts)}");
+    }
+
+    private static string Describe(IReadOnlyList<AddressAttempt> attempts)
+        => string.Join("; ", attempts.Select(a => a.Attempted
+            ? $"{a.Address} ({Family(a.Address)}) {a.Error?.ToString() ?? a.Message ?? "failed"}"
+            : $"{a.Address} ({Family(a.Address)}) not tried"));
+
+    private static string Family(IPAddress address)
+        => address.AddressFamily == AddressFamily.InterNetworkV6 ? "IPv6" : "IPv4";
+
+    /// <summary>The real resolver: DNS, in the order the platform returns.</summary>
+    public static async ValueTask<IPAddress[]> ResolveWithDnsAsync(string host, CancellationToken ct)
+        => await Dns.GetHostAddressesAsync(host, ct).ConfigureAwait(false);
+
+    /// <summary>
+    /// The real connect. One socket per address, created in that address's OWN family rather
+    /// than as a dual-mode socket, so each attempt is independent and a failure on one carries
+    /// no state into the next.
+    /// </summary>
+    public static async ValueTask<Stream> ConnectWithSocketAsync(IPAddress address, int port, CancellationToken ct)
+    {
+        var socket = new Socket(address.AddressFamily, SocketType.Stream, ProtocolType.Tcp) { NoDelay = true };
+        try
+        {
+            await socket.ConnectAsync(new IPEndPoint(address, port), ct).ConfigureAwait(false);
+            return new NetworkStream(socket, ownsSocket: true);
+        }
+        catch
+        {
+            socket.Dispose();
+            throw;
+        }
+    }
+}

--- a/AlRunner.Provisioning/NetworkDiagnosis.cs
+++ b/AlRunner.Provisioning/NetworkDiagnosis.cs
@@ -251,16 +251,15 @@ public static class NetworkDiagnosis
             addressLines.Add($"  {a.Address} ({family}) {outcome}");
         }
 
-        // Only claim the address family is the problem when the addresses say so: an IPv6
-        // address the local routing table rejected, AND an IPv4 address of the same host that
-        // either was never tried or failed for a different reason. If every address failed the
-        // same way, the address family is not what distinguishes them and saying so would be
-        // the same defect in a new spelling.
+        // Only name the address family when the addresses themselves say so: the local routing
+        // table rejected an IPv6 address, AND an IPv4 address of the same host was resolved but
+        // never actually attempted. If the IPv4 address WAS attempted and failed too — for any
+        // reason — then turning IPv6 off cannot help, and suggesting it would be this issue's
+        // own defect in a new spelling: confident advice the observation does not support.
         var v6NoRoute = multi.Attempts.Any(a => a.IsIPv6 && a.Attempted && IsNoRoute(a.Error));
-        var v4Present = multi.Attempts.Any(a => !a.IsIPv6);
-        var v4NoRoute = multi.Attempts.Any(a => !a.IsIPv6 && a.Attempted && IsNoRoute(a.Error));
+        var v4Untried = multi.Attempts.Any(a => !a.IsIPv6 && !a.Attempted);
 
-        if (v6NoRoute && v4Present && !v4NoRoute)
+        if (v6NoRoute && v4Untried)
         {
             addressLines.Add("");
             addressLines.Add("The IPv6 address was rejected by this host's own routing table while an IPv4");
@@ -272,7 +271,7 @@ public static class NetworkDiagnosis
         var single = errors.Count == 1 ? errors[0] : null;
 
         if (single is not null && IsNoRoute(single))
-            return DescribeSocketError(single.Value, multi.Message, what, url, target, addressLines);
+            return DescribeSocketError(single.Value, message: null, what, url, target, addressLines);
 
         if (single == SocketError.TimedOut)
         {
@@ -281,7 +280,7 @@ public static class NetworkDiagnosis
         }
 
         if (single == SocketError.ConnectionRefused)
-            return DescribeSocketError(single.Value, multi.Message, what, url, target, addressLines);
+            return DescribeSocketError(single.Value, message: null, what, url, target, addressLines);
 
         // Mixed or unrecognized failures across the addresses: report them all, claim nothing.
         return new NetworkFailureReport(NetworkFailureKind.Unknown,
@@ -296,11 +295,16 @@ public static class NetworkDiagnosis
                 }).ToList());
     }
 
+    /// <param name="message">
+    /// The OS-level text, when it adds anything. Null when <paramref name="addressLines"/>
+    /// already states the same fact per address — printing both said it twice.
+    /// </param>
     private static NetworkFailureReport DescribeSocketError(
-        SocketError error, string message, string what, string? url, string target,
+        SocketError error, string? message, string what, string? url, string target,
         IReadOnlyList<string> addressLines)
     {
         var request = new[] { $"Request: {url ?? "(url not recorded)"}" };
+        var observed = message is null ? $"Observed: {error}" : $"Observed: {error} — {message}";
 
         switch (error)
         {
@@ -311,7 +315,7 @@ public static class NetworkDiagnosis
                     $"could not resolve the host for {what}.",
                     request.Concat(new[]
                     {
-                        $"Observed: {error} — {message}",
+                        observed,
                         "No connection was attempted, so nothing here is a statement about the CDN —",
                         "check this host's DNS resolver first.",
                     }).ToList());
@@ -320,7 +324,7 @@ public static class NetworkDiagnosis
             case SocketError.HostUnreachable:
                 return new NetworkFailureReport(NetworkFailureKind.NoRouteToAddress,
                     $"this host has no route to {target} for {what}.",
-                    request.Concat(new[] { $"Observed: {error} — {message}" })
+                    request.Concat(new[] { observed })
                         .Concat(addressLines)
                         .Concat(new[]
                         {
@@ -331,7 +335,7 @@ public static class NetworkDiagnosis
             case SocketError.ConnectionRefused:
                 return new NetworkFailureReport(NetworkFailureKind.ConnectionRefused,
                     $"{target} refused the connection for {what}.",
-                    request.Concat(new[] { $"Observed: {error} — {message}" })
+                    request.Concat(new[] { observed })
                         .Concat(addressLines)
                         .Concat(new[]
                         {
@@ -349,7 +353,7 @@ public static class NetworkDiagnosis
             default:
                 return new NetworkFailureReport(NetworkFailureKind.Unknown,
                     $"could not connect to {target} while fetching {what}.",
-                    request.Concat(new[] { $"Observed: {error} — {message}" })
+                    request.Concat(new[] { observed })
                         .Concat(addressLines)
                         .Concat(new[]
                         {

--- a/AlRunner.Provisioning/NetworkDiagnosis.cs
+++ b/AlRunner.Provisioning/NetworkDiagnosis.cs
@@ -1,0 +1,395 @@
+// Issue #2926: every network failure in ArtifactDownloader used to be reported as
+//
+//     Error: could not reach the BC artifact CDN for 28.1.49838.53910 (platform):
+//            Network is unreachable (bcartifacts-...azurefd.net:443)
+//
+// which reads as "Azure is down" or "this build was never published". Neither was true —
+// the host had an AAAA record and no IPv6 route, and an IPv4 address of the same CDN
+// answered a ranged GET seconds later. The reporter spent several minutes checking the CDN
+// by hand before thinking to look at the address family.
+//
+// The defect is not the download. It is that one message was emitted for a set of
+// observations that mean very different things, and it named a cause the observation did
+// not support. This file separates them:
+//
+//   * we got an HTTP status back        -> the CDN answered; ONLY here may we talk about
+//                                          the CDN's own health
+//   * DNS said no                       -> a name-resolution fact
+//   * the local kernel refused a route  -> a fact about THIS host's routing table
+//   * something sent a RST              -> a fact about the far end
+//   * nothing answered in time          -> tells us nothing about where the fault is
+//   * anything else                     -> report what was seen, name no cause
+//
+// The rule the message text has to obey: a claim about the remote service requires bytes
+// from the remote service. `.claude/rules/github-access.md` records the same class of
+// defect one layer up (an unauthenticated 404 read as "this does not exist"), and
+// `.claude/rules/loud-failures.md` is the general form — a signal must not be reported as
+// a stronger conclusion than it supports.
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Authentication;
+
+namespace AlRunner.Provisioning;
+
+/// <summary>
+/// What was actually observed when an HTTP request failed. Ordered from "we know the most"
+/// to "we know the least"; the message text for each kind may only claim what the kind
+/// itself establishes.
+/// </summary>
+public enum NetworkFailureKind
+{
+    /// <summary>The server sent an HTTP response. Its status is a fact about the server.</summary>
+    ServerResponded,
+
+    /// <summary>The host name did not resolve. A DNS fact, not a fact about the server.</summary>
+    NameResolution,
+
+    /// <summary>
+    /// A connect attempt was refused by the local routing stack (ENETUNREACH / EHOSTUNREACH).
+    /// This is the local kernel saying it has no route — a fact about THIS host.
+    /// </summary>
+    NoRouteToAddress,
+
+    /// <summary>Something at the address answered with a RST. A fact about the far end.</summary>
+    ConnectionRefused,
+
+    /// <summary>
+    /// Nothing answered inside the time budget. Consistent with a transient local fault, a
+    /// firewall, packet loss, or an unhealthy server — it does not distinguish between them.
+    /// </summary>
+    Timeout,
+
+    /// <summary>The TCP connection came up but the TLS handshake failed.</summary>
+    Tls,
+
+    /// <summary>The caller cancelled. Not a network observation at all.</summary>
+    Cancelled,
+
+    /// <summary>Something else failed. Report the observation; name no cause.</summary>
+    Unknown,
+}
+
+/// <summary>One address a connect was, or was not, attempted against.</summary>
+/// <param name="Attempted">
+/// False for an address that was resolved but never reached — an earlier address succeeded, or
+/// the budget ran out. Reported so the message can say what was NOT ruled out.
+/// </param>
+public sealed record AddressAttempt(IPAddress Address, bool Attempted, SocketError? Error, string? Message)
+{
+    public bool IsIPv6 => Address.AddressFamily == AddressFamily.InterNetworkV6;
+
+    public static AddressAttempt NotTried(IPAddress address) => new(address, false, null, null);
+
+    public static AddressAttempt Failed(IPAddress address, SocketException ex)
+        => new(address, true, ex.SocketErrorCode, ex.Message);
+
+    public static AddressAttempt Failed(IPAddress address, Exception ex)
+        => ex is SocketException se ? Failed(address, se) : new(address, true, null, ex.Message);
+}
+
+/// <summary>
+/// Thrown by <see cref="MultiAddressConnector"/> when no resolved address could be connected
+/// to. Carries the per-address outcomes so the failure message can report what was tried
+/// rather than collapsing every address into one <c>ex.Message</c> — the collapse is what
+/// hid the address-family problem in #2926.
+/// </summary>
+public sealed class MultiAddressConnectException : Exception
+{
+    public MultiAddressConnectException(string host, int port,
+        IReadOnlyList<AddressAttempt> attempts, Exception? resolutionError, string message)
+        : base(message, resolutionError)
+    {
+        Host = host;
+        Port = port;
+        Attempts = attempts;
+        ResolutionError = resolutionError;
+    }
+
+    public string Host { get; }
+    public int Port { get; }
+    public IReadOnlyList<AddressAttempt> Attempts { get; }
+
+    /// <summary>Set when DNS itself failed, in which case <see cref="Attempts"/> is empty.</summary>
+    public Exception? ResolutionError { get; }
+}
+
+/// <summary>A classified failure plus the lines that report it.</summary>
+public sealed record NetworkFailureReport(NetworkFailureKind Kind, string Headline, IReadOnlyList<string> Detail)
+{
+    /// <summary>Headline first, then indented detail — the shape the existing log messages use.</summary>
+    public IReadOnlyList<string> Lines
+    {
+        get
+        {
+            var lines = new List<string> { "Error: " + Headline };
+            lines.AddRange(Detail.Select(d => "       " + d));
+            return lines;
+        }
+    }
+
+    public void WriteTo(Action<string> logf)
+    {
+        foreach (var line in Lines) logf(line);
+    }
+}
+
+public static class NetworkDiagnosis
+{
+    /// <summary>
+    /// Classify a failed HTTP attempt and produce a message that states what was observed.
+    /// </summary>
+    /// <param name="ex">The exception the request threw.</param>
+    /// <param name="what">
+    /// What was being fetched, in the caller's own words — e.g. "BC 28.1.49838.53910 (platform)".
+    /// </param>
+    /// <param name="url">The URL, used to name the host and port. Optional.</param>
+    public static NetworkFailureReport Describe(Exception ex, string what, string? url = null)
+    {
+        var (host, port) = HostAndPort(url);
+        var target = host is null ? "the server" : $"{host}:{port}";
+        var inner = Unwrap(ex);
+
+        // 1. The server answered. This is the ONLY branch entitled to say anything about the
+        //    CDN's own health, because it is the only one holding bytes the CDN sent.
+        if (FirstOfType<HttpRequestException>(inner) is { StatusCode: { } status } http)
+        {
+            return new NetworkFailureReport(NetworkFailureKind.ServerResponded,
+                $"the BC artifact CDN answered HTTP {(int)status} ({status}) for {what}.",
+                new[]
+                {
+                    $"Request: {url ?? "(url not recorded)"}",
+                    "The server was reached and responded, so this is the CDN's own answer,",
+                    "not a network problem on this host.",
+                });
+        }
+
+        // 2. The caller cancelled, or the client's own timeout elapsed. .NET reports both as
+        //    TaskCanceledException; only the timeout has a TimeoutException inside it.
+        if (FirstOfType<OperationCanceledException>(inner) is { } canceled)
+        {
+            if (FirstOfType<TimeoutException>(canceled) is not null || FirstOfType<SocketException>(inner)?.SocketErrorCode == SocketError.TimedOut)
+                return TimeoutReport(what, url, target);
+            return new NetworkFailureReport(NetworkFailureKind.Cancelled,
+                $"the request for {what} was cancelled before it completed.",
+                new[] { $"Request: {url ?? "(url not recorded)"}" });
+        }
+
+        // 3. Our own multi-address connector ran and every address failed. This is the
+        //    richest observation available: we know each address and why each one failed.
+        if (FirstOfType<MultiAddressConnectException>(inner) is { } multi)
+            return DescribeMultiAddress(multi, what, url);
+
+        // 4. A raw socket failure, with no per-address record (a client not built by
+        //    ArtifactDownloader.CreateClient, or a failure outside the connect callback).
+        if (FirstOfType<SocketException>(inner) is { } socket)
+            return DescribeSocketError(socket.SocketErrorCode, socket.Message, what, url, target,
+                addressLines: Array.Empty<string>());
+
+        // 5. TLS came up short. The TCP connection existed, so the host is reachable.
+        if (FirstOfType<AuthenticationException>(inner) is { } tls)
+            return new NetworkFailureReport(NetworkFailureKind.Tls,
+                $"the TLS handshake with {target} failed while fetching {what}.",
+                new[]
+                {
+                    $"Request: {url ?? "(url not recorded)"}",
+                    $"Reported: {tls.Message}",
+                    "The TCP connection was established, so the host is reachable; the failure is",
+                    "in the handshake (certificate, protocol version, or an intercepting proxy).",
+                });
+
+        // 6. Nothing recognizable. Say exactly what was seen and stop. Naming a cause here is
+        //    how #2926 happened in the first place.
+        return new NetworkFailureReport(NetworkFailureKind.Unknown,
+            $"the request for {what} failed before any response was received.",
+            new[]
+            {
+                $"Request: {url ?? "(url not recorded)"}",
+                $"Observed: {inner.GetType().Name}: {inner.Message}",
+                "Nothing was received from the server, so this does not show the CDN is down;",
+                "there is not enough information here to name a cause.",
+            });
+    }
+
+    private static NetworkFailureReport TimeoutReport(string what, string? url, string target)
+        => new(NetworkFailureKind.Timeout,
+            $"the request for {what} timed out with no response from {target}.",
+            new[]
+            {
+                $"Request: {url ?? "(url not recorded)"}",
+                "A timeout does not say where the fault is: a transient network problem on this",
+                "host, a firewall, packet loss and an unhealthy server all look identical from",
+                "here. This is not evidence that the CDN is down. Retrying is usually the next step.",
+            });
+
+    private static NetworkFailureReport DescribeMultiAddress(
+        MultiAddressConnectException multi, string what, string? url)
+    {
+        var target = $"{multi.Host}:{multi.Port}";
+
+        if (multi.ResolutionError is not null || multi.Attempts.Count == 0)
+        {
+            var socketError = FirstOfType<SocketException>(multi.ResolutionError)?.SocketErrorCode;
+            return new NetworkFailureReport(NetworkFailureKind.NameResolution,
+                $"could not resolve {multi.Host} while fetching {what}.",
+                new[]
+                {
+                    $"Request: {url ?? "(url not recorded)"}",
+                    $"Observed: DNS returned no usable address" +
+                        (socketError is null ? "." : $" ({socketError})."),
+                    "No connection was attempted, so nothing here is a statement about the CDN —",
+                    "check this host's DNS resolver first.",
+                });
+        }
+
+        var addressLines = new List<string> { "Addresses tried:" };
+        foreach (var a in multi.Attempts)
+        {
+            var family = a.IsIPv6 ? "IPv6" : "IPv4";
+            var outcome = !a.Attempted
+                ? "not tried"
+                : a.Error is { } err ? $"{err} — {a.Message}" : a.Message ?? "failed";
+            addressLines.Add($"  {a.Address} ({family}) {outcome}");
+        }
+
+        // Only claim the address family is the problem when the addresses say so: an IPv6
+        // address the local routing table rejected, AND an IPv4 address of the same host that
+        // either was never tried or failed for a different reason. If every address failed the
+        // same way, the address family is not what distinguishes them and saying so would be
+        // the same defect in a new spelling.
+        var v6NoRoute = multi.Attempts.Any(a => a.IsIPv6 && a.Attempted && IsNoRoute(a.Error));
+        var v4Present = multi.Attempts.Any(a => !a.IsIPv6);
+        var v4NoRoute = multi.Attempts.Any(a => !a.IsIPv6 && a.Attempted && IsNoRoute(a.Error));
+
+        if (v6NoRoute && v4Present && !v4NoRoute)
+        {
+            addressLines.Add("");
+            addressLines.Add("The IPv6 address was rejected by this host's own routing table while an IPv4");
+            addressLines.Add("address of the same host was resolved: this host most likely has no working");
+            addressLines.Add("IPv6 route. Retry with DOTNET_SYSTEM_NET_DISABLEIPV6=1 to confirm.");
+        }
+
+        var errors = multi.Attempts.Where(a => a.Attempted).Select(a => a.Error).Distinct().ToList();
+        var single = errors.Count == 1 ? errors[0] : null;
+
+        if (single is not null && IsNoRoute(single))
+            return DescribeSocketError(single.Value, multi.Message, what, url, target, addressLines);
+
+        if (single == SocketError.TimedOut)
+        {
+            var timeout = TimeoutReport(what, url, target);
+            return timeout with { Detail = timeout.Detail.Concat(addressLines).ToList() };
+        }
+
+        if (single == SocketError.ConnectionRefused)
+            return DescribeSocketError(single.Value, multi.Message, what, url, target, addressLines);
+
+        // Mixed or unrecognized failures across the addresses: report them all, claim nothing.
+        return new NetworkFailureReport(NetworkFailureKind.Unknown,
+            $"could not connect to {target} while fetching {what}.",
+            new[] { $"Request: {url ?? "(url not recorded)"}" }
+                .Concat(addressLines)
+                .Concat(new[]
+                {
+                    "Nothing was received from the server, so this does not show the CDN is down;",
+                    "the addresses failed for different reasons and there is not enough here to",
+                    "name a single cause.",
+                }).ToList());
+    }
+
+    private static NetworkFailureReport DescribeSocketError(
+        SocketError error, string message, string what, string? url, string target,
+        IReadOnlyList<string> addressLines)
+    {
+        var request = new[] { $"Request: {url ?? "(url not recorded)"}" };
+
+        switch (error)
+        {
+            case SocketError.HostNotFound:
+            case SocketError.NoData:
+            case SocketError.TryAgain:
+                return new NetworkFailureReport(NetworkFailureKind.NameResolution,
+                    $"could not resolve the host for {what}.",
+                    request.Concat(new[]
+                    {
+                        $"Observed: {error} — {message}",
+                        "No connection was attempted, so nothing here is a statement about the CDN —",
+                        "check this host's DNS resolver first.",
+                    }).ToList());
+
+            case SocketError.NetworkUnreachable:
+            case SocketError.HostUnreachable:
+                return new NetworkFailureReport(NetworkFailureKind.NoRouteToAddress,
+                    $"this host has no route to {target} for {what}.",
+                    request.Concat(new[] { $"Observed: {error} — {message}" })
+                        .Concat(addressLines)
+                        .Concat(new[]
+                        {
+                            "The local network stack refused the connection before any packet reached",
+                            "the server, so this is a routing problem on this host, not a CDN outage.",
+                        }).ToList());
+
+            case SocketError.ConnectionRefused:
+                return new NetworkFailureReport(NetworkFailureKind.ConnectionRefused,
+                    $"{target} refused the connection for {what}.",
+                    request.Concat(new[] { $"Observed: {error} — {message}" })
+                        .Concat(addressLines)
+                        .Concat(new[]
+                        {
+                            "Something answered at that address and rejected the connection. That is a",
+                            "fact about the far end, but not about the CDN's own health — a proxy or a",
+                            "captive network can produce it too.",
+                        }).ToList());
+
+            case SocketError.TimedOut:
+                var timeout = TimeoutReport(what, url, target);
+                return addressLines.Count == 0
+                    ? timeout
+                    : timeout with { Detail = timeout.Detail.Concat(addressLines).ToList() };
+
+            default:
+                return new NetworkFailureReport(NetworkFailureKind.Unknown,
+                    $"could not connect to {target} while fetching {what}.",
+                    request.Concat(new[] { $"Observed: {error} — {message}" })
+                        .Concat(addressLines)
+                        .Concat(new[]
+                        {
+                            "Nothing was received from the server, so this does not show the CDN is down;",
+                            "there is not enough information here to name a cause.",
+                        }).ToList());
+        }
+    }
+
+    private static bool IsNoRoute(SocketError? error)
+        => error is SocketError.NetworkUnreachable or SocketError.HostUnreachable;
+
+    /// <summary>
+    /// Peel <see cref="AggregateException"/> off the front. <c>ResolveVersion</c> blocks on
+    /// <c>.Result</c>, which is exactly how "Error fetching index: One or more errors occurred.
+    /// (A task was canceled.)" reached a user in #2926 — a message with no content at all.
+    /// </summary>
+    private static Exception Unwrap(Exception ex)
+    {
+        while (ex is AggregateException agg && agg.InnerExceptions.Count == 1)
+            ex = agg.InnerExceptions[0];
+        return ex;
+    }
+
+    /// <summary>First exception of type <typeparamref name="T"/> in the inner chain, if any.</summary>
+    private static T? FirstOfType<T>(Exception? ex) where T : Exception
+    {
+        for (var e = ex; e is not null; e = e.InnerException)
+        {
+            if (e is T match) return match;
+            if (e is AggregateException agg)
+                foreach (var i in agg.InnerExceptions)
+                    if (FirstOfType<T>(i) is { } nested) return nested;
+        }
+        return null;
+    }
+
+    private static (string? Host, int Port) HostAndPort(string? url)
+    {
+        if (string.IsNullOrEmpty(url)) return (null, 0);
+        return Uri.TryCreate(url, UriKind.Absolute, out var uri) ? (uri.Host, uri.Port) : (null, 0);
+    }
+}

--- a/AlRunner.Tests/ArtifactDownloader404Tests.cs
+++ b/AlRunner.Tests/ArtifactDownloader404Tests.cs
@@ -82,7 +82,7 @@ public sealed class ArtifactDownloader404Tests
     }
 
     [Fact]
-    public void TryHeadContentLength_ServerError_ReturnsFalseWithCdnReachabilityMessage_DistinctFrom404()
+    public void TryHeadContentLength_ServerError_ReturnsFalseNamingTheStatus_DistinctFrom404()
     {
         using var http = new HttpClient(new StubHandler(HttpStatusCode.InternalServerError));
         var logs = new List<string>();
@@ -95,7 +95,15 @@ public sealed class ArtifactDownloader404Tests
         Assert.Equal(0, size);
         // Must NOT claim the version is unpublished — a 500 is a CDN problem, not a bad version.
         Assert.DoesNotContain(logs, l => l.Contains("no BC artifact published"));
-        Assert.Contains(logs, l => l.Contains("could not reach the BC artifact CDN") && l.Contains("28.1.0.0"));
+        // Issue #2926: this used to assert "could not reach the BC artifact CDN", which was
+        // wrong in both directions. It was wrong here, because a 500 means we DID reach the CDN
+        // and it answered — the status code is the fact worth printing. And it was the same
+        // sentence emitted for a connect failure that never reached the CDN at all, which is
+        // how a host with no IPv6 route was told Azure was down. The status now appears, and
+        // the connect-failure cases no longer share this wording at all.
+        Assert.Contains(logs, l => l.Contains("the BC artifact CDN answered HTTP 500")
+                                   && l.Contains("28.1.0.0"));
+        Assert.Contains(logs, l => l.Contains("The server was reached"));
     }
 
     [Fact]

--- a/AlRunner.Tests/ArtifactDownloaderNetworkDiagnosisTests.cs
+++ b/AlRunner.Tests/ArtifactDownloaderNetworkDiagnosisTests.cs
@@ -1,0 +1,486 @@
+// Issue #2926: tools/DownloadArtifacts reported "could not reach the BC artifact CDN" on a host
+// whose only fault was having no IPv6 route to an AAAA record. The CDN was up; curl downloaded
+// 893 MB from it seconds later over IPv4.
+//
+// Everything below runs against CAPTURED resolver and HTTP outcomes, never the live network.
+// That is deliberate: a test that reads the real network passes for the wrong reason on a
+// healthy box and cannot be made to fail on demand, so it would prove nothing about the one
+// thing this fix is for — telling a transient timeout, an address-family problem and a real
+// outage apart. The one exception is the loopback test at the bottom, which talks to a
+// TcpListener on 127.0.0.1 to prove the connect callback is actually reached by the SYNCHRONOUS
+// HttpClient.Send path that ArtifactDownloader uses everywhere.
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using AlRunner.Provisioning;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ArtifactDownloaderNetworkDiagnosisTests
+{
+    // The exact addresses from the issue report: `getent hosts` returned only the AAAA, and
+    // curl's successful ranged GET came back from this IPv4 address.
+    private static readonly IPAddress CdnV6 = IPAddress.Parse("2603:1061:14:34::1");
+    private static readonly IPAddress CdnV4 = IPAddress.Parse("150.171.109.53");
+
+    private const string CdnHost = "bcartifacts-exdbf9fwegejdqak.b02.azurefd.net";
+    private const string CdnUrl = "https://bcartifacts-exdbf9fwegejdqak.b02.azurefd.net/sandbox/28.1.49838.53910/platform";
+
+    private static SocketException Sock(SocketError error) => new((int)error);
+
+    private static string Text(NetworkFailureReport r) => string.Join("\n", r.Lines);
+
+    /// <summary>
+    /// The single claim this whole issue is about: nothing may assert the CDN is unhealthy
+    /// unless the CDN actually sent us something.
+    /// </summary>
+    private static void AssertMakesNoClaimAboutTheCdn(NetworkFailureReport report)
+    {
+        var text = Text(report);
+        Assert.DoesNotContain("could not reach the BC artifact CDN", text);
+        Assert.DoesNotContain("the BC artifact CDN answered", text);
+    }
+
+    // ------------------------------------------------------------------
+    // Classification: the same failure text used to cover all of these.
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void NoRouteOnIPv6WithIPv4Resolved_NamesTheRoutingFact_AndNeverBlamesTheCdn()
+    {
+        // The captured shape of the issue: the kernel refused the IPv6 route, and the IPv4
+        // address of the same host was resolved but never reached.
+        var attempts = new[]
+        {
+            AddressAttempt.Failed(CdnV6, Sock(SocketError.NetworkUnreachable)),
+            AddressAttempt.NotTried(CdnV4),
+        };
+        var ex = new HttpRequestException("connection failure",
+            new MultiAddressConnectException(CdnHost, 443, attempts, null, "could not connect"));
+
+        var report = NetworkDiagnosis.Describe(ex, "BC 28.1.49838.53910 (platform)", CdnUrl);
+        var text = Text(report);
+
+        Assert.Equal(NetworkFailureKind.NoRouteToAddress, report.Kind);
+        // This is the whole point: the old message sent the reporter to check Azure by hand.
+        AssertMakesNoClaimAboutTheCdn(report);
+        Assert.Contains("not a CDN outage", text);
+        // It must name what was actually observed, per address, including the one NOT tried —
+        // "not tried" and "failed" are different observations.
+        Assert.Contains("2603:1061:14:34::1 (IPv6)", text);
+        Assert.Contains("150.171.109.53 (IPv4) not tried", text);
+        Assert.Contains("NetworkUnreachable", text);
+        // ...and only here, where the evidence supports it, may it name the address family.
+        Assert.Contains("no working", text);
+        Assert.Contains("IPv6 route", text);
+        Assert.Contains("DOTNET_SYSTEM_NET_DISABLEIPV6=1", text);
+    }
+
+    [Fact]
+    public void NoRouteOnBothFamilies_ReportsTheRoutingFact_ButNotTheIPv6Story()
+    {
+        // Both families refused: the address family is not what distinguishes them, so
+        // pointing at IPv6 would be the same defect in a new spelling.
+        var attempts = new[]
+        {
+            AddressAttempt.Failed(CdnV6, Sock(SocketError.NetworkUnreachable)),
+            AddressAttempt.Failed(CdnV4, Sock(SocketError.NetworkUnreachable)),
+        };
+        var ex = new MultiAddressConnectException(CdnHost, 443, attempts, null, "could not connect");
+
+        var report = NetworkDiagnosis.Describe(ex, "BC 28.1.49838.53910 (platform)", CdnUrl);
+        var text = Text(report);
+
+        Assert.Equal(NetworkFailureKind.NoRouteToAddress, report.Kind);
+        Assert.DoesNotContain("DOTNET_SYSTEM_NET_DISABLEIPV6", text);
+        Assert.DoesNotContain("no working", text);
+        Assert.Contains("150.171.109.53 (IPv4) NetworkUnreachable", text);
+        AssertMakesNoClaimAboutTheCdn(report);
+    }
+
+    [Fact]
+    public void MixedFailuresAcrossAddresses_NamesNoCauseAtAll()
+    {
+        // One address had no route, the other actively refused. There is no single cause here
+        // and the tool must not invent one — it reports both and stops.
+        var attempts = new[]
+        {
+            AddressAttempt.Failed(CdnV6, Sock(SocketError.NetworkUnreachable)),
+            AddressAttempt.Failed(CdnV4, Sock(SocketError.ConnectionRefused)),
+        };
+        var ex = new MultiAddressConnectException(CdnHost, 443, attempts, null, "could not connect");
+
+        var report = NetworkDiagnosis.Describe(ex, "BC 28.1.49838.53910 (platform)", CdnUrl);
+        var text = Text(report);
+
+        Assert.Equal(NetworkFailureKind.Unknown, report.Kind);
+        Assert.Contains("not enough here to", text);
+        Assert.Contains("NetworkUnreachable", text);
+        Assert.Contains("ConnectionRefused", text);
+        Assert.DoesNotContain("DOTNET_SYSTEM_NET_DISABLEIPV6", text);
+        AssertMakesNoClaimAboutTheCdn(report);
+    }
+
+    [Fact]
+    public void ClientTimeout_SaysItCannotTellWhereTheFaultIs()
+    {
+        // How .NET reports HttpClient.Timeout elapsing. On this machine these happen for real
+        // and intermittently, so the message has to be honest about proving nothing.
+        var ex = new TaskCanceledException("The request was canceled due to the configured HttpClient.Timeout",
+            new TimeoutException("A task was canceled."));
+
+        var report = NetworkDiagnosis.Describe(ex, "BC 28.1.49838.53910 (platform)", CdnUrl);
+        var text = Text(report);
+
+        Assert.Equal(NetworkFailureKind.Timeout, report.Kind);
+        Assert.Contains("timed out", text);
+        Assert.Contains("does not say where the fault is", text);
+        Assert.Contains("Retrying", text);
+        // A timeout is consistent with all of these and evidence for none of them.
+        AssertMakesNoClaimAboutTheCdn(report);
+        Assert.DoesNotContain("no route", text);
+        Assert.DoesNotContain("routing problem", text);
+        Assert.DoesNotContain("resolve", text);
+    }
+
+    [Fact]
+    public void AggregateExceptionFromResolveVersion_IsUnwrapped_NotEchoed()
+    {
+        // The literal second failure in the issue: ResolveVersion blocks on .Result, so the
+        // user was shown "Error fetching index: One or more errors occurred. (A task was
+        // canceled.)" — a sentence with no information in it whatsoever.
+        var ex = new AggregateException(
+            new TaskCanceledException("canceled", new TimeoutException("A task was canceled.")));
+
+        var report = NetworkDiagnosis.Describe(ex, "the BC version index (prefix '28.1')",
+            "https://bcartifacts-exdbf9fwegejdqak.b02.azurefd.net/sandbox/indexes/w1.json");
+        var text = Text(report);
+
+        Assert.Equal(NetworkFailureKind.Timeout, report.Kind);
+        Assert.DoesNotContain("One or more errors occurred", text);
+        Assert.Contains("the BC version index (prefix '28.1')", text);
+        Assert.Contains("indexes/w1.json", text);
+    }
+
+    [Fact]
+    public void DnsFailure_PointsAtTheResolver_NotAtTheCdn()
+    {
+        var ex = new MultiAddressConnectException(CdnHost, 443, Array.Empty<AddressAttempt>(),
+            Sock(SocketError.HostNotFound), "could not resolve");
+
+        var report = NetworkDiagnosis.Describe(ex, "BC 28.1.49838.53910 (platform)", CdnUrl);
+        var text = Text(report);
+
+        Assert.Equal(NetworkFailureKind.NameResolution, report.Kind);
+        Assert.Contains("could not resolve " + CdnHost, text);
+        Assert.Contains("DNS", text);
+        Assert.Contains("No connection was attempted", text);
+        AssertMakesNoClaimAboutTheCdn(report);
+        Assert.DoesNotContain("DOTNET_SYSTEM_NET_DISABLEIPV6", text);
+    }
+
+    [Fact]
+    public void RawSocketException_WithNoPerAddressRecord_StillClassifies()
+    {
+        // A client built somewhere other than ArtifactHttpClient.Create still has to produce a
+        // sane message — the classifier cannot depend on our connector having run.
+        var ex = new HttpRequestException("name resolution failure", Sock(SocketError.HostNotFound));
+
+        var report = NetworkDiagnosis.Describe(ex, "BC 28.1.49838.53910 (platform)", CdnUrl);
+
+        Assert.Equal(NetworkFailureKind.NameResolution, report.Kind);
+        Assert.Contains("DNS", Text(report));
+        AssertMakesNoClaimAboutTheCdn(report);
+    }
+
+    [Fact]
+    public void ServerResponded_IsTheOnlyKindAllowedToTalkAboutTheCdn()
+    {
+        var ex = new HttpRequestException("Response status code does not indicate success: 503",
+            null, HttpStatusCode.ServiceUnavailable);
+
+        var report = NetworkDiagnosis.Describe(ex, "BC 28.1.49838.53910 (platform)", CdnUrl);
+        var text = Text(report);
+
+        Assert.Equal(NetworkFailureKind.ServerResponded, report.Kind);
+        // We hold bytes the CDN sent, so here — and only here — naming it is honest.
+        Assert.Contains("the BC artifact CDN answered HTTP 503", text);
+        Assert.Contains("The server was reached", text);
+        // ...and it must not be confused with the unpublished-version case (#1659/#2236).
+        Assert.DoesNotContain("no BC artifact published", text);
+    }
+
+    [Fact]
+    public void ConnectionRefused_NamesTheFarEnd_WithoutClaimingTheCdnIsUnhealthy()
+    {
+        var attempts = new[] { AddressAttempt.Failed(CdnV4, Sock(SocketError.ConnectionRefused)) };
+        var ex = new MultiAddressConnectException(CdnHost, 443, attempts, null, "refused");
+
+        var report = NetworkDiagnosis.Describe(ex, "BC 28.1.49838.53910 (platform)", CdnUrl);
+        var text = Text(report);
+
+        Assert.Equal(NetworkFailureKind.ConnectionRefused, report.Kind);
+        Assert.Contains("refused the connection", text);
+        Assert.Contains("proxy", text);
+        AssertMakesNoClaimAboutTheCdn(report);
+    }
+
+    [Fact]
+    public void UnrecognizedFailure_ReportsTheObservation_AndExplicitlyNamesNoCause()
+    {
+        var ex = new IOException("The response ended prematurely.");
+
+        var report = NetworkDiagnosis.Describe(ex, "BC 28.1.49838.53910 (platform)", CdnUrl);
+        var text = Text(report);
+
+        Assert.Equal(NetworkFailureKind.Unknown, report.Kind);
+        Assert.Contains("Observed: IOException: The response ended prematurely.", text);
+        Assert.Contains("not enough information here to name a cause", text);
+        AssertMakesNoClaimAboutTheCdn(report);
+    }
+
+    // ------------------------------------------------------------------
+    // The connector: does it walk the addresses the way curl does?
+    // ------------------------------------------------------------------
+
+    private sealed class FakeStream : MemoryStream
+    {
+        public FakeStream(IPAddress address) => Address = address;
+        public IPAddress Address { get; }
+    }
+
+    private static MultiAddressConnector.ResolveDelegate Resolves(params IPAddress[] addresses)
+        => (_, _) => ValueTask.FromResult(addresses);
+
+    [Fact]
+    public async Task IPv6NoRouteThenIPv4_ConnectsOverIPv4_LikeCurlDoes()
+    {
+        var tried = new List<IPAddress>();
+        var notes = new List<string>();
+
+        var stream = await MultiAddressConnector.ConnectAnyAsync(
+            CdnHost, 443,
+            Resolves(CdnV6, CdnV4),
+            (address, _, _) =>
+            {
+                tried.Add(address);
+                if (address.AddressFamily == AddressFamily.InterNetworkV6)
+                    throw Sock(SocketError.NetworkUnreachable);
+                return ValueTask.FromResult<Stream>(new FakeStream(address));
+            },
+            TimeSpan.FromSeconds(1), CancellationToken.None, notes.Add);
+
+        // The whole reported failure: the tool stopped at the first address.
+        Assert.Equal(new[] { CdnV6, CdnV4 }, tried);
+        Assert.Equal(CdnV4, Assert.IsType<FakeStream>(stream).Address);
+        // A silent fallback is its own problem — every connection then pays for a broken IPv6
+        // route while the host looks healthy. It has to be said once.
+        var note = Assert.Single(notes);
+        Assert.Contains("NetworkUnreachable", note);
+        Assert.Contains("connected over IPv4 (150.171.109.53)", note);
+    }
+
+    [Fact]
+    public async Task FirstAddressSucceeds_SaysNothingAboutAFallbackThatDidNotHappen()
+    {
+        var notes = new List<string>();
+
+        await MultiAddressConnector.ConnectAnyAsync(
+            CdnHost, 443, Resolves(CdnV6, CdnV4),
+            (address, _, _) => ValueTask.FromResult<Stream>(new FakeStream(address)),
+            TimeSpan.FromSeconds(1), CancellationToken.None, notes.Add);
+
+        Assert.Empty(notes);
+    }
+
+    [Fact]
+    public async Task BlackHoledAddress_IsCappedPerAddress_SoTheNextOneIsStillTried()
+    {
+        // A firewall dropping SYNs is the common shape of a broken IPv6 path: no error, just
+        // silence. Without a per-address cap, one dead address eats the entire budget and the
+        // working address is never reached — which looks exactly like the reported bug.
+        var tried = new List<IPAddress>();
+
+        var stream = await MultiAddressConnector.ConnectAnyAsync(
+            CdnHost, 443, Resolves(CdnV6, CdnV4),
+            async (address, _, ct) =>
+            {
+                tried.Add(address);
+                if (address.AddressFamily == AddressFamily.InterNetworkV6)
+                    await Task.Delay(Timeout.Infinite, ct);
+                return new FakeStream(address);
+            },
+            TimeSpan.FromMilliseconds(150), CancellationToken.None);
+
+        Assert.Equal(new[] { CdnV6, CdnV4 }, tried);
+        Assert.Equal(CdnV4, Assert.IsType<FakeStream>(stream).Address);
+    }
+
+    [Fact]
+    public async Task EveryAddressFails_RecordsEachOutcome_ForTheMessageToReport()
+    {
+        var ex = await Assert.ThrowsAsync<MultiAddressConnectException>(async () =>
+            await MultiAddressConnector.ConnectAnyAsync(
+                CdnHost, 443, Resolves(CdnV6, CdnV4),
+                (address, _, _) => throw Sock(address.AddressFamily == AddressFamily.InterNetworkV6
+                    ? SocketError.NetworkUnreachable
+                    : SocketError.ConnectionRefused),
+                TimeSpan.FromSeconds(1), CancellationToken.None));
+
+        Assert.Equal(2, ex.Attempts.Count);
+        Assert.All(ex.Attempts, a => Assert.True(a.Attempted));
+        Assert.Equal(SocketError.NetworkUnreachable, ex.Attempts[0].Error);
+        Assert.Equal(SocketError.ConnectionRefused, ex.Attempts[1].Error);
+        Assert.Null(ex.ResolutionError);
+
+        // ...and the classification of that exception is the mixed case: no single cause.
+        Assert.Equal(NetworkFailureKind.Unknown,
+            NetworkDiagnosis.Describe(ex, "BC 28.1.49838.53910 (platform)", CdnUrl).Kind);
+    }
+
+    [Fact]
+    public async Task ResolverReturnsNothing_IsAResolutionFailure_NotAConnectFailure()
+    {
+        var ex = await Assert.ThrowsAsync<MultiAddressConnectException>(async () =>
+            await MultiAddressConnector.ConnectAnyAsync(
+                CdnHost, 443, Resolves(),
+                (_, _, _) => throw new InvalidOperationException("must not be reached"),
+                TimeSpan.FromSeconds(1), CancellationToken.None));
+
+        Assert.Empty(ex.Attempts);
+        Assert.Equal(NetworkFailureKind.NameResolution,
+            NetworkDiagnosis.Describe(ex, "BC 28.1.49838.53910 (platform)", CdnUrl).Kind);
+    }
+
+    [Fact]
+    public async Task ResolverThrows_KeepsTheDnsErrorInsteadOfReportingAConnectProblem()
+    {
+        var ex = await Assert.ThrowsAsync<MultiAddressConnectException>(async () =>
+            await MultiAddressConnector.ConnectAnyAsync(
+                CdnHost, 443,
+                (_, _) => throw Sock(SocketError.HostNotFound),
+                (_, _, _) => throw new InvalidOperationException("must not be reached"),
+                TimeSpan.FromSeconds(1), CancellationToken.None));
+
+        Assert.Empty(ex.Attempts);
+        Assert.Equal(SocketError.HostNotFound, Assert.IsType<SocketException>(ex.ResolutionError).SocketErrorCode);
+
+        var report = NetworkDiagnosis.Describe(ex, "BC 28.1.49838.53910 (platform)", CdnUrl);
+        Assert.Equal(NetworkFailureKind.NameResolution, report.Kind);
+        Assert.Contains("HostNotFound", Text(report));
+    }
+
+    [Fact]
+    public async Task CallerCancellation_IsNotReportedAsANetworkFailure()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await MultiAddressConnector.ConnectAnyAsync(
+                CdnHost, 443, Resolves(CdnV6, CdnV4),
+                (_, _, _) => throw new InvalidOperationException("must not be reached"),
+                TimeSpan.FromSeconds(1), cts.Token));
+    }
+
+    // ------------------------------------------------------------------
+    // The connect callback has to be reached by the SYNCHRONOUS Send path.
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void CreateClient_ConnectCallbackIsUsedBySynchronousSend_OverLoopback()
+    {
+        // ArtifactDownloader calls http.Send(...), not SendAsync. If SocketsHttpHandler's
+        // ConnectCallback were async-only, the whole fix would be dead code on every path that
+        // matters and nothing above would notice. Loopback only — no external network.
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+        var server = Task.Run(() =>
+        {
+            using var client = listener.AcceptTcpClient();
+            using var netStream = client.GetStream();
+            var buffer = new byte[4096];
+            netStream.Read(buffer, 0, buffer.Length); // the request line + headers
+            var body = "ok";
+            var response = $"HTTP/1.1 200 OK\r\nContent-Length: {body.Length}\r\nConnection: close\r\n\r\n{body}";
+            var bytes = Encoding.ASCII.GetBytes(response);
+            netStream.Write(bytes, 0, bytes.Length);
+            netStream.Flush();
+        });
+
+        using var http = ArtifactHttpClient.Create(TimeSpan.FromSeconds(30));
+        using var resp = http.Send(new HttpRequestMessage(HttpMethod.Get, $"http://127.0.0.1:{port}/probe"));
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal("ok", new StreamReader(resp.Content.ReadAsStream()).ReadToEnd());
+        Assert.True(server.Wait(TimeSpan.FromSeconds(30)));
+    }
+
+    // ------------------------------------------------------------------
+    // The tool-level surface: TryHeadContentLength is where the message came from.
+    // ------------------------------------------------------------------
+
+    private sealed class ThrowingHandler : HttpMessageHandler
+    {
+        private readonly Func<Exception> _make;
+        public ThrowingHandler(Func<Exception> make) => _make = make;
+
+        protected override HttpResponseMessage Send(HttpRequestMessage r, CancellationToken ct) => throw _make();
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage r, CancellationToken ct)
+            => Task.FromException<HttpResponseMessage>(_make());
+    }
+
+    [Fact]
+    public void TryHeadContentLength_AddressFamilyFailure_ReportsTheAddresses_NotACdnOutage()
+    {
+        var attempts = new[]
+        {
+            AddressAttempt.Failed(CdnV6, Sock(SocketError.NetworkUnreachable)),
+            AddressAttempt.NotTried(CdnV4),
+        };
+        using var http = new HttpClient(new ThrowingHandler(() => new HttpRequestException(
+            "connection failure",
+            new MultiAddressConnectException(CdnHost, 443, attempts, null, "could not connect"))));
+        var logs = new List<string>();
+
+        var ok = ArtifactDownloader.TryHeadContentLength(
+            http, CdnUrl, "28.1.49838.53910", "platform", logs.Add, out long size);
+
+        var text = string.Join("\n", logs);
+        Assert.False(ok);
+        Assert.Equal(0, size);
+        // The line the issue was filed about.
+        Assert.DoesNotContain("could not reach the BC artifact CDN", text);
+        Assert.Contains("no route", text);
+        Assert.Contains("2603:1061:14:34::1", text);
+        Assert.Contains("150.171.109.53", text);
+        Assert.Contains("DOTNET_SYSTEM_NET_DISABLEIPV6=1", text);
+        // ...and it must still not be confused with an unpublished version.
+        Assert.DoesNotContain("no BC artifact published", text);
+    }
+
+    [Fact]
+    public void TryHeadContentLength_Timeout_IsHandled_NotThrown()
+    {
+        // A sibling of #1659: this method caught only HttpRequestException, so the single most
+        // common transient failure escaped it as an unhandled exception with a raw stack trace.
+        using var http = new HttpClient(new ThrowingHandler(() => new TaskCanceledException(
+            "The request was canceled due to the configured HttpClient.Timeout of 600 seconds elapsing.",
+            new TimeoutException("A task was canceled."))));
+        var logs = new List<string>();
+
+        var ok = ArtifactDownloader.TryHeadContentLength(
+            http, CdnUrl, "28.1.49838.53910", "platform", logs.Add, out long size);
+
+        var text = string.Join("\n", logs);
+        Assert.False(ok);
+        Assert.Equal(0, size);
+        Assert.Contains("timed out", text);
+        Assert.Contains("does not say where the fault is", text);
+        Assert.DoesNotContain("could not reach the BC artifact CDN", text);
+    }
+}

--- a/AlRunner.Tests/ArtifactDownloaderNetworkDiagnosisTests.cs
+++ b/AlRunner.Tests/ArtifactDownloaderNetworkDiagnosisTests.cs
@@ -103,7 +103,10 @@ public sealed class ArtifactDownloaderNetworkDiagnosisTests
     public void MixedFailuresAcrossAddresses_NamesNoCauseAtAll()
     {
         // One address had no route, the other actively refused. There is no single cause here
-        // and the tool must not invent one — it reports both and stops.
+        // and the tool must not invent one — it reports both and stops. In particular the IPv6
+        // advice must not appear: the IPv4 address was tried and failed too, so turning IPv6
+        // off would not have helped. This assertion caught the first version of the fix doing
+        // exactly that.
         var attempts = new[]
         {
             AddressAttempt.Failed(CdnV6, Sock(SocketError.NetworkUnreachable)),
@@ -314,6 +317,51 @@ public sealed class ArtifactDownloaderNetworkDiagnosisTests
             TimeSpan.FromMilliseconds(150), CancellationToken.None);
 
         Assert.Equal(new[] { CdnV6, CdnV4 }, tried);
+        Assert.Equal(CdnV4, Assert.IsType<FakeStream>(stream).Address);
+    }
+
+    [Fact]
+    public async Task LastAddressIsNotCapped_SoASlowConnectStillSucceeds()
+    {
+        // The cap exists to stop a dead address starving the ones behind it. On the last
+        // address nothing is behind it, so capping there could only turn a slow-but-working
+        // connect into a failure — a regression against the stock client, which would have
+        // waited. Measured on the development box: its IPv6 address fails instantly and its
+        // IPv4 address intermittently black-holes for ~135s, so this distinction is not
+        // hypothetical.
+        var tried = new List<IPAddress>();
+
+        var stream = await MultiAddressConnector.ConnectAnyAsync(
+            CdnHost, 443, Resolves(CdnV6, CdnV4),
+            async (address, _, ct) =>
+            {
+                tried.Add(address);
+                if (address.AddressFamily == AddressFamily.InterNetworkV6)
+                    throw Sock(SocketError.NetworkUnreachable);
+                // Comfortably longer than the per-address cap below.
+                await Task.Delay(TimeSpan.FromMilliseconds(300), ct);
+                return new FakeStream(address);
+            },
+            TimeSpan.FromMilliseconds(50), CancellationToken.None);
+
+        Assert.Equal(new[] { CdnV6, CdnV4 }, tried);
+        Assert.Equal(CdnV4, Assert.IsType<FakeStream>(stream).Address);
+    }
+
+    [Fact]
+    public async Task SoleAddressIsNotCapped_EitherWay()
+    {
+        // Degenerate case of the same rule: with one address the walk must behave exactly like
+        // the stock client, or this fix would make single-homed hosts worse than before.
+        var stream = await MultiAddressConnector.ConnectAnyAsync(
+            CdnHost, 443, Resolves(CdnV4),
+            async (address, _, ct) =>
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(300), ct);
+                return new FakeStream(address);
+            },
+            TimeSpan.FromMilliseconds(50), CancellationToken.None);
+
         Assert.Equal(CdnV4, Assert.IsType<FakeStream>(stream).Address);
     }
 

--- a/AlRunner.Tests/ProvisionNoticeClaimsTests.cs
+++ b/AlRunner.Tests/ProvisionNoticeClaimsTests.cs
@@ -1,0 +1,59 @@
+// Issue #2926. ArtifactDownloader.VersionExists returns a plain bool, and it returns false for
+// two things that are not the same: "the CDN answered 404, this build is not published" and
+// "the probe never got an answer". BcArtifacts.ResolveProvisionTargetCore reads false as the
+// first one and drops a tier; these two notices then printed that reading as fact.
+//
+// On a transient network fault — the address-family failure this issue was filed about, a DNS
+// hiccup, a timeout — both sentences were false, and both sent the reader to check Microsoft's
+// publishing instead of their own network. That is the reported defect, one layer up.
+//
+// The bool cannot carry a third state without changing ResolveProvisionTargetCore's contract,
+// so what these tests pin is the weaker claim that holds either way.
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ProvisionNoticeClaimsTests
+{
+    [Fact]
+    public void CdnMinorNotice_DoesNotAssertTheBuildWasNeverPublished()
+    {
+        var notice = AlRunner.ProgramSupport.CdnMinorProvisionNotice("28.1.49838.53910", "28.1");
+
+        // The claim it must not make: this is only knowable from a 404, and the caller cannot
+        // tell a 404 from a failed probe.
+        Assert.DoesNotContain("is not published", notice);
+        Assert.DoesNotContain("not available", notice);
+        // ...and the weaker claim it must still make, or the message stops being useful.
+        Assert.Contains("could not be obtained from the CDN", notice);
+        Assert.Contains("28.1.49838.53910", notice);
+        Assert.Contains("provisioning the latest 28.1.x instead", notice);
+        // The actionable line has to survive the rewording.
+        Assert.Contains("al-runner provision --bc-version 28.1.49838.53910", notice);
+    }
+
+    [Fact]
+    public void MajorFallbackWarning_DoesNotAssertTheCdnHasNothing()
+    {
+        var notice = AlRunner.ProgramSupport.MajorFallbackWarning("28.1.49838.53910", "28.1", "28");
+
+        Assert.DoesNotContain("not available", notice);
+        Assert.DoesNotContain("is not published", notice);
+        Assert.Contains("could not be obtained from the CDN", notice);
+        // It stays a warning: this tier IS degraded, whatever the reason for the miss.
+        Assert.Contains("warning:", notice);
+        Assert.Contains("KNOWN-DEGRADED", notice);
+        Assert.Contains("Falling back to the latest 28.x", notice);
+        Assert.Contains("al-runner provision --bc-version 28.1", notice);
+    }
+
+    [Fact]
+    public void BothNotices_StillSayTheCdnWasConsulted()
+    {
+        // The mirror defect, from the comment at the top of DefaultProvisionTargetMessagingTests:
+        // the offline branch once claimed a CDN check that never happened. These two branches
+        // DID consult the CDN, so removing the word entirely would be the opposite error.
+        Assert.Contains("CDN", AlRunner.ProgramSupport.CdnMinorProvisionNotice("28.1.49838.53910", "28.1"));
+        Assert.Contains("CDN", AlRunner.ProgramSupport.MajorFallbackWarning("28.1.49838.53910", "28.1", "28"));
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1093,10 +1093,11 @@ if (bcVersionArg == null && artifactPathArg == null)
                         $"Microsoft.Dynamics.Nav.CodeAnalysis. Fix with: al-runner provision --bc-version {engineVersion}"));
                     break;
                 case "cdn-minor":
-                    Console.Error.WriteLine($"[bc] no --bc-version given and BC {engineVersion} is not published on " +
-                        $"the CDN — provisioning the latest {engineMajorMinor}.x instead (still this binary's own " +
-                        $"engine minor). Build-level skew within a minor can still fail to load " +
-                        $"Microsoft.Dynamics.Nav.CodeAnalysis. Fix with: al-runner provision --bc-version {engineVersion}");
+                    // #2926: wording and the reason it is worded that way live in
+                    // ProgramSupport.CdnMinorProvisionNotice — a failed probe is not a
+                    // statement that Microsoft never published the build.
+                    Console.Error.WriteLine(ProgramSupport.CdnMinorProvisionNotice(
+                        engineVersion.ToString(), engineMajorMinor));
                     break;
                 case "major-fallback-offline":
                     // No network step is coming (--no-auto-provision, or the rare case where
@@ -1110,11 +1111,9 @@ if (bcVersionArg == null && artifactPathArg == null)
                 default: // major-fallback: neither the exact build nor the engine's own minor is
                          // available from cache or the CDN — a genuine degradation (e.g. #2010,
                          // Microsoft withdrew the build), not the default-path norm.
-                    Console.Error.WriteLine($"[bc] warning: BC {engineMajorMinor}.x is not cached and not available " +
-                        $"from the CDN — this binary's engine was built for {engineVersion}, so a different minor is " +
-                        $"a KNOWN-DEGRADED configuration (measured: dozens of extra failures from engine/artifact " +
-                        $"minor skew). Falling back to the latest {engineMajor}.x. Fix with: al-runner provision " +
-                        $"--bc-version {engineMajorMinor}");
+                    // #2926: see ProgramSupport.MajorFallbackWarning.
+                    Console.Error.WriteLine(ProgramSupport.MajorFallbackWarning(
+                        engineVersion.ToString(), engineMajorMinor, engineMajor.ToString()));
                     break;
             }
 

--- a/AlRunner/ProgramSupport/ProvisionNotices.cs
+++ b/AlRunner/ProgramSupport/ProvisionNotices.cs
@@ -1,0 +1,44 @@
+// Issue #2926: the two version-selection notices below are the downstream readers of
+// ArtifactDownloader.VersionExists, and both used to state as fact something that boolean
+// cannot establish.
+//
+// VersionExists returns false for "the CDN answered 404" AND for "the probe failed" — a DNS
+// failure, a five-second timeout, or the address-family problem this issue was filed about.
+// BcArtifacts.ResolveProvisionTargetCore treats false as "not published" and walks down a
+// tier, and these two lines then told the user "BC x.y.z is not published on the CDN" and
+// "BC x.y.x is not cached and not available from the CDN". On a transient network fault both
+// sentences are false, and both send the reader to check Microsoft's publishing rather than
+// their own network — the same wrong turn #2926 was filed for one layer down.
+//
+// The signal cannot carry the third state without changing ResolveProvisionTargetCore's
+// contract, which is tracked separately. What these notices can do, and now do, is state the
+// weaker thing that is true either way: the artifact could not be obtained. When the cause was
+// a network failure, ArtifactDownloader has already printed the classified observation above.
+//
+// Extracted from the inline switch in Program.cs so the claim is directly assertable; the
+// switch, its deferred-line ordering and its comments are untouched.
+namespace AlRunner;
+
+internal static partial class ProgramSupport
+{
+    /// <summary>
+    /// "cdn-minor" tier: the engine's exact build could not be obtained, so provisioning falls
+    /// back to the latest build of the engine's own minor.
+    /// </summary>
+    internal static string CdnMinorProvisionNotice(string engineVersion, string engineMajorMinor)
+        => $"[bc] no --bc-version given and BC {engineVersion} could not be obtained from " +
+           $"the CDN — provisioning the latest {engineMajorMinor}.x instead (still this binary's own " +
+           $"engine minor). Build-level skew within a minor can still fail to load " +
+           $"Microsoft.Dynamics.Nav.CodeAnalysis. Fix with: al-runner provision --bc-version {engineVersion}";
+
+    /// <summary>
+    /// "major-fallback" tier: neither the engine's exact build nor its minor could be obtained
+    /// from cache or the CDN. Genuinely degraded — but not necessarily Microsoft's doing.
+    /// </summary>
+    internal static string MajorFallbackWarning(string engineVersion, string engineMajorMinor, string engineMajor)
+        => $"[bc] warning: BC {engineMajorMinor}.x is not cached and could not be obtained " +
+           $"from the CDN — this binary's engine was built for {engineVersion}, so a different minor is " +
+           $"a KNOWN-DEGRADED configuration (measured: dozens of extra failures from engine/artifact " +
+           $"minor skew). Falling back to the latest {engineMajor}.x. Fix with: al-runner provision " +
+           $"--bc-version {engineMajorMinor}";
+}


### PR DESCRIPTION
Closes #2926

`tools/DownloadArtifacts` told a user the BC artifact CDN was down. The CDN was up: the host had an AAAA record and no IPv6 route, and curl downloaded 893 MB from an IPv4 address of the same name seconds later. The reporter spent several minutes checking Azure by hand before thinking to look at the address family.

The bug is not the download. It is that one sentence was printed for a set of observations that mean very different things, and it named a cause the observation did not support — the same class of defect `.claude/rules/github-access.md` records one layer up, where an unauthenticated 404 gets read as "this does not exist".

## What changed

**`NetworkDiagnosis` classifies the failure and reports what was seen.** The rule the message text now obeys: a claim about the remote service requires bytes from the remote service. Only `ServerResponded` — where we hold an HTTP status — may say anything about the CDN's health. A DNS failure points at the resolver. `ENETUNREACH` is the local kernel's own routing table, so it is reported as a fact about this host. A timeout says plainly that it cannot tell a local fault, a firewall and an unhealthy server apart. Anything unrecognized prints the observation and explicitly names no cause.

**`MultiAddressConnector` walks every resolved address, the way curl does**, so the reported case now succeeds instead of stopping at the first address. It is a plain function over an injected resolver and connect, which is what makes the interesting cases testable.

**The IPv6 hint is evidence-gated.** It appears only when the routing table refused an IPv6 address *and* an IPv4 address was resolved but never attempted. If the IPv4 address was also tried and failed, turning IPv6 off cannot help and suggesting it would be this issue's own defect in a new spelling. The first version of the fix got this wrong and `MixedFailuresAcrossAddresses_NamesNoCauseAtAll` caught it.

## Fixing the shape, not just the reported line

1. **Same pattern at other call sites?** Yes, three. `ResolveVersion` printed `Error fetching index: One or more errors occurred. (A task was canceled.)` — an `AggregateException`'s `ToString`, named in the issue, with no information in it; it is now unwrapped. `AlCompiler` collapsed every failure into `Error downloading: {msg}` while fetching from nuget.org, so a message blaming "the CDN" would have been wrong twice over. `DownloadRange` threw a bare `Exception` with no inner, discarding the only record of why both attempts failed.

2. **Sibling function making the same assumption?** Yes. `TryHeadContentLength` and `VersionExists` both caught only `HttpRequestException`, so a client timeout — which .NET raises as `TaskCanceledException` — escaped as an unhandled exception with a raw stack trace. That is exactly the crash #1659 fixed for 404s, still live for the most common transient failure there is.

3. **Two paths reading the same state, same invariant?** No, and this one is user-facing. `VersionExists` returns a bool that is `false` both for "the CDN answered 404" and for "the probe never got an answer". `BcArtifacts.ResolveProvisionTargetCore` reads it as the first and drops a tier, and two notices in `Program.cs` then printed that reading as fact: `BC x.y.z is not published on the CDN` and `is not cached and not available from the CDN`. On a transient fault both sentences are false and both send the reader to check Microsoft's publishing rather than their own network. They now say the weaker thing that is true either way. Separately, all nine `new HttpClient` sites now share one factory, so two paths reaching the same CDN cannot disagree about how to reach it.

## RED → GREEN

RED was produced by stubbing `NetworkDiagnosis.Describe` back to the single pre-fix message and `MultiAddressConnector` back to "stop at the first address", and reverting `ArtifactDownloader.cs` to `origin/main`: **18 of 24 failed.** The 6 that passed are the ones pinning unchanged invariants (the three 404/success tests, caller cancellation, the loopback wiring test, and "a fallback that did not happen is not reported"). Restoring the fix: **24/24**. The two later last-address tests were RED-checked separately by removing the exemption — both failed, both pass with it.

Final state, run on the rebased tree: **77/77** across `ArtifactDownloader*`, `ProvisionNoticeClaimsTests`, `DefaultProvisionTargetTests` and the CLI-text classes.

`CreateClient_ConnectCallbackIsUsedBySynchronousSend_OverLoopback` exists because `ArtifactDownloader` calls `http.Send`, not `SendAsync`. If `ConnectCallback` were async-only the whole fix would be dead code on every path that matters and nothing else here would have noticed. Loopback only.

## Measurements

Everything in the tests runs against captured resolver and HTTP outcomes, never the live network — a test that reads the real network passes for the wrong reason on a healthy box and cannot be made to fail on demand.

Separately, against the real CDN: this development box reproduces the reported condition (the CDN has an AAAA, the box has no IPv6 default route). Forcing the issue's address order, the connector falls back and connects over IPv4 in **48 ms**, reporting the fallback once rather than silently paying for a broken route on every connection.

It also turned up a fault I had to be careful not to misdiagnose. Four of 15 connects to the CDN's IPv4 address black-hole for ~135 s. I first read my own 10 s failures as sync-over-async in the connect callback; measuring showed the stock client hits the identical fault, so the cap was surfacing a real problem rather than causing one:

| connect path | failures / 13 network-hitting tests | wall clock |
|---|---|---|
| this branch | 3, 5, 3 | 52 s – 66 s |
| stock (`origin/main` behavior, via the escape hatch) | 2, 3 | 4 m 20 s – 7 m 46 s |

Same failure rate, same verdict reached 5–9x faster. Those failures are the box, not the change.

That measurement did expose one genuine risk in my first design: capping every address could abandon a slow-but-working connect the caller was willing to wait for. The cap is now not applied to the last address, where nothing is behind it to starve, so every address the stock client would have waited on is still waited on for at least as long.

## Deliberately left out

`VersionExists` still returns a bool and so still cannot distinguish "not published" from "could not ask". Widening it to a tri-state changes `ResolveProvisionTargetCore`'s contract and raises a real question this issue does not answer — whether an undetermined probe should fail loudly instead of silently degrading, which would change CI behavior on a flaky network. Filed separately as #2981. The notices no longer assert the thing the bool cannot support, so nothing is silently wrong in the meantime.

`AL_RUNNER_DISABLE_MULTI_ADDRESS_CONNECT=1` reverts to the stock connect. It is a diagnostic seam, deliberately not advertised in `--help`.

No doc updates: nothing in `README.md`, `docs/` or `--guide` documents these messages, and no flag or scope changed.

Filed by an agent (`impl-17`) on the account holder's behalf.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
