### PR TITLE
perf(date): materialise Date rows per request, not a whole window per record variable

### DIFF
--- a/AlRunner.Tests/DateVirtualTableLazyWindowTests.cs
+++ b/AlRunner.Tests/DateVirtualTableLazyWindowTests.cs
@@ -86,8 +86,7 @@ public sealed class DateVirtualTableLazyWindowTests
     [Fact]
     public void DateWindow_IsMaterialisedPerRequest_NotWholesaleOnFirstTouch()
     {
-        var cacheDir = Path.Combine(
-            Path.GetTempPath(), "al-runner-date-lazy-tests", "cache-" + Guid.NewGuid().ToString("N"));
+        var cacheDir = TestScratch.Dir("al-runner-date-lazy-tests");
         try
         {
             var (exit, stdout, stderr) = Run(cacheDir);

--- a/AlRunner.Tests/DateVirtualTableLazyWindowTests.cs
+++ b/AlRunner.Tests/DateVirtualTableLazyWindowTests.cs
@@ -1,0 +1,118 @@
+// DateVirtualTableLazyWindowTests — issue #2648.
+//
+// The Date system virtual table (2000000007) is computed per request on a real service tier and
+// spans years 1 through 9999. The runner serves it from an in-memory store instead, so it has to
+// INSERT rows, and before this fix it inserted the whole default window — 1900-01-01 to
+// 2099-12-31, about 87,000 rows across the five period types — on the first touch of
+// `Record Date`, whatever the request had asked for. A filter naming one week in 1850 cost about
+// 109,000 row inserts to return 7 rows.
+//
+// WHY THE CAP IS THE INSTRUMENT, AND NOT A STOPWATCH
+//   "It got faster" is not a testable claim: wall clock on a shared machine has measured 1.9 s
+//   and 3.1 s for identical work. The runner already has an exact, deterministic counter for the
+//   thing that actually changed — AL_RUNNER_DATE_WINDOW_MAX_ROWS, the cap PopulateDateSpan checks
+//   an estimated row count against before materialising anything. Setting it to 2,000 is a
+//   statement about ROWS: below the ~87,000 the default window needs, above the 25 a one-week
+//   span needs. So the bounded read in the fixture can only answer if the window was never
+//   materialised, and the unfiltered read can only refuse if it still is for a request that
+//   needs it.
+//
+//   Run against the pre-fix runner the fixture's first two tests fail with
+//   RunnerOutOfScopeException naming the cap, because the eager population refused before any
+//   filter was consulted. That is the RED.
+//
+// This is a RUNNER-MECHANISM claim, not a claim about what BC does. What the Date table itself
+// answers — weekday numbering, ISO weeks, month ends, "Period End" being a closing date — is
+// plain BC behaviour and is covered upstream in the al-language corpus (codeunit 60983, "Test
+// Date Virtual Table"), per .claude/rules/bc-behavior-tests-go-upstream.md.
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class DateVirtualTableLazyWindowTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static readonly string FixtureDir =
+        Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", "DateWindowLazy");
+
+    /// <summary>
+    /// Well below the ~87,000 rows the default 1900..2099 window holds, and well above the 25
+    /// rows EstimateDateRowCount returns for a single week. Any value strictly between those two
+    /// works; 2,000 is far enough from both that a small change to either does not silently turn
+    /// this test into a tautology.
+    /// </summary>
+    private const string RowCap = "2000";
+
+    private static (int ExitCode, string StdOut, string StdErr) Run(string cacheDir)
+    {
+        var sb = new StringBuilder(TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner")));
+        sb.Append(' ').Append($"\"{FixtureDir}\"");
+        sb.Append(' ').Append($"--cache \"{cacheDir}\"");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = sb.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        psi.Environment["AL_RUNNER_DATE_WINDOW_MAX_ROWS"] = RowCap;
+
+        var outSb = new StringBuilder();
+        var errSb = new StringBuilder();
+        using var proc = Process.Start(psi)!;
+        proc.OutputDataReceived += (_, e) => { if (e.Data != null) lock (outSb) outSb.AppendLine(e.Data); };
+        proc.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (errSb) errSb.AppendLine(e.Data); };
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+        if (!proc.WaitForExit(180_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException("al-runner did not exit within 180s.");
+        }
+        // WaitForExit(int) does not drain the async output callbacks; only the parameterless
+        // overload does. Without this the last stdout lines can still be in flight.
+        proc.WaitForExit();
+        return (proc.ExitCode, outSb.ToString(), errSb.ToString());
+    }
+
+    [Fact]
+    public void DateWindow_IsMaterialisedPerRequest_NotWholesaleOnFirstTouch()
+    {
+        var cacheDir = Path.Combine(
+            Path.GetTempPath(), "al-runner-date-lazy-tests", "cache-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var (exit, stdout, stderr) = Run(cacheDir);
+
+            Assert.True(exit == 0,
+                $"expected a clean run (all three fixture tests must pass). exit={exit}\n"
+                + $"stdout:\n{stdout}\nstderr:\n{stderr}");
+
+            // RED before the fix: eager population refused under the 2,000-row cap before the
+            // filter was ever read, so this failed with an out-of-scope error naming the cap.
+            Assert.Contains(
+                "PASS  Codeunit61631.Date_BoundedFilter_MaterialisesOnlyTheBoundedSpan", stdout);
+            // The keyed-Get route (#2870) has to be lazy too — it does not reach the find path.
+            Assert.Contains(
+                "PASS  Codeunit61631.Date_KeyedGetInABoundedSpan_MaterialisesOnlyThatPeriod", stdout);
+            // The control, and the half that must NOT have changed: a read naming no closed
+            // "Period Start" bound is still answered from the whole documented window, so under
+            // this cap it must still refuse by name rather than answer from fewer rows.
+            Assert.Contains(
+                "PASS  Codeunit61631.Date_UnfilteredRead_StillDemandsTheWholeDocumentedWindow", stdout);
+            Assert.DoesNotContain("FAIL", stdout);
+        }
+        finally
+        {
+            try { Directory.Delete(cacheDir, recursive: true); } catch { /* best-effort cleanup */ }
+        }
+    }
+}

--- a/AlRunner.Tests/DateVirtualTableWindowTests.cs
+++ b/AlRunner.Tests/DateVirtualTableWindowTests.cs
@@ -8,6 +8,7 @@
 // count independently, day by day, and compare.
 
 using System;
+using System.Collections.Generic;
 using AlRunner.Patches;
 using Xunit;
 
@@ -105,5 +106,159 @@ public sealed class DateVirtualTableWindowTests
         Assert.True(estimate > RecordPatches.DateWindowMaxRowsDefault,
             $"the full BC Date span estimates at only {estimate:N0} rows, which the "
             + $"{RecordPatches.DateWindowMaxRowsDefault:N0}-row cap would let through");
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────────────────
+// The covered-interval algebra behind per-request materialisation (#2648).
+//
+// Before #2648 the provider recorded ONE min..max envelope, which was enough while the whole
+// window was materialised up front. Per request it is not: materialise one week of 1850, then
+// ask for a day in 2100, and an envelope has to fill the 250 years between — the exact ~109,000
+// rows the issue is about, moved to a later call. The runner-extras Date suite does that in its
+// first two tests, so the set is what makes the fix hold rather than move.
+//
+// DateMissingSpans decides what gets inserted and DateAddCovered decides what is remembered.
+// A gap DateMissingSpans fails to report is a row that never gets materialised — an AL read
+// answering "no such period" for a period that exists. So they are tested directly, against a
+// brute-force day-set oracle as well as by hand.
+public sealed class DateCoveredIntervalTests
+{
+    private static DateTime D(int y, int m, int d) => new(y, m, d);
+
+    private static List<(DateTime Start, DateTime End)> Cover(params (int, int, int, int, int, int)[] spans)
+    {
+        var list = new List<(DateTime Start, DateTime End)>();
+        foreach (var (y1, m1, d1, y2, m2, d2) in spans)
+            RecordPatches.DateAddCovered(list, D(y1, m1, d1), D(y2, m2, d2));
+        return list;
+    }
+
+    [Fact]
+    public void MissingSpans_NothingCovered_IsTheWholeRequest()
+    {
+        var gaps = RecordPatches.DateMissingSpans(new List<(DateTime, DateTime)>(), D(1850, 1, 1), D(1850, 1, 7));
+        Assert.Single(gaps);
+        Assert.Equal((D(1850, 1, 1), D(1850, 1, 7)), gaps[0]);
+    }
+
+    [Fact]
+    public void MissingSpans_RequestFullyInsideOneCoveredSpan_IsEmpty()
+    {
+        var gaps = RecordPatches.DateMissingSpans(Cover((1900, 1, 1, 2099, 12, 31)), D(1950, 1, 1), D(1950, 1, 7));
+        Assert.Empty(gaps);
+    }
+
+    [Fact]
+    public void MissingSpans_DistantRequest_DoesNotDragInTheGapBetween()
+    {
+        // THE case this type exists for. 1850 is materialised; 2100-01-01 is asked for. The gap
+        // reported must be the single day, not 1850-01-08..2100-01-01.
+        var gaps = RecordPatches.DateMissingSpans(Cover((1850, 1, 1, 1850, 1, 7)), D(2100, 1, 1), D(2100, 1, 1));
+        Assert.Single(gaps);
+        Assert.Equal((D(2100, 1, 1), D(2100, 1, 1)), gaps[0]);
+    }
+
+    [Fact]
+    public void MissingSpans_RequestStraddlingTwoCoveredSpans_ReportsOnlyTheHoles()
+    {
+        var covered = Cover((2000, 1, 1, 2000, 1, 10), (2000, 1, 21, 2000, 1, 31));
+        var gaps = RecordPatches.DateMissingSpans(covered, D(1999, 12, 28), D(2000, 2, 5));
+        Assert.Equal(3, gaps.Count);
+        Assert.Equal((D(1999, 12, 28), D(1999, 12, 31)), gaps[0]);
+        Assert.Equal((D(2000, 1, 11), D(2000, 1, 20)), gaps[1]);
+        Assert.Equal((D(2000, 2, 1), D(2000, 2, 5)), gaps[2]);
+    }
+
+    [Fact]
+    public void MissingSpans_InvertedRequest_IsEmpty()
+    {
+        // The half-open-union shape ('..%1|%2..') produced exactly this before it was clamped.
+        // It must describe no rows, never a wrapped or negative span.
+        Assert.Empty(RecordPatches.DateMissingSpans(Cover((1900, 1, 1, 2099, 12, 31)), D(2099, 12, 30), D(1900, 1, 2)));
+    }
+
+    [Fact]
+    public void AddCovered_TouchingSpans_Merge_AndNonTouchingDoNot()
+    {
+        // Adjacent by one day merges: the window materialised as two halves must read as one
+        // span, or WholeWindow never becomes true and every FlowField pays for the window again.
+        var merged = Cover((2000, 1, 1, 2000, 1, 10), (2000, 1, 11, 2000, 1, 20));
+        Assert.Single(merged);
+        Assert.Equal((D(2000, 1, 1), D(2000, 1, 20)), merged[0]);
+
+        // One day further apart does not merge, and the list stays sorted by Start.
+        var separate = Cover((2000, 1, 1, 2000, 1, 10), (2000, 1, 12, 2000, 1, 20));
+        Assert.Equal(2, separate.Count);
+        Assert.Equal((D(2000, 1, 1), D(2000, 1, 10)), separate[0]);
+        Assert.Equal((D(2000, 1, 12), D(2000, 1, 20)), separate[1]);
+    }
+
+    [Fact]
+    public void AddCovered_OutOfOrderAndOverlapping_CollapsesToOneSortedSpan()
+    {
+        var list = Cover((2000, 3, 1, 2000, 3, 31), (2000, 1, 1, 2000, 1, 31), (2000, 2, 1, 2000, 2, 29));
+        Assert.Single(list);
+        Assert.Equal((D(2000, 1, 1), D(2000, 3, 31)), list[0]);
+
+        // A span that swallows several existing ones leaves exactly one behind.
+        var swallow = Cover((2000, 1, 1, 2000, 1, 5), (2000, 2, 1, 2000, 2, 5), (2000, 3, 1, 2000, 3, 5),
+                            (1999, 1, 1, 2001, 1, 1));
+        Assert.Single(swallow);
+        Assert.Equal((D(1999, 1, 1), D(2001, 1, 1)), swallow[0]);
+    }
+
+    [Fact]
+    public void AddCovered_InvertedSpan_IsIgnored()
+    {
+        var list = Cover((2000, 1, 10, 2000, 1, 1));
+        Assert.Empty(list);
+    }
+
+    [Fact]
+    public void AddThenAskAgain_ReportsNothingMissing()
+    {
+        // The invariant the populate loop depends on: whatever was just materialised must not be
+        // materialised a second time, or every repeat read re-walks it and re-throws duplicate
+        // keys over the whole span.
+        var list = Cover((1850, 1, 1, 1850, 1, 7), (2100, 1, 1, 2100, 12, 31), (1900, 1, 1, 2099, 12, 31));
+        Assert.Empty(RecordPatches.DateMissingSpans(list, D(1850, 1, 1), D(1850, 1, 7)));
+        Assert.Empty(RecordPatches.DateMissingSpans(list, D(1900, 1, 1), D(2100, 12, 31)));
+        // ...and something genuinely outside is still reported.
+        var gaps = RecordPatches.DateMissingSpans(list, D(1849, 12, 25), D(1849, 12, 31));
+        Assert.Single(gaps);
+        Assert.Equal((D(1849, 12, 25), D(1849, 12, 31)), gaps[0]);
+    }
+
+    [Theory]
+    [InlineData(2000, 1, 1, 2000, 1, 31)]
+    [InlineData(1999, 12, 20, 2000, 2, 10)]
+    [InlineData(2000, 1, 11, 2000, 1, 20)]
+    [InlineData(2000, 1, 6, 2000, 1, 6)]
+    public void MissingSpans_AgreesWithABruteForceDaySet(int y1, int m1, int d1, int y2, int m2, int d2)
+    {
+        // Independent oracle: build the covered days as a set, ask which requested days are not
+        // in it, and check the returned intervals describe exactly those days. This is what
+        // catches an off-by-one at an interval edge, which is the failure mode that would
+        // silently drop one period.
+        var covered = Cover((2000, 1, 1, 2000, 1, 5), (2000, 1, 7, 2000, 1, 10), (2000, 1, 21, 2000, 1, 31));
+        var coveredDays = new HashSet<DateTime>();
+        foreach (var (s, e) in covered)
+            for (var d = s; d <= e; d = d.AddDays(1))
+                coveredDays.Add(d);
+
+        var want = (Start: D(y1, m1, d1), End: D(y2, m2, d2));
+        var expected = new List<DateTime>();
+        for (var d = want.Start; d <= want.End; d = d.AddDays(1))
+            if (!coveredDays.Contains(d)) expected.Add(d);
+
+        var actual = new List<DateTime>();
+        foreach (var (s, e) in RecordPatches.DateMissingSpans(covered, want.Start, want.End))
+        {
+            Assert.True(s <= e, $"gap [{s:yyyy-MM-dd}..{e:yyyy-MM-dd}] is inverted");
+            for (var d = s; d <= e; d = d.AddDays(1)) actual.Add(d);
+        }
+
+        Assert.Equal(expected, actual);
     }
 }

--- a/AlRunner.Tests/Fixtures/DateWindowLazy/Assert.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/DateWindowLazy/Assert.Codeunit.al
@@ -1,0 +1,27 @@
+// Standalone Assert codeunit — this fixture must stand alone, it does not import from
+// tests/al-language or tests/runner-extras.
+codeunit 61630 "DWL Assert"
+{
+    procedure AreEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if Format(Expected) <> Format(Actual) then
+            Error('Expected %1 but got %2: %3', Format(Expected), Format(Actual), Msg);
+    end;
+
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error('Expected true: %1', Msg);
+    end;
+
+    procedure ExpectedError(Fragment: Text)
+    var
+        Actual: Text;
+    begin
+        Actual := GetLastErrorText();
+        if Actual = '' then
+            Error('Expected an error containing "%1", but no error was raised.', Fragment);
+        if StrPos(Actual, Fragment) = 0 then
+            Error('Expected an error containing "%1", but got: %2', Fragment, Actual);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/DateWindowLazy/DwlTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/DateWindowLazy/DwlTests.Codeunit.al
@@ -1,0 +1,84 @@
+// Issue #2648 — the Date system virtual table (2000000007) must materialise only the periods a
+// request can actually select.
+//
+// The runner serves Date from an in-memory store, so it has to insert rows. Before this fix it
+// inserted the whole default window — 1900-01-01 to 2099-12-31, about 87,000 rows across the
+// five period types — on the FIRST touch of Record Date, whatever the request asked for. A
+// filter naming one week in 1850 then cost about 109,000 row inserts to return 7 rows.
+//
+// The row count is what these tests assert, and they assert it through the row CAP rather than
+// through a clock. DateVirtualTableLazyWindowTests.cs runs this fixture with
+// AL_RUNNER_DATE_WINDOW_MAX_ROWS=2000: below the ~87,000 the default window needs, above the 25
+// a one-week span needs. So the first test can only pass if the window was NOT materialised,
+// and the second can only pass if it still IS for a request that needs it.
+//
+// Nothing here asserts what the Date table SAYS — weekday numbering, ISO weeks, month ends.
+// That is plain BC behaviour and lives upstream in the al-language corpus (codeunit 60983,
+// "Test Date Virtual Table").
+
+codeunit 61631 "DWL Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit "DWL Assert";
+
+    [Test]
+    procedure Date_BoundedFilter_MaterialisesOnlyTheBoundedSpan()
+    var
+        DateRec: Record Date;
+    begin
+        // [GIVEN] a closed range of one week in 1850 — outside the default window entirely,
+        //         so under the old eager scheme this cost the window PLUS a 50-year extension
+        DateRec.SetRange("Period Type", DateRec."Period Type"::Date);
+        DateRec.SetRange("Period Start", DMY2Date(1, 1, 1850), DMY2Date(7, 1, 1850));
+
+        // [THEN] it answers under a 2,000-row cap, which is only possible if the ~87,000-row
+        //        default window was never materialised. Count() takes the count path and
+        //        FindFirst() the find path, so both guards are exercised.
+        Assert.AreEqual(7, DateRec.Count(), 'Expected 7 Date-type rows for 1-7 January 1850.');
+        Assert.IsTrue(DateRec.FindFirst(), 'Record Date found no row for 1 January 1850.');
+        Assert.AreEqual(DMY2Date(1, 1, 1850), DateRec."Period Start", 'Expected the range to start on 1 January 1850.');
+        // Not merely "a row came back": 1 January 1850 was a Tuesday, so BC's Monday = 1
+        // numbering makes its Period No. 2. A blank or default row fails here.
+        Assert.AreEqual(2, DateRec."Period No.", '1 January 1850 was a Tuesday, so Period No. is 2.');
+    end;
+
+    [Test]
+    procedure Date_KeyedGetInABoundedSpan_MaterialisesOnlyThatPeriod()
+    var
+        DateRec: Record Date;
+    begin
+        // A full-primary-key Get takes DataAccess's own primary-key route, not the find path
+        // (#2870). It has to be lazy too, and it has to still answer.
+        Assert.IsTrue(
+            DateRec.Get(DateRec."Period Type"::Date, DMY2Date(3, 1, 1850)),
+            'Record Date.Get found no row for 3 January 1850 under a 2,000-row cap.');
+        Assert.AreEqual(DMY2Date(3, 1, 1850), DateRec."Period Start", 'Get returned a different period.');
+    end;
+
+    [Test]
+    procedure Date_UnfilteredRead_StillDemandsTheWholeDocumentedWindow()
+    var
+        DateRec: Record Date;
+    begin
+        // THE CONTROL, and the reason this cannot be "just materialise less". A read that names
+        // no closed bound on "Period Start" is answered from the WINDOW — that is the documented
+        // approximation in docs/limitations.md. So an unfiltered read must still ask for the
+        // whole 1900..2099 window, and under a 2,000-row cap it must refuse BY NAME rather than
+        // answer from the handful of 1850 rows a sibling test may have materialised.
+        //
+        // If a future change made the window lazy in the sense of "never populate it at all",
+        // this test goes green-to-red-to-wrong: it would answer with too few rows instead.
+        asserterror FindAnyDate(DateRec);
+        Assert.ExpectedError('out-of-scope: Date (virtual table 2000000007)');
+        Assert.ExpectedError('past the');
+    end;
+
+    local procedure FindAnyDate(var DateRec: Record Date): Boolean
+    begin
+        DateRec.SetRange("Period Type", DateRec."Period Type"::Date);
+        exit(DateRec.FindSet());
+    end;
+}

--- a/AlRunner.Tests/Fixtures/DateWindowLazy/app.json
+++ b/AlRunner.Tests/Fixtures/DateWindowLazy/app.json
@@ -1,0 +1,17 @@
+{
+  "id": "d47e1c92-6b30-4a58-9e11-3f0c8a75b264",
+  "name": "Runner Tests Fixture - Date Window Lazy Materialisation",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Issue #2648: the Date virtual table (2000000007) must materialise only the periods a request can actually select, not the whole default window.",
+  "description": "Driven by DateVirtualTableLazyWindowTests.cs with AL_RUNNER_DATE_WINDOW_MAX_ROWS set to 2000 — far below the ~87,000 rows the default 1900..2099 window holds, and far above the 25 rows a one-week filter needs. Under that cap a bounded read can only answer if the runner materialised the bounded span rather than the window, and an unbounded read must still refuse, because an unbounded read is still answered from the window. That makes the row count, not a duration, the thing these tests assert.",
+  "dependencies": [],
+  "platform": "1.0.0.0",
+  "idRanges": [
+    {
+      "from": 61630,
+      "to": 61639
+    }
+  ],
+  "runtime": "14.0"
+}

--- a/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
@@ -769,6 +769,34 @@ public static partial class NclCecilRewrite
                 ByParams(Rt + "TempTableDataProvider", "CalcNumeric", "CalcNumericProviderRequest"),
                 H(recordPatches, "TempTableDataProvider_CalcNumeric"));
 
+            // ── TempTableDataProvider.{Exists,CalcMinMax,CalcSums} — the Date store's safety
+            //    net under per-request materialisation (issue #2648) ────────────────────────
+            // The find, count and keyed-Get guards on DataAccess materialise exactly what their
+            // request can select. Three read paths never reach DataAccess at all — a FlowField
+            // calculation (FlowFieldsHelper) and a TableRelation check
+            // (RecordImplementation.ValidateRelation) go straight to the provider — so they carry
+            // no request the guards could read. MEASURED on this branch with a prepend on
+            // DataAccess.ExistsAsync / CalcMinMaxAsync / CalcSumsAsync instead: the prepend
+            // applied and never fired once, and `count(Date …)` went 73,049 -> 0,
+            // `exist(Date …)` Yes -> No, `min(Date."Period Start")` 1900-01-01 -> blank.
+            //
+            // The helper materialises the whole configured window on the first such read of the
+            // Date store and is a ConditionalWeakTable miss for every other table. CalcNumeric is
+            // not in this list because Cecil REPLACES its body above; the same call sits at the
+            // top of the replacement instead.
+            foreach (var providerRead in new[]
+                     {
+                         ("Exists", "ExistsProviderRequest"),
+                         ("CalcMinMax", "CalcMinMaxProviderRequest"),
+                         ("CalcSums", "CalcSumsProviderRequest"),
+                     })
+            {
+                PrependStaticCall(nclMod,
+                    ByParams(Rt + "TempTableDataProvider", providerRead.Item1, providerRead.Item2),
+                    H(recordPatches, "EnsureDateStoreFullyMaterialised"),
+                    argSlots: 1); // `this` — the provider — is all the helper needs
+            }
+
             // ── BLOB store isolation for database-backed tables (issue #1751) ──────
             // Ncl's TempTableDataProvider.Insert copies the record's NavBLOB into the
             // stored row BY REFERENCE and only CloneBlobs()es the dirty ones, so a BLOB

--- a/AlRunner/Patches/FlowFieldPatches.cs
+++ b/AlRunner/Patches/FlowFieldPatches.cs
@@ -767,6 +767,16 @@ public static class FlowFieldPatches
             catch { }
             if (srcTtdp == null) continue;
 
+            // #2648 — the Date virtual table (2000000007) materialises its rows PER REQUEST, and
+            // this method is a read of the source table's store that carries no request the Date
+            // guards can see: it goes from the handout straight to TempTableDataProvider.Filter,
+            // past DataAccess and past the provider's own public read methods. Measured without
+            // this call, on this branch: `count(Date where …)` returned 0 instead of 73,049,
+            // `exist(Date where …)` No instead of Yes, `min("Date"."Period Start")` blank instead
+            // of 1900-01-01. The call materialises the whole window once per Date store and is a
+            // ConditionalWeakTable miss for every other source table.
+            AlRunner.Patches.RecordPatches.EnsureDateStoreFullyMaterialised(srcTtdp);
+
             // Resolve the formula's where-conditions into a FiltersAndMarks over the SOURCE
             // table, using BC's own FlowFieldsHelper.GetFilterFromMetaFilterCollection.
             //

--- a/AlRunner/Patches/RecordPatches.DateVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.DateVirtualTable.cs
@@ -41,37 +41,62 @@
 //
 // THE WINDOW, AND WHAT IT DOES AND DOES NOT PROMISE
 //   The real table spans years 1 through 9999 — 3.6 million Date rows alone — so it cannot be
-//   materialised whole. We materialise a window of whole years (default 1900-01-01 ..
-//   2099-12-31, about 87,000 rows across all five period types) and EXTEND that window on
-//   demand whenever an AL filter names a closed bound outside it, on all FOUR request paths a
-//   Record Date read can take. They carry four different request types, all deriving from
-//   DataCacheRequest, and each needs its own guard:
+//   materialised whole. There is a bounded WINDOW of whole years (default 1900-01-01 ..
+//   2099-12-31, 86,885 rows across all five period types) that a read is answered from when the
+//   runner cannot see what the read is bounded by.
 //
-//     AL                                  DataAccess method                  request type
+//   NOTHING IS MATERIALISED UNTIL A READ ASKS FOR IT (#2648). The window used to be built at the
+//   handout — RecordImplementation.InitializeImpl, i.e. when the `Record Date` VARIABLE is
+//   constructed, before any filter exists — so a filter naming one week in 1850 cost ~109,000
+//   row inserts (the window, plus a 50-year extension) to return 7 rows, and it made this the
+//   most allocation-heavy surface in tests/runner-extras. Now each read materialises what its
+//   own request can select:
+//
+//     * A read whose "Period Start" filter is CLOSED at both ends of every range materialises
+//       exactly [lowest low .. highest high]. Safe because BC's own filter engine excludes every
+//       row outside those bounds anyway, so a narrower store cannot change an answer.
+//     * A keyed Get materialises the one day its key names.
+//     * Anything else — no "Period Start" filter, an OPEN bound, a filter shape we cannot read —
+//       materialises the whole window, widened by whichever bound IS closed. Those reads ARE
+//       answered from the window, so nothing narrower reproduces them.
+//
+//   FOUR request-carrying guards do the narrowing, not three, because a Record Date read can
+//   take four distinct DataAccess paths. They carry four different request types, all deriving
+//   from DataCacheRequest, and each needs its own guard:
+//
+//     AL                                     DataAccess method               request type
 //     ---------------------------------------------------------------------------------------
 //     Find / FindSet / FindFirst / FindLast  InnerFindAsync                  FindCacheRequest
 //     Count                                  CountAsync                      CountCacheRequest
 //     IsEmpty                                ExistsAsync                     ExistsCacheRequest
 //     Get("Period Type", "Period Start")     InternalTryGetByPrimaryKeyAsync PrimaryKeyCacheRequest
 //
-//   This header said "both request paths ... DataAccess.CountAsync (Count / IsEmpty)" until
-//   #3006. IsEmpty() has never reached CountAsync: RecordImplementation.IsEmptyAsync calls its
-//   own ExistsAsync, which builds an ExistsCacheRequest (decompiled from Ncl.dll 28.1). Because
-//   the comment asserted otherwise, nobody looked, and a closed range outside the window
-//   answered IsEmpty() = true with Count() = 7 on the very next line -- a wrong answer, since a
-//   service tier computes this table across years 1..9999 and answers 7 both ways.
-//
-//   The exists path is shared with more than IsEmpty(): DataAccess.ExistsAsync is also what an
-//   `Exist` FlowField (FlowFieldsHelper), a NavQuery and RecordImplementation.ValidateRelation
-//   reach, so all three now get the widened window too.
+//   This header said "a prepend on DataAccess.CountAsync (Count / IsEmpty)" until #3006, and so
+//   did the count guard's own comment and docs/limitations.md. IsEmpty() has never reached
+//   CountAsync: RecordImplementation.IsEmptyAsync calls its own ExistsAsync, which builds an
+//   ExistsCacheRequest (decompiled from Ncl.dll 28.1). Because three comments asserted
+//   otherwise, nobody looked, and a closed range outside the window answered IsEmpty() = true
+//   with Count() = 7 on the very next line — a wrong answer, since a service tier computes this
+//   table across years 1..9999 and answers 7 both ways.
 //
 //   The find guard lives in RecordPatches.FieldFindIntercept.cs; the other three are prepends
-//   registered in NclCecilRewrite.Runtime.cs. All four funnel into
-//   EnsureDateWindowCoversRequest (or, for the keyed Get, into PopulateDateSpan from the record
-//   id), so one invariant is maintained in one place rather than four copies drifting apart.
-//   Past AL_RUNNER_DATE_WINDOW_MAX_ROWS the extension throws RunnerOutOfScopeException naming
-//   the requested bound, the window and the cap, rather than answering a larger request with
-//   fewer rows.
+//   registered in NclCecilRewrite.Runtime.cs. All four funnel into the same narrowing helper, so
+//   one invariant is maintained in one place rather than four copies drifting apart — which is
+//   how the first three came to disagree in the first place.
+//
+//   Reads that carry NO request — a FlowField whose CalcFormula source is Date, a TableRelation
+//   check — reach the in-memory store without passing ANY of the four, so
+//   EnsureDateStoreFullyMaterialised is the net under those: it materialises the whole window
+//   once per store, from TempTableDataProvider.{Exists,CalcNumeric,CalcMinMax,CalcSums} and from
+//   FlowFieldPatches' own source-table read. Measured without it: a `count(Date …)` FlowField
+//   answered 0 instead of 73,049. Note that this net is a SEPARATE surface from the ExistsAsync
+//   guard above and does not subsume it: the net materialises the DEFAULT window, which does not
+//   contain 1850 or 2300, so an AL IsEmpty() over a closed range outside the window still needs
+//   its own guard to be answered correctly.
+//
+//   Past AL_RUNNER_DATE_WINDOW_MAX_ROWS an extension throws RunnerOutOfScopeException naming the
+//   requested bound, the window and the cap, rather than answering a larger request with fewer
+//   rows.
 //
 //   The one thing the window does NOT cover is an OPEN bound: `SetFilter("Period Start",
 //   '%1..', D)` asks BC for everything up to 9999-12-31, and we answer it from the window.
@@ -238,14 +263,21 @@ public static partial class RecordPatches
         internal DateTime Min = DateTime.MaxValue;
         internal DateTime Max = DateTime.MinValue;
         internal bool Any;
+
+        /// <summary>True once the whole configured window has been materialised into this
+        /// provider. Distinct from <see cref="Any"/>, which is true after ANY span — including a
+        /// single day materialised for one keyed Get.</summary>
+        internal bool WholeWindow;
+
+        /// <summary>The metatable and skeleton session captured when this provider was handed
+        /// out, so a read reaching the provider WITHOUT a DataAccess-level request (a FlowField
+        /// calculation, a TableRelation check) can still materialise. Both are per data-access
+        /// constants; the handout is the only place they are available together.</summary>
+        internal NCLMetaTable? Meta;
+        internal object? Session;
     }
 
     private static readonly ConditionalWeakTable<object, DatePopulatedSpan> _dvtSpanByProvider = new();
-
-    // Remembered so the find-time guard can extend the window without a fresh data-access handout.
-    private static object? _dvtLastDataAccess;
-    private static NCLMetaTable? _dvtLastMetaTable;
-    private static object? _dvtLastSession;
 
     private static bool _dvtReflectionReady;
     private static SystemPopulatedValues? _dvtSystemValues;
@@ -279,16 +311,85 @@ public static partial class RecordPatches
         => table != null && table.TableId == DateVirtualTableId;
 
     /// <summary>
-    /// Populate the in-memory store behind the Date (2000000007) data access with one row per
-    /// period over the configured window. Idempotent per provider; a later call only fills in
-    /// years the provider does not already hold.
+    /// Called when the Date (2000000007) data access is handed out — which is when a
+    /// <c>Record Date</c> VARIABLE is constructed (RecordImplementation.InitializeImpl), before
+    /// any filter exists. It materialises NOTHING (#2648). All it does is the one thing the
+    /// handout has always done to the METATABLE, so the metatable's state at read time is exactly
+    /// what it was when the population lived here.
     /// </summary>
-    private static void PopulateDateVirtualTable(object dataAccess, NCLMetaTable dateMetaTable, object session)
+    private static void PrepareDateVirtualTable(object dataAccess, NCLMetaTable dateMetaTable, object session)
     {
-        var windowStart = new DateTime(DateWindowMinYear, 1, 1);
-        var windowEnd = new DateTime(DateWindowMaxYear, 12, 31);
-        PopulateDateSpan(dataAccess, dateMetaTable, session, windowStart, windowEnd);
+        // Same rationale as the Field and Integer tables: make our metatable report
+        // IsVirtualTable=false so BC's find takes the NORMAL temp-table DataAccess path over our
+        // store. It stays here rather than moving into PopulateDateSpan's caller chain because
+        // it must be true of the metatable from the moment the record exists, not from the moment
+        // the first row is inserted — which is when the eager population used to do it.
+        ClearVirtualBit(dateMetaTable);
+
+        // Register this provider as THE Date store, and park the metatable and session on the
+        // registration. Two things depend on it: EnsureDateStoreFullyMaterialised identifies the
+        // Date provider by this registration alone (a ConditionalWeakTable miss is every other
+        // table, with no reflection and no request), and it needs a metatable and a session to
+        // materialise with when it is reached from a read that carries neither.
+        EnsureDataAccessProviderReflection(dataAccess);
+        if (_pDataAccessDataProvider!.GetValue(dataAccess) is not object provider) return;
+        var span = _dvtSpanByProvider.GetValue(provider, static _ => new DatePopulatedSpan());
+        lock (span)
+        {
+            span.Meta ??= dateMetaTable;
+            span.Session ??= session;
+        }
     }
+
+    /// <summary>
+    /// The safety net under per-request materialisation (#2648), called from the reads of the
+    /// in-memory store that carry NO DataCacheRequest and so are never seen by the find, count or
+    /// keyed-Get guards: TempTableDataProvider.Exists, CalcNumeric, CalcMinMax and CalcSums.
+    ///
+    /// WHY IT HAS TO EXIST. Measured on this branch with the guards wired one layer up instead:
+    /// a `count(Date where …)` FlowField went from 73,049 to 0, an `exist(Date where …)` FlowField
+    /// from Yes to No, a `min("Date"."Period Start")` FlowField from 1900-01-01 to blank, and a
+    /// TableRelation check against a period outside the window stopped raising. FlowFieldsHelper
+    /// and RecordImplementation.ValidateRelation reach the provider without going through
+    /// DataAccess.CalcNumericAsync / ExistsAsync at all, so a prepend there applies and never
+    /// fires — verified by tracing every request that reached it.
+    ///
+    /// WHY IT MATERIALISES THE WHOLE WINDOW rather than something narrower. These callers hold
+    /// the answer to a question the runner cannot see the bounds of from here, so the only span
+    /// that is guaranteed to answer them exactly as the eager scheme did is the one the eager
+    /// scheme built. Doing that ONCE per provider, and only when such a read actually happens,
+    /// means a bundle that reads Date only through finds, counts and keyed Gets — the shape #2648
+    /// is about — never pays for it, and a bundle that does reach one of these paths gets
+    /// precisely the pre-#2648 answers.
+    ///
+    /// For every table but 2000000007 this is one ConditionalWeakTable miss and a return.
+    /// </summary>
+    public static void EnsureDateStoreFullyMaterialised(object provider)
+    {
+        if (!_dvtSpanByProvider.TryGetValue(provider, out var span)) return;   // not the Date store
+        NCLMetaTable meta;
+        object session;
+        lock (span)
+        {
+            if (span.WholeWindow) return;
+            if (span.Meta is not NCLMetaTable m || span.Session is not object s) return;
+            meta = m;
+            session = s;
+        }
+        PopulateDateSpanIntoProvider(provider, meta, session,
+            new DateTime(DateWindowMinYear, 1, 1), new DateTime(DateWindowMaxYear, 12, 31));
+    }
+
+    /// <summary>
+    /// Materialise the whole configured window (default 1900-01-01 .. 2099-12-31, 86,885 rows).
+    /// This is what answers a request that does NOT name a closed bound on both ends of
+    /// "Period Start" — an unfiltered read, an open bound, or a filter shape the runner cannot
+    /// parse — because such a request is answered FROM the window and no narrower store returns
+    /// the same rows. Idempotent per provider.
+    /// </summary>
+    private static void PopulateDefaultDateWindow(object dataAccess, NCLMetaTable dateMetaTable, object session)
+        => PopulateDateSpan(dataAccess, dateMetaTable, session,
+            new DateTime(DateWindowMinYear, 1, 1), new DateTime(DateWindowMaxYear, 12, 31));
 
     /// <summary>
     /// Materialise every period whose start falls in [<paramref name="wantStart"/>..
@@ -299,7 +400,6 @@ public static partial class RecordPatches
     private static void PopulateDateSpan(
         object dataAccess, NCLMetaTable dateMetaTable, object session, DateTime wantStart, DateTime wantEnd)
     {
-        EnsureDateReflection(dateMetaTable);
         EnsureDataAccessProviderReflection(dataAccess);
 
         var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
@@ -307,10 +407,18 @@ public static partial class RecordPatches
                 "the Date data access handed over no in-memory provider, so there is nothing to "
                 + "populate");
 
-        // Remember the handout so the find-time guard can extend the window later without one.
-        _dvtLastDataAccess = dataAccess;
-        _dvtLastMetaTable = dateMetaTable;
-        _dvtLastSession = session;
+        PopulateDateSpanIntoProvider(provider, dateMetaTable, session, wantStart, wantEnd);
+    }
+
+    /// <summary>
+    /// The body of <see cref="PopulateDateSpan"/>, reached either through a DataAccess (the find,
+    /// count and keyed-Get guards) or with the provider already in hand (the provider-level net,
+    /// which has no DataAccess to unwrap).
+    /// </summary>
+    private static void PopulateDateSpanIntoProvider(
+        object provider, NCLMetaTable dateMetaTable, object session, DateTime wantStart, DateTime wantEnd)
+    {
+        EnsureDateReflection(dateMetaTable);
 
         var span = _dvtSpanByProvider.GetValue(provider, static _ => new DatePopulatedSpan());
 
@@ -333,13 +441,15 @@ public static partial class RecordPatches
                         $"[{newMin:yyyy-MM-dd}..{newMax:yyyy-MM-dd}], which is about {estimate:N0} rows, past the ")
                     + System.FormattableString.Invariant(
                         $"{DateWindowMaxRows:N0}-row cap for the materialised window ")
-                    + System.FormattableString.Invariant(
-                        $"(currently [{(span.Any ? span.Min : newMin):yyyy-MM-dd}..{(span.Any ? span.Max : newMax):yyyy-MM-dd}]). ")
+                    + (span.Any
+                        ? System.FormattableString.Invariant(
+                            $"(currently [{span.Min:yyyy-MM-dd}..{span.Max:yyyy-MM-dd}]). ")
+                        : "(nothing is materialised yet — Date rows are materialised per request). ")
                     + "Raise AL_RUNNER_DATE_WINDOW_MAX_ROWS, or narrow the filter");
 
-            // Same rationale as the Field and Integer tables: make our metatable report
-            // IsVirtualTable=false so BC's find takes the NORMAL temp-table DataAccess path
-            // over our populated store.
+            // Belt and braces: PrepareDateVirtualTable already cleared this at handout, and it
+            // is idempotent. It stays here so a future caller that reaches PopulateDateSpan by
+            // some other route cannot leave the bit set.
             ClearVirtualBit(dateMetaTable);
 
             EnsureDateFieldLayout(dateMetaTable);
@@ -354,6 +464,14 @@ public static partial class RecordPatches
             span.Min = newMin;
             span.Max = newMax;
             span.Any = true;
+            span.Meta ??= dateMetaTable;
+            span.Session ??= session;
+            // "The whole configured window is in" — the flag the provider-level net reads. It is
+            // deliberately about the WINDOW, not about the span being non-empty: a single day
+            // materialised for a keyed Get must not convince the net that a FlowField can be
+            // answered.
+            if (newMin <= new DateTime(DateWindowMinYear, 1, 1) && newMax >= new DateTime(DateWindowMaxYear, 12, 31))
+                span.WholeWindow = true;
         }
     }
 
@@ -485,29 +603,39 @@ public static partial class RecordPatches
     private static bool _dvtGuardReady;
 
     /// <summary>
-    /// Called from the InnerFindAsync guard for EVERY find on table 2000000007, before BC's
-    /// own find runs. Reads the request's "Period Start" filter through BC's own
-    /// FilterExpression.ToRangeList and widens the materialised window so it covers every
-    /// CLOSED bound the filter names. Past AL_RUNNER_DATE_WINDOW_MAX_ROWS, PopulateDateSpan
-    /// throws instead of answering a wider request with fewer rows.
+    /// Called from the InnerFindAsync guard for EVERY find on table 2000000007, and prepended to
+    /// DataAccess.CountAsync for every Count()/IsEmpty(), before BC's own read runs. It
+    /// materialises exactly the periods THIS REQUEST can select, which since #2648 is the only
+    /// place Date rows are materialised at all:
     ///
-    /// An OPEN bound (`'%1..'`, `'..%1'`, or a bound sitting at BC's own first/last period
-    /// start) is left to the window: BC would answer it out to year 1 or year 9999, and
-    /// materialising 3.6 million rows is not on the table. That single approximation is
-    /// documented in docs/limitations.md.
+    ///   * Every non-empty range of the "Period Start" filter is closed at BOTH ends → the rows
+    ///     in [lowest low .. highest high] are the only rows the filter can select, so those are
+    ///     the only rows materialised. BC's own filter engine excludes everything outside those
+    ///     bounds regardless of what the store holds, so a narrower store cannot change a single
+    ///     answer. That is the whole safety argument, and it is why the predicate is "every range
+    ///     closed at both ends" rather than "some bound is closed".
+    ///
+    ///   * Anything else — no "Period Start" filter at all, an OPEN bound (`'%1..'`, `'..%1'`, or
+    ///     a bound sitting at BC's own first/last period start), a filter shape ToRangeList
+    ///     cannot express, a request we cannot read → the whole configured window, widened to
+    ///     cover whichever bound IS closed. An open bound is answered FROM the window: BC would
+    ///     answer it out to year 1 or year 9999, and materialising 3.6 million rows is not on the
+    ///     table. That single approximation is documented in docs/limitations.md and is
+    ///     deliberately unchanged here.
+    ///
+    /// Past AL_RUNNER_DATE_WINDOW_MAX_ROWS, PopulateDateSpan throws instead of answering a wider
+    /// request with fewer rows.
     /// </summary>
     internal static void EnsureDateWindowCoversRequest(object dataAccess, object cacheRequest)
     {
-        // A `Record Date temporary` holds exactly the rows AL inserted -- widening the
-        // materialised window into its private store injected real Date rows AL never wrote
-        // (measured: Count went 1 -> 31 across one filtered Count(), and the subsequent
-        // FindSet returned an injected row instead of AL's). Issue #2524.
+        // A `Record Date temporary` holds exactly the rows AL inserted -- materialising into its
+        // private store injected real Date rows AL never wrote (measured: Count went 1 -> 31
+        // across one filtered Count(), and the subsequent FindSet returned an injected row
+        // instead of AL's). Issue #2524.
         if (IsTemporaryRecordDataAccess(dataAccess)) return;
 
-        DateTime? wantLow = null, wantHigh = null;
         NCLMetaTable meta;
         object session;
-
         try
         {
             if (_pReqMaoLight?.GetValue(cacheRequest) is not NCLMetaTable m) return;
@@ -517,64 +645,150 @@ public static partial class RecordPatches
 
             if (_dvtDaSession!.GetValue(dataAccess) is not object s) return;
             session = s;
-
-            var filter = FindPeriodStartFilter(cacheRequest);
-            if (filter == null) return;
-
-            var rangeList = _dvtToRangeList!.Invoke(filter, new[] { session });
-            if (rangeList == null) return;
-            if (_dvtRangeListRanges!.GetValue(rangeList) is not System.Collections.IEnumerable ranges) return;
-
-            // BC's own first and last period start for period type Date — the widest the real
-            // table ever goes. A bound at or past either end is the filter saying "no limit".
-            var bcFirst = (DateTime)_dvtPeriodStartMin!.Invoke(null, new[] { DatePeriodTypeDate() })!;
-            var bcLast = (DateTime)_dvtPeriodStartMax!.Invoke(null, new[] { DatePeriodTypeDate() })!;
-
-            foreach (var range in ranges)
-            {
-                if (range == null) continue;
-                if ((bool)_dvtRangeIsEmpty!.GetValue(range)!) continue;
-
-                if (!(bool)_dvtRangeLowIsMin!.GetValue(range)!
-                    && ToDateTimeOrNull(_dvtRangeLowValue!.GetValue(range)) is DateTime lo
-                    && lo > bcFirst)
-                    wantLow = wantLow == null || lo < wantLow ? lo : wantLow;
-
-                if (!(bool)_dvtRangeHighIsMax!.GetValue(range)!
-                    && ToDateTimeOrNull(_dvtRangeHighValue!.GetValue(range)) is DateTime hi
-                    && hi < bcLast)
-                    wantHigh = wantHigh == null || hi > wantHigh ? hi : wantHigh;
-            }
         }
         catch (RunnerOutOfScopeException) { throw; }
         catch
         {
-            // Reading the filter is best-effort: a shape we cannot parse means we do not widen
-            // the window, never that we answer something different. The find then runs over the
-            // window exactly as it would without this guard.
+            // We could not identify the request or the store behind it, so there is nothing to
+            // materialise against and no answer to protect. Unchanged from before #2648.
             return;
         }
 
-        if (wantLow == null && wantHigh == null) return;
+        DateTime? closedLow, closedHigh;
+        bool fullyBounded;
+        try
+        {
+            fullyBounded = TryReadClosedPeriodStartBounds(cacheRequest, session, out closedLow, out closedHigh);
+        }
+        catch (RunnerOutOfScopeException) { throw; }
+        catch
+        {
+            // Reading the filter is best-effort. A shape we cannot parse falls back to the whole
+            // window — the widest thing the request could be answered from — never to a narrower
+            // store, which WOULD answer something different now that nothing is materialised up
+            // front.
+            fullyBounded = false;
+            closedLow = closedHigh = null;
+        }
+
+        if (fullyBounded && closedLow is DateTime lo && closedHigh is DateTime hi)
+        {
+            PopulateDateSpan(dataAccess, meta, session, lo, hi);
+            return;
+        }
+
+        // The whole configured window, WIDENED by whichever bound the filter did close. Both
+        // sides are clamped to the window rather than substituted for it, because a range list
+        // like `'..%1|%2..'` closes a HIGH bound on its first range and a LOW bound on its
+        // second: taking those as the span produces low=2099-12-30, high=1900-01-02, an inverted
+        // span that materialises nothing. That inversion was harmless before #2648 only because
+        // the window was already in place and PopulateDateSpan's own min/max widened it away;
+        // with nothing materialised up front it returned 0 rows where BC returns 4 (measured).
+        var lowBound = closedLow is DateTime cl && cl < new DateTime(DateWindowMinYear, 1, 1)
+            ? cl : new DateTime(DateWindowMinYear, 1, 1);
+        var highBound = closedHigh is DateTime ch && ch > new DateTime(DateWindowMaxYear, 12, 31)
+            ? ch : new DateTime(DateWindowMaxYear, 12, 31);
 
         // PopulateDateSpan only ever widens, and returns immediately when the span already
-        // covers what was asked for — which is the common case after the first find.
-        PopulateDateSpan(dataAccess, meta, session,
-            wantLow ?? new DateTime(DateWindowMinYear, 1, 1),
-            wantHigh ?? new DateTime(DateWindowMaxYear, 12, 31));
+        // covers what was asked for — the common case after the first such read.
+        PopulateDateSpan(dataAccess, meta, session, lowBound, highBound);
+    }
+
+    /// <summary>
+    /// Reads the request's "Period Start" filter through BC's own FilterExpression.ToRangeList.
+    /// <paramref name="low"/> and <paramref name="high"/> come back as the lowest closed low
+    /// bound and the highest closed high bound any range names, or null when no range names one —
+    /// which is exactly the pair the pre-#2648 guard used to widen the window by.
+    /// </summary>
+    /// <returns>
+    /// True only when the filter names at least one non-empty range AND every non-empty range is
+    /// closed at both ends, i.e. when [low..high] provably contains every row the filter can
+    /// select. False means the request reaches past any bounded span, so the caller must fall
+    /// back to the documented window.
+    /// </returns>
+    private static bool TryReadClosedPeriodStartBounds(
+        object cacheRequest, object session, out DateTime? low, out DateTime? high)
+    {
+        low = null;
+        high = null;
+
+        var filter = FindPeriodStartFilter(cacheRequest);
+        if (filter == null) return false;
+
+        var rangeList = _dvtToRangeList!.Invoke(filter, new[] { session });
+        if (rangeList == null) return false;
+        if (_dvtRangeListRanges!.GetValue(rangeList) is not System.Collections.IEnumerable ranges) return false;
+
+        // BC's own first and last period start for period type Date — the widest the real table
+        // ever goes. A bound at or past either end is the filter saying "no limit", and is
+        // treated as open, exactly as it was before #2648.
+        var bcFirst = (DateTime)_dvtPeriodStartMin!.Invoke(null, new[] { DatePeriodTypeDate() })!;
+        var bcLast = (DateTime)_dvtPeriodStartMax!.Invoke(null, new[] { DatePeriodTypeDate() })!;
+
+        var sawRange = false;
+        var everyRangeClosed = true;
+
+        foreach (var range in ranges)
+        {
+            if (range == null) continue;
+            if ((bool)_dvtRangeIsEmpty!.GetValue(range)!) continue;
+            sawRange = true;
+
+            var lowClosed = false;
+            var highClosed = false;
+
+            if (!(bool)_dvtRangeLowIsMin!.GetValue(range)!
+                && ToDateTimeOrNull(_dvtRangeLowValue!.GetValue(range)) is DateTime lo
+                && lo > bcFirst)
+            {
+                lowClosed = true;
+                low = low == null || lo < low ? lo : low;
+            }
+
+            if (!(bool)_dvtRangeHighIsMax!.GetValue(range)!
+                && ToDateTimeOrNull(_dvtRangeHighValue!.GetValue(range)) is DateTime hi
+                && hi < bcLast)
+            {
+                highClosed = true;
+                high = high == null || hi > high ? hi : high;
+            }
+
+            // One half-open range in a `'..%1|%2..'` shape makes the whole filter unbounded: the
+            // union it selects reaches past anything [low..high] would hold.
+            if (!lowClosed || !highClosed) everyRangeClosed = false;
+        }
+
+        return sawRange && everyRangeClosed;
     }
 
     /// <summary>
     /// Prepended to DataAccess.CountAsync(CountCacheRequest) for every table. Record.Count()
     /// takes the count path, not the find path, so the InnerFindAsync guard never sees it;
-    /// without this a Count over a range outside the materialised Date window would return
-    /// however many rows the window happens to hold. For every table but 2000000007 this does
-    /// one integer comparison and returns.
+    /// without this a Count over a range outside what is materialised would return however many
+    /// rows happen to be there. For every table but 2000000007 this does one integer comparison
+    /// and returns.
     ///
     /// <para>This comment used to say "Record.Count() AND IsEmpty()", and that was wrong — see
-    /// <see cref="DataAccess_DateWindowGuardForExists"/> below. The claim went unchallenged
-    /// long enough to hide a wrong answer for a whole release, which is why the correction is
-    /// spelled out rather than quietly edited: IsEmpty() has never reached CountAsync.</para>
+    /// <see cref="DataAccess_DateWindowGuardForExists"/> below. The claim went unchallenged long
+    /// enough to hide a wrong answer for a whole release, which is why the correction is spelled
+    /// out rather than quietly edited: IsEmpty() has never reached CountAsync.</para>
+    ///
+    /// <para>Which DataAccess entry points are worth guarding was measured twice, from two
+    /// directions, and the two results are easy to mistake for a contradiction:</para>
+    /// <list type="bullet">
+    /// <item>A FlowField calculation and a TableRelation check never reach DataAccess at all —
+    /// they go straight to the in-memory provider — so a prepend on ExistsAsync /
+    /// CalcNumericAsync / CalcMinMaxAsync / CalcSumsAsync applies and then never fires for
+    /// THOSE callers (#2648). That is why the provider-level net
+    /// <see cref="EnsureDateStoreFullyMaterialised"/> exists.</item>
+    /// <item>An AL <c>Record.IsEmpty()</c> DOES reach DataAccess.ExistsAsync, and a prepend
+    /// there fires (#3006): before one existed, a closed range outside the window answered
+    /// IsEmpty() = true and Count() = 7 on the very next line.</item>
+    /// </list>
+    /// <para>So ExistsAsync is guarded and CalcNumericAsync / CalcMinMaxAsync / CalcSumsAsync
+    /// are not. The net does not subsume the ExistsAsync guard: the net materialises the DEFAULT
+    /// window, which does not contain 1850, so IsEmpty() over a closed range outside the window
+    /// still needs a guard that reads that range off the request.</para>
     /// </summary>
     public static void DataAccess_DateWindowGuardForCount(object self, object request)
     {
@@ -653,47 +867,80 @@ public static partial class RecordPatches
         // wrote (#2524).
         if (IsTemporaryRecordDataAccess(self)) return;
 
+        NCLMetaTable meta;
+        object session;
+        DateTime? wanted;
+        bool hasRecordId;
         try
         {
-            if (_pReqMaoLight?.GetValue(request) is not NCLMetaTable meta) return;
+            if (_pReqMaoLight?.GetValue(request) is not NCLMetaTable m) return;
+            meta = m;
             EnsureDateReflection(meta);
             EnsureDateGuardReflection(self, request);
-            if (_dvtDaSession!.GetValue(self) is not object session) return;
-
-            var wanted = PrimaryKeyPeriodStart(request);
-            if (wanted == null) return;
-
-            // One day is all a keyed Get needs; PopulateDateSpan widens to whole periods itself
-            // and returns immediately when the window already covers it, which is the common case.
-            PopulateDateSpan(self, meta, session, wanted.Value, wanted.Value);
+            if (_dvtDaSession!.GetValue(self) is not object s) return;
+            session = s;
+            wanted = PrimaryKeyPeriodStart(request, out hasRecordId);
         }
         catch (RunnerOutOfScopeException) { throw; }
         catch
         {
-            // Best-effort, exactly like the find guard: a request shape we cannot read means we
-            // do not widen, never that we answer something different. The Get then runs over the
-            // window exactly as it would without this guard.
+            // We could not identify the request or the store behind it — nothing to materialise
+            // against. Unchanged from before #2648.
+            return;
         }
+
+        if (wanted != null)
+        {
+            // One day is all a keyed Get needs; PopulateDateSpan widens to whole periods itself
+            // and returns immediately when the span already covers it, which is the common case.
+            PopulateDateSpan(self, meta, session, wanted.Value, wanted.Value);
+            return;
+        }
+
+        // A SystemId-keyed Get names no period, and cannot name one the store does not already
+        // hold: the SystemId of a row that was never materialised has never been handed out.
+        if (!hasRecordId) return;
+
+        // A primary-key Get whose key we could not read. Before #2648 the whole window was
+        // already materialised by the time any Get ran, so such a Get answered from the window;
+        // fall back to exactly that rather than answering from a narrower store.
+        PopulateDefaultDateWindow(self, meta, session);
     }
 
     /// <summary>
     /// The "Period Start" out of a primary-key request's RecordId. Date's primary key is
-    /// ("Period Type", "Period Start"), so it is the SECOND key value. Null for a
-    /// SystemIdCacheRequest, which carries no key values — a Get by SystemId cannot name a
-    /// period the window does not already hold, because the SystemId of an unmaterialised row
-    /// has never been handed out.
+    /// ("Period Type", "Period Start"), so it is the SECOND key value.
     /// </summary>
-    private static DateTime? PrimaryKeyPeriodStart(object request)
+    /// <param name="hasRecordId">
+    /// False for a SystemIdCacheRequest, which carries no RecordId at all — a Get by SystemId
+    /// cannot name a period the store does not already hold, because the SystemId of an
+    /// unmaterialised row has never been handed out. True with a null return means "this IS a
+    /// primary-key Get but the key could not be read", which the caller has to answer
+    /// conservatively; the two cases were indistinguishable while everything was materialised up
+    /// front, and are not any more.
+    /// </param>
+    private static DateTime? PrimaryKeyPeriodStart(object request, out bool hasRecordId)
     {
-        var recordId = request.GetType().GetProperty("RecordId",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(request);
-        if (recordId == null) return null;
+        hasRecordId = false;
+        try
+        {
+            var recordId = request.GetType().GetProperty("RecordId",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(request);
+            if (recordId == null) return null;
+            hasRecordId = true;
 
-        var fields = recordId.GetType().GetProperty("Fields",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(recordId);
-        if (fields is not System.Collections.IList list || list.Count < 2) return null;
+            var fields = recordId.GetType().GetProperty("Fields",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(recordId);
+            if (fields is not System.Collections.IList list || list.Count < 2) return null;
 
-        return ToDateTimeOrNull(list[1]);
+            return ToDateTimeOrNull(list[1]);
+        }
+        catch
+        {
+            // Unreadable, not absent: leave hasRecordId as whatever we established, so the caller
+            // widens rather than assuming a SystemId request.
+            return null;
+        }
     }
 
     /// <summary>The "Period Start" (field 2) FilterExpression on this find request, if any.</summary>

--- a/AlRunner/Patches/RecordPatches.DateVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.DateVirtualTable.cs
@@ -260,13 +260,24 @@ public static partial class RecordPatches
     // ── Per-provider populated span ──────────────────────────────────────────────────────
     private sealed class DatePopulatedSpan
     {
-        internal DateTime Min = DateTime.MaxValue;
-        internal DateTime Max = DateTime.MinValue;
-        internal bool Any;
+        /// <summary>
+        /// The periods this provider holds, as DISJOINT, SORTED, gap-separated intervals rather
+        /// than one min..max envelope. The envelope is what made per-request materialisation
+        /// (#2648) only half a fix: materialise one week of 1850, then Get a day in 2100, and an
+        /// envelope has to fill everything between — 250 years, ~109,000 rows, which is the exact
+        /// number the issue is about, just moved to a later call. The runner-extras Date suite
+        /// does precisely that in its first two tests. With a set, the second request costs the
+        /// ~440 rows of the year it names.
+        /// </summary>
+        internal readonly List<(DateTime Start, DateTime End)> Covered = new();
+
+        /// <summary>Running row estimate of <see cref="Covered"/>, so the cap is checked against
+        /// what is actually materialised rather than against the envelope's span.</summary>
+        internal long CoveredEstimate;
 
         /// <summary>True once the whole configured window has been materialised into this
-        /// provider. Distinct from <see cref="Any"/>, which is true after ANY span — including a
-        /// single day materialised for one keyed Get.</summary>
+        /// provider. Distinct from "Covered is non-empty", which is true after ANY span —
+        /// including a single day materialised for one keyed Get.</summary>
         internal bool WholeWindow;
 
         /// <summary>The metatable and skeleton session captured when this provider was handed
@@ -424,26 +435,31 @@ public static partial class RecordPatches
 
         lock (span)
         {
-            // Nothing new to do.
-            if (span.Any && wantStart >= span.Min && wantEnd <= span.Max) return;
+            var missing = DateMissingSpans(span.Covered, wantStart, wantEnd);
+            if (missing.Count == 0) return;   // nothing new to do
 
-            var newMin = span.Any ? (wantStart < span.Min ? wantStart : span.Min) : wantStart;
-            var newMax = span.Any ? (wantEnd > span.Max ? wantEnd : span.Max) : wantEnd;
-
-            var estimate = EstimateDateRowCount(newMin, newMax);
-            if (estimate > DateWindowMaxRows)
+            // The cap is about how many rows are materialised, so it is checked against what is
+            // already there PLUS what this request would add — not against the envelope, which
+            // would refuse a narrow request purely because an earlier one sat far away.
+            long adding = 0;
+            foreach (var (s0, e0) in missing) adding += EstimateDateRowCount(s0, e0);
+            var total = span.CoveredEstimate + adding;
+            if (total > DateWindowMaxRows)
                 throw DateShapeGap(
                     "a Date filter asks for periods in "
                     // #2968: `:N0` picks up the ambient group separator, so this diagnostic
                     // read differently per operator locale. Invariant, like the rest of the
                     // runner's own output.
                     + System.FormattableString.Invariant(
-                        $"[{newMin:yyyy-MM-dd}..{newMax:yyyy-MM-dd}], which is about {estimate:N0} rows, past the ")
+                        $"[{wantStart:yyyy-MM-dd}..{wantEnd:yyyy-MM-dd}], which would add about {adding:N0} rows ")
                     + System.FormattableString.Invariant(
-                        $"{DateWindowMaxRows:N0}-row cap for the materialised window ")
-                    + (span.Any
+                        $"for {total:N0} in all, past the {DateWindowMaxRows:N0}-row cap for the materialised ")
+                    + "window "
+                    + (span.Covered.Count > 0
                         ? System.FormattableString.Invariant(
-                            $"(currently [{span.Min:yyyy-MM-dd}..{span.Max:yyyy-MM-dd}]). ")
+                              $"(currently {span.CoveredEstimate:N0} rows in {span.Covered.Count} span(s), ")
+                          + System.FormattableString.Invariant(
+                              $"[{span.Covered[0].Start:yyyy-MM-dd}..{span.Covered[^1].End:yyyy-MM-dd}]). ")
                         : "(nothing is materialised yet — Date rows are materialised per request). ")
                     + "Raise AL_RUNNER_DATE_WINDOW_MAX_ROWS, or narrow the filter");
 
@@ -455,37 +471,75 @@ public static partial class RecordPatches
             EnsureDateFieldLayout(dateMetaTable);
             var periodTypes = EnsureDatePeriodTypes(dateMetaTable);
 
-            // Insert only the parts of [newMin..newMax] not already covered, so an extension
-            // does not re-walk (and re-throw duplicate keys over) the whole existing window.
-            foreach (var (start, end) in MissingSpans(span, newMin, newMax))
+            // Insert only the parts this provider does not already hold, so a second request
+            // does not re-walk (and re-throw duplicate keys over) what a first one materialised.
+            foreach (var (start, end) in missing)
                 foreach (var (ordinal, periodType) in periodTypes)
                     InsertDatePeriods(provider, dateMetaTable, session, ordinal, periodType, start, end);
 
-            span.Min = newMin;
-            span.Max = newMax;
-            span.Any = true;
+            DateAddCovered(span.Covered, wantStart, wantEnd);
+            span.CoveredEstimate = total;
             span.Meta ??= dateMetaTable;
             span.Session ??= session;
             // "The whole configured window is in" — the flag the provider-level net reads. It is
-            // deliberately about the WINDOW, not about the span being non-empty: a single day
+            // deliberately about the WINDOW, not about anything being materialised: a single day
             // materialised for a keyed Get must not convince the net that a FlowField can be
-            // answered.
-            if (newMin <= new DateTime(DateWindowMinYear, 1, 1) && newMax >= new DateTime(DateWindowMaxYear, 12, 31))
+            // answered. DateMissingSpans is the authority, so a window that was covered by two
+            // adjacent requests counts, and one with a hole in it does not.
+            if (DateMissingSpans(span.Covered,
+                    new DateTime(DateWindowMinYear, 1, 1), new DateTime(DateWindowMaxYear, 12, 31)).Count == 0)
                 span.WholeWindow = true;
         }
     }
 
-    /// <summary>The sub-spans of [newMin..newMax] the provider does not hold yet.</summary>
-    private static IEnumerable<(DateTime Start, DateTime End)> MissingSpans(
-        DatePopulatedSpan span, DateTime newMin, DateTime newMax)
+    /// <summary>
+    /// The sub-spans of [<paramref name="wantStart"/>..<paramref name="wantEnd"/>] that
+    /// <paramref name="covered"/> does not already hold, in order. <paramref name="covered"/>
+    /// must be disjoint and sorted by Start, which <see cref="DateAddCovered"/> maintains.
+    /// Returns an empty list when the request is entirely covered, or inverted.
+    /// </summary>
+    internal static List<(DateTime Start, DateTime End)> DateMissingSpans(
+        IReadOnlyList<(DateTime Start, DateTime End)> covered, DateTime wantStart, DateTime wantEnd)
     {
-        if (!span.Any)
+        var gaps = new List<(DateTime Start, DateTime End)>();
+        if (wantEnd < wantStart) return gaps;
+
+        var cursor = wantStart;
+        foreach (var (start, end) in covered)
         {
-            yield return (newMin, newMax);
-            yield break;
+            if (end < cursor) continue;             // entirely before what is still wanted
+            if (start > wantEnd) break;             // sorted, so nothing later can overlap either
+            if (start > cursor) gaps.Add((cursor, start.AddDays(-1)));
+            if (end >= cursor) cursor = end.AddDays(1);
+            if (cursor > wantEnd) return gaps;
         }
-        if (newMin < span.Min) yield return (newMin, span.Min.AddDays(-1));
-        if (newMax > span.Max) yield return (span.Max.AddDays(1), newMax);
+        if (cursor <= wantEnd) gaps.Add((cursor, wantEnd));
+        return gaps;
+    }
+
+    /// <summary>
+    /// Record [<paramref name="start"/>..<paramref name="end"/>] as covered, keeping
+    /// <paramref name="covered"/> disjoint, sorted by Start, and merged across intervals that
+    /// touch or overlap — so a window materialised as two adjacent halves reads as one span and
+    /// not as two with a zero-day gap between them.
+    /// </summary>
+    internal static void DateAddCovered(
+        List<(DateTime Start, DateTime End)> covered, DateTime start, DateTime end)
+    {
+        if (end < start) return;
+
+        var i = 0;
+        while (i < covered.Count && covered[i].End.AddDays(1) < start) i++;   // strictly before, no touch
+
+        var newStart = start;
+        var newEnd = end;
+        while (i < covered.Count && covered[i].Start.AddDays(-1) <= newEnd)
+        {
+            if (covered[i].Start < newStart) newStart = covered[i].Start;
+            if (covered[i].End > newEnd) newEnd = covered[i].End;
+            covered.RemoveAt(i);
+        }
+        covered.Insert(i, (newStart, newEnd));
     }
 
     /// <summary>

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -863,6 +863,13 @@ public static partial class RecordPatches
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static object TempTableDataProvider_CalcNumeric(object self, object request)
     {
+        // #2648: a FlowField whose CalcFormula source is the Date virtual table reaches the
+        // provider without ever going through DataAccess, so none of the Date window guards has
+        // seen it. This call materialises the whole window on first such read (and is a
+        // ConditionalWeakTable miss for every other table). It lives inside the replacement body
+        // rather than as a Cecil prepend because Cecil REPLACES this method's body outright.
+        EnsureDateStoreFullyMaterialised(self);
+
         var rt = request.GetType();
         var companyToken   = (int)rt.GetProperty("CompanyToken")!.GetValue(request)!;
         var filtersAndMarks = rt.GetProperty("FiltersAndMarks")!.GetValue(request);
@@ -1931,12 +1938,20 @@ public static partial class RecordPatches
 
             // ── Date system virtual table (2000000007) ───────────────────────────────────
             // Virtual on the service tier (DateDataProvider computes one row per period, for
-            // each of the five period types, on demand). Routed to the same in-memory store as
-            // every other table and populated over a bounded window that the find-time guard
-            // extends when an AL filter names a closed bound outside it, so `Record Date`
-            // iteration answers with real periods instead of "There is no Date within the
-            // filter." Every piece of the period arithmetic is BC's own code, called by
-            // reflection. See RecordPatches.DateVirtualTable.cs.
+            // each of the five period types, ON DEMAND, per request). Routed to the same
+            // in-memory store as every other table, so `Record Date` iteration answers with
+            // real periods instead of "There is no Date within the filter." Every piece of the
+            // period arithmetic is BC's own code, called by reflection.
+            //
+            // NOTHING IS MATERIALISED HERE (#2648). This runs from
+            // RecordImplementation.InitializeImpl — i.e. when the `Record Date` VARIABLE is
+            // constructed, before any filter exists — so populating here meant inserting the
+            // whole default window (1900-01-01..2099-12-31, 86,885 rows) whatever the caller
+            // went on to ask for. A filter naming one week in 1850 cost ~109,000 row inserts to
+            // return 7 rows. The three read paths (find, count, keyed Get) each carry the
+            // request, so each populates exactly what its request can select; a request that
+            // names no closed "Period Start" bound still gets the whole documented window,
+            // because that is what answers it. See RecordPatches.DateVirtualTable.cs.
             if (IsDateVirtualTable(table))
             {
                 if (!perTable.TryGetValue(tableId, out var dateDa))
@@ -1949,11 +1964,16 @@ public static partial class RecordPatches
                 // rather than spelling the anchor itself, so the table cannot claim one thing
                 // from the populator and another from this dispatch chain — the sibling defect
                 // #2945 found for Field, Aggregate Permission Set and All Profile (#2965).
+                //
+                // The CHECK stays at handout even though the rows no longer are (#2648): the
+                // skeleton session is what BC's own GetPeriodName needs to name a period, and a
+                // DataAccessSource without one is a runner defect that must stay loud at exactly
+                // the point it was loud before.
                 var dateSession = _fDasSession?.GetValue(self)
                     ?? throw DateShapeGap(
                         "the DataAccessSource has no skeleton session, so BC's own "
                         + "DateDataProvider.GetPeriodName cannot name a period");
-                PopulateDateVirtualTable(dateDa, table, dateSession);
+                PrepareDateVirtualTable(dateDa, table, dateSession);
                 return dateDa;
             }
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -526,12 +526,22 @@ in-memory store, so it has to materialise rows, and it cannot materialise all of
 
 What it does instead:
 
-- It materialises a window of whole years, **1900-01-01 to 2099-12-31** by default
-  (about 87,000 rows across all five period types).
-- Whenever an AL `"Period Start"` filter names a **closed** bound outside that window,
-  the window widens to cover it before the read runs. This happens on all **four**
-  request paths a `Record Date` read can take, so a filter naming 1850 or 2300 gets
-  real rows whichever one AL uses:
+- **Nothing is materialised until a read asks for it.** Declaring a `Record Date`
+  variable costs no rows at all.
+- A read whose `"Period Start"` filter is **closed at both ends** materialises exactly
+  the periods inside those bounds, and nothing else. A filter naming one week gets
+  about 25 rows, whether that week is in 1850 or 2300. This is safe rather than a
+  shortcut: BC's own filter engine excludes every row outside the filter anyway, so a
+  narrower store cannot change an answer. A keyed `Get` likewise materialises only the
+  day its key names.
+- A read that does **not** close both ends — no `"Period Start"` filter at all, an open
+  bound, or a filter shape the runner cannot read — is answered from a window of whole
+  years, **1900-01-01 to 2099-12-31** by default (86,885 rows across all five period
+  types), widened by whichever bound the filter did close. A FlowField whose
+  `CalcFormula` source is `Date`, and a `TableRelation` to `Date`, also get the whole
+  window: they reach the store without a filter the runner can see.
+- The narrowing happens on all **four** request paths a `Record Date` read can take, so
+  a filter naming 1850 or 2300 gets real rows whichever one AL uses:
 
   | AL | `DataAccess` method | request type |
   |---|---|---|
@@ -544,14 +554,16 @@ What it does instead:
   `IsEmpty()` has never taken the count path: `RecordImplementation.IsEmptyAsync` calls
   its own `ExistsAsync`, which builds an `ExistsCacheRequest`. Until that fourth guard
   existed, `IsEmpty()` answered `true` for a 1850 range that `Count()` answered `7` for
-  on the very next line.
-- Widening past **500,000 rows** raises `RunnerOutOfScopeException`, naming the
-  requested bounds, the current window and the cap. It never answers a wider request
+  on the very next line. The FlowField and `TableRelation` net described above does not
+  cover this case, because it materialises the default window and 1850 is outside it.
+- Materialising past **500,000 rows** raises `RunnerOutOfScopeException`, naming the
+  requested bounds, what is materialised and the cap. It never answers a wider request
   with fewer rows.
 
 The one case the window does not cover is an **open** bound. `SetFilter("Period Start",
 '%1..', D)` asks real BC for every period from `D` to 9999-12-31; the runner answers it
-from the window. `FindFirst` on such a filter is unaffected, because its answer sits at
+from the window — which is why an open bound is one of the shapes that materialises the
+whole window rather than something narrower. `FindFirst` on such a filter is unaffected, because its answer sits at
 the closed end — and that is the shape production AL uses. Iterating an open-ended range
 to the end stops at the window edge instead of year 9999.
 


### PR DESCRIPTION
Closes #2648

The `Date` virtual table (2000000007) materialised its whole default window — 1900-01-01 to 2099-12-31, 86,885 rows across the five period types — at the **handout**, which is `RecordImplementation.InitializeImpl`: when the `Record Date` *variable* is constructed, before any filter exists. A filter naming one week in 1850 therefore paid the window plus a 50-year extension, about 109,000 row inserts, to return 7 rows.

Now each read materialises what its own request can select. A `"Period Start"` filter closed at both ends of every range gets exactly `[lowest low .. highest high]`; a keyed `Get` gets the one day its key names; everything else still gets the whole window.

## Why a narrower store cannot change an answer

BC's own filter engine excludes every row outside the filter regardless of what the store holds. So for a range closed at both ends, the rows inside those bounds are the only rows the read can return, and materialising only those is not an approximation. That is the entire safety argument, and it is why the predicate is "every range closed at both ends" rather than "some bound is closed" — one half-open range in a `'..%1|%2..'` union reaches past any bounded span.

Reads that do not close both ends — no `"Period Start"` filter, an open bound, a filter shape `ToRangeList` cannot express — are answered *from* the window, so nothing narrower reproduces them. Those still get the window, and the documented open-bound limitation in `docs/limitations.md` is unchanged.

## The reads that carry no request, and why the obvious fix does not work

Three DataAccess-level guards do the narrowing: `InnerFindAsync`, `CountAsync`, and `InternalTryGetByPrimaryKeyAsync` (#2870). They are not the whole read surface, and eager materialisation was hiding that — with the store already full, a path with no guard still got right answers. With only those three, measured on this branch:

| AL shape | before | with only the three guards |
|---|---|---|
| `count(Date where …)` FlowField | 73,049 | **0** |
| `exist(Date where …)` FlowField | Yes | **No** |
| `min("Date"."Period Start")` FlowField | 1900-01-01 | **blank** |
| `TableRelation` to `Date`, value in 1850 | raises | **silently accepted** |

Prepending the guard to `DataAccess.ExistsAsync` / `CalcNumericAsync` / `CalcMinMaxAsync` / `CalcSumsAsync` does **not** fix that. I traced every request that reached it: the prepend applies (`[Cecil] Prepended …` for all four) and never fires once, because `FlowFieldsHelper` and `RecordImplementation.ValidateRelation` reach the in-memory store without going through `DataAccess` at all — this repo replaces `FlowFieldsHelper.CalcFieldsAsync` with its own implementation that goes from the handout straight to `TempTableDataProvider.Filter`.

So the net sits one layer down, on the store itself: `TempTableDataProvider.{Exists,CalcMinMax,CalcSums}`, the replacement body of `CalcNumeric`, and `FlowFieldPatches`' own source-table read. It materialises the whole window once per store — exactly the state those callers had before — and is a `ConditionalWeakTable` miss for every other table. Those five entry points plus the three guards are the complete read surface of a `TempTableDataProvider`; `GetBlobContent` is the only one left out, because `Date` has no BLOB field. A query over `Date` is refused by BC itself ("A query cannot be based on a virtual table"), identically on both builds.

## Disjoint covered spans, not one min..max envelope

Per-request materialisation on its own only *moved* the 109,000 rows. The provider recorded one min..max envelope, so materialising one week of 1850 and then asking for a day in 2100 had to fill the 250 years between. The `runner-extras` Date suite does exactly that in its first two tests: with the envelope, its second test took **1,551 ms**; with a disjoint set it takes **2 ms**.

The cap moved with it — it is now checked against the rows actually materialised plus the rows this request would add, rather than against the envelope, which would refuse a narrow request purely because an earlier one sat far away.

`DateMissingSpans` and `DateAddCovered` are `internal` and tested directly, because a gap `DateMissingSpans` fails to report is not a slow answer, it is a missing row — an AL read saying "no such period" for a period that exists. Eleven tests: by hand for the adjacent-merge, swallow, out-of-order and inverted cases, and against a brute-force day-set oracle for the edges.

## Also fixed

The unbounded fallback took `closedLow` / `closedHigh` literally, so `'..1900-01-02|2099-12-30..'` produced `low=2099-12-30, high=1900-01-02` — an inverted span that materialises nothing. It returned 0 rows where BC returns 4. The inversion was already in the code before this change; it was harmless only because the window was already in place and the min/max widening absorbed it. Both bounds are now clamped to the window rather than substituted for it.

Dead code removed: `_dvtLastDataAccess` / `_dvtLastMetaTable` / `_dvtLastSession` were written on every populate and read nowhere, and their comment described a mechanism that no longer exists.

## Does the same shape appear elsewhere?

1. **Same wrong pattern at another call site?** Every other virtual table the runner populates at handout (`AllObj`, `Field`, `Integer`, `All Profile`, `Aggregate Permission Set`, `Report Layout List`, …) materialises the *complete* truth for its table — a bounded set that is the answer. `Date` is the only one whose eager population is a *window*, i.e. a chosen subset of an unbounded table, which is what makes "materialise less" meaningful here and meaningless there. Nothing else to fix.
2. **Does a sibling function make the same assumption?** Yes, and this is where most of the work went — the FlowField and `TableRelation` paths above. `RecordWritePatches.EnsureTableTouchedForAutoIncrement` also calls the handout and then reads rows, but only for AutoIncrement fields, and `Date` has none. `TestDataProvisioner` and `BlobStoreIsolationPatches` likewise cannot reach `Date`.
3. **Do two paths writing the same state keep the same invariant?** `PopulateDateSpanIntoProvider` is the only writer of the covered set, and both entry points (via a `DataAccess`, or with the provider in hand) go through it under the same lock.

I also checked the install-baseline snapshot: `RestoreInstallBaselineSnapshot` creates a **fresh** `DataAccess` per table, so a restored `Date` store gets a new provider with no recorded coverage and the next read re-materialises. There is no stale-coverage window. I deliberately did **not** add `Date` to `IsSelfPopulatingVirtualTableId`; that is a separate decision about what the snapshot carries, and correctness does not depend on it either way.

## RED → GREEN

`AlRunner.Tests/Fixtures/DateWindowLazy` + `DateVirtualTableLazyWindowTests.cs`, driven with `AL_RUNNER_DATE_WINDOW_MAX_ROWS=2000`.

The cap is the instrument on purpose. "It got faster" is not a testable claim on a shared machine, and the runner already has an exact, deterministic counter for the thing that changed: the row estimate `PopulateDateSpan` checks before materialising anything. 2,000 is below the ~87,000 the window needs and above the 25 a one-week span needs, so the assertion is about **rows**, not duration.

Against `origin/main`:

```
FAIL  Date_BoundedFilter_MaterialisesOnlyTheBoundedSpan
      out-of-scope: … asks for periods in [1900-01-01..2099-12-31], which is
      about 86,885 rows, past the 2,000-row cap …
FAIL  Date_KeyedGetInABoundedSpan_MaterialisesOnlyThatPeriod
PASS  Date_UnfilteredRead_StillDemandsTheWholeDocumentedWindow
```

On this branch all three pass. The third is the control: it asserts that an unfiltered read *still* refuses under the same cap, so a change that made the window lazy by never building it at all fails here rather than answering from fewer rows.

## Verified: no answer changed

A 16-case AL probe — FlowField `count` / `exist` / `min` over `Date`, a `TableRelation` check inside and outside the window, unfiltered `FindSet`, open high and open low bounds, disjoint closed ranges, a half-open union, keyed `Get` inside and outside, `Count` / `IsEmpty`, and a temporary `Record Date` — is **byte-identical** between `origin/main` and this branch, both test-by-test in separate processes and as one process in declaration order.

Suites, all run on the rebased tree:

- `tests/al-language` — **2554/2554**, cold and warm, exit 0 with `--count-baseline`.
- `tests/runner-extras` — **273/273**, exit 0 with `--count-baseline`.
- `tests/runner-extras/date-virtual-table-window` alone — 5/5, cold and warm.
- `dotnet test AlRunner.Tests --filter` over `DateVirtualTable*`, `DateCoveredInterval*`, `VirtualTableBitClearing*`, `InstallBaselineVirtualTableExclusion*`, `BaseAppFloorFixtureGuard*`, `FlowFieldDiagnosticNoise*`, `QueryFlowFieldColumnProjection*` — 32 passed, 3 skipped (the 3 skip on `main` too).

No count-baseline change: this PR adds no AL tests to the corpus or to `tests/runner-extras`.

## Measurements

Instructions-retired (`perf stat -e instructions:u`), **A/B interleaved** so drift from other work on the box cancels, 7 iterations each, caches fully warm. Wall clock is not used: identical work has measured 1.9 s and 3.1 s on this machine.

| | BASE min | NEW min | | BASE median | NEW median |
|---|---|---|---|---|---|
| `date-virtual-table-window` | 29.64 G | **23.75 G** (-20%) | | 30.52 G | 27.83 G |
| `object-metadata-system-table` (control) | 11.87 G | 11.86 G (-0.1%) | | 12.55 G | 12.02 G |

The control never touches `Date` and is flat, which is what makes the target's delta believable. Within-build spread is 8-14%, so `min` is the estimator I trust; the medians are consistent in direction but inside that spread.

Peak RSS, the quantity the issue's memory-pressure hypothesis is about:

| | BASE | NEW |
|---|---|---|
| `date-virtual-table-window` | 1,335 MB | **1,099 MB** (-18%) |
| `object-metadata-system-table` (control) | 351 MB | 348 MB |
| full `tests/runner-extras` sweep, 3 interleaved | min 3,507 MB / median 3,671 MB | **min 3,182 MB / median 3,299 MB** (-9% / -10%) |

**Where it does not show up, stated plainly:** the full `runner-extras` sweep is *flat on instructions* — 463.79 G vs 463.27 G min, 3 interleaved iterations. That is not a null result hiding a regression; the Date bundle is about 1.3% of the sweep's instruction count, so even a perfect saving is below the noise there. The sweep's peak RSS does move, by ~350 MB, and that is the number relevant to #2648's actual complaint — the test hit the 60 s watchdog on two different BC legs while siblings passed, which is the signature of memory pressure rather than CPU load.

I did not reproduce a 60 s run and I am not claiming this makes that timeout go away outright. What it removes is the reason that test was the most allocation-heavy in `runner-extras`: a bounded 7-row query now materialises about 25 rows instead of about 109,000.

Written by agent impl-14.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
