### PR TITLE
fix(tests): own the namespace-qualified-relation scratch dir, which broke main

### DIFF
--- a/AlRunner.Tests/NamespaceQualifiedRelationTargetTests.cs
+++ b/AlRunner.Tests/NamespaceQualifiedRelationTargetTests.cs
@@ -199,7 +199,12 @@ public class NamespaceQualifiedRelationTargetTests
 
     private static string NewDir()
     {
-        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        // TestScratch, not a bare Path.Combine under the temp root: #2743's guard requires an
+        // owner sidecar so a KILLED test host's directory is reclaimed by the next runner
+        // instead of leaking forever. This file and that guard landed within minutes of each
+        // other from two different PRs, so neither saw the other and main went red on a
+        // combination that was green in both -- nothing wrong with either change itself.
+        var dir = TestScratch.Dir("al-runner-nqr-tests");
         Directory.CreateDirectory(dir);
         return dir;
     }


### PR DESCRIPTION
`main` is red at `9483fe84`. `ScratchDirOwnershipGuardTests` fails — reproduced on a detached worktree with nothing else in it, and independently by two agents tonight.

Neither PR involved is wrong.

- **#2972** added a guard that scans every file in `AlRunner.Tests` for a scratch directory created without an owner sidecar. Without one, a test host killed by the watchdog or an OOM leaves about 273 MB per root that no later process can tell is dead.
- **#2973** added `AlRunner.Tests/NamespaceQualifiedRelationTargetTests.cs`, whose `NewDir()` builds a path directly under the temp root.

They merged minutes apart. Neither PR's diff contained the other's file, so neither CI run could see the combination, and both were green on their own.

This is the semantic-conflict class recorded in #2924: two individually-green pull requests that are wrong only together. It is the second instance tonight — the first was the count baseline, which #2879 removed by giving each app group its own line. A merge queue is what prevents this one. This change only clears the symptom.

## Why this is separate from #2989

The identical one-line change is also part of PR #2989, which carries the whole #2967 and #2968 body of work in 1,549 lines. Landing it on its own means `main` recovers on its own schedule rather than waiting on that review, and nine armed pull requests stop being blocked behind a red base.

The duplicate is safe: both sides are byte-identical, so whichever lands second resolves silently in the three-way merge.

## The change

`NewDir()` now calls `TestScratch.Dir("al-runner-nqr-tests")` instead of `Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"))`, which is what #2972 established as the convention and what its guard enforces.

Closes #2991

*Opened by an agent (coordinator session).*

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
