### PR TITLE
fix(refusals): say when the runner could not read BC's internals

### DIFF
--- a/AlRunner.Tests/BcShapeGapConventionTests.cs
+++ b/AlRunner.Tests/BcShapeGapConventionTests.cs
@@ -1,0 +1,529 @@
+// BcShapeGapConventionTests — the convention issue #2946 asked for a decision on.
+//
+// THE QUESTION
+//   Four readers of ONE private BC structure, TempTableDataProvider.primaryTree, raised three
+//   different exception types between them:
+//
+//     RecordPatches.StoredTableCensus.cs (x2), RecordPatches.TransactionSnapshot.cs,
+//     RecordPatches.InstallBaseline.cs   -> MissingFieldException, via RequiredField
+//     RowVersionPatches.SystemIdIntegrity.cs -> InvalidOperationException naming the member
+//     RecordPatches.ObjectMetadataSystemTable.cs -> RunnerOutOfScopeException
+//
+//   What a caller could catch therefore depended on which reader it happened to reach. Both
+//   RunnerOutOfScopeException flavours are claims about SCOPE, and none of these is: the
+//   surface is in scope AND implemented, and the runner simply could not read BC's internals.
+//
+// THE ANSWER, AND WHAT THESE TESTS PIN
+//   A third type, BcShapeGapException — see AlRunner/Infrastructure/BcShapeGapException.cs
+//   for the full derivation. Three cases have to stay distinguishable, and a live correctness
+//   bug turned on exactly that (#2894: under the wrong anchor an AL [TryFunction] trapped a
+//   runner shape gap into `false`, the silent default loud-failures.md forbids):
+//
+//                              [TryFunction]        asserterror       expect-oos absorbs?
+//     permanent OOS            traps -> false       catches           yes
+//     not-yet-implemented      tears through        catches (#2871)   yes
+//     BC shape gap             tears through        TEARS THROUGH     NO
+//
+//   The control arm matters as much as the claim. Every tear-through assertion here is paired
+//   with a PERMANENT refusal that is still trapped, so a test cannot pass by discriminating on
+//   exception type alone — "anything that is not a RunnerOutOfScopeException tears through"
+//   would satisfy the tear-through half and fail the control.
+//
+// WHY THESE LIVE IN AlRunner.Tests AND NOT THE UPSTREAM CORPUS
+//   Nothing here is a claim about Business Central. No AL statement can move a private BC
+//   field or rename a static, so a service tier has nothing to adjudicate — on every BC
+//   version the runner supports, TempTableDataProvider.primaryTree exists and none of these
+//   refusals is reachable from AL. The subject is the runner's own refusal contract, which
+//   .claude/rules/bc-behavior-tests-go-upstream.md classifies as runner-specific. Same
+//   reasoning as ObjectMetadataProviderRowProbeTests and VirtualTableRefusalClaimTests.
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using AlRunner;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class BcShapeGapConventionTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private const string Surface = "Object Metadata (system table 2000000071)";
+
+    private static BcShapeGapException Gap() =>
+        new(Surface, "TempTableDataProvider.primaryTree", "field not found — BC's private provider layout moved");
+
+    // ── The two control arms. Neither is a shape gap, and both must keep their behaviour ──
+
+    private static RunnerOutOfScopeException PermanentOos() =>
+        new("NavEmail.Send", "email-smtp — no SMTP transport in the runner", "email");
+
+    private static RunnerOutOfScopeException NotYetImplemented() =>
+        new("INCLObjectXmlMetadataLoader.GetMetaObjectXmlMetadata",
+            "not-yet-implemented — report metadata loader", "todo");
+
+    // ══ 1. The type's own contract ═══════════════════════════════════════════════════════
+
+    [Fact]
+    public void Message_NamesTheSurfaceTheMemberAndTheDoc()
+    {
+        var ex = Gap();
+
+        Assert.Equal(Surface, ex.Surface);
+        Assert.Equal("TempTableDataProvider.primaryTree", ex.Member);
+        Assert.StartsWith("bc-shape-gap: ", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("Object Metadata (system table 2000000071)", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("TempTableDataProvider.primaryTree", ex.Message, StringComparison.Ordinal);
+        Assert.EndsWith(" — see docs/limitations.md#bc-shape-gaps", ex.Message, StringComparison.Ordinal);
+    }
+
+    // The absorption defence, at its root. OutOfScopeMessage.TryParse matches its prefix
+    // ANYWHERE in a text blob (it is handed whole message+stack dumps), so a shape-gap message
+    // that merely CONTAINED "out-of-scope: " would be recovered as an out-of-scope signal by
+    // the reporter and by the expectations manifest.
+    [Fact]
+    public void Message_IsNotMistakenForAnOutOfScopeSignal()
+    {
+        var ex = Gap();
+
+        Assert.DoesNotContain("out-of-scope: ", ex.Message, StringComparison.Ordinal);
+        Assert.False(OutOfScopeMessage.TryParse(ex.Message, out _));
+        Assert.False(OutOfScopeMessage.TryParse(ex.ToString(), out _));
+        Assert.Null(OutOfScopeMessage.FromException(ex));
+        // Nor via an inner chain: a shape gap wrapped in something else is still not OOS.
+        Assert.Null(OutOfScopeMessage.FromException(new InvalidOperationException("wrapped", Gap())));
+    }
+
+    // The positive control for the assertion above: a real refusal IS still recognised, so
+    // "FromException returns null" cannot pass because the parser stopped working.
+    [Fact]
+    public void OutOfScopeSignal_IsStillRecognisedForARealRefusal()
+    {
+        var signal = OutOfScopeMessage.FromException(PermanentOos());
+
+        Assert.NotNull(signal);
+        Assert.Equal("NavEmail.Send", signal!.Value.Api);
+        Assert.StartsWith("email-smtp", signal.Value.Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Find_WalksTheInnerChain_BecauseReflectionAndBcWrapTheRefusal()
+    {
+        var gap = Gap();
+
+        Assert.Same(gap, BcShapeGapException.Find(gap));
+        Assert.Same(gap, BcShapeGapException.Find(new TargetInvocationException(gap)));
+        Assert.Same(gap, BcShapeGapException.Find(
+            new InvalidOperationException("outer", new TargetInvocationException(gap))));
+        Assert.Same(gap, BcShapeGapException.Find(new AggregateException(gap)));
+
+        // Negative: an unrelated chain is not a shape gap, and neither is a refusal.
+        Assert.Null(BcShapeGapException.Find(new InvalidOperationException("boom")));
+        Assert.Null(BcShapeGapException.Find(PermanentOos()));
+        Assert.Null(BcShapeGapException.Find(null));
+    }
+
+    // ══ 2. BcShape.RequiredField — the one resolver the readers share ═════════════════════
+
+    [Fact]
+    public void RequiredField_ResolvesAnInheritedPrivateField_RatherThanCallingItAbsent()
+    {
+        // BC's own CrmTableConnection.CrmTestDataProvider derives from TempTableDataProvider
+        // (#2725). GetField(NonPublic) does not return a base class's private field, so a
+        // plain-GetField resolver would refuse a perfectly readable store.
+        var field = InvokeRequiredField(typeof(DerivedProvider), "primaryTree");
+
+        Assert.NotNull(field);
+        Assert.Equal(typeof(BaseDeclaresPrimaryTree), field!.DeclaringType);
+    }
+
+    [Fact]
+    public void RequiredField_RaisesAShapeGapNamingTheMember_WhenTheFieldIsGone()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => InvokeRequiredField(typeof(ProviderWithoutPrimaryTree), "primaryTree"));
+
+        Assert.Contains(nameof(ProviderWithoutPrimaryTree), ex.Member, StringComparison.Ordinal);
+        Assert.Contains("primaryTree", ex.Member, StringComparison.Ordinal);
+        Assert.Contains("not found", ex.Detail, StringComparison.Ordinal);
+    }
+
+    private static FieldInfo? InvokeRequiredField(Type type, string member)
+    {
+        var t = typeof(RunnerOutOfScopeException).Assembly.GetType("AlRunner.Infrastructure.BcShape")
+            ?? throw new InvalidOperationException("test setup: AlRunner.Infrastructure.BcShape not found");
+        var m = t.GetMethod("RequiredField", BindingFlags.Public | BindingFlags.Static)
+            ?? throw new InvalidOperationException("test setup: BcShape.RequiredField not found");
+        try
+        {
+            return (FieldInfo?)m.Invoke(null, new object?[] { type, member, Surface, "probe detail" });
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            throw tie.InnerException;   // the reflection wrapper is not part of the contract
+        }
+    }
+
+    // ══ 3. AL cannot swallow it — [TryFunction] ═══════════════════════════════════════════
+
+    [Fact]
+    public void TryInvoke_TearsThrough_ForAShapeGap()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => BcRuntime.NavApplicationObjectBase_TryInvoke(null, () => throw Gap()));
+
+        Assert.Equal(Surface, ex.Surface);
+    }
+
+    [Fact]
+    public async Task TryInvokeAsync_TearsThrough_ForAShapeGap()
+    {
+        var ex = await Assert.ThrowsAsync<BcShapeGapException>(
+            async () => await BcRuntime.NavApplicationObjectBase_TryInvokeAsync(null, () => throw Gap()));
+
+        Assert.Equal(Surface, ex.Surface);
+    }
+
+    // Wrapped, because that is how it actually arrives: a refusal raised behind
+    // MethodBase.Invoke comes back inside a TargetInvocationException, and BC's own
+    // RemapToALExceptionAndThrow can rewrap it. TryInvoke's FIRST clause swallows a trappable
+    // NavBaseException, so the shape-gap question has to be asked before that one.
+    [Fact]
+    public void TryInvoke_TearsThrough_EvenWhenTheGapArrivesWrapped()
+    {
+        var ex = Record.Exception(() => BcRuntime.NavApplicationObjectBase_TryInvoke(
+            null, () => throw new TargetInvocationException(Gap())));
+
+        Assert.NotNull(ex);
+        Assert.NotNull(BcShapeGapException.Find(ex));
+    }
+
+    // ── CONTROL ARM: a genuinely permanent refusal is STILL trapped ──
+    // Without this, "tears through" could be satisfied by a TryInvoke that trapped nothing.
+    [Fact]
+    public void TryInvoke_StillTraps_APermanentRefusal()
+    {
+        Assert.False(BcRuntime.NavApplicationObjectBase_TryInvoke(null, () => throw PermanentOos()));
+    }
+
+    [Fact]
+    public async Task TryInvokeAsync_StillTraps_APermanentRefusal()
+    {
+        Assert.False(await BcRuntime.NavApplicationObjectBase_TryInvokeAsync(
+            null, () => throw PermanentOos()));
+    }
+
+    // ══ 4. AL cannot swallow it — asserterror ═════════════════════════════════════════════
+    //
+    // Derived, not copied from the OOS behaviour. `asserterror Foo()` where Foo hits a shape
+    // gap: on real BC, Foo runs and returns, so the asserterror FAILS ("expected an error").
+    // A runner that catches the gap makes that asserterror PASS — the opposite of BC's answer,
+    // and green. Swallowing does not merely hide a gap here, it inverts a result.
+
+    [Fact]
+    public void AssertError_TearsThrough_ForAShapeGap()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => BcRuntime.NavMethodScope_AssertError(null!, () => throw Gap()));
+
+        Assert.Equal(Surface, ex.Surface);
+    }
+
+    [Fact]
+    public void AssertError_TearsThrough_EvenWhenTheGapArrivesWrapped()
+    {
+        var ex = Record.Exception(() => BcRuntime.NavMethodScope_AssertError(
+            null!, () => throw new TargetInvocationException(Gap())));
+
+        Assert.NotNull(ex);
+        Assert.NotNull(BcShapeGapException.Find(ex));
+    }
+
+    // ── CONTROL ARM: asserterror still catches BOTH refusal flavours ──
+    // Returning normally IS the pass signal — NavMethodScope_AssertError throws
+    // NavNCLAssertErrorException when the body did not error. #2871 owns the question of
+    // whether that should change; this change does not touch it.
+    [Fact]
+    public void AssertError_StillCatches_BothRefusalFlavours()
+    {
+        BcRuntime.NavMethodScope_AssertError(null!, () => throw PermanentOos());
+        BcRuntime.NavMethodScope_AssertError(null!, () => throw NotYetImplemented());
+    }
+
+    // ── CONTROL ARM: asserterror still FAILS when the body does not throw ──
+    // Otherwise "tears through" could be satisfied by an asserterror that rethrows everything.
+    [Fact]
+    public void AssertError_StillFails_WhenTheBodyDoesNotThrow()
+    {
+        var ex = Record.Exception(() => BcRuntime.NavMethodScope_AssertError(null!, () => { }));
+
+        Assert.NotNull(ex);
+        Assert.Equal("Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLAssertErrorException",
+            ex!.GetType().FullName);
+    }
+
+    // ══ 5. The manifest may not absorb it ═════════════════════════════════════════════════
+
+    // AlRunner.TestOutcome (the runner's own) shadows AlRunner.Infrastructure.TestOutcome
+    // under `using AlRunner;`, so the manifest one is spelled out.
+    private static AlRunner.Infrastructure.TestOutcome Failed(Exception ex) =>
+        new("Codeunit", "Method", false, ex);
+
+    private static ExpectationEntry Entry(ExpectationMode mode, string? reason = null, string? issue = null) =>
+        new(CodeunitId: 60000,
+            CodeunitName: "Codeunit",
+            Method: "Method",
+            Mode: mode,
+            Reason: reason,
+            Issue: issue,
+            Doc: mode == ExpectationMode.ExpectDivergence ? "docs/limitations.md#x" : null,
+            Note: null,
+            SourceFile: "tests/expectations/known-gaps-probe.json");
+
+    [Fact]
+    public void ExpectOos_DoesNotAbsorbAShapeGap_AndSaysWhy()
+    {
+        var c = ExpectationClassifier.Classify(
+            Failed(Gap()), Entry(ExpectationMode.ExpectOos, reason: "email-smtp"));
+
+        Assert.Equal(ExpectationResult.FailManifestDrift, c.Result);
+        Assert.NotNull(c.Diagnostic);
+        // The message has to say what this actually is. The generic no-signal branch tells the
+        // author to "make the throw site raise RunnerOutOfScopeException", which is precisely
+        // the wrong advice for a BC-layout gap.
+        Assert.Contains(nameof(BcShapeGapException), c.Diagnostic!, StringComparison.Ordinal);
+        Assert.Contains("TempTableDataProvider.primaryTree", c.Diagnostic!, StringComparison.Ordinal);
+        Assert.DoesNotContain("make the throw site raise RunnerOutOfScopeException",
+            c.Diagnostic!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ExpectDivergence_DoesNotAbsorbAShapeGap()
+    {
+        var c = ExpectationClassifier.Classify(Failed(Gap()), Entry(ExpectationMode.ExpectDivergence));
+
+        Assert.Equal(ExpectationResult.FailManifestDrift, c.Result);
+        Assert.Contains(nameof(BcShapeGapException), c.Diagnostic!, StringComparison.Ordinal);
+    }
+
+    // With no entry at all it is a plain failure — NOT the "Unexpected out-of-scope … add an
+    // expect-oos entry" drift message, which would send the author to declare it expected.
+    [Fact]
+    public void NoEntry_IsAPlainFailure_NotAnUndeclaredOosSurface()
+    {
+        var c = ExpectationClassifier.Classify(Failed(Gap()), null);
+
+        Assert.Equal(ExpectationResult.Fail, c.Result);
+        Assert.Null(c.Diagnostic);
+    }
+
+    // expect-fail-known-gap DOES absorb it, deliberately: that mode means "must fail, and this
+    // open issue tracks the work", which is exactly what a shape gap is once written down.
+    [Fact]
+    public void ExpectFailKnownGap_StillAbsorbsAShapeGap()
+    {
+        var c = ExpectationClassifier.Classify(
+            Failed(Gap()), Entry(ExpectationMode.ExpectFailKnownGap, issue: "#2946"));
+
+        Assert.Equal(ExpectationResult.PassKnownGap, c.Result);
+    }
+
+    // ── CONTROL ARM: expect-oos still absorbs a real refusal ──
+    [Fact]
+    public void ExpectOos_StillAbsorbs_ARealPermanentRefusal()
+    {
+        var c = ExpectationClassifier.Classify(
+            Failed(PermanentOos()), Entry(ExpectationMode.ExpectOos, reason: "email-smtp"));
+
+        Assert.Equal(ExpectationResult.PassOos, c.Result);
+    }
+
+    // ══ 6. The reporter buckets it as itself ══════════════════════════════════════════════
+
+    [Fact]
+    public void Reporter_BucketsAShapeGapUnderItsOwnHeading_NotAnIncidentalBcStackFrame()
+    {
+        var ex = Gap();
+        var bucket = ClassifyTest(ex.Message, ex.ToString());
+
+        Assert.Equal($"bc-shape-gap/{Surface}", bucket);
+    }
+
+    // ── CONTROL ARM: real refusals and plain failures keep their buckets ──
+    [Fact]
+    public void Reporter_StillBucketsRefusalsAndPlainFailuresAsBefore()
+    {
+        var oos = PermanentOos();
+        Assert.Equal("out-of-scope/NavEmail.Send", ClassifyTest(oos.Message, oos.ToString()));
+
+        var boom = new InvalidOperationException("runner bug");
+        Assert.Equal("runtime/other", ClassifyTest(boom.Message, boom.ToString()));
+    }
+
+    private static string ClassifyTest(string message, string full)
+    {
+        var m = typeof(Reporter).GetMethod("ClassifyTest", BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("test setup: Reporter.ClassifyTest(string,string) not found");
+        return (string)m.Invoke(null, new object[] { message, full })!;
+    }
+
+    // ══ 7. The convention actually reached the readers ════════════════════════════════════
+    //
+    // The production readers, driven through their real entry points. Without these the type
+    // could exist and be perfectly specified while every reader kept raising what it did
+    // before — which is the state #2946 was filed about.
+
+    [Fact]
+    public void ObjectMetadataRowProbe_RaisesAShapeGap_WhenPrimaryTreeIsGone()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => ProviderHasAnyRow(new ProviderWithoutPrimaryTree()));
+
+        Assert.Equal(Surface, ex.Surface);
+        Assert.Contains("primaryTree", ex.Member, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ObjectMetadataRowProbe_RaisesAShapeGap_WhenPrimaryTreeCannotBeEnumerated()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => ProviderHasAnyRow(new ProviderWithNonEnumerablePrimaryTree()));
+
+        Assert.Contains("primaryTree", ex.Member, StringComparison.Ordinal);
+        Assert.Contains("cannot be enumerated", ex.Detail, StringComparison.Ordinal);
+    }
+
+    // ── CONTROL ARM: the reader still answers BC's genuine questions ──
+    // A fix that threw on every input would satisfy the two assertions above.
+    [Fact]
+    public void ObjectMetadataRowProbe_StillAnswers_ForAReadableStore()
+    {
+        Assert.False(ProviderHasAnyRow(new FakeProvider(null)));                       // BC's "no row ever inserted"
+        Assert.False(ProviderHasAnyRow(new FakeProvider(new List<object>())));
+        Assert.True(ProviderHasAnyRow(new FakeProvider(new List<object> { new() })));
+        Assert.True(ProviderHasAnyRow(new DerivedProvider(new List<object> { new() })));  // inherited field, #2725
+    }
+
+    [Fact]
+    public void RecordPatchesRequiredField_RaisesAShapeGap_NotAMissingFieldException()
+    {
+        var m = typeof(RecordPatches).GetMethod(
+            "RequiredField", BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("test setup: RecordPatches.RequiredField not found");
+
+        var ex = Record.Exception(() =>
+        {
+            try { m.Invoke(null, new object?[] { typeof(ProviderWithoutPrimaryTree), "primaryTree", "probe surface" }); }
+            catch (TargetInvocationException tie) when (tie.InnerException != null) { throw tie.InnerException; }
+        });
+
+        var gap = Assert.IsType<BcShapeGapException>(ex);
+        Assert.Contains("primaryTree", gap.Member, StringComparison.Ordinal);
+
+        // The positive arm: the SAME helper resolves an inherited private field, so the three
+        // readers that go through it agree with the two that use PrivateMemberLookup directly.
+        var found = (FieldInfo?)m.Invoke(null, new object?[] { typeof(DerivedProvider), "primaryTree", "probe surface" });
+        Assert.Equal(typeof(BaseDeclaresPrimaryTree), found!.DeclaringType);
+    }
+
+    // ── The source-shape guard: nobody may quietly go back to a third convention ──
+    // The five files that read TempTableDataProvider's private structure must not spell any
+    // of the three retired conventions at a primaryTree/table read. This is what stops the
+    // disagreement from reappearing one file at a time, which is how it arrived.
+    [Fact]
+    public void NoReaderOfThePrivateProviderStructure_StillRaisesARetiredType()
+    {
+        string[] files =
+        {
+            "RecordPatches.StoredTableCensus.cs",
+            "RecordPatches.TransactionSnapshot.cs",
+            "RecordPatches.InstallBaseline.cs",
+            "RecordPatches.ObjectMetadataSystemTable.cs",
+            "RowVersionPatches.SystemIdIntegrity.cs",
+        };
+
+        var offenders = new List<string>();
+        foreach (var file in files)
+        {
+            var path = Path.Combine(RepoRoot, "AlRunner", "Patches", file);
+            Assert.True(File.Exists(path), $"{file} not found at {path} — it was renamed or moved.");
+
+            foreach (var (line, n) in File.ReadLines(path).Select((l, i) => (l, i + 1)))
+            {
+                // Only THROW sites count; a comment or a catch clause naming the retired type
+                // is documentation, and RecordPatches.StoredTableCensus.cs legitimately catches
+                // the new type to keep its documented "unknown, never empty" contract.
+                if (!line.Contains("throw new MissingFieldException", StringComparison.Ordinal)) continue;
+                offenders.Add($"{file}:{n}");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "these sites still raise a retired convention for a BC-internals read: "
+            + string.Join(", ", offenders));
+    }
+
+    // The doc target a shape gap points at has to exist, or the message sends readers nowhere.
+    [Fact]
+    public void TheDocSectionTheMessagePointsAt_Exists()
+    {
+        var limitations = File.ReadAllText(Path.Combine(RepoRoot, "docs", "limitations.md"));
+
+        Assert.Contains("## BC shape gaps", limitations, StringComparison.OrdinalIgnoreCase);
+        // And scope.md must NOT claim them, since a shape gap is not a scope boundary.
+        var scope = File.ReadAllText(Path.Combine(RepoRoot, "docs", "scope.md"));
+        Assert.DoesNotContain("bc-shape-gap", scope, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ══ Reflected-shape fakes ═════════════════════════════════════════════════════════════
+
+    private static bool ProviderHasAnyRow(object provider)
+    {
+        var m = typeof(RecordPatches).GetMethod(
+            "ProviderHasAnyRow", BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("test setup: RecordPatches.ProviderHasAnyRow not found");
+        try
+        {
+            return (bool)m.Invoke(null, new[] { provider })!;
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            throw tie.InnerException;
+        }
+    }
+
+    private sealed class ProviderWithoutPrimaryTree
+    {
+    }
+
+#pragma warning disable CS0414   // assigned and read only by the reflection under test
+    private sealed class ProviderWithNonEnumerablePrimaryTree
+    {
+        private readonly object primaryTree = new();
+    }
+
+    private sealed class FakeProvider
+    {
+        private readonly IEnumerable? primaryTree;
+        public FakeProvider(IEnumerable? rows) => primaryTree = rows;
+    }
+
+    private class BaseDeclaresPrimaryTree
+    {
+        private readonly IEnumerable? primaryTree;
+        protected BaseDeclaresPrimaryTree(IEnumerable? rows) => primaryTree = rows;
+    }
+#pragma warning restore CS0414
+
+    private sealed class DerivedProvider : BaseDeclaresPrimaryTree
+    {
+        public DerivedProvider(IEnumerable? rows) : base(rows) { }
+    }
+}

--- a/AlRunner.Tests/ObjectMetadataProviderRowProbeTests.cs
+++ b/AlRunner.Tests/ObjectMetadataProviderRowProbeTests.cs
@@ -13,11 +13,12 @@
 //                                      silently shadow real --test-data rows, disabling the
 //                                      #2519 precedence rule with no diagnostic anywhere.
 //
-// Four sibling readers of the SAME private field already fail loud on the second case
-// (RecordPatches.StoredTableCensus.cs x2 and RecordPatches.TransactionSnapshot.cs /
-// RecordPatches.InstallBaseline.cs via RequiredField -> MissingFieldException;
-// RowVersionPatches.SystemIdIntegrity.cs via PrivateMemberLookup -> InvalidOperationException
-// naming the member). This one did not. See .claude/rules/loud-failures.md.
+// Four sibling readers of the SAME private field already failed loud on the second case, and
+// they did it with three different exception types between them — MissingFieldException via
+// RequiredField, an InvalidOperationException naming the member, and this file's own
+// RunnerOutOfScopeException. #2946 made all of them one: BcShapeGapException, which says the
+// thing none of the three said, that the runner could not READ BC's internals. See
+// AlRunner/Infrastructure/BcShapeGapException.cs and .claude/rules/loud-failures.md.
 //
 // WHY THESE LIVE HERE AND NOT IN THE UPSTREAM CORPUS
 //   The claim is about how the RUNNER reflects on a BC private field, not about anything AL
@@ -80,19 +81,20 @@ public sealed class ObjectMetadataProviderRowProbeTests
     [Fact]
     public void MissingPrimaryTreeField_ThrowsNamingTheFieldAndTheTable()
     {
-        var ex = Assert.Throws<RunnerOutOfScopeException>(
+        var ex = Assert.Throws<BcShapeGapException>(
             () => ProviderHasAnyRow(new ProviderWithoutPrimaryTree()));
 
         // Names the member that moved, so a BC layout change points at its own fix.
         Assert.Contains("primaryTree", ex.Message);
         Assert.Contains(nameof(ProviderWithoutPrimaryTree), ex.Message);
-        // Names the surface, and claims a gap rather than a scope boundary (#2894): this table
-        // IS in scope, so the anchor is "not-yet-implemented" and the doc link points at
-        // docs/limitations.md, which is where the table is written up.
-        Assert.Equal("Object Metadata (system table 2000000071)", ex.Api);
-        Assert.StartsWith("not-yet-implemented", ex.Reason);
-        Assert.Contains("object-metadata-system-table", ex.Reason);
-        Assert.EndsWith(" — see docs/limitations.md#object-metadata-system-table", ex.Message);
+        // Names the surface. #2894 moved this off the "permanently out of scope" claim; #2946
+        // moved it off RunnerOutOfScopeException entirely, because BOTH of that type's flavours
+        // are claims about scope and this one is a claim about the runner's ability to read
+        // BC's internals. BcShapeGapConventionTests holds the behavioural half of that
+        // (untrappable from AL, unabsorbable by an expect-oos entry).
+        Assert.Equal("Object Metadata (system table 2000000071)", ex.Surface);
+        Assert.StartsWith("bc-shape-gap: ", ex.Message, StringComparison.Ordinal);
+        Assert.EndsWith(" — see docs/limitations.md#bc-shape-gaps", ex.Message);
         // Says WHY it refuses rather than guessing, so the message is actionable.
         Assert.Contains("--test-data", ex.Message);
     }
@@ -102,13 +104,12 @@ public sealed class ObjectMetadataProviderRowProbeTests
     [Fact]
     public void NonEnumerablePrimaryTree_ThrowsNamingTheFieldAndTheTable()
     {
-        var ex = Assert.Throws<RunnerOutOfScopeException>(
+        var ex = Assert.Throws<BcShapeGapException>(
             () => ProviderHasAnyRow(new ProviderWithNonEnumerablePrimaryTree()));
 
         Assert.Contains("primaryTree", ex.Message);
-        Assert.Equal("Object Metadata (system table 2000000071)", ex.Api);
-        Assert.StartsWith("not-yet-implemented", ex.Reason);
-        Assert.Contains("object-metadata-system-table", ex.Reason);
+        Assert.Equal("Object Metadata (system table 2000000071)", ex.Surface);
+        Assert.Contains("cannot be enumerated", ex.Detail, StringComparison.Ordinal);
     }
 
     // ── The positive arms: BC's genuine answers still come back, unchanged ───────────
@@ -213,8 +214,8 @@ public sealed class ObjectMetadataProviderRowProbeTests
             rowsSynthesised++;
         }
 
-        Assert.Throws<RunnerOutOfScopeException>(() => RunObjectMetadataPopulateOnce(provider, Body));
-        Assert.Throws<RunnerOutOfScopeException>(() => RunObjectMetadataPopulateOnce(provider, Body));
+        Assert.Throws<BcShapeGapException>(() => RunObjectMetadataPopulateOnce(provider, Body));
+        Assert.Throws<BcShapeGapException>(() => RunObjectMetadataPopulateOnce(provider, Body));
 
         Assert.Equal(0, rowsSynthesised);
     }

--- a/AlRunner.Tests/ObjectMetadataSystemTableRefusalTests.cs
+++ b/AlRunner.Tests/ObjectMetadataSystemTableRefusalTests.cs
@@ -174,11 +174,15 @@ public sealed class ObjectMetadataSystemTableRefusalTests
         Assert.DoesNotContain("new RunnerOutOfScopeException(", code, StringComparison.Ordinal);
         Assert.DoesNotContain("docs/scope.md", code, StringComparison.Ordinal);
 
-        // 12 call sites + the factory declaration. A new refusal added without the factory
-        // would fail the two assertions above; this one catches a refusal being DELETED
-        // silently, which would mean a precondition went back to being read as a default.
-        var uses = src.Split("ObjectMetadataShapeGap(").Length - 1;
-        Assert.Equal(13, uses);
+        // TWELVE refusals, still, but they no longer all carry the same type (#2946). Ten go
+        // through ObjectMetadataShapeGap (10 call sites + the factory declaration = 11), and
+        // ProviderHasAnyRow's two go through BcShape, which raises BcShapeGapException: those
+        // two are the only sites in this file where the runner could not READ a BC internal,
+        // as opposed to reading one successfully and disliking the answer. The counts are
+        // asserted separately so a refusal deleted from either group is still caught — a
+        // deletion would mean a precondition went back to being read as a default.
+        Assert.Equal(11, src.Split("ObjectMetadataShapeGap(").Length - 1);
+        Assert.Equal(2, src.Split("BcShape.").Length - 1);
     }
 
     // ── The mechanism: a docAnchor may name its own doc file (backward compatible) ───────

--- a/AlRunner.Tests/RowVersionPatchesTests.cs
+++ b/AlRunner.Tests/RowVersionPatchesTests.cs
@@ -316,7 +316,12 @@ public sealed class RowVersionPatchesTests
         var metaTable = new FakeMetaTable(timestampField: null, systemIdField: new FakeMetaField(0));
         var buffer = new FakeBuffer(metaTable, slotCount: 1) { [0] = NavGuid.NewGuid() };
 
-        var ex = Assert.Throws<InvalidOperationException>(
+        // BcShapeGapException, not InvalidOperationException, since #2946: this is the runner
+        // failing to read a BC internal, and it has to tear through AL's asserterror as well as
+        // through a [TryFunction]. An InvalidOperationException is caught by asserterror, which
+        // would make `asserterror <insert>` pass where real BC's insert succeeds and the
+        // asserterror fails. See AlRunner.Tests/BcShapeGapConventionTests.cs.
+        var ex = Assert.Throws<AlRunner.Infrastructure.BcShapeGapException>(
             () => RowVersionPatches.OnBeforeInsert(provider, CompanyToken, buffer));
 
         Assert.Contains("primaryTree", ex.Message);
@@ -336,7 +341,7 @@ public sealed class RowVersionPatchesTests
         var metaTable = new FakeMetaTable(timestampField: null, systemIdField: new FakeMetaField(0));
         var buffer = new FakeBuffer(metaTable, slotCount: 1) { [0] = NavGuid.NewGuid() };
 
-        var ex = Assert.Throws<InvalidOperationException>(
+        var ex = Assert.Throws<AlRunner.Infrastructure.BcShapeGapException>(
             () => RowVersionPatches.OnBeforeInsert(provider, CompanyToken, buffer));
 
         Assert.Contains("primaryTree", ex.Message);

--- a/AlRunner/Infrastructure/BcShapeGapException.cs
+++ b/AlRunner/Infrastructure/BcShapeGapException.cs
@@ -1,0 +1,209 @@
+// BcShapeGapException — the runner could not READ BC's own internals here (#2946).
+//
+// ── THE THIRD CASE ───────────────────────────────────────────────────────────────────────
+// Before this type the runner had two ways to say "AL touched something I cannot do", and
+// both of them are claims about SCOPE:
+//
+//   RunnerOutOfScopeException, reason = a docs/scope.md anchor
+//       PERMANENTLY out of scope. SMTP, HTTP egress, printing. BC itself, in an environment
+//       that also lacks the surface, raises a trappable error — so an AL [TryFunction]
+//       reading `false` reproduces the observable BC outcome. Trapping it is FAITHFUL.
+//
+//   RunnerOutOfScopeException, reason = "not-yet-implemented — ..."
+//       IN scope, not built yet. BC answers on a service tier and the runner does not, so
+//       trapping it would turn a runner gap into a green test that lies. It tears through.
+//
+// Neither fits the thing most reflection guards under AlRunner/Patches/ actually mean: the
+// surface is in scope AND implemented, but BC's own internals are not the shape the code
+// reflecting on them was written against. A private field that moved, a static that was
+// renamed, a member whose value is a type the runner cannot interpret. That is a BUG REPORT
+// ABOUT THE RUNNER against a specific BC build — not a statement about scope at all.
+//
+// ── WHERE IT APPLIES, AND WHERE IT DOES NOT ──────────────────────────────────────────────
+// The line is whether the runner OBTAINED the information:
+//
+//   RAISE THIS       the read could not be performed. The type/field/property is absent, or
+//                    it is present and holds something of a shape the runner cannot use.
+//                    "TempTableDataProvider.primaryTree not found."
+//                    "primaryTree holds a Dictionary`2, which cannot be enumerated."
+//
+//   DO NOT RAISE IT  the read SUCCEEDED and the answer was merely unwelcome. BC's list came
+//                    back empty; a metatable genuinely has no field 3; a skeleton singleton
+//                    the RUNNER populates is null; the runner's own store wiring handed no
+//                    provider over. Those are answers, and they are answers about the
+//                    runner's or the artifact's state, not about BC's layout. They stay
+//                    "not-yet-implemented" — see RecordPatches.VirtualTableShapeGap.cs and
+//                    RecordPatches.ObjectMetadataSystemTable.cs for the per-site tables.
+//
+// ── WHY A NEW TYPE RATHER THAN A NEW REASON ANCHOR ───────────────────────────────────────
+// The obvious cheaper move is a third anchor on RunnerOutOfScopeException. It was rejected
+// for two independent reasons, and the first one is a defect that has already shipped:
+//
+//   1. Anchor classification is a STRING PREFIX test, and prefixes get mis-spelled silently.
+//      ApplicationObjectBasePatches.IsPermanentOutOfScope decides whether an AL [TryFunction]
+//      may swallow a refusal with
+//          !oos.Reason.StartsWith("not-yet-implemented", StringComparison.Ordinal)
+//      and RecordPatches.QueryProjection.cs's "query-join-synthesized-subquery-not-implemented"
+//      says not-implemented in words while not STARTING with the token — so a [TryFunction]
+//      swallows it today (measured, #2966). A second prefix would be a second chance to make
+//      that mistake. A type is checked by the compiler and by `is`, not by spelling.
+//
+//   2. Anything carrying a RunnerOutOfScopeException can be ABSORBED BY AN `expect-oos`
+//      MANIFEST ENTRY. OutOfScopeMessage.FromException finds the typed exception anywhere in
+//      the inner chain, hands it to ExpectationClassifier, and an entry whose Reason anchor
+//      matches turns the failure into PassOos. A BC-layout regression must never be
+//      declarable as an expected out-of-scope surface: it is not a property of the runner at
+//      all, it is a property of which BC build is on disk, so it can be true on the BC 28.4
+//      leg and false on 27.5 in the same run. Issue #2946 named this as the argument FOR
+//      MissingFieldException, which cannot be absorbed — and the argument against
+//      MissingFieldException was that it carries no Api/Reason pair to bucket on. This type
+//      takes both halves: unabsorbable AND structured.
+//
+// RunnerOutOfScopeException is `sealed`, so this is deliberately NOT a subclass of it — and
+// unsealing it would immediately hand back defect (2), since FromException walks for the base
+// type. It derives from System.Exception directly.
+//
+// ── WHAT AL CAN DO WITH IT: NOTHING ──────────────────────────────────────────────────────
+// It tears through BOTH of AL's error-trapping seams, which is what makes it different from
+// either RunnerOutOfScopeException flavour:
+//
+//                              [TryFunction]        asserterror
+//   permanent OOS              traps -> false       catches -> passes
+//   not-yet-implemented        tears through        catches -> passes   (#2871 tracks this)
+//   BC shape gap (this type)   tears through        tears through
+//
+// The asserterror column is derived, not copied. `asserterror Foo()` where Foo hits a shape
+// gap: on real BC, Foo runs and returns, so the asserterror FAILS ("expected an error"). If
+// the runner catches the gap, the asserterror PASSES — the opposite of BC's answer, and
+// green. Swallowing it does not merely hide a gap, it inverts a result. Nothing relied on
+// the old behaviour for this type because the type is new, so this is the contract from the
+// start rather than a change to an existing one; #2871 remains open for the middle row,
+// which IS an existing contract and a maintainer decision.
+//
+// ── CLASSIFICATION ───────────────────────────────────────────────────────────────────────
+// ExpectationClassifier may NOT absorb one into `expect-oos` (that mode declares a permanent
+// scope boundary) nor into `expect-divergence` (that mode declares an answer the runner gives
+// on purpose). Both refuse it explicitly, naming the type, instead of falling through to a
+// message that would tell the author to go and raise RunnerOutOfScopeException instead.
+// `expect-fail-known-gap` still absorbs it, and that is correct: that mode means "must fail,
+// and this open issue tracks the work", which is exactly what a shape gap is once someone has
+// written it down.
+//
+// See also:
+//   .claude/rules/loud-failures.md         — no silent out-of-scope failures
+//   .claude/rules/precompiled-dll-respect.md — why the runner reflects on BC internals at all
+//   docs/limitations.md#bc-shape-gaps      — the reader-facing write-up
+
+using System;
+using System.Collections;
+using System.Reflection;
+
+namespace AlRunner.Infrastructure;
+
+/// <summary>
+/// Raised when the runner cannot READ a BC internal it reflects on — the member is absent,
+/// or present and holding something the runner cannot interpret. See this file's header for
+/// the line between this and <see cref="RunnerOutOfScopeException"/>, and for why it is a
+/// separate type rather than a third reason anchor.
+/// </summary>
+public sealed class BcShapeGapException : Exception
+{
+    /// <summary>
+    /// Message prefix marking a shape gap. Deliberately NOT
+    /// <see cref="OutOfScopeMessage.Prefix"/>: <c>OutOfScopeMessage.TryParse</c> matches that
+    /// prefix ANYWHERE in a text blob, so a shape-gap message containing it would be recovered
+    /// as an out-of-scope signal by the reporter and by the expectations manifest — the exact
+    /// absorption this type exists to prevent.
+    /// </summary>
+    public const string Prefix = "bc-shape-gap: ";
+
+    /// <summary>Where a reader should look. Not <c>docs/scope.md</c>: a shape gap is not a scope claim.</summary>
+    public const string DefaultDoc = "docs/limitations.md#bc-shape-gaps";
+
+    /// <summary>The AL-visible surface that was being served, e.g. "Object Metadata (system table 2000000071)".</summary>
+    public string Surface { get; }
+
+    /// <summary>The BC internal that could not be read, e.g. "TempTableDataProvider.primaryTree".</summary>
+    public string Member { get; }
+
+    /// <summary>What went wrong and what it costs — the actionable half.</summary>
+    public string Detail { get; }
+
+    /// <summary>Doc target rendered into the message.</summary>
+    public string DocLink { get; }
+
+    public BcShapeGapException(string surface, string member, string detail, string? docLink = null)
+        : base(BuildMessage(surface, member, detail, docLink ?? DefaultDoc))
+    {
+        Surface = surface;
+        Member = member;
+        Detail = detail;
+        DocLink = docLink ?? DefaultDoc;
+    }
+
+    // Stable contract format, same em-dash separators as the out-of-scope convention so a
+    // reader parses both the same way:
+    //     bc-shape-gap: <surface> — <member>: <detail> — see <doc>
+    private static string BuildMessage(string surface, string member, string detail, string docLink)
+        => $"{Prefix}{surface} — {member}: {detail} — see {docLink}";
+
+    /// <summary>
+    /// The shape gap anywhere in <paramref name="ex"/>'s inner-exception chain, else null.
+    ///
+    /// <para>A chain walk, not an <c>is</c> test, and the difference is load-bearing at the
+    /// two trap sites. A refusal raised behind <see cref="MethodBase.Invoke(object, object[])"/>
+    /// arrives wrapped in a <see cref="TargetInvocationException"/>, and BC's own
+    /// <c>RemapToALExceptionAndThrow</c> can rewrap it as a NavBaseException — which
+    /// <c>NavApplicationObjectBase_TryInvoke</c> swallows on its FIRST clause. So both traps
+    /// ask this question before they ask any other one.</para>
+    /// </summary>
+    public static BcShapeGapException? Find(Exception? ex)
+    {
+        const int MaxDepth = 16;   // guard against self-referential inner chains
+        var e = ex;
+        for (var d = 0; e != null && d < MaxDepth; d++, e = e.InnerException)
+        {
+            if (e is BcShapeGapException gap) return gap;
+            if (e is AggregateException agg)
+                foreach (var inner in agg.InnerExceptions)
+                    if (inner is not null && !ReferenceEquals(inner, e) && Find(inner) is { } nested)
+                        return nested;
+        }
+        return null;
+    }
+}
+
+/// <summary>
+/// Reflection reads of BC internals that must not answer a default. Keeps the throw sites
+/// short and, more to the point, keeps them ONE type — before #2946 four readers of the same
+/// private <c>TempTableDataProvider</c> structure raised three different exception types
+/// between them, so what a caller could catch depended on which reader it happened to reach.
+/// </summary>
+internal static class BcShape
+{
+    /// <summary>
+    /// The private instance field <paramref name="member"/> declared on <paramref name="type"/>
+    /// or any base, or a <see cref="BcShapeGapException"/> naming it.
+    ///
+    /// <para>Resolution goes through <see cref="PrivateMemberLookup"/>, never a plain
+    /// <c>GetField(NonPublic)</c>: that does not return a BASE class's private field, and BC's
+    /// own <c>CrmTableConnection.CrmTestDataProvider</c> — the provider behind the
+    /// <c>'@@test@@'</c> CRM test connection — derives from <c>TempTableDataProvider</c>
+    /// (#2725). Reading a derived provider's inherited field as "absent" would turn a
+    /// perfectly readable store into a hard failure now that absence refuses.</para>
+    /// </summary>
+    public static FieldInfo RequiredField(Type type, string member, string surface, string detail)
+        => PrivateMemberLookup.Field(type, member)
+           ?? throw new BcShapeGapException(surface, $"{type.Name}.{member}", $"field not found — {detail}");
+
+    /// <summary>
+    /// <paramref name="value"/> as an <see cref="IEnumerable"/>, or a
+    /// <see cref="BcShapeGapException"/> naming what it actually held. A member that exists
+    /// but holds an uninterpretable shape is the same "BC's layout moved" case as an absent
+    /// one, and folding it into the absent/null branch is how #2786's silent skip happened.
+    /// </summary>
+    public static IEnumerable RequiredEnumerable(object value, string member, string surface, string detail)
+        => value as IEnumerable
+           ?? throw new BcShapeGapException(
+               surface, member, $"holds a {value.GetType().Name}, which cannot be enumerated — {detail}");
+}

--- a/AlRunner/Infrastructure/ExpectationManifest.cs
+++ b/AlRunner/Infrastructure/ExpectationManifest.cs
@@ -278,6 +278,17 @@ public static class ExpectationClassifier
         // an OOS signal and must never be absorbed as one.
         var signal = outcome.Passed ? null : OutOfScopeMessage.FromException(outcome.Exception);
 
+        // A BC shape gap is NOT an out-of-scope signal and must never be absorbed as one
+        // (#2946). It says the runner could not READ BC's internals — a property of which BC
+        // build is on disk, not of the runner — so it can be true on one BC leg and false on
+        // another in the same run, and "expected" is never an honest thing to call it.
+        // Structurally it is already unabsorbable: it is not a RunnerOutOfScopeException and
+        // its message does not carry the out-of-scope prefix, so `signal` is null above. What
+        // is added here is the DIAGNOSTIC — without it, an expect-oos entry lands in the
+        // no-signal branch below, whose advice ("make the throw site raise
+        // RunnerOutOfScopeException") is exactly wrong for a layout gap.
+        var shapeGap = outcome.Passed ? null : BcShapeGapException.Find(outcome.Exception);
+
         if (entry == null)
         {
             // No manifest entry — normal pass/fail. Unexpected OOS surfaces as a
@@ -298,6 +309,14 @@ public static class ExpectationClassifier
                 return new Classification(ExpectationResult.Skipped, null);
 
             case ExpectationMode.ExpectOos:
+                if (shapeGap != null)
+                    return new Classification(
+                        ExpectationResult.FailManifestDrift,
+                        $"Manifest declares expect-oos (reason: {entry.Reason}) but the runner raised a "
+                        + $"{nameof(BcShapeGapException)}: {shapeGap.Surface} — {shapeGap.Member}. "
+                        + "That is not a scope boundary, it is the runner failing to read BC's internals "
+                        + "on this build, so it must not be declared expected. Fix the reflection target, "
+                        + $"or declare it expect-fail-known-gap in {entry.SourceFile} with an open issue.");
                 if (outcome.Passed)
                     return new Classification(
                         ExpectationResult.FailManifestDrift,
@@ -341,6 +360,14 @@ public static class ExpectationClassifier
                 // out-of-scope throw is a different claim with its own mode, and
                 // conflating them would let expect-divergence quietly absorb new OOS
                 // surfaces that expect-oos is supposed to declare.
+                if (shapeGap != null)
+                    return new Classification(
+                        ExpectationResult.FailManifestDrift,
+                        $"Manifest declares expect-divergence (reason: {entry.Reason}) but the runner raised "
+                        + $"a {nameof(BcShapeGapException)}: {shapeGap.Surface} — {shapeGap.Member}. A "
+                        + "divergence is an answer the runner gives on purpose; a shape gap is no answer at "
+                        + $"all. Fix the reflection target, or declare it expect-fail-known-gap in "
+                        + $"{entry.SourceFile} with an open issue.");
                 if (signal is { } divergedButOos)
                     return new Classification(
                         ExpectationResult.FailManifestDrift,

--- a/AlRunner/Patches/ApplicationObjectBasePatches.cs
+++ b/AlRunner/Patches/ApplicationObjectBasePatches.cs
@@ -185,6 +185,10 @@ public static partial class BcRuntime
         }
         catch (Exception ex)
         {
+            // FIRST, before the NavBaseException clause below: a BC shape gap is never
+            // trappable, and BC's own RemapToALExceptionAndThrow can hand it back wrapped in a
+            // NavBaseException that the next clause would swallow. See BcShapeGapException.cs.
+            if (AlRunner.Infrastructure.BcShapeGapException.Find(ex) != null) throw;
             // Rethrow untrappable errors; swallow trappable NavBaseExceptions.
             if (ex is Microsoft.Dynamics.Nav.Types.Exceptions.NavBaseException nbe && !nbe.UntrappableError)
                 return false;
@@ -205,6 +209,16 @@ public static partial class BcRuntime
     /// it reproduces the observable BC outcome. A "not-yet-implemented" surface is the
     /// opposite — it is a runner gap, and swallowing it would turn the gap into a green
     /// test that lies (see .claude/rules/loud-failures.md), so it keeps propagating.
+    ///
+    /// <para>THERE IS A THIRD CASE AND IT IS NOT HANDLED HERE, deliberately (#2946).
+    /// <see cref="AlRunner.Infrastructure.BcShapeGapException"/> — "the runner could not read
+    /// BC's internals" — is not a RunnerOutOfScopeException at all, so it can never reach this
+    /// method's `true` branch however the reason string is spelled. That is the point of it
+    /// being a type: this classification is a STRING PREFIX test, and a prefix gets mis-spelled
+    /// silently (RecordPatches.QueryProjection.cs's
+    /// "query-join-synthesized-subquery-not-implemented" says not-implemented in words while
+    /// not STARTING with the token, so a [TryFunction] swallows it today — #2966). The callers
+    /// above ask <c>BcShapeGapException.Find</c> before anything else instead.</para>
     /// </summary>
     private static bool IsPermanentOutOfScope(Exception ex, out AlRunner.Infrastructure.RunnerOutOfScopeException? oos)
     {
@@ -250,6 +264,8 @@ public static partial class BcRuntime
         }
         catch (Exception ex)
         {
+            // Same ordering as TryInvoke, and for the same reason — see there.
+            if (AlRunner.Infrastructure.BcShapeGapException.Find(ex) != null) throw;
             if (ex is Microsoft.Dynamics.Nav.Types.Exceptions.NavBaseException nbe && !nbe.UntrappableError)
                 return new System.Threading.Tasks.ValueTask<bool>(false);
             // Same permanent-OOS trap as TryInvoke — see IsPermanentOutOfScope.

--- a/AlRunner/Patches/MethodScopePatches.cs
+++ b/AlRunner/Patches/MethodScopePatches.cs
@@ -386,6 +386,30 @@ public static partial class BcRuntime
     public static void NavMethodScope_AssertError(object self, Action body)
     {
         try { body(); }
+        catch (AlRunner.Infrastructure.BcShapeGapException)
+        {
+            // NOT catchable, unlike every other exception this replacement traps (#2946).
+            //
+            // Derived, not copied from the out-of-scope behaviour. `asserterror Foo()` where
+            // Foo hits a BC shape gap: on real BC, Foo runs and returns, so the asserterror
+            // FAILS ("expected an error"). If the runner catches the gap the asserterror
+            // PASSES — the opposite of BC's answer, and green. Swallowing here does not merely
+            // hide a runner gap, it inverts a result.
+            //
+            // This is a NEW contract for a NEW type, not a change to an existing one. Whether
+            // AL should be able to swallow a RunnerOutOfScopeException is a separate, live
+            // question (#2871) that runner-extras suites deliberately rely on today
+            // (tests/runner-extras/table-connection-live-oos, date-virtual-table-window), and
+            // it is untouched — AssertErrorOutOfScopeCatchabilityTests still pins it.
+            throw;
+        }
+        catch (Exception ex) when (AlRunner.Infrastructure.BcShapeGapException.Find(ex) != null)
+        {
+            // Same claim, arriving wrapped: a refusal raised behind MethodBase.Invoke comes
+            // back inside a TargetInvocationException, and BC's own RemapToALExceptionAndThrow
+            // (invoked below) can rewrap it too. An `is` test would miss both.
+            throw;
+        }
         catch (Exception ex)
         {
             // Real BC's own AssertError body (decompiled) is:

--- a/AlRunner/Patches/RecordPatches.InstallBaseline.cs
+++ b/AlRunner/Patches/RecordPatches.InstallBaseline.cs
@@ -255,15 +255,20 @@ public static partial class RecordPatches
                         + "boundary. See docs/scope.md");
 
                 var providerType = provider.GetType();
-                var metaTable = RequiredField(providerType, "table").GetValue(provider)
+                var metaTable = RequiredField(providerType, "table", InstallBaselineSurface).GetValue(provider)
                     ?? throw new InvalidOperationException("TempTableDataProvider.table is null");
                 // A null primaryTree is simply "no rows were ever inserted into this table" —
                 // nothing to snapshot, and the restore starts from an empty store anyway.
-                var primaryTreeValue = RequiredField(providerType, "primaryTree").GetValue(provider);
+                var primaryTreeValue = RequiredField(providerType, "primaryTree", InstallBaselineSurface)
+                    .GetValue(provider);
                 if (primaryTreeValue == null)
                     continue;
-                if (primaryTreeValue is not IEnumerable primaryTree)
-                    throw new InvalidOperationException("TempTableDataProvider.primaryTree is not enumerable");
+                // Present but uninterpretable is the SAME "BC's layout moved" case as absent —
+                // #2946 gave it the same type rather than a second convention.
+                var primaryTree = AlRunner.Infrastructure.BcShape.RequiredEnumerable(
+                    primaryTreeValue, $"{providerType.Name}.primaryTree", InstallBaselineSurface,
+                    $"the install baseline for table {tableId} cannot be captured, so its "
+                    + "install-seeded rows would silently vanish at the next codeunit boundary");
 
                 var rows = new List<NavValue[]>();
                 foreach (var row in primaryTree)
@@ -424,9 +429,50 @@ public static partial class RecordPatches
         .GetProperty("DataProvider", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
         ?.GetValue(dataAccess);
 
-    private static FieldInfo RequiredField(Type type, string name) => type
-        .GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)
-        ?? throw new MissingFieldException(type.FullName, name);
+    /// <summary>
+    /// A private instance field of BC's in-memory provider that the runner must be able to
+    /// read, or a <see cref="AlRunner.Infrastructure.BcShapeGapException"/> naming it.
+    ///
+    /// <para>TWO THINGS CHANGED HERE UNDER #2946, both of them defects rather than polish.</para>
+    ///
+    /// <para>The exception TYPE. This helper used to raise
+    /// <see cref="MissingFieldException"/> while RowVersionPatches.SystemIdIntegrity.cs threw
+    /// an <see cref="InvalidOperationException"/> and
+    /// RecordPatches.ObjectMetadataSystemTable.cs raised a
+    /// <see cref="AlRunner.Infrastructure.RunnerOutOfScopeException"/> — three conventions for
+    /// one private structure, so what a caller could catch depended on which reader it reached.
+    /// None of the three said the true thing, which is that the runner could not READ BC's
+    /// internals; the two RunnerOutOfScopeException flavours are both claims about SCOPE, and
+    /// this surface is in scope and implemented. See
+    /// AlRunner/Infrastructure/BcShapeGapException.cs for the whole derivation.</para>
+    ///
+    /// <para>The RESOLUTION. <c>GetField(NonPublic)</c> does not return a BASE class's private
+    /// field, and BC's own <c>CrmTableConnection.CrmTestDataProvider</c> derives from
+    /// <c>TempTableDataProvider</c> (#2725) — so this helper called an inherited, perfectly
+    /// readable field absent, exactly the bug <see cref="PrivateMemberLookup"/> was written to
+    /// fix and which the two readers that use it directly do not have. Today a
+    /// <c>GetType().Name != "TempTableDataProvider"</c> gate upstream of every caller means no
+    /// derived provider reaches here, so the old resolution was not observably wrong; it was
+    /// wrong the moment that gate moved, and it made "the four readers agree" false in a way a
+    /// reader had to check three files to notice.</para>
+    /// </summary>
+    private static FieldInfo RequiredField(Type type, string name, string surface = ProviderStoreSurface)
+        => AlRunner.Infrastructure.BcShape.RequiredField(
+            type, name, surface,
+            "the runner reflects on BC's in-memory provider to read this table's stored rows, "
+            + "and cannot tell an empty store from an unreadable one without it");
+
+    /// <summary>
+    /// Default surface name for a refusal raised while reading BC's in-memory provider. Callers
+    /// that serve a narrower AL-visible operation (a rollback, a SystemId check) pass their own.
+    /// </summary>
+    internal const string ProviderStoreSurface = "in-memory table store (TempTableDataProvider)";
+
+    /// <summary>Surface name for the per-codeunit install-baseline capture/restore.</summary>
+    private const string InstallBaselineSurface = "install-baseline snapshot";
+
+    /// <summary>Surface name for the AL write-transaction rollback (see RecordPatches.TransactionSnapshot.cs).</summary>
+    internal const string TransactionRollbackSurface = "AL write-transaction rollback";
 
     private static NavValue[] CloneValues(NavValue[] values)
     {

--- a/AlRunner/Patches/RecordPatches.ObjectMetadataSystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.ObjectMetadataSystemTable.cs
@@ -166,9 +166,23 @@
 //          0 is BC's own answer and is kept (see the columns section). A null Instance has no
 //          answer at all, and this is the third primary-key field.
 //      10. EmitVersion property not found       -> (2) unsupported BC assembly shape
-//     ProviderHasAnyRow (both added by #2837, same classification)
-//      11. primaryTree field not found          -> (2) BC's private provider layout moved
-//      12. primaryTree is not enumerable        -> (2) same
+//     ProviderHasAnyRow (both added by #2837)
+//      11. primaryTree field not found          -> (4) BC's private provider layout moved
+//      12. primaryTree is not enumerable        -> (4) same
+//
+//   BUCKET (4), ADDED BY #2946: the runner could not READ BC's internals. These two are the
+//   only sites in this file in it, and they raise BcShapeGapException rather than
+//   RunnerOutOfScopeException — see AlRunner/Infrastructure/BcShapeGapException.cs. The line
+//   is whether the runner obtained the information at all. Sites 2, 3, 8 and 10 are the same
+//   family (a BC type or member that is not there) and are NOT converted here, because
+//   reclassifying them one at a time across this file and the 48 sites in
+//   RecordPatches.VirtualTableShapeGap.cs is a per-site sweep with its own issue; #2946 is the
+//   type convention, and this file's two primaryTree readers are the defect it names.
+//   Sites 1, 4, 5, 6, 7 and 9 stay in bucket (2) on purpose and would be WRONG in (4): each of
+//   those reads SUCCEEDED and the answer was merely unwelcome — BC's list came back empty, the
+//   artifact genuinely has no field 3, a skeleton singleton the RUNNER populates is null, the
+//   runner's own store wiring handed no provider over. An unwelcome answer is not an
+//   unreadable one.
 //
 //   The same "; see docs/scope.md" wording sits on the equivalent provider-null guard in
 //   roughly fifteen sibling virtual-table populators in this directory (AllObj, Integer,
@@ -475,47 +489,47 @@ public static partial class RecordPatches
     /// restructured it and the runner has no idea what the store holds; answering FALSE there
     /// would silently shadow whatever --test-data restored into this table, disabling the
     /// precedence rule in this file's header with no diagnostic anywhere. It used to do
-    /// exactly that. Now it refuses, naming the member, the way every sibling reader of this
-    /// same private field already does: RecordPatches.StoredTableCensus.cs (twice),
-    /// RecordPatches.TransactionSnapshot.cs and RecordPatches.InstallBaseline.cs all go
-    /// through <c>RequiredField</c>, which throws <see cref="MissingFieldException"/>, and
-    /// RowVersionPatches.SystemIdIntegrity.cs throws naming the member. See
-    /// .claude/rules/loud-failures.md.</para>
+    /// exactly that. Now it refuses, naming the member. See .claude/rules/loud-failures.md.</para>
     ///
-    /// <para>A refusal here is a BUG REPORT ABOUT THE RUNNER, not a permanent scope
-    /// boundary — but <see cref="RunnerOutOfScopeException"/> is what this whole file already
-    /// raises when a BC surface it reflects on is not where it expects (SystemTables,
-    /// NavEnvironment, the "Object Type" option string), and it carries the typed
-    /// <c>Api</c>/<c>Reason</c> pair the expectations manifest matches on. Same choice here.
-    /// It is NOT proof against AL swallowing it — <c>asserterror</c> is
-    /// MethodScopePatches.NavMethodScope_AssertError, an unfiltered <c>catch (Exception ex)</c>
-    /// — which is exactly why <see cref="RunObjectMetadataPopulateOnce"/> has to remember a
-    /// refusal instead of leaving the table marked populated and empty.</para>
+    /// <para>THE TYPE IS <see cref="BcShapeGapException"/>, NOT
+    /// <see cref="RunnerOutOfScopeException"/> (#2946). Both of these two refusals are BUG
+    /// REPORTS ABOUT THE RUNNER rather than scope boundaries, and this file used to say so in a
+    /// comment and then raise the scope exception anyway — which is the disagreement #2946 was
+    /// filed about: four readers of this same private structure raised three different types
+    /// between them. Two consequences follow the type rather than the wording. A shape gap can
+    /// never be absorbed by an <c>expect-oos</c> manifest entry, so a BC-layout regression
+    /// cannot be declared expected — it is a property of which BC build is on disk, not of the
+    /// runner, so it can be true on one BC leg and false on another in the same run. And it
+    /// tears through AL's <c>asserterror</c> as well as through a <c>[TryFunction]</c>, which a
+    /// <see cref="RunnerOutOfScopeException"/> does not: <c>asserterror</c> is
+    /// MethodScopePatches.NavMethodScope_AssertError, and on real BC this record-open SUCCEEDS,
+    /// so catching the gap would make an <c>asserterror</c> around it pass where BC fails it.
+    /// <see cref="RunObjectMetadataPopulateOnce"/> still remembers a refusal, because the other
+    /// ten throw sites in this file remain catchable.</para>
     ///
-    /// <para>Resolution goes through <see cref="PrivateMemberLookup"/> rather than a plain
-    /// <c>GetField</c>, because <c>primaryTree</c> is PRIVATE on <c>TempTableDataProvider</c>
-    /// and <c>GetField(NonPublic)</c> on a DERIVED type does not return a base class's private
+    /// <para>Resolution goes through <see cref="BcShape"/>, which uses
+    /// <see cref="PrivateMemberLookup"/> rather than a plain <c>GetField</c>, because
+    /// <c>primaryTree</c> is PRIVATE on <c>TempTableDataProvider</c> and
+    /// <c>GetField(NonPublic)</c> on a DERIVED type does not return a base class's private
     /// fields — BC's own <c>CrmTableConnection.CrmTestDataProvider</c> derives from it (#2725).
     /// Reading a derived provider's inherited field as "absent" would turn a perfectly readable
     /// store into a hard failure now that absence refuses.</para>
     /// </summary>
     private static bool ProviderHasAnyRow(object provider)
     {
-        var field = PrivateMemberLookup.Field(provider.GetType(), "primaryTree")
-            ?? throw ObjectMetadataShapeGap(
-                $"{provider.GetType().Name}.primaryTree not found, so the runner cannot tell a store BC "
-                + "never inserted into from one --test-data already filled; synthesising rows would "
-                + "silently shadow the restored ones. BC's private provider layout moved");
+        const string detail =
+            "the runner cannot tell a store BC never inserted into from one --test-data already "
+            + "filled, and synthesising rows would silently shadow the restored ones";
+
+        var field = BcShape.RequiredField(
+            provider.GetType(), "primaryTree", ObjectMetadataApi, detail);
 
         // A null tree is BC's own "no row was ever inserted": nothing to shadow, synthesise.
         var tree = field.GetValue(provider);
         if (tree == null) return false;
 
-        if (tree is not IEnumerable rows)
-            throw ObjectMetadataShapeGap(
-                $"{provider.GetType().Name}.primaryTree is a {tree.GetType().Name}, which cannot be "
-                + "enumerated, so the runner cannot tell whether --test-data already filled this table. "
-                + "BC's private provider layout moved");
+        var rows = BcShape.RequiredEnumerable(
+            tree, $"{provider.GetType().Name}.primaryTree", ObjectMetadataApi, detail);
 
         // Short-circuit: one row is the whole answer, and a restored backup can be large.
         foreach (var _ in rows) return true;

--- a/AlRunner/Patches/RecordPatches.StoredTableCensus.cs
+++ b/AlRunner/Patches/RecordPatches.StoredTableCensus.cs
@@ -23,6 +23,9 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
+    /// <summary>Surface name a census refusal would carry, if the census ever let one out.</summary>
+    private const string CensusSurface = "stored-table census (diagnostic)";
+
     /// <summary>What the store knows about one table right now.</summary>
     /// <param name="TableId">AL table id.</param>
     /// <param name="TableName">The AL object name BC's own NCLMetaTable carries.</param>
@@ -96,10 +99,15 @@ public static partial class RecordPatches
                     provider = GetDataProvider(dataAccess);
                     if (provider == null || provider.GetType().Name != "TempTableDataProvider") continue;
                     var providerType = provider.GetType();
-                    metaTableObj = RequiredField(providerType, "table").GetValue(provider);
-                    primaryTree = RequiredField(providerType, "primaryTree").GetValue(provider);
+                    metaTableObj = RequiredField(providerType, "table", CensusSurface).GetValue(provider);
+                    primaryTree = RequiredField(providerType, "primaryTree", CensusSurface).GetValue(provider);
                 }
-                catch (MissingFieldException) { continue; }   // BC's private layout moved — unknown, not empty
+                // BC's private layout moved — unknown, NOT empty. See the file header for why
+                // this one reader is allowed to answer "I don't know" where every other reader
+                // of the same structure refuses: a diagnostic that runs at failure time may not
+                // become the reason the failure changed. #2946 moved the type it catches from
+                // MissingFieldException to BcShapeGapException; it did not move the contract.
+                catch (AlRunner.Infrastructure.BcShapeGapException) { continue; }
                 catch (TargetInvocationException) { continue; }
 
                 if (metaTableObj is not NCLMetaTable meta) continue;
@@ -163,10 +171,10 @@ public static partial class RecordPatches
                 provider = GetDataProvider(dataAccess);
                 if (provider == null || provider.GetType().Name != "TempTableDataProvider") continue;
                 var providerType = provider.GetType();
-                metaTableObj = RequiredField(providerType, "table").GetValue(provider);
-                primaryTree = RequiredField(providerType, "primaryTree").GetValue(provider);
+                metaTableObj = RequiredField(providerType, "table", CensusSurface).GetValue(provider);
+                primaryTree = RequiredField(providerType, "primaryTree", CensusSurface).GetValue(provider);
             }
-            catch (MissingFieldException) { continue; }
+            catch (AlRunner.Infrastructure.BcShapeGapException) { continue; }   // see CollectCensus
             catch (TargetInvocationException) { continue; }
 
             if (metaTableObj is not NCLMetaTable meta) continue;

--- a/AlRunner/Patches/RecordPatches.TransactionSnapshot.cs
+++ b/AlRunner/Patches/RecordPatches.TransactionSnapshot.cs
@@ -188,13 +188,14 @@ public static partial class RecordPatches
             if (provider == null || provider.GetType().Name != "TempTableDataProvider") continue;
 
             var providerType = provider.GetType();
-            var metaTable = RequiredField(providerType, "table").GetValue(provider);
+            var metaTable = RequiredField(providerType, "table", TransactionRollbackSurface).GetValue(provider);
             if (metaTable == null) continue;
 
             // A null primaryTree simply means no row was ever inserted — the pre-write image
             // of this table is "empty", which is exactly what an empty row array restores to.
             var rows = new List<NavValue[]>();
-            if (RequiredField(providerType, "primaryTree").GetValue(provider) is IEnumerable primaryTree)
+            if (RequiredField(providerType, "primaryTree", TransactionRollbackSurface)
+                    .GetValue(provider) is IEnumerable primaryTree)
                 foreach (var row in primaryTree)
                     if (row is TempTableRecordBuffer buffer)
                         rows.Add(CloneValues(buffer.ToArray()));
@@ -314,7 +315,8 @@ public static partial class RecordPatches
     {
         var t = provider.GetType();
         foreach (var name in new[] { "trees", "primaryTree", "uniqueIndexes" })
-            AlRunner.Infrastructure.FieldPoke.SetInstance(RequiredField(t, name), provider, null);
+            AlRunner.Infrastructure.FieldPoke.SetInstance(
+                RequiredField(t, name, TransactionRollbackSurface), provider, null);
     }
 
     /// <summary>

--- a/AlRunner/Patches/RowVersionPatches.SystemIdIntegrity.cs
+++ b/AlRunner/Patches/RowVersionPatches.SystemIdIntegrity.cs
@@ -98,6 +98,9 @@ public static partial class RowVersionPatches
                                                             // with reflected-shape fakes, matching this file's and
                                                             // RowVersionPatchesTests.cs's established convention.
     private static FieldInfo? _fPrimaryTree;              // TempTableDataProvider.primaryTree (internal, private)
+
+    /// <summary>The AL-visible operation a shape gap in this file interrupted.</summary>
+    private const string SystemIdIntegritySurface = "AL Record.Insert (SystemId uniqueness check)";
     private static MethodInfo? _mCreateUniqueConstraint;  // NavCSideDuplicateKeyException.CreateUniqueConstraint
 
     /// <summary>
@@ -287,12 +290,20 @@ public static partial class RowVersionPatches
         // derives from it. PrivateMemberLookup walks the hierarchy asking each level for its
         // OWN declarations, which is right for the exact type AND for a derived one; see that
         // class for why climbing to a type of a KNOWN NAME instead is wrong.
+        //
+        // #2946: BcShapeGapException, not the InvalidOperationException this used to raise.
+        // Three readers of this one private structure raised three different types between
+        // them, so what a caller could catch depended on which one it reached — and none of
+        // the three said the true thing, that the runner could not READ BC's internals. The
+        // type also has to be one an AL [TryFunction] and an AL `asserterror` both let
+        // through; an InvalidOperationException is caught by asserterror, which would make
+        // `asserterror <insert>` PASS where real BC's insert succeeds and the asserterror
+        // fails. See AlRunner/Infrastructure/BcShapeGapException.cs.
         if (!AlRunner.Infrastructure.PrivateMemberLookup.FitsInstance(_fPrimaryTree, provider))
-            _fPrimaryTree = AlRunner.Infrastructure.PrivateMemberLookup
-                .Field(provider.GetType(), "primaryTree")
-                ?? throw new InvalidOperationException(
-                    $"[RowVersionPatches] {provider.GetType().Name}.primaryTree field not found — " +
-                    "SystemId integrity check cannot resolve its reflection target");
+            _fPrimaryTree = AlRunner.Infrastructure.BcShape.RequiredField(
+                provider.GetType(), "primaryTree", SystemIdIntegritySurface,
+                "the SystemId integrity check cannot read the stored rows, so a duplicate "
+                + "SystemId would be inserted with no diagnostic");
         // A NULL primaryTree means no rows are stored yet for this table instance
         // (EnsureTreeCreated has not run, which happens INSIDE the real Insert body this
         // prepend runs ahead of) — nothing to collide with, so a quiet return is right.
@@ -302,11 +313,10 @@ public static partial class RowVersionPatches
         // branch silently skipped the duplicate-SystemId check on every insert (#2786).
         var storedTree = _fPrimaryTree.GetValue(provider);
         if (storedTree == null) return;
-        if (storedTree is not System.Collections.IEnumerable storedRows)
-            throw new InvalidOperationException(
-                $"[RowVersionPatches] {provider.GetType().Name}.primaryTree holds a " +
-                $"{storedTree.GetType().Name}, which cannot be enumerated — " +
-                "SystemId integrity check cannot read the stored rows");
+        var storedRows = AlRunner.Infrastructure.BcShape.RequiredEnumerable(
+            storedTree, $"{provider.GetType().Name}.primaryTree", SystemIdIntegritySurface,
+            "the SystemId integrity check cannot read the stored rows, so a duplicate "
+            + "SystemId would be inserted with no diagnostic");
 
         // #2667: answer from a per-store index instead of walking every stored row. The walk
         // ran on EVERY insert into a database-backed table — note that the zero-SystemId early

--- a/AlRunner/Reporter.cs
+++ b/AlRunner/Reporter.cs
@@ -759,6 +759,23 @@ public static class Reporter
                 : $"out-of-scope/{oosSignal.Api}";
         }
 
+        // A BC shape gap gets its own bucket (#2946). Without it the classifier below would
+        // key it on whatever incidental BC frame happens to be innermost on the stack, which
+        // names the code the runner was SERVING rather than the read that failed — and every
+        // shape gap in a run would scatter across unrelated runtime/* buckets.
+        int gapIdx = message.IndexOf(Infrastructure.BcShapeGapException.Prefix, StringComparison.Ordinal);
+        var gapText = gapIdx >= 0 ? message : full;
+        if (gapIdx < 0) gapIdx = full.IndexOf(Infrastructure.BcShapeGapException.Prefix, StringComparison.Ordinal);
+        if (gapIdx >= 0)
+        {
+            var tail = gapText[(gapIdx + Infrastructure.BcShapeGapException.Prefix.Length)..];
+            int nl = tail.IndexOfAny(new[] { '\r', '\n' });
+            if (nl >= 0) tail = tail[..nl];
+            int sep = tail.IndexOf(" — ", StringComparison.Ordinal);
+            var surface = (sep >= 0 ? tail[..sep] : tail).Trim();
+            return surface.Length == 0 ? "bc-shape-gap/unknown" : $"bc-shape-gap/{surface}";
+        }
+
         // Classify by the FIRST (innermost) BC stack frame — that's where the actual NRE
         // originates. Looking anywhere in the stack mis-buckets every AL test as
         // NavMethodScope because every AL method body wraps in a NavMethodScope.

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -107,6 +107,21 @@ An exception carrying *neither* is not an out-of-scope signal. A plain
 `expect-oos` entry stays a failure — widening the matcher must not turn it into
 one that says yes to everything.
 
+**A third refusal type exists and `expect-oos` may never absorb it.**
+`BcShapeGapException` — message prefix `bc-shape-gap: `, written up in
+[limitations.md](limitations.md#bc-shape-gaps) — means the runner could not READ
+one of BC's own internals: a private field, a static type or an internal property
+that is not where the reflecting code expects it on this BC build. That is a bug
+report about the runner, not a scope boundary, and it is a property of which BC
+build is on disk rather than of the runner — so it can be true on one BC leg and
+false on another in the same matrix run, and "expected" is never an honest thing
+to call it. `expect-oos` and `expect-divergence` both refuse it explicitly,
+naming the surface and the member, instead of falling through to advice about
+raising `RunnerOutOfScopeException` that would be exactly wrong here.
+`expect-fail-known-gap` still applies, with an open issue, once someone has
+written the gap down. Settled in
+[#2946](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2946).
+
 New Cecil throw sites therefore have to put the **`docs/scope.md` anchor first
 in the reason slot**, and the API name in the API slot. A message shaped
 `out-of-scope: report-rendering-external — RDLC layout processing …` puts a

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -749,6 +749,60 @@ there, so everything behind it is unmeasured.
 
 ---
 
+<a id="bc-shape-gaps"></a>
+
+## BC shape gaps — the runner could not read BC's internals
+
+A **shape gap** is not a limitation of the runner's scope, and it is not a feature nobody has
+built. It is a bug report: the runner reflects on a private field, a static type or an internal
+property inside BC's own assemblies, and on the BC build in front of it that member is not
+there, or holds something the runner cannot interpret. The surface is in scope, the code that
+serves it is written, and the read failed.
+
+The runner raises `AlRunner.Infrastructure.BcShapeGapException` for exactly that, and the
+message names the surface, the member and why the read mattered:
+
+```
+bc-shape-gap: Object Metadata (system table 2000000071) — TempTableDataProvider.primaryTree:
+field not found — the runner cannot tell a store BC never inserted into from one --test-data
+already filled, and synthesising rows would silently shadow the restored ones —
+see docs/limitations.md#bc-shape-gaps
+```
+
+**If you see one, the first question is which BC version produced it.** A shape gap is a
+property of the build on disk rather than of the runner, so it can fire on one BC minor and not
+another in the same matrix run. Report it with the BC version, the member named in the message
+and the AL that reached it.
+
+### Three refusals, three different meanings
+
+| the runner says | means | AL `[TryFunction]` | AL `asserterror` | can an `expect-oos` entry declare it expected? |
+|---|---|---|---|---|
+| `out-of-scope:` + a `docs/scope.md` anchor | permanently out of scope — SMTP, HTTP egress, printing | traps it into `false` | catches it | yes |
+| `out-of-scope:` + `not-yet-implemented` | in scope, not built yet | tears through | catches it | yes |
+| `bc-shape-gap:` | the runner could not read BC's internals | tears through | **tears through** | **no** |
+
+The first row traps because it is faithful: real BC, in an environment that also lacks the
+surface, raises a trappable error there, so `false` is BC's own answer. Neither of the other two
+has a BC outcome to be faithful to — real BC answers, and the runner does not — so trapping
+either would turn a gap into a green test that lies.
+
+A shape gap goes one step further than `not-yet-implemented` and escapes `asserterror` as well,
+because catching it does not merely hide the gap, it **inverts a result**: on real BC the
+statement inside the `asserterror` succeeds, so the `asserterror` fails; a runner that swallows
+the gap makes it pass.
+
+And it can never be absorbed by an `expect-oos` entry. That mode declares a permanent scope
+boundary, and a BC-layout regression is not one — see [docs/expectations.md](expectations.md).
+`expect-fail-known-gap` still applies, with an open issue, once someone has written the gap
+down.
+
+The convention was settled in
+[#2946](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2946), which was filed
+because four readers of one private BC structure raised three different exception types between
+them. `AlRunner/Infrastructure/BcShapeGapException.cs` carries the full derivation, including
+why it is a separate type rather than a third reason anchor.
+
 ## Known gaps — in scope but not yet implemented
 
 These are not architectural limits. They can be fixed; report them at


### PR DESCRIPTION
Closes #2946

The runner had two ways to say "AL touched something I cannot do", and both are claims about **scope**: `RunnerOutOfScopeException` with a `docs/scope.md` anchor (permanently out of scope) and the same type with reason `not-yet-implemented` (in scope, not built). It had no way to say the third thing, which is what most reflection guards under `AlRunner/Patches/` actually mean — the surface is in scope *and implemented*, and BC's own internals are not the shape the reflecting code was written against.

So six readers of one private structure, `TempTableDataProvider.primaryTree`, raised three different exception types between them, and what a caller could catch depended on which reader it happened to reach.

## The decision

A third type, `AlRunner/Infrastructure/BcShapeGapException.cs`. Message prefix `bc-shape-gap: `, carrying `Surface` / `Member` / `Detail`.

**Why a type and not a third reason anchor**, which is the cheaper move:

1. Anchor classification is a **string-prefix test**, and one has already been mis-spelled in production. `ApplicationObjectBasePatches.IsPermanentOutOfScope` decides whether a `[TryFunction]` may swallow a refusal with `!oos.Reason.StartsWith("not-yet-implemented")`, and `RecordPatches.QueryProjection.cs`'s `query-join-synthesized-subquery-not-implemented` says not-implemented in words while not *starting* with the token — so a `[TryFunction]` swallows it today (measured in #2966). A second prefix is a second chance to make that mistake.
2. Anything carrying a `RunnerOutOfScopeException` **can be absorbed by an `expect-oos` entry**. `OutOfScopeMessage.FromException` finds the typed exception anywhere in the inner chain and hands it to `ExpectationClassifier`. A BC-layout regression must never be declarable as an expected out-of-scope surface: it is a property of which BC build is on disk, not of the runner, so it can be true on the 28.4 leg and false on 27.5 in the same matrix run. #2946 named this as the argument *for* `MissingFieldException`, which cannot be absorbed; the argument *against* `MissingFieldException` was that it carries no structured pair to bucket on. The new type takes both halves.

`RunnerOutOfScopeException` is `sealed`, so this is deliberately not a subclass — unsealing it would immediately hand back point 2, since `FromException` walks for the base type.

## The three cases, and what keeps them distinguishable

|  | `[TryFunction]` | `asserterror` | `expect-oos` absorbs? |
|---|---|---|---|
| permanent OOS | traps → `false` | catches | yes |
| `not-yet-implemented` | tears through | catches (#2871) | yes |
| **BC shape gap** | **tears through** | **tears through** | **no** |

The first row traps because it is *faithful*: real BC, in an environment that also lacks the surface, raises a trappable error there, so `false` is BC's own answer. Neither of the other two has a BC outcome to be faithful to.

**The `asserterror` column is derived, not copied** — the brief asked me to derive it rather than adopt the instinct, and the derivation goes one step further than "it tears through like `not-yet-implemented`". `asserterror Foo()` where `Foo` hits a shape gap: on real BC, `Foo` runs and returns, so the `asserterror` **fails** ("expected an error"). A runner that catches the gap makes that `asserterror` **pass** — the opposite of BC's answer, and green. Swallowing here does not merely hide a gap, it **inverts a result**. That is a stronger argument than the `[TryFunction]` one, where the failure mode is a silent `false` rather than a wrong assertion.

Nothing relied on the old behaviour for this type because the type is new, so this is a contract from the start rather than a change to one. #2871 stays open for the middle row, which *is* an existing contract with runner-extras suites depending on it (`table-connection-live-oos`, `date-virtual-table-window`), and is untouched — `AssertErrorOutOfScopeCatchabilityTests` still pins it.

**Both trap sites ask the shape-gap question first**, before `catch (NavBaseException nbe) when (!nbe.UntrappableError)`, and via an inner-chain walk rather than an `is` test: a refusal raised behind `MethodBase.Invoke` arrives inside a `TargetInvocationException`, and BC's own `RemapToALExceptionAndThrow` can rewrap it as a NavBaseException that the next clause would swallow.

## Where the line falls, which is the part that needs judgement

From the type's header, and it is what makes the convention applicable rather than just declared:

- **Raise it** when the read could not be performed — the type/field/property is absent, or present and holding something the runner cannot interpret.
- **Do not raise it** when the read succeeded and the answer was merely unwelcome — BC's list came back empty, the artifact genuinely has no field 3, a skeleton singleton the *runner* populates is null, the runner's own store wiring handed no provider over.

That is why only 2 of `RecordPatches.ObjectMetadataSystemTable.cs`'s twelve refusals convert here. Its header table now marks sites 11 and 12 as a new bucket (4) and says explicitly why sites 1, 4, 5, 6, 7 and 9 would be **wrong** in it.

## Classification and reporting

- `ExpectationClassifier` refuses to absorb a shape gap under `expect-oos` **or** `expect-divergence`, naming the type, the surface and the member. Structurally it was already unabsorbable — `signal` is null for it — but the generic no-signal branch advises "make the throw site raise `RunnerOutOfScopeException`", which is precisely wrong for a layout gap. `expect-fail-known-gap` still absorbs it, deliberately: that mode means "must fail, and this open issue tracks the work".
- `Reporter.ClassifyTest` gets a `bc-shape-gap/<surface>` bucket. Without it these key on whatever incidental BC frame is innermost, naming the code the runner was *serving* rather than the read that failed, and scattering across unrelated `runtime/*` buckets.
- `docs/limitations.md#bc-shape-gaps` and a paragraph in `docs/expectations.md`.

## Fixing the shape, not just the reported line

**1. Same wrong pattern at another call site?** Yes, and more than the issue said. It named four readers; there are **six** — `RecordPatches.StoredTableCensus.cs` ×2, `RecordPatches.TransactionSnapshot.cs` ×3 (including `ClearProviderInPlace`, which pokes `trees` / `primaryTree` / `uniqueIndexes`), `RecordPatches.InstallBaseline.cs` ×2, `RowVersionPatches.SystemIdIntegrity.cs` ×2, `RecordPatches.ObjectMetadataSystemTable.cs` ×2. All six go through one resolver now.

Beyond them, measured rather than estimated: **233 further reflection-resolution guards in 37 files under `AlRunner/Patches/`**, plus 265 in `NclCecilRewrite.*` that fire at rewrite time and probably should *not* convert, since no AL seam can reach one. Filed as **#2994** with the per-layer counts and the classification line, rather than swept here — reclassifying a site is a judgement, not a rename, and 200+ of them would have buried the decision this PR exists to make.

**2. A sibling making the same assumption?** Yes, and it was a live latent bug rather than a style question. `RecordPatches.RequiredField` resolved with a plain `GetField(NonPublic | Instance)`, which does **not** return a base class's private field — exactly the #2725 defect `PrivateMemberLookup` was written to fix, and which the two readers using `PrivateMemberLookup` directly do not have. So three of the six readers would have called `CrmTableConnection.CrmTestDataProvider`'s inherited, perfectly readable `primaryTree` **absent**. It is not observable today because a `GetType().Name != "TempTableDataProvider"` gate sits upstream of every caller — so I am not claiming a fixed bug, I am claiming a removed trap: it was wrong the moment that gate moved, and "the readers agree" was false in a way you had to open three files to see. `RequiredField` routes through `BcShape.RequiredField` → `PrivateMemberLookup` now, and a test asserts the inherited-field resolution directly.

**3. Two paths writing the same state with different invariants?** Yes, and two of them are legitimately different — which is worth stating because the obvious sweep would have broken them:

- `RecordPatches.StoredTableCensus` **catches** the refusal and continues, keeping its documented "unknown, never empty" contract. Its file header explains why this one reader may answer "I don't know": it is a diagnostic that runs at failure time, and the one thing it may not do is change the failure it is explaining. It also used to construct and catch a `MissingFieldException` across a two-line span, which is control flow wearing an exception; the catch clause moved to the new type and the contract did not.
- `RecordPatches.TableMaterialisation.StoredHasAnyRow` reads the same field and returns three-valued `true`/`false`/`null`, where `null` means "cannot tell, do not load". Also deliberate, also documented, also unchanged.

Those two and `ProviderHasAnyRow` are three probes of the same store with different refusal policies. All three are correct for their callers; nothing said so before.

## RED → GREEN

RED was produced against executing code, not a compile error: the type was added first, with none of the six readers converted and none of the policy sites touched.

```
Failed AssertError_TearsThrough_EvenWhenTheGapArrivesWrapped
Failed AssertError_TearsThrough_ForAShapeGap
Failed ExpectDivergence_DoesNotAbsorbAShapeGap
Failed ExpectOos_DoesNotAbsorbAShapeGap_AndSaysWhy
Failed NoReaderOfThePrivateProviderStructure_StillRaisesARetiredType
Failed ObjectMetadataRowProbe_RaisesAShapeGap_WhenPrimaryTreeCannotBeEnumerated
Failed ObjectMetadataRowProbe_RaisesAShapeGap_WhenPrimaryTreeIsGone
Failed RecordPatchesRequiredField_RaisesAShapeGap_NotAMissingFieldException
Failed Reporter_BucketsAShapeGapUnderItsOwnHeading_NotAnIncidentalBcStackFrame
Failed TheDocSectionTheMessagePointsAt_Exists
Failed!  - Failed: 10, Passed: 18, Total: 28
```

**The 18 that stayed green are the control arms, and two of them were green for a reason worth naming.** `TryInvoke_TearsThrough_ForAShapeGap` and its async twin passed at RED already, because `IsPermanentOutOfScope` casts to `RunnerOutOfScopeException` and a new type is not one. That is honest to report: the `[TryFunction]` half of the answer fell out of the type choice rather than being implemented. The tests still earn their place — they pin it against someone later "helpfully" adding the type to the trap, and the wrapped-arrival test did **not** pass at RED, since ordering the check before the NavBaseException clause is a real change.

The other control arms are what make the tear-through claim mean anything: `TryInvoke_StillTraps_APermanentRefusal` (both sync and async), `AssertError_StillCatches_BothRefusalFlavours`, `AssertError_StillFails_WhenTheBodyDoesNotThrow`, `ExpectOos_StillAbsorbs_ARealPermanentRefusal`, `Reporter_StillBucketsRefusalsAndPlainFailuresAsBefore`, `OutOfScopeSignal_IsStillRecognisedForARealRefusal`, and `ObjectMetadataRowProbe_StillAnswers_ForAReadableStore`. Without the first group, "tears through" would be satisfied by a trap that trapped nothing; without the last, "refuses on a moved layout" would be satisfied by a probe that threw on every input.

GREEN, re-run on the rebased tree (never carried across the rebase):

```
dotnet test AlRunner.Tests -c Release --framework net8.0 --no-build --filter \
  "FullyQualifiedName~BcShapeGapConventionTests|FullyQualifiedName~ObjectMetadata|\
FullyQualifiedName~RowVersionPatchesTests|FullyQualifiedName~TryFunctionOutOfScopeTrapTests|\
FullyQualifiedName~AssertErrorOutOfScopeCatchabilityTests|FullyQualifiedName~ExpectationClassifier|\
FullyQualifiedName~ExpectationManifest|FullyQualifiedName~VirtualTableRefusalClaimTests|\
FullyQualifiedName~Reporter|FullyQualifiedName~InstallBaseline|FullyQualifiedName~TransactionSnapshot|\
FullyQualifiedName~StoredTableCensus|FullyQualifiedName~MethodScope|FullyQualifiedName~AssertError"
Passed!  - Failed: 0, Passed: 230, Skipped: 2, Total: 232, Duration: 2 m 30 s
```

AL side, wider than usual because `NavMethodScope_AssertError` is on the path of every AL `asserterror` in the repo:

```
dotnet run --no-build --project AlRunner -c Release --framework net8.0 -- tests/runner-extras \
  --package-cache "$HOME/.al-runner/platform-apps" --package-cache "$HOME/.al-runner/test-apps" \
  --strict --count-baseline tests/expectations/count-baseline/test-count-baseline.json --cache <private>
Tests: 273 total  pass: 273  fail: 0  error: 0
```

The five suites that specifically `asserterror` a refusal or exercise a shape-gap path were also run on their own: `table-connection-live-oos` 2/2, `date-virtual-table-window` 5/5, `object-metadata-system-table` 4/4, `http-egress-boundary-oos` 4/4, `task-scheduler-oos` 6/6. No new AL test and no new app group, so `tests/expectations/count-baseline/test-count-baseline.json` does not move and is untouched — the `--count-baseline` run above is what confirms that rather than an assumption.

## Six existing tests encoded the retired conventions

They are updated, and that expectation was part of the defect rather than collateral: `ObjectMetadataProviderRowProbeTests` ×3, `RowVersionPatchesTests` ×2 (which asserted `InvalidOperationException` for exactly the two guards this changes), and `ObjectMetadataSystemTableRefusalTests.EveryRefusalInTheFile_GoesThroughTheOneFactory`, whose "13 uses of one factory" count is now two counts — 11 for `ObjectMetadataShapeGap` and 2 for `BcShape` — so a refusal deleted from either group is still caught.

## Why the tests are in `AlRunner.Tests/`, not the upstream corpus

No AL statement can move a private BC field or rename a static, so a service tier has nothing to adjudicate — on every BC version the runner supports, `TempTableDataProvider.primaryTree` exists and none of these refusals is reachable from AL. The subject is the runner's own refusal contract, which `bc-behavior-tests-go-upstream.md` classifies as runner-specific; same shape as `TryFunctionOutOfScopeTrapTests`, `AssertErrorOutOfScopeCatchabilityTests` and `VirtualTableRefusalClaimTests`.

## Deliberately left out

- **The 233-site `AlRunner/Patches/` sweep and the 265 `NclCecilRewrite` sites** — #2994, above.
- **`RecordPatches.ObjectMetadataSystemTable.cs`'s other four BC-internals reads** (sites 2, 3, 8, 10) and **`RecordPatches.VirtualTableShapeGap.cs`'s 55** — also #2994. Both files' headers now record which of their sites are shape gaps and which would be wrong in that bucket, so the sweep starts from a classification rather than a grep.
- **#2766's doubled-pointer sweep and #2966's 96 citations** — untouched, as briefed.
- **Whether AL `asserterror` should swallow a `RunnerOutOfScopeException`** — #2871, a maintainer decision with runner-extras suites depending on today's answer. This PR sets the contract for a new type; it does not change the old one.
- **`InstallBaseline`'s refusal when the provider is not a `TempTableDataProvider` at all** — it names the type and throws loudly already, and whether a `CrmTestDataProvider`'s rows *can* be captured is a behaviour question, not a type one.
- **No expectations manifest entry**, and none is needed: no corpus or runner-extras test reaches any of these refusals, and none is declared today.

---
*Authored by an automated agent (`impl-25`) acting on the account holder's behalf.*

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
