### PR TITLE
ci(corpus): enumerate the corpus's test apps instead of naming one path

### DIFF
--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -464,10 +464,42 @@ jobs:
           # GROWTH above it — the count must be bumped in
           # tests/expectations/count-baseline/ in the same PR that changed it, or this
           # leg goes red with the exact expected/actual numbers to use.
+          #
+          # The corpus apps are ENUMERATED, never named (#2984). This step used to
+          # pass the single path tests/al-language/tests/al-language, and the corpus
+          # then gained a second test app (tests/al-language-onprem, target OnPrem,
+          # for the Scope = OnPrem system tables a Cloud-target app cannot name at
+          # all). With one path hardcoded here, the submodule pin bump that pulls a
+          # new app in is green BY CONSTRUCTION: the app is checked out, never
+          # executed, and the leg still reports success. Nothing is even visibly
+          # skipped — those tests never enter the run, so neither --strict nor
+          # --count-baseline can see them missing. Adding a test app to the corpus
+          # must be enough to make this leg execute it, with no edit here.
+          #
+          # Each app is a SEPARATE positional bundle root, not one root over their
+          # parent directory. Measured against corpus PR #179: one root over the
+          # parent compiles all three apps into a single bundle, where the OnPrem
+          # app's Record "Object Metadata" fails AL0185 — which drops 55 objects
+          # from the Cloud app too and takes the whole corpus down with EMIT-ZERO.
+          # As separate roots the same three apps ran 2595 tests in 80.8s cold,
+          # against 96.0s for the single-app invocation this replaces, because the
+          # AL-output cache makes the shared dependency compile once.
+          #
+          # mapfile from a process substitution, deliberately: a `while read` loop
+          # fed by a here-string is how the corpus's own runner silently executes
+          # exactly ONE test app however many are listed — the child process drains
+          # the here-string from stdin and the loop ends after one pass, leg still
+          # green (measured on corpus run 33996414648).
+          mapfile -t CORPUS_APPS < <(python3 scripts/corpus-app-dirs.py tests/al-language)
+          if [ "${#CORPUS_APPS[@]}" -eq 0 ]; then
+            echo "::error::scripts/corpus-app-dirs.py produced no corpus app directories — refusing to report a green leg for a run that would execute nothing"
+            exit 1
+          fi
+          printf '[corpus] app to run: %s\n' "${CORPUS_APPS[@]}"
           rc=0
           start=$SECONDS
           dotnet run --no-build --project AlRunner -c Release --framework net8.0 -- \
-              tests/al-language/tests/al-language \
+              "${CORPUS_APPS[@]}" \
               --package-cache "$HOME/.al-runner/platform-apps" \
               --package-cache "$HOME/.al-runner/test-apps" \
               --strict \
@@ -491,6 +523,14 @@ jobs:
         # when none did, landing on a different BC leg each CI run. Running a slice that
         # deliberately excludes the report tests keeps that class of bug from coming back
         # disguised as flakiness.
+        #
+        # This one DOES still name a single app on purpose, and it is not the #2984
+        # defect wearing a second hat: `--test Codeunit6020` narrows the run to one
+        # named codeunit, so this step is not a coverage gate and adding a corpus app
+        # cannot make it miss anything. It also passes only the platform-apps cache,
+        # so pointing it at every corpus app would make it depend on each app's
+        # dependency closure resolving from that one cache. The gate that must
+        # enumerate is the --count-baseline step above.
         if: ${{ always() }}
         run: |
           dotnet run --no-build --project AlRunner -c Release --framework net8.0 -- \

--- a/AlRunner.Tests/CorpusAppEnumerationWorkflowTests.cs
+++ b/AlRunner.Tests/CorpusAppEnumerationWorkflowTests.cs
@@ -1,0 +1,211 @@
+// Issue #2984: `.github/workflows/bc-tests.yml` named ONE corpus bundle path,
+// `tests/al-language/tests/al-language`. The corpus then gained a second test app
+// (`tests/al-language-onprem`, target OnPrem, for the `Scope = OnPrem` system tables a
+// Cloud-target app cannot name at all — corpus PR #179). Because the workflow named one
+// path, the submodule pin bump that pulls a new app in is green BY CONSTRUCTION: the app
+// is checked out, never executed, and the leg still reports success.
+//
+// That is worse than the failure this repository already knows about, where a corpus leg
+// goes green while visibly skipping codeunits: here nothing is skipped, because those
+// tests never enter the run at all. Neither `--strict` (which fails on a test FAILING) nor
+// `--count-baseline` (which compares the suites the run actually touched) can see a suite
+// that was never handed to the runner — measured: with the fixture suite declared in the
+// baseline, the single-app invocation still exits 0, because a declared suite the run did
+// not touch is deliberately silent.
+//
+// So the workflow enumerates, and these tests hold that in place. They are the RED for
+// #2984: every one of them fails against the pre-#2984 workflow.
+//
+// What is NOT asserted here, deliberately: which BC legs run, and what reports the two
+// required contexts. `main`'s ruleset requires exactly `All BC versions passed` and
+// `Tests updated`; the per-leg `(required)` text is part of a job's own NAME and makes no
+// leg a required context. AlRunner.Tests/BcLegRerunWorkflowTests.cs owns that property and
+// nothing here may duplicate or weaken it.
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class CorpusAppEnumerationWorkflowTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private const string EnumerationScript = "scripts/corpus-app-dirs.py";
+
+    /// <summary>The literal that must not come back as the corpus leg's bundle argument.</summary>
+    private const string SingleAppPath = "tests/al-language/tests/al-language";
+
+    private static string ReadWorkflow(string name)
+    {
+        var path = Path.Combine(RepoRoot, ".github", "workflows", name);
+        Assert.True(File.Exists(path), $"expected workflow {name} at {path}");
+        return File.ReadAllText(path);
+    }
+
+    /// <summary>
+    /// The `run:` script of the gating corpus step, comments stripped. Located by the step's
+    /// `- name:` line and ended at the next one, so the assertions below are about the step
+    /// that actually runs the corpus rather than about the file as a whole — the xmlport
+    /// order-independence step further down still names one app on purpose (it narrows to
+    /// one codeunit with `--test`, so it is not a coverage gate).
+    /// </summary>
+    private static string GatingCorpusStepScript()
+    {
+        var lines = ReadWorkflow("bc-tests.yml").Split('\n');
+        var start = Array.FindIndex(lines, l => l.TrimEnd() == "      - name: Run al-language corpus");
+        Assert.True(start >= 0,
+            "bc-tests.yml no longer has a step named 'Run al-language corpus'. If it was renamed, "
+            + "update this guard rather than deleting it — it is what keeps a second corpus app "
+            + "from being pulled in by the pin and never executed (#2984).");
+
+        var end = Array.FindIndex(lines, start + 1, l => Regex.IsMatch(l, @"^      - name: "));
+        if (end < 0) end = lines.Length;
+
+        var body = string.Join('\n', lines[start..end]
+            .Where(l => !l.TrimStart().StartsWith('#')));
+
+        Assert.Contains("--count-baseline", body);
+        return body;
+    }
+
+    [Fact]
+    public void GatingCorpusStep_DoesNotNameASingleHardcodedBundlePath()
+    {
+        // The defect, stated directly. Comments are stripped first so the step may keep
+        // explaining the path it no longer passes.
+        var body = GatingCorpusStepScript();
+
+        Assert.DoesNotContain(SingleAppPath, body);
+    }
+
+    [Fact]
+    public void GatingCorpusStep_EnumeratesTheCorpusAndPassesEveryAppAsItsOwnRoot()
+    {
+        var body = GatingCorpusStepScript();
+
+        // Enumerated, not named.
+        Assert.Contains(EnumerationScript, body);
+        // Every enumerated app reaches the runner. `"${CORPUS_APPS[@]}"` — quoted, and the
+        // array form: `$CORPUS_APPS` would pass only the first element, which is the exact
+        // one-app-runs bug in a different disguise.
+        Assert.Contains("\"${CORPUS_APPS[@]}\"", body);
+        // The teeth. Enumeration without --strict runs the new app's tests and ignores their
+        // failures; without --count-baseline a suite that stops being discovered is silent.
+        Assert.Contains("--strict", body);
+        Assert.Contains("test-count-baseline.json", body);
+    }
+
+    [Fact]
+    public void GatingCorpusStep_FailsLoudlyWhenTheEnumerationYieldsNothing()
+    {
+        // An empty app list would put the leg straight back into "green because it ran
+        // nothing" — the same shape as the bug, arrived at from the other side.
+        var body = GatingCorpusStepScript();
+
+        Assert.Contains("${#CORPUS_APPS[@]}", body);
+        Assert.Matches(new Regex(@"::error::[^\n]*corpus-app-dirs"), body);
+    }
+
+    [Fact]
+    public void GatingCorpusStep_NeverFeedsTheAppListThroughStdin()
+    {
+        // The corpus's own runner reads its test-app list with `while read ... <<< "$DIRS"`
+        // and calls the `al` tool without redirecting stdin, so the child drains the
+        // here-string and the loop runs exactly once however many apps are listed — silently,
+        // leg still green (measured on corpus run 33996414648). Anything on this side that
+        // pipes or here-strings the list into a loop containing the runner inherits that bug.
+        var body = GatingCorpusStepScript();
+
+        Assert.DoesNotContain("<<<", body);
+        Assert.DoesNotMatch(new Regex(@"while\s+read"), body);
+    }
+
+    [Fact]
+    public void EnumerationScript_IsCheckedInAndTested()
+    {
+        // A workflow calling a script that does not exist fails at run time on eight legs
+        // instead of here in milliseconds.
+        Assert.True(File.Exists(Path.Combine(RepoRoot, EnumerationScript)),
+            $"{EnumerationScript} is referenced by bc-tests.yml but is not checked in.");
+
+        // pr-check.yml runs every scripts/tests/*.test.py; without this file the script's
+        // own behaviour — including the loud empty-list failure above — is unasserted.
+        Assert.True(File.Exists(Path.Combine(RepoRoot, "scripts", "tests", "corpus-app-dirs.test.py")),
+            "scripts/tests/corpus-app-dirs.test.py is missing; the enumeration would be untested.");
+    }
+
+    /// <summary>
+    /// The sibling of <c>CountBaselineMergeShapeTests.RunnerExtrasGroupKeys_AreExactlyTheAppGroupDirectories</c>,
+    /// which the corpus had no equivalent of. Now that every corpus app runs, every corpus app
+    /// must also carry a count baseline — otherwise a newly-executed app's test count is
+    /// unguarded, and it can later stop being discovered exactly as quietly as before:
+    /// <c>CountBaselineCheck</c> imposes no expectation on a suite the manifest never names.
+    /// </summary>
+    [Fact]
+    public void EveryCorpusAppHasACountBaselineEntry()
+    {
+        var corpusRoot = Path.Combine(RepoRoot, "tests", "al-language");
+        var appDirs = EnumerateCorpusApps(corpusRoot);
+        if (appDirs.Count == 0)
+        {
+            // The submodule is not checked out (a bare `git clone` without --recursive).
+            // Asserting here would fail for a reason that has nothing to do with the
+            // baseline; CI always checks it out, and the workflow's own enumeration exits 1
+            // with the `git submodule update --init` hint when it is missing.
+            Assert.False(Directory.Exists(Path.Combine(corpusRoot, "tests")),
+                $"{corpusRoot} is checked out but no app directory was found under it — "
+                + "the enumeration rule and the corpus layout have diverged.");
+            return;
+        }
+
+        using var doc = System.Text.Json.JsonDocument.Parse(
+            File.ReadAllText(Path.Combine(
+                RepoRoot, "tests", "expectations", "count-baseline", "test-count-baseline.json")));
+        var declared = doc.RootElement.GetProperty("suites").EnumerateObject()
+            .Select(p => p.Name).ToHashSet(StringComparer.Ordinal);
+
+        var missing = appDirs.Select(Path.GetFileName)
+            .Where(n => !declared.Contains(n!))
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(missing.Count == 0,
+            "tests/expectations/count-baseline/test-count-baseline.json has no suite entry for "
+            + string.Join(", ", missing)
+            + ".\nThe corpus leg now runs every corpus app as its own bundle root, and the suite key "
+            + "is the app directory's basename. Add one line per app — a dependency-only app with no "
+            + "tests of its own is { \"tests\": { \"default\": 0 }, \"appGroups\": { \"default\": 1 } } "
+            + "and still counts.");
+    }
+
+    /// <summary>
+    /// The same rule <c>scripts/corpus-app-dirs.py</c> implements and
+    /// <c>ProgramSupport.LooksLikeSuite</c> defines: a directory that declares its own
+    /// app.json, or uses the src//test/ split, is one app, and descent stops there.
+    /// </summary>
+    private static List<string> EnumerateCorpusApps(string root)
+    {
+        var found = new List<string>();
+        if (!Directory.Exists(root)) return found;
+        if (LooksLikeApp(root)) { found.Add(root); return found; }
+
+        void Descend(string dir)
+        {
+            foreach (var child in Directory.GetDirectories(dir).OrderBy(d => d, StringComparer.Ordinal))
+            {
+                if (Path.GetFileName(child).StartsWith('.')) continue;
+                if (LooksLikeApp(child)) found.Add(child);
+                else Descend(child);
+            }
+        }
+
+        Descend(root);
+        return found;
+    }
+
+    private static bool LooksLikeApp(string dir)
+        => File.Exists(Path.Combine(dir, "app.json"))
+        || Directory.Exists(Path.Combine(dir, "src"))
+        || Directory.Exists(Path.Combine(dir, "test"));
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,9 +80,20 @@ dotnet build AlRunner.slnx -c Release
 
 ### Run the al-language corpus
 
+The corpus is more than one app — the Cloud-target coverage app, its internals fixture, and
+(from corpus PR #179 on) an OnPrem-target app for the `Scope = OnPrem` system tables a
+Cloud app cannot name at all. Each is a separate bundle root. Let the enumeration find them,
+the same way CI does, so a local run covers what CI covers:
+
 ```bash
-dotnet run --project AlRunner -c Release -- tests/al-language/tests/al-language
+mapfile -t CORPUS_APPS < <(python3 scripts/corpus-app-dirs.py tests/al-language)
+dotnet run --project AlRunner -c Release -- "${CORPUS_APPS[@]}"
 ```
+
+Naming `tests/al-language/tests/al-language` directly still works and is the right thing when
+you want that one app. It is not the corpus: it is whichever apps the pin happened to carry
+when the path was written, which is how a second corpus app rode in on a pin bump without ever
+being executed (#2984).
 
 ### Run with extra options
 
@@ -111,6 +122,12 @@ git commit -m "Bump tests/al-language to <sha>"
 ```
 
 Tests that newly fail after the bump are runner gaps — patch the runner (or add an expectation entry), never the corpus.
+
+If the bump brings in a whole new corpus **app**, CI runs it automatically — the app list is
+enumerated, not named (#2984) — but the new app also needs its own line in
+`tests/expectations/count-baseline/test-count-baseline.json`, keyed by its directory basename.
+`AlRunner.Tests/CorpusAppEnumerationWorkflowTests.cs` fails in milliseconds when one is missing,
+rather than letting the app's test count go unguarded.
 
 ---
 
@@ -161,7 +178,8 @@ Every PR must:
 Pull requests run against a matrix of BC versions. A PR cannot merge unless every job is green. Run the corpus locally before pushing:
 
 ```bash
-dotnet run --project AlRunner -c Release -- tests/al-language/tests/al-language
+mapfile -t CORPUS_APPS < <(python3 scripts/corpus-app-dirs.py tests/al-language)
+dotnet run --project AlRunner -c Release -- "${CORPUS_APPS[@]}"
 ```
 
 Exit codes: `0` all tests passed, `1` a test failed/errored, `2` a bundle could not execute (process-level error, or a bad invocation), `3` a bundle could not compile, `4` a `--count-baseline` mismatch. All non-zero codes fail CI.

--- a/scripts/corpus-app-dirs.py
+++ b/scripts/corpus-app-dirs.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""List every test app the al-language corpus offers, so CI never has to name one.
+
+Issue #2984. `.github/workflows/bc-tests.yml` used to point the runner at exactly
+one path, `tests/al-language/tests/al-language`. The corpus then gained a second
+test app (`tests/al-language-onprem`, target OnPrem, for the `Scope = OnPrem`
+system tables a Cloud-target app cannot name at all). Because the workflow named
+one path, the submodule pin bump that pulls a new app in is green by
+construction: the app is checked out, never executed, and the leg still reports
+success. Nothing is even skipped visibly -- those tests never enter the run.
+
+So the workflow enumerates instead. Adding a test app to the corpus is enough to
+make this repository's CI execute it.
+
+What counts as an app directory is deliberately the same rule the runner itself
+uses in `ProgramSupport.LooksLikeSuite` (AlRunner/ProgramSupport/Suites.cs): a
+directory that declares its own `app.json`, or uses the `src/` / `test/` split.
+Descent stops at the first such directory on each branch, exactly as
+`EnumerateSuitesBelow` does -- a suite's own sub-directories are part of that
+suite, never separate apps. If the two rules disagreed, this script would hand
+the runner a path the runner does not read as one app, which is the same class of
+silent miscount the enumeration exists to prevent.
+
+Each app is printed on its own line, sorted, to be passed to the runner as a
+SEPARATE positional bundle root:
+
+    mapfile -t CORPUS_APPS < <(python3 scripts/corpus-app-dirs.py tests/al-language)
+    dotnet run ... -- "${CORPUS_APPS[@]}" --strict --count-baseline ...
+
+Separate roots, not one root over the parent directory. Measured against corpus
+PR #179 on 2026-09-06: pointing the runner at the corpus root compiles all three
+apps into ONE bundle, and the OnPrem app's `Record "Object Metadata"` then fails
+`AL0185: Table 'Object Metadata' is missing` -- which drops 55 objects from the
+Cloud app as well and takes the whole corpus down with an EMIT-ZERO compile
+failure. As separate roots the same three apps ran 2595 tests in 80.8s cold,
+against 96.0s for the single-app invocation this replaces.
+
+Exits 1, loudly, when it finds nothing: an enumeration that silently produces an
+empty list would put the workflow straight back into "green because it ran
+nothing".
+
+Usage:
+    corpus-app-dirs.py <corpus-root>
+"""
+import argparse
+import os
+import sys
+
+# Same three markers as ProgramSupport.LooksLikeSuite.
+_SPLIT_DIRS = ("src", "test")
+
+
+def looks_like_app(path):
+    """True when `path` is one app: its own app.json, or the src//test/ split."""
+    if os.path.isfile(os.path.join(path, "app.json")):
+        return True
+    return any(os.path.isdir(os.path.join(path, d)) for d in _SPLIT_DIRS)
+
+
+def enumerate_app_dirs(root):
+    """Every app directory at or below `root`, stopping at the first on each branch.
+
+    Mirrors ProgramSupport.EnumerateSuites: the root itself is checked first (a
+    directory that IS one app is one app, however many category sub-directories
+    it holds), otherwise the root is a container and we descend.
+    """
+    if not os.path.isdir(root):
+        return []
+    if looks_like_app(root):
+        return [root]
+
+    found = []
+
+    def descend(d):
+        try:
+            children = sorted(
+                c for c in os.listdir(d) if os.path.isdir(os.path.join(d, c))
+            )
+        except OSError:
+            # An unreadable directory is not an app, and must not abort the walk --
+            # the runner's own SafeDirectoryScan makes the same choice for the same
+            # reason (#2206).
+            return
+        for name in children:
+            # Dot-directories are never corpus apps: `.git`, `.github`, and the
+            # `.alpackages` symbol caches that hold Microsoft's own app.json files.
+            if name.startswith("."):
+                continue
+            child = os.path.join(d, name)
+            if looks_like_app(child):
+                found.append(child)
+            else:
+                descend(child)
+
+    descend(root)
+    return sorted(found)
+
+
+def main(argv):
+    ap = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    ap.add_argument("root", help="corpus checkout root, e.g. tests/al-language")
+    args = ap.parse_args(argv)
+
+    if not os.path.isdir(args.root):
+        print(
+            f"corpus-app-dirs: '{args.root}' is not a directory. "
+            "If this is the tests/al-language submodule, it is not checked out: "
+            "run `git submodule update --init --recursive`.",
+            file=sys.stderr,
+        )
+        return 1
+
+    dirs = enumerate_app_dirs(args.root)
+    if not dirs:
+        print(
+            f"corpus-app-dirs: no app directory found under '{args.root}'. "
+            "An empty list would make the corpus leg pass by running nothing, so "
+            "this is a hard failure. Expected at least one directory with an "
+            "app.json (or a src//test/ split) below that root.",
+            file=sys.stderr,
+        )
+        return 1
+
+    for d in dirs:
+        print(d)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/tests/corpus-app-dirs.test.py
+++ b/scripts/tests/corpus-app-dirs.test.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/corpus-app-dirs.py (issue #2984).
+
+RED before #2984: this module did not exist, and `.github/workflows/bc-tests.yml`
+named `tests/al-language/tests/al-language` directly, so a second corpus test app
+was checked out by the submodule pin and never executed -- a leg green because it
+ran nothing.
+
+GREEN proves both directions:
+
+  positive -- a corpus tree holding several app directories yields ALL of them,
+              which is the whole claim: a new test app is executed without anyone
+              editing a workflow;
+  negative -- a root with no app directory exits 1 rather than printing an empty
+              list, because an empty list is exactly the silent-skip this replaces;
+              and a directory INSIDE an app is never reported as an app of its own,
+              which would hand the runner a path it does not read as one bundle.
+
+Run: python3 scripts/tests/corpus-app-dirs.test.py
+"""
+import importlib.util
+import io
+import json
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "corpus-app-dirs.py"
+_spec = importlib.util.spec_from_file_location("corpus_app_dirs", SCRIPT_PATH)
+cad = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cad)
+
+
+def make_app(root, rel, app_id="00000000-0000-0000-0000-000000000000"):
+    """Create an app directory (app.json + one .al file) at root/rel."""
+    d = Path(root) / rel
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "app.json").write_text(json.dumps({"id": app_id, "name": rel}))
+    (d / "Some.Codeunit.al").write_text("codeunit 60000 X { }")
+    return d
+
+
+class EnumerateAppDirs(unittest.TestCase):
+    def test_every_app_directory_is_reported_not_just_the_first(self):
+        # The defect itself: the corpus offers three apps, all three must come back.
+        with tempfile.TemporaryDirectory() as tmp:
+            corpus = Path(tmp) / "al-language"
+            make_app(corpus, "tests/al-language")
+            make_app(corpus, "tests/al-language-internals-fixture")
+            make_app(corpus, "tests/al-language-onprem")
+
+            found = cad.enumerate_app_dirs(str(corpus))
+
+            self.assertEqual(
+                [
+                    str(corpus / "tests/al-language"),
+                    str(corpus / "tests/al-language-internals-fixture"),
+                    str(corpus / "tests/al-language-onprem"),
+                ],
+                found,
+            )
+
+    def test_subdirectories_of_an_app_are_part_of_that_app(self):
+        # An app's category sub-directories are not separate bundles. Reporting
+        # `record/` as an app would make the runner compile a fragment with no
+        # manifest, and the app's real tests would run under a suite key nothing
+        # in the count baseline names.
+        with tempfile.TemporaryDirectory() as tmp:
+            corpus = Path(tmp) / "al-language"
+            app = make_app(corpus, "tests/al-language")
+            (app / "record").mkdir()
+            (app / "record" / "Rec.Codeunit.al").write_text("codeunit 60001 Y { }")
+
+            self.assertEqual([str(app)], cad.enumerate_app_dirs(str(corpus)))
+
+    def test_a_root_that_is_itself_one_app_is_that_one_app(self):
+        # Mirrors ProgramSupport.EnumerateSuites' root-first check, so pointing
+        # this at a single app directory keeps meaning what it means today.
+        with tempfile.TemporaryDirectory() as tmp:
+            app = make_app(tmp, "al-language")
+            self.assertEqual([str(app)], cad.enumerate_app_dirs(str(app)))
+
+    def test_src_test_split_counts_as_an_app_without_an_app_json(self):
+        # The runner's LooksLikeSuite accepts this shape; if this script did not,
+        # a corpus app using it would be enumerated as its own sub-directories.
+        with tempfile.TemporaryDirectory() as tmp:
+            corpus = Path(tmp) / "al-language"
+            split = corpus / "tests" / "split-app"
+            (split / "src").mkdir(parents=True)
+            (split / "test").mkdir(parents=True)
+
+            self.assertEqual([str(split)], cad.enumerate_app_dirs(str(corpus)))
+
+    def test_dot_directories_are_never_apps(self):
+        # `.alpackages` holds Microsoft's own app.json files, and `.github` /
+        # `.git` are not AL at all. Reporting one would hand the runner a
+        # Microsoft symbol package as a test bundle.
+        with tempfile.TemporaryDirectory() as tmp:
+            corpus = Path(tmp) / "al-language"
+            real = make_app(corpus, "tests/al-language")
+            make_app(corpus, "tests/al-language/.alpackages/Microsoft_BaseApp")
+            make_app(corpus, ".github/probe")
+
+            self.assertEqual([str(real)], cad.enumerate_app_dirs(str(corpus)))
+
+
+class MainExitCodes(unittest.TestCase):
+    def test_finding_nothing_is_a_hard_failure_not_an_empty_list(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            empty = Path(tmp) / "al-language"
+            (empty / "docs").mkdir(parents=True)
+
+            out, err = io.StringIO(), io.StringIO()
+            with redirect_stdout(out), redirect_stderr(err):
+                rc = cad.main([str(empty)])
+
+            self.assertEqual(1, rc)
+            self.assertEqual("", out.getvalue())
+            self.assertIn("no app directory found", err.getvalue())
+
+    def test_a_missing_root_names_the_submodule_as_the_likely_cause(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out, err = io.StringIO(), io.StringIO()
+            with redirect_stdout(out), redirect_stderr(err):
+                rc = cad.main([os.path.join(tmp, "nope")])
+
+            self.assertEqual(1, rc)
+            self.assertEqual("", out.getvalue())
+            self.assertIn("git submodule update --init", err.getvalue())
+
+    def test_success_prints_one_path_per_line_and_exits_zero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            corpus = Path(tmp) / "al-language"
+            make_app(corpus, "tests/al-language")
+            make_app(corpus, "tests/al-language-onprem")
+
+            out, err = io.StringIO(), io.StringIO()
+            with redirect_stdout(out), redirect_stderr(err):
+                rc = cad.main([str(corpus)])
+
+            self.assertEqual(0, rc)
+            self.assertEqual("", err.getvalue())
+            self.assertEqual(
+                [
+                    str(corpus / "tests/al-language"),
+                    str(corpus / "tests/al-language-onprem"),
+                ],
+                out.getvalue().splitlines(),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -56,6 +56,20 @@ after the merge rather than reusing the earlier number is what caught it: all ni
 run with "Test passed cleanly but manifest declares expect-fail-known-gap". The total stays 2599
 either way — a reclassification, not a count change.
 
+**#2984 — `al-language-internals-fixture` gets a line of its own; `al-language` does not move.**
+The corpus leg used to be handed one path, `tests/al-language/tests/al-language`, so the corpus
+had exactly one suite key however many apps the submodule carried. It now enumerates
+(`scripts/corpus-app-dirs.py`) and passes each corpus app as its own bundle root, so the
+dependency-only fixture app becomes its own suite: `{ "tests": 0, "appGroups": 1 }`, the same
+shape a dependency-only `runner-extras` group has. Measured, not computed — BC 28.1, pinned
+corpus `aa49fb4`: 2 buckets, 2554 tests, exit 0, against 2554 in 1 bucket for the single-app
+invocation it replaces (72.9s → 74.6s cold wall, the 1.7s being the fixture's own compile).
+`al-language` stays at 2554 because nothing about that app's run changed. Rebased onto a
+`main` that has since bumped the pin to `ab6fbefa` (the 2554 -> 2599 entry above): 2554 is
+the number at the pin this was measured against, and enumerating the corpus's apps does not
+move whatever that number is. The fixture app is still a separate, test-free app at
+`ab6fbefa`, so its `{ "tests": 0, "appGroups": 1 }` line is unchanged by the bump.
+
 ## runner-extras
 
 ## Migrated log (everything above 2026-09-05, verbatim)

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -5,6 +5,7 @@
       "tests": { "default": 2599 },
       "appGroups": { "default": 1 }
     },
+    "al-language-internals-fixture": { "tests": { "default": 0 }, "appGroups": { "default": 1 } },
     "runner-extras": {
       "groups": {
         "bundle-page-over-dep-table": { "tests": 2 },

--- a/tests/expectations/divergence-object-metadata.json
+++ b/tests/expectations/divergence-object-metadata.json
@@ -1,0 +1,11 @@
+[
+  {
+    "codeunitId": 61200,
+    "CodeunitName": "Test Object Metadata Sys Table",
+    "Method": "ObjectMetadata_CalcFields_Metadata_HasAPayload",
+    "Mode": "expect-divergence",
+    "Reason": "object-metadata-payload-columns",
+    "Doc": "docs/limitations.md#object-metadata-system-table",
+    "Note": "Real BC writes the output of publishing the system app into the application database, so the Metadata BLOB on Object Metadata (2000000071) carries a payload; a real service tier confirmed that on all eight BC legs of StefanMaron/BusinessCentral.AL.Language.Tests#179. The runner has no application database and publishes nothing into one, so the payload columns read blank, deliberately and permanently — docs/limitations.md records the decision and the column-by-column table. Not expect-fail-known-gap: nothing here is owed. (Refusing those nine columns by name instead of reading blank is a separate, narrower want tracked by #2771; that would change HOW the runner answers, not that it answers differently from a tier.) Measured on BC 28.1 against corpus commit c2fdfb5, the head of PR #179 at the time: the OnPrem app runs 10 tests, 9 pass, and this one fails with 'The Metadata BLOB must carry a payload on a real tier' and no out-of-scope signal, which is exactly what expect-divergence reclassifies to pass-divergence. INERT until the submodule pin bumps: PR #179 has not merged, so no test in this tree matches this entry yet, and CountBaselineCheck / the classifier both leave an unmatched entry alone. Filed by an automated agent (impl-26) for issue #2984."
+  }
+]


### PR DESCRIPTION
Closes #2984

`.github/workflows/bc-tests.yml` named one corpus path,
`tests/al-language/tests/al-language`. The corpus has since gained a second test app
(`tests/al-language-onprem`, `"target": "OnPrem"`, corpus PR #179), so a submodule pin
bump that carries a new app is green by construction: the app is checked out, never
executed, and the leg still reports success. Nothing is even visibly skipped — those
tests never enter the run, so neither `--strict` nor `--count-baseline` can see them
missing.

The corpus leg now **enumerates** the corpus and passes every app as its own bundle root.
Adding a test app to the corpus is enough to make this repository's CI execute it.

## What changed

- **`scripts/corpus-app-dirs.py`** — lists every app directory below a corpus root, using
  the same rule the runner uses (`ProgramSupport.LooksLikeSuite`: own `app.json`, or the
  `src/`/`test/` split, descent stopping at the first hit). Exits 1 loudly on an empty
  list, because an empty list would put the leg straight back into "green because it ran
  nothing".
- **`bc-tests.yml`** — the corpus step reads that list into an array and passes
  `"${CORPUS_APPS[@]}"`. `mapfile` from a process substitution, never a `while read` fed
  by a here-string: that shape is exactly how the corpus's own runner silently executes
  one test app however many are listed, because the child drains the here-string from
  stdin.
- **`tests/expectations/count-baseline/`** — `al-language-internals-fixture` gets a line
  (`tests: 0`, `appGroups: 1`, the same shape a dependency-only `runner-extras` group
  has); `al-language` stays at 2554, since nothing about that app's run changed. Rationale
  in `history.md`.
- **`tests/expectations/divergence-object-metadata.json`** — the `expect-divergence` entry
  for `ObjectMetadata_CalcFields_Metadata_HasAPayload`. `Reason` + `Doc`, no `Issue`, per
  `docs/expectations.md`.
- **`CONTRIBUTING.md`** — the two "run the corpus locally" commands were the same single
  path, so a contributor would run less than CI runs.

## Separate roots, not one root over the parent

Measured, because I tried the cheaper shape first. Pointing the runner at the corpus root
compiles all three apps into ONE bundle, and the OnPrem app's `Record "Object Metadata"`
then fails `AL0185: Table 'Object Metadata' is missing` — which drops 55 objects from the
Cloud app as well and takes the whole corpus down with an `EMIT-ZERO` compile failure,
0 tests run. As separate roots the same three apps ran 2595 tests. The cold-cache smoke
step in this workflow already carried a comment saying the submodule root "sweeps multiple
apps and fixtures into one malformed bundle"; that is the same observation with a number
on it. Filed as #2996 and deliberately **not** fixed here.

## RED → GREEN

**The workflow guard** (`AlRunner.Tests/CorpusAppEnumerationWorkflowTests.cs`), against
`origin/main`'s workflow and baseline restored into the tree:

```
Failed  GatingCorpusStep_DoesNotNameASingleHardcodedBundlePath
Failed  GatingCorpusStep_EnumeratesTheCorpusAndPassesEveryAppAsItsOwnRoot
Failed  GatingCorpusStep_FailsLoudlyWhenTheEnumerationYieldsNothing
Failed  EveryCorpusAppHasACountBaselineEntry
Failed! - Failed: 4, Passed: 2, Total: 6
```

After: 6/6. Two of the six (`NeverFeedsTheAppListThroughStdin`,
`EnumerationScript_IsCheckedInAndTested`) pass in both states — they pin properties the old
workflow also had, and are guards rather than RED assertions. Said plainly rather than
counted as proof.

**The corpus itself**, BC 28.1, pinned corpus `aa49fb4`, cold cache, on the rebased tree:

| | buckets | tests | exit | cold wall |
|---|---|---|---|---|
| `tests/al-language/tests/al-language` (before) | 1 | 2554 | 0 | 72.9s |
| enumerated, `"${CORPUS_APPS[@]}"` (after) | 2 | 2554 | 0 | 79.6s |

The extra bucket is the internals fixture (0 tests, its own compile). `--count-baseline`
is satisfied in both, and I checked the guard has teeth per suite: setting the fixture's
expected count wrong produces
`[count-baseline] DROP: suite 'al-language-internals-fixture' tests count`.

**The divergence entry**, against corpus PR #179's head `c2fdfb5` — the app this repo
cannot run yet, checked out separately and pointed at directly:

```
before:  Tests: 10   pass: 9   fail: 1
         FAIL ObjectMetadata_CalcFields_Metadata_HasAPayload
              Assert.IsTrue failed. The Metadata BLOB must carry a payload on a real tier.
after:   Tests: 10   pass: 10   pass-divergence: 1   --strict exit 0
```

Also measured there, which is the whole point of the wiring: the current workflow shape
runs that app's tests **zero** times and still exits 0.

**`scripts/tests/corpus-app-dirs.test.py`** — 8 tests, run by `pr-check.yml`'s existing
`scripts/tests/*.test.py` step. Positive (all three apps come back; an app's `record/`
subdirectory is part of that app; the `src`/`test` split counts) and negative (an empty
result is exit 1, not an empty list; a missing root names the submodule; dot-directories
are never apps, so `.alpackages` cannot be handed over as a test bundle).

## Fixing the shape, not just the reported line

1. **Same pattern at another call site?** Searched the repo. Two other `bc-tests.yml`
   invocations name the single path and both **stay**, with the reason written into the
   workflow: the xmlport order-independence step narrows to one codeunit with `--test`, so
   it is not a coverage gate and cannot miss a new app (it also passes only the
   platform-apps cache, so enumerating there would make it depend on every app's closure
   resolving from that one cache); the cold-cache smoke step is a crash gate, and is the
   step whose comment documents why the merged-bundle shape does not work. The two
   `CONTRIBUTING.md` commands were the same defect aimed at humans and are fixed.
   `README.md` and `PrintGuide()` keep theirs — they illustrate pointing `al-runner` at a
   bundle, which is still exactly right.
2. **Sibling making the same assumption?** Yes, and it is now covered.
   `CountBaselineMergeShapeTests.RunnerExtrasGroupKeys_AreExactlyTheAppGroupDirectories`
   checks that every `runner-extras` app group has a baseline line; the corpus had no
   equivalent, so a newly-executed corpus app's count would be unguarded —
   `CountBaselineCheck` imposes no expectation on a suite the manifest never names.
   `EveryCorpusAppHasACountBaselineEntry` is that sibling.
3. **Two paths, one invariant?** `test-matrix.yml` (push/PR), `publish.yml` (release) and
   `bc-leg-rerun.yml` all call `bc-tests.yml`, so one edit fixes all three — which is what
   that file is for, held in place by `ReleaseTestParityTests`. Its `--count-baseline`
   marker still matches; that suite is green.

## Required contexts

Untouched. No job was added, removed or renamed, so `All BC versions passed`
(`test-matrix.yml`) and `Tests updated` (`pr-check.yml`) still report exactly as before.
`BcLegRerunWorkflowTests` is green and nothing here duplicates or weakens it.

## Deliberately left out

- **The submodule pin.** Corpus PR #179 is open, and its three Cloud legs (BC 27.0/27.3/
  27.5) are failing, so it is not close to merging. A pin bump is red by construction
  while its fix is unmerged, and this wiring is worth landing on its own — it fixes the
  gate for every future corpus app. The divergence entry above is therefore **inert** until
  the pin moves: no test in this tree matches it, and both the classifier and
  `CountBaselineCheck` leave an unmatched entry alone. If #179's test or codeunit names
  change before it merges, the pin-bump PR goes red as a plain test failure and the entry
  gets corrected then — no silent-green path either way.
- **`al-language-onprem`'s count-baseline line**, for the same reason: it would name a
  suite that does not exist here yet. The new guard forces it to be added by the PR that
  bumps the pin.
- **#2996** — the merged-bundle AL0185, and one app group's compile error zeroing its
  siblings. Reproducible, but CI does not use that shape and I did not want to guess at
  the cause.
- **The upstream `bc-test-from-source.yml` here-string bug** — one keyword in
  `MsDyn365Bc.On.Linux`, which needs rights nobody here has. It is why the corpus runs its
  OnPrem app in a separate job rather than adding to `test_app_dirs`, and why the guard
  above refuses `<<<` and `while read` on this side.

---
*Opened by an automated agent (`impl-26`) acting on the account holder's behalf.*

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
