### PR TITLE
fix(refusals): say twenty-seven scope.md citations outside the virtual tables are gaps

### DIFF
--- a/AlRunner.QueryJoin/JoinContext.cs
+++ b/AlRunner.QueryJoin/JoinContext.cs
@@ -70,7 +70,20 @@ public sealed class JoinContext
     /// <summary>
     /// Factory for AlRunner.Infrastructure.RunnerOutOfScopeException so the executor can
     /// throw the project's typed OOS exception without referencing al-runner's types directly.
-    /// (api, reason) → Exception. Throwing it loudly is required by loud-failures.
+    /// (api, surface, detail) → Exception. Throwing it loudly is required by loud-failures.
+    ///
+    /// <para>THREE parts, not two, and the split is load-bearing (#2966). al-runner builds the
+    /// reason from them as <c>not-yet-implemented — {surface}: {detail}</c>, because
+    /// ApplicationObjectBasePatches.IsPermanentOutOfScope lets an AL [TryFunction] absorb any
+    /// refusal whose reason does NOT start with "not-yet-implemented". These nine refusals are
+    /// join sub-shapes the executor cannot take yet — real BC answers all of them — so
+    /// absorbing one turns a runner gap into a green test that lies. When the executor spelled
+    /// its own reason string it got that wrong at every site.</para>
     /// </summary>
-    public required Func<string, string, Exception> OutOfScope;
+    /// <remarks>
+    /// <paramref name="surface"/> is the site's own anchor, e.g. "query-join-no-link". It must
+    /// not contain " — ": OutOfScopeMessage.TryParse cuts the api from the reason at the first
+    /// one.
+    /// </remarks>
+    public required Func<string /*api*/, string /*surface*/, string /*detail*/, Exception> OutOfScope;
 }

--- a/AlRunner.QueryJoin/JoinExecutor.cs
+++ b/AlRunner.QueryJoin/JoinExecutor.cs
@@ -347,8 +347,8 @@ public static class JoinExecutor
             "LeftOuterJoin" => JoinKind.LeftOuter,
             _ => throw ctx.OutOfScope(
                 "NavQuery (multi-dataitem join)",
-                $"query-join-{lt?.ToLowerInvariant() ?? "unknown"}-not-implemented — only InnerJoin and " +
-                "LeftOuterJoin are supported in-memory; see docs/scope.md")
+                $"query-join-{lt?.ToLowerInvariant() ?? "unknown"}-link-type",
+                "only InnerJoin and LeftOuterJoin are executed in-memory")
         };
     }
 
@@ -368,8 +368,9 @@ public static class JoinExecutor
         if (links.Count == 0)
             throw ctx.OutOfScope(
                 "NavQuery (multi-dataitem join)",
-                "query-join-no-link — a non-root dataitem has no DataItemLink; only equi-linked " +
-                "joins are supported in-memory; see docs/scope.md");
+                "query-join-no-link",
+                "a non-root dataitem has no DataItemLink; only equi-linked joins are executed " +
+                "in-memory");
 
         var plan = new List<LinkCond>(links.Count);
         foreach (var link in links)
@@ -378,8 +379,9 @@ public static class JoinExecutor
             if (linkType != "Field")
                 throw ctx.OutOfScope(
                     "NavQuery (multi-dataitem join)",
-                    $"query-join-nonfield-link — DataItemLink of type '{linkType}' (Const/Expression) " +
-                    "is not supported in-memory; only field=field equi-links are; see docs/scope.md");
+                    "query-join-nonfield-link",
+                    $"DataItemLink of type '{linkType}' (Const/Expression) is not executed in-memory; " +
+                    "only field=field equi-links are");
 
             var srcCol = _pLinkSourceColumn!.GetValue(link)!;       // parent column
             var dstCol = _pLinkDestinationColumn!.GetValue(link)!;  // child column
@@ -388,8 +390,8 @@ public static class JoinExecutor
             if (srcField == null || dstField == null)
                 throw ctx.OutOfScope(
                     "NavQuery (multi-dataitem join)",
-                    "query-join-link-no-source-field — a DataItemLink column has no backing table " +
-                    "field; see docs/scope.md");
+                    "query-join-link-no-source-field",
+                    "a DataItemLink column has no backing table field");
             EnsureNotFlowField(ctx, srcField);
             EnsureNotFlowField(ctx, dstField);
 
@@ -408,8 +410,9 @@ public static class JoinExecutor
         if (fc == "FlowField")
             throw ctx.OutOfScope(
                 "NavQuery (multi-dataitem join)",
-                "query-join-flowfield-link — a DataItemLink references a FlowField; in-memory join " +
-                "only supports links on stored (non-FlowField) fields; see docs/scope.md");
+                "query-join-flowfield-link",
+                "a DataItemLink references a FlowField; the in-memory join links only on stored " +
+                "(non-FlowField) fields");
     }
 
     private static bool LinksHold(List<LinkCond> links, Dictionary<string, object?> combo, object childRow)
@@ -639,8 +642,9 @@ public static class JoinExecutor
         if (_mNegateValue == null)
             throw ctx.OutOfScope(
                 "Query column ReverseSign (JOIN)",
-                "query-reversesign-negatevalue-missing — Microsoft.Dynamics.Nav.Runtime." +
-                "FlowFieldsHelper.NegateValue(NavValue,NavType) not found on this BC build; see docs/scope.md");
+                "query-reversesign-negatevalue-missing",
+                "Microsoft.Dynamics.Nav.Runtime.FlowFieldsHelper.NegateValue(NavValue,NavType) " +
+                "not found on this BC build");
         var navType = _pColNavType?.GetValue(columnObj);
         return _mNegateValue.Invoke(null, new object?[] { value, navType });
     }
@@ -675,9 +679,10 @@ public static class JoinExecutor
             var subDataItemName = (string)_pDataItemName!.GetValue(di)!;
             throw ctx.OutOfScope(
                 "NavQuery (multi-dataitem join with a synthesized sub-dataitem)",
-                $"query-join-synthesized-subquery-not-implemented -- dataitem '{subDataItemName}' is a " +
-                "synthesized sub-dataitem (SubQueryDefinition != null) that is not a FlowField-calculation " +
-                "sub-query; this runner does not support this join sub-shape in-memory; see docs/scope.md");
+                "query-join-synthesized-subquery",
+                $"dataitem '{subDataItemName}' is a synthesized sub-dataitem (SubQueryDefinition != null) " +
+                "that is not a FlowField-calculation sub-query; the in-memory join executor does not take " +
+                "this sub-shape yet");
         }
 
         // Pass 1: genuinely-projected (non-filter-only) columns get their real ColumnIndex slot.
@@ -765,8 +770,9 @@ public static class JoinExecutor
         if (owningTable == null)
             throw ctx.OutOfScope(
                 "NavQuery (multi-dataitem join with a FlowField column)",
-                "query-join-flowfield-owner-unresolved -- NCLMetaField.Parent did not resolve a table " +
-                "for the FlowField column; cannot locate its owning dataitem in the join; see docs/scope.md");
+                "query-join-flowfield-owner-unresolved",
+                "NCLMetaField.Parent did not resolve a table for the FlowField column, so its owning " +
+                "dataitem in the join cannot be located");
         _pTableTableId ??= owningTable.GetType().GetProperty("TableId", F);
         var ownerTableId = _pTableTableId?.GetValue(owningTable);
 
@@ -783,9 +789,10 @@ public static class JoinExecutor
         if (matches != 1)
             throw ctx.OutOfScope(
                 "NavQuery (multi-dataitem join with a FlowField column)",
-                $"query-join-flowfield-owner-ambiguous -- found {matches} real dataitem(s) whose table " +
-                "matches the FlowField's owning table (0 = not in this join; >1 = a self-join on that " +
-                "table); cannot unambiguously pick the FlowField's owner row; see docs/scope.md");
+                "query-join-flowfield-owner-ambiguous",
+                $"found {matches} real dataitem(s) whose table matches the FlowField's owning table " +
+                "(0 = not in this join; >1 = a self-join on that table), so the FlowField's owner row " +
+                "cannot be picked unambiguously");
         return matchName!;
     }
 

--- a/AlRunner.Tests/Fixtures/ExpectationsBundle/suite/Query.al
+++ b/AlRunner.Tests/Fixtures/ExpectationsBundle/suite/Query.al
@@ -1,5 +1,5 @@
-// RightOuterJoin: the runner's in-memory nested-loop join executor cannot
-// faithfully reproduce it, so opening this query throws a typed
+// RightOuterJoin: the runner's in-memory nested-loop join executor does not take
+// this shape yet, so opening this query throws a typed
 // RunnerOutOfScopeException (see AlRunner.QueryJoin/JoinExecutor.cs). The
 // fixture tests below open it WITHOUT asserterror so the throw reaches the
 // test executor and can be classified against the manifest.

--- a/AlRunner.Tests/Fixtures/ExpectationsBundle/suite/Tables.al
+++ b/AlRunner.Tests/Fixtures/ExpectationsBundle/suite/Tables.al
@@ -1,7 +1,15 @@
 // Parent + child tables backing the RightOuterJoin query. The query is the
 // fixture's deterministic typed-OOS surface: the in-memory join executor throws
-// RunnerOutOfScopeException with reason "query-join-rightouterjoin-not-implemented"
-// (permanently out of scope, so this fixture cannot rot into a passing test).
+// RunnerOutOfScopeException with reason
+// "not-yet-implemented — query-join-rightouterjoin-link-type: …".
+//
+// That reason used to read "query-join-rightouterjoin-not-implemented", and this
+// comment used to call the surface "permanently out of scope, so this fixture
+// cannot rot into a passing test". It is not permanent: RightOuterJoin is valid
+// AL that real BC executes, so it is a gap the runner means to close, and the old
+// anchor let an AL [TryFunction] absorb it (#2966). What keeps the fixture from
+// rotting is that the executor still refuses the shape at all — which
+// tests/runner-extras/standalone-suites/query-join pins from the AL side.
 
 table 60800 "Expct Customer"
 {

--- a/AlRunner.Tests/Fixtures/ExpectationsManifest/fixture-expectations.json
+++ b/AlRunner.Tests/Fixtures/ExpectationsManifest/fixture-expectations.json
@@ -4,9 +4,9 @@
     "CodeunitName": "Expct Fixture Tests",
     "Method": "GreenPath_OosDeclared",
     "Mode": "expect-oos",
-    "Reason": "query-join-rightouterjoin-not-implemented",
-    "Doc": "docs/scope.md#queries",
-    "Note": "Fixture entry: matching reason anchor on a TYPED RunnerOutOfScopeException, so the OOS throw reclassifies to pass-oos."
+    "Reason": "not-yet-implemented",
+    "Doc": "docs/limitations.md#query-shape-gaps",
+    "Note": "Fixture entry: matching reason anchor on a TYPED RunnerOutOfScopeException, so the OOS throw reclassifies to pass-oos. The anchor read 'query-join-rightouterjoin-not-implemented' with Doc=docs/scope.md#queries until #2966: RightOuterJoin is valid AL that real BC executes, so the refusal is a gap the runner means to close rather than a permanent boundary — and that Doc anchor never existed in scope.md."
   },
   {
     "codeunitId": 60810,
@@ -46,8 +46,8 @@
     "CodeunitName": "Expct Fixture Tests",
     "Method": "Drift_OosEntryButPasses",
     "Mode": "expect-oos",
-    "Reason": "query-join-rightouterjoin-not-implemented",
-    "Doc": "docs/scope.md#queries",
+    "Reason": "not-yet-implemented",
+    "Doc": "docs/limitations.md#query-shape-gaps",
     "Note": "Fixture entry: deliberately stale — the test passes, so the run must fail with 'Remove the entry'."
   },
   {

--- a/AlRunner.Tests/RunnerShapeGapClaimTests.cs
+++ b/AlRunner.Tests/RunnerShapeGapClaimTests.cs
@@ -1,0 +1,385 @@
+// RunnerShapeGapClaimTests — what the eighteen corrected refusals outside the virtual-table
+// populators actually claim, and what an AL [TryFunction] does with one (#2966).
+//
+// WHY THIS IS A RUNNER-SIDE MECHANISM TEST AND NOT AN AL BUNDLE
+// ------------------------------------------------------------
+// Each of the eighteen fires when something the RUNNER owns is absent or the wrong shape: a
+// join sub-shape its executor does not take, the skeleton session behind a User record, the
+// backing provider of a table in the install baseline, its own form registry, a report object
+// it could not construct, a null dispatch context. No AL statement can arrange any of those,
+// so no bundle under tests/runner-extras/ can drive one — the subject is the C# refusal
+// contract, which .claude/rules/bc-behavior-tests-go-upstream.md classifies as runner-specific
+// (the same shape as VirtualTableRefusalClaimTests and TryFunctionOutOfScopeTrapTests).
+//
+// WHAT WAS WRONG
+// --------------
+// All eighteen cited docs/scope.md, the manifest of what is PERMANENTLY out of scope. The
+// claim is load-bearing, not decorative — ApplicationObjectBasePatches.IsPermanentOutOfScope:
+//
+//     return oos != null && !oos.Reason.StartsWith("not-yet-implemented", StringComparison.Ordinal);
+//
+// so under a scope.md anchor an AL [TryFunction] trapped a runner gap into `false`, and the
+// test went green having quietly done without the surface. The nine query sites are the case
+// the issue named: "query-join-synthesized-subquery-not-implemented" says not-implemented in
+// words yet does not START with the token the trap reads.
+//
+// THE CONTROL ARMS
+// ----------------
+// Two of them, and they are what stops this suite from passing by discriminating on the
+// exception TYPE rather than on what the reason claims:
+//   * PermanentRefusal_IsStillTrappedByATryFunction — same type, a genuinely permanent
+//     surface, still absorbed into `false`, because that is what real BC in an environment
+//     lacking the surface does.
+//   * KeptRefusals_StillCiteScopeMd — the twenty-eight sites classified (1) were read and
+//     LEFT ALONE. If a later sweep deletes their citation the classification was wrong, and
+//     this fails rather than silently widening the change.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Xunit;
+using AlRunner;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+
+namespace AlRunner.Tests;
+
+public sealed class RunnerShapeGapClaimTests
+{
+    private const string QueryDoc = "docs/limitations.md#query-shape-gaps";
+    private const string RuntimeDoc = "docs/limitations.md#runtime-shape-gaps";
+
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    /// <summary>
+    /// The eighteen corrected sites, one entry per distinct surface, keyed by a name
+    /// <see cref="MemberData"/> can carry. The builder reproduces the arguments the real call
+    /// site passes, so a factory whose api or anchor is quietly changed fails here.
+    /// </summary>
+    private static readonly Dictionary<string, (Func<RunnerOutOfScopeException> Build, string Api, string Surface, string Doc)> Sites =
+        new()
+        {
+            ["query-join-synthesized-subquery"] = (
+                () => Invoke("Query", "NavQuery (multi-dataitem join with a synthesized sub-dataitem)", "query-join-synthesized-subquery", "the probe detail"),
+                "NavQuery (multi-dataitem join with a synthesized sub-dataitem)", "query-join-synthesized-subquery", QueryDoc),
+            ["query-having-filter-on-nonprojected-column"] = (
+                () => Invoke("Query", "NavQuery.SetRange/SetFilter on an aggregated column", "query-having-filter-on-nonprojected-column", "the probe detail"),
+                "NavQuery.SetRange/SetFilter on an aggregated column", "query-having-filter-on-nonprojected-column", QueryDoc),
+            ["query-join-runtime-filter-on-nonprojected-column"] = (
+                () => Invoke("Query", "NavQuery (multi-dataitem join)", "query-join-runtime-filter-on-nonprojected-column", "the probe detail"),
+                "NavQuery (multi-dataitem join)", "query-join-runtime-filter-on-nonprojected-column", QueryDoc),
+            ["query-join-runtime-filter-unresolved-column"] = (
+                () => Invoke("Query", "NavQuery (multi-dataitem join)", "query-join-runtime-filter-unresolved-column", "the probe detail"),
+                "NavQuery (multi-dataitem join)", "query-join-runtime-filter-unresolved-column", QueryDoc),
+            ["query-join-static-columnfilter-unresolved-column"] = (
+                () => Invoke("Query", "NavQuery (multi-dataitem join)", "query-join-static-columnfilter-unresolved-column", "the probe detail"),
+                "NavQuery (multi-dataitem join)", "query-join-static-columnfilter-unresolved-column", QueryDoc),
+            ["query-join-leftouter-default"] = (
+                () => Invoke("Query", "NavQuery (multi-dataitem join)", "query-join-leftouter-default", "the probe detail"),
+                "NavQuery (multi-dataitem join)", "query-join-leftouter-default", QueryDoc),
+            ["query-join-no-source"] = (
+                () => Invoke("Query", "NavQuery (multi-dataitem join)", "query-join-no-source", "the probe detail"),
+                "NavQuery (multi-dataitem join)", "query-join-no-source", QueryDoc),
+            ["query-reversesign-negatevalue-missing"] = (
+                () => Invoke("Query", "Query column ReverseSign", "query-reversesign-negatevalue-missing", "the probe detail"),
+                "Query column ReverseSign", "query-reversesign-negatevalue-missing", QueryDoc),
+
+            ["user-property-companion-row"] = (
+                () => Invoke("UserPropertyCompanionRow", "User (2000000120) insert", "the probe detail"),
+                "User (2000000120) insert", "user-property-companion-row", RuntimeDoc),
+            ["install-baseline"] = (
+                () => Invoke("InstallBaselineSnapshot", "install-baseline snapshot (table 27)", "the probe detail"),
+                "install-baseline snapshot (table 27)", "install-baseline", RuntimeDoc),
+            ["testpage-modal-handle"] = (
+                () => Invoke("ModalPageHandle", "TestPage modal page (handle 0000)", "the probe detail"),
+                "TestPage modal page (handle 0000)", "testpage-modal-handle", RuntimeDoc),
+            ["testpage-modal-dispatch-context"] = (
+                () => Invoke("ModalDispatchContext", "TestPage modal dispatch", "testpage-modal-dispatch-context", "the probe detail"),
+                "TestPage modal dispatch", "testpage-modal-dispatch-context", RuntimeDoc),
+            ["testpage-page-dispatch-context"] = (
+                () => Invoke("ModalDispatchContext", "TestPage page dispatch", "testpage-page-dispatch-context", "the probe detail"),
+                "TestPage page dispatch", "testpage-page-dispatch-context", RuntimeDoc),
+            ["report-construction"] = (
+                () => Invoke("ReportConstruction", "NavReport.RunRequestPage(50100)", "the probe detail"),
+                "NavReport.RunRequestPage(50100)", "report-construction", RuntimeDoc),
+        };
+
+    public static IEnumerable<object[]> SiteNames() => Sites.Keys.Select(k => new object[] { k });
+
+    private static readonly Type ShapeGapType =
+        typeof(RecordPatches).Assembly.GetType("AlRunner.Patches.RunnerShapeGap")
+        ?? throw new InvalidOperationException("AlRunner.Patches.RunnerShapeGap not found — was the factory renamed?");
+
+    private static RunnerOutOfScopeException Invoke(string factory, params string[] args)
+    {
+        var m = ShapeGapType.GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)
+            .SingleOrDefault(x => x.Name == factory && x.GetParameters().Length == args.Length
+                                  && x.GetParameters().All(p => p.ParameterType == typeof(string)));
+        Assert.True(m != null, $"RunnerShapeGap.{factory}({args.Length} strings) not found — renamed or removed.");
+        return (RunnerOutOfScopeException)m!.Invoke(null, args.Cast<object?>().ToArray())!;
+    }
+
+    /// <summary>Files whose docs/scope.md refusals were ALL corrected: none may remain.</summary>
+    private static readonly string[] FullyCorrectedFiles =
+    {
+        "RecordPatches.QueryProjection.cs",
+        "RecordPatches.QueryJoin.cs",
+        "UserTableTriggerPatches.cs",
+        "RecordPatches.InstallBaseline.cs",
+        "RunnerModalDispatch.cs",
+    };
+
+    /// <summary>
+    /// Files that carry BOTH a corrected gap and a genuinely permanent refusal. The residual
+    /// count is asserted exactly, so neither an over-sweep (deleting a true scope claim) nor
+    /// an under-sweep (leaving a gap citing scope.md) can pass.
+    /// </summary>
+    private static readonly (string File, int KeptScopeMdSites)[] PartiallyCorrectedFiles =
+    {
+        ("RunnerTestClientSession.cs", 2),   // CreatePage + ActivatePage: client-window concepts
+        ("NavReportSync.cs", 3),             // 2 layout-rendering throws + the client-callback fall-through
+    };
+
+    // ── The claim: in scope, not yet answerable for the shape found ──────────────────────
+
+    [Theory]
+    [MemberData(nameof(SiteNames))]
+    public void Refusal_ClaimsNotYetImplemented_NotAPermanentScopeBoundary(string site)
+    {
+        var (build, api, surface, _) = Sites[site];
+        var ex = build();
+
+        Assert.Equal(api, ex.Api);
+        // StartsWith, not Contains: IsPermanentOutOfScope reads the FIRST token, and
+        // ExpectationManifest.ReasonAnchor cuts at the first em-dash separator.
+        Assert.StartsWith("not-yet-implemented", ex.Reason, StringComparison.Ordinal);
+        // The surface's own anchor survives as the second token, so the surfaces stay distinct.
+        Assert.Contains(surface + ":", ex.Reason, StringComparison.Ordinal);
+        // And the caller's detail is carried through rather than swallowed.
+        Assert.Contains("the probe detail", ex.Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EveryFactoryOnRunnerShapeGap_ClaimsNotYetImplemented_AndNeverCitesScopeMd()
+    {
+        // Discovered, not listed: a factory added later is held to the same invariants without
+        // anyone remembering to extend the table above.
+        var factories = ShapeGapType
+            .GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)
+            .Where(m => m.ReturnType == typeof(RunnerOutOfScopeException)
+                        && m.GetParameters().All(p => p.ParameterType == typeof(string))
+                        // Build is the private plumbing every factory delegates to; it takes
+                        // the doc link as an argument, so probing it proves nothing about a
+                        // call site. Every PUBLIC-facing factory pins its own doc link.
+                        && m.Name != "Build")
+            .ToList();
+
+        Assert.True(factories.Count >= 6, $"expected at least the six factories, found {factories.Count}");
+
+        foreach (var m in factories)
+        {
+            var args = m.GetParameters().Select((_, i) => (object?)$"probe{i}").ToArray();
+            var ex = (RunnerOutOfScopeException)m.Invoke(null, args)!;
+            Assert.StartsWith("not-yet-implemented", ex.Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain("docs/scope.md", ex.Message, StringComparison.Ordinal);
+        }
+    }
+
+    // ── The consequence: an AL [TryFunction] must NOT read a runner gap as `false` ───────
+
+    [Theory]
+    [MemberData(nameof(SiteNames))]
+    public void Refusal_TearsThroughATryFunction_InsteadOfReadingAsFalse(string site)
+    {
+        var (build, api, _, _) = Sites[site];
+
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
+            () => BcRuntime.NavApplicationObjectBase_TryInvoke(null, () => throw build()));
+
+        Assert.Equal(api, ex.Api);
+    }
+
+    [Fact]
+    public void PermanentRefusal_IsStillTrappedByATryFunction_SoTheTestDiscriminatesOnTheClaim()
+    {
+        // Control arm one. Same exception TYPE, but a surface that really is out of scope
+        // forever — and one of THIS issue's own (1) bucket, not a borrowed example: report
+        // rendering needs an external renderer, so real BC without one answers `false` too.
+        var permanent = new RunnerOutOfScopeException(
+            "ReportResultSetProcessorFactory.GetRdlcResultSetProcessor",
+            "report-rendering-external — RDLC layout processing requires an external renderer",
+            "report-rendering");
+
+        Assert.False(BcRuntime.NavApplicationObjectBase_TryInvoke(null, () => throw permanent));
+
+        // And the same for the email surface scope.md leads with, so the arm does not rest on
+        // one anchor spelling.
+        var email = new RunnerOutOfScopeException("NavEmail.Send", "email-smtp — no SMTP transport", "email");
+        Assert.False(BcRuntime.NavApplicationObjectBase_TryInvoke(null, () => throw email));
+    }
+
+    // ── The link: one of them, and it points at a section that exists ────────────────────
+
+    [Theory]
+    [MemberData(nameof(SiteNames))]
+    public void Refusal_LinksToTheDocThatActuallyDocumentsTheLimit(string site)
+    {
+        var (build, _, _, doc) = Sites[site];
+        var msg = build().Message;
+
+        Assert.EndsWith(" — see " + doc, msg, StringComparison.Ordinal);
+        Assert.DoesNotContain("docs/scope.md", msg, StringComparison.Ordinal);
+
+        // Counted on "see docs/", not on the " — see " separator: the old defect was a reason
+        // string ending "see docs/scope.md" with BuildMessage appending its own link after it,
+        // which leaves the separator count at 1 but renders the link twice.
+        Assert.Equal(1, msg.Split("see docs/").Length - 1);
+    }
+
+    [Fact]
+    public void TheDocAnchorsThesePointAt_Exist()
+    {
+        var limitations = File.ReadAllText(Path.Combine(RepoRoot, "docs", "limitations.md"));
+
+        foreach (var anchor in new[] { "query-shape-gaps", "runtime-shape-gaps" })
+            Assert.Contains($"<a id=\"{anchor}\"></a>", limitations, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ScopeMd_NoLongerClaimsMultiDataItemQueriesArePermanentlyOutOfScope()
+    {
+        // The reason the query citations were wrong has to stay true, or the fix is moot:
+        // scope.md §3.13 asserted multi-dataitem joins and the SaveAs* family were permanent,
+        // while the corpus pins the joins as working on a real service tier.
+        var scope = File.ReadAllText(Path.Combine(RepoRoot, "docs", "scope.md"));
+
+        Assert.DoesNotContain(
+            "| Multi-dataitem queries (JOINs), aggregations", scope, StringComparison.Ordinal);
+        Assert.Contains(
+            "Nothing about NavQuery is permanently out of scope", scope, StringComparison.Ordinal);
+        // The anchor stays, because refusals used to point at it and readers still arrive here.
+        Assert.Contains("<a id=\"navquery\"></a>", scope, StringComparison.Ordinal);
+    }
+
+    // ── The wire format the reporter and the expectations manifest read ──────────────────
+
+    [Theory]
+    [MemberData(nameof(SiteNames))]
+    public void TypedAndUntypedRecovery_AgreeOnTheApiAndTheReason(string site)
+    {
+        var (build, api, _, _) = Sites[site];
+        var ex = build();
+
+        var typed = OutOfScopeMessage.FromException(ex);
+        Assert.NotNull(typed);
+        Assert.True(typed!.Value.Typed);
+        Assert.Equal(api, typed.Value.Api);
+        Assert.Equal(ex.Reason, typed.Value.Reason);
+
+        // Untyped path: message text only, which is all a Cecil-injected throw site and the TRX
+        // reader get. It cuts the api from the reason at the first " — ", so no api here may
+        // contain that separator (#2945's Feature Key Modify defect).
+        Assert.True(OutOfScopeMessage.TryParse(ex.Message, out var parsed));
+        Assert.Equal(api, parsed.Api);
+        Assert.Equal(ex.Reason, parsed.Reason);
+        Assert.DoesNotContain("docs/", parsed.Reason, StringComparison.Ordinal);
+    }
+
+    // ── The shape cannot drift back ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void CorrectedFiles_NoLongerConstructTheRefusalDirectly_OrCiteScopeMd()
+    {
+        foreach (var file in FullyCorrectedFiles)
+        {
+            var code = CodeOf(file);
+            Assert.DoesNotContain("docs/scope.md", code, StringComparison.Ordinal);
+            Assert.DoesNotContain("new AlRunner.Infrastructure.RunnerOutOfScopeException(", code, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void KeptRefusals_StillCiteScopeMd_SoTheClassificationWasNotQuietlyWidened()
+    {
+        // Control arm two. The twenty-eight sites classified "genuinely out of scope" were read
+        // and deliberately left alone. A later sweep that deletes their citation would be
+        // asserting something this change measured and rejected.
+        foreach (var (file, kept) in PartiallyCorrectedFiles)
+        {
+            var actual = Regex.Matches(CodeOf(file), "docs/scope\\.md").Count;
+            Assert.True(actual == kept,
+                $"{file}: expected {kept} kept docs/scope.md refusal(s), found {actual}");
+        }
+    }
+
+    [Fact]
+    public void AllEighteenCorrectedRefusalsUnderAlRunnerStillExist_SoNoneWasDeletedRatherThanCorrected()
+    {
+        var files = FullyCorrectedFiles.Concat(PartiallyCorrectedFiles.Select(x => x.File));
+        var total = files.Sum(f =>
+            Regex.Matches(File.ReadAllText(PathOf(f)), @"throw (AlRunner\.Patches\.)?RunnerShapeGap\.").Count);
+
+        // A refusal DELETED rather than corrected means a precondition went back to being read
+        // as a default, which is the failure this whole change is about. Asserted exactly.
+        Assert.Equal(18, total);
+    }
+
+    // ── The nine sites the issue's own measurement could not see ─────────────────────────
+
+    [Fact]
+    public void TheIsolatedJoinExecutor_RoutesItsNineRefusalsThroughTheSameFactory()
+    {
+        // AlRunner.QueryJoin/JoinExecutor.cs is a separate assembly, so it is outside the
+        // AlRunner/ tree the issue measured. It spelled its own reason strings and cited
+        // docs/scope.md at all nine — including "query-join-synthesized-subquery", the SAME
+        // shape the in-proc mirror in RecordPatches.QueryProjection.cs refuses, reached down
+        // the other path. One shape, two claims, depending on which path found it.
+        var src = File.ReadAllText(Path.Combine(RepoRoot, "AlRunner.QueryJoin", "JoinExecutor.cs"));
+        var code = string.Join('\n', src.Split('\n')
+            .Where(l => !l.TrimStart().StartsWith("//", StringComparison.Ordinal)));
+
+        Assert.DoesNotContain("docs/scope.md", code, StringComparison.Ordinal);
+        Assert.Equal(9, Regex.Matches(code, @"ctx\.OutOfScope\(").Count);
+    }
+
+    [Fact]
+    public void TheJoinContextAdapter_ComposesTheAnchor_SoTheExecutorCannotSpellItsOwn()
+    {
+        // The delegate was (api, reason) → Exception, which is what let the executor write a
+        // reason that a [TryFunction] absorbed. It is (api, surface, detail) now, and this
+        // pins BOTH halves: the adapter's arity, and what it builds.
+        var adapter = typeof(RecordPatches).GetMethod(
+            "Join_OutOfScope", BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.True(adapter != null, "RecordPatches.Join_OutOfScope not found — renamed or removed.");
+        Assert.Equal(3, adapter!.GetParameters().Length);
+
+        var ex = (RunnerOutOfScopeException)adapter.Invoke(
+            null, new object?[] { "NavQuery (multi-dataitem join)", "query-join-no-link", "the probe detail" })!;
+
+        Assert.Equal("NavQuery (multi-dataitem join)", ex.Api);
+        Assert.StartsWith("not-yet-implemented", ex.Reason, StringComparison.Ordinal);
+        Assert.Contains("query-join-no-link:", ex.Reason, StringComparison.Ordinal);
+        Assert.EndsWith(" — see " + QueryDoc, ex.Message, StringComparison.Ordinal);
+
+        // The consequence, on the executor's own path this time.
+        var thrown = Assert.Throws<RunnerOutOfScopeException>(
+            () => BcRuntime.NavApplicationObjectBase_TryInvoke(null, () => throw ex));
+        Assert.Equal(ex.Api, thrown.Api);
+    }
+
+    private static string PathOf(string file) => Path.Combine(RepoRoot, "AlRunner", "Patches", file);
+
+    /// <summary>File contents with comment lines stripped — the headers quote the OLD wording
+    /// on purpose, and the claim under test is about code.</summary>
+    private static string CodeOf(string file)
+    {
+        var path = PathOf(file);
+        Assert.True(File.Exists(path), $"{file} not found — was it renamed?");
+        return string.Join('\n', File.ReadAllLines(path)
+            .Where(l => !l.TrimStart().StartsWith("//", StringComparison.Ordinal)));
+    }
+}

--- a/AlRunner/Infrastructure/ExpectationManifest.cs
+++ b/AlRunner/Infrastructure/ExpectationManifest.cs
@@ -354,9 +354,10 @@ public static class ExpectationClassifier
         }
     }
 
-    // Manifest entries hold the bare docs/scope.md anchor ("query-join-rightouterjoin-
-    // not-implemented"), while throw sites append free-text detail after an em-dash
-    // ("<anchor> — only InnerJoin and …"). Reasons match on the anchor.
+    // Manifest entries hold the bare reason anchor — a docs/scope.md section for a permanent
+    // refusal, or "not-yet-implemented" for an in-scope surface the runner cannot answer for
+    // yet — while throw sites append free-text detail after an em-dash ("<anchor> — only
+    // InnerJoin and …"). Reasons match on the anchor.
     private static string ReasonAnchor(string reason)
     {
         int sep = reason.IndexOf(" — ", StringComparison.Ordinal);

--- a/AlRunner/Patches/NavReportSync.cs
+++ b/AlRunner/Patches/NavReportSync.cs
@@ -308,10 +308,9 @@ public static partial class NavReportSync
     {
         var report = navReportOrNull ?? CreateReportForRequestPage(reportId);
         if (report == null)
-            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            throw AlRunner.Patches.RunnerShapeGap.ReportConstruction(
                 $"NavReport.RunRequestPage({reportId})",
-                "not-yet-implemented — the runner could not construct report " + reportId +
-                " to run its request page. See docs/scope.md");
+                "the runner could not construct report " + reportId + " to run its request page");
 
         // offersOk: true — RunRequestPage opens the page with ReportIntent.Parameters, where a
         // plain OK means "these are the parameters" and is available on every request page.
@@ -438,10 +437,9 @@ public static partial class NavReportSync
     {
         var meta = GetNclMetaReportById(reportId);
         if (meta == null)
-            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            throw AlRunner.Patches.RunnerShapeGap.ReportConstruction(
                 $"NavReport.Run/RunModal({reportId})",
-                "not-yet-implemented — the runner could not construct report " + reportId +
-                " to run it. See docs/scope.md");
+                "the runner could not construct report " + reportId + " to run it");
 
         var parent = BcRuntime.SkeletonSession;
         var instance = CreateReportInstance(meta, parent!, skipRestoreSavedReportSettings: true);

--- a/AlRunner/Patches/RecordPatches.InstallBaseline.cs
+++ b/AlRunner/Patches/RecordPatches.InstallBaseline.cs
@@ -247,12 +247,11 @@ public static partial class RecordPatches
                 // RunAll()-per-boundary approach reseeded EVERYTHING, so a quiet `continue`
                 // here is a behaviour change disguised as an optimisation. Say so instead.
                 if (provider.GetType().Name != "TempTableDataProvider")
-                    throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                    throw RunnerShapeGap.InstallBaselineSnapshot(
                         $"install-baseline snapshot (table {tableId})",
-                        $"install-baseline — table {tableId} is backed by {provider.GetType().Name}, "
-                        + "which the per-codeunit baseline snapshot cannot capture or restore; "
-                        + "its install-seeded state would silently vanish at the next codeunit "
-                        + "boundary. See docs/scope.md");
+                        $"table {tableId} is backed by {provider.GetType().Name}, which the per-codeunit "
+                        + "baseline snapshot cannot capture or restore; its install-seeded state would "
+                        + "silently vanish at the next codeunit boundary");
 
                 var providerType = provider.GetType();
                 var metaTable = RequiredField(providerType, "table").GetValue(provider)

--- a/AlRunner/Patches/RecordPatches.QueryJoin.cs
+++ b/AlRunner/Patches/RecordPatches.QueryJoin.cs
@@ -131,8 +131,14 @@ public static partial class RecordPatches
 
     private static void Join_Log(string m) => QLog(m);
 
-    private static Exception Join_OutOfScope(string api, string reason)
-        => new AlRunner.Infrastructure.RunnerOutOfScopeException(api, reason);
+    // The executor's nine refusals route through the SAME factory as this file's own two and
+    // RecordPatches.QueryProjection.cs's seven, so a join sub-shape gap cannot claim one thing
+    // from the in-proc mirror and another from the isolated executor (#2966). Before this the
+    // executor spelled its own reason and cited docs/scope.md, which an AL [TryFunction]
+    // absorbed into `false` — including "query-join-synthesized-subquery", the one shape that
+    // is refused on BOTH paths and used to disagree with itself.
+    private static Exception Join_OutOfScope(string api, string surface, string detail)
+        => RunnerShapeGap.Query(api, surface, detail);
 
     // Produce a typed default NavValue (boxed as object) for an NCLMetaField, matching the
     // field's type — used to fill unmatched LeftOuterJoin child columns. BC projects a
@@ -150,11 +156,11 @@ public static partial class RecordPatches
         _mGetDefaultNavValue ??= tNavValue.GetMethod("GetDefaultNavValue",
             BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static,
             binder: null, types: new[] { tMeta, typeof(bool) }, modifiers: null)
-            ?? throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            ?? throw RunnerShapeGap.Query(
                 "NavQuery (multi-dataitem join)",
-                "query-join-leftouter-default — NavValue.GetDefaultNavValue(INavValueMetadata,bool) " +
-                "not found; cannot mint a typed default for an unmatched LeftOuterJoin child column; " +
-                "see docs/scope.md");
+                "query-join-leftouter-default",
+                "NavValue.GetDefaultNavValue(INavValueMetadata,bool) not found on this BC build, so no " +
+                "typed default can be minted for an unmatched LeftOuterJoin child column");
         // nullSupport:false → the field's typed DEFAULT (0 / '' / 0D), matching BC's NULL→default
         // projection for a non-nullable query column.
         return _mGetDefaultNavValue.Invoke(null, new object?[] { field, false });
@@ -191,9 +197,10 @@ public static partial class RecordPatches
         var queryDef = _tNCLMetaQuery!.GetProperty("QueryDefinition", BindingFlags.Public | BindingFlags.Instance)!
             .GetValue(nclMetaQuery)!;
         if (!_joinSourceByQueryDef.TryGetValue(queryDef, out var dataAccessSource))
-            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            throw RunnerShapeGap.Query(
                 "NavQuery (multi-dataitem join)",
-                "query-join-no-source — internal: join DataAccessSource was not stashed; see docs/scope.md");
+                "query-join-no-source",
+                "internal: the join's DataAccessSource was not stashed");
 
         try
         {

--- a/AlRunner/Patches/RecordPatches.QueryProjection.cs
+++ b/AlRunner/Patches/RecordPatches.QueryProjection.cs
@@ -409,11 +409,12 @@ public static partial class RecordPatches
             if (_pDataItemSubQueryDefinitionQ?.GetValue(diCheck) == null) continue;
             if (_pDataItemSourceFlowFieldQ?.GetValue(diCheck) != null) continue; // FlowField calc — gets a slot below.
             var subDataItemName = _pDataItemNameQ?.GetValue(diCheck) as string ?? "<unknown>";
-            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            throw RunnerShapeGap.Query(
                 "NavQuery (multi-dataitem join with a synthesized sub-dataitem)",
-                $"query-join-synthesized-subquery-not-implemented -- dataitem '{subDataItemName}' is a " +
-                "synthesized sub-dataitem (SubQueryDefinition != null) that is not a FlowField-calculation " +
-                "sub-query; this runner does not support this join sub-shape in-memory; see docs/scope.md");
+                "query-join-synthesized-subquery",
+                $"dataitem '{subDataItemName}' is a synthesized sub-dataitem (SubQueryDefinition != null) " +
+                "that is not a FlowField-calculation sub-query; the in-memory join executor does not take " +
+                "this sub-shape yet");
         }
 
         int maxSlot = -1;
@@ -868,10 +869,11 @@ public static partial class RecordPatches
             foreach (var (slot, expr) in conds)
             {
                 if (slot < 0 || slot >= row.FieldCount)
-                    throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                    throw RunnerShapeGap.Query(
                         "NavQuery.SetRange/SetFilter on an aggregated column",
-                        $"query-having-filter-on-nonprojected-column — filtered slot {slot} is outside the " +
-                        $"projected row (FieldCount {row.FieldCount}); cannot evaluate HAVING; see docs/scope.md");
+                        "query-having-filter-on-nonprojected-column",
+                        $"filtered slot {slot} is outside the projected row (FieldCount {row.FieldCount}), " +
+                        "so the HAVING equivalent cannot be evaluated");
                 if (!EvaluateFilterExpression(expr, row[slot], session))
                     return false;
             }
@@ -933,10 +935,11 @@ public static partial class RecordPatches
                 if (expr == null) continue;
                 if (key == null || _tNCLMetaQueryColumn == null || !_tNCLMetaQueryColumn.IsInstanceOfType(key))
                     // A non-query-column key on a query request should not occur; refuse to guess.
-                    throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                    throw RunnerShapeGap.Query(
                         "NavQuery (multi-dataitem join)",
-                        "query-join-runtime-filter-on-nonprojected-column — a runtime filter is keyed by a " +
-                        $"non-query-column ({key?.GetType().Name ?? "null"}); cannot evaluate post-projection; see docs/scope.md");
+                        "query-join-runtime-filter-on-nonprojected-column",
+                        $"a runtime filter is keyed by a non-query-column ({key?.GetType().Name ?? "null"}), " +
+                        "so it cannot be evaluated post-projection");
                 runtimeFilteredColumnIds.Add(((NCLMetaQueryColumn)key).Id);
                 // #2925: a FlowFilter-class column carries no projected value to compare against
                 // — TranslateQueryFilters has already routed it to the FlowField calculation as
@@ -948,10 +951,11 @@ public static partial class RecordPatches
                     // The filtered column isn't in ANY dataitem's QueryColumns of this query
                     // definition — should not occur (the filter dictionary is keyed by columns that
                     // came from this same query), but refuse to guess rather than silently drop it.
-                    throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                    throw RunnerShapeGap.Query(
                         "NavQuery (multi-dataitem join)",
-                        "query-join-runtime-filter-unresolved-column — a runtime filter's column could not be " +
-                        "located in the query's own DataItems/QueryColumns; see docs/scope.md");
+                        "query-join-runtime-filter-unresolved-column",
+                        "a runtime filter's column could not be located in the query's own " +
+                        "DataItems/QueryColumns");
                 conds.Add((slot, expr));
             }
 
@@ -967,10 +971,11 @@ public static partial class RecordPatches
             if (runtimeFilteredColumnIds.Contains(col.Id)) continue;
             if (IsFlowFilterColumn(col)) continue; // #2925, as above
             if (!slotMap.TryGetValue(col, out var slot))
-                throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                throw RunnerShapeGap.Query(
                     "NavQuery (multi-dataitem join)",
-                    "query-join-static-columnfilter-unresolved-column — a static ColumnFilter's column " +
-                    "could not be located in the query's own DataItems/QueryColumns; see docs/scope.md");
+                    "query-join-static-columnfilter-unresolved-column",
+                    "a static ColumnFilter's column could not be located in the query's own " +
+                    "DataItems/QueryColumns");
             conds.Add((slot, expr));
         }
         if (conds.Count == 0) return rows;
@@ -981,10 +986,11 @@ public static partial class RecordPatches
             foreach (var (slot, expr) in conds)
             {
                 if (slot >= row.FieldCount)
-                    throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                    throw RunnerShapeGap.Query(
                         "NavQuery (multi-dataitem join)",
-                        $"query-join-runtime-filter-on-nonprojected-column — filtered slot {slot} is outside the " +
-                        $"projected row (FieldCount {row.FieldCount}); cannot evaluate post-projection; see docs/scope.md");
+                        "query-join-runtime-filter-on-nonprojected-column",
+                        $"filtered slot {slot} is outside the projected row (FieldCount {row.FieldCount}), " +
+                        "so it cannot be evaluated post-projection");
                 var navValue = row[slot];
                 if (!EvaluateFilterExpression(expr, navValue, session))
                     return false;
@@ -1171,10 +1177,11 @@ public static partial class RecordPatches
                 .FirstOrDefault(m => m.Name == "NegateValue" && m.GetParameters().Length == 2);
         }
         if (_mFlowFieldsHelperNegateValue == null)
-            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            throw RunnerShapeGap.Query(
                 "Query column ReverseSign",
-                "query-reversesign-negatevalue-missing — Microsoft.Dynamics.Nav.Runtime." +
-                "FlowFieldsHelper.NegateValue(NavValue,NavType) not found on this BC build; see docs/scope.md");
+                "query-reversesign-negatevalue-missing",
+                "Microsoft.Dynamics.Nav.Runtime.FlowFieldsHelper.NegateValue(NavValue,NavType) " +
+                "not found on this BC build");
         return (NavValue?)_mFlowFieldsHelperNegateValue.Invoke(null, new object?[] { value, column.NavType });
     }
 

--- a/AlRunner/Patches/RunnerModalDispatch.cs
+++ b/AlRunner/Patches/RunnerModalDispatch.cs
@@ -43,10 +43,11 @@ public static class RunnerModalDispatch
     public static void FormRunModal(object testExecution, object runRequest)
     {
         if (testExecution == null || runRequest == null)
-            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            throw RunnerShapeGap.ModalDispatchContext(
                 "TestPage modal dispatch",
-                "testpage-modal — the runner was asked to run a modal page with no test-execution "
-                + "context or no request. See docs/scope.md");
+                "testpage-modal-dispatch-context",
+                "the runner was asked to run a modal page with no test-execution context or no "
+                + "request");
 
         var handle = FormHandleOf(runRequest);
         var type = testExecution.GetType();
@@ -105,10 +106,10 @@ public static class RunnerModalDispatch
     public static void FormRun(object testExecution, object runRequest)
     {
         if (testExecution == null || runRequest == null)
-            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            throw RunnerShapeGap.ModalDispatchContext(
                 "TestPage page dispatch",
-                "testpage-page — the runner was asked to run a page with no test-execution "
-                + "context or no request. See docs/scope.md");
+                "testpage-page-dispatch-context",
+                "the runner was asked to run a page with no test-execution context or no request");
 
         var handle = FormHandleOf(runRequest);
         var type = testExecution.GetType();

--- a/AlRunner/Patches/RunnerShapeGaps.cs
+++ b/AlRunner/Patches/RunnerShapeGaps.cs
@@ -148,10 +148,9 @@
 //     SkeletonPageCustomizationRepository.cs (1)  page personalization has no store (§3.11).
 //
 //   Several of those twenty-eight still render the link twice, because they end their reason
-//   with "See docs/scope.md" and BuildMessage appends its own — #2951 fixed 47 sites but
-//   matched capital-S "See docs/scope.md" in a different set. The CLAIM is right in every one,
-//   so the doubling is #2766's sweep and not this one's. Measured and recorded there rather
-//   than half-swept here.
+//   with "See docs/scope.md" and BuildMessage appends its own. The CLAIM is right in every
+//   one, so the doubling belongs to #2766 (still open) and not to this change — half-sweeping
+//   it here would leave that issue's measurement wrong without closing it.
 //
 // ── (0), NOT REFUSALS: six sites ─────────────────────────────────────────────────────────
 //   CliText.cs (4) is --guide and --help prose pointing readers at docs/scope.md, and it is
@@ -165,7 +164,8 @@
 //   determined on this BC build", "both triggers resolve to member id N". They should tear
 //   through. Not corrected here for the reason the issue itself gives — 25 citations across
 //   two files that in-flight TestPage work is editing, where a factory sweep would collide.
-//   Filed as a follow-up.
+//   Filed as #2999, which lists all sixteen by line AND lists the fourteen in those same two
+//   files that are genuinely permanent, so the follow-up cannot over-sweep them.
 //
 //   RecordPatches.DateVirtualTable.cs (7) and RecordPatches.cs:1773 (1) — the Date virtual
 //   table, including the sibling site that spells "date-virtual-table" itself instead of

--- a/AlRunner/Patches/RunnerShapeGaps.cs
+++ b/AlRunner/Patches/RunnerShapeGaps.cs
@@ -1,0 +1,243 @@
+// RunnerShapeGaps — the refusals raised OUTSIDE the virtual-table populators that are runner
+// gaps rather than scope boundaries, and the classification behind each one (#2966).
+//
+// ── WHAT WAS WRONG ───────────────────────────────────────────────────────────────────────
+//   #2894 fixed twelve of these in RecordPatches.ObjectMetadataSystemTable.cs and #2945 fixed
+//   55 more across the virtual-table populators. #2966 measured what was left: 77 non-comment
+//   "docs/scope.md" citations in 21 files elsewhere under AlRunner/. MOST of them are correct
+//   — report rendering, printing, external HTTP and the document service really are permanent
+//   — so this file is not a sweep that deletes the citation. It holds the sixteen that were
+//   measurably making a false claim.
+//
+//   docs/scope.md is the manifest of what is PERMANENTLY out of scope. Citing it for a surface
+//   the runner intends to support tells the next developer to stop looking, and it has a
+//   runtime consequence, which is why this is a correctness fix and not a wording one.
+//   ApplicationObjectBasePatches.IsPermanentOutOfScope:
+//
+//       return oos != null && !oos.Reason.StartsWith("not-yet-implemented", StringComparison.Ordinal);
+//
+//   Under a docs/scope.md anchor that returns TRUE, so an AL [TryFunction] traps a runner
+//   shape gap into `false` — the silent default .claude/rules/loud-failures.md exists to
+//   prevent — and the test goes green having quietly done without the surface. With the
+//   "not-yet-implemented" anchor the refusal tears through instead.
+//
+//   The issue named one example and it is real: RecordPatches.QueryProjection.cs's
+//   "query-join-synthesized-subquery-not-implemented" says not-implemented in words, but does
+//   not START with "not-yet-implemented", so it was swallowed.
+//
+// ── CLASSIFYING ALL 77 SITES BEFORE TOUCHING ANY ─────────────────────────────────────────
+//   The issue counted 96 across 23 files. Re-measured on main after #2894 and #2950 landed,
+//   with the same definition (a non-comment line mentioning docs/scope.md), it is 77 across
+//   21 files: the twelve Object Metadata sites are already fixed, and two of the issue's
+//   files no longer carry one. Every one of the 77 was read before anything was changed.
+//
+//   Buckets, the same ones #2894 and #2945 used. A refusal belongs in (1) only when BC ITSELF
+//   cannot answer, so that an AL [TryFunction] reading `false` is the OBSERVABLE BC OUTCOME
+//   rather than a runner gap quietly absorbed.
+//
+//     (0) not a refusal at all — prose or mechanism mentioning the file .............  6
+//     (1) genuinely out of scope — keep the refusal and the scope.md link ...........  28
+//     (2) in scope, not yet answerable — needs the "not-yet-implemented" anchor .....  43
+//     (3) deliberate divergence — the runner answers on purpose, never throws .......  0
+//                                                                                    ----
+//                                                                                      77
+//
+//   The author's estimate that "most are correct" holds for the refusals that cite scope.md
+//   as a scope claim: 28 of the 71 real refusals are right and stay exactly as they are. It
+//   does not hold as a majority — 43 are gaps wearing a permanence claim.
+//
+//   NOTHING landed in (3). An expect-divergence surface returns an answer rather than
+//   throwing (docs/expectations.md), so by construction it cannot be a refusal site. The one
+//   place "docs/scope.md#jobs" appears next to the word divergence is ExpectationManifest.cs,
+//   as the EXAMPLE in the error text that tells a manifest author what a Mode=expect-divergence
+//   entry's `Doc` field should look like. That is (0), and it is correct as written.
+//
+//   Of the 43 in (2), EIGHTEEN are corrected here — the ones whose classification is settled
+//   and whose file is not being edited concurrently. The other 25 are deferred with a reason
+//   and a tracking issue, at the bottom of this header.
+//
+//   NINE MORE sites are corrected that the issue's measurement could not see, because they
+//   are not under AlRunner/ at all: AlRunner.QueryJoin/JoinExecutor.cs, the isolated join
+//   executor assembly. It spelled its own reason strings and cited docs/scope.md at all nine.
+//   One of them refuses the SAME shape as the site the issue named — a synthesized
+//   sub-dataitem that is not the FlowField-calculation shape — reached down the other code
+//   path, so that one shape claimed two different things depending on which path found it.
+//   Both route through this file's Query factory now. 27 sites corrected in total.
+//
+// ── (2), CORRECTED HERE: twenty-seven sites in eight files ───────────────────────────────
+//
+//   RecordPatches.QueryProjection.cs (7), RecordPatches.QueryJoin.cs (2) and
+//   AlRunner.QueryJoin/JoinExecutor.cs (9) — eighteen sites.
+//     Multi-dataitem joins are IMPLEMENTED and pinned by the upstream corpus
+//     (tests/al-language/.../query/TestQueryJoin.al, green on a real service tier and green
+//     here). All eighteen are sub-shapes of a working join the executor cannot take yet, or a
+//     BC helper that moved: a synthesized sub-dataitem that is not the FlowField-calculation
+//     shape, a DataItemLink that is Const/Expression rather than field=field or references a
+//     FlowField, a filter keyed by a column outside the projection, NavValue.GetDefaultNavValue
+//     or FlowFieldsHelper.NegateValue missing on this BC build. BC answers every one of them.
+//
+//     The executor could not call this factory before, because JoinContext.OutOfScope was
+//     (api, reason) → Exception and the executor wrote the reason itself. It is
+//     (api, surface, detail) now, so al-runner composes the anchor in exactly one place for
+//     both paths.
+//
+//     docs/scope.md §3.13 CLAIMED they were permanent — "Multi-dataitem queries (JOINs),
+//     aggregations, SaveAsCsv/SaveAsXml/SaveAsJson … a faithful in-memory equivalent is a
+//     multi-day workstream". That section had gone stale: the joins landed, and SaveAsJson /
+//     SaveAsXml / SaveAsCsv run BC's own implementation against real query metadata. It is
+//     corrected in the same change, because leaving it would leave the file these refusals
+//     used to cite still agreeing with them. Aggregation is a real gap and stays one (#2137).
+//
+//   UserTableTriggerPatches.cs (3).
+//     The User Property row BC writes alongside every User. Real BC creates it and the runner
+//     intends to. Each refusal names a precondition the RUNNER could not meet — no session on
+//     the record under insert, no metadata for table 2000000121, a field the metatable does
+//     not state. None of the three is BC declining to do the work.
+//
+//   RunnerModalDispatch.cs (2).
+//     FormRunModal / FormRun handed a null test-execution context or a null request. A runner
+//     internal invariant, not a surface BC lacks — and precisely the kind of thing a
+//     [TryFunction] must never absorb into `false`.
+//
+//   RecordPatches.InstallBaseline.cs (1).
+//     The per-codeunit install-baseline snapshot cannot capture a table backed by something
+//     other than TempTableDataProvider. The runner's own snapshot mechanism not covering a
+//     case yet; BC has no equivalent concept to decline.
+//
+//   RunnerTestClientSession.cs (1, GetPage).
+//     No form registered under the handle the [ModalPageHandler] is being handed. The runner's
+//     own form registry did not have it; BC's client session would.
+//
+//   NavReportSync.cs (2, SyncRunRequestPage / SyncStaticRun).
+//     These two already LED with "not-yet-implemented", so they already tore through a
+//     [TryFunction] correctly — but they appended "See docs/scope.md" by hand, which
+//     BuildMessage rendered a second time, and sent the reader to a file that documents
+//     nothing about report construction. Anchor unchanged, link corrected, doubling removed.
+//
+// ── (1), LEFT ALONE: twenty-eight sites that really are permanent ────────────────────────
+//   Read and kept. Per file, so the next reader does not re-derive them:
+//
+//     NclCecilRewrite.Reports.cs (6)  RDLC / Word / Excel result-set processors, the print
+//                                     server ctor, the document-service decorator ctor.
+//                                     External renderers and an external service.
+//                                     docs/scope.md#report-rendering, a section that exists.
+//     MockTestPage.cs (6)             a page with no SourceTable; an OnQueryClosePage veto,
+//                                     which in BC leaves the page open awaiting a user (§3.11);
+//                                     a control not bound to a source-table field used to
+//                                     locate a row; and three AL-AUTHORING errors real BC also
+//                                     raises — an option value that is neither member nor
+//                                     caption (twice) and a date spelling SetValue never
+//                                     produces. For those three a [TryFunction] reading false
+//                                     IS BC's outcome, which is the (1) test.
+//     RunnerPageInstance.cs (3)       an action whose effect is RunObject; two lookups that
+//                                     come from a TableRelation and would open the related
+//                                     table's list page. All §3.11 client interaction.
+//     NavReportSync.cs (3)            two layout-rendering throws (#report-rendering) and the
+//                                     request-page client-callback fall-through: with no
+//                                     [RequestPageHandler] declared, real BC's test framework
+//                                     fails the test too.
+//     RunnerTestClientSession.cs (2)  CreatePage and ActivatePage — client-window concepts the
+//                                     runner's dispatch path never reaches.
+//     RequestPageTestPage.cs (2)      a data item or a control the report does not declare;
+//                                     both name what IS declared, both are AL-authoring errors.
+//     MediaPatches.cs (1)             image decode needs System.Drawing, absent on Linux.
+//     RecordPatches.cs (1, l.1632)    table-connections, which IS a scope.md section (§3.15).
+//     HelperShims.cs (1)              HttpClient — #external-http.
+//     NclCecilRewrite.cs (1) and
+//     NclCecilRewrite.Runtime.cs (1)  request-page UI and layout rendering.
+//     SkeletonPageCustomizationRepository.cs (1)  page personalization has no store (§3.11).
+//
+//   Several of those twenty-eight still render the link twice, because they end their reason
+//   with "See docs/scope.md" and BuildMessage appends its own — #2951 fixed 47 sites but
+//   matched capital-S "See docs/scope.md" in a different set. The CLAIM is right in every one,
+//   so the doubling is #2766's sweep and not this one's. Measured and recorded there rather
+//   than half-swept here.
+//
+// ── (0), NOT REFUSALS: six sites ─────────────────────────────────────────────────────────
+//   CliText.cs (4) is --guide and --help prose pointing readers at docs/scope.md, and it is
+//   right to. RunnerOutOfScopeException.cs (1) is BuildMessage's DefaultDoc constant — the
+//   mechanism itself. ExpectationManifest.cs (1) is the example in a validation error.
+//
+// ── (2), DEFERRED: twenty-five sites, each with a reason ─────────────────────────────────
+//   MockTestPage.cs (11) and RunnerPageInstance.cs (5) — sixteen genuine in-scope gaps mixed
+//   in with the permanent ones above: "no AL page object was built for this page", "the runner
+//   could not resolve this control", "whether field N declares an OnLookup could not be
+//   determined on this BC build", "both triggers resolve to member id N". They should tear
+//   through. Not corrected here for the reason the issue itself gives — 25 citations across
+//   two files that in-flight TestPage work is editing, where a factory sweep would collide.
+//   Filed as a follow-up.
+//
+//   RecordPatches.DateVirtualTable.cs (7) and RecordPatches.cs:1773 (1) — the Date virtual
+//   table, including the sibling site that spells "date-virtual-table" itself instead of
+//   calling a factory, which is the same defect #2945 fixed for four other tables. #2648 is
+//   editing that file concurrently; recorded on #2965 rather than split off.
+//
+//   MediaPatches.cs (1, the non-seekable content stream) — the runner cannot sniff a header it
+//   cannot rewind, which is a mechanism gap rather than a scope boundary. Left with its
+//   file-mate above, which IS permanent, so the file is corrected once rather than twice.
+//
+// ── WHY "not-yet-implemented" AND NOT A NEW EXCEPTION TYPE ───────────────────────────────
+//   Whether a BC-shape guard should raise RunnerOutOfScopeException at all is #2946, a
+//   convention decision across AlRunner/Patches/ being settled separately. This file uses the
+//   anchor as it stands and does not redesign the type.
+//
+//   No classification moves. ExpectationManifest.ReasonAnchor cuts at the first em-dash, so
+//   the anchor these report goes from e.g. "query-join-no-source" to "not-yet-implemented".
+//   No manifest entry matches on any of them: the only three Reason values declared today are
+//   task-scheduler-create-task, external-http and report-rendering-external.
+
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Patches;
+
+/// <summary>
+/// One factory per corrected surface, so a refusal cannot drift back to claiming a permanent
+/// scope boundary one call site at a time. See this file's header for the per-site
+/// classification, and <see cref="RecordPatches.VirtualTableShapeGap"/> for the same shape
+/// applied to the virtual-table populators (#2945).
+/// </summary>
+internal static class RunnerShapeGap
+{
+    /// <summary>Where a reader should look for the query-executor gaps. NOT docs/scope.md.</summary>
+    internal const string QueryDoc = "docs/limitations.md#query-shape-gaps";
+
+    /// <summary>Where a reader should look for the remaining runtime shape gaps.</summary>
+    internal const string RuntimeDoc = "docs/limitations.md#runtime-shape-gaps";
+
+    /// <summary>
+    /// The one place these refusals are built. The surface's own anchor is kept as the second
+    /// token of the reason so the surfaces stay distinguishable to a reader and to any future
+    /// expectations entry, exactly as VirtualTableShapeGap does.
+    /// </summary>
+    /// <param name="api">The BC surface the AL author touched. Must not contain " — ":
+    /// OutOfScopeMessage.TryParse cuts the api from the reason at the first one (#2945).</param>
+    /// <param name="surface">The surface's own anchor, e.g. "query-join-no-source".</param>
+    /// <param name="detail">What was actually missing.</param>
+    /// <param name="docLink">Where the reader should look.</param>
+    private static RunnerOutOfScopeException Build(string api, string surface, string detail, string docLink)
+        => new(api, $"not-yet-implemented — {surface}: {detail}", docLink);
+
+    /// <summary>A sub-shape of a working multi-dataitem query the executor cannot take yet.</summary>
+    internal static RunnerOutOfScopeException Query(string api, string surface, string detail)
+        => Build(api, surface, detail, QueryDoc);
+
+    /// <summary>The User Property row BC writes alongside every User could not be written.</summary>
+    internal static RunnerOutOfScopeException UserPropertyCompanionRow(string api, string detail)
+        => Build(api, "user-property-companion-row", detail, RuntimeDoc);
+
+    /// <summary>The per-codeunit install baseline cannot snapshot this table's backing store.</summary>
+    internal static RunnerOutOfScopeException InstallBaselineSnapshot(string api, string detail)
+        => Build(api, "install-baseline", detail, RuntimeDoc);
+
+    /// <summary>The runner's own form registry could not hand over the page asked for.</summary>
+    internal static RunnerOutOfScopeException ModalPageHandle(string api, string detail)
+        => Build(api, "testpage-modal-handle", detail, RuntimeDoc);
+
+    /// <summary>The runner's own modal/page dispatch was handed an incomplete context.</summary>
+    internal static RunnerOutOfScopeException ModalDispatchContext(string api, string surface, string detail)
+        => Build(api, surface, detail, RuntimeDoc);
+
+    /// <summary>The runner could not construct the report object to run it.</summary>
+    internal static RunnerOutOfScopeException ReportConstruction(string api, string detail)
+        => Build(api, "report-construction", detail, RuntimeDoc);
+}

--- a/AlRunner/Patches/RunnerTestClientSession.cs
+++ b/AlRunner/Patches/RunnerTestClientSession.cs
@@ -34,11 +34,10 @@ public sealed class RunnerTestClientSession : ITestClientSession
     public ITestPage GetPage(Guid formHandle, bool forClose = false)
     {
         var form = RegisteredForm(formHandle)
-            ?? throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            ?? throw RunnerShapeGap.ModalPageHandle(
                 $"TestPage modal page (handle {formHandle})",
-                "testpage-modal — no form is registered under this handle, so the runner cannot "
-                + "hand the [ModalPageHandler] the page it is being asked to drive. "
-                + "See docs/scope.md");
+                "no form is registered under this handle in the runner's own form registry, so the "
+                + "[ModalPageHandler] cannot be handed the page it is being asked to drive");
 
         // A REQUEST page is not a page over a record — it has no source table at all, so the
         // record check below would refuse it by name for something that is simply not part of

--- a/AlRunner/Patches/UserTableTriggerPatches.cs
+++ b/AlRunner/Patches/UserTableTriggerPatches.cs
@@ -95,17 +95,17 @@ public static class UserTableTriggerPatches
         if (sid == null || sid.IsZeroOrEmpty) return;
 
         var session = user.ParentSession
-            ?? throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            ?? throw RunnerShapeGap.UserPropertyCompanionRow(
                 "User (2000000120) insert",
-                "user-property-companion-row — the User record under insert has no session, so the "
-                + "User Property row BC creates alongside it cannot be written; see docs/scope.md");
+                "the User record under insert has no session, so the User Property row BC creates "
+                + "alongside it cannot be written");
 
         using var property = new NavRecord(session, UserPropertyTableId, SecurityFiltering.Ignored);
         var propertyMeta = property.MetaTable
-            ?? throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            ?? throw RunnerShapeGap.UserPropertyCompanionRow(
                 "User Property (2000000121)",
-                "user-property-companion-row — the User Property table has no metadata in this run, "
-                + "so the row BC creates alongside every User cannot be written; see docs/scope.md");
+                "the User Property table has no metadata in this run, so the row BC creates alongside "
+                + "every User cannot be written");
 
         property.SetFieldValue(FieldNoByName(propertyMeta, UserSecurityIdFieldName), sid);
         property.SetFieldValue(FieldNoByName(propertyMeta, TelemetryUserIdFieldName), NavGuid.NewGuid());
@@ -134,9 +134,9 @@ public static class UserTableTriggerPatches
         foreach (var f in RecordPatches.GetAllFields(table) ?? Enumerable.Empty<NCLMetaField>())
             if (string.Equals(f.FieldName, fieldName, StringComparison.OrdinalIgnoreCase))
                 return f.FieldNo;
-        throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+        throw RunnerShapeGap.UserPropertyCompanionRow(
             $"{table.TableName} ({table.TableId})",
-            $"user-property-companion-row — the table states no \"{fieldName}\" field, so the User "
-            + "Property row BC creates alongside every User cannot be written; see docs/scope.md");
+            $"the table states no \"{fieldName}\" field, so the User Property row BC creates alongside "
+            + "every User cannot be written");
     }
 }

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -122,12 +122,22 @@ yet, and those belong in `docs/limitations.md`. Pass the full
 against `docs/scope.md`. Nothing about the classification changes either way.
 
 `Reason` matches on the anchor: throw sites may append free-text detail after
-an ` — ` (em-dash) separator, while the entry holds only the leading
-`docs/scope.md` anchor (e.g. a throw site's
-`query-join-rightouterjoin-not-implemented — only InnerJoin and …` matches an
-entry declaring `query-join-rightouterjoin-not-implemented`). Anchors are
-compared for **equality** after that trim, not by prefix or substring:
-`external-htt` does not match `external-http`.
+an ` — ` (em-dash) separator, while the entry holds only the leading anchor
+(e.g. a throw site's
+`not-yet-implemented — query-join-rightouterjoin-link-type: only InnerJoin and …`
+matches an entry declaring `not-yet-implemented`). Anchors are compared for
+**equality** after that trim, not by prefix or substring: `external-htt` does not
+match `external-http`.
+
+One consequence is worth stating plainly, because it costs the manifest real
+precision: every in-scope shape gap reports the SAME anchor,
+`not-yet-implemented`, so an entry declaring it matches whichever such refusal
+that test raises rather than one specific surface. That is the trade the anchor
+exists to make — the token is what stops an AL `[TryFunction]` from absorbing a
+runner gap into `false` (`ApplicationObjectBasePatches.IsPermanentOutOfScope`),
+and the surface's own anchor is kept as the reason's second token for a reader.
+Use `expect-fail-known-gap` with an `Issue` when the entry needs to name one
+surface and one piece of tracked work.
 
 ### `expect-divergence` vs the other two failure modes
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -288,6 +288,8 @@ runs. AL that needs the target codeunit's logic to actually execute should call 
 
 ### Query — joins and dataset export work; aggregation does not
 
+<a id="query-shape-gaps"></a>
+
 Query objects work in-memory: `Open` reads from the mock table store, `Read`
 iterates rows, `Close` releases the result set. `SetFilter`, `SetRange`, and
 `TopNumberOfRows` filter and limit the results, including runtime `SetRange`/
@@ -304,6 +306,19 @@ the query's real metadata and produce a genuine dataset — they are not stubbed
 
 There is no `Query.SaveAsExcel` method in the AL language; this doc previously
 listed one that doesn't exist.
+
+**Sub-shapes of a working join the executor refuses rather than guessing.** Nine
+guards in `AlRunner/Patches/RecordPatches.QueryProjection.cs` and
+`RecordPatches.QueryJoin.cs` raise `RunnerOutOfScopeException` when the query the
+executor is handed is a shape it cannot take: a synthesized sub-dataitem that is
+not the FlowField-calculation shape, a runtime `SetRange`/`SetFilter` or a static
+`ColumnFilter` keyed by a column outside the projected row, or a BC helper
+(`NavValue.GetDefaultNavValue`, `FlowFieldsHelper.NegateValue`) that is not on this
+build. They carry the reason anchor `not-yet-implemented`, so an AL `[TryFunction]`
+cannot trap one into `false`
+([#2966](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2966)).
+These are gaps, not scope boundaries: real BC answers every one of them, and
+`docs/scope.md` no longer claims otherwise.
 
 **Not supported: aggregation.** A column with `Method = Sum` (or `Count`,
 `Average`, `Min`, `Max`) does not aggregate or group — the runner returns each
@@ -826,6 +841,28 @@ there, so everything behind it is unmeasured.
 
 These are not architectural limits. They can be fixed; report them at
 https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues.
+
+<a id="runtime-shape-gaps"></a>
+
+- **Runtime shape gaps outside the virtual tables — the runner refuses rather than answering
+  a shape it cannot produce.** Nine further guards raise `RunnerOutOfScopeException` with the
+  reason anchor `not-yet-implemented`, so an AL `[TryFunction]` cannot absorb one into `false`
+  ([#2966](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2966)):
+  - the **User Property** row BC writes alongside every `User` insert, when the record under
+    insert carries no session, when table 2000000121 has no metadata in this run, or when the
+    metatable states no field of the name the writer needs
+    (`AlRunner/Patches/UserTableTriggerPatches.cs`);
+  - the **per-codeunit install baseline**, when a table is backed by something other than
+    `TempTableDataProvider` and so cannot be snapshotted or restored across a codeunit
+    boundary (`RecordPatches.InstallBaseline.cs`);
+  - a **[ModalPageHandler]** asked for a form handle the runner's own form registry does not
+    hold (`RunnerTestClientSession.cs`), and modal/page dispatch handed a null test-execution
+    context or request (`RunnerModalDispatch.cs`);
+  - **report construction**, when the runner cannot build the report object at all to run it
+    or its request page (`NavReportSync.cs`).
+
+  Real BC does all of these, so each is the runner failing to keep up rather than a surface BC
+  also lacks — which is the test for whether a refusal may cite `docs/scope.md` at all.
 
 <a id="virtual-table-shape-gaps"></a>
 

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -224,11 +224,23 @@ invokes `OnInitReport` → `OnPreReport` → per-DataItem `OnPreDataItem` / `OnP
 |---|---|
 | `Debugger.Attach`, `Break`, `StepInto`, etc. | No debug loop. See `docs/limitations.md#no-debugger-infrastructure`. |
 
-### §3.13. NavQuery — multi-dataitem queries <a id="navquery"></a>
+### §3.13. NavQuery — RETIRED, NavQuery is in scope <a id="navquery"></a>
 
-| API | Reason |
-|---|---|
-| Multi-dataitem queries (JOINs), aggregations (`Sum`, `Avg`, `Min`, `Max`), `SaveAsCsv`/`SaveAsXml`/`SaveAsJson`/`SaveAsExcel` | NavQuery compiles AL into SQL projections. A faithful in-memory equivalent is a multi-day workstream. Single-dataitem queries are in scope today (§2). |
+**Nothing about NavQuery is permanently out of scope.** This section used to list
+multi-dataitem queries (JOINs), aggregations and `SaveAsCsv`/`SaveAsXml`/`SaveAsJson` as
+permanent, on the grounds that "a faithful in-memory equivalent is a multi-day workstream".
+That went stale: inner and left-outer joins across dataitems run a real in-memory join,
+pinned by the upstream corpus (`query/TestQueryJoin.al`, green on a real service tier), and
+`SaveAsJson` / `SaveAsXml` / `SaveAsCsv` run BC's own implementation against real query
+metadata. There is no `Query.SaveAsExcel` in the AL language.
+
+The section is kept as a pointer rather than deleted, because refusals raised by the query
+executor used to cite it and a reader may still arrive here. What remains is a **gap**, not a
+boundary: aggregation ([#2137](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2137))
+and the join sub-shapes the executor cannot take yet — see
+`docs/limitations.md#query-shape-gaps`. Both are tracked work, and the refusals now say so
+with the `not-yet-implemented` anchor
+([#2966](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2966)).
 
 ### §3.14. .NET interop (DotNet AL type) <a id="dotnet-interop"></a>
 

--- a/tests/runner-extras/standalone-suites/query-join/src/QueryJoinTests.al
+++ b/tests/runner-extras/standalone-suites/query-join/src/QueryJoinTests.al
@@ -46,18 +46,33 @@ codeunit 60391 "QJ Query Join Tests"
     end;
 
     [Test]
-    procedure RightOuterJoin_IsOutOfScope_ThrowsNamedReason()
+    procedure RightOuterJoin_IsAGap_ThrowsAReasonThatTearsThroughATryFunction()
     var
         Q: Query "QJ Cust Orders Right";
     begin
-        // RightOuterJoin is not faithfully reproducible by the in-memory nested-loop join.
-        // Per loud-failures, opening/reading it must throw RunnerOutOfScopeException naming
-        // the API and a specific reason — never silently return wrong rows.
+        // RightOuterJoin is valid AL and real BC executes it; the in-memory nested-loop join
+        // executor does not take it yet. Per loud-failures, opening/reading it must throw
+        // RunnerOutOfScopeException naming the API and a specific reason — never silently
+        // return wrong rows.
         Seed();
         asserterror begin
             Q.Open();
             Q.Read();
         end;
-        Assert.ExpectedError('query-join-rightouterjoin-not-implemented');
+
+        // Three claims, and each one is load-bearing (#2966).
+        //
+        // 1. The refusal LEADS with "not-yet-implemented". That token is what
+        //    ApplicationObjectBasePatches.IsPermanentOutOfScope reads to decide whether an AL
+        //    [TryFunction] may absorb the refusal into `false`. This is a runner gap, so it
+        //    must tear through instead. Before #2966 the reason led with the surface anchor
+        //    and a [TryFunction] here read `false` with nothing printed.
+        if StrPos(GetLastErrorText(), 'not-yet-implemented') = 0 then
+            Error('Expected the not-yet-implemented anchor, got: %1', GetLastErrorText());
+        // 2. It no longer claims docs/scope.md, the permanently-out-of-scope manifest.
+        if StrPos(GetLastErrorText(), 'docs/scope.md') > 0 then
+            Error('The refusal still cites docs/scope.md: %1', GetLastErrorText());
+        // 3. And it still names WHICH sub-shape was refused, so the message stays actionable.
+        Assert.ExpectedError('query-join-rightouterjoin-link-type');
     end;
 }


### PR DESCRIPTION
Closes #2966

The issue counted 96 `docs/scope.md` citations in 23 files outside the directory #2945 covered, said most of them are correct, and named one that is the same defect. I read every one before changing anything.

## The re-measurement

Same definition the issue used — a non-comment line mentioning `docs/scope.md` — taken on `main` after #2894 and #2950 landed: **77 sites across 21 files**, not 96 across 23. The twelve Object Metadata sites are already fixed and two of the listed files no longer carry one.

Then I found nine more the issue's measurement could not see, because they are not under `AlRunner/` at all: `AlRunner.QueryJoin/JoinExecutor.cs`, the isolated join-executor assembly.

## Classifying all 77

| bucket | count |
|---|---|
| (0) not a refusal — prose or mechanism that mentions the file | 6 |
| (1) genuinely out of scope — keep the refusal and the link | 28 |
| (2) in scope, not yet answerable — needs `not-yet-implemented` | 43 |
| (3) deliberate divergence | 0 |

**The author's estimate holds in kind but not as a majority.** Of the 71 real refusals, 28 are right and stay exactly as they are — report rendering, printing, external HTTP, the document service, `HttpClient`, page personalization, table connections, image decode without System.Drawing, and eight AL-authoring errors real BC also raises. The other 43 are gaps wearing a permanence claim.

Nothing landed in (3), and that is not an oversight. An `expect-divergence` surface returns an answer rather than throwing (`docs/expectations.md`), so by construction it cannot be a refusal site. The one place `docs/scope.md#jobs` appears next to the word divergence is `ExpectationManifest.cs`, as the example in the error text that tells a manifest author what a `Mode=expect-divergence` entry's `Doc` should look like. That is (0), and it is correct as written.

Of the 43, **27 are corrected here**: 18 in `AlRunner/` plus the 9 in the executor. The per-site verdict for all 77 is in `AlRunner/Patches/RunnerShapeGaps.cs`'s header, including the 28 kept and the 25 deferred, so the next reader does not re-derive it.

## Why this is a correctness fix

`ApplicationObjectBasePatches.IsPermanentOutOfScope`:

```csharp
return oos != null && !oos.Reason.StartsWith("not-yet-implemented", StringComparison.Ordinal);
```

Under a `docs/scope.md` anchor that returns `true`, so an AL `[TryFunction]` trapped a runner gap into `false` and the test went green having quietly done without the surface — the silent default `loud-failures.md` exists to prevent. The site the issue named is exactly that: `query-join-synthesized-subquery-not-implemented` says not-implemented in words but does not *start* with the token the trap reads.

## What changed, and why each is in scope

**Query — 18 sites.** Multi-dataitem joins are implemented and pinned by the upstream corpus (`query/TestQueryJoin.al`, green on a real service tier and green here). All 18 are sub-shapes of a working join the executor does not take yet, or a BC helper that moved: a synthesized sub-dataitem that is not the FlowField-calculation shape, a `DataItemLink` that is Const/Expression rather than field=field, a filter keyed by a column outside the projection, `NavValue.GetDefaultNavValue` or `FlowFieldsHelper.NegateValue` missing on this build. Real BC answers every one.

**User Property companion row — 3.** Real BC writes that row alongside every `User` insert and the runner means to. Each refusal names a precondition the *runner* could not meet.

**Modal/page dispatch — 2**, **install-baseline snapshot — 1**, **modal page handle — 1**. Runner internals, not surfaces BC lacks.

**Report construction — 2.** These already led with `not-yet-implemented`, so they already tore through correctly, but they appended `See docs/scope.md` by hand, which `BuildMessage` rendered a second time and which documents nothing about report construction.

## Fixing the shape, not just the reported line

**1. Same wrong pattern at another call site?** Yes, and it is outside the tree the issue measured. `AlRunner.QueryJoin/JoinExecutor.cs` refuses nine join sub-shapes, spelled its own reason strings, and cited `docs/scope.md` at all nine. One of them refuses the **same shape** as the site the issue named — a synthesized sub-dataitem — reached down the other code path, so that one shape claimed two different things depending on which path found it.

**2. A sibling making the same assumption?** Yes. `JoinContext.OutOfScope` was `(api, reason) → Exception`, which is *why* the executor spelled its own anchor: it had nowhere else to put the surface name. It is `(api, surface, detail)` now, so al-runner composes the anchor in one place for both paths, and the executor cannot get it wrong again.

**3. Two paths writing the same state with different invariants?** Yes, and it is the same one — the in-process mirror in `RecordPatches.QueryProjection.cs` and the isolated executor both refuse the synthesized-sub-dataitem shape and disagreed about what it meant. Both route through `RunnerShapeGap.Query` now.

## An existing test had encoded the wrong claim as correct

`AlRunner.Tests/Fixtures/ExpectationsManifest/fixture-expectations.json` declared the RightOuterJoin refusal as `Reason: "query-join-rightouterjoin-not-implemented"`, `Doc: "docs/scope.md#queries"` — an anchor that does not exist in `scope.md` — and `Tables.al`'s comment called the surface "permanently out of scope, so this fixture cannot rot into a passing test". RightOuterJoin is valid AL that real BC executes. Both are corrected, and the comment now says what actually keeps the fixture from rotting.

`docs/expectations.md` gains the consequence stated plainly: every in-scope shape gap reports the same `not-yet-implemented` anchor, so a manifest entry declaring it matches whichever such refusal a test raises rather than one surface. That is the trade the anchor exists to make, and `expect-fail-known-gap` with an `Issue` is the mode for naming one surface.

## `docs/scope.md` §3.13 was stale, and it had to move

§3.13 listed multi-dataitem JOINs, aggregations and `SaveAsCsv`/`SaveAsXml`/`SaveAsJson` as permanently out of scope, "a faithful in-memory equivalent is a multi-day workstream". The joins landed and the corpus pins them on a real service tier; `SaveAsJson`/`SaveAsXml`/`SaveAsCsv` run BC's own implementation. Leaving it would have left the file these refusals used to cite still agreeing with them. The anchor stays so readers arriving from an old message land somewhere useful, and the section now points at `docs/limitations.md#query-shape-gaps`. Aggregation is a real gap and stays one (#2137).

Two new sections in `docs/limitations.md` — `#query-shape-gaps` and `#runtime-shape-gaps` — carry what these refusals now link to.

## What is deliberately left out

- **Sixteen TestPage gaps** in `MockTestPage.cs` and `RunnerPageInstance.cs`, for the reason the issue itself gives: 25 citations across two files that in-flight TestPage work is editing. Filed as **#2999**, which lists all sixteen by line **and** lists the fourteen in those same two files that are genuinely permanent, so the follow-up cannot over-sweep them.
- **The Date virtual table** — the seven in `RecordPatches.DateVirtualTable.cs` plus the sibling at `RecordPatches.cs:1773` that spells `date-virtual-table` itself instead of calling a factory. #2648 is editing that file; recorded on **#2965** rather than split off.
- **`MediaPatches.cs`'s non-seekable content stream** — a gap, but its file-mate is genuinely permanent, so the file is corrected once rather than twice.
- **The doubled-link residue** at several kept sites. The claim is right in every one, so it is **#2766**'s sweep; half-sweeping it here would leave that issue's measurement wrong without closing it.
- **Whether a BC-shape guard should raise `RunnerOutOfScopeException` at all** — **#2946**, still open, and this change uses the anchor as it stands rather than redesigning the type.

## RED → GREEN

RED was produced against executing code, not a compile error: the factory was flipped back to emit the old strings, and the executor, `JoinContext` and the adapter reverted one commit.

```
Failed!  - Failed: 61, Passed: 4, Total: 65
```

The 4 that stayed green are the control arms — the doc-anchor existence check, the `scope.md` §3.13 check, `KeptRefusals_StillCiteScopeMd` (the 28 sites classified permanent must keep their citation, so an over-sweep fails too), and `PermanentRefusal_IsStillTrappedByATryFunction`, which asserts the **same exception type** with a `report-rendering-external` reason and an `email-smtp` reason still read as `false`. Without that arm the tear-through theory could pass by discriminating on the type rather than on the claim.

GREEN, re-run after rebasing onto `0cbf4562` (never carried across the rebase):

```
dotnet test AlRunner.Tests -c Release --framework net8.0 --no-build --filter \
  "FullyQualifiedName~RunnerShapeGapClaimTests|FullyQualifiedName~VirtualTableRefusalClaimTests|\
FullyQualifiedName~ObjectMetadataSystemTableRefusalTests|FullyQualifiedName~Expectation|\
FullyQualifiedName~OutOfScope|FullyQualifiedName~NavDotNetPatches"
Passed!  - Failed: 0, Passed: 219, Skipped: 6, Total: 225, Duration: 14 s
```

And the AL side, run the way CI runs it:

```
dotnet run --no-build --project AlRunner -c Release --framework net8.0 -- \
  tests/runner-extras tests/runner-extras/standalone-suites \
  --package-cache "$HOME/.al-runner/platform-apps" --package-cache "$HOME/.al-runner/test-apps" \
  --strict --count-baseline tests/expectations/count-baseline/test-count-baseline.json --cache <private>
Tests: 386 total  pass: 386  fail: 0  error: 0
```

No AL test was added or removed — `RightOuterJoin_IsOutOfScope_ThrowsNamedReason` was renamed and strengthened in place — so `test-count-baseline.json` does not move, and the `--count-baseline` run above is what confirms that rather than an assumption.

## One pre-existing failure, not mine

`CollateralFailureReportingTests.BundleProgress_WithoutSuiteErrors_IsExactlyTheOldSingleLine` and `…_WithSuiteErrors_NamesThemUnderTheCountLine` fail on `origin/main` at `0cbf4562` in a clean worktree, with no change of mine applied:

```
Failed!  - Failed: 2, Passed: 26, Total: 28
```

## Why the tests are in `AlRunner.Tests/`, not `tests/runner-extras/`

Most of these 27 fire when something the runner owns is absent or the wrong shape — a join sub-shape its executor does not take, the skeleton session behind a `User` record, the backing provider of a table in the install baseline, its own form registry, a null dispatch context. No AL statement can arrange any of that, so the subject is the C# refusal contract, which `bc-behavior-tests-go-upstream.md` classifies as runner-specific.

The one that AL *can* reach is RightOuterJoin, and it is pinned from AL too:
`tests/runner-extras/standalone-suites/query-join` now asserts three things instead of one — that the reason leads with `not-yet-implemented` (the token the `[TryFunction]` trap reads), that it no longer cites `docs/scope.md`, and that it still names which sub-shape was refused.

The new C# class does not hard-code only a list: alongside the explicit per-site table it discovers every factory on `RunnerShapeGap` by reflection and holds it to the same invariants, so a factory added later is covered without anyone remembering.

---
*Authored by an automated agent (`impl-29`) acting on the account holder's behalf.*

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
