### PR TITLE
fix(testpage): record a refused control write so ValidationErrorCount can read it

### DIFF
--- a/AlRunner.Tests/TestFieldValidationErrorsTests.cs
+++ b/AlRunner.Tests/TestFieldValidationErrorsTests.cs
@@ -1,0 +1,232 @@
+// TestFieldValidationErrorsTests — contract tests for AlRunner.TestFieldValidationErrors,
+// the ledger a TestPage control keeps of the writes it refused (issue #2900).
+//
+// WHAT IS PINNED HERE AND WHAT IS NOT
+//
+// The BC claim — that `asserterror TestPage.Field.SetValue(x)` leaves
+// `Field.ValidationErrorCount() = 1` and `Field.GetValidationError(1)` equal to the bare error
+// text — is a statement about Business Central and belongs upstream, not here
+// (.claude/rules/bc-behavior-tests-go-upstream.md). It is filed as corpus codeunit
+// "TVE Validation Error Tests"; this file pins the runner-side MECHANISM that has to be right
+// for that claim to hold, so a regression is caught in milliseconds without the BC engine.
+//
+// The two halves the runner owns:
+//
+//   1. The ledger's own arithmetic — count, id assignment, and the "consume" that stops BC's
+//      NavTestField.CheckError from re-raising an error it has already reported.
+//   2. WHICH exceptions become a recorded validation error. Only BC/AL errors
+//      (NavNCLException) do. A RunnerOutOfScopeException must tear straight through: recording
+//      it would let AL's `asserterror` absorb a loud refusal and read as a green test, which is
+//      the silent-failure shape .claude/rules/loud-failures.md exists to prevent.
+//
+// RED/GREEN: before this change ValidationErrorCount and GetValidationError were hardcoded
+// `=> 0` / `=> string.Empty` on both LiveNavTestField and PageVariableTestField, so every test
+// below that asserts a non-zero count or a recovered message fails against that implementation,
+// and Microsoft's own Codeunit134614.TestRemoveSUPERPermissionsByUserAll failed on
+// `Assert.AreEqual(1, …ValidationErrorCount())` reading 0.
+using System;
+using AlRunner;
+using AlRunner.Infrastructure;
+using Microsoft.Dynamics.Nav.Types.Exceptions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestFieldValidationErrorsTests
+{
+    private static NavNCLDialogException AlError(string message)
+    {
+        // The same type AL's Error() surfaces as — see ErrorClassifier's class comment.
+        var t = Type.GetType(
+            "Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLDialogException, Microsoft.Dynamics.Nav.Types");
+        Assert.NotNull(t);
+        var ctor = t!.GetConstructor(new[] { typeof(string) });
+        Assert.NotNull(ctor);
+        return (NavNCLDialogException)ctor!.Invoke(new object[] { message });
+    }
+
+    // ── the ledger's arithmetic ──────────────────────────────────────────────
+
+    [Fact]
+    public void AFreshLedger_CountsNothingAndHasNoIds()
+    {
+        var errors = new TestFieldValidationErrors();
+
+        Assert.Equal(0, errors.Count);
+        Assert.Equal(0L, errors.MaxId);
+        Assert.Equal(0L, errors.LastUsedId);
+    }
+
+    [Fact]
+    public void RecordingAnError_RaisesMaxIdAboveLastUsed()
+    {
+        // This inequality IS the trigger: BC's NavTestField.CheckError snapshots
+        // LastUsedValidationErrorId before the write and raises NavTestValidationException when
+        // MaxValidationErrorId has moved past it afterwards. Equal ids mean no exception, so a
+        // ledger that recorded without moving MaxId would swallow the refusal entirely.
+        var errors = new TestFieldValidationErrors();
+
+        errors.Record("There should be at least one enabled 'SUPER' user.");
+
+        Assert.Equal(1, errors.Count);
+        Assert.Equal(1L, errors.MaxId);
+        Assert.Equal(0L, errors.LastUsedId);
+        Assert.True(errors.MaxId > errors.LastUsedId);
+    }
+
+    [Fact]
+    public void ReadingAnError_ReturnsItVerbatimAndConsumesItsId()
+    {
+        var errors = new TestFieldValidationErrors();
+        errors.Record("There should be at least one enabled 'SUPER' user.");
+
+        Assert.Equal("There should be at least one enabled 'SUPER' user.", errors.Get(0));
+
+        // Consumed: BC's own throw path calls GetValidationError, so the NEXT CheckError —
+        // the `.Value` getter, say — must not re-raise the error BC has already reported.
+        Assert.Equal(1L, errors.LastUsedId);
+        Assert.False(errors.MaxId > errors.LastUsedId);
+    }
+
+    [Fact]
+    public void SeveralErrors_KeepTheirOrderAndConsumeUpToTheOneRead()
+    {
+        var errors = new TestFieldValidationErrors();
+        errors.Record("first");
+        errors.Record("second");
+        errors.Record("third");
+
+        Assert.Equal(3, errors.Count);
+        Assert.Equal(3L, errors.MaxId);
+        Assert.Equal("first", errors.Get(0));
+        Assert.Equal("third", errors.Get(2));
+        Assert.Equal(3L, errors.LastUsedId);
+
+        // Reading an OLDER one afterwards must not un-consume the newer id, or BC would
+        // re-raise an error it already reported.
+        Assert.Equal("second", errors.Get(1));
+        Assert.Equal(3L, errors.LastUsedId);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(1)]
+    [InlineData(5)]
+    public void ReadingOutOfRange_ThrowsTheExceptionBcConvertsToItsOwn(int index)
+    {
+        // BC's NavTestField.ALGetValidationError(int) catches IndexOutOfRangeException and
+        // rethrows NavNCLIndexOutOfBoundsException — the AL-visible error for
+        // GetValidationError(0) (it subtracts 1, so AL index 0 reaches -1 here) or an index
+        // past the end. Answering "" instead would swallow BC's own bounds check and let an AL
+        // test compare two empty strings successfully.
+        //
+        // One error is recorded, so index 0 is the ONLY valid one; -1, 1 and 5 are all out.
+        var errors = new TestFieldValidationErrors();
+        errors.Record("only");
+        Assert.Equal("only", errors.Get(0));
+
+        Assert.Throws<IndexOutOfRangeException>(() => errors.Get(index));
+    }
+
+    // ── which exceptions become a validation error ───────────────────────────
+
+    [Fact]
+    public void ASuccessfulWrite_RecordsNothing()
+    {
+        var errors = new TestFieldValidationErrors();
+        var ran = false;
+
+        errors.RunRecordingRefusal(() => ran = true);
+
+        Assert.True(ran);
+        Assert.Equal(0, errors.Count);
+        Assert.Equal(0L, errors.MaxId);
+    }
+
+    [Fact]
+    public void AnAlError_IsRecordedAndDoesNotEscape()
+    {
+        // The whole point: BC's ITestField contract is "the setter records, BC raises". A setter
+        // that throws leaves ValidationErrorCount at 0 and BC with nothing to wrap.
+        var errors = new TestFieldValidationErrors();
+
+        errors.RunRecordingRefusal(
+            () => throw AlError("There should be at least one enabled 'SUPER' user."));
+
+        Assert.Equal(1, errors.Count);
+        Assert.Equal("There should be at least one enabled 'SUPER' user.", errors.Get(0));
+    }
+
+    [Fact]
+    public void AnOutOfScopeRefusal_TearsThroughAndIsNotRecorded()
+    {
+        var errors = new TestFieldValidationErrors();
+
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
+            () => errors.RunRecordingRefusal(
+                () => throw new RunnerOutOfScopeException("TestPage control 42", "testpage-x")));
+
+        Assert.Equal("TestPage control 42", ex.Api);
+        Assert.Equal(0, errors.Count);
+    }
+
+    [Fact]
+    public void AnOutOfScopeMessageOnABcException_TearsThroughAndIsNotRecorded()
+    {
+        // The Cecil-injected throw sites raise the "out-of-scope: <api> — <reason>" convention
+        // as a NavNCLDialogException, which tests/expectations/ matches on. Recording it would
+        // bury an out-of-scope signal inside BC's validation wrapper.
+        var errors = new TestFieldValidationErrors();
+
+        var ex = Assert.Throws<NavNCLDialogException>(
+            () => errors.RunRecordingRefusal(
+                () => throw AlError(
+                    "out-of-scope: NavReport.SaveAs — report-rendering — see docs/scope.md#report-rendering")));
+
+        Assert.Contains("out-of-scope: NavReport.SaveAs", ex.Message);
+        Assert.Equal(0, errors.Count);
+    }
+
+    [Fact]
+    public void ARunnerBug_TearsThroughAndIsNotRecorded()
+    {
+        // A NullReferenceException from the runner's own code is not a BC validation error.
+        // Recording it would present a runner defect to AL as a refusal the page made.
+        var errors = new TestFieldValidationErrors();
+
+        Assert.Throws<NullReferenceException>(
+            () => errors.RunRecordingRefusal(() => throw new NullReferenceException("runner bug")));
+
+        Assert.Equal(0, errors.Count);
+    }
+
+    // ── the message BC composes from what was recorded ───────────────────────
+
+    [Fact]
+    public void BcWrapsTheRecordedText_InTheShapeTheCorpusMeasured()
+    {
+        // Not an assumption: Lang.TestValidationException reads
+        // "Validation error for Field: {0},  Message = '{1}'" in
+        // Microsoft.Dynamics.Nav.Language.dll on the 28.1 artifact, and corpus PR #163 measured
+        // the resulting string on all eight BC legs. This test asserts that BC's own
+        // NavTestValidationException.Create — the call NavTestField.CheckError makes with the
+        // text the ledger recorded — still produces it, so a BC-side change to that resource
+        // shows up here rather than as a mystery in an AL suite.
+        var create = Type.GetType(
+                "Microsoft.Dynamics.Nav.Types.Exceptions.NavTestValidationException, Microsoft.Dynamics.Nav.Types")
+            ?.GetMethod("Create", new[] { typeof(System.Globalization.CultureInfo), typeof(string), typeof(string) });
+        Assert.NotNull(create);
+
+        var ex = (Exception)create!.Invoke(null, new object?[]
+        {
+            System.Globalization.CultureInfo.InvariantCulture,
+            "Rec True",
+            "Your entry of 'False' is not an acceptable value for 'Rec True'. (Select Refresh to discard errors)",
+        })!;
+
+        Assert.Equal(
+            "Validation error for Field: Rec True,  Message = 'Your entry of 'False' is not an "
+            + "acceptable value for 'Rec True'. (Select Refresh to discard errors)'",
+            ex.Message);
+    }
+}

--- a/AlRunner.Tests/TestPageBooleanValueTests.cs
+++ b/AlRunner.Tests/TestPageBooleanValueTests.cs
@@ -28,6 +28,12 @@
 // So BC has a defined answer here and it is "no". That makes it a validation error to reproduce,
 // not an unsupported surface to refuse as out of scope — which is why the negative assertions
 // below check for that message rather than for a RunnerOutOfScopeException.
+//
+// NOTE ON WHAT CHANGED IN #2900. Resolve now raises only the INNER half of that message. The
+// "Validation error for Field: <name>,  Message = '…'" wrapper is composed one layer out, by
+// BC's own NavTestField.CheckError, from the refusal TestFieldValidationErrors records — so the
+// AL-visible string all eight legs measured is unchanged, and the assertions below moved down to
+// the layer this helper actually owns. TestFieldValidationErrorsTests pins the other half.
 using AlRunner;
 using Microsoft.Dynamics.Nav.Types.Exceptions;
 using Microsoft.Dynamics.Nav.Runtime;
@@ -130,8 +136,12 @@ public sealed class TestPageBooleanValueTests
         var ex = Assert.Throws<NavNCLDialogException>(
             () => TestPageBooleanValue.Resolve(input, "Rec True"));
 
-        Assert.Contains("Validation error for Field: Rec True", ex.Message);
-        Assert.Contains("is not an acceptable value", ex.Message);
-        Assert.Contains("(Select Refresh to discard errors)", ex.Message);
+        // The bare inner message, exactly — the wrapper is BC's (#2900), so asserting it here
+        // would pin a string this helper no longer produces.
+        Assert.Equal(
+            $"Your entry of '{input}' is not an acceptable value for 'Rec True'. "
+            + "(Select Refresh to discard errors)",
+            ex.Message);
+        Assert.DoesNotContain("Validation error for Field", ex.Message);
     }
 }

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -2023,6 +2023,12 @@ internal static class TestPageOptionValue
 /// nothing at all — this is a client/page-layer check, not a table-trigger one, so it must
 /// stay out of NavRecord.ALValidateAsync (which Rec.Validate also calls).
 ///
+/// <para>Since #2900 this raises only the INNER half of that message. The
+/// <c>Validation error for Field: &lt;name&gt;,  Message = '…'</c> wrapper is added by BC's own
+/// <c>NavTestField.CheckError</c> from the refusal <see cref="TestFieldValidationErrors"/>
+/// records, so the AL-visible string is the same one #2490 measured — composed by BC rather
+/// than assembled here.</para>
+///
 /// <para>Only numeric field types are checked — MinValue/MaxValue is meaningless on Text/Code/
 /// Boolean/etc., and AL does not let those types declare it.</para>
 ///
@@ -2056,11 +2062,11 @@ internal static class TestPageMinMaxValue
 
         if (!string.IsNullOrEmpty(minText) && decimal.TryParse(minText, NumberStyles.Any, CultureInfo.InvariantCulture, out var min)
             && value < min)
-            throw MakeError(caption, isInteger, "greater than or equal to", minText!, value);
+            throw MakeError(isInteger, "greater than or equal to", minText!, value);
 
         if (!string.IsNullOrEmpty(maxText) && decimal.TryParse(maxText, NumberStyles.Any, CultureInfo.InvariantCulture, out var max)
             && value > max)
-            throw MakeError(caption, isInteger, "less than or equal to", maxText!, value);
+            throw MakeError(isInteger, "less than or equal to", maxText!, value);
     }
 
     // The offending VALUE renders with the field's decimal places (2 by default for a Decimal,
@@ -2072,11 +2078,15 @@ internal static class TestPageMinMaxValue
         => isInteger ? d.ToString("0", CultureInfo.InvariantCulture)
                      : d.ToString("0.00", CultureInfo.InvariantCulture);
 
-    private static System.Exception MakeError(string caption, bool isInteger, string comparison, string boundText, decimal value)
+    private static System.Exception MakeError(bool isInteger, string comparison, string boundText, decimal value)
     {
-        var msg = $"Validation error for Field: {caption},  Message = 'The value must be {comparison} "
+        // The BARE message only. BC's own NavTestField.CheckError wraps whatever an ITestField
+        // records into "Validation error for Field: {Name},  Message = '{recorded}'" using
+        // Lang.TestValidationException, so building that wrapper here too would double it
+        // (#2900). The AL-visible string is unchanged; it is composed one layer out now.
+        var msg = $"The value must be {comparison} "
             + $"{boundText}. Value: {FormatValue(value, isInteger)}. "
-            + "(Select Refresh to discard errors)'";
+            + "(Select Refresh to discard errors)";
 
         var t = System.Type.GetType(
             "Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLDialogException, Microsoft.Dynamics.Nav.Types");
@@ -2195,15 +2205,20 @@ internal static class TestPageBooleanValue
     }
 
     /// <summary>
-    /// BC's own refusal for a value a control will not take, verbatim in shape:
-    /// <c>Validation error for Field: {caption},  Message = 'Your entry of '{value}' is not an
-    /// acceptable value for '{caption}'. (Select Refresh to discard errors)'</c> — including
-    /// the double space after the comma, which is BC's, not a typo.
+    /// BC's own refusal for a value a control will not take:
+    /// <c>Your entry of '{value}' is not an acceptable value for '{caption}'. (Select Refresh
+    /// to discard errors)</c>.
+    /// <para>The <c>Validation error for Field: {name},  Message = '…'</c> wrapper around it —
+    /// including the double space after the comma, which is BC's and not a typo — is added by
+    /// BC's own <c>NavTestField.CheckError</c> once <see cref="TestFieldValidationErrors"/> has
+    /// recorded this message, so it is deliberately absent here (#2900).</para>
     /// </summary>
     private static System.Exception MakeNotAcceptableError(string value, string caption)
     {
-        var msg = $"Validation error for Field: {caption},  Message = 'Your entry of '{value}' "
-            + $"is not an acceptable value for '{caption}'. (Select Refresh to discard errors)'";
+        // The BARE message only — see TestPageMinMaxValue.MakeError for why the
+        // "Validation error for Field: ..." wrapper is BC's to add and no longer ours (#2900).
+        var msg = $"Your entry of '{value}' "
+            + $"is not an acceptable value for '{caption}'. (Select Refresh to discard errors)";
 
         var t = System.Type.GetType(
             "Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLDialogException, Microsoft.Dynamics.Nav.Types");
@@ -2277,6 +2292,13 @@ internal sealed class LiveNavTestField : ITestField
         _onEdited = onEdited;
     }
 
+    // The refusals this control has recorded, read back by ValidationErrorCount /
+    // GetValidationError below. See TestFieldValidationErrors for BC's own contract: the
+    // ITestField setter RECORDS a refusal, it does not throw it — NavTestField.CheckError
+    // (BC's own precompiled code, wrapping every SetValue) is what raises it afterwards, and
+    // it can only do that if the ledger survives the write (#2900).
+    private readonly TestFieldValidationErrors _validationErrors = new();
+
     public string Value
     {
         // An option field answers with its MEMBER NAME, not the ordinal it stores. Returning the
@@ -2290,65 +2312,67 @@ internal sealed class LiveNavTestField : ITestField
                ?? TestPageBooleanValue.Format(_record.GetFieldValue(_fieldNo) as NavValue)
                ?? Convert.ToString(ObjectValue, CultureInfo.InvariantCulture)
                ?? string.Empty;
-        set
+        set => _validationErrors.RunRecordingRefusal(() => Write(value));
+    }
+
+    private void Write(string value)
+    {
+        // Issue #1870 — the Rec-bound half of #1837 that #1869 (the page-variable half)
+        // left open. FieldType (sourced from the source table field's own declared type,
+        // see TryGetMetaFieldType) answers Boolean for a `field(Flag; Rec.Flag)` control
+        // over a `Boolean` table field; falling through to ALCompiler.ToNavValue(value)
+        // there always produced a NavText, which NavTestField.ALSetValue's own Boolean
+        // ALValidateAsync then rejected with "The value 'True' can't be evaluated into
+        // type Boolean" — the same shape of bug TestPageBooleanValue already fixed for
+        // PageVariableTestField.
+        var navValue = CurrentOption() is { } option
+            ? TestPageOptionValue.Resolve(option, value, OptionCaptions(),
+                $"TestPage SetValue (field {_fieldNo})")
+            : FieldType == NavType.Boolean
+                ? TestPageBooleanValue.Resolve(value, Caption)
+                : ALCompiler.ToNavValue(value);
+
+        // MinValue/MaxValue (#2495): measured against real BC (28.1/28.4), a bounded field's
+        // MinValue/MaxValue is enforced on a TestPage control WRITE, but NOT on Rec.Validate
+        // or a plain field assignment — so this check belongs here, at the page-write layer,
+        // and must not move into ALValidateAsync below (that is also what Rec.Validate calls,
+        // and pulling the check in there would enforce it on Validate too, which real BC does
+        // not). See TestPageMinMaxValue.Check's own doc comment for the exact message shape.
+        TestPageMinMaxValue.Check(_record.MetaTable, _fieldNo, FieldType, value, Caption);
+
+        // Setting a field on a page is a VALIDATE, not an assignment. That is what fills in
+        // the caption when a user picks an id, and what lets a field refuse a value outright.
+        // A raw SetFieldValue stored what the test wrote — so the field itself read back
+        // correctly and every field DERIVED from it stayed empty, which made the test fail
+        // pointing at the derived field, the one place the defect was not.
+        //
+        // Issue #2705 — real BC (measured on a 28.4 container) runs the bound field's
+        // OnValidate with CurrFieldNo equal to that field's number for the duration of a
+        // page-driven write (own-table AND tableextension fields alike), while a
+        // Rec.Validate from AL code leaves it at 0. NavRecord.CurrFieldNo
+        // (Microsoft.Dynamics.Nav.Ncl.dll, decompiled) is a plain public get/set property
+        // that nothing in Ncl itself ever assigns — real BC's compiled client/page glue must
+        // set it around a UI-originated validate, which is exactly what a TestPage SetValue
+        // is standing in for here. Restoring the PREVIOUS value (not unconditionally 0)
+        // keeps a nested SetValue-from-OnValidate honest, and the try/finally matches what
+        // arm E of the corpus test measures: OnModify after Close() sees CurrFieldNo = 0
+        // again, so the assignment must not outlive this one validate call.
+        var previousCurrFieldNo = _record.CurrFieldNo;
+        _record.CurrFieldNo = _fieldNo;
+        try
         {
-            // Issue #1870 — the Rec-bound half of #1837 that #1869 (the page-variable half)
-            // left open. FieldType (sourced from the source table field's own declared type,
-            // see TryGetMetaFieldType) answers Boolean for a `field(Flag; Rec.Flag)` control
-            // over a `Boolean` table field; falling through to ALCompiler.ToNavValue(value)
-            // there always produced a NavText, which NavTestField.ALSetValue's own Boolean
-            // ALValidateAsync then rejected with "The value 'True' can't be evaluated into
-            // type Boolean" — the same shape of bug TestPageBooleanValue already fixed for
-            // PageVariableTestField.
-            var navValue = CurrentOption() is { } option
-                ? TestPageOptionValue.Resolve(option, value, OptionCaptions(),
-                    $"TestPage SetValue (field {_fieldNo})")
-                : FieldType == NavType.Boolean
-                    ? TestPageBooleanValue.Resolve(value, Caption)
-                    : ALCompiler.ToNavValue(value);
-
-            // MinValue/MaxValue (#2495): measured against real BC (28.1/28.4), a bounded field's
-            // MinValue/MaxValue is enforced on a TestPage control WRITE, but NOT on Rec.Validate
-            // or a plain field assignment — so this check belongs here, at the page-write layer,
-            // and must not move into ALValidateAsync below (that is also what Rec.Validate calls,
-            // and pulling the check in there would enforce it on Validate too, which real BC does
-            // not). See TestPageMinMaxValue.Check's own doc comment for the exact message shape.
-            TestPageMinMaxValue.Check(_record.MetaTable, _fieldNo, FieldType, value, Caption);
-
-            // Setting a field on a page is a VALIDATE, not an assignment. That is what fills in
-            // the caption when a user picks an id, and what lets a field refuse a value outright.
-            // A raw SetFieldValue stored what the test wrote — so the field itself read back
-            // correctly and every field DERIVED from it stayed empty, which made the test fail
-            // pointing at the derived field, the one place the defect was not.
-            //
-            // Issue #2705 — real BC (measured on a 28.4 container) runs the bound field's
-            // OnValidate with CurrFieldNo equal to that field's number for the duration of a
-            // page-driven write (own-table AND tableextension fields alike), while a
-            // Rec.Validate from AL code leaves it at 0. NavRecord.CurrFieldNo
-            // (Microsoft.Dynamics.Nav.Ncl.dll, decompiled) is a plain public get/set property
-            // that nothing in Ncl itself ever assigns — real BC's compiled client/page glue must
-            // set it around a UI-originated validate, which is exactly what a TestPage SetValue
-            // is standing in for here. Restoring the PREVIOUS value (not unconditionally 0)
-            // keeps a nested SetValue-from-OnValidate honest, and the try/finally matches what
-            // arm E of the corpus test measures: OnModify after Close() sees CurrFieldNo = 0
-            // again, so the assignment must not outlive this one validate call.
-            var previousCurrFieldNo = _record.CurrFieldNo;
-            _record.CurrFieldNo = _fieldNo;
-            try
-            {
-                _record.ALValidateAsync(_fieldNo, navValue, null).GetAwaiter().GetResult();
-            }
-            finally
-            {
-                _record.CurrFieldNo = previousCurrFieldNo;
-            }
-
-            // Then the control's own OnValidate, which is a second and independent trigger: the
-            // table field's runs first, the page's after it.
-            if (_page != null && _controlId != 0) _page.RaiseOnValidate(_controlId);
-
-            _onEdited?.Invoke();
+            _record.ALValidateAsync(_fieldNo, navValue, null).GetAwaiter().GetResult();
         }
+        finally
+        {
+            _record.CurrFieldNo = previousCurrFieldNo;
+        }
+
+        // Then the control's own OnValidate, which is a second and independent trigger: the
+        // table field's runs first, the page's after it.
+        if (_page != null && _controlId != 0) _page.RaiseOnValidate(_controlId);
+
+        _onEdited?.Invoke();
     }
 
     // The stored NavValue, not the unwrapped ClientObject — the option metadata rides on the
@@ -2377,9 +2401,14 @@ internal sealed class LiveNavTestField : ITestField
            ?? TryGetMetaFieldName()
            ?? $"Field {_fieldNo}";
     public NavType FieldType => TryGetMetaFieldType() ?? NavType.Text;
-    public int ValidationErrorCount => 0;
-    public long LastUsedValidationErrorId => 0;
-    public long MaxValidationErrorId => 0;
+    // BC's own NavTestField.CheckError reads all three around every control write, and
+    // NavTestField.ALValidationErrorCount / ALGetValidationError hand the first and fourth
+    // straight to AL. Hardcoded 0/"" made `ValidationErrorCount()` answer 0 after a refusal
+    // real BC counts as 1, and made a refusal escape the setter raw instead of being wrapped
+    // by BC in "Validation error for Field: ..." (#2900). See TestFieldValidationErrors.
+    public int ValidationErrorCount => _validationErrors.Count;
+    public long LastUsedValidationErrorId => _validationErrors.LastUsedId;
+    public long MaxValidationErrorId => _validationErrors.MaxId;
     public object? ObjectValue => LiveNavTestPage.Unwrap(_record.GetFieldValue(_fieldNo));
     public int OptionCount => CurrentOption() is { } option ? TestPageOptionValue.Count(option) : 0;
 
@@ -2394,7 +2423,7 @@ internal sealed class LiveNavTestField : ITestField
     public bool HideValue => false;
     public bool ShowMandatory => false;
 
-    public string GetValidationError(int index) => string.Empty;
+    public string GetValidationError(int index) => _validationErrors.Get(index);
     public void Activate() { }
 
     /// <summary>
@@ -2509,6 +2538,13 @@ internal sealed class PageVariableTestField : ITestField
         _controlId = controlId;
     }
 
+    // The Rec-bound sibling's ledger, for the same reason and read the same way — see
+    // LiveNavTestField._validationErrors and TestFieldValidationErrors. A page-global control
+    // refuses a write through its OnValidate exactly as a Rec-bound one does, so leaving this
+    // half hardcoded would have made the same AL assertion answer differently depending only
+    // on how the control happens to be bound.
+    private readonly TestFieldValidationErrors _validationErrors = new();
+
     public string Value
     {
         // An Option/Enum-bound control answers with its CAPTION, not the ordinal it stores —
@@ -2524,11 +2560,11 @@ internal sealed class PageVariableTestField : ITestField
                ?? TestPageBooleanValue.Format(RunnerPageInstance.GetValue(_expression))
                ?? Convert.ToString(ObjectValue, CultureInfo.InvariantCulture)
                ?? string.Empty;
-        set
+        set => _validationErrors.RunRecordingRefusal(() =>
         {
             RunnerPageInstance.SetValue(_expression, ToBoundValue(value));
             _page.RaiseOnValidate(_controlId);
-        }
+        });
     }
 
     public object? ObjectValue => LiveNavTestPage.Unwrap(RunnerPageInstance.GetValue(_expression));
@@ -2605,9 +2641,14 @@ internal sealed class PageVariableTestField : ITestField
         NavDecimal => NavType.Decimal,
         _ => NavType.Text,
     };
-    public int ValidationErrorCount => 0;
-    public long LastUsedValidationErrorId => 0;
-    public long MaxValidationErrorId => 0;
+    // BC's own NavTestField.CheckError reads all three around every control write, and
+    // NavTestField.ALValidationErrorCount / ALGetValidationError hand the first and fourth
+    // straight to AL. Hardcoded 0/"" made `ValidationErrorCount()` answer 0 after a refusal
+    // real BC counts as 1, and made a refusal escape the setter raw instead of being wrapped
+    // by BC in "Validation error for Field: ..." (#2900). See TestFieldValidationErrors.
+    public int ValidationErrorCount => _validationErrors.Count;
+    public long LastUsedValidationErrorId => _validationErrors.LastUsedId;
+    public long MaxValidationErrorId => _validationErrors.MaxId;
     public int OptionCount => CurrentOption() is { } option ? TestPageOptionValue.Count(option) : 0;
 
     // See LiveNavTestField — a control bound to a page variable declares the same properties
@@ -2618,7 +2659,7 @@ internal sealed class PageVariableTestField : ITestField
     public bool HideValue => false;
     public bool ShowMandatory => false;
 
-    public string GetValidationError(int index) => string.Empty;
+    public string GetValidationError(int index) => _validationErrors.Get(index);
     public void Activate() { }
     /// <summary>Run the control's OnLookup trigger — see LiveNavTestField.Lookup.</summary>
     public void Lookup()

--- a/AlRunner/Patches/TestFieldValidationErrors.cs
+++ b/AlRunner/Patches/TestFieldValidationErrors.cs
@@ -1,0 +1,142 @@
+// TestFieldValidationErrors — the validation-error ledger BC's own TestPage layer expects
+// every ITestField to keep (issue #2900).
+//
+// WHY THIS EXISTS
+//
+// AL's `TestPage.<field>.SetValue(x)` compiles to NavTestField.ALValue's SETTER, which is
+// BC's own precompiled code in Microsoft.Dynamics.Nav.Ncl.dll and reads (decompiled, 28.1):
+//
+//     public string ALValue { set { CheckError(delegate { testField.Activate();
+//                                                         testField.Value = value; }); } }
+//
+//     private T CheckError<T>(FieldOperationReturnValue<T> operation)
+//     {
+//         long lastUsedValidationErrorId = testField.LastUsedValidationErrorId;
+//         int  validationErrorCount      = testField.ValidationErrorCount;
+//         int  num                       = parent.ALValidationErrorCount();
+//         T result = operation();
+//         if (testField.MaxValidationErrorId > lastUsedValidationErrorId)
+//             throw NavTestValidationException.Create(CultureInfo.CurrentCulture, testField.Name,
+//                       testField.GetValidationError(ALValidationErrorCount() - 1));
+//         ...
+//     }
+//
+// So BC's contract is NOT "the ITestField setter throws". It is "the ITestField setter
+// RECORDS the refusal, and BC itself raises it afterwards" — which is why
+// `ValidationErrorCount()` and `GetValidationError(1)` can still be read AFTER the
+// `asserterror` that trapped the write. The runner used to throw straight out of the setter
+// and hardcode both accessors to 0 / "", so Microsoft's own
+// `Codeunit134614.TestRemoveSUPERPermissionsByUserAll` trapped the error and then read
+// `ValidationErrorCount() = 0` where real BC answers 1.
+//
+// THE MESSAGE IS BC'S, NOT OURS
+//
+// NavTestValidationException.Create formats with Lang.TestValidationException, read straight
+// out of Microsoft.Dynamics.Nav.Language.dll's resources on the 28.1 artifact:
+//
+//     Validation error for Field: {0},  Message = '{1}'
+//
+// ({0} = ITestField.Name, {1} = the recorded error text — the double space is BC's.) That is
+// the same string TestPageMinMaxValue and TestPageBooleanValue used to hand-build themselves;
+// now that a refusal is recorded rather than thrown, BC composes it and those helpers carry
+// only the inner message. Microsoft's own Tests-SINGLESERVER asserts both halves —
+// `Assert.ExpectedError('Validation error for Field')` in UserRoleTest, and
+// `GetValidationError(1)` equal to the BARE inner text in TestAppPermissions — which is the
+// evidence that the wrapper belongs to the outer layer and the recorded text does not carry it.
+//
+// IDS
+//
+// BC compares a `LastUsedValidationErrorId` snapshot taken BEFORE the write against
+// `MaxValidationErrorId` after it, so ids only have to be monotonic and "consumed" by
+// GetValidationError. Errors get ids 1..N in order; reading error i marks id i+1 used, which
+// is what stops the very next CheckError (the `.Value` GETTER, say) from re-raising an error
+// BC has already reported. BC's own throw path calls GetValidationError itself, so the
+// consume happens whether or not the AL test goes on to read the ledger.
+
+using System;
+using System.Collections.Generic;
+
+namespace AlRunner;
+
+/// <summary>
+/// Per-control ledger of the validation errors a TestPage write produced, exposed through
+/// <see cref="Microsoft.Dynamics.Nav.Types.Data.ITestField"/>'s
+/// <c>ValidationErrorCount</c> / <c>GetValidationError</c> / <c>MaxValidationErrorId</c> /
+/// <c>LastUsedValidationErrorId</c> members. See this file's header for BC's contract.
+/// </summary>
+internal sealed class TestFieldValidationErrors
+{
+    private readonly List<string> _errors = new();
+    private long _lastUsedId;
+
+    /// <summary>How many refusals this control has recorded. BC's <c>ValidationErrorCount</c>.</summary>
+    internal int Count => _errors.Count;
+
+    /// <summary>
+    /// The id of the newest recorded error, 0 when none. Ids run 1..<see cref="Count"/>, so
+    /// this is just the count — kept as its own member because BC reads it under a different
+    /// name and for a different purpose (the "is there something new since the snapshot"
+    /// test), and conflating the two in the call site would hide that.
+    /// </summary>
+    internal long MaxId => _errors.Count;
+
+    /// <summary>The highest id already handed out by <see cref="Get"/>. BC's <c>LastUsedValidationErrorId</c>.</summary>
+    internal long LastUsedId => _lastUsedId;
+
+    /// <summary>Record a refusal. The text is the bare error message, without BC's wrapper.</summary>
+    internal void Record(string message) => _errors.Add(message ?? string.Empty);
+
+    /// <summary>
+    /// The recorded error at a ZERO-based index, marking its id used.
+    /// <para>Out of range throws <see cref="IndexOutOfRangeException"/> rather than answering
+    /// an empty string, because that is the exception BC's own
+    /// <c>NavTestField.ALGetValidationError(int)</c> is written to catch — it converts it into
+    /// <c>NavNCLIndexOutOfBoundsException</c>, the AL-visible error for
+    /// <c>GetValidationError(0)</c> or an index past the end. Answering "" here would swallow
+    /// BC's own bounds check and let an AL test compare two empty strings successfully.</para>
+    /// </summary>
+    internal string Get(int index)
+    {
+        if (index < 0 || index >= _errors.Count)
+            throw new IndexOutOfRangeException(
+                $"validation error index {index} is outside 0..{_errors.Count - 1}");
+
+        var id = index + 1;
+        if (id > _lastUsedId) _lastUsedId = id;
+        return _errors[index];
+    }
+
+    /// <summary>
+    /// Run a TestPage control write, recording a BC/AL error instead of letting it escape so
+    /// that BC's own <c>NavTestField.CheckError</c> raises it with BC's own wrapper.
+    ///
+    /// <para>ONLY a <see cref="Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLException"/> is
+    /// recorded — that is the base of everything AL's <c>Error()</c>, <c>TestField</c> and
+    /// BC's own validate path raise. Anything else (a
+    /// <see cref="AlRunner.Infrastructure.RunnerOutOfScopeException"/>, a runner
+    /// <c>NullReferenceException</c>, an option-resolution refusal) is NOT a validation error
+    /// and tears straight through: converting a loud refusal into a recorded "validation
+    /// error" would let AL's <c>asserterror</c> absorb it and read as a green test, which is
+    /// exactly what .claude/rules/loud-failures.md forbids.</para>
+    ///
+    /// <para>Two further exclusions, both for the same reason — they are already the OUTER
+    /// layer's own signal, so recording them would wrap a wrapper: a
+    /// <c>NavTestValidationException</c> escaping a nested TestPage operation, and any
+    /// exception carrying the <c>out-of-scope:</c> message convention that the Cecil-injected
+    /// throw sites use (<see cref="AlRunner.Infrastructure.OutOfScopeMessage"/>), which
+    /// tests/expectations/ matches on.</para>
+    /// </summary>
+    internal void RunRecordingRefusal(Action write)
+    {
+        try
+        {
+            write();
+        }
+        catch (Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLException ex)
+            when (ex is not Microsoft.Dynamics.Nav.Types.Exceptions.NavTestValidationException
+                  && AlRunner.Infrastructure.OutOfScopeMessage.FromException(ex) is null)
+        {
+            Record(ex.Message);
+        }
+    }
+}

--- a/AlRunner/Patches/TestFieldValidationErrors.cs
+++ b/AlRunner/Patches/TestFieldValidationErrors.cs
@@ -112,12 +112,13 @@ internal sealed class TestFieldValidationErrors
     ///
     /// <para>ONLY a <see cref="Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLException"/> is
     /// recorded — that is the base of everything AL's <c>Error()</c>, <c>TestField</c> and
-    /// BC's own validate path raise. Anything else (a
-    /// <see cref="AlRunner.Infrastructure.RunnerOutOfScopeException"/>, a runner
-    /// <c>NullReferenceException</c>, an option-resolution refusal) is NOT a validation error
-    /// and tears straight through: converting a loud refusal into a recorded "validation
-    /// error" would let AL's <c>asserterror</c> absorb it and read as a green test, which is
-    /// exactly what .claude/rules/loud-failures.md forbids.</para>
+    /// BC's own validate path raise. Anything else is NOT a validation error and tears
+    /// straight through: a <see cref="AlRunner.Infrastructure.RunnerOutOfScopeException"/>, a
+    /// <see cref="AlRunner.Infrastructure.BcShapeGapException"/> (both plain
+    /// <c>System.Exception</c>s, so neither can match this catch), an option-resolution
+    /// refusal, or a runner <c>NullReferenceException</c>. Converting a loud refusal into a
+    /// recorded "validation error" would let AL's <c>asserterror</c> absorb it and read as a
+    /// green test, which is exactly what .claude/rules/loud-failures.md forbids.</para>
     ///
     /// <para>Two further exclusions, both for the same reason — they are already the OUTER
     /// layer's own signal, so recording them would wrap a wrapper: a


### PR DESCRIPTION
Closes #2900

Opened by an agent (impl-30).

## The issue moved under me, and only half of it was #2932

#2900 was filed as the regression check for #2932, and #2932's fix (PR #2969, still open at the
time of writing) does fix the symptom the title names. Measured, all on Microsoft's
Tests-SINGLESERVER `Codeunit134614`, BC 28.1:

| build | `TestRemoveSUPERPermissionsByUserAll` |
|---|---|
| `main` alone | `An error was expected inside an ASSERTERROR statement.` at line 48 — the refusal never raised |
| `main` + #2969 | reaches line **51**: `Assert.AreEqual failed. Expected:<1>. Actual:<0>. Wrong number of validation errors` |
| `main` + #2969 + this PR | **PASS** |

So the `asserterror` does find something once #2969 lands. What is still broken, and what this
PR fixes, is the half #2900's body called out separately: "`ValidationErrorCount()` /
`GetValidationError()` are untested here as well." They were hardcoded.

Whole codeunit, same three builds: 11P/4F on `main`+#2969, **14P/1F** with this PR. The one
remaining failure, `TestPermissionSetByUserGroupPage`, is a different defect (a control's name
read back where its caption was expected) and is not touched here.

## What was wrong

`LiveNavTestField` and `PageVariableTestField` — the two `ITestField` implementations behind
every Rec-bound and page-global TestPage control — declared:

```csharp
public int ValidationErrorCount => 0;
public long LastUsedValidationErrorId => 0;
public long MaxValidationErrorId => 0;
public string GetValidationError(int index) => string.Empty;
```

Four silent defaults, and they are not decoration: BC's own `NavTestField.ALValue` setter (the
method AL's `SetValue` compiles to, in unmodified `Ncl.dll`) reads all four:

```csharp
public string ALValue { set { CheckError(delegate { testField.Activate();
                                                    testField.Value = value; }); } }

private T CheckError<T>(FieldOperationReturnValue<T> operation)
{
    long lastUsedValidationErrorId = testField.LastUsedValidationErrorId;
    int  validationErrorCount      = testField.ValidationErrorCount;
    int  num                       = parent.ALValidationErrorCount();
    T result = operation();
    if (testField.MaxValidationErrorId > lastUsedValidationErrorId)
        throw NavTestValidationException.Create(CultureInfo.CurrentCulture, testField.Name,
                  testField.GetValidationError(ALValidationErrorCount() - 1));
    ...
}
```

BC's contract is therefore **not** "the `ITestField` setter throws". It is "the setter
*records* the refusal, and BC raises it afterwards" — which is exactly why AL can still read
`ValidationErrorCount()` and `GetValidationError(1)` *after* an `asserterror` has swallowed the
exception. The runner threw straight out of the setter and recorded nothing, so the ledger was
always empty.

## What changed

New `AlRunner/Patches/TestFieldValidationErrors.cs`: the per-control ledger, plus the
run-and-record wrapper both setters now go through. The four members answer from it.

**Only a `NavNCLException` is recorded** — the base of everything AL's `Error()`, `TestField`
and BC's validate path raise. A `RunnerOutOfScopeException`, a `BcShapeGapException` (both
plain `System.Exception`, so neither can match the catch), an option-resolution refusal or a
runner `NullReferenceException` tears straight through. Recording a loud refusal would let
`asserterror` absorb it and read as a green test, which is the shape `loud-failures.md` exists
to prevent. Two further exclusions for the same reason — they are already the outer layer's own
signal, so recording them would wrap a wrapper: a `NavTestValidationException` from a nested
TestPage operation, and anything carrying the `out-of-scope:` message convention that
`tests/expectations/` matches on.

## The wrapper is BC's now, not ours — and the AL-visible string is unchanged

`NavTestValidationException.Create` formats with `Lang.TestValidationException`, which reads
`Validation error for Field: {0},  Message = '{1}'` — extracted from
`Microsoft.Dynamics.Nav.Language.dll`'s resources on the 28.1 artifact, not guessed. That is
the same string `TestPageMinMaxValue.MakeError` and `TestPageBooleanValue.MakeNotAcceptableError`
used to hand-build, so with a refusal now being recorded rather than thrown they would have
double-wrapped it. Both now carry only the inner message and BC composes the rest.

That the two layers are genuinely separate is Microsoft's own claim, not mine:
`Codeunit134614` compares `GetValidationError(1)` against the **bare** text
(`'There should be at least one enabled ''SUPER'' user.'`) while `UserRoleTest` asserts the
trapped error contains `'Validation error for Field'`. Corpus PR #163 measured the composed
string on all eight BC legs.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site?** Yes — `PageVariableTestField` had the identical
   four hardcoded members and the same throwing setter. Both are fixed; leaving one would have
   made the same AL assertion answer differently depending only on how the control is bound.
2. **Sibling functions with the same assumption?** `MockITestField` (the no-page mock) and
   `MockITestPage`'s page-level `ValidationErrorCount` / `GetValidationError` still answer 0 and
   `''`. For `MockITestField` that is faithful — its setter stores a string and nothing can
   refuse it. The page-level pair is a genuine remaining gap and is filed separately rather than
   silently widened here.
3. **Two paths writing the same state with different invariants?** This was the real find. The
   min/max and Boolean refusals composed BC's wrapper themselves while the AL-validate path
   threw raw, so the same control produced two differently shaped messages depending on which
   check refused. They now agree, because only one layer builds the wrapper.

## Proof

**Upstream, where the BC claim belongs** — corpus PR
StefanMaron/BusinessCentral.AL.Language.Tests#182, codeunit 60836, five claims: a refused write
records exactly one error; `GetValidationError(1)` is the bare text; the trapped exception
carries both wrapper and bare text; an accepted write records nothing and stores the value;
reading past the end raises. Against this branch 5/5 pass; against `origin/main` 4 fail and the
accepted-write control passes, so the suite is not vacuous. **Only the corpus CI can say
whether it is right**, and one claim genuinely needs it — see below.

**Runner-side mechanism**, `AlRunner.Tests/TestFieldValidationErrorsTests.cs` (12 tests): the
ledger's arithmetic including the "consume" that stops BC re-raising an error it already
reported, which exceptions become a validation error and which tear through, and that BC's own
`NavTestValidationException.Create` still produces the string corpus PR #163 measured.

**Locally, on this branch:**

- Microsoft `Codeunit134614`: 14P/1F (was 11P/4F), table above for the single-test RED → GREEN.
- Full `tests/al-language` corpus with `--strict --count-baseline`: **2554/2554**.
- Full `tests/runner-extras` with `--strict --count-baseline`: **278/278**.
- `dotnet test AlRunner.Tests --filter` over the five TestPage classes: 50/50.

The corpus run is the one that mattered: this change alters the exception every failing TestPage
`SetValue` produces, so its blast radius is every `asserterror … SetValue` in the suite.

## What I am not claiming

`GetValidationError` past the end of the ledger now throws `IndexOutOfRangeException`, which
BC's `ALGetValidationError(int)` converts into `NavNCLIndexOutOfBoundsException`. That comes
from reading BC's own catch — a catch for an exception that can never be raised would be dead
code — **not** from a measurement. Corpus PR #182's claim 5 is what settles it; if the legs
disagree I will change both the test and this line of the runner.

The measurements above were taken with #2969 cherry-picked on top of `main`, because the
`Codeunit134614` root cause is #2969's, not this PR's. The branch itself is plain `origin/main`
plus these two commits; the corpus, runner-extras and unit-test numbers were all taken in that
state.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
