### PR TITLE
fix(record): answer the Field virtual table on Count, IsEmpty and keyed Get, not only on find

### DIFF
--- a/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
@@ -892,6 +892,23 @@ public static partial class NclCecilRewrite
                 H(recordPatches, "DataAccess_DateWindowGuardForCount"),
                 argSlots: 2); // `this` — the DataAccess — and the count request
 
+            // ── DataAccess.CountAsync — virtual Field table (2000000041) on-demand populate ──
+            // Same gap, one table over. The Field table's rows for a given TableNo are built on
+            // demand, and until #2792 the ONLY place that happened for a table nothing else had
+            // materialised was the find guard above. Record.Count() / IsEmpty() build a
+            // CountCacheRequest, so they missed it and answered over an empty store.
+            //
+            // Measured on main, one Base Application bundle, table 5802 never opened as a Record:
+            //   Field.SetRange(TableNo, 5802); Count()   -> 0   IsEmpty() -> true
+            //   Field.SetRange(TableNo, 5802); FindSet() -> 85 rows
+            // Same filter, same table, two different answers — and 0 is indistinguishable from
+            // "this table has no fields". A service tier computes the virtual table per request
+            // and answers 85 both ways.
+            PrependStaticCall(nclMod,
+                ByParams(Rt + "DataAccess", "CountAsync", "CountCacheRequest"),
+                H(recordPatches, "DataAccess_FieldGuardForCount"),
+                argSlots: 2); // `this` — the DataAccess — and the count request
+
             // ── DataAccess.InternalTryGetByPrimaryKeyAsync — Aggregate Permission Set live
             //    redrive (issue #2504) ──────────────────────────────────────────────────
             // Record.Get() with a full primary key never reaches InnerFindAsync at all — it
@@ -921,6 +938,31 @@ public static partial class NclCecilRewrite
                 ByParams(Rt + "DataAccess", "InternalTryGetByPrimaryKeyAsync", "PrimaryKeyCacheRequest"),
                 H(recordPatches, "DataAccess_DateWindowGuardForGet"),
                 argSlots: 2); // `this` — the DataAccess — and the primary-key request
+
+            // ── DataAccess.InternalTryGetByPrimaryKeyAsync — virtual Field table (#2792) ──────
+            // The third of the three request paths, and the Field table was left behind on it by
+            // both #2504 and #2648. Measured on main, table 5803 never opened as a Record:
+            // Field.Get(5803, 1) answered FALSE, where a service tier answers TRUE with
+            // FieldName "Entry No.". The guard builds that table's Field rows from the RECORD ID
+            // (a keyed Get carries its key there and may carry no TableNo filter at all) and
+            // then returns; the original body runs unchanged, for this and every other table.
+            PrependStaticCall(nclMod,
+                ByParams(Rt + "DataAccess", "InternalTryGetByPrimaryKeyAsync", "PrimaryKeyCacheRequest"),
+                H(recordPatches, "DataAccess_FieldGuardForGet"),
+                argSlots: 2); // `this` — the DataAccess — and the primary-key request
+
+            // ── DataAccess.ExistsAsync — virtual Field table (2000000041), the FOURTH path ────
+            // Record.IsEmpty() does not take the count path. RecordImplementation.IsEmptyAsync
+            // calls its own ExistsAsync, which builds an ExistsCacheRequest and reaches
+            // DataAccess.ExistsAsync — decompiled from Ncl.dll, and not what the Date count
+            // guard's comment above claims. With the count and Get guards in place but not this
+            // one, Field.SetRange(TableNo, 270); IsEmpty() still answered TRUE while Count()
+            // over the same filter answered 2. ExistsAsync is a large async state machine, so
+            // unlike the tiny FindAsync it is not R2R-inlined past the prepend.
+            PrependStaticCall(nclMod,
+                ByParams(Rt + "DataAccess", "ExistsAsync", "ExistsCacheRequest"),
+                H(recordPatches, "DataAccess_FieldGuardForExists"),
+                argSlots: 2); // `this` — the DataAccess — and the exists request
 
             // ── NavDatabase / NavRecordId collation comparers ───────────────────
             ReplaceBodyWithHelper(nclMod,

--- a/AlRunner/Patches/RecordPatches.FieldFindIntercept.cs
+++ b/AlRunner/Patches/RecordPatches.FieldFindIntercept.cs
@@ -295,28 +295,196 @@ public static partial class RecordPatches
             PopulateFieldVirtualTable(dataAccess, fieldMetaTable, session);
 
             // Targeted: if a specific TableNo is filtered and not yet built, build+insert it now.
-            if (filteredTableNo is int t && t > 0)
-            {
-                NCLMetaTable? srcMeta;
-                try { srcMeta = EnsureTableInMetadataCache(t); }
-                catch { srcMeta = null; }
-                if (srcMeta != null)
-                {
-                    EnsureDataAccessProviderReflection(dataAccess);
-                    var provider = _pDataAccessDataProvider!.GetValue(dataAccess)!;
-                    var done = _fvtPopulatedByProvider.GetValue(provider, static _ => new ConcurrentDictionary<int, byte>());
-                    if (done.TryAdd(t, 0))
-                        InsertFieldRowsForTable(provider, fieldMetaTable, srcMeta);
-                }
-            }
+            PopulateFieldRowsForTargetTable(dataAccess, fieldMetaTable, filteredTableNo);
         }
         catch (AlRunner.Infrastructure.RunnerOutOfScopeException) { throw; }
         catch { /* best-effort populate; the find still runs over whatever is present */ }
     }
 
+    /// <summary>
+    /// Build and insert <paramref name="targetTableNo"/>'s real Field rows into the store behind
+    /// the 2000000041 data access, unless they are already there.
+    ///
+    /// This is the ONLY populate that can serve a table the runner has not otherwise
+    /// materialised. The creation-time pass in <see cref="PopulateFieldVirtualTable"/> iterates
+    /// the metadata cache's CURRENT keys, so it covers exactly the tables something else has
+    /// already touched; this one calls <c>EnsureTableInMetadataCache</c> and therefore builds the
+    /// named table on demand. Measured on a Base Application bundle that never opens table 5802
+    /// as a Record: <c>Field.SetRange(TableNo, 5802); FindSet()</c> enumerates 85 rows with this
+    /// arm and 0 without it (issue #2792).
+    ///
+    /// Idempotent per (provider, tableNo) via the same done-set the creation-time pass uses.
+    /// </summary>
+    private static void PopulateFieldRowsForTargetTable(object dataAccess, NCLMetaTable fieldMetaTable, int? targetTableNo)
+    {
+        if (targetTableNo is not int t || t <= 0) return;
+
+        NCLMetaTable? srcMeta;
+        try { srcMeta = EnsureTableInMetadataCache(t); }
+        catch { srcMeta = null; }
+        if (srcMeta == null) return;
+
+        EnsureDataAccessProviderReflection(dataAccess);
+        var provider = _pDataAccessDataProvider!.GetValue(dataAccess)!;
+        var done = _fvtPopulatedByProvider.GetValue(provider, static _ => new ConcurrentDictionary<int, byte>());
+        if (done.TryAdd(t, 0))
+            InsertFieldRowsForTable(provider, fieldMetaTable, srcMeta);
+    }
+
+    /// <summary>
+    /// The populate the find path runs, reached from a request that is NOT a find — the count
+    /// path and the primary-key Get path below. Reads the Field metatable and the session off
+    /// the request/DataAccess with the LIGHT reflection only, so a count or a Get on any of the
+    /// other ~4,000 tables never triggers the heavy find-intercept bind.
+    /// </summary>
+    private static void EnsureFieldRowsForNonFindRequest(object dataAccess, object request, int? targetTableNo)
+    {
+        // Same #2524 invariant the find path holds: a `Record "Field" temporary` holds exactly
+        // the rows AL inserted, and real metadata rows must never be injected into that private
+        // store.
+        if (IsTemporaryRecordDataAccess(dataAccess)) return;
+
+        try
+        {
+            if (FindRequestMetaApplicationObject(request) is not NCLMetaTable fieldMetaTable) return;
+            var session = FieldGuardSession(dataAccess);
+            if (session == null) return;
+
+            PopulateFieldVirtualTable(dataAccess, fieldMetaTable, session);
+            PopulateFieldRowsForTargetTable(dataAccess, fieldMetaTable, targetTableNo);
+        }
+        catch (AlRunner.Infrastructure.RunnerOutOfScopeException) { throw; }
+        catch { /* best-effort populate, exactly as the find path: never a different answer */ }
+    }
+
+    /// <summary>
+    /// Prepended to DataAccess.CountAsync(CountCacheRequest) for every table. <c>Record.Count()</c>
+    /// and <c>Record.IsEmpty()</c> build a CountCacheRequest, not a FindCacheRequest, so the
+    /// InnerFindAsync guard never sees them and the on-demand populate never ran for them.
+    ///
+    /// Measured on main, one Base Application bundle, table 5802 never opened as a Record:
+    ///
+    ///   Field.SetRange(TableNo, 5802); Count()   -> 0     IsEmpty() -> true
+    ///   Field.SetRange(TableNo, 5802); FindSet() -> 85 rows, field 1 = "Entry No.", Integer
+    ///
+    /// The same filter on the same table, answered two different ways depending on which method
+    /// AL called — and the wrong one is the quiet one, because 0 is what "this table has no
+    /// fields" would also look like. On a service tier the Field table is computed per request
+    /// and both answer 85. Same shape as #2648 (Date) and #2504 (Aggregate Permission Set) on
+    /// this method and on the Get path below; the Field table was left behind by both.
+    ///
+    /// For every table but 2000000041 this is one integer comparison and returns.
+    /// </summary>
+    public static void DataAccess_FieldGuardForCount(object self, object request)
+    {
+        if (FindRequestTableId(request) != FieldFindTableId) return;
+        int? filtered;
+        try { filtered = ExtractTableNoFilter(request); }
+        catch { filtered = null; }
+        EnsureFieldRowsForNonFindRequest(self, request, filtered);
+    }
+
+    /// <summary>
+    /// Prepended to DataAccess.ExistsAsync(ExistsCacheRequest) for every table. <c>Record.IsEmpty()</c>
+    /// does NOT take the count path: RecordImplementation.IsEmptyAsync calls its own
+    /// ExistsAsync, which builds an ExistsCacheRequest and goes straight to
+    /// provider.ExistsAsync (decompiled from Ncl.dll — the comment on the Date table's count
+    /// guard, which says IsEmpty() takes the count path, is wrong about this). So it reached
+    /// none of the three guards and answered over an empty store.
+    ///
+    /// Measured on this branch with the count and Get guards already in place, table 270 never
+    /// opened as a Record: <c>Field.SetRange(TableNo, 270); IsEmpty()</c> still answered TRUE
+    /// while <c>Count()</c> over the same filter answered its real field count. A fourth path,
+    /// found only because the test asserted IsEmpty() separately rather than trusting it to
+    /// share Count()'s implementation.
+    ///
+    /// For every table but 2000000041 this is one integer comparison and returns.
+    /// </summary>
+    public static void DataAccess_FieldGuardForExists(object self, object request)
+    {
+        if (FindRequestTableId(request) != FieldFindTableId) return;
+        int? filtered;
+        try { filtered = ExtractTableNoFilter(request); }
+        catch { filtered = null; }
+        EnsureFieldRowsForNonFindRequest(self, request, filtered);
+    }
+
+    /// <summary>
+    /// Prepended to DataAccess.InternalTryGetByPrimaryKeyAsync(PrimaryKeyCacheRequest) for every
+    /// table. A full-primary-key <c>Record.Get()</c> takes DataAccess's own primary-key path
+    /// straight to provider.TryGetByPrimaryKeyAsync, reaching neither the find guard nor the
+    /// count guard.
+    ///
+    /// Measured on main, same bundle, table 5803 never opened as a Record:
+    /// <c>Field.Get(5803, 1)</c> answered FALSE. On a service tier it answers TRUE with
+    /// FieldName "Entry No." — so FALSE here is a wrong answer, not a missing feature, and a
+    /// quiet one: "no such field" is exactly what a Get returning false normally means.
+    ///
+    /// The table is taken from the request's own RecordId rather than from a filter, because a
+    /// keyed Get carries its key there and need carry no TableNo filter at all. The Field
+    /// table's primary key is (TableNo, "No."), so TableNo is the FIRST key value.
+    /// </summary>
+    public static void DataAccess_FieldGuardForGet(object self, object request)
+    {
+        if (FindRequestTableId(request) != FieldFindTableId) return;
+        int? keyed;
+        try { keyed = PrimaryKeyTableNo(request); }
+        catch { keyed = null; }
+        EnsureFieldRowsForNonFindRequest(self, request, keyed);
+    }
+
+    /// <summary>
+    /// The TableNo out of a primary-key request's RecordId — the FIRST key value, the Field
+    /// table's key being (TableNo, "No."). Null for a SystemIdCacheRequest, which carries no key
+    /// values: the SystemId of a row that was never materialised has never been handed out, so
+    /// such a request cannot name a table the store does not already hold.
+    /// </summary>
+    private static int? PrimaryKeyTableNo(object request)
+    {
+        var recordId = request.GetType().GetProperty("RecordId",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(request);
+        if (recordId == null) return null;
+
+        var fields = recordId.GetType().GetProperty("Fields",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(recordId);
+        if (fields is not System.Collections.IList list || list.Count < 1) return null;
+
+        return NavValueToInt(list[0]);
+    }
+
+    private static PropertyInfo? _ffiDaSessionLight;   // DataAccess.Session, bound WITHOUT the heavy bind
+    private static volatile bool _ffiDaSessionLightReady;
+
+    /// <summary>
+    /// DataAccess.Session, resolved off the instance's own type. Deliberately separate from
+    /// <see cref="_pDaSession"/>, which only exists once EnsureFindInterceptReflection has run —
+    /// that heavy bind is reached only from the Field find path, and the count/Get guards must
+    /// not trigger it.
+    /// </summary>
+    private static object? FieldGuardSession(object dataAccess)
+    {
+        try
+        {
+            if (!_ffiDaSessionLightReady)
+            {
+                _ffiDaSessionLight = dataAccess.GetType().GetProperty("Session",
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                _ffiDaSessionLightReady = _ffiDaSessionLight != null;
+                if (!_ffiDaSessionLightReady) return null;
+            }
+            return _ffiDaSessionLight!.GetValue(dataAccess);
+        }
+        catch { return null; }
+    }
+
     private static int? ExtractTableNoFilter(object cacheRequest)
     {
         EnsureFilterReflection(cacheRequest);
+        // A failed bind means "we cannot read this request's filters", never "there is no
+        // TableNo filter" — but the two are indistinguishable to the caller, so both end in the
+        // same place: no targeted populate. Returning here rather than dereferencing a null
+        // handle keeps the count guard (which has no find-path try/catch around it) honest.
+        if (!_filterReflReady) return null;
         var fam = _pFiltersAndMarks!.GetValue(cacheRequest);
         if (fam == null) return null;
         var filters = _pFamFilters!.GetValue(fam);
@@ -372,6 +540,12 @@ public static partial class RecordPatches
         if (_filterReflReady) return;
         var nclAsm = cacheRequest.GetType().Assembly;
         const string rt = "Microsoft.Dynamics.Nav.Runtime.";
+        // DataCacheRequest.FiltersAndMarks — the base of BOTH FindCacheRequest and
+        // CountCacheRequest, so the count guard reads the same TableNo filter the find path
+        // does. It used to be bound only by EnsureFindInterceptReflection, which the count path
+        // must never trigger (that bind is the heavy one, and it runs for the Field table only).
+        _pFiltersAndMarks ??= nclAsm.GetType(rt + "DataCacheRequest")!
+            .GetProperty("FiltersAndMarks", BindingFlags.Public | BindingFlags.Instance);
         var tFam = nclAsm.GetType(rt + "FiltersAndMarks")!;
         _pFamFilters = tFam.GetProperty("Filters", BindingFlags.Public | BindingFlags.Instance);
         var tFfdBase = nclAsm.GetType(rt + "FilterFieldDictionary")!;
@@ -391,7 +565,8 @@ public static partial class RecordPatches
         var tMetaField = nclAsm.GetType(rt + "NCLMetaField")!;
         _pFieldNo = tMetaField.GetProperty("FieldNo", BindingFlags.Public | BindingFlags.Instance)
             ?? tMetaField.GetProperty("No", BindingFlags.Public | BindingFlags.Instance);
-        _filterReflReady = _pFamFilters != null && _pFfdItems != null && _pFieldNo != null;
+        _filterReflReady = _pFamFilters != null && _pFfdItems != null && _pFieldNo != null
+            && _pFiltersAndMarks != null;
     }
 
     private static MethodInfo? _mValueTaskFromResult; // ValueTask.FromResult<ResultSetEnumerator>

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -44,7 +44,7 @@
         "server-reload-dep": { "tests": 0 },
         "server-reload-main": { "tests": 1 },
         "session-user-row": { "tests": 4 },
-        "standalone-suites": { "tests": 108 },
+        "standalone-suites": { "tests": 113 },
         "static-runmodal-record": { "tests": 5 },
         "table-connection-live-oos": { "tests": 2 },
         "tableext-eviction-field-trigger-timing": { "tests": 2 },

--- a/tests/runner-extras/standalone-suites/field-virtual-table/VirtualFieldTableTests.Codeunit.al
+++ b/tests/runner-extras/standalone-suites/field-virtual-table/VirtualFieldTableTests.Codeunit.al
@@ -116,6 +116,143 @@ codeunit 60602 "VFT Tests"
         Assert.IsTrue(SawAmount, 'Normal field 3 (Amount) must survive the filter');
     end;
 
+    // ── Issue #2792: the same table, asked three different ways ─────────────────────
+    //
+    // The runner serves this table from an in-memory store, so it has to BUILD a table's field
+    // rows before it can answer for that table, and it builds them on demand from the table id
+    // the request names. FOUR DataAccess request paths reach the table, each carrying that id
+    // differently:
+    //
+    //   Find / FindSet / FindFirst -> InnerFindAsync(FindCacheRequest)      id in a TableNo filter
+    //   Count                      -> CountAsync(CountCacheRequest)         id in a TableNo filter
+    //   IsEmpty                    -> ExistsAsync(ExistsCacheRequest)       id in a TableNo filter
+    //   Get(TableNo, No.)          -> InternalTryGetByPrimaryKeyAsync(...)  id in the RecordId
+    //
+    // Only the find path ran the populate, so Count() answered 0, IsEmpty() answered true and
+    // Get() answered false for a table nothing had opened, while FindSet() over the same filter
+    // answered with its real rows. Every wrong answer is the quiet kind: 0 rows, "the set is
+    // empty" and "no such field" are exactly what an empty table looks like. Same shape as
+    // #2648 (Date) and #2504 (Aggregate Permission Set), which fixed two of these methods for
+    // their own tables and left this one behind.
+    //
+    // IsEmpty() is a fourth path and not a spelling of Count(): RecordImplementation.IsEmptyAsync
+    // calls its own ExistsAsync rather than counting (decompiled from Ncl.dll). It is asserted
+    // separately below for that reason — assuming it shared Count()'s implementation is what
+    // would have left it broken.
+    //
+    // These three tests exist only because the runner materialises at all — on a service tier
+    // the table is computed per request and there is nothing to materialise. What the rows
+    // themselves say is plain BC behaviour, pinned upstream in the al-language corpus; it is
+    // named here only because a proof that the populate ran has to say what it produced.
+    //
+    // WHY A BASE APPLICATION TABLE, AND A DIFFERENT ONE PER TEST. The precondition is "the
+    // runner has not built this table's metadata yet". Every table declared in AL source the
+    // runner parses — this bundle's own "VFT Sample" included — is in the metadata cache before
+    // any test runs, so it can never show the gap. A precompiled Base Application table is only
+    // built when something asks for it; measured over a full tests/runner-extras run, 193 real
+    // tables were in the cache when this codeunit executed and none of the three below was one
+    // of them. And the populate is idempotent and process-wide, so the first request of any
+    // kind warms that table for every later one — hence one table per test.
+
+    // Count() must build the rows the same way a find does. RED: 0.
+    [Test]
+    procedure Count_TableNotYetMaterialised_CountsRealFields()
+    var
+        FieldRec: Record "Field";
+    begin
+        // [GIVEN] a filter naming Base Application "Value Entry" (5802), which nothing in this
+        //         run has opened as a Record
+        FieldRec.SetRange(TableNo, 5802);
+        FieldRec.SetRange("No.", 1, 2);
+
+        // [THEN] Count() sees its first two real fields, not an empty store
+        Assert.AreEqual(2, FieldRec.Count(), 'Count() must see fields 1 and 2 of Value Entry (5802)');
+    end;
+
+    // IsEmpty() takes the same count path and had the same wrong answer. RED: true.
+    // A different table, because 5802 is warm once the test above has run.
+    [Test]
+    procedure IsEmpty_TableNotYetMaterialised_IsFalse()
+    var
+        FieldRec: Record "Field";
+    begin
+        // [GIVEN] Base Application "Bank Account" (270), likewise untouched
+        FieldRec.SetRange(TableNo, 270);
+
+        // [THEN] the table has fields, so it is not empty
+        Assert.IsFalse(FieldRec.IsEmpty(), 'IsEmpty() must be false for a table that has fields');
+
+        // [AND] Count() agrees with IsEmpty() about the same filter
+        FieldRec.SetRange("No.", 1, 2);
+        Assert.AreEqual(2, FieldRec.Count(), 'Count() must see fields 1 and 2 of Bank Account (270)');
+    end;
+
+    // A keyed Get carries the table id in its RecordId, not in a filter, and reaches neither of
+    // the paths above. RED: Get returns false, so FieldName reads blank.
+    [Test]
+    procedure Get_ByPrimaryKey_TableNotYetMaterialised_ReturnsRealField()
+    var
+        FieldRec: Record "Field";
+    begin
+        // [WHEN] a full-primary-key Get is the first request made for Base Application
+        //        "Dimension Value" (349)
+        Assert.IsTrue(FieldRec.Get(349, 1), 'Field.Get must find field 1 of Dimension Value (349)');
+
+        // [THEN] it is that table's real field 1, not a placeholder
+        Assert.AreEqual(349, FieldRec.TableNo, 'TableNo must be Dimension Value (349)');
+        Assert.AreEqual(1, FieldRec."No.", 'Field No. must be 1');
+        Assert.AreEqualText('Dimension Code', FieldRec.FieldName, 'Field 1 must be named "Dimension Code"');
+        Assert.IsTrue(FieldRec.Type = FieldRec.Type::Code, 'Field 1 must have type Code');
+
+        // [AND] a field number the table does not declare stays absent — the populate builds
+        //       real metadata and never fabricates a row to satisfy the key.
+        Assert.IsFalse(FieldRec.Get(349, 999999), 'Field 999999 of Dimension Value must not exist');
+    end;
+
+    // The four paths must agree on one table, so a regression in any one of them cannot hide
+    // behind the other three. The keyed Get goes first, while the table is still cold.
+    [Test]
+    procedure AllFourPaths_AgreeOnTheSameTable()
+    var
+        FieldRec: Record "Field";
+        Rows: Integer;
+    begin
+        // [GIVEN] Base Application "Avg. Cost Adjmt. Entry Point" (5804), untouched, read by key
+        Assert.IsTrue(FieldRec.Get(5804, 1), 'Field.Get must find field 1 of table 5804');
+
+        // [WHEN] the same table is put to the count path and then the find path
+        FieldRec.Reset();
+        FieldRec.SetRange(TableNo, 5804);
+        Assert.IsFalse(FieldRec.IsEmpty(), 'IsEmpty() must be false for table 5804');
+
+        FieldRec.SetRange("No.", 1, 2);
+        Assert.AreEqual(2, FieldRec.Count(), 'Count() must see fields 1 and 2 of table 5804');
+
+        if FieldRec.FindSet() then
+            repeat
+                Rows += 1;
+            until FieldRec.Next() = 0;
+
+        // [THEN] FindSet enumerates exactly what Count counted
+        Assert.AreEqual(2, Rows, 'FindSet() must enumerate the same 2 fields Count() counted');
+    end;
+
+    // Negative for the three paths added above: an id that is not a table must stay empty on
+    // every one of them. The on-demand populate must not invent a table because a request
+    // named one.
+    [Test]
+    procedure NonExistentTable_StaysEmptyOnCountIsEmptyAndGet()
+    var
+        FieldRec: Record "Field";
+    begin
+        FieldRec.SetRange(TableNo, 1999999);
+        Assert.AreEqual(0, FieldRec.Count(), 'Count() must be 0 for a table id that does not exist');
+        Assert.IsTrue(FieldRec.IsEmpty(), 'IsEmpty() must be true for a table id that does not exist');
+
+        FieldRec.Reset();
+        Assert.IsFalse(FieldRec.Get(1999999, 1), 'Get() must fail for a table id that does not exist');
+    end;
+
     // Negative: a non-existent table must yield zero rows — the provider builds
     // rows from real metadata only and must never fabricate a row.
     [Test]


### PR DESCRIPTION
Closes #2792

## What the issue asked

Whether the Field virtual table's find-time populate is dead code. The honest answer had two branches — delete it, or cover it — and the issue was explicit that the deletion premise must not be acted on as written.

**It is load-bearing.** Disabling only the targeted arm of `EnsureFilteredFieldTablePopulated`, on a Base Application bundle that never opens table 5802 as a `Record`:

| | with the arm | without |
|---|---|---|
| `Field.SetRange(TableNo, 5802); FindSet()` | 85 rows, field 1 `"Entry No."` / Integer | **0 rows** |

Instrumented at the call site, that request enters with `metaCacheBefore=False, doneAdded=True` — the table is not in the metadata cache, so the creation-time pass in `PopulateFieldVirtualTable` (which iterates the cache's current keys) cannot have covered it. The targeted arm is the only populate that calls `EnsureTableInMetadataCache` and therefore builds a table on demand.

Why every earlier measurement read zero: the corpus and `runner-extras` only ever filter the Field table on tables the runner has already parsed from AL source, and those are in the metadata cache before any test runs. Nothing in either suite named a precompiled table nothing else had opened. That is a gap in the coverage, not a property of the code.

## The bug that fell out of asking the sibling question

Four `DataAccess` request paths reach this table, and only the find path ran the populate:

| AL | DataAccess method | request type | before |
|---|---|---|---|
| `Find` / `FindSet` / `FindFirst` | `InnerFindAsync` | `FindCacheRequest` | correct |
| `Count` | `CountAsync` | `CountCacheRequest` | **0** |
| `IsEmpty` | `ExistsAsync` | `ExistsCacheRequest` | **true** |
| `Get(TableNo, No.)` | `InternalTryGetByPrimaryKeyAsync` | `PrimaryKeyCacheRequest` | **false** |

Measured on `main`, same bundle, table 5802 untouched:

```
Field.SetRange(TableNo, 5802); Count()   -> 0      IsEmpty() -> true
Field.SetRange(TableNo, 5802); FindSet() -> 85 rows
Field.Get(5802, 1)                       -> false
```

The same table answered differently depending on which method AL called, and every wrong answer is the quiet kind: 0 rows, "the set is empty" and "no such field" are exactly what an empty table looks like. This is the same shape as #2648 (Date) and #2504 (Aggregate Permission Set), both of which fixed `CountAsync` and `InternalTryGetByPrimaryKeyAsync` for their own tables and left this one behind.

`IsEmpty()` is a fourth path, not a spelling of `Count()`. Decompiled from `Ncl.dll` 28.1: `NavRecord.GetALIsEmptyAsync` -> `RecordImplementation.IsEmptyAsync` -> `RecordImplementation.ExistsAsync` -> `dataAccess.ExistsAsync(new ExistsCacheRequest(...))`. It never touches `CountAsync`. The Date guard's comment claims otherwise, which is what kept it invisible — I only found it because the test asserted `IsEmpty()` separately instead of trusting it to share `Count()`'s implementation, and it failed after the other two guards were already in.

## The three questions

1. **Same wrong pattern at another call site?** Yes — the `CountAsync` and `InternalTryGetByPrimaryKeyAsync` prepends existed for two other virtual tables and simply had no Field branch. Both added here.
2. **Sibling function with the same assumption?** Yes, and it was the one nobody had listed: `ExistsAsync`. Added.
3. **Two paths writing the same state, same invariant?** They do now. The find path's targeted populate is factored into `PopulateFieldRowsForTargetTable` and all four paths call it, rather than four copies of the same invariant drifting apart the way these three already had.

## Deliberately left out

The Date virtual table has the identical `ExistsAsync` gap, measured, not inferred: `Date.SetRange("Period Start", 18500101D..18500107D)` answers `IsEmpty() = true` and then `Count() = 7` on the very next line. Filed as #3006 rather than folded in here, because #2988 is in flight on the Date row path and the fix needs its own proving test and its own count-baseline line. The Aggregate Permission Set table plausibly shares it; I did not measure that and #3006 says so.

## RED -> GREEN

Five tests added to `tests/runner-extras/standalone-suites/field-virtual-table/`. They use Base Application tables rather than the bundle's own, because a table the runner parses from AL source is in the metadata cache before any test runs and can never show the gap — the precondition is "not yet materialised". One table per test, because the first request of any kind warms it for every later one. Measured over a full `tests/runner-extras` run, 193 real tables were in the cache when this codeunit executed, and none of 5802 / 270 / 349 / 5804 was among them.

Full `tests/runner-extras`, all 25 app groups in one process, guards disabled vs enabled:

```
RED    279 pass / 4 fail   Count_TableNotYetMaterialised_CountsRealFields
                           IsEmpty_TableNotYetMaterialised_IsFalse
                           Get_ByPrimaryKey_TableNotYetMaterialised_ReturnsRealField
                           AllFourPaths_AgreeOnTheSameTable
GREEN  283 pass / 0 fail
```

The two negative tests (`NonExistentTable_*`) pass in both states, as they must — an empty answer for a table id that does not exist is right either way.

## Also run, on the rebased tree

- `tests/runner-extras`, CI invocation with `--strict --count-baseline`: **283/283, exit 0**. Baseline `standalone-suites` 108 -> 113.
- `tests/al-language` corpus, CI invocation with `--strict --count-baseline`: **2554/2554, exit 0**. Included because the three prepends sit on methods every table's reads go through, so the blast radius is wider than the Field table.
- `dotnet test AlRunner.Tests` filtered to `JmpHookOrphanAudit`, `NclCecilRewriteCacheKey`, `VirtualTableRefusalClaim`, `DateVirtualTableWindow`, `AggregatePermissionSetVirtualTable`: **98/98**.

All on BC 28.1 — a self-built runner is compiled against Ncl 28.x and cannot execute 27.x artifacts, so the 27.x legs are CI's to report.

Opened by agent `impl-31` on the account holder's behalf.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf