### PR TITLE
fix(phaselog): read VmHWM and VmRSS from one /proc/self/status sample so the peak-RSS invariant cannot race

### DIFF
--- a/AlRunner.Tests/PhaseLogTests.cs
+++ b/AlRunner.Tests/PhaseLogTests.cs
@@ -431,12 +431,17 @@ public sealed class PhaseLogTests : IDisposable
     /// produces a value about 1024x off — and a value 1024x too small still clears an
     /// "8 MB" floor on a process using several GB.
     ///
-    /// A high-water mark can never be below the current working set, and the current
-    /// working set of this test process is a real number in real bytes from a source this
-    /// code does not touch. So that comparison pins the units from below on all three
-    /// platforms at once, without an upper bound: a ratio ceiling would be a flake on a
-    /// loaded CI machine, where the suite spawns runner subprocesses and does heavy AL
-    /// compiles, peaks high, and then releases.
+    /// The current working set of this test process is a real number in real bytes from a
+    /// source this code does not touch, so comparing against it pins the units from below
+    /// on all three platforms at once — with no upper bound, since a ratio ceiling would
+    /// flake on a loaded CI machine where the suite spawns runner subprocesses, peaks high,
+    /// and then releases.
+    ///
+    /// What it can NOT do is state "a high-water mark is never below the current working
+    /// set" exactly, because the two numbers come from two /proc files read at two instants
+    /// (#3005). That claim moved to LinuxRssSample_PeakIsNotBelowCurrentWithinOneSample,
+    /// where one read of one file makes it an invariant; the bound left here is the
+    /// order-of-magnitude one the units hazard actually needs.
     /// </summary>
     [Fact]
     public void PeakRssBytes_IsInBytes_AndNotBelowTheCurrentWorkingSet()
@@ -446,9 +451,105 @@ public sealed class PhaseLogTests : IDisposable
         var peak = PhaseLog.PeakRssBytes();
 
         Assert.True(live > 0, $"the test's own working set should be readable, got {live}");
-        Assert.True(peak >= live,
-            $"peak RSS {peak} is below this process's current working set {live}; "
-            + "a high-water mark cannot be, so the value is in the wrong units or read "
-            + "from the wrong field");
+
+        // BANDED ON PURPOSE, and the band is not a weakening of the units check.
+        // This comparison crosses two sources — VmHWM out of /proc/self/status here
+        // versus /proc/<pid>/stat inside WorkingSet64 — read at two instants, and those
+        // two cannot promise agreement to the page: #3005 saw them 0.13% apart on CI and
+        // the strict >= that used to stand here failed at random. A 1024x units error is
+        // 512x clear of this bound, so the hazard is still caught by an enormous margin,
+        // and the EXACT peak >= current invariant now lives below, where a single read of
+        // a single file makes it true rather than probable.
+        Assert.True(peak * 2 >= live,
+            $"peak RSS {peak} is more than 2x below this process's current working set "
+            + $"{live}; a high-water mark cannot be, so the value is in the wrong units "
+            + "or read from the wrong field");
+    }
+
+    /// <summary>
+    /// The exact half of the claim above, on the one platform that can state it exactly.
+    /// The kernel builds VmHWM and VmRSS from the same counter read inside a single
+    /// task_mem() call (hiwater is max(mm-&gt;hiwater_rss, that same rss)), so within ONE
+    /// read of /proc/self/status "the peak is not below the current" is an invariant, not
+    /// a race. Across two files and two instants — the shape this test used to have — it
+    /// is neither.
+    /// </summary>
+    [Fact]
+    public void LinuxRssSample_PeakIsNotBelowCurrentWithinOneSample()
+    {
+        if (!OperatingSystem.IsLinux()) return;
+
+        Assert.True(PhaseLog.TryReadLinuxRssSample(out var peak, out var current),
+            "a Linux process must be able to read its own /proc/self/status");
+        Assert.True(current > 8 * 1024 * 1024,
+            $"the sample's current RSS looks stubbed or unscaled: {current} bytes");
+        Assert.True(peak >= current,
+            $"peak RSS {peak} is below current RSS {current} in the SAME sample; "
+            + "that is impossible from one read, so the two values were not parsed from "
+            + "one snapshot or one of them is in the wrong units");
+    }
+
+    /// <summary>
+    /// The units hazard, pinned deterministically instead of by comparing live numbers:
+    /// /proc/self/status reports these fields in KILOBYTES, so the parse must scale by
+    /// 1024. Dropping that conversion understates by ~1024x, and a value 1024x too small
+    /// still clears an "8 MB" floor on a process using several GB — which is why the
+    /// original check reached for a live cross-source comparison and inherited its race.
+    /// A fixed input needs no live process at all.
+    /// </summary>
+    [Fact]
+    public void LinuxRssSample_ParsesKilobyteFieldsIntoBytes()
+    {
+        const string status =
+            "Name:\tdotnet\n"
+            + "VmPeak:\t 4472124 kB\n"
+            + "VmSize:\t 4406588 kB\n"
+            + "VmHWM:\t  371448 kB\n"
+            + "VmRSS:\t  370960 kB\n"
+            + "Threads:\t18\n";
+
+        Assert.True(PhaseLog.TryParseLinuxRssSample(status, out var peak, out var current));
+        Assert.Equal(371448L * 1024, peak);
+        Assert.Equal(370960L * 1024, current);
+    }
+
+    /// <summary>
+    /// Negative direction: a status blob without the fields must report failure, not a
+    /// zero the aggregate would present as "this run used no memory". VmPeak is deliberately
+    /// present — it is virtual size, not RSS, and a prefix match loose enough to accept it
+    /// would report a number several times too large.
+    /// </summary>
+    [Fact]
+    public void LinuxRssSample_ReportsFailureWhenTheFieldsAreAbsent()
+    {
+        Assert.False(PhaseLog.TryParseLinuxRssSample(
+            "Name:\tdotnet\nVmPeak:\t 4472124 kB\nThreads:\t18\n", out var peak, out var current));
+        Assert.Equal(0, peak);
+        Assert.Equal(0, current);
+    }
+
+    /// <summary>
+    /// The same two-source hazard on the macOS branch of <see cref="PhaseLog.PeakRssBytes"/>,
+    /// which sanity-checks getrusage's ru_maxrss against Process.WorkingSet64 and falls back
+    /// to the working set when the check fails. Strict &gt;= there discards a perfectly good
+    /// peak over the same sub-percent skew that made #3005 flake, so the guard is banded the
+    /// same way — while a 1024x units error (ru_maxrss is BYTES on Darwin, KILOBYTES on
+    /// Linux) still fails it and still falls back.
+    /// </summary>
+    [Fact]
+    public void DarwinPeakChoice_KeepsASlightlyLowerMaxRss_ButRejectsAUnitsError()
+    {
+        // The exact numbers from #3005: 499,712 bytes apart, peak below live by 0.13%.
+        Assert.Equal(379_863_040L, PhaseLog.ChooseDarwinPeak(379_863_040L, 380_362_752L));
+
+        // Normal case: a real high-water mark above the live working set is kept as-is.
+        Assert.Equal(500_000_000L, PhaseLog.ChooseDarwinPeak(500_000_000L, 380_362_752L));
+
+        // Kilobytes read as bytes — 1024x too small. Rejected, and the working set (a real
+        // measurement and a valid lower bound on the peak) is reported instead.
+        Assert.Equal(380_362_752L, PhaseLog.ChooseDarwinPeak(379_863_040L / 1024, 380_362_752L));
+
+        // A failed getrusage reports 0; that must never be reported as the peak.
+        Assert.Equal(380_362_752L, PhaseLog.ChooseDarwinPeak(0, 380_362_752L));
     }
 }

--- a/AlRunner.Tests/PhaseLogTests.cs
+++ b/AlRunner.Tests/PhaseLogTests.cs
@@ -438,8 +438,8 @@ public sealed class PhaseLogTests : IDisposable
     /// and then releases.
     ///
     /// What it can NOT do is state "a high-water mark is never below the current working
-    /// set" exactly, because the two numbers come from two /proc files read at two instants
-    /// (#3005). That claim moved to LinuxRssSample_PeakIsNotBelowCurrentWithinOneSample,
+    /// set" exactly, because the two numbers come from two reads of /proc/self/status at
+    /// two instants (#3005). That claim moved to LinuxRssSample_PeakIsNotBelowCurrentWithinOneSample,
     /// where one read of one file makes it an invariant; the bound left here is the
     /// order-of-magnitude one the units hazard actually needs.
     /// </summary>
@@ -453,13 +453,15 @@ public sealed class PhaseLogTests : IDisposable
         Assert.True(live > 0, $"the test's own working set should be readable, got {live}");
 
         // BANDED ON PURPOSE, and the band is not a weakening of the units check.
-        // This comparison crosses two sources — VmHWM out of /proc/self/status here
-        // versus /proc/<pid>/stat inside WorkingSet64 — read at two instants, and those
-        // two cannot promise agreement to the page: #3005 saw them 0.13% apart on CI and
-        // the strict >= that used to stand here failed at random. A 1024x units error is
-        // 512x clear of this bound, so the hazard is still caught by an enormous margin,
-        // and the EXACT peak >= current invariant now lives below, where a single read of
-        // a single file makes it true rather than probable.
+        // These two numbers are two reads of the SAME file at two instants — VmHWM out of
+        // /proc/self/status here, and WorkingSet64, which is /proc/self/status VmRSS
+        // (measured: it equalled VmRSS in 35,269 of 37,489 samples under churn and
+        // /proc/<pid>/stat's rss in 0 of them). Two instants cannot promise agreement to
+        // the page: #3005 saw them 0.13% apart on CI and the strict >= that used to stand
+        // here failed at random. A 1024x units error is 512x clear of this bound, so the
+        // hazard is still caught by an enormous margin, and the EXACT peak >= current
+        // invariant now lives below, where a single read makes it true rather than
+        // probable.
         Assert.True(peak * 2 >= live,
             $"peak RSS {peak} is more than 2x below this process's current working set "
             + $"{live}; a high-water mark cannot be, so the value is in the wrong units "

--- a/AlRunner/Infrastructure/PhaseLog.cs
+++ b/AlRunner/Infrastructure/PhaseLog.cs
@@ -546,12 +546,17 @@ public static class PhaseLog
 
     /// <summary>
     /// This process's resident-set high-water mark in bytes. Linux reads VmHWM from
-    /// /proc/self/status — the kernel's own high-water mark, which .NET's
-    /// PeakWorkingSet64 does not surface on Unix. macOS reads getrusage's ru_maxrss,
-    /// because .NET does not implement PeakWorkingSet64 there at all: it returns 0,
-    /// and a silent zero is worse than a missing field, since the aggregate built on
-    /// top presents it as a measurement of a run that used no memory. Falls back to
-    /// the framework property elsewhere.
+    /// /proc/self/status. NOT because PeakWorkingSet64 is missing there — that is a
+    /// claim this comment used to make and it is false: measured on net8.0/Linux after
+    /// unmapping 700 MB, PeakWorkingSet64 returns VmHWM to the byte (763,752,448 from
+    /// both). The reason is that the peak has to be read together with VmRSS out of ONE
+    /// sample, which the framework property cannot give — see TryReadLinuxRssSample.
+    /// macOS reads getrusage's ru_maxrss, because .NET does not implement
+    /// PeakWorkingSet64 there at all: it returns 0, and a silent zero is worse than a
+    /// missing field, since the aggregate built on top presents it as a measurement of
+    /// a run that used no memory. Falls back to the framework property elsewhere — and
+    /// on a Linux box whose /proc/self/status cannot be read, where it is the same
+    /// number by the measurement above.
     /// </summary>
     public static long PeakRssBytes()
     {
@@ -563,13 +568,6 @@ public static class PhaseLog
             using var self = System.Diagnostics.Process.GetCurrentProcess();
 
             if (OperatingSystem.IsMacOS()) return ChooseDarwinPeak(DarwinPeakRssBytes(), self.WorkingSet64);
-
-            // Linux only gets here when /proc/self/status was unreadable or carried neither
-            // field, and PeakWorkingSet64 is not implemented on Unix — so taking it would
-            // report 0, which the aggregate presents as a run that used no memory. Report
-            // the live working set instead, the same real-measurement fallback the Darwin
-            // branch above already uses.
-            if (OperatingSystem.IsLinux()) return self.WorkingSet64;
 
             return self.PeakWorkingSet64;
         }
@@ -603,13 +601,16 @@ public static class PhaseLog
     /// One consistent sample of this process's resident-set counters, in bytes, from a
     /// SINGLE read of /proc/self/status.
     ///
-    /// Reading VmHWM here and taking the "current" number from somewhere else — .NET's
-    /// Process.WorkingSet64, which comes off /proc/&lt;pid&gt;/stat — compares two files
-    /// sampled at two instants, and those cannot promise agreement to the page: #3005 saw
-    /// them 0.13% apart on a CI leg, with the supposed high-water mark reading BELOW the
-    /// live working set. Within one read the kernel derives both fields from the same
-    /// counter read inside task_mem(), with the reported hiwater being the larger of
-    /// mm-&gt;hiwater_rss and that same rss, so <paramref name="peakBytes"/> &gt;=
+    /// Reading VmHWM here and taking the "current" number from .NET's Process.WorkingSet64
+    /// is TWO READS OF THIS SAME FILE at two instants — measured, WorkingSet64 equalled
+    /// /proc/self/status VmRSS in 35,269 of 37,489 samples under churn and
+    /// /proc/&lt;pid&gt;/stat's rss in 0 of them — and two instants cannot promise agreement:
+    /// #3005 saw them 0.13% apart on a CI leg, with the supposed high-water mark reading
+    /// BELOW the live working set, and the same shape inverted 5 times in those 37,489
+    /// local samples against 0 for the one-read shape below. Within one read the kernel
+    /// derives both fields from the same counter read inside task_mem()
+    /// (hiwater_rss = total_rss = anon + file + shmem, then raised to mm-&gt;hiwater_rss
+    /// only if that is larger), so <paramref name="peakBytes"/> &gt;=
     /// <paramref name="currentBytes"/> is an invariant of the sample rather than a race.
     ///
     /// Returns false on anything that is not Linux, and on any read or parse failure.

--- a/AlRunner/Infrastructure/PhaseLog.cs
+++ b/AlRunner/Infrastructure/PhaseLog.cs
@@ -557,33 +557,19 @@ public static class PhaseLog
     {
         try
         {
-            if (OperatingSystem.IsLinux() && File.Exists("/proc/self/status"))
-            {
-                foreach (var line in File.ReadLines("/proc/self/status"))
-                {
-                    if (!line.StartsWith("VmHWM:", StringComparison.Ordinal)) continue;
-                    var kb = line.AsSpan(6).Trim().ToString().Split(' ')[0];
-                    if (long.TryParse(kb, out var v)) return v * 1024;
-                }
-            }
+            if (OperatingSystem.IsLinux() && TryReadLinuxRssSample(out var peak, out _))
+                return peak;
 
             using var self = System.Diagnostics.Process.GetCurrentProcess();
 
-            if (OperatingSystem.IsMacOS())
-            {
-                var maxRss = DarwinPeakRssBytes();
-                // A high-water mark cannot be below the current working set. That check is
-                // what catches the live hazard, which is a units error rather than a wrong
-                // number: ru_maxrss is BYTES on Darwin and KILOBYTES on Linux, so reading
-                // the Linux convention on a Mac produces a value about 1024x too small —
-                // one that sails past any "greater than a few MB" floor while being wrong.
-                // It also catches a wrong field offset, which would read some other member
-                // of struct rusage. On either failure, fall back to the current working
-                // set: a real measurement and a valid lower bound on the peak, rather than
-                // a made-up number or a zero.
-                if (maxRss >= self.WorkingSet64) return maxRss;
-                return self.WorkingSet64;
-            }
+            if (OperatingSystem.IsMacOS()) return ChooseDarwinPeak(DarwinPeakRssBytes(), self.WorkingSet64);
+
+            // Linux only gets here when /proc/self/status was unreadable or carried neither
+            // field, and PeakWorkingSet64 is not implemented on Unix — so taking it would
+            // report 0, which the aggregate presents as a run that used no memory. Report
+            // the live working set instead, the same real-measurement fallback the Darwin
+            // branch above already uses.
+            if (OperatingSystem.IsLinux()) return self.WorkingSet64;
 
             return self.PeakWorkingSet64;
         }
@@ -591,6 +577,99 @@ public static class PhaseLog
         {
             return 0;
         }
+    }
+
+    /// <summary>
+    /// Sanity-checks getrusage's ru_maxrss against the live working set and reports the
+    /// better of the two. The hazard being caught is a units error rather than a wrong
+    /// number: ru_maxrss is BYTES on Darwin and KILOBYTES on Linux, so reading the Linux
+    /// convention on a Mac produces a value about 1024x too small — one that sails past
+    /// any "greater than a few MB" floor while being wrong. A wrong field offset, which
+    /// would read some other member of struct rusage, fails it too. On either failure the
+    /// current working set is reported: a real measurement and a valid lower bound on the
+    /// peak, rather than a made-up number or a zero.
+    ///
+    /// The bound is order-of-magnitude ON PURPOSE. These are two sources read at two
+    /// instants — ru_maxrss from the kernel's rusage accounting, WorkingSet64 from .NET's
+    /// own sampling — and #3005 measured the equivalent pair 0.13% apart under CI load. A
+    /// strict >= here throws away a perfectly good high-water mark over that skew and
+    /// reports the smaller live number as the peak; halving it costs nothing, since a
+    /// 1024x units error still lands 512x below the bound.
+    /// </summary>
+    internal static long ChooseDarwinPeak(long maxRssBytes, long workingSetBytes)
+        => maxRssBytes > 0 && maxRssBytes * 2 >= workingSetBytes ? maxRssBytes : workingSetBytes;
+
+    /// <summary>
+    /// One consistent sample of this process's resident-set counters, in bytes, from a
+    /// SINGLE read of /proc/self/status.
+    ///
+    /// Reading VmHWM here and taking the "current" number from somewhere else — .NET's
+    /// Process.WorkingSet64, which comes off /proc/&lt;pid&gt;/stat — compares two files
+    /// sampled at two instants, and those cannot promise agreement to the page: #3005 saw
+    /// them 0.13% apart on a CI leg, with the supposed high-water mark reading BELOW the
+    /// live working set. Within one read the kernel derives both fields from the same
+    /// counter read inside task_mem(), with the reported hiwater being the larger of
+    /// mm-&gt;hiwater_rss and that same rss, so <paramref name="peakBytes"/> &gt;=
+    /// <paramref name="currentBytes"/> is an invariant of the sample rather than a race.
+    ///
+    /// Returns false on anything that is not Linux, and on any read or parse failure.
+    /// </summary>
+    internal static bool TryReadLinuxRssSample(out long peakBytes, out long currentBytes)
+    {
+        peakBytes = 0;
+        currentBytes = 0;
+        if (!OperatingSystem.IsLinux()) return false;
+        try
+        {
+            // ReadAllText, not ReadLines: one open and one pass, so both fields come out
+            // of the same procfs snapshot. /proc/self/status is well under a page.
+            return TryParseLinuxRssSample(File.ReadAllText("/proc/self/status"), out peakBytes, out currentBytes);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Parses VmHWM (peak) and VmRSS (current) out of one /proc/self/status body. Both
+    /// fields are reported in KILOBYTES, so both are scaled by 1024 — dropping that
+    /// understates by ~1024x, and a value 1024x too small still clears any "a live process
+    /// uses at least a few MB" floor. Split out from the read so the scaling is provable
+    /// against a fixed input instead of against live numbers that move underneath the test.
+    ///
+    /// The field match is exact up to the colon: VmPeak is virtual size, not RSS, and a
+    /// looser prefix match would report a number several times too large.
+    /// </summary>
+    internal static bool TryParseLinuxRssSample(string statusText, out long peakBytes, out long currentBytes)
+    {
+        peakBytes = 0;
+        currentBytes = 0;
+        if (string.IsNullOrEmpty(statusText)) return false;
+
+        foreach (var raw in statusText.Split('\n'))
+        {
+            var line = raw.AsSpan().Trim();
+            if (line.StartsWith("VmHWM:", StringComparison.Ordinal))
+                peakBytes = ParseKilobyteField(line[6..]);
+            else if (line.StartsWith("VmRSS:", StringComparison.Ordinal))
+                currentBytes = ParseKilobyteField(line[6..]);
+            if (peakBytes > 0 && currentBytes > 0) break;
+        }
+
+        if (peakBytes > 0 && currentBytes > 0) return true;
+        peakBytes = 0;
+        currentBytes = 0;
+        return false;
+    }
+
+    /// <summary>"  371448 kB" -&gt; 380,362,752. Returns 0 when the value does not parse.</summary>
+    private static long ParseKilobyteField(ReadOnlySpan<char> value)
+    {
+        value = value.Trim();
+        var end = value.IndexOf(' ');
+        if (end >= 0) value = value[..end];
+        return long.TryParse(value, out var kb) && kb > 0 ? kb * 1024 : 0;
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #3005

`PhaseLogTests.PeakRssBytes_IsInBytes_AndNotBelowTheCurrentWorkingSet` asserted
`PhaseLog.PeakRssBytes() >= Process.GetCurrentProcess().WorkingSet64`. Those two numbers are
**two reads of the same file at two instants** — `VmHWM` out of `/proc/self/status` on one
side, and `WorkingSet64`, which is that same file's `VmRSS`, on the other — and #3005 measured
them 0.13% apart (499,712 bytes of 380 MB) on a BC 27.5 leg, with the "high-water mark" reading
*below* the live working set.

> **Correction (post-review).** The first version of this body, and #3005's body, both said
> `WorkingSet64` comes from `/proc/<pid>/stat`. It does not. Measured over 37,489 samples under
> 8 churn threads on net8.0/Linux: `WorkingSet64` equalled `/proc/self/status` `VmRSS` **35,269
> times** and `/proc/<pid>/stat`'s `rss` **0 times**. Same file, second read — which makes the
> one-read fix *more* obviously right, but a reader chasing a divergence between two different
> files would be chasing something that does not exist. #3005's body has been corrected too. Established as a flake to `ci-verdicts.md`'s standard in the issue: the
identical SHA `4c45c282` failed in run `34000496927` and passed in the single-leg dispatch
`34001414653`.

## The fix: one sample, not a tolerance

`PhaseLog.TryReadLinuxRssSample` reads `/proc/self/status` **once** and parses both `VmHWM`
(peak) and `VmRSS` (current) out of that one body. The kernel derives both from the same
counter read inside a single `task_mem()` call — the hiwater it reports is the larger of
`mm->hiwater_rss` and that same rss — so `peak >= current` is an invariant *of the sample*
rather than a race between two accounting paths. `PeakRssBytes()` now goes through it on Linux.

That is issue #3005's option 2 rather than option 1, and deliberately: a tolerance makes the
assertion vaguer, a single sample makes it **true**, and the strict `>=` survives.

## The units hazard is still caught — and caught harder

The test exists for a **units error**: these fields are kilobytes, so dropping the `* 1024`
understates by ~1024x, and a value 1024x too small still clears an "8 MB" floor on a process
using several GB. That claim no longer rests on live numbers at all — `TryParseLinuxRssSample`
takes the status text as a string, so `LinuxRssSample_ParsesKilobyteFieldsIntoBytes` pins the
scaling against a fixed blob and cannot race with anything.

**Mutation proof** (`kb * 1024` → `kb` in `ParseKilobyteField`, then reverted): 4 of 21 fail.

```
Failed PeakRssBytes_ReportsARealHighWaterMark
  peak RSS looks stubbed: 179936 bytes
Failed LinuxRssSample_PeakIsNotBelowCurrentWithinOneSample
  the sample's current RSS looks stubbed or unscaled: 182972 bytes
Failed PeakRssBytes_IsInBytes_AndNotBelowTheCurrentWorkingSet
  peak RSS 183720 is more than 2x below this process's current working set 187973632; ...
Failed LinuxRssSample_ParsesKilobyteFieldsIntoBytes
  Assert.Equal() Failure: Expected: 380362752  Actual: 371448
```

The live cross-source comparison stays, banded to `peak * 2 >= live` and documented as
order-of-magnitude on purpose: it is the only check that covers macOS and Windows, a 1024x
error lands 512x below that bound, and 0.13% of skew can no longer touch it.

## What the RED does and does not prove

- **RED 1 — structural.** The new tests were written first and the build failed with 7
  `CS0117`s (`TryReadLinuxRssSample`, `TryParseLinuxRssSample`, `ChooseDarwinPeak` do not
  exist). That proves the assertions are new, nothing about the race.
- **RED 2 — mutation.** The four failures above, from a real defect injected into the fix.
  That proves the units hazard the test exists for is still caught.
- **Originally NOT proved, then reproduced.** The first version of this body reported honestly
  that I could not make the inversion happen: 8,596 samples across two shapes gave 0 inversions.
  Two later runs did reproduce it, both running the old two-read shape and the new one-read shape
  in the same loop as each other's control — the reviewer's 20,000 samples under 8 churn threads
  gave **3 old-shape inversions** (gaps 4,096 / 540,672 / 1,212,416 bytes, the same sign and
  magnitude as #3005's 499,712) against **0** new-shape, and my own 37,489-sample run gave
  **5 against 0**. So the mechanism is now measured, not only inferred from CI, and the fix is
  its own control in both runs.
- **Still worth stating plainly:** the invariant does not rest on those runs. It is structural —
  `task_mem()` computes `hiwater_rss = total_rss = anon + file + shmem` and then raises it to
  `mm->hiwater_rss` only if that is larger, printing both from those locals, so one read cannot
  report a peak below its own current. `LinuxRssSample_PeakIsNotBelowCurrentWithinOneSample`
  also did not fail in 10 consecutive filtered runs, which proves no more than that.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site — yes, one, and it is fixed.** The Darwin branch of
   `PeakRssBytes()` sanity-checked `getrusage`'s `ru_maxrss` against `Process.WorkingSet64` with
   the same strict `>=`, and on failure reported the *working set* as the peak. Same two-source
   comparison, same sub-percent skew, and there it silently discards a valid high-water mark
   instead of failing a test. Extracted as `ChooseDarwinPeak(maxRss, workingSet)` and banded
   identically, with `DarwinPeakChoice_KeepsASlightlyLowerMaxRss_ButRejectsAUnitsError` pinning
   all four cases — including #3005's exact numbers, a 1024x units error still being rejected,
   and a failed `getrusage`'s 0 never being reported as a peak. It is a pure function, so the
   macOS decision is unit-tested on a Linux CI leg.
2. **Sibling function making the same assumption — checked, none.** `MemoryCensus.ReadVmRssKb`
   parses `VmRSS:` out of the same file, but it makes no cross-source comparison and asserts no
   invariant; it feeds one diagnostic log line and reports kB by design. Left alone.
3. **Two paths writing the same state — I claimed a missing guard here and I was wrong.** The
   first version of this PR added a Linux fallback to `WorkingSet64` on the parse-failure path,
   arguing that `Process.PeakWorkingSet64` is not implemented on Unix and would report a silent
   **0**. It is implemented. Measured on net8.0/Linux after unmapping 700 MB, `PeakWorkingSet64`
   and `VmHWM` both report **763,752,448** — equal to the byte. So the hunk was wrongly
   motivated, *less* accurate than the line it replaced in the only branch it could run in, and
   unreachable besides (a `/proc/self/status` read that fails fails the framework's read of the
   same file). Reverting it leaves 21/21 passing, which is the other half of the argument: it was
   untested. It is reverted, and the method's pre-existing doc comment, which had made the same
   false claim about .NET since before this PR, now records the measurement instead.

## No corpus test is owed

Deliberate conclusion, not an omission. This is process-memory accounting inside the runner's
own `AL_RUNNER_PHASE_LOG` diagnostic: no AL surface can observe `VmHWM`, `VmRSS` or peak RSS, so
there is nothing here a real BC service tier could adjudicate and nothing to red-test in AL.
The claim about *kernel* behaviour (one `task_mem()` call derives both fields) is settled by the
single-read structure of the code, and the units claim by a fixed-input parse test.

## Tests run

- `dotnet test AlRunner.Tests --filter FullyQualifiedName~PhaseLogTests` — 21/21 pass
  (RED first: 7 compile errors; GREEN after).
- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~PhaseLog|FullyQualifiedName~ServerGcConfig"`
  — 28/28 pass, covering `PhaseLogIntegrationTests` and `PhaseLogServerKillTests`, the other
  consumers of the record this method writes.
- The mutation run above.
- Not run locally: the full `AlRunner.Tests` suite and the AL corpus. This change touches one
  diagnostic method with no compile or dispatch blast radius; CI runs both on all 8 legs.

`tests/expectations/count-baseline/test-count-baseline.json` is deliberately untouched (#2941
and #3004 are both writing it).

---
*Implemented by agent `stma-auto-1` on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
