### PR TITLE
test(guards): scan AlRunner.Tests sources at any depth, not just the top level

### DIFF
--- a/AlRunner.Tests/BaseAppFloorFixtureGuardTests.cs
+++ b/AlRunner.Tests/BaseAppFloorFixtureGuardTests.cs
@@ -51,6 +51,21 @@ public sealed class BaseAppFloorFixtureGuardTests
 
     private static string TestsDir => Path.Combine(RepoRoot, "AlRunner.Tests");
 
+    /// <summary>An allowlist key: the path relative to AlRunner.Tests/, '/' separated.</summary>
+    private static string Rel(string path) =>
+        Path.GetRelativePath(TestsDir, path).Replace(Path.DirectorySeparatorChar, '/');
+
+    /// <summary>
+    /// Every <c>.cs</c> source in the project, at ANY depth, minus build output (the SDK
+    /// generates sources under <c>obj/</c>). #3000: the source scan below enumerated
+    /// <c>SearchOption.TopDirectoryOnly</c> while the fixture scan in the same class already
+    /// walked <c>Fixtures/</c> recursively — so a .cs file below the top level was invisible
+    /// to one half of a guard whose whole value is that it fails automatically.
+    /// </summary>
+    private static IEnumerable<string> TestSourcePaths() =>
+        Directory.EnumerateFiles(TestsDir, "*.cs", SearchOption.AllDirectories)
+            .Where(p => !Rel(p).Split('/').Any(seg => seg is "bin" or "obj"));
+
     // A JSON "application" property, in a .json file or embedded in a C# string —
     // including the escaped \"application\" form used in concatenated manifests.
     private static readonly Regex ApplicationProperty = new(
@@ -76,9 +91,12 @@ public sealed class BaseAppFloorFixtureGuardTests
     };
 
     /// <summary>
-    /// C# test classes permitted to write the floor into a manifest they generate. Three
+    /// C# test sources permitted to write the floor into a manifest they generate. Three
     /// are debt tracked in #2364, not permission; two are legitimate. Keep the reasons —
-    /// the rule was ignored once already because it read as advice.
+    /// the rule was ignored once already because it read as advice. Paths are relative to
+    /// AlRunner.Tests/ with '/' separators, exactly like <see cref="AllowedFixtures"/>; for a
+    /// top-level file that is just the file name, which is why widening the scan (#3000) left
+    /// every entry below unchanged.
     /// </summary>
     private static readonly Dictionary<string, string> AllowedSources = new()
     {
@@ -118,11 +136,11 @@ public sealed class BaseAppFloorFixtureGuardTests
     public void NoTestSource_WritesTheBaseApplicationFloor_ExceptTheAllowlistedFive()
     {
         var offenders = new List<string>();
-        foreach (var path in Directory.EnumerateFiles(TestsDir, "*.cs", SearchOption.TopDirectoryOnly))
+        foreach (var path in TestSourcePaths())
         {
             if (!ApplicationProperty.IsMatch(File.ReadAllText(path))) continue;
-            var name = Path.GetFileName(path);
-            if (!AllowedSources.ContainsKey(name)) offenders.Add(name);
+            var rel = Rel(path);
+            if (!AllowedSources.ContainsKey(rel)) offenders.Add(rel);
         }
 
         Assert.True(offenders.Count == 0,
@@ -149,11 +167,11 @@ public sealed class BaseAppFloorFixtureGuardTests
                 stale.Add($"{rel} ({why})");
         }
 
-        foreach (var (name, why) in AllowedSources)
+        foreach (var (rel, why) in AllowedSources)
         {
-            var path = Path.Combine(TestsDir, name);
+            var path = Path.Combine(TestsDir, rel.Replace('/', Path.DirectorySeparatorChar));
             if (!File.Exists(path) || !ApplicationProperty.IsMatch(File.ReadAllText(path)))
-                stale.Add($"{name} ({why})");
+                stale.Add($"{rel} ({why})");
         }
 
         Assert.True(stale.Count == 0,

--- a/AlRunner.Tests/ScratchDirOwnershipGuardTests.cs
+++ b/AlRunner.Tests/ScratchDirOwnershipGuardTests.cs
@@ -49,10 +49,11 @@ public sealed class ScratchDirOwnershipGuardTests
     private const string Expression = "Path.GetTempPath()";
 
     /// <summary>
-    /// File name → (how many non-comment <c>Path.GetTempPath()</c> occurrences are permitted,
-    /// why they cannot be owned). The count is deliberately exact in both directions: too many
-    /// means a new unowned site slipped into an already-allowlisted file, too few means the
-    /// entry is stale and is silently pre-approving the next one.
+    /// Source path, relative to <c>AlRunner.Tests</c> → (how many non-comment
+    /// <c>Path.GetTempPath()</c> occurrences are permitted, why they cannot be owned). The
+    /// count is deliberately exact in both directions: too many means a new unowned site
+    /// slipped into an already-allowlisted file, too few means the entry is stale and is
+    /// silently pre-approving the next one.
     /// </summary>
     private static readonly Dictionary<string, (int Count, string Why)> Allowed = new()
     {
@@ -95,11 +96,34 @@ public sealed class ScratchDirOwnershipGuardTests
             (1, "drives SweepStale over the real temp root, which is the behaviour under test"),
     };
 
-    /// <summary>Non-comment occurrences of the expression, per file name.</summary>
+    /// <summary>
+    /// The allowlist key: the source path relative to <see cref="TestsDir"/>, with <c>/</c>
+    /// separators on every platform. For a top-level file this is exactly the file name, which
+    /// is why widening the scan below left all of the entries above unchanged — but a file in a
+    /// subdirectory can no longer alias a same-named top-level entry and inherit its budget.
+    /// </summary>
+    private static string Key(string path) =>
+        Path.GetRelativePath(TestsDir, path).Replace(Path.DirectorySeparatorChar, '/');
+
+    /// <summary>
+    /// Every <c>.cs</c> source in the project, at ANY depth, minus build output.
+    ///
+    /// #3000: this enumerated <c>SearchOption.TopDirectoryOnly</c>, so the first test file
+    /// added below the top level would have been unguarded — and silently, because the guard
+    /// keeps reporting green for what it never looks at. <c>bin/</c> and <c>obj/</c> are
+    /// skipped because the SDK writes generated sources there
+    /// (<c>*.AssemblyInfo.cs</c>, <c>*.GlobalUsings.g.cs</c>); they are not test code, and
+    /// whether they exist depends on whether the project has been built.
+    /// </summary>
+    private static IEnumerable<string> TestSources() =>
+        Directory.EnumerateFiles(TestsDir, "*.cs", SearchOption.AllDirectories)
+            .Where(p => !Key(p).Split('/').Any(seg => seg is "bin" or "obj"));
+
+    /// <summary>Non-comment occurrences of the expression, per source path.</summary>
     private static Dictionary<string, int> Occurrences()
     {
         var found = new Dictionary<string, int>(StringComparer.Ordinal);
-        foreach (var path in Directory.EnumerateFiles(TestsDir, "*.cs", SearchOption.TopDirectoryOnly))
+        foreach (var path in TestSources())
         {
             var n = 0;
             foreach (var raw in File.ReadAllLines(path))
@@ -115,7 +139,7 @@ public sealed class ScratchDirOwnershipGuardTests
                     i += Expression.Length;
                 }
             }
-            if (n > 0) found[Path.GetFileName(path)] = n;
+            if (n > 0) found[Key(path)] = n;
         }
         return found;
     }

--- a/AlRunner.Tests/TestArtifactsGateTests.cs
+++ b/AlRunner.Tests/TestArtifactsGateTests.cs
@@ -216,11 +216,20 @@ public class TestArtifactsGateTests
 
     // ---- 3. drift guards over the suite's own source ----------------------------
 
-    private static IEnumerable<(string File, string Text)> TestSources() =>
+    /// <summary>
+    /// Every <c>.cs</c> source in the suite, at ANY depth, minus build output. One place, so
+    /// the two facts below cannot disagree about what "the suite's own source" means — #3000:
+    /// <see cref="EveryTestThatCanSkipIsDeclaredSkippable"/> enumerated
+    /// <c>SearchOption.TopDirectoryOnly</c> of its own while this helper already walked the
+    /// whole tree, so the same file was in scope for one drift guard and invisible to the other.
+    /// </summary>
+    private static IEnumerable<string> TestSourcePaths() =>
         Directory.EnumerateFiles(TestsSourceDir, "*.cs", SearchOption.AllDirectories)
             .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
-                     && !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
-            .Select(f => (Path.GetFileName(f), File.ReadAllText(f)));
+                     && !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal));
+
+    private static IEnumerable<(string File, string Text)> TestSources() =>
+        TestSourcePaths().Select(f => (Path.GetFileName(f), File.ReadAllText(f)));
 
     /// <summary>
     /// One gate, one place. Twenty-three classes each declared their own
@@ -346,7 +355,7 @@ public class TestArtifactsGateTests
         var skipCall = new Regex(@"\bTestArtifacts\.(SkipIfMissing|SkipIf|SkipIfDirectoryMissing)\b|\bSkip\.(If|IfNot|Always)\b");
 
         var offenders = new List<string>();
-        foreach (var file in Directory.EnumerateFiles(TestsSourceDir, "*.cs", SearchOption.TopDirectoryOnly))
+        foreach (var file in TestSourcePaths())
         {
             if (Path.GetFileName(file) is "TestArtifacts.cs" or "TestArtifactsGateTests.cs") continue;
             string? attr = null, method = null;


### PR DESCRIPTION
Closes #3000

`ScratchDirOwnershipGuardTests` enumerated `SearchOption.TopDirectoryOnly`, so any `.cs` file in a subdirectory of `AlRunner.Tests` was never scanned and could build a path under `Path.GetTempPath()` with nothing recording an owner.

## Latent, not live

Measured on this branch's base: **433 `.cs` files in `AlRunner.Tests`, all of them top-level, zero in any subdirectory.** So the guard's coverage was complete as things stood and nothing was being missed. It becomes live the first time anyone adds a test file below the top level, and it fails *silently* — the guard keeps reporting green for what it never looks at. That is the same outcome as #2991, where the guard caught a real violation only because it could see the file; a blind spot inside the guard produces the same miss with no run to blame.

## How the RED was established

Nothing violates these guards today, so the RED had to be constructed. I added a throwaway file at `AlRunner.Tests/RedProbe/` carrying real violations — a `Path.Combine(Path.GetTempPath(), Guid)`, a generated manifest declaring `"application"`, and a plain `[Fact]` reaching `TestArtifacts.SkipIfMissing()` — and ran the guards against it with the pre-fix sources checked out from `origin/main`:

- **RED (pre-fix, probe present):** `Passed! - Failed: 0, Passed: 7` — every guard green with three live violations sitting in a subdirectory.
- **GREEN (post-fix, probe present):** `Failed: 2, Passed: 5` for the two sibling guards, and separately `Failed: 1, Passed: 2` for the scratch guard, each naming the offender by its relative path, e.g. `RedProbe/SubdirUnownedScratchProbe.cs`.
- **Probe removed:** `Passed! - Failed: 0, Passed: 41` across all three guard classes plus `SilentSkipDetectorTests`.

The probe is not in the diff; it existed only to prove the gap and its closure.

## Fixing the shape, not the reported line

Three source-scanning guards over `AlRunner.Tests` had the same defect. Fixing only the reported one would have closed the issue with the bug still in.

1. **`ScratchDirOwnershipGuardTests`** — the reported one.
2. **`BaseAppFloorFixtureGuardTests`** — sibling with the same assumption, and an invariant mismatch inside one class: its *fixture* scan already walked `Fixtures/` with `AllDirectories` and keyed on a relative path, while its *source* scan, twenty lines away, did neither.
3. **`TestArtifactsGateTests`** — same mismatch. Its `TestSources()` helper already used `AllDirectories` plus a `bin`/`obj` filter, while `EveryTestThatCanSkipIsDeclaredSkippable` enumerated `TopDirectoryOnly` of its own. Both now share one `TestSourcePaths()`, so the two drift guards cannot disagree about what "the suite's own source" means.

That existing `TestSources()` is also why the chosen shape is not invented here — `AllDirectories` minus `bin`/`obj` was already the established convention in this directory; two of three guards had simply drifted off it.

Checked and clean: `DocumentServiceProviderScopeGuardTests` and `TddModeTests` also use `TopDirectoryOnly`, but over a specific flat output directory of `.dll`s, where non-recursive is the intended behavior. Not touched.

## What the wider scan surfaced

**Nothing.** No new violations in any of the three guards. No allowlist entry was added, and **no exact-count assertion was weakened** — widening a guard's reach while removing its teeth would be a net loss.

The allowlist keys in the two allowlisted guards now hold the path relative to `AlRunner.Tests` with `/` separators, matching what `BaseAppFloorFixtureGuardTests.AllowedFixtures` already used. For a top-level file that string is exactly the file name, which is why every existing entry is unchanged — but a file in a subdirectory can no longer alias a same-named top-level entry and quietly inherit its budget. That aliasing hole is created by the widening itself, so closing it is part of doing the widening correctly rather than separate scope.

## Upstream corpus

Nothing is owed upstream. This is C# test infrastructure that scans the test project's own source files; no AL surface observes it and no claim about Business Central behavior is involved, so there is nothing a service tier could adjudicate.

## Testing

Targeted, per `.claude/rules/local-test-scope.md`: `dotnet test AlRunner.Tests --filter` over `BaseAppFloorFixtureGuardTests`, `TestArtifactsGateTests`, `ScratchDirOwnershipGuardTests` and `SilentSkipDetectorTests` — 41 passed, 0 failed, re-run after the rebase onto `5ca2847f` rather than carried across it. The full suite is CI's job.

## Deliberately left out

`tests/expectations/count-baseline/test-count-baseline.json` is untouched — #3004 is writing it.

---
Opened by an automated agent (`agent: stma-auto-1`) acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE