### PR TITLE
fix(ci-wait): refuse a verdict resolved from a run that is not the head's live run

### DIFF
--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -19,7 +19,7 @@ tools/ci-wait.py 2379 --timeout 2400
 | 0 | every required check passed **on the current head** — safe to report green |
 | 1 | a required check failed; **the failing log is already printed**. The list is what has reported SO FAR — while other required checks are still running it can still grow, and the verdict says how many have not reported. Do not scope a diagnosis to those names until every check has reported (a one-leg failure that turned out to be eight cost a version-specific diagnosis that was never relevant). |
 | 2 | timed out while still running — **not a verdict**, call again |
-| 3 | could not determine (auth, network, no checks) |
+| 3 | could not determine (auth, network, no checks) — **or** the required-context set could not be established without narrowing it (#3002). A ruleset read that comes back missing a context the tool already knows about is refused, because judging on the smaller set makes "every required check passed" vacuously true. |
 | 4 | **blocked, not failing** — every check passed but the merge is still refused and nothing else says why. Two causes: a *required* context is `cancelled` on this commit (#2726) — the one case where `gh run rerun` is correct, since a cancelled run has no failure log to destroy; or a *required* context produced **no check run at all** and every workflow run for the commit has finished (#2807), which is a trigger/`paths:` filter question, not a re-run. Never reach for `--admin` for either. |
 
 `ci-wait.py` reads the required contexts from the **live branch ruleset** on each
@@ -27,7 +27,16 @@ invocation (`GET /repos/{owner}/{repo}/rules/branches/main`, which reports only 
 rulesets), falling back to its built-in list and saying so loudly if that call fails. A
 required context added in the GitHub UI is therefore waited for immediately rather than
 ignored until someone edits the tool (#2785); `check_required_contexts.py` fails CI when the
-built-in lists and the live ruleset drift apart in either direction.
+built-in lists and the live ruleset drift apart in either direction. What it will **not** do is
+accept a ruleset answer that is *narrower* than its built-in list — that returns exit 3 rather
+than a verdict, because a partial read and a deliberate removal are indistinguishable from here
+and the smaller set is the one that produces a false green (#3002).
+
+**A green names how many required contexts it accounted for**, and that number is worth
+reading. On this repository a real green reads `9/9` or `10/10` checks with
+`2/2 ruleset context(s) accounted for`. Every false green in #3002 named **one** check — that
+asymmetry is the only reason a human caught three wrong verdicts in one night, before the tool
+was taught to refuse them.
 
 Where several runs of one workflow exist on one commit — normal for `require-tests.yml`, which
 has no `concurrency` block and triggers on `labeled`/`unlabeled` — the verdict comes from the
@@ -44,6 +53,50 @@ Measured across one session's 17 subagents, CI waiting was 328 of 3,282 Bash cal
 shape was wrong — 107 `gh run view` polls and 37 `sleep` loops against only 29 blocking
 `gh run watch` calls. Each poll re-sends the whole conversation; this turns ten-to-forty
 round trips into one.
+
+### A cancelled run's leftovers sit in the same rollup as the live run, and `gh pr checks` hides which is which
+
+This is the trap behind #3002, and it bites in **both** directions. The API attaches every
+check run for a commit to that commit, including check runs from workflow runs that were
+cancelled and superseded — #3003 measured **35 of the last 40 `Test Matrix` runs on `main`
+cancelled as superseded**, so this is the common case here, not an edge case.
+
+Two things make it hard to see:
+
+- **A cancelled run does not necessarily report `cancelled`.** Recorded on PR #3010's head
+  `95c16b20`: `Test Matrix` run `34002828792` has run-level `conclusion: cancelled`, and its
+  aggregate job **`All BC versions passed` concluded `failure`** — the aggregate runs
+  `if: always()` over `needs` that were killed. The live run `34004261321` was green
+  throughout. Read literally, that leftover is a failing *required* context.
+- **`gh pr checks` shows one row per context name and drops the rest.** Measured on PR #3016's
+  head `d56466a7`: the API reports **8 `cancelled` check runs**, and `gh pr checks` prints 25
+  rows, every one of them `pass` — not one cancellation appears. So it cannot corroborate a
+  supersession question in either direction; it never shows you *which run* produced the row,
+  and when the newest entry for a name is a leftover from a cancelled run, that leftover is the
+  entire output and is indistinguishable from a live failure.
+
+**The reliable check is the run, not the rollup:**
+
+```bash
+gh run view <run-id> --json headSha,conclusion,status
+# and, for the whole commit:
+gh api "repos/StefanMaron/BusinessCentral.AL.Runner/actions/runs?head_sha=<FULL-SHA>&per_page=100" \
+  --jq '.workflow_runs[] | "\(.id) \(.name) \(.status) \(.conclusion)"'
+```
+
+A `cancelled` conclusion — on an older `headSha`, or on a run of the same workflow that a newer
+run has replaced — is **not this push's verdict**, whatever its individual jobs say. Two runs of
+the same workflow on one SHA is normal here, not exotic: `require-tests.yml` deliberately
+carries no `concurrency` block and triggers on `labeled`/`unlabeled` (#2726).
+
+`head_sha` needs the **full** 40-character SHA. An abbreviated one returns `"workflow_runs": []`
+— which reads exactly like "no runs for this commit" and is a false negative, not an error.
+
+`tools/ci-wait.py` applies all of this itself since #3002: a conclusion from a cancelled run is
+reclassified as a cancellation (so it can block, but can never be reported as a failure or
+counted toward a green), and a name whose newest check run belongs to a run being replaced by
+one still in flight gets no verdict in either direction. You still need the recipe above when
+reading a run by hand.
 
 ## 1. Check for merge conflicts first
 

--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -39,7 +39,8 @@ Exit codes
     0  every required check passed ON THE CURRENT HEAD -- safe to report green
     1  at least one required check failed; the failing log is printed
     2  timed out while still running -- NOT a verdict, call again
-    3  could not determine state (auth, network, no checks reported)
+    3  could not determine state (auth, network, no checks reported, or the
+       required-context set could not be established without narrowing it)
     4  everything green, but the merge is still blocked and nothing else reports
        why: a REQUIRED context is `cancelled` on this commit (#2726), or a
        REQUIRED context produced no check run at all once every workflow run for
@@ -54,6 +55,39 @@ and began a version-specific diagnosis; `gh pr checks` after the run finished
 showed eight legs failing. The failure block therefore says how many required
 checks have not reported yet and that the list can still grow. Nothing about the
 verdict changed -- only what it admits it does not know.
+
+One shape behind three wrong verdicts (#3002)
+---------------------------------------------
+In one night this tool answered wrongly three times, in both directions, and
+every one of them resolved a verdict from a run that was NOT the current head's
+LIVE run:
+
+  PR #2842  GREEN, "all 1 required checks passed"  -- the matrix job had not been
+            created yet, so "every required check that exists has passed" was
+            vacuously true over a set of one.
+  PR #2971  the same line, with eight legs still pending.
+  PR #3010  FAILURE -- read off Test Matrix run 34002828792, whose RUN-LEVEL
+            conclusion is `cancelled` and whose aggregate job "All BC versions
+            passed" therefore concluded `failure` (it runs `if: always()` over
+            cancelled `needs`). The live run 34004261321 was green throughout.
+
+So there are three guards, not three patches:
+
+  * The required-context set may never be narrower than the built-in floor.
+    A partial ruleset read returns exit 3, never a reduced set
+    (resolve_required_contexts).
+  * A check run whose owning workflow run has been superseded by a newer run of
+    the same workflow is not a verdict in EITHER direction -- and that is
+    checked ahead of the failure short-circuit, which is what #3010 slipped
+    past (supersession).
+  * A conclusion produced by a run that was CANCELLED is reclassified as a
+    cancellation, so it can block (exit 4) but can never be reported as a
+    failure or counted toward a green.
+
+And a green must be able to account for every ruleset context BY NAME and say
+so: the line now reads "N/N ruleset context(s) accounted for". Every real green
+that night named nine or ten checks and both false greens named one; that
+asymmetry is the only reason a human caught them.
 
 Exit 4, and why it is not exit 0
 --------------------------------
@@ -176,6 +210,22 @@ def contexts_from_branch_rules(payload) -> tuple[str, ...] | None:
     return tuple(out) or None
 
 
+def live_ruleset_payload(branch: str = "main"):
+    """The raw `rules/branches/<branch>` payload, or None if it cannot be read.
+
+    Split out from the parse so a test can inject a RECORDED response. That
+    matters: the #3002 green-direction defect is in what the fetch returns, and
+    a test that hand-builds a context tuple cannot reproduce it.
+    """
+    rc, out = gh(["api", f"repos/{REPO}/rules/branches/{branch}"])
+    if rc != 0:
+        return None
+    try:
+        return json.loads(out)
+    except Exception:
+        return None
+
+
 def live_ruleset_contexts(branch: str = "main") -> tuple[str, ...] | None:
     """What the branch ruleset requires RIGHT NOW, or None if it cannot be read.
 
@@ -186,13 +236,78 @@ def live_ruleset_contexts(branch: str = "main") -> tuple[str, ...] | None:
     even unauthenticated on this public repo, and reports exactly
     ["All BC versions passed", "Tests updated"] carrying ruleset_id 15001420.
     """
-    rc, out = gh(["api", f"repos/{REPO}/rules/branches/{branch}"])
-    if rc != 0:
+    payload = live_ruleset_payload(branch)
+    if payload is None:
         return None
+    return contexts_from_branch_rules(payload)
+
+
+def resolve_required_contexts(branch: str = "main", fetch=None):
+    """(contexts, status, notes) -- the required set, and how much to trust it.
+
+    status is one of:
+
+      "live"      the ruleset answered and covers every context in the built-in
+                  floor. Use it: a context ADDED in the GitHub UI is waited for
+                  on the next invocation rather than ignored (#2785).
+      "fallback"  the ruleset could not be read at all. Use the built-in list,
+                  loudly. Safe in the one direction that matters -- the built-in
+                  list is the FULL set, never a subset of it, and
+                  .github/scripts/check_required_contexts.py fails CI if the two
+                  ever drift, so it cannot quietly go stale.
+      "degraded"  the ruleset answered but came back MISSING a context the
+                  built-in floor names. That is the #3002 shape and it is not
+                  answerable: a partial read and a context genuinely removed by
+                  a person look identical here, and resolving the ambiguity
+                  toward the SMALLER set is what turns "every required check
+                  that exists has passed" into a vacuous green. The caller must
+                  return exit 3 rather than judge on a narrowed set.
+
+    Never returns a set narrower than RULESET_CONTEXTS. Silently narrowing what
+    counts as required is the defect, whichever route produced it.
+    """
+    fetch = fetch or live_ruleset_payload
+    notes: list[str] = []
+    floor = set(RULESET_CONTEXTS)
+
     try:
-        return contexts_from_branch_rules(json.loads(out))
+        payload = fetch(branch)
     except Exception:
-        return None
+        payload = None
+    live = contexts_from_branch_rules(payload) if payload is not None else None
+
+    if live is None:
+        notes.append(
+            "note: could not read the live branch ruleset for "
+            f"'{branch}'; falling back to the built-in list "
+            f"{list(RULESET_CONTEXTS)}. If a required context has been added "
+            "since, it is NOT being waited for.")
+        return RULESET_CONTEXTS, "fallback", notes
+
+    lost = sorted(floor - set(live))
+    if lost:
+        notes.append(
+            "note: the live branch ruleset answered but did NOT name "
+            f"{lost}, which this tool's built-in list does. A required-context "
+            "set that is a SUBSET of the known one is not usable: a partial "
+            "read and a deliberate removal look the same from here, and "
+            "judging on the smaller set is how a vacuous GREEN gets printed "
+            "(#3002). If the context really was removed, update "
+            "RULESET_CONTEXTS in tools/ci-wait.py and "
+            "DEFAULT_REQUIRED_CONTEXTS in "
+            ".github/scripts/check_required_contexts.py.")
+        return RULESET_CONTEXTS, "degraded", notes
+
+    extra = sorted(set(live) - floor)
+    if extra:
+        notes.append(
+            f"note: the live ruleset requires {sorted(live)}, which adds "
+            f"{extra} to this script's built-in list "
+            f"{sorted(RULESET_CONTEXTS)}. Using the LIVE set. Update "
+            "RULESET_CONTEXTS in tools/ci-wait.py and "
+            "DEFAULT_REQUIRED_CONTEXTS in "
+            ".github/scripts/check_required_contexts.py (#2785).")
+    return tuple(live), "live", notes
 
 
 # FALLBACK only. `main()` asks the live ruleset first, via
@@ -389,6 +504,84 @@ def superseding_runs(newest: dict[str, dict],
     return out
 
 
+def supersession(newest: dict[str, dict],
+                 workflow_runs: list[dict] | None) -> tuple[set[str], set[str]]:
+    """(superseded, killed) -- names whose newest check run is not a live verdict.
+
+    Both sets answer the ONE question behind all three #3002 misreports: is the
+    check run we are about to judge the CURRENT HEAD'S LIVE RUN's word on this
+    name, or something else that happens to be sitting in the same rollup?
+
+    superseded
+        A newer run of the SAME workflow is still IN FLIGHT on this commit, so
+        the conclusion we are reading belongs to a run that is being replaced.
+        The window between the newer run starting and its check run appearing is
+        exactly when the rollup lies. No verdict for these names, in EITHER
+        direction. (A newer run that has already completed without producing a
+        check run for the name supersedes nothing -- the older entry is then the
+        latest word and a ruleset reads it, so it must stay judgeable.)
+
+    killed
+        The workflow run that produced the check run has run-level conclusion
+        `cancelled`. The job was killed, not judged. This matters far more than
+        it sounds: a cancelled Test Matrix run's aggregate job "All BC versions
+        passed" concludes **failure**, not `cancelled`, because it runs
+        `if: always()` over `needs` that were cancelled. Recorded on PR #3010's
+        head 95c16b20 -- run 34002828792 is `cancelled` at the run level and its
+        aggregate job is `failure`, while the live run 34004261321 was green
+        throughout. Read literally, that failure is a FAILED verdict complete
+        with an offer to fetch the log of a job nobody ever ran to completion.
+
+        A killed run's conclusions are therefore reclassified as `cancelled`,
+        which routes them to the exit-4 "blocked, not failing" path when they
+        are still the latest word, and to "no verdict yet" when a replacement is
+        on its way. Neither is ever a green.
+
+        Deliberate trade-off: a job that genuinely failed on its merits inside a
+        run somebody then cancelled is reported as blocked rather than failed.
+        That errs toward "not a verdict", never toward green, and the required
+        aggregate will not report for a cancelled run anyway -- a new run is the
+        only way forward from there regardless.
+
+    #3003 measured 35 of the last 40 `Test Matrix` runs on `main` cancelled as
+    superseded, so neither of these is an edge case here.
+    """
+    if not workflow_runs:
+        return set(), set()
+    by_id = {w.get("id"): w for w in workflow_runs if isinstance(w.get("id"), int)}
+    # Only a run that has NOT finished can still overturn what we are reading.
+    # A newer run of the same workflow that has already COMPLETED without
+    # producing a check run for this name is not superseding anything -- the
+    # older entry is then genuinely the latest word, and a ruleset reads it.
+    # Withholding there would stall every verdict behind a job that was skipped.
+    latest_pending_of_workflow: dict[object, int] = {}
+    for w in workflow_runs:
+        wid = w.get("id")
+        if not isinstance(wid, int) or w.get("status") == "completed":
+            continue
+        name = w.get("name")
+        if wid > latest_pending_of_workflow.get(name, -1):
+            latest_pending_of_workflow[name] = wid
+
+    superseded: set[str] = set()
+    killed: set[str] = set()
+    for name, r in newest.items():
+        rid = run_id_from(r.get("details_url"))
+        if rid is None:
+            continue
+        owner = by_id.get(rid)
+        if owner is None:
+            # The run list is truncated or the run is not in it. Unknown never
+            # resolves toward a verdict on its own; superseding_runs() below
+            # still applies its own conservative rule for ruleset contexts.
+            continue
+        if latest_pending_of_workflow.get(owner.get("name"), rid) > rid:
+            superseded.add(name)
+        elif owner.get("conclusion") == "cancelled":
+            killed.add(name)
+    return superseded, killed
+
+
 def classify(runs: list[dict],
              contexts: tuple[str, ...] = RULESET_CONTEXTS,
              workflow_runs: list[dict] | None = None) -> Verdict:
@@ -409,6 +602,26 @@ def classify(runs: list[dict],
     clean, and this returned GREEN saying "all 1 required checks passed" while
     every BC leg was still queued.
     """
+    floor = set(RULESET_CONTEXTS)
+    if not floor <= set(contexts):
+        # #3002. "Every required check that EXISTS has passed" is vacuously true
+        # when the set of required checks has been narrowed, and that is how a
+        # green naming ONE check got printed twice in one night while a whole
+        # matrix was still queued. A required-context set that does not cover
+        # the built-in floor is not a set this tool can judge on, so it does not
+        # judge -- it says it cannot tell.
+        lost = sorted(floor - set(contexts))
+        return Verdict(3, [
+            "UNDETERMINED -- the required-context set is narrower than the one "
+            "this tool knows about, so no verdict can be trusted:",
+            f"  missing from the set being judged: {', '.join(lost)}",
+            "",
+            "Judging on a narrowed set makes 'every required check passed' "
+            "vacuously true, which is how a GREEN naming a single check gets "
+            "printed while eight legs are still queued (#3002). Re-run this "
+            "tool; if it repeats, the branch ruleset read is degrading.",
+        ], progress="required-context set narrower than the built-in floor")
+
     if not runs:
         return Verdict(None)
 
@@ -418,11 +631,29 @@ def classify(runs: list[dict],
     # present twice, `failure` and then `skipped` after a no-tests-needed label
     # was applied. GitHub took the newer `skipped` and the PR merged; scanning
     # every entry instead would report that merged PR as FAILED.
-    newest = newest_per_name(runs)
+    raw_newest = newest_per_name(runs)
+    superseded, killed = supersession(raw_newest, workflow_runs)
+
+    # A killed run's conclusions are reclassified as `cancelled` BEFORE anything
+    # is judged, so every downstream branch -- failure, block, green -- sees the
+    # same truth: that run was stopped, its word is not a verdict on its merits.
+    newest: dict[str, dict] = {}
+    for n, r in raw_newest.items():
+        if n in killed and r.get("conclusion") != "cancelled":
+            r = dict(r)
+            r["conclusion"] = "cancelled"
+        newest[n] = r
+
     pool = [r for n, r in newest.items() if is_required(n, contexts)] or list(newest.values())
     done = [r for r in pool if r.get("status") == "completed"]
+    # A superseded name is excluded from `bad` outright. `bad` short-circuits
+    # ahead of every in-flight guard below -- deliberately, since a failure is a
+    # verdict -- so a guard placed after it never gets consulted, which is
+    # precisely how #3010's stale failure was reported (the residual noted as
+    # #2922, now closed in the one direction that was actually misreporting).
     bad = [r for r in done if r.get("conclusion") not in NOT_FAILURES
-           and r.get("conclusion") != "cancelled"]
+           and r.get("conclusion") != "cancelled"
+           and (r.get("name") or "") not in superseded]
     missing = [c for c in contexts if c not in newest]
     final = rollup_is_final(workflow_runs)
     inflight = superseding_runs(newest, contexts, workflow_runs)
@@ -434,6 +665,12 @@ def classify(runs: list[dict],
     if inflight:
         progress += (", superseding run in flight for: "
                      + ", ".join(f"{c} (run {w})" for c, w in inflight))
+    if superseded:
+        progress += (", newest check run already superseded for: "
+                     + ", ".join(sorted(superseded)))
+    if killed:
+        progress += (", conclusion came from a CANCELLED workflow run for: "
+                     + ", ".join(sorted(killed)))
 
     if bad:
         # This list is what is known SO FAR. Returning it while other required
@@ -465,6 +702,13 @@ def classify(runs: list[dict],
                 "this tool, or read `gh pr checks` once the run finishes.",
             ]
         return Verdict(1, lines, log_target=bad[0], progress=progress)
+
+    if superseded:
+        # Some name's newest check run belongs to a run that a newer run of the
+        # same workflow has already replaced. Whatever it says -- pass, fail or
+        # cancel -- it is not the live run's word, and the live run's word is
+        # still coming.
+        return Verdict(None, progress=progress)
 
     if len(done) != len(pool):
         # A cancellation seen mid-run is usually a run being superseded while its
@@ -554,9 +798,19 @@ def classify(runs: list[dict],
         ]
         return Verdict(4, lines, progress=progress)
 
-    lines = [f"all {len(pool)} required checks passed."]
+    uniq = list(dict.fromkeys(contexts))
+    accounted = [c for c in uniq if c in newest]
+    if len(accounted) != len(uniq):
+        # Unreachable: `missing` is empty by here. Kept as a hard invariant --
+        # a green that cannot account for every ruleset context BY NAME is not a
+        # green. Both #3002 false greens named ONE check where every real green
+        # that night named nine or ten, and that asymmetry is the only reason a
+        # human caught them.
+        return Verdict(None, progress=progress)
+    lines = [f"all {len(pool)} required checks passed "
+             f"({len(accounted)}/{len(uniq)} ruleset context(s) accounted for)."]
     lines.append("Ruleset contexts confirmed present and passing on this commit: "
-                 + ", ".join(contexts) + ".")
+                 + ", ".join(uniq) + ".")
     if cosmetic:
         lines.append("")
         lines.append("Cosmetic: these NON-required contexts are 'cancelled' on this "
@@ -587,22 +841,16 @@ def main() -> int:
           f"(up to {args.timeout}s, polling internally)")
 
     # Ask the ruleset what it requires RIGHT NOW rather than trusting a tuple
-    # frozen into this file (#2785). A context added to the ruleset since this
-    # was written must be waited for, not silently ignored.
-    live = live_ruleset_contexts()
-    if live is None:
-        contexts = RULESET_CONTEXTS
-        print("note: could not read the live branch ruleset for 'main'; falling back "
-              f"to the built-in list {list(RULESET_CONTEXTS)}. If a required context "
-              "has been added since, it is NOT being waited for.")
-    else:
-        contexts = live
-        if set(live) != set(RULESET_CONTEXTS):
-            print(f"note: the live ruleset requires {sorted(live)}, which differs from "
-                  f"this script's built-in list {sorted(RULESET_CONTEXTS)}. Using the "
-                  "LIVE set. Update RULESET_CONTEXTS in tools/ci-wait.py and "
-                  "DEFAULT_REQUIRED_CONTEXTS in "
-                  ".github/scripts/check_required_contexts.py (#2785).")
+    # frozen into this file (#2785) -- but never accept an answer NARROWER than
+    # the built-in floor, because judging on a reduced required set is what
+    # makes "every required check passed" vacuously true (#3002).
+    contexts, ctx_status, ctx_notes = resolve_required_contexts()
+    for note in ctx_notes:
+        print(note)
+    if ctx_status == "degraded":
+        print("\ncould not establish the required-context set for 'main' -- refusing "
+              "to judge this PR on a narrower one. This is NOT a verdict.")
+        return 3
 
     deadline = time.time() + args.timeout
     last = ""
@@ -661,6 +909,12 @@ def main() -> int:
             print("\nNEVER `gh run rerun` -- it overwrites this log permanently. "
                   "Push a new commit for a fresh run.")
             return 1
+
+        if v.code == 3:
+            print(f"\nUNDETERMINED on {sha[:8]} -- " + v.lines[0])
+            for line in v.lines[1:]:
+                print(line)
+            return 3
 
         if v.code == 4:
             print(f"\nBLOCKED on {sha[:8]} -- " + v.lines[0].split(" -- ", 1)[1])

--- a/tools/test_ci_wait.py
+++ b/tools/test_ci_wait.py
@@ -616,6 +616,226 @@ check("...and is BLOCKED once no newer run of that workflow is coming",
       v.code == 4, f"(code={v.code}) {v.lines}")
 
 
+
+# ===========================================================================
+# #3002 -- three false verdicts in one night, one shape: a verdict resolved
+#          from evidence that is not the current head's LIVE run
+# ===========================================================================
+# Every payload below is RECORDED, not hand-built: fetched back out of the
+# GitHub API for the exact head SHAs that produced the wrong answers, so the
+# cases cannot drift into a reconstruction that agrees with the code.
+#
+#   PR #2842  head e0841eed  GREEN, "all 1 required checks passed"  (matrix job
+#                            had not been created)
+#   PR #2971  head 47f30db4  GREEN, "all 1 required checks passed"  (8 legs
+#                            still pending)
+#   PR #3010  head 95c16b20  FAILURE, read off a superseded CANCELLED run while
+#                            the live run was green
+
+# ---------------------------------------------------------------------------
+# #3010, the RED direction. Recorded from
+#   GET /commits/95c16b20a500f638fbbe7eeb14f78545c22f92ee/check-runs
+#   GET /actions/runs?head_sha=95c16b20a500f638fbbe7eeb14f78545c22f92ee
+#
+# Test Matrix run 34002828792 has RUN-LEVEL conclusion `cancelled`, and its
+# aggregate job "All BC versions passed" concluded `failure` -- the aggregate
+# runs `if: always()` over `needs` that were killed, so a cancelled run reports
+# a FAILING required context. Seven of its eight legs are `cancelled`; leg 27.3
+# had already finished `success`.
+#
+# Test Matrix run 34004261321 replaced it and was green throughout, but its
+# aggregate job starts LAST, so for several minutes the newest check run named
+# "All BC versions passed" on this commit was the failure from the run that had
+# been abandoned. classify() put it in `bad` and returned exit 1 -- and `bad`
+# short-circuits BEFORE the in-flight guard, which is why the guard that exists
+# for exactly this shape never got consulted.
+PR3010_TM_CANCELLED = 34002828792   # run-level conclusion: cancelled
+PR3010_TM_LIVE = 34004261321        # the superseding run, green
+PR3010_RT = 34002828699             # Require Tests -> "Tests updated"
+
+PR3010_LEGS = ["bc-tests / BC 27.0.38460.53934 (required)",
+               "bc-tests / BC 27.5.46862.53931 (required)",
+               "bc-tests / BC 28.4.53241.54318 (required)"]
+
+
+def pr3010_rollup(with_live_legs: bool = False):
+    """The rollup while the live Test Matrix run's aggregate job had not started."""
+    runs = [cr("All BC versions passed", "failure", PR3010_TM_CANCELLED, 101405801410)]
+    for i, n in enumerate(PR3010_LEGS):
+        runs.append(cr(n, "cancelled", PR3010_TM_CANCELLED, 101404706127 + i))
+    runs.append(cr("bc-tests / BC 27.3.44313.53909 (required)", "success",
+                   PR3010_TM_CANCELLED, 101404706089))
+    runs.append(cr("Tests updated", "success", PR3010_RT, 101404642460))
+    if with_live_legs:
+        for i, n in enumerate(PR3010_LEGS):
+            runs.append(cr(n, "success", PR3010_TM_LIVE, 101408579871 + i))
+    return runs
+
+
+PR3010_WF_LIVE_IN_FLIGHT = [
+    {"id": PR3010_RT, "name": "Require Tests", "status": "completed",
+     "conclusion": "success"},
+    {"id": PR3010_TM_CANCELLED, "name": "Test Matrix", "status": "completed",
+     "conclusion": "cancelled"},
+    {"id": PR3010_TM_LIVE, "name": "Test Matrix", "status": "in_progress",
+     "conclusion": None},
+]
+
+v = cw.classify(pr3010_rollup(), workflow_runs=PR3010_WF_LIVE_IN_FLIGHT)
+check("#3010: a `failure` inherited from a CANCELLED workflow run is not a FAILED "
+      "verdict while a newer run of the same workflow is in flight",
+      v.code is None, f"(code={v.code}) {v.lines}")
+check("...and no killed job is offered up for a log fetch",
+      v.log_target is None, str(v.log_target))
+
+v = cw.classify(pr3010_rollup(with_live_legs=True),
+                workflow_runs=PR3010_WF_LIVE_IN_FLIGHT)
+check("...still not FAILED once the live run's LEGS have reported green but its "
+      "aggregate job has not",
+      v.code is None, f"(code={v.code}) {v.lines}")
+
+# Same commit, one instant earlier: the replacement run has not registered yet.
+# The answer is still not "FAILED" -- the job did not fail on its merits, the run
+# was killed -- but it is not "wait" either once nothing further is coming. That
+# is exactly the #2726 shape, and exit 4 already says it.
+PR3010_WF_NO_REPLACEMENT = [
+    {"id": PR3010_RT, "name": "Require Tests", "status": "completed",
+     "conclusion": "success"},
+    {"id": PR3010_TM_CANCELLED, "name": "Test Matrix", "status": "completed",
+     "conclusion": "cancelled"},
+]
+v = cw.classify(pr3010_rollup(), workflow_runs=PR3010_WF_NO_REPLACEMENT)
+check("#3010: a cancelled Test Matrix run with no replacement is BLOCKED, not FAILED",
+      v.code == 4, f"(code={v.code}) {v.lines}")
+check("...and names the required context it is blocked on",
+      any("All BC versions passed" in l for l in v.lines), v.lines)
+check("...and never tells the caller something failed",
+      not any("failed" in l.lower() for l in v.lines), v.lines)
+
+# The guard must not swallow a REAL failure. Same rollup, but the Test Matrix run
+# that produced the failing aggregate ran to completion on its own merits.
+PR3010_WF_GENUINE = [
+    {"id": PR3010_RT, "name": "Require Tests", "status": "completed",
+     "conclusion": "success"},
+    {"id": PR3010_TM_CANCELLED, "name": "Test Matrix", "status": "completed",
+     "conclusion": "failure"},
+]
+v = cw.classify(pr3010_rollup(), workflow_runs=PR3010_WF_GENUINE)
+check("a failing required context from a run that was NOT cancelled is still FAILED",
+      v.code == 1, f"(code={v.code}) {v.lines}")
+check("...and still offers the failing job for the log fetch",
+      (v.log_target or {}).get("name") == "All BC versions passed", str(v.log_target))
+
+# ---------------------------------------------------------------------------
+# #2971 / #2842, the GREEN direction. Recorded from
+#   GET /commits/47f30db4d37415378f227b62e9f6d38433166f17/check-runs
+#   GET /actions/runs?head_sha=47f30db4d37415378f227b62e9f6d38433166f17
+#
+# All three workflow runs were created within one second of the push
+# (00:09:25-26Z), so "All BC versions passed" was always COMING. Exhaustively:
+# with the real two-context ruleset this rollup cannot produce a 1-count green
+# under post-#2882 code -- either the context is in the rollup (pool >= 2) or it
+# is `missing` and the Test Matrix run is in flight, so `final is not True` and
+# the verdict is withheld. The only reachable route to the printed line is a
+# `contexts` of length ONE: a required-context set that got NARROWED.
+PR2971_RT, PR2971_PRC, PR2971_TM = 34000544365, 34000544377, 34000544502
+
+PR2971_JUST_PUSHED = [
+    cr("Tests updated", "success", PR2971_RT, 101398501503),
+    cr("ci-wait.py unit tests", "success", PR2971_PRC, 101398501751),
+    cr("scripts/ unit tests", "success", PR2971_PRC, 101398501706),
+]
+PR2971_WF = [
+    {"id": PR2971_RT, "name": "Require Tests", "status": "completed",
+     "conclusion": "success"},
+    {"id": PR2971_PRC, "name": "PR Check", "status": "completed",
+     "conclusion": "success"},
+    {"id": PR2971_TM, "name": "Test Matrix", "status": "in_progress",
+     "conclusion": None},
+]
+
+# The control: with the real ruleset this is already withheld (#2882 did that).
+v = cw.classify(PR2971_JUST_PUSHED, workflow_runs=PR2971_WF)
+check("#2971 control: the recorded rollup is withheld under the real two-context "
+      "ruleset", v.code is None, f"(code={v.code}) {v.lines}")
+
+# The defect: hand a NARROWED context set to the same rollup. Nothing else about
+# the commit changed, and the verdict flips to a green naming ONE check.
+v = cw.classify(PR2971_JUST_PUSHED, contexts=("Tests updated",),
+                workflow_runs=PR2971_WF)
+check("#3002: a NARROWED required-context set is refused, not answered",
+      v.code != 0, f"(code={v.code}) {v.lines}")
+check("...and it is undetermined (3), not a failure and not a block",
+      v.code == 3, f"(code={v.code}) {v.lines}")
+check("...and says which required context went missing from the set",
+      any("All BC versions passed" in l for l in v.lines), v.lines)
+check("...and never prints the false-green line",
+      not any("all 1 required checks passed" in l for l in v.lines), v.lines)
+
+v = cw.classify(PR2971_JUST_PUSHED, contexts=(), workflow_runs=PR2971_WF)
+check("an EMPTY required-context set is refused too", v.code == 3,
+      f"(code={v.code}) {v.lines}")
+
+# A green must be able to account for every ruleset context BY NAME, and say so.
+# Every real green that night named 9 or 10 checks; both false greens named 1.
+v = cw.classify(green_set())
+check("a green names how many ruleset contexts it accounted for",
+      any("2/2 ruleset context(s)" in l for l in v.lines), v.lines)
+check("...and names them",
+      all(any(c in l for l in v.lines) for c in cw.RULESET_CONTEXTS), v.lines)
+
+# ---------------------------------------------------------------------------
+# Where a narrowed set comes from: the ruleset read itself. The test INJECTS the
+# recorded API response rather than hand-building a tuple, because a hand-built
+# tuple cannot reproduce a degraded read -- the defect is in what the fetch
+# returns, not in what the caller passes.
+#
+# Recorded verbatim from GET /repos/.../rules/branches/main on 2026-09-06.
+RECORDED_BRANCH_RULES = [
+    {"type": "deletion", "ruleset_id": 15001420},
+    {"type": "non_fast_forward", "ruleset_id": 15001420},
+    {"type": "pull_request", "ruleset_id": 15001420},
+    {"type": "required_status_checks", "ruleset_id": 15001420, "parameters": {
+        "strict_required_status_checks_policy": False,
+        "do_not_enforce_on_create": False,
+        "required_status_checks": [{"context": "All BC versions passed"},
+                                   {"context": "Tests updated"}]}},
+]
+DEGRADED_BRANCH_RULES = [
+    r for r in RECORDED_BRANCH_RULES if r["type"] != "required_status_checks"
+] + [{"type": "required_status_checks", "ruleset_id": 15001420, "parameters": {
+        "strict_required_status_checks_policy": False,
+        "do_not_enforce_on_create": False,
+        "required_status_checks": [{"context": "Tests updated"}]}}]
+
+ctx, status, notes = cw.resolve_required_contexts(fetch=lambda b: RECORDED_BRANCH_RULES)
+check("the recorded live ruleset resolves to both required contexts",
+      sorted(ctx) == sorted(cw.RULESET_CONTEXTS) and status == "live",
+      f"{ctx} {status}")
+
+ctx, status, notes = cw.resolve_required_contexts(fetch=lambda b: DEGRADED_BRANCH_RULES)
+check("a ruleset read that drops a known required context is DEGRADED",
+      status == "degraded", f"{ctx} {status}")
+check("...and the degraded set is never handed on as the required set",
+      sorted(ctx) == sorted(cw.RULESET_CONTEXTS), f"{ctx}")
+check("...and the note names the context that went missing",
+      any("All BC versions passed" in n for n in notes), notes)
+
+ctx, status, notes = cw.resolve_required_contexts(fetch=lambda b: None)
+check("an UNREADABLE ruleset falls back to the full built-in set, never a subset",
+      sorted(ctx) == sorted(cw.RULESET_CONTEXTS) and status == "fallback",
+      f"{ctx} {status}")
+
+EXTRA = RECORDED_BRANCH_RULES[:3] + [
+    {"type": "required_status_checks", "ruleset_id": 15001420, "parameters": {
+        "required_status_checks": [{"context": "All BC versions passed"},
+                                   {"context": "Tests updated"},
+                                   {"context": "Some new gate"}]}}]
+ctx, status, notes = cw.resolve_required_contexts(fetch=lambda b: EXTRA)
+check("a context ADDED in the UI is picked up and waited for",
+      sorted(ctx) == ["All BC versions passed", "Some new gate", "Tests updated"]
+      and status == "live", f"{ctx} {status}")
+
 print()
 if FAILURES:
     print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")


### PR DESCRIPTION
Closes #3002

`tools/ci-wait.py` answered wrongly three times in one night, in both directions. The
unattended merge bar rests on this tool, so this fixes the shape rather than the three
symptoms.

## What actually caused it

Every one of the three resolved a verdict from a run that was **not the current head's live
run** — absent in two cases, cancelled-and-superseded in the third.

| PR | head | reported | what the recorded payload shows |
|---|---|---|---|
| #2842 | `e0841eed` | GREEN, "all **1** required checks passed" | matrix job not yet created |
| #2971 | `47f30db4` | GREEN, "all **1** required checks passed" | 8 legs still pending |
| #3010 | `95c16b20` | **FAILURE** | read off a cancelled, superseded run |

### The red direction (#3010) — proven from the recorded payload

`GET /actions/runs?head_sha=95c16b20…` and `GET /commits/95c16b20…/check-runs`, both still
retrievable:

- `Test Matrix` run **34002828792** has **run-level `conclusion: cancelled`** — and its
  aggregate job **`All BC versions passed` concluded `failure`**, not `cancelled`, because the
  aggregate runs `if: always()` over `needs` that were killed. Seven of its eight legs are
  `cancelled`; leg 27.3 had already finished `success`.
- `Test Matrix` run **34004261321** replaced it and was green throughout — but its aggregate
  job starts **last**, so for several minutes the newest check run named `All BC versions
  passed` on that commit was the failure from the run that had been abandoned.

`classify()` put it in `bad` and returned exit 1. The in-flight guard that exists for exactly
this shape never got consulted, because `bad` short-circuits ahead of it — the residual the
code itself notes as #2922.

### The green direction — the hypothesis held, with one correction

The brief's hypothesis was the degraded ruleset, and the arithmetic confirms it is the only
route **through the post-#2882 code**. Exhaustively, over the recorded `47f30db4` payload
(all three workflow runs were created within one second of the push, so the matrix was always
*coming*): with the real two-context ruleset, either the context is in the rollup and
`len(pool) >= 2`, or it is `missing` while the matrix run is in flight so `final is not True`
and the verdict is withheld. A green naming **one** check is unreachable unless `contexts`
itself had length one.

The correction is what the reconstruction/field contradiction was really about. Replaying the
recorded `47f30db4` rollup against `2f84c4de~1` — the code **immediately before** the #2882
fix — prints, verbatim:

```
pre-fix verdict code: 0
pre-fix lines: ['all 1 required checks passed.']
```

and that version's `classify()` takes only `runs`, with no ruleset awareness at all. So the
observed text is exactly what the *pre-fix* tool prints, and the reviewer who replayed it
against `main` and got the correct `code=None` was also right — they were running different
code. **I could not determine which copy actually ran**, and I am not claiming it: an agent
runs whatever `tools/ci-wait.py` its cwd resolves to, and that copy can lag (measured: the
top-level checkout is at `9368b0d3` while `origin/main` is `723a1832` right now). I found no
recorded evidence of a degraded ruleset read, and I say so rather than assert one.

That ambiguity is the argument for fixing it structurally: the tool must refuse a verdict it
cannot fully account for, whichever route produced the narrow set.

## What changed (all in `tools/ci-wait.py`)

1. **`resolve_required_contexts()` never hands on a set narrower than the built-in floor.**
   Unreadable ruleset → fall back to the full built-in list, loudly (unchanged, and safe: the
   built-in list is the full set, and `check_required_contexts.py` fails CI on drift). Ruleset
   answers *missing* a known context → **exit 3**, because a partial read and a deliberate
   removal are indistinguishable from here. A context *added* in the UI is still picked up.
   `classify()` re-checks the floor itself, so a direct caller cannot get a vacuous green either.
2. **`supersession()`** marks names whose newest check run belongs to a run being replaced by a
   newer run of the same workflow **still in flight** — no verdict in *either* direction, and
   checked **ahead of** the `bad` short-circuit. A newer run that already completed without
   producing that check run supersedes nothing (the older entry is then the latest word, and a
   ruleset reads it) — that distinction is load-bearing and is covered by a pre-existing test.
3. **A conclusion from a cancelled run is reclassified as a cancellation**, so it can block
   (exit 4) but can never be reported as a failure or counted toward a green. Deliberate
   trade-off, documented in the code: a job that genuinely failed inside a run somebody then
   cancelled is reported as blocked rather than failed. That errs toward "not a verdict", never
   toward green, and a cancelled run's required aggregate will not report anyway.
4. **A green names what it accounted for**: `all 10 required checks passed (2/2 ruleset
   context(s) accounted for)`. Verified end-to-end against PR #3010's merged head.

## RED → GREEN, from recorded payloads

Tests replay payloads fetched back out of the API for the exact heads, not hand-built ones —
the green-direction defect is in what the *fetch* returns, so a test constructing its own tuple
cannot reproduce it; the degraded case injects a recorded `rules/branches/main` response with a
context removed.

Against the old code all three fail, reproducing the field observations verbatim:

```
FAIL #3010: a `failure` inherited from a CANCELLED workflow run is not a FAILED verdict …
     (code=1) ['1 of 6 required checks failed:',
               '  All BC versions passed: failure   (workflow run 34002828792)']
FAIL #3002: a NARROWED required-context set is refused, not answered
     (code=0) ['all 1 required checks passed.', …]
AttributeError: module 'ci_wait' has no attribute 'resolve_required_contexts'
```

After: `python3 tools/test_ci_wait.py` → **all checks passed**, including every pre-existing
one. `python3 .github/scripts/test_check_required_contexts.py` → all checks passed (it loads
`RULESET_CONTEXTS` and `contexts_from_branch_rules` out of this module; both kept).

Negative coverage is explicit: a failing required context from a run that was **not** cancelled
is still exit 1 and still offers its log; a failing leg with a superseding run of a *different*
workflow queued is still exit 1; a cancelled required context with no replacement is still
exit 4.

## Fixing the shape, not the reported line

- **Same wrong pattern at another call site?** Yes — `superseding_runs()` only considered the
  two ruleset contexts, so the eight matrix legs were exempt from the supersession rule that
  protected the aggregate. `supersession()` covers every name in the rollup. On `95c16b20`
  seven legs carried `cancelled` from the killed run, which `bad` already skipped by luck; a
  leg carrying `failure` from a killed run would have misreported the same way.
- **Sibling function with the same assumption?** The `bad` short-circuit versus the in-flight
  guard was the asymmetry itself — one path had the guard, the other returned before reaching
  it. Both now consult supersession.
- **Anything else in the repo reading check-run conclusions?** Searched: no. `ci-wait.py` is the
  only consumer.
- **Deliberately left out:** the mirror residual noted as #2922 in the *unbounded* form ("any
  stale FAILED where a newer run is queued") is narrowed here to the cases that actually
  misreport — superseded and cancelled-run conclusions — rather than delaying every failure.
  A failure from a live run is still a verdict, reported immediately.

## `ci-verdicts.md`

Adds the sibling trap, in the form I could measure rather than the form it was reported in:
**`gh pr checks` collapses to one row per context name and drops superseded entries entirely.**
On PR #3016's head `d56466a7` the API reports **8 `cancelled` check runs** and `gh pr checks`
prints **25 rows, every one `pass`** — not one cancellation appears. So it cannot corroborate a
supersession question in either direction, which matters because the corroboration step #3002
currently recommends inherits exactly that blind spot. The reliable check is
`gh run view <id> --json headSha,conclusion`. Also records that `head_sha=` needs the **full**
40-character SHA — an abbreviated one returns `"workflow_runs": []`, which reads like "no runs"
and is a false negative (hit while gathering this evidence).

## Corpus

Nothing is owed upstream. This is CI plumbing; no AL surface observes it, and there is no
claim about Business Central behaviour anywhere in the change. Stating it rather than staying
silent, per the wider rule.

Scope kept to the three files named in the brief. `tests/expectations/count-baseline/` is
untouched (#3004 is writing it).

---
Opened by an automated agent (`agent: stma-auto-1`) acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE