### PR TITLE
fix(tests): guards that scan nothing now fail, and none of them exempts by bare file name

### DIFF
--- a/AlRunner.Tests/BaseAppFloorFixtureGuardTests.cs
+++ b/AlRunner.Tests/BaseAppFloorFixtureGuardTests.cs
@@ -62,9 +62,37 @@ public sealed class BaseAppFloorFixtureGuardTests
     /// walked <c>Fixtures/</c> recursively — so a .cs file below the top level was invisible
     /// to one half of a guard whose whole value is that it fails automatically.
     /// </summary>
-    private static IEnumerable<string> TestSourcePaths() =>
-        Directory.EnumerateFiles(TestsDir, "*.cs", SearchOption.AllDirectories)
-            .Where(p => !Rel(p).Split('/').Any(seg => seg is "bin" or "obj"));
+    private static IReadOnlyList<string> TestSourcePaths()
+    {
+        var paths = Directory.EnumerateFiles(TestsDir, "*.cs", SearchOption.AllDirectories)
+            .Where(p => !Rel(p).Split('/').Any(seg => seg is "bin" or "obj"))
+            .ToList();
+
+        // #3021 — non-vacuity. Nothing else in this class notices an empty scan: the
+        // stale-entry fact below probes File.Exists on the allowlist keys directly, so it stays
+        // green while both scanning facts pass having read no file at all.
+        Assert.True(paths.Count > 0,
+            $"expected .cs sources under {TestsDir}, found none — the guard is not looking at "
+            + "anything, so a manifest written with the Base Application floor would pass unseen.");
+
+        return paths;
+    }
+
+    /// <summary>
+    /// Every checked-in fixture manifest, at any depth under <c>Fixtures/</c>. Same non-vacuity
+    /// obligation as <see cref="TestSourcePaths"/>, and for the same reason (#3021).
+    /// </summary>
+    private static IReadOnlyList<string> FixtureManifestPaths()
+    {
+        var fixtures = Path.Combine(TestsDir, "Fixtures");
+        var paths = Directory.EnumerateFiles(fixtures, "app.json", SearchOption.AllDirectories).ToList();
+
+        Assert.True(paths.Count > 0,
+            $"expected app.json fixtures under {fixtures}, found none — "
+            + "the guard is not looking at anything.");
+
+        return paths;
+    }
 
     // A JSON "application" property, in a .json file or embedded in a C# string —
     // including the escaped \"application\" form used in concatenated manifests.
@@ -116,11 +144,10 @@ public sealed class BaseAppFloorFixtureGuardTests
     public void NoFixtureManifest_DeclaresTheBaseApplicationFloor_ExceptTheAllowlistedFour()
     {
         var offenders = new List<string>();
-        foreach (var path in Directory.EnumerateFiles(
-                     Path.Combine(TestsDir, "Fixtures"), "app.json", SearchOption.AllDirectories))
+        foreach (var path in FixtureManifestPaths())
         {
             if (!ApplicationProperty.IsMatch(File.ReadAllText(path))) continue;
-            var rel = Path.GetRelativePath(TestsDir, path).Replace(Path.DirectorySeparatorChar, '/');
+            var rel = Rel(path);
             if (!AllowedFixtures.ContainsKey(rel)) offenders.Add(rel);
         }
 

--- a/AlRunner.Tests/CliDocumentationTests.cs
+++ b/AlRunner.Tests/CliDocumentationTests.cs
@@ -416,8 +416,15 @@ public sealed class CliDocumentationTests
     public void NoRemediationText_NamesTheCheckoutOnlyDownloadArtifactsInvocation()
     {
         var root = Path.Combine(RepoRoot, "AlRunner");
+        var sources = Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories).ToList();
         var offenders = new List<string>();
-        foreach (var file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+
+        // #3021 — non-vacuity: a scan that finds nothing must fail, not report a clean tree.
+        Assert.True(sources.Count > 0,
+            $"expected the runner's C# sources under {root}, found none — the guard is not "
+            + "looking at anything.");
+
+        foreach (var file in sources)
         {
             var lines = File.ReadAllLines(file);
             for (int i = 0; i < lines.Length; i++)

--- a/AlRunner.Tests/DocumentServiceProviderScopeGuardTests.cs
+++ b/AlRunner.Tests/DocumentServiceProviderScopeGuardTests.cs
@@ -42,7 +42,11 @@ public sealed class DocumentServiceProviderScopeGuardTests
     private static readonly string RepoRoot = Path.GetFullPath(
         Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
 
-    private const string SelfFileName = "DocumentServiceProviderScopeGuardTests.cs";
+    /// <summary>
+    /// This file, keyed by its path relative to the repo root — not by its bare name, so a
+    /// same-named file in another directory cannot inherit the exemption (#3021).
+    /// </summary>
+    private const string SelfSourcePath = "AlRunner.Tests/DocumentServiceProviderScopeGuardTests.cs";
 
     /// <summary>MEF's discovery glob, as a regex over a bare file name.</summary>
     private static readonly Regex MefProviderFileName = new(
@@ -65,20 +69,33 @@ public sealed class DocumentServiceProviderScopeGuardTests
         @"DocumentServiceMock says",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-    private static IEnumerable<string> RunnerSourceFiles()
+    /// <summary>The reporting key: a path relative to the repo root, '/' separated.</summary>
+    private static string Rel(string path) =>
+        Path.GetRelativePath(RepoRoot, path).Replace(Path.DirectorySeparatorChar, '/');
+
+    private static IReadOnlyList<string> RunnerSourceFiles()
     {
+        var paths = new List<string>();
         foreach (var dir in Directory.EnumerateDirectories(RepoRoot, "AlRunner*"))
         {
             foreach (var path in Directory.EnumerateFiles(dir, "*.cs", SearchOption.AllDirectories))
             {
-                // Build intermediates are copies of the sources already scanned.
-                var rel = Path.GetRelativePath(RepoRoot, path)
-                    .Replace(Path.DirectorySeparatorChar, '/');
-                if (rel.Contains("/bin/") || rel.Contains("/obj/")) continue;
-                if (Path.GetFileName(path) == SelfFileName) continue;
-                yield return path;
+                // Build intermediates are copies of the sources already scanned. Segments, not a
+                // substring, so this means the same thing as the other three source guards (#3021).
+                if (Rel(path).Split('/').Any(seg => seg is "bin" or "obj")) continue;
+                if (Rel(path) == SelfSourcePath) continue;
+                paths.Add(path);
             }
         }
+
+        // #3021 — non-vacuity, here rather than only in the first fact below:
+        // NoRunnerSource_CopiesTheMockErrorLiterals reads the same enumeration and had no such
+        // check, so an empty scan left it green while proving nothing.
+        Assert.True(paths.Count > 0,
+            $"expected the runner's C# sources under {RepoRoot}, found none — " +
+            "the guard is not looking at anything.");
+
+        return paths;
     }
 
     [Fact]
@@ -91,8 +108,7 @@ public sealed class DocumentServiceProviderScopeGuardTests
         {
             scanned++;
             if (HandlerContract.IsMatch(File.ReadAllText(path)))
-                offenders.Add(Path.GetRelativePath(RepoRoot, path)
-                    .Replace(Path.DirectorySeparatorChar, '/'));
+                offenders.Add(Rel(path));
         }
 
         // Non-vacuity: a scan that found no files would pass while proving nothing.
@@ -117,8 +133,7 @@ public sealed class DocumentServiceProviderScopeGuardTests
         foreach (var path in RunnerSourceFiles())
         {
             if (CopiedMockLiteral.IsMatch(File.ReadAllText(path)))
-                offenders.Add(Path.GetRelativePath(RepoRoot, path)
-                    .Replace(Path.DirectorySeparatorChar, '/'));
+                offenders.Add(Rel(path));
         }
 
         Assert.True(offenders.Count == 0,

--- a/AlRunner.Tests/FlowFieldDiagnosticNoiseTests.cs
+++ b/AlRunner.Tests/FlowFieldDiagnosticNoiseTests.cs
@@ -163,9 +163,15 @@ public sealed class FlowFieldDiagnosticNoiseTests
     public void NoPatchWritesABareStackTraceAsItsOwnConsoleErrorCall()
     {
         var patchesDir = Path.Combine(RepoRoot, "AlRunner", "Patches");
+        var patchSources = Directory.EnumerateFiles(patchesDir, "*.cs", SearchOption.AllDirectories).ToList();
         var offenders = new List<string>();
 
-        foreach (var file in Directory.EnumerateFiles(patchesDir, "*.cs", SearchOption.AllDirectories))
+        // #3021 — non-vacuity: a scan that finds nothing must fail, not report a clean tree.
+        Assert.True(patchSources.Count > 0,
+            $"expected patch sources under {patchesDir}, found none — the guard is not looking "
+            + "at anything.");
+
+        foreach (var file in patchSources)
         {
             var lines = File.ReadAllLines(file);
             for (int i = 0; i < lines.Length; i++)

--- a/AlRunner.Tests/ScratchDirOwnershipGuardTests.cs
+++ b/AlRunner.Tests/ScratchDirOwnershipGuardTests.cs
@@ -115,9 +115,23 @@ public sealed class ScratchDirOwnershipGuardTests
     /// (<c>*.AssemblyInfo.cs</c>, <c>*.GlobalUsings.g.cs</c>); they are not test code, and
     /// whether they exist depends on whether the project has been built.
     /// </summary>
-    private static IEnumerable<string> TestSources() =>
-        Directory.EnumerateFiles(TestsDir, "*.cs", SearchOption.AllDirectories)
-            .Where(p => !Key(p).Split('/').Any(seg => seg is "bin" or "obj"));
+    private static IReadOnlyList<string> TestSources()
+    {
+        var paths = Directory.EnumerateFiles(TestsDir, "*.cs", SearchOption.AllDirectories)
+            .Where(p => !Key(p).Split('/').Any(seg => seg is "bin" or "obj"))
+            .ToList();
+
+        // #3021 — non-vacuity. An enumeration that finds nothing makes
+        // NoTestSource_BuildsAnUnownedTempPath pass having read no source at all. That fact was
+        // protected only by ACCIDENT: EveryAllowlistEntry_MatchesItsRecordedCount reads the same
+        // enumeration and fails when it is empty, so the class went red for a reason that names
+        // the allowlist rather than the scan. Assert the real cause here instead.
+        Assert.True(paths.Count > 0,
+            $"expected .cs sources under {TestsDir}, found none — the guard is not looking at "
+            + "anything, so an unowned scratch path anywhere in the project would pass unseen.");
+
+        return paths;
+    }
 
     /// <summary>Non-comment occurrences of the expression, per source path.</summary>
     private static Dictionary<string, int> Occurrences()

--- a/AlRunner.Tests/TestArtifactsGateTests.cs
+++ b/AlRunner.Tests/TestArtifactsGateTests.cs
@@ -217,19 +217,47 @@ public class TestArtifactsGateTests
     // ---- 3. drift guards over the suite's own source ----------------------------
 
     /// <summary>
+    /// The key every drift guard below exempts and reports by: the source path relative to
+    /// <see cref="TestsSourceDir"/>, with <c>/</c> separators on every platform. For a
+    /// top-level file that is exactly the file name, which is why the exemptions read
+    /// unchanged — but a file in a subdirectory can no longer alias a same-named top-level
+    /// exemption and disappear from the guard. #3021: the exemptions matched on
+    /// <c>Path.GetFileName</c>, so <c>AliasProbe/TestArtifacts.cs</c> was exempt everywhere
+    /// the real <c>TestArtifacts.cs</c> is, and a violation in it passed silently.
+    /// </summary>
+    private static string Rel(string path) =>
+        Path.GetRelativePath(TestsSourceDir, path).Replace(Path.DirectorySeparatorChar, '/');
+
+    /// <summary>
     /// Every <c>.cs</c> source in the suite, at ANY depth, minus build output. One place, so
-    /// the two facts below cannot disagree about what "the suite's own source" means — #3000:
+    /// the four facts below cannot disagree about what "the suite's own source" means — #3000:
     /// <see cref="EveryTestThatCanSkipIsDeclaredSkippable"/> enumerated
     /// <c>SearchOption.TopDirectoryOnly</c> of its own while this helper already walked the
     /// whole tree, so the same file was in scope for one drift guard and invisible to the other.
+    ///
+    /// <para>#3021: the build-output filter tested the ABSOLUTE path for a <c>/bin/</c> or
+    /// <c>/obj/</c> substring, so a checkout under such a path — <c>~/obj/al-runner</c>, a CI
+    /// workspace named <c>bin</c> — excluded every file in the project and every guard below
+    /// passed having read nothing. It now splits the RELATIVE path into segments, the same way
+    /// <c>ScratchDirOwnershipGuardTests</c> and <c>BaseAppFloorFixtureGuardTests</c> do, so
+    /// "minus build output" has one meaning across all three. The non-vacuity assertion is the
+    /// backstop: an enumeration that finds nothing is a broken guard, not a clean suite.</para>
     /// </summary>
-    private static IEnumerable<string> TestSourcePaths() =>
-        Directory.EnumerateFiles(TestsSourceDir, "*.cs", SearchOption.AllDirectories)
-            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
-                     && !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal));
+    private static IReadOnlyList<string> TestSourcePaths()
+    {
+        var paths = Directory.EnumerateFiles(TestsSourceDir, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !Rel(f).Split('/').Any(seg => seg is "bin" or "obj"))
+            .ToList();
 
-    private static IEnumerable<(string File, string Text)> TestSources() =>
-        TestSourcePaths().Select(f => (Path.GetFileName(f), File.ReadAllText(f)));
+        Assert.True(paths.Count > 0,
+            $"expected .cs sources under {TestsSourceDir}, found none — the guard is not "
+            + "looking at anything, so every drift guard in this class would pass vacuously.");
+
+        return paths;
+    }
+
+    private static IEnumerable<(string Rel, string Text)> TestSources() =>
+        TestSourcePaths().Select(f => (Rel(f), File.ReadAllText(f)));
 
     /// <summary>
     /// One gate, one place. Twenty-three classes each declared their own
@@ -241,7 +269,7 @@ public class TestArtifactsGateTests
     {
         var offenders = TestSources()
             .Where(s => Regex.IsMatch(s.Text, @"bool\s+ArtifactsPresent\s*\("))
-            .Select(s => s.File)
+            .Select(s => s.Rel)
             .OrderBy(f => f, StringComparer.Ordinal)
             .ToList();
 
@@ -261,16 +289,16 @@ public class TestArtifactsGateTests
     public void OnlyTheSharedHelperNamesTheArtifactCachePathsInCode()
     {
         var offenders = new List<string>();
-        foreach (var (file, text) in TestSources())
+        foreach (var (rel, text) in TestSources())
         {
-            if (file is "TestArtifacts.cs" or "TestArtifactsGateTests.cs") continue;
+            if (rel is "TestArtifacts.cs" or "TestArtifactsGateTests.cs") continue;
             foreach (var line in text.Split('\n'))
             {
                 var trimmed = line.TrimStart();
                 if (trimmed.StartsWith("//", StringComparison.Ordinal)) continue;
                 if (trimmed.Contains(".bcartifacts.cache", StringComparison.Ordinal)
                     || trimmed.Contains("\"al-runner\", \"artifacts\"", StringComparison.Ordinal))
-                    offenders.Add($"{file}: {trimmed.Trim()}");
+                    offenders.Add($"{rel}: {trimmed.Trim()}");
             }
         }
 
@@ -327,13 +355,13 @@ public class TestArtifactsGateTests
     public void NoTestSilentlyReturnsWhenItsEnvironmentIsUnavailable()
     {
         var offenders = new List<string>();
-        foreach (var (file, text) in TestSources())
+        foreach (var (rel, text) in TestSources())
         {
             // The regexes above, and the synthetic offenders SilentSkipDetectorTests feeds them,
             // are literals in these two files.
-            if (file is "TestArtifactsGateTests.cs" or "SilentSkipDetectorTests.cs") continue;
+            if (rel is "TestArtifactsGateTests.cs" or "SilentSkipDetectorTests.cs") continue;
             foreach (var hit in FindSilentSkipReturns(text))
-                offenders.Add($"{file}: {hit}");
+                offenders.Add($"{rel}: {hit}");
         }
 
         Assert.True(offenders.Count == 0,
@@ -357,7 +385,8 @@ public class TestArtifactsGateTests
         var offenders = new List<string>();
         foreach (var file in TestSourcePaths())
         {
-            if (Path.GetFileName(file) is "TestArtifacts.cs" or "TestArtifactsGateTests.cs") continue;
+            var rel = Rel(file);
+            if (rel is "TestArtifacts.cs" or "TestArtifactsGateTests.cs") continue;
             string? attr = null, method = null;
             foreach (var line in File.ReadAllLines(file))
             {
@@ -370,7 +399,7 @@ public class TestArtifactsGateTests
                 }
                 if (attr is "Fact" or "Theory" && method != null && skipCall.IsMatch(line))
                 {
-                    offenders.Add($"{Path.GetFileName(file)}.{method} is [{attr}] but can skip");
+                    offenders.Add($"{rel}.{method} is [{attr}] but can skip");
                     attr = null;
                 }
             }


### PR DESCRIPTION
Closes #3021

Both residuals from the review of PR #3017, plus the same shape wherever else it appears in `AlRunner.Tests`. No allowlist and no exact-count assertion was touched.

## What the two constructed REDs proved

Nothing violates these guards today, so both REDs were planted, the way #3017's were. Full pre-fix sources, measured — not read.

**RED 1 — the aliasing hole.** Planted `AlRunner.Tests/AliasProbe/TestArtifacts.cs` (a plain `[Fact]` calling `TestArtifacts.SkipIfMissing()`, plus a hand-spelled `.bcartifacts.cache` path) and `AlRunner.Tests/AliasProbe/SilentSkipDetectorTests.cs` (a `[skip]`-then-`return` silent skip). Bare names chosen to match existing exemptions exactly.

- Before: `Failed: 0, Passed: 33`. Three drift guards read those files and exempted them.
- After: three facts fail and name the offender by relative path —
  `AliasProbe/TestArtifacts.cs.ProbeFactThatCanSkip is [Fact] but can skip`,
  `AliasProbe/TestArtifacts.cs: private static readonly string Legacy = Path.Combine("home", ".bcartifacts.cache", "sandbox");`,
  `AliasProbe/SilentSkipDetectorTests.cs: [skip] artifacts not provisioned`.

**RED 2 — the vacuity.** Redirected each guard's enumeration at an empty directory (the condition `TestArtifactsGateTests`' absolute-path `/bin/` `/obj/` substring filter produces for real if the checkout sits under such a path) and left everything else alone.

Passed while reading no file at all:

- all four `TestArtifactsGateTests` drift guards;
- both `BaseAppFloorFixtureGuardTests` scanning facts — and its stale-entry fact stayed green too, since it probes `File.Exists` on the allowlist keys directly and cannot see an empty scan;
- `DocumentServiceProviderScopeGuardTests.NoRunnerSource_CopiesTheMockErrorLiterals`, the sibling of a fact that already had a non-vacuity assertion;
- `FlowFieldDiagnosticNoiseTests.NoPatchWritesABareStackTraceAsItsOwnConsoleErrorCall` and `CliDocumentationTests.NoRemediationText_NamesTheCheckoutOnlyDownloadArtifactsInvocation` (found by grepping the shape, not in the issue).

Failed, but only by accident and for the wrong reason: `ScratchDirOwnershipGuardTests.EveryAllowlistEntry_MatchesItsRecordedCount` (reads the same enumeration, so an empty scan reads as a stale allowlist) and `DocumentServiceProviderScopeGuardTests.NoRunnerSource_DeclaresADocumentServiceHandler` (its existing `scanned > 100`).

**So yes — a guard was actually scanning nothing and still passing**, in the constructed condition, in six facts across four classes, with two more failing only for a reason that misnames the cause.

After the fix all ten enumeration-backed facts fail with a message naming the real cause and the directory searched, e.g. `expected .cs sources under …/AlRunner.Tests, found none — the guard is not looking at anything, so every drift guard in this class would pass vacuously.`

## The fix

1. Every source enumeration materialises and asserts it found something, following the convention already in `DocumentServiceProviderScopeGuardTests` and `BracelessIfSecondStatementGuardTests`. The assertion sits in the shared helper, so every fact reading it inherits the check instead of each one needing its own.
2. `TestArtifactsGateTests` filters build output on **relative-path segments**, like `ScratchDirOwnershipGuardTests` and `BaseAppFloorFixtureGuardTests` — "minus build output" now has one meaning.
3. `TestArtifactsGateTests` exempts and reports through a `Rel()` key, so a subdirectory file can no longer inherit a top-level exemption. `DocumentServiceProviderScopeGuardTests`' self-exemption is keyed on its relative path for the same reason. `BaseAppFloorFixtureGuardTests`' fixture fact reuses the `Rel()` helper it already had instead of re-spelling it inline.

## Fixing the shape, not the reported line

- **Same wrong pattern at another call site?** Yes. `FlowFieldDiagnosticNoiseTests` and `CliDocumentationTests` each scan a source tree with no non-vacuity check; both demonstrated to pass on an empty scan and both fixed here. `BracelessIfSecondStatementGuardTests` (`files.Count > 50`) and `ParserStaticsIsolationGuardTests` (throws on `files.Length == 0`) already had one — that is where the convention comes from.
- **Sibling function with the same assumption?** Yes — `NoRunnerSource_CopiesTheMockErrorLiterals`, sitting beside a fact that already asserted `scanned > 100` and reading the identical enumeration.
- **Two paths writing the same state, one guard missing?** The build-output filter was the case: three spellings of "minus build output" (absolute substring, relative substring, relative segments) for one concept. All four scanning guards now use segments.

## Not weakened

The exact-count facts — `ScratchDirOwnershipGuardTests.EveryAllowlistEntry_MatchesItsRecordedCount` and `BaseAppFloorFixtureGuardTests.EveryAllowlistEntry_StillDeclaresTheFloor` — and every allowlist entry are unchanged. Adding an allowlist entry is still a deliberate act.

## Corpus

Nothing owed upstream. This is C# test infrastructure scanning the test project's own sources; there is no BC-behaviour claim here and no AL surface observes it, so there is nothing a service tier could adjudicate.

`tests/expectations/count-baseline/test-count-baseline.json` is untouched (#3004 is still open against it); no test methods were added or removed.

## Verification

`dotnet test AlRunner.Tests --filter` over the nine affected/adjacent guard classes (`TestArtifactsGateTests`, `ScratchDirOwnershipGuardTests`, `BaseAppFloorFixtureGuardTests`, `DocumentServiceProviderScopeGuardTests`, `SilentSkipDetectorTests`, `FlowFieldDiagnosticNoiseTests`, `CliDocumentationTests`, `BracelessIfSecondStatementGuardTests`, `ParserStaticsIsolationGuardTests`): **100 passed, 0 failed**. Every probe was removed before pushing and the branch diff confirms none remains.

---
Implemented by an automated agent (`agent: stma-auto-1`) acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE