### PR TITLE
fix(test-data): make TestDataProvisioner's --test-data tallies Interlocked

### DIFF
--- a/AlRunner.Tests/TestDataLazyHydrationTests.cs
+++ b/AlRunner.Tests/TestDataLazyHydrationTests.cs
@@ -371,6 +371,62 @@ public sealed class TestDataLazyLoadPolicyTests : IDisposable
         Assert.All(TableLoadReads(),
             l => Assert.Contains("|Untouched|", l, StringComparison.Ordinal));
     }
+
+    /// <summary>
+    /// #2997, the behavioural half. Drives the REAL write-off path — the notifier Arm() installs,
+    /// so the increment under test is production code and not a stand-in — from several threads
+    /// at once and asserts the exact total. Against the unfixed `_deferredLoadsWrittenOff++` the
+    /// read-modify-write drops counts and the total comes back short.
+    ///
+    /// WHAT THIS DOES NOT PROVE, stated plainly: this is a hammer, not a forced interleaving.
+    /// Nothing here makes two threads collide at the increment — it makes a collision very
+    /// likely by running a large number of them, so against unsynchronised code it fails
+    /// PROBABILISTICALLY, not by construction. Against the fixed code it is exact and
+    /// deterministic. The deterministic proof of the mechanism is
+    /// TestDataProvisionerTallyAtomicityTests.
+    ///
+    /// The per-table reason and the stderr line are written on every call as they are in a real
+    /// run; stderr is redirected because the point is the count, and 80,000 NOT LOADED lines in
+    /// a CI log is not information.
+    /// </summary>
+    [Fact]
+    public void TheWriteOffTally_IsExactUnderConcurrentWriteOffs()
+    {
+        TestDataProvisioner.Arm();
+        var noteWrittenOff = RecordPatches.TestDataDeferredLoadWriteOffNotifier;
+        Assert.NotNull(noteWrittenOff);
+        Assert.Equal(0, TestDataProvisioner.DeferredLoadsWrittenOff);
+
+        const int Threads = 8;
+        const int PerThread = 10_000;
+
+        var savedErr = Console.Error;
+        Console.SetError(TextWriter.Null);
+        try
+        {
+            var go = new ManualResetEventSlim(false);
+            var workers = Enumerable.Range(0, Threads).Select(_ => Task.Run(() =>
+            {
+                go.Wait(TimeSpan.FromSeconds(30));
+                for (var n = 0; n < PerThread; n++)
+                    noteWrittenOff!(TouchedTableId, "a concurrency probe (#2997)");
+            })).ToArray();
+            go.Set();
+            Assert.True(Task.WaitAll(workers, TimeSpan.FromSeconds(120)),
+                "a write-off worker never completed");
+        }
+        finally
+        {
+            Console.SetError(savedErr);
+        }
+
+        Assert.Equal(Threads * PerThread, TestDataProvisioner.DeferredLoadsWrittenOff);
+
+        // …and the count really is the count of write-offs, not of calls: a table the plan does
+        // not offer still returns before the tally, on every thread.
+        noteWrittenOff!(NotInTheBackupTableId, "not in the plan");
+        Assert.Equal(Threads * PerThread, TestDataProvisioner.DeferredLoadsWrittenOff);
+    }
 }
 
 /// <summary>

--- a/AlRunner.Tests/TestDataProvisionerTallyAtomicityTests.cs
+++ b/AlRunner.Tests/TestDataProvisionerTallyAtomicityTests.cs
@@ -1,0 +1,151 @@
+// TestDataProvisionerTallyAtomicityTests — the mechanism guard for issue #2997.
+//
+// WHAT IS UNDER TEST, AND WHAT THIS DELIBERATELY DOES NOT CLAIM
+//   TestDataProvisioner's --test-data tallies (_tablesDone, _rowsDone, _refused,
+//   _readerRefused, _droppedColumns, _columnsNotInThisBuild, _deferredLoadsWrittenOff) were
+//   plain `int++` / `+=` written from LoadOnDemand and NoteDeferredLoadWrittenOff, which two
+//   threads can be inside at once — TestExecutor.InvokeWithTimeout runs every [Test] on its own
+//   worker thread and does NOT kill it when the watchdog expires, so an abandoned thread keeps
+//   hydrating while the bundle loop carries on in the same process (the route #2914 established).
+//   A read-modify-write from two threads can drop a count.
+//
+//   These counters are DIAGNOSTICS. Nothing branches on them: they are the numbers the
+//   --test-data summary prints, plus DeferredLoadsWrittenOff, which one test asserts. A lost
+//   count misreports a run that had already gone abnormal (a test overran its watchdog and the
+//   suite was abandoned mid-bundle). It is not data corruption, and #2914 — merged — is what
+//   covers the structure that does matter.
+//
+//   An off-by-one under a genuine race is not deterministically reproducible, so this file does
+//   NOT try to reproduce one. It pins the MECHANISM over the compiled IL of the loaded
+//   al-runner.dll: every write to a tally goes through System.Threading.Interlocked, and the
+//   only plain store left in the type is ResetForTests's (which runs with no other thread in
+//   play). That is a deterministic RED → GREEN — it failed on the unfixed code and passes on the
+//   fixed code — and it is exactly as strong as its wording: it proves each increment is atomic,
+//   not that any particular interleaving was ever observed.
+//
+//   The behavioural half — eight threads through the real write-off path, asserting the exact
+//   total — is TestDataLazyLoadPolicyTests.TheWriteOffTally_IsExactUnderConcurrentWriteOffs.
+//   That one is a hammer, not a forced interleaving; its limits are stated there.
+//
+//   The IL is read rather than the source text because there is no reflection surface for "how
+//   was this field written", and a source-text scan of this repo has failed under Linux CI
+//   before (see InstallBaselineAppendConcurrencyTests, which pins #2914's walkers the same way).
+using AlRunner;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestDataProvisionerTallyAtomicityTests
+{
+    /// <summary>Every running tally on TestDataProvisioner. Named individually rather than
+    /// discovered, so adding a counter without deciding how it is written fails review here
+    /// rather than shipping unsynchronised.</summary>
+    public static TheoryData<string> Tallies => new()
+    {
+        "_tablesDone", "_rowsDone", "_refused", "_readerRefused",
+        "_droppedColumns", "_columnsNotInThisBuild", "_deferredLoadsWrittenOff",
+    };
+
+    private static TypeDefinition Provisioner()
+    {
+        var asm = AssemblyDefinition.ReadAssembly(typeof(TestDataProvisioner).Assembly.Location);
+        var type = asm.MainModule.GetType(typeof(TestDataProvisioner).FullName);
+        Assert.True(type != null, "TestDataProvisioner not found in the loaded al-runner.dll");
+        return type!;
+    }
+
+    /// <summary>The type plus anything the compiler generated inside it (closures, iterator
+    /// state machines): a lambda writing a tally is still a write to a tally.</summary>
+    private static IEnumerable<MethodDefinition> AllMethods(TypeDefinition type)
+        => type.Methods.Concat(type.NestedTypes.SelectMany(n => n.Methods)).Where(m => m.HasBody);
+
+    private static bool Touches(Instruction i, OpCode op, string field)
+        => i.OpCode == op && i.Operand is FieldReference fr && fr.Name == field;
+
+    /// <summary>
+    /// The claim, first half: nothing writes a tally with a plain store except ResetForTests.
+    /// `x++` and `x += n` on a static field compile to ldsfld/add/stsfld — a read-modify-write
+    /// two threads can interleave — so the ABSENCE of stsfld outside the reset is the absence of
+    /// the defect. Against the unfixed code LoadOnDemand carries five of these and
+    /// NoteDeferredLoadWrittenOff the sixth.
+    ///
+    /// ResetForTests is the one legitimate plain writer and is asserted as such below, so this
+    /// cannot be satisfied by deleting the reset.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Tallies))]
+    public void NoMethodButResetForTests_StoresATallyDirectly(string field)
+    {
+        var offenders = AllMethods(Provisioner())
+            .Where(m => m.Name != nameof(TestDataProvisioner.ResetForTests))
+            .Where(m => m.Body.Instructions.Any(i => Touches(i, OpCodes.Stsfld, field)))
+            .Select(m => m.Name)
+            .ToArray();
+
+        Assert.True(offenders.Length == 0,
+            $"{field} is written with a plain stsfld by: {string.Join(", ", offenders)}. "
+            + "That is a read-modify-write two --test-data hydration threads can interleave "
+            + "(#2997); use Interlocked.Increment/Add.");
+    }
+
+    /// <summary>
+    /// Second half, and the one that makes the first non-vacuous: the tally really is still
+    /// counted, and counted atomically. A "fix" that simply deleted every increment would pass
+    /// the stsfld check above and fail here.
+    ///
+    /// Matched as "the address of the field is taken, and an Interlocked call consumes it" —
+    /// Interlocked.Increment/Add take `ref int`, which is ldsflda, and no other shape in this
+    /// type does.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Tallies))]
+    public void EveryTally_IsMutatedThroughInterlocked(string field)
+    {
+        var sites = 0;
+        foreach (var m in AllMethods(Provisioner()))
+        {
+            foreach (var i in m.Body.Instructions.Where(x => Touches(x, OpCodes.Ldsflda, field)))
+            {
+                // Interlocked.Increment(ref f) calls immediately; Interlocked.Add(ref f, n)
+                // pushes its addend first, and the addend can itself be a call (a property
+                // getter on the hydration result), so scan a short window rather than requiring
+                // the next instruction. Another field address appearing first ends the window —
+                // that would be a different call's argument, not this one's.
+                for (var next = i.Next; next != null; next = next.Next)
+                {
+                    if (next.OpCode == OpCodes.Ldsflda || next.OpCode == OpCodes.Ldflda) break;
+                    if ((next.OpCode == OpCodes.Call || next.OpCode == OpCodes.Callvirt)
+                        && next.Operand is MethodReference mr
+                        && mr.DeclaringType.FullName == "System.Threading.Interlocked")
+                    {
+                        sites++;
+                        break;
+                    }
+                    if (next.Offset - i.Offset > 40) break;   // bounded: this is one call, not a block
+                }
+            }
+        }
+
+        Assert.True(sites > 0,
+            $"{field} is never passed to System.Threading.Interlocked, so either it is no "
+            + "longer counted at all or it is counted by some other unsynchronised means (#2997).");
+    }
+
+    /// <summary>
+    /// ResetForTests stays a plain store, deliberately: it runs between runs with no other
+    /// thread in play, and routing it through Interlocked would suggest a concurrency it does
+    /// not have. Asserted so the exemption in the first test is a stated decision rather than a
+    /// hole — if the reset ever stops writing these fields, the first test goes vacuous and this
+    /// one says so.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Tallies))]
+    public void ResetForTests_StillClearsEveryTally(string field)
+    {
+        var reset = Provisioner().Methods.Single(m => m.Name == nameof(TestDataProvisioner.ResetForTests));
+        Assert.True(reset.Body.Instructions.Any(i => Touches(i, OpCodes.Stsfld, field)),
+            $"ResetForTests no longer clears {field}, so a stale count survives into the next run.");
+    }
+}

--- a/AlRunner/TestDataProvisioner.cs
+++ b/AlRunner/TestDataProvisioner.cs
@@ -169,6 +169,18 @@ internal static class TestDataProvisioner
     private static ArmedPlan? _armed;
 
     // Running tallies, accumulated across on-demand loads rather than known at Arm() time.
+    //
+    // #2997: mutated ONLY through Interlocked, never `++` or `+=`. Two threads can be inside
+    // LoadOnDemand at once — TestExecutor.InvokeWithTimeout runs every [Test] on its own worker
+    // thread and does not kill it when the watchdog expires, so an abandoned thread keeps
+    // hydrating while the bundle loop carries on in the same process (the route #2914
+    // established) — and a read-modify-write from two threads drops counts. Measured: eight
+    // threads doing 10,000 write-offs each landed 79,543 of 80,000.
+    //
+    // Reads are Volatile.Read. Not for tearing — these are aligned int32s, which the CLI
+    // guarantees are read and written atomically (ECMA-335 I.12.6.6), so a torn read was never
+    // possible — but so a reader is not handed a value from before another thread's increment
+    // that it has no other reason to see.
     private static int _tablesDone, _rowsDone, _refused, _readerRefused, _droppedColumns, _columnsNotInThisBuild;
 
     /// <summary>Tables the backup offers that ended the run without their rows because the
@@ -176,7 +188,7 @@ internal static class TestDataProvisioner
     /// is an assertable count rather than something inferred from log text.</summary>
     private static int _deferredLoadsWrittenOff;
 
-    internal static int DeferredLoadsWrittenOff => _deferredLoadsWrittenOff;
+    internal static int DeferredLoadsWrittenOff => Volatile.Read(ref _deferredLoadsWrittenOff);
 
     /// <summary>The most recent hydration's outcome — the assertable signal a test uses
     /// instead of re-deriving what happened from log text. Under the on-demand policy it is
@@ -267,7 +279,7 @@ internal static class TestDataProvisioner
                 + $"company '{armed.Company}' has no table with this id, so nothing was loaded";
             return;
         }
-        _deferredLoadsWrittenOff++;
+        Interlocked.Increment(ref _deferredLoadsWrittenOff);
         _tableOutcome[tableId] = "its storage was first created from inside another table's "
             + $"--test-data hydration and {reason}, so the rows "
             + $"'{Path.GetFileName(armed.Backup)}' company '{armed.Company}' holds for it were "
@@ -290,6 +302,8 @@ internal static class TestDataProvisioner
     {
         _lastSummary = null;
         _armed = null;
+        // Plain stores on purpose (#2997): the reset runs between runs with no other thread in
+        // play, and routing it through Interlocked would imply a concurrency it does not have.
         _tablesDone = _rowsDone = _refused = _readerRefused = _droppedColumns = _columnsNotInThisBuild = 0;
         _deferredLoadsWrittenOff = 0;
         _tableOutcome.Clear();
@@ -399,16 +413,16 @@ internal static class TestDataProvisioner
                 out var meta, out var pristineRows);
             if (result.Rows > 0)
             {
-                _tablesDone++;
+                Interlocked.Increment(ref _tablesDone);
                 // The rows are in the live store now, but no snapshot knows about them: a load
                 // fired mid-test is long past CaptureInstallBaselineSnapshot(). Without this
                 // the very next codeunit/test boundary would wipe them.
                 if (meta != null)
                     RecordPatches.AppendBaselineTable(source, tableId, meta, pristineRows);
             }
-            _rowsDone += result.Rows;
-            _droppedColumns += result.ColumnsFromUninstalledApps;
-            _columnsNotInThisBuild += result.ColumnsNotInThisBuild;
+            Interlocked.Add(ref _rowsDone, result.Rows);
+            Interlocked.Add(ref _droppedColumns, result.ColumnsFromUninstalledApps);
+            Interlocked.Add(ref _columnsNotInThisBuild, result.ColumnsNotInThisBuild);
             _tableOutcome[tableId] = result.Rows > 0
                 ? $"{result.Rows} row(s) loaded from '{Path.GetFileName(armed.Backup)}' company '{armed.Company}'"
                 : $"'{entry.TableName}' in '{Path.GetFileName(armed.Backup)}' company '{armed.Company}' "
@@ -418,7 +432,7 @@ internal static class TestDataProvisioner
         }
         catch (TestDataHydrationRefusal ex)
         {
-            _refused++;
+            Interlocked.Increment(ref _refused);
             _tableOutcome[tableId] = $"the backup's rows for it were refused — {ex.Message}";
             Console.Error.WriteLine($"[test-data] REFUSED {ex.Message}");
         }
@@ -428,14 +442,16 @@ internal static class TestDataProvisioner
             // a table that is unavailable, not a run that is broken. Reported with the reader's
             // own text IN FULL, because that text is the only diagnosis there is and the bundle
             // reporter keeps only line 1 of an EXEC-FAIL message.
-            _readerRefused++;
+            Interlocked.Increment(ref _readerRefused);
             _tableOutcome[tableId] =
                 $"the backup reader refused table '{entry.TableName}' — {ex.Message.Split('\n')[0]}";
             Console.Error.WriteLine(
                 $"[test-data] READER REFUSED table '{entry.TableName}': {ex.Message}");
         }
-        _lastSummary = new Summary(armed.Backup, armed.Company, _tablesDone, _rowsDone,
-            armed.SkippedAmbiguous, _refused, _readerRefused, _droppedColumns, _columnsNotInThisBuild);
+        _lastSummary = new Summary(armed.Backup, armed.Company,
+            Volatile.Read(ref _tablesDone), Volatile.Read(ref _rowsDone),
+            armed.SkippedAmbiguous, Volatile.Read(ref _refused), Volatile.Read(ref _readerRefused),
+            Volatile.Read(ref _droppedColumns), Volatile.Read(ref _columnsNotInThisBuild));
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #2997

## What was wrong

`TestDataProvisioner`'s seven running tallies — `_tablesDone`, `_rowsDone`, `_refused`,
`_readerRefused`, `_droppedColumns`, `_columnsNotInThisBuild`, `_deferredLoadsWrittenOff` — were
plain `int++` / `+=`, written from `LoadOnDemand` and `NoteDeferredLoadWrittenOff`. Two threads
can be inside those at once by the route #2914 established (`TestExecutor.InvokeWithTimeout` runs
every `[Test]` on its own worker thread and does not kill it when the watchdog expires, so an
abandoned thread keeps hydrating while the bundle loop carries on in the same process), and a
read-modify-write from two threads drops counts.

## Scope — keeping the issue's own framing

The issue was filed by the agent that fixed the real concurrency defect next door, and it scoped
itself down on purpose. That framing is unchanged here:

- **Diagnostics only.** Nothing branches on these numbers. They are what the `--test-data`
  summary prints, plus `DeferredLoadsWrittenOff`, which one test asserts.
- **Reachable only under an already-degenerate condition** — `--test-data` plus a watchdog abort
  (or a warm `--server` session). No CI leg passes `--test-data`.
- So a lost count **misreports a run that was already abnormal**. It is not data corruption. The
  rows are unaffected; #2914 covers the structure that does matter.
- The watchdog-thread question is deliberately left alone: not killing the thread is existing
  behaviour that #2280's auto-resume rests on, and changing it is a much larger change.

## The fix

`Interlocked.Increment` / `Interlocked.Add` at all seven mutation sites — the smaller change of
the two the issue named, because the counters live in `TestDataProvisioner` while #2914's leaf
lock lives in `RecordPatches`. It is also the house style: every other multi-threaded static
counter in `AlRunner/` already uses `Interlocked`.

**Are any read mid-flight?** Yes — all six summary counters are read at the end of every
`LoadOnDemand` to build `_lastSummary`, and `_deferredLoadsWrittenOff` through its property. A
**torn** read was never possible: these are aligned `int32`s, which the CLI guarantees are read
and written atomically (ECMA-335 I.12.6.6). What was possible is *staleness*, so those seven read
sites now use `Volatile.Read`. The commit and the code comment both say that is a freshness fix
and not a tearing fix, so nobody later reads it as a claim that reads were unsafe.

`ResetForTests` keeps its plain stores, deliberately — it runs between runs with no other thread
in play, and routing it through `Interlocked` would imply a concurrency it does not have. That
exemption is now pinned by a test rather than left implicit.

## RED → GREEN

Two tests, and here is exactly what each does and does not prove.

**1. `TestDataProvisionerTallyAtomicityTests` — the mechanism, deterministic.** Reads the compiled
IL of the loaded `al-runner.dll` with Mono.Cecil, the way
`InstallBaselineAppendConcurrencyTests` pins #2914's walkers. Three claims per counter: no method
but `ResetForTests` stores it with a plain `stsfld`; it is still passed to
`System.Threading.Interlocked` (so deleting the increments cannot satisfy the first claim); and
`ResetForTests` still clears it (so the exemption in the first claim cannot go vacuous).

- **Proves:** every write to a tally is atomic, by construction, checked over the shipped IL.
- **Does not prove:** that any particular interleaving was ever observed. It is a structural
  guard, not a race reproduction.

**2. `TestDataLazyLoadPolicyTests.TheWriteOffTally_IsExactUnderConcurrentWriteOffs` — the
behaviour.** Drives the *real* write-off notifier that `Arm()` installs (production code, not a
stand-in) from 8 threads x 10,000 calls and asserts the exact total, plus that a table the plan
does not offer still returns before the tally.

- **Proves:** the count is exact under 8-way contention through the production path.
- **Does not prove, and this is the honest limit:** it is a hammer, not a forced interleaving.
  Nothing makes two threads collide at the increment; it makes a collision very likely. So
  against unsynchronised code it fails *probabilistically*, not by construction. Against the
  fixed code it is exact and deterministic, so it cannot flake green-to-red.

Measured, with the final test code:

| | result |
|---|---|
| RED (`AlRunner/TestDataProvisioner.cs` reverted to `origin/main`) | **15 failed**, 7 passed — the contention test reported `Expected: 80000 / Actual: 79565`, i.e. 435 counts really were lost |
| GREEN | 115 passed, 0 failed across `TestDataProvisioner*`, `TestDataLazyLoadPolicy*`, `TestDataProvisioning*`, `TestDataBaselineAppend*`, `InstallBaselineAppendConcurrency*`, `NestedTableMaterialisationHydration*`, `BackupReaderServe*`, `TestDataSymbolPackages*`, `MissingTestDataDiagnosis*` |

The earlier RED run measured 79,543/80,000 — a different number each time, which is what a real
lost-update looks like.

## Fixing the shape, not just the reported line

All three questions answered, including where the answer is "nothing found":

1. **Same wrong pattern at another call site?** Nothing found. Every other `private static int/long`
   counter in `AlRunner/` written from more than one thread already uses `Interlocked`
   (`NavRecordRefPatches._nextLinkId`, `SessionPatches._alRunnerSessionCounter`, both
   `_rowVersion`s, `CodeunitEventDispatcher._dispatchCount`), or a lock
   (`RecordLinkPatches._nextId` — both `++_nextId` sites are inside `lock (_lock)`, and that one
   is an identity generator where a lost increment would be a real bug), or is `[ThreadStatic]`
   (`_materialisationDepth`, `_testDataLoadDepth`, `_navMethodScopeDepth`).
2. **Sibling function with the same assumption?** `LoadOnDemand` and `NoteDeferredLoadWrittenOff`
   are the two writers; both fixed. `_tableOutcome` on the same path was already a
   `ConcurrentDictionary`, and `_lastSummary` is a reference assignment — inherently a
   last-writer-wins snapshot, not something a lock would make more meaningful.
3. **Two paths writing the same state with different invariants?** The third writer is
   `ResetForTests`. It keeps plain stores on purpose, and the third IL claim exists so that
   decision is stated and enforced rather than being an unexamined hole in the first claim.

## Corpus

Nothing owed upstream. These counters are runner diagnostics behind `--test-data`; no AL surface
observes them, and real BC has no equivalent, so there is no BC-behaviour claim here for a service
tier to adjudicate.

## Deliberately left out

- The watchdog thread is still not killed (see Scope).
- `tests/expectations/count-baseline/test-count-baseline.json` is untouched — #3004 is open
  against it.

---
*Implemented by agent `stma-auto-1` on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE