### PR TITLE
fix(pkgdedup): bound the shared al-runner-pkgdedup staging root

### DIFF
--- a/AlRunner.Tests/BcCompilerPkgDedupInUseClaimTests.cs
+++ b/AlRunner.Tests/BcCompilerPkgDedupInUseClaimTests.cs
@@ -1,0 +1,136 @@
+// BcCompilerPkgDedupInUseClaimTests — BOTH staging paths must claim the stage they hand to a
+// compile (issue #2990).
+//
+// PkgDedupCache's age rule is only safe because a live process's stage carries a claim. That
+// makes "did the claim get written" a property of DeduplicateAppPackageDirs, not of the cache
+// class, and it has two exits that reach a compile:
+//
+//   * the CREATE path — stage the picked .app set into `<key>.tmp-<rand>` and publish it;
+//   * the REUSE path — `Directory.Exists(<key>)`, hand the existing one straight back.
+//
+// The reuse path is the one that matters and the easy one to forget. A stage is WRITTEN once
+// and READ on every reuse, so a stage a --watch session has reused daily for a month still has
+// a month-old mtime; if only the create path claimed, the age rule would eventually delete a
+// directory that is in constant use. This test therefore drives the same call twice and
+// asserts the claim is recreated by the second call specifically.
+//
+// It asserts on the claim, never by pruning: this runs against the machine's real
+// al-runner-pkgdedup root, which other runners share.
+using System.IO.Compression;
+using System.Reflection;
+using System.Text;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class BcCompilerPkgDedupInUseClaimTests : IDisposable
+{
+    private readonly string _root;
+    private readonly List<string> _stagesToClean = new();
+
+    public BcCompilerPkgDedupInUseClaimTests()
+    {
+        _root = TestScratch.Dir("al-runner-pkgdedup-claim-tests");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        // Only what this test caused to exist: a stage keyed by this fixture's own GUID paths
+        // cannot be anyone else's.
+        foreach (var stage in _stagesToClean)
+        {
+            try { File.Delete(PkgDedupCache.InUseMarkerPath(stage)); } catch { }
+            try { Directory.Delete(stage, recursive: true); } catch { }
+        }
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void BothStagingPaths_ClaimTheStageTheyHandToTheCompile()
+    {
+        var dirA = Path.Combine(_root, "a", ".alpackages");
+        var dirB = Path.Combine(_root, "b", ".alpackages");
+        Directory.CreateDirectory(dirA);
+        Directory.CreateDirectory(dirB);
+
+        var onlyInA = "aaaaaaaa-1111-0000-0000-0000000000a1";
+        var shared = "bbbbbbbb-2222-0000-0000-0000000000b2";
+        WriteApp(dirA, "OnlyInA.app", onlyInA, "Only In A", "Contoso", "1.0.0.0");
+        WriteApp(dirA, "Shared.app", shared, "Shared", "Contoso", "1.0.0.0");
+        // The cross-dir (AppId, Version) duplicate is what forces the staging branch.
+        WriteApp(dirB, "Shared.app", shared, "Shared", "Contoso", "1.0.0.0");
+
+        var packageDirs = new List<string> { dirA, dirB };
+
+        // ── create path ──────────────────────────────────────────────────────────────────
+        var first = InvokeDeduplicate(packageDirs);
+        Assert.NotEqual(packageDirs, first);   // the staging branch really engaged
+        var stage = Assert.Single(first);
+        _stagesToClean.Add(stage);
+
+        var marker = PkgDedupCache.InUseMarkerPath(stage);
+        Assert.True(File.Exists(marker),
+            $"the create path must claim the stage it returns; no '{marker}'");
+        Assert.True(ScratchDirs.TryReadOwner(marker, out var pid, out _, out _));
+        Assert.Equal(Environment.ProcessId, pid);
+
+        // ── reuse path ───────────────────────────────────────────────────────────────────
+        // Remove the claim and backdate the stage to well past any threshold, so the second
+        // call has to re-establish both facts by itself.
+        File.Delete(marker);
+        var ancient = DateTime.UtcNow - TimeSpan.FromDays(30);
+        Directory.SetLastWriteTimeUtc(stage, ancient);
+
+        var second = InvokeDeduplicate(packageDirs);
+        Assert.Equal(stage, Assert.Single(second));   // same content key, so the reuse branch ran
+
+        Assert.True(File.Exists(marker),
+            "the REUSE path must claim the stage too — a stage reused for months is never " +
+            "rewritten, so nothing else would tell the prune it is alive");
+        Assert.True(Directory.GetLastWriteTimeUtc(stage) > ancient + TimeSpan.FromDays(1),
+            "reuse must stamp last-USE on the stage, or an age rule measures its creation date");
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────────────────
+
+    private static List<string> InvokeDeduplicate(List<string> packageDirs)
+    {
+        var method = typeof(BcCompiler)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .SingleOrDefault(m => m.Name == "DeduplicateAppPackageDirs" && m.GetParameters().Length == 2)
+            ?? throw new InvalidOperationException(
+                "BcCompiler.DeduplicateAppPackageDirs(dirs, excludeAppId) not found by reflection.");
+        return (List<string>)method.Invoke(null, new object?[] { packageDirs, null })!;
+    }
+
+    private static void WriteApp(string dir, string fileName,
+        string appId, string name, string publisher, string version)
+        => File.WriteAllBytes(Path.Combine(dir, fileName), MakeMinimalApp(appId, name, publisher, version));
+
+    private static byte[] MakeMinimalApp(string appId, string name, string publisher, string version)
+    {
+        var xml = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{appId}" Name="{name}" Publisher="{publisher}" Version="{version}"/>
+            </Package>
+            """;
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            using (var es = zip.CreateEntry("NavxManifest.xml").Open())
+                es.Write(Encoding.UTF8.GetBytes(xml));
+            // The dedup scan drops any .app without one before staging ever happens.
+            using (var ss = zip.CreateEntry("SymbolReference.json").Open())
+                ss.Write(Encoding.UTF8.GetBytes("{}"));
+        }
+        var zipBytes = ms.ToArray();
+        var result = new byte[8 + zipBytes.Length];
+        result[0] = (byte)'N'; result[1] = (byte)'A'; result[2] = (byte)'V'; result[3] = (byte)'X';
+        BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
+        zipBytes.CopyTo(result, 8);
+        return result;
+    }
+}

--- a/AlRunner.Tests/PkgDedupCachePruneTests.cs
+++ b/AlRunner.Tests/PkgDedupCachePruneTests.cs
@@ -1,0 +1,318 @@
+// PkgDedupCachePruneTests — the al-runner-pkgdedup staging root must be bounded, and
+// bounding it must never take a stage directory away from a process still using it
+// (issue #2990).
+//
+// The two halves are not equally important. "Something got deleted" is the easy half; the
+// SURVIVAL cases below are the ones that decide whether this feature is a disk-hygiene fix
+// or a data-loss bug, so most of this file is about directories that must still be there
+// afterwards:
+//
+//   * a stage claimed by a LIVE process survives no matter how old it looks,
+//   * a stage whose name is not one the runner writes is never touched at all,
+//   * a stage used recently survives,
+//   * a stage whose directory mtime is ancient but whose in-use marker is recent survives,
+//   * ScratchDirs' own sweep still leaves a marked pkgdedup stage alone — the in-use marker
+//     deliberately does NOT use the `.owner` suffix, because that sweep deletes the
+//     directory when its owner dies, which for a deliberately shared cache would destroy
+//     cross-run reuse on every process exit.
+//
+// Every case runs against a fixture root built by the test. Nothing here reads or writes
+// the machine's real Path.GetTempPath()/al-runner-pkgdedup.
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PkgDedupCachePruneTests : IDisposable
+{
+    private readonly string _root;
+
+    public PkgDedupCachePruneTests()
+    {
+        _root = TestScratch.Dir("al-runner-pkgdedup-prune-tests");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private static readonly TimeSpan MaxAge = TimeSpan.FromDays(7);
+    private static readonly DateTime Now = new(2026, 9, 6, 12, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>A stage directory named exactly as BcCompiler names one, with one staged
+    /// .app inside and a chosen last-use time.</summary>
+    private string Stage(string name, TimeSpan age)
+    {
+        var dir = Path.Combine(_root, name);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "Contoso_App_1.0.0.0.app"), "NAVX");
+        Directory.SetLastWriteTimeUtc(dir, Now - age);
+        return dir;
+    }
+
+    private const string KeyA = "0123456789abcdef";
+    private const string KeyB = "fedcba9876543210";
+
+    // ── Removal ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Prune_RemovesStageUntouchedBeyondMaxAge()
+    {
+        var stale = Stage(KeyA, TimeSpan.FromDays(30));
+
+        var result = PkgDedupCache.Prune(_root, MaxAge, Now);
+
+        Assert.False(Directory.Exists(stale), "a stage untouched for 30 days must be reclaimed");
+        Assert.Equal(new[] { stale }, result.Removed);
+        Assert.Equal(0, result.Kept);
+        Assert.Equal(0, result.Failed);
+    }
+
+    [Fact]
+    public void Prune_RemovesAbandonedTmpStagingDirectory()
+    {
+        // The `<key>.tmp-<rand>` scratch name. Normally renamed onto `<key>` within
+        // milliseconds, but it survives the whole run when PkgDedupStaging.Publish falls
+        // back to it, and forever when the process is killed mid-staging.
+        var tmp = Stage(KeyA + ".tmp-0a1b2c3d", TimeSpan.FromDays(30));
+
+        var result = PkgDedupCache.Prune(_root, MaxAge, Now);
+
+        Assert.False(Directory.Exists(tmp), "an abandoned .tmp- staging dir must be reclaimed");
+        Assert.Equal(new[] { tmp }, result.Removed);
+    }
+
+    [Fact]
+    public void Prune_RemovesStageClaimedOnlyByADeadProcess()
+    {
+        var stale = Stage(KeyA, TimeSpan.FromDays(30));
+        var marker = WriteMarker(KeyA, DeadPid, startJiffies: 0, age: TimeSpan.FromDays(30));
+
+        var result = PkgDedupCache.Prune(_root, MaxAge, Now);
+
+        Assert.False(Directory.Exists(stale), "a dead process's claim must not preserve a stage");
+        Assert.False(File.Exists(marker), "the dead owner's marker must go with the directory");
+        Assert.Contains(stale, result.Removed);
+    }
+
+    [Fact]
+    public void Prune_RemovesOrphanMarkerLeftByADeadProcess()
+    {
+        // No directory: the stage was already gone (published elsewhere, or removed by an
+        // earlier pass) and only the claim is left. Markers are files, so nothing else in
+        // the tree would ever reclaim them.
+        var marker = WriteMarker(KeyA, DeadPid, startJiffies: 0, age: TimeSpan.FromDays(30));
+
+        var result = PkgDedupCache.Prune(_root, MaxAge, Now);
+
+        Assert.False(File.Exists(marker), "an orphan marker whose owner is dead must be reclaimed");
+        Assert.Equal(1, result.MarkersRemoved);
+    }
+
+    [Fact]
+    public void Prune_RemovesLeftoverPruningDirectoryFromAnEarlierPass()
+    {
+        // Prune renames a doomed stage aside before deleting it, so no other process can
+        // ever observe a half-emptied stage under its real name. A crash between the two
+        // leaves the renamed tree behind; the next pass must finish the job.
+        var leftover = Path.Combine(_root, KeyA + ".pruning-9f8e7d6c");
+        Directory.CreateDirectory(leftover);
+        File.WriteAllText(Path.Combine(leftover, "x.app"), "NAVX");
+
+        var result = PkgDedupCache.Prune(_root, MaxAge, Now);
+
+        Assert.False(Directory.Exists(leftover), "a leftover .pruning- tree must be finished off");
+        Assert.Contains(leftover, result.Removed);
+    }
+
+    [Fact]
+    public void Prune_RemovesOnlyTheStaleStage_LeavingItsNeighbourIntact()
+    {
+        var stale = Stage(KeyA, TimeSpan.FromDays(30));
+        var fresh = Stage(KeyB, TimeSpan.FromHours(1));
+
+        PkgDedupCache.Prune(_root, MaxAge, Now);
+
+        Assert.False(Directory.Exists(stale));
+        Assert.True(Directory.Exists(fresh));
+        Assert.True(File.Exists(Path.Combine(fresh, "Contoso_App_1.0.0.0.app")),
+            "the surviving stage must keep its staged packages, not just its directory");
+    }
+
+    // ── Survival: the half that stops this becoming a data-loss bug ────────────────────
+
+    [Fact]
+    public void Prune_KeepsStageClaimedByALiveProcess_HoweverOldItLooks()
+    {
+        // THE load-bearing case. A --watch or --server session holds a stage for as long as
+        // it runs and may not touch it again for days, so age alone cannot decide. This
+        // process is the live claimant, and the directory is backdated far past any
+        // threshold: only the liveness check can save it.
+        var live = Stage(KeyA, TimeSpan.FromDays(3650));
+        var marker = PkgDedupCache.MarkInUse(live);
+        File.SetLastWriteTimeUtc(marker, Now - TimeSpan.FromDays(3650));
+        Directory.SetLastWriteTimeUtc(live, Now - TimeSpan.FromDays(3650));
+
+        var result = PkgDedupCache.Prune(_root, MaxAge, Now);
+
+        Assert.True(Directory.Exists(live),
+            "a stage claimed by a LIVE process must never be pruned, at any age");
+        Assert.True(File.Exists(Path.Combine(live, "Contoso_App_1.0.0.0.app")),
+            "and its staged packages must still be there");
+        Assert.Empty(result.Removed);
+        Assert.Equal(1, result.Kept);
+    }
+
+    [Fact]
+    public void Prune_KeepsStageUsedWithinMaxAge()
+    {
+        var recent = Stage(KeyA, TimeSpan.FromDays(6));
+
+        var result = PkgDedupCache.Prune(_root, MaxAge, Now);
+
+        Assert.True(Directory.Exists(recent), "6 days is inside the 7-day threshold");
+        Assert.Empty(result.Removed);
+        Assert.Equal(1, result.Kept);
+    }
+
+    [Fact]
+    public void Prune_KeepsStageWhoseMarkerIsRecentEvenWhenTheDirectoryMtimeIsAncient()
+    {
+        // Stamping the directory's mtime on reuse is best-effort — a read-only mount, a
+        // different uid, a filesystem that refuses utimes. The marker write is the second,
+        // independent record of "someone used this", so the newer of the two decides.
+        Stage(KeyA, TimeSpan.FromDays(30));
+        WriteMarker(KeyA, DeadPid, startJiffies: 0, age: TimeSpan.FromHours(2));
+
+        var result = PkgDedupCache.Prune(_root, MaxAge, Now);
+
+        Assert.True(Directory.Exists(Path.Combine(_root, KeyA)),
+            "a claim recorded two hours ago is recent use, whatever the directory mtime says");
+        Assert.Equal(1, result.Kept);
+    }
+
+    [Fact]
+    public void Prune_KeepsOrphanMarkerOfALiveProcess()
+    {
+        // A live process claims the stage a moment before creating it. Deleting the claim
+        // here would leave its directory unprotected for the rest of its run.
+        var marker = PkgDedupCache.MarkInUse(Path.Combine(_root, KeyA));
+
+        PkgDedupCache.Prune(_root, MaxAge, Now);
+
+        Assert.True(File.Exists(marker), "a live process's claim must survive even with no directory yet");
+    }
+
+    [Theory]
+    [InlineData("not-a-stage")]              // someone else's directory
+    [InlineData("0123456789ABCDEF")]         // uppercase: never a name BcCompiler writes
+    [InlineData("0123456789abcde")]          // 15 hex digits
+    [InlineData("0123456789abcdef0")]        // 17 hex digits
+    [InlineData("0123456789abcdef.tmp")]     // no random suffix
+    [InlineData("0123456789abcdef.tmp-zz1b2c3d")] // non-hex random suffix
+    [InlineData("0123456789abcdeg")]         // 'g' is not hex
+    public void Prune_NeverTouchesADirectoryItDoesNotRecognise(string name)
+    {
+        // Fails closed: the prune deletes only names it can prove the runner wrote. Anything
+        // else under the root belongs to someone else, and a shared temp root is exactly
+        // where a wrong guess is unrecoverable.
+        var foreign = Stage(name, TimeSpan.FromDays(3650));
+
+        var result = PkgDedupCache.Prune(_root, MaxAge, Now);
+
+        Assert.True(Directory.Exists(foreign), $"'{name}' is not a stage name the runner writes");
+        Assert.Empty(result.Removed);
+        Assert.Equal(1, result.Skipped);
+    }
+
+    [Fact]
+    public void Prune_OnAMissingRootDoesNothingAndDoesNotCreateIt()
+    {
+        var absent = Path.Combine(_root, "never-created");
+
+        var result = PkgDedupCache.Prune(absent, MaxAge, Now);
+
+        Assert.Empty(result.Removed);
+        Assert.False(Directory.Exists(absent), "the prune must not conjure the root it is asked about");
+    }
+
+    // ── The marker itself ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void MarkInUse_RecordsLastUseSoTheNextPruneSeesTheStageAsFresh()
+    {
+        // A stage is WRITTEN once and READ on every reuse, so its own mtime records only its
+        // creation; atime is not usable (relatime/noatime are the defaults). MarkInUse is the
+        // explicit last-USE stamp that makes the age rule mean what it says.
+        var stage = Stage(KeyA, TimeSpan.FromDays(30));
+
+        PkgDedupCache.MarkInUse(stage);
+
+        var stamped = Directory.GetLastWriteTimeUtc(stage);
+        Assert.True(DateTime.UtcNow - stamped < TimeSpan.FromMinutes(5),
+            $"MarkInUse must stamp the stage's last-use time; it still reads {stamped:O}");
+    }
+
+    [Fact]
+    public void MarkInUseMarker_IsNotAScratchDirsOwnerSidecar()
+    {
+        // Pinning the suffix choice, not just its spelling. ScratchDirs.SweepStale deletes a
+        // directory whose `.owner` sidecar names a dead process. Every runner process exits,
+        // so an `.owner` sidecar on a pkgdedup stage would destroy the shared cache on the
+        // first sweep after the creating run — the cache exists precisely to be reused BY
+        // LATER PROCESSES. An in-use claim therefore means "someone is reading this", never
+        // "this belongs to me, delete it when I go".
+        var stage = Stage(KeyA, TimeSpan.FromDays(30));
+        var marker = PkgDedupCache.MarkInUse(stage);
+
+        Assert.EndsWith(".inuse-" + Environment.ProcessId, marker);
+        Assert.NotEqual(ScratchDirs.MarkerPathFor(stage), marker);
+        Assert.False(File.Exists(ScratchDirs.MarkerPathFor(stage)));
+
+        // And the sweep really does leave it alone, marker and all.
+        ScratchDirs.SweepStale(_root);
+
+        Assert.True(Directory.Exists(stage),
+            "ScratchDirs' owner-liveness sweep must not reclaim a shared pkgdedup stage");
+        Assert.True(File.Exists(marker));
+    }
+
+    // ── The configured threshold ───────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(null, 7)]      // unset: the default
+    [InlineData("", 7)]
+    [InlineData("14", 14)]
+    [InlineData("0", 7)]       // non-positive would prune a stage in use right now
+    [InlineData("-3", 7)]
+    [InlineData("banana", 7)]
+    [InlineData("99999999999", 7)]  // beyond TimeSpan.FromDays' range
+    public void MaxAgeFromEnvironment_FallsBackToTheDefaultForAnythingUnusable(string? raw, int expectedDays)
+    {
+        Assert.Equal(TimeSpan.FromDays(expectedDays), PkgDedupCache.MaxAgeFrom(raw));
+    }
+
+    [Fact]
+    public void MaxAgeFromEnvironment_HonoursAFractionalOverride()
+    {
+        Assert.Equal(TimeSpan.FromDays(0.5), PkgDedupCache.MaxAgeFrom("0.5"));
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────────────
+
+    /// <summary>A pid no process can have. Linux caps pid_max at 2^22 and Windows pids are far
+    /// smaller still, so Process.GetProcessById cannot find one here and ScratchDirs.IsOwnerAlive
+    /// reports it dead — portably, without spawning anything or relying on /proc.
+    /// A non-positive pid would NOT work: ScratchDirs reads that as "unreadable, assume alive".</summary>
+    private const int DeadPid = 2_146_999_999;
+
+    private string WriteMarker(string stageName, int pid, long startJiffies, TimeSpan age)
+    {
+        var path = Path.Combine(_root, stageName + ".inuse-" + pid);
+        File.WriteAllText(path, $"pid={pid}\nstart=1\nstartjiffies={startJiffies}\ncreated={Now:O}\n");
+        File.SetLastWriteTimeUtc(path, Now - age);
+        return path;
+    }
+}

--- a/AlRunner.Tests/PkgDedupCachePruneTests.cs
+++ b/AlRunner.Tests/PkgDedupCachePruneTests.cs
@@ -112,6 +112,42 @@ public sealed class PkgDedupCachePruneTests : IDisposable
     }
 
     [Fact]
+    public void Prune_RemovesLeftoverStaleDirectoryFromAReplacedStage()
+    {
+        // PkgDedupStaging.TryMoveAside renames a stage whose entries no longer resolve to
+        // `<key>.stale-<rand>` and then deletes it best-effort, swallowing every failure
+        // (#2989). A tree that could not be deleted then sits there forever — the same leak
+        // this class closes, reached through a sibling function. Note there is no age or
+        // liveness test here and there should not be: the rename already made it unreachable
+        // under the stage name, so no compile can adopt it, and the renamer had already
+        // decided it was garbage.
+        var aside = Path.Combine(_root, KeyA + ".stale-1a2b3c4d");
+        Directory.CreateDirectory(aside);
+        File.WriteAllText(Path.Combine(aside, "dangling.app"), "NAVX");
+        Directory.SetLastWriteTimeUtc(aside, Now);   // brand new: still goes
+
+        var result = PkgDedupCache.Prune(_root, MaxAge, Now);
+
+        Assert.False(Directory.Exists(aside), "a leftover .stale- tree must be finished off");
+        Assert.Contains(aside, result.Removed);
+    }
+
+    [Theory]
+    [InlineData(".stale-1a2b3c4d")]
+    [InlineData(".pruning-1a2b3c4d")]
+    public void Prune_NeverTreatsAForeignNameAsARenamedAsideLeftover(string suffix)
+    {
+        // The stage-key half still has to check out. `something.stale-1a2b3c4d` is not ours.
+        var foreign = Stage("something" + suffix, TimeSpan.FromDays(3650));
+
+        var result = PkgDedupCache.Prune(_root, MaxAge, Now);
+
+        Assert.True(Directory.Exists(foreign), "only a leftover of a REAL stage key is ours to finish");
+        Assert.Empty(result.Removed);
+        Assert.Equal(1, result.Skipped);
+    }
+
+    [Fact]
     public void Prune_RemovesLeftoverPruningDirectoryFromAnEarlierPass()
     {
         // Prune renames a doomed stage aside before deleting it, so no other process can

--- a/AlRunner.Tests/PkgDedupStaleStageReuseTests.cs
+++ b/AlRunner.Tests/PkgDedupStaleStageReuseTests.cs
@@ -102,13 +102,22 @@ public sealed class PkgDedupStaleStageReuseTests : IDisposable
         // A marker no rebuild would reproduce: if the directory is rebuilt, it is gone.
         var marker = Path.Combine(first, "reuse-marker.txt");
         File.WriteAllText(marker, "published-once");
-        var createdAt = Directory.GetCreationTimeUtc(first);
+        // #2990: this used to compare Directory.GetCreationTimeUtc across the two calls. That
+        // is not a reliable "was it rebuilt" proxy here — on a filesystem that does not expose
+        // a birth time, .NET derives the creation time from the mtime, so ANY legitimate write
+        // to the directory moves it. The reuse path now stamps the stage's last-USE time (a
+        // stage is written once and read forever, so its own mtime would otherwise record only
+        // its creation date and the prune would eventually delete a stage in daily use). The
+        // marker FILE inside the stage carries the same claim without that coupling: a rebuild
+        // replaces the whole directory, so neither the file nor its timestamps survive one.
+        var markerCreatedAt = File.GetCreationTimeUtc(marker);
 
         var second = Assert.Single(InvokeDeduplicateAppPackageDirs(packageDirs, excludeAppId: null));
 
         Assert.Equal(first, second);
         Assert.True(File.Exists(marker), "an intact stage must be adopted, not rebuilt");
-        Assert.Equal(createdAt, Directory.GetCreationTimeUtc(second));
+        Assert.Equal("published-once", File.ReadAllText(marker));
+        Assert.Equal(markerCreatedAt, File.GetCreationTimeUtc(marker));
     }
 
     // ── PkgDedupStaging.Publish: the concurrent-runner half of the same defect ──────────

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -1018,7 +1018,7 @@ public sealed partial class BcCompiler
 
         lock (_stageSync)
         {
-            _stageRootCache ??= Path.Combine(Path.GetTempPath(), "al-runner-pkgdedup");
+            _stageRootCache ??= PkgDedupCache.Root;
             var stage = Path.Combine(_stageRootCache, key);
             // #2967: existence is a valid test of COMPLETENESS — a stage is only ever created
             // by one atomic rename, measured — but it is NOT a test of VALIDITY. The key
@@ -1052,9 +1052,20 @@ public sealed partial class BcCompiler
                 // same staged files, so the compile is unaffected; only the cross-compile
                 // reuse of this key is lost.
                 var published = PkgDedupStaging.Publish(tmp, stage, Console.Error);
+                // Claim it before it is handed to a compile (#2990). `published` is `stage`
+                // normally and `tmp` when Publish had to fall back, and BOTH need the claim:
+                // the fallback scratch dir is used for this entire run and nothing else ever
+                // deletes it, so without this it is exactly the shape that accumulated.
+                PkgDedupCache.MarkInUse(published);
                 _stageProvenance[published] = (packageDirs.ToList(), unstaged);
                 return new List<string> { published };
             }
+            // The REUSE path needs the same claim as the create path above, and needs it more.
+            // A stage reused for months is never rewritten, so its own mtime records only the
+            // day it was created — claiming here is what tells the prune it is live, and what
+            // stamps its last-USE time. Marking only the create path would leave every
+            // long-lived --watch / --server session's stage looking abandoned.
+            PkgDedupCache.MarkInUse(stage);
             _stageProvenance[stage] = (packageDirs.ToList(), unstaged);
             return new List<string> { stage };
         }

--- a/AlRunner/Infrastructure/PkgDedupCache.cs
+++ b/AlRunner/Infrastructure/PkgDedupCache.cs
@@ -57,6 +57,12 @@
 //   restages correctly. A crash between the rename and the delete leaves the aside tree,
 //   which the next pass finishes.
 //
+//   The same finishing applies to `<name>.stale-<rand>`, which PkgDedupStaging.TryMoveAside
+//   leaves when it replaces a stage whose entries no longer resolve (#2989). Its delete is
+//   best-effort and swallows every failure, so a tree that could not be removed stays under
+//   that name with nothing else in the root to reclaim it — the same unbounded growth this
+//   class closes, reached through a sibling function rather than through the stage itself.
+//
 //   RESIDUAL RACE, stated rather than papered over: another process can pass
 //   `Directory.Exists(stage)` in the instant between this pass reading the markers and
 //   renaming the directory aside. It needs a stage nobody has used for seven days to be
@@ -80,9 +86,16 @@ internal static class PkgDedupCache
     /// <see cref="ScratchDirs.OwnerMarkerSuffix"/> — see this file's header.</summary>
     internal const string InUseInfix = ".inuse-";
 
-    /// <summary>Marks a tree renamed aside for deletion. Recognised on a later pass so a prune
-    /// interrupted between the rename and the delete is finished rather than leaked.</summary>
+    /// <summary>Marks a tree THIS class renamed aside for deletion. Recognised on a later pass so
+    /// a prune interrupted between the rename and the delete is finished rather than leaked.</summary>
     internal const string PruningInfix = ".pruning-";
+
+    /// <summary>What PkgDedupStaging.TryMoveAside renames a stale stage to before replacing it
+    /// (#2989). Its delete is best-effort and swallows every failure, so a held or unreadable
+    /// tree stays under this name forever with nothing else in the tree to reclaim it — the same
+    /// leak this class exists to close, arrived at from a sibling function. Recognised here for
+    /// the same reason and on the same terms as PruningInfix.</summary>
+    internal const string StaleInfix = ".stale-";
 
     /// <summary>Far longer than any plausible run. The claim in condition 2 is what actually
     /// protects a live stage; this covers a claim that was never written (a pre-#2990 build)
@@ -213,12 +226,24 @@ internal static class PkgDedupCache
         return rest.StartsWith(".tmp-", StringComparison.Ordinal) && IsLowerHex(rest[5..], 8);
     }
 
-    /// <summary>True for a tree an earlier pass renamed aside and did not finish deleting.</summary>
-    internal static bool IsPruningLeftoverName(string name)
+    /// <summary>
+    /// True for a stage tree that has already been renamed out from under its real name and
+    /// whose deletion did not finish — either by this class (<see cref="PruningInfix"/>) or by
+    /// PkgDedupStaging replacing a stale stage (<see cref="StaleInfix"/>).
+    ///
+    /// <para>These need no liveness or age test, and get none. The rename is what makes them
+    /// unreachable: no lookup resolves a stage under one of these names, so no compile can adopt
+    /// one, and the process that renamed it had already decided to delete it. Finishing that
+    /// delete is strictly what the renamer intended.</para>
+    /// </summary>
+    internal static bool IsRenamedAsideLeftoverName(string name)
+        => IsLeftoverWithInfix(name, PruningInfix) || IsLeftoverWithInfix(name, StaleInfix);
+
+    private static bool IsLeftoverWithInfix(string name, string infix)
     {
-        var idx = name.IndexOf(PruningInfix, StringComparison.Ordinal);
+        var idx = name.IndexOf(infix, StringComparison.Ordinal);
         if (idx <= 0) return false;
-        return IsStageDirName(name[..idx]) && IsLowerHex(name[(idx + PruningInfix.Length)..], 8);
+        return IsStageDirName(name[..idx]) && IsLowerHex(name[(idx + infix.Length)..], 8);
     }
 
     private static bool IsLowerHex(string s, int length)
@@ -292,15 +317,16 @@ internal static class PkgDedupCache
                     continue;
                 }
                 if (!Directory.Exists(entry)) { result.Skipped++; continue; }
-                if (IsPruningLeftoverName(name)) { leftovers.Add(entry); continue; }
+                if (IsRenamedAsideLeftoverName(name)) { leftovers.Add(entry); continue; }
                 stages.Add(entry);
             }
             catch (IOException) { result.Skipped++; }
             catch (UnauthorizedAccessException) { result.Skipped++; }
         }
 
-        // Trees a previous pass renamed aside. Already unreachable under their real names, so
-        // nobody can be reading them by the argument above: finish the job unconditionally.
+        // Trees renamed aside by an earlier prune, or by PkgDedupStaging replacing a stale
+        // stage. Already unreachable under their real names, so nobody can adopt one: finish
+        // the job the renamer started. See IsRenamedAsideLeftoverName.
         foreach (var leftover in leftovers)
         {
             if (TryDeleteTree(leftover)) result.Removed.Add(leftover);

--- a/AlRunner/Infrastructure/PkgDedupCache.cs
+++ b/AlRunner/Infrastructure/PkgDedupCache.cs
@@ -1,0 +1,393 @@
+// PkgDedupCache — bounding the shared package-dedup staging root (issue #2990).
+//
+// WHAT ACCUMULATES
+//   BcCompiler.DeduplicateAppPackageDirs stages one symlink per deduplicated .app into
+//   <temp>/al-runner-pkgdedup/<key>/, where <key> is a hash of the ABSOLUTE PATHS of the
+//   picked .app set. That key space is unbounded in practice: fixture bundles live under
+//   GUID-named temp trees, so every test run mints keys that will never be looked up again.
+//   Nothing removed them. Measured on the reporting machine with nine runners active: 138
+//   stage directories, 28,004 staged entries. On a stock Linux desktop /tmp is a tmpfs, so
+//   that is RAM charged to no process — the same accumulation #2706 measured (126 GB) on the
+//   test side, and the same one that has killed every shell on this machine at least once.
+//
+//   ScratchDirs.SweepStale already walks this root (it matches the `al-runner-` prefix) and
+//   deliberately removes nothing here: it deletes only directories whose `.owner` sidecar
+//   names a dead process, and a pkgdedup stage has no sidecar. That is not an oversight to
+//   correct — see the next paragraph.
+//
+// WHY ScratchDirs' RULE CANNOT BE APPLIED AS-IS
+//   ScratchDirs is single-owner: one process reserves a directory, and the directory dies
+//   with that process. This cache is the opposite by design. Deduplicating across CONCURRENT
+//   AND SUBSEQUENT runners is the entire point, so a stage must outlive the process that
+//   created it. Giving a stage an `.owner` sidecar would have the next runner start delete it
+//   as soon as its creator exited — which is every run — and the cache would never hit.
+//   (PkgDedupCachePruneTests pins that, so the suffix cannot drift back onto `.owner`.)
+//
+// THE POLICY, AND WHY IT FAILS CLOSED
+//   Removing a directory a live process is reading is worse than the disk it reclaims, so
+//   three independent conditions must ALL hold before anything is deleted:
+//
+//     1. The name is one BcCompiler provably writes — `<16 hex>` or `<16 hex>.tmp-<8 hex>`.
+//        Anything else under the root belongs to somebody else and is never touched, so a
+//        future change to the naming scheme degrades to "stops reclaiming", never to
+//        "deletes the wrong tree".
+//     2. No LIVE process claims it. Every process that stages or reuses a stage writes an
+//        in-use marker beside it (`<stage>.inuse-<pid>`), in ScratchDirs' own sidecar format,
+//        and liveness is decided by ScratchDirs.IsOwnerAlive — pid plus the boot-relative
+//        start time, so a reused pid cannot masquerade as the original owner. Unlike an
+//        `.owner` sidecar this is a claim by ANY NUMBER of processes at once, and it means
+//        "someone is reading this", never "delete this when I exit".
+//     3. It has not been used for `maxAge` — 7 days by default, overridable with
+//        AL_RUNNER_PKGDEDUP_MAX_AGE_DAYS. "Used" is the NEWER of the directory's own mtime
+//        and its markers' mtimes, because a stage is written once and read on every reuse:
+//        its own mtime otherwise records only its creation. atime cannot serve — relatime
+//        and noatime are the norm — so MarkInUse stamps the directory explicitly, and the
+//        marker mtime is the backup record for when that stamp cannot be written.
+//
+//   Condition 3 alone is the rule ScratchDirs' header warns about, the one thing that can
+//   delete a directory a live process is still reading. Condition 2 is what makes it safe:
+//   an idle --watch or --server session that has not touched its stage in a month still
+//   holds a live claim on it. The threshold is generous anyway, because a run started from a
+//   BUILD THAT PREDATES THIS FILE writes no marker at all, and condition 3 is the only thing
+//   standing between such a run and its stage.
+//
+//   Deletion goes through a rename to `<name>.pruning-<rand>` first. The rename is atomic, so
+//   no other process can ever observe a stage that exists under its real name but has been
+//   half emptied — it sees the stage or it sees nothing, and "nothing" is a cache miss that
+//   restages correctly. A crash between the rename and the delete leaves the aside tree,
+//   which the next pass finishes.
+//
+//   RESIDUAL RACE, stated rather than papered over: another process can pass
+//   `Directory.Exists(stage)` in the instant between this pass reading the markers and
+//   renaming the directory aside. It needs a stage nobody has used for seven days to be
+//   picked up in exactly that window. The consequence is bounded: the packages vanish from
+//   under the compile, BC's reader reports AL1023 and the run fails loudly with a compile
+//   error. It cannot produce a passing test with the wrong answer, because a missing symbol
+//   is a compile error, not a different result. Closing it completely needs a cross-process
+//   lock around every stage read, which costs every compile to protect a seven-day-old edge.
+using System.Globalization;
+using System.Text;
+
+namespace AlRunner.Infrastructure;
+
+internal static class PkgDedupCache
+{
+    /// <summary>The shared staging root. Must stay in step with BcCompiler's `_stageRootCache`,
+    /// which is the only thing that writes into it.</summary>
+    internal static string Root => Path.Combine(Path.GetTempPath(), "al-runner-pkgdedup");
+
+    /// <summary>Separates a stage name from the pid of a process reading it. Deliberately NOT
+    /// <see cref="ScratchDirs.OwnerMarkerSuffix"/> — see this file's header.</summary>
+    internal const string InUseInfix = ".inuse-";
+
+    /// <summary>Marks a tree renamed aside for deletion. Recognised on a later pass so a prune
+    /// interrupted between the rename and the delete is finished rather than leaked.</summary>
+    internal const string PruningInfix = ".pruning-";
+
+    /// <summary>Far longer than any plausible run. The claim in condition 2 is what actually
+    /// protects a live stage; this covers a claim that was never written (a pre-#2990 build)
+    /// or lost (SIGKILL), so it buys safety at the price of a week of disk.</summary>
+    internal static readonly TimeSpan DefaultMaxAge = TimeSpan.FromDays(7);
+
+    internal const string MaxAgeEnvVar = "AL_RUNNER_PKGDEDUP_MAX_AGE_DAYS";
+
+    /// <summary>What one <see cref="Prune(string, TimeSpan, DateTime)"/> pass did.
+    /// <see cref="Removed"/> lists deleted directories; <see cref="Kept"/> counts recognised
+    /// stages examined and deliberately left; <see cref="Skipped"/> counts entries whose names
+    /// the prune does not recognise and therefore refuses to judge; <see cref="Failed"/> counts
+    /// deletions that threw and will be retried next pass.</summary>
+    internal sealed class PruneResult
+    {
+        public List<string> Removed { get; } = new();
+        public int Kept { get; set; }
+        public int Failed { get; set; }
+        public int Skipped { get; set; }
+        public int MarkersRemoved { get; set; }
+    }
+
+    // ── In-use claims ──────────────────────────────────────────────────────────────────────
+
+    private static readonly object Gate = new();
+    private static readonly HashSet<string> Claimed = new(StringComparer.Ordinal);
+    private static bool _exitHooked;
+    private static long? _ownStartTicks;
+    private static long? _ownStartJiffies;
+
+    /// <summary>The claim path this process would write for <paramref name="stageDir"/>.</summary>
+    internal static string InUseMarkerPath(string stageDir) => InUseMarkerPath(stageDir, Environment.ProcessId);
+
+    internal static string InUseMarkerPath(string stageDir, int pid)
+        => stageDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+           + InUseInfix + pid.ToString(CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// Record that this process is reading <paramref name="stageDir"/>, and stamp the stage's
+    /// last-USE time. Call it on EVERY path that hands a stage to a compile — the one that
+    /// created it and the one that reused an existing one — because a stage reused for months
+    /// without ever being rewritten is exactly the one an age rule would otherwise delete.
+    ///
+    /// <para>The claim is removed at ProcessExit; the DIRECTORY is not. A shared cache entry
+    /// must outlive the run that used it, which is the whole difference from
+    /// <see cref="ScratchDirs.Reserve"/>.</para>
+    ///
+    /// <para>Best-effort throughout: a claim that cannot be written leaves the stage protected
+    /// by the age rule alone, which is the pre-#2990 behaviour and still correct.</para>
+    /// </summary>
+    /// <returns>The claim path, whether or not it could be written.</returns>
+    internal static string MarkInUse(string stageDir)
+    {
+        var full = Path.GetFullPath(stageDir);
+        var marker = InUseMarkerPath(full);
+        var now = DateTime.UtcNow;
+        try
+        {
+            var parent = Path.GetDirectoryName(full);
+            if (!string.IsNullOrEmpty(parent)) Directory.CreateDirectory(parent);
+            File.WriteAllText(marker,
+                $"pid={Environment.ProcessId}\nstart={OwnStartTicks}\nstartjiffies={OwnStartJiffies}\n" +
+                $"created={now:O}\n", Encoding.UTF8);
+        }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+
+        // Separate try: the stamp failing must not lose the claim, and vice versa.
+        try { if (Directory.Exists(full)) Directory.SetLastWriteTimeUtc(full, now); }
+        catch (IOException) { }
+        catch (UnauthorizedAccessException) { }
+
+        lock (Gate)
+        {
+            Claimed.Add(marker);
+            if (!_exitHooked)
+            {
+                _exitHooked = true;
+                AppDomain.CurrentDomain.ProcessExit += (_, _) => ReleaseAllClaims();
+            }
+        }
+        return marker;
+    }
+
+    private static void ReleaseAllClaims()
+    {
+        string[] snapshot;
+        lock (Gate) { snapshot = Claimed.ToArray(); Claimed.Clear(); }
+        foreach (var m in snapshot)
+        {
+            // Only the claim. Never the directory — a later runner is meant to find it.
+            try { File.Delete(m); } catch { }
+        }
+    }
+
+    private static long OwnStartTicks
+    {
+        get
+        {
+            if (_ownStartTicks is long t) return t;
+            long v;
+            try { using var me = System.Diagnostics.Process.GetCurrentProcess(); v = me.StartTime.ToUniversalTime().Ticks; }
+            catch { v = 0; }
+            _ownStartTicks = v;
+            return v;
+        }
+    }
+
+    private static long OwnStartJiffies
+        => _ownStartJiffies ??= ScratchDirs.TryReadStartJiffies(Environment.ProcessId) ?? 0;
+
+    // ── Name recognition (condition 1) ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// True for the two names BcCompiler writes under the root: the published stage
+    /// <c>&lt;16 lowercase hex&gt;</c> (SHA-256 of the picked set, truncated) and the scratch
+    /// name it is published from, <c>&lt;16 hex&gt;.tmp-&lt;8 hex&gt;</c>.
+    /// Everything else answers false and is never deleted.
+    /// </summary>
+    internal static bool IsStageDirName(string name)
+    {
+        if (string.IsNullOrEmpty(name)) return false;
+        var dot = name.IndexOf('.');
+        var key = dot < 0 ? name : name[..dot];
+        if (!IsLowerHex(key, 16)) return false;
+        if (dot < 0) return true;
+        var rest = name[dot..];
+        return rest.StartsWith(".tmp-", StringComparison.Ordinal) && IsLowerHex(rest[5..], 8);
+    }
+
+    /// <summary>True for a tree an earlier pass renamed aside and did not finish deleting.</summary>
+    internal static bool IsPruningLeftoverName(string name)
+    {
+        var idx = name.IndexOf(PruningInfix, StringComparison.Ordinal);
+        if (idx <= 0) return false;
+        return IsStageDirName(name[..idx]) && IsLowerHex(name[(idx + PruningInfix.Length)..], 8);
+    }
+
+    private static bool IsLowerHex(string s, int length)
+    {
+        if (s.Length != length) return false;
+        foreach (var c in s)
+            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) return false;
+        return true;
+    }
+
+    // ── The threshold (condition 3) ────────────────────────────────────────────────────────
+
+    /// <summary>The configured threshold, or <see cref="DefaultMaxAge"/> when the environment
+    /// says nothing usable. Anything non-positive or unparseable falls back rather than being
+    /// honoured: "0" would mean "delete a stage the moment it is written", which is precisely
+    /// the failure this class exists to avoid, and a typo must never be able to ask for it.</summary>
+    internal static TimeSpan MaxAgeFromEnvironment()
+        => MaxAgeFrom(Environment.GetEnvironmentVariable(MaxAgeEnvVar));
+
+    internal static TimeSpan MaxAgeFrom(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return DefaultMaxAge;
+        if (!double.TryParse(raw.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out var days))
+            return DefaultMaxAge;
+        if (!(days > 0) || double.IsNaN(days) || double.IsInfinity(days)) return DefaultMaxAge;
+        try { return TimeSpan.FromDays(days); }
+        catch (OverflowException) { return DefaultMaxAge; }
+        catch (ArgumentException) { return DefaultMaxAge; }
+    }
+
+    // ── The pass ───────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Prune the real root with the configured threshold. Never throws.</summary>
+    internal static PruneResult Prune() => Prune(Root, MaxAgeFromEnvironment(), DateTime.UtcNow);
+
+    /// <summary>
+    /// One pass over <paramref name="root"/>. Deletes a stage only when all three conditions in
+    /// this file's header hold. Never throws, and never creates <paramref name="root"/>: a
+    /// machine that has never staged anything must not gain a directory by being swept.
+    /// Safe to run concurrently from any number of processes — every decision is made per
+    /// directory from that directory's own claims, and the aside-rename makes the removal
+    /// atomic to anyone else looking.
+    /// </summary>
+    internal static PruneResult Prune(string root, TimeSpan maxAge, DateTime utcNow)
+    {
+        var result = new PruneResult();
+        string[] entries;
+        try
+        {
+            if (!Directory.Exists(root)) return result;
+            entries = Directory.GetFileSystemEntries(root);
+        }
+        catch (IOException) { return result; }
+        catch (UnauthorizedAccessException) { return result; }
+
+        var markers = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        var stages = new List<string>();
+        var leftovers = new List<string>();
+
+        foreach (var entry in entries)
+        {
+            try
+            {
+                var name = Path.GetFileName(entry);
+                var idx = name.LastIndexOf(InUseInfix, StringComparison.Ordinal);
+                if (idx > 0 && File.Exists(entry))
+                {
+                    var target = name[..idx];
+                    if (!markers.TryGetValue(target, out var list)) markers[target] = list = new List<string>();
+                    list.Add(entry);
+                    continue;
+                }
+                if (!Directory.Exists(entry)) { result.Skipped++; continue; }
+                if (IsPruningLeftoverName(name)) { leftovers.Add(entry); continue; }
+                stages.Add(entry);
+            }
+            catch (IOException) { result.Skipped++; }
+            catch (UnauthorizedAccessException) { result.Skipped++; }
+        }
+
+        // Trees a previous pass renamed aside. Already unreachable under their real names, so
+        // nobody can be reading them by the argument above: finish the job unconditionally.
+        foreach (var leftover in leftovers)
+        {
+            if (TryDeleteTree(leftover)) result.Removed.Add(leftover);
+            else result.Failed++;
+        }
+
+        foreach (var stage in stages)
+        {
+            var name = Path.GetFileName(stage);
+            if (!IsStageDirName(name)) { result.Skipped++; continue; }   // condition 1
+            markers.TryGetValue(name, out var claims);
+
+            if (AnyClaimantAlive(claims)) { result.Kept++; continue; }   // condition 2
+            if (utcNow - LastUseUtc(stage, claims) < maxAge) { result.Kept++; continue; }   // condition 3
+
+            // Rename first so no other process ever sees a half-emptied stage under its real
+            // name; then delete. A failure at either step is retried by the next pass.
+            var aside = stage + PruningInfix + Guid.NewGuid().ToString("N")[..8];
+            try { Directory.Move(stage, aside); }
+            catch (IOException) { result.Failed++; continue; }
+            catch (UnauthorizedAccessException) { result.Failed++; continue; }
+
+            if (TryDeleteTree(aside)) result.Removed.Add(stage);
+            else result.Failed++;
+        }
+
+        // Claims whose stage is gone — deleted just now, or by another runner. A claim is a
+        // file, so nothing else in this tree would ever reclaim one. Only dead claimants'
+        // claims go: a live process routinely claims a stage a moment before creating it.
+        foreach (var (target, list) in markers)
+        {
+            if (Directory.Exists(Path.Combine(root, target))) continue;
+            foreach (var marker in list)
+            {
+                if (IsClaimantAlive(marker)) continue;
+                try { File.Delete(marker); result.MarkersRemoved++; }
+                catch (IOException) { }
+                catch (UnauthorizedAccessException) { }
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>The newer of the stage's own mtime and its claims' mtimes. Taking the maximum
+    /// is what makes each record a backstop for the other: a reuse that could not stamp the
+    /// directory still wrote a claim, and a claim lost to SIGKILL still left the stamp.</summary>
+    private static DateTime LastUseUtc(string stage, List<string>? claims)
+    {
+        DateTime last;
+        try { last = Directory.GetLastWriteTimeUtc(stage); }
+        catch { return DateTime.UtcNow; }   // unreadable: treat as just-used, i.e. keep it
+        if (claims == null) return last;
+        foreach (var claim in claims)
+        {
+            try
+            {
+                var t = File.GetLastWriteTimeUtc(claim);
+                if (t > last) last = t;
+            }
+            catch { /* vanished mid-pass: the remaining records still decide */ }
+        }
+        return last;
+    }
+
+    private static bool AnyClaimantAlive(List<string>? claims)
+    {
+        if (claims == null) return false;
+        foreach (var claim in claims)
+            if (IsClaimantAlive(claim)) return true;
+        return false;
+    }
+
+    /// <summary>An unreadable or unparseable claim counts as ALIVE. It is the conservative
+    /// answer, and the only cost of being wrong is one stage kept until the next pass.</summary>
+    private static bool IsClaimantAlive(string markerPath)
+    {
+        if (!ScratchDirs.TryReadOwner(markerPath, out var pid, out var startTicks, out var startJiffies))
+            return true;
+        return ScratchDirs.IsOwnerAlive(pid, startTicks, startJiffies);
+    }
+
+    private static bool TryDeleteTree(string dir)
+    {
+        try { Directory.Delete(dir, recursive: true); return true; }
+        catch (DirectoryNotFoundException) { return true; }   // someone else finished it
+        catch (IOException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
+    }
+}

--- a/AlRunner/Infrastructure/PkgDedupStaging.cs
+++ b/AlRunner/Infrastructure/PkgDedupStaging.cs
@@ -84,12 +84,18 @@
 //   merely bypassing matters: bypassing leaves the poison in place for the next runner, and
 //   the next, forever.
 //
-// WHAT THIS DOES NOT FIX
-//   Stages whose picked path set never recurs are still never reclaimed — they are dead disk
-//   until someone clears the temp root. Self-healing on reuse is the part that affects
-//   correctness; an age- or ownership-based prune of a deliberately shared, owner-less cache
-//   is a separate decision, and ScratchDirs' header explains why an age rule on a directory a
-//   live process may be reading is the one rule that can do harm.
+// WHAT THIS DOES NOT FIX — AND WHERE THAT IS NOW FIXED (#2990)
+//   Self-healing on reuse is the part that affects correctness, and it only reaches a stage
+//   that is looked up again; a stage whose picked path set never recurs was never reclaimed at
+//   all. That prune landed separately, in PkgDedupCache, and the hazard flagged here is the one
+//   its design turns on: an age rule alone is the one rule that can delete a directory a live
+//   process is reading, so a stage also has to be unclaimed by any live process before it goes.
+//
+//   One thing here feeds that prune. TryMoveAside's `.stale-<rand>` tree is removed by a
+//   TryDelete that swallows every failure, so a tree it cannot remove stays under that name
+//   with nothing else to reclaim it. PkgDedupCache recognises the name and finishes the job on
+//   a later pass; it needs no liveness or age test, because the rename has already put the tree
+//   beyond the reach of any lookup.
 using System.Diagnostics;
 
 namespace AlRunner.Infrastructure;

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -242,6 +242,29 @@ catch (Exception ex)
     PerfTrace.Log($"scratch sweep skipped: {ex.GetType().Name}: {ex.Message}");
 }
 
+// #2990: the package-dedup staging root is deliberately SHARED and owner-less — a stage must
+// outlive the run that created it, or the cache never hits — so ScratchDirs' owner-liveness
+// rule above cannot reclaim anything here and never did. Measured: 138 stage directories and
+// 28,004 staged entries on this machine, growing without bound because the stage key includes
+// the .app set's absolute paths and fixture bundles live under GUID-named temp trees.
+// PkgDedupCache removes only what it can prove is both unclaimed by a live process and unused
+// for a week; see its header for the three conditions and the one race that remains.
+try
+{
+    var pruned = AlRunner.Infrastructure.PkgDedupCache.Prune();
+    // Same reasoning as the sweep above: deleting directories on the runner's own initiative is
+    // announced unconditionally, because this line is the only evidence that would exist if the
+    // liveness or age test ever misjudged a stage that was still in use.
+    if (pruned.Removed.Count > 0)
+        Console.Error.WriteLine($"pkgdedup prune: reclaimed {pruned.Removed.Count} unused staging dir(s) under {AlRunner.Infrastructure.PkgDedupCache.Root}");
+    if (pruned.Removed.Count > 0 || pruned.Failed > 0 || pruned.MarkersRemoved > 0)
+        PerfTrace.Log($"pkgdedup prune: removed {pruned.Removed.Count}, kept {pruned.Kept}, skipped {pruned.Skipped}, failed {pruned.Failed}, markers {pruned.MarkersRemoved}");
+}
+catch (Exception ex)
+{
+    PerfTrace.Log($"pkgdedup prune skipped: {ex.GetType().Name}: {ex.Message}");
+}
+
 // Failure classification (the FAILURE CLASSIFICATION block + v2-classification.json)
 // is a runner-development diagnostic, not something end users care about. Default off.
 // Enable by passing --out PATH (which sets the JSON output path) or --classify (which

--- a/README.md
+++ b/README.md
@@ -119,6 +119,17 @@ runners can share one `TMPDIR`; directories from builds before this mechanism (n
 no pid in the name) are left alone and can be removed by hand. See
 `AlRunner/Infrastructure/ScratchDirs.cs`.
 
+One temp directory is not owned by any single process: `al-runner-pkgdedup/`, where the
+compiler stages a deduplicated set of `.app` packages under a name derived from that set.
+Sharing it across concurrent and later runs is the point, so a stage has to outlive the run
+that created it and the ownership sweep above cannot reclaim anything there. It is pruned on
+a separate rule instead: every run writes a `<stage>.inuse-<pid>` claim on the stage it uses,
+and a stage is deleted only when no live process claims it **and** nothing has used it for
+seven days. A directory whose name is not one the compiler writes is never touched. Set
+`AL_RUNNER_PKGDEDUP_MAX_AGE_DAYS` to change the threshold; anything unparseable or
+non-positive falls back to the default rather than being honoured. See
+`AlRunner/Infrastructure/PkgDedupCache.cs`.
+
 ### Watch mode (live dashboard)
 
 ```bash


### PR DESCRIPTION
Closes #2990

## What distinguishes a safe-to-remove stage from a live one

I went looking for this before writing anything, because the issue is explicit that an age
heuristic is the one rule that can do harm here.

**Who writes them.** `BcCompiler.DeduplicateAppPackageDirs` populates `<key>.tmp-<rand>` under
the staging lock and then renames it onto `<key>`. The rename is atomic, so the published name
is itself the completion marker — a `<key>` directory never exists half-staged. What does *not*
exist is any liveness record: nothing said "a process is reading this right now", and that is
the actual gap, not the missing delete.

**Why `ScratchDirs`' rule cannot be reused as-is.** `ScratchDirs` is single-owner and deletes a
directory when its `.owner` sidecar names a dead process. Every runner process exits, so an
`.owner` sidecar on a pkgdedup stage would destroy the cache on the first sweep after the run
that created it — and reuse by *later* processes is the entire point. `SweepStale` already walks
this root (it matches the `al-runner-` prefix) and correctly removes nothing there.

**What breaks if a live one goes.** The staged packages vanish from under the compile, BC's
native reader reports AL1023, and the run fails with compile errors. Loud, not silent: a missing
symbol is a compile error, never a different test result. That matters — it is the less-bad of
the two failure modes — but a confusing failed run is still worse than the disk reclaimed.

**Is the growth really unbounded?** Yes, and nothing else cleans up on any schedule. The key is
a hash of the picked `.app` set's **absolute paths**, and fixture bundles live under GUID-named
temp trees, so the key space does not repeat. I watched three ordinary runs mint six stage
directories in my own isolated `TMPDIR` while testing this.

## The policy, and how it fails closed

Three conditions must **all** hold before anything is deleted:

1. **The name is one the compiler provably writes** — `<16 lowercase hex>` or
   `<16 hex>.tmp-<8 hex>`. Anything else under the root is skipped, not judged. A future change
   to the naming scheme degrades to "stops reclaiming", never to "deletes the wrong tree".
2. **No live process claims it.** Every staging path now writes `<stage>.inuse-<pid>` beside the
   stage, in `ScratchDirs`' own sidecar format, and liveness is decided by
   `ScratchDirs.IsOwnerAlive` — pid plus the boot-relative start time, so a reused pid cannot
   masquerade as the original owner. Unlike `.owner` this is a claim by *any number* of processes
   at once and means "someone is reading this", never "delete this when I exit". It is removed at
   `ProcessExit`; the directory is not.
3. **Unused for 7 days**, overridable with `AL_RUNNER_PKGDEDUP_MAX_AGE_DAYS`. "Used" is the newer
   of the directory mtime and its claims' mtimes, so each is a backstop for the other. A stage is
   written once and read on every reuse, so its own mtime would otherwise record only its
   creation date; `MarkInUse` stamps it explicitly, because atime cannot serve (relatime/noatime
   are the defaults).

Condition 3 alone is the dangerous rule; condition 2 is what makes it safe — an idle `--watch`
or `--server` session that has not touched its stage in a month still holds a live claim.
The threshold stays generous anyway, because a run from a build predating this change writes no
claim at all and has only condition 3 protecting it. Anything unparseable or non-positive in the
env var falls back to the default rather than being honoured: `0` would mean "delete a stage the
moment it is written".

Deletion renames the tree to `<name>.pruning-<rand>` first, so no other process can observe a
stage that exists under its real name but has been half emptied; a leftover from a crash between
the two steps is finished by the next pass.

**Residual race, stated rather than papered over** (also in the file header): another process can
pass `Directory.Exists(stage)` in the instant between this pass reading the claims and renaming
the directory aside. It needs a stage nobody has used for seven days to be picked up in exactly
that window, and the consequence is the loud AL1023 failure above. Closing it completely needs a
cross-process lock around every stage read, which taxes every compile to protect a seven-day-old
edge.

## RED -> GREEN

**RED.** `PkgDedupCache` first went in as a no-op stub (`Prune` returning an empty result,
`MarkInUse` returning its argument). 21 of the 28 tests failed against it. The 7 that passed are
exactly the survival cases a no-op gets right by doing nothing — which is why the survival tests
below assert `Kept == 1` rather than just "still exists": a directory the pruner never examined
is not the same as one it examined and spared.

**GREEN.** 37/37 across both new classes; 68/68 including the whole `ScratchDirs` family.

**The survival half** (`AlRunner.Tests/PkgDedupCachePruneTests.cs`), which is what stops this
being a data-loss bug:

- a stage claimed by a **live** process survives with its mtime and its claim both backdated
  **ten years** — only the liveness check can save it, and `Kept == 1` proves it was examined;
- its staged `.app` is asserted still present, not just the directory;
- seven name shapes that are **not** ones the compiler writes survive at ten years old
  (uppercase hex, 15 and 17 digits, a non-hex digit, `.tmp` with no suffix, a non-hex random
  suffix, an unrelated name) — `Skipped`, never `Removed`;
- a stage whose directory mtime is 30 days old but whose claim was written 2 hours ago survives,
  proving the newer-of-the-two rule;
- a live process's claim survives even with no directory yet (claimed a moment before creating);
- a stage 6 days old survives the 7-day threshold;
- `ScratchDirs.SweepStale` leaves a claimed stage and its claim alone — pinning the suffix
  *choice*, so it cannot drift back onto `.owner` and take the cache with it;
- `Prune` on a missing root does nothing **and does not create it**.

**The removal half:** a 30-day stage; an abandoned `.tmp-` staging dir; a stage claimed only by a
dead process (claim removed with it); an orphan claim from a dead process; a leftover `.pruning-`
tree; and a stale stage removed while its fresh neighbour keeps its packages.

## Fixing the shape, not the reported line

**Does the same wrong pattern appear at another call site?** I checked every
`Path.GetTempPath()` root the runner writes. `al-runner-sibling-symbols` is already age-pruned,
the ncl-shadow root and the Cecil cache are `keepNewest`-pruned, and the seven `ScratchDirs`
roots are ownership-swept. The three unmanaged ones are bounded by a *repeating* key rather than
a per-run one: `al-runner-query-symbols` is one file per module name, overwritten;
`alrunner-v2-win32-stubs` is a fixed name; `al-runner-precompile` is keyed by
publisher/name/version and clears its own `*.al` on each use (0 entries on this machine).
pkgdedup was the only root whose key space does not repeat. `bccompiler-dump` is debug-gated.

**Does a sibling function make the same assumption?** Yes, twice.

`PkgDedupStaging.Publish` falls back to returning the `.tmp-` scratch directory when the rename
will not go through, and that directory is then used for the whole run with nothing ever
deleting it. Same leak, different name. Claiming whatever `Publish` returns covers both, and the
`.tmp-` shape is prunable.

The second one surfaced when I rebased onto #2989, which landed while this was in flight.
`PkgDedupStaging.TryMoveAside` renames a stage whose entries no longer resolve to
`<key>.stale-<rand>` and removes it with a `TryDelete` that swallows every failure — so a tree
that could not be deleted stays under that name forever, with nothing else in the root to
reclaim it. That is this issue's defect reached through the repair path rather than through the
stage. `Prune` now finishes those too. Renamed-aside trees get no liveness or age test and
should not: the rename already made them unreachable under a stage name, so no compile can adopt
one, and the process that renamed it had decided it was garbage. The stage-key half of the name
still has to check out, so `something.stale-1a2b3c4d` is left alone — asserted in both
directions.

**Do two code paths that write the same state maintain the same invariant?** This was the real
find. `DeduplicateAppPackageDirs` has two exits — stage-and-publish, and reuse-an-existing-one —
and the reuse path is the one that matters more: a stage a `--watch` session has reused daily for
a month is never rewritten, so with only the create path claiming, the age rule would eventually
delete a directory in constant use. `BcCompilerPkgDedupInUseClaimTests` drives the same call
twice and asserts both. I verified each half is independently load-bearing by deleting one
`MarkInUse` call at a time against the committed baseline: removing only the create-path call
fails on "the create path must claim the stage it returns"; removing only the reuse-path call
fails on "the REUSE path must claim the stage too". Neither assertion rides on the other.

## Corpus

**Nothing owed upstream, and I checked rather than assumed.** This is disk hygiene for a
runner-local temp directory. There is no AL surface: the staging root holds symlinks to `.app`
files consumed by BC's package reader before compilation, and AL code has no API that can observe
a temp directory's existence, name, age or mtime — the claim being made is about
`Path.GetTempPath()` and process liveness, not about anything Business Central does. A corpus
test could not express it, and a real service tier has nothing to adjudicate. If the cache were
observable through AL somehow that answer would change, and I did not find any route by which it
is.

## Deliberately left out

- **The `al-runner prune` operator verb** the issue floats. The automatic pass is safe enough
  that it does not need a human to authorize each deletion, and `AL_RUNNER_PKGDEDUP_MAX_AGE_DAYS`
  covers the "reclaim it now" case without new CLI surface.
- **The size/LRU cap** the issue also floats. Worth being explicit about the trade: this bounds
  the root at *a week of stages* rather than *forever*, which is bounded but not necessarily
  small on a busy machine. A cap would bound the population directly, but it deletes cache
  entries that are recently used and would need a cap value nobody has measured — the correctness
  argument that the issue says is missing. If a week's worth turns out to be too much, the env
  var handles it with no code change, and that measurement is the input a cap needs.
- **Closing the residual race.** Documented above and in the file header rather than solved,
  because the fix costs every compile.

## One pre-existing test adjusted, and why

`PkgDedupStaleStageReuseTests.StageWithEveryEntryResolving_IsReusedNotRebuilt` (from #2989)
compared `Directory.GetCreationTimeUtc` across two calls to show an intact stage was adopted
rather than rebuilt. Where the filesystem exposes no birth time, .NET derives the creation time
from the mtime, so the reuse path's last-use stamp moves it — measured, a 1 ms difference. The
test's claim is right and unchanged; only the proxy was over-specific. It now rests on the
marker file the test writes *inside* the stage, which a rebuild could not reproduce, plus that
file's own content and creation time. I did not weaken the assertion to make my change pass —
the file-based check is strictly the more direct statement of "this directory was not replaced".

I considered dropping the mtime stamp instead. It is load-bearing: claims are deleted at clean
process exit, so after a normal run the directory's own mtime is the only surviving record that
the stage was used at all. Without the stamp, a stage reused daily by cleanly-exiting runs would
show its creation date and be pruned while in active use.

## A comment that would have shipped stale

`PkgDedupStaging`'s header carries a "WHAT THIS DOES NOT FIX" section describing the
unreclaimed-stage problem as an open, separate decision, and warning that an age rule on a
directory a live process may be reading is the one rule that can do harm. This PR makes that
decision, so the note would ship describing a shipped feature as absent — the #2118 shape. It
now says where the prune landed, how the hazard it raises is handled, and that `TryMoveAside`'s
best-effort delete is one of the leaks the prune finishes. Comment only.

## Verification run locally

- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~ScratchDir|FullyQualifiedName~PkgDedup"` — 77/77 after the rebase onto #2989 (68/68 before it landed).
- A real end-to-end runner invocation (`tests/runner-extras/date-virtual-table-window`, both
  package caches) — 5/5 pass, exit 0, exercising the new startup prune on the shared path. Re-run
  after the rebase, since the rebase touched `BcCompiler`'s staging block.
  `ScratchDirsRunnerStartupTests` spawns the real runner too and stays green.
- All of it under a `TMPDIR` under `/home`. **The machine's real `al-runner-pkgdedup` was never
  pruned while developing this** — read-only inspection only, since other agents are live here.

Filed and implemented by the stma-auto-1 agent (Claude) on Stefan's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
