### PR TITLE
fix(refusals): say sixteen TestPage refusals are gaps, not scope boundaries

### DIFF
--- a/AlRunner.Tests/TestPageRefusalClaimTests.cs
+++ b/AlRunner.Tests/TestPageRefusalClaimTests.cs
@@ -1,0 +1,496 @@
+// TestPageRefusalClaimTests — what the sixteen corrected TestPage refusals claim, what an AL
+// [TryFunction] does with one, and which fourteen in the same two files must keep claiming
+// permanence (#2999).
+//
+// WHY THIS IS A RUNNER-SIDE MECHANISM TEST AND NOT AN AL BUNDLE
+// ------------------------------------------------------------
+// Every one of the sixteen fires when something the RUNNER owns is absent or the wrong shape:
+// no AL page object was built for a page, a page built without an ITreeObject owner, a control
+// the runner could not resolve to a binding, a SubPageLink field its own DependencyPageMetadataXml
+// could not resolve to an id, an Option binding carrying no option metadata, two emitted methods
+// hashing to one member id, and — for the two BcShapeGapException sites — a private BC field
+// reflection could not read. No AL statement can arrange any of those, so no bundle under
+// tests/runner-extras/ can drive one. The subject is the C# refusal contract, which
+// .claude/rules/bc-behavior-tests-go-upstream.md classifies as runner-specific (same shape as
+// RunnerShapeGapClaimTests, VirtualTableRefusalClaimTests and BcShapeGapConventionTests).
+//
+// WHAT WAS WRONG
+// --------------
+// All sixteen led with a testpage-* anchor under docs/scope.md, the manifest of what is
+// PERMANENTLY out of scope. The claim is load-bearing, not decorative —
+// ApplicationObjectBasePatches.IsPermanentOutOfScope:
+//
+//     return oos != null && !oos.Reason.StartsWith("not-yet-implemented", StringComparison.Ordinal);
+//
+// so an AL [TryFunction] trapped a runner gap into `false` and the test went green having
+// quietly done without the surface — the silent default loud-failures.md exists to prevent.
+//
+// The sharper seam is the one TestPage work actually hits: `asserterror Foo()` where Foo
+// reaches one of these. On real BC, Foo runs and returns, so the asserterror FAILS. A runner
+// that absorbs the gap makes it PASS. That does not hide a result, it INVERTS one — which is
+// why the two sites where the runner could not READ BC's internals raise
+// BcShapeGapException, whose contract is to tear through both seams (#2946/#2995).
+//
+// THE CONTROL ARMS — three of them
+// --------------------------------
+// Without these the suite could pass by discriminating on exception TYPE rather than on what
+// the reason claims, which would prove nothing:
+//
+//   * PermanentTestPageRefusal_IsStillTrappedByATryFunction — the SAME type as the fourteen
+//     corrected sites, on a genuinely permanent surface drawn from THIS issue's own kept list,
+//     still absorbed into `false`.
+//   * PermanentTestPageRefusal_IsStillCatchableByAssertError — the same, on AL's other seam,
+//     so the BcShapeGapException tear-through cannot pass by "anything unusual tears through".
+//   * KeptRefusals_StillClaimPermanence — the fourteen sites #2999 deliberately excluded were
+//     read and LEFT ALONE. If a later sweep deletes their citation the classification was
+//     wrong, and this fails rather than silently widening the change.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Xunit;
+using AlRunner;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPageRefusalClaimTests
+{
+    private const string Doc = "docs/limitations.md#testpage-shape-gaps";
+    private const string Detail = "the probe detail";
+
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static string PathOf(string file) => Path.Combine(RepoRoot, "AlRunner", "Patches", file);
+
+    /// <summary>File contents with comment lines stripped — the file headers quote the OLD
+    /// wording on purpose, and the claim under test is about code.</summary>
+    private static string CodeOf(string file)
+    {
+        var path = PathOf(file);
+        Assert.True(File.Exists(path), $"{file} not found — was it renamed?");
+        return string.Join('\n', File.ReadAllLines(path)
+            .Where(l => !l.TrimStart().StartsWith("//", StringComparison.Ordinal)));
+    }
+
+    /// <summary>
+    /// <see cref="CodeOf"/> with adjacent string literals joined, so a refusal written as five
+    /// concatenated source lines can be matched on the sentence it actually renders. Without
+    /// this every marker below would have to encode the exact line breaks of the source, which
+    /// makes the test fail on a reflow rather than on the claim it is about.
+    /// </summary>
+    private static string FlattenedCodeOf(string file)
+        => Regex.Replace(CodeOf(file), "\"\\s*\\+\\s*\\$?\"", string.Empty);
+
+    // ══ The fourteen sites that keep RunnerOutOfScopeException, with a corrected anchor ═══
+
+    /// <summary>
+    /// One entry per corrected call site, reproducing the arguments the real site passes, so a
+    /// factory whose api or anchor is quietly changed fails here rather than in the field.
+    /// </summary>
+    private static readonly Dictionary<string, (Func<RunnerOutOfScopeException> Build, string Api, string Surface)> Sites =
+        new()
+        {
+            // MockTestPage.cs — ten
+            ["part-no-definition"] = (
+                () => TestPageShapeGap.Part("TestPage part 42 (page 60100)", Detail),
+                "TestPage part 42 (page 60100)", "testpage-part"),
+            ["part-no-owner"] = (
+                () => TestPageShapeGap.Part("TestPage part 42 → page 60101", Detail),
+                "TestPage part 42 → page 60101", "testpage-part"),
+            ["part-recordless-not-live"] = (
+                () => TestPageShapeGap.Part("TestPage part 43 → page 60102", Detail),
+                "TestPage part 43 → page 60102", "testpage-part"),
+            ["part-not-live"] = (
+                () => TestPageShapeGap.Part("TestPage part 44 → page 60103", Detail),
+                "TestPage part 44 → page 60103", "testpage-part"),
+            ["part-link-unresolved-part-field"] = (
+                () => TestPageShapeGap.PartLink("TestPage part → page 60104 SubPageLink (FIELD)", Detail),
+                "TestPage part → page 60104 SubPageLink (FIELD)", "testpage-part-link"),
+            ["part-link-field-value-not-a-number"] = (
+                () => TestPageShapeGap.PartLink("TestPage part → page 60105 SubPageLink", Detail),
+                "TestPage part → page 60105 SubPageLink", "testpage-part-link"),
+            ["control-binding"] = (
+                () => TestPageShapeGap.ControlBinding("TestPage control 788108655", Detail),
+                "TestPage control 788108655", "testpage-control-binding"),
+            ["option-value-no-metadata"] = (
+                () => TestPageShapeGap.OptionValue("TestPage control 12 on page 60106", Detail),
+                "TestPage control 12 on page 60106", "testpage-option-value"),
+            ["lookup-no-page-object"] = (
+                () => TestPageShapeGap.Lookup("TestPage lookup on field 7", Detail),
+                "TestPage lookup on field 7", "testpage-lookup"),
+            ["drilldown-no-page-object"] = (
+                () => TestPageShapeGap.DrillDown("TestPage drilldown on field 7", Detail),
+                "TestPage drilldown on field 7", "testpage-drilldown"),
+
+            // RunnerPageInstance.cs — four
+            ["control-property-frozen-not-boolean"] = (
+                () => TestPageShapeGap.ControlProperty("TestPage Visible on page 60107 element 3", Detail),
+                "TestPage Visible on page 60107 element 3", "testpage-control-property"),
+            ["control-property-live-not-boolean"] = (
+                () => TestPageShapeGap.ControlProperty("TestPage Editable on page 60107 element 4", Detail),
+                "TestPage Editable on page 60107 element 4", "testpage-control-property"),
+            ["control-property-unevaluatable"] = (
+                () => TestPageShapeGap.ControlProperty("TestPage Enabled on page 60107 element 5", Detail),
+                "TestPage Enabled on page 60107 element 5", "testpage-control-property"),
+            ["trigger-member-id-collision"] = (
+                () => TestPageShapeGap.TriggerAmbiguity(
+                    "TestPage OnLookup (member 123456)", "testpage-onlookup", Detail),
+                "TestPage OnLookup (member 123456)", "testpage-onlookup"),
+        };
+
+    public static IEnumerable<object[]> SiteNames() => Sites.Keys.Select(k => new object[] { k });
+
+    // ══ The two sites where the runner could not READ BC's own internals ═════════════════
+
+    /// <summary>
+    /// A SubPageLink whose <c>FilterType</c> is outside FIELD/CONST/FILTER. Measured on BC
+    /// 28.1's <c>Microsoft.Dynamics.Nav.Types.dll</c>: the enum declares exactly CONST, FILTER
+    /// and FIELD, and the runner's OWN emitter
+    /// (<c>DependencyPageMetadataXml.EmitSubFormLinkXml</c>) writes only those three spellings.
+    /// So a fourth value can only have come from BC's own compiled metadata — a read the runner
+    /// performed and could not interpret, which is the BcShapeGapException case and not the
+    /// runner failing to keep up.
+    /// </summary>
+    private static BcShapeGapException SubPageLinkKindGap() =>
+        new("TestPage part → page 60108 SubPageLink",
+            "Microsoft.Dynamics.Nav.Types.Metadata.FilterType",
+            "holds 'Something', which is not one of FIELD/CONST/FILTER — the probe detail");
+
+    /// <summary>
+    /// Whether a source-table field declares an OnLookup could not be determined, because
+    /// <c>RecordPatches.TryHasFieldLookupTrigger</c> could not reflect BC's private
+    /// field-trigger backing fields. Its three-valued answer exists precisely so this outcome
+    /// stays distinct from "the field declares no trigger" — and null is returned ONLY when the
+    /// read failed, never when it succeeded and said no.
+    /// </summary>
+    private static BcShapeGapException FieldLookupTriggerGap() =>
+        new("TestPage lookup on control 9 (page 60109)",
+            "NCLMetaField.EventTriggerDataValue / EventTriggerData.LookupHandler",
+            "backing field not found — the probe detail");
+
+    public static IEnumerable<object[]> ShapeGaps() => new[]
+    {
+        new object[] { nameof(SubPageLinkKindGap) },
+        new object[] { nameof(FieldLookupTriggerGap) },
+    };
+
+    private static BcShapeGapException ShapeGap(string name) =>
+        name == nameof(SubPageLinkKindGap) ? SubPageLinkKindGap() : FieldLookupTriggerGap();
+
+    // ══ The control arms — refusals in these same two files that must NOT move ═══════════
+
+    /// <summary>
+    /// A page with no <c>SourceTable</c> — MockTestPage.RequireRecord. #2999 lists it among the
+    /// fourteen genuinely permanent: BC itself has no record-backed rowset for such a page, so
+    /// an AL [TryFunction] reading `false` is the OBSERVABLE BC OUTCOME rather than a gap.
+    /// </summary>
+    private static RunnerOutOfScopeException PermanentNoSourceTable() =>
+        new("TestPage page 60110 (Next())",
+            "testpage-modal-no-source-table — this page has no SourceTable, so there is no "
+            + "record-backed rowset for this operation. See docs/scope.md");
+
+    /// <summary>
+    /// A lookup that could only come from a TableRelation — RunnerPageInstance. Permanent for
+    /// the same reason, and pinned from AL as well by
+    /// tests/runner-extras/testpage-lookup-tablerelation-oos.
+    /// </summary>
+    private static RunnerOutOfScopeException PermanentTableRelationLookup() =>
+        new("TestPage lookup on control 9 (page 60111)",
+            "testpage-lookup — neither the control nor its source table field declares an "
+            + "OnLookup trigger, so the lookup comes from a TableRelation and would open the "
+            + "related table's list page, which the runner cannot stand up. See docs/scope.md");
+
+    // ══ 1. The claim: in scope, not yet answerable for the shape found ═══════════════════
+
+    [Theory]
+    [MemberData(nameof(SiteNames))]
+    public void Refusal_ClaimsNotYetImplemented_NotAPermanentScopeBoundary(string site)
+    {
+        var (build, api, surface) = Sites[site];
+        var ex = build();
+
+        Assert.Equal(api, ex.Api);
+        // StartsWith, not Contains: IsPermanentOutOfScope reads the FIRST token, and
+        // ExpectationManifest.ReasonAnchor cuts at the first em-dash separator.
+        Assert.StartsWith("not-yet-implemented", ex.Reason, StringComparison.Ordinal);
+        // The surface's own anchor survives as the second token, so the surfaces stay distinct
+        // to a reader and to any future expectations entry.
+        Assert.Contains(surface + ":", ex.Reason, StringComparison.Ordinal);
+        // And the caller's detail is carried through rather than swallowed.
+        Assert.Contains(Detail, ex.Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EveryFactoryOnTestPageShapeGap_ClaimsNotYetImplemented_AndNeverCitesScopeMd()
+    {
+        // Discovered, not listed: a factory added later is held to the same invariants without
+        // anyone remembering to extend the table above.
+        var factories = typeof(TestPageShapeGap)
+            .GetMethods(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public)
+            .Where(m => m.ReturnType == typeof(RunnerOutOfScopeException)
+                        && m.GetParameters().All(p => p.ParameterType == typeof(string))
+                        // Build is the private plumbing every factory delegates to; probing it
+                        // proves nothing about a call site.
+                        && m.Name != "Build")
+            .ToList();
+
+        Assert.True(factories.Count >= 8, $"expected at least the eight factories, found {factories.Count}");
+
+        foreach (var m in factories)
+        {
+            var args = m.GetParameters().Select((_, i) => (object?)$"probe{i}").ToArray();
+            var ex = (RunnerOutOfScopeException)m.Invoke(null, args)!;
+            Assert.StartsWith("not-yet-implemented", ex.Reason, StringComparison.Ordinal);
+            Assert.DoesNotContain("docs/scope.md", ex.Message, StringComparison.Ordinal);
+        }
+    }
+
+    // ══ 2. The consequence: an AL [TryFunction] must NOT read a runner gap as `false` ════
+
+    [Theory]
+    [MemberData(nameof(SiteNames))]
+    public void Refusal_TearsThroughATryFunction_InsteadOfReadingAsFalse(string site)
+    {
+        var (build, api, _) = Sites[site];
+
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
+            () => BcRuntime.NavApplicationObjectBase_TryInvoke(null, () => throw build()));
+
+        Assert.Equal(api, ex.Api);
+    }
+
+    [Fact]
+    public void PermanentTestPageRefusal_IsStillTrappedByATryFunction_SoTheTestDiscriminatesOnTheClaim()
+    {
+        // CONTROL ARM ONE. Same exception TYPE, same two files, but surfaces #2999 measured as
+        // genuinely permanent. Real BC in an environment that also lacks the surface answers
+        // `false`, so trapping these is faithful — and a sweep that "fixed" them too would
+        // fail here instead of shipping.
+        Assert.False(BcRuntime.NavApplicationObjectBase_TryInvoke(
+            null, () => throw PermanentNoSourceTable()));
+        Assert.False(BcRuntime.NavApplicationObjectBase_TryInvoke(
+            null, () => throw PermanentTableRelationLookup()));
+    }
+
+    // ══ 3. The sharper seam for TestPage work: asserterror ═══════════════════════════════
+
+    [Theory]
+    [MemberData(nameof(ShapeGaps))]
+    public void ShapeGap_TearsThroughBothTryFunctionAndAssertError(string name)
+    {
+        // A BC-layout read that could not be performed is not a scope claim at all, so neither
+        // of AL's error-trapping seams may absorb it. asserterror is the one that INVERTS a
+        // result rather than hiding one: on real BC the call returns, so `asserterror Foo()`
+        // FAILS; a runner that catches the gap makes it PASS.
+        var tryFn = Assert.Throws<BcShapeGapException>(
+            () => BcRuntime.NavApplicationObjectBase_TryInvoke(null, () => throw ShapeGap(name)));
+        Assert.Equal(ShapeGap(name).Member, tryFn.Member);
+
+        var asserted = Assert.Throws<BcShapeGapException>(
+            () => BcRuntime.NavMethodScope_AssertError(null!, () => throw ShapeGap(name)));
+        Assert.Equal(ShapeGap(name).Surface, asserted.Surface);
+    }
+
+    [Fact]
+    public void PermanentTestPageRefusal_IsStillCatchableByAssertError_SoTheTearThroughIsAboutTheClaim()
+    {
+        // CONTROL ARM TWO. Returning normally IS the pass signal — NavMethodScope_AssertError
+        // throws NavNCLAssertErrorException when the body does NOT raise. Without this arm,
+        // "anything that is not a plain exception tears through" would satisfy the assertion
+        // above and prove nothing about the claim.
+        BcRuntime.NavMethodScope_AssertError(null!, () => throw PermanentNoSourceTable());
+        BcRuntime.NavMethodScope_AssertError(null!, () => throw PermanentTableRelationLookup());
+
+        // And the fourteen corrected ones are STILL catchable by asserterror — #2871 is the
+        // open question about that row and this change does not touch it. Only the two BC-shape
+        // reads tear through here.
+        BcRuntime.NavMethodScope_AssertError(
+            null!, () => throw TestPageShapeGap.Lookup("TestPage lookup on field 7", Detail));
+    }
+
+    [Theory]
+    [MemberData(nameof(ShapeGaps))]
+    public void ShapeGap_IsNotAbsorbableAsAnOutOfScopeSignal(string name)
+    {
+        // The other half of why these two are a different type: anything carrying a
+        // RunnerOutOfScopeException can be declared away by an `expect-oos` manifest entry, and
+        // a BC-layout regression must never be declarable as an expected scope boundary — it is
+        // a property of which BC build is on disk, so it can be true on one leg and false on
+        // another in the same run.
+        var gap = ShapeGap(name);
+
+        Assert.DoesNotContain("out-of-scope: ", gap.Message, StringComparison.Ordinal);
+        Assert.False(OutOfScopeMessage.TryParse(gap.Message, out _));
+        Assert.Null(OutOfScopeMessage.FromException(gap));
+        Assert.StartsWith("bc-shape-gap: ", gap.Message, StringComparison.Ordinal);
+    }
+
+    // ══ 4. The link: one of them, and it points at a section that exists ═════════════════
+
+    [Theory]
+    [MemberData(nameof(SiteNames))]
+    public void Refusal_LinksToTheDocThatActuallyDocumentsTheLimit(string site)
+    {
+        var (build, _, _) = Sites[site];
+        var msg = build().Message;
+
+        Assert.EndsWith(" — see " + Doc, msg, StringComparison.Ordinal);
+        Assert.DoesNotContain("docs/scope.md", msg, StringComparison.Ordinal);
+
+        // Counted on "see docs/", not on the " — see " separator: the defect at these sites was
+        // a reason ending "See docs/scope.md" with BuildMessage appending its own link after
+        // it, which leaves the separator count at 1 but renders the link twice (#2766/#2931).
+        Assert.Equal(1, msg.Split("see docs/").Length - 1);
+    }
+
+    [Fact]
+    public void TheDocAnchorsTheseRefusalsPointAt_Exist()
+    {
+        var limitations = File.ReadAllText(Path.Combine(RepoRoot, "docs", "limitations.md"));
+
+        foreach (var anchor in new[] { "testpage-shape-gaps", "bc-shape-gaps" })
+            Assert.Contains($"<a id=\"{anchor}\"></a>", limitations, StringComparison.Ordinal);
+    }
+
+    // ══ 5. The wire format the reporter and the expectations manifest read ═══════════════
+
+    [Theory]
+    [MemberData(nameof(SiteNames))]
+    public void TypedAndUntypedRecovery_AgreeOnTheApiAndTheReason(string site)
+    {
+        var (build, api, _) = Sites[site];
+        var ex = build();
+
+        var typed = OutOfScopeMessage.FromException(ex);
+        Assert.NotNull(typed);
+        Assert.True(typed!.Value.Typed);
+        Assert.Equal(api, typed.Value.Api);
+        Assert.Equal(ex.Reason, typed.Value.Reason);
+
+        // Untyped path: message text only, which is all a Cecil-injected throw site and the TRX
+        // reader get. It cuts the api from the reason at the first " — ", so no api here may
+        // contain that separator (#2945's Feature Key Modify defect). Note these apis DO carry
+        // a "→", which is not the separator and is safe.
+        Assert.True(OutOfScopeMessage.TryParse(ex.Message, out var parsed));
+        Assert.Equal(api, parsed.Api);
+        Assert.Equal(ex.Reason, parsed.Reason);
+        Assert.DoesNotContain("docs/", parsed.Reason, StringComparison.Ordinal);
+    }
+
+    // ══ 6. The shape cannot drift back ══════════════════════════════════════════════════
+
+    [Fact]
+    public void AllSixteenCorrectedRefusalsStillExist_SoNoneWasDeletedRatherThanCorrected()
+    {
+        // A refusal DELETED rather than corrected means a precondition went back to being read
+        // as a default, which is the failure this whole change is about. Asserted exactly, per
+        // file, so a site that moves between the two files cannot hide in a total — and this is
+        // also what covers the four sites the marker theories cannot address individually,
+        // because two PAIRS of them render identical text (the two "could not be driven live"
+        // branches, and the frozen/live "is not a Boolean" pair).
+        var mock = CodeOf("MockTestPage.cs");
+        var page = CodeOf("RunnerPageInstance.cs");
+
+        Assert.Equal(10, Regex.Matches(mock, @"throw TestPageShapeGap\.").Count);
+        Assert.Equal(1, Regex.Matches(mock, @"throw new AlRunner\.Infrastructure\.BcShapeGapException\(").Count);
+
+        Assert.Equal(4, Regex.Matches(page, @"throw TestPageShapeGap\.").Count);
+        Assert.Equal(1, Regex.Matches(page, @"throw new AlRunner\.Infrastructure\.BcShapeGapException\(").Count);
+    }
+
+    /// <summary>
+    /// The source of the <c>throw</c> statement whose rendered text contains
+    /// <paramref name="marker"/>. Bracketed from the nearest preceding <c>throw</c> to the
+    /// statement's closing <c>);</c>, so the assertion is about ONE refusal rather than about
+    /// the file as a whole.
+    /// </summary>
+    private static string ThrowStatementContaining(string file, string marker)
+    {
+        var code = FlattenedCodeOf(file);
+        var idx = code.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(idx >= 0, $"{file}: no refusal rendering '{marker}' — was it deleted rather than corrected?");
+        var start = code.LastIndexOf("throw ", idx, StringComparison.Ordinal);
+        var end = code.IndexOf(");", idx, StringComparison.Ordinal);
+        Assert.True(start >= 0 && end > start, $"{file}: could not bracket the throw around '{marker}'");
+        return code[start..end];
+    }
+
+    /// <summary>The fourteen corrected sites, by the sentence each one renders.</summary>
+    public static IEnumerable<object[]> CorrectedMarkers() => new[]
+    {
+        new object[] { "MockTestPage.cs", "could not resolve this control to a subpage part" },
+        new object[] { "MockTestPage.cs", "the hosting page was built without an ITreeObject owner" },
+        new object[] { "MockTestPage.cs", "the part's own page could not be driven live" },
+        new object[] { "MockTestPage.cs", "the part's own field this link constrains could not be resolved" },
+        new object[] { "MockTestPage.cs", "must be the parent's field number" },
+        new object[] { "MockTestPage.cs", "nor to a page variable the runner could resolve" },
+        new object[] { "MockTestPage.cs", "bound to an Option with no option metadata" },
+        new object[] { "MockTestPage.cs", "so its OnLookup trigger cannot be reached" },
+        new object[] { "MockTestPage.cs", "so its OnDrillDown trigger cannot be reached" },
+        new object[] { "RunnerPageInstance.cs", "which is not a Boolean" },
+        new object[] { "RunnerPageInstance.cs", "which cannot be evaluated:" },
+        new object[] { "RunnerPageInstance.cs", "the runner cannot tell which trigger belongs to it" },
+    };
+
+    /// <summary>The fourteen #2999 named as permanent, by the sentence each one renders.</summary>
+    public static IEnumerable<object[]> KeptMarkers() => new[]
+    {
+        new object[] { "MockTestPage.cs", "this page has no SourceTable" },
+        new object[] { "MockTestPage.cs", "OnQueryClosePage returned false" },
+        new object[] { "MockTestPage.cs", "so it cannot be used to locate a row" },
+        new object[] { "MockTestPage.cs", "is not an acceptable value" },
+        new object[] { "MockTestPage.cs", "is not one of the option's values" },
+        new object[] { "MockTestPage.cs", "is not the round-trip spelling TestPage" },
+        new object[] { "RunnerPageInstance.cs", "would open the related table's list page" },
+        new object[] { "RunnerPageInstance.cs", "so there is no table-field OnLookup to fall back to" },
+    };
+
+    [Theory]
+    [MemberData(nameof(CorrectedMarkers))]
+    public void CorrectedSite_KeepsItsSentenceAndDropsTheScopeMdClaim(string file, string marker)
+    {
+        // Per-site, not a count: the distinctive text of each corrected refusal must still be
+        // in the file (it was corrected, not deleted) and its own throw must no longer claim
+        // permanence. A count would pass even if a later change swapped WHICH sites carry it.
+        Assert.DoesNotContain("docs/scope.md", ThrowStatementContaining(file, marker), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [MemberData(nameof(KeptMarkers))]
+    public void KeptRefusal_StillClaimsPermanence_SoTheClassificationWasNotQuietlyWidened(string file, string marker)
+    {
+        // CONTROL ARM THREE. #2999 lists the fourteen citations in these same two files that
+        // are genuinely permanent and says explicitly not to sweep them. For these, an AL
+        // [TryFunction] reading `false` IS the observable BC outcome, which is the whole test
+        // for the bucket. A sweep that "fixed" them too fails here.
+        Assert.Contains("docs/scope.md", ThrowStatementContaining(file, marker), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MockTestPage_KeepsExactlyItsSixPermanentCitations()
+    {
+        // Exact, because nothing in flight reclassifies a MockTestPage refusal: six citations
+        // across five throws (the option-value refusal spells the pointer on both branches of
+        // one ternary). Under-sweep and over-sweep both fail.
+        Assert.Equal(6, Regex.Matches(CodeOf("MockTestPage.cs"), "docs/scope\\.md").Count);
+    }
+
+    [Fact]
+    public void RunnerPageInstance_KeepsItsTwoUncontestedPermanentCitations()
+    {
+        // NOT exact, and the reason is recorded rather than hidden: the third permanent
+        // citation in this file is the RunObject action refusal, which #2931 reclassifies as
+        // not-yet-implemented on the strength of a real-service-tier measurement (corpus PR
+        // #172, all 8 BC legs). That site is #2931's to decide and is untouched here, so this
+        // asserts the two lookup refusals #2999 named and allows either outcome for the third.
+        var count = Regex.Matches(CodeOf("RunnerPageInstance.cs"), "docs/scope\\.md").Count;
+        Assert.True(count is 2 or 3,
+            $"expected the 2 TableRelation-lookup citations (+ optionally #2931's RunObject one), found {count}");
+    }
+}

--- a/AlRunner.Tests/TestPageRefusalClaimTests.cs
+++ b/AlRunner.Tests/TestPageRefusalClaimTests.cs
@@ -1,5 +1,5 @@
 // TestPageRefusalClaimTests — what the sixteen corrected TestPage refusals claim, what an AL
-// [TryFunction] does with one, and which fourteen in the same two files must keep claiming
+// [TryFunction] does with one, and which nine in the same two files must keep claiming
 // permanence (#2999).
 //
 // WHY THIS IS A RUNNER-SIDE MECHANISM TEST AND NOT AN AL BUNDLE
@@ -41,9 +41,12 @@
 //     still absorbed into `false`.
 //   * PermanentTestPageRefusal_IsStillCatchableByAssertError — the same, on AL's other seam,
 //     so the BcShapeGapException tear-through cannot pass by "anything unusual tears through".
-//   * KeptRefusals_StillClaimPermanence — the fourteen sites #2999 deliberately excluded were
-//     read and LEFT ALONE. If a later sweep deletes their citation the classification was
-//     wrong, and this fails rather than silently widening the change.
+//   * KeptRefusals_StillClaimPermanence — the sites #2999 deliberately excluded were read and
+//     LEFT ALONE. If a later sweep deletes their citation the classification was wrong, and
+//     this fails rather than silently widening the change. NINE citations, not the fourteen
+//     #2999's prose claims: 25 measured on origin/main minus the 16 gaps it lists by line, and
+//     the issue's own enumeration of the permanent ones lists nine. WHICH sites are permanent
+//     is what matters and the issue has that right; only its total is off.
 
 using System;
 using System.Collections.Generic;
@@ -187,7 +190,7 @@ public sealed class TestPageRefusalClaimTests
 
     /// <summary>
     /// A page with no <c>SourceTable</c> — MockTestPage.RequireRecord. #2999 lists it among the
-    /// fourteen genuinely permanent: BC itself has no record-backed rowset for such a page, so
+    /// genuinely permanent ones: BC itself has no record-backed rowset for such a page, so
     /// an AL [TryFunction] reading `false` is the OBSERVABLE BC OUTCOME rather than a gap.
     /// </summary>
     private static RunnerOutOfScopeException PermanentNoSourceTable() =>
@@ -438,7 +441,12 @@ public sealed class TestPageRefusalClaimTests
         new object[] { "RunnerPageInstance.cs", "the runner cannot tell which trigger belongs to it" },
     };
 
-    /// <summary>The fourteen #2999 named as permanent, by the sentence each one renders.</summary>
+    /// <summary>
+    /// The eight permanent THROWS (nine citations — the option-value refusal spells the pointer
+    /// on both branches of one ternary), by the sentence each one renders. The RunObject action
+    /// is the ninth throw and is deliberately absent: see
+    /// <see cref="RunnerPageInstance_KeepsItsTwoUncontestedPermanentCitations"/>.
+    /// </summary>
     public static IEnumerable<object[]> KeptMarkers() => new[]
     {
         new object[] { "MockTestPage.cs", "this page has no SourceTable" },
@@ -465,8 +473,8 @@ public sealed class TestPageRefusalClaimTests
     [MemberData(nameof(KeptMarkers))]
     public void KeptRefusal_StillClaimsPermanence_SoTheClassificationWasNotQuietlyWidened(string file, string marker)
     {
-        // CONTROL ARM THREE. #2999 lists the fourteen citations in these same two files that
-        // are genuinely permanent and says explicitly not to sweep them. For these, an AL
+        // CONTROL ARM THREE. #2999 lists the citations in these same two files that are
+        // genuinely permanent and says explicitly not to sweep them. For these, an AL
         // [TryFunction] reading `false` IS the observable BC outcome, which is the whole test
         // for the bucket. A sweep that "fixed" them too fails here.
         Assert.Contains("docs/scope.md", ThrowStatementContaining(file, marker), StringComparison.Ordinal);

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -158,8 +158,12 @@ internal class LiveNavTestPage : MockITestPage
     /// </summary>
     protected internal NavRecord RequireRecord(string what)
         => _tornDown ? throw MakeTestPageNotOpenException()
+        // The api carries no " — ": OutOfScopeMessage.TryParse cuts the api from the reason at
+        // the FIRST one, so an api that spells the separator itself makes the untyped recovery
+        // path report "TestPage page 60100" with "New() — testpage-modal-no-source-table — …"
+        // as the reason. Same defect #2945 fixed for Feature Key Modify (#2999).
         : _record ?? throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-            $"TestPage page {_pageId} — {what}",
+            $"TestPage page {_pageId} ({what})",
             "testpage-modal-no-source-table — this page has no SourceTable, so there is no "
             + "record-backed rowset for this operation. Controls bound to page variables are "
             + "supported; row navigation, filtering, Insert/Modify and Rec-bound field access "
@@ -200,23 +204,25 @@ internal class LiveNavTestPage : MockITestPage
         if (Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_PAGE_METADATA") == "1")
             Console.Out.WriteLine($"[MockTestPage.GetPart] controlId={controlId} pageId={_pageId} _page={(_page == null ? "null" : "set")} _page.Form={( _page?.Form == null ? "null" : _page.Form.GetType().FullName)}");
 
+        // BOTH branches are runner gaps, which is why one factory serves them. The second one
+        // reads like an AL-authoring error and is not: the AL compiler resolves a part by NAME
+        // and emits its control id, so an id that reaches here always named a real part on the
+        // real page. Finding no part for it means the runner's page metadata is incomplete.
         var definition = _page?.TryGetPartDefinition(controlId)
-            ?? throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            ?? throw TestPageShapeGap.Part(
                 $"TestPage part {controlId} (page {_pageId})",
-                "testpage-part — the runner could not resolve this control to a subpage part"
+                "the runner could not resolve this control to a subpage part"
                 + (_page == null
                     ? "; no AL page object was built for the hosting page, so its part definitions "
                       + "are unavailable — see AlPageMetadataRegistry"
-                    : "; the hosting page's metadata declares no part with this control id")
-                + ". See docs/scope.md");
+                    : "; the hosting page's metadata declares no part with this control id"));
 
         var partPageId = definition.PagePartID;
         if (_owner == null)
-            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            throw TestPageShapeGap.Part(
                 $"TestPage part {controlId} → page {partPageId}",
-                "testpage-part — the hosting page was built without an ITreeObject owner, so "
-                + "the runner has nothing to construct the part's own page under. "
-                + "See docs/scope.md");
+                "the hosting page was built without an ITreeObject owner, so the runner has "
+                + "nothing to construct the part's own page under");
 
         var built = TestPageFactory.TryBuild(_owner, partPageId, out var why);
 
@@ -293,19 +299,15 @@ internal class LiveNavTestPage : MockITestPage
             adopted = fromHost != null;
             partPage = fromHost ?? TestPageFactory.TryBuildRecordless(_owner, partPageId);
             if (partPage == null)
-                throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                throw TestPageShapeGap.Part(
                     $"TestPage part {controlId} → page {partPageId}",
-                    "testpage-part — the part's own page could not be driven live"
-                    + (why == null ? string.Empty : $" ({why})")
-                    + ". See docs/scope.md");
+                    PartNotLive(why));
         }
         else
         {
-            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            throw TestPageShapeGap.Part(
                 $"TestPage part {controlId} → page {partPageId}",
-                "testpage-part — the part's own page could not be driven live"
-                + (why == null ? string.Empty : $" ({why})")
-                + ". See docs/scope.md");
+                PartNotLive(why));
         }
 
         // The parent record is only needed to evaluate FIELD SubPageLink pairs (issue #2053).
@@ -518,25 +520,40 @@ internal class LiveNavTestPage : MockITestPage
     /// than filtering on no field: an unfiltered part shows other rows' children, which is a
     /// wrong answer, not a missing one.
     /// </summary>
+    /// <summary>
+    /// The detail both "could not be driven live" refusals report. They are ONE shape reached
+    /// down two branches — the recordless path and the fall-through — and they carried
+    /// byte-identical reason text written out twice, so the same gap could drift into claiming
+    /// two different things depending on which branch found it (#2999).
+    /// </summary>
+    private static string PartNotLive(string? why)
+        => "the part's own page could not be driven live" + (why == null ? string.Empty : $" ({why})");
+
     private static SubPageLinkEntry[] SubPageLinks(
         Microsoft.Dynamics.Nav.Types.Metadata.InfopartPageDefinition definition, int partPageId)
     {
         var links = new List<SubPageLinkEntry>();
         foreach (var link in definition.SubFormLink ?? new List<Microsoft.Dynamics.Nav.Types.Metadata.FilterDefinition>())
         {
+            // Both of these are RUNNER gaps, not BC-shape gaps, and the distinction is measured
+            // rather than assumed: DependencyPageMetadataXml.EmitSubFormLinkXml DELIBERATELY
+            // writes FieldID 0 and a non-numeric FilterValue when it cannot resolve a field
+            // NAME to an id, precisely so these two refusals fire. The read succeeded; the
+            // answer is about the runner's own metadata reconstruction, which is the line
+            // BcShapeGapException draws (#2995).
             if (link.FieldID <= 0)
-                throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                throw TestPageShapeGap.PartLink(
                     $"TestPage part → page {partPageId} SubPageLink ({link.FilterType})",
-                    $"testpage-part-link — the part's own field this link constrains could not be resolved "
-                    + $"(FieldID {link.FieldID}, {link.FilterType} '{link.FilterValue}'). See docs/scope.md");
+                    $"the part's own field this link constrains could not be resolved "
+                    + $"(FieldID {link.FieldID}, {link.FilterType} '{link.FilterValue}')");
             switch (link.FilterType)
             {
                 case Microsoft.Dynamics.Nav.Types.Metadata.FilterType.FIELD:
                     if (!int.TryParse(link.FilterValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parentFieldNo))
-                        throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                        throw TestPageShapeGap.PartLink(
                             $"TestPage part → page {partPageId} SubPageLink",
-                            $"testpage-part-link — a FIELD link's value must be the parent's field number, "
-                            + $"but this one is '{link.FilterValue}'. See docs/scope.md");
+                            $"a FIELD link's value must be the parent's field number, "
+                            + $"but this one is '{link.FilterValue}'");
                     links.Add(new SubPageLinkEntry(link.FieldID, link.FilterType, parentFieldNo, string.Empty));
                     break;
                 case Microsoft.Dynamics.Nav.Types.Metadata.FilterType.CONST:
@@ -544,13 +561,22 @@ internal class LiveNavTestPage : MockITestPage
                     links.Add(new SubPageLinkEntry(link.FieldID, link.FilterType, 0, link.FilterValue ?? string.Empty));
                     break;
                 default:
-                    // FilterType has exactly FIELD/CONST/FILTER (Types.dll 27.5–28.x). A new
-                    // member in a future BC would land here: refuse by name rather than treat
+                    // A BC SHAPE GAP, not a scope claim and not a runner gap — the one site in
+                    // this file where the runner READ BC's own metadata and could not interpret
+                    // what it held (#2946/#2995). FilterType has exactly FIELD/CONST/FILTER:
+                    // measured on BC 28.1's Microsoft.Dynamics.Nav.Types.dll, and the runner's
+                    // own EmitSubFormLinkXml writes only those three spellings, so a fourth
+                    // value can ONLY have come from BC's compiled page metadata. That makes it a
+                    // property of which BC build is on disk — it could be true on one matrix leg
+                    // and false on another in the same run — which is exactly what may not be
+                    // declarable as an expected out-of-scope surface. Refuse rather than treat
                     // it as one of the three and filter wrongly.
-                    throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                        $"TestPage part → page {partPageId} SubPageLink ({link.FilterType})",
-                        $"testpage-part-link — SubPageLink kind {link.FilterType} is not one of FIELD/CONST/FILTER; "
-                        + $"this part links field {link.FieldID} by {link.FilterType} '{link.FilterValue}'. See docs/scope.md");
+                    throw new AlRunner.Infrastructure.BcShapeGapException(
+                        $"TestPage part → page {partPageId} SubPageLink",
+                        "Microsoft.Dynamics.Nav.Types.Metadata.FilterType",
+                        $"holds {link.FilterType}, which is not one of FIELD/CONST/FILTER; this part "
+                        + $"links field {link.FieldID} by {link.FilterType} '{link.FilterValue}', and "
+                        + "filtering it as any of the three would show the wrong rows rather than none");
             }
         }
         return links.ToArray();
@@ -1218,7 +1244,10 @@ internal class LiveNavTestPage : MockITestPage
         // alternatives — closing anyway hides that the page objected, and hanging is worse.
         if (_page != null && !_page.RaiseOnClosePage(_formResult))
             throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                $"TestPage page {_pageId} — OnQueryClosePage",
+                // No " — " in the api — see RequireRecord. The CLAIM is unchanged and stays a
+                // permanent scope boundary (#2999 lists it among the fourteen): BC leaves the
+                // page open awaiting a user, so a [TryFunction] reading false is BC's outcome.
+                $"TestPage page {_pageId} (OnQueryClosePage)",
                 "testpage-close-veto — the page's OnQueryClosePage returned false, which in BC "
                 + "leaves the page open awaiting the user. See docs/scope.md");
         FlushParts(); FlushRow(); _opened = false;
@@ -1288,16 +1317,16 @@ internal class LiveNavTestPage : MockITestPage
         // produced "The supplied field number '<hash>' cannot be found in the '<table>'
         // table" — a control-name hash reported as a missing field, blaming the table for
         // the runner's own inability to resolve the control. Say what actually happened.
-        throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+        throw TestPageShapeGap.ControlBinding(
             $"TestPage control {id}",
-            "testpage-control-binding — this control is bound neither to a field of the page's "
+            "this control is bound neither to a field of the page's "
             + $"source table nor to a page variable the runner could resolve (table "
             + $"{_record?.MetaTable?.TableName ?? "?"}"
             + (_page == null
                 ? "; no AL page object was built for this page, so page-variable-bound controls "
                   + "cannot be resolved — see AlPageMetadataRegistry"
                 : "; the page object has no source expression for this control id")
-            + "). See docs/scope.md");
+            + ")");
     }
 
     // Every cursor move leaves the in-progress new row, so it must be persisted first —
@@ -1766,10 +1795,10 @@ internal static class TestPageOptionValue
     internal static NavValue Resolve(NavOption current, string value, string[]? captions, string context)
     {
         var metadata = current.NavOptionMetadata
-            ?? throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            ?? throw TestPageShapeGap.OptionValue(
                 context,
-                "testpage-option-value — the control is bound to an Option with no option "
-                + "metadata, so a value cannot be resolved by name. See docs/scope.md");
+                "the control is bound to an Option with no option metadata, so a value cannot "
+                + "be resolved by name");
 
         var options = Members(metadata);
         var ordinals = Ordinals(metadata);
@@ -2434,10 +2463,10 @@ internal sealed class LiveNavTestField : ITestField
     public void Lookup()
     {
         if (_page == null)
-            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            throw TestPageShapeGap.Lookup(
                 $"TestPage lookup on field {_fieldNo}",
-                "testpage-lookup — no AL page object was built for this page, so its OnLookup "
-                + "trigger cannot be reached. See docs/scope.md");
+                "no AL page object was built for this page, so its OnLookup trigger cannot be "
+                + "reached");
 
         // BC's contract: the trigger writes the selection back and returns true; a false
         // return means the user cancelled and the field keeps its value.
@@ -2464,10 +2493,10 @@ internal sealed class LiveNavTestField : ITestField
     public void Drilldown()
     {
         if (_page == null)
-            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            throw TestPageShapeGap.DrillDown(
                 $"TestPage drilldown on field {_fieldNo}",
-                "testpage-drilldown — no AL page object was built for this page, so its "
-                + "OnDrillDown trigger cannot be reached. See docs/scope.md");
+                "no AL page object was built for this page, so its OnDrillDown trigger cannot "
+                + "be reached");
 
         _page.RaiseOnDrillDown(_controlId);
     }

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -774,13 +774,16 @@ internal sealed class RunnerPageInstance
         // The whole property text as one registered name. This is the shape a bare page global
         // takes, it is by far the most common one, and taking it first means the parser below
         // never sees a name whose own spelling happens to contain grammar characters.
+        // The api carries no " — ": OutOfScopeMessage.TryParse cuts the api from the reason at
+        // the FIRST one, so "TestPage page N element M — Visible" made the untyped recovery path
+        // report the api as "TestPage page N element M" and fold "Visible" into the reason. Same
+        // defect #2945 fixed for Feature Key Modify, live at all three sites here (#2999).
         if (atOpen && _expressionValuesAtOpen.TryGetValue(raw, out var frozen))
             return frozen is bool fb
                 ? fb
-                : throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                    $"TestPage page {_pageId} element {elementId} — {propertyName}",
-                    $"testpage-control-property — expression '{raw}' evaluated to "
-                    + $"'{frozen ?? "null"}', which is not a Boolean. See docs/scope.md");
+                : throw TestPageShapeGap.ControlProperty(
+                    $"TestPage {propertyName} on page {_pageId} element {elementId}",
+                    $"expression '{raw}' evaluated to '{frozen ?? "null"}', which is not a Boolean");
 
         var expression = _sourceExpressions[raw];
         if (expression != null)
@@ -788,10 +791,10 @@ internal sealed class RunnerPageInstance
             var direct = GetValue(expression);
             return direct?.ClientObject is bool db
                 ? db
-                : throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                    $"TestPage page {_pageId} element {elementId} — {propertyName}",
-                    $"testpage-control-property — expression '{raw}' evaluated to "
-                    + $"'{direct?.ClientObject ?? "null"}', which is not a Boolean. See docs/scope.md");
+                : throw TestPageShapeGap.ControlProperty(
+                    $"TestPage {propertyName} on page {_pageId} element {elementId}",
+                    $"expression '{raw}' evaluated to '{direct?.ClientObject ?? "null"}', "
+                    + "which is not a Boolean");
         }
 
         // Not one bare name, so it is an expression: `not Flag`, `A and B`, `Value <> ''`. The
@@ -807,10 +810,9 @@ internal sealed class RunnerPageInstance
         // Loudly, not true-by-default: this property IS the page's read-only contract, and
         // answering "editable" for one we could not evaluate makes every test of that contract
         // unfailable. Naming the expression and what went wrong is what makes the gap fixable.
-        throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-            $"TestPage page {_pageId} element {elementId} — {propertyName}",
-            $"testpage-control-property — the property is bound to expression '{raw}', which "
-            + $"cannot be evaluated: {why}. See docs/scope.md");
+        throw TestPageShapeGap.ControlProperty(
+            $"TestPage {propertyName} on page {_pageId} element {elementId}",
+            $"the property is bound to expression '{raw}', which cannot be evaluated: {why}");
     }
 
     /// <summary>
@@ -1245,17 +1247,25 @@ internal sealed class RunnerPageInstance
 
         var has = AlRunner.Patches.RecordPatches.TryHasFieldLookupTrigger(sourceRecord, sourceFieldNo);
 
-        // Undeterminable is its own outcome, with its own message. Saying "neither declares an
+        // Undeterminable is its own outcome, with its own TYPE. Saying "neither declares an
         // OnLookup trigger" when the real reason is that BC's metafield shape moved under our
         // reflection would send the reader to look at their AL, where there is nothing to find.
+        //
+        // A BC SHAPE GAP, not a scope claim (#2946/#2995). This site's own text already said
+        // "This is a runner/BC-shape problem, not a problem with the AL under test" while
+        // raising a permanence claim about scope. TryHasFieldLookupTrigger is three-valued on
+        // purpose and returns null ONLY when EnsureFieldTriggerReflection could not resolve BC's
+        // private backing fields, or the reflection threw — a read that SUCCEEDS and says the
+        // field declares no trigger returns false and lands on the permanent refusal below.
+        // That is exactly the line: the read could not be performed, versus the read succeeded
+        // and the answer was unwelcome.
         if (has == null)
-            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            throw new AlRunner.Infrastructure.BcShapeGapException(
                 $"TestPage lookup on control {controlId} (page {_pageId})",
-                $"testpage-lookup — the control declares no OnLookup trigger, and whether field "
-                + $"{sourceFieldNo} of its source table declares one could not be determined on this "
-                + "BC build (RecordPatches.TryHasFieldLookupTrigger could not read BC's field-trigger "
-                + "metadata). This is a runner/BC-shape problem, not a problem with the AL under test. "
-                + "See docs/scope.md");
+                "NCLMetaField.EventTriggerDataValue / EventTriggerData.LookupHandler",
+                $"could not determine whether field {sourceFieldNo} of the source table declares "
+                + "an OnLookup trigger on this BC build, so the runner cannot tell a field with a "
+                + "table trigger from one whose lookup comes from a TableRelation");
 
         if (has != true)
             throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
@@ -1785,12 +1795,16 @@ internal sealed class RunnerPageInstance
             }
             else if (MemberId(declaringObjectId, memberName) != memberId) continue;
 
+            // A runner gap, not a BC-shape gap: the collision is in the RUNNER's own name→id
+            // hash over emitted method names, not in anything BC's metadata states. The anchor
+            // stays per-surface (testpage-onlookup / -onaction / …) so the four callers of this
+            // one method remain distinguishable to a reader.
             if (match != null)
-                throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                throw TestPageShapeGap.TriggerAmbiguity(
                     $"TestPage {surface} (member {memberId})",
-                    $"testpage-{surface.ToLowerInvariant()} — both '{match.Name}' and '{m.Name}' on "
-                    + $"{target.GetType().Name} resolve to member {memberId}; the runner cannot "
-                    + "tell which trigger belongs to it. See docs/scope.md");
+                    $"testpage-{surface.ToLowerInvariant()}",
+                    $"both '{match.Name}' and '{m.Name}' on {target.GetType().Name} resolve to "
+                    + $"member {memberId}; the runner cannot tell which trigger belongs to it");
             match = m;
         }
         return match == null ? null : new TriggerMatch(target, match);

--- a/AlRunner/Patches/TestPageShapeGaps.cs
+++ b/AlRunner/Patches/TestPageShapeGaps.cs
@@ -1,0 +1,237 @@
+// TestPageShapeGaps — the sixteen TestPage refusals in MockTestPage.cs and RunnerPageInstance.cs
+// that were claiming a permanent scope boundary for a runner gap, and the per-site
+// classification behind each of the twenty-five citations in those two files (#2999).
+//
+// ── WHAT WAS WRONG ───────────────────────────────────────────────────────────────────────
+//   #2894 fixed twelve of these in RecordPatches.ObjectMetadataSystemTable.cs, #2945 fixed 55
+//   across the virtual-table populators, and #2966/#3001 classified the remaining 77 sites
+//   elsewhere under AlRunner/ and corrected 27. It deliberately left these two files alone,
+//   because in-flight TestPage work was editing both and a factory sweep would have collided.
+//   #2999 is that deferral coming due, and it is deliberately narrow: it lists the sixteen
+//   gaps by line AND the fourteen citations in the same two files that are genuinely
+//   permanent, so the follow-up cannot over-sweep.
+//
+//   docs/scope.md is the manifest of what is PERMANENTLY out of scope. Citing it for a surface
+//   the runner intends to support tells the next developer to stop looking, and it has a
+//   RUNTIME consequence, which is why this is a correctness fix and not a wording one.
+//   ApplicationObjectBasePatches.IsPermanentOutOfScope:
+//
+//       return oos != null && !oos.Reason.StartsWith("not-yet-implemented", StringComparison.Ordinal);
+//
+//   Under a docs/scope.md anchor that returns TRUE, so an AL [TryFunction] traps a runner
+//   shape gap into `false` — the silent default .claude/rules/loud-failures.md exists to
+//   prevent — and the test goes green having quietly done without the surface.
+//
+//   TestPage work has a SECOND and sharper seam, and it is the reason two of these sixteen
+//   are a different type entirely. `asserterror Foo()` where Foo reaches one of these: on real
+//   BC, Foo runs and returns, so the asserterror FAILS ("expected an error"). If the runner
+//   absorbs the gap the asserterror PASSES. That does not hide a result, it INVERTS one.
+//
+// ── THE THREE BUCKETS, AND WHAT LANDED IN EACH ───────────────────────────────────────────
+//   The same buckets #2894, #2945 and #2966 used. A refusal belongs in (1) only when BC ITSELF
+//   cannot answer, so that an AL [TryFunction] reading `false` is the OBSERVABLE BC OUTCOME
+//   rather than a runner gap quietly absorbed.
+//
+//     (1) genuinely out of scope — keep the refusal and the scope.md link .......... 14
+//     (2) in scope, not yet answerable — needs the "not-yet-implemented" anchor .... 14
+//     (2b) in scope, implemented, but BC's own internals could not be READ ......... 2
+//     (3) deliberate divergence — the runner answers on purpose, never throws ...... 0
+//                                                                                  ----
+//                                                                                    30
+//
+//   Thirty citations, not twenty-five, because two of the fourteen kept ones are the two
+//   branches of a single ternary and are counted here per claim rather than per string.
+//
+//   NOTHING landed in (3), and that is structural rather than an oversight — #3001 found zero
+//   for the same reason. An expect-divergence surface RETURNS AN ANSWER rather than throwing
+//   (docs/expectations.md), so by construction a refusal site cannot be one.
+//
+//   (2b) is #2995's BcShapeGapException, and its rule is narrow: raise it when the read COULD
+//   NOT BE PERFORMED, never when the read succeeded and the answer was merely unwelcome. Two
+//   of the sixteen meet that bar and the other fourteen do not — see the tables below, where
+//   the two SubPageLink siblings that look like they qualify are shown not to.
+//
+// ── (2), CORRECTED HERE: fourteen sites ──────────────────────────────────────────────────
+//
+//   MockTestPage.cs — ten. Every one is the runner failing to build or resolve something it
+//   owns; real BC has a page object, an owner and a control binding for all of them.
+//     GetPart, no part definition ... no AL page object was built for the hosting page, so its
+//                                     part definitions are unavailable (or the built page's
+//                                     metadata declares no part with this control id — also
+//                                     the runner's, since the AL COMPILER resolved the part by
+//                                     name before a control id ever reached here).
+//     GetPart, no owner ............. the hosting page was built without an ITreeObject owner.
+//                                     A runner internal with no BC counterpart to decline.
+//     GetPart, not live (x2) ........ the part's own page could not be driven live. TWO throw
+//                                     sites with byte-identical reason text, on the recordless
+//                                     branch and on the fall-through — one shape that claimed
+//                                     itself twice, now built in one place.
+//     SubPageLinks, FieldID <= 0 .... the part's own field this link constrains could not be
+//                                     resolved. NOT a BC-shape gap: the 0 is written by the
+//                                     runner's OWN DependencyPageMetadataXml.EmitSubFormLinkXml
+//                                     when it cannot resolve the part field NAME to an id.
+//     SubPageLinks, FIELD value ..... a FIELD link's value is not the parent's field number.
+//                                     NOT a BC-shape gap either, and for the same reason: that
+//                                     same emitter deliberately writes the unresolved field
+//                                     NAME here precisely so this refusal fires. The read
+//                                     succeeded; the answer is about the RUNNER's metadata
+//                                     reconstruction, which is the line #2995 draws.
+//     ControlIdToField, unresolved .. bound neither to a source-table field nor to a page
+//                                     variable the runner could resolve.
+//     TestPageOptionValue.Resolve ... the control is bound to an Option carrying no option
+//                                     metadata, so a value cannot be resolved by name.
+//     Lookup / Drilldown ............ no AL page object was built for this page, so its
+//                                     OnLookup / OnDrillDown trigger cannot be reached.
+//
+//   RunnerPageInstance.cs — four.
+//     EvaluateProperty (x3) ......... a frozen-at-open expression, a live expression, and an
+//                                     expression the parser could not evaluate at all. Real BC
+//                                     evaluates every AL Boolean property expression; these are
+//                                     shapes the runner's own evaluator does not take yet
+//                                     (#2596 tracks one of them). The two "not a Boolean" sites
+//                                     are again one shape with two throw sites.
+//     FindTriggerOnTarget ........... two emitted methods on one object hash to the same member
+//                                     id. The collision is in the RUNNER's own name→id hash
+//                                     over emitted method names, not in anything BC states.
+//
+// ── (2b), NOW BcShapeGapException: two sites ─────────────────────────────────────────────
+//   Both meet #2995's test — the runner could not perform the read at all:
+//
+//   MockTestPage.SubPageLinks, unknown FilterType.
+//     Reached only when BC's own Microsoft.Dynamics.Nav.Types.Metadata.FilterType holds a
+//     member outside FIELD/CONST/FILTER. MEASURED on BC 28.1's Microsoft.Dynamics.Nav.Types.dll
+//     (System.Reflection.Metadata dump of the enum's static fields): exactly CONST, FILTER,
+//     FIELD. And the runner's own emitter writes only those three spellings, so a fourth value
+//     can ONLY have come from BC's compiled metadata. That makes it a property of which BC
+//     build is on disk — true on one leg and false on another in the same run — which is
+//     exactly the case #2995 says must not be declarable as an expected scope boundary.
+//
+//   RunnerPageInstance.RaiseSourceFieldOnLookup, undeterminable field trigger.
+//     RecordPatches.TryHasFieldLookupTrigger is three-valued ON PURPOSE, and it returns null
+//     ONLY when EnsureFieldTriggerReflection could not resolve BC's private
+//     NCLMetaField.<EventTriggerDataValue>k__BackingField / EventTriggerData.<LookupHandler>
+//     k__BackingField, or the reflection threw. A successful read that says "no trigger"
+//     returns false and lands on the PERMANENT refusal below instead. The site's own comment
+//     already said "This is a runner/BC-shape problem, not a problem with the AL under test" —
+//     it was describing a BcShapeGapException while raising a scope claim.
+//
+// ── (1), LEFT ALONE: fourteen citations that really are permanent ────────────────────────
+//   Read and kept, exactly as #2999 requires. Per file, so the next reader does not re-derive:
+//
+//     MockTestPage.cs (6 citations / 5 throws)
+//       * a page with no SourceTable (the StandardDialog shape) — BC has no record-backed
+//         rowset for one either, so `false` is BC's own answer;
+//       * an OnQueryClosePage veto, which in BC leaves the page open awaiting a user (§3.11);
+//       * a control not bound to a source-table field, used to LOCATE A ROW;
+//       * three AL-AUTHORING errors real BC also raises — an option value that is neither a
+//         member nor a caption (two branches of one ternary, hence 6 citations over 5 throws),
+//         and a date spelling TestPage SetValue never produces.
+//
+//     RunnerPageInstance.cs (3 citations, of which 2 are #2999's and the third is contested)
+//       * two lookups that come from a TableRelation and would open the related table's list
+//         page — §3.11 client interaction, and pinned from AL by
+//         tests/runner-extras/testpage-lookup-tablerelation-oos;
+//       * an action whose effect is RunObject. #2999 lists this among the permanent fourteen,
+//         but #2931 (PR #2951, in flight) RECLASSIFIES it as not-yet-implemented on the
+//         strength of a real-service-tier measurement — corpus PR
+//         StefanMaron/BusinessCentral.AL.Language.Tests#172 invoked a RunObject action on a
+//         TestPage across all 8 BC legs and it opened nothing and raised nothing. A measured
+//         verdict outranks a classification made by reading (see
+//         .claude/rules/ask-the-corpus-before-claiming-bc-behavior.md), so that site is #2931's
+//         to decide and is UNTOUCHED here. The test for this file allows either outcome for it
+//         and pins the two lookups exactly.
+//
+// ── A SIBLING DEFECT FOUND AND NOT FIXED HERE ────────────────────────────────────────────
+//   The (2b) site above refuses loudly when _fLookupHandlerBacking / _fValidateHandlerBacking
+//   could not be resolved. The WRITE path over the same two fields does the opposite:
+//   RecordPatches.NclMetaTableBuilder.cs guards every handler install with
+//   `&& _fValidateHandlerBacking != null` (and the lookup equivalent), so on a BC build whose
+//   layout moved the field trigger is SILENTLY NEVER INSTALLED and the AL that depends on it
+//   runs with no trigger at all. Two code paths over one piece of state, one refusing and one
+//   defaulting. Filed rather than folded in, because it changes trigger installation and needs
+//   its own RED → GREEN — see the issue linked from the PR that landed this file.
+//
+// ── WHY THE DOC LINK MOVED ───────────────────────────────────────────────────────────────
+//   docs/limitations.md#testpage-shape-gaps, not docs/scope.md. scope.md documents permanent
+//   boundaries and has nothing to say about any of these; sending a reader there asserted a
+//   permanence that is not true AND gave them no section to read. Several of these sites also
+//   rendered the pointer twice ("… See docs/scope.md — see docs/scope.md", #2766/#2931),
+//   because they spelled it in the reason while BuildMessage appends its own. Passing the link
+//   as the docAnchor argument instead removes that as a consequence rather than as a sweep.
+//
+//   No classification moves as a result. ExpectationManifest.ReasonAnchor cuts at the first
+//   em-dash, so the anchor these report goes from e.g. "testpage-lookup" to
+//   "not-yet-implemented"; no manifest entry matches on any of them. The four entries in
+//   tests/expectations/known-gaps-testpage-control-property.json match on
+//   (CodeunitName, Method) under Mode=expect-fail-known-gap, which means "must fail" — and a
+//   not-yet-implemented refusal still fails. The AL suite that DOES assert on one of these
+//   anchors, tests/runner-extras/testpage-lookup-tablerelation-oos, drives a PERMANENT site
+//   that is untouched.
+
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Patches;
+
+/// <summary>
+/// One factory per corrected TestPage surface, so a refusal cannot drift back to claiming a
+/// permanent scope boundary one call site at a time. See this file's header for the per-site
+/// classification of all thirty citations in <c>MockTestPage.cs</c> and
+/// <c>RunnerPageInstance.cs</c>, <see cref="RunnerShapeGap"/> for the same shape applied
+/// outside the TestPage surface (#2966), and
+/// <see cref="AlRunner.Infrastructure.BcShapeGapException"/> for the two sites here that are
+/// not scope claims at all.
+/// </summary>
+internal static class TestPageShapeGap
+{
+    /// <summary>Where a reader should look for these gaps. NOT docs/scope.md.</summary>
+    internal const string Doc = "docs/limitations.md#testpage-shape-gaps";
+
+    /// <summary>
+    /// The one place these refusals are built. The surface's own anchor is kept as the second
+    /// token of the reason so the surfaces stay distinguishable to a reader and to any future
+    /// expectations entry, exactly as <see cref="RunnerShapeGap"/> and
+    /// <c>RecordPatches.VirtualTableShapeGap</c> do.
+    /// </summary>
+    /// <param name="api">The AL-visible surface the test touched. Must not contain " — ":
+    /// OutOfScopeMessage.TryParse cuts the api from the reason at the first one (#2945).</param>
+    /// <param name="surface">The surface's own anchor, e.g. "testpage-part".</param>
+    /// <param name="detail">What was actually missing.</param>
+    private static RunnerOutOfScopeException Build(string api, string surface, string detail)
+        => new(api, $"not-yet-implemented — {surface}: {detail}", Doc);
+
+    /// <summary>A subpage part the runner could not resolve, own, or drive live.</summary>
+    internal static RunnerOutOfScopeException Part(string api, string detail)
+        => Build(api, "testpage-part", detail);
+
+    /// <summary>A SubPageLink entry whose fields the runner's own metadata could not resolve.</summary>
+    internal static RunnerOutOfScopeException PartLink(string api, string detail)
+        => Build(api, "testpage-part-link", detail);
+
+    /// <summary>A control the runner could not bind to a source-table field or a page variable.</summary>
+    internal static RunnerOutOfScopeException ControlBinding(string api, string detail)
+        => Build(api, "testpage-control-binding", detail);
+
+    /// <summary>A Visible/Editable/Enabled expression the runner's evaluator could not answer.</summary>
+    internal static RunnerOutOfScopeException ControlProperty(string api, string detail)
+        => Build(api, "testpage-control-property", detail);
+
+    /// <summary>An Option-bound control the runner could not resolve a value by name for.</summary>
+    internal static RunnerOutOfScopeException OptionValue(string api, string detail)
+        => Build(api, "testpage-option-value", detail);
+
+    /// <summary>An OnLookup trigger the runner could not reach.</summary>
+    internal static RunnerOutOfScopeException Lookup(string api, string detail)
+        => Build(api, "testpage-lookup", detail);
+
+    /// <summary>An OnDrillDown trigger the runner could not reach.</summary>
+    internal static RunnerOutOfScopeException DrillDown(string api, string detail)
+        => Build(api, "testpage-drilldown", detail);
+
+    /// <summary>
+    /// Two emitted methods on one object resolving to a single member id. The surface is passed
+    /// in because the caller serves OnValidate, OnAction, OnLookup and OnDrillDown from one
+    /// method and the anchor names which one was being resolved.
+    /// </summary>
+    internal static RunnerOutOfScopeException TriggerAmbiguity(string api, string surface, string detail)
+        => Build(api, surface, detail);
+}

--- a/AlRunner/Patches/TestPageShapeGaps.cs
+++ b/AlRunner/Patches/TestPageShapeGaps.cs
@@ -8,8 +8,8 @@
 //   elsewhere under AlRunner/ and corrected 27. It deliberately left these two files alone,
 //   because in-flight TestPage work was editing both and a factory sweep would have collided.
 //   #2999 is that deferral coming due, and it is deliberately narrow: it lists the sixteen
-//   gaps by line AND the fourteen citations in the same two files that are genuinely
-//   permanent, so the follow-up cannot over-sweep.
+//   gaps by line AND the citations in the same two files that are genuinely permanent, so the
+//   follow-up cannot over-sweep.
 //
 //   docs/scope.md is the manifest of what is PERMANENTLY out of scope. Citing it for a surface
 //   the runner intends to support tells the next developer to stop looking, and it has a
@@ -32,15 +32,20 @@
 //   cannot answer, so that an AL [TryFunction] reading `false` is the OBSERVABLE BC OUTCOME
 //   rather than a runner gap quietly absorbed.
 //
-//     (1) genuinely out of scope — keep the refusal and the scope.md link .......... 14
+//     (1) genuinely out of scope — keep the refusal and the scope.md link ..........  9
 //     (2) in scope, not yet answerable — needs the "not-yet-implemented" anchor .... 14
-//     (2b) in scope, implemented, but BC's own internals could not be READ ......... 2
-//     (3) deliberate divergence — the runner answers on purpose, never throws ...... 0
-//                                                                                  ----
-//                                                                                    30
+//     (2b) in scope, implemented, but BC's own internals could not be READ .........  2
+//     (3) deliberate divergence — the runner answers on purpose, never throws ......  0
+//                                                                                   ----
+//                                                                                     25
 //
-//   Thirty citations, not twenty-five, because two of the fourteen kept ones are the two
-//   branches of a single ternary and are counted here per claim rather than per string.
+//   NINE KEPT, NOT FOURTEEN. #2999's prose says "the other fourteen citations", but its own
+//   enumeration of them lists nine, and nine is what the files hold: 25 citations measured on
+//   origin/main (17 in MockTestPage.cs, 8 in RunnerPageInstance.cs) minus the 16 gaps it lists
+//   by line. The number used here is the measured one; the issue's list of WHICH sites are
+//   permanent is correct and is what this change respects. Those nine citations sit on eight
+//   throws, because the option-value refusal spells the pointer on both branches of one
+//   ternary.
 //
 //   NOTHING landed in (3), and that is structural rather than an oversight — #3001 found zero
 //   for the same reason. An expect-divergence surface RETURNS AN ANSWER rather than throwing
@@ -115,7 +120,7 @@
 //     already said "This is a runner/BC-shape problem, not a problem with the AL under test" —
 //     it was describing a BcShapeGapException while raising a scope claim.
 //
-// ── (1), LEFT ALONE: fourteen citations that really are permanent ────────────────────────
+// ── (1), LEFT ALONE: nine citations that really are permanent ────────────────────────────
 //   Read and kept, exactly as #2999 requires. Per file, so the next reader does not re-derive:
 //
 //     MockTestPage.cs (6 citations / 5 throws)
@@ -127,11 +132,11 @@
 //         member nor a caption (two branches of one ternary, hence 6 citations over 5 throws),
 //         and a date spelling TestPage SetValue never produces.
 //
-//     RunnerPageInstance.cs (3 citations, of which 2 are #2999's and the third is contested)
+//     RunnerPageInstance.cs (3 citations, of which 2 are uncontested and the third is not)
 //       * two lookups that come from a TableRelation and would open the related table's list
 //         page — §3.11 client interaction, and pinned from AL by
 //         tests/runner-extras/testpage-lookup-tablerelation-oos;
-//       * an action whose effect is RunObject. #2999 lists this among the permanent fourteen,
+//       * an action whose effect is RunObject. #2999 lists this among the permanent ones,
 //         but #2931 (PR #2951, in flight) RECLASSIFIES it as not-yet-implemented on the
 //         strength of a real-service-tier measurement — corpus PR
 //         StefanMaron/BusinessCentral.AL.Language.Tests#172 invoked a RunObject action on a
@@ -147,9 +152,10 @@
 //   RecordPatches.NclMetaTableBuilder.cs guards every handler install with
 //   `&& _fValidateHandlerBacking != null` (and the lookup equivalent), so on a BC build whose
 //   layout moved the field trigger is SILENTLY NEVER INSTALLED and the AL that depends on it
-//   runs with no trigger at all. Two code paths over one piece of state, one refusing and one
-//   defaulting. Filed rather than folded in, because it changes trigger installation and needs
-//   its own RED → GREEN — see the issue linked from the PR that landed this file.
+//   runs with no trigger at all — and WireFieldTriggerHandlers still returns true. Two code
+//   paths over one piece of state, one refusing and one defaulting. Filed as #3026 rather than
+//   folded in, because it changes trigger INSTALLATION rather than refusal wording and needs
+//   its own RED → GREEN. Not reachable on 27.0–28.4, where both members resolve.
 //
 // ── WHY THE DOC LINK MOVED ───────────────────────────────────────────────────────────────
 //   docs/limitations.md#testpage-shape-gaps, not docs/scope.md. scope.md documents permanent

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -962,7 +962,7 @@ https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues.
 
   Real BC drives every one of these, so each is the runner failing to keep up rather than a
   surface BC also lacks — which is the test for whether a refusal may cite `docs/scope.md` at
-  all. Fourteen further refusals in those same two files genuinely are permanent and keep their
+  all. Eight further refusals in those same two files genuinely are permanent and keep their
   `docs/scope.md` citation: a page with no `SourceTable`, an `OnQueryClosePage` veto, a lookup
   that could only come from a `TableRelation`, and the AL-authoring errors real BC also raises.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -899,6 +899,19 @@ because four readers of one private BC structure raised three different exceptio
 them. `AlRunner/Infrastructure/BcShapeGapException.cs` carries the full derivation, including
 why it is a separate type rather than a third reason anchor.
 
+Two shape gaps live on the TestPage surface
+([#2999](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2999)), and both are
+reached only when BC's own metadata is not the shape the runner reads:
+
+- a **SubPageLink whose `FilterType`** is outside `FIELD`/`CONST`/`FILTER`. Measured on BC
+  28.1's `Microsoft.Dynamics.Nav.Types.dll`, that enum declares exactly those three, and the
+  runner's own dependency-metadata emitter writes only those three spellings — so a fourth
+  value can only have come from BC's compiled page metadata.
+- **whether a source-table field declares an `OnLookup`**, when reflection cannot resolve
+  `NCLMetaField`'s private `EventTriggerDataValue` / `EventTriggerData.LookupHandler` backing
+  fields. A read that *succeeds* and says the field declares no trigger is a different outcome
+  and stays a permanent refusal, because that lookup would come from a `TableRelation`.
+
 ## Known gaps — in scope but not yet implemented
 
 These are not architectural limits. They can be fixed; report them at
@@ -925,6 +938,33 @@ https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues.
 
   Real BC does all of these, so each is the runner failing to keep up rather than a surface BC
   also lacks — which is the test for whether a refusal may cite `docs/scope.md` at all.
+
+<a id="testpage-shape-gaps"></a>
+
+- **TestPage shape gaps — the runner refuses rather than driving a page it could not build.**
+  Fourteen guards in `AlRunner/Patches/MockTestPage.cs` and
+  `AlRunner/Patches/RunnerPageInstance.cs` raise `RunnerOutOfScopeException` with the reason
+  anchor `not-yet-implemented`, so neither an AL `[TryFunction]` nor a silent default can
+  absorb one
+  ([#2999](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2999)):
+  - a **subpage part** the runner could not resolve to a part definition, could not own
+    (the hosting page was built without an `ITreeObject` owner), or could not drive live;
+  - a **`SubPageLink`** whose part field or whose `field(...)` parent field the runner's own
+    dependency-metadata reconstruction could not resolve to a field number;
+  - a **control** bound neither to a source-table field nor to a page variable the runner could
+    resolve, and an **Option-bound control** carrying no option metadata;
+  - **`OnLookup` / `OnDrillDown`**, when no AL page object was built for the page at all;
+  - a **`Visible`/`Editable`/`Enabled` expression** that evaluated to a non-Boolean or that the
+    runner's expression evaluator could not evaluate
+    ([#2596](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2596));
+  - two emitted **trigger methods** on one object hashing to the same member id, so the runner
+    cannot tell which one the test asked for.
+
+  Real BC drives every one of these, so each is the runner failing to keep up rather than a
+  surface BC also lacks — which is the test for whether a refusal may cite `docs/scope.md` at
+  all. Fourteen further refusals in those same two files genuinely are permanent and keep their
+  `docs/scope.md` citation: a page with no `SourceTable`, an `OnQueryClosePage` veto, a lookup
+  that could only come from a `TableRelation`, and the AL-authoring errors real BC also raises.
 
 <a id="virtual-table-shape-gaps"></a>
 


### PR DESCRIPTION
Closes #2999

The issue lists sixteen TestPage refusals in `MockTestPage.cs` and `RunnerPageInstance.cs` that lead with a `testpage-*` anchor under `docs/scope.md`, and — deliberately — also lists the ones in those same two files that are genuinely permanent, so the follow-up cannot over-sweep. I read all twenty-five citations in both files before changing anything.

## Why this is a correctness fix

`ApplicationObjectBasePatches.IsPermanentOutOfScope`:

```csharp
return oos != null && !oos.Reason.StartsWith("not-yet-implemented", StringComparison.Ordinal);
```

Under a `docs/scope.md` anchor that returns `true`, so an AL `[TryFunction]` trapped a runner gap into `false` and the test went green having quietly done without the surface.

TestPage work has a second seam, and it is the reason two of the sixteen change type rather than wording: `asserterror Foo()` where `Foo` reaches one of these. On real BC `Foo` runs and returns, so the `asserterror` **fails**. A runner that absorbs the gap makes it **pass** — that inverts a result rather than hiding one.

## Classifying all twenty-five citations

| bucket | count |
|---|---|
| (1) genuinely out of scope — keep the refusal and the link | 9 |
| (2) in scope, not yet answerable — needs `not-yet-implemented` | 14 |
| (2b) in scope and implemented, but BC's internals could not be READ | 2 |
| (3) deliberate divergence | 0 |

Nothing landed in (3), and that is structural rather than an oversight — #3001 found zero for the same reason. An `expect-divergence` surface returns an answer rather than throwing (`docs/expectations.md`), so a refusal site cannot be one.

**One correction to the issue's arithmetic.** #2999's prose says "the other fourteen citations" are permanent. Its own enumeration of them lists **nine**, and nine is what the files hold: 25 citations measured on `main` (17 in `MockTestPage.cs`, 8 in `RunnerPageInstance.cs`) minus the 16 gaps it lists by line. **Which** sites are permanent is what matters, and the issue has that right — only its total is off. Those nine citations sit on eight throws, because the option-value refusal spells the pointer on both branches of one ternary. The measured number is what the file header and the tests use.

## The two that are `BcShapeGapException`, and the two that look like they should be but are not

#2995's rule is narrow: raise it when the read **could not be performed**, not when the read succeeded and the answer was merely unwelcome. Applying that separated four sites that look alike.

**Raise it — `MockTestPage.SubPageLinks`, a `FilterType` outside FIELD/CONST/FILTER.** Measured rather than taken from the existing comment: a `System.Reflection.Metadata` dump of BC 28.1's `Microsoft.Dynamics.Nav.Types.dll` shows the enum declares exactly `CONST`, `FILTER`, `FIELD`. The runner's own `DependencyPageMetadataXml.EmitSubFormLinkXml` writes only those three spellings, so a fourth value can only have come from BC's compiled metadata — a property of which BC build is on disk, true on one leg and false on another in the same run.

**Raise it — `RaiseSourceFieldOnLookup`, an undeterminable field trigger.** `RecordPatches.TryHasFieldLookupTrigger` is three-valued on purpose and returns `null` **only** when `EnsureFieldTriggerReflection` could not resolve BC's private `NCLMetaField.<EventTriggerDataValue>k__BackingField` / `EventTriggerData.<LookupHandler>k__BackingField`, or the reflection threw; a successful read that says "no trigger" returns `false` and lands on the permanent refusal instead. The site's own text already said "This is a runner/BC-shape problem, not a problem with the AL under test" while raising a scope claim.

**Do NOT raise it — the two `SubPageLink` siblings at `FieldID <= 0` and a non-numeric FIELD value.** The issue describes the second as "the runner reading BC's metadata". Reading `EmitSubFormLinkXml` shows it is the runner reading its **own** output: that emitter *deliberately* writes `FieldID` 0 and the unresolved field NAME when it cannot resolve a name to an id, "precisely so this refusal fires". The read succeeded; the answer is about the runner's metadata reconstruction. Both stay `not-yet-implemented`.

## Fixing the shape, not just the reported line

**1. Same wrong pattern at another call site?** Yes, and my own test caught it. Five refusals across both files spell `" — "` inside the **api** argument, which is the separator `OutOfScopeMessage.TryParse` cuts on — so the untyped recovery path reported `TestPage page 60107 element 4` as the api and folded `Editable` into the reason. That is #2945's Feature Key Modify defect, live at five sites. All five are corrected; two of them are permanent refusals where only the api spelling changes and the scope claim is untouched.

**2. A sibling making the same assumption?** Yes, and it is not fixable here. The (2b) lookup site refuses loudly when `_fLookupHandlerBacking` / `_fValidateHandlerBacking` are null. The **write** path over that same reflection state does the opposite: `RecordPatches.NclMetaTableBuilder.cs` guards every handler install with `&& _fValidateHandlerBacking != null` and silently skips, so on a BC build whose layout moved the field trigger is never installed, nothing is printed, and `WireFieldTriggerHandlers` still returns `true`. Filed as **#3026** rather than folded in: it changes trigger installation rather than refusal wording and needs its own RED → GREEN. Not reachable on 27.0–28.4, where both members resolve.

**3. Two paths writing the same state with different invariants?** Yes, twice. The "part's own page could not be driven live" refusal existed as **two throw sites with byte-identical reason text** (the recordless branch and the fall-through), so one shape could drift into claiming two different things depending on which branch found it — both build their detail in one place now. The two "expression is not a Boolean" sites in `EvaluateProperty` are the same shape, and both route through one factory.

## What I deliberately did not touch

**The RunObject action refusal** (`RunnerPageInstance`, "an action whose effect is RunObject"). #2999 lists it among the permanent ones, but **#2931 / PR #2951 reclassifies it as `not-yet-implemented`** on the strength of a real-service-tier measurement — corpus PR `StefanMaron/BusinessCentral.AL.Language.Tests#172` invoked a `RunObject` action on a TestPage across all 8 BC legs and it opened nothing and raised nothing. A measured verdict outranks a classification made by reading (`ask-the-corpus-before-claiming-bc-behavior.md`), so that site is #2931's to decide and is untouched.

Its test consequence is recorded rather than hidden: `RunnerPageInstance_KeepsItsTwoUncontestedPermanentCitations` pins the two `TableRelation` lookups #2999 named and accepts either outcome for the third, so this PR stays green whichever order it and #2951 merge in. Every other assertion is exact.

## RED → GREEN

RED against executing code, not a compile error: the factory, the doc sections and the full test class were added first, with the sixteen call sites left exactly as they were.

```
Failed!  - Failed: 18, Passed: 69, Total: 87
```

The 69 that stayed green are what makes the 18 mean something — all three control arms passed at RED, so the suite cannot be passing now by discriminating on exception type:

- `PermanentTestPageRefusal_IsStillTrappedByATryFunction` — the same `RunnerOutOfScopeException` type, on two surfaces from #2999's own kept list, still absorbed into `false`.
- `PermanentTestPageRefusal_IsStillCatchableByAssertError` — the same on AL's other seam, plus one of the fourteen corrected refusals still catchable there, since #2871 is the open question about that row and this change does not touch it.
- `KeptRefusal_StillClaimsPermanence` — the permanent sites named individually rather than counted, so a later sweep that deletes a citation fails here instead of shipping.

One of the 18 was not a test bug: `TypedAndUntypedRecovery` is what surfaced the five em-dash apis above.

GREEN, re-run after rebasing onto `9ba81187` (never carried across the rebase):

```
dotnet test AlRunner.Tests -c Release --framework net8.0 --no-build --filter \
  "FullyQualifiedName~TestPageRefusalClaimTests|FullyQualifiedName~RunnerShapeGapClaimTests|\
FullyQualifiedName~BcShapeGapConventionTests|FullyQualifiedName~VirtualTableRefusalClaimTests|\
FullyQualifiedName~OutOfScope|FullyQualifiedName~Expectation|FullyQualifiedName~AssertError|\
FullyQualifiedName~TestPage|FullyQualifiedName~PageControl|FullyQualifiedName~LiveNavTestPart|\
FullyQualifiedName~PageExtensionParser"
Passed!  - Failed: 0, Passed: 482, Skipped: 10, Total: 492, Duration: 58 s
```

And the AL side, run the way CI runs it:

```
dotnet run --no-build --project AlRunner -c Release --framework net8.0 -- \
  tests/runner-extras tests/runner-extras/standalone-suites \
  --package-cache "$HOME/.al-runner/platform-apps" --package-cache "$HOME/.al-runner/test-apps" \
  --strict --count-baseline tests/expectations/count-baseline/test-count-baseline.json --cache <private>
Tests: 400 total  pass: 400  fail: 0  error: 0
```

No AL test was added or removed, so `test-count-baseline.json` does not move, and the `--count-baseline` run above is what confirms that rather than an assumption.

## Why the tests are in `AlRunner.Tests/`, not `tests/runner-extras/`

Every one of the sixteen fires when something the runner owns is absent or the wrong shape: no AL page object built for a page, a page built without an `ITreeObject` owner, a control it could not resolve, a `SubPageLink` field its own emitter could not resolve, an Option binding with no metadata, two emitted methods hashing to one member id, a private BC field reflection could not read. No AL statement can arrange any of those, so no bundle can drive one — the subject is the C# refusal contract, which `bc-behavior-tests-go-upstream.md` classifies as runner-specific.

The new class does not rest on a hard-coded list alone: alongside the per-site table it discovers every factory on `TestPageShapeGap` by reflection and holds it to the same invariants, so a factory added later is covered without anyone remembering.

## No classification moves

`ExpectationManifest.ReasonAnchor` cuts at the first em-dash, so the anchor these report goes from e.g. `testpage-lookup` to `not-yet-implemented`. No manifest entry matches on any of them. The four entries in `tests/expectations/known-gaps-testpage-control-property.json` match on `(CodeunitName, Method)` under `Mode=expect-fail-known-gap`, which means "must fail" — and a `not-yet-implemented` refusal still fails. The one AL suite that asserts on such an anchor, `tests/runner-extras/testpage-lookup-tablerelation-oos`, drives a permanent site that is untouched.

---
*Authored by an automated agent (`impl-35`) acting on the account holder's behalf.*

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
