### PR TITLE
fix(date): answer Record Date.IsEmpty() over the widened window, and stop its nine refusals claiming permanent scope

### DIFF
--- a/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
+++ b/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
@@ -1,6 +1,6 @@
-// VirtualTableRefusalClaimTests — what the 48 refusals in the sixteen
+// VirtualTableRefusalClaimTests — what the refusals in the seventeen
 // RecordPatches.*VirtualTable.cs populators actually claim, and what an AL [TryFunction]
-// does with one (#2945).
+// does with one (#2945, extended to the Date table by #2965).
 //
 // WHY THIS IS A RUNNER-SIDE MECHANISM TEST AND NOT AN AL BUNDLE
 // ------------------------------------------------------------
@@ -52,14 +52,16 @@ namespace AlRunner.Tests;
 public sealed class VirtualTableRefusalClaimTests
 {
     private const string GapDoc = "docs/limitations.md#virtual-table-shape-gaps";
+    private const string DateDoc = "docs/limitations.md#date-virtual-table";
     private const string TimeZoneDoc = "docs/limitations.md#time-zone-virtual-table";
     private const string WindowsLanguageDoc = "docs/limitations.md#windows-language-virtual-table";
 
     private static readonly string RepoRoot = Path.GetFullPath(
         Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
 
-    /// <summary>The sixteen files this issue covers. ObjectMetadataSystemTable is #2894's and
-    /// DateVirtualTable is #2648's — both deliberately outside this change.</summary>
+    /// <summary>The seventeen files covered. ObjectMetadataSystemTable is #2894's and keeps its
+    /// own factory. DateVirtualTable joined under #2965 — it was held back from #2945 only
+    /// because #2648 was changing it concurrently, not because it classified differently.</summary>
     private static readonly string[] CoveredFiles =
     {
         "RecordPatches.AggregatePermissionSetVirtualTable.cs",
@@ -67,6 +69,7 @@ public sealed class VirtualTableRefusalClaimTests
         "RecordPatches.AllObjWithCaptionVirtualTable.cs",
         "RecordPatches.AllProfileVirtualTable.cs",
         "RecordPatches.CodeunitMetadataVirtualTable.cs",
+        "RecordPatches.DateVirtualTable.cs",
         "RecordPatches.FeatureKeyVirtualTable.cs",
         "RecordPatches.FieldVirtualTable.cs",
         "RecordPatches.IntegerVirtualTable.cs",
@@ -104,6 +107,7 @@ public sealed class VirtualTableRefusalClaimTests
         new object[] { "AllObjWithCaptionShapeGap",      "AllObjWithCaption (virtual table 2000000058)",        "allobjwithcaption-virtual-table",         GapDoc },
         new object[] { "AllProfileShapeGap",             "All Profile (virtual table 2000000178)",              "all-profile-virtual-table",              GapDoc },
         new object[] { "CodeunitMetadataShapeGap",       "CodeUnit Metadata (virtual table 2000000137)",        "codeunit-metadata-virtual-table",         GapDoc },
+        new object[] { "DateShapeGap",                   "Date (virtual table 2000000007)",                     "date-virtual-table",                      DateDoc },
         new object[] { "FeatureKeyShapeGap",             "Feature Key (system table 2000000211)",               "feature-key-virtual-table",               GapDoc },
         new object[] { "FeatureKeyModifyShapeGap",       "Feature Key (system table 2000000211): Modify",       "feature-key-modify",                      GapDoc },
         new object[] { "FieldVirtualShapeGap",           "Field (virtual table 2000000041)",                    "field-virtual-table",                     GapDoc },
@@ -161,8 +165,8 @@ public sealed class VirtualTableRefusalClaimTests
     public void EveryDiscoveredFactory_ClaimsNotYetImplemented()
     {
         var factories = AllShapeGapFactories().ToList();
-        Assert.True(factories.Count >= 18,
-            $"expected at least the 18 virtual-table factories, found {factories.Count}");
+        Assert.True(factories.Count >= 19,
+            $"expected at least the 19 virtual-table factories, found {factories.Count}");
 
         foreach (var m in factories)
         {
@@ -226,13 +230,15 @@ public sealed class VirtualTableRefusalClaimTests
         var scope = File.ReadAllText(Path.Combine(RepoRoot, "docs", "scope.md"));
 
         foreach (var anchor in new[]
-                 { "virtual-table-shape-gaps", "time-zone-virtual-table", "windows-language-virtual-table" })
+                 { "virtual-table-shape-gaps", "time-zone-virtual-table", "windows-language-virtual-table",
+                   "date-virtual-table" })
             Assert.Contains($"<a id=\"{anchor}\"></a>", limitations, StringComparison.Ordinal);
 
         // The reason the old link was wrong has to stay true, or this fix is moot: scope.md is
         // the permanent manifest and names none of these tables.
         foreach (var table in new[]
-                 { "AllObj", "Time Zone", "Windows Language", "Feature Key", "Page Control Field" })
+                 { "AllObj", "Time Zone", "Windows Language", "Feature Key", "Page Control Field",
+                   "virtual table 2000000007" })
             Assert.DoesNotContain(table, scope, StringComparison.OrdinalIgnoreCase);
     }
 
@@ -298,6 +304,10 @@ public sealed class VirtualTableRefusalClaimTests
         // precondition went back to being read as a default, which is the failure this whole
         // change is about, so the count is asserted exactly.
         //
+        // 58 -> 67 (#2965): the Date populator's eight refusals joined, plus the ninth in
+        // RecordPatches.cs's dispatch chain that spelled "date-virtual-table" itself. The Date
+        // file was held out of #2945 only because #2648 was rewriting it at the time.
+        //
         // 55 -> 58 (#2938): the Table Metadata populator gained three refusals when TableType
         // and DataClassification stopped being answered with a constant. Two guard the option
         // set itself (the column carries no option metadata / its option string is empty) and
@@ -306,7 +316,7 @@ public sealed class VirtualTableRefusalClaimTests
         // ordinal 0 would assert "Normal" about a table that declared something else, which is
         // the same silent wrong answer the issue is about. Going UP is the expected direction
         // here; this assertion exists to catch the count going down.
-        Assert.Equal(58, total);
+        Assert.Equal(67, total);
     }
 
 

--- a/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
@@ -881,12 +881,15 @@ public static partial class NclCecilRewrite
                 H(recordPatches, "DataAccess_FieldFindManaged"));
 
             // ── DataAccess.CountAsync — Date virtual table (2000000007) window guard ─────
-            // Record.Count() / IsEmpty() reach a CountCacheRequest, not a FindCacheRequest, so
-            // the find guard above never sees them. Without this prepend a Count over a range
-            // outside the materialised Date window would answer with however many rows the
-            // window happens to hold — the silent short answer the window guard exists to
-            // prevent. The helper widens the window (or throws past the row cap) and returns;
-            // the original CountAsync body then runs unchanged, for this and every other table.
+            // Record.Count() reaches a CountCacheRequest, not a FindCacheRequest, so the find
+            // guard above never sees it. Without this prepend a Count over a range outside the
+            // materialised Date window would answer with however many rows the window happens
+            // to hold — the silent short answer the window guard exists to prevent. The helper
+            // widens the window (or throws past the row cap) and returns; the original
+            // CountAsync body then runs unchanged, for this and every other table.
+            //
+            // This comment used to read "Record.Count() / IsEmpty()". IsEmpty() has never
+            // reached CountAsync — see the ExistsAsync prepend below (#3006).
             PrependStaticCall(nclMod,
                 ByParams(Rt + "DataAccess", "CountAsync", "CountCacheRequest"),
                 H(recordPatches, "DataAccess_DateWindowGuardForCount"),
@@ -951,11 +954,32 @@ public static partial class NclCecilRewrite
                 H(recordPatches, "DataAccess_FieldGuardForGet"),
                 argSlots: 2); // `this` — the DataAccess — and the primary-key request
 
+            // ── DataAccess.ExistsAsync — Date virtual table (2000000007), the FOURTH path ───
+            // Record.IsEmpty() does not take the count path. RecordImplementation.IsEmptyAsync
+            // calls its OWN ExistsAsync, which builds an ExistsCacheRequest and reaches
+            // DataAccess.ExistsAsync — decompiled from Ncl.dll 28.1, and not what the count
+            // guard's comment claimed for a whole release. Measured on main, one process, one
+            // record variable, on consecutive lines:
+            //
+            //   Date.SetRange("Period Start", 18500101D..18500107D);
+            //   IsEmpty() -> TRUE      Count() -> 7
+            //
+            // A service tier computes this table across years 1..9999 and answers 7 both ways,
+            // so TRUE is a wrong answer, not a missing feature — and the quiet kind, because
+            // "this range holds no periods" is what IsEmpty() returning true normally means.
+            // ExistsAsync is a large async state machine, so unlike the tiny FindAsync it is
+            // not R2R-inlined past the prepend.
+            PrependStaticCall(nclMod,
+                ByParams(Rt + "DataAccess", "ExistsAsync", "ExistsCacheRequest"),
+                H(recordPatches, "DataAccess_DateWindowGuardForExists"),
+                argSlots: 2); // `this` — the DataAccess — and the exists request
+
             // ── DataAccess.ExistsAsync — virtual Field table (2000000041), the FOURTH path ────
             // Record.IsEmpty() does not take the count path. RecordImplementation.IsEmptyAsync
             // calls its own ExistsAsync, which builds an ExistsCacheRequest and reaches
-            // DataAccess.ExistsAsync — decompiled from Ncl.dll, and not what the Date count
-            // guard's comment above claims. With the count and Get guards in place but not this
+            // DataAccess.ExistsAsync — decompiled from Ncl.dll. The Date count guard's comment
+            // used to claim otherwise; #3006 corrected it and added the Date half of this same
+            // prepend directly above. With the count and Get guards in place but not this
             // one, Field.SetRange(TableNo, 270); IsEmpty() still answered TRUE while Count()
             // over the same filter answered 2. ExistsAsync is a large async state machine, so
             // unlike the tiny FindAsync it is not R2R-inlined past the prepend.

--- a/AlRunner/Patches/RecordPatches.DateVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.DateVirtualTable.cs
@@ -64,6 +64,61 @@
 //   DateTimeHelper, NCLMetaTable, NavValue, ReadOnlyRecordBuffer and TempTableDataProvider are
 //   runtime-engine types; we call BC's own helpers by reflection and feed the result into our
 //   own in-memory store.
+//
+// WHAT THE REFUSALS IN THIS FILE CLAIM (#2965)
+//   All nine used to end "see docs/scope.md". That file is the manifest of what is
+//   PERMANENTLY out of scope -- SMTP, HTTP egress, printing -- and it names no table at all,
+//   let alone this one, which this very file implements. The citation was also load-bearing
+//   rather than decorative. ApplicationObjectBasePatches.IsPermanentOutOfScope:
+//
+//       return oos != null && !oos.Reason.StartsWith("not-yet-implemented", StringComparison.Ordinal);
+//
+//   Under the old anchor that returned TRUE, so an AL [TryFunction] reading the Date table
+//   trapped a runner shape gap into `false` -- the silent default .claude/rules/loud-failures.md
+//   exists to prevent. They all route through DateShapeGap now, so the refusal tears through.
+//
+//   Every site was classified before it was touched, in the three buckets
+//   RecordPatches.VirtualTableShapeGap.cs defines:
+//
+//     site                                          what is missing                     bucket
+//     ---------------------------------------------------------------------------------------
+//     PopulateDateSpan: no in-memory provider       the runner's own store wiring         (2)
+//     PopulateDateSpan: past the row cap            the window is bounded; BC is not      (2)
+//     InsertDateRow: DatePeriodRoundUp refused      BC's own helper answered no           (2)
+//     PeriodName: GetPeriodName threw               BC's own provider threw               (2)
+//     EnsureDateFieldLayout: column moved           BC's metatable shape                  (2)
+//     EnsureDatePeriodTypes: no field 1             BC's metatable shape                  (2)
+//     EnsureDatePeriodTypes: no option metadata     BC's metatable shape                  (2)
+//     EnsureDatePeriodTypes: no matching option     BC's metatable shape                  (2)
+//     RecordPatches.cs dispatch: no skeleton session  the runner's own state              (2)
+//
+//   Nothing is in bucket (1), "genuinely out of scope". To be in (1) a refusal has to be
+//   faithful to real BC -- BC itself unable to answer, so an AL [TryFunction] reading `false`
+//   is the OBSERVABLE BC OUTCOME rather than a runner gap. Real BC computes this table on
+//   demand across years 1 through 9999 and never refuses a Date read, so a refusal here is
+//   always the runner failing to keep up.
+//
+//   THE ROW-CAP REFUSAL WAS CHECKED SEPARATELY, because it is not obviously the same category
+//   as the other eight: the other eight fire when BC's shape or the runner's store is not what
+//   this file needs, while the row cap fires on a perfectly well-formed request that the runner
+//   has simply chosen not to serve. It lands in (2) all the same, and for the stronger of the
+//   two reasons: a service tier answers that request with rows, so `false` from a [TryFunction]
+//   would be a WRONG answer rather than an unavailable one. It is not bucket (3) either --
+//   "implementable now" would mean writing the message differently, and the message already
+//   says exactly what to do (raise AL_RUNNER_DATE_WINDOW_MAX_ROWS, or narrow the filter). What
+//   would actually retire it is computing rows per request instead of materialising a window.
+//
+//   tests/runner-extras/date-virtual-table-window pins the row-cap refusal with
+//   Assert.ExpectedError('out-of-scope: Date (virtual table 2000000007)'), which matches on the
+//   API prefix only. RunnerOutOfScopeException.BuildMessage renders
+//   "out-of-scope: <api> - <reason> - see <link>", so rewriting the REASON leaves that prefix
+//   untouched -- confirmed by running the suite, not assumed.
+//
+//   One site changed its Api as well as its reason: the "Period Name" refusal used to raise
+//   Api = `Date (virtual table 2000000007) - "Period Name"`. OutOfScopeMessage.TryParse cuts
+//   the api from the reason at the FIRST em-dash, so that api made the typed and untyped
+//   recovery paths disagree -- the same defect #2945 found on the Feature Key Modify surface.
+//   The column is named in the DETAIL now, and there is one Date surface rather than two.
 using System.Collections.Concurrent;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -74,6 +129,22 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
+    /// <summary>
+    /// Every refusal raised for the Date table, built in one place. See
+    /// RecordPatches.VirtualTableShapeGap.cs for the three-bucket classification and for why
+    /// the anchor is "not-yet-implemented" rather than a docs/scope.md section (#2945); see
+    /// this file's header for the per-site classification behind the nine (#2965).
+    /// </summary>
+    /// <remarks>
+    /// The doc link is this table's OWN limitations section rather than the shared
+    /// shape-gaps one, because the window and its row cap are already written up there and
+    /// that section is what a reader hitting the cap needs.
+    /// </remarks>
+    internal static RunnerOutOfScopeException DateShapeGap(string detail)
+        => VirtualTableShapeGap(
+            "Date (virtual table 2000000007)", "date-virtual-table", detail,
+            "docs/limitations.md#date-virtual-table");
+
     internal const int DateVirtualTableId = 2000000007;
 
     // Field numbers of the Date table, exactly as BC's own DateDataProvider hardcodes them
@@ -210,9 +281,9 @@ public static partial class RecordPatches
         EnsureDataAccessProviderReflection(dataAccess);
 
         var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
-            ?? throw new RunnerOutOfScopeException(
-                "Date (virtual table 2000000007)",
-                "date-virtual-table — Date data access has no in-memory provider; see docs/scope.md");
+            ?? throw DateShapeGap(
+                "the Date data access handed over no in-memory provider, so there is nothing to "
+                + "populate");
 
         // Remember the handout so the find-time guard can extend the window later without one.
         _dvtLastDataAccess = dataAccess;
@@ -231,9 +302,8 @@ public static partial class RecordPatches
 
             var estimate = EstimateDateRowCount(newMin, newMax);
             if (estimate > DateWindowMaxRows)
-                throw new RunnerOutOfScopeException(
-                    "Date (virtual table 2000000007)",
-                    $"date-virtual-table — a Date filter asks for periods in "
+                throw DateShapeGap(
+                    "a Date filter asks for periods in "
                     // #2968: `:N0` picks up the ambient group separator, so this diagnostic
                     // read differently per operator locale. Invariant, like the rest of the
                     // runner's own output.
@@ -243,8 +313,7 @@ public static partial class RecordPatches
                         $"{DateWindowMaxRows:N0}-row cap for the materialised window ")
                     + System.FormattableString.Invariant(
                         $"(currently [{(span.Any ? span.Min : newMin):yyyy-MM-dd}..{(span.Any ? span.Max : newMax):yyyy-MM-dd}]). ")
-                    + "Raise AL_RUNNER_DATE_WINDOW_MAX_ROWS, or narrow the filter; "
-                    + "see docs/limitations.md#date-virtual-table");
+                    + "Raise AL_RUNNER_DATE_WINDOW_MAX_ROWS, or narrow the filter");
 
             // Same rationale as the Field and Integer tables: make our metatable report
             // IsVirtualTable=false so BC's find takes the NORMAL temp-table DataAccess path
@@ -332,10 +401,9 @@ public static partial class RecordPatches
         var values = _dvtSystemValues!.Invoke(dateMetaTable, DateVirtualTableId, periodTypeOrdinal, dayNumber, 0);
 
         if (!TryRoundUp(periodStart, periodType, out var periodEnd))
-            throw new RunnerOutOfScopeException(
-                "Date (virtual table 2000000007)",
-                $"date-virtual-table — BC's DatePeriodRoundUp refused {periodStart:yyyy-MM-dd} for period type "
-                + $"{periodType}; see docs/scope.md");
+            throw DateShapeGap(
+                $"BC's own DateTimeHelper.DatePeriodRoundUp refused {periodStart:yyyy-MM-dd} for period "
+                + $"type {periodType}, so the row's \"Period End\" cannot be built");
 
         var periodNo = (int)_dvtCalcPeriodNumber!.Invoke(null, new object?[] { periodType, periodStart })!;
 
@@ -476,12 +544,54 @@ public static partial class RecordPatches
 
     /// <summary>
     /// Prepended to DataAccess.CountAsync(CountCacheRequest) for every table. Record.Count()
-    /// and IsEmpty() take the count path, not the find path, so the InnerFindAsync guard never
-    /// sees them; without this a Count over a range outside the materialised Date window would
-    /// return however many rows the window happens to hold. For every table but 2000000007 this
-    /// does one integer comparison and returns.
+    /// takes the count path, not the find path, so the InnerFindAsync guard never sees it;
+    /// without this a Count over a range outside the materialised Date window would return
+    /// however many rows the window happens to hold. For every table but 2000000007 this does
+    /// one integer comparison and returns.
+    ///
+    /// <para>This comment used to say "Record.Count() AND IsEmpty()", and that was wrong — see
+    /// <see cref="DataAccess_DateWindowGuardForExists"/> below. The claim went unchallenged
+    /// long enough to hide a wrong answer for a whole release, which is why the correction is
+    /// spelled out rather than quietly edited: IsEmpty() has never reached CountAsync.</para>
     /// </summary>
     public static void DataAccess_DateWindowGuardForCount(object self, object request)
+    {
+        if (FindRequestTableId(request) != DateVirtualTableId) return;
+        EnsureDateWindowCoversRequest(self, request);
+    }
+
+    /// <summary>
+    /// Prepended to DataAccess.ExistsAsync(ExistsCacheRequest) for every table — the FOURTH
+    /// request path into this table, and the one the count guard's comment above wrongly
+    /// claimed to cover (issue #3006).
+    ///
+    /// <para><c>Record.IsEmpty()</c> does not take the count path. Decompiled from Ncl.dll
+    /// 28.1: <c>NavRecord.GetALIsEmptyAsync</c> -> <c>RecordImplementation.IsEmptyAsync()</c>
+    /// -> <c>RecordImplementation.IsEmptyAsync(FiltersAndMarks)</c> -> its own
+    /// <c>ExistsAsync(FiltersAndMarks, SecurityFiltering)</c> ->
+    /// <c>dataAccess.ExistsAsync(new ExistsCacheRequest(...))</c>. <c>CountAsync</c> is never
+    /// on that chain. <c>ExistsCacheRequest</c> derives from <c>DataCacheRequest</c> exactly as
+    /// the find, count and primary-key requests do, so it carries the same
+    /// <c>MetaApplicationObject</c> and <c>FiltersAndMarks</c> this guard reads — the guard
+    /// simply was never registered on it.</para>
+    ///
+    /// <para>Measured on main before this existed, one process, one record variable, on
+    /// consecutive lines:</para>
+    /// <code>
+    ///   Date.SetRange("Period Start", 18500101D..18500107D);
+    ///   IsEmpty()  -> TRUE
+    ///   Count()    -> 7
+    /// </code>
+    /// <para>On a real service tier the Date table spans years 1 through 9999 and both answer
+    /// the same thing, so TRUE is a wrong answer rather than a missing feature — and a quiet
+    /// one, since "this range holds no periods" is what an IsEmpty() returning true normally
+    /// means.</para>
+    ///
+    /// <para><c>DataAccess.ExistsAsync</c> is a large async state machine, so unlike the tiny
+    /// <c>FindAsync</c> it is not R2R-inlined past a prepend. For every table but 2000000007
+    /// this does one integer comparison and returns.</para>
+    /// </summary>
+    public static void DataAccess_DateWindowGuardForExists(object self, object request)
     {
         if (FindRequestTableId(request) != DateVirtualTableId) return;
         EnsureDateWindowCoversRequest(self, request);
@@ -694,13 +804,12 @@ public static partial class RecordPatches
         }
         catch (TargetInvocationException tie)
         {
-            throw new RunnerOutOfScopeException(
-                "Date (virtual table 2000000007) — \"Period Name\"",
-                "date-virtual-table — BC's DateDataProvider.GetPeriodName could not name the period "
-                + $"({periodType} starting {periodStart:yyyy-MM-dd}): {tie.InnerException?.Message}. "
-                + "The session's FormatSettings are what BC reads for the weekday and month names; "
-                + "answering with an invented name would put a wrong caption in a green test. "
-                + "See docs/scope.md");
+            throw DateShapeGap(
+                "BC's own DateDataProvider.GetPeriodName could not name the period for the "
+                + $"\"Period Name\" column ({periodType} starting {periodStart:yyyy-MM-dd}): "
+                + $"{tie.InnerException?.Message}. The session's FormatSettings are what BC reads "
+                + "for the weekday and month names; answering with an invented name would put a "
+                + "wrong caption in a green test");
         }
     }
 
@@ -726,12 +835,12 @@ public static partial class RecordPatches
                 && string.Equals(actual.Replace(" ", string.Empty), name.Replace(" ", string.Empty),
                     StringComparison.OrdinalIgnoreCase))
                 return;
-            throw new RunnerOutOfScopeException(
-                "Date (virtual table 2000000007)",
-                $"date-virtual-table — field {fieldNo} of the Date metatable is "
+            throw DateShapeGap(
+                $"field {fieldNo} of the Date metatable is "
                 + $"'{(byNo.TryGetValue(fieldNo, out var a) ? a : "<absent>")}', not '{name}' "
                 + $"[fields={string.Join("/", allFields.Select(f => $"{f.FieldNo}:{f.FieldName}"))}] "
-                + "— BC metadata shape changed; see docs/scope.md");
+                + "- BC's own column layout moved, and writing a value at the old slot would put "
+                + "\"Period No.\" into \"Period End\"");
         }
 
         Expect(DateFieldPeriodType, "Period Type");
@@ -756,15 +865,14 @@ public static partial class RecordPatches
 
         var typeField = (GetAllFields(dateMetaTable) ?? Enumerable.Empty<NCLMetaField>())
             .FirstOrDefault(f => f.FieldNo == DateFieldPeriodType)
-            ?? throw new RunnerOutOfScopeException(
-                "Date (virtual table 2000000007)",
-                "date-virtual-table — the Date metatable has no field 1 (\"Period Type\"); see docs/scope.md");
+            ?? throw DateShapeGap(
+                "the Date metatable has no field 1 (\"Period Type\"), which is the field every row "
+                + "is keyed on");
 
         var optionString = typeField.FieldOptionMetadata?.OptionString
-            ?? throw new RunnerOutOfScopeException(
-                "Date (virtual table 2000000007)",
-                "date-virtual-table — the Date \"Period Type\" field carries no option metadata, so its "
-                + "ordinals cannot be resolved; see docs/scope.md");
+            ?? throw DateShapeGap(
+                "the Date \"Period Type\" field carries no option metadata, so its ordinals cannot be "
+                + "resolved and a guessed one would mis-key every row");
 
         var parts = optionString.Split(',');
         var pairs = new List<(int, object)>();
@@ -780,11 +888,10 @@ public static partial class RecordPatches
         }
 
         if (pairs.Count == 0)
-            throw new RunnerOutOfScopeException(
-                "Date (virtual table 2000000007)",
-                $"date-virtual-table — none of the Date \"Period Type\" options ('{optionString}') matches a "
-                + $"BC DatePeriodType value ('{string.Join(",", Enum.GetNames(_dvtPeriodTypeEnum!))}'); "
-                + "see docs/scope.md");
+            throw DateShapeGap(
+                $"none of the Date \"Period Type\" options ('{optionString}') matches a "
+                + $"BC DatePeriodType value ('{string.Join(",", Enum.GetNames(_dvtPeriodTypeEnum!))}'), "
+                + "so there is no period type to enumerate");
 
         _dvtPeriodTypes = pairs.ToArray();
         return _dvtPeriodTypes;

--- a/AlRunner/Patches/RecordPatches.DateVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.DateVirtualTable.cs
@@ -43,13 +43,35 @@
 //   The real table spans years 1 through 9999 — 3.6 million Date rows alone — so it cannot be
 //   materialised whole. We materialise a window of whole years (default 1900-01-01 ..
 //   2099-12-31, about 87,000 rows across all five period types) and EXTEND that window on
-//   demand whenever an AL filter names a closed bound outside it. EnsureDateWindowCoversRequest
-//   does that, from both request paths a Record Date read can take: the InnerFindAsync guard in
-//   RecordPatches.FieldFindIntercept.cs (FindFirst / FindSet / FindLast / Get) and a prepend on
-//   DataAccess.CountAsync (Count / IsEmpty), which carry different request types. Past
-//   AL_RUNNER_DATE_WINDOW_MAX_ROWS the extension throws RunnerOutOfScopeException naming the
-//   requested bound, the window and the cap, rather than answering a larger request with fewer
-//   rows.
+//   demand whenever an AL filter names a closed bound outside it, on all FOUR request paths a
+//   Record Date read can take. They carry four different request types, all deriving from
+//   DataCacheRequest, and each needs its own guard:
+//
+//     AL                                  DataAccess method                  request type
+//     ---------------------------------------------------------------------------------------
+//     Find / FindSet / FindFirst / FindLast  InnerFindAsync                  FindCacheRequest
+//     Count                                  CountAsync                      CountCacheRequest
+//     IsEmpty                                ExistsAsync                     ExistsCacheRequest
+//     Get("Period Type", "Period Start")     InternalTryGetByPrimaryKeyAsync PrimaryKeyCacheRequest
+//
+//   This header said "both request paths ... DataAccess.CountAsync (Count / IsEmpty)" until
+//   #3006. IsEmpty() has never reached CountAsync: RecordImplementation.IsEmptyAsync calls its
+//   own ExistsAsync, which builds an ExistsCacheRequest (decompiled from Ncl.dll 28.1). Because
+//   the comment asserted otherwise, nobody looked, and a closed range outside the window
+//   answered IsEmpty() = true with Count() = 7 on the very next line -- a wrong answer, since a
+//   service tier computes this table across years 1..9999 and answers 7 both ways.
+//
+//   The exists path is shared with more than IsEmpty(): DataAccess.ExistsAsync is also what an
+//   `Exist` FlowField (FlowFieldsHelper), a NavQuery and RecordImplementation.ValidateRelation
+//   reach, so all three now get the widened window too.
+//
+//   The find guard lives in RecordPatches.FieldFindIntercept.cs; the other three are prepends
+//   registered in NclCecilRewrite.Runtime.cs. All four funnel into
+//   EnsureDateWindowCoversRequest (or, for the keyed Get, into PopulateDateSpan from the record
+//   id), so one invariant is maintained in one place rather than four copies drifting apart.
+//   Past AL_RUNNER_DATE_WINDOW_MAX_ROWS the extension throws RunnerOutOfScopeException naming
+//   the requested bound, the window and the cap, rather than answering a larger request with
+//   fewer rows.
 //
 //   The one thing the window does NOT cover is an OPEN bound: `SetFilter("Period Start",
 //   '%1..', D)` asks BC for everything up to 9999-12-31, and we answer it from the window.

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -1944,11 +1944,15 @@ public static partial class RecordPatches
                     var createdDate = _mCreateTempDataAccess!.Invoke(self, new object[] { table })!;
                     dateDa = perTable.GetOrAdd(tableId, createdDate);
                 }
+                // The ninth Date refusal, and the only one outside
+                // RecordPatches.DateVirtualTable.cs. It routes through that file's factory
+                // rather than spelling the anchor itself, so the table cannot claim one thing
+                // from the populator and another from this dispatch chain — the sibling defect
+                // #2945 found for Field, Aggregate Permission Set and All Profile (#2965).
                 var dateSession = _fDasSession?.GetValue(self)
-                    ?? throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                        "Date (virtual table 2000000007)",
-                        "date-virtual-table — DataAccessSource has no skeleton session, so BC's own "
-                        + "DateDataProvider.GetPeriodName cannot name a period; see docs/scope.md");
+                    ?? throw DateShapeGap(
+                        "the DataAccessSource has no skeleton session, so BC's own "
+                        + "DateDataProvider.GetPeriodName cannot name a period");
                 PopulateDateVirtualTable(dateDa, table, dateSession);
                 return dateDa;
             }

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -529,9 +529,22 @@ What it does instead:
 - It materialises a window of whole years, **1900-01-01 to 2099-12-31** by default
   (about 87,000 rows across all five period types).
 - Whenever an AL `"Period Start"` filter names a **closed** bound outside that window,
-  the window widens to cover it before the read runs. This happens on both request
-  paths — `FindFirst` / `FindSet` / `FindLast` / `Get`, and `Count` / `IsEmpty` — so a
-  filter naming 1850 or 2300 gets real rows.
+  the window widens to cover it before the read runs. This happens on all **four**
+  request paths a `Record Date` read can take, so a filter naming 1850 or 2300 gets
+  real rows whichever one AL uses:
+
+  | AL | `DataAccess` method | request type |
+  |---|---|---|
+  | `Find` / `FindSet` / `FindFirst` / `FindLast` | `InnerFindAsync` | `FindCacheRequest` |
+  | `Count` | `CountAsync` | `CountCacheRequest` |
+  | `IsEmpty` | `ExistsAsync` | `ExistsCacheRequest` |
+  | `Get(Period Type, Period Start)` | `InternalTryGetByPrimaryKeyAsync` | `PrimaryKeyCacheRequest` |
+
+  This list said "both request paths — find, and `Count` / `IsEmpty`" until #3006.
+  `IsEmpty()` has never taken the count path: `RecordImplementation.IsEmptyAsync` calls
+  its own `ExistsAsync`, which builds an `ExistsCacheRequest`. Until that fourth guard
+  existed, `IsEmpty()` answered `true` for a 1850 range that `Count()` answered `7` for
+  on the very next line.
 - Widening past **500,000 rows** raises `RunnerOutOfScopeException`, naming the
   requested bounds, the current window and the cap. It never answers a wider request
   with fewer rows.

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -72,6 +72,22 @@ move whatever that number is. The fixture app is still a separate, test-free app
 
 ## runner-extras
 
+### date-virtual-table-window 5 -> 9 (PRs for #3006 and #2965)
+
+Four tests added to an existing app group, so no new group line. Written down because two of
+the four assert something the group's name does not suggest and the reason is worth keeping:
+
+- `Date_IsEmptyBeforeTheWindow_WidensTheWindowLikeCountDoes` and
+  `Date_ClosedRangePastTheRowCap_ThrowsOnTheIsEmptyPathToo` cover `IsEmpty()`, which is a
+  FOURTH `DataAccess` request path (`ExistsAsync`/`ExistsCacheRequest`) and not a spelling of
+  `Count()` — the assumption that let #3006 sit unnoticed.
+- `Date_IsEmptyInsideTheWindow_StillAnswersTrueWhenNothingMatches` is its negative arm: a
+  materialised range that genuinely holds no Week period must still answer `true`.
+- `Date_RowCapRefusal_TearsThroughATryFunction_InsteadOfReadingAsFalse` is #2965's: it asserts
+  the runtime consequence of the refusal's claim, not its wording.
+
+Measured by running the group, not computed: `9P/0F/0E across 9 tests`, cold and warm.
+
 ## Migrated log (everything above 2026-09-05, verbatim)
 
 This is the `_comment` string `test-count-baseline.json` used to carry: 40,178 characters on

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -9,7 +9,7 @@
     "runner-extras": {
       "groups": {
         "bundle-page-over-dep-table": { "tests": 2 },
-        "date-virtual-table-window": { "tests": 5 },
+        "date-virtual-table-window": { "tests": 9 },
         "db-trigger-inject-timing": { "tests": 2 },
         "dep-tableext-invoke-dep": { "tests": 0 },
         "dep-tableext-invoke-main": { "tests": 4 },

--- a/tests/runner-extras/date-virtual-table-window/DvtwAssert.Codeunit.al
+++ b/tests/runner-extras/date-virtual-table-window/DvtwAssert.Codeunit.al
@@ -14,6 +14,12 @@ codeunit 64560 "Dvtw Assert"
             Error('Expected true: %1', Msg);
     end;
 
+    procedure IsFalse(Condition: Boolean; Msg: Text)
+    begin
+        if Condition then
+            Error('Expected false: %1', Msg);
+    end;
+
     procedure ExpectedError(Fragment: Text)
     begin
         if StrPos(GetLastErrorText(), Fragment) = 0 then

--- a/tests/runner-extras/date-virtual-table-window/DvtwTests.Codeunit.al
+++ b/tests/runner-extras/date-virtual-table-window/DvtwTests.Codeunit.al
@@ -91,6 +91,69 @@ codeunit 64561 "Dvtw Tests"
     end;
 
     [Test]
+    procedure Date_IsEmptyBeforeTheWindow_WidensTheWindowLikeCountDoes()
+    var
+        DateRec: Record Date;
+    begin
+        // Issue #3006. IsEmpty() is a FOURTH request path into the table, not a spelling of
+        // Count(). Decompiled from Ncl.dll 28.1: NavRecord.GetALIsEmptyAsync ->
+        // RecordImplementation.IsEmptyAsync -> RecordImplementation.ExistsAsync ->
+        // dataAccess.ExistsAsync(new ExistsCacheRequest(...)). It never reaches CountAsync, so
+        // the count guard never saw it and the window was never widened for an IsEmpty().
+        //
+        // Measured on main before the fix, this exact pair on consecutive lines:
+        //   IsEmpty() -> TRUE      Count() -> 7
+        // Same record variable, same filter, opposite answers. On a service tier the Date
+        // table spans years 1 through 9999, so TRUE is a wrong answer rather than a missing
+        // feature — and the quiet kind, since "this range holds no periods" is exactly what an
+        // IsEmpty() returning true normally means.
+        //
+        // The year is 1820 rather than 1850 ON PURPOSE. The first test in this codeunit widens
+        // the window down to 1850 through Count(), so an IsEmpty() over 1850 placed after it
+        // would pass with no guard on the exists path at all. 1820 is named by nothing else in
+        // this suite, so this test proves the same thing whatever order the suite runs in.
+        //
+        // [GIVEN] a closed range a century before the default window starts
+        DateRec.SetRange("Period Type", DateRec."Period Type"::Date);
+        DateRec.SetRange("Period Start", DMY2Date(1, 1, 1820), DMY2Date(7, 1, 1820));
+
+        // [WHEN] IsEmpty() asks FIRST — before anything else has widened the window for it
+        // [THEN] it answers over the widened window, and the other three paths agree with it
+        Assert.IsFalse(DateRec.IsEmpty(), 'Record Date.IsEmpty() reported 1-7 January 1820 as empty.');
+        Assert.AreEqual(7, DateRec.Count(), 'Expected 7 Date-type rows for 1-7 January 1820.');
+        Assert.IsTrue(DateRec.FindFirst(), 'Record Date found no row for 1 January 1820.');
+        Assert.AreEqual(DMY2Date(1, 1, 1820), DateRec."Period Start", 'Expected the range to start on 1 January 1820.');
+        // Not merely "a row came back": 1 January 1820 was a Saturday, so its "Period No." is 6
+        // under BC's Monday = 1 numbering. A blank or defaulted row fails here.
+        Assert.AreEqual(6, DateRec."Period No.", '1 January 1820 was a Saturday, so Period No. is 6.');
+    end;
+
+    [Test]
+    procedure Date_IsEmptyInsideTheWindow_StillAnswersTrueWhenNothingMatches()
+    var
+        DateRec: Record Date;
+    begin
+        // The negative arm, and the control for the test above. A guard that widened the window
+        // and then reported every range as non-empty would pass that test and fail this one.
+        //
+        // 3 January 1950 is a Tuesday and sits inside the default window, so it is already
+        // materialised: there IS a Date period starting that day, and there is NO Week period,
+        // because BC's weeks start on Monday. So the same single-day filter must answer
+        // opposite things for the two period types, and both answers are about rows that exist
+        // rather than about rows that were never built.
+        DateRec.SetRange("Period Type", DateRec."Period Type"::Date);
+        DateRec.SetRange("Period Start", DMY2Date(3, 1, 1950), DMY2Date(3, 1, 1950));
+        Assert.IsFalse(DateRec.IsEmpty(), '3 January 1950 is a Date period, so IsEmpty() must be false.');
+        Assert.AreEqual(1, DateRec.Count(), 'Expected exactly one Date-type row for 3 January 1950.');
+
+        DateRec.Reset();
+        DateRec.SetRange("Period Type", DateRec."Period Type"::Week);
+        DateRec.SetRange("Period Start", DMY2Date(3, 1, 1950), DMY2Date(3, 1, 1950));
+        Assert.IsTrue(DateRec.IsEmpty(), 'No Week period starts on Tuesday 3 January 1950, so IsEmpty() must be true.');
+        Assert.AreEqual(0, DateRec.Count(), 'Expected no Week-type row starting on Tuesday 3 January 1950.');
+    end;
+
+    [Test]
     procedure Date_ClosedRangePastTheRowCap_ThrowsOutOfScope()
     var
         DateRec: Record Date;
@@ -121,8 +184,67 @@ codeunit 64561 "Dvtw Tests"
         Assert.ExpectedError('out-of-scope: Date (virtual table 2000000007)');
     end;
 
+    [Test]
+    procedure Date_ClosedRangePastTheRowCap_ThrowsOnTheIsEmptyPathToo()
+    var
+        DateRec: Record Date;
+    begin
+        // Issue #3006, the other half. The same range through IsEmpty() instead of Count() or
+        // FindFirst(). Without the exists-path guard the runner would answer FALSE from the
+        // rows it happens to hold — "this eight-century range has periods in it" — which is
+        // true by accident and says nothing about the range that was asked for.
+        DateRec.SetRange("Period Type", DateRec."Period Type"::Date);
+        DateRec.SetRange("Period Start", DMY2Date(1, 1, 1200), DMY2Date(31, 12, 9998));
+
+        asserterror IsEmptyRows(DateRec);
+        Assert.ExpectedError('out-of-scope: Date (virtual table 2000000007)');
+        Assert.ExpectedError('past the');
+    end;
+
+    [Test]
+    procedure Date_RowCapRefusal_TearsThroughATryFunction_InsteadOfReadingAsFalse()
+    var
+        DateRec: Record Date;
+        Reached: Boolean;
+    begin
+        // Issue #2965 — the runtime consequence of what the refusal CLAIMS, not its wording.
+        //
+        // All nine Date refusals used to end "see docs/scope.md".
+        // ApplicationObjectBasePatches.IsPermanentOutOfScope reads the reason's FIRST token:
+        //
+        //     return oos != null && !oos.Reason.StartsWith("not-yet-implemented", ...);
+        //
+        // so under the old anchor it returned TRUE and an AL [TryFunction] trapped the refusal
+        // into `false` — the silent default .claude/rules/loud-failures.md exists to prevent.
+        // AL would then carry on having quietly done without the table, and the test would go
+        // green. docs/scope.md is the manifest of what is permanently out of scope (SMTP, HTTP
+        // egress, printing); it names no table, and real BC computes this one on demand across
+        // years 1 through 9999 and never refuses a Date read at all.
+        //
+        // [GIVEN] a range far past the row cap — the one Date refusal AL can actually provoke
+        DateRec.SetRange("Period Type", DateRec."Period Type"::Date);
+        DateRec.SetRange("Period Start", DMY2Date(1, 1, 1200), DMY2Date(31, 12, 9998));
+
+        // [WHEN] a [TryFunction] reads it
+        // [THEN] the refusal tears through rather than being reported as "it just did not work"
+        asserterror Reached := TryFindFirst(DateRec);
+        Assert.ExpectedError('out-of-scope: Date (virtual table 2000000007)');
+        Assert.IsFalse(Reached, 'TryFindFirst must not have completed.');
+    end;
+
     local procedure CountRows(var DateRec: Record Date): Integer
     begin
         exit(DateRec.Count());
+    end;
+
+    local procedure IsEmptyRows(var DateRec: Record Date): Boolean
+    begin
+        exit(DateRec.IsEmpty());
+    end;
+
+    [TryFunction]
+    local procedure TryFindFirst(var DateRec: Record Date)
+    begin
+        DateRec.FindFirst();
     end;
 }


### PR DESCRIPTION
Closes #3006
Closes #2965

Two defects in the same file, landed together because they collide line-for-line otherwise.

## #3006 — `IsEmpty()` answered over the unwidened window

`IsEmpty()` is a **fourth** `DataAccess` request path, not a spelling of `Count()`. Decompiled from `Ncl.dll` 28.1:

- `RecordImplementation.IsEmptyAsync()` -> `IsEmptyAsync(FiltersAndMarks)`
- -> its own `ExistsAsync(FiltersAndMarks, SecurityFiltering)`
- -> `dataAccess.ExistsAsync(new ExistsCacheRequest(...))`

`CountAsync` is never on that chain. The Date window guard was registered on `InnerFindAsync`, `CountAsync` and `InternalTryGetByPrimaryKeyAsync`, but not on `ExistsAsync`, so a closed `"Period Start"` range outside the materialised window answered:

```
Date.SetRange("Period Start", 18500101D..18500107D);
IsEmpty()  -> true
Count()    -> 7      // on the very next line
```

A service tier computes this table across years 1 through 9999 and answers 7 both ways, so `true` is a wrong answer rather than a missing feature — and the quiet kind, since "this range holds no periods" is what `IsEmpty()` returning true normally means.

Fixed by `DataAccess_DateWindowGuardForExists`, prepended on `ByParams(Rt + "DataAccess", "ExistsAsync", "ExistsCacheRequest")`. `ExistsCacheRequest` derives from `DataCacheRequest` exactly as the other three do, so it carries the same `MetaApplicationObject` and `FiltersAndMarks` the guard already reads — the reflection needed no change. `ExistsAsync` is a large async state machine, so unlike the tiny `FindAsync` it is not R2R-inlined past a prepend.

## #2965 — nine refusals claimed a permanent scope boundary

All nine Date refusals ended `see docs/scope.md`. `ApplicationObjectBasePatches.IsPermanentOutOfScope` tests `!Reason.StartsWith("not-yet-implemented")`, so under that anchor an AL `[TryFunction]` reading the Date table trapped a runner gap into `false`. The runner printed its own confession during the RED run:

```
[oos-in-try] Date (virtual table 2000000007) - date-virtual-table - a Date filter asks for
periods in [1200-01-01..9998-12-31], which is about 3,822,462 rows, past the 500,000-row cap
... see docs/scope.md - reached inside an AL [TryFunction]; returning false, which is what
real BC does in an environment that also lacks this surface.
```

Real BC does no such thing here — it computes the rows. All nine route through a `DateShapeGap(detail)` factory now (`RecordPatches.VirtualTableShapeGap`, anchor `not-yet-implemented`, doc link `docs/limitations.md#date-virtual-table`), with a per-site classification table in the file header.

**The row-cap refusal was checked separately**, as the issue asked. It lands in bucket (2) with the other eight, and for the stronger reason: the other eight fire when BC's shape or the runner's store is not what the file needs, while the row cap fires on a perfectly well-formed request the runner has chosen not to serve — so a service tier would have answered it with rows, and `false` from a `[TryFunction]` is a *wrong* answer rather than an unavailable one. It is not bucket (3) either: "implementable now" would mean writing the message differently, and the message already says exactly what to do. What would retire it is computing rows per request instead of materialising a window.

The existing `Assert.ExpectedError('out-of-scope: Date (virtual table 2000000007)')` in `tests/runner-extras/date-virtual-table-window` matches on the API prefix, which `BuildMessage` still renders unchanged — **confirmed by running the suite, not assumed**.

One site also changed its `Api`: the "Period Name" refusal raised `Date (virtual table 2000000007) - "Period Name"`. `OutOfScopeMessage.TryParse` cuts the api from the reason at the first em-dash, so that api made the typed and untyped recovery paths disagree — the same defect #2945 found on the Feature Key Modify surface. The column is named in the detail now, and there is one Date surface rather than two.

## Fix the shape, not just the reported line

**1. Same wrong pattern at another call site?** Yes, three more, none of them in the issues.

- **A ninth refusal.** #2965 says eight; there are nine. `RecordPatches.cs`'s `GetDataAccessForTable` dispatch chain spelled `date-virtual-table ... see docs/scope.md` itself. Left alone, the table would claim one thing from the populator and another from the dispatch chain — the exact sibling defect #2945 found for Field, Aggregate Permission Set and All Profile — and `EachSurfaceAnchorIsSpelledInExactlyOneFile` would have failed. It routes through `DateShapeGap` now.
- **The same wrong claim in two more places.** `RecordPatches.DateVirtualTable.cs`'s own file header ("both request paths ... `DataAccess.CountAsync` (Count / IsEmpty)") and `docs/limitations.md#date-virtual-table` ("This happens on both request paths — ... and `Count` / `IsEmpty`"). Both corrected, both now carry the four-path table. This is the claim that kept the bug invisible for a release, so leaving two undisturbed copies of it would have re-armed the trap.

**2. Sibling function with the same assumption?** `find_callers` on `DataAccess.ExistsAsync` returns more than `RecordImplementation`: `FlowFieldsHelper` (an `Exist` FlowField), `NavQuery`, and `RecordImplementation.ValidateRelation` (a table relation pointing at Date). All three reached the unwidened window too, and all three are fixed by the same prepend because it sits on the shared entry point. `MarkedRecordsHelper.ExistsWithManyMarksAsync` re-enters `ExistsAsync`, and the prepend runs *before* that branch, so it is not a bypass.

**3. Two paths writing the same state, same invariant?** They do now. All four Date guards funnel into `EnsureDateWindowCoversRequest` / `PopulateDateSpan` rather than four copies of the invariant drifting apart, which is how the first three ended up disagreeing.

## Deliberately left out

**The Aggregate Permission Set table.** #3006 says it "shares the same three guards and has no `ExistsAsync` guard either". Reading the code, that premise is not accurate: it has **two** guards (find and keyed Get) and no `CountAsync` guard at all, so it is not the same shape. Its store is populated at data-access-creation time rather than windowed, so `Count()`/`IsEmpty()` answer over a populated-but-possibly-stale store — a weaker and different defect from Date's, and I did not measure it. Not folded in on a premise I could not confirm; #3006's own "do not treat that as established" stands, and this note is the correction to its reasoning.

## RED -> GREEN

Both RED baselines were run, not reasoned about.

**#3006**, before the `ExistsAsync` prepend — the two new `IsEmpty` tests fail and nothing else does:

```
RED    6P/2F   Date_IsEmptyBeforeTheWindow_WidensTheWindowLikeCountDoes
                 "Expected false: Record Date.IsEmpty() reported 1-7 January 1820 as empty."
               Date_ClosedRangePastTheRowCap_ThrowsOnTheIsEmptyPathToo
                 "An error was expected inside an ASSERTERROR statement."
GREEN  8P/0F
```

**#2965**, with the factory temporarily emitting the old `docs/scope.md` reason — the `[TryFunction]` test fails and prints the `[oos-in-try] ... returning false` line quoted above:

```
RED    8P/1F   Date_RowCapRefusal_TearsThroughATryFunction_InsteadOfReadingAsFalse
GREEN  9P/0F
```

The tests use **1820**, not the issue's 1850, on purpose: the first test in the codeunit widens the window down to 1850 through `Count()`, so an `IsEmpty()` over 1850 placed after it would pass with no exists guard at all. 1820 is named by nothing else in the suite, so the test proves the same thing whatever order the suite runs in. The negative arm (`Date_IsEmptyInsideTheWindow_StillAnswersTrueWhenNothingMatches`) asserts a *materialised* range that genuinely holds no `Week` period still answers `true` and `Count() = 0`, so a guard that widened and then called everything non-empty fails it.

## Also run, on the rebased tree

`main` moved under this branch while it was in progress — #3008 landed a Field-table `ExistsAsync` prepend on the same method. The rebase conflicted there; both prepends are kept, sitting together, and every number below was re-measured **after** the rebase.

- `tests/runner-extras`, CI invocation with `--strict --count-baseline`: **291/291, exit 0**, cold and again warm. Baseline `date-virtual-table-window` 5 -> 9.
- `tests/al-language` corpus, CI invocation with `--strict --count-baseline`: **2599/2599, exit 0**. Run because the `ExistsAsync` prepend sits on a method every table's `IsEmpty`, `Exist` FlowField, query and `ValidateRelation` goes through — a much wider blast radius than the Date table.
- `dotnet test AlRunner.Tests` filtered to `VirtualTableRefusalClaim`, `DateVirtualTable`, `NclCecilRewrite`, `JmpHookOrphanAudit`, `TryFunctionOutOfScope`, `OutOfScope`, `AggregatePermissionSetVirtualTable`, `FieldVirtualTable`: **127 passed, 0 failed, 6 skipped**.

`VirtualTableRefusalClaimTests` gains the Date surface: `CoveredFiles` 16 -> 17, the exact refusal count 58 -> 67 (eight in the populator plus the ninth in the dispatch chain), the discovered-factory floor 18 -> 19, and `date-virtual-table` added to the doc-anchor-exists check.

All on BC 28.1 — a self-built runner is compiled against Ncl 28.x and cannot execute 27.x artifacts, so the 27.x legs are CI's to report.

Opened by agent `impl-34` on the account holder's behalf.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
