### PR TITLE
fix(testpage): use the tier's measured refusal text and out-of-range behavior

### DIFF
--- a/AlRunner.Tests/TestFieldValidationErrorsTests.cs
+++ b/AlRunner.Tests/TestFieldValidationErrorsTests.cs
@@ -24,6 +24,11 @@
 // below that asserts a non-zero count or a recovered message fails against that implementation,
 // and Microsoft's own Codeunit134614.TestRemoveSUPERPermissionsByUserAll failed on
 // `Assert.AreEqual(1, …ValidationErrorCount())` reading 0.
+//
+// TWO VALUES HERE WERE CORRECTED BY A SERVICE TIER, NOT DERIVED. Corpus run 34002487601
+// measured what BC really stores and what it really does past the end of the ledger; the first
+// draft of this file asserted a bare message and an IndexOutOfRangeException, and both were
+// wrong. See TestFieldValidationErrors' header for the measurement and the binding split.
 using System;
 using AlRunner;
 using AlRunner.Infrastructure;
@@ -66,7 +71,7 @@ public sealed class TestFieldValidationErrorsTests
         // ledger that recorded without moving MaxId would swallow the refusal entirely.
         var errors = new TestFieldValidationErrors();
 
-        errors.Record("There should be at least one enabled 'SUPER' user.");
+        errors.Record("There should be at least one enabled 'SUPER' user.", appendRefreshSuffix: false);
 
         Assert.Equal(1, errors.Count);
         Assert.Equal(1L, errors.MaxId);
@@ -78,7 +83,7 @@ public sealed class TestFieldValidationErrorsTests
     public void ReadingAnError_ReturnsItVerbatimAndConsumesItsId()
     {
         var errors = new TestFieldValidationErrors();
-        errors.Record("There should be at least one enabled 'SUPER' user.");
+        errors.Record("There should be at least one enabled 'SUPER' user.", appendRefreshSuffix: false);
 
         Assert.Equal("There should be at least one enabled 'SUPER' user.", errors.Get(0));
 
@@ -92,9 +97,9 @@ public sealed class TestFieldValidationErrorsTests
     public void SeveralErrors_KeepTheirOrderAndConsumeUpToTheOneRead()
     {
         var errors = new TestFieldValidationErrors();
-        errors.Record("first");
-        errors.Record("second");
-        errors.Record("third");
+        errors.Record("first", appendRefreshSuffix: false);
+        errors.Record("second", appendRefreshSuffix: false);
+        errors.Record("third", appendRefreshSuffix: false);
 
         Assert.Equal(3, errors.Count);
         Assert.Equal(3L, errors.MaxId);
@@ -112,20 +117,26 @@ public sealed class TestFieldValidationErrorsTests
     [InlineData(-1)]
     [InlineData(1)]
     [InlineData(5)]
-    public void ReadingOutOfRange_ThrowsTheExceptionBcConvertsToItsOwn(int index)
+    public void ReadingOutOfRange_RaisesTheSameExceptionTheTierRaises(int index)
     {
-        // BC's NavTestField.ALGetValidationError(int) catches IndexOutOfRangeException and
-        // rethrows NavNCLIndexOutOfBoundsException — the AL-visible error for
-        // GetValidationError(0) (it subtracts 1, so AL index 0 reaches -1 here) or an index
-        // past the end. Answering "" instead would swallow BC's own bounds check and let an AL
-        // test compare two empty strings successfully.
+        // MEASURED, corpus run 34002487601, not derived. BC's client does
+        // System.Linq.Enumerable.ElementAt, so an out-of-range read raises
+        // ArgumentOutOfRangeException(index) — which NavTestField.ALGetValidationError's
+        // `catch (IndexOutOfRangeException)` does NOT match, so it escapes to the test framework
+        // as "Unexpected CLR exception thrown." and AL `asserterror` does not trap it.
+        //
+        // The first draft of this test asserted IndexOutOfRangeException, reasoning that BC
+        // would not carry a catch for something unreachable. The tier says the catch IS
+        // unreachable. Asserting the Argument flavour is what keeps the runner from inventing a
+        // trappable AL error the tier never produces.
         //
         // One error is recorded, so index 0 is the ONLY valid one; -1, 1 and 5 are all out.
         var errors = new TestFieldValidationErrors();
-        errors.Record("only");
+        errors.Record("only", appendRefreshSuffix: false);
         Assert.Equal("only", errors.Get(0));
 
-        Assert.Throws<IndexOutOfRangeException>(() => errors.Get(index));
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => errors.Get(index));
+        Assert.Equal("index", ex.ParamName);
     }
 
     // ── which exceptions become a validation error ───────────────────────────
@@ -136,7 +147,7 @@ public sealed class TestFieldValidationErrorsTests
         var errors = new TestFieldValidationErrors();
         var ran = false;
 
-        errors.RunRecordingRefusal(() => ran = true);
+        errors.RunRecordingRefusal(() => ran = true, appendRefreshSuffix: true);
 
         Assert.True(ran);
         Assert.Equal(0, errors.Count);
@@ -144,17 +155,45 @@ public sealed class TestFieldValidationErrorsTests
     }
 
     [Fact]
-    public void AnAlError_IsRecordedAndDoesNotEscape()
+    public void AnAlError_OnARecBoundControl_IsRecordedWithBcsRefreshSuffix()
     {
         // The whole point: BC's ITestField contract is "the setter records, BC raises". A setter
         // that throws leaves ValidationErrorCount at 0 and BC with nothing to wrap.
+        //
+        // The suffix is MEASURED (corpus run 34002487601): a Rec-bound control's OnValidate
+        // raising `Error('Deliberate OnValidate failure for VAL-1')` is stored by real BC as
+        // that text plus " (Select Refresh to discard errors)". The first draft recorded the
+        // bare message and the tier disagreed on all reporting legs.
         var errors = new TestFieldValidationErrors();
 
         errors.RunRecordingRefusal(
-            () => throw AlError("There should be at least one enabled 'SUPER' user."));
+            () => throw AlError("Deliberate OnValidate failure for VAL-1"),
+            appendRefreshSuffix: true);
+
+        Assert.Equal(1, errors.Count);
+        Assert.Equal("Deliberate OnValidate failure for VAL-1 (Select Refresh to discard errors)",
+            errors.Get(0));
+    }
+
+    [Fact]
+    public void AnAlError_OnAPageVariableControl_IsRecordedBare()
+    {
+        // A page-global control stages no row edit, so there is nothing for "Refresh to discard"
+        // to discard. Microsoft's Tests-SINGLESERVER Codeunit134614 asserts exactly this, with
+        // exact equality, for a control verified to be page-variable-bound on page 9807.
+        //
+        // This half rests on Microsoft's assertion, NOT on a service-tier run in this
+        // repository — corpus PR #184 asks it directly. Pinning it here means a change of mind
+        // has to be deliberate.
+        var errors = new TestFieldValidationErrors();
+
+        errors.RunRecordingRefusal(
+            () => throw AlError("There should be at least one enabled 'SUPER' user."),
+            appendRefreshSuffix: false);
 
         Assert.Equal(1, errors.Count);
         Assert.Equal("There should be at least one enabled 'SUPER' user.", errors.Get(0));
+        Assert.DoesNotContain("Select Refresh", errors.Get(0));
     }
 
     [Fact]
@@ -164,7 +203,8 @@ public sealed class TestFieldValidationErrorsTests
 
         var ex = Assert.Throws<RunnerOutOfScopeException>(
             () => errors.RunRecordingRefusal(
-                () => throw new RunnerOutOfScopeException("TestPage control 42", "testpage-x")));
+                () => throw new RunnerOutOfScopeException("TestPage control 42", "testpage-x"),
+                appendRefreshSuffix: true));
 
         Assert.Equal("TestPage control 42", ex.Api);
         Assert.Equal(0, errors.Count);
@@ -181,7 +221,8 @@ public sealed class TestFieldValidationErrorsTests
         var ex = Assert.Throws<NavNCLDialogException>(
             () => errors.RunRecordingRefusal(
                 () => throw AlError(
-                    "out-of-scope: NavReport.SaveAs — report-rendering — see docs/scope.md#report-rendering")));
+                    "out-of-scope: NavReport.SaveAs — report-rendering — see docs/scope.md#report-rendering"),
+                appendRefreshSuffix: true));
 
         Assert.Contains("out-of-scope: NavReport.SaveAs", ex.Message);
         Assert.Equal(0, errors.Count);
@@ -195,7 +236,8 @@ public sealed class TestFieldValidationErrorsTests
         var errors = new TestFieldValidationErrors();
 
         Assert.Throws<NullReferenceException>(
-            () => errors.RunRecordingRefusal(() => throw new NullReferenceException("runner bug")));
+            () => errors.RunRecordingRefusal(() => throw new NullReferenceException("runner bug"),
+                appendRefreshSuffix: true));
 
         Assert.Equal(0, errors.Count);
     }
@@ -221,7 +263,10 @@ public sealed class TestFieldValidationErrorsTests
         {
             System.Globalization.CultureInfo.InvariantCulture,
             "Rec True",
-            "Your entry of 'False' is not an acceptable value for 'Rec True'. (Select Refresh to discard errors)",
+            // The inner text as the ledger now stores it: the helper's core plus the suffix
+            // TestFieldValidationErrors appends for a Rec-bound control.
+            "Your entry of 'False' is not an acceptable value for 'Rec True'."
+                + TestFieldValidationErrors.RefreshSuffix,
         })!;
 
         Assert.Equal(

--- a/AlRunner.Tests/TestPageBooleanValueTests.cs
+++ b/AlRunner.Tests/TestPageBooleanValueTests.cs
@@ -29,11 +29,13 @@
 // not an unsupported surface to refuse as out of scope — which is why the negative assertions
 // below check for that message rather than for a RunnerOutOfScopeException.
 //
-// NOTE ON WHAT CHANGED IN #2900. Resolve now raises only the INNER half of that message. The
-// "Validation error for Field: <name>,  Message = '…'" wrapper is composed one layer out, by
-// BC's own NavTestField.CheckError, from the refusal TestFieldValidationErrors records — so the
-// AL-visible string all eight legs measured is unchanged, and the assertions below moved down to
-// the layer this helper actually owns. TestFieldValidationErrorsTests pins the other half.
+// NOTE ON WHAT CHANGED IN #2900. Resolve now raises only the CORE of that message. Two layers
+// are added around it by code that is not this helper's: TestFieldValidationErrors appends
+// " (Select Refresh to discard errors)" when it records the refusal, and BC's own
+// NavTestField.CheckError then wraps the result in "Validation error for Field: <name>,
+// Message = '…'". The AL-visible string all eight legs measured is unchanged; the assertions
+// below moved down to the layer this helper actually owns, and
+// TestFieldValidationErrorsTests pins the other two.
 using AlRunner;
 using Microsoft.Dynamics.Nav.Types.Exceptions;
 using Microsoft.Dynamics.Nav.Runtime;
@@ -136,12 +138,13 @@ public sealed class TestPageBooleanValueTests
         var ex = Assert.Throws<NavNCLDialogException>(
             () => TestPageBooleanValue.Resolve(input, "Rec True"));
 
-        // The bare inner message, exactly — the wrapper is BC's (#2900), so asserting it here
-        // would pin a string this helper no longer produces.
+        // The core message, exactly — neither the refresh suffix nor BC's wrapper belongs to
+        // this helper any more (#2900), so asserting either here would pin a string it no
+        // longer produces.
         Assert.Equal(
-            $"Your entry of '{input}' is not an acceptable value for 'Rec True'. "
-            + "(Select Refresh to discard errors)",
+            $"Your entry of '{input}' is not an acceptable value for 'Rec True'.",
             ex.Message);
         Assert.DoesNotContain("Validation error for Field", ex.Message);
+        Assert.DoesNotContain("Select Refresh", ex.Message);
     }
 }

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -2023,11 +2023,13 @@ internal static class TestPageOptionValue
 /// nothing at all — this is a client/page-layer check, not a table-trigger one, so it must
 /// stay out of NavRecord.ALValidateAsync (which Rec.Validate also calls).
 ///
-/// <para>Since #2900 this raises only the INNER half of that message. The
-/// <c>Validation error for Field: &lt;name&gt;,  Message = '…'</c> wrapper is added by BC's own
-/// <c>NavTestField.CheckError</c> from the refusal <see cref="TestFieldValidationErrors"/>
-/// records, so the AL-visible string is the same one #2490 measured — composed by BC rather
-/// than assembled here.</para>
+/// <para>Since #2900 this raises only the CORE of that message. Two layers are added around it
+/// by code that is not this helper's: <see cref="TestFieldValidationErrors"/> appends
+/// <c>" (Select Refresh to discard errors)"</c> when it records the refusal (BC's client does
+/// that, measured on corpus run 34002487601), and BC's own <c>NavTestField.CheckError</c> then
+/// wraps the result in <c>Validation error for Field: &lt;name&gt;,  Message = '…'</c>. The
+/// AL-visible string is the same one #2490 measured; it is now composed rather than
+/// assembled here, which is what stops the suffix appearing twice.</para>
 ///
 /// <para>Only numeric field types are checked — MinValue/MaxValue is meaningless on Text/Code/
 /// Boolean/etc., and AL does not let those types declare it.</para>
@@ -2085,8 +2087,7 @@ internal static class TestPageMinMaxValue
         // Lang.TestValidationException, so building that wrapper here too would double it
         // (#2900). The AL-visible string is unchanged; it is composed one layer out now.
         var msg = $"The value must be {comparison} "
-            + $"{boundText}. Value: {FormatValue(value, isInteger)}. "
-            + "(Select Refresh to discard errors)";
+            + $"{boundText}. Value: {FormatValue(value, isInteger)}.";
 
         var t = System.Type.GetType(
             "Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLDialogException, Microsoft.Dynamics.Nav.Types");
@@ -2206,19 +2207,20 @@ internal static class TestPageBooleanValue
 
     /// <summary>
     /// BC's own refusal for a value a control will not take:
-    /// <c>Your entry of '{value}' is not an acceptable value for '{caption}'. (Select Refresh
-    /// to discard errors)</c>.
-    /// <para>The <c>Validation error for Field: {name},  Message = '…'</c> wrapper around it —
-    /// including the double space after the comma, which is BC's and not a typo — is added by
-    /// BC's own <c>NavTestField.CheckError</c> once <see cref="TestFieldValidationErrors"/> has
-    /// recorded this message, so it is deliberately absent here (#2900).</para>
+    /// <c>Your entry of '{value}' is not an acceptable value for '{caption}'.</c>
+    /// <para>Two layers are deliberately absent here (#2900), because neither is this helper's
+    /// to add: <see cref="TestFieldValidationErrors"/> appends
+    /// <c>" (Select Refresh to discard errors)"</c> when it records the refusal, and BC's own
+    /// <c>NavTestField.CheckError</c> then wraps it in <c>Validation error for Field: {name},
+    /// Message = '…'</c> — including the double space after the comma, which is BC's and not a
+    /// typo. The composed result is the string corpus PR #163 measured on all eight legs.</para>
     /// </summary>
     private static System.Exception MakeNotAcceptableError(string value, string caption)
     {
         // The BARE message only — see TestPageMinMaxValue.MakeError for why the
         // "Validation error for Field: ..." wrapper is BC's to add and no longer ours (#2900).
         var msg = $"Your entry of '{value}' "
-            + $"is not an acceptable value for '{caption}'. (Select Refresh to discard errors)";
+            + $"is not an acceptable value for '{caption}'.";
 
         var t = System.Type.GetType(
             "Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLDialogException, Microsoft.Dynamics.Nav.Types");
@@ -2312,7 +2314,10 @@ internal sealed class LiveNavTestField : ITestField
                ?? TestPageBooleanValue.Format(_record.GetFieldValue(_fieldNo) as NavValue)
                ?? Convert.ToString(ObjectValue, CultureInfo.InvariantCulture)
                ?? string.Empty;
-        set => _validationErrors.RunRecordingRefusal(() => Write(value));
+        // appendRefreshSuffix: true — a Rec-bound control stages a row edit, and real BC's
+        // client decorates its recorded validation error with the offer to discard it. Measured
+        // on corpus run 34002487601; see TestFieldValidationErrors' header.
+        set => _validationErrors.RunRecordingRefusal(() => Write(value), appendRefreshSuffix: true);
     }
 
     private void Write(string value)
@@ -2560,11 +2565,16 @@ internal sealed class PageVariableTestField : ITestField
                ?? TestPageBooleanValue.Format(RunnerPageInstance.GetValue(_expression))
                ?? Convert.ToString(ObjectValue, CultureInfo.InvariantCulture)
                ?? string.Empty;
+        // appendRefreshSuffix: false — a page-global control stages no row edit, so there is
+        // nothing for "Refresh to discard" to discard. Microsoft's Tests-SINGLESERVER
+        // Codeunit134614 asserts the bare text with exact equality for exactly this binding
+        // shape (verified mechanically to be page-variable-bound, not Rec-bound). This is the
+        // half no service-tier run has confirmed yet — corpus PR #184 asks it.
         set => _validationErrors.RunRecordingRefusal(() =>
         {
             RunnerPageInstance.SetValue(_expression, ToBoundValue(value));
             _page.RaiseOnValidate(_controlId);
-        });
+        }, appendRefreshSuffix: false);
     }
 
     public object? ObjectValue => LiveNavTestPage.Unwrap(RunnerPageInstance.GetValue(_expression));

--- a/AlRunner/Patches/TestFieldValidationErrors.cs
+++ b/AlRunner/Patches/TestFieldValidationErrors.cs
@@ -39,10 +39,39 @@
 // ({0} = ITestField.Name, {1} = the recorded error text — the double space is BC's.) That is
 // the same string TestPageMinMaxValue and TestPageBooleanValue used to hand-build themselves;
 // now that a refusal is recorded rather than thrown, BC composes it and those helpers carry
-// only the inner message. Microsoft's own Tests-SINGLESERVER asserts both halves —
-// `Assert.ExpectedError('Validation error for Field')` in UserRoleTest, and
-// `GetValidationError(1)` equal to the BARE inner text in TestAppPermissions — which is the
-// evidence that the wrapper belongs to the outer layer and the recorded text does not carry it.
+// only the inner message.
+//
+// WHAT THE RECORDED TEXT IS, MEASURED — AND WHY IT DIFFERS BY BINDING
+//
+// Corpus run 34002487601 (StefanMaron/BusinessCentral.AL.Language.Tests PR #182, identical on
+// every leg that reported) measured what a REC-BOUND control records when its OnValidate
+// raises `Error('Deliberate OnValidate failure for VAL-1')`:
+//
+//     Deliberate OnValidate failure for VAL-1 (Select Refresh to discard errors)
+//
+// So real BC appends " (Select Refresh to discard errors)" — the client's offer to discard the
+// staged row edit — to the AL message before storing it. An earlier version of this file
+// recorded the bare message and was wrong; that suffix is exactly why TestPageMinMaxValue and
+// TestPageBooleanValue already carried it inside their own hand-built strings.
+//
+// Microsoft's Tests-SINGLESERVER Codeunit134614 asserts the opposite for its own control, with
+// exact equality and no suffix:
+//
+//     Assert.AreEqual('There should be at least one enabled ''SUPER'' user.',
+//         PermissionSetByUser.AllUsersHavePermission.GetValidationError(1), ...)
+//
+// These are not the same shape, and the difference is mechanical rather than guessed: probing
+// the runner's own control-binding map (AL_RUNNER_BINDING_PROBE over that test) shows page 9807
+// resolves AllUsersHavePermission as a PAGE VARIABLE, while page 60797's NameCtl in the corpus
+// test is REC-BOUND. A page-global control stages no row edit, so there is nothing for
+// "Refresh to discard" to discard.
+//
+// Hence the suffix lives on LiveNavTestField (Rec-bound) and NOT on PageVariableTestField.
+// That split rests on ONE measurement per side, and only the Rec-bound side's is a service-tier
+// measurement — the page-global side rests on Microsoft's assertion, which no tier run in this
+// repository has confirmed. Corpus PR #184 asks it directly; until that answers, this is the
+// most defensible reading of the evidence available and is flagged as such rather than
+// presented as settled.
 //
 // IDS
 //
@@ -55,6 +84,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace AlRunner;
 
@@ -83,27 +113,48 @@ internal sealed class TestFieldValidationErrors
     /// <summary>The highest id already handed out by <see cref="Get"/>. BC's <c>LastUsedValidationErrorId</c>.</summary>
     internal long LastUsedId => _lastUsedId;
 
-    /// <summary>Record a refusal. The text is the bare error message, without BC's wrapper.</summary>
-    internal void Record(string message) => _errors.Add(message ?? string.Empty);
+    /// <summary>
+    /// The suffix real BC's client appends to a REC-BOUND control's recorded validation error —
+    /// its offer to discard the staged row edit. Measured, see this file's header; not added for
+    /// a page-global control, which stages no edit.
+    /// </summary>
+    internal const string RefreshSuffix = " (Select Refresh to discard errors)";
+
+    /// <summary>
+    /// Record a refusal, exactly as BC's client stores it. <paramref name="message"/> is the
+    /// bare AL error text; <paramref name="appendRefreshSuffix"/> adds
+    /// <see cref="RefreshSuffix"/> for the binding shape BC adds it to. Neither carries BC's
+    /// "Validation error for Field: …" wrapper — that is composed one layer out.
+    /// </summary>
+    internal void Record(string message, bool appendRefreshSuffix)
+        => _errors.Add((message ?? string.Empty) + (appendRefreshSuffix ? RefreshSuffix : string.Empty));
 
     /// <summary>
     /// The recorded error at a ZERO-based index, marking its id used.
-    /// <para>Out of range throws <see cref="IndexOutOfRangeException"/> rather than answering
-    /// an empty string, because that is the exception BC's own
-    /// <c>NavTestField.ALGetValidationError(int)</c> is written to catch — it converts it into
-    /// <c>NavNCLIndexOutOfBoundsException</c>, the AL-visible error for
-    /// <c>GetValidationError(0)</c> or an index past the end. Answering "" here would swallow
-    /// BC's own bounds check and let an AL test compare two empty strings successfully.</para>
+    /// <para>Out of range goes through <see cref="Enumerable.ElementAt{TSource}(IEnumerable{TSource}, int)"/>
+    /// because that is literally what BC's own client does — corpus run 34002487601's stack is
+    /// <c>System.Linq.Enumerable.ElementAt → TestPageClient.TestFieldProxy.GetValidationError →
+    /// NavTestField.ALGetValidationError</c> — so an out-of-range read raises
+    /// <see cref="ArgumentOutOfRangeException"/> with parameter name <c>index</c>, exactly as
+    /// the tier does.</para>
+    /// <para>An earlier version threw <see cref="IndexOutOfRangeException"/>, reasoning that
+    /// <c>ALGetValidationError</c> catches that type and would not carry a catch for something
+    /// unreachable. Measured, the catch IS unreachable: LINQ raises the Argument flavour, it
+    /// does not match, and the exception escapes to the test framework as
+    /// <c>"Unexpected CLR exception thrown."</c> — which AL <c>asserterror</c> does NOT trap.
+    /// Throwing the Argument flavour reproduces that whole chain; throwing the Index flavour
+    /// would have made the runner convert it into a trappable AL error the tier never produces.</para>
     /// </summary>
     internal string Get(int index)
     {
-        if (index < 0 || index >= _errors.Count)
-            throw new IndexOutOfRangeException(
-                $"validation error index {index} is outside 0..{_errors.Count - 1}");
+        // Deliberately Enumerable.ElementAt and not _errors[index]: the indexer raises
+        // ArgumentOutOfRangeException too, but ElementAt is the call BC makes, and matching the
+        // call rather than the outcome is what keeps this faithful if either side changes.
+        var message = _errors.ElementAt(index);
 
         var id = index + 1;
         if (id > _lastUsedId) _lastUsedId = id;
-        return _errors[index];
+        return message;
     }
 
     /// <summary>
@@ -127,7 +178,7 @@ internal sealed class TestFieldValidationErrors
     /// throw sites use (<see cref="AlRunner.Infrastructure.OutOfScopeMessage"/>), which
     /// tests/expectations/ matches on.</para>
     /// </summary>
-    internal void RunRecordingRefusal(Action write)
+    internal void RunRecordingRefusal(Action write, bool appendRefreshSuffix)
     {
         try
         {
@@ -137,7 +188,7 @@ internal sealed class TestFieldValidationErrors
             when (ex is not Microsoft.Dynamics.Nav.Types.Exceptions.NavTestValidationException
                   && AlRunner.Infrastructure.OutOfScopeMessage.FromException(ex) is null)
         {
-            Record(ex.Message);
+            Record(ex.Message, appendRefreshSuffix);
         }
     }
 }


### PR DESCRIPTION
Closes #3030

Opened by an agent (impl-30). Follow-up to #3007, which merged as `a895d95c` while its corpus
PR was still in flight.

## The tier disagreed with two things #3007 assumed

#3007 shipped with one claim flagged as an inference rather than a measurement, and one that was
not flagged at all. Corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#182 asked a real
service tier, and run **34002487601** answered both — identically on every leg that reported.
Three of the five claims passed; these two did not.

### 1. The recorded text is the AL message plus BC's refresh suffix

```
Expected:<Deliberate OnValidate failure for VAL-1>
Actual:  <Deliberate OnValidate failure for VAL-1 (Select Refresh to discard errors)>
```

`TestFieldValidationErrors.Record` stored `ex.Message`. Real BC's client appends its offer to
discard the staged row edit before storing.

This was not flagged in #3007, and the evidence that it was wrong had been sitting in the diff:
`TestPageMinMaxValue.MakeError` and `TestPageBooleanValue.MakeNotAcceptableError` already
carried that suffix inside their own hand-built strings, measured against real BC in #2490 and
corpus PR #163. #3007 stripped it from them on the theory that BC's wrapper supplied it. Nothing
supplied it, so those two refusals lost the suffix as well.

### 2. Out of range raises the other exception, and `asserterror` cannot trap it

```
System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'index')
   at System.Linq.Enumerable.ElementAt[TSource](IEnumerable`1 source, Int32 index)
   at Microsoft.Dynamics.Nav.Client.TestPageClient.TestFieldProxy.GetValidationError(Int32 index)
   at Microsoft.Dynamics.Nav.Runtime.NavTestField.ALGetValidationError(Int32 index)
   ...
   at Microsoft.Dynamics.Nav.Runtime.NavMethodScope.AssertErrorAsync(Func`1 body)
```

#3007 threw `IndexOutOfRangeException`, reasoning that `ALGetValidationError` carries a catch for
that type and BC would not carry a catch for something unreachable. The catch **is** unreachable:
BC's client uses LINQ's `ElementAt`, which raises the **Argument** flavour, the catch does not
match, and the exception escapes as `Unexpected CLR exception thrown.`. `AssertErrorAsync` is in
the stack and rethrew it, so AL `asserterror` does not trap it either. The runner was converting
an untrappable CLR failure into a trappable AL error the tier never produces.

## The fix

- Record the AL message **plus** `" (Select Refresh to discard errors)"` on a Rec-bound control,
  and take that suffix back out of the two hand-built helper messages so it is added exactly
  once. The composed AL-visible string is again the one corpus PR #163 measured on all eight
  legs.
- `Get` reads through `Enumerable.ElementAt` — literally the call BC's client makes, so the
  exception type, its parameter name and its escape path are the tier's, not an approximation of
  them.

## The part that is still a reading, and is now flagged as one

A page-**global** control's text stays bare, because Microsoft's Tests-SINGLESERVER
`Codeunit134614` asserts exactly that with exact equality:

```al
Assert.AreEqual('There should be at least one enabled ''SUPER'' user.',
    PermissionSetByUser.AllUsersHavePermission.GetValidationError(1), 'Wrong validation error message');
```

That this is a different shape from the corpus test's control is **mechanical, not inferred**:
probing the runner's own control-binding map over that test shows page 9807 resolves
`AllUsersHavePermission` as a page variable (`PageVariableTestField`), while page 60797's
`NameCtl` is Rec-bound (`LiveNavTestField`). A page-global control stages no row edit, so there
is nothing for "Refresh to discard" to discard.

What is **not** measured is Microsoft's half — no service-tier run in this repository has
confirmed it. Corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#184 asks it directly, with
three arms and exact equality, and says in its own body that a red result means both the runner
and Microsoft's assertion are wrong. Until it answers, this is the most defensible reading of
the evidence available, and the code, the unit test and the issue all say so rather than
presenting it as settled.

## Corpus PR #182 corrected, not weakened

Both wrong claims were corrected to the measured values, and no arm was deleted:

- Claim 2 now asserts the suffixed string, still with exact equality — which is what caught the
  original error instead of tolerating it.
- Claim 3 additionally asserts the suffix appears in the trapped exception, which is what would
  catch an implementation that appended it twice.
- Claim 5 could not survive as written: there is no passing AL test that can state "reading past
  the end raises", because the tier's answer is an untrappable CLR exception. The arm now stops
  **at** the boundary and asserts that the index `ValidationErrorCount()` reports is itself
  readable — a 1-based ledger, which fails against a 0-based one. The measured out-of-range
  behaviour is written into the file header with the run id rather than lost.

## Verification

- Corpus codeunit 60836, corrected, against this branch: **5/5**.
- Corpus codeunit 60808 (the new page-global question): 3/3 against this branch — which says it
  compiles and is not vacuous, not that the split is right.
- Microsoft `Codeunit134614` with #2969 applied: **14P/1F**, unchanged from #3007. The
  page-global path staying bare is what keeps its exact-equality assertion green.
- Full `tests/al-language` with `--strict --count-baseline`: **2599/2599**.
- Full `tests/runner-extras` with `--strict --count-baseline`: **287/287**.
- `dotnet test AlRunner.Tests --filter` over the five TestPage classes: **51/51**.

The two unit tests that encoded the wrong beliefs now assert the measured values and say in
their comments that a tier corrected them, so the next reader does not re-derive the old answer.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
