### PR TITLE
fix(permissions): say a BC-internals read that failed is a shape gap, not an out-of-scope refusal

### DIFF
--- a/AlRunner.Tests/PermissionMetadataShapeGapTests.cs
+++ b/AlRunner.Tests/PermissionMetadataShapeGapTests.cs
@@ -189,6 +189,107 @@ public sealed class PermissionMetadataShapeGapTests
         "RecordPatches.PermissionMetadataPopulator.cs",
     };
 
+    // ══ 6. The three factories, and what AL can do with what they raise: nothing ══════════
+
+    public static TheoryData<string, string> Factories() => new()
+    {
+        { "AggregatePermissionSetBcShapeGap", "Aggregate Permission Set (virtual table 2000000167)" },
+        { "MetadataPermissionSetBcShapeGap",  "Metadata Permission Set (virtual table 2000000250)" },
+        { "PermissionMetadataBcShapeGap",     "Permission metadata (NavAppGroup permission-set inventory)" },
+    };
+
+    [Theory]
+    [MemberData(nameof(Factories))]
+    public void EachFactory_NamesItsSurfaceTheMemberAndTheShapeGapDoc(string factory, string surface)
+    {
+        var ex = Build(factory, "NavAppGroup.permissionSetLookup", "field not found — probe");
+
+        Assert.Equal(surface, ex.Surface);
+        Assert.Equal("NavAppGroup.permissionSetLookup", ex.Member);
+        Assert.StartsWith("bc-shape-gap: ", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(surface, ex.Message, StringComparison.Ordinal);
+        Assert.Contains("NavAppGroup.permissionSetLookup", ex.Message, StringComparison.Ordinal);
+        // NOT docs/scope.md: a shape gap is not a scope claim.
+        Assert.EndsWith(" — see docs/limitations.md#bc-shape-gaps", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("docs/scope.md", ex.Message, StringComparison.Ordinal);
+    }
+
+    // The absorption defence: none of these may be recovered as an out-of-scope signal, so no
+    // expect-oos entry can ever declare a BC-layout regression on these tables as expected.
+    [Theory]
+    [MemberData(nameof(Factories))]
+    public void NeitherTheReporterNorTheManifest_MistakesOneForAnOutOfScopeRefusal(string factory, string surface)
+    {
+        var ex = Build(factory, "MetaPermissionSet.Access", "property not found — probe");
+
+        Assert.False(OutOfScopeMessage.TryParse(ex.Message, out _));
+        Assert.Null(OutOfScopeMessage.FromException(ex));
+        Assert.NotNull(BcShapeGapException.Find(ex));
+        _ = surface;
+    }
+
+    // ── The AL seams. This is the behaviour change the conversion is FOR. ──
+    // Before it these sites raised InvalidOperationException, which NavMethodScope_AssertError
+    // catches — so `asserterror <read of one of these tables>` passed while real BC, which reads
+    // the table fine, would have failed it.
+
+    [Theory]
+    [MemberData(nameof(Factories))]
+    public void AssertError_TearsThrough_ForEachPermissionSurface(string factory, string surface)
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => BcRuntime.NavMethodScope_AssertError(
+            null!, () => throw Build(factory, "NavAppGroup.BaseGroup", "static field not found — probe")));
+
+        Assert.Equal(surface, ex.Surface);
+    }
+
+    [Theory]
+    [MemberData(nameof(Factories))]
+    public void TryFunction_TearsThrough_ForEachPermissionSurface(string factory, string surface)
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => BcRuntime.NavApplicationObjectBase_TryInvoke(
+            null, () => throw Build(factory, "NavCode(int, string)", "constructor not found — probe")));
+
+        Assert.Equal(surface, ex.Surface);
+    }
+
+    // ── CONTROL ARMS ──
+    // Without these, "tears through" would be satisfied by seams that trapped nothing at all,
+    // and by an assertion that merely discriminated on exception type.
+
+    [Fact]
+    public void BothSeams_StillTrapAPermanentRefusal_SoTearThroughIsNotVacuous()
+    {
+        Assert.False(BcRuntime.NavApplicationObjectBase_TryInvoke(
+            null, () => throw new RunnerOutOfScopeException(
+                "NavEmail.Send", "email-smtp — no SMTP transport in the runner", "email")));
+
+        // asserterror returning normally IS its pass signal.
+        BcRuntime.NavMethodScope_AssertError(null!, () => throw new RunnerOutOfScopeException(
+            "NavEmail.Send", "email-smtp — no SMTP transport in the runner", "email"));
+    }
+
+    // The three refusals in this slice that were NOT converted keep the OLD contract, and that
+    // is the point of leaving them: "data access has no in-memory provider" is an answer about
+    // the RUNNER's own store wiring, so an expect-oos entry may still absorb it.
+    [Fact]
+    public void TheUnconvertedVirtualTableRefusals_AreStillAbsorbableOutOfScopeSignals()
+    {
+        var refusal = RecordPatches.MetadataPermissionSetShapeGap("data access has no in-memory provider");
+
+        Assert.IsType<RunnerOutOfScopeException>(refusal);
+        Assert.Null(BcShapeGapException.Find(refusal));
+        Assert.NotNull(OutOfScopeMessage.FromException(refusal));
+        Assert.StartsWith("not-yet-implemented", refusal.Reason, StringComparison.Ordinal);
+    }
+
+    private static BcShapeGapException Build(string factory, string member, string detail)
+    {
+        var m = typeof(RecordPatches).GetMethod(factory, BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"test setup: RecordPatches.{factory} not found");
+        return (BcShapeGapException)m.Invoke(null, new object?[] { member, detail })!;
+    }
+
     // ══ Plumbing ═════════════════════════════════════════════════════════════════════════
 
     private static object? Invoke(string name, params object?[] args)

--- a/AlRunner.Tests/PermissionMetadataShapeGapTests.cs
+++ b/AlRunner.Tests/PermissionMetadataShapeGapTests.cs
@@ -1,0 +1,228 @@
+// PermissionMetadataShapeGapTests — the permission-metadata slice of #2994.
+//
+// WHAT IS BEING PROVED
+//   #2946 settled that "the runner could not READ BC's internals" raises
+//   BcShapeGapException, and converted six readers. This file covers the next slice: every
+//   BC-internals reflection guard behind the two permission virtual tables and the permission
+//   metadata layer they share —
+//
+//     RecordPatches.AggregatePermissionSetVirtualTable.cs   (Aggregate Permission Set, 2000000167)
+//     RecordPatches.MetadataPermissionSetVirtualTable.cs    (Metadata Permission Set, 2000000250)
+//     RecordPatches.PermissionMetadataPopulator.cs          (the NavAppGroup inventory both drive)
+//
+//   The third file is in the slice because EnsurePermissionMetadataPopulated() is called from
+//   the AL-entered populate path of BOTH tables and from nowhere else, so its refusals reach
+//   AL exactly as the tables' own do. Leaving it out would have half-converted one path.
+//
+// WHY IT MATTERS THAT THE TYPE CHANGES
+//   NavMethodScope_AssertError is an unfiltered catch(Exception). So today
+//   `asserterror <read of Metadata Permission Set>` around a site whose BC member has moved
+//   PASSES, where real BC reads the table fine and the asserterror fails. Catching the refusal
+//   does not hide the gap, it INVERTS the result. BcShapeGapException tears through both AL
+//   seams, which is the whole point of the conversion.
+//
+// THE FOUR END-TO-END ARMS
+//   SetProperty, SetBackingField, SetEmptyListBackingField and BuildIncludeList each take the
+//   reflected type or target as a PARAMETER, so they can be driven with a fake standing in for
+//   a BC type whose member moved — real production code, no BC install required. Every one is
+//   paired with a control arm that still succeeds, so a conversion that threw unconditionally
+//   would fail here rather than pass.
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PermissionMetadataShapeGapTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    // ══ 1. SetProperty — BC's MetaPermissionSet / MetaPermission property moved ═══════════
+
+    [Fact]
+    public void SetProperty_RaisesAShapeGapNamingTheMember_WhenBcsPropertyIsGone()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Invoke("SetProperty", new HasNoSuchProperty(), "Assignable", true));
+
+        Assert.Contains("Assignable", ex.Member, StringComparison.Ordinal);
+        Assert.Contains(nameof(HasNoSuchProperty), ex.Member, StringComparison.Ordinal);
+        Assert.StartsWith("bc-shape-gap: ", ex.Message, StringComparison.Ordinal);
+    }
+
+    // CONTROL: it still writes a property that IS there.
+    [Fact]
+    public void SetProperty_StillWrites_WhenThePropertyIsPresent()
+    {
+        var target = new HasAutoProperty();
+        Invoke("SetProperty", target, nameof(HasAutoProperty.Name), "SUPER");
+        Assert.Equal("SUPER", target.Name);
+    }
+
+    // ══ 2. SetBackingField — the auto-property backing field BC generates ════════════════
+
+    [Fact]
+    public void SetBackingField_RaisesAShapeGapNamingTheMember_WhenTheBackingFieldIsGone()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Invoke("SetBackingField", typeof(HasNoSuchProperty), new HasNoSuchProperty(), "Permissions", null));
+
+        Assert.Contains("Permissions", ex.Member, StringComparison.Ordinal);
+        Assert.Contains("backing field", ex.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SetBackingField_StillPokes_WhenTheBackingFieldIsPresent()
+    {
+        var target = new HasAutoProperty();
+        Invoke("SetBackingField", typeof(HasAutoProperty), target, nameof(HasAutoProperty.Name), "SECURITY");
+        Assert.Equal("SECURITY", target.Name);
+    }
+
+    // ══ 3. SetEmptyListBackingField — the property whose element type it reads ════════════
+
+    [Fact]
+    public void SetEmptyListBackingField_RaisesAShapeGapNamingTheProperty_WhenItIsGone()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Invoke("SetEmptyListBackingField", typeof(HasNoSuchProperty), new HasNoSuchProperty(), "IncludedPermissionSets"));
+
+        Assert.Contains("IncludedPermissionSets", ex.Member, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SetEmptyListBackingField_StillInstallsAnEmptyList_WhenThePropertyIsPresent()
+    {
+        var target = new HasListProperty();
+        Invoke("SetEmptyListBackingField", typeof(HasListProperty), target, nameof(HasListProperty.Items));
+
+        Assert.NotNull(target.Items);
+        Assert.Empty(target.Items!);
+    }
+
+    // ══ 4. BuildIncludeList — BC's include/exclude element type is one it cannot fill ═════
+
+    [Fact]
+    public void BuildIncludeList_RaisesAShapeGapNamingTheElementType_WhenItCannotBeFilled()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Invoke("BuildIncludeList", typeof(List<NotFillableElement>), (IReadOnlyList<string>)new[] { "SUPER" }));
+
+        Assert.Contains(nameof(NotFillableElement), ex.Member, StringComparison.Ordinal);
+    }
+
+    // CONTROL: the string element type — what BC actually declares — still fills.
+    [Fact]
+    public void BuildIncludeList_StillFills_AStringElementList()
+    {
+        var list = (IList)Invoke("BuildIncludeList", typeof(List<string>), (IReadOnlyList<string>)new[] { "SUPER", "SECURITY" })!;
+
+        Assert.Equal(2, list.Count);
+        Assert.Equal("SUPER", list[0]);
+        Assert.Equal("SECURITY", list[1]);
+    }
+
+    // ══ 5. The sweep happened, and it stopped exactly where the judgement said ════════════
+    //
+    // Pins BOTH directions. Under-conversion fails (a BC-internals read still raising the
+    // retired type is not in the allowlist); over-conversion fails too (the five deliberate
+    // NON-conversions have to survive). Matching on message text rather than line number so
+    // the guard does not rot on an unrelated edit.
+
+    [Fact]
+    public void EveryRemainingInvalidOperationExceptionInTheSlice_IsOneOfTheFiveDeliberateNonConversions()
+    {
+        // Each of these five raises after a read that SUCCEEDED, so BcShapeGapException.cs's
+        // line says they stay as they are:
+        //   * the field/assembly was resolved and BC (or the runner's own setup) answered null,
+        //   * or the assembly is absent, which is the runner's load chain rather than BC's layout.
+        string[] allowed =
+        {
+            "PermissionSetRecord.permissionSetKey was null",       // BC's record answered null
+            "NavAppGroup.BaseGroup is null",                       // skeleton the RUNNER populates
+            "Microsoft.Dynamics.Nav.Ncl is not loaded",            // runner load chain, not BC shape
+            "Microsoft.Dynamics.Nav.Types is not loaded",          // ditto (x2 — two resolvers)
+        };
+
+        var offenders = new List<string>();
+        var survivors = 0;
+
+        foreach (var file in SliceFiles)
+        {
+            var path = Path.Combine(RepoRoot, "AlRunner", "Patches", file);
+            Assert.True(File.Exists(path), $"{file} not found at {path} — it was renamed or moved.");
+
+            var lines = File.ReadAllLines(path);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                if (!lines[i].Contains("throw new InvalidOperationException", StringComparison.Ordinal)) continue;
+
+                // The whole throw expression, which may span lines.
+                var end = i;
+                while (end < lines.Length - 1 && !lines[end].TrimEnd().EndsWith(";", StringComparison.Ordinal)) end++;
+                var text = string.Join(" ", lines.Skip(i).Take(end - i + 1).Select(l => l.Trim()));
+
+                if (allowed.Any(a => text.Contains(a, StringComparison.Ordinal))) { survivors++; continue; }
+                offenders.Add($"{file}:{i + 1}: {text}");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "these BC-internals reads still raise the retired InvalidOperationException convention "
+            + $"instead of BcShapeGapException (#2994):{Environment.NewLine}"
+            + string.Join(Environment.NewLine, offenders));
+
+        Assert.Equal(5, survivors);
+    }
+
+    private static readonly string[] SliceFiles =
+    {
+        "RecordPatches.AggregatePermissionSetVirtualTable.cs",
+        "RecordPatches.MetadataPermissionSetVirtualTable.cs",
+        "RecordPatches.PermissionMetadataPopulator.cs",
+    };
+
+    // ══ Plumbing ═════════════════════════════════════════════════════════════════════════
+
+    private static object? Invoke(string name, params object?[] args)
+    {
+        var m = typeof(RecordPatches).GetMethod(name, BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException($"test setup: RecordPatches.{name} not found");
+        try
+        {
+            return m.Invoke(null, args);
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            throw tie.InnerException;   // the reflection wrapper is not part of the contract
+        }
+    }
+
+    private sealed class HasNoSuchProperty
+    {
+    }
+
+    private sealed class HasAutoProperty
+    {
+        public string? Name { get; set; }
+    }
+
+    private sealed class HasListProperty
+    {
+        public List<string>? Items { get; set; }
+    }
+
+    private sealed class NotFillableElement
+    {
+        // Deliberately NOT the (int, string) shape BuildIncludeList knows how to fill.
+        public NotFillableElement(long ignored) => Ignored = ignored;
+        public long Ignored { get; }
+    }
+}

--- a/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
+++ b/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
@@ -290,7 +290,13 @@ public sealed class VirtualTableRefusalClaimTests
         var total = CoveredFiles.Concat(SiblingFiles).Sum(file =>
         {
             var src = File.ReadAllText(Path.Combine(RepoRoot, "AlRunner", "Patches", file));
-            return Regex.Matches(src, @"throw (RecordPatches\.)?[A-Za-z]+ShapeGap\(").Count;
+            // The (?<!Bc) is load-bearing. #2994 added a SECOND convention whose factories also
+            // end in "ShapeGap" — AggregatePermissionSetBcShapeGap and friends — but those return
+            // BcShapeGapException, a different type with a different contract (it tears through
+            // asserterror and no expect-oos entry can absorb it). Counting both together would
+            // make this number mean nothing. This assertion is about the RunnerOutOfScopeException
+            // refusals #2945 corrected, so a *BcShapeGap( call is deliberately not one of them.
+            return Regex.Matches(src, @"throw (RecordPatches\.)?[A-Za-z]+(?<!Bc)ShapeGap\(").Count;
         });
 
         // 51 in the sixteen populators + 3 in RecordPatches.cs's dispatch chain + 4 in

--- a/AlRunner/Patches/RecordPatches.AggregatePermissionSetVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AggregatePermissionSetVirtualTable.cs
@@ -332,58 +332,82 @@ public static partial class RecordPatches
         const string rt = "Microsoft.Dynamics.Nav.Runtime.";
 
         _apsProviderType = ResolveType(rt + "AggregatePermissionSetDataProvider", rt + "AggregatePermissionSetDataProvider")
-            ?? throw new InvalidOperationException("AggregatePermissionSetDataProvider type not found in Ncl");
+            ?? throw AggregatePermissionSetBcShapeGap(
+                "AggregatePermissionSetDataProvider",
+                "type not found in Ncl — the Aggregate Permission Set table cannot be populated");
 
         var tNavSession = ResolveType(rt + "NavSession", rt + "NavSession")
-            ?? throw new InvalidOperationException("NavSession type not found");
+            ?? throw AggregatePermissionSetBcShapeGap(
+                "NavSession",
+                "type not found in Ncl — the Aggregate Permission Set table cannot be populated");
         var tNclMetadata = ResolveType(rt + "NCLMetadata", rt + "NCLMetadata")
-            ?? throw new InvalidOperationException("NCLMetadata type not found");
+            ?? throw AggregatePermissionSetBcShapeGap(
+                "NCLMetadata",
+                "type not found in Ncl — the Aggregate Permission Set table cannot be populated");
         var tNavValue = ResolveType(rt + "NavValue", "Microsoft.Dynamics.Nav.Types.NavValue")
-            ?? throw new InvalidOperationException("NavValue type not found");
+            ?? throw AggregatePermissionSetBcShapeGap(
+                "NavValue",
+                "type not found in Ncl or Types — the Aggregate Permission Set table cannot be populated");
         var tNavCode = ResolveType(rt + "NavCode", "Microsoft.Dynamics.Nav.Types.NavCode")
-            ?? throw new InvalidOperationException("NavCode type not found");
+            ?? throw AggregatePermissionSetBcShapeGap(
+                "NavCode",
+                "type not found in Ncl or Types — the Aggregate Permission Set table cannot be populated");
         var tPermissionSetKey = ResolveType(
             "Microsoft.Dynamics.Nav.Runtime.Permissions.PermissionSetKey",
             "Microsoft.Dynamics.Nav.Runtime.Permissions.PermissionSetKey")
-            ?? throw new InvalidOperationException("PermissionSetKey type not found");
+            ?? throw AggregatePermissionSetBcShapeGap(
+                "Permissions.PermissionSetKey",
+                "type not found in Ncl — the Aggregate Permission Set table cannot be populated");
         var tPermissionSetRecord = _apsProviderType.GetNestedType("PermissionSetRecord", BindingFlags.Public | BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException("AggregatePermissionSetDataProvider.PermissionSetRecord type not found");
+            ?? throw AggregatePermissionSetBcShapeGap(
+                "AggregatePermissionSetDataProvider.PermissionSetRecord",
+                "nested type not found — the Aggregate Permission Set table cannot be populated");
 
         _apsProviderCtor = _apsProviderType.GetConstructor(
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
             binder: null, types: new[] { tNavSession, tNclMetadata }, modifiers: null)
-            ?? throw new InvalidOperationException(
-                "AggregatePermissionSetDataProvider(NavSession, NCLMetadata) ctor not found");
+            ?? throw AggregatePermissionSetBcShapeGap(
+                "AggregatePermissionSetDataProvider(NavSession, NCLMetadata)",
+                "constructor not found — the Aggregate Permission Set table cannot be populated");
 
         _apsGetSystemPermissionSets = _apsProviderType.GetMethod("GetSystemPermissionSets",
             BindingFlags.NonPublic | BindingFlags.Instance, binder: null,
             types: new[] { tNavValue, tNavCode }, modifiers: null)
-            ?? throw new InvalidOperationException(
-                "AggregatePermissionSetDataProvider.GetSystemPermissionSets(NavValue, NavCode) not found");
+            ?? throw AggregatePermissionSetBcShapeGap(
+                "AggregatePermissionSetDataProvider.GetSystemPermissionSets(NavValue, NavCode)",
+                "method not found — the Aggregate Permission Set table cannot be populated");
 
         _apsGetTenantPermissionSets = _apsProviderType.GetMethod("GetTenantPermissionSets",
             BindingFlags.NonPublic | BindingFlags.Instance, binder: null,
             types: new[] { tNavValue, tNavCode }, modifiers: null)
-            ?? throw new InvalidOperationException(
-                "AggregatePermissionSetDataProvider.GetTenantPermissionSets(NavValue, NavCode) not found");
+            ?? throw AggregatePermissionSetBcShapeGap(
+                "AggregatePermissionSetDataProvider.GetTenantPermissionSets(NavValue, NavCode)",
+                "method not found — the Aggregate Permission Set table cannot be populated");
 
         _apsCreateRecordBuffer = _apsProviderType.GetMethod("CreateRecordBuffer",
             BindingFlags.NonPublic | BindingFlags.Instance, binder: null,
             types: new[] { tPermissionSetRecord, typeof(string) }, modifiers: null)
-            ?? throw new InvalidOperationException(
-                "AggregatePermissionSetDataProvider.CreateRecordBuffer(PermissionSetRecord, string) not found");
+            ?? throw AggregatePermissionSetBcShapeGap(
+                "AggregatePermissionSetDataProvider.CreateRecordBuffer(PermissionSetRecord, string)",
+                "method not found — the Aggregate Permission Set table cannot be populated");
 
         _apsRecordKeyField = tPermissionSetRecord.GetField("permissionSetKey",
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException("PermissionSetRecord.permissionSetKey field not found");
+            ?? throw AggregatePermissionSetBcShapeGap(
+                "PermissionSetRecord.permissionSetKey",
+                "field not found — the Aggregate Permission Set table cannot be populated");
 
         _apsKeyAppIdProp = tPermissionSetKey.GetProperty("AppId",
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException("PermissionSetKey.AppId property not found");
+            ?? throw AggregatePermissionSetBcShapeGap(
+                "PermissionSetKey.AppId",
+                "property not found — the Aggregate Permission Set table cannot be populated");
 
         _apsSessionNclMetadata = tNavSession.GetProperty("NCLMetadata",
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException("NavSession.NCLMetadata property not found");
+            ?? throw AggregatePermissionSetBcShapeGap(
+                "NavSession.NCLMetadata",
+                "property not found — the Aggregate Permission Set table cannot be populated");
 
         _apsReflectionReady = true;
     }
@@ -397,10 +421,14 @@ public static partial class RecordPatches
         var nclAsm = dataAccess.GetType().Assembly;
         const string rt = "Microsoft.Dynamics.Nav.Runtime.";
         var tDataAccess = nclAsm.GetType(rt + "DataAccess")
-            ?? throw new InvalidOperationException("DataAccess type not found in Ncl");
+            ?? throw AggregatePermissionSetBcShapeGap(
+                "DataAccess",
+                "type not found in Ncl — the Aggregate Permission Set table cannot be populated");
         _apsDataAccessSession = tDataAccess.GetProperty("Session",
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException("DataAccess.Session not found");
+            ?? throw AggregatePermissionSetBcShapeGap(
+                "DataAccess.Session",
+                "property not found — the Aggregate Permission Set table cannot be populated");
         _apsLiveGuardReady = true;
     }
 

--- a/AlRunner/Patches/RecordPatches.MetadataPermissionSetVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.MetadataPermissionSetVirtualTable.cs
@@ -329,9 +329,9 @@ public static partial class RecordPatches
         var code = RoleIdNavCode(permissionSet, MetadataPermissionSetRoleIdLength);
         _mpsNavStringValueValue ??= code.GetType().GetProperty("Value",
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-            ?? throw new InvalidOperationException(
-                $"[MetadataPermissionSet] {code.GetType().Name}.Value not found — the Name "
-                + "fallback cannot read the Role ID back off BC's own NavCode");
+            ?? throw MetadataPermissionSetBcShapeGap(
+                $"{code.GetType().Name}.Value",
+                "property not found, so the Name fallback cannot read the Role ID back off BC's own NavCode — the Metadata Permission Set table cannot be populated");
         return _mpsNavStringValueValue.GetValue(code) as string ?? string.Empty;
     }
 
@@ -349,21 +349,33 @@ public static partial class RecordPatches
         const string rt = "Microsoft.Dynamics.Nav.Runtime.";
 
         var tNavGuid = ResolveType(rt + "NavGuid", "Microsoft.Dynamics.Nav.Types.NavGuid")
-            ?? throw new InvalidOperationException("NavGuid type not found");
+            ?? throw MetadataPermissionSetBcShapeGap(
+                "NavGuid",
+                "type not found in Ncl or Types — the Metadata Permission Set table cannot be populated");
         _mpsNavGuidCreate = tNavGuid.GetMethod("Create", BindingFlags.Public | BindingFlags.Static,
             binder: null, types: new[] { typeof(Guid) }, modifiers: null)
-            ?? throw new InvalidOperationException("NavGuid.Create(Guid) not found");
+            ?? throw MetadataPermissionSetBcShapeGap(
+                "NavGuid.Create(Guid)",
+                "method not found — the Metadata Permission Set table cannot be populated");
 
         var tNavBoolean = ResolveType(rt + "NavBoolean", "Microsoft.Dynamics.Nav.Types.NavBoolean")
-            ?? throw new InvalidOperationException("NavBoolean type not found");
+            ?? throw MetadataPermissionSetBcShapeGap(
+                "NavBoolean",
+                "type not found in Ncl or Types — the Metadata Permission Set table cannot be populated");
         _mpsNavBooleanCreate = tNavBoolean.GetMethod("Create", BindingFlags.Public | BindingFlags.Static,
             binder: null, types: new[] { typeof(bool) }, modifiers: null)
-            ?? throw new InvalidOperationException("NavBoolean.Create(bool) not found");
+            ?? throw MetadataPermissionSetBcShapeGap(
+                "NavBoolean.Create(bool)",
+                "method not found — the Metadata Permission Set table cannot be populated");
 
         var tNavCode = ResolveType(rt + "NavCode", "Microsoft.Dynamics.Nav.Types.NavCode")
-            ?? throw new InvalidOperationException("NavCode type not found");
+            ?? throw MetadataPermissionSetBcShapeGap(
+                "NavCode",
+                "type not found in Ncl or Types — the Metadata Permission Set table cannot be populated");
         _mpsNavCodeCtor = tNavCode.GetConstructor(new[] { typeof(int), typeof(string) })
-            ?? throw new InvalidOperationException("NavCode(int,string) ctor not found");
+            ?? throw MetadataPermissionSetBcShapeGap(
+                "NavCode(int, string)",
+                "constructor not found — the Metadata Permission Set table cannot be populated");
 
         _ = nclAsm;
         _mpsReflectionReady = true;

--- a/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
@@ -182,12 +182,13 @@ public static partial class RecordPatches
     private static void InstallPermissionSetSlot(object baseGroup, List<object> summaries)
     {
         var arr = _fSummariesByType!.GetValue(baseGroup) as Array
-            ?? throw new InvalidOperationException(
-                "NavAppGroup.groupObjectMetadataSummariesByType is not an array — Ncl shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "NavAppGroup.groupObjectMetadataSummariesByType",
+                "holds a value that is not an array, so the PermissionSet slot cannot be indexed — BC's permission-set metadata inventory cannot be populated");
         if (PermissionSetObjectTypeOrdinal >= arr.Length)
-            throw new InvalidOperationException(
-                $"NavAppGroup.groupObjectMetadataSummariesByType has {arr.Length} slots, "
-                + $"so ObjectType.PermissionSet ({PermissionSetObjectTypeOrdinal}) is out of range — Ncl shape changed; do not commit");
+            throw PermissionMetadataBcShapeGap(
+                "NavAppGroup.groupObjectMetadataSummariesByType",
+                $"has {arr.Length} slots, so ObjectType.PermissionSet ({PermissionSetObjectTypeOrdinal}) is out of range — BC's permission-set metadata inventory cannot be populated");
 
         var comparer = _fComparerInstance!.GetValue(null)
             ?? Activator.CreateInstance(_tGroupSummaryComparer!)!;
@@ -198,8 +199,9 @@ public static partial class RecordPatches
         // which is the same ordering BC's own constructor applies before freezing the array.
         var compare = _tGroupSummaryComparer!.GetMethod("Compare",
             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException(
-                "GroupSummaryComparer.Compare not found — Ncl shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "NavAppGroup.GroupSummaryComparer.Compare",
+                "method not found — BC's permission-set metadata inventory cannot be populated");
         summaries.Sort((x, y) => (int)compare.Invoke(comparer, new[] { x, y })!);
 
         var typed = Array.CreateInstance(_tSummary!, summaries.Count);
@@ -208,8 +210,9 @@ public static partial class RecordPatches
         var frozenType = _tFrozenSharingArrayOpen!.MakeGenericType(_tSummary!);
         var ctor = frozenType.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
             .FirstOrDefault(c => c.GetParameters().Length == 2)
-            ?? throw new InvalidOperationException(
-                "FrozenSharingArray<T>(IReadOnlyList<T>, IComparer<T>) not found — Ncl shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "FrozenSharingArray<T>(IReadOnlyList<T>, IComparer<T>)",
+                "constructor not found — BC's permission-set metadata inventory cannot be populated");
         arr.SetValue(ctor.Invoke(new[] { typed, comparer }), PermissionSetObjectTypeOrdinal);
     }
 
@@ -246,8 +249,9 @@ public static partial class RecordPatches
         var lazyCtor = lazyType.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
             .FirstOrDefault(c => c.GetParameters().Length == 1
                                  && c.GetParameters()[0].ParameterType == funcType)
-            ?? throw new InvalidOperationException(
-                "LazyEx<T>(Func<T>) not found — Ncl shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "LazyEx<T>(Func<T>)",
+                "constructor not found — BC's permission-set metadata inventory cannot be populated");
         FieldPoke.SetInstance(lazyField, baseGroup, lazyCtor.Invoke(new object?[] { factory }));
     }
 
@@ -301,73 +305,95 @@ public static partial class RecordPatches
         const BindingFlags Inst = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
 
         _tNavAppGroupPM = ncl.GetType("Microsoft.Dynamics.Nav.Runtime.Apps.NavAppGroup")
-            ?? throw new InvalidOperationException("NavAppGroup not found — Ncl shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "NavAppGroup",
+                "type not found in Ncl — BC's permission-set metadata inventory cannot be populated");
         _fBaseGroupPM = _tNavAppGroupPM.GetField("BaseGroup", BindingFlags.Public | BindingFlags.Static)
-            ?? throw new InvalidOperationException("NavAppGroup.BaseGroup not found — Ncl shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "NavAppGroup.BaseGroup",
+                "static field not found — BC's permission-set metadata inventory cannot be populated");
         _fSummariesByType = _tNavAppGroupPM.GetField("groupObjectMetadataSummariesByType", Inst)
-            ?? throw new InvalidOperationException(
-                "NavAppGroup.groupObjectMetadataSummariesByType not found — Ncl shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "NavAppGroup.groupObjectMetadataSummariesByType",
+                "field not found — BC's permission-set metadata inventory cannot be populated");
         _fPermissionSetLookup = _tNavAppGroupPM.GetField("permissionSetLookup", Inst)
-            ?? throw new InvalidOperationException(
-                "NavAppGroup.permissionSetLookup not found — Ncl shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "NavAppGroup.permissionSetLookup",
+                "field not found — BC's permission-set metadata inventory cannot be populated");
 
         _tSummary = ncl.GetType("Microsoft.Dynamics.Nav.Runtime.Apps.NavAppGroupObjectMetadataSummary")
-            ?? throw new InvalidOperationException(
-                "NavAppGroupObjectMetadataSummary not found — Ncl shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "NavAppGroupObjectMetadataSummary",
+                "type not found in Ncl — BC's permission-set metadata inventory cannot be populated");
         _ctorSummary = _tSummary.GetConstructors(Inst).FirstOrDefault(c => c.GetParameters().Length == 6)
-            ?? throw new InvalidOperationException(
-                "NavAppGroupObjectMetadataSummary(NavAppGroup, NavAppRuntimeMetadata, ObjectType, int, string, string) "
-                + "not found — Ncl shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "NavAppGroupObjectMetadataSummary(NavAppGroup, NavAppRuntimeMetadata, ObjectType, int, string, string)",
+                "constructor not found — BC's permission-set metadata inventory cannot be populated");
 
         _tFrozenSharingArrayOpen = ncl.GetType("Microsoft.Dynamics.Nav.Runtime.FrozenSharingArray`1")
-            ?? throw new InvalidOperationException("FrozenSharingArray`1 not found — Ncl shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "FrozenSharingArray`1",
+                "type not found in Ncl — BC's permission-set metadata inventory cannot be populated");
         _tGroupSummaryComparer = _tNavAppGroupPM.GetNestedType("GroupSummaryComparer",
             BindingFlags.Public | BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException(
-                "NavAppGroup.GroupSummaryComparer not found — Ncl shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "NavAppGroup.GroupSummaryComparer",
+                "nested type not found — BC's permission-set metadata inventory cannot be populated");
         _fComparerInstance = _tGroupSummaryComparer.GetField("Instance",
             BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException(
-                "GroupSummaryComparer.Instance not found — Ncl shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "NavAppGroup.GroupSummaryComparer.Instance",
+                "static field not found — BC's permission-set metadata inventory cannot be populated");
 
         _tNavCode = ncl.GetType("Microsoft.Dynamics.Nav.Runtime.NavCode")
             ?? types.GetType("Microsoft.Dynamics.Nav.Types.NavCode")
-            ?? throw new InvalidOperationException("NavCode not found — Ncl shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "NavCode",
+                "type not found in Ncl or Types — BC's permission-set metadata inventory cannot be populated");
         _ctorNavCode = _tNavCode.GetConstructors(Inst).FirstOrDefault(c =>
         {
             var p = c.GetParameters();
             return p.Length == 2 && p[0].ParameterType == typeof(int) && p[1].ParameterType == typeof(string);
-        }) ?? throw new InvalidOperationException("NavCode(int, string) not found — Ncl shape changed; do not commit");
+        }) ?? throw PermissionMetadataBcShapeGap(
+            "NavCode(int, string)",
+            "constructor not found — BC's permission-set metadata inventory cannot be populated");
 
         _tObjectTypePM = types.GetType("Microsoft.Dynamics.Nav.Types.ObjectType")
-            ?? throw new InvalidOperationException("ObjectType not found — Types shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "ObjectType",
+                "type not found in Types — BC's permission-set metadata inventory cannot be populated");
         if (!Enum.IsDefined(_tObjectTypePM, PermissionSetObjectTypeOrdinal)
             || Enum.ToObject(_tObjectTypePM, PermissionSetObjectTypeOrdinal).ToString() != "PermissionSet")
-            throw new InvalidOperationException(
-                $"ObjectType value {PermissionSetObjectTypeOrdinal} is not PermissionSet in this BC build "
-                + "— the slot index this file writes would be the wrong object type; do not commit");
+            throw PermissionMetadataBcShapeGap(
+                "ObjectType",
+                $"value {PermissionSetObjectTypeOrdinal} is not PermissionSet in this BC build, so the slot index this file writes would be the wrong object type — BC's permission-set metadata inventory cannot be populated");
 
         var apps = AppDomain.CurrentDomain.GetAssemblies()
                        .FirstOrDefault(a => a.GetName().Name == "Microsoft.Dynamics.Nav.Apps")
                    ?? Assembly.Load("Microsoft.Dynamics.Nav.Apps");
         _tAppRuntimeMetadata = apps.GetType("Microsoft.Dynamics.Nav.Apps.Runtime.NavAppRuntimeMetadata")
-            ?? throw new InvalidOperationException(
-                "NavAppRuntimeMetadata not found — Microsoft.Dynamics.Nav.Apps shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "NavAppRuntimeMetadata",
+                "type not found in Microsoft.Dynamics.Nav.Apps — BC's permission-set metadata inventory cannot be populated");
         // The SHORTER of the two public constructors: same values minus the summaries and
         // dependencies lists, which a synthesised owner has nothing truthful to put in.
         _ctorAppRuntimeMetadata = _tAppRuntimeMetadata.GetConstructors()
             .OrderBy(c => c.GetParameters().Length).FirstOrDefault()
-            ?? throw new InvalidOperationException(
-                "NavAppRuntimeMetadata has no public constructor — Apps shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "NavAppRuntimeMetadata",
+                "has no public constructor — BC's permission-set metadata inventory cannot be populated");
         _tAppId = _ctorAppRuntimeMetadata.GetParameters()
             .FirstOrDefault(p => p.ParameterType.Name == "AppId")?.ParameterType
-            ?? throw new InvalidOperationException(
-                "NavAppRuntimeMetadata's constructor takes no AppId — Apps shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "NavAppRuntimeMetadata..ctor",
+                "takes no AppId parameter — BC's permission-set metadata inventory cannot be populated");
         _ctorAppId = _tAppId.GetConstructors().FirstOrDefault(c =>
         {
             var p = c.GetParameters();
             return p.Length == 1 && p[0].ParameterType == typeof(Guid);
-        }) ?? throw new InvalidOperationException("AppId(Guid) not found — Common shape changed; do not commit");
+        }) ?? throw PermissionMetadataBcShapeGap(
+            "AppId(Guid)",
+            "constructor not found — BC's permission-set metadata inventory cannot be populated");
 
         _permMetaReflectionReady = true;
     }
@@ -411,12 +437,14 @@ public static partial class RecordPatches
 
         var ncl = _tNavAppGroupPM!.Assembly;
         var metaType = ncl.GetType("Microsoft.Dynamics.Nav.Runtime.NCLMetaPermissionSet")
-            ?? throw new InvalidOperationException(
-                "NCLMetaPermissionSet not found — Ncl shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "NCLMetaPermissionSet",
+                "type not found in Ncl — BC's permission-set metadata inventory cannot be populated");
         _mCreateEmptyMetaPermissionSet ??= metaType.GetMethod("CreateEmptyNCLMetaPermissionSet",
             BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException(
-                "NCLMetaPermissionSet.CreateEmptyNCLMetaPermissionSet not found — Ncl shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "NCLMetaPermissionSet.CreateEmptyNCLMetaPermissionSet",
+                "static method not found — BC's permission-set metadata inventory cannot be populated");
 
         var baseGroup = _fBaseGroupPM!.GetValue(null);
         var meta = _mCreateEmptyMetaPermissionSet.Invoke(null,
@@ -429,8 +457,9 @@ public static partial class RecordPatches
         // this way every field BC sets is set, by BC.
         var assign = metaType.GetMethod("AssignFromMetaPermissionSet",
             BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
-            ?? throw new InvalidOperationException(
-                "NCLMetaPermissionSet.AssignFromMetaPermissionSet not found — Ncl shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "NCLMetaPermissionSet.AssignFromMetaPermissionSet",
+                "method not found — BC's permission-set metadata inventory cannot be populated");
         assign.Invoke(meta, new[] { BuildMetaPermissionSet(declaration) });
 
         EnsureCachePopulatorReflection();
@@ -444,8 +473,9 @@ public static partial class RecordPatches
     {
         var f = declaring.GetField($"<{propertyName}>k__BackingField",
             BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
-            ?? throw new InvalidOperationException(
-                $"NCLMetaPermissionSet.{propertyName} has no backing field — Ncl shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                $"NCLMetaPermissionSet.{propertyName}",
+                "has no backing field — BC's permission-set metadata inventory cannot be populated");
         FieldPoke.SetInstance(f, target, value);
     }
 
@@ -453,8 +483,9 @@ public static partial class RecordPatches
     {
         var prop = declaring.GetProperty(propertyName,
             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException(
-                $"NCLMetaPermissionSet.{propertyName} not found — Ncl shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                $"NCLMetaPermissionSet.{propertyName}",
+                "property not found — BC's permission-set metadata inventory cannot be populated");
         var element = prop.PropertyType.IsGenericType
             ? prop.PropertyType.GetGenericArguments()[0]
             : typeof(object);
@@ -552,19 +583,22 @@ public static partial class RecordPatches
             ?? throw new InvalidOperationException("Microsoft.Dynamics.Nav.Types is not loaded");
 
         _tMetaPermissionSet ??= types.GetType("Microsoft.Dynamics.Nav.Types.Metadata.MetaPermissionSet")
-            ?? throw new InvalidOperationException(
-                "MetaPermissionSet not found — Types shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "MetaPermissionSet",
+                "type not found in Types — BC's permission-set metadata inventory cannot be populated");
         _tMetaPermission ??= types.GetType("Microsoft.Dynamics.Nav.Types.Metadata.MetaPermission")
-            ?? throw new InvalidOperationException(
-                "MetaPermission not found — Types shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "MetaPermission",
+                "type not found in Types — BC's permission-set metadata inventory cannot be populated");
         // AccessModifier is the enum MetaPermissionSet.Access is declared as. Take it FROM
         // that property rather than from a namespace guess: it does not live where the
         // sibling metadata types do, and hardcoding a namespace turned into a run-aborting
         // "Types shape changed" on the first real run.
         _tAccessModifier ??= _tMetaPermissionSet.GetProperty("Access",
             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?.PropertyType
-            ?? throw new InvalidOperationException(
-                "MetaPermissionSet.Access not found — Types shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                "MetaPermissionSet.Access",
+                "property not found — BC's permission-set metadata inventory cannot be populated");
 
         var mps = Activator.CreateInstance(_tMetaPermissionSet)!;
         SetProperty(mps, "Id", declaration.Id);
@@ -589,8 +623,9 @@ public static partial class RecordPatches
             SetProperty(mp, "Value", p.Value);
             var objectTypeProp = _tMetaPermission.GetProperty("Type",
                 BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-                ?? throw new InvalidOperationException(
-                    "MetaPermission.Type not found — Types shape changed; do not commit");
+                ?? throw PermissionMetadataBcShapeGap(
+                    "MetaPermission.Type",
+                    "property not found — BC's permission-set metadata inventory cannot be populated");
             objectTypeProp.SetValue(mp, Enum.ToObject(objectTypeProp.PropertyType, p.ObjectType));
             permissions.Add(mp);
         }
@@ -641,9 +676,9 @@ public static partial class RecordPatches
                     return ps.Length == 2 && ps[0].ParameterType == typeof(int) && ps[1].ParameterType == typeof(string);
                 });
             if (ctor != null) { list.Add(ctor.Invoke(new object?[] { 30, name })); continue; }
-            throw new InvalidOperationException(
-                $"MetaPermissionSet include/exclude list element type {element.Name} is not one this "
-                + "code knows how to fill — Types shape changed; do not commit");
+            throw PermissionMetadataBcShapeGap(
+                $"MetaPermissionSet include/exclude list element type {element.Name}",
+                "is not one this code knows how to fill — BC's permission-set metadata inventory cannot be populated");
         }
         return list;
     }
@@ -664,8 +699,9 @@ public static partial class RecordPatches
     {
         var prop = target.GetType().GetProperty(name,
             BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException(
-                $"{target.GetType().Name}.{name} not found — Types shape changed; do not commit");
+            ?? throw PermissionMetadataBcShapeGap(
+                $"{target.GetType().Name}.{name}",
+                "property not found — BC's permission-set metadata inventory cannot be populated");
         prop.SetValue(target, value);
     }
 }

--- a/AlRunner/Patches/RecordPatches.PermissionShapeGaps.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionShapeGaps.cs
@@ -1,0 +1,133 @@
+// RecordPatches.PermissionShapeGaps — the permission surface's BC-internals refusals (#2994).
+//
+// ── WHAT THIS SLICE IS ───────────────────────────────────────────────────────────────────
+// #2946 settled the convention: a refusal meaning "the runner could not READ BC's internals"
+// raises BcShapeGapException, not RunnerOutOfScopeException and not a hand-rolled
+// InvalidOperationException. It converted six readers and deliberately left the rest, because
+// reclassifying a site is a per-site judgement rather than a rename. #2994 is the sweep; this
+// file is its permission-surface slice, covering three files:
+//
+//     RecordPatches.AggregatePermissionSetVirtualTable.cs  — Aggregate Permission Set, 2000000167
+//     RecordPatches.MetadataPermissionSetVirtualTable.cs   — Metadata Permission Set, 2000000250
+//     RecordPatches.PermissionMetadataPopulator.cs         — the NavAppGroup inventory both drive
+//
+// The populator is in the slice rather than left for later because
+// EnsurePermissionMetadataPopulated() has exactly two callers — the AL-entered populate path
+// of each of the two tables — and nothing else. Its refusals therefore reach AL on the same
+// path the tables' own do, and converting the tables without it would have left one half of a
+// single path raising the retired convention.
+//
+// ── WHY THE TYPE CHANGE IS A CORRECTNESS FIX, NOT A RENAME ───────────────────────────────
+// MethodScopePatches.NavMethodScope_AssertError is an unfiltered catch(Exception). So before
+// this change, `asserterror <any read of these two tables>` PASSED whenever a BC member behind
+// them had moved — while real BC reads the tables fine, so the asserterror fails there.
+// Swallowing the refusal did not merely hide a gap, it inverted the result, and green.
+// BcShapeGapException tears through both AL seams (see BcShapeGapException.cs's table), and it
+// cannot be absorbed by an expect-oos manifest entry — correct, because which BC build is on
+// disk is not a scope boundary and can differ between two legs of one matrix run.
+//
+// ── CLASSIFYING THE 64 SITES ─────────────────────────────────────────────────────────────
+// Every refusal in the three files was read and classified before it was touched. The line is
+// BcShapeGapException.cs's: RAISE IT when the read could not be performed; DO NOT when the read
+// SUCCEEDED and the answer was merely unwelcome.
+//
+//   converted to BcShapeGapException ........ 56
+//   left as they are ......................... 8
+//
+// The 56 are the reflection resolutions: a type, method, property, field, constructor or nested
+// type of BC's own Ncl / Types / Apps assemblies that came back null, plus four sites where the
+// member WAS found and holds a shape this code cannot drive — which BcShapeGapException.cs puts
+// on the same side of the line as an absent one ("present and holds something of a shape the
+// runner cannot use"):
+//
+//   * groupObjectMetadataSummariesByType is not an array
+//   * ... has fewer slots than ObjectType.PermissionSet's ordinal
+//   * ObjectType's PermissionSet ordinal means a different object type in this BC build
+//   * MetaPermissionSet's include/exclude element type is one BuildIncludeList cannot fill
+//
+// The last two are worth naming: both are read successfully and both are still gaps, because
+// what they return is a statement about BC's LAYOUT that this code cannot act on. They are also
+// the ones that can genuinely differ between two supported BC minors, which is precisely the
+// property the type exists to report.
+//
+// ── THE 8 THAT WERE NOT CONVERTED, AND WHY ───────────────────────────────────────────────
+// Five keep their InvalidOperationException and three keep their RunnerOutOfScopeException.
+// PermissionMetadataShapeGapTests pins all of them, so over-converting fails a test just as
+// under-converting does.
+//
+//   1. AggregatePermissionSetVirtualTable "PermissionSetRecord.permissionSetKey was null"
+//      The field was resolved and READ; BC's own record answered null. An answer, not a
+//      failure to read one.
+//
+//   2. PermissionMetadataPopulator "NavAppGroup.BaseGroup is null"
+//      Same: the static field resolves, and the value is null. BcShapeGapException.cs names
+//      this case exactly — "a skeleton singleton the RUNNER populates is null" — and the
+//      existing message already says so ("or the skeleton session was not set up").
+//
+//   3-5. "Microsoft.Dynamics.Nav.Ncl is not loaded" (x1) and
+//        "Microsoft.Dynamics.Nav.Types is not loaded" (x2)
+//      An assembly missing from the AppDomain is a fact about the runner's own load chain, not
+//      about BC's internal layout. Reporting it as a shape gap would send the reader to
+//      docs/limitations.md#bc-shape-gaps, whose first instruction is "ask which BC version
+//      produced it" — the wrong question for a provisioning or load-order problem. Nothing in
+//      the runner works at all if these are absent.
+//
+//   6-8. The three VirtualTableShapeGap refusals (RunnerOutOfScopeException, anchor
+//        "not-yet-implemented"), classified by #2945 and unchanged here:
+//        two "data access has no in-memory provider" (bucket (a): the runner's own store
+//        wiring handed no provider over) and one "NavSession.NCLMetadata is null on the
+//        skeleton session" (again a skeleton the runner populates). All three are answers
+//        about the RUNNER's state, so none is a BC-layout report.
+//
+// ── DELIBERATELY LEFT FOR LATER ──────────────────────────────────────────────────────────
+// #2994 is a ~540-site sweep and this is one slice of it. Not touched here:
+//   * RecordPatches.DateVirtualTable.cs and RecordPatches.AllObjVirtualTable.cs — both have
+//     open PRs against them (#3028/#2988 and #3004); converting them concurrently would
+//     collide. DateVirtualTable's own refusals are already tracked by #2965.
+//   * The other virtual tables (Field, Integer, AllProfile, ReportMetadata) and
+//     RecordPatches.FieldFindIntercept.cs.
+//   * AlRunner/Infrastructure/NclCecilRewrite.* — ~268 sites that fire at REWRITE time, before
+//     any AL executes. No AL seam can trap one, so the new type buys nothing there; #2994's own
+//     table says "probably not" and this slice agrees.
+//
+// A note on counting, for whoever takes the next slice: #2994's site count comes from a
+// heuristic (a throw within four lines of text saying a member was not found). In these three
+// files that heuristic found 49 of the 61 InvalidOperationException sites — it misses wordings
+// like "has no backing field", "is not an array", "has no public constructor" and "takes no
+// AppId". Treat the issue's 538 as a floor.
+//
+// See also:
+//   AlRunner/Infrastructure/BcShapeGapException.cs   — the derivation and the line
+//   RecordPatches.VirtualTableShapeGap.cs            — the sibling classification for #2945
+//   docs/limitations.md#bc-shape-gaps                — the reader-facing write-up
+
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    /// <summary>
+    /// A BC-internals read behind the Aggregate Permission Set virtual table (2000000167) that
+    /// could not be performed. See this file's header for the per-site classification.
+    /// </summary>
+    /// <param name="member">The BC member that could not be read, e.g. "PermissionSetKey.AppId".</param>
+    /// <param name="detail">What went wrong and what it costs.</param>
+    internal static BcShapeGapException AggregatePermissionSetBcShapeGap(string member, string detail)
+        => new("Aggregate Permission Set (virtual table 2000000167)", member, detail);
+
+    /// <summary>
+    /// A BC-internals read behind the Metadata Permission Set virtual table (2000000250) that
+    /// could not be performed.
+    /// </summary>
+    internal static BcShapeGapException MetadataPermissionSetBcShapeGap(string member, string detail)
+        => new("Metadata Permission Set (virtual table 2000000250)", member, detail);
+
+    /// <summary>
+    /// A BC-internals read behind the permission METADATA layer — the NavAppGroup permission-set
+    /// inventory both permission virtual tables populate through
+    /// <c>EnsurePermissionMetadataPopulated</c> (#2893).
+    /// </summary>
+    internal static BcShapeGapException PermissionMetadataBcShapeGap(string member, string detail)
+        => new("Permission metadata (NavAppGroup permission-set inventory)", member, detail);
+}


### PR DESCRIPTION
Closes #3033

The permission-surface slice of the sweep tracked by #2994, which stays open — this is one slice of roughly 540 candidate sites, not the whole thing.

## What changed

56 BC-internals reflection guards across three files now raise `BcShapeGapException` instead of a hand-rolled `InvalidOperationException`:

| file | surface | converted | left |
|---|---|---|---|
| `RecordPatches.AggregatePermissionSetVirtualTable.cs` | Aggregate Permission Set (2000000167) | 16 | 1 + 2 |
| `RecordPatches.MetadataPermissionSetVirtualTable.cs` | Metadata Permission Set (2000000250) | 7 | 0 + 1 |
| `RecordPatches.PermissionMetadataPopulator.cs` | the NavAppGroup inventory both drive | 33 | 4 |

`RecordPatches.PermissionShapeGaps.cs` is new: three thin factories plus the per-site classification table, in the shape `RecordPatches.VirtualTableShapeGap.cs` and `RecordPatches.ObjectMetadataSystemTable.cs` already use.

## Not a rename — it changes what AL observes

`MethodScopePatches.NavMethodScope_AssertError` is an unfiltered `catch (Exception)`. So before this, `asserterror <any read of either permission table>` **passed** whenever a BC member behind it had moved, while real BC reads the table fine and the `asserterror` fails there. Catching the refusal did not hide a gap, it inverted a result, and green. `BcShapeGapException` tears through both AL seams and cannot be absorbed by an `expect-oos` entry — right, because which BC build is on disk is not a scope boundary and can differ between two legs of one matrix run.

## The 8 I did not convert, and why

The line from `BcShapeGapException.cs` is whether the read could be **performed**, not whether its answer was welcome. Eight sites failed that test, and `PermissionMetadataShapeGapTests` pins all eight — so over-converting fails a test just as under-converting does.

1. `"PermissionSetRecord.permissionSetKey was null"` — the field resolved and was read; BC's own record answered null. An answer.
2. `"NavAppGroup.BaseGroup is null"` — same, and it is the case `BcShapeGapException.cs` names explicitly ("a skeleton singleton the RUNNER populates is null"). The existing message already admits it ("or the skeleton session was not set up").
3-5. `"Microsoft.Dynamics.Nav.Ncl is not loaded"` (x1), `"Microsoft.Dynamics.Nav.Types is not loaded"` (x2) — an assembly missing from the AppDomain is a fact about the runner's own load chain, not BC's layout. Reporting it as a shape gap sends the reader to `docs/limitations.md#bc-shape-gaps`, whose first instruction is "ask which BC version produced it" — the wrong question for a provisioning problem.
6-8. The three `VirtualTableShapeGap` refusals (`RunnerOutOfScopeException`, `not-yet-implemented`) classified by #2945: two "data access has no in-memory provider" and one "NavSession.NCLMetadata is null on the skeleton session". All three are statements about the **runner's** state.

Four sites went the other way and **were** converted although the read succeeded, because what came back is a statement about BC's layout this code cannot act on — `BcShapeGapException.cs` puts "present and holds something of a shape the runner cannot use" on the gap side: the summaries slot is not an array; it has fewer slots than `ObjectType.PermissionSet`'s ordinal; that ordinal means a different object type in this BC build; the include/exclude element type is one `BuildIncludeList` cannot fill. The middle two can genuinely differ between supported BC minors, which is the property the type exists to report.

## Fixing the shape, not the reported line

- **Same pattern elsewhere?** Yes — ~480 sites across the repo, named in the new file's header as remaining scope for #2994, with the reasons for each exclusion.
- **Sibling functions with the same blind spot?** Within the slice I swept **all 61** `InvalidOperationException` sites in the three files, not the 49 the issue's heuristic finds. It misses wordings like "has no backing field", "is not an array", "has no public constructor" and "takes no AppId". **Treat #2994's 538 as a floor, not a total** — that is recorded in the new file's header for whoever takes the next slice.
- **Two paths writing the same state?** This is why the populator is in the slice rather than a later one: `EnsurePermissionMetadataPopulated()` has exactly two callers, the AL-entered populate path of each table. Converting the tables alone would have left half of one path on the retired convention.

## Tests

`AlRunner.Tests/PermissionMetadataShapeGapTests.cs`, 23 tests.

The genuine RED → GREEN is four arms driving **real production helpers** with fakes standing in for a BC type whose member moved — `SetProperty`, `SetBackingField`, `SetEmptyListBackingField`, `BuildIncludeList` all take the reflected type or target as a parameter, so no BC install is needed. RED: 5 failed / 4 passed, each failure `Expected BcShapeGapException, Actual InvalidOperationException`. GREEN: 9/9, then 23/23 with the rest.

Every gap arm asserts the **specific** type and that `Member` names the member that could not be read, never merely that something threw. Every one is paired with a control arm that still succeeds, so a change that threw unconditionally would fail here. The two AL-seam theories are paired with a control proving the seams still trap a permanent refusal, so "tears through" cannot pass on a seam that traps nothing.

The source guard asserts both directions at once: no BC-internals read still raises the retired type, **and** exactly the five deliberate non-conversions survive.

**One existing guard needed a fix, and it caught a real problem.** `VirtualTableRefusalClaimTests` counts `throw *ShapeGap(` to prove none of #2945's 48 refusals was deleted rather than corrected. My factories also end in "ShapeGap" but return a different type with a different contract, so the count went 58 → 81 and the number stopped meaning anything. The regex now excludes `*BcShapeGap(` explicitly, with a comment saying why, and the count is 58 again.

Ran locally: `PermissionMetadataShapeGapTests`, `BcShapeGapConventionTests`, `AggregatePermissionSetVirtualTableTests`, `PermissionMetadataPopulationTests`, `VirtualTableRefusalClaimTests`, `RunnerShapeGapClaimTests`, `ObjectMetadataSystemTableRefusalTests`, `BcAppSymbolCachePermissionSetTests`, `ObjectMetadataProviderRowProbeTests` — 229 passed, 0 failed. I did not run the full `AlRunner.Tests` suite or the AL corpus; CI does both.

## Corpus: nothing is owed upstream

Checked per this slice rather than assumed. The conversion only changes which exception type a refusal raises, and every one of these refusals fires **only when BC's own layout is not what the code reflecting on it expects**. On every BC version the runner supports, all 56 reads succeed and none of the refusals is reachable from AL — so there is no AL statement a service tier could run that would observe the difference, and the claim is not about Business Central at all. It is the same reasoning `BcShapeGapConventionTests` gives for living in `AlRunner.Tests`. No corpus PR, and no `tests/al-language` pin bump.

`tests/expectations/` needed no change either: no entry references these tables' anchors, so nothing was relying on absorbing a refusal that can no longer be absorbed. `tests/expectations/count-baseline/test-count-baseline.json` is untouched (#3004 is open against it).

## Docs

None needed. `docs/limitations.md#bc-shape-gaps` already documents the contract generically and this slice adds no new user-visible behaviour, surface or flag.

## Filed, not fixed here

#3031 — both permission-table symbol reads swallow every exception (`catch { continue; }` in `BuildKnownAppNameIndex`, `catch (Exception)` in `EnumerateKnownPermissionSets`), so an app whose `SymbolReference.json` cannot be read silently contributes no rows and no App Name instead of refusing. That is a `loud-failures.md` defect rather than a classification one, and deciding which exceptions may legitimately be tolerated needs a look at what `BcAppSymbolCache.Get` can actually throw. Neither site can swallow a gap from this slice — I checked that `BcAppSymbolCache.Get` does not call into any converted guard.

---
*Authored by an automated agent (`stma-auto-1`) acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
