### PR TITLE
fix(cache): identify the persisted app-manifests index by package content, not a stat

### DIFF
--- a/AlRunner.Tests/AppLoaderManifestIndexIdentityTests.cs
+++ b/AlRunner.Tests/AppLoaderManifestIndexIdentityTests.cs
@@ -1,0 +1,428 @@
+// AppLoaderManifestIndexIdentityTests — issue #2987.
+//
+// AppLoader.ReadManifest and AppLoader.ReadPackageMeta keyed their PERSISTED, CROSS-PROCESS
+// `app-manifests` index on `{fullPath}|{Length}|{LastWriteTimeUtc.Ticks}` — a filesystem stat
+// standing in for the package's content, the same substitution #1820 removed from
+// BcAppSymbolCache.Get, #2754/#2847 from the AL-output key's dependency terms, #2846 from
+// ComputeSourceWorkspaceKey and #2955 from the r2r-chunks cache.
+//
+// What that index holds is a package's IDENTITY — Publisher, Name, Version, AppId, the whole
+// declared Dependencies list — plus HasSymbolReference. So two runs agreeing on the stat and
+// disagreeing on the bytes make the second one resolve a package under another package's
+// identity, or against another package's declared closure. HasSymbolReference has its own
+// documented consequence in ReadPackageMetaFromZip's comment: reporting false for a package
+// that carries one "drops a package from the scan set and produces AL1023 against the whole
+// compilation".
+//
+// The pre-#2987 doc comment called the stat "not a correctness hazard, only a cache miss" and
+// cited AppLoaderManifestCacheTests.ReadManifest_TouchedMtime_IsReparsedNotServedStale. That
+// test covers only the case where the stat MOVES. The hazard is the case where it does not —
+// a checkout, a rebuild landing on the same size, a copy preserving mtime — which is what the
+// first two arms below construct.
+//
+// Packages are synthesized rather than taken from a provisioned platform dir, so these arms run
+// everywhere: a stat collision has to be CONSTRUCTED (identical length, identical mtime,
+// different bytes) and a real .app cannot be edited into that shape.
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// AppLoader's memos and the CacheRoots override are both process-wide mutable static state —
+// see CacheRootsSerialCollection's header.
+[Collection(CacheRootsSerialCollection.Name)]
+public sealed class AppLoaderManifestIndexIdentityTests
+{
+    // ── package synthesis ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A minimal NAVX <c>.app</c>: the 8-byte NAVX header, then a ZIP carrying
+    /// <c>NavxManifest.xml</c>, optionally <c>SymbolReference.json</c>, and a STORED
+    /// <c>pad.bin</c> of exactly <paramref name="padBytes"/> bytes.
+    ///
+    /// <para>The pad is what makes a stat collision constructible. Everything is stored
+    /// uncompressed and every zip entry's name is fixed, so the file's total length is a known
+    /// constant plus <paramref name="padBytes"/> — which lets <see cref="WriteCollidingPair"/>
+    /// bring two packages with different content to byte-identical LENGTH without touching
+    /// either one's manifest.</para>
+    /// </summary>
+    private static byte[] BuildApp(
+        Guid appId, string name, string publisher, string version,
+        Guid depId, string depName, bool symbolReference, int padBytes)
+    {
+        var xml = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{appId}" Name="{name}" Publisher="{publisher}" Version="{version}"
+                   Application="1.0.0.0" Platform="1.0.0.0"/>
+              <Dependencies>
+                <Dependency Id="{depId}" Name="{depName}" Publisher="DepPub" MinVersion="1.0.0.0"/>
+              </Dependencies>
+            </Package>
+            """;
+
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            using (var s = zip.CreateEntry("NavxManifest.xml", CompressionLevel.NoCompression).Open())
+                s.Write(Encoding.UTF8.GetBytes(xml));
+            if (symbolReference)
+                using (var s = zip.CreateEntry("SymbolReference.json", CompressionLevel.NoCompression).Open())
+                    s.Write("{}"u8);
+            if (padBytes > 0)
+                using (var s = zip.CreateEntry("pad.bin", CompressionLevel.NoCompression).Open())
+                    s.Write(new byte[padBytes]);
+        }
+        var zipBytes = ms.ToArray();
+
+        var result = new byte[8 + zipBytes.Length];
+        result[0] = (byte)'N'; result[1] = (byte)'A'; result[2] = (byte)'V'; result[3] = (byte)'X';
+        BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
+        zipBytes.CopyTo(result, 8);
+        return result;
+    }
+
+    /// <summary>
+    /// Two packages with genuinely different content, padded to exactly the same LENGTH. The
+    /// caller writes them to the same path in turn under the same mtime, which is the stat
+    /// collision under test.
+    /// </summary>
+    private static (byte[] A, byte[] B) WriteCollidingPair(
+        Guid appIdA, string nameA, string versionA, bool symbolReferenceA,
+        Guid appIdB, string nameB, string versionB, bool symbolReferenceB)
+    {
+        var depId = new Guid("11111111-1111-1111-1111-111111111111");
+        byte[] Build(Guid id, string n, string v, bool sym, int pad)
+            => BuildApp(id, n, "Pub", v, depId, "Dep", sym, pad);
+
+        // Both start WITH a pad entry, so the entry's own fixed zip overhead (local header +
+        // central-directory record for the name "pad.bin") is already in both lengths. From
+        // there the payload grows the file 1:1, so one adjustment lands it exactly — padding
+        // up from zero would not, because the first pad byte also buys ~90 bytes of headers.
+        var a = Build(appIdA, nameA, versionA, symbolReferenceA, 1);
+        var b = Build(appIdB, nameB, versionB, symbolReferenceB, 1);
+        if (a.Length < b.Length) a = Build(appIdA, nameA, versionA, symbolReferenceA, 1 + (b.Length - a.Length));
+        else if (b.Length < a.Length) b = Build(appIdB, nameB, versionB, symbolReferenceB, 1 + (a.Length - b.Length));
+
+        Assert.Equal(a.Length, b.Length);
+        Assert.NotEqual(a, b);
+        return (a, b);
+    }
+
+    // ── harness ───────────────────────────────────────────────────────────────────
+
+    private static string NewDir(string prefix)
+    {
+        var dir = TestScratch.FlatDir(prefix);
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static string IndexRoot(string cacheRoot) => Path.Combine(cacheRoot, "app-manifests");
+
+    private static string[] IndexEntries(string cacheRoot)
+        => Directory.Exists(IndexRoot(cacheRoot))
+            ? Directory.GetFiles(IndexRoot(cacheRoot), "*.json").OrderBy(f => f, StringComparer.Ordinal).ToArray()
+            : Array.Empty<string>();
+
+    /// <summary>
+    /// The persisted index outlives the process; the in-process memos and the shared
+    /// content-hash memo do not. Clearing all three between the halves of an arm is what makes
+    /// that arm a test of the ON-DISK key rather than of a memo — the same "simulate a fresh
+    /// process" step AppLoaderR2rChunkCacheIdentityTests takes.
+    /// </summary>
+    private static void SimulateProcessRestart()
+    {
+        AppLoader.ResetManifestMemoForTests();
+        RunnerFingerprint.ClearFileContentHashMemoForTests();
+    }
+
+    private static void WithCacheRoot(Action<string> body)
+    {
+        var cacheRoot = TestScratch.FlatDir("app-loader-manifest-index-identity-tests-");
+        CacheRoots.SetOverride(cacheRoot);
+        SimulateProcessRestart();
+        try { body(cacheRoot); }
+        finally
+        {
+            CacheRoots.ResetForTests();
+            SimulateProcessRestart();
+            if (Directory.Exists(cacheRoot)) Directory.Delete(cacheRoot, recursive: true);
+        }
+    }
+
+    // ── the defect ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ReadManifest_SamePathSameLengthSameMtime_DifferentBytes_ServesTheNewPackagesIdentity()
+    {
+        WithCacheRoot(cacheRoot =>
+        {
+            var dir = NewDir("manifest-identity-collide-");
+            var appPath = Path.Combine(dir, "Pkg.app");
+            var stamp = new DateTime(2021, 6, 1, 12, 0, 0, DateTimeKind.Utc);
+
+            var appIdA = new Guid("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+            var appIdB = new Guid("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+            var (bytesA, bytesB) = WriteCollidingPair(
+                appIdA, "AAA", "1.0.0.0", symbolReferenceA: true,
+                appIdB, "BBB", "2.0.0.0", symbolReferenceB: true);
+
+            File.WriteAllBytes(appPath, bytesA);
+            File.SetLastWriteTimeUtc(appPath, stamp);
+            var lengthA = new FileInfo(appPath).Length;
+
+            var manifestA = AppLoader.ReadManifest(appPath);
+            Assert.NotNull(manifestA);
+            Assert.Equal(appIdA, manifestA!.AppId);
+            Assert.Equal("AAA", manifestA.Name);
+            Assert.Equal(new Version(1, 0, 0, 0), manifestA.Version);
+            Assert.Equal(1, AppLoader.ManifestParseInvocationCountForTests(appPath));
+
+            // Same path replaced with different bytes, restored to the same length and the
+            // same mtime: `{fullPath}|{Length}|{LastWriteTimeUtc.Ticks}` is now PROVABLY
+            // identical for two packages with different content. Both halves of that claim
+            // are asserted before the read that depends on them.
+            SimulateProcessRestart();
+            File.WriteAllBytes(appPath, bytesB);
+            File.SetLastWriteTimeUtc(appPath, stamp);
+            Assert.Equal(lengthA, new FileInfo(appPath).Length);
+            Assert.Equal(stamp, File.GetLastWriteTimeUtc(appPath));
+
+            var manifestB = AppLoader.ReadManifest(appPath);
+            Assert.NotNull(manifestB);
+            // The decisive assertions: the identity served describes the package on disk NOW.
+            Assert.Equal(appIdB, manifestB!.AppId);
+            Assert.Equal("BBB", manifestB.Name);
+            Assert.Equal(new Version(2, 0, 0, 0), manifestB.Version);
+            Assert.NotEqual(appIdA, manifestB.AppId);
+            // ...and it got there by genuinely reparsing, not by a HIT that happened to hold
+            // the right answer.
+            Assert.Equal(2, AppLoader.ManifestParseInvocationCountForTests(appPath));
+
+            // Two contents, two entries — neither overwrote the other's.
+            Assert.Equal(2, IndexEntries(cacheRoot).Length);
+        });
+    }
+
+    [Fact]
+    public void ReadPackageMeta_SamePathSameLengthSameMtime_DifferentSymbolReference_IsNotServedStale()
+    {
+        WithCacheRoot(_ =>
+        {
+            var dir = NewDir("manifest-identity-symref-");
+            var appPath = Path.Combine(dir, "Pkg.app");
+            var stamp = new DateTime(2022, 3, 4, 5, 6, 7, DateTimeKind.Utc);
+
+            var appIdA = new Guid("cccccccc-cccc-cccc-cccc-cccccccccccc");
+            var appIdB = new Guid("dddddddd-dddd-dddd-dddd-dddddddddddd");
+            // A carries NO SymbolReference.json, B does. Reporting A's `false` for B is the
+            // answer that drops a package from the scan set and produces AL1023 against the
+            // whole compilation.
+            var (bytesA, bytesB) = WriteCollidingPair(
+                appIdA, "AAA", "1.0.0.0", symbolReferenceA: false,
+                appIdB, "BBB", "1.0.0.0", symbolReferenceB: true);
+
+            File.WriteAllBytes(appPath, bytesA);
+            File.SetLastWriteTimeUtc(appPath, stamp);
+            var lengthA = new FileInfo(appPath).Length;
+
+            var metaA = AppLoader.ReadPackageMeta(appPath);
+            Assert.NotNull(metaA.Manifest);
+            Assert.Equal(appIdA, metaA.Manifest!.AppId);
+            Assert.False(metaA.HasSymbolReference);
+
+            SimulateProcessRestart();
+            File.WriteAllBytes(appPath, bytesB);
+            File.SetLastWriteTimeUtc(appPath, stamp);
+            Assert.Equal(lengthA, new FileInfo(appPath).Length);
+            Assert.Equal(stamp, File.GetLastWriteTimeUtc(appPath));
+
+            var metaB = AppLoader.ReadPackageMeta(appPath);
+            Assert.NotNull(metaB.Manifest);
+            Assert.Equal(appIdB, metaB.Manifest!.AppId);
+            Assert.True(metaB.HasSymbolReference);
+            // HasSymbolReference is what AppLoader.HasSymbolReference answers, so assert
+            // through the public entry point the scan set actually consults too.
+            Assert.True(AppLoader.HasSymbolReference(appPath));
+        });
+    }
+
+    // ── the arms that must keep passing: the index is still a cache ───────────────
+
+    [Fact]
+    public void ReadManifest_SamePackageTwiceAcrossProcesses_IsAGenuineIndexHit()
+    {
+        WithCacheRoot(_ =>
+        {
+            var dir = NewDir("manifest-identity-hit-");
+            var appPath = Path.Combine(dir, "Pkg.app");
+            var appId = new Guid("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+            File.WriteAllBytes(appPath, BuildApp(
+                appId, "Hit", "Pub", "3.2.1.0",
+                new Guid("22222222-2222-2222-2222-222222222222"), "Dep", symbolReference: true, padBytes: 0));
+
+            var first = AppLoader.ReadManifest(appPath);
+            Assert.Equal(appId, first!.AppId);
+            Assert.Equal(1, AppLoader.ManifestParseInvocationCountForTests(appPath));
+
+            SimulateProcessRestart();
+            var second = AppLoader.ReadManifest(appPath);
+            Assert.Equal(appId, second!.AppId);
+            Assert.Equal("Hit", second.Name);
+            Assert.Equal(new Version(3, 2, 1, 0), second.Version);
+            Assert.Single(second.Dependencies);
+            // Served from the on-disk index across a simulated process restart, not reparsed.
+            Assert.Equal(1, AppLoader.ManifestParseInvocationCountForTests(appPath));
+        });
+    }
+
+    [Fact]
+    public void ReadManifest_ByteIdenticalPackageAtAnotherPathWithAnotherMtime_HitsTheSameEntry()
+    {
+        WithCacheRoot(cacheRoot =>
+        {
+            var dir = NewDir("manifest-identity-redownload-");
+            var pathOne = Path.Combine(dir, "Pkg.app");
+            var pathTwo = Path.Combine(dir, "redownloaded", "Pkg.app");
+            Directory.CreateDirectory(Path.GetDirectoryName(pathTwo)!);
+
+            var appId = new Guid("ffffffff-ffff-ffff-ffff-ffffffffffff");
+            var bytes = BuildApp(appId, "Redownloaded", "Pub", "1.2.3.4",
+                new Guid("33333333-3333-3333-3333-333333333333"), "Dep", symbolReference: true, padBytes: 0);
+            File.WriteAllBytes(pathOne, bytes);
+            File.SetLastWriteTimeUtc(pathOne, new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+            Assert.Equal(appId, AppLoader.ReadManifest(pathOne)!.AppId);
+            Assert.Equal(1, AppLoader.ManifestParseInvocationCountForTests(pathOne));
+
+            // A CI re-download: byte-for-byte the same package, a different path, a fresh
+            // mtime. Nothing about its CONTENT changed, so nothing needs reparsing — the case
+            // the stat key MISSed unconditionally (#1815's argument).
+            SimulateProcessRestart();
+            File.Copy(pathOne, pathTwo);
+            File.SetLastWriteTimeUtc(pathTwo, DateTime.UtcNow);
+            Assert.NotEqual(File.GetLastWriteTimeUtc(pathOne), File.GetLastWriteTimeUtc(pathTwo));
+
+            var served = AppLoader.ReadManifest(pathTwo);
+            Assert.Equal(appId, served!.AppId);
+            Assert.Equal("Redownloaded", served.Name);
+            Assert.Equal(0, AppLoader.ManifestParseInvocationCountForTests(pathTwo)); // served, not parsed
+            Assert.Single(IndexEntries(cacheRoot));                                   // one content, one entry
+        });
+    }
+
+    // ── the guard: no identity ⇒ no shared entry, in either direction ─────────────
+    //
+    // Driven through the hash-provider seam. Without the guard the sentinel ("unknown", what
+    // RunnerFingerprint.ComputeContentHash answers for a file it cannot read) would BE the
+    // entry name, and every unidentifiable package would share one entry — the same
+    // wrong-answer shape this fix removes, reintroduced by the fix.
+
+    [Fact]
+    public void UnknownContentHash_TwoPackagesNeverShareAnIndexEntry_AndNothingIsPublished()
+    {
+        WithCacheRoot(cacheRoot =>
+        {
+            var dir = NewDir("manifest-identity-unknown-");
+            var pathA = Path.Combine(dir, "A.app");
+            var pathB = Path.Combine(dir, "B.app");
+            var appIdA = new Guid("0a0a0a0a-0a0a-0a0a-0a0a-0a0a0a0a0a0a");
+            var appIdB = new Guid("0b0b0b0b-0b0b-0b0b-0b0b-0b0b0b0b0b0b");
+            var depId = new Guid("44444444-4444-4444-4444-444444444444");
+            File.WriteAllBytes(pathA, BuildApp(appIdA, "AAA", "Pub", "1.0.0.0", depId, "Dep", true, 0));
+            File.WriteAllBytes(pathB, BuildApp(appIdB, "BBB", "Pub", "1.0.0.0", depId, "Dep", true, 0));
+
+            var a = AppLoader.ReadManifestCore(pathA, static _ => RunnerFingerprint.UnknownContentHash);
+            var b = AppLoader.ReadManifestCore(pathB, static _ => RunnerFingerprint.UnknownContentHash);
+
+            // Each package still answers its OWN identity — the guard costs a reparse, never a
+            // wrong answer.
+            Assert.Equal(appIdA, a!.AppId);
+            Assert.Equal(appIdB, b!.AppId);
+            Assert.Equal("AAA", a.Name);
+            Assert.Equal("BBB", b.Name);
+            // Nothing an unidentifiable package produced may be published where another
+            // process could read it as that package's manifest.
+            Assert.Empty(IndexEntries(cacheRoot));
+        });
+    }
+
+    [Fact]
+    public void HashProviderThrows_StillAnswersThisPackagesOwnIdentity_AndPublishesNothing()
+    {
+        WithCacheRoot(cacheRoot =>
+        {
+            var dir = NewDir("manifest-identity-throw-");
+            var appPath = Path.Combine(dir, "Pkg.app");
+            var appId = new Guid("0c0c0c0c-0c0c-0c0c-0c0c-0c0c0c0c0c0c");
+            File.WriteAllBytes(appPath, BuildApp(appId, "Throws", "Pub", "9.9.9.9",
+                new Guid("55555555-5555-5555-5555-555555555555"), "Dep", true, 0));
+
+            var manifest = AppLoader.ReadManifestCore(
+                appPath, static _ => throw new IOException("cannot read the package"));
+
+            Assert.NotNull(manifest);
+            Assert.Equal(appId, manifest!.AppId);
+            Assert.Equal("Throws", manifest.Name);
+            Assert.Empty(IndexEntries(cacheRoot));
+        });
+    }
+
+    [Fact]
+    public void ReadPackageMeta_UnknownContentHash_PublishesNothing_AndStillAnswersBothQuestions()
+    {
+        WithCacheRoot(cacheRoot =>
+        {
+            var dir = NewDir("manifest-identity-meta-unknown-");
+            var withSym = Path.Combine(dir, "WithSym.app");
+            var withoutSym = Path.Combine(dir, "WithoutSym.app");
+            var depId = new Guid("66666666-6666-6666-6666-666666666666");
+            var idWith = new Guid("0d0d0d0d-0d0d-0d0d-0d0d-0d0d0d0d0d0d");
+            var idWithout = new Guid("0e0e0e0e-0e0e-0e0e-0e0e-0e0e0e0e0e0e");
+            File.WriteAllBytes(withSym, BuildApp(idWith, "WithSym", "Pub", "1.0.0.0", depId, "Dep", true, 0));
+            File.WriteAllBytes(withoutSym, BuildApp(idWithout, "NoSym", "Pub", "1.0.0.0", depId, "Dep", false, 0));
+
+            var w = AppLoader.ReadPackageMetaCore(withSym, static _ => RunnerFingerprint.UnknownContentHash);
+            var n = AppLoader.ReadPackageMetaCore(withoutSym, static _ => RunnerFingerprint.UnknownContentHash);
+
+            Assert.Equal(idWith, w.Manifest!.AppId);
+            Assert.True(w.HasSymbolReference);
+            Assert.Equal(idWithout, n.Manifest!.AppId);
+            Assert.False(n.HasSymbolReference);
+            Assert.Empty(IndexEntries(cacheRoot));
+        });
+    }
+
+    // ── the entry-name convention ────────────────────────────────────────────────
+
+    /// <summary>
+    /// A pre-#2987 stat-keyed entry name is also 64 lowercase hex characters plus
+    /// <c>.json</c> — indistinguishable from a content hash by shape. The <c>sha256-</c>
+    /// prefix is what makes a warm pre-fix cache directory unreadable as a content-keyed one
+    /// rather than silently misread (#2955's convention).
+    /// </summary>
+    [Fact]
+    public void IndexEntryName_CarriesTheSha256Prefix()
+    {
+        WithCacheRoot(cacheRoot =>
+        {
+            var dir = NewDir("manifest-identity-name-");
+            var appPath = Path.Combine(dir, "Pkg.app");
+            File.WriteAllBytes(appPath, BuildApp(
+                new Guid("0f0f0f0f-0f0f-0f0f-0f0f-0f0f0f0f0f0f"), "Named", "Pub", "1.0.0.0",
+                new Guid("77777777-7777-7777-7777-777777777777"), "Dep", true, 0));
+
+            Assert.NotNull(AppLoader.ReadManifest(appPath));
+
+            var entries = IndexEntries(cacheRoot);
+            Assert.Single(entries);
+            var name = Path.GetFileName(entries[0]);
+            Assert.StartsWith("sha256-", name);
+            Assert.Equal("sha256-" + RunnerFingerprint.ComputeContentHash(appPath) + ".json", name);
+            Assert.Equal(entries[0], AppLoader.ManifestIndexPathForTests(appPath));
+        });
+    }
+}

--- a/AlRunner.Tests/CacheKeyUnhashableDependencyTests.cs
+++ b/AlRunner.Tests/CacheKeyUnhashableDependencyTests.cs
@@ -21,36 +21,48 @@
 // property #2754 exists to remove, and the exact property the #2754 PR body criticised in
 // the old "?" term ("simply cannot HIT", which was never true).
 //
-// Constructing "resolved but unhashable"
-// -------------------------------------
-// It looks impossible from outside the process: DependencyResolver.EnsureIndexed calls
-// AppLoader.ReadManifest on every .app it finds, so a package it cannot open is a package it
-// never indexes, and the run fails at resolution instead of reaching the hash.
+// "Resolved but unhashable" no longer exists end-to-end (#2987) — READ THIS FIRST
+// -----------------------------------------------------------------------------
+// This file used to construct that state and drive all three claims through the real runner.
+// The construction was: DependencyResolver.EnsureIndexed calls AppLoader.ReadManifest on every
+// .app it finds, and ReadManifest was backed by an on-disk index keyed by (full path, length,
+// last-write-ticks) — which `chmod 000` changes none of. So one warm-up run with the package
+// readable populated that index, and the next run resolved the package from the index WITHOUT
+// opening it while ComputeAppContentHash, which must read the bytes, threw.
 //
-// But ReadManifest is backed by an on-disk index under CacheRoots.Resolve("app-manifests"),
-// keyed by (full path, length, last-write-ticks) — and `chmod 000` changes none of those. So:
-// run once with the package readable to warm that index (the same --cache root is shared
-// across all runs here, which is what makes the index visible to the next process), then make
-// it unreadable. The resolver now answers from the index WITHOUT opening the file, and
-// ComputeAppContentHash — which must read the bytes — throws.
+// #2987 keyed that index on the package's CONTENT, because a stat standing in for content in a
+// PERSISTED, cross-process index is what let one package be served under another's identity.
+// Identifying a package therefore now requires reading it, and the construction above is gone:
+// an unreadable package is not indexed at all, so it is never resolved, so the hash is never
+// reached. A package the resolver DID index is one whose hash it already computed and memoized
+// under the same (path, length, mtime) key the dep term will use — so the degraded term cannot
+// be reached for a resolved dependency even if the file becomes unreadable mid-run.
 //
-// That construction is also the review finding's other half in concrete form: "the resolver
-// read this package's manifest moments ago" does not imply the bytes are readable, so
-// "unhashable means the compile is about to fail anyway" is an assumption, not a fact.
+// That is also what closes #2954's residue ("unhashable on two consecutive runs while the
+// content changes between them") without the "do not cache this run" signal that issue
+// proposes: the state that signal existed to handle no longer occurs.
 //
-// The three arms
-// --------------
-// NEGATIVE (the regression) — X unhashable, Y's content CHANGES between two runs. The keys
-// must differ. This is the arm that fails against the throw-and-collapse code.
+// What the arms are now
+// ---------------------
+// The two claims that still have teeth are pinned directly on ProgramSupport
+// .DependencyContentTerm, which is `internal` for exactly this reason — a defensive branch no
+// caller can reach still has to behave, and #2954's own review comment sets that bar ("driven
+// by a test rather than shipped unexercised"):
 //
-// CONTROL — X unhashable, nothing else changes. The keys must be EQUAL. Without it the
-// negative arm would be satisfied by a degraded term that simply varies per run (a nonce),
-// which would force a permanent MISS for any bundle with an unreadable dependency instead of
-// tracking what actually changed.
+//   NON-COLLAPSING — one unhashable package degrades ONE term. Two different unhashable
+//   packages must not produce the same term, which is the property the throw-and-collapse
+//   code destroyed: it replaced the whole list with `unresolved:<type>:<message>`, a string
+//   deterministic across runs, so a warm cache served the DLL compiled against a DIFFERENT
+//   dependency's earlier bytes.
 //
-// LOUD — the run must SAY it keyed a dependency on something weaker than its content, naming
-// the package. A cache silently downgrading its own identity is the failure mode
-// .claude/rules/loud-failures.md exists for.
+//   LOUD — keying a dependency on something weaker than its content must SAY so, naming the
+//   package (.claude/rules/loud-failures.md).
+//
+// And the end-to-end arm now pins the behaviour that REPLACED the old construction: a package
+// which becomes unreadable after being indexed is skipped and NAMED, rather than resolved from
+// an entry nothing can tie to the bytes on disk. Silently dropping it would produce "a required
+// dependency package is missing" for a package sitting in the cache directory — the
+// mysterious-missing-dependency shape #2206 is about.
 
 using System.Diagnostics;
 using System.IO.Compression;
@@ -111,11 +123,13 @@ public sealed class CacheKeyUnhashableDependencyTests : IDisposable
     }
 
     /// <summary>
-    /// The shared setup all three arms use: a bundle depending on X and Y, both packages
-    /// written and resolvable, one warm-up run to populate the app-manifest index under the
-    /// shared cache root, then X made unreadable.
+    /// A bundle depending on X and Y, both packages written and resolvable, one warm-up run to
+    /// populate the app-manifest index under the shared cache root, then X made unreadable.
+    ///
+    /// <para>Before #2987 the warm-up was what made X resolvable-but-unhashable. It now makes
+    /// X resolvable only while it is readable, which is the point of the arm below.</para>
     /// </summary>
-    private (string Bundle, string PkgDir, string CacheDir, string XPath, string YPath) ArrangeUnhashableX(string name)
+    private (string Bundle, string PkgDir, string CacheDir, string XPath, string YPath) ArrangeUnreadableX(string name)
     {
         var bundle = WriteTwoDepFixture(Path.Combine(_scratch, name + "-bundle"));
         var pkgDir = Path.Combine(_scratch, name + "-pkg");
@@ -125,84 +139,128 @@ public sealed class CacheKeyUnhashableDependencyTests : IDisposable
         var xPath = WriteSyntheticApp(pkgDir, DepXId, "Fabrikam Dep X", payloadFill: (byte)'X');
         var yPath = WriteSyntheticApp(pkgDir, DepYId, "Fabrikam Dep Y", payloadFill: (byte)'1');
 
-        // Warm-up run, with BOTH packages readable: this is what writes the app-manifests index
-        // entries the later runs resolve X from without opening it.
         var warm = RunPrintCacheKey(bundle, pkgDir, cacheDir);
         Assert.True(warm.Key != null, $"warm-up run produced no cache key:\n{warm.Output}");
 
         Skip.IfNot(TryMakeUnreadable(xPath),
             "cannot make a file unreadable here (running as root, or a filesystem that ignores "
-            + "mode bits), so 'resolved but unhashable' cannot be constructed");
+            + "mode bits)");
 
         return (bundle, pkgDir, cacheDir, xPath, yPath);
     }
 
     /// <summary>
-    /// THE REGRESSION ARM. One unhashable dependency must not erase the identity of the others:
-    /// with X unhashable throughout, changing Y's bytes must still change the key.
+    /// THE END-TO-END ARM, rewritten for #2987. A dependency package that becomes unreadable
+    /// after its manifest was indexed must be SKIPPED AND NAMED — not resolved from an index
+    /// entry that a stat, and only a stat, ties to those bytes.
     ///
-    /// Against the throw-and-collapse code both runs key on the identical
-    /// `unresolved:UnauthorizedAccessException:Access to the path '…' is denied.` string, the
-    /// keys are equal, and a warm cache serves the DLL compiled against Y's previous bytes.
+    /// <para>Both halves matter. Resolving it anyway is the defect #2987 removes: the entry
+    /// carries the package's Publisher/Name/Version/AppId and its whole declared dependency
+    /// list, so a stat collision serves one package's identity for another's bytes. Skipping it
+    /// SILENTLY is the #2206 shape: the run fails with "a required dependency package is
+    /// missing" while the package sits in the cache directory, and nothing connects the two.
+    /// The warm-up run above proves the package WAS resolvable a moment earlier, so this arm
+    /// cannot pass by the package having been broken all along.</para>
     /// </summary>
     [SkippableFact]
-    public void UnhashableDependency_DoesNotHideAnotherDependencysContentChange()
+    public void DependencyUnreadableAfterIndexing_IsSkippedAndNamed_NotResolvedFromTheIndex()
     {
         TestArtifacts.SkipIfMissing();
-        var (bundle, pkgDir, cacheDir, _, yPath) = ArrangeUnhashableX("regression");
-
-        var before = RunPrintCacheKey(bundle, pkgDir, cacheDir);
-        Assert.True(before.Key != null, $"no cache key with X unreadable:\n{before.Output}");
-
-        // Y keeps its declared id/name/publisher/version and changes only its bytes — the same
-        // shape #2754 is about, now with an unhashable sibling standing next to it.
-        var yBefore = File.ReadAllBytes(yPath);
-        WriteSyntheticApp(pkgDir, DepYId, "Fabrikam Dep Y", payloadFill: (byte)'2');
-        Assert.False(yBefore.AsSpan().SequenceEqual(File.ReadAllBytes(yPath)),
-            "Y's bytes did not change — the fixture is not exercising the defect");
-
-        var after = RunPrintCacheKey(bundle, pkgDir, cacheDir);
-        Assert.True(after.Key != null, $"no cache key after rewriting Y:\n{after.Output}");
-
-        Assert.NotEqual(before.Key, after.Key);
-    }
-
-    /// <summary>
-    /// THE CONTROL. With X unhashable and nothing else touched, the key must be STABLE. This is
-    /// what forbids "fixing" the arm above with a per-run nonce: a degraded term that simply
-    /// varies would satisfy the inequality while forcing a permanent MISS on every bundle that
-    /// has an unreadable dependency, which is a different way of throwing the cache away.
-    /// </summary>
-    [SkippableFact]
-    public void UnhashableDependency_WithNothingElseChanged_KeysStably()
-    {
-        TestArtifacts.SkipIfMissing();
-        var (bundle, pkgDir, cacheDir, _, _) = ArrangeUnhashableX("control");
-
-        var first = RunPrintCacheKey(bundle, pkgDir, cacheDir);
-        var second = RunPrintCacheKey(bundle, pkgDir, cacheDir);
-
-        Assert.True(first.Key != null, $"no cache key on the first run:\n{first.Output}");
-        Assert.Equal(first.Key, second.Key);
-    }
-
-    /// <summary>
-    /// THE LOUD ARM. Downgrading a dependency's cache identity from its content to a path+stat
-    /// is exactly the kind of quiet weakening .claude/rules/loud-failures.md is about, so the
-    /// run must name the package it could not hash. Against the throw-and-collapse code the
-    /// message is the generic "dependency resolution failed" instead — which is also a false
-    /// statement, since resolution succeeded.
-    /// </summary>
-    [SkippableFact]
-    public void UnhashableDependency_IsReportedByName()
-    {
-        TestArtifacts.SkipIfMissing();
-        var (bundle, pkgDir, cacheDir, xPath, _) = ArrangeUnhashableX("loud");
+        var (bundle, pkgDir, cacheDir, xPath, _) = ArrangeUnreadableX("unreadable");
 
         var run = RunPrintCacheKey(bundle, pkgDir, cacheDir);
 
-        Assert.Contains("could not hash dependency package", run.Output);
-        Assert.Contains(Path.GetFileName(xPath), run.Output);
+        // Named, with the reason and the path — not silently dropped.
+        Assert.Contains("[packages] cannot read", run.Output);
+        Assert.Contains(xPath, run.Output);
+
+        // And NOT served from the warm index entry: no cache key comes out of a run whose
+        // closure could not be resolved. Before #2987 this run produced a key.
+        Assert.True(run.Key == null,
+            "a package whose bytes cannot be read was still resolved — the app-manifests index "
+            + $"answered for content nothing verified:\n{run.Output}");
+    }
+
+    /// <summary>
+    /// NON-COLLAPSING, pinned directly on the degraded term (#2987 made it unreachable through
+    /// the runner — see this file's header). Two DIFFERENT unhashable packages must produce
+    /// two DIFFERENT terms.
+    ///
+    /// <para>This is the property the throw-and-collapse code destroyed. It replaced the whole
+    /// dependency list with one `unresolved:&lt;type&gt;:&lt;message&gt;` string — an exception
+    /// type and message, both deterministic across runs — so two closures that differ only in
+    /// another dependency's bytes keyed identically and a warm cache served the wrong DLL.
+    /// Asserting the two terms differ, and that each names its own package, is what a
+    /// per-dependency degradation means.</para>
+    /// </summary>
+    [SkippableFact]
+    public void DependencyContentTerm_TwoUnhashablePackages_DegradeSeparately()
+    {
+        var dir = Path.Combine(_scratch, "term-separate");
+        Directory.CreateDirectory(dir);
+        var a = WriteSyntheticApp(dir, DepXId, "Fabrikam Dep X", payloadFill: (byte)'X');
+        var b = WriteSyntheticApp(dir, DepYId, "Fabrikam Dep Y", payloadFill: (byte)'1');
+
+        // Readable first: the term is the package's content hash, and the two differ. Without
+        // this half the arm below would pass against an implementation that degraded
+        // EVERYTHING, which is the opposite of what is being claimed.
+        var hashedA = ProgramSupport.DependencyContentTerm(a);
+        var hashedB = ProgramSupport.DependencyContentTerm(b);
+        Assert.StartsWith("sha256:", hashedA);
+        Assert.StartsWith("sha256:", hashedB);
+        Assert.NotEqual(hashedA, hashedB);
+
+        Skip.IfNot(TryMakeUnreadable(a) && TryMakeUnreadable(b),
+            "cannot make a file unreadable here (running as root, or a filesystem that ignores "
+            + "mode bits)");
+        AlRunner.Infrastructure.RunnerFingerprint.ClearFileContentHashMemoForTests();
+
+        var degradedA = ProgramSupport.DependencyContentTerm(a);
+        var degradedB = ProgramSupport.DependencyContentTerm(b);
+
+        Assert.StartsWith("unhashable:", degradedA);
+        Assert.StartsWith("unhashable:", degradedB);
+        // Each names its OWN package: the term carries the path, so one unhashable package
+        // cannot stand in for another.
+        Assert.Contains(Path.GetFullPath(a), degradedA);
+        Assert.Contains(Path.GetFullPath(b), degradedB);
+        Assert.NotEqual(degradedA, degradedB);
+    }
+
+    /// <summary>
+    /// LOUD. Downgrading a dependency's cache identity from its content to a path+stat is the
+    /// kind of quiet weakening .claude/rules/loud-failures.md exists for, so it must name the
+    /// package it could not hash — and say what it fell back to.
+    /// </summary>
+    [SkippableFact]
+    public void DependencyContentTerm_Unhashable_IsReportedByName()
+    {
+        var dir = Path.Combine(_scratch, "term-loud");
+        Directory.CreateDirectory(dir);
+        var x = WriteSyntheticApp(dir, DepXId, "Fabrikam Dep X", payloadFill: (byte)'X');
+
+        Skip.IfNot(TryMakeUnreadable(x),
+            "cannot make a file unreadable here (running as root, or a filesystem that ignores "
+            + "mode bits)");
+        AlRunner.Infrastructure.RunnerFingerprint.ClearFileContentHashMemoForTests();
+
+        var stderr = new StringWriter();
+        var previous = Console.Error;
+        string term;
+        try
+        {
+            Console.SetError(stderr);
+            term = ProgramSupport.DependencyContentTerm(x);
+        }
+        finally { Console.SetError(previous); }
+
+        Assert.StartsWith("unhashable:", term);
+        var said = stderr.ToString();
+        Assert.Contains("could not hash dependency package", said);
+        Assert.Contains(Path.GetFullPath(x), said);
+        // It must also say what it did INSTEAD — "could not hash" alone leaves the reader
+        // unable to tell a weakened key from a failed run.
+        Assert.Contains("keying it on path+stat instead", said);
     }
 
     // ── fixture writers ───────────────────────────────────────────────────────────────────

--- a/AlRunner.Tests/RunnerFingerprintContentHashMemoTests.cs
+++ b/AlRunner.Tests/RunnerFingerprintContentHashMemoTests.cs
@@ -1,0 +1,144 @@
+// RunnerFingerprintContentHashMemoTests — issue #2987.
+//
+// RunnerFingerprint.ComputeFileContentHashMemoized is the ONE memo every layer that identifies
+// a file by its content shares: BcAppSymbolCache (#1820), the AL-output key's dependency terms
+// (#2847), the r2r-chunks cache (#2955) and — since #2987 — AppLoader's persisted app-manifests
+// index. It was keyed on the full path alone, on the premise that "nothing in this process
+// writes to a dependency .app".
+//
+// That premise does not hold for every caller. InProcessAppPackager writes synthetic .app
+// packages mid-run, and a --watch process outlives a rebuild of one. A path-keyed memo answers
+// the FIRST bytes it ever saw for those, so a caller keying a PERSISTED cache on it would
+// consult the previous package's entry — the wrong-answer shape content addressing removes,
+// reintroduced one layer down. Concretely: it is what would have made
+// AppLoaderManifestCacheTests.ReadManifest_TouchedMtime_IsReparsedNotServedStale start serving
+// V1's manifest for V2's package once the index went content-keyed.
+//
+// The memo key is now (full path, length, last-write UTC). The two arms below pin both halves
+// of what that does and does not buy — including, deliberately, the case it still cannot see,
+// so nobody reads this memo as a content check.
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Clears process-wide static state (the shared hash memo) — joins the serial collection that
+// every other class touching it already belongs to.
+[Collection(CacheRootsSerialCollection.Name)]
+public sealed class RunnerFingerprintContentHashMemoTests
+{
+    private static string NewFile(string name, byte[] content, DateTime mtimeUtc)
+    {
+        var dir = TestScratch.FlatDir("runner-fingerprint-memo-tests-");
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, name);
+        File.WriteAllBytes(path, content);
+        File.SetLastWriteTimeUtc(path, mtimeUtc);
+        return path;
+    }
+
+    /// <summary>
+    /// A file rewritten in place with a moved mtime must hash as its NEW bytes, without anyone
+    /// clearing the memo. This is the property #2987 added and the one AppLoader's on-disk
+    /// index now depends on: the memo feeds a persisted cache key, so a stale answer here is a
+    /// stale entry there.
+    /// </summary>
+    [Fact]
+    public void RewrittenInPlaceWithAMovedMtime_HashesTheNewBytes()
+    {
+        RunnerFingerprint.ClearFileContentHashMemoForTests();
+        try
+        {
+            var path = NewFile("pkg.bin", "version-one"u8.ToArray(),
+                new DateTime(2021, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+            var first = RunnerFingerprint.ComputeFileContentHashMemoized(path);
+            Assert.Equal(RunnerFingerprint.ComputeContentHash(path), first);
+            Assert.NotEqual(RunnerFingerprint.UnknownContentHash, first);
+
+            File.WriteAllBytes(path, "version-two-is-longer"u8.ToArray());
+            File.SetLastWriteTimeUtc(path, new DateTime(2021, 1, 2, 0, 0, 0, DateTimeKind.Utc));
+
+            var second = RunnerFingerprint.ComputeFileContentHashMemoized(path);
+            Assert.NotEqual(first, second);
+            // Not merely "different" — it is exactly what a fresh process would compute.
+            Assert.Equal(RunnerFingerprint.ComputeContentHash(path), second);
+        }
+        finally { RunnerFingerprint.ClearFileContentHashMemoForTests(); }
+    }
+
+    /// <summary>
+    /// The limit, stated rather than left to be discovered: a rewrite that lands on the SAME
+    /// length and the SAME mtime is invisible to the memo, which keeps answering the bytes it
+    /// first saw. That is what makes this a memo and not a content check — and it is precisely
+    /// why the PERSISTED keys built from this value, which outlive the process, are the ones
+    /// that have to be right (#2987, #2955).
+    ///
+    /// <para>It is also a proving assertion in the other direction: an implementation that
+    /// re-read the file on every call would fail here, so this pins that the memoization is
+    /// real and not accidentally removed.</para>
+    /// </summary>
+    [Fact]
+    public void RewrittenInPlaceOntoTheSameLengthAndMtime_KeepsTheMemoizedAnswer()
+    {
+        RunnerFingerprint.ClearFileContentHashMemoForTests();
+        try
+        {
+            var stamp = new DateTime(2022, 5, 6, 7, 8, 9, DateTimeKind.Utc);
+            var path = NewFile("pkg.bin", "aaaaaaaaaaaa"u8.ToArray(), stamp);
+
+            var memoized = RunnerFingerprint.ComputeFileContentHashMemoized(path);
+
+            var replacement = "bbbbbbbbbbbb"u8.ToArray();
+            Assert.Equal(new FileInfo(path).Length, replacement.Length); // the collision, asserted
+            File.WriteAllBytes(path, replacement);
+            File.SetLastWriteTimeUtc(path, stamp);
+            Assert.Equal(stamp, File.GetLastWriteTimeUtc(path));
+
+            // The memo answers the old bytes...
+            Assert.Equal(memoized, RunnerFingerprint.ComputeFileContentHashMemoized(path));
+            // ...and the unmemoized computation shows they really did change, so this is the
+            // memo's blind spot rather than two identical files.
+            Assert.NotEqual(memoized, RunnerFingerprint.ComputeContentHash(path));
+
+            // Clearing it — what a fresh process does implicitly — recovers the new answer.
+            RunnerFingerprint.ClearFileContentHashMemoForTests();
+            Assert.Equal(RunnerFingerprint.ComputeContentHash(path),
+                         RunnerFingerprint.ComputeFileContentHashMemoized(path));
+        }
+        finally { RunnerFingerprint.ClearFileContentHashMemoForTests(); }
+    }
+
+    /// <summary>Two files with different bytes never share a memo entry, and a missing file
+    /// answers the sentinel rather than throwing or inheriting a neighbour's hash.</summary>
+    [Fact]
+    public void DistinctFilesGetDistinctHashes_AndAMissingFileGetsTheSentinel()
+    {
+        RunnerFingerprint.ClearFileContentHashMemoForTests();
+        try
+        {
+            var stamp = new DateTime(2023, 2, 3, 4, 5, 6, DateTimeKind.Utc);
+            var a = NewFile("a.bin", "alpha"u8.ToArray(), stamp);
+            var b = NewFile("b.bin", "bravo"u8.ToArray(), stamp);
+
+            var hashA = RunnerFingerprint.ComputeFileContentHashMemoized(a);
+            var hashB = RunnerFingerprint.ComputeFileContentHashMemoized(b);
+            Assert.NotEqual(hashA, hashB);
+            Assert.Equal(64, hashA.Length);
+            Assert.Equal(RunnerFingerprint.ComputeContentHash(a), hashA);
+            Assert.Equal(RunnerFingerprint.ComputeContentHash(b), hashB);
+
+            var missing = Path.Combine(Path.GetDirectoryName(a)!, "not-there.bin");
+            Assert.Equal(RunnerFingerprint.UnknownContentHash,
+                         RunnerFingerprint.ComputeFileContentHashMemoized(missing));
+
+            // And once it exists, the sentinel is not what it inherits — the stat that failed
+            // memoized under the bare path, so a successful stat is a different key.
+            File.WriteAllBytes(missing, "charlie"u8.ToArray());
+            var appeared = RunnerFingerprint.ComputeFileContentHashMemoized(missing);
+            Assert.NotEqual(RunnerFingerprint.UnknownContentHash, appeared);
+            Assert.Equal(RunnerFingerprint.ComputeContentHash(missing), appeared);
+        }
+        finally { RunnerFingerprint.ClearFileContentHashMemoForTests(); }
+    }
+}

--- a/AlRunner/AppLoader.cs
+++ b/AlRunner/AppLoader.cs
@@ -69,14 +69,14 @@ public static class AppLoader
         => _manifestParseInvocationCountByPath.TryGetValue(Path.GetFullPath(appPath), out var c) ? c : 0;
 
     /// <summary>Test-only: the exact on-disk index path <see cref="ReadManifest"/> would use
-    /// for <paramref name="appPath"/> AT ITS CURRENT length/mtime — lets a test corrupt/inspect
-    /// that specific entry directly.</summary>
-    internal static string ManifestIndexPathForTests(string appPath)
+    /// for <paramref name="appPath"/> AT ITS CURRENT CONTENT — lets a test corrupt/inspect that
+    /// specific entry directly. Returns null for a package whose content hash is unavailable,
+    /// because such a package has no index entry in either direction (#2987).</summary>
+    internal static string? ManifestIndexPathForTests(string appPath)
     {
-        var fullPath = Path.GetFullPath(appPath);
-        var fi = new FileInfo(fullPath);
-        var memoKey = $"{fullPath}|{fi.Length}|{fi.LastWriteTimeUtc.Ticks}";
-        return ManifestIndexPath(memoKey);
+        var identity = TryPackageIdentity(
+            Path.GetFullPath(appPath), static p => RunnerFingerprint.ComputeFileContentHashMemoized(p));
+        return identity == null ? null : ManifestIndexPath(identity);
     }
 
     /// <summary>
@@ -87,15 +87,48 @@ public static class AppLoader
     /// Backed by a two-level cache (issue #perf-B): an in-process memo, and — on a memo
     /// miss — a small on-disk index under <c>CacheRoots.Resolve("app-manifests")</c> so a
     /// SEPARATE process (a later `al-runner` invocation, or one of the 4 that run in
-    /// parallel in CI) can skip re-parsing too. Both are keyed by (full path, length,
-    /// last-write-time-UTC) — a plain stat, not a content hash: the whole point is to avoid
-    /// touching a 98MB Base Application .app's bytes just to answer "have I seen this
-    /// exact file before". A file that changes on disk (new size or mtime — e.g. CI
-    /// re-downloading a package) gets a different key and is simply reparsed; this is not
-    /// a correctness hazard, only a cache miss (see AppLoaderManifestCacheTests
-    /// .ReadManifest_TouchedMtime_IsReparsedNotServedStale).
+    /// parallel in CI) can skip re-parsing too. The two are keyed DIFFERENTLY, and #2987 is
+    /// the reason:
+    ///
+    /// <para><b>The in-process memo</b> stays keyed on the stat — (full path, length,
+    /// last-write-time-UTC). It cannot outlive the process, so the only thing it has to get
+    /// right is noticing a file rewritten underneath it, which a stat does.</para>
+    ///
+    /// <para><b>The on-disk index</b> is keyed on the SHA-256 of the package's own bytes, via
+    /// <see cref="RunnerFingerprint.ComputeFileContentHashMemoized"/> — the one memo shared
+    /// with the bc-symbols cache, the r2r-chunks cache (#2955) and the AL-output key's
+    /// dependency terms (#2847), so a package any of them has already hashed costs a
+    /// dictionary lookup here. It is persisted and read by other processes, so a stat is not
+    /// good enough: two runs can agree on (path, length, mtime) and disagree on the bytes —
+    /// a checkout, a rebuild landing on the same size, a copy preserving mtime — and the
+    /// loser then reads an entry describing a package it does not have. What it would read is
+    /// not a derived detail but the package's IDENTITY: Publisher, Name, Version, AppId and
+    /// the whole declared Dependencies list, feeding DependencyResolver. The comment that
+    /// used to sit here called that "not a correctness hazard, only a cache miss", citing a
+    /// test (AppLoaderManifestCacheTests.ReadManifest_TouchedMtime_IsReparsedNotServedStale)
+    /// that only ever covered the case where the stat MOVES.</para>
+    ///
+    /// <para><b>What it costs.</b> Hashing every scanned package is not free, and unlike
+    /// #2955's call site this one runs over every <c>.app</c> in every package-cache
+    /// directory during DependencyResolver.EnsureIndexed, including packages the run never
+    /// loads. Measured on this repo's own CI package set — <c>~/.al-runner/platform-apps</c>
+    /// plus <c>~/.al-runner/test-apps</c>, 108 packages, 143 MB, warm page cache,
+    /// instructions-retired over 3 runs each: the stat costs 221 M instructions (5.9 ms), the
+    /// content hash 643 M (100.6 ms), and the uncached parse this index exists to avoid
+    /// 1,112 M (157 ms). So the index still saves the larger half of what it always saved,
+    /// and the marginal cost in a REAL run is far below that 95 ms delta because the packages
+    /// a run actually loads are hashed by the caches above regardless — see the PR for #2987
+    /// for the end-to-end numbers.</para>
+    ///
+    /// <para>Entries are named <c>sha256-&lt;hash&gt;.json</c>. A pre-#2987 stat-keyed entry
+    /// name was also 64 lowercase hex characters plus <c>.json</c> — identical in shape,
+    /// meaning something else entirely — so the prefix is what stops a warm pre-fix cache
+    /// directory from being silently misread as a content-keyed one.</para>
     /// </summary>
     public static AppManifest? ReadManifest(string appPath)
+        => ReadManifestCore(appPath, static p => RunnerFingerprint.ComputeFileContentHashMemoized(p));
+
+    internal static AppManifest? ReadManifestCore(string appPath, Func<string, string> contentHashOf)
     {
         string fullPath;
         long length;
@@ -120,21 +153,49 @@ public static class AppLoader
         if (_manifestMemo.TryGetValue(memoKey, out var memoized))
             return memoized;
 
-        var indexed = TryReadManifestIndex(memoKey);
-        if (indexed != null)
+        var identity = TryPackageIdentity(fullPath, contentHashOf);
+        if (identity != null)
         {
-            PerfTrace.Log($"app-manifests HIT {Path.GetFileName(fullPath)}");
-            _manifestMemo[memoKey] = indexed;
-            return indexed;
+            var indexed = TryReadManifestIndex(identity);
+            if (indexed != null)
+            {
+                PerfTrace.Log($"app-manifests HIT {Path.GetFileName(fullPath)}");
+                _manifestMemo[memoKey] = indexed;
+                return indexed;
+            }
         }
 
         _manifestParseInvocationCountByPath.AddOrUpdate(fullPath, 1, static (_, c) => c + 1);
         var parsed = ReadManifestUncached(fullPath);
         PerfTrace.Log($"app-manifests MISS {Path.GetFileName(fullPath)}");
         _manifestMemo[memoKey] = parsed;
-        if (parsed != null)
-            TryWriteManifestIndex(memoKey, parsed);
+        if (parsed != null && identity != null)
+            TryWriteManifestIndex(identity, parsed);
         return parsed;
+    }
+
+    /// <summary>
+    /// The package's content hash, or null when it cannot be computed — the signal that this
+    /// package gets NO shared index entry, in either direction (#2955's guard, same reasoning).
+    ///
+    /// <para>Keying on the <see cref="RunnerFingerprint.UnknownContentHash"/> sentinel instead
+    /// would give every unidentifiable package ONE shared index entry, so the first such
+    /// package's Publisher/Name/Version/AppId/Dependencies would be served as every later
+    /// one's — the exact wrong-answer shape content addressing exists to remove, reintroduced
+    /// by the fix. Costing a reparse is the only thing this branch can ever do.</para>
+    /// </summary>
+    private static string? TryPackageIdentity(string fullPath, Func<string, string> contentHashOf)
+    {
+        string hash;
+        try { hash = contentHashOf(fullPath); }
+        catch (Exception ex)
+        {
+            // Hashing reads the file; a package we cannot read is one we cannot identify.
+            PerfTrace.Log($"app-manifests identity unavailable for {Path.GetFileName(fullPath)}: " +
+                          $"{ex.Message} — not consulting or writing the shared index");
+            return null;
+        }
+        return string.IsNullOrEmpty(hash) || hash == RunnerFingerprint.UnknownContentHash ? null : hash;
     }
 
     /// <summary>The actual parse, with no caching — streams the .app straight off disk via
@@ -152,20 +213,22 @@ public static class AppLoader
 
     // ── on-disk manifest index (issue #perf-B) ─────────────────────────────────
 
-    private static string ManifestIndexPath(string memoKey)
-    {
-        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(memoKey))).ToLowerInvariant();
-        return Path.Combine(CacheRoots.Resolve("app-manifests"), hash + ".json");
-    }
+    /// <summary>The entry for one package CONTENT (#2987). The <c>sha256-</c> prefix is load
+    /// bearing: a pre-fix entry name was 64 lowercase hex characters plus <c>.json</c> too,
+    /// and named the hash of a <c>path|length|mtime</c> string instead — indistinguishable by
+    /// shape from what this returns, so without the prefix a warm pre-fix cache directory
+    /// would be read as if its entries were content-keyed.</summary>
+    private static string ManifestIndexPath(string contentHash)
+        => Path.Combine(CacheRoots.Resolve("app-manifests"), "sha256-" + contentHash + ".json");
 
-    private static AppManifest? TryReadManifestIndex(string memoKey)
-        => TryReadIndexPayload(memoKey) is { } hit ? hit.Manifest : null;
+    private static AppManifest? TryReadManifestIndex(string contentHash)
+        => TryReadIndexPayload(contentHash) is { } hit ? hit.Manifest : null;
 
     /// <summary>The whole index entry, so a caller that needs the symbol-reference flag can see
     /// whether it was recorded at all rather than inferring false from its absence.</summary>
-    private static (AppManifest Manifest, bool? HasSymbolReference)? TryReadIndexPayload(string memoKey)
+    private static (AppManifest Manifest, bool? HasSymbolReference)? TryReadIndexPayload(string contentHash)
     {
-        var path = ManifestIndexPath(memoKey);
+        var path = ManifestIndexPath(contentHash);
         if (!File.Exists(path)) return null;
         try
         {
@@ -187,11 +250,11 @@ public static class AppLoader
         }
     }
 
-    private static void TryWriteManifestIndex(string memoKey, AppManifest manifest, bool? hasSymbolReference = null)
+    private static void TryWriteManifestIndex(string contentHash, AppManifest manifest, bool? hasSymbolReference = null)
     {
         try
         {
-            var path = ManifestIndexPath(memoKey);
+            var path = ManifestIndexPath(contentHash);
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             var payload = ToPayload(manifest, hasSymbolReference);
             // Atomic (temp file + rename) — 4 CI processes can race a write to the SAME
@@ -267,6 +330,11 @@ public static class AppLoader
     /// directory, and for the R2R packages Microsoft ships, by the same buffered nested
     /// <c>.app</c>. Asking them separately opened every package twice.</para>
     ///
+    /// <para>Keyed exactly like <see cref="ReadManifest"/> — stat for the process memo, the
+    /// package's content hash for the persisted index (#2987). See that method for why the two
+    /// differ, and note that the index entry is SHARED between them, so the two must never
+    /// compute the identity differently.</para>
+    ///
     /// <para>Measured on the al-language corpus with two package caches (459 <c>.app</c> files,
     /// 117 MB, Microsoft_Base Application 98 MB of it), first uncached
     /// <c>DeduplicateAppPackageDirs</c> scan of a process: 835 ms, of which
@@ -277,6 +345,10 @@ public static class AppLoader
     /// every process after the first. See issue #2607.</para>
     /// </summary>
     public static (AppManifest? Manifest, bool HasSymbolReference) ReadPackageMeta(string appPath)
+        => ReadPackageMetaCore(appPath, static p => RunnerFingerprint.ComputeFileContentHashMemoized(p));
+
+    internal static (AppManifest? Manifest, bool HasSymbolReference) ReadPackageMetaCore(
+        string appPath, Func<string, string> contentHashOf)
     {
         string fullPath;
         long length;
@@ -301,9 +373,16 @@ public static class AppLoader
             && _manifestMemo.TryGetValue(memoKey, out var memoManifest))
             return (memoManifest, memoFlag);
 
+        // Content-keyed exactly like ReadManifest's, and it MUST be the same key: the two
+        // methods read and write the same entries, so a package they identified differently
+        // would have ReadManifest's entry (HasSymbolReference null) and ReadPackageMeta's
+        // entry (the flag recorded) sitting under two names for the same bytes.
+        var identity = TryPackageIdentity(fullPath, contentHashOf);
+
         // Only a FULL index entry can serve this: an entry written before the flag existed has
         // HasSymbolReference null, and null means "go and look", never false.
-        if (TryReadIndexPayload(memoKey) is { HasSymbolReference: { } storedFlag } hit)
+        if (identity != null
+            && TryReadIndexPayload(identity) is { HasSymbolReference: { } storedFlag } hit)
         {
             PerfTrace.Log($"app-manifests HIT+symref {Path.GetFileName(fullPath)}");
             _manifestMemo[memoKey] = hit.Manifest;
@@ -316,8 +395,8 @@ public static class AppLoader
         PerfTrace.Log($"app-manifests MISS {Path.GetFileName(fullPath)}");
         _manifestMemo[memoKey] = read.Manifest;
         _symbolReferenceMemo[memoKey] = read.HasSymbolReference;
-        if (read.Manifest != null)
-            TryWriteManifestIndex(memoKey, read.Manifest, read.HasSymbolReference);
+        if (read.Manifest != null && identity != null)
+            TryWriteManifestIndex(identity, read.Manifest, read.HasSymbolReference);
         return read;
     }
 

--- a/AlRunner/AppLoader.cs
+++ b/AlRunner/AppLoader.cs
@@ -168,6 +168,9 @@ public static class AppLoader
         _manifestParseInvocationCountByPath.AddOrUpdate(fullPath, 1, static (_, c) => c + 1);
         var parsed = ReadManifestUncached(fullPath);
         PerfTrace.Log($"app-manifests MISS {Path.GetFileName(fullPath)}");
+        // No identity AND no parse means the bytes are unreadable — say so, or the package
+        // vanishes from the scan set without explanation. See ReportUnreadablePackage.
+        if (parsed == null && identity == null) ReportUnreadablePackage(fullPath);
         _manifestMemo[memoKey] = parsed;
         if (parsed != null && identity != null)
             TryWriteManifestIndex(identity, parsed);
@@ -197,6 +200,40 @@ public static class AppLoader
         }
         return string.IsNullOrEmpty(hash) || hash == RunnerFingerprint.UnknownContentHash ? null : hash;
     }
+
+    // Packages already reported as unreadable, so a path scanned by several layers within one
+    // process says it once rather than once per scan.
+    private static readonly ConcurrentDictionary<string, byte> _unreadablePackagesReported =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Says, once per package per process, that a <c>.app</c> was skipped because its bytes
+    /// could not be read — on stderr, not through PerfTrace, because it is off by default.
+    ///
+    /// <para>This is the diagnosis #2987 owes the user. Before #2987 a package that became
+    /// unreadable AFTER its manifest was indexed still resolved, because the index was keyed on
+    /// a stat and a stat survives <c>chmod 000</c>. Now the index is keyed on the package's
+    /// content, so a package we cannot read is a package we cannot identify, and it drops out
+    /// of the scan set. Refusing is the right answer — serving an identity we cannot tie to the
+    /// bytes on disk is the whole defect — but dropping out SILENTLY is not: the run would then
+    /// fail with "a required dependency package is missing" naming the dependency, while the
+    /// package sits right there in the cache directory, unreadable. That is the
+    /// mysterious-missing-dependency shape #2206 is about, and this line is what keeps it from
+    /// recurring in a new form.</para>
+    /// </summary>
+    private static void ReportUnreadablePackage(string fullPath)
+    {
+        if (!_unreadablePackagesReported.TryAdd(fullPath, 0)) return;
+        Console.Error.WriteLine(
+            $"  [packages] cannot read '{fullPath}' — skipping it. Its bytes could not be read, "
+            + "so it cannot be identified or parsed, and a package the runner cannot identify is "
+            + "not indexed. If a dependency is reported missing below, this is why. Check the "
+            + "file's permissions and that it is a complete .app.");
+    }
+
+    /// <summary>Test-only: forget which packages have been reported, so an arm that expects the
+    /// line can run after one that already triggered it for the same path.</summary>
+    internal static void ResetUnreadablePackageReportsForTests() => _unreadablePackagesReported.Clear();
 
     /// <summary>The actual parse, with no caching — streams the .app straight off disk via
     /// <see cref="OpenAppZip"/> rather than reading the whole file into memory first (the
@@ -393,6 +430,7 @@ public static class AppLoader
         _manifestParseInvocationCountByPath.AddOrUpdate(fullPath, 1, static (_, c) => c + 1);
         var read = ReadPackageMetaUncached(fullPath);
         PerfTrace.Log($"app-manifests MISS {Path.GetFileName(fullPath)}");
+        if (read.Manifest == null && identity == null) ReportUnreadablePackage(fullPath);
         _manifestMemo[memoKey] = read.Manifest;
         _symbolReferenceMemo[memoKey] = read.HasSymbolReference;
         if (read.Manifest != null && identity != null)

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -802,9 +802,12 @@ public sealed partial class BcCompiler
     // package rewritten in place (InProcessAppPackager's synthetic .apps, a --watch rebuild)
     // invalidates its own entry.
     //
-    // AppLoader.ReadPackageMeta keeps the same key across PROCESSES in its on-disk index and
-    // answers both questions off one open; this is the in-process layer in front of it, and the
-    // one ResetSharedReferencesForTests clears so a test can force the scan to re-read.
+    // AppLoader.ReadPackageMeta answers both questions off one open and carries them across
+    // PROCESSES in its on-disk index — that index is keyed on the package's CONTENT since
+    // #2987, not on this stat; this is the in-process layer in front of it, and the one
+    // ResetSharedReferencesForTests clears so a test can force the scan to re-read. A stat is
+    // the right key HERE precisely because this dictionary dies with the process: all it has
+    // to notice is a package rewritten underneath it.
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<
         string, (long Length, long Ticks, AppManifest? Manifest, bool HasSymbolReference)> _appMetaCache = new();
 

--- a/AlRunner/Infrastructure/RunnerFingerprint.cs
+++ b/AlRunner/Infrastructure/RunnerFingerprint.cs
@@ -105,20 +105,41 @@ internal static class RunnerFingerprint
     //
     // ComputeContentHash reads the WHOLE file; the call sites ask per virtual-table lookup,
     // per dependency and per cache key, so an unmemoized hash is a re-read each time.
-    // Content does not change mid-run (nothing in this process writes to a dependency .app),
-    // so "one entry per path, never invalidated" is the whole invalidation policy — and it
-    // is why a test that simulates a process restart has to clear this explicitly.
+    //
+    // The memo key is (full path, length, last-write UTC) — NOT the path alone, which is what
+    // it was until #2987. "One entry per path, never invalidated" rested on "nothing in this
+    // process writes to a dependency .app", and that premise does not hold for every caller:
+    // InProcessAppPackager writes synthetic .app packages mid-run, and a --watch process
+    // outlives a rebuild of one. A path-keyed memo answers the FIRST bytes it ever saw for
+    // those, so a caller keying a persisted cache on it would consult the previous package's
+    // entry — the wrong-answer shape content addressing exists to remove, reintroduced one
+    // layer down. The stat is not trusted to identify CONTENT here (that is the whole point of
+    // this method); it is only used to notice that the file has been written since, which is
+    // exactly what a stat can tell you. A rewrite that lands on the same length and mtime is
+    // one the memo will not notice — that is a memo, not a cache key, and it lives and dies
+    // with the process, which is why the persisted keys built FROM this value are the ones
+    // that have to be right.
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, string> _fileContentHashes =
         new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
-    /// <see cref="ComputeContentHash"/> memoized per full path — the entry point every
-    /// cache key that identifies a FILE by its content should use.
+    /// <see cref="ComputeContentHash"/> memoized per (full path, length, mtime) — the entry
+    /// point every cache key that identifies a FILE by its content should use.
     /// </summary>
     internal static string ComputeFileContentHashMemoized(string path)
     {
         var fullPath = Path.GetFullPath(path);
-        return _fileContentHashes.GetOrAdd(fullPath, static p => ComputeContentHash(p));
+        string memoKey;
+        try
+        {
+            var fi = new FileInfo(fullPath);
+            // A file we cannot stat memoizes under the bare path: ComputeContentHash is about
+            // to answer UnknownContentHash for it anyway, and a later call that CAN stat it
+            // gets a different key and recomputes rather than inheriting that answer.
+            memoKey = fi.Exists ? $"{fullPath}|{fi.Length}|{fi.LastWriteTimeUtc.Ticks}" : fullPath;
+        }
+        catch { memoKey = fullPath; }
+        return _fileContentHashes.GetOrAdd(memoKey, _ => ComputeContentHash(fullPath));
     }
 
     /// <summary>Test-only: drops the memo, so a test that rewrites a file in place can

--- a/AlRunner/Patches/RecordPatches.BcAppFallback.cs
+++ b/AlRunner/Patches/RecordPatches.BcAppFallback.cs
@@ -556,12 +556,34 @@ public static partial class RecordPatches
             var asmInfo = !string.IsNullOrEmpty(asm.Location) && File.Exists(asm.Location)
                 ? new FileInfo(asm.Location)
                 : null;
-            var suffix = asmInfo != null
-                ? $"{asmInfo.Length:x}-{asmInfo.LastWriteTimeUtc.Ticks:x}"
+            // #2987 — the suffix is the SystemApp DLL's CONTENT hash. It was its length +
+            // mtime, under a comment calling that "content-addressed", which is the same
+            // substitution #2987 removed from AppLoader's app-manifests index and #2955 from
+            // the r2r-chunks cache: the published name promises "this is the package inside
+            // THESE bytes" to every other process on the machine, and a stat cannot keep that
+            // promise. Two runner builds whose SystemApp DLL agrees on length and mtime — a
+            // rebuild, a checkout, a copy — would have the second adopt the first's extracted
+            // package and register it as its own. BC reports a package that does not match as
+            // `AL1023 ... is not valid` against the whole compilation, so it is a run-wide
+            // failure attributed to the wrong thing.
+            //
+            // Affordable here for the reason it was not obviously affordable in #2987: this
+            // runs ONCE per process over a ~6 MB DLL, not once per package over a whole
+            // package cache, and it goes through the shared memo, so a DLL any other layer has
+            // already hashed costs a dictionary lookup.
+            //
+            // A DLL whose hash is unavailable falls back to the per-process GUID the
+            // no-asmInfo case already used: no identity, no shared name, never a shared name
+            // that lies.
+            var contentHash = asmInfo != null
+                ? SafeContentHash(asmInfo.FullName)
+                : null;
+            var suffix = contentHash != null
+                ? "sha256-" + contentHash
                 : Guid.NewGuid().ToString("N");
-            // #2967 — SCRATCH-DIR CLASSIFICATION: deliberately SHARED and content-addressed
-            // (the suffix is the SystemApp DLL's length + mtime), so it must NOT become a
-            // per-process path: every runner on the machine reuses one 6 MB extraction.
+            // #2967 — SCRATCH-DIR CLASSIFICATION: deliberately SHARED and content-addressed,
+            // so it must NOT become a per-process path: every runner on the machine reuses one
+            // 6 MB extraction.
             //
             // It was UNSAFE as written, though, and this was the one site matching the
             // "reader sees a half-written file under a name that promises its content" shape.
@@ -591,6 +613,24 @@ public static partial class RecordPatches
             var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
             Console.Error.WriteLine($"[RecordPatches] BcAppFallback: SystemApp registration failed: {inner.GetType().Name}: {inner.Message}");
         }
+    }
+
+    /// <summary>
+    /// The file's content hash, or null when it cannot be computed. Null is what makes the
+    /// caller fall back to a per-process name instead of publishing a SHARED name it cannot
+    /// stand behind — keying on RunnerFingerprint's "unknown" sentinel would give every
+    /// unidentifiable DLL one shared extraction, which is the wrong-answer shape #2987 removes
+    /// rather than a smaller version of it.
+    /// </summary>
+    private static string? SafeContentHash(string path)
+    {
+        try
+        {
+            var hash = AlRunner.Infrastructure.RunnerFingerprint.ComputeFileContentHashMemoized(path);
+            return string.IsNullOrEmpty(hash)
+                || hash == AlRunner.Infrastructure.RunnerFingerprint.UnknownContentHash ? null : hash;
+        }
+        catch { return null; }
     }
 
     /// <summary>

--- a/AlRunner/ProgramSupport/Dependencies.cs
+++ b/AlRunner/ProgramSupport/Dependencies.cs
@@ -677,8 +677,27 @@ internal static partial class ProgramSupport
     /// test in this repo can construct, and an untestable branch is what this method exists to
     /// stop shipping.</para>
     /// </summary>
-    private static string DependencyContentTerm(string appPath)
+    // internal, not private: #2987 made this branch unreachable end-to-end (see the
+    // paragraph above), so a direct unit test is the only thing that still exercises it.
+    internal static string DependencyContentTerm(string appPath)
     {
+        // #2987 — READ THIS BEFORE CHANGING THE DEGRADED PATH BELOW.
+        //
+        // Everything after the `if (hash != "unknown")` line is now DEFENSIVE, not a path a
+        // real run reaches. AppLoader's app-manifests index used to be keyed on a stat, so a
+        // package could be RESOLVED from a warm index entry while its bytes were unreadable —
+        // which is exactly what CacheKeyUnhashableDependencyTests used to construct with
+        // `chmod 000`, and what made "resolved but unhashable" a real state. #2987 keyed that
+        // index on the package's CONTENT, so identifying a package now requires reading it:
+        // a package the resolver indexed is a package whose hash it computed, memoized under
+        // the same (path, length, mtime) key this call will use. The degraded term therefore
+        // cannot be reached for a resolved dependency.
+        //
+        // That is also what closes #2954's residue — "unhashable on two consecutive runs while
+        // the content changes between them" — without a "do not cache this run" signal: the
+        // state it needed no longer exists. Kept rather than deleted because the reachability
+        // argument is about the CALLER, and a future caller that resolves a dependency some
+        // other way would land here; it must degrade one term, never collapse the list.
         string failure;
         try
         {


### PR DESCRIPTION
Closes #2987

`AppLoader.ReadManifest` and `AppLoader.ReadPackageMeta` both built `{fullPath}|{Length}|{LastWriteTimeUtc.Ticks}` and used it, hashed, as the filename of an entry under `CacheRoots.Resolve("app-manifests")` — an index that is persisted on disk and read by other processes. What that entry holds is the package's identity: Publisher, Name, Version, AppId, the whole declared `Dependencies` list, and `HasSymbolReference`. Two runs can agree on the stat and disagree on the bytes, and the loser reads an entry that describes a package it does not have.

The persisted index is now keyed on the SHA-256 of the package's own bytes, through `RunnerFingerprint.ComputeFileContentHashMemoized` — the one memo already shared with the bc-symbols cache (#1820), the r2r-chunks cache (#2955) and the AL-output key's dependency terms (#2847). No new hashing path and no fourth convention. Entries are named `sha256-<hash>.json`, because a pre-fix entry name was also 64 lowercase hex characters plus `.json` and meant something else entirely.

The in-process memo stays keyed on the stat, as #2987 recommends: it cannot outlive the process, so all it has to notice is a file rewritten underneath it.

## RED → GREEN

`AlRunner.Tests/AppLoaderManifestIndexIdentityTests.cs`, 8 arms. The decisive one writes two packages padded to identical length, to one path, under one mtime — both asserted before the read that depends on them:

```
ReadManifest_SamePathSameLengthSameMtime_DifferentBytes_ServesTheNewPackagesIdentity
Expected: bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
Actual:   aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
```

Package B was served package A's AppId. 7 of 8 arms failed before the change, 8/8 pass after. The sibling arm does the same for `HasSymbolReference`, the flag whose wrong answer `ReadPackageMetaFromZip`'s own comment says "drops a package from the scan set and produces AL1023 against the whole compilation".

## The measurement #2987 asked for, and what it decided

This index is consulted for every `.app` in every package-cache directory during `DependencyResolver.EnsureIndexed`, including packages the run never loads, so the cost direction is genuinely opposite to #2955's. Instructions-retired (`perf stat`), because several agents run on this box and wall clock is unusable here.

**Isolated primitives**, 108 packages / 143 MB, 3 runs each, spread under 0.01%:

| | instructions | wall |
|---|---|---|
| stat (what it was) | 221.0 M | 5.9 ms |
| SHA-256 of content (what it is) | 642.9 M | 100.6 ms |
| the uncached parse the index avoids | 1,111.6 M | 157 ms |

**One runner invocation**, smallest fixture in the repo, warm, 5 runs, spread under 0.5%:

| | instructions | delta |
|---|---|---|
| before | 11.095 G | |
| after | 13.782 G | **+2.687 G, +24%** |

That is the worst case and it looked disqualifying, so I measured where it goes. 694 MB gets hashed to resolve 6 packages, and the decomposition says why:

```
122.5 MB   6 files  ~/.local/share/al-runner/artifacts/28.1.49838.54169/platform-apps
122.5 MB   6 files  ~/.al-runner/platform-apps
122.5 MB   6 files  ~/.local/share/al-runner/artifacts/28.1.49838.53910/platform-apps
122.5 MB   6 files  ~/.local/share/al-runner/artifacts/28.1.49838.54044/platform-apps
122.5 MB   6 files  ~/.local/share/al-runner/artifacts/28.1.49838.53997/platform-apps
 21.3 MB 107 files  ...53910/test-apps   (and two more test-apps directories)
```

Base Application, 98 MB, hashed once per provisioned BC artifact version. This box has four; a CI leg provisions one. So the 24% is a fixed per-process cost against 1.6 s of work on a box with unusual amounts of BC provisioned, not the number that decides.

**A real suite**, `tests/runner-extras`, 282 tests, warm, 3 runs:

| | median | min | max |
|---|---|---|---|
| before | 571.17 G | 569.16 G | 599.37 G |
| after | 591.62 G | 578.34 G | 611.65 G |

**+1.6% (min to min) to +3.6% (median to median)**; the ranges overlap, so I am not claiming better precision than that. 282/282 pass on both binaries.

**Control** — `--help`, which does no package scan, must be flat and is: 706.2 M before, 706.5 M after (+0.04%).

So: I did not force #2955's shape. I measured it, found the cost acceptable on any workload that does real work, and am naming the two things that make the worst case worse than it needs to be as follow-ups rather than folding them in.

One asymmetry against #2955 is worth stating, because it cuts the other way: there, the stat MISSed unconditionally in CI (every `.app` re-downloaded per run, fresh mtime), so content-keying was strictly cheaper. Here the stat already HITs — measured 351 index HITs and 0 MISSes on one invocation, before and after — so this change buys correctness and pays for it. That is the trade, stated plainly.

## Fixing the shape, not just the reported line

**Does the same wrong pattern appear at another call site?** Yes, one: `RecordPatches.BcAppFallback` named its shared `/tmp/al-runner-systemapp-<suffix>.app` extraction after the SystemApp DLL's length + mtime, under a comment calling that "content-addressed". It is published where every other runner on the machine reads it, and a name that promises "the package inside these bytes" cannot be kept by a stat. Now the DLL's content hash. Affordable for the reason it was not obviously affordable in `ReadManifest`: once per process over a ~6 MB DLL, through the same memo.

Checked and deliberately left alone: `BcCompiler._appMetaCache` and `BcAppSymbolCache.GetTableExtensions` are in-process dictionaries, where a stat is the right key because it dies with the process — I corrected `BcCompiler`'s comment, which claimed `ReadPackageMeta` "keeps the same key across PROCESSES". `TestDataOptions.BuildCacheIdentity` is persisted and stat-keyed, but states its own reasoning (a ~1 GB backup, re-hashed per run, would cost more than the hydration it guards) rather than asserting safety it does not have.

**Does a sibling function make the same assumption?** `ReadPackageMeta` did, and moves with `ReadManifest` — they read and write the same entries, so they must compute the identity identically or one package gets two entries.

**If two code paths write the same state, do they maintain the same invariant?** This found the real bug in the fix. `ComputeFileContentHashMemoized` memoized on the path alone, never invalidated, on the premise that "nothing in this process writes to a dependency .app". `InProcessAppPackager` writes synthetic `.app` packages mid-run and a `--watch` process outlives a rebuild of one, so that premise does not hold for every caller — and a persisted key built on a stale memo is the same wrong answer one layer down. Concretely it would have made `AppLoaderManifestCacheTests.ReadManifest_TouchedMtime_IsReparsedNotServedStale` start serving V1's manifest for V2's package. The memo key is now (path, length, mtime); `RunnerFingerprintContentHashMemoTests` pins both halves, including the case it still cannot see, so nobody reads the memo as a content check.

## What this costs, beyond CPU

Identifying a package now requires reading it, so a package whose bytes are unreadable is no longer resolved from a warm index entry. That is the right answer — serving an identity nothing ties to the bytes on disk is the defect — but dropping out silently would produce "a required dependency package is missing" for a package sitting in the cache directory, which is the mysterious-missing-dependency shape of #2206 in a new form. `AppLoader` now names it on stderr, once per package per process.

It also removes the construction `CacheKeyUnhashableDependencyTests` used: a warm-up run indexed the package, `chmod 000` left path/length/mtime untouched, and the resolver answered from the index without opening the file. Those three arms are rewritten rather than skipped — one end-to-end arm pinning the new contract (skipped **and named**, and no cache key comes out), and two pinning the degraded term directly on `ProgramSupport.DependencyContentTerm`, now `internal` for that purpose: that one unhashable package degrades one term rather than collapsing the list, and that it says so naming the package.

## This also answers #2954, and it is not a PR there

#2954 wants a "do not cache this run" signal for a package that is resolved but unhashable. That state was reachable only because the manifest index was keyed on a stat: a package could be resolved from a warm entry while its bytes were unreadable. With the index keyed on content, a resolved package is one the runner read and hashed, memoized under the same (path, length, mtime) key the dependency term will use — so `DependencyContentTerm`'s degraded branch cannot be reached for a resolved dependency even if the file becomes unreadable mid-run. #2954's residue closes by construction, without the run-wide signal whose cost that issue and #2992's author both flagged as the thing that would make the cure exceed the exposure. I have written this up on #2954 rather than opening a second PR; the branch stays, defensively, with the reachability argument recorded next to it.

## Not fixed here, filed instead

- The scan hashes the same inode twice in CI: `provision-bc` does `cp -al` from `~/.al-runner/platform-apps` into the artifacts directory, and the memo is path-keyed, so 122 MB of hard links is hashed under both names.
- The scan covers every provisioned BC artifact version's `platform-apps`, not the selected one, so Base Application is hashed once per version present. Four copies on this box, one of them used.

Both make the worst case worse and neither belongs in a correctness fix.

Opened by Claude Code agent `impl-36`.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
