### PR TITLE
fix(field-triggers): refuse loudly when BC's handler backing field cannot be read

### DIFF
--- a/AlRunner.Tests/FieldTriggerHandlerBackingShapeGapTests.cs
+++ b/AlRunner.Tests/FieldTriggerHandlerBackingShapeGapTests.cs
@@ -1,0 +1,323 @@
+// FieldTriggerHandlerBackingShapeGapTests — issue #3026.
+//
+// THE DEFECT
+// ----------
+// RecordPatches resolves two of BC's private auto-property backing fields once, in
+// EnsureFieldTriggerReflection:
+//
+//     _fValidateHandlerBacking = _tEventTriggerData.GetField("<ValidateHandler>k__BackingField", …);
+//     _fLookupHandlerBacking   = _tEventTriggerData.GetField("<LookupHandler>k__BackingField", …);
+//
+// Both are FieldInfo? and both are null on a BC build whose NCLMetaField.EventTriggerData
+// layout is not the shape that reflection was written against.
+//
+// The READ path over that same state already refuses: RecordPatches.TryHasFieldLookupTrigger
+// is three-valued ON PURPOSE and returns null — never "no trigger" — when the read could not
+// be performed, and RunnerPageInstance.RaiseSourceFieldOnLookup turns that null into a
+// BcShapeGapException (#2999).
+//
+// The WRITE path defaulted, and did it silently: every handler install was guarded with
+// `&& _fValidateHandlerBacking != null` (and the lookup equivalent), so the AL table's
+// OnValidate / OnLookup field trigger was NEVER INSTALLED, nothing was printed, and
+// WireFieldTriggerHandlers still returned true. AL that depends on the trigger then ran with
+// no trigger at all — the silent default .claude/rules/loud-failures.md exists to prevent,
+// and worse than a refusal because the test does not fail, it PASSES having skipped the
+// trigger.
+//
+// WHAT THE NEGATIVE TESTS PROVE, AND WHY THEY ARE WORDED THE WAY THEY ARE
+// ----------------------------------------------------------------------
+// Each negative test captures WireFieldTriggerHandlers' return value and the handler slot's
+// contents and puts BOTH into the assertion message, so the RED run reports the silence
+// itself ("returned True and installed no ValidateHandler") rather than the bare xUnit
+// "expected an exception". Measured on origin/main before the fix, that is exactly what both
+// printed.
+//
+// The positive control is what stops the fix from passing by throwing unconditionally: with
+// the statics untouched, the same call must still INSTALL both handlers and return true.
+//
+// WHY A RUNNER-SIDE MECHANISM TEST AND NOT AN AL BUNDLE OR A CORPUS TEST
+// ---------------------------------------------------------------------
+// No AL statement can move a private BC field. The subject is what the runner does when it
+// cannot read BC's own layout — the runner's refusal contract, which
+// .claude/rules/bc-behavior-tests-go-upstream.md classifies as runner-specific (same shape as
+// BcShapeGapConventionTests and RunnerShapeGapClaimTests). On every supported BC build
+// (verified on 27.5 and 28.1: both are `internal FieldTriggerHandler<NavApplicationObjectBase>
+// { get; set; }` auto-properties, so both k__BackingFields exist) the refusal is unreachable,
+// which is why the fault is injected here by nulling the cached FieldInfo rather than by
+// finding a BC version that exhibits it.
+//
+// HOW THE FAULT IS INJECTED
+// -------------------------
+// The private static FieldInfo is set to null for the duration of one call and restored in a
+// finally — the same state a build with a moved layout would leave EnsureFieldTriggerReflection
+// in. Nothing in production is made settable for the test's benefit. The class joins
+// BcEngineCollection, which is DisableParallelization, so no other test observes the window.
+
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Reflection;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Stand-in for an AL-emitted <c>Record&lt;id&gt;</c> type. Never instantiated — the wiring
+/// only reads its <see cref="FieldTriggerHandlerAttribute"/>s, opens a delegate over the
+/// annotated methods and casts to it from <c>NavApplicationObjectBase</c>, all of which are
+/// type-level operations. It derives from <see cref="NavRecord"/> because
+/// <c>BuildSyncWrapper</c> emits <c>(NavApplicationObjectBase x) =&gt; inner((TConcrete)x)</c>
+/// and <c>Expression.Convert</c> rejects an unrelated target type.
+///
+/// <para><c>internal</c>, not public, on purpose: xUnit discovery calls
+/// <c>Assembly.GetExportedTypes()</c>, which resolves a PUBLIC type's whole base chain —
+/// and <c>NavComplexValue</c> lives in Microsoft.Dynamics.Nav.Types.dll, which is a
+/// reference-only assembly here and is not in the test bin dir. Measured: as a public type
+/// this took the entire assembly down with "Catastrophic failure: ... Could not load file or
+/// assembly 'Microsoft.Dynamics.Nav.Types'" before a single test ran.</para>
+/// </summary>
+internal sealed class FieldTriggerGapStandInRecord : NavRecord
+{
+    /// <summary>Never called; the wiring path needs a type, not an instance.</summary>
+    internal FieldTriggerGapStandInRecord() : base(null!, 0) { }
+
+    [FieldTriggerHandler(FieldTriggerType.OnValidate, FieldTriggerHandlerBackingShapeGapTests.ValidateFieldNo)]
+    public void OnValidateNo() { }
+
+    [FieldTriggerHandler(FieldTriggerType.OnLookup, FieldTriggerHandlerBackingShapeGapTests.LookupFieldNo)]
+    public void OnLookupDescription() { }
+}
+
+[Collection(BcEngineCollection.Name)]
+public sealed class FieldTriggerHandlerBackingShapeGapTests : IDisposable
+{
+    internal const int ValidateFieldNo = 1;
+    internal const int LookupFieldNo = 2;
+
+    // One table id per test so no test observes state a sibling installed. Chosen outside
+    // every other id in AlRunner.Tests (these land in the process-wide static _parsedTables
+    // / _metaTableCache the whole assembly shares).
+    private const int PositiveControlTableId = 93950;
+    private const int ValidateGapTableId = 93951;
+    private const int LookupGapTableId = 93952;
+
+    private readonly BcEngineFixture _engine;
+    private readonly string _root;
+
+    public FieldTriggerHandlerBackingShapeGapTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = TestScratch.Dir("al-runner-3026-tests");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    // ── plumbing ────────────────────────────────────────────────────────────────────────
+
+    private static FieldInfo Static(string name) =>
+        typeof(RecordPatches).GetField(name, BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException($"RecordPatches.{name} not found — this test tracks that field.");
+
+    private static readonly MethodInfo EnsureReflection =
+        typeof(RecordPatches).GetMethod("EnsureFieldTriggerReflection", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("RecordPatches.EnsureFieldTriggerReflection not found.");
+
+    private static readonly MethodInfo WireOne =
+        typeof(RecordPatches).GetMethod("WireFieldTriggerHandlers", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("RecordPatches.WireFieldTriggerHandlers not found.");
+
+    /// <summary>Calls the real wiring entry point, unwrapping reflection's TargetInvocationException.</summary>
+    private static bool Wire(NCLMetaTable table, int tableId)
+    {
+        try
+        {
+            return (bool)WireOne.Invoke(null, new object[] { table, tableId })!;
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
+            throw;
+        }
+    }
+
+    /// <summary>The metatable for a freshly written one-off AL table, with the stand-in
+    /// Record type registered for it so <c>FindRecordType</c> resolves.</summary>
+    private NCLMetaTable Arrange(int tableId)
+    {
+        var dir = Path.Combine(_root, tableId.ToString());
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "Table.al"), $$"""
+            table {{tableId}} "FieldTriggerGap {{tableId}}"
+            {
+                fields
+                {
+                    field({{ValidateFieldNo}}; "No."; Code[20]) { }
+                    field({{LookupFieldNo}}; "Description"; Text[50]) { }
+                }
+                keys
+                {
+                    key(PK; "No.") { Clustered = true; }
+                }
+            }
+            """);
+        RecordPatches.AddSourceDir(dir);
+
+        var skeleton = AlRunner.BcRuntime.SkeletonNCLMetadata;
+        Assert.NotNull(skeleton);
+        var table = RecordPatches.NCLMetadata_GetMetaTableById(skeleton!, tableId, false, 0);
+        Assert.NotNull(table);
+        Assert.Equal(tableId, table.TableId);
+
+        EnsureReflection.Invoke(null, null);
+
+        var cache = (ConcurrentDictionary<int, Type>)Static("_recordTypeCache").GetValue(null)!;
+        cache[tableId] = typeof(FieldTriggerGapStandInRecord);
+
+        return table;
+    }
+
+    /// <summary>Reads a handler slot straight off BC's own EventTriggerData, using FieldInfos
+    /// captured before any fault injection, so a nulled static cannot hide the answer.</summary>
+    private static object? ReadHandler(NCLMetaTable table, int fieldNo, FieldInfo etdValueBacking, FieldInfo handlerBacking)
+    {
+        if (!table.TryGetFieldByNo(fieldNo, out var metaField)) return null;
+        var etd = etdValueBacking.GetValue(metaField);
+        return etd == null ? null : handlerBacking.GetValue(etd);
+    }
+
+    // ── 1. POSITIVE CONTROL ─────────────────────────────────────────────────────────────
+    // Without it the fix could pass by refusing unconditionally.
+
+    [SkippableFact]
+    public void WithBothBackingFieldsResolved_BothHandlersAreActuallyInstalled()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // MUST run before the statics below are read: they are populated lazily, and reading
+        // them first made two of these tests pass or NRE depending on which sibling had
+        // already run.
+        EnsureReflection.Invoke(null, null);
+
+        var etdValue = (FieldInfo)Static("_fEventTriggerDataValueBacking").GetValue(null)!;
+        var validate = (FieldInfo)Static("_fValidateHandlerBacking").GetValue(null)!;
+        var lookup = (FieldInfo)Static("_fLookupHandlerBacking").GetValue(null)!;
+
+        var table = Arrange(PositiveControlTableId);
+
+        Assert.True(Wire(table, PositiveControlTableId),
+            "wiring a table whose Record type resolved must report success");
+
+        Assert.NotNull(ReadHandler(table, ValidateFieldNo, etdValue, validate));
+        Assert.NotNull(ReadHandler(table, LookupFieldNo, etdValue, lookup));
+    }
+
+    // ── 2. THE VALIDATE GAP ─────────────────────────────────────────────────────────────
+
+    [SkippableFact]
+    public void ValidateHandlerBackingUnreadable_RefusesLoudly_InsteadOfSkippingTheInstall()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // MUST run before the statics below are read: they are populated lazily, and reading
+        // them first made two of these tests pass or NRE depending on which sibling had
+        // already run.
+        EnsureReflection.Invoke(null, null);
+
+        var etdValue = (FieldInfo)Static("_fEventTriggerDataValueBacking").GetValue(null)!;
+        var validateStatic = Static("_fValidateHandlerBacking");
+        var validate = (FieldInfo)validateStatic.GetValue(null)!;
+
+        var table = Arrange(ValidateGapTableId);
+
+        bool? returned = null;
+        Exception? thrown;
+        validateStatic.SetValue(null, null);   // BC's layout moved: the read cannot be performed
+        try
+        {
+            thrown = Record.Exception(() => returned = Wire(table, ValidateGapTableId));
+        }
+        finally
+        {
+            validateStatic.SetValue(null, validate);
+        }
+
+        var installed = ReadHandler(table, ValidateFieldNo, etdValue, validate);
+        Assert.True(thrown != null,
+            $"WireFieldTriggerHandlers returned {returned} and left EventTriggerData.ValidateHandler " +
+            $"{(installed == null ? "null" : "set")} — the silent skip #3026 reports: the AL field " +
+            "OnValidate trigger is never installed, nothing is printed, and the caller is told the " +
+            "table was wired, so AL depending on that trigger runs with no trigger and still passes.");
+
+        var gap = BcShapeGapException.Find(thrown);
+        Assert.True(gap != null,
+            $"expected a BcShapeGapException, got {thrown!.GetType().Name}: {thrown.Message}");
+        Assert.Equal("NCLMetaField.EventTriggerData.ValidateHandler", gap!.Member);
+        Assert.Contains("<ValidateHandler>k__BackingField", gap.Message, StringComparison.Ordinal);
+        Assert.Contains(ValidateGapTableId.ToString(), gap.Message, StringComparison.Ordinal);
+        Assert.StartsWith("bc-shape-gap: ", gap.Message, StringComparison.Ordinal);
+
+        // A shape gap is never absorbable as an out-of-scope surface — it is a property of
+        // which BC build is on disk, not of the runner's scope.
+        Assert.Null(OutOfScopeMessage.FromException(gap));
+
+        // And the refusal is not masking a partial install.
+        Assert.Null(installed);
+    }
+
+    // ── 3. THE LOOKUP GAP — the sibling over the same state ─────────────────────────────
+
+    [SkippableFact]
+    public void LookupHandlerBackingUnreadable_RefusesLoudly_InsteadOfSkippingTheInstall()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // MUST run before the statics below are read: they are populated lazily, and reading
+        // them first made two of these tests pass or NRE depending on which sibling had
+        // already run.
+        EnsureReflection.Invoke(null, null);
+
+        var etdValue = (FieldInfo)Static("_fEventTriggerDataValueBacking").GetValue(null)!;
+        var lookupStatic = Static("_fLookupHandlerBacking");
+        var lookup = (FieldInfo)lookupStatic.GetValue(null)!;
+
+        var table = Arrange(LookupGapTableId);
+
+        bool? returned = null;
+        Exception? thrown;
+        lookupStatic.SetValue(null, null);
+        try
+        {
+            thrown = Record.Exception(() => returned = Wire(table, LookupGapTableId));
+        }
+        finally
+        {
+            lookupStatic.SetValue(null, lookup);
+        }
+
+        var installed = ReadHandler(table, LookupFieldNo, etdValue, lookup);
+        Assert.True(thrown != null,
+            $"WireFieldTriggerHandlers returned {returned} and left EventTriggerData.LookupHandler " +
+            $"{(installed == null ? "null" : "set")} — the same silent skip on the lookup half. " +
+            "RecordPatches.TryHasFieldLookupTrigger refuses over exactly this FieldInfo; the write " +
+            "path must not default where the read path declines to answer.");
+
+        var gap = BcShapeGapException.Find(thrown);
+        Assert.True(gap != null,
+            $"expected a BcShapeGapException, got {thrown!.GetType().Name}: {thrown.Message}");
+        Assert.Equal("NCLMetaField.EventTriggerData.LookupHandler", gap!.Member);
+        Assert.Contains("<LookupHandler>k__BackingField", gap.Message, StringComparison.Ordinal);
+        Assert.Contains(LookupGapTableId.ToString(), gap.Message, StringComparison.Ordinal);
+        Assert.Null(OutOfScopeMessage.FromException(gap));
+        Assert.Null(installed);
+    }
+}

--- a/AlRunner/Patches/FieldTriggerShapeGaps.cs
+++ b/AlRunner/Patches/FieldTriggerShapeGaps.cs
@@ -1,0 +1,189 @@
+// FieldTriggerShapeGaps — the field-trigger INSTALL path's refusals (#3026).
+//
+// ── THE DEFECT ───────────────────────────────────────────────────────────────────────────
+// RecordPatches.EnsureFieldTriggerReflection resolves BC's private field-trigger members
+// once and caches them as nullable statics. Every one of them is null on exactly one kind of
+// build: one whose NCLMetaField / EventTriggerData layout is not the shape this reflection
+// was written against.
+//
+// The READ path over that state already refuses. RecordPatches.TryHasFieldLookupTrigger is
+// three-valued ON PURPOSE — its own comment says a caller that refuses on `false` would be
+// telling the developer "your AL declares no OnLookup", which "would be a lie if the real
+// reason were that reflection could not find BC's backing field on a build whose shape
+// moved" — and RunnerPageInstance.RaiseSourceFieldOnLookup turns that null into a
+// BcShapeGapException (#2999).
+//
+// The WRITE path over the SAME state defaulted, and did it silently:
+//
+//     if (kvp.Value.validate != null && _fValidateHandlerBacking != null) { …install… }
+//
+// so on a build where the member moved, the AL table's OnValidate / OnLookup field trigger
+// was NEVER INSTALLED, nothing was printed, and WireFieldTriggerHandlers still returned true
+// — its contract for "this table is wired, do not retry". AL that depends on the trigger then
+// ran with no trigger at all. That is the silent default .claude/rules/loud-failures.md
+// exists to prevent, and it is worse than a refusal: the test does not fail, it PASSES having
+// skipped the trigger. Two code paths over one piece of state, one refusing and one
+// defaulting, is the invariant mismatch — not the null check itself.
+//
+// ── WHY BcShapeGapException AND NOT A SCOPE CLAIM ────────────────────────────────────────
+// It meets #2995's test exactly: the read could not be PERFORMED. It is a property of which
+// BC build is on disk, so it can be true on one matrix leg and false on another in the same
+// run — the case that must never be absorbable by an `expect-oos` manifest entry, and the
+// reason this is a type rather than a third reason anchor on RunnerOutOfScopeException. See
+// AlRunner/Infrastructure/BcShapeGapException.cs.
+//
+// ── NOT REACHABLE ON ANY SUPPORTED BUILD, WHICH IS THE ARGUMENT FOR FIXING IT NOW ────────
+// Measured on the pristine service-tier Microsoft.Dynamics.Nav.Ncl.dll for BC 27.5 and 28.1
+// (ilspycmd, NCLMetaField): EventTriggerData declares
+//
+//     internal FieldTriggerHandler<NavApplicationObjectBase> LookupHandler   { get; set; }
+//     internal FieldTriggerHandler<NavApplicationObjectBase> ValidateHandler { get; set; }
+//     internal List<FieldTriggerHandler<NavApplicationObjectBase>> OnBeforeValidateHandlers { get; set; }
+//     internal List<FieldTriggerHandler<NavApplicationObjectBase>> OnAfterValidateHandlers  { get; set; }
+//
+// — all four auto-properties, so all four compiler-generated backing fields exist, on every
+// BC version the runner supports. No refusal here is reachable today; that is what makes the
+// change free now and impossible to make cheaply after a BC update reaches it.
+//
+// ── PROPORTIONALITY: REFUSE WHERE THERE IS SOMETHING TO INSTALL ──────────────────────────
+// Every refusal below fires only once the runner KNOWS it has a handler to install for a
+// specific table and field. A table that declares no field trigger at all still wires
+// (trivially) and returns true on a moved-layout build, because nothing was skipped for it.
+// That is why several of these checks moved OUT of the method-top guards and DOWN to the
+// install sites — the top guards refused to answer for every table, which is both louder
+// than the fact warrants and, being an early `return`, silent anyway.
+//
+// The two members that could NOT be made proportional are FieldTriggerHandlerAttribute and
+// FieldTriggerType: they are what the SCAN reads, so without them the runner cannot even
+// determine whether a table declares a field trigger. There is no "nothing to install" answer
+// to give, and on such a build every AL field trigger in the bundle stops firing — the
+// maximal instance of this very defect. Those refuse for any table.
+//
+// ── WHAT STAYS A QUIET SKIP, AND WHY ─────────────────────────────────────────────────────
+//   * FindRecordType returning null — the table's own assembly is not loaded into the
+//     AppDomain YET. Pre-registration walks every suite's src/ up front, so this is the
+//     common, correct, retry-later case; WireFieldTriggerHandlers returns false and the
+//     caller deliberately does not record the table as wired. Nothing about BC's shape.
+//   * Microsoft.Dynamics.Nav.Ncl not being loaded at all — EnsureFieldTriggerReflection's
+//     own First() throws, WireFieldTriggerHandlers' catch keeps swallowing it. Runner state,
+//     not BC layout.
+//   * BuildFieldTriggerHandler declining a trigger method whose return type is neither void
+//     nor ValueTask — that is a property of the AL the runner EMITTED, not of BC's layout,
+//     and it already prints. It stays a null return.
+//
+// ── THE CATCH THAT WOULD HAVE EATEN THIS ─────────────────────────────────────────────────
+// WireFieldTriggerHandlers ends in a catch-all that prints and returns false. Left alone it
+// would have converted every refusal below into a stderr line plus the same not-installed
+// outcome — still green, still no trigger. Its filter now lets a shape gap through, which is
+// the only reason any of this reaches AL.
+//
+// See also:
+//   .claude/rules/loud-failures.md            — no silent out-of-scope failures
+//   docs/limitations.md#bc-shape-gaps         — the reader-facing write-up
+//   AlRunner/Patches/TestPageShapeGaps.cs     — the read-path sibling, and where #3026 was filed
+
+using System.Reflection;
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Patches;
+
+/// <summary>
+/// One place the field-trigger install path's <see cref="BcShapeGapException"/>s are built, so
+/// a refusal cannot drift back into a silent skip one call site at a time. See this file's
+/// header for the defect and for the per-member classification.
+/// </summary>
+internal static class FieldTriggerShapeGap
+{
+    private const string Doc = BcShapeGapException.DefaultDoc;
+
+    private static string Surface(int tableId, int fieldNo)
+        => $"AL field trigger installation (table {tableId}, field {fieldNo})";
+
+    private static string Surface(int tableId)
+        => $"AL field trigger installation (table {tableId})";
+
+    /// <summary>
+    /// The <c>ValidateHandler</c> / <c>LookupHandler</c> slot on BC's
+    /// <c>NCLMetaField.EventTriggerData</c>, or a refusal naming it. Called only once a
+    /// handler for <paramref name="fieldNo"/> is in hand, so this can never fire for a field
+    /// that declares no trigger.
+    /// </summary>
+    internal static FieldInfo RequireHandlerBacking(
+        FieldInfo? backing, string handlerProperty, int tableId, int fieldNo)
+        => backing ?? throw new BcShapeGapException(
+            Surface(tableId, fieldNo),
+            $"NCLMetaField.EventTriggerData.{handlerProperty}",
+            $"backing field <{handlerProperty}>k__BackingField not found on this BC build, so the "
+            + $"field's AL trigger cannot be installed — the trigger would never fire and the AL "
+            + "relying on it would pass having silently run without it",
+            Doc);
+
+    /// <summary>
+    /// The <c>OnBeforeValidateHandlers</c> / <c>OnAfterValidateHandlers</c> list property a
+    /// tableextension's <c>modify(field)</c> triggers are installed through. Called only once
+    /// at least one such handler has been built.
+    /// </summary>
+    internal static PropertyInfo RequireHandlerListProperty(
+        PropertyInfo? property, string propertyName, int tableId, int fieldNo)
+        => property ?? throw new BcShapeGapException(
+            Surface(tableId, fieldNo),
+            $"NCLMetaField.EventTriggerData.{propertyName}",
+            $"property not found on this BC build, so the tableextension's AL {propertyName} field "
+            + "triggers cannot be installed — they would never fire",
+            Doc);
+
+    /// <summary>
+    /// The closed <c>List&lt;FieldTriggerHandler&lt;NavApplicationObjectBase&gt;&gt;</c> the
+    /// before/after handler lists are boxed into.
+    /// </summary>
+    internal static System.Type RequireHandlerListType(System.Type? listType, int tableId, int fieldNo)
+        => listType ?? throw new BcShapeGapException(
+            Surface(tableId, fieldNo),
+            "List<FieldTriggerHandler<NavApplicationObjectBase>>",
+            "the handler-list type could not be closed on this BC build (FieldTriggerHandler`1 or "
+            + "NavApplicationObjectBase is absent), so the tableextension's before/after field "
+            + "triggers cannot be installed",
+            Doc);
+
+    /// <summary>BC's <c>NCLMetaField.EventTriggerData</c> nested type.</summary>
+    internal static System.Type RequireEventTriggerDataType(System.Type? type, int tableId)
+        => type ?? throw new BcShapeGapException(
+            Surface(tableId),
+            "NCLMetaField.EventTriggerData",
+            "nested type not found on this BC build, so no AL field trigger can be installed on "
+            + "this table's metafields",
+            Doc);
+
+    /// <summary>BC's <c>NCLMetaField.&lt;EventTriggerDataValue&gt;k__BackingField</c>.</summary>
+    internal static FieldInfo RequireEventTriggerDataValueBacking(FieldInfo? backing, int tableId)
+        => backing ?? throw new BcShapeGapException(
+            Surface(tableId),
+            "NCLMetaField.EventTriggerDataValue",
+            "backing field <EventTriggerDataValue>k__BackingField not found on this BC build, so "
+            + "built handlers cannot be attached to this table's metafields",
+            Doc);
+
+    /// <summary>
+    /// A type the field-trigger SCAN needs. Deliberately not proportional — without these the
+    /// runner cannot tell whether a table declares a field trigger at all, and on such a build
+    /// every AL field trigger in the bundle would stop firing silently.
+    /// </summary>
+    internal static System.Type RequireScanType(System.Type? type, string typeName, int tableId)
+        => type ?? throw new BcShapeGapException(
+            Surface(tableId),
+            $"Microsoft.Dynamics.Nav.Runtime.{typeName}",
+            "type not found on this BC build, so the runner cannot determine which AL methods are "
+            + "field triggers — every field trigger in the bundle would silently never fire",
+            Doc);
+
+    /// <summary>
+    /// A type or constructor <c>BuildFieldTriggerHandler</c> needs to wrap one already-found AL
+    /// trigger method. Named by the method being wrapped, which is what a reader needs.
+    /// </summary>
+    internal static BcShapeGapException HandlerConstruction(string member, MethodInfo target, string detail)
+        => new(
+            $"AL field trigger {target.DeclaringType?.Name}.{target.Name}",
+            member,
+            detail,
+            Doc);
+}

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -1355,10 +1355,17 @@ public static partial class RecordPatches
         try
         {
             EnsureFieldTriggerReflection();
-            if (_tFieldTriggerHandlerAttr == null || _tFieldTriggerType == null
-                || _tFieldTriggerHandler1 == null || _tEventTriggerData == null
-                || _fEventTriggerDataValueBacking == null)
-                return false;
+            // The SCAN's own two types. #3026: these cannot be made proportional — without
+            // them the runner cannot determine whether this table declares a field trigger at
+            // all, so there is no "nothing to install" answer to give, and on a build missing
+            // them EVERY AL field trigger in the bundle would silently never fire. The other
+            // three members this used to demand up front are required at the install sites
+            // below instead, so a table with no triggers is not refused for a member it never
+            // needed. See FieldTriggerShapeGaps.cs.
+            var attrType = FieldTriggerShapeGap.RequireScanType(
+                _tFieldTriggerHandlerAttr, "FieldTriggerHandlerAttribute", tableId);
+            var triggerTypeEnum = FieldTriggerShapeGap.RequireScanType(
+                _tFieldTriggerType, "FieldTriggerType", tableId);
 
             var recordType = FindRecordType(tableId);
             if (recordType == null) return false;
@@ -1369,13 +1376,13 @@ public static partial class RecordPatches
                                                      | BindingFlags.Instance | BindingFlags.Static
                                                      | BindingFlags.DeclaredOnly))
             {
-                var attrs = mi.GetCustomAttributes(_tFieldTriggerHandlerAttr, inherit: false);
+                var attrs = mi.GetCustomAttributes(attrType, inherit: false);
                 if (attrs.Length == 0) continue;
                 foreach (var a in attrs)
                 {
-                    var fieldNo = (int)_tFieldTriggerHandlerAttr.GetProperty("FieldNo")!.GetValue(a)!;
-                    var ttObj = _tFieldTriggerHandlerAttr.GetProperty("TriggerType")!.GetValue(a)!;
-                    var ttName = Enum.GetName(_tFieldTriggerType, ttObj);
+                    var fieldNo = (int)attrType.GetProperty("FieldNo")!.GetValue(a)!;
+                    var ttObj = attrType.GetProperty("TriggerType")!.GetValue(a)!;
+                    var ttName = Enum.GetName(triggerTypeEnum, ttObj);
                     byField.TryGetValue(fieldNo, out var pair);
                     if (ttName == "OnValidate") pair.validate = mi;
                     else if (ttName == "OnLookup") pair.lookup = mi;
@@ -1405,6 +1412,13 @@ public static partial class RecordPatches
 
             // For each field with handler(s): build EventTriggerData, set ValidateHandler/LookupHandler,
             // poke onto NCLMetaField.EventTriggerDataValue backing field.
+            //
+            // #3026: required HERE rather than in the method-top guard, because reaching this
+            // line is what establishes that there IS something to install.
+            var etdType = FieldTriggerShapeGap.RequireEventTriggerDataType(_tEventTriggerData, tableId);
+            var etdValueBacking = FieldTriggerShapeGap.RequireEventTriggerDataValueBacking(
+                _fEventTriggerDataValueBacking, tableId);
+
             foreach (var kvp in byField)
             {
                 var fieldNo = kvp.Key;
@@ -1413,28 +1427,42 @@ public static partial class RecordPatches
                 catch { continue; }
                 if (metaField == null) continue;
 
-                var existing = _fEventTriggerDataValueBacking.GetValue(metaField);
-                var etd = existing ?? Activator.CreateInstance(_tEventTriggerData)!;
+                var existing = etdValueBacking.GetValue(metaField);
+                var etd = existing ?? Activator.CreateInstance(etdType)!;
 
-                if (kvp.Value.validate != null && _fValidateHandlerBacking != null)
+                if (kvp.Value.validate != null)
                 {
+                    // #3026: `&& _fValidateHandlerBacking != null` here USED to skip the
+                    // install silently — the AL field OnValidate trigger was never installed,
+                    // nothing was printed, and this method still returned true.
+                    var backing = FieldTriggerShapeGap.RequireHandlerBacking(
+                        _fValidateHandlerBacking, "ValidateHandler", tableId, fieldNo);
                     var handler = BuildFieldTriggerHandler(kvp.Value.validate, recordType);
                     if (handler != null)
-                        AlRunner.Infrastructure.FieldPoke.SetInstance(_fValidateHandlerBacking, etd, handler);
+                        AlRunner.Infrastructure.FieldPoke.SetInstance(backing, etd, handler);
                 }
-                if (kvp.Value.lookup != null && _fLookupHandlerBacking != null)
+                if (kvp.Value.lookup != null)
                 {
+                    var backing = FieldTriggerShapeGap.RequireHandlerBacking(
+                        _fLookupHandlerBacking, "LookupHandler", tableId, fieldNo);
                     var handler = BuildFieldTriggerHandler(kvp.Value.lookup, recordType);
                     if (handler != null)
-                        AlRunner.Infrastructure.FieldPoke.SetInstance(_fLookupHandlerBacking, etd, handler);
+                        AlRunner.Infrastructure.FieldPoke.SetInstance(backing, etd, handler);
                 }
-                AlRunner.Infrastructure.FieldPoke.SetInstance(_fEventTriggerDataValueBacking, metaField, etd);
+                AlRunner.Infrastructure.FieldPoke.SetInstance(etdValueBacking, metaField, etd);
             }
 
             WireExtensionValidateHandlers(built, tableId);
             return true;
         }
-        catch (Exception ex)
+        // #3026: the filter is load-bearing. Without it this catch converts every refusal
+        // raised above into a stderr line plus the same not-installed outcome the refusals
+        // exist to stop — still green, still no trigger. A BcShapeGapException tears through
+        // both of AL's trapping seams by contract (see BcShapeGapException.cs), and it cannot
+        // do that if this frame swallows it first. Everything else — notably Ncl not being
+        // loaded yet, which makes EnsureFieldTriggerReflection's First() throw — keeps its
+        // old behaviour.
+        catch (Exception ex) when (AlRunner.Infrastructure.BcShapeGapException.Find(ex) is null)
         {
             Console.Error.WriteLine($"[RecordPatches] WireFieldTriggerHandlers({tableId}) failed: {ex.GetType().Name}: {ex.Message}");
             return false;
@@ -1459,10 +1487,13 @@ public static partial class RecordPatches
     /// </summary>
     private static void WireExtensionValidateHandlers(NCLMetaTable built, int tableId)
     {
-        if (_pOnBeforeValidateHandlers == null || _pOnAfterValidateHandlers == null
-            || _tFieldTriggerHandlerListClosed == null || _fEventTriggerDataValueBacking == null
-            || _tEventTriggerData == null)
-            return;
+        // #3026: the five-member guard that used to stand here returned silently for EVERY
+        // table on a moved-layout build, including the overwhelming majority that have no
+        // tableextension field trigger to install at all. Each member is now demanded at the
+        // point of use, once the runner knows it has a handler in hand — see
+        // FieldTriggerShapeGaps.cs. Only the callers' own precondition survives here:
+        // WireFieldTriggerHandlers is the sole caller and has already refused if the scan
+        // types are absent.
         if (!_parsedTables.TryGetValue(tableId, out var parsed)) return;
         if (!_extensionIdsByBaseTable.TryGetValue(parsed.TableName.ToLowerInvariant(), out var extIds)
             || extIds.Count == 0)
@@ -1515,6 +1546,12 @@ public static partial class RecordPatches
         fieldsToWire.UnionWith(afterByField.Keys);
         fieldsToWire.UnionWith(validateByField.Keys);
         fieldsToWire.UnionWith(lookupByField.Keys);
+        if (fieldsToWire.Count == 0) return;   // nothing to install: nothing to refuse over
+
+        var etdType = FieldTriggerShapeGap.RequireEventTriggerDataType(_tEventTriggerData, tableId);
+        var etdValueBacking = FieldTriggerShapeGap.RequireEventTriggerDataValueBacking(
+            _fEventTriggerDataValueBacking, tableId);
+
         foreach (var fieldNo in fieldsToWire)
         {
             NCLMetaField? metaField;
@@ -1522,25 +1559,40 @@ public static partial class RecordPatches
             catch { continue; }
             if (metaField == null) continue;
 
-            var etd = _fEventTriggerDataValueBacking.GetValue(metaField)
-                      ?? Activator.CreateInstance(_tEventTriggerData)!;
+            var etd = etdValueBacking.GetValue(metaField)
+                      ?? Activator.CreateInstance(etdType)!;
             if (beforeByField.TryGetValue(fieldNo, out var before))
-                _pOnBeforeValidateHandlers.SetValue(etd, ToHandlerList(before));
+                FieldTriggerShapeGap.RequireHandlerListProperty(
+                        _pOnBeforeValidateHandlers, "OnBeforeValidateHandlers", tableId, fieldNo)
+                    .SetValue(etd, ToHandlerList(before, tableId, fieldNo));
             if (afterByField.TryGetValue(fieldNo, out var after))
-                _pOnAfterValidateHandlers.SetValue(etd, ToHandlerList(after));
-            if (validateByField.TryGetValue(fieldNo, out var extValidate) && _fValidateHandlerBacking != null)
-                AlRunner.Infrastructure.FieldPoke.SetInstance(_fValidateHandlerBacking, etd, extValidate);
-            if (lookupByField.TryGetValue(fieldNo, out var extLookup) && _fLookupHandlerBacking != null)
-                AlRunner.Infrastructure.FieldPoke.SetInstance(_fLookupHandlerBacking, etd, extLookup);
-            AlRunner.Infrastructure.FieldPoke.SetInstance(_fEventTriggerDataValueBacking, metaField, etd);
+                FieldTriggerShapeGap.RequireHandlerListProperty(
+                        _pOnAfterValidateHandlers, "OnAfterValidateHandlers", tableId, fieldNo)
+                    .SetValue(etd, ToHandlerList(after, tableId, fieldNo));
+            // #3026: `&& _fValidateHandlerBacking != null` here silently dropped the OnValidate
+            // / OnLookup trigger of a field a TABLEEXTENSION adds (issue #1835's shape), with
+            // the same "returned normally, installed nothing" outcome as the base-table path.
+            if (validateByField.TryGetValue(fieldNo, out var extValidate))
+                AlRunner.Infrastructure.FieldPoke.SetInstance(
+                    FieldTriggerShapeGap.RequireHandlerBacking(
+                        _fValidateHandlerBacking, "ValidateHandler", tableId, fieldNo),
+                    etd, extValidate);
+            if (lookupByField.TryGetValue(fieldNo, out var extLookup))
+                AlRunner.Infrastructure.FieldPoke.SetInstance(
+                    FieldTriggerShapeGap.RequireHandlerBacking(
+                        _fLookupHandlerBacking, "LookupHandler", tableId, fieldNo),
+                    etd, extLookup);
+            AlRunner.Infrastructure.FieldPoke.SetInstance(etdValueBacking, metaField, etd);
         }
     }
 
     // Box a List<object> of FieldTriggerHandler<NavApplicationObjectBase> into the strongly
     // typed List<FieldTriggerHandler<NavApplicationObjectBase>> the EventTriggerData expects.
-    private static object ToHandlerList(List<object> handlers)
+    private static object ToHandlerList(List<object> handlers, int tableId, int fieldNo)
     {
-        var list = (System.Collections.IList)Activator.CreateInstance(_tFieldTriggerHandlerListClosed!)!;
+        var listType = FieldTriggerShapeGap.RequireHandlerListType(
+            _tFieldTriggerHandlerListClosed, tableId, fieldNo);
+        var list = (System.Collections.IList)Activator.CreateInstance(listType)!;
         foreach (var h in handlers) list.Add(h);
         return list;
     }
@@ -1561,9 +1613,21 @@ public static partial class RecordPatches
                 .First(a => a.GetName().Name == "Microsoft.Dynamics.Nav.Ncl");
             _tNavApplicationObjectBase = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.NavApplicationObjectBase");
         }
-        if (_tNavApplicationObjectBase == null) return null;
+        // #3026: both of these used to return null, which every install site then skipped
+        // silently — the trigger was not installed and the caller was told the table was
+        // wired. Neither is reachable on a supported build; both mean BC's own layout moved.
+        if (_tNavApplicationObjectBase == null)
+            throw FieldTriggerShapeGap.HandlerConstruction(
+                "Microsoft.Dynamics.Nav.Runtime.NavApplicationObjectBase", target,
+                "type not found on this BC build, so the AL trigger method cannot be wrapped in a "
+                + "FieldTriggerHandler and the trigger would never fire");
+        if (_tFieldTriggerHandler1 == null)
+            throw FieldTriggerShapeGap.HandlerConstruction(
+                "Microsoft.Dynamics.Nav.Runtime.FieldTriggerHandler`1", target,
+                "type not found on this BC build, so the AL trigger method cannot be wrapped and "
+                + "the trigger would never fire");
 
-        var ftHandler = _tFieldTriggerHandler1!.MakeGenericType(_tNavApplicationObjectBase);
+        var ftHandler = _tFieldTriggerHandler1.MakeGenericType(_tNavApplicationObjectBase);
         var ret = target.ReturnType;
 
         // We can't Delegate.CreateDelegate directly for an Action<NavApplicationObjectBase>
@@ -1578,8 +1642,13 @@ public static partial class RecordPatches
             // del is Func<TConcrete, ValueTask>; we need Func<NavApplicationObjectBase, ValueTask>.
             // Build via a small wrapper closure.
             var wrapper = BuildAsyncWrapper(del, _tNavApplicationObjectBase, recordType);
-            var ctor = ftHandler.GetConstructor(new[] { typeof(Type), funcT });
-            return ctor?.Invoke(new object[] { recordType, wrapper });
+            var ctor = ftHandler.GetConstructor(new[] { typeof(Type), funcT })
+                ?? throw FieldTriggerShapeGap.HandlerConstruction(
+                    "FieldTriggerHandler<NavApplicationObjectBase>..ctor(Type, Func<T, ValueTask>)",
+                    target,
+                    "constructor not found on this BC build, so the async AL trigger method cannot "
+                    + "be wrapped and the trigger would never fire");
+            return ctor.Invoke(new object[] { recordType, wrapper });
         }
         else if (ret == typeof(void))
         {
@@ -1588,8 +1657,12 @@ public static partial class RecordPatches
                 BindingFlags.NonPublic | BindingFlags.Static)!.MakeGenericMethod(recordType);
             var del = (Delegate)helper.Invoke(null, new object?[] { target })!;
             var wrapper = BuildSyncWrapper(del, _tNavApplicationObjectBase, recordType);
-            var ctor = ftHandler.GetConstructor(new[] { typeof(Type), actT });
-            return ctor?.Invoke(new object[] { recordType, wrapper });
+            var ctor = ftHandler.GetConstructor(new[] { typeof(Type), actT })
+                ?? throw FieldTriggerShapeGap.HandlerConstruction(
+                    "FieldTriggerHandler<NavApplicationObjectBase>..ctor(Type, Action<T>)", target,
+                    "constructor not found on this BC build, so the AL trigger method cannot be "
+                    + "wrapped and the trigger would never fire");
+            return ctor.Invoke(new object[] { recordType, wrapper });
         }
         Console.Error.WriteLine($"[RecordPatches] WireFieldTriggerHandlers: skip {target.DeclaringType?.Name}.{target.Name} — unsupported return type {ret.Name}");
         return null;

--- a/AlRunner/Patches/TestPageShapeGaps.cs
+++ b/AlRunner/Patches/TestPageShapeGaps.cs
@@ -146,16 +146,17 @@
 //         to decide and is UNTOUCHED here. The test for this file allows either outcome for it
 //         and pins the two lookups exactly.
 //
-// ── A SIBLING DEFECT FOUND AND NOT FIXED HERE ────────────────────────────────────────────
+// ── A SIBLING DEFECT FOUND HERE, FIXED IN #3026 ──────────────────────────────────────────
 //   The (2b) site above refuses loudly when _fLookupHandlerBacking / _fValidateHandlerBacking
-//   could not be resolved. The WRITE path over the same two fields does the opposite:
-//   RecordPatches.NclMetaTableBuilder.cs guards every handler install with
+//   could not be resolved. The WRITE path over the same two fields used to do the opposite:
+//   RecordPatches.NclMetaTableBuilder.cs guarded every handler install with
 //   `&& _fValidateHandlerBacking != null` (and the lookup equivalent), so on a BC build whose
-//   layout moved the field trigger is SILENTLY NEVER INSTALLED and the AL that depends on it
-//   runs with no trigger at all — and WireFieldTriggerHandlers still returns true. Two code
+//   layout moved the field trigger was SILENTLY NEVER INSTALLED and the AL that depends on it
+//   ran with no trigger at all — and WireFieldTriggerHandlers still returned true. Two code
 //   paths over one piece of state, one refusing and one defaulting. Filed as #3026 rather than
-//   folded in, because it changes trigger INSTALLATION rather than refusal wording and needs
-//   its own RED → GREEN. Not reachable on 27.0–28.4, where both members resolve.
+//   folded in, because it changes trigger INSTALLATION rather than refusal wording and needed
+//   its own RED → GREEN; that fix is now in AlRunner/Patches/FieldTriggerShapeGaps.cs. Still
+//   not reachable on 27.0–28.4, where every member resolves.
 //
 // ── WHY THE DOC LINK MOVED ───────────────────────────────────────────────────────────────
 //   docs/limitations.md#testpage-shape-gaps, not docs/scope.md. scope.md documents permanent

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -925,6 +925,23 @@ reached only when BC's own metadata is not the shape the runner reads:
   fields. A read that *succeeds* and says the field declares no trigger is a different outcome
   and stays a permanent refusal, because that lookup would come from a `TableRelation`.
 
+The **write** side of those same two backing fields refuses too
+([#3026](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3026)). Installing a
+table's AL `OnValidate` / `OnLookup` field trigger pokes
+`NCLMetaField.EventTriggerData.ValidateHandler` / `.LookupHandler`; if either cannot be
+resolved, the runner now names it and stops, instead of skipping the install and reporting the
+table as wired. The skip was the worse half of the pair: nothing was printed, the trigger never
+fired, and AL that depended on it *passed*. The same applies to the tableextension
+`OnBeforeValidate` / `OnAfterValidate` handler lists and to the types
+`BuildFieldTriggerHandler` wraps a trigger method in.
+
+The refusal is proportional — it fires only for a table and field the runner has a handler in
+hand for. A table that declares no field trigger still wires and reports success on such a
+build, because nothing was skipped for it. The two exceptions are
+`FieldTriggerHandlerAttribute` and `FieldTriggerType`, which are what the scan itself reads: on
+a build missing either, the runner cannot tell whether *any* table declares a trigger, so it
+refuses for every table rather than let the whole bundle's field triggers go quiet.
+
 ## Known gaps — in scope but not yet implemented
 
 These are not architectural limits. They can be fixed; report them at


### PR DESCRIPTION
Closes #3026

## Can the backing field legitimately be absent? No — so throwing is right.

Measured, not inferred. `ilspycmd` on the pristine service-tier
`Microsoft.Dynamics.Nav.Ncl.dll` for **BC 27.5 and 28.1**, type `NCLMetaField`:

```
public class EventTriggerData
    internal FieldTriggerHandler<NavApplicationObjectBase> LookupHandler   { get; set; }
    internal FieldTriggerHandler<NavApplicationObjectBase> ValidateHandler { get; set; }
    internal List<FieldTriggerHandler<NavApplicationObjectBase>> OnBeforeValidateHandlers { get; set; }
    internal List<FieldTriggerHandler<NavApplicationObjectBase>> OnAfterValidateHandlers  { get; set; }
```

All four are auto-properties, so all four compiler-generated `k__BackingField`s exist, and
they are declared directly on `EventTriggerData` (no base-class lookup problem). There is no
supported configuration in which the read fails. A null there can only mean BC's own layout
moved — which is `BcShapeGapException`'s exact test ("the read could not be *performed*"), and
is a property of which BC build is on disk, so it must not be absorbable by an `expect-oos`
entry. The issue's framing holds.

## What the RED proved about the silent half

The negative tests capture `WireFieldTriggerHandlers`' return value **and** the handler slot's
contents and put both into the assertion message, so the RED run reports the silence itself
rather than a bare "expected an exception". Verbatim, on `origin/main` before the fix:

```
WireFieldTriggerHandlers returned True and left EventTriggerData.ValidateHandler null
  — the silent skip #3026 reports: the AL field OnValidate trigger is never installed,
    nothing is printed, and the caller is told the table was wired, so AL depending on
    that trigger runs with no trigger and still passes.

WireFieldTriggerHandlers returned True and left EventTriggerData.LookupHandler null
  — the same silent skip on the lookup half.
```

`Failed: 2, Passed: 1` — the third is the positive control, which **passed before the fix as
well as after**. That is what stops the fix from passing by refusing unconditionally: with the
statics untouched, the same call must still install both handlers and return true.

After the fix: `Passed: 3, Failed: 0`, and the negatives assert the specific type
(`BcShapeGapException`, found through the chain), the exact
`Member` (`NCLMetaField.EventTriggerData.ValidateHandler` / `.LookupHandler`), the
`<…>k__BackingField` spelling and the table id in the message, that
`OutOfScopeMessage.FromException` does **not** recover it as an out-of-scope signal, and that
the slot really is still empty (the refusal is not masking a partial install).

The fault is injected by nulling the cached `FieldInfo` for the duration of one call and
restoring it in a `finally` — the state a moved-layout build would leave
`EnsureFieldTriggerReflection` in. Nothing in production was made settable for the test.

Run locally with the CI recipe (warm `ncl-cecil`, pre-copy the rewritten Ncl into the test bin,
`--settings engine.runsettings`), so these execute rather than skip. `BcEngineReadinessGuardTests`
already fails CI if the engine is not ready there.

## Fixing the shape, not just the reported line

**1. Does the same wrong pattern appear at another call site?** Yes — four, not two. The issue
names the two in `WireFieldTriggerHandlers`; `WireExtensionValidateHandlers` has the identical
`&& _fValidateHandlerBacking != null` / `&& _fLookupHandlerBacking != null` pair for the
`OnValidate`/`OnLookup` triggers of a field a **tableextension adds** (issue #1835's shape).
All four now refuse.

**2. Does a sibling function make the same assumption?** Yes — `BuildFieldTriggerHandler`
returns `null` when `NavApplicationObjectBase` is absent, and `ctor?.Invoke(...)` returns null
when `FieldTriggerHandler<T>`'s `(Type, Action<T>)` / `(Type, Func<T, ValueTask>)` constructor
is absent. Every install site then skips a `null` handler silently — the same outcome by a
different route, and both are BC-layout facts. Both now throw. The third `null` return there
(a trigger method whose return type is neither `void` nor `ValueTask`) stays a `null`: that is
a property of the AL the runner **emitted**, not of BC's layout, and it already prints.

**3. Do two code paths writing the same state maintain the same invariant?** They did not, and
that is the issue. Beyond the reported pair, both methods' *method-top* guards had the same
defect in a coarser form — an early `return` covering `EventTriggerData`,
`<EventTriggerDataValue>k__BackingField`, `OnBefore/OnAfterValidateHandlers` and the closed
handler-list type, firing for **every** table on a moved-layout build and saying nothing. Those
members are now demanded at the point of use, so the refusal is **proportional**: it fires only
once the runner has a handler in hand for a specific table and field. A table with no field
trigger still wires and returns true on such a build, because nothing was skipped for it.

Two members could not be made proportional and refuse for any table:
`FieldTriggerHandlerAttribute` and `FieldTriggerType` are what the *scan* reads, so without
them the runner cannot determine whether any table declares a trigger — and on such a build
every AL field trigger in the bundle goes quiet, the maximal instance of this defect.

**The catch that would have eaten all of it.** `WireFieldTriggerHandlers` ends in a catch-all
that prints and returns `false`. Left alone it would have converted every refusal above into a
stderr line plus the same not-installed outcome — still green, still no trigger. Its filter is
now `when (BcShapeGapException.Find(ex) is null)`. Everything else keeps its old behaviour,
notably Ncl not being loaded yet (which makes `EnsureFieldTriggerReflection`'s `First()` throw)
and `FindRecordType` returning null, which is the ordinary retry-later case and stays a quiet
`false`.

None of the three `WireFieldTriggerHandlersForTable` call sites
(`NavRecordRefPatches`, `RecordPatches.CreateObjectInstance`, `RecordPatches.cs`) wraps the call
in a catch, so the refusal reaches AL.

## The corpus question

**Asked, and the answer is no upstream test is owed.**

The refusal itself is not expressible in AL: no AL statement can move a private BC field, and
on every supported build the refusal is unreachable by construction. The subject is the
runner's own refusal contract — the classification
`.claude/rules/bc-behavior-tests-go-upstream.md` gives to runner-specific claims, and the same
shape as `BcShapeGapConventionTests` and `RunnerShapeGapClaimTests`.

The one genuinely BC-behavioural claim nearby — that a table's field `OnValidate` / `OnLookup`
trigger, and a tableextension's `OnBeforeValidate` / `OnAfterValidate`, actually fire — is
**already adjudicated upstream on a real service tier**: `_fixtures/tables/ALTTriggered.al`,
`ALTTriggeredOrder.TableExt.al`, `ALTUniversalValidated.TableExt.al` and the `handlers/`
`TestPageOnValidate*` suites cover it. Nothing new to add, and no corpus PR to open — so
nothing here is waiting on the BC 27.0/27.3/27.5 zero-test problem (corpus #180).

## Deliberately left out

- **`docs/expectations.md` / `tests/expectations/`** — nothing to declare. No refusal added
  here is reachable on 27.0–28.4, so no test's classification changes.
- **`tests/expectations/count-baseline/test-count-baseline.json`** — untouched (#3004).
- **Files touched by PR #3034** (the permission-surface `BcShapeGapException` sweep) — no
  overlap: that PR works `BcAppSymbolCachePermissionSet` / `PermissionMetadataPopulation`
  surfaces; this one touches `RecordPatches.NclMetaTableBuilder.cs`, a new
  `AlRunner/Patches/FieldTriggerShapeGaps.cs`, and a comment block in `TestPageShapeGaps.cs`.
- **`CHANGELOG.md`** — never edited.

---
*Implemented by an automated agent (`stma-auto-1`) acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
