### PR TITLE
fix(cache): key the content-hash memo on the file, not the path, so hard-linked packages are read once

### DIFF
--- a/AlRunner.Tests/FileIdentityTests.cs
+++ b/AlRunner.Tests/FileIdentityTests.cs
@@ -1,0 +1,162 @@
+// FileIdentityTests — issue #3036. Pins the identity key itself, independently of the memo
+// that consumes it (RunnerFingerprintFileIdentityMemoTests).
+//
+// The key is read out of a hand-declared `struct statx` layout, so the first thing worth
+// proving is that the offsets are actually right and not accidentally plausible: the
+// device, inode and size this type reports are cross-checked against coreutils `stat`,
+// which reads the same kernel structure through libc. An offset that were wrong by a field
+// would still produce a stable-looking key, and every dedup test above would still pass.
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class FileIdentityTests : IDisposable
+{
+    private readonly string _root;
+
+    public FileIdentityTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-tests", "fileid-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private static string? Run(string exe, params string[] args)
+    {
+        try
+        {
+            var psi = new System.Diagnostics.ProcessStartInfo(exe)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            foreach (var a in args) psi.ArgumentList.Add(a);
+            using var p = System.Diagnostics.Process.Start(psi);
+            if (p == null) return null;
+            var stdout = p.StandardOutput.ReadToEnd();
+            p.WaitForExit(30_000);
+            return p.ExitCode == 0 ? stdout.Trim() : null;
+        }
+        catch { return null; }
+    }
+
+    private string Write(string name, byte[] bytes)
+    {
+        var p = Path.Combine(_root, name);
+        File.WriteAllBytes(p, bytes);
+        return p;
+    }
+
+    [Fact]
+    public void Key_ReportsTheSameDeviceInodeAndSizeAsCoreutilsStat()
+    {
+        if (!OperatingSystem.IsLinux()) return;
+        var path = Write("probe.bin", new byte[1234]);
+
+        // Deliberately NOT a soft skip. A statx that stopped answering on Linux is the fix
+        // in #3036 silently ceasing to apply, which is exactly the thing a test must shout
+        // about rather than pass over.
+        var key = FileIdentity.TryGetStableKey(path);
+        Assert.NotNull(key);
+
+        // %Hd major, %Ld minor, %i inode, %s size — the same four fields, via libc.
+        var expected = Run("stat", "-c", "%Hd %Ld %i %s", path);
+        Assert.NotNull(expected); // coreutils stat is the oracle; without it this proves nothing
+        var f = expected!.Split(' ');
+        Assert.Equal(4, f.Length);
+        Assert.Equal($"ino|{f[0]}:{f[1]}:{f[2]}|{f[3]}", key![..key.LastIndexOf('|')]);
+    }
+
+    [Fact]
+    public void Key_IsEqualForHardLinksAndDifferentForTwoFiles()
+    {
+        if (!OperatingSystem.IsLinux()) return;
+        var a = Write("a.bin", new byte[] { 1, 2, 3 });
+        var b = Path.Combine(_root, "b.bin");
+        Assert.NotNull(Run("ln", a, b)); // no hard link, nothing to prove — fail, do not skip
+        var c = Write("c.bin", new byte[] { 1, 2, 3 }); // same bytes, its own inode
+
+        var ka = FileIdentity.TryGetStableKey(a);
+        var kb = FileIdentity.TryGetStableKey(b);
+        var kc = FileIdentity.TryGetStableKey(c);
+        Assert.NotNull(ka);
+
+        Assert.Equal(ka, kb);
+        Assert.NotEqual(ka, kc);
+    }
+
+    [Fact]
+    public void Key_CarriesTheDevice_SoInodesFromTwoFilesystemsCannotCollide()
+    {
+        if (!OperatingSystem.IsLinux()) return;
+        // Inode numbers are unique only within a device, and a package cache can span two
+        // mounts. Prove the device is actually IN the key by finding a second filesystem
+        // and showing the device component differs — not by inspecting the source.
+        var here = Write("here.bin", new byte[] { 9 });
+        string? other = null;
+        foreach (var dir in new[] { "/dev/shm", "/run/user/" + Environment.GetEnvironmentVariable("UID"), "/run/shm" })
+        {
+            try
+            {
+                if (!Directory.Exists(dir)) continue;
+                var cand = Path.Combine(dir, "al-runner-fileid-" + Guid.NewGuid().ToString("N"));
+                File.WriteAllBytes(cand, new byte[] { 9 });
+                other = cand;
+                break;
+            }
+            catch { }
+        }
+        // /dev/shm is a tmpfs on every Linux this runs on, including GitHub's runners, so
+        // "no second filesystem" is a broken environment rather than a reason to pass.
+        Assert.NotNull(other);
+
+        try
+        {
+            var k1 = FileIdentity.TryGetStableKey(here);
+            var k2 = FileIdentity.TryGetStableKey(other);
+            Assert.NotNull(k1);
+            Assert.NotNull(k2);
+            var dev1 = string.Join(':', k1!.Split('|')[1].Split(':')[..2]);
+            var dev2 = string.Join(':', k2!.Split('|')[1].Split(':')[..2]);
+            Assert.NotEqual(dev1, dev2);
+            // And the two files really are distinct despite identical content and length —
+            // the device is what makes that survivable if their inode numbers ever agree.
+            Assert.NotEqual(k1, k2);
+        }
+        finally { try { File.Delete(other!); } catch { } }
+    }
+
+    [Fact]
+    public void Key_ChangesWhenTheFileIsRewritten_SoAReusedInodeCannotServeStaleContent()
+    {
+        if (!OperatingSystem.IsLinux()) return;
+        var p = Write("rewritten.bin", new byte[] { 1, 2, 3 });
+        var before = FileIdentity.TryGetStableKey(p);
+        Assert.NotNull(before);
+
+        File.WriteAllBytes(p, new byte[] { 1, 2, 3, 4, 5 }); // same inode, new size
+        var after = FileIdentity.TryGetStableKey(p);
+        Assert.NotEqual(before, after);
+    }
+
+    [Fact]
+    public void Key_IsNull_ForAPathThatDoesNotExist()
+    {
+        Assert.Null(FileIdentity.TryGetStableKey(Path.Combine(_root, "absent.bin")));
+    }
+
+    [Fact]
+    public void Key_IsNull_OnAPlatformWithoutStatx()
+    {
+        // Not a claim about Linux — a claim about the contract every caller relies on:
+        // "cannot answer" is null, never a fabricated key. On a non-Linux box this is the
+        // real assertion; on Linux the missing-file case above covers the same contract.
+        if (OperatingSystem.IsLinux()) return;
+        Assert.Null(FileIdentity.TryGetStableKey(Write("x.bin", new byte[] { 1 })));
+    }
+}

--- a/AlRunner.Tests/FileIdentityTests.cs
+++ b/AlRunner.Tests/FileIdentityTests.cs
@@ -17,7 +17,8 @@ public sealed class FileIdentityTests : IDisposable
 
     public FileIdentityTests()
     {
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-tests", "fileid-" + Guid.NewGuid().ToString("N"));
+        // TestScratch, not a hand-built temp path — see ScratchDirOwnershipGuardTests.
+        _root = TestScratch.Dir("al-runner-fileid");
         Directory.CreateDirectory(_root);
     }
 
@@ -99,7 +100,7 @@ public sealed class FileIdentityTests : IDisposable
         // and showing the device component differs — not by inspecting the source.
         var here = Write("here.bin", new byte[] { 9 });
         string? other = null;
-        foreach (var dir in new[] { "/dev/shm", "/run/user/" + Environment.GetEnvironmentVariable("UID"), "/run/shm" })
+        foreach (var dir in new[] { "/dev/shm", "/run/shm" })
         {
             try
             {

--- a/AlRunner.Tests/RunnerFingerprintFileIdentityMemoTests.cs
+++ b/AlRunner.Tests/RunnerFingerprintFileIdentityMemoTests.cs
@@ -20,6 +20,14 @@ using Xunit;
 
 namespace AlRunner.Tests;
 
+// Clears process-wide static state (the shared hash memo) — joins the serial collection that
+// every other class touching it already belongs to. It also reads the process-global
+// computation counter as a delta and asserts an EXACT value, so a class hashing a file on
+// another thread (ManifestDependencyEdgeScanTests, BcCompilerSharedReferenceMemoTests,
+// CacheKeyDependencyContentIdentityTests) turns "2" into "3": reproduced at 3 failures in 14
+// runs of a filter that co-schedules them, under xunit.runner.json's
+// parallelizeTestCollections + maxParallelThreads 4.
+[Collection(CacheRootsSerialCollection.Name)]
 public sealed class RunnerFingerprintFileIdentityMemoTests : IDisposable
 {
     private readonly string _root;

--- a/AlRunner.Tests/RunnerFingerprintFileIdentityMemoTests.cs
+++ b/AlRunner.Tests/RunnerFingerprintFileIdentityMemoTests.cs
@@ -27,8 +27,10 @@ public sealed class RunnerFingerprintFileIdentityMemoTests : IDisposable
     public RunnerFingerprintFileIdentityMemoTests()
     {
         // A fixture tree of our own — never the real shared package cache, which other
-        // processes on this machine are using while these tests run.
-        _root = Path.Combine(Path.GetTempPath(), "al-runner-tests", "fileid-memo-" + Guid.NewGuid().ToString("N"));
+        // processes on this machine are using while these tests run. TestScratch, not a
+        // hand-built temp path: ScratchDirs records an owner so a killed test host's tree is
+        // reclaimed rather than leaked (ScratchDirOwnershipGuardTests enforces this).
+        _root = TestScratch.Dir("al-runner-fileid-memo");
         Directory.CreateDirectory(_root);
         RunnerFingerprint.ClearFileContentHashMemoForTests();
     }

--- a/AlRunner.Tests/RunnerFingerprintFileIdentityMemoTests.cs
+++ b/AlRunner.Tests/RunnerFingerprintFileIdentityMemoTests.cs
@@ -1,0 +1,177 @@
+// RunnerFingerprintFileIdentityMemoTests — issue #3036.
+//
+// `.github/actions/provision-bc` populates `~/.al-runner/platform-apps` and then hard-links
+// that tree into the default artifacts directory (`cp -al`, with a `cp -a` copy fallback).
+// Program.cs folds both into the package-cache search set, so the SAME inodes are reached
+// through two absolute paths — and a memo keyed on the path answers "never seen this file"
+// for the second one, re-reading and re-hashing 122.5 MB of packages, Base Application's
+// 98 MB among them, on every runner invocation.
+//
+// These tests pin BOTH directions, and the second one is the load-bearing half:
+//
+//   * dedup enough — two paths to ONE file are hashed once (`HardLink_*`, `Symlink_*`);
+//   * dedup no further — two DISTINCT files stay distinct even when everything a stat can
+//     see about them agrees (`DistinctFilesWithIdenticalSizeAndMtime_*`). A memo keyed on
+//     (length, mtime), or on an inode number without the device, would serve one file's
+//     hash for another file's bytes. That is a silently WRONG cache answer, strictly worse
+//     than the duplicated work this issue is about.
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class RunnerFingerprintFileIdentityMemoTests : IDisposable
+{
+    private readonly string _root;
+
+    public RunnerFingerprintFileIdentityMemoTests()
+    {
+        // A fixture tree of our own — never the real shared package cache, which other
+        // processes on this machine are using while these tests run.
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-tests", "fileid-memo-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        RunnerFingerprint.ClearFileContentHashMemoForTests();
+    }
+
+    public void Dispose()
+    {
+        RunnerFingerprint.ClearFileContentHashMemoForTests();
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private string Write(string name, byte[] bytes)
+    {
+        var p = Path.Combine(_root, name);
+        File.WriteAllBytes(p, bytes);
+        return p;
+    }
+
+    /// <summary>Hard-links <paramref name="target"/> at <paramref name="linkPath"/>, or
+    /// returns false when the platform/filesystem cannot (Windows, cross-device, ...).</summary>
+    private static bool TryHardLink(string target, string linkPath)
+    {
+        if (OperatingSystem.IsWindows()) return false;
+        try
+        {
+            var psi = new System.Diagnostics.ProcessStartInfo("ln")
+            {
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+            };
+            psi.ArgumentList.Add(target);
+            psi.ArgumentList.Add(linkPath);
+            using var p = System.Diagnostics.Process.Start(psi);
+            if (p == null) return false;
+            p.WaitForExit(30_000);
+            return p.ExitCode == 0 && File.Exists(linkPath);
+        }
+        catch { return false; }
+    }
+
+    // ── dedup enough ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void HardLinkedPaths_AreHashedOnce_AndAgreeOnTheHash()
+    {
+        var a = Write("pkg-a.app", System.Text.Encoding.UTF8.GetBytes("the same bytes, reached two ways"));
+        var b = Path.Combine(_root, "pkg-b.app");
+        var linked = TryHardLink(a, b);
+        if (!OperatingSystem.IsLinux()) { if (!linked) return; }
+        // On Linux this must not be a soft skip: a test that quietly proves nothing is how
+        // a dedup fix silently stops applying without anything going red.
+        else Assert.True(linked, "could not hard-link inside the fixture tree");
+
+        var before = RunnerFingerprint.ContentHashComputationCountForTests;
+        var ha = RunnerFingerprint.ComputeFileContentHashMemoized(a);
+        var hb = RunnerFingerprint.ComputeFileContentHashMemoized(b);
+        var computed = RunnerFingerprint.ContentHashComputationCountForTests - before;
+
+        Assert.Equal(ha, hb);
+        Assert.NotEqual(RunnerFingerprint.UnknownContentHash, ha);
+        Assert.Equal(
+            "e0a3d1a6e1f5b6ba0f0d5b6b5ed6f2b1e7a2b1c3d4e5f60718293a4b5c6d7e8f".Length,
+            ha.Length); // a real SHA-256 hex digest, not a sentinel
+        Assert.Equal(1, computed);
+    }
+
+    [Fact]
+    public void SymlinkedPath_IsHashedOnce_BecauseItResolvesToTheSameFile()
+    {
+        if (OperatingSystem.IsWindows()) return;
+        var a = Write("real.app", System.Text.Encoding.UTF8.GetBytes("symlink target bytes"));
+        var link = Path.Combine(_root, "link.app");
+        File.CreateSymbolicLink(link, a);
+
+        var before = RunnerFingerprint.ContentHashComputationCountForTests;
+        var ha = RunnerFingerprint.ComputeFileContentHashMemoized(a);
+        var hl = RunnerFingerprint.ComputeFileContentHashMemoized(link);
+        var computed = RunnerFingerprint.ContentHashComputationCountForTests - before;
+
+        Assert.Equal(ha, hl);
+        Assert.Equal(1, computed);
+    }
+
+    // ── dedup no further: distinct files must stay distinct ─────────────────
+
+    [Fact]
+    public void DistinctFilesWithIdenticalContent_AreHashedSeparately()
+    {
+        var bytes = System.Text.Encoding.UTF8.GetBytes("identical content, two separate files");
+        var a = Write("twin-a.app", bytes);
+        var b = Write("twin-b.app", bytes);
+
+        var before = RunnerFingerprint.ContentHashComputationCountForTests;
+        var ha = RunnerFingerprint.ComputeFileContentHashMemoized(a);
+        var hb = RunnerFingerprint.ComputeFileContentHashMemoized(b);
+        var computed = RunnerFingerprint.ContentHashComputationCountForTests - before;
+
+        Assert.Equal(ha, hb); // same bytes really do hash the same
+        Assert.Equal(2, computed); // but they are two files, and each was read
+    }
+
+    [Fact]
+    public void DistinctFilesWithIdenticalSizeAndMtime_GetTheirOwnHashes()
+    {
+        // Everything a stat can see agrees: same length, same last-write time, same
+        // directory. Only the bytes differ. A memo that keys on the stat rather than on
+        // file identity answers the first file's hash for the second file's bytes.
+        var a = Write("same-stat-a.app", new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 });
+        var b = Write("same-stat-b.app", new byte[] { 8, 7, 6, 5, 4, 3, 2, 1 });
+        var stamp = new DateTime(2020, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        File.SetLastWriteTimeUtc(a, stamp);
+        File.SetLastWriteTimeUtc(b, stamp);
+        Assert.Equal(new FileInfo(a).Length, new FileInfo(b).Length);
+        Assert.Equal(File.GetLastWriteTimeUtc(a), File.GetLastWriteTimeUtc(b));
+
+        var before = RunnerFingerprint.ContentHashComputationCountForTests;
+        var ha = RunnerFingerprint.ComputeFileContentHashMemoized(a);
+        var hb = RunnerFingerprint.ComputeFileContentHashMemoized(b);
+        var computed = RunnerFingerprint.ContentHashComputationCountForTests - before;
+
+        Assert.NotEqual(ha, hb);
+        Assert.Equal(2, computed);
+        // And each answer is the real hash of ITS OWN bytes, not merely "not the other one".
+        Assert.Equal(Sha256Hex(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }), ha);
+        Assert.Equal(Sha256Hex(new byte[] { 8, 7, 6, 5, 4, 3, 2, 1 }), hb);
+    }
+
+    [Fact]
+    public void MissingFile_AnswersUnknown_AndDoesNotPoisonThePathOnceItExists()
+    {
+        // A path that cannot be identified falls back to path keying and answers the
+        // "unknown" sentinel. The file then appears — the later call must NOT inherit
+        // that sentinel from the memo.
+        var p = Path.Combine(_root, "later.app");
+        Assert.Equal(RunnerFingerprint.UnknownContentHash, RunnerFingerprint.ComputeFileContentHashMemoized(p));
+
+        var bytes = System.Text.Encoding.UTF8.GetBytes("now it exists");
+        File.WriteAllBytes(p, bytes);
+        Assert.Equal(Sha256Hex(bytes), RunnerFingerprint.ComputeFileContentHashMemoized(p));
+    }
+
+    private static string Sha256Hex(byte[] bytes)
+    {
+        using var sha = System.Security.Cryptography.SHA256.Create();
+        return Convert.ToHexString(sha.ComputeHash(bytes)).ToLowerInvariant();
+    }
+}

--- a/AlRunner/Infrastructure/FileIdentity.cs
+++ b/AlRunner/Infrastructure/FileIdentity.cs
@@ -81,10 +81,17 @@ internal static class FileIdentity
             var buf = new StatxBuffer();
             // AT_FDCWD with an absolute path; flags 0 = follow symlinks. The mask is a
             // request, not a promise — the kernel reports what it actually filled in
-            // stx_mask, and an inode it did not fill is one we must not key on.
-            var rc = statx(AT_FDCWD, fullPath, 0, StatxIno | StatxSize | StatxMtime, ref buf);
+            // stx_mask.
+            const uint wanted = StatxIno | StatxSize | StatxMtime;
+            var rc = statx(AT_FDCWD, fullPath, 0, wanted, ref buf);
             if (rc != 0) return null;
-            if ((buf.Mask & StatxIno) == 0) return null;
+            // ALL THREE, not just the inode. Size and mtime are what bound inode reuse (see
+            // the header), so a filesystem that reported an inode and declined the other two
+            // would silently hand back `ino|maj:min:ino|0|0.0` — a key carrying none of the
+            // anti-aliasing weight, for every file on that mount. Answering null instead
+            // costs the dedup and keeps the fallback's guarantees. Defensive rather than
+            // observed: the mask measured on this repo's filesystems is 0x9fff.
+            if ((buf.Mask & wanted) != wanted) return null;
             return string.Create(
                 System.Globalization.CultureInfo.InvariantCulture,
                 $"ino|{buf.DevMajor}:{buf.DevMinor}:{buf.Ino}|{buf.Size}|{buf.MtimeSec}.{buf.MtimeNsec}");

--- a/AlRunner/Infrastructure/FileIdentity.cs
+++ b/AlRunner/Infrastructure/FileIdentity.cs
@@ -1,0 +1,129 @@
+// FileIdentity — "are these two paths the same file?", answered by the filesystem rather
+// than by comparing paths.
+//
+// Issue #3036. `.github/actions/provision-bc` populates `~/.al-runner/platform-apps` and
+// then hard-links that tree into the default artifacts directory:
+//
+//     cp -al "$HOME/.al-runner/platform-apps/." "$DEFAULT_PLATFORM_APPS/" \
+//       || cp -a "$HOME/.al-runner/platform-apps/." "$DEFAULT_PLATFORM_APPS/"
+//
+// Program.cs folds ProvisioningCheck.CollectRunnerOwnedProvisionDirs(...) into the
+// package-cache search set and CI additionally passes `--package-cache
+// "$HOME/.al-runner/platform-apps"`, so both directories are scanned — and they are the
+// same inodes. Nothing about a path reveals that, so a memo keyed on the path re-reads and
+// re-hashes 122.5 MB of packages (98 MB of it Base Application) on every invocation.
+//
+// ── The key, and why it cannot collide ─────────────────────────────────────────────────
+//
+// The key is (device, inode, size, mtime). All four, deliberately:
+//
+//   * An inode number is unique only WITHIN a device. Two package-cache roots on different
+//     filesystems — `$HOME` on one mount, an artifacts directory on another, which is a
+//     perfectly ordinary developer or CI layout — reach inode numbers from independent
+//     numbering spaces, so an inode-only key would eventually declare two unrelated
+//     packages "the same file" and serve one's content hash for the other's bytes.
+//     Including the device makes the pair globally unique on a live filesystem.
+//
+//   * (device, inode) is unique among files that exist AT THE SAME TIME, and no further.
+//     Delete a file and the kernel is free to hand its inode number to the next file
+//     created — so within one long-lived process (a `--watch` run, or a run that unlinks a
+//     staging package it wrote), a bare (device, inode) key CAN be asked about two
+//     genuinely different files. Size and mtime bound that: a reused inode carrying
+//     different content almost always differs in one of them, and the ONE case it does not
+//     — a reused inode whose new file has the same length and was written inside the same
+//     timestamp tick — is a strictly smaller window than the same-length-same-mtime
+//     collision a stat-only key is exposed to for two files that both still exist.
+//
+// So the key never says "same file" for two files that exist at once, which is the only
+// claim the memo above it makes. It is NOT a content identity and must never be persisted
+// to disk or shared between processes: an inode number means nothing on another machine,
+// and means something different on this one after the file is gone. In-process memo only.
+//
+// ── Platform ───────────────────────────────────────────────────────────────────────────
+//
+// .NET exposes no portable file-identity primitive (`FileInfo` has no inode;
+// `ResolveLinkTarget` answers for symlinks only, not hard links), so this is a syscall.
+// Linux `statx` was chosen over `stat`: its struct layout is defined by the kernel uapi and
+// is identical on every architecture, whereas `struct stat`'s layout is libc- and
+// arch-specific and glibc did not export a plain `stat` symbol before 2.33.
+//
+// Anywhere `statx` is unavailable — Windows, macOS, a libc without it — TryGetStableKey
+// returns null and every caller falls back to path keying, i.e. exactly today's behaviour:
+// duplicated work, never a wrong answer. The same is true of the `cp -a` fallback in the
+// provisioning action above: if the hard link cannot be made (typically because the two
+// directories are on different filesystems) the copy is a genuinely separate file with its
+// own inode, this returns two different keys, and both copies are hashed — which is
+// correct, because they really are two files that could drift apart. A future provisioning
+// path that copies instead of linking therefore does not break anything here; it silently
+// gives up the saving, and #3036's measurement is the thing to re-run if that happens.
+using System.Runtime.InteropServices;
+
+namespace AlRunner.Infrastructure;
+
+internal static class FileIdentity
+{
+    /// <summary>
+    /// A key identifying the FILE at <paramref name="fullPath"/> — equal for two paths that
+    /// are hard links to one inode, different for two files that both exist — or null when
+    /// this platform cannot answer, in which case callers must fall back to the path.
+    ///
+    /// <para>Symlinks are followed, so a symlink and its target share a key: they are the
+    /// same bytes, which is the question the callers are asking.</para>
+    ///
+    /// <para>Never persist this. See the header for why it is meaningless off this machine
+    /// and meaningless on it once the file is unlinked.</para>
+    /// </summary>
+    internal static string? TryGetStableKey(string fullPath)
+    {
+        if (!_statxUsable) return null;
+        try
+        {
+            var buf = new StatxBuffer();
+            // AT_FDCWD with an absolute path; flags 0 = follow symlinks. The mask is a
+            // request, not a promise — the kernel reports what it actually filled in
+            // stx_mask, and an inode it did not fill is one we must not key on.
+            var rc = statx(AT_FDCWD, fullPath, 0, StatxIno | StatxSize | StatxMtime, ref buf);
+            if (rc != 0) return null;
+            if ((buf.Mask & StatxIno) == 0) return null;
+            return string.Create(
+                System.Globalization.CultureInfo.InvariantCulture,
+                $"ino|{buf.DevMajor}:{buf.DevMinor}:{buf.Ino}|{buf.Size}|{buf.MtimeSec}.{buf.MtimeNsec}");
+        }
+        catch (EntryPointNotFoundException) { _statxUsable = false; return null; }
+        catch (DllNotFoundException) { _statxUsable = false; return null; }
+        catch (PlatformNotSupportedException) { _statxUsable = false; return null; }
+        catch { return null; }
+    }
+
+    // Latched off the first time the P/Invoke itself proves unavailable, so a platform
+    // without statx pays one failed bind rather than one per file. A per-call failure
+    // (ENOENT, EACCES) is NOT a reason to latch — the next file may well be readable.
+    private static volatile bool _statxUsable = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+
+    private const int AT_FDCWD = -100;
+    private const uint StatxMtime = 0x00000040;
+    private const uint StatxIno = 0x00000100;
+    private const uint StatxSize = 0x00000200;
+
+    // struct statx, uapi/linux/stat.h — 256 bytes, identical layout on every architecture.
+    // Only the fields this type reads are declared; the rest is covered by Size.
+    [StructLayout(LayoutKind.Explicit, Size = 256)]
+    private struct StatxBuffer
+    {
+        [FieldOffset(0)] public uint Mask;
+        [FieldOffset(32)] public ulong Ino;
+        [FieldOffset(40)] public ulong Size;
+        [FieldOffset(112)] public long MtimeSec;   // stx_mtime.tv_sec
+        [FieldOffset(120)] public uint MtimeNsec;  // stx_mtime.tv_nsec
+        [FieldOffset(136)] public uint DevMajor;
+        [FieldOffset(140)] public uint DevMinor;
+    }
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern int statx(
+        int dirfd,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string pathname,
+        int flags,
+        uint mask,
+        ref StatxBuffer statxbuf);
+}

--- a/AlRunner/Infrastructure/RunnerFingerprint.cs
+++ b/AlRunner/Infrastructure/RunnerFingerprint.cs
@@ -106,41 +106,82 @@ internal static class RunnerFingerprint
     // ComputeContentHash reads the WHOLE file; the call sites ask per virtual-table lookup,
     // per dependency and per cache key, so an unmemoized hash is a re-read each time.
     //
-    // The memo key is (full path, length, last-write UTC) — NOT the path alone, which is what
-    // it was until #2987. "One entry per path, never invalidated" rested on "nothing in this
-    // process writes to a dependency .app", and that premise does not hold for every caller:
-    // InProcessAppPackager writes synthetic .app packages mid-run, and a --watch process
-    // outlives a rebuild of one. A path-keyed memo answers the FIRST bytes it ever saw for
-    // those, so a caller keying a persisted cache on it would consult the previous package's
-    // entry — the wrong-answer shape content addressing exists to remove, reintroduced one
-    // layer down. The stat is not trusted to identify CONTENT here (that is the whole point of
-    // this method); it is only used to notice that the file has been written since, which is
-    // exactly what a stat can tell you. A rewrite that lands on the same length and mtime is
-    // one the memo will not notice — that is a memo, not a cache key, and it lives and dies
-    // with the process, which is why the persisted keys built FROM this value are the ones
-    // that have to be right.
+    // The memo key identifies the FILE, not the path: (device, inode, size, last-write) where
+    // the platform can answer, falling back to (full path, length, last-write UTC).
+    //
+    // The stat half is #2987. "One entry per path, never invalidated" rested on "nothing in
+    // this process writes to a dependency .app", and that premise does not hold for every
+    // caller: InProcessAppPackager writes synthetic .app packages mid-run, and a --watch
+    // process outlives a rebuild of one. A path-keyed memo answers the FIRST bytes it ever saw
+    // for those, so a caller keying a persisted cache on it would consult the previous
+    // package's entry — the wrong-answer shape content addressing exists to remove,
+    // reintroduced one layer down. The stat is not trusted to identify CONTENT here (that is
+    // the whole point of this method); it is only used to notice that the file has been
+    // written since, which is exactly what a stat can tell you. A rewrite that lands on the
+    // same length and mtime is one the memo will not notice — that is a memo, not a cache key,
+    // and it lives and dies with the process, which is why the persisted keys built FROM this
+    // value are the ones that have to be right.
+    //
+    // The device/inode half is #3036. `provision-bc` hard-links `~/.al-runner/platform-apps`
+    // into the default artifacts directory and Program.cs scans both, so the same inodes
+    // arrive here under two absolute paths — and neither the path nor a stat can see that, so
+    // the second one was a full re-read of 122.5 MB, 98 MB of it Base Application, on every
+    // invocation. FileIdentity answers "same file?" from the filesystem instead; see its
+    // header for why (device, inode, size, mtime) cannot say "same file" about two files that
+    // both exist, which is the only claim this memo makes. Size and mtime appear in BOTH
+    // halves and do the same job in each: notice that the file has been written since.
+    // A platform that cannot answer falls back to the stat key and behaves as it did before.
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<string, string> _fileContentHashes =
         new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
-    /// <see cref="ComputeContentHash"/> memoized per (full path, length, mtime) — the entry
-    /// point every cache key that identifies a FILE by its content should use.
+    /// <see cref="ComputeContentHash"/> memoized per FILE — the entry point every cache key
+    /// that identifies a file by its content should use. Two paths that are hard links to one
+    /// inode share an entry and are read once (#3036); two files that both exist never do,
+    /// whatever their paths, lengths or timestamps say.
     /// </summary>
     internal static string ComputeFileContentHashMemoized(string path)
     {
         var fullPath = Path.GetFullPath(path);
-        string memoKey;
+        // The two key spaces are kept disjoint by the "ino|" / "path|" prefixes rather than by
+        // an argument about what an absolute path can start with — a memo whose two keying
+        // schemes could ever produce the same string is the wrong-answer shape this exists to
+        // avoid, not a place to be clever.
+        var memoKey = FileIdentity.TryGetStableKey(fullPath) ?? StatKey(fullPath);
+        return _fileContentHashes.GetOrAdd(memoKey, _ =>
+        {
+            System.Threading.Interlocked.Increment(ref _contentHashComputations);
+            return ComputeContentHash(fullPath);
+        });
+    }
+
+    /// <summary>
+    /// The fallback key for a file the filesystem cannot identify for us (no statx: Windows,
+    /// macOS, an older libc) — #2987's (path, length, mtime).
+    ///
+    /// <para>A file we cannot stat at all memoizes under the bare path: ComputeContentHash is
+    /// about to answer <see cref="UnknownContentHash"/> for it anyway, and a later call that
+    /// CAN stat it gets a different key and recomputes rather than inheriting that answer.</para>
+    /// </summary>
+    private static string StatKey(string fullPath)
+    {
         try
         {
             var fi = new FileInfo(fullPath);
-            // A file we cannot stat memoizes under the bare path: ComputeContentHash is about
-            // to answer UnknownContentHash for it anyway, and a later call that CAN stat it
-            // gets a different key and recomputes rather than inheriting that answer.
-            memoKey = fi.Exists ? $"{fullPath}|{fi.Length}|{fi.LastWriteTimeUtc.Ticks}" : fullPath;
+            return fi.Exists
+                ? $"path|{fullPath}|{fi.Length}|{fi.LastWriteTimeUtc.Ticks}"
+                : "path|" + fullPath;
         }
-        catch { memoKey = fullPath; }
-        return _fileContentHashes.GetOrAdd(memoKey, _ => ComputeContentHash(fullPath));
+        catch { return "path|" + fullPath; }
     }
+
+    private static int _contentHashComputations;
+
+    /// <summary>Test-only: how many times this process has actually READ AND HASHED a file
+    /// through the memo. The memo's whole job is that this stays below the number of calls,
+    /// and a test that asserts on returned hashes alone cannot see the difference between
+    /// one read and two — two paths to one file return the same hash either way.</summary>
+    internal static int ContentHashComputationCountForTests => Volatile.Read(ref _contentHashComputations);
 
     /// <summary>Test-only: drops the memo, so a test that rewrites a file in place can
     /// observe what a fresh process would compute for it. Production code never needs


### PR DESCRIPTION
Closes #3036

`provision-bc` populates `~/.al-runner/platform-apps` and then hard-links it into the
default artifacts directory (`cp -al`, verified at
`.github/actions/provision-bc/action.yml:64-65`, not inherited from the issue text).
`Program.cs` folds `ProvisioningCheck.CollectRunnerOwnedProvisionDirs(...)` into the
package-cache search set and CI passes `--package-cache "$HOME/.al-runner/platform-apps"`
on top, so the same inodes arrive at `RunnerFingerprint.ComputeFileContentHashMemoized`
under two absolute paths. A path-keyed memo cannot see that, so the same bytes were read
and SHA-256'd twice.

`FileIdentity` (new, `AlRunner/Infrastructure/FileIdentity.cs`) answers "same file?" from
the filesystem, and the memo keys on what it returns.

## The identity key, and why it cannot collide

The key is **(device, inode, size, mtime)** — `ino|<devmajor>:<devminor>:<ino>|<size>|<sec>.<nsec>`.
All four parts are load-bearing:

* **Device, not inode alone.** An inode number is unique only within a device. Two
  package-cache roots on different filesystems — `$HOME` on one mount and an artifacts
  directory on another is an ordinary layout — draw from independent inode-numbering
  spaces, so an inode-only key would eventually declare two unrelated packages the same
  file and serve one's content hash for the other's bytes. `FileIdentityTests
  .Key_CarriesTheDevice_SoInodesFromTwoFilesystemsCannotCollide` proves the device is
  actually in the key by finding a second mount (`/dev/shm`) and showing the device
  component differs — not by reading the source.
* **Size and mtime bound inode reuse.** `(device, inode)` is unique among files that exist
  *at the same time*, and no further: the kernel may hand a deleted file's inode number to
  the next file created. Within one long-lived process (a `--watch` run, a run that unlinks
  a staging package it wrote) a bare `(device, inode)` key can therefore be asked about two
  different files. Size and mtime close that, and what remains — a reused inode whose new
  file has the same length and lands inside the same timestamp tick — is a strictly smaller
  window than the same-length-same-mtime exposure a stat-only key already carries for two
  files that both still exist.

So the key never says "same file" about two files that exist at once, which is the only
claim the memo above it makes. It is deliberately **never persisted**: an inode number
means nothing on another machine and something different on this one once the file is gone.
The header comment says that in the source, where the next person to widen this will read it.

The two key spaces are kept disjoint by explicit `ino|` / `path|` prefixes rather than by an
argument about what an absolute path can start with.

## The hard-link assumption, and what happens if it stops holding

Checked in the code, not assumed. The provisioning action already has a copy fallback:
`cp -al ... || cp -a ...`. When the link fails (typically two filesystems) the copy is a
genuinely separate file with its own inode, this returns two different keys, and both copies
are hashed — which is correct, because they really are two files that can drift apart. Same
for any future provisioning path that copies instead of linking: the saving is silently
given up, never a wrong answer. That is written into `FileIdentity`'s header so a later
reader knows to re-run #3036's measurement rather than assume the fix still applies.

The same "degrades to today's behaviour" property covers platforms without `statx`
(Windows, macOS, a libc without it): `TryGetStableKey` returns null and the caller falls
back to path keying.

On Linux the tests deliberately do **not** soft-skip. `RunnerFingerprintFileIdentityMemoTests
.HardLinkedPaths_AreHashedOnce_AndAgreeOnTheHash` asserts the computation count is exactly 1,
so a `statx` that stopped answering goes red instead of quietly passing.

## RED → GREEN

RED, measured against `c9c4c463~1` (`dotnet test AlRunner.Tests --filter FullyQualifiedName~RunnerFingerprintFileIdentityMemoTests`):
`Failed: 3, Passed: 2`. **Two of those three rows are the evidence for this change**, and the
third is stale — worth stating plainly rather than leaving in:

* `HardLinkedPaths_AreHashedOnce_AndAgreeOnTheHash` and
  `SymlinkedPath_IsHashedOnce_BecauseItResolvesToTheSameFile` failed with
  `Expected: 1, Actual: 2` computations. These are the defect.
* `MissingFile_AnswersUnknown_AndDoesNotPoisonThePathOnceItExists` failed with
  `Expected: fc3e2047…, Actual: unknown`. That was RED only because `c9c4c463~1` still keyed
  the memo on the bare `fullPath`; **#3035 fixed it, so it is not reproducible against today's
  `main` and this change does not fix it.** The test stays as a regression guard, not as
  evidence.

GREEN, after the change: `Passed: 5`, and `FileIdentityTests` `Passed: 6`.

**The negative direction is the load-bearing half**, and both negative tests already passed
in RED — that is the point: this change must not move them.

* `DistinctFilesWithIdenticalSizeAndMtime_GetTheirOwnHashes` — two files in one directory,
  same length, `File.SetLastWriteTimeUtc` to the same instant, different bytes. Asserts the
  two answers differ **and** that each equals the real SHA-256 of its own bytes, not merely
  "not the other one". A memo keyed on the stat, or on an inode without the device, fails it.
* `DistinctFilesWithIdenticalContent_AreHashedSeparately` — identical bytes, two inodes:
  same hash, but the computation count must be 2.
* `FileIdentityTests.Key_ChangesWhenTheFileIsRewritten_SoAReusedInodeCannotServeStaleContent`
  — same inode, new size, different key.

**Offset check.** The key is read out of a hand-declared `struct statx`, so
`Key_ReportsTheSameDeviceInodeAndSizeAsCoreutilsStat` cross-checks device/inode/size against
coreutils `stat -c '%Hd %Ld %i %s'`, which reads the same kernel structure through libc.
Mutation-tested: moving `stx_ino` from offset 32 to 48 turns that test red (`Failed: 1,
Passed: 5`), so the check is real and not a formality. `statx` was chosen over `stat`
precisely because its layout is kernel-uapi and identical on every architecture, whereas
`struct stat`'s is libc- and arch-specific and glibc did not export a plain `stat` before 2.33.

All fixtures are built under the test's own temp tree. Nothing reads, writes or prunes the
real shared package cache.

## Measured

* Hashing the duplicated set costs **78–85 ms warm** on this box (`sha256sum` over the
  122.5 MB / 6 files in `~/.al-runner/platform-apps`, three runs, page cache warm). That is
  the per-invocation saving once a second hard-linked root is in the search set, and it
  matches the issue's ~0.09 s estimate.
* The added cost is one `statx` per memo call: **0.73 µs** (200,000 stat-family syscalls on
  the same file, 146.3 ms total). The memo is consulted on the order of hundreds of times
  per run.
* End-to-end sanity: `tests/runner-extras/date-virtual-table-window` with **two
  hard-linked `--package-cache` roots** (a `cp -al` of `~/.al-runner/platform-apps` into my
  own scratch, same inode confirmed with `stat -c %i`): 9/9 pass.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Every direct `ComputeContentHash` call is
   inside `RunnerFingerprint` itself (3 sites: the running assembly, the definition, and the
   memo), so there is no second path-keyed content memo to fix. One site hashes a package's
   bytes *outside* the shared memo: `DependencyLoader.cs:738` (`app-bytes:` in a persisted
   dep-cache key). Deliberately left alone and filed instead — routing it through the memo
   would change that key's hex casing (the memo lowercases, `Convert.ToHexString` does not)
   and would need a guard so an unreadable package does not key on the `unknown` sentinel.
   Both are real risks on a persisted key for one saved hash per dependency, so it is filed
   as #3043 rather than folded in here. #3043 stays open after this merges.
2. **Sibling making the same assumption?** Yes — `AppLoader.ReadManifest` / `ReadPackageMeta`
   memoize on `{fullPath}|{length}|{mtime}`, so hard-linked paths miss there too. Not fixed
   here on purpose: that string doubles as the **on-disk** index key, and inode identity must
   never be persisted (see above), so the honest fix there is to split the memo key from the
   index key. Today the cost is one small JSON index read, not a hash. Note the composition:
   #3035 re-keys that index on the package's content hash obtained from *this* memo, so once
   both land, the second hard-linked path gets its hash free from here and then hits the same
   index entry — the sibling closes as a side effect rather than needing its own inode key.
3. **Two writers, one invariant?** The memo has a single writer (`GetOrAdd`). The
   test-only counter is read as a delta, so the existing `ClearFileContentHashMemoForTests`
   not resetting it is not an invariant gap.

## #3036 and #3037: two fixes, not one

They do not share a root cause, a file, or a loop, and neither blocks the other:

* **#3036 (here)** is about **file identity**: two paths, one inode, in
  `RunnerFingerprint.ComputeFileContentHashMemoized`. Removes 122.5 MB of the 694 MB in
  #3037's table.
* **#3037** is about **search-set breadth**: `ProvisioningCheck.CollectRunnerOwnedProvisionDirs`
  returning every provisioned artifact version rather than the selected one. Different file,
  different question, and an open semantic question (whether version-aware resolution needs
  the other versions) that this change does not touch. The remaining ~450 MB in that table is
  four *different* versions' downloads — separate files with separate inodes, not hard links,
  so inode dedup correctly does nothing about them.

They compose cleanly and another agent can take #3037 without touching anything here.

**Composed with #3035, which merged while this was open.** It had changed the same method's
key from `fullPath` to `fullPath|len|mtime`, so this branch was rebased onto `c9c4c463` and
the method hand-merged: the key is now `FileIdentity.TryGetStableKey(...)` —
(device, inode, size, mtime) — with #3035's `path|<full path>|<len>|<mtime>` as the fallback
when the platform cannot identify the file. Size and mtime appear in both halves and do the
same job in each: notice that the file has been written since. All targeted tests were re-run
after the rebase, not carried across it:

* `RunnerFingerprint|FileIdentity|BcAppSymbolCache|CacheKey|AppLoader|Manifest` — 203 passed,
  0 failed, 6 skipped (46 s). This includes #3035's own `RunnerFingerprintContentHashMemoTests`
  and `AppLoaderManifestIndexIdentityTests`.
* `PkgDedup|Dependenc|BcCompiler` — 246 passed, 0 failed, 32 skipped (1 m 58 s).

## Corpus

Nothing owed upstream. The claim here is about file identity in a runner-local, in-process
memo — `st_dev`/`st_ino` on this machine — with no AL surface and no statement about what
Business Central does. A BC service tier has nothing to adjudicate. The proving tests are
runner mechanism tests under `AlRunner.Tests/`, which is the right home for them.

## One CI fix on top

The first push went red on both unit-test legs (BC 27.5 and 28.4), one test each, same
cause: `ScratchDirOwnershipGuardTests` requires a test fixture root to be reserved through
`TestScratch` so `ScratchDirs` records an owner and a killed test host's tree is reclaimed
rather than leaked. Both new test files had built theirs with `Path.Combine(Path.GetTempPath(),
...)` directly. Fixed in `7c9b29ac` by switching to `TestScratch.Dir(...)`; nothing about the
change under test moved. Not a flake and not classified as one.

## Not done

* `docs/` unchanged — no user-visible behaviour, flag or limitation changes.
* `tests/expectations/count-baseline/test-count-baseline.json` untouched (#3004 is open
  against it).
* Nothing under the real shared cache was written or pruned.

Implemented by Claude Code agent `stma-auto-1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
