### PR TITLE
fix(bcapp): key .app-derived caches on a registration epoch, and drop the negative table cache with them

### DIFF
--- a/AlRunner.Tests/BcAppRegistrationEpochInvalidationTests.cs
+++ b/AlRunner.Tests/BcAppRegistrationEpochInvalidationTests.cs
@@ -1,0 +1,406 @@
+// BcAppRegistrationEpochInvalidationTests — issue #2888, the three instances of the
+// "state derived from _bcAppPaths outlives a change to _bcAppPaths" family that #2944
+// (_depPageMetadataXml / _depReportMetadataXml) deliberately left alone.
+//
+// The registration set moves in BOTH directions, through one funnel
+// -----------------------------------------------------------------
+//   * AddBcAppPath GROWS it — once per dependency .app, per bundle.
+//   * ClearPerBundleBcAppPaths SHRINKS it — every --server request, every --watch cycle
+//     (since #2755 / PR #2873).
+// Both end in InvalidateBcAppIndexes(), which is where every derived index is dropped.
+// The three pieces of state below were derived from the same set and were not dropped
+// there.
+//
+// 1. RecordPatches._bcMissCache (RecordPatches.BcAppFallback.cs) — the negative cache
+//    "no registered .app declares table N". Nothing cleared it, anywhere: not
+//    AddBcAppPath, not ResetForReload. So a table id that missed under bundle 1 stayed
+//    permanently missing for bundle 2..N of a --server process even though bundle 2's own
+//    dependency declares it, and a miss taken between two AddBcAppPath calls in a single
+//    run was never revisited. Covered by AMissedTableId_* below.
+//
+// 2. The seven generation keys of the form (_bcAppPaths.Count, ...). A COUNT is a sound
+//    generation only while the list cannot shrink. It can, so a set that loses N entries
+//    and gains N different ones reads as the same generation and the previous epoch's rows
+//    are served — ABA, not staleness. The shape is proved behaviourally on
+//    _depProcessingOnlyBuiltFrom (DependencyReportMetadata.cs), the one keyed on the bare
+//    count with no other term to confound it; the remaining six are the identical
+//    expression and are pinned structurally by NoGenerationKeyUsesTheAppPathCount below,
+//    because their enumerators are private and reachable only through the virtual-table
+//    provider path.
+//
+// 3. NavReportSync._realMetaCache — a second-order memo over the memo #2944 fixed.
+//    BcRuntime.ResetForNewBundleReload clears it before ResetForReload, so the SHRINK
+//    direction was already covered; the GROW direction was not, so a null memoized before
+//    a registration masks the fix for that consumer. GetRealMetaReport then falls through
+//    to the legacy stub that stamps ProcessingOnly, and BC refuses SaveAs — a wrong
+//    refusal rather than a throw. Covered by ANullRealMetaReport_* below.
+//
+// Why these are mechanism tests and not corpus tests
+// --------------------------------------------------
+// Every claim here is about cache lifetime across a registration-set change inside ONE
+// runner process — multi-bundle / server-mode wiring, which
+// .claude/rules/bc-behavior-tests-go-upstream.md names as explicitly runner-specific. Real
+// BC has no _bcMissCache, no _bcAppPaths and no MetaReport memo keyed on one; the AL a
+// corpus test would run is identical on both sides of every fix here. Instance 3 was
+// checked separately rather than inheriting that answer, because its symptom (SaveAs
+// refused on a report that is not processing-only) IS AL-visible where #2944's was not:
+// what AL cannot express is the runner-internal ordering that produces it — a
+// GetRealMetaReport miss BEFORE the .app declaring the report is registered, inside one
+// process. On a service tier the report metadata is simply there.
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// RecordPatchesSerialCollection: this class calls RecordPatches.ResetForReload() directly,
+// which ParserStaticsIsolationGuardTests requires, and it registers .apps (which argues for
+// CacheRootsSerialCollection — a class can only join one). Same trade-off, and the same
+// reasoning, as DependencyMetadataMemoInvalidationTests and
+// DependencyReportProcessingOnlyTests: every .app written here is a fresh GUID-named file
+// and BcAppSymbolCache's key is content-addressed, so the worst a concurrent CacheRoots
+// override can do is turn a HIT into a MISS and re-parse the same bytes to the same result.
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class BcAppRegistrationEpochInvalidationTests : IDisposable
+{
+    private readonly string _root;
+
+    public BcAppRegistrationEpochInvalidationTests()
+    {
+        _root = TestScratch.Dir("al-runner-2888-tests");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    // Ids process-wide unique among AlRunner.Tests statics — _bcAppPaths, _parsedTables and
+    // both report memos are process-global and nothing in the test host unregisters an .app.
+    // Neighbouring blocks in use: 881234xx and 881235xx (DependencyPageMetadataXmlTests),
+    // 881235xx (DependencyMetadataMemoInvalidationTests, disjoint literals), 881236xx
+    // (DependencyReportProcessingOnlyTests), 881237xx (TableRelationWhereFieldLinkTests).
+    // This file owns 881238xx.
+    private const int UnrelatedTableId = 88123801;
+    private const int LateTableId = 88123802;
+    private const int NeverDeclaredTableId = 88123803;
+    private const int AbaReportId = 88123850;
+    private const int UnrelatedReportId = 88123851;
+    private const int LateRealMetaReportId = 88123852;
+
+    private string WriteApp(string symbolReferenceJson)
+    {
+        var appPath = Path.Combine(_root, Guid.NewGuid().ToString("N") + ".app");
+        using var zip = new FileStream(appPath, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+        return appPath;
+    }
+
+    /// <summary>Top-level "Tables" container, the shape BcAppSymbolCache parses and
+    /// SymbolAppFixture.SymbolReferenceForTable writes.</summary>
+    private static string TablesJson(int tableId, string tableName, params (int Id, string Name)[] fields)
+    {
+        var sb = new StringBuilder();
+        sb.Append("{ \"RuntimeVersion\": \"15.1\", \"Tables\": [ {");
+        sb.Append($" \"Id\": {tableId}, \"Name\": \"{tableName}\", \"Fields\": [");
+        for (var i = 0; i < fields.Length; i++)
+        {
+            if (i > 0) sb.Append(',');
+            sb.Append($" {{ \"Id\": {fields[i].Id}, \"Name\": \"{fields[i].Name}\", \"TypeDefinition\": {{ \"Name\": \"Integer\" }} }}");
+        }
+        sb.Append("] } ] }");
+        return sb.ToString();
+    }
+
+    /// <summary>Namespaced "Reports" container, the shape DependencyReportProcessingOnlyTests
+    /// writes. <paramref name="processingOnly"/> null omits the property entirely, which is
+    /// how the vast majority of real Base App reports look.</summary>
+    private static string ReportsJson(int reportId, string name, bool? processingOnly)
+    {
+        var props = $"{{ \"Name\": \"Caption\", \"Value\": \"{name}\" }}";
+        if (processingOnly is bool po)
+            props += $", {{ \"Name\": \"ProcessingOnly\", \"Value\": \"{(po ? 1 : 0)}\" }}";
+        return $$"""
+            {
+              "RuntimeVersion": "15.1",
+              "Namespaces": [ { "Name": "BARE", "Reports": [
+                { "Id": {{reportId}}, "Name": "{{name}}", "Properties": [ {{props}} ] }
+              ] } ]
+            }
+            """;
+    }
+
+    // ── 1. _bcMissCache ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The negative cache must not outlive a registration that ADDS the .app declaring the
+    /// table it recorded a miss for.
+    ///
+    /// <para>Driven through <c>TryResolveDependencyFieldId</c> — a real production consumer
+    /// (#2467, resolving a dependency part's SubPageLink field names to numbers), not a
+    /// test-only probe. Its first act on a _parsedTables miss is
+    /// TryPopulateParsedTableFromBcApps, whose first act is the _bcMissCache check.</para>
+    ///
+    /// <para>Both polarities are here. The negative arm matters most: without it a "fix"
+    /// that simply stopped consulting the negative cache — or one that answered a field id
+    /// for anything asked about — would pass.</para>
+    /// </summary>
+    [Fact]
+    public void AMissedTableId_IsResolvableAfterALaterAppDeclaresIt()
+    {
+        RecordPatches.AddBcAppPath(WriteApp(TablesJson(UnrelatedTableId, "BARE Unrelated", (1, "Entry No."))));
+
+        // Precondition AND the thing that memoizes the miss. Asserted rather than assumed:
+        // if another test had already registered an .app declaring this id, the assertion
+        // after the registration below could pass without the fix.
+        Assert.Null(RecordPatches.TryResolveDependencyFieldId(LateTableId, "Payload"));
+
+        RecordPatches.AddBcAppPath(WriteApp(TablesJson(
+            LateTableId, "BARE Late Table", (1, "Entry No."), (42, "Payload"))));
+
+        // The concrete value, not merely "not null": 42 is the field id the second .app's
+        // symbol file states, so a fix that resolved the table but lost the field mapping
+        // cannot pass either.
+        Assert.Equal(42, RecordPatches.TryResolveDependencyFieldId(LateTableId, "Payload"));
+        Assert.Equal(1, RecordPatches.TryResolveDependencyFieldId(LateTableId, "Entry No."));
+
+        // Negative arm 1: a field that table does not declare stays unresolvable.
+        Assert.Null(RecordPatches.TryResolveDependencyFieldId(LateTableId, "No Such Field"));
+        // Negative arm 2: a table no registered .app declares at all stays unresolvable —
+        // dropping the negative cache must not turn every miss into an answer.
+        Assert.Null(RecordPatches.TryResolveDependencyFieldId(NeverDeclaredTableId, "Payload"));
+    }
+
+    /// <summary>
+    /// The same negative cache across a bundle roll. This is the route that is live on
+    /// <c>main</c> with no assumption about intra-run call ordering: ResetForReload
+    /// unregisters bundle 1's .apps and clears _parsedTables, so every miss bundle 1 took
+    /// has to be retaken against bundle 2's registrations — and nothing cleared the miss
+    /// cache on that path either.
+    ///
+    /// <para>The roll is followed by a registration because that is what Program.cs does
+    /// (ResetForNewBundleReload at 4049, AddBcAppPath at 4578); the discriminating fact is
+    /// that bundle 1 asked about this id and got a miss BEFORE the roll.</para>
+    /// </summary>
+    [Fact]
+    public void AMissedTableId_DoesNotSurviveTheBundleRollIntoABundleThatDeclaresIt()
+    {
+        RecordPatches.ResetForReload();
+        RecordPatches.AddBcAppPath(WriteApp(TablesJson(UnrelatedTableId, "BARE Unrelated", (1, "Entry No."))));
+
+        const int RollTableId = 88123804;
+        Assert.Null(RecordPatches.TryResolveDependencyFieldId(RollTableId, "Payload"));
+
+        RecordPatches.ResetForReload();
+        RecordPatches.AddBcAppPath(WriteApp(TablesJson(
+            RollTableId, "BARE Rolled Table", (1, "Entry No."), (7, "Payload"))));
+
+        Assert.Equal(7, RecordPatches.TryResolveDependencyFieldId(RollTableId, "Payload"));
+    }
+
+    // ── 2. the count-keyed generations ───────────────────────────────────────
+
+    /// <summary>
+    /// ABA on a generation keyed by <c>_bcAppPaths.Count</c>: one .app out, one different
+    /// .app in, same count, contents changed — and the memo built from the first is served
+    /// for the second.
+    ///
+    /// <para><c>_depProcessingOnlyBuiltFrom</c> is the site keyed on the BARE count, with no
+    /// second tuple term that could accidentally rescue the comparison, so it is where the
+    /// shape is provable rather than argued. The other six sites are the same expression
+    /// inside a tuple; <see cref="NoGenerationKeyUsesTheAppPathCount"/> pins them.</para>
+    ///
+    /// <para>Both reads deliberately happen at the SAME registered-app count. The leading
+    /// ResetForReload establishes the baseline so the two AddBcAppPath calls land on
+    /// identical counts; without it the test would be measuring whatever count previous
+    /// tests in this process left behind, and could pass by accident.</para>
+    ///
+    /// <para>The answer flips true → false, which is the direction that costs something: a
+    /// report wrongly reported processing-only gets no layout attempt at all.</para>
+    /// </summary>
+    [Fact]
+    public void ADependencyProcessingOnlyAnswer_DoesNotSurviveASameCountSwapOfTheRegisteredApps()
+    {
+        RecordPatches.ResetForReload();
+        var countBefore = RecordPatches.RegisteredBcAppPathsForTests().Count;
+
+        RecordPatches.AddBcAppPath(WriteApp(ReportsJson(AbaReportId, "BARE Aba Report", processingOnly: true)));
+        Assert.True(RecordPatches.IsDependencyReportProcessingOnly(AbaReportId),
+            "the registered .app states ProcessingOnly = 1, so this must be true — and it is what memoizes the set");
+
+        RecordPatches.ResetForReload();
+        RecordPatches.AddBcAppPath(WriteApp(ReportsJson(AbaReportId, "BARE Aba Report", processingOnly: null)));
+
+        // The ABA precondition, asserted rather than assumed: if the two registrations did
+        // not land on the same count, the assertion below would pass on the broken build
+        // too and prove nothing.
+        Assert.Equal(countBefore + 1, RecordPatches.RegisteredBcAppPathsForTests().Count);
+
+        // AL's default for a report that states no ProcessingOnly is false, and the only
+        // registered .app now states none.
+        Assert.False(RecordPatches.IsDependencyReportProcessingOnly(AbaReportId),
+            "the only registered .app declares no ProcessingOnly, so the answer must be AL's default");
+
+        // And the rebuild is a real rebuild, not an empty set: a third same-count swap back
+        // to a declaring .app answers true again.
+        RecordPatches.ResetForReload();
+        RecordPatches.AddBcAppPath(WriteApp(ReportsJson(AbaReportId, "BARE Aba Report", processingOnly: true)));
+        Assert.True(RecordPatches.IsDependencyReportProcessingOnly(AbaReportId));
+
+        // Negative arm: a report no registered .app declares is not processing-only.
+        Assert.False(RecordPatches.IsDependencyReportProcessingOnly(88123859));
+    }
+
+    /// <summary>
+    /// The SHRINK direction of the same generation key, isolated. The assertion sits BETWEEN
+    /// the roll and the next registration, deliberately: assert after re-registering and the
+    /// test passes on a build that only bumps the epoch on the GROW path, which is the half
+    /// <see cref="ADependencyProcessingOnlyAnswer_DoesNotSurviveASameCountSwapOfTheRegisteredApps"/>
+    /// and <see cref="AMissedTableId_IsResolvableAfterALaterAppDeclaresIt"/> already cover.
+    /// (Same trap, same reasoning, as DependencyMetadataMemoInvalidationTests' third test.)
+    ///
+    /// <para>Immediately after a roll no per-bundle .app is registered at all, so the only
+    /// honest answer for a report declared solely by bundle 1's .app is AL's default — and a
+    /// generation the roll did not move answers with bundle 1's set instead.</para>
+    /// </summary>
+    [Fact]
+    public void ADependencyProcessingOnlyAnswer_DoesNotSurviveTheRollThatUnregistersItsApp()
+    {
+        const int RollOnlyReportId = 88123853;
+
+        RecordPatches.ResetForReload();
+        var app = WriteApp(ReportsJson(RollOnlyReportId, "BARE Roll Only", processingOnly: true));
+        RecordPatches.AddBcAppPath(app);
+        Assert.True(RecordPatches.IsDependencyReportProcessingOnly(RollOnlyReportId),
+            "the registered .app states ProcessingOnly = 1 — this is the read that memoizes the set");
+
+        RecordPatches.ResetForReload();
+
+        // Precondition, asserted rather than assumed: the roll really did unregister the
+        // .app. Without it, a false below could mean the memo was rebuilt OR that the .app
+        // was never registered, and only the first is the claim.
+        Assert.DoesNotContain(
+            RecordPatches.RegisteredBcAppPathsForTests(),
+            p => string.Equals(p, app, StringComparison.OrdinalIgnoreCase));
+
+        Assert.False(RecordPatches.IsDependencyReportProcessingOnly(RollOnlyReportId),
+            "no .app declaring this report is registered any more, so the answer must be AL's default");
+    }
+
+    /// <summary>
+    /// Structural guard for the six remaining count-keyed generations, whose enumerators are
+    /// private and reachable only through the virtual-table provider path. Every one of them
+    /// now keys on the monotonic registration epoch instead, which cannot ABA.
+    ///
+    /// <para>This is a guard, not the proof — the proof is the test above, on the seventh
+    /// site with the identical expression. What this adds is that a future
+    /// <c>_bcAppPaths.Count</c> reintroduced into a generation key fails immediately rather
+    /// than waiting for someone to hit the ABA in a --watch session.</para>
+    /// </summary>
+    [Fact]
+    public void NoGenerationKeyUsesTheAppPathCount()
+    {
+        var patchesDir = Path.Combine(RepoRoot(), "AlRunner", "Patches");
+        Assert.True(Directory.Exists(patchesDir), $"expected the patches directory at {patchesDir}");
+
+        var offenders = new List<string>();
+        var files = Directory.GetFiles(patchesDir, "*.cs", SearchOption.AllDirectories);
+        Assert.NotEmpty(files);
+
+        foreach (var file in files)
+        {
+            var lines = File.ReadAllLines(file);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+                if (!line.Contains("_bcAppPaths.Count", StringComparison.Ordinal)) continue;
+                // A generation key is an ASSIGNMENT of the count into a comparison value.
+                // Diagnostic interpolations that merely REPORT how many .apps were scanned
+                // are fine and stay (two of them exist, in the trace lines of the table- and
+                // report-metadata builders).
+                var trimmed = line.TrimStart();
+                if (trimmed.StartsWith("//", StringComparison.Ordinal)
+                    || trimmed.StartsWith("///", StringComparison.Ordinal)
+                    || trimmed.StartsWith("*", StringComparison.Ordinal))
+                    continue;
+                if (!line.Contains("generation", StringComparison.OrdinalIgnoreCase)
+                    && !line.Contains("BuiltFrom", StringComparison.Ordinal))
+                    continue;
+                offenders.Add($"{Path.GetFileName(file)}:{i + 1}: {trimmed}");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "a cache generation must key on RecordPatches' registration EPOCH, never on _bcAppPaths.Count — "
+            + "a count cannot distinguish a set that lost N entries and gained N different ones (#2888):"
+            + Environment.NewLine + string.Join(Environment.NewLine, offenders));
+    }
+
+    // ── 3. NavReportSync._realMetaCache ──────────────────────────────────────
+
+    /// <summary>
+    /// The second-order memo: a null MetaReport memoized before the .app declaring that
+    /// report was registered must not survive the registration.
+    ///
+    /// <para>Observed through GetRealMetaReport's own stderr, which distinguishes the two
+    /// states exactly. With no metadata available anywhere the factory returns null at its
+    /// first branch and says nothing; with metadata available it always names the report id
+    /// — "built REAL MetaReport for report N" when the BC Types assembly is present in the
+    /// host, "real MetaReport build FAILED for report N" when it is not. So a second call
+    /// that produces NO line naming the id is a served memo, on either kind of host.</para>
+    ///
+    /// <para>The underlying dependency metadata is asserted non-null between the two calls,
+    /// so a green here cannot mean the second .app was unreadable and the answer was null
+    /// for an honest reason.</para>
+    /// </summary>
+    [Fact]
+    public void ANullRealMetaReport_DoesNotSurviveALaterAppDeclaringThatReport()
+    {
+        RecordPatches.AddBcAppPath(WriteApp(ReportsJson(UnrelatedReportId, "BARE Unrelated Report", null)));
+
+        string? first = null;
+        var beforeStderr = CaptureStderr(() => first = ObjectOrNull(() => NavReportSync.GetRealMetaReport(LateRealMetaReportId)));
+        Assert.Null(first);
+        Assert.DoesNotContain($"report {LateRealMetaReportId}", beforeStderr);
+
+        RecordPatches.AddBcAppPath(WriteApp(ReportsJson(LateRealMetaReportId, "BARE Late Real Meta", null)));
+
+        // Positive control: the memo #2944 fixed answers for this id now, so metadata IS
+        // available to the factory this test is about.
+        Assert.NotNull(RecordPatches.TryBuildDependencyReportMetadata(LateRealMetaReportId));
+
+        var afterStderr = CaptureStderr(() => NavReportSync.GetRealMetaReport(LateRealMetaReportId));
+        Assert.Contains($"MetaReport", afterStderr);
+        Assert.Contains($"report {LateRealMetaReportId}", afterStderr);
+    }
+
+    /// <summary>Reduce a MetaReport (or null) to a marker string, so the assertion above
+    /// never depends on the BC Types assembly being loadable in the test host.</summary>
+    private static string? ObjectOrNull(Func<object?> f) => f() == null ? null : "built";
+
+    private static string CaptureStderr(Action action)
+    {
+        var saved = Console.Error;
+        var buffer = new StringWriter();
+        try
+        {
+            Console.SetError(buffer);
+            action();
+        }
+        finally
+        {
+            Console.SetError(saved);
+        }
+        return buffer.ToString();
+    }
+
+    // Same locator BaseAppFloorFixtureGuardTests uses for the same reason: the test binary
+    // sits at <repo>/AlRunner.Tests/bin/<config>/<tfm>/.
+    private static string RepoRoot() => Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+}

--- a/AlRunner.Tests/DependencyMetadataMemoInvalidationTests.cs
+++ b/AlRunner.Tests/DependencyMetadataMemoInvalidationTests.cs
@@ -65,9 +65,17 @@ public sealed class DependencyMetadataMemoInvalidationTests : IDisposable
     }
 
     // Ids process-wide unique among AlRunner.Tests statics (_bcAppPaths and both memos are
-    // process-global and nothing in the test host unregisters an .app), and outside every
-    // neighbouring file's block: DependencyPageMetadataXmlTests owns 881234xx and
-    // DependencyReportProcessingOnlyTests owns 881236xx, so this file uses 881235xx.
+    // process-global and nothing in the test host unregisters an .app).
+    //
+    // The block boundaries are NOT as tidy as an earlier version of this comment claimed
+    // (#2888): DependencyPageMetadataXmlTests spans 881234xx AND 881235xx (88123501-503,
+    // 88123520-521, 88123593-599), so this file does not own 881235xx — it owns the five
+    // literals below, which are disjoint from every one of those. Verified, and there is no
+    // live collision; the correction is here because a wrong statement about shared
+    // process-global state is exactly the kind of unchecked claim that produced the memo bug
+    // this file tests. DependencyReportProcessingOnlyTests owns 881236xx,
+    // TableRelationWhereFieldLinkTests 881237xx, BcAppRegistrationEpochInvalidationTests
+    // 881238xx.
     private const int UnrelatedPageId = 88123510;
     private const int LatePageId = 88123511;
     private const int ReloadPageId = 88123512;

--- a/AlRunner/Patches/DependencyReportMetadata.cs
+++ b/AlRunner/Patches/DependencyReportMetadata.cs
@@ -120,10 +120,19 @@ public static partial class RecordPatches
     private static HashSet<int>? _depProcessingOnlyReportIds;
 
     /// <summary>
-    /// Generation the set above was built from. The registered-.app list grows as
-    /// dependencies load, and this question is first asked well before the last one is
-    /// registered, so a set memoized without this key would freeze an early, short answer
-    /// for the rest of the run.
+    /// Generation the set above was built from — RecordPatches' .app registration EPOCH. The
+    /// registered-.app list grows as dependencies load, and this question is first asked well
+    /// before the last one is registered, so a set memoized without this key would freeze an
+    /// early, short answer for the rest of the run.
+    ///
+    /// <para>It was <c>_bcAppPaths.Count</c> until #2888, and a count is a sound generation
+    /// only while the list cannot SHRINK — which it has been able to do since #2755 / PR
+    /// #2873 gave ResetForReload a real clear. One bundle out, one bundle in, same number of
+    /// .apps, and this comparison read "same generation" while every entry had changed:
+    /// bundle 2 was told a report is processing-only because bundle 1's .app said so, and
+    /// NavReportSync.TryRunOrControlFlow then skips the layout entirely. This is the one site
+    /// of the seven keyed on the bare count with no second term, which is why
+    /// BcAppRegistrationEpochInvalidationTests proves the ABA here.</para>
     /// </summary>
     private static int _depProcessingOnlyBuiltFrom = -1;
 
@@ -137,7 +146,7 @@ public static partial class RecordPatches
     /// </summary>
     internal static bool IsDependencyReportProcessingOnly(int reportId)
     {
-        var generation = _bcAppPaths.Count;
+        var generation = BcAppRegistrationEpoch;
         var set = _depProcessingOnlyReportIds;
         if (set == null || _depProcessingOnlyBuiltFrom != generation)
         {

--- a/AlRunner/Patches/RecordPatches.BcAppFallback.cs
+++ b/AlRunner/Patches/RecordPatches.BcAppFallback.cs
@@ -59,8 +59,38 @@ public static partial class RecordPatches
     private static bool _bcSymbolExtensionIndexBuilt;
     private static readonly object _bcTableIndexLock = new();
 
-    // Negative cache: tableIds we've already tried and not found.
+    // Negative cache: tableIds we've already tried and not found. DERIVED from the
+    // registered .app set, so InvalidateBcAppIndexes drops it with every other derived
+    // index — see the reasoning there (#2888).
     private static readonly HashSet<int> _bcMissCache = new();
+
+    // Monotonic registration epoch, bumped by InvalidateBcAppIndexes — i.e. exactly once per
+    // change to _bcAppPaths, in either direction, because that method is the single funnel
+    // both AddBcAppPath and ClearPerBundleBcAppPaths pass through.
+    //
+    // Why this exists (#2888). Seven caches elsewhere in RecordPatches memoize "which
+    // registration set was I built from" and used to spell that as _bcAppPaths.Count. A count
+    // is a sound generation only while the list cannot SHRINK — true until #2755 / PR #2873
+    // gave ResetForReload a real clear, and false since. A --server request or a --watch cycle
+    // that unregisters N .apps and registers N different ones leaves the count where it
+    // started, so the comparison reads "same generation" while the contents changed
+    // completely, and the previous bundle's rows are served for the new one. That is ABA, not
+    // staleness: no amount of extra tuple terms fixes it, because every one of them
+    // (_parsedTables, _parsedPages, _parsedReports, _parsedObjectDecls) is ALSO cleared and
+    // repopulated by the same reload, and in --watch mode — same bundle, one edited file —
+    // they all come back at the counts they had.
+    //
+    // A monotonic counter cannot ABA. It is read without the lock (an int read is atomic, and
+    // Volatile.Read pairs with the Interlocked.Increment below) because the generation checks
+    // are the fast path of every virtual-table row handout.
+    private static int _bcAppRegistrationEpoch;
+
+    /// <summary>
+    /// The current BC .app registration epoch — see <see cref="_bcAppRegistrationEpoch"/>.
+    /// Every cache whose contents are derived from <see cref="_bcAppPaths"/> keys its
+    /// generation on this, never on the list's Count.
+    /// </summary>
+    internal static int BcAppRegistrationEpoch => System.Threading.Volatile.Read(ref _bcAppRegistrationEpoch);
 
     /// <summary>
     /// Drop the PER-BUNDLE .app registrations and every index derived from them, so the next
@@ -156,6 +186,36 @@ public static partial class RecordPatches
         // duplicating them at each call site.
         _depPageMetadataXml.Clear();
         _depReportMetadataXml.Clear();
+        // #2888, instance 1: the negative table cache. It records "no registered .app declares
+        // table N" — derived from precisely this registration set, and until now dropped by
+        // nothing at all: not by this method, not by ResetForReload. So a miss taken by bundle
+        // 1 of a --server/--watch process was still answered "missing" for bundle 2, whose own
+        // dependency declares the table, for the rest of the process's life; and within a
+        // single run, a miss taken between two AddBcAppPath calls was never revisited even
+        // though this method is called after each one exactly so it would be. The symptom is
+        // TryPopulateParsedTableFromBcApps returning false with the table's symbols sitting
+        // readable in a registered .app — i.e. "no NCLMetaTable for table N", the same shape
+        // #2478 and #2712 produced from the neighbouring indexes.
+        _bcMissCache.Clear();
+        // #2888, instance 3: NavReportSync._realMetaCache is a SECOND-ORDER memo over
+        // _depReportMetadataXml two lines up — GetRealMetaReport GetOrAdds a MetaReport built
+        // from TryBuildDependencyReportMetadata's answer, and memoizes null when there is
+        // none. BcRuntime.ResetForNewBundleReload already clears it immediately before calling
+        // ResetForReload, so the SHRINK direction was covered end to end; the GROW direction
+        // was not, and a null memoized before the .app declaring the report was registered
+        // would mask the fix above for that one consumer. Its failure mode is quieter than the
+        // page memo's: GetRealMetaReport falls back to the legacy stub, which stamps
+        // ProcessingOnly, and BC then REFUSES SaveAs on a report that renders fine — a wrong
+        // refusal rather than a throw. Cleared here rather than at the AddBcAppPath call site
+        // for the same reason #2478 gave: one funnel cannot drift from the registration set.
+        // The explicit call in ResetForNewBundleReload stays — it also covers
+        // AlReportMetadataRegistry.Clear(), this memo's OTHER input, which is not derived from
+        // _bcAppPaths at all.
+        NavReportSync.ResetMetadataCache();
+        // Bumped LAST, and unconditionally: every cache keyed on the epoch must observe a
+        // value it has not built against, and everything above must already be dropped when
+        // it does.
+        System.Threading.Interlocked.Increment(ref _bcAppRegistrationEpoch);
     }
 
     /// <summary>

--- a/AlRunner/Patches/RecordPatches.BcAppFallback.cs
+++ b/AlRunner/Patches/RecordPatches.BcAppFallback.cs
@@ -211,6 +211,15 @@ public static partial class RecordPatches
         // The explicit call in ResetForNewBundleReload stays — it also covers
         // AlReportMetadataRegistry.Clear(), this memo's OTHER input, which is not derived from
         // _bcAppPaths at all.
+        //
+        // The PAGE-side twin of this instance — EnsureRealPageMetadata's _pagesWithRealMetadata
+        // / _pagesRealMetadataFailed plus the _metaFormCache entry a failed load leaves behind
+        // — is deliberately NOT cleared here, and is tracked in #3011. Same asymmetry (shrink
+        // covered by ResetPageMetadataForReload, grow not), but it is latent rather than live:
+        // every EnsureRealPageMetadata caller is on the test-execution path, which runs after
+        // registration completes. And unlike this one line, the fix is not free — clearing
+        // _metaFormCache once per registered .app has a real blast radius, and #1957 requires
+        // the two sets and the NCLMetaForm instances they describe to be discarded together.
         NavReportSync.ResetMetadataCache();
         // Bumped LAST, and unconditionally: every cache keyed on the epoch must observe a
         // value it has not built against, and everything above must already be dropped when

--- a/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
@@ -92,7 +92,13 @@ public static partial class RecordPatches
     private sealed record CodeunitMetaRow(int Id, string Name, int TableNo, bool SingleInstance, string Subtype);
 
     private static List<CodeunitMetaRow>? _codeunitMetaRows;
-    private static (int Apps, int Decls) _codeunitMetaRowsBuiltFrom = (-1, -1);
+    // The .app term is RecordPatches' registration EPOCH, never _bcAppPaths.Count (#2888):
+    // the registered set can SHRINK since #2755 / PR #2873, so a count cannot tell a set that
+    // lost N entries and gained N different ones from the one it was built against — and in
+    // --watch mode (same bundle, one edited file) that is the NORMAL case, not a corner. The
+    // remaining terms stay counts and are sound as counts, because the dictionaries they count
+    // are only ever cleared by ResetForReload, which bumps the epoch in the same breath.
+    private static (int Epoch, int Decls) _codeunitMetaRowsBuiltFrom = (-1, -1);
     private static readonly object _codeunitMetaRowsLock = new();
 
     // Resolved once per process from the parsed CodeUnit Metadata metatable's own "Subtype"
@@ -165,11 +171,11 @@ public static partial class RecordPatches
     /// </summary>
     private static List<CodeunitMetaRow> EnumerateKnownCodeunitMetadata()
     {
-        var generation = (_bcAppPaths.Count, _parsedObjectDecls.Count);
+        var generation = (BcAppRegistrationEpoch, _parsedObjectDecls.Count);
         if (_codeunitMetaRows != null && _codeunitMetaRowsBuiltFrom == generation) return _codeunitMetaRows;
         lock (_codeunitMetaRowsLock)
         {
-            generation = (_bcAppPaths.Count, _parsedObjectDecls.Count);
+            generation = (BcAppRegistrationEpoch, _parsedObjectDecls.Count);
             if (_codeunitMetaRows != null && _codeunitMetaRowsBuiltFrom == generation) return _codeunitMetaRows;
 
             var rows = new Dictionary<int, CodeunitMetaRow>();

--- a/AlRunner/Patches/RecordPatches.PageControlFieldVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.PageControlFieldVirtualTable.cs
@@ -78,7 +78,13 @@ public static partial class RecordPatches
         string Enabled, string Editable, string Visible, string SourceExpression, int Sequence);
 
     private static List<PageControlFieldRow>? _pageControlFieldRows;
-    private static (int Apps, int Parsed) _pageControlFieldRowsBuiltFrom = (-1, -1);
+    // The .app term is RecordPatches' registration EPOCH, never _bcAppPaths.Count (#2888):
+    // the registered set can SHRINK since #2755 / PR #2873, so a count cannot tell a set that
+    // lost N entries and gained N different ones from the one it was built against — and in
+    // --watch mode (same bundle, one edited file) that is the NORMAL case, not a corner. The
+    // remaining terms stay counts and are sound as counts, because the dictionaries they count
+    // are only ever cleared by ResetForReload, which bumps the epoch in the same breath.
+    private static (int Epoch, int Parsed) _pageControlFieldRowsBuiltFrom = (-1, -1);
     private static readonly object _pageControlFieldRowsLock = new();
 
     private static void PopulatePageControlFieldVirtualTable(object dataAccess, NCLMetaTable metaTable)
@@ -126,11 +132,11 @@ public static partial class RecordPatches
 
     private static List<PageControlFieldRow> EnumerateKnownPageControlFields()
     {
-        var generation = (_bcAppPaths.Count, _parsedPages.Count);
+        var generation = (BcAppRegistrationEpoch, _parsedPages.Count);
         if (_pageControlFieldRows != null && _pageControlFieldRowsBuiltFrom == generation) return _pageControlFieldRows;
         lock (_pageControlFieldRowsLock)
         {
-            generation = (_bcAppPaths.Count, _parsedPages.Count);
+            generation = (BcAppRegistrationEpoch, _parsedPages.Count);
             if (_pageControlFieldRows != null && _pageControlFieldRowsBuiltFrom == generation) return _pageControlFieldRows;
 
             var rows = new List<PageControlFieldRow>();

--- a/AlRunner/Patches/RecordPatches.PageMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.PageMetadataVirtualTable.cs
@@ -101,7 +101,13 @@ public static partial class RecordPatches
         int CardPageId);
 
     private static List<PageMetaRow>? _pageMetaRows;
-    private static (int Apps, int Parsed) _pageMetaRowsBuiltFrom = (-1, -1);
+    // The .app term is RecordPatches' registration EPOCH, never _bcAppPaths.Count (#2888):
+    // the registered set can SHRINK since #2755 / PR #2873, so a count cannot tell a set that
+    // lost N entries and gained N different ones from the one it was built against — and in
+    // --watch mode (same bundle, one edited file) that is the NORMAL case, not a corner. The
+    // remaining terms stay counts and are sound as counts, because the dictionaries they count
+    // are only ever cleared by ResetForReload, which bumps the epoch in the same breath.
+    private static (int Epoch, int Parsed) _pageMetaRowsBuiltFrom = (-1, -1);
     private static readonly object _pageMetaRowsLock = new();
 
     // Resolved once per process from the parsed Page Metadata metatable's own "PageType"
@@ -179,11 +185,11 @@ public static partial class RecordPatches
     /// </summary>
     private static List<PageMetaRow> EnumerateKnownPageMetadata()
     {
-        var generation = (_bcAppPaths.Count, _parsedPages.Count);
+        var generation = (BcAppRegistrationEpoch, _parsedPages.Count);
         if (_pageMetaRows != null && _pageMetaRowsBuiltFrom == generation) return _pageMetaRows;
         lock (_pageMetaRowsLock)
         {
-            generation = (_bcAppPaths.Count, _parsedPages.Count);
+            generation = (BcAppRegistrationEpoch, _parsedPages.Count);
             if (_pageMetaRows != null && _pageMetaRowsBuiltFrom == generation) return _pageMetaRows;
 
             var rows = new Dictionary<int, PageMetaRow>();

--- a/AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs
@@ -118,7 +118,13 @@ public static partial class RecordPatches
     // build-once cache did: report 1306 stayed invisible while the bundle's own
     // reports resolved fine).
     private static List<ReportRow>? _reportRows;
-    private static (int Apps, int Parsed) _reportRowsBuiltFrom = (-1, -1);
+    // The .app term is RecordPatches' registration EPOCH, never _bcAppPaths.Count (#2888):
+    // the registered set can SHRINK since #2755 / PR #2873, so a count cannot tell a set that
+    // lost N entries and gained N different ones from the one it was built against — and in
+    // --watch mode (same bundle, one edited file) that is the NORMAL case, not a corner. The
+    // remaining terms stay counts and are sound as counts, because the dictionaries they count
+    // are only ever cleared by ResetForReload, which bumps the epoch in the same breath.
+    private static (int Epoch, int Parsed) _reportRowsBuiltFrom = (-1, -1);
     private static readonly object _reportRowsLock = new();
 
     /// <summary>
@@ -270,11 +276,11 @@ public static partial class RecordPatches
     /// </summary>
     private static List<ReportRow> EnumerateKnownReports()
     {
-        var generation = (_bcAppPaths.Count, _parsedReports.Count);
+        var generation = (BcAppRegistrationEpoch, _parsedReports.Count);
         if (_reportRows != null && _reportRowsBuiltFrom == generation) return _reportRows;
         lock (_reportRowsLock)
         {
-            generation = (_bcAppPaths.Count, _parsedReports.Count);
+            generation = (BcAppRegistrationEpoch, _parsedReports.Count);
             if (_reportRows != null && _reportRowsBuiltFrom == generation) return _reportRows;
 
             var rows = new Dictionary<int, ReportRow>();
@@ -395,12 +401,18 @@ public static partial class RecordPatches
     // Assembly count is part of the generation: a Tier-1 precompiled dependency's reports
     // only become knowable once its DLL is loaded, which happens AFTER this set is first
     // asked for. Without it the empty answer would be memoized for the whole run.
-    private static (int Apps, int Parsed, int Assemblies) _knownReportIdsBuiltFrom = (-1, -1, -1);
+    // The .app term is RecordPatches' registration EPOCH, never _bcAppPaths.Count (#2888):
+    // the registered set can SHRINK since #2755 / PR #2873, so a count cannot tell a set that
+    // lost N entries and gained N different ones from the one it was built against — and in
+    // --watch mode (same bundle, one edited file) that is the NORMAL case, not a corner. The
+    // remaining terms stay counts and are sound as counts, because the dictionaries they count
+    // are only ever cleared by ResetForReload, which bumps the epoch in the same breath.
+    private static (int Epoch, int Parsed, int Assemblies) _knownReportIdsBuiltFrom = (-1, -1, -1);
 
     /// <summary>Memoized backing set, rebuilt on the same generation key as the row cache.</summary>
     internal static HashSet<int> KnownReportIdSet()
     {
-        var generation = (_bcAppPaths.Count, _parsedReports.Count,
+        var generation = (BcAppRegistrationEpoch, _parsedReports.Count,
             AppDomain.CurrentDomain.GetAssemblies().Length);
         if (_knownReportIds != null && _knownReportIdsBuiltFrom == generation) return _knownReportIds;
 

--- a/AlRunner/Patches/RecordPatches.TableMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.TableMetadataVirtualTable.cs
@@ -103,7 +103,13 @@ public static partial class RecordPatches
     // would permanently hide every Base Application table — the same trap the Report
     // Metadata provider documents.
     private static List<TableMetadataRow>? _tableMetadataRows;
-    private static (int Apps, int Parsed, int Pages) _tableMetadataRowsBuiltFrom = (-1, -1, -1);
+    // The .app term is RecordPatches' registration EPOCH, never _bcAppPaths.Count (#2888):
+    // the registered set can SHRINK since #2755 / PR #2873, so a count cannot tell a set that
+    // lost N entries and gained N different ones from the one it was built against — and in
+    // --watch mode (same bundle, one edited file) that is the NORMAL case, not a corner. The
+    // remaining terms stay counts and are sound as counts, because the dictionaries they count
+    // are only ever cleared by ResetForReload, which bumps the epoch in the same breath.
+    private static (int Epoch, int Parsed, int Pages) _tableMetadataRowsBuiltFrom = (-1, -1, -1);
     private static readonly object _tableMetadataRowsLock = new();
 
     /// <summary>
@@ -248,11 +254,11 @@ public static partial class RecordPatches
     /// </summary>
     private static List<TableMetadataRow> EnumerateKnownTableMetadata()
     {
-        var generation = (_bcAppPaths.Count, _parsedTables.Count, _parsedPages.Count);
+        var generation = (BcAppRegistrationEpoch, _parsedTables.Count, _parsedPages.Count);
         if (_tableMetadataRows != null && _tableMetadataRowsBuiltFrom == generation) return _tableMetadataRows;
         lock (_tableMetadataRowsLock)
         {
-            generation = (_bcAppPaths.Count, _parsedTables.Count, _parsedPages.Count);
+            generation = (BcAppRegistrationEpoch, _parsedTables.Count, _parsedPages.Count);
             if (_tableMetadataRows != null && _tableMetadataRowsBuiltFrom == generation) return _tableMetadataRows;
 
             // Built once and closed over below rather than through ResolvePageReference's own


### PR DESCRIPTION
Closes #2888

Three siblings of the memo #2944 fixed, all derived from `RecordPatches._bcAppPaths`, none of them dropped when that set changes. #2944 deliberately left them alone because they are this issue's scope. Reachability was established **per instance** and they are not the same story.

Items 1 and 4 of the issue body (the SystemApp package surviving the clear, and enum re-registration) landed with #2873 and are not touched here.

## 1. `_bcMissCache` — LIVE, one direction, two routes

`RecordPatches.BcAppFallback.cs:63`, the negative cache recording "no registered `.app` declares table N". It was cleared by **nothing at all** — not `AddBcAppPath`, not `InvalidateBcAppIndexes`, not `ResetForReload`.

- **Grow, within one run.** `AddBcAppPath` ends in `InvalidateBcAppIndexes()` precisely so a "newly-added `.app` gets picked up on next miss". Every index derived from `_bcAppPaths` was dropped there; this one was not, so a miss taken between two registrations was never revisited.
- **Grow, across a bundle roll.** This is the route that needs no assumption about intra-run call ordering. `ResetForReload` clears `_parsedTables` and unregisters bundle 1's `.app`s, so every miss bundle 1 took has to be retaken against bundle 2's registrations — and nothing cleared the miss cache on that path either. A table id that missed under bundle 1 stayed permanently missing for bundle 2..N of a `--server`/`--watch` process, with the table's symbols sitting readable in a registered `.app`.

Only the negative direction is defective: a stale negative after a *shrink* is still the correct answer, so there is nothing to fix there.

Symptom is `no NCLMetaTable for table N` — the same shape #2478 and #2712 produced from the neighbouring indexes.

## 2. The seven `_bcAppPaths.Count`-keyed generations — LIVE, and measured rather than argued

`_tableMetadataRowsBuiltFrom`, `_pageMetaRowsBuiltFrom`, `_pageControlFieldRowsBuiltFrom`, `_reportRowsBuiltFrom`, `_knownReportIdsBuiltFrom`, `_codeunitMetaRowsBuiltFrom`, and `_depProcessingOnlyBuiltFrom`.

A count is a sound generation only while the list cannot shrink. It could not until PR #2873 gave `ResetForReload` a real clear; it can now. One bundle out, one bundle in, same number of `.app`s, and the comparison reads "same generation" while every entry changed — **ABA, not staleness**.

Two facts make this live rather than theoretical:

- **`ResetForReload` does not clear any of the seven caches.** Grepped for each field name in `RecordPatches.cs`: no hits. The count-keyed generation is the *only* thing standing between a bundle roll and stale rows.
- **In `--watch` mode the whole tuple ABAs, not just the `.app` term.** Same bundle, one edited file: the `.app` count is identical by construction, and `_parsedTables` / `_parsedPages` / `_parsedReports` / `_parsedObjectDecls` are cleared and repopulated to the counts they had. So an edit that changes a table's fields without changing object counts serves the previous cycle's rows.

Measured, not asserted: `ADependencyProcessingOnlyAnswer_DoesNotSurviveASameCountSwapOfTheRegisteredApps` fails on `main` at the `Assert.False`, having been told a report is `ProcessingOnly` because the *previous* registration set said so. `_depProcessingOnlyBuiltFrom` is the one site keyed on the bare count with no second tuple term to confound the measurement, which is why the proof lives there; the other six are the identical expression and their enumerators are private, reachable only through the virtual-table provider path.

The fix is a monotonic epoch bumped inside `InvalidateBcAppIndexes()` — the single funnel both `AddBcAppPath` and `ClearPerBundleBcAppPaths` already pass through — substituted at the twelve `generation = ...` sites. Rebuild count is unchanged: every registration that used to move the count now moves the epoch.

The remaining tuple terms stay counts and are sound as counts, because the dictionaries they count are only ever cleared by `ResetForReload`, which bumps the epoch in the same breath.

## 3. `NavReportSync._realMetaCache` — LATENT, and said so rather than dressed up

A second-order memo: `GetRealMetaReport` `GetOrAdd`s a `MetaReport` built from `TryBuildDependencyReportMetadata`'s answer — the memo #2944 just fixed — and memoizes `null` when there is none.

- **Shrink: already covered.** `BcRuntime.cs:537` clears it immediately before `ResetForReload`.
- **Grow: was not covered**, so a null memoized before a registration masks #2944's fix for this one consumer.

**Reachability, checked rather than assumed: latent today.** `GetRealMetaReport` is reached during report execution, and `Program.cs` completes dependency registration (2354/2357 on the CLI path, 4578/4579 on the server path) before any test runs. There is no ordering in the current code that produces the miss-then-register sequence inside one bundle. It is fixed as cheap insurance — three lines in the funnel it should always have been in — not because anyone has hit it.

Its failure mode is the quiet one and worth recording: `GetRealMetaReport` falls through to the legacy stub stamping `ProcessingOnly`, so BC **refuses `SaveAs`** on a report that renders fine — a wrong refusal rather than a throw.

## Fixing the shape, not the reported line

**Same wrong pattern at another call site?** Every remaining `_bcAppPaths` consumer does a live `foreach (var appPath in _bcAppPaths.ToArray())`, not a memo. The only two surviving `_bcAppPaths.Count` uses are diagnostic trace interpolations (`RecordPatches.TableMetadataVirtualTable.cs:233`, `RecordPatches.ReportMetadataVirtualTable.cs:371`), which are correct as counts and stay. `RegisteredBcAppSymbolStateKey` hashes contents and was already sound.

**Does a sibling function make the same assumption? Yes — one, and it is filed rather than fixed.** `EnsureRealPageMetadata`'s `_pagesWithRealMetadata` / `_pagesRealMetadataFailed`, plus the `_metaFormCache` entry a failed load leaves behind, are the exact page-side twin of instance 3: shrink covered by `ResetPageMetadataForReload`, grow not covered. It is **latent** for the same measured reason (all five callers — `TestPageFactory` ×2, `RunnerPageInstance` ×2, and `GetMetaApplicationObject`'s `Page` branch — are on the test-execution path), and the fix is not free: clearing `_metaFormCache` once per registered `.app` has real blast radius, and #1957 requires the two sets and the `NCLMetaForm` instances they describe to be discarded together, so a half fix is worse than none. Filed as **#3011** and cross-referenced in the funnel's comment.

**Do two writers of the same state keep the same invariant?** `AddBcAppPath` and `ClearPerBundleBcAppPaths` are the only writers of `_bcAppPaths`, and both now funnel through `InvalidateBcAppIndexes`. That is the invariant, and it is the same argument #2478 gave for funnelling the index resets.

Deliberately not touched: `_bcQuerySymbolJsonPaths`, the sibling accumulating list already called out in `ResetForReload`'s comment and tracked in #2939.

## RED → GREEN

Six tests in `AlRunner.Tests/BcAppRegistrationEpochInvalidationTests.cs`. All six RED on the merge base, each with the failure its claim predicts:

| test | RED on `main` |
|---|---|
| `AMissedTableId_IsResolvableAfterALaterAppDeclaresIt` | `Assert.Equal() Failure: Expected 42, Actual null` |
| `AMissedTableId_DoesNotSurviveTheBundleRollIntoABundleThatDeclaresIt` | same, at the post-roll resolve |
| `ADependencyProcessingOnlyAnswer_DoesNotSurviveASameCountSwapOfTheRegisteredApps` | `Assert.False` — the ABA |
| `ADependencyProcessingOnlyAnswer_DoesNotSurviveTheRollThatUnregistersItsApp` | `Assert.False` — the shrink |
| `ANullRealMetaReport_DoesNotSurviveALaterAppDeclaringThatReport` | stderr empty, no `MetaReport` line |
| `NoGenerationKeyUsesTheAppPathCount` | lists all twelve offending lines |

GREEN after the fix: 6/6.

**Each test was checked against a build where only ONE funnel direction clears**, by hoisting the new clears + the epoch bump out of `InvalidateBcAppIndexes` into a helper and wiring it to one call site at a time:

- **grow-only build** → fails exactly `ADependencyProcessingOnlyAnswer_DoesNotSurviveTheRollThatUnregistersItsApp` (1 failed, 5 passed).
- **shrink-only build** → fails exactly `AMissedTableId_IsResolvableAfterALaterAppDeclaresIt` and `ANullRealMetaReport_DoesNotSurviveALaterAppDeclaringThatReport` (2 failed, 4 passed).

The two tests that pass under both partials do so by construction — they traverse a roll *and* a registration, so a bump on either path breaks them — and they are kept for the route they document, not as direction evidence. That is stated here rather than left for a reviewer to work out.

The shrink test asserts **between** the roll and the next registration, deliberately: asserting after re-registration would pass on a grow-only build. Same trap, same reasoning, as #2944's third test.

Every test asserts concrete values (field id `42`, field id `7`, field id `1`, `true`/`false` on a specific report id) with negative arms — an unknown field, an undeclared table, an undeclared report — so a fix that simply stopped consulting the caches, or answered for anything asked about, fails.

## Tests run

- The six above, RED → GREEN, plus both one-direction-only builds.
- Filtered `AlRunner.Tests` over the changed surface — 165 passed, 2 skipped (they need BC artifacts absent locally; CI runs them): `BcAppRegistrationEpochInvalidation`, `DependencyMetadataMemoInvalidation`, `DependencyReportProcessingOnly`, `DependencyPageMetadataXml`, `DependencyPageShapeResolution`, `RecordPatchesWarmReloadExtensionIndex`, `RecordPatchesBcAppSymbolReadFailure`, `RecordPatchesPrecompiledTableExtEviction`, `ParserStaticsIsolationGuard`, `CodeunitMetadataVirtualTable`, `VirtualTableRefusalClaim`, `TableRelationWhereFieldLink`, `RecordPatchesGetPageControlFieldMapDependency`.
- Re-run after rebasing onto `c9c4c463` rather than carried across it.

Not run: the full `AlRunner.Tests` suite and the AL corpus — CI does both on all eight legs.

## Does any of this belong upstream in the corpus?

**No, and instance 3 was checked separately rather than inheriting #2944's answer**, because its observable really is different: a refused `SaveAs` is something AL can see, where #2944's observables (a synthesized XML document, a stderr line) are not.

What AL cannot express is the runner-internal ordering that produces the refusal — a `GetRealMetaReport` miss *before* the `.app` declaring the report is registered, inside one process. On a service tier there is no registration order, no `_bcAppPaths`, and no memo; the metadata is simply there. An AL test would assert "a dependency report that is not processing-only supports `SaveAs`", which is plain BC behaviour, already pinned upstream (`handlers/RreProcessingOnlyReport.Report.al`, `handlers/TestReportSaveAsStream.al`), and green on the runner both before and after this change — it cannot distinguish the builds.

The same holds for instances 1 and 2: every claim here is about cache lifetime across a registration-set change inside one runner process, which `.claude/rules/bc-behavior-tests-go-upstream.md` names as explicitly runner-specific multi-bundle/server-mode wiring. Nothing in this PR asserts anything new about what BC does, so there is no claim for a service tier to adjudicate and no submodule pin to bump.

## Other notes

- **Also corrected:** the id-block comment in `DependencyMetadataMemoInvalidationTests.cs` claimed `DependencyPageMetadataXmlTests` owns `881234xx`. That class spans `881234xx` **and** `881235xx` (`88123501-503`, `88123520-521`, `88123593-599`). No live collision — the literals are disjoint, verified — but a wrong statement about shared process-global state is the same unchecked claim that produced the memo bug. This file uses `881238xx`.
- No user-visible behaviour change, so `README.md`, `PrintGuide()`, `docs/limitations.md` and `docs/scope.md` are unchanged.
- `tests/expectations/count-baseline/test-count-baseline.json` deliberately untouched — no AL tests added.

---
Implemented by an automated agent (`agent: stma-auto-1`) acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
