### PR TITLE
fix(permission-metadata): refuse loudly when a BC member behind a null-forgiving read has moved

### DIFF
--- a/AlRunner.Tests/PermissionMetadataNullForgivingGuardTests.cs
+++ b/AlRunner.Tests/PermissionMetadataNullForgivingGuardTests.cs
@@ -1,0 +1,378 @@
+// PermissionMetadataNullForgivingGuardTests — the `!` half of the permission-metadata slice (#3046).
+//
+// WHAT #3034 LEFT, AND WHY ITS SWEEP COULD NOT SEE IT
+//   #3034 converted 56 of the 61 InvalidOperationException refusals in
+//   RecordPatches.PermissionMetadataPopulator.cs to BcShapeGapException, and its header says
+//   every refusal in the file was read and classified. That claim is true as written — but its
+//   search shape was `throw new InvalidOperationException`, and five BC-internals reads in the
+//   same file are not `throw` sites at all. They are null-forgiving `!` operators:
+//
+//     _tNavAppGroupPM!.GetProperty("PermissionSetGroupObjectMetadataSummaries", ...)!
+//     lazyType.GetGenericArguments()[0]                       (permissionSetLookup's LazyEx<T>)
+//     dictType.GetMethod("Add")!                              (that LazyEx's dictionary)
+//     _tSummary!.GetProperty("ObjectName", ...)!
+//     _tMetaPermissionSet.GetProperty("Included/ExcludedPermissionSets")!   (x2)
+//
+//   `!` is a compiler annotation and throws nothing by itself, so a member Microsoft moves does
+//   not fail at the lookup: the lookup hands back a silent null, and the NullReferenceException
+//   lands at the first USE of it (.PropertyType, .Invoke, .GetValue). The generic-argument read
+//   is the one that does fail on the spot, with IndexOutOfRangeException. Neither says which
+//   member moved, which is the message #3034 exists to produce.
+//
+// THE INVERSION, WHICH IS THE POINT
+//   MethodScopePatches.NavMethodScope_AssertError is an unfiltered catch(Exception), so it
+//   swallows an NRE exactly as it swallowed the retired InvalidOperationException: AL sees an
+//   absent or default answer and `asserterror` PASSES, while real BC reads the member fine and
+//   would have failed it. The AssertError/TryFunction arms below fail on a pre-fix build with
+//   "No exception was thrown" — that failure IS the inversion, and it is what the guards remove.
+//
+// THE INCLUDED/EXCLUDED PAIR IS THE SHARPEST OF THE FIVE
+//   SetProperty(mps, "IncludedPermissionSets", ...) WAS converted by #3034 — but the unguarded
+//   GetProperty("IncludedPermissionSets")! is an ARGUMENT to that call, so it evaluates first
+//   and the new guard on the very same property is unreachable through that path. The
+//   source-shape arm at the bottom is what keeps a future edit from reintroducing that.
+//
+// HOW THESE ARE DRIVEN
+//   Two ways, both against real production code and neither needing a BC install:
+//     * directly, with a fake type standing in for a BC type whose member moved — the shape
+//       PermissionMetadataShapeGapTests' four arms already use, since the helpers take the
+//       declaring type as a PARAMETER; and
+//     * through InstallFreshPermissionSetLookup itself, by injecting a fake into the cached
+//       reflection statics for one call and restoring them in a finally (#3041's shape) — so
+//       the refusal is proved on the real call path, not only on the helper.
+//   Every refusal arm is paired with a control arm that still succeeds, so a guard that threw
+//   unconditionally would fail here rather than pass.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PermissionMetadataNullForgivingGuardTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private const BindingFlags Priv = BindingFlags.NonPublic | BindingFlags.Static;
+
+    // ══ 1. RequireBcProperty — MetaPermissionSet.IncludedPermissionSets et al ════════════
+
+    [Fact]
+    public void RequireBcProperty_RaisesAShapeGapNamingTheMember_WhenBcsPropertyHasMoved()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Invoke("RequireBcProperty", typeof(FakeMetaPermissionSetWithoutIncludes), "IncludedPermissionSets"));
+
+        Assert.Equal("Permission metadata (NavAppGroup permission-set inventory)", ex.Surface);
+        Assert.Equal($"{nameof(FakeMetaPermissionSetWithoutIncludes)}.IncludedPermissionSets", ex.Member);
+        Assert.Contains("property not found", ex.Detail, StringComparison.Ordinal);
+        Assert.StartsWith("bc-shape-gap: ", ex.Message, StringComparison.Ordinal);
+        Assert.EndsWith(" — see docs/limitations.md#bc-shape-gaps", ex.Message, StringComparison.Ordinal);
+    }
+
+    // CONTROL: the property that IS there is still returned, with its real PropertyType — the
+    // value BuildIncludeList is handed at the call site.
+    [Fact]
+    public void RequireBcProperty_StillReturnsTheProperty_AndItsElementType_WhenPresent()
+    {
+        var prop = (PropertyInfo)Invoke("RequireBcProperty",
+            typeof(FakeMetaPermissionSet), "IncludedPermissionSets")!;
+
+        Assert.Equal("IncludedPermissionSets", prop.Name);
+        Assert.Equal(typeof(List<int>), prop.PropertyType);
+    }
+
+    // A non-public property still resolves: BC declares these publicly today, and SetProperty —
+    // which writes the very same member — has always looked with NonPublic too. The argument
+    // read used the default flags and so could have missed what the write then found.
+    [Fact]
+    public void RequireBcProperty_FindsANonPublicProperty_SoTheReadAndTheWriteAgree()
+    {
+        var prop = (PropertyInfo)Invoke("RequireBcProperty",
+            typeof(FakeMetaPermissionSet), "HiddenPermissionSets")!;
+
+        Assert.Equal(typeof(List<string>), prop.PropertyType);
+    }
+
+    // ══ 2. RequireBcMethod — the lookup dictionary's Add ═════════════════════════════════
+
+    [Fact]
+    public void RequireBcMethod_RaisesAShapeGapNamingTheMember_WhenTheMethodHasMoved()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Invoke("RequireBcMethod", typeof(NoAddCollection), "Add"));
+
+        Assert.Equal($"{nameof(NoAddCollection)}.Add", ex.Member);
+        Assert.Contains("method not found", ex.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RequireBcMethod_StillReturnsTheMethod_WhenPresent()
+    {
+        var m = (MethodInfo)Invoke("RequireBcMethod", typeof(Dictionary<string, object>), "Add")!;
+
+        Assert.Equal("Add", m.Name);
+        Assert.Equal(2, m.GetParameters().Length);
+    }
+
+    // ══ 3. RequireBcLookupDictionaryType — permissionSetLookup's LazyEx<T> ═══════════════
+
+    [Fact]
+    public void RequireBcLookupDictionaryType_RaisesAShapeGapNamingTheField_WhenTheFieldIsNotAOneArgumentGeneric()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Invoke("RequireBcLookupDictionaryType", typeof(string)));
+
+        Assert.Equal("NavAppGroup.permissionSetLookup", ex.Member);
+        Assert.Contains("String", ex.Detail, StringComparison.Ordinal);
+        Assert.Contains("LazyEx<T>", ex.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RequireBcLookupDictionaryType_StillUnwrapsTheDictionary_ForTheShapeBcDeclares()
+    {
+        var dictType = (Type)Invoke("RequireBcLookupDictionaryType",
+            typeof(FakeLazy<Dictionary<string, object>>))!;
+
+        Assert.Equal(typeof(Dictionary<string, object>), dictType);
+    }
+
+    // ══ 4. THE INVERSION — both AL seams, on all three guards ═══════════════════════════
+    //
+    // Measured on the pre-fix build: every one of these fails with "Assert.Throws() Failure: No
+    // exception was thrown", because the seam swallowed the NullReferenceException /
+    // IndexOutOfRangeException and AL's asserterror PASSED on a read real BC performs fine. That
+    // failure text is the inversion, and removing it is what the guards are for.
+
+    public static TheoryData<string, string> UnreadableMembers() => new()
+    {
+        { "IncludedPermissionSets", "FakeMetaPermissionSetWithoutIncludes.IncludedPermissionSets" },
+        { "ExcludedPermissionSets", "FakeMetaPermissionSetWithoutIncludes.ExcludedPermissionSets" },
+        { "ObjectName",             "NoAddCollection.ObjectName" },
+        { "Add",                    "NoAddCollection.Add" },
+        { "permissionSetLookup",    "NavAppGroup.permissionSetLookup" },
+    };
+
+    /// <summary>
+    /// Drive the production helper whose BC member the named case has moved, AND dereference
+    /// what it hands back exactly as the call site does. The dereference is the point: `!` is a
+    /// compiler annotation and throws nothing by itself, so a pre-fix build gets a silent null
+    /// out of the lookup and NREs at the first use of it — <c>.PropertyType</c> fed to
+    /// BuildIncludeList, <c>.Invoke</c> on the dictionary's Add, <c>.GetValue</c> on the
+    /// summary. That NRE is what the seam then swallows.
+    /// </summary>
+    private static object? ReadMovedMember(string @case) => @case switch
+    {
+        "IncludedPermissionSets" => ((PropertyInfo)Invoke("RequireBcProperty", typeof(FakeMetaPermissionSetWithoutIncludes), "IncludedPermissionSets")!).PropertyType,
+        "ExcludedPermissionSets" => ((PropertyInfo)Invoke("RequireBcProperty", typeof(FakeMetaPermissionSetWithoutIncludes), "ExcludedPermissionSets")!).PropertyType,
+        "ObjectName"             => ((PropertyInfo)Invoke("RequireBcProperty", typeof(NoAddCollection), "ObjectName")!).Name,
+        "Add"                    => ((MethodInfo)Invoke("RequireBcMethod", typeof(NoAddCollection), "Add")!).Name,
+        "permissionSetLookup"    => Invoke("RequireBcLookupDictionaryType", typeof(string)),
+        _ => throw new InvalidOperationException($"test setup: unknown case {@case}"),
+    };
+
+    [Theory]
+    [MemberData(nameof(UnreadableMembers))]
+    public void AssertError_TearsThrough_InsteadOfSwallowingTheNullForgivingFailure(string @case, string member)
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => BcRuntime.NavMethodScope_AssertError(null!, () => ReadMovedMember(@case)));
+
+        Assert.Equal("Permission metadata (NavAppGroup permission-set inventory)", ex.Surface);
+        Assert.Equal(member, ex.Member);
+    }
+
+    [Theory]
+    [MemberData(nameof(UnreadableMembers))]
+    public void TryFunction_TearsThrough_InsteadOfSwallowingTheNullForgivingFailure(string @case, string member)
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => BcRuntime.NavApplicationObjectBase_TryInvoke(null, () => ReadMovedMember(@case)));
+
+        Assert.Equal("Permission metadata (NavAppGroup permission-set inventory)", ex.Surface);
+        Assert.Equal(member, ex.Member);
+    }
+
+    // CONTROL: the seams still trap what they are supposed to trap, so "tears through" above is
+    // a statement about BcShapeGapException and not about a seam that catches nothing.
+    [Fact]
+    public void BothSeams_StillTrapAPermanentRefusal_SoTearThroughIsNotVacuous()
+    {
+        Assert.False(BcRuntime.NavApplicationObjectBase_TryInvoke(
+            null, () => throw new RunnerOutOfScopeException(
+                "NavEmail.Send", "email-smtp — no SMTP transport in the runner", "email")));
+
+        BcRuntime.NavMethodScope_AssertError(null!, () => throw new RunnerOutOfScopeException(
+            "NavEmail.Send", "email-smtp — no SMTP transport in the runner", "email"));
+    }
+
+    // ══ 5. The real call path — InstallFreshPermissionSetLookup, with a fake injected ════
+    //
+    // #3041's shape: overwrite the cached reflection statics for exactly one call and restore
+    // them in a finally. Nothing in production is made settable for the test. The arms below
+    // prove the refusal on the path AL actually reaches, not only on the helper in isolation.
+
+    [Fact]
+    public void InstallFreshPermissionSetLookup_RaisesAShapeGap_WhenSummaryObjectNameHasMoved()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => WithInjectedStatics(
+            lookupField: typeof(FakeAppGroup).GetField(nameof(FakeAppGroup.PermissionSetLookup))!,
+            summaryType: typeof(NoAddCollection),           // stands in for a Summary with no ObjectName
+            () => Invoke("InstallFreshPermissionSetLookup", new object(), new List<object>())));
+
+        Assert.Equal($"{nameof(NoAddCollection)}.ObjectName", ex.Member);
+        Assert.Contains("property not found", ex.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InstallFreshPermissionSetLookup_RaisesAShapeGap_WhenPermissionSetLookupIsNoLongerAGenericLazy()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => WithInjectedStatics(
+            lookupField: typeof(FakeAppGroup).GetField(nameof(FakeAppGroup.NotALazy))!,
+            summaryType: typeof(FakeSummary),
+            () => Invoke("InstallFreshPermissionSetLookup", new object(), new List<object>())));
+
+        Assert.Equal("NavAppGroup.permissionSetLookup", ex.Member);
+        Assert.Contains("String", ex.Detail, StringComparison.Ordinal);
+    }
+
+    // CONTROL: with a summary type that HAS ObjectName the same call gets past all three guards
+    // and fails later, on the LazyEx constructor a fake Lazy does not provide — proving the
+    // guards above refused on the member and not on the injection itself.
+    [Fact]
+    public void InstallFreshPermissionSetLookup_GetsPastAllThreeGuards_WhenTheMembersArePresent()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => WithInjectedStatics(
+            lookupField: typeof(FakeAppGroup).GetField(nameof(FakeAppGroup.PermissionSetLookup))!,
+            summaryType: typeof(FakeSummary),
+            () => Invoke("InstallFreshPermissionSetLookup", new object(), new List<object>())));
+
+        Assert.Equal("LazyEx<T>(Func<T>)", ex.Member);
+    }
+
+    // ══ 6. The shape, not just the four lines the issue named ═══════════════════════════
+    //
+    // A null-forgiving `!` on a BC-internals member lookup is invisible to #3034's search shape
+    // by construction, so a source-level assertion is the only thing that keeps the next edit
+    // from adding one back. Scoped to the three files of #3034's slice.
+
+    [Fact]
+    public void NoBcInternalsMemberLookupInTheSlice_IsGuardedOnlyByANullForgivingOperator()
+    {
+        var lookup = new Regex(@"\.Get(Propert|Method|Field|NestedType|Constructor)[a-z]*\s*\([^;]*?\)\s*!");
+        var offenders = new List<string>();
+
+        foreach (var file in SliceFiles)
+        {
+            var path = Path.Combine(RepoRoot, "AlRunner", "Patches", file);
+            Assert.True(File.Exists(path), $"{file} not found at {path} — it was renamed or moved.");
+
+            // Comments are stripped first, for the same reason the sibling guard in
+            // PermissionMetadataShapeGapTests skips them: prose describing the shape — this
+            // file's own header does exactly that — is not a live read.
+            var code = string.Join("\n", File.ReadAllLines(path).Select(StripLineComment));
+
+            foreach (var statement in code.Split(';'))
+            {
+                var flat = string.Join(" ", statement.Split('\n').Select(l => l.Trim()));
+                if (lookup.IsMatch(flat)) offenders.Add($"{file}: {flat.Trim()}");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "these BC-internals member lookups are guarded only by `!`, so a member Microsoft moves "
+            + $"NREs into NavMethodScope_AssertError instead of naming the gap (#3046):{Environment.NewLine}"
+            + string.Join(Environment.NewLine, offenders));
+    }
+
+    private static string StripLineComment(string line)
+    {
+        var at = line.IndexOf("//", StringComparison.Ordinal);
+        return at < 0 ? line : line.Substring(0, at);
+    }
+
+    private static readonly string[] SliceFiles =
+    {
+        "RecordPatches.AggregatePermissionSetVirtualTable.cs",
+        "RecordPatches.MetadataPermissionSetVirtualTable.cs",
+        "RecordPatches.PermissionMetadataPopulator.cs",
+    };
+
+    // ══ Plumbing ════════════════════════════════════════════════════════════════════════
+
+    private static void WithInjectedStatics(FieldInfo lookupField, Type summaryType, Action body)
+    {
+        var fLookup = Static("_fPermissionSetLookup");
+        var fSummary = Static("_tSummary");
+        var savedLookup = fLookup.GetValue(null);
+        var savedSummary = fSummary.GetValue(null);
+        try
+        {
+            fLookup.SetValue(null, lookupField);
+            fSummary.SetValue(null, summaryType);
+            body();
+        }
+        finally
+        {
+            fLookup.SetValue(null, savedLookup);
+            fSummary.SetValue(null, savedSummary);
+        }
+    }
+
+    private static FieldInfo Static(string name)
+        => typeof(RecordPatches).GetField(name, Priv)
+           ?? throw new InvalidOperationException($"test setup: RecordPatches.{name} not found");
+
+    private static object? Invoke(string name, params object?[] args)
+    {
+        var m = typeof(RecordPatches).GetMethod(name, Priv)
+            ?? throw new InvalidOperationException($"test setup: RecordPatches.{name} not found");
+        try
+        {
+            return m.Invoke(null, args);
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            throw tie.InnerException;   // the reflection wrapper is not part of the contract
+        }
+    }
+
+    private sealed class FakeMetaPermissionSet
+    {
+        public List<int>? IncludedPermissionSets { get; set; }
+        public List<int>? ExcludedPermissionSets { get; set; }
+        internal List<string>? HiddenPermissionSets { get; set; }
+    }
+
+    private sealed class FakeMetaPermissionSetWithoutIncludes
+    {
+        public int Id { get; set; }
+    }
+
+    private sealed class NoAddCollection
+    {
+        public int Count => 0;
+    }
+
+    private sealed class FakeSummary
+    {
+        public string ObjectName => "SUPER";
+    }
+
+    private sealed class FakeLazy<T>
+    {
+        public T? Value { get; set; }
+    }
+
+    private sealed class FakeAppGroup
+    {
+        public FakeLazy<Dictionary<string, object>>? PermissionSetLookup;
+        public string? NotALazy;
+    }
+}

--- a/AlRunner.Tests/PermissionMetadataShapeGapTests.cs
+++ b/AlRunner.Tests/PermissionMetadataShapeGapTests.cs
@@ -163,6 +163,11 @@ public sealed class PermissionMetadataShapeGapTests
             for (var i = 0; i < lines.Length; i++)
             {
                 if (!lines[i].Contains("throw new InvalidOperationException", StringComparison.Ordinal)) continue;
+                // A COMMENT naming the retired convention is prose, not a refusal. Without this
+                // the guard fires on the header of any change that explains what it converted —
+                // measured, #3046's own comment tripped it (StartsWith, so an end-of-line
+                // comment after live code still counts).
+                if (lines[i].TrimStart().StartsWith("//", StringComparison.Ordinal)) continue;
 
                 // The whole throw expression, which may span lines.
                 var end = i;

--- a/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
@@ -156,9 +156,7 @@ public static partial class RecordPatches
 
             if (Environment.GetEnvironmentVariable("AL_RUNNER_DIAG_PERMMETA") == "1")
             {
-                var lookup = _tNavAppGroupPM!
-                    .GetProperty("PermissionSetGroupObjectMetadataSummaries",
-                        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!
+                var lookup = RequireBcProperty(_tNavAppGroupPM!, "PermissionSetGroupObjectMetadataSummaries")
                     .GetValue(baseGroup) as IEnumerable;
                 var lookupCount = 0;
                 if (lookup != null) foreach (var _ in lookup) lookupCount++;
@@ -226,11 +224,10 @@ public static partial class RecordPatches
     {
         var lazyField = _fPermissionSetLookup!;
         var lazyType = lazyField.FieldType;                       // LazyEx<Dictionary<NavCode, Summary>>
-        var dictType = lazyType.GetGenericArguments()[0];
+        var dictType = RequireBcLookupDictionaryType(lazyType);
         var dict = Activator.CreateInstance(dictType)!;
-        var add = dictType.GetMethod("Add")!;
-        var nameProp = _tSummary!.GetProperty("ObjectName",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var add = RequireBcMethod(dictType, "Add");
+        var nameProp = RequireBcProperty(_tSummary!, "ObjectName");
 
         foreach (var s in summaries)
         {
@@ -632,10 +629,10 @@ public static partial class RecordPatches
         SetProperty(mps, "Permissions", permissions);
 
         SetProperty(mps, "IncludedPermissionSets",
-            BuildIncludeList(_tMetaPermissionSet.GetProperty("IncludedPermissionSets")!.PropertyType,
+            BuildIncludeList(RequireBcProperty(_tMetaPermissionSet, "IncludedPermissionSets").PropertyType,
                 declaration.IncludedPermissionSets));
         SetProperty(mps, "ExcludedPermissionSets",
-            BuildIncludeList(_tMetaPermissionSet.GetProperty("ExcludedPermissionSets")!.PropertyType, null));
+            BuildIncludeList(RequireBcProperty(_tMetaPermissionSet, "ExcludedPermissionSets").PropertyType, null));
 
         return mps;
     }
@@ -693,6 +690,55 @@ public static partial class RecordPatches
         foreach (var (permissionSet, _, _) in EnumerateKnownPermissionSets())
             index.TryAdd(permissionSet.Name, permissionSet.Id);
         return _permissionSetIdByName = index;
+    }
+
+    // ── the reads that used to be guarded only by `!` (#3046) ───────────────────────────
+    //
+    // #3034 converted this file's 56 refusals of the retired convention, but its search shape
+    // was a `throw` of that exception type, and these five reads are not throw sites at
+    // all. `!` is a compiler annotation: it throws nothing, it hands a null onward, and the
+    // NullReferenceException lands at the first USE of that null — where nothing names the
+    // member that moved, and where NavMethodScope_AssertError swallows it and lets AL's
+    // asserterror pass on a read real BC performs fine.
+    //
+    // Each is a reflection resolution against BC's own Ncl / Types assemblies, so
+    // BcShapeGapException.cs's line puts all three on the "the read could not be performed"
+    // side, exactly like the 56.
+
+    /// <summary>
+    /// A property of a BC type this file reads by name. Looks with NonPublic as well as Public
+    /// deliberately: <see cref="SetProperty"/> WRITES these same members with those flags, and
+    /// a read narrower than the write would miss a member the write then finds.
+    /// </summary>
+    private static PropertyInfo RequireBcProperty(Type declaring, string propertyName)
+        => declaring.GetProperty(propertyName,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+           ?? throw PermissionMetadataBcShapeGap(
+               $"{declaring.Name}.{propertyName}",
+               "property not found — BC's permission-set metadata inventory cannot be populated");
+
+    /// <summary>A method of a BC-shape-derived type this file invokes by name.</summary>
+    private static MethodInfo RequireBcMethod(Type declaring, string methodName)
+        => declaring.GetMethod(methodName)
+           ?? throw PermissionMetadataBcShapeGap(
+               $"{declaring.Name}.{methodName}",
+               "method not found — BC's permission-set metadata inventory cannot be populated");
+
+    /// <summary>
+    /// The dictionary type inside <c>NavAppGroup.permissionSetLookup</c>, which BC declares as
+    /// <c>LazyEx&lt;Dictionary&lt;NavCode, NavAppGroupObjectMetadataSummary&gt;&gt;</c>. Not a
+    /// null read — an IndexOutOfRangeException on a non-generic field type, swallowed by the
+    /// same seam and just as anonymous, so it gets the same treatment.
+    /// </summary>
+    private static Type RequireBcLookupDictionaryType(Type lazyType)
+    {
+        var args = lazyType.GetGenericArguments();
+        if (args.Length != 1)
+            throw PermissionMetadataBcShapeGap(
+                "NavAppGroup.permissionSetLookup",
+                $"is declared as {lazyType.Name}, not the one-argument LazyEx<T> whose T is the lookup dictionary"
+                + " — BC's permission-set metadata inventory cannot be populated");
+        return args[0];
     }
 
     private static void SetProperty(object target, string name, object? value)


### PR DESCRIPTION
Closes #3046

Five BC-internals reads in `AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs`
were guarded only by the null-forgiving `!` operator. #3034 converted this file's 56
`throw`-site refusals to `BcShapeGapException`, but its search shape was a `throw`, and a
`!` is not a throw site — so a member Microsoft moves at any of these five produced an
anonymous exception with no member name instead of the message #3034 exists to produce.

## What `!` actually does, and why that made it invisible

`!` is a compiler annotation. It throws nothing. The lookup hands a **silent null** onward
and the `NullReferenceException` lands at the first *use* of that null — `.PropertyType` fed
to `BuildIncludeList`, `.Invoke` on the dictionary's `Add`, `.GetValue` on the summary.
`NavMethodScope_AssertError` is an unfiltered `catch(Exception)`, so it swallowed that NRE
and AL's `asserterror` **passed** on a read real BC performs fine. Same inversion #2945 and
#3034 removed for the throw sites.

The Included/Excluded pair is the sharpest of the five: `SetProperty(mps,
"IncludedPermissionSets", …)` *was* converted by #3034, but the unguarded
`GetProperty("IncludedPermissionSets")!` is an **argument** to that call, so it evaluates
first and the new guard on the very same property is unreachable through that path.

## Classification — all five converted, and why

Line numbers are from `c3bd13f9`, as in the issue; the issue named four and the shape sweep
found a fifth in the same function. Every one is a reflection resolution against BC's own
Ncl / Types assemblies, which is the side of `BcShapeGapException.cs`'s line the other 56 sit
on — "the read could not be performed", not "the read succeeded and the answer was
unwelcome".

| site | read | verdict |
|---|---|---|
| 635 | `_tMetaPermissionSet.GetProperty("IncludedPermissionSets")!` | **converted** — Types-assembly property resolution; the argument that made #3034's guard unreachable |
| 638 | `_tMetaPermissionSet.GetProperty("ExcludedPermissionSets")!` | **converted** — same, sibling call one line down |
| 232 | `_tSummary!.GetProperty("ObjectName", …)!` | **converted** — Ncl property resolution on `NavAppGroupObjectMetadataSummary`. The *leading* `!` on `_tSummary` stays: that cached field is already guarded by name in `EnsurePermMetaReflection`, so it cannot be null here |
| 160 | `_tNavAppGroupPM!.GetProperty("PermissionSetGroupObjectMetadataSummaries", …)!` | **converted** — Ncl property resolution. Behind `AL_RUNNER_DIAG_PERMMETA=1`, and opt-in diagnostics are exactly where a wrong answer is least likely to be noticed |
| 229 | `lazyType.GetGenericArguments()[0]` (sibling, not in the issue) | **converted** — `permissionSetLookup`'s declared type is BC's; a non-generic one throws `IndexOutOfRangeException` at the read, swallowed by the same seam and just as anonymous |

Nothing in this file classified as a deliberate non-conversion. The eight #3034 left alone
are untouched and `PermissionMetadataShapeGapTests` still pins all of them.

One behavioural detail worth naming: sites 635/638 used `GetProperty(name)` with the
**default** binding flags (`Public | Instance | Static`); the guarded helper uses
`Instance | Public | NonPublic`, matching `SetProperty`, which **writes those same two
members** and succeeds on every supported BC today. That the write works with Instance-only
flags is what establishes the properties are instance members, so dropping `Static` cannot
lose a member the old read found — and adding `NonPublic` closes the case where the read was
narrower than the write.

## RED → GREEN

New file `AlRunner.Tests/PermissionMetadataNullForgivingGuardTests.cs` — 22 tests, driven two
ways, neither needing a BC install: directly against the production helpers with a fake type
standing in for a BC type whose member moved (the shape `PermissionMetadataShapeGapTests`'
four arms already use), and **through `InstallFreshPermissionSetLookup` itself**, injecting
the fake into the cached reflection statics for one call and restoring them in a `finally`
(#3041's shape — nothing in production was made settable for the test).

**RED**, on a build with the reads extracted into helpers but the `!` semantics preserved
exactly — `Failed: 16, Passed: 6`:

- All five `AssertError_TearsThrough_…` arms: **`Assert.Throws() Failure: No exception was
  thrown`**. The seam swallowed the NRE / `IndexOutOfRangeException`, `asserterror` returned
  normally, and AL saw a pass. *That failure text is the inversion.*
- All five `TryFunction_TearsThrough_…` arms: `Exception type was not an exact match /
  Actual: typeof(System.NullReferenceException)` (and `System.IndexOutOfRangeException` for
  the generic-argument case) — the other seam lets it out, but anonymous, naming no member.
- `InstallFreshPermissionSetLookup_RaisesAShapeGap_WhenSummaryObjectNameHasMoved`:
  `Expected: "NoAddCollection.ObjectName" / Actual: "LazyEx<T>(Func<T>)"`. On the real call
  path a moved `ObjectName` did not merely go unreported — the run continued and refused
  later naming a **different member**, which is worse than silence.
- `NoBcInternalsMemberLookupInTheSlice_IsGuardedOnlyByANullForgivingOperator` listed the
  offending statements by text.

**GREEN**: `Passed! - Failed: 0, Passed: 22`.

The six that passed in RED are the control arms — each refusal is paired with one that still
succeeds (a property that *is* there returns with its real `PropertyType`; `Dictionary.Add`
resolves; the `LazyEx<T>` shape unwraps; both seams still trap a `RunnerOutOfScopeException`)
— so a guard that threw unconditionally would fail here rather than pass.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — one, in the same function as site 232:
   `lazyType.GetGenericArguments()[0]`, converted above. The issue's grep could not see it
   because it is not a `!` either.
2. **Sibling function making the same assumption?** No. Every other cached reflection member
   in this file is resolved once in `EnsurePermMetaReflection` and guarded there by name; the
   `!` on those cached fields at their use sites is therefore sound. `Activator.CreateInstance(…)!`
   and `compare.Invoke(…)!` are left alone deliberately: neither is a member *lookup*, and
   neither manufactures a null (`CreateInstance` throws `MissingMethodException`, and an
   `int`-returning `Compare` cannot return null).
3. **Two paths writing the same state with different invariants?** Yes, and it is the
   binding-flags mismatch above: the read of `Included/ExcludedPermissionSets` used narrower
   flags than the write of the same two members. They agree now.

**Beyond this file, deliberately not fixed here:** the same shape appears **143 more times
across 37 files** in `AlRunner/` (27 in `RecordPatches.QueryProjection.cs` alone). That is a
sweep the size of #2994's, needs the same per-site judgement, and several of them —
the `NclCecilRewrite.*` ones — fire at rewrite time where no AL seam can trap the refusal, so
they may correctly classify the other way. Filed as **#3051** with the measurement and a
suggested slicing rather than silently fixing one file's worth. Nothing here is left
untracked.

## Also in this PR

`PermissionMetadataShapeGapTests`' existing source scan now skips comment lines. It matched
the literal `throw new InvalidOperationException` anywhere in a line, so **a comment
explaining the retired convention failed it** — this change's own header tripped it, and any
future PR quoting the phrase would have hit the same confusing failure. A commented-out throw
is not live code, so skipping comments cannot hide a real conversion miss. The new file's own
scan strips comments for the same reason.

## The corpus question

**This asserts nothing about what BC does, so nothing goes upstream.** Every claim here is
about the runner's own reflection layer: that a lookup which cannot find a BC member raises
`BcShapeGapException` naming it, rather than handing a null onward for something else to NRE
on. The refusals are **unreachable on 27.0–28.4** — all five members are present on every
supported BC, which is precisely why the file works today and why the corpus can never
execute a single one of these paths. Two independent measurements establish that: the 52
permission unit tests pass unchanged, and CI's eight legs run the whole corpus against
`Microsoft.Dynamics.Nav.Ncl` / `.Types` from every supported minor with the permission
metadata layer populating normally. A test asserting these refusals against a service tier
would need a BC build where Microsoft *had already moved* the member, which is exactly the
future event the guard exists to report. The 27.x blackout is not the reason — the refusals
being unreachable on green BC is.

## Checks run

- `dotnet test AlRunner.Tests --filter FullyQualifiedName~PermissionMetadataNullForgivingGuardTests` → **22/22**
- `dotnet test AlRunner.Tests --filter "…PermissionMetadataShapeGapTests|…VirtualTableRefusalClaimTests|…BcShapeGap|…PermissionMetadataNullForgivingGuardTests"` → **159/159**
- `dotnet test AlRunner.Tests --filter FullyQualifiedName~Permission` → **52/52**
- `VirtualTableRefusalClaimTests`' exact count is **still 67** on the merged tree, verified
  independently as well as through the test. Expected: its regex carries a `(?<!Bc)`
  lookbehind, so `PermissionMetadataBcShapeGap` throws are invisible to it by design — the
  number was checked rather than assumed, and not adjusted.

No AL corpus run locally: the change adds guards on paths that succeed on every supported BC,
so there is nothing for a corpus run to move that CI's eight legs will not measure anyway.
No doc change — `docs/limitations.md#bc-shape-gaps` already describes this class of refusal
and no user-visible behaviour changed on a green BC.

---
*Written by an agent (`stma-auto-1`) acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
