### PR TITLE
perf(provision): stop scanning patch directories whose packages a kept one already covers

### DIFF
--- a/AlRunner.Tests/PackageCacheFinalSearchSetTests.cs
+++ b/AlRunner.Tests/PackageCacheFinalSearchSetTests.cs
@@ -119,6 +119,64 @@ public sealed class PackageCacheFinalSearchSetTests
         return Path.Combine(TestArtifacts.StandardCacheDir(home), version.ToString());
     }
 
+    /// <summary>
+    /// Issue #3037: three patch directories of the selected major.minor, each holding its
+    /// own copy of the same two packages at that patch's version — the shape a developer box
+    /// reaches after provisioning a few BC patches. Nothing Microsoft, for the same reason
+    /// <see cref="WriteFixture"/>'s manifests declare nothing Microsoft: need detection must
+    /// stay out of this, or the test acquires a 116 MB download.
+    /// </summary>
+    private static IReadOnlyList<string> DuplicatePatchVersions()
+    {
+        var engine = AlRunner.Infrastructure.BcArtifacts.EngineBuiltVersion()
+            ?? throw new InvalidOperationException("EngineBuiltVersion() unavailable.");
+        // Same major.minor as the selected engine (that is what CollectRunnerOwnedProvisionDirs
+        // matches on), and deliberately NOT the engine's own patch, so this exercises the
+        // sibling-patch path on every BC leg of the matrix rather than only on 28.1.
+        return new[] { $"{engine.Major}.{engine.Minor}.0.1", $"{engine.Major}.{engine.Minor}.0.2", $"{engine.Major}.{engine.Minor}.0.3" };
+    }
+
+    private static void WriteDuplicatePatchDirs(string isolatedHome)
+    {
+        var artifactsRoot = TestArtifacts.StandardCacheDir(isolatedHome);
+        foreach (var version in DuplicatePatchVersions())
+        {
+            foreach (var kind in new[] { "platform-apps", "test-apps" })
+            {
+                var dir = Path.Combine(artifactsRoot, version, kind);
+                Directory.CreateDirectory(dir);
+                File.WriteAllBytes(
+                    Path.Combine(dir, $"Repro3037_{kind} Filler_{version}.app"),
+                    MinimalNavxApp(Guid.NewGuid().ToString(), $"{kind} Filler", "Repro3037", version));
+            }
+        }
+    }
+
+    /// <summary>A minimal NAVX .app — NAVX header, then a ZIP holding only NavxManifest.xml.</summary>
+    private static byte[] MinimalNavxApp(string appId, string name, string publisher, string version)
+    {
+        var xml = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{appId}" Name="{name}" Publisher="{publisher}" Version="{version}"/>
+            </Package>
+            """;
+        using var ms = new MemoryStream();
+        using (var zip = new System.IO.Compression.ZipArchive(
+            ms, System.IO.Compression.ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = zip.CreateEntry("NavxManifest.xml");
+            using var es = entry.Open();
+            es.Write(Encoding.UTF8.GetBytes(xml));
+        }
+        var zipBytes = ms.ToArray();
+        var result = new byte[8 + zipBytes.Length];
+        result[0] = (byte)'N'; result[1] = (byte)'A'; result[2] = (byte)'V'; result[3] = (byte)'X';
+        BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
+        zipBytes.CopyTo(result, 8);
+        return result;
+    }
+
     private static string RunAgainstIsolatedHome(
         string testsDir, string alCacheDir, string isolatedHome, bool foldRunnerOwnedDirs)
     {
@@ -203,6 +261,47 @@ public sealed class PackageCacheFinalSearchSetTests
 
             Assert.Contains("package caches (requested): 0 dir(s)", output);
             Assert.Matches(new Regex(@"package caches \(final search set\): 2 dir\(s\)"), output);
+        }
+        finally
+        {
+            try { Directory.Delete(scratchRoot, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Issue #3037, end to end: three provisioned patch directories of the selected
+    /// major.minor, each holding a duplicate of the same two packages. Before the fix the
+    /// final search set was all SIX runner-owned directories and dependency resolution read
+    /// a manifest — and therefore a content hash — for every package in every one of them.
+    /// It is now the newest patch's two directories, and the bundle still compiles and its
+    /// test still passes, which is the half that matters: a narrower search set that stopped
+    /// resolving the closure would be a regression, not an optimisation.
+    /// </summary>
+    [SkippableFact]
+    public void FinalSearchSet_DuplicatePatchDirs_FoldsInOnlyTheNewest()
+    {
+        TestArtifacts.SkipIfMissing();
+        var scratchRoot = TestScratch.Dir("al-runner-pkgcache-3037");
+        var testsDir = WriteFixture(scratchRoot);
+        var isolatedHome = Path.Combine(scratchRoot, "home");
+        Directory.CreateDirectory(isolatedHome);
+        WriteDuplicatePatchDirs(isolatedHome);
+        var alCacheDir = Path.Combine(scratchRoot, "al-out");
+        try
+        {
+            // foldRunnerOwnedDirs: false — WriteDuplicatePatchDirs has already created the
+            // runner-owned dirs this case is about, under patch versions of its own.
+            var output = RunAgainstIsolatedHome(testsDir, alCacheDir, isolatedHome, foldRunnerOwnedDirs: false);
+
+            Assert.Contains("package caches (requested): 0 dir(s)", output);
+            Assert.Contains("package caches (final search set): 2 dir(s)", output);
+            var versions = DuplicatePatchVersions();
+            var newest = versions[^1];
+            Assert.Contains(Path.Combine(TestArtifacts.StandardCacheDir(isolatedHome), newest, "platform-apps"), output);
+            Assert.Contains(Path.Combine(TestArtifacts.StandardCacheDir(isolatedHome), newest, "test-apps"), output);
+            // The two older patches are no longer in the search set at all.
+            foreach (var older in versions.Take(versions.Count - 1))
+                Assert.DoesNotContain(Path.Combine(TestArtifacts.StandardCacheDir(isolatedHome), older), output);
         }
         finally
         {

--- a/AlRunner.Tests/ProvisioningCheckTests.cs
+++ b/AlRunner.Tests/ProvisioningCheckTests.cs
@@ -2129,6 +2129,72 @@ public sealed class ProvisioningCheckTests : IDisposable
         Assert.Contains(older, dirs);
     }
 
+    // ── The trade this narrowing makes, pinned in both directions ────────────
+    // Coverage is decided from file NAMES. A name is not its bytes, so a package whose name
+    // dominates but whose content is unusable hides a complete older copy that the
+    // unfiltered search set would have resolved from. The reachable shape is an interrupted
+    // ArtifactDownloader write: neither downloader writes to a temporary file and renames,
+    // so a killed 98 MB File.WriteAllBytes leaves a truncated package behind under the right
+    // name. These two tests state the cost and the consequence, so neither can change
+    // silently.
+
+    /// <summary>Helper: a package with the right NAME and unusable BYTES — the leading third
+    /// of a well-formed one, which is the shape an interrupted write leaves: the NAVX header
+    /// is intact and the archive behind it is not.</summary>
+    private static void WriteTruncatedApp(string dir, string fileName,
+        string name, string publisher, string version)
+    {
+        Directory.CreateDirectory(dir);
+        var whole = MakeR2RNavxApp(Guid.NewGuid().ToString(), name, publisher, version);
+        File.WriteAllBytes(Path.Combine(dir, fileName), whole.Take(whole.Length / 3).ToArray());
+    }
+
+    [Fact]
+    public void CollectRunnerOwnedProvisionDirs_TruncatedPackageInTheDominantDir_LosesTheOlderCompleteCopy()
+    {
+        var root = Path.Combine(_dir, "artifacts-3037-truncated");
+        var older = Path.Combine(root, "28.1.49838.54100", "platform-apps");
+        WritePlatformAppSet(older, "28.1.49838.54100");
+        var newest = Path.Combine(root, "28.1.49838.54308", "platform-apps");
+        WritePlatformAppSet(newest, "28.1.49838.54308");
+        File.Delete(Path.Combine(newest, "Microsoft_Base Application_28.1.49838.54308.app"));
+        WriteTruncatedApp(newest, "Microsoft_Base Application_28.1.49838.54308.app",
+            "Base Application", "Microsoft", "28.1.49838.54308");
+
+        var dirs = ProvisioningCheck.CollectRunnerOwnedProvisionDirs(root, "28.1");
+
+        // The cost: the newest directory NAMES every app, so the older complete copy of Base
+        // Application is dropped even though it is the only usable one on disk.
+        Assert.Equal(new[] { newest }, dirs.ToArray());
+    }
+
+    [Fact]
+    public void CollectRunnerOwnedProvisionDirs_TruncatedPackageInTheDominantDir_FailsLoudlyNamingTheApp()
+    {
+        // The consequence, and why the cost is acceptable: what the run does about it is
+        // report Base Application as missing — by name, over a search set it can print — not
+        // return a wrong answer. Nothing caches the narrowed result, so re-fetching the
+        // package clears it.
+        var root = Path.Combine(_dir, "artifacts-3037-truncated-loud");
+        var older = Path.Combine(root, "28.1.49838.54100", "platform-apps");
+        WritePlatformAppSet(older, "28.1.49838.54100");
+        var newest = Path.Combine(root, "28.1.49838.54308", "platform-apps");
+        WritePlatformAppSet(newest, "28.1.49838.54308");
+        File.Delete(Path.Combine(newest, "Microsoft_Base Application_28.1.49838.54308.app"));
+        WriteTruncatedApp(newest, "Microsoft_Base Application_28.1.49838.54308.app",
+            "Base Application", "Microsoft", "28.1.49838.54308");
+        var required = new[] { "Application", "Base Application", "System Application" };
+
+        var narrowed = ProvisioningCheck.CollectRunnerOwnedProvisionDirs(root, "28.1");
+
+        Assert.Equal(new[] { "Base Application" },
+            ProvisioningCheck.FindMissingPlatformApps(required, narrowed).ToArray());
+        // The contrast that proves the fixture is sound and the difference really is the
+        // narrowing: over BOTH directories the older complete copy answers, as it did before
+        // this filter existed.
+        Assert.Empty(ProvisioningCheck.FindMissingPlatformApps(required, new[] { newest, older }));
+    }
+
     // ── AppFileCoverageKey: the filename split the narrowing rests on ────────
 
     [Theory]

--- a/AlRunner.Tests/ProvisioningCheckTests.cs
+++ b/AlRunner.Tests/ProvisioningCheckTests.cs
@@ -1960,4 +1960,199 @@ public sealed class ProvisioningCheckTests : IDisposable
             new[] { "Application", "System" },
             missing.OrderBy(n => n, StringComparer.Ordinal).ToArray());
     }
+
+    // ── Issue #3037: redundant patch directories must not be scanned ─────────
+    // CollectRunnerOwnedProvisionDirs returns the platform-apps/test-apps directory of
+    // EVERY provisioned patch of the selected major.minor. On a developer box that has
+    // provisioned a few patches, each of those holds its own complete copy of the same
+    // curated download set — Base Application alone is ~98 MB — and every caller
+    // (DependencyResolver.EnsureIndexed, FindMissingPlatformApps, ScanDependencyEdges)
+    // reads a manifest, and therefore a content hash, for every .app in every one of
+    // them. Measured on one such box: 694.2 MB across 355 files scanned to resolve six
+    // packages.
+    //
+    // The union itself is NOT gratuitous — #2226 can leave `provision`'s platform-app and
+    // test-app sub-steps under DIFFERENT patch directories of the same major.minor, and
+    // ArtifactDownloader writes each .app straight into its output directory as it
+    // downloads (no temp-dir-then-rename), so a partially populated set is reachable too.
+    // The narrowing below is therefore by CONTRIBUTION, not by version: a directory is
+    // dropped only when every app in it is already covered, at an equal or higher
+    // filename-encoded version, by a directory already kept.
+
+    /// <summary>Helper: the curated platform-app download set, named the way
+    /// ArtifactDownloader writes it (<c>&lt;Publisher&gt;_&lt;Name&gt;_&lt;Version&gt;.app</c>).</summary>
+    private static void WritePlatformAppSet(string dir, string version)
+    {
+        Directory.CreateDirectory(dir);
+        foreach (var name in new[] { "Application", "Base Application", "System Application", "Business Foundation" })
+            WriteR2RApp(dir, $"Microsoft_{name}_{version}.app", Guid.NewGuid().ToString(), name, "Microsoft", version);
+    }
+
+    /// <summary>Helper: test-toolkit apps, whose filenames carry NO version
+    /// (<c>Microsoft_Any.app</c>) — the shape ArtifactDownloader.TestApps writes.</summary>
+    private static void WriteTestToolkit(string dir, string version, params string[] names)
+    {
+        Directory.CreateDirectory(dir);
+        foreach (var name in names)
+            WriteR2RApp(dir, $"Microsoft_{name}.app", Guid.NewGuid().ToString(), name, "Microsoft", version);
+    }
+
+    [Fact]
+    public void CollectRunnerOwnedProvisionDirs_DuplicatePlatformSetsAcrossPatches_ScansOnlyTheNewest()
+    {
+        var root = Path.Combine(_dir, "artifacts-3037-dup-platform");
+        WritePlatformAppSet(Path.Combine(root, "28.1.49838.53910", "platform-apps"), "28.1.49838.53910");
+        WritePlatformAppSet(Path.Combine(root, "28.1.49838.54044", "platform-apps"), "28.1.49838.54044");
+        WritePlatformAppSet(Path.Combine(root, "28.1.49838.54308", "platform-apps"), "28.1.49838.54308");
+
+        var dirs = ProvisioningCheck.CollectRunnerOwnedProvisionDirs(root, "28.1");
+
+        Assert.Equal(
+            new[] { Path.Combine(root, "28.1.49838.54308", "platform-apps") },
+            dirs.ToArray());
+    }
+
+    [Fact]
+    public void CollectRunnerOwnedProvisionDirs_DuplicateTestToolkitsAcrossPatches_ScansOnlyTheNewest()
+    {
+        // Test-toolkit filenames carry no version, so "already covered" here rests on the
+        // patch-directory order (newest first) rather than on a filename comparison.
+        var root = Path.Combine(_dir, "artifacts-3037-dup-test");
+        WriteTestToolkit(Path.Combine(root, "28.1.49838.53910", "test-apps"), "28.1.49838.53910",
+            "Any", "Library Assert", "Test Runner");
+        WriteTestToolkit(Path.Combine(root, "28.1.49838.54308", "test-apps"), "28.1.49838.54308",
+            "Any", "Library Assert", "Test Runner");
+
+        var dirs = ProvisioningCheck.CollectRunnerOwnedProvisionDirs(root, "28.1");
+
+        Assert.Equal(
+            new[] { Path.Combine(root, "28.1.49838.54308", "test-apps") },
+            dirs.ToArray());
+    }
+
+    [Fact]
+    public void CollectRunnerOwnedProvisionDirs_PartiallyDownloadedNewestPatch_StillScansTheOlderOne()
+    {
+        // ArtifactDownloader.PlatformApps writes each .app straight into outputDir and
+        // `continue`s past an entry it could not fetch, so an interrupted download leaves a
+        // PARTIAL set behind. The older, complete patch directory must stay in the search
+        // set — dropping it is exactly the "mysterious missing-dependency error" #2206 warns
+        // about.
+        var root = Path.Combine(_dir, "artifacts-3037-partial");
+        WritePlatformAppSet(Path.Combine(root, "28.1.49838.53910", "platform-apps"), "28.1.49838.53910");
+        var newest = Path.Combine(root, "28.1.49838.54308", "platform-apps");
+        Directory.CreateDirectory(newest);
+        WriteR2RApp(newest, "Microsoft_Application_28.1.49838.54308.app",
+            Guid.NewGuid().ToString(), "Application", "Microsoft", "28.1.49838.54308");
+
+        var dirs = ProvisioningCheck.CollectRunnerOwnedProvisionDirs(root, "28.1");
+
+        Assert.Equal(
+            new[]
+            {
+                newest,
+                Path.Combine(root, "28.1.49838.53910", "platform-apps"),
+            },
+            dirs.ToArray());
+        // And the older set really does still answer the need — the point of keeping it.
+        Assert.Empty(ProvisioningCheck.FindMissingPlatformApps(
+            new[] { "Application", "Base Application", "System Application" }, dirs));
+    }
+
+    [Fact]
+    public void CollectRunnerOwnedProvisionDirs_OlderPatchHoldingAHigherVersionedApp_IsStillScanned()
+    {
+        // Dropping is by filename-encoded version, never by directory order alone, so a
+        // hand-placed newer package under an older patch directory cannot be discarded —
+        // the resolver picks the highest satisfying version, and it must still see it.
+        var root = Path.Combine(_dir, "artifacts-3037-higher-in-older");
+        var older = Path.Combine(root, "28.1.49838.53910", "platform-apps");
+        WritePlatformAppSet(older, "28.1.49838.53910");
+        WriteR2RApp(older, "Microsoft_Base Application_28.1.49838.99999.app",
+            Guid.NewGuid().ToString(), "Base Application", "Microsoft", "28.1.49838.99999");
+        WritePlatformAppSet(Path.Combine(root, "28.1.49838.54308", "platform-apps"), "28.1.49838.54308");
+
+        var dirs = ProvisioningCheck.CollectRunnerOwnedProvisionDirs(root, "28.1");
+
+        Assert.Contains(older, dirs);
+    }
+
+    [Fact]
+    public void CollectRunnerOwnedProvisionDirs_CrossPatchKindSplit_KeepsBoth()
+    {
+        // The #2226/#2234 shape with real packages in it rather than empty directories:
+        // platform apps under one patch, the test toolkit under another. Neither covers the
+        // other, so both stay.
+        var root = Path.Combine(_dir, "artifacts-3037-kind-split");
+        WriteTestToolkit(Path.Combine(root, "28.1.49838.53910", "test-apps"), "28.1.49838.53910", "Any");
+        WritePlatformAppSet(Path.Combine(root, "28.1.49838.54044", "platform-apps"), "28.1.49838.54044");
+
+        var dirs = ProvisioningCheck.CollectRunnerOwnedProvisionDirs(root, "28.1");
+
+        Assert.Equal(
+            new[]
+            {
+                Path.Combine(root, "28.1.49838.54044", "platform-apps"),
+                Path.Combine(root, "28.1.49838.53910", "test-apps"),
+            },
+            dirs.ToArray());
+    }
+
+    [Fact]
+    public void CollectRunnerOwnedProvisionDirs_EmptyDirs_AreStillReturned()
+    {
+        // An empty directory reads nothing, so it can never be the cost this narrowing is
+        // about — and it is still worth naming in "here is where we looked" diagnostics.
+        // Regression guard for CollectRunnerOwnedProvisionDirs_FindsDirsAcrossDifferentPatchVersions
+        // and PackageCacheFinalSearchSetTests, both of which fold in EMPTY runner-owned dirs.
+        var root = Path.Combine(_dir, "artifacts-3037-empty");
+        Directory.CreateDirectory(Path.Combine(root, "28.1.49838.53910", "platform-apps"));
+        Directory.CreateDirectory(Path.Combine(root, "28.1.49838.53910", "test-apps"));
+        Directory.CreateDirectory(Path.Combine(root, "28.1.49838.54308", "platform-apps"));
+
+        var dirs = ProvisioningCheck.CollectRunnerOwnedProvisionDirs(root, "28.1");
+
+        Assert.Equal(3, dirs.Count);
+    }
+
+    [Fact]
+    public void CollectRunnerOwnedProvisionDirs_OlderTestAppsHoldingAnAppTheNewestLacks_IsStillScanned()
+    {
+        var root = Path.Combine(_dir, "artifacts-3037-extra-toolkit-app");
+        var older = Path.Combine(root, "28.1.49838.53910", "test-apps");
+        WriteTestToolkit(older, "28.1.49838.53910", "Any", "Library Assert", "Tests-TestLibraries");
+        WriteTestToolkit(Path.Combine(root, "28.1.49838.54308", "test-apps"), "28.1.49838.54308",
+            "Any", "Library Assert");
+
+        var dirs = ProvisioningCheck.CollectRunnerOwnedProvisionDirs(root, "28.1");
+
+        Assert.Contains(older, dirs);
+    }
+
+    // ── AppFileCoverageKey: the filename split the narrowing rests on ────────
+
+    [Theory]
+    [InlineData("Microsoft_Base Application_28.1.49838.54308.app", "Microsoft_Base Application", "28.1.49838.54308")]
+    [InlineData("microsoft_system application_28.2.0.0.app", "microsoft_system application", "28.2.0.0")]
+    [InlineData("Microsoft_Any.app", "Microsoft_Any", null)]
+    [InlineData("System.app", "System", null)]
+    [InlineData("Microsoft_Tests-ERM.app", "Microsoft_Tests-ERM", null)]
+    public void AppFileCoverageKey_SplitsTheTrailingVersionOnlyWhenThereIsOne(
+        string fileName, string expectedStem, string? expectedVersion)
+    {
+        var (stem, version) = ProvisioningCheck.AppFileCoverageKey(fileName);
+
+        Assert.Equal(expectedStem, stem);
+        Assert.Equal(expectedVersion == null ? null : Version.Parse(expectedVersion), version);
+    }
+
+    [Fact]
+    public void AppFileCoverageKey_IsCaseInsensitiveOnTheStem()
+    {
+        var (a, _) = ProvisioningCheck.AppFileCoverageKey("Microsoft_Base Application_28.1.0.0.app");
+        var (b, _) = ProvisioningCheck.AppFileCoverageKey("MICROSOFT_BASE APPLICATION_28.1.0.0.app");
+
+        Assert.Equal(a, b, StringComparer.OrdinalIgnoreCase);
+        Assert.NotEqual(a, b, StringComparer.Ordinal);
+    }
 }

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -650,16 +650,24 @@ public static class ProvisioningCheck
     /// set (Base Application alone is ~98 MB), and every caller — <see
     /// cref="AlRunner.DependencyResolver"/>'s index, <see cref="FindMissingPlatformApps"/>,
     /// <see cref="ScanDependencyEdges"/> — reads a manifest, and since #2987 therefore a
-    /// content hash, for every <c>.app</c> in every directory returned here. Measured on a
-    /// box with four provisioned patches: 694.2 MB across 355 files scanned to resolve six
-    /// packages, most of it the same Base Application four times over.
+    /// content hash, for every <c>.app</c> in every directory returned here.
     ///
-    /// So a directory is omitted when — and only when — every package in it is already
-    /// reachable, at an equal or higher version, through a directory that stays; see
-    /// <see cref="ContributesUncoveredPackages"/> for why that is lossless and which cases it
-    /// deliberately keeps (a partially downloaded newest patch, a hand-placed newer package
-    /// under an older patch, and every empty directory). It never fabricates a directory, and
-    /// it never omits one whose contents are not otherwise reachable.</para>
+    /// Measured against <c>main</c> at 80abc76a — so WITH #3042's inode-keyed content-hash
+    /// memo already in place, which collapses hard-linked duplicates and does nothing for
+    /// these, since separate downloads are separate files. Four provisioned patches, one
+    /// bundle needing six packages: the search set was 8 directories / 351 packages /
+    /// 677.4 MB, and is now 3 / 119 / 266.5 MB. Interleaved, 5 samples, best-of:
+    /// 2.18 s wall and 2.41 s CPU before, 1.81 s and 1.75 s after, against a same-binary
+    /// control that moved 0.10 s. On a hard-linked root the difference is 0.03 s — inside
+    /// that control — because #3042 already covers that shape.
+    ///
+    /// So a directory is omitted when — and only when — every package in it is already named,
+    /// at an equal or higher version, by a directory that stays. Coverage is decided from the
+    /// DIRECTORY LISTING — names and the versions those names encode — and never from a
+    /// package's contents; <see cref="ContributesUncoveredPackages"/> states exactly what that
+    /// buys, what it costs, and which cases it deliberately keeps (a partially downloaded
+    /// newest patch, a hand-placed newer package under an older patch, and every empty
+    /// directory). It never fabricates a directory.</para>
     /// </summary>
     public static IReadOnlyList<string> CollectRunnerOwnedProvisionDirs(
         string artifactsRootDir, string majorMinorPrefix)
@@ -688,17 +696,17 @@ public static class ProvisioningCheck
     /// its whole contents into <paramref name="covered"/> so a later (older) patch directory
     /// is measured against it.
     ///
-    /// <para><b>Why this is lossless.</b> The narrowing decides purely on FILE NAMES — one
-    /// directory listing per directory, no package is opened, nothing is hashed — and it
-    /// drops a directory only when every package in it is already reachable at an equal or
-    /// higher version through a directory that stays. Three consequences worth stating,
-    /// because each is a way this could have gone wrong:</para>
+    /// <para><b>What the decision rests on.</b> FILE NAMES — one directory listing per
+    /// directory, no package is opened, nothing is hashed — so a directory is dropped only
+    /// when every package in it is already NAMED, at an equal or higher filename-encoded
+    /// version, by a directory that stays. Three cases it deliberately keeps, because each is
+    /// a way this could have gone wrong:</para>
     /// <list type="bullet">
-    /// <item>A directory whose newest sibling is only PARTIALLY downloaded stays.
-    /// <see cref="AlRunner.Provisioning.ArtifactDownloader.PlatformApps"/> writes each
-    /// <c>.app</c> straight into its output directory and <c>continue</c>s past an entry it
-    /// could not fetch, so a partial set is reachable, and the older complete one is what
-    /// answers the need.</item>
+    /// <item>A directory whose newest sibling holds a DIFFERENT, smaller set stays. The
+    /// curated download sets are fetched entry by entry, so an interrupted
+    /// <see cref="AlRunner.Provisioning.ArtifactDownloader.PlatformApps"/> can leave a newest
+    /// patch that names only some of the apps, and the older complete one supplies the
+    /// rest.</item>
     /// <item>The <see cref="EnumerateVersionDirNames"/> order is newest patch first, so a
     /// duplicate is dropped from the OLDER directory, never the newer one. But the decision
     /// does not rest on that order where a file name can settle it: a hand-placed
@@ -711,11 +719,39 @@ public static class ProvisioningCheck
     /// behind — the shape #2234's own regression tests construct.</item>
     /// </list>
     ///
+    /// <para><b>What it costs, stated rather than papered over.</b> A name is not its bytes.
+    /// A file whose NAME dominates but whose CONTENT is unusable — the reachable shape being
+    /// a <c>File.WriteAllBytes</c> interrupted part-way through a 98 MB package, since neither
+    /// downloader writes to a temporary file and renames — now hides a complete older copy
+    /// that the unfiltered search set would have resolved from. Reproduced: a
+    /// <c>Microsoft_Base Application_&lt;newer&gt;.app</c> truncated to 1 MB over a complete
+    /// copy one patch back turns a run that used to pass into exit 2 with "missing from every
+    /// searched cache: Base Application".</para>
+    ///
+    /// <para>That is a deliberate trade, not an oversight, and it is pinned by
+    /// ProvisioningCheckTests.CollectRunnerOwnedProvisionDirs_TruncatedPackageInTheDominantDir_*.
+    /// The failure is LOUD — it names the app, lists every directory searched and prints the
+    /// provision command — and nothing caches the narrowed result, so it is a refusal rather
+    /// than a wrong answer, and it clears the moment the package is re-fetched. It is argued
+    /// to be BETTER than silently resolving around it: a truncated package in the artifact
+    /// cache is a real defect, and recovering from a stale patch leaves it there indefinitely
+    /// while making the next `provision` look unnecessary.</para>
+    ///
+    /// <para>Two content checks were considered and rejected. A ZIP end-of-central-directory
+    /// record in the last 64 bytes: measured on this machine, 0 of 119 real packages have one
+    /// — every signed <c>.app</c> carries a ~10 KB signature blob after the archive, ending
+    /// in an <c>NXSB</c> trailer, so the EOCD sits ~10 KB from the end and the check would
+    /// credit nothing. Requiring that <c>NXSB</c> trailer instead does catch truncation, but
+    /// it is an undocumented property of Microsoft's signing that no unsigned package would
+    /// satisfy. Neither closes the general case — a package corrupt in the MIDDLE passes both
+    /// — so neither would restore a literal losslessness claim, and a strong claim resting on
+    /// a weak check is worse than an accurate weaker one. The honest check is reading the
+    /// manifest, which is the entire cost this avoids.</para>
+    ///
     /// <para>An unrecognised file-name shape yields no version from
     /// <see cref="AppFileCoverageKey"/>, which can only make this MORE conservative: it can
-    /// no longer prove one copy outranks another, so the directory stays. The failure
-    /// direction is a directory scanned needlessly, never a package that should have been
-    /// found and was not.</para>
+    /// no longer prove one copy outranks another, so the directory stays. That failure
+    /// direction is a directory scanned needlessly, never a package that goes unfound.</para>
     /// </summary>
     private static bool ContributesUncoveredPackages(string dir, Dictionary<string, Version?> covered)
     {

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -643,21 +643,150 @@ public static class ProvisioningCheck
     ///
     /// This is the single source of truth both the run path and need detection now share,
     /// so they can no longer independently drift onto different search sets. Pure
-    /// filesystem existence scan — no network — and it can only ADD directories that exist
-    /// on disk, never remove or fabricate one.
+    /// filesystem scan — no network, and no package is opened or hashed.
+    ///
+    /// <para><b>Issue #3037 — redundant patch directories are left out.</b> Every provisioned
+    /// patch of the same major.minor holds its own complete copy of the same curated download
+    /// set (Base Application alone is ~98 MB), and every caller — <see
+    /// cref="AlRunner.DependencyResolver"/>'s index, <see cref="FindMissingPlatformApps"/>,
+    /// <see cref="ScanDependencyEdges"/> — reads a manifest, and since #2987 therefore a
+    /// content hash, for every <c>.app</c> in every directory returned here. Measured on a
+    /// box with four provisioned patches: 694.2 MB across 355 files scanned to resolve six
+    /// packages, most of it the same Base Application four times over.
+    ///
+    /// So a directory is omitted when — and only when — every package in it is already
+    /// reachable, at an equal or higher version, through a directory that stays; see
+    /// <see cref="ContributesUncoveredPackages"/> for why that is lossless and which cases it
+    /// deliberately keeps (a partially downloaded newest patch, a hand-placed newer package
+    /// under an older patch, and every empty directory). It never fabricates a directory, and
+    /// it never omits one whose contents are not otherwise reachable.</para>
     /// </summary>
     public static IReadOnlyList<string> CollectRunnerOwnedProvisionDirs(
         string artifactsRootDir, string majorMinorPrefix)
     {
         var dirs = new List<string>();
+        // Issue #3037's redundancy filter. Stem -> the highest filename-encoded version of
+        // that app already reachable through a directory ALREADY in `dirs`; a null value
+        // means "present, but its file name encodes no version", which is the ordinary case
+        // for the test toolkit (Microsoft_Any.app) and for System.app.
+        var covered = new Dictionary<string, Version?>(StringComparer.OrdinalIgnoreCase);
         foreach (var name in EnumerateVersionDirNames(artifactsRootDir, majorMinorPrefix))
         {
             var platformDir = PlatformAppsDirFor(artifactsRootDir, name);
-            if (Directory.Exists(platformDir)) dirs.Add(platformDir);
+            if (Directory.Exists(platformDir) && ContributesUncoveredPackages(platformDir, covered))
+                dirs.Add(platformDir);
             var testDir = TestAppsDirFor(artifactsRootDir, name);
-            if (Directory.Exists(testDir)) dirs.Add(testDir);
+            if (Directory.Exists(testDir) && ContributesUncoveredPackages(testDir, covered))
+                dirs.Add(testDir);
         }
         return dirs;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="dir"/> holds at least one package that <paramref name="covered"/>
+    /// does not already account for at an equal or higher version — and, when it does, folds
+    /// its whole contents into <paramref name="covered"/> so a later (older) patch directory
+    /// is measured against it.
+    ///
+    /// <para><b>Why this is lossless.</b> The narrowing decides purely on FILE NAMES — one
+    /// directory listing per directory, no package is opened, nothing is hashed — and it
+    /// drops a directory only when every package in it is already reachable at an equal or
+    /// higher version through a directory that stays. Three consequences worth stating,
+    /// because each is a way this could have gone wrong:</para>
+    /// <list type="bullet">
+    /// <item>A directory whose newest sibling is only PARTIALLY downloaded stays.
+    /// <see cref="AlRunner.Provisioning.ArtifactDownloader.PlatformApps"/> writes each
+    /// <c>.app</c> straight into its output directory and <c>continue</c>s past an entry it
+    /// could not fetch, so a partial set is reachable, and the older complete one is what
+    /// answers the need.</item>
+    /// <item>The <see cref="EnumerateVersionDirNames"/> order is newest patch first, so a
+    /// duplicate is dropped from the OLDER directory, never the newer one. But the decision
+    /// does not rest on that order where a file name can settle it: a hand-placed
+    /// higher-versioned package under an older patch directory is uncovered, so that
+    /// directory stays and the resolver still sees the version it would have picked.</item>
+    /// <item>An EMPTY directory always stays. It reads nothing, so it cannot be the cost
+    /// this exists to remove, and it is still worth naming in the "here is where we looked"
+    /// diagnostics that <see cref="FindMissingPlatformApps"/>'s callers build. It is also
+    /// what a `provision` run that created the directory and then failed to fill it leaves
+    /// behind — the shape #2234's own regression tests construct.</item>
+    /// </list>
+    ///
+    /// <para>An unrecognised file-name shape yields no version from
+    /// <see cref="AppFileCoverageKey"/>, which can only make this MORE conservative: it can
+    /// no longer prove one copy outranks another, so the directory stays. The failure
+    /// direction is a directory scanned needlessly, never a package that should have been
+    /// found and was not.</para>
+    /// </summary>
+    private static bool ContributesUncoveredPackages(string dir, Dictionary<string, Version?> covered)
+    {
+        // Same scan the resolver itself uses (recursive, tolerant of an unreadable
+        // subdirectory) so this can never claim a directory is redundant on a narrower
+        // view of its contents than DependencyResolver.EnsureIndexed will take.
+        var files = AlRunner.Infrastructure.SafeDirectoryScan.Files(dir, "*.app");
+        if (files.Count == 0) return true;
+
+        var keys = new List<(string Stem, Version? Version)>(files.Count);
+        var contributes = false;
+        foreach (var file in files)
+        {
+            var key = AppFileCoverageKey(Path.GetFileName(file));
+            keys.Add(key);
+            if (!covered.TryGetValue(key.Stem, out var keptVersion)) { contributes = true; continue; }
+            // Covered unless this copy can be PROVEN newer than what is already kept.
+            if (key.Version != null && (keptVersion == null || keptVersion < key.Version))
+                contributes = true;
+        }
+        if (!contributes) return false;
+
+        foreach (var (stem, version) in keys)
+        {
+            if (!covered.TryGetValue(stem, out var keptVersion))
+            {
+                covered[stem] = version;
+                continue;
+            }
+            // Never downgrade a known version to "unknown": a versionless duplicate tells us
+            // nothing about what is reachable, and forgetting the version we DO know would
+            // make a later directory look uncovered for no reason.
+            if (version != null && (keptVersion == null || keptVersion < version))
+                covered[stem] = version;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Splits a package file name into the identity the redundancy filter in
+    /// <see cref="CollectRunnerOwnedProvisionDirs"/> compares on: a STEM
+    /// (<c>&lt;Publisher&gt;_&lt;Name&gt;</c>, or the whole base name when there is no
+    /// trailing version) and, when the name carries one, the VERSION it encodes.
+    ///
+    /// <para><c>Microsoft_Base Application_28.1.49838.54308.app</c> →
+    /// (<c>Microsoft_Base Application</c>, <c>28.1.49838.54308</c>);
+    /// <c>Microsoft_Any.app</c> → (<c>Microsoft_Any</c>, <c>null</c>);
+    /// <c>System.app</c> → (<c>System</c>, <c>null</c>). Those are exactly the three shapes
+    /// <see cref="AlRunner.Provisioning.ArtifactDownloader"/> writes into a runner-owned
+    /// <c>platform-apps</c>/<c>test-apps</c> directory: the platform set keeps the artifact
+    /// entry's versioned base name, the test toolkit's entries carry no version, and
+    /// <c>System.app</c> has no publisher prefix at all.</para>
+    ///
+    /// <para>A name that does not fit — a trailing segment that is not a
+    /// <see cref="Version"/>, an app whose own name ends in something version-like — simply
+    /// yields no version, which makes the caller MORE conservative (it can no longer prove
+    /// one copy outranks another), never less. That is the safe direction: an unrecognised
+    /// name costs a directory that could have been skipped, not a package that should have
+    /// been found.</para>
+    /// </summary>
+    internal static (string Stem, Version? Version) AppFileCoverageKey(string fileName)
+    {
+        var baseName = Path.GetFileNameWithoutExtension(fileName);
+        var cut = baseName.LastIndexOf('_');
+        if (cut <= 0) return (baseName, null);
+        var tail = baseName[(cut + 1)..];
+        // Version.TryParse accepts "1.2" and up but also parses a bare number as a failure,
+        // which is what we want: an app whose name's last segment is a plain word or a
+        // single number is not a versioned file name.
+        if (!Version.TryParse(tail, out var version)) return (baseName, null);
+        return (baseName[..cut], version);
     }
 
     // ── Issue #1996: manifest-driven need detection ──────────────────────────


### PR DESCRIPTION
Closes #3037

## What the issue asked first

Not "narrow the search set" — "does anything depend on seeing other versions' packages?" It does, and the dependency is live on the box this was measured on, so **outcome 1 (narrow to the selected version) is off the table**. This PR is outcome 2: keep the fallback, pay for it only when it is used.

### Evidence that other patch directories are load-bearing

1. **This machine's own run needs one.** The selected engine is `28.1.49838.53910`; its artifact directory has no `platform-apps` and no `test-apps` at all. Every Microsoft package the run resolves comes from a *different* patch, `28.1.49838.54308`. Narrowing to the selected version would have resolved nothing.
2. **It is documented and test-pinned.** `CollectRunnerOwnedProvisionDirs`' own comment, and `ProvisioningCheckTests.CollectRunnerOwnedProvisionDirs_FindsDirsAcrossDifferentPatchVersions` / `NeedDetection_PlatformAppsUnderADifferentPatchThanSelectedEngine_AreNotReportedMissing`, exist because #2226 can leave `provision`'s platform-app and test-app sub-steps under different patch directories of the same major.minor. #2226 is still open.
3. **It is still reachable in the code, not just historically.** `Provisioning.EnsurePlatformAppsProvisioned` writes platform apps to `PlatformAppsDirFor(ResolveVersion(mm))` — the CDN's *latest* for the major.minor — while `EnsureTestToolkitProvisioned` writes to `TestAppsDirFor(fullVersion)`. Those two need not be the same patch.
4. **A partial set is reachable too.** `ArtifactDownloader.PlatformApps` and `.TestApps` write each `.app` straight into the output directory with `File.WriteAllBytes` and `continue` past an entry they could not fetch — no temp-directory-then-rename. An interrupted download leaves a partially populated directory behind, and today the union is what masks it with a complete older one.

## The change

`CollectRunnerOwnedProvisionDirs` now leaves a directory out when — and only when — **every package in it is already NAMED, at an equal or higher filename-encoded version, by a directory that stays**. Coverage is decided from the directory listing — names, and the versions those names encode — and never from a package's contents: one listing per directory, no package opened, nothing hashed.

`AppFileCoverageKey` splits a package file name into a stem and, when there is one, the version it encodes. Those are exactly the three shapes `ArtifactDownloader` writes: `Microsoft_Base Application_28.1.49838.54308.app` (platform set, versioned), `Microsoft_Any.app` (test toolkit, no version) and `System.app` (no publisher prefix).

Deliberately kept, each with its own test:

- a **partially downloaded newest patch** — the older complete directory stays and still answers the need;
- a **hand-placed higher-versioned package under an older patch** — the version comparison, not directory order, decides, so the resolver still sees the version it would have picked;
- **every empty directory** — it reads nothing, so it cannot be the cost, and it is still worth naming in "here is where we looked" diagnostics. This is also what the #2234 regression tests and `PackageCacheFinalSearchSetTests` construct, and they pass unchanged;
- the **#2226 cross-patch kind split** — platform apps under one patch, the test toolkit under another, neither covering the other.

An unrecognised file-name shape yields no version, which makes the filter *more* conservative, never less: the failure direction is a directory scanned needlessly, not a package that should have been found and was not.

### What it costs — the claim the first review falsified

The first version of this body said the narrowing "never omits [a directory] whose contents are not otherwise reachable", and the `ContributesUncoveredPackages` doc said "why this is lossless". **Both were wrong, and the reviewer reproduced it.** A name is not its bytes: a package whose *name* dominates but whose *content* is unusable now hides a complete older copy that the unfiltered search set would have resolved from. The reachable shape is the one this PR's own rationale opens — neither downloader writes to a temporary file and renames, so a `File.WriteAllBytes` interrupted part-way through a 98 MB package leaves a truncated file under the right name. With `Microsoft_Base Application_.54308.app` truncated over a complete `.54100` copy: `main` resolves from `.54100` and passes 24 tests; this PR exits 2 with "missing from every searched cache: Base Application".

I corrected the claim rather than defending it, and I did **not** take the suggested repair, because it does not work on this file format. Crediting a package only when it carries a ZIP end-of-central-directory record in its last 64 bytes: measured on this machine, **0 of 119 real packages have one** — every signed `.app` carries a ~10 KB Microsoft signature blob after the archive, ending in an `NXSB` trailer, so the EOCD sits ~10 KB from the end and the check would credit nothing at all, turning the whole narrowing off. Requiring that `NXSB` trailer instead *does* catch truncation, but it rests on an undocumented property of Microsoft's signing that no unsigned package would satisfy. Neither closes the general case — a package corrupt in the *middle* passes both — so neither restores a literal losslessness claim, and a strong claim resting on a weak check is worse than an accurate weaker one. The only honest check is reading the manifest, which is the entire cost this avoids.

So the accurate statement, now in the code and pinned by two tests: **coverage is by name and version; a truncated or corrupt file in a dominant directory loses the older complete copy.** I argue that is the better behaviour, deliberately, not an accident worth apologising for:

- It fails **loudly** — names the app, lists every directory searched, prints the provision command — and nothing caches the narrowed result, so it is a refusal rather than a wrong answer, and it clears the moment the package is re-fetched.
- A truncated package sitting in the artifact cache is a real defect. `main`'s silent recovery from a stale patch leaves it there indefinitely and makes the next `provision` look unnecessary; telling the developer is the more useful outcome.

`CollectRunnerOwnedProvisionDirs_TruncatedPackageInTheDominantDir_LosesTheOlderCompleteCopy` pins the cost, and `..._FailsLoudlyNamingTheApp` pins the consequence — including the contrast that the same required set resolves fine over *both* directories, so the difference really is the narrowing and not a broken fixture.

## RED → GREEN

**RED** (`git checkout origin/main -- AlRunner/Infrastructure/ProvisioningCheck.cs` equivalent — `ContributesUncoveredPackages` forced to `return true`):

```
Failed CollectRunnerOwnedProvisionDirs_DuplicatePlatformSetsAcrossPatches_ScansOnlyTheNewest
  Expected: [.../28.1.49838.54308/platform-apps]
  Actual:   [...54308/platform-apps, ...54044/platform-apps, ...53910/platform-apps]
Failed CollectRunnerOwnedProvisionDirs_DuplicateTestToolkitsAcrossPatches_ScansOnlyTheNewest
Failed PackageCacheFinalSearchSetTests.FinalSearchSet_DuplicatePatchDirs_FoldsInOnlyTheNewest
```

**GREEN**: `ProvisioningCheckTests` 127/127 (the two added trade-off tests included), `PackageCacheFinalSearchSetTests` 3/3, and a targeted sweep over the surface (`ProvisioningCheckTests`, `DependencyResolverTests`, `ManifestDependencyEdgeScanTests`, `EnsureTestToolkitProvisionedTests`, `PackageCacheFinalSearchSetTests`, `SourceDepSymbolsWithoutPackageCacheTests`, `PlaceholderFloorProvisioningTests`, `ArtifactsRootEnvOverrideTests`, `PkgDedupSearchSetProvenanceTests`) 206/206, re-run after the rebase onto `80abc76a`.

Four of the six new `CollectRunnerOwnedProvisionDirs` tests pass on `main` too, on purpose — they are the negative controls that stop this from becoming "drop everything but the newest".

## Re-measured, and against what

**Re-measured after the first review.** The original figures here were taken against `main` at `44500443`, before #3042 merged, on a root whose duplicates were hard links — which is exactly the shape #3042's inode-keyed content-hash memo collapses, so that baseline flattered this PR. Everything below is a fresh measurement against `main` at `80abc76a`, which contains #3042 (`407693c8`), on a root of **distinct files**: 345 packages, 345 distinct inodes.

Branch rebased onto `80abc76a`. Four `28.1` patch directories with `platform-apps`, three with `test-apps`, copied (not linked) from the real set under `AL_RUNNER_ARTIFACTS_ROOT`. Fixture `tests/runner-extras/session-user-row`, `--package-cache ~/.al-runner/platform-apps`, every cache warmed first, 5 interleaved samples, CPU from `getrusage(RUSAGE_CHILDREN)`:

| | search set | `.app` files scanned | bytes scanned | wall min/med | CPU min/med |
|---|---|---|---|---|---|
| `main` @ 80abc76a | 8 dirs | 351 | 677.4 MB | 2.18 s / 2.41 s | 2.41 s / 2.58 s |
| this PR | 3 dirs | 119 | 266.5 MB | 1.81 s / 1.95 s | 1.75 s / 1.91 s |
| same-binary control | 8 dirs | 351 | 677.4 MB | 2.28 s / 2.34 s | 2.62 s / 2.69 s |

61% fewer bytes; ~0.4 s wall and ~0.7 s CPU per invocation, against a same-binary control that moved 0.10 s — so the effect is several times the noise floor.

**And the two changes do not overlap.** The same benchmark on a *hard-linked* root: `main` 1.66 s, this PR 1.63 s — a 0.03 s difference, inside the control, because #3042 already collapses that shape. What this PR removes is four separate downloads with four separate inodes, which inode dedup correctly does nothing about. On the real single-patch artifacts root the search set is unchanged at 3 directories — CI provisions one version and sees no difference either way.

**Selection is unchanged, not just resolution** — re-verified on the new distinct-inode root against `80abc76a`, not carried over from the first measurement. `tests/runner-extras/microsoft-dependencies`, before and after, the full `[dep] ... <- <path>` list diffed byte for byte: identical, full paths included, only the wall-time line differing. `microsoft-test-library` resolves its whole 10-package Microsoft closure from the narrowed set (3P/0F/0E), `microsoft-dependencies` 24P/0F/0E, `session-user-row` 4P/0F/0E.

## Fixing the shape, not the reported line

- **Same wrong pattern at another call site?** `CollectRunnerOwnedProvisionDirs` has two production callers — `Program.cs`'s fold into `packageCacheDirs` and `Provisioning.DefaultPackageCacheDirs` — and both were paying it. Fixing the collector fixes both; that single-source-of-truth property is what #2234 built it for.
- **Sibling function with the same assumption?** `Provisioning.FindWarmProvisionedVersion` is the other place that walks every patch of the major.minor. It does **not** have the defect: it stops at the first version that satisfies the need, newest first, so it already pays only for what it uses. It carries its own inline copy of `EnumerateVersionDirNames`' filter-and-sort, which is a drift risk — left alone deliberately, because it needs the *unfiltered* list (its whole job is to consider older patches when the newest is incomplete), and sharing the now-filtered collector would be wrong. Nothing else unions across versions: `SelectVersionDirOrNull` and `SelectArtifactVersionDir` each pick exactly one directory.
- **Two paths writing the same state with different invariants?** Run path and need detection read the *same* list from the same function, before and after. That was already true and stays true — which is why the narrowing could not desynchronise them.

## Does this assert anything about BC?

No, and it owes no corpus test. What a directory is named, which of them the runner searches, and how it identifies a `.app` are facts about this runner's own artifact cache layout and `ArtifactDownloader`'s output; a BC service tier has no opinion on any of it and could not adjudicate the claim. Per `.claude/rules/bc-behavior-tests-go-upstream.md` this is the "no → runner-side" branch. The upstream corpus was reachable this morning, so this is a scope answer, not an availability excuse.

## Deliberately left out

- **No pruning of stale artifact directories.** The issue floats it as an alternative; deleting a provisioned artifact set is outside this issue's blast radius and `.claude/skills/autonomous-cycle` forbids deleting a shared cache an agent did not create. Nothing here deletes anything.
- **No change to how a package is identified.** The per-`.app` content hash is #2987/#3035/#3042's design in `AlRunner/Infrastructure/RunnerFingerprint.cs`; this PR reduces how many packages reach that code, not what it does. Nothing in that file, or in `FileIdentity.cs`, is touched here.
- **No content check on a package before crediting it as coverage.** Reasoned through and rejected above, with the measurement that rejects it.

---
Written by Claude Code agent `stma-auto-1` acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
