### PR TITLE
fix(field-triggers): refuse the two silent skips left on the install path

### DIFF
--- a/AlRunner.Tests/FieldTriggerInstallSilentSkipTests.cs
+++ b/AlRunner.Tests/FieldTriggerInstallSilentSkipTests.cs
@@ -1,0 +1,390 @@
+// FieldTriggerInstallSilentSkipTests — issue #3048.
+//
+// THE DEFECT: TWO SILENT SKIPS LEFT ON THE FIELD-TRIGGER INSTALL PATH
+// ------------------------------------------------------------------
+// #3026 converted seventeen refusals on this path from silent skips to named
+// BcShapeGapExceptions. Two skips on the same rewritten lines survived, because neither is a
+// question about BC's layout and so BcShapeGapException is the wrong type for either:
+//
+//   1. `catch { continue; }` around NCLMetaTable.GetFieldByNo, in BOTH install loops —
+//      RecordPatches.WireFieldTriggerHandlers (the base table's own OnValidate/OnLookup) and
+//      RecordPatches.WireExtensionValidateHandlers (a tableextension's before/after lists and
+//      the OnValidate/OnLookup of fields it ADDS). A field the metatable does not carry was
+//      skipped with nothing recorded, and the caller was still told the table was wired.
+//
+//   2. BuildFieldTriggerHandler returning null for a trigger method whose return type is
+//      neither void nor ValueTask. It wrote one line to stderr and returned null; all four
+//      call sites then skipped the install with `if (handler != null)` / `if (… == null)
+//      continue;` — and WireFieldTriggerHandlers STILL returned true, its contract for "this
+//      table is wired, do not retry". A successful-looking install that installed nothing.
+//
+// WHY THE NEGATIVE TESTS ARE WORDED THE WAY THEY ARE
+// --------------------------------------------------
+// The failure being fixed is SILENCE, so each negative test captures WireFieldTriggerHandlers'
+// return value (and, where the field exists to read, the handler slot) and puts both into the
+// assertion message. On origin/main the RED run therefore reports the silence itself —
+// "returned True and installed no ValidateHandler" — rather than the bare xUnit "expected an
+// exception", which would be true of any not-yet-written throw.
+//
+// WHAT `catch { continue; }` WAS ACTUALLY ABSORBING
+// -------------------------------------------------
+// Decompiled from the pristine service-tier Microsoft.Dynamics.Nav.Ncl.dll (28.1.49838.54308),
+// NCLMetaTable.GetFieldByNo(int fieldNo, bool trapError = false) has exactly three outcomes
+// when trapError is false: it returns the field (or a DisabledFields entry, which is also
+// non-null), it throws NavNCLFieldNotFoundException naming the field and the table caption, or
+// it throws InvalidOperationException("field is null") for a hole in AllFields. It CANNOT
+// return null — so the `if (metaField == null) continue;` that followed each catch was dead on
+// every supported build, and the catch itself could only ever be swallowing one of those two
+// throws. Neither is a legitimate condition: both mean the runner's own metatable does not
+// carry a field its own emitted AL declares a trigger for.
+//
+// Measured rather than assumed: with the three sites instrumented to print instead of skip,
+// the al-language corpus (2523 tests) and tests/runner-extras (298 tests) executed 253 table
+// wirings covering 2,592 base-table field installs and 55 tableextension field installs, and
+// produced ZERO hits on any of the three. Nothing legitimate reaches them, which is why the
+// fix is a refusal rather than a narrower catch.
+//
+// WHY RunnerOutOfScopeException AND NOT BcShapeGapException
+// ---------------------------------------------------------
+// Neither refusal is a property of the BC build on disk — a shape gap's message asks the
+// reader "which BC version produced this?", and that is the wrong question for both. An
+// unresolvable field is the runner's own metatable disagreeing with the runner's own emitted
+// AL; an unsupported return type is a property of the AL the runner EMITTED. Both are in-scope
+// surfaces the runner has not built an answer for, which is the case
+// .claude/rules/loud-failures.md assigns to RunnerOutOfScopeException with the reason anchor
+// `not-yet-implemented` — the anchor that stops an AL [TryFunction] absorbing the gap into
+// `false`.
+//
+// WHY A RUNNER-SIDE MECHANISM TEST AND NOT AN AL BUNDLE OR A CORPUS TEST
+// ----------------------------------------------------------------------
+// The subject is the runner's own install path over its own emitted AL, and the refusal
+// contract it must honour when it cannot install a trigger. No statement about Business
+// Central is being made, so there is nothing for a service tier to adjudicate — the same
+// classification .claude/rules/bc-behavior-tests-go-upstream.md gives
+// FieldTriggerHandlerBackingShapeGapTests, whose harness this file reuses.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Runtime.Extensions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Stand-in <c>Record&lt;id&gt;</c> whose two triggers use the two return types
+/// <c>BuildFieldTriggerHandler</c> supports — <c>void</c> and <c>ValueTask</c>. The positive
+/// control: without it the fix could pass by refusing unconditionally.
+///
+/// <para><c>internal</c>, not public, for the reason spelled out on
+/// <c>FieldTriggerGapStandInRecord</c>: xUnit discovery resolves a PUBLIC type's whole base
+/// chain, and <c>NavComplexValue</c> lives in a reference-only assembly that is not in the
+/// test bin dir.</para>
+/// </summary>
+internal sealed class FieldTriggerInstallSupportedReturnsRecord : NavRecord
+{
+    internal FieldTriggerInstallSupportedReturnsRecord() : base(null!, 0) { }
+
+    [FieldTriggerHandler(FieldTriggerType.OnValidate, FieldTriggerInstallSilentSkipTests.ValidateFieldNo)]
+    public void OnValidateNo() { }
+
+    [FieldTriggerHandler(FieldTriggerType.OnLookup, FieldTriggerInstallSilentSkipTests.LookupFieldNo)]
+    public ValueTask OnLookupDescription() => default;
+}
+
+/// <summary>Declares a trigger for a field number the table does not have.</summary>
+internal sealed class FieldTriggerInstallUnresolvableFieldRecord : NavRecord
+{
+    internal FieldTriggerInstallUnresolvableFieldRecord() : base(null!, 0) { }
+
+    [FieldTriggerHandler(FieldTriggerType.OnValidate, FieldTriggerInstallSilentSkipTests.GhostFieldNo)]
+    public void OnValidateGhost() { }
+}
+
+/// <summary>Declares a trigger the runner cannot wrap: the return type is neither void nor ValueTask.</summary>
+internal sealed class FieldTriggerInstallBadReturnTypeRecord : NavRecord
+{
+    internal FieldTriggerInstallBadReturnTypeRecord() : base(null!, 0) { }
+
+    [FieldTriggerHandler(FieldTriggerType.OnValidate, FieldTriggerInstallSilentSkipTests.ValidateFieldNo)]
+    public int OnValidateNo() => 0;
+}
+
+/// <summary>No field triggers of its own, so wiring falls straight through to the
+/// tableextension path — which is where this record's table is interesting.</summary>
+internal sealed class FieldTriggerInstallNoTriggerRecord : NavRecord
+{
+    internal FieldTriggerInstallNoTriggerRecord() : base(null!, 0) { }
+}
+
+/// <summary>
+/// Stand-in <c>TableExtension&lt;id&gt;</c>, declaring a <c>modify(field)</c>-style
+/// <c>OnBeforeValidate</c> for a field number the base table does not have. Never
+/// instantiated — <c>WireExtensionValidateHandlers</c> only reads the type's attributes and
+/// opens delegates over the annotated methods.
+/// </summary>
+internal sealed class FieldTriggerInstallStandInExtension : NavRecordExtension
+{
+    internal FieldTriggerInstallStandInExtension() : base(null!, 0) { }
+
+    [FieldTriggerHandler(FieldTriggerType.OnBeforeValidate, FieldTriggerInstallSilentSkipTests.GhostFieldNo)]
+    public void OnBeforeValidateGhost() { }
+}
+
+[Collection(BcEngineCollection.Name)]
+public sealed class FieldTriggerInstallSilentSkipTests : IDisposable
+{
+    internal const int ValidateFieldNo = 1;
+    internal const int LookupFieldNo = 2;
+
+    /// <summary>A field number no table written by this class declares.</summary>
+    internal const int GhostFieldNo = 4242;
+
+    // One table id per test so no test observes state a sibling installed. Chosen outside every
+    // other id in AlRunner.Tests (these land in the process-wide static _parsedTables /
+    // _metaTableCache the whole assembly shares).
+    private const int SupportedReturnsTableId = 93960;
+    private const int UnresolvableFieldTableId = 93961;
+    private const int BadReturnTypeTableId = 93962;
+    private const int ExtensionGhostFieldTableId = 93963;
+    private const int StandInExtensionId = 93964;
+
+    private readonly BcEngineFixture _engine;
+    private readonly string _root;
+
+    public FieldTriggerInstallSilentSkipTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = TestScratch.Dir("al-runner-3048-tests");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    // ── plumbing (same shape as FieldTriggerHandlerBackingShapeGapTests) ────────────────
+
+    private static FieldInfo Static(string name) =>
+        typeof(RecordPatches).GetField(name, BindingFlags.NonPublic | BindingFlags.Static)
+        ?? typeof(RecordPatches).GetField(name, BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+        ?? throw new InvalidOperationException($"RecordPatches.{name} not found — this test tracks that field.");
+
+    private static readonly MethodInfo EnsureReflection =
+        typeof(RecordPatches).GetMethod("EnsureFieldTriggerReflection", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("RecordPatches.EnsureFieldTriggerReflection not found.");
+
+    private static readonly MethodInfo WireOne =
+        typeof(RecordPatches).GetMethod("WireFieldTriggerHandlers", BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException("RecordPatches.WireFieldTriggerHandlers not found.");
+
+    /// <summary>Calls the real wiring entry point, unwrapping reflection's TargetInvocationException.</summary>
+    private static bool Wire(NCLMetaTable table, int tableId)
+    {
+        try
+        {
+            return (bool)WireOne.Invoke(null, new object[] { table, tableId })!;
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
+            throw;
+        }
+    }
+
+    private static string TableName(int tableId) => $"FieldTriggerInstall {tableId}";
+
+    /// <summary>The metatable for a freshly written one-off AL table, with <paramref name="recordType"/>
+    /// registered as its Record type so <c>FindRecordType</c> resolves.</summary>
+    private NCLMetaTable Arrange(int tableId, Type recordType)
+    {
+        var dir = Path.Combine(_root, tableId.ToString());
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "Table.al"), $$"""
+            table {{tableId}} "{{TableName(tableId)}}"
+            {
+                fields
+                {
+                    field({{ValidateFieldNo}}; "No."; Code[20]) { }
+                    field({{LookupFieldNo}}; "Description"; Text[50]) { }
+                }
+                keys
+                {
+                    key(PK; "No.") { Clustered = true; }
+                }
+            }
+            """);
+        RecordPatches.AddSourceDir(dir);
+
+        var skeleton = AlRunner.BcRuntime.SkeletonNCLMetadata;
+        Assert.NotNull(skeleton);
+        var table = RecordPatches.NCLMetadata_GetMetaTableById(skeleton!, tableId, false, 0);
+        Assert.NotNull(table);
+        Assert.Equal(tableId, table.TableId);
+
+        // The table must genuinely not carry the ghost field, or the negative tests would be
+        // asserting over a table that never reaches the unresolvable-field path at all.
+        Assert.False(table.TryGetFieldByNo(GhostFieldNo, out _),
+            $"table {tableId} unexpectedly carries field {GhostFieldNo} — the negative tests need it absent.");
+
+        EnsureReflection.Invoke(null, null);
+
+        var cache = (ConcurrentDictionary<int, Type>)Static("_recordTypeCache").GetValue(null)!;
+        cache[tableId] = recordType;
+
+        return table;
+    }
+
+    /// <summary>Reads a handler slot straight off BC's own EventTriggerData.</summary>
+    private static object? ReadHandler(NCLMetaTable table, int fieldNo, FieldInfo etdValueBacking, FieldInfo handlerBacking)
+    {
+        if (!table.TryGetFieldByNo(fieldNo, out var metaField)) return null;
+        var etd = etdValueBacking.GetValue(metaField);
+        return etd == null ? null : handlerBacking.GetValue(etd);
+    }
+
+    private static void AssertNotYetImplementedRefusal(Exception thrown, string apiFragment, string detailFragment)
+    {
+        var signal = OutOfScopeMessage.FromException(thrown);
+        Assert.True(signal is { Typed: true },
+            $"expected a typed RunnerOutOfScopeException, got {thrown.GetType().Name}: {thrown.Message}");
+        Assert.Contains(apiFragment, signal!.Value.Api, StringComparison.Ordinal);
+        Assert.StartsWith("not-yet-implemented", signal.Value.Reason, StringComparison.Ordinal);
+        Assert.Contains(detailFragment, thrown.Message, StringComparison.Ordinal);
+
+        // Not a shape gap: neither refusal is a property of which BC build is on disk, and the
+        // shape-gap message would send the reader to "which BC version produced this?".
+        Assert.Null(BcShapeGapException.Find(thrown));
+    }
+
+    // ── 1. POSITIVE CONTROL — both supported return types still install ─────────────────
+
+    [SkippableFact]
+    public void VoidAndValueTaskTriggers_AreBothActuallyInstalled_AndWiringReportsSuccess()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // MUST run before the statics below are read: they are populated lazily.
+        EnsureReflection.Invoke(null, null);
+
+        var etdValue = (FieldInfo)Static("_fEventTriggerDataValueBacking").GetValue(null)!;
+        var validate = (FieldInfo)Static("_fValidateHandlerBacking").GetValue(null)!;
+        var lookup = (FieldInfo)Static("_fLookupHandlerBacking").GetValue(null)!;
+
+        var table = Arrange(SupportedReturnsTableId, typeof(FieldTriggerInstallSupportedReturnsRecord));
+
+        Assert.True(Wire(table, SupportedReturnsTableId),
+            "wiring a table whose Record type resolved must report success");
+
+        Assert.NotNull(ReadHandler(table, ValidateFieldNo, etdValue, validate));   // void
+        Assert.NotNull(ReadHandler(table, LookupFieldNo, etdValue, lookup));       // ValueTask
+    }
+
+    // ── 2. THE UNRESOLVABLE FIELD, BASE-TABLE LOOP ─────────────────────────────────────
+
+    [SkippableFact]
+    public void FieldTheMetatableDoesNotCarry_RefusesNamingIt_InsteadOfContinuingPastIt()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        EnsureReflection.Invoke(null, null);
+        var table = Arrange(UnresolvableFieldTableId, typeof(FieldTriggerInstallUnresolvableFieldRecord));
+
+        bool? returned = null;
+        var thrown = Record.Exception(() => returned = Wire(table, UnresolvableFieldTableId));
+
+        Assert.True(thrown != null,
+            $"WireFieldTriggerHandlers returned {returned} for a table whose only AL field trigger " +
+            $"targets field {GhostFieldNo}, which its metatable does not carry. GetFieldByNo threw " +
+            "NavNCLFieldNotFoundException, `catch { continue; }` swallowed it, and the caller was told " +
+            "the table was wired — so the OnValidate trigger never fires, nothing is printed, and AL " +
+            "depending on it passes having run without it (#3048).");
+
+        AssertNotYetImplementedRefusal(thrown!, $"field {GhostFieldNo}", UnresolvableFieldTableId.ToString());
+    }
+
+    // ── 3. THE UNRESOLVABLE FIELD, TABLEEXTENSION LOOP — the sibling over the same state ─
+
+    [SkippableFact]
+    public void TableExtensionFieldTheMetatableDoesNotCarry_RefusesNamingIt_InsteadOfContinuingPastIt()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        EnsureReflection.Invoke(null, null);
+        var table = Arrange(ExtensionGhostFieldTableId, typeof(FieldTriggerInstallNoTriggerRecord));
+
+        // Register a tableextension for this base table without going through AL parsing: the
+        // subject is the install loop, not extension discovery. Both statics are process-global,
+        // so both are removed again in the finally — the class is DisableParallelization
+        // (BcEngineCollection), so no sibling observes the window.
+        var extIds = (Dictionary<string, List<int>>)Static("_extensionIdsByBaseTable").GetValue(null)!;
+        var extTypes = (ConcurrentDictionary<int, Type>)Static("_tableExtensionTypeCache").GetValue(null)!;
+        var key = TableName(ExtensionGhostFieldTableId).ToLowerInvariant();
+
+        bool? returned = null;
+        Exception? thrown;
+        lock (extIds)
+            extIds[key] = new List<int> { StandInExtensionId };
+        extTypes[StandInExtensionId] = typeof(FieldTriggerInstallStandInExtension);
+        try
+        {
+            thrown = Record.Exception(() => returned = Wire(table, ExtensionGhostFieldTableId));
+        }
+        finally
+        {
+            lock (extIds) extIds.Remove(key);
+            extTypes.TryRemove(StandInExtensionId, out _);
+        }
+
+        Assert.True(thrown != null,
+            $"WireFieldTriggerHandlers returned {returned} for a table whose tableextension declares an " +
+            $"OnBeforeValidate for field {GhostFieldNo}, which the base metatable does not carry. The " +
+            "second `catch { continue; }` — in WireExtensionValidateHandlers, over the same GetFieldByNo " +
+            "call — swallowed the same exception, so issue #1835's shape (an extension trigger that never " +
+            "fires) came back silently on this half (#3048).");
+
+        AssertNotYetImplementedRefusal(thrown!, $"field {GhostFieldNo}", ExtensionGhostFieldTableId.ToString());
+    }
+
+    // ── 4. THE UNSUPPORTED RETURN TYPE ─────────────────────────────────────────────────
+
+    [SkippableFact]
+    public void TriggerReturnTypeTheRunnerCannotWrap_RefusesNamingTheMethod_InsteadOfReportingSuccess()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        EnsureReflection.Invoke(null, null);
+
+        var etdValue = (FieldInfo)Static("_fEventTriggerDataValueBacking").GetValue(null)!;
+        var validate = (FieldInfo)Static("_fValidateHandlerBacking").GetValue(null)!;
+
+        var table = Arrange(BadReturnTypeTableId, typeof(FieldTriggerInstallBadReturnTypeRecord));
+
+        bool? returned = null;
+        var thrown = Record.Exception(() => returned = Wire(table, BadReturnTypeTableId));
+
+        var installed = ReadHandler(table, ValidateFieldNo, etdValue, validate);
+        Assert.True(thrown != null,
+            $"WireFieldTriggerHandlers returned {returned} and left EventTriggerData.ValidateHandler " +
+            $"{(installed == null ? "null" : "set")}. BuildFieldTriggerHandler declined the Int32-returning " +
+            "trigger, wrote one line to stderr, returned null — and every call site skipped the install " +
+            "while the caller still reported the table as wired: a successful-looking install that " +
+            "installed nothing (#3048).");
+
+        AssertNotYetImplementedRefusal(thrown!, "OnValidateNo", "Int32");
+
+        // And the refusal is not masking a partial install.
+        Assert.Null(installed);
+    }
+}

--- a/AlRunner.Tests/FieldTriggerInstallSilentSkipTests.cs
+++ b/AlRunner.Tests/FieldTriggerInstallSilentSkipTests.cs
@@ -39,7 +39,7 @@
 // carry a field its own emitted AL declares a trigger for.
 //
 // Measured rather than assumed: with the three sites instrumented to print instead of skip,
-// the al-language corpus (2523 tests) and tests/runner-extras (298 tests) executed 253 table
+// the al-language corpus (2599 tests) and tests/runner-extras (298 tests) executed 253 table
 // wirings covering 2,592 base-table field installs and 55 tableextension field installs, and
 // produced ZERO hits on any of the three. Nothing legitimate reaches them, which is why the
 // fix is a refusal rather than a narrower catch.

--- a/AlRunner/Patches/FieldTriggerInstallGaps.cs
+++ b/AlRunner/Patches/FieldTriggerInstallGaps.cs
@@ -1,0 +1,107 @@
+// FieldTriggerInstallGaps — the field-trigger install path's NON-shape-gap refusals (#3048).
+//
+// ── WHY A SECOND FILE NEXT TO FieldTriggerShapeGaps.cs ───────────────────────────────────
+// #3026 converted seventeen silent skips on this path into named BcShapeGapExceptions, and
+// deliberately left two alone. Both are still silent skips, and both are still wrong — but
+// neither is a question about BC's layout, so BcShapeGapException is the wrong TYPE for
+// either. A shape gap's message tells the reader "the runner could not read BC's internals"
+// and its first question is "which BC version produced this?" (docs/limitations.md
+// #bc-shape-gaps). For these two that question has no answer, because nothing about the BC
+// build on disk is involved:
+//
+//   * FIELD UNRESOLVABLE — the runner's own metatable does not carry a field number that the
+//     runner's own emitted AL declares a field trigger for. Both sides are the runner's.
+//   * UNSUPPORTED TRIGGER RETURN TYPE — the AL the runner EMITTED declares a trigger method
+//     returning something other than void or ValueTask, which BuildFieldTriggerHandler has no
+//     FieldTriggerHandler<T> constructor to wrap. Again: a property of our own output.
+//
+// Both are IN-SCOPE surfaces the runner has not built an answer for, which is the case
+// .claude/rules/loud-failures.md assigns to RunnerOutOfScopeException with the reason anchor
+// `not-yet-implemented`. That anchor is load-bearing, not cosmetic: for an AL [TryFunction],
+// ApplicationObjectBasePatches.IsPermanentOutOfScope traps a refusal into `false` UNLESS the
+// reason starts with `not-yet-implemented`. Under a docs/scope.md anchor a runner gap here
+// would read as a clean `if not TryX()`, which is the silent default the rule forbids.
+//
+// ── WHAT THE `catch { continue; }` WAS ACTUALLY ABSORBING ────────────────────────────────
+// Decompiled from the pristine service-tier Microsoft.Dynamics.Nav.Ncl.dll (28.1.49838.54308),
+// NCLMetaTable.GetFieldByNo(int fieldNo, bool trapError = false) has exactly three outcomes
+// with trapError false: it returns AllFields[idx] (or a DisabledFields entry — also non-null),
+// it throws NavNCLFieldNotFoundException naming the field and the table caption, or it throws
+// InvalidOperationException("field is null") for a hole in AllFields. It cannot return null,
+// so the `if (metaField == null) continue;` that followed each catch was dead code on every
+// supported build, and the catch could only ever have been swallowing one of those two throws.
+//
+// Measured, not assumed: with the three sites instrumented to print instead of skip, the
+// al-language corpus (2523 tests) and tests/runner-extras (298 tests) performed 253 table
+// wirings covering 2,592 base-table field installs and 55 tableextension field installs, and
+// hit NONE of the three. There is no legitimate traffic to tolerate here — which is why the
+// fix is a refusal rather than a narrower catch that keeps skipping.
+//
+// ── WHAT A REFUSAL HERE COSTS ────────────────────────────────────────────────────────────
+// WireFieldTriggerHandlersAll runs at bundle load, so a refusal on this path aborts the run
+// rather than failing one attributable test (issue #3047 tracks that this is unpinned). That
+// is the same trade #3026 accepted for the seventeen shape gaps, and it is the right side of
+// it: an abort names the table, the field and the reason, where the skip it replaces produced
+// a green suite in which the trigger simply never fired.
+//
+// See also:
+//   .claude/rules/loud-failures.md              — no silent out-of-scope failures
+//   docs/limitations.md#runtime-shape-gaps      — the reader-facing write-up
+//   AlRunner/Patches/FieldTriggerShapeGaps.cs   — the BC-layout half of the same install path
+
+using System;
+using System.Reflection;
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Patches;
+
+/// <summary>
+/// One place the field-trigger install path's <see cref="RunnerOutOfScopeException"/>s are
+/// built, so a refusal cannot drift back into a silent skip one call site at a time. See this
+/// file's header for the defect and for why these are not <see cref="BcShapeGapException"/>s.
+/// </summary>
+internal static class FieldTriggerInstallGap
+{
+    /// <summary>
+    /// docs/limitations.md, deliberately, NOT docs/scope.md: both refusals are in-scope gaps,
+    /// and citing the scope manifest would assert a permanence that is not true (see
+    /// <c>RunnerOutOfScopeException.BuildMessage</c>).
+    /// </summary>
+    private const string Doc = "docs/limitations.md#runtime-shape-gaps";
+
+    /// <summary>
+    /// A field the install loop has a built AL trigger handler for, which the metatable the
+    /// runner built for that table does not carry. Raised from BOTH install loops — the base
+    /// table's own <c>OnValidate</c>/<c>OnLookup</c> in
+    /// <c>RecordPatches.WireFieldTriggerHandlers</c>, and a tableextension's before/after lists
+    /// and added-field triggers in <c>WireExtensionValidateHandlers</c> — because both wrote
+    /// the same <c>EventTriggerData</c> state through the same <c>GetFieldByNo</c> call and
+    /// both swallowed the same exception.
+    /// </summary>
+    /// <param name="cause">
+    /// What <c>GetFieldByNo</c> did, verbatim, so the reader is not left guessing which of the
+    /// two failure modes fired.
+    /// </param>
+    internal static RunnerOutOfScopeException FieldUnresolvable(int tableId, int fieldNo, string cause)
+        => new($"AL field trigger installation (table {tableId}, field {fieldNo})",
+            "not-yet-implemented — field-trigger-install: this table's AL declares a field trigger "
+            + $"for field {fieldNo}, but the metatable the runner built for table {tableId} does not "
+            + $"carry that field ({cause}), so the handler cannot be attached and the trigger would "
+            + "never fire",
+            Doc);
+
+    /// <summary>
+    /// An AL trigger method whose return type <c>BuildFieldTriggerHandler</c> has no
+    /// <c>FieldTriggerHandler&lt;NavApplicationObjectBase&gt;</c> constructor for. BC closes
+    /// that type over exactly two shapes — <c>Action&lt;T&gt;</c> and
+    /// <c>Func&lt;T, ValueTask&gt;</c> — and the AL compiler emits a field trigger as one of
+    /// those two, so anything else is the runner's own emitted AL in a shape this path has
+    /// never been taught to wrap.
+    /// </summary>
+    internal static RunnerOutOfScopeException UnsupportedTriggerReturnType(MethodInfo target, Type returnType)
+        => new($"AL field trigger {target.DeclaringType?.Name}.{target.Name}",
+            $"not-yet-implemented — field-trigger-install: the trigger method returns {returnType.Name}, "
+            + "and only void and ValueTask can be wrapped in a FieldTriggerHandler, so the handler "
+            + "cannot be built and the trigger would never fire",
+            Doc);
+}

--- a/AlRunner/Patches/FieldTriggerInstallGaps.cs
+++ b/AlRunner/Patches/FieldTriggerInstallGaps.cs
@@ -32,7 +32,7 @@
 // supported build, and the catch could only ever have been swallowing one of those two throws.
 //
 // Measured, not assumed: with the three sites instrumented to print instead of skip, the
-// al-language corpus (2523 tests) and tests/runner-extras (298 tests) performed 253 table
+// al-language corpus (2599 tests) and tests/runner-extras (298 tests) performed 253 table
 // wirings covering 2,592 base-table field installs and 55 tableextension field installs, and
 // hit NONE of the three. There is no legitimate traffic to tolerate here — which is why the
 // fix is a refusal rather than a narrower catch that keeps skipping.

--- a/AlRunner/Patches/FieldTriggerShapeGaps.cs
+++ b/AlRunner/Patches/FieldTriggerShapeGaps.cs
@@ -68,8 +68,13 @@
 //     own First() throws, WireFieldTriggerHandlers' catch keeps swallowing it. Runner state,
 //     not BC layout.
 //   * BuildFieldTriggerHandler declining a trigger method whose return type is neither void
-//     nor ValueTask — that is a property of the AL the runner EMITTED, not of BC's layout,
-//     and it already prints. It stays a null return.
+//     nor ValueTask — that is a property of the AL the runner EMITTED, not of BC's layout, so
+//     it is not a shape gap. It is not a quiet skip either any more: #3048 made it a
+//     RunnerOutOfScopeException with the reason anchor `not-yet-implemented`, because printing
+//     and returning null still left every call site skipping the install while
+//     WireFieldTriggerHandlers reported the table as wired. See FieldTriggerInstallGaps.cs,
+//     which also covers the `catch { continue; }` around GetFieldByNo in both install loops —
+//     the other silent skip #3026 left behind for the same "not about BC's layout" reason.
 //
 // ── THE CATCH THAT WOULD HAVE EATEN THIS ─────────────────────────────────────────────────
 // WireFieldTriggerHandlers ends in a catch-all that prints and returns false. Left alone it
@@ -80,6 +85,7 @@
 // See also:
 //   .claude/rules/loud-failures.md            — no silent out-of-scope failures
 //   docs/limitations.md#bc-shape-gaps         — the reader-facing write-up
+//   AlRunner/Patches/FieldTriggerInstallGaps.cs — the same install path's non-shape-gap refusals
 //   AlRunner/Patches/TestPageShapeGaps.cs     — the read-path sibling, and where #3026 was filed
 
 using System.Reflection;

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -1422,10 +1422,12 @@ public static partial class RecordPatches
             foreach (var kvp in byField)
             {
                 var fieldNo = kvp.Key;
-                NCLMetaField? metaField;
-                try { metaField = built.GetFieldByNo(fieldNo, /*trapError:*/ false); }
-                catch { continue; }
-                if (metaField == null) continue;
+                // #3048: this used to be `catch { continue; }` — a field the metatable does not
+                // carry was skipped with nothing recorded, and the caller was still told the
+                // table was wired, so the AL trigger silently never fired. See
+                // FieldTriggerInstallGaps.cs for what GetFieldByNo can actually raise and for
+                // the measurement showing nothing legitimate reaches here.
+                var metaField = ResolveMetaFieldForTriggerInstall(built, tableId, fieldNo);
 
                 var existing = etdValueBacking.GetValue(metaField);
                 var etd = existing ?? Activator.CreateInstance(etdType)!;
@@ -1438,16 +1440,14 @@ public static partial class RecordPatches
                     var backing = FieldTriggerShapeGap.RequireHandlerBacking(
                         _fValidateHandlerBacking, "ValidateHandler", tableId, fieldNo);
                     var handler = BuildFieldTriggerHandler(kvp.Value.validate, recordType);
-                    if (handler != null)
-                        AlRunner.Infrastructure.FieldPoke.SetInstance(backing, etd, handler);
+                    AlRunner.Infrastructure.FieldPoke.SetInstance(backing, etd, handler);
                 }
                 if (kvp.Value.lookup != null)
                 {
                     var backing = FieldTriggerShapeGap.RequireHandlerBacking(
                         _fLookupHandlerBacking, "LookupHandler", tableId, fieldNo);
                     var handler = BuildFieldTriggerHandler(kvp.Value.lookup, recordType);
-                    if (handler != null)
-                        AlRunner.Infrastructure.FieldPoke.SetInstance(backing, etd, handler);
+                    AlRunner.Infrastructure.FieldPoke.SetInstance(backing, etd, handler);
                 }
                 AlRunner.Infrastructure.FieldPoke.SetInstance(etdValueBacking, metaField, etd);
             }
@@ -1462,7 +1462,15 @@ public static partial class RecordPatches
         // do that if this frame swallows it first. Everything else — notably Ncl not being
         // loaded yet, which makes EnsureFieldTriggerReflection's First() throw — keeps its
         // old behaviour.
-        catch (Exception ex) when (AlRunner.Infrastructure.BcShapeGapException.Find(ex) is null)
+        //
+        // #3048 widened it to the TYPED RunnerOutOfScopeException for the same reason: the two
+        // refusals in FieldTriggerInstallGaps.cs are raised from inside this try, and swallowing
+        // one here would restore precisely the silent skip they replace. Typed only — a BC
+        // exception whose message merely happens to contain the out-of-scope convention is not
+        // one of ours and must keep the old behaviour.
+        catch (Exception ex) when (AlRunner.Infrastructure.BcShapeGapException.Find(ex) is null
+                                   && AlRunner.Infrastructure.OutOfScopeMessage.FromException(ex)
+                                      is not { Typed: true })
         {
             Console.Error.WriteLine($"[RecordPatches] WireFieldTriggerHandlers({tableId}) failed: {ex.GetType().Name}: {ex.Message}");
             return false;
@@ -1524,7 +1532,6 @@ public static partial class RecordPatches
                     if (ttName == "OnValidate" || ttName == "OnLookup")
                     {
                         var single = BuildFieldTriggerHandler(mi, extType);
-                        if (single == null) continue;
                         if (ttName == "OnValidate") validateByField[fieldNo] = single;
                         else lookupByField[fieldNo] = single;
                         continue;
@@ -1534,7 +1541,6 @@ public static partial class RecordPatches
                                : null;
                     if (target == null) continue;
                     var handler = BuildFieldTriggerHandler(mi, extType);
-                    if (handler == null) continue;
                     if (!target.TryGetValue(fieldNo, out var list))
                         target[fieldNo] = list = new List<object>();
                     list.Add(handler);
@@ -1554,10 +1560,10 @@ public static partial class RecordPatches
 
         foreach (var fieldNo in fieldsToWire)
         {
-            NCLMetaField? metaField;
-            try { metaField = built.GetFieldByNo(fieldNo, /*trapError:*/ false); }
-            catch { continue; }
-            if (metaField == null) continue;
+            // #3048: the sibling of the base-table loop's skip, over the same GetFieldByNo call
+            // and the same EventTriggerData state — issue #1835's shape (a tableextension
+            // trigger that never fires) came back silently on this half.
+            var metaField = ResolveMetaFieldForTriggerInstall(built, tableId, fieldNo);
 
             var etd = etdValueBacking.GetValue(metaField)
                       ?? Activator.CreateInstance(etdType)!;
@@ -1586,6 +1592,40 @@ public static partial class RecordPatches
         }
     }
 
+    /// <summary>
+    /// The metafield an install loop is about to attach a built AL trigger handler to, or a
+    /// refusal naming the table and the field (#3048).
+    ///
+    /// <para>Called only once a handler for <paramref name="fieldNo"/> is in hand, so it can
+    /// never fire for a field that declares no trigger. <c>trapError: false</c> is deliberate
+    /// and unchanged: BC's own body then returns the field (or a <c>DisabledFields</c> entry,
+    /// also non-null), or throws — it cannot return null, which is why the null branch below
+    /// says what it says rather than skipping.</para>
+    /// </summary>
+    private static NCLMetaField ResolveMetaFieldForTriggerInstall(NCLMetaTable built, int tableId, int fieldNo)
+    {
+        NCLMetaField? metaField;
+        try
+        {
+            metaField = built.GetFieldByNo(fieldNo, /*trapError:*/ false);
+        }
+        catch (Exception ex) when (AlRunner.Infrastructure.BcShapeGapException.Find(ex) is null
+                                   && AlRunner.Infrastructure.OutOfScopeMessage.FromException(ex)
+                                      is not { Typed: true })
+        {
+            // NavNCLFieldNotFoundException (the field is not in AllFields) or
+            // InvalidOperationException("field is null") (a hole in AllFields). The filter keeps
+            // a refusal raised deeper from being re-wrapped into a second one.
+            throw FieldTriggerInstallGap.FieldUnresolvable(
+                tableId, fieldNo, $"{ex.GetType().Name}: {ex.Message}");
+        }
+        return metaField
+            ?? throw FieldTriggerInstallGap.FieldUnresolvable(
+                tableId, fieldNo,
+                "NCLMetaTable.GetFieldByNo(trapError: false) returned null, which BC's own body "
+                + "cannot do on any supported build");
+    }
+
     // Box a List<object> of FieldTriggerHandler<NavApplicationObjectBase> into the strongly
     // typed List<FieldTriggerHandler<NavApplicationObjectBase>> the EventTriggerData expects.
     private static object ToHandlerList(List<object> handlers, int tableId, int fieldNo)
@@ -1599,7 +1639,13 @@ public static partial class RecordPatches
 
     private static Type? _tNavApplicationObjectBase;
 
-    private static object? BuildFieldTriggerHandler(MethodInfo target, Type recordType)
+    /// <summary>
+    /// Wrap one AL trigger method in BC's <c>FieldTriggerHandler&lt;NavApplicationObjectBase&gt;</c>.
+    /// Returns non-null or throws (#3048): every caller used to skip its install on a null and
+    /// still report the table as wired, so a handler that could not be built was indistinguishable
+    /// from one that was.
+    /// </summary>
+    private static object BuildFieldTriggerHandler(MethodInfo target, Type recordType)
     {
         // FieldTriggerHandler<T> is closed by BC over T = NavApplicationObjectBase
         // (the base class for all AL-emitted Record/Codeunit/etc. types) — this is
@@ -1664,8 +1710,11 @@ public static partial class RecordPatches
                     + "wrapped and the trigger would never fire");
             return ctor.Invoke(new object[] { recordType, wrapper });
         }
-        Console.Error.WriteLine($"[RecordPatches] WireFieldTriggerHandlers: skip {target.DeclaringType?.Name}.{target.Name} — unsupported return type {ret.Name}");
-        return null;
+        // #3048: this used to print one stderr line and return null, and every call site then
+        // skipped the install while WireFieldTriggerHandlers still returned true — a
+        // successful-looking install that installed nothing. It is NOT a BcShapeGapException:
+        // the return type is a property of the AL the runner emitted, not of BC's layout.
+        throw FieldTriggerInstallGap.UnsupportedTriggerReturnType(target, ret);
     }
 
     // Helpers that produce strongly typed delegates over the concrete recordType.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -935,6 +935,13 @@ fired, and AL that depended on it *passed*. The same applies to the tableextensi
 `OnBeforeValidate` / `OnAfterValidate` handler lists and to the types
 `BuildFieldTriggerHandler` wraps a trigger method in.
 
+Two further skips on those same rewritten lines were **not** shape gaps and are covered above
+under [runtime shape gaps](#runtime-shape-gaps): an unresolvable field number and an
+unsupported trigger return type
+([#3048](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3048)). They refuse
+with `out-of-scope:` + `not-yet-implemented` rather than `bc-shape-gap:`, because neither is a
+property of the BC build on disk.
+
 The refusal is proportional — it fires only for a table and field the runner has a handler in
 hand for. A table that declares no field trigger still wires and reports success on such a
 build, because nothing was skipped for it. The two exceptions are
@@ -964,7 +971,16 @@ https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues.
     hold (`RunnerTestClientSession.cs`), and modal/page dispatch handed a null test-execution
     context or request (`RunnerModalDispatch.cs`);
   - **report construction**, when the runner cannot build the report object at all to run it
-    or its request page (`NavReportSync.cs`).
+    or its request page (`NavReportSync.cs`);
+  - **AL field-trigger installation**, in two shapes that used to be skipped in silence
+    ([#3048](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3048)) — a field
+    the runner's own metatable does not carry although the runner's own emitted AL declares a
+    trigger for it, and a trigger method whose return type is neither `void` nor `ValueTask`,
+    which BC's `FieldTriggerHandler<T>` has no constructor for
+    (`AlRunner/Patches/FieldTriggerInstallGaps.cs`). Neither is a BC shape gap: both sides of
+    each disagreement are the runner's own, so "which BC version produced this?" has no answer.
+    Both used to leave `WireFieldTriggerHandlers` reporting the table as wired, so the trigger
+    never fired and AL depending on it passed anyway.
 
   Real BC does all of these, so each is the runner failing to keep up rather than a surface BC
   also lacks — which is the test for whether a refusal may cite `docs/scope.md` at all.


### PR DESCRIPTION
Closes #3048

#3041 (merged as `fe8f7584`) converted seventeen refusals on the field-trigger install path
from silent skips to named `BcShapeGapException`s, and deliberately left two alone because
neither is a question about BC's layout. Both were still silent skips, and both still produced
a **successful-looking install that installed nothing**.

## What each `catch` was actually absorbing, and how I established it

`NCLMetaTable.GetFieldByNo(int fieldNo, bool trapError = false)`, decompiled from the pristine
service-tier `Microsoft.Dynamics.Nav.Ncl.dll` 28.1.49838.54308, has exactly three outcomes with
`trapError` false:

- returns `AllFields[idx]`, or a `DisabledFields` entry — both non-null;
- throws `NavNCLFieldNotFoundException`, naming the field and the table caption;
- throws `InvalidOperationException("field is null")` for a hole in `AllFields`.

It **cannot return null**. So the `if (metaField == null) continue;` that followed each
`catch { continue; }` was dead code on every supported build, and the catch could only ever
have been swallowing one of those two throws. Neither is a legitimate condition: both mean the
runner's own metatable does not carry a field the runner's own emitted AL declares a trigger
for.

`git log -S` on the line finds it introduced whole at the v2 cutover (#1654) with no recorded
reason — the "catch with no recorded reason" shape, so reading it was not enough. I measured
it: all three sites instrumented to **print instead of skip**, then the full al-language corpus
(2599 tests) and `tests/runner-extras` (298 tests) run against BC 28.1. Positive control on the
same instrumented build, so a zero cannot mean "the path never executed":

| | table wirings | field installs | hits on the three sites |
|---|---|---|---|
| al-language corpus | 87 base + 9 extension | 1,013 base + 19 extension | 0 |
| runner-extras | 147 base + 10 extension | 1,579 base + 36 extension | 0 |

253 wirings, 2,647 field installs, **zero** unresolvable fields and **zero** unsupported return
types. There is no legitimate traffic to tolerate, so the fix is a refusal rather than a
narrower catch that keeps skipping.

The one ordering hazard I expected to find — a base metatable cached before a tableextension's
fields were merged into it — turns out to be handled upstream of this path by
`EvictCachedMetaTableForBaseTable` (#2126), which is consistent with the zero.

## The two refusals

**1. Unresolvable field, in BOTH install loops.** `WireFieldTriggerHandlers` (the base table's
own `OnValidate`/`OnLookup`) and `WireExtensionValidateHandlers` (a tableextension's
before/after lists and the `OnValidate`/`OnLookup` of fields it *adds*) made the same
`GetFieldByNo` call and swallowed the same exception. Both now go through one
`ResolveMetaFieldForTriggerInstall` that refuses, naming the table and the field.

**2. Unsupported trigger return type.** `BuildFieldTriggerHandler` printed one stderr line and
returned `null`; all four call sites skipped the install with `if (handler != null)` /
`if (… == null) continue;`, and `WireFieldTriggerHandlers` still returned `true`. It now
throws, and the method's return type is non-nullable — so all four null guards are gone with
it, rather than one of them being fixed.

Both are `RunnerOutOfScopeException` with the reason anchor `not-yet-implemented`, **not**
`BcShapeGapException`. An unresolvable field is the runner's own metatable disagreeing with the
runner's own emitted AL; a return type is a property of the AL the runner emitted. A shape gap's
message asks "which BC version produced this?", and for neither of these does that question have
an answer. `loud-failures.md` assigns exactly this case — in scope, not built yet — to
`RunnerOutOfScopeException`, and the `not-yet-implemented` anchor is load-bearing: it is what
stops an AL `[TryFunction]` absorbing the gap into `false`.

`WireFieldTriggerHandlers`' outer `catch` is widened to let a **typed**
`RunnerOutOfScopeException` through, for the same reason #3026 widened it for
`BcShapeGapException`: both new refusals are raised inside that `try`, and swallowing one there
would restore precisely the skip it replaces. Typed only — a BC exception whose message merely
happens to contain the out-of-scope convention keeps the old behaviour.

## Which refusals can abort a whole bundle

Both. `WireFieldTriggerHandlersAll` runs at bundle load (three call sites), so a refusal here
aborts the run rather than failing one attributable test — the same trade #3026 accepted for its
seventeen, unstated and unpinned today, tracked by #3047. It is the right side of the trade: the
abort names the table, the field and the reason, where the skip it replaces produced a green
suite in which the trigger simply never fired.

## RED → GREEN

The failure being fixed is *silence*, so each negative test captures
`WireFieldTriggerHandlers`' return value (and, where the field exists to read, the handler slot)
and puts both in the assertion message. RED on this branch's parent, verbatim:

```
WireFieldTriggerHandlers returned True for a table whose only AL field trigger targets field
4242, which its metatable does not carry. GetFieldByNo threw NavNCLFieldNotFoundException,
`catch { continue; }` swallowed it, and the caller was told the table was wired — so the
OnValidate trigger never fires, nothing is printed, and AL depending on it passes having run
without it (#3048).

WireFieldTriggerHandlers returned True for a table whose tableextension declares an
OnBeforeValidate for field 4242, which the base metatable does not carry. The second
`catch { continue; }` — in WireExtensionValidateHandlers, over the same GetFieldByNo call —
swallowed the same exception, so issue #1835's shape (an extension trigger that never fires)
came back silently on this half (#3048).

WireFieldTriggerHandlers returned True and left EventTriggerData.ValidateHandler null.
BuildFieldTriggerHandler declined the Int32-returning trigger, wrote one line to stderr,
returned null — and every call site skipped the install while the caller still reported the
table as wired: a successful-looking install that installed nothing (#3048).
```

`Failed: 3, Passed: 1` — the fourth is the positive control, which passed in RED and is what
stops the fix passing by refusing unconditionally: a `void` trigger and a `ValueTask` trigger
(the two shapes `BuildFieldTriggerHandler` supports) must both still be *installed*, read back
off BC's own `EventTriggerData`, and the wiring must still report success.

GREEN: `Passed: 4, Failed: 0`. Each negative additionally asserts the refusal is typed, that its
`Api` names the table and field (or the method), that its `Reason` starts `not-yet-implemented`,
and that `BcShapeGapException.Find` returns null on it — so a future change that reclassifies
either refusal as a shape gap fails here.

Fault injection follows #3041's rule: nothing in production is made settable for a test. The
tableextension case seeds the two process-global caches by reflection and removes both in a
`finally`, in a `DisableParallelization` collection.

## What else I ran

- **al-language corpus**, CI's invocation (`--strict --count-baseline --package-cache`):
  **2599/2599 pass**, exit 0.
- **`tests/runner-extras`**, CI's invocation: **298/298 pass**, exit 0.
- **Filtered `AlRunner.Tests`** over the changed surface —
  `FieldTrigger|TableExt|VirtualTableRefusalClaim|RunnerShapeGapClaim|BcShapeGapConvention|PrivateMemberLookup|AlMemberSyntaxIndex|RecordTriggerXRec|RecordPatches`:
  **263/263 pass, 0 skipped**.

All on BC 28.1.49838.54308. I did not run the whole `AlRunner.Tests` suite.

`VirtualTableRefusalClaimTests`' `Assert.Equal(67, total)` is **unchanged and passing**: its
regex is `throw (RecordPatches\.)?[A-Za-z]+(?<!Bc)ShapeGap\(` over a fixed file list that does
not include `RecordPatches.NclMetaTableBuilder.cs`, and the new refusals live in a new file with
factory names that do not end in `ShapeGap`. Verified by running the test, not by reading it.

## Does this assert anything about BC? No — and the corpus cannot express it

Neither refusal is a statement about Business Central, and neither is expressible upstream:

- The **unresolvable field** is the runner's own metatable disagreeing with the runner's own
  emitted AL. Both sides are ours. No AL statement can create that disagreement — an AL author
  writes `field(N; …)` and `trigger OnValidate()`, and the compiler emits the attribute from the
  same declaration the parser reads.
- The **return type** of a field trigger is chosen by the AL compiler, not written in AL source.
  BC closes `FieldTriggerHandler<T>` over exactly `Action<T>` and `Func<T, ValueTask>`, so
  there is no AL a corpus test could write to select a third shape.

Nothing is left untested as a result: neither claim needs a service tier, and no AL-observable
behaviour changes while a trigger *can* be installed — which the positive control and both full
AL suites hold in place. If some BC version in 27.0–28.4 did reach either refusal, CI's eight
legs surface it as a loud red on that leg, which is exactly the outcome this change is for.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site?** Yes — the issue names one `catch { continue; }`;
   there were two, the second in `WireExtensionValidateHandlers` over the same `GetFieldByNo`
   call. Both fixed, and the extension one has its own test.
2. **Sibling function with the same assumption?** Yes — the issue names
   `BuildFieldTriggerHandler` returning `null`, and **four** call sites skipped on it. Making
   the return type non-nullable removed all four at once. One more `TryGetFieldByNo(…) continue`
   exists at `RecordPatches.NclMetaTableBuilder.cs:1764`, in `FixupEnumFieldOptionMetadata` — a
   different surface (enum option metadata, not trigger installation) with its own catch that
   already prints, so it is deliberately **not** in this PR.
3. **Two paths writing the same state with different invariants?** That was the defect: the
   base-table and tableextension loops both wrote `NCLMetaField.EventTriggerData`, and #3026 had
   already given them matching `BcShapeGapException` guards while leaving them mismatched on this
   one. They now refuse identically through one helper.

Docs: `docs/limitations.md#runtime-shape-gaps` gains both refusals, and the `#bc-shape-gaps`
section gains a pointer saying why these two are not shape gaps. The stale "it stays a null
return" bullet in `FieldTriggerShapeGaps.cs`' header is corrected — it described the behaviour
this PR replaces.

---
*Written by an agent (`stma-auto-1`) acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
