### PR TITLE
fix(record): decide Object's --test-data precedence from what the backup loaded, not from what the store holds

### DIFF
--- a/AlRunner.Tests/ObjectSystemTableBaselineExclusionTests.cs
+++ b/AlRunner.Tests/ObjectSystemTableBaselineExclusionTests.cs
@@ -1,0 +1,392 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #2875 — the Object system table (2000000001) could not tell a --test-data backup's
+/// rows from its OWN projection replayed back into a fresh provider by an install-baseline
+/// restore.
+///
+/// <para>The latch in PopulateObjectSystemTable asked <c>ProviderHasAnyRow</c>, and that
+/// question cannot distinguish the two writers. A boundary restore builds a BRAND-NEW
+/// in-memory provider, which gets a fresh ConditionalWeakTable entry, so rows the projection
+/// itself wrote before the capture read back as "somebody else owns this table" and the
+/// top-up never ran again for that provider. #2842 narrowed it to runs that have a
+/// --test-data loader at all; the residue was --test-data plus an install baseline.</para>
+///
+/// <para>The fix removes the ambiguity at its source rather than guessing better: the
+/// projection's rows are never put in a baseline in the first place, exactly like the
+/// self-populating virtual tables of #2272, so the only rows a restored provider can hold for
+/// this table are a backup's. Provenance is recorded by the one other writer —
+/// TestDataProvisioner's on-demand load — so "the backup owns this table" is a fact the
+/// runner has measured, not one it infers from row presence.</para>
+///
+/// <para>WHAT THIS TEST CAN AND CANNOT REACH. The exclusion half is drivable in CI with no
+/// backup at all: a fixture whose Install trigger touches <c>Record "Object"</c> materialises
+/// the projection inside the capture window, and the capture must then report 2000000001 as
+/// left out. The --test-data half is not — CI has no BC database backup — so the provenance
+/// switch itself is pinned by ObjectSystemTableRowProvenanceTests, which drives the same two
+/// writers directly.</para>
+///
+/// <para>Both halves of the #2272 standard are asserted here, because either alone is
+/// worthless: the table is GONE from the baseline (from the capture marker, which names the
+/// ids it skipped), and it still ANSWERS truthfully afterwards — across a codeunit boundary
+/// and a test boundary, on all four DataAccess request paths (find, count, keyed Get and
+/// IsEmpty, which RecordImplementation.IsEmptyAsync serves from its own ExistsAsync rather
+/// than from CountAsync), positively for objects the fixture declares and negatively for an
+/// id it does not.</para>
+///
+/// <para>The fixture also seeds an ordinary row from the same Install trigger and asserts it
+/// survives every boundary. That is the control: it fails if the change broke the install
+/// baseline generally rather than narrowing what goes into it.</para>
+///
+/// <para>Spawns the real runner; needs the BC artifact cache. Skips (loudly) when absent.</para>
+/// </summary>
+public class ObjectSystemTableBaselineExclusionTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    /// <summary>The literal id, not RecordPatches.ObjectSystemTableId: a test that reads the
+    /// same constant the implementation does cannot notice that constant changing.</summary>
+    private const int ObjectSystemTableId = 2000000001;
+
+    private const int BaseId = 62760;
+    private const int TableId = BaseId + 0;
+    private const int PageId = BaseId + 1;
+    private const int TestsAId = BaseId + 2;
+    private const int TestsBId = BaseId + 3;
+    private const int AssertId = BaseId + 4;
+    private const int InstallId = BaseId + 5;
+
+    /// <summary>An id inside the fixture's own idRange that the fixture deliberately does not
+    /// declare. It has to come from the fixture's OWN range: the runner accumulates its object
+    /// inventory across every app group in a process, so an id borrowed from anywhere else
+    /// could be claimed by something and the negative arms would fail for an unrelated
+    /// reason.</summary>
+    private const int NeverDeclaredId = BaseId + 19;
+
+    private static (string output, int exit) RunRunner(string[] extraArgs, params string[] bundles)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" --package-cache \"").Append(TestArtifacts.PlatformAppsDir()).Append('"');
+        foreach (var a in extraArgs) args.Append(' ').Append(a);
+        foreach (var b in bundles) args.Append(" \"").Append(b).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+            Environment =
+            {
+                ["AL_RUNNER_PERF"] = "1",
+                // The capture marker is the claim. On a machine with a warm on-disk dep+company
+                // baseline the dependency capture is skipped entirely, so force it to be
+                // recomputed rather than measuring the cache.
+                ["AL_RUNNER_NO_DEP_COMPANY_CACHE"] = "1",
+            },
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(300_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>Writes the fixture. `target: OnPrem` is mandatory: Microsoft declares Object
+    /// Scope = OnPrem, so a Cloud-target app fails AL0296 on `Record "Object"`. No
+    /// "application" property — see .claude/rules/no-base-app-in-csharp-tests.md.</summary>
+    private static void WriteFixture(string dir)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{Guid.NewGuid()}}",
+          "name": "IT2875 Object Baseline",
+          "publisher": "IssueTest2875",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": {{BaseId}}, "to": {{BaseId + 19}} } ],
+          "runtime": "14.0",
+          "target": "OnPrem"
+        }
+        """);
+
+        var al = FixtureAlTemplate
+            .Replace("$TABLE$", TableId.ToString())
+            .Replace("$PAGE$", PageId.ToString())
+            .Replace("$TESTSA$", TestsAId.ToString())
+            .Replace("$TESTSB$", TestsBId.ToString())
+            .Replace("$ASSERT$", AssertId.ToString())
+            .Replace("$INSTALL$", InstallId.ToString())
+            .Replace("$ABSENT$", NeverDeclaredId.ToString());
+        File.WriteAllText(Path.Combine(dir, "Fixture.al"), al);
+    }
+
+    private const string FixtureAlTemplate = """
+        table $TABLE$ "IT2875 Widget"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "No."; Code[20]) { }
+                field(2; Description; Text[50]) { }
+            }
+            keys { key(PK; "No.") { Clustered = true; } }
+        }
+
+        page $PAGE$ "IT2875 Widget Card"
+        {
+            PageType = Card;
+            SourceTable = "IT2875 Widget";
+            layout
+            {
+                area(content)
+                {
+                    field("No."; Rec."No.") { ApplicationArea = All; }
+                    field(Description; Rec.Description) { ApplicationArea = All; }
+                }
+            }
+        }
+
+        codeunit $INSTALL$ "IT2875 Install"
+        {
+            Subtype = Install;
+
+            // Two things, both before CaptureInstallBaseline() runs.
+            //
+            // 1. Touch Object, so the projection materialises INSIDE the capture window. That
+            //    is what makes "was 2000000001 in the baseline?" a deterministic question on
+            //    every BC version, rather than one that depends on whether a dependency
+            //    Install trigger or Company-Initialize happened to read the table.
+            // 2. Seed an ordinary row. That is the control for the whole change: if the
+            //    install baseline stopped working generally rather than getting narrower, the
+            //    seed stops surviving the boundary and every test below fails on it.
+            trigger OnInstallAppPerCompany()
+            var
+                Obj: Record "Object";
+                Widget: Record "IT2875 Widget";
+            begin
+                Obj.SetRange(Type, Obj.Type::Table);
+                if Obj.FindFirst() then;
+
+                Widget.Init();
+                Widget."No." := 'SEED';
+                Widget.Description := 'seeded by the install trigger';
+                Widget.Insert();
+            end;
+        }
+
+        codeunit $ASSERT$ "IT2875 Assert"
+        {
+            procedure IsTrue(Condition: Boolean; Msg: Text)
+            begin
+                if not Condition then
+                    Error('Assert.IsTrue failed. %1', Msg);
+            end;
+
+            procedure IsFalse(Condition: Boolean; Msg: Text)
+            begin
+                if Condition then
+                    Error('Assert.IsFalse failed. %1', Msg);
+            end;
+
+            procedure AreEqual(Expected: Text; Actual: Text; Msg: Text)
+            begin
+                if Expected <> Actual then
+                    Error('Assert.AreEqual failed. Expected <%1>, got <%2>. %3', Expected, Actual, Msg);
+            end;
+
+            // Every claim is a concrete value for a concrete object THIS app group declares,
+            // and every one has a negative twin against $ABSENT$ — an id in the fixture's own
+            // range that it deliberately does not declare. An empty table fails the positive
+            // arms; a table answering for an object that does not exist fails the negative
+            // ones. Both are needed: after the restore stops carrying this table, "it is gone
+            // from the baseline" and "it still answers" have to be true at the same time.
+            //
+            // All FOUR DataAccess request paths are exercised, not just find. IsEmpty() is not
+            // a spelling of Count(): RecordImplementation.IsEmptyAsync calls its own
+            // ExistsAsync, so a fix that repopulates on find and count and forgets IsEmpty is
+            // green until somebody writes this line.
+            procedure CheckObjectTable()
+            var
+                Obj: Record "Object";
+                Widget: Record "IT2875 Widget";
+            begin
+                // ── keyed Get (InternalTryGetByPrimaryKeyAsync) ──────────────────────────
+                IsTrue(Obj.Get(Obj.Type::Table, '', $TABLE$), 'Object must list table $TABLE$');
+                AreEqual('IT2875 Widget', Obj.Name, 'Object.Name for table $TABLE$');
+                IsTrue(Obj.Get(Obj.Type::Codeunit, '', $ASSERT$), 'Object must list codeunit $ASSERT$');
+                AreEqual('IT2875 Assert', Obj.Name, 'Object.Name for codeunit $ASSERT$');
+                IsTrue(Obj.Get(Obj.Type::Page, '', $PAGE$), 'Object must list page $PAGE$');
+                AreEqual('IT2875 Widget Card', Obj.Name, 'Object.Name for page $PAGE$');
+                IsFalse(Obj.Get(Obj.Type::Table, '', $ABSENT$), 'Object must NOT list table $ABSENT$');
+                IsFalse(Obj.Get(Obj.Type::Table, '', $ASSERT$), 'Object must NOT list $ASSERT$ as a table');
+
+                // ── find (InnerFindAsync) ────────────────────────────────────────────────
+                Obj.Reset();
+                Obj.SetRange(Type, Obj.Type::Table);
+                Obj.SetRange(ID, $TABLE$);
+                IsTrue(Obj.FindSet(), 'Object.FindSet must return table $TABLE$');
+                AreEqual('IT2875 Widget', Obj.Name, 'Object.FindSet name for table $TABLE$');
+
+                // ── count (CountAsync) ───────────────────────────────────────────────────
+                AreEqual('1', Format(Obj.Count()), 'Object.Count for table $TABLE$');
+
+                // ── IsEmpty (ExistsAsync — a fourth path, not a spelling of Count) ───────
+                IsFalse(Obj.IsEmpty(), 'Object.IsEmpty must be false for table $TABLE$');
+
+                // Negative twins on the same three non-Get paths.
+                Obj.Reset();
+                Obj.SetRange(Type, Obj.Type::Table);
+                Obj.SetRange(ID, $ABSENT$);
+                IsFalse(Obj.FindSet(), 'Object.FindSet must find nothing for table $ABSENT$');
+                AreEqual('0', Format(Obj.Count()), 'Object.Count for table $ABSENT$');
+                IsTrue(Obj.IsEmpty(), 'Object.IsEmpty must be true for table $ABSENT$');
+
+                // ── the control: ordinary install-seeded state still survives the boundary ─
+                IsTrue(Widget.Get('SEED'), 'the install-seeded Widget row must survive the boundary restore');
+                AreEqual('seeded by the install trigger', Widget.Description, 'seeded Widget description');
+            end;
+        }
+
+        codeunit $TESTSA$ "IT2875 Tests A"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure ObjectAnswersAcrossBoundaryA1()
+            var
+                IT2875Assert: Codeunit "IT2875 Assert";
+            begin
+                IT2875Assert.CheckObjectTable();
+            end;
+
+            [Test]
+            procedure ObjectAnswersAcrossBoundaryA2()
+            var
+                IT2875Assert: Codeunit "IT2875 Assert";
+            begin
+                IT2875Assert.CheckObjectTable();
+            end;
+        }
+
+        // Symmetric with A, sharing one body: codeunit execution order is not id order, so a
+        // fixture whose proof depends on which of the two runs first proves nothing.
+        codeunit $TESTSB$ "IT2875 Tests B"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure ObjectAnswersAcrossBoundaryB1()
+            var
+                IT2875Assert: Codeunit "IT2875 Assert";
+            begin
+                IT2875Assert.CheckObjectTable();
+            end;
+
+            [Test]
+            procedure ObjectAnswersAcrossBoundaryB2()
+            var
+                IT2875Assert: Codeunit "IT2875 Assert";
+            begin
+                IT2875Assert.CheckObjectTable();
+            end;
+        }
+        """;
+
+    private static readonly Regex CaptureLine = new(
+        @"InstallBaseline\.Capture .* skipped-self-populating \[([0-9,]*)\]", RegexOptions.Compiled);
+    private static readonly Regex RestoreLine = new(
+        @"InstallBaseline\.Restore (\d+) row\(s\)", RegexOptions.Compiled);
+
+    private static void AssertObjectExcludedAndStillAnswers(string output, int exitCode)
+    {
+        // [THEN] Every AL assertion passed — Object still answers on all four request paths
+        // after the restores below, and the ordinary install-seeded row still survives them.
+        Assert.Equal(0, exitCode);
+        Assert.Contains("4P/0F/0E", output);
+
+        // [THEN] The capture NAMED 2000000001 among the tables it left out. The marker names
+        // ids rather than counting them precisely so "skipped Object" cannot be confused with
+        // "skipped something else".
+        //
+        // The LAST marker is the per-app-group CaptureInstallBaseline(), which runs after the
+        // fixture's own Install trigger — i.e. after the touch that materialised the
+        // projection. That is the capture whose output a codeunit/test boundary restores.
+        var captures = CaptureLine.Matches(output);
+        Assert.True(captures.Count > 0,
+            $"expected at least one InstallBaseline.Capture marker naming its skipped tables, got:\n{output}");
+        var lastSkipped = captures[^1].Groups[1].Value
+            .Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(int.Parse)
+            .ToHashSet();
+        Assert.True(lastSkipped.Contains(ObjectSystemTableId),
+            $"the fixture's Install trigger materialised table {ObjectSystemTableId} (Object), but the "
+            + $"install-baseline capture did not report skipping it (skipped: "
+            + $"{string.Join(",", lastSkipped.OrderBy(i => i))}). A projection captured into the "
+            + $"baseline is replayed into a fresh provider at the next boundary, which is the row "
+            + $"set #2875 says the runner cannot tell from a backup's. Output:\n{output}");
+
+        // [THEN] A boundary restore actually happened, so the assertions above were made on
+        // the far side of one rather than on the install-time store.
+        Assert.True(RestoreLine.Matches(output).Count > 0,
+            $"expected at least one InstallBaseline.Restore marker (no boundary restore happened, "
+            + $"so this test asserted nothing) in:\n{output}");
+    }
+
+    /// <summary>Default isolation (codeunit): a restore runs at every codeunit boundary.</summary>
+    [SkippableFact]
+    public void CodeunitBoundary_BaselineOmitsObjectProjection_AndObjectStillAnswers()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = TestScratch.Dir("al-runner-2875-codeunit");
+        try
+        {
+            var app = Path.Combine(root, "app");
+            WriteFixture(app);
+            var (output, exitCode) = RunRunner(Array.Empty<string>(), app);
+            AssertObjectExcludedAndStillAnswers(output, exitCode);
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+        }
+    }
+
+    /// <summary>TestIsolation.Test: a restore runs at every TEST boundary — a separate code
+    /// path in TestExecutor, and the one that replays the baseline most often.</summary>
+    [SkippableFact]
+    public void TestBoundary_BaselineOmitsObjectProjection_AndObjectStillAnswers()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = TestScratch.Dir("al-runner-2875-test");
+        try
+        {
+            var app = Path.Combine(root, "app");
+            WriteFixture(app);
+            var (output, exitCode) = RunRunner(new[] { "--isolation", "test" }, app);
+            AssertObjectExcludedAndStillAnswers(output, exitCode);
+
+            Assert.True(RestoreLine.Matches(output).Count >= 4,
+                $"expected at least one baseline restore per test under --isolation test, got "
+                + $"{RestoreLine.Matches(output).Count} in:\n{output}");
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+        }
+    }
+}

--- a/AlRunner.Tests/ObjectSystemTableRowProvenanceTests.cs
+++ b/AlRunner.Tests/ObjectSystemTableRowProvenanceTests.cs
@@ -1,0 +1,208 @@
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #2875, the half CI cannot reach through AL: which writer owns the rows of a table the
+/// runner can BOTH synthesise and load from a --test-data backup.
+///
+/// <para>Object (2000000001) is a real application-database SQL table, so a restored backup can
+/// carry rows for it, and it is also projected from the runner's loaded-object inventory when
+/// there is no database behind it. Deciding between the two by asking the in-memory store "do
+/// you already hold a row?" is what #2875 is about: a store does not remember who filled it, and
+/// an install-baseline restore hands out a BRAND-NEW provider carrying rows the projection
+/// itself wrote, which then read as somebody else's.</para>
+///
+/// <para>The runner now records the fact instead. TestDataProvisioner's on-demand load calls
+/// <c>RecordPatches.NoteBackupContributedRows</c> for every table it actually loaded rows into,
+/// and both consumers ask that rather than the store. These tests drive exactly those calls —
+/// the same entry points production uses — because the end-to-end path needs a BC database
+/// backup, which CI has none of. The exclusion half IS driven end to end, in
+/// ObjectSystemTableBaselineExclusionTests.</para>
+///
+/// <para>Shares the process-global install-baseline statics with
+/// InstallBaselineAppendConcurrencyTests and TestDataBaselineAppendTests, so it joins their
+/// non-parallel collection.</para>
+/// </summary>
+[Collection(InstallBaselineStaticsCollection.Name)]
+public sealed class ObjectSystemTableRowProvenanceTests : IDisposable
+{
+    /// <summary>The literal ids, never the runner's own constants: a test that reads the same
+    /// constant the implementation does cannot notice that constant changing.</summary>
+    private const int ObjectTableId = 2000000001;
+    private const int ObjectMetadataTableId = 2000000071;
+    private const int AllObjTableId = 2000000038;
+    private const int OrdinaryTableId = 61030;
+
+    private readonly List<RecordPatches.BaselineSource>? _savedInstallBaseline;
+
+    public ObjectSystemTableRowProvenanceTests()
+    {
+        // These tests hand AppendBaselineTable a synthetic DataAccessSource; leaving one in the
+        // live per-app-group baseline would hand _mCreateTempDataAccess an object that is not a
+        // DataAccessSource the next time anything restores.
+        _savedInstallBaseline = RecordPatches.InstallBaselineForTests;
+        RecordPatches.InstallBaselineForTests = null;
+        RecordPatches.SetActiveDepCompanyBaseline(null);
+        RecordPatches.ResetBackupRowProvenance();
+    }
+
+    public void Dispose()
+    {
+        RecordPatches.InstallBaselineForTests = _savedInstallBaseline;
+        RecordPatches.SetActiveDepCompanyBaseline(null);
+        RecordPatches.ResetBackupRowProvenance();
+    }
+
+    private static RecordPatches.InstallBaselineSnapshot EmptySnapshot()
+        => new(new List<RecordPatches.BaselineSource>(), null, null, null);
+
+    private static NavValue[][] Rows(params string[] values)
+        => values.Select(v => new NavValue[] { new NavText(0, v) }).ToArray();
+
+    /// <summary>
+    /// The default state of every run — including every run without --test-data, which is the
+    /// corpus, runner-extras, CI and the normal user configuration. Nothing has loaded rows for
+    /// Object, so its rows are the runner's own projection and it must not reach a baseline: a
+    /// captured projection is replayed into a fresh provider at the next boundary, and that
+    /// replay is precisely what the projection cannot tell from a backup's rows.
+    /// </summary>
+    [Fact]
+    public void WithNoBackupLoad_ObjectIsProjectionOwned_AndTheBaselineWriterRefusesIt()
+    {
+        Assert.False(RecordPatches.BackupOwnsRowsFor(ObjectTableId));
+        Assert.True(RecordPatches.IsProjectionOwnedSystemTableId(ObjectTableId));
+
+        var source = new object();
+        var depCompany = EmptySnapshot();
+        RecordPatches.SetActiveDepCompanyBaseline(depCompany);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => RecordPatches.AppendBaselineTable(source, ObjectTableId, new object(), Rows("X")));
+        Assert.Contains("2000000001", ex.Message);
+        Assert.Contains("#2875", ex.Message);
+
+        // Refused means refused: nothing partial was published before the throw.
+        Assert.Empty(depCompany.Sources);
+    }
+
+    /// <summary>
+    /// The --test-data case. Once the on-demand load reports that the backup put rows into
+    /// Object, those rows are the better answer and the table stops being projection-owned:
+    /// the projection stands down, and the append that carries the backup's rows across the
+    /// next boundary is allowed through rather than refused.
+    ///
+    /// <para>The ordering matters and is the reason the throw above stays unreachable in
+    /// production: TestDataProvisioner.LoadOnDemand notes the provenance BEFORE it appends.</para>
+    /// </summary>
+    [Fact]
+    public void AfterTheBackupLoadsRows_ObjectIsBackupOwned_AndTheAppendIsCarried()
+    {
+        RecordPatches.NoteBackupContributedRows(ObjectTableId);
+
+        Assert.True(RecordPatches.BackupOwnsRowsFor(ObjectTableId));
+        Assert.False(RecordPatches.IsProjectionOwnedSystemTableId(ObjectTableId));
+
+        var source = new object();
+        var depCompany = EmptySnapshot();
+        RecordPatches.SetActiveDepCompanyBaseline(depCompany);
+
+        RecordPatches.AppendBaselineTable(source, ObjectTableId, new object(), Rows("FROM-BACKUP"));
+
+        var table = Assert.Single(Assert.Single(depCompany.Sources).Tables);
+        Assert.Equal(ObjectTableId, table.TableId);
+        Assert.Equal("FROM-BACKUP", table.Rows[0][0].ToString());
+    }
+
+    /// <summary>
+    /// Provenance is per table, not a global "a backup is armed" flag. A backup that carries
+    /// rows for some other table says nothing about Object, and the older narrowing — "does a
+    /// --test-data loader exist at all" — could not make that distinction, which is why it left
+    /// a residue.
+    /// </summary>
+    [Fact]
+    public void ProvenanceIsPerTable_ARowLoadedElsewhereDoesNotClaimObject()
+    {
+        RecordPatches.NoteBackupContributedRows(OrdinaryTableId);
+
+        Assert.True(RecordPatches.BackupOwnsRowsFor(OrdinaryTableId));
+        Assert.False(RecordPatches.BackupOwnsRowsFor(ObjectTableId));
+        Assert.True(RecordPatches.IsProjectionOwnedSystemTableId(ObjectTableId));
+    }
+
+    /// <summary>
+    /// Object is the ONLY table this predicate can claim. Object Metadata (2000000071) is the
+    /// same shape of table, but its synthesised rows are the fixed BC-declared
+    /// application-database id list plus one process-constant emit version, so a replay of it is
+    /// byte-identical to a fresh projection and there is nothing for a restore to get wrong —
+    /// excluding it from the baseline would be a behaviour change with no defect behind it. An
+    /// ordinary business table is never projection-owned either.
+    /// </summary>
+    [Fact]
+    public void OnlyObjectIsProjectionOwned_NotItsSiblingAndNotAnOrdinaryTable()
+    {
+        Assert.False(RecordPatches.IsProjectionOwnedSystemTableId(ObjectMetadataTableId));
+        Assert.False(RecordPatches.IsProjectionOwnedSystemTableId(OrdinaryTableId));
+        Assert.False(RecordPatches.IsProjectionOwnedSystemTableId(AllObjTableId));
+
+        // And an ordinary table is appendable with no provenance at all — the refusal above is
+        // about Object specifically, not a new gate on every append.
+        var source = new object();
+        var depCompany = EmptySnapshot();
+        RecordPatches.SetActiveDepCompanyBaseline(depCompany);
+        RecordPatches.AppendBaselineTable(source, OrdinaryTableId, new object(), Rows("ORDINARY"));
+        Assert.Equal(OrdinaryTableId, Assert.Single(Assert.Single(depCompany.Sources).Tables).TableId);
+    }
+
+    /// <summary>
+    /// #2272's refusal is not weakened by any of this. AllObj is refused because it is a
+    /// self-populating virtual table, and no amount of backup provenance makes it appendable —
+    /// the two checks are independent, and the message still names the self-populating reason
+    /// rather than the new one.
+    /// </summary>
+    [Fact]
+    public void BackupProvenanceDoesNotUnlockASelfPopulatingVirtualTable()
+    {
+        RecordPatches.NoteBackupContributedRows(AllObjTableId);
+        RecordPatches.SetActiveDepCompanyBaseline(EmptySnapshot());
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => RecordPatches.AppendBaselineTable(new object(), AllObjTableId, new object(), Rows("X")));
+        Assert.Contains("self-populating virtual table", ex.Message);
+    }
+
+    /// <summary>
+    /// The record describes one armed backup and must not outlive it.
+    /// TestDataProvisioner.ResetForTests clears it in the same breath as the loader itself; left
+    /// behind, one run's backup would keep telling the next run's projection to stand down, and
+    /// that run would answer for Object out of an empty table.
+    /// </summary>
+    [Fact]
+    public void ResettingProvenance_PutsObjectBackUnderTheProjection()
+    {
+        RecordPatches.NoteBackupContributedRows(ObjectTableId);
+        Assert.False(RecordPatches.IsProjectionOwnedSystemTableId(ObjectTableId));
+
+        RecordPatches.ResetBackupRowProvenance();
+
+        Assert.False(RecordPatches.BackupOwnsRowsFor(ObjectTableId));
+        Assert.True(RecordPatches.IsProjectionOwnedSystemTableId(ObjectTableId));
+    }
+
+    /// <summary>The provisioner's own reset is the production caller of that clear, so it is
+    /// asserted through the provisioner rather than only through the primitive above — a reset
+    /// that forgot the new state would leave the two halves out of step.</summary>
+    [Fact]
+    public void TestDataProvisionerReset_ClearsProvenanceWithTheLoader()
+    {
+        RecordPatches.NoteBackupContributedRows(ObjectTableId);
+        RecordPatches.TestDataOnDemandLoader = static (_, _) => { };
+
+        AlRunner.TestDataProvisioner.ResetForTests();
+
+        Assert.Null(RecordPatches.TestDataOnDemandLoader);
+        Assert.False(RecordPatches.BackupOwnsRowsFor(ObjectTableId));
+    }
+}

--- a/AlRunner/Patches/RecordPatches.BackupRowProvenance.cs
+++ b/AlRunner/Patches/RecordPatches.BackupRowProvenance.cs
@@ -1,0 +1,96 @@
+// RecordPatches.BackupRowProvenance — which system tables a --test-data backup actually put
+// rows into, recorded by the writer that did it rather than inferred from the store afterwards.
+//
+// WHY THIS EXISTS (issue #2875)
+//   Object (2000000001) and Object Metadata (2000000071) are real application-database SQL
+//   tables, not virtual ones, so a restored --test-data backup can genuinely carry rows for
+//   them AND the runner can synthesise rows for them. When both are possible, something has to
+//   decide which set wins, and both tables decided it by asking their in-memory store "do you
+//   already hold a row?" (ProviderHasAnyRow).
+//
+//   That question has the wrong shape. It answers "are there rows", and the decision needs
+//   "did somebody OTHER THAN this projection put rows here". The two come apart the moment an
+//   install-baseline restore is in play: a restore builds a BRAND-NEW TempTableDataProvider, so
+//   the ConditionalWeakTable guard that remembers "this projection owns this provider" is empty
+//   for it, and rows THIS projection wrote before the capture read back as somebody else's.
+//   The projection then latched itself off for a provider holding its own stale output — for
+//   Object, whose row set is this run's object inventory rather than a fixed list, that is a
+//   silently partial answer with an unchanged exit code.
+//
+//   #2842 narrowed it by additionally requiring that a --test-data loader exist at all, which
+//   closes it for every run without --test-data. The residue was --test-data together with an
+//   install baseline, and narrowing further along the same axis cannot close it: no property of
+//   the STORE distinguishes the two writers.
+//
+// WHAT THIS DOES INSTEAD
+//   Stops inferring. TestDataProvisioner.LoadOnDemand is the only other writer of these tables,
+//   and it knows exactly what it loaded, so it says so: one call per table that actually got
+//   rows out of the backup. Everything downstream then asks a fact instead of a symptom.
+//
+//   Two consumers, and they are two halves of one answer:
+//     * PopulateObjectSystemTable defers to the backup when, and only when, the backup
+//       contributed rows to 2000000001.
+//     * CaptureInstallBaselineSnapshot leaves 2000000001 out of the baseline entirely when the
+//       projection owns it — the #2272 treatment, for the same reason: the branch in
+//       GetDataAccessForTableCore re-derives the projection on every access, so carrying it
+//       across a boundary buys nothing and costs the ambiguity above. With the projection never
+//       captured, the only rows a restored provider can hold for this table are a backup's, so
+//       the confusion is gone by construction rather than by a better guess.
+//
+//   It deliberately does NOT weaken #2272's loud refusal. The self-populating virtual tables
+//   are refused by AppendBaselineTable whatever this file says; provenance only ever decides
+//   the question for a table that has both possible writers.
+//
+// LIFETIME
+//   Process-wide and monotonic within a run, which matches what it records: "this run's armed
+//   backup has rows for table N" does not stop being true because a later app group looked at
+//   the table through a different provider. TestDataProvisioner.ResetForTests clears it, the
+//   same place it clears the loader itself.
+using System.Collections.Concurrent;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    /// <summary>Table ids the --test-data on-demand load actually put rows into. A set rather
+    /// than a count: the only question anyone asks is membership.</summary>
+    private static readonly ConcurrentDictionary<int, byte> _backupContributedRows = new();
+
+    /// <summary>Called by <c>TestDataProvisioner.LoadOnDemand</c> for every table it loaded at
+    /// least one row into, BEFORE it appends that table to the install baselines — so
+    /// <see cref="IsProjectionOwnedSystemTableId"/> is already false by the time
+    /// <see cref="AppendBaselineTable"/> checks it.</summary>
+    internal static void NoteBackupContributedRows(int tableId) => _backupContributedRows[tableId] = 0;
+
+    /// <summary>True when a --test-data backup put rows into <paramref name="tableId"/> in this
+    /// run. False for every table in a run without --test-data, and for a table the armed
+    /// backup's plan does not offer or whose rows it holds none of.</summary>
+    internal static bool BackupOwnsRowsFor(int tableId) => _backupContributedRows.ContainsKey(tableId);
+
+    /// <summary>Drop everything recorded here. Paired with clearing
+    /// <see cref="TestDataOnDemandLoader"/>: the two describe the same armed backup, and a
+    /// provenance record outliving the loader that produced it would let one run's backup
+    /// speak for the next.</summary>
+    internal static void ResetBackupRowProvenance() => _backupContributedRows.Clear();
+
+    /// <summary>
+    /// True when <paramref name="tableId"/>'s rows in this run are a projection this runner
+    /// synthesised, rather than anything a backup or an install trigger wrote.
+    ///
+    /// <para>Only Object (2000000001) can answer true. It is the one table that is BOTH
+    /// projected from the loaded-object inventory on every access — the
+    /// <see cref="IsSelfPopulatingVirtualTableId"/> description, word for word — and reachable
+    /// by the --test-data on-demand loader, because its dispatch branch calls the loader
+    /// explicitly instead of falling through. That combination is why it could not simply be
+    /// added to that list.</para>
+    ///
+    /// <para>Object Metadata (2000000071) is deliberately NOT here. It is the same shape of
+    /// table, but its synthesised row set is the fixed BC-declared application-database id list
+    /// plus one process-constant emit version, so a replay of it is byte-identical to a fresh
+    /// projection and there is nothing for a restore to get wrong. Object's row set is this
+    /// run's object inventory, which is what makes the distinction load-bearing for it and not
+    /// for its sibling.</para>
+    /// </summary>
+    internal static bool IsProjectionOwnedSystemTableId(int tableId)
+        => tableId == ObjectSystemTableId && !BackupOwnsRowsFor(tableId);
+}

--- a/AlRunner/Patches/RecordPatches.InstallBaseline.cs
+++ b/AlRunner/Patches/RecordPatches.InstallBaseline.cs
@@ -198,6 +198,25 @@ public static partial class RecordPatches
                 + "(see IsSelfPopulatingVirtualTableId) and must not be appended to an install "
                 + "baseline; GetDataAccessForTableCore re-derives it on every access.");
 
+        // #2875: the same invariant for the one table that is self-populating AND reachable by
+        // the on-demand loader. Object (2000000001) is projected from the loaded-object
+        // inventory on every access, so a baseline carrying THAT projection replays it into a
+        // brand-new provider at the next boundary and the projection can no longer tell its own
+        // stale output from a backup's rows.
+        //
+        // Unreachable from the loader by construction, and loudly so rather than skipped: this
+        // method's only production caller records the load's provenance immediately before
+        // calling it (TestDataProvisioner.LoadOnDemand), which is exactly what makes the table
+        // not projection-owned. So reaching this throw means a NEW writer appended a projection
+        // it did not load, which is the bug the check exists to stop rather than one to absorb.
+        if (IsProjectionOwnedSystemTableId(tableId))
+            throw new InvalidOperationException(
+                $"install-baseline — table {tableId} holds a runner-synthesised projection in "
+                + "this run (no --test-data backup contributed rows to it; see "
+                + "RecordPatches.BackupRowProvenance.cs) and must not be appended to an install "
+                + "baseline; GetDataAccessForTableCore re-derives it on every access, and a "
+                + "replayed projection is indistinguishable from a backup's rows (#2875).");
+
         var rows = new NavValue[pristineRows.Length][];
         for (var i = 0; i < pristineRows.Length; i++)
             rows[i] = CloneValues(pristineRows[i]);
@@ -347,7 +366,18 @@ public static partial class RecordPatches
                 // bundles anyway (Program.cs's run loop never resets them), so the top-up
                 // already reports the union — dropping the rows here changes what it costs,
                 // not what it answers.
-                if (IsSelfPopulatingVirtualTableId(tableId))
+                //
+                // ── And the one table that is BOTH of those and loader-backed (#2875) ──
+                // Object (2000000001) is a real application-database SQL table, so a
+                // --test-data backup can genuinely own its rows and those must be captured.
+                // With no backup behind them its rows are a projection of the loaded-object
+                // inventory, re-derived on every access exactly like the ids above — and
+                // capturing THAT is worse than merely wasteful: a boundary restore replays it
+                // into a brand-new provider, whose ConditionalWeakTable guard is empty, so the
+                // projection reads its own stale output as somebody else's rows and latches
+                // itself off. IsProjectionOwnedSystemTableId asks which of the two writers
+                // actually produced them rather than guessing from row presence.
+                if (IsSelfPopulatingVirtualTableId(tableId) || IsProjectionOwnedSystemTableId(tableId))
                 {
                     skippedVirtual.Add(tableId);
                     continue;

--- a/AlRunner/Patches/RecordPatches.InstallBaselineDisk.cs
+++ b/AlRunner/Patches/RecordPatches.InstallBaselineDisk.cs
@@ -67,7 +67,16 @@ public static partial class RecordPatches
     /// install-trigger output, and which
     /// <see cref="GetDataAccessForTableCore"/> re-populates on every access. Excluded from the
     /// on-disk baseline — see the file header for why that is a correctness decision and not
-    /// just a size one.</summary>
+    /// just a size one.
+    ///
+    /// <para>UNCONDITIONAL, and it stays that way: no backup can own rows in any of these,
+    /// because every one of them is a virtual table with no SQL behind it. The one table that
+    /// fits the same description but CAN also be loaded from a backup — Object (2000000001) —
+    /// is therefore not in this list; it is decided per run by
+    /// <see cref="IsProjectionOwnedSystemTableId"/> (#2875). Do not merge the two: adding
+    /// 2000000001 here would drop a backup's real rows on the floor, and making this predicate
+    /// conditional would weaken #2272's refusal for tables that have no second writer at
+    /// all.</para></summary>
     internal static bool IsSelfPopulatingVirtualTableId(int tableId) => tableId switch
     {
         AllObjVirtualTableId or AllObjWithCaptionVirtualTableId or FieldVirtualTableId

--- a/AlRunner/Patches/RecordPatches.ObjectSystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.ObjectSystemTable.cs
@@ -111,13 +111,18 @@
 //   Like Object Metadata and unlike every virtual table, 2000000001 is a real SQL table and a
 //   restored backup can genuinely carry rows for it. So the branch in GetDataAccessForTableCore
 //   lets the --test-data on-demand loader run FIRST on a freshly created store, and the
-//   populator below does nothing for the lifetime of a provider that already had a row on
-//   first touch AND is in a run where such a loader exists at all. Real rows always win; the
-//   projection is the fallback for the (normal) case of a run with no application database.
+//   populator below does nothing at all when that load actually produced rows for this table.
+//   Real rows always win; the projection is the fallback for the (normal) case of a run with no
+//   application database.
 //
-//   That second condition is load-bearing rather than defensive — see the latch comment in
-//   PopulateObjectSystemTable. Without it, an install-baseline restore of rows THIS projection
-//   wrote is indistinguishable from a backup's, and the residue that remains is issue #2875.
+//   "Actually produced rows" is a fact the loader RECORDS (RecordPatches.BackupRowProvenance.cs,
+//   #2875), not something read back off the store. Reading the store was the bug: an
+//   install-baseline restore replays this projection's own rows into a brand-new provider, and
+//   a provider cannot say who filled it, so the projection latched itself off for a store
+//   holding nothing but its own stale output. The companion half is in
+//   CaptureInstallBaselineSnapshot, which no longer captures this table while the projection
+//   owns it — so there is nothing to replay in the first place, and the two halves together
+//   close the ambiguity rather than narrow it.
 //
 // PRECOMPILED-DLL RESPECT
 //   Runtime-engine and Types-assembly members only (NCLMetaTable, NCLMetaField, NavValue,
@@ -144,17 +149,16 @@ public static partial class RecordPatches
 
     /// <summary>
     /// Per-in-memory-provider state for the Object (2000000001) projection.
-    /// <para><see cref="DeferToRealRows"/> is decided ONCE, on the first handout of a
-    /// provider, right after the --test-data on-demand loader has had its turn: a store that
-    /// already holds a row is serving real rows out of a restored backup, and those must never
-    /// be shadowed by a projection.</para>
     /// <para><see cref="Inserted"/> makes the top-up idempotent per (type ordinal, id) so
     /// later handouts pick up objects registered since without re-inserting — and, just as
     /// importantly, without resurrecting a row AL has deleted in between.</para>
+    /// <para>It is the only per-provider state left. "Does a --test-data backup own this
+    /// table's rows" used to be latched here too, decided from the provider on first handout;
+    /// #2875 moved it to <see cref="BackupOwnsRowsFor"/>, because a provider cannot say who
+    /// filled it and a boundary restore hands out a new one carrying replayed rows.</para>
     /// </summary>
     private sealed class ObjectSystemTableState
     {
-        internal bool DeferToRealRows;
         internal readonly ConcurrentDictionary<(int TypeOrdinal, int Id), byte> Inserted = new();
     }
 
@@ -214,47 +218,37 @@ public static partial class RecordPatches
                 "Object (system table 2000000001)",
                 "object-system-table — data access has no in-memory provider; see docs/scope.md");
 
-        // THE LATCH ASKS "DID SOMETHING OTHER THAN THIS PROJECTION PUT ROWS HERE?", and
-        // ProviderHasAnyRow alone cannot answer that. An install-baseline restore replays rows
-        // THIS projection wrote earlier in the run into a BRAND-NEW provider, which gets a
-        // fresh ConditionalWeakTable entry — so a bare ProviderHasAnyRow reads true, latches,
-        // and the top-up never runs again for that provider. Harmless for Object Metadata,
-        // whose row set is a fixed BC-declared id list identical whoever produced it; NOT
-        // harmless here, where the row set is THIS run's inventory and a disk baseline keyed by
-        // dependency key can be restored for a different app group.
+        // THE LATCH ASKS "DID SOMETHING OTHER THAN THIS PROJECTION PUT ROWS HERE?", and no
+        // property of the PROVIDER can answer that. The old test — ProviderHasAnyRow, narrowed
+        // by #2842 to runs that have a --test-data loader at all — read a store, and a store
+        // does not remember who filled it. An install-baseline restore replays rows THIS
+        // projection wrote earlier in the run into a BRAND-NEW provider, which gets a fresh
+        // ConditionalWeakTable entry, so the projection read its own stale output as somebody
+        // else's, latched, and never topped up that provider again. Harmless for Object
+        // Metadata, whose row set is a fixed BC-declared id list identical whoever produced it;
+        // NOT harmless here, where the row set is THIS run's object inventory.
         //
-        // So the latch is additionally conditioned on a --test-data loader EXISTING at all,
-        // because that is the only writer besides this projection that can legitimately own
-        // rows in this store. With no loader in the run, any rows present are ours (directly or
-        // replayed through a baseline) and the top-up must go ahead; the per-key
-        // NavRecordAlreadyExistsException catch in InsertVirtualRow absorbs the ones already
-        // there, so a replayed row survives and only genuinely-missing objects are added.
+        // So the question is asked of the WRITER instead (#2875). The --test-data on-demand
+        // load is the only other writer of this table, and it records the tables it actually
+        // loaded rows into — see RecordPatches.BackupRowProvenance.cs. That fact outlives any
+        // provider, so a restore cannot launder a projection into a backup.
         //
-        // Deliberately NOT conditioned on "this call materialised the storage". That question is
-        // GetOrCreateHydratedDataAccess's own, and it is the wrong one here: this populate runs
-        // on EVERY touch of the table, not only the materialising one, so keying the latch on it
-        // would skip the top-up for every later caller. Conditioning on the loader existing is
-        // strictly never worse than a bare ProviderHasAnyRow: identical whenever a loader
-        // exists, and correct where a bare one is wrong.
+        // The other half of the same fix removes the ambiguity at its source: a projection-owned
+        // Object table is no longer captured into an install baseline at all (the #2272
+        // treatment, applied conditionally), so there is nothing for a restore to replay. The
+        // two halves are deliberately both here — the exclusion means a restored provider can
+        // only ever hold a backup's rows, and this check means the projection knows it.
         //
-        // WHAT THIS DOES NOT CLOSE, and why it is not closed here: --test-data AND an install
-        // baseline together, with AL touching Record "Object" before CaptureInstallBaselineSnapshot
-        // runs. Issue #2875 tracks it. The obvious fix — adding 2000000001 to
-        // IsSelfPopulatingVirtualTableId so the projection is never captured — is NOT a drop-in:
-        // this is the first self-populating table that also materialises through the on-demand
-        // loader, so it
-        // would make AppendBaselineTable's deliberate InvalidOperationException reachable for the
-        // first time on any backup that carries Object rows (a real on-prem database has them).
-        // Resolving that is a change to a shared invariant, not a rider on this fix.
-        var backupLoaderExists = TestDataOnDemandLoader != null;
-        var state = _objsStateByProvider.GetValue(
-            provider, p => new ObjectSystemTableState
-            {
-                DeferToRealRows = backupLoaderExists && ProviderHasAnyRow(p),
-            });
+        // Deliberately NOT latched per provider any more. A latch was only ever a way to
+        // remember the answer to a question that had to be asked at exactly the right moment;
+        // provenance is a run-scoped fact, so it can be read on every touch and is the same
+        // answer whichever provider is in hand. `Inserted` stays per provider, because THAT is
+        // genuinely per-store state: it is what keeps the top-up idempotent without
+        // resurrecting a row AL deleted in between.
+        var state = _objsStateByProvider.GetValue(provider, static _ => new ObjectSystemTableState());
 
         // A --test-data backup's real rows are the better answer — leave them alone.
-        if (state.DeferToRealRows) return;
+        if (BackupOwnsRowsFor(ObjectSystemTableId)) return;
 
         var ordinals = EnsureObjectTypeOrdinals(metaTable);
 

--- a/AlRunner/TestDataProvisioner.cs
+++ b/AlRunner/TestDataProvisioner.cs
@@ -310,6 +310,10 @@ internal static class TestDataProvisioner
         RecordPatches.TestDataOnDemandLoader = null;
         RecordPatches.TestDataDeferredLoadNotifier = null;
         RecordPatches.TestDataDeferredLoadWriteOffNotifier = null;
+        // #2875: the provenance record describes the backup this loader was armed for, so it
+        // has to go with the loader. Left behind, one run's backup would keep speaking for the
+        // next — and the thing it says is "do not synthesise rows for this table".
+        RecordPatches.ResetBackupRowProvenance();
     }
 
     /// <summary>
@@ -414,6 +418,16 @@ internal static class TestDataProvisioner
             if (result.Rows > 0)
             {
                 Interlocked.Increment(ref _tablesDone);
+                // #2875: say so, rather than leaving anyone downstream to infer it from the
+                // store. A table the runner can ALSO synthesise rows for (Object 2000000001)
+                // has to know which writer owns its rows, and "the provider has rows" cannot
+                // answer that once an install-baseline restore can replay a projection into a
+                // brand-new provider. This is the only place the fact exists.
+                //
+                // BEFORE the append, deliberately: AppendBaselineTable refuses a
+                // projection-owned table, and this call is what makes this one not projection
+                // owned. See RecordPatches.BackupRowProvenance.cs.
+                RecordPatches.NoteBackupContributedRows(tableId);
                 // The rows are in the live store now, but no snapshot knows about them: a load
                 // fired mid-test is long past CaptureInstallBaselineSnapshot(). Without this
                 // the very next codeunit/test boundary would wipe them.

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -769,11 +769,22 @@ whether this legacy table's field 20 holds the object's AL caption is a BC claim
 can adjudicate; **issue #2839** tracks it rather than guessing.
 
 A `--test-data` backup's real rows take precedence over the projection, and that precedence is
-conditioned on such a loader existing in the run at all — an install-baseline restore replays
-rows the projection itself wrote into a fresh provider, which a bare "does the store have rows"
-test cannot tell apart from a backup's. **issue #2875** records what that leaves open
-(`--test-data` and an install baseline together) and why the obvious fix — excluding 2000000001
-from install-baseline capture — is not a drop-in.
+decided from what the backup **actually loaded** rather than from what the in-memory store
+happens to hold (#2875). Reading the store was the earlier design and it could not work: an
+install-baseline restore replays rows the projection itself wrote into a brand-new provider, so
+the projection read its own stale output as somebody else's and stopped topping the table up.
+The on-demand load now records the tables it put rows into, and the projection stands down for
+this table only when that record names it. Its companion is in the capture: while the projection
+owns the rows, table 2000000001 is left out of the install baseline entirely — the same treatment
+the self-populating virtual tables get (#2272), and for the same reason, since the dispatch
+branch re-derives the projection on every access. With nothing captured there is nothing to
+replay, so the ambiguity is gone rather than narrowed.
+
+One case in the same family is **not** closed here and is reported rather than silent: a store
+published by a *nested* materialisation owes a `--test-data` load that could not run there, and
+the projection fills it before that debt is settled, so the settle writes the load off. Object
+Metadata's dispatch branch holds its populate off until the debt is settled; `Object`'s does not.
+**issue #2877** covers the deferred-load mechanism.
 
 `tests/runner-extras/object-system-table` asserts the runner-side behaviour so it cannot move
 quietly.


### PR DESCRIPTION
Closes #2875

Authored by the `impl-4` agent.

## What was wrong

`Object` (2000000001) is a real application-database SQL table, so a restored `--test-data`
backup can genuinely carry rows for it — and the runner also projects its own object inventory
into it when there is no database behind it. Deciding which of the two wins was done by asking
the in-memory store whether it already held a row:

```csharp
DeferToRealRows = backupLoaderExists && ProviderHasAnyRow(p)
```

A store does not remember who filled it. An install-baseline restore builds a **brand-new**
`TempTableDataProvider`, so the `ConditionalWeakTable` guard that remembers "this projection owns
this provider" is empty for it, and rows the projection itself wrote before the capture read back
as somebody else's. The projection then latched itself off for a provider holding nothing but its
own stale output. Because `Object`'s row set is *this run's object inventory* rather than a fixed
list, that is a silently partial answer with an unchanged exit code.

## What this does

Two halves, and they need each other.

**1. Ask the writer, not the store.** `TestDataProvisioner.LoadOnDemand` is the only other writer
of this table and it knows exactly what it loaded, so it now says so — one call per table that
actually got rows out of the backup (`RecordPatches.BackupRowProvenance.cs`). The projection
stands down when, and only when, that record names 2000000001. Provenance outlives any provider,
so a restore cannot launder a projection into a backup.

**2. Never capture the projection.** While the projection owns the rows, 2000000001 is left out
of the install baseline entirely — the treatment the self-populating virtual tables got in #2272,
for exactly the reason that file gives: the dispatch branch re-derives the projection on every
access, so carrying it across a boundary buys nothing. With nothing captured there is nothing to
replay, so the ambiguity is **gone by construction** rather than narrowed by a better heuristic.

### Why the conditional form, and why the loud refusal survives

The issue notes that adding 2000000001 to `IsSelfPopulatingVirtualTableId` is not a drop-in: it
would make `AppendBaselineTable`'s deliberate `InvalidOperationException` (#2272) reachable for
the first time, on any backup that carries `Object` rows. The conditional predicate avoids that
rather than trading it away. `LoadOnDemand` records the provenance **before** it appends, so at
the moment of the append the table is not projection-owned and the append is legitimate — the
throw stays unreachable in production by construction, not by hope.

Nothing about #2272's refusal is weakened. `IsSelfPopulatingVirtualTableId` stays unconditional
(no backup can own rows in a virtual table with no SQL behind it), and a test asserts that
recording provenance for AllObj does **not** make it appendable. Both baseline writers — the
capture skip and the append throw — consult the same predicate, so they cannot drift apart the
way the #2272 invariant could if only one of them had it.

## RED then GREEN

`AlRunner.Tests/ObjectSystemTableBaselineExclusionTests.cs` spawns the real runner on a generated
fixture whose `Install` trigger touches `Record "Object"`, so the projection materialises inside
the capture window on every BC version.

- **RED (measured on this branch's parent):** `PERF InstallBaseline.Capture 6 table(s), 273
  row(s), skipped-self-populating []` — `Object` was captured, and every boundary replayed it.
  Both tests failed.
- **GREEN:** the marker names 2000000001, and all 4 AL tests still pass across a codeunit boundary
  and (second test) a test boundary.

The AL half asserts the answer on **all four DataAccess request paths**, not just find, because
`RecordImplementation.IsEmptyAsync` serves `IsEmpty()` from its own `ExistsAsync` rather than from
`CountAsync`:

| path | assertion |
|---|---|
| keyed `Get` (`InternalTryGetByPrimaryKeyAsync`) | its own table/page/codeunit by id, with the concrete `Name`; negative for an undeclared id and for the right id under the wrong `Type` |
| find (`InnerFindAsync`) | `FindSet` returns the row, with the concrete `Name`; negative twin |
| count (`CountAsync`) | `Count() = 1`; negative twin `= 0` |
| `IsEmpty` (`ExistsAsync`) | `false` for a declared object; `true` for an undeclared id |

An ordinary row seeded by the same `Install` trigger is asserted to survive every boundary. That
is the control: it fails if the install baseline stopped working generally rather than getting
narrower.

The `--test-data` half cannot be reached end to end in CI (no BC database backup), so
`AlRunner.Tests/ObjectSystemTableRowProvenanceTests.cs` drives the same two production entry
points directly — 7 tests covering: projection-owned by default and refused by the baseline
writer; backup-owned after a load and the append carried; provenance is per table, not a global
"a backup is armed" flag; only `Object` can be projection-owned; #2272's refusal is not
unlockable by provenance; and the reset clears it (through `TestDataProvisioner.ResetForTests`,
the production caller, not only the primitive).

## Fixing the shape, not just the reported line

**Does the same wrong pattern appear at another call site?** `ProviderHasAnyRow` has one other
caller: `PopulateObjectMetadataSystemTable` (2000000071), where the guard is even barer — no
loader condition at all. It is **not** a defect there and is deliberately left alone: that
table's synthesised row set is `EnumerateApplicationDatabaseTableIds()`, the fixed BC-declared id
list, plus one process-constant emit version, so a replayed projection is byte-identical to a
fresh one and there is nothing for a restore to get wrong. Object's row set is this run's
inventory, which is the whole reason the distinction is load-bearing for it and not for its
sibling. A test pins that 2000000071 is not projection-owned, so the asymmetry is asserted rather
than assumed.

**Does a sibling function make the same assumption?** Yes, and I did not fix it here.
`SettleDeferredTestDataLoad` uses `StoredHasAnyRow` to decide whether paying a deferred load would
mix rows — the same "rows present implies somebody else owns them" shape. For `Object` it is
reachable: a store published by a nested materialisation owes a load that could not run there, the
projection fills it, and the settle then writes the load off. `MaterialiseObjectMetadataStore`
holds its populate off until that debt is settled; `Object`'s dispatch branch does not. That is
issue #2877's mechanism, an agent is on that issue, and the fix lives in the shared dispatch chain
in `RecordPatches.cs` — so it is recorded in `docs/limitations.md` and left to that work rather
than raced here. It is reported at runtime through `TestDataDeferredLoadWriteOffNotifier`, not
silent.

**Do two code paths writing the same state maintain the same invariant?** They do now. The capture
skip and the `AppendBaselineTable` throw both consult `IsProjectionOwnedSystemTableId`. The disk
codec's own filters (`InstallBaselineDisk`'s write filter and the two digests) are correct
unchanged and were deliberately not touched: a projection-owned `Object` never enters the
snapshot, so the writer never sees it, and a backup-owned one *should* be persisted. Filtering it
there too would have dropped a backup's real rows.

## Merge ordering

**This PR does not touch the shared virtual-table dispatch if-chain in `RecordPatches.cs`** — no
conflict with the other virtual-table PRs.

## Local verification

- `ObjectSystemTableBaselineExclusionTests` — 2/2, RED before the fix (output quoted above).
- `ObjectSystemTableRowProvenanceTests` — 7/7.
- Filtered `AlRunner.Tests` over every neighbouring surface (`InstallBaseline*`,
  `TestDataLazyHydration`, `TestDataBaselineAppend`, `ObjectMetadata*`, `ObjectSystemTable*`,
  `BcShapeGapConvention`, `TestDataProvisioning`, `InstallSeedDepCompany`,
  `*TableMaterialisation*`) — 151 passed, 2 skipped, 0 failed.
- `tests/runner-extras/{object-system-table, object-metadata-system-table, install-trigger-seed}`
  — 12/12, run **twice** (cold and warm cache), identical both times.

The full `AlRunner.Tests` suite and the corpus were not run locally; CI runs both on all 8 legs.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
