### PR TITLE
fix(deps): give every R2R chunk of an app its module identity, not just the first

### DIFF
--- a/AlRunner.Tests/DependencyR2rChunkModuleIdentityTests.cs
+++ b/AlRunner.Tests/DependencyR2rChunkModuleIdentityTests.cs
@@ -1,0 +1,184 @@
+// DependencyR2rChunkModuleIdentityTests — #3054.
+//
+// Microsoft ships large apps as several ReadyToRun DLL chunks (Base Application is five).
+// DependencyLoader's Tier-2 loop loads every chunk, but until #3054 it handed the caller
+// back only the FIRST one, and LoadAll then registered only that one. Every AL object the
+// AL compiler happened to place in chunks 2..n therefore had no app identity in any of the
+// per-Assembly registries the runner keys module ownership on.
+//
+// The two things that broke, both measured against real BC artifacts before the fix:
+//
+//   * NavApp.GetCallerModuleInfo (BcRuntime.TryGetImmediateCallerModule) walks the managed
+//     stack and SKIPS any frame whose assembly is not in BcRuntime's module map, so a call
+//     out of an unregistered chunk was attributed to whichever registered frame sat below
+//     it. On BC 27.3, Base Application's codeunit 3999 "Reten. Pol. Install - BaseApp"
+//     lives in a non-primary chunk; its AddAllowedTable(405) call reported System
+//     Application as the caller, BC's own ModuleOwnsTable check correctly refused ("the
+//     table is not owned by module {63CA2FA4-…}"), and codeunit 2 "Company-Initialize"
+//     then died on "Table 405 Change Log Entry is not in the list of allowed tables".
+//   * InstallTriggerRunner fires the Install codeunits of exactly the assemblies LoadAll
+//     returns (TestExecutor → SetDependencyAssemblies), so an Install codeunit in a
+//     non-primary chunk never ran. Same measurement: BC 27.3 fired no install trigger for
+//     codeunit 3999 at all, while BC 28.1 — where that codeunit happens to land in the
+//     primary chunk — did.
+//
+// WHY THIS TEST DOES NOT USE A BC ARTIFACT
+//   The claim is entirely about the runner's own loader bookkeeping — "an app loaded as N
+//   assemblies is one module across all N" — and nothing about Business Central, so it does
+//   not belong upstream in the al-language corpus. Two Roslyn-compiled stub assemblies
+//   zipped into a synthetic `publishedartifacts/*.dll` package drive the REAL Tier-2 path
+//   (AppLoader.IsR2R → ExtractAllDllPaths → LoadFromAssemblyPath → LoadAll's registration)
+//   in milliseconds, with no Base Application floor — see
+//   .claude/rules/no-base-app-in-csharp-tests.md.
+//
+// The BC-behaviour half of #3054 — that table 405 IS in the retention-policy allowed list
+// after a company is initialised — is a statement about BC and is asserted upstream in the
+// al-language corpus, where a real service tier adjudicates it.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Reflection;
+using AlRunner;
+using AlRunner.Infrastructure;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// In <see cref="CacheRootsSerialCollection"/> because AppLoader.ExtractAllDllPaths resolves
+/// the r2r-chunks cache directory through the process-wide CacheRoots override this class
+/// sets for the duration.
+/// </summary>
+[Collection(CacheRootsSerialCollection.Name)]
+public sealed class DependencyR2rChunkModuleIdentityTests : IDisposable
+{
+    private const string Publisher = "R2rChunkFixture";
+    private const string AppName = "MultiChunkDep";
+    private static readonly Version AppVersion = new(1, 2, 3, 4);
+
+    private readonly string _root = TestScratch.Dir("al-runner-r2r-chunk-module-identity");
+    private readonly string _cacheRoot = TestScratch.FlatDir("al-runner-r2r-chunk-module-identity-cache-");
+
+    public void Dispose()
+    {
+        CacheRoots.ResetForTests();
+        try { Directory.Delete(_root, recursive: true); } catch { /* best effort */ }
+        try { Directory.Delete(_cacheRoot, recursive: true); } catch { /* best effort */ }
+    }
+
+    private static byte[] CompileStub(string assemblyName)
+    {
+        var refs = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(
+                Path.Combine(Path.GetDirectoryName(typeof(object).Assembly.Location)!, "System.Runtime.dll")),
+        };
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { CSharpSyntaxTree.ParseText("public static class Marker { public static int N => 1; }") },
+            refs,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var ms = new MemoryStream();
+        var result = compilation.Emit(ms);
+        Assert.True(result.Success,
+            string.Join("; ", result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// A synthetic R2R package carrying <paramref name="chunkNames"/> as
+    /// <c>publishedartifacts/*.dll</c> entries — the shape AppLoader.IsR2R recognises and
+    /// DependencyLoader's Tier 2 loads. Returns the .app path.
+    /// </summary>
+    private string WriteMultiChunkApp(IReadOnlyList<string> chunkNames)
+    {
+        Directory.CreateDirectory(_root);
+        var appPath = Path.Combine(_root, $"{Publisher}_{AppName}_{AppVersion}_{Guid.NewGuid():N}.app");
+        using var zip = ZipFile.Open(appPath, ZipArchiveMode.Create);
+        for (var i = 0; i < chunkNames.Count; i++)
+        {
+            var entry = zip.CreateEntry($"publishedartifacts/chunk{i:D3}.dll");
+            using var s = entry.Open();
+            var bytes = CompileStub(chunkNames[i]);
+            s.Write(bytes, 0, bytes.Length);
+        }
+        return appPath;
+    }
+
+    [Fact]
+    public void EveryR2rChunkOfOneApp_IsReturnedAndCarriesThatAppsModuleIdentity()
+    {
+        CacheRoots.SetOverride(_cacheRoot);
+
+        var appId = Guid.NewGuid();
+        var suffix = Guid.NewGuid().ToString("N");
+        var chunkNames = new[] { $"r2rchunk-a-{suffix}", $"r2rchunk-b-{suffix}", $"r2rchunk-c-{suffix}" };
+        var appPath = WriteMultiChunkApp(chunkNames);
+        var manifest = new AppManifest(Publisher, AppName, AppVersion, appId, Array.Empty<DependencyRef>());
+
+        var loaded = new DependencyLoader(null!, null!)
+            .LoadAll(new[] { (manifest, appPath) }, _root);
+
+        // 1. LoadAll hands back EVERY chunk. This list is exactly what
+        //    InstallTriggerRunner.SetDependencyAssemblies scans, so a chunk missing here is a
+        //    chunk whose Install codeunits can never fire. Pre-fix this was 1, not 3.
+        var loadedNames = loaded.Select(a => a.GetName().Name).OrderBy(n => n, StringComparer.Ordinal).ToList();
+        Assert.Equal(chunkNames.OrderBy(n => n, StringComparer.Ordinal).ToList(), loadedNames);
+
+        // 2. Every chunk carries THIS app's identity in BcRuntime's module map — the map
+        //    NavApp.GetCallerModuleInfo's stack walk consults, and the one
+        //    RecordPatches.BuildObjectOwnerIndex reads through RegisteredModuleAssemblies().
+        var registered = BcRuntime.RegisteredModuleAssemblies();
+        foreach (var asm in loaded)
+        {
+            Assert.Contains(registered, e => ReferenceEquals(e.Assembly, asm) && e.AppId == appId);
+            var info = BcRuntime.GetModuleAppInfoFor(asm);
+            Assert.Equal(appId, info.AppId);
+            Assert.Equal(AppName, info.Name);
+            Assert.Equal(Publisher, info.Publisher);
+            Assert.Equal(AppVersion.ToString(), info.Version);
+        }
+
+        // 3. The app is still ONE module, not three: RegisteredModules() deduplicates by app
+        //    id, which is what seeds a single Published Application row per app (#2963). A fix
+        //    that registered each chunk as its own module would break that instead.
+        Assert.Single(BcRuntime.RegisteredModules().Where(m => m.AppId == appId));
+
+        // 4. Not vacuous: the map does not answer "this app" for an arbitrary assembly. Without
+        //    this, an implementation that returned the fixture's identity for everything would
+        //    satisfy every assertion above.
+        Assert.DoesNotContain(registered, e => ReferenceEquals(e.Assembly, typeof(string).Assembly));
+    }
+
+    [Fact]
+    public void ASecondResolutionOfTheSameApp_StillYieldsEveryChunk()
+    {
+        // The DependencyLoader cache is keyed by app id and short-circuits LoadOne entirely on
+        // the second bundle in a run (and on every later --watch/--server cycle). Handing back
+        // only the cached primary there would put every app group after the first back into
+        // the pre-fix state, so the cache entry has to carry the whole chunk set too.
+        CacheRoots.SetOverride(_cacheRoot);
+
+        var appId = Guid.NewGuid();
+        var suffix = Guid.NewGuid().ToString("N");
+        var chunkNames = new[] { $"r2rchunk-d-{suffix}", $"r2rchunk-e-{suffix}" };
+        var appPath = WriteMultiChunkApp(chunkNames);
+        var manifest = new AppManifest(Publisher, AppName, AppVersion, appId, Array.Empty<DependencyRef>());
+        var loader = new DependencyLoader(null!, null!);
+
+        var first = loader.LoadAll(new[] { (manifest, appPath) }, _root);
+        var second = loader.LoadAll(new[] { (manifest, appPath) }, _root);
+
+        Assert.Equal(2, first.Count);
+        Assert.Equal(
+            first.Select(a => a.GetName().Name).OrderBy(n => n, StringComparer.Ordinal).ToList(),
+            second.Select(a => a.GetName().Name).OrderBy(n => n, StringComparer.Ordinal).ToList());
+        // Same Assembly instances, not a second load of the same bytes under new identities.
+        foreach (var asm in first) Assert.Contains(second, a => ReferenceEquals(a, asm));
+    }
+}

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -40,7 +40,17 @@ public sealed class DependencyLoader
     // reload cycle purely to discover "this one has no sidecars anyway").
     private readonly record struct LoadedAppEntry(
         Assembly Asm, string Name, string Publisher, string Version, string SourcePath,
-        string? Tier3CacheKey = null);
+        string? Tier3CacheKey = null,
+        // #3054: EVERY assembly this app was loaded as, not just the primary one. Microsoft
+        // ships Base Application as five R2R DLL chunks and the app is ONE module spread
+        // across all of them, so a cache hit has to hand back the whole set — re-registering
+        // only Asm would put the later app groups in a run back into the pre-fix state that
+        // LoadAll's registration loop exists to prevent.
+        IReadOnlyList<Assembly>? Assemblies = null)
+    {
+        /// <summary>Every assembly of this app, primary first; never empty.</summary>
+        internal IReadOnlyList<Assembly> AllAssemblies => Assemblies ?? new[] { Asm };
+    }
 
     private static readonly ConcurrentDictionary<Guid, LoadedAppEntry> _cache = new();
     private static readonly ConcurrentDictionary<string, Assembly> _byName =
@@ -150,7 +160,6 @@ public sealed class DependencyLoader
                         m.AppId,
                         existing.Name, existing.Publisher, existing.Version, existing.SourcePath,
                         m.Name, m.Publisher, newVersion, path);
-
                 // Same directory with a changed identity falls through to a recompile rather
                 // than into the reuse below: serving `existing.Asm` would run the PREVIOUS
                 // version's compiled module for the new one's tests — the silent wrong answer
@@ -174,7 +183,10 @@ public sealed class DependencyLoader
                     // real cost paid every cycle for a ~100MB Base Application package for no reason.
                     if (existing.Tier3CacheKey != null)
                         ReplayDependencyMetadataSidecars(m, existing.Tier3CacheKey);
-                    list.Add(existing.Asm);
+                    // #3054: every assembly, not just the primary — see
+                    // LoadedAppEntry.Assemblies. Handing back only the cached primary here
+                    // would put every app group after the first back into the pre-fix state.
+                    list.AddRange(existing.AllAssemblies);
                     continue;
                 }
             }
@@ -235,9 +247,10 @@ public sealed class DependencyLoader
 
             Assembly? asm;
             string? tier3CacheKey;
+            IReadOnlyList<Assembly> chunks;
             try
             {
-                (asm, tier3CacheKey) = LoadOne(m, path, bucketRoot);
+                (asm, tier3CacheKey, chunks) = LoadOne(m, path, bucketRoot);
             }
             // #2131: this guard USED to be bare `when (microsoftSourceOnly)` — it caught
             // and silently swallowed EVERY Microsoft-source-only Tier-3 failure, including
@@ -263,30 +276,11 @@ public sealed class DependencyLoader
             }
             if (asm != null)
             {
-                _cache[m.AppId] = new LoadedAppEntry(asm, m.Name, m.Publisher, m.Version.ToString(), path, tier3CacheKey);
-                _byName[asm.GetName().Name ?? ""] = asm;
-                // #2683: this assembly is now the CURRENT generation for its simple name.
-                // Without this, BcRuntime.IsStaleBundleAssembly answered false for every
-                // generation of a dependency module — the registry only ever held bundle
-                // assemblies — so the AL type finders (Codeunit/Record/Page…) enumerated the
-                // previous cycle's copy and, per #1901, in practice found it FIRST, because
-                // AppDomain.CurrentDomain.GetAssemblies() tends to return the oldest first.
-                // A --watch edit to a dependency then recompiled and reloaded everything
-                // correctly and still executed the previous cycle's bodies.
-                BcRuntime.RegisterAssemblyGeneration(asm);
-                // Register app metadata so AlCallStackCapture can decorate frames.
-                AlCallStackCapture.RegisterAssemblyInfo(asm, m.Name, m.Publisher, m.Version.ToString());
-                // Register the assembly's app package so NavApp.GetResource can serve
-                // this app's packaged resources (.app /resources/ part, or the sibling
-                // source dir for source deps packaged into a synthetic workspace .app).
-                AlRunner.Patches.NavAppResourcePatches.RegisterDependencyAssembly(
-                    asm, m.AppId, m.Name, m.Publisher, m.Version.ToString(), path);
-                // Per-assembly module identity: this dep's code sees ITS OWN app info
-                // from NavApp.GetCurrentModuleInfo (real BC's executing-module rule),
-                // not the bundle's.
-                BcRuntime.RegisterModuleInfoForAssembly(
-                    asm, m.AppId, m.Name, m.Publisher, m.Version.ToString());
-                list.Add(asm);
+                var appAssemblies = chunks.Count > 0 ? chunks : new List<Assembly> { asm };
+                _cache[m.AppId] = new LoadedAppEntry(
+                    asm, m.Name, m.Publisher, m.Version.ToString(), path, tier3CacheKey, appAssemblies);
+                RegisterAppAssemblies(appAssemblies, m, path);
+                list.AddRange(appAssemblies);
             }
         }
         return list;
@@ -338,7 +332,74 @@ public sealed class DependencyLoader
         return SafeEnumerateFiles(bucketRoot, fileName).FirstOrDefault();
     }
 
-    private (Assembly? Asm, string? Tier3CacheKey) LoadOne(AppManifest m, string appPath, string bucketRoot)
+    /// <summary>
+    /// Give EVERY assembly an app was loaded as the app's identity, in all four per-assembly
+    /// registries the runner keys by <see cref="Assembly"/> (#3054).
+    ///
+    /// WHY THIS IS A LOOP AND NOT ONE CALL
+    ///   Microsoft ships large apps as several R2R DLL chunks — Base Application is five —
+    ///   and <see cref="LoadOne"/> loads all of them. Until this existed only the FIRST chunk
+    ///   was registered, so every AL object that happened to be compiled into chunks 2..n had
+    ///   no module identity at all:
+    ///
+    ///     * <c>NavApp.GetCallerModuleInfo</c> walks the managed stack and skips frames whose
+    ///       assembly is unregistered, so a call OUT of an unregistered chunk was attributed
+    ///       to whichever registered frame sat below it. Measured on BC 27.3: Base
+    ///       Application's codeunit 3999 "Reten. Pol. Install - BaseApp" lives in a
+    ///       non-primary chunk, so its <c>Reten. Pol. Allowed Tables.AddAllowedTable(405)</c>
+    ///       call reported System Application as the caller, BC's own ModuleOwnsTable check
+    ///       correctly refused ("the table is not owned by module {63CA2FA4-…}"), and
+    ///       codeunit 2 "Company-Initialize" then died on "Table 405 Change Log Entry is not
+    ///       in the list of allowed tables".
+    ///     * <c>InstallTriggerRunner</c> scans the assemblies LoadAll returns, so an Install
+    ///       codeunit in a non-primary chunk never ran. Same measurement: BC 27.3 fired no
+    ///       install trigger for codeunit 3999 at all, while BC 28.1 — where the same
+    ///       codeunit happens to land in the primary chunk — did.
+    ///
+    ///   Which chunk a given object lands in is Microsoft's build layout, so the symptom
+    ///   appeared and disappeared across BC builds with no version ordering to it (27.0,
+    ///   28.0 and 28.1 unaffected; 27.3, 27.5, 28.2, 28.3 and 28.4 affected).
+    /// </summary>
+    private static void RegisterAppAssemblies(IReadOnlyList<Assembly> assemblies, AppManifest m, string appPath)
+    {
+        var version = m.Version.ToString();
+        foreach (var asm in assemblies)
+        {
+            _byName[asm.GetName().Name ?? ""] = asm;
+            // #2683: this assembly is now the CURRENT generation for its simple name.
+            // Without this, BcRuntime.IsStaleBundleAssembly answered false for every
+            // generation of a dependency module — the registry only ever held bundle
+            // assemblies — so the AL type finders (Codeunit/Record/Page…) enumerated the
+            // previous cycle's copy and, per #1901, in practice found it FIRST, because
+            // AppDomain.CurrentDomain.GetAssemblies() tends to return the oldest first.
+            // A --watch edit to a dependency then recompiled and reloaded everything
+            // correctly and still executed the previous cycle's bodies.
+            BcRuntime.RegisterAssemblyGeneration(asm);
+            // Register app metadata so AlCallStackCapture can decorate frames.
+            AlCallStackCapture.RegisterAssemblyInfo(asm, m.Name, m.Publisher, version);
+            // Register the assembly's app package so NavApp.GetResource can serve
+            // this app's packaged resources (.app /resources/ part, or the sibling
+            // source dir for source deps packaged into a synthetic workspace .app).
+            AlRunner.Patches.NavAppResourcePatches.RegisterDependencyAssembly(
+                asm, m.AppId, m.Name, m.Publisher, version, appPath);
+            // Per-assembly module identity: this dep's code sees ITS OWN app info
+            // from NavApp.GetCurrentModuleInfo (real BC's executing-module rule),
+            // not the bundle's.
+            BcRuntime.RegisterModuleInfoForAssembly(asm, m.AppId, m.Name, m.Publisher, version);
+        }
+    }
+
+    /// <summary>Shared empty list for the LoadOne return paths that load a single assembly
+    /// (or none): the caller then falls back to just <c>Asm</c>.</summary>
+    private static readonly IReadOnlyList<Assembly> EmptyAssemblies = Array.Empty<Assembly>();
+
+    /// <summary>
+    /// Load one dependency app. <c>Assemblies</c> is EVERY assembly the app was loaded as and
+    /// is non-empty only for the multi-chunk R2R tier; every other tier produces one assembly
+    /// and returns it empty, which the caller reads as "just <c>Asm</c>" (#3054).
+    /// </summary>
+    private (Assembly? Asm, string? Tier3CacheKey, IReadOnlyList<Assembly> Assemblies) LoadOne(
+        AppManifest m, string appPath, string bucketRoot)
     {
         // Tier 1: precompiled DLL.
         var precompiled = FindPrecompiledSidecar(m, bucketRoot);
@@ -353,7 +414,7 @@ public sealed class DependencyLoader
                 // asm.GetTypes() on this assembly (asm.Location is empty for a byte[]-loaded
                 // assembly, so it couldn't cheaply re-derive this later on its own).
                 AlRunner.Patches.RecordPatches.SeedCompiledReportIdsFromPEBytes(asm, bytes);
-                return (asm, null);
+                return (asm, null, EmptyAssemblies);
             }
             catch (Exception ex)
             {
@@ -395,6 +456,7 @@ public sealed class DependencyLoader
             if (dllPaths.Count > 0)
             {
                 Assembly? primary = null;
+                var chunkAssemblies = new List<Assembly>();
                 int loaded = 0;
                 foreach (var dllPath in dllPaths)
                 {
@@ -409,6 +471,7 @@ public sealed class DependencyLoader
                         var n = asm.GetName().Name ?? "";
                         _byName[n] = asm;
                         primary ??= asm;
+                        chunkAssemblies.Add(asm);
                         loaded++;
                     }
                     catch (Exception ex)
@@ -426,7 +489,10 @@ public sealed class DependencyLoader
                 }
                 if (loaded > 1)
                     Console.Error.WriteLine($"[deps] tier-2 R2R: {m.Name} loaded {loaded} DLL chunk(s)");
-                return (primary, null);
+                // #3054: EVERY chunk, not just `primary`. An app split across several R2R
+                // DLLs is one module; handing back only the first left the rest with no app
+                // identity and out of the Install-trigger scan — see RegisterAppAssemblies.
+                return (primary, null, chunkAssemblies);
             }
         }
 
@@ -448,7 +514,7 @@ public sealed class DependencyLoader
                 Console.Error.WriteLine(
                     $"[deps] DLL-first: {m.Publisher}_{m.Name} v{m.Version} — {codeunitIds.Count} codeunit(s) " +
                     $"served from extracted service-tier DLLs; skipping source compile");
-                return (null, null); // lazy dispatch via ServiceTierDllIndex
+                return (null, null, EmptyAssemblies); // lazy dispatch via ServiceTierDllIndex
             }
         }
 
@@ -459,7 +525,7 @@ public sealed class DependencyLoader
             Console.Error.WriteLine(
                 $"[deps] NOTE: {m.Publisher}_{m.Name} v{m.Version} is symbol-only " +
                 $"(no runtime code in package); relying on service-tier/already-loaded assembly");
-            return (null, null);
+            return (null, null, EmptyAssemblies);
         }
 
         var cacheKey = ComputeSourceDependencyCacheKey(m, appPath);
@@ -507,7 +573,7 @@ public sealed class DependencyLoader
                     replayedEnums = AlEnumMetadataRegistry.LoadSidecar(enumRegistrySidecar);
                 Console.Error.WriteLine(
                     $"[deps] source-cache HIT: {m.Name} v{m.Version} key={cacheKey[..12]} ({cachedBytes.Length} bytes, {replayedReports} report-metadata entries, {replayedEnums} enum-registry entries)");
-                return (Assembly.Load(cachedBytes), cacheKey);
+                return (Assembly.Load(cachedBytes), cacheKey, EmptyAssemblies);
             }
             catch (Exception ex)
             {
@@ -621,7 +687,7 @@ public sealed class DependencyLoader
         {
             Console.Error.WriteLine($"[deps] source-cache write failed for {m.Name}: {ex.Message}");
         }
-        try { return (Assembly.Load(compile.AssemblyBytes!), cacheKey); }
+        try { return (Assembly.Load(compile.AssemblyBytes!), cacheKey, EmptyAssemblies); }
         catch (Exception ex)
         {
             // LOAD-FAIL: the compiled bytes could not be loaded into the ALC.

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -669,3 +669,29 @@ entry cheap to find. The general lesson stands: one local run is not the measure
 decides a manifest entry.
 
 Written by agent fbk-1 (automated implementation agent).
+
+### 2645 -> 2648 (pin 0309cec6 -> 83b54a91, PR #3067)
+
+One corpus commit, and it is the whole reason for the bump:
+StefanMaron/BusinessCentral.AL.Language.Tests#188, three tests in codeunit 60293 "Test Reten
+Pol Allowed Tables" pinning that Base Application's own table 405 "Change Log Entry" is on the
+retention-policy allowed list, that the registration carries the concrete date field
+(2000000001 SystemCreatedAt), and that a table nobody registers (18 "Customer") is absent.
+
+They are the upstream proof for #3054. Without them the eight legs run a corpus that cannot
+observe #3067's loader fix at all: on `main` the Company-Initialize abort is swallowed, so
+every affected test passes either way and the PR would carry no CI evidence for its own claim.
+Two of the three fail on a red BC build before the fix and pass after it.
+
+Nothing else comes with the bump. `83b54a91` is the immediate child of the pin `main` already
+carries, so this is one corpus commit rather than the ten-commit jump an earlier revision of
+this branch had to take before `main` caught up — and no new `expect-fail-known-gap` entry is
+owed, because `main` already declares the three that arrived with the intermediate commits
+(#3066, #3049, #2932) and #3061 fixed the fourth (60276, OnQueryClosePage on a handler-driven
+page).
+
+2648 is measured from the runner's own `--count-baseline` GROWTH output ("expected 2645, actual
+2648"), on BC 27.3 and BC 28.1, not counted off the source. Both legs reported the same number,
+so no `byBcVersion` override; the eight CI legs are what confirm that. appGroups is unchanged at
+1 — all three tests joined the single existing al-language app group. `runner-extras`,
+`al-language-internals-fixture` and `al-language-onprem` are `main`'s values, untouched.

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Schema, semantics and how to bump: README.md in this directory. Per-bump rationale: history.md, never a prose line in here (#2485).",
   "suites": {
     "al-language": {
-      "tests": { "default": 2645 },
+      "tests": { "default": 2648 },
       "appGroups": { "default": 1 }
     },
     "al-language-internals-fixture": { "tests": { "default": 0 }, "appGroups": { "default": 1 } },


### PR DESCRIPTION
Closes #3054

## What was happening

Microsoft ships large apps as several ReadyToRun DLL chunks — Base Application is **five**.
`DependencyLoader`'s Tier-2 loop loads every chunk, but it handed the caller back only the
**first** one (`primary`), and `LoadAll` then registered only that one. Every AL object the AL
compiler happened to place in chunks 2..n therefore had no app identity in any of the four
per-`Assembly` registries the runner keys on (`BcRuntime._moduleInfoByAssembly`,
`AlCallStackCapture`, `NavAppResourcePatches`, the assembly-generation registry).

Two things broke as a result:

1. **`NavApp.GetCallerModuleInfo` answered with the wrong app.**
   `BcRuntime.TryGetImmediateCallerModule` walks the managed stack and *skips* any frame whose
   assembly is not in the module map, so a call out of an unregistered chunk was attributed to
   whichever registered frame sat below it.
2. **Install triggers in a non-primary chunk never ran.** `InstallTriggerRunner` fires the
   Install codeunits of exactly the assemblies `LoadAll` returns.

Which chunk a given object lands in is Microsoft's build layout, which is why #3054's per-leg
split had no version ordering to it: 27.0 / 28.0 / 28.1 unaffected, 27.3 / 27.5 / 28.2 / 28.3 /
28.4 affected.

## The measurement

Reproduced locally by provisioning a **red-version** artifact, which is what the previous agent
could not do (this box only had 28.1, a green leg).

`AL_RUNNER_VERBOSE=1` is load-bearing: `Log.cs` suppresses any `[Component]`-tagged line at
default verbosity, and `[CompanyInitializer] … did not complete` is one of them. The diagnosis
was being printed and dropped.

**BC 27.3 (red leg), one small Base-App bundle, before the fix** — dumping BC's own
`Retention Policy Log Entry` (3905) rows straight out of the in-memory store:

```
row11 Warning  Cannot add table 405 Change Log Entry to the list of allowed tables
               because the table is not owned by module {63CA2FA4-4F03-4F2B-A480-172FEF340D3F}.
row12 Error    Table 405 Change Log Entry is not in the list of allowed tables.
```

`63CA2FA4-…` is **System Application**. The AL that registers table 405 is Base Application's
codeunit 3999 `"Reten. Pol. Install - BaseApp"`. Dumping the managed frames of that
`AddAllowedTable` call on 27.3 shows exactly why:

```
[4] * Codeunit3905+<AddAllowedTable_873312463>d__16::MoveNext  asm=BE2A0AB5…  (System Application)
[7] * Codeunit3905::AddAllowedTable_873312463                  asm=BE2A0AB5…  (System Application)
[8] * Codeunit3905::OnInvokeAsync                              asm=BE2A0AB5…  (System Application)
[13]  Codeunit3999::AddChangeLogEntryToAllowedTables           asm=77CD81F3…  (UNREGISTERED)
[17]  Codeunit3999::AddAllowedTables_1635129500                asm=77CD81F3…  (UNREGISTERED)
[25]  Codeunit3999::AddAllowedTablesOnBeforeCompanyInit        asm=77CD81F3…  (UNREGISTERED)
```

`*` = in `BcRuntime`'s module map. Base App's chunk `77CD81F3…` is not, so the walk skipped it
and answered "System Application"; BC's own `ModuleOwnsTable` then correctly refused, and
codeunit 2 `"Company-Initialize"` died on the downstream error.

On **28.1 (green leg)** the identical frame shape resolves correctly, because on that build
codeunit 3999 happens to sit in `0A4BE0A6…`, the chunk that *was* registered — and its install
trigger fires there too (`PERF InstallTrigger Codeunit3999`), while on 27.3 no install trigger
for 3999 ran at all.

### Before → after, matched runner build and app set

| | before | after |
|---|---|---|
| BC 27.3, small bundle | `[CompanyInitializer] … did not complete: Table 405 … not in the list of allowed tables` | clean; `InstallTrigger Codeunit3999 (77CD81F3…)` now fires |
| BC 28.2, small bundle | same failure | clean |
| BC 27.3 corpus, **with #2979 applied** | 2596 P / **3 F** (60990 ×2 "General Ledger Setup does not exist", 60207) | **2599 / 2599** |
| BC 28.2 corpus, with #2979 applied | (red per #3054's CI table) | **2599 / 2599** |
| BC 28.1 corpus, this PR alone | 2599 / 2599 | **2599 / 2599** (control, no regression) |

`--package-cache` pointed at freshly downloaded 27.3 / 28.2 / 28.1 platform + test-toolkit
artifacts; `AL_RUNNER_NO_DEP_COMPANY_CACHE=1` so the install-baseline cache could not hide the
recompute. #2979 was applied **only for the measurement** and is not part of this diff.

## What this means for #2979

#3054's body said the affected tests were declared in `known-gaps-published-application.json`.
That file exists neither on `main` nor in #2979's diff — #2979's own note is the accurate
version, and this line is corrected rather than repeated. What is true, and is what the issue
was actually blocked on: post-#3004 those tests were failing only because of this loader defect,
so there is no per-BC-version scoping to add and nothing left for the expectations schema to
express. #2979 should go green on all eight legs once this merges and it rebases.

Deliberately **not** done here, per the task's bounds: no per-BC-version scoping in
`tests/expectations/`. It would have hidden a real loader defect behind a classification.

## Fixing the shape, not the reported line

- **Same wrong pattern at another call site?** Yes — `LoadAll`'s cache-hit branch
  (`list.Add(existing.Asm)`) had it too, and would have put every app group after the first back
  into the pre-fix state. `LoadedAppEntry` now carries the whole chunk set and the second test
  pins it.
- **Do sibling functions make the same assumption?** Yes, three of them: `AlCallStackCapture`,
  `NavAppResourcePatches` and the assembly-generation registry are all keyed by `Assembly` and
  were all registered for `primary` only. All four now go through one `RegisterAppAssemblies`
  loop, so they cannot drift apart again.
- **Do two paths that write the same state keep the same invariant?** They do now — the fresh-load
  path and the cache-hit path both hand back `AllAssemblies`.

## Tests

`AlRunner.Tests/DependencyR2rChunkModuleIdentityTests.cs` drives the real Tier-2 path with a
synthetic three-chunk `publishedartifacts/*.dll` package built from Roslyn stubs — no BC
artifact, no Base Application floor (`no-base-app-in-csharp-tests.md`), 0.7 s.

* RED before the fix: `Expected: [a, b, c]  Actual: [a]`, and the cache-hit test `Expected: 2 Actual: 1`.
* GREEN after: 2/2.
* Also run green: `CorruptSidecarLoaderCallSiteTests` (3), `DependencyResolverTests` (35),
  `AppLoaderR2rChunkCacheTests` (2), `DependencyShadowDiagnosticTests` (5).

The claim this test makes is entirely about the runner's own loader bookkeeping, so it stays here.
The **BC-behaviour** half — that table 405 is in the retention-policy allowed list once a company
is initialised — is a statement a service tier must adjudicate and is going upstream as a corpus
PR; that corpus test is not needed to prove this fix, which is why the pin is not bumped here.

---
Written by agent `stma-auto-1` acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
