### PR TITLE
fix(permission-metadata): name the BC-layout change instead of throwing a type asserterror swallows

### DIFF
--- a/AlRunner.Tests/PermissionMetadataMethodOverloadGuardTests.cs
+++ b/AlRunner.Tests/PermissionMetadataMethodOverloadGuardTests.cs
@@ -193,6 +193,188 @@ public sealed class PermissionMetadataMethodOverloadGuardTests
         Assert.Equal("NavAppGroup.GroupSummaryComparer.Compare", ex.Member);
     }
 
+    // ══ 2b. RequireBcInstance — the MissingMethodException route ════════════════════════
+    //
+    // Activator.CreateInstance(Type) raises MissingMethodException when the parameterless
+    // constructor is gone. Anonymous, and absorbed by the same seam, so `asserterror` PASSES on
+    // an instantiation real BC performs fine. Both directions, like every other helper in this
+    // family.
+
+    [Fact]
+    public void RequireBcInstance_RaisesAShapeGapNamingTheType_WhenTheConstructorIsGone()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => Invoke("RequireBcInstance",
+            typeof(NoParameterlessCtor), "MetaPermission"));
+
+        Assert.Equal("Permission metadata (NavAppGroup permission-set inventory)", ex.Surface);
+        Assert.Equal("MetaPermission", ex.Member);
+        Assert.Contains("NoParameterlessCtor has no parameterless constructor", ex.Detail,
+            StringComparison.Ordinal);
+    }
+
+    // THE INVERSION for this route: pre-fix the MissingMethodException was swallowed and the
+    // asserterror passed. The refusal must tear through instead.
+    [Fact]
+    public void AssertError_TearsThrough_InsteadOfSwallowingTheMissingConstructor()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => BcRuntime.NavMethodScope_AssertError(
+            null!, () => Invoke("RequireBcInstance", typeof(NoParameterlessCtor), "MetaPermission")));
+
+        Assert.Equal("MetaPermission", ex.Member);
+    }
+
+    // THE INVERSION on the REAL call path, which is what the pre-fix build can be measured
+    // against: InstallFreshPermissionSetLookup over a lookup whose dictionary type lost its
+    // parameterless constructor. Pre-fix that is Activator.CreateInstance raising
+    // MissingMethodException, swallowed, asserterror green.
+    [Fact]
+    public void AssertError_TearsThrough_WhenTheLookupDictionaryLostItsConstructor()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => BcRuntime.NavMethodScope_AssertError(
+            null!, () => WithInjectedStatics(
+                typeof(FakeAppGroup).GetField(nameof(FakeAppGroup.NoCtorLookup))!,
+                typeof(FakeSummary),
+                () => Invoke("InstallFreshPermissionSetLookup", new object(), new List<object>()))));
+
+        Assert.Equal("NavAppGroup.permissionSetLookup", ex.Member);
+        Assert.Contains("has no parameterless constructor", ex.Detail, StringComparison.Ordinal);
+    }
+
+    // CONTROL: a type that HAS one is still constructed, so the refusal is about the missing
+    // constructor and not about the helper refusing everything.
+    [Fact]
+    public void RequireBcInstance_StillConstructs_WhenTheParameterlessConstructorIsThere()
+    {
+        var made = Invoke("RequireBcInstance", typeof(PlainAddDictionary<string, object>), "x");
+
+        Assert.IsType<PlainAddDictionary<string, object>>(made);
+    }
+
+    // A NON-PUBLIC constructor is accepted. Activator.CreateInstance(Type) would refuse it, so
+    // this is deliberately wider than what it replaced: BC's own types are frequently internal,
+    // and refusing a constructor that exists would turn a working build into a shape gap.
+    [Fact]
+    public void RequireBcInstance_AcceptsANonPublicConstructor_WhichActivatorWouldHaveRefused()
+    {
+        Assert.Throws<MissingMethodException>(() => Activator.CreateInstance(typeof(NonPublicCtor)));
+
+        Assert.IsType<NonPublicCtor>(Invoke("RequireBcInstance", typeof(NonPublicCtor), "x"));
+    }
+
+    // THE VALUE-TYPE CARVE-OUT, which is load-bearing and had nothing pinning it. A struct
+    // declares NO parameterless constructor, so the reference-type path would refuse one — and
+    // BC declares MetaPermission as a struct with ctors = 0 on every shipped build measured
+    // (27.3.44313.53909, 27.5.46862.48827, 28.1.49838.53910, 28.1.49838.54308, 28.2.50931.54319).
+    // Without this branch the permission-set inventory refuses to populate on all five.
+    [Fact]
+    public void RequireBcInstance_ConstructsAStruct_ThatDeclaresNoParameterlessConstructor()
+    {
+        Assert.Empty(typeof(StructWithNoCtor).GetConstructors(
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
+
+        var made = Invoke("RequireBcInstance", typeof(StructWithNoCtor), "MetaPermission");
+
+        Assert.IsType<StructWithNoCtor>(made);
+        Assert.Equal(0, ((StructWithNoCtor)made!).Id);
+    }
+
+    // ══ 2c. Compare's return type — the InvalidCastException route ══════════════════════
+    //
+    // `(int)compare.Invoke(...)` is a BC-shape assumption. A Compare that stopped returning int
+    // raises InvalidCastException inside the seam, so the asserterror passes on a sort real BC
+    // performs fine. Driven through InstallPermissionSetSlot — the real call path — with the
+    // four reflection statics it reads injected for one call.
+
+    [Fact]
+    public void InstallPermissionSetSlot_RaisesAShapeGap_WhenCompareNoLongerReturnsInt()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => InstallSlotWithComparer(typeof(StringComparer2)));
+
+        Assert.Equal("NavAppGroup.GroupSummaryComparer.Compare", ex.Member);
+        Assert.Contains("returns String, not the Int32 this sort unboxes", ex.Detail,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AssertError_TearsThrough_InsteadOfSwallowingTheCompareReturnTypeChange()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => BcRuntime.NavMethodScope_AssertError(
+            null!, () => InstallSlotWithComparer(typeof(StringComparer2))));
+
+        Assert.Equal("NavAppGroup.GroupSummaryComparer.Compare", ex.Member);
+    }
+
+    // CONTROL: an int-returning Compare gets PAST the guard and fails at the next refusal — the
+    // FrozenSharingArray constructor the fake open generic does not provide. Without this the
+    // arms above could be satisfied by a guard that refused every comparer.
+    [Fact]
+    public void InstallPermissionSetSlot_GetsPastTheGuard_WhenCompareStillReturnsInt()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => InstallSlotWithComparer(typeof(IntComparer2)));
+
+        Assert.Equal("FrozenSharingArray<T>(IReadOnlyList<T>, IComparer<T>)", ex.Member);
+    }
+
+    /// <summary>
+    /// TWO summaries, not zero: List.Sort does not call the comparison delegate for a shorter
+    /// list, so an empty one never reaches `(int)compare.Invoke(...)` and the pre-fix build would
+    /// sail past the very cast these arms are about. With two, the pre-fix build raises
+    /// InvalidCastException there — which is the failure the seam swallowed.
+    /// </summary>
+    private static void InstallSlotWithComparer(Type comparerType) => WithStatics(
+        new (string, object?)[]
+        {
+            ("_fSummariesByType",       typeof(FakeGroupWithSlots).GetField(nameof(FakeGroupWithSlots.Slots))),
+            ("_fComparerInstance",      comparerType.GetField("Instance")),
+            ("_tGroupSummaryComparer",  comparerType),
+            ("_tSummary",               typeof(FakeSummary)),
+            ("_tFrozenSharingArrayOpen", typeof(FakeFrozen<>)),
+        },
+        () => Invoke("InstallPermissionSetSlot", new FakeGroupWithSlots(),
+            new List<object> { new FakeSummary(), new FakeSummary() }));
+
+    // ══ 2d. The property route — GetProperty carries it too ═════════════════════════════
+    //
+    // Type.GetProperty(name, flags) throws AmbiguousMatchException for a `new`-hidden property
+    // whose TYPE changed, and for two same-name properties in one type. FindBcProperty
+    // enumerates instead, so the outcome is the property or a named refusal.
+
+    [Fact]
+    public void FindBcProperty_CountsBothDeclarations_WhenAHiddenPropertyChangedItsType()
+    {
+        // The premise, measured rather than assumed: the call this replaced DOES throw here.
+        Assert.Throws<AmbiguousMatchException>(() => typeof(HidesWithADifferentType).GetProperty(
+            "P", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
+
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Invoke("RequireBcProperty", typeof(HidesWithADifferentType), "P"));
+
+        Assert.Equal("HidesWithADifferentType.P", ex.Member);
+        Assert.Contains("BC declares 2 properties named P", ex.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AssertError_TearsThrough_InsteadOfSwallowingTheAmbiguousProperty()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => BcRuntime.NavMethodScope_AssertError(
+            null!, () => Invoke("RequireBcProperty", typeof(HidesWithADifferentType), "P")));
+
+        Assert.Equal("HidesWithADifferentType.P", ex.Member);
+    }
+
+    // CONTROL: a `new`-hidden property of the SAME type is NOT ambiguous — reflection's
+    // hiding-by-name-and-signature filter drops the base one — so it still resolves, to the
+    // derived declaration. This is why the guard's comment says the trigger is narrower than
+    // "a hidden property".
+    [Fact]
+    public void FindBcProperty_StillResolves_WhenTheHiddenPropertyKeptItsType()
+    {
+        var prop = (PropertyInfo)Invoke("RequireBcProperty", typeof(HidesWithTheSameType), "P")!;
+
+        Assert.Equal(typeof(HidesWithTheSameType), prop.DeclaringType);
+        Assert.Equal(2, prop.GetValue(new HidesWithTheSameType()));
+    }
+
     // ══ 3. RequireBcLookupKeyValueTypes ═════════════════════════════════════════════════
 
     [Fact]
@@ -216,13 +398,30 @@ public sealed class PermissionMetadataMethodOverloadGuardTests
 
     // ══ 4. The shape, not just the one line the issue named ═════════════════════════════
     //
-    // The two sibling files in the same slice already pin every signature they look up
-    // (NavGuid.Create(Guid), AggregatePermissionSetDataProvider.GetSystemPermissionSets(NavValue,
-    // NavCode), …) — the populator's helper was the outlier. This keeps the next edit from
-    // reintroducing a name-only GetMethod anywhere in the slice.
+    // TWO member kinds, and the guard covers BOTH — the first version covered only GetMethod,
+    // which left the file able to drift straight back into the defect through GetProperty.
+    // Measured on .NET 8.0.30 (the two shapes are NOT the same, and the difference matters):
+    //
+    //   Type.GetMethod(name, flags)    throws AmbiguousMatchException for an overload added in
+    //                                  the SAME type, and for a `new`-hidden method whose
+    //                                  signature changed.
+    //   Type.GetProperty(name, flags)  throws for a `new`-hidden property whose TYPE changed
+    //                                  (int P -> string P) and for two same-name properties in
+    //                                  one type (an added indexer). It does NOT throw for a
+    //                                  `new`-hidden property of the SAME type — reflection's
+    //                                  hiding-by-name-and-signature filter drops the base one.
+    //   Type.GetField(name, flags)     throws in NONE of those shapes; it returns the
+    //                                  most-derived field. Field lookups are therefore not
+    //                                  offenders and are deliberately not listed here.
+    //
+    // A method lookup clears the guard by pinning `types:`; a property lookup clears it by going
+    // through FindBcProperty, which enumerates and so cannot throw. The two sibling files in the
+    // slice already pinned every method signature (NavGuid.Create(Guid),
+    // GetSystemPermissionSets(NavValue, NavCode), …) — the populator's helper was the outlier —
+    // and their four property lookups were converted with it.
 
     [Fact]
-    public void NoMethodLookupInTheSlice_ResolvesByNameWithoutASignature()
+    public void NoMemberLookupInTheSlice_ResolvesByNameWithoutASignature()
     {
         var offenders = new List<string>();
 
@@ -237,14 +436,21 @@ public sealed class PermissionMetadataMethodOverloadGuardTests
             foreach (var statement in code.Split(';'))
             {
                 var flat = string.Join(" ", statement.Split('\n').Select(l => l.Trim()));
-                if (!flat.Contains(".GetMethod(", StringComparison.Ordinal)) continue;
-                if (flat.Contains("types:", StringComparison.Ordinal)) continue;
-                offenders.Add($"{file}: {flat.Trim()}");
+
+                // A method lookup is acceptable only with an explicit signature.
+                if (flat.Contains(".GetMethod(", StringComparison.Ordinal)
+                    && !flat.Contains("types:", StringComparison.Ordinal))
+                    offenders.Add($"{file}: {flat.Trim()}");
+
+                // A property lookup has no signature to pin — the plural enumeration is the
+                // only acceptable form, and it is spelled GetProperties, which does not match.
+                if (flat.Contains(".GetProperty(", StringComparison.Ordinal))
+                    offenders.Add($"{file}: {flat.Trim()}");
             }
         }
 
         Assert.True(offenders.Count == 0,
-            "these method lookups resolve by name alone, so an overload Microsoft ships raises "
+            "these member lookups resolve by name alone, so a declaration Microsoft adds raises "
             + "AmbiguousMatchException into NavMethodScope_AssertError instead of naming the gap "
             + $"(#3062):{Environment.NewLine}" + string.Join(Environment.NewLine, offenders));
     }
@@ -283,6 +489,26 @@ public sealed class PermissionMetadataMethodOverloadGuardTests
         }
     }
 
+    /// <summary>
+    /// <see cref="WithInjectedStatics"/> generalised to any set of RecordPatches statics, for the
+    /// call paths that read more than two. Same contract: overwrite for exactly one call, restore
+    /// every one of them in a finally, and make nothing in production settable for the test.
+    /// </summary>
+    private static void WithStatics((string Name, object? Value)[] statics, Action body)
+    {
+        var fields = statics.Select(x => (Field: Static(x.Name), x.Value)).ToArray();
+        var saved = fields.Select(f => f.Field.GetValue(null)).ToArray();
+        try
+        {
+            foreach (var (field, value) in fields) field.SetValue(null, value);
+            body();
+        }
+        finally
+        {
+            for (var i = 0; i < fields.Length; i++) fields[i].Field.SetValue(null, saved[i]);
+        }
+    }
+
     private static FieldInfo Static(string name)
         => typeof(RecordPatches).GetField(name, Priv)
            ?? throw new InvalidOperationException($"test setup: RecordPatches.{name} not found");
@@ -308,6 +534,14 @@ public sealed class PermissionMetadataMethodOverloadGuardTests
         public void Add(TKey key, TValue value, bool overwrite) { }
     }
 
+    /// <summary>A lookup dictionary whose parameterless constructor Microsoft removed.</summary>
+    public sealed class NoCtorDictionary<TKey, TValue> where TKey : notnull
+    {
+        public NoCtorDictionary(int required) => Required = required;
+        public int Required { get; }
+        public void Add(TKey key, TValue value) { }
+    }
+
     /// <summary>The shape BC declares today: exactly one Add.</summary>
     public sealed class PlainAddDictionary<TKey, TValue> where TKey : notnull
     {
@@ -315,10 +549,62 @@ public sealed class PermissionMetadataMethodOverloadGuardTests
         internal void Hidden() { }
     }
 
-    private sealed class FakeSummary
+    public sealed class FakeSummary
     {
         public string ObjectName => "SUPER";
     }
+
+    /// <summary>A BC type whose parameterless constructor Microsoft removed.</summary>
+    public sealed class NoParameterlessCtor
+    {
+        public NoParameterlessCtor(int required) => Required = required;
+        public int Required { get; }
+    }
+
+    /// <summary>A BC type whose only constructor is non-public — common for Ncl internals.</summary>
+    public sealed class NonPublicCtor
+    {
+        internal NonPublicCtor() { }
+    }
+
+    /// <summary>Stands in for MetaPermission, which BC declares as a struct.</summary>
+    public struct StructWithNoCtor
+    {
+        public int Id;
+    }
+
+    private sealed class FakeGroupWithSlots
+    {
+        // Longer than ObjectType.PermissionSet's ordinal (20), so the slot is in range.
+        public object?[] Slots = new object?[64];
+    }
+
+    public sealed class StringComparer2
+    {
+        public static readonly StringComparer2 Instance = new();
+        public string Compare(FakeSummary x, FakeSummary y) => "not an int";
+    }
+
+    public sealed class IntComparer2
+    {
+        public static readonly IntComparer2 Instance = new();
+        public int Compare(FakeSummary x, FakeSummary y) => 0;
+    }
+
+    /// <summary>An open generic standing in for FrozenSharingArray&lt;T&gt;, with no two-argument
+    /// constructor — the refusal the int-returning control arm is expected to reach.</summary>
+    public sealed class FakeFrozen<T>
+    {
+    }
+
+    private class BaseWithP { public int P => 1; }
+
+    /// <summary>The shape GetProperty(name, flags) cannot resolve: both declarations are
+    /// returned by GetProperties because the types differ.</summary>
+    private sealed class HidesWithADifferentType : BaseWithP { public new string P => "two"; }
+
+    /// <summary>The shape it CAN resolve: same type, so the base one is filtered out.</summary>
+    private sealed class HidesWithTheSameType : BaseWithP { public new int P => 2; }
 
     private sealed class FakeLazy<T>
     {
@@ -329,5 +615,6 @@ public sealed class PermissionMetadataMethodOverloadGuardTests
     {
         public FakeLazy<OverloadedAddDictionary<string, object>>? OverloadedLookup;
         public FakeLazy<PlainAddDictionary<string, object>>? PlainLookup;
+        public FakeLazy<NoCtorDictionary<string, object>>? NoCtorLookup;
     }
 }

--- a/AlRunner.Tests/PermissionMetadataMethodOverloadGuardTests.cs
+++ b/AlRunner.Tests/PermissionMetadataMethodOverloadGuardTests.cs
@@ -1,0 +1,333 @@
+// PermissionMetadataMethodOverloadGuardTests — the wrong-TYPE half of the AssertError inversion (#3062).
+//
+// ── THE SECOND ROUTE INTO THE SAME INVERSION ─────────────────────────────────────────────
+// #3046 / PR #3053 closed one way for a BC-internals read to reach AL as "no error at all": a
+// lookup guarded only by `!` hands back a silent null, and the NullReferenceException at the
+// first USE of it is swallowed by MethodScopePatches.NavMethodScope_AssertError, so AL's
+// `asserterror` PASSES on a read real BC performs fine.
+//
+// A null is not the only way in. NavMethodScope_AssertError rethrows exactly one type
+// (BcShapeGapException) and absorbs everything else, so a THROW OF THE WRONG TYPE inverts the
+// result the same way — and no `!` appears in it, so #3051's sweep of null-forgiving lookups
+// cannot find these by construction.
+//
+// ── THE SITE, AND WHY IT IS THE SHARPEST ONE ─────────────────────────────────────────────
+// RecordPatches.PermissionMetadataPopulator.RequireBcMethod was ADDED by #3053, in the helper
+// written to fix the first kind of inversion, and it resolved by Type.GetMethod(string). That
+// overload throws AmbiguousMatchException the moment Microsoft ships a second method of the
+// same name — which is precisely the BC-layout change the helper exists to NAME. Absorbed by
+// the seam, it becomes a green asserterror over a population that silently did not happen.
+//
+// ── WHICH SEAM ACTUALLY INVERTS ──────────────────────────────────────────────────────────
+// Only asserterror. NavApplicationObjectBase_TryInvoke rethrows anything that is not a
+// trappable NavBaseException or a permanently out-of-scope refusal, so an AmbiguousMatchException
+// already reached AL as a failure there. The TryFunction arm below is therefore a CONTROL —
+// it pins that the corrected refusal still tears through — and not a second RED.
+//
+// ── MEASURED RED (pre-fix production file, this test file unchanged) ─────────────────────
+//     AssertError_TearsThrough_InsteadOfSwallowingTheAmbiguousMatch
+//         Assert.Throws() Failure: No exception was thrown
+// That message IS the inversion: the seam swallowed the AmbiguousMatchException and the
+// asserterror passed. Post-fix the overload resolves, the population runs on, and the only
+// refusal that reaches AL is a named BcShapeGapException.
+//
+// ── WHAT THE FIX DOES ────────────────────────────────────────────────────────────────────
+// RequireBcMethod enumerates candidates (which cannot throw) instead of calling
+// GetMethod(string), and takes the signature the call site's Invoke argument array is built
+// for. Three of the file's four method lookups can state that signature from something already
+// in hand — the lookup dictionary's own generic arguments, the summary type, the instance being
+// passed — so an added overload is RESOLVED. The fourth would have to resolve two more BC types
+// by name just to state it, so it stays unique-by-name, where a second declaration is refused
+// BY NAME rather than arriving as an anonymous AmbiguousMatchException.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(PermissionMetadataStaticsSerialCollection.Name)]
+public sealed class PermissionMetadataMethodOverloadGuardTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private const BindingFlags Priv = BindingFlags.NonPublic | BindingFlags.Static;
+
+    // ══ 1. THE INVERSION, on the real call path ═════════════════════════════════════════
+    //
+    // InstallFreshPermissionSetLookup with a lookup whose dictionary type declares a second
+    // Add — the shape a Microsoft overload produces. Both arms drive PRODUCTION code through
+    // the AL seams; nothing here is a re-implementation of the helper.
+
+    [Fact]
+    public void AssertError_TearsThrough_InsteadOfSwallowingTheAmbiguousMatch()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => BcRuntime.NavMethodScope_AssertError(
+            null!, () => InstallLookupOverAnOverloadedDictionary()));
+
+        // Getting as far as the LazyEx constructor is the proof that the overloaded Add was
+        // RESOLVED rather than choked on: it is the next refusal after the Add lookup, and the
+        // fake Lazy is what cannot satisfy it. Pre-fix this arm never reached here — the
+        // AmbiguousMatchException was raised two steps earlier and the seam ate it.
+        Assert.Equal("Permission metadata (NavAppGroup permission-set inventory)", ex.Surface);
+        Assert.Equal("LazyEx<T>(Func<T>)", ex.Member);
+    }
+
+    // CONTROL, not a second RED: TryInvoke rethrew the AmbiguousMatchException before this
+    // change too. What it pins is that the corrected path still ends in a refusal AL cannot
+    // trap, rather than in a silent success.
+    [Fact]
+    public void TryFunction_StillCannotTrapTheRefusal_OnTheCorrectedPath()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => BcRuntime.NavApplicationObjectBase_TryInvoke(
+            null, () => InstallLookupOverAnOverloadedDictionary()));
+
+        Assert.Equal("LazyEx<T>(Func<T>)", ex.Member);
+    }
+
+    // CONTROL: with a single-Add dictionary the same call reaches the same refusal, so the arms
+    // above are about the overload being resolved and not about the injection itself failing.
+    [Fact]
+    public void TheSamePath_ReachesTheSameRefusal_WithASingleAddDictionary()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => WithInjectedStatics(
+            typeof(FakeAppGroup).GetField(nameof(FakeAppGroup.PlainLookup))!,
+            typeof(FakeSummary),
+            () => Invoke("InstallFreshPermissionSetLookup", new object(), new List<object>())));
+
+        Assert.Equal("LazyEx<T>(Func<T>)", ex.Member);
+    }
+
+    private static void InstallLookupOverAnOverloadedDictionary() => WithInjectedStatics(
+        typeof(FakeAppGroup).GetField(nameof(FakeAppGroup.OverloadedLookup))!,
+        typeof(FakeSummary),
+        () => Invoke("InstallFreshPermissionSetLookup", new object(), new List<object>()));
+
+    // ══ 2. RequireBcMethod resolves the SIGNATURE, not just the name ════════════════════
+
+    [Fact]
+    public void RequireBcMethod_ResolvesTheDeclaredSignature_WhenBcAlsoShipsAnOverload()
+    {
+        var m = (MethodInfo)Invoke("RequireBcMethod",
+            typeof(OverloadedAddDictionary<string, object>), "Add",
+            new[] { typeof(string), typeof(object) }, null)!;
+
+        Assert.Equal(new[] { typeof(string), typeof(object) },
+            m.GetParameters().Select(p => p.ParameterType).ToArray());
+    }
+
+    // The selection DISCRIMINATES: asked for the three-parameter overload it returns that one,
+    // so the arm above is not satisfied by a helper that always hands back the first candidate.
+    [Fact]
+    public void RequireBcMethod_ReturnsTheOtherOverload_WhenThatIsTheSignatureAskedFor()
+    {
+        var m = (MethodInfo)Invoke("RequireBcMethod",
+            typeof(OverloadedAddDictionary<string, object>), "Add",
+            new[] { typeof(string), typeof(object), typeof(bool) }, null)!;
+
+        Assert.Equal(3, m.GetParameters().Length);
+        Assert.Equal(typeof(bool), m.GetParameters()[2].ParameterType);
+    }
+
+    [Fact]
+    public void RequireBcMethod_RaisesAShapeGapNamingTheSignature_WhenTheParametersHaveMoved()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => Invoke("RequireBcMethod",
+            typeof(OverloadedAddDictionary<string, object>), "Add",
+            new[] { typeof(int) }, null));
+
+        Assert.Equal("OverloadedAddDictionary`2.Add", ex.Member);
+        Assert.Contains("method not found with signature (Int32)", ex.Detail, StringComparison.Ordinal);
+    }
+
+    // The unique-by-name path (CreateEmptyNCLMetaPermissionSet's): a second declaration is
+    // refused BY NAME. Pre-fix this was an AmbiguousMatchException, which asserterror absorbed.
+    [Fact]
+    public void RequireBcMethod_RaisesAShapeGap_WhenNoSignatureIsGivenAndBcDeclaresTwo()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => Invoke("RequireBcMethod",
+            typeof(OverloadedAddDictionary<string, object>), "Add", null, null));
+
+        Assert.Equal("OverloadedAddDictionary`2.Add", ex.Member);
+        Assert.Contains("BC declares 2 methods named Add", ex.Detail, StringComparison.Ordinal);
+        Assert.Contains("cannot tell which one", ex.Detail, StringComparison.Ordinal);
+    }
+
+    // CONTROL: unique by name still resolves with no signature given, so the refusal above is
+    // about the second declaration and not about the null signature.
+    [Fact]
+    public void RequireBcMethod_StillResolvesByNameAlone_WhenBcDeclaresExactlyOne()
+    {
+        var m = (MethodInfo)Invoke("RequireBcMethod",
+            typeof(PlainAddDictionary<string, object>), "Add", null, null)!;
+
+        Assert.Equal(2, m.GetParameters().Length);
+    }
+
+    // A non-public method resolves: two of this file's four lookups are NonPublic on BC's own
+    // types, so a helper narrower than they are would refuse a build that works.
+    [Fact]
+    public void RequireBcMethod_FindsANonPublicMethod_SoTheFourCallSitesAgree()
+    {
+        var m = (MethodInfo)Invoke("RequireBcMethod",
+            typeof(PlainAddDictionary<string, object>), "Hidden", null, null)!;
+
+        Assert.Equal("Hidden", m.Name);
+    }
+
+    // The custom member name the Compare call site passes survives, so the refusal still says
+    // NavAppGroup.GroupSummaryComparer.Compare rather than the bare nested type's name.
+    [Fact]
+    public void RequireBcMethod_UsesTheCallSitesMemberName_WhenOneIsGiven()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => Invoke("RequireBcMethod",
+            typeof(PlainAddDictionary<string, object>), "Compare", null,
+            "NavAppGroup.GroupSummaryComparer.Compare"));
+
+        Assert.Equal("NavAppGroup.GroupSummaryComparer.Compare", ex.Member);
+    }
+
+    // ══ 3. RequireBcLookupKeyValueTypes ═════════════════════════════════════════════════
+
+    [Fact]
+    public void RequireBcLookupKeyValueTypes_ReturnsTheDictionarysOwnKeyAndValueTypes()
+    {
+        var kv = (Type[])Invoke("RequireBcLookupKeyValueTypes",
+            typeof(Dictionary<string, int>))!;
+
+        Assert.Equal(new[] { typeof(string), typeof(int) }, kv);
+    }
+
+    [Fact]
+    public void RequireBcLookupKeyValueTypes_RaisesAShapeGap_WhenTheLookupIsNotATwoArgumentGeneric()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => Invoke("RequireBcLookupKeyValueTypes", typeof(List<string>)));
+
+        Assert.Equal("NavAppGroup.permissionSetLookup", ex.Member);
+        Assert.Contains("two-argument Dictionary", ex.Detail, StringComparison.Ordinal);
+    }
+
+    // ══ 4. The shape, not just the one line the issue named ═════════════════════════════
+    //
+    // The two sibling files in the same slice already pin every signature they look up
+    // (NavGuid.Create(Guid), AggregatePermissionSetDataProvider.GetSystemPermissionSets(NavValue,
+    // NavCode), …) — the populator's helper was the outlier. This keeps the next edit from
+    // reintroducing a name-only GetMethod anywhere in the slice.
+
+    [Fact]
+    public void NoMethodLookupInTheSlice_ResolvesByNameWithoutASignature()
+    {
+        var offenders = new List<string>();
+
+        foreach (var file in SliceFiles)
+        {
+            var path = Path.Combine(RepoRoot, "AlRunner", "Patches", file);
+            Assert.True(File.Exists(path), $"{file} not found at {path} — it was renamed or moved.");
+
+            // Comments stripped first: this file's own siblings quote the retired shape in prose.
+            var code = string.Join("\n", File.ReadAllLines(path).Select(StripLineComment));
+
+            foreach (var statement in code.Split(';'))
+            {
+                var flat = string.Join(" ", statement.Split('\n').Select(l => l.Trim()));
+                if (!flat.Contains(".GetMethod(", StringComparison.Ordinal)) continue;
+                if (flat.Contains("types:", StringComparison.Ordinal)) continue;
+                offenders.Add($"{file}: {flat.Trim()}");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "these method lookups resolve by name alone, so an overload Microsoft ships raises "
+            + "AmbiguousMatchException into NavMethodScope_AssertError instead of naming the gap "
+            + $"(#3062):{Environment.NewLine}" + string.Join(Environment.NewLine, offenders));
+    }
+
+    private static string StripLineComment(string line)
+    {
+        var at = line.IndexOf("//", StringComparison.Ordinal);
+        return at < 0 ? line : line.Substring(0, at);
+    }
+
+    private static readonly string[] SliceFiles =
+    {
+        "RecordPatches.AggregatePermissionSetVirtualTable.cs",
+        "RecordPatches.MetadataPermissionSetVirtualTable.cs",
+        "RecordPatches.PermissionMetadataPopulator.cs",
+    };
+
+    // ══ Plumbing ════════════════════════════════════════════════════════════════════════
+
+    private static void WithInjectedStatics(FieldInfo lookupField, Type summaryType, Action body)
+    {
+        var fLookup = Static("_fPermissionSetLookup");
+        var fSummary = Static("_tSummary");
+        var savedLookup = fLookup.GetValue(null);
+        var savedSummary = fSummary.GetValue(null);
+        try
+        {
+            fLookup.SetValue(null, lookupField);
+            fSummary.SetValue(null, summaryType);
+            body();
+        }
+        finally
+        {
+            fLookup.SetValue(null, savedLookup);
+            fSummary.SetValue(null, savedSummary);
+        }
+    }
+
+    private static FieldInfo Static(string name)
+        => typeof(RecordPatches).GetField(name, Priv)
+           ?? throw new InvalidOperationException($"test setup: RecordPatches.{name} not found");
+
+    private static object? Invoke(string name, params object?[] args)
+    {
+        var m = typeof(RecordPatches).GetMethod(name, Priv)
+            ?? throw new InvalidOperationException($"test setup: RecordPatches.{name} not found");
+        try
+        {
+            return m.Invoke(null, args);
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            throw tie.InnerException;   // the reflection wrapper is not part of the contract
+        }
+    }
+
+    /// <summary>Stands in for the lookup dictionary after Microsoft ships a second Add.</summary>
+    public sealed class OverloadedAddDictionary<TKey, TValue> where TKey : notnull
+    {
+        public void Add(TKey key, TValue value) { }
+        public void Add(TKey key, TValue value, bool overwrite) { }
+    }
+
+    /// <summary>The shape BC declares today: exactly one Add.</summary>
+    public sealed class PlainAddDictionary<TKey, TValue> where TKey : notnull
+    {
+        public void Add(TKey key, TValue value) { }
+        internal void Hidden() { }
+    }
+
+    private sealed class FakeSummary
+    {
+        public string ObjectName => "SUPER";
+    }
+
+    private sealed class FakeLazy<T>
+    {
+        public T? Value { get; set; }
+    }
+
+    private sealed class FakeAppGroup
+    {
+        public FakeLazy<OverloadedAddDictionary<string, object>>? OverloadedLookup;
+        public FakeLazy<PlainAddDictionary<string, object>>? PlainLookup;
+    }
+}

--- a/AlRunner.Tests/PermissionMetadataMethodOverloadGuardTests.cs
+++ b/AlRunner.Tests/PermissionMetadataMethodOverloadGuardTests.cs
@@ -283,7 +283,14 @@ public sealed class PermissionMetadataMethodOverloadGuardTests
     // `(int)compare.Invoke(...)` is a BC-shape assumption. A Compare that stopped returning int
     // raises InvalidCastException inside the seam, so the asserterror passes on a sort real BC
     // performs fine. Driven through InstallPermissionSetSlot — the real call path — with the
-    // four reflection statics it reads injected for one call.
+    // five reflection statics it reads injected for one call.
+    //
+    // Measured on the pre-fix build, the absorbed exception is not the InvalidCastException
+    // itself: List.Sort catches whatever the comparison delegate throws and rethrows it as
+    // System.InvalidOperationException ("Failed to compare two elements in the array") with the
+    // cast failure as InnerException. So the seam absorbs a type whose name says nothing about
+    // reflection at all — more anonymous than the raw cast failure, not less, and one more
+    // reason type-based classification at the seam could not have caught this.
 
     [Fact]
     public void InstallPermissionSetSlot_RaisesAShapeGap_WhenCompareNoLongerReturnsInt()

--- a/AlRunner.Tests/PermissionMetadataNullForgivingGuardTests.cs
+++ b/AlRunner.Tests/PermissionMetadataNullForgivingGuardTests.cs
@@ -54,6 +54,7 @@ using Xunit;
 
 namespace AlRunner.Tests;
 
+[Collection(PermissionMetadataStaticsSerialCollection.Name)]
 public sealed class PermissionMetadataNullForgivingGuardTests
 {
     private static readonly string RepoRoot = Path.GetFullPath(
@@ -106,7 +107,7 @@ public sealed class PermissionMetadataNullForgivingGuardTests
     public void RequireBcMethod_RaisesAShapeGapNamingTheMember_WhenTheMethodHasMoved()
     {
         var ex = Assert.Throws<BcShapeGapException>(
-            () => Invoke("RequireBcMethod", typeof(NoAddCollection), "Add"));
+            () => Invoke("RequireBcMethod", typeof(NoAddCollection), "Add", null, null));
 
         Assert.Equal($"{nameof(NoAddCollection)}.Add", ex.Member);
         Assert.Contains("method not found", ex.Detail, StringComparison.Ordinal);
@@ -115,7 +116,7 @@ public sealed class PermissionMetadataNullForgivingGuardTests
     [Fact]
     public void RequireBcMethod_StillReturnsTheMethod_WhenPresent()
     {
-        var m = (MethodInfo)Invoke("RequireBcMethod", typeof(Dictionary<string, object>), "Add")!;
+        var m = (MethodInfo)Invoke("RequireBcMethod", typeof(Dictionary<string, object>), "Add", null, null)!;
 
         Assert.Equal("Add", m.Name);
         Assert.Equal(2, m.GetParameters().Length);
@@ -172,7 +173,7 @@ public sealed class PermissionMetadataNullForgivingGuardTests
         "IncludedPermissionSets" => ((PropertyInfo)Invoke("RequireBcProperty", typeof(FakeMetaPermissionSetWithoutIncludes), "IncludedPermissionSets")!).PropertyType,
         "ExcludedPermissionSets" => ((PropertyInfo)Invoke("RequireBcProperty", typeof(FakeMetaPermissionSetWithoutIncludes), "ExcludedPermissionSets")!).PropertyType,
         "ObjectName"             => ((PropertyInfo)Invoke("RequireBcProperty", typeof(NoAddCollection), "ObjectName")!).Name,
-        "Add"                    => ((MethodInfo)Invoke("RequireBcMethod", typeof(NoAddCollection), "Add")!).Name,
+        "Add"                    => ((MethodInfo)Invoke("RequireBcMethod", typeof(NoAddCollection), "Add", null, null)!).Name,
         "permissionSetLookup"    => Invoke("RequireBcLookupDictionaryType", typeof(string)),
         _ => throw new InvalidOperationException($"test setup: unknown case {@case}"),
     };

--- a/AlRunner.Tests/PermissionMetadataStaticsSerialCollection.cs
+++ b/AlRunner.Tests/PermissionMetadataStaticsSerialCollection.cs
@@ -1,0 +1,24 @@
+// PermissionMetadataStaticsSerialCollection — serialises the classes that inject into
+// RecordPatches' permission-metadata reflection statics (#3062).
+//
+// WithInjectedStatics overwrites RecordPatches._fPermissionSetLookup and _tSummary for the
+// duration of one call and restores them in a finally. That is safe for ONE class at a time and
+// only for one: xunit gives each test class its own collection by default and runs collections
+// in parallel (xunit.runner.json sets maxParallelThreads 4), so a second class doing the same
+// injection races the first and each sees the other's fake. Measured when
+// PermissionMetadataMethodOverloadGuardTests joined
+// PermissionMetadataNullForgivingGuardTests — the older class's ObjectName arm started
+// reporting "LazyEx<T>(Func<T>)", the refusal belonging to the NEWER class's fake.
+//
+// Same stopgap shape as RecordPatchesSerialCollection, and the same caveat: it only works for
+// classes that remember to join. Any future class calling WithInjectedStatics must carry
+// [Collection(PermissionMetadataStaticsSerialCollection.Name)].
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class PermissionMetadataStaticsSerialCollection
+{
+    public const string Name = "permission-metadata-statics-serial";
+}

--- a/AlRunner/Patches/RecordPatches.AggregatePermissionSetVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AggregatePermissionSetVirtualTable.cs
@@ -397,17 +397,17 @@ public static partial class RecordPatches
                 "PermissionSetRecord.permissionSetKey",
                 "field not found — the Aggregate Permission Set table cannot be populated");
 
-        _apsKeyAppIdProp = tPermissionSetKey.GetProperty("AppId",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+        _apsKeyAppIdProp = FindBcProperty(tPermissionSetKey, "AppId", out var nAppId)
             ?? throw AggregatePermissionSetBcShapeGap(
                 "PermissionSetKey.AppId",
-                "property not found — the Aggregate Permission Set table cannot be populated");
+                BcPropertyGapDetail("AppId", nAppId)
+                + " — the Aggregate Permission Set table cannot be populated");
 
-        _apsSessionNclMetadata = tNavSession.GetProperty("NCLMetadata",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+        _apsSessionNclMetadata = FindBcProperty(tNavSession, "NCLMetadata", out var nNclMetadata)
             ?? throw AggregatePermissionSetBcShapeGap(
                 "NavSession.NCLMetadata",
-                "property not found — the Aggregate Permission Set table cannot be populated");
+                BcPropertyGapDetail("NCLMetadata", nNclMetadata)
+                + " — the Aggregate Permission Set table cannot be populated");
 
         _apsReflectionReady = true;
     }
@@ -424,11 +424,11 @@ public static partial class RecordPatches
             ?? throw AggregatePermissionSetBcShapeGap(
                 "DataAccess",
                 "type not found in Ncl — the Aggregate Permission Set table cannot be populated");
-        _apsDataAccessSession = tDataAccess.GetProperty("Session",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+        _apsDataAccessSession = FindBcProperty(tDataAccess, "Session", out var nSession)
             ?? throw AggregatePermissionSetBcShapeGap(
                 "DataAccess.Session",
-                "property not found — the Aggregate Permission Set table cannot be populated");
+                BcPropertyGapDetail("Session", nSession)
+                + " — the Aggregate Permission Set table cannot be populated");
         _apsLiveGuardReady = true;
     }
 

--- a/AlRunner/Patches/RecordPatches.MetadataPermissionSetVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.MetadataPermissionSetVirtualTable.cs
@@ -327,11 +327,11 @@ public static partial class RecordPatches
     private static string RoleIdText(BcAppSymbolCache.PermissionSetSymbol permissionSet)
     {
         var code = RoleIdNavCode(permissionSet, MetadataPermissionSetRoleIdLength);
-        _mpsNavStringValueValue ??= code.GetType().GetProperty("Value",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+        _mpsNavStringValueValue ??= FindBcProperty(code.GetType(), "Value", out var nValue)
             ?? throw MetadataPermissionSetBcShapeGap(
                 $"{code.GetType().Name}.Value",
-                "property not found, so the Name fallback cannot read the Role ID back off BC's own NavCode — the Metadata Permission Set table cannot be populated");
+                BcPropertyGapDetail("Value", nValue)
+                + ", so the Name fallback cannot read the Role ID back off BC's own NavCode — the Metadata Permission Set table cannot be populated");
         return _mpsNavStringValueValue.GetValue(code) as string ?? string.Empty;
     }
 

--- a/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
@@ -189,17 +189,24 @@ public static partial class RecordPatches
                 $"has {arr.Length} slots, so ObjectType.PermissionSet ({PermissionSetObjectTypeOrdinal}) is out of range — BC's permission-set metadata inventory cannot be populated");
 
         var comparer = _fComparerInstance!.GetValue(null)
-            ?? Activator.CreateInstance(_tGroupSummaryComparer!)!;
+            ?? RequireBcInstance(_tGroupSummaryComparer!, "NavAppGroup.GroupSummaryComparer");
 
         // GroupSummaryComparer implements IComparer<NavAppGroupObjectMetadataSummary> and NOT
         // the non-generic IComparer, so Array.Sort's non-generic overload cannot take it —
         // measured, it throws InvalidCastException. Drive its Compare(x, y) directly instead,
         // which is the same ordering BC's own constructor applies before freezing the array.
-        var compare = _tGroupSummaryComparer!.GetMethod("Compare",
-            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-            ?? throw PermissionMetadataBcShapeGap(
+        var compare = RequireBcMethod(_tGroupSummaryComparer!, "Compare",
+            new[] { _tSummary!, _tSummary! }, "NavAppGroup.GroupSummaryComparer.Compare");
+        // The (int) cast below is a BC-shape assumption, not an AL one: a Compare that stopped
+        // returning int would raise InvalidCastException (or, if it went void, a
+        // NullReferenceException on the unboxed null) INSIDE the seam that absorbs everything
+        // but a BcShapeGapException, so `asserterror` would pass on a sort real BC performs
+        // fine (#3062). Refuse by name here instead, before the cast can be reached.
+        if (compare.ReturnType != typeof(int))
+            throw PermissionMetadataBcShapeGap(
                 "NavAppGroup.GroupSummaryComparer.Compare",
-                "method not found — BC's permission-set metadata inventory cannot be populated");
+                $"returns {compare.ReturnType.Name}, not the Int32 this sort unboxes"
+                + " — BC's permission-set metadata inventory cannot be populated");
         summaries.Sort((x, y) => (int)compare.Invoke(comparer, new[] { x, y })!);
 
         var typed = Array.CreateInstance(_tSummary!, summaries.Count);
@@ -225,8 +232,8 @@ public static partial class RecordPatches
         var lazyField = _fPermissionSetLookup!;
         var lazyType = lazyField.FieldType;                       // LazyEx<Dictionary<NavCode, Summary>>
         var dictType = RequireBcLookupDictionaryType(lazyType);
-        var dict = Activator.CreateInstance(dictType)!;
-        var add = RequireBcMethod(dictType, "Add");
+        var dict = RequireBcInstance(dictType, "NavAppGroup.permissionSetLookup");
+        var add = RequireBcMethod(dictType, "Add", RequireBcLookupKeyValueTypes(dictType));
         var nameProp = RequireBcProperty(_tSummary!, "ObjectName");
 
         foreach (var s in summaries)
@@ -437,11 +444,12 @@ public static partial class RecordPatches
             ?? throw PermissionMetadataBcShapeGap(
                 "NCLMetaPermissionSet",
                 "type not found in Ncl — BC's permission-set metadata inventory cannot be populated");
-        _mCreateEmptyMetaPermissionSet ??= metaType.GetMethod("CreateEmptyNCLMetaPermissionSet",
-            BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
-            ?? throw PermissionMetadataBcShapeGap(
-                "NCLMetaPermissionSet.CreateEmptyNCLMetaPermissionSet",
-                "static method not found — BC's permission-set metadata inventory cannot be populated");
+        // No signature pinned: two of the five parameter types (INCLMetaApplicationObjectLoader,
+        // NavAppGroup) would have to be resolved by name just to state it, and a wrong statement
+        // would refuse a build that works. Unique by name is the weaker guarantee, and it is
+        // still enough to keep an added overload from arriving as an AmbiguousMatchException the
+        // asserterror seam swallows.
+        _mCreateEmptyMetaPermissionSet ??= RequireBcMethod(metaType, "CreateEmptyNCLMetaPermissionSet");
 
         var baseGroup = _fBaseGroupPM!.GetValue(null);
         var meta = _mCreateEmptyMetaPermissionSet.Invoke(null,
@@ -452,12 +460,11 @@ public static partial class RecordPatches
         // excludes, and Permissions as PermissionDefinition objects. Poking the backing fields
         // by hand (what this did before) could only ever fill the ones somebody remembered;
         // this way every field BC sets is set, by BC.
-        var assign = metaType.GetMethod("AssignFromMetaPermissionSet",
-            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
-            ?? throw PermissionMetadataBcShapeGap(
-                "NCLMetaPermissionSet.AssignFromMetaPermissionSet",
-                "method not found — BC's permission-set metadata inventory cannot be populated");
-        assign.Invoke(meta, new[] { BuildMetaPermissionSet(declaration) });
+        // Build the MetaPermissionSet FIRST so its own runtime type pins the signature looked
+        // up: the argument this call passes and the overload it resolves then cannot disagree.
+        var mps = BuildMetaPermissionSet(declaration);
+        var assign = RequireBcMethod(metaType, "AssignFromMetaPermissionSet", new[] { mps.GetType() });
+        assign.Invoke(meta, new[] { mps });
 
         EnsureCachePopulatorReflection();
         if (_fNCLMetaAppObjMetadataLoaded != null)
@@ -597,7 +604,7 @@ public static partial class RecordPatches
                 "MetaPermissionSet.Access",
                 "property not found — BC's permission-set metadata inventory cannot be populated");
 
-        var mps = Activator.CreateInstance(_tMetaPermissionSet)!;
+        var mps = RequireBcInstance(_tMetaPermissionSet, "MetaPermissionSet");
         SetProperty(mps, "Id", declaration.Id);
         SetProperty(mps, "Name", declaration.Name);
         SetProperty(mps, "Assignable", declaration.Assignable);
@@ -615,7 +622,7 @@ public static partial class RecordPatches
         {
             // MetaPermission is a STRUCT: box it once, set the three properties on the box,
             // then add — adding first would copy an empty value into the list.
-            var mp = Activator.CreateInstance(_tMetaPermission)!;
+            var mp = RequireBcInstance(_tMetaPermission!, "MetaPermission");
             SetProperty(mp, "Id", p.ObjectId);
             SetProperty(mp, "Value", p.Value);
             var objectTypeProp = _tMetaPermission.GetProperty("Type",
@@ -717,12 +724,102 @@ public static partial class RecordPatches
                $"{declaring.Name}.{propertyName}",
                "property not found — BC's permission-set metadata inventory cannot be populated");
 
-    /// <summary>A method of a BC-shape-derived type this file invokes by name.</summary>
-    private static MethodInfo RequireBcMethod(Type declaring, string methodName)
-        => declaring.GetMethod(methodName)
-           ?? throw PermissionMetadataBcShapeGap(
-               $"{declaring.Name}.{methodName}",
-               "method not found — BC's permission-set metadata inventory cannot be populated");
+    /// <summary>
+    /// A method of a BC-shape-derived type this file invokes by name (#3062).
+    ///
+    /// Resolved by ENUMERATING candidates rather than by <c>Type.GetMethod(string)</c>, because
+    /// that overload throws <see cref="System.Reflection.AmbiguousMatchException"/> the moment
+    /// Microsoft ships a second method of the same name — which is exactly the BC-layout change
+    /// this helper exists to name, and which <c>NavMethodScope_AssertError</c> would swallow, so
+    /// `asserterror` would PASS on a read real BC performs fine. Enumerating cannot throw, so
+    /// every outcome here is either the method or a BcShapeGapException naming the member.
+    ///
+    /// <paramref name="parameterTypes"/> pins the signature the call site's <c>Invoke</c>
+    /// argument array is built for. Pass it wherever the types are derivable from something
+    /// already in hand and so cannot be stated wrongly (the lookup dictionary's own generic
+    /// arguments, the summary type, the instance being passed); an added overload is then
+    /// resolved rather than merely reported. Where it is null the method must be unique by
+    /// name, and a second one is refused BY NAME instead of arriving as an anonymous
+    /// AmbiguousMatchException.
+    ///
+    /// Two candidates left after filtering are refused rather than guessed: with distinct
+    /// signatures that is a real overload the call site cannot choose between, and with
+    /// identical ones it is a `new`-hidden member, where picking silently could drive the wrong
+    /// declaration. Measured on Ncl 27.3, 27.5, 28.1 (two builds) and 28.2, all four call sites
+    /// in this file resolve to exactly one candidate today, so neither refusal fires on a BC
+    /// build the runner has seen.
+    /// </summary>
+    private static MethodInfo RequireBcMethod(
+        Type declaring, string methodName, Type[]? parameterTypes = null, string? memberName = null)
+    {
+        var member = memberName ?? $"{declaring.Name}.{methodName}";
+        var signature = parameterTypes == null
+            ? string.Empty
+            : $"({string.Join(", ", parameterTypes.Select(t => t.Name))})";
+
+        var candidates = declaring.GetMethods(
+                BindingFlags.Instance | BindingFlags.Static
+                | BindingFlags.Public | BindingFlags.NonPublic)
+            .Where(m => m.Name == methodName)
+            .Where(m => parameterTypes == null
+                        || m.GetParameters().Select(pp => pp.ParameterType).SequenceEqual(parameterTypes))
+            .ToArray();
+
+        if (candidates.Length == 0)
+            throw PermissionMetadataBcShapeGap(
+                member,
+                $"method not found{(signature.Length == 0 ? string.Empty : " with signature " + signature)}"
+                + " — BC's permission-set metadata inventory cannot be populated");
+
+        if (candidates.Length > 1)
+            throw PermissionMetadataBcShapeGap(
+                member,
+                $"BC declares {candidates.Length} methods named {methodName}"
+                + $"{(signature.Length == 0 ? string.Empty : " with signature " + signature)}"
+                + ", so the runner cannot tell which one its call site means"
+                + " — BC's permission-set metadata inventory cannot be populated");
+
+        return candidates[0];
+    }
+
+    /// <summary>
+    /// A BC type this file instantiates. <c>Activator.CreateInstance(Type)</c> raises
+    /// MissingMethodException when the parameterless constructor is gone — anonymous, and
+    /// absorbed by the asserterror seam exactly like the AmbiguousMatchException above (#3062).
+    /// Resolve the constructor first so the refusal names the type instead.
+    /// </summary>
+    private static object RequireBcInstance(Type type, string member)
+    {
+        // A struct has no declared parameterless constructor and never needs one — measured:
+        // BC declares MetaPermission as a value type, and asking for one refuses a shape that
+        // works. Only a reference type can lose the constructor Activator.CreateInstance wants.
+        if (type.IsValueType) return Activator.CreateInstance(type)!;
+
+        var ctor = type.GetConstructor(
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null, types: Type.EmptyTypes, modifiers: null)
+            ?? throw PermissionMetadataBcShapeGap(
+                member,
+                $"{type.Name} has no parameterless constructor"
+                + " — BC's permission-set metadata inventory cannot be populated");
+        return ctor.Invoke(null);
+    }
+
+    /// <summary>
+    /// The key and value types of <c>NavAppGroup.permissionSetLookup</c>'s dictionary, which are
+    /// the signature of the <c>Add</c> this file drives. Derived from the dictionary type itself
+    /// rather than stated, so the signature cannot disagree with the instance it is invoked on.
+    /// </summary>
+    private static Type[] RequireBcLookupKeyValueTypes(Type dictType)
+    {
+        var args = dictType.GetGenericArguments();
+        if (args.Length != 2)
+            throw PermissionMetadataBcShapeGap(
+                "NavAppGroup.permissionSetLookup",
+                $"holds a {dictType.Name}, not the two-argument Dictionary<TKey, TValue> whose Add this"
+                + " code drives — BC's permission-set metadata inventory cannot be populated");
+        return args;
+    }
 
     /// <summary>
     /// The dictionary type inside <c>NavAppGroup.permissionSetLookup</c>, which BC declares as

--- a/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
@@ -485,11 +485,7 @@ public static partial class RecordPatches
 
     private static void SetEmptyListBackingField(Type declaring, object target, string propertyName)
     {
-        var prop = declaring.GetProperty(propertyName,
-            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-            ?? throw PermissionMetadataBcShapeGap(
-                $"NCLMetaPermissionSet.{propertyName}",
-                "property not found — BC's permission-set metadata inventory cannot be populated");
+        var prop = RequireBcProperty(declaring, propertyName);
         var element = prop.PropertyType.IsGenericType
             ? prop.PropertyType.GetGenericArguments()[0]
             : typeof(object);
@@ -598,11 +594,7 @@ public static partial class RecordPatches
         // that property rather than from a namespace guess: it does not live where the
         // sibling metadata types do, and hardcoding a namespace turned into a run-aborting
         // "Types shape changed" on the first real run.
-        _tAccessModifier ??= _tMetaPermissionSet.GetProperty("Access",
-            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)?.PropertyType
-            ?? throw PermissionMetadataBcShapeGap(
-                "MetaPermissionSet.Access",
-                "property not found — BC's permission-set metadata inventory cannot be populated");
+        _tAccessModifier ??= RequireBcProperty(_tMetaPermissionSet, "Access").PropertyType;
 
         var mps = RequireBcInstance(_tMetaPermissionSet, "MetaPermissionSet");
         SetProperty(mps, "Id", declaration.Id);
@@ -625,11 +617,7 @@ public static partial class RecordPatches
             var mp = RequireBcInstance(_tMetaPermission!, "MetaPermission");
             SetProperty(mp, "Id", p.ObjectId);
             SetProperty(mp, "Value", p.Value);
-            var objectTypeProp = _tMetaPermission.GetProperty("Type",
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-                ?? throw PermissionMetadataBcShapeGap(
-                    "MetaPermission.Type",
-                    "property not found — BC's permission-set metadata inventory cannot be populated");
+            var objectTypeProp = RequireBcProperty(_tMetaPermission!, "Type");
             objectTypeProp.SetValue(mp, Enum.ToObject(objectTypeProp.PropertyType, p.ObjectType));
             permissions.Add(mp);
         }
@@ -713,16 +701,58 @@ public static partial class RecordPatches
     // side, exactly like the 56.
 
     /// <summary>
-    /// A property of a BC type this file reads by name. Looks with NonPublic as well as Public
-    /// deliberately: <see cref="SetProperty"/> WRITES these same members with those flags, and
-    /// a read narrower than the write would miss a member the write then finds.
+    /// The single property named <paramref name="propertyName"/> on <paramref name="declaring"/>,
+    /// or null when there is not exactly one — with <paramref name="candidateCount"/> saying which
+    /// of the two ways that happened, so each surface can raise its OWN refusal (#3062).
+    ///
+    /// Enumerating rather than calling <c>Type.GetProperty(name, flags)</c> is the point.
+    /// Measured on .NET 8.0.30, that overload raises
+    /// <see cref="System.Reflection.AmbiguousMatchException"/> in two shapes, and
+    /// <c>NavMethodScope_AssertError</c> absorbs it, so an AL `asserterror` PASSES on a read real
+    /// BC performs fine:
+    ///
+    ///   * a `new`-hidden property whose TYPE changed (int P -> string P): GetProperties returns
+    ///     both, GetProperty throws. A `new`-hidden property of the SAME type does NOT throw —
+    ///     hiding-by-name-and-signature filters the base one — so the trigger is narrower than
+    ///     "a hidden property";
+    ///   * two same-name properties in one type, which is what an added indexer overload is.
+    ///
+    /// <c>Type.GetField</c> has neither shape and returns the most-derived, which is why the
+    /// field lookups in this slice are left alone.
+    ///
+    /// The flags are exactly the ones all nine call sites in the slice already used —
+    /// Instance | Public | NonPublic, no Static — so nothing but the ambiguity outcome changes.
+    /// NonPublic is deliberate: <see cref="SetProperty"/> WRITES these same members with those
+    /// flags, and a read narrower than the write would miss a member the write then finds.
     /// </summary>
+    private static PropertyInfo? FindBcProperty(Type declaring, string propertyName, out int candidateCount)
+    {
+        var candidates = declaring.GetProperties(
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+            .Where(pr => pr.Name == propertyName)
+            .ToArray();
+        candidateCount = candidates.Length;
+        return candidates.Length == 1 ? candidates[0] : null;
+    }
+
+    /// <summary>
+    /// The leading half of a property refusal's detail — "property not found", or the named
+    /// ambiguity. Each surface appends its own "… cannot be populated" tail, so the three
+    /// surfaces keep their own messages while sharing the classification.
+    /// </summary>
+    private static string BcPropertyGapDetail(string propertyName, int candidateCount)
+        => candidateCount == 0
+            ? "property not found"
+            : $"BC declares {candidateCount} properties named {propertyName}, so the runner cannot"
+              + " tell which one it means";
+
+    /// <summary>A property of a BC type this file reads by name.</summary>
     private static PropertyInfo RequireBcProperty(Type declaring, string propertyName)
-        => declaring.GetProperty(propertyName,
-            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+        => FindBcProperty(declaring, propertyName, out var candidateCount)
            ?? throw PermissionMetadataBcShapeGap(
                $"{declaring.Name}.{propertyName}",
-               "property not found — BC's permission-set metadata inventory cannot be populated");
+               BcPropertyGapDetail(propertyName, candidateCount)
+               + " — BC's permission-set metadata inventory cannot be populated");
 
     /// <summary>
     /// A method of a BC-shape-derived type this file invokes by name (#3062).
@@ -840,11 +870,7 @@ public static partial class RecordPatches
 
     private static void SetProperty(object target, string name, object? value)
     {
-        var prop = target.GetType().GetProperty(name,
-            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
-            ?? throw PermissionMetadataBcShapeGap(
-                $"{target.GetType().Name}.{name}",
-                "property not found — BC's permission-set metadata inventory cannot be populated");
+        var prop = RequireBcProperty(target.GetType(), name);
         prop.SetValue(target, value);
     }
 }


### PR DESCRIPTION
Closes #3062

`NavMethodScope_AssertError` rethrows only `BcShapeGapException` and absorbs everything else,
so a **throw of the wrong type** from a BC-internals read inverts an AL result exactly as
#3053's silent null did: `asserterror` passes while real BC performs the read fine. No `!`
appears in it, so #3051's sweep cannot find these.

## The three sites, and what each now does

| site | was | now |
|---|---|---|
| `RequireBcMethod` — `GetMethod(name)` | `AmbiguousMatchException` when Microsoft ships an overload | enumerates candidates (cannot throw) and matches the signature the call site's `Invoke` array is built for |
| `Activator.CreateInstance(dictType)` and three siblings | `MissingMethodException` | `RequireBcInstance` resolves the constructor first and refuses by name |
| `(int)compare.Invoke(…)` | `InvalidCastException`, rewrapped by `List.Sort` as `InvalidOperationException` | `Compare.ReturnType` is checked before the cast can unbox |
| **nine `GetProperty(name, flags)` sites across the slice** (found in review) | `AmbiguousMatchException` on a `new`-hidden property whose TYPE changed, or on an added indexer | `FindBcProperty` enumerates; each surface keeps its own refusal message |

`RequireBcMethod` is the sharpest of the three because **#3053 added it**, inside the helper
written to fix the first kind of inversion.

Three of the file's four method lookups can state their signature from something already in
hand — the lookup dictionary's own generic arguments, the summary type, the instance being
passed — so an added overload is **resolved**. `CreateEmptyNCLMetaPermissionSet` would need two
more BC types resolved by name just to state its signature, and a wrong statement would refuse a
build that works, so it stays unique-by-name, where a second declaration is refused BY NAME
instead of arriving as an anonymous `AmbiguousMatchException`. That difference is written into
the code comment rather than left implicit.

`AssignFromMetaPermissionSet` reorders one line: the `MetaPermissionSet` is built **before** the
lookup so its own runtime type pins the signature, and the argument passed cannot disagree with
the overload resolved.

## RED to GREEN: the inversion, not the exception

Measured by reverting only `RecordPatches.PermissionMetadataPopulator.cs` to `HEAD~1` and
running the new test file unchanged (it drives production through reflection, so it compiles
against both trees):

```
AssertError_TearsThrough_InsteadOfSwallowingTheAmbiguousMatch           No exception was thrown
AssertError_TearsThrough_WhenTheLookupDictionaryLostItsConstructor      No exception was thrown
AssertError_TearsThrough_InsteadOfSwallowingTheCompareReturnTypeChange  No exception was thrown
AssertError_TearsThrough_InsteadOfSwallowingTheAmbiguousProperty        No exception was thrown
```

Four routes, four independent `Assert.Throws() Failure: No exception was thrown` — one per row of
the table above. That message **is** the defect: the seam swallowed the failure and the
`asserterror` passed on a population that silently did not happen.

**Every route is driven through the real call path**, not only the helper:
`InstallFreshPermissionSetLookup` over a dictionary type with two `Add` declarations, and again
over one whose parameterless constructor is gone; `InstallPermissionSetSlot` with a comparer whose
`Compare` returns `string`. The `Compare` arms pass **two** summaries deliberately — `List.Sort`
does not call the comparison delegate for a shorter list, so a one-element list never reaches the
cast the arms are about.

One correction the RED forced: on the `Compare` route the absorbed exception is **not** the
`InvalidCastException` the source suggests. `List.Sort` catches whatever the delegate throws and
rethrows it as `System.InvalidOperationException` ("Failed to compare two elements in the array")
with the cast failure as `InnerException` — more anonymous than the raw failure, not less, and one
more reason type-matching at the seam could not have caught this. Recorded in the test's comment.

The same pre-fix run also recorded, for the sibling arms:

```
TryFunction_StillCannotTrapTheRefusal_OnTheCorrectedPath
    Actual: typeof(System.Reflection.AmbiguousMatchException)
NoMethodLookupInTheSlice_ResolvesByNameWithoutASignature
    4 offenders, all in RecordPatches.PermissionMetadataPopulator.cs
```

The `TryFunction` line is why that arm is labelled a CONTROL and not a second RED:
`NavApplicationObjectBase_TryInvoke` rethrows anything that is not a trappable `NavBaseException`
or a permanent out-of-scope refusal, so the `AmbiguousMatchException` already reached AL as a
failure there. **Only `asserterror` inverts.**

GREEN: the same arms pass, and the direct arms prove the selection *discriminates* — asked for
`(TKey, TValue)` it returns the two-parameter `Add`, asked for `(TKey, TValue, bool)` it returns
the three-parameter one, so nothing here is satisfied by a helper that always hands back the
first candidate.

## The seam itself: measured, and deliberately not widened

The issue's other option was to widen what `AssertError` rethrows. I instrumented the seam to
record every exception type it absorbs — 2,610 corpus tests + 298 `runner-extras`, BC
28.1.49838.53910 — before deciding. 297 exceptions absorbed; **zero** reflection-failure types
of any kind. Type alone cannot decide (`DivideByZeroException` and `OverflowException` reach the
seam from AL code and must stay catchable; `InvalidCastException` means opposite things
depending on who raised it), and origin alone cannot either
(`AllProfileWritePatches.GuardAllProfileDelete` raises `InvalidOperationException` from inside a
runner patch, deliberately trappable). The five sanctioned `InvalidOperationException` survivors
in this file are sanctioned **per site**, and `BcShapeGapException` was introduced as "a NEW
contract for a NEW type, not a change to an existing one" (#2995), with #2871 left as the
separate live question.

So the seam is untouched. Full measurement and reasoning:
https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3062#issuecomment-5558449431

One distinction the review drew, and it is right: **the zero is evidence that a NARROW widening
would be free, not that it is unnecessary.** `AmbiguousMatchException` and `MissingMethodException`
are types no AL program can produce, so the corpus counter-evidence does not touch them. That is an
open question rather than something the measurement settled, and it is recorded on #3069 —
together with the caveat that any such rule would have to walk `InnerException`, since `List.Sort`
already rewraps one of these routes.

The instrumentation was temporary and is not in this diff. The **method** — the patch, the two
commands, and what the `origin` column means — is recorded on #3069, so the number can be
reproduced rather than trusted.

## What the review round changed

**`RequireBcInstance` and the `Compare` guard shipped untested** — the only members of that family
without both directions. Both now have them. The `IsValueType` carve-out in `RequireBcInstance` is
pinned separately because it is load-bearing: BC declares `MetaPermission` as a **struct with
`ctors = 0`** on all five shipped builds measured (27.3.44313.53909, 27.5.46862.48827,
28.1.49838.53910, 28.1.49838.54308, 28.2.50931.54319), so without that branch the inventory would
refuse to populate on every one of them. `RequireBcInstance` also accepts a **non-public**
constructor, which `Activator.CreateInstance(Type)` refuses — deliberately wider than what it
replaced, since BC's own types are frequently internal, and asserted against `Activator` in the
same arm so the difference is pinned rather than assumed.

**`GetProperty` carries the identical route, and the guard did not cover it.** Measured on .NET
8.0.30, `BindingFlags.Instance | Public | NonPublic`:

| shape | `GetMethod` | `GetProperty` | `GetField` |
|---|---|---|---|
| second declaration in the SAME type | throws | throws (an added indexer) | n/a |
| `new`-hidden, signature/type CHANGED | throws | throws | OK, most-derived |
| `new`-hidden, SAME type | n/a | OK, hiding filter drops the base one | OK |

So the property trigger is **narrower** than "a `new`-hidden property" — it needs a type change —
and `GetField` is genuinely unaffected, which is why field lookups are left alone rather than
swept along. All nine `GetProperty` sites in the slice (four in the populator, three in
`AggregatePermissionSetVirtualTable`, one in `MetadataPermissionSetVirtualTable`, plus the shared
helper) now go through `FindBcProperty`, which enumerates and cannot throw. The guard — renamed
`NoMemberLookupInTheSlice_ResolvesByNameWithoutASignature` — covers both member kinds and records
which ones carry the route and which do not, so it now means what its name suggests.

Two incidental findings, neither acted on beyond a note: `SetEmptyListBackingField` has **no
callers**, and its hardcoded `NCLMetaPermissionSet.` member name disagreed with the `declaring`
parameter it takes (now derived from it). And #3069 carries the `GetProperty` finding, the
`GetField` exclusion, and the warning that a reused guard must be widened along with the file.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — three more `GetMethod` calls in the same
   file resolved by name alone, and three more `Activator.CreateInstance` calls on BC types.
   All converted. A source-shape guard now fails the build if a name-only method lookup returns
   to any of the three slice files.
2. **Sibling functions making the same assumption?** Checked, and the answer is no — the two
   sibling files in the same slice (`AggregatePermissionSetVirtualTable`,
   `MetadataPermissionSetVirtualTable`) already pass `types:` on every lookup
   (`NavGuid.Create(Guid)`, `GetSystemPermissionSets(NavValue, NavCode)`, …). The populator's
   helper was the outlier.
3. **Two paths writing the same state with different invariants?** Yes, and it bit during this
   work. `WithInjectedStatics` overwrites `RecordPatches._fPermissionSetLookup` / `_tSummary`
   and restores them in a `finally` — safe for one test class, and xunit runs classes in
   parallel. Adding a second class made the older class's `ObjectName` arm report
   `LazyEx<T>(Func<T>)`, the refusal belonging to the newer class's fake.
   `PermissionMetadataStaticsSerialCollection` serialises both, same stopgap shape as
   `RecordPatchesSerialCollection`.

Left out deliberately: the **212 name-only method lookups outside this slice** — filed as
**#3069** with the counts and a suggested per-file split, rather than swept here.

## Local verification

* `dotnet test AlRunner.Tests --filter "…PermissionMetadata|…BcShapeGap|…VirtualTableRefusalClaim|…AssertErrorOutOfScope|…AggregatePermissionSet|…MetadataPermissionSet"` — **192 passed, 0 failed** (179 before the review round).
* Full corpus, matching CI's invocation (`--package-cache ~/.al-runner/platform-apps --strict --count-baseline …`): **2,610 / 2,610 pass**, 0 fail, 0 error — re-run after the review round, not carried over.
* `tests/runner-extras`: **298 / 298 pass**, likewise re-run. Both counts are unchanged from the
  pre-change run and the corpus one is enforced by `--count-baseline`, so nothing was silently
  skipped (#3078).
* `VirtualTableRefusalClaimTests`' `Assert.Equal(67, total)` is unchanged and passing — the new
  refusals are `PermissionMetadataBcShapeGap`, which that regex excludes by design via `(?<!Bc)`.
* No `tests/expectations/` drift in either direction; both suites are green with the manifest as
  it stands.

## Does this assert anything about what BC does?

No, and the reason is not "it's infrastructure". Every refusal added here is unreachable on any
BC build where the lookup succeeds — measured directly against Ncl 27.3, 27.5, 28.1 (two builds)
and 28.2, where all four method names have exactly one declaration and every constructor is
present. A corpus test would have to run on a BC build where Microsoft had shipped the overload
to observe anything, so a service tier has no answer to give: the AL-observable behaviour on
every tier the corpus runs is unchanged, which the 2,610/2,610 corpus run above is the evidence
for. That is a claim carried by direct measurement of five shipped Ncl builds, not by inference
from a sibling.

---
*Authored by an agent (`stma-auto-1`) acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
