### PR TITLE
fix(record): refuse a CalcFields field that is not a FlowField or a BLOB, the way BC does

### DIFF
--- a/AlRunner.Tests/CalcFieldsFieldClassRefusalTests.cs
+++ b/AlRunner.Tests/CalcFieldsFieldClassRefusalTests.cs
@@ -1,0 +1,238 @@
+// CalcFieldsFieldClassRefusalTests — AlRunner#3012.
+//
+// These are RUNNER-MECHANISM tests, not claims about what real BC does. The BC-observable
+// claim ("Record.CalcFields accepts a field only if it is a FlowField carrying a CalcFormula,
+// or a BLOB; everything else is refused before anything is calculated") is measured upstream
+// against a live BC service tier — record/TestCalcFieldsFieldClass.Codeunit.al in
+// StefanMaron/BusinessCentral.AL.Language.Tests, corpus PR #189.
+//
+// What THIS file pins is the wiring the fix rests on, which the corpus cannot see, and every
+// one of these can regress SILENTLY:
+//
+//   * The runner REPLACES RecordImplementation.CalcFieldsAsync(DataError, NCLMetaField[], bool)
+//     outright (FlowFieldPatches.RecordImpl_CalcFieldsAsync_3), so BC's own classification loop
+//     — the one that raises both refusals — never runs. It has to be re-issued by the
+//     replacement, and for four years it was not: every entry point dropped a non-FlowField on
+//     the floor with `if (!Equals(fieldClass, _fcFlowField)) continue;`, so
+//     `Rec.CalcFields("No.")` did nothing at all and reported success.
+//
+//   * The classification must run BEFORE the BLOB load and BEFORE the FlowField aggregation,
+//     exactly as BC runs its loop before either. A version that classified per field inside
+//     the work still throws — so a test asserting only "CalcFields errors" stays green — but
+//     leaves the acceptable part of the call applied, which real BC never does.
+//
+//   * The AL-visible messages must be BC's own resources. If Lang.MustBeAFlowField or
+//     Lang.MustDefineFormula stops resolving, BuildCalcFieldsRefusal silently falls back to a
+//     literal kept here, and the runner's wording drifts from the service tier's without any
+//     other test noticing.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using AlRunner.Patches;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class CalcFieldsFieldClassRefusalTests
+{
+    private readonly BcEngineFixture _engine;
+
+    public CalcFieldsFieldClassRefusalTests(BcEngineFixture engine) => _engine = engine;
+
+    /// <summary>The Cecil-rewritten Ncl this test host itself loaded.</summary>
+    private static string NclPath => Path.Combine(
+        Path.GetDirectoryName(typeof(CalcFieldsFieldClassRefusalTests).Assembly.Location)
+            ?? AppContext.BaseDirectory,
+        "Microsoft.Dynamics.Nav.Ncl.dll");
+
+    private static string? LangString(string name)
+    {
+        foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            var lang = asm.GetType("Microsoft.Dynamics.Nav.Common.Language.Lang", throwOnError: false);
+            var value = lang?.GetProperty(name, BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                            ?.GetValue(null) as string;
+            if (!string.IsNullOrEmpty(value)) return value;
+        }
+        return null;
+    }
+
+    private static AssemblyDefinition OpenOurAssembly() =>
+        AssemblyDefinition.ReadAssembly(typeof(FlowFieldPatches).Assembly.Location);
+
+    // Cecil reads method bodies LAZILY off the still-open file, so the AssemblyDefinition has
+    // to outlive every Instruction walk below — hence the explicit `asm` parameter rather than
+    // a self-contained lookup that disposes it on return.
+    private static MethodDefinition OurMethod(AssemblyDefinition asm, string name)
+    {
+        var patches = asm.MainModule.GetType("AlRunner.Patches.FlowFieldPatches");
+        Assert.NotNull(patches);
+
+        var m = patches!.Methods.SingleOrDefault(x => x.Name == name);
+        Assert.True(m != null, $"FlowFieldPatches.{name} not found — if it was renamed, re-anchor "
+                               + "this test on the new name rather than deleting it (#3012)");
+        Assert.True(m!.HasBody, $"FlowFieldPatches.{name} must have a readable body");
+        return m;
+    }
+
+    private static int IndexOfCallTo(MethodDefinition m, string calleeName) =>
+        m.Body.Instructions.ToList().FindIndex(i =>
+            (i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt)
+            && i.Operand is MethodReference mr && mr.Name == calleeName);
+
+    /// <summary>
+    /// Both refusal messages come from BC's own resource class, and both must still say what
+    /// the upstream corpus test asserts. A BC version that rewords either one breaks the
+    /// corpus assertion too — this test is what makes that visible here rather than only on
+    /// eight BC legs.
+    /// </summary>
+    [SkippableFact]
+    public void BothRefusalMessagesComeFromBcsOwnLangResource()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        Assert.Equal("The {0} field in the {1} table must be a FlowField.",
+            LangString("MustBeAFlowField"));
+        Assert.Equal("You must define a CalcFormula for the {0} FlowField in the {1} table.",
+            LangString("MustDefineFormula"));
+        Assert.Equal(
+            "The field {0} in the {1} table is not a FlowField or a BLOB field and cannot be "
+            + "passed in calls to CalcFields.",
+            LangString("OnlyFlowFieldsAllowedInCallsToCalcFields"));
+    }
+
+    /// <summary>
+    /// The ordering guarantee, read off our own IL: the RecordImplementation entry point must
+    /// classify the field list BEFORE it loads a BLOB and BEFORE it enters the FlowField core.
+    /// </summary>
+    [Fact]
+    public void RecordEntryPointClassifiesBeforeItLoadsOrCalculatesAnything()
+    {
+        using var asm = OpenOurAssembly();
+        var entry = OurMethod(asm, "RecordImpl_CalcFieldsAsync_3");
+
+        int classifyAt = IndexOfCallTo(entry, "ClassifyCalcFieldsRequest");
+        Assert.True(classifyAt >= 0,
+            "RecordImpl_CalcFieldsAsync_3 must call ClassifyCalcFieldsRequest — without it a "
+            + "field that is neither a FlowField nor a BLOB is silently ignored (#3012)");
+
+        int blobLoadAt = IndexOfCallTo(entry, "LoadBlobField");
+        Assert.True(blobLoadAt >= 0,
+            "expected RecordImpl_CalcFieldsAsync_3 to call LoadBlobField — if the BLOB load "
+            + "moved, re-anchor this ordering assertion rather than deleting it");
+
+        int calcAt = IndexOfCallTo(entry, "CalcFlowFieldValuesCore");
+        Assert.True(calcAt >= 0,
+            "expected RecordImpl_CalcFieldsAsync_3 to call CalcFlowFieldValuesCore");
+
+        Assert.True(classifyAt < blobLoadAt,
+            $"classification (instruction {classifyAt}) must precede the BLOB load "
+            + $"({blobLoadAt}): BC throws before it loads any BLOB content, so a refused "
+            + "CalcFields must leave the record's BLOB fields untouched");
+        Assert.True(classifyAt < calcAt,
+            $"classification (instruction {classifyAt}) must precede the FlowField core "
+            + $"({calcAt}): a refused CalcFields computes nothing at all in BC, not even the "
+            + "part of the field list that was acceptable");
+    }
+
+    /// <summary>
+    /// The classification must REFUSE, not skip. Both of BC's record-level refusals are built
+    /// through BuildCalcFieldsRefusal and thrown; a regression that turned either back into a
+    /// `continue` would restore the exact silent-success defect #3012 is about, and no other
+    /// runner-side test would fail.
+    /// </summary>
+    [Fact]
+    public void ClassificationThrowsBothOfBcsRecordLevelRefusals()
+    {
+        using var asm = OpenOurAssembly();
+        var classify = OurMethod(asm, "ClassifyCalcFieldsRequest");
+        var instructions = classify.Body.Instructions.ToList();
+
+        int refusalCalls = instructions.Count(i =>
+            i.OpCode == OpCodes.Call
+            && i.Operand is MethodReference mr && mr.Name == "BuildCalcFieldsRefusal");
+        Assert.True(refusalCalls >= 2,
+            $"ClassifyCalcFieldsRequest must build both of BC's record-level refusals — the "
+            + $"non-FlowField one and the missing-CalcFormula one — but found {refusalCalls} "
+            + "call(s) to BuildCalcFieldsRefusal");
+
+        int throws = instructions.Count(i => i.OpCode == OpCodes.Throw);
+        Assert.True(throws >= 2,
+            $"ClassifyCalcFieldsRequest must THROW both refusals rather than skipping the "
+            + $"field, but found {throws} throw instruction(s)");
+
+        // The missing-CalcFormula refusal carries BC's own error number; the non-FlowField one
+        // has none (BC constructs it through the message-only NavCSideException ctor).
+        var constants = instructions
+            .Where(i => i.OpCode == OpCodes.Ldc_I4)
+            .Select(i => (int)i.Operand!)
+            .ToHashSet();
+        Assert.Contains(18023430, constants);
+    }
+
+    /// <summary>
+    /// BC's third refusal in this area — 18023494, inside
+    /// FlowFieldsHelper.GetDistinctSourceTablesFromFlowFields — is unreachable from AL because
+    /// the record-level loop above throws first, but it still guards the FlowFieldsHelper entry
+    /// point that BC's own code re-enters. It must stay wired to the validation pass.
+    /// </summary>
+    [Fact]
+    public void HelperEntryPointStillCarriesBcs18023494Refusal()
+    {
+        using var asm = OpenOurAssembly();
+        var validate = OurMethod(asm, "ValidateFlowFieldFormulas");
+        Assert.True(IndexOfCallTo(validate, "BuildOnlyFlowFieldsAllowedRefusal") >= 0,
+            "ValidateFlowFieldFormulas must refuse a non-FlowField reaching the FlowFieldsHelper "
+            + "entry point, the way GetDistinctSourceTablesFromFlowFields does (#3012)");
+
+        var builder = OurMethod(asm, "BuildOnlyFlowFieldsAllowedRefusal");
+        var constants = builder.Body.Instructions
+            .Where(i => i.OpCode == OpCodes.Ldc_I4)
+            .Select(i => (int)i.Operand!)
+            .ToHashSet();
+        Assert.Contains(18023494, constants);
+    }
+
+    /// <summary>
+    /// The upstream shape this fix mirrors, read off the shipped artifact: BC still classifies
+    /// the CalcFields field list inside RecordImplementation itself — reading
+    /// Lang.MustBeAFlowField and raising 18023430 — rather than deferring it to FlowFieldsHelper.
+    /// If a BC service update moves either refusal, the runner is reproducing a check at the
+    /// wrong layer and the AL-visible message changes with it; nothing else here would notice,
+    /// because the async body lives in a compiler-generated state machine that no call graph
+    /// walks into.
+    /// </summary>
+    [Fact]
+    public void BcStillClassifiesTheFieldListInsideRecordImplementation()
+    {
+        using var asm = AssemblyDefinition.ReadAssembly(NclPath);
+        var recordImpl = asm.MainModule.GetType("Microsoft.Dynamics.Nav.Runtime.RecordImplementation");
+        Assert.NotNull(recordImpl);
+
+        var bodies = new List<MethodDefinition>();
+        void Collect(TypeDefinition t)
+        {
+            bodies.AddRange(t.Methods.Where(m => m.HasBody));
+            foreach (var nested in t.NestedTypes) Collect(nested);
+        }
+        Collect(recordImpl!);
+
+        bool readsMustBeAFlowField = bodies.Any(m => m.Body.Instructions.Any(i =>
+            i.Operand is MethodReference mr && mr.Name == "get_MustBeAFlowField"));
+        Assert.True(readsMustBeAFlowField,
+            "RecordImplementation (or one of its async state machines) no longer reads "
+            + "Lang.MustBeAFlowField — BC moved the non-FlowField refusal, so re-derive where "
+            + "the runner should raise it instead of leaving the replacement at the old layer");
+
+        bool raises18023430 = bodies.Any(m => m.Body.Instructions.Any(i =>
+            i.OpCode == OpCodes.Ldc_I4 && (int)i.Operand! == 18023430));
+        Assert.True(raises18023430,
+            "RecordImplementation no longer raises 18023430 (MustDefineFormula) — BC moved the "
+            + "missing-CalcFormula refusal");
+    }
+}

--- a/AlRunner/Patches/ALDatabasePatches.cs
+++ b/AlRunner/Patches/ALDatabasePatches.cs
@@ -185,7 +185,7 @@ public static class ALDatabasePatches
     /// here to a plain InvalidOperationException carrying the right text but the wrong type.
     /// Scan for either spelling across whatever is loaded instead.
     /// </summary>
-    private static Type? ResolveNavCSideExceptionType()
+    internal static Type? ResolveNavCSideExceptionType()
     {
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
         {
@@ -206,7 +206,7 @@ public static class ALDatabasePatches
     /// matched, and every caller silently shipped its runner paraphrase instead of BC's
     /// text. Scan the loaded assemblies for the real class instead.
     /// </summary>
-    private static string? LangString(string name)
+    internal static string? LangString(string name)
     {
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
         {

--- a/AlRunner/Patches/FlowFieldPatches.cs
+++ b/AlRunner/Patches/FlowFieldPatches.cs
@@ -445,20 +445,27 @@ public static class FlowFieldPatches
                     BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
             if (bufferIndexer == null) return new System.Threading.Tasks.ValueTask<bool>(false);
 
-            // BLOBs first. BC excludes them from the FlowField pipeline entirely
+            // BC's own classification of the field list, BEFORE anything is loaded or
+            // calculated (#3012). This is where `Rec.CalcFields("No.")` and
+            // `Rec.CalcFields("<a FlowFilter>")` are refused, and where a FlowField with no
+            // CalcFormula is refused — see ClassifyCalcFieldsRequest for BC's own loop. It
+            // runs first for the reason BC runs it first: a refused call must compute nothing
+            // and load nothing, not leave the acceptable part of the list applied.
+            var blobFields = new List<object>();
+            var flowFields = new List<object>();
+            ClassifyCalcFieldsRequest(fields, blobFields, flowFields);
+
+            // BLOBs. BC excludes them from the FlowField pipeline entirely
             // (`fieldsToCalc.Where(f => f.FieldNclType != NavNclType.NavBlob)`) and loads their
             // content from the record's OWN DataAccess, so this stays on the RecordImplementation
             // entry point where `self` is available — the shared core below has no `self`.
-            if (_pNclMetaFieldFieldNclType != null && _nclTypeNavBlob != null)
-                foreach (var fieldObj in fields)
-                {
-                    if (fieldObj == null) continue;
-                    if (!Equals(_pNclMetaFieldFieldNclType.GetValue(fieldObj), _nclTypeNavBlob)) continue;
-                    int blobColumn = -1;
-                    try { blobColumn = (int)_pNclMetaFieldColumnIndex!.GetValue(fieldObj)!; } catch { }
-                    if (blobColumn >= 0)
-                        LoadBlobField(self, parentBuffer, bufferIndexer, blobColumn);
-                }
+            foreach (var fieldObj in blobFields)
+            {
+                int blobColumn = -1;
+                try { blobColumn = (int)_pNclMetaFieldColumnIndex!.GetValue(fieldObj)!; } catch { }
+                if (blobColumn >= 0)
+                    LoadBlobField(self, parentBuffer, bufferIndexer, blobColumn);
+            }
 
             // Then the FlowFields, through the same core BC's own
             // FlowFieldsHelper.CalcFieldsAsync now routes to (#1757). Entering at
@@ -466,13 +473,19 @@ public static class FlowFieldPatches
             // BC's own `0 → 1, n → n+1` step before handing the level to
             // GetFilterFromMetaFilterCollection, so a formula that references another
             // FlowField re-enters here one level deeper and BC's >50 guard still bites.
+            //
+            // Only the FlowFields reach the core, exactly as BC hands `flowFields.ToArray()`
+            // to FlowFieldsHelper.CalcFieldsAsync — and BC skips the call altogether when that
+            // list is empty, so a `CalcFields(<a Blob>)` does not enter the FlowField pipeline
+            // at all.
             var calculated = new List<Tuple<INavFieldMetadata, NavValue>>();
-            CalcFlowFieldValuesCore(
-                session, companyToken, parentBuffer,
-                tableState != null ? _pTableStateFiltersAndMarks?.GetValue(tableState) : null,
-                _fRecImplSecurityFiltering?.GetValue(self),
-                tableState != null ? _pTableStateReadIsolation?.GetValue(tableState) : null,
-                fields, recursionLevel: 0, calculated);
+            if (flowFields.Count > 0)
+                CalcFlowFieldValuesCore(
+                    session, companyToken, parentBuffer,
+                    tableState != null ? _pTableStateFiltersAndMarks?.GetValue(tableState) : null,
+                    _fRecImplSecurityFiltering?.GetValue(self),
+                    tableState != null ? _pTableStateReadIsolation?.GetValue(tableState) : null,
+                    ToNclMetaFieldArray(flowFields), recursionLevel: 0, calculated);
 
             foreach (var item in calculated)
                 bufferIndexer.SetValue(parentBuffer, item.Item2,
@@ -590,6 +603,208 @@ public static class FlowFieldPatches
         return _ctorFieldDictionary.Invoke(new object[] { calculated.ToArray() });
     }
 
+    // ── BC's own CalcFields field-list classification (#3012) ────────────────────────────
+    //
+    // RecordImplementation.CalcFieldsAsync(DataError, NCLMetaField[], bool) — the method
+    // RecordImpl_CalcFieldsAsync_3 replaces — does NOT hand its field array straight on to
+    // FlowFieldsHelper. It walks it first, splits it three ways, and throws on the first
+    // field it cannot place (decompiled from Ncl 28.1.49838.53910):
+    //
+    //     foreach (NCLMetaField item in fields.Where(field => field.FieldActive))
+    //     {
+    //         if (item.FieldNclType == NavNclType.NavBlob)
+    //         { GetWriteableBlobOnFieldAndEnsureInMutablePartOfBuffer(item); blobFields.Add(item); continue; }
+    //
+    //         if (item.FieldClass != FieldClass.FlowField)
+    //             throw new NavCSideException(string.Format(CultureInfo.CurrentCulture,
+    //                 Lang.MustBeAFlowField, await parentRecord.ALFieldCaptionAsync(item.FieldNo),
+    //                 metaTable.TableCaptions.GetValueOrDefault()));
+    //
+    //         if (item.CalculationFormula == NCLMetaCalculationFormula.EmptyFormula)
+    //             throw new NavCSideException(18023430, string.Format(CultureInfo.CurrentCulture,
+    //                 Lang.MustDefineFormula, await parentRecord.ALFieldCaptionAsync(item.FieldNo),
+    //                 metaTable.TableCaptions.GetValueOrDefault()));
+    //
+    //         flowFields.Add(item);
+    //     }
+    //
+    // The runner used to have no equivalent: every entry point dropped a non-FlowField on the
+    // floor with `if (!Equals(fieldClass, _fcFlowField)) continue;`, so `Rec.CalcFields("No.")`
+    // and `Rec.CalcFields("<a FlowFilter>")` both did nothing at all and reported success —
+    // exactly the silent default `loud-failures.md` exists to prevent, and measured green on
+    // the runner while real BC refuses both.
+    //
+    // Two things deliberately NOT copied, each for a reason:
+    //
+    //   * BC's third refusal for this area, NavCSideException(18023494,
+    //     Lang.OnlyFlowFieldsAllowedInCallsToCalcFields), lives one layer down in
+    //     FlowFieldsHelper.GetDistinctSourceTablesFromFlowFields. AL never reaches it — this
+    //     loop throws first — so it is reproduced in ValidateFlowFieldFormulas below, on the
+    //     FlowFieldsHelper entry point, where BC's own other callers of that helper would.
+    //
+    //   * `.Where(field => field.FieldActive)`. NCLMetaField.FieldActive is computed from
+    //     `fieldFlags & FieldFlags.Active`, and the runner's own NclMetaTableBuilder never
+    //     populates fieldFlags at all, so it reads false for every field the runner builds.
+    //     Filtering on it here would silently turn EVERY CalcFields into a no-op. Applying it
+    //     is tracked separately rather than guessed at.
+
+    /// <summary>
+    /// Splits a <c>CalcFields</c> field list the way BC's own <c>RecordImplementation</c> does:
+    /// BLOBs into <paramref name="blobFields"/>, FlowFields carrying a CalcFormula into
+    /// <paramref name="flowFields"/>, and anything else straight into BC's own refusal.
+    /// </summary>
+    private static void ClassifyCalcFieldsRequest(
+        Array fields, List<object> blobFields, List<object> flowFields)
+    {
+        foreach (var fieldObj in fields)
+        {
+            if (fieldObj == null) continue;
+
+            if (_pNclMetaFieldFieldNclType != null && _nclTypeNavBlob != null
+                && Equals(_pNclMetaFieldFieldNclType.GetValue(fieldObj), _nclTypeNavBlob))
+            {
+                blobFields.Add(fieldObj);
+                continue;
+            }
+
+            if (!Equals(_pNclMetaFieldFieldClass!.GetValue(fieldObj), _fcFlowField))
+                throw BuildCalcFieldsRefusal(fieldObj, errorNumber: null, "MustBeAFlowField",
+                    "The {0} field in the {1} table must be a FlowField.");
+
+            // BC compares against NCLMetaCalculationFormula.EmptyFormula. A null formula is not
+            // a shape BC can produce — it means the runner failed to materialise one — but it
+            // is the same observable situation for AL (there is no formula to evaluate), and
+            // the alternative is the silent skip this whole block exists to remove.
+            var formula = _pNclMetaFieldCalculationFormula!.GetValue(fieldObj);
+            if (formula == null
+                || (_fCalcFormulaEmpty != null && ReferenceEquals(formula, _fCalcFormulaEmpty.GetValue(null))))
+                throw BuildCalcFieldsRefusal(fieldObj, errorNumber: 18023430, "MustDefineFormula",
+                    "You must define a CalcFormula for the {0} FlowField in the {1} table.");
+
+            flowFields.Add(fieldObj);
+        }
+    }
+
+    /// <summary>
+    /// Build one of BC's own <c>NavCSideException</c> refusals for a CalcFields field list.
+    /// The wording comes from BC's own <c>Lang</c> resource class (in
+    /// Microsoft.Dynamics.Nav.Language.dll, resolved by reflection — the runner does not
+    /// reference it), so a BC version that rewords or localises the message is followed
+    /// automatically instead of drifting from a copy kept here. <paramref name="fallbackFormat"/>
+    /// is BC 28.1's own en-US text and is used only if the resource cannot be read, so AL still
+    /// sees the refusal rather than a silent success.
+    /// </summary>
+    private static Exception BuildCalcFieldsRefusal(
+        object fieldObj, int? errorNumber, string langResourceName, string fallbackFormat)
+    {
+        var format = ALDatabasePatches.LangString(langResourceName) ?? fallbackFormat;
+        var message = string.Format(System.Globalization.CultureInfo.CurrentCulture, format,
+            FieldCaptionForRefusal(fieldObj), TableCaptionForRefusal(fieldObj));
+
+        try
+        {
+            var tCSide = ALDatabasePatches.ResolveNavCSideExceptionType();
+            const BindingFlags CtorFlags =
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+            if (tCSide != null && errorNumber is int number)
+            {
+                var ctorNumbered = tCSide.GetConstructor(
+                    CtorFlags, null, new[] { typeof(int), typeof(string) }, null);
+                if (ctorNumbered != null)
+                    return (Exception)ctorNumbered.Invoke(new object[] { number, message });
+            }
+
+            if (tCSide != null)
+            {
+                var ctorPlain = tCSide.GetConstructor(
+                    CtorFlags, null, new[] { typeof(string) }, null);
+                if (ctorPlain != null)
+                    return (Exception)ctorPlain.Invoke(new object[] { message });
+            }
+        }
+        catch
+        {
+            // fall through — the refusal itself matters more than its exact CLR type
+        }
+
+        // Never swallow the refusal: an untyped exception still stops the call and still
+        // carries BC's message, which is what AL's asserterror observes.
+        return new InvalidOperationException(message);
+    }
+
+    /// <summary>
+    /// BC formats these two messages with <c>NavRecord.ALFieldCaptionAsync(item.FieldNo)</c> and
+    /// <c>metaTable.TableCaptions.GetValueOrDefault()</c>. <c>NCLMetaField.FieldCaption</c> is
+    /// the property that async method reads, and <c>NCLMetaTable.TableCaptionSafe</c> is BC's
+    /// own "captions, else the object name" accessor; both fall back to the name here so a
+    /// table whose caption strings were never materialised still names the field and the table
+    /// rather than producing "The  field in the  table must be a FlowField."
+    /// </summary>
+    private static string FieldCaptionForRefusal(object fieldObj)
+    {
+        var field = fieldObj as NCLMetaField;
+        if (field == null) return string.Empty;
+        try
+        {
+            var caption = field.FieldCaption;
+            if (!string.IsNullOrEmpty(caption)) return caption;
+        }
+        catch { }
+        return field.FieldName ?? string.Empty;
+    }
+
+    private static string TableCaptionForRefusal(object fieldObj)
+    {
+        var parent = (fieldObj as NCLMetaField)?.Parent;
+        if (parent == null) return string.Empty;
+        try
+        {
+            var pSafe = parent.GetType().GetProperty("TableCaptionSafe",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            if (pSafe?.GetValue(parent) is string safe && !string.IsNullOrEmpty(safe))
+                return safe;
+        }
+        catch { }
+        return parent.TableName ?? string.Empty;
+    }
+
+    /// <summary>
+    /// BC's <c>NavCSideException(18023494, Lang.OnlyFlowFieldsAllowedInCallsToCalcFields)</c> —
+    /// "The field {0} in the {1} table is not a FlowField or a BLOB field and cannot be passed
+    /// in calls to CalcFields." Unlike the two RecordImplementation refusals this one is
+    /// formatted with the raw <c>FieldName</c> / <c>Parent.TableName</c>, not with captions,
+    /// so it is built separately rather than through BuildCalcFieldsRefusal.
+    /// </summary>
+    private static Exception BuildOnlyFlowFieldsAllowedRefusal(NCLMetaField field)
+    {
+        var format = ALDatabasePatches.LangString("OnlyFlowFieldsAllowedInCallsToCalcFields")
+            ?? "The field {0} in the {1} table is not a FlowField or a BLOB field and cannot "
+               + "be passed in calls to CalcFields.";
+        var message = string.Format(System.Globalization.CultureInfo.CurrentCulture, format,
+            field.FieldName, field.Parent?.TableName);
+
+        try
+        {
+            var tCSide = ALDatabasePatches.ResolveNavCSideExceptionType();
+            var ctor = tCSide?.GetConstructor(
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+                null, new[] { typeof(int), typeof(string) }, null);
+            if (ctor != null)
+                return (Exception)ctor.Invoke(new object[] { 18023494, message });
+        }
+        catch { }
+
+        return new InvalidOperationException(message);
+    }
+
+    private static NCLMetaField[] ToNclMetaFieldArray(List<object> fields)
+    {
+        var arr = new NCLMetaField[fields.Count];
+        for (int i = 0; i < fields.Count; i++) arr[i] = (NCLMetaField)fields[i];
+        return arr;
+    }
+
     /// <summary>
     /// Runs BC's own <c>FlowFieldsHelper.CheckFlowFieldProperties</c> over every FlowField in
     /// <paramref name="fields"/>, reproducing all five of its runtime refusals (#2970).
@@ -638,7 +853,24 @@ public static class FlowFieldPatches
                 && Equals(_pNclMetaFieldFieldNclType.GetValue(fieldObj), _nclTypeNavBlob))
                 continue;
 
-            if (!Equals(_pNclMetaFieldFieldClass!.GetValue(fieldObj), _fcFlowField)) continue;
+            // #3012 — BC's GetDistinctSourceTablesFromFlowFields refuses a non-FlowField here,
+            // as the very first thing it does per field, AFTER its caller has filtered BLOBs
+            // out (`fieldsToCalc.Where(f => f.FieldNclType != NavNclType.NavBlob)`):
+            //
+            //     if (flowField.FieldClass != FieldClass.FlowField)
+            //         throw new NavCSideException(18023494, string.Format(...,
+            //             Lang.OnlyFlowFieldsAllowedInCallsToCalcFields,
+            //             flowField.FieldName, flowField.Parent.TableName));
+            //
+            // A record-level CalcFields never gets this far — ClassifyCalcFieldsRequest above
+            // has already refused with RecordImplementation's own wording, which is what AL
+            // sees. This guards the OTHER entry point, FlowFieldsHelper_CalcFieldsAsync, which
+            // BC's own code re-enters (GetFilterFromMetaFilterCollection resolving a
+            // `field(<a FlowField>)` condition, RecordIsWithinFilteredFlowFieldsAsync). Those
+            // callers pass FlowFields by construction, so this is the runner declining to be
+            // more permissive than BC on a path BC also checks — not a skip.
+            if (!Equals(_pNclMetaFieldFieldClass!.GetValue(fieldObj), _fcFlowField))
+                throw BuildOnlyFlowFieldsAllowedRefusal(field);
 
             var formula = _pNclMetaFieldCalculationFormula!.GetValue(fieldObj);
             if (formula == null) continue;

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -695,3 +695,40 @@ page).
 so no `byBcVersion` override; the eight CI legs are what confirm that. appGroups is unchanged at
 1 — all three tests joined the single existing al-language app group. `runner-extras`,
 `al-language-internals-fixture` and `al-language-onprem` are `main`'s values, untouched.
+
+## 2648 -> 2661 — corpus pin 83b54a91 (#188) -> 3268bf1b (#191)
+
+Folded into the fix PR for #3012, which is what the bump exists to enable: corpus #189 added
+`codeunit 60444 "CalcFields Field Class Tests"` (7 tests), the RED -> GREEN for
+`fix(record): refuse a CalcFields field that is not a FlowField or a BLOB`. Three corpus
+commits come in with it, because the corpus history is linear: **#185** (360e1f0, a RunObject
+action with no handler bound), **#189** (3060794, the CalcFields refusals) and **#191**
+(3268bf1, Table Metadata for a table declaring no `DataClassification`).
+
++13 tests, read off the guard's own GROWTH line ("expected 2648, actual 2661") on BC 28.1, not
+counted off the source. No file in the range carries a `#if` version gate, so the count is
+uniform across the eight legs and stays a single `default`; appGroups is unchanged at 1, and
+`runner-extras`, `al-language-internals-fixture` and `al-language-onprem` are `main`'s values,
+untouched.
+
+**Not pinned at corpus master head, deliberately.** Master moved on to 861a566 (#193, the close
+lifecycle of a page that closes itself) while this was in flight. 3268bf1b is the last commit
+this branch has actually measured, and #193 lands in the handlers/close-lifecycle area where
+#3061 has just been fixed and more is open — taking it unverified is how the previous revision
+of this branch ended up carrying #188's failures for a defect (#3054) that belonged to another
+PR. A later bump can take it after measuring it.
+
+Two of the thirteen fail, both from #185, and both get entries in
+`known-gaps-testpage-runobject-no-handler.json` linking **#2975**, which stays open: real BC
+opens a RunObject target with no handler bound and runs its OnOpenPage, and the runner raises
+`NavNCLMissingUIHandlerException`. #2951 made an action's RunObject perform its target, so the
+sibling eight-test suite (codeunit 60455) passes; the no-handler arm was held out of that suite
+deliberately while the question was open.
+
+Those two entries are **confirmed on all eight legs**, not on one local run: at the previous
+revision of this branch (head `ac70dac1`, run 34029802786) no leg reported "Test passed cleanly
+but manifest declares expect-fail-known-gap", including the three legs that were otherwise
+green. That is the drift complaint which retired codeunit 60455's five entries two bumps ago,
+and it settles the caveat this file recorded for them.
+
+Written by agent stma-auto-1 (automated implementation agent).

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Schema, semantics and how to bump: README.md in this directory. Per-bump rationale: history.md, never a prose line in here (#2485).",
   "suites": {
     "al-language": {
-      "tests": { "default": 2648 },
+      "tests": { "default": 2661 },
       "appGroups": { "default": 1 }
     },
     "al-language-internals-fixture": { "tests": { "default": 0 }, "appGroups": { "default": 1 } },

--- a/tests/expectations/known-gaps-testpage-runobject-no-handler.json
+++ b/tests/expectations/known-gaps-testpage-runobject-no-handler.json
@@ -1,0 +1,18 @@
+[
+  {
+    "codeunitId": 60285,
+    "CodeunitName": "TPARONH Tests",
+    "Method": "RunObjectActionWithoutAHandlerOpensItsTargetUnattended",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2975",
+    "Note": "A page action's RunObject invoked with NO handler bound: real BC opens the target anyway, runs its OnOpenPage, and raises nothing AL can see -- measured on 27.0, 27.3, 27.5, 28.0, 28.1, 28.2, 28.3 and 28.4 (StefanMaron/BusinessCentral.AL.Language.Tests#185). The runner refuses instead, with NavNCLMissingUIHandlerException 'Unhandled UI: Page 60282'. #2951 made an action's RunObject perform its target, which is why the sibling eight-test suite (codeunit 60455 'TPARO Tests') passes here; the no-handler arm was deliberately held out of that suite while the question was open and is what #2975 still tracks. The three control arms in THIS codeunit pass on the runner -- a plain Page.Run on the same target IS refused, an OnAction trigger calling Page.Run on the same host and row IS refused, and the logging target does record its own opening when a handler is bound -- so the fixture, the target page and the action-invoke path are all ruled out, and the RunObject declaration is the only thing left."
+  },
+  {
+    "codeunitId": 60285,
+    "CodeunitName": "TPARONH Tests",
+    "Method": "RunObjectActionOnTheControlsTargetWithoutAHandler_NoThrow",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2975",
+    "Note": "The same gap as the entry above, aimed at the clean Card target rather than the logging one, so the comparison has a RunObject side on exactly the page the two Page.Run controls refuse. Its whole claim is that the statement completes; the runner raises NavNCLMissingUIHandlerException 'Unhandled UI: Page 60281' instead."
+  }
+]


### PR DESCRIPTION
Closes #3012

## The defect

`Record.CalcFields` accepted a field that is neither a FlowField nor a BLOB and **silently
did nothing** with it. `Rec.CalcFields("No.")` and `Rec.CalcFields("<a FlowFilter>")` both
compile with no AL diagnostic and both reported success on the runner. Real BC refuses both.

## What BC actually does — and where the issue's premise was wrong

The issue pointed at `FlowFieldsHelper.GetDistinctSourceTablesFromFlowFields`, which raises
`NavCSideException(18023494, Lang.OnlyFlowFieldsAllowedInCallsToCalcFields)`. **AL never
reaches that one.** Decompiled from `Microsoft.Dynamics.Nav.Ncl.dll` 28.1.49838.53910,
`RecordImplementation.CalcFieldsAsync(DataError, NCLMetaField[], bool)` — the method the
runner replaces — classifies the field list itself first:

```csharp
foreach (NCLMetaField item in fields.Where(field => field.FieldActive))
{
    if (item.FieldNclType == NavNclType.NavBlob)
    { GetWriteableBlobOnFieldAndEnsureInMutablePartOfBuffer(item); blobFields.Add(item); continue; }

    if (item.FieldClass != FieldClass.FlowField)
        throw new NavCSideException(string.Format(…, Lang.MustBeAFlowField,
            await parentRecord.ALFieldCaptionAsync(item.FieldNo),
            metaTable.TableCaptions.GetValueOrDefault()));

    if (item.CalculationFormula == NCLMetaCalculationFormula.EmptyFormula)
        throw new NavCSideException(18023430, string.Format(…, Lang.MustDefineFormula, …));

    flowFields.Add(item);
}
```

So the messages AL sees, read out of `Microsoft.Dynamics.Nav.Language.dll`, are:

| refusal | number | text |
|---|---|---|
| not a FlowField | *(none — message-only ctor)* | `The {0} field in the {1} table must be a FlowField.` |
| FlowField with no CalcFormula | 18023430 | `You must define a CalcFormula for the {0} FlowField in the {1} table.` |
| non-FlowField reaching `FlowFieldsHelper` | 18023494 | `The field {0} in the {1} table is not a FlowField or a BLOB field and cannot be passed in calls to CalcFields.` |

## The BLOB question, and how it was established

The issue flagged that BC's message says "not a FlowField **or a BLOB field**" while the code
tests `FieldClass != 1`, which are not the same predicate. They are reconciled by the caller:
BC removes BLOBs from the list **before** either check — `RecordImplementation` splits them
into `blobFields` in the loop above, and `CalcFieldsFromNonVirtualTablesAsync` passes
`fieldsToCalc.Where(f => f.FieldNclType != NavNclType.NavBlob)` down to
`GetDistinctSourceTablesFromFlowFields`. A Blob column's `FieldClass` is `Normal`, exactly
like the Code and Text columns that ARE refused, so the exemption is a **data-type** test, not
a field-class one.

That is a reading of BC's code. The **measurement** is upstream and now merged: corpus
`Record_CalcFields_BlobField_LoadsTheStoredBytes` (a Blob alone loads its bytes) and
`Record_CalcFields_BlobAlongsideNormalField_ThrowsForTheNormalField` (the exemption is per
field, not per call — a Blob in the list does not turn the check off for the ordinary column
beside it), both green on all eight BC legs.

## The fix

`ClassifyCalcFieldsRequest` reproduces BC's loop on the `RecordImplementation` entry point,
and only the FlowFields it collects reach `CalcFlowFieldValuesCore` — as BC hands
`flowFields.ToArray()` to `FlowFieldsHelper`, and skips that call entirely when the list is
empty. Both messages are read out of BC's own `Lang` resource class rather than restated, so a
reworded or localised BC message is followed instead of drifting from a copy kept here.

Ordering matters and is pinned: BC classifies before it loads or calculates anything, so a
refused `CalcFields` writes nothing — not the valid FlowField named beside the bad field, and
not the BLOB named beside it either.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — `CalcFlowFieldValuesCore` is reached
   from three entry points and all three shared the `continue`. Classification now happens
   once, at the record entry, and only FlowFields go down; the core's own `continue` is now
   defensive. The other two entry points (`FlowFieldsHelper_CalcFieldsAsync`,
   `CalcOneFlowFieldForQueryRow`) were checked: BC's own re-entrant callers of the helper
   pass FlowFields by construction, and the query path passes the single
   `NCLMetaQueryDataItem.SourceFlowField`.
2. **Does a sibling function make the same assumption?** Yes, and it is fixed here too. The
   same loop carries BC's **missing-CalcFormula** refusal (18023430), which the runner also
   skipped silently. `alc` accepts `field(30; "X"; Decimal) { FieldClass = FlowField; }` with
   no `CalcFormula` — measured, the corpus compiles with exactly that field added — so the
   shape is reachable from AL and is now pinned upstream and reproduced here.
3. **Two paths writing the same state with different invariants?** The 18023494 refusal in
   `GetDistinctSourceTablesFromFlowFields` is BC's guard on the *other* entry into the same
   work. It is unreachable from AL but is reproduced in `ValidateFlowFieldFormulas` anyway,
   so the runner is never more permissive than BC on a path BC checks.

**Deliberately left out:** BC's `.Where(field => field.FieldActive)`. `NCLMetaField.FieldActive`
is computed from `fieldFlags & FieldFlags.Active`, and the runner's `NclMetaTableBuilder` never
populates `fieldFlags` at all — measured, there is no reference to `FieldFlags` anywhere in
`AlRunner/`. Filtering on it would read false for every runner-built field and turn **every**
`CalcFields` into a no-op. That is exactly the kind of faithful-looking change that is a silent
disaster; applying it needs the metatable builder to populate the flags first, which is not this
change.

## Corpus pin bump, folded in

The upstream test merged as **`3060794a`** (corpus PR #189, 18/18 legs green), so the pin moves
from `83b54a91` (#188, what `main` carries after #3067) to **`3268bf1b`** (#191). The corpus
history is linear, so #185 and #191 come in with it. `3268bf1b` rather than `3060794a` because
#191's tests were **verified** to pass here, not assumed.

**Not corpus master head, deliberately.** Master moved on to `861a566` (#193, the close lifecycle
of a page that closes itself) while this was in flight, in the handlers area where #3061 has just
been fixed and more is open. `3268bf1b` is the last commit this branch has measured; taking #193
unverified is how the previous revision of this branch ended up carrying #188's failures for a
defect (#3054) that belonged to #3067.

**Counts read off the guard's own GROWTH line, never computed:** al-language `2648 -> 2661`
on BC 28.1. No file in the range carries a `#if` version gate, so the count is uniform across the
eight legs and stays a single `default`. `tests/runner-extras` needed no change — the guard
accepted it unmodified at 304 tests.

**Eleven of the thirteen new tests pass unchanged.** The two that do not are both from corpus
#185 and are a **separate** runner gap, tracked by **#2975**, which stays open after this
merges: real BC opens a RunObject target with no handler bound and runs its `OnOpenPage`, while
the runner raises `NavNCLMissingUIHandlerException` ("Unhandled UI: Page 60282" / "Page 60281").
#2951 made an action's RunObject perform its target, which is why the sibling eight-test suite
(codeunit 60455) passes; the no-handler arm was deliberately held out of that suite while the
question was open. Entries in `tests/expectations/known-gaps-testpage-runobject-no-handler.json`;
rationale in `tests/expectations/count-baseline/history.md`.

**Caveat those two entries carry, and it is written into `history.md` as well:** they rest on
**one local run**, against artifact 28.1.49838.53910, and this box cannot cross-check another
version — the 27.3, 27.5, 28.2 and 28.1.49838.54308 artifact roots all fail to load
`Microsoft.Bcl.AsyncInterfaces` because only the 28.1.49838.53910 platform-app cache is
populated here. The immediately preceding `history.md` entry records codeunit 60455's five
entries being added on exactly that evidence and then removed when the matrix drift guard said
they passed cleanly. If the guard says the same for either of these, the entry is wrong and
comes out. Unlike that case, the observed failure is the runner refusing to open an unattended
page at all rather than an artifact-patch difference.

## RED → GREEN, at this PR's own pin

Measured on this branch, reverting only `AlRunner/Patches/FlowFieldPatches.cs` to `origin/main`
and rebuilding, then restoring and rebuilding (staged diff verified empty after the restore):

```
dotnet run --no-build --project AlRunner -c Release --framework net8.0 -- \
  tests/al-language/tests/al-language --package-cache "$HOME/.al-runner/platform-apps" \
  --test Record_CalcFields_
```

| | RED (fix reverted) | GREEN |
|---|---|---|
| codeunit 60444 | 6 FAIL, 1 PASS (`…_BlobField_LoadsTheStoredBytes`) | **7 PASS** |
| all `Record_CalcFields_*` | 30 pass / 6 fail (36) | **36 pass / 0 fail** |

Each of the six failures was `NavNCLAssertErrorException: An error was expected inside an
ASSERTERROR statement.` — the silent success.

## What else was run, in this state (after the rebase, rebuilt)

- **Full corpus at the new pin**, CI's own invocation (`--strict`, `--count-baseline`):
  **2661 pass / 0 fail / 0 error**, exit 0, 16 `pass-known-gap`.
- **`tests/runner-extras`** (both package caches, `--strict`, `--count-baseline`):
  **304 pass / 0 fail / 0 error**, exit 0.
- **`dotnet test AlRunner.Tests --filter FullyQualifiedName~CalcFieldsFieldClass|~FlowField|~Blob|~Expectation|~CountBaseline`**:
  **111 pass, 1 skipped**. The skip is `BothRefusalMessagesComeFromBcsOwnLangResource`, a
  `SkippableFact` gated on the in-process BC engine, which fails to bootstrap on this box for
  every test that needs it (the pre-existing `CodeunitRunWriteTransactionRefusalTests` skips for
  the same reason). It runs on CI.

## Runner-side tests

`AlRunner.Tests/CalcFieldsFieldClassRefusalTests.cs` — mechanism tests only; the BC claim is
upstream. They pin the ordering (classify before load, before calculate), that the
classification throws rather than skips, that 18023430 and 18023494 are both carried, that both
messages resolve out of BC's own `Lang` with the exact text the corpus asserts, and — read off
the shipped artifact including its async state machines — that BC still classifies the field
list inside `RecordImplementation` rather than deferring it.

---

Written by agent `stma-auto-1` on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
