### PR TITLE
fix(table-metadata): resolve an undeclared option column's default by name, not ordinal 0

### DIFF
--- a/AlRunner.Tests/BcAppSymbolCacheTableMetadataPropertiesTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCacheTableMetadataPropertiesTests.cs
@@ -147,9 +147,17 @@ public class BcAppSymbolCacheTableMetadataPropertiesTests
             var bare = Assert.Single(tables, t => t.TableId == 60903);
             // The negative half. "Declares none" must stay distinguishable from "declares the
             // default" all the way through: the parser records null, and the row builder
-            // applies AL's own defaults (TableType = Normal, DataClassification =
-            // CustomerContent, ExternalName = blank). A parser that substituted those strings
-            // here would make the two cases indistinguishable downstream.
+            // applies the defaults (TableType = Normal, DataClassification = CustomerContent,
+            // ExternalName = blank). A parser that substituted those strings here would make
+            // the two cases indistinguishable downstream.
+            //
+            // CustomerContent there was reasoning when this comment was written, and is now a
+            // measurement: Microsoft documents the DataClassification default as
+            // ToBeClassified, and corpus fixture ALT Unclassified (60837) put the question to a
+            // real service tier in StefanMaron/BusinessCentral.AL.Language.Tests#191, which
+            // came back CustomerContent on all sixteen legs (BC 27.0-28.4, Cloud and OnPrem).
+            // See RecordPatches.TableMetadataVirtualTable.cs's AlDefaultDataClassification
+            // (#3019).
             Assert.Null(bare.TableTypeName);
             Assert.Null(bare.DataClassificationName);
             Assert.Null(bare.ExternalName);

--- a/AlRunner.Tests/BcAppSymbolCacheTableMetadataPropertiesTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCacheTableMetadataPropertiesTests.cs
@@ -155,9 +155,10 @@ public class BcAppSymbolCacheTableMetadataPropertiesTests
             // measurement: Microsoft documents the DataClassification default as
             // ToBeClassified, and corpus fixture ALT Unclassified (60837) put the question to a
             // real service tier in StefanMaron/BusinessCentral.AL.Language.Tests#191, which
-            // came back CustomerContent on all sixteen legs (BC 27.0-28.4, Cloud and OnPrem).
-            // See RecordPatches.TableMetadataVirtualTable.cs's AlDefaultDataClassification
-            // (#3019).
+            // answered CustomerContent on the eight Cloud legs of run 34026600861 (BC 27.0
+            // through 28.4) — the legs that actually execute codeunit 60801. See
+            // RecordPatches.TableMetadataVirtualTable.cs's AlDefaultDataClassification, which
+            // records why eight is the number and why it is enough (#3019).
             Assert.Null(bare.TableTypeName);
             Assert.Null(bare.DataClassificationName);
             Assert.Null(bare.ExternalName);

--- a/AlRunner.Tests/TableMetadataOptionDefaultOrdinalTests.cs
+++ b/AlRunner.Tests/TableMetadataOptionDefaultOrdinalTests.cs
@@ -1,0 +1,140 @@
+// TableMetadataOptionDefaultOrdinalTests — how Table Metadata (2000000136) answers an option
+// column for a table that declares NOTHING for it (#3019).
+//
+// WHY THIS IS A RUNNER-SIDE MECHANISM TEST AND NOT AN AL BUNDLE
+// ------------------------------------------------------------
+// The BC-behaviour half of #3019 — "a table declaring no DataClassification reports
+// CustomerContent" — belongs upstream and is there: corpus fixture ALT Unclassified (60837)
+// and Record_TableMetadata_Get_TableDeclaringNoDataClassification_ReportsTheDefault, in
+// StefanMaron/BusinessCentral.AL.Language.Tests#191, green on all sixteen legs (BC 27.0, 27.3,
+// 27.5, 28.0, 28.1, 28.2, 28.3, 28.4, Cloud and OnPrem). Nothing here re-states that claim.
+//
+// What it pins instead is the ROUTE, which no AL test can see. Both defaults this file needs
+// sit FIRST in their column's option set in every BC artifact measured so far, so the
+// undeclared branch returned a hardcoded ordinal 0 and was right by coincidence. That is the
+// same shape as the bug #2938 fixed for DECLARED values, and the reason EnsureOptionOrdinals
+// reads ordinals out of the artifact instead of writing them down: in BC 28.1's own TableType
+// option string, Temporary is at 6 and NOT at the 5 a reading of AL's documented enum
+// suggests. An option set that is reordered, extended at the front, or missing the default
+// member entirely is indistinguishable from today's through an AL assertion, because AL can
+// only see the artifact it is running on.
+//
+// So the assertions below drive the resolver with option strings the test chooses, including
+// reordered ones. Every case is asserted at TWO different ordinals for the same member name,
+// which is exactly what a `return 0` cannot satisfy.
+
+using System;
+using System.Collections.Generic;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TableMetadataOptionDefaultOrdinalTests
+{
+    // BC 28.1.49838.53910's own option strings for the two Table Metadata option columns the
+    // runner answers, copied verbatim from the artifact's System.app rather than from AL's
+    // documented enums — which is the distinction this whole file is about.
+    private const string RealDataClassification =
+        "CustomerContent,ToBeClassified,EndUserIdentifiableInformation,AccountData,"
+        + "EndUserPseudonymousIdentifiers,OrganizationIdentifiableInformation,SystemMetadata";
+    private const string RealTableType =
+        "Normal,CRM,ExternalSQL,Exchange,MicrosoftGraph,Query,Temporary";
+
+    private static int Resolve(string optionString, string? declaredName, string alDefault, string fieldName = "DataClassification")
+        => RecordPatches.ResolveOptionMemberOrdinal(
+            RecordPatches.ParseOptionOrdinals(fieldName, optionString),
+            fieldName, optionString, declaredName, alDefault, tableId: 60837);
+
+    [Fact]
+    public void UndeclaredDataClassification_ResolvesCustomerContentByName_NotOrdinalZero()
+    {
+        // On the real artifact CustomerContent IS first, so this half is what a hardcoded 0
+        // also produced — it pins the answer the service tier measured on corpus PR #191.
+        Assert.Equal(0, Resolve(RealDataClassification, declaredName: null, "CustomerContent"));
+
+        // The half a hardcoded 0 cannot produce. Same column, same "declares nothing" input,
+        // an option set whose members are in a different order: the answer has to MOVE with
+        // CustomerContent, because the member is what the row means and the position is only
+        // how this artifact happens to spell it.
+        const string Reordered =
+            "ToBeClassified,SystemMetadata,AccountData,CustomerContent,"
+            + "EndUserIdentifiableInformation,EndUserPseudonymousIdentifiers,"
+            + "OrganizationIdentifiableInformation";
+        Assert.Equal(3, Resolve(Reordered, declaredName: null, "CustomerContent"));
+
+        // A third position, so the two above cannot be satisfied by any pair of constants.
+        Assert.Equal(1, Resolve("ToBeClassified,CustomerContent", declaredName: null, "CustomerContent"));
+    }
+
+    [Fact]
+    public void UndeclaredTableType_ResolvesNormalByName_NotOrdinalZero()
+    {
+        // The sibling column, which shares the resolver and had the same hardcoded branch.
+        Assert.Equal(0, Resolve(RealTableType, null, "Normal", "TableType"));
+        Assert.Equal(2, Resolve("CRM,Temporary,Normal,Query", null, "Normal", "TableType"));
+    }
+
+    [Fact]
+    public void DeclaredValue_StillResolvesItsOwnOrdinalFromTheArtifact()
+    {
+        // The declared path, unchanged by #3019 and asserted here so a refactor of the shared
+        // resolver cannot break it silently. SystemMetadata is at 6 and ToBeClassified at 1 in
+        // the real option string — neither is a value a reading of the docs would predict from
+        // position alone.
+        Assert.Equal(6, Resolve(RealDataClassification, "SystemMetadata", "CustomerContent"));
+        Assert.Equal(1, Resolve(RealDataClassification, "ToBeClassified", "CustomerContent"));
+
+        // The reason ordinals are read rather than written down, restated as an assertion:
+        // Temporary is 6 in BC 28.1's TableType set, not the 5 AL's documented enum suggests.
+        Assert.Equal(6, Resolve(RealTableType, "Temporary", "Normal", "TableType"));
+    }
+
+    [Fact]
+    public void UndeclaredValue_DefaultMemberAbsentFromTheOptionSet_IsRefusedNotDefaulted()
+    {
+        // An artifact whose DataClassification column does not carry CustomerContent at all.
+        // Answering 0 there would report ToBeClassified about a table that said nothing — a
+        // wrong answer dressed as a default, which is what .claude/rules/loud-failures.md
+        // forbids. The refusal has to name the column, the member it looked for and the set it
+        // looked in, so the next reader can tell an artifact change from a runner bug.
+        const string WithoutDefault = "ToBeClassified,AccountData,SystemMetadata";
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
+            () => Resolve(WithoutDefault, declaredName: null, "CustomerContent"));
+
+        Assert.Contains("60837", ex.Message);
+        Assert.Contains("declares no DataClassification", ex.Message);
+        Assert.Contains("CustomerContent", ex.Message);
+        Assert.Contains(WithoutDefault, ex.Message);
+        // Category (2) of RecordPatches.VirtualTableShapeGap.cs: in scope, the runner cannot
+        // answer yet. The anchor is load-bearing — IsPermanentOutOfScope reads it to decide
+        // whether an AL [TryFunction] traps this into `false` or it tears through.
+        Assert.StartsWith("not-yet-implemented", ex.Reason);
+    }
+
+    [Fact]
+    public void DeclaredValue_NotAMemberOfTheOptionSet_IsRefusedNotDefaulted()
+    {
+        // The #2938 refusal, still in place: a declared member the column does not list is a
+        // shape mismatch, never ordinal 0. Asserted alongside the new one so the two refusals
+        // stay distinguishable in the message a reader gets.
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
+            () => Resolve(RealDataClassification, "NotAMember", "CustomerContent"));
+
+        Assert.Contains("declares DataClassification = 'NotAMember'", ex.Message);
+        Assert.Contains("not a member of that column's own option set", ex.Message);
+    }
+
+    [Fact]
+    public void ParseOptionOrdinals_EmptyOptionString_IsRefused()
+    {
+        // The precondition behind every lookup above. An empty option string would otherwise
+        // make the map empty, and an empty map turns every resolution into the refusal path —
+        // which would read as "this artifact renamed a member" rather than "this column has no
+        // option metadata at all".
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
+            () => RecordPatches.ParseOptionOrdinals("DataClassification", ""));
+        Assert.Contains("option string is empty", ex.Message);
+    }
+}

--- a/AlRunner.Tests/TableMetadataOptionDefaultOrdinalTests.cs
+++ b/AlRunner.Tests/TableMetadataOptionDefaultOrdinalTests.cs
@@ -6,8 +6,11 @@
 // The BC-behaviour half of #3019 — "a table declaring no DataClassification reports
 // CustomerContent" — belongs upstream and is there: corpus fixture ALT Unclassified (60837)
 // and Record_TableMetadata_Get_TableDeclaringNoDataClassification_ReportsTheDefault, in
-// StefanMaron/BusinessCentral.AL.Language.Tests#191, green on all sixteen legs (BC 27.0, 27.3,
-// 27.5, 28.0, 28.1, 28.2, 28.3, 28.4, Cloud and OnPrem). Nothing here re-states that claim.
+// StefanMaron/BusinessCentral.AL.Language.Tests#191. The assertion RAN, and passed, on the eight
+// Cloud legs of run 34026600861 (BC 27.0, 27.3, 27.5, 28.0, 28.1, 28.2, 28.3, 28.4). That run's
+// eight OnPrem legs are green as well but build a different app (tests/al-language-onprem,
+// codeunits 61200 and 61201) and never execute codeunit 60801, so they say the fixture compiles
+// there, not what the column answered. Nothing here re-states that claim.
 //
 // What it pins instead is the ROUTE, which no AL test can see. Both defaults this file needs
 // sit FIRST in their column's option set in every BC artifact measured so far, so the
@@ -22,6 +25,20 @@
 // So the assertions below drive the resolver with option strings the test chooses, including
 // reordered ones. Every case is asserted at TWO different ordinals for the same member name,
 // which is exactly what a `return 0` cannot satisfy.
+//
+// WHAT ALREADY COVERS THE REFACTOR ITSELF
+// ---------------------------------------
+// The rewritten undeclared branch is not first exercised here. Codeunit 60801's
+// Record_TableMetadata_Get_DeclaredTable_ReturnsMatchingRow, already in the corpus at the pin
+// this repo carries, asserts TableType::Normal for ALT Relation Parent — a fixture that
+// declares no TableType — so it drives exactly this branch through a live NCLMetaTable and
+// that artifact's real OptionString on every BC leg of this repo's own matrix. The same
+// codeunit asserts DataClassification::CustomerContent through the DECLARED path, which is
+// what establishes, per leg, that the member this file's default names is present in that
+// artifact's option set at all: the precondition the refusal below tests for.
+//
+// This file adds the cases those cannot reach, because an AL test only ever sees the option
+// set of the artifact it is running on.
 
 using System;
 using System.Collections.Generic;

--- a/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
+++ b/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
@@ -322,7 +322,15 @@ public sealed class VirtualTableRefusalClaimTests
         // ordinal 0 would assert "Normal" about a table that declared something else, which is
         // the same silent wrong answer the issue is about. Going UP is the expected direction
         // here; this assertion exists to catch the count going down.
-        Assert.Equal(67, total);
+        //
+        // 67 -> 68 (#3019): the same populator's UNDECLARED branch stopped hardcoding ordinal
+        // 0 and now resolves AL's default member by name against the column's own option set,
+        // so it gained the matching refusal — an artifact whose option set does not carry that
+        // member at all. The declared and undeclared misses say different things and are
+        // deliberately two sites, not one: "this table declared something the column does not
+        // list" and "this artifact's column does not list the default" point at different
+        // causes. TableMetadataOptionDefaultOrdinalTests pins both messages.
+        Assert.Equal(68, total);
     }
 
 

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -766,9 +766,13 @@ public static partial class RecordPatches
             var lookupPage = PageRefText(PropValue(table.PropertyList, "LookupPageId"));
             var drillDownPage = PageRefText(PropValue(table.PropertyList, "DrillDownPageId"));
             // DataClassification / ExternalName feed the Table Metadata (2000000136) columns of
-            // the same name (#2938). Both are kept AS WRITTEN and null when undeclared: AL's
-            // own defaults (CustomerContent, blank) are applied at row-build time, so "declares
+            // the same name (#2938). Both are kept AS WRITTEN and null when undeclared: the
+            // defaults (CustomerContent, blank) are applied at row-build time, so "declares
             // none" stays distinguishable from "declares the default" all the way through.
+            // CustomerContent there is a MEASUREMENT, not AL documentation — Microsoft
+            // documents ToBeClassified — settled on sixteen green BC legs by
+            // StefanMaron/BusinessCentral.AL.Language.Tests#191 and cited at
+            // RecordPatches.TableMetadataVirtualTable.cs's AlDefaultDataClassification (#3019).
             var dataClassification = PropValue(table.PropertyList, "DataClassification")?.ToString()?.Trim();
             // AlStringLiteralText, not the raw node text: ExternalName is an AL STRING LITERAL
             // (ExternalName = 'alt_entity'), so the node stringifies WITH its single quotes and a

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -770,9 +770,11 @@ public static partial class RecordPatches
             // defaults (CustomerContent, blank) are applied at row-build time, so "declares
             // none" stays distinguishable from "declares the default" all the way through.
             // CustomerContent there is a MEASUREMENT, not AL documentation — Microsoft
-            // documents ToBeClassified — settled on sixteen green BC legs by
+            // documents ToBeClassified — settled on the eight Cloud legs of corpus run
+            // 34026600861 (BC 27.0 through 28.4) by
             // StefanMaron/BusinessCentral.AL.Language.Tests#191 and cited at
-            // RecordPatches.TableMetadataVirtualTable.cs's AlDefaultDataClassification (#3019).
+            // RecordPatches.TableMetadataVirtualTable.cs's AlDefaultDataClassification, which
+            // records why eight is the number and why it is enough (#3019).
             var dataClassification = PropValue(table.PropertyList, "DataClassification")?.ToString()?.Trim();
             // AlStringLiteralText, not the raw node text: ExternalName is an AL STRING LITERAL
             // (ExternalName = 'alt_entity'), so the node stringifies WITH its single quotes and a

--- a/AlRunner/Patches/RecordPatches.TableMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.TableMetadataVirtualTable.cs
@@ -234,9 +234,17 @@ public static partial class RecordPatches
     /// <c>DataClassification</c>, and
     /// <c>Record_TableMetadata_Get_TableDeclaringNoDataClassification_ReportsTheDefault</c> in
     /// StefanMaron/BusinessCentral.AL.Language.Tests#191 asserts <c>CustomerContent</c> for it.
-    /// That PR came back green on all sixteen legs — BC 27.0, 27.3, 27.5, 28.0, 28.1, 28.2,
-    /// 28.3 and 28.4, Cloud and OnPrem — so a real service tier reports <c>CustomerContent</c>
-    /// and the documented <c>ToBeClassified</c> is not what a Table Metadata row carries.</para>
+    /// That assertion RAN, and passed, on the eight Cloud legs of run 34026600861 — BC 27.0,
+    /// 27.3, 27.5, 28.0, 28.1, 28.2, 28.3 and 28.4 — so a real service tier reports
+    /// <c>CustomerContent</c> and the documented <c>ToBeClassified</c> is not what a Table
+    /// Metadata row carries.</para>
+    /// <para>Eight, not sixteen: that run has eight further OnPrem legs and they are all green
+    /// too, but they build a DIFFERENT app (<c>tests/al-language-onprem</c>, codeunits 61200
+    /// and 61201) and never execute codeunit 60801. Their green says the fixture compiles in
+    /// that closure as well; it is not a second measurement of this answer. Eight is enough
+    /// for this particular claim on its own terms — the legs span both supported majors, and
+    /// an option member's position in its column's option set is a property of the artifact's
+    /// System package, not of the deployment target.</para>
     /// </summary>
     private const string AlDefaultDataClassification = "CustomerContent";
 

--- a/AlRunner/Patches/RecordPatches.TableMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.TableMetadataVirtualTable.cs
@@ -86,10 +86,12 @@ public static partial class RecordPatches
     /// resolved — which is reported, never silent).
     /// </summary>
     /// <param name="TableTypeName">The declared <c>TableType</c> as written, or null for a table
-    /// declaring none (AL's default, <c>Normal</c>). Resolved to the column's own option ordinal
-    /// at row-build time, never to a hardcoded number — see <see cref="EnsureOptionOrdinals"/>.</param>
-    /// <param name="DataClassificationName">Same, for <c>DataClassification</c>; null means AL's
-    /// default <c>CustomerContent</c>.</param>
+    /// declaring none (AL's default, <c>Normal</c> — see <see cref="AlDefaultTableType"/>).
+    /// Resolved to the column's own option ordinal at row-build time, never to a hardcoded
+    /// number — see <see cref="EnsureOptionOrdinals"/>.</param>
+    /// <param name="DataClassificationName">Same, for <c>DataClassification</c>; null means the
+    /// default a real service tier was measured to report, <c>CustomerContent</c> — see
+    /// <see cref="AlDefaultDataClassification"/>, which cites the measurement.</param>
     /// <param name="ExternalName">The declared <c>ExternalName</c>, or null for a table declaring
     /// none — which the column reports as blank.</param>
     private sealed record TableMetadataRow(
@@ -151,23 +153,30 @@ public static partial class RecordPatches
     {
         object? Text(string s) => _aovNavTextCreateTruncated!.Invoke(null, new object?[] { field.FieldDefinedLength, s ?? string.Empty });
 
-        // An option column answered from the DECLARED member name, resolved against this
-        // field's own option set. A table declaring nothing gets ordinal 0, which is what AL's
-        // own default is for both option columns here (TableType = Normal,
-        // DataClassification = CustomerContent) — so the fallback states the truth rather than
-        // hiding a miss. A declared name the option set does not list is a genuine shape
-        // mismatch and is refused, not defaulted: answering 0 there would say "Normal" about a
-        // table that declared something else, the exact silent-default this change removes.
-        object? Option(string? declaredName)
-        {
-            var ordinals = EnsureOptionOrdinals(field);
-            if (string.IsNullOrWhiteSpace(declaredName)) return _aovNavOptionCreate!.Invoke(null, new object?[] { field.FieldOptionMetadata, 0 });
-            if (ordinals.TryGetValue(NormalizeObjectTypeName(declaredName), out var ordinal))
-                return _aovNavOptionCreate!.Invoke(null, new object?[] { field.FieldOptionMetadata, ordinal });
-            throw TableMetadataShapeGap(
-                $"table {row.Id} declares {field.FieldName} = '{declaredName}', which is not a member of "
-                + $"that column's own option set ('{field.FieldOptionMetadata?.OptionString}')");
-        }
+        // An option column answered from a member NAME resolved against this field's own option
+        // set — the declared one when the table states the property, and AL's own default for
+        // that property when it does not. A declared name the option set does not list is a
+        // genuine shape mismatch and is refused, not defaulted: answering 0 there would say
+        // "Normal" about a table that declared something else, the exact silent-default #2938
+        // removed.
+        //
+        // THE UNDECLARED CASE USED TO HARDCODE ORDINAL 0, and that was a smaller version of the
+        // same bug (#3019). Both defaults happen to sit at 0 in every artifact measured so far,
+        // so the answer was right; the ROUTE was not. This file already refuses to write option
+        // ordinals down — see EnsureOptionOrdinals, where TableType puts Temporary at 6 and NOT
+        // the 5 a reading of AL's documented enum suggests — and the undeclared branch was the
+        // one place still asserting a position instead of asking for one. Naming the member and
+        // looking it up means a reordered option set moves the fallback with it, and an artifact
+        // whose option set does not carry the default member at all is refused rather than
+        // silently answered with whichever member happens to be first.
+        object? Option(string? declaredName, string alDefaultMemberName)
+            => _aovNavOptionCreate!.Invoke(null, new object?[]
+            {
+                field.FieldOptionMetadata,
+                ResolveOptionMemberOrdinal(
+                    EnsureOptionOrdinals(field), field.FieldName ?? string.Empty,
+                    field.FieldOptionMetadata?.OptionString, declaredName, alDefaultMemberName, row.Id)
+            });
 
         switch (NormalizeObjectTypeName(field.FieldName ?? string.Empty))
         {
@@ -196,15 +205,40 @@ public static partial class RecordPatches
                 // is the only thing the symbol path recorded before TableTypeName existed; it is
                 // consulted only when no name was captured, so a v29-era cached ParsedTable
                 // still reports Temporary rather than silently reading Normal.
-                return Option(row.TableTypeName ?? (row.IsTemporary ? "Temporary" : null));
+                return Option(row.TableTypeName ?? (row.IsTemporary ? "Temporary" : null), AlDefaultTableType);
             case "dataclassification":
-                return Option(row.DataClassificationName);
+                return Option(row.DataClassificationName, AlDefaultDataClassification);
             case "externalname":
                 return Text(row.ExternalName ?? string.Empty);
             default:
                 return _aovGetDefaultNavValue!.Invoke(null, new object?[] { field, false });
         }
     }
+
+    /// <summary>
+    /// AL's default <c>TableType</c> for a table that declares none, as a MEMBER NAME resolved
+    /// against the column's own option set at row-build time. Pinned upstream by
+    /// <c>Record_TableMetadata_Get_DeclaredTable_ReturnsMatchingRow</c> in the al-language
+    /// corpus, which asserts <c>Normal</c> for a fixture declaring no <c>TableType</c> and is
+    /// green on a real BC service tier.
+    /// </summary>
+    private const string AlDefaultTableType = "Normal";
+
+    /// <summary>
+    /// AL's default <c>DataClassification</c> for a table that declares none, same treatment.
+    /// <para>MEASURED, not reasoned about (#3019). Microsoft's DataClassification documentation
+    /// describes the default as <c>ToBeClassified</c>, which is the SECOND member of this
+    /// column's option set, so "the default" and "the first member" were two different answers
+    /// and this code had picked one of them by reading the option string rather than by asking
+    /// anything. The corpus fixture <c>ALT Unclassified</c> (60837) declares no
+    /// <c>DataClassification</c>, and
+    /// <c>Record_TableMetadata_Get_TableDeclaringNoDataClassification_ReportsTheDefault</c> in
+    /// StefanMaron/BusinessCentral.AL.Language.Tests#191 asserts <c>CustomerContent</c> for it.
+    /// That PR came back green on all sixteen legs — BC 27.0, 27.3, 27.5, 28.0, 28.1, 28.2,
+    /// 28.3 and 28.4, Cloud and OnPrem — so a real service tier reports <c>CustomerContent</c>
+    /// and the documented <c>ToBeClassified</c> is not what a Table Metadata row carries.</para>
+    /// </summary>
+    private const string AlDefaultDataClassification = "CustomerContent";
 
     // One ordinal map per option COLUMN of this metatable, keyed by the field name. Two columns
     // need one here (TableType, DataClassification), and the metatable is built once per run.
@@ -232,19 +266,70 @@ public static partial class RecordPatches
         {
             var optionMetadata = field.FieldOptionMetadata
                 ?? throw TableMetadataShapeGap($"\"{fieldName}\" carries no option metadata");
-
-            var map = new Dictionary<string, int>(StringComparer.Ordinal);
-            var parts = (optionMetadata.OptionString ?? string.Empty).Split(',');
-            for (int i = 0; i < parts.Length; i++)
-            {
-                var key = NormalizeObjectTypeName(parts[i]);
-                if (key.Length == 0) continue;
-                map.TryAdd(key, i);
-            }
-            if (map.Count == 0)
-                throw TableMetadataShapeGap($"\"{fieldName}\" option string is empty");
-            return map;
+            return ParseOptionOrdinals(fieldName, optionMetadata.OptionString);
         });
+    }
+
+    /// <summary>
+    /// The member-name-to-ordinal map of one option string, positional and normalized the same
+    /// way every lookup against it is. Separate from <see cref="EnsureOptionOrdinals"/> only so
+    /// a test can hand it an option string; the cache and the metatable read stay there.
+    /// </summary>
+    internal static Dictionary<string, int> ParseOptionOrdinals(string fieldName, string? optionString)
+    {
+        var map = new Dictionary<string, int>(StringComparer.Ordinal);
+        var parts = (optionString ?? string.Empty).Split(',');
+        for (int i = 0; i < parts.Length; i++)
+        {
+            var key = NormalizeObjectTypeName(parts[i]);
+            if (key.Length == 0) continue;
+            map.TryAdd(key, i);
+        }
+        if (map.Count == 0)
+            throw TableMetadataShapeGap($"\"{fieldName}\" option string is empty");
+        return map;
+    }
+
+    /// <summary>
+    /// Resolve one option column's value to an ordinal in that column's OWN option set, from a
+    /// member NAME in every case — the declared one when the table states the property, and
+    /// <paramref name="alDefaultMemberName"/> when it does not. Both misses are refused rather
+    /// than defaulted.
+    /// <para>Split out of <c>BuildTableMetadataValue</c>'s local <c>Option</c> so the resolution
+    /// can be exercised against an option string the caller chooses; the row-build path holds
+    /// live BC metatable objects that a unit test cannot construct. Its behaviour on a
+    /// REORDERED option set is the whole point (#3019) and is what
+    /// <c>TableMetadataOptionDefaultOrdinalTests</c> pins.</para>
+    /// </summary>
+    /// <param name="ordinals">Member name (normalized) to ordinal, from
+    /// <see cref="EnsureOptionOrdinals"/> or <see cref="ParseOptionOrdinals"/>.</param>
+    /// <param name="fieldName">The column, for the refusal message.</param>
+    /// <param name="optionString">The column's own option string, for the refusal message.</param>
+    /// <param name="declaredName">What the table declares, or null/blank when it declares nothing.</param>
+    /// <param name="alDefaultMemberName">The member a table declaring nothing reports.</param>
+    /// <param name="tableId">The table, for the refusal message.</param>
+    internal static int ResolveOptionMemberOrdinal(
+        IReadOnlyDictionary<string, int> ordinals, string fieldName, string? optionString,
+        string? declaredName, string alDefaultMemberName, int tableId)
+    {
+        if (string.IsNullOrWhiteSpace(declaredName))
+        {
+            // The undeclared branch. It used to return a literal 0 and be right by coincidence:
+            // both defaults this file needs sit first in their column's option set today. A
+            // reordered set would have moved the member without moving the answer, which is the
+            // failure EnsureOptionOrdinals exists to prevent for DECLARED values (#3019).
+            if (ordinals.TryGetValue(NormalizeObjectTypeName(alDefaultMemberName), out var defaultOrdinal))
+                return defaultOrdinal;
+            throw TableMetadataShapeGap(
+                $"table {tableId} declares no {fieldName}, and the default for it "
+                + $"('{alDefaultMemberName}') is not a member of that column's own option set "
+                + $"('{optionString}')");
+        }
+        if (ordinals.TryGetValue(NormalizeObjectTypeName(declaredName), out var ordinal))
+            return ordinal;
+        throw TableMetadataShapeGap(
+            $"table {tableId} declares {fieldName} = '{declaredName}', which is not a member of "
+            + $"that column's own option set ('{optionString}')");
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #3019

## The verdict

A real BC service tier reports **`CustomerContent`** in `Table Metadata`'s `DataClassification`
column for a table that declares no `DataClassification`. Microsoft's documentation describes the
default as `ToBeClassified`, which is the **second** member of that column's option set, so the
two were genuinely different answers.

Measured, not reasoned about. Corpus fixture `ALT Unclassified` (60837) and
`Record_TableMetadata_Get_TableDeclaringNoDataClassification_ReportsTheDefault` went up as
[BusinessCentral.AL.Language.Tests#191](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/191)
and ran, and passed, on the **eight Cloud legs** of run `34026600861` — BC 27.0, 27.3, 27.5,
28.0, 28.1, 28.2, 28.3 and 28.4. **No difference across majors.** The BC 27.0 leg ran 2646 tests,
2646 passed, so the caveat in the issue about 27.x evaluating zero tests is stale — corpus issue
#180 fixed that this morning, and the question got a full eight-leg answer.

**Eight, not sixteen.** That run has eight further OnPrem legs and they are green too, but they
build a *different app* — `tests/al-language-onprem`, codeunits 61200 and 61201, 19 tests on the
28.1 leg — and codeunit 60801 does not appear in their logs at all. Their green establishes that
the fixture **compiles** in that closure; it is not a second measurement of the answer. Eight is
enough for this claim on its own terms: the legs span both supported majors, and an option
member's position in its column's option set is a property of the artifact's System package, not of
the deployment target. (The four code comments carrying the stronger reading are corrected in
`3fdcd908`; overstating a measurement in a comment is the exact defect this PR exists to fix.)

So the runner's answer was already right. **This PR changes no observable value on any artifact
measured so far.**

## What it does change: the route

The undeclared branch returned a hardcoded ordinal `0`, and was right only because both defaults
this file needs happen to sit first in their column's option set:

```csharp
if (string.IsNullOrWhiteSpace(declaredName))
    return _aovNavOptionCreate!.Invoke(null, new object?[] { field.FieldOptionMetadata, 0 });
```

That is the same shape as the bug #2938 fixed for *declared* values, in the one file that already
argues at length against writing option ordinals down — `EnsureOptionOrdinals`' own doc comment
notes that `Temporary` is **6** in BC 28.1's `TableType` set, not the 5 a reading of AL's
documented enum suggests. The undeclared branch was the last place still asserting a position
instead of asking for one.

It now names the default member and looks it up through the same map, so a reordered option set
moves the fallback with it, and an artifact whose column does not carry the default member at all
is **refused** rather than silently answered with whichever member happens to be first.

The two AL defaults are now named constants that cite what settled them:
`AlDefaultTableType = "Normal"` (pinned upstream by the existing 60801 test) and
`AlDefaultDataClassification = "CustomerContent"` (pinned by corpus #191).

## RED → GREEN

`AlRunner.Tests/TableMetadataOptionDefaultOrdinalTests.cs`, 6 tests. `BuildTableMetadataValue`
holds live BC metatable objects a unit test cannot construct, so the resolution was split into
`ResolveOptionMemberOrdinal` / `ParseOptionOrdinals`, which take an option string the test chooses.

- **RED** — with the pre-#3019 `return 0` put back in place, **3 of the 6 fail**:
  `UndeclaredDataClassification_...` (`Expected: 3, Actual: 0`),
  `UndeclaredTableType_...` (`Expected: 2, Actual: 0`), and
  `UndeclaredValue_DefaultMemberAbsentFromTheOptionSet_IsRefusedNotDefaulted`, which got a value
  where it expected a refusal.
- **GREEN** — 6/6 with the change.

Every undeclared case is asserted at **two or three different ordinals for the same member name**,
which is exactly what a `return 0` cannot satisfy. The declared path is asserted alongside it
(`SystemMetadata` = 6, `ToBeClassified` = 1, `Temporary` = 6) so a refactor of the now-shared
resolver cannot break it silently, and both refusals are asserted on their message text **and** on
the `not-yet-implemented` reason anchor that decides whether an AL `[TryFunction]` traps them.

The refactored branch is *also* already exercised end-to-end on every leg of this repo's own
matrix at the **current** pin, which neither the review nor I spotted at first:
`Record_TableMetadata_Get_DeclaredTable_ReturnsMatchingRow` (codeunit 60801) asserts
`TableType::Normal` for `ALT Relation Parent` — **a fixture that declares no `TableType`** — so it
drives the rewritten undeclared branch through a live `NCLMetaTable` and that artifact's real
`OptionString`. The same codeunit asserts `DataClassification::CustomerContent` through the
*declared* path, which establishes per leg that the member this PR's default names is present in
that artifact's option set at all — the precondition the new refusal tests for.

This is a runner-mechanism test, not a second copy of the BC claim: no AL assertion can see a
reordered option set, because AL can only observe the artifact it is running on.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — one, in the same `Option` local, and it is
   fixed here: `TableType`'s undeclared branch shared the identical hardcoded `0`. It is covered
   by its own assertions above.
2. **Sibling functions making the same assumption?** `RecordPatches.PageMetadataVirtualTable.cs`
   (`PageType`) and `RecordPatches.CodeunitMetadataVirtualTable.cs` (`Subtype`) resolve their one
   option column the same way and are **deliberately left alone**: they do not hardcode an ordinal
   at all, they fall through to `GetDefaultNavValue`. That is a real difference in invariant from
   this file, which *refuses* an unrecognised member — but which of the two is right is a separate
   question with no measurement behind it either way, and answering it by guessing is the failure
   this issue was about. Filed as a follow-up rather than fixed silently: **#3080**.
3. **Two paths writing the same state, one guard apart?** Both `ParsedTable` producers were
   checked. `RecordPatches.AlSourceParser.cs` (source-compiled tables) and
   `AlRunner/Patches/BcAppSymbolCache.cs` (precompiled dependencies) both record `null` for an
   undeclared `DataClassification` and leave the defaulting to the row builder, so they agree and
   there is one place to be right. Nothing to fix.

**Four comment sites** stated the `CustomerContent` default as a fact about AL, none of them
citing anything. All four now cite the measurement:
`RecordPatches.TableMetadataVirtualTable.cs` (the `Option` block and the `TableMetadataRow` doc),
`RecordPatches.AlSourceParser.cs`, and `AlRunner.Tests/BcAppSymbolCacheTableMetadataPropertiesTests.cs`.

## Counts, re-derived

Re-measured from `Microsoft_Base Application_28.1.49838.53910.app` rather than taken from the
issue. The flat-read trap is real: `SymbolReference.json` reports **12** tables at the top level
and **1523** once `Namespaces` is walked recursively. Of those 1523:

| `DataClassification` | tables |
|---|---|
| `CustomerContent` (declared) | 1447 |
| `SystemMetadata` (declared) | 61 |
| `OrganizationIdentifiableInformation` (declared) | 2 |
| **declared nothing** | **13** |

The issue says "61 explicit other"; it is **63** (61 + 2). The existing count in
`BcAppSymbolCache.cs` was already right and is unchanged. The 13 that declare nothing — the whole
blast radius in Base Application today — are 53 `Accounting Period Buffer`, 142 `Dispute Status`,
213 `Alt. Cust. VAT Reg.`, 502/503/504 the three Reminder text tables, 1366 `Field Monitoring
Setup`, 5808 `Cost Adjustment Parameter`, 5812 `Item Application Trace`, 5817/5819 the Matched
Order Line pair, 5825 `Undo Sales Shpt. Line Params` and 6315 `Power BI Filter`. All were already
being reported as `CustomerContent`, and still are.

## Tests run

- `dotnet test AlRunner.Tests --filter` over `TableMetadataOptionDefaultOrdinalTests`,
  `VirtualTableRefusalClaimTests`, `BcAppSymbolCacheTableMetadataPropertiesTests` and
  `CodeunitMetadataVirtualTableTests` — **95 passed, 0 failed**.
- The corpus `Table Metadata` suite (codeunit 60801) against the **corpus branch behind #191** —
  12/12 pass, including the new upstream test.
- The corpus `--test Metadata` selection at the **current pin** — 34/34 pass.

The refusal-count guard in `VirtualTableRefusalClaimTests` moved 67 → 68 with the reason recorded
next to it; the declared and undeclared misses are deliberately two sites, because "this table
declared something the column does not list" and "this artifact's column does not list the
default" point at different causes.

## Deliberately left out

- **No submodule pin bump**, and the reason is the general rule rather than convenience. A bump
  is folded into a fix PR when the newly-pulled-in tests are **red without the fix** — that is
  what makes the bump the proving artifact, and it is the shape `al-language-submodule.md` and
  `bc-behavior-tests-go-upstream.md` both describe. Corpus #191's test is **green without this
  change**, because the runner already answered `CustomerContent`; a bump here would prove
  nothing, and would additionally drag in ten unrelated corpus commits and their red risk.
  (#3067's bump *is* red by construction, which is why it carries one and this does not.)
  **#3079 already bumps `0309cec` → `3268bf1b`**, the merge commit of corpus #191, so #191
  reaches this repo's CI regardless of merge order — there is nothing left for this PR to carry.
- **The `PageType` / `Subtype` invariant mismatch** — #3080, above.

---

Written by an automated agent (`stma-auto-1`) acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
