### PR TITLE
fix(test-exec): run test codeunits in ascending object ID instead of Assembly.GetTypes() order

### DIFF
--- a/AlRunner.Tests/AlObjectEmitOrderDeterminismTests.cs
+++ b/AlRunner.Tests/AlObjectEmitOrderDeterminismTests.cs
@@ -23,9 +23,25 @@
 // served the same wrongly-ordered assembly out of one cache entry.
 //
 // The file names here are deliberately anti-correlated with the object IDs: Alpha.Codeunit.al
-// declares the HIGHER id (62242) and Zeta.Codeunit.al the lower (62241). So a fix that
-// accidentally sorted by object id, or one that left creation order in place, produces a
-// different answer than the one asserted — the test cannot pass by coincidence.
+// declares the HIGHER id (62242) and Zeta.Codeunit.al the lower (62241). So creation order,
+// file-name order and object-id order are three different answers here, and the test cannot
+// pass by coincidence whichever one the runner implements.
+//
+// #2801 UPDATE — the expected order changed, the claim did not. This file used to assert that
+// the answer was ordinal FILE order. That was the right observation about #2872's fix and the
+// wrong contract: sorting the compiler's inputs does not pin the output, because
+// Assembly.GetTypes() has no defined order either. Measured against a three-codeunit fixture
+// whose ordinal file order is 62295, 62290, 62285, GetTypes() returned 62295, 62285, 62290 —
+// neither file order nor id order — and on CI run 34016494342 the SuiteAbortOnTimeoutTests
+// fixture flipped again on a build that already carried #2872's sort. TestExecutor now orders
+// test codeunits by ascending AL object ID, which is the order a real BC test suite runs
+// (TestSuiteMgt.GetTestMethods walks the codeunit inventory in primary-key order; see
+// TestCodeunitExecutionOrderTests for the full citation). So the expectation below is
+// 62241 before 62242.
+//
+// What this file proves is unchanged and is now stronger: identical AL content must run in one
+// order regardless of how the files were created — and, since that order is no longer derived
+// from the file names, regardless of what they are called.
 using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -145,8 +161,8 @@ public sealed class AlObjectEmitOrderDeterminismTests : IDisposable
 
     /// <summary>
     /// Positive: identical AL content, opposite file-creation order, one execution order —
-    /// and it is the ordinal order of the source file paths (Alpha before Zeta), not the
-    /// order the files were created in and not the order of the object ids.
+    /// and it is ascending AL object ID (Zeta's 62241 before Alpha's 62242), not the order the
+    /// files were created in and not the ordinal order of their names (#2801).
     /// </summary>
     [SkippableFact]
     public void SameSources_DifferentFileCreationOrder_RunInTheSameOrder()
@@ -169,10 +185,10 @@ public sealed class AlObjectEmitOrderDeterminismTests : IDisposable
         Assert.Equal(2, orderA.Count);
         Assert.Equal(2, orderB.Count);
 
-        var expected = new[] { "Codeunit62242.AlphaOnly", "Codeunit62241.ZetaOnly" };
+        var expected = new[] { "Codeunit62241.ZetaOnly", "Codeunit62242.AlphaOnly" };
         Assert.True(orderA.SequenceEqual(expected),
-            "the bundle whose Zeta.Codeunit.al was created FIRST must still run Alpha's codeunit "
-            + "first — source-path ordinal order, not creation order. Got: ["
+            "the bundle whose Zeta.Codeunit.al was created FIRST must run codeunit 62241 before "
+            + "62242 — ascending object id, not creation order and not file-name order. Got: ["
             + string.Join(", ", orderA) + "]\n--- runner output ---\n" + outA);
         Assert.True(orderB.SequenceEqual(expected),
             "the bundle whose Alpha.Codeunit.al was created FIRST must run in the same order as "

--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -168,6 +168,30 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
             // UnmeasuredWeightSeconds, which is the single-threaded tail #1887 exists to
             // prevent.
             ["BcVersionDefaultDocumentationTests"] = 62,
+            // #2801/#3082: this PR's own new collection. Measured 60.1s on the BC 28.4 leg
+            // of run 34028084404, where it was absent from this table and tripped
+            // check-collection-weights.py; every other leg of that run stayed under 60s,
+            // since the gate lists any absent collection at or above the threshold and
+            // named no other leg. Same straddling shape as the two entries above, so the
+            // observed MAXIMUM is what goes in rather than a rounded-down low end.
+            ["TestCodeunitExecutionOrderTests"] = 60,
+            // #2801/#3083: NOT introduced by the PR that tripped on it — this collection is
+            // untouched by #3083, and it failed there only because its wall time crossed the
+            // threshold on that leg. Measured 63.7s on the BC 27.5 leg of run 34030851146,
+            // while staying under 60s on every leg of run 34028084404 (#3082), which is a
+            // measured straddle rather than an inferred one: two independent runs of the
+            // same untouched collection landed on opposite sides of the line. Carries the
+            // observed MAXIMUM for the same reason as the entries above. Added here rather
+            // than on #3083 because #3082 is the PR that changes this suite's dispatch
+            // behaviour anyway.
+            //
+            // The threshold is 2x UnmeasuredWeightSeconds = 60s of summed wall time on a
+            // shared GitHub runner, so a collection sitting near it makes a REQUIRED check
+            // depend on how loaded the runner was. That put an unrelated red on two PRs in
+            // one batch. Adding these two entries fixes today; the shape recurs with the
+            // next collection that lands near 60s, and that is tracked separately rather
+            // than papered over here.
+            ["SuiteAbortOnTimeoutTests"] = 63,
             // #2178: 3 tests, each spawning a real runner subprocess over a three-app source
             // chain (two of them compile all three apps cold). Measured 53.3s (28.3) to
             // 90.5s (27.5) across the eight legs of its first CI run, where it was absent

--- a/AlRunner.Tests/TestCodeunitExecutionOrderTests.cs
+++ b/AlRunner.Tests/TestCodeunitExecutionOrderTests.cs
@@ -1,0 +1,287 @@
+// TestCodeunitExecutionOrderTests — the runner must execute test codeunits in a defined
+// order (#2801), and that order is ascending AL object ID.
+//
+// WHY THERE IS AN ORDER AT ALL. `TestExecutor.Run` took `assembly.GetTypes()` and walked it
+// directly. .NET makes no promise about that array's order, so the runner's test-execution
+// order was whatever BC's AL compiler happened to lay the types out as. On 2026-09-06 that
+// order came out reversed on one CI leg (run 34016494342, BC 28.4.53241.54318): the two
+// codeunits of the `SuiteAbortOnTimeoutTests` resume fixture ran Second-then-First, so the
+// fixture's hang landed LAST, nothing was left for the watchdog abort to abandon, no resume
+// was triggered, and three tests failed. The same commit's 27.5 leg ran the identical suite
+// and passed. It was read as a watchdog that fired too late; the log shows the watchdog fired
+// and the suite aborted exactly as designed. The order was the whole defect.
+//
+// WHY ASCENDING OBJECT ID, rather than name order or file order. This is Microsoft's order,
+// not a preference. In the shipped Test Runner app (`Microsoft_Test Runner.app`,
+// `src/src/TestSuiteMgt.Codeunit.al`), `GetTestMethods` iterates the codeunit inventory with
+// a bare `FindSet()`/`Next()` and NO `SetCurrentKey`, so it walks primary-key order, handing
+// each row to `AddTestMethod` with a monotonically increasing `Line No.`:
+//
+//     if CodeunitMetadata.FindSet() then
+//         repeat
+//             TestLineNo := GetLastTestLineNo(ALTestSuite) + 10000;
+//             AddTestMethod(CodeunitMetadata, ALTestSuite, TestLineNo);
+//         until CodeunitMetadata.Next() = 0;
+//
+// `AddTestMethod` stores `TestMethodLine."Test Codeunit" := CodeunitMetadata.ID`, and every
+// consumer then reads the lines back with `SetCurrentKey("Line No."); Ascending(true)`. The
+// pre-CLEAN27 overload does the same over `AllObjWithCaption`, whose primary key is
+// ("Object Type", "Object ID"). Both inventories are keyed on the object ID, so a BC test
+// suite runs its codeunits in ascending object ID.
+//
+// WHAT THIS TEST PROVES, and why it cannot pass by luck. The fixture names its files so that
+// ordinal FILE order is the exact REVERSE of object-ID order — Aardvark=62295, Middle=62290,
+// Zulu=62285. File order is what reaches the AL compiler (SafeDirectoryScan.Files sorts
+// ordinally, #2892), so an implementation that does not reorder produces DESCENDING ids here,
+// deterministically. The assertions below are written as the RULE ("the ids that ran are in
+// ascending order"), not as a hardcoded sequence that an unsorted implementation might satisfy
+// on a lucky day.
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestCodeunitExecutionOrderTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    /// <summary>`PASS  Codeunit62290.MidDeclaredFirst (0ms)` -> ("62290", "MidDeclaredFirst").</summary>
+    private static readonly Regex RanLine = new(
+        @"^\s*PASS\s+Codeunit(?<id>\d+)\.(?<method>\w+)\s", RegexOptions.Compiled | RegexOptions.Multiline);
+
+    private readonly string _root;
+
+    public TestCodeunitExecutionOrderTests()
+    {
+        _root = TestScratch.Dir("al-runner-codeunit-order");
+        Directory.CreateDirectory(_root);
+        WriteFixture(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    /// <summary>
+    /// Three codeunits whose FILE name order is the reverse of their OBJECT ID order, so
+    /// "did the runner reorder anything?" has a visible answer. Each declares two [Test]
+    /// procedures whose declaration order is the reverse of their alphabetical order, which
+    /// is how the method-level guarantee below stays distinguishable from a blanket sort.
+    /// </summary>
+    private static void WriteFixture(string dir)
+    {
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "b7c8d9e0-f1a2-3456-7890-abcdef123456",
+          "name": "Codeunit Execution Order Fixture",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": 62280, "to": 62299 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        // Sorts FIRST by file name, highest object ID.
+        File.WriteAllText(Path.Combine(dir, "Aardvark.Codeunit.al"), """
+        codeunit 62295 "Order Probe High"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure ZetaDeclaredFirst()
+            begin
+            end;
+
+            [Test]
+            procedure AlphaDeclaredSecond()
+            begin
+            end;
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(dir, "Middle.Codeunit.al"), """
+        codeunit 62290 "Order Probe Mid"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure ZetaDeclaredFirst()
+            begin
+            end;
+
+            [Test]
+            procedure AlphaDeclaredSecond()
+            begin
+            end;
+        }
+        """);
+
+        // Sorts LAST by file name, lowest object ID.
+        File.WriteAllText(Path.Combine(dir, "Zulu.Codeunit.al"), """
+        codeunit 62285 "Order Probe Low"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure ZetaDeclaredFirst()
+            begin
+            end;
+
+            [Test]
+            procedure AlphaDeclaredSecond()
+            begin
+            end;
+        }
+        """);
+    }
+
+    /// <summary>
+    /// Positive, and the claim of the whole file: the codeunits ran in ascending object ID.
+    ///
+    /// Stated as the rule — the observed id sequence equals its own ascending sort — so it
+    /// says what the contract is rather than restating one sequence. The fixture makes it
+    /// unsatisfiable by an implementation that does not reorder: file order is the reverse
+    /// of id order, so leaving `assembly.GetTypes()` alone yields 62295, 62290, 62285.
+    /// </summary>
+    [SkippableFact]
+    public void TestCodeunits_RunInAscendingObjectIdOrder_NotFileOrder()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, exit) = RunRunner(_root);
+        Assert.Equal(0, exit);
+
+        var ids = CodeunitIdsInExecutionOrder(output);
+        Assert.Equal(new[] { 62285, 62290, 62295 }, ids);
+        Assert.True(ids.SequenceEqual(ids.OrderBy(x => x)),
+            "test codeunits must execute in ascending AL object ID (BC's own suite order — see "
+            + "TestSuiteMgt.Codeunit.al). Got: [" + string.Join(", ", ids) + "]. The fixture's FILE "
+            + "order is the reverse of its id order, so a descending result means nothing reordered "
+            + "the types and the runner is still executing in Assembly.GetTypes() order."
+            + "\n--- runner output ---\n" + output);
+    }
+
+    /// <summary>
+    /// Negative — ordering must not change WHAT runs. A sort that dropped a codeunit, or
+    /// duplicated one, would still be "ascending" and would still pass the test above.
+    /// Six tests, three codeunits, two per codeunit, every one of them passing.
+    /// </summary>
+    [SkippableFact]
+    public void Ordering_DoesNotChangeWhichTestsRun()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, exit) = RunRunner(_root);
+        Assert.Equal(0, exit);
+
+        var ran = RanInExecutionOrder(output);
+        Assert.Equal(6, ran.Count);
+        Assert.Equal(6, ran.Distinct().Count());
+        Assert.Equal(
+            new[]
+            {
+                "62285.AlphaDeclaredSecond", "62285.ZetaDeclaredFirst",
+                "62290.AlphaDeclaredSecond", "62290.ZetaDeclaredFirst",
+                "62295.AlphaDeclaredSecond", "62295.ZetaDeclaredFirst",
+            },
+            ran.OrderBy(x => x, StringComparer.Ordinal).ToArray());
+        Assert.Contains("pass:        6", output);
+    }
+
+    /// <summary>
+    /// Negative — the fix must order CODEUNITS only. Methods inside a codeunit keep their
+    /// source-declaration order, which `OrderTestMethodsBySourceDeclaration` has guaranteed
+    /// since before this change. Each codeunit declares `ZetaDeclaredFirst` before
+    /// `AlphaDeclaredSecond`, so a blanket alphabetical or id-derived sort that reached the
+    /// method level would invert every pair here and fail.
+    /// </summary>
+    [SkippableFact]
+    public void MethodsWithinACodeunit_KeepSourceDeclarationOrder()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, exit) = RunRunner(_root);
+        Assert.Equal(0, exit);
+
+        var ran = RanInExecutionOrder(output);
+        Assert.Equal(
+            new[]
+            {
+                "62285.ZetaDeclaredFirst", "62285.AlphaDeclaredSecond",
+                "62290.ZetaDeclaredFirst", "62290.AlphaDeclaredSecond",
+                "62295.ZetaDeclaredFirst", "62295.AlphaDeclaredSecond",
+            },
+            ran);
+    }
+
+    /// <summary>
+    /// The order is a property of the runner, not of one lucky process. Three separate runner
+    /// processes, each with its own cold cache directory, must all produce the same sequence —
+    /// which is the actual defect #2801 describes (a sequence that changed between processes on
+    /// the same commit and the same BC build).
+    /// </summary>
+    [SkippableFact]
+    public void ExecutionOrder_IsStableAcrossProcesses()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var sequences = new List<string>();
+        for (var i = 0; i < 3; i++)
+        {
+            var cache = Path.Combine(_root, "..", $"cache-{Guid.NewGuid():N}");
+            var (output, exit) = RunRunner(_root, $"--cache \"{Path.GetFullPath(cache)}\"");
+            Assert.Equal(0, exit);
+            sequences.Add(string.Join(",", RanInExecutionOrder(output)));
+            try { Directory.Delete(Path.GetFullPath(cache), recursive: true); } catch { }
+        }
+
+        Assert.Single(sequences.Distinct());
+        Assert.StartsWith("62285.", sequences[0], StringComparison.Ordinal);
+    }
+
+    private static List<int> CodeunitIdsInExecutionOrder(string output)
+    {
+        var ids = new List<int>();
+        foreach (Match m in RanLine.Matches(output))
+        {
+            var id = int.Parse(m.Groups["id"].Value);
+            if (ids.Count == 0 || ids[^1] != id) ids.Add(id);
+        }
+        return ids;
+    }
+
+    private static List<string> RanInExecutionOrder(string output) =>
+        RanLine.Matches(output)
+            .Select(m => $"{m.Groups["id"].Value}.{m.Groups["method"].Value}")
+            .ToList();
+
+    private (string output, int exit) RunRunner(string bundle, params string[] extraArgs)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" \"{bundle}\"");
+        foreach (var a in extraArgs) args.Append($" {a}");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(300_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+}

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -407,6 +407,9 @@ public sealed class TestExecutor
                 Console.Error.WriteLine($"    {r}");
         }
         typeSw.Stop();
+        // #2801: Assembly.GetTypes() has no defined order, and this loop's order IS the
+        // test-execution order. Pin it before anything reads `types`.
+        types = OrderTestCodeunitsByObjectId(types);
         PerfTrace.Log($"TestExecutor.GetTypes {types.Length} type(s) {typeSw.ElapsedMilliseconds}ms");
         // #1861: reflecting over the freshly-loaded module's types is one of the issue's
         // named candidates for the flat per-app-group tax. Marked directly (not via
@@ -909,7 +912,13 @@ public sealed class TestExecutor
     {
         var filter = NormaliseFilter(TestFilter);
         var tests = new List<string>();
-        foreach (var t in assembly.GetTypes())
+        // #2801: the same unordered Assembly.GetTypes() walk Run() had. Discovery must report
+        // the order execution will actually use, or "the tests in this bundle" is a different
+        // list from "the order they run in". Today's only caller (--server's runtests handler)
+        // puts the result straight into a HashSet, so this changes nothing observable yet; it
+        // is here so a later order-sensitive consumer inherits the guarantee rather than
+        // rediscovering that discovery never had one.
+        foreach (var t in OrderTestCodeunitsByObjectId(assembly.GetTypes()))
         {
             if (!IsTestCodeunit(t)) continue;
             if (filter != null && !CodeunitMatchesFilter(t, filter)) continue;
@@ -1053,6 +1062,93 @@ public sealed class TestExecutor
     /// whose scope type or span attribute can't be found — never worse than the previous
     /// (pure-reflection) behaviour, only ever more faithful to real BC.
     /// </summary>
+    /// <summary>
+    /// Order a freshly-loaded test assembly's types by ascending AL object ID — the order a
+    /// real BC test suite runs its codeunits in (#2801).
+    ///
+    /// <para><b>Why this exists.</b> <see cref="Run"/> and <see cref="DiscoverTests"/> both
+    /// walk <c>Assembly.GetTypes()</c>, and the CLR does not define that array's order. It is
+    /// therefore whatever BC's AL compiler laid the TypeDefs out as, which is not stable: on
+    /// CI run 34016494342 (BC 28.4.53241.54318) the two codeunits of the
+    /// <c>SuiteAbortOnTimeoutTests</c> resume fixture executed Second-then-First, so the
+    /// fixture's hang ran LAST, the watchdog abort had nothing left to abandon, no resume was
+    /// triggered, and three tests failed — while the same commit's 27.5 leg passed. Sorting
+    /// the compiler's *input* files (#2892) does not reach this: measured against the
+    /// three-codeunit fixture in <c>TestCodeunitExecutionOrderTests</c>, whose file order is
+    /// 62295, 62290, 62285, <c>GetTypes()</c> returned 62295, 62285, 62290 — neither file
+    /// order nor id order.</para>
+    ///
+    /// <para><b>Why ascending object ID</b> rather than name or file order. It is Microsoft's
+    /// order, read out of the shipped Test Runner app rather than chosen here.
+    /// <c>TestSuiteMgt.GetTestMethods</c> walks the codeunit inventory with a bare
+    /// <c>FindSet()</c>/<c>Next()</c> and no <c>SetCurrentKey</c> — so, primary-key order —
+    /// giving each row a monotonically increasing <c>Line No.</c>, and every consumer reads
+    /// the lines back with <c>SetCurrentKey("Line No."); Ascending(true)</c>. The inventory is
+    /// <c>CodeUnit Metadata</c> (keyed on <c>ID</c>) since v27 and <c>AllObjWithCaption</c>
+    /// (keyed on "Object Type", "Object ID") before it; both are keyed on the object ID.</para>
+    ///
+    /// <para><b>Stable, and total.</b> A type whose object ID cannot be read — every
+    /// non-codeunit type in the assembly, plus BC's compiler-generated nested types — keeps
+    /// its relative <c>GetTypes()</c> position and sorts after everything that resolved. Only
+    /// test codeunits are ever executed (<c>IsTestCodeunit</c>), so this changes the order
+    /// tests run in and nothing else. Deliberately does NOT touch method order inside a
+    /// codeunit: <see cref="OrderTestMethodsBySourceDeclaration"/> already pins that to source
+    /// declaration order, which is a different rule and stays.</para>
+    /// </summary>
+    private static Type[] OrderTestCodeunitsByObjectId(Type[] types) =>
+        types
+            .Select((t, i) => (t, i, id: TryReadAlObjectId(t)))
+            .OrderBy(x => x.id ?? int.MaxValue)
+            .ThenBy(x => x.i)
+            .Select(x => x.t)
+            .ToArray();
+
+    /// <summary>
+    /// The AL object ID an emitted type carries, or null when it is not an AL object type.
+    ///
+    /// Reads BC's <c>[ApplicationObjectId]</c> through <see cref="CustomAttributeData"/>
+    /// (metadata only — materialising the attribute can throw
+    /// <c>CustomAttributeFormatException</c> on types whose IL references attribute properties
+    /// we do not carry), and falls back to the <c>Codeunit&lt;N&gt;</c> type-name shape the AL
+    /// compiler emits. Same two-step, same order, as
+    /// <c>EventSubscriberPatches.TryReadCodeunitId</c> / <c>ExtractCodeunitIdFromTypeName</c>,
+    /// which have resolved codeunit identity this way since #1794.
+    /// </summary>
+    private static int? TryReadAlObjectId(Type t) =>
+        _objectIdCache.GetOrAdd(t, static type =>
+        {
+            IList<CustomAttributeData> attrs;
+            try { attrs = CustomAttributeData.GetCustomAttributes(type); }
+            catch { attrs = Array.Empty<CustomAttributeData>(); }
+            foreach (var ad in attrs)
+            {
+                if (ad.AttributeType.Name != "ApplicationObjectIdAttribute") continue;
+                try
+                {
+                    var attr = type.GetCustomAttributes(ad.AttributeType, inherit: false).FirstOrDefault();
+                    var aoid = attr?.GetType()
+                        .GetProperty("ApplicationObjectId", BindingFlags.Public | BindingFlags.Instance)
+                        ?.GetValue(attr);
+                    var num = aoid?.GetType()
+                        .GetProperty("ObjectNumber", BindingFlags.Public | BindingFlags.Instance)
+                        ?.GetValue(aoid);
+                    if (num is int n && n != 0) return n;
+                }
+                catch { /* fall through to the name shape */ }
+                break;
+            }
+            // "Codeunit62295" -> 62295. Not a general "strip the prefix" parse: the suffix must
+            // be entirely digits, so a hand-written `CodeunitHelpers` class cannot be mistaken
+            // for object 0 and sorted to the front.
+            var name = type.Name;
+            if (name.StartsWith("Codeunit", StringComparison.Ordinal)
+                && int.TryParse(name.AsSpan("Codeunit".Length), out var id))
+                return id;
+            return null;
+        });
+
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, int?> _objectIdCache = new();
+
     private static MethodInfo[] OrderTestMethodsBySourceDeclaration(Type t) =>
         _sourceOrderCache.GetOrAdd(t, static type =>
         {


### PR DESCRIPTION
Closes #2801

`TestExecutor.Run` walked `assembly.GetTypes()` directly, and the CLR defines no order for that array. The runner's test-execution order was therefore whatever BC's AL compiler happened to lay the TypeDefs out as, and that is not stable across processes.

## What it cost

On CI run `34016494342` (job `101441420263`, BC 28.4.53241.54318) the two codeunits of the `SuiteAbortOnTimeoutTests` resume fixture executed Second-then-First. The fixture's hang therefore ran **last**, the watchdog abort had nothing left to abandon, no resume was triggered, and three tests failed. The same commit's 27.5 leg ran the identical suite and passed. That failed PR #2974's required check and blocked it.

I corrected #2801's title and body as part of this work. It asserted that the watchdog intermittently fails to fire under load. Its own log disproves that: `Test exceeded 2s timeout.` and `[test-exec] SUITE ABORTED` are both present, and `AssertHangEscalatedToAbort` checks exactly those two strings and runs *before* the assertion that failed. Anyone starting from the old premise would have widened a timeout and fixed nothing.

## Why sorting the compiler's inputs was not enough

#2892 sorted `SafeDirectoryScan.Files` ordinally and is present in the failing commit. It cannot pin the output on its own, because `Assembly.GetTypes()` is not ordered either. Measured against this PR's new three-codeunit fixture, whose ordinal **file** order is 62295, 62290, 62285, `GetTypes()` returned **62295, 62285, 62290** — neither file order nor id order. That is the RED baseline below.

## Why ascending object ID

This is Microsoft's order, read out of the shipped Test Runner app rather than chosen here. In `Microsoft_Test Runner.app`, `src/src/TestSuiteMgt.Codeunit.al`, `GetTestMethods` walks the codeunit inventory with a bare `FindSet()`/`Next()` and **no `SetCurrentKey`** — so, primary-key order — handing each row to `AddTestMethod` with a monotonically increasing `Line No.`:

```al
if CodeunitMetadata.FindSet() then
    repeat
        TestLineNo := GetLastTestLineNo(ALTestSuite) + 10000;
        AddTestMethod(CodeunitMetadata, ALTestSuite, TestLineNo);
    until CodeunitMetadata.Next() = 0;
```

`AddTestMethod` stores `TestMethodLine."Test Codeunit" := CodeunitMetadata.ID`, and every consumer reads the lines back with `SetCurrentKey("Line No."); Ascending(true)`. The pre-CLEAN27 overload does the same over `AllObjWithCaption`, whose primary key is `("Object Type", "Object ID")`. Both inventories are keyed on the object ID.

### What that establishes, what it does not, and who is adjudicating it

**The scoped claim: a suite populated through the entry points Microsoft ships in `Test Suite Mgt.` runs its test codeunits in ascending object ID.** All three public ones — `SelectTestMethods`, `SelectTestMethodsByRange`, `SelectTestMethodsByExtension` — funnel into the `GetTestMethods` walk above, so for any suite Microsoft's own API builds, add order and ascending object ID coincide. That is the path this change is the analogue of: the runner always runs *every* test codeunit in a bundle, which is the inventory walk, never a hand-picked list.

**The unscoped version — "BC runs test codeunits in ascending object ID" — is false, and this PR does not assert it.** `Line No.` is assigned in **add** order, and `RunSelectedTests` reads the lines back with `SetCurrentKey("Line No."); Ascending(true)`. A caller that inserts `Test Method Line` rows itself picks its own order and gets it. Not hypothetical: `MsDyn365Bc.On.Linux`'s `Test Suite Runner.AddTestCodeunit` — the harness the AL-language corpus's own CI uses on its WebSocket legs — adds one codeunit per call from a caller-supplied list with `"Line No." := LastLineNo + 10000`. Hand it a descending list and BC runs it descending. So the explicit-add case does falsify the general claim, and the rule holds for the inventory-walk path only.

**A service tier is now adjudicating the load-bearing half rather than a reading of the AL.** The step the runner's order actually depends on is that the inventory walk yields ascending object ID *even when the caller's filter names the codeunits in some other order*: `SelectTestMethodsByRange` does `CodeunitMetadata.SetFilter(ID, TestCodeunitFilter)` and hands the record straight to `GetTestMethods`, so by then the filter's token order is invisible — if the inventory orders by key. Nothing in the corpus asserted that. **Corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#198** now does: eight tests over three codeunits (`SIS Cache` 60608, `Test AllObj Virtual Table` 60802, `ALT Codeunit Meta Probe` 60963) chosen so that name order, id order and the filter's token order all disagree, so ordering alphabetically, replaying the filter's tokens, or answering a fixed ascending list each fails a different test. Its eight BC legs decide it.

**What the corpus cannot decide, said plainly so nobody re-litigates it.** Multi-codeunit *execution* order is not observable from inside the corpus, because both of its CI runner paths impose their own order before BC ever sees a suite: `run-tests-altool.py` discovers codeunits with `sorted(set(ids))` and invokes the `al` tool **once per codeunit**, and the WebSocket path's `SetupSuite` loops over a caller-supplied id list calling `AddTestCodeunit` one at a time. An execution order measured there would be measuring the harness. So one link stays on reading: that ascending `Line No.` decides run order. It is a single `SetCurrentKey("Line No."); Ascending(true)` in `RunSelectedTests`, it is the only unadjudicated step left in the chain, and I would rather name it than let the PR read as if a tier had confirmed it.

**No pin bump here.** The corpus PR has not merged, and a pin bump belongs in whatever PR needs the newly-pulled-in tests to pass. Nothing in this change depends on it: the fix is a determinism fix whose C# proving tests stand on their own, and the corpus PR settles the *justification* for choosing ascending object ID over any other total order.

## The exact contract, stated precisely

**Within one emitted assembly (one app group), test codeunits execute in strictly ascending AL object ID.** Order *across* app groups is decided elsewhere and this PR does not change it — measured on `tests/runner-extras`, which is 21 app groups: each is strictly ascending internally, and the 20 descending steps between them are the group boundaries.

The sort is stable and total. A type whose object ID cannot be read — every non-codeunit type, plus BC's compiler-generated nested types — keeps its relative `GetTypes()` position and sorts last. Only test codeunits are ever executed. Method order inside a codeunit is untouched: `OrderTestMethodsBySourceDeclaration` already pins that to source declaration order, which is a different rule and stays.

## RED to GREEN

New `AlRunner.Tests/TestCodeunitExecutionOrderTests.cs`. The fixture names its files so ordinal **file** order is the exact reverse of object-ID order (Aardvark=62295, Middle=62290, Zulu=62285), so an implementation that does not reorder produces a wrong answer deterministically rather than on a lucky day. The assertions state the *rule* (`ids.SequenceEqual(ids.OrderBy(x => x))`), not one hardcoded sequence.

RED, on `origin/main`:

```
TestCodeunits_RunInAscendingObjectIdOrder_NotFileOrder
  Expected: int[]     [62285, 62290, 62295]
  Actual:   List<int> [62295, 62285, 62290]
ExecutionOrder_IsStableAcrossProcesses
  Assert.StartsWith() Failure: String: "62295.ZetaDeclaredFirst,..." Expected start: "62285."
MethodsWithinACodeunit_KeepSourceDeclarationOrder ... FAIL
Failed: 3, Passed: 1
```

GREEN, after the fix: `Passed: 4`.

Both directions are covered. Positive: the ascending rule. Negative: `Ordering_DoesNotChangeWhichTestsRun` pins that six tests across three codeunits still run, each exactly once, all passing — a sort that dropped or duplicated a codeunit would still be "ascending" and would still pass the positive test. Negative: `MethodsWithinACodeunit_KeepSourceDeclarationOrder` declares `ZetaDeclaredFirst` before `AlphaDeclaredSecond` in each codeunit, so a blanket sort that reached the method level would invert all three pairs.

`SuiteAbortOnTimeoutTests`, the suite #2801 is about, goes 7/7 with the fix.

## An existing test had encoded the superseded rule

`AlObjectEmitOrderDeterminismTests.SameSources_DifferentFileCreationOrder_RunInTheSameOrder` asserted that the answer is ordinal **file-path** order, and went red here. That is not a regression — it is #2892's test encoding a contract this PR replaces. Its real claim (identical AL content runs in one order whatever order the files were created in) is unchanged and now stronger, since the order no longer depends on the file names either. Only the expected sequence moves, 62242,62241 to 62241,62242. I updated it rather than deleting it, and said why in the file.

## Blast radius

Changing execution order globally needs measuring, so:

| run | result |
|---|---|
| al-language corpus, cold cache, `--strict --count-baseline` | **2610/2610 pass, exit 0** |
| al-language corpus, warm cache (second run) | **2610/2610 pass, exit 0** |
| `tests/runner-extras`, `--strict --count-baseline` | **298/298 pass, exit 0** |
| `AlRunner.Tests`, filtered to the execution surface (9 classes) | **55/55 pass** |

The count baseline is met in every case, so no test silently stopped being discovered. Run twice because this touches execution order and a warm cache serves a previously-emitted assembly. BC 28.1.49838.53910, private `--cache` outside the repo.

I also verified the rule holds on the real corpus rather than only on my fixture: **339 codeunit blocks, strictly ascending, zero descending steps, each codeunit contiguous.**

## Fixing the shape, not the reported line

- **Same wrong pattern at another call site?** Yes — `DiscoverTests` had the identical unordered `assembly.GetTypes()` walk, so "the tests in this bundle" and "the order they run in" were two different lists. It now shares the helper. Honest scope: its only caller (`--server`'s `runtests` handler) puts the result straight into a `HashSet`, so nothing observable changes there today. It is here so a later order-sensitive consumer inherits the guarantee instead of rediscovering that discovery never had one. No test claims otherwise.
- **Sibling function with the same assumption?** This *is* that finding. `OrderTestMethodsBySourceDeclaration` shows the runner already decided not to trust reflection order — for methods. The codeunit level was the half nobody had pinned.
- **Two paths writing the same state?** `Run` and `DiscoverTests` both derive their view of a bundle's tests from that one array; now both order it identically.

## Left out deliberately

- **Cross-app-group order** is still whatever the bundle/app-group pipeline produces. Nothing observed it going wrong, and pinning it is a larger change than this issue needs.
- **Why the failures cluster on 28.4 rather than 27.5** is still unexplained. Both legs run the class on every run. I ruled out the timeout, machine load (11 runs, idle and at load average 19 on 12 cores), the file sort, cache-key ambiguity, and the BC artifact build (the failing job and `main`'s green run used the same 28.4.53241.54318). This PR removes the *dependence* on that order rather than explaining the skew, so the symptom goes away either way — but I would rather say the skew is unexplained than imply it is solved.
- **`RecordPatches.CodeunitMetadataVirtualTable` returns `rows.Values.ToList()`**, dictionary insertion order, where BC's virtual table would answer in primary-key order. This is now measured rather than flagged: corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#198's eight tests were run against this branch's build (BC 28.1.49838.53910, the corpus branch checked out separately and passed as the bundle path), and all eight pass — so today's insertion order does come out ascending by ID, for `CodeUnit Metadata` and `AllObjWithCaption` alike. A control run with the expected sequence changed to the filter's token order fails three of them with `Expected:<60802,60963,60608> Actual:<60608,60802,60963>`, so that is a real measurement and not a vacuous pass. It holds by coincidence rather than by construction — nothing in the patch sorts — which is exactly why the assertion belongs upstream, where it keeps being checked.

---

Authored by agent impl-6.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
