### PR TITLE
fix(pages): carry the five SourceObject properties a dependency page's symbol file states

### DIFF
--- a/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
+++ b/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
@@ -949,6 +949,298 @@ public class DependencyPageMetadataXmlTests
         }
     }
 
+    // Issue #2860 — the five further <SourceObject> properties the symbol file states and the
+    // synthesized XML dropped. Own app/fixture, because the point of most of these tests is
+    // exactly which attributes are ABSENT, and the shared fixtures above already state
+    // properties of their own.
+    //
+    // WHAT "CORRECT" MEANS HERE, MEASURED
+    //   The rule this fixture pins is not "write the AL default when the file says nothing" —
+    //   it is "write the attribute if and only if the symbol file states it, with the value
+    //   the symbol file states". That is what the real AL compiler does, measured on BC 28.1
+    //   by compiling four pages and reading back the metadata it captured for each
+    //   (AL_RUNNER_TRACE_PAGE_METADATA=2):
+    //
+    //     LinksAllowed = false; ShowFilter = false; SaveValues = true;
+    //     PopulateAllFields = true; DataCaptionFields = "No.", Descr;
+    //       -> <SourceObject DataCaptionFields="1,3" LinksAllowed="0" PopulateAllFields="1"
+    //                        SaveValues="1" ShowFilter="0" SourceTable="64900" />
+    //
+    //     LinksAllowed = true; ShowFilter = true; SaveValues = false; PopulateAllFields = false;
+    //       -> <SourceObject LinksAllowed="1" PopulateAllFields="0" SaveValues="0"
+    //                        ShowFilter="1" SourceTable="64900" />      // AL DEFAULTS, still written
+    //
+    //     (declares none of them)
+    //       -> <SourceObject SourceTable="64900" />
+    //
+    //     no SourceTable at all; LinksAllowed = false; ShowFilter = false; SaveValues = true;
+    //       -> <SourceObject LinksAllowed="0" SaveValues="1" ShowFilter="0" />
+    //
+    //   The second and fourth lines are the two an "obvious" implementation gets wrong: a
+    //   plain bool defaulting to the AL default cannot tell "declared as the default" from
+    //   "not declared", and nesting the attributes alongside SourceTable drops them for the
+    //   30 Base Application 28.1 pages that declare one of the five without a source table.
+    //   DataCaptionFields is already FIELD NUMBERS in the symbol file (measured: all 381
+    //   Base Application 28.1 pages stating it state a comma-separated numeric list), which
+    //   is the same representation the compiler writes.
+    private const int SodAllStatedPageId = 88123701;
+    private const int SodAlDefaultsPageId = 88123702;
+    private const int SodStatesNonePageId = 88123703;
+    private const int SodNoSourceTablePageId = 88123704;
+    private const int SodBadCaptionFieldsPageId = 88123705;
+
+    private const string SourceObjectPropsSymbolReference = """
+        {
+          "RuntimeVersion": "15.1",
+          "Pages": [
+            {
+              "Id": 88123701,
+              "Name": "DPX SOD All Stated",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "88123620" },
+                { "Name": "LinksAllowed", "Value": "0" },
+                { "Name": "ShowFilter", "Value": "0" },
+                { "Name": "SaveValues", "Value": "1" },
+                { "Name": "PopulateAllFields", "Value": "1" },
+                { "Name": "DataCaptionFields", "Value": "1,3" }
+              ]
+            },
+            {
+              "Id": 88123702,
+              "Name": "DPX SOD AL Defaults",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "88123620" },
+                { "Name": "LinksAllowed", "Value": "1" },
+                { "Name": "ShowFilter", "Value": "1" },
+                { "Name": "SaveValues", "Value": "0" },
+                { "Name": "PopulateAllFields", "Value": "0" }
+              ]
+            },
+            {
+              "Id": 88123703,
+              "Name": "DPX SOD States None",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "88123620" }
+              ]
+            },
+            {
+              "Id": 88123704,
+              "Name": "DPX SOD No Source Table",
+              "Properties": [
+                { "Name": "PageType", "Value": "NavigatePage" },
+                { "Name": "LinksAllowed", "Value": "0" },
+                { "Name": "ShowFilter", "Value": "0" },
+                { "Name": "SaveValues", "Value": "1" }
+              ]
+            },
+            {
+              "Id": 88123705,
+              "Name": "DPX SOD Bad Caption Fields",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "88123620" },
+                { "Name": "DataCaptionFields", "Value": "\"No.\",Descr" }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private static readonly string[] SodProperties =
+        { "LinksAllowed", "ShowFilter", "SaveValues", "PopulateAllFields", "DataCaptionFields" };
+
+    /// <summary>
+    /// The core #2860 claim: every one of the five properties the symbol file states reaches
+    /// the synthesized <c>&lt;SourceObject&gt;</c> verbatim.
+    ///
+    /// <para><c>PopulateAllFields</c> is the one with teeth. BC's own
+    /// <c>SourceObjectDefinition(XmlNode)</c> constructor initialises it to <c>false</c>
+    /// before reading attributes, so a dropped attribute is indistinguishable from a declared
+    /// <c>PopulateAllFields = false</c> — and <c>NavForm.NewRecordAsync</c> reads
+    /// <c>MasterPage.PageProperties.SourceObject.PopulateAllFields</c> on EVERY new row, as
+    /// the <c>includeNonPrimaryKeyFields</c> argument to
+    /// <c>NavRecord.InitializeFieldsFromFilters</c>. For the 46 Base Application 28.1 pages
+    /// that declare it true, the runner answered <c>false</c>, and a new row was initialised
+    /// from primary-key filters only where BC initialises it from all of them.</para>
+    ///
+    /// <para><c>SaveValues</c> has a live reader too — <c>NavForm.InitializeFromMetadata</c>
+    /// assigns <c>saveValues = masterPage.PageProperties.SourceObject.SaveValues</c>, which
+    /// gates <c>ApplySourceTableViewAndSavedValuesAsync</c>'s call to
+    /// <c>ApplyLatestValuesAsync()</c> on the <c>NavForm.OpenForm()</c> route
+    /// RunnerModalDispatch takes. Carrying it is not a new risk: a page the runner
+    /// SOURCE-compiles already gets <c>SaveValues="1"</c> from the real compiler and opens
+    /// and closes through that route today. <c>LinksAllowed</c>, <c>ShowFilter</c> and
+    /// <c>DataCaptionFields</c> are read in Ncl only by <c>PageDataProvider</c>, the data
+    /// provider behind the Page Metadata (2000000138) system table — which this runner
+    /// substitutes wholesale, so they have no reader here YET; they are carried because the
+    /// value is the symbol file's own, not because a reader was found for each.</para>
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_SourceObjectPropertiesStatedBySymbolFile_AreCarriedVerbatim()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SourceObjectPropsSymbolReference));
+
+            var sourceObject = ReadSourceObjectFor(SodAllStatedPageId);
+
+            Assert.Equal("0", sourceObject.GetAttribute("LinksAllowed"));
+            Assert.Equal("0", sourceObject.GetAttribute("ShowFilter"));
+            Assert.Equal("1", sourceObject.GetAttribute("SaveValues"));
+            Assert.Equal("1", sourceObject.GetAttribute("PopulateAllFields"));
+            // Field NUMBERS, exactly as both the symbol file and the compiler state them —
+            // writing the AL source's field NAMES here would be a value BC cannot use.
+            Assert.Equal("1,3", sourceObject.GetAttribute("DataCaptionFields"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The half that a <c>bool</c> field with an AL default silently gets wrong: a page
+    /// STATING the AL default must still carry the attribute, because "stated" and
+    /// "not stated" are different documents to BC — the setters for ShowFilter and SaveValues
+    /// raise a <c>Specified</c> bit that <c>SourceObjectDefinition.Equals</c> compares and
+    /// <c>Freeze()</c> clones, so collapsing the two changes what page-customization merge
+    /// sees. Measured above: the compiler writes <c>LinksAllowed="1" PopulateAllFields="0"
+    /// SaveValues="0" ShowFilter="1"</c> for exactly this AL.
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_SourceObjectPropertiesStatedAsTheirAlDefaults_AreStillCarried()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SourceObjectPropsSymbolReference));
+
+            var sourceObject = ReadSourceObjectFor(SodAlDefaultsPageId);
+
+            Assert.Equal("1", sourceObject.GetAttribute("LinksAllowed"));
+            Assert.Equal("1", sourceObject.GetAttribute("ShowFilter"));
+            Assert.Equal("0", sourceObject.GetAttribute("SaveValues"));
+            Assert.Equal("0", sourceObject.GetAttribute("PopulateAllFields"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The negative direction, and the reason the two tests above cannot be satisfied by
+    /// writing all five unconditionally: a page whose symbol file states none of them must
+    /// carry none of them. Absence is BC's own representation of "the AL declares nothing
+    /// here", and the compiler emits exactly that.
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_PageStatingNoneOfTheFive_CarriesNoneOfThem()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SourceObjectPropsSymbolReference));
+
+            var sourceObject = ReadSourceObjectFor(SodStatesNonePageId);
+
+            foreach (var name in SodProperties)
+                Assert.False(sourceObject.HasAttribute(name),
+                    $"a page whose symbol file states no {name} must not be given the attribute");
+            // …while everything the file DOES state is still there.
+            Assert.Equal("88123620", sourceObject.GetAttribute("SourceTable"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The five do not belong to the SourceTable the way InsertAllowed/AutoSplitKey do: the
+    /// compiler writes them on a <c>&lt;SourceObject&gt;</c> that carries no SourceTable
+    /// attribute at all (measured above), and 30 Base Application 28.1 pages are that shape —
+    /// wizards and NavigatePages declaring <c>LinksAllowed = false</c> / <c>ShowFilter =
+    /// false</c>, and page 9991 "Code Coverage Setup" declaring <c>SaveValues = true</c>.
+    /// Nesting them inside the <c>SourceTable &gt; 0</c> branch would drop all 30 silently.
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_SourceObjectPropertiesWithoutASourceTable_AreStillCarried()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SourceObjectPropsSymbolReference));
+
+            var sourceObject = ReadSourceObjectFor(SodNoSourceTablePageId);
+
+            Assert.False(sourceObject.HasAttribute("SourceTable"));
+            Assert.Equal("0", sourceObject.GetAttribute("LinksAllowed"));
+            Assert.Equal("0", sourceObject.GetAttribute("ShowFilter"));
+            Assert.Equal("1", sourceObject.GetAttribute("SaveValues"));
+            Assert.False(sourceObject.HasAttribute("PopulateAllFields"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// <c>DataCaptionFields</c> is the one of the five that is not a boolean, and the only one
+    /// with a shape the runner must check rather than pass through: BC reads it as a
+    /// comma-separated list of FIELD NUMBERS. Every one of the 381 Base Application 28.1
+    /// pages stating it states numbers, because the same compiler produces both the symbol
+    /// file and the metadata — but a value that is not that shape cannot be reconstructed
+    /// into one here (resolving names would need the source table's field inventory, which a
+    /// page with no source table does not have at all), so it is omitted and SAID, never
+    /// written through as text BC would misread as field numbers.
+    ///
+    /// <para>Omitting is itself a wrong answer — it reads as "this page declares no data
+    /// caption fields" — which is exactly why the diagnostic is part of the claim and is
+    /// asserted here. It is the same choice, for the same reason, that the SourceTableView
+    /// <c>Sorting</c> arm already makes: nothing downstream can be made to fail on this
+    /// value, so the failure has to be reported rather than encoded.</para>
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_DataCaptionFieldsThatIsNotFieldNumbers_IsRefusedLoudlyNotWrittenAsText()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
+        Directory.CreateDirectory(dir);
+        var previousError = Console.Error;
+        var captured = new StringWriter();
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SourceObjectPropsSymbolReference));
+
+            // This test is the only requester of this page id, and the built document is
+            // memoized per id, so the one and only build happens inside the capture.
+            Console.SetError(captured);
+            var sourceObject = ReadSourceObjectFor(SodBadCaptionFieldsPageId);
+            Console.SetError(previousError);
+
+            Assert.False(sourceObject.HasAttribute("DataCaptionFields"),
+                "a DataCaptionFields value that is not a field-number list must not be written through");
+
+            var diagnostic = captured.ToString();
+            Assert.Contains("DataCaptionFields", diagnostic);
+            Assert.Contains(SodBadCaptionFieldsPageId.ToString(), diagnostic);
+        }
+        finally
+        {
+            Console.SetError(previousError);
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
     private static XmlElement ReadSourceObject(int pageId)
     {
         var xml = RecordPatches.TryBuildDependencyPageMetadata(pageId);

--- a/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
+++ b/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
@@ -699,6 +699,7 @@ public class DependencyPageMetadataXmlTests
     private const int NoViewPageId = 88123602;
     private const int UnresolvableViewPageId = 88123603;
     private const int WhereOnlyViewPageId = 88123604;
+    private const int ViewPlusPropsPageId = 88123605;
 
     private const string ViewSymbolReference = """
         {
@@ -747,6 +748,17 @@ public class DependencyPageMetadataXmlTests
               "Properties": [
                 { "Name": "PageType", "Value": "List" },
                 { "Name": "SourceTable", "Value": "88123620" },
+                { "Name": "SourceTableView", "Value": "where(Bucket = const(7))" }
+              ]
+            },
+            {
+              "Id": 88123605,
+              "Name": "DPX View Plus Props Page",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "88123620" },
+                { "Name": "LinksAllowed", "Value": "0" },
+                { "Name": "PopulateAllFields", "Value": "1" },
                 { "Name": "SourceTableView", "Value": "where(Bucket = const(7))" }
               ]
             }
@@ -1237,6 +1249,49 @@ public class DependencyPageMetadataXmlTests
         finally
         {
             Console.SetError(previousError);
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The combination is its own case, and the corpus found it when the unit tests could not:
+    /// <c>&lt;SourceTableView&gt;</c> is a CHILD ELEMENT of <c>&lt;SourceObject&gt;</c> while the
+    /// #2860 five are ATTRIBUTES of it, and <c>XmlWriter</c> refuses an attribute once the
+    /// writer has entered element content. Writing the five after the view therefore threw
+    /// <c>InvalidOperationException</c> for exactly the pages declaring BOTH — Base Application
+    /// 700 "Error Messages" and 1710 "Deferral Lines - G/L", each <c>LinksAllowed = 0</c>
+    /// alongside a <c>SourceTableView</c> — and the throw surfaced as a NULL metadata document,
+    /// so BC NRE'd in
+    /// <c>NCLMetaForm.GetFrozenPageDefinitionWithExtensionWithoutMergedMultiLanguage</c> and
+    /// page 1710's view silently stopped filtering. Three corpus tests caught it against a
+    /// clean 2599/2599 baseline.
+    ///
+    /// <para>So this asserts both halves survive together, which is what pins the write
+    /// ORDER — attributes first, child elements after.</para>
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_PageWithBothAViewAndSourceObjectProperties_CarriesBoth()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, ViewSymbolReference));
+
+            var sourceObject = ReadSourceObjectFor(ViewPlusPropsPageId);
+            var ns = MetaNs(sourceObject.OwnerDocument!);
+
+            Assert.Equal("0", sourceObject.GetAttribute("LinksAllowed"));
+            Assert.Equal("1", sourceObject.GetAttribute("PopulateAllFields"));
+
+            var filter = (XmlElement?)sourceObject.SelectSingleNode("m:SourceTableView/m:TableFilters", ns);
+            Assert.NotNull(filter);
+            Assert.Equal("2", filter!.GetAttribute("FieldID"));
+            Assert.Equal("CONST", filter.GetAttribute("FilterType"));
+            Assert.Equal("7", filter.GetAttribute("FilterValue"));
+        }
+        finally
+        {
             Directory.Delete(dir, recursive: true);
         }
     }

--- a/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
+++ b/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
@@ -1000,6 +1000,7 @@ public class DependencyPageMetadataXmlTests
     private const int SodStatesNonePageId = 88123703;
     private const int SodNoSourceTablePageId = 88123704;
     private const int SodBadCaptionFieldsPageId = 88123705;
+    private const int SodUnreadableBoolPageId = 88123706;
 
     private const string SourceObjectPropsSymbolReference = """
         {
@@ -1055,6 +1056,16 @@ public class DependencyPageMetadataXmlTests
                 { "Name": "PageType", "Value": "List" },
                 { "Name": "SourceTable", "Value": "88123620" },
                 { "Name": "DataCaptionFields", "Value": "\"No.\",Descr" }
+              ]
+            },
+            {
+              "Id": 88123706,
+              "Name": "DPX SOD Unreadable Bool",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "88123620" },
+                { "Name": "PopulateAllFields", "Value": "yes" },
+                { "Name": "LinksAllowed", "Value": "0" }
               ]
             }
           ]
@@ -1292,6 +1303,61 @@ public class DependencyPageMetadataXmlTests
         }
         finally
         {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The boolean counterpart of the <c>DataCaptionFields</c> refusal above, and it is held to
+    /// the same standard: a property the symbol file STATES in a form this cannot read as a
+    /// boolean must not be folded into "the page declares nothing". Both produce the same
+    /// absent attribute, so absence alone cannot tell them apart — which is exactly why the
+    /// diagnostic is part of the claim rather than a nicety.
+    ///
+    /// <para>The report is driven from <c>PageSymbol.UnreadableBooleanProperties</c>, carried in
+    /// the parsed PAYLOAD rather than written at parse time, and that is deliberate. Parsing
+    /// happens behind a content-addressed on-disk cache, so a <c>Console.Error</c> line written
+    /// from the parser is emitted on a cache MISS and silently lost on every warm run after —
+    /// the failure mode <c>AlPageMetadataRegistry</c>'s header calls "the trap this whole class
+    /// exists to avoid". Putting it in the payload means a cache HIT replays it, which is also
+    /// the correct answer: the same bytes carry the same unreadable value.</para>
+    ///
+    /// <para>The page states a second, readable property too, so this cannot pass by the
+    /// synthesizer giving up on the page as a whole.</para>
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_BooleanStatedInAFormItCannotRead_IsRefusedLoudlyNotTreatedAsUnstated()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
+        Directory.CreateDirectory(dir);
+        var previousError = Console.Error;
+        var captured = new StringWriter();
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SourceObjectPropsSymbolReference));
+
+            // Only this test asks for this page id, and the document is memoized per id, so
+            // the one and only build happens inside the capture.
+            Console.SetError(captured);
+            var sourceObject = ReadSourceObjectFor(SodUnreadableBoolPageId);
+            Console.SetError(previousError);
+
+            Assert.False(sourceObject.HasAttribute("PopulateAllFields"),
+                "an unreadable value must not be invented into a readable one");
+            // …and the rest of the page is unaffected.
+            Assert.Equal("0", sourceObject.GetAttribute("LinksAllowed"));
+
+            var diagnostic = captured.ToString();
+            Assert.Contains("PopulateAllFields", diagnostic);
+            Assert.Contains(SodUnreadableBoolPageId.ToString(), diagnostic);
+            // The unreadable value itself, so the reader can see WHAT the file said.
+            Assert.Contains("yes", diagnostic);
+            // The readable one must not be reported as a problem.
+            Assert.DoesNotContain("LinksAllowed", diagnostic);
+        }
+        finally
+        {
+            Console.SetError(previousError);
             Directory.Delete(dir, recursive: true);
         }
     }

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -369,7 +369,24 @@ internal static partial class BcAppSymbolCache
         // Application values are numeric), so it needs no name resolution, only a shape
         // check. See RecordPatches.EmitSourceObjectPropertiesXml.
         bool? LinksAllowed = null, bool? ShowFilter = null, bool? SaveValues = null,
-        bool? PopulateAllFields = null, string? DataCaptionFields = null);
+        bool? PopulateAllFields = null, string? DataCaptionFields = null,
+        // Names of the booleans above the symbol file STATED but this could not read as a
+        // boolean, with the value it stated ("PopulateAllFields=yes"). Null when there were
+        // none, which is the case for every Microsoft-produced symbol file measured.
+        //
+        // It lives in the PAYLOAD rather than being written to stderr where it is detected,
+        // and that is the whole point. Parsing sits behind a content-addressed on-disk cache,
+        // so a Console.Error line written by the parser is emitted on a cache MISS and
+        // silently lost on every warm run after — the failure mode AlPageMetadataRegistry's
+        // header calls "the trap this whole class exists to avoid". Carrying it here means a
+        // cache HIT replays it, which is also the truthful answer: the same bytes carry the
+        // same unreadable value. RecordPatches.EmitSourceObjectPropertiesXml reports it.
+        //
+        // Why it is reported at all: an unreadable value and an absent property both produce
+        // the same missing attribute, so absence cannot distinguish them, and silently
+        // treating "I could not read this" as "the AL declares nothing" is the exact shape of
+        // the defect #2860 is about, one level up.
+        List<string>? UnreadableBooleanProperties = null);
 
     /// <summary>
     /// One action's <c>RunObject</c> declaration as SymbolReference.json states it.
@@ -1124,10 +1141,11 @@ internal static partial class BcAppSymbolCache
         // #2860's five. SymbolBoolOrNull, not SymbolBool/SymbolBoolFalse: for these the
         // absence of the property is itself information BC acts on, so it must survive as
         // null rather than be folded into an AL default here. See PageSymbol's own note.
-        var linksAllowed = SymbolBoolOrNull(props, "LinksAllowed");
-        var showFilter = SymbolBoolOrNull(props, "ShowFilter");
-        var saveValues = SymbolBoolOrNull(props, "SaveValues");
-        var populateAllFields = SymbolBoolOrNull(props, "PopulateAllFields");
+        List<string>? unreadableBooleans = null;
+        var linksAllowed = SymbolBoolOrNull(props, "LinksAllowed", ref unreadableBooleans);
+        var showFilter = SymbolBoolOrNull(props, "ShowFilter", ref unreadableBooleans);
+        var saveValues = SymbolBoolOrNull(props, "SaveValues", ref unreadableBooleans);
+        var populateAllFields = SymbolBoolOrNull(props, "PopulateAllFields", ref unreadableBooleans);
         props.TryGetValue("DataCaptionFields", out var dataCaptionFields);
 
         return new PageSymbol(pageId, name!, sourceTableId, sourceTableTemporary,
@@ -1138,7 +1156,8 @@ internal static partial class BcAppSymbolCache
             memberNames, actionRefTargets,
             ParseSourceTableView(pageId, sourceTableView), runObjects,
             linksAllowed, showFilter, saveValues, populateAllFields,
-            string.IsNullOrWhiteSpace(dataCaptionFields) ? null : dataCaptionFields);
+            string.IsNullOrWhiteSpace(dataCaptionFields) ? null : dataCaptionFields,
+            unreadableBooleans);
     }
 
     /// <summary>
@@ -1481,17 +1500,29 @@ internal static partial class BcAppSymbolCache
     /// <summary>
     /// The three-state form of <see cref="SymbolBool"/> for a property whose ABSENCE is
     /// itself information: null when the symbol file states nothing, otherwise the stated
-    /// value. A value the file states but this cannot read as a boolean also answers null —
-    /// the same "state what the file states, never invent" rule, since inventing a default
-    /// for an unreadable value would be indistinguishable from the file stating that
-    /// default. Both spellings the file uses are accepted ("1"/"0" in practice, "true"/
-    /// "false" tolerated), matching SymbolBool/SymbolBoolFalse.
+    /// value. Both spellings the file uses are accepted ("1"/"0" in practice, "true"/"false"
+    /// tolerated), matching SymbolBool/SymbolBoolFalse.
+    ///
+    /// <para>A value the file STATES but this cannot read as a boolean also answers null — the
+    /// "state what the file states, never invent" rule, since inventing a default would be
+    /// indistinguishable from the file stating that default. But the two nulls are different
+    /// facts, and returning them identically with nothing said is the very shape of defect
+    /// #2860 fixes one level up, so the unreadable one is recorded in
+    /// <paramref name="unreadable"/> for the caller to carry into
+    /// <see cref="PageSymbol.UnreadableBooleanProperties"/> and report. It is recorded rather
+    /// than written here because this runs behind a content-addressed on-disk cache, where a
+    /// stderr line survives only until the first warm run.</para>
+    ///
+    /// <para>The two-state siblings above have the same blind spot and are deliberately left
+    /// alone: they cannot express it without changing what every existing caller sees, and no
+    /// Microsoft-produced symbol file measured states a boolean in any form but "1"/"0".</para>
     /// </summary>
-    private static bool? SymbolBoolOrNull(Dictionary<string, string> props, string name)
+    private static bool? SymbolBoolOrNull(Dictionary<string, string> props, string name, ref List<string>? unreadable)
     {
         if (!props.TryGetValue(name, out var v) || string.IsNullOrWhiteSpace(v)) return null;
         if (v == "1" || string.Equals(v, "true", StringComparison.OrdinalIgnoreCase)) return true;
         if (v == "0" || string.Equals(v, "false", StringComparison.OrdinalIgnoreCase)) return false;
+        (unreadable ??= new List<string>()).Add($"{name}={v}");
         return null;
     }
 

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -347,7 +347,29 @@ internal static partial class BcAppSymbolCache
         PageTableViewSymbol? TableView = null,
         // Member id of every action that declares a RunObject -> what it declares (#2931).
         // See ActionRunObjectSymbol for why this is a NAME and not a resolved object id.
-        Dictionary<int, ActionRunObjectSymbol>? MemberIdToRunObject = null);
+        Dictionary<int, ActionRunObjectSymbol>? MemberIdToRunObject = null,
+        // The five further <SourceObject> properties the symbol file states (#2860), all
+        // NULLABLE rather than defaulted, because for these five "the AL declares nothing"
+        // and "the AL declares the default" are DIFFERENT documents and BC can tell them
+        // apart. Measured on BC 28.1 by reading back the metadata the real AL compiler
+        // captured for a page declaring each as its own AL default: it writes
+        // LinksAllowed="1" PopulateAllFields="0" SaveValues="0" ShowFilter="1" — the
+        // attribute is present precisely when the AL states the property, whatever the
+        // value. The ShowFilter/SaveValues setters on BC's SourceObjectDefinition also raise
+        // a Specified bit that Equals() compares and Freeze() clones, so collapsing the two
+        // states is observable, not cosmetic.
+        //
+        // Counts on Base Application 28.1's own SymbolReference.json (2610 pages):
+        // LinksAllowed 550 (548 "0", 2 "1"), DataCaptionFields 381, SaveValues 201
+        // (196 "1", 5 "0"), ShowFilter 117 (115 "0", 2 "1"), PopulateAllFields 49
+        // (46 "1", 3 "0"). 30 of those pages declare one of them with NO SourceTable at all.
+        //
+        // DataCaptionFields is a comma-separated list of FIELD NUMBERS, not names — the
+        // symbol file and the compiled metadata share that representation (all 381 Base
+        // Application values are numeric), so it needs no name resolution, only a shape
+        // check. See RecordPatches.EmitSourceObjectPropertiesXml.
+        bool? LinksAllowed = null, bool? ShowFilter = null, bool? SaveValues = null,
+        bool? PopulateAllFields = null, string? DataCaptionFields = null);
 
     /// <summary>
     /// One action's <c>RunObject</c> declaration as SymbolReference.json states it.
@@ -1099,13 +1121,24 @@ internal static partial class BcAppSymbolCache
 
         props.TryGetValue("SourceTableView", out var sourceTableView);
 
+        // #2860's five. SymbolBoolOrNull, not SymbolBool/SymbolBoolFalse: for these the
+        // absence of the property is itself information BC acts on, so it must survive as
+        // null rather than be folded into an AL default here. See PageSymbol's own note.
+        var linksAllowed = SymbolBoolOrNull(props, "LinksAllowed");
+        var showFilter = SymbolBoolOrNull(props, "ShowFilter");
+        var saveValues = SymbolBoolOrNull(props, "SaveValues");
+        var populateAllFields = SymbolBoolOrNull(props, "PopulateAllFields");
+        props.TryGetValue("DataCaptionFields", out var dataCaptionFields);
+
         return new PageSymbol(pageId, name!, sourceTableId, sourceTableTemporary,
             string.IsNullOrWhiteSpace(pageType) ? "Card" : pageType!, caption,
             editable, insertAllowed, modifyAllowed, deleteAllowed, controls,
             string.IsNullOrWhiteSpace(cardPageName) ? null : cardPageName,
             autoSplitKey, multipleNewLines, delayedInsert, parts,
             memberNames, actionRefTargets,
-            ParseSourceTableView(pageId, sourceTableView), runObjects);
+            ParseSourceTableView(pageId, sourceTableView), runObjects,
+            linksAllowed, showFilter, saveValues, populateAllFields,
+            string.IsNullOrWhiteSpace(dataCaptionFields) ? null : dataCaptionFields);
     }
 
     /// <summary>
@@ -1444,6 +1477,23 @@ internal static partial class BcAppSymbolCache
 
     private static bool SymbolBoolFalse(Dictionary<string, string> props, string name)
         => props.TryGetValue(name, out var v) && (v == "0" || string.Equals(v, "false", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// The three-state form of <see cref="SymbolBool"/> for a property whose ABSENCE is
+    /// itself information: null when the symbol file states nothing, otherwise the stated
+    /// value. A value the file states but this cannot read as a boolean also answers null —
+    /// the same "state what the file states, never invent" rule, since inventing a default
+    /// for an unreadable value would be indistinguishable from the file stating that
+    /// default. Both spellings the file uses are accepted ("1"/"0" in practice, "true"/
+    /// "false" tolerated), matching SymbolBool/SymbolBoolFalse.
+    /// </summary>
+    private static bool? SymbolBoolOrNull(Dictionary<string, string> props, string name)
+    {
+        if (!props.TryGetValue(name, out var v) || string.IsNullOrWhiteSpace(v)) return null;
+        if (v == "1" || string.Equals(v, "true", StringComparison.OrdinalIgnoreCase)) return true;
+        if (v == "0" || string.Equals(v, "false", StringComparison.OrdinalIgnoreCase)) return false;
+        return null;
+    }
 
     /// <summary>
     /// Parse one entry of a SymbolReference.json <c>Reports</c> array into the subset the

--- a/AlRunner/Patches/DependencyPageMetadataXml.cs
+++ b/AlRunner/Patches/DependencyPageMetadataXml.cs
@@ -178,9 +178,6 @@ public static partial class RecordPatches
                 if (page.AutoSplitKey) w.WriteAttributeString("AutoSplitKey", "1");
                 if (page.MultipleNewLines) w.WriteAttributeString("MultipleNewLines", "1");
                 if (page.DelayedInsert) w.WriteAttributeString("DelayedInsert", "1");
-                // The page's SourceTableView, which BC's own NavForm.ApplySourceTableView
-                // reads from exactly here (issue #2820) — see EmitSourceTableViewXml.
-                if (page.TableView is { } view) EmitSourceTableViewXml(w, page, view);
             }
             // The attributes above only mean anything alongside a SourceTable, so a page
             // without one gets the bare element the compiler itself emits — not
@@ -189,7 +186,25 @@ public static partial class RecordPatches
             //
             // The five below are OUTSIDE that branch on purpose — measured, not assumed; see
             // EmitSourceObjectPropertiesXml.
+            //
+            // ORDER IS LOAD-BEARING, and this is the whole reason the SourceTableView child
+            // element moved below them: every attribute of <SourceObject> must be written
+            // BEFORE its first child element, because XmlWriter refuses an attribute once the
+            // writer has entered element content. Writing these five after
+            // EmitSourceTableViewXml threw InvalidOperationException for exactly the pages
+            // declaring a SourceTableView AND one of the five — Base Application 700 "Error
+            // Messages" and 1710 "Deferral Lines - G/L", both `LinksAllowed = 0` plus a view —
+            // and the throw came back as a NULL metadata document, so BC then NRE'd in
+            // NCLMetaForm.GetFrozenPageDefinitionWithExtensionWithoutMergedMultiLanguage and
+            // page 1710's view stopped filtering. The unit tests could not see it: their
+            // fixture pages declare a view or one of the five, never both. Three corpus tests
+            // did.
             EmitSourceObjectPropertiesXml(w, page);
+            // The page's SourceTableView, which BC's own NavForm.ApplySourceTableView reads
+            // from exactly here (issue #2820) — see EmitSourceTableViewXml. A CHILD ELEMENT,
+            // so it must come after every attribute above.
+            if (page.SourceTableId > 0 && page.TableView is { } view)
+                EmitSourceTableViewXml(w, page, view);
             w.WriteEndElement(); // SourceObject
             w.WriteEndElement(); // Properties
 

--- a/AlRunner/Patches/DependencyPageMetadataXml.cs
+++ b/AlRunner/Patches/DependencyPageMetadataXml.cs
@@ -320,6 +320,19 @@ public static partial class RecordPatches
         Flag("SaveValues", page.SaveValues);
         Flag("PopulateAllFields", page.PopulateAllFields);
 
+        // A boolean the symbol file STATED in a form the parser could not read comes through
+        // as the same null as "not stated at all", and therefore as the same absent attribute
+        // — so absence cannot distinguish them and the difference has to be said out loud.
+        // Treating "I could not read this" as "the AL declares nothing" is the shape of the
+        // defect this whole change fixes, and it is not allowed to reappear one level down.
+        // Never observed on a Microsoft-produced symbol file; this fires only if the format
+        // changes under us, which is exactly when silence would cost the most.
+        if (page.UnreadableBooleanProperties is { Count: > 0 } unreadable)
+            Console.Error.WriteLine(
+                $"[RecordPatches] page {page.Id} \"{page.Name}\": SourceObject property value(s) "
+                + string.Join(", ", unreadable)
+                + " not readable as a boolean — omitted, so the page reads as declaring nothing there");
+
         if (page.DataCaptionFields is not { Length: > 0 } captionFields) return;
 
         // The only one of the five that is not a boolean, and the only one whose shape has to

--- a/AlRunner/Patches/DependencyPageMetadataXml.cs
+++ b/AlRunner/Patches/DependencyPageMetadataXml.cs
@@ -23,7 +23,10 @@
 //   #1769/#1779 already parse for the Page Metadata virtual table. Nothing here is inferred
 //   from behaviour or defaulted to something convenient: Id / Name / PageType / Caption /
 //   Editable / SourceObject (SourceTable + SourceTableTemporary) come straight off the
-//   symbol file's own Properties array.
+//   symbol file's own Properties array, as do the SourceObject flags added since —
+//   Insert/Modify/DeleteAllowed, AutoSplitKey, MultipleNewLines, DelayedInsert,
+//   SourceTableView (#2820), and LinksAllowed / ShowFilter / SaveValues /
+//   PopulateAllFields / DataCaptionFields (#2860, see EmitSourceObjectPropertiesXml).
 //
 // WHAT IS DELIBERATELY OMITTED, AND WHY THAT IS SAFE HERE
 //   Ordinary field Content/Controls, ActionContainers, ViewContainers,
@@ -183,6 +186,10 @@ public static partial class RecordPatches
             // without one gets the bare element the compiler itself emits — not
             // SourceTable="0", which would answer "table 0" to a question about a table the
             // page does not have.
+            //
+            // The five below are OUTSIDE that branch on purpose — measured, not assumed; see
+            // EmitSourceObjectPropertiesXml.
+            EmitSourceObjectPropertiesXml(w, page);
             w.WriteEndElement(); // SourceObject
             w.WriteEndElement(); // Properties
 
@@ -229,6 +236,113 @@ public static partial class RecordPatches
     }
 
     private const string XsiNs = "http://www.w3.org/2001/XMLSchema-instance";
+
+    /// <summary>
+    /// The five further <c>&lt;SourceObject&gt;</c> properties the symbol file states and this
+    /// synthesizer used to drop (issue #2860): <c>LinksAllowed</c>, <c>ShowFilter</c>,
+    /// <c>SaveValues</c>, <c>PopulateAllFields</c> and <c>DataCaptionFields</c>.
+    ///
+    /// <para>THE RULE, AND WHY IT IS NOT "WRITE THE NON-DEFAULT ONES". Each attribute is
+    /// written if and only if the symbol file states the property, carrying the value the
+    /// symbol file states — including when that value IS the AL default. That is what the
+    /// real AL compiler does, measured on BC 28.1 by compiling pages that declare these and
+    /// reading back the metadata the compiler captured for each
+    /// (<c>AL_RUNNER_TRACE_PAGE_METADATA=2</c>):</para>
+    /// <code>
+    /// // LinksAllowed=false ShowFilter=false SaveValues=true PopulateAllFields=true
+    /// // DataCaptionFields="No.",Descr
+    /// &lt;SourceObject DataCaptionFields="1,3" LinksAllowed="0" PopulateAllFields="1"
+    ///               SaveValues="1" ShowFilter="0" SourceTable="64900" /&gt;
+    ///
+    /// // the same four declared as their AL DEFAULTS — still written
+    /// &lt;SourceObject LinksAllowed="1" PopulateAllFields="0" SaveValues="0"
+    ///               ShowFilter="1" SourceTable="64900" /&gt;
+    ///
+    /// // a page declaring none of them
+    /// &lt;SourceObject SourceTable="64900" /&gt;
+    ///
+    /// // a page with NO SourceTable declaring three of them
+    /// &lt;SourceObject LinksAllowed="0" SaveValues="1" ShowFilter="0" /&gt;
+    /// </code>
+    ///
+    /// <para>WHY NOT INSIDE THE <c>SourceTable</c> BRANCH, unlike InsertAllowed/AutoSplitKey:
+    /// the last measurement above. 30 Base Application 28.1 pages declare one of these five
+    /// with no source table — wizards and NavigatePages declaring <c>LinksAllowed = false</c>
+    /// or <c>ShowFilter = false</c>, and page 9991 "Code Coverage Setup" declaring
+    /// <c>SaveValues = true</c> — and <c>NavForm.InitializeFromMetadata</c> reads
+    /// <c>SourceObject.SaveValues</c> with no SourceTable guard.</para>
+    ///
+    /// <para>WHAT READS THEM. <c>PopulateAllFields</c> is the one with teeth:
+    /// <c>NavForm.NewRecordAsync</c> passes
+    /// <c>MasterPage.PageProperties.SourceObject.PopulateAllFields</c> as
+    /// <c>NavRecord.InitializeFieldsFromFilters</c>' <c>includeNonPrimaryKeyFields</c>
+    /// argument on EVERY new row, and BC's <c>SourceObjectDefinition(XmlNode)</c> constructor
+    /// initialises the field to <c>false</c> before reading attributes — so the dropped
+    /// attribute was not a missing value but a wrong one, <c>false</c> where BC answers
+    /// <c>true</c>, for the 46 Base Application 28.1 pages declaring it.
+    /// <c>SaveValues</c> is read by <c>NavForm.InitializeFromMetadata</c> into
+    /// <c>NavForm.saveValues</c>, which gates
+    /// <c>ApplySourceTableViewAndSavedValuesAsync</c>'s call to <c>ApplyLatestValuesAsync()</c>
+    /// on the <c>NavForm.OpenForm()</c> route <c>RunnerModalDispatch.TryOpenForm</c> takes —
+    /// and carrying it adds no new risk, because a page the runner SOURCE-compiles already
+    /// gets <c>SaveValues="1"</c> from the real compiler and opens and closes through that
+    /// same route today. <c>LinksAllowed</c>, <c>ShowFilter</c> and <c>DataCaptionFields</c>
+    /// are referenced in Ncl only from <c>PageDataProvider</c>, the data provider behind the
+    /// Page Metadata (2000000138) system table, which this runner substitutes wholesale
+    /// (RecordPatches.PageMetadataVirtualTable.cs) — so those three have no reader here yet
+    /// and are carried because the value is the symbol file's own, not because one was found.
+    /// The virtual table's own missing columns are tracked separately.</para>
+    /// </summary>
+    private static void EmitSourceObjectPropertiesXml(XmlWriter w, BcAppSymbolCache.PageSymbol page)
+    {
+        void Flag(string name, bool? stated)
+        {
+            if (stated is { } value) w.WriteAttributeString(name, value ? "1" : "0");
+        }
+
+        Flag("LinksAllowed", page.LinksAllowed);
+        Flag("ShowFilter", page.ShowFilter);
+        Flag("SaveValues", page.SaveValues);
+        Flag("PopulateAllFields", page.PopulateAllFields);
+
+        if (page.DataCaptionFields is not { Length: > 0 } captionFields) return;
+
+        // The only one of the five that is not a boolean, and the only one whose shape has to
+        // be checked rather than passed through: BC reads DataCaptionFields as a
+        // comma-separated list of FIELD NUMBERS. All 381 Base Application 28.1 pages stating
+        // it state numbers, because the same compiler writes both the symbol file and the
+        // compiled metadata — but a value that is not that shape cannot be turned into one
+        // here (resolving field NAMES would need the source table's field inventory, which a
+        // page declaring no source table does not have at all), so it is omitted and SAID.
+        //
+        // Omitting is itself a wrong answer — it reads as "this page declares no data caption
+        // fields" — which is exactly why the diagnostic is not optional. Same choice, same
+        // reason, as the SourceTableView Sorting arm below: nothing downstream can be made to
+        // fail on this value, so the failure has to be reported rather than encoded.
+        if (!IsFieldNumberList(captionFields))
+        {
+            Console.Error.WriteLine(
+                $"[RecordPatches] page {page.Id} \"{page.Name}\": DataCaptionFields "
+                + $"\"{captionFields}\" is not the comma-separated field-number list BC reads "
+                + "— omitted, so the page reads as declaring none");
+            return;
+        }
+        w.WriteAttributeString("DataCaptionFields", captionFields);
+    }
+
+    /// <summary>A non-empty comma-separated list of decimal field numbers, and nothing
+    /// else — the shape BC's <c>DataCaptionFields</c> consumers parse.</summary>
+    private static bool IsFieldNumberList(string value)
+    {
+        foreach (var part in value.Split(','))
+        {
+            var trimmed = part.Trim();
+            if (trimmed.Length == 0) return false;
+            foreach (var c in trimmed)
+                if (c < '0' || c > '9') return false;
+        }
+        return true;
+    }
 
     /// <summary>
     /// One subpage PART control, as an <c>InfopartPageDefinition</c> — the shape the real AL

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -767,3 +767,20 @@ manifest is nothing at all.
 
 Written by agent fbk-1 (automated implementation agent).
 
+## `microsoft-dependencies` 24 -> 26 (issue #2860)
+
+Two tests added to `MicrosoftDependencyTests`, pinning `PopulateAllFields` end to end on a page
+that ships PRECOMPILED inside a dependency `.app` — the shape whose runtime metadata comes from
+`RecordPatches.DependencyPageMetadataXml` rather than from the AL compiler.
+
+They are a pair, and only the pair proves anything. Base Application page 367 "Post Codes"
+declares `PopulateAllFields = true` over table 225, primary key `(Code, City)`, so filtering
+`"Country/Region Code"` (field 4, outside the key) and calling `New()` must carry the filter onto
+the new row. Page 427 "Payment Methods" declares nothing over table 289, key `(Code)`, so
+filtering `Description` (field 2) and calling `New()` must leave it blank. An implementation that
+wrote the attribute unconditionally would fail the second; one that never wrote it fails the
+first.
+
+No `absentOn`: both pages and both tables exist on every supported leg, and the bundle already
+declares `"application": "27.0.0.0"`. The 26 is measured from a run of the bundle, not counted
+off the source.

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -28,7 +28,7 @@
         "install-trigger-seed": { "tests": 3 },
         "install-trigger-text-constant": { "tests": 2 },
         "manual-binding-dep": { "tests": 3, "absentOn": ["27.0", "27.3", "27.5"] },
-        "microsoft-dependencies": { "tests": 24 },
+        "microsoft-dependencies": { "tests": 26 },
         "microsoft-test-library": { "tests": 3, "absentOn": ["27.0", "27.3", "27.5"] },
         "navapp-callermodule-dispatch-dep": { "tests": 0 },
         "navapp-callermodule-dispatch-main": { "tests": 4 },

--- a/tests/runner-extras/microsoft-dependencies/MDAssert.Codeunit.al
+++ b/tests/runner-extras/microsoft-dependencies/MDAssert.Codeunit.al
@@ -18,6 +18,12 @@ codeunit 61000 "MD Assert"
             Error('Assert.AreEqual failed. Expected:<%1>. Actual:<%2>. %3', Expected, Actual, Msg);
     end;
 
+    procedure AreEqualText(Expected: Text; Actual: Text; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqualText failed. Expected:<%1>. Actual:<%2>. %3', Expected, Actual, Msg);
+    end;
+
     procedure Contains(Haystack: Text; Needle: Text; Msg: Text)
     begin
         if not (StrPos(Haystack, Needle) > 0) then

--- a/tests/runner-extras/microsoft-dependencies/MicrosoftDependencyTests.Codeunit.al
+++ b/tests/runner-extras/microsoft-dependencies/MicrosoftDependencyTests.Codeunit.al
@@ -635,6 +635,61 @@ codeunit 61001 "Microsoft Dependency Tests"
             'the isolation guard runs before the codeunit lookup, so it reports first.');
     end;
 
+    // Issue #2860 — PopulateAllFields on a page that ships PRECOMPILED inside a dependency
+    // .app, so its runtime metadata is not the AL compiler's own but the document
+    // RecordPatches.DependencyPageMetadataXml reconstructs from SymbolReference.json.
+    //
+    // BC's NavForm.NewRecordAsync passes
+    // MasterPage.PageProperties.SourceObject.PopulateAllFields as the
+    // includeNonPrimaryKeyFields argument to NavRecord.InitializeFieldsFromFilters, so with
+    // it true a new row picks up a filter on a NON-primary-key field, and with it false (BC's
+    // own default, and what SourceObjectDefinition's XmlNode constructor initialises the
+    // field to) it picks up only primary-key filters. The dropped attribute was therefore not
+    // a missing value but a wrong one.
+    //
+    // The pair below is what makes this prove something rather than pass: page 367
+    // "Post Codes" declares PopulateAllFields = true and page 427 "Payment Methods" declares
+    // nothing, and both are read out of the SAME reconstructed-metadata path. An
+    // implementation that wrote the attribute unconditionally would fail the second test; one
+    // that never wrote it fails the first.
+    //
+    // The BC-behaviour half of this claim — that PopulateAllFields governs which filtered
+    // fields a new row is initialised from — is plain BC behaviour for a service tier to
+    // adjudicate. What is runner-specific, and is what this suite pins, is that a page
+    // reached only through a precompiled dependency's symbol file answers the same as one the
+    // runner compiled itself.
+    [Test]
+    procedure PopulateAllFieldsTrue_OnPrecompiledDependencyPage_InitialisesNonPrimaryKeyFilterOnNew()
+    var
+        PostCodes: TestPage "Post Codes";
+    begin
+        // Table 225 "Post Code" has primary key (Code, City); "Country/Region Code" is field
+        // 4 and is NOT part of it.
+        PostCodes.OpenEdit();
+        PostCodes.Filter.SetFilter("Country/Region Code", 'ZZ');
+        PostCodes.New();
+
+        Assert.AreEqualText('ZZ', PostCodes."Country/Region Code".Value(),
+            'page 367 declares PopulateAllFields = true, so a new row must take the non-primary-key filter too.');
+        PostCodes.Close();
+    end;
+
+    [Test]
+    procedure PopulateAllFieldsUnstated_OnPrecompiledDependencyPage_LeavesNonPrimaryKeyFilterAlone()
+    var
+        PaymentMethods: TestPage "Payment Methods";
+    begin
+        // Table 289 "Payment Method" has primary key (Code); Description is field 2 and is
+        // NOT part of it. Page 427 states no PopulateAllFields at all.
+        PaymentMethods.OpenEdit();
+        PaymentMethods.Filter.SetFilter(Description, 'ZZ');
+        PaymentMethods.New();
+
+        Assert.AreEqualText('', PaymentMethods.Description.Value(),
+            'page 427 states no PopulateAllFields, so BC''s own false applies and a new row must NOT take the non-primary-key filter.');
+        PaymentMethods.Close();
+    end;
+
     local procedure EnsureGeneralLedgerSetupExists()
     var
         GeneralLedgerSetup: Record "General Ledger Setup";


### PR DESCRIPTION
Closes #2860

`RecordPatches.DependencyPageMetadataXml` rebuilds a page's runtime `PageDefinition` from a precompiled dependency `.app`'s `SymbolReference.json`. It dropped five `<SourceObject>` properties the symbol file states. **All five turned out to be recoverable verbatim — none needed to refuse.** The only refusal I had to build is a shape guard on `DataCaptionFields`, described below.

## What each one is, and what reads it

| property | Base App 28.1 pages stating it | reader in Ncl |
|---|---:|---|
| `PopulateAllFields` | 49 (46 `"1"`) | `NavForm.NewRecordAsync` — **live, every new row** |
| `SaveValues` | 201 (196 `"1"`) | `NavForm.InitializeFromMetadata` → `NavForm.saveValues`; `MetadataProvider.ModifyReportRequestPage` |
| `LinksAllowed` | 550 (548 `"0"`) | `PageDataProvider` only |
| `DataCaptionFields` | 381 | `PageDataProvider` only |
| `ShowFilter` | 117 (115 `"0"`) | `PageDataProvider` only |

Reader evidence is an IL scan of `Microsoft.Dynamics.Nav.Ncl.dll` 28.1 for call sites of each getter, not a reading of the code. `PageDataProvider` is the data provider behind the **Page Metadata (2000000138)** system table, which this runner substitutes wholesale — so those three have no reader here *yet*. I carried them anyway because the value is the symbol file's own, and said so in the code comment rather than implying a reader was found for each.

`PopulateAllFields` was not a missing value but a **wrong** one. BC's `SourceObjectDefinition(XmlNode)` constructor initialises the field to `false` before reading attributes, so a dropped attribute is indistinguishable from a declared `PopulateAllFields = false`, and `NavForm.NewRecordAsync` passes it straight into `NavRecord.InitializeFieldsFromFilters` as `includeNonPrimaryKeyFields`.

## The rule, measured rather than reasoned

Write the attribute **if and only if the symbol file states the property**, with the value it states — including when that value is the AL default. That is what the real AL compiler does. Measured on BC 28.1 by compiling pages and reading back the metadata it captured (`AL_RUNNER_TRACE_PAGE_METADATA=2`):

```xml
<!-- LinksAllowed=false ShowFilter=false SaveValues=true PopulateAllFields=true
     DataCaptionFields="No.",Descr -->
<SourceObject DataCaptionFields="1,3" LinksAllowed="0" PopulateAllFields="1"
              SaveValues="1" ShowFilter="0" SourceTable="64900" />

<!-- the same four declared as their AL DEFAULTS - still written -->
<SourceObject LinksAllowed="1" PopulateAllFields="0" SaveValues="0"
              ShowFilter="1" SourceTable="64900" />

<!-- declares none of them -->
<SourceObject SourceTable="64900" />

<!-- NO SourceTable, declaring three of them -->
<SourceObject LinksAllowed="0" SaveValues="1" ShowFilter="0" />
```

Two consequences an "obvious" implementation gets wrong, and both have a test:

- `PageSymbol` carries these as `bool?`, not `bool`. "Declares nothing" and "declares the default" are different documents, and BC can tell them apart — the `ShowFilter` and `SaveValues` setters raise a `Specified` bit that `Equals()` compares and `Freeze()` clones.
- They are **outside** the `SourceTable > 0` branch, unlike `InsertAllowed`/`AutoSplitKey`. The last snippet above is why: 30 Base App pages declare one of the five with no source table (wizards declaring `LinksAllowed = false`, page 9991 "Code Coverage Setup" declaring `SaveValues = true`), and `NavForm.InitializeFromMetadata` reads `SourceObject.SaveValues` with no SourceTable guard.

On `SaveValues` specifically, which #2860 flagged as a possible scope question: it is not one. A page the runner **source**-compiles already gets `SaveValues="1"` from the real compiler and opens and closes through the same `NavForm.OpenForm()` route `RunnerModalDispatch` takes. Dropping it for dependency pages was an inconsistency between two routes, not a scope boundary. I verified a `SaveValues = true` page over that route before carrying it.

## Why the proving test stays in `runner-extras` rather than going upstream

The structural exemption in `bc-behavior-tests-go-upstream.md`, stated explicitly because it is what justifies the placement: **this defect cannot be expressed in the corpus at all.** It exists only for a page hydrated from a *precompiled* dependency `.app`'s `SymbolReference.json`, and a corpus test would source-compile its page — taking the real-compiler metadata path, which already carried all five — so the test would pass against the unfixed runner and prove nothing. The BC-behaviour claim underneath (`PopulateAllFields` governs which filtered fields a new row is initialised from) is a service tier's to adjudicate; the claim this PR makes is that a page reached only through a symbol file answers the same as one the runner compiled itself, which is runner-specific by construction.

## The two refusals

`DataCaptionFields` is a comma-separated list of **field numbers**, which is already how the symbol file states it — all 381 Base App pages stating it state numbers, because the same compiler writes both artifacts. A value that is not that shape cannot be reconstructed into one here (resolving names needs the source table's field inventory, which a page with no source table does not have), so it is omitted **and reported on stderr**. Omitting is itself a wrong answer — it reads as "declares none" — which is exactly why the diagnostic is part of the test's claim, not an afterthought. Same choice, same reason, as the existing `SourceTableView` `Sorting` arm.

The **booleans** are now held to that same standard (review finding). `SymbolBoolOrNull` used to answer `null` both for a property the file does not state and for one it states in a form the parser cannot read — and both produce the same absent attribute, so absence cannot tell them apart. That is the shape of this very defect one level down, so the unreadable case is reported too.

It is recorded in `PageSymbol.UnreadableBooleanProperties` — the parsed **payload** — rather than written where it is detected, and that part is not incidental: parsing sits behind a content-addressed on-disk cache, so a `Console.Error` line from the parser is emitted on a cache MISS and silently lost on every warm run after, which is the failure mode `AlPageMetadataRegistry`'s header calls "the trap this whole class exists to avoid". In the payload, a cache HIT replays it — also the truthful answer, since the same bytes carry the same unreadable value. `SymbolBool`/`SymbolBoolFalse` have the same blind spot and are deliberately left alone: two-state helpers cannot express it without changing what every existing caller sees, and no Microsoft-produced symbol file measured states a boolean in any form but `"1"`/`"0"`.

## RED → GREEN

**Mechanism** (`AlRunner.Tests/DependencyPageMetadataXmlTests.cs`), 5 of 7 new tests RED before the fix:

- stated values carried verbatim — RED
- stated **AL defaults** still carried — RED (kills a `bool`-with-default implementation)
- a page stating none of the five carries none — green in both states, and it is the guard that kills an unconditional-write implementation
- the five on a page with no SourceTable — RED
- non-numeric `DataCaptionFields` omitted **and** the diagnostic emitted — RED
- a boolean stated as an unreadable value omitted **and** the diagnostic emitted, naming the value, while a readable property on the same page is unaffected — RED
- a page declaring **both** a `SourceTableView` and one of the five — see below

**End to end** (`tests/runner-extras/microsoft-dependencies`), on real Base Application pages whose metadata comes only from this synthesizer:

- page 367 "Post Codes" (`PopulateAllFields = true`, table 225 key `(Code, City)`): filter `"Country/Region Code"` (field 4, outside the key), `New()` → reads `''` before the fix, `'ZZ'` after.
- page 427 "Payment Methods" (states nothing, table 289 key `(Code)`): filter `Description`, `New()` → `''` in both states.

Only the pair proves anything: an unconditional write fails the second, never writing fails the first.

## A regression the unit tests could not see, and the corpus did

The first version wrote the new attributes **after** `EmitSourceTableViewXml`. `XmlWriter` refuses an attribute once it has entered element content, so pages declaring a `SourceTableView` **and** one of the five threw `InvalidOperationException`, which surfaced as a null metadata document — BC then NRE'd in `NCLMetaForm.GetFrozenPageDefinitionWithExtensionWithoutMergedMultiLanguage`, and page 1710's view silently stopped filtering. Base App 700 "Error Messages" and 1710 "Deferral Lines - G/L" are that shape.

The unit fixtures declared a view **or** one of the five, never both. Three corpus tests caught it against an otherwise clean baseline. Fixed by ordering (attributes first, child elements after) and pinned by a fixture page declaring both — verified to fail on the broken order and pass on the fixed one.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** No. `DependencyPageMetadataXml` is the only writer of a synthesized `<SourceObject>` in the tree.
2. **Does a sibling make the same assumption?** **Yes**, and it is filed as #3063 rather than silently left. `RecordPatches.PageMetadataVirtualTable`'s `BuildPageMetadataValue` answers BC's default for **nine** Page Metadata columns whose values the runner already parses. Measured, not read off the code: a page declaring all of `LinksAllowed`/`ShowFilter`/`SaveValues`/`PopulateAllFields`/`DataCaptionFields`, and a second declaring `AutoSplitKey`/`DelayedInsert`/`MultipleNewLines`/`SourceTableView`, both produce `LinksAllowed=No ShowFilter=No SaveValues=No PopulateAllFields=No DataCaptionFields=[] AutoSplitKey=No DelayedInsert=No MultipleNewLines=No SourceTableView=[]`. It is not folded in here because it needs the AL-source-parsed half too (`ParsedPage` carries none of the five, and AL source states `DataCaptionFields` as field *names* where the metadata wants numbers) — and both halves must land together or the table answers differently depending on where a page came from.
3. **Two paths writing the same state?** Yes, and that was the defect: the real compiler's metadata for a source-compiled page versus this synthesizer's for a precompiled one. The measurement above is the check that they now converge.

## Deliberately left out

- The Page Metadata virtual-table columns (#3063) — reasoned above.
- No `CacheVersion` bump. `PageSymbol` is reachable from `CachePayload`, so `PayloadShape`'s structural hash already keys the new members differently, the same call #2820 made. Verified rather than assumed: cold and warm runs against the **shared** `bc-symbols` cache both pass.
- Nothing touched near #2460 (dependency page action tree), which is assigned to a human.

## What I ran

| | result |
|---|---|
| `DependencyPageMetadataXmlTests` | 26/26 |
| `DependencyPage*` / `PageMetadata*` / `BcAppSymbolCache*` / `SourceTableView*` / `DependencyMetadataMemo*` / `TestPage*` | 256 passed, 7 pre-existing skips |
| al-language corpus | 2665/2665, exit 0 (`--strict --count-baseline`) |
| full `tests/runner-extras` as CI invokes it | 306/306, exit 0 |
| `microsoft-dependencies` cold and warm | 26/26 both |

All of the above is measured on the current head, rebased onto `89664f02`. The corpus was run deliberately rather than routinely — `SaveValues` activates a BC code path, and `main` has since taken changes to adjacent surfaces (#3079 CalcFields, #3082 test execution order, #3098 TestPage close) — and it is what caught the ordering bug the first time. `tests/expectations/count-baseline/test-count-baseline.json` moves `microsoft-dependencies` 24 → 26 in this PR, with the rationale in `history.md`.

Implemented by agent impl-3.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
