### PR TITLE
perf(deps): fold the dependency cache key's package hash into the shared content-hash memo

### DIFF
--- a/AlRunner.Tests/DependencyCacheKeyContentHashMemoTests.cs
+++ b/AlRunner.Tests/DependencyCacheKeyContentHashMemoTests.cs
@@ -1,0 +1,275 @@
+// DependencyCacheKeyContentHashMemoTests — issue #3043.
+//
+// `DependencyLoader.ComputeSourceDependencyCacheKey` names `compiled-deps/<key>.dll` and its
+// five metadata sidecars, so the string it returns is PERSISTED and read by later runs and by
+// other processes. It used to end its key with
+//
+//     using (var fs = File.OpenRead(appPath))
+//         WriteLine($"app-bytes:{Convert.ToHexString(sha.ComputeHash(fs))}");
+//
+// which is a second full SHA-256 pass over bytes `RunnerFingerprint.ComputeFileContentHashMemoized`
+// has already answered for — `AppLoader.ReadManifest` (#2987), `AppLoader.ExtractAllDllPaths`,
+// `BcAppSymbolCache` and `ProgramSupport.DependencyContentTerm` all go through that one memo, and
+// since #2987 every scanned package is hashed by the manifest index, so "already hashed" is the
+// normal case rather than the exception.
+//
+// Measured on this repo's own `tests/runner-extras` leg (both package caches, cold `--cache`
+// root and again warm, probe counting every SHA-256 file read): 7 packages, 634,797 bytes,
+// re-read identically on both runs, and all 7 were already in the memo (750 memo lookups
+// apiece, one computation). Small — that is the honest number — but free.
+//
+// The reason #3042 filed this instead of folding it in is that both hazards land on a
+// persisted key, and NEITHER is visible in the returned value:
+//
+//   CASING — `Convert.ToHexString` is uppercase, `ComputeContentHash` lowercases. Substituting
+//   the memo's answer directly changes the key's TEXT for identical bytes, orphaning every
+//   `compiled-deps` entry on every machine and CI cache. `Key_IsUnchangedByTheCasingOfTheHashItIsGiven`
+//   and `Key_IsByteIdenticalToTheFreshReadKeyThisReplaces` are the two that fail if the
+//   `.ToUpperInvariant()` is dropped.
+//
+//   SENTINEL — `File.OpenRead` threw for an unreadable package; the memo answers
+//   `UnknownContentHash`. Passed through, every unidentifiable package gets ONE key, so the
+//   first one's compiled DLL is served for all of them. `UnknownContentHash_Throws_*` pins the
+//   refusal, and pins that two different unidentifiable packages cannot collapse onto one key.
+//
+// The memo-count test is the one that was RED: the old code did not consult the memo at all, so
+// `ContentHashComputationCountForTests` did not move when the key was computed. Asserting only
+// that the count "does not increase" — the shape the issue suggested — passes on the OLD code
+// too and proves nothing; the assertion with teeth is that computing the key on a cold memo
+// increments it by exactly one, i.e. the read now goes THROUGH the memo where every other layer
+// can share it.
+
+using AlRunner;
+using AlRunner.Infrastructure;
+using System.Security.Cryptography;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Reads the process-global content-hash computation counter as an exact delta and clears the
+// shared memo — the same reason RunnerFingerprintFileIdentityMemoTests joins this collection.
+[Collection(CacheRootsSerialCollection.Name)]
+public sealed class DependencyCacheKeyContentHashMemoTests : IDisposable
+{
+    private readonly string _root;
+
+    public DependencyCacheKeyContentHashMemoTests()
+    {
+        _root = TestScratch.Dir("al-runner-depkey-memo");
+        Directory.CreateDirectory(_root);
+        RunnerFingerprint.ClearFileContentHashMemoForTests();
+    }
+
+    public void Dispose()
+    {
+        RunnerFingerprint.ClearFileContentHashMemoForTests();
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private static AppManifest Manifest(string name = "Dep One") => new(
+        Publisher: "Contoso",
+        Name: name,
+        Version: new Version(1, 2, 3, 4),
+        AppId: Guid.Parse("11111111-2222-3333-4444-555555555555"),
+        Dependencies: new[]
+        {
+            new DependencyRef(Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"), "Base", "Microsoft", new Version(28, 0, 0, 0)),
+        });
+
+    private string WritePackage(string name, string body)
+    {
+        var p = Path.Combine(_root, name);
+        File.WriteAllBytes(p, Encoding.UTF8.GetBytes(body));
+        return p;
+    }
+
+    /// <summary>
+    /// The key exactly as the pre-#3043 code computed it: a fresh <see cref="File.OpenRead"/>
+    /// and <see cref="Convert.ToHexString(byte[])"/> — uppercase — for the <c>app-bytes:</c>
+    /// line, everything else in the same order. Reproduced here rather than hardcoded because
+    /// the key also carries the runner's own content hash and the selected BC version, both of
+    /// which change per build; what has to stay fixed is that the two agree.
+    /// </summary>
+    private static string FreshReadReferenceKey(AppManifest manifest, string appPath)
+    {
+        using var sha = SHA256.Create();
+        using var ms = new MemoryStream();
+        void WriteLine(string s)
+        {
+            var bytes = Encoding.UTF8.GetBytes(s + "\n");
+            ms.Write(bytes, 0, bytes.Length);
+        }
+
+        WriteLine("schema:v2");
+        RunnerFingerprint.WriteKeyLines(WriteLine);
+        WriteLine($"app:{manifest.AppId}:{manifest.Publisher}:{manifest.Name}:{manifest.Version}");
+        foreach (var dep in manifest.Dependencies.OrderBy(
+                     d => $"{d.Publisher}/{d.Name}/{d.Version}/{d.AppId}", StringComparer.OrdinalIgnoreCase))
+            WriteLine($"dep:{dep.AppId}:{dep.Publisher}:{dep.Name}:{dep.Version}");
+        using (var fs = File.OpenRead(appPath))
+            WriteLine($"app-bytes:{Convert.ToHexString(sha.ComputeHash(fs))}");
+
+        ms.Position = 0;
+        return Convert.ToHexString(sha.ComputeHash(ms)).ToLowerInvariant();
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The saving. RED before #3043: the first assertion read 0, because the key was computed
+    // from a File.OpenRead the memo never saw.
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Key_HashesThroughTheSharedMemo_AndASecondKeyForTheSamePackageReadsNothing()
+    {
+        var pkg = WritePackage("dep.app", "package bytes v1");
+        var m = Manifest();
+
+        var before = RunnerFingerprint.ContentHashComputationCountForTests;
+        var key1 = DependencyLoader.ComputeSourceDependencyCacheKeyCore(
+            m, pkg, p => RunnerFingerprint.ComputeFileContentHashMemoized(p));
+
+        // Went THROUGH the memo — this is the half that was RED. A key computed from its own
+        // File.OpenRead leaves this counter untouched, so "did not increase" is not the claim.
+        Assert.Equal(before + 1, RunnerFingerprint.ContentHashComputationCountForTests);
+
+        var key2 = DependencyLoader.ComputeSourceDependencyCacheKeyCore(
+            m, pkg, p => RunnerFingerprint.ComputeFileContentHashMemoized(p));
+
+        // ...and the second key cost no read at all.
+        Assert.Equal(before + 1, RunnerFingerprint.ContentHashComputationCountForTests);
+        Assert.Equal(key1, key2);
+    }
+
+    [Fact]
+    public void Key_ForAPackageAnotherLayerAlreadyHashed_CostsNoRead()
+    {
+        // The real shape: AppLoader.ReadManifest hashed this package while indexing it, long
+        // before DependencyLoader reaches Tier 3 for it.
+        var pkg = WritePackage("dep.app", "package bytes v1");
+        var primed = RunnerFingerprint.ComputeFileContentHashMemoized(pkg);
+        Assert.Equal(64, primed.Length);
+
+        var before = RunnerFingerprint.ContentHashComputationCountForTests;
+        var key = DependencyLoader.ComputeSourceDependencyCacheKeyCore(
+            Manifest(), pkg, p => RunnerFingerprint.ComputeFileContentHashMemoized(p));
+
+        Assert.Equal(before, RunnerFingerprint.ContentHashComputationCountForTests);
+        Assert.Equal(64, key.Length);
+    }
+
+    [Fact]
+    public void Key_NeverOpensThePackageItself_OnlyTheHashDelegateDoes()
+    {
+        // Decisive and portable: the package does not exist, so anything that opened it would
+        // throw. The delegate is the ONLY route to the bytes.
+        var absent = Path.Combine(_root, "not-on-disk.app");
+        Assert.False(File.Exists(absent));
+
+        var calls = new List<string>();
+        var key = DependencyLoader.ComputeSourceDependencyCacheKeyCore(
+            Manifest(), absent,
+            p => { calls.Add(p); return new string('a', 64); });
+
+        Assert.Equal(new[] { absent }, calls);
+        Assert.Equal(64, key.Length);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Hazard 1: the persisted key's value must not move.
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void Key_IsByteIdenticalToTheFreshReadKeyThisReplaces()
+    {
+        var pkg = WritePackage("dep.app", "package bytes v1");
+        var m = Manifest();
+
+        Assert.Equal(
+            FreshReadReferenceKey(m, pkg),
+            DependencyLoader.ComputeSourceDependencyCacheKeyCore(
+                m, pkg, p => RunnerFingerprint.ComputeFileContentHashMemoized(p)));
+    }
+
+    [Fact]
+    public void Key_IsUnchangedByTheCasingOfTheHashItIsGiven()
+    {
+        // The memo lowercases; Convert.ToHexString uppercases. The key must not be able to tell
+        // the difference, or swapping one source of the hash for the other silently orphans the
+        // on-disk cache. Drop the `.ToUpperInvariant()` in AppBytesTerm and these two keys stop
+        // being equal.
+        var pkg = WritePackage("dep.app", "package bytes v1");
+        var m = Manifest();
+        const string Lower = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        var upper = Lower.ToUpperInvariant();
+
+        var fromLower = DependencyLoader.ComputeSourceDependencyCacheKeyCore(m, pkg, _ => Lower);
+        var fromUpper = DependencyLoader.ComputeSourceDependencyCacheKeyCore(m, pkg, _ => upper);
+
+        Assert.Equal(fromUpper, fromLower);
+    }
+
+    [Fact]
+    public void Key_StillChangesWhenThePackageBytesChange()
+    {
+        // The negative direction of the two pins above: agreeing on casing must not have made
+        // the app-bytes line inert. Two different packages, two different keys.
+        var m = Manifest();
+        var a = WritePackage("a.app", "package bytes v1");
+        var b = WritePackage("b.app", "package bytes v2 — different");
+
+        var keyA = DependencyLoader.ComputeSourceDependencyCacheKeyCore(
+            m, a, p => RunnerFingerprint.ComputeFileContentHashMemoized(p));
+        var keyB = DependencyLoader.ComputeSourceDependencyCacheKeyCore(
+            m, b, p => RunnerFingerprint.ComputeFileContentHashMemoized(p));
+
+        Assert.NotEqual(keyA, keyB);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Hazard 2: the `unknown` sentinel must never become a shared key.
+    // ---------------------------------------------------------------------------------------
+
+    [Fact]
+    public void UnknownContentHash_Throws_RatherThanGivingEveryUnidentifiablePackageOneKey()
+    {
+        var m = Manifest();
+        var a = Path.Combine(_root, "unreadable-a.app");
+        var b = Path.Combine(_root, "unreadable-b.app");
+
+        var exA = Assert.Throws<FileNotFoundException>(() =>
+            DependencyLoader.ComputeSourceDependencyCacheKeyCore(
+                m, a, _ => RunnerFingerprint.UnknownContentHash));
+        var exB = Assert.Throws<FileNotFoundException>(() =>
+            DependencyLoader.ComputeSourceDependencyCacheKeyCore(
+                m, b, _ => RunnerFingerprint.UnknownContentHash));
+
+        // Each names its OWN package, so nothing aliases the two onto one diagnosis either.
+        Assert.Contains("unreadable-a.app", exA.Message);
+        Assert.Contains("unreadable-b.app", exB.Message);
+        Assert.DoesNotContain("unreadable-b.app", exA.Message);
+        Assert.Equal(a, exA.FileName);
+        Assert.Equal(b, exB.FileName);
+    }
+
+    [Fact]
+    public void EmptyContentHash_Throws_ForTheSameReason()
+    {
+        var ex = Assert.Throws<FileNotFoundException>(() =>
+            DependencyLoader.ComputeSourceDependencyCacheKeyCore(
+                Manifest(), Path.Combine(_root, "empty-hash.app"), _ => ""));
+        Assert.Contains("empty-hash.app", ex.Message);
+    }
+
+    [Fact]
+    public void MissingPackage_StillThrows_AsTheFreshReadDid()
+    {
+        // End-to-end through the production overload (the real memo, no injected delegate):
+        // File.OpenRead threw FileNotFoundException for a package that is not there, and the
+        // memo's `unknown` answer must not have quietly turned that into a cache key.
+        var absent = Path.Combine(_root, "gone.app");
+        Assert.Throws<FileNotFoundException>(() =>
+            DependencyLoader.ComputeSourceDependencyCacheKeyCore(
+                Manifest(), absent, p => RunnerFingerprint.ComputeFileContentHashMemoized(p)));
+    }
+}

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -730,7 +730,26 @@ public sealed class DependencyLoader
         }
     }
 
+    /// <summary>
+    /// The Tier-3 source-compile cache key for one dependency package — the NAME of
+    /// <c>compiled-deps/&lt;key&gt;.dll</c> and its five metadata sidecars, so this string's
+    /// VALUE is persisted, shared across processes, and read by later runs. Changing what it
+    /// computes for unchanged inputs orphans every existing entry on every machine; #3043's
+    /// whole difficulty is that the obvious refactor does exactly that.
+    /// </summary>
     private static string ComputeSourceDependencyCacheKey(AppManifest manifest, string appPath)
+        => ComputeSourceDependencyCacheKeyCore(
+               manifest, appPath, static p => RunnerFingerprint.ComputeFileContentHashMemoized(p));
+
+    /// <summary>
+    /// Testable core: takes the "which bytes is this package?" answer as a delegate, the same
+    /// seam <see cref="AppLoader.ReadManifestCore"/> and <c>AppLoader.ExtractAllDllPathsCore</c>
+    /// use, so a test can prove this method never opens <paramref name="appPath"/> itself —
+    /// which is the entire claim of #3043 and is not visible in the returned key (a fresh read
+    /// and a memo hit of the same bytes agree by construction).
+    /// </summary>
+    internal static string ComputeSourceDependencyCacheKeyCore(
+        AppManifest manifest, string appPath, Func<string, string> contentHashOf)
     {
         using var sha = SHA256.Create();
         using var ms = new MemoryStream();
@@ -752,11 +771,58 @@ public sealed class DependencyLoader
         WriteLine($"app:{manifest.AppId}:{manifest.Publisher}:{manifest.Name}:{manifest.Version}");
         foreach (var dep in manifest.Dependencies.OrderBy(d => $"{d.Publisher}/{d.Name}/{d.Version}/{d.AppId}", StringComparer.OrdinalIgnoreCase))
             WriteLine($"dep:{dep.AppId}:{dep.Publisher}:{dep.Name}:{dep.Version}");
-        using (var fs = File.OpenRead(appPath))
-            WriteLine($"app-bytes:{Convert.ToHexString(sha.ComputeHash(fs))}");
+        WriteLine($"app-bytes:{AppBytesTerm(appPath, contentHashOf)}");
 
         ms.Position = 0;
         return Convert.ToHexString(sha.ComputeHash(ms)).ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// The value of the key's <c>app-bytes:</c> line. Two hazards live here, both of them
+    /// only hazards BECAUSE the key above is persisted (#3043).
+    ///
+    /// <para><b>Casing.</b> This line used to be
+    /// <c>Convert.ToHexString(SHA256.ComputeHash(File.OpenRead(appPath)))</c>, and
+    /// <see cref="Convert.ToHexString(byte[])"/> is UPPERCASE, where
+    /// <see cref="RunnerFingerprint.ComputeContentHash"/> ends in
+    /// <c>.ToLowerInvariant()</c>. Substituting the memo's answer directly would have changed
+    /// this line's text for identical bytes, so every <c>compiled-deps</c> entry on every
+    /// machine and CI cache would have been orphaned and every dependency recompiled once —
+    /// a silent, invisible-in-review cost. <c>.ToUpperInvariant()</c> here restores the exact
+    /// byte sequence the fresh read produced, so the persisted key value is UNCHANGED.
+    /// Round-tripping is exact because the alphabet is hex.
+    /// <c>DependencyCacheKeyContentHashMemoTests
+    /// .Key_IsUnchangedByTheCasingOfTheHashItIsGiven</c> fails if this call is dropped.</para>
+    ///
+    /// <para><b>The sentinel.</b> <see cref="File.OpenRead"/> THREW for a package it could not
+    /// read; the memo answers <see cref="RunnerFingerprint.UnknownContentHash"/> instead. Passing
+    /// that through would give every unidentifiable package one shared
+    /// <c>app-bytes:UNKNOWN</c> line, so the first such package's compiled DLL and its five
+    /// metadata sidecars would be served for every later one — the wrong-answer shape content
+    /// addressing exists to remove (#2955, #2987), reintroduced one layer down. So it throws,
+    /// exactly as the fresh read did, naming the package. Same guard as
+    /// <c>AppLoader.TryPackageIdentity</c> and <c>RecordPatches.BcAppFallback.SafeContentHash</c>,
+    /// which return null for the same reason; here a cache key has no "no identity" value to
+    /// return, and refusing loudly is what the fresh read already did
+    /// (<c>.claude/rules/loud-failures.md</c>).</para>
+    ///
+    /// <para>Unreachable in a real run for the same reason <c>ProgramSupport
+    /// .DependencyContentTerm</c>'s degraded path is: a package the resolver indexed is one
+    /// whose bytes it read (#2987), and <c>AppLoader.ExtractAl</c> has already opened this one
+    /// a few lines above the call site. Kept and tested anyway — a defensive branch no caller
+    /// can reach still has to behave (#2954).</para>
+    /// </summary>
+    private static string AppBytesTerm(string appPath, Func<string, string> contentHashOf)
+    {
+        var hash = contentHashOf(appPath);
+        if (string.IsNullOrEmpty(hash) || hash == RunnerFingerprint.UnknownContentHash)
+            throw new FileNotFoundException(
+                $"dependency package '{appPath}' could not be identified by content, so it has no " +
+                "compiled-deps cache key. Keying it on the shared 'unknown' sentinel would serve " +
+                "one unidentifiable package's compiled DLL and metadata sidecars for every other " +
+                "unidentifiable package.",
+                appPath);
+        return hash.ToUpperInvariant();
     }
 
     // Cheap source scan for "codeunit <id> ..." declarations → "Codeunit<id>" type names,

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -34,10 +34,19 @@ public sealed class DependencyLoader
     // ISV .apps) — and is set ONLY when LoadOne actually took the Tier-3 source-compile
     // path (see its own return points). #2593/#2579: this is what lets the LoadAll
     // cache-hit fast path replay a Tier-3 dependency's metadata sidecars on every reuse
-    // WITHOUT re-hashing the .app file (ComputeSourceDependencyCacheKey reads and
-    // SHA256's the whole file — cheap for a small test-library .app, NOT cheap for a
-    // ~100MB Base Application .app, which would otherwise pay that cost on every single
-    // reload cycle purely to discover "this one has no sidecars anyway").
+    // without recomputing its cache key on every reload cycle purely to discover "this
+    // one has no sidecars anyway".
+    //
+    // #3043 changed what that costs, and the comment here used to state the old one: the
+    // key computation no longer reads the .app itself, it asks the shared content-hash
+    // memo (RunnerFingerprint.ComputeFileContentHashMemoized), so for a package any other
+    // layer has already identified — which is every package the resolver indexed — it is a
+    // dictionary lookup rather than a SHA-256 pass over ~100MB of Base Application.
+    //
+    // The gate stays, for the reason that did NOT change: a Tier-1/Tier-2 entry never went
+    // through Tier 3, so it has no sidecars to replay and the call does nothing for it.
+    // That was always the load-bearing half; the read it also used to avoid is simply no
+    // longer part of the argument.
     private readonly record struct LoadedAppEntry(
         Assembly Asm, string Name, string Publisher, string Version, string SourcePath,
         string? Tier3CacheKey = null);
@@ -169,9 +178,11 @@ public sealed class DependencyLoader
                     // resolved as R3Driver's dependency). Gated on the stored Tier3CacheKey, not a
                     // File.Exists probe recomputed from scratch — a Tier-1/Tier-2 entry (the
                     // overwhelming majority: Base Application, System Application, most real ISV
-                    // .apps) never went through Tier 3 and has no sidecars to replay, and
-                    // ComputeSourceDependencyCacheKey hashes the WHOLE .app file, which would be a
-                    // real cost paid every cycle for a ~100MB Base Application package for no reason.
+                    // .apps) never went through Tier 3 and has no sidecars to replay, so the call
+                    // would do nothing at all for it, every cycle. (This comment also used to cite
+                    // the whole-.app SHA-256 the key computation performed; since #3043 that goes
+                    // through the shared content-hash memo, so that half of the rationale is gone
+                    // and "nothing to replay" is the whole of it.)
                     if (existing.Tier3CacheKey != null)
                         ReplayDependencyMetadataSidecars(m, existing.Tier3CacheKey);
                     list.Add(existing.Asm);


### PR DESCRIPTION
Closes #3043

`DependencyLoader.ComputeSourceDependencyCacheKey` ended its key with its own
`File.OpenRead` + SHA-256 over the whole `.app`, outside
`RunnerFingerprint.ComputeFileContentHashMemoized` — the one memo every other layer that
needs "which bytes is this package?" already shares (`AppLoader.ReadManifest` since #2987,
`AppLoader.ExtractAllDllPaths`, `BcAppSymbolCache`, `ProgramSupport.DependencyContentTerm`).

The issue's stated reason for filing this separately rather than folding it into #3042 was
that the obvious fix touches a **persisted** key. Both hazards are real, both were measured
rather than reasoned about, and **neither changes the key's value in this PR**.

## Hazard 1 — hex casing. Real, and handled.

`Convert.ToHexString` is uppercase; `RunnerFingerprint.ComputeContentHash` ends in
`.ToLowerInvariant()`. The `app-bytes:` line feeds the SHA-256 whose hex *is* the filename of
`compiled-deps/<key>.dll` and its five metadata sidecars, so swapping one source of the hash
for the other silently orphans every entry in every `~/.cache/al-runner/compiled-deps` and
every CI cache. `AppBytesTerm` uppercases the memo's answer back; hex round-trips exactly.

**Measured end-to-end, with a validated detector.** Pinning `RunnerFingerprint.ContentHash`
to a constant so a pre-fix and a post-fix build agree on every *other* key line, then running
`tests/runner-extras` (both package caches) into a fresh `--cache` root each time and
comparing the `compiled-deps/*.dll` filenames actually written:

| build | keys written | vs. pre-fix |
|---|---|---|
| pre-fix (`File.OpenRead` + `Convert.ToHexString`) | 7 | — |
| this PR | 7 | **identical filenames** |
| control: this PR with `.ToUpperInvariant()` removed | 7 | **all 7 different** |

The control row is what makes the middle row mean something — it shows the comparison detects
a key change rather than being incapable of noticing one. (A first attempt ran the three
builds into one *shared* warm root; the control wrote nothing there, so that comparison proved
nothing and was discarded. Fresh root per build is the version above.)

## Hazard 2 — the `unknown` sentinel. Real, and it throws.

`File.OpenRead` **threw** for a package it could not read. The memo returns
`RunnerFingerprint.UnknownContentHash` instead, and passing that through would give every
unidentifiable package one shared `app-bytes:UNKNOWN` line — the first such package's compiled
DLL *and* its five metadata sidecars served for every later one. `AppBytesTerm` refuses,
naming the package, which is exactly what the fresh read did
(`.claude/rules/loud-failures.md`), and is the cache-key analogue of the `null` that
`AppLoader.TryPackageIdentity` and `RecordPatches.BcAppFallback.SafeContentHash` return.

Unreachable in a real run, for the same reason `ProgramSupport.DependencyContentTerm`'s
degraded path is: a package the resolver indexed is one whose bytes it read (#2987), and
`AppLoader.ExtractAl` has already opened this one a few lines above the call site. Tested
anyway — #2954's bar for a defensive branch.

## The measured saving

Probe counting every SHA-256 file read (path + byte length), on `tests/runner-extras` with
both package caches, once on a cold `--cache` root and once warm:

| | files hashed outside the memo | bytes | memo computations | memo bytes |
|---|---|---|---|---|
| before, cold | 7 | 634,797 | 232 | 291.74 MB |
| before, warm | 7 | 634,797 | 232 | 291.74 MB |
| after, cold | **0** | **0** | 232 | 291.74 MB |
| after, warm | **0** | **0** | 232 | 291.74 MB |

All 7 were already in the memo before `DependencyLoader` re-read them — 750 memo lookups
apiece against one computation — so the work removed is a duplicate, not work that moved. The
memo's own totals are unchanged; the 7 reads become 7 dictionary lookups. Warm equals cold
because the key is computed on every run, cache HIT or MISS.

**0.61 MB is small and I am not going to dress it up.** Against the 291.74 MB the memo already
hashes it is 0.21%. Two things make it worth the change anyway: it removes the last `.app`
content hash outside the shared memo, so a future change to the memo (like #3042's device/inode
keying) applies uniformly; and the key stops mixing manifest fields observed at one time with a
content hash observed at another — see the composition note below.

**Correction — an earlier version of this body claimed the corpus leg's saving was zero, and
that was wrong.** It said `ComputeSourceDependencyCacheKey` "is never reached" on a
`tests/al-language` run. It is reached **three times**. The claim came from a badly configured
measurement, not from the code: my corpus probe ran one root instead of the two
`scripts/corpus-app-dirs.py` yields, and one package cache instead of the two `bc-tests.yml`
passes, so no Microsoft test-library package was ever resolved as a dependency. This is the
twin of a mistake I had already caught once in this same PR — a `compiled-deps` directory that
writes nothing reads exactly like "never reached" — and it got me from the other side.

Re-measured with the corpus invoked exactly as `bc-tests.yml` does (both roots, both package
caches, fresh absolute `--cache`), 2610/2610 passing:

| package | bytes | already in the memo when the key was computed? |
|---|---|---|
| `Microsoft_System Application Test Library.app` | 201,985 | yes |
| `Microsoft_Any.app` | 21,198 | yes |
| `AL_Language_AL_Internals_Test_Fixture_1_0_0_0.app` (`<cache>/workspace-deps/<hash>/`) | 2,316 | yes |
| **total** | **225,499** | |

Corroborated at file level: a fresh corpus cache root comes back with exactly 3
`compiled-deps/*.dll` plus 5 sidecars each, where the withdrawn claim predicts an empty
directory. All three were hashed by the memo *before* the key was computed — checked by
ordering the probe records, not assumed — so on the corpus leg too this is removed duplicate
work, not work that moved.

**The third row deserves its own sentence, because it is `InProcessAppPackager` output** — the
mid-run package writer the memo's own header names as the reason it stopped being path-keyed,
so "is it safe to memo-hash *that* one?" is the question this correction raises. It is, and the
reason is already recorded in the code: `AlRunner/BcCompiler.cs:151` documents that the layered
pre-pass republishes exactly such a package under a **new content-addressed path**
(`<cache>/workspace-deps/<hash>/…`) on every warm edit cycle. A content change therefore moves
the path, so there is no stable path for a stale entry to sit under — the republished package
arrives as a file the memo has never seen, whatever it held for the previous cycle.

225 KB is immaterial next to the 291.74 MB the memo already hashes, and it does not change the
case for this PR either way. It is corrected here because a later reader would otherwise cite
the withdrawn sentence.

## Composition with #3035's persisted index and #3042's memo key

Traced rather than re-derived, per #3042's review. That review established that a stale memo
hash would be written into `app-manifests/sha256-<hash>.json` and read by other processes, and
judged the composition safe: the only new staleness route #3042 introduces is inode reuse, no
code path reaches it, and its rename-replace row is strictly safer than the key #3035 shipped
with. This PR adds a second consumer of the same memoized hash, writing it into a different
persisted key space, so the same table applies unchanged.

One row of it does change meaning for this call site, and I would rather name it than have a
reviewer find it: on an **in-place rewrite landing on the same size and the same mtime tick**
— the memo's one documented blind spot, listed as "stale (unchanged)" in #3042 — the old fresh
read would have MISSed and recompiled, where this HITs and serves the earlier DLL. Two things
bound that. It is already the exposure for the manifest index, the r2r-chunks cache and the
AL-output key's dep terms in that same window, so this is not a new class of wrongness. And it
removes a genuine incoherence: today the key mixes `manifest.AppId/Publisher/Name/Version/
Dependencies` served from the memo-keyed index at time T1 with a content hash read fresh at
T2, so the two halves of one key could already describe different bytes. After this they come
from one observation.

## Does the same shape repeat? (answered: no, and here is the check)

Every `File.OpenRead` + SHA-256 site under `AlRunner/` was read, not grepped and assumed:

* `ProgramSupport/Dependencies.cs:473`, `ProgramSupport/SiblingCompile.cs:1105`,
  `BcCompiler.Incremental.cs:339` — all hash **`.al` source files**, not packages. Routing
  those through the memo would be a correctness regression, not a saving: they are the
  *watched, mutable* inputs whose edits `--watch` and server mode exist to notice, and the
  memo's stat-based invalidation is blind to a same-length write inside one mtime tick —
  plausible for a small source file being edited, not for a 100 MB package. They also hash
  each file once per key computation, so there is no duplicate read to remove.
* `ProgramSupport/ServerSupport.cs:23` — a changed-files diff, not a cache key; it
  deliberately swallows unreadable files.
* `Infrastructure/InProcessAppPackager.cs:293` (copies `.al` into a zip) and
  `Patches/RecordPatches.ReportMetadataVirtualTable.cs:710` (a PE metadata scan) are not
  content hashes at all.

So `DependencyLoader.cs:755` was the only remaining `.app` content hash outside the shared
memo. Sibling functions in `DependencyLoader`: it computes exactly one cache key, and the
single producer feeds both the reader (`LoadOne`) and the sidecar replay
(`ReplayDependencyMetadataSidecars`), so there is no second path to keep in step.

## RED → GREEN

`AlRunner.Tests/DependencyCacheKeyContentHashMemoTests.cs`, 9 tests. RED taken with the
pre-fix `app-bytes` expression restored behind the same seam so the file compiles:

```
Failed:  2, Passed:  7   (RED)
Passed:  9               (GREEN)
```

The two RED rows are the evidence:

* `Key_HashesThroughTheSharedMemo_AndASecondKeyForTheSamePackageReadsNothing` — `Expected: 2,
  Actual: 1` computations. **The issue's suggested assertion would not have caught this.**
  "`ContentHashComputationCountForTests` must not increase for the second read" is already
  true of the old code, because the old code never touched the memo at all. The assertion with
  teeth is that a key computed on a cold memo increments it by exactly one.
* `Key_NeverOpensThePackageItself_OnlyTheHashDelegateDoes` — `FileNotFoundException` from
  `File.OpenRead`. The package does not exist and the injected delegate is the only route to
  the bytes, so anything opening the file fails. Portable; no `chmod`, no root-dependent skip.

Three of the seven RED-passing rows pass there for the wrong reason and only have teeth after
the change (the sentinel tests inject a delegate the old code ignores, and the old code then
throws off its own `File.OpenRead`). Rather than leave that as a claim, both pins were mutation-
tested against the fixed code:

| mutation | fails |
|---|---|
| `return hash;` (drop `.ToUpperInvariant()`) | `Key_IsUnchangedByTheCasingOfTheHashItIsGiven`, `Key_IsByteIdenticalToTheFreshReadKeyThisReplaces` |
| `if (false)` (drop the sentinel guard) | `UnknownContentHash_Throws_…`, `EmptyContentHash_Throws_…`, `MissingPackage_StillThrows_…` |

`Key_IsByteIdenticalToTheFreshReadKeyThisReplaces` reproduces the pre-#3043 expression
verbatim in-process and asserts the two keys are equal, which is the in-process half of the
end-to-end filename comparison in Hazard 1.

## What else was run

* `dotnet test AlRunner.Tests --filter` over `DependencyCacheKeyContentHashMemoTests`,
  `RunnerFingerprint*`, `CacheKeyDependency*`, `CacheKeyUnhashableDependency*`,
  `AppLoaderManifest*`, `FileIdentity*`, `DependencyLoader*`, `DependencyMetadataMemo*`,
  `AlCacheWriterDependencyCacheOrdering*` — **60 passed, 0 failed**.
* `tests/runner-extras` (both package caches, `--strict --count-baseline`) on the exact tree
  pushed here: **cold 298/298 in 98.3 s, warm 298/298 in 52.0 s**, 7 `compiled-deps` entries
  written cold and re-used warm. The warm second run is the check `local-test-scope.md`
  requires for a cache-sensitive change, and it is the one that would show a key that failed
  to HIT itself.
* Not run: the full `AlRunner.Tests` suite (15–31 min, and the filter above covers the changed
  surface), and the `tests/al-language` corpus, where this code is never reached.

## The corpus question

**Nothing here belongs upstream, and the reason is that no claim in this PR is about Business
Central.** The change is entirely about how the runner names a file in its own on-disk cache:
which of two internal helpers computes a SHA-256, whether that hex is upper or lower case, and
what happens when a `.app` cannot be read. A BC service tier cannot adjudicate any of it —
delete AL Runner and not one of the nine tests is a statement about anything. There is also no
observable AL-visible behaviour change to write a corpus test *for*: the persisted key value is
byte-identical, proven above. Per `bc-behavior-tests-go-upstream.md` this is squarely the
"`tests/runner-extras`/`AlRunner.Tests`" side of the test, and the mechanism-test-under-
`AlRunner.Tests` shape is what the "Tests updated" gate wants here.

## Deliberately left out

* **A `--cache` relative-path defect found while measuring**, filed as #3084 rather than fixed
  here: a relative `--cache` path makes every `r2r-chunks` sidecar fail to load with
  `Path "…" is not an absolute path`, so the run drops to a lower tier where Base Application's
  objects do not exist. Measured on one bundle: relative `--cache` gives 0 pass / 3 fail and 16
  `[provision-gap]` blocks, absolute gives 3 pass / 0 fail and none. Same family as #2114,
  unrelated to this change.
* **`.al`-source hashing is not folded into the memo** — see the shape section; that would
  trade a real invalidation property for a saving that does not exist.

---

*Filed by Claude Code agent `stma-auto-1`, acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
