### PR TITLE
test(oos): stop a throw site from doubling the scope.md pointer, and read IL to do it

### DIFF
--- a/AlRunner.Tests/OutOfScopePointerCallSiteGuardTests.cs
+++ b/AlRunner.Tests/OutOfScopePointerCallSiteGuardTests.cs
@@ -1,0 +1,179 @@
+// OutOfScopePointerCallSiteGuardTests — no throw site may produce a doubled docs/scope.md.
+//
+// WHAT THIS ADDS OVER RunnerOutOfScopeMessagePointerTests (#3073)
+// ---------------------------------------------------------------
+// That file pins the NORMALISER: given these inputs, TrimTrailingDocPointer produces these
+// outputs. It proves the normaliser works on inputs someone thought to write down. It cannot
+// notice a twenty-fifth throw site written in a form nobody anticipated — which is the actual
+// failure #2766 was about, and the reason a per-site audit was proposed there in the first
+// place. This file pins the CALL SITES: whatever they write, the message that reaches a
+// developer names docs/scope.md once.
+//
+// WHY THIS READS IL AND NOT SOURCE
+// ---------------------------------
+// Three reasons, in order of how much they cost when ignored:
+//
+//   1. IL HAS NO COMMENTS. A raw-text scan of AlRunner/ finds 43 mentions of docs/scope.md, of
+//      which only 24 are live reason strings; the rest are comments, --guide text, the
+//      mechanism itself, and Cecil-injected literals. #3064 is the standing example of what
+//      happens when a guard cannot tell those apart — the Base App floor guard matched a
+//      COMMENT documenting compliance and failed a PR that contained no violation. A guard
+//      that has to special-case comments will drift out of step with them.
+//      ScratchDirOwnershipGuardTests carries the same warning in its own header ("Comment
+//      lines are not counted"), which is a heuristic this shape does not need.
+//
+//   2. IL SEES EVERY SPELLING. The same refusal is written as `new RunnerOutOfScopeException`,
+//      `new AlRunner.Infrastructure.RunnerOutOfScopeException`, and target-typed `new(...)`
+//      inside a factory method — and all three compile to one `newobj`. A source scan written
+//      for this exact task during #2766 measurement missed the second and third spellings and
+//      reported 7 sites where there were 24. That is not a hypothetical: it is why the count
+//      in #2766's title was wrong for weeks. A guard that under-reports is worse than none,
+//      because it certifies the thing it did not look at.
+//
+//   3. IT MEASURES WHAT SHIPS. The literals scanned here are the ones in the assembly a user
+//      runs, after the compiler has folded adjacent constants.
+//
+// WHAT COUNTS AS A VIOLATION
+// --------------------------
+// A literal is a CANDIDATE when a human reading it would say it ends with a pointer sentence:
+// strip trailing punctuation, brackets and quotes, and what remains ends "see docs/scope.md".
+// The guard peels more liberally than the normaliser ON PURPOSE — that gap is the whole
+// mechanism. A candidate the normaliser does not strip is the defect, because BuildMessage
+// then appends its own link and the reader sees the file named twice.
+//
+// Two shapes are deliberately NOT candidates, and both are load-bearing rather than
+// convenient:
+//
+//   * An ANCHORED pointer ("docs/scope.md#email") carries a section the appended bare link
+//     does not, so it survives by design — RunnerOutOfScopeMessagePointerTests requires it.
+//     It is excluded here by construction, not by an exception: peeling leaves "…#email",
+//     which does not end "see docs/scope.md".
+//   * A pointer MID-SENTENCE is prose about the file, not a citation of it.
+//
+// Separately, a literal that carries the whole `out-of-scope: <api> — <reason> — see …`
+// convention by itself — the Cecil-injected throw sites and HelperShims, which cannot
+// construct the typed exception (#1743) and so never reach the normaliser at all — is checked
+// against the same end state from the other direction: it must name the file exactly once,
+// since nothing will be appended to it.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AlRunner.Infrastructure;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class OutOfScopePointerCallSiteGuardTests
+{
+    private const string Pointer = "docs/scope.md";
+    private const string Convention = "out-of-scope: ";
+
+    /// <summary>
+    /// Types that DEFINE the convention rather than cite it. Their literals are the mechanism
+    /// — the bare file name, the prefix — and are not throw-site reasons.
+    /// </summary>
+    private static bool IsMechanism(TypeDefinition t)
+    {
+        var n = t.FullName;
+        return n.StartsWith("AlRunner.Infrastructure.RunnerOutOfScopeException", StringComparison.Ordinal)
+            || n.StartsWith("AlRunner.Infrastructure.OutOfScopeMessage", StringComparison.Ordinal)
+            || n.StartsWith("AlRunner.Infrastructure.RunnerScope", StringComparison.Ordinal);
+    }
+
+    private static int Occurrences(string haystack, string needle)
+    {
+        int count = 0, i = 0;
+        while ((i = haystack.IndexOf(needle, i, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            i += needle.Length;
+        }
+        return count;
+    }
+
+    /// <summary>
+    /// Would a human read this literal as ending in a pointer sentence? Deliberately more
+    /// permissive than <see cref="RunnerOutOfScopeException.TrimTrailingDocPointer"/>: every
+    /// trailing non-alphanumeric character is peeled, so any wrapping punctuation an author
+    /// invents is still recognised here even when the normaliser does not handle it yet.
+    /// </summary>
+    private static bool EndsWithAPointerSentence(string s)
+    {
+        var t = s.TrimEnd();
+        int end = t.Length;
+        while (end > 0 && !char.IsLetterOrDigit(t[end - 1])) end--;
+        return t[..end].EndsWith("see " + Pointer, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void NoThrowSiteWritesAPointerTheNormaliserCannotStrip()
+    {
+        var path = typeof(RunnerOutOfScopeException).Assembly.Location;
+        using var asm = AssemblyDefinition.ReadAssembly(path);
+
+        var offenders = new List<string>();
+        var candidates = 0;
+        var mentions = 0;
+
+        foreach (var type in asm.MainModule.GetTypes())
+        {
+            if (IsMechanism(type)) continue;
+            foreach (var method in type.Methods)
+            {
+                if (!method.HasBody) continue;
+                foreach (var ins in method.Body.Instructions)
+                {
+                    if (ins.OpCode != OpCodes.Ldstr || ins.Operand is not string s) continue;
+                    if (!s.Contains(Pointer, StringComparison.Ordinal)) continue;
+                    mentions++;
+
+                    var where = $"{type.FullName}.{method.Name}";
+
+                    // A whole hand-built message: nothing gets appended to it, so it must
+                    // already name the file exactly once.
+                    if (s.Contains(Convention, StringComparison.Ordinal))
+                    {
+                        var n = Occurrences(s, Pointer);
+                        if (n != 1)
+                            offenders.Add(
+                                $"{where}\n    names {Pointer} {n} times in one hand-built "
+                                + $"'{Convention}' message, which nothing normalises\n    literal: {s}");
+                        continue;
+                    }
+
+                    if (!EndsWithAPointerSentence(s)) continue;
+                    candidates++;
+
+                    if (RunnerOutOfScopeException.TrimTrailingDocPointer(s) == s)
+                        offenders.Add(
+                            $"{where}\n    ends with a {Pointer} pointer that "
+                            + $"TrimTrailingDocPointer does not strip, so BuildMessage's appended "
+                            + $"link names the file twice\n    literal: {s}");
+                }
+            }
+        }
+
+        // A guard that scans nothing passes for the wrong reason (#3022). These two floors say
+        // the walk actually reached the refusal surface; they are lower bounds, not counts, so
+        // deleting a refusal does not fail this test spuriously.
+        Assert.True(mentions >= 20,
+            $"expected the IL walk to find at least 20 {Pointer} literals in {path}, found "
+            + $"{mentions} — the scan is not reaching the refusal sites and this guard is "
+            + "certifying nothing");
+        Assert.True(candidates >= 15,
+            $"expected at least 15 trailing-pointer reason literals, found {candidates} — see "
+            + "the comment above; a collapse here means the classifier stopped recognising the "
+            + "shape it exists to police");
+
+        Assert.True(offenders.Count == 0,
+            $"{offenders.Count} out-of-scope throw site(s) produce a message naming {Pointer} "
+            + "more than once.\n\n"
+            + "Write the reason WITHOUT a trailing 'see docs/scope.md' — "
+            + "RunnerOutOfScopeException appends the canonical link itself. An anchored pointer "
+            + "('docs/scope.md#email') is fine and survives on purpose. See issue #3073 and "
+            + "AlRunner.Tests/RunnerOutOfScopeMessagePointerTests.cs.\n\n"
+            + string.Join("\n\n", offenders));
+    }
+}

--- a/AlRunner.Tests/RunnerOutOfScopeMessagePointerTests.cs
+++ b/AlRunner.Tests/RunnerOutOfScopeMessagePointerTests.cs
@@ -62,6 +62,20 @@ public class RunnerOutOfScopeMessagePointerTests
     // Colon lead-in — same TrimEnd set, also in live use.
     [InlineData("testpage-action — the page has no such action: see docs/scope.md",
                 "testpage-action — the page has no such action")]
+    // BRACKETED FORMS (#3073). No live throw site writes one today — the only two
+    // "(see docs/scope.md" occurrences in AlRunner/ are both comments — so these are the hole
+    // rather than a bug anyone is hitting. They belong here because the normaliser's whole
+    // stated rationale is that it also covers every throw site written AFTER it; a form it
+    // silently passes through weakens exactly that claim, and nothing fails when an author
+    // writes one, so it would survive review. OutOfScopePointerCallSiteGuardTests is the other
+    // half: this pins the normaliser, that one pins the call sites.
+    [InlineData("testpage-action — the page declares no OnAction trigger (see docs/scope.md)",
+                "testpage-action — the page declares no OnAction trigger")]
+    [InlineData("email-smtp — sending mail needs a real SMTP server [see docs/scope.md]",
+                "email-smtp — sending mail needs a real SMTP server")]
+    // Bracket AND a trailing sentence period.
+    [InlineData("testpage-action — the page has no such action (see docs/scope.md).",
+                "testpage-action — the page has no such action")]
     public void ReasonEndingInAScopePointerYieldsExactlyOnePointerInTheMessage(
         string reason, string expectedReason)
     {

--- a/AlRunner/Infrastructure/RunnerOutOfScopeException.cs
+++ b/AlRunner/Infrastructure/RunnerOutOfScopeException.cs
@@ -76,12 +76,23 @@ public sealed class RunnerOutOfScopeException : Exception
     /// link does not necessarily repeat, and a pointer in the MIDDLE of a sentence is prose.
     /// <c>Reason</c> keeps its anchor either way — <c>ExpectationManifest.ReasonAnchor</c>
     /// reads the text BEFORE the first em-dash separator, which this never touches.</para>
+    ///
+    /// <para>"Trailing" tolerates the punctuation an author wraps the pointer in — a closing
+    /// bracket, a sentence period, or both: "(see docs/scope.md)", "[see docs/scope.md]",
+    /// "(see docs/scope.md).". #3073 added those. No throw site writes one today, so this is
+    /// closing the hole rather than fixing a live doubling: a form passed through silently
+    /// would contradict the paragraph above, which is what makes it worth handling at all.
+    /// <c>OutOfScopePointerCallSiteGuardTests</c> enforces the other half — that no call site
+    /// defeats this method — by reading the compiled IL.</para>
     /// </summary>
     internal static string TrimTrailingDocPointer(string reason)
     {
         if (string.IsNullOrEmpty(reason)) return reason;
-        var trimmed = reason.TrimEnd();
-        if (trimmed.EndsWith(".")) trimmed = trimmed[..^1].TrimEnd();
+        // Peel a trailing sentence period and/or closing bracket before looking for the
+        // pointer. Safe to over-peel here: the pointer itself ends in a letter, so if what is
+        // underneath is not the pointer we return `reason` UNCHANGED below, never the peeled
+        // text — that early return is what keeps a reason like "… Report 'X' (5)" intact.
+        var trimmed = reason.TrimEnd().TrimEnd(' ', '\t', '.', ')', ']');
         const string Pointer = "docs/scope.md";
         if (!trimmed.EndsWith(Pointer, StringComparison.OrdinalIgnoreCase)) return reason;
 
@@ -89,7 +100,9 @@ public sealed class RunnerOutOfScopeException : Exception
         // "See" / "see" is the only lead-in in use; anything else is prose that happens to end
         // in the file name and is left alone rather than silently truncated.
         if (!head.EndsWith("see", StringComparison.OrdinalIgnoreCase)) return reason;
-        return head[..^3].TrimEnd().TrimEnd('.', ',', ';', ':').TrimEnd();
+        // The opening bracket of a "(see …)" wrapper is dropped with the same pass that drops
+        // the lead-in punctuation, so the sentence in front of it is all that is left.
+        return head[..^3].TrimEnd().TrimEnd('.', ',', ';', ':', '(', '[').TrimEnd();
     }
 
     // Stable contract format. AL tests match with:


### PR DESCRIPTION
Closes #3073

Opened by agent **impl-1**, which also filed #3073 while measuring #2766.

Two parts. The guard is the one that matters — #2766 asked for a per-site audit, and an audit
does not survive the next call site.

## 1. The normaliser now peels a bracket

`TrimTrailingDocPointer` peels a closing bracket and a sentence period before looking for the
pointer, so these normalise like the forms already handled:

```
"… trigger (see docs/scope.md)"    -> "… trigger"
"… server [see docs/scope.md]"     -> "… server"
"… action (see docs/scope.md)."    -> "… action"
```

No throw site writes one today — the only two `(see docs/scope.md` occurrences in `AlRunner/`
are both comments — so this closes a hole rather than fixing a live doubling. It is worth
closing because the method's stated rationale is that it also covers throw sites written after
it, and a form it passes through silently contradicts that while failing nothing.

An anchored pointer and a mid-sentence mention still survive untouched; the peel is safe
because a non-match returns the reason **unchanged** rather than the peeled text, which is what
keeps a reason like `… Report 'X' (5)` intact.

## 2. `OutOfScopePointerCallSiteGuardTests` — the real deliverable

`RunnerOutOfScopeMessagePointerTests` pins the normaliser against inputs someone thought to
write down. It cannot notice a twenty-fifth call site written in a form nobody anticipated.
This guard pins the call sites: it walks the compiled assembly and fails if any throw site
produces a message naming `docs/scope.md` more than once.

**It reads IL, not source.** Three reasons:

1. **IL has no comments.** A raw-text scan of `AlRunner/` finds **43** mentions, of which only
   **24** are live reason strings; the rest are comments, `--guide` text, the mechanism itself,
   and Cecil-injected literals. #3064 is the standing example of what happens when a guard
   cannot tell those apart — the Base App floor guard matched a *comment documenting
   compliance* and failed a PR containing no violation. `ScratchDirOwnershipGuardTests` carries
   the same warning in its own header; this shape does not need the heuristic.
2. **IL sees every spelling.** `new RunnerOutOfScopeException`, the fully-qualified form, and
   target-typed `new(...)` inside a factory all compile to one `newobj`. The source scan I
   wrote for the #2766 measurement missed the second and third and reported **7** sites where
   there were **24** — that is why #2766's title carried a wrong count. A guard that
   under-reports certifies what it did not look at.
3. **It measures what ships**, after the compiler has folded adjacent constants.

**What counts as a violation.** A literal is a candidate when peeling all trailing
non-alphanumerics leaves text ending `see docs/scope.md`. The guard peels *more liberally than
the normaliser on purpose* — that gap is the detection mechanism. A candidate the normaliser
does not strip is the defect. Anchored pointers (`docs/scope.md#email`) and mid-sentence
mentions are excluded **by construction**, not by an exception list: neither ends that way.

Hand-built complete messages — the Cecil-injected sites and `HelperShims`, which cannot
construct the typed exception (#1743) and never reach the normaliser — are checked from the
other direction: exactly one mention, because nothing gets appended to them.

## Mutation proof

Asserting a guard runs is not the same as proving it fires. Both classifier branches were
proved with a temporary probe, then the probe was removed:

```
AlRunner.Patches.MutationProbe.Boom
    ends with a docs/scope.md pointer that TrimTrailingDocPointer does not strip, so
    BuildMessage's appended link names the file twice
    literal: mutation-probe — this refusal names the doc twice, see docs/scope.md;

AlRunner.Patches.MutationProbe.HandBuilt
    names docs/scope.md 2 times in one hand-built 'out-of-scope: ' message, which nothing
    normalises
    literal: out-of-scope: MutationProbe.HandBuilt — probe — see docs/scope.md — see docs/scope.md
```

The first probe uses a trailing `;` **after** the file name — punctuation the widened
normaliser still does not peel — so it proves the guard catches a form the fix does not cover,
which is the whole point of having both.

Two floors (at least 20 literals, at least 15 candidates; actual **41** and **25**) exist
because a guard that scans nothing passes for the wrong reason (#3022). They are lower bounds,
so deleting a refusal does not fail this spuriously.

## Verification

- RED → GREEN on part 1: the three bracket cases failed, then passed.
- **479 passed**, 15 skipped, 0 failed across `~OutOfScope|~Refusal|~ObjectMetadata|~ShapeGap|~Expectation|~Guard`.
- Full al-language corpus, `--strict --count-baseline`, private `--cache` outside the repo:
  **2610/2610 pass, 0 fail, 0 error, exit 0**, baseline matched, buckets intact (2 `pass-oos`,
  12 `pass-known-gap`, 1 `pass-divergence`).

The corpus count is 2610 here against the 2599 I reported on #2766 earlier today; the
difference is the submodule pin moving on `main` between the two branches, not this change. I
had written 2599 into the commit message before running it on this branch and amended it after
measuring rather than shipping a number I had not taken in this state.

## Deliberately left out

Widening the normaliser to peel *every* trailing punctuation character. That would close the
gap the guard detects through, leaving nothing to detect. The split is intentional: the
normaliser handles the forms authors actually write, the guard catches the ones they invent.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
