### PR TITLE
test(expectations): declare the two RunObject-without-a-handler gaps ahead of the pin

### DIFF
--- a/tests/expectations/known-gaps-testpage-runobject-no-handler.json
+++ b/tests/expectations/known-gaps-testpage-runobject-no-handler.json
@@ -4,15 +4,15 @@
     "CodeunitName": "TPARONH Tests",
     "Method": "RunObjectActionWithoutAHandlerOpensItsTargetUnattended",
     "Mode": "expect-fail-known-gap",
-    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2975",
-    "Note": "A page action's RunObject invoked with NO handler bound: real BC opens the target anyway, runs its OnOpenPage, and raises nothing AL can see -- measured on 27.0, 27.3, 27.5, 28.0, 28.1, 28.2, 28.3 and 28.4 (StefanMaron/BusinessCentral.AL.Language.Tests#185). The runner refuses instead, with NavNCLMissingUIHandlerException 'Unhandled UI: Page 60282'. #2951 made an action's RunObject perform its target, which is why the sibling eight-test suite (codeunit 60455 'TPARO Tests') passes here; the no-handler arm was deliberately held out of that suite while the question was open and is what #2975 still tracks. The three control arms in THIS codeunit pass on the runner -- a plain Page.Run on the same target IS refused, an OnAction trigger calling Page.Run on the same host and row IS refused, and the logging target does record its own opening when a handler is bound -- so the fixture, the target page and the action-invoke path are all ruled out, and the RunObject declaration is the only thing left."
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3090",
+    "Note": "A page action's RunObject invoked with NO handler bound: real BC opens the target anyway, runs its OnOpenPage, and raises nothing AL can see -- measured on 27.0, 27.3, 27.5, 28.0, 28.1, 28.2, 28.3 and 28.4 (StefanMaron/BusinessCentral.AL.Language.Tests#185). The runner refuses instead, with NavNCLMissingUIHandlerException 'Unhandled UI: Page 60282'. #2951 made an action's RunObject perform its target, which is why the sibling eight-test suite (codeunit 60455 'TPARO Tests') passes here; the no-handler arm was deliberately held out of that suite while the question was open and is what #3090 tracks. #3090 rather than #2975 on purpose: #2975's title concludes BC does not perform the RunObject at all, and #185 overturns exactly that half by measuring the target opening; #3090 states the gap the way the service tier measured it, and stays open after this entry lands. The three control arms in THIS codeunit pass on the runner -- a plain Page.Run on the same target IS refused, an OnAction trigger calling Page.Run on the same host and row IS refused, and the logging target does record its own opening when a handler is bound -- so the fixture, the target page and the action-invoke path are all ruled out, and the RunObject declaration is the only thing left."
   },
   {
     "codeunitId": 60285,
     "CodeunitName": "TPARONH Tests",
     "Method": "RunObjectActionOnTheControlsTargetWithoutAHandler_NoThrow",
     "Mode": "expect-fail-known-gap",
-    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2975",
-    "Note": "The same gap as the entry above, aimed at the clean Card target rather than the logging one, so the comparison has a RunObject side on exactly the page the two Page.Run controls refuse. Its whole claim is that the statement completes; the runner raises NavNCLMissingUIHandlerException 'Unhandled UI: Page 60281' instead."
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3090",
+    "Note": "The same gap as the entry above, tracked by #3090 for the same reason, aimed at the clean Card target rather than the logging one, so the comparison has a RunObject side on exactly the page the two Page.Run controls refuse. Its whole claim is that the statement completes; the runner raises NavNCLMissingUIHandlerException 'Unhandled UI: Page 60281' instead."
   }
 ]


### PR DESCRIPTION
Closes #3090

Declares the two `Codeunit60285` failures as known gaps so the next corpus pin bump has somewhere green to land. **No pin bump here** — deliberately.

## What actually fails today

Re-measured rather than carried forward. Current `main` (`b78a1291`, pin `0309cec`, so with #3061 merged) against corpus `master` at `360e1f0`, BC 28.1.49838.53910, all three corpus apps:

```
Tests: 2672 total   pass: 2670 (pass-known-gap 16)   fail: 2

FAIL  Codeunit60285.RunObjectActionWithoutAHandlerOpensItsTargetUnattended
FAIL  Codeunit60285.RunObjectActionOnTheControlsTargetWithoutAHandler_NoThrow
```

Two, not the seven I reported earlier on #2876 — `main` moved underneath that number and every other failure has since been absorbed by merged work. Both remaining ones are the same refusal:

```
Unexpected out-of-scope: TestPage action 1801247129 on page 60283
(reason: testpage-action — ... An action whose effect is RunObject cannot be performed here.)
  at AlRunner.Patches.RunnerPageInstance.RaiseOnAction(Int32 actionId)
```

## Classification, and why this mode

`expect-fail-known-gap`, both. The surface is in scope, real BC does it, the runner does not yet, and #3090 tracks the work — which is the whole of what the mode asserts. Not `expect-oos`: #3027 already recorded the `testpage-action` refusals as gaps rather than scope boundaries, and this mode accepts any non-pass result, an out-of-scope signal included. That is the same reasoning the RunObject entries in #2979 give for codeunit 60455, so the two files agree.

Nothing in either `Note` claims anything about BC that a service tier has not confirmed. Corpus #185 is green on all eight legs (27.0, 27.3, 27.5, 28.0–28.4), and the corpus file's own header records that it measures **the opposite of what it asserted when first written**: the invoke raises nothing AL can see, *and* the target page opens anyway and runs its own `OnOpenPage`.

That is also why #3090 is a new issue rather than a link to #2975. #2975's title concludes BC does not perform the RunObject at all; #185 keeps the "AL is never told" half and overturns the other. Attaching these entries to #2975 would have buried a contradiction inside a `Note`. #3090 stays open after this merges.

## Verified by re-running, not by reading

The silent-match trap is real and I checked for it explicitly rather than trusting the file:

| run | result |
|---|---|
| current pin `0309cec` + these entries | **2664/2664, exit 0**, `pass-known-gap` **16** |
| corpus master `360e1f0` + these entries | **2672/2672, exit 0**, `pass-known-gap` **18** |
| corpus master `360e1f0`, entries absent | 2 failures, exit 1 |
| corpus master `360e1f0`, `CodeunitName` changed to `"TPARONH Testz"` | 2 failures, exit 1, `pass-known-gap` back to **16** |

The last row is the negative control. One wrong letter makes both entries inert and **nothing warns** — no "entry matched nothing", no stale-entry audit, just a red run that looks like the gap was never declared. So the `pass-known-gap` 16 → 18 movement in row 2 is what proves the entries actually take effect.

Row 1 is the safety check for landing ahead of the pin: at `main`'s own pin codeunit 60285 does not exist, the entries match nothing, and the run stays green with the count baseline satisfied. I confirmed against `ExpectationManifest.cs` and `docs/expectations.md` that drift is only detected for tests that **run**, so an entry ahead of the pin is inert by design rather than by luck.

## What I did not do, and why

**No pin bump**, per the request — and there is a second reason to keep it out. Three open PRs are each already bumping the pin independently and writing their own known-gaps files for overlapping failures:

| PR | closes | bumps pin to | new expectations files |
|---|---|---|---|
| #2979 | #2932 | `3ba2fdd` | `module-ownership`, `testpage-part-draft-line`, `testpage-runobject-action` |
| #3074 | #3066 | `8333e31` | `module-ownership` (same filename as #2979), `table-event-subscriber-error` |
| #3061 | #3050 | `0309cec` | merged already |

They will collide with each other on the gitlink, on `count-baseline/test-count-baseline.json` and on `history.md`. Adding a fourth bump would make that worse. This PR touches exactly one new file that nobody else is writing, so it conflicts with none of them in either direction.

**Nothing else needed an entry.** Every other failure I measured is either already covered or already fixed — see the report I am handing back with this. In particular `Codeunit60490.TableEventSubscriberInAnotherApp_ErrorReachesTheCaller` is **not** untracked: it is #2932, and #2979 fixes it rather than classifying it. I did not file a duplicate.

The diff touches only `tests/expectations/`, so the `Tests updated` gate is not triggered.

Authored by an agent (impl-2).

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
