### PR TITLE
feat(preflight): check that the code-navigation tools answer, not that they exist

### DIFF
--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -143,6 +143,31 @@ the cause.
 
 7. **No stale worktree for this identity**, and no leftover scratch directories from a killed
    run.
+8. **Code-navigation tooling answers correctly** — the C# language server behind
+   `tools/lsp-query.py`, `graphify`, and the bc-decompiler MCP server. Not "is it installed":
+   each of these fails by producing a confidently wrong answer rather than an error, so the
+   check is whether it returns a **known-good answer** that the checkout is verified to contain.
+
+   - `tools/lsp-query.py` exits 2 when the server never answered. Read as "nothing calls this",
+     that is a false negative wearing the shape of a finding.
+   - `graphify update` and `graphify query` both default to `graphify-out/graph.json` *relative
+     to the current directory*, so a rebuild in one directory and a query in another silently
+     use different files. A root-level copy once sat 13 days stale while the documented rebuild
+     appeared to work.
+   - `.mcp.json` changes need a **session restart**, so "configured" and "usable right now" are
+     different states and only the second is worth anything. Preflight establishes the second by
+     speaking MCP to the server directly; a session still has to restart before it can call it.
+
+   Each probe also validates its own fixture against the working tree first, so a renamed symbol
+   reports as "this check's probe drifted" rather than as a broken language server.
+
+   **These WARN and never FAIL.** They do not affect whether the runner is correct, only how
+   fast and how accurately an agent reads it, and every one degrades to a documented fallback
+   (`rg`, `tools/context-pack.py`) that still produces correct work. Halting an unattended cycle
+   over a four-day-old graph file costs more than the staleness does, and the remedy is a
+   two-second rebuild. `--strict` is where zero tolerance belongs, because that is the caller's
+   policy and not this step's. Keeping FAIL for the checks that genuinely mean "this box will
+   produce wrong answers" is what keeps FAIL worth reading.
 
 **Print the preflight as a readable report** — one line per check, PASS or FAIL with the reason
 and the command that produced it. That report is what a new contributor reads to find out

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -150,10 +150,6 @@ the cause.
 
    - `tools/lsp-query.py` exits 2 when the server never answered. Read as "nothing calls this",
      that is a false negative wearing the shape of a finding.
-   - `graphify update` and `graphify query` both default to `graphify-out/graph.json` *relative
-     to the current directory*, so a rebuild in one directory and a query in another silently
-     use different files. A root-level copy once sat 13 days stale while the documented rebuild
-     appeared to work.
    - `.mcp.json` changes need a **session restart**, so "configured" and "usable right now" are
      different states and only the second is worth anything. Preflight establishes the second by
      speaking MCP to the server directly; a session still has to restart before it can call it.
@@ -161,13 +157,26 @@ the cause.
    Each probe also validates its own fixture against the working tree first, so a renamed symbol
    reports as "this check's probe drifted" rather than as a broken language server.
 
-   **These WARN and never FAIL.** They do not affect whether the runner is correct, only how
-   fast and how accurately an agent reads it, and every one degrades to a documented fallback
-   (`rg`, `tools/context-pack.py`) that still produces correct work. Halting an unattended cycle
-   over a four-day-old graph file costs more than the staleness does, and the remedy is a
-   two-second rebuild. `--strict` is where zero tolerance belongs, because that is the caller's
-   policy and not this step's. Keeping FAIL for the checks that genuinely mean "this box will
-   produce wrong answers" is what keeps FAIL worth reading.
+   **Repair the graph, do not report it.** `graphify update` and `graphify query` both default
+   to `graphify-out/graph.json` *relative to the current directory*, and two things follow:
+
+   - A **stale** graph is rebuilt, not classified. It costs about two seconds warm, and telling
+     a human to run a two-second command is asking a person to do a script's job — in an
+     unattended loop there is no person to ask.
+   - A **stray** `graphify-out/` outside `AlRunner/` is deleted. It is gitignored derived data,
+     and while it exists a query run from the repository root reads it instead. Measured: an
+     18-day-old root copy answered `No matching nodes found.` — exit 0 — for a symbol that
+     exists, while the correct graph returned 11 nodes. A rebuild under `AlRunner/` never
+     touches it, so the two diverge indefinitely; that is the 13-day-stale incident `CLAUDE.md`
+     records. Both repairs are reported rather than folded into a silent PASS.
+
+   **Severity: WARN, with one exception.** A tool that is absent or unusable does not halt a
+   cycle — each degrades to a documented fallback (`rg`, `tools/context-pack.py`) that still
+   produces correct work, so it makes an agent slower rather than wrong, and `--strict` is where
+   zero tolerance belongs. The exception is a **stray graph that could not be deleted**: that is
+   not a missing tool, it is a tool confidently answering wrong, with no fallback and no rebuild
+   that fixes it. That one FAILs. Keeping FAIL for "this box produces wrong answers" is what
+   keeps FAIL worth reading.
 
 **Print the preflight as a readable report** — one line per check, PASS or FAIL with the reason
 and the command that produced it. That report is what a new contributor reads to find out

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -26,8 +26,14 @@ tools/lsp-query.py, graphify, and the bc-decompiler MCP server (#3087). Those
 three do not affect whether the runner is correct; they affect whether an agent
 gets a confidently wrong answer while reading it, which each of them has already
 produced here. So they are probed for a KNOWN-GOOD ANSWER rather than for
-presence, and they only ever WARN -- see the comment on LSP_PROBE_SYMBOL for why
-a stale graph must not be allowed to halt a cycle.
+presence -- an installed-but-broken tool returns nothing, which is what a real
+negative looks like.
+
+The graph is REPAIRED rather than reported: a stale one is rebuilt (~2s) and a
+stray copy outside AlRunner/ is deleted, because telling a human to run a
+two-second command is asking a person to do a script's job and an unattended loop
+has no person to ask. This is the only check in this file that writes anything;
+--no-tools skips it. See the comment on LSP_PROBE_SYMBOL for the severity split.
 
 Usage:
     tools/preflight.py                 # human-readable report
@@ -100,21 +106,25 @@ OMARCHY_USAGE_BIN = "/usr/share/omarchy/bin/omarchy-agent-usage-claude"
 # nothing. Each probe additionally validates its own fixture against the checkout,
 # so a probe that has drifted reports itself as drifted instead of blaming the tool.
 #
-# SEVERITY: these top out at WARN and never FAIL, which is a deliberate choice
-# rather than an oversight.
+# SEVERITY: WARN by default, with exactly one condition that can FAIL. The split
+# is the point, so it is spelled out.
 #   - overall_exit() turns any FAIL into exit 1, and the autonomous cycle treats
-#     that as "do not start". Halting an unattended cycle because a 3.4 MB graph
-#     file is four days old costs far more than the staleness does, and the
-#     remedy is a two-second rebuild.
-#   - Every one of these degrades to a documented fallback that still produces
-#     correct work: ripgrep, tools/context-pack.py, reading the DLL another way.
-#     A missing navigation tool makes an agent slower, not wrong.
-#   - `--strict` already exists for the operator who wants zero tolerance: it
-#     turns any WARN into exit 2. That is the right place for that policy,
-#     because it is the caller's call and not this file's.
-# A genuinely untrustworthy box is what FAIL is for -- disk, memory, push, the
-# corpus baseline. Navigation tooling is not that, and saying so keeps FAIL
-# meaning something.
+#     that as "do not start". A tool being absent, or a server not answering, does
+#     not earn that: each degrades to a documented fallback that still produces
+#     correct work (ripgrep, tools/context-pack.py, reading the DLL another way),
+#     so it makes an agent slower rather than wrong. `--strict` already turns any
+#     WARN into exit 2 for a caller who wants zero tolerance.
+#   - The exception is a STRAY GRAPH that could not be removed. That one is not
+#     "a tool is missing", it is a tool CONFIDENTLY ANSWERING WRONG: measured, an
+#     18-day-old graph at the repo root returned "No matching nodes found." -- exit
+#     0 -- for a symbol that exists, while the correct graph returned 11 nodes. No
+#     rebuild fixes it, because a rebuild under AlRunner/ never touches it. That is
+#     precisely the class of failure preflight exists to catch, so it can halt.
+#     Preflight deletes it first and only fails if it could not.
+#   - Staleness is not reported at all any more. It is repaired -- see
+#     probe_graphify.
+# Keeping FAIL for "this box produces wrong answers" is what keeps FAIL worth
+# reading; the stray graph is in that category, and nothing else here is.
 LSP_PROBE_SYMBOL = "SafeDirectoryScan"
 # The answer the probe must get back. Checked against the working tree first, so a
 # rename turns into "the probe fixture moved" rather than "the language server is
@@ -1233,7 +1243,13 @@ class GraphifyState:
     graph_mtime: Optional[float] = None
     newest_source: Optional[float] = None
     newest_source_path: str = ""
-    stray: list = field(default_factory=list)   # other graph.json copies a query could pick up
+    stray_removed: list = field(default_factory=list)   # stray graph dirs preflight deleted
+    stray_kept: list = field(default_factory=list)      # stray graph dirs it could NOT delete
+    stray_error: str = ""
+    rebuilt: bool = False               # preflight ran `graphify update .` itself
+    rebuild_rc: Optional[int] = None
+    rebuild_secs: Optional[float] = None
+    rebuild_out: str = ""
     query_rc: Optional[int] = None
     query_out: str = ""
 
@@ -1315,46 +1331,63 @@ def classify_lsp(st: LspState) -> CheckResult:
 
 
 def classify_graphify(st: GraphifyState) -> CheckResult:
-    """Verdict on graphify, including the two traps that produce wrong answers quietly."""
+    """Verdict on graphify.
+
+    Two failure modes, and they are NOT the same size:
+
+    * A **stray graph outside AlRunner/** makes a query run from the repo root read
+      a different file, indefinitely -- rebuilding the canonical one does not touch
+      it. Measured on the box this was written on: an 18-day-old root copy answered
+      `No matching nodes found.` for a symbol that exists, while the correct graph
+      returned 11 nodes. That is a confident false negative, which is the failure
+      class preflight exists to catch, so it can FAIL. Preflight deletes the stray
+      first (it is gitignored, derived, and rebuilt in two seconds) and only fails
+      if it could not.
+
+    * A **stale graph** is not reported at all any more, because reporting it asked a
+      human to run a two-second command -- and in an unattended loop there is no
+      human to ask. `probe_graphify` rebuilds it and this says that it did. CLAUDE.md
+      already says "rebuild rather than wonder whether it is current".
+    """
     name = "nav-graphify"
     cmd = f"cd {GRAPHIFY_DIR} && graphify query \"{GRAPHIFY_PROBE_QUERY}\""
     rebuild = f"cd {GRAPHIFY_DIR} && graphify update .   # ~2 seconds"
+    stray_why = (
+        "Both `graphify update` and `graphify query` default to graphify-out/graph.json "
+        "relative to the CURRENT directory, so a query run from the repository root "
+        "reads the stray one and a rebuild under AlRunner/ never touches it. A stale "
+        "graph answers `No matching nodes found.` -- and exits 0 -- for symbols that "
+        "exist, which is indistinguishable from a true negative.")
     if not st.binary:
         return CheckResult(name=name, status="WARN", command="command -v graphify",
                            summary="graphify is not on PATH",
                            remedy="Install it, or use tools/context-pack.py and rg instead. "
                                   "Nothing is blocked.")
-    # The wrong-directory trap first: it is the one that answers, plausibly, from the
-    # wrong file. A stale graph you know about is better than a fresh one you are not
-    # actually querying.
-    if st.stray:
+    # A stray that is still there is the one condition here that can halt a cycle: it
+    # produces wrong answers, silently, and no rebuild fixes it.
+    if st.stray_kept:
         return CheckResult(
-            name=name, status="WARN", command=cmd,
-            summary=f"a second graph exists outside {GRAPHIFY_DIR}/ and a query run from "
-                    f"there would silently use it",
-            detail=[f"stray: {p}" for p in st.stray] +
-                   [f"canonical: {st.graph or '(missing)'}",
-                    "Both `graphify update` and `graphify query` default to "
-                    "graphify-out/graph.json relative to the CURRENT directory, so a "
-                    "rebuild in one place and a query in another use different files "
-                    "with no warning."],
-            remedy=f"Delete the stray copy, and always run both halves from "
-                   f"{GRAPHIFY_DIR}/:\n{rebuild}")
+            name=name, status="FAIL", command=cmd,
+            summary=f"a graph outside {GRAPHIFY_DIR}/ could not be removed and will answer "
+                    f"false negatives",
+            detail=[f"stray: {p}" for p in st.stray_kept]
+                   + ([st.stray_error] if st.stray_error else [])
+                   + [stray_why],
+            remedy="Delete it by hand -- it is gitignored derived data:\n"
+                   + "\n".join(f"  rm -rf {p}" for p in st.stray_kept))
+    if st.rebuilt and st.rebuild_rc not in (0, None):
+        return CheckResult(
+            name=name, status="WARN", command=rebuild,
+            summary=f"the graph needed rebuilding and `graphify update .` exited "
+                    f"{st.rebuild_rc}",
+            detail=[(st.rebuild_out or "").strip()[:400]],
+            remedy="Run it by hand and read the output. Meanwhile use rg / "
+                   "tools/context-pack.py; nothing is blocked.")
     if not st.graph:
-        return CheckResult(name=name, status="WARN", command=cmd,
-                           summary=f"no graph at {GRAPHIFY_DIR}/{GRAPHIFY_REL}",
+        return CheckResult(name=name, status="WARN", command=rebuild,
+                           summary=f"no graph at {GRAPHIFY_DIR}/{GRAPHIFY_REL}, and preflight "
+                                   f"could not build one",
                            remedy=rebuild)
-    if (st.graph_mtime is not None and st.newest_source is not None
-            and st.graph_mtime < st.newest_source):
-        behind = st.newest_source - st.graph_mtime
-        return CheckResult(
-            name=name, status="WARN", command=cmd,
-            summary=f"the graph is stale: {human_age(behind)} behind the newest source file",
-            detail=[f"graph   {ts(st.graph_mtime)}  {st.graph}",
-                    f"source  {ts(st.newest_source)}  {st.newest_source_path}",
-                    "A stale graph answers with line numbers and edges that no longer "
-                    "exist, and looks exactly like a fresh one."],
-            remedy=rebuild)
     if st.query_rc not in (None, 0):
         return CheckResult(name=name, status="WARN", command=cmd,
                            summary=f"the graph exists but a query against it exited {st.query_rc}",
@@ -1366,12 +1399,32 @@ def classify_graphify(st: GraphifyState) -> CheckResult:
             detail=[f"expected a node named {LSP_PROBE_SYMBOL}",
                     (st.query_out or "").strip()[:400]],
             remedy=rebuild)
+    # Healthy. Anything preflight had to FIX to get here is said out loud rather than
+    # folded into a silent PASS -- a reader has to be able to tell "it was already
+    # right" from "it was wrong and preflight repaired it".
+    fixed = []
+    if st.stray_removed:
+        fixed += [f"removed a stray graph that would have answered false negatives: {p}"
+                  for p in st.stray_removed] + [stray_why]
+    if st.rebuilt:
+        secs = f" in {st.rebuild_secs:.1f}s" if st.rebuild_secs is not None else ""
+        fixed.append(f"rebuilt the graph{secs} -- it was missing or behind "
+                     f"{os.path.basename(st.newest_source_path) or 'the sources'}")
+    detail = fixed + ["Query with bare symbols or `Symbol callers`. An English question "
+                      "matches on the words you type and silently returns unrelated nodes."]
+    if st.stray_removed:
+        return CheckResult(
+            name=name, status="WARN", command=cmd,
+            summary=f"a stray graph outside {GRAPHIFY_DIR}/ was found and removed; the "
+                    f"graph now resolves {LSP_PROBE_SYMBOL}",
+            detail=detail, remedy="Nothing to do -- preflight removed it. It comes back "
+                                  "if something runs `graphify update` from the repo root.",
+            data={"graph": st.graph, "stray_removed": st.stray_removed})
     return CheckResult(
         name=name, status="PASS", command=cmd,
-        summary=f"graph is current and resolved {LSP_PROBE_SYMBOL}",
-        detail=["Query with bare symbols or `Symbol callers`. An English question "
-                "matches on the words you type and silently returns unrelated nodes."],
-        data={"graph": st.graph})
+        summary=("rebuilt, and resolved " + LSP_PROBE_SYMBOL) if st.rebuilt
+                else f"graph is current and resolved {LSP_PROBE_SYMBOL}",
+        detail=detail, data={"graph": st.graph, "rebuilt": st.rebuilt})
 
 
 def classify_decompiler(st: DecompilerState) -> CheckResult:
@@ -1481,26 +1534,70 @@ def probe_lsp(repo: str, timeout: float = 180) -> LspState:
     return st
 
 
-def probe_graphify(repo: str, timeout: float = 60) -> GraphifyState:
+def stray_graph_dirs(repo: str) -> list:
+    """graphify-out directories that are NOT the canonical one under AlRunner/.
+
+    The documented trap is a rebuild in one directory and a query in another, and the
+    two directories in play are the repo root and AlRunner/ -- so a graph at the root
+    is the stray. A `graphify query` run from there reads it, forever, and a rebuild
+    under AlRunner/ never touches it.
+    """
+    canonical = os.path.abspath(os.path.join(repo, GRAPHIFY_DIR, "graphify-out"))
+    root = os.path.abspath(os.path.join(repo, "graphify-out"))
+    return [root] if os.path.isdir(root) and root != canonical else []
+
+
+def probe_graphify(repo: str, timeout: float = 180) -> GraphifyState:
+    """Measure graphify -- and REPAIR what is cheap and unambiguous to repair.
+
+    This probe is not read-only, unlike every other check in this file, and that is
+    deliberate on two counts:
+
+    * A stray graph is **deleted**. It is gitignored derived data, rebuilt in about two
+      seconds, and while it exists a query from the repo root answers false negatives.
+      Leaving it in place to report it would leave the box broken for the next agent.
+    * A stale or missing graph is **rebuilt** rather than reported. It costs ~2s warm,
+      and CLAUDE.md already says "rebuild rather than wonder whether it is current".
+      Telling a human to run a two-second command is asking a person to do a script's
+      job, and in an unattended loop there is no person to ask.
+
+    Both repairs are reported in the result, never folded into a silent PASS.
+    `--no-tools` skips this check entirely for a caller who wants nothing touched.
+    """
     st = GraphifyState(binary=shutil.which("graphify"))
-    canonical = os.path.join(repo, GRAPHIFY_DIR, GRAPHIFY_REL)
-    if os.path.exists(canonical):
-        st.graph = canonical
+    for stray in stray_graph_dirs(repo):
         try:
-            st.graph_mtime = os.path.getmtime(canonical)
+            shutil.rmtree(stray)
+            st.stray_removed.append(stray)
+        except OSError as exc:
+            st.stray_kept.append(stray)
+            st.stray_error = str(exc)
+
+    graph_dir = os.path.join(repo, GRAPHIFY_DIR)
+    canonical = os.path.join(graph_dir, GRAPHIFY_REL)
+    st.newest_source, st.newest_source_path = newest_source_mtime(graph_dir)
+
+    def graph_mtime() -> Optional[float]:
+        try:
+            return os.path.getmtime(canonical)
         except OSError:
-            st.graph_mtime = None
-    # The documented trap is a rebuild in one directory and a query in another. The
-    # two directories in play are the repo root and AlRunner/, so a graph at the root
-    # is the stray -- a `graphify query` run from there uses it and says nothing.
-    root_copy = os.path.join(repo, GRAPHIFY_REL)
-    if os.path.exists(root_copy) and os.path.abspath(root_copy) != os.path.abspath(canonical):
-        st.stray.append(root_copy)
-    st.newest_source, st.newest_source_path = newest_source_mtime(
-        os.path.join(repo, GRAPHIFY_DIR))
-    if st.binary and st.graph and not st.stray:
-        r = run([st.binary, "query", GRAPHIFY_PROBE_QUERY],
-                cwd=os.path.join(repo, GRAPHIFY_DIR), timeout=timeout)
+            return None
+
+    mtime = graph_mtime()
+    stale = mtime is None or (st.newest_source is not None and mtime < st.newest_source)
+    if st.binary and not st.stray_kept and stale:
+        started = time.monotonic()
+        r = run([st.binary, "update", "."], cwd=graph_dir, timeout=timeout)
+        st.rebuilt = True
+        st.rebuild_rc = 124 if r.timed_out else r.rc
+        st.rebuild_secs = time.monotonic() - started
+        st.rebuild_out = r.out + r.err
+        mtime = graph_mtime()
+
+    if mtime is not None:
+        st.graph, st.graph_mtime = canonical, mtime
+    if st.binary and st.graph and not st.stray_kept:
+        r = run([st.binary, "query", GRAPHIFY_PROBE_QUERY], cwd=graph_dir, timeout=timeout)
         st.query_rc, st.query_out = r.rc, r.out + r.err
     return st
 

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -21,12 +21,21 @@ moment, and that ambiguity is the whole incident.
 
 A check a busy coordinator can decline is not a check.
 
+It also checks the CODE-NAVIGATION tooling -- the C# language server behind
+tools/lsp-query.py, graphify, and the bc-decompiler MCP server (#3087). Those
+three do not affect whether the runner is correct; they affect whether an agent
+gets a confidently wrong answer while reading it, which each of them has already
+produced here. So they are probed for a KNOWN-GOOD ANSWER rather than for
+presence, and they only ever WARN -- see the comment on LSP_PROBE_SYMBOL for why
+a stale graph must not be allowed to halt a cycle.
+
 Usage:
     tools/preflight.py                 # human-readable report
     tools/preflight.py --json          # machine-readable, same verdicts
     tools/preflight.py --strict        # warnings are also non-zero
     tools/preflight.py --reap          # remove worktrees of MERGED PRs, if clean
     tools/preflight.py --with-corpus   # also run the corpus baseline (minutes)
+    tools/preflight.py --no-tools      # skip the code-navigation checks (~10s)
 """
 from __future__ import annotations
 
@@ -38,6 +47,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 from dataclasses import dataclass, field
 from typing import Any, Iterable, Optional
 
@@ -64,6 +74,64 @@ BUDGET_WARN_FRACTION = 0.85
 BUDGET_STALE_MINUTES = 60
 
 OMARCHY_USAGE_BIN = "/usr/share/omarchy/bin/omarchy-agent-usage-claude"
+
+# --------------------------------------------------------------------------
+# code-navigation tooling (issue #3087)
+# --------------------------------------------------------------------------
+# WHY THESE ARE CHECKED AT ALL, AND WHY THEY ONLY EVER WARN.
+#
+# The three tools below -- the C# language server behind tools/lsp-query.py,
+# graphify, and the bc-decompiler MCP server -- are how an agent finds code
+# without a grep sweep. None of them affects whether the runner is correct. What
+# they affect is whether an agent gets a *confidently wrong answer*, and each has
+# already produced one here:
+#
+#   * lsp-query.py exits 2 when the server never answered. An agent reading that
+#     as "nothing calls this" has a false negative that looks like a finding.
+#   * `graphify update` and `graphify query` both default to graphify-out/graph.json
+#     RELATIVE TO THE CURRENT DIRECTORY, so a rebuild run from one directory and a
+#     query from another silently use different files. A root-level copy once sat
+#     13 days stale while the documented rebuild appeared to be working.
+#   * .mcp.json changes need a session restart, so "configured" and "usable right
+#     now" are different states, and only the second one is worth anything.
+#
+# So the checks probe for a KNOWN-GOOD ANSWER rather than for the tool's presence:
+# "is it installed" cannot distinguish a working server from one that returns
+# nothing. Each probe additionally validates its own fixture against the checkout,
+# so a probe that has drifted reports itself as drifted instead of blaming the tool.
+#
+# SEVERITY: these top out at WARN and never FAIL, which is a deliberate choice
+# rather than an oversight.
+#   - overall_exit() turns any FAIL into exit 1, and the autonomous cycle treats
+#     that as "do not start". Halting an unattended cycle because a 3.4 MB graph
+#     file is four days old costs far more than the staleness does, and the
+#     remedy is a two-second rebuild.
+#   - Every one of these degrades to a documented fallback that still produces
+#     correct work: ripgrep, tools/context-pack.py, reading the DLL another way.
+#     A missing navigation tool makes an agent slower, not wrong.
+#   - `--strict` already exists for the operator who wants zero tolerance: it
+#     turns any WARN into exit 2. That is the right place for that policy,
+#     because it is the caller's call and not this file's.
+# A genuinely untrustworthy box is what FAIL is for -- disk, memory, push, the
+# corpus baseline. Navigation tooling is not that, and saying so keeps FAIL
+# meaning something.
+LSP_PROBE_SYMBOL = "SafeDirectoryScan"
+# The answer the probe must get back. Checked against the working tree first, so a
+# rename turns into "the probe fixture moved" rather than "the language server is
+# broken" -- a check that cannot tell those apart is worse than no check.
+LSP_PROBE_FILE = "AlRunner/Infrastructure/SafeDirectoryScan.cs"
+LSP_PROBE_DECL = "class SafeDirectoryScan"
+
+# graphify is documented (CLAUDE.md) to be rebuilt AND queried from AlRunner/.
+GRAPHIFY_DIR = "AlRunner"
+GRAPHIFY_REL = os.path.join("graphify-out", "graph.json")
+GRAPHIFY_PROBE_QUERY = f"{LSP_PROBE_SYMBOL} callers"
+
+# The BC contexts CLAUDE.md's table promises. common284/navlang275/... also exist
+# on some boxes; they are extra, not required, so their absence is not a finding.
+DECOMPILER_ALIASES = ["bc260", "bc270", "bc273", "bc275",
+                      "bc280", "bc281", "bc282", "bc283", "bc284"]
+DECOMPILER_SERVER = "bc-decompiler"
 
 EXIT_MEANING = {
     0: "every check passed (warnings may be present; see --strict)",
@@ -1139,6 +1207,408 @@ def check_budget(skip_fallback: bool = False) -> CheckResult:
                               "can be paced against a measured figure rather than a guess.")
 
 
+# --------------------------------------------------------------------------
+# code-navigation tooling: observed state, then pure verdicts
+# --------------------------------------------------------------------------
+# The state each probe observed is captured in a dataclass and the verdict is a
+# pure function of it, for the reason stated at the top of test_preflight.py: a
+# threshold suite that reads the live box passes for the wrong reason on a healthy
+# one and cannot be made to fail on demand. Every negative case below -- server
+# down, graph stale, graph in the wrong directory, MCP server unregistered, a
+# context missing -- is constructed directly in the tests.
+@dataclass
+class LspState:
+    script: bool = False            # tools/lsp-query.py is in this checkout
+    server_on_path: bool = False    # csharp-ls resolves
+    fixture_ok: bool = False        # LSP_PROBE_FILE still declares LSP_PROBE_SYMBOL
+    rc: Optional[int] = None        # lsp-query.py exit: 0 answered, 1 real negative, 2 server failed
+    out: str = ""
+    timed_out: bool = False
+
+
+@dataclass
+class GraphifyState:
+    binary: Optional[str] = None        # graphify on PATH
+    graph: Optional[str] = None         # the canonical AlRunner/graphify-out/graph.json
+    graph_mtime: Optional[float] = None
+    newest_source: Optional[float] = None
+    newest_source_path: str = ""
+    stray: list = field(default_factory=list)   # other graph.json copies a query could pick up
+    query_rc: Optional[int] = None
+    query_out: str = ""
+
+
+@dataclass
+class DecompilerState:
+    config: Optional[str] = None    # path to the .mcp.json that was read
+    registered: bool = False        # it declares a bc-decompiler server
+    target: str = ""                # the .dll/binary the entry points at
+    target_exists: bool = False
+    probe_rc: Optional[int] = None  # 0 = the server answered over stdio
+    aliases: list = field(default_factory=list)
+    error: str = ""
+
+
+def classify_lsp(st: LspState) -> CheckResult:
+    """Verdict on the C# language server, from a probe with a known-good answer."""
+    name, cmd = "nav-lsp", f"tools/lsp-query.py symbol {LSP_PROBE_SYMBOL}"
+    fallback = ("Nothing is blocked: use rg / tools/context-pack.py meanwhile. "
+                "Never read a failed lookup as 'nothing calls this'.")
+    if not st.script:
+        return CheckResult(name=name, status="WARN", command=cmd,
+                           summary="tools/lsp-query.py is not in this checkout",
+                           remedy="Check the repository out fully.\n" + fallback)
+    if not st.fixture_ok:
+        # The probe, not the tool. Say so, or the next reader spends an hour on a
+        # language server that was fine all along.
+        return CheckResult(
+            name=name, status="WARN", command=cmd,
+            summary=f"this check's own probe has drifted: {LSP_PROBE_FILE} no longer "
+                    f"declares '{LSP_PROBE_DECL}'",
+            detail=["The language server was NOT tested -- there is no known-good answer "
+                    "to compare against, so a result either way would mean nothing."],
+            remedy=f"Update LSP_PROBE_SYMBOL / LSP_PROBE_FILE / LSP_PROBE_DECL in "
+                   f"tools/preflight.py to a symbol that still exists.")
+    if not st.server_on_path:
+        return CheckResult(name=name, status="WARN", command="command -v csharp-ls",
+                           summary="csharp-ls is not on PATH, so every lsp-query.py call "
+                                   "will exit 2",
+                           remedy="mise use -g dotnet:csharp-ls\n" + fallback)
+    if st.timed_out:
+        return CheckResult(name=name, status="WARN", command=cmd,
+                           summary="the language server did not answer within the probe timeout",
+                           remedy="Run the command by hand to see where it stops.\n" + fallback)
+    if st.rc == 2:
+        return CheckResult(
+            name=name, status="WARN", command=cmd,
+            summary="the language server could not be started or did not answer (exit 2)",
+            detail=["Exit 2 is NOT a negative result. An empty answer from a broken server "
+                    "looks exactly like 'nothing calls this', which is how a false negative "
+                    "gets acted on as a finding.",
+                    (st.out or "").strip()[:400]],
+            remedy="Check csharp-ls runs: csharp-ls --version. The plugin must be active "
+                   "for .cs.\n" + fallback)
+    if st.rc == 1:
+        return CheckResult(
+            name=name, status="WARN", command=cmd,
+            summary=f"the server answered but did not find {LSP_PROBE_SYMBOL}, which this "
+                    f"checkout does declare",
+            detail=[f"{LSP_PROBE_FILE} contains '{LSP_PROBE_DECL}', so a real negative here "
+                    f"means the server's index does not match the working tree."],
+            remedy="Re-run once (the first call builds the index). If it persists, the "
+                   "solution AlRunner.slnx may not cover the file.\n" + fallback)
+    if st.rc != 0:
+        return CheckResult(name=name, status="WARN", command=cmd,
+                           summary=f"lsp-query.py exited {st.rc}, which is not a documented code",
+                           remedy="Run it by hand and read the output.\n" + fallback)
+    if LSP_PROBE_FILE not in st.out:
+        return CheckResult(
+            name=name, status="WARN", command=cmd,
+            summary="the server answered, but not with the known-good answer",
+            detail=[f"expected the reply to name {LSP_PROBE_FILE}",
+                    (st.out or "").strip()[:400]],
+            remedy="The index is stale or points at a different tree. Re-run; if it "
+                   "persists, restart the server.\n" + fallback)
+    return CheckResult(name=name, status="PASS", command=cmd,
+                       summary=f"answered with the known-good result ({LSP_PROBE_FILE})",
+                       data={"rc": st.rc})
+
+
+def classify_graphify(st: GraphifyState) -> CheckResult:
+    """Verdict on graphify, including the two traps that produce wrong answers quietly."""
+    name = "nav-graphify"
+    cmd = f"cd {GRAPHIFY_DIR} && graphify query \"{GRAPHIFY_PROBE_QUERY}\""
+    rebuild = f"cd {GRAPHIFY_DIR} && graphify update .   # ~2 seconds"
+    if not st.binary:
+        return CheckResult(name=name, status="WARN", command="command -v graphify",
+                           summary="graphify is not on PATH",
+                           remedy="Install it, or use tools/context-pack.py and rg instead. "
+                                  "Nothing is blocked.")
+    # The wrong-directory trap first: it is the one that answers, plausibly, from the
+    # wrong file. A stale graph you know about is better than a fresh one you are not
+    # actually querying.
+    if st.stray:
+        return CheckResult(
+            name=name, status="WARN", command=cmd,
+            summary=f"a second graph exists outside {GRAPHIFY_DIR}/ and a query run from "
+                    f"there would silently use it",
+            detail=[f"stray: {p}" for p in st.stray] +
+                   [f"canonical: {st.graph or '(missing)'}",
+                    "Both `graphify update` and `graphify query` default to "
+                    "graphify-out/graph.json relative to the CURRENT directory, so a "
+                    "rebuild in one place and a query in another use different files "
+                    "with no warning."],
+            remedy=f"Delete the stray copy, and always run both halves from "
+                   f"{GRAPHIFY_DIR}/:\n{rebuild}")
+    if not st.graph:
+        return CheckResult(name=name, status="WARN", command=cmd,
+                           summary=f"no graph at {GRAPHIFY_DIR}/{GRAPHIFY_REL}",
+                           remedy=rebuild)
+    if (st.graph_mtime is not None and st.newest_source is not None
+            and st.graph_mtime < st.newest_source):
+        behind = st.newest_source - st.graph_mtime
+        return CheckResult(
+            name=name, status="WARN", command=cmd,
+            summary=f"the graph is stale: {human_age(behind)} behind the newest source file",
+            detail=[f"graph   {ts(st.graph_mtime)}  {st.graph}",
+                    f"source  {ts(st.newest_source)}  {st.newest_source_path}",
+                    "A stale graph answers with line numbers and edges that no longer "
+                    "exist, and looks exactly like a fresh one."],
+            remedy=rebuild)
+    if st.query_rc not in (None, 0):
+        return CheckResult(name=name, status="WARN", command=cmd,
+                           summary=f"the graph exists but a query against it exited {st.query_rc}",
+                           detail=[(st.query_out or "").strip()[:400]], remedy=rebuild)
+    if st.query_rc == 0 and LSP_PROBE_SYMBOL not in st.query_out:
+        return CheckResult(
+            name=name, status="WARN", command=cmd,
+            summary="the graph answered, but not with the known-good node",
+            detail=[f"expected a node named {LSP_PROBE_SYMBOL}",
+                    (st.query_out or "").strip()[:400]],
+            remedy=rebuild)
+    return CheckResult(
+        name=name, status="PASS", command=cmd,
+        summary=f"graph is current and resolved {LSP_PROBE_SYMBOL}",
+        detail=["Query with bare symbols or `Symbol callers`. An English question "
+                "matches on the words you type and silently returns unrelated nodes."],
+        data={"graph": st.graph})
+
+
+def classify_decompiler(st: DecompilerState) -> CheckResult:
+    """Verdict on the bc-decompiler MCP server.
+
+    Two states that are easy to conflate: *registered* in .mcp.json, and *usable
+    right now*. Registering a server mid-session does nothing until the session
+    restarts, so the second is the one worth reporting -- and the only way to
+    establish it from outside the session is to speak MCP to the server directly,
+    which is what the probe does.
+    """
+    name = "nav-bc-decompiler"
+    cmd = f"tools/preflight.py  (spawns the {DECOMPILER_SERVER} server and calls list_contexts)"
+    setup = "tools/setup-bc-decompiler.sh   (needs the .NET 10 SDK; the runner stays on net8.0)"
+    if not st.config:
+        return CheckResult(name=name, status="WARN", command="cat .mcp.json",
+                           summary="no .mcp.json in the repository root",
+                           detail=[".mcp.json is gitignored and per-machine, so a fresh "
+                                   "checkout never has one."],
+                           remedy=setup)
+    if not st.registered:
+        return CheckResult(name=name, status="WARN", command=f"cat {st.config}",
+                           summary=f"{st.config} declares no '{DECOMPILER_SERVER}' server",
+                           remedy=setup)
+    if not st.target_exists:
+        return CheckResult(name=name, status="WARN", command=f"cat {st.config}",
+                           summary=f"{DECOMPILER_SERVER} is registered but its target is missing",
+                           detail=[f"target: {st.target or '(none)'}"],
+                           remedy="Re-publish it: " + setup)
+    if st.probe_rc != 0:
+        return CheckResult(
+            name=name, status="WARN", command=cmd,
+            summary="the server is registered but did not answer over stdio",
+            detail=[st.error.strip()[:400] or "no output"],
+            remedy="Run it by hand to see the error:\n"
+                   f"  dotnet {st.target}\n" + setup)
+    missing = [a for a in DECOMPILER_ALIASES if a not in st.aliases]
+    if missing:
+        return CheckResult(
+            name=name, status="WARN", command=cmd,
+            summary=f"the server answers, but {len(missing)} BC context(s) are not registered: "
+                    f"{', '.join(missing)}",
+            detail=[f"present: {', '.join(st.aliases) or '(none)'}",
+                    "A missing alias makes compare_symbols across that version impossible, "
+                    "which is how a Cecil rewrite that stopped being reached goes unnoticed."],
+            remedy="Load the missing versions once (contexts persist across restarts) -- "
+                   "see the end of " + setup)
+    return CheckResult(
+        name=name, status="PASS", command=cmd,
+        summary=f"server answers and all {len(DECOMPILER_ALIASES)} BC contexts are registered",
+        detail=["Registered, and proven to answer -- but a .mcp.json change still needs a "
+                "SESSION RESTART before this session or its subagents can call it. "
+                "In-session, confirm with mcp__bc-decompiler__status."],
+        data={"aliases": st.aliases})
+
+
+def ts(epoch: float) -> str:
+    return dt.datetime.fromtimestamp(epoch).strftime("%Y-%m-%d %H:%M")
+
+
+def human_age(seconds: float) -> str:
+    if seconds < 90:
+        return f"{int(seconds)}s"
+    if seconds < 5400:
+        return f"{seconds / 60:.0f}m"
+    if seconds < 172800:
+        return f"{seconds / 3600:.1f}h"
+    return f"{seconds / 86400:.1f}d"
+
+
+# --------------------------------------------------------------------------
+# code-navigation tooling: the probes themselves
+# --------------------------------------------------------------------------
+def newest_source_mtime(root: str) -> tuple[Optional[float], str]:
+    """Newest .cs under `root`, ignoring build output and the graph itself."""
+    newest, path = None, ""
+    for base, dirs, files in os.walk(root):
+        dirs[:] = [d for d in dirs if d not in ("bin", "obj", "graphify-out", ".git")]
+        for f in files:
+            if not f.endswith(".cs"):
+                continue
+            fp = os.path.join(base, f)
+            try:
+                m = os.path.getmtime(fp)
+            except OSError:
+                continue
+            if newest is None or m > newest:
+                newest, path = m, fp
+    return newest, path
+
+
+def probe_lsp(repo: str, timeout: float = 180) -> LspState:
+    st = LspState()
+    script = os.path.join(repo, "tools", "lsp-query.py")
+    st.script = os.path.exists(script)
+    fixture = os.path.join(repo, LSP_PROBE_FILE)
+    try:
+        with open(fixture, encoding="utf-8", errors="replace") as fh:
+            st.fixture_ok = LSP_PROBE_DECL in fh.read()
+    except OSError:
+        st.fixture_ok = False
+    st.server_on_path = shutil.which("csharp-ls") is not None
+    if not (st.script and st.fixture_ok and st.server_on_path):
+        return st
+    r = run([sys.executable, script, "symbol", LSP_PROBE_SYMBOL], cwd=repo, timeout=timeout)
+    st.rc, st.out, st.timed_out = r.rc, r.out + r.err, r.timed_out
+    return st
+
+
+def probe_graphify(repo: str, timeout: float = 60) -> GraphifyState:
+    st = GraphifyState(binary=shutil.which("graphify"))
+    canonical = os.path.join(repo, GRAPHIFY_DIR, GRAPHIFY_REL)
+    if os.path.exists(canonical):
+        st.graph = canonical
+        try:
+            st.graph_mtime = os.path.getmtime(canonical)
+        except OSError:
+            st.graph_mtime = None
+    # The documented trap is a rebuild in one directory and a query in another. The
+    # two directories in play are the repo root and AlRunner/, so a graph at the root
+    # is the stray -- a `graphify query` run from there uses it and says nothing.
+    root_copy = os.path.join(repo, GRAPHIFY_REL)
+    if os.path.exists(root_copy) and os.path.abspath(root_copy) != os.path.abspath(canonical):
+        st.stray.append(root_copy)
+    st.newest_source, st.newest_source_path = newest_source_mtime(
+        os.path.join(repo, GRAPHIFY_DIR))
+    if st.binary and st.graph and not st.stray:
+        r = run([st.binary, "query", GRAPHIFY_PROBE_QUERY],
+                cwd=os.path.join(repo, GRAPHIFY_DIR), timeout=timeout)
+        st.query_rc, st.query_out = r.rc, r.out + r.err
+    return st
+
+
+def read_mcp_entry(repo: str, server: str) -> tuple[Optional[str], Optional[dict]]:
+    """The named server's entry from the repo's .mcp.json, or (path, None)."""
+    path = os.path.join(repo, ".mcp.json")
+    if not os.path.exists(path):
+        return None, None
+    try:
+        with open(path, encoding="utf-8") as fh:
+            doc = json.load(fh)
+    except (OSError, ValueError):
+        return path, None
+    servers = doc.get("mcpServers") or {}
+    entry = servers.get(server)
+    return path, (entry if isinstance(entry, dict) else None)
+
+
+def mcp_call(argv: list[str], tool: str, *, cwd: Optional[str] = None,
+             timeout: float = 90) -> tuple[int, dict, str]:
+    """Speak MCP over stdio to a server and call one tool. Returns (rc, payload, error).
+
+    rc 0 means the server initialized AND answered the call. Anything else is an
+    error string, never an empty success -- the whole point of the check is that
+    "no answer" and "an empty answer" must not look the same.
+
+    mise prints its activation banner on STDOUT for shimmed commands (`dotnet` is
+    one), which would land in the middle of a JSON-RPC stream. Non-JSON lines are
+    skipped rather than parsed, for the same reason strip_shim_banner() exists.
+    """
+    try:
+        p = subprocess.Popen(argv, cwd=cwd, stdin=subprocess.PIPE,
+                             stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    except (FileNotFoundError, PermissionError, OSError) as exc:
+        return 127, {}, str(exc)
+    deadline = time.time() + timeout
+
+    def send(obj: dict) -> None:
+        assert p.stdin is not None
+        p.stdin.write((json.dumps(obj) + "\n").encode())
+        p.stdin.flush()
+
+    def read_response(want_id: int) -> Optional[dict]:
+        assert p.stdout is not None
+        while time.time() < deadline:
+            line = p.stdout.readline()
+            if not line:
+                return None
+            try:
+                doc = json.loads(line.decode("utf-8", "replace"))
+            except ValueError:
+                continue            # mise banner, or any other non-protocol noise
+            if doc.get("id") == want_id:
+                return doc
+        return None
+
+    try:
+        send({"jsonrpc": "2.0", "id": 1, "method": "initialize",
+              "params": {"protocolVersion": "2024-11-05", "capabilities": {},
+                         "clientInfo": {"name": "al-runner-preflight", "version": "1"}}})
+        if read_response(1) is None:
+            return 1, {}, "server did not respond to initialize"
+        send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        send({"jsonrpc": "2.0", "id": 2, "method": "tools/call",
+              "params": {"name": tool, "arguments": {}}})
+        doc = read_response(2)
+        if doc is None:
+            return 1, {}, f"server did not respond to {tool}"
+        if "error" in doc:
+            return 1, {}, json.dumps(doc["error"])[:400]
+        try:
+            text = doc["result"]["content"][0]["text"]
+            return 0, json.loads(text), ""
+        except (KeyError, IndexError, TypeError, ValueError) as exc:
+            return 1, {}, f"unreadable {tool} reply: {exc}"
+    except OSError as exc:
+        return 1, {}, str(exc)
+    finally:
+        try:
+            p.kill()
+            p.wait(timeout=5)
+        except Exception:
+            pass
+
+
+def probe_decompiler(repo: str, timeout: float = 90) -> DecompilerState:
+    st = DecompilerState()
+    st.config, entry = read_mcp_entry(repo, DECOMPILER_SERVER)
+    if st.config is None or entry is None:
+        return st
+    st.registered = True
+    argv = [entry.get("command") or ""] + list(entry.get("args") or [])
+    st.target = next((a for a in argv[1:] if a.endswith(".dll")), argv[-1] if argv[1:] else "")
+    st.target_exists = bool(st.target) and os.path.exists(st.target)
+    if not st.target_exists:
+        return st
+    rc, payload, err = mcp_call(argv, "list_contexts", cwd=repo, timeout=timeout)
+    st.probe_rc, st.error = rc, err
+    if rc == 0:
+        data = payload.get("data") or {}
+        aliases = data.get("registeredAliases")
+        if not isinstance(aliases, list):
+            aliases = [i.get("contextAlias") for i in (data.get("items") or [])]
+        st.aliases = [a for a in aliases if isinstance(a, str)]
+    return st
+
+
 def check_corpus(repo: str, enabled: bool) -> CheckResult:
     """The skill's step 1: the corpus is the known-good baseline, and its expected
     count is checked in at tests/expectations/count-baseline/.
@@ -1287,6 +1757,10 @@ def main(argv: Optional[list[str]] = None) -> int:
                          "is missing (it needs the network)")
     ap.add_argument("--no-sizes", action="store_true",
                     help="skip recursive size measurement (faster, less useful)")
+    ap.add_argument("--no-tools", action="store_true",
+                    help="skip the code-navigation checks (C# LSP, graphify, bc-decompiler). "
+                         "They cost about 10s, dominated by the language server's first "
+                         "answer, and only ever WARN")
     args = ap.parse_args(argv)
 
     here = os.path.dirname(os.path.abspath(__file__))
@@ -1333,6 +1807,19 @@ def main(argv: Optional[list[str]] = None) -> int:
         check_github(slug),
         check_corpus(repo, args.with_corpus),
     ]
+    if args.no_tools:
+        # A SKIP, never silence: a reader must be able to tell "these passed" from
+        # "these were not run", which is the same rule check_corpus follows.
+        results += [CheckResult(name=n, status="SKIP",
+                                summary="not run (--no-tools)",
+                                command="tools/preflight.py   # without --no-tools")
+                    for n in ("nav-lsp", "nav-graphify", "nav-bc-decompiler")]
+    else:
+        results += [
+            classify_lsp(probe_lsp(repo)),
+            classify_graphify(probe_graphify(repo)),
+            classify_decompiler(probe_decompiler(repo)),
+        ]
     results.sort(key=lambda r: _ORDER.get(r.status, 9))
 
     reap_log: list[str] = []

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -653,6 +653,271 @@ check("--json keeps the machine-readable status", j["checks"][1]["status"] == "F
 check("--json documents what the exit code means",
       "exit_code_meaning" in j and j["exit_code_meaning"], str(j.get("exit_code_meaning")))
 
+
+# -------------------------------------------------- code-navigation tooling (#3087)
+# These three checks exist because each tool fails in a way that produces a
+# confidently wrong answer rather than an error, so the tests below are mostly the
+# NEGATIVE direction: a deliberately broken state must produce a non-PASS with a
+# remedy. A check that only passes when everything is fine has not been tested.
+#
+# The verdicts are pure functions of a state dataclass, so every broken state is
+# constructed here rather than arranged on the box -- the same reason the disk and
+# memory thresholds are proven against captured `df` output.
+
+def nav_states():
+    """A healthy state for each of the three checks, to mutate one field at a time."""
+    lsp = pf.LspState(script=True, server_on_path=True, fixture_ok=True, rc=0,
+                      out=f"{pf.LSP_PROBE_FILE}:79:21  {pf.LSP_PROBE_SYMBOL}\n")
+    graph = pf.GraphifyState(binary="/usr/bin/graphify", graph="/repo/AlRunner/graphify-out/graph.json",
+                             graph_mtime=2000.0, newest_source=1000.0,
+                             newest_source_path="/repo/AlRunner/X.cs",
+                             query_rc=0, query_out=f"NODE {pf.LSP_PROBE_SYMBOL} [src=...]")
+    dec = pf.DecompilerState(config="/repo/.mcp.json", registered=True,
+                             target="/opt/DecompilerServer.dll", target_exists=True,
+                             probe_rc=0, aliases=list(pf.DECOMPILER_ALIASES))
+    return lsp, graph, dec
+
+
+_lsp, _graph, _dec = nav_states()
+
+# ---- the healthy direction, so the broken ones below mean something
+check("nav-lsp passes when the server returns the known-good answer",
+      pf.classify_lsp(_lsp).status == "PASS", pf.classify_lsp(_lsp).summary)
+check("nav-graphify passes on a current graph that resolves the probe node",
+      pf.classify_graphify(_graph).status == "PASS", pf.classify_graphify(_graph).summary)
+check("nav-bc-decompiler passes when the server answers with every BC context",
+      pf.classify_decompiler(_dec).status == "PASS", pf.classify_decompiler(_dec).summary)
+
+# ---- nav-lsp: the ways a language server lies
+import dataclasses as _dc
+
+
+def lsp_with(**kw):
+    return pf.classify_lsp(_dc.replace(_lsp, **kw))
+
+
+r = lsp_with(rc=2, out="csharp-ls: not found")
+check("exit 2 (server never answered) is not reported as PASS", r.status == "WARN", r.summary)
+check("exit 2 is spelled out as NOT a negative result",
+      "NOT a negative" in " ".join(r.detail), str(r.detail))
+
+r = lsp_with(rc=1, out="")
+check("a real not-found for a symbol this checkout DOES declare is reported",
+      r.status == "WARN", r.summary)
+
+# The one that matters most: the server answered, exit 0, and the answer is wrong.
+# Without a known-good expected answer this state is indistinguishable from health.
+r = lsp_with(rc=0, out="SomeOther/File.cs:1:1  Unrelated\n")
+check("exit 0 with the WRONG answer is not reported as PASS", r.status == "WARN", r.summary)
+check("the wrong-answer case names the answer it expected",
+      pf.LSP_PROBE_FILE in " ".join(r.detail), str(r.detail))
+
+r = lsp_with(fixture_ok=False)
+check("a drifted probe fixture blames the probe, not the server", r.status == "WARN", r.summary)
+check("a drifted probe fixture says the server was not tested",
+      "NOT tested" in " ".join(r.detail), str(r.detail))
+check("a drifted probe fixture says which constants to update",
+      "LSP_PROBE_SYMBOL" in r.remedy, r.remedy)
+
+r = lsp_with(server_on_path=False)
+check("a missing csharp-ls is reported with the install command",
+      r.status == "WARN" and "mise use -g dotnet:csharp-ls" in r.remedy, r.remedy)
+
+r = lsp_with(timed_out=True, rc=124)
+check("a language server that never answers is reported as a timeout", r.status == "WARN", r.summary)
+
+r = pf.classify_lsp(pf.LspState(script=False))
+check("a checkout without tools/lsp-query.py is reported", r.status == "WARN", r.summary)
+
+# ---- nav-graphify: stale, wrong directory, and no graph at all
+def graph_with(**kw):
+    return pf.classify_graphify(_dc.replace(_graph, **kw))
+
+
+r = graph_with(graph_mtime=1000.0, newest_source=1000.0 + 18 * 86400)
+check("a graph older than the newest source is reported stale", r.status == "WARN", r.summary)
+check("the stale summary quantifies how far behind it is",
+      "18.0d" in r.summary, r.summary)
+check("the stale remedy is the two-second rebuild",
+      "graphify update ." in r.remedy, r.remedy)
+
+r = graph_with(stray=["/repo/graphify-out/graph.json"])
+check("a second graph outside AlRunner/ is reported", r.status == "WARN", r.summary)
+check("the stray graph is named, so it can be deleted",
+      "/repo/graphify-out/graph.json" in " ".join(r.detail), str(r.detail))
+
+r = graph_with(graph=None, graph_mtime=None)
+check("no graph at all is reported with the rebuild command",
+      r.status == "WARN" and "graphify update ." in r.remedy, r.remedy)
+
+r = graph_with(query_rc=1, query_out="boom")
+check("a graph that exists but cannot be queried is reported", r.status == "WARN", r.summary)
+
+r = graph_with(query_out="NODE SomethingElse [src=...]")
+check("a query that answers WITHOUT the known-good node is not a PASS",
+      r.status == "WARN", r.summary)
+
+r = graph_with(binary=None)
+check("graphify missing from PATH is reported", r.status == "WARN", r.summary)
+
+check("the passing graphify report warns about English-question queries",
+      "English question" in " ".join(pf.classify_graphify(_graph).detail),
+      str(pf.classify_graphify(_graph).detail))
+
+# ---- nav-bc-decompiler: configured is not the same as usable
+def dec_with(**kw):
+    return pf.classify_decompiler(_dc.replace(_dec, **kw))
+
+
+r = pf.classify_decompiler(pf.DecompilerState())
+check("no .mcp.json is reported with the setup script",
+      r.status == "WARN" and "setup-bc-decompiler.sh" in r.remedy, r.remedy)
+
+r = dec_with(registered=False)
+check("an .mcp.json without a bc-decompiler entry is reported", r.status == "WARN", r.summary)
+
+r = dec_with(target_exists=False)
+check("a registered server whose DLL is missing is reported", r.status == "WARN", r.summary)
+
+# Registered and present, but the server does not actually answer. This is the
+# "configured but not usable" state the check exists to separate out.
+r = dec_with(probe_rc=1, error="server did not respond to initialize")
+check("a registered server that does not answer is not reported as PASS",
+      r.status == "WARN", r.summary)
+check("the non-answering server's error is shown",
+      "did not respond" in " ".join(r.detail), str(r.detail))
+
+r = dec_with(aliases=[a for a in pf.DECOMPILER_ALIASES if a != "bc284"])
+check("a missing BC context is reported", r.status == "WARN", r.summary)
+check("the missing BC context is named", "bc284" in r.summary, r.summary)
+
+check("the passing decompiler report says a .mcp.json change needs a session restart",
+      "SESSION RESTART" in " ".join(pf.classify_decompiler(_dec).detail),
+      str(pf.classify_decompiler(_dec).detail))
+
+# ---- the severity policy is a decision, so it is pinned here
+_broken = [
+    pf.classify_lsp(pf.LspState(script=False)),
+    pf.classify_lsp(_dc.replace(_lsp, rc=2)),
+    pf.classify_lsp(_dc.replace(_lsp, fixture_ok=False)),
+    pf.classify_lsp(_dc.replace(_lsp, server_on_path=False)),
+    pf.classify_lsp(_dc.replace(_lsp, timed_out=True, rc=124)),
+    pf.classify_lsp(_dc.replace(_lsp, rc=0, out="nope")),
+    pf.classify_graphify(pf.GraphifyState()),
+    graph_with(stray=["/repo/graphify-out/graph.json"]),
+    graph_with(graph_mtime=1.0, newest_source=99999.0),
+    graph_with(query_rc=1),
+    # Every branch, not every classifier: an earlier version of this list reached
+    # classify_graphify only through GraphifyState() (graphify not on PATH), so a
+    # mutation turning the "no graph" branch into a FAIL slipped past the severity
+    # guard entirely. It was caught by a different test, which is luck, not coverage.
+    graph_with(graph=None, graph_mtime=None),
+    graph_with(query_out="NODE SomethingElse"),
+    pf.classify_lsp(_dc.replace(_lsp, rc=1)),
+    pf.classify_lsp(_dc.replace(_lsp, rc=99)),
+    dec_with(registered=False),
+    pf.classify_decompiler(pf.DecompilerState()),
+    dec_with(probe_rc=1),
+    dec_with(target_exists=False),
+    dec_with(aliases=[]),
+]
+check("no navigation check can ever FAIL - they must not halt a cycle",
+      all(r.status != "FAIL" for r in _broken),
+      str([(r.name, r.status) for r in _broken if r.status == "FAIL"]))
+check("every broken navigation state still says what to do about it",
+      all(r.remedy for r in _broken),
+      str([r.name for r in _broken if not r.remedy]))
+check("every broken navigation state names the command that produced it",
+      all(r.command for r in _broken),
+      str([r.name for r in _broken if not r.command]))
+check("a warning navigation check leaves the exit code at 0 (advisory, not blocking)",
+      pf.overall_exit(_broken, strict=False) == 0, str(pf.overall_exit(_broken, False)))
+check("--strict still promotes a navigation warning to exit 2",
+      pf.overall_exit(_broken, strict=True) == 2)
+
+# ---- human_age, used in the stale summary
+check("human_age reports seconds", pf.human_age(30) == "30s")
+check("human_age reports minutes", pf.human_age(600) == "10m")
+check("human_age reports hours", pf.human_age(7200) == "2.0h")
+check("human_age reports days", pf.human_age(18 * 86400) == "18.0d")
+
+# ---- newest_source_mtime ignores build output, or every graph looks stale
+_srcdir = tempfile.mkdtemp(prefix="preflight-src-")
+os.makedirs(os.path.join(_srcdir, "obj"), exist_ok=True)
+with open(os.path.join(_srcdir, "Real.cs"), "w") as fh:
+    fh.write("x")
+os.utime(os.path.join(_srcdir, "Real.cs"), (1000, 1000))
+with open(os.path.join(_srcdir, "obj", "Generated.cs"), "w") as fh:
+    fh.write("x")
+os.utime(os.path.join(_srcdir, "obj", "Generated.cs"), (9_000_000, 9_000_000))
+_m, _p = pf.newest_source_mtime(_srcdir)
+check("newest_source_mtime skips obj/ build output", _m == 1000, f"{_m} {_p}")
+check("newest_source_mtime names the file it picked", _p.endswith("Real.cs"), _p)
+shutil.rmtree(_srcdir, ignore_errors=True)
+
+# ---- read_mcp_entry against a real file
+_cfgdir = tempfile.mkdtemp(prefix="preflight-mcp-")
+_path, _entry = pf.read_mcp_entry(_cfgdir, pf.DECOMPILER_SERVER)
+check("a repo with no .mcp.json reports no config", _path is None and _entry is None)
+with open(os.path.join(_cfgdir, ".mcp.json"), "w") as fh:
+    json.dump({"mcpServers": {"bc-decompiler": {"command": "dotnet", "args": ["/x/S.dll"]}}}, fh)
+_path, _entry = pf.read_mcp_entry(_cfgdir, pf.DECOMPILER_SERVER)
+check("the bc-decompiler entry is read out of .mcp.json",
+      _entry is not None and _entry["args"] == ["/x/S.dll"], str(_entry))
+with open(os.path.join(_cfgdir, ".mcp.json"), "w") as fh:
+    fh.write("{ not json")
+_path, _entry = pf.read_mcp_entry(_cfgdir, pf.DECOMPILER_SERVER)
+check("an unparseable .mcp.json is reported as 'no entry', not raised",
+      _path is not None and _entry is None)
+shutil.rmtree(_cfgdir, ignore_errors=True)
+
+# ---- mcp_call must survive mise's banner landing in the JSON-RPC stream
+# `dotnet` is a mise shim on this box, and mise prints its activation banner on
+# STDOUT. In a line-delimited JSON-RPC stream that is not a formatting nuisance --
+# it is a parse error on the first read, which would report a healthy server as
+# broken. Same failure mode strip_shim_banner() exists for, one layer down.
+_fake = tempfile.mkdtemp(prefix="preflight-mcp-srv-")
+_srv = os.path.join(_fake, "srv.py")
+with open(_srv, "w") as fh:
+    fh.write(
+        "import json,sys\n"
+        "sys.stdout.write('mise ~/.config/mise/config.toml tools: dotnet@10.0.0\\n')\n"
+        "sys.stdout.flush()\n"
+        "for line in sys.stdin:\n"
+        "    try: msg=json.loads(line)\n"
+        "    except ValueError: continue\n"
+        "    if msg.get('method')=='initialize':\n"
+        "        print(json.dumps({'jsonrpc':'2.0','id':msg['id'],'result':{}}),flush=True)\n"
+        "    elif msg.get('method')=='tools/call':\n"
+        "        body=json.dumps({'status':'ok','data':{'registeredAliases':['bc281']}})\n"
+        "        print(json.dumps({'jsonrpc':'2.0','id':msg['id'],\n"
+        "            'result':{'content':[{'type':'text','text':body}]}}),flush=True)\n")
+_rc, _payload, _err = pf.mcp_call([sys.executable, _srv], "list_contexts", timeout=30)
+check("mcp_call talks to a server whose stdout starts with a mise banner",
+      _rc == 0, f"rc={_rc} err={_err}")
+check("mcp_call returns the tool payload past the banner",
+      _payload.get("data", {}).get("registeredAliases") == ["bc281"], str(_payload))
+
+_rc, _payload, _err = pf.mcp_call([sys.executable, "-c", "import sys; sys.exit(0)"],
+                                  "list_contexts", timeout=20)
+check("a server that exits without answering is an error, never an empty success",
+      _rc != 0 and _err, f"rc={_rc} err={_err}")
+
+_rc, _payload, _err = pf.mcp_call(["/nonexistent/mcp-server"], "list_contexts", timeout=10)
+check("a server binary that does not exist is an error, never an empty success",
+      _rc != 0 and _err, f"rc={_rc} err={_err}")
+shutil.rmtree(_fake, ignore_errors=True)
+
+# ---- the report a contributor actually reads
+_txt = pf.render_report([pf.classify_lsp(_dc.replace(_lsp, rc=2)),
+                         graph_with(stray=["/repo/graphify-out/graph.json"]),
+                         dec_with(probe_rc=1, error="no answer")], strict=False)
+check("the navigation warnings render one line each with a name",
+      _txt.count("WARN") >= 3, _txt)
+check("the rendered navigation report tells the reader what to do",
+      _txt.count("-> what to do:") >= 3, _txt)
+
+
 print()
 if FAILURES:
     print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -672,6 +672,8 @@ def nav_states():
                              graph_mtime=2000.0, newest_source=1000.0,
                              newest_source_path="/repo/AlRunner/X.cs",
                              query_rc=0, query_out=f"NODE {pf.LSP_PROBE_SYMBOL} [src=...]")
+    # Healthy = nothing stray, nothing rebuilt. probe_graphify repairs both before
+    # the classifier ever sees them, so a healthy state carries no trace of either.
     dec = pf.DecompilerState(config="/repo/.mcp.json", registered=True,
                              target="/opt/DecompilerServer.dll", target_exists=True,
                              probe_rc=0, aliases=list(pf.DECOMPILER_ALIASES))
@@ -729,25 +731,49 @@ check("a language server that never answers is reported as a timeout", r.status 
 r = pf.classify_lsp(pf.LspState(script=False))
 check("a checkout without tools/lsp-query.py is reported", r.status == "WARN", r.summary)
 
-# ---- nav-graphify: stale, wrong directory, and no graph at all
+# ---- nav-graphify: the stray copy FAILs, staleness is repaired rather than reported
 def graph_with(**kw):
     return pf.classify_graphify(_dc.replace(_graph, **kw))
 
 
-r = graph_with(graph_mtime=1000.0, newest_source=1000.0 + 18 * 86400)
-check("a graph older than the newest source is reported stale", r.status == "WARN", r.summary)
-check("the stale summary quantifies how far behind it is",
-      "18.0d" in r.summary, r.summary)
-check("the stale remedy is the two-second rebuild",
-      "graphify update ." in r.remedy, r.remedy)
+# The stray copy is the one navigation condition that can halt a cycle, because it
+# is a tool answering WRONG rather than a tool being absent, and no rebuild fixes it.
+r = graph_with(stray_kept=["/repo/graphify-out"], stray_error="Permission denied")
+check("a stray graph that could NOT be removed is a FAIL", r.status == "FAIL", r.summary)
+check("the un-removable stray is named so it can be deleted by hand",
+      "/repo/graphify-out" in " ".join(r.detail), str(r.detail))
+check("the un-removable stray reports why removal failed",
+      "Permission denied" in " ".join(r.detail), str(r.detail))
+check("the un-removable stray explains the false negative it causes",
+      "No matching nodes found" in " ".join(r.detail), str(r.detail))
+check("a FAILing stray halts the cycle", pf.overall_exit([r], strict=False) == 1)
 
-r = graph_with(stray=["/repo/graphify-out/graph.json"])
-check("a second graph outside AlRunner/ is reported", r.status == "WARN", r.summary)
-check("the stray graph is named, so it can be deleted",
-      "/repo/graphify-out/graph.json" in " ".join(r.detail), str(r.detail))
+# Removed: the box is repaired, so it must not halt -- but it must not read as a
+# clean PASS either, or nobody learns the root copy keeps coming back.
+r = graph_with(stray_removed=["/repo/graphify-out"])
+check("a stray graph preflight REMOVED does not halt the cycle",
+      r.status == "WARN" and pf.overall_exit([r], strict=False) == 0, r.status)
+check("the removed stray is named in the report",
+      "/repo/graphify-out" in " ".join(r.detail), str(r.detail))
+
+# Staleness: no longer a verdict at all. probe_graphify rebuilds; this reports it.
+r = graph_with(rebuilt=True, rebuild_rc=0, rebuild_secs=1.9)
+check("a graph preflight rebuilt is a PASS, not a staleness warning",
+      r.status == "PASS", r.summary)
+check("the PASS says it rebuilt rather than hiding the repair",
+      "rebuilt" in r.summary, r.summary)
+check("the rebuild duration is reported",
+      "1.9s" in " ".join(r.detail), str(r.detail))
+check("no verdict mentions the word stale any more - staleness is fixed, not classified",
+      "stale" not in (r.summary + " ".join(r.detail)).lower(), r.summary + str(r.detail))
+
+r = graph_with(rebuilt=True, rebuild_rc=1, rebuild_out="graphify: boom")
+check("a rebuild that FAILED is reported", r.status == "WARN", r.summary)
+check("the failed rebuild shows graphify's output",
+      "boom" in " ".join(r.detail), str(r.detail))
 
 r = graph_with(graph=None, graph_mtime=None)
-check("no graph at all is reported with the rebuild command",
+check("no graph, and preflight could not build one, is reported",
       r.status == "WARN" and "graphify update ." in r.remedy, r.remedy)
 
 r = graph_with(query_rc=1, query_out="boom")
@@ -763,6 +789,55 @@ check("graphify missing from PATH is reported", r.status == "WARN", r.summary)
 check("the passing graphify report warns about English-question queries",
       "English question" in " ".join(pf.classify_graphify(_graph).detail),
       str(pf.classify_graphify(_graph).detail))
+
+# stray_graph_dirs: the root copy is a stray, AlRunner/'s own is never one.
+_g = tempfile.mkdtemp(prefix="preflight-stray-")
+os.makedirs(os.path.join(_g, "AlRunner", "graphify-out"), exist_ok=True)
+check("the canonical graph under AlRunner/ is not treated as a stray",
+      pf.stray_graph_dirs(_g) == [], str(pf.stray_graph_dirs(_g)))
+os.makedirs(os.path.join(_g, "graphify-out"), exist_ok=True)
+check("a graphify-out at the repository root IS a stray",
+      pf.stray_graph_dirs(_g) == [os.path.join(_g, "graphify-out")],
+      str(pf.stray_graph_dirs(_g)))
+shutil.rmtree(_g, ignore_errors=True)
+
+# probe_graphify REMOVES a stray rather than reporting it, and only reports the ones
+# it could not remove. Both halves against a real directory, because "did it actually
+# delete the thing" is not a claim a constructed state can make.
+_g = tempfile.mkdtemp(prefix="preflight-stray-rm-")
+os.makedirs(os.path.join(_g, "AlRunner"))
+os.makedirs(os.path.join(_g, "graphify-out"))
+with open(os.path.join(_g, "graphify-out", "graph.json"), "w") as fh:
+    fh.write("{}")
+_st = pf.probe_graphify(_g, timeout=10)
+check("probe_graphify deletes a stray graph directory rather than reporting it",
+      not os.path.exists(os.path.join(_g, "graphify-out")), str(_st.stray_removed))
+check("the deletion is reported, not silent",
+      _st.stray_removed == [os.path.join(_g, "graphify-out")], str(_st.stray_removed))
+shutil.rmtree(_g, ignore_errors=True)
+
+# The FAIL path has to be reachable, not merely classifiable: a directory whose parent
+# denies unlink. Skipped as root, which ignores the permission bits.
+if os.geteuid() != 0:
+    import stat as _stat
+    _g = tempfile.mkdtemp(prefix="preflight-stray-keep-")
+    os.makedirs(os.path.join(_g, "AlRunner"))
+    os.makedirs(os.path.join(_g, "graphify-out"))
+    with open(os.path.join(_g, "graphify-out", "graph.json"), "w") as fh:
+        fh.write("{}")
+    os.chmod(_g, _stat.S_IRUSR | _stat.S_IXUSR)
+    try:
+        _st = pf.probe_graphify(_g, timeout=10)
+        _r = pf.classify_graphify(_st)
+        check("a stray that cannot be deleted is kept and reported",
+              _st.stray_kept == [os.path.join(_g, "graphify-out")], str(_st.stray_kept))
+        check("an un-deletable stray reaches FAIL end to end, not just in a fixture",
+              _r.status == "FAIL", _r.summary)
+        check("and that FAIL is what halts a cycle",
+              pf.overall_exit([_r], strict=False) == 1)
+    finally:
+        os.chmod(_g, _stat.S_IRWXU)
+        shutil.rmtree(_g, ignore_errors=True)
 
 # ---- nav-bc-decompiler: configured is not the same as usable
 def dec_with(**kw):
@@ -804,8 +879,8 @@ _broken = [
     pf.classify_lsp(_dc.replace(_lsp, timed_out=True, rc=124)),
     pf.classify_lsp(_dc.replace(_lsp, rc=0, out="nope")),
     pf.classify_graphify(pf.GraphifyState()),
-    graph_with(stray=["/repo/graphify-out/graph.json"]),
-    graph_with(graph_mtime=1.0, newest_source=99999.0),
+    graph_with(stray_removed=["/repo/graphify-out"]),
+    graph_with(rebuilt=True, rebuild_rc=1, rebuild_out="boom"),
     graph_with(query_rc=1),
     # Every branch, not every classifier: an earlier version of this list reached
     # classify_graphify only through GraphifyState() (graphify not on PATH), so a
@@ -821,9 +896,19 @@ _broken = [
     dec_with(target_exists=False),
     dec_with(aliases=[]),
 ]
-check("no navigation check can ever FAIL - they must not halt a cycle",
+check("a tool being absent or unusable never halts a cycle - only a wrong ANSWER does",
       all(r.status != "FAIL" for r in _broken),
       str([(r.name, r.status) for r in _broken if r.status == "FAIL"]))
+# The boundary itself, asserted from both sides in one place so it cannot drift: the
+# un-removable stray graph is the ONLY navigation condition that may halt a cycle.
+# Everything above degrades to rg / tools/context-pack.py and merely slows an agent
+# down; a stray graph makes graphify answer "No matching nodes found." for symbols
+# that exist, which no fallback rescues and no rebuild fixes.
+check("the un-removable stray graph is the one navigation condition that CAN fail",
+      pf.classify_graphify(_dc.replace(_graph, stray_kept=["/x"])).status == "FAIL")
+check("and it is the ONLY one - every other broken state stays advisory",
+      {r.status for r in _broken} == {"WARN"},
+      str(sorted({(r.name, r.status) for r in _broken})))
 check("every broken navigation state still says what to do about it",
       all(r.remedy for r in _broken),
       str([r.name for r in _broken if not r.remedy]))
@@ -910,7 +995,7 @@ shutil.rmtree(_fake, ignore_errors=True)
 
 # ---- the report a contributor actually reads
 _txt = pf.render_report([pf.classify_lsp(_dc.replace(_lsp, rc=2)),
-                         graph_with(stray=["/repo/graphify-out/graph.json"]),
+                         graph_with(stray_removed=["/repo/graphify-out"]),
                          dec_with(probe_rc=1, error="no answer")], strict=False)
 check("the navigation warnings render one line each with a name",
       _txt.count("WARN") >= 3, _txt)


### PR DESCRIPTION
Closes #3087

Adds three checks to `tools/preflight.py`: the C# language server behind `tools/lsp-query.py`, `graphify`, and the bc-decompiler MCP server.

## Correction to an earlier version of this body

An earlier version of this description claimed that a stale graph reported `SafeDirectoryScan` at `loc=L51` while the class was at line 79. **That was wrong, and it was my error.** Both numbers were correct; the comparison was not. I ran `graphify query` in the **root checkout**, which sits on `agent/orchestrator/drift-2805` where the file is 168 lines and the class is at line 51, and `tools/lsp-query.py` in **my worktree** on `origin/main`, where #2892's doc comment makes the file 202 lines with the class at line 79. Comparing line numbers across two different trees is the same wrong-directory mistake this check exists to catch.

The replacement measurement is reproducible in a temp directory in seconds, and is a better motivating case anyway:

```
$ graphify update .                      # graph built with only Alpha.cs present
$ cat > Beta.cs ...                      # add a file
$ graphify query "BetaThing"
No matching nodes found.
exit=0
$ graphify update . && graphify query "BetaThing"
Traversal: BFS depth=2 | Start: ['BetaThing'] | 3 nodes found
```

A stale graph answers `No matching nodes found.` — **exit 0** — for a symbol that exists on disk. The cost of staleness is absent nodes reading as a true negative, not wrong line numbers.

## What is actually being checked

Not "is it installed". Each of these three fails by producing a **confidently wrong answer rather than an error**:

- `tools/lsp-query.py` exits 2 when the server never answered. Read as "nothing calls this", that is a false negative shaped like a finding.
- `graphify update` and `graphify query` both default to `graphify-out/graph.json` **relative to the current directory**.
- `.mcp.json` changes need a **session restart**, so "configured" and "usable right now" are different states and only the second is worth anything.

So each check probes for a **known-good answer** rather than for presence — an installed-but-broken tool returns nothing, and nothing is what a real negative looks like. `nav-lsp` requires the reply to name `AlRunner/Infrastructure/SafeDirectoryScan.cs`; `nav-graphify` requires the query to return a node called `SafeDirectoryScan`; `nav-bc-decompiler` requires `list_contexts` to return all nine `bc260`…`bc284` aliases.

Each probe **validates its own fixture against the working tree first**, so a renamed symbol reports as "this check's probe has drifted, the language server was NOT tested" and names the constants to update, rather than blaming a tool that was fine.

## graphify: repair, don't report

**Staleness is rebuilt, not classified.** Measured 1.89s warm. `CLAUDE.md` already says "rebuild rather than wonder whether it is current", and a check that tells a human to run a two-second command is asking a person to do a script's job — in an unattended loop there is no person to ask. `probe_graphify` runs `graphify update .` and the report says that it did. No verdict mentions staleness any more, and a test asserts that.

**A stray graph is deleted, and FAILs if it cannot be.** This is the valuable half, and it is not comparable to a graph being a few days old, because rebuilding does not fix it. Measured on this box: an 18-day-old `graphify-out` at the repository root answered `No matching nodes found.` for a symbol that exists, while the correct graph under `AlRunner/` returned 11 nodes — and a rebuild under `AlRunner/` never touches the root copy, so the two diverge indefinitely. That is the 13-day-stale incident `CLAUDE.md` records. Preflight deletes it (gitignored derived data, rebuilt in two seconds) and returns FAIL only if it could not.

`probe_graphify` is therefore the only check in this file that writes anything. That is stated where it happens, and `--no-tools` skips it.

## The bc-decompiler check speaks MCP

"Usable right now" cannot be read out of a config file, so the check spawns the server and talks to it over stdio — `initialize`, then `tools/call list_contexts`. It then says separately that a `.mcp.json` change still needs a session restart, and points at `mcp__bc-decompiler__status` for the in-session answer. Preflight can prove the server works; it cannot prove your session has loaded it, and it says so rather than implying otherwise.

Non-JSON lines in the JSON-RPC stream are skipped rather than parsed. `dotnet` is a mise shim here and mise prints its activation banner on **stdout**; in a line-delimited JSON-RPC stream that is a parse error on the first read, which would report a healthy server as broken. Same trap `strip_shim_banner()` exists for, one layer down, with a test that runs `mcp_call` against a fake server whose stdout starts with a banner.

## Severity: WARN, with exactly one exception

A tool that is **absent or unusable** only WARNs. It does not affect whether the runner is correct, it degrades to a documented fallback that still produces correct work (`rg`, `tools/context-pack.py`), and it makes an agent slower rather than wrong. `--strict` already promotes any WARN to exit 2 for a caller who wants zero tolerance.

The exception is a **stray graph that could not be deleted**, which FAILs and halts the cycle. That is not a missing tool — it is a tool confidently answering wrong, with no fallback and no rebuild that repairs it. Keeping FAIL for "this box produces wrong answers" is what keeps FAIL worth reading, and this is in that category.

A test pins the boundary from both sides, so it cannot drift: the un-removable stray *is* FAIL, and every other broken state is *exactly* `{"WARN"}`.

## Tests

Verdicts are pure functions of a state dataclass, so every broken state is constructed rather than arranged on the box. Covering: exit 2 / exit 1 / undocumented exit / timeout / `csharp-ls` missing / drifted fixture / **exit 0 with the wrong answer**; stray kept, stray removed, rebuild failed, no graph, query fails, query answers without the known-good node, `graphify` missing; no `.mcp.json`, no entry, unparseable JSON, DLL missing, server silent, context missing; plus `human_age`, `newest_source_mtime` skipping `obj/`, `read_mcp_entry`, `stray_graph_dirs`, and `mcp_call`.

**Verified end to end, not only in fixtures.** With a stray planted at the repository root and the canonical graph backdated, one `probe_graphify` call removed the stray, rebuilt in 1.89s (2.07s total) and resolved the probe symbol. A `graphify-out` whose parent denies unlink reaches FAIL and exit 1 — that is now a test too, skipped under root, which ignores the permission bits.

**Mutation-checked.** Each of these turns the suite red: dropping the known-good comparison (3 checks), ignoring missing contexts (3), dropping stray detection (5), conflating "answers" with "registered" (5), escalating a WARN branch to FAIL (4).

That last one found a real gap in my own tests: the severity guard originally reached `classify_graphify` only through the "not on PATH" branch, so the mutation slipped past it and was caught by a different test — luck, not coverage. `_broken` now covers every branch of all three classifiers.

## Cost

Per probe, in isolation: lsp 5.79s, decompiler 3.70s, graphify ~2.1s including a rebuild. `--no-tools` skips them and reports **SKIP rather than silence**, so a green preflight is never read as "these passed" — the same rule `check_corpus` follows.

## Also updated

Step 8 of `.claude/skills/autonomous-cycle/SKILL.md`'s preflight section. `preflight.py`'s docstring says it implements that skill and "does not add policy of its own", so adding a class of check without adding the step would have made that false.

## Left out deliberately

- **Asserting on graphify's English-question resolver bug.** The trap is real, but a test that pins wrong behavior encodes a bug as a contract. It is guidance in the passing check's detail line instead.
- **Verifying "usable in *this* session".** A separate process cannot observe the session's MCP registration; the check says a restart is still required rather than implying it checked.
- **`serena`**, the other server in `.mcp.json`. #3087 names three tools; a fourth is scope I did not take.

---

Authored by agent impl-6.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
