### PR TITLE
docs(skills): size the reviewer pool from measured throughput, arm on approve, and make a conflicted PR visible

### DIFF
--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -57,9 +57,22 @@ In the same session at least four confident conclusions were wrong and were caug
 a human pushed back or because something was re-measured. Parallelism multiplies that risk.
 Serial work with a review step does not.
 
-Exactly one agent runs. When it returns, you review, act, and start the next.
+Exactly one **implementation** agent runs, plus one **reviewer** alongside it. That pairing is
+the default and the human changes it at session start, not the loop. One implementer produces at
+most one PR at a time, so a single reviewer always outpaces it and review cannot fall behind by
+construction. When the implementer returns, you act on it and start the next; when the reviewer
+returns, you start the next reviewer rather than a second implementer.
 
 ## Reviewing is not overhead, and it is where queues actually stall
+
+**The default is one implementation agent and one reviewer.** Not a ratio to compute — a
+baseline to start from, changed only by the human at session start. One implementer produces at
+most one PR at a time and one reviewer clears roughly four an hour, so review cannot fall behind
+by construction, and the pile-up this section describes never begins.
+
+The measured throughput below is what to scale *by* when a human raises the concurrency, not a
+license to raise it. At six implementation agents you need roughly two reviewers to hold steady;
+work that out from the numbers rather than adding implementers because slots are free.
 
 When a coordinator does run several agents at once — the attended mode this skill's serial rule
 does not cover — the thing that breaks first is review, not implementation. Measured across one

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -59,6 +59,97 @@ Serial work with a review step does not.
 
 Exactly one agent runs. When it returns, you review, act, and start the next.
 
+## Reviewing is not overhead, and it is where queues actually stall
+
+When a coordinator does run several agents at once — the attended mode this skill's serial rule
+does not cover — the thing that breaks first is review, not implementation. Measured across one
+attended session on 2026-09-06:
+
+| agent | work | wall | rate |
+|---|---|---|---|
+| reviewer (runner PRs) | 6 PRs in one pass | 93 min | ~15.6 min/PR |
+| reviewer (corpus PRs) | 3 PRs in one pass | 64 min | ~21 min/PR |
+| implementation agent | 1 PR each | 35-85 min | ~1 PR/hour |
+
+So **one reviewer sustains roughly 4 PRs/hour, and six implementation agents produce 5-6.**
+The queue grows by arithmetic, not by anyone choosing badly. The balancing ratio is about
+**one reviewer per four implementation agents**, and a coordinator that spawns implementation
+agents whenever a slot frees will fall behind indefinitely without ever making an obvious
+mistake.
+
+**Count an open unreviewed PR against the concurrency budget, exactly like an unfinished
+implementation.** A coordinator running 6 implementation agents with 6 unreviewed PRs is
+running at 12, not 6, and should stop starting new work. This is the accounting that makes
+priority 3 below fire on its own instead of needing to be remembered — the priority order
+already puts "a PR is waiting on review" *above* "an issue is ready to work", and it still got
+skipped, because starting an implementation agent feels like progress and starting a reviewer
+feels like overhead.
+
+**Review in batches of three or four, not one at a time and not six or more.** Both extremes
+were measured:
+
+- **Batches that are too large go stale.** A batch of six took 93 minutes; during it, three PRs
+  from the original brief merged and two of the remaining six had their head SHA move. Two of
+  six verdicts came back "no verdict on current head" — a third of the batch wasted. Review
+  takes ~15 min/PR and heads move every 30-60 min under load, so the batch has to finish inside
+  the window in which its subjects hold still.
+- **Batches of one lose the findings that matter most.** The single most valuable result in that
+  session was cross-PR: two PRs bumped the same submodule pin to different revisions, conflicting
+  three ways, and the reviewer worked out which had to merge first because its revision was an
+  ancestor of the other. **A one-PR-at-a-time reviewer cannot see that**, and neither can the
+  coordinator, who is not reading the diffs.
+
+**A reviewer that approves a PR arms auto-merge on it immediately, in the same pass.** Do not
+hand an approval back to the coordinator and wait for it to act — that round trip is where the
+verdict goes stale, and staleness is the main cost of reviewing in batches. The reviewer has
+just read the head SHA; it is the only actor that knows the verdict and the SHA are consistent
+at that instant.
+
+```bash
+gh pr merge <N> --repo <owner>/<repo> --squash --auto
+```
+
+Arm **only** when all of these hold. Any one missing means report it to the coordinator instead:
+
+- **The PR is on a branch this loop owns.** Check the **branch prefix**, never the author field
+  — every loop running under one account reports that account as the author, and an outside
+  contributor's PR is never merged by us.
+- No release run is in progress (`publish.yml` pushes a fast-forward; a merge during its
+  ~40-minute run kills it).
+- `git merge-tree --write-tree --messages origin/<base> origin/<branch>` is clean.
+- If the PR asserts anything about BC's behaviour, its corpus PR has **merged**, and the pin bump
+  and count-baseline update are folded in.
+- No *other* PR in the same batch conflicts with it. Where two do — two submodule pin bumps to
+  different revisions, say — arm only the one that must merge first and report the ordering.
+
+**Record the SHA you armed against** in the verdict. If the head moves afterwards, GitHub keeps
+auto-merge armed against the new head, which nobody has reviewed; the coordinator needs the SHA
+to notice.
+
+**Arming is refused on a PR that is already mergeable** — GitHub answers `Pull request is in
+clean status`, because there is nothing left to wait for. That is not an error to retry or
+report as a failure: it means the PR can merge now, so say so and let the coordinator merge it
+directly. Check the exit code; a loop that printed "armed" regardless of it once left four green
+PRs sitting unarmed.
+
+Arming is not merging, and it does not replace the merge bar — it is the bar expressed as a
+standing instruction to GitHub, so a PR lands the moment its checks go green instead of at the
+coordinator's next sweep.
+
+**Keep one reviewer continuously alive rather than spawning one when a queue becomes visible.**
+Reactive spawning is what produces the pile-up: by the time the queue is obvious it is already
+several PRs deep, and the batch needed to clear it is large enough to go stale. Start the
+replacement when a reviewer returns.
+
+**A review verdict must name the head SHA it was made against.** Heads move under a review in
+minutes when other loops and outside contributors are pushing. A verdict without a SHA cannot be
+checked for staleness, and merging on a stale one has already nearly merged a commit whose CI was
+red. Re-read the head immediately before merging and pass `--match-head-commit`, so the merge
+refuses rather than silently taking something else.
+
+These numbers come from a single session and review time varies with PR size. Re-measure with
+`tools/agent-cost.py` before treating the ratio as fixed.
+
 ## Preflight — run this first, every time, and stop if it fails
 
 A fresh or drifted box does not announce that it is broken; it produces numbers that look fine.
@@ -219,8 +310,32 @@ a merge can turn `main` red, which outranks everything you were about to do.
    consecutive cycles on the same red, notify a human and demote it so other work continues.
    Never ship a speculative fix to get past it: unattended and self-reviewed, that is how a wrong
    change reaches `main`.
-2. **One of our PRs is red.** Drive it green, or close it with the reason. A red PR left open is
-   worse than no PR: it looks like progress.
+2. **One of our PRs is red, or conflicted.** Drive it green, or close it with the reason. A red
+   PR left open is worse than no PR: it looks like progress.
+
+   **Check `mergeStateStatus` for `DIRTY` on every sweep, not just the check conclusions.** A
+   conflicted PR is *not* red — **CI does not run at all on a PR with conflicts**, so it keeps
+   whatever green checks it last earned and reads as healthy in `gh pr list` and in any
+   conclusions-based summary. Nothing about it looks wrong, and it can sit indefinitely. This
+   happened on 2026-09-06: a PR sat `DIRTY` for hours behind a green-looking check set and was
+   found only by a manual sweep, because the priority order below asks about *red* and a
+   conflicted PR never becomes red.
+
+   ```bash
+   gh pr list --repo <owner>/<repo> --state open \
+     --json number,mergeStateStatus,statusCheckRollup
+   ```
+
+   `DIRTY`/`CONFLICTING` → rebase on the base branch, resolve, force-push with
+   `--force-with-lease`, re-check until it reads `BLOCKED` or `CLEAN`. **Resolve on the merits,
+   not mechanically:** a conflict means someone else changed the same code, so read what landed
+   and decide whether this PR's change is still the right one. If `main`'s newer version already
+   does what the PR intended, closing it as superseded is the correct outcome.
+
+   **Never force-push a branch you do not own.** Where several loops or outside contributors
+   share a repository, check the *branch prefix*, not the author field — loops running under the
+   same account all report that account as the author. Getting this wrong means force-pushing
+   another loop's work.
 3. **A PR is waiting on review.** Dispatch the `reviewer` agent. A PR authored by the account
    the loop runs as may be merged unattended **only when every one of these aligns** — any one
    missing sends it to the human queue instead:

--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -97,6 +97,75 @@ one dispatch this turned a single issue into four sharing one root cause (#2723 
 agent which of the related issues its change closes for free rather than assigning all of
 them; "these three are one fix, that one is not, here is why" is a complete answer.
 
+## Keep a reviewer running, and size the batch
+
+Review is the step that stalls, and it stalls by arithmetic rather than by anyone deciding
+badly. Measured on 2026-09-06: a reviewer clears **6 PRs in 93 minutes (~15.6 min/PR)** and
+**3 corpus PRs in 64 minutes (~21 min/PR)**, so one reviewer sustains about **4 PRs/hour**.
+Implementation agents take 35-85 minutes and produce one PR each, so six of them produce
+**5-6 PRs/hour**. One reviewer cannot keep up with six implementation agents. Budget roughly
+**one reviewer per four implementation agents**.
+
+**Treat an open unreviewed PR as unfinished work that counts against your concurrency budget.**
+Six implementation agents plus six unreviewed PRs is twelve, not six. Without that accounting
+you will keep starting implementation agents whenever a slot frees, because starting one feels
+like progress and starting a reviewer feels like overhead - and the queue grows every hour.
+
+**Batch three or four PRs per reviewer.** Larger batches go stale: a batch of six ran 93
+minutes, during which three PRs from the brief merged and two heads moved, so a third of the
+verdicts came back "no verdict on current head". Smaller batches lose the cross-PR findings that
+are the reason to batch at all - the most valuable result that day was spotting that two PRs
+bumped the same submodule pin to different revisions and working out which had to merge first.
+A per-PR reviewer cannot see that, and neither can you.
+
+**A reviewer that approves a PR arms auto-merge on it immediately, in the same pass.** Do not
+hand an approval back to the coordinator and wait for it to act — that round trip is where the
+verdict goes stale, and staleness is the main cost of reviewing in batches. The reviewer has
+just read the head SHA; it is the only actor that knows the verdict and the SHA are consistent
+at that instant.
+
+```bash
+gh pr merge <N> --repo <owner>/<repo> --squash --auto
+```
+
+Arm **only** when all of these hold. Any one missing means report it to the coordinator instead:
+
+- **The PR is on a branch this loop owns.** Check the **branch prefix**, never the author field
+  — every loop running under one account reports that account as the author, and an outside
+  contributor's PR is never merged by us.
+- No release run is in progress (`publish.yml` pushes a fast-forward; a merge during its
+  ~40-minute run kills it).
+- `git merge-tree --write-tree --messages origin/<base> origin/<branch>` is clean.
+- If the PR asserts anything about BC's behaviour, its corpus PR has **merged**, and the pin bump
+  and count-baseline update are folded in.
+- No *other* PR in the same batch conflicts with it. Where two do — two submodule pin bumps to
+  different revisions, say — arm only the one that must merge first and report the ordering.
+
+**Record the SHA you armed against** in the verdict. If the head moves afterwards, GitHub keeps
+auto-merge armed against the new head, which nobody has reviewed; the coordinator needs the SHA
+to notice.
+
+**Arming is refused on a PR that is already mergeable** — GitHub answers `Pull request is in
+clean status`, because there is nothing left to wait for. That is not an error to retry or
+report as a failure: it means the PR can merge now, so say so and let the coordinator merge it
+directly. Check the exit code; a loop that printed "armed" regardless of it once left four green
+PRs sitting unarmed.
+
+Arming is not merging, and it does not replace the merge bar — it is the bar expressed as a
+standing instruction to GitHub, so a PR lands the moment its checks go green instead of at the
+coordinator's next sweep.
+
+**Start the next reviewer when one returns**, not when a queue becomes visible. By the time a
+pile-up is obvious it is already too deep to clear in one fresh batch.
+
+**Require the head SHA in every verdict**, and re-read it immediately before merging. Heads move
+within minutes when other loops and outside contributors push. Pass `--match-head-commit` so a
+merge refuses rather than quietly taking a commit nobody reviewed - a SHA in one brief had a red
+verdict attached by the time the review finished.
+
+One session's sample, and review time scales with PR size. Re-measure with `tools/agent-cost.py`
+rather than treating the ratio as settled.
+
 ## Triage
 
 Run the `triager` subagent at the **start** of a cycle, and again whenever the open-issue

--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -99,6 +99,15 @@ them; "these three are one fix, that one is not, here is why" is a complete answ
 
 ## Keep a reviewer running, and size the batch
 
+**The default is one implementation agent and one reviewer.** Not a ratio to compute — a
+baseline to start from, changed only by the human at session start. One implementer produces at
+most one PR at a time and one reviewer clears roughly four an hour, so review cannot fall behind
+by construction, and the pile-up this section describes never begins.
+
+The measured throughput below is what to scale *by* when a human raises the concurrency, not a
+license to raise it. At six implementation agents you need roughly two reviewers to hold steady;
+work that out from the numbers rather than adding implementers because slots are free.
+
 Review is the step that stalls, and it stalls by arithmetic rather than by anyone deciding
 badly. Measured on 2026-09-06: a reviewer clears **6 PRs in 93 minutes (~15.6 min/PR)** and
 **3 corpus PRs in 64 minutes (~21 min/PR)**, so one reviewer sustains about **4 PRs/hour**.


### PR DESCRIPTION
Closes #3097

Three gaps in the coordination skills, all found by running an attended multi-agent session on 2026-09-06 and watching what actually piled up. Every number here was measured in that session, not estimated.

## Reviewing stalls by arithmetic

| agent | work | wall | rate |
|---|---|---|---|
| reviewer (runner PRs) | 6 PRs, one pass | 93 min | ~15.6 min/PR |
| reviewer (corpus PRs) | 3 PRs, one pass | 64 min | ~21 min/PR |
| implementation agent | 1 PR each | 35-85 min | ~1 PR/hour |

One reviewer sustains ~4 PRs/hour; six implementation agents produce 5-6. So the pile-up is not a scheduling mistake anyone makes — it is the ratio. Both skills now say roughly **one reviewer per four implementation agents**, and to **count an open unreviewed PR against the concurrency budget** like an unfinished implementation. That accounting is what makes the existing priority order fire on its own: `autonomous-cycle` already ranks review above picking up a new issue, and it still got skipped, because starting an implementation agent feels like progress.

## Batch three or four

- Six went stale: during that 93-minute pass, three PRs from the brief merged and two heads moved, so a third of the verdicts came back with no verdict on the current head.
- One at a time loses the reason to batch: the most valuable finding that day was that two PRs bumped the same submodule pin to different revisions, and one had to merge first because its revision was an ancestor of the other. A per-PR reviewer cannot see that.

## An approving reviewer arms auto-merge in the same pass

Against the SHA it just verified, rather than handing the approval back and waiting — that round trip is exactly where a verdict goes stale. Guarded on branch ownership, release windows, `merge-tree` cleanliness, a merged corpus PR where one is owed, and conflicts with others in the same batch. Also records the trap that GitHub **refuses** to arm an already-mergeable PR (`Pull request is in clean status`), which is not a failure to retry — a loop that printed "armed" regardless of the exit code once left four green PRs unarmed.

## A conflicted PR is invisible to a priority order that asks about "red"

CI does not run at all on a PR with conflicts, so it keeps its last green checks and reads as healthy in `gh pr list` and in any conclusions-based summary. `ci-verdicts.md` documents the symptom; the priority order did not encode it. A PR sat `DIRTY` for hours behind a green-looking check set this session and was found only by a manual sweep.

Priority 2 now covers `mergeStateStatus`, says to resolve **on the merits** rather than mechanically (a conflict means someone else changed the same code, and "superseded, close it" is a legitimate outcome), and warns that the **branch prefix, not the author field**, identifies whose branch it is. Several loops run under one account and all report that account as the author — this session I briefed a reviewer that four PRs were "ours" when they belonged to a separate autonomous loop, and dispatched an agent to force-push one before catching it.

## What this does not claim

One session's sample, and review time scales with PR size — the 15.6 min/PR average includes some very small PRs. Both sections say so and point at `tools/agent-cost.py` for re-measurement, rather than presenting the ratio as settled.

Documentation only: two skill files, no code, no workflows, no `CHANGELOG.md`.

---
Written by an agent (coordinator session) acting on the account holder's behalf.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
