### PR TITLE
fix(ci): see a colon between a closing keyword and its issue reference

### DIFF
--- a/.github/scripts/check_closing_reference.sh
+++ b/.github/scripts/check_closing_reference.sh
@@ -112,8 +112,36 @@ REF_HASH='(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#[0-9]+'
 REF_URL='https?://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/(?:issues|pull)/[0-9]+'
 REF="(?:${REF_HASH}|${REF_URL})"
 
-CANONICAL_LINE_RE="^[[:space:]]*(?:${KEYWORDS})[[:space:]]+${REF}[[:space:]]*[.]?[[:space:]]*\$"
-STRAY_MATCH_RE="\\b(?:${KEYWORDS})[[:space:]]+${REF}"
+# Separator between the keyword and the reference.
+#
+# This used to be "[[:space:]]+", which REQUIRES whitespace and therefore could
+# not match a colon. GitHub's parser honors "closes: #N"; ours did not see it,
+# in either direction. That closed #2942 by accident when PR #2951 merged --
+# merge commit bb09fa5b carried "which this PR closes: #2942 for RunPageLink"
+# in a commit message, the issue timeline attributes the close to that commit,
+# and this check was green (#3094).
+#
+# DELIBERATELY WIDER than any syntax GitHub documents. The two failure
+# directions do not cost the same:
+#
+#   * a false positive costs the author one reword, or one "No linked issue:"
+#     line -- it is visible and it is cheap;
+#   * a false negative silently closes somebody else's issue, and the only
+#     reason anyone noticed this time is that a human read the merge commit.
+#
+# So the separator matches an optional single punctuation mark with optional
+# whitespace either side, and matching something GitHub would ignore is an
+# acceptable price. It still cannot span WORDS, which is what keeps ordinary
+# prose ("this fixes the regression reported in #456") out -- that case, and
+# the bare-number case the "#" requirement excludes, are both covered in
+# test_check_closing_reference.sh so a future widening cannot quietly eat them.
+#
+# The colon is not first inside the bracket expression on purpose: "[:" opens a
+# POSIX character class, so "[,;:]" is unambiguous where "[:;,]" is not.
+SEP='[[:space:]]*[,;:]?[[:space:]]*'
+
+CANONICAL_LINE_RE="^[[:space:]]*(?:${KEYWORDS})${SEP}${REF}[[:space:]]*[.]?[[:space:]]*\$"
+STRAY_MATCH_RE="\\b(?:${KEYWORDS})${SEP}${REF}"
 ESCAPE_LINE_RE='^[[:space:]]*No linked issue:[[:space:]]*(.*)$'
 
 extract_number() {
@@ -139,7 +167,12 @@ is_declared() {
 
 while IFS= read -r line; do
   if printf '%s' "$line" | command grep -qiP "$CANONICAL_LINE_RE"; then
-    match=$(printf '%s' "$line" | command grep -oiP "(?:${KEYWORDS})[[:space:]]+${REF}")
+    # ${SEP}, not a hardcoded "[[:space:]]+". This extraction is a THIRD copy of
+    # the keyword/reference shape, and when the separator was widened in the two
+    # named constants but not here, CANONICAL_LINE_RE matched the line while this
+    # found nothing -- so "Closes: #123" was silently recorded as declaring no
+    # target, and the PR was told it had no closing reference at all (#3094).
+    match=$(printf '%s' "$line" | command grep -oiP "(?:${KEYWORDS})${SEP}${REF}")
     num=$(extract_number "$match")
     [ -n "$num" ] && declared_targets="$declared_targets $num"
   fi

--- a/.github/scripts/test_check_closing_reference.sh
+++ b/.github/scripts/test_check_closing_reference.sh
@@ -263,6 +263,73 @@ assert_exit "PR_COMMITS unset still fails a stray body reference" 1 "fix: someth
 
 This does not close #456."
 
+# --- #3094: the SEPARATOR, not the reference form ----------------------------
+#
+# The third occurrence of this bug class, after #2127/#2125 and #2486/#2479.
+# Both earlier fixes widened WHERE the script looks (the body, then the commit
+# messages). This one is about the shape of the reference itself: the script
+# required whitespace between the keyword and the reference
+# ("[[:space:]]+"), so no colon form matched EITHER pattern, while GitHub's
+# parser honors it.
+#
+# Measured, not assumed. Merge commit bb09fa5b (PR #2951) carried the line
+# below in a commit message, and the issue timeline attributes the close to it:
+#
+#   closed at 2026-09-06T09:55:35Z commit_id=bb09fa5b...
+#
+# #2942 was closed although the sentence says in plain words that it stays
+# open. The guard was green.
+#
+# The first case is that exact string.
+assert_exit_commits "the real #3094 sentence: 'closes: #N' in a commit message fails" 1 \
+  "feat: something" \
+  "Closes #2931" \
+  "feat: something
+
+open rather than #2931, which this PR closes: #2942 for RunPageLink and #2943"
+
+# Both directions of the same defect, in the body this time.
+assert_exit "a stray colon-form close of an undeclared issue fails" 1 "fix: something" \
+  "Closes #123
+
+This does not close: #456."
+assert_exit "a stray colon-form close with no space fails" 1 "fix: something" \
+  "Closes #123
+
+This does not close:#456."
+assert_exit "a stray semicolon-form close fails" 1 "fix: something" \
+  "Closes #123
+
+Superseded; fixes; #456 stays open."
+assert_exit "a stray colon-form close naming a URL fails" 1 "fix: something" \
+  "Closes #123
+
+This does not close: https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/456"
+assert_exit "a stray colon-form close with a repo prefix fails" 1 "fix: something" \
+  "Closes #123
+
+Not this one, resolved: owner/repo#456"
+
+# The MIRROR bug: a body that declares its target with a colon is declaring it
+# as far as GitHub is concerned, so the script must recognise it as the
+# canonical line rather than reporting "no linked issue" while GitHub closes one.
+assert_exit "a canonical 'Closes: #N' line is recognised as the declared target" 0 \
+  "fix: something" "Closes: #123"
+assert_exit "a canonical 'Closes: #N' line with a trailing period passes" 0 \
+  "fix: something" "Closes: #123."
+
+# Widening the separator must not start matching ordinary prose. A keyword and
+# a reference separated by WORDS is not a closing reference in any form GitHub
+# honors, and flagging it would train authors to ignore this check.
+assert_exit "a keyword separated from the reference by prose still passes" 0 \
+  "fix: something" "Closes #123
+
+This fixes the regression reported in #456."
+assert_exit "'fixes N bugs' with no # is still not a reference" 0 "fix: something" \
+  "Closes #123
+
+This fixes 3 bugs in the parser."
+
 # --- #2646: the PR template must not answer the check on the author's behalf ---
 #
 # The template exists so the escape hatch is discoverable where the body is

--- a/tools/pr-body.py
+++ b/tools/pr-body.py
@@ -148,8 +148,21 @@ REF_HASH = r"(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#[0-9]+"
 REF_URL = r"https?://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/(?:issues|pull)/[0-9]+"
 REF = f"(?:{REF_HASH}|{REF_URL})"
 
-CANONICAL_LINE_RE = re.compile(rf"^[ \t]*(?:{KEYWORDS})[ \t]+{REF}[ \t]*\.?[ \t]*$", re.I)
-STRAY_RE = re.compile(rf"\b(?:{KEYWORDS})[ \t]+{REF}", re.I)
+# Separator between the keyword and the reference. This was "[ \t]+", which
+# REQUIRES whitespace and so could not match a colon -- while GitHub's parser
+# honors "closes: #N". That accidentally closed #2942 when PR #2951 merged
+# (#3094). Kept deliberately wider than any documented GitHub syntax, because
+# the two failure directions do not cost the same: a false positive costs one
+# reword, a false negative silently closes somebody else's issue.
+#
+# It must stay in step with SEP in .github/scripts/check_closing_reference.sh --
+# that script is the server-side gate, this is only the local preflight, and
+# tools/test_pr_body.py asserts parity between the two on a case list that now
+# includes the colon forms.
+SEP = r"[ \t]*[,;:]?[ \t]*"
+
+CANONICAL_LINE_RE = re.compile(rf"^[ \t]*(?:{KEYWORDS}){SEP}{REF}[ \t]*\.?[ \t]*$", re.I)
+STRAY_RE = re.compile(rf"\b(?:{KEYWORDS}){SEP}{REF}", re.I)
 
 
 def _ref_number(fragment: str) -> int | None:
@@ -171,7 +184,12 @@ def declared_targets(body: str) -> list[int]:
     out: list[int] = []
     for line in body.split("\n"):
         if CANONICAL_LINE_RE.match(line):
-            m = STRAY_RE.search(line) or re.search(rf"(?:{KEYWORDS})[ \t]+{REF}", line, re.I)
+            # {SEP}, not a hardcoded "[ \t]+". This is a THIRD copy of the
+            # keyword/reference shape; the shell script has the same one, and
+            # widening the two named constants but not this extraction made
+            # CANONICAL_LINE_RE match a line that then yielded no number, so
+            # "Closes: #123" declared nothing at all (#3094).
+            m = STRAY_RE.search(line) or re.search(rf"(?:{KEYWORDS}){SEP}{REF}", line, re.I)
             n = _ref_number(m.group(0)) if m else None
             if n is not None and n not in out:
                 out.append(n)

--- a/tools/test_pr_body.py
+++ b/tools/test_pr_body.py
@@ -585,6 +585,18 @@ CASES = [
     ("prose with a bare number", "Closes #2783\n\nThis fixes 3 bugs in the parser.\n"),
     ("cross-repo declaration", "Fixes StefanMaron/BusinessCentral.AL.Runner#42\n"),
     ("url reference inline", "Closes #2783\n\nsee https://github.com/o/r/issues/77 fixes https://github.com/o/r/issues/77\n"),
+    # #3094: the colon separator. GitHub honors "closes: #N" and neither
+    # implementation saw it, so this pair of files agreed with each other and
+    # both disagreed with GitHub -- which is the one failure mode a parity
+    # suite cannot catch by construction unless the case is actually listed
+    # here. It closed #2942 for real when PR #2951 merged.
+    ("colon declaration", "Closes: #2783\n"),
+    ("colon inline foreign keyword", "Closes #2783\n\nThis does not close: #2125.\n"),
+    ("colon with no space", "Closes #2783\n\nThis does not close:#2125.\n"),
+    ("semicolon inline foreign keyword", "Closes #2783\n\nSuperseded; fixes; #2125 stays open.\n"),
+    ("colon cross-repo inline", "Closes #2783\n\nNot this one, resolved: owner/repo#2125\n"),
+    ("colon url inline", "Closes #2783\n\nThis does not close: https://github.com/o/r/issues/2125\n"),
+    ("colon restatement of a declared target", "Closes #2783\n\nIt closes: #2783 indeed.\n"),
 ]
 
 if not shutil.which("bash") or not os.path.exists(SH):


### PR DESCRIPTION
Closes #3094

Opened by agent **impl-1**, which also filed #3094.

> **Note on the text below.** Every quoted string has the `#` removed from its issue number on
> purpose. These strings are live closing references and GitHub parses commit messages and PR
> bodies alike — quoting one verbatim here would shut issue 2942 a second time, which is the
> defect this PR is about. The script's own rule is that a bare number is not a reference, so
> the digits alone are inert. I ran the new guard against this PR's own title, body and commit
> message before opening it: `rc=0`, declared target 3094.

## The bug

`.github/scripts/check_closing_reference.sh` required **whitespace** between the closing
keyword and the reference:

```bash
STRAY_MATCH_RE="\\b(?:${KEYWORDS})[[:space:]]+${REF}"
```

`[[:space:]]+` cannot match a colon. GitHub's parser honors the colon form; ours never saw it.
Issue 2942 was shut when PR #2951 merged, and this check was green.

Confirmed from the timeline rather than inferred:

```
$ gh api repos/StefanMaron/BusinessCentral.AL.Runner/issues/2942/timeline
shut at 2026-09-06T09:55:35Z commit_id=bb09fa5bcb13284974422a28e622d94205b4288e
```

The line responsible, in a commit message inside merge commit `bb09fa5b`:

```
open rather than #2931, which this PR closes: 2942 for RunPageLink and 2943
```

The sentence says in plain words that those two stay open. 2943, further along and not
adjacent to a keyword, survived — which is itself evidence the adjacency is what fires.

**It failed in both directions.** A stray colon form went undetected; and a body declaring a
colon form was not recognised as declaring anything, so the author would be told they had no
linked issue while GitHub shut one anyway.

## Three copies of the shape, not two

The separator was hardcoded in `CANONICAL_LINE_RE`, in `STRAY_MATCH_RE`, and **a third time
inline** in the pass that extracts the number from a canonical line — in the shell script and
again in its Python mirror. I widened the two named constants first, and the tests caught the
miss: `CANONICAL_LINE_RE` matched a line the extraction then found nothing in, so a canonical
colon-form declaration recorded no target at all and the PR was told it had no closing
reference. Each file now has one `SEP` definition and uses it in all three places.

## The separator is deliberately wider than GitHub's documented syntax

The two failure directions do not cost the same:

- a **false positive** costs the author one reword or one `No linked issue:` line, and is
  visible immediately;
- a **false negative** silently shuts someone else's issue, and the only reason anyone caught
  this one is that a human read the merge commit.

So `SEP` is `[[:space:]]*[,;:]?[[:space:]]*` — matching things GitHub would ignore is an
acceptable price. It still cannot span **words**, which is what keeps ordinary prose out.
Both prose cases are pinned by tests so a future widening cannot quietly eat them:
`this fixes the regression reported in 456` and `this fixes 3 bugs in the parser` must keep
passing.

(The colon is not first inside the bracket expression on purpose: `[:` opens a POSIX class.)

## The Python mirror, and why its parity suite could not have caught this

`tools/pr-body.py` reimplements the same canonical/stray distinction so a body can be refused
locally, and `pr-check.yml`'s `pr-body-tests` job asserts parity between the two. Its case
list contained no colon form — so **the two implementations agreed with each other while both
disagreed with GitHub**, which is the one failure a parity suite cannot catch by construction
unless the case is listed. Six colon and semicolon cases added.

## Proof

- **RED** — 8 of the new shell cases failed before the fix, 5 parity cases failed on the
  Python side.
- **GREEN** — `test_check_closing_reference.sh`: **54 passed, 0 failed**.
  `tools/test_pr_body.py`: **all checks passed**.
- **Against the real string, not a paraphrase.** Feeding `aa625784`'s actual commit message
  through the guard now fails and names the right issue:

```
::error::A COMMIT MESSAGE on this branch contains a closing keyword ... next to issue
number 2942, which is not one of this PR's declared canonical targets.
rc=1
```

## Third occurrence — and why the obvious fail-closed fix would not have helped

After #2127/#2125 (PR body) and #2486/#2479 (commit message, which is when the guard was
extended to scan commit messages).

You asked whether the guard can fail closed instead of needing a new pattern each time. The
intuitive answer is to stop modelling GitHub's parser and ask it: `closingIssuesReferences` is
GitHub's own parse and is authoritative. I measured whether that would have worked, on the
very PR that caused this:

```
$ gh pr view 2951 --json closingIssuesReferences
closingIssuesReferences = 2931
```

**2942 is absent, yet merging shut it.** So `closingIssuesReferences` covers the PR title and
body only, not commit messages — and both of the last two occurrences were commit messages,
which have no pre-merge API. A cross-check against GitHub's parse would have caught neither.

That is why this change widens the pattern and leans it toward over-matching instead. The
cross-check is still worth having for the title/body half, but it is a separate, smaller win
than it first appears, and it is not the fix for this bug class.

**Residual, stated plainly:** a separator outside `[,;:]` and whitespace — `closes - 1`,
`closes -> 1` — would still slip through. I did not widen to arbitrary punctuation because
this repository's squash-merged commit subjects end in `(#N)`, so a rule loose enough to
accept any punctuation starts matching changelog-style lines like `- Fixed (#123)`. That
trade seemed worth naming rather than silently picking.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
