### PR TITLE
fix(cache): root a relative --cache once, and refuse an unrooted cache root loudly

### DIFF
--- a/AlRunner.Tests/RelativeCacheRootTests.cs
+++ b/AlRunner.Tests/RelativeCacheRootTests.cs
@@ -1,0 +1,242 @@
+// RelativeCacheRootTests — issue #3084.
+//
+// THE DEFECT
+//   `--cache` accepts a relative directory and CacheRoots stored it verbatim, so every path
+//   CacheRoots.Resolve derived from it stayed relative. One of those paths — the r2r-chunks
+//   cache — is handed straight to AssemblyLoadContext.LoadFromAssemblyPath, which REQUIRES an
+//   absolute path and refuses a relative one outright. Every extracted R2R chunk of Base
+//   Application / System Application / Business Foundation therefore failed to load, the run
+//   dropped to a tier where those apps' objects do not exist, and it reported ordinary test
+//   failures. Reproduced on tests/runner-extras/microsoft-test-library, BC 28.1, identical
+//   build and package caches, the ONLY difference being the form of the --cache value:
+//
+//       --cache .measure/relcache    -> exit 1, 3 tests, 0 pass / 3 fail, 16 [provision-gap]
+//       --cache "$PWD/.measure/abs"  -> exit 0, 3 tests, 3 pass / 0 fail,  0 [provision-gap]
+//
+//   Silent in the way that matters: nothing says "your cache path is relative". It says
+//   "'Microsoft Base Application' has a precompiled sidecar DLL that could not be loaded ...
+//   Fix: rebuild or replace the sidecar DLL" — advice that is wrong for this cause — and then
+//   the run continues and fails tests, which a reader takes for an unprovisioned dependency.
+//
+// WHAT EACH TEST HERE CLAIMS
+//   1-3  Resolve roots and normalizes what SetOverride was given, and leaves an already-
+//        absolute value exactly as it was. The cheap "is the path computed correctly" half.
+//   4    The decisive one: drive the real producer (AppLoader.ExtractAllDllPaths) under a
+//        relative override and assert the paths it hands back are accepted by the actual API
+//        the loader calls with them — LoadFromAssemblyPath — instead of asserting a property
+//        that merely correlates with that. Pre-fix this throws ArgumentException("... is not
+//        an absolute path"); post-fix the only thing left to complain about is the bytes.
+//   5    The loud half. A cache root that is somehow still not absolute must abort with a
+//        message naming the value, the flag and the CONSEQUENCE, not degrade into a wrong
+//        answer. Reached through an internal seam because both production writers of the
+//        override now root what they store — see SetOverrideBypassingRootingForTests.
+//   6    The sibling-writer invariant: DisableForRun adopts a raw environment value, and it
+//        must root that too, or the two writers of one field disagree about the invariant.
+//
+//   The link from DependencyLoader to the producer this file drives is already pinned by
+//   CorruptSidecarLoaderCallSiteTests, whose Tier-2 case asserts the reported chunk path
+//   lives under `r2r-chunks` — so loader -> ExtractAllDllPaths -> rooted path is covered end
+//   to end across the two files. That test is in RecordPatchesSerialCollection (it reads the
+//   process-global ProvisionGapLog) and this class must be in CacheRootsSerialCollection (it
+//   writes the process-global cache override), which is why the two claims live apart.
+//
+// Nothing here is a claim about Business Central: path resolution and assembly loading are
+// runner infrastructure, invisible to AL, and the al-language corpus has no way to pass a
+// --cache value at all. Nothing in this file belongs upstream.
+
+using System.IO.Compression;
+using System.Runtime.Loader;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(CacheRootsSerialCollection.Name)]
+public sealed class RelativeCacheRootTests : IDisposable
+{
+    // An owned scratch directory, named RELATIVELY. Path.GetRelativePath against the test
+    // host's working directory gives a genuinely non-rooted string that still points at a
+    // directory ScratchDirs will reclaim — better than a bare "relcache" leaf, which would
+    // litter the build output and, worse, resolve differently depending on where the test
+    // host was launched from.
+    private readonly string _absScratch = TestScratch.Dir("al-runner-relative-cache-root");
+    private readonly string _relScratch;
+
+    public RelativeCacheRootTests()
+        => _relScratch = Path.GetRelativePath(Environment.CurrentDirectory, _absScratch);
+
+    public void Dispose()
+    {
+        CacheRoots.ResetForTests();
+        try { Directory.Delete(_absScratch, recursive: true); } catch { /* best effort */ }
+    }
+
+    [Fact]
+    public void Resolve_RelativeOverride_IsRootedAgainstTheWorkingDirectory()
+    {
+        Assert.False(Path.IsPathRooted(_relScratch), "the fixture must actually be relative");
+
+        CacheRoots.SetOverride(_relScratch);
+        try
+        {
+            // The exact value, not just "it is rooted": a fix that rooted against the wrong
+            // base would satisfy IsPathRooted and still write to the wrong disk location.
+            Assert.Equal(Path.Combine(_absScratch, "r2r-chunks"), CacheRoots.Resolve("r2r-chunks"));
+            Assert.Equal(Path.Combine(_absScratch, "compiled-deps"), CacheRoots.Resolve("compiled-deps"));
+            Assert.Equal(Path.Combine(_absScratch, "ncl-shadow"), CacheRoots.Resolve("ncl-shadow"));
+
+            // And the whole point, stated as the precondition the consumer imposes.
+            Assert.True(Path.IsPathRooted(CacheRoots.Resolve("r2r-chunks")));
+        }
+        finally { CacheRoots.ResetForTests(); }
+    }
+
+    [Fact]
+    public void Resolve_RelativeOverrideWithDotSegments_IsNormalizedNotJustConcatenated()
+    {
+        // Path.Combine would have produced "<parent>/nonexistent-sibling/../<leaf>/r2r-chunks",
+        // a string that resolves correctly for File.Exists and is still not what any tool
+        // comparing two cache paths would call equal. GetFullPath collapses it.
+        var parent = Path.GetDirectoryName(_absScratch)!;
+        var leaf = Path.GetFileName(_absScratch);
+        var relParent = Path.GetRelativePath(Environment.CurrentDirectory, parent);
+        var noisy = Path.Combine(relParent, "nonexistent-sibling", "..", leaf);
+
+        Assert.False(Path.IsPathRooted(noisy));
+
+        CacheRoots.SetOverride(noisy);
+        try
+        {
+            Assert.Equal(Path.Combine(_absScratch, "r2r-chunks"), CacheRoots.Resolve("r2r-chunks"));
+            Assert.DoesNotContain("..", CacheRoots.Resolve("r2r-chunks"), StringComparison.Ordinal);
+        }
+        finally { CacheRoots.ResetForTests(); }
+    }
+
+    [Fact]
+    public void Resolve_AbsoluteOverride_IsUnchangedByTheRooting()
+    {
+        // The control. Rooting must be a no-op for the value every existing caller already
+        // passes, or this change would silently relocate every warm cache in existence.
+        CacheRoots.SetOverride(_absScratch);
+        try
+        {
+            Assert.Equal(Path.Combine(_absScratch, "r2r-chunks"), CacheRoots.Resolve("r2r-chunks"));
+            Assert.Equal(Path.Combine(_absScratch, "bc-symbols"), CacheRoots.Resolve("bc-symbols"));
+        }
+        finally { CacheRoots.ResetForTests(); }
+    }
+
+    /// <summary>
+    /// The decisive test: the paths the r2r-chunks producer hands back must be paths the API
+    /// the loader calls with them will actually accept.
+    ///
+    /// The chunk bytes are deliberately a 5-byte non-PE, the same shape
+    /// CorruptSidecarLoaderCallSiteTests uses — extraction never parses them, and using
+    /// garbage keeps this test from having to find a real assembly it can load into the
+    /// default context without colliding with an identity already loaded there. That makes
+    /// the assertion an exclusion rather than a success: LoadFromAssemblyPath must reject
+    /// these bytes for what they CONTAIN (BadImageFormatException), never for where they
+    /// LIVE (ArgumentException, "is not an absolute path"), which is the only complaint it
+    /// had pre-fix and the one that produced the silent tier drop.
+    /// </summary>
+    [Fact]
+    public void ExtractAllDllPaths_UnderARelativeCacheOverride_ProducesPathsLoadFromAssemblyPathAccepts()
+    {
+        var appPath = WriteSyntheticR2RApp();
+
+        CacheRoots.SetOverride(_relScratch);
+        try
+        {
+            var chunks = AppLoader.ExtractAllDllPaths(appPath);
+            Assert.Equal(2, chunks.Count);
+
+            foreach (var chunk in chunks)
+            {
+                Assert.True(Path.IsPathRooted(chunk), $"chunk path must be absolute: {chunk}");
+                Assert.True(File.Exists(chunk), $"chunk must exist on disk: {chunk}");
+                Assert.StartsWith(Path.Combine(_absScratch, "r2r-chunks"), chunk, StringComparison.Ordinal);
+
+                var ex = Assert.ThrowsAny<Exception>(
+                    () => AssemblyLoadContext.Default.LoadFromAssemblyPath(chunk));
+                Assert.IsType<BadImageFormatException>(ex);
+                Assert.DoesNotContain("is not an absolute path", ex.Message, StringComparison.Ordinal);
+            }
+        }
+        finally { CacheRoots.ResetForTests(); }
+    }
+
+    [Fact]
+    public void Resolve_WithAnUnrootedOverride_ThrowsNamingTheValueTheFlagAndTheConsequence()
+    {
+        CacheRoots.SetOverrideBypassingRootingForTests("some-relative-cache");
+        try
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() => CacheRoots.Resolve("r2r-chunks"));
+
+            // Every part a reader needs in order NOT to go looking at their package cache.
+            Assert.Contains("some-relative-cache", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("r2r-chunks", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("--cache", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("LoadFromAssemblyPath", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("#3084", ex.Message, StringComparison.Ordinal);
+        }
+        finally { CacheRoots.ResetForTests(); }
+    }
+
+    [Fact]
+    public void Resolve_WithARootedOverride_DoesNotThrow()
+    {
+        // The negative half of the guard: it must fire on the shape it is for, and on nothing
+        // else. Without this, a guard that threw unconditionally would pass the test above.
+        CacheRoots.SetOverrideBypassingRootingForTests(_absScratch);
+        try
+        {
+            Assert.Equal(Path.Combine(_absScratch, "r2r-chunks"), CacheRoots.Resolve("r2r-chunks"));
+        }
+        finally { CacheRoots.ResetForTests(); }
+    }
+
+    [Fact]
+    public void DisableForRun_AdoptingARelativeEnvironmentRoot_RootsItAndRepublishesTheRootedForm()
+    {
+        var previous = Environment.GetEnvironmentVariable(CacheRoots.NoCacheRootEnvVar);
+        Environment.SetEnvironmentVariable(CacheRoots.NoCacheRootEnvVar, _relScratch);
+        try
+        {
+            var root = CacheRoots.DisableForRun();
+
+            Assert.Equal(_absScratch, root);
+            Assert.Equal(Path.Combine(_absScratch, "r2r-chunks"), CacheRoots.Resolve("r2r-chunks"));
+            // Republished, so a re-exec'd child inherits the absolute form instead of
+            // re-resolving the same relative string against its own working directory.
+            Assert.Equal(_absScratch, Environment.GetEnvironmentVariable(CacheRoots.NoCacheRootEnvVar));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(CacheRoots.NoCacheRootEnvVar, previous);
+            CacheRoots.ResetForTests();
+        }
+    }
+
+    /// <summary>
+    /// A syntactically valid .app carrying two `publishedartifacts/*.dll` entries — enough for
+    /// AppLoader.IsR2R and ExtractAllDlls, and two chunks rather than one so a fix that
+    /// happened to root only the first would still fail.
+    /// </summary>
+    private string WriteSyntheticR2RApp()
+    {
+        Directory.CreateDirectory(_absScratch);
+        var appPath = Path.Combine(_absScratch, "RelCacheFixture_R2RDep_1.0.0.0.app");
+        byte[] bogusPe = { 0x4D, 0x5A, 0x90, 0x00, 0x03 };
+        using (var zip = ZipFile.Open(appPath, ZipArchiveMode.Create))
+        {
+            foreach (var name in new[] { "publishedartifacts/chunk000.dll", "publishedartifacts/chunk001.dll" })
+            {
+                using var s = zip.CreateEntry(name).Open();
+                s.Write(bogusPe, 0, bogusPe.Length);
+            }
+        }
+        return appPath;
+    }
+}

--- a/AlRunner/Infrastructure/CacheRoots.cs
+++ b/AlRunner/Infrastructure/CacheRoots.cs
@@ -75,8 +75,49 @@ public static class CacheRoots
     /// <see cref="DisableForRun"/> for the <c>--no-cache</c> case — it also arranges
     /// cleanup and re-exec continuity that calling this directly with an ad hoc directory
     /// would not get.
+    ///
+    /// <para><b>Rooted here, once (issue #3084).</b> A <c>--cache</c> value is user-supplied
+    /// and may be relative; every path <see cref="Resolve"/> derives from it then stays
+    /// relative, and the failure that produces is silent in the worst way. The r2r-chunks
+    /// cache feeds <c>AssemblyLoadContext.LoadFromAssemblyPath</c>, which REQUIRES an
+    /// absolute path and refuses a relative one — so with <c>--cache .measure/relcache</c>
+    /// every extracted chunk of Base Application / System Application / Business Foundation
+    /// failed to load, the run dropped to a tier where those apps' objects do not exist, and
+    /// it reported ordinary test failures plus 16 <c>[provision-gap]</c> blocks instead of
+    /// naming the cache path. Measured on tests/runner-extras/microsoft-test-library, same
+    /// build and same package caches: relative <c>--cache</c> 0 pass / 3 fail, absolute
+    /// <c>--cache</c> 3 pass / 0 fail.
+    ///
+    /// Rooted at the WRITE site rather than in <see cref="Resolve"/> for two reasons.
+    /// A new named cache added later cannot forget to root itself, the way N read sites
+    /// each doing their own <c>Path.GetFullPath</c> can. And rooting here PINS the root to
+    /// the working directory as it was when the flag was parsed: <c>Path.GetFullPath</c>
+    /// inside <see cref="Resolve"/> would re-resolve against whatever the current directory
+    /// happens to be at each call, so a <c>--watch</c> session or anything else that moves
+    /// the process's CWD mid-run would move a live run's cache underneath it.
+    ///
+    /// Same family as issue #2114, which rooted the HOME-derived half of exactly this
+    /// problem; <c>--cache</c> is the user-supplied root that sweep did not reach, and it
+    /// is strictly worse because #2114 crashed the process where this one degrades quietly.
+    /// This changes no persisted cache KEY — no cache resolved here hashes its own root
+    /// (r2r-chunks keys on the package content hash, ncl-cecil on the Ncl bytes plus the
+    /// runner content hash, and Program.cs's AL-output key deliberately hashes source paths
+    /// RELATIVE to the common source root) — and for an unchanged working directory
+    /// <c>GetFullPath</c> names the same physical directory the relative form already
+    /// resolved to, so entries written by an earlier run under a relative <c>--cache</c>
+    /// stay reachable.</para>
     /// </summary>
-    public static void SetOverride(string? cacheDir) => _override = cacheDir;
+    public static void SetOverride(string? cacheDir) => _override = Root(cacheDir);
+
+    /// <summary>
+    /// <c>Path.GetFullPath</c>, plus a null passthrough for the bare-default case. Both
+    /// writers of <see cref="_override"/> go through this so the invariant
+    /// "<see cref="_override"/> is absolute or null" holds no matter which one wrote it —
+    /// <see cref="DisableForRun"/> mints under <see cref="Path.GetTempPath"/> (already
+    /// absolute) but ALSO adopts a value out of the environment, which nothing validates.
+    /// </summary>
+    private static string? Root(string? dir)
+        => string.IsNullOrEmpty(dir) ? dir : Path.GetFullPath(dir);
 
     /// <summary>
     /// <c>--no-cache</c> (#2555): redirects every cache resolved through <see cref="Resolve"/>
@@ -100,15 +141,30 @@ public static class CacheRoots
         string root;
         if (!string.IsNullOrEmpty(existing))
         {
-            root = existing;
+            // #3084: rooted, like every other write to _override. This branch is the ONE
+            // path into the override that does not come from Program.cs's flag parsing —
+            // it adopts a raw environment value, which nothing validates and which a
+            // caller (or a shell that exported a relative path) can set to anything. The
+            // sibling branch below is absolute by construction (Path.GetTempPath), so
+            // without this the two writers of the same field would not maintain the same
+            // invariant, which is exactly how #3084's silent tier-drop got in.
+            root = Path.GetFullPath(existing);
+            // Republish the rooted form so a child re-exec'd from here inherits an absolute
+            // path. Rooting only in this process would leave the child to root the SAME
+            // relative value against ITS working directory — the one-throwaway-root-per-RUN
+            // guarantee this branch exists to provide would then quietly become two.
+            if (!string.Equals(root, existing, StringComparison.Ordinal))
+                Environment.SetEnvironmentVariable(NoCacheRootEnvVar, root);
         }
         else
         {
             // Reserved (not created — nothing may ever write into it) through ScratchDirs
             // (#2706) so a run killed before CleanupThrowawayRoot fires is reclaimed by the
             // next runner start instead of leaking a full cache per killed --no-cache run.
-            root = ScratchDirs.Reserve(
-                Path.Combine(Path.GetTempPath(), "al-runner-no-cache-" + Guid.NewGuid().ToString("N")));
+            root = Path.GetFullPath(ScratchDirs.Reserve(
+                Path.Combine(Path.GetTempPath(), "al-runner-no-cache-" + Guid.NewGuid().ToString("N"))));
+            // Publish the ROOTED form, so a re-exec'd child inherits an absolute path
+            // even if this generation was handed a relative one (#3084).
             Environment.SetEnvironmentVariable(NoCacheRootEnvVar, root);
         }
         _override = root;
@@ -146,8 +202,51 @@ public static class CacheRoots
         // AlRunnerPaths.UserHome throws loudly (issue #2114) rather than silently handing
         // back a relative path when $HOME names a directory that does not exist.
         var root = _override ?? Path.Combine(AlRunnerPaths.UserHome, ".cache", "al-runner");
+        // #3084: the invariant, restated where it is consumed. Both writers of _override
+        // root what they store, so this cannot fire through SetOverride/DisableForRun —
+        // it fires for a THIRD writer added later that forgets to. Stated here, and not
+        // only at the write sites, because this one method is the choke point every named
+        // cache goes through (compiled-deps, workspace-deps, ncl-cecil, bc-symbols,
+        // ncl-shadow, app-manifests, r2r-chunks, install-baseline), so one guard covers
+        // all eight rather than each consumer having to know that LoadFromAssemblyPath —
+        // or a re-exec, or a path-prefix comparison — is downstream of it.
+        //
+        // Loud rather than best-effort-rooted-here on purpose (.claude/rules/loud-failures.md):
+        // silently calling Path.GetFullPath at THIS point would re-resolve against whatever
+        // the current directory is right now, which is the moving-target bug the write-site
+        // rooting exists to prevent, and would hide the defect that produced the unrooted
+        // value instead of naming it.
+        if (!Path.IsPathRooted(root))
+            throw new InvalidOperationException(BuildUnrootedCacheRootMessage(root, name));
         return Path.Combine(root, name);
     }
+
+    /// <summary>
+    /// The diagnostic for a cache root that is not absolute. Separate and internal so the
+    /// tests can assert the exact text without reaching into <see cref="Resolve"/>'s
+    /// control flow. Names the value, the flag that most likely supplied it, and — the part
+    /// that was missing in #3084 — the consequence, so the reader is not left to conclude
+    /// from 16 <c>[provision-gap]</c> blocks that their package cache is unprovisioned.
+    /// </summary>
+    internal static string BuildUnrootedCacheRootMessage(string root, string name)
+        => $"al-runner resolved the '{name}' cache to a RELATIVE root '{root}'. Every cache " +
+           $"root must be absolute: the r2r-chunks cache feeds " +
+           $"AssemblyLoadContext.LoadFromAssemblyPath, which refuses a relative path, and a " +
+           $"relative root also means a different directory for any part of the run that " +
+           $"executes from a different working directory. Left unchecked this does not fail " +
+           $"the load loudly — it drops Base Application / System Application / Business " +
+           $"Foundation to a lower tier where their objects do not exist, and the run then " +
+           $"reports ordinary test failures. Pass an absolute directory to --cache (issue #3084).";
+
+    /// <summary>
+    /// Test-only seam for the <see cref="Resolve"/> rootedness guard above. Both production
+    /// writers of the override root what they store, so the guard is unreachable through
+    /// them by construction — and a guard with no test is a guard nobody knows still works.
+    /// Same shape, and the same reason, as
+    /// <c>AppLoader.ExtractAllDllPathsCore</c>'s internal content-hash-provider overload,
+    /// which exists so the identity tests can drive its no-identity branch.
+    /// </summary>
+    internal static void SetOverrideBypassingRootingForTests(string cacheDir) => _override = cacheDir;
 
     /// <summary>Test-only: resets the override so test processes/hosts that share this
     /// static (e.g. in-process unit tests, as opposed to the spawned-subprocess

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -510,7 +510,25 @@ for (int i = 0; i < args.Length; i++)
     // #2555: --cache and --no-cache are last-wins against each other for BOTH
     // alCacheDir and cacheRootOverride — an explicit --cache re-enables everything
     // a preceding --no-cache turned off, including the other caches' redirect.
-    if (args[i] == "--cache" && i + 1 < args.Length) { alCacheDir = args[++i]; cacheRootOverride = alCacheDir; noCacheRequested = false; continue; }
+    // #3084: rooted HERE, once, for BOTH consumers. CacheRoots.SetOverride roots what it
+    // stores too, but alCacheDir deliberately does NOT go through CacheRoots (see that
+    // class's "Deliberately NOT wired into alCacheDir" note), so it needs its own rooting
+    // or the AL-output cache keeps the CWD-dependent behaviour this fixes everywhere else.
+    // Path.GetFullPath is the only thing that can throw in this parse loop; a malformed
+    // --cache value returns the same exit 2 every other CLI usage error here returns,
+    // rather than an unhandled exception out of top-level statements (exit 134).
+    if (args[i] == "--cache" && i + 1 < args.Length)
+    {
+        var rawCacheDir = args[++i];
+        try { alCacheDir = Path.GetFullPath(rawCacheDir); }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(
+                $"--cache '{rawCacheDir}' is not a usable directory path: {ex.Message}");
+            return 2;
+        }
+        cacheRootOverride = alCacheDir; noCacheRequested = false; continue;
+    }
     // #2555: previously only disabled the AL-output cache (alCacheDir); the other
     // caches CacheRoots redirects stayed warm, so a run reached for specifically to
     // reproduce/measure a cold compile still got most of what "cold" is supposed to

--- a/AlRunner/ProgramSupport/CliText.cs
+++ b/AlRunner/ProgramSupport/CliText.cs
@@ -524,6 +524,10 @@ internal static partial class ProgramSupport
         w.WriteLine("                          are unchanged) AND every other named cache normally under");
         w.WriteLine("                          ~/.cache/al-runner/<name> (compiled-deps, workspace-deps,");
         w.WriteLine("                          ncl-cecil, bc-symbols, and more) as <DIR>/<name>.");
+        w.WriteLine("                          A relative DIR is resolved against the working directory");
+        w.WriteLine("                          ONCE, when the flag is parsed, and stored absolute: an");
+        w.WriteLine("                          unrooted cache root cannot be handed to the .NET assembly");
+        w.WriteLine("                          loader, and would otherwise move with the process (#3084).");
         w.WriteLine("  --no-cache              Disable every on-disk cache for this run, not just the");
         w.WriteLine("                          AL-output cache: the other named caches above are");
         w.WriteLine("                          redirected to a throwaway per-run directory (removed on");


### PR DESCRIPTION
Closes #3084

`--cache` accepted a relative directory and `CacheRoots.SetOverride` stored it verbatim.
`CacheRoots.Resolve` then `Path.Combine`d a cache name onto it without ever rooting it, so
every one of the eight named caches derived from a relative `--cache` stayed relative. One of
them, `r2r-chunks`, feeds `AssemblyLoadContext.LoadFromAssemblyPath`, which requires an
absolute path and refuses a relative one — so every extracted R2R chunk of Base Application /
System Application / Business Foundation failed to load, and the run dropped to a tier where
those apps' objects do not exist.

## Reproduced here before fixing

The measurement in the issue was taken by another agent while working on #3043, so I
reproduced the differential on my own box first. Same worktree, same Release build, same
package caches, same bundle; the only difference is the form of the `--cache` value:

| `--cache` | exit | tests | `[provision-gap]` blocks |
|---|---|---|---|
| `.measure/relcache` | 1 | 3 total, **0 pass / 3 fail** | **16** |
| `"$PWD/.measure/abscache"` | 0 | 3 total, 3 pass / 0 fail | 0 |

on `tests/runner-extras/microsoft-test-library`, BC 28.1.49838.54308. First failing test
`Codeunit62202.BaseAppFlowField_MatchedOrderLines_CalcFieldsAndSetRange` — Base Application's
objects not being there, seen from AL.

## Why `Resolve` never rooted it — the guard question

Not an oversight anyone could have caught by reading `Resolve`, because the two paths into it
looked equally safe and only one was:

* The **default** branch is `Path.Combine(AlRunnerPaths.UserHome, ".cache", "al-runner")`, and
  `AlRunnerPaths.UserHome` has validated rootedness and thrown loudly since **#2114**. So the
  no-flag path could not produce a relative root.
* The **override** branch is a raw CLI string, and nothing between the flag and
  `LoadFromAssemblyPath` looks at it.

And the consumers that *would* have exposed it defensively rooted at their own end, so nobody
ever saw a relative path escape. `DependencyResolver.FromSource` — the one place two cache
paths are compared, by prefix — calls `Path.GetFullPath` on **both** sides before comparing, so
`workspace-deps` being relative never broke source-supersedes-package ranking (#2688). Even
`AppLoader.ExtractAllDllPathsCore`, the function containing the defect, opens with
`Path.GetFullPath(appPath)` — it roots the *package* argument and not the *cache* directory two
lines later. The one consumer that could not defend itself is the .NET assembly loader, and its
complaint arrives as a caught exception rather than as a crash.

## #2114: same root cause, reached from a source that sweep did not cover

Same root cause, not merely the same symptom — an unrooted path silently resolving against the
process's CWD and only being detected inside `LoadFromAssemblyPath`, which is the exact chain
`AlRunnerPaths`' class comment already describes. #2114's fix rooted the **HOME-derived** half
and swept five more `Path.Combine` sites on that same root. `--cache` is a *user-supplied* root,
so it was never in that sweep's blast radius.

One asymmetry worth recording, because it inverts the severity: #2114 ended in an **unhandled**
exception, SIGABRT and a core dump. This one lands inside `DependencyLoader.LoadOne`'s tier-2
`catch`, which reports a provisioning gap and carries on. The louder bug was the safer one.

## What I did about the silent tier drop

Two separable things, per the issue.

**1. Root it, once, at the write site.** `CacheRoots.SetOverride` now stores
`Path.GetFullPath(dir)`, and `Program.cs` roots `alCacheDir` at `--cache` parse time (the
AL-output cache deliberately does not go through `CacheRoots`, so it needs its own). Rooting at
the **write** site rather than inside `Resolve` is deliberate: `GetFullPath` inside `Resolve`
would re-resolve against whatever the CWD is at each call, which is the moving-target half of
the bug — `--watch`, or anything that moves the process's working directory mid-run, would move
a live run's cache underneath it. Rooting once at parse time pins it.

**2. Make an unrooted cache root a refusal, not a degradation.** `Resolve` now throws
`InvalidOperationException` naming the value, the flag and — the part that was missing — the
*consequence*, instead of returning a path that produces a wrong answer dressed as a
provisioning problem. Placed in `Resolve` rather than at the `LoadFromAssemblyPath` call site
because `Resolve` is the single choke point all eight named caches go through
(`compiled-deps`, `workspace-deps`, `ncl-cecil`, `bc-symbols`, `ncl-shadow`, `app-manifests`,
`r2r-chunks`, `install-baseline`), so one guard covers all eight and a cache added later cannot
forget it. Fixing only (1) would have left the next producer of an unrooted root just as silent.

Note what this does **not** change: a genuinely corrupt sidecar still reports a
`[provision-gap]` and still degrades. That is #2750's deliberate, tested behaviour, its
remediation advice is correct for that cause, and inverting it is a different question from
this one.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site?** All 13 `CacheRoots.Resolve` consumers were
   checked. None roots its own result and none needed to — rooting the single root fixes all of
   them at once. The one path-vs-path *comparison*, `DependencyResolver.FromSource`, already
   roots both sides.
2. **Does a sibling function make the same assumption?** Yes, and it did. `DisableForRun` is the
   other writer of `_override`: its mint branch is absolute by construction
   (`Path.GetTempPath()`), but its **adopt** branch reads `AL_RUNNER_NO_CACHE_ROOT` straight out
   of the environment, which nothing validates. That branch now roots what it adopts, and
   republishes the rooted form so a re-exec'd child inherits an absolute path instead of
   re-resolving the same relative string against its own working directory — otherwise the
   one-throwaway-root-per-RUN guarantee that branch exists to provide quietly becomes two.
3. **Two writers, one invariant?** That is exactly what (2) was. Both writers of `_override` now
   maintain "absolute or null", and `Resolve` states it where it is consumed.

Nothing was left out and filed for later.

## Persisted-key blast radius: none

Checked, because a stored form changing from relative to absolute matters if anything hashes or
compares it. Nothing does:

* `ComputeAlCacheKey` (`ProgramSupport/Dependencies.cs`) hashes source paths **relative to the
  common source root**, explicitly so the key is invariant to where the run was invoked from.
  The cache directory is not an input.
* `r2r-chunks` keys on the package's content hash (`sha256-<hash>`); `ncl-cecil` on the Ncl
  bytes plus the runner content hash; `app-manifests`, `bc-symbols` and `install-baseline`
  likewise on content. No cache resolved through `CacheRoots` hashes its own root.
* No on-disk manifest or index records the root as a string.

So no existing entry is invalidated and no key shape needed a version bump. And for an
unchanged working directory `GetFullPath` names the *same physical directory* the relative form
already resolved to, so entries an earlier run wrote under a relative `--cache` remain
reachable — confirmed on disk below.

## RED → GREEN

**RED, end to end:** the differential above, measured on this worktree before any change.

**RED, unit.** New `AlRunner.Tests/RelativeCacheRootTests.cs`. Verified by committing the fix,
then `git checkout origin/main -- AlRunner/Infrastructure/CacheRoots.cs AlRunner/Program.cs`
(no `git stash` — shared across worktrees) and re-running: **5 of 7 failed**, and the two that
passed are the controls, which is the point of having them. The decisive failure:

```
chunk path must be absolute: ../../../../../../../../../../../../../tmp/al-runner-relative-cache-root/<guid>/r2r-chunks/sha256-35a45a…/000.dll
```

**GREEN, unit:** 7/7, `Skipped: 0`. Filtered runs after the rebase:
`RelativeCacheRootTests|CacheRoots|CorruptSidecar|R2rChunk` → **37 passed, 0 failed, 0 skipped**.

**GREEN, end to end — cold and warm**, since this is a cache-sensitive change:

| run | wall | result | gaps |
|---|---|---|---|
| cold, `--cache .measure/relcache2` | 54s | exit 0, 3 pass / 0 fail | 0 |
| warm, same relative `--cache` | 7s | exit 0, 3 pass / 0 fail | 0 |

The 54s → 7s drop is the caches actually HITting under the rooted path, and the directory they
HIT in is `<cwd>/.measure/relcache2/{r2r-chunks,ncl-cecil,bc-symbols,…}` — the same physical
location the relative form resolved to, which is the "existing entries stay reachable" claim
observed rather than argued. Re-measured again after the rebase: exit 0, 3/3, 0 gaps.

The tests assert specific values, not "something threw": the exact resolved path, that
`..` segments are normalized away and not merely concatenated, and — the load-bearing one —
that `LoadFromAssemblyPath` rejects the produced chunk for what it **contains**
(`BadImageFormatException`) and never for where it **lives** (`ArgumentException`, "is not an
absolute path"), which was its only complaint pre-fix. Two controls keep the guard honest: an
already-absolute override must be unchanged by the rooting, and the guard must not fire on a
rooted root.

The `Resolve` guard is reached through an internal seam
(`SetOverrideBypassingRootingForTests`), because both production writers now root what they
store and the guard is otherwise unreachable by construction. Same shape and the same reason as
`AppLoader.ExtractAllDllPathsCore`'s internal content-hash-provider overload. A guard nobody can
run is a guard nobody knows still works.

## Corpus question: nothing owed upstream, and I checked whether that was too convenient

No. Path resolution and assembly loading are runner infrastructure, and the corpus has no way to
express the claim: an al-language test cannot pass `--cache`, cannot observe the runner's cache
root, and would be asserting something about a CLI flag that does not exist on a BC service
tier. `tests/runner-extras/` cannot carry it either, for the same reason one layer down — AL
cannot see the cache path, and the runner-extras CI step passes no `--cache` at all, which is
precisely why CI never saw this.

The consequence *is* AL-observable — AL sees a world without Base Application — but that is a
runner **misconfiguration** consequence, not a statement about what BC does, and nothing here
proposes any change to BC-observable behaviour. This is the "genuinely inexpressible" case, and
what carries it is the mechanism rather than a sibling measurement: the claim rests on the
corpus's own interface (no `--cache`, no cache-root visibility), not on an inference from
something a service tier answered nearby.

I did consider a CI-level guard — a second `dotnet run` over
`tests/runner-extras/microsoft-test-library` with a relative `--cache`, matching the existing
xmlport-isolation and `--isolation`-disabled steps. Rejected: that suite is `absentOn` BC
27.0/27.3/27.5 (Application Test Library ships from 28.0), so it needs per-version gating in
YAML, and the C# tests above bind the same mechanism in **13 ms** with no BC artifacts, versus
eight legs of real runner time.

## Docs

`--help` now says a relative `--cache` is rooted once at parse time and why. `README.md`,
`docs/limitations.md` and `docs/scope.md` need nothing — no surface gained or lost, and the
flag's contract is unchanged for every value anyone was already passing.

## Not from my change

* `ProvisionExplicitModesTests` (2 tests) fail here on artifact-CDN egress — this box cannot
  reach `bcartifacts-…azurefd.net`.
* `BcCompilerEmitRetryTests` skips with `BC engine bootstrap failed: TargetInvocationException`.
  Checked rather than assumed: reverting both production files to `origin/main` and re-running
  produced the **identical** skip reason, so it is pre-existing and environment-shaped, not
  #3078's content-hash invalidation. Every other local run in this PR reports `Skipped: 0`.
* One `NoCacheLastWinsIntegrationTests.NoCacheAlone_DoesNotLeakItsThrowawayTempDirectory`
  failure in a batch that did **not** include any new test of mine; it passed alone and passed
  on an identical re-run of the same batch.

---

*Implemented by Claude Code agent `stma-auto-1`, acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
