### PR TITLE
fix(log): stop the [Component] filter eating every "Loud, never silent" diagnosis

### DIFF
--- a/AlRunner.Tests/LoudDiagnosisReachesTheUserTests.cs
+++ b/AlRunner.Tests/LoudDiagnosisReachesTheUserTests.cs
@@ -1,0 +1,242 @@
+// LoudDiagnosisReachesTheUserTests — issue #3068.
+//
+// What went wrong
+// ---------------
+// Log.Install() drops any line starting with a `[Tag]` unless --verbose. That filter exists
+// for a real reason and this file does NOT weaken it: measured on one healthy, fully-passing
+// run of tests/runner-extras/precompiled-table-relation, it suppresses 843 lines —
+// 379 [RecordPatches], 371 [Cecil], 65 [Subscribers], 15 [BcRuntime], and a tail of others.
+// That volume is exactly what the filter is for.
+//
+// But a handful of call sites are not chatter. They fire ONLY when a foundational row or
+// initialisation step did not happen, and each one says, in its own words, that downstream AL
+// will now fail because of it. Their absence does not make the run quieter — it turns a
+// cascade of "<Setup Table> does not exist" failures into a mystery and points the reader at
+// missing test data instead. #3068 measured the cost: on BC 27.3 codeunit 2
+// "Company-Initialize" aborted on every run and the runner said nothing at default verbosity;
+// an agent spent a long stretch believing the code path never ran.
+//
+// The tell was already in the source. Three call sites carry the comment "Loud, never silent"
+// — CompanyInitializer, RecordPatches.CompanySystemTable, RecordPatches.UserSystemTable — and
+// at the time this file was written ALL THREE were silenced by this filter, three lines below
+// a Log.cs comment that says a severity tag is never an internal diagnostic. The author's
+// stated intent and the observed behaviour were opposites in every instance.
+//
+// How it is fixed, and why not by editing Log.cs
+// ----------------------------------------------
+// Not by adding [CompanyInitializer] & co. to Log's exemption list. Two established decisions
+// point the other way:
+//
+//   * #2750 refused to exempt `[deps]` to surface one corrupt-sidecar message, because that
+//     would have surfaced all of DependencyLoader's tier-by-tier internals with it. It
+//     re-tagged the one important line instead. LogUserFacingTagsTests pins `[deps]` as
+//     deliberately suppressed, and this file does not disturb that.
+//   * #2210/#2221/#2239 (CleanRunStartupVerbosityTests) established that hiding a line by
+//     editing Log's allowlist is the wrong lever in the other direction too, and moved every
+//     line behind an explicit `if (Log.Verbose)` at its own call site.
+//
+// Both say the same thing: the visibility decision belongs at the call site, not in a regex.
+// So each of these lines now uses the already-exempt `[warn]` severity tag, in the
+// `[warn] <Component>: <message>` shape ProvisioningCheck and BcAppFallback already use.
+// Log.cs's own comment is the rule being applied: "A severity tag is never an internal
+// diagnostic — if something is worth calling a warning, it is worth the user seeing it."
+//
+// Why this test reads the production source
+// -----------------------------------------
+// Asserting a string literal typed into this file would prove nothing: it would stay green
+// with the production call site still tagged [CompanyInitializer]. So each case below names
+// a source file and an anchor phrase, pulls THE REAL message out of that call site, and runs
+// THAT through the real filter. Re-tag the production line back and this test goes red.
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Serial: swaps the process-wide Console writers and Log.Verbose. See ConsoleFilterSerialCollection.
+[Collection(ConsoleFilterSerialCollection.Name)]
+public sealed class LoudDiagnosisReachesTheUserTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    /// <summary>Push one line through the real Log filter and return what got out.</summary>
+    private static string FilterOnce(string line, bool verbose)
+    {
+        var savedOut = Console.Out;
+        var savedErr = Console.Error;
+        var savedVerbose = Log.Verbose;
+        var sink = new StringWriter();
+        try
+        {
+            Console.SetOut(sink);
+            Console.SetError(sink);
+            Log.Install();
+            Log.Verbose = verbose;
+            Console.Error.WriteLine(line);
+            return sink.ToString();
+        }
+        finally
+        {
+            Log.Verbose = savedVerbose;
+            Console.SetOut(savedOut);
+            Console.SetError(savedErr);
+        }
+    }
+
+    /// <summary>
+    /// Reconstruct the message a `Console.Error.WriteLine(...)` call site actually emits:
+    /// find the anchor phrase, walk back to the enclosing Console.Error.WriteLine, then
+    /// concatenate every string literal in that statement and substitute a placeholder for
+    /// each interpolation hole. The result is a realistic rendering of the real line — good
+    /// enough to be exact about the prefix the filter decides on, and about the body.
+    /// </summary>
+    private static string ExtractEmittedMessage(string relativePath, string anchor)
+    {
+        var path = Path.Combine(RepoRoot, relativePath);
+        Assert.True(File.Exists(path), $"diagnosis call site source not found: {path}");
+        var lines = File.ReadAllLines(path);
+
+        // The anchor phrase usually also appears in the comment block above the call site, so
+        // take the first occurrence that actually resolves to a Console.Error.WriteLine — not
+        // simply the first occurrence in the file.
+        var anchorHits = Enumerable.Range(0, lines.Length)
+            .Where(i => lines[i].Contains(anchor, StringComparison.Ordinal))
+            .ToList();
+        Assert.True(anchorHits.Count > 0,
+            $"anchor phrase not found in {relativePath}: \"{anchor}\". If the message was " +
+            "reworded, update the anchor — do not delete the case.");
+
+        var start = -1;
+        foreach (var hit in anchorHits)
+        {
+            for (var i = hit; i >= 0 && i >= hit - 10; i--)
+            {
+                var text = lines[i];
+                if (text.TrimStart().StartsWith("//", StringComparison.Ordinal)) continue;
+                if (text.Contains("Console.Error.WriteLine(", StringComparison.Ordinal)) { start = i; break; }
+            }
+            if (start >= 0) break;
+        }
+        Assert.True(start >= 0,
+            $"the anchor \"{anchor}\" in {relativePath} is no longer inside a " +
+            "Console.Error.WriteLine(...) call — the diagnosis may have been deleted or " +
+            "routed somewhere this test cannot see.");
+
+        // Collect the statement text up to the balanced closing paren.
+        var stmt = new StringBuilder();
+        var depth = 0;
+        var opened = false;
+        for (var i = start; i < lines.Length && i < start + 12; i++)
+        {
+            stmt.Append(lines[i]).Append('\n');
+            foreach (var ch in lines[i])
+            {
+                if (ch == '(') { depth++; opened = true; }
+                else if (ch == ')') depth--;
+            }
+            if (opened && depth <= 0) break;
+        }
+
+        // Concatenate the string literals, unescape, and stand a token in for each hole.
+        var literals = Regex.Matches(stmt.ToString(), "\"((?:[^\"\\\\]|\\\\.)*)\"");
+        Assert.True(literals.Count > 0, $"no string literal in the statement at {relativePath}:{start + 1}");
+        var message = string.Concat(literals.Select(m => m.Groups[1].Value))
+            .Replace("\\\"", "\"")
+            .Replace("\\n", " ");
+        message = Regex.Replace(message, @"\{[^{}]*\}", "<value>");
+        return message;
+    }
+
+    public static TheoryData<string, string> DiagnosisCallSites() => new()
+    {
+        // #3068 — the reported one. Codeunit 2 "Company-Initialize" aborted part-way, so every
+        // setup table it had not reached yet is missing; without this line the reader sees only
+        // the downstream "does not exist" failures and a [test-data] hint suggesting the wrong
+        // remedy.
+        { "AlRunner/CompanyInitializer.cs", "did not complete" },
+
+        // #2329 — all three branches of the Company-row seed. Comment at the site:
+        // "Loud, never silent: without this row Company.Get(CompanyName()) fails for a company
+        // every other surface reports as existing, and the failure surfaces several layers up
+        // inside Base App code where it reads as a corpus bug."
+        { "AlRunner/Patches/RecordPatches.CompanySystemTable.cs", "has no DataAccessSource yet, so the" },
+        { "AlRunner/Patches/RecordPatches.CompanySystemTable.cs", "exposes no company name" },
+        { "AlRunner/Patches/RecordPatches.CompanySystemTable.cs", "could not seed the Company row" },
+
+        // #2296 — all three branches of the User-row seed. Same shape, same comment: the
+        // failure surfaces layers up inside Microsoft AL where it reads as an application bug.
+        { "AlRunner/Patches/RecordPatches.UserSystemTable.cs", "there is no skeleton session, so the User row" },
+        { "AlRunner/Patches/RecordPatches.UserSystemTable.cs", "exposes no user identity" },
+        { "AlRunner/Patches/RecordPatches.UserSystemTable.cs", "was REFUSED and is NOT present" },
+
+        // #2963, and named in #3068 as the same class: System Application module-ownership
+        // checks silently decline for the whole run when this row set is not seeded.
+        { "AlRunner/Patches/RecordPatches.PublishedApplicationSystemTable.cs", "Published Application rows" },
+    };
+
+    /// <summary>
+    /// Each of these fires only when something foundational did not happen, and says the run's
+    /// AL will now fail because of it. It has to survive the DEFAULT filter — reaching the
+    /// user only under --verbose is the defect, not the fix.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(DiagnosisCallSites))]
+    public void RunFatalDiagnosis_SurvivesTheDefaultFilter(string relativePath, string anchor)
+    {
+        var message = ExtractEmittedMessage(relativePath, anchor);
+        var got = FilterOnce(message, verbose: false);
+        Assert.Contains(message, got);
+    }
+
+    /// <summary>
+    /// The same messages under --verbose, so the fix cannot be read as "it was visible anyway".
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(DiagnosisCallSites))]
+    public void RunFatalDiagnosis_AlsoSurvivesVerbose(string relativePath, string anchor)
+    {
+        var message = ExtractEmittedMessage(relativePath, anchor);
+        Assert.Contains(message, FilterOnce(message, verbose: true));
+    }
+
+    /// <summary>
+    /// Every case above names the concrete consequence for the run. A diagnosis that only says
+    /// something failed, without saying what stops working, is the version that got ignored.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(DiagnosisCallSites))]
+    public void RunFatalDiagnosis_NamesTheConsequence(string relativePath, string anchor)
+    {
+        var message = ExtractEmittedMessage(relativePath, anchor);
+        Assert.True(
+            message.Contains("will fail", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("will refuse", StringComparison.OrdinalIgnoreCase)
+            || message.Contains("will decline", StringComparison.OrdinalIgnoreCase),
+            $"{relativePath} (\"{anchor}\") no longer tells the reader what stops working: {message}");
+    }
+
+    /// <summary>
+    /// NEGATIVE CONTROL — the filter still does its job. These are the tags measured on one
+    /// healthy passing run of tests/runner-extras/precompiled-table-relation (843 suppressed
+    /// lines in total). If promoting the diagnoses above had been done by widening Log's
+    /// exemption list instead, this is what would have come with them.
+    /// </summary>
+    [Theory]
+    [InlineData("[RecordPatches] BuildNCLMetaTable(18) failed: NullReferenceException: x")]       // 379 lines
+    [InlineData("[Cecil] rewriting NavDialog")]                                                   // 371 lines
+    [InlineData("[Subscribers] inject: injected=12 failed=0 skipped-no-publisher=3 keys=41")]     //  65 lines
+    [InlineData("[BcRuntime] applying patch")]                                                    //  15 lines
+    [InlineData("[Dispatch] codeunit 130 method Run")]                                            //   3 lines
+    // #2750 decided `deps` stays suppressed and re-tagged the one line that mattered. Measured
+    // here: `[deps] tier-2 R2R: Base Application loaded 5 DLL chunk(s)` prints on a HEALTHY,
+    // fully-passing run — five chunks is Base Application's normal shape, not a fault — so it
+    // is information, not a diagnosis, and it stays where #2750 put it.
+    [InlineData("[deps] tier-2 R2R: Base Application loaded 5 DLL chunk(s)")]
+    [InlineData("[deps] source-cache HIT: Sidecar Dep v1.0.0.0 key=0123456789ab")]
+    public void InternalChatter_IsStillSuppressedByDefault(string line)
+    {
+        Assert.DoesNotContain(line, FilterOnce(line, verbose: false));
+        Assert.Contains(line, FilterOnce(line, verbose: true));
+    }
+}

--- a/AlRunner/CompanyInitializer.cs
+++ b/AlRunner/CompanyInitializer.cs
@@ -58,11 +58,20 @@ internal static class CompanyInitializer
         }
         catch (Exception ex)
         {
+            // #3068: tagged `[warn]`, NOT `[CompanyInitializer]`. Log.cs drops any line starting
+            // with a `[Component]` tag at default verbosity, so for as long as this said
+            // `[CompanyInitializer]` the comment below was false — the line only reached the
+            // user under --verbose. Measured on BC 27.3: company initialisation aborted on every
+            // run and the runner said nothing, so the reader saw only the downstream
+            // "<Setup Table> does not exist" failures and a `[test-data]` hint pointing at the
+            // wrong remedy. `[warn]` is exempt from that filter by design (Log.cs: "a severity
+            // tag is never an internal diagnostic"), and the exemption list does not have to
+            // grow a component at a time. Do not re-tag this with a component name.
             // Loud, never silent — see the KNOWN INCOMPLETE note above. Not fatal: the rows it
             // did insert stay, and a bundle that never reads the rest still runs correctly.
             var inner = ex is TargetInvocationException tie && tie.InnerException != null ? tie.InnerException : ex;
             Console.Error.WriteLine(
-                $"[CompanyInitializer] codeunit 2 \"Company-Initialize\" did not complete: " +
+                $"[warn] CompanyInitializer: codeunit 2 \"Company-Initialize\" did not complete: " +
                 $"{inner.GetType().Name}: {inner.Message} — the company is PARTIALLY initialized; " +
                 $"setup tables it had not reached yet are missing, and AL that reads them will fail.");
         }

--- a/AlRunner/Log.cs
+++ b/AlRunner/Log.cs
@@ -66,6 +66,13 @@ public static class Log
     //     `[test-data]`, `[provision-gap]`, `[count-baseline]`, `[dep-load-fail]`, … — fails
     //     the pattern and passes through whether or not anyone intended it. That is
     //     load-bearing and pinned by LogUserFacingTagsTests; do not "tidy" the class.
+    //     It is ALSO accidental for most of them: punctuation, not intent, decides. #2257
+    //     owns that — it tracks the whole set and the per-tag decision each one needs, and
+    //     it is where the count lives, so this comment does not carry a number that would
+    //     rot here. Re-measured 2026-09-06 for that issue: 30 distinct hyphenated tags
+    //     across 83 console-output call sites, several plainly internal (`[type-index]`,
+    //     `[emit-timing]`, `[mem-census]`, `[instrumentation-counters]`, `[DIAG-RETRY]`).
+    //     Retagging that set is #2257's job, deliberately not this change's.
     //   * only the START of the value is examined, so a multi-line WriteLine is decided
     //     entirely by its first line.
     //

--- a/AlRunner/Log.cs
+++ b/AlRunner/Log.cs
@@ -56,6 +56,36 @@ public static class Log
     // `[expectations]`, `[reexec]` and `[dap]` notes above each describe. A severity tag is
     // never an internal diagnostic — if something is worth calling a warning, it is worth
     // the user seeing it.
+    //
+    // #3068 — READ THIS BEFORE ADDING A COMPONENT NAME TO THE LIST BELOW. The list is an
+    // EXACT, whole-tag, case-sensitive match: the lookahead requires `]` right after the
+    // word, so `[dep]` is exempt and `[deps]` is a different tag that is not (deliberately —
+    // see #2750). Two further properties of the pattern are easy to misread:
+    //
+    //   * the tag character class `[A-Za-z0-9._+]` has NO HYPHEN, so every hyphenated tag —
+    //     `[test-data]`, `[provision-gap]`, `[count-baseline]`, `[dep-load-fail]`, … — fails
+    //     the pattern and passes through whether or not anyone intended it. That is
+    //     load-bearing and pinned by LogUserFacingTagsTests; do not "tidy" the class.
+    //   * only the START of the value is examined, so a multi-line WriteLine is decided
+    //     entirely by its first line.
+    //
+    // The right lever for a line that must be seen is its TAG AT THE CALL SITE, not this
+    // list. #2750 established that going the other way (exempting `[deps]` to surface one
+    // corrupt-sidecar message) would have surfaced all of DependencyLoader's internals with
+    // it, and re-tagged the one line instead; #2210/#2221/#2239 established the mirror image
+    // for hiding a line, moving each behind an explicit `if (Log.Verbose)` at its own call
+    // site rather than touching this regex.
+    //
+    // Measured for #3068 on one healthy, fully-passing run of
+    // tests/runner-extras/precompiled-table-relation: this filter suppressed 843 lines —
+    // 379 `[RecordPatches]`, 371 `[Cecil]`, 65 `[Subscribers]`, 15 `[BcRuntime]`, plus a
+    // tail. That volume is the whole justification for the filter and must stay suppressed.
+    // In the same sweep, all three call sites in the codebase whose comment reads "Loud,
+    // never silent" — CompanyInitializer, RecordPatches.CompanySystemTable,
+    // RecordPatches.UserSystemTable — turned out to be silenced by this filter, along with
+    // `[PublishedApplication]`. They now use `[warn] <Component>: <message>`, the shape
+    // ProvisioningCheck and BcAppFallback already use, and LoudDiagnosisReachesTheUserTests
+    // reads those real call sites and pushes their real messages through this filter.
     private static readonly Regex ComponentTag =
         new(@"^\[(?!(?:layered|watch|provision|bc|dep|expectations|reexec|dap|warn)\])[A-Za-z][A-Za-z0-9._+]*\]",
             RegexOptions.Compiled);

--- a/AlRunner/Patches/RecordPatches.CompanySystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.CompanySystemTable.cs
@@ -73,11 +73,14 @@ public static partial class RecordPatches
         var source = ResolveSkeletonDataAccessSource();
         if (source == null)
         {
+            // #3068: `[warn]`, not `[CompanySystemTable]` — Log.cs suppresses component tags at
+            // default verbosity, which made "loud, never silent" untrue here for as long as this
+            // carried one. Same for the two sibling branches below.
             // Loud, never silent: without this row Company.Get(CompanyName()) fails for a
             // company every other surface reports as existing, and the failure surfaces
             // several layers up inside Base App code where it reads as a corpus bug.
             Console.Error.WriteLine(
-                "[CompanySystemTable] the skeleton session has no DataAccessSource yet, so the "
+                "[warn] CompanySystemTable: the skeleton session has no DataAccessSource yet, so the "
                 + "Company row (2000000006) was not seeded — Company.Get(CompanyName()) will fail. "
                 + "See AlRunner#2329.");
             return;
@@ -87,7 +90,7 @@ public static partial class RecordPatches
         if (companyName == null)
         {
             Console.Error.WriteLine(
-                "[CompanySystemTable] the skeleton NavCompany exposes no company name, so the "
+                "[warn] CompanySystemTable: the skeleton NavCompany exposes no company name, so the "
                 + "Company row (2000000006) was not seeded — Company.Get(CompanyName()) will fail. "
                 + "See AlRunner#2329.");
             return;
@@ -104,7 +107,7 @@ public static partial class RecordPatches
             if (inner.GetType().Name == "NavRecordAlreadyExistsException")
                 return; // already present — nothing to do, and not a failure.
             Console.Error.WriteLine(
-                $"[CompanySystemTable] could not seed the Company row (2000000006): "
+                $"[warn] CompanySystemTable: could not seed the Company row (2000000006): "
                 + $"{inner.GetType().Name}: {inner.Message} — Company.Get(CompanyName()) will fail. "
                 + "See AlRunner#2329.");
         }

--- a/AlRunner/Patches/RecordPatches.PublishedApplicationSystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.PublishedApplicationSystemTable.cs
@@ -158,8 +158,11 @@ public static partial class RecordPatches
         var source = ResolveSkeletonDataAccessSource();
         if (source == null)
         {
+            // #3068: `[warn]`, not `[PublishedApplication]` — Log.cs drops component-tagged lines
+            // at default verbosity, so this explanation for a whole run's worth of declined
+            // module-ownership checks was reaching nobody unless --verbose was set.
             Console.Error.WriteLine(
-                "[PublishedApplication] the skeleton session has no DataAccessSource yet, so no "
+                "[warn] PublishedApplication: the skeleton session has no DataAccessSource yet, so no "
                 + "Published Application rows (2000000206) were seeded — System Application "
                 + "module-ownership checks will decline. See AlRunner#2963.");
             return;

--- a/AlRunner/Patches/RecordPatches.UserSystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.UserSystemTable.cs
@@ -206,11 +206,14 @@ public static partial class RecordPatches
         var session = AlRunner.BcRuntime.SkeletonSession;
         if (session == null)
         {
+            // #3068: `[warn]`, not `[UserSystemTable]` — Log.cs suppresses component tags at
+            // default verbosity, which made "loud, never silent" untrue here for as long as this
+            // carried one. Same for the two sibling branches below.
             // Loud, never silent: without this row every Validate of a field relating to
             // User."User Security ID" refuses the id the runner itself reports, and the failure
             // surfaces layers up inside Microsoft AL where it reads as an application bug.
             Console.Error.WriteLine(
-                "[UserSystemTable] there is no skeleton session, so the User row (2000000120) was "
+                "[warn] UserSystemTable: there is no skeleton session, so the User row (2000000120) was "
                 + "not seeded — every TableRelation to User.\"User Security ID\" will refuse "
                 + "UserSecurityId(). See AlRunner#2296.");
             return UserRowSeedOutcome.NoSessionIdentity;
@@ -220,7 +223,7 @@ public static partial class RecordPatches
         if (userSid == null || userName == null)
         {
             Console.Error.WriteLine(
-                "[UserSystemTable] the skeleton session exposes no user identity "
+                "[warn] UserSystemTable: the skeleton session exposes no user identity "
                 + $"(name={userName ?? "<null>"}, sid={(userSid == null ? "<null>" : "set")}), so the "
                 + "User row (2000000120) was not seeded — every TableRelation to "
                 + "User.\"User Security ID\" will refuse UserSecurityId(). See AlRunner#2296.");
@@ -298,7 +301,7 @@ public static partial class RecordPatches
                 // _userRowSeededForThisBundle is deliberately NOT set: no row was seeded, and a
                 // flag claiming otherwise is the defect this branch exists to remove.
                 Console.Error.WriteLine(
-                    $"[UserSystemTable] the User row (2000000120) for the session user "
+                    $"[warn] UserSystemTable: the User row (2000000120) for the session user "
                     + $"'{userName}' ({userSid}) was REFUSED and is NOT present — {refusalDetail}. "
                     + "Every TableRelation to User.\"User Security ID\" will refuse the id "
                     + "UserSecurityId() itself returns, and Microsoft AL guarded by "


### PR DESCRIPTION
Closes #3068

## What the exemption rule actually is

`Log.cs` drops a line when this matches its **start**:

```
^\[(?!(?:layered|watch|provision|bc|dep|expectations|reexec|dap|warn)\])[A-Za-z][A-Za-z0-9._+]*\]
```

So: **exact, whole-tag, case-sensitive** match against a nine-word allowlist. Three properties are easy to misread, and all three have bitten:

1. The lookahead requires `]` immediately after the word, so `[dep]` is exempt and `[deps]` is simply a **different tag**, not a prefix miss. That is deliberate — see below.
2. **The tag character class has no hyphen.** Every hyphenated tag fails the pattern entirely and passes through whether or not anyone chose that: `[test-data]`, `[provision-gap]`, `[count-baseline]`, `[dep-load-fail]`, `[option-captions]`, `[page-metadata]` and ~25 more. `LogUserFacingTagsTests` already pins this as load-bearing.
3. Only the start of the value is examined, so a multi-line `WriteLine` is decided entirely by its first line.

## What the list was protecting

The filter arrives in `de1cf363` ("output cleanup — quiet diagnostic spam"), whose message records the measurement: a bucket run went from a **1095-line internal-state dump** to a focused report, with `--verbose` still surfacing all **3304** diagnostic lines.

Re-measured today on one healthy, fully-passing run of `tests/runner-extras/precompiled-table-relation`, the filter suppressed **843 lines**: 379 `[RecordPatches]`, 371 `[Cecil]`, 65 `[Subscribers]`, 15 `[BcRuntime]`, 3 `[deps]`, 3 `[Dispatch]`, and a tail. That volume is real and the filter keeps earning its keep. **Nothing here widens it.**

## Inventory: what the rule silently eats

Across `AlRunner/`, 78 distinct tags are suppressed and 45 pass through. Filtering the suppressed set to lines carrying failure language gives **171 call sites**. Nearly all are genuine chatter — recovery traces of the form "hook not found; skipping", "ctor failed; falling back to a skeleton". Those stay suppressed.

A small set is a different thing: lines that fire **only** when a foundational row or initialization step did not happen, and that name what stops working for the rest of the run. The tell was already in the source — grep for the comment `Loud, never silent`:

| call site | comment says | was |
|---|---|---|
| `CompanyInitializer.cs` | "Loud, never silent" | **suppressed** |
| `RecordPatches.CompanySystemTable.cs` | "Loud, never silent" | **suppressed** |
| `RecordPatches.UserSystemTable.cs` | "Loud, never silent" | **suppressed** |

Three of three. Plus `[PublishedApplication]`, named in the issue as the same class. Eight `Console.Error` call sites once each file's sibling branches are included — the sibling question mattered here: `CompanySystemTable` and `UserSystemTable` each have three early-return branches with the identical defect, and the issue only named one file.

Measured: **none of these four tags emits a single line on a healthy run**, so promoting them adds nothing to a clean run. Confirmed after the change — the same run still prints 32 lines and zero `[warn]`.

## The fix, and why not in `Log.cs`

Re-tagged at the call sites to `[warn] <Component>: <message>`, the shape `ProvisioningCheck` and `BcAppFallback` already use. The regex is unchanged.

Editing the allowlist was the wrong lever in **both** directions before:

- **#2750** refused to exempt `[deps]` in order to surface one corrupt-sidecar message, because all of `DependencyLoader`'s tier-by-tier internals would have come with it; it re-tagged that one line instead.
- **#2210/#2221/#2239** (`CleanRunStartupVerbosityTests`) established the mirror image for *hiding* a line, moving each behind an explicit `if (Log.Verbose)` at its own call site — "hiding a line by editing Log's allowlist either does nothing or, worse, makes the line invisible even under `--verbose`".

Both say the visibility decision belongs at the call site. `Log.cs` gains a comment recording the rule, the hyphen property, and the 843-line measurement, so the next reader does not rediscover it.

## Deliberate negative result: `[deps] tier-2 R2R` stays suppressed

The brief asked me to fix this one too, on the grounds that it would have revealed Base Application arriving as five chunks in #3054. I measured it and concluded otherwise:

```
[deps] tier-2 R2R: Base Application loaded 5 DLL chunk(s)
```

fires on a **healthy, fully-passing, exit-0 run**. Five chunks is Base Application's normal shape, not a fault — the defect in #3054 was that only the first chunk was returned, not the count. Promoting it would print it on essentially every run that loads Base App, which is chatter, and #2750 already adjudicated the `deps` namespace with a pinned negative test. Inverting that silently would have been the wrong call. It is pinned as still-suppressed here, with the measurement in the comment.

## RED → GREEN

`AlRunner.Tests/LoudDiagnosisReachesTheUserTests.cs` does not assert string literals typed into the test — that would stay green with production still tagged `[CompanyInitializer]`. It names a source file and an anchor phrase, pulls **the real message out of the real call site**, and pushes it through **the real filter**.

- **RED** (before): `Failed: 8, Passed: 23, Skipped: 0`. All 8 diagnosis sites produced **empty output** — e.g. `Not found: "[CompanyInitializer] codeunit 2 "Company-"···` against `String: ""`.
- **GREEN** (after): `Passed: 31, Skipped: 0`.

Both directions are asserted with concrete strings:

- positive — each real message survives the **default** filter, and also `--verbose`;
- each message still names its consequence (`will fail` / `will refuse` / `will decline`), so it cannot be weakened into "something failed";
- negative control — the measured chatter stays suppressed at default and appears under verbose: `[RecordPatches]` (379 lines/run), `[Cecil]` (371), `[Subscribers]` (65), `[BcRuntime]` (15), `[Dispatch]`, and both `[deps]` cases.

Also run, all green with `Skipped: 0`: `LogUserFacingTagsTests`, `CleanRunStartupVerbosityTests`, `CorruptSidecarLoudnessTests`, `FlowFieldDiagnosticNoiseTests`, `ParallelFanOutVisibilityTests`, `StartupOutputReexecDedupTests`, `ProvisionGapLogTests`.

## The corpus question

**Nothing goes upstream.** The claim is "a line the runner writes to stderr reaches the user at default verbosity" — a statement about `Log.cs`, with no assertion about what BC does. If AL Runner did not exist the test would be meaningless, which is the `bc-behavior-tests-go-upstream.md` test.

I did consider a `tests/runner-extras/` AL test, since provisioning-gap messages and out-of-scope reasons are runner-only claims that *are* red-testable in AL. It does not work here: an AL bundle cannot make codeunit 2 `Company-Initialize` abort, or strip the skeleton session's `DataAccessSource`, on demand — those are runner-internal failure states with no AL-reachable trigger. A `runner-extras` bundle could only assert the absence of these lines on a healthy run, which is what already happens and proves nothing. The source-derived C# test is strictly stronger: it binds to the actual production call sites.

## What I deliberately left out

- **The end-to-end reproduction on BC 27.3.** The issue's reproducer needs a 27.3-provisioned `platform-apps` cache; running `--bc-version 27.3` against the 28.1 cache on this box fails to compile (exit 3) before company initialization is ever reached. #3068 already measured the symptom on 27.3, and the RED→GREEN above binds to the same call site.
- **The other 163 suppressed failure-language lines.** They are recovery traces on paths that carry on working, which is what the filter is for.
- **`[server] … AL-DIAGNOSTIC-FAIL`** (`Program.cs`). It is suppressed, but server mode already returns the same diagnostics to the client through `compilationErrors` with exit code 3, so the information is not lost. Left alone rather than changed on a guess.
- **The missing hyphen in the tag character class.** Adding it would honestly classify the currently-visible hyphenated tags, but would also suppress user-facing ones such as `[test-data]` and `[provision-gap]`; `LogUserFacingTagsTests` explicitly pins that behavior as load-bearing. Documented in `Log.cs` instead of changed — and, after review, given an owner rather than a number in prose: **#2257** already tracks that exact set and the per-tag decision each one needs, and `d72ee676` points the comment at it. Re-measured for that issue on 2026-09-06 by scanning `AlRunner/**/*.cs` for string literals opening with a hyphenated `[tag]` and testing each against the real regex: **30 distinct tags across 83 console-output call sites** (32 distinct / 99 sites if literals not matched to an output call within two lines are counted too). Several are plainly internal — `[type-index]`, `[emit-timing]`, `[mem-census]`, `[instrumentation-counters]`, `[DIAG-RETRY]`. A ~30-site retagging is #2257's job, not this PR's.

---
Implemented by agent `stma-auto-1` acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
