### PR TITLE
fix(ci): read the collection-weight gate against the leg's own clock, and fail only above 2.5x

### DIFF
--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -523,19 +523,33 @@ jobs:
       # genuinely missing from the table is loud CI failure, per
       # .claude/rules/loud-failures.md, not another quiet report.
       #
-      # #3103: it fails only above 3x UnmeasuredWeightSeconds, and reports the 2x..3x band as
-      # a ::warning:: annotation instead. This leg rolls up into the aggregate required check
-      # that main's ruleset gates on — the job named in test-matrix.yml, deliberately not
-      # spelled out here, because ReleaseTestParityTests asserts that exact name appears in
-      # no workflow but that one and cannot tell a comment from the real thing. The old
-      # single line at 2x was summed wall clock on a shared runner — the same untouched
-      # collection landed at 59.4s on one PR's run and 63.7s on another's, so an unrelated PR
-      # went red. Both bands are also scaled by how slow this leg measured against the weight
-      # table's own entries. See the script's header.
+      # #3103: it fails only above --fail-threshold and reports the band between the
+      # advisory line (2x UnmeasuredWeightSeconds) and that one as a ::warning:: annotation
+      # instead. This leg rolls up into the aggregate required check that main's ruleset
+      # gates on — the job named in test-matrix.yml, deliberately not spelled out here,
+      # because ReleaseTestParityTests asserts that exact name appears in no workflow but
+      # that one and cannot tell a comment from the real thing. The old single line at 2x
+      # was summed wall clock on a shared runner — the same untouched collection landed at
+      # 59.4s on one PR's run and 63.7s on another's, so an unrelated PR went red. Both
+      # bands are also scaled by how slow this leg measured against the weight table's own
+      # entries. See the script's header.
+      #
+      # WHY 75s (2.5x) AND NOT THE SCRIPT'S 3x DEFAULT. 2x is under the top of the observed
+      # noise (63.7s), which is the flake being fixed; 3x (90s) clears it by 26s but stops
+      # enforcing over roughly eight entries of the weight table, among them
+      # CountBaselineIntegrationTests at 84s — one of the two collections #1887 originally
+      # FOUND with this gate, so a 90s line cannot catch its own founding case. 75s clears
+      # the noise top by 11.3s, about 2.6x the measured 4.3s run-to-run spread, and roughly
+      # doubles the number of entries still enforced. The script keeps 3x as its default
+      # for other callers; this number is a judgement about THIS weight table and is
+      # pinned, with the reasoning above, by
+      # scripts/tests/check-collection-weights.test.py::WorkflowFailThresholdTests — which
+      # asserts bands and floors rather than exact counts, so adding a collection to the
+      # table does not turn an unrelated PR red.
       - name: Collection weight table freshness (unit tests)
         if: ${{ matrix.target.unit-tests }}
         run: |
-          python3 scripts/check-collection-weights.py trx/unit-tests.trx
+          python3 scripts/check-collection-weights.py trx/unit-tests.trx --fail-threshold 75
 
       - name: Phase-log report (unit tests)
         # always(): a red unit-test step is exactly when the timings are most worth

--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -522,6 +522,13 @@ jobs:
       # produced a trx — a collection dispatched at UnmeasuredWeightSeconds because it is
       # genuinely missing from the table is loud CI failure, per
       # .claude/rules/loud-failures.md, not another quiet report.
+      #
+      # #3103: it fails only above 3x UnmeasuredWeightSeconds, and reports the 2x..3x band as
+      # a ::warning:: annotation instead. This job rolls up into the `All BC versions passed`
+      # required check, and the old single line at 2x was summed wall clock on a shared
+      # runner — the same untouched collection landed at 59.4s on one PR's run and 63.7s on
+      # another's, so an unrelated PR went red. Both bands are also scaled by how slow this
+      # leg measured against the weight table's own entries. See the script's header.
       - name: Collection weight table freshness (unit tests)
         if: ${{ matrix.target.unit-tests }}
         run: |

--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -524,11 +524,14 @@ jobs:
       # .claude/rules/loud-failures.md, not another quiet report.
       #
       # #3103: it fails only above 3x UnmeasuredWeightSeconds, and reports the 2x..3x band as
-      # a ::warning:: annotation instead. This job rolls up into the `All BC versions passed`
-      # required check, and the old single line at 2x was summed wall clock on a shared
-      # runner — the same untouched collection landed at 59.4s on one PR's run and 63.7s on
-      # another's, so an unrelated PR went red. Both bands are also scaled by how slow this
-      # leg measured against the weight table's own entries. See the script's header.
+      # a ::warning:: annotation instead. This leg rolls up into the aggregate required check
+      # that main's ruleset gates on — the job named in test-matrix.yml, deliberately not
+      # spelled out here, because ReleaseTestParityTests asserts that exact name appears in
+      # no workflow but that one and cannot tell a comment from the real thing. The old
+      # single line at 2x was summed wall clock on a shared runner — the same untouched
+      # collection landed at 59.4s on one PR's run and 63.7s on another's, so an unrelated PR
+      # went red. Both bands are also scaled by how slow this leg measured against the weight
+      # table's own entries. See the script's header.
       - name: Collection weight table freshness (unit tests)
         if: ${{ matrix.target.unit-tests }}
         run: |

--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -73,8 +73,14 @@
 //
 // scripts/check-collection-weights.py is the loud guard that replaces "someone reads it by
 // hand": run against the same trx/unit-tests.trx the occupancy report already parses, it
-// fails CI when a collection above 2x UnmeasuredWeightSeconds is absent from this table —
-// the exact shape of both misses above. It deliberately does NOT flag drift on entries
+// reports a collection absent from this table above 2x UnmeasuredWeightSeconds and FAILS CI
+// above 3x — the exact shape of both misses above. #3103 split those two bands apart: the
+// single failing line used to sit at 2x, which is summed wall clock on a shared runner, so
+// SuiteAbortOnTimeoutTests measured 59.4s on one PR's run and 63.7s on another's and turned
+// a required check red on a PR that had never touched it. Both bands are now scaled by how
+// slow the leg itself ran, measured from the entries in THIS table (see that script's
+// header). The "record the observed MAXIMUM" rule below is unaffected — it was always about
+// dispatch order, not about satisfying the gate. It deliberately does NOT flag drift on entries
 // that already exist (see its own header for why: the same class's summed duration varies
 // materially by BC leg, and a percentage-drift check on top of that would be a noisy gate
 // nobody trusts). Re-measure existing entries with scripts/trx-occupancy.py by hand when

--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -74,7 +74,9 @@
 // scripts/check-collection-weights.py is the loud guard that replaces "someone reads it by
 // hand": run against the same trx/unit-tests.trx the occupancy report already parses, it
 // reports a collection absent from this table above 2x UnmeasuredWeightSeconds and FAILS CI
-// above 3x — the exact shape of both misses above. #3103 split those two bands apart: the
+// above the --fail-threshold bc-tests.yml passes it, 75s = 2.5x (the script's own
+// DEFAULT_FAIL_MULTIPLE is 3x, but nothing in this repository runs it without the flag)
+// — the exact shape of both misses above. #3103 split those two bands apart: the
 // single failing line used to sit at 2x, which is summed wall clock on a shared runner, so
 // SuiteAbortOnTimeoutTests measured 59.4s on one PR's run and 63.7s on another's and turned
 // a required check red on a PR that had never touched it. Both bands are now scaled by how

--- a/AlRunner.Tests/CollectionCostOrdererTests.cs
+++ b/AlRunner.Tests/CollectionCostOrdererTests.cs
@@ -238,6 +238,35 @@ public sealed class CollectionCostOrdererTests
     }
 
     /// <summary>
+    /// #3103 loosened the freshness guard's failing band; it must not have loosened it into
+    /// nothing. The step in bc-tests.yml still has to FAIL its leg, because a collection
+    /// genuinely missing from the table above the failing band is the #1887 tail — and this
+    /// job rolls up into the `All BC versions passed` required check, so `continue-on-error`
+    /// there would silently retire the whole guard while leaving the step in place.
+    /// </summary>
+    [Fact]
+    public void FreshnessGuard_IsWiredAsAFailingStepWithItsOwnUnitSuite()
+    {
+        var repoRoot = Path.GetFullPath(
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+        Assert.True(File.Exists(Path.Combine(repoRoot, "scripts", "check-collection-weights.py")),
+            "scripts/check-collection-weights.py is referenced by bc-tests.yml but is not checked in.");
+        // pr-check.yml runs every scripts/tests/*.test.py; without this file the two bands
+        // and the leg calibration #3103 added are unasserted.
+        Assert.True(
+            File.Exists(Path.Combine(repoRoot, "scripts", "tests", "check-collection-weights.test.py")),
+            "scripts/tests/check-collection-weights.test.py is missing; the guard's own behaviour would be untested.");
+
+        var workflow = File.ReadAllText(Path.Combine(repoRoot, ".github", "workflows", "bc-tests.yml"));
+        var steps = workflow.Split("      - name: ");
+        var step = Assert.Single(steps.Where(s => s.StartsWith("Collection weight table freshness")));
+
+        Assert.Contains("scripts/check-collection-weights.py", step);
+        Assert.DoesNotContain("continue-on-error", step);
+    }
+
+    /// <summary>
     /// The orderer is dead code unless the assembly attribute names it. Asserts the exact
     /// type and assembly strings xUnit resolves, so a typo (which xUnit reports only as a
     /// diagnostic message and otherwise ignores) fails the build instead of silently

--- a/AlRunner.Tests/CollectionCostOrdererTests.cs
+++ b/AlRunner.Tests/CollectionCostOrdererTests.cs
@@ -252,8 +252,9 @@ public sealed class CollectionCostOrdererTests
 
         Assert.True(File.Exists(Path.Combine(repoRoot, "scripts", "check-collection-weights.py")),
             "scripts/check-collection-weights.py is referenced by bc-tests.yml but is not checked in.");
-        // pr-check.yml runs every scripts/tests/*.test.py; without this file the two bands
-        // and the leg calibration #3103 added are unasserted.
+        // pr-gate.yml's scripts-tests job runs every scripts/tests/*.test.py (it moved there
+        // from pr-check.yml in #3165); without this file the two bands and the leg
+        // calibration #3103 added are unasserted.
         Assert.True(
             File.Exists(Path.Combine(repoRoot, "scripts", "tests", "check-collection-weights.test.py")),
             "scripts/tests/check-collection-weights.test.py is missing; the guard's own behaviour would be untested.");

--- a/AlRunner.Tests/CollectionCostOrdererTests.cs
+++ b/AlRunner.Tests/CollectionCostOrdererTests.cs
@@ -241,7 +241,7 @@ public sealed class CollectionCostOrdererTests
     /// #3103 loosened the freshness guard's failing band; it must not have loosened it into
     /// nothing. The step in bc-tests.yml still has to FAIL its leg, because a collection
     /// genuinely missing from the table above the failing band is the #1887 tail — and this
-    /// job rolls up into the `All BC versions passed` required check, so `continue-on-error`
+    /// job rolls up into the `BC test matrix passed` required check, so `continue-on-error`
     /// there would silently retire the whole guard while leaving the step in place.
     /// </summary>
     [Fact]

--- a/scripts/check-collection-weights.py
+++ b/scripts/check-collection-weights.py
@@ -56,6 +56,17 @@ their own comments say they crossed only on whichever leg happened to run slow. 
    cannot switch the gate off. It needs MIN_CALIBRATION_SAMPLES pairs; below that it is two
    numbers, not a measurement, and the factor stays 1.0.
 
+   MEASURED, and worth knowing before you credit this half with anything: on #3110's own
+   run (34054350482) BOTH unit legs printed "leg clock at or under the table's", i.e. the
+   factor came back 1.0 and the bands were the unscaled 60s/75s. That is structural rather
+   than luck. MeasuredWeightSeconds records each collection's observed MAXIMUM, so
+   median(observed / recorded) is normally BELOW 1.0 and the floor swallows it; the
+   calibration engages only on a leg slower than the historical max for most collections.
+   So the flake in #3103 is fixed by the flat 60s -> 75s move, not by this. Kept anyway,
+   because it is the half that protects a genuinely slow leg, and because it can only ever
+   loosen -- it cannot produce a false red. Do not read a green run as evidence it works;
+   read the "leg clock" clause in the output, which says which case you are in.
+
 2. **Advisory below, failing above.** At/above 2x UnmeasuredWeightSeconds the collection is
    worth recording, and is reported as a GitHub `::warning::` annotation so it lands in the
    checks UI instead of 400 lines down a log — visible, per #1887's actual complaint, but

--- a/scripts/check-collection-weights.py
+++ b/scripts/check-collection-weights.py
@@ -27,11 +27,48 @@ above threshold has no such false-positive mode: below threshold it is genuinely
 file header's own argument — the ~66 collections under it total 2.8s), and above threshold
 it is precisely the failure #1887 found.
 
-Usage:
-  scripts/check-collection-weights.py <results.trx> [--orderer PATH] [--threshold SECONDS]
+Two bands, and a clock that is not the wall clock (#3103)
+--------------------------------------------------------
+This runs in bc-tests.yml WITHOUT continue-on-error, inside the legs that roll up into the
+`All BC versions passed` required check. So every number it compares against decides
+whether somebody's pull request goes red — and until #3103 it compared summed wall-clock
+seconds measured on GitHub's shared runners against one fixed line at 2x
+UnmeasuredWeightSeconds (60s). Wall clock on a shared runner is not a property of the
+collection: SuiteAbortOnTimeoutTests, untouched by either pull request, summed 59.4s on
+PR #3082's run and 63.7s on PR #3083's and produced opposite verdicts on the same code.
+A red required check that is routinely somebody else's fault is worse than the drift it
+guards, because it teaches people to skim past red.
 
-Exit code is 1 (loud failure) when a heavy collection is missing from the table, 0
-otherwise — including when the trx file is absent/unparsable, matching
+The evidence that the old line sat exactly where the mass is: of the collections added to
+MeasuredWeightSeconds *because* they tripped this gate, most were recorded at 60-63s, and
+their own comments say they crossed only on whichever leg happened to run slow. So:
+
+1. **Calibrate to the leg, not to the wall.** Collections already in the table measure long
+   on exactly the legs where an unlisted one measures long, so the median of
+   observed/recorded over the paired entries IS this leg's clock relative to the clock the
+   table was recorded on. Both bands are scaled by it. The factor floors at 1.0 — a fast
+   leg must never make the gate STRICTER than the historical line, or this change would
+   turn PRs red that pass today — and is clamped at MAX_LOAD_FACTOR so a wrecked table
+   cannot switch the gate off. It needs MIN_CALIBRATION_SAMPLES pairs; below that it is two
+   numbers, not a measurement, and the factor stays 1.0.
+
+2. **Advisory below, failing above.** At/above 2x UnmeasuredWeightSeconds the collection is
+   worth recording, and is reported as a GitHub `::warning::` annotation so it lands in the
+   checks UI instead of 400 lines down a log — visible, per #1887's actual complaint, but
+   exit 0. Only at/above 3x does it fail: a collection weighted 30s when it really costs
+   90s+ is the tail #1887 measured, and 90s sits in a sparse part of the observed
+   distribution rather than in the middle of it.
+
+What is deliberately unchanged: a genuinely heavy unlisted collection (#1887's own
+InstallSeedDepCompanyCacheTests at ~196s) still fails the leg, on a slow leg too, because
+196s does not become cheap when the box is 60% slow.
+
+Usage:
+  scripts/check-collection-weights.py <results.trx> [--orderer PATH]
+      [--advisory-threshold SECONDS] [--fail-threshold SECONDS] [--no-load-calibration]
+
+Exit code is 1 (loud failure) when a collection above the failing band is missing from the
+table, 0 otherwise — including when the trx file is absent/unparsable, matching
 scripts/trx-occupancy.py's "nothing to report" convention for a step that should not fail
 the build over missing input data.
 """
@@ -54,8 +91,22 @@ DEFAULT_ORDERER = Path(__file__).resolve().parent.parent / "AlRunner.Tests" / "C
 
 # A collection below 2x UnmeasuredWeightSeconds cannot create a meaningful tail — the file
 # header's own argument for why the ~66 collections below that line total 2.8s and are
-# harmless. Anything at or above it is exactly the shape #1887 found.
-DEFAULT_THRESHOLD_MULTIPLE = 2
+# harmless. At or above it, the collection is worth recording: that is the ADVISORY band.
+DEFAULT_ADVISORY_MULTIPLE = 2
+
+# ...and 3x is where being weighted at UnmeasuredWeightSeconds costs a tail worth turning a
+# required check red for. #3103: keeping the failing line at 2x put it in the middle of the
+# observed distribution — most collections ever added to the table because this gate caught
+# them measured 60-63s, i.e. within noise of the line itself.
+DEFAULT_FAIL_MULTIPLE = 3
+
+# Fewer paired collections than this is not a measurement of the leg, so no calibration.
+# The real table carries ~45 entries and a real run observes nearly all of them.
+MIN_CALIBRATION_SAMPLES = 8
+
+# An upper bound on how far a slow leg may push the bands out, so a table that has drifted
+# wholesale (or a truncated trx) cannot silently disable the gate.
+MAX_LOAD_FACTOR = 3.0
 
 
 def load_trx_per_collection_seconds(path):
@@ -104,12 +155,55 @@ def find_missing_heavy(observed_seconds, table, threshold_seconds):
     )
 
 
+def leg_load_factor(observed_seconds, table,
+                    min_samples=MIN_CALIBRATION_SAMPLES, max_factor=MAX_LOAD_FACTOR):
+    """How slow THIS leg ran, relative to the clock MeasuredWeightSeconds was recorded on.
+
+    #3103. Every collection already in the table is a stopwatch that was started on the
+    same box as the unlisted one, so the median of observed/recorded across the paired
+    entries separates "this collection got heavier" from "this runner was busy". The median
+    (not the mean) because the table is hand-maintained and a couple of its entries are
+    knowingly stale — the script's header says drift-on-a-present-entry is out of scope, so
+    those entries must not be allowed to drag the calibration.
+
+    Floored at 1.0: this is allowed to widen the bands on a slow leg, never to narrow them
+    on a fast one. Narrowing would fail collections that pass today, which is a different
+    change from the one #3103 asks for. Clamped at max_factor, and refused outright below
+    min_samples pairs.
+    """
+    ratios = sorted(observed_seconds[cls] / recorded
+                    for cls, recorded in table.items()
+                    if recorded > 0 and cls in observed_seconds)
+    if len(ratios) < min_samples:
+        return 1.0
+    mid = len(ratios) // 2
+    median = ratios[mid] if len(ratios) % 2 else (ratios[mid - 1] + ratios[mid]) / 2
+    return min(max(median, 1.0), max_factor)
+
+
+def classify_missing(observed_seconds, table, advisory_seconds, fail_seconds):
+    """Split the unlisted-and-heavy collections into (failing, advisory).
+
+    Failing is at/above fail_seconds — the #1887 tail, loud and red. Advisory is the band
+    between advisory_seconds and fail_seconds: worth recording, reported by name, exit 0.
+    Both heaviest-first.
+    """
+    over = find_missing_heavy(observed_seconds, table, advisory_seconds)
+    failing = [(cls, secs) for cls, secs in over if secs >= fail_seconds]
+    advisory = [(cls, secs) for cls, secs in over if secs < fail_seconds]
+    return failing, advisory
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("path")
     ap.add_argument("--orderer", default=str(DEFAULT_ORDERER))
-    ap.add_argument("--threshold", type=float, default=None,
-                     help="override the computed 2x-unmeasured threshold directly")
+    ap.add_argument("--advisory-threshold", type=float, default=None,
+                    help="override the computed 2x-unmeasured 'worth recording' line")
+    ap.add_argument("--fail-threshold", type=float, default=None,
+                    help="override the computed 3x-unmeasured 'fail the leg' line")
+    ap.add_argument("--no-load-calibration", action="store_true",
+                    help="compare raw wall-clock seconds, without the #3103 leg calibration")
     args = ap.parse_args()
 
     try:
@@ -122,27 +216,50 @@ def main():
         return 0
 
     table, unmeasured = load_table(args.orderer)
-    threshold = args.threshold if args.threshold is not None else unmeasured * DEFAULT_THRESHOLD_MULTIPLE
 
-    missing = find_missing_heavy(observed, table, threshold)
-    if not missing:
+    load_factor = 1.0 if args.no_load_calibration else leg_load_factor(observed, table)
+    advisory = (args.advisory_threshold if args.advisory_threshold is not None
+                else unmeasured * DEFAULT_ADVISORY_MULTIPLE) * load_factor
+    fail = (args.fail_threshold if args.fail_threshold is not None
+            else unmeasured * DEFAULT_FAIL_MULTIPLE) * load_factor
+
+    failing, borderline = classify_missing(observed, table, advisory, fail)
+
+    calibration = (f"leg clock {load_factor:.2f}x the table's"
+                   if load_factor > 1.0 else "leg clock at or under the table's")
+    bands = (f"bands this run: report >= {advisory:.0f}s, fail >= {fail:.0f}s "
+             f"({calibration}; {len(table)} entries checked against "
+             f"{len(observed)} observed collections)")
+
+    # Borderline entries are reported whether or not anything failed: they are the drift
+    # #1887 cares about, and ::warning:: puts them in the checks UI rather than 400 lines
+    # down a log. Not a failure — see this file's header on why wall clock at 60s is not a
+    # property of the collection (#3103).
+    for cls, secs in borderline:
+        print(f"::warning file=AlRunner.Tests/CollectionCostOrderer.cs::"
+              f"{cls} cost {secs:.1f}s this run and is absent from "
+              f"CollectionCostOrderer.MeasuredWeightSeconds, so it is dispatched as if it "
+              f"cost {unmeasured}s. Record it (issue #1887).")
+
+    if not failing:
         print(f"CollectionCostOrderer.MeasuredWeightSeconds: no collection above "
-              f"{threshold:.0f}s is missing from the table ({len(table)} entries checked "
-              f"against {len(observed)} observed collections). OK.")
+              f"{fail:.0f}s is missing from the table; {bands}. OK.")
         return 0
 
     print("=" * 78)
     print("STALE CollectionCostOrderer.MeasuredWeightSeconds TABLE (issue #1887)")
     print("=" * 78)
-    print(f"The following collection(s) cost >= {threshold:.0f}s this run but are absent")
+    print(f"The following collection(s) cost >= {fail:.0f}s this run but are absent")
     print(f"from the table in {args.orderer}. Each falls back to")
     print(f"UnmeasuredWeightSeconds ({unmeasured}s) and can be scheduled as a")
     print("single-threaded tail late in the run — exactly the failure issue #1887 found.")
     print()
-    for cls, secs in missing:
+    for cls, secs in failing:
         print(f"  {secs:7.1f}s  {cls}")
     print()
-    noun = "it" if len(missing) == 1 else "them"
+    print(bands + ".")
+    print()
+    noun = "it" if len(failing) == 1 else "them"
     print(f"Add {noun} to MeasuredWeightSeconds in AlRunner.Tests/CollectionCostOrderer.cs")
     print("with its measured seconds (round down), per the file header's")
     print("'Why a measured table' note.")

--- a/scripts/check-collection-weights.py
+++ b/scripts/check-collection-weights.py
@@ -59,9 +59,15 @@ their own comments say they crossed only on whichever leg happened to run slow. 
 2. **Advisory below, failing above.** At/above 2x UnmeasuredWeightSeconds the collection is
    worth recording, and is reported as a GitHub `::warning::` annotation so it lands in the
    checks UI instead of 400 lines down a log — visible, per #1887's actual complaint, but
-   exit 0. Only at/above 3x does it fail: a collection weighted 30s when it really costs
-   90s+ is the tail #1887 measured, and 90s sits in a sparse part of the observed
-   distribution rather than in the middle of it.
+   exit 0. Above the failing band it exits 1. That band is an absolute number of SECONDS,
+   not a fixed multiple: --fail-threshold sets it outright, and DEFAULT_FAIL_MULTIPLE (3x,
+   i.e. 90s) is only the fallback for a caller that passes nothing. The shipping caller
+   passes one -- bc-tests.yml runs this with --fail-threshold 75 (2.5x). 90s would stop
+   enforcing over roughly eight entries of the weight table, among them
+   CountBaselineIntegrationTests at 84s, one of the two collections #1887 originally FOUND
+   with this gate, so it cannot catch its own founding case. That step's comment carries the
+   full reasoning, and the number is pinned by
+   scripts/tests/check-collection-weights.test.py::WorkflowFailThresholdTests.
 
 What is deliberately unchanged: a genuinely heavy unlisted collection (#1887's own
 InstallSeedDepCompanyCacheTests at ~196s) still fails the leg, on a slow leg too, because

--- a/scripts/check-collection-weights.py
+++ b/scripts/check-collection-weights.py
@@ -30,7 +30,11 @@ it is precisely the failure #1887 found.
 Two bands, and a clock that is not the wall clock (#3103)
 --------------------------------------------------------
 This runs in bc-tests.yml WITHOUT continue-on-error, inside the legs that roll up into the
-`All BC versions passed` required check. So every number it compares against decides
+`BC test matrix passed` required check (renamed from `All BC versions passed` by #3200
+when the pull-request matrix narrowed to three legs; the check-collection-weights step is
+unaffected by that narrowing, because it is gated on the matrix's `unit-tests` flag, which
+#3200 still computes from the FULL version list -- 27.5 and 28.4, on a pull request exactly
+as on a push). So every number it compares against decides
 whether somebody's pull request goes red — and until #3103 it compared summed wall-clock
 seconds measured on GitHub's shared runners against one fixed line at 2x
 UnmeasuredWeightSeconds (60s). Wall clock on a shared runner is not a property of the

--- a/scripts/tests/check-collection-weights.test.py
+++ b/scripts/tests/check-collection-weights.test.py
@@ -91,6 +91,88 @@ class FindMissingHeavyTests(unittest.TestCase):
             [cls for cls, _ in missing], ["VeryHeavyUnlistedTests", "MediumUnlistedTests"])
 
 
+class LegLoadFactorTests(unittest.TestCase):
+    """#3103: the gate is compared against a wall clock measured on shared runners, so the
+    same collection landed at 59.4s on one PR's run and 63.7s on another's and produced
+    opposite verdicts. The leg's own clock is recoverable from the run itself — every
+    collection that IS in the table measures long on the same leg that measures an unlisted
+    one long — so calibrate against that instead of trusting raw seconds."""
+
+    def test_is_one_when_the_leg_measures_exactly_what_the_table_records(self):
+        table = {f"C{i}Tests": 100 for i in range(10)}
+        observed = dict(table)
+        self.assertAlmostEqual(ccw.leg_load_factor(observed, table), 1.0, places=3)
+
+    def test_tracks_a_uniformly_slow_leg(self):
+        # Every measured collection ran 40% long; that is the leg, not the collections.
+        table = {f"C{i}Tests": 100 for i in range(10)}
+        observed = {k: v * 1.4 for k, v in table.items()}
+        self.assertAlmostEqual(ccw.leg_load_factor(observed, table), 1.4, places=3)
+
+    def test_never_tightens_the_gate_on_a_fast_leg(self):
+        # Deliberately constructed: a leg 40% FASTER than the table. Scaling the bar down
+        # would fail collections that pass today, so the factor floors at 1.0 -- this
+        # change may only ever loosen the gate, never tighten it.
+        table = {f"C{i}Tests": 100 for i in range(10)}
+        observed = {k: v * 0.6 for k, v in table.items()}
+        self.assertAlmostEqual(ccw.leg_load_factor(observed, table), 1.0, places=3)
+
+    def test_ignores_a_few_wildly_drifted_entries(self):
+        # The table is hand-maintained and some entries are stale by design (the script's
+        # own header says drift-on-a-present-entry is out of scope). A median over the
+        # pairs must not be dragged by two of them.
+        table = {f"C{i}Tests": 100 for i in range(10)}
+        observed = {k: v * 1.2 for k, v in table.items()}
+        observed["C0Tests"] = 1000
+        observed["C1Tests"] = 5
+        self.assertAlmostEqual(ccw.leg_load_factor(observed, table), 1.2, places=3)
+
+    def test_falls_back_to_one_without_enough_paired_collections(self):
+        # Two pairs is not a leg measurement, it is two numbers. Refuse to calibrate.
+        table = {"C0Tests": 100, "C1Tests": 100}
+        observed = {"C0Tests": 500, "C1Tests": 500}
+        self.assertAlmostEqual(ccw.leg_load_factor(observed, table), 1.0, places=3)
+
+    def test_is_clamped_so_a_broken_table_cannot_disable_the_gate(self):
+        table = {f"C{i}Tests": 10 for i in range(10)}
+        observed = {k: 10_000 for k in table}
+        self.assertAlmostEqual(
+            ccw.leg_load_factor(observed, table), ccw.MAX_LOAD_FACTOR, places=3)
+
+
+class ClassifyMissingTests(unittest.TestCase):
+    """Two bands, not one: at/above the advisory line the collection is worth recording;
+    only at/above the fail line does it cost enough tail to justify a red required check."""
+
+    TABLE = {"HeavyKnownTests": 200}
+
+    def test_a_borderline_collection_is_advisory_not_failing(self):
+        failing, advisory = ccw.classify_missing(
+            {"BorderlineUnlistedTests": 63.7}, self.TABLE,
+            advisory_seconds=60, fail_seconds=90)
+        self.assertEqual(failing, [])
+        self.assertEqual([cls for cls, _ in advisory], ["BorderlineUnlistedTests"])
+
+    def test_a_genuinely_heavy_collection_still_fails(self):
+        failing, advisory = ccw.classify_missing(
+            {"NewHeavyUnlistedTests": 196}, self.TABLE,
+            advisory_seconds=60, fail_seconds=90)
+        self.assertEqual([cls for cls, _ in failing], ["NewHeavyUnlistedTests"])
+        self.assertEqual(advisory, [])
+
+    def test_a_light_collection_is_neither(self):
+        failing, advisory = ccw.classify_missing(
+            {"TinyUnlistedTests": 5}, self.TABLE,
+            advisory_seconds=60, fail_seconds=90)
+        self.assertEqual((failing, advisory), ([], []))
+
+    def test_a_present_entry_is_neither_however_heavy(self):
+        failing, advisory = ccw.classify_missing(
+            {"HeavyKnownTests": 900}, self.TABLE,
+            advisory_seconds=60, fail_seconds=90)
+        self.assertEqual((failing, advisory), ([], []))
+
+
 class MainExitCodeTests(unittest.TestCase):
     """End-to-end through main(): a missing heavy collection in a real trx must fail the
     process (exit 1), a clean one must not (exit 0) — the actual CI contract."""
@@ -147,6 +229,114 @@ class MainExitCodeTests(unittest.TestCase):
             return ccw.main()
         finally:
             sys.argv = old_argv
+
+
+class StraddleTheThresholdTests(unittest.TestCase):
+    """#3103, end to end through main(). Every fixture here is built deliberately: the
+    verdict must be a property of the collection, not of how loaded GitHub's shared runner
+    happened to be while it was measured."""
+
+    HEADER = ('<?xml version="1.0" encoding="UTF-8"?>\n'
+              '<TestRun xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">\n')
+
+    def _write_trx(self, per_class_seconds):
+        """A trx with one test per class, each running for the given number of seconds."""
+        defs, results = [], []
+        for i, (cls, secs) in enumerate(per_class_seconds.items()):
+            tid = f"{i:08d}-1111-1111-1111-111111111111"
+            defs.append(f'    <UnitTest id="{tid}">'
+                        f'<TestMethod className="AlRunner.Tests.{cls}" name="F" /></UnitTest>')
+            total_ms = int(round(secs * 1000))
+            end = ("2026-01-01T"
+                   f"{total_ms // 3_600_000:02d}:"
+                   f"{total_ms // 60_000 % 60:02d}:"
+                   f"{total_ms // 1000 % 60:02d}."
+                   f"{total_ms % 1000:03d}+00:00")
+            results.append(f'    <UnitTestResult testId="{tid}" '
+                           f'startTime="2026-01-01T00:00:00.000+00:00" endTime="{end}" />')
+        xml = (self.HEADER + "  <TestDefinitions>\n" + "\n".join(defs)
+               + "\n  </TestDefinitions>\n  <Results>\n" + "\n".join(results)
+               + "\n  </Results>\n</TestRun>\n")
+        with tempfile.NamedTemporaryFile("w", suffix=".trx", delete=False) as f:
+            f.write(xml)
+            return f.name
+
+    def _write_orderer(self, entries):
+        body = "\n".join(f'["{k}"] = {v},' for k, v in entries.items())
+        with tempfile.NamedTemporaryFile("w", suffix=".cs", delete=False) as f:
+            f.write("public const int UnmeasuredWeightSeconds = 30;\n")
+            f.write("MeasuredWeightSeconds = new Dictionary<string, int> {\n"
+                    + body + "\n};\n")
+            return f.name
+
+    @staticmethod
+    def _run(trx, orderer):
+        import contextlib, io, sys
+        old_argv = sys.argv
+        buf = io.StringIO()
+        try:
+            sys.argv = ["check-collection-weights.py", trx, "--orderer", orderer]
+            with contextlib.redirect_stdout(buf):
+                rc = ccw.main()
+        finally:
+            sys.argv = old_argv
+        return rc, buf.getvalue()
+
+    # A reference-speed leg: twelve measured collections that each land exactly on their
+    # recorded value, so leg_load_factor is 1.0 and the bars are the unscaled 60s/90s.
+    REFERENCE_TABLE = {f"Known{i}Tests": 100 for i in range(12)}
+
+    def _reference_leg(self, extra, load=1.0):
+        observed = {k: v * load for k, v in self.REFERENCE_TABLE.items()}
+        observed.update(extra)
+        return self._write_trx(observed), self._write_orderer(self.REFERENCE_TABLE)
+
+    def test_the_same_collection_gets_the_same_verdict_on_both_sides_of_60s(self):
+        # The measured instance from #3103: SuiteAbortOnTimeoutTests, untouched by either
+        # PR, summed 59.4s on one run and 63.7s on another and produced opposite verdicts.
+        verdicts = {}
+        for secs in (59.4, 63.7):
+            trx, orderer = self._reference_leg({"SuiteAbortOnTimeoutTests": secs})
+            verdicts[secs] = self._run(trx, orderer)[0]
+        self.assertEqual(verdicts[59.4], verdicts[63.7])
+        self.assertEqual(verdicts[63.7], 0)
+
+    def test_a_borderline_collection_is_still_named_in_the_output(self):
+        # Not failing is not the same as going quiet: #1887's whole complaint was drift
+        # nobody saw. It must still be reported, and as a GitHub annotation so it lands in
+        # the checks UI rather than 400 lines down a log.
+        trx, orderer = self._reference_leg({"SuiteAbortOnTimeoutTests": 63.7})
+        rc, out = self._run(trx, orderer)
+        self.assertEqual(rc, 0)
+        self.assertIn("SuiteAbortOnTimeoutTests", out)
+        self.assertIn("::warning", out)
+
+    def test_a_genuinely_heavy_unlisted_collection_still_fails_the_run(self):
+        # #1887's own case, InstallSeedDepCompanyCacheTests at ~196s. This is the property
+        # the fix may not give up.
+        trx, orderer = self._reference_leg({"InstallSeedDepCompanyCacheTests": 196})
+        rc, out = self._run(trx, orderer)
+        self.assertEqual(rc, 1)
+        self.assertIn("InstallSeedDepCompanyCacheTests", out)
+
+    def test_identical_seconds_are_read_against_the_legs_own_clock(self):
+        # The load-bearing assertion, and the one a no-op implementation cannot pass: the
+        # SAME 100s measurement fails on a leg running at the table's speed and passes on a
+        # leg where every measured collection also ran 60% long -- because on that leg 100s
+        # is ~62s of work, under the bar. Nothing about the collection changed; only the
+        # box did.
+        fast_trx, orderer = self._reference_leg({"UnlistedTests": 100}, load=1.0)
+        slow_trx, _ = self._reference_leg({"UnlistedTests": 100}, load=1.6)
+        self.assertEqual(self._run(fast_trx, orderer)[0], 1)
+        self.assertEqual(self._run(slow_trx, orderer)[0], 0)
+
+    def test_a_slow_leg_cannot_hide_a_collection_that_is_heavy_at_reference_speed(self):
+        # The negative direction of the same knob: 400s on a leg running 60% long is still
+        # 250s of real work, far above the bar, so calibration must not swallow it.
+        trx, orderer = self._reference_leg({"UnlistedTests": 400}, load=1.6)
+        rc, out = self._run(trx, orderer)
+        self.assertEqual(rc, 1)
+        self.assertIn("UnlistedTests", out)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/check-collection-weights.test.py
+++ b/scripts/tests/check-collection-weights.test.py
@@ -10,6 +10,7 @@ drift-on-a-present-entry is deliberately out of scope here).
 Run: python3 scripts/tests/check-collection-weights.test.py
 """
 import importlib.util
+import re
 import tempfile
 import textwrap
 import unittest
@@ -270,12 +271,13 @@ class StraddleTheThresholdTests(unittest.TestCase):
             return f.name
 
     @staticmethod
-    def _run(trx, orderer):
+    def _run(trx, orderer, extra=None):
         import contextlib, io, sys
         old_argv = sys.argv
         buf = io.StringIO()
         try:
-            sys.argv = ["check-collection-weights.py", trx, "--orderer", orderer]
+            sys.argv = (["check-collection-weights.py", trx, "--orderer", orderer]
+                        + list(extra or []))
             with contextlib.redirect_stdout(buf):
                 rc = ccw.main()
         finally:
@@ -337,6 +339,108 @@ class StraddleTheThresholdTests(unittest.TestCase):
         rc, out = self._run(trx, orderer)
         self.assertEqual(rc, 1)
         self.assertIn("UnlistedTests", out)
+
+
+class WorkflowFailThresholdTests(unittest.TestCase):
+    """The failing line bc-tests.yml actually runs with, and why it is 2.5x rather than 3x.
+
+    The script's own DEFAULT_FAIL_MULTIPLE stays 3 for any other caller; the corpus leg
+    passes --fail-threshold explicitly. That number is a judgement about THIS repository's
+    weight table, so it is pinned against the real table rather than the fixture one -- a
+    later edit that drops the flag, or moves it back to 3x, fails here.
+    """
+
+    REPO = Path(__file__).resolve().parent.parent.parent
+    WORKFLOW = REPO / ".github" / "workflows" / "bc-tests.yml"
+    ORDERER = REPO / "AlRunner.Tests" / "CollectionCostOrderer.cs"
+
+    FAIL_MULTIPLE = 2.5
+
+    # Measured in #3103: the same untouched collection (SuiteAbortOnTimeoutTests) summed
+    # 59.4s on one run and 63.7s on another. Properties of a shared GitHub runner, not of
+    # the weight table -- so they stay fixed as the table grows.
+    OBSERVED_NOISE_TOP = 63.7
+    OBSERVED_NOISE_SPREAD = 4.3
+
+    def _workflow_fail_threshold(self):
+        text = self.WORKFLOW.read_text()
+        line = [ln for ln in text.splitlines()
+                if "check-collection-weights.py" in ln and not ln.strip().startswith("#")]
+        self.assertEqual(len(line), 1,
+                         "expected exactly one check-collection-weights.py invocation "
+                         f"in bc-tests.yml, found {len(line)}")
+        m = re.search(r"--fail-threshold\s+(\d+(?:\.\d+)?)", line[0])
+        self.assertIsNotNone(
+            m, "bc-tests.yml must pass --fail-threshold explicitly: the script's 3x default "
+               "is looser than this repository's weight table can afford (see below)")
+        return float(m.group(1))
+
+    def test_the_workflow_passes_two_and_a_half_times_unmeasured_weight(self):
+        _, unmeasured = ccw.load_table(str(self.ORDERER))
+        self.assertEqual(self._workflow_fail_threshold(), self.FAIL_MULTIPLE * unmeasured)
+
+    def test_the_chosen_line_clears_the_observed_noise_but_three_x_gives_up_too_much(self):
+        """The two-sided argument, measured against the real table, not asserted.
+
+        Below: 2x (60s) sits UNDER the top of the observed noise cluster -- the same
+        untouched collection summed 59.4s and 63.7s on two runs -- which is the flake
+        #3103 fixes. Above: at 3x (90s) the gate stops being enforced over 8 entries of
+        the real table, among them CountBaselineIntegrationTests at 84s, which is one of
+        the two collections #1887 originally FOUND with this gate. A line that cannot
+        catch its own founding case is decoration.
+        """
+        table, unmeasured = ccw.load_table(str(self.ORDERER))
+        chosen = self.FAIL_MULTIPLE * unmeasured
+        weights = sorted(table.values())
+
+        # The noise half, and the only part built from constants rather than from the
+        # table: 2x sits UNDER the top of the observed cluster, the chosen line clears it.
+        # OBSERVED_NOISE_TOP/SPREAD are measurements from #3103, not table properties, so
+        # this pair cannot drift as collections are added.
+        self.assertGreater(chosen, self.OBSERVED_NOISE_TOP)
+        self.assertLess(2 * unmeasured, self.OBSERVED_NOISE_TOP)
+        self.assertGreater(chosen - self.OBSERVED_NOISE_TOP, 2 * self.OBSERVED_NOISE_SPREAD)
+
+        # The founding-case half. Deliberately a BAND, not == 84: the point is that this
+        # collection is enforced at the chosen line and would not be at 3x, which stays
+        # true however the entry is re-measured, and does not go red because someone else
+        # added a table entry.
+        founding = table["CountBaselineIntegrationTests"]
+        self.assertGreaterEqual(
+            founding, chosen,
+            "CountBaselineIntegrationTests is one of the two collections #1887 found with "
+            "this gate; if it no longer sits at or above the failing line, the argument for "
+            f"{self.FAIL_MULTIPLE}x has to be re-made rather than quietly kept")
+        self.assertLess(
+            founding, 3 * unmeasured,
+            "if this entry has grown past 3x, the 'a 90s line cannot catch its own founding "
+            "case' argument no longer holds and this test should be revisited")
+
+        # ...and the slice of the table that stops being enforced at 3x is a real one, not
+        # a rounding difference. A floor, not an exact count, for the same reason.
+        enforced_at = lambda bar: sum(1 for w in weights if w >= bar)
+        given_up = enforced_at(chosen) - enforced_at(3 * unmeasured)
+        self.assertGreaterEqual(
+            given_up, 5,
+            f"moving the line to 3x would give up enforcement over only {given_up} entries; "
+            "if the table has shifted that far, 2.5x may no longer be buying anything")
+
+    def test_an_eighty_four_second_collection_fails_at_the_workflows_line(self):
+        """End to end through the script, so the number above is not just arithmetic."""
+        bar = self._workflow_fail_threshold()
+        reference = {f"Known{i}Tests": 100 for i in range(12)}
+        helper = StraddleTheThresholdTests("run")
+        trx = helper._write_trx({**reference, "CountBaselineIntegrationTests": 84})
+        orderer = helper._write_orderer(reference)
+
+        rc_at_workflow_line, out = helper._run(trx, orderer, extra=["--fail-threshold", str(bar)])
+        self.assertEqual(rc_at_workflow_line, 1)
+        self.assertIn("CountBaselineIntegrationTests", out)
+
+        # The same run at the script's untuned 3x default: reported, but not failing.
+        rc_at_default, out_default = helper._run(trx, orderer)
+        self.assertEqual(rc_at_default, 0)
+        self.assertIn("CountBaselineIntegrationTests", out_default)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #3103

## What was wrong

`scripts/check-collection-weights.py` runs in `bc-tests.yml` **without `continue-on-error`**, inside the legs that roll up into the `All BC versions passed` required check. It compared summed wall-clock seconds, measured on GitHub's shared runners, against a single fixed line at `2 x UnmeasuredWeightSeconds` = 60 s.

Wall clock on a shared runner is not a property of the collection. `SuiteAbortOnTimeoutTests`, untouched by either PR, summed 59.4 s on PR #3082's run and 63.7 s on PR #3083's and produced opposite verdicts on the same code.

The table itself is the evidence that the line sat in the wrong place: of the collections ever added to `MeasuredWeightSeconds` *because* this gate caught them, most were recorded at 60-63 s, and their own comments say they crossed only on whichever leg happened to run slow (`InstallBaselineVirtualTableExclusionTests` 61, `StartupOutputReexecDedupTests` 61, `BcVersionDefaultDocumentationTests` 62, `MissingTestDataDiagnosisTests` 60, `TestPageBooleanRecBoundDispatchTests` 63). The failing line was in the middle of the observed distribution, not above it.

**Measured over the real table** (45 entries, parsed out of `CollectionCostOrderer.MeasuredWeightSeconds` at this head): smallest entry **21 s**, median **63 s**, largest 285 s. The absence of any small entries is what makes the calibration meaningful — every ratio it takes a median over is `observed / recorded` on values of tens of seconds, so the ratios are not quantisation noise, and a median across ~40 of them is a real estimate of this leg's clock rather than an artifact of dividing small numbers.

## What changed

Both changes are in `scripts/check-collection-weights.py`.

**1. Calibrate to the leg, not to the wall.** Every collection already in the table is a stopwatch started on the same box as the unlisted one, so the median of `observed / recorded` over the paired entries is this leg's clock relative to the clock the table was recorded on. Both bands scale by it.

- Floored at 1.0 — a fast leg must never make the gate *stricter* than the historical 60 s line, or this change would turn PRs red that pass today. **The change is strictly loosening everywhere.**
- Clamped at `MAX_LOAD_FACTOR = 3.0` so a wholesale-drifted table or a truncated TRX cannot silently switch the gate off.
- Refused below `MIN_CALIBRATION_SAMPLES = 8` pairs: fewer than that is two numbers, not a measurement. The real table has 45 entries and a real run observes nearly all of them.
- Median, not mean, because the script's own header says drift on a *present* entry is deliberately out of scope, so a couple of knowingly-stale entries must not drag the calibration.

**2. Two bands instead of one line.** At/above `2x` the collection is reported by name as a GitHub `::warning::` annotation — so it lands in the checks UI rather than 400 lines down a log — and exits 0. Only at/above the failing line (`--fail-threshold`, see below) does it fail the leg. That preserves what #1887 actually wanted (drift is visible and named) while taking the noisy band off the required check.

**Why the failing line moves from 2x to 2.5x (60 s -> 75 s flat), not just with calibration.** This is the larger of the two loosenings, so it is argued here rather than assumed. It was drafted at 3x; review recommended 2.5x and I took it, for the reason two paragraphs down.

The case: *the 60 s line sits on the cluster it created.* Five of the 45 entries fall in the 4-second band 60-63 s — `MissingTestDataDiagnosisTests` 60, `InstallBaselineVirtualTableExclusionTests` 61, `StartupOutputReexecDedupTests` 61, `BcVersionDefaultDocumentationTests` 62, `TestPageBooleanRecBoundDispatchTests` 63 — and every one entered the table *because this gate caught it*, at a value their own comments attribute to whichever leg ran slow. A threshold sitting on top of the values it produced flips on run-to-run noise by construction, which is what #3082 vs #3083 measured: 59.4 s and 63.7 s, same untouched collection, opposite verdicts. Local density around each candidate line, measured: within +/-3 s, **5 entries at 60 s vs 1 at 90 s**; within +/-5 s, 5 vs 3. Honest caveat — at +/-10 s the two are indistinguishable (7 vs 9), so the argument is that 60 s sits *on its own cluster*, not that 90 s is globally sparse.

Calibration alone cannot fix it, because the factor is floored at 1.0: a leg running at or above the table's reference clock gets 1.0 and therefore the unmodified 60 s line — exactly the straddler case. Only moving the number helps there.

The cost, stated plainly: **10 entries of the table sit in [60, 75)**, so a genuinely-unlisted collection of that size now produces a named `::warning::` instead of a red leg. What is preserved is #1887's actual complaint — it was found by a human reading a TRX occupancy report, and a named annotation in the checks UI is strictly more visible than that. What is given up is *automatic enforcement* across 60-75 s. **Both** of #1887's own finds still fail the leg: `InstallSeedDepCompanyCacheTests` at ~196 s (on a slow leg too), and `CountBaselineIntegrationTests` at 84 s, which the 3x line this PR was drafted with would have let through.

**Why 2.5x and not the 3x this was drafted with.** The draft argued for 3x on the grounds that 75 s still sits inside the [60, 90) mass. Re-measured against the table at this head (45 entries; min 21 s, median 63 s, max 285 s), that reasoning was the wrong way round. 3x (90 s) clears the observed noise top of 63.7 s by 26 s, but stops enforcing over roughly eight more entries — among them `CountBaselineIntegrationTests` at 84 s, one of the two collections #1887 originally *found* with this gate, so a 90 s line cannot catch its own founding case. 75 s clears the same noise top by 11.3 s, about 2.6x the measured 4.3 s run-to-run spread, and leaves 19 entries enforced against 11 at 3x. The defect being fixed here is the flake; 2.5x fixes it while giving up the least enforcement. Both are strictly looser than today, so neither can turn a currently-green PR red. The script keeps 3x as its `DEFAULT_FAIL_MULTIPLE` for any other caller — only `bc-tests.yml` passes `--fail-threshold 75`.

`--threshold` is replaced by `--advisory-threshold` / `--fail-threshold`, plus `--no-load-calibration`. Nothing in the repo passed `--threshold` (the workflow calls the script with the TRX path only).

Comments in `AlRunner.Tests/CollectionCostOrderer.cs` and `.github/workflows/bc-tests.yml` that documented the old single 2x line are updated — they are the second and third places the same invariant is written down.

## RED -> GREEN

`scripts/tests/check-collection-weights.test.py`, 18 new tests. Every fixture is constructed deliberately: a 12-entry reference table plus a synthesized TRX whose measured collections land at a chosen multiple of their recorded values, so the leg's speed is an input to the test rather than something the tree happens to be in.

RED, against the script as it was on `main` — 3 failures and 10 errors:

```
FAIL: test_the_same_collection_gets_the_same_verdict_on_both_sides_of_60s
AssertionError: 0 != 1
FAIL: test_identical_seconds_are_read_against_the_legs_own_clock
AssertionError: 1 != 0
FAIL: test_a_borderline_collection_is_still_named_in_the_output
AssertionError: 1 != 0
```

(the 10 errors are `leg_load_factor` / `classify_missing` / `MAX_LOAD_FACTOR` not existing yet.)

GREEN: `Ran 26 tests ... OK` — the 8 pre-existing tests still pass unchanged. Three of the 18 are `WorkflowFailThresholdTests`, added when the failing line moved to 2.5x: they read the `--fail-threshold` that `bc-tests.yml` actually passes and pin it against `UnmeasuredWeightSeconds` parsed from the real `CollectionCostOrderer.cs`, so dropping the flag or moving it back to 3x fails. RED for those three, measured on this branch before the change: 2 failures (`bc-tests.yml must pass --fail-threshold explicitly`), and 2 again with the value set to 90 instead of 75. They assert bands and floors rather than exact counts, so adding a collection to the weight table does not turn an unrelated PR red — the failure mode this PR exists to remove.

Two of the new tests passed *before* the fix as well, and that is deliberate: `test_a_genuinely_heavy_unlisted_collection_still_fails_the_run` (#1887's own `InstallSeedDepCompanyCacheTests` at ~196 s) and `test_a_slow_leg_cannot_hide_a_collection_that_is_heavy_at_reference_speed` pin the property the fix may not give up.

The load-bearing one a no-op implementation cannot pass is `test_identical_seconds_are_read_against_the_legs_own_clock`: the **same** 100 s measurement fails on a leg running at the table's speed and passes on a leg where every measured collection also ran 60% long, because there 100 s is ~62 s of work. Nothing about the collection changes; only the box does.

Also verified end to end against the **real** 45-entry table with the real script:

| scenario | verdict |
|---|---|
| fast leg, straddler at 59.4 s | rc=0, silent |
| fast leg, straddler at 63.7 s | rc=0, `::warning::` naming the collection |
| slow leg (1.2x), straddler at 63.7 s | rc=0, bands report >= 72 s / fail >= 108 s |
| reference leg, unlisted 196 s | **rc=1** |
| slow leg (1.6x), unlisted 196 s | **rc=1**, fail band 144 s |

`AlRunner.Tests`: `--filter FullyQualifiedName~CollectionCostOrdererTests` -> 9/9 passed, including one new wiring guard, `FreshnessGuard_IsWiredAsAFailingStepWithItsOwnUnitSuite`. It asserts the step still exists, still invokes the script, and still has **no** `continue-on-error` — because loosening the failing band must not become loosening it into nothing. Checked for vacuity by mutation: inserting `continue-on-error: true` into that step makes the assertion fail. Known gap, worth a sentence rather than a fix here: that mutation exercises a **step-level** `continue-on-error` only. A **job-level** `continue-on-error:` on the `bc-tests` job would neutralise the step just as effectively, and this guard would not catch it. All five `scripts/tests/*.test.py` suites pass.

### Correction: the "no runtime path" reasoning below was wrong, and it cost a red CI run

An earlier revision of this body said: *"Not run: the full `AlRunner.Tests` suite. The diff touches no file under `AlRunner/` and no runtime path — one new C# test plus comments."*

That inference is bad, and it failed deterministically on **both** unit-test legs. The diff touches a **workflow file**, and this repository has C# tests that assert over workflow files — the wiring guard this PR itself adds is one of them. `ReleaseTestParityTests.RequiredStatusCheck_StaysAJobInTestMatrixYml` asserts the aggregate required check's name appears in `test-matrix.yml` and in no other workflow, and this branch's own new comment in `bc-tests.yml` named it verbatim. A text assertion cannot tell a comment from a job declaration.

**"Touches no runtime path" is not the same as "cannot break a test."** The transferable rule: when a diff touches anything under `.github/workflows/`, run the workflow-guard classes — they are C# tests over YAML text, and nothing about "no runtime path" protects you from them.

Fixed in `9640d9a2` by rewording the comment so it still says what it meant without the literal string, and recording in the comment itself why the name is deliberately not spelled out there.

Verified locally, both directions:

- **RED** at head `28667f3c`: `--filter FullyQualifiedName~ReleaseTestParityTests` -> `Failed: 1, Passed: 11`, failing at `ReleaseTestParityTests.cs:267` with `Assert.DoesNotContain() Failure: Sub-string found`.
- **GREEN** after the reword: that filter plus every other workflow-reading guard class (`BcLegRerunWorkflowTests`, `CorpusAppEnumerationWorkflowTests`, `CollectionCostOrdererTests`, `CrashDumpCaptureWiringTests`, `MsBucketWorkflowTests`, `PublishReleaseOrderingTests`, `TestArtifactsGateTests`) -> **86 passed, 0 failed**.
- `scripts/tests/check-collection-weights.test.py` -> `Ran 26 tests ... OK`; `bc-tests.yml` still parses as YAML; `dotnet test --filter FullyQualifiedName~ReleaseTestParity|FullyQualifiedName~CollectionCostOrderer` -> 21 passed.

Occurrences of that literal string in `bc-tests.yml`: **0** on `origin/main`, **1** at `28667f3c`, **0** now.

Still not run: the full `AlRunner.Tests` suite (15-31 min), per `.claude/rules/local-test-scope.md`. CI runs it on both unit-test legs.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site?** No. `check-collection-weights.py` is the only CI step in the repository that fails on a measured duration. `trx-occupancy.py` and `phase-log-report.py` also parse timings but contain no `return 1` / `sys.exit(1)` at all and are `continue-on-error: true` besides. No workflow here sets `timeout-minutes`.
2. **Sibling function with the same assumption?** `find_missing_heavy` was the only comparator; it is kept (its three existing tests still pass) and `classify_missing` wraps it, so there is one comparison site, not two.
3. **Two paths maintaining the same invariant?** The 60 s line existed as a number in the script and as prose in two other files — `CollectionCostOrderer.cs`'s header and `bc-tests.yml`'s step comment. Both are updated in this PR. The threshold value itself has only ever had one source: `load_table` parses `UnmeasuredWeightSeconds` straight out of the C#.

Deliberately left out: the `SuiteAbortOnTimeoutTests` / `TestCodeunitExecutionOrderTests` table entries, which #3082 is adding. This PR does not touch `MeasuredWeightSeconds`.

## Not a BC-behaviour claim

This is CI infrastructure. It asserts nothing about what Business Central does — no AL, no service tier, no runtime semantics — so it owes nothing to the upstream `BusinessCentral.AL.Language.Tests` corpus and there is nothing here a real BC service tier could adjudicate.

It also moves no required-context name, so `check_required_contexts.py` and `tools/ci-wait.py`'s built-in lists are unaffected: all ten contexts the `main` ruleset requires are unchanged, and this step was never a context of its own. (Measured against the live ruleset, because an earlier revision of this body said the ruleset requires only `All BC versions passed` and `Tests updated` -- it requires ten, and the aggregate was renamed to `BC test matrix passed` by #3141.)

### Review correction (impl-9): the calibration this PR is named after is inert, and the flat move is the fix

Measured from **this PR's own CI**, run `34054350482`, on both unit legs (27.5 and 28.4):

```
CollectionCostOrderer.MeasuredWeightSeconds: no collection above 75s is missing from
the table; bands this run: report >= 60s, fail >= 75s (leg clock at or under the
table's; 45 entries checked against 498 observed collections). OK.
```

`leg_load_factor` came back **1.0 on both legs**, so the bands were the unscaled 60 s / 75 s. That is structural rather than luck: `MeasuredWeightSeconds` records each collection's observed **maximum**, so `median(observed / recorded)` normally lands below 1.0 and the 1.0 floor swallows it. The calibration engages only on a leg slower than the historical max for most collections.

So **what actually fixes the flake is the flat 60 s -> 75 s move, not the clock normalisation.** The calibration is kept — it can only ever loosen, so it cannot produce a false red, and it is the half that protects a genuinely slow leg — but it is no longer claimed as the fix. The script header now records the measurement, so the next reader does not credit a green run to a code path that did not run.

### Review correction (impl-9): three stale claims in the tree

- `AlRunner.Tests/CollectionCostOrderer.cs` said the guard "FAILS CI above 3x". `bc-tests.yml` passes `--fail-threshold 75` = **2.5x**; 3x is only the script's `DEFAULT_FAIL_MULTIPLE` fallback, and nothing in this repository calls it without the flag. The **PR title said 3x too** — and this repo's `squash_merge_commit_title` is `COMMIT_OR_PR_TITLE`, so with several commits on the branch the PR title becomes the merge-commit subject and lands in `CHANGELOG.md`. Retitled.
- `AlRunner.Tests/CollectionCostOrdererTests.cs` credited `pr-check.yml` with running every `scripts/tests/*.test.py`. That job moved to `pr-gate.yml` in #3165.
- `scripts/check-collection-weights.py`'s prose had already been corrected in `e037e038`; the body's claim that all three sites were updated is now true.

Counts in this body were re-measured against the table at the rebased head: 45 entries, min 21 s, median 63 s, max 285 s; **10** entries in [60, 75), 8 in [75, 90). An earlier revision said 43 entries / median 69 s / 8 in [60, 75).

### Blocked by a broken `main`, not by this PR

`main` at `598f628a` (PR #3248's merge) **does not compile** — `BcAppSymbolCache.cs(1319,26): error CS7036`, a call site missed when `ParseSubPageLink` gained an `out` parameter. Bisected: `65e5e562` builds, `598f628a` does not. Filed as **#3267**. This PR is rebased onto current `main`, so its CI is red for that reason until #3267 lands.

The verification above was therefore run on a tree with **identical content** based on the last good `main` (`65e5e562` + this branch's six commits, all five changed files byte-identical): `26 tests OK` for `check-collection-weights.test.py`, all five `scripts/tests/*.test.py` suites OK, and **86 passed / 0 failed** across `CollectionCostOrdererTests`, `ReleaseTestParityTests`, `BcLegRerunWorkflowTests`, `CorpusAppEnumerationWorkflowTests`, `CrashDumpCaptureWiringTests`, `MsBucketWorkflowTests`, `PublishReleaseOrderingTests` and `TestArtifactsGateTests` — run as whole classes, not behind a narrow filter.

### Update (impl-3): that blocker is gone, and the verification above now stands on the real tree

The section above is kept for the record but no longer describes this PR. #3267
landed; `main` is `492394be` and compiles. This branch is rebased onto it — the
six commits replay unchanged, no conflicts — so the substitute-tree caveat is
retired and the numbers were re-measured on the actual head:

- `scripts/tests/*.test.py`, all five suites: pass, including
  `check-collection-weights.test.py`.
- `dotnet test AlRunner.Tests --filter` over `CollectionCostOrdererTests`,
  `ReleaseTestParityTests`, `BcLegRerunWorkflowTests`,
  `CorpusAppEnumerationWorkflowTests`, `CrashDumpCaptureWiringTests`,
  `MsBucketWorkflowTests`, `PublishReleaseOrderingTests`,
  `TestArtifactsGateTests`: **86 passed, 0 failed**.
- The 2.5x figure agrees across all three places it is written: this PR's title,
  `bc-tests.yml`'s `--fail-threshold 75`, and the prose in
  `AlRunner.Tests/CollectionCostOrderer.cs`. `UnmeasuredWeightSeconds` is 30, so
  75 s is 2.5x.

CI on `f4748494`: all ten required contexts SUCCESS, including `BC test matrix
passed` across the 27.0, 27.5 and 28.4 legs. **The earlier red was inherited from
the broken `main`, not this PR's own.**

Rebased and re-verified by agent `impl-3` on the account holder's behalf.

---

Authored by agent `stma-auto-1`; review fixes applied by agent `impl-9`.

---

Written by agent `stma-auto-1` (cycle 137; corrected and re-measured in cycle 139) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE


