### PR TITLE
fix(permissions): delete two dead permission-metadata helpers and guard the shape that hid them

### DIFF
--- a/AlRunner.Tests/PermissionMetadataShapeGapTests.cs
+++ b/AlRunner.Tests/PermissionMetadataShapeGapTests.cs
@@ -21,12 +21,18 @@
 //   does not hide the gap, it INVERTS the result. BcShapeGapException tears through both AL
 //   seams, which is the whole point of the conversion.
 //
-// THE FOUR END-TO-END ARMS
-//   SetProperty, SetBackingField, SetEmptyListBackingField and BuildIncludeList each take the
-//   reflected type or target as a PARAMETER, so they can be driven with a fake standing in for
-//   a BC type whose member moved — real production code, no BC install required. Every one is
-//   paired with a control arm that still succeeds, so a conversion that threw unconditionally
-//   would fail here rather than pass.
+// THE TWO END-TO-END ARMS
+//   SetProperty and BuildIncludeList each take the reflected type or target as a PARAMETER, so
+//   they can be driven with a fake standing in for a BC type whose member moved — real
+//   production code, no BC install required. Each is paired with a control arm that still
+//   succeeds, so a conversion that threw unconditionally would fail here rather than pass.
+//
+//   #3100 removed two further arms, over SetBackingField and SetEmptyListBackingField. Those two
+//   helpers were superseded inside PR #2921 itself — 793ab838 poked NCLMetaPermissionSet's
+//   backing fields by hand, 75630e98 replaced that with BC's own AssignFromMetaPermissionSet —
+//   so their arms exercised production code no production path could reach, and read as coverage
+//   of a live one. Driving a private member by name cannot tell the difference;
+//   ReflectionDrivenHelperLivenessTests measures it from IL and now guards this file.
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -66,48 +72,7 @@ public sealed class PermissionMetadataShapeGapTests
         Assert.Equal("SUPER", target.Name);
     }
 
-    // ══ 2. SetBackingField — the auto-property backing field BC generates ════════════════
-
-    [Fact]
-    public void SetBackingField_RaisesAShapeGapNamingTheMember_WhenTheBackingFieldIsGone()
-    {
-        var ex = Assert.Throws<BcShapeGapException>(
-            () => Invoke("SetBackingField", typeof(HasNoSuchProperty), new HasNoSuchProperty(), "Permissions", null));
-
-        Assert.Contains("Permissions", ex.Member, StringComparison.Ordinal);
-        Assert.Contains("backing field", ex.Detail, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public void SetBackingField_StillPokes_WhenTheBackingFieldIsPresent()
-    {
-        var target = new HasAutoProperty();
-        Invoke("SetBackingField", typeof(HasAutoProperty), target, nameof(HasAutoProperty.Name), "SECURITY");
-        Assert.Equal("SECURITY", target.Name);
-    }
-
-    // ══ 3. SetEmptyListBackingField — the property whose element type it reads ════════════
-
-    [Fact]
-    public void SetEmptyListBackingField_RaisesAShapeGapNamingTheProperty_WhenItIsGone()
-    {
-        var ex = Assert.Throws<BcShapeGapException>(
-            () => Invoke("SetEmptyListBackingField", typeof(HasNoSuchProperty), new HasNoSuchProperty(), "IncludedPermissionSets"));
-
-        Assert.Contains("IncludedPermissionSets", ex.Member, StringComparison.Ordinal);
-    }
-
-    [Fact]
-    public void SetEmptyListBackingField_StillInstallsAnEmptyList_WhenThePropertyIsPresent()
-    {
-        var target = new HasListProperty();
-        Invoke("SetEmptyListBackingField", typeof(HasListProperty), target, nameof(HasListProperty.Items));
-
-        Assert.NotNull(target.Items);
-        Assert.Empty(target.Items!);
-    }
-
-    // ══ 4. BuildIncludeList — BC's include/exclude element type is one it cannot fill ═════
+    // ══ 2. BuildIncludeList — BC's include/exclude element type is one it cannot fill ═════
 
     [Fact]
     public void BuildIncludeList_RaisesAShapeGapNamingTheElementType_WhenItCannotBeFilled()
@@ -129,7 +94,7 @@ public sealed class PermissionMetadataShapeGapTests
         Assert.Equal("SECURITY", list[1]);
     }
 
-    // ══ 5. The sweep happened, and it stopped exactly where the judgement said ════════════
+    // ══ 3. The sweep happened, and it stopped exactly where the judgement said ════════════
     //
     // Pins BOTH directions. Under-conversion fails (a BC-internals read still raising the
     // retired type is not in the allowlist); over-conversion fails too (the five deliberate
@@ -194,7 +159,7 @@ public sealed class PermissionMetadataShapeGapTests
         "RecordPatches.PermissionMetadataPopulator.cs",
     };
 
-    // ══ 6. The three factories, and what AL can do with what they raise: nothing ══════════
+    // ══ 4. The three factories, and what AL can do with what they raise: nothing ══════════
 
     public static TheoryData<string, string> Factories() => new()
     {
@@ -318,11 +283,6 @@ public sealed class PermissionMetadataShapeGapTests
     private sealed class HasAutoProperty
     {
         public string? Name { get; set; }
-    }
-
-    private sealed class HasListProperty
-    {
-        public List<string>? Items { get; set; }
     }
 
     private sealed class NotFillableElement

--- a/AlRunner.Tests/ReflectionDrivenHelperLivenessTests.cs
+++ b/AlRunner.Tests/ReflectionDrivenHelperLivenessTests.cs
@@ -1,0 +1,245 @@
+// ReflectionDrivenHelperLivenessTests — issue #3100.
+//
+// THE FAILURE MODE THIS EXISTS TO CATCH
+//   A test that reaches a private production helper through reflection cannot tell whether
+//   production code reaches it too. PermissionMetadataShapeGapTests drives four helpers on
+//   RecordPatches by name — real production code, no BC install required, which is exactly why
+//   the idiom is used — and two of them (SetBackingField, SetEmptyListBackingField) had no
+//   production caller at all. They were superseded inside PR #2921 itself: commit 793ab838 poked
+//   NCLMetaPermissionSet's backing fields by hand, commit 75630e98 replaced that with BC's own
+//   AssignFromMetaPermissionSet and removed the call sites but not the helpers. Squash-merge hid
+//   the intermediate state, so `git log -S` showed one hit and the pair read as freshly landed.
+//   Their four arms passed the whole time, because a reflection call site IS a call site as far
+//   as the test is concerned.
+//
+// HOW LIVENESS IS MEASURED
+//   From IL, not from grep. Every method declared on RecordPatches (and its nested types, which
+//   is where lambdas compile to) is decoded with the real opcode table, and every call /
+//   callvirt / newobj / ldftn / ldvirtftn / jmp token is resolved back to a method. Reachability
+//   is then a BFS from the methods production code outside this partial class can actually enter
+//   through — anything not `private` — plus every nested-type method, which is the conservative
+//   direction: it can only ever call a dead helper ALIVE, never a live one dead.
+//
+//   A grep would have counted the declaration line, the doc comment, and the dead helper's own
+//   call to SetBackingField as evidence of life. All three are exactly what was wrong.
+//
+//   IL alone is not enough in the other direction either: production enters some members BY NAME
+//   rather than by a call. RecordPatches.QueryJoin.cs binds twelve adapters through
+//   Delegate.CreateDelegate over nameof(...), which compiles to a ldstr and NOT a ldftn, so a
+//   pure call graph calls Join_OutOfScope dead when it is live on every query-join refusal —
+//   measured, it was this guard's only false positive across the whole test suite. A member
+//   PRODUCTION names as a literal is therefore a root too. That is the same blind spot
+//   CLAUDE.md records for hooks: an orphaned registration and a live one look identical
+//   statically, so the analysis has to be conservative wherever a name is the entry point.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Text.RegularExpressions;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ReflectionDrivenHelperLivenessTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+
+    [Fact]
+    public void EveryRecordPatchesHelperDrivenByReflectionFromTests_IsReachableFromProductionCode()
+    {
+        var target = typeof(RecordPatches);
+        var byName = DeclaredMethods(target)
+            .GroupBy(m => m.Name, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.ToList(), StringComparer.Ordinal);
+
+        // Every test in the suite, not just the file #3100 came from: a member driven by name
+        // is invisible to the compiler wherever it is driven from.
+        var testDir = Path.Combine(RepoRoot, "AlRunner.Tests");
+        Assert.True(Directory.Exists(testDir), $"AlRunner.Tests not found at {testDir}.");
+
+        var exercised = new SortedSet<string>(StringComparer.Ordinal);
+        var whereNamed = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var file in Directory.GetFiles(testDir, "*.cs", SearchOption.AllDirectories))
+            foreach (var name in MemberNamesQuotedIn(file, byName.Keys))
+                if (exercised.Add(name)) whereNamed[name] = Path.GetFileName(file);
+
+        // Anti-vacuity: an extraction that found nothing would make the offender list empty for
+        // the wrong reason.
+        Assert.True(exercised.Count >= 5,
+            "no RecordPatches member names were found quoted anywhere in AlRunner.Tests — the "
+            + "scan stopped working, it did not find a clean suite. Found: "
+            + (exercised.Count == 0 ? "(none)" : string.Join(", ", exercised)));
+
+        var reachable = ReachableFromOutsideThePartialClass(target, NamedByProductionSource(byName.Keys));
+
+        var dead = exercised
+            .Where(n => byName[n].All(m => !reachable.Contains(m.MetadataToken)))
+            .ToList();
+
+        Assert.True(dead.Count == 0,
+            "these RecordPatches members are driven by a test through reflection but are not "
+            + "reachable from any production entry point, so their arms prove nothing about a "
+            + "live path (#3100): "
+            + string.Join(", ", dead.Select(n => $"{n} (named in {whereNamed[n]})")) + Environment.NewLine
+            + "Either wire the member — the fix is then the missing call site, proved by a test "
+            + "of the behaviour that call site produces — or delete it together with its arms.");
+
+        // Anti-vacuity, the other direction: the analysis must be able to say ALIVE, or an
+        // implementation that marked everything reachable would pass this test unchanged.
+        Assert.Contains("SetProperty", exercised);
+        Assert.True(byName["SetProperty"].Any(m => reachable.Contains(m.MetadataToken)),
+            "SetProperty is called from BuildMetaPermissionSet on the live populate path, so a "
+            + "liveness analysis that cannot see it is broken rather than strict.");
+    }
+
+    // ── liveness ─────────────────────────────────────────────────────────────────────────
+
+    private static IEnumerable<MethodInfo> DeclaredMethods(Type t) => t.GetMethods(
+        BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic
+        | BindingFlags.DeclaredOnly);
+
+    private static IEnumerable<MethodBase> DeclaredMethodsAndCtors(Type t)
+    {
+        const BindingFlags All = BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public
+                                 | BindingFlags.NonPublic | BindingFlags.DeclaredOnly;
+        foreach (var m in t.GetMethods(All)) yield return m;
+        foreach (var c in t.GetConstructors(All)) yield return c;
+    }
+
+    private static HashSet<int> ReachableFromOutsideThePartialClass(Type target, ISet<string> namedByProduction)
+    {
+        var universe = new Dictionary<int, MethodBase>();
+        foreach (var m in DeclaredMethodsAndCtors(target)) universe[m.MetadataToken] = m;
+        foreach (var nested in target.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic))
+            foreach (var m in DeclaredMethodsAndCtors(nested)) universe[m.MetadataToken] = m;
+
+        var seen = new HashSet<int>();
+        var queue = new Queue<MethodBase>();
+        foreach (var m in universe.Values)
+        {
+            // Roots: anything outside this partial class could call — plus every nested-type
+            // method, since a lambda body's caller is the compiler, not a name we can follow —
+            // plus anything production names as a literal, which is how the QueryJoin adapters
+            // and the Cecil-installed patches are entered.
+            var isRoot = m.DeclaringType != target || !m.IsPrivate || namedByProduction.Contains(m.Name);
+            if (isRoot && seen.Add(m.MetadataToken)) queue.Enqueue(m);
+        }
+
+        while (queue.Count > 0)
+            foreach (var callee in CalleeTokensOf(queue.Dequeue()))
+                if (universe.TryGetValue(callee, out var next) && seen.Add(callee)) queue.Enqueue(next);
+
+        return seen;
+    }
+
+    private static IEnumerable<int> CalleeTokensOf(MethodBase method)
+    {
+        byte[]? il;
+        try { il = method.GetMethodBody()?.GetILAsByteArray(); }
+        catch (Exception) { il = null; }
+        if (il == null) yield break;
+
+        var module = method.Module;
+        var typeArgs = method.DeclaringType is { IsGenericType: true } dt ? dt.GetGenericArguments() : null;
+        var methodArgs = method.IsGenericMethodDefinition ? method.GetGenericArguments() : null;
+
+        var pos = 0;
+        while (pos < il.Length)
+        {
+            short value = il[pos++];
+            if (value == 0xFE)
+            {
+                if (pos >= il.Length) yield break;
+                value = (short)(0xFE00 | il[pos++]);
+            }
+            if (!OpCodesByValue.TryGetValue(value, out var op)) yield break;   // refuse to guess
+
+            var operandSize = OperandSize(op.OperandType, il, pos);
+            if (operandSize < 0 || pos + operandSize > il.Length) yield break;
+
+            if (IsCallLike(op) && operandSize == 4)
+            {
+                var token = BitConverter.ToInt32(il, pos);
+                MethodBase? callee = null;
+                try { callee = module.ResolveMethod(token, typeArgs, methodArgs); }
+                catch (Exception) { /* not a methoddef/ref we can follow */ }
+                if (callee != null)
+                {
+                    var def = callee is MethodInfo { IsGenericMethod: true } mi
+                        ? mi.GetGenericMethodDefinition()
+                        : callee;
+                    yield return def.MetadataToken;
+                }
+            }
+
+            pos += operandSize;
+        }
+    }
+
+    private static bool IsCallLike(OpCode op) =>
+        op == OpCodes.Call || op == OpCodes.Callvirt || op == OpCodes.Newobj
+        || op == OpCodes.Ldftn || op == OpCodes.Ldvirtftn || op == OpCodes.Jmp;
+
+    private static int OperandSize(OperandType t, byte[] il, int pos) => t switch
+    {
+        OperandType.InlineNone => 0,
+        OperandType.ShortInlineBrTarget or OperandType.ShortInlineI or OperandType.ShortInlineVar => 1,
+        OperandType.InlineVar => 2,
+        OperandType.InlineBrTarget or OperandType.InlineField or OperandType.InlineI
+            or OperandType.InlineMethod or OperandType.InlineSig or OperandType.InlineString
+            or OperandType.InlineTok or OperandType.InlineType or OperandType.ShortInlineR => 4,
+        OperandType.InlineI8 or OperandType.InlineR => 8,
+        OperandType.InlineSwitch => pos + 4 <= il.Length ? 4 + 4 * BitConverter.ToInt32(il, pos) : -1,
+        _ => -1,
+    };
+
+    private static readonly Dictionary<short, OpCode> OpCodesByValue = typeof(OpCodes)
+        .GetFields(BindingFlags.Public | BindingFlags.Static)
+        .Where(f => f.FieldType == typeof(OpCode))
+        .Select(f => (OpCode)f.GetValue(null)!)
+        .GroupBy(o => o.Value)
+        .ToDictionary(g => g.Key, g => g.First());
+
+    // ── what a test file names ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Member names production itself spells out — <c>nameof(X)</c> (which compiles to a plain
+    /// string, leaving no call edge) or a quoted <c>"X"</c> handed to a reflection lookup. Every
+    /// one is an entry point a call graph cannot see, so every one is a root.
+    /// </summary>
+    private static HashSet<string> NamedByProductionSource(IEnumerable<string> candidates)
+    {
+        var known = new HashSet<string>(candidates, StringComparer.Ordinal);
+        var named = new HashSet<string>(StringComparer.Ordinal);
+        var root = Path.Combine(RepoRoot, "AlRunner");
+        Assert.True(Directory.Exists(root), $"AlRunner sources not found at {root}.");
+
+        foreach (var file in Directory.GetFiles(root, "*.cs", SearchOption.AllDirectories))
+        {
+            var src = File.ReadAllText(file);
+            foreach (Match m in Regex.Matches(src, "\"([A-Za-z_][A-Za-z0-9_]*)\""))
+                if (known.Contains(m.Groups[1].Value)) named.Add(m.Groups[1].Value);
+            foreach (Match m in Regex.Matches(src, @"\bnameof\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)"))
+                if (known.Contains(m.Groups[1].Value)) named.Add(m.Groups[1].Value);
+        }
+        return named;
+    }
+
+    /// <summary>
+    /// Member names of <paramref name="candidates"/> that appear as string LITERALS in the test
+    /// source — the only way a test can name a private member. Prose in a comment does not
+    /// count, which matters: the file's own banner lists all four helpers by name.
+    /// </summary>
+    private static IEnumerable<string> MemberNamesQuotedIn(string path, IEnumerable<string> candidates)
+    {
+        var known = new HashSet<string>(candidates, StringComparer.Ordinal);
+        var src = File.ReadAllText(path);
+        foreach (Match m in Regex.Matches(src, "\"([A-Za-z_][A-Za-z0-9_]*)\""))
+            if (known.Contains(m.Groups[1].Value)) yield return m.Groups[1].Value;
+    }
+}

--- a/AlRunner.Tests/ReflectionDrivenHelperLivenessTests.cs
+++ b/AlRunner.Tests/ReflectionDrivenHelperLivenessTests.cs
@@ -208,6 +208,21 @@ public sealed class ReflectionDrivenHelperLivenessTests
     // ── what a test file names ───────────────────────────────────────────────────────────
 
     /// <summary>
+    /// The source of a file with whole-line comments removed. A doc comment is prose, and prose
+    /// must not vote: <c>&lt;see cref="SetProperty"/&gt;</c> looks exactly like a quoted member
+    /// name to a regex, and counting it would have made this guard's liveness root set — and its
+    /// own anti-vacuity control — satisfiable by a sentence about the code.
+    /// </summary>
+    private static string CodeLinesOf(string path) => string.Join(Environment.NewLine,
+        File.ReadAllLines(path).Where(l =>
+        {
+            var t = l.TrimStart();
+            return !t.StartsWith("//", StringComparison.Ordinal)
+                   && !t.StartsWith("/*", StringComparison.Ordinal)
+                   && !t.StartsWith("*", StringComparison.Ordinal);
+        }));
+
+    /// <summary>
     /// Member names production itself spells out — <c>nameof(X)</c> (which compiles to a plain
     /// string, leaving no call edge) or a quoted <c>"X"</c> handed to a reflection lookup. Every
     /// one is an entry point a call graph cannot see, so every one is a root.
@@ -221,7 +236,7 @@ public sealed class ReflectionDrivenHelperLivenessTests
 
         foreach (var file in Directory.GetFiles(root, "*.cs", SearchOption.AllDirectories))
         {
-            var src = File.ReadAllText(file);
+            var src = CodeLinesOf(file);
             foreach (Match m in Regex.Matches(src, "\"([A-Za-z_][A-Za-z0-9_]*)\""))
                 if (known.Contains(m.Groups[1].Value)) named.Add(m.Groups[1].Value);
             foreach (Match m in Regex.Matches(src, @"\bnameof\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)"))
@@ -238,8 +253,7 @@ public sealed class ReflectionDrivenHelperLivenessTests
     private static IEnumerable<string> MemberNamesQuotedIn(string path, IEnumerable<string> candidates)
     {
         var known = new HashSet<string>(candidates, StringComparer.Ordinal);
-        var src = File.ReadAllText(path);
-        foreach (Match m in Regex.Matches(src, "\"([A-Za-z_][A-Za-z0-9_]*)\""))
+        foreach (Match m in Regex.Matches(CodeLinesOf(path), "\"([A-Za-z_][A-Za-z0-9_]*)\""))
             if (known.Contains(m.Groups[1].Value)) yield return m.Groups[1].Value;
     }
 }

--- a/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
@@ -473,26 +473,6 @@ public static partial class RecordPatches
         return meta;
     }
 
-    private static void SetBackingField(Type declaring, object target, string propertyName, object? value)
-    {
-        var f = declaring.GetField($"<{propertyName}>k__BackingField",
-            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
-            ?? throw PermissionMetadataBcShapeGap(
-                $"NCLMetaPermissionSet.{propertyName}",
-                "has no backing field — BC's permission-set metadata inventory cannot be populated");
-        FieldPoke.SetInstance(f, target, value);
-    }
-
-    private static void SetEmptyListBackingField(Type declaring, object target, string propertyName)
-    {
-        var prop = RequireBcProperty(declaring, propertyName);
-        var element = prop.PropertyType.IsGenericType
-            ? prop.PropertyType.GetGenericArguments()[0]
-            : typeof(object);
-        SetBackingField(declaring, target, propertyName,
-            Activator.CreateInstance(typeof(List<>).MakeGenericType(element)));
-    }
-
     // ── source-declared permissions: names in, ids out (#2910) ──────────────────────────
 
     /// <summary>


### PR DESCRIPTION
Closes #3100

## Direction: DELETE, and the evidence is a bisect, not a reading

`SetEmptyListBackingField` and `SetBackingField` were **superseded before they shipped**, inside PR #2921 itself. The two commits that settle it:

| commit (PR #2921) | `BuildNclMetaPermissionSet` |
|---|---|
| `793ab838` | calls `SetBackingField` x2 and `SetEmptyListBackingField` x3 |
| `75630e98` | calls neither — BC's own `AssignFromMetaPermissionSet` fills the instance |

`75630e98` removed the call sites and left the helper bodies behind. The PR was squash-merged as `23f35707`, so the intermediate state is invisible in `main`'s history and `git log -S` reports one hit — which is why #3100 read this as "dead since it landed" rather than "orphaned later". Both readings point the same way: **nothing needs them**, and wiring them back would undo #2910, whose whole point is stated at the surviving call site — "poking the backing fields by hand could only ever fill the ones somebody remembered; this way every field BC sets is set, by BC."

So: both helpers deleted, and the four arms over them deleted with them.

## Wider than the issue: `SetBackingField` is dead too

#3100 names one helper. `SetBackingField` is equally dead — its only caller was `SetEmptyListBackingField`. A grep finds it "called" and is wrong; that call site is inside the dead code. Deleting one and keeping the other would have left the same defect in place under a different name.

Also checked, and both alive, so both arms stay: `SetProperty` (called from `BuildMetaPermissionSet` on the live populate path) and `BuildIncludeList` (called twice from the same method). The three `*BcShapeGap` factories are `internal` and called from all three slice files.

## Why the two tests passed against dead code

They call the helper **directly, by reflected name** — `Invoke("SetEmptyListBackingField", ...)` through `typeof(RecordPatches).GetMethod(name, NonPublic | Static)` — with a hand-made fake standing in for the BC type. No production path is involved at any point. A reflection call site is a call site as far as the test can tell, and nothing else objects either: C# emits no warning for an unreferenced private method, and the knowledge graph maps static structure, where an orphaned member and a live one look identical.

That is the "test agrees with itself" failure mode, and it generalises: the idiom of driving a private helper by name is used deliberately across this suite, precisely because it runs real production code without a BC install. It buys that at the cost of not being able to see whether production still reaches the code.

## So the shape is guarded, not just the instance

`AlRunner.Tests/ReflectionDrivenHelperLivenessTests.cs` measures liveness from IL:

* decodes every method on `RecordPatches` and its nested types with the real opcode table (built from `System.Reflection.Emit.OpCodes`, so operands are never misread as opcodes), resolving every `call` / `callvirt` / `newobj` / `ldftn` / `ldvirtftn` / `jmp` token;
* BFS from what production can actually enter: anything not `private`, plus every nested-type method (lambdas — conservative, can only ever call a dead helper alive);
* **plus anything production names as a literal.** `RecordPatches.QueryJoin.cs` binds twelve adapters via `Delegate.CreateDelegate` over `nameof(...)`, which compiles to `ldstr` and leaves no call edge. `Join_OutOfScope` was this guard's only false positive across the entire suite, and it is live on every query-join refusal. Same blind spot `CLAUDE.md` records for hooks: statically, an orphaned registration and a live one are identical;
* scans **every** file in `AlRunner.Tests`, not just the one #3100 came from;
* reads **code lines only**. A second commit fixes this: `<see cref="SetProperty"/>` is indistinguishable from a quoted member name to a regex, and counting prose would have made the guard's own anti-vacuity control satisfiable by a sentence about the code.

Two anti-vacuity assertions in both directions: the extraction must find members (or an empty offender list means the scan broke), and `SetProperty` must come back **reachable** (or an analysis that marked everything alive would pass unchanged).

## RED → GREEN

* **RED**, before any deletion: `SetBackingField, SetEmptyListBackingField`. Not flagged in the same run: `SetProperty`, `BuildIncludeList`, the three factories — so the analysis discriminates rather than accusing everything.
* **RED re-verified against the final guard** (comment stripping and suite-wide scan in place), by restoring one helper and one arm: `SetEmptyListBackingField (named in PermissionMetadataShapeGapTests.cs)`.
* **GREEN**: `dotnet test AlRunner.Tests --filter "…ReflectionDrivenHelperLivenessTests|…PermissionMetadata|…RunnerShapeGapClaimTests|…BcShapeGapConventionTests"` — 161 passed, 0 failed. An earlier run also covering `AggregatePermission` and `QueryJoin` — 166 passed, 0 failed.

## Does anything observable change?

No. The deleted methods were `private static` with zero production callers, proved by IL reachability rather than by grep, and nothing else in the tree names them. `RequireBcProperty` and `FieldPoke.SetInstance`, their only callees, keep other live callers. Nothing in the deleted code raised `InvalidOperationException`, so the slice's `Assert.Equal(5, survivors)` sweep is untouched — verified by running it.

## Does this assert anything about BC?

No. `bc-behavior-tests-go-upstream.md` asks whether the test would still be a meaningful statement about AL/BC if the runner did not exist. It would not: the claim is "a private C# helper in this repo is reachable from production code in this repo." There is no AL surface, no service-tier-observable behaviour, and no change to what AL code observes — the removed code was never executed. Nothing to send to the corpus.

## Deliberately left out

74 files in `AlRunner.Tests` use `BindingFlags.NonPublic`. This guard covers `RecordPatches` — the type #3100 is about — across all of them, and comes back clean apart from what is fixed here. Extending it to other production types needs a per-type target list and a per-finding judgement (wire vs delete), which is a different change; the machinery is in one file and takes a type, so it is a small edit when someone wants it.

---
*Written by an agent (`stma-auto-1`, autonomous cycle 137) acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE