### PR TITLE
ci(expectations): flag a PR that closes a gap issue while its known-gap entry survives

### DIFF
--- a/.github/scripts/check_expectation_gap_issues.py
+++ b/.github/scripts/check_expectation_gap_issues.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""A PR that closes a gap issue may not leave the known-gap entry declaring it (#3089).
+
+`tests/expectations/known-gaps-*.json` entries are `expect-fail-known-gap`: the
+surface is in scope, real BC does it, the runner does not yet, and `Issue` links
+the open work. The manifest is deliberately loud in BOTH directions at RUN time
+-- a test that passes while an entry declares a known gap fails the run with
+"Test passed cleanly but manifest declares expect-fail-known-gap ... Remove the
+entry", and a test that fails without an entry fails with "add an entry".
+
+That machinery works. What nothing checked is the moment the two get out of
+step: a PR fixes the gap, closes the issue, and forgets to delete the entry.
+Nothing in the PR is wrong on its own, so it merges green -- and the NEXT run of
+`main` is red, on a commit whose author has moved on. This broke `main` twice in
+one hour on 2026-09-05:
+
+  | issue | closed by | entry left behind in                        |
+  |-------|-----------|---------------------------------------------|
+  | #2795 | PR #2809  | known-gaps-testpage-boolean-spelling.json    |
+  | #2805 | PR #2825  | known-gaps-start-session-isolation.json (x2) |
+
+Reported as #2844 / #2858 and fixed by deleting the entries (#2845, #2859).
+#2858 diagnosed the mechanism and closed without a guard.
+
+WHAT THIS CHECKS, AND WHAT IT DELIBERATELY DOES NOT
+---------------------------------------------------
+
+Blocking (this script's default mode, and it needs NO network):
+
+    If this PR closes issue N, and an expect-fail-known-gap entry links issue N,
+    fail.
+
+That is not a heuristic. The PR asserts the gap is fixed; the manifest asserts
+it is not. Exactly one of them is right, they are in the same diff, and the
+author is the person who can settle it -- by deleting the entry, by re-targeting
+it at the issue that actually tracks the remaining work, or by dropping the
+closing reference. Both incidents above are exactly this shape and would have
+been caught before merge.
+
+NOT blocking, and on purpose (`--report-closed-issues`):
+
+    An entry linking an issue that is already closed, in a PR that has nothing
+    to do with it.
+
+#2858 makes the point that constrains this: a closed issue does not by itself
+prove the entry is stale. An issue can be closed as a duplicate, or closed while
+the gap remains. Six entries pointed at closed issues at the time and only one
+was actually failing. So that direction is a lead worth surfacing as a warning
+annotation, never a verdict worth failing a build on -- and it is the only half
+that touches the network, which is the other reason it does not gate.
+
+A CHECK THAT CANNOT CHECK MUST NOT REPORT A PASS
+------------------------------------------------
+
+Every way this could quietly become decoration exits 2 instead of 0: a manifest
+directory that is not there, a file that will not parse, an entry whose `Issue`
+cannot be resolved to a real issue, a `known-gaps-*.json` holding entries that
+are not known gaps (a prefix/Mode disagreement would silence the whole file),
+and a run where the PR title, body and commit messages are all empty (which
+means the fetch failed -- every PR has a title and at least one commit). A
+passing run prints how many entries it actually scanned, so a green tick is
+never mute about its scope.
+
+Inputs (environment variables, all optional individually, but not all-empty):
+  PR_TITLE   - the pull request's title
+  PR_BODY    - the pull request's body
+  PR_COMMITS - every commit message on the branch, concatenated. This repo's
+               squash setting is squash_merge_commit_message=COMMIT_MESSAGES, so
+               a closing keyword in a commit message closes the issue even
+               though it never appears in the PR body (#2491).
+  GITHUB_REPOSITORY - owner/repo that a bare "#N" resolves against.
+
+Usage:
+  check_expectation_gap_issues.py [MANIFEST_DIR] [--report-closed-issues]
+
+Exit codes:
+  0  no entry links an issue this PR closes (or, in report mode, always)
+  1  an entry links an issue this PR closes -- delete or re-target it
+  2  the check could not be performed; see the ::error:: line
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+DEFAULT_MANIFEST_DIR = os.path.join(REPO_ROOT, "tests", "expectations")
+DEFAULT_REPO = "StefanMaron/BusinessCentral.AL.Runner"
+
+# --------------------------------------------------------------------------
+# Closing references. These three constants are kept byte-identical to
+# tools/pr-body.py's (themselves a port of check_closing_reference.sh), and
+# test_check_expectation_gap_issues.py asserts that parity -- three copies of a
+# parse that silently disagree is how a guard ends up checking a different set
+# of issues from the one GitHub will actually close.
+# --------------------------------------------------------------------------
+
+KEYWORDS = "close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved"
+# "#N" (the "#" is REQUIRED -- "fixes 3 bugs" is prose, and treating a bare number
+# as a reference is a false positive that shipped once already), "owner/repo#N",
+# or a full issue/PR URL. Deliberately NOT "GH-N": that only becomes live with a
+# configured autolink, and this repo has none.
+REF_HASH = r"(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#[0-9]+"
+REF_URL = r"https?://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/(?:issues|pull)/[0-9]+"
+REF = f"(?:{REF_HASH}|{REF_URL})"
+
+# Unlike check_closing_reference.sh, this scan does NOT distinguish a canonical
+# trailer line from a stray inline reference. That distinction is about where the
+# author DECLARED intent, which is that script's business. This one only cares
+# what GitHub will actually close on merge, and GitHub closes both.
+CLOSING_RE = re.compile(rf"\b(?:{KEYWORDS})[ \t]+(?P<ref>{REF})", re.I)
+
+_URL_RE = re.compile(
+    r"^https?://github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+)/(?:issues|pull)/([0-9]+)$",
+    re.I)
+_HASH_RE = re.compile(r"^(?:([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+))?#([0-9]+)$")
+
+
+class ManifestError(Exception):
+    """The manifest could not be read well enough for the check to mean anything."""
+
+
+def _parse_ref(ref: str, default_owner: str, default_repo: str
+               ) -> tuple[str, str, int] | None:
+    """(owner, repo, number) for "#N", "owner/repo#N" or a full issue/PR URL."""
+    ref = ref.strip()
+    m = _URL_RE.match(ref)
+    if m:
+        return m.group(1), m.group(2), int(m.group(3))
+    m = _HASH_RE.match(ref)
+    if m:
+        return (m.group(1) or default_owner), (m.group(2) or default_repo), int(m.group(3))
+    return None
+
+
+def default_owner_repo() -> tuple[str, str]:
+    slug = os.environ.get("GITHUB_REPOSITORY") or DEFAULT_REPO
+    owner, _, repo = slug.partition("/")
+    return owner, repo
+
+
+def closing_references(text: str, source: str
+                       ) -> list[tuple[tuple[str, str, int], str, str]]:
+    """Every ((owner, repo, number), source, line) GitHub would close from `text`."""
+    owner, repo = default_owner_repo()
+    found: list[tuple[tuple[str, str, int], str, str]] = []
+    for line in (text or "").split("\n"):
+        for m in CLOSING_RE.finditer(line):
+            triple = _parse_ref(m.group("ref"), owner, repo)
+            if triple is not None:
+                found.append((triple, source, line.strip()))
+    return found
+
+
+# --------------------------------------------------------------------------
+# The manifest
+# --------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class GapEntry:
+    source_file: str
+    codeunit: str
+    method: str
+    issue: str
+    owner: str
+    repo: str
+    number: int
+
+    @property
+    def key(self) -> tuple[str, str, int]:
+        # GitHub owner/repo names are case-insensitive; issue numbers are not names.
+        return (self.owner.lower(), self.repo.lower(), self.number)
+
+
+def load_known_gap_entries(manifest_dir: str) -> list[GapEntry]:
+    """Every expect-fail-known-gap entry under `manifest_dir` (non-recursive).
+
+    Raises ManifestError rather than returning a short list: a guard that
+    silently reads fewer entries than the manifest holds is worse than no guard,
+    because it looks like coverage.
+    """
+    if not os.path.isdir(manifest_dir):
+        raise ManifestError(
+            f"expectation manifest directory '{manifest_dir}' does not exist. That is a "
+            "broken checkout or a wrong path, not an empty manifest -- refusing to report "
+            "a pass without having read anything.")
+
+    entries: list[GapEntry] = []
+    for name in sorted(f for f in os.listdir(manifest_dir) if f.endswith(".json")):
+        path = os.path.join(manifest_dir, name)
+        if not os.path.isfile(path):
+            continue
+        try:
+            with open(path, encoding="utf-8") as fh:
+                doc = json.load(fh)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ManifestError(
+                f"{name}: could not be read as JSON ({exc}). The runner's own loader aborts "
+                "on a malformed expectation file, and so does this check.") from exc
+        if not isinstance(doc, list):
+            raise ManifestError(
+                f"{name}: top level must be a JSON array of expectation objects "
+                f"(got {type(doc).__name__}).")
+
+        in_file = 0
+        for i, raw in enumerate(doc):
+            if not isinstance(raw, dict):
+                raise ManifestError(f"{name}: entry {i} is not a JSON object.")
+            if (raw.get("Mode") or "") != "expect-fail-known-gap":
+                continue
+            in_file += 1
+            cu = str(raw.get("CodeunitName") or "?")
+            method = str(raw.get("Method") or "?")
+            issue = raw.get("Issue")
+            if not isinstance(issue, str) or not issue.strip():
+                raise ManifestError(
+                    f"{name}: expect-fail-known-gap entry {cu}.{method} has no 'Issue'. That "
+                    "mode means 'real BC does this, the runner does not yet, and Issue tracks "
+                    "the work' -- without the link there is nothing for this check to compare "
+                    "against, and nothing tracking the gap.")
+            triple = _parse_ref(issue, *default_owner_repo())
+            if triple is None:
+                raise ManifestError(
+                    f"{name}: expect-fail-known-gap entry {cu}.{method} has Issue '{issue}', "
+                    "which is not a resolvable GitHub issue reference (expected a full "
+                    ".../issues/N URL, or owner/repo#N).")
+            entries.append(GapEntry(name, cu, method, issue.strip(), *triple))
+
+        if in_file == 0 and len(doc) > 0 and name.startswith("known-gaps-"):
+            raise ManifestError(
+                f"{name}: the file name says known-gaps but not one of its {len(doc)} "
+                "entries is expect-fail-known-gap. tests/expectations/README.md requires the "
+                "file prefix and the entry Mode to agree, and a disagreement silences this "
+                "whole file for the check below -- which is the failure mode the check exists "
+                "to prevent. Move the entries into the file matching their Mode.")
+
+    return entries
+
+
+# --------------------------------------------------------------------------
+# The non-blocking sweep -- the only part that touches the network
+# --------------------------------------------------------------------------
+
+def issue_state(owner: str, repo: str, number: int) -> str | None:
+    """'open' / 'closed', or None when the state could not be determined.
+
+    None is never treated as evidence of anything: the caller says out loud that
+    it could not check, and does not change its verdict either way.
+    """
+    try:
+        proc = subprocess.run(
+            ["gh", "api", f"repos/{owner}/{repo}/issues/{number}", "--jq", ".state"],
+            capture_output=True, text=True, timeout=30)
+        if proc.returncode == 0 and proc.stdout.strip() in ("open", "closed"):
+            return proc.stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{owner}/{repo}/issues/{number}",
+        headers={"Accept": "application/vnd.github+json",
+                 "User-Agent": "check_expectation_gap_issues"})
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            state = json.load(resp).get("state")
+            return state if state in ("open", "closed") else None
+    except (urllib.error.URLError, OSError, ValueError, json.JSONDecodeError):
+        return None
+
+
+def report_closed_issues(entries: list[GapEntry]) -> int:
+    """Warn about entries linking an already-closed issue. NEVER fails the job."""
+    if not entries:
+        print("No expect-fail-known-gap entries in the manifest -- nothing to sweep.")
+        return 0
+
+    by_issue: dict[tuple[str, str, int], list[GapEntry]] = {}
+    for e in entries:
+        by_issue.setdefault(e.key, []).append(e)
+
+    closed = unresolved = 0
+    for key in sorted(by_issue):
+        group = by_issue[key]
+        owner, repo, number = group[0].owner, group[0].repo, group[0].number
+        state = issue_state(owner, repo, number)
+        where = ", ".join(sorted({f"{e.source_file} ({e.codeunit}.{e.method})" for e in group}))
+        if state is None:
+            unresolved += 1
+            print(f"::warning::Could not determine the state of {owner}/{repo}#{number}, so "
+                  f"the stale-entry sweep did NOT run for it. Entries: {where}. This half of "
+                  "the check is advisory and never fails the job -- but an unreachable API is "
+                  "not a clean bill of health either, so it says so rather than staying quiet.")
+        elif state == "closed":
+            closed += 1
+            print(f"::warning::{owner}/{repo}#{number} is CLOSED, but {len(group)} "
+                  f"expect-fail-known-gap entr{'y' if len(group) == 1 else 'ies'} still link "
+                  f"it: {where}. A closed issue does not by itself prove the entry is stale "
+                  "(#2858: it may have closed as a duplicate, or with the gap still open), so "
+                  "this is a lead and not a verdict -- check whether the test now passes, then "
+                  "either delete the entry or re-target it at the issue tracking what remains.")
+
+    print(f"Swept {len(by_issue)} linked issue(s) across {len(entries)} entr"
+          f"{'y' if len(entries) == 1 else 'ies'}: {closed} closed, {unresolved} unresolved.")
+    return 0
+
+
+# --------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    report = "--report-closed-issues" in args
+    positional = [a for a in args if not a.startswith("-")]
+    manifest_dir = positional[0] if positional else DEFAULT_MANIFEST_DIR
+
+    try:
+        entries = load_known_gap_entries(manifest_dir)
+    except ManifestError as exc:
+        print(f"::error::{exc}", file=sys.stderr)
+        return 2
+
+    if report:
+        return report_closed_issues(entries)
+
+    title = os.environ.get("PR_TITLE", "")
+    body = os.environ.get("PR_BODY", "")
+    commits = os.environ.get("PR_COMMITS", "")
+    if not (title + body + commits).strip():
+        print("::error::PR_TITLE, PR_BODY and PR_COMMITS are all empty. Every pull request has "
+              "a title and at least one commit, so this is a failure to fetch them, not a PR "
+              "with nothing in it -- refusing to report a pass without having read the text "
+              "whose closing references decide this check.", file=sys.stderr)
+        return 2
+
+    refs = (closing_references(body, "body")
+            + closing_references(title, "title")
+            + closing_references(commits, "commit message"))
+    closing: dict[tuple[str, str, int], tuple[str, str]] = {}
+    for triple, source, line in refs:
+        closing.setdefault((triple[0].lower(), triple[1].lower(), triple[2]), (source, line))
+
+    offenders = [(e, closing[e.key]) for e in entries if e.key in closing]
+
+    if offenders:
+        for entry, (source, line) in offenders:
+            print(
+                f"::error file=tests/expectations/{entry.source_file}::This PR closes "
+                f"{entry.owner}/{entry.repo}#{entry.number} (from the PR {source}: "
+                f"\"{line}\"), but tests/expectations/{entry.source_file} still declares "
+                f"expect-fail-known-gap for {entry.codeunit}.{entry.method} linking that same "
+                "issue. The PR says the gap is fixed and the manifest says it is not; exactly "
+                "one is right, and both are in this diff. Once this merges the manifest goes "
+                "loud in the other direction and the NEXT run of main fails with \"Test passed "
+                "cleanly but manifest declares expect-fail-known-gap ... Remove the entry\" -- "
+                "which is how main went red twice on 2026-09-05 (#2844, #2858). Settle it "
+                "here: delete the entry if this fix makes that test pass, re-target it at the "
+                "OPEN issue tracking whatever remains, or drop the closing reference if this "
+                "PR does not actually close the issue.",
+                file=sys.stderr)
+        one = len(offenders) == 1
+        print(f"::error::{len(offenders)} expect-fail-known-gap entr{'y' if one else 'ies'} "
+              f"link{'s' if one else ''} an issue this PR closes.", file=sys.stderr)
+        return 1
+
+    print(f"Checked {len(entries)} expect-fail-known-gap entr"
+          f"{'y' if len(entries) == 1 else 'ies'} in {manifest_dir} against "
+          f"{len(closing)} closing reference(s) declared by this PR: no overlap.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_expectation_gap_issues.py
+++ b/.github/scripts/check_expectation_gap_issues.py
@@ -76,13 +76,26 @@ it at the issue that actually tracks the remaining work, or by dropping the
 closing reference.
 
 "Blocking" here means the job goes red, not that the merge is refused. This job
-is not a required status check on `main` -- the ruleset requires only "All BC
-versions passed" and "Tests updated" -- so tools/ci-wait.py's is_required()
-answers False for it, auto-merge ignores it, and it cannot turn a ci-wait
-verdict red. It annotates, and a human reads the annotation. That is
-pre-existing and shared with the sibling closing-reference jobs in the same
-workflow; nothing in this script can change it, and making the job required is a
-separate decision for whoever owns the ruleset.
+is not a required status check on `main` yet, so tools/ci-wait.py's is_required()
+answers False for it, auto-merge ignores it, and it cannot turn a ci-wait verdict
+red. It annotates, and a human reads the annotation.
+
+That standing is NOT shared with the sibling jobs in this workflow, and an
+earlier revision of this docstring said it was, which had the argument exactly
+backwards. Measured against the live branch ruleset on 2026-09-06, `main`
+requires TEN contexts, not two -- "BC test matrix passed" (renamed from "All BC
+versions passed" by #3141), "Tests updated", and the eight pr-gate.yml jobs,
+among them "PR title/body must not contain a CI-skip directive" and "PR body
+closing references must be correct, both directions". Both of those DO gate. So
+once this lands, this job is the only job in pr-gate.yml that does not, which is
+an argument for promoting it rather than a precedent excusing it.
+
+That promotion is a ruleset edit, an administrator action, and deliberately not
+claimed here. The seam is PENDING_REQUIRED_CONTEXTS in
+.github/scripts/check_required_contexts.py: this context is listed there, so the
+guard analyses it exactly like a required one -- produced by a pull_request
+workflow, not cancellable on the head commit -- while the live drift comparison
+tolerates it in either state until the ruleset catches up.
 
 NOT blocking, and on purpose (`--report-closed-issues`):
 

--- a/.github/scripts/check_expectation_gap_issues.py
+++ b/.github/scripts/check_expectation_gap_issues.py
@@ -11,16 +11,55 @@ entry", and a test that fails without an entry fails with "add an entry".
 That machinery works. What nothing checked is the moment the two get out of
 step: a PR fixes the gap, closes the issue, and forgets to delete the entry.
 Nothing in the PR is wrong on its own, so it merges green -- and the NEXT run of
-`main` is red, on a commit whose author has moved on. This broke `main` twice in
-one hour on 2026-09-05:
+`main` is red, on a commit whose author has moved on. That happened twice in one
+hour on 2026-09-05: #2795 (closed by PR #2809) left an entry in
+known-gaps-testpage-boolean-spelling.json, and #2805 (closed by PR #2825) left
+two in known-gaps-start-session-isolation.json. Reported after the fact as #2844
+and #2858 and fixed by deleting the entries (#2845, #2859); #2858 diagnosed the
+mechanism and closed without a guard.
 
-  | issue | closed by | entry left behind in                        |
-  |-------|-----------|---------------------------------------------|
-  | #2795 | PR #2809  | known-gaps-testpage-boolean-spelling.json    |
-  | #2805 | PR #2825  | known-gaps-start-session-isolation.json (x2) |
+Those two are why the shape is known. They are NOT incidents this gate would
+have prevented -- see the next section, which says so with the measurements,
+because an earlier version of this file claimed otherwise.
 
-Reported as #2844 / #2858 and fixed by deleting the entries (#2845, #2859).
-#2858 diagnosed the mechanism and closed without a guard.
+THE TWO ORDERINGS, AND WHICH ONE THE GATE COVERS
+------------------------------------------------
+
+Manifest/issue drift arrives in one of two orders, and the blocking gate below
+covers exactly one of them.
+
+FORWARD -- the entry is already in the checkout when the closing PR is checked.
+The PR text and the manifest then contradict each other inside a single diff,
+and the gate is red before anyone merges. This is the ordering the gate exists
+for, and the ordinary one: an entry normally predates the fix that closes its
+issue.
+
+INVERSE -- the entry lands after the closing PR's own check has run. Nothing
+evaluated at that PR's check time can see an entry that is not there yet, so the
+gate cannot help. Only the non-gating sweep further down covers it, on some
+LATER PR, and only once the linked issue has actually closed.
+
+Both 2026-09-05 incidents were the inverse ordering. Measured, not reasoned:
+
+  - Both known-gaps files were created by PR #2808's merge at 16:56:43Z, and
+    #2808 closes nothing -- so it declared no closing reference for the gate to
+    compare its own new entries against.
+  - PR #2825 (closes #2805) merged at 16:48:28Z, eight minutes BEFORE the entry
+    existed anywhere.
+  - PR #2809 (closes #2795) had exactly one PR Check, created 16:29:20Z, 27
+    minutes before #2808 merged. `main`'s ruleset sets
+    strict_required_status_checks_policy=false, so the base moving underneath it
+    re-triggered nothing.
+  - Replaying each PR's real title, body and commit messages against the
+    manifest as it stood at its OWN check time (base 43d85ea6, which held 12
+    expect-fail-known-gap entries and neither of the two files) exits 0 for
+    both.
+  - The sweep would not have caught them that hour either: #2808's last PR Check
+    ran at 16:39:50Z, when #2795 and #2805 were both still open -- they closed
+    at 17:29:30Z and 16:48:29Z.
+
+So this gate is not credited with a prevented incident. It closes the forward
+ordering, which nothing checked before, and the sweep reports the inverse one.
 
 WHAT THIS CHECKS, AND WHAT IT DELIBERATELY DOES NOT
 ---------------------------------------------------
@@ -34,8 +73,16 @@ That is not a heuristic. The PR asserts the gap is fixed; the manifest asserts
 it is not. Exactly one of them is right, they are in the same diff, and the
 author is the person who can settle it -- by deleting the entry, by re-targeting
 it at the issue that actually tracks the remaining work, or by dropping the
-closing reference. Both incidents above are exactly this shape and would have
-been caught before merge.
+closing reference.
+
+"Blocking" here means the job goes red, not that the merge is refused. This job
+is not a required status check on `main` -- the ruleset requires only "All BC
+versions passed" and "Tests updated" -- so tools/ci-wait.py's is_required()
+answers False for it, auto-merge ignores it, and it cannot turn a ci-wait
+verdict red. It annotates, and a human reads the annotation. That is
+pre-existing and shared with the sibling closing-reference jobs in the same
+workflow; nothing in this script can change it, and making the job required is a
+separate decision for whoever owns the ruleset.
 
 NOT blocking, and on purpose (`--report-closed-issues`):
 

--- a/.github/scripts/check_required_contexts.py
+++ b/.github/scripts/check_required_contexts.py
@@ -177,24 +177,43 @@ DEFAULT_REQUIRED_CONTEXTS = [
 # is outstanding -- ci-wait.py reads the LIVE ruleset first and only falls back
 # to its built-in tuple when that read fails, loudly -- so the promotion is
 # tidying, not a race.
-# Empty, and that is the finished state, not an oversight: the `main` ruleset
-# requires all ten names in DEFAULT_REQUIRED_CONTEXTS above, so nothing is
-# waiting to be gated (#3199, measured 2026-09-06). Keeping the list empty is
-# what makes the live drift comparison in resolve_contexts() EXACT again --
-# every pending name is a name the comparison deliberately tolerates in either
-# state, so a non-empty list is a hole in the #2785 check for as long as it
-# lasts. Refill it only while a new gating job is landing, and empty it in the
-# same pass that adds the name to the ruleset.
-# Refilled for #3255: pr-gate.yml's require-corpus-linkage job produces this
-# context, and the `main` ruleset does not require it yet. It is analysed here
-# exactly like a required one -- produced by a pull_request workflow, and not
-# cancellable on the head commit -- while the live drift comparison tolerates it
-# in either state, which is what lets the code half land before the by-hand
-# ruleset edit. Empty this list again in the same pass that adds the name to the
-# ruleset and promotes it into DEFAULT_REQUIRED_CONTEXTS above and into
-# RULESET_CONTEXTS in tools/ci-wait.py.
+# Empty is this list's RESTING state, not the only legal one. The `main` ruleset
+# requires all ten names in DEFAULT_REQUIRED_CONTEXTS above, so nothing that
+# already gates is waiting here (#3199, measured 2026-09-06), and #3244 emptied
+# it for a reason: every pending name is a name the live drift comparison in
+# resolve_contexts() deliberately tolerates in EITHER state, so each entry is a
+# hole in the #2785 check for as long as it lasts.
+#
+# #3244 also said what refills it -- "only while a new gating job is landing" --
+# and that is the case for BOTH entries below. Each names a blocking job that
+# pr-gate.yml already produces and the `main` ruleset does not require yet, so
+# each is listed for exactly as long as that is true, and each comes out in the
+# same pass that adds its name to the ruleset.
+#
+# Two entries, not one, and that is deliberate: #3255 and #3089 landed their
+# gating jobs independently, and dropping either name while its job blocks would
+# reopen precisely the #2785 hole this file exists to close -- a context the
+# ruleset requires that nothing here analyses. Merging these two refills by
+# keeping only one side is the mistake to avoid.
 PENDING_REQUIRED_CONTEXTS: list[str] = [
+    # #3255's gate. pr-gate.yml's require-corpus-linkage job produces this
+    # context. Analysed here exactly like a required one -- produced by a
+    # pull_request workflow, and not cancellable on the head commit -- while the
+    # live drift comparison tolerates it in either state, which is what lets the
+    # code half land before the by-hand ruleset edit. Promote it into
+    # DEFAULT_REQUIRED_CONTEXTS above and into RULESET_CONTEXTS in
+    # tools/ci-wait.py in the same pass that adds it to the ruleset.
     "AL-observable changes must declare corpus linkage",
+    # #3089's gate. Deliberately NOT promoted into DEFAULT_REQUIRED_CONTEXTS or
+    # into tools/ci-wait.py's RULESET_CONTEXTS: the live ruleset does not require
+    # this name yet, and ci-wait.py treats RULESET_CONTEXTS as a FLOOR, returning
+    # exit 3 UNDETERMINED whenever the live ruleset is a subset of it (#3002). So
+    # promoting early would stop every agent's CI wait in this repository from
+    # returning a verdict until a maintainer edited the ruleset by hand. Listed
+    # here it is still ANALYSED like a required one -- produced by a pull_request
+    # workflow, not cancellable on the head commit -- which is the whole point of
+    # the seam.
+    "A PR closing a gap issue must not leave its known-gap entry behind",
 ]
 
 REPO = "StefanMaron/BusinessCentral.AL.Runner"

--- a/.github/scripts/test_check_expectation_gap_issues.py
+++ b/.github/scripts/test_check_expectation_gap_issues.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Unit tests for check_expectation_gap_issues.py (#3089).
+
+Same pattern as test_check_required_contexts.py and
+test_check_closing_reference.sh: every case builds the condition it is about
+DELIBERATELY, in a temp directory, so the suite proves the guard rather than
+describing whatever `tests/expectations/` happens to contain today. A suite
+that only asserted over the shipped manifest would go green the moment the
+manifest emptied out, which is precisely the vacuous pass this guard exists to
+prevent elsewhere.
+
+Run: python3 .github/scripts/test_check_expectation_gap_issues.py
+"""
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.abspath(os.path.join(HERE, "..", ".."))
+
+_spec = importlib.util.spec_from_file_location(
+    "check_expectation_gap_issues",
+    os.path.join(HERE, "check_expectation_gap_issues.py"),
+)
+cegi = importlib.util.module_from_spec(_spec)
+# Registering before exec_module is the documented importlib recipe, and it is
+# load-bearing here: @dataclass resolves annotations through
+# sys.modules[cls.__module__], which is None for an unregistered module.
+sys.modules[_spec.name] = cegi
+_spec.loader.exec_module(cegi)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+ISSUE = "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues"
+
+
+def gap(issue: str, *, codeunit: str = "TP Blank Temporal Tests",
+        method: str = "TestPageField_Value_BlankRecBoundDate_ReadsEmptyString",
+        mode: str = "expect-fail-known-gap") -> dict:
+    e = {
+        "codeunitId": 60830,
+        "CodeunitName": codeunit,
+        "Method": method,
+        "Mode": mode,
+        "Note": "constructed by test_check_expectation_gap_issues.py",
+    }
+    if issue is not None:
+        e["Issue"] = issue
+    return e
+
+
+def run(files: dict[str, object] | None, *, title: str = "", body: str = "",
+        commits: str = "", argv: list[str] | None = None,
+        repo: str = "StefanMaron/BusinessCentral.AL.Runner",
+        manifest_dir: str | None = None) -> tuple[int, str]:
+    """Write a synthetic manifest, run the guard, return (rc, combined output).
+
+    `files` maps a file name to either a JSON-serialisable object or a raw
+    string (so a malformed-JSON case can be expressed).
+    """
+    env_keys = ("PR_TITLE", "PR_BODY", "PR_COMMITS", "GITHUB_REPOSITORY")
+    saved = {k: os.environ.get(k) for k in env_keys}
+    tmp = None
+    try:
+        if manifest_dir is None:
+            tmp = tempfile.TemporaryDirectory()
+            manifest_dir = tmp.name
+            for name, content in (files or {}).items():
+                text = content if isinstance(content, str) else json.dumps(content, indent=2)
+                with open(os.path.join(manifest_dir, name), "w", encoding="utf-8") as fh:
+                    fh.write(text)
+        os.environ["PR_TITLE"] = title
+        os.environ["PR_BODY"] = body
+        os.environ["PR_COMMITS"] = commits
+        os.environ["GITHUB_REPOSITORY"] = repo
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = cegi.main([manifest_dir] + list(argv or []))
+        return rc, out.getvalue() + err.getvalue()
+    finally:
+        if tmp is not None:
+            tmp.cleanup()
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+# ---------------------------------------------------------------------------
+print("The gate: a PR that closes issue N may not leave an entry linking N")
+# ---------------------------------------------------------------------------
+
+rc, out = run({"known-gaps-blank-temporal.json": [gap(f"{ISSUE}/2361")]},
+              body="Fixes the thing.\n\nCloses #2361\n")
+check("a canonical 'Closes #N' with an entry linking N fails", rc == 1, f"rc={rc}")
+check("...and the message names the manifest file",
+      "known-gaps-blank-temporal.json" in out, out)
+check("...and the method, so the author knows which entry to delete",
+      "TestPageField_Value_BlankRecBoundDate_ReadsEmptyString" in out, out)
+check("...and the issue number", "2361" in out, out)
+
+rc, out = run({"known-gaps-blank-temporal.json": [gap(f"{ISSUE}/2361")]},
+              body="Closes #3089\n")
+check("an entry linking an OPEN issue this PR does not close passes",
+      rc == 0, f"rc={rc}: {out}")
+
+rc, out = run({"known-gaps-blank-temporal.json": [gap(f"{ISSUE}/9999")]},
+              body="Closes #2361\n")
+check("re-targeting the entry to a different issue in the same PR passes",
+      rc == 0, f"rc={rc}: {out}")
+
+rc, out = run({"known-gaps-blank-temporal.json": []},
+              body="Closes #2361\n")
+check("deleting the entry outright in the same PR passes",
+      rc == 0, f"rc={rc}: {out}")
+
+rc, out = run({"known-gaps-a.json": [gap(f"{ISSUE}/1")],
+               "known-gaps-b.json": [gap(f"{ISSUE}/2361", codeunit="Other Cu")]},
+              body="Closes #1\nCloses #2361\n")
+check("a PR declaring several targets is checked against all of them",
+      rc == 1 and "known-gaps-a.json" in out and "known-gaps-b.json" in out,
+      f"rc={rc}: {out}")
+
+rc, out = run({"known-gaps-x.json": [gap(f"{ISSUE}/2361")]},
+              title="fix(testpage): closes #2361", body="No linked issue: title only\n")
+check("a closing reference in the PR TITLE is caught (GitHub honors it there too)",
+      rc == 1, f"rc={rc}: {out}")
+
+rc, out = run({"known-gaps-x.json": [gap(f"{ISSUE}/2361")]},
+              body="Closes #3089\n",
+              commits="fix(testpage): read blank dates\n\nIt also fixes #2361 along the way.\n")
+check("a STRAY reference in a commit message is caught (route B, #2491)",
+      rc == 1 and "commit message" in out.lower(), f"rc={rc}: {out}")
+
+rc, out = run({"known-gaps-x.json": [gap(f"{ISSUE}/2361")]},
+              body="Closes StefanMaron/BusinessCentral.AL.Runner#2361\n")
+check("the owner/repo#N form is caught", rc == 1, f"rc={rc}: {out}")
+
+rc, out = run({"known-gaps-x.json": [gap(f"{ISSUE}/2361")]},
+              body=f"Closes {ISSUE}/2361\n")
+check("the full-URL form is caught", rc == 1, f"rc={rc}: {out}")
+
+rc, out = run({"known-gaps-x.json": [gap(f"{ISSUE}/2361")]},
+              body="Closes #3089\n\nThis fixes 2361 rendering glitches in the parser.\n")
+check("a bare number with no '#' is not a reference (the #2129 false positive)",
+      rc == 0, f"rc={rc}: {out}")
+
+rc, out = run({"known-gaps-x.json": [gap("https://github.com/other/repo/issues/2361")]},
+              body="Closes #2361\n")
+check("a bare '#N' does not match an entry linking ANOTHER repository's issue N",
+      rc == 0, f"rc={rc}: {out}")
+
+rc, out = run({"known-gaps-x.json": [gap("https://github.com/other/repo/issues/2361")]},
+              body="Closes other/repo#2361\n")
+check("...but the explicit cross-repo form does match it", rc == 1, f"rc={rc}: {out}")
+
+rc, out = run({"oos-http.json": [{"codeunitId": 1, "CodeunitName": "Cu", "Method": "M",
+                                  "Mode": "expect-oos", "Reason": "external-http"}],
+               "divergence-session.json": [{"codeunitId": 2, "CodeunitName": "Cu2", "Method": "M",
+                                            "Mode": "expect-divergence", "Reason": "r",
+                                            "Doc": "docs/scope.md#jobs"}]},
+              body="Closes #2361\n")
+check("expect-oos and expect-divergence entries are never flagged (only known-gaps carry an Issue)",
+      rc == 0, f"rc={rc}: {out}")
+
+rc, out = run({"known-gaps-x.json": [gap(f"{ISSUE}/2361")]},
+              body="No linked issue: a docs typo\n")
+check("a PR with no closing reference at all passes", rc == 0, f"rc={rc}: {out}")
+
+rc, out = run({"known-gaps-x.json": [gap(f"{ISSUE}/2361")]},
+              body="See #2361 for the background.\n\nCloses #3089\n")
+check("referring to the gap issue WITHOUT a closing keyword passes",
+      rc == 0, f"rc={rc}: {out}")
+
+
+# ---------------------------------------------------------------------------
+print()
+print("Anti-fail-open: a check that cannot check must not report a pass")
+# ---------------------------------------------------------------------------
+
+rc, out = run({"known-gaps-x.json": [gap(None)]}, body="Closes #2361\n")
+check("an expect-fail-known-gap entry with no Issue is a hard error, not a skip",
+      rc == 2 and "Issue" in out, f"rc={rc}: {out}")
+
+rc, out = run({"known-gaps-x.json": [gap("TBD")]}, body="Closes #2361\n")
+check("an Issue field that is not a resolvable issue URL is a hard error",
+      rc == 2, f"rc={rc}: {out}")
+
+rc, out = run({"known-gaps-x.json": "{ not json"}, body="Closes #2361\n")
+check("malformed JSON in the manifest is a hard error", rc == 2, f"rc={rc}: {out}")
+
+rc, out = run({"known-gaps-x.json": [gap(f"{ISSUE}/2361")]}, body="", title="", commits="")
+check("blank title AND body AND commit messages is a hard error, not a vacuous pass",
+      rc == 2, f"rc={rc}: {out}")
+
+rc, out = run(None, body="Closes #2361\n",
+              manifest_dir=os.path.join(tempfile.gettempdir(), "cegi-does-not-exist-3089"))
+check("a missing manifest directory is a hard error (a broken checkout, not an empty manifest)",
+      rc == 2, f"rc={rc}: {out}")
+
+rc, out = run({"known-gaps-x.json": [gap(f"{ISSUE}/2361", mode="expect-oos")]},
+              body="Closes #2361\n")
+check("a known-gaps-*.json file holding no expect-fail-known-gap entry is a hard error "
+      "(the prefix/Mode disagreement would otherwise silence the whole file)",
+      rc == 2, f"rc={rc}: {out}")
+
+rc, out = run({"oos-http.json": [{"codeunitId": 1, "CodeunitName": "Cu", "Method": "M",
+                                  "Mode": "expect-oos", "Reason": "external-http"}]},
+              body="Closes #2361\n")
+check("a manifest with no known-gaps-*.json file at all passes, and SAYS it checked nothing",
+      rc == 0 and "0 expect-fail-known-gap" in out, f"rc={rc}: {out}")
+
+rc, out = run({"known-gaps-x.json": [gap(f"{ISSUE}/2361")]}, body="Closes #3089\n")
+check("a passing run reports how many entries it actually scanned",
+      "1 expect-fail-known-gap" in out, out)
+
+
+# ---------------------------------------------------------------------------
+print()
+print("The non-blocking sweep: entries linking an already-closed issue")
+# ---------------------------------------------------------------------------
+
+def run_report(files: dict[str, object], states: dict[tuple[str, str, int], str | None]):
+    original = cegi.issue_state
+    cegi.issue_state = lambda owner, repo, n: states.get((owner, repo, n))
+    try:
+        return run(files, body="Closes #3089\n", argv=["--report-closed-issues"])
+    finally:
+        cegi.issue_state = original
+
+
+key = ("StefanMaron", "BusinessCentral.AL.Runner", 2361)
+
+rc, out = run_report({"known-gaps-x.json": [gap(f"{ISSUE}/2361")]}, {key: "closed"})
+check("an entry linking a CLOSED issue is reported as a warning", "::warning" in out, out)
+check("...naming the issue and the entry",
+      "2361" in out and "known-gaps-x.json" in out, out)
+check("...and does NOT fail the job (a closed issue does not by itself prove staleness)",
+      rc == 0, f"rc={rc}: {out}")
+
+rc, out = run_report({"known-gaps-x.json": [gap(f"{ISSUE}/2361")]}, {key: "open"})
+check("an entry linking an OPEN issue produces no warning",
+      rc == 0 and "::warning" not in out, f"rc={rc}: {out}")
+
+rc, out = run_report({"known-gaps-x.json": [gap(f"{ISSUE}/2361")]}, {})
+check("an unreachable API is LOUD about not having checked, and still does not fail",
+      rc == 0 and "::warning" in out and "could not" in out.lower(), f"rc={rc}: {out}")
+check("...and says explicitly that the sweep did not run for that entry",
+      "2361" in out, out)
+
+
+# ---------------------------------------------------------------------------
+print()
+print("Drift guards")
+# ---------------------------------------------------------------------------
+
+_pb_spec = importlib.util.spec_from_file_location(
+    "pr_body", os.path.join(REPO_ROOT, "tools", "pr-body.py"))
+pb = importlib.util.module_from_spec(_pb_spec)
+sys.modules[_pb_spec.name] = pb
+_pb_spec.loader.exec_module(pb)
+
+check("KEYWORDS matches tools/pr-body.py's", cegi.KEYWORDS == pb.KEYWORDS,
+      f"{cegi.KEYWORDS!r} vs {pb.KEYWORDS!r}")
+check("REF_HASH matches tools/pr-body.py's", cegi.REF_HASH == pb.REF_HASH,
+      f"{cegi.REF_HASH!r} vs {pb.REF_HASH!r}")
+check("REF_URL matches tools/pr-body.py's", cegi.REF_URL == pb.REF_URL,
+      f"{cegi.REF_URL!r} vs {pb.REF_URL!r}")
+
+# Which workflow runs which half is load-bearing after #3198 split the guards
+# that must block (pr-gate.yml) from the advisory ones (pr-check.yml). The
+# deterministic half of this guard meets pr-gate.yml's stated rule of thumb --
+# a failure is a real defect in the PR, it cannot fail environmentally, it is
+# cheap -- and the half that calls api.github.com does not, so they must not be
+# in the same file. Asserting the split, not just "some workflow mentions it",
+# is what stops the blocking half sliding back into the advisory file, where
+# #3116, #3112 and #3095 each merged with a red job.
+def _workflow(name):
+    return open(os.path.join(REPO_ROOT, ".github", "workflows", name),
+                encoding="utf-8").read()
+
+_gate, _adv = _workflow("pr-gate.yml"), _workflow("pr-check.yml")
+
+check("pr-gate.yml runs the guard (or every assertion above is decoration)",
+      "check_expectation_gap_issues.py" in _gate, "")
+check("the blocking half is NOT the sweep (pr-gate.yml must not go online)",
+      "--report-closed-issues" not in _gate, "")
+check("pr-check.yml runs the non-blocking sweep",
+      "--report-closed-issues" in _adv, "")
+check("the advisory file does not also run the blocking half",
+      "check_expectation_gap_issues.py --report-closed-issues" in _adv
+      and "check_expectation_gap_issues.py\n" not in _adv, "")
+check("this very test suite is run by github-scripts-tests' glob",
+      ".github/scripts/test_*.py" in _gate, "")
+
+# The shipped manifest: not a substitute for the synthetic cases above (it would
+# go green on an empty directory), but it does prove the extraction still works
+# against the real schema, and that the gate FIRES on real entries.
+shipped = os.path.join(REPO_ROOT, "tests", "expectations")
+rc, out = run(None, body="No linked issue: reading the shipped manifest\n",
+              manifest_dir=shipped)
+check("the shipped tests/expectations/ manifest parses cleanly", rc == 0, f"rc={rc}: {out}")
+
+entries = cegi.load_known_gap_entries(shipped)
+print(f"  note shipped manifest carries {len(entries)} expect-fail-known-gap entr"
+      f"{'y' if len(entries) == 1 else 'ies'}")
+fired = []
+for e in entries:
+    rc, out = run(None, body=f"Closes {e.owner}/{e.repo}#{e.number}\n", manifest_dir=shipped)
+    fired.append((e.number, rc == 1))
+check("the gate fires for every issue the shipped manifest actually links",
+      all(ok for _, ok in fired), str(fired))
+
+# ...and that assertion must not be able to pass by finding nothing: if the
+# directory ships a known-gaps-*.json at all, it has to have yielded entries.
+_has_gap_file = any(f.startswith("known-gaps-") and f.endswith(".json")
+                    for f in os.listdir(shipped))
+check("shipped known-gaps-*.json files yield entries (else the check above is vacuous)",
+      (not _has_gap_file) or len(entries) > 0, f"gap files={_has_gap_file}, entries={len(entries)}")
+
+
+print()
+if FAILURES:
+    print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")
+    sys.exit(1)
+print("all checks passed")

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -148,3 +148,31 @@ jobs:
   # coverage has a real test there, so a separate hand-maintained manifest adds nothing.
   # The old file is preserved for reference at docs/archive/coverage.yaml.
   # See docs/v1-to-v2-migration.md's "Dropped" table.
+
+  expectation-gap-closed-issue-sweep:
+    name: Known-gap entries linking an already-closed issue (advisory)
+    permissions:
+      contents: read
+      issues: read
+    runs-on: ubuntu-latest
+    # The ONLINE half of check_expectation_gap_issues.py (#3089). The offline
+    # half -- "this PR closes issue N and an entry still links issue N" -- gates
+    # from pr-gate.yml. This one is advisory for the same two reasons the
+    # ruleset-drift job above is: it talks to api.github.com, so it can go red
+    # for something no author did; and #2858 established that a closed issue does
+    # not by itself prove an entry is stale. An entry can link an issue closed as
+    # a duplicate, or closed with the gap still open -- six entries pointed at
+    # closed issues when #2858 was filed and only one was actually failing.
+    #
+    # So it emits ::warning:: annotations and never a failure, and when the API
+    # is unreachable it names what it could NOT check rather than reporting
+    # nothing. It is also the only half that can see the INVERSE ordering, where
+    # the entry lands after the closing PR's own check has already run -- the
+    # ordering both 2026-09-05 incidents (#2844, #2858) actually took.
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Report entries linking an already-closed issue (non-blocking)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python3 .github/scripts/check_expectation_gap_issues.py --report-closed-issues

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -411,3 +411,91 @@ jobs:
             python3 "$s" || rc=1
           done
           exit $rc
+
+  expectation-gap-issue-consistency:
+    name: A PR closing a gap issue must not leave its known-gap entry behind
+    permissions:
+      contents: read
+      pull-requests: read   # gh pr view --json commits (#2491)
+    runs-on: ubuntu-latest
+    # #3089, and it belongs on THIS side of the split by the header's own rule of
+    # thumb: a failure means a real defect in the pull request, it cannot fail for
+    # an environmental reason -- this half makes no network call beyond reading
+    # the PR's own commit messages -- and it costs about a second. The ONLINE half
+    # of the same script, which looks up whether a linked issue has closed, is
+    # advisory and lives in pr-check.yml.
+    #
+    # tests/expectations/known-gaps-*.json entries declare a gap and link the OPEN
+    # issue tracking it. The manifest is already loud in both directions at RUN
+    # time -- a test that passes while an entry declares a known gap fails the run
+    # with "Test passed cleanly but manifest declares expect-fail-known-gap ...
+    # Remove the entry".
+    #
+    # The hole is the moment the two get out of step. A PR fixes the gap, closes
+    # the issue and forgets to delete the entry. Nothing in that PR is wrong on
+    # its own, so it merges green -- and the next run of main is red, on a commit
+    # whose author has moved on. That happened twice in one hour on 2026-09-05:
+    # #2795 closed by PR #2809 left an entry in
+    # known-gaps-testpage-boolean-spelling.json, and #2805 closed by PR #2825 left
+    # two in known-gaps-start-session-isolation.json (reported after the fact as
+    # #2844 and #2858).
+    #
+    # This job would NOT have caught either of those, and does not claim to. Both
+    # were the INVERSE ordering -- the entry arrived after the closing PR's own
+    # check had run, so there was nothing yet in the checkout to contradict. Both
+    # files were created by PR #2808's merge at 16:56:43Z; #2825 merged at
+    # 16:48:28Z, eight minutes earlier, and #2809's single PR Check ran at
+    # 16:29:20Z with strict_required_status_checks_policy=false on main, so the
+    # base moving re-triggered nothing. Replayed against the manifest as it stood
+    # at each PR's own check time, the script exits 0 for both. The inverse
+    # ordering is what the advisory sweep in pr-check.yml reports.
+    #
+    # What this DOES cover is the FORWARD ordering, which nothing checked before:
+    # the entry is already in the checkout when the closing PR is checked. Narrow
+    # on purpose -- THIS PR closes issue N and an entry links issue N. That is not
+    # a heuristic; the PR asserts the gap is fixed, the manifest asserts it is
+    # not, both are in the same diff, so the author is the person who can settle
+    # it.
+    #
+    # Adding it here does not by itself make it a required context -- see the
+    # header. It is in the file whose jobs are meant to gate, which is the half of
+    # that pairing this PR can actually do.
+    #
+    # Logic in check_expectation_gap_issues.py, extracted so it is unit-tested
+    # against synthetic manifests rather than provable only by merging a PR and
+    # watching main go red the next morning. Its suite is one of the
+    # .github/scripts/test_*.py that github-scripts-tests above runs.
+    steps:
+      - uses: actions/checkout@v6
+
+      # Same reasoning as reject-ci-skip-directives and
+      # reject-bad-closing-references (#2491): this repo's squash setting is
+      # squash_merge_commit_message=COMMIT_MESSAGES, so a closing keyword in a
+      # commit message closes the issue even though it never appears in the PR
+      # body. Asked of the API rather than reconstructed from git, and an empty
+      # answer is a failed fetch rather than an empty branch.
+      - name: Collect the branch's commit messages
+        id: commits
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          msgs=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+                   --json commits --jq '.commits[] | .messageHeadline, .messageBody')
+          if [ -z "${msgs//[[:space:]]/}" ]; then
+            echo "::error::Could not read any commit message for PR #$PR_NUMBER. Every PR has at least one commit, so this is a failure to fetch, not an empty branch -- refusing to report a pass without having read the text that becomes the merge commit." >&2
+            exit 1
+          fi
+          {
+            echo "messages<<PR_COMMITS_EOF"
+            printf '%s\n' "$msgs"
+            echo "PR_COMMITS_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check no expect-fail-known-gap entry links an issue this PR closes
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_COMMITS: ${{ steps.commits.outputs.messages }}
+        run: python3 .github/scripts/check_expectation_gap_issues.py

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -474,19 +474,22 @@ jobs:
       # commit message closes the issue even though it never appears in the PR
       # body. Asked of the API rather than reconstructed from git, and an empty
       # answer is a failed fetch rather than an empty branch.
+      #
+      # Through the same pr_commit_messages.sh those two use, not a third inline
+      # copy of the fetch. #3198 extracted it for a reason this job shares
+      # exactly: a job in THIS file produces a required (here, pending-required)
+      # context, so an unretried transient API error blocks a merge for something
+      # the author did not do. The helper retries, and its empty-output-is-a-
+      # failed-fetch refusal is unit-tested in test_pr_commit_messages.sh instead
+      # of living in a `run:` block nothing can exercise.
       - name: Collect the branch's commit messages
         id: commits
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
-          msgs=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-                   --json commits --jq '.commits[] | .messageHeadline, .messageBody')
-          if [ -z "${msgs//[[:space:]]/}" ]; then
-            echo "::error::Could not read any commit message for PR #$PR_NUMBER. Every PR has at least one commit, so this is a failure to fetch, not an empty branch -- refusing to report a pass without having read the text that becomes the merge commit." >&2
-            exit 1
-          fi
+          msgs=$(bash .github/scripts/pr_commit_messages.sh \
+                   "${{ github.event.pull_request.number }}")
           {
             echo "messages<<PR_COMMITS_EOF"
             printf '%s\n' "$msgs"

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -345,14 +345,26 @@ separate, ruleset-level fact.** It sits in `pr-gate.yml` because it meets that
 file's rule of thumb — a failure is a real defect in the pull request, it cannot
 fail for an environmental reason, and it is cheap. But as `pr-gate.yml`'s own
 header says, being in that file does not by itself make a job a required
-context: `main`'s ruleset currently requires exactly two, `All BC versions
-passed` and `Tests updated`, so `tools/ci-wait.py`'s `is_required()` answers
-`False` for this job and auto-merge ignores it. Adding it to the ruleset is an
-administrator action and is deliberately not claimed here. What this PR can do
-is put it on the side of the split whose jobs are meant to gate, next to
-`reject-ci-skip-directives` and `reject-bad-closing-references` — rather than in
-`pr-check.yml`, where #3116, #3112 and #3095 each merged with a job in a
-FAILURE state.
+context, and this one is not required yet, so `tools/ci-wait.py`'s
+`is_required()` answers `False` for it and auto-merge ignores it.
+
+Note what that does **not** mean. Measured against the live branch ruleset on
+2026-09-06, `main` requires **ten** contexts: `BC test matrix passed` (renamed
+from `All BC versions passed` by #3141), `Tests updated`, and the eight
+`pr-gate.yml` jobs — including `reject-ci-skip-directives` and
+`reject-bad-closing-references`, which **do** gate. So this job's non-required
+standing is not shared with its neighbours; after this lands it is the only job
+in `pr-gate.yml` that does not gate. That is a reason to promote it, not a
+precedent that excuses it. Promotion is a ruleset edit, an administrator action,
+deliberately not claimed here — the interim seam is
+`PENDING_REQUIRED_CONTEXTS` in `.github/scripts/check_required_contexts.py`,
+which lists this context so the guard analyses it like a required one while the
+drift comparison tolerates it in either state.
+
+What this PR can do is put it on the side of the split whose jobs are meant to
+gate, next to `reject-ci-skip-directives` and `reject-bad-closing-references` —
+rather than in `pr-check.yml`, where #3116, #3112 and #3095 each merged with a
+job in a FAILURE state.
 
 ### The two orderings, and which one this covers
 

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -350,7 +350,12 @@ context, and this one is not required yet, so `tools/ci-wait.py`'s
 
 Note what that does **not** mean. Measured against the live branch ruleset on
 2026-09-06, `main` requires **ten** contexts: `BC test matrix passed` (renamed
-from `All BC versions passed` by #3141), `Tests updated`, and the eight
+by #3141 — the retired name is deliberately not written out here, because
+`BcMatrixDocumentationDriftTests.NoDocumentNamesTheRetiredAggregateCheck`
+forbids any document under `docs/` from carrying it: a doc that names a context
+which no longer reports sends an agent looking for a check that will never
+arrive, indistinguishable from one that has not started), `Tests updated`, and
+the eight
 `pr-gate.yml` jobs — including `reject-ci-skip-directives` and
 `reject-bad-closing-references`, which **do** gate. So this job's non-required
 standing is not shared with its neighbours; after this lands it is the only job

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -296,9 +296,10 @@ a clean run does not hide manifested deviations from the corpus.
    at a closed issue is the exact bookkeeping lie this mode set exists to avoid.
 
    Since #3089 one half of that *is* checked, in CI rather than in the run:
-   `pr-check.yml`'s `expectation-gap-issue-consistency` job fails a PR that
-   declares `Closes #N` while an entry still links issue N
-   (`.github/scripts/check_expectation_gap_issues.py`). See
+   `pr-check.yml`'s `expectation-gap-issue-consistency` job goes red on a PR
+   that declares `Closes #N` while an entry still links issue N
+   (`.github/scripts/check_expectation_gap_issues.py`). It is an annotation, not
+   a merge block — the job is not a required status check. See
    [the guard](#the-ci-guard-on-issue-links) below for what it does and does not
    cover.
 3. **`expect-divergence` requires `Reason` + `Doc`, and forbids `Issue`.** It
@@ -334,12 +335,50 @@ and the line the reference came from.
 That is not a guess about which one is wrong. The PR asserts the gap is fixed;
 the manifest asserts it is not; both are in the same diff, so the author can
 settle it — delete the entry, re-target it at the open issue tracking what
-remains, or drop the closing reference. Before this existed the disagreement
-merged green and turned up as a red `main` the next morning, twice in one hour on
-2026-09-05: issue #2795 (fixed by PR #2809) left an entry in
-`known-gaps-testpage-boolean-spelling.json`, and issue #2805 (fixed by PR #2825)
-left two in `known-gaps-start-session-isolation.json`. Both were reported after
-the fact, as #2844 and #2858.
+remains, or drop the closing reference.
+
+**"Blocking" means the job goes red, not that the merge is refused.** `main`'s
+ruleset requires exactly two contexts, `All BC versions passed` and
+`Tests updated`; this job is neither, so `tools/ci-wait.py`'s `is_required()`
+answers `False` for it, auto-merge ignores it, and it cannot turn a `ci-wait`
+verdict red. It annotates and a human reads the annotation — the same standing
+as `reject-ci-skip-directives` and `reject-bad-closing-references` in the same
+workflow. Making it required is a ruleset decision, deliberately not taken here.
+
+### The two orderings, and which one this covers
+
+Manifest/issue drift arrives in one of two orders:
+
+- **Forward** — the entry is already in the checkout when the closing PR is
+  checked. The PR text and the manifest contradict each other inside one diff,
+  and the gate is red before anyone merges. This is the ordering the gate is
+  for, and the ordinary one, since an entry normally predates the fix that
+  closes its issue. Nothing checked it before #3089.
+- **Inverse** — the entry lands *after* the closing PR's own check has run.
+  Nothing evaluated at that PR's check time can see an entry that is not there
+  yet, so the gate cannot help. Only the non-blocking sweep below covers it, on
+  a later PR, and only once the linked issue has actually closed.
+
+**The two 2026-09-05 incidents were the inverse ordering, so this gate would not
+have caught either**, and it is not credited with them. What happened, measured
+rather than reasoned: issue #2795 (fixed by PR #2809) left an entry in
+`known-gaps-testpage-boolean-spelling.json` and issue #2805 (fixed by PR #2825)
+left two in `known-gaps-start-session-isolation.json`; both were reported after
+the fact, as #2844 and #2858. But both files were *created* by PR #2808's merge
+at 16:56:43Z, and #2808 closes nothing, so it declared no closing reference for
+the gate to compare its own new entries against. PR #2825 merged at 16:48:28Z,
+eight minutes before the entry existed anywhere. PR #2809's single `PR Check`
+ran at 16:29:20Z, 27 minutes before #2808 merged, and the ruleset sets
+`strict_required_status_checks_policy: false`, so the base moving underneath it
+re-triggered nothing. Replaying each PR's real title, body and commit messages
+against the manifest as it stood at its **own** check time (base `43d85ea6`,
+which held 12 `expect-fail-known-gap` entries and neither of those two files)
+exits 0 for both. The sweep would not have caught them that hour either:
+#2808's last `PR Check` ran at 16:39:50Z, when #2795 and #2805 were both still
+open — they closed at 17:29:30Z and 16:48:29Z.
+
+Those incidents are how the shape became known. They are not evidence of an
+incident prevented, and this page does not claim one.
 
 **Non-blocking, and it is the only half that touches the network.**
 `--report-closed-issues` looks up every linked issue and emits a `::warning::`

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -296,12 +296,11 @@ a clean run does not hide manifested deviations from the corpus.
    at a closed issue is the exact bookkeeping lie this mode set exists to avoid.
 
    Since #3089 one half of that *is* checked, in CI rather than in the run:
-   `pr-check.yml`'s `expectation-gap-issue-consistency` job goes red on a PR
+   `pr-gate.yml`'s `expectation-gap-issue-consistency` job goes red on a PR
    that declares `Closes #N` while an entry still links issue N
-   (`.github/scripts/check_expectation_gap_issues.py`). It is an annotation, not
-   a merge block — the job is not a required status check. See
+   (`.github/scripts/check_expectation_gap_issues.py`). See
    [the guard](#the-ci-guard-on-issue-links) below for what it does and does not
-   cover.
+   cover, and for what "goes red" is and is not worth.
 3. **`expect-divergence` requires `Reason` + `Doc`, and forbids `Issue`.** It
    declares a standing decision, so it has to point at where that decision is
    recorded. If you find yourself wanting to link an issue, the entry is a gap,
@@ -322,8 +321,12 @@ a clean run does not hide manifested deviations from the corpus.
 
 ## The CI guard on issue links
 
-`.github/scripts/check_expectation_gap_issues.py`, run by `pr-check.yml`'s
-`expectation-gap-issue-consistency` job. Two halves, deliberately unequal.
+`.github/scripts/check_expectation_gap_issues.py`. Two halves, deliberately
+unequal — and since #3198 they live in different workflows, because that is the
+split #3198 introduced: `pr-gate.yml` holds the guards that are meant to block,
+`pr-check.yml` the advisory ones. The offline half is
+`pr-gate.yml`'s `expectation-gap-issue-consistency`; the half that calls
+`api.github.com` is `pr-check.yml`'s `expectation-gap-closed-issue-sweep`.
 
 **Blocking, and it needs no network.** If the PR closes issue N — read from the
 title, the body and every commit message, because this repo squash-merges with
@@ -337,13 +340,19 @@ the manifest asserts it is not; both are in the same diff, so the author can
 settle it — delete the entry, re-target it at the open issue tracking what
 remains, or drop the closing reference.
 
-**"Blocking" means the job goes red, not that the merge is refused.** `main`'s
-ruleset requires exactly two contexts, `All BC versions passed` and
-`Tests updated`; this job is neither, so `tools/ci-wait.py`'s `is_required()`
-answers `False` for it, auto-merge ignores it, and it cannot turn a `ci-wait`
-verdict red. It annotates and a human reads the annotation — the same standing
-as `reject-ci-skip-directives` and `reject-bad-closing-references` in the same
-workflow. Making it required is a ruleset decision, deliberately not taken here.
+**"Blocking" means the job goes red. Whether the merge is refused is a
+separate, ruleset-level fact.** It sits in `pr-gate.yml` because it meets that
+file's rule of thumb — a failure is a real defect in the pull request, it cannot
+fail for an environmental reason, and it is cheap. But as `pr-gate.yml`'s own
+header says, being in that file does not by itself make a job a required
+context: `main`'s ruleset currently requires exactly two, `All BC versions
+passed` and `Tests updated`, so `tools/ci-wait.py`'s `is_required()` answers
+`False` for this job and auto-merge ignores it. Adding it to the ruleset is an
+administrator action and is deliberately not claimed here. What this PR can do
+is put it on the side of the split whose jobs are meant to gate, next to
+`reject-ci-skip-directives` and `reject-bad-closing-references` — rather than in
+`pr-check.yml`, where #3116, #3112 and #3095 each merged with a job in a
+FAILURE state.
 
 ### The two orderings, and which one this covers
 

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -355,12 +355,12 @@ by #3141 — the retired name is deliberately not written out here, because
 forbids any document under `docs/` from carrying it: a doc that names a context
 which no longer reports sends an agent looking for a check that will never
 arrive, indistinguishable from one that has not started), `Tests updated`, and
-the eight
-`pr-gate.yml` jobs — including `reject-ci-skip-directives` and
+eight of the ten `pr-gate.yml` jobs — including `reject-ci-skip-directives` and
 `reject-bad-closing-references`, which **do** gate. So this job's non-required
-standing is not shared with its neighbours; after this lands it is the only job
-in `pr-gate.yml` that does not gate. That is a reason to promote it, not a
-precedent that excuses it. Promotion is a ruleset edit, an administrator action,
+standing is not shared with most of its neighbours; after this lands it is one
+of the two jobs in `pr-gate.yml` that do not gate, the other being #3255's
+`require-corpus-linkage`. That is a reason to promote it, not a precedent that
+excuses it. Promotion is a ruleset edit, an administrator action,
 deliberately not claimed here — the interim seam is
 `PENDING_REQUIRED_CONTEXTS` in `.github/scripts/check_required_contexts.py`,
 which lists this context so the guard analyses it like a required one while the

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -289,11 +289,18 @@ a clean run does not hide manifested deviations from the corpus.
    anchor in `docs/scope.md`. If a new surface is OOS for a reason not yet
    documented, add the section to `docs/scope.md` in the same PR.
 2. **`expect-fail-known-gap` requires an `Issue` link.** No untracked known
-   failures. The issue must be open at PR time. Nothing in the run can check
+   failures. The issue must be open at PR time. Nothing in the *run* can check
    that — the manifest is evaluated in-process with no network — so when the
    issue closes, the entry must move to whichever mode is now true
    (`expect-oos`, `expect-divergence`) or be deleted. A known-gap entry pointing
    at a closed issue is the exact bookkeeping lie this mode set exists to avoid.
+
+   Since #3089 one half of that *is* checked, in CI rather than in the run:
+   `pr-check.yml`'s `expectation-gap-issue-consistency` job fails a PR that
+   declares `Closes #N` while an entry still links issue N
+   (`.github/scripts/check_expectation_gap_issues.py`). See
+   [the guard](#the-ci-guard-on-issue-links) below for what it does and does not
+   cover.
 3. **`expect-divergence` requires `Reason` + `Doc`, and forbids `Issue`.** It
    declares a standing decision, so it has to point at where that decision is
    recorded. If you find yourself wanting to link an issue, the entry is a gap,
@@ -311,3 +318,45 @@ a clean run does not hide manifested deviations from the corpus.
    file — so the full-corpus CI leg runs with `--expectations-require-match`
    and fails on an entry that matched no test. See the section above; a typo
    here does not make the entry invalid, it makes it inert.
+
+## The CI guard on issue links
+
+`.github/scripts/check_expectation_gap_issues.py`, run by `pr-check.yml`'s
+`expectation-gap-issue-consistency` job. Two halves, deliberately unequal.
+
+**Blocking, and it needs no network.** If the PR closes issue N — read from the
+title, the body and every commit message, because this repo squash-merges with
+`squash_merge_commit_message=COMMIT_MESSAGES` and a closing keyword in a commit
+message closes the issue regardless of the body — and an `expect-fail-known-gap`
+entry links issue N, the job fails and names the file, the codeunit, the method
+and the line the reference came from.
+
+That is not a guess about which one is wrong. The PR asserts the gap is fixed;
+the manifest asserts it is not; both are in the same diff, so the author can
+settle it — delete the entry, re-target it at the open issue tracking what
+remains, or drop the closing reference. Before this existed the disagreement
+merged green and turned up as a red `main` the next morning, twice in one hour on
+2026-09-05: issue #2795 (fixed by PR #2809) left an entry in
+`known-gaps-testpage-boolean-spelling.json`, and issue #2805 (fixed by PR #2825)
+left two in `known-gaps-start-session-isolation.json`. Both were reported after
+the fact, as #2844 and #2858.
+
+**Non-blocking, and it is the only half that touches the network.**
+`--report-closed-issues` looks up every linked issue and emits a `::warning::`
+for the ones already closed. It never fails the job, because #2858 established
+that a closed issue does not by itself prove the entry is stale — an issue can
+close as a duplicate, or close with the gap still open. Six entries pointed at
+closed issues at the time and only one was actually failing. When the API cannot
+be reached it prints a warning naming what it could **not** check rather than
+reporting nothing, so an unreachable API never reads as a clean bill of health.
+
+**What makes it non-vacuous.** Every path where the check could quietly become
+decoration exits 2 (a failure, not a pass): a missing manifest directory, a file
+that will not parse, an entry whose `Issue` does not resolve to a real issue
+reference, a `known-gaps-*.json` whose entries are not known gaps — a
+prefix/`Mode` disagreement would otherwise silence that whole file — and a run
+where the PR title, body and commit messages are all empty, which means the fetch
+failed rather than that the PR is empty. A passing run prints how many entries it
+actually scanned. `.github/scripts/test_check_expectation_gap_issues.py` builds
+each of these conditions on purpose in a temp directory rather than asserting
+over whatever the manifest holds today.

--- a/tests/expectations/README.md
+++ b/tests/expectations/README.md
@@ -25,7 +25,20 @@ expectation should touch one file with one entry.
 
 The file prefix and the entry's `Mode` must agree — the prefix is what a human
 scanning the directory reads. Moving an entry between modes means moving it
-between files.
+between files. A `known-gaps-*.json` holding entries that are not
+`expect-fail-known-gap` fails `pr-check.yml`, because that disagreement would
+silence the whole file for the guard below.
+
+## A PR that closes a gap issue must delete or re-target its entry
+
+`pr-check.yml`'s `expectation-gap-issue-consistency` job fails a PR that declares
+`Closes #N` while an `expect-fail-known-gap` entry here still links issue N. The
+PR says the gap is fixed and the manifest says it is not; both are in the same
+diff, so it is settled there rather than by a red `main` the next morning — which
+is what happened twice in one hour on 2026-09-05 (see #2844 and #2858). The same
+job also warns, without failing, about entries linking an issue that is already
+closed; a closed issue is a lead, not proof the entry is stale. Details and the
+anti-vacuity rules: [`docs/expectations.md`](../../docs/expectations.md#the-ci-guard-on-issue-links).
 
 ## `count-baseline/` is a different concern, deliberately not a top-level `.json`
 

--- a/tests/expectations/README.md
+++ b/tests/expectations/README.md
@@ -31,14 +31,22 @@ silence the whole file for the guard below.
 
 ## A PR that closes a gap issue must delete or re-target its entry
 
-`pr-check.yml`'s `expectation-gap-issue-consistency` job fails a PR that declares
-`Closes #N` while an `expect-fail-known-gap` entry here still links issue N. The
-PR says the gap is fixed and the manifest says it is not; both are in the same
-diff, so it is settled there rather than by a red `main` the next morning — which
-is what happened twice in one hour on 2026-09-05 (see #2844 and #2858). The same
-job also warns, without failing, about entries linking an issue that is already
-closed; a closed issue is a lead, not proof the entry is stale. Details and the
-anti-vacuity rules: [`docs/expectations.md`](../../docs/expectations.md#the-ci-guard-on-issue-links).
+`pr-check.yml`'s `expectation-gap-issue-consistency` job goes red on a PR that
+declares `Closes #N` while an `expect-fail-known-gap` entry here still links
+issue N. The PR says the gap is fixed and the manifest says it is not; both are
+in the same diff, so it is settled there rather than by a red `main` the next
+morning. It annotates rather than blocks — the job is not a required status
+check on `main`.
+
+It covers one of the two orderings: the entry already being in the checkout when
+the closing PR is checked. The mirror case — the entry arriving *after* that
+check has run — is invisible to it, and is what the same job's non-blocking
+sweep reports, without failing, for entries linking an issue that is already
+closed; a closed issue is a lead, not proof the entry is stale. The 2026-09-05
+incidents behind this (#2844, #2858) were that inverse ordering, so the gate
+would not have caught them; it closes the other direction. Details, the
+measurements and the anti-vacuity rules:
+[`docs/expectations.md`](../../docs/expectations.md#the-ci-guard-on-issue-links).
 
 ## `count-baseline/` is a different concern, deliberately not a top-level `.json`
 

--- a/tests/expectations/README.md
+++ b/tests/expectations/README.md
@@ -26,17 +26,18 @@ expectation should touch one file with one entry.
 The file prefix and the entry's `Mode` must agree — the prefix is what a human
 scanning the directory reads. Moving an entry between modes means moving it
 between files. A `known-gaps-*.json` holding entries that are not
-`expect-fail-known-gap` fails `pr-check.yml`, because that disagreement would
-silence the whole file for the guard below.
+`expect-fail-known-gap` fails the guard below, because that disagreement would
+silence the whole file for it.
 
 ## A PR that closes a gap issue must delete or re-target its entry
 
-`pr-check.yml`'s `expectation-gap-issue-consistency` job goes red on a PR that
+`pr-gate.yml`'s `expectation-gap-issue-consistency` job goes red on a PR that
 declares `Closes #N` while an `expect-fail-known-gap` entry here still links
 issue N. The PR says the gap is fixed and the manifest says it is not; both are
 in the same diff, so it is settled there rather than by a red `main` the next
-morning. It annotates rather than blocks — the job is not a required status
-check on `main`.
+morning. It is in the workflow whose jobs are meant to gate, but `main`'s
+ruleset does not list it, so today it annotates rather than refuses the merge —
+see `docs/expectations.md`.
 
 It covers one of the two orderings: the entry already being in the checkout when
 the closing PR is checked. The mirror case — the entry arriving *after* that


### PR DESCRIPTION
Closes #3089

## The hole

`tests/expectations/known-gaps-*.json` entries are `expect-fail-known-gap`: the surface is in scope, real BC does it, the runner does not yet, and `Issue` links the open work. The manifest is already loud in both directions **at run time** — a test that passes while an entry declares a known gap fails the run with `Test passed cleanly but manifest declares expect-fail-known-gap … Remove the entry`, and a test that fails without an entry fails with "add an entry". That machinery works and is untouched here.

What nothing checked is the moment the two get out of step. A PR fixes the gap, closes the issue, and leaves the entry behind. Nothing in that PR is wrong on its own, so it merges green — and the next run of `main` is red, on a commit whose author has moved on.

| gap issue | its fix landed in | entry left behind in | `main` red at |
|---|---|---|---|
| #2795 | PR #2809 | `known-gaps-testpage-boolean-spelling.json` | 17:34 |
| #2805 | PR #2825 | `known-gaps-start-session-isolation.json` (2 entries) | 17:34 |

Both were reported after the fact, as #2844 and #2858, and each was repaired by deleting the entry. #2858 diagnosed the mechanism and closed without a guard.

## What this adds

`.github/scripts/check_expectation_gap_issues.py`, split across both PR workflows since this branch's last two commits. Two halves, deliberately unequal: the **blocking** half is `pr-gate.yml`'s new `expectation-gap-issue-consistency` job; the **online** half is `pr-check.yml`'s advisory `expectation-gap-closed-issue-sweep`.

**Blocking, and it needs no network at all.** If this PR declares a closing reference for issue N — read from the title, the body and every commit message, because this repo squash-merges with `squash_merge_commit_message=COMMIT_MESSAGES` and a closing keyword in a commit message fires regardless of the body — and an `expect-fail-known-gap` entry links issue N, the job fails and names the file, the codeunit, the method, and the line the reference came from.

That is not a heuristic. The PR asserts the gap is fixed and the manifest asserts it is not; exactly one is right, and both are in the same diff, so the author settles it — delete the entry, re-target it at the open issue tracking what remains, or drop the closing reference.

**Non-blocking, and the only half that touches the network.** `--report-closed-issues` looks up each linked issue and emits a `::warning::` for the ones already closed. It never changes the job's verdict, because #2858 established that a closed issue does not by itself prove the entry is stale — an issue can close as a duplicate, or close with the gap still open; six entries pointed at closed issues at the time and only one was actually failing. A blanket "links a closed issue → fail" would be a false-positive generator, which is why the issue asked for a warning here and this PR does not gate on it.

## What it does when it cannot reach the API

The blocking half never asks. It is a string parse of the PR text against JSON files in the checkout, so an unreachable GitHub API cannot weaken it, cannot make it flaky, and cannot make it skip.

The non-blocking half is the only caller of `issue_state()`, which tries `gh api` first and then a plain `urllib` request, and returns `None` if neither answers. `None` is never read as "open" and never read as "closed": the sweep prints

```
::warning::Could not determine the state of <owner>/<repo>#<N>, so the stale-entry
sweep did NOT run for it. Entries: … This half of the check is advisory and never
fails the job -- but an unreachable API is not a clean bill of health either, so it
says so rather than staying quiet.
```

and the run summary ends `… : 0 closed, 3 unresolved`. So it skips, loudly, per entry, and the count of what it could not check is in the log. It stays non-gating on purpose: making an advisory sweep fail a build on a network timeout would be worse than the drift it is looking for.

## Why it cannot pass vacuously

Every path where the check could quietly become decoration exits **2** — a failure, not a pass:

| condition | why it is not a skip |
|---|---|
| manifest directory missing | a broken checkout or a wrong path, not an empty manifest |
| a file that will not parse as JSON, or is not an array | the runner's own loader aborts on this too |
| an `expect-fail-known-gap` entry with no `Issue`, or an `Issue` that does not resolve | nothing left to compare against, and nothing tracking the gap |
| a `known-gaps-*.json` whose entries are not `expect-fail-known-gap` | a prefix/`Mode` disagreement silences that whole file for the gate — the exact failure mode the gate exists to prevent |
| `PR_TITLE`, `PR_BODY` and `PR_COMMITS` all empty | every PR has a title and at least one commit, so this is a failed fetch — the same reasoning as the sibling jobs' commit-message step |

A passing run prints how many entries it actually scanned (`Checked 14 expect-fail-known-gap entries … against 1 closing reference(s)`), so a green tick is never mute about its scope.

## RED → GREEN

**RED, stage 1** — the suite written first, no implementation: `FileNotFoundError` on import.

**RED, stage 2** — the interesting one. A no-op stub exposing the same module surface (`main()` returning `0`, `load_known_gap_entries()` returning `[]`) was dropped in, to prove the suite is not satisfiable by an implementation that always returns a default:

```
FAILED: 26 check(s): a canonical 'Closes #N' with an entry linking N fails, …the message
names the manifest file, …the method, …the issue number, a PR declaring several targets is
checked against all of them, a closing reference in the PR TITLE is caught, a STRAY
reference in a commit message is caught, the owner/repo#N form is caught, the full-URL form
is caught, …an expect-fail-known-gap entry with no Issue is a hard error, …malformed JSON is
a hard error, blank title AND body AND commit messages is a hard error, …a missing manifest
directory is a hard error, …an entry linking a CLOSED issue is reported as a warning, an
unreachable API is LOUD about not having checked, pr-check.yml runs the guard, …
```

**GREEN** — `python3 .github/scripts/test_check_expectation_gap_issues.py` → `all checks passed`, 41 checks.

Both directions are covered, as the issue asked: a stale entry is caught; an entry linking an open issue the PR does not close passes; re-targeting the entry to a different issue in the same PR passes; deleting it passes; referring to the gap issue *without* a closing keyword passes; and `fixes 2361 rendering glitches` is not treated as a reference to 2361 (the false-positive class that shipped once already after #2129).

## RETRACTED: this gate would NOT have caught #2809 or #2825

An earlier revision of this PR had a section here claiming the guard, replayed
against the two 2026-09-05 incidents, returned `rc=1` for both and so would have
blocked them. **That claim was wrong, and it is now withdrawn.** The replay used
the manifest as it stood *after* PR #2808's merge — a state that never coexisted
with either PR's own check run. Reviewer-flagged, and reproduced independently
before editing anything.

Measured on the API and on git:

| fact | value |
|---|---|
| both `known-gaps` files created by | PR #2808's merge, 16:56:43Z (#2808 declares no closing reference) |
| PR #2825, declared target issue #2805 | merged **16:48:28Z** — 8 min *before* the entry existed |
| PR #2809, declared target issue #2795 | exactly one `PR Check`, created **16:29:20Z** — 27 min before #2808 merged |
| `main` ruleset | `strict_required_status_checks_policy: false`, so the base moving re-triggered nothing |
| replay vs each PR's **own** check-time manifest (base `43d85ea6`: 12 entries, neither file present) | **rc=0 for both** |
| would the sweep have caught them that hour? | no — #2808's last `PR Check` ran 16:39:50Z, while #2795 and #2805 were both still open (closed 17:29:30Z, 16:48:29Z) |

Both incidents were the **inverse ordering** — the entry arriving after the
closing PR's check — which only the non-gating sweep covers. The gate covers the
**forward ordering**: the entry already in the checkout when the closing PR is
checked. Nothing checked that before, and it is the ordinary case, since an entry
normally predates the fix that closes its issue.

The two incidents are how the shape became known. They are not a prevented
incident, and the tree no longer says they are — the false claim had reached the
script docstring, the job comment, `docs/expectations.md` and
`tests/expectations/README.md`, all of which merge and outlive this PR. All four
are corrected in `e96fd33`, wording only.

### Second overstatement, also corrected

"Rejects a PR" overstates what this job does. It is **not** a required status
check on `main` yet, so `tools/ci-wait.py`'s `is_required()` answers `False` for
it, auto-merge ignores it, and it cannot turn a `ci-wait` verdict red. It goes
red and annotates; a human reads the annotation. Making it required is a ruleset
decision, not this PR's.

**Correction (impl-9): the reasoning attached to that was wrong, and inverted.**
An earlier revision of this body — and the same passage in the script docstring
and in `docs/expectations.md` — said `main`'s ruleset "requires only" /
"currently requires exactly two", `All BC versions passed` and `Tests updated`,
and that this job's non-required standing was "shared with
`reject-ci-skip-directives` and `reject-bad-closing-references`".

Measured against `GET /repos/StefanMaron/BusinessCentral.AL.Runner/rules/branches/main`
on 2026-09-06, `main` requires **ten** contexts:

```
BC test matrix passed                                          <- renamed from
Tests updated                                                     "All BC versions
PR title/body must not contain a CI-skip directive                 passed" by #3141
PR body closing references must be correct, both directions
pull_request trigger lists must keep their load-bearing event types
Required contexts must not be cancellable on the same commit
Agent definitions must allowlist the MCP tools they document
tools/ unit tests
.github/scripts/ unit tests
scripts/ unit tests
```

Both named siblings **are** required. So the standing is not shared — after this
merges, `expectation-gap-issue-consistency` is the only job in `pr-gate.yml` that
does not gate. That is an argument for promoting it, not a precedent excusing it.
Corrected in the script docstring and in `docs/expectations.md`, and each now
points at `PENDING_REQUIRED_CONTEXTS` as the interim seam.

### What still holds

Against `main`'s current manifest and this PR's own body:
`Checked 14 expect-fail-known-gap entries … no overlap`, rc 0. The 41-check suite
is untouched by the correction and still passes. Mutating the gate to
`offenders = []` still fails 11 of those checks, so the suite is not
stub-satisfiable.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** The closing-reference parse now exists in three places — `check_closing_reference.sh`, `tools/pr-body.py`, and this script. Two of them were already parity-tested against each other; the new suite asserts `KEYWORDS`, `REF_HASH` and `REF_URL` are byte-identical to `tools/pr-body.py`'s, so a third silently-diverging copy cannot appear. It deliberately does *not* copy the canonical/stray distinction: that is about where the author declared intent, and this check only cares what GitHub will actually close.

2. **Does a sibling assumption exist?** Yes, and it is now partly closed. `tests/expectations/README.md` has always required the file prefix and the entry `Mode` to agree, and **nothing enforced it** — I checked the C# schema tests and the loader. A `known-gaps-*.json` full of `expect-oos` entries would have silenced that whole file for this gate, so the loader here rejects it. The general rule (every prefix agreeing with every `Mode`, in both directions) is still unenforced; that is wider than this issue and I have filed it separately rather than fold it in — see the note below.

3. **Two code paths writing the same state?** The two directions of manifest/issue drift. This PR gates the one where the PR itself supplies the evidence, and reports the one where it does not. That asymmetry is the issue's own design and #2858's finding, not a shortcut.

## Not a claim about BC

Nothing here asserts anything about Business Central. It is repository hygiene about our own manifest and our own workflow, so it owes no upstream corpus test. There is no AL in the diff, `AlRunner/` is untouched, and the `Tests updated` gate does not trigger.

## What I deliberately left out

- **The general prefix/`Mode` agreement check** for `oos-*`, `divergence-*` and `disabled-*` files. Adjacent and cheap, but wider than this issue, and four other open PRs are currently touching `tests/expectations/`. Filed as a follow-up.
- **Failing on an entry that links a closed issue.** The issue explicitly asks for this to stay a warning, and #2858 is the evidence.
- **Any C# change.** The runtime-side manifest loader already does its half correctly; the hole was in CI, and that is where the fix went.

---

Filed by an agent (`stma-auto-1`, cycle 137) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE



## Review fixes applied by impl-9

**The merge conflict is resolved.** The branch was written when
`PENDING_REQUIRED_CONTEXTS` held eight names; `main` (via #3199, then #3244)
promoted all eight into `DEFAULT_REQUIRED_CONTEXTS` and emptied the pending list.
Resolved by keeping **exactly one** name there — this PR's own gate — and leaving
`main`'s surrounding comment intact:

```python
PENDING_REQUIRED_CONTEXTS: list[str] = [
    "A PR closing a gap issue must not leave its known-gap entry behind",
]
```

Re-adding the eight would have degraded **silently**: `resolve_contexts()` prints
a `::notice::` for a name present in both lists and nothing else, so there would
be no red to notice. The context name was verified by reading the `name:` of the
`expectation-gap-issue-consistency` job in `pr-gate.yml` at this head and
checking it against the list programmatically — a mismatch there is the silent
failure mode where an entry never matches and nothing says so.

`git merge-tree --write-tree --messages origin/main <head>` is now **CLEAN**, and
the branch is rebased onto current `main`.

**Conflict ahead with #3261.** PR #3261 (`agent/impl-26/corpus-guard`) adds its
own entry, `"AL-observable changes must declare corpus linkage"`, to the same
list, and `git merge-tree` between the two branches reports **CONFLICT**. Neither
depends on the other and the order is free; the requirement is that **whoever
lands second appends rather than replaces**, leaving a two-entry list. Dropping
the other name is the silent-degradation case again: the guard stops analysing
that context, and the live-ruleset drift comparison cannot flag the omission,
because a name in neither the pending list nor the ruleset looks like nothing at
all. Neither PR's test suite pins the list's length or membership, so nothing
would catch it. Suggested order: **#3113 first** (older, and its only blocker is
now cleared), then #3261 rebases and appends.

**Verification re-run after the rebase**, not carried across it: all five
`.github/scripts/test_*.py` and all five `test_*.sh` suites pass, including this
PR's own 41-check suite and `test_check_required_contexts.py`. Because the diff
touches `.github/workflows/`, the C# workflow-guard classes were run too —
`ReleaseTestParityTests`, `BcLegRerunWorkflowTests`, `CorpusAppEnumerationWorkflowTests`,
`CrashDumpCaptureWiringTests`, `MsBucketWorkflowTests`, `PublishReleaseOrderingTests`,
`TestArtifactsGateTests`, `CollectionCostOrdererTests` — as whole classes rather
than behind a narrow filter: **85 passed, 0 failed**.

**CI will be red for a reason that is not this PR.** `main` at `598f628a`
(PR #3248's merge) does not compile: `BcAppSymbolCache.cs(1319,26): error CS7036`,
a call site missed when `ParseSubPageLink` gained an `out` parameter. Bisected —
`65e5e562` builds, `598f628a` does not. Filed as **#3267**. The C# run above was
therefore done on a tree with byte-identical content based on the last good
`main`.

---

Authored by agent `stma-auto-1`; review fixes applied by agent `impl-9`.
