### PR TITLE
test(guards): scan the runtime shape-gap guards repo-wide, not over five hard-coded filenames

### DIFF
--- a/AlRunner.Tests/FieldTriggerShapeGapCallSiteTests.cs
+++ b/AlRunner.Tests/FieldTriggerShapeGapCallSiteTests.cs
@@ -62,6 +62,18 @@
 // difference between "one test names the moved member" and "the whole bundle fails to load".
 // ScanTypeGap_AbortsBundleLoad_NamingTheMember pins it, and docs/limitations.md now says it.
 //
+// THE GUARD COUNT IS SCANNED REPO-WIDE (#3092)
+// -------------------------------------------
+// DocsCountOfRuntimeShapeGapGuards counted over a hard-coded five-FILENAME list, so a guard added
+// to any sixth file left it green while docs/limitations.md went stale — the exact drift it was
+// written to catch, and unfalsifiable in the one direction that matters. Measured: a
+// `throw RunnerShapeGap.ReportConstruction(...)` added to RecordPatches.cs took the real count to
+// 10 and the test still passed. The scan is now discovered rather than listed, it refuses a root
+// it finds nothing in (a scan with nothing to scan reports zero violations and reads as success),
+// and both counting helpers strip comments so prose cannot move a number that tracks code. The
+// number did not change: the five happened to hold all nine runtime sites, so this closes a hole
+// rather than correcting a count.
+//
 // WHY A RUNNER-SIDE MECHANISM TEST AND NOT AN AL BUNDLE OR A CORPUS TEST
 // ----------------------------------------------------------------------
 // No AL statement can move a private BC field, and no statement about Business Central is being
@@ -191,6 +203,89 @@ public sealed class FieldTriggerShapeGapCallSiteTests : IDisposable
     {
         try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
     }
+
+    // ── the repo-wide guard scan (#3092) ────────────────────────────────────────────────
+    //
+    // DocsCountOfRuntimeShapeGapGuards used to count over a hard-coded five-FILENAME list, so a
+    // guard added to any other file left it green while docs/limitations.md went stale — the
+    // exact drift it was written to catch. Measured on the merged tree: adding a
+    // `throw RunnerShapeGap.ReportConstruction(...)` to RecordPatches.cs, which is not one of the
+    // five, moved the real count to 10 and the test still passed.
+    //
+    // The scan below is discovered rather than listed, so a new file is covered the moment it
+    // exists. Three properties keep it honest, each pinned by its own test:
+    //
+    //   * it CANNOT PASS VACUOUSLY. A scan that finds nothing reports zero mismatches and reads
+    //     as success, which is the worst thing a guard can do. ProductionSources throws when a
+    //     root yields no sources, and the real scan additionally asserts a floor on the file
+    //     count, so a glob that silently narrows to a handful of files fails rather than passes.
+    //   * it EXCLUDES .claude, and that is load-bearing rather than tidiness. Agent worktrees
+    //     live in .claude/worktrees/, each a full checkout of this repository: 9,078 further .cs
+    //     files in the main checkout at the time of writing. Walking into them would count every
+    //     other branch's guards, so the number would be wrong locally and right in CI, where the
+    //     directory does not exist. That divergence is worse than the bug being fixed.
+    //   * it EXCLUDES test projects (any *.Tests directory). Guards are production call sites;
+    //     a `throw RunnerShapeGap.` written in a fixture or an expected-value string is not one,
+    //     and counting them would let a test move the number the docs are held to.
+
+    private static readonly string[] SkippedDirectories =
+    {
+        "bin", "obj", ".git", ".claude", ".vs", "node_modules", "packages",
+        "tests",   // the al-language submodule and the AL corpora — no production C# lives here
+    };
+
+    /// <summary>
+    /// Every production C# source under <paramref name="root"/>, discovered by walking rather
+    /// than by a maintained list. Throws when the walk finds nothing, so "the directory moved"
+    /// can never be mistaken for "no violations found".
+    /// </summary>
+    private static IReadOnlyList<string> ProductionSources(string root)
+    {
+        var found = new List<string>();
+        var pending = new Stack<string>();
+        pending.Push(root);
+
+        while (pending.Count > 0)
+        {
+            var dir = pending.Pop();
+            foreach (var sub in Directory.EnumerateDirectories(dir))
+            {
+                var name = Path.GetFileName(sub);
+                if (SkippedDirectories.Contains(name, StringComparer.Ordinal)) continue;
+                if (name.EndsWith(".Tests", StringComparison.Ordinal)) continue;
+                pending.Push(sub);
+            }
+
+            found.AddRange(Directory.EnumerateFiles(dir, "*.cs"));
+        }
+
+        if (found.Count == 0)
+            throw new InvalidOperationException(
+                $"The guard scan found no C# sources under '{root}'. A scan with nothing to scan " +
+                "reports zero violations and reads as success, so it fails here instead (#3092).");
+
+        found.Sort(StringComparer.Ordinal);
+        return found;
+    }
+
+    /// <summary>
+    /// The source of <paramref name="path"/> with whole-line <c>//</c> comments removed. Both
+    /// counting helpers strip comments, for the reason VirtualTableRefusalClaimTests already
+    /// documents: headers in this repository quote old wordings on purpose, and the claim under
+    /// test is about CODE. Measured before this was shared: a commented-out
+    /// <c>throw RunnerShapeGap.</c> in NavReportSync.cs turned the count red, so prose could
+    /// move a number that is supposed to track code (#3092).
+    /// </summary>
+    private static string CodeOf(string path)
+    {
+        Assert.True(File.Exists(path), $"{path} not found — was it renamed?");
+        return string.Join('\n', File.ReadAllLines(path)
+            .Where(l => !l.TrimStart().StartsWith("//", StringComparison.Ordinal)));
+    }
+
+    /// <summary>Total matches of <paramref name="pattern"/> across <paramref name="files"/>, comments stripped.</summary>
+    private static int CountAcross(IEnumerable<string> files, string pattern) =>
+        files.Sum(f => Regex.Matches(CodeOf(f), pattern).Count);
 
     // ── plumbing (same shape as FieldTriggerHandlerBackingShapeGapTests) ────────────────
 
@@ -648,15 +743,16 @@ public sealed class FieldTriggerShapeGapCallSiteTests : IDisposable
         ["HandlerConstruction"] = 4,                   // 2 absent types + 2 absent constructors
     };
 
-    private static string InstallPathCode()
-    {
-        var path = Path.Combine(RepoRoot, "AlRunner", "Patches", "RecordPatches.NclMetaTableBuilder.cs");
-        Assert.True(File.Exists(path), $"{path} not found — was it renamed?");
-        // Comments are stripped first: the file's headers quote the OLD `&& _fXxx != null`
-        // wording on purpose, and the claim under test is about CODE.
-        return string.Join('\n', File.ReadAllLines(path)
-            .Where(l => !l.TrimStart().StartsWith("//", StringComparison.Ordinal)));
-    }
+    private static readonly string InstallPathFile =
+        Path.Combine(RepoRoot, "AlRunner", "Patches", "RecordPatches.NclMetaTableBuilder.cs");
+
+    // The census below and TheTwoUninjectableSites read ONE file on purpose: they assert
+    // per-helper call-site counts on the field-trigger install path, and that path is this file.
+    // That is the same narrowing #3092 removed from the runtime-guard count, so it is not left
+    // to a comment — EveryFieldTriggerShapeGapSiteIsOnTheInstallPath asserts repo-wide that no
+    // FieldTriggerShapeGap call site exists anywhere else, which is what makes reading one file
+    // complete rather than merely convenient.
+    private static string InstallPathCode() => CodeOf(InstallPathFile);
 
     [Fact]
     public void AllSeventeenCallSitesStillStand_SoNoneDriftedBackToASilentNullCheck()
@@ -840,6 +936,42 @@ public sealed class FieldTriggerShapeGapCallSiteTests : IDisposable
 
     // ── 7. THE DOCS COUNT THAT WENT STALE ─────────────────────────────────────────────
 
+    /// <summary>
+    /// Every <c>throw RunnerShapeGap.&lt;Factory&gt;</c> in production code, keyed by factory.
+    /// Repo-wide (#3092) rather than over a five-filename list.
+    /// </summary>
+    private static Dictionary<string, int> RunnerShapeGapSitesByFactory()
+    {
+        var sources = ProductionSources(RepoRoot);
+
+        // Anti-vacuous floor. ProductionSources already refuses an empty walk; this catches the
+        // subtler version, where an exclusion or a moved directory quietly narrows the scan to a
+        // handful of files and every count below still "matches".
+        Assert.True(sources.Count >= 150,
+            $"The guard scan found only {sources.Count} production C# sources under {RepoRoot}. " +
+            "That is far below this repository's size, so an exclusion or a renamed directory has " +
+            "narrowed the scan and the counts below would be measuring almost nothing (#3092).");
+
+        var byFactory = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var file in sources)
+            foreach (Match m in Regex.Matches(CodeOf(file), @"throw (?:AlRunner\.Patches\.)?RunnerShapeGap\.([A-Za-z]+)"))
+            {
+                var factory = m.Groups[1].Value;
+                byFactory[factory] = byFactory.TryGetValue(factory, out var n) ? n + 1 : 1;
+            }
+
+        return byFactory;
+    }
+
+    /// <summary>
+    /// RunnerShapeGap.Query routes to <c>docs/limitations.md#query-shape-gaps</c>, a DIFFERENT
+    /// section with its own prose, so it is not one of the runtime guards this count is about.
+    /// It is excluded by name rather than by file, because the query sites live in files
+    /// (RecordPatches.QueryProjection.cs, RecordPatches.QueryJoin.cs) that a filename-based scan
+    /// would have had to know about in advance — the failure mode #3092 is removing.
+    /// </summary>
+    private const string QueryFactory = "Query";
+
     [Fact]
     public void DocsCountOfRuntimeShapeGapGuards_MatchesTheCallSitesThatExist()
     {
@@ -848,20 +980,19 @@ public sealed class FieldTriggerShapeGapCallSiteTests : IDisposable
         // which is how an unpinned count in prose goes stale. The counting rule is CALL SITES,
         // the same rule the original nine were counted under, and it is asserted here so the
         // next addition cannot leave the prose behind.
-        var guardFiles = new[]
-        {
-            "UserTableTriggerPatches.cs",            // 3 — no session, no metadata, no such field
-            "RecordPatches.InstallBaseline.cs",      // 1 — table not backed by TempTableDataProvider
-            "RunnerTestClientSession.cs",            // 1 — modal handler asked for an unknown form handle
-            "RunnerModalDispatch.cs",                // 2 — null test-execution context, null request
-            "NavReportSync.cs",                      // 2 — report object, request page
-        };
+        //
+        // #3092 widened this from five hard-coded filenames to a repo-wide scan. The number did
+        // not move — the five happened to hold all nine runtime sites on the day — so this is a
+        // hole closed, not a count corrected.
+        var byFactory = RunnerShapeGapSitesByFactory();
 
-        var runnerShapeGapSites = guardFiles.Sum(f => Regex.Matches(
-            File.ReadAllText(Path.Combine(RepoRoot, "AlRunner", "Patches", f)),
-            @"throw (?:AlRunner\.Patches\.)?RunnerShapeGap\.").Count);
+        var runnerShapeGapSites = byFactory
+            .Where(kv => kv.Key != QueryFactory)
+            .Sum(kv => kv.Value);
 
-        var installGapSites = Regex.Matches(InstallPathCode(), @"throw FieldTriggerInstallGap\.").Count;
+        var installGapSites = CountAcross(
+            ProductionSources(RepoRoot), @"throw (?:AlRunner\.Patches\.)?FieldTriggerInstallGap\.");
+
         var total = runnerShapeGapSites + installGapSites;
 
         Assert.Equal(9, runnerShapeGapSites);
@@ -871,6 +1002,137 @@ public sealed class FieldTriggerShapeGapCallSiteTests : IDisposable
         var limitations = File.ReadAllText(Path.Combine(RepoRoot, "docs", "limitations.md"));
         Assert.Contains($"{total} further guards raise `RunnerOutOfScopeException`", limitations,
             StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheScanReachesTheFilesTheHardCodedListMissed_AndStillReachesTheFiveItHad()
+    {
+        // The five filenames that WERE the whole scan before #3092.
+        var oldList = new[]
+        {
+            "UserTableTriggerPatches.cs",
+            "RecordPatches.InstallBaseline.cs",
+            "RunnerTestClientSession.cs",
+            "RunnerModalDispatch.cs",
+            "NavReportSync.cs",
+        };
+
+        var scanned = ProductionSources(RepoRoot)
+            .Select(Path.GetFileName)
+            .ToHashSet(StringComparer.Ordinal);
+
+        // Nothing was lost widening it.
+        foreach (var file in oldList)
+            Assert.Contains(file, scanned);
+
+        // RecordPatches.cs is the file #3092 measured the miss on: a guard added there left the
+        // old scan green. It is in the set now, and so is every other production source.
+        Assert.Contains("RecordPatches.cs", scanned);
+
+        // Files that hold RunnerShapeGap sites today and were NOT on the old list. Had a runtime
+        // guard rather than a Query one landed in either, the docs would have gone stale silently.
+        Assert.Contains("RecordPatches.QueryProjection.cs", scanned);
+        Assert.Contains("RecordPatches.QueryJoin.cs", scanned);
+
+        // Projects other than AlRunner are production too, and the old list could not see them.
+        Assert.Contains("JoinExecutor.cs", scanned);
+
+        Assert.True(scanned.Count > oldList.Length,
+            "The widened scan must be a strict superset of the five filenames it replaced.");
+    }
+
+    [Fact]
+    public void AGuardInANewlyScannedFileIsCounted_AndACommentedOutOneIsNot()
+    {
+        // The negative control the finding came from, run through the SAME counting code that
+        // produces the number above: a guard in a file no list mentions must move the count.
+        var dir = Path.Combine(TestScratch.Dir("al-runner-3092-scan"), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+
+        var real = Path.Combine(dir, "NewlyAddedPatches.cs");
+        File.WriteAllText(real,
+            "internal static class NewlyAddedPatches\n{\n" +
+            "    internal static void Guard()\n" +
+            "        => throw RunnerShapeGap.ReportConstruction(\"Probe.Api\", \"probe\");\n}\n");
+
+        const string pattern = @"throw (?:AlRunner\.Patches\.)?RunnerShapeGap\.([A-Za-z]+)";
+        Assert.Equal(1, CountAcross(new[] { real }, pattern));
+
+        // ...and the mirror: a count that a COMMENT can move is a count that will eventually be
+        // "fixed" by editing prose. Both counting helpers strip comments, so this reads zero.
+        var commented = Path.Combine(dir, "CommentedOutPatches.cs");
+        File.WriteAllText(commented,
+            "internal static class CommentedOutPatches\n{\n" +
+            "    // was: throw RunnerShapeGap.ReportConstruction(\"Probe.Api\", \"probe\");\n" +
+            "    internal static void Guard() { }\n}\n");
+
+        Assert.Equal(0, CountAcross(new[] { commented }, pattern));
+
+        // The install-path counter strips comments too — it always did, and now both share one
+        // implementation so they cannot drift apart again.
+        var installish = Path.Combine(dir, "InstallishPatches.cs");
+        File.WriteAllText(installish,
+            "internal static class InstallishPatches\n{\n" +
+            "    // throw FieldTriggerInstallGap.FieldUnresolvable(target, 42);\n" +
+            "    internal static void Live()\n" +
+            "        => throw FieldTriggerInstallGap.UnsupportedTriggerReturnType(\"t\", \"r\");\n}\n");
+
+        Assert.Equal(1, CountAcross(new[] { installish },
+            @"throw (?:AlRunner\.Patches\.)?FieldTriggerInstallGap\."));
+    }
+
+    [Fact]
+    public void TheScanRefusesARootWithNothingInIt_SoItCannotReportSuccessByFindingNothing()
+    {
+        // The failure this guard must not have: a renamed directory or a changed exclusion leaves
+        // the walk empty, zero mismatches are found, and the test passes. Constructed on purpose.
+        var root = Path.Combine(TestScratch.Dir("al-runner-3092-empty"), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        var empty = Assert.Throws<InvalidOperationException>(() => ProductionSources(root));
+        Assert.Contains("found no C# sources", empty.Message, StringComparison.Ordinal);
+
+        // A root holding ONLY excluded content is just as empty, and must fail the same way
+        // rather than silently counting zero. One entry per exclusion, so a dropped exclusion
+        // shows up here as a test that stops throwing.
+        foreach (var excluded in SkippedDirectories.Concat(new[] { "Some.Tests" }))
+        {
+            var sub = Path.Combine(root, excluded);
+            Directory.CreateDirectory(sub);
+            File.WriteAllText(Path.Combine(sub, "Generated.cs"),
+                "internal static class G { internal static void X() => throw RunnerShapeGap.Query(\"a\", \"b\", \"c\"); }");
+        }
+
+        var stillEmpty = Assert.Throws<InvalidOperationException>(() => ProductionSources(root));
+        Assert.Contains("found no C# sources", stillEmpty.Message, StringComparison.Ordinal);
+
+        // ...and one real file in the same root is found, so the exclusions are not simply
+        // swallowing everything.
+        File.WriteAllText(Path.Combine(root, "Real.cs"), "internal static class R { }");
+        Assert.Single(ProductionSources(root));
+    }
+
+    [Fact]
+    public void EveryFieldTriggerShapeGapSiteIsOnTheInstallPath_SoReadingOneFileIsComplete()
+    {
+        // AllSeventeenCallSitesStillStand and TheTwoUninjectableSites read
+        // RecordPatches.NclMetaTableBuilder.cs alone. That is correct only while the install path
+        // IS that file; #3092 flagged it as the same narrowing rather than leaving it to a
+        // comment. If a FieldTriggerShapeGap site ever lands elsewhere, the census above would go
+        // blind to it exactly the way the runtime count did — so it fails here first.
+        var strays = ProductionSources(RepoRoot)
+            .Where(f => !string.Equals(f, InstallPathFile, StringComparison.Ordinal))
+            .Select(f => (File: f, Hits: Regex.Matches(CodeOf(f), @"FieldTriggerShapeGap\.[A-Za-z]+\(").Count))
+            .Where(x => x.Hits > 0)
+            .ToList();
+
+        Assert.True(strays.Count == 0,
+            "FieldTriggerShapeGap call sites exist outside the install-path file, which the " +
+            "seventeen-site census cannot see: " +
+            string.Join(", ", strays.Select(x => $"{x.File} ({x.Hits})")));
+
+        // ...and the install path really does hold them, so the assertion above is not vacuous.
+        Assert.Equal(17, Regex.Matches(InstallPathCode(), @"FieldTriggerShapeGap\.[A-Za-z]+\(").Count);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #3092

`DocsCountOfRuntimeShapeGapGuards` asserts that `docs/limitations.md`'s count of runtime shape-gap
guards matches the code, but it counted over a hard-coded five-**filename** list. A guard added to
any other file left it green while the documented number went stale — the exact drift it was written
to catch. A guard that scans a narrower set than the property it claims does not fail when it goes
blind; it keeps passing.

## RED → GREEN

**RED, the defect itself.** Injected `throw RunnerShapeGap.ReportConstruction(...)` into
`AlRunner/Patches/RecordPatches.cs` — not one of the five — reproducing the issue's measurement. The
real count became 10, the docs still said 12, and the existing test passed:

```
Passed!  - Failed: 0, Passed: 1  (with the tenth guard present)
```

**RED, the widened scan.** Same probe still in place, new scan in: it sees what the old one could
not, and fails for exactly the right reason.

```
DocsCountOfRuntimeShapeGapGuards_MatchesTheCallSitesThatExist [FAIL]
  Assert.Equal() Failure: Values differ
  Expected: 9
  Actual:   10
```

**GREEN.** Probe removed (`AlRunner/Patches/RecordPatches.cs` restored from a copy taken outside the
repository; md5 `1d91bd8c` verified identical, and `git status` shows the file untouched in the
diff). `FieldTriggerShapeGapCallSiteTests` + `VirtualTableRefusalClaimTests`: **103 passed, 0
failed**, 28 skipped (the pre-existing artifact-dependent `SkippableFact`s).

## The count did not move, and where that number comes from

**9 runtime + 3 install = 12**, unchanged. The five files happened to hold all nine runtime sites on
the day, so this closes a hole rather than correcting a count — as #3092 predicted. Every number in
this PR was read from a test's own failure output or from a scan run in Python, never computed by
hand.

The widened scan finds **18** `throw RunnerShapeGap.` sites repo-wide against the old list's 9. The
extra 9 are all `RunnerShapeGap.Query` in `RecordPatches.QueryProjection.cs` (7) and
`RecordPatches.QueryJoin.cs` (2) — correctly excluded, since `Query` routes to
`docs/limitations.md#query-shape-gaps`, a different section with its own prose. **`Query` is excluded
by factory name, not by file**: excluding it by file would have required the scan to know those two
filenames in advance, which is the failure mode being removed.

`VirtualTableRefusalClaimTests`' count of **68** is deliberately untouched and verified still green.
The two regexes are disjoint — `throw [A-Za-z]+(?<!Bc)ShapeGap\(` needs `ShapeGap(` directly, and
`RunnerShapeGap.Foo(` has a dot in between — so nothing here moves it.

## It cannot pass vacuously

The failure to avoid was a scan that finds zero files and reports success. Three properties, each
pinned by its own test, and both **mutation-tested** rather than assumed:

- `ProductionSources` **throws** when a root yields no C# sources.
  `TheScanRefusesARootWithNothingInIt` builds that condition on purpose — an empty root, then a root
  holding *only* excluded content, one directory per exclusion so a dropped exclusion shows up as a
  test that stops throwing — then drops one real file in to prove the exclusions are not simply
  swallowing everything. Mutation: disabling the throw ⇒ `Assert.Throws() Failure: No exception was
  thrown`.
- A **floor of 150 files** on the real scan catches the subtler version, where an exclusion or a
  renamed directory narrows it to a handful and every count still "matches". Mutation: hiding the
  `AlRunner` directory ⇒ `The guard scan found only 8 production C# sources ... an exclusion or a
  renamed directory has narrowed the scan`.
- **Both directions of detection.** `AGuardInANewlyScannedFileIsCounted_AndACommentedOutOneIsNot`
  runs the same counting code over a guard written into a file no list mentions (counted: 1) and a
  commented-out one (not counted: 0) — so a legitimate site is caught and prose cannot move the
  number.

`TheScanReachesTheFilesTheHardCodedListMissed_AndStillReachesTheFiveItHad` asserts the new set is a
strict superset of the old five, and that it reaches `RecordPatches.cs` — the file the miss was
measured on.

## `.claude` is excluded, and that is load-bearing

Agent worktrees under `.claude/worktrees/` are full checkouts of this repository: **9,078 further
`.cs` files** in the main checkout right now. A naive repo-wide walk would count every other branch's
guards, making the number wrong locally and right in CI, where the directory does not exist. That
divergence would be worse than the bug being fixed, so the exclusion carries a comment saying why.
Test projects are excluded too — guards are production call sites.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — the `FieldTriggerInstallGap` count read one
   file via `InstallPathCode()`. Widened to the same repo-wide scan.
2. **Sibling function making the same assumption?** Yes — the seventeen-site census and
   `TheTwoUninjectableSites` read `RecordPatches.NclMetaTableBuilder.cs` alone. #3092 said this was
   "worth a comment if it is not widened"; instead of a comment,
   `EveryFieldTriggerShapeGapSiteIsOnTheInstallPath` asserts repo-wide that no `FieldTriggerShapeGap`
   call site exists anywhere else (measured: all 17 are on the install path). That converts the
   narrowing from an unfalsifiable assumption into a checked invariant, and the assertion is
   non-vacuous because it also pins the 17.
3. **Two paths writing the same state with different invariants?** Yes — the two counting helpers
   treated comments differently (`InstallPathCode()` stripped `//`, the `RunnerShapeGap` count did
   not). They now share one `CodeOf` implementation, so they cannot drift apart again.

## Does this assert anything about what BC does?

**No.** This is a repository guard over our own source tree — it counts `throw` sites in this
repository's C# and compares them to this repository's docs. No service tier can adjudicate it, and
it owes nothing to the upstream corpus (`.claude/rules/bc-behavior-tests-go-upstream.md`).

## Deliberately left out

- **`VirtualTableRefusalClaimTests` is the same shape and has a real blind spot**: a repo-wide scan
  finds **10** matching sites in `RecordPatches.ObjectMetadataSystemTable.cs` that its hard-coded
  19-file list does not count. That exclusion looks deliberate — the file is #2894's and "keeps its
  own factory", while the count is about the refusals #2945 corrected — but nothing asserts it stays
  put. Widening it would move a load-bearing 68 and change the meaning of a claim owned by a
  different issue, so it is **not** touched here. Filing as a follow-up rather than fixing silently
  (`.claude/rules/file-issues-for-gaps.md`).
- No `AlRunner/` production code changed, so `require-tests` is not triggered; the diff is one test
  file.
- No docs change: the documented number is still 12.

---
*Written by an agent (`stma-auto-1`, autonomous cycle 137) acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
