### PR TITLE
test(events): cover the ValueTask<T> reflection arm at both async-unwrap seams

### DIFF
--- a/AlRunner.Tests/AwaitIfTaskTests.cs
+++ b/AlRunner.Tests/AwaitIfTaskTests.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Threading.Tasks;
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Pins <c>BcRuntime.AwaitIfTask</c>, the third of the runner's three async-unwrapping seams
+/// and — until #3115 — the only one with no tests at all.
+///
+/// The other two are <c>BcRuntime.ObserveAsyncResult</c> (event dispatch;
+/// DispatchObserveAsyncResultTests.cs and ObservingSubscriberMethodInfoTests.cs) and
+/// <c>RunnerPageInstance.AwaitTriggerResult</c> (page triggers; PageTriggerAwaitTests.cs). All
+/// three exist for one reason: BC's AL compiler emits an async state machine whenever the body
+/// needs one, an exception raised inside such a body is CAPTURED onto the returned
+/// Task/ValueTask instead of thrown, and discarding that awaitable therefore discards the AL
+/// author's Error().
+///
+/// This seam is the one on <c>Codeunit.Run</c> (CodeunitPatches) and on the report trigger
+/// invocations in NavReportSync, so a swallow here means a codeunit or report that raised an
+/// error appears to have succeeded — see .claude/rules/loud-failures.md.
+///
+/// WHY C# AND NOT AL: the shape being covered is which CLR arm unwraps which awaitable type.
+/// AL cannot observe or distinguish that — an AL reproducer takes whichever arm the emit
+/// produced and passes either way — and the runner's own emitter produces synchronous bodies,
+/// so first-party AL cannot even reach the async shapes. The BC-behaviour claim that an AL
+/// error reaches its caller is pinned upstream in the al-language corpus; what is pinned here
+/// is the runner-side mechanism that makes it hold.
+/// </summary>
+public class AwaitIfTaskTests
+{
+    [Fact]
+    public void FaultedTask_RethrowsTheOriginalException()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => BcRuntime.AwaitIfTask(Task.FromException(new InvalidOperationException("task boom"))));
+
+        // The ORIGINAL exception, not an AggregateException — an AL `asserterror` matches on
+        // the message, so a wrapper would break it.
+        Assert.Equal("task boom", ex.Message);
+    }
+
+    [Fact]
+    public void FaultedValueTask_RethrowsTheOriginalException()
+    {
+        var failed = new ValueTask(Task.FromException(new InvalidOperationException("valuetask boom")));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => BcRuntime.AwaitIfTask(failed));
+
+        Assert.Equal("valuetask boom", ex.Message);
+    }
+
+    [Fact]
+    public void FaultedGenericValueTask_RethrowsTheOriginalException_ThroughTheReflectionArm()
+    {
+        // ValueTask<T> is the arm that needs reflection: boxed, it matches neither
+        // `case Task t` nor `case ValueTask vt`, so AwaitIfTask can only reach it through
+        // ValueTask<>.AsTask. Assert that first, so this test cannot quietly drift onto one of
+        // the arms above and stop proving anything about the reflection. Remove that arm and
+        // this test fails with "no exception was thrown" — the silent swallow itself.
+        object failed = new ValueTask<int>(Task.FromException<int>(new InvalidOperationException("generic boom")));
+        Assert.IsType<ValueTask<int>>(failed);
+        Assert.False(failed is Task, "ValueTask<T> must not match `case Task t`");
+        Assert.False(failed is ValueTask, "ValueTask<T> must not match `case ValueTask vt`");
+
+        var ex = Assert.Throws<InvalidOperationException>(() => BcRuntime.AwaitIfTask(failed));
+
+        Assert.Equal("generic boom", ex.Message);
+    }
+
+    [Fact]
+    public void SuccessfulResults_AreAwaitedWithoutBeingTurnedIntoFailures()
+    {
+        // Negative half: a synchronous trigger returns null, a completed async one returns a
+        // completed awaitable, and neither may be turned into a failure by the observation.
+        BcRuntime.AwaitIfTask(null);
+        BcRuntime.AwaitIfTask(Task.CompletedTask);
+        BcRuntime.AwaitIfTask(default(ValueTask));
+        BcRuntime.AwaitIfTask(new ValueTask<int>(7));
+    }
+
+    [Fact]
+    public void NonAwaitableReturnValue_IsIgnored()
+    {
+        // A trigger may legitimately return an ordinary value; unwrapping must not choke on it.
+        BcRuntime.AwaitIfTask("a string");
+        BcRuntime.AwaitIfTask(42);
+    }
+
+    [Fact]
+    public void AwaitedBodyRunsToCompletion_NotJustToItsFirstAwait()
+    {
+        // "It did not throw" is not enough: the state machine has to have RUN. An
+        // AwaitIfTask that returned before completing the awaitable would pass every test
+        // above that only checks for the absence of an exception.
+        int ran = 0;
+        async ValueTask<int> Body()
+        {
+            ran++;
+            await Task.Yield();
+            ran++;
+            return 1;
+        }
+
+        BcRuntime.AwaitIfTask(Body());
+        Assert.Equal(2, ran);
+    }
+}

--- a/AlRunner.Tests/ObservingSubscriberMethodInfoTests.cs
+++ b/AlRunner.Tests/ObservingSubscriberMethodInfoTests.cs
@@ -64,6 +64,23 @@ public class ObservingSubscriberMethodInfoTests
             await Task.Yield();
             throw new InvalidOperationException("ASYNC-GENERIC-SUBSCRIBER-ERROR");
         }
+
+        // async ValueTask<T> is the ONLY shape that reaches BcRuntime.ObserveAsyncResult's
+        // last arm — the one that has to find ValueTask<>.AsTask by reflection, because a
+        // boxed ValueTask<T> is neither a Task nor a ValueTask and so matches no case label.
+        public async ValueTask<int> AsyncGenericValueTaskThrows()
+        {
+            AsyncCalls++;
+            await Task.Yield();
+            throw new InvalidOperationException("ASYNC-GENERIC-VALUETASK-SUBSCRIBER-ERROR");
+        }
+
+        public async ValueTask<int> AsyncGenericValueTaskOk()
+        {
+            AsyncCalls++;
+            await Task.Yield();
+            return 42;
+        }
     }
 
     private static MethodInfo M(string name) =>
@@ -113,10 +130,64 @@ public class ObservingSubscriberMethodInfoTests
     [Fact]
     public void AsyncGenericSubscriberThatThrows_AlsoSurfacesTheError()
     {
-        // Task<T> / ValueTask<T> take a different arm of BcRuntime.ObserveAsyncResult.
+        // Task<T> takes the SAME arm of BcRuntime.ObserveAsyncResult as a plain Task —
+        // `case Task t`, because Task<T> derives from Task. An earlier version of this
+        // comment claimed a different arm; that was wrong (#3115), so the claim is asserted
+        // here rather than left as prose. The genuinely different arm is ValueTask<T>'s,
+        // covered by AsyncGenericValueTaskSubscriberThatThrows_... below.
+        var raw = M(nameof(Subscriber.AsyncGenericThrows)).Invoke(new Subscriber(), null);
+        Assert.IsAssignableFrom<Task>(raw);
+
         var tie = Assert.Throws<TargetInvocationException>(
             () => Invoke(M(nameof(Subscriber.AsyncGenericThrows)), new Subscriber()));
         Assert.Equal("ASYNC-GENERIC-SUBSCRIBER-ERROR", tie.InnerException!.Message);
+    }
+
+    [Fact]
+    public void AsyncGenericValueTaskSubscriberThatThrows_SurfacesTheErrorThroughTheReflectionArm()
+    {
+        // The arm this test exists for: a boxed ValueTask<T> matches NEITHER `case Task t`
+        // NOR `case ValueTask vt`, so BcRuntime.ObserveAsyncResult can only observe it by
+        // finding ValueTask<>.AsTask through reflection. Assert that first — otherwise this
+        // test could silently drift onto one of the arms the tests above already cover and
+        // stop proving anything about the reflection. Remove that arm and this test fails
+        // with "no exception was thrown", which is exactly the swallow of #2932.
+        var target = new Subscriber();
+        var raw = M(nameof(Subscriber.AsyncGenericValueTaskThrows)).Invoke(target, null)!;
+        Assert.IsType<ValueTask<int>>(raw);
+        Assert.False(raw is Task, "ValueTask<T> must not match `case Task t`");
+        Assert.False(raw is ValueTask, "ValueTask<T> must not match `case ValueTask vt`");
+
+        // Undecorated, MethodInfo.Invoke RETURNED NORMALLY above: the error is reachable only
+        // by completing the returned ValueTask<int>. That is precisely the value BC's
+        // memberId==0 branch discards, and precisely the swallow #2932 was about.
+        var onlyOnTheTask = Assert.Throws<InvalidOperationException>(
+            () => ((ValueTask<int>)raw).AsTask().GetAwaiter().GetResult());
+        Assert.Equal("ASYNC-GENERIC-VALUETASK-SUBSCRIBER-ERROR", onlyOnTheTask.Message);
+        Assert.Equal(1, target.AsyncCalls);
+
+        // Decorated, the same call raises — wrapped in a TargetInvocationException, which is
+        // what routes it to BC's CallEventSubscriberInternalAsync ExceptionDispatchInfo arm,
+        // the same arm a synchronously-thrown subscriber error already takes.
+        var decoratedTarget = new Subscriber();
+        var tie = Assert.Throws<TargetInvocationException>(
+            () => Invoke(M(nameof(Subscriber.AsyncGenericValueTaskThrows)), decoratedTarget));
+        var inner = Assert.IsType<InvalidOperationException>(tie.InnerException);
+        Assert.Equal("ASYNC-GENERIC-VALUETASK-SUBSCRIBER-ERROR", inner.Message);
+        // The state machine ran to the throw rather than being short-circuited.
+        Assert.Equal(1, decoratedTarget.AsyncCalls);
+    }
+
+    [Fact]
+    public void AsyncGenericValueTaskSubscriberThatSucceeds_ReturnsItsValueAndRanItsBody()
+    {
+        // Negative half: observing the reflection arm must not manufacture a failure, and
+        // must not eat the subscriber's return value either — BC's memberId==0 branch
+        // discards it, but the decorator sits in front of BC and has to hand it back.
+        var target = new Subscriber();
+        var result = Invoke(M(nameof(Subscriber.AsyncGenericValueTaskOk)), target);
+        Assert.Equal(42, Assert.IsType<ValueTask<int>>(result).AsTask().GetAwaiter().GetResult());
+        Assert.Equal(1, target.AsyncCalls);
     }
 
     // ---- and the negative half: it must not manufacture failures ---------------------
@@ -174,5 +245,33 @@ public class ObservingSubscriberMethodInfoTests
         Assert.Equal(1, withParam.GetParameters().Length);
         Assert.Equal(typeof(int), withParam.GetParameters()[0].ParameterType);
         Assert.Equal(typeof(void), withParam.ReturnType);
+    }
+
+    [Fact]
+    public void EqualsIsAsymmetric_ByDesignAndPinnedHere()
+    {
+        // Equality on this decorator is asymmetric, and that is deliberate (#3115): the
+        // decorator answers as the method it wraps, and the inner RuntimeMethodInfo cannot be
+        // taught to answer back. It is safe only because nothing compares it — see the doc
+        // comment on ObservingSubscriberMethodInfo.Equals for the whole-assembly scan of
+        // Ncl.dll that establishes that. This test is here so that changing the semantics is
+        // a deliberate act rather than a silent one, and so the hash/equality mismatch below
+        // is on the record for whoever puts one of these in a set.
+        var inner = M(nameof(Subscriber.AsyncOk));
+        var decorator = new ObservingSubscriberMethodInfo(inner);
+
+        Assert.True(decorator.Equals(inner));
+        Assert.False(inner.Equals(decorator));
+        Assert.True(decorator.Equals(new ObservingSubscriberMethodInfo(inner)));
+        Assert.False(decorator.Equals(new ObservingSubscriberMethodInfo(M(nameof(Subscriber.SyncOk)))));
+        Assert.False(decorator.Equals(null));
+
+        // Same hash as the inner method. That is what makes the asymmetry reachable in a
+        // hashed collection at all — both land in the same bucket, and only then does the
+        // direction of the Equals call decide the answer, so such a collection would report
+        // membership differently depending on which of the two was stored. Not asserted here:
+        // which side a given collection calls Equals on is a BCL implementation detail, and
+        // pinning it would be pinning the BCL rather than this type.
+        Assert.Equal(inner.GetHashCode(), decorator.GetHashCode());
     }
 }

--- a/AlRunner/Patches/ObservingSubscriberMethodInfo.cs
+++ b/AlRunner/Patches/ObservingSubscriberMethodInfo.cs
@@ -122,6 +122,40 @@ internal sealed class ObservingSubscriberMethodInfo : MethodInfo
     public override MethodInfo GetGenericMethodDefinition() => _inner.GetGenericMethodDefinition();
     public override MethodBody? GetMethodBody() => _inner.GetMethodBody();
     public override string ToString() => _inner.ToString()!;
+    /// <summary>
+    /// DELIBERATELY ASYMMETRIC, and safe only because nothing compares this object (#3115).
+    ///
+    /// <c>decorator.Equals(inner)</c> is <c>true</c> — the decorator answers as the method it
+    /// wraps, which is the point. <c>inner.Equals(decorator)</c> is <c>false</c>: the inner
+    /// <c>RuntimeMethodInfo</c> knows nothing about this type and there is no way to teach it.
+    /// <see cref="GetHashCode"/> returns the inner method's hash either way, so a
+    /// <c>HashSet</c>/<c>Dictionary</c> holding one of the two and probed with the other hits
+    /// the same bucket and then answers differently depending on WHICH side was stored — which
+    /// side a given collection calls <c>Equals</c> on is a BCL implementation detail, so the
+    /// only safe reading is that membership is not well-defined for a mixed collection.
+    ///
+    /// Why that is harmless today — measured, not assumed:
+    ///
+    ///  * On the runner side, <c>EventSubscriberPatches._injectedSubscriberMethods</c> is keyed
+    ///    on the inner <c>sub.Method</c> and this decorator is never added to it. It is
+    ///    constructed in <c>BuildSubscription</c> and handed straight to BC.
+    ///  * It DOES outlive that call — BC's <c>NavEventSubscription</c> ctor stores
+    ///    <c>subscriberMethodInfo.RawMethodInfo</c> and re-exposes it as the public
+    ///    <c>SubscriberMethodInfo</c> property — but a whole-assembly scan of
+    ///    <c>Microsoft.Dynamics.Nav.Ncl.dll</c> 28.1.49838.53910 finds only three uses of that
+    ///    property: <c>.DeclaringType</c>, <c>.Invoke(...)</c>, and the
+    ///    <c>EventSubscriberDiagnosticMessage</c> helpers reading <c>Name</c>/<c>GetParameters</c>/
+    ///    <c>ReturnType</c>. No equality comparison, and no collection keyed on it —
+    ///    <c>NavEventScope.RemoveSubscribersFromAppGroup</c> removes by
+    ///    <c>SubscriberNavAppGroup.GroupId</c>, not by method identity.
+    ///
+    /// So: do NOT "fix" the asymmetry on sight. Making it symmetric would mean changing what
+    /// the decorator claims to be equal to, across every BC reflection path that receives it,
+    /// for a comparison no caller performs. If a caller ever does start comparing it, THAT is
+    /// the change to reason about, and <c>EqualsIsAsymmetric_ByDesignAndPinnedHere</c> in
+    /// <c>AlRunner.Tests/ObservingSubscriberMethodInfoTests.cs</c> is the test that will make
+    /// it a deliberate decision rather than a silent one.
+    /// </summary>
     public override bool Equals(object? obj)
         => obj is ObservingSubscriberMethodInfo o ? _inner.Equals(o._inner) : _inner.Equals(obj);
     public override int GetHashCode() => _inner.GetHashCode();


### PR DESCRIPTION
Closes #3115

Follow-up to the review of PR 2979 (issue 2932, merged as `8ef72629`). Tests, comments and one
doc comment. **No runtime behaviour change** — the only non-test file touched gains a doc
comment.

## What the reflection arm is, and why it needed a test

All three of the runner's async-unwrap seams have the same three arms:

```csharp
case Task t:      t.GetAwaiter().GetResult();  return;
case ValueTask vt: vt.GetAwaiter().GetResult(); return;
// ... and then, for ValueTask<T>, reflection over ValueTask<>.AsTask
```

A boxed `ValueTask<T>` matches **neither** case label, so the third arm is the only way to
observe one — and if that arm is removed, the method falls off the end and returns normally.
The captured error is swallowed, which is exactly the defect issue 2932 was about. `Task<T>`,
by contrast, derives from `Task` and takes `case Task t` like any other task.

## Three findings, verified against the merged code first

**1. A wrong comment — confirmed.** `AsyncGenericSubscriberThatThrows_AlsoSurfacesTheError`
said "`Task<T>` / `ValueTask<T>` take a different arm". Its target returns `Task<int>`, which
takes `case Task t` — the same arm. Corrected, and the test now *asserts*
`Assert.IsAssignableFrom<Task>(raw)` so the claim is enforced by code instead of prose.

**2. The coverage gap — real, but narrower than it was relayed to me.** The finding said the
`ValueTask<T>.AsTask` arm has no throwing test anywhere and that `DispatchObserveAsyncResultTests`
covers `ValueTask<int>` in the success direction only. That part does not hold up:
`DispatchObserveAsyncResultTests.FaultedGenericValueTask_RethrowsTheOriginalException` has
existed since the v2 cutover (`146bdbbb`) and drives that arm with a faulted `ValueTask<int>`.

What *is* missing is one level up. No test drove an `async ValueTask<T>` subscriber through
`ObservingSubscriberMethodInfo` — the decorator PR 2979 installs on the table-event path. Its
tests covered a throwing `async ValueTask` and a throwing `async Task<int>`, and neither
reaches the reflection arm, so the decorator's own contract for that shape (the captured
exception comes back out **wrapped in a `TargetInvocationException`**, which is what routes it
to BC's `CallEventSubscriberInternalAsync` `ExceptionDispatchInfo` arm) was unpinned. Added.

**3. Asymmetric `Equals` — safe, but not for the reason given.** Documented, not changed. See
below; the reasoning needed correcting, and that is worth reading.

## Fixing the shape, not just the reported line

- **Same wrong pattern at another call site?** No other comment in the tree makes the
  `Task<T>`-takes-a-different-arm claim (checked across `AlRunner/` and `AlRunner.Tests/`).
- **Does a sibling make the same assumption?** There are three seams, not one, and **the
  sibling gap was bigger than the reported one**. `BcRuntime.AwaitIfTask` — the seam on
  `Codeunit.Run` and on the `NavReportSync` trigger invocations, so a swallow there means a
  codeunit or report that raised an error appears to have succeeded — had **no tests at all**.
  New `AlRunner.Tests/AwaitIfTaskTests.cs` covers all three arms in both directions, plus
  "the state machine actually ran to completion, not just to its first await". The third seam,
  `RunnerPageInstance.AwaitTriggerResult`, already had the faulted `ValueTask<T>` case covered
  in `PageTriggerAwaitTests` — nothing to add.
- **Do two paths maintain the same invariant?** One real difference, deliberately left alone
  and called out here rather than silently changed: the decorator wraps an async-captured
  exception in a `TargetInvocationException` so both AL compile shapes reach BC by the same
  route, while `CodeunitEventDispatcher`'s own direct call to `ObserveAsyncResult` rethrows it
  raw (a *synchronous* subscriber's error on that path arrives wrapped, because
  `MethodInfo.Invoke` wraps it). That asymmetry predates PR 2979, is on a path the runner
  dispatches itself rather than handing to BC, and changing it is a runtime behaviour change —
  out of scope for a test-and-comment PR. Not filed as an issue because no failure is attached
  to it; flagged here for the reviewer to rule on.

## RED evidence

Not "the test passes". For each seam the arm was disabled (`if (false && ty.IsGenericType …)`),
the new test run, and the failure checked to be the **swallow** rather than a compile error:

```
ObservingSubscriberMethodInfoTests.AsyncGenericValueTaskSubscriberThatThrows_SurfacesTheErrorThroughTheReflectionArm [FAIL]
  Assert.Throws() Failure: No exception was thrown
  Expected: typeof(System.Reflection.TargetInvocationException)

AwaitIfTaskTests.FaultedGenericValueTask_RethrowsTheOriginalException_ThroughTheReflectionArm [FAIL]
  Assert.Throws() Failure: No exception was thrown
  Expected: typeof(System.InvalidOperationException)
```

In the first run, `DispatchObserveAsyncResultTests.FaultedGenericValueTask_...` went red
alongside it — confirming the mutation hit the arm it was aimed at.

GREEN after restoring both arms:
`dotnet test AlRunner.Tests --filter "…ObservingSubscriberMethodInfoTests|…DispatchObserveAsyncResultTests|…AwaitIfTaskTests|…PageTriggerAwaitTests"`
→ **28 passed, 0 failed**.

Each new test also asserts, before anything else, that the value it is about is a
`ValueTask<T>` and is neither a `Task` nor a `ValueTask` — so it cannot quietly drift onto an
arm the older tests already cover and go on passing while proving nothing.

## The asymmetric `Equals`, and a correction to the reasoning

`decorator.Equals(inner)` is `true`; `inner.Equals(decorator)` is `false`; `GetHashCode`
returns the inner method's hash either way. The relayed reason for it being safe was that the
decorator never escapes `BuildSubscription`. **It does escape**: BC's `NavEventSubscription`
ctor stores `subscriberMethodInfo.RawMethodInfo` in a field and re-exposes it as the public
`SubscriberMethodInfo` property, so the decorator is live inside BC's subscription object for
as long as it is registered — which is the whole point of installing it.

The conclusion survives, on a different basis: **nothing compares it.** Measured against
`Microsoft.Dynamics.Nav.Ncl.dll` 28.1.49838.53910, whole-assembly decompile, every reference to
`SubscriberMethodInfo` — the only uses are `.DeclaringType`, `.Invoke(...)`, and the
`EventSubscriberDiagnosticMessage` helpers reading `Name`/`GetParameters`/`ReturnType`. No
equality comparison, no collection keyed on it, and `NavEventScope.RemoveSubscribersFromAppGroup`
removes by `SubscriberNavAppGroup.GroupId`, not by method identity. On the runner side,
`_injectedSubscriberMethods` is keyed on the inner `sub.Method` and the decorator is never added
to it.

So it is documented on the method, with that scan recorded, plus
`EqualsIsAsymmetric_ByDesignAndPinnedHere` to make a future change to the semantics a deliberate
act rather than a silent one. Which side of a mixed hashed collection calls `Equals` is a BCL
implementation detail, so that is described but deliberately **not** asserted — a test there
would be pinning the BCL, not this type.

## Why these tests are not upstream in the corpus

"An error raised inside a table-event subscriber reaches the caller" *is* a BC-behaviour claim,
and it is already pinned upstream —
`Codeunit60490.TableEventSubscriberInAnotherApp_ErrorReachesTheCaller` is the RED baseline
PR 2979 was proven against, and `record/TestTableEventAsyncSubscriberError.al` covers the async
shape.

What is added here is a different claim: **which CLR arm unwraps a `ValueTask<T>` versus a
`Task<T>`**. AL cannot observe or distinguish that — a corpus test takes whichever arm the emit
produced and passes either way — and the runner's own emitter emits subscribers as synchronous
`void` methods, so first-party AL cannot even reach the async shapes. The mechanism is
runner-internal, so the test belongs in `AlRunner.Tests`, at the seam, next to the tests that
already pin the rest of it. This is a structural argument about this specific claim, not a
general licence: anything expressible in AL still goes upstream.

## Deliberately left out

- The `TargetInvocationException`-wrapping asymmetry between the two `ObserveAsyncResult`
  callers (above) — a runtime change, not a test change.
- `AwaitIfTask`'s `rt.GetMethod("AsTask")!` uses a null-forgiving operator where the other two
  seams use `?? throw new InvalidOperationException("… BC/runtime shape changed")`. It would
  NRE rather than say why. Cosmetic, unreachable in practice, and a runtime edit; left alone.
- No `docs/` change: no behaviour changed.

---
Written by agent `stma-auto-1` (cycle 138) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
