### PR TITLE
fix(cache): one error contract for every startup cache-root writer, and a guard for the al-out root

### DIFF
--- a/AlRunner.Tests/CacheRootStartupFailureTests.cs
+++ b/AlRunner.Tests/CacheRootStartupFailureTests.cs
@@ -133,7 +133,9 @@ public sealed class CacheRootStartupFailureTests
         // --expectations is passed explicitly, at an empty directory, only to get PAST
         // Program.cs's expectations auto-probe: that probe reads Environment.CurrentDirectory,
         // whose getter throws for the same unlinked-cwd reason, and would abort earlier than
-        // the line under test (measured: Program.cs:843). It is scaffolding for reaching the
+        // the line under test (measured: Program.cs:843, exit 134 — filed as its own defect,
+        // issue #3120, since deciding what the runner should DO with an unreadable working
+        // directory is a different question from this one). Scaffolding for reaching the
         // cache-root block, not part of the claim.
         var emptyExpectations = TestScratch.Dir("al-runner-no-cache-root-expectations");
         Directory.CreateDirectory(emptyExpectations);

--- a/AlRunner.Tests/CacheRootStartupFailureTests.cs
+++ b/AlRunner.Tests/CacheRootStartupFailureTests.cs
@@ -87,6 +87,14 @@ public sealed class CacheRootStartupFailureTests
         // The negative half: a guard that threw unconditionally would satisfy the test
         // above. It must also hand the value straight back, because Resolve composes on
         // the return value.
+        //
+        // Allowlisted in ScratchDirOwnershipGuardTests rather than routed through
+        // TestScratch, deliberately: RequireRooted is `Path.IsPathRooted(dir) ? dir :
+        // throw` and touches no filesystem, so this path is never created and there is
+        // nothing to own. Reserving it would CREATE the parent and drop a .owner sidecar
+        // for a directory that will never exist — litter, to satisfy a guard about leaks.
+        // The temp root is here only because it is conveniently absolute, which is the
+        // same reason AlRunnerPathsTests is on that allowlist.
         var abs = Path.Combine(Path.GetTempPath(), "al-runner-required-rooted");
         Assert.Equal(abs, CacheRoots.RequireRooted(abs, "al-out"));
     }
@@ -147,13 +155,84 @@ public sealed class CacheRootStartupFailureTests
                 "--no-cache",
                 "--expectations", emptyExpectations,
             },
-            env: new Dictionary<string, string> { [CacheRoots.NoCacheRootEnvVar] = "relcache" });
+            env: new Dictionary<string, string?> { [CacheRoots.NoCacheRootEnvVar] = "relcache" });
 
         Assert.Equal(2, exit);
         Assert.Contains(
             "AL_RUNNER_NO_CACHE_ROOT 'relcache' is not a usable directory path:",
             output, StringComparison.Ordinal);
         // The part that regressed: exit 134 with a stack trace, not a documented exit.
+        AssertNotAnUnhandledCrash(exit, output);
+    }
+
+    /// <summary>
+    /// The sibling of the test above, and the review follow-up to this PR's own first cut.
+    ///
+    /// <para>DisableForRun has TWO failure sites, not one. It ADOPTS
+    /// AL_RUNNER_NO_CACHE_ROOT when that variable is set (the test above), and otherwise
+    /// MINTS a root through ScratchDirs.Reserve — publishing it to the variable only after
+    /// the reserve succeeds. So a throw from the mint branch leaves the variable unset, and
+    /// the catch in Program.cs, which reads the variable back to name the offending value,
+    /// got null. Reusing the one wording for both sites then printed:</para>
+    ///
+    /// <code>AL_RUNNER_NO_CACHE_ROOT '' is not a usable directory path: Unable to find the specified file.</code>
+    ///
+    /// <para>naming a variable the user never set and quoting an empty value that was
+    /// nobody's input — an error whose stated cause did not happen, which sends the reader
+    /// to unset something already unset. Both directions are asserted: the honest message
+    /// is present, AND the misattributed one is absent. Without the second assertion this
+    /// would still pass if the code printed both.</para>
+    ///
+    /// <para>REACHING the mint branch's throw needs Path.GetFullPath to reject the minted
+    /// path. Reserve swallows IOException and UnauthorizedAccessException, so an unwritable
+    /// temp root is not enough — the GetFullPath on its first line is outside that catch and
+    /// is the only part that can throw. A RELATIVE TMPDIR makes the minted path relative
+    /// (measured on net8.0/Linux: TMPDIR=reltmp gives Path.GetTempPath() == "reltmp/"), and
+    /// the unlinked working directory this file's helper sets up makes getcwd(2) fail, so
+    /// GetFullPath of that relative path throws. Both halves are real process states.</para>
+    /// </summary>
+    [SkippableFact]
+    public void NoCache_WhenMintingItsOwnRootFails_BlamesTheMintAndNotAnUnsetEnvironmentVariable()
+    {
+        SkipUnlessLinux();
+        TestArtifacts.SkipIfMissing();
+
+        // Same scaffolding, and the same reason, as the test above (issue #3120).
+        var emptyExpectations = TestScratch.Dir("al-runner-mint-failure-expectations");
+        Directory.CreateDirectory(emptyExpectations);
+
+        var (exit, output) = RunFromUnlinkedWorkingDirectory(
+            new[]
+            {
+                Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", "RecordTriggerXRec"),
+                "--no-cache",
+                "--expectations", emptyExpectations,
+            },
+            env: new Dictionary<string, string?>
+            {
+                // Unset, so DisableForRun takes the MINT branch rather than the adopt one.
+                [CacheRoots.NoCacheRootEnvVar] = null,
+                // Relative, so the path it mints is relative and GetFullPath rejects it
+                // against the unlinked cwd.
+                ["TMPDIR"] = "reltmp",
+            });
+
+        Assert.Equal(2, exit);
+
+        // Positive: the message names what actually failed — the runner's own mint, under
+        // the directory it tried to mint in — and offers the remedy that applies.
+        Assert.Contains(
+            "al-runner could not reserve a throwaway --no-cache root under 'reltmp/':",
+            output, StringComparison.Ordinal);
+        Assert.Contains(
+            "Set AL_RUNNER_NO_CACHE_ROOT to a writable absolute directory",
+            output, StringComparison.Ordinal);
+
+        // Negative, and the whole point: it must NOT blame the variable that is unset.
+        Assert.DoesNotContain(
+            "AL_RUNNER_NO_CACHE_ROOT '' is not a usable directory path",
+            output, StringComparison.Ordinal);
+
         AssertNotAnUnhandledCrash(exit, output);
     }
 
@@ -249,7 +328,7 @@ public sealed class CacheRootStartupFailureTests
     /// that makes Path.GetFullPath reject a value that can actually reach the runner.
     /// </summary>
     private static (int Exit, string Output) RunFromUnlinkedWorkingDirectory(
-        string[] runnerArgs, IDictionary<string, string>? env)
+        string[] runnerArgs, IDictionary<string, string?>? env)
     {
         var doomed = Path.Combine(TestScratch.Dir("al-runner-unlinked-cwd"), "doomed");
         Directory.CreateDirectory(doomed);
@@ -269,7 +348,14 @@ public sealed class CacheRootStartupFailureTests
         };
         psi.ArgumentList.Add("-c");
         psi.ArgumentList.Add(script.ToString());
-        if (env != null) foreach (var kv in env) psi.Environment[kv.Key] = kv.Value;
+        // A null VALUE removes the variable, so a test can assert on the branch taken when
+        // something is UNSET without depending on the ambient environment not having it.
+        if (env != null)
+            foreach (var kv in env)
+            {
+                if (kv.Value == null) psi.Environment.Remove(kv.Key);
+                else psi.Environment[kv.Key] = kv.Value;
+            }
         return Capture(psi);
     }
 

--- a/AlRunner.Tests/CacheRootStartupFailureTests.cs
+++ b/AlRunner.Tests/CacheRootStartupFailureTests.cs
@@ -1,0 +1,315 @@
+// CacheRootStartupFailureTests — issue #3111, the review follow-up to #3104.
+//
+// #3104 rooted a relative `--cache` once at parse time and added a loud guard to
+// CacheRoots.Resolve. Its reviewer left three findings, all confirmed against the merged
+// commit (82d7fe22) before anything here was written:
+//
+//   1. Program.cs's `CacheRoots.DisableForRun()` call sat outside any try, and that method
+//      now calls Path.GetFullPath on the RAW AL_RUNNER_NO_CACHE_ROOT value. A value
+//      GetFullPath rejects therefore aborted out of top-level statements. Measured on the
+//      merged build, before the fix in this PR:
+//
+//        Unhandled exception. System.IO.FileNotFoundException: Unable to find the specified file.
+//           at Interop.Sys.GetCwd()
+//           at System.IO.Path.GetFullPathInternal(String path)
+//           at AlRunner.Infrastructure.CacheRoots.DisableForRun() in .../CacheRoots.cs:line 151
+//           at Program.<Main>$(String[] args) in .../Program.cs:line 1364
+//        EXIT=134
+//
+//      while the `--cache` flag, three hundred lines up, returned the documented exit 2 for
+//      the identical failure. Exit 134 instead of a documented exit is the worse half of
+//      #2114, which #3104's own commit message cites.
+//
+//   2. Two branches with no coverage: `--cache` given a value GetFullPath rejects, and the
+//      alCacheDir rooting itself. Every `--cache` caller in AlRunner.Tests passes an
+//      ABSOLUTE path, so neither branch was ever entered.
+//
+//   3. alCacheDir does not flow through CacheRoots at all (that class's "Deliberately NOT
+//      wired into alCacheDir" note), so #3104's guard covered every cache derived from a
+//      --cache value and not the al-out half of the same value.
+//
+// HOW A REJECTED PATH IS PRODUCED ON LINUX, since this is not obvious
+//   Path.GetFullPath rejects almost nothing on Unix. Measured on net8.0/Linux: an embedded
+//   NUL throws ArgumentException but cannot arrive through an env var or through execve
+//   argv (SetEnvironmentVariable truncates at it); a 300,001-character path succeeds; there
+//   is no length check. The one reachable trigger is a RELATIVE value while the process's
+//   working directory has been unlinked — getcwd(2) then fails with ENOENT and GetFullPath
+//   surfaces it as FileNotFoundException. `cd d && rm -rf d && exec …` is a real process
+//   state, so that is what these tests set up. It is also why the reviewer called the crash
+//   practically unreachable on Linux and non-blocking: rare, but reachable and deterministic.
+//
+// Nothing here is a claim about Business Central. `--cache`, AL_RUNNER_NO_CACHE_ROOT and a
+// cache root are runner CLI/infrastructure surfaces: AL cannot pass a --cache value and
+// cannot observe a cache root, so this is structurally inexpressible in the al-language
+// corpus rather than conveniently kept local. See RelativeCacheRootTests' header for the
+// same reasoning about #3104 itself.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.RegularExpressions;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class CacheRootStartupFailureTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    // ── Finding 3: the guard the al-out root never had ────────────────────────────────
+
+    [Fact]
+    public void RequireRooted_WithARelativeDirectory_ThrowsNamingTheValueTheCacheAndBothConsumers()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => CacheRoots.RequireRooted("some-relative-cache", "al-out"));
+
+        // The value and the cache, so the reader knows WHICH root is wrong…
+        Assert.Contains("some-relative-cache", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("al-out", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("--cache", ex.Message, StringComparison.Ordinal);
+        // …and both consequences, not just the one #3084 was reported through. r2r-chunks
+        // feeds LoadFromAssemblyPath; ncl-shadow is handed to a CHILD process as a
+        // `dotnet exec` argument (ProgramSupport/Provisioning.cs:106), which breaks for a
+        // reason that has nothing to do with assembly loading.
+        Assert.Contains("LoadFromAssemblyPath", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("ncl-shadow", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("dotnet exec", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("#3084", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RequireRooted_WithAnAbsoluteDirectory_ReturnsItUnchanged()
+    {
+        // The negative half: a guard that threw unconditionally would satisfy the test
+        // above. It must also hand the value straight back, because Resolve composes on
+        // the return value.
+        var abs = Path.Combine(Path.GetTempPath(), "al-runner-required-rooted");
+        Assert.Equal(abs, CacheRoots.RequireRooted(abs, "al-out"));
+    }
+
+    [Fact]
+    public void BuildUnusableCacheRootMessage_NamesTheSourceTheValueAndTheUnderlyingFailure()
+    {
+        // One wording for all three startup writers of a cache root, so the exit-2 text a
+        // user sees does not depend on which of them failed.
+        Assert.Equal(
+            "--cache 'relcache' is not a usable directory path: Unable to find the specified file.",
+            CacheRoots.BuildUnusableCacheRootMessage("--cache", "relcache", "Unable to find the specified file."));
+        Assert.Equal(
+            "AL_RUNNER_NO_CACHE_ROOT 'relcache' is not a usable directory path: boom",
+            CacheRoots.BuildUnusableCacheRootMessage(CacheRoots.NoCacheRootEnvVar, "relcache", "boom"));
+    }
+
+    // ── Finding 2a: --cache given a value Path.GetFullPath rejects ────────────────────
+
+    [SkippableFact]
+    public void Cache_WithAValueGetFullPathRejects_ExitsTwoNamingTheFlag()
+    {
+        SkipUnlessLinux();
+
+        // No BC artifacts needed: the --cache parse branch returns before bundle
+        // validation, so this is the whole run.
+        var (exit, output) = RunFromUnlinkedWorkingDirectory(
+            new[] { "--cache", "relcache" }, env: null);
+
+        Assert.Equal(2, exit);
+        Assert.Contains(
+            "--cache 'relcache' is not a usable directory path:", output, StringComparison.Ordinal);
+        AssertNotAnUnhandledCrash(exit, output);
+    }
+
+    // ── Finding 1: AL_RUNNER_NO_CACHE_ROOT must not abort the process ─────────────────
+
+    [SkippableFact]
+    public void NoCache_WithAnAdoptedEnvironmentRootGetFullPathRejects_ExitsTwoInsteadOfCrashing()
+    {
+        SkipUnlessLinux();
+        TestArtifacts.SkipIfMissing();
+
+        // --expectations is passed explicitly, at an empty directory, only to get PAST
+        // Program.cs's expectations auto-probe: that probe reads Environment.CurrentDirectory,
+        // whose getter throws for the same unlinked-cwd reason, and would abort earlier than
+        // the line under test (measured: Program.cs:843). It is scaffolding for reaching the
+        // cache-root block, not part of the claim.
+        var emptyExpectations = TestScratch.Dir("al-runner-no-cache-root-expectations");
+        Directory.CreateDirectory(emptyExpectations);
+
+        var (exit, output) = RunFromUnlinkedWorkingDirectory(
+            new[]
+            {
+                Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", "RecordTriggerXRec"),
+                "--no-cache",
+                "--expectations", emptyExpectations,
+            },
+            env: new Dictionary<string, string> { [CacheRoots.NoCacheRootEnvVar] = "relcache" });
+
+        Assert.Equal(2, exit);
+        Assert.Contains(
+            "AL_RUNNER_NO_CACHE_ROOT 'relcache' is not a usable directory path:",
+            output, StringComparison.Ordinal);
+        // The part that regressed: exit 134 with a stack trace, not a documented exit.
+        AssertNotAnUnhandledCrash(exit, output);
+    }
+
+    // ── Finding 2b: the alCacheDir rooting path ──────────────────────────────────────
+
+    /// <summary>
+    /// A RELATIVE `--cache` on the command line must produce a working run, and the
+    /// AL-output cache must carry the ABSOLUTE equivalent of that directory.
+    ///
+    /// Two assertions, because they fail for different reasons:
+    ///
+    ///   * The `[cache] WROTE … path=` line (behind --verbose since #2239) names an
+    ///     absolute path under the relative directory's absolute equivalent. This is the
+    ///     decisive half, and it isolates alCacheDir specifically — the one root that never
+    ///     flows through CacheRoots.Resolve. Measured with ONLY the parse-time rooting
+    ///     reverted (so #3104's CacheRoots.SetOverride rooting is still in place, and every
+    ///     derived cache is still absolute):
+    ///         [cache] WROTE key=7c5f1cd7… path=rel-out/7c5f1cd7….dll
+    ///     — relative, silently, with the run otherwise green. That is the value the process
+    ///     CARRIES, not merely where the bytes happened to land: for an unchanged working
+    ///     directory the rooted and unrooted forms name the same physical directory, so a
+    ///     file-exists check alone could not tell the fix from its absence.
+    ///   * The run PASSES, `pass: 1`, exit 0. A regression assertion rather than a
+    ///     discriminator — it also held in the reverted state above, because with the
+    ///     derived caches rooted the AL-output path alone was survivable in that
+    ///     configuration. It is here so a future change that makes a relative --cache
+    ///     unusable end to end (the #3084 symptom: exit 1, `pass: 0 / fail: 1`) fails a test
+    ///     instead of being reported as ordinary AL failures.
+    ///
+    /// Revert the parse-time rooting with the al-out guard #3111 added still in place and
+    /// this instead exits 2 naming the al-out root — loud either way, never silent.
+    /// </summary>
+    [SkippableFact]
+    public void RelativeCache_RunsCleanlyAndCarriesTheAbsoluteAlOutputRoot()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var workDir = TestScratch.Dir("al-runner-relative-cache-cli");
+        Directory.CreateDirectory(workDir);
+        var emptyExpectations = Path.Combine(workDir, "expectations");
+        Directory.CreateDirectory(emptyExpectations);
+
+        // Relative, and never before seen — so the AL-output cache is a guaranteed MISS and
+        // the run must WRITE, which is the line this test reads.
+        const string RelativeCache = "rel-out";
+        var expectedAbsolute = Path.Combine(workDir, RelativeCache);
+
+        var (exit, output) = RunRunner(
+            workDir,
+            new[]
+            {
+                Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", "RecordTriggerXRec"),
+                "--cache", RelativeCache,
+                "--expectations", emptyExpectations,
+                "--verbose",
+            });
+
+        Assert.True(exit == 0 && output.Contains("pass:        1", StringComparison.Ordinal),
+            $"a relative --cache must produce the same passing run an absolute one does:\n{output}");
+
+        var wrote = Regex.Match(output, @"\[cache\] WROTE key=\S+ path=(?<path>\S+)");
+        Assert.True(wrote.Success, $"expected a '[cache] WROTE … path=' line:\n{output}");
+
+        var writtenPath = wrote.Groups["path"].Value;
+        Assert.True(Path.IsPathRooted(writtenPath),
+            $"the AL-output cache path must be absolute, was '{writtenPath}':\n{output}");
+        Assert.StartsWith(expectedAbsolute + Path.DirectorySeparatorChar, writtenPath, StringComparison.Ordinal);
+        Assert.True(File.Exists(writtenPath), $"cached assembly must exist at '{writtenPath}'");
+
+        // And the guard on this root — the one alCacheDir never had — stayed quiet, which
+        // is the same fact stated from the other side.
+        Assert.DoesNotContain("is not a usable directory path", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("RELATIVE root", output, StringComparison.Ordinal);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────────────
+
+    private static void SkipUnlessLinux()
+        => Skip.IfNot(RuntimeInformation.IsOSPlatform(OSPlatform.Linux),
+            "unlinking a live working directory is a Unix behaviour; Windows refuses to remove it");
+
+    private static void AssertNotAnUnhandledCrash(int exit, string output)
+    {
+        Assert.DoesNotContain("Unhandled exception", output, StringComparison.Ordinal);
+        // 128 + SIGABRT(6): what CoreCLR's default unhandled-exception handler produces.
+        Assert.NotEqual(134, exit);
+    }
+
+    /// <summary>
+    /// Runs the built runner with its working directory UNLINKED — `cd d && rm -rf d &&
+    /// exec dotnet …`, which leaves the process with a valid but nameless cwd, so getcwd(2)
+    /// fails and every Path.GetFullPath of a relative path throws. The only Linux state
+    /// that makes Path.GetFullPath reject a value that can actually reach the runner.
+    /// </summary>
+    private static (int Exit, string Output) RunFromUnlinkedWorkingDirectory(
+        string[] runnerArgs, IDictionary<string, string>? env)
+    {
+        var doomed = Path.Combine(TestScratch.Dir("al-runner-unlinked-cwd"), "doomed");
+        Directory.CreateDirectory(doomed);
+
+        var script = new StringBuilder();
+        script.Append("rm -rf ").Append(ShellQuote(doomed)).Append(" && exec dotnet ");
+        script.Append(ShellQuote(RunnerDll()));
+        foreach (var a in RunnerArgsWithBcVersion(runnerArgs)) script.Append(' ').Append(ShellQuote(a));
+
+        var psi = new ProcessStartInfo("/bin/sh")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = doomed,
+        };
+        psi.ArgumentList.Add("-c");
+        psi.ArgumentList.Add(script.ToString());
+        if (env != null) foreach (var kv in env) psi.Environment[kv.Key] = kv.Value;
+        return Capture(psi);
+    }
+
+    private static (int Exit, string Output) RunRunner(string workingDirectory, string[] runnerArgs)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = workingDirectory,
+        };
+        psi.ArgumentList.Add(RunnerDll());
+        foreach (var a in RunnerArgsWithBcVersion(runnerArgs)) psi.ArgumentList.Add(a);
+        return Capture(psi);
+    }
+
+    private static string[] RunnerArgsWithBcVersion(string[] runnerArgs)
+    {
+        // TestBuildConfig.BcVersionArg is " --bc-version <v>" (or empty) — split so it can
+        // be passed as ArgumentList entries rather than a command line.
+        var extra = TestBuildConfig.BcVersionArg.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        return runnerArgs.Concat(extra).ToArray();
+    }
+
+    /// <summary>The built al-runner.dll, unquoted — TestBuildConfig.RunArgs returns it quoted
+    /// for command-line use, and both call sites here quote for themselves.</summary>
+    private static string RunnerDll() => TestBuildConfig.RunArgs(ProjectPath).Trim('"');
+
+    private static string ShellQuote(string s) => "'" + s.Replace("'", "'\\''") + "'";
+
+    private static (int Exit, string Output) Capture(ProcessStartInfo psi)
+    {
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(300_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (p.ExitCode, sb.ToString());
+    }
+}

--- a/AlRunner.Tests/ScratchDirOwnershipGuardTests.cs
+++ b/AlRunner.Tests/ScratchDirOwnershipGuardTests.cs
@@ -77,6 +77,10 @@ public sealed class ScratchDirOwnershipGuardTests
             (1, "a .so path that must not exist; this file's three real directories ARE owned"),
 
         // ── path strings handed to a resolver, never created ────────────────────────────
+        ["CacheRootStartupFailureTests.cs"] =
+            (1, "one absolute path handed to CacheRoots.RequireRooted, which is a pure "
+              + "Path.IsPathRooted check that touches no filesystem, so the path is never "
+              + "created; this file's three real directories ARE owned via TestScratch"),
         ["ArtifactsRootEnvOverrideTests.cs"] =
             (3, "AL_RUNNER_ARTIFACTS_ROOT values fed to BcArtifacts.ResolveArtifactsRoot; the "
               + "test asserts on the resolved string and never touches the filesystem"),

--- a/AlRunner/Infrastructure/CacheRoots.cs
+++ b/AlRunner/Infrastructure/CacheRoots.cs
@@ -162,7 +162,7 @@ public static class CacheRoots
             // (#2706) so a run killed before CleanupThrowawayRoot fires is reclaimed by the
             // next runner start instead of leaking a full cache per killed --no-cache run.
             root = Path.GetFullPath(ScratchDirs.Reserve(
-                Path.Combine(Path.GetTempPath(), "al-runner-no-cache-" + Guid.NewGuid().ToString("N"))));
+                Path.Combine(ThrowawayRootParent, "al-runner-no-cache-" + Guid.NewGuid().ToString("N"))));
             // Publish the ROOTED form, so a re-exec'd child inherits an absolute path
             // even if this generation was handed a relative one (#3084).
             Environment.SetEnvironmentVariable(NoCacheRootEnvVar, root);
@@ -253,6 +253,37 @@ public static class CacheRoots
         => Path.IsPathRooted(dir)
             ? dir
             : throw new InvalidOperationException(BuildUnrootedCacheRootMessage(dir, name));
+
+    /// <summary>
+    /// The directory <see cref="DisableForRun"/> mints its throwaway root under when
+    /// <see cref="NoCacheRootEnvVar"/> is unset. A property rather than a second inline
+    /// <c>Path.GetTempPath()</c> so the error path below names the directory the mint
+    /// actually failed under, instead of a second copy of the expression that could drift
+    /// from it — the same "two code paths, one invariant" hygiene the rest of this class
+    /// is about.
+    /// </summary>
+    internal static string ThrowawayRootParent => Path.GetTempPath();
+
+    /// <summary>
+    /// The diagnostic for the OTHER way <see cref="DisableForRun"/> can fail: the branch
+    /// that mints a throwaway root itself, reached only when <see cref="NoCacheRootEnvVar"/>
+    /// is unset.
+    ///
+    /// <para>Separate from <see cref="BuildUnusableCacheRootMessage"/> because that one
+    /// names a SOURCE and a VALUE, and this branch has neither — nothing supplied a path,
+    /// the runner chose one. #3111's first cut reused it anyway and reported
+    /// <c>AL_RUNNER_NO_CACHE_ROOT '' is not a usable directory path: …</c>, naming a
+    /// variable the user never set and quoting an empty value that was never anybody's
+    /// input. An error that names a cause which did not happen is worse than a generic
+    /// one: it sends the reader to unset a variable that is already unset.</para>
+    /// </summary>
+    /// <param name="parent">The directory the mint was attempted under, normally
+    /// <see cref="ThrowawayRootParent"/>.</param>
+    /// <param name="detail">The underlying failure, normally the exception's message.</param>
+    internal static string BuildUnreservableThrowawayRootMessage(string parent, string detail)
+        => $"al-runner could not reserve a throwaway --no-cache root under '{parent}': " +
+           $"{detail}. Set {NoCacheRootEnvVar} to a writable absolute directory, or drop " +
+           $"--no-cache to use the normal cache root.";
 
     /// <summary>
     /// One wording for "this cache root could not even be turned into a usable path", shared

--- a/AlRunner/Infrastructure/CacheRoots.cs
+++ b/AlRunner/Infrastructure/CacheRoots.cs
@@ -211,15 +211,65 @@ public static class CacheRoots
         // all eight rather than each consumer having to know that LoadFromAssemblyPath —
         // or a re-exec, or a path-prefix comparison — is downstream of it.
         //
+        // #3111, inventory: r2r-chunks is not the only consumer that would break. ncl-shadow
+        // is resolved by NclShadowRuntime.EnsureShadowDir and the dll under it is added to a
+        // child process's ArgumentList at ProgramSupport/Provisioning.cs:106 (`dotnet exec
+        // <dll>`) — a relative root there is resolved by the CHILD, against whatever working
+        // directory the child happens to inherit, so it is undefended for a reason unrelated
+        // to assembly loading. Both consequences are named in the message below.
+        //
         // Loud rather than best-effort-rooted-here on purpose (.claude/rules/loud-failures.md):
         // silently calling Path.GetFullPath at THIS point would re-resolve against whatever
         // the current directory is right now, which is the moving-target bug the write-site
         // rooting exists to prevent, and would hide the defect that produced the unrooted
         // value instead of naming it.
-        if (!Path.IsPathRooted(root))
-            throw new InvalidOperationException(BuildUnrootedCacheRootMessage(root, name));
+        //
+        // #3111: the check itself moved into RequireRooted so the ONE cache root that
+        // deliberately does not come through here — Program.cs's alCacheDir, see this
+        // class's "Deliberately NOT wired into alCacheDir" note — can assert the same
+        // invariant with the same wording instead of having no guard at all.
+        RequireRooted(root, name);
         return Path.Combine(root, name);
     }
+
+    /// <summary>
+    /// Throws unless <paramref name="dir"/> is absolute; returns it unchanged when it is.
+    ///
+    /// <para>Extracted from <see cref="Resolve"/> in #3111 because the guard #3084 added
+    /// covered every cache that flows through <see cref="Resolve"/> and NOTHING else, and
+    /// there is exactly one cache root that does not flow through it: the AL-output
+    /// directory (<c>Program.cs</c>'s <c>alCacheDir</c>), which keeps exact-directory
+    /// semantics on purpose and therefore never asks this class for a path. That left the
+    /// two halves of one <c>--cache</c> value under different rules — the derived roots
+    /// guarded, the al-out root not — which is the same "two code paths write the same
+    /// state, only one holds the invariant" shape #3084's <see cref="DisableForRun"/> half
+    /// was about. Call it from any consumer that holds a cache root it did not get from
+    /// <see cref="Resolve"/>.</para>
+    /// </summary>
+    /// <param name="dir">The cache root to check.</param>
+    /// <param name="name">The cache's name, for the diagnostic (e.g. <c>"r2r-chunks"</c>,
+    /// <c>"al-out"</c>).</param>
+    internal static string RequireRooted(string dir, string name)
+        => Path.IsPathRooted(dir)
+            ? dir
+            : throw new InvalidOperationException(BuildUnrootedCacheRootMessage(dir, name));
+
+    /// <summary>
+    /// One wording for "this cache root could not even be turned into a usable path", shared
+    /// by all three writers of a cache root at startup (#3111): <c>Program.cs</c>'s
+    /// <c>--cache</c> parsing, its <see cref="DisableForRun"/> call, and its
+    /// <see cref="SetOverride"/> call. They previously had one inline message between them
+    /// and no message at all on the other two paths, which is how the
+    /// <see cref="DisableForRun"/> path came to abort the process with an unhandled
+    /// exception (exit 134) where <c>--cache</c> returned the documented exit 2 — the exact
+    /// asymmetry #2114 is about, one flag over.
+    /// </summary>
+    /// <param name="source">What supplied the value, spelled the way the user typed it:
+    /// <c>"--cache"</c>, or the environment variable's name.</param>
+    /// <param name="value">The offending value, quoted into the message verbatim.</param>
+    /// <param name="detail">The underlying failure, normally the exception's message.</param>
+    internal static string BuildUnusableCacheRootMessage(string source, string value, string detail)
+        => $"{source} '{value}' is not a usable directory path: {detail}";
 
     /// <summary>
     /// The diagnostic for a cache root that is not absolute. Separate and internal so the
@@ -233,7 +283,9 @@ public static class CacheRoots
            $"root must be absolute: the r2r-chunks cache feeds " +
            $"AssemblyLoadContext.LoadFromAssemblyPath, which refuses a relative path, and a " +
            $"relative root also means a different directory for any part of the run that " +
-           $"executes from a different working directory. Left unchecked this does not fail " +
+           $"executes from a different working directory — the ncl-shadow root is handed to " +
+           $"a CHILD process as a `dotnet exec` argument (ProgramSupport/Provisioning.cs), " +
+           $"which is a second consumer that cannot survive one. Left unchecked this does not fail " +
            $"the load loudly — it drops Base Application / System Application / Business " +
            $"Foundation to a lower tier where their objects do not exist, and the run then " +
            $"reports ordinary test failures. Pass an absolute directory to --cache (issue #3084).";

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -523,8 +523,10 @@ for (int i = 0; i < args.Length; i++)
         try { alCacheDir = Path.GetFullPath(rawCacheDir); }
         catch (Exception ex)
         {
-            Console.Error.WriteLine(
-                $"--cache '{rawCacheDir}' is not a usable directory path: {ex.Message}");
+            // #3111: one wording, shared with the two other startup writers of a cache
+            // root below, so they cannot drift apart again.
+            Console.Error.WriteLine(AlRunner.Infrastructure.CacheRoots.BuildUnusableCacheRootMessage(
+                "--cache", rawCacheDir, ex.Message));
             return 2;
         }
         cacheRootOverride = alCacheDir; noCacheRequested = false; continue;
@@ -1349,7 +1351,31 @@ string? variantSwapDir = null;
     }
 }
 
-if (alCacheDir != null) Directory.CreateDirectory(alCacheDir);
+if (alCacheDir != null)
+{
+    // #3111: alCacheDir is the ONE cache root that deliberately never goes through
+    // CacheRoots.Resolve (exact-directory semantics — see that class's "Deliberately NOT
+    // wired into alCacheDir" note), so #3084's rootedness guard did not cover it: the
+    // caches derived from a --cache value were guarded and the al-out half of the SAME
+    // value was not. Same invariant, same wording, asserted here instead.
+    //
+    // Wrapped, like the --cache parse above, so a root this process cannot use returns the
+    // documented exit 2 rather than aborting out of top-level statements with an unhandled
+    // exception — which is what CreateDirectory alone did for a permission/ENOTDIR failure
+    // too, not just for the new guard.
+    try
+    {
+        AlRunner.Infrastructure.CacheRoots.RequireRooted(alCacheDir, "al-out");
+        Directory.CreateDirectory(alCacheDir);
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine(AlRunner.Infrastructure.CacheRoots.BuildUnusableCacheRootMessage(
+            cacheRootOverride != null ? "--cache" : "the default AL-output cache directory",
+            alCacheDir, ex.Message));
+        return 2;
+    }
+}
 // #1821/#2555: must run before the Cecil rewrite below (first ncl-cecil consumer), the
 // shadow-hop re-exec decision right after it (first ncl-shadow consumer), and well
 // before any DependencyLoader/BcAppSymbolCache/workspace-deps/AppLoader call — every one
@@ -1359,15 +1385,40 @@ if (alCacheDir != null) Directory.CreateDirectory(alCacheDir);
 // directory is minted (or, on a re-exec'd child, adopted from CacheRoots.NoCacheRootEnvVar
 // — see that constant's doc) before either re-exec decision point can hand off to a child
 // that would otherwise mint its own.
-if (noCacheRequested)
+//
+// #3111: wrapped. Both calls below root what they store (#3084), and Path.GetFullPath can
+// throw — DisableForRun adopts a RAW AL_RUNNER_NO_CACHE_ROOT value that nothing validates,
+// so the throw is reachable from outside the process (measured on Linux: a relative value
+// plus an unlinked working directory makes getcwd fail, and GetFullPath surfaces that as
+// FileNotFoundException). Unwrapped, that aborted out of top-level statements with an
+// unhandled exception and exit 134, while the --cache flag three hundred lines up returned
+// the documented exit 2 for the identical failure — the two writers of one field
+// disagreeing about their own error contract, which is the shape #2114 is about.
+try
 {
-    AlRunner.Infrastructure.CacheRoots.DisableForRun();
-    AppDomain.CurrentDomain.ProcessExit += (_, _) =>
-        AlRunner.Infrastructure.CacheRoots.CleanupThrowawayRoot();
+    if (noCacheRequested)
+    {
+        AlRunner.Infrastructure.CacheRoots.DisableForRun();
+        AppDomain.CurrentDomain.ProcessExit += (_, _) =>
+            AlRunner.Infrastructure.CacheRoots.CleanupThrowawayRoot();
+    }
+    else
+    {
+        AlRunner.Infrastructure.CacheRoots.SetOverride(cacheRootOverride);
+    }
 }
-else
+catch (Exception ex)
 {
-    AlRunner.Infrastructure.CacheRoots.SetOverride(cacheRootOverride);
+    // Read back rather than remembered: DisableForRun republishes the ROOTED form on
+    // success, but it throws before that, so the variable still holds exactly the value
+    // the user (or their shell) exported and the message names it verbatim.
+    var badRoot = noCacheRequested
+        ? Environment.GetEnvironmentVariable(AlRunner.Infrastructure.CacheRoots.NoCacheRootEnvVar)
+        : cacheRootOverride;
+    Console.Error.WriteLine(AlRunner.Infrastructure.CacheRoots.BuildUnusableCacheRootMessage(
+        noCacheRequested ? AlRunner.Infrastructure.CacheRoots.NoCacheRootEnvVar : "--cache",
+        badRoot ?? "", ex.Message));
+    return 2;
 }
 // #2041/#2066: deferred — see `deferredStartupLines`' declaration above. This generation
 // may still hand off via either re-exec decision below, and touches no bundle work at all

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1415,9 +1415,25 @@ catch (Exception ex)
     var badRoot = noCacheRequested
         ? Environment.GetEnvironmentVariable(AlRunner.Infrastructure.CacheRoots.NoCacheRootEnvVar)
         : cacheRootOverride;
-    Console.Error.WriteLine(AlRunner.Infrastructure.CacheRoots.BuildUnusableCacheRootMessage(
-        noCacheRequested ? AlRunner.Infrastructure.CacheRoots.NoCacheRootEnvVar : "--cache",
-        badRoot ?? "", ex.Message));
+
+    // …but only ONE of DisableForRun's two branches has a value to name. It adopts
+    // AL_RUNNER_NO_CACHE_ROOT when that is set, and otherwise MINTS a root through
+    // ScratchDirs.Reserve, publishing it to the variable only after that succeeds — so a
+    // throw from the mint branch leaves the variable unset and the read-back above
+    // returns null. Attributing that to `AL_RUNNER_NO_CACHE_ROOT ''` blames an input the
+    // user never gave and points them at a variable that is already unset, which is worse
+    // than saying nothing. Narrow the attribution to what is actually known instead.
+    //
+    // The `--cache` arm needs no such split: SetOverride's null/empty passthrough cannot
+    // throw, so reaching this catch with !noCacheRequested means cacheRootOverride held a
+    // real value the user typed.
+    Console.Error.WriteLine(
+        noCacheRequested && string.IsNullOrEmpty(badRoot)
+            ? AlRunner.Infrastructure.CacheRoots.BuildUnreservableThrowawayRootMessage(
+                AlRunner.Infrastructure.CacheRoots.ThrowawayRootParent, ex.Message)
+            : AlRunner.Infrastructure.CacheRoots.BuildUnusableCacheRootMessage(
+                noCacheRequested ? AlRunner.Infrastructure.CacheRoots.NoCacheRootEnvVar : "--cache",
+                badRoot ?? "", ex.Message));
     return 2;
 }
 // #2041/#2066: deferred — see `deferredStartupLines`' declaration above. This generation

--- a/AlRunner/ProgramSupport/CliText.cs
+++ b/AlRunner/ProgramSupport/CliText.cs
@@ -528,6 +528,9 @@ internal static partial class ProgramSupport
         w.WriteLine("                          ONCE, when the flag is parsed, and stored absolute: an");
         w.WriteLine("                          unrooted cache root cannot be handed to the .NET assembly");
         w.WriteLine("                          loader, and would otherwise move with the process (#3084).");
+        w.WriteLine("                          A DIR this process cannot resolve to a path at all exits 2");
+        w.WriteLine("                          naming the flag and the value, never an unhandled crash");
+        w.WriteLine("                          (#3111) — same for AL_RUNNER_NO_CACHE_ROOT under --no-cache.");
         w.WriteLine("  --no-cache              Disable every on-disk cache for this run, not just the");
         w.WriteLine("                          AL-output cache: the other named caches above are");
         w.WriteLine("                          redirected to a throwaway per-run directory (removed on");


### PR DESCRIPTION
Closes #3111

Review follow-up to PR #3104 (relative `--cache` rooting, merged as `82d7fe22`). Its reviewer approved it and left three non-blocking findings plus one inventory note. All four were verified against the merged code before anything was changed; all three findings held up.

## Finding 1 — `DisableForRun` crashed instead of exiting 2. Confirmed.

`Program.cs:1364` called `CacheRoots.DisableForRun()` at brace depth 0 with no enclosing `try` (checked with a brace-depth scan, not by eye), and that method now calls `Path.GetFullPath` on the raw `AL_RUNNER_NO_CACHE_ROOT` value. Measured on the merged build:

```
Unhandled exception. System.IO.FileNotFoundException: Unable to find the specified file.
   at Interop.Sys.GetCwd()
   at System.IO.Path.GetFullPathInternal(String path)
   at AlRunner.Infrastructure.CacheRoots.DisableForRun() in .../CacheRoots.cs:line 151
   at Program.<Main>$(String[] args) in .../Program.cs:line 1364
EXIT=134
```

Fixed with the same `try` → stderr → `return 2` shape the `--cache` branch already uses, as the reviewer proposed, and both now share one message builder (`CacheRoots.BuildUnusableCacheRootMessage`) so they cannot drift apart again. `SetOverride` is inside the same wrapper: it cannot throw today (its input is already rooted at parse time), but it is the other writer of the same field and leaving it outside would recreate the asymmetry one level down.

### How a rejected path is reachable on Linux at all

The reviewer called this practically unreachable, and that needed measuring rather than assuming. On net8.0/Linux, `Path.GetFullPath`:

| input | result |
|---|---|
| embedded NUL | `ArgumentException` — but `SetEnvironmentVariable` truncates at the NUL and `execve` argv cannot carry one, so it cannot arrive |
| 40,000-char relative, 300,001-char absolute | accepted; there is no length check on Unix |
| relative value, working directory unlinked | `FileNotFoundException` — `getcwd(2)` fails with `ENOENT` |

So one reachable trigger: a relative value while the cwd has been removed (`cd d && rm -rf d && exec …`). Rare, deterministic, and a real process state — which is both why the reviewer judged it non-blocking and what the tests use.

## Finding 2 — two untested branches. Confirmed.

Every `--cache` caller in `AlRunner.Tests` passes an absolute path (`TestScratch.Dir(...)` or a `Path.Combine` of an absolute root), so neither the reject branch nor the rooting was ever entered. Both are covered now, through the CLI.

## Finding 3 — `alCacheDir` had neither the guard nor a test. Confirmed.

`alCacheDir` deliberately never flows through `CacheRoots.Resolve` (that class's "Deliberately NOT wired into alCacheDir" note), so #3104's rootedness guard covered every cache derived from a `--cache` value and not the al-out half of the *same* value. The check moved out of `Resolve` into `CacheRoots.RequireRooted(dir, name)`, and `Program.cs` asserts it on the al-out root — one invariant, one wording, two consumers.

## Inventory note — `ncl-shadow`. Confirmed, with a corrected path.

`CacheRoots.Resolve("ncl-shadow")` → `NclShadowRuntime.EnsureShadowDir` → `psi.ArgumentList.Add(shadowDll)` at **`AlRunner/ProgramSupport/Provisioning.cs:106`** (the finding cited `AlRunner/Provisioning.cs:106`; there is no such file — it is under `ProgramSupport/`). It is already covered by the `Resolve` guard, so nothing about the merged fix changes; what changed is that the guard's diagnostic named only `LoadFromAssemblyPath`, and now names the `dotnet exec` child-process consumer too, because that breaks for a reason unrelated to assembly loading.

## RED → GREEN

RED baseline: `AlRunner/Program.cs` replaced with its pre-#3104 content (`82d7fe22^` — the file has not changed on `main` since), keeping the new `CacheRoots.cs` so the suite compiles. Restored from a copy outside the repository, never with `git checkout <rev> --`.

| test | RED | GREEN |
|---|---|---|
| `NoCache_WithAnAdoptedEnvironmentRootGetFullPathRejects_ExitsTwoInsteadOfCrashing` | `Assert.Equal(2, exit)` → **actual 134**, output carries `Unhandled exception` + the `DisableForRun` stack | exit 2, `AL_RUNNER_NO_CACHE_ROOT 'relcache' is not a usable directory path: …` |
| `Cache_WithAValueGetFullPathRejects_ExitsTwoNamingTheFlag` | `Assert.Equal(2, exit)` → **actual 134** | exit 2, `--cache 'relcache' is not a usable directory path: …` |
| `RelativeCache_RunsCleanlyAndCarriesTheAbsoluteAlOutputRoot` | `[cache] WROTE key=7c5f1cd7… path=rel-out/7c5f1cd7….dll` → **relative**, run otherwise green and silent | `path=<workdir>/rel-out/….dll`, absolute, `pass: 1`, exit 0 |
| `RequireRooted_*`, `BuildUnusableCacheRootMessage_*` | the members did not exist; the pre-change `Resolve` message contains neither `ncl-shadow` nor `dotnet exec` | pass |

`Failed: 3, Passed: 3` → `Passed: 6`.

The third row is the interesting one. In that RED state #3104's `SetOverride` rooting was still in place, so every *derived* cache was absolute and only the al-out root was not — the run stayed green and wrote to a relative path with nothing said about it. That is finding 3's asymmetry, reproduced. With `RequireRooted` on the al-out root, the same reverted state exits 2 instead: loud either way, never silent.

Also run, all green: `CacheRoot*` + `NoCacheLastWins*` + `RelativeCacheRoot*` (28 passed), `CleanRunStartupVerbosityTests` + `ScratchDirsRunnerStartupTests` (7 passed), `CliDocumentationTests` (20 passed). Not run: the full `AlRunner.Tests` sweep — CI does that on each of the 8 legs.

## Wider sweep

- **Same wrong pattern at another call site?** `CacheRoots`' override has exactly two writers, both in `Program.cs`, and both are now inside the wrapper. Its eight named caches all reach disk through `Resolve`, which still guards. The al-out root was the only consumer outside that path, and it is the subject of finding 3.
- **Sibling function with the same assumption?** Yes, one, and it is a different subsystem: with the same unlinked cwd the runner aborts at `Program.cs:843` (`Environment.CurrentDirectory` in the expectations auto-probe) with exit 134 — reached *before* the cache-root block, which is why the `--no-cache` test passes `--expectations` explicitly to get past it. Deliberately not fixed here: the fix is a behavior decision (abort, or fall back to the bundle-ancestor probe), not a wrapper. Filed as #3120 and referenced from the test comment.
- **Two paths writing one state with different invariants?** That is findings 1 and 3, and both are closed above.

## Not a claim about BC

Nothing here asserts anything about Business Central: `--cache`, `AL_RUNNER_NO_CACHE_ROOT` and a cache root are runner CLI/infrastructure surfaces. AL cannot pass a `--cache` value and cannot observe a cache root, so this is structurally inexpressible in the al-language corpus rather than conveniently kept local — the same reasoning the reviewer accepted for #3104 itself. No corpus PR, no submodule pin bump.

## Docs

One `--help` line under `--cache`, saying an unusable value exits 2 naming the flag rather than crashing, and that `AL_RUNNER_NO_CACHE_ROOT` behaves the same under `--no-cache`. No `docs/limitations.md` or `docs/scope.md` change: nothing about what the runner can do moved.

---
Opened by agent `stma-auto-1` (cycle 137) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
