### PR TITLE
test(expectations): point the RunObject no-handler gaps at an issue that is not falsified

### DIFF
--- a/tests/expectations/known-gaps-testpage-runobject-no-handler.json
+++ b/tests/expectations/known-gaps-testpage-runobject-no-handler.json
@@ -4,15 +4,15 @@
     "CodeunitName": "TPARONH Tests",
     "Method": "RunObjectActionWithoutAHandlerOpensItsTargetUnattended",
     "Mode": "expect-fail-known-gap",
-    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2975",
-    "Note": "A page action's RunObject invoked with NO handler bound: real BC opens the target anyway, runs its OnOpenPage, and raises nothing AL can see -- measured on 27.0, 27.3, 27.5, 28.0, 28.1, 28.2, 28.3 and 28.4 (StefanMaron/BusinessCentral.AL.Language.Tests#185). The runner refuses instead, with NavNCLMissingUIHandlerException 'Unhandled UI: Page 60282'. #2951 made an action's RunObject perform its target, which is why the sibling eight-test suite (codeunit 60455 'TPARO Tests') passes here; the no-handler arm was deliberately held out of that suite while the question was open and is what #2975 still tracks. The three control arms in THIS codeunit pass on the runner -- a plain Page.Run on the same target IS refused, an OnAction trigger calling Page.Run on the same host and row IS refused, and the logging target does record its own opening when a handler is bound -- so the fixture, the target page and the action-invoke path are all ruled out, and the RunObject declaration is the only thing left."
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3090",
+    "Note": "A page action's RunObject invoked with NO handler bound: real BC opens the target anyway, runs its OnOpenPage, and raises nothing AL can see -- measured on 27.0, 27.3, 27.5, 28.0, 28.1, 28.2, 28.3 and 28.4 (StefanMaron/BusinessCentral.AL.Language.Tests#185). The runner refuses instead, with NavNCLMissingUIHandlerException 'Unhandled UI: Page 60282'. #2951 made an action's RunObject perform its target, which is why the sibling eight-test suite (codeunit 60455 'TPARO Tests') passes here; the no-handler arm was deliberately held out of that suite while the question was open and is what #3090 tracks. Re-pointed from #2975: that issue's premise -- that an action's RunObject is not performed at all -- is falsified in both directions now, by codeunit 60455 green on all eight real-BC legs and by #2951 making the runner perform it, so an entry linking it would describe this gap to the next reader as the opposite of what a service tier measured. The three control arms in THIS codeunit pass on the runner -- a plain Page.Run on the same target IS refused, an OnAction trigger calling Page.Run on the same host and row IS refused, and the logging target does record its own opening when a handler is bound -- so the fixture, the target page and the action-invoke path are all ruled out, and the RunObject declaration is the only thing left."
   },
   {
     "codeunitId": 60285,
     "CodeunitName": "TPARONH Tests",
     "Method": "RunObjectActionOnTheControlsTargetWithoutAHandler_NoThrow",
     "Mode": "expect-fail-known-gap",
-    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2975",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3090",
     "Note": "The same gap as the entry above, aimed at the clean Card target rather than the logging one, so the comparison has a RunObject side on exactly the page the two Page.Run controls refuse. Its whole claim is that the statement completes; the runner raises NavNCLMissingUIHandlerException 'Unhandled UI: Page 60281' instead."
   }
 ]


### PR DESCRIPTION
No linked issue: closed unmerged. #2975 is the surviving tracker for the two known-gap entries, and this PR must not shut it — that would leave them untracked. The original closing line was removed for that reason; see the closing comment on this PR. (Written without a closing keyword next to the number on purpose: GitHub's parser fires on the pattern and ignores the negation around it.)

> **Closed unmerged.** The reasoning is in the comment below. Everything after this line is the original body, kept for the record, and its argument no longer holds.


Supersedes #3093, which is now shut as a duplicate — PR #3079 landed the same two entries first, so the only part still worth changing is the `Issue` field.

## The defect

`main` carries two `expect-fail-known-gap` entries for codeunit 60285 pointing at #2975, whose title reads *"an action's RunObject is not performed — and a real service tier says BC does not perform it either"*.

That premise is falsified in **both** directions:

- **Real BC performs it.** Corpus codeunit 60455 `"TPARO Tests"` is green on all eight legs (27.0, 27.3, 27.5, 28.0–28.4), so the RunObject route does open its target and does reach a bound `[PageHandler]`.
- **The runner performs it too.** #2951 implemented it, and #2931 is shut as a result — which is why `main` carries **no known-gap entries for 60455 at all**. I confirmed that by listing every entry in `tests/expectations/` and by running the corpus: 60455 passes.

So the one issue those entries point at is the one issue that says the gap does not exist as described. A reader following the link gets the opposite of what a service tier measured. #3090 describes it as measured: the target opens, runs its own `OnOpenPage`, and AL is never told.

## What this changes

Two `Issue` fields, `2975` → `3090`.

Plus one clause I did not plan to touch and could not leave: the first `Note` said *"is what #2975 still tracks"*, which would contradict the `Issue` field sitting beside it. It now names #3090 and records why it was re-pointed. Nothing else in either `Note` changed — the notes that landed with #3079 are accurate and current, including the `NavNCLMissingUIHandlerException` symptom that replaced the older out-of-scope refusal once #2951 landed.

Three lines total, expectations metadata only, no behaviour change.

## Why the original PR shut #2975 rather than correcting it

#2975 has nothing left to track once these two entries move:

| what #2975 covered | where it lives now |
|---|---|
| an action's `RunObject` is not performed | no longer true — #2951 landed the implementation, #2931 is shut, 60455 passes |
| the no-handler arm | **#3090** |
| the corpus tier cannot adjudicate action-opened pages (its Patch #21 comment) | **#2986**, filed for exactly that |
| `RunObject` naming a report / codeunit / xmlport / query | **#2943** |

Its investigative value is the Patch #21 measurement in its comment, and that is already carried by #2986, so shutting it loses nothing. The alternative — rewriting its title and body until they match the measurement — would leave an issue that is a duplicate of #3090 with a different number.

I am recording the same reasoning as a comment on #2975 itself, so it is on the thread whether or not this merges.

## Does this PR assert anything about BC's behaviour?

Yes, in the `Note` text — and the proving test for it is **already upstream**, so nothing new needs to go there. Codeunit 60285 `"TPARONH Tests"` lives in the corpus (`tests/al-language/tests/al-language/handlers/TestPageActionRunObjectNoHandler_Tests.al`, corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#185) and its no-handler arms are green on all eight real-BC legs. That corpus run is what the `Note` reports; this PR only changes which issue number the entry links to. There is no new BC claim here and therefore no new corpus PR.

## Verified by re-running, not by reading

On BC 28.1.49838.53910 at pin `861a5662`, all three corpus apps, `--strict --count-baseline`:

| run | result |
|---|---|
| with these entries | **2684/2684, exit 0**, `pass-known-gap` **13** |
| `CodeunitName` changed to `"TPARONH Testz"` | 2 failures, exit 1, `pass-known-gap` **11** |

The second row is the negative control, carried over from #3093 because it is the part that proves anything. One wrong letter makes both entries inert and **nothing warns** — there is no unmatched-entry audit in `ExpectationManifest.cs` or in `docs/expectations.md`. So the 11 → 13 movement is what shows the entries actually bite; reading the file cannot show that.

Re-checked on this push: `CodeunitName` `"TPARONH Tests"` and both `Method` names were compared character-for-character against the AL source (`codeunit 60285 "TPARONH Tests"` at line 147, `RunObjectActionWithoutAHandlerOpensItsTargetUnattended` at 184, `RunObjectActionOnTheControlsTargetWithoutAHandler_NoThrow` at 257), not against the issue text or a neighbouring entry.

## Known-red checks that are not this PR

- **`preflight.py unit tests`** — red on `main` and on at least three unrelated branches; impl-5 is on it. This PR does not touch `tools/preflight.py`.
- **`bc-tests / BC 28.4` on the previous head** — the corpus legs all passed; the failure was three `AlRunner.Tests.SuiteAbortOnTimeoutTests` cases in the unit-test step, which is #3086 ("SuiteAbortOnTimeoutTests and AlObjectEmitOrderDeterminismTests flake on the 27.5 and 28.4 legs"). A three-line JSON metadata change cannot reach that code.

Authored by an agent (impl-2).

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
