### PR TITLE
fix(metadata): answer Page Metadata's PageType from BC's own runtime enum, and CodeUnit Metadata's SubType from the compiler's

### DIFF
--- a/AlRunner.Tests/MetadataOptionColumnOrdinalTests.cs
+++ b/AlRunner.Tests/MetadataOptionColumnOrdinalTests.cs
@@ -1,0 +1,364 @@
+// MetadataOptionColumnOrdinalTests — where Page Metadata (2000000138) and CodeUnit Metadata
+// (2000000137) get the ordinal of their one option column from, and what they do with a member
+// the column's own option string does not list (#3080).
+//
+// THE TWO COLUMNS LOOK IDENTICAL AND ANSWER DIFFERENTLY, AND A TIER DECIDED BOTH
+// -----------------------------------------------------------------------------
+// Both columns are filled the same way in Ncl — `GetOptionValue(5, (int)<some runtime enum>)`
+// — and in both cases that enum reaches past the last member the column names. For PageType
+// the extra ordinal comes through: a `PageType = PromptDialog` page reports 20, past
+// HeadlinePart at 12. For SubType it does not: a `Subtype = Install` codeunit reports 0,
+// `Normal`, even though CodeunitSubType numbers Install at 4.
+//
+// Both were measured on real BC, not reasoned about, and the second one contradicted the
+// reasoning: StefanMaron/BusinessCentral.AL.Language.Tests#196 (PageType, 20) and #201
+// (SubType, 0 for Install and 1 for Test in the same run) each ran on eight Cloud legs, 27.0
+// through 28.4. The reason for the difference is one frame upstream of the provider — the
+// value handed to the SubType column is what the AL COMPILER wrote into
+// NavCodeunitOptionsAttribute, and the compiler emits Test, TestRunner and Upgrade but never
+// Install. Measured over Base Application 28.1's own assemblies: of 1,690 codeunits carrying
+// that attribute, 28 of 28 declared-Upgrade carry 3, 2 of 2 declared-TestRunner carry 2, and
+// all three declared-Install (3999, 5000, 7582) carry 0. Not one carries 4.
+//
+// WHY THIS IS A RUNNER-SIDE MECHANISM TEST AND NOT (ONLY) AN AL BUNDLE
+// -------------------------------------------------------------------
+// The BC-behaviour claims are upstream, in the two corpus PRs above. Nothing here restates
+// them.
+//
+// What this file pins is the ROUTE, which no AL assertion can see. An AL test only ever
+// observes the artifact it runs on, and on that artifact each column's option string and the
+// runtime enum agree wherever they overlap — so a test written against one cannot tell which
+// of the two the runner read, nor whether the runner reached the right answer for the right
+// reason. The cases below hand the resolvers an option string and an enum that DISAGREE, and
+// hand the SubType resolver a map that offers Install at 4, which is exactly what no single
+// artifact can construct.
+//
+// The enums below are copied verbatim out of BC 28.1.49838.53910's own
+// Microsoft.Dynamics.Nav.Types.dll, and BcEnumsStillReachBeyondTheOptionString checks that
+// copy against the artifact the leg actually built with, so it cannot rot into a fiction.
+
+using System;
+using System.Collections.Generic;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class MetadataOptionColumnOrdinalTests
+{
+    // BC 28.1.49838.53910's own OptionMembers for the two columns, read out of System.app's
+    // PageMetadata.Table.al and CodeUnitMetadata.Table.al. Both are a strict PREFIX of the
+    // runtime enum the provider casts — which is the whole subject of this file.
+    private const string RealPageTypeOptions =
+        "Card,List,RoleCenter,CardPart,ListPart,Document,Worksheet,ListPlus,ConfirmationDialog,"
+        + "NavigatePage,StandardDialog,API,HeadlinePart";
+    private const string RealSubTypeOptions = "Normal,Test,TestRunner,Upgrade";
+
+    /// <summary>Microsoft.Dynamics.Nav.Types.Metadata.PageType, verbatim.</summary>
+    private enum BcPageType
+    {
+        Card, List, RoleCenter, CardPart, ListPart, Document, Worksheet, ListPlus,
+        ConfirmationDialog, NavigatePage, StandardDialog, API, HeadlinePart, ReportPreview,
+        ReportProcessingOnly, XmlPort, ReportViewer, FilterPage, ListQuery, BannerPart,
+        PromptDialog, ConfigurationDialog, UserControlHost
+    }
+
+    /// <summary>Microsoft.Dynamics.Nav.Types.CodeunitSubType, verbatim.</summary>
+    private enum BcCodeunitSubType { Normal, Test, TestRunner, Upgrade, Install }
+
+    private static Dictionary<string, int> PageTypeMap(string optionString = RealPageTypeOptions)
+        => RecordPatches.BuildMetadataOptionOrdinals(optionString, typeof(BcPageType));
+
+    // No enum, matching production: EnsureCodeunitSubtypeOrdinals passes bcRuntimeEnum: null
+    // for this column. SubTypeMapOverlaid below is the adversarial one.
+    private static Dictionary<string, int> SubTypeMap(string optionString = RealSubTypeOptions)
+        => RecordPatches.BuildMetadataOptionOrdinals(optionString, bcRuntimeEnum: null);
+
+    private static int Page(string? declared, string optionString = RealPageTypeOptions)
+        => RecordPatches.ResolvePageTypeOrdinal(PageTypeMap(optionString), optionString, declared, pageId: 60017);
+
+    private static int Codeunit(string? declared, string optionString = RealSubTypeOptions)
+        => RecordPatches.ResolveCodeunitSubtypeOrdinal(SubTypeMap(optionString), optionString, declared, codeunitId: 60963);
+
+    // ── The defect: a member past the end of the option string ───────────────────────────
+
+    [Fact]
+    public void PageTypeBeyondTheOptionString_ResolvesTheRuntimeEnumOrdinal_NotCard()
+    {
+        // BC 28.1's PageType option string stops at HeadlinePart (12). PromptDialog and
+        // UserControlHost are real, compiler-accepted AL — Base Application 28.1 ships one page
+        // of each (5836 "Copilot Marketing Text", 6324 "Power BI Element Addin Host") — and
+        // PageDataProvider writes GetOptionValue(5, (int)properties.PageType), so a service
+        // tier reports the ENUM ordinal even though the column names no member there.
+        //
+        // Before #3080 both fell through to NavValue.GetDefaultNavValue, i.e. 0, so the runner
+        // said "Card" about a page that declared neither. 0 is the answer this must not give.
+        Assert.Equal(20, Page("PromptDialog"));
+        Assert.Equal(22, Page("UserControlHost"));
+
+        // Distinguishing 20 from 22 is the point: a fix that answered "the count of members"
+        // or any other single constant would satisfy neither pair.
+        Assert.NotEqual(Page("PromptDialog"), Page("UserControlHost"));
+    }
+
+    [Fact]
+    public void DeclaredInstallSubtype_ResolvesNormal_NotTheRuntimeEnumOrdinal()
+    {
+        // CodeunitSubType is Normal,Test,TestRunner,Upgrade,Install — five members — while the
+        // column lists the first four, so the shape looks exactly like the PageType case above
+        // and the analogous answer would be 4. A service tier says otherwise: corpus #201 reads
+        // an Install fixture through this column on all eight legs and gets 0.
+        Assert.Equal(0, Codeunit("Install"));
+        Assert.Equal(Codeunit("Normal"), Codeunit("Install"));
+        Assert.NotEqual(4, Codeunit("Install"));
+
+        // And the column is not simply always 0 — the three subtypes the compiler DOES emit
+        // keep their own ordinals, so the Install translation flattened nothing else. This is
+        // the same contrast corpus #201 draws by reading a Subtype = Test codeunit in the same
+        // run as the Install one.
+        Assert.Equal(1, Codeunit("Test"));
+        Assert.Equal(2, Codeunit("TestRunner"));
+        Assert.Equal(3, Codeunit("Upgrade"));
+    }
+
+    [Fact]
+    public void DeclaredInstallSubtype_ResolvesTheNormalMemberByName_NotAHardcodedZero()
+    {
+        // On the real column Normal is at 0, so "translated to Normal" and "returned 0" are
+        // indistinguishable there. Reordered, they are not: a resolver that hardcoded 0 would
+        // report Test about an Install codeunit.
+        const string Reordered = "Test,Upgrade,Normal";
+        Assert.Equal(2, Codeunit("Install", Reordered));
+        Assert.Equal(0, Codeunit("Test", Reordered));
+    }
+
+    [Fact]
+    public void DeclaredInstallSubtype_StaysNormal_EvenWhenAnInstallOrdinalIsOnOffer()
+    {
+        // The translation is unconditional and sits in FRONT of the lookup, so a map that does
+        // carry install -> 4 cannot produce 4. Two ways such a map can arise, and the answer is
+        // the tier's either way:
+        //
+        //   (a) somebody overlays the runtime enum onto this column — which is what the first
+        //       shape of #3080's fix did, and what the tier rejected;
+        //   (b) a future artifact's column names Install as a fifth member. Even then an
+        //       Install codeunit reports 0, because the value reaching the column is the
+        //       compiler's, not the AL author's.
+        //
+        // If a future AL compiler ever starts emitting Install, corpus #201 goes red on that
+        // version and this translation is what has to change. That is the intended alarm.
+        var overlaid = RecordPatches.BuildMetadataOptionOrdinals(RealSubTypeOptions, typeof(BcCodeunitSubType));
+        Assert.Equal(4, overlaid[NormalizedFor("Install")]);   // the map really is offering 4
+        Assert.Equal(0, RecordPatches.ResolveCodeunitSubtypeOrdinal(
+            overlaid, RealSubTypeOptions, "Install", codeunitId: 60963));
+
+        const string ColumnNamingInstall = "Normal,Test,TestRunner,Upgrade,Install";
+        Assert.Equal(0, Codeunit("Install", ColumnNamingInstall));
+    }
+
+    // ── The half that already worked, which the fix must not move ────────────────────────
+
+    [Fact]
+    public void MembersTheOptionStringDoesList_KeepTheirOrdinals()
+    {
+        Assert.Equal(0, Page("Card"));
+        Assert.Equal(1, Page("List"));
+        Assert.Equal(12, Page("HeadlinePart"));
+        Assert.Equal(0, Codeunit("Normal"));
+        Assert.Equal(1, Codeunit("Test"));
+        Assert.Equal(2, Codeunit("TestRunner"));
+    }
+
+    [Fact]
+    public void TheRuntimeEnumWins_WhenTheOptionStringDisagreesAboutASharedName()
+    {
+        // The two sources cannot disagree on any artifact measured so far — the option string
+        // is a prefix of the enum — but BC's providers consult only the enum, so if they ever
+        // did, the enum is the answer. Constructed here because no artifact can construct it:
+        // an option string listing List first would put List at 0 by position, and the enum
+        // says 1.
+        const string Reordered = "List,Card,RoleCenter";
+        Assert.Equal(1, Page("List", Reordered));
+        Assert.Equal(0, Page("Card", Reordered));
+    }
+
+    [Fact]
+    public void WithoutTheRuntimeEnum_TheOptionStringStillAnswersEveryMemberItLists()
+    {
+        // The degraded path: a BC build where the enum type cannot be resolved. Every member
+        // the column names still resolves, so the runner keeps working; only the members past
+        // the end of the option string become unanswerable.
+        var optionOnly = RecordPatches.BuildMetadataOptionOrdinals(RealPageTypeOptions, bcRuntimeEnum: null);
+
+        Assert.Equal(0, optionOnly[NormalizedFor("Card")]);
+        Assert.Equal(12, optionOnly[NormalizedFor("HeadlinePart")]);
+        Assert.False(optionOnly.ContainsKey(NormalizedFor("PromptDialog")));
+
+        // And this is exactly where the wrong answer came from before #3080, because the map
+        // was ALWAYS this one: the miss fell through to NavValue.GetDefaultNavValue — ordinal
+        // 0, "Card" — about a page that declared PromptDialog. Unanswerable is the truthful
+        // outcome; 0 is the one that must never come back.
+        var refusal = Assert.Throws<RunnerOutOfScopeException>(
+            () => RecordPatches.ResolvePageTypeOrdinal(optionOnly, RealPageTypeOptions, "PromptDialog", 5836));
+        Assert.Contains("PromptDialog", refusal.Message);
+    }
+
+    // NormalizeObjectTypeName is private to RecordPatches; these two names contain nothing it
+    // strips, so the normalized key is the lower-cased name.
+    private static string NormalizedFor(string member) => member.ToLowerInvariant();
+
+    // ── The default, and the two refusals ────────────────────────────────────────────────
+
+    [Fact]
+    public void UndeclaredPageType_ResolvesCardByName_NotOrdinalZero()
+    {
+        // Both parsers already substitute "Card" before a row is built, so this branch is the
+        // backstop for a null that slips through (a stale symbol payload, a cache version that
+        // predates the property). It has to resolve the MEMBER, not a position: on the real
+        // artifact Card is 0 and the two are indistinguishable, so the second case is what
+        // makes the assertion mean anything.
+        Assert.Equal(0, Page(null));
+        Assert.Equal(0, Page("   "));
+        Assert.Equal(0, Page(null, "List,RoleCenter,Card"));   // enum wins: Card is 0 there too
+
+        // With no enum to consult, the position in the option string is the answer, and it
+        // moves with the member rather than staying at 0.
+        var reorderedOptionOnly = RecordPatches.BuildMetadataOptionOrdinals("List,RoleCenter,Card", null);
+        Assert.Equal(2, RecordPatches.ResolvePageTypeOrdinal(
+            reorderedOptionOnly, "List,RoleCenter,Card", null, pageId: 60017));
+    }
+
+    [Fact]
+    public void UndeclaredSubtype_ResolvesNormalByName_NotOrdinalZero()
+    {
+        Assert.Equal(0, Codeunit(null));
+
+        var reorderedOptionOnly = RecordPatches.BuildMetadataOptionOrdinals("Test,Upgrade,Normal", null);
+        Assert.Equal(2, RecordPatches.ResolveCodeunitSubtypeOrdinal(
+            reorderedOptionOnly, "Test,Upgrade,Normal", null, codeunitId: 60963));
+    }
+
+    [Fact]
+    public void PageTypeInNeitherSource_IsRefusedNotDefaulted()
+    {
+        // Unreachable from valid AL — the compiler validates PageType against the same enum —
+        // and that is exactly why answering 0 would be undetectable. Refusing here is only safe
+        // BECAUSE the enum overlay covers PromptDialog and UserControlHost; refusing on the
+        // option string alone would have thrown on every run that loads the Base Application.
+        var ex = Assert.Throws<RunnerOutOfScopeException>(() => Page("NotAPageType"));
+
+        Assert.Contains("60017", ex.Message);
+        Assert.Contains("declares PageType = 'NotAPageType'", ex.Message);
+        Assert.Contains(RealPageTypeOptions, ex.Message);
+        // Category (2) of RecordPatches.VirtualTableShapeGap.cs: in scope, not answerable yet.
+        // The anchor is load-bearing — IsPermanentOutOfScope reads it to decide whether an AL
+        // [TryFunction] traps this into `false` or it tears through.
+        Assert.StartsWith("not-yet-implemented", ex.Reason);
+        Assert.Equal("Page Metadata (virtual table 2000000138)", ex.Api);
+    }
+
+    [Fact]
+    public void SubtypeTheColumnDoesNotName_IsRefusedNotDefaulted()
+    {
+        // Unreachable from valid AL, and that is exactly why answering 0 would be undetectable.
+        // Refusing here is safe BECAUSE the Install translation runs first: the one subtype AL
+        // accepts that this column does not name never reaches this branch, so it can only fire
+        // on something that is not an AL codeunit subtype at all.
+        var ex = Assert.Throws<RunnerOutOfScopeException>(() => Codeunit("NotASubtype"));
+
+        Assert.Contains("60963", ex.Message);
+        Assert.Contains("declares Subtype = 'NotASubtype'", ex.Message);
+        Assert.Contains(RealSubTypeOptions, ex.Message);
+        // The message has to say why "not in the option string" is the right test for this
+        // column when it is the wrong test for PageType, or the next reader re-derives it.
+        Assert.Contains("Install", ex.Message);
+        Assert.StartsWith("not-yet-implemented", ex.Reason);
+        Assert.Equal("CodeUnit Metadata (virtual table 2000000137)", ex.Api);
+
+        // Install itself is NOT refused — it is translated. The refusal and the translation are
+        // the two halves of the same decision and this pins that they did not get swapped.
+        Assert.Equal(0, Codeunit("Install"));
+    }
+
+    [Fact]
+    public void UndeclaredValue_DefaultMemberAbsentFromBothSources_IsRefusedNotDefaulted()
+    {
+        // The mirror of the Table Metadata refusal #3019 added: an artifact whose column does
+        // not carry the AL default at all. Answering 0 would report whichever member happens to
+        // be first about an object that said nothing.
+        const string WithoutCard = "List,RoleCenter,Document";
+        var ex = Assert.Throws<RunnerOutOfScopeException>(() => RecordPatches.ResolvePageTypeOrdinal(
+            RecordPatches.BuildMetadataOptionOrdinals(WithoutCard, null), WithoutCard, null, pageId: 60017));
+
+        Assert.Contains("declares no PageType", ex.Message);
+        Assert.Contains("'Card'", ex.Message);
+        Assert.Contains(WithoutCard, ex.Message);
+
+        const string WithoutNormal = "Test,TestRunner,Upgrade";
+        var ex2 = Assert.Throws<RunnerOutOfScopeException>(() => RecordPatches.ResolveCodeunitSubtypeOrdinal(
+            RecordPatches.BuildMetadataOptionOrdinals(WithoutNormal, null), WithoutNormal, null, codeunitId: 60963));
+
+        Assert.Contains("declares no Subtype", ex2.Message);
+        Assert.Contains("'Normal'", ex2.Message);
+
+        // A declared Install on that same column reaches the same refusal, by the same route —
+        // the translation makes it a request for "Normal", which this column does not name.
+        // Refused, not quietly answered as one of the three members it does name.
+        var ex3 = Assert.Throws<RunnerOutOfScopeException>(() => RecordPatches.ResolveCodeunitSubtypeOrdinal(
+            RecordPatches.BuildMetadataOptionOrdinals(WithoutNormal, null), WithoutNormal, "Install", codeunitId: 60963));
+        Assert.Contains("'Install'", ex3.Message);
+    }
+
+    // ── The copies above, checked against the artifact this leg actually built with ──────
+
+    /// <summary>BC's runtime enum behind CodeUnit Metadata's SubType column. Not a constant in
+    /// AlRunner any more — the production resolver deliberately does not consult it (#3080) —
+    /// so it lives here, where the only thing it is used for is keeping the verbatim copy of
+    /// it above honest.</summary>
+    private const string BcCodeunitSubTypeEnumName = "Microsoft.Dynamics.Nav.Types.CodeunitSubType";
+
+    [Fact]
+    public void BcEnumsStillReachBeyondTheOptionString_OnTheArtifactUnderTest()
+    {
+        // AlRunner.Tests references Microsoft.Dynamics.Nav.Types out of the resolved artifact,
+        // so this binds to whichever BC version the leg is running — 27.0 through 28.4 across
+        // the matrix. It is the guard that keeps the verbatim copies above honest, and the
+        // guard that the runner is naming a type that exists.
+        var pageType = RecordPatches.ResolveBcOptionEnum(RecordPatches.BcPageTypeEnumName);
+        var subType = RecordPatches.ResolveBcOptionEnum(BcCodeunitSubTypeEnumName);
+
+        Assert.True(pageType != null, $"{RecordPatches.BcPageTypeEnumName} did not resolve on this BC build.");
+        Assert.True(subType != null, $"{BcCodeunitSubTypeEnumName} did not resolve on this BC build.");
+
+        // BOTH enums carry members their column cannot name. For PageType that is the premise
+        // of the overlay; for CodeunitSubType it is the premise that turned out to be
+        // necessary but NOT sufficient, which is why it is asserted here and acted on only
+        // there. If Install ever stopped being past the end of that column, the comment above
+        // explaining why this file treats the two columns differently would be stale.
+        Assert.Contains("PromptDialog", Enum.GetNames(pageType!));
+        Assert.Contains("UserControlHost", Enum.GetNames(pageType!));
+        Assert.Contains("Install", Enum.GetNames(subType!));
+        Assert.True(
+            Convert.ToInt32(Enum.Parse(subType!, "Install")) >= RealSubTypeOptions.Split(',').Length,
+            "CodeunitSubType.Install is no longer past the last member the SubType column names.");
+
+        // PageType: the runner's answer for a member past the end is the enum's own value,
+        // whatever this version numbers it — asserted against the enum rather than against 20,
+        // so a BC release that inserts a member does not make this test wrong about BC.
+        var live = RecordPatches.BuildMetadataOptionOrdinals(RealPageTypeOptions, pageType);
+        Assert.Equal(
+            Convert.ToInt32(Enum.Parse(pageType!, "PromptDialog")),
+            RecordPatches.ResolvePageTypeOrdinal(live, RealPageTypeOptions, "PromptDialog", 5836));
+
+        // SubType: the runner's answer is NOT the enum's value, and this is the assertion that
+        // says so against the live artifact rather than against a copy. What a service tier
+        // reports for an Install codeunit is Normal's ordinal, on every leg (corpus #201).
+        Assert.NotEqual(
+            Convert.ToInt32(Enum.Parse(subType!, "Install")),
+            RecordPatches.ResolveCodeunitSubtypeOrdinal(
+                SubTypeMap(), RealSubTypeOptions, "Install", codeunitId: 60963));
+        Assert.Equal(0, RecordPatches.ResolveCodeunitSubtypeOrdinal(
+            SubTypeMap(), RealSubTypeOptions, "Install", codeunitId: 60963));
+    }
+}

--- a/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
+++ b/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
@@ -336,11 +336,34 @@ public sealed class VirtualTableRefusalClaimTests
         // package or assembly it could not read, which PopulateAllObjVirtualTable then wrote
         // out as Guid.Empty -- indistinguishable from "this app does not own it".
         //
+        // 71 -> 75 (#3080): the Page Metadata and CodeUnit Metadata populators each
+        // gained the same two refusals, for the same invariant but not for the same reason.
+        // Both columns used to fall through to NavValue.GetDefaultNavValue for a member name
+        // the column's option string does not list, under a comment saying the case could not
+        // arise. It arises.
+        //
+        // Page Metadata: BC 28.1's PageType column stops at HeadlinePart while the runtime
+        // enum reaches PromptDialog (20) and UserControlHost (22), and Base Application 28.1
+        // ships a page of each -- both answered "Card", about a page that declared neither.
+        // Refusing is only correct once those members RESOLVE, which is why #3080 added BC's
+        // own runtime PageType enum as a second ordinal source before adding these throws;
+        // refusing on the option string alone would have taken Page Metadata out entirely.
+        //
+        // CodeUnit Metadata: its SubType column stops at Upgrade while CodeunitSubType adds
+        // Install (4), so the analogous overlay looked right, and it is not -- a service tier
+        // disagreed on all eight legs (corpus #201: an Install codeunit reports 0). The AL
+        // compiler never writes Install into object metadata, so the three Base App Install
+        // codeunits answered "Normal" were answered CORRECTLY. That column resolves from its
+        // own option string with an Install -> Normal translation in front, and these two
+        // throws can now only fire on a subtype AL does not accept at all.
+        // MetadataOptionColumnOrdinalTests pins all four messages.
+        //
         // NOTE TO WHOEVER REBASES THIS NEXT: more than one open PR moves this number at a
-        // time (#3128 moves it too, by a different amount). Do NOT add your delta to whatever
-        // is on main -- run the test, read the "Actual:" value out of the failure message, and
-        // write that. An arithmetic guess here is how the assertion silently stopped meaning
-        // what it says once before.
+        // time -- as this rebase found: #3015 moved it to 72 on main while this branch was
+        // moving it to 75 from the same base of 71, and neither delta is the answer. Do NOT
+        // add your delta to whatever is on main -- run the test, read the "Actual:" value out
+        // of the failure message, and write that. An arithmetic guess here is how the
+        // assertion silently stopped meaning what it says once before.
 
         // 71 -> 72 (#3015): the AllObj populator gained one more. It resolves its columns by
         // field NUMBER rather than by name, and a number matching nothing was simply never
@@ -354,8 +377,9 @@ public sealed class VirtualTableRefusalClaimTests
         // EnsureAllObjSharedReflection.
         //
         // Per the note above: this number was READ OUT of the test's own failure message after
-        // rebasing onto #3117, not arrived at by adding 1 to what was on main.
-        Assert.Equal(72, total);
+        // rebasing this branch's four #3080 refusals onto main's #3015 one, not arrived at by
+        // adding 4 to 72 or 1 to 75.
+        Assert.Equal(999999, total);
     }
 
 

--- a/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
+++ b/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
@@ -336,7 +336,7 @@ public sealed class VirtualTableRefusalClaimTests
         // package or assembly it could not read, which PopulateAllObjVirtualTable then wrote
         // out as Guid.Empty -- indistinguishable from "this app does not own it".
         //
-        // 71 -> 75 (#3080): the Page Metadata and CodeUnit Metadata populators each
+        // +4 (#3080): the Page Metadata and CodeUnit Metadata populators each
         // gained the same two refusals, for the same invariant but not for the same reason.
         // Both columns used to fall through to NavValue.GetDefaultNavValue for a member name
         // the column's option string does not list, under a comment saying the case could not
@@ -359,13 +359,21 @@ public sealed class VirtualTableRefusalClaimTests
         // MetadataOptionColumnOrdinalTests pins all four messages.
         //
         // NOTE TO WHOEVER REBASES THIS NEXT: more than one open PR moves this number at a
-        // time -- as this rebase found: #3015 moved it to 72 on main while this branch was
-        // moving it to 75 from the same base of 71, and neither delta is the answer. Do NOT
-        // add your delta to whatever is on main -- run the test, read the "Actual:" value out
-        // of the failure message, and write that. An arithmetic guess here is how the
-        // assertion silently stopped meaning what it says once before.
+        // time, and this rebase is the case in point. #3015 and #3080 both branched from 71;
+        // #3015 merged first and wrote 72, this branch had written 75, and NEITHER running
+        // total survives the rebase. The two entries below it are therefore written as
+        // DELTAS (+1, +4) rather than as `71 -> n` -- a running total in a comment is a claim
+        // about what else had merged when it was written, which stops being true the moment
+        // somebody else's PR lands first.
+        //
+        // Do NOT add your delta to whatever is on main -- run the test, read the "Actual:"
+        // value out of the failure message, and write that. An arithmetic guess here is how
+        // the assertion silently stopped meaning what it says once before. (Here the two
+        // deltas happen to be disjoint and 71+1+4 does land on 76. That is a fact about these
+        // two changes, confirmed by the measurement afterwards, not a method for the next one:
+        // two PRs touching one populator can move the same throw.)
 
-        // 71 -> 72 (#3015): the AllObj populator gained one more. It resolves its columns by
+        // +1 (#3015): the AllObj populator gained one more. It resolves its columns by
         // field NUMBER rather than by name, and a number matching nothing was simply never
         // written — the row still inserted, the column kept BC's own default, and
         // `AllObj."App Runtime Package ID" <> PublishedApplication."Runtime Package ID"` then
@@ -379,7 +387,7 @@ public sealed class VirtualTableRefusalClaimTests
         // Per the note above: this number was READ OUT of the test's own failure message after
         // rebasing this branch's four #3080 refusals onto main's #3015 one, not arrived at by
         // adding 4 to 72 or 1 to 75.
-        Assert.Equal(999999, total);
+        Assert.Equal(76, total);
     }
 
 

--- a/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
@@ -153,15 +153,117 @@ public static partial class RecordPatches
             case "singleinstance":
                 return NavBoolean(row.SingleInstance);
             case "subtype":
-                if (subtypeOrdinals.TryGetValue(NormalizeObjectTypeName(row.Subtype), out var ordinal))
-                    return _aovNavOptionCreate!.Invoke(null, new object?[] { field.FieldOptionMetadata, ordinal });
-                // A Subtype this BC artifact's option set does not list (should not happen —
-                // the compiler validated it against the same enum) — BC's own default rather
-                // than a guessed ordinal.
-                return _aovGetDefaultNavValue!.Invoke(null, new object?[] { field, false });
+                return _aovNavOptionCreate!.Invoke(null, new object?[]
+                {
+                    field.FieldOptionMetadata,
+                    ResolveCodeunitSubtypeOrdinal(
+                        subtypeOrdinals, field.FieldOptionMetadata?.OptionString, row.Subtype, row.Id)
+                });
             default:
                 return _aovGetDefaultNavValue!.Invoke(null, new object?[] { field, false });
         }
+    }
+
+    /// <summary>
+    /// AL's default <c>Subtype</c> for a codeunit that declares none. Pinned upstream by
+    /// <c>Record_CodeunitMetadata_Get_DeclaredCodeunit_ReturnsMatchingRow</c> in the al-language
+    /// corpus, which asserts <c>Subtype::Normal</c> for ALT Codeunit Meta Probe — a fixture
+    /// that declares no <c>Subtype</c> — and is green on a real BC service tier.
+    /// <para>Both row sources already substitute it before a row is built
+    /// (<c>d.Subtype ?? "Normal"</c> in <see cref="EnumerateKnownCodeunitMetadata"/>), so this
+    /// is the backstop, and the one place the substitution is stated as a MEMBER NAME resolved
+    /// against the live column rather than as a position.</para>
+    /// </summary>
+    private const string AlDefaultCodeunitSubtype = "Normal";
+
+    /// <summary>
+    /// The one AL codeunit subtype the AL compiler does not carry into object metadata, and the
+    /// member it collapses to. <c>Install</c> is a subtype AL accepts and
+    /// <c>Microsoft.Dynamics.Nav.Types.CodeunitSubType</c> numbers 4, one past the last member
+    /// this column names — but nothing ever puts a 4 in front of the column, because the
+    /// compiler writes 0 for it.
+    /// <para>Measured, not inferred, on Base Application 28.1.49838.53910: decoding every
+    /// <c>NavCodeunitOptionsAttribute</c> in the package's own assemblies (1,690) and joining
+    /// it to the same package's <c>SymbolReference.json</c> and AL sources, which record the
+    /// DECLARED property —</para>
+    /// <para><c>Subtype = Upgrade</c>: 28 codeunits, attribute value 3, 28 of 28.
+    /// <c>Subtype = TestRunner</c>: 2 codeunits, attribute value 2, 2 of 2.
+    /// <c>SubType = Install</c>: codeunits 3999, 5000 and 7582 — attribute value <b>0</b>, all
+    /// three. Across all 1,690 the only values that occur are 0, 2 and 3; not one carries 4.</para>
+    /// <para>A real service tier agrees:
+    /// <c>Record_CodeunitMetadata_Get_InstallCodeunit_ReportsSubtypeNormal</c> in the
+    /// al-language corpus reads an <c>Install</c> fixture through this column on eight Cloud
+    /// legs and gets ordinal 0, <c>Subtype::Normal</c>, on every one — while a
+    /// <c>Subtype = Test</c> codeunit read in the same run reports 1, so the column is not
+    /// simply always Normal.</para>
+    /// </summary>
+    private const string AlSubtypeTheCompilerDoesNotEmit = "Install";
+
+    /// <summary>
+    /// The ordinal CodeUnit Metadata's <c>SubType</c> column carries for one codeunit: the
+    /// declared member when the codeunit states the property,
+    /// <see cref="AlDefaultCodeunitSubtype"/> when it does not,
+    /// <see cref="AlDefaultCodeunitSubtype"/> again when it declares
+    /// <see cref="AlSubtypeTheCompilerDoesNotEmit"/>, and a refusal when the column's option
+    /// string does not know the name.
+    /// <para>The lookup is the column's own <c>OptionString</c> and nothing else — no runtime
+    /// enum is overlaid here, unlike Page Metadata's <c>PageType</c> (#3080). The enum DOES
+    /// reach one member further, and reading only that far predicts 4 for an <c>Install</c>
+    /// codeunit; a service tier says 0. The reason is upstream of the provider:
+    /// <c>NCLMetaCodeunit.Subtype</c> returns <c>options?.Subtype</c> off the codeunit's
+    /// <c>NavCodeunitOptionsAttribute</c> — what the compiler wrote, not what the AL author
+    /// declared — through <c>GetValueOrDefault()</c>. See
+    /// <see cref="AlSubtypeTheCompilerDoesNotEmit"/> for the measurement and
+    /// RecordPatches.MetadataOptionEnumOrdinals.cs for the contrast with PageType.</para>
+    /// <para>The translation has to live here rather than in either row source, because BOTH
+    /// sources carry the declared name: the AL parser reads <c>Subtype = Install;</c> out of
+    /// source, and BcAppSymbolCache reads <c>"Subtype": "Install"</c> out of
+    /// SymbolReference.json (present there for all three Base Application codeunits above). One
+    /// translation in front of one lookup keeps the two paths answering the same thing.</para>
+    /// <para>A name the option string does not know is refused rather than defaulted (#3080),
+    /// in both directions — declared miss, and default-member miss. Before this, a miss fell
+    /// through to <c>NavValue.GetDefaultNavValue</c> — ordinal 0 — under a comment claiming the
+    /// case could not arise. With the <c>Install</c> translation in front, the refusal can only
+    /// fire on a subtype AL does not accept at all, which is what it is for.</para>
+    /// <para>Split out of <c>BuildCodeunitMetadataValue</c> so the resolution can be driven with
+    /// an option string the caller chooses; the cases that matter — a column that orders its
+    /// members differently, or omits the default — are ones no single artifact can present.</para>
+    /// </summary>
+    /// <param name="ordinals">Member name (normalized) to ordinal, from
+    /// <see cref="EnsureCodeunitSubtypeOrdinals"/> or
+    /// <see cref="BuildMetadataOptionOrdinals(string?, Type?)"/> with a null enum.</param>
+    /// <param name="optionString">The column's own option string, for the refusal message.</param>
+    /// <param name="declaredSubtype">What the codeunit declares, or null/blank when it declares nothing.</param>
+    /// <param name="codeunitId">The codeunit, for the refusal message.</param>
+    internal static int ResolveCodeunitSubtypeOrdinal(
+        IReadOnlyDictionary<string, int> ordinals, string? optionString, string? declaredSubtype, int codeunitId)
+    {
+        // What the compiler wrote, not what the author declared. Unconditional and in front of
+        // the lookup, so an "Install" key that somehow reached the map — an overlaid enum, an
+        // artifact whose column grew a fifth member — still cannot make this answer 4.
+        var effectiveSubtype =
+            string.Equals(NormalizeObjectTypeName(declaredSubtype ?? string.Empty),
+                          NormalizeObjectTypeName(AlSubtypeTheCompilerDoesNotEmit), StringComparison.Ordinal)
+                ? AlDefaultCodeunitSubtype
+                : declaredSubtype;
+
+        if (string.IsNullOrWhiteSpace(effectiveSubtype))
+        {
+            if (ordinals.TryGetValue(NormalizeObjectTypeName(AlDefaultCodeunitSubtype), out var defaultOrdinal))
+                return defaultOrdinal;
+            throw CodeunitMetadataShapeGap(
+                $"codeunit {codeunitId} declares no Subtype, and the default for it "
+                + $"('{AlDefaultCodeunitSubtype}') is not a member of that column's own option set "
+                + $"('{optionString}')");
+        }
+        if (ordinals.TryGetValue(NormalizeObjectTypeName(effectiveSubtype), out var ordinal))
+            return ordinal;
+        throw CodeunitMetadataShapeGap(
+            $"codeunit {codeunitId} declares Subtype = '{declaredSubtype}', which is not a member of "
+            + $"that column's own option set ('{optionString}'). AL accepts one subtype the column "
+            + $"does not name — '{AlSubtypeTheCompilerDoesNotEmit}', which the compiler emits as "
+            + $"'{AlDefaultCodeunitSubtype}' and this resolver translates — so this is not an AL "
+            + "codeunit subtype at all");
     }
 
     /// <summary>
@@ -261,6 +363,12 @@ public static partial class RecordPatches
     /// metatable's own NCLOptionMetadata.OptionString, matched by name — never a hardcoded
     /// table, so the mapping tracks whatever the System package in the resolved artifact
     /// declares. Mirrors Page Metadata's EnsurePageTypeOrdinals for its "PageType" column.
+    /// <para>The option string is the ONLY source for this column, which is not true of Page
+    /// Metadata's PageType sibling. BC's CodeUnitDataProvider does write
+    /// GetOptionValue(5, (int)metaCodeunit.Subtype) — the ordinal of its own CodeunitSubType
+    /// enum, which carries Install one past this column's last member — but the value reaching
+    /// it is the one the AL compiler wrote, and the compiler emits no Install. Measured, and
+    /// confirmed on a service tier: see ResolveCodeunitSubtypeOrdinal (#3080).</para>
     /// </summary>
     private static Dictionary<string, int> EnsureCodeunitSubtypeOrdinals(NCLMetaTable metaTable)
     {
@@ -273,14 +381,10 @@ public static partial class RecordPatches
         var optionMetadata = field.FieldOptionMetadata
             ?? throw CodeunitMetadataShapeGap("\"Subtype\" carries no option metadata");
 
-        var map = new Dictionary<string, int>(StringComparer.Ordinal);
-        var parts = (optionMetadata.OptionString ?? string.Empty).Split(',');
-        for (int i = 0; i < parts.Length; i++)
-        {
-            var key = NormalizeObjectTypeName(parts[i]);
-            if (key.Length == 0) continue;
-            map.TryAdd(key, i);
-        }
+        // Deliberately no runtime-enum overlay: this column is filled from what the AL compiler
+        // wrote, and the compiler never writes a value past the members the column names. See
+        // ResolveCodeunitSubtypeOrdinal and RecordPatches.MetadataOptionEnumOrdinals.cs.
+        var map = BuildMetadataOptionOrdinals(optionMetadata.OptionString, bcRuntimeEnum: null);
         if (map.Count == 0)
             throw CodeunitMetadataShapeGap("\"Subtype\" option string is empty");
 

--- a/AlRunner/Patches/RecordPatches.MetadataOptionEnumOrdinals.cs
+++ b/AlRunner/Patches/RecordPatches.MetadataOptionEnumOrdinals.cs
@@ -1,0 +1,230 @@
+// RecordPatches.MetadataOptionEnumOrdinals — where the ordinal of Page Metadata's
+// (2000000138) "PageType" option column actually comes from, and why CodeUnit Metadata's
+// (2000000137) "SubType" column deliberately does NOT come from the same place (#3080).
+//
+// ── WHAT WAS WRONG ───────────────────────────────────────────────────────────────────────
+//   The Page Metadata populator resolved its one option column by looking the declared member
+//   NAME up in that column's own OptionString, and fell back to BC's zero value when the name
+//   was not there:
+//
+//       if (pageTypeOrdinals.TryGetValue(NormalizeObjectTypeName(row.PageType), out var o))
+//           return NavOption.Create(field.FieldOptionMetadata, o);
+//       // "should not happen — the compiler validated it against the same enum"
+//       return NavValue.GetDefaultNavValue(field, false);
+//
+//   The comment was wrong, and measurably so. That column does NOT list every member the AL
+//   compiler accepts. Read out of BC 28.1.49838.53910's own System.app:
+//
+//     Page Metadata "PageType"  OptionMembers = Card,List,RoleCenter,CardPart,ListPart,
+//                               Document,Worksheet,ListPlus,ConfirmationDialog,NavigatePage,
+//                               StandardDialog,API,HeadlinePart                    (13)
+//
+//   while the runtime enum it is filled from carries more:
+//
+//     Microsoft.Dynamics.Nav.Types.Metadata.PageType (Microsoft.Dynamics.Nav.Types.dll)
+//       Card=0 … HeadlinePart=12, ReportPreview=13, ReportProcessingOnly=14, XmlPort=15,
+//       ReportViewer=16, FilterPage=17, ListQuery=18, BannerPart=19, PromptDialog=20,
+//       ConfigurationDialog=21, UserControlHost=22                                 (23)
+//
+//   So the option string is a PREFIX of the enum, and `PageType = PromptDialog` /
+//   `PageType = UserControlHost` are ordinary, compiler-accepted AL that lands outside it.
+//   Not hypothetical: Base Application 28.1 ships page 5836 "Copilot Marketing Text"
+//   (PromptDialog) and page 6324 "Power BI Element Addin Host" (UserControlHost). Both were
+//   answered `PageType::Card` by this runner, about a page that declared something else —
+//   the silent default .claude/rules/loud-failures.md exists to stop.
+//
+// ── WHAT REAL BC DOES, MEASURED ON A SERVICE TIER ────────────────────────────────────────
+//   Not a name lookup. PageDataProvider casts the runtime enum straight to int and hands the
+//   raw value to the column, whether or not the column lists a member at that position
+//   (Ncl.dll 28.1, decompiled):
+//
+//     PageDataProvider           buffer[4] = GetOptionValue(5, (int)properties.PageType);
+//     MetadataDataProvider       GetOptionValue(no, v) => MetaTable.GetFieldByNo(no)
+//                                    .FieldOptionMetadata.CreateNavOption(v);
+//     NCLOptionMetadata          CreateNavOption(int value) — takes the out-of-range branch
+//                                    for value >= Count and returns
+//                                    NavOption.CreateBypassCache(this, value). It does not
+//                                    clamp, and it does not default.
+//
+//   A real service tier confirms it: StefanMaron/BusinessCentral.AL.Language.Tests#196 puts a
+//   `PageType = PromptDialog` page in front of eight Cloud legs (27.0 through 28.4) and the
+//   column reports 20 on every one — an ordinal with no member name in it at all. So for THIS
+//   column the enum is the source of truth for the number, and the option string only names
+//   the members it happens to cover.
+//
+// ── WHY CODEUNIT METADATA'S "SubType" IS NOT OVERLAID THE SAME WAY ───────────────────────
+//   Because the same reasoning, applied to that column, produced a wrong answer, and a
+//   service tier caught it. CodeUnitDataProvider looks identical —
+//   `buffer[4] = GetOptionValue(5, (int)metaCodeunit.Subtype)` — and
+//   Microsoft.Dynamics.Nav.Types.CodeunitSubType really does run Normal=0, Test=1,
+//   TestRunner=2, Upgrade=3, Install=4, one member past the four its column names. Predicting
+//   4 for a `Subtype = Install` codeunit follows, and it is wrong:
+//   StefanMaron/BusinessCentral.AL.Language.Tests#201 reads exactly that on a tier and gets
+//   ordinal 0, `Subtype::Normal`, on all eight legs. The ROW is there — the same test's
+//   `Get` succeeds — only the value differs.
+//
+//   The step the decompilation missed is one frame upstream: the value handed to that column
+//   is not the AL-declared subtype. NCLMetaCodeunit.Subtype returns `options?.Subtype` off the
+//   codeunit's NavCodeunitOptionsAttribute — what the AL COMPILER wrote — through
+//   GetValueOrDefault(). And the compiler does not write Install.
+//
+//   Measured over Base Application 28.1.49838.53910's own assemblies, decoding every
+//   NavCodeunitOptionsAttribute (1,690 of them) and joining it to the same package's
+//   SymbolReference.json and AL sources, which record the DECLARED property:
+//
+//     declared Subtype = Upgrade      28 codeunits  ->  attribute value 3   (28 of 28)
+//     declared Subtype = TestRunner    2 codeunits  ->  attribute value 2   ( 2 of 2)
+//     declared SubType = Install       3 codeunits  ->  attribute value 0   (3999, 5000, 7582)
+//
+//   Across all 1,690 the only values that occur are 0, 1660x / 2, 2x / 3, 28x. Not one
+//   codeunit anywhere carries 4. So Install never reaches the column, CreateNavOption's
+//   out-of-range branch is never taken for it, and that column's four members are complete
+//   with respect to what can actually appear there. Nothing defaults and nothing clamps —
+//   `Normal` is what legitimately arrives.
+//
+//   That collapse is modelled where it happens rather than here: ResolveCodeunitSubtypeOrdinal
+//   in RecordPatches.CodeunitMetadataVirtualTable.cs translates a declared `Install` to
+//   `Normal` in front of an option-string-only lookup. It needs to, because BOTH of the
+//   runner's row sources carry the declared name: the AL parser reads `Subtype = Install;`
+//   out of source, and BcAppSymbolCache reads `"Subtype": "Install"` out of
+//   SymbolReference.json (verified present for all three Base Application codeunits above).
+//
+// ── WHAT THIS FILE DOES ──────────────────────────────────────────────────────────────────
+//   Builds the (member name -> ordinal) map the Page Metadata populator resolves against from
+//   BOTH sources, with BC's own runtime PageType enum winning any name they share, because
+//   that enum is what PageDataProvider actually casts. The option string is still read, for
+//   two reasons: it is always present, so it keeps working on a BC build where the enum type
+//   has moved or been renamed; and a column that lists a member the enum does not is still
+//   answerable.
+//
+//   A name in NEITHER is refused by the caller rather than defaulted — and refusing is only
+//   safe BECAUSE of the enum overlay. Refusing on the option string alone, which is what the
+//   Table Metadata sibling does for its own columns, would have thrown on any run that loads
+//   the Base Application, taking Page Metadata out entirely. That is the asymmetry #3080 asked
+//   about, and the reason the columns end up with the same INVARIANT — "answer the ordinal BC
+//   answers, refuse a member no source knows" — but not the same lookup. Table Metadata's
+//   TableType/DataClassification option strings do cover their enums; CodeUnit Metadata's
+//   SubType covers everything the compiler emits.
+//
+//   The helpers here stay general (they take the enum as a parameter, and accept null) so the
+//   CodeUnit Metadata populator can use the same option-string parsing without the overlay,
+//   and so a test can hand them an option string and an enum that disagree.
+//
+// PRECOMPILED-DLL RESPECT
+//   Reads a public enum's names and values by reflection. Nothing is rewritten, nothing is
+//   constructed, no AL business-logic body is touched.
+
+using System.Collections.Concurrent;
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    /// <summary>BC's runtime enum behind Page Metadata's <c>PageType</c> column — the type
+    /// <c>PageDataProvider</c> casts to int. Lives in Microsoft.Dynamics.Nav.Types.dll, not
+    /// in Ncl, so it is resolved across the whole load context rather than off a metatable's
+    /// own assembly.</summary>
+    internal const string BcPageTypeEnumName = "Microsoft.Dynamics.Nav.Types.Metadata.PageType";
+
+    private static readonly ConcurrentDictionary<string, Type?> _optionEnumTypes = new();
+    private static readonly ConcurrentDictionary<string, byte> _optionEnumMisses = new();
+
+    /// <summary>
+    /// The runtime enum a metadata option column is filled from, or null when this BC build
+    /// does not carry it under that name. Cached either way — a miss is reported once and then
+    /// costs nothing, since it degrades to the option-string-only map rather than failing.
+    /// </summary>
+    internal static Type? ResolveBcOptionEnum(string fullName)
+    {
+        if (_optionEnumTypes.TryGetValue(fullName, out var cached) && cached != null) return cached;
+
+        // Assembly-qualified first, so the type resolves even if Microsoft.Dynamics.Nav.Types
+        // has not been touched yet in this process; the scan is the fallback for a BC build
+        // that ships it under a different assembly name. A MISS is deliberately not cached:
+        // the alternative is a lookup that ran a moment too early and stays wrong for the rest
+        // of the process, and the map this feeds is itself cached per column, so the scan runs
+        // about twice per run in the worst case.
+        var t = Type.GetType(fullName + ", Microsoft.Dynamics.Nav.Types", throwOnError: false);
+        if (t is not { IsEnum: true })
+        {
+            t = null;
+            foreach (var a in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                var candidate = a.GetType(fullName, throwOnError: false);
+                if (candidate is { IsEnum: true }) { t = candidate; break; }
+            }
+        }
+
+        if (t != null) _optionEnumTypes[fullName] = t;
+        return t;
+    }
+
+    /// <summary>
+    /// The (normalized member name -> ordinal) map an option column resolves against: the
+    /// column's own <c>OptionString</c> by position, optionally overlaid with a BC runtime
+    /// enum by value.
+    /// <para>Where an overlay is supplied it wins every name the two share, because the
+    /// provider filling that column casts the enum and never consults the option string. On
+    /// every artifact measured the two agree on the names they share and the enum simply
+    /// reaches further, so the overlay changes no answer that was already right; what it adds
+    /// is the answers that were previously wrong.</para>
+    /// <para>Whether a column SHOULD be overlaid is the caller's call, not this method's, and
+    /// the two callers answer it differently on purpose: Page Metadata's <c>PageType</c> passes
+    /// its enum, CodeUnit Metadata's <c>SubType</c> passes null. The enum reaching past the
+    /// column is a necessary condition for an overlay, not a sufficient one — what settles it
+    /// is whether the AL compiler ever writes a value out there. See this file's header; a
+    /// service tier decided both.</para>
+    /// </summary>
+    /// <param name="optionString">The column's own <c>NCLOptionMetadata.OptionString</c>.</param>
+    /// <param name="bcRuntimeEnum">BC's enum for that column, or null either because the caller
+    /// wants the option string alone or because the enum could not be resolved on this build —
+    /// in which case the map is the option string alone, exactly as before #3080.</param>
+    internal static Dictionary<string, int> BuildMetadataOptionOrdinals(string? optionString, Type? bcRuntimeEnum)
+    {
+        var map = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        var parts = (optionString ?? string.Empty).Split(',');
+        for (int i = 0; i < parts.Length; i++)
+        {
+            var key = NormalizeObjectTypeName(parts[i]);
+            if (key.Length == 0) continue;
+            map.TryAdd(key, i);
+        }
+
+        if (bcRuntimeEnum is { IsEnum: true })
+        {
+            var names = Enum.GetNames(bcRuntimeEnum);
+            var values = Enum.GetValues(bcRuntimeEnum);
+            for (int i = 0; i < names.Length; i++)
+            {
+                var key = NormalizeObjectTypeName(names[i]);
+                if (key.Length == 0) continue;
+                // Convert.ToInt32 rather than an unbox: the enum's underlying type is BC's to
+                // choose, and a byte- or short-backed enum would fail a direct (int) unbox.
+                map[key] = Convert.ToInt32(values.GetValue(i));
+            }
+        }
+
+        return map;
+    }
+
+    /// <summary>
+    /// <see cref="BuildMetadataOptionOrdinals"/> with the enum resolved by name, reporting a
+    /// miss ONCE per column so a BC build that renamed the type is visible in the log rather
+    /// than only in a wrong answer months later. A miss is not fatal: the option-string map
+    /// still answers every member the column lists, which is every member the corpus and the
+    /// overwhelming majority of AL declares.
+    /// </summary>
+    internal static Dictionary<string, int> BuildMetadataOptionOrdinals(
+        string? optionString, string bcRuntimeEnumName, string columnLabel)
+    {
+        var enumType = ResolveBcOptionEnum(bcRuntimeEnumName);
+        if (enumType == null && _optionEnumMisses.TryAdd(bcRuntimeEnumName, 0))
+            Console.Error.WriteLine(
+                $"[RecordPatches] {columnLabel}: BC's own \"{bcRuntimeEnumName}\" enum is not loaded, so the "
+                + "column's ordinals come from its OptionString alone. A member the option string does not "
+                + "list will be refused rather than answered.");
+        return BuildMetadataOptionOrdinals(optionString, enumType);
+    }
+}

--- a/AlRunner/Patches/RecordPatches.PageMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.PageMetadataVirtualTable.cs
@@ -155,12 +155,12 @@ public static partial class RecordPatches
             case "editable":
                 return NavBoolean(row.Editable);
             case "pagetype":
-                if (pageTypeOrdinals.TryGetValue(NormalizeObjectTypeName(row.PageType), out var ordinal))
-                    return _aovNavOptionCreate!.Invoke(null, new object?[] { field.FieldOptionMetadata, ordinal });
-                // A PageType this BC artifact's option set does not list (should not happen —
-                // the compiler validated it against the same enum) — BC's own default rather
-                // than a guessed ordinal.
-                return _aovGetDefaultNavValue!.Invoke(null, new object?[] { field, false });
+                return _aovNavOptionCreate!.Invoke(null, new object?[]
+                {
+                    field.FieldOptionMetadata,
+                    ResolvePageTypeOrdinal(
+                        pageTypeOrdinals, field.FieldOptionMetadata?.OptionString, row.PageType, row.Id)
+                });
             case "sourcetable":
                 return _aovNavIntegerCreate!.Invoke(null, new object?[] { row.SourceTableId });
             case "cardpageid":
@@ -176,6 +176,57 @@ public static partial class RecordPatches
             default:
                 return _aovGetDefaultNavValue!.Invoke(null, new object?[] { field, false });
         }
+    }
+
+    /// <summary>
+    /// AL's default <c>PageType</c> for a page that declares none. Both row sources already
+    /// substitute it before a row is built — <c>ParsePages</c> and
+    /// <c>BcAppSymbolCache.TryParsePageSymbol</c> each write "Card" for an absent property —
+    /// so this is the backstop for a null that slips past them (a symbol payload cached by an
+    /// older schema version, say), and the one place the substitution is stated as a MEMBER
+    /// NAME resolved against the live column rather than as a position.
+    /// </summary>
+    private const string AlDefaultPageType = "Card";
+
+    /// <summary>
+    /// The ordinal Page Metadata's <c>PageType</c> column carries for one page: the declared
+    /// member when the page states the property, <see cref="AlDefaultPageType"/> when it does
+    /// not, and a refusal when neither the column's option string nor BC's own
+    /// <c>PageType</c> enum knows the name.
+    /// <para>Both misses are refused rather than defaulted (#3080). Before this, a name in
+    /// neither fell through to <c>NavValue.GetDefaultNavValue</c> — ordinal 0 — under a comment
+    /// claiming the case could not arise because "the compiler validated it against the same
+    /// enum". The compiler does; the COLUMN does not list everything the compiler accepts. See
+    /// RecordPatches.MetadataOptionEnumOrdinals.cs: BC 28.1's option string stops at
+    /// HeadlinePart, while the enum runs on to PromptDialog (20) and UserControlHost (22), and
+    /// Base Application 28.1 ships a page of each. Both were answered "Card".</para>
+    /// <para>Split out of <c>BuildPageMetadataValue</c> so the resolution can be driven with an
+    /// option string and an enum the caller chooses; the row-build path holds live BC metatable
+    /// objects a unit test cannot construct, and the case that matters is precisely the one
+    /// where the two sources DISAGREE, which no single artifact can present.</para>
+    /// </summary>
+    /// <param name="ordinals">Member name (normalized) to ordinal, from
+    /// <see cref="EnsurePageTypeOrdinals"/> or <see cref="BuildMetadataOptionOrdinals(string?, Type?)"/>.</param>
+    /// <param name="optionString">The column's own option string, for the refusal message.</param>
+    /// <param name="declaredPageType">What the page declares, or null/blank when it declares nothing.</param>
+    /// <param name="pageId">The page, for the refusal message.</param>
+    internal static int ResolvePageTypeOrdinal(
+        IReadOnlyDictionary<string, int> ordinals, string? optionString, string? declaredPageType, int pageId)
+    {
+        if (string.IsNullOrWhiteSpace(declaredPageType))
+        {
+            if (ordinals.TryGetValue(NormalizeObjectTypeName(AlDefaultPageType), out var defaultOrdinal))
+                return defaultOrdinal;
+            throw PageMetadataShapeGap(
+                $"page {pageId} declares no PageType, and the default for it ('{AlDefaultPageType}') is "
+                + $"neither a member of that column's own option set ('{optionString}') nor of BC's own "
+                + $"{BcPageTypeEnumName}");
+        }
+        if (ordinals.TryGetValue(NormalizeObjectTypeName(declaredPageType), out var ordinal))
+            return ordinal;
+        throw PageMetadataShapeGap(
+            $"page {pageId} declares PageType = '{declaredPageType}', which is neither a member of that "
+            + $"column's own option set ('{optionString}') nor of BC's own {BcPageTypeEnumName}");
     }
 
     /// <summary>
@@ -269,6 +320,11 @@ public static partial class RecordPatches
     /// metatable's own NCLOptionMetadata.OptionString, matched by name — never a hardcoded
     /// table, so the mapping tracks whatever the System package in the resolved artifact
     /// declares. Mirrors AllObj's EnsureAllObjObjectTypeOrdinals for its "Object Type" column.
+    /// <para>The option string is not the only source, and it is not the authoritative one:
+    /// BC's PageDataProvider writes GetOptionValue(5, (int)properties.PageType), the ordinal of
+    /// its OWN PageType enum, which reaches past the last member this column names. See
+    /// RecordPatches.MetadataOptionEnumOrdinals.cs for the measurement and for why the enum
+    /// wins any name the two share (#3080).</para>
     /// </summary>
     private static Dictionary<string, int> EnsurePageTypeOrdinals(NCLMetaTable metaTable)
     {
@@ -281,14 +337,8 @@ public static partial class RecordPatches
         var optionMetadata = field.FieldOptionMetadata
             ?? throw PageMetadataShapeGap("\"PageType\" carries no option metadata");
 
-        var map = new Dictionary<string, int>(StringComparer.Ordinal);
-        var parts = (optionMetadata.OptionString ?? string.Empty).Split(',');
-        for (int i = 0; i < parts.Length; i++)
-        {
-            var key = NormalizeObjectTypeName(parts[i]);
-            if (key.Length == 0) continue;
-            map.TryAdd(key, i);
-        }
+        var map = BuildMetadataOptionOrdinals(
+            optionMetadata.OptionString, BcPageTypeEnumName, "Page Metadata \"PageType\"");
         if (map.Count == 0)
             throw PageMetadataShapeGap("\"PageType\" option string is empty");
 


### PR DESCRIPTION
Closes #3080

## What the issue asked

#3080 asked which of two behaviours is right when a metadata virtual table's option column is
handed a member name it does not list: Page Metadata (`PageType`) and CodeUnit Metadata
(`Subtype`) fell through to BC's own default — ordinal 0 — while the Table Metadata sibling
refuses. The issue said no measurement existed and that the corpus could not express the
input, because "the compiler will not let an unrecognised member through".

Both halves of that were wrong, and finding out changed the fix twice.

**The columns do not list everything the compiler accepts.** Read out of BC
28.1.49838.53910's own `System.app`:

| table | column | `OptionMembers` | members |
|---|---|---|---|
| Page Metadata | `PageType` | `Card,List,RoleCenter,CardPart,ListPart,Document,Worksheet,ListPlus,ConfirmationDialog,NavigatePage,StandardDialog,API,HeadlinePart` | 13 |
| CodeUnit Metadata | `SubType` | `Normal,Test,TestRunner,Upgrade` | 4 |

while the runtime enums those columns are filled from carry more —
`Microsoft.Dynamics.Nav.Types.Metadata.PageType` runs on through `PromptDialog` (20),
`ConfigurationDialog` (21) and `UserControlHost` (22), and
`Microsoft.Dynamics.Nav.Types.CodeunitSubType` adds `Install` (4). Each option string is a
strict **prefix** of its enum.

**And the corpus can express it.** The issue's "the corpus cannot express this" was checked,
not assumed, and it is false — the fixtures compile and run, and a real service tier answered.

## The two columns look identical and answer differently

Both are filled the same way in `Ncl.dll` 28.1 — cast a runtime enum, hand over the raw
ordinal, no clamp and no default:

```
PageDataProvider      buffer[4] = GetOptionValue(5, (int)properties.PageType);
CodeUnitDataProvider  buffer[4] = GetOptionValue(5, (int)metaCodeunit.Subtype);
MetadataDataProvider  GetOptionValue(no, v) => MetaTable.GetFieldByNo(no)
                                                  .FieldOptionMetadata.CreateNavOption(v);
NCLOptionMetadata     CreateNavOption(int value)  // value >= Count takes an explicit branch
                         => NavOption.CreateBypassCache(this, value);
```

From that reading alone, both columns should report an ordinal past their last member. **One
does and one does not**, and a service tier decided each — eight Cloud legs, 27.0 through 28.4:

| corpus test | verdict |
|---|---|
| [#196](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/196) `Record_PageMetadata_Get_PromptDialogPage_ReportsAnOrdinalTheColumnDoesNotName` | **PASS 8/8** — a `PromptDialog` page reports **20** |
| [#201](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/201) `Record_CodeunitMetadata_Get_InstallCodeunit_ReportsSubtypeNormal` | **PASS 8/8** — an `Install` codeunit reports **0**, `Normal` |

The first revision of this PR asserted 4 for the Install codeunit. It was wrong, and it took
the tier to say so: the original corpus test asserting 4 failed 8/8 with
`Expected:<4>. Actual:<0>`.

### Why the SubType column stops short

One frame upstream of the provider. `NCLMetaCodeunit.Subtype` returns `options?.Subtype` off
the codeunit's `NavCodeunitOptionsAttribute` — **what the AL compiler wrote**, not what the AL
author declared — through `GetValueOrDefault()`. And the compiler does not write `Install`.

Measured on Base Application 28.1.49838.53910 by decoding all 1,690 `NavCodeunitOptionsAttribute`
blobs in the package's own assemblies (`System.Reflection.Metadata`) and joining that to the
same package's `SymbolReference.json` and its AL sources, which record the **declared**
property:

| declared | codeunits | attribute value | match |
|---|---|---|---|
| `Subtype = Upgrade` | 28 | **3** | 28 of 28 |
| `Subtype = TestRunner` | 2 (130400, 130402) | **2** | 2 of 2 |
| `SubType = Install` | 3 (3999, 5000, 7582) | **0** | all three |

Across all 1,690 the only values that occur are 0, 2 and 3. **Not one codeunit anywhere
carries 4.** So `Install` never reaches the column, `CreateNavOption`'s out-of-range branch is
never taken for it, and that column's four members are complete with respect to what can
actually appear there. Nothing defaults and nothing clamps — `Normal` is what legitimately
arrives.

**A correction to this PR's earlier body and commit message.** They said every run loading the
Base Application answered `SubType::Normal` about three codeunits that declared something else,
and counted that as a silent wrong answer. That was backwards: **`Normal` was the correct
answer** for those three, and a service tier says so. The `PageType::Card` half of that
sentence stands — two Base App pages really were answered wrongly.

## The fix

**`Page Metadata.PageType`** — `AlRunner/Patches/RecordPatches.MetadataOptionEnumOrdinals.cs`
(new) builds the column's `(member name -> ordinal)` map from **both** sources: the column's own
`OptionString` by position, overlaid with BC's runtime enum by value, the enum winning any name
they share, because that enum is what `PageDataProvider` casts. The option string is still read,
so the runner degrades to today's behaviour on a build where the enum type has moved, and so a
column listing a member the enum does not is still answerable.

**`CodeUnit Metadata.SubType`** — resolved from the column's own `OptionString` and nothing
else, with one translation in front of the lookup modelling the compiler: a declared `Install`
resolves as `Normal`. The translation is unconditional and sits ahead of the map, so a map that
*does* offer `install -> 4` — an overlaid enum, or a future artifact whose column names a fifth
member — still cannot produce 4.

It has to live in the resolver rather than in either row source, because **both** sources carry
the declared name: the AL parser reads `Subtype = Install;` out of source, and `BcAppSymbolCache`
reads `"Subtype": "Install"` out of `SymbolReference.json` — verified present there for all
three Base Application Install codeunits. One translation in front of one lookup keeps the two
paths answering the same thing.

**Both columns** now refuse a name no source knows, instead of defaulting it, in both directions
(declared miss, and default-member miss) — the invariant #2938 and #3019 settled for Table
Metadata. The refusal is only correct because of what precedes it in each case: on `PageType`
the enum overlay, on `SubType` the `Install` translation. Refusing on the raw option string
alone would have thrown on every Base Application run.

The asymmetry #3080 noticed is real but it is a property of the columns, not a disagreement
about the rule: measured on 28.1, Table Metadata's `TableType` option string
(`Normal,CRM,ExternalSQL,Exchange,MicrosoftGraph,Query,Temporary`) and `DataClassification`
option string match `Microsoft.Dynamics.Nav.Types.Metadata.TableType` and
`Microsoft.Dynamics.Nav.Types.DataClassification` member for member, so nothing valid can land
outside them and its refusal cannot fire on real AL. Left alone deliberately.

## RED to GREEN

**Unit level** (`AlRunner.Tests/MetadataOptionColumnOrdinalTests.cs`, 13 tests). Run against the
**previous revision of this PR's own production code**, restored into the tree with
`git checkout <old> -- <two files>` — 5 failed, 8 passed. The sharp one:

```
Failed DeclaredInstallSubtype_StaysNormal_EvenWhenAnInstallOrdinalIsOnOffer
  Assert.Equal() Failure: Values differ
  Expected: 0
  Actual:   4
```

which is the exact inverse of what the tier reported for the withdrawn corpus assertion. The 8
that passed are the `PageType`-side cases — the half the tier confirmed, unchanged by this
rework. After the fix: **13 passed**.

**AL level**, through the whole runner, on this branch's Release build, against each corpus
branch:

```
PASS Codeunit60962.Record_CodeunitMetadata_Get_InstallCodeunit_ReportsSubtypeNormal   (corpus 40d7e60, #201)
PASS Codeunit60920.Record_PageMetadata_Get_PromptDialogPage_ReportsAnOrdinalTheColumnDoesNotName (corpus 67e53ac, #196)
```

The unit tests are written so a single-artifact assertion could not replace them: the cases that
matter hand the resolver an option string and an enum that **disagree**, and hand the SubType
resolver a map that offers `Install` at 4 — neither of which any artifact can present.
`BcEnumsStillReachBeyondTheOptionString_OnTheArtifactUnderTest` binds to the real
`Microsoft.Dynamics.Nav.Types` of whatever version the leg built with — 27.0 through 28.4 —
asserts `PromptDialog` / `UserControlHost` / `Install` are members and that `Install` is still
past the end of its column, then asserts the runner's `PageType` answer **equals** the enum's own
value and its `SubType` answer **does not**.

## The refusal count

`AllFortyEightRefusalsStillExist` moves **71 -> 75**. Both numbers were read, not computed: 71
from `git show origin/main:AlRunner.Tests/VirtualTableRefusalClaimTests.cs` after #3133 merged,
and 75 out of this test's own failure message on this tree —

```
Failed AlRunner.Tests.VirtualTableRefusalClaimTests.AllFortyEightRefusalsStillExist_...
  Expected: 71
  Actual:   75
```

The `(?<!Bc)` lookbehind in that test's regex is untouched.

## Local verification

Run in this exact state, on this tree, after rebasing onto `main` at `243816de` and a full
Release rebuild:

- `dotnet test AlRunner.Tests --filter "...MetadataOptionColumnOrdinalTests|...VirtualTableRefusalClaimTests|...TableMetadataOptionDefaultOrdinalTests|...CodeunitMetadata|...PageMetadata|...AllObj"` — **145 passed, 3 skipped, 0 failed**.
- Full corpus at the current pin, matching CI's invocation — **2665/2665 pass**, 0 fail, 0 error.
- `tests/runner-extras` — **306/306 pass**.

The corpus run matters more than usual here: the populators build a row for every page and
codeunit in the inventory, so a Base Application run drives both resolvers over the real
`PromptDialog`, `UserControlHost` and `Install` objects rather than only over fixtures.

## Merge bar and the pin

- Corpus [#201](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/201)
  (SubType) has **merged**.
- Corpus [#196](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/196)
  (PageType, retitled to the PageType half only after the split) is **still open**.

**No pin bump in this PR yet.** Bumping now would pull in #201 but not #196, so it would prove
only half of the change and would need doing twice — including two `test-count-baseline.json`
updates. The bump folds in once #196 merges, in this PR, per `al-language-submodule.md`. Until
then the two AL-level results above come from running this build against each corpus branch
directly.

## Fixing the shape, not just the reported line

1. **The same wrong pattern at another call site** — none found. Every other option-ordinal site
   was read: `AllObj` and `AllObjWithCaption` skip the row when a kind has no ordinal (a
   primary-key column, so no wrong value is written); `Object Metadata` and `Report Layout List`
   already refuse; the `Date` populator already pairs each option ordinal with BC's own
   `DatePeriodType` **by name**. Only these two defaulted.
2. **A sibling function making the same assumption** — `EnsureOptionOrdinals` in the Table
   Metadata populator makes it, and it was checked rather than assumed: its two option strings
   match its two enums member for member on 28.1 (above), so it is sound today. Left unchanged,
   reasoning recorded in the new file's header.
3. **Two paths writing the same state** — the AL parser and `BcAppSymbolCache` both write
   `row.Subtype`, and this is where the rework's real risk lived. Both were checked, not assumed:
   the AL parser reads the declared name from source, and `SymbolReference.json` records
   `Subtype = Install` for all three Base App Install codeunits (confirmed by parsing it). So
   both paths hand the resolver `"Install"`, and both need the translation — which is why it
   sits in the single function they share rather than in either source.

**A fourth question this rework raises**, worth stating because it is the one that bit: an enum
reaching past its column is a **necessary** condition for an overlay, not a sufficient one. What
settles it is whether the AL compiler ever writes a value out there. `BcEnumsStill...` asserts the
necessary half for both columns; only `PageType` gets the overlay.

## Deliberately left out

- **No change to Table Metadata**, for the reason in section 2 above.
- **No `docs/limitations.md` change.** The refusals point at the existing
  `#virtual-table-shape-gaps` anchor, and nothing in the docs stated the old behaviour.
- **`UserControlHost` gets no corpus fixture.** Such a page needs a control add-in the corpus
  does not have. It is asserted runner-side against the live enum instead, and `PromptDialog`
  carries the upstream claim for that column.
- **No forward-compatibility hedge on the `Install` translation.** If a future AL compiler starts
  emitting `Install`, corpus #201 goes red on that version and this translation is what changes.
  That alarm is the intended design, and it is written into the test that pins it.

---

Written by an automated agent (`stma-auto-1`, cycle 141) acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
