### PR TITLE
fix(tests): make a bc-engine-serial skip say which collection, why, and what would fix it

### DIFF
--- a/.claude/skills/al-runner-tests/SKILL.md
+++ b/.claude/skills/al-runner-tests/SKILL.md
@@ -129,6 +129,37 @@ an exit code.
 
 Read one with `dotnet-dump analyze <file>` (`clrstack`, `clrmodules`, `eeversion`).
 
+## `dotnet test` skips the BC-engine tests locally unless you bootstrap first
+
+The ~28 rows in AlRunner.Tests' **`bc-engine-serial`** collection load the BC engine
+in-process. On a local box they **skip** unless two things are set up, and at `dotnet test`'s
+default verbosity a skip prints no reason at all — measured 2026-09-06: five of five rows
+`[SKIP]`, no reason shown, `Skipped! - Failed: 0, Passed: 0, Skipped: 5`, **exit code 0**. A
+RED baseline taken in that state is worthless: revert the fix, see "passed", and you have
+concluded the opposite of the truth.
+
+```bash
+dotnet build AlRunner.Tests/AlRunner.Tests.csproj -c Release
+tools/engine-test-bootstrap.sh                       # idempotent; converges in 2 passes
+dotnet test AlRunner.Tests/AlRunner.Tests.csproj -c Release --no-build \
+    --settings engine.runsettings --filter FullyQualifiedName~YourTestClass
+```
+
+**Re-run `tools/engine-test-bootstrap.sh` after EVERY build.** A build restores a pristine
+`bin/Microsoft.Dynamics.Nav.Ncl.dll`, and rows that had been running go back to skipping.
+`tools/engine-test-bootstrap.sh --verify` answers "would they run right now?" — exit 0 yes,
+exit 1 no with the reason printed.
+
+Since #3078 the skip reason itself names the collection, the unwrapped cause and the remedy
+(`AlRunner.Tests/BcEngineSkipReason.cs`), but you only see it at
+`--logger "console;verbosity=normal"` or higher. **`Skipped: N` in a summary is not a pass** —
+if N is non-zero on a suite you are using as a baseline, find out which rows and why before
+believing the run.
+
+CI does this bootstrap itself (`.github/workflows/bc-tests.yml`, the "Warm the Ncl Cecil
+rewrite cache" and "Generate .runsettings" steps), so the rows execute there. The gap is
+purely local, which is exactly why nothing catches it for you.
+
 ## Proving-test rules
 
 A skeptic must be able to read any test and say: "yes, if this passes, feature X works correctly." Every test satisfies all four:

--- a/AlRunner.Tests/BcEngineCollection.cs
+++ b/AlRunner.Tests/BcEngineCollection.cs
@@ -68,7 +68,18 @@ internal static class BcEngineBootstrap
     [ModuleInitializer]
     internal static void Initialize()
     {
-        Probe($"init: nclLoaded={AppDomain.CurrentDomain.GetAssemblies().Any(a => a.GetName().Name == "Microsoft.Dynamics.Nav.Ncl")}");
+        // #3078: captured up front rather than only probed. When Ncl is already loaded by
+        // the time this initializer runs, NclCecilRewrite.RewriteInPlace early-returns
+        // without effect and the failure surfaces far downstream — as a
+        // TargetInvocationException out of BcRuntime.EnsureApplied() whose message names
+        // nothing. Knowing this flag here is what lets the skip reason say
+        // "DOTNET_STARTUP_HOOKS is not wired" instead. It deliberately does NOT change
+        // which runs end up Ready: an already-loaded Ncl that is already REWRITTEN (CI
+        // pre-copies one into the test bin dir) still bootstraps fine and never reaches a
+        // skip reason at all.
+        var nclAlreadyLoaded = AppDomain.CurrentDomain.GetAssemblies()
+            .Any(a => a.GetName().Name == "Microsoft.Dynamics.Nav.Ncl");
+        Probe($"init: nclLoaded={nclAlreadyLoaded}");
 
         string serviceTierDir;
         try
@@ -92,14 +103,19 @@ internal static class BcEngineBootstrap
         }
         catch (Exception ex)
         {
-            SkipReason = $"BC artifacts not provisioned: {ex.Message}";
+            SkipReason = BcEngineSkipReason.Format(
+                BcEngineSkipCause.ArtifactsMissing,
+                $"BC artifacts could not be selected: {BcEngineSkipReason.Describe(ex)}.");
             return;
         }
 
         if (!File.Exists(Path.Combine(serviceTierDir, "Microsoft.Dynamics.Nav.CodeAnalysis.dll"))
             || !File.Exists(Path.Combine(serviceTierDir, "Microsoft.Dynamics.Nav.Ncl.dll")))
         {
-            SkipReason = $"BC artifacts incomplete in '{serviceTierDir}'";
+            SkipReason = BcEngineSkipReason.Format(
+                BcEngineSkipCause.ArtifactsIncomplete,
+                $"'{serviceTierDir}' does not hold both Microsoft.Dynamics.Nav.CodeAnalysis.dll "
+                + "and Microsoft.Dynamics.Nav.Ncl.dll.");
             return;
         }
 
@@ -137,10 +153,10 @@ internal static class BcEngineBootstrap
                 // We just replaced the file this process is about to load. Skip rather than
                 // risk a torn image; the NEXT run finds bin already rewritten, the copy is a
                 // no-op, and these tests execute normally.
-                SkipReason =
-                    "bin/Microsoft.Dynamics.Nav.Ncl.dll was rewritten by this process (first run " +
-                    "after a build), so loading it here risks BadImageFormatException 0x80131124. " +
-                    "Re-run the suite — bin is now rewritten and these tests will execute.";
+                SkipReason = BcEngineSkipReason.Format(
+                    BcEngineSkipCause.BinRewrittenThisProcess,
+                    $"'{binNcl}' was rewritten by this process, so loading it here risks "
+                    + "BadImageFormatException 0x80131124.");
                 return;
             }
 
@@ -155,10 +171,10 @@ internal static class BcEngineBootstrap
                 // CI hits this on every fresh runner (cold ~/.cache/al-runner/ncl-cecil).
                 // The workflow warms the cache with a throwaway runner invocation before
                 // `dotnet test` so these tests really execute there instead of skipping.
-                SkipReason =
-                    "Ncl Cecil cache was cold, so the rewrite happened in this process; " +
-                    "loading it here would risk BadImageFormatException 0x80131124. Warm the " +
-                    "cache with one runner invocation before `dotnet test` to run these tests.";
+                SkipReason = BcEngineSkipReason.Format(
+                    BcEngineSkipCause.CecilCacheCold,
+                    "the Ncl Cecil cache missed, so the rewrite happened in this process; loading "
+                    + "it here would risk BadImageFormatException 0x80131124.");
                 return;
             }
 
@@ -170,7 +186,18 @@ internal static class BcEngineBootstrap
         {
             // Report rather than take the whole assembly down: without artifacts-backed
             // engine state only the two engine tests are affected, and they no-op below.
-            SkipReason = $"BC engine bootstrap failed: {ex.GetType().Name}: {ex.Message}";
+            // #3078: attribute the failure rather than reporting the reflection wrapper.
+            // `nclAlreadyLoaded` is the discriminator: with Ncl already loaded un-rewritten,
+            // BcRuntime.EnsureApplied() is being applied to an image the Cecil rewrite never
+            // touched, and THAT is the diagnosis — not whatever exception it happened to
+            // raise while running against it.
+            var (cause, detail) = nclAlreadyLoaded
+                ? (BcEngineSkipCause.NclPreloaded,
+                   "Microsoft.Dynamics.Nav.Ncl was already loaded before this bootstrap ran, so the "
+                   + "Cecil rewrite had no effect and applying the runtime patches failed with "
+                   + $"{BcEngineSkipReason.Describe(ex)}.")
+                : (BcEngineSkipCause.BootstrapThrew, $"{BcEngineSkipReason.Describe(ex)}.");
+            SkipReason = BcEngineSkipReason.Format(cause, detail);
         }
     }
 }

--- a/AlRunner.Tests/BcEngineCollection.cs
+++ b/AlRunner.Tests/BcEngineCollection.cs
@@ -216,8 +216,17 @@ public sealed class BcEngineFixture
     /// </summary>
     public bool Ready => BcEngineBootstrap.Ready;
 
-    /// <summary>Why <see cref="Ready"/> is false, for a test that wants to report it.</summary>
-    public string? SkipReason => BcEngineBootstrap.SkipReason;
+    /// <summary>
+    /// Why <see cref="Ready"/> is false, for a test that wants to report it.
+    ///
+    /// #3078: routed through <see cref="BcEngineSkipReason.OrDefault"/> so it is never null
+    /// while the engine is unready. The 132 call sites in this collection all spell
+    /// <c>_engine.SkipReason ?? "the in-process BC engine is not ready (see
+    /// BcEngineCollection)."</c> — a fallback that is accurate and carries neither a cause
+    /// nor a remedy, i.e. the same defect this issue is about, at 132 places. Making the
+    /// property total fixes them all without touching one of them.
+    /// </summary>
+    public string SkipReason => BcEngineSkipReason.OrDefault(BcEngineBootstrap.SkipReason);
 }
 
 [CollectionDefinition(Name, DisableParallelization = true)]

--- a/AlRunner.Tests/BcEngineSkipAttributionTests.cs
+++ b/AlRunner.Tests/BcEngineSkipAttributionTests.cs
@@ -1,0 +1,275 @@
+// BcEngineSkipAttributionTests — issue #3078.
+//
+// The claim under test is NOT "BC does X". Nothing here asserts anything about Business
+// Central: BcEngineSkipReason is test-harness plumbing that decides what a skipped row in
+// the bc-engine-serial collection tells the developer reading it. There is no service
+// tier that could adjudicate the wording of an xUnit skip message, so this test belongs
+// here and not in the upstream AL-language corpus
+// (.claude/rules/bc-behavior-tests-go-upstream.md).
+//
+// Every condition below is CONSTRUCTED on purpose. None of it reads whatever this
+// particular box happens to have provisioned — a test that asserted over the ambient
+// engine state would pass on a machine where the engine is ready and prove nothing about
+// the message a machine where it is NOT ready would print. The two source-scanning guards
+// at the bottom carry their own fixture guards (assert the file was found and is
+// substantial) so they cannot rot into vacuously passing scans, which is the exact defect
+// #3017 records and the reason #3078 was filed.
+
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class BcEngineSkipAttributionTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    // ---- Describe: the real exception must survive, not the wrapper's fixed string ----
+
+    /// <summary>
+    /// The measured RED. A [ModuleInitializer] that calls BcRuntime.EnsureApplied() through
+    /// reflection surfaces every failure as TargetInvocationException, whose Message is the
+    /// constant "Exception has been thrown by the target of an invocation." — carrying no
+    /// type, no message, no diagnosis. That is verbatim what a local run printed at
+    /// `--logger "console;verbosity=normal"` before this fix.
+    /// </summary>
+    [Fact]
+    public void Describe_UnwrapsTargetInvocationException_ToTheRealCause()
+    {
+        var inner = new PlatformNotSupportedException("Windows Principal functionality is not supported on this platform.");
+        var wrapped = new TargetInvocationException(inner);
+
+        var described = BcEngineSkipReason.Describe(wrapped);
+
+        Assert.Contains("PlatformNotSupportedException", described, StringComparison.Ordinal);
+        Assert.Contains("Windows Principal functionality is not supported on this platform.", described, StringComparison.Ordinal);
+        // The wrapper's own placeholder message must NOT be what the developer is shown.
+        Assert.DoesNotContain("Exception has been thrown by the target of an invocation", described, StringComparison.Ordinal);
+        // The wrapper is still named, so the reflection boundary is not hidden either.
+        Assert.Contains("TargetInvocationException", described, StringComparison.Ordinal);
+    }
+
+    /// <summary>Nested wrappers: reflection over an async/aggregating path stacks two of them.</summary>
+    [Fact]
+    public void Describe_UnwrapsNestedWrappers_ToTheInnermostCause()
+    {
+        var innermost = new BadImageFormatException("Index not found. (0x80131124)");
+        var wrapped = new TargetInvocationException(new AggregateException("one or more errors", innermost));
+
+        var described = BcEngineSkipReason.Describe(wrapped);
+
+        Assert.Contains("BadImageFormatException", described, StringComparison.Ordinal);
+        Assert.Contains("Index not found. (0x80131124)", described, StringComparison.Ordinal);
+        Assert.DoesNotContain("one or more errors", described, StringComparison.Ordinal);
+    }
+
+    /// <summary>Negative direction: an exception that is NOT a wrapper is reported as itself.</summary>
+    [Fact]
+    public void Describe_LeavesAnUnwrappedExceptionAlone()
+    {
+        var described = BcEngineSkipReason.Describe(new InvalidOperationException("artifacts root is empty"));
+
+        Assert.Equal("InvalidOperationException: artifacts root is empty", described);
+    }
+
+    /// <summary>
+    /// A wrapper with no inner exception must not degrade to the useless placeholder
+    /// message either — it is reported as itself, wrapper name included.
+    /// </summary>
+    [Fact]
+    public void Describe_WrapperWithNoInner_ReportsTheWrapperItself()
+    {
+        var described = BcEngineSkipReason.Describe(new TargetInvocationException("outer detail", null));
+
+        Assert.Contains("TargetInvocationException", described, StringComparison.Ordinal);
+        Assert.Contains("outer detail", described, StringComparison.Ordinal);
+    }
+
+    // ---- Format: every reason names the collection, the cause and the remedy ----
+
+    /// <summary>
+    /// The property that makes a skip attributable, asserted over EVERY declared cause
+    /// rather than the two that happen to fire on the author's box. A cause added later
+    /// with no remedy fails here instead of shipping another silent skip.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(AllCauses))]
+    public void Format_NamesTheCollection_TheDetail_AndAnActionableRemedy(BcEngineSkipCause cause)
+    {
+        const string detail = "SENTINEL-DETAIL-9f3c";
+
+        var reason = BcEngineSkipReason.Format(cause, detail);
+
+        // Which collection stopped running.
+        Assert.Contains(BcEngineCollection.Name, reason, StringComparison.Ordinal);
+        // That it is a skip and therefore asserted nothing — the thing a green summary hides.
+        Assert.Contains("SKIP", reason, StringComparison.OrdinalIgnoreCase);
+        // Why.
+        Assert.Contains(detail, reason, StringComparison.Ordinal);
+        Assert.Contains(cause.ToString(), reason, StringComparison.Ordinal);
+        // What would make it run.
+        Assert.Contains(BcEngineSkipReason.BootstrapTool, reason, StringComparison.Ordinal);
+        Assert.Contains("Remedy", reason, StringComparison.Ordinal);
+    }
+
+    public static TheoryData<BcEngineSkipCause> AllCauses()
+    {
+        var data = new TheoryData<BcEngineSkipCause>();
+        foreach (var cause in Enum.GetValues<BcEngineSkipCause>()) data.Add(cause);
+        return data;
+    }
+
+    /// <summary>
+    /// Fixture guard for the theory above: it is only meaningful while there is more than
+    /// one cause to enumerate. If the enum were ever collapsed to a single value the
+    /// theory would still pass while covering almost nothing.
+    /// </summary>
+    [Fact]
+    public void AllCauses_CoversEveryBranchThatCanLeaveTheEngineUnready()
+    {
+        var causes = Enum.GetValues<BcEngineSkipCause>();
+
+        Assert.True(causes.Length >= 6,
+            $"BcEngineSkipCause declares only {causes.Length} values; the attribution theory needs one per " +
+            "branch in BcEngineBootstrap.Initialize that can leave Ready false.");
+        Assert.Contains(BcEngineSkipCause.NclPreloaded, causes);
+        Assert.Contains(BcEngineSkipCause.CecilCacheCold, causes);
+        Assert.Contains(BcEngineSkipCause.BootstrapThrew, causes);
+    }
+
+    /// <summary>
+    /// Two different causes must not produce the same remedy text, or "attributable" is a
+    /// word rather than a property: a developer whose Cecil cache is cold and one whose
+    /// startup hooks are unwired need different next steps.
+    /// </summary>
+    [Fact]
+    public void Format_GivesNclPreloadedAndCecilCacheCold_DistinctDiagnoses()
+    {
+        var preloaded = BcEngineSkipReason.Format(BcEngineSkipCause.NclPreloaded, "d");
+        var cold = BcEngineSkipReason.Format(BcEngineSkipCause.CecilCacheCold, "d");
+
+        Assert.NotEqual(preloaded, cold);
+        // The startup-hook diagnosis must name the mechanism that is missing.
+        Assert.Contains("DOTNET_STARTUP_HOOKS", preloaded, StringComparison.Ordinal);
+        Assert.DoesNotContain("DOTNET_STARTUP_HOOKS", cold, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// No silent default: an undeclared cause must throw rather than quietly produce a
+    /// reason with no remedy in it (.claude/rules/loud-failures.md).
+    /// </summary>
+    [Fact]
+    public void Format_ThrowsOnAnUndeclaredCause_RatherThanEmittingARemedylessReason()
+    {
+        var ex = Record.Exception(() => BcEngineSkipReason.Format((BcEngineSkipCause)9999, "d"));
+
+        Assert.NotNull(ex);
+        Assert.IsType<ArgumentOutOfRangeException>(ex);
+    }
+
+    // ---- Guards: the remedy must exist, and nothing may bypass the formatter ----
+
+    /// <summary>
+    /// A remedy naming a path that is not in the repository is silence with extra steps.
+    /// Asserts the tool exists, is not a stub, and is executable — the last one because a
+    /// non-executable script fails with "Permission denied", which reads like a broken
+    /// remedy rather than a missing chmod.
+    /// </summary>
+    [Fact]
+    public void TheRemedyNamedByEveryReason_ExistsAndIsExecutable()
+    {
+        var tool = Path.Combine(RepoRoot, BcEngineSkipReason.BootstrapTool.Replace('/', Path.DirectorySeparatorChar));
+
+        Assert.True(File.Exists(tool), $"Every bc-engine-serial skip reason points at '{tool}', which does not exist.");
+        Assert.True(new FileInfo(tool).Length > 500, $"'{tool}' is too small to be performing the engine bootstrap.");
+
+        if (!OperatingSystem.IsWindows())
+        {
+            var mode = File.GetUnixFileMode(tool);
+            Assert.True(mode.HasFlag(UnixFileMode.UserExecute), $"'{tool}' is not executable (mode {mode}).");
+        }
+    }
+
+    /// <summary>
+    /// The drift guard. Every SkipReason assignment in BcEngineCollection.cs must go
+    /// through BcEngineSkipReason.Format, or a future branch reintroduces exactly the bare,
+    /// remedy-less string this issue is about — and every assertion above would still pass
+    /// while the real run went quiet again. Same shape as the artifact-gate drift guard in
+    /// TestArtifactsGateTests.
+    /// </summary>
+    [Fact]
+    public void EverySkipReasonAssignment_GoesThroughTheFormatter()
+    {
+        var source = Path.Combine(RepoRoot, "AlRunner.Tests", "BcEngineCollection.cs");
+
+        // Fixture guard first: a scan of a file that is not there passes vacuously.
+        Assert.True(File.Exists(source), $"'{source}' not found — this guard would otherwise scan nothing and pass.");
+        var text = File.ReadAllText(source);
+        Assert.True(text.Length > 4000, $"'{source}' is only {text.Length} chars; the guard is scanning the wrong file.");
+        Assert.Contains("BcEngineBootstrap", text, StringComparison.Ordinal);
+
+        // `SkipReason =` but not `SkipReason =>` (the fixture's expression-bodied forward)
+        // and not the auto-property declaration (which has no `=` at all).
+        var assignments = Regex.Matches(text, @"SkipReason\s*=(?!=|>)\s*(?<rhs>[^\r\n]*)")
+            .Select(m => m.Groups["rhs"].Value.Trim())
+            .ToList();
+
+        Assert.True(assignments.Count >= 4,
+            $"Found only {assignments.Count} SkipReason assignments in BcEngineCollection.cs; " +
+            "the regex has drifted away from the source and this guard is measuring nothing.");
+
+        var bare = assignments
+            .Where(rhs => !rhs.StartsWith("BcEngineSkipReason.", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.True(bare.Count == 0,
+            "Every bc-engine-serial skip reason must be built by BcEngineSkipReason.Format so it names the " +
+            "collection, the cause and the remedy (issue #3078). These assignments bypass it:\n  " +
+            string.Join("\n  ", bare));
+    }
+
+    /// <summary>
+    /// The bootstrap tool and .github/workflows/bc-tests.yml must agree on the two facts
+    /// that make the engine collection run: the startup-hook chain (al-runner.dll first,
+    /// then AlRunner.Tests.dll — the order matters, see EngineStartupHook.cs) and the
+    /// warm-up bundle. A tool that drifts from what CI does sends a local developer to a
+    /// bootstrap that no longer matches the one measurement that is known to work.
+    /// </summary>
+    [Fact]
+    public void BootstrapTool_AndCiWorkflow_AgreeOnTheStartupHookChain()
+    {
+        var tool = File.ReadAllText(Path.Combine(RepoRoot, "tools", "engine-test-bootstrap.sh"));
+        var workflow = File.ReadAllText(Path.Combine(RepoRoot, ".github", "workflows", "bc-tests.yml"));
+
+        Assert.True(workflow.Length > 10000, "bc-tests.yml is unexpectedly small — this guard is reading the wrong file.");
+
+        foreach (var (text, what) in new[] { (tool, "tools/engine-test-bootstrap.sh"), (workflow, ".github/workflows/bc-tests.yml") })
+        {
+            Assert.True(text.Contains("DOTNET_STARTUP_HOOKS", StringComparison.Ordinal),
+                $"{what} no longer mentions DOTNET_STARTUP_HOOKS.");
+            // Both files also MENTION the variable in prose, so match every occurrence and
+            // keep the ones that actually carry a hook chain (a `.dll` on the same line).
+            var valueLines = Regex.Matches(text, @"<DOTNET_STARTUP_HOOKS>[^\r\n]*")
+                .Select(m => m.Value)
+                .Where(v => v.Contains(".dll", StringComparison.Ordinal))
+                .ToList();
+
+            Assert.True(valueLines.Count > 0,
+                $"{what} has no <DOTNET_STARTUP_HOOKS> element carrying a hook chain — only prose. " +
+                "Either the wiring is gone or this guard is reading the wrong file.");
+
+            foreach (var line in valueLines)
+            {
+                var alRunnerAt = line.IndexOf("al-runner.dll", StringComparison.Ordinal);
+                var testsAt = line.IndexOf("AlRunner.Tests.dll", StringComparison.Ordinal);
+                Assert.True(alRunnerAt >= 0 && testsAt >= 0,
+                    $"{what}'s DOTNET_STARTUP_HOOKS does not name both hook assemblies: '{line}'");
+                Assert.True(alRunnerAt < testsAt,
+                    $"{what} has the startup-hook chain in the wrong order — al-runner.dll must precede " +
+                    $"AlRunner.Tests.dll (see AlRunner/EngineTestBinResolverStartupHook.cs): '{line}'");
+            }
+        }
+    }
+}

--- a/AlRunner.Tests/BcEngineSkipAttributionTests.cs
+++ b/AlRunner.Tests/BcEngineSkipAttributionTests.cs
@@ -131,7 +131,7 @@ public sealed class BcEngineSkipAttributionTests
     {
         var causes = Enum.GetValues<BcEngineSkipCause>();
 
-        Assert.True(causes.Length >= 6,
+        Assert.True(causes.Length >= 7,
             $"BcEngineSkipCause declares only {causes.Length} values; the attribution theory needs one per " +
             "branch in BcEngineBootstrap.Initialize that can leave Ready false.");
         Assert.Contains(BcEngineSkipCause.NclPreloaded, causes);
@@ -167,6 +167,57 @@ public sealed class BcEngineSkipAttributionTests
 
         Assert.NotNull(ex);
         Assert.IsType<ArgumentOutOfRangeException>(ex);
+    }
+
+    // ---- OrDefault: !Ready implies an attributable reason, with no exceptions ----
+
+    /// <summary>
+    /// The sibling instance of the reported defect. 132 call sites across the
+    /// bc-engine-serial collection spell
+    /// <c>_engine.SkipReason ?? "the in-process BC engine is not ready (see
+    /// BcEngineCollection)."</c>. That fallback fires whenever the bootstrap recorded no
+    /// reason — the [ModuleInitializer] never having run, which is the #1813 shape itself —
+    /// and it is accurate, remedy-less and therefore exactly as silent as the message this
+    /// issue is about. BcEngineFixture.SkipReason is total now, so the fallback is
+    /// unreachable; this pins the replacement rather than trusting 132 edits nobody made.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void OrDefault_TurnsAnAbsentReason_IntoAnAttributableOne(string? absent)
+    {
+        var reason = BcEngineSkipReason.OrDefault(absent);
+
+        Assert.Contains(BcEngineCollection.Name, reason, StringComparison.Ordinal);
+        Assert.Contains(nameof(BcEngineSkipCause.BootstrapDidNotRun), reason, StringComparison.Ordinal);
+        Assert.Contains(BcEngineSkipReason.BootstrapTool, reason, StringComparison.Ordinal);
+        Assert.Contains("Remedy", reason, StringComparison.Ordinal);
+    }
+
+    /// <summary>Negative direction: a real reason is passed through untouched.</summary>
+    [Fact]
+    public void OrDefault_LeavesARecordedReasonAlone()
+    {
+        var recorded = BcEngineSkipReason.Format(BcEngineSkipCause.CecilCacheCold, "the cache missed.");
+
+        Assert.Equal(recorded, BcEngineSkipReason.OrDefault(recorded));
+    }
+
+    /// <summary>
+    /// The invariant itself, stated over the type rather than over this box's state:
+    /// BcEngineFixture.SkipReason must be non-nullable, so no caller can reach a null and
+    /// substitute a fallback of its own. Reading the ambient fixture instead would assert
+    /// nothing on a machine where the engine came up.
+    /// </summary>
+    [Fact]
+    public void FixtureSkipReason_IsNotNullable_SoNoCallerCanSubstituteABareFallback()
+    {
+        var property = typeof(BcEngineFixture).GetProperty(nameof(BcEngineFixture.SkipReason));
+        Assert.NotNull(property);
+
+        var nullability = new NullabilityInfoContext().Create(property!);
+        Assert.Equal(NullabilityState.NotNull, nullability.ReadState);
     }
 
     // ---- Guards: the remedy must exist, and nothing may bypass the formatter ----

--- a/AlRunner.Tests/BcEngineSkipReason.cs
+++ b/AlRunner.Tests/BcEngineSkipReason.cs
@@ -1,0 +1,188 @@
+// BcEngineSkipReason — the one place a bc-engine-serial skip reason is built.
+//
+// Why this file exists (issue #3078)
+// ----------------------------------
+// Every test in the bc-engine-serial collection (BcEngineCollection) skips when
+// BcEngineBootstrap could not stand the in-process BC engine up. Skipping is CORRECT —
+// a box without the prerequisites genuinely cannot exercise the engine, and failing
+// there would make the suite unrunnable for a legitimate reason. The defect is that the
+// skip said nothing a developer could act on.
+//
+// Measured on a local box, 2026-09-06, `dotnet test --filter
+// FullyQualifiedName~CodeunitRunWriteTransactionRefusalTests`:
+//
+//   * At the DEFAULT console verbosity (minimal) VSTest prints `[SKIP]` and
+//     `Skipped <name>` and NEVER prints the reason. The run ends
+//     `Skipped! - Failed: 0, Passed: 0, Skipped: 5` with exit code 0.
+//   * `Console.Error` from the [ModuleInitializer] is swallowed too — the existing
+//     `[Cecil] WARNING: Ncl already loaded before in-place rewrite — no effect` line did
+//     not reach the console at minimal verbosity either.
+//   * Raise verbosity to `normal` and the reason finally appears — and says:
+//     `BC engine bootstrap failed: TargetInvocationException: Exception has been thrown
+//     by the target of an invocation.`
+//
+// So the ONE channel that reaches a developer carried a message naming neither the real
+// exception (TargetInvocationException.Message is a fixed string; the inner exception is
+// the diagnosis and it was dropped), nor which collection had stopped running, nor
+// anything to do about it. That is the silent-default shape from
+// .claude/rules/loud-failures.md wearing test clothing: the caller cannot distinguish
+// "ran and passed" from "did not run".
+//
+// The fix is not to stop skipping. It is that a skip must be ATTRIBUTABLE: which
+// collection, why, and what would make it run. Every reason is built here so that
+// property is enforced in one place, and BcEngineSkipAttributionTests fails the build if
+// BcEngineCollection.cs ever assigns a reason that bypasses it.
+
+using System.Reflection;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Why the in-process BC engine bootstrap did not complete. One value per branch that can
+/// leave <see cref="BcEngineBootstrap.Ready"/> false.
+/// </summary>
+public enum BcEngineSkipCause
+{
+    /// <summary>BC service-tier artifacts are not provisioned on this machine at all.</summary>
+    ArtifactsMissing,
+
+    /// <summary>An artifacts directory exists but does not hold the DLLs the engine needs.</summary>
+    ArtifactsIncomplete,
+
+    /// <summary>
+    /// Microsoft.Dynamics.Nav.Ncl was already loaded, un-rewritten, before the bootstrap
+    /// ran — so the Cecil rewrite could not take effect. Issue #1813: VSTest's own
+    /// DiaSession loads Ncl for stack-trace source mapping before any test code runs, and
+    /// DOTNET_STARTUP_HOOKS is what gets in front of it.
+    /// </summary>
+    NclPreloaded,
+
+    /// <summary>
+    /// The bootstrap replaced bin/Microsoft.Dynamics.Nav.Ncl.dll in this process, so
+    /// loading it here risks BadImageFormatException 0x80131124. Self-healing: the next
+    /// run finds bin already rewritten.
+    /// </summary>
+    BinRewrittenThisProcess,
+
+    /// <summary>
+    /// The Ncl Cecil cache missed, so the rewrite ran in this process — same
+    /// BadImageFormatException hazard, which is why Program.cs re-execs and a test host
+    /// (which cannot re-exec) skips instead.
+    /// </summary>
+    CecilCacheCold,
+
+    /// <summary>The bootstrap threw. The detail carries the unwrapped exception.</summary>
+    BootstrapThrew,
+}
+
+internal static class BcEngineSkipReason
+{
+    /// <summary>The collection every one of these reasons is about.</summary>
+    internal const string Collection = BcEngineCollection.Name;
+
+    /// <summary>
+    /// The repo-relative bootstrap tool that makes the engine collection runnable on a
+    /// local box. Named by EVERY reason: a remedy the reader has to go and find is the
+    /// same silence in a longer sentence. BcEngineSkipAttributionTests asserts this file
+    /// actually exists and is executable, because a remedy naming a path that is not there
+    /// is worse than none.
+    /// </summary>
+    internal const string BootstrapTool = "tools/engine-test-bootstrap.sh";
+
+    /// <summary>
+    /// The one sentence a skipped bc-engine-serial row prints. Always three things, in
+    /// this order: WHICH collection stopped running (and that it asserted nothing), WHY,
+    /// and WHAT WOULD MAKE IT RUN. BcEngineSkipAttributionTests asserts all three for
+    /// every declared cause.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// A cause with no remedy. Deliberately a throw and not a generic fallback string: a
+    /// fallback would let a new branch ship the remedy-less reason this whole file exists
+    /// to prevent, and it would do it silently (.claude/rules/loud-failures.md).
+    /// </exception>
+    internal static string Format(BcEngineSkipCause cause, string detail)
+    {
+        var remedy = Remedy(cause);
+        return $"[{Collection}] SKIPPED — this test asserted NOTHING. The in-process BC engine "
+             + $"bootstrap did not complete, so every test in the '{Collection}' collection is "
+             + $"skipping. Cause ({cause}): {detail} Remedy: {remedy}";
+    }
+
+    private static string Remedy(BcEngineSkipCause cause) => cause switch
+    {
+        BcEngineSkipCause.ArtifactsMissing or BcEngineSkipCause.ArtifactsIncomplete =>
+            "provision the BC service tier with `dotnet build AlRunner.slnx "
+            + "-p:AllowBcArtifactDownload=true`, then run `" + BootstrapTool + "` and re-run "
+            + "`dotnet test` with `--settings engine.runsettings`.",
+
+        BcEngineSkipCause.NclPreloaded =>
+            "DOTNET_STARTUP_HOOKS is not wired into this test host, so VSTest's own DiaSession "
+            + "loaded Microsoft.Dynamics.Nav.Ncl before the Cecil rewrite could take effect "
+            + "(issue #1813). Run `" + BootstrapTool + "` — it generates engine.runsettings — "
+            + "then re-run `dotnet test --settings engine.runsettings`. CI does this in the "
+            + "'Generate .runsettings for in-process BC engine tests' step of "
+            + ".github/workflows/bc-tests.yml.",
+
+        BcEngineSkipCause.BinRewrittenThisProcess =>
+            "this run replaced bin/Microsoft.Dynamics.Nav.Ncl.dll, which happens on the first "
+            + "`dotnet test` after every build, so bin is now rewritten and a second run "
+            + "executes these tests. `" + BootstrapTool + "` performs that repeat for you and "
+            + "reports whether it converged — re-run it after every build.",
+
+        BcEngineSkipCause.CecilCacheCold =>
+            "warm the Ncl Cecil cache with one runner invocation before `dotnet test` — `"
+            + BootstrapTool + "` does it and repeats until the engine comes up. If it stays "
+            + "cold across repeats, the shared ~/.cache/al-runner/ncl-cecil cache is being "
+            + "pruned between runs (NclCecilRewrite.PruneCacheFiles keeps only the 8 newest "
+            + "entries, and the key folds the runner's own content hash, so more than 8 "
+            + "concurrent runner builds evict each other); re-run it or use --cache to give "
+            + "this checkout its own cache root.",
+
+        BcEngineSkipCause.BootstrapThrew =>
+            "this is not a normal environment gap — the bootstrap raised the exception above. "
+            + "Run `" + BootstrapTool + "` for a clean bootstrap; if it still throws, that is a "
+            + "runner defect and belongs in an issue rather than being skipped past.",
+
+        _ => throw new ArgumentOutOfRangeException(
+                 nameof(cause), cause,
+                 $"No remedy declared for BcEngineSkipCause '{cause}'. Every cause must name what "
+                 + "would make the " + Collection + " collection run (issue #3078)."),
+    };
+
+    /// <summary>
+    /// Renders an exception so the DIAGNOSIS survives.
+    ///
+    /// The bootstrap runs under reflection (a [ModuleInitializer] invoked by the .NET
+    /// hosting layer), so its failures arrive wrapped in TargetInvocationException — whose
+    /// own Message is the fixed string "Exception has been thrown by the target of an
+    /// invocation." Reporting `ex.GetType().Name + ex.Message` therefore printed a sentence
+    /// containing no information at all; that was measured verbatim on a local run
+    /// (see this file's header). Unwrap to the innermost real exception, and still name the
+    /// wrappers so the reflection boundary is not hidden either.
+    /// </summary>
+    internal static string Describe(Exception ex)
+    {
+        var wrappers = new List<string>();
+        var current = ex;
+
+        while (true)
+        {
+            Exception? inner = current switch
+            {
+                TargetInvocationException tie => tie.InnerException,
+                // Only a single-inner AggregateException is unwrapped: with several inner
+                // exceptions there is no one "real cause" to promote, and picking the first
+                // would hide the rest.
+                AggregateException { InnerExceptions.Count: 1 } agg => agg.InnerExceptions[0],
+                _ => null,
+            };
+
+            if (inner is null) break;
+            wrappers.Add(current.GetType().Name);
+            current = inner;
+        }
+
+        var core = $"{current.GetType().Name}: {current.Message}";
+        return wrappers.Count == 0 ? core : $"{core} (via {string.Join(" -> ", wrappers)})";
+    }
+}

--- a/AlRunner.Tests/BcEngineSkipReason.cs
+++ b/AlRunner.Tests/BcEngineSkipReason.cs
@@ -73,6 +73,16 @@ public enum BcEngineSkipCause
 
     /// <summary>The bootstrap threw. The detail carries the unwrapped exception.</summary>
     BootstrapThrew,
+
+    /// <summary>
+    /// <see cref="BcEngineBootstrap.Initialize"/> never ran, so there is no reason recorded
+    /// at all — Ready is false purely by default. Reachable whenever something prevents the
+    /// [ModuleInitializer] from firing, which is the #1813 shape itself. Its own cause
+    /// because the 132 call sites that read the fixture's reason used to fall back to a bare
+    /// "the in-process BC engine is not ready (see BcEngineCollection)." here: accurate,
+    /// and carrying no cause and no remedy — the same defect as the reason it replaces.
+    /// </summary>
+    BootstrapDidNotRun,
 }
 
 internal static class BcEngineSkipReason
@@ -108,6 +118,22 @@ internal static class BcEngineSkipReason
              + $"skipping. Cause ({cause}): {detail} Remedy: {remedy}";
     }
 
+    /// <summary>
+    /// The invariant: <c>!Ready</c> implies an ATTRIBUTABLE reason. Every branch of
+    /// <see cref="BcEngineBootstrap.Initialize"/> records one, but the initializer not
+    /// having run at all records nothing — and the 132 <c>SkipReason ?? "…"</c> call sites
+    /// across the collection then printed a bare fallback with no cause and no remedy.
+    /// Routing the fixture's own accessor through here closes that hole in one place
+    /// instead of at every call site.
+    /// </summary>
+    internal static string OrDefault(string? reason) =>
+        string.IsNullOrWhiteSpace(reason)
+            ? Format(BcEngineSkipCause.BootstrapDidNotRun,
+                     "BcEngineBootstrap.Initialize recorded no reason, which means it never ran — "
+                     + "nothing invoked a member of AlRunner.Tests.dll early enough to trigger its "
+                     + "[ModuleInitializer] before the BC engine was needed.")
+            : reason;
+
     private static string Remedy(BcEngineSkipCause cause) => cause switch
     {
         BcEngineSkipCause.ArtifactsMissing or BcEngineSkipCause.ArtifactsIncomplete =>
@@ -137,6 +163,11 @@ internal static class BcEngineSkipReason
             + "entries, and the key folds the runner's own content hash, so more than 8 "
             + "concurrent runner builds evict each other); re-run it or use --cache to give "
             + "this checkout its own cache root.",
+
+        BcEngineSkipCause.BootstrapDidNotRun =>
+            "run `" + BootstrapTool + "`. It wires DOTNET_STARTUP_HOOKS through "
+            + "engine.runsettings, which is what forces this assembly's [ModuleInitializer] to "
+            + "run before the test host touches any BC type (issue #1813).",
 
         BcEngineSkipCause.BootstrapThrew =>
             "this is not a normal environment gap — the bootstrap raised the exception above. "

--- a/tools/engine-test-bootstrap.sh
+++ b/tools/engine-test-bootstrap.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# engine-test-bootstrap.sh — make the bc-engine-serial tests actually RUN on a local box,
+# and say so out loud when they still will not. Issue #3078.
+#
+# The problem
+# -----------
+# The tests in AlRunner.Tests' `bc-engine-serial` collection (see
+# AlRunner.Tests/BcEngineCollection.cs) load the BC engine IN-PROCESS. That needs two
+# things a plain `dotnet test` does not set up:
+#
+#   1. bin/Microsoft.Dynamics.Nav.Ncl.dll already Cecil-rewritten. A process that performs
+#      the rewrite and then loads the result dies with BadImageFormatException 0x80131124,
+#      which is why the runner re-execs and why a test host — which cannot re-exec — skips
+#      instead. A BUILD restores the pristine Ncl.dll, so this is needed again after every
+#      build, not once per checkout.
+#   2. DOTNET_STARTUP_HOOKS wired through a .runsettings file. Without it VSTest's own
+#      DiaSession loads Ncl for stack-trace source mapping before any test code runs, the
+#      rewrite becomes a no-op, and the bootstrap fails (issue #1813).
+#
+# Without both, every one of those tests SKIPS. `dotnet test` then exits 0 and prints
+# `Passed!`, and at its default verbosity it does not print skip reasons at all — measured
+# 2026-09-06: 5 of 5 rows `[SKIP]` with no reason shown, exit code 0. A suite read as green
+# had executed none of the tests that mattered, and a RED baseline taken that way is worth
+# nothing.
+#
+# What this script does (idempotent — safe and cheap to re-run at any time)
+# ------------------------------------------------------------------------
+#   1. Writes engine.runsettings at the repo root with the absolute DOTNET_STARTUP_HOOKS
+#      chain for the chosen configuration.
+#   2. Runs the readiness probe repeatedly. Pass 1 lets the bootstrap copy the rewritten
+#      Ncl.dll into the test bin dir (it then skips, by design, rather than load a file it
+#      just wrote); pass 2 finds bin already correct and the engine comes up.
+#   3. Reports success only when the probe actually PASSED. A skip is reported as a
+#      failure of this script, with the skip reason printed, because "it skipped" is the
+#      condition this script exists to remove.
+#
+# Deliberately does NOT copy out of ~/.cache/al-runner/ncl-cecil by hand the way
+# .github/workflows/bc-tests.yml does. That cache is keyed on the runner's own content
+# hash and pruned to the 8 newest entries, so on a machine running several checkouts at
+# once `ls -t | head -1` names another checkout's entry — measured here: a pass picked up a
+# 16-minute-old file, and an entry written by one pass had been evicted by the next.
+# Letting the bootstrap itself do the copy, keyed correctly, has no such race.
+#
+# Usage:
+#   tools/engine-test-bootstrap.sh                 # bootstrap, then verify (Release)
+#   tools/engine-test-bootstrap.sh -c Debug        # same, Debug build output
+#   tools/engine-test-bootstrap.sh --verify        # verify only; no bootstrap passes
+#   tools/engine-test-bootstrap.sh --max-passes 5  # raise the repeat cap
+#
+# Exit codes: 0 the engine collection will run; 1 it will not (reason printed);
+#             2 usage or a missing build.
+
+set -euo pipefail
+
+CONFIG=Release
+TFM=net8.0
+MAX_PASSES=3
+VERIFY_ONLY=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -c|--configuration) CONFIG="${2:?-c needs a value}"; shift 2 ;;
+    --verify)           VERIFY_ONLY=1; shift ;;
+    --max-passes)       MAX_PASSES="${2:?--max-passes needs a value}"; shift 2 ;;
+    -h|--help)          sed -n '2,45p' "$0"; exit 0 ;;
+    *) echo "engine-test-bootstrap: unknown argument '$1' (try --help)" >&2; exit 2 ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+BIN="$REPO_ROOT/AlRunner.Tests/bin/$CONFIG/$TFM"
+RUNSETTINGS="$REPO_ROOT/engine.runsettings"
+# One test whose only job is to answer "is the in-process engine ready" — it PASSES when
+# the engine came up and SKIPS (never silently returns) when it did not.
+PROBE_FILTER='FullyQualifiedName~BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned'
+
+if [ ! -f "$BIN/AlRunner.Tests.dll" ] || [ ! -f "$BIN/al-runner.dll" ]; then
+  cat >&2 <<MSG
+engine-test-bootstrap: '$CONFIG' build output not found under
+  $BIN
+Build it first:
+  dotnet build AlRunner.Tests/AlRunner.Tests.csproj -c $CONFIG
+MSG
+  exit 2
+fi
+
+# Step 1 — the .runsettings. Rewritten every time: it holds absolute paths, so a copy from
+# another checkout (or another configuration) silently points at the wrong bin dir.
+#
+# The hook chain order is load-bearing and must match bc-tests.yml: al-runner.dll installs
+# a same-directory dependency resolver BEFORE AlRunner.Tests.dll is entered
+# (AlRunner/EngineTestBinResolverStartupHook.cs, AlRunner.Tests/EngineStartupHook.cs).
+# BcEngineSkipAttributionTests.BootstrapTool_AndCiWorkflow_AgreeOnTheStartupHookChain
+# fails the build if this file and the workflow ever disagree about it.
+cat > "$RUNSETTINGS" <<XML
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generated by tools/engine-test-bootstrap.sh. Absolute paths: do not copy between
+     checkouts or configurations; re-run the script instead. -->
+<RunSettings>
+  <RunConfiguration>
+    <EnvironmentVariables>
+      <DOTNET_STARTUP_HOOKS>$BIN/al-runner.dll:$BIN/AlRunner.Tests.dll</DOTNET_STARTUP_HOOKS>
+    </EnvironmentVariables>
+  </RunConfiguration>
+</RunSettings>
+XML
+echo "engine-test-bootstrap: wrote $RUNSETTINGS ($CONFIG)"
+
+# Runs the probe once. Prints nothing on success; on a skip, prints the reason — which is
+# attributable since #3078 (names the collection, the cause and what to do).
+run_probe() {
+  local log="$1"
+  set +e
+  dotnet test AlRunner.Tests/AlRunner.Tests.csproj -c "$CONFIG" --no-build \
+      --settings "$RUNSETTINGS" --filter "$PROBE_FILTER" \
+      --logger "console;verbosity=normal" >"$log" 2>&1
+  set -e
+  # `Passed: 1` in the summary is the only thing that means the engine actually came up.
+  # Deliberately NOT the exit code: `dotnet test` exits 0 for an all-skipped run, which is
+  # the entire defect this script exists to remove.
+  grep -qE '^ *Passed: *[1-9]' "$log"
+}
+
+LOG="$(mktemp -t engine-bootstrap-XXXXXX.log)"
+trap 'rm -f "$LOG"' EXIT
+
+PASSES=$MAX_PASSES
+[ "$VERIFY_ONLY" -eq 1 ] && PASSES=1
+
+for pass in $(seq 1 "$PASSES"); do
+  if run_probe "$LOG"; then
+    echo "engine-test-bootstrap: OK — the 'bc-engine-serial' collection will run (pass $pass/$PASSES)."
+    echo
+    echo "Run the suite with:"
+    echo "  dotnet test AlRunner.Tests/AlRunner.Tests.csproj -c $CONFIG --no-build --settings $RUNSETTINGS"
+    echo
+    echo "Re-run this script after every build: a build restores a pristine"
+    echo "bin/Microsoft.Dynamics.Nav.Ncl.dll and the engine tests go back to skipping."
+    exit 0
+  fi
+  echo "engine-test-bootstrap: pass $pass/$PASSES did not bring the engine up yet."
+done
+
+# Still not ready. Say exactly why, loudly — never exit 0 having proved nothing.
+echo >&2
+echo "engine-test-bootstrap: FAILED — the bc-engine-serial collection would SKIP, so a" >&2
+echo "  \`dotnet test\` run would report green having executed none of those tests." >&2
+echo >&2
+echo "Reason reported by the bootstrap:" >&2
+grep -E 'bc-engine-serial|\[SKIP\]|Cause \(|Remedy:' "$LOG" >&2 || sed -n '1,60p' "$LOG" >&2
+exit 1


### PR DESCRIPTION
Closes #3078

The bc-engine-serial tests skip on a local box and `dotnet test` reports green having
executed none of them. **Skipping is not the bug** — a box without the prerequisites
genuinely cannot exercise the in-process BC engine, and failing there would trade one
problem for a worse one. The silence is the bug. This PR makes the skip loud and
attributable and ships the tool that removes it, without turning a single legitimate skip
into a failure.

## What actually causes it (measured, not inferred)

All on this box, 2026-09-06, `--filter FullyQualifiedName~CodeunitRunWriteTransactionRefusalTests`:

1. **At the default console verbosity the reason is never printed.** Five of five rows show
   `[SKIP]` and `Skipped <name>` with no reason at all. The run ends
   `Skipped! - Failed: 0, Passed: 0, Skipped: 5` and **exit code 0**.
2. **`Console.Error` from the `[ModuleInitializer]` is swallowed too.** The existing
   `[Cecil] WARNING: Ncl already loaded before in-place rewrite — no effect` did not reach
   the console either. So the reason string is the *only* channel that can reach a developer.
3. **That one channel carried nothing.** At `--logger "console;verbosity=normal"` the reason
   finally appears and reads, verbatim:
   `BC engine bootstrap failed: TargetInvocationException: Exception has been thrown by the target of an invocation.`
   `TargetInvocationException.Message` is a fixed string; the bootstrap runs under reflection,
   so the inner exception — the entire diagnosis — was being discarded.

An `AL_RUNNER_TEST_ENGINE_PROBE` trace pinned the mechanism: `init: nclLoaded=True`,
`rewrite: cold=False changed=False`. Ncl was already loaded, un-rewritten, before the
bootstrap ran, so `NclCecilRewrite.RewriteInPlace` early-returned with no effect and
`BcRuntime.EnsureApplied()` then blew up applying patches to an untouched image. That is
issue #1813's shape: `DOTNET_STARTUP_HOOKS` was not wired, so VSTest's own `DiaSession`
loaded Ncl first.

**It was not the `ncl-cecil` cache key** on the first run — the cache was warm and `changed`
was false. But cache thrash is real here and showed up between passes: the key folds the
runner's content hash, `PruneCacheFiles` keeps only the 8 newest entries, and with several
checkouts running at once an entry written by one pass had been **evicted by the next**
(`cold=True` on a run that had hit the cache moments earlier). Two consequences, both handled
below: the bootstrap must be allowed to repeat, and copying by `ls -t | head -1` the way
`bc-tests.yml` does names another checkout's file. A pass here picked up a 16-minute-old
entry that way.

## Should the skip stay a skip?

Yes, in every case. The prerequisites are a real environment fact, two of the causes are
self-healing on a second run, and making a provisioned-but-unbootstrapped box go red would
make the suite unrunnable for people who have not yet run one command. Nothing about which
runs end up `Ready` changed — only what a non-ready run says. The CI half already fails loud
and is untouched (`BcEngineReadinessGuard.AssertReadyOnCi`).

## The fix

**`AlRunner.Tests/BcEngineSkipReason.cs`** — one place that builds every reason, and every
reason carries three things: **which** collection stopped running (and that it asserted
nothing), **why** (with `TargetInvocationException` / single-inner `AggregateException`
unwrapped to the real cause, wrappers still named), and **what would make it run** (a
cause-specific remedy that always names the tool). An undeclared cause **throws** rather than
falling back to a remedy-less string — a generic fallback is how this defect ships again.

The same run now reports:

> `[bc-engine-serial] SKIPPED — this test asserted NOTHING. … Cause (NclPreloaded): Microsoft.Dynamics.Nav.Ncl was already loaded before this bootstrap ran, so the Cecil rewrite had no effect and applying the runtime patches failed with TypeInitializationException: The type initializer for 'Microsoft.Dynamics.Nav.Runtime.NavEnvironment' threw an exception. (via TargetInvocationException). Remedy: DOTNET_STARTUP_HOOKS is not wired into this test host … Run `tools/engine-test-bootstrap.sh` …`

**`tools/engine-test-bootstrap.sh`** — the remedy, idempotent, `--verify`, `-c Debug`. It
writes `engine.runsettings` and then repeats the readiness probe until the engine comes up,
because pass 1 copies the rewritten Ncl.dll and skips by design. It deliberately does **not**
hand-copy out of `~/.cache/al-runner/ncl-cecil` the way the workflow does, for the eviction
reason above — letting the bootstrap do its own correctly-keyed copy has no such race. It
reports success only on an actual `Passed:`, never on `dotnet test`'s exit code, since exit 0
for an all-skipped run is the whole defect.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site?** Yes — `BcEngineFixture.SkipReason` was
   nullable and **132 call sites across 51 files** spell
   `_engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection)."`.
   That fallback fires when the bootstrap recorded no reason at all (the `[ModuleInitializer]`
   never ran — #1813's own shape) and is accurate, remedy-less, and exactly as silent as the
   message being fixed. `BcEngineSkipReason.OrDefault` makes the property total, fixing all
   132 without editing one, and a reflection test pins `SkipReason` as non-nullable so no
   caller can reintroduce its own fallback.
2. **Sibling doing the same thing?** `ServerProtocolTestEventTests.cs:29` renders the same
   `{ex.GetType().Name}: {ex.Message}`, but passes `ex.ToString()` alongside, so the inner
   exception survives. Checked, left alone.
3. **Two paths writing the same state, same invariant?** `SkipReason` is assigned in five
   branches and `Ready` in one. The invariant is `!Ready` implies an attributable reason; the
   "never initialized" path maintained neither. A source-scanning drift guard now fails the
   build if any assignment in `BcEngineCollection.cs` bypasses the formatter, and `OrDefault`
   covers the uninitialized path.

## Does this assert anything about BC?

**No, and here is the argument** rather than the bare answer. The subject is what an xUnit
skip message tells a developer and whether a shell script converges — harness plumbing that
exists only because AL Runner exists. Applying `bc-behavior-tests-go-upstream.md`'s test: if
AL Runner did not exist, none of these assertions would be a meaningful statement about
AL or BC, and there is no service tier that could adjudicate the wording of a skip reason or
the exit code of `tools/engine-test-bootstrap.sh`. The BC-shaped facts it leans on
(`BadImageFormatException 0x80131124` on rewrite-then-load, `DiaSession` preloading Ncl) are
already-settled runner facts from #1813/#1976, and this PR neither re-asserts nor changes
them. So no corpus PR is owed.

## RED → GREEN

**RED, on the real box.** `dotnet test --filter …CodeunitRunWriteTransactionRefusalTests`:
`Skipped! - Failed: 0, Passed: 0, Skipped: 5`, **exit 0**, no reason at any default
verbosity; at `verbosity=normal`, the empty `TargetInvocationException` sentence above.
Then the new tests against a placeholder reproducing exactly today's semantics
(`Format` returning the bare detail, `Describe` returning the wrapper's own message):
**13 failed, 3 passed**.

**GREEN.** `BcEngineSkipAttributionTests` **22/22 passed**. The full `bc-engine-serial`
collection — 53 classes — **361 passed, 0 skipped** after `tools/engine-test-bootstrap.sh`,
against the rebased tree, rebuilt (not `--no-build` over a stale binary).

**The tool, both directions.** Bootstrap from a post-build tree: pass 1 does not come up,
pass 2 `OK`, exit 0. `--verify` on that tree: exit 0. Then the skip condition **constructed
deliberately** — the pristine service-tier `Ncl.dll` copied over the test bin copy, which is
byte-for-byte what a build leaves behind (`sha256 49b11d9b…`, the same hash the first RED run
measured) — `--verify` exits **1** and prints `Cause (BinRewrittenThisProcess)` with its
remedy. None of the assertions read ambient engine state; the source-scanning guards carry
their own fixture guards (file found, non-trivial, minimum match count) so they cannot rot
into a vacuous pass, which is the #3017 defect this issue is a cousin of.

## Deliberately left out

- **`bc-tests.yml` still does its own inline bootstrap.** Switching CI to the tool would
  exercise it on eight legs, but a bug there reds every leg for no gain — CI is not where
  this defect lives. Instead a parity guard asserts the tool and the workflow agree on the
  startup-hook chain and its order, so they cannot drift apart silently.
- **The `ncl-cecil` prune/eviction churn is worked around, not fixed.** `keepNewest: 8` against
  a content-hash-keyed cache is too small when several checkouts run concurrently. The tool
  repeats and the `CecilCacheCold` remedy names the mechanism explicitly, but the cache
  policy itself is untouched — it is a production change with its own blast radius and it
  belongs in its own issue.
- **No production code changed at all**, so `require-tests` is not triggered; the diff is
  tests, one tool and one skill doc.

---
*Written by an agent (`stma-auto-1`, autonomous cycle 138) on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
