### PR TITLE
fix(allobj): refuse loudly when the owner index cannot read an assembly, instead of silently unowning every object it declares

### DIFF
--- a/AlRunner.Tests/AllObjOwnerIndexLoudFailureTests.cs
+++ b/AlRunner.Tests/AllObjOwnerIndexLoudFailureTests.cs
@@ -1,0 +1,194 @@
+// AllObjOwnerIndexLoudFailureTests — issue #3117, follow-up to #3107 (which fixed #3049).
+//
+// WHAT THIS PINS
+//   RecordPatches.BuildObjectOwnerIndex answers "which app owns object (kind, id)". Whatever
+//   it cannot answer for is left out of the index, and PopulateAllObjVirtualTable then writes
+//   Guid.Empty into AllObj's "App Package ID" / "App Runtime Package ID" columns:
+//
+//       var owningAppId = ownerIndex.TryGetValue((normalized, id), out var owner)
+//                       ? owner : Guid.Empty;
+//
+//   Leaving an object out is the CORRECT, deliberate answer when the runner genuinely does not
+//   know who owns it (#3107's comment explains why attributing it to the current bundle would
+//   be a permission granted on a guess). It is the WRONG answer when the runner failed to look,
+//   because real System Application code — Reten. Pol. Allowed Tbl. Impl.ModuleOwnsTable —
+//   compares those columns against the caller's Published Application row and simply declines.
+//   "This app does not own it" and "we could not find out" become the same observable outcome:
+//   no message, no exit-code change, a green run. That is the silent default
+//   .claude/rules/loud-failures.md exists to prevent.
+//
+//   Before #3117 the read failures were swallowed by three bare `catch { continue; }` blocks.
+//   Now they raise a RunnerOutOfScopeException naming the assembly or package that could not
+//   be read.
+//
+// WHY THE READER IS INJECTED
+//   The condition is "reading this assembly's type metadata throws". A test cannot make a real
+//   R2R assembly's TypeDef table unreadable on demand, so AddEmittedAssemblyOwners takes the
+//   name-reader as a parameter and the tests hand it a thrower. Same shape, and the same
+//   reason, as Win32Stubs.FindCompiler(Func<string, bool>) / Win32StubsLoudFailureTests.
+//
+// WHY THIS IS NOT AN UPSTREAM CORPUS TEST
+//   Object ownership as AL observes it through AllObj IS BC-observable, and that half of the
+//   claim is already upstream and adjudicated on eight real BC legs — Codeunit 60405
+//   "Test Module Owns Own Table" (BusinessCentral.AL.Language.Tests#181). This file asserts
+//   something different and strictly runner-local: how the RUNNER reports its own failure to
+//   read its own emitted assemblies. A BC service tier is never in that state and AL cannot
+//   observe it, so there is nothing for the corpus to adjudicate.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class AllObjOwnerIndexLoudFailureTests
+{
+    private static readonly Guid AppUnderTest = new("6EDA7750-0000-4000-8000-000000000001");
+    private static readonly Guid SomeOtherApp = new("5A8EDAC8-0000-4000-8000-000000000002");
+
+    /// <summary>Every prefix the scan asks for, answered with nothing.</summary>
+    private static IEnumerable<string> NoTypes(string prefix) => Array.Empty<string>();
+
+    // ----------------------------------------------------------------------------------
+    // The failure path — the whole point of #3117.
+    // ----------------------------------------------------------------------------------
+
+    [Fact]
+    public void ReaderThrowingOnCall_RaisesALoudRefusal_InsteadOfLeavingObjectsUnowned()
+    {
+        var index = new Dictionary<(string Kind, int Id), Guid>();
+
+        var ex = Assert.Throws<RunnerOutOfScopeException>(() =>
+            RecordPatches.AddEmittedAssemblyOwners(
+                index, "MyApp.Emitted", AppUnderTest,
+                _ => throw new BadImageFormatException("TypeDef table is truncated")));
+
+        // Names WHAT could not be read...
+        Assert.Contains("MyApp.Emitted", ex.Message);
+        // ...and WHY, carrying the underlying failure rather than flattening it.
+        Assert.Contains("BadImageFormatException", ex.Message);
+        Assert.Contains("TypeDef table is truncated", ex.Message);
+        // ...and what the consequence would have been, so the reader is not left guessing.
+        Assert.Contains("no owning app", ex.Message);
+
+        // The bug WAS the default. Assert against it explicitly: a swallow would have returned
+        // normally and left this index empty, which is indistinguishable from "owns nothing".
+        Assert.Empty(index);
+    }
+
+    [Fact]
+    public void ReaderThrowingMidEnumeration_RaisesALoudRefusal_NotJustOnTheCall()
+    {
+        // The regression this guards: both real producers are LAZY — TypeNamesWithPrefix is a
+        // `yield return` iterator and EnumerateWithPrefix(...).Select(...) is deferred — so the
+        // pre-#3117 `try { names = ...; } catch { continue; }` wrapped only the assignment and
+        // caught nothing the enumeration itself raised. A try that does not span the foreach
+        // lets this escape unnamed; this test fails if that ever comes back.
+        var index = new Dictionary<(string Kind, int Id), Guid>();
+
+        var ex = Assert.Throws<RunnerOutOfScopeException>(() =>
+            RecordPatches.AddEmittedAssemblyOwners(
+                index, "Lazy.Emitted", AppUnderTest, ThrowsAfterFirst));
+
+        Assert.Contains("Lazy.Emitted", ex.Message);
+        Assert.Contains("InvalidOperationException", ex.Message);
+        Assert.Contains("metadata-only", ex.Message);
+
+        static IEnumerable<string> ThrowsAfterFirst(string prefix)
+        {
+            yield return prefix + "1";
+            throw new InvalidOperationException("TypeNamesWithPrefix is metadata-only");
+        }
+    }
+
+    [Fact]
+    public void TheRefusal_IsNotPermanentlyOutOfScope_SoATryFunctionCannotTrapItIntoFalse()
+    {
+        // BcRuntime.NavApplicationObjectBase_TryInvoke traps a PERMANENTLY out-of-scope refusal
+        // into `false`, and lets a "not-yet-implemented" one tear through
+        // (RecordPatches.VirtualTableShapeGap.cs, TryFunctionOutOfScopeTrapTests). If this
+        // refusal ever acquired a scope.md anchor instead, an AL [TryFunction] reading AllObj
+        // would silently receive `false` — the exact silent default this issue is about, just
+        // relocated. Pinned so that change cannot happen quietly.
+        var ex = Assert.Throws<RunnerOutOfScopeException>(() =>
+            RecordPatches.AddEmittedAssemblyOwners(
+                new Dictionary<(string Kind, int Id), Guid>(), "Anything", AppUnderTest,
+                _ => throw new BadImageFormatException("boom")));
+
+        Assert.StartsWith("not-yet-implemented", ex.Reason);
+        Assert.Contains("allobj-virtual-table", ex.Reason);
+    }
+
+    // ----------------------------------------------------------------------------------
+    // The success path — so none of the above can be satisfied by a method that always throws.
+    // ----------------------------------------------------------------------------------
+
+    [Fact]
+    public void EveryEmittedObjectKind_IsIndexedAgainstTheDeclaringAssemblysApp()
+    {
+        var index = new Dictionary<(string Kind, int Id), Guid>();
+
+        RecordPatches.AddEmittedAssemblyOwners(index, "MyApp.Emitted", AppUnderTest, prefix => prefix switch
+        {
+            "Record"   => new[] { "Record60404" },
+            "Codeunit" => new[] { "Codeunit60405" },
+            "Page"     => new[] { "Page60406" },
+            "Report"   => new[] { "Report60407" },
+            "Query"    => new[] { "Query60408" },
+            "XmlPort"  => new[] { "XmlPort60409" },
+            _          => Array.Empty<string>(),
+        });
+
+        // Concrete ids and concrete kinds: a no-op implementation returning an empty map fails
+        // every one of these, and so does one that indexes the wrong AL kind vocabulary.
+        Assert.Equal(AppUnderTest, index[("table", 60404)]);
+        Assert.Equal(AppUnderTest, index[("codeunit", 60405)]);
+        Assert.Equal(AppUnderTest, index[("page", 60406)]);
+        Assert.Equal(AppUnderTest, index[("report", 60407)]);
+        Assert.Equal(AppUnderTest, index[("query", 60408)]);
+        Assert.Equal(AppUnderTest, index[("xmlport", 60409)]);
+        Assert.Equal(6, index.Count);
+    }
+
+    [Fact]
+    public void ASymbolReferenceAnswer_OutranksTheAssemblyScan()
+    {
+        // #3049's union rule: the assembly pass only fills ids no symbol reference claimed, so a
+        // table an app does not own keeps the owner it already had. Without this, the assembly
+        // pass would let a bundle claim ownership of objects another app declares.
+        var index = new Dictionary<(string Kind, int Id), Guid>
+        {
+            [("table", 60404)] = SomeOtherApp,
+        };
+
+        RecordPatches.AddEmittedAssemblyOwners(index, "MyApp.Emitted", AppUnderTest, prefix =>
+            prefix == "Record" ? new[] { "Record60404", "Record60410" } : Array.Empty<string>());
+
+        Assert.Equal(SomeOtherApp, index[("table", 60404)]);   // symbol answer preserved
+        Assert.Equal(AppUnderTest, index[("table", 60410)]);   // unclaimed id filled in
+    }
+
+    [Fact]
+    public void NamesThatCarryNoPositiveObjectId_AreIgnoredRatherThanIndexedAsZero()
+    {
+        var index = new Dictionary<(string Kind, int Id), Guid>();
+
+        RecordPatches.AddEmittedAssemblyOwners(index, "MyApp.Emitted", AppUnderTest, prefix =>
+            prefix == "Record"
+                ? new[] { "Record0", "RecordHelper", "Record-5", "Record", "Record60404" }
+                : Array.Empty<string>());
+
+        // Only the one real object id survives; nothing lands under id 0 or a negative id.
+        Assert.Equal(new[] { ("table", 60404) }, index.Keys.ToArray());
+    }
+
+    [Fact]
+    public void AnAssemblyDeclaringNoEmittedObjects_IndexesNothingAndDoesNotThrow()
+    {
+        var index = new Dictionary<(string Kind, int Id), Guid>();
+        RecordPatches.AddEmittedAssemblyOwners(index, "Empty.Emitted", AppUnderTest, NoTypes);
+        Assert.Empty(index);
+    }
+}

--- a/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
+++ b/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
@@ -330,7 +330,18 @@ public sealed class VirtualTableRefusalClaimTests
         // deliberately two sites, not one: "this table declared something the column does not
         // list" and "this artifact's column does not list the default" point at different
         // causes. TableMetadataOptionDefaultOrdinalTests pins both messages.
-        Assert.Equal(68, total);
+        //
+        // 68 -> 71 (#3117): BuildObjectOwnerIndex's three bare `catch { continue; }` blocks
+        // became AllObjShapeGap refusals. Each one had been unowning every object of the
+        // package or assembly it could not read, which PopulateAllObjVirtualTable then wrote
+        // out as Guid.Empty -- indistinguishable from "this app does not own it".
+        //
+        // NOTE TO WHOEVER REBASES THIS NEXT: more than one open PR moves this number at a
+        // time (#3128 moves it too, by a different amount). Do NOT add your delta to whatever
+        // is on main -- run the test, read the "Actual:" value out of the failure message, and
+        // write that. An arithmetic guess here is how the assertion silently stopped meaning
+        // what it says once before.
+        Assert.Equal(71, total);
     }
 
 

--- a/AlRunner/Patches/RecordPatches.AllObjVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AllObjVirtualTable.cs
@@ -126,7 +126,24 @@ public static partial class RecordPatches
         var ordinals = EnsureAllObjObjectTypeOrdinals(allObjMetaTable);
         var done = _aovPopulatedByProvider.GetValue(provider, static _ => new ConcurrentDictionary<(int, int), byte>());
 
-        var owners = BuildObjectOwnerIndex();
+        // #3117: built on FIRST ACTUAL INSERT, not on entry. PopulateAllObjVirtualTable runs on
+        // every AllObj data-access handout, but `done` makes all but the first few handouts
+        // insert nothing — and BuildObjectOwnerIndex walks every registered module assembly's
+        // TypeDef name index six times (once per _emittedObjectTypePrefixes entry), Base
+        // Application included, so an eager build paid that price to produce no rows.
+        //
+        // Measured on the al-language corpus (2665 tests, BC 28.1, warm compile cache), which
+        // is what settles the "cost is not the reason for a skip any more" claim #3107's PR
+        // body made with no number behind it:
+        //
+        //   eager (as merged in #3107): 74 calls, 74 builds, 1905.2 ms total
+        //   this shape:                 74 calls,  3 builds,   48.7 ms total
+        //
+        // 71 of the 74 handouts rebuilt a 10,349-entry dictionary and inserted zero rows. For
+        // scale, the rest of this method — EnumerateKnownAlObjects plus the inserts, which is
+        // work that actually has to happen — measured 1119.5 ms over the same 74 calls, so the
+        // redundant build was NOT the same order as the necessary work: it was 1.7x larger.
+        Dictionary<(string Kind, int Id), Guid>? ownerIndex = null;
 
         foreach (var (kind, id, name, _) in EnumerateKnownAlObjects())
         {   // AllObj has no caption column; the shared inventory carries one for
@@ -151,7 +168,8 @@ public static partial class RecordPatches
             // does not know — and answering "the bundle" there would let the bundle own it,
             // which is a permission granted on a guess. An unowned object simply fails the
             // ownership check, which is what a wrong guess should look like.
-            var owningAppId = owners.TryGetValue((normalized, id), out var owner) ? owner : Guid.Empty;
+            ownerIndex ??= BuildObjectOwnerIndex();
+            var owningAppId = ownerIndex.TryGetValue((normalized, id), out var owner) ? owner : Guid.Empty;
             InsertAllObjRow(provider, allObjMetaTable, typeOrdinal, id, name, owningAppId);
         }
     }
@@ -343,8 +361,22 @@ public static partial class RecordPatches
         foreach (var appPath in _bcAppPaths.ToArray())
         {
             BcAppSymbolCache.AppSymbols symbols;
+            // #3117: NOT swallowed. This used to `catch { continue; }` on the reasoning that
+            // "the AllObj row itself is built either way" — true, but it is then built with
+            // Guid.Empty in the two package columns, and an ownership check reading those
+            // cannot tell "this app does not own it" from "we could not find out". That is the
+            // silent default .claude/rules/loud-failures.md exists to prevent, and it is the
+            // same reasoning AllObjShapeGap already applies to an unreadable option ordinal:
+            // the owner is a STORED COLUMN VALUE, so a wrong one mis-keys every row it writes
+            // and no test can see it.
             try { symbols = BcAppSymbolCache.Get(appPath); }
-            catch { continue; }   // the AllObj row itself is built either way; see EnumerateBcAppObjects
+            catch (Exception ex)
+            {
+                throw AllObjShapeGap(
+                    $"the SymbolReference of dependency package '{Path.GetFileName(appPath)}' could not be "
+                    + $"read ({ex.GetType().Name}: {ex.Message}), so every object it declares would be "
+                    + "stamped with no owning app instead of its real one");
+            }
             if (!Guid.TryParse(symbols.AppId, out var appId) || appId == Guid.Empty)
                 // A symbol reference stating no app id leaves its objects unowned rather than
                 // getting an invented owner — Guid.Empty then matches no Published Application
@@ -387,37 +419,102 @@ public static partial class RecordPatches
         //
         // So both sources are read and the SYMBOL answer wins on conflict: it is exact for a
         // precompiled .app, and the assembly pass only fills ids no symbol reference claimed.
-        // Cost is not the reason for a skip any more either — TypeNamesWithPrefix reads the
-        // TypeDef table and resolves no CLR Type at all, where EnumerateWithPrefix
-        // materialised a RuntimeType per match.
+        //
+        // On cost (#3117): #3107 asserted "cost is not the reason for a skip any more" with no
+        // number behind it. Measured since, on the al-language corpus: one build of this index
+        // is ~25 ms with Base Application loaded (10,349 entries), and it is NOT free. What
+        // makes it affordable is that the caller now builds it at most once per handout that
+        // actually inserts a row — see PopulateAllObjVirtualTable — rather than on every
+        // handout. The half of the original claim that does hold is the mechanism:
+        // TypeNamesWithPrefix reads the TypeDef table and resolves no CLR Type at all, where
+        // EnumerateWithPrefix materialised a RuntimeType per match.
         foreach (var (asm, appId) in AlRunner.BcRuntime.RegisteredModuleAssemblies())
         {
+            var asmName = SafeAssemblyName(asm);
             AlRunner.Infrastructure.AssemblyTypeIndex typeIndex;
+            // #3117: NOT swallowed, for the reason on the symbol-reference read above. A throw
+            // here drops EVERY object this assembly declares from the index, and each one then
+            // takes the Guid.Empty branch in PopulateAllObjVirtualTable — silently, with no
+            // message and no exit-code change. AssemblyTypeIndex's own constructor is written
+            // to FALL BACK rather than throw (unreadable metadata degrades to
+            // Assembly.GetTypes()), so an exception escaping For() is genuinely exceptional
+            // rather than routine: measured over the al-language corpus (2665 tests) and
+            // tests/runner-extras (304 tests), neither this site nor the two around it fired
+            // once.
             try { typeIndex = AlRunner.Infrastructure.AssemblyTypeIndex.For(asm); }
-            catch { continue; }
-            foreach (var (prefix, kind) in _emittedObjectTypePrefixes)
+            catch (Exception ex)
             {
-                IEnumerable<string> names;
-                try
-                {
-                    names = typeIndex.IsMetadataBacked
-                        ? typeIndex.TypeNamesWithPrefix(prefix)
-                        // A dynamic (Reflection.Emit) assembly has no TypeDef table to read;
-                        // it has a handful of types, so resolving them is cheap.
-                        : typeIndex.EnumerateWithPrefix(prefix).Select(t => t.Name);
-                }
-                catch { continue; }
-                foreach (var name in names)
-                {
-                    if (!int.TryParse(name.AsSpan(prefix.Length), out var id) || id <= 0) continue;
-                    var key = (NormalizeObjectTypeName(kind), id);
-                    // TryAdd, not an assignment: a symbol reference that named this object
-                    // already answered, and that answer is the authoritative one.
-                    index.TryAdd(key, appId);
-                }
+                throw AllObjShapeGap(
+                    $"the type index of module assembly '{asmName}' could not be read "
+                    + $"({ex.GetType().Name}: {ex.Message}), so every object it declares would be "
+                    + "stamped with no owning app instead of its real one");
             }
+
+            AddEmittedAssemblyOwners(index, asmName, appId, prefix =>
+                typeIndex.IsMetadataBacked
+                    ? typeIndex.TypeNamesWithPrefix(prefix)
+                    // A dynamic (Reflection.Emit) assembly has no TypeDef table to read;
+                    // it has a handful of types, so resolving them is cheap.
+                    : typeIndex.EnumerateWithPrefix(prefix).Select(t => t.Name));
         }
         return index;
+    }
+
+    /// <summary>Assembly name for a diagnostic, without letting the diagnostic itself throw.</summary>
+    private static string SafeAssemblyName(System.Reflection.Assembly asm)
+    {
+        try { return asm.GetName().Name ?? asm.ToString(); }
+        catch { return "<unnamed assembly>"; }
+    }
+
+    /// <summary>
+    /// Fold one registered module assembly's emitted AL object types into
+    /// <paramref name="index"/>, one pass per <see cref="_emittedObjectTypePrefixes"/> entry.
+    ///
+    /// <para><paramref name="typeNamesForPrefix"/> is a parameter rather than a direct
+    /// <c>AssemblyTypeIndex</c> call so the FAILURE path is directly testable — the whole point
+    /// of #3117 is that this method must not answer quietly when it cannot read, and a test
+    /// cannot make a real R2R assembly's TypeDef table unreadable on demand. Same shape as
+    /// <c>Win32Stubs.FindCompiler(Func&lt;string, bool&gt;)</c>, pinned by
+    /// <c>Win32StubsLoudFailureTests</c> for the same reason.</para>
+    /// </summary>
+    internal static void AddEmittedAssemblyOwners(
+        Dictionary<(string Kind, int Id), Guid> index,
+        string assemblyName,
+        Guid appId,
+        Func<string, IEnumerable<string>> typeNamesForPrefix)
+    {
+        foreach (var (prefix, kind) in _emittedObjectTypePrefixes)
+        {
+            var normalizedKind = NormalizeObjectTypeName(kind);
+            // The enumeration runs INSIDE the try, not just the call that produces it. Both
+            // producers are lazy — TypeNamesWithPrefix is a `yield return` iterator and
+            // EnumerateWithPrefix(...).Select(...) is deferred too — so wrapping only the
+            // assignment (as the code this replaces did) caught nothing the enumeration itself
+            // raised; TypeNamesWithPrefix's own "metadata-only" InvalidOperationException would
+            // have sailed straight past it.
+            try
+            {
+                foreach (var name in typeNamesForPrefix(prefix))
+                {
+                    if (!int.TryParse(name.AsSpan(prefix.Length), out var id) || id <= 0) continue;
+                    // TryAdd, not an assignment: a symbol reference that named this object
+                    // already answered, and that answer is the authoritative one (#3049).
+                    index.TryAdd((normalizedKind, id), appId);
+                }
+            }
+            catch (RunnerOutOfScopeException)
+            {
+                throw;   // already named its surface; do not re-wrap
+            }
+            catch (Exception ex)
+            {
+                throw AllObjShapeGap(
+                    $"module assembly '{assemblyName}' could not be scanned for '{prefix}*' object "
+                    + $"types ({ex.GetType().Name}: {ex.Message}), so every {kind} it declares would "
+                    + "be stamped with no owning app instead of its real one");
+            }
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #3117

Follow-up to the two non-blocking review findings on PR #3107 (merged as `7b89f451`), the implementation of
issue #3049. Both were verified against the merged code before anything was changed; one
needed its framing corrected, and that correction is below rather than buried.

## Finding 2 (the real one): a swallowed read failure was indistinguishable from "not owned"

`BuildObjectOwnerIndex` carried three bare `catch { continue; }` blocks. When one fired, every
object the affected package or assembly declares dropped out of the index, and
`PopulateAllObjVirtualTable` then took its `Guid.Empty` branch and wrote that into AllObj's
"App Package ID" / "App Runtime Package ID" columns. Real System Application code —
`Reten. Pol. Allowed Tbl. Impl.ModuleOwnsTable`, the path #3049 was about — compares those
against the caller's Published Application row and simply declines. So **"this app does not own
it" and "we could not find out" were the same observable outcome**: no message, no exit-code
change, a green run.

All three now raise `AllObjShapeGap` naming what could not be read, the underlying exception
type and message, and the consequence. That is this file's own established mechanism, and it is
the same reasoning its `AllObjShapeGap` doc comment already applies to an unreadable option
ordinal: *the owner is a stored column value, so a wrong one mis-keys every row it writes and no
test can see it.*

Two details that made a stderr warning the wrong answer here:

- `Program.cs:2232-2233` sets **both** `Console.Out` and `Console.Error` to `TextWriter.Null`
  for the bundle loop under the dashboard UI, so a printed warning can vanish. A throw cannot.
- The refusal keeps the `not-yet-implemented` anchor, so `IsPermanentOutOfScope` stays false and
  an AL `[TryFunction]` reading AllObj **cannot** trap it into `false`. A test pins this, because
  re-anchoring it at `docs/scope.md` would relocate the same silent default rather than remove it.

### Correction to how the finding was relayed

It reached me as "#3107 changed this from skipping one prefix to skipping the whole assembly."
Checked against the diff, that overstates the delta. Before #3107 the call was
`try { types = AssemblyTypeIndex.For(asm).EnumerateWithPrefix(prefix); } catch { continue; }`
*inside* the prefix loop, so a throw from `For(asm)` already fired once per prefix and skipped
all six — the whole assembly. Hoisting it changed the shape, not the net effect.

What #3107 **did** change is reachability: it removed `if (fromSymbols.Contains(appId)) continue;`,
so assemblies whose app a symbol reference already covered — Base Application and System
Application among them — now reach `AssemblyTypeIndex.For` where before they never did. The
swallow is exposed to strictly more assemblies. The reviewer's "pre-existing in kind" reading
was right.

### The not-disk-cached claim holds — confirmed independently

Checked because a `Guid.Empty` reaching a cache would have changed the fix. It cannot, and the
protection is structural rather than incidental:

- `AllObjVirtualTableId` (2000000038) is in `IsSelfPopulatingVirtualTableId`
  (`RecordPatches.InstallBaselineDisk.cs`), excluding it from the install-baseline disk snapshot
  on all three paths — persist, restore, and cache-key hash. Its doc comment declares the
  exclusion "UNCONDITIONAL, and it stays that way."
- `AssemblyTypeIndex._cache` is a `ConditionalWeakTable`; a throwing factory stores nothing.
- `BcAppSymbolCache` does have an on-disk payload, but a failed parse throws and stores nothing
  (#2712).

Per-run, per-process. Not persisted.

### A latent trap fixed alongside it

Both producers are lazy — `TypeNamesWithPrefix` is a `yield return` iterator and
`EnumerateWithPrefix(...).Select(...)` is deferred — so the old `try` wrapped only the
*assignment* and caught nothing the enumeration itself raised. `TypeNamesWithPrefix`'s own
"metadata-only" `InvalidOperationException` would have sailed straight past it. The enumeration
now runs inside the `try`, and a dedicated test covers exactly this (it fails if the `try` ever
stops spanning the `foreach`).

## Finding 1: measured, and the measurement changed the answer

#3107's body asserted "cost is not the reason for a skip any more" with no number. Measured on
the al-language corpus (2665 tests, BC 28.1), timing `BuildObjectOwnerIndex` separately from the
rest of `PopulateAllObjVirtualTable`:

| | calls | index builds | time in `BuildObjectOwnerIndex` |
|---|---|---|---|
| eager, as merged in #3107 | 74 | 74 | **1905.2 ms** |
| built on first actual insert (this PR) | 74 | 3 | **48.7 ms** |

For scale, the rest of the method — `EnumerateKnownAlObjects` plus the inserts, work that has to
happen — measured **1119.5 ms** over the same 74 calls.

So the reviewer's hypothesis that this was "the same order as the pre-existing
`EnumerateKnownAlObjects` cost" did not hold: it was **1.7x larger than the necessary work**, and
**71 of the 74 handouts rebuilt a 10,349-entry dictionary to insert zero rows**, because `done`
had already claimed every object. That is a structural fact about call counts, not a
machine-speed artifact, which is why it carries the decision. I did **not** claim a wall-clock
improvement: the runs had differing compile-cache warmth, so only the instrumented counter is a
clean comparison.

This is the outcome the brief asked me to be willing to reject, so to be explicit: had the number
come back in the same order I would have recorded it in a comment and changed no code. It did
not, so the build is now hoisted behind the idempotence check. The stale claim in the file's own
comment is corrected in place rather than left to mislead the next reader.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site?** Yes — the finding named one `catch`, there were
   **three**. The `BcAppSymbolCache.Get` swallow in the same method was not reported at all and
   is fixed here too.
2. **Sibling making the same assumption?** `EnumerateBcAppObjects` catches the same
   `BcAppSymbolCache.Get` failure. It already reports on stderr and continues, which is
   deliberate and correct for it — a missing row is "absent", not "wrongly owned" — so it is left
   alone. Noting it because "nothing found" is not the answer there; the answer is "found, and
   correct as-is."
3. **Two paths writing the same state, same invariant?** The symbol pass and the assembly pass
   both write the owner index. They now fail the same way. `TryAdd` vs assignment is the one
   deliberate asymmetry (the symbol answer outranks the assembly scan, #3049) and a test pins it.

## Does this assert something about what BC does?

Worth separating, because half of it does and half does not. **Object ownership as AL observes it
through AllObj is BC-observable**, and that half is already upstream and adjudicated on eight real
BC legs — Codeunit 60405 `"Test Module Owns Own Table"`, BusinessCentral.AL.Language.Tests#181,
pinned by #3107. This PR does not change what AL observes on any path where the reads succeed:
the index content, the `TryAdd` precedence and the resulting column values are identical, which
is what the corpus run below demonstrates.

What is new here is **fault reporting** — "when the runner cannot read its own emitted assembly's
type metadata, it says so loudly." A BC service tier is never in that state and AL cannot observe
it, so there is nothing for the corpus to adjudicate and no upstream test is owed. The proving
tests are therefore runner-side under `AlRunner.Tests/`, per the workflow's
runner-side-mechanism-test route.

## RED → GREEN

RED was constructed deliberately, by restoring the pre-#3117 swallow inside the new method while
holding its signature constant — the same technique #3107 used to verify its own RED.

- **RED:** `Failed: 3, Passed: 4, Total: 7`. The three loud-failure tests failed with
  `Assert.Throws() Failure: No exception was thrown` — which *is* the bug, stated exactly.
- **GREEN:** `Passed: 7, Total: 7`.

The 4 success-path tests pass in both states by design: they assert concrete ids, kinds and
GUIDs, so they fail against a no-op implementation *and* against a fix that merely always throws.
The `Guid.Empty`/empty-index default is asserted against explicitly, since that default is the
bug.

## Verification actually run in this state

- `AllObjOwnerIndexLoudFailureTests` — 7/7.
- `StaleBundleSymbolAppOwnershipTests` (#3107's own ownership test, this exact path) — 8/8 with
  the new tests.
- al-language corpus, CI flags with `--package-cache` and `--count-baseline`: **2665/2665, exit 0**.
- `tests/runner-extras`, CI flags with both package caches: **304/304, exit 0**.

Instrumented separately and then reverted: none of the three catch sites fired **once** across
those 2969 tests, which is what makes converting them to throws safe rather than a gamble on
eight CI legs. That measurement is why the refusal is defensible as genuinely exceptional.

## Follow-up: the count assertion CI caught, and the collision with #3128

CI was right and the first push was wrong. The three new `AllObjShapeGap` throw sites are
counted by `VirtualTableRefusalClaimTests.AllFortyEightRefusalsStillExist_...`, which asserts the
total exactly, and that assertion was left at `68`. It failed deterministically on both unit-test
legs.

**Root cause is named in "Deliberately left out" below and is exactly what it says**: no full
sweep locally. The diff touched no runtime path this test exercises, but the test asserts over
the *tree*, so "touches no runtime path" was never the relevant question — the same lesson #3110
learned from the other direction.

The fix is one line, `68` -> `71`. **The number was read from the test's own failure output**, not
computed:

```
Assert.Equal() Failure: Values differ
Expected: 68
Actual:   71
```

That distinction is load-bearing. This assertion has been broken by an author before, when
factories also ending in `ShapeGap` returned a different type and pushed the count 58 -> 81 while
the assertion silently stopped meaning what it says. The `(?<!Bc)` lookbehind in its regex exists
because of that and is untouched here.

### Whoever rebases second must re-read the number, not add to it

**PR #3128 moves this same assertion, by a different amount.** As of this writing `main` reads
`68`; #3128 takes it to `72` (+4) and this PR takes it to `71` (+3). Whichever merges second is
the one that has to change, and **both `71` and `72` will look entirely plausible to whoever is
holding the rebase** — which is precisely how a wrong number gets committed with confidence.

The rule, not the number: **run the test, read the `Actual:` value out of the failure message,
write that.** Do not add your delta to whatever is on `main`. Naive arithmetic gives 75 today, but
#3128's shape is not settled — corpus PR #196 came back with a **split verdict** on all eight
Cloud legs (the `PromptDialog` page half passed, confirming 20; the Install codeunit half failed
`Expected:<4>. Actual:<0>`, a real tier reporting 0), so #3128 may land with a different set of
throw sites than it has now. A number derived by addition would be wrong and would look right.

The same warning is now a comment in the test, immediately above the assertion, where a rebaser
will actually be looking. #3128 has been commented with the reciprocal note, since its author had
no way to know either.

### Sibling sweep for this specific defect

Asked whether any *other* test hardcodes a count that these three throw sites move.
`RunnerShapeGapClaimTests.AllEighteenCorrectedRefusalsUnderAlRunnerStillExist_...` is the only
other exact-count assertion of this family, and it counts `throw RunnerShapeGap.` — a different
convention that `AllObjShapeGap(` does not match. Verified by running it, not by reading it: it
passes unchanged. **Nothing else found.**

### Verification run in the corrected state

Rebased onto `main` at `be7a4de0` first (`git submodule update --init --recursive` after), then
rebuilt — **not** `--no-build`, which would have measured the pre-rebase binary:

- **RED**, before the fix: `AllFortyEightRefusalsStillExist_...` fails `Expected: 68 / Actual: 71`;
  the other 85 in the class pass.
- **GREEN**, after: filtered run over `VirtualTableRefusalClaimTests`,
  `ReflectionDrivenHelperLivenessTests`, `RunnerShapeGapClaimTests`, `FieldTriggerShapeGapCallSiteTests`
  and the AllObj/owner-index classes — **238 passed, 0 failed**, 31 skipped (platform-gated
  field-trigger cases that skip on Linux, unrelated).
- `ReflectionDrivenHelperLivenessTests` specifically — the IL-based `RecordPatches` scan #3112
  added, which is the guard family these throw sites live in — **1/1**, confirmed by running it
  under its own filter rather than trusting the aggregate. It did not exist on the pre-rebase base
  commit, which is the reason the rebase happened before measuring rather than after.

Everything above in this PR — the cost measurement, the `Guid.Empty` finding, the corpus and
runner-extras runs — is unchanged by this follow-up and was not re-run in the rebased state; the
rebase picked up three commits (#3116, #3082, #3112) that touch none of those paths.

## Deliberately left out

- **`EnumerateBcAppObjects`'s stderr-and-continue is unchanged**, per question 2 above.
- **No full `dotnet test AlRunner.Tests` sweep locally** — filtered runs plus both AL bundle sets;
  CI runs the full suite on each of the 8 legs. **This is what cost the first push**: it is the
  direct cause of the count assertion above being left at `68`, and the reason CI found it instead
  of the author.
- **No `docs/` change**: no user-visible behavior, flag or scope change. A previously-silent
  internal read failure now surfaces as a refusal, which `docs/limitations.md#virtual-table-shape-gaps`
  already covers as the anchor for this class of gap.
- **Issue #2946 stays open** and is not addressed here: the runner still has no exception type
  meaning "I could not read BC's internals", so these refusals borrow the virtual-table shape-gap
  anchor. That is the pre-existing convention, not something this PR settles.

---
*Written by agent `stma-auto-1` (autonomous cycles 138 and 140) on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
