### PR TITLE
feat(expectations): report an expectations entry that matched no test instead of ignoring it

### DIFF
--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -503,12 +503,13 @@ jobs:
               --package-cache "$HOME/.al-runner/platform-apps" \
               --package-cache "$HOME/.al-runner/test-apps" \
               --strict \
+              --expectations-require-match \
               --count-baseline tests/expectations/count-baseline/test-count-baseline.json \
               --out al-language-results.json || rc=$?
           elapsed=$(( SECONDS - start ))
           echo "elapsed=${elapsed}s" >> "$GITHUB_OUTPUT"
           if [ "$rc" -ne 0 ]; then
-            echo "::error::al-language run failed (exit $rc: 1=test failure, 2=exec fail, 3=compile fail, 4=count-baseline mismatch, 134/139=crash)"
+            echo "::error::al-language run failed (exit $rc: 1=test failure, 2=exec fail, 3=compile fail, 4=count-baseline mismatch, 5=expectations entry matched no test, 134/139=crash)"
             exit "$rc"
           fi
 

--- a/AlRunner.Tests/ExpectationManifestWiringTests.cs
+++ b/AlRunner.Tests/ExpectationManifestWiringTests.cs
@@ -290,4 +290,142 @@ public sealed class ExpectationManifestWiringTests : IDisposable
 
         Assert.Contains("[expectations] no tests/expectations manifest found", output, StringComparison.Ordinal);
     }
+
+    // ── #3123: an entry that matches NO test ──────────────────────────────────────
+    //
+    // Every drift direction above is about a test the manifest MATCHED. An entry that
+    // matched nothing produced no diagnostic at all: Lookup returned null, the
+    // classifier took its no-entry branch, and the run's output was byte-comparable to
+    // a run with an empty manifest directory. One wrong letter untracked a declared gap.
+    //
+    // --expectations-require-match is the opt-in that turns that into a verdict. It has
+    // to be opt-in: the expectations directory is auto-probed and shared across every
+    // invocation in this repo, and an entry naming a corpus codeunit legitimately
+    // matches nothing in a run over a different bundle.
+
+    /// <summary>Writes a one-entry manifest into scratch and returns its directory.</summary>
+    private string OneEntryManifest(string name, string codeunitName, string method)
+    {
+        var dir = Path.Combine(_scratchRoot, name);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "known-gaps-fixture.json"), $$"""
+        [
+          {
+            "codeunitId": 60810,
+            "CodeunitName": "{{codeunitName}}",
+            "Method": "{{method}}",
+            "Mode": "expect-fail-known-gap",
+            "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3123"
+          }
+        ]
+        """);
+        return dir;
+    }
+
+    /// <summary>
+    /// The correct entry, with the audit on: the known-gap failure still reclassifies to
+    /// green AND the audit reports the scope it accounted for. This is the control that
+    /// keeps the two tests below from passing against an implementation that always
+    /// reports an unmatched entry.
+    /// </summary>
+    [SkippableFact]
+    public void RequireMatch_CorrectEntry_StaysGreen_AndSaysWhatItAccountedFor()
+    {
+        TestArtifacts.SkipIfMissing();
+        var dir = OneEntryManifest("match-ok", "Expct Fixture Tests", "GreenPath_KnownGapDeclared");
+
+        var (output, exit) = RunRunner(
+            $"--expectations \"{dir}\" --expectations-require-match "
+            + $"--test GreenPath_KnownGapDeclared \"{SuitePath}\"");
+
+        AssertCount(output, "pass-known-gap:", 1);
+        Assert.Contains("all 1 entries matched a discovered test", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("UNMATCHED", output, StringComparison.Ordinal);
+        Assert.True(exit == 0, $"a matched entry must not fail the run. exit={exit}\n{output}");
+    }
+
+    /// <summary>
+    /// One letter missing from CodeunitName. Before #3123 this ran as a plain FAIL with
+    /// no mention of the entry anywhere; now it must name the entry, say the id was
+    /// loaded under a different name, and reach exit code 5.
+    /// </summary>
+    [SkippableFact]
+    public void RequireMatch_MisspelledCodeunitName_FailsTheRun_AndNamesTheCorrection()
+    {
+        TestArtifacts.SkipIfMissing();
+        var dir = OneEntryManifest("match-name-typo", "Expct Fixture Test", "GreenPath_KnownGapDeclared");
+
+        var (output, exit) = RunRunner(
+            $"--expectations \"{dir}\" --expectations-require-match "
+            + $"--test GreenPath_KnownGapDeclared \"{SuitePath}\"");
+
+        Assert.Contains("UNMATCHED", output, StringComparison.Ordinal);
+        Assert.Contains("known-gaps-fixture.json", output, StringComparison.Ordinal);
+        Assert.Contains("Expct Fixture Test.GreenPath_KnownGapDeclared", output, StringComparison.Ordinal);
+        Assert.Contains("object id 60810 was loaded as \"Expct Fixture Tests\"", output, StringComparison.Ordinal);
+        Assert.True(exit == 5,
+            $"an entry that matches no test must fail with exit 5 under --expectations-require-match. "
+            + $"exit={exit}\n{output}");
+    }
+
+    /// <summary>
+    /// The same hole through the other field: a misspelled Method on a codeunit that IS
+    /// loaded. The diagnostic must list the methods that do exist, so the correction is
+    /// in the message rather than a source-tree hunt away.
+    /// </summary>
+    [SkippableFact]
+    public void RequireMatch_MisspelledMethod_FailsTheRun_AndListsTheRealMethods()
+    {
+        TestArtifacts.SkipIfMissing();
+        var dir = OneEntryManifest("match-method-typo", "Expct Fixture Tests", "GreenPath_KnownGapDeclare");
+
+        var (output, exit) = RunRunner(
+            $"--expectations \"{dir}\" --expectations-require-match "
+            + $"--test GreenPath_KnownGapDeclared \"{SuitePath}\"");
+
+        Assert.Contains("declares no test method 'GreenPath_KnownGapDeclare'", output, StringComparison.Ordinal);
+        Assert.Contains("GreenPath_KnownGapDeclared", output, StringComparison.Ordinal);
+        Assert.True(exit == 5, $"expected exit 5, got {exit}\n{output}");
+    }
+
+    /// <summary>
+    /// WITHOUT the flag, the misspelled entry must behave exactly as it did before
+    /// #3123 — a plain failure, no audit output, exit 1. This pins the deliberate scope
+    /// choice: the audit is opt-in, so the shared auto-probed manifest cannot start
+    /// failing the runner-extras leg or AlRunner.Tests' own fixture runs.
+    /// </summary>
+    [SkippableFact]
+    public void WithoutRequireMatch_AMisspelledEntry_IsUnchanged()
+    {
+        TestArtifacts.SkipIfMissing();
+        var dir = OneEntryManifest("match-no-flag", "Expct Fixture Test", "GreenPath_KnownGapDeclared");
+
+        var (output, exit) = RunRunner(
+            $"--expectations \"{dir}\" --test GreenPath_KnownGapDeclared \"{SuitePath}\"");
+
+        Assert.DoesNotContain("UNMATCHED", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("match audit", output, StringComparison.Ordinal);
+        AssertCount(output, "  fail:", 1);
+        Assert.True(exit == 1, $"expected the pre-#3123 behaviour, exit 1. exit={exit}\n{output}");
+    }
+
+    /// <summary>
+    /// The flag must not be satisfiable by having nothing to check. Pointed at a
+    /// directory with no entries it fails rather than reporting a vacuous match.
+    /// </summary>
+    [SkippableFact]
+    public void RequireMatch_AgainstAnEmptyManifest_FailsRatherThanPassingVacuously()
+    {
+        TestArtifacts.SkipIfMissing();
+        var dir = Path.Combine(_scratchRoot, "match-empty");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "known-gaps-empty.json"), "[]");
+
+        var (output, exit) = RunRunner(
+            $"--expectations \"{dir}\" --expectations-require-match "
+            + $"--test GreenPath_PlainPass \"{SuitePath}\"");
+
+        Assert.Contains("declares 0 entries", output, StringComparison.Ordinal);
+        Assert.True(exit == 5, $"expected exit 5, got {exit}\n{output}");
+    }
 }

--- a/AlRunner.Tests/ExpectationManifestWiringTests.cs
+++ b/AlRunner.Tests/ExpectationManifestWiringTests.cs
@@ -353,15 +353,18 @@ public sealed class ExpectationManifestWiringTests : IDisposable
     public void RequireMatch_MisspelledCodeunitName_FailsTheRun_AndNamesTheCorrection()
     {
         TestArtifacts.SkipIfMissing();
-        var dir = OneEntryManifest("match-name-typo", "Expct Fixture Test", "GreenPath_KnownGapDeclared");
+        // Driven against a test that PASSES, so nothing else can move the exit code and
+        // the 5 is attributable to the audit alone.
+        var dir = OneEntryManifest("match-name-typo", "Expct Fixture Test", "GreenPath_PlainPass");
 
         var (output, exit) = RunRunner(
             $"--expectations \"{dir}\" --expectations-require-match "
-            + $"--test GreenPath_KnownGapDeclared \"{SuitePath}\"");
+            + $"--test GreenPath_PlainPass \"{SuitePath}\"");
 
+        AssertCount(output, "  fail:", 0);
         Assert.Contains("UNMATCHED", output, StringComparison.Ordinal);
         Assert.Contains("known-gaps-fixture.json", output, StringComparison.Ordinal);
-        Assert.Contains("Expct Fixture Test.GreenPath_KnownGapDeclared", output, StringComparison.Ordinal);
+        Assert.Contains("Expct Fixture Test.GreenPath_PlainPass", output, StringComparison.Ordinal);
         Assert.Contains("object id 60810 was loaded as \"Expct Fixture Tests\"", output, StringComparison.Ordinal);
         Assert.True(exit == 5,
             $"an entry that matches no test must fail with exit 5 under --expectations-require-match. "
@@ -377,15 +380,40 @@ public sealed class ExpectationManifestWiringTests : IDisposable
     public void RequireMatch_MisspelledMethod_FailsTheRun_AndListsTheRealMethods()
     {
         TestArtifacts.SkipIfMissing();
-        var dir = OneEntryManifest("match-method-typo", "Expct Fixture Tests", "GreenPath_KnownGapDeclare");
+        var dir = OneEntryManifest("match-method-typo", "Expct Fixture Tests", "GreenPath_PlainPas");
+
+        var (output, exit) = RunRunner(
+            $"--expectations \"{dir}\" --expectations-require-match "
+            + $"--test GreenPath_PlainPass \"{SuitePath}\"");
+
+        AssertCount(output, "  fail:", 0);
+        Assert.Contains("declares no test method 'GreenPath_PlainPas'", output, StringComparison.Ordinal);
+        Assert.Contains("GreenPath_PlainPass", output, StringComparison.Ordinal);
+        Assert.True(exit == 5, $"expected exit 5, got {exit}\n{output}");
+    }
+
+    /// <summary>
+    /// An unmatched entry alongside a real test failure. The audit must still SAY so —
+    /// that is the whole point — but exit code 1 outranks 5, because "a test failed" is
+    /// the more actionable statement and the manifest problem is already in the log.
+    /// This pins the ranking rather than leaving it to be rediscovered.
+    /// </summary>
+    [SkippableFact]
+    public void RequireMatch_AlongsideARealTestFailure_StillReports_ButTheFailureRanksFirst()
+    {
+        TestArtifacts.SkipIfMissing();
+        var dir = OneEntryManifest("match-and-fail", "Expct Fixture Test", "GreenPath_KnownGapDeclared");
 
         var (output, exit) = RunRunner(
             $"--expectations \"{dir}\" --expectations-require-match "
             + $"--test GreenPath_KnownGapDeclared \"{SuitePath}\"");
 
-        Assert.Contains("declares no test method 'GreenPath_KnownGapDeclare'", output, StringComparison.Ordinal);
-        Assert.Contains("GreenPath_KnownGapDeclared", output, StringComparison.Ordinal);
-        Assert.True(exit == 5, $"expected exit 5, got {exit}\n{output}");
+        // The entry did not match, so the known-gap reclassification never happened and
+        // the test failed plainly — exactly the pre-#3123 outcome, now explained.
+        AssertCount(output, "  fail:", 1);
+        Assert.Contains("UNMATCHED", output, StringComparison.Ordinal);
+        Assert.Contains("object id 60810 was loaded as \"Expct Fixture Tests\"", output, StringComparison.Ordinal);
+        Assert.True(exit == 1, $"a real test failure outranks the audit. exit={exit}\n{output}");
     }
 
     /// <summary>

--- a/AlRunner.Tests/ExpectationMatchAuditTests.cs
+++ b/AlRunner.Tests/ExpectationMatchAuditTests.cs
@@ -1,0 +1,179 @@
+// ExpectationMatchAuditTests — an expectations entry that matches NO test must be
+// reportable (issue #3123).
+//
+// tests/expectations/ was loud in both directions for a test the manifest MATCHED: a
+// test that passes against a known-gap entry fails the run with "Remove the entry", and
+// a test that raises an undeclared out-of-scope signal fails with "Add an entry". An
+// entry that matched nothing was the one hole. ExpectationManifest.Lookup returns null
+// for a name it does not hold, ExpectationClassifier takes its `entry == null` branch,
+// and the result is a plain pass or a plain fail — so one wrong letter in CodeunitName
+// or Method silently converted a declared, tracked gap into an undeclared one, and the
+// run went red in a way indistinguishable from a gap nobody had declared.
+//
+// Measured before the fix, against AlRunner.Tests/Fixtures/ExpectationsBundle (codeunit
+// 60810 "Expct Fixture Tests") on BC 28.1, one entry per run, only the quoted field
+// differing:
+//
+//   "CodeunitName": "Expct Fixture Tests"   → PASS (known-gap), pass-known-gap: 1, exit 0
+//   "CodeunitName": "Expct Fixture Test"    → FAIL, fail: 1,                      exit 1
+//   "Method": "GreenPath_KnownGapDeclare"   → FAIL, fail: 1,                      exit 1
+//
+// All three printed "[expectations] loaded 1 entry from <dir>" first. `loaded` was true
+// and said nothing about `matched`; the two failing runs produced no warning and no
+// mention of the entry anywhere.
+//
+// These are the pure tests over the audit itself. The end-to-end proof that the audit
+// reaches the exit code lives in ExpectationManifestWiringTests.
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ExpectationMatchAuditTests
+{
+    private static ExpectationManifest LoadOneEntryManifest(
+        string codeunitName, string method, int codeunitId = 60810)
+    {
+        var dir = TestScratch.Dir("al-runner-match-audit");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "known-gaps-fixture.json"), $$"""
+        [
+          {
+            "codeunitId": {{codeunitId}},
+            "CodeunitName": "{{codeunitName}}",
+            "Method": "{{method}}",
+            "Mode": "expect-fail-known-gap",
+            "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3123"
+          }
+        ]
+        """);
+        try { return ExpectationManifest.LoadFromDirectory(dir); }
+        finally { try { Directory.Delete(dir, recursive: true); } catch { } }
+    }
+
+    private static DiscoveredTestCodeunit TheFixtureCodeunit() =>
+        new(60810, "Expct Fixture Tests", "Codeunit60810",
+            new[] { "GreenPath_PlainPass", "GreenPath_KnownGapDeclared", "Drift_OosEntryButPasses" });
+
+    [Fact]
+    public void ExactEntry_MatchesTheDiscoveredCodeunit()
+    {
+        var manifest = LoadOneEntryManifest("Expct Fixture Tests", "GreenPath_KnownGapDeclared");
+        manifest.NoteDiscoveredTestCodeunit(TheFixtureCodeunit());
+
+        Assert.Empty(manifest.FindUnmatchedEntries());
+    }
+
+    [Fact]
+    public void OneWrongLetterInCodeunitName_IsReported_AndNamesTheIdItFoundInstead()
+    {
+        // The exact shape from the measurement above: id 60810 is right, the name is
+        // one letter short.
+        var manifest = LoadOneEntryManifest("Expct Fixture Test", "GreenPath_KnownGapDeclared");
+        manifest.NoteDiscoveredTestCodeunit(TheFixtureCodeunit());
+
+        var unmatched = Assert.Single(manifest.FindUnmatchedEntries());
+        Assert.Equal("Expct Fixture Test", unmatched.Entry.CodeunitName);
+        // The diagnostic must give the reader the correction, not just the complaint:
+        // the id WAS loaded, under this other name.
+        Assert.Contains("object id 60810 was loaded as \"Expct Fixture Tests\"",
+            unmatched.Diagnostic, StringComparison.Ordinal);
+        Assert.Contains("Check CodeunitName for a typo", unmatched.Diagnostic, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OneWrongLetterInMethod_IsReported_AndListsTheMethodsThatDoExist()
+    {
+        var manifest = LoadOneEntryManifest("Expct Fixture Tests", "GreenPath_KnownGapDeclare");
+        manifest.NoteDiscoveredTestCodeunit(TheFixtureCodeunit());
+
+        var unmatched = Assert.Single(manifest.FindUnmatchedEntries());
+        Assert.Contains("declares no test method 'GreenPath_KnownGapDeclare'",
+            unmatched.Diagnostic, StringComparison.Ordinal);
+        Assert.Contains("GreenPath_KnownGapDeclared", unmatched.Diagnostic, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CodeunitNotLoadedAtAll_IsReportedAsNotLoaded_NotAsATypo()
+    {
+        // The legitimate case: an entry naming a corpus codeunit during a run over a
+        // different bundle. It is still "unmatched" — deciding what that MEANS is the
+        // caller's job (--expectations-require-match), which is why the diagnostic must
+        // not accuse anyone of a typo here.
+        var manifest = LoadOneEntryManifest("Some Other Suite", "SomeTest", codeunitId: 60999);
+        manifest.NoteDiscoveredTestCodeunit(TheFixtureCodeunit());
+
+        var unmatched = Assert.Single(manifest.FindUnmatchedEntries());
+        Assert.Equal(
+            "no codeunit named \"Some Other Suite\" (id 60999) was loaded in this run",
+            unmatched.Diagnostic);
+        Assert.DoesNotContain("typo", unmatched.Diagnostic, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void NothingDiscoveredAtAll_LeavesEveryEntryUnmatched()
+    {
+        // Guards the direction that would make the audit decoration: with no discovery
+        // recorded, an entry must NOT read as matched.
+        var manifest = LoadOneEntryManifest("Expct Fixture Tests", "GreenPath_KnownGapDeclared");
+
+        Assert.Single(manifest.FindUnmatchedEntries());
+    }
+
+    [Fact]
+    public void WildcardEntry_MatchesWhenTheCodeunitHasAnyTestMethod()
+    {
+        var manifest = LoadOneEntryManifest("Expct Fixture Tests", "*");
+        manifest.NoteDiscoveredTestCodeunit(TheFixtureCodeunit());
+
+        Assert.Empty(manifest.FindUnmatchedEntries());
+    }
+
+    [Fact]
+    public void WildcardEntry_OnAMisspelledCodeunit_IsStillReported()
+    {
+        // "*" must widen the METHOD, never the codeunit — otherwise a wildcard entry
+        // would be exempt from the whole audit.
+        var manifest = LoadOneEntryManifest("Expct Fixture Test", "*");
+        manifest.NoteDiscoveredTestCodeunit(TheFixtureCodeunit());
+
+        Assert.Single(manifest.FindUnmatchedEntries());
+    }
+
+    [Fact]
+    public void EntryWrittenAgainstTheClrTypeName_Matches()
+    {
+        // TestExecutor.LookupExpectation honours entries written against either the AL
+        // object name or the CLR type name, so the audit must too — otherwise it would
+        // report a working entry as orphaned.
+        var manifest = LoadOneEntryManifest("Codeunit60810", "GreenPath_KnownGapDeclared");
+        manifest.NoteDiscoveredTestCodeunit(TheFixtureCodeunit());
+
+        Assert.Empty(manifest.FindUnmatchedEntries());
+    }
+
+    [Fact]
+    public void ADiscoveryFromAnyBundle_Counts()
+    {
+        // The manifest instance is shared across every bundle in a process, so an entry
+        // matched by the second bundle must not be reported because the first did not
+        // have it.
+        var manifest = LoadOneEntryManifest("Expct Fixture Tests", "GreenPath_KnownGapDeclared");
+        manifest.NoteDiscoveredTestCodeunit(
+            new DiscoveredTestCodeunit(60455, "Other Suite", "Codeunit60455", new[] { "Whatever" }));
+        manifest.NoteDiscoveredTestCodeunit(TheFixtureCodeunit());
+
+        Assert.Empty(manifest.FindUnmatchedEntries());
+    }
+
+    [Theory]
+    [InlineData("Codeunit60810", 60810)]
+    [InlineData("Codeunit6020", 6020)]
+    [InlineData("Codeunit", null)]
+    [InlineData("CodeunitAbc", null)]
+    [InlineData("SomethingElse60810", null)]
+    public void ParseAlObjectId_ReadsTheIdOffTheEmittedTypeName(string typeName, int? expected)
+    {
+        Assert.Equal(expected, AlRunner.TestExecutor.ParseAlObjectId(typeName));
+    }
+}

--- a/AlRunner/Infrastructure/ExpectationManifest.cs
+++ b/AlRunner/Infrastructure/ExpectationManifest.cs
@@ -60,6 +60,26 @@ public sealed record ExpectationEntry(
 }
 
 /// <summary>
+/// A test codeunit a run actually loaded, as the match audit sees it (#3123).
+/// <paramref name="ObjectId"/> is the AL object id parsed from the emitted CLR type
+/// name ("Codeunit60810"); null when the type name does not carry one.
+/// <paramref name="TestMethods"/> is the UNFILTERED set of [Test] methods the type
+/// declares, so a <c>--test</c> filter narrowing what RUNS cannot make an entry look
+/// orphaned.
+/// </summary>
+public sealed record DiscoveredTestCodeunit(
+    int? ObjectId,
+    string Name,
+    string TypeName,
+    IReadOnlyCollection<string> TestMethods);
+
+/// <summary>
+/// An entry the run loaded but could not attach to any discovered test, with a
+/// diagnostic saying what WAS found instead (#3123).
+/// </summary>
+public sealed record UnmatchedExpectation(ExpectationEntry Entry, string Diagnostic);
+
+/// <summary>
 /// Loaded view of all expectation files under a directory (default
 /// <c>tests/expectations/</c>). Use <see cref="Lookup"/> to query expectations
 /// at result-classification time.
@@ -71,10 +91,92 @@ public sealed class ExpectationManifest
 
     public IReadOnlyList<ExpectationEntry> Entries { get; }
 
+    // #3123: what this run actually loaded. The manifest instance is created once per
+    // process and shared across every bundle, so accumulating here — rather than per
+    // TestExecutor.Run — is what makes the audit whole-run rather than per-bundle.
+    private readonly List<DiscoveredTestCodeunit> _discovered = new();
+    private readonly object _discoveredLock = new();
+
     private ExpectationManifest(IReadOnlyList<ExpectationEntry> entries)
     {
         Entries = entries;
         _byName = entries.ToDictionary(e => (e.CodeunitName, e.Method), e => e);
+    }
+
+    /// <summary>
+    /// Record a test codeunit this run loaded. Called from the executor at discovery
+    /// time, BEFORE any filter narrows which methods run.
+    /// </summary>
+    public void NoteDiscoveredTestCodeunit(DiscoveredTestCodeunit codeunit)
+    {
+        lock (_discoveredLock) _discovered.Add(codeunit);
+    }
+
+    /// <summary>
+    /// Entries that no discovered test could ever have consulted (#3123).
+    ///
+    /// The manifest is loud in both directions for a test it MATCHED — a pass against a
+    /// known-gap entry says "remove the entry", an undeclared OOS throw says "add an
+    /// entry". An entry that matches NOTHING was the one hole: <see cref="Lookup"/>
+    /// returns null for a name it does not hold, the classifier takes its no-entry
+    /// branch, and the result is a plain pass or a plain fail. One wrong letter in
+    /// <c>CodeunitName</c> or <c>Method</c> therefore converted a declared, tracked gap
+    /// into an undeclared one with nothing said anywhere.
+    ///
+    /// This is deliberately NOT a verdict on its own: an entry naming a corpus codeunit
+    /// is legitimately unmatched in a run over a different bundle, which is most runs.
+    /// The caller decides what an unmatched entry means — see
+    /// <c>--expectations-require-match</c>, which is opted into only by an invocation
+    /// that really is expected to cover every entry.
+    /// </summary>
+    public IReadOnlyList<UnmatchedExpectation> FindUnmatchedEntries()
+    {
+        DiscoveredTestCodeunit[] discovered;
+        lock (_discoveredLock) discovered = _discovered.ToArray();
+
+        var unmatched = new List<UnmatchedExpectation>();
+        foreach (var entry in Entries)
+        {
+            // Mirrors LookupExpectation: entries may be written against the AL object
+            // name OR the CLR type name, and "*" matches every test method.
+            var named = discovered
+                .Where(d => d.Name == entry.CodeunitName || d.TypeName == entry.CodeunitName)
+                .ToList();
+            if (named.Any(d => entry.MatchesAll || d.TestMethods.Contains(entry.Method)))
+                continue;
+
+            unmatched.Add(new UnmatchedExpectation(entry, Explain(entry, named, discovered)));
+        }
+        return unmatched;
+    }
+
+    private static string Explain(
+        ExpectationEntry entry,
+        IReadOnlyList<DiscoveredTestCodeunit> named,
+        IReadOnlyList<DiscoveredTestCodeunit> discovered)
+    {
+        // Most specific first: the codeunit IS here, the method name is the problem.
+        if (named.Count > 0)
+        {
+            var methods = named.SelectMany(d => d.TestMethods).Distinct().OrderBy(m => m, StringComparer.Ordinal).ToList();
+            var shown = methods.Count <= 12
+                ? string.Join(", ", methods)
+                : string.Join(", ", methods.Take(12)) + $", … ({methods.Count} total)";
+            return $"codeunit \"{entry.CodeunitName}\" was loaded but declares no test method "
+                 + $"'{entry.Method}'. Its test methods: {shown}";
+        }
+
+        // Next: the object id IS here under a different name — the shape a one-letter
+        // CodeunitName typo produces.
+        var byId = discovered.Where(d => d.ObjectId == entry.CodeunitId).ToList();
+        if (byId.Count > 0)
+        {
+            var names = string.Join(", ", byId.Select(d => $"\"{d.Name}\"").Distinct());
+            return $"no codeunit named \"{entry.CodeunitName}\" was loaded; object id "
+                 + $"{entry.CodeunitId} was loaded as {names}. Check CodeunitName for a typo";
+        }
+
+        return $"no codeunit named \"{entry.CodeunitName}\" (id {entry.CodeunitId}) was loaded in this run";
     }
 
     /// <summary>

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -399,6 +399,19 @@ var extraPreprocessorSymbols = new List<string>();
 // directory activates classification, so ordinary runs outside this repo are
 // untouched.
 string? expectationsDirArg = null;
+// --expectations-require-match: opt-in assertion that THIS invocation is expected to
+// discover a test for every entry in the active expectations manifest, so an entry that
+// matches nothing is a failure (issue #3123, exit code 5).
+//
+// Opt-in, and it has to be. The expectations directory is auto-probed and shared by every
+// invocation in this repo: the corpus leg runs the three tests/al-language apps, while the
+// runner-extras leg, the --test Codeunit6020 xmlport slice and AlRunner.Tests' own fixture
+// bundles run against the SAME manifest, where those entries legitimately match nothing.
+// Anchoring on the entry's codeunitId instead of a flag was tried and rejected: AL object
+// ids are namespaced per app.json, so ids really are reused across bundles here (60820 is
+// a corpus test codeunit AND AlRunner.Tests/Fixtures/BcFloorSkip's "BC Floor Skip Future"),
+// which makes "id loaded under a different name" indistinguishable from a typo.
+bool expectationsRequireMatch = false;
 // --count-baseline PATH: opt-in test/app-group expected-count manifest (issue #1880;
 // see AlRunner/Infrastructure/CountBaseline.cs for the schema and rationale). Unlike
 // --expectations there is NO auto-probed default — a baseline built for a full-corpus
@@ -502,6 +515,7 @@ for (int i = 0; i < args.Length; i++)
     if (args[i] == "--per-suite") { bundledMode = false; continue; }
     if (args[i] == "--bundled") { bundledMode = true; continue; }
     if (args[i] == "--expectations" && i + 1 < args.Length) { expectationsDirArg = args[++i]; continue; }
+    if (args[i] == "--expectations-require-match") { expectationsRequireMatch = true; continue; }
     if (args[i] == "--count-baseline" && i + 1 < args.Length) { countBaselinePath = args[++i]; continue; }
     // #1821: the SAME --cache value also becomes the isolation root for every other
     // cache CacheRoots redirects (compiled-deps/workspace-deps/ncl-cecil/bc-symbols/
@@ -3924,6 +3938,72 @@ if (countBaseline != null)
     }
 }
 
+// ── Expectations match audit (issue #3123) ───────────────────────────────────────
+//
+// tests/expectations is loud in both directions for a test it MATCHED. An entry that
+// matched NOTHING was the hole: ExpectationManifest.Lookup returns null for a name it
+// does not hold, the classifier takes its no-entry branch, and one wrong letter in
+// CodeunitName or Method silently converts a declared, tracked gap into an undeclared
+// one — a red run indistinguishable from a gap nobody declared.
+//
+// Opt-in on purpose; see --expectations-require-match's declaration for why anchoring
+// on codeunitId instead would produce false positives on this repo's own fixtures.
+bool expectationsMatchFailure = false;
+if (expectationsRequireMatch)
+{
+    if (expectations == null)
+    {
+        // The flag asserts every entry matched. With no manifest active there are no
+        // entries to match, and reporting that as satisfied would be a vacuous green.
+        Console.Error.WriteLine(
+            "[expectations] --expectations-require-match was given but no expectations "
+            + "manifest is active — nothing to require a match against. Pass --expectations DIR, "
+            + "or drop the flag.");
+        expectationsMatchFailure = true;
+    }
+    else if (expectations.Entries.Count == 0)
+    {
+        Console.Error.WriteLine(
+            "[expectations] --expectations-require-match was given but the active manifest "
+            + "declares 0 entries — the flag would pass without checking anything. Check the "
+            + "--expectations path.");
+        expectationsMatchFailure = true;
+    }
+    else if (willResume)
+    {
+        // Same reasoning as --count-baseline above: this attempt ran a slice and hands
+        // the rest to a fresh process, so its discovery set is not the run's.
+        Console.Error.WriteLine(
+            "[expectations] match audit skipped: this attempt is resuming in a fresh process; "
+            + "the final attempt audits the whole run.");
+    }
+    else
+    {
+        var unmatched = expectations.FindUnmatchedEntries();
+        if (unmatched.Count > 0)
+        {
+            expectationsMatchFailure = true;
+            foreach (var u in unmatched)
+                Console.Error.WriteLine(
+                    $"[expectations] UNMATCHED: {u.Entry.SourceFile}: "
+                    + $"{u.Entry.CodeunitName}.{u.Entry.Method} ({u.Entry.Mode}) matched no test "
+                    + $"in this run — {u.Diagnostic}.");
+            Console.Error.WriteLine(
+                $"[expectations] {unmatched.Count} of {expectations.Entries.Count} entr"
+                + $"{(unmatched.Count == 1 ? "y" : "ies")} matched no test. An entry that matches "
+                + "nothing declares nothing: the test it names still fails as if undeclared. Fix "
+                + "the CodeunitName/Method, or remove the entry.");
+        }
+        else
+        {
+            // Never mute about its scope: a green audit says how much it accounted for.
+            Console.Error.WriteLine(
+                $"[expectations] match audit: all {expectations.Entries.Count} entries matched a "
+                + "discovered test.");
+        }
+    }
+}
+
 // Computed once regardless of --no-strict-exit: needed both as the process exit code
 // and as the "exitCode" field in --output-json, which reports the real outcome even
 // when the process itself exits 0 for JSON-only consumers.
@@ -3959,7 +4039,8 @@ int computedExitCode = 0;
         // "some tests failed". Below a compile failure, which is the more fundamental problem.
         : (execFail > 0 || carryIncomplete) ? 2  // bucket-level execution error, or a lost attempt
         : (failed + errored > 0 ? 1               // at least one test failed
-        : (countBaselineMismatch ? 4 : 0));      // #1880: suite's count didn't exactly match its baseline
+        : (countBaselineMismatch ? 4                    // #1880: suite's count didn't exactly match its baseline
+        : (expectationsMatchFailure ? 5 : 0)));  // #3123: an expectations entry matched no test
 }
 
 if (outputJson && willResume)

--- a/AlRunner/ProgramSupport/CliText.cs
+++ b/AlRunner/ProgramSupport/CliText.cs
@@ -627,6 +627,8 @@ internal static partial class ProgramSupport
         w.WriteLine("                            3  a bundle could not compile");
         w.WriteLine("                            4  --count-baseline: a suite's test or app-group count did");
         w.WriteLine("                               not exactly match its declared baseline (see --count-baseline)");
+        w.WriteLine("                            5  --expectations-require-match: an expectations entry matched");
+        w.WriteLine("                               no test in this run");
         w.WriteLine("  --no-strict-exit        Always exit 0 regardless of test outcome, so callers can");
         w.WriteLine("                          parse the JSON output without the process failing the step.");
         w.WriteLine("  --dump-csharp DIR       Write the intermediate C# emitted by BC's Compilation.Emit");
@@ -641,6 +643,18 @@ internal static partial class ProgramSupport
         w.WriteLine("                          invoked. Manifest drift is loud: an entry whose test now");
         w.WriteLine("                          passes, or an out-of-scope throw with no entry, fails");
         w.WriteLine("                          the run with a diagnostic naming the entry to fix.");
+        w.WriteLine("  --expectations-require-match");
+        w.WriteLine("                          Assert that this invocation discovers a test for EVERY entry");
+        w.WriteLine("                          in the active manifest, and fail (exit 5) on any that");
+        w.WriteLine("                          matched nothing, naming the file, the codeunit and the");
+        w.WriteLine("                          method. Without it such an entry is silently inert: one");
+        w.WriteLine("                          wrong letter in CodeunitName or Method untracks a declared");
+        w.WriteLine("                          gap, and the test it names fails as if undeclared (#3123).");
+        w.WriteLine("                          Off by default, for the same reason as --count-baseline —");
+        w.WriteLine("                          the manifest is shared across invocations, so an entry");
+        w.WriteLine("                          naming a corpus codeunit legitimately matches nothing in a");
+        w.WriteLine("                          run over a different bundle. Only pass it where covering");
+        w.WriteLine("                          every entry is actually true.");
         w.WriteLine("  --count-baseline PATH   Load a per-suite test/app-group expected-count manifest");
         w.WriteLine("                          (schema: AlRunner/Infrastructure/CountBaseline.cs) and");
         w.WriteLine("                          fail the run (exit 4) if a suite's count does not exactly");

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -741,6 +741,17 @@ public sealed class TestExecutor
 
             var loopSw = System.Diagnostics.Stopwatch.StartNew();
             var orderedMethods = OrderTestMethodsBySourceDeclaration(t);
+
+            // #3123: record what this run actually loaded, so an expectations entry that
+            // could never have matched anything can be REPORTED rather than silently doing
+            // nothing. Deliberately the UNFILTERED test-method list and deliberately here,
+            // before --test/--exclude narrow what runs: the audit asks "does this entry name
+            // something that exists", not "did this entry get consulted".
+            Expectations?.NoteDiscoveredTestCodeunit(new Infrastructure.DiscoveredTestCodeunit(
+                ParseAlObjectId(t.Name),
+                displayName,
+                t.Name,
+                orderedMethods.Where(IsTestMethod).Select(m => m.Name).ToArray()));
             try
             {
                 for (int mi = 0; mi < orderedMethods.Length; mi++)
@@ -996,6 +1007,19 @@ public sealed class TestExecutor
     {
         var qualified = $"{codeunit}.{method}".ToLowerInvariant();
         return qualified.Contains(filterLower) || method.ToLowerInvariant().Contains(filterLower);
+    }
+
+    /// <summary>
+    /// The AL object id carried by an emitted test codeunit's CLR type name
+    /// ("Codeunit60810" → 60810). Null when the name does not carry one — the audit in
+    /// <see cref="Infrastructure.ExpectationManifest.FindUnmatchedEntries"/> then simply
+    /// has one fewer clue to offer, and never guesses.
+    /// </summary>
+    internal static int? ParseAlObjectId(string typeName)
+    {
+        const string prefix = "Codeunit";
+        if (!typeName.StartsWith(prefix, StringComparison.Ordinal)) return null;
+        return int.TryParse(typeName.AsSpan(prefix.Length), out var id) ? id : null;
     }
 
     private static bool IsTestCodeunit(Type t)

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -20,6 +20,56 @@ outside this repo behaves exactly as if the mechanism did not exist. Pass
 directory must exist). A malformed manifest aborts the invocation with exit
 code 2 before a single test runs.
 
+### `--expectations-require-match`: an entry that matches nothing (#3123)
+
+Drift is loud in both directions for a test the manifest **matched**: a test that
+passes against an entry fails with "remove the entry", a test that raises an
+undeclared out-of-scope signal fails with "add an entry". An entry that matches
+**nothing at all** was the one hole. `Lookup` returns null for a name it does not
+hold, the classifier takes its no-entry branch, and the result is a plain pass or a
+plain fail — so one wrong letter in `CodeunitName` or `Method` silently converts a
+declared, tracked gap into an undeclared one, and the run goes red in a way
+indistinguishable from a gap nobody declared.
+
+Measured on `AlRunner.Tests/Fixtures/ExpectationsBundle` (codeunit 60810
+`"Expct Fixture Tests"`), one entry per run, only the quoted field differing:
+
+| entry | result | exit |
+|---|---|---|
+| `"CodeunitName": "Expct Fixture Tests"` | `PASS (known-gap)`, `pass-known-gap: 1` | 0 |
+| `"CodeunitName": "Expct Fixture Test"` | `FAIL`, `fail: 1`, no diagnostic anywhere | 1 |
+| `"Method": "GreenPath_KnownGapDeclare"` | `FAIL`, `fail: 1`, no diagnostic anywhere | 1 |
+
+All three printed `[expectations] loaded 1 entry from <dir>` first. `loaded` is true
+and says nothing about `matched`.
+
+`--expectations-require-match` asserts that **this invocation discovers a test for
+every entry in the active manifest**, and fails with exit code 5 on any that matched
+nothing, naming the file, the codeunit, the method, and what was found instead — the
+object id loaded under a different name, or the test methods that do exist. A green
+audit says how much it accounted for (`match audit: all 17 entries matched a
+discovered test`), so it is never mute about its scope, and it refuses to run against
+an inactive or empty manifest rather than passing vacuously.
+
+It is **opt-in**, for the same reason `--count-baseline` is. The expectations
+directory is auto-probed and shared by every invocation in this repo: the corpus leg
+runs the three `tests/al-language` apps, while the runner-extras leg, the
+`--test Codeunit6020` xmlport slice and `AlRunner.Tests`' own fixture bundles run
+against the same manifest, where those entries legitimately match nothing. Only
+`.github/workflows/bc-tests.yml`'s full-corpus step passes the flag, because only
+there is "every entry is covered" true.
+
+Anchoring on the entry's `codeunitId` instead of a flag was tried and rejected. AL
+object ids are namespaced per `app.json`, so ids really are reused across bundles
+here — 60820 is a corpus test codeunit **and**
+`AlRunner.Tests/Fixtures/BcFloorSkip`'s `"BC Floor Skip Future"` — which makes "the
+id was loaded under a different name" indistinguishable from a typo.
+
+The residual, deliberately: an entry with **both** a wrong `CodeunitName` and a wrong
+`codeunitId` is still reported, but the diagnostic can only say the codeunit was not
+loaded. And an entry naming a codeunit no run covers is never audited at all, because
+no invocation can honestly assert it should have been.
+
 ## Layout
 
 ```
@@ -236,3 +286,8 @@ a clean run does not hide manifested deviations from the corpus.
 6. **Schema validation.** The loader (`ExpectationManifest.cs`) rejects
    unknown `Mode` values and missing required fields. Runner startup fails
    loudly if any expectation file is malformed.
+7. **`CodeunitName` and `Method` must name something that exists.** The schema
+   cannot check this — it is a join against the tests, not a property of the
+   file — so the full-corpus CI leg runs with `--expectations-require-match`
+   and fails on an entry that matched no test. See the section above; a typo
+   here does not make the entry invalid, it makes it inert.


### PR DESCRIPTION
Closes #3123

## The hole

`tests/expectations/` is loud in both directions for a test the manifest **matched**: a test that passes against a known-gap entry fails the run with "Remove the entry", an undeclared out-of-scope throw fails with "Add an entry". An entry that matched **nothing at all** was the one hole. `ExpectationManifest.Lookup` returns null for a name it does not hold, `ExpectationClassifier` takes its `entry == null` branch, and the result is a plain pass or a plain fail — so one wrong letter in `CodeunitName` or `Method` silently converted a declared, tracked gap into an undeclared one, and the run went red in a way indistinguishable from a gap nobody had declared.

Found reviewing PR #3093 against #3090, #2975 and #3079: two agents landed the same two `known-gaps` entries independently, and checking whether either version actually matched the corpus object had to be done by hand, because the runner would not say.

## RED → GREEN

**RED-A, the hole itself.** `AlRunner.Tests/Fixtures/ExpectationsBundle` (codeunit 60810 `"Expct Fixture Tests"`), unmodified `main`, BC 28.1.49838.53910. One entry per run, `expect-fail-known-gap` on a test that fails by design; only the quoted field differs.

| entry | runner said | exit |
|---|---|---|
| `"CodeunitName": "Expct Fixture Tests"` | `PASS (known-gap)` · `pass-known-gap: 1` · `fail: 0` | **0** |
| `"CodeunitName": "Expct Fixture Test"` | `FAIL Codeunit60810.GreenPath_KnownGapDeclared` · `fail: 1` | **1** |
| `"Method": "GreenPath_KnownGapDeclare"` | `FAIL Codeunit60810.GreenPath_KnownGapDeclared` · `fail: 1` | **1** |

All three printed `[expectations] loaded 1 entry from <dir>` first. `loaded` was true and said nothing about `matched`; the two failing runs mentioned the entry nowhere else, and their output was comparable to a run with an empty manifest directory. On the same binary, `--expectations-require-match` exits 2 with `Unknown option`.

**RED-B, the suite is not satisfiable by a no-op.** With `FindUnmatchedEntries` stubbed to return an empty list and everything else in place:

```
Failed!  - Failed: 5, Passed: 9, Total: 14   (ExpectationMatchAuditTests)
  OneWrongLetterInCodeunitName_IsReported_AndNamesTheIdItFoundInstead
  OneWrongLetterInMethod_IsReported_AndListsTheMethodsThatDoExist
  CodeunitNotLoadedAtAll_IsReportedAsNotLoaded_NotAsATypo
  NothingDiscoveredAtAll_LeavesEveryEntryUnmatched
  WildcardEntry_OnAMisspelledCodeunit_IsStillReported
```

The stub was restored from a copy taken outside the repository and `git status` confirmed byte-exact before re-running.

**GREEN.**

| run | result |
|---|---|
| `ExpectationMatchAuditTests` (pure) | 14 passed, 0 failed |
| `ExpectationManifestWiringTests` (spawns the real CLI) | 12 passed, 0 failed |
| `CliDocumentationTests` + the four other expectation classes | 66 passed, 0 failed |
| `*Workflow*` guards + wiring | 47 passed, 0 failed |
| **the real corpus**, CI's invocation plus the new flag | **2684 pass / 0 fail, exit 0**, `[expectations] match audit: all 17 entries matched a discovered test`, 2m13s |

The end-to-end diagnostic the misspelled entry now produces:

```
[expectations] UNMATCHED: known-gaps-fixture.json: Expct Fixture Test.GreenPath_PlainPass
  (ExpectFailKnownGap) matched no test in this run — no codeunit named "Expct Fixture Test"
  was loaded; object id 60810 was loaded as "Expct Fixture Tests". Check CodeunitName for a typo.
[expectations] 1 of 1 entry matched no test. An entry that matches nothing declares nothing:
  the test it names still fails as if undeclared. Fix the CodeunitName/Method, or remove the entry.
```

## What changed

The executor records every test codeunit it loads — object id parsed off the emitted CLR type name, AL object name, CLR type name, and the **unfiltered** `[Test]` method list, so a `--test` filter narrowing what *runs* cannot make an entry look orphaned. `FindUnmatchedEntries` reports entries no discovered test could have consulted, and the diagnostic carries the correction rather than just the complaint: the id loaded under a different name, or the methods that do exist.

`--expectations-require-match` turns that into a verdict, exit code 5. `.github/workflows/bc-tests.yml` passes it on the full-corpus step only.

## Why it is opt-in, and what was tried first

Anchoring on the entry's `codeunitId` — so no flag would be needed — was tried and **rejected on a measurement**. AL object ids are namespaced per `app.json`, so they really are reused across bundles here: **60820** is a corpus test codeunit *and* `AlRunner.Tests/Fixtures/BcFloorSkip`'s `"BC Floor Skip Future"`, and **61200** collides the same way. That makes "the id was loaded under a different name" indistinguishable from a typo, and would have turned `AlRunner.Tests`' own fixture runs red.

So the flag is the scoping mechanism, same reasoning as `--count-baseline`: the expectations directory is auto-probed and shared by every invocation here, and an entry naming a corpus codeunit legitimately matches nothing in the runner-extras leg, the `--test Codeunit6020` xmlport slice, or a fixture run. Only the full-corpus step can honestly assert coverage, so only it passes the flag.

## Why it cannot pass vacuously

- No manifest active → fails, rather than reporting that zero entries all matched.
- Manifest with 0 entries → fails, with `declares 0 entries`.
- A green audit **names its scope**: `all 17 entries matched a discovered test`. A tick is never mute about how much it accounted for.
- A resumed attempt stands down **loudly**, pointing at the final attempt, the same shape `--count-baseline` uses.
- `WithoutRequireMatch_AMisspelledEntry_IsUnchanged` pins that the default is untouched, so the shared auto-probed manifest cannot start failing other legs.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site? Yes, and it is filed.** `CountBaselineCheck.Evaluate` does `if (!actualBySuite.TryGetValue(suite, out var actual)) continue;` — a declared baseline suite that produced no bucket yields neither a DROP nor a GROWTH. That is the same defect in the guard whose own message is "a bundle or app group may have silently stopped being discovered" (#1880): a whole suite can vanish and the leg stays green. The `continue` is load-bearing today — one baseline file has four keys and two `--count-baseline` invocations each cover a different subset — so fixing it means deciding how an invocation declares which keys it covers, which is a design change to the baseline's shape rather than a line. Filed as #3130 rather than folded in; four other open PRs are touching `tests/expectations/` right now.

2. **Does a sibling function make the same assumption?** `TestExclusionFilter.IsExcluded` has the identical join shape and is **not** a defect: an `--exclude-test` pattern matching nothing excludes nothing, so the failure direction is "runs more than asked". Checked, not assumed.

3. **Two paths writing the same state?** The manifest already guarded intra-file and cross-file duplicate entries at load time; the entry-to-test join was the one identity check it did not make. That asymmetry is what this closes.

**Deliberately left out:** an entry wrong in **both** `CodeunitName` and `codeunitId` is still reported, but the diagnostic can only say the codeunit was not loaded — there is nothing left to anchor the correction on. Documented in `docs/expectations.md` rather than left to be discovered.

## Not a claim about BC

Nothing here asserts anything about Business Central — it is the runner's own expectations machinery, so it owes no upstream corpus test. (The two `known-gaps` entries that led me here *do* assert BC behaviour, and they were already adjudicated upstream by corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#185; that half is settled on the issues, not in this diff.)

## Related, without closing any of them

While reviewing PR #3093 I closed it unmerged — its two entries had already landed on `main` at `1aef9e75` via PR #3079 — and issue #3090 was retired as a duplicate of #2975, which survives as the tracker for those entries and stays open. Reasoning is recorded on each thread. None of that is in this diff.

---

Written by an agent (`stma-auto-1`, cycle 138) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
