### PR TITLE
fix(preflight): build both halves of the stray-graph FAIL, and name a stray when graphify is absent

### DIFF
--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -1359,10 +1359,31 @@ def classify_graphify(st: GraphifyState) -> CheckResult:
         "graph answers `No matching nodes found.` -- and exits 0 -- for symbols that "
         "exist, which is indistinguishable from a true negative.")
     if not st.binary:
+        # No querier, so no wrong answer is possible and nothing here may halt a cycle.
+        # The stray repair is still reported: probe_graphify deletes a stray before this
+        # branch is ever reached, and an un-deletable one stays on disk and starts
+        # answering false negatives the moment somebody installs graphify in this
+        # checkout. Reporting only "not on PATH" dropped both facts on the floor.
+        detail, remedy = [], ("Install it, or use tools/context-pack.py and rg instead. "
+                              "Nothing is blocked.")
+        if st.stray_kept:
+            detail = ([f"a graph outside {GRAPHIFY_DIR}/ could not be removed and is "
+                       f"still there:"]
+                      + [f"stray: {p}" for p in st.stray_kept]
+                      + ([st.stray_error] if st.stray_error else [])
+                      + [stray_why,
+                         "Not a halt while graphify is absent -- nothing can read it "
+                         "yet -- but it answers false negatives as soon as one is "
+                         "installed here."])
+            remedy = ("Delete it by hand -- it is gitignored derived data:\n"
+                      + "\n".join(f"  rm -rf {p}" for p in st.stray_kept)
+                      + "\n" + remedy)
+        elif st.stray_removed:
+            detail = [f"removed a stray graph that would have answered false negatives: {p}"
+                      for p in st.stray_removed] + [stray_why]
         return CheckResult(name=name, status="WARN", command="command -v graphify",
                            summary="graphify is not on PATH",
-                           remedy="Install it, or use tools/context-pack.py and rg instead. "
-                                  "Nothing is blocked.")
+                           detail=detail, remedy=remedy)
     # A stray that is still there is the one condition here that can halt a cycle: it
     # produces wrong answers, silently, and no rebuild fixes it.
     if st.stray_kept:

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -818,6 +818,16 @@ shutil.rmtree(_g, ignore_errors=True)
 
 # The FAIL path has to be reachable, not merely classifiable: a directory whose parent
 # denies unlink. Skipped as root, which ignores the permission bits.
+#
+# The FAIL needs BOTH halves of its precondition, and the test has to build both. An
+# un-deletable stray is one half; `graphify` being installed is the other, because a
+# stray is only dangerous while something can query it, so classify_graphify answers
+# "not on PATH" first on a machine without the binary. An earlier version of this block
+# built the stray and read the binary off the machine running the tests, which passes on
+# a developer box and fails on a CI runner -- red on three unrelated PRs at once (#3140).
+# `graphify` is never executed here: probe_graphify guards both of its `run` calls on
+# `not st.stray_kept`, so a kept stray means no subprocess, and the path only has to
+# exist as a string.
 if os.geteuid() != 0:
     import stat as _stat
     _g = tempfile.mkdtemp(prefix="preflight-stray-keep-")
@@ -826,18 +836,69 @@ if os.geteuid() != 0:
     with open(os.path.join(_g, "graphify-out", "graph.json"), "w") as fh:
         fh.write("{}")
     os.chmod(_g, _stat.S_IRUSR | _stat.S_IXUSR)
+    _real_which = shutil.which
+    pf.shutil.which = lambda c, *a, **k: ("/fake/bin/graphify" if c == "graphify"
+                                          else _real_which(c, *a, **k))
     try:
         _st = pf.probe_graphify(_g, timeout=10)
         _r = pf.classify_graphify(_st)
+        check("the test supplies the graphify binary instead of reading the machine",
+              _st.binary == "/fake/bin/graphify", str(_st.binary))
         check("a stray that cannot be deleted is kept and reported",
               _st.stray_kept == [os.path.join(_g, "graphify-out")], str(_st.stray_kept))
         check("an un-deletable stray reaches FAIL end to end, not just in a fixture",
               _r.status == "FAIL", _r.summary)
         check("and that FAIL is what halts a cycle",
               pf.overall_exit([_r], strict=False) == 1)
+        # A kept stray must not spawn graphify -- the binary above does not exist, so a
+        # regression that dropped the `not st.stray_kept` guard would show up as rc 127.
+        check("a kept stray stops preflight running graphify at all",
+              _st.rebuilt is False and _st.query_rc is None,
+              f"rebuilt={_st.rebuilt} query_rc={_st.query_rc}")
+
+        # Same machine, same stray, no binary: the danger needs a querier, so this is a
+        # WARN and the cycle continues. The stray still has to be NAMED -- it stays on
+        # disk and starts answering false negatives the moment graphify is installed.
+        pf.shutil.which = lambda c, *a, **k: (None if c == "graphify"
+                                              else _real_which(c, *a, **k))
+        _st_nb = pf.probe_graphify(_g, timeout=10)
+        _r_nb = pf.classify_graphify(_st_nb)
+        check("a kept stray without graphify installed does not halt a cycle",
+              _r_nb.status == "WARN", _r_nb.status)
+        check("but the kept stray is still named, not dropped for want of a binary",
+              os.path.join(_g, "graphify-out") in " ".join([_r_nb.summary, *_r_nb.detail,
+                                                           _r_nb.remedy or ""]),
+              _r_nb.summary + str(_r_nb.detail))
+        check("and the remedy is deleting the stray, not installing graphify",
+              "rm -rf" in (_r_nb.remedy or ""), str(_r_nb.remedy))
     finally:
+        pf.shutil.which = _real_which
         os.chmod(_g, _stat.S_IRWXU)
         shutil.rmtree(_g, ignore_errors=True)
+
+# A stray preflight SUCCESSFULLY removed is a real change to the machine, and
+# probe_graphify's contract is that both repairs are reported, "never folded into a
+# silent PASS". Without a binary the classifier returned "graphify is not on PATH" and
+# said nothing about the directory it had just deleted (#3140).
+_g = tempfile.mkdtemp(prefix="preflight-stray-nobin-")
+os.makedirs(os.path.join(_g, "AlRunner"))
+os.makedirs(os.path.join(_g, "graphify-out"))
+_real_which = shutil.which
+pf.shutil.which = lambda c, *a, **k: (None if c == "graphify" else _real_which(c, *a, **k))
+try:
+    _st = pf.probe_graphify(_g, timeout=10)
+    _r = pf.classify_graphify(_st)
+    check("a stray is deleted even when graphify is not installed",
+          _st.stray_removed == [os.path.join(_g, "graphify-out")]
+          and not os.path.exists(os.path.join(_g, "graphify-out")), str(_st.stray_removed))
+    check("the deletion is reported even when graphify is not installed",
+          os.path.join(_g, "graphify-out") in " ".join([_r.summary, *_r.detail]),
+          _r.summary + str(_r.detail))
+    check("reporting the deletion does not turn a missing binary into a halt",
+          _r.status == "WARN", _r.status)
+finally:
+    pf.shutil.which = _real_which
+    shutil.rmtree(_g, ignore_errors=True)
 
 # ---- nav-bc-decompiler: configured is not the same as usable
 def dec_with(**kw):


### PR DESCRIPTION
Closes #3140

`preflight.py unit tests` was red on PRs #3136, #3125 and #3101 — three unrelated
branches — so the defect is on `main`. Log read from run 34039038698; I did not re-run it.

```
FAIL an un-deletable stray reaches FAIL end to end, not just in a fixture   graphify is not on PATH
FAIL and that FAIL is what halts a cycle
FAILED: 2 check(s)
```

## Diagnosis

Both checks are in the one block that drives `probe_graphify` end to end. It builds a real
un-deletable stray graph directory and asserts `classify_graphify` returns FAIL.
`classify_graphify` reaches that FAIL branch only past an earlier `if not st.binary:` guard
returning WARN "graphify is not on PATH". The test built one half of the precondition and
read the other half — a `graphify` binary — off the machine running it. GitHub runners have
no `graphify`; my machine does.

## Which option, and why

**Option 1: the test was wrong, the production ordering is right.**

`tools/test_preflight.py` pins the severity policy explicitly: "a tool being absent or
unusable never halts a cycle - only a wrong ANSWER does". A stray graph is dangerous for one
specific reason — `graphify query` reads it and answers a confident false negative that
exits 0. With no `graphify` on the machine, nothing reads it and no wrong answer is possible.
Making it FAIL ahead of the PATH check would halt a cycle for a condition that cannot occur
on that machine, which is the thing the policy forbids, and it would put `classify_graphify`
out of step with the ordering every other classifier in the file uses.

So the FAIL stays behind the PATH check, and the test now builds both halves of its own
precondition by stubbing the PATH lookup — the same technique the passing fixture-based
checks around it already use. `graphify` is still never executed: `probe_graphify` guards
both of its `run` calls on `not st.stray_kept`, so a kept stray means no subprocess and the
binary only has to exist as a string. A new check pins that, so a regression dropping the
guard shows up as a failure instead of quietly running a path that does not exist.

I did not skip the checks when `graphify` is absent. The coverage is the point.

## A second defect, found while reading that guard

The `not st.binary` guard returned before reporting the stray in either direction, and that
is a production bug, not a test artifact.

`probe_graphify` deletes a stray before the guard is ever consulted, and its docstring says
both repairs are "reported in the result, never folded into a silent PASS". On a machine
without `graphify` neither half held: a stray it had just deleted went unmentioned, and a
stray it could not delete went unmentioned while staying on disk. The un-deletable case is
the one that matters — the directory sits there and starts answering false negatives the
moment anyone installs `graphify` in that checkout, and the report that could have warned
about it said "Nothing is blocked."

Both are now named in the not-on-PATH WARN, with `rm -rf <stray>` as the remedy. Still a
WARN, so the severity policy is unchanged and the check that pins it still passes.

## The three shape questions

1. **Same wrong pattern at another call site?** One other block calls `probe_graphify`
   end to end (the `preflight-stray-rm-` deletion block). Its claims are binary-independent,
   so it passes either way — confirmed empirically, it was green on the stripped PATH before
   this change. The new no-binary block covers the same operation with the binary explicitly
   absent, so the pair now covers both states deliberately. The three `mcp_call` sites build
   their own subject (`sys.executable`, an explicit nonexistent path) and do not read the
   machine.
2. **Sibling function with the same assumption?** `classify_lsp` and `classify_decompiler`
   both have tool-absent early returns, but zero FAIL branches between them — I counted.
   Nothing can be masked, so `classify_graphify` is the only place this precedence question
   exists. `probe_lsp` reads `shutil.which("csharp-ls")` but no test drives it end to end.
3. **Two paths writing the same state with different invariants?** Yes, and that is the
   second defect above. `stray_removed` and `stray_kept` are written in one place and read
   in two classifier paths; the healthy path reported them and the not-on-PATH path dropped
   them.

## RED to GREEN

RED, matching CI exactly:

```
$ env PATH=/usr/bin:/bin python3 tools/test_preflight.py | tail -1
FAILED: 2 check(s): an un-deletable stray reaches FAIL end to end, not just in a fixture, and that FAIL is what halts a cycle
```

After the test change alone, the original two pass and the three new production claims fail
identically with and without `graphify` installed — which is the property being restored:
the result no longer depends on the machine.

GREEN, after the `classify_graphify` change:

```
$ env PATH=/usr/bin:/bin python3 tools/test_preflight.py | tail -1   # rc 0
all checks passed
$ python3 tools/test_preflight.py | tail -1                          # rc 0
all checks passed
```

CI runs exactly `python3 tools/test_preflight.py` (`pr-check.yml:399`).

## Scope

This asserts nothing about Business Central's behavior, so it owes nothing to the upstream
corpus. It touches no AL, no `AlRunner/`, and no `.app` handling — `tools/` only, so the
"Tests updated" gate does not apply.

---

Opened by the agent **impl-5** on the account holder's behalf.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
