### PR TITLE
test(guards): stop the _BCVersion drift gate walking into every agent's worktree

### DIFF
--- a/AlRunner.Tests/BCVersionDefaultTests.cs
+++ b/AlRunner.Tests/BCVersionDefaultTests.cs
@@ -17,23 +17,85 @@ namespace AlRunner.Tests;
 /// still wins everywhere it does today. These tests are the drift gate that keeps that
 /// true — they fail the moment a second per-project default reappears (the actual defect
 /// this issue reported), or the shared declaration loses its override guard.
+///
+/// Issue #3139: the scan below used to be
+/// `Directory.EnumerateFiles(RepoRoot, "*.csproj", SearchOption.AllDirectories)` with a
+/// single `tests/al-language/` prefix skip, which walked straight into `.claude/worktrees/`.
+/// Every concurrent agent keeps a FULL checkout of this repository there, so the guard read
+/// 126 project files on a developer box against the repository's own 6 — 95% of its input was
+/// other people's branches. It was latent rather than live (nothing there declared
+/// `_BCVersion` at the time), and that is the problem, not the reprieve: the verdict depended
+/// on what other agents happened to have checked out. Worse, `.claude/worktrees/` is
+/// gitignored, so it does not exist on a CI runner — the guard was wrong locally and right in
+/// CI, the one combination no CI leg can ever surface. The walk is now explicit about what it
+/// descends into, refuses an empty result, and holds a floor on what it found.
 /// </summary>
 public class BCVersionDefaultTests
 {
     private static readonly string RepoRoot = Path.GetFullPath(
         Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
 
-    [Fact]
-    public void NoProjectFile_DeclaresItsOwnBCVersionDefault()
+    /// <summary>
+    /// Directory names the project walk never descends into.
+    ///
+    /// `.claude` is the load-bearing one and the reason #3139 exists — agent worktrees under
+    /// `.claude/worktrees/` are full checkouts of this repository, so walking them makes this
+    /// guard's answer depend on other branches. `al-language` is the read-only upstream
+    /// submodule, skipped by NAME rather than by a `tests/al-language/` path prefix so that it
+    /// is still skipped when it appears at another depth (a worktree's own copy sits at
+    /// `.claude/worktrees/&lt;id&gt;/tests/al-language/`, which the old prefix test never matched).
+    /// The build-output and tooling names are ordinary hygiene.
+    /// </summary>
+    private static readonly string[] SkippedDirectories =
+    {
+        "bin", "obj", ".git", ".claude", ".vs", "node_modules", "packages", "al-language",
+    };
+
+    /// <summary>
+    /// Every MSBuild project file belonging to THIS repository, discovered by walking rather
+    /// than by a maintained list, and never leaving the repository's own tree.
+    /// Throws when the walk finds nothing: a scan with nothing to scan reports zero offenders
+    /// and reads as success, which is the worst property a guard can have (the #3021 /
+    /// #3092 non-vacuity rule).
+    /// </summary>
+    internal static IReadOnlyList<string> RepositoryProjectFiles(string root)
+    {
+        var found = new List<string>();
+        var pending = new Stack<string>();
+        pending.Push(root);
+
+        while (pending.Count > 0)
+        {
+            var dir = pending.Pop();
+            foreach (var sub in Directory.EnumerateDirectories(dir))
+            {
+                if (SkippedDirectories.Contains(Path.GetFileName(sub), StringComparer.Ordinal)) continue;
+                pending.Push(sub);
+            }
+
+            found.AddRange(Directory.EnumerateFiles(dir, "*.csproj"));
+        }
+
+        if (found.Count == 0)
+            throw new InvalidOperationException(
+                $"Found no *.csproj under '{root}'. A scan with nothing to scan reports zero "
+                + "offenders and reads as a pass, so it fails here instead (#3139).");
+
+        found.Sort(StringComparer.Ordinal);
+        return found;
+    }
+
+    /// <summary>
+    /// Live `&lt;_BCVersion` declarations in the project files under <paramref name="root"/>,
+    /// as "relative/path: line". Whole-line comments do not count — a commented-out
+    /// declaration is history, not a default.
+    /// </summary>
+    internal static IReadOnlyList<string> BCVersionDeclarations(string root)
     {
         var offenders = new List<string>();
-        foreach (var file in Directory.EnumerateFiles(RepoRoot, "*.csproj", SearchOption.AllDirectories))
+        foreach (var file in RepositoryProjectFiles(root))
         {
-            // tests/al-language is a read-only upstream submodule; not ours to police,
-            // and it declares no BC-version defaults of its own anyway.
-            var rel = Path.GetRelativePath(RepoRoot, file).Replace('\\', '/');
-            if (rel.StartsWith("tests/al-language/", StringComparison.Ordinal)) continue;
-
+            var rel = Path.GetRelativePath(root, file).Replace('\\', '/');
             foreach (var line in File.ReadAllLines(file))
             {
                 var trimmed = line.TrimStart();
@@ -42,7 +104,27 @@ public class BCVersionDefaultTests
                     offenders.Add($"{rel}: {line.Trim()}");
             }
         }
+        return offenders;
+    }
 
+    [Fact]
+    public void NoProjectFile_DeclaresItsOwnBCVersionDefault()
+    {
+        var projects = RepositoryProjectFiles(RepoRoot);
+
+        // Anti-vacuity floor. RepositoryProjectFiles already refuses an empty walk; this
+        // catches the subtler version where an added exclusion quietly narrows the scan to a
+        // handful of files and the guard reports a clean tree it never looked at. The
+        // repository tracks six .csproj files; naming two of them keeps the floor honest even
+        // if the count changes.
+        Assert.True(projects.Count >= 6,
+            $"expected at least the repository's six tracked project files, found {projects.Count}: "
+            + string.Join(", ", projects.Select(p => Path.GetRelativePath(RepoRoot, p))));
+        var rels = projects.Select(p => Path.GetRelativePath(RepoRoot, p).Replace('\\', '/')).ToList();
+        Assert.Contains("AlRunner/AlRunner.csproj", rels);
+        Assert.Contains("AlRunner.Tests/AlRunner.Tests.csproj", rels);
+
+        var offenders = BCVersionDeclarations(RepoRoot);
         Assert.True(offenders.Count == 0,
             "Only Directory.Build.props may declare a _BCVersion default. A per-project "
             + "default drifts from the shared one exactly like AlRunner.csproj and "
@@ -50,6 +132,130 @@ public class BCVersionDefaultTests
             + "whichever project MSBuild happens to evaluate first, and mismatched "
             + "defaults across projects break with CS1705. Offending declarations:\n  "
             + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// #3139, the direct regression assertion: no path this guard reads may come from
+    /// `.claude/`. On a developer or agent box that directory holds one full checkout of this
+    /// repository per concurrent agent; on a CI runner it does not exist at all, because it is
+    /// gitignored. A guard that reads it answers a different question in the two places.
+    ///
+    /// Read the limit of this one honestly: it only has anything to find when the suite runs
+    /// from the MAIN checkout, because `RepoRoot` inside an agent worktree is the worktree,
+    /// which has no nested `.claude/worktrees/` of its own — and CI has no `.claude/` at all.
+    /// Measured on the main checkout: 126 project files before the fix, 6 after, matching
+    /// `git ls-files '*.csproj'` exactly. The unconditional proof is the synthetic pair below,
+    /// which builds the offending tree itself and therefore cannot go quiet depending on where
+    /// it is run from.
+    /// </summary>
+    [Fact]
+    public void ProjectWalk_NeverLeavesTheRepositoryIntoAgentWorktrees()
+    {
+        var strays = RepositoryProjectFiles(RepoRoot)
+            .Select(p => Path.GetRelativePath(RepoRoot, p).Replace('\\', '/'))
+            .Where(rel => rel.StartsWith(".claude/", StringComparison.Ordinal)
+                       || rel.Contains("/tests/al-language/", StringComparison.Ordinal)
+                       || rel.StartsWith("tests/al-language/", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.True(strays.Count == 0,
+            "This guard walked outside the repository's own tree. Everything under .claude/ is "
+            + "another agent's checkout and everything under tests/al-language/ is a read-only "
+            + "upstream submodule; neither is ours to police, and both make the answer depend "
+            + "on local state that CI does not have (#3139). Strays:\n  "
+            + string.Join("\n  ", strays));
+    }
+
+    /// <summary>
+    /// The same claim proven against a synthetic tree, so it cannot pass merely because no
+    /// worktree happens to declare `_BCVersion` today. That was exactly the state of the bug
+    /// when it was found: latent, green, and one `git worktree add` away from failing in
+    /// somebody else's checkout while naming a file that is not in their branch.
+    /// </summary>
+    [Fact]
+    public void ProjectWalk_IgnoresADeclarationInsideAnAgentWorktree()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "bcver-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            WriteProject(root, "AlRunner/AlRunner.csproj", "<PropertyGroup></PropertyGroup>");
+            WriteProject(root, ".claude/worktrees/other-agent/AlRunner/AlRunner.csproj",
+                "<PropertyGroup>\n    <_BCVersion>28.1.49838.53910</_BCVersion>\n  </PropertyGroup>");
+            WriteProject(root, "tests/al-language/Sub/Sub.csproj",
+                "<PropertyGroup>\n    <_BCVersion>27.0.0.0</_BCVersion>\n  </PropertyGroup>");
+
+            var found = RepositoryProjectFiles(root)
+                .Select(p => Path.GetRelativePath(root, p).Replace('\\', '/'))
+                .ToList();
+            Assert.Equal(new[] { "AlRunner/AlRunner.csproj" }, found);
+
+            Assert.Empty(BCVersionDeclarations(root));
+        }
+        finally
+        {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The negative direction, and the one that keeps the exclusions from neutering the guard:
+    /// a declaration in the repository's OWN project files is still caught, and the message
+    /// names the file and the line so the author knows what to delete.
+    /// </summary>
+    [Fact]
+    public void ProjectWalk_StillCatchesADeclarationInTheRepositorysOwnProject()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "bcver-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            WriteProject(root, "AlRunner/AlRunner.csproj",
+                "<PropertyGroup>\n    <_BCVersion>28.1.49838.53910</_BCVersion>\n  </PropertyGroup>");
+            WriteProject(root, "tools/DownloadArtifacts/DownloadArtifacts.csproj",
+                "<PropertyGroup></PropertyGroup>");
+
+            var offenders = BCVersionDeclarations(root);
+            Assert.Single(offenders);
+            Assert.StartsWith("AlRunner/AlRunner.csproj: ", offenders[0]);
+            Assert.Contains("<_BCVersion>28.1.49838.53910</_BCVersion>", offenders[0]);
+
+            // A commented-out declaration is history, not a default.
+            WriteProject(root, "AlRunner.Tests/AlRunner.Tests.csproj",
+                "<PropertyGroup>\n    <!-- <_BCVersion>27.0.0.0</_BCVersion> -->\n  </PropertyGroup>");
+            Assert.Single(BCVersionDeclarations(root));
+        }
+        finally
+        {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// A walk that finds nothing must throw, not report a clean tree. A moved or mistyped root
+    /// is the one failure that turns this whole class into decoration.
+    /// </summary>
+    [Fact]
+    public void ProjectWalk_ThrowsWhenItFindsNoProjectsAtAll()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "bcver-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, ".claude", "worktrees", "other-agent"));
+            File.WriteAllText(Path.Combine(root, ".claude", "worktrees", "other-agent", "X.csproj"), "<Project />");
+
+            var ex = Assert.Throws<InvalidOperationException>(() => RepositoryProjectFiles(root));
+            Assert.Contains("reads as a pass", ex.Message);
+        }
+        finally
+        {
+            if (Directory.Exists(root)) Directory.Delete(root, recursive: true);
+        }
+    }
+
+    private static void WriteProject(string root, string relativePath, string propertyGroup)
+    {
+        var full = Path.Combine(root, relativePath.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, $"<Project Sdk=\"Microsoft.NET.Sdk\">\n  {propertyGroup}\n</Project>\n");
     }
 
     [Fact]

--- a/AlRunner.Tests/BCVersionDefaultTests.cs
+++ b/AlRunner.Tests/BCVersionDefaultTests.cs
@@ -175,7 +175,7 @@ public class BCVersionDefaultTests
     [Fact]
     public void ProjectWalk_IgnoresADeclarationInsideAnAgentWorktree()
     {
-        var root = Path.Combine(Path.GetTempPath(), "bcver-" + Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("bcver");
         try
         {
             WriteProject(root, "AlRunner/AlRunner.csproj", "<PropertyGroup></PropertyGroup>");
@@ -205,7 +205,7 @@ public class BCVersionDefaultTests
     [Fact]
     public void ProjectWalk_StillCatchesADeclarationInTheRepositorysOwnProject()
     {
-        var root = Path.Combine(Path.GetTempPath(), "bcver-" + Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("bcver");
         try
         {
             WriteProject(root, "AlRunner/AlRunner.csproj",
@@ -236,7 +236,7 @@ public class BCVersionDefaultTests
     [Fact]
     public void ProjectWalk_ThrowsWhenItFindsNoProjectsAtAll()
     {
-        var root = Path.Combine(Path.GetTempPath(), "bcver-" + Guid.NewGuid().ToString("N"));
+        var root = TestScratch.Dir("bcver");
         try
         {
             Directory.CreateDirectory(Path.Combine(root, ".claude", "worktrees", "other-agent"));


### PR DESCRIPTION
Closes #3139

## The hole

`AlRunner.Tests/BCVersionDefaultTests.cs` walked `RepoRoot` with
`SearchOption.AllDirectories` for `*.csproj` and skipped exactly one path prefix,
`tests/al-language/`. `.claude/worktrees/` holds one **full checkout of this repository per
concurrent agent**, so the `_BCVersion` drift gate was reading other people's branches.

| | before | after |
|---|---|---|
| `.csproj` scanned, measured on the main checkout | **126** | **6** |
| ...of those, under `.claude/` | 120 | 0 |
| ...the repository's own | 6 | 6 |
| matches `git ls-files '*.csproj'` | no | **yes, exactly** |

95% of the guard's input was not the repository.

Two things make it worse than a slow walk.

**It was latent, not live.** No worktree `.csproj` declares `<_BCVersion` today, so the test
passed. That is the defect rather than a reprieve: the verdict depended on what other agents
happened to have checked out. Any branch that adds the very drift this test exists to catch
(#2102) would fail it in every *other* agent's local run, naming a file that is not in their
branch and that they cannot fix.

**It was wrong locally and right in CI.** `.claude/worktrees/` is gitignored (`.gitignore:61`,
plus `**/.claude/worktrees/` in `.git/info/exclude`), so a CI runner does not have it. The
guard passed every leg while lying on every developer and agent box — the one combination no
CI leg can ever surface.

## What changed

The walk is now explicit about what it descends into and refuses to answer from nothing:

- `SkippedDirectories` — `bin`, `obj`, `.git`, `.claude`, `.vs`, `node_modules`, `packages`,
  `al-language`. `.claude` is the load-bearing entry; the rest is hygiene. Same shape as the
  `ProductionSources` walk PR #3116 landed for the runtime shape-gap guards.
- **`al-language` is skipped by directory NAME, not by a path prefix.** The old
  `rel.StartsWith("tests/al-language/")` test never matched a worktree's own copy at
  `.claude/worktrees/<id>/tests/al-language/`, so the submodule exclusion was defeated inside
  a worktree too. As a side note it currently matched nothing at all — the submodule ships no
  `.csproj`, so the only exclusion the guard had was dead while the contamination that was
  real went unfiltered.
- `RepositoryProjectFiles` throws when the walk finds nothing (the #3021 / #3092 non-vacuity
  rule), and the real-root test holds a floor of the six tracked projects, naming two of them,
  so a future exclusion that quietly narrows the scan fails rather than reporting a clean tree
  it never read.
- The scan is split into `RepositoryProjectFiles(root)` and `BCVersionDeclarations(root)` so
  both can be driven against a synthetic tree instead of only against whatever this machine
  happens to hold.

## RED → GREEN

The exclusion set is the only variable between the two runs.

**RED** — `SkippedDirectories` set to the pre-fix set (`al-language` alone):

```
Failed!  - Failed: 2, Passed: 4, Skipped: 0, Total: 6
  ProjectWalk_IgnoresADeclarationInsideAnAgentWorktree [FAIL]
  ProjectWalk_ThrowsWhenItFindsNoProjectsAtAll [FAIL]
```

The first builds a synthetic tree whose only `<_BCVersion` sits in
`.claude/worktrees/other-agent/AlRunner/AlRunner.csproj`; the pre-fix walk finds it and
reports it as an offender. The second puts a project file *only* under `.claude/` and the
pre-fix walk counts it, so a root with no repository projects at all reads as a pass.

**GREEN** — with the fix:

```
Passed!  - Failed: 0, Passed: 6, Skipped: 0, Total: 6
```

**Correction (head `6d1da824`).** The first push of this branch was red on `All BC versions
passed`: the three synthetic-tree tests built their root with
`Path.Combine(Path.GetTempPath(), "bcver-" + Guid)`, and
`ScratchDirOwnershipGuardTests.NoTestSource_BuildsAnUnownedTempPath_ExceptTheAllowlisted`
rejects that — these directories ARE created, so the allowlist's sanctioned category (a path
that never exists, the `CacheRoots.RequireRooted` case in #3122) does not apply. They now use
`TestScratch.Dir("bcver")`, which reserves the path with `ScratchDirs`. The local 6/6 GREEN
above was honest but filtered to `BCVersionDefaultTests`, so the tree-wide guard never ran —
"the diff touches no runtime path" was the reasoning, and it is wrong for guards that assert
over the *tree* rather than over behavior. Third PR broken by that shape this session; tracked
as #3196. Re-verified at this head by running `ScratchDirOwnershipGuardTests` ALONGSIDE
`BCVersionDefaultTests` (9/9 passed), plus all 11 tree-scanning guard classes together
(188/188 passed, `VirtualTableRefusalClaimTests` included). RED was reproduced locally first:
with the raw temp expression restored, the guard fails naming `BCVersionDefaultTests.cs`,
exactly as CI did.

**Negative control.** `ProjectWalk_StillCatchesADeclarationInTheRepositorysOwnProject` passes
in **both** states — an exclusion that neutered the guard would fail it. It also pins that a
commented-out declaration is history, not a default, and asserts the message names the file
and the exact line.

## What I deliberately left in the open

`ProjectWalk_NeverLeavesTheRepositoryIntoAgentWorktrees` — the direct assertion against the
real root — can only find something when the suite runs from the **main** checkout, because
`RepoRoot` inside an agent worktree is the worktree, which has no nested `.claude/worktrees/`,
and CI has no `.claude/` at all. That limit is written into its doc comment rather than left
for a reader to discover, and it is exactly why the synthetic pair exists alongside it: those
build the offending tree themselves and cannot go quiet depending on where they run.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** No — checked all 18
   `SearchOption.AllDirectories` call sites in `AlRunner.Tests/`. `BCVersionDefaultTests` was
   the only one rooted at `RepoRoot` itself. `VirtualTableRefusalClaimTests:345` and
   `CliDocumentationTests:418` root at `Path.Combine(RepoRoot, "AlRunner")`;
   `ParserStaticsIsolationGuardTests:439` at `TestSourceDirectory()`;
   `BaseAppFloorFixtureGuardTests`, `ScratchDirOwnershipGuardTests` and `TestArtifactsGateTests`
   at `TestsDir`/`TestsSourceDir`; the `*.app` walks at temp or package search dirs. None can
   reach `.claude/`.
2. **Does a sibling assumption exist?** Yes, and it is fixed here: the `tests/al-language/`
   exclusion was written as a `RepoRoot`-relative prefix, which the same worktree nesting
   defeats. Skipping by name closes both at once.
3. **Two paths writing the same state?** The two guards that walk this repository looking for
   source files — this one and `FieldTriggerShapeGapCallSiteTests` (PR #3116) — now maintain
   the same invariant, that `.claude` is never descended into. They keep separate skip lists
   because they want different things (`.Tests` projects are excluded there and required here),
   which is a real difference rather than duplication.

## Scope

No `AlRunner/` change, so the `Tests updated` gate does not trigger. No BC behavior is
asserted anywhere in this diff, so nothing is owed to the upstream corpus — this is a claim
about which files a test in this repository reads.

---

Filed and implemented by an agent (`stma-auto-1`, cycle 139; corrected in cycle 142) on the
account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
