### PR TITLE
perf(date): stop materialising the 86,885-row window behind a guard that already narrowed the request

### DIFF
--- a/AlRunner.Tests/DateVirtualTableLazyWindowTests.cs
+++ b/AlRunner.Tests/DateVirtualTableLazyWindowTests.cs
@@ -107,6 +107,30 @@ public sealed class DateVirtualTableLazyWindowTests
             // this cap it must still refuse by name rather than answer from fewer rows.
             Assert.Contains(
                 "PASS  Codeunit61631.Date_UnfilteredRead_StillDemandsTheWholeDocumentedWindow", stdout);
+
+            // #3044 — Record.IsEmpty() reaches DataAccess.ExistsAsync, whose guard materialises
+            // exactly what the request can select, and ExistsAsync then calls
+            // TempTableDataProvider.Exists, where the provider-level net materialised the whole
+            // 86,885-row window BEHIND it. Under this same 2,000-row cap the stacked pair does
+            // not merely cost more, it refuses: run against the pre-fix runner this line fails
+            // with "would add about 86,885 rows for 86,910 in all … (currently 25 rows in 1
+            // span(s), [1820-01-01..1820-01-07])". That is the RED, and it is a row count, not
+            // a duration.
+            Assert.Contains(
+                "PASS  Codeunit61631.Date_IsEmptyOnABoundedSpan_DoesNotMaterialiseTheWindow", stdout);
+            // The other direction: the fast path has to answer TRUE for a closed range that
+            // legitimately selects nothing, not just "not empty" whenever it skips the window.
+            Assert.Contains(
+                "PASS  Codeunit61631.Date_IsEmptyOnABoundedSpanThatSelectsNothing_ReturnsTrue", stdout);
+            // The two controls. An IsEmpty() naming no closed bound is still answered from the
+            // whole window, and a FlowField over Date — which reaches the provider without any
+            // DataAccess guard having seen it, the shape #2988's net exists for — still demands
+            // it too. Both must still refuse by name under the cap.
+            Assert.Contains(
+                "PASS  Codeunit61631.Date_UnboundedIsEmpty_StillDemandsTheWholeDocumentedWindow", stdout);
+            Assert.Contains(
+                "PASS  Codeunit61631.Date_FlowFieldOverDate_StillDemandsTheWholeDocumentedWindow", stdout);
+
             Assert.DoesNotContain("FAIL", stdout);
         }
         finally

--- a/AlRunner.Tests/Fixtures/DateWindowLazy/DateCountHolder.Table.al
+++ b/AlRunner.Tests/Fixtures/DateWindowLazy/DateCountHolder.Table.al
@@ -1,0 +1,28 @@
+// Issue #3044 — the source table for Date_FlowFieldOverDate_StillDemandsTheWholeDocumentedWindow.
+//
+// A FlowField whose CalcFormula source is the Date virtual table reaches
+// TempTableDataProvider without a DataCacheRequest, so none of the DataAccess-level Date
+// window guards ever sees it. It is the exact shape #2988's provider-level net was built for,
+// and the control proving #3044 did not weaken that net: this FlowField names no closed
+// "Period Start" bound, so it must still demand the whole 1900..2099 window and refuse under
+// AL_RUNNER_DATE_WINDOW_MAX_ROWS=2000.
+table 61632 "DWL Date Count Holder"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Code"; Code[10]) { DataClassification = CustomerContent; }
+        field(2; "Date Rows"; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count(Date);
+            Editable = false;
+        }
+    }
+
+    keys
+    {
+        key(PK; "Code") { Clustered = true; }
+    }
+}

--- a/AlRunner.Tests/Fixtures/DateWindowLazy/DwlTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/DateWindowLazy/DwlTests.Codeunit.al
@@ -76,9 +76,112 @@ codeunit 61631 "DWL Tests"
         Assert.ExpectedError('past the');
     end;
 
+    // ── Issue #3044 — IsEmpty() must not materialise the window behind a guard that has
+    //    already narrowed the very same request ────────────────────────────────────────────
+    //
+    // Record.IsEmpty() does not take the count path: it reaches DataAccess.ExistsAsync, whose
+    // guard materialises exactly what the request can select (25 rows for a closed week), and
+    // ExistsAsync then calls TempTableDataProvider.Exists, where the provider-level safety net
+    // materialised the whole 86,885-row default window BEHIND it. Both guards are correct and
+    // neither subsumes the other; they simply stacked.
+    //
+    // The instrument is the row cap again, not a clock. Under AL_RUNNER_DATE_WINDOW_MAX_ROWS
+    // = 2000 the stacked pair does not merely cost more, it REFUSES — measured on main before
+    // this fix, this test failed with
+    //
+    //   a Date filter asks for periods in [1900-01-01..2099-12-31], which would add about
+    //   86,885 rows for 86,910 in all, past the 2,000-row cap for the materialised window
+    //   (currently 25 rows in 1 span(s), [1820-01-01..1820-01-07])
+    //
+    // — the two guards visible in one diagnostic. So this can only pass if the net now
+    // recognises that the store already holds every row this request can select.
+
+    [Test]
+    procedure Date_IsEmptyOnABoundedSpan_DoesNotMaterialiseTheWindow()
+    var
+        DateRec: Record Date;
+    begin
+        // [GIVEN] a closed week in 1820 — outside the default 1900..2099 window entirely
+        DateRec.SetRange("Period Type", DateRec."Period Type"::Date);
+        DateRec.SetRange("Period Start", DMY2Date(1, 1, 1820), DMY2Date(7, 1, 1820));
+
+        // [THEN] IsEmpty() answers FALSE under a 2,000-row cap. Before #3044 it refused here.
+        Assert.AreEqual(false, DateRec.IsEmpty(), 'Seven Date-type periods exist in 1-7 January 1820.');
+
+        // Not merely "it did not throw": the same range still has to hold the right rows, so a
+        // fix that skipped the window by materialising nothing would fail on the next two lines.
+        Assert.AreEqual(7, DateRec.Count(), 'Expected 7 Date-type rows for 1-7 January 1820.');
+        Assert.IsTrue(DateRec.FindFirst(), 'Record Date found no row for 1 January 1820.');
+        // 1 January 1820 was a Saturday, so BC's Monday = 1 numbering makes its Period No. 6.
+        Assert.AreEqual(6, DateRec."Period No.", '1 January 1820 was a Saturday, so Period No. is 6.');
+    end;
+
+    [Test]
+    procedure Date_IsEmptyOnABoundedSpanThatSelectsNothing_ReturnsTrue()
+    var
+        DateRec: Record Date;
+    begin
+        // THE OTHER DIRECTION. A closed range the filter engine legitimately selects nothing
+        // from: 2-7 January 1821 is Tuesday to Sunday, so it contains no Monday and therefore
+        // no Week period starts in it. The fast path has to answer TRUE here — a fix that
+        // returned "not empty" whenever it skipped the window would pass the test above and
+        // fail this one.
+        DateRec.SetRange("Period Type", DateRec."Period Type"::Week);
+        DateRec.SetRange("Period Start", DMY2Date(2, 1, 1821), DMY2Date(7, 1, 1821));
+        Assert.AreEqual(true, DateRec.IsEmpty(), 'No week starts between 2 and 7 January 1821.');
+        Assert.AreEqual(0, DateRec.Count(), 'Count must agree with IsEmpty over the same range.');
+
+        // And the same days DO hold Date-type periods, so the span really was materialised and
+        // TRUE above came from the filter, not from an empty store.
+        DateRec.SetRange("Period Type", DateRec."Period Type"::Date);
+        Assert.AreEqual(false, DateRec.IsEmpty(), '2-7 January 1821 holds six Date-type periods.');
+        Assert.AreEqual(6, DateRec.Count(), 'Expected 6 Date-type rows for 2-7 January 1821.');
+    end;
+
+    [Test]
+    procedure Date_UnboundedIsEmpty_StillDemandsTheWholeDocumentedWindow()
+    var
+        DateRec: Record Date;
+    begin
+        // THE CONTROL for #3044, and the half that must NOT have changed. An IsEmpty() naming
+        // no closed "Period Start" bound is still answered from the WHOLE documented window, so
+        // under a 2,000-row cap it must still refuse BY NAME — even though sibling tests have
+        // by now materialised several bounded spans it could have answered from.
+        //
+        // A fix that skipped the window unconditionally, or whenever ANY span was materialised,
+        // goes green above and red here.
+        asserterror IsAnyDateEmpty(DateRec);
+        Assert.ExpectedError('out-of-scope: Date (virtual table 2000000007)');
+        Assert.ExpectedError('past the');
+    end;
+
+    [Test]
+    procedure Date_FlowFieldOverDate_StillDemandsTheWholeDocumentedWindow()
+    var
+        Holder: Record "DWL Date Count Holder";
+    begin
+        // THE SECOND CONTROL. A FlowField whose CalcFormula source is Date reaches the provider
+        // WITHOUT going through DataAccess at all, so no guard has narrowed anything and the
+        // provider-level net is the only thing standing between it and a wrong answer (#2988
+        // measured `count(Date …)` returning 0 instead of 73,049 without it). It names no
+        // closed "Period Start" bound, so it must still demand the whole window and refuse
+        // under the cap.
+        Holder.Code := 'X';
+        Holder.Insert();
+        asserterror Holder.CalcFields("Date Rows");
+        Assert.ExpectedError('out-of-scope: Date (virtual table 2000000007)');
+        Assert.ExpectedError('past the');
+    end;
+
     local procedure FindAnyDate(var DateRec: Record Date): Boolean
     begin
         DateRec.SetRange("Period Type", DateRec."Period Type"::Date);
         exit(DateRec.FindSet());
+    end;
+
+    local procedure IsAnyDateEmpty(var DateRec: Record Date): Boolean
+    begin
+        DateRec.SetRange("Period Type", DateRec."Period Type"::Date);
+        exit(DateRec.IsEmpty());
     end;
 }

--- a/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
@@ -784,6 +784,15 @@ public static partial class NclCecilRewrite
             // Date store and is a ConditionalWeakTable miss for every other table. CalcNumeric is
             // not in this list because Cecil REPLACES its body above; the same call sits at the
             // top of the replacement instead.
+            //
+            // It takes the PROVIDER REQUEST as well as the provider (#3044). Every one of these
+            // three reads carries a DataProviderRequest, and a DataProviderRequest carries the
+            // same FiltersAndMarks a DataCacheRequest does — on the Exists path it is literally
+            // the same object, since DataAccess.ExistsAsync passes request.FiltersAndMarks
+            // straight through. That lets the net tell "nothing has narrowed this request" from
+            // "a DataAccess-level guard already materialised every row this request can select",
+            // which is what Record.IsEmpty() over a closed range hits: the ExistsAsync guard
+            // materialises 25 rows and the net used to materialise 86,885 more behind it.
             foreach (var providerRead in new[]
                      {
                          ("Exists", "ExistsProviderRequest"),
@@ -793,8 +802,8 @@ public static partial class NclCecilRewrite
             {
                 PrependStaticCall(nclMod,
                     ByParams(Rt + "TempTableDataProvider", providerRead.Item1, providerRead.Item2),
-                    H(recordPatches, "EnsureDateStoreFullyMaterialised"),
-                    argSlots: 1); // `this` — the provider — is all the helper needs
+                    H(recordPatches, "EnsureDateStoreCoversProviderRequest"),
+                    argSlots: 2); // `this` — the provider — and the provider request
             }
 
             // ── BLOB store isolation for database-backed tables (issue #1751) ──────

--- a/AlRunner/Patches/RecordPatches.DateVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.DateVirtualTable.cs
@@ -392,6 +392,123 @@ public static partial class RecordPatches
     }
 
     /// <summary>
+    /// The request-carrying form of <see cref="EnsureDateStoreFullyMaterialised"/>, prepended to
+    /// TempTableDataProvider.{Exists, CalcMinMax, CalcSums} and called at the top of the
+    /// CalcNumeric replacement — every provider read that DOES hold a
+    /// <c>DataProviderRequest</c>. Issue #3044.
+    ///
+    /// <para>THE PROBLEM. Two guards, both correct, stacked on <c>Record.IsEmpty()</c>.
+    /// <see cref="DataAccess_DateWindowGuardForExists"/> materialises exactly what the request
+    /// can select — 25 rows for a closed week — and then <c>DataAccess.ExistsAsync</c> calls
+    /// <c>provider.Exists</c>, where the net materialised the whole 86,885-row default window
+    /// behind it. Measured on main, warm, one test per process, BC 28.1: a closed week answered
+    /// by <c>Count()</c> + <c>FindFirst()</c> cost 57-107 ms, the same shape answered by
+    /// <c>IsEmpty()</c> cost 494-568 ms. Under
+    /// <c>AL_RUNNER_DATE_WINDOW_MAX_ROWS=2000</c> the second one does not merely cost more, it
+    /// REFUSES, naming "about 86,885 rows for 86,910 in all … (currently 25 rows in 1 span(s),
+    /// [1820-01-01..1820-01-07])" — the two guards visible in one diagnostic.</para>
+    ///
+    /// <para>THE RULE, and why it changes no answer. This skips the window ONLY when the store
+    /// already holds every row this request can select: every non-empty range of its
+    /// "Period Start" filter is closed at both ends, and <see cref="DateMissingSpans"/> reports
+    /// nothing missing between the lowest low and the highest high. That is the same safety
+    /// argument <see cref="EnsureDateWindowCoversRequest"/> rests on — BC's own filter engine
+    /// excludes everything outside those bounds regardless of what the store holds — applied to
+    /// the request the provider is about to answer rather than to the one DataAccess saw. In
+    /// every other case, including every one of #2988's measured arms, it falls through to the
+    /// whole window exactly as before:
+    /// a <c>count(Date where …)</c> or <c>exist(Date where …)</c> FlowField and a TableRelation
+    /// check name no closed "Period Start" bound (or name one nothing has materialised), so
+    /// nothing is skipped. It never materialises LESS than the previous code did for a request
+    /// that needed it — it only declines to do work already done.</para>
+    ///
+    /// <para>The coverage question is asked only once a DataAccess-level Date guard has bound
+    /// the filter reflection in this process (<c>_dvtGuardReady</c>). Before that there is by
+    /// construction no narrowed span to have covered anything, and the fall-through is the old
+    /// behaviour.</para>
+    ///
+    /// <para>For every table but 2000000007 this is one ConditionalWeakTable miss and a
+    /// return — the same cost as the request-less form.</para>
+    /// </summary>
+    public static void EnsureDateStoreCoversProviderRequest(object provider, object providerRequest)
+    {
+        if (!_dvtSpanByProvider.TryGetValue(provider, out var span)) return;   // not the Date store
+        NCLMetaTable meta;
+        object session;
+        lock (span)
+        {
+            if (span.WholeWindow) return;
+            if (span.Meta is not NCLMetaTable m || span.Session is not object s) return;
+            meta = m;
+            session = s;
+        }
+
+        if (DateProviderRequestAlreadyCovered(span, providerRequest, session)) return;
+
+        PopulateDateSpanIntoProvider(provider, meta, session,
+            new DateTime(DateWindowMinYear, 1, 1), new DateTime(DateWindowMaxYear, 12, 31));
+    }
+
+    /// <summary>
+    /// True when <paramref name="providerRequest"/>'s "Period Start" filter is closed at both
+    /// ends of every non-empty range AND the provider already holds every period in
+    /// [lowest low .. highest high]. False for anything else — an unreadable request, a shape
+    /// with an open bound, a bounded request over periods nothing has materialised — so the
+    /// caller falls back to the whole window, which is what it did before #3044.
+    /// </summary>
+    private static bool DateProviderRequestAlreadyCovered(
+        DatePopulatedSpan span, object providerRequest, object session)
+    {
+        // No DataAccess-level Date guard has run in this process, so nothing has narrowed
+        // anything and the filter accessors this needs are not bound yet.
+        if (!_dvtGuardReady) return false;
+
+        object? filter;
+        DateTime? low, high;
+        try
+        {
+            var fam = ProviderRequestFiltersAndMarks(providerRequest);
+            if (fam == null) return false;
+            filter = PeriodStartFilterIn(fam);
+            if (filter == null) return false;
+            if (!TryReadClosedBoundsOfFilter(filter, session, out low, out high)) return false;
+        }
+        catch (RunnerOutOfScopeException) { throw; }
+        catch
+        {
+            // Reading the filter is best-effort, exactly as it is one layer up: a shape we
+            // cannot parse falls back to the whole window, never to a narrower store.
+            return false;
+        }
+
+        if (low is not DateTime lo || high is not DateTime hi) return false;
+
+        lock (span)
+            return DateMissingSpans(span.Covered, lo, hi).Count == 0;
+    }
+
+    private static PropertyInfo? _dvtProviderReqFiltersAndMarks;
+
+    /// <summary>
+    /// <c>DataProviderRequest.FiltersAndMarks</c>. Bound separately from the DataCacheRequest
+    /// property of the same name because the two are different declaring types — passing a
+    /// provider request to the DataCacheRequest accessor throws rather than returning null.
+    /// </summary>
+    private static object? ProviderRequestFiltersAndMarks(object providerRequest)
+    {
+        if (_dvtProviderReqFiltersAndMarks == null)
+        {
+            var tProviderRequest = providerRequest.GetType().Assembly
+                .GetType("Microsoft.Dynamics.Nav.Runtime.DataProviderRequest");
+            if (tProviderRequest == null) return null;
+            _dvtProviderReqFiltersAndMarks = tProviderRequest.GetProperty(
+                "FiltersAndMarks", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (_dvtProviderReqFiltersAndMarks == null) return null;
+        }
+        return _dvtProviderReqFiltersAndMarks.GetValue(providerRequest);
+    }
+
+    /// <summary>
     /// Materialise the whole configured window (default 1900-01-01 .. 2099-12-31, 86,885 rows).
     /// This is what answers a request that does NOT name a closed bound on both ends of
     /// "Period Start" — an unfiltered read, an open bound, or a filter shape the runner cannot
@@ -768,6 +885,20 @@ public static partial class RecordPatches
 
         var filter = FindPeriodStartFilter(cacheRequest);
         if (filter == null) return false;
+        return TryReadClosedBoundsOfFilter(filter, session, out low, out high);
+    }
+
+    /// <summary>
+    /// The closed-bounds half of <see cref="TryReadClosedPeriodStartBounds"/>, split out so the
+    /// provider-level net (#3044) can ask the same question of a request it reaches WITHOUT a
+    /// DataCacheRequest — a <c>DataProviderRequest</c> carries its own <c>FiltersAndMarks</c>,
+    /// and the bound-reading rules must not fork between the two layers.
+    /// </summary>
+    private static bool TryReadClosedBoundsOfFilter(
+        object filter, object session, out DateTime? low, out DateTime? high)
+    {
+        low = null;
+        high = null;
 
         var rangeList = _dvtToRangeList!.Invoke(filter, new[] { session });
         if (rangeList == null) return false;
@@ -999,9 +1130,17 @@ public static partial class RecordPatches
 
     /// <summary>The "Period Start" (field 2) FilterExpression on this find request, if any.</summary>
     private static object? FindPeriodStartFilter(object cacheRequest)
+        => _pFiltersAndMarks!.GetValue(cacheRequest) is object fam ? PeriodStartFilterIn(fam) : null;
+
+    /// <summary>
+    /// The "Period Start" (field 2) FilterExpression inside a <c>FiltersAndMarks</c>, if any.
+    /// Reached from both layers: a DataCacheRequest's FiltersAndMarks (the DataAccess guards)
+    /// and a DataProviderRequest's (the provider-level net, #3044) are the same type — indeed
+    /// on the Exists path they are the same OBJECT, since DataAccess.ExistsAsync passes
+    /// <c>request.FiltersAndMarks</c> straight into the ExistsProviderRequest it builds.
+    /// </summary>
+    private static object? PeriodStartFilterIn(object fam)
     {
-        var fam = _pFiltersAndMarks!.GetValue(cacheRequest);
-        if (fam == null) return null;
         var filters = _pFamFilters!.GetValue(fam);
         if (filters == null) return null;
         if (_pFfdItems!.GetValue(filters) is not Array items) return null;

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -868,7 +868,12 @@ public static partial class RecordPatches
         // seen it. This call materialises the whole window on first such read (and is a
         // ConditionalWeakTable miss for every other table). It lives inside the replacement body
         // rather than as a Cecil prepend because Cecil REPLACES this method's body outright.
-        EnsureDateStoreFullyMaterialised(self);
+        //
+        // #3044: the request goes with it, so a read whose "Period Start" filter is closed at
+        // both ends AND already materialised does not re-materialise the whole window behind a
+        // guard that had already narrowed it. Anything else — which is every FlowField shape
+        // #2988 measured — still gets the window.
+        EnsureDateStoreCoversProviderRequest(self, request);
 
         var rt = request.GetType();
         var companyToken   = (int)rt.GetProperty("CompanyToken")!.GetValue(request)!;


### PR DESCRIPTION
Closes #3044

`Record.IsEmpty()` on the Date virtual table cost roughly an order of magnitude more than a `Count()` plus `FindFirst()` over the same closed range, because two correct guards stacked. This makes the provider-level net able to tell "nothing has narrowed this request" from "a guard already materialised every row this request can select", without weakening the net.

## The 17x reproduced

Measured myself before changing anything, on this machine, BC 28.1, one test per process, Debug build, same 7-day-range shape as the issue:

| call | cold | warm (3 runs) |
|---|---|---|
| `Count()` + `FindFirst()` over a week in 1850 | 133 ms | 107 / 69 / 57 ms |
| `IsEmpty()` over a week in 1820 | 1996 ms | 567 / 568 / 494 ms |

So 15x cold and 8-9x warm here against the issue's 17x — same defect, same order, and the direction is the one the issue says is backwards on its face: `IsEmpty()` can stop at the first row, `Count()` cannot.

## Where the cost actually was — measured in rows, not milliseconds

The runner already has an exact counter for this: `AL_RUNNER_DATE_WINDOW_MAX_ROWS`, the cap `PopulateDateSpan` checks an estimated row count against before materialising anything. Running the same `IsEmpty()` under `AL_RUNNER_DATE_WINDOW_MAX_ROWS=2000` does not merely cost more, it refuses, and the refusal names both guards in one line:

```
a Date filter asks for periods in [1900-01-01..2099-12-31], which would add about
86,885 rows for 86,910 in all, past the 2,000-row cap for the materialised window
(currently 25 rows in 1 span(s), [1820-01-01..1820-01-07])
```

`currently 25 rows in 1 span(s), [1820-01-01..1820-01-07]` is #3028's `DataAccess.ExistsAsync` guard having already materialised exactly what the request can select. `would add about 86,885 rows` is #2988's provider-level net materialising the whole default window behind it. `DataAccess.ExistsAsync` builds an `ExistsProviderRequest` and calls `provider.Exists`, and the net sat on that method with no way to see that the request had already been narrowed.

## The layer this lands in

The runtime engine, not a precompiled AL business-logic DLL: `TempTableDataProvider.{Exists, CalcMinMax, CalcSums}` are Cecil prepend sites in `Ncl.dll`, which `.claude/rules/precompiled-dll-respect.md` puts squarely on our side of the line. No method body in `Microsoft.Dynamics.Nav.BaseApplication.dll` or `…SystemApplication.dll` is touched, and the Date rows themselves are still laid out by BC's own `VirtualDataProvider.GetSystemPopulatedVirtualRecordValues` and BC's own period arithmetic.

## The change

The net takes the `DataProviderRequest` as well as the provider (`EnsureDateStoreCoversProviderRequest`, `argSlots: 2`), and skips the window when — and **only** when — both hold:

1. every non-empty range of that request's `"Period Start"` filter is closed at both ends, and
2. `DateMissingSpans` reports nothing missing between the lowest low and the highest high.

That is the same safety argument `EnsureDateWindowCoversRequest` already rests on — BC's own filter engine excludes everything outside those bounds regardless of what the store holds — applied to the request the provider is about to answer rather than to the one `DataAccess` saw. `ExistsProviderRequest` derives from `DataProviderRequest`, which carries the same `FiltersAndMarks` a `DataCacheRequest` does; on the Exists path it is literally the same object, since `DataAccess.ExistsAsync` passes `request.FiltersAndMarks` straight into the request it builds (decompiled from Ncl.dll 28.1).

The bound-reading logic is not forked: `TryReadClosedPeriodStartBounds` was split so both layers call the same `TryReadClosedBoundsOfFilter` / `PeriodStartFilterIn`.

## Does any observable behaviour change? No — and here is why that is checkable rather than hopeful

**No corpus test is owed**, and the reason is structural rather than convenient.

The rule is one-directional: the net can now *skip* work, and it can never do *less* than the previous code did for a request that needed it. Whenever the skip fires, the store already holds every row the request's filter can select, so the provider returns exactly the rows it would have returned from the superset. The three edge cases worth naming explicitly, because they are the ones that would have been observable:

- **An empty filter range, or a range that excludes every date.** Covered by a positive test, not by reasoning: `Date_IsEmptyOnABoundedSpanThatSelectsNothing_ReturnsTrue` filters `"Period Type" = Week` over 2-7 January 1821 (Tuesday to Sunday, so no Monday and no week start), asserts `IsEmpty() = true` and `Count() = 0`, then re-filters the same days to `Period Type = Date` and asserts `IsEmpty() = false` and `Count() = 6` — so the TRUE came from the filter and not from an empty store.
- **An open bound, a `'..%1|%2..'` shape, or a filter the runner cannot parse.** Predicate (1) fails, so nothing is skipped and the whole window is materialised, exactly as before. `Date_UnboundedIsEmpty_StillDemandsTheWholeDocumentedWindow` pins that: under the 2,000-row cap an `IsEmpty()` naming no closed bound must still refuse *by name*, even though sibling tests have by then materialised several bounded spans it could have answered from.
- **A bounded request over periods nothing has materialised.** Predicate (2) fails, whole window, unchanged. This is every one of #2988's measured arms — a `count(Date …)` / `exist(Date …)` FlowField and a `ValidateRelation` TableRelation check reach the provider without any `DataAccess` guard having narrowed anything. `Date_FlowFieldOverDate_StillDemandsTheWholeDocumentedWindow` pins that arm with a real `CalcFormula = count(Date)` FlowField on a fixture table: it must still refuse under the cap.

So the claim this PR makes is a claim about the runner's own cost, which AL cannot observe and the corpus therefore cannot express. What the Date table *says* — weekday numbering, ISO weeks, month ends — is plain BC behaviour and is already covered upstream by corpus codeunit 60983.

## RED → GREEN, counted rather than timed

A wall-clock assertion on a shared CI runner is a flake generator (#3110). This uses the row cap instead, which is deterministic and states the real claim. `AL_RUNNER_DATE_WINDOW_MAX_ROWS=2000` is below the ~87,000 the default window needs and above the ~25 a one-week span needs, so a bounded read can only answer if the window was never materialised.

**RED** — `AlRunner/` reverted to `origin/main` in this same worktree, rebuilt, fixture re-run:

```
PASS  Date_BoundedFilter_MaterialisesOnlyTheBoundedSpan
PASS  Date_KeyedGetInABoundedSpan_MaterialisesOnlyThatPeriod
PASS  Date_UnfilteredRead_StillDemandsTheWholeDocumentedWindow
FAIL  Date_IsEmptyOnABoundedSpan_DoesNotMaterialiseTheWindow
      … would add about 86,885 rows for 86,935 in all … (currently 50 rows in 2 span(s), …)
FAIL  Date_IsEmptyOnABoundedSpanThatSelectsNothing_ReturnsTrue
      … would add about 86,885 rows for 86,959 in all … (currently 74 rows in 3 span(s), …)
PASS  Date_UnboundedIsEmpty_StillDemandsTheWholeDocumentedWindow
PASS  Date_FlowFieldOverDate_StillDemandsTheWholeDocumentedWindow
```

Exactly the two fast-path tests fail; both controls pass on the pre-fix runner too, which is what makes them controls.

**GREEN** — sources restored from `HEAD`, **rebuilt** (a `--no-build` run after a revert measures the old binary, which for a cost change is fatal), fixture re-run **cold and warm**, since a cache-sensitive change is one of the two cases `local-test-scope.md` says to run twice: 7/7 both times.

And the cost, same instrument as the reproduction, warm, after the fix: `IsEmpty()` 49 / 42 / 46 ms against `Count()` + `FindFirst()` 64 / 58 / 62 ms. `IsEmpty()` is now the cheaper of the two, which is the shape it should always have had.

## What else was run, in this state, rebuilt

- `dotnet test AlRunner.Tests --filter FullyQualifiedName~DateVirtualTable` — 9/9.
- `dotnet test AlRunner.Tests --filter "…PlainRunInstrumentationGate|…FlowField|…CecilRewrite"` — 21/21 (the prepend's arity and the FlowField path are what changed).
- `tests/runner-extras` with `--strict` — **304/304**.
- The al-language corpus, all three apps, with `--strict` — **2684/2684**, exit 0.

No `dotnet test AlRunner.Tests` sweep: 15+ minutes for a change whose blast radius the filters above cover, and CI runs it on all eight legs anyway.

## Fixing the shape, not just the reported line

1. **The same wrong pattern at another call site.** The net had five callers. Four hold a `DataProviderRequest` — the three Cecil prepends plus the `TempTableDataProvider_CalcNumeric` replacement — and all four are fixed here, not just the `Exists` one the issue reported. The fifth, in `FlowFieldPatches`, sits *before* the CalcFormula's `FiltersAndMarks` is resolved and so has no request to read; moving it past `GetFilterFromMetaFilterCollection` is a restructuring with a real risk of leaving a source-store read unprotected, which is the wrong answer #2988 measured. Deliberately left out and filed as **#3144**, with the current behaviour pinned by a test so a future fix has to change the test rather than slip past it.
2. **A sibling function making the same assumption.** Checked the virtual Field table (2000000041), which has the same four request paths: it has `DataAccess_FieldGuardFor{Count, Get, Exists}` and **no** provider-level net, so there is nothing there to stack. Nothing found.
3. **Two code paths writing the same state.** `PopulateDateSpan` and `PopulateDateSpanIntoProvider` both write `span.Covered` / `span.CoveredEstimate` / `span.WholeWindow`; the former delegates to the latter, so there is one writer and one invariant, and `DateMissingSpans` stays the single authority for "is this covered". No divergence to fix.

## Deliberately not done

- No `docs/limitations.md`, `README.md` or `PrintGuide()` change — the documented Date window approximation is untouched, because nothing about which rows are materialised for a request that needs them has changed.
- No `tests/expectations/count-baseline/` edit. The fixture is an `AlRunner.Tests` fixture, not a corpus or `runner-extras` bundle, so it is not counted there — four PRs are already serialising on those two files (#3108).
- No corpus PR, for the reason argued above.

---

*Implemented by an agent (`stma-auto-1`, cycle 139) on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
