### PR TITLE
fix(ci-wait): never print a genuine failure under "Superseded ... Harmless"

### DIFF
--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -582,6 +582,44 @@ def supersession(newest: dict[str, dict],
     return superseded, killed
 
 
+def discount_reason(name: str, superseded: set[str], killed: set[str]) -> str | None:
+    """Why a non-passing conclusion is NOT this commit's word on `name`, or None.
+
+    THE INVARIANT, and the only place it is decided:
+
+        A `failure` may be discounted ONLY when the workflow run that PRODUCED
+        it is itself cancelled, or is being replaced by a newer run of the same
+        workflow that is still in flight. NEVER on the strength of some OTHER
+        check run carrying the same context name.
+
+    Both admissible reasons are properties of the *producing run*, which is why
+    both sets arrive from supersession() keyed on the run behind the check run.
+    "Some other entry for this name was cancelled" is not on the list, and #3142
+    is what happens when it is used as though it were: on PR #3112's head
+    c6377b30 a GREEN verdict listed `preflight.py unit tests` under
+    "Superseded ... Harmless" because a *sibling* entry for that name was
+    cancelled, while its newest check run had concluded `failure` inside a run
+    that was itself `failure` -- neither cancelled nor superseded. Nothing in
+    the output said anything had failed.
+
+    That misreport could not change the merge decision on #3112 only because the
+    absorbed context was not a ruleset context. One ruleset edit -- exactly what
+    resolve_required_contexts() reads live, with nobody editing this file -- is
+    all that separates the two payloads, and #3002 exists because three wrong
+    verdicts in one night were caught by a human rather than by this tool.
+
+    Returning None means "this is a real verdict on the merits". Callers must
+    treat that as undiscountable in EVERY direction: it cannot be dropped from
+    the failing list, and it cannot be printed as harmless noise.
+    """
+    if name in superseded:
+        return ("the run that produced it is being replaced by a newer run of "
+                "the same workflow, still in flight")
+    if name in killed:
+        return "the workflow run that produced it was cancelled"
+    return None
+
+
 def classify(runs: list[dict],
              contexts: tuple[str, ...] = RULESET_CONTEXTS,
              workflow_runs: list[dict] | None = None) -> Verdict:
@@ -638,8 +676,14 @@ def classify(runs: list[dict],
     # is judged, so every downstream branch -- failure, block, green -- sees the
     # same truth: that run was stopped, its word is not a verdict on its merits.
     newest: dict[str, dict] = {}
+    # What a reclassified check run actually said, kept so the exit-4 advice can
+    # tell "nobody ever ran this to completion" (re-running destroys no log) from
+    # "this job failed on its merits inside a run somebody then cancelled" (it
+    # has a real failing log, and `gh run rerun` would overwrite it permanently).
+    killed_originals: dict[str, str] = {}
     for n, r in raw_newest.items():
         if n in killed and r.get("conclusion") != "cancelled":
+            killed_originals[n] = r.get("conclusion") or "?"
             r = dict(r)
             r["conclusion"] = "cancelled"
         newest[n] = r
@@ -653,7 +697,7 @@ def classify(runs: list[dict],
     # #2922, now closed in the one direction that was actually misreporting).
     bad = [r for r in done if r.get("conclusion") not in NOT_FAILURES
            and r.get("conclusion") != "cancelled"
-           and (r.get("name") or "") not in superseded]
+           and discount_reason(r.get("name") or "", superseded, killed) is None]
     missing = [c for c in contexts if c not in newest]
     final = rollup_is_final(workflow_runs)
     inflight = superseding_runs(newest, contexts, workflow_runs)
@@ -743,10 +787,31 @@ def classify(runs: list[dict],
          if r.get("conclusion") == "cancelled" and is_required(r.get("name"), contexts)),
         key=lambda r: r.get("name") or "",
     )
-    superseded = sorted(
+    # DELIBERATELY not the verdict-path `superseded` -- this used to shadow that
+    # name with a far weaker rule and is #3142. A cancelled entry is "harmlessly
+    # superseded" only when the newer run that replaced it actually re-reported
+    # the context as PASSING. If the newer run said `failure`, the failure is the
+    # commit's word on that name (discount_reason() returns None for it) and it
+    # belongs in `undiscounted` below, not under the heading "Harmless".
+    resolved_cancellations = sorted(
         {(r.get("name") or "") for r in runs
          if r.get("conclusion") == "cancelled"
-         and newest.get(r.get("name") or "", {}).get("id") != r.get("id")}
+         and newest.get(r.get("name") or "", {}).get("id") != r.get("id")
+         and newest.get(r.get("name") or "", {}).get("conclusion") in NOT_FAILURES}
+    )
+    # Real failures on this commit that nothing legitimately discounts. Every
+    # REQUIRED one is already gone -- it would have returned exit 1 above -- so
+    # what is left is non-required, gates no merge, and is exactly the red X a
+    # reader has to be told about rather than left to find. #3137 has had one of
+    # these red on every PR for days, which is how a tool got a real failure to
+    # absorb in the first place.
+    undiscounted = sorted(
+        (r for r in newest.values()
+         if r.get("status") == "completed"
+         and r.get("conclusion") not in NOT_FAILURES
+         and r.get("conclusion") != "cancelled"
+         and discount_reason(r.get("name") or "", superseded, killed) is None),
+        key=lambda r: r.get("name") or "",
     )
     cosmetic = sorted(
         {(r.get("name") or "") for r in newest.values()
@@ -770,6 +835,23 @@ def classify(runs: list[dict],
             "for --admin; branch protection is working, the context genuinely is not",
             "satisfied.",
         ]
+        # ...with one exception, and it is the expensive one to get wrong. A
+        # check run that concluded `failure` on its merits inside a run somebody
+        # then cancelled is reported as blocked rather than failed (the
+        # deliberate trade-off in supersession(), which errs away from green).
+        # It DOES have a failing log, so the blanket advice above would send a
+        # reader to overwrite the one piece of evidence permanently.
+        real = [r for r in blocking if (r.get("name") or "") in killed_originals]
+        if real:
+            lines += [
+                "",
+                "CAREFUL -- these were NOT merely stopped. Their check run concluded",
+                "on its merits inside a workflow run that was cancelled afterwards,",
+                "so a real log exists and `gh run rerun` WOULD overwrite it:",
+            ]
+            lines += [f"  {r['name']}: {killed_originals[r['name']]} "
+                      f"(inside a cancelled run)" for r in real]
+            lines.append("Read those logs BEFORE re-running anything.")
         for r in blocking:
             if r.get("details_url"):
                 lines.append(f"  {r['details_url']}")
@@ -807,20 +889,44 @@ def classify(runs: list[dict],
         # that night named nine or ten, and that asymmetry is the only reason a
         # human caught them.
         return Verdict(None, progress=progress)
+    if any(is_required(r.get("name"), contexts)
+           and r.get("conclusion") not in NOT_FAILURES
+           for r in newest.values()):
+        # Unreachable: a required failure returned exit 1 and a required
+        # cancellation returned exit 4 above. Kept as a hard invariant, because
+        # what it forbids is the exact thing #3142 did in the printed output --
+        # a green standing over a required context that is not passing. If a
+        # future discount rule ever lets one through, this says "cannot tell"
+        # rather than green.
+        return Verdict(None, progress=progress)
+
     lines = [f"all {len(pool)} required checks passed "
              f"({len(accounted)}/{len(uniq)} ruleset context(s) accounted for)."]
     lines.append("Ruleset contexts confirmed present and passing on this commit: "
                  + ", ".join(uniq) + ".")
+    if undiscounted:
+        # Printed BEFORE the two "this is noise" sections, and never merged into
+        # them: these are genuine failures that happen not to gate the merge, and
+        # a reader who learns to skim past red is how the next real one is missed.
+        lines.append("")
+        lines.append(f"NOT required, but genuinely FAILING on this commit -- "
+                     f"{len(undiscounted)} check(s). The merge is not gated on "
+                     f"them, and they are NOT superseded noise:")
+        for r in undiscounted:
+            rid = run_id_from(r.get("details_url"))
+            lines.append(f"  {r['name']}: {r.get('conclusion')}"
+                         + (f"   (workflow run {rid})" if rid else ""))
     if cosmetic:
         lines.append("")
         lines.append("Cosmetic: these NON-required contexts are 'cancelled' on this "
                      "commit and do not block a merge:")
         lines += [f"  {n}" for n in cosmetic]
-    if superseded:
+    if resolved_cancellations:
         lines.append("")
         lines.append("Superseded: these contexts have a 'cancelled' entry on this "
-                     "commit that a newer run already re-reported. Harmless.")
-        lines += [f"  {n}" for n in superseded]
+                     "commit that a newer run already re-reported as passing. "
+                     "Harmless.")
+        lines += [f"  {n}" for n in resolved_cancellations]
     return Verdict(0, lines, progress=progress)
 
 

--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -101,11 +101,17 @@ was refused, because a superseded PR Check run had left the required
 green tool and a refused merge is to assume branch protection is broken and
 reach for --admin, which bypasses the ruleset to work around a phantom.
 
-This is the one case in this repository where `gh run rerun` is the right call:
-a cancelled run has no failure log to overwrite, so re-running it destroys no
-evidence, and it re-reports the context as success within a minute. The workflow
-side of #2726 stops required contexts being cancellable in the first place; this
-verdict exists for anything that still gets there.
+This is the one case in this repository where `gh run rerun` can be the right
+call, and it is CONDITIONAL: only while nothing on the commit concluded `failure`
+before the cancellation. A check run can fail on its merits and have its parent
+workflow run cancelled only afterwards, and a re-run destroys that log exactly as
+it destroys any other. `.claude/rules/ci-verdicts.md` section 3 is the normative
+statement and carries the check to run first -- correct it there, not here.
+
+Where the condition holds, re-running re-reports the context as success within a
+minute. The workflow side of #2726 stops required contexts being cancellable in
+the first place; this verdict exists for anything that still gets there, and the
+exit-4 output names any entry that fails the condition.
 """
 from __future__ import annotations
 
@@ -830,10 +836,14 @@ def classify(runs: list[dict],
             "context name, and 'cancelled' does not satisfy a required check, so the",
             "merge is refused while `gh pr checks` still reads SUCCESS (#2726).",
             "",
-            "Re-run the cancelled run -- this is the ONE case where `gh run rerun` is",
-            "correct: a cancelled run has no failure log to overwrite. Do NOT reach",
-            "for --admin; branch protection is working, the context genuinely is not",
-            "satisfied.",
+            "Re-run the cancelled run -- this is the ONE case where `gh run rerun`",
+            "can be correct, and only while nothing on this commit concluded",
+            "`failure` before the cancellation: a check run that concluded",
+            "`failure` on its merits has a real log, and a re-run destroys it",
+            "like any other. The check to run first is in",
+            ".claude/rules/ci-verdicts.md section 3.",
+            "Do NOT reach for --admin; branch protection is working, the context",
+            "genuinely is not satisfied.",
         ]
         # ...with one exception, and it is the expensive one to get wrong. A
         # check run that concluded `failure` on its merits inside a run somebody

--- a/tools/test_ci_wait.py
+++ b/tools/test_ci_wait.py
@@ -836,6 +836,131 @@ check("a context ADDED in the UI is picked up and waited for",
       sorted(ctx) == ["All BC versions passed", "Some new gate", "Tests updated"]
       and status == "live", f"{ctx} {status}")
 
+
+# ===========================================================================
+# #3142: "Superseded ... Harmless" must never absorb a genuine failure
+# ===========================================================================
+# Observed on PR #3112's head c6377b30: a GREEN verdict listed
+# `preflight.py unit tests` under "Superseded ... Harmless" while that context's
+# NEWEST check run on the commit concluded `failure`, from a workflow run that
+# was itself `failure` -- neither cancelled nor superseded. Nothing else in the
+# output said anything had failed.
+#
+# The payload is BUILT here rather than fetched, so the property is pinned
+# independently of whatever the API happens to return today. It is the shape of
+# the real one: three check runs for one context name, the middle one cancelled
+# by a superseding run, the newest a real failure.
+#
+# The invariant: a `failure` may be discounted ONLY when the run that PRODUCED
+# it is itself cancelled or superseded -- never on the strength of some OTHER
+# run carrying the same context name.
+MATRIX_RUN, KILLED_PR_CHECK, LIVE_PR_CHECK, REQ_RUN = 34036994584, 34037049850, 34037050361, 34036994488
+
+C6377B30_RUNS = [
+    {"id": MATRIX_RUN, "name": "Test Matrix", "status": "completed", "conclusion": "success"},
+    {"id": KILLED_PR_CHECK, "name": "PR Check", "status": "completed", "conclusion": "cancelled"},
+    {"id": LIVE_PR_CHECK, "name": "PR Check", "status": "completed", "conclusion": "failure"},
+    {"id": REQ_RUN, "name": "Require Tests", "status": "completed", "conclusion": "success"},
+]
+
+
+def absorbed_failure_set(failing_name):
+    """Required contexts all green; `failing_name` red on the live run, with a
+    cancelled sibling entry left behind by a superseded run of that workflow."""
+    runs = [cr(n, "success", MATRIX_RUN, 101496852900 + i) for i, n in enumerate(LEGS)]
+    runs.append(cr("All BC versions passed", "success", MATRIX_RUN, 101499731123))
+    runs.append(cr("Tests updated", "success", REQ_RUN, 101496768931))
+    # the cancelled leftover, and a genuinely failing NEWEST entry for one name
+    runs.append(cr(failing_name, "cancelled", KILLED_PR_CHECK, 101496919780))
+    runs.append(cr(failing_name, "failure", LIVE_PR_CHECK, 101496925176))
+    return runs
+
+
+runs = absorbed_failure_set("preflight.py unit tests")
+v = cw.classify(runs, workflow_runs=C6377B30_RUNS)
+# The verdict itself is correct and must STAY correct: `preflight.py unit tests`
+# is not a ruleset context, so it does not gate the merge.
+check("a failing NON-required context still does not block the merge",
+      v.code == 0, f"(code={v.code}) {v.lines}")
+harmless = [l for l in v.lines if "harmless" in l.lower()]
+idx = v.lines.index(harmless[0]) if harmless else len(v.lines)
+check("...but a context whose NEWEST run FAILED is never listed as harmlessly "
+      "superseded (#3142)",
+      not any("preflight.py unit tests" in l for l in v.lines[idx:]),
+      "\n".join(v.lines))
+check("...and the green output NAMES it as failing, so a real red is not silent",
+      any("preflight.py unit tests" in l and "failure" in l for l in v.lines),
+      "\n".join(v.lines))
+check("...and points at the workflow run that produced the failure",
+      any(str(LIVE_PR_CHECK) in l for l in v.lines), "\n".join(v.lines))
+
+# The mirror, so this is not just "never say harmless": a cancelled entry that a
+# newer run really did re-report as SUCCESS is still explained as harmless.
+runs = [cr(n, "success", MATRIX_RUN, 101496852900 + i) for i, n in enumerate(LEGS)]
+runs.append(cr("All BC versions passed", "success", MATRIX_RUN, 101499731123))
+runs.append(cr("Tests updated", "success", REQ_RUN, 101496768931))
+runs.append(cr("scripts/ unit tests", "cancelled", KILLED_PR_CHECK, 101496919785))
+runs.append(cr("scripts/ unit tests", "success", LIVE_PR_CHECK, 101496925213))
+v = cw.classify(runs, workflow_runs=C6377B30_RUNS)
+check("a cancelled entry a newer run re-reported as SUCCESS is still GREEN",
+      v.code == 0, f"(code={v.code}) {v.lines}")
+check("...and is still explained as harmlessly superseded",
+      any("scripts/ unit tests" in l for l in v.lines)
+      and any("harmless" in l.lower() for l in v.lines), "\n".join(v.lines))
+check("...and is NOT reported as a failing check",
+      not any("scripts/ unit tests" in l and "failure" in l for l in v.lines),
+      "\n".join(v.lines))
+
+# The same shape on a REQUIRED context has to fail outright, not merely be
+# named. One ruleset edit is all that separates the two payloads.
+runs = absorbed_failure_set("Tests updated")
+v = cw.classify(runs, workflow_runs=C6377B30_RUNS)
+check("the same shape on a REQUIRED context is a FAILED verdict, not a green "
+      "with a footnote",
+      v.code == 1, f"(code={v.code}) {v.lines}")
+check("...and never describes that failure as harmless",
+      not any("harmless" in l.lower() for l in v.lines), "\n".join(v.lines))
+
+# A failure inside a run that IS cancelled at the run level stays discountable --
+# that is the deliberate #3002 trade-off, and narrowing it is not this fix.
+runs = [cr(n, "success", MATRIX_RUN, 101496852900 + i) for i, n in enumerate(LEGS)]
+runs.append(cr("All BC versions passed", "success", MATRIX_RUN, 101499731123))
+runs.append(cr("Tests updated", "success", REQ_RUN, 101496768931))
+runs.append(cr("scripts/ unit tests", "failure", KILLED_PR_CHECK, 101496919785))
+v = cw.classify(runs, workflow_runs=C6377B30_RUNS)
+check("a failure from a run that is itself CANCELLED is still discounted",
+      v.code == 0, f"(code={v.code}) {v.lines}")
+check("...and is not announced as a real failing check",
+      not any("scripts/ unit tests" in l and "failure" in l for l in v.lines),
+      "\n".join(v.lines))
+
+# A REQUIRED context whose check run concluded `failure` on its merits inside a
+# run that was cancelled afterwards is still reported as BLOCKED, not FAILED --
+# that trade-off errs away from green and is not being narrowed here. But the
+# exit-4 advice ("a cancelled run has no failure log to overwrite") is wrong for
+# exactly this entry: it has one, and `gh run rerun` destroys it permanently.
+runs = [cr(n, "success", MATRIX_RUN, 101496852900 + i) for i, n in enumerate(LEGS)]
+runs.append(cr("All BC versions passed", "success", MATRIX_RUN, 101499731123))
+runs.append(cr("Tests updated", "failure", KILLED_PR_CHECK, 101496919511))
+v = cw.classify(runs, workflow_runs=C6377B30_RUNS)
+check("a required failure inside a CANCELLED run is blocked, not failed",
+      v.code == 4, f"(code={v.code}) {v.lines}")
+check("...and the output warns that this one has a real log to lose",
+      any("WOULD overwrite" in l for l in v.lines), "\n".join(v.lines))
+check("...and says what it actually concluded, not just 'cancelled'",
+      any("Tests updated" in l and "failure" in l for l in v.lines),
+      "\n".join(v.lines))
+
+# ...and the plain case keeps the unqualified advice, or the warning above would
+# just be noise on every cancellation.
+runs = [cr(n, "success", MATRIX_RUN, 101496852900 + i) for i, n in enumerate(LEGS)]
+runs.append(cr("All BC versions passed", "success", MATRIX_RUN, 101499731123))
+runs.append(cr("Tests updated", "cancelled", KILLED_PR_CHECK, 101496919511))
+v = cw.classify(runs, workflow_runs=C6377B30_RUNS)
+check("a genuinely cancelled required context is blocked with no such warning",
+      v.code == 4 and not any("WOULD overwrite" in l for l in v.lines),
+      f"(code={v.code}) " + "\n".join(v.lines))
+
 print()
 if FAILURES:
     print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")

--- a/tools/test_ci_wait.py
+++ b/tools/test_ci_wait.py
@@ -960,6 +960,25 @@ v = cw.classify(runs, workflow_runs=C6377B30_RUNS)
 check("a genuinely cancelled required context is blocked with no such warning",
       v.code == 4 and not any("WOULD overwrite" in l for l in v.lines),
       f"(code={v.code}) " + "\n".join(v.lines))
+# ...but the advice it DOES print may never restate the falsified claim. The
+# exemption is a narrowing, not a reversal: re-running is still right in the
+# #2726 case, conditional on nothing having failed before the cancellation.
+advice = "\n".join(v.lines)
+check("the exit-4 advice no longer claims a cancelled run has no log to lose",
+      "no failure log" not in advice, advice)
+check("...states the condition instead of exempting cancellations outright",
+      "only while nothing on this commit concluded" in advice, advice)
+check("...and points at the rule file rather than restating the reasoning",
+      "ci-verdicts.md" in advice, advice)
+check("...while still calling the re-run correct where the condition holds",
+      "gh run rerun" in advice and "--admin" in advice, advice)
+
+# The same claim lived twice; the docstring copy is pinned too, so a reader who
+# opens the file instead of running it gets the narrowed version.
+check("the module docstring does not carry the falsified claim either",
+      "no failure log" not in (cw.__doc__ or ""), (cw.__doc__ or "")[:0])
+check("...and defers to the rule file as the normative statement",
+      "ci-verdicts.md" in (cw.__doc__ or ""), "")
 
 print()
 if FAILURES:


### PR DESCRIPTION
Closes #3142

`tools/ci-wait.py` printed a genuinely failing check under the heading
"Superseded ... Harmless" on a GREEN verdict. That is the #3002 hazard shape running in the
direction that produces a false green.

## The exact input that triggers it

A context with **more than one check run on the head commit**, where

- at least one entry concluded `cancelled` and is **not** the newest, and
- the **newest** entry concluded `failure`, from a workflow run that is itself neither
  cancelled nor superseded.

Reproduced on the real payload for head `c6377b30716484502fad6bbe69db6b44efab9498`
(PR #3112, merged as `a7a91143`), fed straight into `classify()`. `preflight.py unit tests`
has three check runs there: `failure` (run 34036994482), `cancelled` (run 34037049850, run-level
cancelled), and — newest — `failure` from run 34037050361, whose own run-level conclusion is
`failure`.

Before:

```
EXIT CODE: 0
all 10 required checks passed (2/2 ruleset context(s) accounted for).
...
Superseded: these contexts have a 'cancelled' entry on this commit that a newer run
already re-reported. Harmless.
  ...
  preflight.py unit tests      <-- newest check run concluded FAILURE
```

After, same payload:

```
EXIT CODE: 0
all 10 required checks passed (2/2 ruleset context(s) accounted for).

NOT required, but genuinely FAILING on this commit -- 1 check(s). The merge is not
gated on them, and they are NOT superseded noise:
  preflight.py unit tests: failure   (workflow run 34037050361)

Superseded: ... that a newer run already re-reported as passing. Harmless.
  <the 11 names that genuinely were re-reported as success>
```

## Root cause

`classify()` computed two different things under one variable name. The verdict-path
`superseded`, from `supersession()`, asks whether the run that **produced** a check run is
being replaced — sound. The GREEN-path `superseded` **shadowed** it with a far weaker rule:
any `cancelled` entry for the name that is not the newest, selected across `runs`, then
declaring the **name** harmless. What the newest run actually concluded never entered into it.

So the answer to "which of the two #3002 rules is over-reaching" is: **neither**. Both verdict
rules key on the producing run and hold. The over-reach was a third, undocumented rule in the
display path that borrowed the word "superseded" for a weaker concept.

Stated plainly, because it bounds the severity: **the verdict path was sound in every direction
and only the display path was wrong.** No verdict this tool returned was incorrect — required
contexts were judged correctly throughout. What was wrong is what it printed alongside a correct
green, which is a real defect (a reader acts on the printed text, and "Harmless" is an
instruction to ignore) but not a wrong merge decision.

## The fix

- `discount_reason()` states the invariant once and is the only place a non-passing conclusion
  may be set aside: **only** because the run that produced it is itself cancelled, or is being
  replaced by a newer run of the same workflow still in flight — never on the strength of some
  other check run carrying the same context name.
- `bad` (verdict) and the display both route through it. The display set is renamed
  `resolved_cancellations`, ending the shadowing, and now requires the newest conclusion to be
  in `NOT_FAILURES` before anything is called harmless.
- A hard invariant before the green lines refuses a green standing over any required context
  that is not passing. Unreachable today (a required failure exits 1, a required cancellation
  exits 4); kept so a future discount rule says "cannot tell" rather than green.
- Real failures that gate no merge get their own named section rather than being invisible.
  Exit code stays 0 — the ruleset decides merges — but a red X is never printed as noise.

## Was the merge decision on #3112 wrong?

No. `main`'s live ruleset requires exactly `All BC versions passed` and `Tests updated`, both
genuinely green, and `preflight.py unit tests` is not required. That does not soften it: one
ruleset edit — the thing `resolve_required_contexts()` reads live, with nobody editing this
file — turns a context the tool was willing to call harmless into one that gates a merge.

## The mirror direction

Checked, and preserved rather than "improved":

- A genuinely cancelled required context is still exit 4, never reported as a failure.
- A required-context set narrower than the built-in floor still returns exit 3 rather than a
  narrowed verdict.
- A cancelled entry that a newer run really did re-report as **success** is still explained as
  harmless — pinned by its own test, so this is not "never say harmless".
- A failure inside a run that IS cancelled at the run level is still discounted (the deliberate
  #3002 trade-off, erring away from green). Not narrowed here.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** `ci-wait.py` is the only place in the repo that
   compares a check run's conclusion against other entries carrying the same name.
   `.github/scripts/check_required_contexts.py` is a static workflow-file guard and reads no
   rollup; `tools/pr-body.py`'s mention of ci-wait is an unrelated retry list. Nothing else found.
2. **Sibling function with the same assumption?** Yes — one claim, in three places in this file,
   all fixed here. "A cancelled run has no failure log to overwrite, so `gh run rerun` is
   correct" is false for a check run that concluded `failure` on its merits inside a run
   cancelled afterwards: it has a real log, and re-running destroys it permanently. This very
   head is the evidence — `preflight.py unit tests` carries two `failure` check runs on
   `c6377b30` alongside the cancelled one.
   - The **exit-4 output** now names any such entry and warns the log would be overwritten.
     Tested both ways, so the warning does not appear on an ordinary cancellation.
   - The **module docstring** and the **exit-4 advice string** carried the same claim
     unconditionally. Both are now narrowed — **not reversed**: re-running a cancelled required
     context is still correct in the #2726 case, conditional on first checking that nothing on
     the commit concluded `failure` before the cancellation. Both point at
     `.claude/rules/ci-verdicts.md` section 3 rather than restating the reasoning, so one
     normative statement remains to correct next time.
   - The prose copies elsewhere (`ci-verdicts.md` and the two coordination skills) are PR #3157
     / issue #3156, by another agent; it deliberately left these two in-file copies to avoid
     conflicting with this branch, so they are folded in here rather than split across two PRs.
   - The reworded advice says "concluded `failure`" rather than "failed" on purpose: a
     pre-existing guard asserts an exit-4 verdict never tells a caller something *failed*, and
     that guard keeps holding unweakened rather than being loosened to fit new prose.
3. **Two paths writing the same state, same invariant?** This was exactly the defect — two sets
   named `superseded` computed by different rules. Now one shared `discount_reason()`, one
   renamed display set, and a hard invariant guarding the green.

## RED → GREEN

`tools/test_ci_wait.py`. The payload is **built as a fixture**, not fetched, so it cannot rot
when the API's answer for that commit changes.

RED, on the pre-fix code:

```
FAIL ...but a context whose NEWEST run FAILED is never listed as harmlessly superseded (#3142)
FAIL ...and the green output NAMES it as failing, so a real red is not silent
FAIL ...and points at the workflow run that produced the failure
FAILED: 3 check(s)
```

GREEN after: `all checks passed`, including every pre-existing check in the file (the mirror
cases above already passed pre-fix and still do, so they pin behaviour the fix must not break).
`.github/scripts/check_required_contexts.py` also run — clean; `RULESET_CONTEXTS` is untouched.

## Scope

**Does this assert anything about what BC does?** No. It is CI verdict tooling, so it owes
nothing to the upstream corpus.

Related and deliberately **not** touched here: #3137 (`preflight.py unit tests` red on every PR
since `df9ce63c`, `graphify is not on PATH`). It is what gave this tool a real failure to absorb,
but it is separable and wants its own PR; this change makes such a failure impossible to
mislabel rather than removing today's instance. Also related: #3002 (the false greens this tool
was hardened against), #3112 (where this was observed), #2922 (the mirror residual — a stale
FAILED where a newer run is queued — still untouched).

Diff is `tools/` only, so the `require-tests` gate does not trigger.

---
*Implemented by an agent (`stma-auto-1`, autonomous cycle 139) acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
