### PR TITLE
fix(testpage): a plain Cancel needs dialog chrome, and bump the corpus pin to 6e198a97

### DIFF
--- a/AlRunner.Tests/TestPageBuiltInCancelAffordanceTests.cs
+++ b/AlRunner.Tests/TestPageBuiltInCancelAffordanceTests.cs
@@ -1,0 +1,189 @@
+// TestPageBuiltInCancelAffordanceTests — which built-in actions LiveNavTestPage offers, and in
+// particular the extra condition on plain Cancel (#3124).
+//
+// WHAT IS PINNED WHERE. The BC-behaviour claim — that TestPage.Cancel() on a non-lookup page
+// whose PageType gives the client no dialog chrome is REFUSED, "The built-in action = Cancel is
+// not found on the page." — belongs upstream and is measured there, on a real service tier:
+// corpus codeunit 60276 "MQC Tests", arm PlainModal_HasNoBuiltInCancelAction
+// (StefanMaron/BusinessCentral.AL.Language.Tests#192), green on all eight cloud legs. Two more
+// corpus files record the same refusal on a plain Card opened with OpenNew()
+// (TestPageRecordTriggers.al) and on the precompiled List page "Error Messages"
+// (TestPageModalHandler_PrecompiledPage.al); TestPageModalHandler_ModalPage.al records the
+// positive side, that PageType = StandardDialog is what gives the client OK/Cancel chrome.
+//
+// What this file pins is the RUNNER's own decision table, as a pure function, so that every row
+// of it is covered without a loaded BC runtime and without a service tier — the same split, and
+// the same shape, as TestPageClientConstructionRuleTests. The corpus can only reach the rows a
+// corpus fixture happens to declare; these reach all of them, including the two the corpus does
+// not have a page for (an unknown PageType, and a page whose lookup mode the runner cannot
+// read).
+using AlRunner;
+using Microsoft.Dynamics.Nav.Types;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPageBuiltInCancelAffordanceTests
+{
+    // THE REGRESSION ROW, and the three page types a real service tier has actually REFUSED.
+    // "MQC Trace Modal" is PageType = Worksheet, run modally without LookupMode, and its
+    // Cancel() must not resolve. Before #3124 it did, so a corpus arm that real BC refuses
+    // closed the page and reported Action::Cancel instead. Card (opened with OpenNew(),
+    // TestPageRecordTriggers.al) and List (precompiled "Error Messages",
+    // TestPageModalHandler_PrecompiledPage.al) are the other two the corpus measures.
+    [Theory]
+    [InlineData("Worksheet")]
+    [InlineData("Card")]
+    [InlineData("List")]
+    public void NonLookupPageMeasuredWithoutDialogChrome_OffersNoPlainCancel(string pageType)
+        => Assert.False(LiveNavTestPage.OffersBuiltInAction(FormResult.Cancel, lookupMode: false, pageType));
+
+    // INFERRED, NOT MEASURED — kept separate from the rows above on purpose, so a later reader
+    // cannot mistake these for service-tier facts. No corpus test drives Cancel() on any of
+    // these three page types; they are refused because FormState.RunModal is assigned in exactly
+    // two UI builders (NavigatePageBuilder, StandardDialogBuilder) and none of them is one.
+    //
+    // ConfirmationDialog is the row to watch, and it is the reason this test exists separately:
+    // its NAME suggests OK/Cancel chrome, it moves from permissive to REFUSING here, and
+    // refusing is the riskier direction — a wrong refusal breaks AL that works on real BC,
+    // whereas a wrong permission only fails to reproduce a BC error. It is drawn from the same
+    // builder fact that was judged too thin to act on for NavigatePage (which keeps its
+    // permissive answer below). #3131 tracks getting both measured upstream; if BC turns out to
+    // offer Cancel on a ConfirmationDialog, THIS is the test that has to change, not the one
+    // above.
+    [Theory]
+    [InlineData("ConfirmationDialog")]
+    [InlineData("ListPlus")]
+    [InlineData("Document")]
+    public void NonLookupPageInferredWithoutDialogChrome_OffersNoPlainCancel_Unmeasured(string pageType)
+        => Assert.False(LiveNavTestPage.OffersBuiltInAction(FormResult.Cancel, lookupMode: false, pageType));
+
+    // The other half, and what stops the rule above from being "Cancel never resolves": a page
+    // built by a dialog builder DOES offer it. StandardDialog is measured — every green
+    // Cancel().Invoke() in the corpus and in tests/runner-extras is aimed at one.
+    [Fact]
+    public void NonLookupStandardDialogPage_OffersPlainCancel()
+        => Assert.True(LiveNavTestPage.OffersBuiltInAction(FormResult.Cancel, lookupMode: false, "StandardDialog"));
+
+    // INFERRED, NOT MEASURED, and the permissive direction of the same builder fact: NavigatePage
+    // keeps the answer it already had rather than gaining a refusal. Its chrome is
+    // Back/Next/Finish/Cancel rather than OK/Cancel, so BC may well answer differently here --
+    // #3131, same issue as the refusing inference above.
+    [Fact]
+    public void NonLookupNavigatePage_OffersPlainCancel_Unmeasured()
+        => Assert.True(LiveNavTestPage.OffersBuiltInAction(FormResult.Cancel, lookupMode: false, "NavigatePage"));
+
+    // PageType comes from AL source or from a dependency's SymbolReference.json, neither of
+    // which normalises case, so the comparison may not be ordinal-exact.
+    [Theory]
+    [InlineData("standarddialog")]
+    [InlineData("STANDARDDIALOG")]
+    [InlineData("navigatepage")]
+    public void DialogPageTypeMatchIsCaseInsensitive(string pageType)
+        => Assert.True(LiveNavTestPage.OffersBuiltInAction(FormResult.Cancel, lookupMode: false, pageType));
+
+    // Cancel is the ONLY built-in that gained a condition. Plain OK is offered by every
+    // non-lookup page whatever its type — the corpus's PlainModal_HandlerOk arm runs on the
+    // same Worksheet page the first test refuses Cancel on, and it is green upstream. A fix
+    // that gated both would have broken it.
+    [Theory]
+    [InlineData("Worksheet")]
+    [InlineData("Card")]
+    [InlineData("StandardDialog")]
+    public void NonLookupPage_AlwaysOffersPlainOk(string pageType)
+        => Assert.True(LiveNavTestPage.OffersBuiltInAction(FormResult.OK, lookupMode: false, pageType));
+
+    // A lookup page must answer NULL for plain Cancel even when it IS a dialog, so BC's
+    // FindBuiltInAction(Cancel, LookupCancel) falls through to LookupCancel — which is how
+    // LookupModal_HandlerCancel_RunsQueryClosePageWithLookupCancel reports LookupCancel rather
+    // than Cancel. Same for plain OK falling through to LookupOK.
+    [Theory]
+    [InlineData("StandardDialog")]
+    [InlineData("Worksheet")]
+    public void LookupPage_OffersNeitherPlainCancelNorPlainOk(string pageType)
+    {
+        Assert.False(LiveNavTestPage.OffersBuiltInAction(FormResult.Cancel, lookupMode: true, pageType));
+        Assert.False(LiveNavTestPage.OffersBuiltInAction(FormResult.OK, lookupMode: true, pageType));
+    }
+
+    // ...and the lookup pair it falls through to IS offered, on any page type. The Cancel gate
+    // must not reach LookupCancel: gating that instead would have made every cancelled lookup
+    // in the corpus unreachable.
+    [Theory]
+    [InlineData("StandardDialog")]
+    [InlineData("Worksheet")]
+    public void LookupPage_OffersTheLookupPair(string pageType)
+    {
+        Assert.True(LiveNavTestPage.OffersBuiltInAction(FormResult.LookupCancel, lookupMode: true, pageType));
+        Assert.True(LiveNavTestPage.OffersBuiltInAction(FormResult.LookupOK, lookupMode: true, pageType));
+    }
+
+    // The mirror: a NON-lookup page has no LookupOK/LookupCancel, which is what makes BC's
+    // OK -> LookupOK fallback land on plain OK there rather than on the lookup one.
+    [Fact]
+    public void NonLookupPage_OffersNeitherLookupResult()
+    {
+        Assert.False(LiveNavTestPage.OffersBuiltInAction(FormResult.LookupOK, lookupMode: false, "StandardDialog"));
+        Assert.False(LiveNavTestPage.OffersBuiltInAction(FormResult.LookupCancel, lookupMode: false, "StandardDialog"));
+    }
+
+    // Results outside the two closing pairs are not this rule's business and stay untouched —
+    // a claim about lookup-vs-normal closing is not a claim about which other built-ins exist.
+    [Theory]
+    [InlineData("Worksheet")]
+    [InlineData("StandardDialog")]
+    public void ResultsOutsideTheClosingPairsAreLeftAlone(string pageType)
+    {
+        Assert.True(LiveNavTestPage.OffersBuiltInAction(FormResult.Yes, lookupMode: false, pageType));
+        Assert.True(LiveNavTestPage.OffersBuiltInAction(FormResult.No, lookupMode: true, pageType));
+        Assert.True(LiveNavTestPage.OffersBuiltInAction(FormResult.Print, lookupMode: false, pageType));
+    }
+
+    // A null PageType means TryGetAnyPageType found the page in NEITHER the runner's parsed AL
+    // nor a dependency's symbols — a fact about the runner's inventory, not about the page. It
+    // stays permissive, because refusing on the strength of a lookup miss would turn every
+    // unknown page's Cancel() into a spurious "not found".
+    [Fact]
+    public void UnknownPageType_KeepsThePermissiveAnswer()
+    {
+        Assert.True(LiveNavTestPage.OffersBuiltInAction(FormResult.Cancel, lookupMode: false, pageType: null));
+        Assert.True(LiveNavTestPage.OffersBuiltInAction(FormResult.Cancel, lookupMode: null, pageType: null));
+        Assert.True(LiveNavTestPage.OffersBuiltInAction(FormResult.LookupCancel, lookupMode: null, pageType: null));
+    }
+
+    // A page with no RunnerPageInstance (lookupMode unknown) still gets the Cancel rule, because
+    // the PageType is known even when the mode is not — that is the precompiled "Error Messages"
+    // List case the corpus records BC refusing. Everything else about such a page stays as
+    // permissive as it was.
+    [Fact]
+    public void UnknownLookupMode_StillAppliesTheCancelRuleButNothingElse()
+    {
+        Assert.False(LiveNavTestPage.OffersBuiltInAction(FormResult.Cancel, lookupMode: null, "List"));
+        Assert.True(LiveNavTestPage.OffersBuiltInAction(FormResult.Cancel, lookupMode: null, "StandardDialog"));
+        Assert.True(LiveNavTestPage.OffersBuiltInAction(FormResult.OK, lookupMode: null, "List"));
+        Assert.True(LiveNavTestPage.OffersBuiltInAction(FormResult.LookupOK, lookupMode: null, "List"));
+    }
+
+    // The affordance predicate on its own, so a reader can see the set is exactly two names plus
+    // the unknown case — and so a future edit that widened it to "any dialog-ish name" fails
+    // here rather than silently in the corpus.
+    //
+    // Two of these rows are NOT service-tier facts, and the table cannot show that by itself:
+    // NavigatePage (true) and ConfirmationDialog (false) are both inferred from the UI-builder
+    // fact and tracked by #3131 — see the two *_Unmeasured tests above, which are where those
+    // two claims are pinned with their provenance attached. StandardDialog/Card/List/Worksheet
+    // are measured upstream; ListPlus/Document/API/"" ride on the same inference as
+    // ConfirmationDialog but are not surprising members of the no-chrome set.
+    [Theory]
+    [InlineData("StandardDialog", true)]
+    [InlineData("NavigatePage", true)]        // inferred, #3131
+    [InlineData(null, true)]
+    [InlineData("ConfirmationDialog", false)] // inferred, #3131 — the riskier direction
+    [InlineData("Card", false)]
+    [InlineData("List", false)]
+    [InlineData("Worksheet", false)]
+    [InlineData("API", false)]
+    [InlineData("", false)]
+    public void HasDialogCancelAffordance_IsExactlyTheTwoDialogBuilderPageTypes(string? pageType, bool expected)
+        => Assert.Equal(expected, LiveNavTestPage.HasDialogCancelAffordance(pageType));
+}

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -445,11 +445,34 @@ internal class LiveNavTestPage : MockITestPage
     /// exactly the distinction BC's own fallback pair encodes. Results outside those two
     /// pairs (Yes/No, Print, …) are left alone: this is about lookup-vs-normal closing,
     /// not a claim about which other built-ins a page has.
+    ///
+    /// <para>Plain <c>Cancel</c> carries a SECOND condition on top of that, and it is not
+    /// symmetric with OK: a page only has a built-in Cancel when its PageType gives the client
+    /// dialog chrome to put one on. See <see cref="HasDialogCancelAffordance(string?)"/>.</para>
     /// </summary>
     private bool Offers(FormResult formResult)
+        => OffersBuiltInAction(
+            formResult,
+            // Null, not false: no RunnerPageInstance means the page's lookup mode is UNKNOWN
+            // (a precompiled page the runner could not build one for), which is a different
+            // input from "opened as a normal page" and must not collapse into it.
+            lookupMode: _page?.LookupMode,
+            pageType: RecordPatches.TryGetAnyPageType(_pageId));
+
+    /// <summary>
+    /// The decision behind <see cref="Offers"/>, as a pure function of the three inputs, so it
+    /// can be pinned without a loaded BC runtime (the shape
+    /// <c>TestPageClientConstructionRule</c> uses for the same reason).
+    /// <paramref name="lookupMode"/> is null when the page's mode is unknown.
+    /// </summary>
+    internal static bool OffersBuiltInAction(FormResult formResult, bool? lookupMode, string? pageType)
     {
-        if (_page == null) return true;
-        bool lookup = _page.LookupMode;
+        // Asked before the lookup test on purpose: a lookup page must answer NULL for plain
+        // Cancel either way, so BC's FindBuiltInAction(Cancel, LookupCancel) falls through to
+        // LookupCancel. The two conditions agree there and only the non-lookup case differs.
+        if (formResult == FormResult.Cancel && !HasDialogCancelAffordance(pageType)) return false;
+
+        if (lookupMode is not bool lookup) return true;
         return formResult switch
         {
             FormResult.OK or FormResult.Cancel => !lookup,
@@ -457,6 +480,47 @@ internal class LiveNavTestPage : MockITestPage
             _ => true,
         };
     }
+
+    /// <summary>
+    /// Whether this page's PageType gives the client a real Cancel affordance, which is what
+    /// BC requires before <c>TestPage.Cancel()</c> resolves to anything. A page without one
+    /// gets <c>NavTestActionNotFoundException</c>: "The built-in action = Cancel is not found
+    /// on the page." — and that is NOT the same rule as plain OK, which every non-lookup page
+    /// has.
+    ///
+    /// <para>MEASURED ON A REAL SERVICE TIER, all eight cloud legs, and it is the correction of
+    /// a wrong prediction. Corpus "MQC Tests" (codeunit 60276) first carried an arm asserting
+    /// that a cancelled PLAIN modal reports Action::Cancel, by symmetry with the OK/LookupOK
+    /// pair. BC refused it, and the arm is now
+    /// <c>PlainModal_HasNoBuiltInCancelAction</c> — <c>Cancel().Invoke()</c> on
+    /// "MQC Trace Modal" (PageType = Worksheet) raises rather than closing the page
+    /// (StefanMaron/BusinessCentral.AL.Language.Tests#192). The corpus records the same refusal
+    /// on two further shapes: a plain Card opened with <c>OpenNew()</c>
+    /// (TestPageRecordTriggers.al) and the precompiled List page "Error Messages"
+    /// (TestPageModalHandler_PrecompiledPage.al). Its positive side is
+    /// <c>PageType = StandardDialog</c>, which every green <c>Cancel().Invoke()</c> in the
+    /// corpus and in tests/runner-extras is aimed at — and TestPageModalHandler_ModalPage.al
+    /// states the finding directly: "an action literally named Cancel is not enough on a plain
+    /// Card-type modal (still 'not found' even when declared); PageType = StandardDialog is
+    /// what actually gives the client OK/Cancel chrome."</para>
+    ///
+    /// <para>The set is the two page types built by a DIALOG builder, which is the same fact
+    /// <see cref="RunnerPageInstance"/>'s TargetPageOpensModally rests on and reached the same
+    /// way: <c>FormState.RunModal</c> is assigned in exactly two builders in BC 28.1's UI
+    /// builder assembly, <c>NavigatePageBuilder</c> and <c>StandardDialogBuilder</c>. Only
+    /// StandardDialog is measured on a service tier; NavigatePage rides on the shared builder
+    /// fact and keeps the behaviour it already had here, and issue #3131 tracks getting it —
+    /// and ConfirmationDialog — measured upstream rather than reasoned about.</para>
+    ///
+    /// <para>An UNKNOWN PageType keeps today's permissive answer rather than refusing: null
+    /// from <c>TryGetAnyPageType</c> means the page is not in this run's inventory at all, not
+    /// that it declares no dialog chrome, and turning that into a "not found" would refuse
+    /// pages on the strength of a lookup miss.</para>
+    /// </summary>
+    internal static bool HasDialogCancelAffordance(string? pageType)
+        => pageType == null
+           || string.Equals(pageType, "StandardDialog", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(pageType, "NavigatePage", StringComparison.OrdinalIgnoreCase);
 
     private sealed class RecordingBuiltInAction : ITestAction
     {

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -808,3 +808,43 @@ what adjudicate it. If any of them discovers a different number, the exit-4 mess
 and the line gains an `absentOn`.
 
 Written by agent impl-13 (automated implementation agent).
+
+## 2665 -> 2676 — corpus pin 861a5662 (#193) -> 6e198a97 (#195, #190, #192, #194, #198)
+
++11 tests, and the number is the guard's own `actual`, read off the run that reported
+
+```
+[count-baseline] GROWTH: suite 'al-language' tests count: expected 2668, actual 2676 (BC 28.1)
+```
+
+not computed from the diff. It was read twice, because the pin moved mid-task: the first four
+corpus commits put it at 2668, and corpus #198 merged while this branch was being measured and
+took it to 2676. Both numbers came from the guard.
+
+Where the eleven come from:
+
+| corpus PR | tests | what it adds |
+|---|---|---|
+| #190 | +1 | `Validate_RelationWithWhereFieldLink_NarrowsToTheReferencingRowsOwnGroup` in `fieldref/TestFieldRefRelation.al`, alongside the rename/renumber of `ALTRelationWhereField` that makes a swapped `where(A = field(B))` role detectable at all |
+| #192 | +1 | `PlainModal_HasNoBuiltInCancelAction` in `handlers/TestPageModalQueryClose_Tests.al` |
+| #194 | +1 | `ControlPageRunOnTheLoggingTargetWithoutAHandlerIsRefusedAndOpensNothing` in `handlers/TestPageActionRunObjectNoHandler_Tests.al`, plus the `SingleInstance` probe codeunit 60286 it reads |
+| #195 | 0 | renames a test; the version literal moves into a `Label` |
+| #198 | +8 | `record/TestCodeunitInventoryOrder.al`, codeunit 60964, pinning the row order of the Codeunit Metadata and AllObjWithCaption inventories |
+
+#192 also renames `Modal_HandlerInvokesNothing_ObservedCloseLifecycle` to `LookupModal_...` and
+`LookupCancelHandler` to `CancelHandler`, and drops two log assertions it argues are
+unfalsifiable; none of that moves the count.
+
+`appGroups` is unchanged at 1. `runner-extras` (304 tests, run separately and green),
+`al-language-internals-fixture` (0) and `al-language-onprem` (19) are `main`'s values,
+untouched — #192's only OnPrem change derives four `Published Application` version parts from
+`ModuleInfo` instead of writing `1/0/0/0` out, which adds no test.
+
+**One runner gap, fixed in this PR rather than declared.** `PlainModal_HasNoBuiltInCancelAction`
+was the only red test of the eleven: real BC refuses `TestPage.Cancel()` on a non-lookup page
+whose PageType gives the client no dialog chrome, and the runner offered it. `LiveNavTestPage`
+now gates plain `Cancel` on the PageType. **No new expectation entries** — the other ten passed
+unchanged, including all eight of #198's, which their author expected to pass only by
+coincidence.
+
+Written by agent stma-auto-1 (automated implementation agent), cycle 138.

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Schema, semantics and how to bump: README.md in this directory. Per-bump rationale: history.md, never a prose line in here (#2485).",
   "suites": {
     "al-language": {
-      "tests": { "default": 2665 },
+      "tests": { "default": 2676 },
       "appGroups": { "default": 1 }
     },
     "al-language-internals-fixture": { "tests": { "default": 0 }, "appGroups": { "default": 1 } },


### PR DESCRIPTION
Closes #3124

Bumps `tests/al-language` from `861a5662` to `6e198a97`. Five upstream corpus PRs come in, each already green on all eight cloud legs against a real BC service tier: #195, #190, #192, #194 and #198.

The brief for this bump named `e85a8867`. The pin was re-read after fetching rather than hardcoded, and corpus #198 had merged in the meantime — so the target is `6e198a97` and the count moved twice. Both numbers were read from the guard, not computed.

## Measured, not assumed: which of the eleven new tests were red

The standing rule is that a pin bump cannot be its own PR because it is red by construction. That is a claim about *this* bump, so it was measured before the PR's shape was chosen. **Ten of eleven passed unchanged; one was red.**

Runner build against the new pin, CI's own invocation (three corpus app roots, both package caches, `--strict`, `--count-baseline`):

| new test | source | result |
|---|---|---|
| `Validate_RelationWithWhereFieldLink_NarrowsToTheReferencingRowsOwnGroup` | #190 | PASS |
| `ControlPageRunOnTheLoggingTargetWithoutAHandlerIsRefusedAndOpensNothing` | #194 | PASS |
| `Record_CodeunitMetadata_FindSetWithoutSetCurrentKey_ReturnsAscendingId` | #198 | PASS |
| `Record_CodeunitMetadata_FilterTokenOrderDoesNotDecideRowOrder` | #198 | PASS |
| `Record_CodeunitMetadata_AscendingFalse_ReturnsDescendingId` | #198 | PASS |
| `Record_CodeunitMetadata_RowOrderIsByIdNotByName` | #198 | PASS |
| `Record_CodeunitMetadata_FindFirstAndFindLast_AreLowestAndHighestId` | #198 | PASS |
| `Record_CodeunitMetadata_TestCodeunitsInThisAppsRange_AreStrictlyAscending` | #198 | PASS |
| `Record_AllObjWithCaption_CodeunitRows_FindSetReturnsAscendingObjectId` | #198 | PASS |
| `Record_CodeunitMetadata_FilterNamingNoCodeunit_ReturnsNoRows` | #198 | PASS |
| **`PlainModal_HasNoBuiltInCancelAction`** | **#192** | **FAIL** |

Everything renamed by #195 and #192 (`NavApp_GetCurrentModuleInfo_AppVersion_MatchesAppJsonManifest`, `LookupModal_HandlerInvokesNothing_ObservedCloseLifecycle`) passed too, and #192's OnPrem change — deriving four `Published Application` version parts from `ModuleInfo` instead of writing `1/0/0/0` out — left the OnPrem app at 19 tests, all green.

So the bump is **not** red by construction here. It carries one real gap, fixed in this PR rather than declared. **No expectation entries were added, in any mode.**

## The gap, and the fix

`PlainModal_HasNoBuiltInCancelAction` asserts that `TestPage.Cancel()` on a non-lookup modal whose PageType gives the client no dialog chrome is refused:

```
NavNCLAssertErrorException: An error was expected inside an ASSERTERROR statement.
    "MQC Tests"(CodeUnit 60276).PlainModal_HasNoBuiltInCancelAction line 6
```

Real BC raises `NavTestActionNotFoundException`: *"The built-in action = Cancel is not found on the page."* The runner offered the action instead, so the page closed and reported `Action::Cancel`.

`LiveNavTestPage.Offers` had one condition — lookup-vs-normal — applied symmetrically to `OK` and `Cancel`. That is right for `OK` and wrong for `Cancel`: a plain page only has a built-in Cancel when its PageType builds dialog chrome to put one on. `Offers` now gates plain `Cancel` on the PageType (`RecordPatches.TryGetAnyPageType`), and the whole decision moved into a pure static (`OffersBuiltInAction(formResult, lookupMode, pageType)`) so every row of the table can be pinned without a loaded BC runtime — the shape `TestPageClientConstructionRule` already uses.

`Cancel` is the only built-in that gained a condition. Plain `OK` is still offered by every non-lookup page (`PlainModal_HandlerOk_...` runs on the same Worksheet page and is green upstream), and a lookup page still answers null for plain `Cancel` so BC's `FindBuiltInAction(Cancel, LookupCancel)` falls through to `LookupCancel`.

### Where the rule came from

Decompiled `NavTestPageBase.GetBuiltInAction` (BC 28.1) confirms the fallback pairs the refusal rides on: `OK -> FindBuiltInAction(OK, LookupOK)`, `Cancel -> FindBuiltInAction(Cancel, LookupCancel)`, and a null from every element throws `NavTestActionNotFoundException`. What decides the null is a service-tier measurement, and the corpus already had it in four places:

| PageType | plain `Cancel()` | measured in |
|---|---|---|
| Worksheet | refused | `MQC Tests.PlainModal_HasNoBuiltInCancelAction` (#192) |
| Card via `OpenNew()` | refused | `TestPageRecordTriggers.al`, note above `Close_WithoutOK_StillPersistsTheNewRow` |
| List, precompiled "Error Messages" | refused | `TestPageModalHandler_PrecompiledPage.al` |
| StandardDialog | found | `TestPageModalHandler_ModalPage.al` — "an action literally named Cancel is not enough on a plain Card-type modal (still 'not found' even when declared); PageType = StandardDialog is what actually gives the client OK/Cancel chrome" |

Every green `Cancel().Invoke()` in the corpus and in `tests/runner-extras/` is aimed at a `StandardDialog` page or a lookup-mode one — checked, not assumed.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** `RequestPageTestPage.GetBuiltInAction` is the only other override, and it is deliberately unconditional for a different reason (a report request page really does carry OK/Cancel chrome; its `Parameters`-capture entry point is what its own null answer encodes). The corpus's three `RequestPage.Cancel().Invoke()` arms are green before and after. Left alone.
2. **Does a sibling make the same assumption?** Yes — `Offers`'s `OK` arm. It is *correct* there, and the check is what stopped the fix from gating both: `PlainModal_HandlerOk_...` is green upstream on the same Worksheet page and would have gone red. The asymmetry is now stated in the code rather than implied.
3. **Two code paths writing the same state, same invariant?** `_invokedFormResult` is written only by `RecordingBuiltInAction.Invoke`, which is now unreachable for a plain `Cancel` on a chrome-less page — the same path that would otherwise call `DiscardPendingNewRow()`. That matches `TestPageRecordTriggers.al`'s second measured fact, that a plain Card page has no client-level way to abandon a new row at all.

**The pin is deliberately NOT the tip of corpus `master`, and must not be "fixed" to it.** `6e198a97` is a strict ancestor of `master`, chosen because it is the newest commit whose tests this PR makes pass. Two later corpus merges belong to other PRs and pulling either in here would turn this PR red by construction — the exact thing the pin-bump rule forbids:

- **corpus #199** adds `record/TestCalcFieldsPrecompiledTableExtFlowField.al`, the proving test for #3121 — that is open PR **#3180**'s fold, not this one's.
- **corpus #202** (merged 16:24:08Z) has an arm that fails against the runner today; it needs **#3057**'s fix or a `known-gaps` entry riding in the same PR. Neither is here.

So a lagging pin here is the correct state, not an oversight. Re-pointing it without the matching fix is how a red-by-construction bump gets created by someone being helpful.

**Deliberately left out, and filed rather than guessed: #3131.** The set is `StandardDialog` and `NavigatePage` — the two page types built by a dialog builder, the same fact `RunnerPageInstance.TargetPageOpensModally` rests on (`FormState.RunModal` is assigned in exactly two builders in BC 28.1's UI builder assembly). Only `StandardDialog` is measured on a service tier. `NavigatePage` keeps the behaviour it already had here rather than being changed on an inference, and `ConfirmationDialog` is refused on the same inference. #3131 records both as unmeasured and says what corpus test would settle them; it stays open after this merges.

Review flagged an asymmetry worth naming: `ConfirmationDialog` moves from permissive to **refusing** on the inference judged too thin to act on for `NavigatePage`, and refusing is the riskier direction — a wrong refusal breaks AL that works on real BC, whereas a wrong permission only fails to reproduce a BC error. The rule is unchanged, but the test no longer presents the two kinds of row as one. `TestPageBuiltInCancelAffordanceTests` now separates the three service-tier-measured refusals (Worksheet, Card, List) from the inferred ones in a test named `..._Unmeasured`, does the same for the measured `StandardDialog` vs the inferred `NavigatePage`, and marks both inferred rows in the affordance table inline with `// inferred, #3131`. No assertion changed; every row is still covered. A later reader can no longer mistake `ConfirmationDialog` for something a service tier answered.

An unknown PageType keeps today's permissive answer. Null from `TryGetAnyPageType` means the page is not in this run's inventory, not that it declares no chrome, and refusing on a lookup miss would turn every unknown page's `Cancel()` into a spurious "not found".

## RED -> GREEN

The proving test is upstream, where a BC-behaviour claim belongs, and it is already merged and green on eight legs — so this PR is the fix PR its pin bump folds into.

- **RED**, pin at `6e198a97`, fix reverted in the working tree and the runner rebuilt: `FAIL Codeunit60276.PlainModal_HasNoBuiltInCancelAction (416ms)`, exit 1.
- **GREEN**, fix restored and rebuilt: `PASS Codeunit60276.PlainModal_HasNoBuiltInCancelAction (218ms)`, exit 0.

Plus a runner-side mechanism test, `AlRunner.Tests/TestPageBuiltInCancelAffordanceTests.cs`, pinning the C# decision table rather than restating the BC claim — 32 cases including the rows the corpus has no fixture for (unknown PageType, unknown lookup mode). It proves rather than passes: with `HasDialogCancelAffordance` reverted to the pre-fix `=> true`, **13 of the 32 fail**.

## What was run, in this state

| | result |
|---|---|
| Full corpus, CI's invocation, three app roots + both package caches + `--strict` + `--count-baseline` | **exit 0**, 2695/2695 pass (2 `pass-oos`, 13 `pass-known-gap`, 2 `pass-divergence`), 0 fail, 0 error |
| `tests/runner-extras`, same flags | **exit 0**, 304/304 pass |
| `dotnet test AlRunner.Tests --filter FullyQualifiedName~TestPageBuiltInCancelAffordanceTests` | 32 passed |
| `dotnet test AlRunner.Tests --filter "~TestPage\|~ModalPage\|~Expectation\|~CountBaseline"` | 294 passed, 8 skipped, 0 failed |

All four re-run after the rebase onto `be7a4de0`, with a full rebuild first — no `--no-build` result is carried across the rebase. The full `AlRunner.Tests` suite was not run locally; CI runs it on each of the eight legs.

## Count baseline: 2665 -> 2676

Read from the guard's own output, never computed:

```
[count-baseline] GROWTH: suite 'al-language' tests count: expected 2668, actual 2676 (BC 28.1)
```

Twice, because the pin moved mid-task — the first four commits took it to 2668, #198 took it to 2676. `appGroups` unchanged at 1; `al-language-internals-fixture` (0), `al-language-onprem` (19) and every `runner-extras` group untouched. `history.md` gets one entry appended at EOF, matching the two entries before it, to keep the merge conflict surface minimal (#3108).

## Two coordination notes

- **PR #3082** asserts the BC ordering claim that corpus #198 adjudicates, and deliberately does not carry the pin bump — its author left it for whichever PR needs the new tests. That is this one, so this PR is what lets #3082 clear the merge bar's corpus clause.
- **`tests/expectations/known-gaps-testpage-runobject-no-handler.json` is untouched.** It was read before anything else, together with PR #3093 and issue #3090 (both since closed), because #194 adds an arm to the very codeunit it declares (60285 "TPARONH Tests"). The new arm passes, the two declared methods still fail exactly as declared, and #2975 stays open — so there was nothing to add, edit or remove, and no second declaration of those methods anywhere in this diff.

Nothing under `tests/al-language/` was edited, and `CHANGELOG.md` is untouched.

---
*Opened by agent `stma-auto-1` (cycle 138) on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
