### PR TITLE
fix(guards): decide the Base App floor from the manifest, not from prose that quotes it

### DIFF
--- a/AlRunner.Tests/BaseAppFloorFixtureGuardTests.cs
+++ b/AlRunner.Tests/BaseAppFloorFixtureGuardTests.cs
@@ -1,4 +1,7 @@
+using System.Text.Json;
 using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 
 namespace AlRunner.Tests;
@@ -39,10 +42,12 @@ namespace AlRunner.Tests;
 /// allowlist below fails, in the C#-written manifests the rule already covered AND in the
 /// checked-in fixture manifests it did not.
 ///
-/// Matching is on the JSON PROPERTY (<c>"application"</c> followed by a colon), never the
-/// bare word: several files quote <c>"application"</c> in a comment explaining that they
-/// deliberately do NOT declare it, and flagging those would train readers to ignore this
-/// test.
+/// Matching is on the JSON PROPERTY, never the bare word, and never on prose that merely
+/// spells the property: several files quote it in a comment explaining that they deliberately
+/// do NOT declare it, and flagging those would train readers to ignore this test. A raw-text
+/// regex could not draw that line and did flag one (#3064), so a .json file is now read as a
+/// parsed manifest and a .cs file is searched only inside its string literals — see
+/// <see cref="DeclaresBaseApplicationFloor(string, string)"/>.
 /// </summary>
 public sealed class BaseAppFloorFixtureGuardTests
 {
@@ -106,11 +111,91 @@ public sealed class BaseAppFloorFixtureGuardTests
         DeclaresBaseApplicationFloor(path, File.ReadAllText(path));
 
     /// <summary>
-    /// RED placeholder (#3064): still the raw-text scan, so a comment quoting the property
-    /// counts as declaring it. Replaced in the next commit.
+    /// #3064 — the same question about content held in memory, dispatched on the file kind.
+    /// A <c>.json</c> file IS a manifest, so the property is read from the parsed document; a
+    /// <c>.cs</c> file only ever REACHES a manifest through a string literal, so only string
+    /// literals are searched.
+    ///
+    /// Before this, both were one raw-text regex over the whole file, which cannot tell a JSON
+    /// property from a comment quoting one. ServerAppVersionBumpTests.cs (PR #2908) failed the
+    /// BC 27.5 and 28.4 legs for a <c>//</c> comment written to record that the file complies
+    /// with this very rule — so the guard punished a file for explaining that it obeyed, and
+    /// the cheapest way back to green was to delete the explanation. The alternative, adding
+    /// the file to <see cref="AllowedSources"/>, would have recorded a violation that does not
+    /// exist, and an allowlist carrying entries for files that never violated anything is one
+    /// a reader stops trusting — which is the mechanism the rule depends on.
     /// </summary>
     internal static bool DeclaresBaseApplicationFloor(string fileName, string text) =>
-        ApplicationProperty.IsMatch(text);
+        Path.GetExtension(fileName).Equals(".json", StringComparison.OrdinalIgnoreCase)
+            ? ManifestDeclaresFloor(text)
+            : CSharpWritesFloor(text);
+
+    /// <summary>
+    /// A manifest declares the floor on exactly the terms the runner reads it. All three
+    /// readers — <c>Dependencies.ReadDependencies</c>, <c>InProcessAppPackager</c> and
+    /// <c>Provisioning</c> — do <c>root.TryGetProperty("application", …)</c> and gate on
+    /// <c>ValueKind == JsonValueKind.String</c> with a non-blank value, so a key of that name
+    /// nested in a <c>dependencies[]</c> entry, or a null one, synthesises no implicit
+    /// Microsoft/Application root and costs nothing. Matching the readers is what makes this a
+    /// guard against the COST rather than against a spelling.
+    ///
+    /// A manifest that will not parse falls back to the raw scan and over-reports. A guard that
+    /// answered "no violation" about content it could not read would be the exact failure this
+    /// class exists to prevent, so the fallback errs toward flagging.
+    /// </summary>
+    private static bool ManifestDeclaresFloor(string text)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(text);
+            return doc.RootElement.ValueKind == JsonValueKind.Object
+                && doc.RootElement.TryGetProperty("application", out var v)
+                && v.ValueKind == JsonValueKind.String
+                && !string.IsNullOrWhiteSpace(v.GetString());
+        }
+        catch (JsonException)
+        {
+            return ApplicationProperty.IsMatch(text);
+        }
+    }
+
+    /// <summary>
+    /// A C# source writes the floor when the property appears inside a STRING LITERAL, the only
+    /// route by which text in a .cs file can end up in a manifest on disk. Roslyn is what draws
+    /// the line: the sibling guards in this project strip whole-line <c>//</c> comments by hand
+    /// (ScratchDirOwnershipGuardTests, FieldTriggerShapeGapCallSiteTests), which misses a
+    /// trailing comment and a <c>/* */</c> block, and a hand-rolled stripper would in turn have
+    /// to know not to cut at the <c>//</c> inside a URL literal. Tokenising asks the compiler
+    /// instead.
+    ///
+    /// <c>DescendantTokens()</c> does not descend into trivia, so comments — including XML doc
+    /// comments and <c>#if false</c> regions — contribute no tokens at all. Both
+    /// <c>Text</c> (the escaped form a manifest embedded in a C# literal uses,
+    /// <c>\"application\":</c>) and <c>ValueText</c> (the unescaped value) are checked, so
+    /// either spelling counts.
+    /// </summary>
+    private static bool CSharpWritesFloor(string text)
+    {
+        foreach (var token in CSharpSyntaxTree.ParseText(text).GetRoot().DescendantTokens())
+        {
+            if (!IsStringContent(token.Kind())) continue;
+            if (ApplicationProperty.IsMatch(token.Text) || ApplicationProperty.IsMatch(token.ValueText))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>Every token kind whose text is string CONTENT rather than code.</summary>
+    private static bool IsStringContent(SyntaxKind kind) => kind
+        is SyntaxKind.StringLiteralToken
+        or SyntaxKind.Utf8StringLiteralToken
+        or SyntaxKind.SingleLineRawStringLiteralToken
+        or SyntaxKind.MultiLineRawStringLiteralToken
+        or SyntaxKind.Utf8SingleLineRawStringLiteralToken
+        or SyntaxKind.Utf8MultiLineRawStringLiteralToken
+        or SyntaxKind.InterpolatedStringTextToken
+        or SyntaxKind.InterpolatedRawStringEndToken;
 
     /// <summary>
     /// Checked-in fixture manifests permitted to declare the floor, with the reason. Each

--- a/AlRunner.Tests/BaseAppFloorFixtureGuardTests.cs
+++ b/AlRunner.Tests/BaseAppFloorFixtureGuardTests.cs
@@ -100,6 +100,19 @@ public sealed class BaseAppFloorFixtureGuardTests
         @"\\?""application\\?""\s*:", RegexOptions.Compiled);
 
     /// <summary>
+    /// True when <paramref name="path"/> DECLARES the Base Application floor.
+    /// </summary>
+    internal static bool DeclaresBaseApplicationFloor(string path) =>
+        DeclaresBaseApplicationFloor(path, File.ReadAllText(path));
+
+    /// <summary>
+    /// RED placeholder (#3064): still the raw-text scan, so a comment quoting the property
+    /// counts as declaring it. Replaced in the next commit.
+    /// </summary>
+    internal static bool DeclaresBaseApplicationFloor(string fileName, string text) =>
+        ApplicationProperty.IsMatch(text);
+
+    /// <summary>
     /// Checked-in fixture manifests permitted to declare the floor, with the reason. Each
     /// one has the FLOOR ITSELF as its subject: remove it and the fixture stops testing
     /// anything. Paths are relative to AlRunner.Tests/, with '/' separators.
@@ -146,7 +159,7 @@ public sealed class BaseAppFloorFixtureGuardTests
         var offenders = new List<string>();
         foreach (var path in FixtureManifestPaths())
         {
-            if (!ApplicationProperty.IsMatch(File.ReadAllText(path))) continue;
+            if (!DeclaresBaseApplicationFloor(path)) continue;
             var rel = Rel(path);
             if (!AllowedFixtures.ContainsKey(rel)) offenders.Add(rel);
         }
@@ -165,7 +178,7 @@ public sealed class BaseAppFloorFixtureGuardTests
         var offenders = new List<string>();
         foreach (var path in TestSourcePaths())
         {
-            if (!ApplicationProperty.IsMatch(File.ReadAllText(path))) continue;
+            if (!DeclaresBaseApplicationFloor(path)) continue;
             var rel = Rel(path);
             if (!AllowedSources.ContainsKey(rel)) offenders.Add(rel);
         }
@@ -190,14 +203,14 @@ public sealed class BaseAppFloorFixtureGuardTests
         foreach (var (rel, why) in AllowedFixtures)
         {
             var path = Path.Combine(TestsDir, rel.Replace('/', Path.DirectorySeparatorChar));
-            if (!File.Exists(path) || !ApplicationProperty.IsMatch(File.ReadAllText(path)))
+            if (!File.Exists(path) || !DeclaresBaseApplicationFloor(path))
                 stale.Add($"{rel} ({why})");
         }
 
         foreach (var (rel, why) in AllowedSources)
         {
             var path = Path.Combine(TestsDir, rel.Replace('/', Path.DirectorySeparatorChar));
-            if (!File.Exists(path) || !ApplicationProperty.IsMatch(File.ReadAllText(path)))
+            if (!File.Exists(path) || !DeclaresBaseApplicationFloor(path))
                 stale.Add($"{rel} ({why})");
         }
 
@@ -206,4 +219,193 @@ public sealed class BaseAppFloorFixtureGuardTests
             "Delete them — a stale entry silently permits the next fixture that takes the name:\n  "
             + string.Join("\n  ", stale));
     }
+
+    // ── #3064: what counts as DECLARING the floor, versus merely spelling it ──────────────
+    //
+    // These facts drive DeclaresBaseApplicationFloor directly, on synthetic content, because
+    // the two scanning facts above can only ever assert about the sources that happen to be
+    // checked in today — they cannot show what the matcher does with a shape nobody has
+    // written yet.
+    //
+    // The guard scans every .cs file in this project, THIS ONE INCLUDED. So the fixtures below
+    // must never spell the manifest key next to a colon in this source; they compose it from
+    // Key at runtime instead. Spelling it here would make this file an offender of the rule it
+    // enforces, and the only ways out would be adding it to AllowedSources — recording a
+    // violation that does not exist, which is exactly the degradation #3064 warns about — or
+    // deleting the tests.
+
+    private const string Key = "application";
+
+    /// <summary>
+    /// Expands a fixture's placeholders: <c>PROP</c> becomes the quoted manifest key,
+    /// <c>EPROP</c> the backslash-escaped form a manifest embedded in a C# string literal
+    /// uses. EPROP is substituted first, because PROP is a substring of it.
+    /// </summary>
+    private static string Sub(string template) => template
+        .Replace("EPROP", "\\\"" + Key + "\\\"")
+        .Replace("PROP", "\"" + Key + "\"");
+
+    /// <summary>
+    /// Anchors the placeholder trick against reality: <see cref="Sub"/> must produce the exact
+    /// spelling a genuine allowlisted manifest uses, and that manifest must still read as a
+    /// declaration. Without this, every fixture below could agree with a matcher that is wrong
+    /// about what a real app.json looks like.
+    /// </summary>
+    [Fact]
+    public void ThePlaceholderExpansion_MatchesARealAllowlistedManifest()
+    {
+        var real = Path.Combine(TestsDir, "Fixtures", "SubscriberScanAudit", "app.json");
+        Assert.True(File.Exists(real), $"{real} not found — was the fixture renamed?");
+
+        Assert.Contains(Sub("PROP"), File.ReadAllText(real), StringComparison.Ordinal);
+        Assert.True(DeclaresBaseApplicationFloor(real));
+    }
+
+    /// <summary>
+    /// #3064, the reported defect. A source that quotes the property while explaining that it
+    /// deliberately does NOT declare the floor is not a violation. The raw-text scan could not
+    /// tell the two apart, so ServerAppVersionBumpTests.cs (PR #2908) failed the BC 27.5 and
+    /// 28.4 legs for a <c>//</c> comment written to document compliance with this very rule,
+    /// and the cheapest way back to green was to delete the explanation.
+    /// </summary>
+    [Fact]
+    public void AProseCommentQuotingTheProperty_IsNotADeclaration()
+    {
+        var src = Sub(""""
+            public class Fixture
+            {
+                // No PROP: "1.0.0.0" here — the Base Application floor is not the subject.
+                /* Nor PROP: "27.0.0.0" in a block comment. */
+                /// <summary>Nor <c>PROP: "1.0.0.0"</c> in a doc comment.</summary>
+                public string Manifest() => "{ \"id\": \"a\", \"platform\": \"1.0.0.0\" }";
+            }
+            """");
+
+        Assert.False(DeclaresBaseApplicationFloor("Fixture.cs", src),
+            "a comment quoting the property declares no floor: nothing in this source reaches a "
+            + "manifest, so no runner subprocess loads the platform closure because of it.");
+    }
+
+    /// <summary>
+    /// The control that stops the fix above from being a weakening: the plain shape every
+    /// allowlisted source actually uses — a manifest embedded in a C# string literal with the
+    /// quotes escaped — must still read as a declaration. This one is green before AND after,
+    /// which is what makes the RED case believable rather than a matcher that returns false.
+    /// </summary>
+    [Fact]
+    public void AManifestInAStringLiteral_IsADeclaration()
+    {
+        var src = Sub(""""
+            public class Fixture
+            {
+                public string Manifest() => "{ \"id\": \"a\", EPROP: \"1.0.0.0\" }";
+            }
+            """");
+
+        Assert.True(DeclaresBaseApplicationFloor("Fixture.cs", src));
+    }
+
+    /// <summary>
+    /// ProvisionExplicitModesTests.cs's shape: the property is written in one literal and the
+    /// version concatenated on from a variable, so the key and its value never share a token.
+    /// </summary>
+    [Fact]
+    public void AManifestConcatenatedAcrossLiterals_IsADeclaration()
+    {
+        var src = Sub(""""
+            public class Fixture
+            {
+                public string Manifest(string major) => "{ EPROP: \"" + major + ".0.0.0\" }";
+            }
+            """");
+
+        Assert.True(DeclaresBaseApplicationFloor("Fixture.cs", src));
+    }
+
+    /// <summary>A raw string literal carries no escapes, so the key is spelled plainly.</summary>
+    [Fact]
+    public void AManifestInARawStringLiteral_IsADeclaration()
+    {
+        var src = Sub(""""
+            public class Fixture
+            {
+                public string Manifest() => """
+                    { "id": "a", PROP: "1.0.0.0" }
+                    """;
+            }
+            """");
+
+        Assert.True(DeclaresBaseApplicationFloor("Fixture.cs", src));
+    }
+
+    /// <summary>And an interpolated one, where the key sits in interpolated-text tokens.</summary>
+    [Fact]
+    public void AManifestBuiltByInterpolation_IsADeclaration()
+    {
+        var src = Sub(""""
+            public class Fixture
+            {
+                public string Manifest(string v) => $"{{ EPROP: \"{v}\" }}";
+            }
+            """");
+
+        Assert.True(DeclaresBaseApplicationFloor("Fixture.cs", src));
+    }
+
+    /// <summary>A source that writes only the platform floor declares no Base App floor.</summary>
+    [Fact]
+    public void ASourceWritingOnlyThePlatformFloor_IsNotADeclaration()
+    {
+        var src = """"
+            public class Fixture
+            {
+                public string Manifest() => "{ \"id\": \"a\", \"platform\": \"1.0.0.0\" }";
+            }
+            """";
+
+        Assert.False(DeclaresBaseApplicationFloor("Fixture.cs", src));
+    }
+
+    /// <summary>The checked-in-fixture half: a manifest that declares the floor at the root.</summary>
+    [Fact]
+    public void AFixtureManifestDeclaringTheFloor_IsADeclaration() =>
+        Assert.True(DeclaresBaseApplicationFloor("app.json",
+            Sub("""{ "id": "a", "platform": "1.0.0.0", PROP: "1.0.0.0" }""")));
+
+    /// <summary>And one that does not.</summary>
+    [Fact]
+    public void AFixtureManifestWithoutTheFloor_IsNotADeclaration() =>
+        Assert.False(DeclaresBaseApplicationFloor("app.json",
+            """{ "id": "a", "platform": "1.0.0.0", "dependencies": [] }"""));
+
+    /// <summary>
+    /// Nested, not root: all three readers of this property —
+    /// <c>Dependencies.ReadDependencies</c>, <c>InProcessAppPackager</c> and
+    /// <c>Provisioning</c> — call <c>root.TryGetProperty("application", …)</c>, so a key of
+    /// that name inside a <c>dependencies[]</c> entry injects no implicit Microsoft/Application
+    /// root and costs nothing. The raw-text scan called it a violation.
+    /// </summary>
+    [Fact]
+    public void TheKeyNestedInsideAnotherObject_IsNotTheTopLevelFloor() =>
+        Assert.False(DeclaresBaseApplicationFloor("app.json",
+            Sub("""{ "id": "a", "dependencies": [ { "name": "X", PROP: "1.0.0.0" } ] }""")));
+
+    /// <summary>
+    /// Same three readers gate on <c>ValueKind == JsonValueKind.String</c> and a non-blank
+    /// value, so a null floor synthesises no dependency either.
+    /// </summary>
+    [Fact]
+    public void ANullFloor_IsNotADeclaration() =>
+        Assert.False(DeclaresBaseApplicationFloor("app.json", Sub("""{ "id": "a", PROP: null }""")));
+
+    /// <summary>
+    /// A manifest that will not parse must not read as clean. The precision this fix buys comes
+    /// from understanding the file; on input the matcher does not understand, it falls back to
+    /// the raw scan and over-reports, because a guard answering "no violation" about content it
+    /// could not read is the exact failure mode this class exists to prevent.
+    /// </summary>
+    [Fact]
+    public void AnUnparseableManifest_FallsBackToTheRawScan_RatherThanReadingClean() =>
+        Assert.True(DeclaresBaseApplicationFloor("app.json",
+            Sub("""{ "id": "a", PROP: "1.0.0.0", }}}""")));
 }

--- a/AlRunner.Tests/ServerAppVersionBumpTests.cs
+++ b/AlRunner.Tests/ServerAppVersionBumpTests.cs
@@ -34,10 +34,11 @@ public sealed class ServerAppVersionBumpTests
         var root = TestScratch.Dir("al-runner-server-versionbump-" + suffix);
         Directory.CreateDirectory(root);
 
-        // No Base Application floor is declared below: it is not the subject here and costs
-        // ~70 s cold per invocation (.claude/rules/no-base-app-in-csharp-tests.md). Written
-        // without the literal property spelling because BaseAppFloorFixtureGuardTests scans
-        // this file as raw text and cannot tell a comment from a manifest key (see #3064).
+        // No "application": below — the Base Application floor is not the subject here and
+        // costs ~70 s cold per invocation (.claude/rules/no-base-app-in-csharp-tests.md).
+        // Spelling the property in prose is safe again as of #3064: the guard reads a .cs
+        // file's string literals, not its comments, so this sentence is also the end-to-end
+        // witness for that fix — reverting the guard to a raw-text scan turns this file red.
         File.WriteAllText(Path.Combine(root, "app.json"), $$"""
         {
           "id": "{{appId}}",


### PR DESCRIPTION
Closes #3064

## Diagnosis

`BaseAppFloorFixtureGuardTests` decided who declares the Base Application floor with one raw-text regex over the whole file:

```csharp
private static readonly Regex ApplicationProperty = new(
    @"\\?""application\\?""\s*:", RegexOptions.Compiled);
```

That matches the characters anywhere, so a `//` comment quoting the property counts as declaring it. `ServerAppVersionBumpTests.cs` (PR #2908) failed the BC 27.5 and 28.4 legs for a comment written to record that the file complies with `.claude/rules/no-base-app-in-csharp-tests.md` — the guard punished a file for explaining that it obeyed the rule, and the cheapest way back to green was to delete the explanation. The alternative, adding the file to `AllowedSources`, would have recorded a violation that does not exist; an allowlist carrying entries for files that never violated anything is one a reader stops trusting, and that allowlist is the mechanism the rule depends on.

## What changed

The three matching call sites now go through one `DeclaresBaseApplicationFloor`, which dispatches on the file kind:

- **`.json` — parse it.** A manifest declares the floor on exactly the terms the runner reads it: a top-level `application` property, `ValueKind == JsonValueKind.String`, non-blank. That is the same `root.TryGetProperty("application", …)` all three readers use — `Dependencies.ReadDependencies`, `InProcessAppPackager` and `Provisioning` — so the guard now matches the condition that causes the cost rather than a spelling.
- **`.cs` — tokenize it.** Roslyn (`CSharpSyntaxTree.ParseText(...).GetRoot().DescendantTokens()`), matching only string-literal tokens: the only route by which text in a `.cs` file reaches a manifest on disk. `DescendantTokens()` does not descend into trivia, so comments — line, block, XML doc, and `#if false` regions — contribute no tokens at all. Both `token.Text` (the escaped `\"application\":` form an embedded manifest uses) and `token.ValueText` are checked.
- **The old regex stays as the fallback** for a manifest that will not parse. A guard answering "no violation" about content it could not read is the exact failure this class exists to prevent, so unreadable input over-reports.

The guard is not weakened: every real embedded-manifest shape still counts, and all nine allowlist entries still match, so no entry went stale.

Also removed the workaround this cost: `ServerAppVersionBumpTests.cs` spells `"application":` in its comment again. That doubles as the end-to-end witness — revert the matcher to a raw-text scan and that file goes red.

## RED → GREEN

RED (commit 1) routes the call sites through the helper while it is still the raw regex, and adds twelve facts driving it on synthetic content. Three fail, and they are the defect:

| fact | raw-text scan | correct |
|---|---|---|
| `AProseCommentQuotingTheProperty_IsNotADeclaration` (`//`, `/* */` and `///`) | declares | does not |
| `TheKeyNestedInsideAnotherObject_IsNotTheTopLevelFloor` | declares | does not — no reader looks below the root |
| `ANullFloor_IsNotADeclaration` | declares | does not — all three readers gate on `ValueKind == String` |

Nine controls pass before and after, which is what stops the fix from being a matcher that returns `false`: a manifest in a plain string literal, one concatenated across literals (the `ProvisionExplicitModesTests` shape, where the key and its value never share a token), one in a raw string literal, one built by interpolation, a `.json` manifest that declares the floor, one that does not, a source writing only the platform floor, an unparseable manifest, and `ThePlaceholderExpansion_MatchesARealAllowlistedManifest`.

That last one matters. The guard scans every `.cs` file in the project, this one included, so the fixtures cannot spell the key next to a colon in this source — they compose it from `Key` at runtime. Spelling it would make the file an offender of the rule it enforces. So one fact anchors the composition against reality: the composed spelling must be `Assert.Contains`-present in a genuine allowlisted `app.json`, and that file must still read as a declaration. Without it, every synthetic fixture could agree with a matcher that is wrong about what a real manifest looks like.

GREEN (commit 2): 15/15.

## Tests run locally

`dotnet test AlRunner.Tests --filter` over `BaseAppFloorFixtureGuardTests`, `ParserStaticsIsolationGuardTests`, `ScratchDirOwnershipGuardTests`, `DocumentServiceProviderScopeGuardTests`, `BracelessIfSecondStatementGuardTests`, `TestArtifactsGateTests`, `ServerAppVersionBumpTests` — **81 passed, 0 failed, 30 s**. That covers every sibling source-scanning guard plus the file whose comment I edited. Not the full suite; CI runs the sweep. No result claimed here that I did not run in this state.

Cost: the source scan now parses ~250 C# files, taking the class from 74 ms to about 1 s. Paid twice per run, in the source scan and the stale check.

## Fixing the shape, not the reported line

1. **The same wrong pattern at another call site.** Inside this class, all three sites — the fixture scan, the source scan, and the stale check — used the same regex and now share one matcher, so the forward and negative directions can never disagree about what a declaration is.

2. **A sibling making the same assumption — yes, one, and it is already carrying the workaround.** `DocumentServiceProviderScopeGuardTests` scans `AlRunner*` sources with two raw-text regexes and excludes its own source (`SelfSourcePath`) because three of the four matches in that file are prose. That exclusion is a hole: the one file never checked is the one whose author is most likely to be experimenting with the contract it forbids. Filed as #3153 rather than fixed here — its claim is about identifiers in code, not string content, so it needs the opposite token filter ("everything except trivia") and its own RED to GREEN. #3153 also records the audit of the other five siblings, none of which is currently wrong.

3. **Two paths writing the same state.** Covered by (1): one matcher, one invariant.

## Not upstream

This is C#-test infrastructure. It asserts nothing about Business Central's behaviour, so it owes nothing to the al-language corpus.

---
Opened by an agent (impl-6) acting on the account holder's behalf.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf