### PR TITLE
docs(ci): narrow the cancelled-run re-run exemption to commits with no failure log

### DIFF
--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -20,7 +20,7 @@ tools/ci-wait.py 2379 --timeout 2400
 | 1 | a required check failed; **the failing log is already printed**. The list is what has reported SO FAR — while other required checks are still running it can still grow, and the verdict says how many have not reported. Do not scope a diagnosis to those names until every check has reported (a one-leg failure that turned out to be eight cost a version-specific diagnosis that was never relevant). |
 | 2 | timed out while still running — **not a verdict**, call again |
 | 3 | could not determine (auth, network, no checks) — **or** the required-context set could not be established without narrowing it (#3002). A ruleset read that comes back missing a context the tool already knows about is refused, because judging on the smaller set makes "every required check passed" vacuously true. |
-| 4 | **blocked, not failing** — every check passed but the merge is still refused and nothing else says why. Two causes: a *required* context is `cancelled` on this commit (#2726) — the one case where `gh run rerun` is correct, since a cancelled run has no failure log to destroy; or a *required* context produced **no check run at all** and every workflow run for the commit has finished (#2807), which is a trigger/`paths:` filter question, not a re-run. Never reach for `--admin` for either. |
+| 4 | **blocked, not failing** — every check passed but the merge is still refused and nothing else says why. Two causes: a *required* context is `cancelled` on this commit (#2726) — the one case where `gh run rerun` can be correct, but only after checking that no check run on this commit concluded `failure` before the cancellation (see section 3); or a *required* context produced **no check run at all** and every workflow run for the commit has finished (#2807), which is a trigger/`paths:` filter question, not a re-run. Never reach for `--admin` for either. |
 
 `ci-wait.py` reads the required contexts from the **live branch ruleset** on each
 invocation (`GET /repos/{owner}/{repo}/rules/branches/main`, which reports only *active*
@@ -142,6 +142,28 @@ run — not even after saving the log.** A re-run is never a diagnostic step —
 evidence a diagnosis needs, and section 5's flake-evidence standard needs a second, independent
 run, not the same one overwritten in place. See "Getting a second run of the same commit"
 under section 5 for how to get one without this.
+
+### "Cancelled" does not mean "no log to lose"
+
+This rule used to exempt cancelled runs outright, on the reasoning that a cancelled run never
+produced a failure log. It can have produced one: a check run concludes `failure` **on its
+merits** and its parent workflow run is cancelled only afterwards, so the log is real and
+`gh run rerun` overwrites it just the same. Measured on head `c6377b30` (#3142), where
+`preflight.py unit tests` carried three check runs for the one name — a `failure`, a
+`cancelled` from run 34037049850, and a newest `failure` from run 34037050361 whose own
+run-level conclusion was `failure`.
+
+So before re-running a cancelled required context, ask whether anything on that commit failed
+on its merits:
+
+```bash
+gh api "repos/StefanMaron/BusinessCentral.AL.Runner/commits/<FULL-SHA>/check-runs?per_page=100" \
+  --jq '.check_runs[] | select(.conclusion=="failure") | "\(.name) \(.id)"'
+```
+
+Nothing failing → re-run the cancelled run; that is the #2726 case and it stands. Something
+failing → read and save its log first, or get the second run by one of the routes in section 5
+instead.
 
 ## 4. Diagnose from the log, not from a theory
 

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -745,8 +745,10 @@ Hard limits, whatever the loop concludes:
 - Never force-push a branch you do not own, and never `--admin` past a failing check.
 - Never merge a PR authored by someone else.
 - Never re-run a **failed** CI job — it destroys the log permanently. Re-running a **cancelled**
-  one is fine; it has no failure log to lose, and a cancelled required context can block a merge
-  with everything green.
+  required context is still the fix when one blocks a merge with everything green, but check
+  first that nothing on that commit concluded `failure` before the cancellation — a check run
+  can fail on its merits inside a run somebody cancelled afterwards, and that log is as real as
+  any other (`ci-verdicts.md` §3).
 - Never delete a shared cache or a scratch directory you did not create. Other work may be live.
 - Never read a secret, and never try to unlock a credential agent.
 

--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -226,10 +226,13 @@ required context is cancellable on its own commit any more; `check_required_cont
 CI if one becomes so again. And `ci-wait.py` now returns **exit 4** naming the cancelled
 context instead of reporting GREEN.
 
-If you still land in this state, re-run just the cancelled run — it clears in under a minute,
-and that is NOT the forbidden `gh run rerun`, because a cancelled run has no failure log to
-destroy. Do not reach for `--admin`: protection is working, the context genuinely is not
-satisfied.
+If you still land in this state, re-run just the cancelled run — it clears in under a minute.
+That is NOT the forbidden `gh run rerun`, **provided nothing on that commit concluded
+`failure` before the cancellation**: a check run can fail on its merits and only then have its
+run cancelled, and re-running destroys that log like any other. Check the commit's check runs
+first and, if one failed, read its log or take a second run by another route
+(`ci-verdicts.md` §3, §5). Do not reach for `--admin`: protection is working, the context
+genuinely is not satisfied.
 
 **Auto-merge drains the queue — but a drained queue is not a verified one.** The
 "branches must be up to date" protection rule was removed, so arming several PRs lets them


### PR DESCRIPTION
Closes #3156

Three checked-in agent documents told every agent in this repository that re-running a **cancelled** CI run is always safe, because a cancelled run has no failure log to lose. That is false in a reachable case, and a measurement made while fixing `tools/ci-wait.py` (issue #3142, PR #3151) falsified it.

## The measurement

A check run can conclude `failure` **on its merits** and only afterwards have its parent workflow run cancelled. Its log is real, and `gh run rerun` on the cancelled run overwrites it exactly as re-running a failed run would.

On head `c6377b30716484502fad6bbe69db6b44efab9498`, `preflight.py unit tests` had three check runs for the one context name: a `failure`, a `cancelled` (run 34037049850, cancelled at the run level), and a newest `failure` from run 34037050361 whose own run-level conclusion is `failure`. The recipe added below reproduces it today:

```
$ gh api "repos/StefanMaron/BusinessCentral.AL.Runner/commits/c6377b3071.../check-runs?per_page=100" \
    --jq '.check_runs[] | select(.conclusion=="failure") | "\(.name) \(.id)"'
preflight.py unit tests 101496925176
preflight.py unit tests 101496769151
```

## A narrowing, not a reversal

Re-running a cancelled required context is still the right move in the #2726 case the guidance was written for, and that survives. What changes is the condition: check first whether any check run on that commit concluded `failure` before the cancellation. If one did, read and save its log, or take a second run by one of the routes already in `ci-verdicts.md` §5 (`bc-leg-rerun.yml`, the corpus `ci.yml` `bc_version` input, an empty commit) — pointed at, not restated.

## What changed

- `.claude/rules/ci-verdicts.md:23` — exit-4 row: "the one case where `gh run rerun` is correct, since a cancelled run has no failure log to destroy" becomes "can be correct, but only after checking that no check run on this commit concluded `failure` before the cancellation (see section 3)".
- `.claude/rules/ci-verdicts.md` §3 — a short subsection, "Cancelled does not mean no log to lose", carrying the measurement and the one-line check. This is now the single normative statement.
- `.claude/skills/autonomous-cycle/SKILL.md:747-750` — Blast radius bullet, corrected and pointed at `ci-verdicts.md` §3.
- `.claude/skills/orchestrating-a-session/SKILL.md:229-235` — the "re-run just the cancelled run" paragraph, corrected and pointed at `ci-verdicts.md` §3, §5.

## Other copies

Swept `.claude/rules/`, `.claude/skills/`, `.claude/commands/`, `.claude/agents/`, `docs/`, `README.md` and `.github/` with `rg` (not the bare `grep -E` shell function, which exits 0 with no output here). The only other copies of the claim are `tools/ci-wait.py:105` and `:769`, inside a file PR #3151 is currently changing — deliberately untouched here so the two do not conflict. #3151 already adds the conditional warning to the tool's output path.

## Scope and testing

Documentation only: prose in three rule/skill files. It asserts nothing about BC, so nothing is owed to the upstream corpus, and it touches no code and no test — `require-tests.yml`'s gate does not trigger, since the diff is outside `AlRunner/`. The one executable claim in the new text (the `gh api` recipe) was run against the measured SHA and reproduces the mixed shape; that output is quoted above. No guard asserts on the prose of these files, so nothing else moves.

## On a drift guard

Not worth adding, in my judgement. The three copies drifted because each restated the *reasoning* in its own voice, and a substring guard over prose would either be trivially satisfied or would force identical wording across three documents that deliberately differ in register. The structural fix is the one made here: the two skill files now state the rule and defer to `ci-verdicts.md` §3 for why, so there is one place to correct next time. That costs nothing to maintain; a text guard would.

---
Written by agent `stma-auto-1` (cycle 140) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
