### PR TITLE
ci(main): put a floor under how long main can sit without a verdict

### DIFF
--- a/.github/workflows/main-verdict-floor.yml
+++ b/.github/workflows/main-verdict-floor.yml
@@ -19,40 +19,73 @@ name: Main verdict floor
 #   merge interval   median 359 s, mean 673 s -> ~130 pushes/day
 #   full matrix run  mean 22.8 min wall, max 26.4 min, 74.6 job-minutes over 12 jobs
 #
-# A 23-minute run against a 6-minute median merge interval essentially never survives.
-# Modelling arrivals as Poisson: P(no merge in 22.8 min) = exp(-1368/673) = 13%, against an
-# observed 16/100. The mechanism is `cancel-in-progress: true` on a group keyed by
-# `github.ref`, which on `main` is the constant `refs/heads/main`.
+# A 23-minute run against a 6-minute median merge interval essentially never survives. The
+# mechanism is `cancel-in-progress: true` on a group keyed by `github.ref`, which on `main` is
+# the constant `refs/heads/main`, so every merge cancels the run the previous merge started.
+#
+# Modelling arrivals as Poisson gives P(no merge in 22.8 min) = exp(-1368/673) = 13% against an
+# observed 16/100, but that is a consistency check on ONE sample rather than a second
+# measurement: the arrival rate and the survival rate come from the same 100 timestamps, and
+# the service time is measured only over the 16 that survived. Nothing was fitted after the
+# fact, so it is not circular — it just is not independent confirmation.
+#
+# WHAT A CANCELLED RUN ACTUALLY COSTS
+#
+# Less than its wall time suggests, and this is the number the rest of the reasoning rests on.
+# Job-level timings (summing completed_at - started_at per job) over a 20-run sample of the 83:
+# mean 27.7 job-minutes, median 14.3, against 74.6 for a full run. So a cancelled run costs
+# 37% of a full one and cancelling saves about 63%.
+#
+# The reason is that the matrix legs are not CREATED until `resolve-versions` finishes (~0.8
+# min plus its own queue), so a run cancelled early burns almost nothing: five of the twenty
+# had zero jobs ever started, and estimating across all 83 walls, 49% died under six minutes.
+# Note that the low job queue delay (median 3 s, p99 177 s over 179 jobs in the busiest hour)
+# does NOT contradict this — it measures job-creation-to-job-start, not run-creation-to-leg-
+# start, so it says nothing about a run's first minute.
+#
+# This means test-matrix.yml's existing header was roughly right about the cost it was
+# addressing. This workflow does not overturn that decision; it covers what that decision
+# leaves uncovered.
 #
 # WHY THE FIX IS NOT "STOP CANCELLING"
 #
-# Two measurements rule that out, and both are counter-intuitive enough to be worth stating.
-#
-# 1. `cancel-in-progress: false` on the EXISTING shared per-ref group would be much worse
-#    than the problem. Runs in one concurrency group do not run in parallel when cancellation
-#    is off — they QUEUE. Utilisation is rho = lambda * W = (130/day) * 22.8 min = 2.05 > 1,
-#    an unstable queue that grows without bound. That is precisely the state test-matrix.yml's
-#    header records from 2026-09-03: six `main` runs queued behind hours of backlog, about to
-#    report on commits already six merges stale.
-#
-# 2. Giving each push its OWN group avoids the queue, but the tail is unaffordable. Replaying
+# 1. Giving each push its OWN group avoids any queue, but the tail is unaffordable. Replaying
 #    the observed arrival times against a 22.8-minute run gives a peak of 11 concurrent `main`
 #    runs — 72 concurrent jobs from `main` alone. GitHub Actions concurrency is scoped per
 #    ACCOUNT, so those slots come out of this repo's pull-request CI and the corpus
 #    repository's, i.e. out of the gate that actually blocks merges.
 #
-# Worth recording because it is the fact that inverts the existing reasoning: cancelling
-# `main` reclaims much less than it looks like it does. The legs start within seconds of each
-# other (job queue delay median 3 s, p99 177 s, max 206 s over 179 jobs in the busiest hour),
-# so a run cancelled at the median 6.5 min has already burned ~53 of its 74.6 job-minutes.
-# Across the 83 cancelled runs, cancelling saves 40% of the cost and 100% of the answer.
+# 2. `cancel-in-progress: false` on the EXISTING shared per-ref group is the simplest
+#    alternative, and it is NOT ruled out here — it is unmeasured. The arithmetic says
+#    rho = lambda * W = (130/day) * 22.8 min = 2.05, but that only implies an unbounded queue
+#    if same-group runs actually queue without bound, and nothing here establishes that.
+#
+#    The evidence that exists points the other way. `main` ran in exactly that configuration
+#    until c93598f8 landed 2026-09-03T21:31Z. Over the 37.3 h before it: 84 runs, 56 success /
+#    3 failure / 25 cancelled = 70% completion, with wall times clearly inflated by queueing
+#    (max 77.9 min against 26.4 min today). That is queueing, but 70% sustained over 37 hours
+#    is not an unbounded queue — it is consistent with GitHub holding at most one pending run
+#    per group and cancelling the rest. It also ran at 2.25 runs/h against today's 5.40, so it
+#    cannot tell us what happens at today's rate.
+#
+#    WHAT WOULD SETTLE IT, in ten minutes and one runner: on a scratch branch, a workflow with
+#    a fixed concurrency group, `cancel-in-progress: false` and a 5-minute sleep job. Push
+#    twice about a minute apart, then a third time. Observe whether run 2 goes pending, and
+#    whether run 3 cancels run 2 or queues behind it. Until someone does that, treat the
+#    per-push-group cost above as the measured comparison and this row as open.
 #
 # THE COST OF THIS WORKFLOW, AGAINST THE ALTERNATIVE
 #
-#   never cancel `main`   time-weighted mean +2.2 jobs, p95 21, PEAK 72
-#   this floor            time-weighted mean +2.5 jobs, p95 12, PEAK 12  (bounded by design)
+# Time-weighted mean concurrent jobs attributable to `main`, over the same 18.5 h window:
 #
-# Within noise on the average, 6x apart on the tail. The floor's peak is bounded by
+#   today (cancelling)    3.14 jobs
+#   never cancel `main`   6.72 jobs   (+3.57)   PEAK 72
+#   this floor            +2.09 jobs            PEAK 12  (bounded by design)
+#
+# So the floor is not merely comparable on the average — it is about 1.7x cheaper than never
+# cancelling, as well as 6x smaller on the tail. (An earlier draft of this comment put those
+# two within noise of each other; that came from treating today's baseline as 71%-loaded when
+# it is 37%-loaded, and correcting it favours this design.) The floor's peak is bounded by
 # construction: one run at a time, and a cadence longer than the longest observed run, so a
 # floor run can never be overtaken by its own successor.
 #

--- a/.github/workflows/main-verdict-floor.yml
+++ b/.github/workflows/main-verdict-floor.yml
@@ -1,0 +1,192 @@
+name: Main verdict floor
+
+# Issue #3003. `main`'s post-merge matrix is cancelled far more often than it completes, so
+# `main`'s health is not red — it is UNKNOWN, and unknown is worse than red because nothing
+# signals it. This workflow puts a floor under that: `main` may not go longer than one
+# cadence without a conclusive eight-leg verdict.
+#
+# WHAT IS AND IS NOT BROKEN
+#
+# `All BC versions passed` still gates every pull request targeting `main`, and that is
+# untouched. This is not a hole a red PR can merge through. What the cancellation destroys is
+# the POST-MERGE signal: when a merge breaks `main`, or when two individually-green PRs
+# conflict semantically after landing (#2924, and #2991 for the concrete instance), the run
+# that would have said so is cancelled by the next merge and nobody is notified.
+#
+# THE MEASUREMENT (2026-09-06, 100 most recent Test Matrix runs on `main`, 18.5 h)
+#
+#   conclusion       cancelled 83 | success 13 | failure 3 | in progress 1
+#   merge interval   median 359 s, mean 673 s -> ~130 pushes/day
+#   full matrix run  mean 22.8 min wall, max 26.4 min, 74.6 job-minutes over 12 jobs
+#
+# A 23-minute run against a 6-minute median merge interval essentially never survives.
+# Modelling arrivals as Poisson: P(no merge in 22.8 min) = exp(-1368/673) = 13%, against an
+# observed 16/100. The mechanism is `cancel-in-progress: true` on a group keyed by
+# `github.ref`, which on `main` is the constant `refs/heads/main`.
+#
+# WHY THE FIX IS NOT "STOP CANCELLING"
+#
+# Two measurements rule that out, and both are counter-intuitive enough to be worth stating.
+#
+# 1. `cancel-in-progress: false` on the EXISTING shared per-ref group would be much worse
+#    than the problem. Runs in one concurrency group do not run in parallel when cancellation
+#    is off — they QUEUE. Utilisation is rho = lambda * W = (130/day) * 22.8 min = 2.05 > 1,
+#    an unstable queue that grows without bound. That is precisely the state test-matrix.yml's
+#    header records from 2026-09-03: six `main` runs queued behind hours of backlog, about to
+#    report on commits already six merges stale.
+#
+# 2. Giving each push its OWN group avoids the queue, but the tail is unaffordable. Replaying
+#    the observed arrival times against a 22.8-minute run gives a peak of 11 concurrent `main`
+#    runs — 72 concurrent jobs from `main` alone. GitHub Actions concurrency is scoped per
+#    ACCOUNT, so those slots come out of this repo's pull-request CI and the corpus
+#    repository's, i.e. out of the gate that actually blocks merges.
+#
+# Worth recording because it is the fact that inverts the existing reasoning: cancelling
+# `main` reclaims much less than it looks like it does. The legs start within seconds of each
+# other (job queue delay median 3 s, p99 177 s, max 206 s over 179 jobs in the busiest hour),
+# so a run cancelled at the median 6.5 min has already burned ~53 of its 74.6 job-minutes.
+# Across the 83 cancelled runs, cancelling saves 40% of the cost and 100% of the answer.
+#
+# THE COST OF THIS WORKFLOW, AGAINST THE ALTERNATIVE
+#
+#   never cancel `main`   time-weighted mean +2.2 jobs, p95 21, PEAK 72
+#   this floor            time-weighted mean +2.5 jobs, p95 12, PEAK 12  (bounded by design)
+#
+# Within noise on the average, 6x apart on the tail. The floor's peak is bounded by
+# construction: one run at a time, and a cadence longer than the longest observed run, so a
+# floor run can never be overtaken by its own successor.
+#
+# It does not give every merged commit its own verdict, and that is deliberate — during a
+# burst, verdicts on five superseded trees are the waste the 2026-09-03 measurement correctly
+# objected to. What it gives is a bound on how long `main` can be red without anyone knowing.
+# Bisecting the ~5 merges between two floor runs is what `bc-leg-rerun.yml` is for.
+#
+# This is unrelated to #3141 (cutting the PR matrix from 8 legs to 3). If that lands, runs get
+# faster and the push-triggered run survives more often, which shrinks how often this floor
+# fires — it does not make it unnecessary, and nothing here depends on that decision.
+#
+# NOTE ON publish.yml: the release pushes to `main` as a fast-forward and any merge during its
+# ~40-minute run kills it. This workflow changes nothing about that. It adds no merge, holds
+# no lock on `main`, has its own concurrency group, and never writes to the repository — its
+# only effect on a release is the shared runner pool, at a bounded 12 jobs.
+
+on:
+  schedule:
+    # Derived, not chosen. Cadence must exceed a run's wall time or floor runs overlap, and
+    # with cancellation off, overlap means a queue with rho > 1. Measured mean 22.8 min, max
+    # 26.4 min, so the floor is 27 min; `*/30` is the first cron-expressible value above it.
+    # Re-derive this if the matrix gets materially slower or faster; the guard in
+    # AlRunner.Tests/MainVerdictFloorWorkflowTests.cs holds the relationship, not the number.
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+# Read-only. `actions: read` is what lets the guard below ask whether this commit already has
+# a verdict; nothing here needs write access to anything.
+permissions:
+  contents: read
+  actions: read
+
+# One floor run at a time, and never cancelled. A cancelled floor run would reproduce the
+# exact bug this workflow exists to fix. Cancellation is safe to switch off HERE, unlike on
+# the push path, because arrivals are one per cadence rather than one per merge: rho =
+# 22.8/30 = 0.76 < 1, so the queue is stable and at most one run deep.
+concurrency:
+  group: main-verdict-floor
+  cancel-in-progress: false
+
+jobs:
+  verdict-needed:
+    name: Does main HEAD still lack a verdict?
+    runs-on: ubuntu-latest
+    outputs:
+      needed: ${{ steps.check.outputs.needed }}
+    steps:
+      - name: Look for a conclusive verdict on this commit
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # This is a floor, not a second matrix. When the push-triggered run survived — 16%
+          # of the time in the sample, and most of the time overnight — HEAD's verdict is
+          # already known and re-running buys nothing.
+          #
+          # Keyed on the head SHA because that is what a verdict is ABOUT: a completed run
+          # for an older push is not this commit's result (ci-verdicts.md section 2). Both
+          # producers count, this workflow and the gating one, so a floor run does not
+          # re-verify a commit an earlier floor run already answered for.
+          conclusive=$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${SHA}&per_page=100" \
+            --jq '[.workflow_runs[]
+                   | select(.path == ".github/workflows/test-matrix.yml"
+                         or .path == ".github/workflows/main-verdict-floor.yml")
+                   | select(.conclusion == "success" or .conclusion == "failure")]
+                  | length')
+
+          if [ "$conclusive" -gt 0 ]; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            echo "$SHA already has $conclusive conclusive matrix run(s) — nothing to do."
+          else
+            echo "needed=true" >> "$GITHUB_OUTPUT"
+            echo "$SHA has no conclusive matrix run. Establishing one."
+          fi
+
+  floor-matrix:
+    # Deliberately NOT the job id `bc-tests`. A check's context is the leg name qualified by
+    # the CALLING job, so naming it `bc-tests` here would make these legs report the identical
+    # context to the gating path's (`bc-tests / BC <ver> (required)`) on the same head SHA.
+    # Those legs are not required contexts, so it would not gate anything — but it would make
+    # `gh pr checks` ambiguous about which run a verdict came from, which is the stale-verdict
+    # trap ci-verdicts.md section 2 exists for. `bc-leg-rerun.yml` learned this first.
+    #
+    # The matrix itself is bc-tests.yml's, called rather than copied. A second hand-maintained
+    # spelling of these steps drifted four times and failed two releases (#1976).
+    #
+    # No `bc-version-filter`: a floor that ran three of eight legs would re-introduce the
+    # BC-version blindness it exists to remove.
+    #
+    # `ref` is pinned to the SHA the guard above decided about, so the verdict this run
+    # records is unambiguously about that commit even if `main` moved while it was queued.
+    needs: verdict-needed
+    if: needs.verdict-needed.outputs.needed == 'true'
+    uses: ./.github/workflows/bc-tests.yml
+    with:
+      ref: ${{ github.sha }}
+
+  floor-verdict:
+    # Deliberately NOT named `All BC versions passed`. That context is one of main's two
+    # required status checks, declared in test-matrix.yml, and a second workflow reporting it
+    # on the same head SHA would make `gh pr checks` ambiguous about which run a verdict came
+    # from — the stale-verdict trap ci-verdicts.md section 2 exists for.
+    #
+    # It still has to FAIL when the matrix fails: a red scheduled run on the default branch is
+    # what actually notifies the account holder, and that notification is the whole deliverable
+    # of this workflow.
+    name: main verdict (post-merge)
+    needs: [verdict-needed, floor-matrix]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report
+        run: |
+          set -euo pipefail
+          needed='${{ needs.verdict-needed.outputs.needed }}'
+          result='${{ needs.floor-matrix.result }}'
+
+          if [ "$needed" != "true" ]; then
+            echo "main HEAD ${GITHUB_SHA} already had a verdict; floor did not re-run the matrix."
+            exit 0
+          fi
+
+          if [ "$result" != "success" ]; then
+            echo "main is NOT green at ${GITHUB_SHA} (matrix: ${result})."
+            echo ""
+            echo "This is the post-merge signal, not a pull-request gate — every commit since"
+            echo "the last conclusive run is a candidate. Open this run, find the red leg, then"
+            echo "narrow it with .github/workflows/bc-leg-rerun.yml rather than re-running this."
+            exit 1
+          fi
+
+          echo "main is green at ${GITHUB_SHA} across all BC versions."

--- a/AlRunner.Tests/MainVerdictFloorWorkflowTests.cs
+++ b/AlRunner.Tests/MainVerdictFloorWorkflowTests.cs
@@ -8,32 +8,39 @@
 //   merge interval        median 359 s, mean 673 s  -> ~130 pushes/day
 //   full matrix run       mean 22.8 min wall, max 26.4 min, 74.6 job-minutes over 12 jobs
 //
-// A 23-minute run against a 6-minute median merge interval essentially never survives:
-// modelling arrivals as Poisson gives P(no merge in 22.8 min) = exp(-1368/673) = 13%, and
-// the observed completion rate is 16/100. The mechanism is `cancel-in-progress: true` on a
-// concurrency group keyed by `github.ref`, which on `main` is the constant
-// `refs/heads/main`, so every merge cancels the run the previous merge started.
+// A 23-minute run against a 6-minute median merge interval essentially never survives. The
+// mechanism is `cancel-in-progress: true` on a concurrency group keyed by `github.ref`, which
+// on `main` is the constant `refs/heads/main`, so every merge cancels the run the previous
+// merge started.
 //
-// THE TWO MEASUREMENTS THAT DECIDE THE SHAPE OF THE FIX
+// WHAT A CANCELLED RUN COSTS, AND WHY IT IS LESS THAN IT LOOKS
 //
-// 1. Cancelling `main` reclaims much less than it appears to. The eight legs start within
-//    seconds of each other (job queue delay: median 3 s, p99 177 s, max 206 s, measured over
-//    179 jobs in the busiest hour), so a run cancelled at the median 6.5 min has already
-//    burned ~53 of its 74.6 job-minutes. Averaged over the 83 cancelled runs, cancelling
-//    saves 40% of the cost and 100% of the answer.
+// Job-level timings over a 20-run sample of the 83 cancelled runs: mean 27.7 job-minutes,
+// median 14.3, against 74.6 for a full run — so a cancelled run costs 37% of a full one and
+// cancelling saves about 63%. The matrix legs are not CREATED until `resolve-versions`
+// finishes, so a run cancelled early burns almost nothing; five of the twenty had zero jobs
+// ever started, and across all 83 walls 49% died under six minutes. (The low job queue delay
+// — median 3 s over 179 jobs in the busiest hour — does not bear on this: it measures
+// job-creation-to-job-start, not run-creation-to-leg-start.)
 //
-// 2. `cancel-in-progress: false` on the existing shared per-ref group would be far worse
-//    than the problem. Runs in one group do not run concurrently when cancellation is off —
-//    they QUEUE. Utilisation is rho = lambda * W = (130/day) * 22.8 min = 2.05 > 1, an
-//    unstable queue that grows without bound. That is exactly the state test-matrix.yml's
-//    header records from 2026-09-03: six `main` runs queued behind hours of backlog,
-//    reporting on commits already six merges stale.
+// So test-matrix.yml's existing header was roughly right about the cost it was addressing.
+// This workflow does not overturn that decision; it covers what that decision leaves
+// uncovered.
 //
-// So the fix cannot be "stop cancelling". Giving each push its own group would avoid the
-// queue, but the tail is unaffordable: replaying the observed arrival times against a
-// 22.8-minute run gives a peak of 11 concurrent `main` runs — 72 concurrent jobs from
-// `main` alone, on an Actions concurrency pool that is scoped per ACCOUNT and shared with
-// this repo's pull-request CI and with the corpus repository's.
+// WHY THE FIX IS NOT "STOP CANCELLING"
+//
+// Giving each push its own group avoids any queue, but the tail is unaffordable: replaying
+// the observed arrival times against a 22.8-minute run gives a peak of 11 concurrent `main`
+// runs — 72 concurrent jobs from `main` alone, on an Actions concurrency pool scoped per
+// ACCOUNT and shared with this repo's pull-request CI and the corpus repository's.
+//
+// `cancel-in-progress: false` on the existing shared group is the simplest alternative and is
+// NOT ruled out — it is unmeasured. rho = lambda * W = (130/day) * 22.8 min = 2.05, but that
+// implies an unbounded queue only if same-group runs queue without bound, which nothing here
+// establishes. `main` ran in that configuration until c93598f8 (2026-09-03T21:31Z): over the
+// 37.3 h before, 84 runs at 70% completion with wall times inflated by queueing (max 77.9 min
+// against 26.4 today) — queueing, but not unbounded, and at 2.25 runs/h against today's 5.40.
+// The workflow header names the ten-minute experiment that would settle it.
 //
 // WHAT THIS WORKFLOW DOES INSTEAD
 //
@@ -41,15 +48,16 @@
 // push-triggered matrix keeps cancelling — that is correct and stays — and a scheduled run
 // re-establishes the verdict on `main` HEAD whenever cancellation destroyed it.
 //
-// The cost comparison is the argument for it, and the two options are within noise of each
-// other on the average while differing by 6x on the tail:
+// Time-weighted mean concurrent jobs attributable to `main`, over the same 18.5 h window:
 //
-//   never cancel `main`   time-weighted mean +2.2 jobs, p95 21, PEAK 72
-//   scheduled floor       time-weighted mean +2.5 jobs, p95 12, PEAK 12   (bounded by design)
+//   today (cancelling)    3.14 jobs
+//   never cancel `main`   6.72 jobs   (+3.57)   PEAK 72
+//   scheduled floor       +2.09 jobs            PEAK 12   (bounded by design)
 //
-// The floor's peak is bounded by construction: one run at a time (its own concurrency group
-// with cancellation off) and a cadence longer than the longest observed run, so a floor run
-// can never overlap its own successor.
+// The floor is about 1.7x cheaper than never cancelling as well as 6x smaller on the tail.
+// Its peak is bounded by construction: one run at a time (its own concurrency group with
+// cancellation off) and a cadence longer than the longest observed run, so a floor run can
+// never overlap its own successor.
 using System.Text.RegularExpressions;
 using Xunit;
 
@@ -173,9 +181,17 @@ public sealed class MainVerdictFloorWorkflowTests
         // gating path's (`bc-tests / BC <ver> (required)`) on the same head SHA — and unlike
         // bc-leg-rerun.yml, the floor runs on `main`, which is exactly where the gating path
         // also reports. `gh pr checks` could then not tell which run a verdict came from.
-        var jobs = WorkflowParity.SplitJobs(CodeOnly(Read(Floor)));
+        var code = CodeOnly(Read(Floor));
+        var jobs = WorkflowParity.SplitJobs(code);
 
         Assert.DoesNotContain("bc-tests", jobs.Keys);
+
+        // The id is only half of it. A `name:` overrides the id in the context, so keeping the
+        // id `floor-matrix` while adding `name: bc-tests` would collide exactly as before and
+        // pass an id-only check. There is no `name:` on the calling job today, which is what
+        // makes the id load-bearing — so assert both, or the guard has a hole the size of the
+        // thing it guards.
+        Assert.DoesNotMatch(new Regex(@"name:\s*[""']?bc-tests[""']?\s*$", RegexOptions.Multiline), code);
     }
 
     [Fact]

--- a/AlRunner.Tests/MainVerdictFloorWorkflowTests.cs
+++ b/AlRunner.Tests/MainVerdictFloorWorkflowTests.cs
@@ -1,0 +1,223 @@
+// Issue #3003: `main`'s post-merge matrix is cancelled far more often than it completes, so
+// `main`'s health is not red — it is UNKNOWN, and unknown is worse than red because nothing
+// signals it.
+//
+// Measured 2026-09-06 over the 100 most recent Test Matrix runs on `main` (18.5 h):
+//
+//   conclusion            cancelled 83 | success 13 | failure 3 | in progress 1
+//   merge interval        median 359 s, mean 673 s  -> ~130 pushes/day
+//   full matrix run       mean 22.8 min wall, max 26.4 min, 74.6 job-minutes over 12 jobs
+//
+// A 23-minute run against a 6-minute median merge interval essentially never survives:
+// modelling arrivals as Poisson gives P(no merge in 22.8 min) = exp(-1368/673) = 13%, and
+// the observed completion rate is 16/100. The mechanism is `cancel-in-progress: true` on a
+// concurrency group keyed by `github.ref`, which on `main` is the constant
+// `refs/heads/main`, so every merge cancels the run the previous merge started.
+//
+// THE TWO MEASUREMENTS THAT DECIDE THE SHAPE OF THE FIX
+//
+// 1. Cancelling `main` reclaims much less than it appears to. The eight legs start within
+//    seconds of each other (job queue delay: median 3 s, p99 177 s, max 206 s, measured over
+//    179 jobs in the busiest hour), so a run cancelled at the median 6.5 min has already
+//    burned ~53 of its 74.6 job-minutes. Averaged over the 83 cancelled runs, cancelling
+//    saves 40% of the cost and 100% of the answer.
+//
+// 2. `cancel-in-progress: false` on the existing shared per-ref group would be far worse
+//    than the problem. Runs in one group do not run concurrently when cancellation is off —
+//    they QUEUE. Utilisation is rho = lambda * W = (130/day) * 22.8 min = 2.05 > 1, an
+//    unstable queue that grows without bound. That is exactly the state test-matrix.yml's
+//    header records from 2026-09-03: six `main` runs queued behind hours of backlog,
+//    reporting on commits already six merges stale.
+//
+// So the fix cannot be "stop cancelling". Giving each push its own group would avoid the
+// queue, but the tail is unaffordable: replaying the observed arrival times against a
+// 22.8-minute run gives a peak of 11 concurrent `main` runs — 72 concurrent jobs from
+// `main` alone, on an Actions concurrency pool that is scoped per ACCOUNT and shared with
+// this repo's pull-request CI and with the corpus repository's.
+//
+// WHAT THIS WORKFLOW DOES INSTEAD
+//
+// A floor: `main` may not go longer than one cadence without a conclusive verdict. The
+// push-triggered matrix keeps cancelling — that is correct and stays — and a scheduled run
+// re-establishes the verdict on `main` HEAD whenever cancellation destroyed it.
+//
+// The cost comparison is the argument for it, and the two options are within noise of each
+// other on the average while differing by 6x on the tail:
+//
+//   never cancel `main`   time-weighted mean +2.2 jobs, p95 21, PEAK 72
+//   scheduled floor       time-weighted mean +2.5 jobs, p95 12, PEAK 12   (bounded by design)
+//
+// The floor's peak is bounded by construction: one run at a time (its own concurrency group
+// with cancellation off) and a cadence longer than the longest observed run, so a floor run
+// can never overlap its own successor.
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class MainVerdictFloorWorkflowTests
+{
+    private static readonly string WorkflowDir = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".github", "workflows"));
+
+    private const string Floor = "main-verdict-floor.yml";
+    private const string Gating = "test-matrix.yml";
+    private const string RequiredCheckJobName = "All BC versions passed";
+
+    /// <summary>
+    /// Longest `main` Test Matrix run observed in the 100-run sample above, in minutes. The
+    /// floor's cadence must exceed it, or a floor run can be overtaken by its own successor —
+    /// which with cancellation off means queueing, the unstable-queue failure mode this
+    /// workflow exists to avoid.
+    /// </summary>
+    private const int LongestObservedRunMinutes = 27;
+
+    private static string Read(string name)
+    {
+        var path = Path.Combine(WorkflowDir, name);
+        Assert.True(File.Exists(path), $"expected workflow {name} at {path}");
+        return File.ReadAllText(path);
+    }
+
+    private static string CodeOnly(string text) =>
+        string.Join('\n', text.Split('\n').Where(l => !l.TrimStart().StartsWith('#')));
+
+    [Fact]
+    public void Floor_RunsOnlyOnAScheduleAndOnDemand()
+    {
+        // The cost guard. A `push` trigger here would run a SECOND eight-leg matrix on every
+        // merge — 130 extra runs a day — and a `pull_request` trigger would put a
+        // non-gating reporter on the same events the real gate uses.
+        Assert.Equal(new[] { "schedule", "workflow_dispatch" }, WorkflowTriggers.TriggersOf(Read(Floor)));
+    }
+
+    [Fact]
+    public void Floor_CadenceExceedsTheLongestObservedMatrixRun()
+    {
+        // Derived, not chosen: a cadence shorter than a run's wall time makes runs overlap,
+        // and with `cancel-in-progress: false` overlap means a queue with rho > 1. The
+        // measured mean is 22.8 min and the measured max 26.4 min, so the cadence floor is
+        // 27 min; `*/30` is the first cron-expressible value above it.
+        var cron = Regex.Match(CodeOnly(Read(Floor)), @"cron:\s*'\*/(\d+) \* \* \* \*'");
+
+        Assert.True(cron.Success,
+            "the floor must declare a fixed-minute cadence (`cron: '*/N * * * *'`) so this "
+            + "guard can compare N against the longest observed run.");
+        Assert.True(int.Parse(cron.Groups[1].Value) > LongestObservedRunMinutes,
+            $"cadence is {cron.Groups[1].Value} min but the longest observed `main` matrix run "
+            + $"is {LongestObservedRunMinutes} min — floor runs would overlap and queue.");
+    }
+
+    [Fact]
+    public void Floor_NeverCancelsItself_AndDoesNotShareTheGatingGroup()
+    {
+        // A cancelled floor run reproduces the bug it exists to fix. Sharing the gating
+        // workflow's group would be worse still: a merge would cancel the floor, so the
+        // floor could never outlive the merge rate that defeats the push-triggered run.
+        var code = CodeOnly(Read(Floor));
+
+        Assert.Matches(new Regex(@"cancel-in-progress:\s*false"), code);
+        Assert.DoesNotMatch(new Regex(@"group:.*github\.ref"), code);
+    }
+
+    [Fact]
+    public void Floor_NeverDeclaresTheRequiredAggregateCheck()
+    {
+        // `All BC versions passed` is one of main's two required status checks. A second
+        // workflow reporting that context on the same head SHA makes `gh pr checks`
+        // ambiguous about which run a verdict came from — the stale-verdict trap in
+        // ci-verdicts.md section 2. Matches the job-name FORM so the file's comments may
+        // name the context while explaining why they must not declare it.
+        Assert.DoesNotMatch(
+            new Regex(@"name:\s*" + Regex.Escape(RequiredCheckJobName)), CodeOnly(Read(Floor)));
+    }
+
+    [Fact]
+    public void Floor_DelegatesToTheSharedMatrix_AtFullWidth()
+    {
+        // Delegation rather than a copy: a hand-maintained second spelling of these steps
+        // drifted four times and failed two releases (#1976). And no version filter — a
+        // floor that ran three of eight legs would re-introduce exactly the BC-version
+        // blindness it is meant to remove.
+        var code = CodeOnly(Read(Floor));
+
+        Assert.Contains(WorkflowParity.DelegationMarker, code, StringComparison.Ordinal);
+        Assert.Empty(WorkflowParity.FindInlinedBcTestSteps(code));
+        Assert.DoesNotContain("bc-version-filter", code, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Floor_SkipsWhenMainHeadAlreadyHasAConclusiveVerdict()
+    {
+        // The floor is a floor, not a second matrix. When the push-triggered run survived —
+        // 16% of the time in the sample, and most of the time overnight — HEAD's verdict is
+        // already known and running it again buys nothing. The guard keys on the head SHA
+        // because that is what a verdict is about (ci-verdicts.md section 2).
+        var code = CodeOnly(Read(Floor));
+        var jobs = WorkflowParity.SplitJobs(code);
+
+        Assert.Contains("verdict-needed", jobs.Keys);
+        Assert.Contains("head_sha=", jobs["verdict-needed"], StringComparison.Ordinal);
+
+        // and the expensive job must actually be gated on it, or the guard is decoration
+        var matrix = jobs.Single(j => j.Value.Contains(WorkflowParity.DelegationMarker, StringComparison.Ordinal));
+        Assert.Contains("needs: verdict-needed", matrix.Value, StringComparison.Ordinal);
+        Assert.Matches(new Regex(@"if:\s*needs\.verdict-needed\.outputs\.\w+\s*==\s*'true'"), matrix.Value);
+    }
+
+    [Fact]
+    public void Floor_UsesADistinctCallingJobName_SoItsLegContextsDoNotCollide()
+    {
+        // A check's context is the leg name qualified by the CALLING job, so a job id of
+        // `bc-tests` here would make the floor's legs report the identical context to the
+        // gating path's (`bc-tests / BC <ver> (required)`) on the same head SHA — and unlike
+        // bc-leg-rerun.yml, the floor runs on `main`, which is exactly where the gating path
+        // also reports. `gh pr checks` could then not tell which run a verdict came from.
+        var jobs = WorkflowParity.SplitJobs(CodeOnly(Read(Floor)));
+
+        Assert.DoesNotContain("bc-tests", jobs.Keys);
+    }
+
+    [Fact]
+    public void OnlyTheGatingMatrixAndTheFloor_RunTheEightLegMatrixOnPushesToMain()
+    {
+        // The census behind "the same shape does not repeat elsewhere". Two workflows trigger
+        // on a push to `main`: this repo's gating matrix, and sync-changelog-unreleased.yml.
+        // The changelog sync shares the pattern — one concurrency group, cancellation on —
+        // but not the pathology: it takes a median of 11 s against a 359 s median merge
+        // interval (rho = 0.03), so 56 of its last 60 runs completed. Cancellation starves a
+        // workflow only when its wall time approaches the merge interval, which is a property
+        // of the run, not of the concurrency block.
+        //
+        // This guard fails if a third push-to-main workflow starts calling the eight-leg
+        // matrix, because that would double `main`'s post-merge cost without anyone pricing
+        // it — the thing #3003 is about.
+        var callers = Directory.GetFiles(WorkflowDir, "*.yml")
+            .Where(f => CodeOnly(File.ReadAllText(f))
+                .Contains(WorkflowParity.DelegationMarker, StringComparison.Ordinal))
+            .Select(Path.GetFileName)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
+
+        // publish.yml gates a release and bc-leg-rerun.yml is dispatch-only; neither runs on
+        // a push. ms-bucket.yml is not here — it drives the provisioning action directly
+        // rather than the shared matrix.
+        Assert.Equal(
+            new[] { "bc-leg-rerun.yml", Floor, "publish.yml", Gating },
+            callers);
+    }
+
+    [Fact]
+    public void GatingMatrix_StillCancelsSupersededRuns()
+    {
+        // The mirror, and the reason this change is safe. Cancellation on pull requests is
+        // correct and wanted: a superseded commit's verdict is worthless and its slots are
+        // taken from every other repository on the account. Turning it off here — on a group
+        // keyed by `github.ref` — would queue rather than parallelise, at rho = 2.05. This
+        // guard fails if a future change trades main's silent gap for a saturated queue.
+        var code = CodeOnly(Read(Gating));
+
+        Assert.Matches(new Regex(@"group:.*github\.ref"), code);
+        Assert.Matches(new Regex(@"cancel-in-progress:\s*true"), code);
+    }
+}


### PR DESCRIPTION
Closes #3003

## The mechanism, confirmed

`.github/workflows/test-matrix.yml` keys its concurrency group on `github.ref`, which on `main` is the constant `refs/heads/main`, and sets `cancel-in-progress: true`. So every merge cancels the run the previous merge started.

Measured over the 100 most recent Test Matrix runs on `main` (18.5 h, 2026-09-06):

| | |
|---|---|
| conclusion | cancelled 83, success 13, failure 3, in progress 1 |
| merge interval | median 359 s, mean 673 s, p25 120 s -> ~130 pushes/day |
| full matrix run | mean 22.8 min wall, max 26.4 min, 74.6 job-minutes over 12 jobs |

I checked the merge interval two independent ways, because the figure I was handed was 12 s. Run creation times give a median of 359 s and `git log` commit times 364 s. There **are** bursts — 30 of 199 commit gaps under 60 s, p10 33-37 s — which is probably where 12 s came from, but the typical gap is six minutes.

A Poisson model gives P(no merge in 22.8 min) = 13% against an observed 16/100. That is a consistency check on **one** sample, not a second measurement: the arrival rate and the survival rate come from the same 100 timestamps, and the service time is measured only over the 16 survivors. Nothing was fitted after the fact, so it is not circular — it just is not independent confirmation, and an earlier draft of this body overstated it as "the model and the measurement agree".

## What is and is not broken

`All BC versions passed` still gates every pull request targeting `main`. This is not a hole a red PR can merge through. What the cancellation destroys is the post-merge signal: when a merge breaks `main`, or when two individually-green PRs conflict semantically after landing, the run that would have said so is cancelled by the next merge and nobody is notified.

## What a cancelled run actually costs

**37% of a full run, not the 71% an earlier draft of this body claimed.** Job-level timings (summing `completed_at - started_at` per job) over a 20-run sample of the 83 cancelled runs: mean **27.7 job-minutes**, median 14.3, against 74.6 for a full run. So cancelling saves about **63%** of the cost, not 40%.

The reason is that the matrix legs are not *created* until `resolve-versions` finishes (~0.8 min plus its own queue), so a run cancelled early burns almost nothing — five of the twenty had zero jobs ever started. The low job queue delay I reported (median 3 s, p99 177 s over 179 jobs in the busiest hour) is real but does not bear on this: it measures job-creation-to-job-start, not run-creation-to-leg-start, so it says nothing about a run's first minute.

I re-derived this independently before writing it down, because my first sample was biased: I drew the 14 most recent cancelled runs, and one ID in that list was a typo that silently 404'd. Estimating instead across **all 83** walls, using the measured wall-to-job-minute relation, gives 28.4 mean and 38% — converging on the 20-run sample. It also shows why the median is so much lower than the mean: **49% of cancelled runs die under six minutes**, before the legs exist.

Consequence for the framing, and it cuts against my original argument: this does **not** invert `test-matrix.yml`'s existing reasoning. That header was roughly right about the cost it was addressing. This PR does not overturn that decision; it covers what that decision leaves uncovered. An earlier draft of this body claimed the inversion and it is withdrawn.

## The arithmetic on removing cancellation

**Per-push concurrency groups avoid any queue, but the tail does not fit.** Replaying the observed arrival times against a 22.8-minute run gives a peak of 11 concurrent `main` runs, **72 concurrent jobs from `main` alone**. Actions concurrency is scoped per account, so those slots come out of pull-request CI here and in the corpus repository — the gate that actually blocks merges.

**`cancel-in-progress: false` on the existing shared group is NOT ruled out — it is unmeasured, and I should not have written it off.** The arithmetic (rho = lambda·W = 130/day × 22.8 min = 2.05) is fine, but it implies an unbounded queue only if same-group runs actually queue without bound, and nothing here establishes that premise. It was the claim I used to eliminate the simplest alternative, so it needed to be measured, not asserted.

The one natural experiment available points the other way. `main` ran in exactly that configuration until `c93598f8` landed 2026-09-03T21:31Z — I confirmed from the diff that this is the commit that turned cancellation on. Over the 37.3 h before it: **84 runs, 56 success / 3 failure / 25 cancelled = 70% completion**, with wall times clearly inflated by queueing (max 77.9 min against 26.4 min today). That is queueing, but 70% sustained over 37 hours is not an unbounded queue — it is consistent with GitHub holding at most one pending run per group and cancelling the rest.

That window ran at **2.25 runs/h against today's 5.40**, so it cannot tell us what happens at today's rate, and I am not claiming the alternative is better. **What would settle it**, in ten minutes and one runner: a scratch branch with a workflow carrying a fixed concurrency group, `cancel-in-progress: false` and a 5-minute sleep job. Push twice about a minute apart, then a third time. Observe whether run 2 goes pending, and whether run 3 cancels run 2 or queues behind it.

## What I changed

A new `.github/workflows/main-verdict-floor.yml`. The push path keeps cancelling, unchanged and untouched; a scheduled run re-establishes the verdict on `main` HEAD whenever cancellation destroyed it.

- **Cadence is derived, not chosen.** It has to exceed a run's wall time or floor runs overlap. Measured max is 26.4 min, so the floor is 27; `*/30` is the first cron-expressible value above it.
- **Its own concurrency group, cancellation off.** Safe here precisely because arrivals are one per cadence rather than one per merge.
- **It skips when the commit already has a verdict.** A guard job asks whether any conclusive Test Matrix or floor run exists for this head SHA, filtering on the **run-level** conclusion — which matters, because a cancelled Test Matrix run leaves `All BC versions passed` at conclusion `failure` while the run itself reads `cancelled`.
- **It delegates to `bc-tests.yml` at full width** — no `bc-version-filter`.
- **It never declares `All BC versions passed`,** and its calling job is `floor-matrix`, not `bc-tests`, so its leg contexts cannot be confused with the gating path's on the same head SHA.

Corrected cost table — time-weighted mean concurrent jobs attributable to `main`, over the same 18.5 h window:

| | time-weighted mean | peak |
|---|---|---|
| today (cancelling) | 3.14 jobs | — |
| never cancel `main` | 6.72 jobs (**+3.57**) | **72** |
| this floor | **+2.09 jobs** | **12** (bounded by design) |

Both columns of the earlier table were wrong, and correcting them favours this design: I had reported +2.2 for never-cancelling and +2.5 for the floor, "within noise of each other". That came from treating today's baseline as 71%-loaded when it is 37%-loaded. The floor is actually about **1.7x cheaper** than never cancelling, as well as 6x smaller on the tail. The p95 figures in that table came from the same broken model and are dropped rather than restated.

What this does not do is give every merged commit its own verdict, and that is deliberate. During a burst, verdicts on five superseded trees are the waste the 2026-09-03 measurement correctly objected to. What it gives is a bound on how long `main` can be red without anyone knowing. Bisecting the ~5 merges between two floor runs is what `bc-leg-rerun.yml` is for.

## RED -> GREEN

`AlRunner.Tests/MainVerdictFloorWorkflowTests.cs`, 9 tests. Measured in both broken states rather than described:

| state | result |
|---|---|
| workflow file absent | **8 failed, 1 passed** |
| workflow file present but empty | **6 failed, 3 passed** |
| workflow as shipped | **9 passed** |

My original report of "6 failed / 1 passed" was accurate for the moment it was taken — the file was absent and the test class had 7 tests, the last two having been added afterwards during the shape audit. Restated above against the final 9 so the numbers reproduce.

The one test passing at RED is `GatingMatrix_StillCancelsSupersededRuns`, the mirror guard: it asserts the PR path still cancels, so it is meant to pass in both states and fails only if someone later trades main's silent gap for a saturated queue.

Also run: `BcLegRerunWorkflowTests`, `MsBucketWorkflowTests`, `CorpusAppEnumerationWorkflowTests`, `ReleaseTestParityTests`, `PublishReleaseOrderingTests`, `CrashDumpCaptureWiringTests`, `TestArtifactsGateTests` — 86/86 — and `tools/test_ci_wait.py`. I did not run the full `AlRunner.Tests` suite; this diff touches no runner code.

## Fixing the shape, not just the reported line

**Does the same pattern appear elsewhere?** Two workflows trigger on a push to `main`. The other is `sync-changelog-unreleased.yml`, with the identical shape — one concurrency group, cancellation on. It does not have the pathology: median 11 s against a 359 s median merge interval (rho = 0.031), and 56 of its last 60 runs completed. Cancellation starves a workflow only when its wall time approaches the merge interval, which is a property of the run, not of the concurrency block. No change needed, and a guard fails if a third push-to-main workflow starts calling the eight-leg matrix.

**Does a sibling make the same assumption?** `pr-check.yml` and `require-tests.yml` are `pull_request`-only, where cancellation is correct. `publish.yml` is dispatch-only and has no concurrency block at all.

**Did I make the mistake I was auditing for?** Twice, and both are now guarded. My first draft named the calling job `bc-tests`, which would have collided contexts with the gating path on the same head SHA. And the guard I wrote for that checked only `jobs.Keys` — job **ids** — so an edit keeping the id `floor-matrix` while adding `name: bc-tests` would have collided and still passed. Both halves are asserted now, and I verified the strengthened guard actually fires by adding `name: bc-tests` and watching it fail, rather than assuming it would.

## Interactions I checked

- **`publish.yml`** pushes the release as a fast-forward, and any merge during its ~40-minute run kills it. This adds no merge, holds no lock on `main`, has its own concurrency group and never writes to the repository. Its only effect on a release is the shared runner pool, at a bounded 12 jobs.
- **The floor cannot satisfy, disturb or clear `All BC versions passed`** in either direction — it never declares that job name, and it never runs on a pull request.
- **#3141** (cutting the PR matrix to 3 legs) interacts but nothing here depends on it. If it lands, runs get faster and the floor fires less often; it does not make the floor unnecessary, since the floor bounds the gap rather than shrinking it.

## Corpus

This is CI plumbing and asserts nothing about Business Central's behaviour, so it owes nothing to the upstream corpus. No corpus PR, no submodule pin change.

---

Written by an automated agent (`agent: impl-7`) acting on the account holder's behalf. The three corrections above were raised in review; each one runs against the argument I originally made and in favour of the design that shipped.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
