### PR TITLE
test(testpage): pin a refusal raised in a table subscriber below a page-global control write

### DIFF
--- a/AlRunner.Tests/Fixtures/TestPageSubscriberRefusal/TsrAssert.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/TestPageSubscriberRefusal/TsrAssert.Codeunit.al
@@ -1,0 +1,15 @@
+// Standalone Assert — this fixture stands alone and imports nothing.
+codeunit 70600 "TSR Assert"
+{
+    procedure AreEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if Format(Expected) <> Format(Actual) then
+            Error('Expected <%1> but got <%2>: %3', Format(Expected), Format(Actual), Msg);
+    end;
+
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error('Expected true: %1', Msg);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/TestPageSubscriberRefusal/TsrGuard.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/TestPageSubscriberRefusal/TsrGuard.Codeunit.al
@@ -1,0 +1,25 @@
+// The refusal, raised where Microsoft's own one is raised: in a subscriber to the table's
+// OnBeforeDeleteEvent, NOT in the page control's OnValidate body. Nothing on the page knows
+// this exists; the only thing connecting it to the control write is the platform's table-event
+// dispatch under Delete(true).
+codeunit 70602 "TSR Guard"
+{
+    var
+        GuardedRowErr: Label 'TSR row %1 is guarded and cannot be deleted', Comment = '%1 = the row No.';
+
+    [EventSubscriber(ObjectType::Table, Database::"TSR Row", 'OnBeforeDeleteEvent', '', false, false)]
+    local procedure RefuseGuardedRow(var Rec: Record "TSR Row"; RunTrigger: Boolean)
+    begin
+        if not RunTrigger then
+            exit;
+        if Rec.Guarded then
+            Error(GuardedRowErr, Rec."No.");
+    end;
+
+    // The expected text, so the test asserts against the label the subscriber actually raises
+    // rather than a copy of it that could drift.
+    procedure ExpectedMessage(No: Code[20]): Text
+    begin
+        exit(StrSubstNo(GuardedRowErr, No));
+    end;
+}

--- a/AlRunner.Tests/Fixtures/TestPageSubscriberRefusal/TsrPage.Page.al
+++ b/AlRunner.Tests/Fixtures/TestPageSubscriberRefusal/TsrPage.Page.al
@@ -1,0 +1,45 @@
+// A list page whose PurgeAll control binds to a page GLOBAL variable, not to a field of the
+// source table — the same binding shape as page 9816 "Permission Set by User"'s
+// AllUsersHavePermission, which is the control issue #3105 reported.
+//
+// The control's own OnValidate raises nothing. It calls Delete(true), and the refusal comes
+// from "TSR Guard"'s OnBeforeDeleteEvent subscriber underneath that.
+page 70603 "TSR Page"
+{
+    PageType = List;
+    SourceTable = "TSR Row";
+    ApplicationArea = All;
+    UsageCategory = Lists;
+
+    layout
+    {
+        area(Content)
+        {
+            field(PurgeAll; PurgeAll)
+            {
+                ApplicationArea = All;
+                Caption = 'Purge All';
+
+                trigger OnValidate()
+                var
+                    Row: Record "TSR Row";
+                begin
+                    if not PurgeAll then
+                        exit;
+                    if Row.FindSet() then
+                        repeat
+                            Row.Delete(true);
+                        until Row.Next() = 0;
+                end;
+            }
+            repeater(Rows)
+            {
+                field("No."; Rec."No.") { ApplicationArea = All; }
+                field(Guarded; Rec.Guarded) { ApplicationArea = All; }
+            }
+        }
+    }
+
+    var
+        PurgeAll: Boolean;
+}

--- a/AlRunner.Tests/Fixtures/TestPageSubscriberRefusal/TsrRow.Table.al
+++ b/AlRunner.Tests/Fixtures/TestPageSubscriberRefusal/TsrRow.Table.al
@@ -1,0 +1,18 @@
+// The row the page's control deletes. `Guarded` is what the subscriber below reads to decide
+// whether to refuse, so both arms of the test drive the SAME code path and differ only in the
+// data — an implementation that refused (or accepted) unconditionally fails one of them.
+table 70601 "TSR Row"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { DataClassification = CustomerContent; }
+        field(2; Guarded; Boolean) { DataClassification = CustomerContent; }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/AlRunner.Tests/Fixtures/TestPageSubscriberRefusal/TsrTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/TestPageSubscriberRefusal/TsrTests.Codeunit.al
@@ -1,0 +1,87 @@
+codeunit 70604 "TSR Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit "TSR Assert";
+        Guard: Codeunit "TSR Guard";
+
+    local procedure Seed(No: Code[20]; Guarded: Boolean)
+    var
+        Row: Record "TSR Row";
+    begin
+        Row.DeleteAll();
+        Row.Init();
+        Row."No." := No;
+        Row.Guarded := Guarded;
+        Row.Insert();
+        // Committed on purpose. `asserterror` unwinds to the last commit, so without this the
+        // row the refusal was supposed to SAVE would be gone for a reason that has nothing to
+        // do with the refusal, and the assertion below would pass against an implementation
+        // that deleted the row and then rolled back.
+        Commit();
+    end;
+
+    // THE CLAIM. The subscriber's Error travels back up through Delete(true), through the
+    // control's OnValidate, through the page-global control write, and out of SetValue where
+    // the caller's asserterror can trap it.
+    [Test]
+    procedure SubscriberRefusal_ReachesTheAssertErrorAroundSetValue()
+    var
+        Pg: TestPage "TSR Page";
+        Row: Record "TSR Row";
+    begin
+        Seed('GUARDED', true);
+
+        Pg.OpenEdit();
+        asserterror Pg.PurgeAll.SetValue(true);
+
+        // BC wraps the recorded text; the subscriber's own message is inside it.
+        Assert.IsTrue(
+            StrPos(GetLastErrorText(), Guard.ExpectedMessage('GUARDED')) > 0,
+            'the trapped error must carry the subscriber''s own message, got: ' + GetLastErrorText());
+
+        // And the delete it refused did not happen.
+        Assert.AreEqual(1, Row.Count(), 'the refused row must still be there');
+    end;
+
+    // The ledger, read AFTER the asserterror swallowed the exception — the half Microsoft's
+    // Codeunit134614.TestRemoveSUPERPermissionsByUserAll asserts and the half issue #3105
+    // reported as never reached.
+    [Test]
+    procedure SubscriberRefusal_RecordsExactlyOneValidationError()
+    var
+        Pg: TestPage "TSR Page";
+    begin
+        Seed('GUARDED', true);
+
+        Pg.OpenEdit();
+        asserterror Pg.PurgeAll.SetValue(true);
+
+        Assert.AreEqual(1, Pg.PurgeAll.ValidationErrorCount(),
+            'a refusal raised below the control write must be recorded once on the control');
+        Assert.AreEqual(Guard.ExpectedMessage('GUARDED'), Pg.PurgeAll.GetValidationError(1),
+            'a page-global control stages no row edit, so the stored text is the bare message');
+    end;
+
+    // THE MIRROR. A row the subscriber does not refuse goes through, the delete happens, and
+    // nothing is recorded — so "make every SetValue throw" cannot satisfy the arms above.
+    [Test]
+    procedure UnguardedRow_IsDeletedAndRecordsNoValidationError()
+    var
+        Pg: TestPage "TSR Page";
+        Row: Record "TSR Row";
+    begin
+        Seed('OPEN', false);
+
+        Pg.OpenEdit();
+        Pg.PurgeAll.SetValue(true);
+
+        Assert.AreEqual(0, Pg.PurgeAll.ValidationErrorCount(),
+            'an accepted write must record no validation error');
+        Assert.AreEqual('Yes', Pg.PurgeAll.Value(),
+            'the accepted value must be readable back from the page-global control');
+        Assert.AreEqual(0, Row.Count(), 'the accepted write must have performed the delete');
+    end;
+}

--- a/AlRunner.Tests/Fixtures/TestPageSubscriberRefusal/app.json
+++ b/AlRunner.Tests/Fixtures/TestPageSubscriberRefusal/app.json
@@ -1,0 +1,24 @@
+{
+  "id": "0c4d9a71-6b52-4e18-9f3a-2d8c7b1e5406",
+  "name": "Runner Tests Fixture - TestPage Subscriber Refusal",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Issue #3105: a refusal raised inside a TABLE EVENT SUBSCRIBER, several frames below a TestPage page-global control write, must reach the asserterror that wraps SetValue and be recorded once on that control's validation-error ledger.",
+  "description": "Runner-mechanism fixture. The existing coverage raises the refusal in the control's OWN OnValidate body (corpus codeunits 60808, 60820, 60836); this one raises it in a subscriber the platform's table-event dispatch invokes underneath Delete(true), which is how Microsoft's Codeunit134614.TestRemoveSUPERPermissionsByUserAll refuses -- the System Application's Access Control OnBeforeDeleteEvent subscriber, four frames below the control write. A regression in the runner's own dispatch-under-a-control-write path would leave every existing test green, so it is pinned here. Declares no application floor: everything it needs is its own.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "idRanges": [
+    {
+      "from": 70600,
+      "to": 70619
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner.Tests/TestFieldValidationErrorsTests.cs
+++ b/AlRunner.Tests/TestFieldValidationErrorsTests.cs
@@ -180,11 +180,14 @@ public sealed class TestFieldValidationErrorsTests
     {
         // A page-global control stages no row edit, so there is nothing for "Refresh to discard"
         // to discard. Microsoft's Tests-SINGLESERVER Codeunit134614 asserts exactly this, with
-        // exact equality, for a control verified to be page-variable-bound on page 9807.
+        // exact equality, for a control verified to be page-variable-bound on page 9816
+        // "Permission Set by User" (an earlier version of this comment said 9807, which is
+        // "User Card").
         //
-        // This half rests on Microsoft's assertion, NOT on a service-tier run in this
-        // repository — corpus PR #184 asks it directly. Pinning it here means a change of mind
-        // has to be deliberate.
+        // This no longer rests on Microsoft's assertion alone: corpus PR #184 asked a real
+        // service tier and merged 2026-09-06 green on all eight BC Cloud legs (run 34016443056),
+        // so corpus codeunit 60808 now states it. Pinning it here means a change of mind has to
+        // be deliberate.
         var errors = new TestFieldValidationErrors();
 
         errors.RunRecordingRefusal(

--- a/AlRunner.Tests/TestPageSubscriberRefusalTests.cs
+++ b/AlRunner.Tests/TestPageSubscriberRefusalTests.cs
@@ -1,0 +1,116 @@
+// TestPageSubscriberRefusalTests — issue #3105.
+//
+// This is a RUNNER-MECHANISM test. The BC claim it rests on — that `asserterror` around a
+// TestPage control write traps the refusal and leaves ValidationErrorCount() = 1 — is settled
+// upstream by corpus codeunits 60808, 60820 and 60836, all green on a real service tier
+// (.claude/rules/bc-behavior-tests-go-upstream.md). What is pinned HERE is the one cell of that
+// shape none of them reaches, and it is the cell issue #3105 reported broken:
+//
+//     the refusal is raised in a TABLE EVENT SUBSCRIBER that the platform's own event dispatch
+//     invokes underneath Delete(true), several frames BELOW the page-global control's
+//     OnValidate — not in the trigger body the way every existing test raises it.
+//
+// That is how Microsoft's Codeunit134614.TestRemoveSUPERPermissionsByUserAll refuses: page 9816
+// "Permission Set by User"'s AllUsersHavePermission control (a page GLOBAL, not a Rec-bound
+// field) deletes an "Access Control" row, and the System Application's
+// "User Permissions Impl."(153).CheckSuperPermissionsBeforeDeleteAccessControl subscriber raises
+// four frames down. A regression in the runner's dispatch-under-a-control-write path would leave
+// 60808/60820/60836 green and break that shape silently, which is exactly the failure mode #3105
+// describes.
+//
+// STATE OF #3105 WHEN THIS WAS WRITTEN, MEASURED — not a fix, a pin.
+//
+// The defect does not reproduce on main. Rebuilding the bundle #3105 names (TestAppPermissions +
+// LibrarySingleServer + the two permission sets from Tests-SINGLESERVER, BC 28.1.49838.53910,
+// both package caches), Codeunit134614.TestRemoveSUPERPermissionsByUserAll PASSES, and both
+// assertions #3105 says are never reached run and pass. In a whole-codeunit run it still fails,
+// but as the "already bound" cascade behind TestAddPermissionSet — whose root is the
+// NavUserAccountHelper.IsPermissionSetAssigned NRE tracked in #3039, and whose cascade mechanism
+// was settled as not-a-runner-defect in #2393. Disabling that ONE root test takes codeunit
+// 134614 from 4P/11F to 13P/1F, this test among the 13.
+//
+// PROVING PROPERTY, demonstrated rather than asserted. Making the fixture's subscriber return
+// instead of raising — the swallow #3105 hypothesised — turns the two refusal arms red with
+// "NavNCLAssertErrorException: An error was expected inside an ASSERTERROR statement.", the exact
+// message #3105 reports, while the accepting arm stays green. So the arms discriminate in both
+// directions: an implementation that swallowed the subscriber's error fails the first two, and
+// one that refused every write fails the third.
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPageSubscriberRefusalTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static readonly string FixtureDir =
+        Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", "TestPageSubscriberRefusal");
+
+    private static (int ExitCode, string StdOut, string StdErr) Run(string cacheDir)
+    {
+        var sb = new StringBuilder(TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner")));
+        sb.Append(' ').Append($"\"{FixtureDir}\"");
+        sb.Append(' ').Append($"--cache \"{cacheDir}\"");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = sb.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+
+        var outSb = new StringBuilder();
+        var errSb = new StringBuilder();
+        using var proc = Process.Start(psi)!;
+        proc.OutputDataReceived += (_, e) => { if (e.Data != null) lock (outSb) outSb.AppendLine(e.Data); };
+        proc.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (errSb) errSb.AppendLine(e.Data); };
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+        if (!proc.WaitForExit(180_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException("al-runner did not exit within 180s.");
+        }
+        // WaitForExit(int) does not drain the async output callbacks; the parameterless
+        // overload does. See #2496.
+        proc.WaitForExit();
+        return (proc.ExitCode, outSb.ToString(), errSb.ToString());
+    }
+
+    [Fact]
+    public void ARefusalRaisedInATableSubscriber_ReachesTheAssertErrorAndTheControlsLedger()
+    {
+        var cacheDir = TestScratch.Dir("al-runner-tsr-tests");
+        try
+        {
+            var (exit, stdout, stderr) = Run(cacheDir);
+
+            Assert.True(exit == 0,
+                $"every fixture test must pass. exit={exit}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            // The claim: the subscriber's Error travels out of SetValue, carrying its own
+            // message, and the delete it refused did not happen.
+            Assert.Contains("PASS  Codeunit70604.SubscriberRefusal_ReachesTheAssertErrorAroundSetValue", stdout);
+
+            // The ledger, read after asserterror swallowed the exception — the half Microsoft's
+            // Codeunit134614 asserts and #3105 reported as never reached.
+            Assert.Contains("PASS  Codeunit70604.SubscriberRefusal_RecordsExactlyOneValidationError", stdout);
+
+            // The mirror, without which "throw on every SetValue" would satisfy the two above.
+            Assert.Contains("PASS  Codeunit70604.UnguardedRow_IsDeletedAndRecordsNoValidationError", stdout);
+
+            Assert.DoesNotContain("FAIL", stdout);
+        }
+        finally
+        {
+            try { Directory.Delete(cacheDir, recursive: true); } catch { /* best-effort cleanup */ }
+        }
+    }
+}

--- a/AlRunner/Patches/TestFieldValidationErrors.cs
+++ b/AlRunner/Patches/TestFieldValidationErrors.cs
@@ -61,17 +61,19 @@
 //         PermissionSetByUser.AllUsersHavePermission.GetValidationError(1), ...)
 //
 // These are not the same shape, and the difference is mechanical rather than guessed: probing
-// the runner's own control-binding map (AL_RUNNER_BINDING_PROBE over that test) shows page 9807
-// resolves AllUsersHavePermission as a PAGE VARIABLE, while page 60797's NameCtl in the corpus
-// test is REC-BOUND. A page-global control stages no row edit, so there is nothing for
-// "Refresh to discard" to discard.
+// the runner's own control-binding map (AL_RUNNER_BINDING_PROBE over that test) shows page 9816
+// "Permission Set by User" resolves AllUsersHavePermission as a PAGE VARIABLE, while page
+// 60797's NameCtl in the corpus test is REC-BOUND. A page-global control stages no row edit, so
+// there is nothing for "Refresh to discard" to discard. (An earlier version of this comment said
+// page 9807; 9807 is "User Card", and AllUsersHavePermission is not on it.)
 //
 // Hence the suffix lives on LiveNavTestField (Rec-bound) and NOT on PageVariableTestField.
-// That split rests on ONE measurement per side, and only the Rec-bound side's is a service-tier
-// measurement — the page-global side rests on Microsoft's assertion, which no tier run in this
-// repository has confirmed. Corpus PR #184 asks it directly; until that answers, this is the
-// most defensible reading of the evidence available and is flagged as such rather than
-// presented as settled.
+// BOTH SIDES ARE NOW SERVICE-TIER MEASUREMENTS. The Rec-bound side came from corpus run
+// 34002487601 (PR #182). The page-global side was the open question this comment used to flag:
+// corpus PR #184 asked it directly and merged 2026-09-06 with all eight BC Cloud legs green
+// (run 34016443056), so corpus codeunit 60808 "TP PageVar Validation Error" now states on a real
+// tier that a page-global control's stored validation error carries NO refresh suffix. The split
+// below is measured, not the most defensible reading of partial evidence.
 //
 // IDS
 //


### PR DESCRIPTION
Closes #3105

## What #3105 reported, and what is actually true now

#3105 says `asserterror PermissionSetByUser.AllUsersHavePermission.SetValue(false)` finds
nothing to trap in Microsoft's `Codeunit134614.TestRemoveSUPERPermissionsByUserAll`, and lists
three candidate causes, flagging the third — "the error is raised and swallowed somewhere
between the control write and the `asserterror`" — as the one to rule out first because it
would apply to every TestPage control write.

**Measured on `main` at `a7a91143`, BC 28.1.49838.53910: the defect does not reproduce, and all
three candidates are ruled out.** Rebuilding exactly the bundle #3105 names
(`TestAppPermissions.Codeunit.al` + `LibrarySingleServer.Codeunit.al` + the two permission sets
from `Tests-SINGLESERVER`, both package caches, private `--cache`):

```
PASS  Codeunit134614.TestRemoveSUPERPermissionsByUserAll (1275ms)
```

Both assertions #3105 says are never reached run and pass — `ValidationErrorCount() = 1` and
`GetValidationError(1) = 'There should be at least one enabled ''SUPER'' user.'`.

Probing the same page directly confirms which mechanism carries it: the refusal comes from
`"User Permissions Impl."(CodeUnit 153).CheckSuperPermissionsBeforeDeleteAccessControl`, a
subscriber to `"Access Control"(Table 2000000053)`'s `OnBeforeDeleteEvent`, four frames below
the control write, and it arrives at the caller as
`NavTestValidationException: Validation error for Field: AllUsersHavePermission,  Message = 'There should be at least one enabled 'SUPER' user.'`.

**In a whole-codeunit run it still fails**, but as the "already bound" cascade, not as this
defect. Causal experiment (the one #2393 used): disabling *only* `TestAddPermissionSet` — whose
root is the `NavUserAccountHelper.IsPermissionSetAssigned` NRE tracked in **#3039** — takes
codeunit 134614 from **4P/11F to 13P/1F**, `TestRemoveSUPERPermissionsByUserAll` among the 13.
The cascade mechanism itself was settled as not-a-runner-defect in **#2393**. So #3105 has no
work left of its own; #3039 owns what remains.

## So this PR pins the shape instead of fixing it

The shape was fixed without ever being pinned. Corpus codeunits 60808, 60820 and 60836 all
cover `asserterror` + the validation-error ledger, and **all three raise the error in the
control's own `OnValidate` body**. Page 9816's raises it in a table event subscriber the
platform invokes underneath `Delete(true)`. A regression in dispatch-under-a-control-write
would leave all three green and break Microsoft's shape silently — which is precisely the
failure mode #3105 describes.

- **Corpus PR
  [StefanMaron/BusinessCentral.AL.Language.Tests#200](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/200)**
  asks a real service tier: new codeunit 60826 with its own table/page/subscriber fixtures, four
  claims in both directions. The eight `BC <ver> / test` **Cloud** legs adjudicate it; the
  `BC OnPrem <ver>` legs build a different app and never execute it.
- **This PR** adds the runner-side mechanism pin so a regression fails in seconds here without
  waiting on the submodule bump: fixture bundle
  `AlRunner.Tests/Fixtures/TestPageSubscriberRefusal/` (no application floor) plus
  `AlRunner.Tests/TestPageSubscriberRefusalTests.cs`, following the precedent of
  `TestPageNewRecordValidationTests`.

## RED / GREEN

There is no RED for a fix, because there is no defect left to fix — stated plainly rather than
manufactured. What is demonstrated instead is that the new tests **prove**:

| fixture state | result |
|---|---|
| as committed | 3P/0F — refusal trapped, ledger reads 1, mirror arm deletes the row |
| subscriber returns instead of raising (the swallow #3105 hypothesised) | both refusal arms red with `NavNCLAssertErrorException: An error was expected inside an ASSERTERROR statement.` — **the exact message #3105 reports** — and the accepting arm stays green |

So the arms discriminate in both directions: swallowing the subscriber's error fails the first
two, refusing every write fails the third.

The seed calls `Commit()` on purpose. Without it the first arm read `0` rows after the refusal,
because `asserterror` unwinds to the last commit and took the seeded row with it — the row would
have been "gone" for a reason unrelated to the refusal, and the assertion would have passed
against an implementation that deleted the row and then rolled back.

## Fixing the shape, not just the reported line

- **Same wrong pattern at another call site?** Nothing found. The refusal path is
  `PageVariableTestField.Value` setter -> `TestFieldValidationErrors.RunRecordingRefusal` ->
  `RunnerPageInstance.RaiseOnValidate`; the Rec-bound sibling `LiveNavTestField` uses the same
  ledger, and both are already covered by `TestFieldValidationErrorsTests`.
- **Sibling function making the same assumption?** The matrix of (Rec-bound / page-global) x
  (source-compiled / precompiled) x (trigger-body / below-the-trigger) had exactly one empty
  cell, which is what #200 and this fixture fill. The other five were verified green by running
  60808, 60820, 60836 and 60249 against `main`, plus a direct probe of page 9816's own
  `ShowDomainName` (Boolean page-global on a precompiled page: `No` -> `Yes`) and
  `SelectedCompany` (Text page-global on a precompiled page: its `OnValidate` runs and rewrites
  the value).
- **Two code paths writing the same state?** `LiveNavTestField` appends BC's
  `" (Select Refresh to discard errors)"` suffix and `PageVariableTestField` does not. That
  split was flagged in the source as resting on Microsoft's assertion with no tier run behind
  it; corpus PR #184 has since merged green on all eight BC Cloud legs (run 34016443056), so
  the comment is corrected to record the measurement.

Also corrected: two comments named page **9807** as the home of `AllUsersHavePermission`. 9807
is "User Card" — every other reference in the repo says so. It is **9816** "Permission Set by
User", verified against the Base Application's own AL source on the 28.1 artifact and by driving
`TestPage "Permission Set by User"` directly.

## What was run

- `dotnet test AlRunner.Tests --filter "…TestFieldValidationErrorsTests|…BaseAppFloorFixtureGuardTests|…TestPageSubscriberRefusalTests"` — **18 passed, 0 failed**.
- The new fixture bundle through the runner — 3P/0F; and the inverted-subscriber negative
  control, 2F/1P as tabulated above.
- Corpus branch through the runner (BC 28.1) — codeunit 60826, 3P/0F.
- Corpus codeunits 60808, 60820, 60836, 60249 and 60133 against `main` — all pass.

Not run, deliberately: the full `AlRunner.Tests` suite and the full corpus. This diff touches
one comment block in `AlRunner/` and adds test-only files; CI covers the sweep.

## Deliberately left out

- **#3039's NRE root.** It is the only thing still failing `TestRemoveSUPERPermissionsByUserAll`
  in a whole-codeunit run, it already has an open issue and an owner, and it is not this issue's
  defect.
- **No `known-gaps` entry.** There is no gap: the shape works.
- **No pin bump.** #200 has not merged; when it does, the bump and the count baseline belong in
  whichever PR carries them, not here.

---
Written by an agent (`stma-auto-1`, cycle 139) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE