### PR TITLE
fix(agents): derive an agent's worktree path from identity AND issue, so two loops on one slot cannot share a checkout

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -95,7 +95,18 @@ works here.
 
 Per-issue directories do not accumulate: `tools/preflight.py --reap` removes the worktrees of MERGED pull requests once they are clean, keyed on the pull request's state rather than on the directory's name.
 
-Verify with `git rev-parse --show-toplevel` before your first commit. Never `git add -A` / `git add .` in a tree that might carry another agent's edits — stage only the files you changed, by name.
+Before your first commit, verify **both** the directory and the branch:
+
+```
+git rev-parse --show-toplevel        # the worktree you meant to be in
+git rev-parse --abbrev-ref HEAD      # MUST equal agent/<AGENT-ID>/issue-<N>
+```
+
+The second line is the one that catches #3014, and it catches it even if the first passes. That agent was in a checkout whose HEAD was `agent/stma-auto-1/issue-3005` while it was working issue 3011; the directory looked right to it, and the branch did not match its issue. **A branch that names an issue other than yours is not yours to commit to** — stop and report, whatever the prefix says.
+
+Note what that prefix does and does not mean. `agent/<AGENT-ID>/` records who **created** a branch, not who may write to it, and nothing enforces it: a second agent committing there is a normal push that no check refuses. It is a naming convention, not an ownership boundary, and today it was used as one on `agent/impl-4/issue-2771` by two different writers. The assignee locks an *issue*; nothing plays that role for a *branch*.
+
+Never `git add -A` / `git add .` in a tree that might carry another agent's edits — stage only the files you changed, by name.
 
 ### RED → GREEN
 
@@ -222,6 +233,8 @@ If `mergeStateStatus` already reads `DIRTY`/`CONFLICTING` at this point, that is
 with `main`, not a CI problem — rebase, resolve, re-run your targeted tests (never carry a
 stale test result across a rebase), force-push with `--force-with-lease`, and re-check the
 SHA before returning.
+
+**If `--force-with-lease` is rejected, that is the finding — never force past it.** The rejection means the remote moved since you last fetched, so somebody else wrote to your branch, and the lease is the only thing standing between their work and your overwrite. Twice on 2026-09-06 it was the sole reason work survived: once where the repository owner had pushed to a corpus branch 44 minutes earlier, once where two agents shared a branch. Fetch, read what arrived with `git log @{u}...HEAD`, and report it. Do not reach for `--force`.
 
 Then report: the issue, the PR number, the head SHA, what you changed, what the RED → GREEN
 proved, and anything you deliberately left out. Return. Do not claim another issue.

--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -65,27 +65,35 @@ Read it: `gh issue view <N> --repo StefanMaron/BusinessCentral.AL.Runner`.
 
 If you were not handed an isolated checkout, run `git status --short` on the tree you were given before touching git. Uncommitted changes you did not make mean another agent is mid-edit there — do **not** `git checkout -b`, you will either drag their work onto your branch or yank the tree out from under them. Take a worktree instead.
 
-`.claude/worktrees/<AGENT-ID>` may already exist from an earlier task, because identities are reused. That is expected. **Do not pick a fresh identity just to get a clean directory** — reset the one you have:
+Your working tree is `.claude/worktrees/<AGENT-ID>-issue-<N>` — the identity **and** the issue number, mirroring the branch name `agent/<AGENT-ID>/issue-<N>`. Both halves are load-bearing, and the issue number is the one that is easy to leave out.
+
+A path built from the identity alone is the #3014 defect. Two autonomous loops claimed the slot `stma-auto-1`, so both rendered the same directory `.claude/worktrees/stma-auto-1` — while their branch names, which *do* carry the issue number, stayed distinct. A directory is what `git commit` and `git push` consult to decide which branch they act on, so the second loop's two commits (554 added lines across 9 files, belonging to a different issue) landed on the first loop's PR branch, and the Test Matrix reported **success** on the mixture. Same account on both sides, so the author field, the branch prefix and the commit shape were all identical, and nothing objected at any layer.
+
+The directory normally does not exist yet. It exists only when you are **resuming the same issue** (Step 1), because the issue number is part of the name. **Do not pick a fresh identity just to get a clean directory** — reset the one you have:
 
 ```
 git fetch origin main
 
-# Only if the worktree already exists from a previous task:
-git -C .claude/worktrees/<AGENT-ID> status --porcelain              # must be empty
-git -C .claude/worktrees/<AGENT-ID> log --oneline origin/main..HEAD # must be empty
-rm -rf .claude/worktrees/<AGENT-ID> && git worktree prune   # NOT `git worktree remove` — see below
+# Only if the worktree already exists, i.e. you are resuming this same issue:
+git -C .claude/worktrees/<AGENT-ID>-issue-<N> status --porcelain              # must be empty
+git -C .claude/worktrees/<AGENT-ID>-issue-<N> log --oneline origin/main..HEAD # must be empty
+rm -rf .claude/worktrees/<AGENT-ID>-issue-<N> && git worktree prune   # NOT `git worktree remove` — see below
 
-git worktree add .claude/worktrees/<AGENT-ID> -b agent/<AGENT-ID>/issue-<N> origin/main
-cd .claude/worktrees/<AGENT-ID>
+git worktree add .claude/worktrees/<AGENT-ID>-issue-<N> -b agent/<AGENT-ID>/issue-<N> origin/main
+cd .claude/worktrees/<AGENT-ID>-issue-<N>
 ```
 
 **`git worktree remove` refuses on every worktree in this repository.** It reports
 `fatal: working trees containing submodules cannot be moved or removed`, because each one
 carries `tests/al-language/`. `--force` does not help. Run the two checks below, then
-`rm -rf .claude/worktrees/<AGENT-ID> && git worktree prune`, which is the only sequence that
+`rm -rf .claude/worktrees/<AGENT-ID>-issue-<N> && git worktree prune`, which is the only sequence that
 works here.
 
+**If that directory already exists and you are not resuming this issue, stop and report.** Somebody else is in it. Do not reset it, do not `cd` into it, and do not run the two checks as though it were yours to reclaim — a foreign claim looks identical whether the agent that made it is live or gone.
+
 **Never remove a worktree without running both checks first.** An agent that crashed mid-task leaves its only copy of that work there — nowhere else. If either check prints anything, stop and report rather than discard.
+
+Per-issue directories do not accumulate: `tools/preflight.py --reap` removes the worktrees of MERGED pull requests once they are clean, keyed on the pull request's state rather than on the directory's name.
 
 Verify with `git rev-parse --show-toplevel` before your first commit. Never `git add -A` / `git add .` in a tree that might carry another agent's edits — stage only the files you changed, by name.
 

--- a/AlRunner.Tests/AgentWorktreePathCollisionGuardTests.cs
+++ b/AlRunner.Tests/AgentWorktreePathCollisionGuardTests.cs
@@ -1,0 +1,163 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Guards the invariant #3014 established: an agent's worktree path must be derived from the
+/// SAME two components as its branch name — the identity AND the issue number — so that two
+/// agents sharing an identity but working different issues cannot land in the same directory.
+///
+/// The incident (#3014): two autonomous loops both claimed the slot <c>stma-auto-1</c>. Their
+/// branch names did NOT collide — <c>agent/stma-auto-1/issue-3005</c> and
+/// <c>agent/stma-auto-1/issue-3011</c> are distinct, because a branch name carries the issue
+/// number. The WORKTREE PATH collided, because <c>.claude/agents/impl-agent.md</c> derived it
+/// from the identity alone: both loops rendered <c>.claude/worktrees/stma-auto-1</c>. A
+/// directory is what <c>git commit</c> and <c>git push</c> consult to decide which branch they
+/// act on, so the second loop's two commits (<c>6c36e717</c>, <c>67762959</c> — 554 added lines
+/// across 9 files, belonging to a different issue entirely) landed on the first loop's PR
+/// branch. CI run <c>34003048066</c> then reported Test Matrix SUCCESS on head <c>67762959</c>:
+/// a green required-check verdict on the union of two unrelated changes.
+///
+/// Nothing objected at any layer, and nothing could have: both loops push as the same account,
+/// so the author field is identical, the branch prefix is identical, and the commits are
+/// well-formed. The asymmetry between "branch name carries the issue number" and "worktree path
+/// does not" was the entire mechanism.
+///
+/// This is enforced here rather than described in a rule because the prose form of exactly this
+/// requirement already existed and was not enough. <c>.claude/skills/autonomous-cycle/SKILL.md</c>
+/// says "Two contributors must never write to the same path or push to the same branch" — and
+/// the violation arrived anyway. That is the same failure shape
+/// <see cref="ScratchDirOwnershipGuardTests"/> records: an allowlist written as prose with no
+/// test behind it was ignored.
+///
+/// Scope is <c>.claude/agents/</c> — the directory whose files PRESCRIBE a worktree to create,
+/// rather than a hard-coded filename, so a future agent definition inherits the guard. Other
+/// mentions of <c>.claude/worktrees/</c> elsewhere in the repository (e.g.
+/// <c>.claude/rules/no-git-stash-with-worktrees.md</c>'s <c>impl-*</c> glob) DESCRIBE existing
+/// directories and are deliberately out of scope.
+///
+/// Within those files, only a <b>template</b> is asserted over — a path token carrying at least
+/// one <c>&lt;...&gt;</c> placeholder, which is what makes it something an agent renders. A fully
+/// concrete token such as <c>.claude/worktrees/stma-auto-1</c> is a citation of one historical
+/// directory, and this file's own summary above contains exactly that; the section of
+/// <c>impl-agent.md</c> that explains the incident does too. Flagging those would be the failure
+/// <see cref="ScratchDirOwnershipGuardTests"/> names — a guard that fires on prose quoting the
+/// thing it forbids trains readers to ignore it. The distinction is not a loophole: a
+/// prescription has to tell the agent which identity to substitute, so it cannot be written
+/// without a placeholder and still be usable.
+/// </summary>
+public sealed class AgentWorktreePathCollisionGuardTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static string AgentsDir => Path.Combine(RepoRoot, ".claude", "agents");
+
+    /// <summary>The issue-number placeholder an agent definition uses in a branch name.</summary>
+    private const string IssuePlaceholder = "<N>";
+
+    /// <summary>
+    /// Every <c>.claude/worktrees/...</c> path token written in an agent definition, paired with
+    /// the file and line it came from. The trailing character class stops at whatever ends a path
+    /// in markdown prose or a fenced command — whitespace, a backtick, a quote or a bracket.
+    /// </summary>
+    private static bool IsTemplate(string token) => token.Contains('<');
+
+    /// <summary>Templates only — the tokens an agent is expected to render.</summary>
+    private static List<(string File, int Line, string Token)> PrescribedTemplates() =>
+        WorktreePathTokens().Where(t => IsTemplate(t.Token)).ToList();
+
+    private static IEnumerable<(string File, int Line, string Token)> WorktreePathTokens()
+    {
+        var rx = new Regex(@"\.claude/worktrees/([^\s`""'’)\]]+)");
+        foreach (var path in Directory.EnumerateFiles(AgentsDir, "*.md", SearchOption.AllDirectories)
+                                      .OrderBy(p => p, StringComparer.Ordinal))
+        {
+            var lines = File.ReadAllLines(path);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                foreach (Match m in rx.Matches(lines[i]))
+                {
+                    yield return (Path.GetRelativePath(RepoRoot, path), i + 1, m.Groups[1].Value);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// The guard proper. Every prescribed worktree path must carry the issue-number placeholder,
+    /// so it cannot be rendered without one.
+    /// </summary>
+    [Fact]
+    public void EveryPrescribedWorktreePathCarriesTheIssueNumber()
+    {
+        var tokens = PrescribedTemplates();
+
+        Assert.True(tokens.Count > 0,
+            $"no `.claude/worktrees/<...>` TEMPLATE found under {AgentsDir}. Either the " +
+            "agent definitions stopped prescribing a worktree, or this guard's regex drifted — " +
+            "either way it is no longer guarding anything. " +
+            $"({WorktreePathTokens().Count()} worktree path token(s) were seen in total.)");
+
+        var offenders = tokens
+            .Where(t => !t.Token.Contains(IssuePlaceholder, StringComparison.Ordinal))
+            .Select(t => $"  {t.File}:{t.Line}  .claude/worktrees/{t.Token}")
+            .ToList();
+
+        Assert.True(offenders.Count == 0,
+            $"{offenders.Count} of {tokens.Count} prescribed worktree path(s) omit the " +
+            $"`{IssuePlaceholder}` issue placeholder, so two agents sharing an identity but " +
+            "working different issues render the SAME directory — the #3014 mechanism, which " +
+            "put one loop's commits on another loop's PR branch and got a green CI verdict on " +
+            "the mixture. Derive the path from identity AND issue, mirroring the branch name " +
+            "`agent/<AGENT-ID>/issue-<N>`:\n" + string.Join("\n", offenders));
+    }
+
+    /// <summary>
+    /// The incident itself, rendered. Two DIFFERENT issues under the SAME identity must produce
+    /// two different directories. This is the assertion that fails against the pre-fix wording:
+    /// both sides render <c>.claude/worktrees/stma-auto-1</c>.
+    /// </summary>
+    [Fact]
+    public void SameIdentityDifferentIssuesRenderDifferentWorktrees()
+    {
+        const string Identity = "stma-auto-1";
+
+        foreach (var (file, line, token) in PrescribedTemplates())
+        {
+            var a = Render(token, Identity, "3005");
+            var b = Render(token, Identity, "3011");
+
+            Assert.True(a != b,
+                $"{file}:{line}: the documented worktree path `.claude/worktrees/{token}` " +
+                $"renders to `{a}` for BOTH issue 3005 and issue 3011 under identity " +
+                $"'{Identity}'. That is exactly the #3014 collision: one loop committed and " +
+                "pushed into the other's checkout, onto the other's branch.");
+        }
+    }
+
+    /// <summary>
+    /// The converse, so the fix cannot be satisfied by a path that varies ONLY by issue and
+    /// drops the identity — that would collide across identities instead, which is the same
+    /// defect wearing the other hat.
+    /// </summary>
+    [Fact]
+    public void DifferentIdentitiesSameIssueRenderDifferentWorktrees()
+    {
+        foreach (var (file, line, token) in PrescribedTemplates())
+        {
+            var a = Render(token, "stma-auto-1", "3005");
+            var b = Render(token, "stma-auto-2", "3005");
+
+            Assert.True(a != b,
+                $"{file}:{line}: the documented worktree path `.claude/worktrees/{token}` " +
+                $"renders to `{a}` for both identity 'stma-auto-1' and 'stma-auto-2' on issue " +
+                "3005, so two loops on DIFFERENT slots would share a checkout.");
+        }
+    }
+
+    private static string Render(string token, string identity, string issue) =>
+        token.Replace("<AGENT-ID>", identity, StringComparison.Ordinal)
+             .Replace(IssuePlaceholder, issue, StringComparison.Ordinal);
+}

--- a/AlRunner.Tests/AgentWorktreePathCollisionGuardTests.cs
+++ b/AlRunner.Tests/AgentWorktreePathCollisionGuardTests.cs
@@ -157,6 +157,40 @@ public sealed class AgentWorktreePathCollisionGuardTests
         }
     }
 
+    /// <summary>
+    /// The path fix above makes a same-identity/different-issue collision impossible to express.
+    /// This pins the independent check that catches the same incident from the other side, and
+    /// catches it even when the directory is the right one: before its first commit an agent must
+    /// verify the BRANCH its checkout is on, not only the toplevel directory.
+    ///
+    /// #3014's second loop was in a checkout whose HEAD was <c>agent/stma-auto-1/issue-3005</c>
+    /// while it worked issue 3011. <c>git rev-parse --show-toplevel</c> — the only verification
+    /// the definition asked for — would have looked correct to it. Comparing HEAD against its own
+    /// issue number would not have.
+    ///
+    /// This is a doc-shape assertion, and deliberately so: the requirement already existed as
+    /// prose in <c>.claude/skills/autonomous-cycle/SKILL.md</c> ("Two contributors must never
+    /// write to the same path or push to the same branch") and was not followed. Prose with no
+    /// test behind it is what this issue is made of, so the replacement prose gets a test.
+    /// </summary>
+    [Fact]
+    public void ImplAgentVerifiesTheBranchNotJustTheDirectoryBeforeCommitting()
+    {
+        var path = Path.Combine(AgentsDir, "impl-agent.md");
+        var text = File.ReadAllText(path);
+
+        Assert.True(text.Contains("git rev-parse --show-toplevel", StringComparison.Ordinal),
+            "impl-agent.md no longer tells the agent to verify the worktree directory before " +
+            "its first commit.");
+
+        Assert.True(text.Contains("git rev-parse --abbrev-ref HEAD", StringComparison.Ordinal),
+            "impl-agent.md tells the agent to verify its working DIRECTORY before the first " +
+            "commit but not its BRANCH. That is the #3014 hole: an agent sharing a checkout " +
+            "sees the directory it expected and a branch belonging to somebody else's issue, " +
+            "and commits onto it. Add a `git rev-parse --abbrev-ref HEAD` check against " +
+            "`agent/<AGENT-ID>/issue-<N>`.");
+    }
+
     private static string Render(string token, string identity, string issue) =>
         token.Replace("<AGENT-ID>", identity, StringComparison.Ordinal)
              .Replace(IssuePlaceholder, issue, StringComparison.Ordinal);


### PR DESCRIPTION
Closes #3014

Loop infrastructure only. This asserts nothing about Business Central and owes nothing to the upstream corpus — no `tests/al-language` test, no pin bump.

## What actually happened

I diagnosed this from the repository rather than from the issue body, and **the issue body's stated cause is wrong.**

It blames the "between units you hold nothing" window in `.claude/skills/autonomous-cycle/SKILL.md`, on the theory that the second loop started while the slot was momentarily free, re-read, and legitimately saw nothing. That window did not occur. Reconstructing slot occupancy from the label event log:

| time (UTC) | event |
|---|---|
| 2026-09-05 23:04:13 | #2979 labeled `agent: stma-auto-1` (closed 09-06 13:24) |
| 2026-09-05 23:54:58 | #2963 labeled `agent: stma-auto-1` (closed 09-06 06:54) |
| 2026-09-06 00:43:48 | #3004 labeled |
| 2026-09-06 00:48:04 | #2888 labeled |
| 2026-09-06 00:48:46 | #3005 labeled |

There is **no `unlabeled` event anywhere in that span.** From 23:04:13 until well past the incident, at least two open issues continuously carried `agent: stma-auto-1`. By the skill's own definition — "a slot is taken if any open issue or PR carries that label" — the slot was visibly taken at every instant, and the *first* read should have rejected it. The compare-and-swap re-read never even came into play.

**So the slot protocol is correct as written and was not followed. No change to it is warranted**, and I made none. The issue's own third option — a durable lock marker — would fix a hole that does not exist while reintroducing the stale-lock problem the design deliberately refuses.

A second protocol would also have caught it and also did not run: `impl-agent.md`'s reset guard requires `git log --oneline origin/main..HEAD` to be empty, and that shared worktree was sitting one commit ahead of `main`.

Two other corrections to the issue body, from the API: the cited run `33003048066` does not exist (a digit is missing — the real one is **`34003048066`**), and the "foreign commits" are two, `6c36e717` and `67762959`, totalling **554 additions across 9 files**.

## The mechanism, and why nothing caught it

The branch names did **not** collide: `agent/stma-auto-1/issue-3005` and `issue-3011` are distinct, because a branch name carries the issue number.

The **worktree path** collided. `impl-agent.md` derived it from the identity alone, so both loops rendered `.claude/worktrees/stma-auto-1`. A directory is what `git commit` and `git push` consult to decide which branch they act on. That asymmetry — branch name carries the issue number, path does not — is the entire mechanism, and it matches the observation in the issue that every per-issue worktree was uncontested while only the bare name collided.

Nothing objected at any layer, and nothing could have: both loops push as the same account, so author, branch prefix and commit shape were identical. `git push` was a plain fast-forward, so even `--force-with-lease` had nothing to refuse. Test Matrix run `34003048066` then reported **success** on head `67762959` — a green required-check verdict on the union of two unrelated changes.

## What changed

**1. The worktree path now mirrors the branch name** — `.claude/worktrees/<AGENT-ID>-issue-<N>` against `agent/<AGENT-ID>/issue-<N>`. Path and branch become a bijection, so two agents can only collide on a directory if they have already collided on an *issue*, and the issue-claim protocol demonstrably worked here — no two loops ever claimed the same issue. This makes the collision impossible to express rather than detected after the fact. It is also what the loop already does in practice (`tools/test_preflight.py`'s own fixtures are `stma-auto-1-issue-2858`, `-issue-2907`), so it aligns the documentation with the shape that already works. Disk is unaffected: `--reap` keys on a merged PR being clean, not on the directory's name.

**2. Verify the branch, not just the directory, before the first commit.** The definition asked only for `git rev-parse --show-toplevel`. Adding `git rev-parse --abbrev-ref HEAD` against `agent/<AGENT-ID>/issue-<N>` catches this incident *independently* of the path fix — that agent's directory looked right to it while HEAD named issue 3005 and it was working 3011.

**3. Said plainly that the branch prefix is not an ownership boundary.** `agent/<AGENT-ID>/` records who *created* a branch, not who may write to it, and nothing enforces it. Today two writers used `agent/impl-4/issue-2771` — I confirmed it: commit `a923f028` on that branch carries a `Note` self-attributing to `stma-auto-1`, later rewritten by `impl-4` at `afbaa5f6`. The assignee locks an *issue*; nothing plays that role for a *branch*. I did not invent a mechanism to make it one — names cannot distinguish two agents with the same identity on the same issue, which is what that case was.

**4. A rejected `--force-with-lease` is the finding, never something to force past.** The flag was prescribed in three places; what to do when it is *rejected* was written nowhere. It was the sole reason work survived twice on 2026-09-06 — once where the repo owner had pushed to a corpus branch 44 minutes earlier, once where two agents shared a branch.

## RED → GREEN

New guard `AlRunner.Tests/AgentWorktreePathCollisionGuardTests.cs`, scoped to `.claude/agents/` — the directory whose files *prescribe* a worktree — so a future agent definition inherits it.

- **RED:** 2 of 3 failed, naming all 7 un-suffixed occurrences and rendering the incident directly: "`.claude/worktrees/<AGENT-ID>` renders to `stma-auto-1` for BOTH issue 3005 and issue 3011".
- The third test (different identities → different directories) **passed at RED** and still passes. It is the converse guard, so the fix cannot be satisfied by a path that drops the identity instead.
- **GREEN:** 4 of 4.
- **Mutation proof:** reverting both fixes in the working tree (path suffix removed, `--abbrev-ref` line dropped) fails 3 of 4. Restored from a copy held outside the repository per `no-git-stash-with-worktrees.md`; `git diff HEAD` empty afterward, re-run green.

One refinement worth flagging: the first version of the guard fired on my own prose *citing* `.claude/worktrees/stma-auto-1` as the thing that went wrong. It now asserts only over **templates** (tokens carrying a `<...>` placeholder); a fully concrete token is a citation. That is not a loophole — a prescription must tell the agent which identity to substitute, so it cannot be written without a placeholder and still be usable — and it avoids the failure `ScratchDirOwnershipGuardTests` names, where a guard that fires on prose quoting the thing it forbids trains readers to ignore it.

Also ran `tools/test_preflight.py` (all checks passed), since it parses worktree paths. I did not modify it.

## Deliberately left out

- **No change to the slot compare-and-swap.** The evidence says it was right and was not run.
- **No branch-ownership mechanism.** Every candidate reduces to a name, and names cannot separate two agents sharing an identity *and* an issue — the `impl-4` case. The ref-level CAS that already exists (`--force-with-lease`) is the real mechanism there, and it worked; I documented how to respond to it instead of adding a layer.
- **No unmatched-expectations-entry audit.** The near-miss where a known-gap entry would have pointed at an issue closed by its own PR is real and was caught by reading, not tooling — but it is a different defect from this one. Worth its own issue; say the word and I will file it.
- **Nothing under `agent/stma-auto-1/` was touched.** Read only.

---
Written by an automated agent (`agent: impl-10`) on the account holder's behalf.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
