### PR TITLE
fix(pkgdedup): apply the stage-name rule to claim files, floor the age threshold, and bound the rollout window with a measurement

### DIFF
--- a/AlRunner.Tests/PkgDedupCachePruneTests.cs
+++ b/AlRunner.Tests/PkgDedupCachePruneTests.cs
@@ -230,15 +230,73 @@ public sealed class PkgDedupCachePruneTests : IDisposable
     }
 
     [Fact]
-    public void Prune_KeepsOrphanMarkerOfALiveProcess()
+    public void Prune_KeepsOrphanMarkerOfALiveProcess_AndReapsADeadOnesInTheSamePass()
     {
         // A live process claims the stage a moment before creating it. Deleting the claim
         // here would leave its directory unprotected for the rest of its run.
-        var marker = PkgDedupCache.MarkInUse(Path.Combine(_root, KeyA));
+        //
+        // The original of this test asserted only `File.Exists(marker)`, which passes against
+        // a pruner that does nothing at all — the one survival case in this file that did not
+        // clear the bar its siblings set with `Kept == 1` (#3038).
+        //
+        // `Assert.Equal(0, result.MarkersRemoved)`, the fix #3038 proposed, does NOT close
+        // that: zero is also what a do-nothing pruner reports, so the pair of assertions is
+        // still satisfied by an empty pass. A negative counter cannot carry this weight; only
+        // positive evidence that the pass ran and drew the distinction can. So the fixture
+        // carries a DEAD claimant's orphan marker beside the live one, and the pass must
+        // remove exactly that one — `MarkersRemoved == 0` now means "the pruner did nothing"
+        // and fails, and `== 2` means "it ignored liveness" and fails.
+        var live = PkgDedupCache.MarkInUse(Path.Combine(_root, KeyA));
+        var dead = WriteMarker(KeyB, DeadPid, startJiffies: 0, age: TimeSpan.FromDays(30));
 
-        PkgDedupCache.Prune(_root, MaxAge, Now);
+        var result = PkgDedupCache.Prune(_root, MaxAge, Now);
 
-        Assert.True(File.Exists(marker), "a live process's claim must survive even with no directory yet");
+        Assert.True(File.Exists(live), "a live process's claim must survive even with no directory yet");
+        Assert.False(File.Exists(dead), "and a dead one's must not — same pass, same root");
+        Assert.Equal(1, result.MarkersRemoved);
+    }
+
+    [Theory]
+    [InlineData("not-a-stage")]                       // someone else's file
+    [InlineData("0123456789ABCDEF")]                  // uppercase: never a name BcCompiler writes
+    [InlineData("0123456789abcdef0")]                 // 17 hex digits
+    [InlineData("0123456789abcdef.tmp")]              // no random suffix
+    [InlineData("0123456789abcdef.pruning-1a2b3c4d")] // a name MarkInUse never targets
+    public void Prune_NeverJudgesAMarkerWhoseTargetIsNotAStageName(string target)
+    {
+        // Condition 1 — "a name the runner provably writes, or we do not judge it" — governs
+        // the ORPHAN-MARKER loop as well as the stage loop (#3038). It did not: any file
+        // shaped `<anything>.inuse-<n>` whose target directory was absent and whose sidecar
+        // parsed with a dead pid was deleted, without the target's name ever being tested.
+        //
+        // MarkInUse only ever produces stage keys as targets, so no loss was constructible —
+        // but the header and #3024's PR body both state the rule without that caveat, and a
+        // shared temp root is exactly where the code and its documentation must not diverge.
+        var foreign = WriteMarker(target, DeadPid, startJiffies: 0, age: TimeSpan.FromDays(30));
+
+        var result = PkgDedupCache.Prune(_root, MaxAge, Now);
+
+        Assert.True(File.Exists(foreign),
+            $"'{target}' is not a stage name the runner writes, so its sidecar is not ours to delete");
+        Assert.Equal(0, result.MarkersRemoved);
+        Assert.Equal(1, result.Skipped);   // refused to judge, not silently swallowed
+        Assert.Empty(result.Removed);
+    }
+
+    [Fact]
+    public void Prune_StillRemovesTheOrphanMarkerOfADeadProcessesTmpStagingDir()
+    {
+        // The counterpart that keeps the rule above from being over-broad. `<key>.tmp-<rand>`
+        // IS a name the runner writes, and PkgDedupStaging.Publish falls back to it, so
+        // MarkInUse really does target one — its orphan claim must still be reclaimed.
+        var marker = WriteMarker(KeyA + ".tmp-0a1b2c3d", DeadPid, startJiffies: 0,
+                                 age: TimeSpan.FromDays(30));
+
+        var result = PkgDedupCache.Prune(_root, MaxAge, Now);
+
+        Assert.False(File.Exists(marker),
+            "a dead process's claim on a vanished .tmp- staging dir is exactly what this loop is for");
+        Assert.Equal(1, result.MarkersRemoved);
     }
 
     [Theory]
@@ -334,6 +392,33 @@ public sealed class PkgDedupCachePruneTests : IDisposable
     public void MaxAgeFromEnvironment_HonoursAFractionalOverride()
     {
         Assert.Equal(TimeSpan.FromDays(0.5), PkgDedupCache.MaxAgeFrom("0.5"));
+    }
+
+    [Theory]
+    [InlineData("0.00001")]   // 0.86 seconds
+    [InlineData("0.0001")]    // 8.6 seconds
+    [InlineData("0.001")]     // 1.4 minutes
+    [InlineData("0.04")]      // 57.6 minutes — just under the floor
+    public void MaxAgeFromEnvironment_RaisesAnImplausiblyShortThresholdToTheFloor(string raw)
+    {
+        // MaxAgeFrom rejects zero and negatives because "delete a stage the moment it is
+        // written" is the failure this class exists to avoid — but it honoured ANY positive
+        // fraction, so `0.00001` asked for a 0.86-second threshold and got it (#3038).
+        //
+        // That is not merely a fast prune. It collapses condition 3, and condition 3 is the
+        // ONLY protection a directory carrying no claim has: a `<key>.tmp-<rand>` staging dir
+        // gets no claim until Publish returns, and a run from a build predating #2990 writes
+        // no claim at all. A sub-minute threshold makes both reachable at once.
+        Assert.Equal(PkgDedupCache.MinMaxAge, PkgDedupCache.MaxAgeFrom(raw));
+    }
+
+    [Fact]
+    public void MaxAgeFromEnvironment_HonoursAnythingAtOrAboveTheFloor()
+    {
+        // The floor raises, it does not clamp everything to itself.
+        Assert.Equal(TimeSpan.FromHours(1), PkgDedupCache.MaxAgeFrom("0.0416666666666667"));
+        Assert.Equal(TimeSpan.FromHours(3), PkgDedupCache.MaxAgeFrom("0.125"));
+        Assert.Equal(TimeSpan.FromDays(30), PkgDedupCache.MaxAgeFrom("30"));
     }
 
     // ── Helpers ────────────────────────────────────────────────────────────────────────

--- a/AlRunner/Infrastructure/PkgDedupCache.cs
+++ b/AlRunner/Infrastructure/PkgDedupCache.cs
@@ -67,6 +67,30 @@
 //   that name with nothing else in the root to reclaim it — the same unbounded growth this
 //   class closes, reached through a sibling function rather than through the stage itself.
 //
+//   THE ROLLOUT WINDOW, AND HOW FAR IT ACTUALLY REACHES (#3038). A runner from a build that
+//   predates this file writes no claim, so condition 2 is vacuously satisfied for it and a
+//   new-build runner in another worktree can prune a stage such a process has just adopted.
+//   There is no way to retrofit a claim into an already-running process, so the window cannot
+//   be closed — only bounded, and the bound is condition 3. Reaching the failure needs a stage
+//   that NO new-build runner has touched for maxAge, because any new-build use stamps its
+//   mtime; on the default threshold that means a stage created a week ago and read only by
+//   claim-less builds since.
+//
+//   Measured on the reporting machine on 2026-09-06, hours after this file landed, with 114
+//   worktrees present: 140 built al-runner.dll, 120 of them claim-less, the newest of those
+//   built 08:36 against a merge at 08:37 — so no further claim-less binaries are being
+//   produced, and the population only shrinks. In the one shared root (TMPDIR is set here, so
+//   Path.GetTempPath() is not /tmp and /tmp/al-runner-pkgdedup does not exist at all): 180
+//   stage directories, oldest 1.28 days, ZERO past the threshold. Nothing in the cache was
+//   eligible for deletion at any point in the window, and the earliest date anything could
+//   become eligible was 2026-09-12 — by which a claim-less binary would have to have been
+//   both never rebuilt and continuously running for six days.
+//
+//   That bound is entirely condition 3's, which is why MinMaxAge exists: a mistyped
+//   AL_RUNNER_PKGDEDUP_MAX_AGE_DAYS used to be able to shrink it to under a second, and with
+//   both conditions vacuous at once the window would have been immediate rather than
+//   week-deep. The floor is the only part of this that was fixable, and it is fixed.
+//
 //   RESIDUAL RACE, stated rather than papered over: another process can pass
 //   `Directory.Exists(stage)` in the instant between this pass reading the markers and
 //   renaming the directory aside. It needs a stage nobody has used for seven days to be
@@ -340,7 +364,7 @@ internal static class PkgDedupCache
                 // into the marker table and counted nowhere.
                 if (idx > 0 && IsStageDirName(name[..idx]) && File.Exists(entry))
                 {
-                    var target = name[..idx];
+                    var target = name[..idx];   // already proven a stage name by the test above
                     if (!markers.TryGetValue(target, out var list)) markers[target] = list = new List<string>();
                     list.Add(entry);
                     continue;

--- a/AlRunner/Infrastructure/PkgDedupCache.cs
+++ b/AlRunner/Infrastructure/PkgDedupCache.cs
@@ -30,7 +30,10 @@
 //     1. The name is one BcCompiler provably writes — `<16 hex>` or `<16 hex>.tmp-<8 hex>`.
 //        Anything else under the root belongs to somebody else and is never touched, so a
 //        future change to the naming scheme degrades to "stops reclaiming", never to
-//        "deletes the wrong tree".
+//        "deletes the wrong tree". This governs CLAIM FILES as well as directories: a file
+//        spelt `<something>.inuse-<n>` is only read as a claim, and only ever deleted, when
+//        `<something>` passes the same test (#3038). MarkInUse produces nothing else, so this
+//        costs no reclamation; it keeps the code saying what the rule says.
 //     2. No LIVE process claims it. Every process that stages or reuses a stage writes an
 //        in-use marker beside it (`<stage>.inuse-<pid>`), in ScratchDirs' own sidecar format,
 //        and liveness is decided by ScratchDirs.IsOwnerAlive — pid plus the boot-relative
@@ -38,7 +41,8 @@
 //        `.owner` sidecar this is a claim by ANY NUMBER of processes at once, and it means
 //        "someone is reading this", never "delete this when I exit".
 //     3. It has not been used for `maxAge` — 7 days by default, overridable with
-//        AL_RUNNER_PKGDEDUP_MAX_AGE_DAYS. "Used" is the NEWER of the directory's own mtime
+//        AL_RUNNER_PKGDEDUP_MAX_AGE_DAYS, which is floored at one hour so a mistyped
+//        fraction cannot ask for condition-3-in-name-only. "Used" is the NEWER of the directory's own mtime
 //        and its markers' mtimes, because a stage is written once and read on every reuse:
 //        its own mtime otherwise records only its creation. atime cannot serve — relatime
 //        and noatime are the norm — so MarkInUse stamps the directory explicitly, and the
@@ -103,6 +107,19 @@ internal static class PkgDedupCache
     internal static readonly TimeSpan DefaultMaxAge = TimeSpan.FromDays(7);
 
     internal const string MaxAgeEnvVar = "AL_RUNNER_PKGDEDUP_MAX_AGE_DAYS";
+
+    /// <summary>The shortest threshold <see cref="MaxAgeFrom"/> will hand back, whatever the
+    /// environment asks for. Rejecting only zero and negatives was not enough: `0.00001` is a
+    /// positive number of days and bought a 0.86-SECOND threshold (#3038), which is the very
+    /// thing the fallback above exists to refuse, spelt differently.
+    ///
+    /// <para>Condition 3 is the only protection a directory carrying no claim has, and two
+    /// such directories exist by construction: a `&lt;key&gt;.tmp-&lt;rand&gt;` that
+    /// <c>PkgDedupStaging.Publish</c> has not returned from yet, and any stage a run from a
+    /// build predating #2990 is reading. An hour is far longer than either staging or a
+    /// compile and far shorter than the default, so it bounds a typo without taking the knob
+    /// away.</para></summary>
+    internal static readonly TimeSpan MinMaxAge = TimeSpan.FromHours(1);
 
     /// <summary>What one <see cref="Prune(string, TimeSpan, DateTime)"/> pass did.
     /// <see cref="Removed"/> lists deleted directories; <see cref="Kept"/> counts recognised
@@ -259,7 +276,9 @@ internal static class PkgDedupCache
     /// <summary>The configured threshold, or <see cref="DefaultMaxAge"/> when the environment
     /// says nothing usable. Anything non-positive or unparseable falls back rather than being
     /// honoured: "0" would mean "delete a stage the moment it is written", which is precisely
-    /// the failure this class exists to avoid, and a typo must never be able to ask for it.</summary>
+    /// the failure this class exists to avoid, and a typo must never be able to ask for it.
+    /// A positive value below <see cref="MinMaxAge"/> is raised to it for the same reason —
+    /// "0.00001" is not zero but asks for the same thing.</summary>
     internal static TimeSpan MaxAgeFromEnvironment()
         => MaxAgeFrom(Environment.GetEnvironmentVariable(MaxAgeEnvVar));
 
@@ -269,9 +288,11 @@ internal static class PkgDedupCache
         if (!double.TryParse(raw.Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out var days))
             return DefaultMaxAge;
         if (!(days > 0) || double.IsNaN(days) || double.IsInfinity(days)) return DefaultMaxAge;
-        try { return TimeSpan.FromDays(days); }
+        TimeSpan asked;
+        try { asked = TimeSpan.FromDays(days); }
         catch (OverflowException) { return DefaultMaxAge; }
         catch (ArgumentException) { return DefaultMaxAge; }
+        return asked < MinMaxAge ? MinMaxAge : asked;
     }
 
     // ── The pass ───────────────────────────────────────────────────────────────────────────
@@ -309,7 +330,15 @@ internal static class PkgDedupCache
             {
                 var name = Path.GetFileName(entry);
                 var idx = name.LastIndexOf(InUseInfix, StringComparison.Ordinal);
-                if (idx > 0 && File.Exists(entry))
+                // Condition 1 applies here too (#3038). A claim is only ours to interpret —
+                // and, further down, only ours to DELETE — when the thing it claims is a name
+                // the runner provably writes. MarkInUse never targets anything else, so this
+                // rejects nothing the runner produced; what it stops is judging a file that
+                // merely happens to be spelt `<something>.inuse-<n>`. Rejected here rather
+                // than in the orphan loop so the rule is applied once, and so such a file
+                // lands in Skipped — "refused to judge" — instead of being silently swallowed
+                // into the marker table and counted nowhere.
+                if (idx > 0 && IsStageDirName(name[..idx]) && File.Exists(entry))
                 {
                     var target = name[..idx];
                     if (!markers.TryGetValue(target, out var list)) markers[target] = list = new List<string>();

--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ a separate rule instead: every run writes a `<stage>.inuse-<pid>` claim on the s
 and a stage is deleted only when no live process claims it **and** nothing has used it for
 seven days. A directory whose name is not one the compiler writes is never touched. Set
 `AL_RUNNER_PKGDEDUP_MAX_AGE_DAYS` to change the threshold; anything unparseable or
-non-positive falls back to the default rather than being honoured. See
+non-positive falls back to the default rather than being honoured, and any positive value
+under one hour is raised to one hour — a stage still being staged into carries no claim yet,
+so a sub-minute threshold would delete it out from under the run that is writing it. See
 `AlRunner/Infrastructure/PkgDedupCache.cs`.
 
 ### Watch mode (live dashboard)


### PR DESCRIPTION
Closes #3038

Three residuals, three different causes. Two are code defects and are fixed; one is
not fixable and is now bounded by measurement instead of by hope. One of the three
turned out to have a proposed fix that does not do what the issue says it does, and
I have the mutation run that shows it.

## Residual 1 — the rollout window: not fixable, but I measured how far it reaches

A runner built before the pruner landed writes no `.inuse-<pid>` claim, so condition 2
("no live process claims this stage") is vacuous for it, and a new-build runner in
another worktree can prune a stage it has just adopted. That much is real and there is
no way to retrofit a claim into a running process.

What the issue did not establish is whether the window is reachable. It is not, and the
reason is condition 3. Reaching the failure needs a stage that **no new-build runner has
touched for `maxAge`** — any new-build use stamps the directory's mtime — so on the
default threshold it needs a stage created a week ago and read only by claim-less builds
since. Measured on this machine on 2026-09-06, hours after the pruner merged:

- 114 worktrees, 140 built `al-runner.dll`. **120 write no claim.** The newest claim-less
  binary was built at 08:36; the merge that added claims was 08:37, so the boundary is
  exactly the merge and the claim-less population only shrinks from here.
- One shared staging root (`TMPDIR` is set here, so `Path.GetTempPath()` is not `/tmp`,
  and `/tmp/al-runner-pkgdedup` does not exist at all): **180 stage directories, oldest
  1.28 days, zero past the 7-day threshold.** Nothing in the cache was eligible for
  deletion at any point in the window, and the earliest date anything could become
  eligible was 2026-09-12 — by which a claim-less binary would have to have been both
  never rebuilt and continuously running for six days. No `--watch` or `--server` session
  was running; every live runner process was seconds to minutes old.

Detection note, because it is a trap worth recording: searching the binaries for the ASCII
bytes `.inuse-` reports **every** build as claim-less, including ones built after the
merge. .NET string literals live in the `#US` heap as UTF-16LE. The numbers above are from
a UTF-16LE search.

That bound belongs entirely to condition 3 — which is why residual 4 below is not a nit.

## Residual 2 — the orphan-marker loop now applies the name-shape rule

`Prune`'s stage loop fails closed on an unrecognised name; the orphan-marker loop did not.
It deleted any file spelt `<anything>.inuse-<n>` whose target directory was absent and
whose sidecar parsed with a dead pid, without ever testing `target`.

Fixed at **classification** rather than in the orphan loop, which is where the issue
suggested it. One rule applied once, and it also makes the counter honest: such a file now
falls through to `Skipped` — "refused to judge" — instead of being silently swallowed into
the marker table and counted nowhere. RED: five foreign targets (`not-a-stage`,
`0123456789ABCDEF`, `0123456789abcdef0`, `0123456789abcdef.tmp`,
`0123456789abcdef.pruning-1a2b3c4d`) were all deleted by the old code. GREEN: all five
survive with `Skipped == 1`. The counterpart that keeps the guard from being over-broad —
a dead process's orphan claim on `<key>.tmp-<rand>`, which `MarkInUse` really does produce
via `Publish`'s fallback — still gets reaped.

## Residual 3 — the weak survival test, and why the issue's proposed fix does not fix it

The issue proposed adding `Assert.Equal(0, result.MarkersRemoved)` to
`Prune_KeepsOrphanMarkerOfALiveProcess`. **That does not put it on the same footing as its
siblings.** The siblings assert `Kept == 1` — positive evidence that the pass examined
something and spared it. `MarkersRemoved == 0` is what a do-nothing pruner reports too, so
both assertions still pass against an empty pass.

Measured, not argued. Stubbing `Prune` to return an empty result:

| version of the test | verdict against a do-nothing pruner |
|---|---|
| original (`File.Exists` only) | **passes** |
| the issue's proposal (`+ Assert.Equal(0, MarkersRemoved)`) | **passes** |
| this PR's version | **fails** |

The fixture now carries a dead claimant's orphan marker beside the live one and asserts
`MarkersRemoved == 1`, so `0` means "the pruner did nothing" and `2` means "it ignored
liveness" — both fail. Whole-class mutation run: 26 failed / 16 passed of 42, with this
test among the failures.

## Residual 4 — the threshold floor, which is what keeps residual 1 out of reach

`MaxAgeFrom` rejected zero and negatives but honoured any positive fraction, so
`AL_RUNNER_PKGDEDUP_MAX_AGE_DAYS=0.00001` bought a 0.86-second threshold. That is not
merely a fast prune: condition 3 is the only protection a directory carrying **no claim**
has, and two such directories exist by construction — a `<key>.tmp-<rand>` that
`PkgDedupStaging.Publish` has not returned from yet, and any stage a claim-less build is
reading. A sub-minute threshold makes both reachable at once, which is exactly the state
residual 1 is one condition away from. Floored at one hour: far longer than staging or a
compile, far shorter than the default, so it bounds a typo without taking the knob away.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site?** No. `InUseInfix` has one producer
   (`MarkInUse`) and one consumer (`Prune`); `tools/context-pack.py PkgDedupCache` shows
   the only production call sites are `BcCompiler.cs:1062/1071` and `Program.cs:254`.
2. **A sibling function making the same assumption?** `ScratchDirs.HandleSidecar` deletes
   a sidecar's `target` tree with no name-shape test at all — checked, and it is **not**
   the same defect. ScratchDirs is single-owner by design: the sidecar is the authority,
   and the scan is scoped by `HasScannedPrefix` at depth 0. Left alone.
3. **Two paths writing the same state, same invariant?** The genuine asymmetry is that the
   create path claims *after* `Publish` returns while the reuse path claims before use, so
   the staging window carries no claim. I deliberately did **not** add a claim on `tmp`:
   with the one-hour floor no reachable threshold can expire a directory inside a staging
   operation, so the claim would protect nothing and would leave an orphan marker per
   staging op until process exit. Recording the reasoning rather than the code.

## Does anything here assert BC behaviour?

No. Every claim in this PR is about the runner's own shared temp root: which filenames the
runner writes, which of them a prune may delete, and how a threshold is parsed. BC's
compiler is downstream of all of it — the only BC-side consequence is the `AL1023` a
vanished stage produces, and nothing here asserts that. **Nothing is owed upstream to the
corpus.**

## Tests run

- `dotnet test AlRunner.Tests --filter FullyQualifiedName~PkgDedup` — **57/57 passed**
  (all six PkgDedup classes), after the rebase-free push of this exact tree.
- `--filter "FullyQualifiedName~CliDocumentationTests|FullyQualifiedName~RuleCrossReferenceTests|FullyQualifiedName~ScratchDirs"`
  — **52/52 passed** (the README/doc-drift guards, since `README.md` changed, plus the
  sibling sweep).
- The two mutation runs above.

Not run: the full `AlRunner.Tests` suite, and no AL bundle — nothing here is on the
compile or dispatch path.

---
Written by an automated agent (`agent: impl-14`) acting on the account holder's behalf.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
