### PR TITLE
fix(tools): refuse a verdict from a copy of the tool that origin/main has moved on

### DIFF
--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -19,7 +19,7 @@ tools/ci-wait.py 2379 --timeout 2400
 | 0 | every required check passed **on the current head** — safe to report green |
 | 1 | a required check failed; **the failing log is already printed**. The list is what has reported SO FAR — while other required checks are still running it can still grow, and the verdict says how many have not reported. Do not scope a diagnosis to those names until every check has reported (a one-leg failure that turned out to be eight cost a version-specific diagnosis that was never relevant). |
 | 2 | timed out while still running — **not a verdict**, call again |
-| 3 | could not determine (auth, network, no checks) — **or** the required-context set could not be established without narrowing it (#3002). A ruleset read that comes back missing a context the tool already knows about is refused, because judging on the smaller set makes "every required check passed" vacuously true. |
+| 3 | could not determine (auth, network, no checks) — **or** the running copy of `ci-wait.py` is itself behind `origin/main` (#3020) — **or** the required-context set could not be established without narrowing it (#3002). A ruleset read that comes back missing a context the tool already knows about is refused, because judging on the smaller set makes "every required check passed" vacuously true. |
 | 4 | **blocked, not failing** — every check passed but the merge is still refused and nothing else says why. Two causes: a *required* context is `cancelled` on this commit (#2726) — the one case where `gh run rerun` can be correct, but only after checking that no check run on this commit concluded `failure` before the cancellation (see section 3); or a *required* context produced **no check run at all** and every workflow run for the commit has finished (#2807), which is a trigger/`paths:` filter question, not a re-run. Never reach for `--admin` for either. |
 
 `ci-wait.py` reads the required contexts from the **live branch ruleset** on each
@@ -48,6 +48,48 @@ It enforces the two rules agents keep getting wrong: checks are matched against 
 **current head SHA**, so a newer completed run for an older push is never reported as this
 push's result; and on failure it fetches `--log-failed` for you, so there is never a reason
 to reach for `gh run rerun`, which destroys the log permanently.
+
+### Run it from a tree you have fetched — the tool being right says nothing about your copy
+
+You invoke `tools/ci-wait.py` by relative path, so you run the copy in **your worktree**, and a
+worktree is created once at the start of a task and never fast-forwarded again. Measured over
+this box's 109 worktrees on 2026-09-06, **71 of the 99 copies of `ci-wait.py` were not
+`origin/main`'s**, across four distinct versions, and replaying the recorded PR #2971 rollup
+through them, **59 printed a false GREEN** that had already been fixed on `main`. The same
+count for `pr-body.py` and `preflight.py` was 40 of 59. A tool nobody has changed lately —
+`context-pack.py` — was identical in all 105, which is the point: it is the tools **under
+active repair** that run old, so the copy most likely to carry a fixed bug is the one most
+likely to be on disk.
+
+`ci-wait.py` and `pr-body.py` now refuse rather than answer when `origin/main` has moved their
+own file since your checkout branched (`tools/agent_self_freshness.py`) — exit 3 for
+`ci-wait.py`, refuse-to-write for `pr-body.py`. A branch that legitimately *edits* one of them
+is not stale and is not refused: what makes a copy stale is `origin/main` moving the file since
+the branch point, not your working file differing from `origin/main`'s. There is no flag to
+switch the check off.
+
+**Expect it to fire in bursts, and do not read a burst as an outage.** A worktree only goes
+stale when `ci-wait.py` (or `pr-body.py`) next changes on `main`, so nothing refuses for days
+and then every worktree older than that merge refuses at once. That file changed five times in
+four days. A wave of exit-3 refusals right after a merge is the guard working exactly as
+designed; the fix is `git fetch origin main` in each worktree, not reverting anything.
+
+Two things it cannot do, so do them yourself:
+
+- **It cannot help a copy older than itself.** The stale copies already on disk have no guard
+  in them. `git fetch origin main` in your worktree before you trust any tool in `tools/`, or
+  run `origin/main`'s copy directly:
+  ```bash
+  git fetch origin main
+  git show origin/main:tools/ci-wait.py > /tmp/ci-wait.py && python3 /tmp/ci-wait.py <PR>
+  ```
+- **It cannot turn a network failure into a verdict.** `refs/remotes/origin/main` is shared by
+  every worktree of the repository, so the check itself costs no network; one `git ls-remote`
+  confirms that shared ref against the remote. If the remote is unreachable, that is a loud
+  note and the local check stands — never a refusal, because a network blip is not evidence of
+  a stale checkout.
+
+`tools/preflight.py` carries the same exposure and is **not** guarded yet (#3164).
 
 Measured across one session's 17 subagents, CI waiting was 328 of 3,282 Bash calls, and the
 shape was wrong — 107 `gh run view` polls and 37 `sleep` loops against only 29 blocking

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -381,6 +381,19 @@ jobs:
       - name: Run tools/test_ci_wait.py
         run: python3 tools/test_ci_wait.py
 
+      # #3020: the verdict logic being right on origin/main says nothing about
+      # the copy an agent actually ran out of its own worktree. 71 of the 99
+      # copies on the development box were not origin/main's, and 59 of those
+      # print a false GREEN on a recorded rollup. These cases build throwaway git
+      # repositories -- a bare remote, a checkout, and a commit landing on the
+      # remote after the checkout branched -- because the question is what git
+      # says about that relationship, and a mocked answer would prove nothing.
+      # It sets user.name/user.email per throwaway repository, so it needs no
+      # global git identity on the runner -- verified by running it under an
+      # empty GIT_CONFIG_GLOBAL.
+      - name: Run tools/test_agent_self_freshness.py
+        run: python3 tools/test_agent_self_freshness.py
+
   preflight-tests:
     name: preflight.py unit tests
     runs-on: ubuntu-latest

--- a/tools/agent_self_freshness.py
+++ b/tools/agent_self_freshness.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Refuse to answer out of a checkout that is behind `origin/main` on this file.
+
+Why this exists
+---------------
+`tools/ci-wait.py` decides whether a PR is green, and the unattended merge bar
+reads that decision. An agent invokes it by relative path, so it runs whichever
+copy is on disk in that agent's worktree -- and a worktree is created once, at
+the start of a task, and never fast-forwarded again. The tool being correct on
+`origin/main` says nothing about the copy that actually ran.
+
+Measured on this box on 2026-09-06, across the 109 worktrees of this repository:
+
+    tools/ci-wait.py       99 present, 4 distinct versions, 71 NOT origin/main's
+    tools/pr-body.py       59 present, 2 distinct versions, 40 NOT origin/main's
+    tools/preflight.py     59 present, 4 distinct versions, 40 NOT origin/main's
+    tools/context-pack.py 105 present, 1 distinct version,   0 NOT origin/main's
+
+That last row is the point. The spread is not "old worktrees are old" -- a tool
+nobody has changed lately is identical everywhere. It is the tools under ACTIVE
+REPAIR that are running old, which is exactly backwards: the copy most likely to
+carry a bug somebody already fixed is the one most likely to be on disk.
+
+And it is not theoretical. Replaying the recorded PR #2971 rollup -- "Tests
+updated" reported success, the matrix job not created yet -- through each of the
+four on-disk versions of ci-wait.py:
+
+    210986c3b 2026-09-02   exit 0   "GREEN -- all 1 required checks passed."
+    6fa0fc2a9 2026-09-05   exit 0   "GREEN -- all 1 required checks passed."
+    2f84c4de1 2026-09-06   exit 2   still running, NOT a verdict
+    0cf933f08 2026-09-06   exit 2   still running, NOT a verdict   <- origin/main
+
+59 of the 99 worktrees carrying the tool would have printed that false GREEN.
+The oldest version answers a second recorded shape (#3010, a superseded
+cancelled run) with a false FAILURE. Three of the four versions on disk disagree
+with origin/main on at least one recorded input, in both directions.
+
+What makes a copy stale
+-----------------------
+NOT "the working file differs from origin/main's". That test would fire on every
+branch legitimately fixing the tool, which is why the issue expected a freshness
+check to need an escape hatch for that case.
+
+The right question is whether `origin/main` has moved this file since the
+checkout branched:
+
+    mb = git merge-base HEAD origin/main
+    stale  <=>  origin/main:<file>  !=  mb:<file>
+
+A branch that edits the tool is current until main also edits it -- at which
+point it genuinely must absorb that change before its answer can be trusted.
+A checkout that has not touched the tool but branched before a fix landed is
+stale, which is the measured case. No flag, no escape hatch, no judgement.
+
+`refs/remotes/origin/main` is a REPOSITORY-level ref, shared by every worktree of
+this repository, so the comparison costs no network: any agent's `git fetch`
+refreshes it for all 109. Its reflog on this box shows it moving every ten to
+forty minutes. `remote_check=True` closes that residual window with one
+`git ls-remote` (measured 0.5s), and closing it is the ONLY thing the network is
+used for -- an unreachable remote costs a loud note, never a refusal, because a
+transient network failure is not evidence of a stale checkout.
+
+`git ls-remote` without `--exit-code` exits 0 and prints nothing when the ref
+does not exist, which is indistinguishable from a failed connection. With it, a
+missing ref exits 2 (measured, git 2.55). `parse_ls_remote` below therefore
+treats an unparseable exit 0 as UNREACHABLE and only a literal exit 2 as
+"no such ref" -- and requires a 40-hex sha rather than mere non-emptiness,
+because `mise` prints a banner on stdout that a non-emptiness test would swallow.
+
+What it cannot do
+-----------------
+It cannot help a copy that predates it. The ~71 stale ci-wait.py copies already
+on disk have no guard in them and never will; they stop mattering as those
+worktrees are recycled. Nothing that lives inside the file can fix a copy of the
+file that is older than the fix -- only the invocation rule in
+`.claude/rules/ci-verdicts.md` covers those.
+
+A copy moved outside a git repository is UNKNOWN, and answers with a loud note
+rather than refusing. That is deliberate: the remedy this module prints is to run
+`origin/main`'s copy out of a temp directory, and a remedy that refuses itself is
+not a remedy.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from dataclasses import dataclass, field
+
+_SHA_LINE = re.compile(r"^([0-9a-f]{40})\s+(\S+)$")
+
+
+@dataclass
+class Freshness:
+    """What could be established about the running copy, and whether to stop.
+
+    state:
+      "current"  origin/main has not moved this file since this checkout's merge
+                 base with it. The working file may still differ (a branch fixing
+                 the tool) -- that is noted, not refused.
+      "stale"    origin/main carries a version of this file that this checkout
+                 has not incorporated. REFUSE: the running code is known to be
+                 behind a published change to itself.
+      "new"      the file does not exist on origin/main at all. Not refused.
+      "unknown"  could not be established -- outside a git repository, no
+                 origin/main ref, git missing, a shallow clone with no merge
+                 base. Not refused; said out loud.
+
+    base_confirmed:
+      "confirmed"          the local origin/main ref matches the remote's main.
+      "refreshed"          it did not, and a fetch brought it up to date.
+      "behind-unfetchable" it did not, and the fetch failed.
+      "unreachable"        the remote could not be reached at all.
+      "no-ref"             the remote has no refs/heads/main.
+      "skipped"            remote_check was off, or the answer was already stale.
+    """
+
+    state: str
+    refuse: bool
+    notes: list[str] = field(default_factory=list)
+    base_confirmed: str = "skipped"
+    local_blob: str | None = None
+    base_blob: str | None = None
+
+
+def make_runner(fn):
+    """Wrap a (args, timeout) -> (rc, stdout, stderr) callable as a runner."""
+    return fn
+
+
+def _default_runner(args: list[str], timeout: int | None = None):
+    try:
+        p = subprocess.run(args, capture_output=True, text=True, timeout=timeout)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return 128, "", str(exc)
+    return p.returncode, p.stdout or "", p.stderr or ""
+
+
+def parse_ls_remote(rc: int, out: str) -> tuple[str | None, str]:
+    """(sha, state) out of `git ls-remote --exit-code <remote> <ref>`.
+
+    state is "ok", "no-ref" (exit 2 -- the ref genuinely does not exist), or
+    "unreachable" (anything else, INCLUDING exit 0 with nothing parseable in it,
+    which is what a failed connection looks like without --exit-code).
+
+    Never accepts a capture for being merely non-empty: `mise` prints a banner on
+    stdout, and a non-emptiness test has already broken a health check, a
+    PR-existence check and a version capture in this repository.
+    """
+    for line in (out or "").splitlines():
+        m = _SHA_LINE.match(line.strip())
+        if m:
+            return m.group(1), "ok"
+    if rc == 2:
+        return None, "no-ref"
+    return None, "unreachable"
+
+
+def _git(runner, root: str | None, *args: str, timeout: int | None = 30):
+    argv = ["git"] + (["-C", root] if root else []) + list(args)
+    rc, out, err = runner(argv, timeout)
+    return rc, out.strip(), err.strip()
+
+
+def _rev(runner, root, spec):
+    rc, out, _ = _git(runner, root, "rev-parse", "--verify", "--quiet", spec)
+    return out if rc == 0 and out else None
+
+
+def _remedy(relpath: str) -> str:
+    return ("remedy -- run origin/main's copy without touching this branch:\n"
+            "    git fetch origin main\n"
+            f"    git show origin/main:{relpath} > /tmp/{os.path.basename(relpath)} "
+            f"&& python3 /tmp/{os.path.basename(relpath)} <args>\n"
+            "  or work from a checkout that is up to date with origin/main.")
+
+
+def assess(path: str, *, remote_check: bool = True, remote: str = "origin",
+           branch: str = "main", runner=None, timeout: int = 20) -> Freshness:
+    """Whether the copy of `path` on disk is behind origin/<branch> on that file."""
+    runner = runner or _default_runner
+    ref = f"refs/remotes/{remote}/{branch}"
+
+    path = os.path.abspath(path)
+    directory = os.path.dirname(path)
+    rc, root, _ = _git(runner, None, "-C", directory, "rev-parse", "--show-toplevel")
+    if rc != 0 or not root:
+        return Freshness("unknown", False, [
+            f"note: could not establish whether {os.path.basename(path)} is current -- "
+            f"{directory} is not inside a git repository (or git is unavailable). "
+            "Answering anyway; nothing here has checked that this copy of the tool "
+            "carries the latest fixes."])
+
+    rc, relpath, _ = _git(runner, root, "ls-files", "--full-name", "--", path)
+    relpath = relpath.splitlines()[0].strip() if relpath else ""
+    if rc != 0 or not relpath:
+        return Freshness("unknown", False, [
+            f"note: could not establish whether {os.path.basename(path)} is current -- "
+            f"it is not a tracked file in {root}. Answering anyway."])
+
+    base = _rev(runner, root, ref)
+    if not base:
+        return Freshness("unknown", False, [
+            f"note: could not establish whether {relpath} is current -- this "
+            f"repository has no {ref}. Answering anyway."])
+
+    notes: list[str] = []
+    result = _evaluate(runner, root, relpath, base, notes)
+
+    # The remote confirmation runs only when the local answer was NOT already
+    # stale: a refusal should be instant and should not depend on the network.
+    if result.state != "stale" and remote_check:
+        rc, out, _ = _git(runner, root, "ls-remote", "--exit-code", remote,
+                          f"refs/heads/{branch}", timeout=timeout)
+        tip, tip_state = parse_ls_remote(rc, out)
+        if tip_state == "ok" and tip == base:
+            result.base_confirmed = "confirmed"
+        elif tip_state == "ok":
+            frc, _, ferr = _git(runner, root, "fetch", "--quiet", remote, branch,
+                                timeout=timeout)
+            new_base = _rev(runner, root, ref) if frc == 0 else None
+            if frc == 0 and new_base:
+                notes.append(f"note: {ref} was behind {remote}/{branch} and has been "
+                             f"fetched ({base[:8]} -> {new_base[:8]}).")
+                result = _evaluate(runner, root, relpath, new_base, notes)
+                result.base_confirmed = "refreshed"
+            else:
+                result.base_confirmed = "behind-unfetchable"
+                notes.append(
+                    f"note: could not confirm this copy of {relpath} is current -- "
+                    f"{ref} is behind {remote}/{branch} ({base[:8]} vs {tip[:8]}) and "
+                    f"the fetch failed ({ferr[:120]}). The check below ran against the "
+                    "OLDER ref, so it can miss anything published since.")
+        elif tip_state == "no-ref":
+            result.base_confirmed = "no-ref"
+            notes.append(f"note: could not confirm this copy of {relpath} is current -- "
+                         f"{remote} reports no refs/heads/{branch}. Checked against the "
+                         "local ref only.")
+        else:
+            result.base_confirmed = "unreachable"
+            notes.append(f"note: could not confirm this copy of {relpath} is current -- "
+                         f"`git ls-remote {remote}` did not answer. This is a NETWORK "
+                         "failure, not evidence of a stale checkout, so the local check "
+                         f"against {ref} stands on its own.")
+
+    result.notes = notes
+    return result
+
+
+def _evaluate(runner, root: str, relpath: str, base: str, notes: list[str]) -> Freshness:
+    """The staleness question itself, against one resolved origin/main commit."""
+    base_blob = _rev(runner, root, f"{base}:{relpath}")
+    local_blob = None
+    rc, out, _ = _git(runner, root, "hash-object", os.path.join(root, relpath))
+    if rc == 0 and out:
+        local_blob = out.split()[0]
+
+    if base_blob is None:
+        notes.append(f"note: {relpath} does not exist on origin/main; nothing to be "
+                     "behind. Answering.")
+        return Freshness("new", False, base_confirmed="skipped",
+                         local_blob=local_blob, base_blob=None)
+
+    rc, mb, _ = _git(runner, root, "merge-base", "HEAD", base)
+    if rc != 0 or not mb:
+        # No merge base (shallow clone, unrelated history): fall back to comparing
+        # the working file itself. Weaker -- it cannot tell a legitimate local edit
+        # from staleness -- so it only NOTES, it does not refuse.
+        if local_blob and local_blob != base_blob:
+            notes.append(
+                f"note: could not establish whether {relpath} is current -- no merge "
+                f"base with origin/main (shallow clone?). The file differs from "
+                "origin/main's copy, which may be a local edit or may be staleness. "
+                "Answering anyway.")
+        return Freshness("unknown", False, base_confirmed="skipped",
+                         local_blob=local_blob, base_blob=base_blob)
+
+    mb_blob = _rev(runner, root, f"{mb}:{relpath}")
+
+    if mb_blob != base_blob:
+        notes.append(
+            f"note: {relpath} is STALE. origin/main carries a version of this file "
+            f"(blob {base_blob[:12]}) that this checkout has not incorporated: at its "
+            f"merge base with origin/main ({mb[:8]}) the file is "
+            f"{(mb_blob or 'absent')[:12]}. This copy predates a published change to "
+            "itself, so its answer cannot be trusted.")
+        notes.append(_remedy(relpath))
+        return Freshness("stale", True, base_confirmed="skipped",
+                         local_blob=local_blob, base_blob=base_blob)
+
+    if local_blob and local_blob != base_blob:
+        notes.append(
+            f"note: the running {relpath} differs from origin/main's copy, but "
+            "origin/main has not moved this file since this checkout branched -- a "
+            "branch that edits the tool, not a stale one. Answering.")
+
+    return Freshness("current", False, base_confirmed="skipped",
+                     local_blob=local_blob, base_blob=base_blob)

--- a/tools/agent_self_freshness.py
+++ b/tools/agent_self_freshness.py
@@ -88,6 +88,9 @@ import subprocess
 from dataclasses import dataclass, field
 
 _SHA_LINE = re.compile(r"^([0-9a-f]{40})\s+(\S+)$")
+# A remote NAME. git allows a lot here, but nothing that looks like a URL or a
+# path, which is the confusion worth catching (see assess).
+_REMOTE_NAME = re.compile(r"^[A-Za-z0-9._-]+$")
 
 
 @dataclass
@@ -177,7 +180,18 @@ def _remedy(relpath: str) -> str:
 
 def assess(path: str, *, remote_check: bool = True, remote: str = "origin",
            branch: str = "main", runner=None, timeout: int = 20) -> Freshness:
-    """Whether the copy of `path` on disk is behind origin/<branch> on that file."""
+    """Whether the copy of `path` on disk is behind origin/<branch> on that file.
+
+    `remote` is a configured remote NAME, because the comparison is made against
+    `refs/remotes/<remote>/<branch>`. A URL would resolve no such ref and answer
+    "unknown", which dresses a caller's mistake up as a fact about the
+    environment -- so it is refused outright instead.
+    """
+    if not _REMOTE_NAME.match(remote):
+        raise ValueError(
+            f"remote must be a configured remote name, not {remote!r}: this "
+            "compares against refs/remotes/<remote>/<branch>, and a URL resolves "
+            "no such ref.")
     runner = runner or _default_runner
     ref = f"refs/remotes/{remote}/{branch}"
 

--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -39,8 +39,9 @@ Exit codes
     0  every required check passed ON THE CURRENT HEAD -- safe to report green
     1  at least one required check failed; the failing log is printed
     2  timed out while still running -- NOT a verdict, call again
-    3  could not determine state (auth, network, no checks reported, or the
-       required-context set could not be established without narrowing it)
+    3  could not determine state (auth, network, no checks reported, the
+       required-context set could not be established without narrowing it, or
+       THIS FILE is behind origin/main -- see "Which copy is running" below)
     4  everything green, but the merge is still blocked and nothing else reports
        why: a REQUIRED context is `cancelled` on this commit (#2726), or a
        REQUIRED context produced no check run at all once every workflow run for
@@ -89,6 +90,29 @@ so: the line now reads "N/N ruleset context(s) accounted for". Every real green
 that night named nine or ten checks and both false greens named one; that
 asymmetry is the only reason a human caught them.
 
+Which copy is running (#3020)
+-----------------------------
+Everything above is about this FILE being right. It says nothing about the copy
+that actually ran: an agent invokes this by relative path from its own worktree,
+and a worktree is created once and never fast-forwarded. Measured 2026-09-06 over
+this repository's 109 worktrees, 71 of the 99 copies of this file were NOT
+origin/main's, in four distinct versions -- and replaying the recorded PR #2971
+rollup through them, 59 printed the exact false GREEN #3018 had already fixed.
+
+So before any verdict, this asks `tools/agent_self_freshness.py` whether
+origin/main has moved this file since the checkout branched. If it has, that is
+exit 3 -- NOT a verdict -- and no GitHub call is made at all.
+
+Exit 3 rather than a new code, deliberately. Agents branch on these numbers, and
+3 already means "no verdict, do not act", which is exactly the right handling; a
+code nobody recognises would be handled by whatever each caller's else-branch
+happens to do. The several causes of 3 are distinguished in the printed message,
+which is already how the rest of them are told apart.
+
+A branch that legitimately edits this tool is not stale and is not refused: what
+makes a copy stale is origin/main having moved the file since the branch point,
+not the working file differing from origin/main's.
+
 Exit 4, and why it is not exit 0
 --------------------------------
 A branch ruleset satisfies a required status check from the newest check run
@@ -117,10 +141,17 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
 import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    import agent_self_freshness as _freshness
+except Exception:  # pragma: no cover - a copy detached from its sibling module
+    _freshness = None
 
 REPO = "StefanMaron/BusinessCentral.AL.Runner"
 TRANSIENT = ("i/o timeout", "connection reset", "502 Bad", "dial tcp",
@@ -947,7 +978,39 @@ def main() -> int:
     ap.add_argument("--timeout", type=int, default=1800)
     ap.add_argument("--interval", type=int, default=25)
     ap.add_argument("--no-log", action="store_true")
+    # Skips only the `git ls-remote` that confirms the local origin/main ref
+    # against the remote. It does NOT disable the staleness check itself: there
+    # is no flag for that, because the only legitimate reason to want one -- a
+    # branch that edits this tool -- is already not refused.
+    ap.add_argument("--no-freshness-fetch", action="store_true")
     args = ap.parse_args()
+
+    # BEFORE anything is asked of GitHub: is the copy of this file that is
+    # running actually current? A stale copy answers confidently and wrongly,
+    # and #3002's false GREEN is still on disk in most of this box's worktrees
+    # (#3020). A refusal here is exit 3 -- undetermined, never a verdict.
+    if _freshness is None:
+        print("note: could not establish whether this copy of ci-wait.py is current "
+              "-- tools/agent_self_freshness.py could not be imported. Answering "
+              "anyway; nothing has checked that this copy carries the latest fixes.")
+    else:
+        # Both halves, not just this file. The verdict logic lives here, but the
+        # freshness rule itself lives in the sibling module, and a stale copy of
+        # THAT is a stale guard -- the same blind spot one level down. The remote
+        # confirmation is asked for once and reused, so this costs one ls-remote.
+        refused = False
+        confirm = not args.no_freshness_fetch
+        for target in (os.path.abspath(__file__),
+                       os.path.abspath(_freshness.__file__)):
+            fresh = _freshness.assess(target, remote_check=confirm)
+            confirm = False  # one ls-remote, not one per file
+            for note in fresh.notes:
+                print(note)
+            refused = refused or fresh.refuse
+        if refused:
+            print("\nREFUSING to judge PR #%s from a STALE ci-wait.py. This is NOT a "
+                  "verdict -- nothing was asked of GitHub." % args.pr)
+            return 3
 
     sha = head_sha(args.pr)
     if not sha:

--- a/tools/pr-body.py
+++ b/tools/pr-body.py
@@ -38,6 +38,13 @@ REFUSING TO WRITE. When in doubt it exits non-zero and explains.
 
 The guards
 ----------
+  self-current        this file is not behind `origin/main` on itself. An agent
+                      runs the copy in its own worktree, and 40 of the 59
+                      worktrees carrying this file on the development box had a
+                      version that was not origin/main's (#3020). A copy that
+                      predates a guard is a copy running without that guard, so
+                      it refuses instead. A branch that legitimately EDITS this
+                      file is not stale and is not refused.
   fetch-parsed        the body is read as JSON (`gh pr view --json body`, no --jq),
                       so an empty body is distinguishable from a failed fetch. A
                       response that does not parse, or has no `body` key, is a
@@ -116,6 +123,12 @@ import sys
 import tempfile
 import time
 from typing import Callable
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    import agent_self_freshness as _freshness
+except Exception:  # pragma: no cover - a copy detached from its sibling module
+    _freshness = None
 
 REPO = "StefanMaron/BusinessCentral.AL.Runner"
 
@@ -594,8 +607,44 @@ def build_new_body(orig: str, args, edits: list[Edit]) -> tuple[str, list[Result
     return new, results
 
 
+def freshness_refusal(printer=None) -> int | None:
+    """EXIT_PRECONDITION if this copy of the tool is behind origin/main, else None.
+
+    Same shape as #3020's defect in ci-wait.py, one tool over: an agent runs the
+    copy in its own worktree, and a worktree is created once and never
+    fast-forwarded. Measured 2026-09-06, 40 of the 59 worktrees carrying this
+    file had a version that was not origin/main's. Every guard in this module was
+    added because an unguarded edit destroyed a body, so running a copy that
+    predates a guard is running without that guard -- and this tool's whole
+    failure mode is REFUSING TO WRITE, which is what a stale copy should do too.
+    """
+    printer = printer or (lambda m: print(m, file=sys.stderr))
+    if _freshness is None:
+        printer("note: could not establish whether this copy of pr-body.py is current "
+                "-- tools/agent_self_freshness.py could not be imported. Proceeding; "
+                "nothing has checked that this copy carries the latest guards.")
+        return None
+    refused = False
+    confirm = True
+    for target in (os.path.abspath(__file__), os.path.abspath(_freshness.__file__)):
+        fresh = _freshness.assess(target, remote_check=confirm)
+        confirm = False  # one ls-remote, not one per file
+        for note in fresh.notes:
+            printer(note)
+        refused = refused or fresh.refuse
+    if refused:
+        printer("\nREFUSING TO WRITE -- this copy of pr-body.py is STALE. Its guards "
+                "are older than origin/main's, and a guard you do not have cannot "
+                "refuse anything. Nothing was read or written.")
+        return EXIT_PRECONDITION
+    return None
+
+
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    stale = freshness_refusal()
+    if stale is not None:
+        return stale
     edits = collect_edits(args)
     editing = bool(edits or args.append or args.append_file or args.body_file)
 

--- a/tools/test_agent_self_freshness.py
+++ b/tools/test_agent_self_freshness.py
@@ -281,6 +281,53 @@ try:
 finally:
     shutil.rmtree(tmp, ignore_errors=True)
 
+# ---------------------------------------------------------------------------
+# The same shape one tool over. pr-body.py is the only sanctioned way to edit a
+# PR body, every one of its guards exists because an unguarded edit destroyed
+# one, and 40 of the 59 worktrees carrying it had a version that was not
+# origin/main's. Running a copy that predates a guard is running without it.
+
+print("\npr-body.py refuses a stale copy of itself")
+
+tmp = tempfile.mkdtemp()
+try:
+    remote, work = make_repo(tmp)
+    for name in ("pr-body.py", "agent_self_freshness.py"):
+        shutil.copy(os.path.join(HERE, name), os.path.join(work, "tools", name))
+    git(work, "add", "-A")
+    git(work, "commit", "-m", "the real tool")
+    git(work, "push", "origin", "main")
+    land_on_remote(tmp, remote, "tools/pr-body.py", "# a newer pr-body\n")
+    git(work, "fetch", "origin", "main")
+
+    stale = os.path.join(work, "tools/pr-body.py")
+    spec = importlib.util.spec_from_file_location("pr_body_stale", stale)
+    pb = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(pb)
+
+    said: list[str] = []
+    rc = pb.freshness_refusal(printer=said.append)
+    check("a stale pr-body.py refuses with EXIT_PRECONDITION",
+          rc == pb.EXIT_PRECONDITION, f"{rc}")
+    check("...and says nothing was read or written",
+          any("Nothing was read or written" in m for m in said), said)
+    check("...and prints the runnable remedy",
+          any("git show origin/main:" in m for m in said), said)
+
+    # A current copy must get out of the way, or the guard is just an outage.
+    git(work, "merge", "--ff-only", "origin/main")
+    shutil.copy(os.path.join(HERE, "pr-body.py"), stale)
+    git(work, "add", "-A")
+    git(work, "commit", "-m", "restore")
+    spec = importlib.util.spec_from_file_location("pr_body_fresh", stale)
+    pb2 = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(pb2)
+    said2: list[str] = []
+    check("a current pr-body.py is NOT refused",
+          pb2.freshness_refusal(printer=said2.append) is None, said2)
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
+
 print()
 if FAILURES:
     print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")

--- a/tools/test_agent_self_freshness.py
+++ b/tools/test_agent_self_freshness.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/agent_self_freshness.py, and for ci-wait.py refusing on a
+stale copy of itself.
+
+The staleness cases build a REAL throwaway git repository -- a bare "remote", a
+work checkout, and a commit landing on the remote's main after the checkout
+branched -- because the whole question is what git says about a checkout's
+relationship to `origin/main`, and a mocked answer to that would prove nothing.
+`tools/test_preflight.py` already builds throwaway repositories for the same
+reason.
+
+The `git ls-remote` cases are driven through an injected runner instead, because
+the one that matters -- exit 0 with no parseable line, which is what a failed
+connection looks like -- cannot be produced on demand from a working network.
+
+Run: python3 tools/test_agent_self_freshness.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import contextlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+import agent_self_freshness as asf  # noqa: E402
+
+_spec = importlib.util.spec_from_file_location("ci_wait", os.path.join(HERE, "ci-wait.py"))
+cw = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cw)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+# ---------------------------------------------------------------------------
+# A throwaway repository: `remote` is bare, `work` is a checkout of it.
+# `tools/ci-wait.py` lands in v1, then v2 lands on the remote's main only.
+
+def git(cwd, *args):
+    p = subprocess.run(["git", "-C", cwd, *args], capture_output=True, text=True)
+    if p.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} -> {p.returncode}: {p.stderr}")
+    return p.stdout.strip()
+
+
+def make_repo(tmp: str) -> tuple[str, str]:
+    remote = os.path.join(tmp, "remote.git")
+    work = os.path.join(tmp, "work")
+    subprocess.run(["git", "init", "--bare", "-b", "main", remote],
+                   capture_output=True, check=True)
+    subprocess.run(["git", "clone", remote, work], capture_output=True, check=True)
+    git(work, "config", "user.email", "t@t")
+    git(work, "config", "user.name", "t")
+    os.makedirs(os.path.join(work, "tools"), exist_ok=True)
+    write(work, "tools/ci-wait.py", "# v1\n")
+    git(work, "add", "-A")
+    git(work, "commit", "-m", "v1")
+    git(work, "push", "origin", "main")
+    return remote, work
+
+
+def write(root: str, rel: str, text: str) -> None:
+    path = os.path.join(root, rel)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as fh:
+        fh.write(text)
+
+
+def land_on_remote(tmp: str, remote: str, rel: str, text: str) -> None:
+    """Publish a new version of `rel` on the remote's main, behind the work tree's back."""
+    other = tempfile.mkdtemp(dir=tmp)
+    subprocess.run(["git", "clone", remote, other], capture_output=True, check=True)
+    git(other, "config", "user.email", "t@t")
+    git(other, "config", "user.name", "t")
+    write(other, rel, text)
+    git(other, "add", "-A")
+    git(other, "commit", "-m", "newer")
+    git(other, "push", "origin", "main")
+
+
+print("agent_self_freshness")
+
+tmp = tempfile.mkdtemp()
+try:
+    # --- RED: the checkout is behind origin/main on this very file --------------
+    remote, work = make_repo(tmp)
+    land_on_remote(tmp, remote, "tools/ci-wait.py", "# v2 -- the fix\n")
+    git(work, "fetch", "origin", "main")     # origin/main now v2; HEAD still v1
+
+    r = asf.assess(os.path.join(work, "tools/ci-wait.py"), remote_check=False)
+    check("a checkout behind origin/main ON THIS FILE is STALE", r.state == "stale",
+          f"{r.state} {r.notes}")
+    check("...and refuse is set", r.refuse is True, f"{r.refuse}")
+    check("...and the note names origin/main's version",
+          any("origin/main" in n for n in r.notes), r.notes)
+    check("...and the note names a remedy that does not touch the branch",
+          any("git show origin/main:" in n for n in r.notes), r.notes)
+
+    # A stale copy that has ALSO been edited locally is still stale: editing an
+    # old file does not incorporate what landed on main since.
+    write(work, "tools/ci-wait.py", "# v1 plus a local tweak\n")
+    r = asf.assess(os.path.join(work, "tools/ci-wait.py"), remote_check=False)
+    check("a stale copy that is also locally EDITED is still STALE", r.state == "stale",
+          f"{r.state} {r.notes}")
+
+    # --- GREEN: fast-forward and it is current ---------------------------------
+    git(work, "checkout", "--", "tools/ci-wait.py")
+    git(work, "merge", "--ff-only", "origin/main")
+    r = asf.assess(os.path.join(work, "tools/ci-wait.py"), remote_check=False)
+    check("a fast-forwarded checkout is CURRENT", r.state == "current",
+          f"{r.state} {r.notes}")
+    check("...and does not refuse", r.refuse is False, f"{r.refuse}")
+
+    # --- a branch that LEGITIMATELY modifies the tool is not stale --------------
+    # This is the escape the issue said a freshness check would need. It needs no
+    # flag: what makes a copy stale is origin/main having moved the file since the
+    # branch point, not the working file differing from origin/main's.
+    git(work, "checkout", "-b", "agent/x/issue-1")
+    write(work, "tools/ci-wait.py", "# v2 plus my fix\n")
+    git(work, "add", "-A")
+    git(work, "commit", "-m", "my fix to the tool")
+    r = asf.assess(os.path.join(work, "tools/ci-wait.py"), remote_check=False)
+    check("a branch that MODIFIES the tool is not stale", r.state == "current",
+          f"{r.state} {r.notes}")
+    check("...and says the working copy differs from origin/main",
+          any("differs from origin/main" in n for n in r.notes), r.notes)
+
+    # ...until origin/main moves the file underneath it, which it must then absorb.
+    land_on_remote(tmp, remote, "tools/ci-wait.py", "# v3 -- landed while I worked\n")
+    git(work, "fetch", "origin", "main")
+    r = asf.assess(os.path.join(work, "tools/ci-wait.py"), remote_check=False)
+    check("a modifying branch goes STALE once main moves the same file",
+          r.state == "stale", f"{r.state} {r.notes}")
+
+    # --- a file origin/main does not have at all --------------------------------
+    r = asf.assess(os.path.join(work, "tools/brand-new.py"), remote_check=False)
+    check("a file that does not exist locally is UNKNOWN, not stale",
+          r.state == "unknown" and r.refuse is False, f"{r.state} {r.notes}")
+
+    write(work, "tools/brand-new.py", "# new\n")
+    git(work, "add", "-A")
+    git(work, "commit", "-m", "add a new tool")
+    r = asf.assess(os.path.join(work, "tools/brand-new.py"), remote_check=False)
+    check("a file introduced by this branch is NEW, and does not refuse",
+          r.state == "new" and r.refuse is False, f"{r.state} {r.notes}")
+
+    # --- outside a git repository ----------------------------------------------
+    # The remedy this tool prints runs origin/main's copy out of a temp directory,
+    # so that copy must not refuse itself. It says so out loud instead.
+    loose = os.path.join(tmp, "loose")
+    os.makedirs(loose, exist_ok=True)
+    write(loose, "ci-wait.py", "# v3\n")
+    r = asf.assess(os.path.join(loose, "ci-wait.py"), remote_check=False)
+    check("a copy outside any git repository is UNKNOWN and answers anyway",
+          r.state == "unknown" and r.refuse is False, f"{r.state} {r.notes}")
+    check("...and says why it could not be established",
+          any("could not" in n.lower() for n in r.notes), r.notes)
+
+    # --- the remote confirmation is never allowed to REFUSE ---------------------
+    # `origin/main` is a repository-level ref shared by every worktree, and on this
+    # box it is refreshed every few tens of minutes. Confirming it against the
+    # remote closes that window; failing to confirm it must cost a NOTE, never a
+    # verdict, or a network blip strands every agent.
+    git(work, "checkout", "main")
+    git(work, "merge", "--ff-only", "origin/main")
+
+    def unreachable(args, timeout=None):
+        # Only the remote call fails; every other git command runs for real, so
+        # the local half of the check is genuinely exercised.
+        if "ls-remote" in args:
+            return 128, "", "fatal: could not read from remote repository"
+        return asf._default_runner(args, timeout)
+
+    r = asf.assess(os.path.join(work, "tools/ci-wait.py"), remote_check=True,
+                   runner=asf.make_runner(unreachable))
+    check("an unreachable remote does NOT refuse", r.refuse is False,
+          f"{r.state} {r.notes}")
+    check("...and says the base could not be confirmed",
+          r.base_confirmed == "unreachable", r.base_confirmed)
+    check("...and the note is loud about it",
+          any("could not confirm" in n.lower() for n in r.notes), r.notes)
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
+
+# ---------------------------------------------------------------------------
+# `git ls-remote` with exit 0 and no parseable line is what a FAILED CONNECTION
+# looks like -- not "the ref does not exist". `--exit-code` is what separates
+# them: measured on git 2.55, a missing ref exits 2 and a present one exits 0
+# with "<40-hex>\trefs/heads/main". Reading an empty exit 0 as "no such ref"
+# would make the tool refuse for the wrong reason.
+
+sha = "a" * 40
+check("a well-formed ls-remote line parses to the sha",
+      asf.parse_ls_remote(0, f"{sha}\trefs/heads/main\n") == (sha, "ok"))
+check("exit 2 is 'the ref does not exist', not a network failure",
+      asf.parse_ls_remote(2, "") == (None, "no-ref"))
+check("exit 0 with NO output is a network failure, never 'no-ref'",
+      asf.parse_ls_remote(0, "") == (None, "unreachable"))
+check("exit 0 with unparseable output is a network failure",
+      asf.parse_ls_remote(0, "warning: something\n") == (None, "unreachable"))
+check("a non-zero exit that is not 2 is a network failure",
+      asf.parse_ls_remote(128, "fatal: could not read") == (None, "unreachable"))
+# mise prints a banner on stdout; a capture that is merely non-empty is not proof.
+check("a mise banner ahead of the line does not break the parse",
+      asf.parse_ls_remote(0, f"mise ~/.config/mise/config.toml tools: git\n{sha}\trefs/heads/main\n")
+      == (sha, "ok"))
+check("a mise banner ALONE is still unreachable, not a sha",
+      asf.parse_ls_remote(0, "mise ~/.config/mise/config.toml tools: git\n")
+      == (None, "unreachable"))
+check("a short hex string is not accepted as a sha",
+      asf.parse_ls_remote(0, "abc123\trefs/heads/main\n") == (None, "unreachable"))
+
+# ---------------------------------------------------------------------------
+# ci-wait.py must REFUSE, with exit 3, before it asks GitHub anything.
+
+print("\nci-wait.py refuses a stale copy of itself")
+
+tmp = tempfile.mkdtemp()
+try:
+    remote, work = make_repo(tmp)
+    shutil.copy(os.path.join(HERE, "ci-wait.py"), os.path.join(work, "tools/ci-wait.py"))
+    shutil.copy(os.path.join(HERE, "agent_self_freshness.py"),
+                os.path.join(work, "tools/agent_self_freshness.py"))
+    git(work, "add", "-A")
+    git(work, "commit", "-m", "the real tool")
+    git(work, "push", "origin", "main")
+    land_on_remote(tmp, remote, "tools/ci-wait.py", "# a newer ci-wait\n")
+    git(work, "fetch", "origin", "main")
+
+    stale = os.path.join(work, "tools/ci-wait.py")
+    spec = importlib.util.spec_from_file_location("ci_wait_stale", stale)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+
+    asked: list[str] = []
+
+    def gh_spy(args, attempts=4):
+        asked.append(" ".join(args))
+        return 0, json.dumps([])
+
+    m.gh = gh_spy
+    old = sys.argv
+    sys.argv = ["ci-wait.py", "2971", "--timeout", "1", "--interval", "0", "--no-log"]
+    buf = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
+            code = m.main()
+    finally:
+        sys.argv = old
+    text = buf.getvalue()
+
+    check("a stale ci-wait.py exits 3 -- undetermined, not a verdict", code == 3,
+          f"code={code} {text[:400]}")
+    check("...and asks GitHub NOTHING", asked == [], asked)
+    check("...and says it refused because it is not current",
+          "STALE" in text and "not a verdict" in text.lower(), text[:400])
+    check("...and prints the runnable remedy", "git show origin/main:" in text, text[:600])
+
+    # Same repository, fast-forwarded: the guard must get out of the way.
+    git(work, "merge", "--ff-only", "origin/main")
+    shutil.copy(os.path.join(HERE, "ci-wait.py"), os.path.join(work, "tools/ci-wait.py"))
+    git(work, "add", "-A")
+    git(work, "commit", "-m", "restore")
+    r = asf.assess(os.path.join(work, "tools/ci-wait.py"), remote_check=False)
+    check("the same file on a fast-forwarded checkout is not refused",
+          r.refuse is False, f"{r.state} {r.notes}")
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
+
+print()
+if FAILURES:
+    print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")
+    sys.exit(1)
+print("all checks passed")

--- a/tools/test_agent_self_freshness.py
+++ b/tools/test_agent_self_freshness.py
@@ -193,6 +193,59 @@ try:
           r.base_confirmed == "unreachable", r.base_confirmed)
     check("...and the note is loud about it",
           any("could not confirm" in n.lower() for n in r.notes), r.notes)
+
+    # --- the one branch that JUSTIFIES spending an ls-remote -------------------
+    # refs/remotes/origin/main is shared by every worktree and is refreshed every
+    # few tens of minutes, so the local check catches days-scale drift on its own.
+    # The remote call earns its keep only here: the shared ref is itself behind,
+    # and the file moved inside that window. This is the only path on which the
+    # remote check turns "current" into a refusal, so it is the only one that
+    # decides whether the call is worth making at all.
+    base_before = git(work, "rev-parse", "refs/remotes/origin/main")
+    land_on_remote(tmp, remote, "tools/ci-wait.py", "# v4 -- landed minutes ago\n")
+    # Deliberately NOT fetched: local origin/main still points at v3.
+    r = asf.assess(os.path.join(work, "tools/ci-wait.py"), remote_check=True)
+    check("a local origin/main that is itself behind is fetched and re-judged",
+          r.base_confirmed == "refreshed", f"{r.base_confirmed} {r.notes}")
+    check("...and the answer flips from current to STALE",
+          r.state == "stale" and r.refuse is True, f"{r.state} {r.refuse}")
+    check("...and the ref actually moved",
+          git(work, "rev-parse", "refs/remotes/origin/main") != base_before)
+    check("...and the note names both ends of the fetch",
+          any(base_before[:8] in n for n in r.notes), r.notes)
+
+    # Same situation, but the fetch fails. Knowing we are behind and being unable
+    # to close the gap is a LOUD NOTE on the older ref's answer, never a refusal:
+    # a failed fetch is a network fact, not evidence about this checkout.
+    git(work, "merge", "--ff-only", "origin/main")
+    land_on_remote(tmp, remote, "tools/ci-wait.py", "# v5\n")
+
+    def fetch_fails(args, timeout=None):
+        if "fetch" in args:
+            return 128, "", "fatal: unable to access remote"
+        return asf._default_runner(args, timeout)
+
+    r = asf.assess(os.path.join(work, "tools/ci-wait.py"), remote_check=True,
+                   runner=asf.make_runner(fetch_fails))
+    check("a failed fetch off a known-behind ref does NOT refuse", r.refuse is False,
+          f"{r.state} {r.notes}")
+    check("...and records that the base is behind and unfetchable",
+          r.base_confirmed == "behind-unfetchable", r.base_confirmed)
+    check("...and says the check ran against the OLDER ref",
+          any("OLDER ref" in n for n in r.notes), r.notes)
+
+    # --- `remote` is a remote NAME, not a URL ---------------------------------
+    # A URL resolves no refs/remotes/<name>/main, so it would answer "unknown" --
+    # a caller error dressed up as an environment fact. Refuse the argument
+    # instead; nothing in this repository passes anything but the default.
+    for bad in ("https://github.com/o/r.git", "git@github.com:o/r.git", "a/b"):
+        try:
+            asf.assess(os.path.join(work, "tools/ci-wait.py"), remote=bad,
+                       remote_check=False)
+            check(f"a URL-shaped remote ({bad[:20]}) is refused", False, "no ValueError")
+        except ValueError as exc:
+            check(f"a URL-shaped remote ({bad[:20]}) is refused",
+                  "remote name" in str(exc), str(exc))
 finally:
     shutil.rmtree(tmp, ignore_errors=True)
 


### PR DESCRIPTION
Closes #3020

## What I measured first

The issue asked two questions before any design: how stale a worktree copy really gets, and whether a stale copy can actually get a verdict wrong. Both have answers.

**Version spread.** Hashing `tools/ci-wait.py` in each of this box's 109 worktrees and comparing against `origin/main`'s blob:

| file | present in | distinct versions | not `origin/main`'s |
|---|---|---|---|
| `tools/ci-wait.py` | 99 | 4 | **71** |
| `tools/pr-body.py` | 59 | 2 | **40** |
| `tools/preflight.py` | 59 | 4 | **40** |
| `tools/context-pack.py` | 105 | 1 | **0** |

The last row is the finding. This is not "old worktrees are old" — a tool nobody has changed lately is byte-identical in all 105. It is the tools under active repair that run old, so the copy most likely to carry a bug somebody already fixed is the copy most likely to be on disk. The four `ci-wait.py` versions are all from the last four days: `210986c3b` (09-02), `6fa0fc2a9` (09-05), `2f84c4de1` (09-06), `0cf933f08` (09-06, current).

**Can a stale copy mislead?** Yes, in both directions, on inputs recorded from real PRs. I loaded each of the four on-disk versions, stubbed its `gh()` with the recorded responses, and called `main()`:

Recorded PR #2971 rollup — `Tests updated` reported success, the matrix job not created yet:

```
210986c3b 2026-09-02   exit 0   "GREEN on abc12345 -- all 1 required checks passed."
6fa0fc2a9 2026-09-05   exit 0   "GREEN on abc12345 -- all 1 required checks passed."
2f84c4de1 2026-09-06   exit 2   still running -- NOT a verdict
0cf933f08 2026-09-06   exit 2   still running -- NOT a verdict     <- origin/main
```

**59 of the 99 worktrees carrying the tool print that false green.** Recorded PR #3010 shape (a superseded cancelled Test Matrix run beside a green live one), the oldest version answers `exit 1`, a false failure. Three of the four on-disk versions disagree with `origin/main` on at least one recorded input.

So the exposure is live and measured, not theoretical.

## The fix

New `tools/agent_self_freshness.py`. The staleness rule is:

```
mb = git merge-base HEAD origin/main
stale  <=>  origin/main:<file>  !=  mb:<file>
```

That is, `origin/main` has moved this file since the checkout branched — **not** "the working file differs from `origin/main`'s". The difference matters: the issue expected a freshness check to need an escape hatch for a branch that legitimately edits the tool, and this rule does not, because such a branch is current until `main` also edits the same file, at which point it genuinely does have to absorb that change. I confirmed this against the real worktrees: 71 assess as `stale`, 33 as `current`, and the 5 that differ from the blob count are exactly branches editing `ci-wait.py` (including PR #3151's and this one). No flag switches the check off.

`refs/remotes/origin/main` is a repository-level ref shared by all 109 worktrees, so the comparison costs **no network**. Its reflog shows it moving every 10-40 minutes, so one `git ls-remote` (measured 0.5s) closes that residual window.

**Loud, never silently degrading, and a network failure is never mistaken for staleness:**

- The local check runs first. A refusal is instant and needs no network at all.
- `git ls-remote --exit-code` is read through a parser that requires a 40-hex sha on a line. Exit 2 is "the ref does not exist"; **exit 0 with nothing parseable is `unreachable`**, because that is what a failed connection looks like without `--exit-code`. A `mise` banner alone parses as `unreachable`, not as a sha — the parser never tests a capture for mere non-emptiness.
- Unreachable remote, missing ref, or a failed fetch each produce a loud note and `base_confirmed` recording exactly which, and the local check stands. **None of them refuses.**
- Outside a git repository, untracked, no `origin/main`, or no merge base (shallow clone) is `unknown` — noted loudly, answers anyway. That is deliberate: the remedy the tool prints runs `origin/main`'s copy out of `/tmp`, and a remedy that refuses itself is not a remedy.

`ci-wait.py` checks **both** its own file and the guard module's, because a stale guard is the same blind spot one level down.

### Exit code: 3, not a new one

A refusal is **exit 3**. Agents branch on these numbers, and 3 already means "no verdict, do not act", which is the correct handling. A code nobody recognizes would be handled by whatever each caller's else-branch happens to do — a worse failure mode than an over-broad 3. The several causes of 3 are already distinguished by the printed message, which is how the rest of them are told apart. No existing code changes meaning.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site?** Yes — `tools/pr-body.py`, 40 of 59 worktrees stale. Every guard in it exists because an unguarded edit destroyed PR #2790's body, so a copy predating a guard runs without that guard. Its stated failure mode is already refusing to write, so a stale copy refuses with `EXIT_PRECONDITION` before anything is read or written. Fixed here.
2. **Sibling making the same assumption?** `tools/preflight.py`, also 40 of 59. I did **not** touch it — PR #3145 is open on that file. Follow-up filed as #3164, and `.claude/rules/ci-verdicts.md` names it so it is not lost. `tools/context-pack.py`, `lsp-query.py` and `agent-cost.py` are navigation and measurement, not verdicts, and `context-pack.py` is identical in all 105 worktrees; I left them alone.
3. **Two paths, one invariant?** `ci-wait.py` and `pr-body.py` now use the same module and the same rule rather than two hand-rolled checks.

## What this cannot do, stated plainly

It cannot help a copy older than itself. The ~71 stale `ci-wait.py` copies on disk have no guard in them and never will; they stop mattering as worktrees are recycled. Nothing living inside a file can fix a copy of that file that predates the fix. `.claude/rules/ci-verdicts.md` gains the invocation half for those, including the `git show origin/main:tools/ci-wait.py > /tmp/...` recipe.

## RED to GREEN

RED, twice over:

1. The differential above — a 09-02 copy answering `exit 0 GREEN` where the current one answers `exit 2`, reproduced on the first run.
2. `tools/test_agent_self_freshness.py` failed with `ModuleNotFoundError` before the module existed.

GREEN: the new suite builds real throwaway git repositories — a bare remote, a checkout, and a commit landing on the remote after the checkout branched — because the question is what git says about that relationship, and a mocked answer would prove nothing. It covers stale, stale-and-locally-edited, fast-forwarded, a branch that edits the tool, that branch going stale once main moves the same file, a new file, outside a repository, and an unreachable remote never refusing. The `ls-remote` parser cases are injected, because "exit 0 with no parseable line" cannot be produced on demand from a working network. End to end, a stale `ci-wait.py` returns 3 and a spy confirms it asks GitHub **nothing**.

The suite also covers the one branch that justifies spending an `ls-remote` at all: the shared `refs/remotes/origin/main` being itself behind, the fetch closing that gap, and the answer flipping from `current` to a refusal (`base_confirmed=refreshed`). Its sibling is covered too — knowing the ref is behind and failing to fetch is `behind-unfetchable`, a loud note on the older ref's answer, never a refusal. 44 checks in total.

Also run: `tools/test_ci_wait.py`, `tools/test_pr_body.py`, `tools/test_preflight.py` — all pass. New suite verified under an empty `GIT_CONFIG_GLOBAL`, so it needs no git identity on the runner. Wired into the `ci-wait-tests` job in `pr-check.yml`.

## Neither required context actually runs these tests

Worth stating so the merge decision is not misread. `require-tests.yml` runs on this PR, hits "No AlRunner/ source changes — test check skipped", and reports `Tests updated` success; `All BC versions passed` does not exercise `tools/` either. So both required contexts are green **without executing any of the 44 checks** — only the advisory `ci-wait.py unit tests` job does. That gap is #3165, and impl-20 is building the fix; it is not something this PR introduces or can fix. Read the green as "nothing broke", and the proof as the suite output quoted above.

## Scope

This is agent tooling. It asserts nothing about Business Central, so nothing here is owed to the upstream corpus, and no submodule pin moves. The diff does not touch `AlRunner/`, so the `Tests updated` gate does not fire; it does not touch `CHANGELOG.md` or `tests/al-language`, and it does not touch `tools/preflight.py`.

---
Implemented by `agent: impl-12`, an automated agent acting on the account holder's behalf.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
