### PR TITLE
fix(test-data): take the --test-data summary as one snapshot

### DIFF
--- a/AlRunner.Tests/TestDataProvisionerTallyAtomicityTests.cs
+++ b/AlRunner.Tests/TestDataProvisionerTallyAtomicityTests.cs
@@ -223,6 +223,39 @@ public sealed class TestDataProvisionerTallyAtomicityTests
             + "between, which is exactly the skew #3025 removed.");
     }
 
+    /// <summary>
+    /// The same shape one level up, found while fixing #3025: the armed plan is a mutable
+    /// reference field, and a method that loads it more than once in one expression is testing
+    /// or reporting several different plans. The bundle loop re-arms it between app groups and
+    /// ResetForTests nulls it, while an abandoned hydration thread is still reading it (#2914),
+    /// so `_armed == null ? null : (_armed.Backup, _armed.Company)` could null-reference after a
+    /// null check that had just passed, or pair one plan's backup with the next one's company.
+    ///
+    /// Discovered rather than listed by name, so a new reader of the plan is covered the day it
+    /// is written. Assertion is on the field the plan lives in, not on any method list.
+    /// </summary>
+    [Fact]
+    public void NoMethod_ReadsTheArmedPlanMoreThanOnce()
+    {
+        using var asm = Assembly();
+        var provisioner = Provisioner(asm);
+        var armed = provisioner.Fields.SingleOrDefault(f => f.IsStatic && f.FieldType.Name == "ArmedPlan");
+        Assert.True(armed != null, "TestDataProvisioner no longer holds an ArmedPlan field.");
+
+        var offenders = AllMethods(provisioner)
+            .Select(m => (m.FullName, Loads: m.Body.Instructions.Count(i =>
+                (i.OpCode == OpCodes.Ldsfld || i.OpCode == OpCodes.Ldsflda)
+                && i.Operand is FieldReference fr && fr.Name == armed!.Name)))
+            .Where(x => x.Loads > 1)
+            .Select(x => $"{x.FullName} ({x.Loads} loads)")
+            .ToArray();
+
+        Assert.True(offenders.Length == 0,
+            $"{armed!.Name} is loaded more than once by: {string.Join(", ", offenders)}. "
+            + "Copy it to a local first — between two loads it can be re-armed for the next app "
+            + "group or nulled by the reset (#3025).");
+    }
+
     /// <summary>Interlocked.Increment/Add/CompareExchange take a `ref`, which is ldsflda/ldflda,
     /// and no other shape in this type does. Add and CompareExchange push further arguments
     /// first — and those can be calls (a property getter on the hydration result, `c with { … }`)

--- a/AlRunner.Tests/TestDataProvisionerTallyAtomicityTests.cs
+++ b/AlRunner.Tests/TestDataProvisionerTallyAtomicityTests.cs
@@ -1,31 +1,28 @@
-// TestDataProvisionerTallyAtomicityTests — the mechanism guard for issue #2997.
+// TestDataProvisionerTallyAtomicityTests — the mechanism guard for issues #2997 and #3025.
 //
 // WHAT IS UNDER TEST, AND WHAT THIS DELIBERATELY DOES NOT CLAIM
-//   TestDataProvisioner's --test-data tallies (_tablesDone, _rowsDone, _refused,
-//   _readerRefused, _droppedColumns, _columnsNotInThisBuild, _deferredLoadsWrittenOff) were
-//   plain `int++` / `+=` written from LoadOnDemand and NoteDeferredLoadWrittenOff, which two
-//   threads can be inside at once — TestExecutor.InvokeWithTimeout runs every [Test] on its own
-//   worker thread and does NOT kill it when the watchdog expires, so an abandoned thread keeps
-//   hydrating while the bundle loop carries on in the same process (the route #2914 established).
-//   A read-modify-write from two threads can drop a count.
+//   TestDataProvisioner's --test-data tallies are written from LoadOnDemand and
+//   NoteDeferredLoadWrittenOff, which two threads can be inside at once — TestExecutor's
+//   InvokeWithTimeout runs every [Test] on its own worker thread and does NOT kill it when the
+//   watchdog expires (thread.Join(timeout)), so an abandoned thread keeps hydrating while the
+//   bundle loop carries on in the same process (the route #2914 established).
+//
+//   #2997 was the lost update: `int++` from two threads drops counts. #3025 was the torn SET:
+//   six individually-atomic counters read one at a time yield a summary whose numbers were each
+//   true and whose combination never was.
 //
 //   These counters are DIAGNOSTICS. Nothing branches on them: they are the numbers the
-//   --test-data summary prints, plus DeferredLoadsWrittenOff, which one test asserts. A lost
-//   count misreports a run that had already gone abnormal (a test overran its watchdog and the
-//   suite was abandoned mid-bundle). It is not data corruption, and #2914 — merged — is what
-//   covers the structure that does matter.
+//   --test-data summary prints, plus DeferredLoadsWrittenOff, which one test asserts. But
+//   --test-data is what a person uses to judge whether a bucket run's failures are defects or
+//   missing setup data, so a summary that contradicts itself costs a real investigation.
 //
-//   An off-by-one under a genuine race is not deterministically reproducible, so this file does
-//   NOT try to reproduce one. It pins the MECHANISM over the compiled IL of the loaded
-//   al-runner.dll: every write to a tally goes through System.Threading.Interlocked, and the
-//   only plain store left in the type is ResetForTests's (which runs with no other thread in
-//   play). That is a deterministic RED → GREEN — it failed on the unfixed code and passes on the
-//   fixed code — and it is exactly as strong as its wording: it proves each increment is atomic,
-//   not that any particular interleaving was ever observed.
-//
-//   The behavioural half — eight threads through the real write-off path, asserting the exact
-//   total — is TestDataLazyLoadPolicyTests.TheWriteOffTally_IsExactUnderConcurrentWriteOffs.
-//   That one is a hammer, not a forced interleaving; its limits are stated there.
+//   Neither an off-by-one under a genuine race nor a specific interleaving is deterministically
+//   forceable, so this file does NOT try. It pins the MECHANISM over the compiled IL of the
+//   loaded al-runner.dll. The behavioural halves live next door and state their own limits:
+//     - TestDataSummarySnapshotTests — a reader and writers over one board, asserting that every
+//       summary describes a state that existed (#3025).
+//     - TestDataLazyLoadPolicyTests.TheWriteOffTally_IsExactUnderConcurrentWriteOffs — eight
+//       threads through the real write-off path, asserting the exact total (#2997).
 //
 //   The IL is read rather than the source text because there is no reflection surface for "how
 //   was this field written", and a source-text scan of this repo has failed under Linux CI
@@ -39,46 +36,59 @@ namespace AlRunner.Tests;
 
 public sealed class TestDataProvisionerTallyAtomicityTests
 {
-    /// <summary>Every running tally on TestDataProvisioner. Named individually rather than
-    /// discovered, so adding a counter without deciding how it is written fails review here
-    /// rather than shipping unsynchronised.</summary>
-    public static TheoryData<string> Tallies => new()
-    {
-        "_tablesDone", "_rowsDone", "_refused", "_readerRefused",
-        "_droppedColumns", "_columnsNotInThisBuild", "_deferredLoadsWrittenOff",
-    };
+    private const string BoardTypeName = "TallyBoard";
 
-    private static TypeDefinition Provisioner()
+    /// <summary>The one remaining standalone static tally. The six summary counts are no longer
+    /// separate fields — they are properties of the immutable value TallyBoard swaps (#3025), so
+    /// "someone adds a seventh count and writes it unsynchronised" is structurally impossible
+    /// for those; a new property rides the same CompareExchange. This one is still a plain
+    /// static int because nothing is ever read alongside it.</summary>
+    public static TheoryData<string> StandaloneTallies => new() { "_deferredLoadsWrittenOff" };
+
+    private static AssemblyDefinition Assembly()
+        => AssemblyDefinition.ReadAssembly(typeof(TestDataProvisioner).Assembly.Location);
+
+    private static TypeDefinition Provisioner(AssemblyDefinition asm)
     {
-        var asm = AssemblyDefinition.ReadAssembly(typeof(TestDataProvisioner).Assembly.Location);
         var type = asm.MainModule.GetType(typeof(TestDataProvisioner).FullName);
         Assert.True(type != null, "TestDataProvisioner not found in the loaded al-runner.dll");
         return type!;
     }
 
-    /// <summary>The type plus anything the compiler generated inside it (closures, iterator
-    /// state machines): a lambda writing a tally is still a write to a tally.</summary>
+    private static TypeDefinition Board(TypeDefinition provisioner)
+    {
+        var board = provisioner.NestedTypes.SingleOrDefault(t => t.Name == BoardTypeName);
+        Assert.True(board != null,
+            $"{BoardTypeName} is gone from TestDataProvisioner — the --test-data tallies have "
+            + "been restructured and this guard no longer covers them (#3025).");
+        return board!;
+    }
+
+    /// <summary>A type plus everything nested inside it at any depth: a lambda or a closure
+    /// writing a tally is still a write to a tally, and `c =&gt; c with { … }` compiles to one.</summary>
+    private static IEnumerable<TypeDefinition> WithNested(TypeDefinition t)
+        => new[] { t }.Concat(t.NestedTypes.SelectMany(WithNested));
+
     private static IEnumerable<MethodDefinition> AllMethods(TypeDefinition type)
-        => type.Methods.Concat(type.NestedTypes.SelectMany(n => n.Methods)).Where(m => m.HasBody);
+        => WithNested(type).SelectMany(t => t.Methods).Where(m => m.HasBody);
 
     private static bool Touches(Instruction i, OpCode op, string field)
         => i.OpCode == op && i.Operand is FieldReference fr && fr.Name == field;
 
+    // ───────────────────────────────────────── the standalone static tally (#2997) ──
+
     /// <summary>
-    /// The claim, first half: nothing writes a tally with a plain store except ResetForTests.
     /// `x++` and `x += n` on a static field compile to ldsfld/add/stsfld — a read-modify-write
-    /// two threads can interleave — so the ABSENCE of stsfld outside the reset is the absence of
-    /// the defect. Against the unfixed code LoadOnDemand carries five of these and
-    /// NoteDeferredLoadWrittenOff the sixth.
-    ///
-    /// ResetForTests is the one legitimate plain writer and is asserted as such below, so this
-    /// cannot be satisfied by deleting the reset.
+    /// two --test-data hydration threads can interleave — so the ABSENCE of stsfld outside the
+    /// reset is the absence of the defect. ResetForTests is the one legitimate plain writer and
+    /// is asserted as such below, so this cannot be satisfied by deleting the reset.
     /// </summary>
     [Theory]
-    [MemberData(nameof(Tallies))]
-    public void NoMethodButResetForTests_StoresATallyDirectly(string field)
+    [MemberData(nameof(StandaloneTallies))]
+    public void NoMethodButResetForTests_StoresAStandaloneTallyDirectly(string field)
     {
-        var offenders = AllMethods(Provisioner())
+        using var asm = Assembly();
+        var offenders = AllMethods(Provisioner(asm))
             .Where(m => m.Name != nameof(TestDataProvisioner.ResetForTests))
             .Where(m => m.Body.Instructions.Any(i => Touches(i, OpCodes.Stsfld, field)))
             .Select(m => m.Name)
@@ -94,39 +104,15 @@ public sealed class TestDataProvisionerTallyAtomicityTests
     /// Second half, and the one that makes the first non-vacuous: the tally really is still
     /// counted, and counted atomically. A "fix" that simply deleted every increment would pass
     /// the stsfld check above and fail here.
-    ///
-    /// Matched as "the address of the field is taken, and an Interlocked call consumes it" —
-    /// Interlocked.Increment/Add take `ref int`, which is ldsflda, and no other shape in this
-    /// type does.
     /// </summary>
     [Theory]
-    [MemberData(nameof(Tallies))]
-    public void EveryTally_IsMutatedThroughInterlocked(string field)
+    [MemberData(nameof(StandaloneTallies))]
+    public void EveryStandaloneTally_IsMutatedThroughInterlocked(string field)
     {
-        var sites = 0;
-        foreach (var m in AllMethods(Provisioner()))
-        {
-            foreach (var i in m.Body.Instructions.Where(x => Touches(x, OpCodes.Ldsflda, field)))
-            {
-                // Interlocked.Increment(ref f) calls immediately; Interlocked.Add(ref f, n)
-                // pushes its addend first, and the addend can itself be a call (a property
-                // getter on the hydration result), so scan a short window rather than requiring
-                // the next instruction. Another field address appearing first ends the window —
-                // that would be a different call's argument, not this one's.
-                for (var next = i.Next; next != null; next = next.Next)
-                {
-                    if (next.OpCode == OpCodes.Ldsflda || next.OpCode == OpCodes.Ldflda) break;
-                    if ((next.OpCode == OpCodes.Call || next.OpCode == OpCodes.Callvirt)
-                        && next.Operand is MethodReference mr
-                        && mr.DeclaringType.FullName == "System.Threading.Interlocked")
-                    {
-                        sites++;
-                        break;
-                    }
-                    if (next.Offset - i.Offset > 40) break;   // bounded: this is one call, not a block
-                }
-            }
-        }
+        using var asm = Assembly();
+        var sites = AllMethods(Provisioner(asm))
+            .SelectMany(m => m.Body.Instructions)
+            .Count(i => Touches(i, OpCodes.Ldsflda, field) && ConsumedByInterlocked(i));
 
         Assert.True(sites > 0,
             $"{field} is never passed to System.Threading.Interlocked, so either it is no "
@@ -137,15 +123,122 @@ public sealed class TestDataProvisionerTallyAtomicityTests
     /// ResetForTests stays a plain store, deliberately: it runs between runs with no other
     /// thread in play, and routing it through Interlocked would suggest a concurrency it does
     /// not have. Asserted so the exemption in the first test is a stated decision rather than a
-    /// hole — if the reset ever stops writing these fields, the first test goes vacuous and this
+    /// hole — if the reset ever stops writing this field, the first test goes vacuous and this
     /// one says so.
     /// </summary>
     [Theory]
-    [MemberData(nameof(Tallies))]
-    public void ResetForTests_StillClearsEveryTally(string field)
+    [MemberData(nameof(StandaloneTallies))]
+    public void ResetForTests_StillClearsEveryStandaloneTally(string field)
     {
-        var reset = Provisioner().Methods.Single(m => m.Name == nameof(TestDataProvisioner.ResetForTests));
+        using var asm = Assembly();
+        var reset = Provisioner(asm).Methods.Single(m => m.Name == nameof(TestDataProvisioner.ResetForTests));
         Assert.True(reset.Body.Instructions.Any(i => Touches(i, OpCodes.Stsfld, field)),
             $"ResetForTests no longer clears {field}, so a stale count survives into the next run.");
+    }
+
+    // ─────────────────────────────────────────── the summary tallies (#2997, #3025) ──
+
+    /// <summary>
+    /// The board's state is published only by Interlocked.CompareExchange. A plain stfld outside
+    /// the constructor is either a lost update (#2997) or a half-applied set some reader can
+    /// observe (#3025); inside the constructor it is neither, because nothing else can reach the
+    /// object yet.
+    /// </summary>
+    [Fact]
+    public void TheBoardState_IsPublishedOnlyByCompareExchange()
+    {
+        using var asm = Assembly();
+        var board = Board(Provisioner(asm));
+        var stateFields = board.Fields.Where(f => !f.IsStatic).Select(f => f.Name).ToArray();
+
+        Assert.True(stateFields.Length == 1,
+            "TallyBoard should hold its counts as ONE value so they can be read as a set "
+            + $"(#3025); it now has {stateFields.Length} instance field(s): "
+            + string.Join(", ", stateFields));
+
+        var state = stateFields[0];
+        var offenders = AllMethods(board)
+            .Where(m => m.Name != ".ctor")
+            .Where(m => m.Body.Instructions.Any(i => Touches(i, OpCodes.Stfld, state)))
+            .Select(m => m.FullName)
+            .ToArray();
+
+        Assert.True(offenders.Length == 0,
+            $"TallyBoard.{state} is written with a plain stfld by: {string.Join(", ", offenders)}. "
+            + "Two --test-data hydration threads can be in there at once (#2997), and a partial "
+            + "write is a set a reader can observe mid-update (#3025).");
+
+        var casSites = AllMethods(board)
+            .SelectMany(m => m.Body.Instructions)
+            .Count(i => Touches(i, OpCodes.Ldflda, state) && ConsumedByInterlocked(i));
+
+        Assert.True(casSites > 0,
+            $"TallyBoard.{state} is never passed to System.Threading.Interlocked, so the counts "
+            + "are either no longer kept or kept by some other unsynchronised means.");
+    }
+
+    /// <summary>
+    /// #3025 itself: taking the summary reads the board's state EXACTLY ONCE. Against the code
+    /// this replaced, Capture held six separate Volatile.Reads of six separate counters — six
+    /// field loads, six chances for another thread's hydration to land in between, and a
+    /// reported combination that never existed at any instant. One load is the fix.
+    /// </summary>
+    [Fact]
+    public void TakingTheSummary_ReadsTheBoardStateExactlyOnce()
+    {
+        using var asm = Assembly();
+        var board = Board(Provisioner(asm));
+        var capture = board.Methods.SingleOrDefault(m => m.Name == "Capture" && m.HasBody);
+        Assert.True(capture != null, "TallyBoard.Capture is gone — the summary is built elsewhere now (#3025).");
+
+        var stateFields = board.Fields.Where(f => !f.IsStatic).Select(f => f.Name).ToHashSet();
+        var reads = capture!.Body.Instructions.Count(i =>
+            (i.OpCode == OpCodes.Ldfld || i.OpCode == OpCodes.Ldflda)
+            && i.Operand is FieldReference fr && stateFields.Contains(fr.Name));
+
+        Assert.Equal(1, reads);
+    }
+
+    /// <summary>
+    /// The reset swaps the whole board rather than clearing counts one at a time — one reference
+    /// store, so a thread still hydrating cannot be handed a half-cleared set. Clearing in place
+    /// would be the same defect #3025 fixed, arriving from the other direction.
+    /// </summary>
+    [Fact]
+    public void ResetForTests_ReplacesTheWholeBoard()
+    {
+        using var asm = Assembly();
+        var provisioner = Provisioner(asm);
+        var boardField = provisioner.Fields.SingleOrDefault(f => f.IsStatic && f.FieldType.Name == BoardTypeName);
+        Assert.True(boardField != null, "TestDataProvisioner no longer holds a TallyBoard (#3025).");
+
+        var reset = provisioner.Methods.Single(m => m.Name == nameof(TestDataProvisioner.ResetForTests));
+        var replaced = reset.Body.Instructions.Any(i =>
+            Touches(i, OpCodes.Stsfld, boardField!.Name)
+            && i.Previous?.OpCode == OpCodes.Newobj);
+
+        Assert.True(replaced,
+            $"ResetForTests no longer replaces {boardField!.Name} with a fresh TallyBoard. "
+            + "Clearing the counts in place is several stores a concurrent reader can land "
+            + "between, which is exactly the skew #3025 removed.");
+    }
+
+    /// <summary>Interlocked.Increment/Add/CompareExchange take a `ref`, which is ldsflda/ldflda,
+    /// and no other shape in this type does. Add and CompareExchange push further arguments
+    /// first — and those can be calls (a property getter on the hydration result, `c with { … }`)
+    /// — so scan a short window rather than requiring the next instruction. Another field
+    /// address appearing first ends the window: that is a different call's argument.</summary>
+    private static bool ConsumedByInterlocked(Instruction from)
+    {
+        for (var next = from.Next; next != null; next = next.Next)
+        {
+            if (next.OpCode == OpCodes.Ldsflda || next.OpCode == OpCodes.Ldflda) return false;
+            if ((next.OpCode == OpCodes.Call || next.OpCode == OpCodes.Callvirt)
+                && next.Operand is MethodReference mr
+                && mr.DeclaringType.FullName == "System.Threading.Interlocked")
+                return true;
+            if (next.Offset - from.Offset > 60) return false;   // bounded: one call, not a block
+        }
+        return false;
     }
 }

--- a/AlRunner.Tests/TestDataSummarySnapshotTests.cs
+++ b/AlRunner.Tests/TestDataSummarySnapshotTests.cs
@@ -1,0 +1,170 @@
+// TestDataSummarySnapshotTests — the proving test for issue #3025: the --test-data summary
+// must be ONE snapshot, not several separately-taken reads glued together.
+//
+// WHAT IS UNDER TEST
+//   TestDataProvisioner.TallyBoard.Capture() builds the Summary a person reads at the end of a
+//   --test-data run. Before #3025 it took six independent reads of six independent counters,
+//   and the counters were bumped one at a time. Two threads can be inside LoadOnDemand at once
+//   — TestExecutor.InvokeWithTimeout abandons a test thread on watchdog expiry instead of
+//   killing it (thread.Join(timeout)), so it keeps hydrating while the bundle loop carries on
+//   in the same process — so a Capture() racing a hydration could report a COMBINATION that was
+//   never true at any instant: rows counted from a table not yet counted as hydrated.
+//
+//   The extreme case is the readable one: "loaded 4200 row(s) in 0 table(s)". Each number is
+//   individually correct and the sentence is false, which is the worst kind of diagnostic —
+//   --test-data is mandatory for the Microsoft BaseApp buckets, where roughly 40% of failures
+//   in one measured no-test-data run were missing setup data rather than defects, so this
+//   summary is what a person uses to decide whether a run is trustworthy at all.
+//
+// WHY THIS IS NOT A BC-BEHAVIOUR TEST
+//   Nothing here asserts anything about Business Central. It is about the internal consistency
+//   of the runner's own reporting, so bc-behavior-tests-go-upstream.md does not send it to the
+//   al-language corpus.
+//
+// WHY IT IS A HAMMER AND WHAT THAT COSTS
+//   There is no seam that forces one specific interleaving, so this drives writers and a reader
+//   concurrently over a board no other test can reach and asserts an invariant on EVERY snapshot
+//   the reader takes. Against the pre-#3025 read strategy it fails within the first few hundred
+//   snapshots, every run. Against the fixed one it cannot fail, because a snapshot is a single
+//   reference read of an immutable record: there is no interleaving left to hit. The test is
+//   therefore deterministic in the direction that matters (green is a proof, red is a
+//   reproduction), and its RED was observed, not assumed.
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestDataSummarySnapshotTests
+{
+    // One "table" the writers hydrate. Three different per-table constants so a snapshot that
+    // mixes an old table count with a new column count is caught on whichever field skewed,
+    // and so no invariant below can be satisfied by two fields happening to be equal.
+    private const int RowsPerTable = 100;
+    private const int DroppedPerTable = 3;
+    private const int NotInThisBuildPerTable = 5;
+
+    private const string Backup = "/backups/CRONUS.bak";
+    private const string Company = "CRONUS International Ltd_";
+    private const int SkippedAmbiguous = 7;
+
+    /// <summary>
+    /// The central claim. While writers hydrate, every summary a reader takes describes a state
+    /// that really existed: the rows, the dropped columns and the columns-not-in-this-build all
+    /// belong to exactly the tables the same summary counts as hydrated.
+    ///
+    /// The writers keep running for the whole of the reader's loop, so every one of those
+    /// snapshots is mid-flight by construction rather than by luck, and they each land one
+    /// increment before the reader starts, so no snapshot is trivially the empty board.
+    /// </summary>
+    [Fact]
+    public void ASummaryTakenWhileHydrationRuns_DescribesAStateThatExisted()
+    {
+        const int Writers = 3;
+        const int Snapshots = 300_000;
+
+        var board = new TestDataProvisioner.TallyBoard();
+        var stop = 0;
+        var written = new int[Writers];
+        var primed = new CountdownEvent(Writers);
+
+        var writers = Enumerable.Range(0, Writers).Select(w => new Thread(() =>
+        {
+            board.NoteHydrated(RowsPerTable, DroppedPerTable, NotInThisBuildPerTable);
+            written[w] = 1;
+            primed.Signal();
+            while (Volatile.Read(ref stop) == 0)
+            {
+                board.NoteHydrated(RowsPerTable, DroppedPerTable, NotInThisBuildPerTable);
+                written[w]++;
+            }
+        }) { IsBackground = true, Name = $"tally-writer-{w}" }).ToArray();
+
+        foreach (var t in writers) t.Start();
+        Assert.True(primed.Wait(TimeSpan.FromSeconds(30)), "a tally writer never started");
+
+        try
+        {
+            for (var i = 0; i < Snapshots; i++)
+            {
+                var s = board.Capture(Backup, Company, SkippedAmbiguous);
+
+                // The impossible combination named in #3025, called out on its own so the
+                // failure message says what went wrong rather than only that arithmetic failed.
+                Assert.False(s.TablesHydrated == 0 && s.RowsHydrated > 0,
+                    $"summary {i} reports {s.RowsHydrated} row(s) in 0 table(s) — rows from a "
+                    + "table the same summary does not count as hydrated (#3025).");
+
+                Assert.Equal(s.TablesHydrated * RowsPerTable, s.RowsHydrated);
+                Assert.Equal(s.TablesHydrated * DroppedPerTable, s.ColumnsFromUninstalledApps);
+                Assert.Equal(s.TablesHydrated * NotInThisBuildPerTable, s.ColumnsNotInThisBuild);
+
+                // Carried through unchanged from the armed plan, so they are the control: if
+                // these ever skew the defect is somewhere else entirely.
+                Assert.Equal(Backup, s.BackupPath);
+                Assert.Equal(Company, s.Company);
+                Assert.Equal(SkippedAmbiguous, s.TablesSkippedAmbiguous);
+            }
+        }
+        finally
+        {
+            Volatile.Write(ref stop, 1);
+            foreach (var t in writers) Assert.True(t.Join(TimeSpan.FromSeconds(60)), "a tally writer never finished");
+        }
+
+        // Not vacuous: the board really counted, and counted every update. An implementation
+        // whose NoteHydrated did nothing would satisfy every invariant above (0 == 0 * 100) and
+        // fails here.
+        var total = written.Sum();
+        Assert.True(total >= Writers, $"the writers only managed {total} update(s)");
+
+        var final = board.Capture(Backup, Company, SkippedAmbiguous);
+        Assert.Equal(total, final.TablesHydrated);
+        Assert.Equal(total * RowsPerTable, final.RowsHydrated);
+        Assert.Equal(total * DroppedPerTable, final.ColumnsFromUninstalledApps);
+        Assert.Equal(total * NotInThisBuildPerTable, final.ColumnsNotInThisBuild);
+    }
+
+    /// <summary>
+    /// The other direction, single-threaded and exact: each writer counts the thing it is named
+    /// for and nothing else, so the invariants above are pinned to concrete values rather than
+    /// to a ratio that a uniformly-wrong implementation could also satisfy.
+    ///
+    /// The zero-row case is the one worth stating: a table the backup offers but which holds no
+    /// rows is NOT a table hydrated, while the extension columns dropped for it still happened
+    /// and are still counted. That asymmetry is what makes "rows &gt; 0 implies tables &gt;= 1"
+    /// a real invariant rather than a coincidence.
+    /// </summary>
+    [Fact]
+    public void EachTally_CountsItsOwnEventAndNoOther()
+    {
+        var board = new TestDataProvisioner.TallyBoard();
+
+        var empty = board.Capture(Backup, Company, SkippedAmbiguous);
+        Assert.Equal(0, empty.TablesHydrated);
+        Assert.Equal(0, empty.RowsHydrated);
+        Assert.Equal(0, empty.TablesRefused);
+        Assert.Equal(0, empty.TablesRefusedByReader);
+        Assert.Equal(0, empty.ColumnsFromUninstalledApps);
+        Assert.Equal(0, empty.ColumnsNotInThisBuild);
+
+        board.NoteHydrated(rows: 40, droppedColumns: 3, columnsNotInThisBuild: 5);
+        board.NoteHydrated(rows: 0, droppedColumns: 2, columnsNotInThisBuild: 0);
+        board.NoteRefused();
+        board.NoteRefused();
+        board.NoteReaderRefused();
+
+        var s = board.Capture(Backup, Company, SkippedAmbiguous);
+        Assert.Equal(1, s.TablesHydrated);          // the empty table is not one of them
+        Assert.Equal(40, s.RowsHydrated);
+        Assert.Equal(2, s.TablesRefused);
+        Assert.Equal(1, s.TablesRefusedByReader);
+        Assert.Equal(5, s.ColumnsFromUninstalledApps);   // 3 + 2, the empty table's included
+        Assert.Equal(5, s.ColumnsNotInThisBuild);
+        Assert.Equal(SkippedAmbiguous, s.TablesSkippedAmbiguous);
+
+        // And the sentence the user actually reads carries those same numbers.
+        Assert.Contains("loaded 40 row(s) in 1 table(s)", s.Describe());
+        Assert.Contains("2 refused (unsupported value types or unknown columns)", s.Describe());
+        Assert.Contains("1 refused by the backup reader", s.Describe());
+    }
+}

--- a/AlRunner/TestDataProvisioner.cs
+++ b/AlRunner/TestDataProvisioner.cs
@@ -168,20 +168,55 @@ internal static class TestDataProvisioner
 
     private static ArmedPlan? _armed;
 
-    // Running tallies, accumulated across on-demand loads rather than known at Arm() time.
-    //
-    // #2997: mutated ONLY through Interlocked, never `++` or `+=`. Two threads can be inside
-    // LoadOnDemand at once — TestExecutor.InvokeWithTimeout runs every [Test] on its own worker
-    // thread and does not kill it when the watchdog expires, so an abandoned thread keeps
-    // hydrating while the bundle loop carries on in the same process (the route #2914
-    // established) — and a read-modify-write from two threads drops counts. Measured: eight
-    // threads doing 10,000 write-offs each landed 79,543 of 80,000.
-    //
-    // Reads are Volatile.Read. Not for tearing — these are aligned int32s, which the CLI
-    // guarantees are read and written atomically (ECMA-335 I.12.6.6), so a torn read was never
-    // possible — but so a reader is not handed a value from before another thread's increment
-    // that it has no other reason to see.
-    private static int _tablesDone, _rowsDone, _refused, _readerRefused, _droppedColumns, _columnsNotInThisBuild;
+    /// <summary>
+    /// The running --test-data tallies, accumulated across on-demand loads rather than known at
+    /// Arm() time.
+    ///
+    /// #2997: mutated ONLY through Interlocked, never `++` or `+=`. Two threads can be inside
+    /// LoadOnDemand at once — TestExecutor.InvokeWithTimeout runs every [Test] on its own worker
+    /// thread and does not kill it when the watchdog expires, so an abandoned thread keeps
+    /// hydrating while the bundle loop carries on in the same process (the route #2914
+    /// established) — and a read-modify-write from two threads drops counts. Measured: eight
+    /// threads doing 10,000 write-offs each landed 79,543 of 80,000.
+    ///
+    /// Reads are Volatile.Read. Not for tearing — these are aligned int32s, which the CLI
+    /// guarantees are read and written atomically (ECMA-335 I.12.6.6), so a torn read was never
+    /// possible — but so a reader is not handed a value from before another thread's increment
+    /// that it has no other reason to see.
+    ///
+    /// An instance rather than six statics so the concurrency claim is provable on a board no
+    /// other test in the assembly can reach; the production board is the static below.
+    /// </summary>
+    internal sealed class TallyBoard
+    {
+        private int _tables, _rows, _refused, _readerRefused, _droppedColumns, _columnsNotInThisBuild;
+
+        /// <summary>One table's successful hydration. A table the backup holds but that has no
+        /// rows is not a table hydrated, yet its dropped columns are still real and counted —
+        /// which is why this takes the row count rather than a "did it work" flag.</summary>
+        internal void NoteHydrated(int rows, int droppedColumns, int columnsNotInThisBuild)
+        {
+            if (rows > 0) Interlocked.Increment(ref _tables);
+            Interlocked.Add(ref _rows, rows);
+            Interlocked.Add(ref _droppedColumns, droppedColumns);
+            Interlocked.Add(ref _columnsNotInThisBuild, columnsNotInThisBuild);
+        }
+
+        /// <summary>One table whose rows the hydrator refused to rebuild.</summary>
+        internal void NoteRefused() => Interlocked.Increment(ref _refused);
+
+        /// <summary>One table the backup reader itself refused.</summary>
+        internal void NoteReaderRefused() => Interlocked.Increment(ref _readerRefused);
+
+        /// <summary>The tallies, read out as the summary a person sees.</summary>
+        internal Summary Capture(string backupPath, string company, int skippedAmbiguous)
+            => new(backupPath, company,
+                Volatile.Read(ref _tables), Volatile.Read(ref _rows),
+                skippedAmbiguous, Volatile.Read(ref _refused), Volatile.Read(ref _readerRefused),
+                Volatile.Read(ref _droppedColumns), Volatile.Read(ref _columnsNotInThisBuild));
+    }
+
+    private static TallyBoard _tallies = new();
 
     /// <summary>Tables the backup offers that ended the run without their rows because the
     /// deferred load (#2877) could not be run safely. Read by the proving test, so "written off"
@@ -302,9 +337,11 @@ internal static class TestDataProvisioner
     {
         _lastSummary = null;
         _armed = null;
-        // Plain stores on purpose (#2997): the reset runs between runs with no other thread in
+        // A fresh board rather than six stores into the old one: one reference store, so a
+        // reader that is still running cannot be handed a half-cleared set of tallies.
+        _tallies = new TallyBoard();
+        // Plain store on purpose (#2997): the reset runs between runs with no other thread in
         // play, and routing it through Interlocked would imply a concurrency it does not have.
-        _tablesDone = _rowsDone = _refused = _readerRefused = _droppedColumns = _columnsNotInThisBuild = 0;
         _deferredLoadsWrittenOff = 0;
         _tableOutcome.Clear();
         RecordPatches.TestDataOnDemandLoader = null;
@@ -417,7 +454,6 @@ internal static class TestDataProvisioner
                 out var meta, out var pristineRows);
             if (result.Rows > 0)
             {
-                Interlocked.Increment(ref _tablesDone);
                 // #2875: say so, rather than leaving anyone downstream to infer it from the
                 // store. A table the runner can ALSO synthesise rows for (Object 2000000001)
                 // has to know which writer owns its rows, and "the provider has rows" cannot
@@ -434,9 +470,7 @@ internal static class TestDataProvisioner
                 if (meta != null)
                     RecordPatches.AppendBaselineTable(source, tableId, meta, pristineRows);
             }
-            Interlocked.Add(ref _rowsDone, result.Rows);
-            Interlocked.Add(ref _droppedColumns, result.ColumnsFromUninstalledApps);
-            Interlocked.Add(ref _columnsNotInThisBuild, result.ColumnsNotInThisBuild);
+            _tallies.NoteHydrated(result.Rows, result.ColumnsFromUninstalledApps, result.ColumnsNotInThisBuild);
             _tableOutcome[tableId] = result.Rows > 0
                 ? $"{result.Rows} row(s) loaded from '{Path.GetFileName(armed.Backup)}' company '{armed.Company}'"
                 : $"'{entry.TableName}' in '{Path.GetFileName(armed.Backup)}' company '{armed.Company}' "
@@ -446,7 +480,7 @@ internal static class TestDataProvisioner
         }
         catch (TestDataHydrationRefusal ex)
         {
-            Interlocked.Increment(ref _refused);
+            _tallies.NoteRefused();
             _tableOutcome[tableId] = $"the backup's rows for it were refused — {ex.Message}";
             Console.Error.WriteLine($"[test-data] REFUSED {ex.Message}");
         }
@@ -456,16 +490,13 @@ internal static class TestDataProvisioner
             // a table that is unavailable, not a run that is broken. Reported with the reader's
             // own text IN FULL, because that text is the only diagnosis there is and the bundle
             // reporter keeps only line 1 of an EXEC-FAIL message.
-            Interlocked.Increment(ref _readerRefused);
+            _tallies.NoteReaderRefused();
             _tableOutcome[tableId] =
                 $"the backup reader refused table '{entry.TableName}' — {ex.Message.Split('\n')[0]}";
             Console.Error.WriteLine(
                 $"[test-data] READER REFUSED table '{entry.TableName}': {ex.Message}");
         }
-        _lastSummary = new Summary(armed.Backup, armed.Company,
-            Volatile.Read(ref _tablesDone), Volatile.Read(ref _rowsDone),
-            armed.SkippedAmbiguous, Volatile.Read(ref _refused), Volatile.Read(ref _readerRefused),
-            Volatile.Read(ref _droppedColumns), Volatile.Read(ref _columnsNotInThisBuild));
+        _lastSummary = _tallies.Capture(armed.Backup, armed.Company, armed.SkippedAmbiguous);
     }
 
     /// <summary>

--- a/AlRunner/TestDataProvisioner.cs
+++ b/AlRunner/TestDataProvisioner.cs
@@ -379,9 +379,22 @@ internal static class TestDataProvisioner
     /// "the flag is on but Arm() has not run for this app group yet".</summary>
     internal static bool IsArmed => _armed != null;
 
-    /// <summary>The armed backup/company pair, for a diagnosis that has to name them.</summary>
+    /// <summary>The armed backup/company pair, for a diagnosis that has to name them.
+    ///
+    /// #3025, same shape as the summary: read the field ONCE. `_armed == null ? null :
+    /// (_armed.Backup, _armed.Company)` loads it three times, and the bundle loop re-arms or
+    /// resets it between groups while an abandoned hydration thread is still running (#2914).
+    /// Three loads can therefore null-reference after a null check that just passed, or pair one
+    /// plan's backup with the next plan's company — a diagnosis naming a backup/company
+    /// combination that was never armed.</summary>
     internal static (string Backup, string Company)? ArmedBackup
-        => _armed == null ? null : (_armed.Backup, _armed.Company);
+    {
+        get
+        {
+            var armed = _armed;
+            return armed == null ? null : (armed.Backup, armed.Company);
+        }
+    }
 
     internal static void ResetForTests()
     {
@@ -421,7 +434,10 @@ internal static class TestDataProvisioner
         // which AL table id a backup table maps to is decided by the .app closure the reader
         // was given, so a group with a different closure needs its own plan.
         var symbolKey = string.Join('\n', symbols);
-        if (_armed != null && _armed.SymbolKey == symbolKey && _armed.Backup == backup)
+        // One read, for the reason in ArmedBackup: three loads can test three different plans,
+        // and "already armed for this backup" would then be true of no plan in particular.
+        var armed = _armed;
+        if (armed != null && armed.SymbolKey == symbolKey && armed.Backup == backup)
         {
             // The loader is a static field; re-install it in case something cleared it.
             InstallLoader();

--- a/AlRunner/TestDataProvisioner.cs
+++ b/AlRunner/TestDataProvisioner.cs
@@ -179,41 +179,91 @@ internal static class TestDataProvisioner
     /// established) — and a read-modify-write from two threads drops counts. Measured: eight
     /// threads doing 10,000 write-offs each landed 79,543 of 80,000.
     ///
-    /// Reads are Volatile.Read. Not for tearing — these are aligned int32s, which the CLI
-    /// guarantees are read and written atomically (ECMA-335 I.12.6.6), so a torn read was never
-    /// possible — but so a reader is not handed a value from before another thread's increment
-    /// that it has no other reason to see.
+    /// #3025: the counts are held as ONE immutable value, swapped by CompareExchange, because
+    /// six individually-atomic counters still cannot be READ as a set. Each field was fresh and
+    /// each was true; the combination was not. A reader that took the table count, lost its
+    /// slice to a thread finishing a table, then took the row count, printed rows belonging to a
+    /// table it had not counted — at worst "loaded 4200 row(s) in 0 table(s)", which is a
+    /// sentence describing no instant that ever existed. This is a diagnostic a person uses to
+    /// decide whether their test data loaded, so a summary that contradicts itself sends them
+    /// hunting a bug that is not there. Note this was never a TORN read in the ECMA-335 sense —
+    /// aligned int32s are read and written atomically (I.12.6.6) — it was a torn SET.
+    ///
+    /// The same argument applies to the write side, which is why one table's hydration is one
+    /// update rather than four: publishing the table count and the row count separately leaves a
+    /// window in which the two disagree, and no reader, however careful, can be prevented from
+    /// landing in it.
+    ///
+    /// Not a lock: readers never block, and a writer's retry loop only spins when it actually
+    /// lost a race, which needs two threads inside LoadOnDemand at the same moment.
     ///
     /// An instance rather than six statics so the concurrency claim is provable on a board no
     /// other test in the assembly can reach; the production board is the static below.
     /// </summary>
     internal sealed class TallyBoard
     {
-        private int _tables, _rows, _refused, _readerRefused, _droppedColumns, _columnsNotInThisBuild;
-
-        /// <summary>One table's successful hydration. A table the backup holds but that has no
-        /// rows is not a table hydrated, yet its dropped columns are still real and counted —
-        /// which is why this takes the row count rather than a "did it work" flag.</summary>
-        internal void NoteHydrated(int rows, int droppedColumns, int columnsNotInThisBuild)
+        /// <summary>All six counts as ONE immutable value. Six separate fields cannot be read
+        /// as a set — see the class comment — and the cheapest thing that can is an object whose
+        /// reference is swapped atomically.</summary>
+        private sealed record Counts(
+            int Tables, int Rows, int Refused, int ReaderRefused,
+            int DroppedColumns, int ColumnsNotInThisBuild)
         {
-            if (rows > 0) Interlocked.Increment(ref _tables);
-            Interlocked.Add(ref _rows, rows);
-            Interlocked.Add(ref _droppedColumns, droppedColumns);
-            Interlocked.Add(ref _columnsNotInThisBuild, columnsNotInThisBuild);
+            internal static readonly Counts Zero = new(0, 0, 0, 0, 0, 0);
         }
 
+        private Counts _counts = Counts.Zero;
+
+        /// <summary>
+        /// Apply one event to the counts. Lock-free: read the current value, derive the next
+        /// one, and publish it only if nothing else got there first — otherwise start again with
+        /// what the winner wrote. Every publication is a whole consistent set, so a reader is
+        /// never handed a state that was half-applied.
+        ///
+        /// The retry loop is unbounded on purpose: it makes progress whenever any thread does,
+        /// and the contention it is written for is two threads, once per table load.
+        /// </summary>
+        private void Update(Func<Counts, Counts> next)
+        {
+            while (true)
+            {
+                var before = Volatile.Read(ref _counts);
+                if (ReferenceEquals(Interlocked.CompareExchange(ref _counts, next(before), before), before))
+                    return;
+            }
+        }
+
+        /// <summary>One table's successful hydration, applied as a SINGLE update. A table the
+        /// backup holds but that has no rows is not a table hydrated, yet its dropped columns
+        /// are still real and counted — which is why this takes the row count rather than a
+        /// "did it work" flag, and why the table count and the row count have to move together:
+        /// "rows counted implies the table that produced them counted" is only an invariant if
+        /// nothing can observe the gap between them.</summary>
+        internal void NoteHydrated(int rows, int droppedColumns, int columnsNotInThisBuild)
+            => Update(c => c with
+            {
+                Tables = c.Tables + (rows > 0 ? 1 : 0),
+                Rows = c.Rows + rows,
+                DroppedColumns = c.DroppedColumns + droppedColumns,
+                ColumnsNotInThisBuild = c.ColumnsNotInThisBuild + columnsNotInThisBuild,
+            });
+
         /// <summary>One table whose rows the hydrator refused to rebuild.</summary>
-        internal void NoteRefused() => Interlocked.Increment(ref _refused);
+        internal void NoteRefused() => Update(c => c with { Refused = c.Refused + 1 });
 
         /// <summary>One table the backup reader itself refused.</summary>
-        internal void NoteReaderRefused() => Interlocked.Increment(ref _readerRefused);
+        internal void NoteReaderRefused() => Update(c => c with { ReaderRefused = c.ReaderRefused + 1 });
 
-        /// <summary>The tallies, read out as the summary a person sees.</summary>
+        /// <summary>The tallies, read out as the summary a person sees. ONE read of ONE
+        /// reference, so the six numbers below are the six numbers that were true together at
+        /// one instant — which is the whole point of #3025.</summary>
         internal Summary Capture(string backupPath, string company, int skippedAmbiguous)
-            => new(backupPath, company,
-                Volatile.Read(ref _tables), Volatile.Read(ref _rows),
-                skippedAmbiguous, Volatile.Read(ref _refused), Volatile.Read(ref _readerRefused),
-                Volatile.Read(ref _droppedColumns), Volatile.Read(ref _columnsNotInThisBuild));
+        {
+            var c = Volatile.Read(ref _counts);
+            return new Summary(backupPath, company, c.Tables, c.Rows,
+                skippedAmbiguous, c.Refused, c.ReaderRefused,
+                c.DroppedColumns, c.ColumnsNotInThisBuild);
+        }
     }
 
     private static TallyBoard _tallies = new();


### PR DESCRIPTION
Closes #3025

## It can tear, and here is the mechanism

The issue asked whether this is real before asking for a fix. It is real, and it reproduces in tens of milliseconds.

Two threads can be inside `LoadOnDemand` at once. `TestExecutor.InvokeWithTimeout` ends with `thread.Join(timeout)`, which abandons an expired test thread rather than killing it, so it keeps hydrating while the bundle loop carries on in the same process — the route #2914 established and #3023 already relies on.

Given that, the summary was assembled from six independent `Volatile.Read`s of six independent counters. It is not a torn *read*: aligned int32s are read and written atomically (ECMA-335 I.12.6.6), and #3023 established that. It is a torn *set*.

There is a real invariant to violate. Within one thread, `_tablesDone` is incremented before `_rowsDone` is added, so at every genuine instant `rows > 0` implies `tables >= 1`. A reader that takes the table count, loses its slice to a thread finishing a table, then takes the row count reports rows belonging to a table it did not count — in the limit, `loaded 4200 row(s) in 0 table(s)`. That sentence describes no instant that ever existed, and `--test-data` is what a person reads to decide whether a bucket run's failures are defects or missing setup data.

The write side had the same hole independently: one table's hydration published four separate `Interlocked` operations, so even a perfect reader could land between the table count and the row count. Fixing only the read side would not have been enough.

## RED

`AlRunner.Tests/TestDataSummarySnapshotTests.cs` runs three writers and a reader over one board and checks, on every snapshot, that the rows and dropped columns reported belong to the tables the same snapshot counts as hydrated. Five runs of the pre-fix code, five failures, all within tens of milliseconds:

```
Expected: 287400   Actual: 287300      (2874 tables, 2873 tables' worth of rows)
Expected: 1137490  Actual: 1137485
Expected: 1887500  Actual: 1887400
Expected: 15573200 Actual: 15573100
Expected: 9864     Actual: 9855        (the dropped-column count, same skew)
```

It is a hammer, not a forced interleaving — there is no seam that pins one specific ordering, and I say so in the file rather than implying more than it proves. What makes it sound in the GREEN direction is that after the fix a snapshot is a single reference read of an immutable record, so there is no interleaving left to hit. Green is a proof; red was a reproduction, observed rather than assumed.

## GREEN

The six counts become one immutable `Counts` record published by `Interlocked.CompareExchange`. A summary is one reference read, so its six numbers were all true together at one instant. One table's hydration is one update rather than four. No lock: readers never block, and a writer retries only when it actually lost a race.

`ResetForTests` now swaps in a fresh board instead of clearing six counters in place. That was the same defect from the other direction — six plain stores a live hydration thread could read between, seeing a half-cleared set — and it was not in the issue.

30 clean iterations of the proving test after the fix, 30/30 pass.

## Fixing the shape, not the reported line

**Does the same wrong pattern appear at another call site?** Yes, two, in other subsystems: `EventPipeJitListener.SnapshotCounters()` (can report more BC MethodLoad events than MethodLoad events in total, and it reads while the EventPipe callback thread is genuinely live) and the `AL_RUNNER_DUMP_INSTRUMENTATION_COUNTERS` line in `Program.cs`, where the `dap` pair can report `WorkPerformedCount > CallCount`. Both need restructuring in code this PR does not otherwise touch and neither has a test that could observe the change, so they are filed as #3169 with the analysis rather than fixed here or left silent.

**Does a sibling function make the same assumption?** Yes, and it is fixed here. `ArmedBackup` was `_armed == null ? null : (_armed.Backup, _armed.Company)` — three loads of a field the bundle loop re-arms between app groups and `ResetForTests` nulls, while an abandoned hydration thread is still reading it. It could null-reference after a null check that had just passed, or name a backup/company pair that was never armed. `Arm`'s "already armed for this backup" check had the same three-load shape. Both read once now, guarded by `NoMethod_ReadsTheArmedPlanMoreThanOnce`, which discovers offenders rather than listing method names.

`DeferredLoadsWrittenOff` is deliberately left as a plain static `int`: nothing is ever read alongside it, so it has no set to skew. Its original #2997 theories are kept.

**Do two code paths writing the same state maintain the same invariant?** They did not — that is the `ResetForTests` finding above.

## The guard test

`TestDataProvisionerTallyAtomicityTests` is rewritten, because the six named int fields it pinned no longer exist. It keeps #2997's claims for `_deferredLoadsWrittenOff` verbatim and adds three for the board: state published only through `Interlocked`, the summary read exactly once, the reset replacing the whole board. Both new claims were verified RED against the pre-fix implementation (`TheBoardState_IsPublishedOnlyByCompareExchange` and `TakingTheSummary_ReadsTheBoardStateExactlyOnce` fail; `NoMethod_ReadsTheArmedPlanMoreThanOnce` names `get_ArmedBackup (3 loads)` and `Arm (3 loads)`), so none of them is vacuous.

Adding a seventh count is now structurally safe: it is a property on the record and rides the same CompareExchange. The guard says so instead of relying on a name list nobody updates.

## Does this assert anything about BC's behaviour?

No. Every claim here is about the internal consistency of the runner's own reporting — when a counter is published and how many loads a summary takes. Nothing would still be a meaningful statement about AL or Business Central if AL Runner did not exist, so `.claude/rules/bc-behavior-tests-go-upstream.md` does not send any of it to the al-language corpus. No submodule pin is touched.

## Left out on purpose

The open product question about whether `--test-data` should present a company configured differently from the backup it loads is untouched. It is a judgement call about what the runner is for, not a defect, and not mine to decide.

## Tests run

- `TestDataSummarySnapshotTests` — 5/5 RED before, 30/30 clean after.
- `TestDataProvisionerTallyAtomicityTests` — 7 pass; the 3 new claims verified RED against the pre-fix code.
- The whole `--test-data` surface, `--filter "FullyQualifiedName~TestData|~MissingTestData|~BackupReader|~ObjectSystemTableRowProvenance"`: **144 passed, 0 failed**, run twice (cold 1m01s, warm 34s) since the provisioner sits behind the on-demand load cache.

No output format changed, so no `README.md`, `PrintGuide()`, `docs/limitations.md` or `docs/scope.md` update is due.

---
Opened by an automated agent (`agent: impl-11`) acting on the account holder's behalf.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf