### PR TITLE
fix(page-metadata): revalidate EnsureRealPageMetadata's negative answers when the .app set grows

### DIFF
--- a/AlRunner.Tests/PageRealMetadataEpochRevalidationTests.cs
+++ b/AlRunner.Tests/PageRealMetadataEpochRevalidationTests.cs
@@ -1,0 +1,356 @@
+// PageRealMetadataEpochRevalidationTests — issue #3011, the PAGE-side instance of the
+// "state derived from _bcAppPaths outlives a change to _bcAppPaths" family that #2944
+// (_depPageMetadataXml / _depReportMetadataXml) and #2888 (_bcMissCache, the seven
+// count-keyed generations, NavReportSync._realMetaCache) worked through on the table and
+// report sides.
+//
+// The state, and why it is the same defect
+// ----------------------------------------
+// RecordPatches.EnsureRealPageMetadata gives exactly two NEGATIVE answers, and both are
+// derived from the registered .app set:
+//
+//   * "no NCLMetaForm could be built for this id" — BuildNCLMetaForm's own existence check
+//     calls HasDependencyPageMetadata, which walks _bcAppPaths; and _metaFormCache memoizes
+//     the resulting null;
+//   * "LoadMetadata() threw" — the load reaches TryBuildDependencyPageMetadata, the memo
+//     #2889/#2944 fixed, so a null taken there before a registration produced a throw the
+//     old _pagesRealMetadataFailed set then remembered forever.
+//
+// The SHRINK direction was covered (ResetForReload -> ResetPageMetadataForReload, #1957).
+// The GROW direction was not: nothing revisited either answer when AddBcAppPath registered
+// the .app that would now supply the metadata, so the page answered null for the rest of
+// the process — a second-order memo masking the first-order fix for its own consumer,
+// which is precisely NavReportSync._realMetaCache's shape one subsystem over.
+//
+// What changed
+// ------------
+// Both negative answers now share ONE record, stamped with the .app registration epoch
+// (#2888's monotonic counter) they were taken at, and are retaken exactly once when that
+// epoch moves. The success set is deliberately not stamped — see the field comment in
+// RecordPatches.RealPageMetadata.cs, and #1957 for what re-running a load on an already
+// loaded instance costs.
+//
+// Why these are mechanism tests and not corpus tests
+// --------------------------------------------------
+// Every claim here is about cache lifetime across a registration-set change inside ONE
+// runner process, which .claude/rules/bc-behavior-tests-go-upstream.md names as explicitly
+// runner-specific: real BC has no _bcAppPaths, no _metaFormCache and no on-demand
+// "opt this page into a real metadata load" memo at all — on a service tier a page's
+// metadata is simply there. There is no AL a corpus test could run that would distinguish
+// the two builds, and by the reachability analysis in #3011 the miss-then-register ordering
+// is not even reachable from AL today: every EnsureRealPageMetadata caller is on the
+// test-execution path, which runs after registration completes. The defect is latent, and a
+// latent defect's proving test is a state-lifetime property, not a scenario.
+//
+// What the assertions are, and why a count
+// ----------------------------------------
+// The observable is the DECISION — was the question re-asked, and exactly once per epoch —
+// not the NCLMetaForm that comes back. That is deliberate and not a convenience: whether a
+// real NCLMetaForm can be built at all depends on the BC engine being loaded in-process,
+// which this test host does not guarantee (BcEngineBootstrap can and does report
+// SkipReason on a box with no usable artifacts). Asserting on the returned object would
+// make the test's meaning depend on the environment; asserting on the retake count and the
+// stamp does not, and both are still impossible to satisfy with a no-op — a build that
+// never retakes fails the positive arm, and one that always retakes fails the bound.
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// RecordPatchesSerialCollection: this class calls RecordPatches.ResetForReload() directly,
+// which ParserStaticsIsolationGuardTests requires. Same trade-off against
+// CacheRootsSerialCollection as BcAppRegistrationEpochInvalidationTests, and the same
+// reasoning: every .app written here is a fresh GUID-named file and BcAppSymbolCache's key
+// is content-addressed, so a concurrent CacheRoots override can at worst turn a HIT into a
+// MISS and re-parse the same bytes to the same answer.
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class PageRealMetadataEpochRevalidationTests : IDisposable
+{
+    private readonly string _root;
+
+    public PageRealMetadataEpochRevalidationTests()
+    {
+        _root = TestScratch.Dir("al-runner-3011-tests");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    // Process-wide unique ids: _bcAppPaths, _metaFormCache, AlPageMetadataRegistry and the
+    // negative record are all process-global and nothing in the test host unregisters an
+    // .app. Neighbouring blocks in use: 881234xx (DependencyPageMetadataXmlTests), 881235xx
+    // (DependencyMetadataMemoInvalidationTests), 881236xx (DependencyReportProcessingOnlyTests),
+    // 881237xx (TableRelationWhereFieldLinkTests), 881238xx
+    // (BcAppRegistrationEpochInvalidationTests). This file owns 881239xx.
+    private const int LateDeclaredPageId = 88123901;
+    private const int BoundedRetakePageId = 88123902;
+    private const int SteadyStatePageId = 88123903;
+    private const int NoMetadataSourcePageId = 88123904;
+    private const int UnrelatedPageId = 88123905;
+
+    private string WriteApp(string symbolReferenceJson)
+    {
+        var appPath = Path.Combine(_root, Guid.NewGuid().ToString("N") + ".app");
+        using var zip = new FileStream(appPath, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+        return appPath;
+    }
+
+    /// <summary>Top-level "Pages" container, the same shape DependencyPageMetadataXmlTests
+    /// writes and BcAppSymbolCache.PageSymbol parses.</summary>
+    private static string PagesJson(int pageId, string name) => $$"""
+        {
+          "RuntimeVersion": "15.1",
+          "Pages": [
+            {
+              "Id": {{pageId}},
+              "Name": "{{name}}",
+              "Properties": [
+                { "Name": "Caption", "Value": "{{name}}" },
+                { "Name": "PageType", "Value": "Card" }
+              ]
+            }
+          ]
+        }
+        """;
+
+    /// <summary>
+    /// The runner's own emit-captured metadata XML is what opens
+    /// <see cref="RecordPatches.EnsureRealPageMetadata"/>'s gate; without it the method
+    /// returns before it ever consults the negative record, so nothing under test is
+    /// reached. Registering it is exactly what BcCompiler.Emit does for a page the runner
+    /// compiled itself — the content is irrelevant here, only the gate is.
+    /// </summary>
+    private static void OpenTheGateFor(int pageId) =>
+        AlPageMetadataRegistry.Register(pageId, $"<PageDefinition ID=\"{pageId}\" />");
+
+    // ── the defect: the GROW direction ───────────────────────────────────────
+
+    /// <summary>
+    /// A negative answer taken before the .app declaring the page was registered must not
+    /// survive that registration.
+    ///
+    /// <para>Both halves are asserted with CONCRETE epoch values rather than "not null":
+    /// the stamp must be the epoch current when the answer was taken, must still be that
+    /// epoch while nothing has registered, and must NOT still be that epoch once something
+    /// has. A build that recorded the answer and never revisited it — main's behaviour
+    /// before #3011 — fails the last assertion; one that recorded no stamp at all fails the
+    /// first.</para>
+    ///
+    /// <para>After the retake the record may be gone entirely rather than re-stamped: with
+    /// a usable BC engine in-process the rebuilt metaform can load and the answer becomes
+    /// positive. Both outcomes are "the question was retaken", which is the claim; what is
+    /// excluded either way is the answer still standing at the OLD epoch.</para>
+    /// </summary>
+    [Fact]
+    public void ANegativeAnswer_DoesNotSurviveARegistrationThatDeclaresThePage()
+    {
+        RecordPatches.ResetForReload();
+        OpenTheGateFor(LateDeclaredPageId);
+
+        var epochAtMiss = RecordPatches.BcAppRegistrationEpoch;
+
+        // No registered .app declares this page yet, so no NCLMetaForm can be built for it
+        // and the answer is null. This is also what records the negative answer.
+        Assert.Null(RecordPatches.EnsureRealPageMetadata(LateDeclaredPageId));
+        Assert.Equal(epochAtMiss, RecordPatches.PageRealMetadataNegativeEpochForTests(LateDeclaredPageId));
+        Assert.Equal(0, RecordPatches.PageRealMetadataRetakesForTests(LateDeclaredPageId));
+
+        RecordPatches.AddBcAppPath(WriteApp(PagesJson(LateDeclaredPageId, "PRM Late Page")));
+
+        // Precondition, asserted rather than assumed: the registration really did move the
+        // epoch, and the page really is declared now. Without both, the assertions below
+        // could pass on a build that never revalidates anything.
+        var epochAfterRegistration = RecordPatches.BcAppRegistrationEpoch;
+        Assert.NotEqual(epochAtMiss, epochAfterRegistration);
+        Assert.True(RecordPatches.HasDependencyPageMetadata(LateDeclaredPageId),
+            "the .app just registered declares this page, so the dependency-metadata opt-in must see it");
+
+        RecordPatches.EnsureRealPageMetadata(LateDeclaredPageId);
+
+        Assert.Equal(1, RecordPatches.PageRealMetadataRetakesForTests(LateDeclaredPageId));
+        Assert.NotEqual(epochAtMiss,
+            RecordPatches.PageRealMetadataNegativeEpochForTests(LateDeclaredPageId) ?? epochAfterRegistration);
+    }
+
+    /// <summary>
+    /// The bound, and the half that makes the test above non-vacuous: a retake happens at
+    /// most ONCE per registration epoch. An implementation that simply dropped the negative
+    /// record — or re-derived the answer on every call — passes the grow test and fails
+    /// this one, and it would put BuildNCLMetaForm (which walks every registered .app's page
+    /// list) on every TestPage construction.
+    /// </summary>
+    [Fact]
+    public void ANegativeAnswer_IsRetakenAtMostOncePerRegistrationEpoch()
+    {
+        RecordPatches.ResetForReload();
+        OpenTheGateFor(BoundedRetakePageId);
+
+        Assert.Null(RecordPatches.EnsureRealPageMetadata(BoundedRetakePageId));
+        RecordPatches.AddBcAppPath(WriteApp(PagesJson(BoundedRetakePageId, "PRM Bounded Page")));
+
+        RecordPatches.EnsureRealPageMetadata(BoundedRetakePageId);
+        Assert.Equal(1, RecordPatches.PageRealMetadataRetakesForTests(BoundedRetakePageId));
+
+        // Four more asks, no registration in between: the answer for this epoch already
+        // stands, whichever way it went.
+        for (var i = 0; i < 4; i++) RecordPatches.EnsureRealPageMetadata(BoundedRetakePageId);
+        Assert.Equal(1, RecordPatches.PageRealMetadataRetakesForTests(BoundedRetakePageId));
+    }
+
+    /// <summary>
+    /// The same bound at the FIRST epoch, before anything has registered: repeated asks
+    /// while the registration set holds still must not retake the question even once, and
+    /// the stamp must stay put. This is the assertion an "always revalidate" implementation
+    /// fails.
+    /// </summary>
+    [Fact]
+    public void ANegativeAnswer_IsNotRetakenWhileTheRegistrationSetHoldsStill()
+    {
+        RecordPatches.ResetForReload();
+        OpenTheGateFor(SteadyStatePageId);
+
+        var epoch = RecordPatches.BcAppRegistrationEpoch;
+        for (var i = 0; i < 5; i++) Assert.Null(RecordPatches.EnsureRealPageMetadata(SteadyStatePageId));
+
+        Assert.Equal(0, RecordPatches.PageRealMetadataRetakesForTests(SteadyStatePageId));
+        Assert.Equal(epoch, RecordPatches.PageRealMetadataNegativeEpochForTests(SteadyStatePageId));
+    }
+
+    // ── the negative arm: what must NOT be revalidated ───────────────────────
+
+    /// <summary>
+    /// A page NOTHING describes — no emit-captured XML, no dependency .app — never gets a
+    /// negative record and is never retaken, however many .apps register afterwards.
+    ///
+    /// <para>This is the arm that stops the fix from becoming "retake everything". The vast
+    /// majority of ids EnsureRealPageMetadata is asked about fall out at its opt-in gate;
+    /// stamping and re-deriving each of those once per registered .app would put a walk of
+    /// every registered .app's page list on a path that currently costs one dictionary
+    /// lookup, and would grow the record without bound.</para>
+    /// </summary>
+    [Fact]
+    public void APageNoSourceDescribes_IsNeverStampedAndNeverRetaken()
+    {
+        RecordPatches.ResetForReload();
+
+        Assert.Null(RecordPatches.EnsureRealPageMetadata(NoMetadataSourcePageId));
+        Assert.Null(RecordPatches.PageRealMetadataNegativeEpochForTests(NoMetadataSourcePageId));
+
+        // An unrelated registration moves the epoch. The page still has no metadata source,
+        // so it must still fall out at the gate.
+        RecordPatches.AddBcAppPath(WriteApp(PagesJson(UnrelatedPageId, "PRM Unrelated Page")));
+        Assert.NotEqual(NoMetadataSourcePageId, UnrelatedPageId);
+
+        Assert.Null(RecordPatches.EnsureRealPageMetadata(NoMetadataSourcePageId));
+        Assert.Null(RecordPatches.PageRealMetadataNegativeEpochForTests(NoMetadataSourcePageId));
+        Assert.Equal(0, RecordPatches.PageRealMetadataRetakesForTests(NoMetadataSourcePageId));
+    }
+
+    // ── the SHRINK direction #1957 fixed, still intact ───────────────────────
+
+    /// <summary>
+    /// A bundle roll still discards the negative record. Redundant with the epoch on this
+    /// path — ResetForReload bumps it through InvalidateBcAppIndexes — and asserted anyway,
+    /// because the redundancy is the argument for keeping
+    /// <c>ResetPageMetadataForReload</c>'s explicit clear and it should fail loudly if
+    /// someone removes that clear on the strength of the epoch alone.
+    /// </summary>
+    [Fact]
+    public void ANegativeAnswer_DoesNotSurviveABundleRoll()
+    {
+        RecordPatches.ResetForReload();
+        OpenTheGateFor(SteadyStatePageId);
+
+        Assert.Null(RecordPatches.EnsureRealPageMetadata(SteadyStatePageId));
+        Assert.NotNull(RecordPatches.PageRealMetadataNegativeEpochForTests(SteadyStatePageId));
+
+        RecordPatches.ResetForReload();
+
+        Assert.Null(RecordPatches.PageRealMetadataNegativeEpochForTests(SteadyStatePageId));
+        Assert.Equal(0, RecordPatches.PageRealMetadataRetakesForTests(SteadyStatePageId));
+        Assert.False(RecordPatches.PageHasRealMetadataForTests(SteadyStatePageId));
+    }
+
+    // ── structural guard: ONE record, ONE guard, for BOTH negative answers ───
+
+    /// <summary>
+    /// The two negative answers must keep sharing one epoch-stamped record read by one
+    /// guard.
+    ///
+    /// <para>This is a guard, not the proof — the proof is the behavioural tests above,
+    /// which drive the "no NCLMetaForm could be built" branch. The catch branch cannot be
+    /// driven from a test host without a usable in-process BC engine (LoadMetadata has to
+    /// run and throw), and #3011's whole point is that a covered branch sitting next to an
+    /// uncovered one is how this family of defects keeps recurring: #2478 was a reset that
+    /// reset one half of a pair, #2888 instance 3 a second-order memo whose sibling was
+    /// fixed and it was not. Holding both writes on one field read by one guard makes that
+    /// divergence structurally impossible rather than merely unintended.</para>
+    /// </summary>
+    [Fact]
+    public void BothNegativeAnswersShareOneEpochStampedRecordAndOneGuard()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            RepoRoot(), "AlRunner", "Patches", "RecordPatches.RealPageMetadata.cs"));
+
+        var code = string.Join('\n', source.Split('\n')
+            .Where(l => !l.TrimStart().StartsWith("//", StringComparison.Ordinal)
+                     && !l.TrimStart().StartsWith("///", StringComparison.Ordinal)));
+
+        // Scoped to EnsureRealPageMetadata's own body: the read-only test accessor above it
+        // consults the same field and is not a guard.
+        var body = MethodBody(code, "internal static object? EnsureRealPageMetadata", "private static void EvictPageMetaForm");
+        Assert.Equal(1, CountOf(body, "_pageRealMetadataNegativeEpoch.TryGetValue("));
+        Assert.True(CountOf(body, "_pageRealMetadataNegativeEpoch[") >= 2,
+            "both negative answers — 'no NCLMetaForm could be built' and 'LoadMetadata threw' — must "
+            + "stamp the SAME record, or one of them can be revalidated while the other is not (#3011)");
+
+        // The pre-#3011 epoch-less failure set must not come back anywhere in the runner.
+        var offenders = Directory
+            .GetFiles(Path.Combine(RepoRoot(), "AlRunner"), "*.cs", SearchOption.AllDirectories)
+            .Where(f => File.ReadAllText(f).Contains("_pagesRealMetadataFailed", StringComparison.Ordinal))
+            .Select(Path.GetFileName)
+            .ToList();
+        Assert.True(offenders.Count == 0,
+            "a negative real-page-metadata answer must carry the registration epoch it was taken at, "
+            + "never live in an unstamped set that only a bundle roll clears (#3011): "
+            + string.Join(", ", offenders));
+
+        // #1957: the SUCCESS set is deliberately NOT epoch-stamped, so this clear is the
+        // only thing that discards it when the NCLMetaForm instances it describes go.
+        Assert.Contains("_pagesWithRealMetadata.Clear()", code, StringComparison.Ordinal);
+    }
+
+    /// <summary>The source between <paramref name="startMarker"/> and
+    /// <paramref name="endMarker"/>. Both must be present exactly once, asserted — a marker
+    /// that stopped matching after a rename would otherwise silently shrink the region to
+    /// nothing and make every count assertion below it pass vacuously.</summary>
+    private static string MethodBody(string code, string startMarker, string endMarker)
+    {
+        var start = code.IndexOf(startMarker, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"expected to find \"{startMarker}\" in RecordPatches.RealPageMetadata.cs");
+        var end = code.IndexOf(endMarker, start, StringComparison.Ordinal);
+        Assert.True(end > start, $"expected to find \"{endMarker}\" after \"{startMarker}\"");
+        return code[start..end];
+    }
+
+    private static int CountOf(string haystack, string needle)
+    {
+        var n = 0;
+        for (var i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+            n++;
+        return n;
+    }
+
+    private static string RepoRoot() => Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+}

--- a/AlRunner/Patches/RecordPatches.BcAppFallback.cs
+++ b/AlRunner/Patches/RecordPatches.BcAppFallback.cs
@@ -212,14 +212,22 @@ public static partial class RecordPatches
         // AlReportMetadataRegistry.Clear(), this memo's OTHER input, which is not derived from
         // _bcAppPaths at all.
         //
-        // The PAGE-side twin of this instance — EnsureRealPageMetadata's _pagesWithRealMetadata
-        // / _pagesRealMetadataFailed plus the _metaFormCache entry a failed load leaves behind
-        // — is deliberately NOT cleared here, and is tracked in #3011. Same asymmetry (shrink
-        // covered by ResetPageMetadataForReload, grow not), but it is latent rather than live:
-        // every EnsureRealPageMetadata caller is on the test-execution path, which runs after
-        // registration completes. And unlike this one line, the fix is not free — clearing
-        // _metaFormCache once per registered .app has a real blast radius, and #1957 requires
-        // the two sets and the NCLMetaForm instances they describe to be discarded together.
+        // The PAGE-side twin of this instance — EnsureRealPageMetadata's negative answers,
+        // plus the _metaFormCache entry a failed load leaves behind — is fixed (#3011) but
+        // NOT here, and the difference is deliberate. Two reasons this method is the wrong
+        // place for it, both absent for every other instance above:
+        //   1. LOCK ORDER. This method runs while HOLDING _bcTableIndexLock.
+        //      EnsureRealPageMetadata holds _realPageMetadataLock across LoadMetadata(),
+        //      which reaches BC code that takes _bcTableIndexLock, so touching the page state
+        //      from here inverts the order against a live load — a deadlock, not a cost.
+        //   2. BLAST RADIUS. AddBcAppPath runs once per dependency .app, so a clear here
+        //      would discard page metadata N times per bundle, and #1957 requires the
+        //      NCLMetaForm instances and the bookkeeping describing them to be discarded
+        //      together — a partial clear is worse than none.
+        // Instead the page-side negative answers carry the epoch below, and are retaken
+        // lazily and once per (page, epoch) — see RecordPatches.RealPageMetadata.cs. The
+        // increment at the end of this method is what drives them, so the funnel is still
+        // the single point of truth; only the eviction moved to the reader.
         NavReportSync.ResetMetadataCache();
         // Bumped LAST, and unconditionally: every cache keyed on the epoch must observe a
         // value it has not built against, and everything above must already be dropped when

--- a/AlRunner/Patches/RecordPatches.RealPageMetadata.cs
+++ b/AlRunner/Patches/RecordPatches.RealPageMetadata.cs
@@ -38,8 +38,85 @@ namespace AlRunner.Patches;
 public static partial class RecordPatches
 {
     private static readonly HashSet<int> _pagesWithRealMetadata = new();
-    private static readonly HashSet<int> _pagesRealMetadataFailed = new();
+
+    // #3011. The page-side NEGATIVE answers, each stamped with the .app registration epoch
+    // (BcAppRegistrationEpoch — RecordPatches.BcAppFallback.cs) it was taken at.
+    //
+    // There are exactly two of them and they now share one record, deliberately:
+    //   * BuildNCLMetaForm returned null — no NCLMetaForm could be built for the id at all;
+    //   * LoadMetadata() threw — a metaform exists but its real metadata would not load.
+    // Both are derived from the registered .app set. HasDependencyPageMetadata walks
+    // _bcAppPaths, and BuildNCLMetaForm's own existence check calls it; the load itself
+    // reaches TryBuildDependencyPageMetadata, the memo #2889/#2944 fixed. So both answers
+    // are true only for as long as that set holds still, and answering from either one
+    // after the set has grown is the same defect #2888 fixed on the report side
+    // (NavReportSync._realMetaCache): a second-order memo that keeps serving a null taken
+    // before a registration, masking the first-order fix for its own consumer.
+    //
+    // Why an epoch stamp instead of a clear at the InvalidateBcAppIndexes funnel — the shape
+    // #2888 used for every other instance, and the one #3011's body suggests:
+    //   1. LOCK ORDER. EnsureRealPageMetadata holds _realPageMetadataLock across
+    //      LoadMetadata(), which reaches BC code that takes _bcTableIndexLock (table metadata
+    //      for the page's source table). InvalidateBcAppIndexes runs while HOLDING
+    //      _bcTableIndexLock, so taking _realPageMetadataLock there would invert the order
+    //      against a live load and is a deadlock, not an inefficiency.
+    //   2. COST. AddBcAppPath runs once per dependency .app. A clear at the funnel does the
+    //      work N times per bundle whether or not anything ever failed; the stamp does it
+    //      lazily, once per (page, epoch), and only for a page that actually got a negative
+    //      answer — normally none at all.
+    //   3. #1957's invariant. A retry may not re-run LoadMetadata() on the instance the
+    //      failed attempt already mutated, so the retake evicts that instance first
+    //      (EvictPageMetaForm) rather than clearing a set and hoping.
+    //
+    // The SUCCESS set above is deliberately NOT stamped and NOT revalidated. It records that
+    // one specific live NCLMetaForm has had its real metadata loaded into it, which a later
+    // registration does not falsify — and re-running the load on it is exactly what #1957
+    // forbids. Its lifetime is still governed by ResetPageMetadataForReload, because a bundle
+    // roll discards the instances it describes; the epoch cannot substitute for that.
+    private static readonly Dictionary<int, int> _pageRealMetadataNegativeEpoch = new();
+
+    // Per-page count of "the registration set moved, so the negative answer was taken again".
+    // Test-visible bookkeeping in production code for the same reason
+    // PopulateNclMetadataCacheCallCount is: the claim #3011's proving test makes is about a
+    // DECISION (was the question re-asked, and exactly once per epoch), and a count is the
+    // only way to state it that a no-op implementation cannot satisfy. Written only on the
+    // retake path, so it stays empty for every page that never got a negative answer.
+    private static readonly Dictionary<int, int> _pageRealMetadataRetakes = new();
+
     private static readonly object _realPageMetadataLock = new();
+
+    /// <summary>
+    /// The registration epoch at which <see cref="EnsureRealPageMetadata"/> last answered
+    /// null for <paramref name="pageId"/>, or null when it holds no negative answer for that
+    /// page — either because it never gave one, or because the answer has since been retaken
+    /// against a newer epoch. See <c>_pageRealMetadataNegativeEpoch</c> (#3011).
+    /// </summary>
+    internal static int? PageRealMetadataNegativeEpochForTests(int pageId)
+    {
+        lock (_realPageMetadataLock)
+            return _pageRealMetadataNegativeEpoch.TryGetValue(pageId, out var e) ? e : null;
+    }
+
+    /// <summary>
+    /// How many times a negative real-page-metadata answer for <paramref name="pageId"/> has
+    /// been retaken because the .app registration set changed under it (#3011). Zero for a
+    /// page that never got a negative answer, and for one whose negative answer has never
+    /// been revisited.
+    /// </summary>
+    internal static int PageRealMetadataRetakesForTests(int pageId)
+    {
+        lock (_realPageMetadataLock)
+            return _pageRealMetadataRetakes.TryGetValue(pageId, out var n) ? n : 0;
+    }
+
+    /// <summary>Whether <paramref name="pageId"/> is recorded as having had its REAL page
+    /// metadata successfully loaded — the success set #1957 requires
+    /// <see cref="ResetPageMetadataForReload"/> to discard alongside the
+    /// <c>NCLMetaForm</c> instances it describes.</summary>
+    internal static bool PageHasRealMetadataForTests(int pageId)
+    {
+        lock (_realPageMetadataLock) return _pagesWithRealMetadata.Contains(pageId);
+    }
 
     /// <summary>
     /// Clear the "already loaded" / "already failed" bookkeeping alongside
@@ -61,8 +138,8 @@ public static partial class RecordPatches
     /// <c>OnOpenPage</c> quietly stopped running from the second cycle onward.
     /// </para>
     /// <para>
-    /// The failure set is cleared for the mirror reason, not merely for symmetry: a page
-    /// that could not load against the previous generation must get a fresh attempt
+    /// The negative record is cleared for the mirror reason, not merely for symmetry: a
+    /// page that could not load against the previous generation must get a fresh attempt
     /// against this one, or an edit that fixes the underlying cause could never be
     /// observed to have fixed it. This runs once per <c>--watch</c> cycle, so a page whose
     /// metadata load genuinely, repeatedly fails pays for one retry per cycle — not a
@@ -70,13 +147,21 @@ public static partial class RecordPatches
     /// (<see cref="EnsureRealPageMetadata"/>'s catch block), so a real gap stays visible
     /// rather than being silently swallowed by either generation's cache.
     /// </para>
+    /// <para>
+    /// #3011 makes the negative half redundant on this path — the reload bumps
+    /// <see cref="BcAppRegistrationEpoch"/> through <c>InvalidateBcAppIndexes</c>, so every
+    /// stamped negative answer is stale by then anyway — and it stays here regardless,
+    /// because the SUCCESS set is not epoch-stamped and cannot be: this clear is the only
+    /// thing that discards it, and #1957's NRE is what happens when it does not.
+    /// </para>
     /// </summary>
     internal static void ResetPageMetadataForReload()
     {
         lock (_realPageMetadataLock)
         {
             _pagesWithRealMetadata.Clear();
-            _pagesRealMetadataFailed.Clear();
+            _pageRealMetadataNegativeEpoch.Clear();
+            _pageRealMetadataRetakes.Clear();
         }
     }
 
@@ -86,18 +171,61 @@ public static partial class RecordPatches
     /// metadata XML for the page (a precompiled dependency's page) or when the load
     /// failed — in both cases the caller must not pretend it has a control tree.
     /// Idempotent: the load runs at most once per page per run (per --watch cycle — see
-    /// <see cref="ResetForReload"/>).
+    /// <see cref="ResetForReload"/>), and a NEGATIVE answer is retaken at most once per .app
+    /// registration epoch (#3011 — see <c>_pageRealMetadataNegativeEpoch</c>).
     /// </summary>
     internal static object? EnsureRealPageMetadata(int pageId)
     {
         if (!AlPageMetadataRegistry.TryGet(pageId, out _) && !HasDependencyPageMetadata(pageId)) return null;
 
-        var meta = _metaFormCache.GetOrAdd(pageId, BuildNCLMetaForm);
-        if (meta == null) return null;
+        // Read once, outside the lock: an int read is atomic and the epoch only ever moves
+        // forward, so a concurrent bump can at worst make this call record its negative
+        // answer against the older epoch — which the next call then retakes. The opposite
+        // (a stale answer surviving a bump) is the defect, and cannot happen this way.
+        var epoch = BcAppRegistrationEpoch;
 
         lock (_realPageMetadataLock)
         {
-            if (_pagesRealMetadataFailed.Contains(pageId)) return null;
+            object? meta;
+            if (_pageRealMetadataNegativeEpoch.TryGetValue(pageId, out var negativeAt))
+            {
+                // Same registration set the negative answer was taken against: it still
+                // stands, and re-deriving it would be a retry storm on the TestPage path.
+                if (negativeAt == epoch) return null;
+
+                // The set has changed. Discard everything the negative attempt left behind
+                // and take the question again — exactly once for this epoch, because the
+                // record below is rewritten with the new epoch if the answer is still no.
+                //
+                // The metaform goes with it (#1957): a failed LoadMetadata() leaves the
+                // instance half-mutated, and re-running LoadMetadata() on that same object
+                // is precisely what must not happen. EvictPageMetaForm drops it from
+                // _metaFormCache AND from BC's own metadataCacheEntries[Page], so the two
+                // cannot disagree about which instance is page N's.
+                _pageRealMetadataNegativeEpoch.Remove(pageId);
+                _pageRealMetadataRetakes[pageId] =
+                    (_pageRealMetadataRetakes.TryGetValue(pageId, out var n) ? n : 0) + 1;
+                EvictPageMetaForm(pageId);
+
+                meta = _metaFormCache.GetOrAdd(pageId, BuildNCLMetaForm);
+                if (meta != null) RefreshPageInMetadataCache(pageId, meta);
+            }
+            else
+            {
+                meta = _metaFormCache.GetOrAdd(pageId, BuildNCLMetaForm);
+            }
+
+            if (meta == null)
+            {
+                // No NCLMetaForm could be built. That answer is derived from the registered
+                // .app set too — BuildNCLMetaForm's existence check calls
+                // HasDependencyPageMetadata — so it is stamped rather than memoized forever.
+                // _metaFormCache memoizes the null itself, which is why the retake above has
+                // to evict it before asking again.
+                _pageRealMetadataNegativeEpoch[pageId] = epoch;
+                return null;
+            }
+
             if (_pagesWithRealMetadata.Contains(pageId)) return meta;
 
             try
@@ -120,7 +248,10 @@ public static partial class RecordPatches
             catch (Exception ex)
             {
                 var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
-                _pagesRealMetadataFailed.Add(pageId);
+                // Same record, same stamp, same guard as the "no metaform" branch above —
+                // one mechanism for both negative answers, so neither can be covered while
+                // the other is not (#3011).
+                _pageRealMetadataNegativeEpoch[pageId] = epoch;
                 // Put the flag back so the skeleton behaves exactly as it did before the
                 // attempt — a half-loaded metaform is worse than none.
                 if (_fNCLMetaAppObjMetadataLoaded != null)
@@ -133,6 +264,91 @@ public static partial class RecordPatches
                         $"[page-metadata] page {pageId} LoadMetadata THREW {inner.GetType().Name}: {inner.Message}");
                 return null;
             }
+        }
+    }
+
+    /// <summary>
+    /// Drop page <paramref name="pageId"/>'s <c>NCLMetaForm</c> from BOTH layers that can
+    /// serve it: the runner's own <c>_metaFormCache</c> and the skeleton NCLMetadata's
+    /// <c>metadataCacheEntries[Page]</c> dictionary <see cref="PopulateNclMetadataCache"/>
+    /// fills from it.
+    ///
+    /// <para>Both, not one (#3011). <c>PopulateOneObjectType</c> wraps the very object
+    /// <c>_metaFormCache</c> holds in an <c>NCLMetadataCacheEntry</c> and stores it in BC's
+    /// dictionary, so the two layers hold the SAME instance by reference — which is what
+    /// makes <see cref="EnsureRealPageMetadata"/>'s in-place load visible to BC at all.
+    /// Evicting only the runner's copy and rebuilding would hand out a second, different
+    /// <c>NCLMetaForm</c> for one page id while BC's dictionary kept the first: our own
+    /// <c>NCLMetadata_GetMetaApplicationObjectByType</c> hook would answer with the new one
+    /// and anything reading the dictionary with the old one. Same eviction shape, and the
+    /// same reasoning, as <c>TddReparseAndRefreshTable</c> on the table side.</para>
+    ///
+    /// <para>Best-effort on the BC half: if the reflection handles are unavailable the entry
+    /// stays, and the caller's rebuild is then a no-op against BC's view rather than a
+    /// divergence, because <see cref="RefreshPageInMetadataCache"/> puts the fresh instance
+    /// back under the same key.</para>
+    /// </summary>
+    private static void EvictPageMetaForm(int pageId)
+    {
+        _metaFormCache.TryRemove(pageId, out _);
+        TryMutatePageMetadataCacheEntries(dict => dict.Remove(pageId));
+    }
+
+    /// <summary>
+    /// Put <paramref name="meta"/> back into the skeleton NCLMetadata's
+    /// <c>metadataCacheEntries[Page]</c> under <paramref name="pageId"/>, so BC's dictionary
+    /// and <c>_metaFormCache</c> agree on which <c>NCLMetaForm</c> is that page's after a
+    /// <see cref="EvictPageMetaForm"/> + rebuild (#3011).
+    ///
+    /// <para>Assigns rather than TryAdds, and that is the difference from
+    /// <c>PopulateOneObjectType</c>: this runs precisely when a stale entry may still be
+    /// there, so skipping an existing key would reinstate exactly the divergence the
+    /// eviction exists to prevent. <c>metadataLoaded</c> is set true first, matching what
+    /// the populator does with a freshly built skeleton — the caller flips it back to false
+    /// for the load attempt that follows.</para>
+    /// </summary>
+    private static void RefreshPageInMetadataCache(int pageId, object meta)
+    {
+        if (_mCreateWithBase == null) { EnsureCachePopulatorReflection(); }
+        if (_mCreateWithBase == null) return;
+        try
+        {
+            if (_fNCLMetaAppObjMetadataLoaded != null)
+                AlRunner.Infrastructure.FieldPoke.SetInstance(_fNCLMetaAppObjMetadataLoaded, meta, true);
+            var entry = _mCreateWithBase.Invoke(null, new object?[] { meta });
+            if (entry != null) TryMutatePageMetadataCacheEntries(dict => dict[pageId] = entry);
+        }
+        catch (Exception ex)
+        {
+            var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
+            Console.Error.WriteLine(
+                $"[RecordPatches] page {pageId}: could not refresh the NCLMetadata cache entry "
+                + $"({inner.GetType().Name}: {inner.Message})");
+        }
+    }
+
+    /// <summary>Run <paramref name="mutate"/> against the skeleton NCLMetadata's
+    /// <c>metadataCacheEntries[Page]</c> dictionary, or do nothing when there is no skeleton
+    /// / the reflection handles did not resolve. Never throws: a failure here leaves BC's
+    /// own lookup to raise its ordinary not-found, which is loud, rather than turning a
+    /// cache-maintenance problem into an unrelated exception mid-load.</summary>
+    private static void TryMutatePageMetadataCacheEntries(Action<System.Collections.IDictionary> mutate)
+    {
+        try
+        {
+            var skeleton = BcRuntime.SkeletonNCLMetadata;
+            if (skeleton == null) return;
+            EnsureCachePopulatorReflection();
+            if (_fNCLMetadataCacheEntries == null) return;
+            if (_fNCLMetadataCacheEntries.GetValue(skeleton) is not Array arr) return;
+            const int objectTypePage = 8;
+            if (arr.Length <= objectTypePage) return;
+            if (arr.GetValue(objectTypePage) is not System.Collections.IDictionary dict) return;
+            mutate(dict);
+        }
+        catch
+        {
+            // Best-effort, exactly as TddReparseAndRefreshTable's own eviction is.
         }
     }
 }

--- a/AlRunner/Patches/RecordPatches.RealXmlPortMetadata.cs
+++ b/AlRunner/Patches/RecordPatches.RealXmlPortMetadata.cs
@@ -31,6 +31,18 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
+    // KNOWN GAP — #3172. Nothing clears either of these sets, on any path: they appear
+    // nowhere else in the runner. RecordPatches.ResetForReload discards every
+    // NCLMetaXmlPort via _metaXmlPortCache.Clear() without discarding the bookkeeping that
+    // describes them, so from the second --watch cycle / --server request onward the
+    // success set short-circuits a brand-new, never-loaded skeleton as "already loaded" —
+    // the page-side defect #1957 fixed with ResetPageMetadataForReload, never mirrored
+    // here. Left out of #3011's PR because neither set can be populated from a test host
+    // without the BC engine loaded in-process, so the fix could not be proved there; see
+    // the issue for what a proving test has to look like. The GROW direction #3011 fixed on
+    // the page side is a SEPARATE and unverified question here — this file's gate reads
+    // AlXmlPortMetadataRegistry and _parsedXmlPorts, neither of which is derived from the
+    // registered .app set.
     private static readonly HashSet<int> _xmlPortsWithRealMetadata = new();
     private static readonly HashSet<int> _xmlPortsRealMetadataFailed = new();
     private static readonly object _realXmlPortMetadataLock = new();


### PR DESCRIPTION
Closes #3011

## Is it really the same mechanism as the table/report-side issue?

Yes for the mechanism, no for the fix — and the difference is a lock-order constraint, not a preference.

#2888's third instance, `NavReportSync._realMetaCache`, is a second-order memo over `_depReportMetadataXml`: it caches a result computed from the memo #2944 fixed, so a null taken before a registration keeps masking that fix for its own consumer. `EnsureRealPageMetadata` has the identical relationship, and it has **two** negative answers rather than one:

- **"no `NCLMetaForm` could be built."** `BuildNCLMetaForm`'s existence check calls `HasDependencyPageMetadata`, which walks `_bcAppPaths`, and `_metaFormCache.GetOrAdd` memoizes the resulting null. This one the issue body does not name, and it is reached from `NCLMetadata_GetMetaApplicationObjectByType`'s `?? _metaFormCache.GetOrAdd(...)` fallback as well as from `EnsureRealPageMetadata` itself.
- **"`LoadMetadata()` threw."** The load reaches `TryBuildDependencyPageMetadata`, the memo #2889/#2944 fixed; a null taken there raises the loader's not-yet-implemented out-of-scope throw, which this method catches and recorded permanently in `_pagesRealMetadataFailed`.

Both are derived from the registered `.app` set, both had the shrink direction covered (`ResetForReload` -> `ResetPageMetadataForReload`, #1957) and the grow direction not.

**Where it diverges from #2888.** Every other instance in that family is fixed by a clear inside `InvalidateBcAppIndexes`. That does not work here, and would be a deadlock rather than a cost:

1. `InvalidateBcAppIndexes` runs while **holding** `_bcTableIndexLock`. `EnsureRealPageMetadata` holds `_realPageMetadataLock` across `LoadMetadata()`, which reaches BC code that takes `_bcTableIndexLock` (table metadata for the page's source table). Taking `_realPageMetadataLock` from the funnel inverts the order against a live load.
2. `AddBcAppPath` runs once per dependency `.app`, so a clear at the funnel does the work N times per bundle whether or not anything ever failed.
3. #1957 requires the bookkeeping and the `NCLMetaForm` instances it describes to be discarded together, so a partial clear is worse than none.

So the fix keeps #2888's mechanism — the monotonic registration epoch — and moves the eviction to the reader: both negative answers now share **one** record stamped with the epoch they were taken at, and are retaken **exactly once** when that epoch moves. The funnel is still the single point of truth; only the eviction is lazy.

## What changed

`AlRunner/Patches/RecordPatches.RealPageMetadata.cs`

- `_pagesRealMetadataFailed` (a `HashSet<int>`) is replaced by `_pageRealMetadataNegativeEpoch` (a `Dictionary<int, int>`), written by **both** negative branches and read by **one** guard. The two answers cannot be covered separately, which is how #2478 and #2888's instance 3 happened.
- The retake calls `EvictPageMetaForm`, which drops the metaform from `_metaFormCache` **and** from BC's own `metadataCacheEntries[Page]`, then `RefreshPageInMetadataCache` puts the rebuilt instance back under the same key. Both layers, because `PopulateOneObjectType` wraps the very object `_metaFormCache` holds and stores it in BC's dictionary — they hold the same instance by reference, which is what makes the in-place load visible to BC at all. Evicting only ours would hand out two different `NCLMetaForm`s for one page id. Same shape as `TddReparseAndRefreshTable` on the table side.
- Evicting before the rebuild is what keeps #1957's rule: a failed load's half-mutated instance is never reloaded.
- The **success** set is deliberately not stamped and not revalidated. A later registration does not falsify "this live instance has had its metadata loaded", and re-running the load on it is exactly what #1957 forbids. `ResetPageMetadataForReload` therefore stays and stays clearing it.

`AlRunner/Patches/RecordPatches.BcAppFallback.cs` — the comment that said this was deliberately left unfixed now records why the fix is not at the funnel.

## RED -> GREEN

`AlRunner.Tests/PageRealMetadataEpochRevalidationTests.cs`, six facts. The observable is the **decision** — was the question re-asked, and exactly once per epoch — not the returned `NCLMetaForm`. That is deliberate: whether a real `NCLMetaForm` can be built depends on the BC engine being loaded in-process, which this test host does not guarantee (`BcEngineBootstrap` reports a `SkipReason` on a box without usable artifacts), so asserting on the object would make the test's meaning depend on the environment. Same reasoning as `PopulateNclMetadataCacheCallCount`, which #1833 uses for the same kind of claim.

Measured, both failure directions, on the same test file:

| implementation | result |
|---|---|
| the guard unconditional (`main`'s behaviour: a negative answer answers forever) | **2 failed**, 4 passed — `ANegativeAnswer_DoesNotSurviveARegistrationThatDeclaresThePage`, `ANegativeAnswer_IsRetakenAtMostOncePerRegistrationEpoch` |
| the guard removed (the naive fix: retake on every ask) | **2 failed**, 4 passed — `ANegativeAnswer_IsRetakenAtMostOncePerRegistrationEpoch`, `ANegativeAnswer_IsNotRetakenWhileTheRegistrationSetHoldsStill` |
| as shipped | **6 passed** |

So the suite discriminates in both directions and cannot be satisfied by a no-op or by dropping the record. The other four facts are the negative arm (a page nothing describes is never stamped and never retaken, so the fix does not become "retake everything"), the shrink direction still working across a bundle roll, and a structural guard that the two negative answers keep sharing one epoch-stamped record read by one guard, that the pre-fix unstamped set does not come back anywhere in `AlRunner/`, and that `ResetPageMetadataForReload` still clears the success set.

The RED baselines were produced by editing only the guard condition in a committed tree, with the file copied outside the repository first and restored from that copy; `git status` was empty and the GREEN run re-confirmed afterwards.

## Tests run locally

- `PageRealMetadataEpochRevalidationTests` — 6/6, run twice (cold and `--no-build` warm), because the change is cache-lifetime code and `local-test-scope.md` asks for a warm second run there.
- Filtered `AlRunner.Tests` over the surrounding surface — `PageRealMetadata`, `BcAppRegistrationEpoch`, `DependencyMetadataMemo`, `DependencyPageMetadata`, `BcAppPathsReset`, `SkeletonProfilePageMetadataCache`, `ParserStaticsIsolationGuard`, `DependencyReportProcessingOnly`, `RecordPatchesWarmReload`, `PageMetadataVirtualTable`, `PageControlField`: **75 passed, 7 skipped, 0 failed**, run twice.
- A second filtered run adding every `XmlPort` class after the sibling survey: **71 passed, 1 skipped, 0 failed**.

Not run: the full `AlRunner.Tests` suite, the AL corpus, `runner-extras`. CI covers those on all eight legs.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes, and it is in this diff: the `_metaFormCache` memoized null is a first-order instance of the same shape that the issue body does not mention, reached from `NCLMetadata_GetMetaApplicationObjectByType`'s fallback as well as from `EnsureRealPageMetadata`. Fixing only `_pagesRealMetadataFailed` would have left a page permanently answering "no such page" after the `.app` declaring it registered. Every other reader of `_metaFormCache` for pages either funnels through `EnsureRealPageMetadata` first or runs at bundle start before any registration can be missed.
2. **Sibling function with the same assumption?** Yes — `RecordPatches.RealXmlPortMetadata.cs`, a near-verbatim copy whose own header says so, with the same `_xmlPortsWithRealMetadata` / `_xmlPortsRealMetadataFailed` pair. It is **worse**: grepped across the whole runner, those two fields appear in that one file only, and nothing clears either of them on any path, so it fails the SHRINK direction #1957 fixed — live on every `--watch` cycle and every `--server` request, not latent. Filed as #3172 and marked at the site rather than fixed here, because neither set can be populated from a test host without the BC engine in-process, so the fix could only have shipped with a structural test. The GROW direction does **not** transfer to it unexamined and I have not claimed it does: the page gate has a `HasDependencyPageMetadata` arm that walks `_bcAppPaths`, the xmlport gate reads `AlXmlPortMetadataRegistry` and `_parsedXmlPorts` and neither is `.app`-derived.
3. **Two paths writing the same state, same invariant?** They deliberately differ, and the difference is now documented and pinned rather than accidental: the shrink path clears the success set and the negative record; the grow path revalidates only the negative record. The structural test asserts `_pagesWithRealMetadata.Clear()` is still in `ResetPageMetadataForReload`, so the success set cannot be dropped from it on the mistaken grounds that the epoch now covers it.

## Deliberately left out

- The `_metaReportCache` / `_metaQueryCache` / `_metaXmlPortCache` / `_metaTableCache` negative memos. They have the same `GetOrAdd`-memoizes-null shape, but whether each builder's null is derived from `_bcAppPaths` differs per cache and I did not measure them; that is a separate survey, not something to fold in on a resemblance.
- Anything under `tests/`. This is runner cache-lifetime behaviour with no AL surface, so no corpus test and no `tests/runner-extras/` bundle — see the file header for the full argument.

---

Opened by an automated agent (`agent: impl-17`) on the account holder's behalf.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
