### PR TITLE
fix(execute): pick the OnRun codeunit by object id, and make the #2801 ordering rule provable without the AL compiler

### DIFF
--- a/AlRunner.Tests/ServerExecuteCodeunitSelectionTests.cs
+++ b/AlRunner.Tests/ServerExecuteCodeunitSelectionTests.cs
@@ -1,0 +1,125 @@
+// ServerExecuteCodeunitSelectionTests — which codeunit `execute` runs must be a rule, not a
+// property of the AL compiler's TypeDef layout (#3086).
+//
+// `Program.RunFirstCodeunitOnRun` documented itself as running "the bundle's first OnRun-bearing
+// codeunit", and "first" meant "first in Assembly.GetTypes()". The CLR does not define that
+// array's order — the same undefined order that made TestExecutor.Run execute test codeunits in
+// a shifting order across CI legs (#2801, fixed in #3082). Here the consequence is larger than
+// an ordering one: it decides WHICH CODE RUNS AT ALL, and the response says nothing about a
+// choice having been made.
+//
+// Measured on this repo at be7a4de0, before the fix, two `execute` requests each holding two
+// OnRun-bearing codeunits:
+//
+//     code declared 60191 then 60190  ->  {"tests":[{"name":"Codeunit60191.OnRun", ...}]}
+//     code declared 60190 then 60191  ->  {"tests":[{"name":"Codeunit60190.OnRun", ...}]}
+//
+// Same two codeunits, different answer. The rule is now ascending AL object id — the rule test
+// codeunits already run under, out of the same helper (TestExecutor.OrderTestCodeunitsByObjectId)
+// rather than a second arbitrary one.
+//
+// WHAT THIS FILE CAN AND CANNOT PROVE. It drives the real runner, so what it observes is the AL
+// compiler's layout on this machine composed with the rule. That makes its RED a measurement
+// rather than a guarantee: on a machine whose layout already agreed with the rule, the first
+// test below would have passed unfixed. TestCodeunitOrderingContractTests carries the
+// unconditional half — it hands the helper an input array it controls, so it fails against a
+// no-op on any machine. Neither is sufficient alone: that one proves the rule is a rule, this
+// one proves `execute` is actually wired to it.
+//
+// Ghost-test guard: every assertion names the exact codeunit — both the `name` field and a
+// value the OnRun trigger itself computed and put in its Error() message, so "the right codeunit
+// was selected" cannot be satisfied by a response that merely mentions it.
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class ServerExecuteCodeunitSelectionTests : IClassFixture<SharedCliServer>
+{
+    private readonly SharedCliServer _fixture;
+
+    public ServerExecuteCodeunitSelectionTests(SharedCliServer fixture) => _fixture = fixture;
+
+    // `Subtype = Test` alone does NOT make a codeunit a test codeunit as far as run-mode
+    // selection is concerned — measured: a Subtype=Test codeunit with no [Test] procedure was
+    // still picked as the non-test preference. Both Program.RunFirstCodeunitOnRun and
+    // TestExecutor.IsTestCodeunit ask the same question, "does it carry a [Test] method", so the
+    // fixture has to carry one for the preference below to be under test at all.
+    private static string OnRunCodeunit(int id, string name, bool test = false) =>
+        $"codeunit {id} \"{name}\" {{ {(test ? "Subtype = Test; " : "")}" +
+        $"trigger OnRun() begin Error('ran %1', {id}); end; " +
+        (test ? "[Test] procedure ATest() begin end; " : "") + "} ";
+
+    private async Task AssertExecuteRuns(string code, int expectedId)
+    {
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new { command = "execute", code }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        Assert.False(d.TryGetProperty("compilationErrors", out _), $"unexpected compile error: {r}");
+
+        var tests = d.GetProperty("tests");
+        // Exactly one OnRun is run per bundle, whichever one is chosen — a fix that ran BOTH
+        // would satisfy a "the right one ran" assertion while changing the contract.
+        Assert.Equal(1, tests.GetArrayLength());
+        Assert.Equal($"Codeunit{expectedId}.OnRun", tests[0].GetProperty("name").GetString());
+        // The trigger's own computed value: proof the body executed, not that the runner merely
+        // named a codeunit it never entered.
+        Assert.Contains($"ran {expectedId}", tests[0].GetProperty("message").GetString());
+    }
+
+    /// <summary>
+    /// Positive: the HIGHER id is declared first, so declaration order and object-id order
+    /// disagree — the one arrangement that distinguishes "lowest object id" from "whatever came
+    /// back first". Measured RED before the fix on this machine (ran 60441).
+    /// </summary>
+    [SkippableFact]
+    public async Task Execute_HigherIdDeclaredFirst_RunsTheLowestObjectId()
+    {
+        TestArtifacts.SkipIfMissing();
+        await AssertExecuteRuns(
+            OnRunCodeunit(60441, "Exec Order Zulu SZ") + OnRunCodeunit(60440, "Exec Order Alpha SZ"),
+            expectedId: 60440);
+    }
+
+    /// <summary>
+    /// Control: the same two-codeunit shape with declaration order and id order AGREEING. It
+    /// passed before the fix and must still pass — otherwise the change did not make the choice
+    /// defined, it merely inverted an arbitrary one.
+    /// </summary>
+    [SkippableFact]
+    public async Task Execute_LowerIdDeclaredFirst_StillRunsTheLowestObjectId()
+    {
+        TestArtifacts.SkipIfMissing();
+        await AssertExecuteRuns(
+            OnRunCodeunit(60442, "Exec Order Alpha TZ") + OnRunCodeunit(60443, "Exec Order Zulu TZ"),
+            expectedId: 60442);
+    }
+
+    /// <summary>
+    /// Negative, and the rule that outranks the id: `execute` prefers a NON-test codeunit. Here
+    /// the test codeunit carries the LOWER id, so sorting by id alone would pick it. It must not
+    /// — `execute` is run-mode, and a Subtype=Test codeunit is only ever the fallback when the
+    /// bundle has nothing else with an OnRun.
+    /// </summary>
+    [SkippableFact]
+    public async Task Execute_PrefersNonTestCodeunit_EvenWhenATestCodeunitHasTheLowerId()
+    {
+        TestArtifacts.SkipIfMissing();
+        await AssertExecuteRuns(
+            OnRunCodeunit(60444, "Exec Order Test UZ", test: true)
+            + OnRunCodeunit(60445, "Exec Order Plain UZ"),
+            expectedId: 60445);
+    }
+
+    /// <summary>
+    /// The single-codeunit request — overwhelmingly the common `execute` — is untouched by any
+    /// of this. Cheap, and it is the case a regression here would break for every user at once.
+    /// </summary>
+    [SkippableFact]
+    public async Task Execute_SingleOnRunCodeunit_IsUnaffected()
+    {
+        TestArtifacts.SkipIfMissing();
+        await AssertExecuteRuns(OnRunCodeunit(60446, "Exec Order Solo VZ"), expectedId: 60446);
+    }
+}

--- a/AlRunner.Tests/TestCodeunitExecutionOrderTests.cs
+++ b/AlRunner.Tests/TestCodeunitExecutionOrderTests.cs
@@ -29,13 +29,26 @@
 // ("Object Type", "Object ID"). Both inventories are keyed on the object ID, so a BC test
 // suite runs its codeunits in ascending object ID.
 //
-// WHAT THIS TEST PROVES, and why it cannot pass by luck. The fixture names its files so that
+// WHAT THIS TEST PROVES. The whole chain — AL source, emit, load, execute — really is wired to
+// ascending object id, end to end, through the real runner. The fixture names its files so that
 // ordinal FILE order is the exact REVERSE of object-ID order — Aardvark=62295, Middle=62290,
-// Zulu=62285. File order is what reaches the AL compiler (SafeDirectoryScan.Files sorts
-// ordinally, #2892), so an implementation that does not reorder produces DESCENDING ids here,
-// deterministically. The assertions below are written as the RULE ("the ids that ran are in
-// ascending order"), not as a hardcoded sequence that an unsorted implementation might satisfy
-// on a lucky day.
+// Zulu=62285 — and file order is what reaches the AL compiler (SafeDirectoryScan.Files sorts
+// ordinally, #2892). The assertions are written as the RULE ("the ids that ran are in ascending
+// order"), not as a hardcoded sequence.
+//
+// WHAT IT CANNOT PROVE, corrected (#3086). This header used to say an implementation that does
+// not reorder "produces DESCENDING ids here, deterministically". That is false, and the commit
+// that wrote it measured the counter-example itself: GetTypes() returned 62295, 62285, 62290 for
+// this very fixture — neither file order nor id order. What this test observes is the compiler's
+// layout on this machine composed with the rule, and the layout is the thing #2801 established is
+// not stable. So it detects a broken sort only when the layout happens to disagree with ascending
+// id; measured with OrderTestCodeunitsByObjectId reduced to `types => types`, three of the four
+// tests here failed and all seven SuiteAbortOnTimeoutTests — the suite whose flake motivated the
+// fix — still passed.
+//
+// TestCodeunitOrderingContractTests carries the unconditional half: it hands the ordering helper
+// an input array it controls, so it fails against a no-op on any machine, any BC version, in
+// milliseconds. Neither file replaces the other.
 using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;

--- a/AlRunner.Tests/TestCodeunitOrderingContractTests.cs
+++ b/AlRunner.Tests/TestCodeunitOrderingContractTests.cs
@@ -1,0 +1,229 @@
+// TestCodeunitOrderingContractTests — the no-op-proof half of #2801's ordering fix (#3086).
+//
+// WHY THIS FILE EXISTS. #3082 made TestExecutor order test codeunits by ascending AL object
+// id instead of walking Assembly.GetTypes() in whatever order the CLR handed back, and
+// guarded it with two end-to-end suites — TestCodeunitExecutionOrderTests and
+// AlObjectEmitOrderDeterminismTests. Both spawn the runner over an AL fixture and read the
+// order back out of its printed output, so what they can observe is
+//
+//     (the AL compiler's TypeDef layout on this machine, today)  ->  the sort  ->  the output
+//
+// and the first term is exactly the thing #2801 established is not stable. They therefore
+// detect a broken sort only when the layout happens to disagree with ascending id.
+//
+// Measured, on this repo at be7a4de0, with OrderTestCodeunitsByObjectId reduced to
+// `types => types`:
+//
+//     AlObjectEmitOrderDeterminismTests          1 of 1 FAILED
+//     TestCodeunitExecutionOrderTests            3 of 4 FAILED
+//     SuiteAbortOnTimeoutTests                   0 of 7 failed — ALL SEVEN PASSED
+//
+// The suite whose flake motivated the fix does not notice the fix being removed. It was
+// green because GetTypes() happened to return its two-codeunit fixture in ascending id
+// order on this machine; on the CI leg in issue #3086 it returned the other one, and the
+// same six tests went red. A guard that swings with the thing under test is not a guard.
+//
+// WHAT THIS FILE DOES INSTEAD. It calls the ordering helper directly with an input array it
+// controls, so "whatever order GetTypes() returned" is a variable of the test rather than a
+// condition of the machine. Every fact below fails outright against `types => types`,
+// deterministically, on any machine and any BC version — and needs no BC artifact, no
+// subprocess and no AL compile, so it runs in milliseconds rather than the ~60s the
+// end-to-end pair costs.
+//
+// It does NOT replace those suites. They prove the whole chain (AL source -> emit -> load ->
+// execute) really is wired to this rule; this proves the rule itself is a rule.
+using System.Reflection;
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestCodeunitOrderingContractTests
+{
+    // ── Fixture types ────────────────────────────────────────────────────────────────
+    //
+    // TestExecutor.TryReadAlObjectId resolves an id from BC's [ApplicationObjectId]
+    // attribute first and falls back to the `Codeunit<digits>` type-name shape. Plain C#
+    // classes named that way exercise the fallback exactly as an emitted AL codeunit does,
+    // because the fallback reads nothing but Type.Name.
+
+    private sealed class Codeunit62801 { }
+    private sealed class Codeunit62802 { }
+    private sealed class Codeunit62803 { }
+
+    /// <summary>Not an AL object at all — no attribute, and the name's suffix is not digits.</summary>
+    private sealed class CodeunitHelpers { }
+
+    /// <summary>Second unresolvable type, so "keeps their relative input order" is testable.</summary>
+    private sealed class NotAnAlObject { }
+
+    /// <summary>
+    /// Stand-in for BC's <c>Microsoft.Dynamics.Nav.Runtime.ApplicationObjectIdAttribute</c>.
+    /// TryReadAlObjectId matches it by <c>Type.Name</c> and reads
+    /// <c>ApplicationObjectId.ObjectNumber</c> reflectively, so the shape is the contract and
+    /// the namespace is not.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    private sealed class ApplicationObjectIdAttribute : Attribute
+    {
+        public ApplicationObjectIdAttribute(int objectNumber) => ApplicationObjectId = new Aoid(objectNumber);
+        public Aoid ApplicationObjectId { get; }
+
+        internal sealed class Aoid
+        {
+            public Aoid(int objectNumber) => ObjectNumber = objectNumber;
+            public int ObjectNumber { get; }
+        }
+    }
+
+    /// <summary>
+    /// Name says 62899, attribute says 62800. The attribute is documented to win, and nothing
+    /// tested that before: an implementation that dropped the attribute branch and kept only
+    /// the name fallback passed every existing test, because in real AL output the two always
+    /// agree.
+    /// </summary>
+    [ApplicationObjectId(62800)]
+    private sealed class Codeunit62899 { }
+
+    private static int[] IdsOf(IEnumerable<Type> types) =>
+        types.Select(t => t.Name.StartsWith("Codeunit", StringComparison.Ordinal)
+                          && int.TryParse(t.Name.AsSpan("Codeunit".Length), out var n) ? n : -1)
+             .ToArray();
+
+    // ── The rule ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Positive, and the one that fails hardest against a no-op: fed strictly DESCENDING, the
+    /// helper must return strictly ASCENDING. `types => types` returns the input unchanged and
+    /// fails here on every machine, which is precisely what the end-to-end guards cannot
+    /// promise.
+    /// </summary>
+    [Fact]
+    public void DescendingInput_ComesBackAscending()
+    {
+        var ordered = TestExecutor.OrderTestCodeunitsByObjectId(
+            new[] { typeof(Codeunit62803), typeof(Codeunit62802), typeof(Codeunit62801) });
+
+        Assert.Equal(new[] { 62801, 62802, 62803 }, IdsOf(ordered));
+    }
+
+    /// <summary>
+    /// The rule stated as a rule: EVERY one of the six input permutations of three codeunits
+    /// must produce the same single answer. This is the property `Assembly.GetTypes()` denies
+    /// the caller and the reason the helper exists — asserted exhaustively, so it cannot hold
+    /// only for the arrangement one compiler happened to emit.
+    /// </summary>
+    [Fact]
+    public void EveryInputPermutation_ProducesTheSameAscendingOrder()
+    {
+        var all = new[] { typeof(Codeunit62801), typeof(Codeunit62802), typeof(Codeunit62803) };
+        var expected = new[] { 62801, 62802, 62803 };
+        var seen = 0;
+
+        foreach (var permutation in Permutations(all))
+        {
+            seen++;
+            Assert.Equal(expected, IdsOf(TestExecutor.OrderTestCodeunitsByObjectId(permutation)));
+        }
+
+        // 3! — proves the loop actually ran the whole space rather than zero or one case.
+        Assert.Equal(6, seen);
+    }
+
+    /// <summary>
+    /// The documented "stable, and total" half. A type whose object id cannot be read sorts
+    /// AFTER everything that resolved, and two such types keep their relative input order —
+    /// so feeding the pair both ways round is the only way to tell "stable" from "happens to
+    /// come out that way".
+    /// </summary>
+    [Fact]
+    public void UnresolvableTypes_SortLast_AndKeepTheirRelativeInputOrder()
+    {
+        var helpersFirst = TestExecutor.OrderTestCodeunitsByObjectId(
+            new[] { typeof(CodeunitHelpers), typeof(Codeunit62803), typeof(NotAnAlObject), typeof(Codeunit62801) });
+        Assert.Equal(
+            new[] { typeof(Codeunit62801), typeof(Codeunit62803), typeof(CodeunitHelpers), typeof(NotAnAlObject) },
+            helpersFirst);
+
+        var helpersSecond = TestExecutor.OrderTestCodeunitsByObjectId(
+            new[] { typeof(NotAnAlObject), typeof(Codeunit62803), typeof(CodeunitHelpers), typeof(Codeunit62801) });
+        Assert.Equal(
+            new[] { typeof(Codeunit62801), typeof(Codeunit62803), typeof(NotAnAlObject), typeof(CodeunitHelpers) },
+            helpersSecond);
+    }
+
+    /// <summary>
+    /// Negative: a class called <c>CodeunitHelpers</c> must not be read as object 0 and sorted
+    /// to the FRONT of the run. It is the one failure mode a sloppier "strip the prefix, parse
+    /// what is left" implementation produces, and it would put a non-test type ahead of every
+    /// real codeunit.
+    /// </summary>
+    [Fact]
+    public void NonNumericCodeunitPrefix_IsNotReadAsObjectZero()
+    {
+        var ordered = TestExecutor.OrderTestCodeunitsByObjectId(
+            new[] { typeof(CodeunitHelpers), typeof(Codeunit62801) });
+
+        Assert.Equal(typeof(Codeunit62801), ordered[0]);
+    }
+
+    /// <summary>
+    /// The [ApplicationObjectId] branch, and its precedence over the name shape: a type NAMED
+    /// Codeunit62899 but carrying an attribute id of 62800 sorts as 62800 — i.e. FIRST, ahead
+    /// of 62801, which it could not do if only the name were read.
+    /// </summary>
+    [Fact]
+    public void ApplicationObjectIdAttribute_WinsOverTheTypeNameShape()
+    {
+        var ordered = TestExecutor.OrderTestCodeunitsByObjectId(
+            new[] { typeof(Codeunit62801), typeof(Codeunit62803), typeof(Codeunit62899) });
+
+        Assert.Equal(
+            new[] { typeof(Codeunit62899), typeof(Codeunit62801), typeof(Codeunit62803) },
+            ordered);
+    }
+
+    /// <summary>
+    /// Nothing is added and nothing is dropped. A sort that silently loses a type would hide
+    /// whole codeunits from the run — the same class of silent test loss #2415 was filed for —
+    /// and every assertion above would still pass while it happened.
+    /// </summary>
+    [Fact]
+    public void OrderingIsAPermutation_NoTypeAddedOrDropped()
+    {
+        var input = new[]
+        {
+            typeof(Codeunit62803), typeof(CodeunitHelpers), typeof(Codeunit62899),
+            typeof(Codeunit62801), typeof(NotAnAlObject), typeof(Codeunit62802),
+        };
+
+        var ordered = TestExecutor.OrderTestCodeunitsByObjectId(input);
+
+        Assert.Equal(input.Length, ordered.Length);
+        Assert.Equal(input.OrderBy(t => t.Name, StringComparer.Ordinal),
+                     ordered.OrderBy(t => t.Name, StringComparer.Ordinal));
+    }
+
+    /// <summary>
+    /// Degenerate inputs the helper is handed on any bundle with no test codeunits at all —
+    /// pinned so a future rewrite cannot throw on them, which would take down the whole run.
+    /// </summary>
+    [Fact]
+    public void EmptyAndSingletonInputs_AreHandled()
+    {
+        Assert.Empty(TestExecutor.OrderTestCodeunitsByObjectId(Array.Empty<Type>()));
+        Assert.Equal(new[] { typeof(Codeunit62802) },
+                     TestExecutor.OrderTestCodeunitsByObjectId(new[] { typeof(Codeunit62802) }));
+    }
+
+    private static IEnumerable<Type[]> Permutations(Type[] items)
+    {
+        if (items.Length <= 1) { yield return items; yield break; }
+        for (var i = 0; i < items.Length; i++)
+        {
+            var rest = items.Where((_, j) => j != i).ToArray();
+            foreach (var tail in Permutations(rest))
+                yield return new[] { items[i] }.Concat(tail).ToArray();
+        }
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -6474,14 +6474,31 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
     }
 
 
-    // Run the bundle's OnRun-bearing codeunit (run-mode), mirroring CodeunitPatches'
-    // OnRun dispatch. Prefers a non-[Test] codeunit; returns one TestResult named
-    // "<Codeunit>.OnRun". An AL Error inside OnRun surfaces as a Fail (exitCode 1).
+    // Run the bundle's lowest-object-id OnRun-bearing codeunit (run-mode), mirroring
+    // CodeunitPatches' OnRun dispatch. Prefers a non-[Test] codeunit; returns one TestResult
+    // named "<Codeunit>.OnRun". An AL Error inside OnRun surfaces as a Fail (exitCode 1).
+    //
+    // #3086: "the FIRST OnRun-bearing codeunit" used to mean "first in Assembly.GetTypes()",
+    // and the CLR does not define that array's order — the same undefined order that made
+    // TestExecutor.Run execute test codeunits in a shifting order (#2801). Here it is worse
+    // than an ordering problem: it decides WHICH CODE RUNS AT ALL. Measured on this build, one
+    // `execute` request holding two OnRun-bearing codeunits:
+    //
+    //   declared 60191 then 60190  ->  ran Codeunit60191.OnRun
+    //   declared 60190 then 60191  ->  ran Codeunit60190.OnRun
+    //
+    // Same two codeunits, different answer, and nothing in the response says a choice was
+    // made. Ordering the candidates by ascending AL object id first makes the choice defined
+    // and identical to the rule test codeunits already run under — one rule, one helper
+    // (TestExecutor.OrderTestCodeunitsByObjectId), rather than a second arbitrary one here.
+    // Both `execute` shapes below stay exactly as they were for the overwhelmingly common
+    // single-codeunit request; only a multi-codeunit bundle changes, from a coin flip to the
+    // lowest id.
     IReadOnlyList<TestResult> RunFirstCodeunitOnRun(Assembly asm)
     {
         var navCodeunit = typeof(Microsoft.Dynamics.Nav.Runtime.NavCodeunit);
         Type? target = null;
-        foreach (var t in asm.GetTypes())
+        foreach (var t in TestExecutor.OrderTestCodeunitsByObjectId(asm.GetTypes()))
         {
             if (!t.Name.StartsWith("Codeunit", StringComparison.Ordinal)) continue;
             if (!navCodeunit.IsAssignableFrom(t)) continue;

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -6229,7 +6229,7 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
         }
     }
 
-    // ── execute: run every requested bundle's first OnRun-bearing codeunit
+    // ── execute: run every requested bundle's lowest-object-id OnRun-bearing codeunit
     // (run-mode), aggregating the results. #1917: v1 also accepted an inline
     // `code` string — a temp single-file bundle is synthesised from it (see
     // SynthesizeInlineCodeBundle) and run through the SAME compile pipeline a
@@ -6341,7 +6341,7 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                     0,
                     Array.Empty<string>(),
                     true,
-                    "affectedOnly selection is applied to runTests; execute always runs the first OnRun codeunit");
+                    "affectedOnly selection is applied to runTests; execute always runs the lowest-object-id OnRun codeunit");
             }
 
             return AlRunner.ServerProtocol.Execute(allTests, exitCode,

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -1119,8 +1119,19 @@ public sealed class TestExecutor
     /// tests run in and nothing else. Deliberately does NOT touch method order inside a
     /// codeunit: <see cref="OrderTestMethodsBySourceDeclaration"/> already pins that to source
     /// declaration order, which is a different rule and stays.</para>
+    ///
+    /// <para><b>Internal, not private</b>, for two reasons. <c>Program.RunFirstCodeunitOnRun</c>
+    /// (server-mode <c>execute</c>) picks WHICH codeunit's <c>OnRun</c> to run out of the same
+    /// unordered <c>Assembly.GetTypes()</c> array and shares this rule rather than growing a
+    /// second, differently-arbitrary one (#3086). And
+    /// <c>TestCodeunitOrderingContractTests</c> drives it with an input array it controls: the
+    /// end-to-end guards (<c>TestCodeunitExecutionOrderTests</c>,
+    /// <c>AlObjectEmitOrderDeterminismTests</c>) can only observe whatever layout the AL
+    /// compiler happened to emit that day, so they pass or fail a no-op implementation by
+    /// luck — measured, with this method reduced to <c>types =&gt; types</c>, all seven
+    /// <c>SuiteAbortOnTimeoutTests</c> cases still passed.</para>
     /// </summary>
-    private static Type[] OrderTestCodeunitsByObjectId(Type[] types) =>
+    internal static Type[] OrderTestCodeunitsByObjectId(Type[] types) =>
         types
             .Select((t, i) => (t, i, id: TryReadAlObjectId(t)))
             .OrderBy(x => x.id ?? int.MaxValue)

--- a/docs/server-mode.md
+++ b/docs/server-mode.md
@@ -165,12 +165,23 @@ signal can reach the runner mid-run rather than being queued behind it.
 
 ### `execute`
 
-Runs each bundle's first `OnRun`-bearing codeunit (run-mode). Unlike `runTests`
+Runs one `OnRun`-bearing codeunit per bundle (run-mode). Unlike `runTests`
 this is **not** streamed — one v1-shaped response line, no `type` discriminator:
 
 ```json
 {"exitCode":0,"tests":[{"name":"Codeunit60110.OnRun","status":"pass","durationMs":7}]}
 ```
+
+**Which codeunit**, when a bundle holds more than one with an `OnRun` trigger: the
+one with the **lowest AL object id**, preferring a codeunit that declares no `[Test]`
+procedure. A `Subtype = Test` codeunit is only ever selected when the bundle has
+nothing else with an `OnRun`.
+
+This used to read "the first `OnRun`-bearing codeunit", and "first" meant first in
+`Assembly.GetTypes()` — an array the CLR gives no defined order for, so two `execute`
+requests holding the same codeunits could run different code (#3086). It is the same
+rule test codeunits run under (#2801). Single-codeunit requests, which is nearly all
+of them, are unaffected either way.
 
 v1's `execute` also accepted an inline `code` string and a `captureValues` flag.
 v2 now supports `code` too (#1917): a temp single-file bundle is synthesised


### PR DESCRIPTION
Closes #3086

## Diagnosis: ordering, not timing — and the reported instance was already fixed

The failure the issue describes is **ordering**, not the 60-second wall clock #3103 raised.
I read the full log of the newest occurrence, the BC 28.4 leg of run `34038548342` on PR
#3125:

```
PASS  Codeunit62213.SecondA (11ms)
PASS  Codeunit62213.SecondB (0ms)
PASS  Codeunit62212.RanBeforeHang (0ms)
ERROR Codeunit62212.Hangs (2015ms)
      Test exceeded 2s timeout.
[test-exec] SUITE ABORTED: ... Hangs: watchdog timeout aborted the run
```

The watchdog fired on time and the suite aborted exactly as designed. Codeunit 62213 had
already run, so the abort had nothing to abandon, no resume was triggered, and the three
`SuiteAbortOnTimeoutTests` cases failed on that. Nothing is wall-clock-gated here.

That instance is **not evidence of a second cause**: PR #3125's head `624b1bcc` does not
contain `89664f02` (#3082's fix), which merged about sixteen minutes after that run started.
`git merge-base --is-ancestor 89664f02 624b1bcc` says so.

## What was actually still wrong

Two things, and neither is a second flake.

### 1. The fix's own guards can pass with the fix removed

#3082 left two end-to-end guards. Both spawn the runner over an AL fixture and read the order
back out of its printed output, so what they observe is *the AL compiler's TypeDef layout on
that machine* composed with the sort — and that layout is exactly the thing #2801 established
is not stable. Measured at `be7a4de0`, with `OrderTestCodeunitsByObjectId` reduced to
`types => types`:

| collection | failed |
|---|---|
| `AlObjectEmitOrderDeterminismTests` | 1 of 1 |
| `TestCodeunitExecutionOrderTests` | 3 of 4 |
| `SuiteAbortOnTimeoutTests` | **0 of 7 — all seven passed** |

The suite whose flake motivated the fix does not notice the fix being removed. It was green
because `GetTypes()` happened to hand back its two-codeunit fixture in ascending id order on
this machine; on the CI leg in #3086 it did the other thing. (Seven, not six — the reviewer
recounted the `[Fact]`s and I had miscounted. My own tally corroborates it: the neutered run
reported `Failed: 4, Passed: 8, Total: 12` across the three collections, which is 1 + 4 + 7.)

`TestCodeunitExecutionOrderTests`' header also claimed an unsorted implementation "produces
DESCENDING ids here, deterministically". That is false, and #3082 measured the counter-example
itself — `GetTypes()` returned 62295, 62285, 62290 for that fixture, neither file order nor id
order. Corrected in place.

**New: `AlRunner.Tests/TestCodeunitOrderingContractTests.cs`** drives the ordering helper with
an input array the test controls, so "whatever order `GetTypes()` returned" is a variable of
the test rather than a condition of the machine. Seven facts: descending input comes back
ascending; all six permutations of three codeunits give one answer; the unresolvable-id tail
sorts last and stays stable; `CodeunitHelpers` is not read as object 0; `[ApplicationObjectId]`
takes precedence over the type-name shape (nothing tested that branch before — in real AL
output the two always agree); the result is a permutation with nothing dropped; empty and
singleton inputs are handled. **Five of the seven fail against `types => types` on any machine**,
in 44 ms against the ~60 s the end-to-end pair costs. It does not replace them.

### 2. The same wrong pattern at another call site, deciding which code runs

`Program.RunFirstCodeunitOnRun` — server-mode `execute` — picked which codeunit's `OnRun` to
run by walking `asm.GetTypes()` and taking the first non-test match. Same undefined array,
larger consequence: it decides **which code runs at all**, and the response says nothing about
a choice having been made. Measured on this build before the change, one `execute` request each:

```
declared 60191 then 60190  ->  {"tests":[{"name":"Codeunit60191.OnRun", ...}]}
declared 60190 then 60191  ->  {"tests":[{"name":"Codeunit60190.OnRun", ...}]}
```

Same two codeunits, different answer. Selection now goes through the same
`TestExecutor.OrderTestCodeunitsByObjectId` — lowest object id, still preferring a codeunit
that declares no `[Test]` procedure. One rule, one helper, rather than a second arbitrary one.
Single-codeunit requests, nearly all of them, are unaffected.

## RED → GREEN

| test | RED | GREEN |
|---|---|---|
| `TestCodeunitOrderingContractTests` (7) | 5 fail against `types => types` — deterministic, machine-independent | 7/7, 44 ms |
| `ServerExecuteCodeunitSelectionTests.Execute_HigherIdDeclaredFirst_RunsTheLowestObjectId` | ran `Codeunit60441` (expected 60440) with the sort removed from `RunFirstCodeunitOnRun` | runs `Codeunit60440` |
| the three control cases in that file | pass before **and** after | pass — so the change made the choice defined, it did not merely invert an arbitrary one |

The `execute` test's RED is a measurement on this machine, not a guarantee: on a box whose
layout already agreed with the rule it would have passed unfixed. That asymmetry is the whole
point of the unit-level file, and both headers say so.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site?** Yes — `RunFirstCodeunitOnRun`, fixed above. I
   checked every other `GetTypes()` consumer in `AlRunner/`: the remaining ones look up a type
   by name, or feed a `HashSet`, or scan for attributes, and none of them turns array position
   into an observable answer.
2. **Sibling function with the same assumption?** `OrderTestMethodsBySourceDeclaration` has a
   related shape — when no method's `SignatureSpanAttribute` line resolves it falls back to
   `Type.GetMethods()` order, which is also undefined, silently. I could not make it fire:
   quoted and non-ASCII AL procedure names (`procedure "Quoted Name Two"`, `procedure
   "Ünïcodé Fôur"`) all resolve and run in source order. Left alone rather than patched on
   speculation, and filed as #3201 so it is tracked rather than living only in this PR's
   prose; the fallback now carries a comment pointing at it.
3. **Two paths writing the same state?** `Run` and `DiscoverTests` share the helper, and
   `execute` now does too — that was the divergence.

## Deliberately not in this PR

- **The wall-clock question (#3103).** These three cases are not wall-clock-gated, so nothing
  here addresses it. `SuiteAbortOnTimeoutTests` measured 45.2 s summed on the run above,
  against the 63 s #3082 recorded in `CollectionCostOrderer`; the weights gate only fails on a
  collection **above** the threshold that is **missing**, so an over-estimate is harmless and I
  left it.
- **Cross-assembly ordering.** `TestExecutor.Run` is called once per assembly and sorts within
  it, so a bundle whose dependency apps also carry test codeunits is not globally ordered by
  id. Real BC's `CodeunitMetadata.FindSet()` walks the whole tenant inventory. That is a
  BC-behaviour claim and belongs upstream, not here; nothing in #3086 depends on it.

## Where the tests live

Runner-only, both of them: `execute`'s selection rule is a runner affordance BC has no
equivalent for, and the ordering helper is runner C#. Nothing here asserts BC behaviour, so
nothing is owed to the corpus.

## Local verification

Rebuilt, then `dotnet test AlRunner.Tests --no-build --filter` over `Server*`,
`TestCodeunitOrderingContractTests`, `TestCodeunitExecutionOrderTests`,
`AlObjectEmitOrderDeterminismTests`, `SuiteAbortOnTimeoutTests`, `TestTimeoutFlagTests` —
**160 passed, 0 failed** (4 m 15 s). Plus `ServerAffected*` after the two message-string
edits: 12/12. I did not run the full suite.

After the six-to-seven reword (comment-only in production source), rebuilt and re-ran the five
collections the change touches: **23 passed, 0 failed** (56 s) — and 23 is 7 + 4 + 1 + 7 + 4,
which re-confirms the corrected count a third time.

## Rebased onto current main (impl-5)

Rebased from `be7a4de0` onto `1301843d`, 44 commits. The branch was red on
`Required contexts must not be cancellable on the same commit` — not a test failure. It
predated #3198, which moved the gating guards into `pr-gate.yml` (no `concurrency` block, so a
required context cannot be cancelled), and #3200, which renamed the matrix aggregate. Both are
ancestors now.

**One conflict, in `AlRunner/TestExecutor.cs`.** My side was the old
`OrderTestMethodsBySourceDeclaration` carrying a comment that *noted* the #3201
reflection-order fallback. #3219 landed on main in the meantime and *fixed* #3201, rewriting
that method. I took main's side whole: the comment's subject no longer exists, and keeping my
side would both undo #3219 and leave two definitions of the same method. That is the only thing
#3219 overtook — `TestExecutor.cs` here shrinks from +17/-1 to +13/-1.

**#3219 did not overtake the PR's two claims.** It orders a codeunit's *test methods*;
this PR orders *codeunits*, and picks which one `execute` runs. On current main
`RunFirstCodeunitOnRun` still walks `asm.GetTypes()` unordered and
`OrderTestCodeunitsByObjectId` is still `private`, so both claims still hold.

No conflict in `tests/expectations/count-baseline/` or `history.md`: this PR touches neither,
and both are byte-identical to main (`git diff --quiet origin/main..HEAD` on each). It adds no
AL test, so there is no count for me to re-measure that would differ from main's — any drift
in those numbers would be main's, not this branch's. The `tests/al-language` pin is untouched.

### Re-verified after the rebase

Rebuilt and ran the affected classes in full, not a narrow filter (BC 27.0 skips
`AlRunner.Tests`, so a green 27.0 leg would prove nothing about them):
`TestCodeunitOrderingContractTests`, `ServerExecuteCodeunitSelectionTests`,
`TestCodeunitExecutionOrderTests`, plus #3219's `TestMethodOrderingContractTests` because it
owns the file I resolved — **26 passed, 0 failed** (50 s).

RED re-established against current main rather than carried over: with
`OrderTestCodeunitsByObjectId` reduced to `types => types`, **9 of 15 fail**. The
machine-independent half is the point — `TestCodeunitOrderingContractTests` alone goes
**5 of 7 failed in 57 ms**, no AL compiler involved, which is the "provable without the AL
compiler" claim measured directly. Restored from a copy kept outside the repository, then
rebuilt and re-ran to 26/26 green.

Runner invocations used a private cache outside the repository.

---
*Authored by agent `impl-5`.*

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf

