### PR TITLE
fix(pages): show an error from OnQueryClosePage the way BC's client does

### DIFF
--- a/AlRunner.Tests/RunnerFormCloseHandlerTests.cs
+++ b/AlRunner.Tests/RunnerFormCloseHandlerTests.cs
@@ -1,0 +1,135 @@
+// RunnerFormCloseHandlerTests — the runner-side mechanism behind issue #3057.
+//
+// WHAT IS PINNED HERE, AND WHAT IS NOT
+//   That real BC turns an error raised in OnQueryClosePage into a MESSAGE and refuses the
+//   close is a plain BC-behaviour claim, and it is asserted upstream in the al-language corpus
+//   (codeunit "QCE Query Close Error Tests"), where a real service tier adjudicates it. None
+//   of that is re-asserted here.
+//
+//   What these tests pin is the runner's own classifier: RunnerFormCloseHandler reproduces the
+//   catch ORDER of NavFormCloseHandler.ExecuteCloseCore rather than turning every failed close
+//   into a message. That ordering is the part a corpus test cannot see — the corpus can only
+//   observe the one branch an AL Error() lands in, and a classifier that collapsed every
+//   branch into "show a message" would look identical to it while quietly rewriting the
+//   envelope of a connection loss, a missing UI handler, or a runner-internal failure.
+using System;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Types;
+using Microsoft.Dynamics.Nav.Types.Exceptions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class RunnerFormCloseHandlerTests
+{
+    /// <summary>
+    /// Stands in for BC's NavTestExecution. RunnerFormCloseHandler finds
+    /// <c>TestHandleMessage(string)</c> by reflection, so a double with the same shape is
+    /// enough — and it lets the test observe exactly what text was handed to the message
+    /// channel, which a real NavTestExecution would swallow into a handler lookup.
+    /// </summary>
+    private sealed class FakeTestExecution
+    {
+        private readonly bool _handled;
+        internal string? Seen { get; private set; }
+        internal FakeTestExecution(bool handled) => _handled = handled;
+        internal bool TestHandleMessage(string message)
+        {
+            Seen = message;
+            return _handled;
+        }
+    }
+
+    // Positive: the veto branch. BC's NavFormCloseNotAllowedException case shows NO message and
+    // refuses the close, and it is checked before everything else. A classifier that reached
+    // the message branch here would have to consult the (null) message channel and rethrow.
+    [Fact]
+    public void Veto_RefusesTheCloseWithoutTouchingTheMessageChannel()
+    {
+        var probe = new FakeTestExecution(handled: true);
+
+        var mayClose = RunnerFormCloseHandler.RefuseCloseAfter(
+            new NavFormCloseNotAllowedException("the page said no"), probe);
+
+        Assert.False(mayClose);
+        Assert.Null(probe.Seen);
+    }
+
+    // Positive: the general case. An AL error is handed to BC's own message channel, verbatim
+    // — not reworded, not prefixed by the runner.
+    [Fact]
+    public void AlError_IsHandedToTheMessageChannelVerbatim()
+    {
+        var probe = new FakeTestExecution(handled: true);
+
+        // A [MessageHandler] consumed it, so BC's own `return false` is reached and the page
+        // stays open — a shape the runner refuses loudly rather than modelling.
+        var oos = Assert.Throws<RunnerOutOfScopeException>(() =>
+            RunnerFormCloseHandler.RefuseCloseAfter(
+                new NavNCLDialogException("close refused by OnQueryClosePage"), probe));
+
+        Assert.Equal("close refused by OnQueryClosePage", probe.Seen);
+        Assert.Contains("testpage-close-refused-after-message", oos.Message, StringComparison.Ordinal);
+    }
+
+    // Negative: no message channel means the text has nowhere to go. Losing it would be a
+    // silent no-op, so the ORIGINAL exception is rethrown — the same object, not a copy and not
+    // a runner-invented wrapper.
+    [Fact]
+    public void AlError_WithNoTestExecution_RethrowsTheOriginalUntouched()
+    {
+        var original = new NavNCLDialogException("nowhere to show this");
+
+        var thrown = Assert.Throws<NavNCLDialogException>(() =>
+            RunnerFormCloseHandler.RefuseCloseAfter(original, testExecution: null));
+
+        Assert.Same(original, thrown);
+    }
+
+    // Negative: a [MessageHandler] that is not there. TestHandleMessage returning false means
+    // no [Test] was executing, so nothing received the text — same outcome as no channel at all.
+    [Fact]
+    public void AlError_WhenTheMessageChannelDeclinesIt_RethrowsTheOriginal()
+    {
+        var probe = new FakeTestExecution(handled: false);
+        var original = new NavNCLDialogException("declined");
+
+        var thrown = Assert.Throws<NavNCLDialogException>(() =>
+            RunnerFormCloseHandler.RefuseCloseAfter(original, probe));
+
+        Assert.Same(original, thrown);
+        Assert.Equal("declined", probe.Seen);
+    }
+
+    // Negative: an exception BC's close handler classifies BEFORE its general case keeps its
+    // own identity. BC calls ShowError for this one, which on the test client is an error, not
+    // a message — collapsing it into the message branch would change what the test sees.
+    [Fact]
+    public void MissingUiHandler_IsNotConvertedIntoAMessage()
+    {
+        var probe = new FakeTestExecution(handled: true);
+        var original = new NavNCLMissingUIHandlerException("Unhandled UI: Message something");
+
+        var thrown = Assert.Throws<NavNCLMissingUIHandlerException>(() =>
+            RunnerFormCloseHandler.RefuseCloseAfter(original, probe));
+
+        Assert.Same(original, thrown);
+        Assert.Null(probe.Seen);
+    }
+
+    // Negative: a runner-internal failure is not a BC exception at all and must never be
+    // rewritten into a page message — that would hide a runner bug behind an AL-looking error.
+    [Fact]
+    public void NonBcException_IsRethrownAndNeverShownAsAMessage()
+    {
+        var probe = new FakeTestExecution(handled: true);
+        var original = new InvalidOperationException("NavForm.QueryCloseForm(int) not found");
+
+        var thrown = Assert.Throws<InvalidOperationException>(() =>
+            RunnerFormCloseHandler.RefuseCloseAfter(original, probe));
+
+        Assert.Same(original, thrown);
+        Assert.Null(probe.Seen);
+    }
+}

--- a/AlRunner/Patches/RunnerFormCloseHandler.cs
+++ b/AlRunner/Patches/RunnerFormCloseHandler.cs
@@ -1,0 +1,184 @@
+// RunnerFormCloseHandler — stand in for the CLIENT half of BC's page-close round trip, the
+// same way RunnerModalDispatch stands in for the client half of the page-OPEN round trip.
+//
+// THE PROBLEM IT SOLVES
+//   Closing a page in BC is a client round trip, so an AL error raised inside
+//   OnQueryClosePage does NOT propagate the way an error from a directly-called AL procedure
+//   does. The server raises it out of NavForm.QueryCloseFormAsync; the CLIENT is what decides
+//   what the caller ends up seeing. The runner has no client, so until #3057 the raw
+//   exception went straight back to the AL that opened the page — an envelope real BC never
+//   produces.
+//
+// HOW BC DOES IT
+//   Microsoft.Dynamics.Nav.Client.UI.dll, NavFormCloseHandler.ExecuteCloseCore (decompiled,
+//   BC 28.1.49838.53910), in catch order:
+//
+//       catch (NavFilterErrorOnQueryCloseException)  -> ShowError,   close refused
+//       catch (NavErrorOnQueryCloseException)        -> ShowConfirm, then force-close on yes
+//       catch (NavNSFormNotOpenedException)          -> force-close
+//       catch (NavConnectionLostException) / (NavClientClosingException)
+//       catch (NavFormCloseNotAllowedException)      -> LastClosePrevented = true, refuse
+//       catch (NavOnClosePageException)              -> ShowError, force-close
+//       catch (NavObjectDefinitionChangedException)  -> ShowError, force-close
+//       catch (NavNCLMissingUIHandlerException)      -> ShowError, force-close
+//       catch (NavTestWrappedException)              -> force-close, rethrow
+//       catch (NavSqlConnectionLostException)        -> ShowError unless suppressed, force-close
+//       catch (NavBaseException ex)                  -> if (!ex.SuppressMessage)
+//                                                           displayMessage.ShowMessage(ex.Message);
+//                                                       return false;      // close REFUSED
+//
+//   An AL Error() / TestField() failure inside OnQueryClosePage is none of the named types —
+//   it is a plain NavBaseException, so it lands in that LAST catch. So BC shows the AL error
+//   text as a MESSAGE and refuses the close.
+//
+//   In a test session `displayMessage.ShowMessage` is TestPageMessageHelper.ShowMessage
+//   (Microsoft.Dynamics.Nav.Client.TestPageClient.dll), which forwards to the session's
+//   OnShowMessageCallback — NavTestExecution.TestHandleMessage. That resolves a
+//   [MessageHandler] or raises BC's own "Unhandled UI: Message {text}". Measured on a real BC
+//   28.4.53241.0 service tier (issue #3057): an unfilled "Payment Registration Setup" closed
+//   through its [ModalPageHandler] reports
+//       Unhandled UI: Message Journal Template Name must have a value in Payment Registration
+//       Setup: User ID=ADMIN. It cannot be zero or empty.
+//   and not the raw NavTestFieldException.
+//
+// WHAT THIS CLASS DOES NOT DO
+//   It does not invent a message channel. `Message` goes through BC's own
+//   NavTestExecution.TestHandleMessage — the identical method BC's NavDialog.ALMessage calls
+//   for an AL Message() statement — so which [MessageHandler] answers, and the exact wording
+//   of the refusal when none does, stay BC's decisions.
+//
+//   The named exception types above are RETHROWN rather than reproduced. Every one of them
+//   reaches the caller as an error in BC too (ShowError on the test client is
+//   TestPageMessageHelper.ShowErrorMessage, which throws NavTestWrappedException carrying the
+//   same text), so rethrowing the original preserves the observable AL outcome — the text —
+//   without the runner claiming to model a force-close-and-continue it has no path to.
+using System.Reflection;
+
+namespace AlRunner.Patches;
+
+internal static class RunnerFormCloseHandler
+{
+    /// <summary>
+    /// Exception type names BC's own close handler catches BEFORE its general
+    /// <c>NavBaseException</c> case, and turns into something other than a message. Matched by
+    /// name because these types live across Ncl / Types / the client assemblies and the runner
+    /// links none of them directly.
+    /// </summary>
+    private static readonly string[] NotAMessage =
+    {
+        "NavFilterErrorOnQueryCloseException",
+        "NavErrorOnQueryCloseException",
+        "NavNSFormNotOpenedException",
+        "NavConnectionLostException",
+        "NavClientClosingException",
+        "NavOnClosePageException",
+        "NavObjectDefinitionChangedException",
+        "NavNCLMissingUIHandlerException",
+        "NavTestWrappedException",
+        "NavSqlConnectionLostException",
+    };
+
+    /// <summary>
+    /// Classify an exception that escaped a page's OnQueryClosePage, reproducing
+    /// <c>NavFormCloseHandler.ExecuteCloseCore</c>'s decision.
+    /// </summary>
+    /// <returns>
+    /// <c>false</c> when the close must be refused and the caller must NOT treat the close as
+    /// having happened. Never returns <c>true</c>: an exception this method does not classify
+    /// as a message either propagates or is replaced by a louder one.
+    /// </returns>
+    /// <remarks>
+    /// The common case does not return at all. With no <c>[MessageHandler]</c> declared,
+    /// <c>TestHandleMessage</c> raises BC's own "Unhandled UI: Message {text}" refusal from
+    /// inside the call — exactly the outcome a real service tier produces for this shape.
+    /// </remarks>
+    internal static bool RefuseCloseAfter(Exception ex, object? testExecution)
+    {
+        var name = ex.GetType().Name;
+
+        // BC's NavFormCloseNotAllowedException case: the trigger vetoed by returning false.
+        // No message, close prevented — the runner already relied on this and it stays.
+        if (name == "NavFormCloseNotAllowedException") return false;
+
+        // Anything BC classifies ahead of its general case, or anything that is not a BC
+        // exception at all (a runner-internal failure), keeps its own identity.
+        if (Array.IndexOf(NotAMessage, name) >= 0 || !IsNavBaseException(ex))
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex).Throw();
+
+        // BC: `if (!ex.SuppressMessage) displayMessage.ShowMessage(ex.Message);` — a suppressed
+        // message is shown nowhere on a real tier either, so refusing the close is the whole of
+        // BC's behaviour here and nothing is lost.
+        if (SuppressMessage(ex)) return false;
+
+        if (!TryShowMessage(ex.Message, testExecution))
+            // No message channel means the text would vanish, and a silently refused close is
+            // exactly the silent no-op .claude/rules/loud-failures.md forbids. Let the original
+            // through instead — worse envelope, but nothing is lost.
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex).Throw();
+
+        // A [MessageHandler] consumed the text, so BC's `return false` is reached: the close is
+        // refused and the page is STILL OPEN, waiting for a user who does not exist here. That
+        // is the same boundary MockTestPage.Close already names for an OnQueryClosePage veto
+        // (#2999) — the runner has no model for a page that refuses to close and keeps running.
+        // Throwing says so; returning false would let the caller force the page shut and report
+        // a close BC did not perform. Tracked in #3179.
+        throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            "TestPage page close (OnQueryClosePage)",
+            "testpage-close-refused-after-message — OnQueryClosePage raised an error, a "
+            + "[MessageHandler] consumed it, and BC then leaves the page OPEN. The runner has no "
+            + "model for a page that outlives its own close. See docs/scope.md");
+    }
+
+    private static bool IsNavBaseException(Exception ex)
+    {
+        for (var t = ex.GetType(); t != null; t = t.BaseType)
+            if (t.Name == "NavBaseException") return true;
+        return false;
+    }
+
+    /// <summary>
+    /// <c>NavBaseException.SuppressMessage</c> — BC skips the message entirely when it is set.
+    /// Read reflectively (the property is on a type in Types.dll the runner does not link) and
+    /// defaulted to false, which is the value every AL-raised error carries.
+    /// </summary>
+    private static bool SuppressMessage(Exception ex)
+        => ex.GetType().GetProperty("SuppressMessage", BindingFlags.Public | BindingFlags.Instance)?
+               .GetValue(ex) is bool suppress && suppress;
+
+    /// <summary>
+    /// BC's <c>displayMessage.ShowMessage</c> on the test client: hand the text to
+    /// <c>NavTestExecution.TestHandleMessage</c>, the same method an AL <c>Message()</c>
+    /// statement reaches. Returns whether the text was delivered — false only when there is no
+    /// test-execution context to deliver it to, which the caller treats as a reason to let the
+    /// original exception through rather than lose it.
+    /// </summary>
+    private static bool TryShowMessage(string message, object? testExecution)
+    {
+        if (testExecution == null) return false;
+
+        var handle = testExecution.GetType().GetMethod(
+            "TestHandleMessage",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            binder: null,
+            types: new[] { typeof(string) },
+            modifiers: null);
+        if (handle == null)
+            throw new InvalidOperationException(
+                "NavTestExecution.TestHandleMessage(string) not found — Ncl shape changed; do not commit");
+
+        try
+        {
+            // TestHandleMessage returns false when no [Test] is executing (BC's FindHandler is
+            // `if (executingTestMethod == null) return null;`). That is not a delivery.
+            return handle.Invoke(testExecution, new object?[] { message }) is bool handled && handled;
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            // The "Unhandled UI: Message …" refusal, and any NavTestWrappedException a
+            // [MessageHandler] itself raised. Both are BC's own answer and must reach the test
+            // with BC's own stack, not a reflection wrapper.
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
+            throw; // unreachable; satisfies the compiler
+        }
+    }
+}

--- a/AlRunner/Patches/RunnerModalDispatch.cs
+++ b/AlRunner/Patches/RunnerModalDispatch.cs
@@ -88,7 +88,7 @@ public static class RunnerModalDispatch
             // fired every close trigger a second time, so a page persisting from
             // OnQueryClosePage wrote twice (issue #3091). Real BC runs each exactly once:
             // corpus codeunit 60296 "MQC Self Close Tests".
-            if (opened && IsFormOpen(form) && !TryQueryCloseForm(form!, result)) result = null;
+            if (opened && IsFormOpen(form) && !TryQueryCloseForm(form!, result, testExecution)) result = null;
         }
         finally
         {
@@ -161,7 +161,7 @@ public static class RunnerModalDispatch
             // [PageHandler]-driven Page.Run raises OnQueryClosePage with CloseAction OK and
             // then OnClosePage. A trapped page is the test's to close, so it is left alone.
             if (opened && !trapped && IsFormOpen(form))
-                TryQueryCloseForm(form!, NonModalCloseResult(form!));
+                TryQueryCloseForm(form!, NonModalCloseResult(form!), testExecution);
         }
         finally
         {
@@ -326,9 +326,13 @@ public static class RunnerModalDispatch
     /// here reproduces exactly that: the caller drops the handler's result, so the FormResult.None
     /// BC already pushed on formResultStack is what the calling AL reads back.
     ///
-    /// Anything else the trigger raises — an Error() in AL, most of all — propagates untouched.
+    /// Anything ELSE the trigger raises — an Error() in AL, most of all — is classified by
+    /// <see cref="RunnerFormCloseHandler"/>, which reproduces what BC's own client-side close
+    /// handler does with it: show the text as a message and refuse the close. Letting it
+    /// propagate untouched, which is what this method used to do, produced an envelope no real
+    /// service tier produces (issue #3057).
     /// </summary>
-    private static bool TryQueryCloseForm(object form, object? result)
+    private static bool TryQueryCloseForm(object form, object? result, object? testExecution)
     {
         var queryCloseForm = form.GetType().GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
             .FirstOrDefault(m => m.Name == "QueryCloseForm"
@@ -351,9 +355,9 @@ public static class RunnerModalDispatch
             Invoke(queryCloseForm, form, new object?[] { closeActionValue });
             return true;
         }
-        catch (Exception ex) when (ex.GetType().Name == "NavFormCloseNotAllowedException")
+        catch (Exception ex)
         {
-            return false;
+            return RunnerFormCloseHandler.RefuseCloseAfter(ex, testExecution);
         }
     }
 

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -1579,12 +1579,43 @@ internal sealed partial class RunnerPageInstance
     /// </summary>
     internal bool RaiseOnClosePage(Microsoft.Dynamics.Nav.Types.FormResult closeAction)
     {
-        if (InvokeRecordTrigger("OnQueryClosePage",
+        object? queryClose;
+        try
+        {
+            queryClose = InvokeRecordTrigger("OnQueryClosePage",
                 new[] { typeof(Microsoft.Dynamics.Nav.Types.FormResult) },
-                new object[] { closeAction }) is false)
-            return false;
+                new object[] { closeAction });
+        }
+        catch (Exception ex)
+        {
+            // An AL Error() inside OnQueryClosePage is not the caller's error to receive raw:
+            // in BC the close is a client round trip, and the client's own close handler shows
+            // the text as a MESSAGE and refuses the close. Same decision as the handler-driven
+            // path in RunnerModalDispatch — TestPageProxy.InternalClose reaches
+            // NavFormCloseHandler.ExecuteCloseCore too, so both shapes must agree. See
+            // RunnerFormCloseHandler and issue #3057.
+            return RunnerFormCloseHandler.RefuseCloseAfter(ex, TestExecutionOrNull());
+        }
+
+        if (queryClose is false) return false;
         InvokeRecordTrigger("OnClosePage", Type.EmptyTypes, Array.Empty<object>());
         return true;
+    }
+
+    /// <summary>
+    /// BC's <c>NavTestExecution</c> for this page's session, reached the way BC reaches it —
+    /// <c>NavApplicationObjectBase.Session</c> on the form, then <c>NavSession.TestExecution</c>.
+    /// Null outside a test session, which is what <see cref="RunnerFormCloseHandler"/> treats as
+    /// "no message channel".
+    /// </summary>
+    private object? TestExecutionOrNull()
+    {
+        var session = _form.GetType()
+            .GetProperty("Session", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?
+            .GetValue(_form);
+        return session?.GetType()
+            .GetProperty("TestExecution", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?
+            .GetValue(session);
     }
 
     /// <summary>

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1274,6 +1274,19 @@ https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues.
   and `RunModal()` reports `Action::None`
   ([#3050](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3050)).
 
+  A ninth refusal joins them on the same surface, this one on **both** close paths. An
+  `OnQueryClosePage` that raises an AL *error* — as opposed to vetoing — is shown by BC's own
+  client-side close handler as a **message**, after which the close is refused and the page
+  stays open. The runner reproduces the message half through BC's own
+  `NavTestExecution.TestHandleMessage` (`AlRunner/Patches/RunnerFormCloseHandler.cs`), so with
+  no `[MessageHandler]` declared the test sees BC's `Unhandled UI: Message …` refusal, exactly
+  as a service tier produces it. With a `[MessageHandler]` declared the handler consumes the
+  text and control returns to a page real BC has left open, which the runner has no model for;
+  it raises `RunnerOutOfScopeException` with reason `testpage-close-refused-after-message`
+  rather than force the page shut and report a close BC did not perform
+  ([#3057](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3057),
+  [#3179](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3179)).
+
 <a id="virtual-table-shape-gaps"></a>
 
 - **System virtual tables — the runner refuses rather than answering a shape it cannot read.**

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -960,3 +960,36 @@ companion row is gone, which the unfixed runner does not do. `al-language` (2676
 pin bump is involved.
 
 Written by agent impl-24 (automated implementation agent).
+
+## al-language 2681 → 2689 — corpus pin `b0c6248a` → `7394c15f` (#3057, corpus #202)
+
++8 tests, all in the `tests/al-language` app, from the three corpus commits between the two
+pins. `git -C tests/al-language diff --name-only b0c6248a..7394c15f` touches nothing outside
+that app, so `runner-extras` (330), `appGroups` (1), `al-language-internals-fixture` (0) and
+`al-language-onprem` (19) are `main`'s values, untouched.
+
+Where the 8 come from, counted per file rather than inferred from the totals:
+
+| corpus commit | corpus PR | file | `[Test]` delta |
+|---|---|---|---|
+| `cd824ef` | #196 | `record/TestPageMetadataVirtualTable.al` | 3 → 4 (+1) |
+| `def7430` | #200 | `handlers/TestPageSubscriberRefusal_Tests.al` | new, +3 |
+| `7394c15` | #202 | `handlers/TestPageQueryCloseError_Tests.al` | new, +4 |
+
+**Why the bump is folded into this PR and not its own.** Of those 8, exactly 2 are red without
+this PR's fix, and both are #202's — the two arms that assert an AL error raised inside
+`OnQueryClosePage` arrives as BC's own unhandled-message refusal. Measured, not predicted: a
+build of `main` (`d6776eeb`) run against the corpus at `7394c15f` gives 2689 tests, 2687 pass,
+2 fail, and the two are `ErrorInQueryClosePage_ArrivesAsAnUnhandledMessage` and
+`ErrorInQueryClosePage_TestPageClose_ArrivesAsAnUnhandledMessage`. The same corpus on this
+branch is 2689/2689. So the bump alone would be red by construction and belongs here.
+
+The other 6 already pass on `main` — the runner fixes for corpus #196 and #200 merged as #3128
+and #3180 earlier, ahead of their pin. An earlier draft of this PR predicted 5 failures at this
+pin, attributing four more to corpus #199 and one to #196; those were measured before #3128 and
+#3180 merged, and all five are now green.
+
+**2689 is measured at this head, not carried forward.** The prediction in the PR body was also
+2689, but it was made against a different `main` and was re-run rather than copied.
+
+Written by agent impl-4 (automated implementation agent).

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Schema, semantics and how to bump: README.md in this directory. Per-bump rationale: history.md, never a prose line in here (#2485).",
   "suites": {
     "al-language": {
-      "tests": { "default": 2681 },
+      "tests": { "default": 2689 },
       "appGroups": { "default": 1 }
     },
     "al-language-internals-fixture": { "tests": { "default": 0 }, "appGroups": { "default": 1 } },

--- a/tests/runner-extras/microsoft-dependencies/MicrosoftDependencyTests.Codeunit.al
+++ b/tests/runner-extras/microsoft-dependencies/MicrosoftDependencyTests.Codeunit.al
@@ -529,12 +529,20 @@ codeunit 61001 "Microsoft Dependency Tests"
     //   err = "Unhandled UI: Message Journal Template Name must have a value in Payment
     //          Registration Setup: User ID=ADMIN. It cannot be zero or empty."
     //   Rec.Get(UserId()) afterwards = No
-    // So on BC the row does NOT survive: the failing close takes the insert with it. The
-    // runner keeps it, and wraps the TestField as NavTestFieldException where BC wraps it in
-    // its own "Unhandled UI: Message" envelope. Both of those are a DIFFERENT defect from the
-    // missing trigger — tracked in #3057, and deliberately not asserted here — so this test
-    // pins only the part the trigger decides: that page 982's OnQueryClosePage runs on the
-    // handler's confirming close and reports the unfilled setup.
+    //
+    // #3057 read that as TWO runner defects. Only one of them was real. The envelope was: the
+    // runner surfaced the raw NavTestFieldException where BC's client-side close handler shows
+    // an error from OnQueryClosePage as a MESSAGE, so a test with no [MessageHandler] gets BC's
+    // unhandled-UI refusal. That is fixed, and the general rule is pinned upstream in corpus
+    // codeunit "QCE Query Close Error Tests", where a real service tier adjudicates it.
+    //
+    // The rollback half was NOT a runner defect, and this test is where the wrong reading came
+    // from. The DeleteAll() below used to be uncommitted, so the asserterror rolled it back
+    // along with everything else since the last Commit() — resurrecting the row the PREVIOUS
+    // [Test] in this codeunit had left behind (TestIsolation = Codeunit does not reset table
+    // state between methods). The row that "survived" was never the one page 982 had just
+    // inserted. Committing the cleanup removes that route entirely, and the runner then agrees
+    // with the service tier: no row.
     [Test]
     [HandlerFunctions('PaymentRegistrationSetupModalHandler')]
     procedure PrecompiledPage_OnOpenPage_ModalSetupPageValidatesOnTheConfirmingClose()
@@ -542,13 +550,18 @@ codeunit 61001 "Microsoft Dependency Tests"
         PaymentRegistrationSetup: Record "Payment Registration Setup";
     begin
         PaymentRegistrationSetup.DeleteAll();
+        // Load-bearing, not tidiness — see the note above. Without it this test can pass on a
+        // row an earlier [Test] left behind.
+        Commit();
 
         asserterror OpenPaymentRegistrationPage();
 
         Assert.Contains(GetLastErrorText(), 'Journal Template Name must have a value',
             'Page 982''s OnQueryClosePage must run on the handler''s confirming close, so its ValidateMandatoryFields(true) reports the unfilled setup.');
-        Assert.IsTrue(PaymentRegistrationSetup.Get(UserId()),
-            'Page 982''s OnOpenPage must still have inserted the current user''s row before the close failed. (Real BC then rolls that insert back and the runner does not — #3057.)');
+        Assert.Contains(GetLastErrorText(), 'Unhandled UI: Message',
+            'An error raised in a precompiled page''s OnQueryClosePage must arrive in BC''s message envelope, not as the raw AL exception (#3057).');
+        Assert.IsFalse(PaymentRegistrationSetup.Get(UserId()),
+            'The row page 982''s OnOpenPage inserted was never committed, so the failed close must take it with it — nothing may be left for the next test to find.');
     end;
 
     local procedure OpenPaymentRegistrationPage()


### PR DESCRIPTION
Closes #3057

*Opened by agent `impl-8` (automated implementation agent).*

## What #3057 reported, and what turned out to be true

The issue named two divergences from a real BC 28.4 container. Only one of them was a runner defect.

**The envelope — real, and fixed here.** Closing a page in BC is a client round trip, so an AL error raised inside `OnQueryClosePage` does not propagate the way an error from a directly called procedure does. BC's own close handler decides what the caller sees. From `NavFormCloseHandler.ExecuteCloseCore` (`Microsoft.Dynamics.Nav.Client.UI.dll`, decompiled at BC 28.1.49838.53910), the last catch:

```csharp
catch (NavBaseException ex12)
{
    if (!ex12.SuppressMessage)
        displayMessage.ShowMessage(ex12.Message);
    return false;      // the close is REFUSED
}
```

An AL `Error()` or a failed `TestField()` is none of the types caught above it, so it lands there: BC shows the text as a **message** and refuses the close. On the test client `displayMessage.ShowMessage` is `TestPageMessageHelper.ShowMessage`, which forwards to `NavTestExecution.TestHandleMessage` — so with no `[MessageHandler]` declared the test gets BC's own `Unhandled UI: Message …` refusal. That is exactly the string the issue measured on the container. The runner had no client and surfaced the raw exception.

**The rollback — not a runner defect.** The issue reported that real BC drops the row page 982's `OnOpenPage` inserted and the runner keeps it. Run in isolation, the runner drops it too. What the arm in `tests/runner-extras/microsoft-dependencies` was actually observing is its own cleanup: `PaymentRegistrationSetup.DeleteAll()` was uncommitted, so the `asserterror` rolled it back along with everything else since the last `Commit()` — resurrecting the row the **previous** `[Test]` in that codeunit had left behind (`TestIsolation = Codeunit` does not reset table state between methods). The row that "survived" was never the one page 982 had just inserted. This PR commits that cleanup, which removes the route, and then asserts the row is gone.

## The change

New `AlRunner/Patches/RunnerFormCloseHandler.cs` reproduces `ExecuteCloseCore`'s classification:

- `NavFormCloseNotAllowedException` — the veto. Close refused, no message. Unchanged behavior.
- The types BC catches ahead of its general case (`NavNCLMissingUIHandlerException`, `NavOnClosePageException`, `NavTestWrappedException`, the connection-loss ones, …) — rethrown, keeping their own identity. BC calls `ShowError` for those, which on the test client is an error too, so the text the AL sees is the same.
- Anything that is not a BC exception at all — rethrown, so a runner-internal failure can never be repainted as an AL-looking page message.
- Everything else — handed to BC's own `NavTestExecution.TestHandleMessage`, the identical method `NavDialog.ALMessage` calls for an AL `Message()` statement. Nothing about the message channel is a runner invention.
- No message channel available — the original exception is rethrown rather than the text lost (`.claude/rules/loud-failures.md`).

## Fixing the shape, not the reported line

Three questions, answered:

1. **Another call site with the same wrong pattern?** Yes. `TryQueryCloseForm` is shared by `FormRunModal` and `FormRun`, so the modal and non-modal handler-driven paths both had it and both are fixed by the one change.
2. **A sibling making the same assumption?** Yes, and it is a different mechanism: `MockTestPage.Close()` does not go through `NavForm.QueryCloseForm` at all — it invokes the AL trigger directly through `RunnerPageInstance.RaiseOnClosePage`. In BC that path reaches the *same* close handler (`TestPageProxy.InternalClose` → `LogicalForm.Close`), so it had the same blind spot. It now goes through the same classifier, and the upstream corpus PR carries an arm for it.
3. **Two paths writing the same state, one guard?** The veto branch was the guard only one of them had. Now both classify the whole set of outcomes, in BC's order.

## Deliberately left out, and filed

When a `[MessageHandler]` **is** declared, it consumes the text and BC's `return false` is reached — the page refused to close and is still open. The runner has no model for that, so it raises `RunnerOutOfScopeException` with reason `testpage-close-refused-after-message` rather than force the page shut and report a close BC did not perform. No service tier has been asked what a test observes afterwards. Filed as #3179 (stays open after this merges), documented in `docs/limitations.md`, and deliberately not covered by the corpus PR because a page that refuses to close could hang a leg.

## The proving test is upstream

The claim is plain BC behavior, so it lives in the corpus: **StefanMaron/BusinessCentral.AL.Language.Tests#202**, codeunit `QCE Query Close Error Tests` (60677), four arms — a negative control that closes normally and keeps the page's write, the envelope on a handler-driven modal close, the rollback of the page's own uncommitted write, and the envelope again on the `TestPage.Close()` path.

### The pin bump — landed here, measured 2026-09-07 by `impl-4`

Corpus #202 merged as `7394c15`. **The bump is now in this PR**, which is where it belongs:
the four arms that prove this fix only reach our CI once the pin moves, and a bump on its own
would be red, because two of those four fail without the fix below.

An earlier version of this section held the bump back, predicting five failures at `7394c15`
that this PR does not own — four from corpus #199 and one from corpus #196. That prediction was
made before their fixes merged. **#3152 (17:41), #3128 (20:25) and #3180 (21:14) have all
landed, and all five are now green.** The prediction was not carried forward; every number
below was re-measured at this head.

`main`'s pin was `b0c6248a`; `b0c6248a...7394c15f` is ahead 3, behind 0, so nothing else was
going to pull #202 in. The three incoming commits touch only the `tests/al-language` app —
`git -C tests/al-language diff --name-only b0c6248a..7394c15f` lists eleven files, all under
it — so `al-language-internals-fixture` (0), `al-language-onprem` (19) and `runner-extras`
(330) are `main`'s values, untouched.

**+8 tests, 2681 → 2689**, counted per file rather than inferred from the totals:

| corpus commit | corpus PR | file | `[Test]` delta |
|---|---|---|---|
| `cd824ef` | #196 | `record/TestPageMetadataVirtualTable.al` | 3 -> 4 (+1) |
| `def7430` | #200 | `handlers/TestPageSubscriberRefusal_Tests.al` | new, +3 |
| `7394c15` | #202 | `handlers/TestPageQueryCloseError_Tests.al` | new, +4 |

### RED -> GREEN at the bumped pin

Both halves run on BC 28.1.49838.53910 against the same corpus checkout at `7394c15f`, with a
private `--cache` outside the repository and the flag set `.github/workflows/bc-tests.yml` uses.
"Before" is a build of `origin/main` at `d6776eeb`; "after" is this branch at `a3cd7240`.

| | before (`main` `d6776eeb`) | after (this branch) |
|---|---|---|
| corpus total | 2689 | 2689 |
| pass / fail | 2687 / **2** | **2689 / 0** |
| exit code | 1 | 0 |

The two failures before are exactly this PR's subject, and nothing else:

```
FAIL  Codeunit60677.ErrorInQueryClosePage_ArrivesAsAnUnhandledMessage
FAIL  Codeunit60677.ErrorInQueryClosePage_TestPageClose_ArrivesAsAnUnhandledMessage
```

Per arm, so the two controls are visible:

| | before | after |
|---|---|---|
| `NoErrorInQueryClosePage_ClosesNormallyAndKeepsThePagesWrite` | PASS | PASS |
| `ErrorInQueryClosePage_ArrivesAsAnUnhandledMessage` | **FAIL** | PASS |
| `ErrorInQueryClosePage_RollsBackThePagesUncommittedWrite` | PASS | PASS |
| `ErrorInQueryClosePage_TestPageClose_ArrivesAsAnUnhandledMessage` | **FAIL** | PASS |

The two control arms passing in both columns is the point: the fix moves only the envelope.

The other six incoming tests — corpus #196's one and corpus #200's three, plus the three
`TestPageMetadataVirtualTable` tests that file already had — pass in the **before** column too.
That is the measured evidence that #3128 and #3180 landing ahead of this bump did their job,
and that this PR carries no failure it does not own.

No expectation entries were added for anything in this bump. Nothing needed one.

## Runner-side coverage that ships now

`AlRunner.Tests/RunnerFormCloseHandlerTests.cs` — six tests pinning the classifier's own catch order, which is the part no corpus test can see (a corpus test only ever observes the one branch an AL `Error()` lands in, so a classifier that collapsed every branch into "show a message" would look identical to it). 6/6 pass.

## What I ran

Two authors, two heads. Which is which:

**`impl-8`, at the pre-rebase head, not re-run since:** the six
`AlRunner.Tests/RunnerFormCloseHandlerTests.cs` tests 6/6, and `tests/runner-extras` in full
including `microsoft-dependencies` 26/26.

**`impl-4`, at the current head (`a3cd7240`), 2026-09-07,** rebased onto `origin/main`
(`d6776eeb`), BC 28.1.49838.53910, private `--cache` outside the repository, flags as
`.github/workflows/bc-tests.yml` runs them. Everything below was executed in this state:

- `dotnet build AlRunner/AlRunner.csproj` and the full `AlRunner.slnx` on the rebased,
  bump-carrying tree: **0 errors**.
- The corpus at the bumped pin `7394c15f`, as the CI leg runs it (`--strict
  --count-baseline`): **2689 total, 2689 pass, 0 fail, 0 error, exit 0**, 1 bucket, 0
  compile-fail, 0 exec-fail. Run twice against the same private cache, cold then warm —
  identical both times, so no cache-hit divergence.
- The same corpus against a build of `origin/main` (`d6776eeb`), which is the RED half:
  **2689 total, 2687 pass, 2 fail, exit 1** — the two arms tabulated above.
- The xmlport order-independence guard the leg runs next
  (`--test "Codeunit6020" --strict`): **63/63, exit 0**.
- `tests/runner-extras` in full, since this touches every page close: **330 total, 330 pass,
  exit 0**. Also cold then warm, identical.
- `dotnet test AlRunner.Tests --filter` over `RunnerFormCloseHandlerTests`,
  `TestPageRefusalClaimTests`, `NonModalPageRunDispatchBindingTests`,
  `ModalPageRowLoadDispatchTests`, `TestPageErrorTeardownContractTests` and
  `TestCodeunitOrderingContractTests` — **113 passed, 0 failed, 4 skipped**; the four skips
  need the in-process BC engine.

I did not run the whole `AlRunner.Tests` suite; CI does that on the unit legs.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/202
