### PR TITLE
fix(reflection): resolve eleven BC method lookups by enumeration, and ratchet the rest

### DIFF
--- a/AlRunner.Tests/BcShapeMethodLookupTests.cs
+++ b/AlRunner.Tests/BcShapeMethodLookupTests.cs
@@ -46,6 +46,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using AlRunner.Infrastructure;
 using AlRunner.Patches;
 using Xunit;
@@ -264,6 +265,317 @@ public sealed class BcShapeMethodLookupTests
         Assert.NotNull(m);
         Assert.Equal("HiddenHelper", m!.Name);
     }
+
+    // ══ 4. The shape, not just the sites converted here ═════════════════════════════════
+    //
+    // The issue reports 212 name-only lookups. Re-measured on this tree with an argument-level
+    // parser rather than a per-statement regex, the census is:
+    //
+    //     Type.GetMethod(...) call sites in AlRunner/**/*.cs   324
+    //       ... passing an explicit signature                  123
+    //       ... resolving by NAME ALONE                        201
+    //             of which target typeof(<a runner-owned type>) 103
+    //             of which could reach a Microsoft-shipped type  98
+    //
+    // The 103 are the Cecil rewriter and the hook installers resolving the runner's OWN
+    // replacement methods. Microsoft cannot ship an overload into AlRunner.BcRuntime, so no BC
+    // update can move them, and converting them would buy nothing. The scan below therefore
+    // counts only the second group — a lookup whose declaring type comes from somewhere other
+    // than this assembly.
+    //
+    // What it asserts, and the limit of it: the repo-wide TOTAL, which cannot rise without a
+    // failure, so a new name-only BC-typed lookup anywhere in AlRunner/ is caught the moment it
+    // is written. It does not pin the per-file distribution, so moving one site out of file A
+    // and into file B nets to zero and passes; the per-file breakdown is printed on failure for
+    // whoever has to update the number. Deliberately a ratchet rather than a zero: 76 sites
+    // remain, and #3069 asks for them file by file so the guard never has to be weakened.
+
+    /// <summary>
+    /// Every remaining name-only method lookup that could reach a Microsoft-shipped type. Lower
+    /// it as sites are converted; it may never rise. On a mismatch the assertion prints the
+    /// per-file breakdown, which is the number to put here.
+    /// </summary>
+    private const int NameOnlyBcTypedMethodLookups = 76;
+
+    /// <summary>The floor is not cosmetic: a scan that silently narrowed to a handful of files
+    /// would report a small number and read as progress. AlRunner/ holds ~195 sources.</summary>
+    private const int MinimumProductionSourcesScanned = 150;
+
+    /// <summary>Files this change converted. They must stay at zero, so the slice cannot regress
+    /// while the ratchet above is being lowered elsewhere.</summary>
+    private static readonly string[] ConvertedFiles =
+    {
+        "Patches/AsyncStateMachineSpike.cs",
+        "Patches/BlobStoreIsolationPatches.cs",
+        "Patches/NavRecordRefPatches.cs",
+        "Patches/RecordPatches.FieldFindIntercept.cs",
+        "Patches/RecordPatches.FieldVirtualTable.cs",
+        "Patches/RecordPatches.QueryProjection.cs",
+    };
+
+    [Fact]
+    public void NameOnlyBcTypedMethodLookups_HaveNotIncreased()
+    {
+        var byFile = ScanNameOnlyBcTypedLookups(out var filesScanned);
+
+        Assert.True(filesScanned >= MinimumProductionSourcesScanned,
+            $"the scan saw only {filesScanned} production sources under AlRunner/, below the "
+            + $"{MinimumProductionSourcesScanned} floor — it narrowed, and a narrowed scan reports "
+            + "a small number that reads as progress.");
+
+        var total = byFile.Values.Sum();
+        Assert.True(total == NameOnlyBcTypedMethodLookups,
+            $"name-only BC-typed method lookups are {total}, recorded as "
+            + $"{NameOnlyBcTypedMethodLookups}. Converting sites? Lower the constant. Adding one? "
+            + "Use BcShape.FindMethod/RequiredMethod instead (#3069). Breakdown:"
+            + Environment.NewLine
+            + string.Join(Environment.NewLine,
+                byFile.OrderByDescending(kv => kv.Value).ThenBy(kv => kv.Key, StringComparer.Ordinal)
+                      .Select(kv => $"  {kv.Value,4}  {kv.Key}")));
+    }
+
+    [Fact]
+    public void TheConvertedFiles_HaveNoNameOnlyBcTypedMethodLookupLeft()
+    {
+        var byFile = ScanNameOnlyBcTypedLookups(out _);
+
+        var offenders = ConvertedFiles
+            .Where(f => byFile.TryGetValue(f, out var n) && n > 0)
+            .Select(f => $"  {byFile[f]}  {f}")
+            .ToArray();
+
+        Assert.True(offenders.Length == 0,
+            "these files were converted by #3069 and must resolve every BC method lookup through "
+            + "BcShape, so an added Microsoft overload names the gap instead of arriving as an "
+            + "AmbiguousMatchException the asserterror seam absorbs:" + Environment.NewLine
+            + string.Join(Environment.NewLine, offenders));
+    }
+
+    /// <summary>
+    /// CONTROL for the scan itself: it must actually FIND something in the shape it looks for,
+    /// or both assertions above are vacuous. Pins that at least one known-remaining file is still
+    /// counted, and that a file made only of runner-owned lookups is not.
+    /// </summary>
+    [Fact]
+    public void TheScan_CountsABcTypedLookupAndIgnoresARunnerOwnedOne()
+    {
+        var byFile = ScanNameOnlyBcTypedLookups(out _);
+
+        // BcRuntime.cs holds both kinds: dozens of typeof(AlRunner.BcRuntime).GetMethod(nameof(…))
+        // hook installs (not counted) and a set of lazily-resolved BC lookups (counted).
+        Assert.True(byFile.GetValueOrDefault("BcRuntime.cs") > 0,
+            "the scan found no BC-typed name-only lookup in BcRuntime.cs, which has several — the "
+            + "target classifier is over-matching and the totals above mean nothing.");
+
+        // NclCecilRewrite.Dispatch.cs is entirely runner-owned helper resolution: every lookup
+        // there is typeof(AlRunner.…).GetMethod(nameof(…)) against the runner's own patch classes.
+        Assert.Equal(0, byFile.GetValueOrDefault("Infrastructure/NclCecilRewrite.Dispatch.cs"));
+    }
+
+    // ── the scanner ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Per-file counts of <c>Type.GetMethod</c> call sites that pass no signature AND whose
+    /// declaring type is not a type of this assembly. Keys are paths relative to <c>AlRunner/</c>.
+    /// </summary>
+    private static Dictionary<string, int> ScanNameOnlyBcTypedLookups(out int filesScanned)
+    {
+        var runnerRoot = Path.Combine(RepoRoot, "AlRunner");
+        var sources = ProductionSources(runnerRoot);
+        filesScanned = sources.Count;
+
+        var runnerTypeNames = RunnerTypeNames();
+        var result = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        foreach (var path in sources)
+        {
+            var code = CodeWithoutLineComments(path);
+            var runnerOwnedLocals = RunnerOwnedLocals(code, runnerTypeNames);
+            var count = 0;
+
+            foreach (var (target, args) in GetMethodCalls(code))
+            {
+                if (args.Count == 0) continue;                     // StackFrame.GetMethod()
+                if (HasExplicitSignature(args)) continue;
+                if (IsRunnerOwnedTarget(target, runnerTypeNames, runnerOwnedLocals)) continue;
+                count++;
+            }
+
+            if (count > 0)
+                result[Path.GetRelativePath(runnerRoot, path).Replace('\\', '/')] = count;
+        }
+
+        return result;
+    }
+
+    /// <summary>Simple and full names of every type in the AlRunner assembly.</summary>
+    private static HashSet<string> RunnerTypeNames()
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var t in typeof(BcRuntime).Assembly.GetTypes())
+        {
+            names.Add(t.Name);
+            if (t.FullName != null) names.Add(t.FullName.Replace('+', '.'));
+        }
+        return names;
+    }
+
+    /// <summary>
+    /// Locals assigned <c>typeof(&lt;a runner type&gt;)</c> in this file. Without this the Cecil
+    /// rewriter's <c>var patchTypeMi = typeof(AlRunner.Patches.MediaSetPatches); … patchTypeMi
+    /// .GetMethod(nameof(…))</c> would count as a BC lookup, which would ask for conversions that
+    /// buy nothing and make the ratchet dishonest.
+    /// </summary>
+    private static HashSet<string> RunnerOwnedLocals(string code, HashSet<string> runnerTypeNames)
+    {
+        var locals = new HashSet<string>(StringComparer.Ordinal);
+        foreach (Match m in Regex.Matches(code, @"\b(?:var|Type)\s+(\w+)\s*=\s*typeof\(\s*([\w\.]+)\s*\)"))
+            if (runnerTypeNames.Contains(m.Groups[2].Value)) locals.Add(m.Groups[1].Value);
+        return locals;
+    }
+
+    private static bool IsRunnerOwnedTarget(
+        string target, HashSet<string> runnerTypeNames, HashSet<string> runnerOwnedLocals)
+    {
+        var typeofMatch = Regex.Match(target, @"typeof\(\s*([\w\.]+)\s*\)\s*[!?]?\s*$");
+        if (typeofMatch.Success) return runnerTypeNames.Contains(typeofMatch.Groups[1].Value);
+
+        var identifier = Regex.Match(target, @"([A-Za-z_]\w*)\s*[!?]?\s*$");
+        return identifier.Success && runnerOwnedLocals.Contains(identifier.Groups[1].Value);
+    }
+
+    /// <summary>
+    /// A signature is explicit when <c>types:</c> is named, or when a positional argument is a
+    /// <c>Type[]</c> — <c>Type.EmptyTypes</c>, <c>new[] { … }</c>, <c>new Type[] { … }</c>, or an
+    /// identifier ending in "Types". Those overloads match one signature and cannot raise
+    /// AmbiguousMatchException.
+    /// </summary>
+    private static bool HasExplicitSignature(IReadOnlyList<string> args)
+    {
+        if (args.Any(a => a.StartsWith("types:", StringComparison.Ordinal))) return true;
+
+        // GetMethod(name, types) | (name, flags, types) | (name, flags, binder, types, modifiers)
+        foreach (var index in new[] { 1, 2, 3 })
+            if (index < args.Count && LooksLikeTypeArray(args[index])) return true;
+        return false;
+    }
+
+    private static bool LooksLikeTypeArray(string arg)
+        => arg.StartsWith("Type.EmptyTypes", StringComparison.Ordinal)
+           || arg.StartsWith("new[]", StringComparison.Ordinal)
+           || arg.StartsWith("new []", StringComparison.Ordinal)
+           || arg.StartsWith("new Type[", StringComparison.Ordinal)
+           || Regex.IsMatch(arg, @"^[\w\.]*Types$")
+           || Regex.IsMatch(arg, @"^\w+ParameterTypes$");
+
+    /// <summary>
+    /// Every <c>.GetMethod(</c> call in <paramref name="code"/> as (text preceding the call,
+    /// top-level arguments). A character scanner rather than a regex: an argument list holds
+    /// nested calls, generics and string literals containing brackets, so a regex either stops at
+    /// the first <c>)</c> or swallows the rest of the file.
+    /// </summary>
+    private static IEnumerable<(string Target, IReadOnlyList<string> Args)> GetMethodCalls(string code)
+    {
+        foreach (Match m in Regex.Matches(code, @"\.GetMethod\s*\("))
+        {
+            var i = m.Index + m.Length;
+            var depth = 1;
+            var inString = false;
+            while (i < code.Length && depth > 0)
+            {
+                var c = code[i];
+                if (inString)
+                {
+                    if (c == '\\') { i += 2; continue; }
+                    if (c == '"') inString = false;
+                    i++;
+                    continue;
+                }
+                if (c == '"') inString = true;
+                else if (c is '(' or '[' or '{') depth++;
+                else if (c is ')' or ']' or '}') depth--;
+                i++;
+            }
+            var inner = code.Substring(m.Index + m.Length, Math.Max(0, i - 1 - (m.Index + m.Length)));
+            var targetStart = Math.Max(0, m.Index - 200);
+            yield return (Flatten(code.Substring(targetStart, m.Index - targetStart)), SplitTopLevel(inner));
+        }
+    }
+
+    private static string Flatten(string s) => Regex.Replace(s, @"\s+", " ").TrimEnd();
+
+    private static IReadOnlyList<string> SplitTopLevel(string s)
+    {
+        var args = new List<string>();
+        var current = new System.Text.StringBuilder();
+        var depth = 0;
+        var inString = false;
+        for (var i = 0; i < s.Length; i++)
+        {
+            var c = s[i];
+            if (inString)
+            {
+                current.Append(c);
+                if (c == '\\' && i + 1 < s.Length) { current.Append(s[++i]); continue; }
+                if (c == '"') inString = false;
+                continue;
+            }
+            if (c == '"') { inString = true; current.Append(c); continue; }
+            if (c is '(' or '[' or '{' or '<') depth++;
+            else if (c is ')' or ']' or '}' or '>') depth--;
+            if (c == ',' && depth == 0) { args.Add(Flatten(current.ToString()).Trim()); current.Clear(); continue; }
+            current.Append(c);
+        }
+        if (current.ToString().Trim().Length > 0) args.Add(Flatten(current.ToString()).Trim());
+        return args;
+    }
+
+    /// <summary>
+    /// The source with whole-line <c>//</c> comments removed, for the reason the sibling guards
+    /// already document: headers in this repository quote the retired shape in prose on purpose,
+    /// and the claim under test is about CODE.
+    /// </summary>
+    private static string CodeWithoutLineComments(string path)
+        => string.Join('\n', File.ReadAllLines(path)
+            .Where(l => !l.TrimStart().StartsWith("//", StringComparison.Ordinal)));
+
+    /// <summary>
+    /// Every production C# source under <paramref name="root"/>, discovered by walking. Throws
+    /// when the walk finds nothing — same contract as FieldTriggerShapeGapCallSiteTests, and for
+    /// the same reason: a scan with nothing to scan reports zero and reads as success. .claude is
+    /// excluded because agent worktrees there are full checkouts of this repository.
+    /// </summary>
+    private static IReadOnlyList<string> ProductionSources(string root)
+    {
+        var skipped = new[] { "bin", "obj", ".git", ".claude", ".vs", "node_modules", "packages" };
+        var found = new List<string>();
+        var pending = new Stack<string>();
+        pending.Push(root);
+
+        while (pending.Count > 0)
+        {
+            var dir = pending.Pop();
+            foreach (var sub in Directory.EnumerateDirectories(dir))
+            {
+                var name = Path.GetFileName(sub);
+                if (skipped.Contains(name, StringComparer.Ordinal)) continue;
+                if (name.EndsWith(".Tests", StringComparison.Ordinal)) continue;
+                pending.Push(sub);
+            }
+            found.AddRange(Directory.EnumerateFiles(dir, "*.cs"));
+        }
+
+        if (found.Count == 0)
+            throw new InvalidOperationException(
+                $"The scan found no C# sources under '{root}'. A scan with nothing to scan reports "
+                + "zero violations and reads as success, so it fails here instead.");
+
+        found.Sort(StringComparer.Ordinal);
+        return found;
+    }
+
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
 
     // ══ 4. Plumbing ═════════════════════════════════════════════════════════════════════
 

--- a/AlRunner.Tests/BcShapeMethodLookupTests.cs
+++ b/AlRunner.Tests/BcShapeMethodLookupTests.cs
@@ -1,0 +1,347 @@
+// BcShapeMethodLookupTests — name-only BC method lookups outside the permission slice (#3069).
+//
+// ── THE MECHANISM, AND WHAT IT IS *NOT* ──────────────────────────────────────────────────
+// `Type.GetMethod(name)` / `Type.GetMethod(name, flags)` do NOT silently hand back the wrong
+// member when Microsoft ships a second method of that name. Measured, not assumed — the first
+// arm below asserts it: reflection's default binder raises AmbiguousMatchException. So the
+// defect is not a wrong answer at the reflection layer.
+//
+// It becomes a wrong answer one layer up. MethodScopePatches.NavMethodScope_AssertError — AL's
+// `asserterror` seam — rethrows exactly one type (BcShapeGapException) and absorbs everything
+// else. An AmbiguousMatchException raised under an `asserterror` is therefore SWALLOWED, and the
+// asserterror PASSES on a call real BC performs fine. Green, and the opposite of BC's answer.
+// #3062 fixed that inversion for the three permission-slice files; this is the same repair for
+// the record/query paths, behind one shared helper instead of a file-private one.
+//
+// No `!` appears in the shape, so #3051's sweep of null-forgiving lookups cannot find it: these
+// two issues share a SEAM, not a mechanism. #3051 is a member that MOVED (silent null, NRE at
+// the first use); this is a member that MULTIPLIED (a throw of the wrong type). BcShape.FindMethod
+// deliberately still answers null on absence, so converting a site here does not change what it
+// does on a build where the member is gone — that half stays #3051's.
+//
+// ── WHY IT IS LATENT TODAY, AND WHY IT IS STILL REAL ─────────────────────────────────────
+// Measured over Ncl 27.5.46862.48827 and 28.1.49838.50621: every BC method name the converted
+// call sites look up has exactly ONE declaration on the type they look it up on, so the
+// conversion changes nothing on any BC build the runner has seen.
+//
+// Microsoft does add overloads to types the runner reflects on, though — measured on the same
+// two builds, Microsoft.Dynamics.Nav.Runtime.NavReport.Execute went from 4 declarations to 6
+// (`Execute(String, String)` and `Execute(String, String, NavRecordRef)` are new in 28.1). The
+// runner does not look that one up by name; the point is that the event is ordinary, and the day
+// it lands on a name the runner DOES look up, this is the difference between a named refusal and
+// a green asserterror.
+//
+// ── MEASURED RED (production call sites unconverted, this file unchanged) ────────────────
+//   AssertError_TearsThrough_InsteadOfSwallowingTheAmbiguousEvaluate
+//       Assert.Throws() Failure: No exception was thrown
+//   TryFunction_CannotTrapTheRefusal_OnTheCorrectedEvaluatePath
+//       System.Reflection.AmbiguousMatchException : Ambiguous match found.
+//   BcShape_FindMethod_* / NoBcTypedNameOnlyMethodLookup_* : green either way (helper + scan)
+//
+// The first arm IS the inversion: the seam swallowed the AmbiguousMatchException and returned
+// normally, which in AL is an `asserterror` that passed. The second shows the other seam already
+// refused it, so only asserterror inverts — that arm is a CONTROL, not a second RED.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class BcShapeMethodLookupTests
+{
+    private const BindingFlags Priv = BindingFlags.NonPublic | BindingFlags.Static;
+    private const BindingFlags PublicInstance = BindingFlags.Public | BindingFlags.Instance;
+
+    // ══ 1. The premise, measured rather than assumed ════════════════════════════════════
+
+    [Fact]
+    public void TypeGetMethodByName_ThrowsAmbiguousMatch_WhenBcShipsASecondDeclaration()
+    {
+        Assert.Throws<AmbiguousMatchException>(
+            () => typeof(TwoEvaluates).GetMethod("Evaluate", PublicInstance));
+
+        // ... and the single-declaration type it stands in for does not, so the throw above is
+        // about the second declaration and not about the lookup itself.
+        Assert.NotNull(typeof(OneEvaluate).GetMethod("Evaluate", PublicInstance));
+    }
+
+    /// <summary>
+    /// The other half of the premise, and the reason this issue is NOT "reflection returns the
+    /// wrong member": a `new`-hidden declaration whose SIGNATURE changed is ambiguous too, so
+    /// reflection refuses rather than picking. There is no silent-wrong-member outcome to fix
+    /// at this layer — the wrong answer is manufactured by the seam that absorbs the throw.
+    /// </summary>
+    [Fact]
+    public void TypeGetMethodByName_ThrowsAmbiguousMatch_ForAHiddenDeclarationWithANewSignature()
+    {
+        Assert.Throws<AmbiguousMatchException>(
+            () => typeof(HidesEvaluateWithADifferentSignature).GetMethod("Evaluate", PublicInstance));
+    }
+
+    /// <summary>
+    /// The seam, on the raw expression the production sites used to contain: it returns NORMALLY.
+    /// In AL that is `asserterror` passing over a call real BC performs fine. This arm asserts
+    /// the FRAMEWORK behaviour the fix routes around, so it stays green after the fix.
+    /// </summary>
+    [Fact]
+    public void AssertError_AbsorbsARawAmbiguousMatch_WhichIsWhatInvertsTheResult()
+    {
+        var reached = false;
+
+        BcRuntime.NavMethodScope_AssertError(null!, () =>
+        {
+            reached = true;
+            typeof(TwoEvaluates).GetMethod("Evaluate", PublicInstance);
+        });
+
+        Assert.True(reached, "the body must actually run, else this arm proves nothing");
+    }
+
+    // ══ 2. THE INVERSION, on the real call path ═════════════════════════════════════════
+    //
+    // RecordPatches.EvaluateFilterExpression is the runner's driver for BC's
+    // FilterExpression.Evaluate(NavValue, ISortingRulesProvider) — the WHERE evaluation behind AL
+    // query filtering, so it is reachable from AL and therefore from `asserterror`. Both arms
+    // drive PRODUCTION code with the two reflection statics it reads injected for one call;
+    // nothing here re-implements the helper.
+
+    [Fact]
+    public void AssertError_TearsThrough_InsteadOfSwallowingTheAmbiguousEvaluate()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => BcRuntime.NavMethodScope_AssertError(
+            null!, () => EvaluateWith(typeof(TwoEvaluates), new TwoEvaluates())));
+
+        Assert.Equal("FilterExpression.Evaluate", ex.Member);
+        Assert.Contains("BC declares 2 methods named Evaluate", ex.Detail, StringComparison.Ordinal);
+        Assert.Contains("cannot tell which one", ex.Detail, StringComparison.Ordinal);
+    }
+
+    // CONTROL, not a second RED: NavApplicationObjectBase_TryInvoke rethrew the raw
+    // AmbiguousMatchException before this change too. What it pins is that the corrected refusal
+    // still tears through, rather than becoming something an AL [TryFunction] can trap.
+    [Fact]
+    public void TryFunction_CannotTrapTheRefusal_OnTheCorrectedEvaluatePath()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => BcRuntime.NavApplicationObjectBase_TryInvoke(
+            null, () => EvaluateWith(typeof(TwoEvaluates), new TwoEvaluates())));
+
+        Assert.Equal("FilterExpression.Evaluate", ex.Member);
+    }
+
+    /// <summary>
+    /// CONTROL, and the arm that makes the two above mean something: with a SINGLE Evaluate the
+    /// same production path resolves it and returns the fake's own answer. Both directions, so a
+    /// helper that always refused — or one that always answered a constant — fails here.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void EvaluateFilterExpression_StillDrivesTheSingleEvaluate_AndReturnsItsAnswer(bool answer)
+    {
+        Assert.Equal(answer, EvaluateWith(typeof(OneEvaluate), new OneEvaluate(answer)));
+    }
+
+    /// <summary>
+    /// Absence still refuses the way it did before — with the call site's own
+    /// InvalidOperationException, NOT a shape gap. This pins that the conversion moved exactly one
+    /// outcome (ambiguity) and left the null-forgiving half to #3051, so the two issues stay
+    /// separately fixable.
+    /// </summary>
+    [Fact]
+    public void EvaluateFilterExpression_KeepsItsOwnRefusal_WhenEvaluateIsGoneEntirely()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => EvaluateWith(typeof(NoEvaluate), new NoEvaluate()));
+
+        Assert.Contains("FilterExpression.Evaluate", ex.Message, StringComparison.Ordinal);
+        Assert.IsNotType<BcShapeGapException>(ex);
+    }
+
+    // ══ 3. BcShape.FindMethod / RequiredMethod ══════════════════════════════════════════
+
+    [Fact]
+    public void FindMethod_ResolvesTheOnlyDeclaration()
+    {
+        var m = BcShape.FindMethod(typeof(OneEvaluate), "Evaluate", PublicInstance,
+            "surface", "OneEvaluate.Evaluate", "detail");
+
+        Assert.NotNull(m);
+        Assert.Equal(2, m!.GetParameters().Length);
+    }
+
+    [Fact]
+    public void FindMethod_AnswersNull_WhenBcDeclaresNone_SoAbsenceStaysTheCallSitesProblem()
+    {
+        Assert.Null(BcShape.FindMethod(typeof(NoEvaluate), "Evaluate", PublicInstance,
+            "surface", "NoEvaluate.Evaluate", "detail"));
+    }
+
+    [Fact]
+    public void FindMethod_RaisesAShapeGapNamingTheMemberAndTheCount_WhenBcDeclaresTwo()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => BcShape.FindMethod(
+            typeof(TwoEvaluates), "Evaluate", PublicInstance,
+            "Query filtering (WHERE evaluation)", "FilterExpression.Evaluate", "the filter cannot be applied"));
+
+        Assert.Equal("Query filtering (WHERE evaluation)", ex.Surface);
+        Assert.Equal("FilterExpression.Evaluate", ex.Member);
+        Assert.Contains("BC declares 2 methods named Evaluate on TwoEvaluates", ex.Detail,
+            StringComparison.Ordinal);
+        Assert.Contains("the filter cannot be applied", ex.Detail, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// STRICTER than what it replaces, on purpose and in exactly one case: a `new`-hidden
+    /// declaration of the SAME signature. Type.GetMethod hands back the most-derived one without
+    /// complaint (asserted here, so the difference is measured), which could silently drive the
+    /// wrong declaration; this refuses instead.
+    /// </summary>
+    [Fact]
+    public void FindMethod_RefusesANewHiddenDeclarationOfTheSameSignature_WhichGetMethodWouldHaveGuessed()
+    {
+        var guessed = typeof(HidesEvaluateWithTheSameSignature).GetMethod("Evaluate", PublicInstance);
+        Assert.Equal(typeof(HidesEvaluateWithTheSameSignature), guessed!.DeclaringType);
+
+        var ex = Assert.Throws<BcShapeGapException>(() => BcShape.FindMethod(
+            typeof(HidesEvaluateWithTheSameSignature), "Evaluate", PublicInstance,
+            "surface", "Hidden.Evaluate", "detail"));
+
+        Assert.Contains("BC declares 2 methods named Evaluate", ex.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FindMethod_ResolvesTheAskedForOverload_WhenTheSignatureIsPinned()
+    {
+        var two = BcShape.FindMethod(typeof(TwoEvaluates), "Evaluate", PublicInstance,
+            "surface", "member", "detail", new[] { typeof(object), typeof(object) });
+
+        Assert.Equal(2, two!.GetParameters().Length);
+    }
+
+    // The pinned selection DISCRIMINATES: asked for the one-parameter overload it returns THAT
+    // one, so the arm above is not satisfied by a helper that hands back the first candidate.
+    [Fact]
+    public void FindMethod_ReturnsTheOtherOverload_WhenThatIsTheSignatureAskedFor()
+    {
+        var one = BcShape.FindMethod(typeof(TwoEvaluates), "Evaluate", PublicInstance,
+            "surface", "member", "detail", new[] { typeof(object) });
+
+        Assert.Equal(1, one!.GetParameters().Length);
+        Assert.Equal(typeof(object), one.GetParameters()[0].ParameterType);
+    }
+
+    [Fact]
+    public void RequiredMethod_RaisesAShapeGapNamingTheSignature_WhenTheParametersHaveMoved()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(() => BcShape.RequiredMethod(
+            typeof(TwoEvaluates), "Evaluate", PublicInstance,
+            "surface", "TwoEvaluates.Evaluate", "the filter cannot be applied",
+            new[] { typeof(int) }));
+
+        Assert.Equal("TwoEvaluates.Evaluate", ex.Member);
+        Assert.Contains("method not found with signature (Int32)", ex.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RequiredMethod_ResolvesWhenItIsThere_SoTheRefusalIsAboutAbsence()
+    {
+        Assert.Equal("Evaluate", BcShape.RequiredMethod(typeof(OneEvaluate), "Evaluate",
+            PublicInstance, "surface", "member", "detail").Name);
+    }
+
+    [Fact]
+    public void FindMethod_FindsANonPublicMethod_SoTheConvertedSitesKeepTheirOwnFlags()
+    {
+        var m = BcShape.FindMethod(typeof(OneEvaluate), "HiddenHelper",
+            BindingFlags.NonPublic | BindingFlags.Instance, "surface", "member", "detail");
+
+        Assert.NotNull(m);
+        Assert.Equal("HiddenHelper", m!.Name);
+    }
+
+    // ══ 4. Plumbing ═════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Drives production <c>RecordPatches.EvaluateFilterExpression</c> with the two reflection
+    /// statics it reads pointed at <paramref name="filterExpressionType"/> for exactly one call,
+    /// and restores both in a finally. Nothing in production becomes settable for the test.
+    /// </summary>
+    private static bool EvaluateWith(Type filterExpressionType, object expr) => WithStatics(
+        new (string, object?)[] { ("_tFilterExpr", filterExpressionType), ("_mFilterExprEvaluate", null) },
+        () => (bool)Invoke("EvaluateFilterExpression", expr, new object(), null)!);
+
+    private static T WithStatics<T>((string Name, object? Value)[] statics, Func<T> body)
+    {
+        var fields = statics.Select(x => (Field: Static(x.Name), x.Value)).ToArray();
+        var saved = fields.Select(f => f.Field.GetValue(null)).ToArray();
+        try
+        {
+            foreach (var (field, value) in fields) field.SetValue(null, value);
+            return body();
+        }
+        finally
+        {
+            for (var i = 0; i < fields.Length; i++) fields[i].Field.SetValue(null, saved[i]);
+        }
+    }
+
+    private static FieldInfo Static(string name)
+        => typeof(RecordPatches).GetField(name, Priv)
+           ?? throw new InvalidOperationException($"test setup: RecordPatches.{name} not found");
+
+    private static object? Invoke(string name, params object?[] args)
+    {
+        var m = typeof(RecordPatches).GetMethod(name, Priv)
+            ?? throw new InvalidOperationException($"test setup: RecordPatches.{name} not found");
+        try
+        {
+            return m.Invoke(null, args);
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            throw tie.InnerException;   // the reflection wrapper is not part of the contract
+        }
+    }
+
+    /// <summary>The shape BC declares today: exactly one Evaluate.</summary>
+    public sealed class OneEvaluate
+    {
+        private readonly bool _answer;
+        public OneEvaluate(bool answer = true) => _answer = answer;
+        public bool Evaluate(object navValue, object? sortingRules) => _answer;
+        internal void HiddenHelper() { }
+    }
+
+    /// <summary>Stands in for FilterExpression after Microsoft ships a second Evaluate.</summary>
+    public sealed class TwoEvaluates
+    {
+        public bool Evaluate(object navValue, object? sortingRules) => true;
+        public bool Evaluate(object navValue) => true;
+    }
+
+    /// <summary>Stands in for a build where Evaluate is gone entirely.</summary>
+    public sealed class NoEvaluate
+    {
+    }
+
+    public class EvaluateBase
+    {
+        public bool Evaluate(object navValue, object? sortingRules) => false;
+    }
+
+    public sealed class HidesEvaluateWithADifferentSignature : EvaluateBase
+    {
+        public new bool Evaluate(object navValue) => true;
+    }
+
+    public sealed class HidesEvaluateWithTheSameSignature : EvaluateBase
+    {
+        public new bool Evaluate(object navValue, object? sortingRules) => true;
+    }
+}

--- a/AlRunner/Infrastructure/BcShapeGapException.cs
+++ b/AlRunner/Infrastructure/BcShapeGapException.cs
@@ -96,6 +96,7 @@
 
 using System;
 using System.Collections;
+using System.Linq;
 using System.Reflection;
 
 namespace AlRunner.Infrastructure;
@@ -195,6 +196,75 @@ internal static class BcShape
     public static FieldInfo RequiredField(Type type, string member, string surface, string detail)
         => PrivateMemberLookup.Field(type, member)
            ?? throw new BcShapeGapException(surface, $"{type.Name}.{member}", $"field not found — {detail}");
+
+    /// <summary>
+    /// The one method named <paramref name="name"/> that <paramref name="declaring"/> exposes
+    /// under <paramref name="flags"/>, or <c>null</c> when BC declares NONE.
+    ///
+    /// <para>What this is for: <see cref="Type.GetMethod(string, BindingFlags)"/> throws
+    /// <see cref="AmbiguousMatchException"/> the moment Microsoft ships a second method of that
+    /// name. That is a bare framework exception carrying no member name, and
+    /// <c>MethodScopePatches.NavMethodScope_AssertError</c> rethrows only
+    /// <see cref="BcShapeGapException"/> — so under an AL <c>asserterror</c> it is ABSORBED and
+    /// the asserterror PASSES, on a call real BC performs fine. Enumerating cannot throw, so
+    /// every outcome here is the method, <c>null</c>, or a refusal that names the member
+    /// (#3069, and #3062 for the same repair inside the permission slice).</para>
+    ///
+    /// <para><b>Absence still answers <c>null</c>, deliberately.</b> A member that MOVED is the
+    /// null-forgiving shape #3051 tracks, and converting it here would change what every call
+    /// site does on a build where the member is simply gone. This helper changes exactly one
+    /// outcome — ambiguity — and leaves absence to the call site, which is why it can be dropped
+    /// into a site that tolerates null and a site that throws on null without reading either
+    /// differently. Use <see cref="RequiredMethod"/> where absence must refuse too.</para>
+    ///
+    /// <para><paramref name="types"/> pins the signature the call site's <c>Invoke</c> argument
+    /// array is built for; pass it wherever the types are derivable from something already in
+    /// hand, and an added overload is then RESOLVED rather than merely reported. Where it is
+    /// null the method must be unique by name, and a second declaration is refused BY NAME.</para>
+    ///
+    /// <para>Two survivors are refused rather than guessed. With distinct signatures that is a
+    /// real overload the call site cannot choose between; with identical ones it is a
+    /// <c>new</c>-hidden member, where <see cref="Type.GetMethod(string, BindingFlags)"/> would
+    /// silently hand back the most-derived declaration and could drive the wrong one. This is
+    /// therefore STRICTER than what it replaces in that one case — measured on Ncl
+    /// 27.5.46862.48827 and 28.1.49838.50621, every call site converted to it resolves to
+    /// exactly one candidate, so neither refusal fires on a BC build the runner has seen.</para>
+    /// </summary>
+    public static MethodInfo? FindMethod(
+        Type declaring, string name, BindingFlags flags,
+        string surface, string member, string detail, Type[]? types = null)
+    {
+        var candidates = declaring.GetMethods(flags)
+            .Where(m => string.Equals(m.Name, name, StringComparison.Ordinal))
+            .Where(m => types == null
+                        || m.GetParameters().Select(pp => pp.ParameterType).SequenceEqual(types))
+            .ToArray();
+
+        if (candidates.Length == 1) return candidates[0];
+        if (candidates.Length == 0) return null;
+
+        throw new BcShapeGapException(
+            surface, member,
+            $"BC declares {candidates.Length} methods named {name}{Signature(types)}"
+            + $" on {declaring.Name}, so the runner cannot tell which one its call site means"
+            + $" — {detail}");
+    }
+
+    /// <summary>
+    /// <see cref="FindMethod"/> for a call site that cannot proceed without the method: absence
+    /// refuses too, naming what was looked for instead of handing back a null whose
+    /// <see cref="NullReferenceException"/> lands somewhere that names nothing.
+    /// </summary>
+    public static MethodInfo RequiredMethod(
+        Type declaring, string name, BindingFlags flags,
+        string surface, string member, string detail, Type[]? types = null)
+        => FindMethod(declaring, name, flags, surface, member, detail, types)
+           ?? throw new BcShapeGapException(
+               surface, member,
+               $"method not found{Signature(types)} on {declaring.Name} — {detail}");
+
+    private static string Signature(Type[]? types)
+        => types == null ? string.Empty : $" with signature ({string.Join(", ", types.Select(t => t.Name))})";
 
     /// <summary>
     /// <paramref name="value"/> as an <see cref="IEnumerable"/>, or a

--- a/AlRunner/Patches/AsyncStateMachineSpike.cs
+++ b/AlRunner/Patches/AsyncStateMachineSpike.cs
@@ -187,8 +187,12 @@ public static partial class BcRuntime
 
         var sharedDict = ctor.Invoke(new object?[] { _skeletonSharedObjectContainer });
 
-        var mSet = treeType.GetMethod("SetReferenceTarget",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var mSet = BcShape.RequiredMethod(
+            treeType, "SetReferenceTarget",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            "RecordRef (shared record-reference materialisation)",
+            "TreeHandler.SetReferenceTarget",
+            "the RecordRef's shared reference target cannot be installed");
         mSet.Invoke(tree, new object?[] { sharedDict });
         return sharedDict;
     }

--- a/AlRunner/Patches/BlobStoreIsolationPatches.cs
+++ b/AlRunner/Patches/BlobStoreIsolationPatches.cs
@@ -68,6 +68,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.Dynamics.Nav.Runtime;
 using Microsoft.Dynamics.Nav.Types;
+using AlRunner.Infrastructure;
 
 namespace AlRunner.Patches;
 
@@ -261,8 +262,12 @@ public static class BlobStoreIsolationPatches
         if (ReferenceEquals(workTableBuffer, storedTableBuffer)) return;
 
         var mrbType = mutableRecordBuffer.GetType();
-        _mGetChangedFieldValue ??= mrbType.GetMethod("GetChangedFieldValue",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        _mGetChangedFieldValue ??= BcShape.FindMethod(
+            mrbType, "GetChangedFieldValue",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            "BLOB store isolation (per-record buffered BLOB writes)",
+            "MutableRecordBuffer.GetChangedFieldValue",
+            "a buffered BLOB write cannot be read back");
         if (_mGetChangedFieldValue == null) return;
 
         var metaTable = mrbType.GetProperty("MetaTable", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)

--- a/AlRunner/Patches/BlobStoreIsolationPatches.cs
+++ b/AlRunner/Patches/BlobStoreIsolationPatches.cs
@@ -272,7 +272,12 @@ public static class BlobStoreIsolationPatches
 
         var metaTable = mrbType.GetProperty("MetaTable", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
             ?.GetValue(mutableRecordBuffer);
-        var getFieldByIndex = metaTable?.GetType().GetMethod("GetFieldByIndex", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var getFieldByIndex = metaTable == null ? null : BcShape.FindMethod(
+            metaTable.GetType(), "GetFieldByIndex",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            "BLOB store isolation (per-record buffered BLOB writes)",
+            "NCLMetaTable.GetFieldByIndex",
+            "the record's BLOB fields cannot be enumerated");
         var fieldCount = mrbType.GetProperty("FieldCount", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
             ?.GetValue(mutableRecordBuffer) is int fc ? fc : 0;
         if (metaTable == null || getFieldByIndex == null) return;

--- a/AlRunner/Patches/NavRecordRefPatches.cs
+++ b/AlRunner/Patches/NavRecordRefPatches.cs
@@ -96,8 +96,12 @@ public static partial class BcRuntime
                 BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
                 null, Type.EmptyTypes, null);
         if (_mTreeSetReferenceTarget == null)
-            _mTreeSetReferenceTarget = tree.GetType().GetMethod("SetReferenceTarget",
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            _mTreeSetReferenceTarget = AlRunner.Infrastructure.BcShape.FindMethod(
+                tree.GetType(), "SetReferenceTarget",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                "RecordRef (shared record-reference materialisation)",
+                "TreeHandler.SetReferenceTarget",
+                "the RecordRef's shared reference target cannot be installed");
 
         var existing = _mTreeGetReferenceTarget?.Invoke(tree, null);
         if (existing != null) return existing;
@@ -287,8 +291,12 @@ public static partial class BcRuntime
                 BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
                 null, Type.EmptyTypes, null);
         if (_mTreeSetReferenceTarget == null)
-            _mTreeSetReferenceTarget = tree.GetType().GetMethod("SetReferenceTarget",
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            _mTreeSetReferenceTarget = AlRunner.Infrastructure.BcShape.FindMethod(
+                tree.GetType(), "SetReferenceTarget",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                "RecordRef (shared record-reference materialisation)",
+                "TreeHandler.SetReferenceTarget",
+                "the RecordRef's shared reference target cannot be installed");
         var existing = _mTreeGetReferenceTarget?.Invoke(tree, null);
         if (existing != null) return existing;
 
@@ -496,8 +504,12 @@ public static partial class BcRuntime
                 BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
                 null, Type.EmptyTypes, null);
         if (_mTreeSetReferenceTarget == null)
-            _mTreeSetReferenceTarget = tree.GetType().GetMethod("SetReferenceTarget",
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            _mTreeSetReferenceTarget = AlRunner.Infrastructure.BcShape.FindMethod(
+                tree.GetType(), "SetReferenceTarget",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                "RecordRef (shared record-reference materialisation)",
+                "TreeHandler.SetReferenceTarget",
+                "the RecordRef's shared reference target cannot be installed");
         var existing = _mTreeGetReferenceTarget?.Invoke(tree, null);
         if (existing != null) return existing;
 
@@ -540,8 +552,12 @@ public static partial class BcRuntime
                 BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
                 null, Type.EmptyTypes, null);
         if (_mTreeSetReferenceTarget == null)
-            _mTreeSetReferenceTarget = tree.GetType().GetMethod("SetReferenceTarget",
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            _mTreeSetReferenceTarget = AlRunner.Infrastructure.BcShape.FindMethod(
+                tree.GetType(), "SetReferenceTarget",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                "RecordRef (shared record-reference materialisation)",
+                "TreeHandler.SetReferenceTarget",
+                "the RecordRef's shared reference target cannot be installed");
         var existing = _mTreeGetReferenceTarget?.Invoke(tree, null);
         if (existing != null) return existing;
 
@@ -581,8 +597,12 @@ public static partial class BcRuntime
                 BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
                 null, Type.EmptyTypes, null);
         if (_mTreeSetReferenceTarget == null)
-            _mTreeSetReferenceTarget = tree.GetType().GetMethod("SetReferenceTarget",
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            _mTreeSetReferenceTarget = AlRunner.Infrastructure.BcShape.FindMethod(
+                tree.GetType(), "SetReferenceTarget",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                "RecordRef (shared record-reference materialisation)",
+                "TreeHandler.SetReferenceTarget",
+                "the RecordRef's shared reference target cannot be installed");
         var existing = _mTreeGetReferenceTarget?.Invoke(tree, null);
         if (existing != null) return existing;
 
@@ -621,8 +641,12 @@ public static partial class BcRuntime
                 BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
                 null, Type.EmptyTypes, null);
         if (_mTreeSetReferenceTarget == null)
-            _mTreeSetReferenceTarget = tree.GetType().GetMethod("SetReferenceTarget",
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            _mTreeSetReferenceTarget = AlRunner.Infrastructure.BcShape.FindMethod(
+                tree.GetType(), "SetReferenceTarget",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                "RecordRef (shared record-reference materialisation)",
+                "TreeHandler.SetReferenceTarget",
+                "the RecordRef's shared reference target cannot be installed");
         var existing = _mTreeGetReferenceTarget?.Invoke(tree, null);
         if (existing != null) return existing;
 

--- a/AlRunner/Patches/RecordPatches.FieldFindIntercept.cs
+++ b/AlRunner/Patches/RecordPatches.FieldFindIntercept.cs
@@ -51,6 +51,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.Dynamics.Nav.Runtime;
+using AlRunner.Infrastructure;
 
 namespace AlRunner.Patches;
 
@@ -638,8 +639,14 @@ public static partial class RecordPatches
             const string rt = "Microsoft.Dynamics.Nav.Runtime.";
 
             var tDataAccess = nclAsm.GetType(rt + "DataAccess")!;
-            _mInnerFindAsync = tDataAccess.GetMethod("InnerFindAsync",
-                BindingFlags.NonPublic | BindingFlags.Instance)
+            // Enumerated rather than Type.GetMethod(name, flags) — see BcShape.FindMethod and
+            // #3069. A second InnerFindAsync would otherwise arrive as an anonymous
+            // AmbiguousMatchException that the asserterror seam absorbs.
+            _mInnerFindAsync = BcShape.FindMethod(
+                tDataAccess, "InnerFindAsync", BindingFlags.NonPublic | BindingFlags.Instance,
+                "Field virtual table (system table 2000000041) find interception",
+                "DataAccess.InnerFindAsync",
+                "the Field virtual table cannot be served")
                 ?? throw new InvalidOperationException("DataAccess.InnerFindAsync not found");
             _pDaSession = tDataAccess.GetProperty("Session", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
                 ?? throw new InvalidOperationException("DataAccess.Session not found");

--- a/AlRunner/Patches/RecordPatches.FieldVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.FieldVirtualTable.cs
@@ -303,8 +303,12 @@ public static partial class RecordPatches
         _tFieldDataProvider = nclAsm.GetType(rt + "FieldDataProvider")
             ?? throw new InvalidOperationException("FieldDataProvider type not found");
 
-        _mGetFieldRecordBuffer = _tFieldDataProvider.GetMethod("GetFieldRecordBuffer",
-            BindingFlags.NonPublic | BindingFlags.Instance)
+        // Enumerated rather than Type.GetMethod(name, flags) — see BcShape.FindMethod and #3069.
+        _mGetFieldRecordBuffer = BcShape.FindMethod(
+            _tFieldDataProvider, "GetFieldRecordBuffer", BindingFlags.NonPublic | BindingFlags.Instance,
+            "Field virtual table (system table 2000000041)",
+            "FieldDataProvider.GetFieldRecordBuffer",
+            "the Field virtual table cannot be served")
             ?? throw new InvalidOperationException("FieldDataProvider.GetFieldRecordBuffer not found");
 
         var tVdp = nclAsm.GetType(rt + "VirtualDataProvider");

--- a/AlRunner/Patches/RecordPatches.QueryProjection.cs
+++ b/AlRunner/Patches/RecordPatches.QueryProjection.cs
@@ -63,6 +63,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.Dynamics.Nav.Runtime;
 using Microsoft.Dynamics.Nav.Types;
+using AlRunner.Infrastructure;
 
 namespace AlRunner.Patches;
 
@@ -1002,7 +1003,15 @@ public static partial class RecordPatches
     /// <summary>Invoke BC's FilterExpression.Evaluate(NavValue, ISortingRulesProvider) by reflection.</summary>
     private static bool EvaluateFilterExpression(object expr, object navValue, object? sortingRules)
     {
-        _mFilterExprEvaluate ??= _tFilterExpr!.GetMethod("Evaluate", BindingFlags.Public | BindingFlags.Instance)
+        // BcShape.FindMethod, not Type.GetMethod(name, flags): a second Evaluate raises
+        // AmbiguousMatchException, which NavMethodScope_AssertError absorbs, so an AL
+        // `asserterror` over a filtered query would PASS on a filter real BC applies (#3069).
+        // Absence still answers null and still hits the InvalidOperationException below —
+        // that half is #3051's, and is deliberately untouched here.
+        _mFilterExprEvaluate ??= BcShape.FindMethod(
+                _tFilterExpr!, "Evaluate", BindingFlags.Public | BindingFlags.Instance,
+                "Query filtering (WHERE evaluation)", "FilterExpression.Evaluate",
+                "the query's filter expression cannot be evaluated")
             ?? throw new InvalidOperationException("FilterExpression.Evaluate(NavValue, ISortingRulesProvider) not found");
         return (bool)_mFilterExprEvaluate.Invoke(expr, new[] { navValue, sortingRules })!;
     }


### PR DESCRIPTION
Closes #3069

## What the defect actually is, and what it is not

`Type.GetMethod(name)` and `Type.GetMethod(name, flags)` do **not** silently hand back the
wrong member when Microsoft ships a second method of that name. Measured, not assumed — the
first arm of the new test asserts it: reflection's default binder raises
`AmbiguousMatchException`, and it does so for a `new`-hidden declaration with a changed
signature too. So there is no silent-wrong-member outcome to fix at the reflection layer.

The wrong answer is manufactured one layer up. `NavMethodScope_AssertError` — AL's
`asserterror` seam — rethrows exactly one type (`BcShapeGapException`) and absorbs everything
else. An `AmbiguousMatchException` raised under an `asserterror` is therefore swallowed and the
`asserterror` **passes**, on a call real BC performs fine. Green, and the opposite of BC's
answer. That is the inversion #3062 closed for the three permission-slice files.

## The count, re-measured

The issue reports 212 name-only lookups measured at `80abc76a` with a per-statement regex. I
re-measured on `be7a4de0` with an argument-level parser (`types:` named argument, or a
positional `Type[]`, counts as an explicit signature; `StackFrame.GetMethod()` is excluded):

```
Type.GetMethod(...) call sites in AlRunner/**/*.cs   324
  ... passing an explicit signature                  123
  ... resolving by NAME ALONE                        201
        of which target a runner-owned type          114
        of which could reach a Microsoft type         87
```

**114 of the 201 cannot misresolve because of anything Microsoft does.** They are the Cecil
rewriter and the hook installers resolving the runner's *own* replacement methods —
`typeof(AlRunner.BcRuntime).GetMethod(nameof(...))` and friends, 103 written that way directly
and 11 through a local assigned `typeof(<a runner type>)`. Microsoft cannot ship an overload
into `AlRunner.BcRuntime`. Converting them would buy nothing, so the guard added here does not
ask for it.

That leaves **87** that could reach a Microsoft-shipped type. This PR converts 11 of them; 76
remain, ratcheted.

## How many can misresolve *today*: zero, and that is not the same as "not a problem"

I loaded the shipped assemblies and counted declarations per (type, method name) for every
lookup whose target resolves statically to a named BC type — 43 pairs plus the 11 converted
here, on Ncl/Types from `27.5.46862.48827` and `28.1.49838.50621`. Every one has **exactly one
declaration**, so this PR changes nothing on any BC build the runner has seen.

Microsoft does add overloads to types the runner reflects on, though. Same two builds,
same scan: `Microsoft.Dynamics.Nav.Runtime.NavReport.Execute` went from **4 declarations to
6** — `Execute(String, String)` and `Execute(String, String, NavRecordRef)` are new in 28.1.
The runner does not look that one up by name; the point is that the event is ordinary. The day
it lands on a name the runner does look up, this is the difference between a named refusal and
a green `asserterror`.

## The fix

`BcShape.FindMethod` / `BcShape.RequiredMethod` in `AlRunner/Infrastructure/`: enumerate
candidates instead of asking the binder to choose, so every outcome is the method, `null`, or a
`BcShapeGapException` naming the member. This generalises `RequireBcMethod`, which #3053 wrote
as a private helper inside `RecordPatches.PermissionMetadataPopulator.cs`.

**Absence still answers `null`, deliberately** — see the sibling-issue section below.

Converted, all against BC types and all reachable from AL:

| file | lookups | BC member |
|---|---|---|
| `NavRecordRefPatches.cs` | 6 | `TreeHandler.SetReferenceTarget` |
| `AsyncStateMachineSpike.cs` | 1 | `TreeHandler.SetReferenceTarget` |
| `RecordPatches.QueryProjection.cs` | 1 | `FilterExpression.Evaluate` |
| `RecordPatches.FieldFindIntercept.cs` | 1 | `DataAccess.InnerFindAsync` |
| `RecordPatches.FieldVirtualTable.cs` | 1 | `FieldDataProvider.GetFieldRecordBuffer` |
| `BlobStoreIsolationPatches.cs` | 2 | `MutableRecordBuffer.GetChangedFieldValue`, `NCLMetaTable.GetFieldByIndex` |

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes, and it is the bulk of the change. The
   seven `SetReferenceTarget` sites are not seven separate bugs — they are one shape repeated,
   found by grepping for the shape rather than the symptom.
2. **Does a sibling make the same assumption?** This is the sharpest finding. At every one of
   those seven sites the **`GetReferenceTarget` lookup two or three lines above already passes
   `Type.EmptyTypes`**, and the `SetReferenceTarget` next to it does not. One path had the
   guard, its sibling did not, seven times over, and nobody had noticed.
3. **Do two paths writing the same state keep the same invariant?** The two BLOB-store lookups
   in `BlobStoreIsolationPatches.cs` bracket one write path and only one of them was on my
   original list; the repo-wide guard found the second, which is what the guard is for.

Deliberately left out, and why:

- **`MethodScopePatches.TryRemapToALException`** and **`ResolveGetMethodScopeFlags`** — both
  sit inside a local `catch { }` / `catch { /* leave flags at default */ }`, so a named refusal
  raised there would be swallowed by the call site itself. Converting them needs that catch
  reconsidered, which is a behaviour change on a different axis. They stay in the ratchet.
- **`FlowFieldPatches.cs`** (6 remaining) — another agent holds that file in this session.
- The 76 remaining sites generally — #3069 asks for them file by file so the guard never has
  to be weakened, and the ratchet below is what makes that safe.

## Relationship to #3051 — same seam, different mechanism, and this PR does not resolve it

The two issues look like one and are not:

| | #3051 | #3069 (this) |
|---|---|---|
| what BC did | a member **moved** | a member **multiplied** |
| what reflection returns | a silent `null` | a throw of the wrong type |
| where it lands | `NullReferenceException` at the first *use*, naming nothing | `AmbiguousMatchException` at the lookup, naming nothing |
| how you find it | search for `!` | `!` never appears — search for the missing signature |

They share only the seam that absorbs both. `BcShape.FindMethod` therefore still answers `null`
on absence **on purpose**: converting that half here would change what every call site does on
a build where the member is gone, and would tangle the two issues into one un-splittable
change. A dedicated arm pins it —
`EvaluateFilterExpression_KeepsItsOwnRefusal_WhenEvaluateIsGoneEntirely` asserts the call site's
own `InvalidOperationException` still comes out, and explicitly not a shape gap.

So #3051 stays open and unassigned, and this PR neither resolves nor duplicates it. The shared
helper does make its remaining work smaller: a file being converted for #3051 can pick up the
`RequiredMethod` overload in the same edit.

## RED → GREEN, measured

RED, with the production call sites unconverted and the test file exactly as it is here:

```
AssertError_TearsThrough_InsteadOfSwallowingTheAmbiguousEvaluate
    Assert.Throws() Failure: No exception was thrown
    Expected: typeof(AlRunner.Infrastructure.BcShapeGapException)

TryFunction_CannotTrapTheRefusal_OnTheCorrectedEvaluatePath
    Assert.Throws() Failure: Exception type was not an exact match
    Actual: typeof(System.Reflection.AmbiguousMatchException)
```

The first **is** the inversion: the seam swallowed the throw and returned normally, which in AL
is an `asserterror` that passed. The second is a control — `NavApplicationObjectBase_TryInvoke`
already refused it, so only `asserterror` inverts.

GREEN: `20/20` in the class.

Both arms drive **production** `RecordPatches.EvaluateFilterExpression` — the runner's driver
for BC's `FilterExpression.Evaluate(NavValue, ISortingRulesProvider)`, i.e. AL query filtering —
with the two reflection statics it reads injected for one call and restored in a `finally`.
Nothing in production became settable for the test.

The tests discriminate rather than merely pass:

- a **single-`Evaluate`** fake drives the same production path through to the end and returns
  the fake's own answer, asserted for `true` **and** `false`, so neither a helper that always
  refuses nor one that answers a constant survives;
- pinned-signature selection is asserted **both ways** — asked for the two-parameter overload it
  returns that one, asked for the one-parameter overload it returns the other — so "hand back
  the first candidate" fails;
- the `new`-hidden same-signature case asserts what `Type.GetMethod` does first (returns the
  most-derived, silently) and then that the helper refuses, so the one place this is *stricter*
  than what it replaced is measured rather than claimed.

## The guard, and why it is a ratchet

`NameOnlyBcTypedMethodLookups_HaveNotIncreased` scans `AlRunner/` repo-wide and holds the total
at 76. It cannot rise without failing, so a new name-only BC-typed lookup anywhere is caught the
moment it is written; the per-file breakdown prints on any mismatch.

Runner ownership is decided by reflecting over this assembly's own type names, not by a string
prefix, and it follows a local assigned `typeof(<a runner type>)` — which is how the Cecil files
spell it, and without it 11 sites would be counted that no BC change can affect.

Three things stop it passing vacuously: a floor on production sources scanned (a narrowed scan
reports a small number that reads as progress), an explicit zero for the six converted files, and
a control arm asserting the scan still **finds** a BC-typed lookup in `BcRuntime.cs` and still
ignores the entirely runner-owned `NclCecilRewrite.Dispatch.cs`.

Falsifiability measured rather than asserted: adding one name-only lookup to
`TelemetryPatches.cs` took the count to 77 against the recorded 76 and the guard failed. Its
honest limit, stated in the file: it pins the total, not the per-file distribution, so moving a
site between files nets to zero.

## Does this assert anything about BC's behaviour?

**No** — so the proving test stays in `AlRunner.Tests/` and no corpus PR is needed. The claim is
about the runner's own reflection layer and its `asserterror` seam: which exception type reaches
AL when the runner cannot resolve a member. BC has no opinion on that. The BC *facts* used here
(`SetReferenceTarget(ITreeObject)`, the per-name declaration counts, `NavReport.Execute` 4→6)
come from shipped IL, read with the decompiler and by loading the assemblies, which is the
evidence a service tier could not give a different answer to.

## What I ran

- `dotnet test AlRunner.Tests --filter FullyQualifiedName~BcShapeMethodLookupTests` — 20/20.
- `dotnet test AlRunner.Tests --filter "…BcShape|…ShapeGap|…PermissionMetadata|…BlobStoreIsolation|…RecordRef"` — 211 passed, 0 failed, 31 skipped (the skips need a BC engine fixture and are pre-existing).
- `dotnet test AlRunner.Tests --filter "…DocsCount|…RunnerShapeGapClaim|…BcShapeGapConvention|…Docs"` — 96/96, so the documented shape-gap guard count did not move.
- **al-language corpus**, BC 28.1.49838.53910, all three apps: **2684/2684 pass**, 0 fail, 0 error.
- **runner-extras**: **304/304 pass**.

I did not run the full `AlRunner.Tests` suite locally; CI runs it on each of the 8 legs.

---
*Opened by an agent (`impl-16`) acting on the account holder's behalf.*

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
