### PR TITLE
fix(bundle): collect a multi-app bundle's manifests from the suites, at any depth

### DIFF
--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -718,12 +718,20 @@ jobs:
       - name: Run cold-cache binary smoke test
         run: |
           set +e
-          # Point at the canonical corpus app (a real bundle with a proper app.json +
-          # dependency closure), NOT the submodule ROOT — the root sweeps multiple apps
-          # and fixtures into one malformed bundle with no Base Application reference, so
-          # any cross-app tableextension there fails to resolve (AL0185/AL0247) and aborts
-          # the whole emit. The crash-gate purpose (cold Cecil rewrite + emit + run) is
-          # fully exercised by the canonical app. --strict tolerated codes are 0|1|2 below.
+          # Point at the canonical corpus app, NOT the submodule ROOT — one app is all the
+          # crash gate (cold Cecil rewrite + emit + run) needs, and the root would pay for
+          # compiling all three corpus apps to prove the same thing.
+          #
+          # This comment used to give a different reason: that the root "sweeps multiple
+          # apps and fixtures into one malformed bundle with no Base Application
+          # reference", so cross-app references failed AL0185/AL0247 and aborted the emit.
+          # That was a runner defect, not a property of the tree, and #2996 fixed it —
+          # CollectBundleManifests only scanned the bundle root's DIRECT children for
+          # app.json while the corpus apps sit one level further down, so the bundle
+          # resolved no dependencies at all. The submodule root now runs as one bundle and
+          # produces the same result as passing the three apps separately. Staying on the
+          # canonical app here is a cost choice, not a workaround.
+          # --strict tolerated codes are 0|1|2 below.
           #
           # --auto-provision: as of #1678 the platform-app R2R gate also scans the target
           # bundle's OWN .alpackages (not just the home-rooted default caches) — and the

--- a/AlRunner.Tests/NestedBundleManifestDiscoveryTests.cs
+++ b/AlRunner.Tests/NestedBundleManifestDiscoveryTests.cs
@@ -1,0 +1,193 @@
+// NestedBundleManifestDiscoveryTests — issue #2996.
+//
+// RUNNER-MECHANISM test. Two functions decide what a multi-app bundle is, and they used to
+// disagree about how deep an app may sit:
+//
+//   • ProgramSupport.EnumerateSuites recurses to ARBITRARY depth, stopping on each branch at
+//     the first directory that LooksLikeSuite. It decides which apps become AppGroups and get
+//     compiled.
+//   • ProgramSupport.CollectBundleManifests scanned only the bundle root's DIRECT children.
+//     It decides whose app.json contributes to the bundle's dependency closure — the
+//     `application` / `platform` / Microsoft roots that give every module in the bundle the
+//     platform symbol set.
+//
+// For a tree one level deeper than the scan — the al-language corpus root, whose three apps
+// live at <root>/tests/<app>/app.json — the first function found three apps to compile and
+// the second found no manifests at all. Program.cs then printed
+// "WARN: no app.json under <root> — skipping dep loading" and compiled all three apps with
+// NO Microsoft closure, so every reference to a platform object failed AL0185:
+// `Table 'Object Metadata' is missing`, `Table 'AllObj' is missing`, `Codeunit 'Temp Blob'
+// is missing`, `Table 'Customer' is missing`. 60 objects were dropped from the Cloud app and
+// the OnPrem app emitted zero. Measured on BC 28.1 against corpus master 861a566:
+//
+//     al-runner <corpus>          -> compile-fail, 0 tests   (apps at depth 2)
+//     al-runner <corpus>/tests    -> 2698 tests, 2696 pass    (apps at depth 1)
+//
+// Same apps, same runner, same caches; only the nesting differs. The reported symptom looked
+// like a Target=OnPrem / Scope=OnPrem resolution problem, and is not — nothing in the failure
+// depends on the manifest's `target`.
+//
+// The fix makes CollectBundleManifests derive its set FROM EnumerateSuites, so the two can no
+// longer drift: the manifests are exactly the app.json files of the suites that will be
+// compiled. That invariant is what NestedManifests_AreExactlyTheSuiteManifests pins — a test
+// asserting only "depth 2 works" would pass again if someone hard-coded a second level.
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class NestedBundleManifestDiscoveryTests : IDisposable
+{
+    private readonly string _root;
+
+    public NestedBundleManifestDiscoveryTests()
+    {
+        _root = TestScratch.Dir("al-runner-nested-bundle-manifests");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    /// <summary>
+    /// Writes a minimal app manifest at <paramref name="relativeDir"/> and one .al file next to
+    /// it, so the directory also satisfies EnumerateSuites' flat-bundle shape. No "application"
+    /// property — see .claude/rules/no-base-app-in-csharp-tests.md; nothing here compiles AL.
+    /// </summary>
+    private string WriteApp(string relativeDir, string name, string? platform = null)
+    {
+        var dir = Path.Combine(_root, relativeDir.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(dir);
+        var platformProp = platform == null ? "" : $@", ""platform"": ""{platform}""";
+        File.WriteAllText(
+            Path.Combine(dir, "app.json"),
+            $@"{{ ""id"": ""{DeterministicId(name)}"", ""name"": ""{name}"", ""publisher"": ""P"", ""version"": ""1.0.0.0""{platformProp} }}");
+        File.WriteAllText(Path.Combine(dir, "Dummy.al"), "codeunit 50000 Dummy { }");
+        return Path.Combine(Path.GetFullPath(dir), "app.json");
+    }
+
+    private static string DeterministicId(string name)
+    {
+        var bytes = System.Security.Cryptography.MD5.HashData(System.Text.Encoding.UTF8.GetBytes(name));
+        return new Guid(bytes).ToString();
+    }
+
+    // ---------------------------------------------------------------------------------
+    // The defect: a manifest two levels below the bundle root.
+    // ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void ManifestsTwoLevelsDown_AreCollected()
+    {
+        // The al-language corpus shape: <root>/tests/<app>/app.json. <root>/tests holds no
+        // app.json, no src/ and no test/, so it is a plain container the walk must pass through.
+        var cloud = WriteApp("tests/al-language", "AL Language Coverage Tests");
+        var onprem = WriteApp("tests/al-language-onprem", "AL Language Coverage Tests (OnPrem)");
+
+        var manifests = ProgramSupport.CollectBundleManifests(
+            bucketRoot: null, bundleAbs: _root);
+
+        // RED before the fix: Directory.EnumerateDirectories(_root) sees only "tests", which has
+        // no app.json of its own, so this list was EMPTY and the bundle resolved no dependencies.
+        Assert.Equal(2, manifests.Count);
+        Assert.Contains(cloud, manifests);
+        Assert.Contains(onprem, manifests);
+    }
+
+    [Fact]
+    public void ManifestsThreeLevelsDown_AreCollected()
+    {
+        // Nothing about the fix may be specific to "one more level" — the walk is unbounded,
+        // exactly as EnumerateSuites' is.
+        var deep = WriteApp("a/b/c/app-deep", "Deep App");
+
+        var manifests = ProgramSupport.CollectBundleManifests(
+            bucketRoot: null, bundleAbs: _root);
+
+        Assert.Equal(new[] { deep }, manifests);
+    }
+
+    // ---------------------------------------------------------------------------------
+    // The invariant the fix installs: manifests == the suites' own manifests.
+    // ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void NestedManifests_AreExactlyTheSuiteManifests()
+    {
+        // Mixed depths in one tree, which is the case a hard-coded depth limit gets wrong.
+        WriteApp("shallow-app", "Shallow App");
+        WriteApp("tests/nested-app", "Nested App");
+        WriteApp("a/b/deep-app", "Deep App");
+
+        var expected = ProgramSupport.EnumerateSuites(_root)
+            .Select(s => Path.Combine(s, "app.json"))
+            .Where(File.Exists)
+            .OrderBy(p => p, StringComparer.Ordinal)
+            .ToList();
+
+        var manifests = ProgramSupport.CollectBundleManifests(
+            bucketRoot: null, bundleAbs: _root);
+
+        Assert.Equal(3, expected.Count);           // the fixture really does have three apps
+        Assert.Equal(expected, manifests);          // and the closure covers exactly them
+    }
+
+    // ---------------------------------------------------------------------------------
+    // Negative directions — the fix must not turn into "every app.json in the tree".
+    // ---------------------------------------------------------------------------------
+
+    [Fact]
+    public void ManifestInsideASuite_IsNotCollected()
+    {
+        // A vendored/extracted package under an app that IS a suite. EnumerateSuites stops
+        // descending at the first suite on a branch, so the inner manifest is part of that
+        // suite's own directory, never a bundle member. Recursing over every app.json in the
+        // tree instead of over the suites would wrongly pull this one into the closure.
+        var outer = WriteApp("app-a", "App A");
+        WriteApp("app-a/.alpackages/Vendored", "Vendored Package");
+
+        var manifests = ProgramSupport.CollectBundleManifests(
+            bucketRoot: null, bundleAbs: _root);
+
+        Assert.Equal(new[] { outer }, manifests);
+    }
+
+    [Fact]
+    public void BucketRootWithItsOwnManifest_StillWinsAlone()
+    {
+        // A bundle root that IS one app speaks for the whole bucket: exactly its own manifest,
+        // and the children below it are its sub-directories, not sibling apps.
+        var rootManifest = WriteApp(".", "Root App");
+        WriteApp("tests/child", "Child App");
+
+        var manifests = ProgramSupport.CollectBundleManifests(
+            bucketRoot: _root, bundleAbs: _root);
+
+        Assert.Equal(new[] { rootManifest }, manifests);
+    }
+
+    [Fact]
+    public void MissingBundleDirectory_YieldsNoManifests()
+    {
+        var absent = Path.Combine(_root, "does-not-exist");
+
+        Assert.Empty(ProgramSupport.CollectBundleManifests(bucketRoot: null, bundleAbs: absent));
+    }
+
+    [Fact]
+    public void NestedSuiteDeclaringANewerBc_IsDroppedFromTheClosure()
+    {
+        // BcFloorGate has to keep working through the deeper walk: one suite's unreachable
+        // Microsoft floor must not join a bundle-wide union and abort every sibling. 999.0 is
+        // above any BC that could be selected, so this gates deterministically.
+        var ok = WriteApp("tests/app-ok", "App Ok");
+        WriteApp("tests/app-future", "App Future", platform: "999.0.0.0");
+
+        AlRunner.BcFloorGate.ResetForTests();
+        var manifests = ProgramSupport.CollectBundleManifests(
+            bucketRoot: null, bundleAbs: _root);
+
+        Assert.Equal(new[] { ok }, manifests);
+    }
+}

--- a/AlRunner/ProgramSupport/Dependencies.cs
+++ b/AlRunner/ProgramSupport/Dependencies.cs
@@ -20,14 +20,32 @@ internal static partial class ProgramSupport
     /// STANDALONE passed, because then FindBucketRoot landed on a directory that does have an
     /// app.json. Union the children instead: their manifests are where the `application` /
     /// `platform` roots are declared.
+    ///
+    /// #2996: "the children" means the SUITES, at whatever depth they sit — not the bundle
+    /// root's direct sub-directories, which is what this used to scan. EnumerateSuites recurses
+    /// until it finds a suite on each branch and is what decides which apps become AppGroups
+    /// and get compiled; a one-level scan here disagreed with it for any tree one level deeper.
+    /// The al-language corpus root is exactly that shape — its three apps live at
+    /// &lt;root&gt;/tests/&lt;app&gt;/app.json — so pointing the runner at it found three apps to
+    /// compile and ZERO manifests to resolve dependencies from. Program.cs printed
+    /// "WARN: no app.json under &lt;root&gt; — skipping dep loading" and compiled all three with no
+    /// Microsoft closure at all: AL0185 on `Table 'Object Metadata'`, `Table 'AllObj'`,
+    /// `Codeunit 'Temp Blob'`, `Table 'Customer'`, 60 objects dropped from one app and zero
+    /// emitted from another. Running the same three apps from &lt;root&gt;/tests — one level
+    /// shallower, nothing else changed — gave 2698 tests. Deriving this set FROM EnumerateSuites
+    /// keeps the two from drifting again: the manifests are exactly the app.json files of the
+    /// suites that are about to be compiled.
     /// </summary>
     internal static List<string> CollectBundleManifests(string? bucketRoot, string bundleAbs)
     {
         if (bucketRoot != null && File.Exists(Path.Combine(bucketRoot, "app.json")))
             return new List<string> { Path.Combine(bucketRoot, "app.json") };
         if (!Directory.Exists(bundleAbs)) return new List<string>();
-        // Direct children only — that is the shape EnumerateSuites recognises, and it keeps
-        // the scan away from app.json files buried inside extracted .app packages.
+        // The suites this bundle will actually compile — the same enumeration BuildAppGroups
+        // consumes, so the dependency closure covers exactly the apps in the bundle and no
+        // others. EnumerateSuites stops descending at the first suite on each branch, which is
+        // what keeps the scan away from app.json files buried inside a suite's own extracted
+        // .app packages (the property the old direct-children scan was relied on for).
         //
         // Suites declaring a newer BC than the one under test are dropped HERE, before their
         // dependencies join the union. The union is bundle-wide, so one such suite's unmet
@@ -38,9 +56,10 @@ internal static partial class ProgramSupport
         // Deliberately NOT applied to the bucket-root branch above: a root manifest speaks for
         // the whole bucket, so honoring a floor there would silently skip everything under it.
         // That case should stay a loud failure.
-        var children = Directory.EnumerateDirectories(bundleAbs)
+        var children = EnumerateSuites(bundleAbs)
             .Select(d => Path.Combine(d, "app.json"))
             .Where(File.Exists)
+            .Distinct(StringComparer.Ordinal)
             .OrderBy(p => p, StringComparer.Ordinal)
             .ToList();
 


### PR DESCRIPTION
Closes #2996

## What AL0185 was actually rejecting

Nothing to do with `Scope = OnPrem`, and nothing to do with the manifest's `target`.

Two functions decide what a multi-app bundle is, and they disagreed about how deep an app may sit:

- `ProgramSupport.EnumerateSuites` recurses to arbitrary depth, stopping on each branch at the first directory that `LooksLikeSuite`. It decides which apps become `AppGroup`s and get compiled.
- `ProgramSupport.CollectBundleManifests` scanned only the bundle root's **direct children** for `app.json`. It decides whose manifest contributes to the bundle's dependency closure — the `application` / `platform` / Microsoft roots that give every module in the bundle its platform symbol set.

The al-language corpus root is one level deeper than that scan: its three apps live at `<root>/tests/<app>/app.json`, and `<root>/tests` holds no manifest of its own. So the first function found three apps to compile and the second found **zero** manifests. The run printed

```
[<corpus>] WARN: no app.json under <corpus> — skipping dep loading
```

and then compiled all three apps against no Microsoft closure at all. Every platform reference failed `AL0185`: `Table 'Object Metadata'`, `Table 'AllObj'`, `Table 'Published Application'`, `Codeunit 'Temp Blob'`, `Table 'Customer'`, `Codeunit 'Assert'`. `Object Metadata` is `Scope = OnPrem`, which is why the symptom read as a target/scope problem; `AllObj` and `Customer` are not, which is what gives it away.

## The measurement

Corpus at `master` `861a566` (which now carries `tests/al-language-onprem`), BC 28.1, same runner build and same package caches for every row. The corpus tree was copied to a path with no `app.json` in any ancestor — `FindBucketRoot` walks up, and a stray manifest above the bundle silently becomes the bucket root.

| invocation | apps' depth below the root | result |
|---|---|---|
| `al-runner <corpus>` (before) | 2 | compile-fail, **0 tests**, 60 objects dropped from the Cloud app, OnPrem app emitted zero |
| `al-runner <corpus>/tests` (before) | 1 | 2698 tests, 2696 pass |
| `al-runner <corpus>` (after) | 2 | **2698 tests, 2696 pass** |

The two remaining failures are identical in every passing row (`PlainModal_HasNoBuiltInCancelAction`, `ErrorInQueryClosePage_ArrivesAsAnUnhandledMessage`) and are corpus-ahead-of-pin drift, not this change. The point of the third row is that it now matches the second exactly.

## The fix

`CollectBundleManifests` derives its set **from `EnumerateSuites`** instead of re-implementing a shallower walk, so the two cannot drift again: the manifests are exactly the `app.json` files of the suites that are about to be compiled. `EnumerateSuites` stops descending at the first suite on each branch, which preserves the property the direct-children scan was relied on for — an `app.json` buried inside a suite's own extracted `.app` packages is still not swept in.

`BcFloorGate` filtering and the bucket-root branch are unchanged.

## Fixing the shape, not just the reported line

**Is the same wrong pattern at another call site?** No — `CollectBundleManifests` is the single implementation, and all three consumers were wrong together and are fixed together: the `bundle-manifests` stage in `Program.cs`, `GetOrderedDepIds` (which keys the AL-output cache on the resolved closure, so a bundle that resolved nothing was also keying on nothing), and the `ScanManifestDependencyRoots` provisioning pre-scan. I searched for other bundle-rooted one-level directory scans (`Directory.EnumerateDirectories` over a bundle/bucket root); this was the only one.

**Does a sibling function make the same assumption?** `SiblingCompile.BuildSiblingSourceDeps` also scans one level — `Directory.EnumerateDirectories(parent)` of each bundle root. I checked it and it is a different relationship, not the same bug: it serves the invocation where each app is passed as its own bundle root and it looks for apps sitting *next to* that app, which are at the same level by definition. There is no second enumeration it has to agree with, and the separate-roots invocation demonstrably worked throughout.

**Do two code paths write the same state with different invariants?** That is precisely this defect: the compile set and the dependency set were computed by two independent walks with different depth rules and nothing tying them together. `NestedManifests_AreExactlyTheSuiteManifests` pins the invariant directly, so a test asserting only "depth 2 works" cannot be satisfied by hard-coding a second level.

## The issue's second item does not survive measurement

The issue also reports that "one app group's compile error takes the whole bundle down" — the Cloud app losing 55 objects when bundled with the failing OnPrem app. That was a misattribution. Both apps lost the same platform closure independently; the Cloud app was not collateral damage from its sibling.

I measured the underlying claim two ways rather than assume it:

- **One object in one app fails to compile** (a deliberately broken codeunit added to the OnPrem app): only that object is dropped, the bucket is reported `partial`, the missing codeunit is named, exit 3 — and **2679 tests from all three apps still ran**.
- **A whole app group emits zero** (a two-app bundle where one app's only object cannot compile): the good app's test still ran, `EMIT-ZERO` was reported as a suite error, the bucket was `partial` rather than `compile-fail`, and the run said plainly that the missing tests are "MISSING from this run, not passing".

So a compile failure in one app group degrades loudly and does not zero its siblings. There is no separate defect here and I have not filed a follow-up issue for one, because there is no evidence of it — the `Buckets: compile-fail: 1 / Tests: 0` in the original report came from every group failing at once.

## Tests

- `AlRunner.Tests/NestedBundleManifestDiscoveryTests.cs`, 7 tests. **RED: 4 failed, 3 passed** against unmodified `Dependencies.cs`; **GREEN: 7 passed**. The 3 that passed RED are the negative guards, and they are the point — `ManifestInsideASuite_IsNotCollected`, `BucketRootWithItsOwnManifest_StillWinsAlone` and `MissingBundleDirectory_YieldsNoManifests` fail if the fix turns into "every `app.json` anywhere in the tree". `NestedSuiteDeclaringANewerBc_IsDroppedFromTheClosure` proves `BcFloorGate` still runs through the deeper walk.
- `dotnet test AlRunner.Tests --filter "…Bundle|…Suite|…BcFloor|…Manifest|…FindBucketRoot|…Dependenc"` — 455 passed, 0 failed, 7 skipped.
- `tests/runner-extras` as one bundle — 55 suites, **304/304 pass**, exit 0. Every one of its apps sits at depth 1, so the set of collected manifests is unchanged there by construction; this run confirms it.

## Not included

No user-facing behavior changed beyond a supported invocation now giving the answer it always should have, so `README.md`, `PrintGuide()`, `docs/limitations.md` and `docs/scope.md` are untouched. I did correct the cold-cache smoke step's comment in `bc-tests.yml`, which explained its choice of target by asserting the defect this PR removes; the step's wiring is unchanged and still points at the canonical app, now for the reason that actually remains (cost). The submodule pin is untouched.

---
*Opened by an automated agent (`impl-15`) acting on the account holder's behalf.*

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
