### PR TITLE
fix(seeding): refuse a system-table column the seeder cannot find, instead of skipping it

### DIFF
--- a/AlRunner.Tests/FieldTriggerShapeGapCallSiteTests.cs
+++ b/AlRunner.Tests/FieldTriggerShapeGapCallSiteTests.cs
@@ -995,9 +995,13 @@ public sealed class FieldTriggerShapeGapCallSiteTests : IDisposable
 
         var total = runnerShapeGapSites + installGapSites;
 
-        Assert.Equal(9, runnerShapeGapSites);
+        // 9 -> 10 / 12 -> 13 (#3015): SeededRowColumns.ThrowIfAnyColumnCouldNotBeWritten. One
+        // call site, not three, because the Company, Published Application and Installed
+        // Application seeders all build their rows through it. Both numbers were READ OUT of
+        // this test's own failure message, not arrived at by arithmetic.
+        Assert.Equal(10, runnerShapeGapSites);
         Assert.Equal(3, installGapSites);
-        Assert.Equal(12, total);
+        Assert.Equal(13, total);
 
         var limitations = File.ReadAllText(Path.Combine(RepoRoot, "docs", "limitations.md"));
         Assert.Contains($"{total} further guards raise `RunnerOutOfScopeException`", limitations,

--- a/AlRunner.Tests/SeededRowColumnsTests.cs
+++ b/AlRunner.Tests/SeededRowColumnsTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using AlRunner.Infrastructure;
 using AlRunner.Patches;
 using Xunit;
 
@@ -41,7 +42,7 @@ public sealed class SeededRowColumnsTests
         var byName = new Dictionary<string, (int FieldNo, int Slot)>(StringComparer.OrdinalIgnoreCase);
         foreach (var f in fields) byName[f.Name] = (f.FieldNo, f.Slot);
         return new SeededRowColumns<(int FieldNo, int Slot)>(
-            tableLabel: "Published Application (2000000206)",
+            tableLabel: "Published Application (system table 2000000206)",
             fieldByName: byName,
             slotOf: f => f.Slot,
             describeField: f => $"{f.FieldNo}:?",
@@ -96,17 +97,27 @@ public sealed class SeededRowColumnsTests
         Assert.False(ledger.TryResolve("Runtime Package ID", out _, out var slot));
         Assert.Equal(-1, slot);
 
-        var ex = Assert.Throws<InvalidOperationException>(
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
             () => ledger.ThrowIfAnyColumnCouldNotBeWritten());
 
         // The message has to be actionable on its own: which table, which column, why, and
         // what the metatable actually states instead.
-        Assert.Contains("Published Application (2000000206)", ex.Message);
+        Assert.Contains("Published Application (system table 2000000206)", ex.Message);
         Assert.Contains("\"Runtime Package ID\"", ex.Message);
         Assert.Contains("no field of that name", ex.Message);
         Assert.Contains("3:?", ex.Message);
         Assert.Contains("5:?", ex.Message);
         Assert.Contains("3015", ex.Message);
+
+        // The anchor is load-bearing, not cosmetic. ApplicationObjectBasePatches
+        // .IsPermanentOutOfScope lets an AL [TryFunction] absorb a refusal into `false` unless
+        // the reason STARTS WITH "not-yet-implemented" — so a seeding gap without it would be
+        // swallowed back into the silent default this whole change removes.
+        Assert.StartsWith("not-yet-implemented — seeded-system-table-row:", ex.Reason,
+            StringComparison.Ordinal);
+        Assert.Equal("Published Application (system table 2000000206)", ex.Api);
+        Assert.EndsWith(" — see docs/limitations.md#runtime-shape-gaps", ex.Message,
+            StringComparison.Ordinal);
     }
 
     [Fact]
@@ -120,7 +131,7 @@ public sealed class SeededRowColumnsTests
         Assert.False(ledger.TryResolve("Tenant ID", out _, out var slot));
         Assert.Equal(-1, slot);
 
-        var ex = Assert.Throws<InvalidOperationException>(
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
             () => ledger.ThrowIfAnyColumnCouldNotBeWritten());
         Assert.Contains("\"Tenant ID\"", ex.Message);
         Assert.Contains("slot 7", ex.Message);
@@ -141,7 +152,7 @@ public sealed class SeededRowColumnsTests
         Assert.True(ledger.TryResolve("ID", out _, out _));
 
         Assert.Equal(2, ledger.Unwritable.Count);
-        var ex = Assert.Throws<InvalidOperationException>(
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
             () => ledger.ThrowIfAnyColumnCouldNotBeWritten());
         Assert.Contains("\"Version Major\"", ex.Message);
         Assert.Contains("\"Version Minor\"", ex.Message);
@@ -168,6 +179,14 @@ public sealed class SeededRowColumnsTests
     /// This is the link a unit test over the ledger alone cannot make: neither seeder can be
     /// driven from a test, because both need a real BC <c>NCLMetaTable</c> and a live
     /// DataAccessSource, and neither can be made to lose a column.
+    ///
+    /// IT IS A SOURCE-TEXT GREP AND IT PROVES LESS THAN IT LOOKS: a comment naming the type
+    /// satisfies the first assertion, and the second only rules out the one silent-skip line
+    /// #3015 was filed against, spelled exactly that way. It is a supplementary guard against
+    /// the wiring being reverted, not evidence that the wiring is correct. What actually proves
+    /// that is the runner-extras suite — with this change a required column that does not
+    /// resolve aborts the run, so 306 green AL tests against a real BC metatable are the
+    /// end-to-end half.
     /// </summary>
     [Theory]
     [InlineData("RecordPatches.PublishedApplicationSystemTable.cs")]

--- a/AlRunner.Tests/SeededRowColumnsTests.cs
+++ b/AlRunner.Tests/SeededRowColumnsTests.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// AlRunner#3015 — a system-table seeder must not silently skip a column it cannot find.
+///
+/// The runner seeds rows a real service tier would have written at publish / company-create
+/// time: Company (2000000006), Published Application (2000000206) and Installed Application
+/// (2000000212). Each locates its columns by NAME off the metatable, which is right. What was
+/// wrong was the failure branch — both the Published Application and the Company seeder's
+/// local <c>Set</c> helper read
+///
+///     if (!fieldByName.TryGetValue(fieldName, out var f)) return;
+///
+/// so a renamed column left BC's own default in the slot, the row was still inserted, and
+/// still found by its key. `Reten. Pol. Allowed Tbl. Impl.ModuleOwnsTable` then compares
+/// `AllObj."App Runtime Package ID"` against `PublishedApplication."Runtime Package ID"`,
+/// the comparison fails for every app, and BC LOGS A WARNING rather than raising — so the
+/// failure is invisible from AL too. That is the silent default `.claude/rules/loud-failures.md`
+/// forbids, on the one column whose whole purpose is to be compared.
+///
+/// The third sibling seeder already got this right: <c>FieldByNameOnUser</c> in
+/// RecordPatches.UserSystemTable.cs throws, citing the same rule. These tests pin the shared
+/// mechanism that brings the other two up to it.
+/// </summary>
+public sealed class SeededRowColumnsTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    /// <summary>A stand-in metatable: column name → (field no, value-slot index).</summary>
+    private static SeededRowColumns<(int FieldNo, int Slot)> Ledger(
+        int slotCount, params (string Name, int FieldNo, int Slot)[] fields)
+    {
+        var byName = new Dictionary<string, (int FieldNo, int Slot)>(StringComparer.OrdinalIgnoreCase);
+        foreach (var f in fields) byName[f.Name] = (f.FieldNo, f.Slot);
+        return new SeededRowColumns<(int FieldNo, int Slot)>(
+            tableLabel: "Published Application (2000000206)",
+            fieldByName: byName,
+            slotOf: f => f.Slot,
+            describeField: f => $"{f.FieldNo}:?",
+            slotCount: slotCount);
+    }
+
+    // ---------------------------------------------------------------- positive
+
+    [Fact]
+    public void AResolvedColumnHandsBackItsOwnFieldAndSlot()
+    {
+        // Not "did not throw": the caller has to be handed the SLOT it writes into and the
+        // FIELD it types the value with, or the value lands in the wrong column.
+        var ledger = Ledger(
+            slotCount: 4,
+            ("ID", 3, 2), ("Runtime Package ID", 1, 0), ("Name", 4, 3));
+
+        Assert.True(ledger.TryResolve("Runtime Package ID", out var field, out var slot));
+        Assert.Equal(1, field.FieldNo);
+        Assert.Equal(0, slot);
+
+        Assert.True(ledger.TryResolve("Name", out field, out slot));
+        Assert.Equal(4, field.FieldNo);
+        Assert.Equal(3, slot);
+
+        ledger.ThrowIfAnyColumnCouldNotBeWritten();   // every column resolved — nothing to report
+        Assert.Empty(ledger.Unwritable);
+    }
+
+    [Fact]
+    public void ColumnNamesAreMatchedTheWayTheMetatableDictionaryMatchesThem()
+    {
+        // The production dictionary is OrdinalIgnoreCase, and BC's own casing for these
+        // columns has moved before ("Id" vs "ID" on Company). Resolution must not depend on
+        // the literal the seeder happens to spell.
+        var ledger = Ledger(slotCount: 2, ("Runtime Package ID", 1, 0));
+
+        Assert.True(ledger.TryResolve("runtime package id", out _, out var slot));
+        Assert.Equal(0, slot);
+        Assert.Empty(ledger.Unwritable);
+    }
+
+    // ---------------------------------------------------------------- negative
+
+    [Fact]
+    public void AColumnTheTableDoesNotHaveIsRefusedByName()
+    {
+        // The #3015 case exactly: BC renames "Runtime Package ID" and the seeder's write
+        // evaporates.
+        var ledger = Ledger(slotCount: 3, ("ID", 3, 0), ("Name", 4, 1), ("Publisher", 5, 2));
+
+        Assert.False(ledger.TryResolve("Runtime Package ID", out _, out var slot));
+        Assert.Equal(-1, slot);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ledger.ThrowIfAnyColumnCouldNotBeWritten());
+
+        // The message has to be actionable on its own: which table, which column, why, and
+        // what the metatable actually states instead.
+        Assert.Contains("Published Application (2000000206)", ex.Message);
+        Assert.Contains("\"Runtime Package ID\"", ex.Message);
+        Assert.Contains("no field of that name", ex.Message);
+        Assert.Contains("3:?", ex.Message);
+        Assert.Contains("5:?", ex.Message);
+        Assert.Contains("3015", ex.Message);
+    }
+
+    [Fact]
+    public void AColumnWhoseSlotIsOutsideTheRowIsRefusedToo()
+    {
+        // The second silent branch the seeders carried: the name resolved, but FieldIndex
+        // pointed outside the value array, so `Set` returned and the column stayed default.
+        var ledger = Ledger(slotCount: 2, ("ID", 3, 0), ("Tenant ID", 12, 7));
+
+        Assert.True(ledger.TryResolve("ID", out _, out _));
+        Assert.False(ledger.TryResolve("Tenant ID", out _, out var slot));
+        Assert.Equal(-1, slot);
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ledger.ThrowIfAnyColumnCouldNotBeWritten());
+        Assert.Contains("\"Tenant ID\"", ex.Message);
+        Assert.Contains("slot 7", ex.Message);
+        Assert.Contains("2 value slot", ex.Message);
+        // The one that DID resolve must not be blamed.
+        Assert.DoesNotContain("\"ID\"", ex.Message);
+    }
+
+    [Fact]
+    public void EveryUnwritableColumnIsNamedNotOnlyTheFirst()
+    {
+        // A shape change usually moves more than one column. Reporting only the first turns
+        // one fix into several rounds of trial and error.
+        var ledger = Ledger(slotCount: 2, ("ID", 3, 0));
+
+        Assert.False(ledger.TryResolve("Version Major", out _, out _));
+        Assert.False(ledger.TryResolve("Version Minor", out _, out _));
+        Assert.True(ledger.TryResolve("ID", out _, out _));
+
+        Assert.Equal(2, ledger.Unwritable.Count);
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ledger.ThrowIfAnyColumnCouldNotBeWritten());
+        Assert.Contains("\"Version Major\"", ex.Message);
+        Assert.Contains("\"Version Minor\"", ex.Message);
+        Assert.Contains("2 of the column", ex.Message);
+    }
+
+    [Fact]
+    public void AskingTwiceForTheSameMissingColumnReportsItOnce()
+    {
+        // The Published Application seeder runs this per app, and a repeated name would
+        // otherwise multiply the message by the number of loaded modules.
+        var ledger = Ledger(slotCount: 1, ("ID", 3, 0));
+
+        Assert.False(ledger.TryResolve("Package ID", out _, out _));
+        Assert.False(ledger.TryResolve("Package ID", out _, out _));
+
+        Assert.Equal(1, ledger.Unwritable.Count);
+    }
+
+    // ------------------------------------------------- the production call sites
+
+    /// <summary>
+    /// The mechanism above is only worth anything if the seeders actually go through it.
+    /// This is the link a unit test over the ledger alone cannot make: neither seeder can be
+    /// driven from a test, because both need a real BC <c>NCLMetaTable</c> and a live
+    /// DataAccessSource, and neither can be made to lose a column.
+    /// </summary>
+    [Theory]
+    [InlineData("RecordPatches.PublishedApplicationSystemTable.cs")]
+    [InlineData("RecordPatches.CompanySystemTable.cs")]
+    public void EverySeederResolvesItsColumnsThroughTheCheckedPath(string fileName)
+    {
+        var path = Path.Combine(RepoRoot, "AlRunner", "Patches", fileName);
+        Assert.True(File.Exists(path), path);
+        var source = File.ReadAllText(path);
+
+        Assert.Contains("SeededRowColumns", source);
+
+        // The exact silent-skip shape #3015 was filed against, in either seeder's local
+        // `Set` helper. It resolved a column name and, on failure, simply returned.
+        Assert.DoesNotContain("if (!fieldByName.TryGetValue(fieldName, out var f)) return;", source);
+    }
+}

--- a/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
+++ b/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
@@ -341,7 +341,21 @@ public sealed class VirtualTableRefusalClaimTests
         // is on main -- run the test, read the "Actual:" value out of the failure message, and
         // write that. An arithmetic guess here is how the assertion silently stopped meaning
         // what it says once before.
-        Assert.Equal(71, total);
+
+        // 71 -> 72 (#3015): the AllObj populator gained one more. It resolves its columns by
+        // field NUMBER rather than by name, and a number matching nothing was simply never
+        // written — the row still inserted, the column kept BC's own default, and
+        // `AllObj."App Runtime Package ID" <> PublishedApplication."Runtime Package ID"` then
+        // declined for every app while BC logged a warning rather than raising. #3004 shipped
+        // 6/7 for the two package columns, which are 60/61, and the stamp did nothing; it was
+        // caught by checking, not by a failure. Raised once per process from
+        // PopulateAllObjVirtualTable, the ONE call site holding the genuine AllObj metatable —
+        // see EnsureAllObjColumnsExist for why it cannot be raised from
+        // EnsureAllObjSharedReflection.
+        //
+        // Per the note above: this number was READ OUT of the test's own failure message after
+        // rebasing onto #3117, not arrived at by adding 1 to what was on main.
+        Assert.Equal(72, total);
     }
 
 

--- a/AlRunner/Patches/RecordPatches.AllObjVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AllObjVirtualTable.cs
@@ -601,6 +601,52 @@ public static partial class RecordPatches
             binder: null, types: new[] { tNavValueMetadata, typeof(bool) }, modifiers: null)
             ?? throw new InvalidOperationException("NavValue.GetDefaultNavValue(INavValueMetadata,bool) not found");
 
+        EnsureAllObjColumnsExist(allObjMetaTable);
+
         _aovReflectionReady = true;
+    }
+
+    /// <summary>
+    /// The same defect class as AlRunner#3015, at the one seeder that resolves its columns by
+    /// field NUMBER rather than by name. <see cref="InsertAllObjRow"/> switches on
+    /// <c>field.FieldNo</c> while walking the metatable, so a number that matches nothing is
+    /// simply never written: the row still inserts, the column keeps BC's own default, and the
+    /// ownership comparison
+    /// <c>AllObj."App Runtime Package ID" &lt;&gt; PublishedApplication."Runtime Package ID"</c>
+    /// then declines for every app while BC logs a warning rather than raising.
+    ///
+    /// That is not hypothetical here — #3004 shipped 6/7 for the two package columns, which are
+    /// 60/61, and the stamp silently did nothing. It was found by checking, not by a failure.
+    ///
+    /// Checked once per process off the same metatable <see cref="EnsureAllObjReflection"/>
+    /// already holds, never per row: AllObj is seeded one row per known AL object, thousands of
+    /// them, and a per-row check would be paid thousands of times to answer a question about
+    /// the table.
+    /// </summary>
+    private static void EnsureAllObjColumnsExist(NCLMetaTable allObjMetaTable)
+    {
+        var byNo = new HashSet<int>();
+        foreach (var f in GetAllFields(allObjMetaTable) ?? Enumerable.Empty<NCLMetaField>())
+            byNo.Add(f.FieldNo);
+
+        var required = new (int No, string Name)[]
+        {
+            (AllObjFieldObjectType, "Object Type"),
+            (AllObjFieldObjectId, "Object ID"),
+            (AllObjFieldObjectName, "Object Name"),
+            (AllObjFieldAppPackageId, "App Package ID"),
+            (AllObjFieldAppRuntimePackageId, "App Runtime Package ID"),
+        };
+        var missing = required.Where(r => !byNo.Contains(r.No)).ToList();
+        if (missing.Count == 0) return;
+
+        throw AllObjShapeGap(
+            "AllObj metatable has no field "
+            + string.Join(", ", missing.Select(m => $"{m.No} (\"{m.Name}\")"))
+            + " — every AllObj row would be written with BC's own default in that column and "
+            + "every later read would look correct; module-ownership checks would then decline "
+            + $"for every app without raising [tableId={allObjMetaTable.TableId} "
+            + $"name='{allObjMetaTable.TableName}' "
+            + $"fields={string.Join("/", byNo.OrderBy(n => n))}] — see AlRunner#3015");
     }
 }

--- a/AlRunner/Patches/RecordPatches.AllObjVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AllObjVirtualTable.cs
@@ -87,6 +87,10 @@ public static partial class RecordPatches
     private const int AllObjFieldAppRuntimePackageId = 61;
 
     private static bool _aovReflectionReady;
+    // #3015 — AllObj's own columns, checked once per process. Separate from
+    // _aovReflectionReady on purpose: that flag guards work driven by ANY populator's
+    // metatable, this one guards a question that can only be asked of AllObj's.
+    private static bool _aovColumnsChecked;
     // Shared by AllObj, Report Metadata and Report Layout List; see SystemPopulatedValues.
     private static SystemPopulatedValues? _aovSystemValues;
     private static ConstructorInfo? _aovCtorReadOnlyBuffer;    // ReadOnlyRecordBuffer(NCLMetaApplicationObject, NavValue[])
@@ -117,6 +121,7 @@ public static partial class RecordPatches
     /// </summary>
     private static void PopulateAllObjVirtualTable(object dataAccess, NCLMetaTable allObjMetaTable)
     {
+        EnsureAllObjColumnsExist(allObjMetaTable);
         EnsureAllObjReflection(allObjMetaTable);
         EnsureDataAccessProviderReflection(dataAccess);
 
@@ -546,11 +551,30 @@ public static partial class RecordPatches
         return new string(buf[..n]);
     }
 
-    private static void EnsureAllObjReflection(NCLMetaTable allObjMetaTable)
+    /// <summary>
+    /// Bind the shared runtime-engine reflection every virtual-table populator uses. Despite
+    /// the "AllObj" in the name this is NOT AllObj-specific and NOT AllObj-only: eighteen
+    /// populators call it and seventeen of them hand it their OWN metatable — Windows Language,
+    /// Time Zone, Feature Key, Codeunit Metadata and the rest. Only
+    /// <see cref="PopulateAllObjVirtualTable"/> passes AllObj's.
+    ///
+    /// So <paramref name="anyMetaTable"/> is used for exactly one thing: reaching the Ncl
+    /// assembly it was loaded from. Nothing here may read its table id, its fields or its
+    /// options, and NOTHING THAT VALIDATES A PARTICULAR TABLE'S SHAPE BELONGS IN THIS METHOD.
+    /// #3015 put AllObj's field-number check here and it refused Windows Language (2000000045)
+    /// for not having AllObj's columns — a loud WRONG refusal on a surface that works, which is
+    /// the same defect class as the silent wrong answer that change exists to remove. Worse, it
+    /// threw before <c>_aovReflectionReady</c> was set, so which populator reached this method
+    /// first decided whether the process worked at all; six of eight CI legs passed on that
+    /// ordering luck. The check now lives in
+    /// <see cref="EnsureAllObjColumnsExist(NCLMetaTable)"/>, called from the one site that
+    /// holds the genuine metatable.
+    /// </summary>
+    private static void EnsureAllObjReflection(NCLMetaTable anyMetaTable)
     {
         if (_aovReflectionReady) return;
 
-        var nclAsm = allObjMetaTable.GetType().Assembly;
+        var nclAsm = anyMetaTable.GetType().Assembly;
         const string rt = "Microsoft.Dynamics.Nav.Runtime.";
 
         _aovSystemValues = SystemPopulatedValues.Bind(nclAsm);
@@ -601,8 +625,6 @@ public static partial class RecordPatches
             binder: null, types: new[] { tNavValueMetadata, typeof(bool) }, modifiers: null)
             ?? throw new InvalidOperationException("NavValue.GetDefaultNavValue(INavValueMetadata,bool) not found");
 
-        EnsureAllObjColumnsExist(allObjMetaTable);
-
         _aovReflectionReady = true;
     }
 
@@ -618,13 +640,31 @@ public static partial class RecordPatches
     /// That is not hypothetical here — #3004 shipped 6/7 for the two package columns, which are
     /// 60/61, and the stamp silently did nothing. It was found by checking, not by a failure.
     ///
-    /// Checked once per process off the same metatable <see cref="EnsureAllObjReflection"/>
-    /// already holds, never per row: AllObj is seeded one row per known AL object, thousands of
-    /// them, and a per-row check would be paid thousands of times to answer a question about
-    /// the table.
+    /// CALLED FROM <see cref="PopulateAllObjVirtualTable"/> AND NOWHERE ELSE — that is the one
+    /// call site holding the genuine AllObj metatable. The first version of this lived in
+    /// <see cref="EnsureAllObjReflection"/>, whose parameter is named for AllObj and is not
+    /// AllObj for seventeen of its eighteen callers; it duly refused Windows Language
+    /// (2000000045) for not declaring AllObj's columns. The table-id check below exists so that
+    /// a future re-wiring says "wrong table" instead of inventing a shape gap in a table that
+    /// has none.
+    ///
+    /// Checked once per process, never per row: AllObj is seeded one row per known AL object,
+    /// thousands of them, and a per-row check would be paid thousands of times over to answer a
+    /// question about the table.
     /// </summary>
     private static void EnsureAllObjColumnsExist(NCLMetaTable allObjMetaTable)
     {
+        if (_aovColumnsChecked) return;
+
+        // A claim about the RUNNER's own wiring, not about BC's metadata, so it is deliberately
+        // not an AllObjShapeGap: a shape gap says "this BC artifact is not the shape we were
+        // written against", which would be a lie about whatever table was actually passed.
+        if (allObjMetaTable.TableId != AllObjVirtualTableId)
+            throw new InvalidOperationException(
+                $"EnsureAllObjColumnsExist was handed table {allObjMetaTable.TableId} "
+                + $"'{allObjMetaTable.TableName}', not AllObj ({AllObjVirtualTableId}). It may only "
+                + "be called from PopulateAllObjVirtualTable — see AlRunner#3015.");
+
         var byNo = new HashSet<int>();
         foreach (var f in GetAllFields(allObjMetaTable) ?? Enumerable.Empty<NCLMetaField>())
             byNo.Add(f.FieldNo);
@@ -638,7 +678,13 @@ public static partial class RecordPatches
             (AllObjFieldAppRuntimePackageId, "App Runtime Package ID"),
         };
         var missing = required.Where(r => !byNo.Contains(r.No)).ToList();
-        if (missing.Count == 0) return;
+        if (missing.Count == 0)
+        {
+            // Set AFTER the work, never before it, so a refusal keeps refusing rather than
+            // latching a "checked" that was never reached.
+            _aovColumnsChecked = true;
+            return;
+        }
 
         throw AllObjShapeGap(
             "AllObj metatable has no field "

--- a/AlRunner/Patches/RecordPatches.CompanySystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.CompanySystemTable.cs
@@ -160,14 +160,25 @@ public static partial class RecordPatches
         // does not resolve is raised before the Insert.
         //
         // WHERE THAT RAISE GOES, and why it is not the refusal the Published Application
-        // seeder makes: this row is seeded per app group, AFTER the dep+company baseline cache
-        // block in TestExecutor, so it is NOT part of the snapshot persisted to disk. The
-        // caller's existing catch therefore reaches stderr on EVERY run rather than once, on
-        // the single run that would have poisoned a cache. Reporting is enough here for
-        // exactly that reason and for no other; the dependency Published Application rows,
-        // which are inside the persisted MISS branch, refuse instead.
+        // seeder makes. Two reasons, and the second is the stronger one:
+        //
+        //   1. This row is seeded per app group, AFTER the dep+company baseline cache block in
+        //      TestExecutor (line 606 — the block ends at 594), so it is NOT part of the
+        //      snapshot persisted to disk. The caller's existing catch therefore reaches stderr
+        //      on EVERY run, rather than once on the single run that would have poisoned a
+        //      cache and then never again.
+        //
+        //   2. Stderr is not the only signal, and it is not the one that stops the run. A
+        //      refused row is a row that was never inserted, so Company.Get(CompanyName())
+        //      raises for a company every other surface reports as existing and the tests that
+        //      read it go RED — which is how #2329 presented in the first place. That is worth
+        //      naming, because Console.Error on its own has repeatedly not been a sufficient
+        //      signal in this repository.
+        //
+        // The dependency Published Application rows are inside the persisted MISS branch and
+        // have neither property, so they refuse.
         var columns = new SeededRowColumns<NCLMetaField>(
-            $"Company ({CompanySystemTableId})", fieldByName,
+            $"{meta.TableName} (system table {CompanySystemTableId})", fieldByName,
             slotOf: f => f.FieldIndex,
             describeField: f => $"{f.FieldNo}:{f.FieldName}",
             slotCount: values.Length);

--- a/AlRunner/Patches/RecordPatches.CompanySystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.CompanySystemTable.cs
@@ -29,7 +29,9 @@
 //
 //   Every other column gets BC's own NavValue.GetDefaultNavValue, and every field is located
 //   by NAME off the metatable at runtime — never by a hardcoded ordinal, so a BC metadata
-//   change says so instead of silently writing a value into the wrong slot.
+//   change says so instead of silently writing a value into the wrong slot. Since #3015 a name
+//   that does not resolve says so too: only "Name" used to be checked, and a renamed
+//   "Display Name" or "Id" kept its default on a row that still inserted and still Get()s.
 //
 //   It runs once per bundle, immediately before CaptureInstallBaseline(), so the row is part
 //   of the committed baseline every test is restored to and survives the per-codeunit restore.
@@ -152,32 +154,45 @@ public static partial class RecordPatches
             values[idx] = f.EmptyValue;
         }
 
+        // #3015 — this used to hard-check only "Name" and skip every other column in silence,
+        // so a renamed "Display Name" or "Id" produced a row that was inserted, found by its
+        // primary key, and wrong. Each Set() below now declares its column required; one that
+        // does not resolve is raised before the Insert.
+        //
+        // WHERE THAT RAISE GOES, and why it is not the refusal the Published Application
+        // seeder makes: this row is seeded per app group, AFTER the dep+company baseline cache
+        // block in TestExecutor, so it is NOT part of the snapshot persisted to disk. The
+        // caller's existing catch therefore reaches stderr on EVERY run rather than once, on
+        // the single run that would have poisoned a cache. Reporting is enough here for
+        // exactly that reason and for no other; the dependency Published Application rows,
+        // which are inside the persisted MISS branch, refuse instead.
+        var columns = new SeededRowColumns<NCLMetaField>(
+            $"Company ({CompanySystemTableId})", fieldByName,
+            slotOf: f => f.FieldIndex,
+            describeField: f => $"{f.FieldNo}:{f.FieldName}",
+            slotCount: values.Length);
+
         // BC's own value factory, so each column is typed by its own field metadata rather
-        // than by a type this file picked. A field the metatable does not have is skipped:
-        // "Name" is the only one whose absence is a shape change worth failing on.
+        // than by a type this file picked.
         void Set(string fieldName, object? value)
         {
+            // Resolve FIRST, then look at the value: companyId is genuinely nullable (it is
+            // read by reflection off the skeleton NavCompany), and checking the value first
+            // would let a renamed "Id" hide behind a run where there was nothing to write.
+            if (!columns.TryResolve(fieldName, out var f, out var idx)) return;
+            // A null is the absence of a VALUE, not a metadata mismatch: BC's own EmptyValue,
+            // already in the slot, is the faithful answer.
             if (value == null) return;
-            if (!fieldByName.TryGetValue(fieldName, out var f)) return;
-            var idx = f.FieldIndex;
-            if (idx < 0 || idx >= values.Length) return;
             values[idx] = value is NavValue already
                 ? already
                 : NavValue.CreateNavValueFromObject(f, value);
         }
 
-        // "Name" is the primary key and the value AL's CompanyName() returns, so it is the
-        // one field whose absence means this is not the Company table we think it is.
-        if (!fieldByName.ContainsKey("Name"))
-            throw new InvalidOperationException(
-                $"Company metatable ({CompanySystemTableId}) has no \"Name\" field "
-                + $"[fields={string.Join("/", fieldByName.Values.Select(f => $"{f.FieldNo}:{f.FieldName}"))}] "
-                + "— BC metadata shape changed");
-
         Set("Name", companyName);
         Set("Display Name", companyName);
         Set("Evaluation Company", false);
         Set("Id", companyId);
+        columns.ThrowIfAnyColumnCouldNotBeWritten();
 
         var perTable = _dataAccessByTable.GetValue(source,
             static _ => new System.Collections.Concurrent.ConcurrentDictionary<int, object>());

--- a/AlRunner/Patches/RecordPatches.PublishedApplicationSystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.PublishedApplicationSystemTable.cs
@@ -75,7 +75,11 @@
 //
 //   Every other column keeps NCLMetaField.EmptyValue, BC's own per-field default — nothing is
 //   invented. Fields are located by NAME off the metatable at runtime, so a BC metadata change
-//   says so instead of writing into the wrong slot.
+//   says so instead of writing into the wrong slot — and, since #3015, a name that does not
+//   resolve REFUSES rather than skipping the write. Only "ID" used to be checked that way;
+//   every other column, "Runtime Package ID" and the four version parts included, silently
+//   kept its default, which is the one shape that makes a wrong row look like a right one at
+//   every later read. SeededRowColumns.cs carries the full argument.
 //
 //   It runs once per bundle, immediately before CaptureInstallBaseline(), for the same reason
 //   the Company row does: seeded after the baseline, the first codeunit boundary drops it.
@@ -269,9 +273,9 @@ public static partial class RecordPatches
 
         InsertApplicationTableRow(
             PublishedApplicationSystemTableId, meta, source,
-            // "ID" is the column BC filters on to find an app at all. Its absence means this is
-            // not the Published Application table this file was written against.
-            requiredFieldName: "ID",
+            // Every column below is required, "ID" no more than the rest (#3015). It is the
+            // one BC filters on to find an app at all, but a missing "Runtime Package ID" or
+            // "Version Major" is just as fatal and used to be skipped in silence.
             fill: Set =>
             {
                 Set("ID", module.AppId);
@@ -303,8 +307,6 @@ public static partial class RecordPatches
     {
         InsertApplicationTableRow(
             InstalledApplicationSystemTableId, meta, source,
-            // The whole point of the row: the column the FlowField matches on.
-            requiredFieldName: "Runtime Package ID",
             fill: Set =>
             {
                 Set("Runtime Package ID", AppPackageIdentity.RuntimePackageIdFor(module.AppId));
@@ -321,10 +323,14 @@ public static partial class RecordPatches
     /// metatable at runtime, so a BC metadata change says so instead of writing into the wrong
     /// slot, and every column the caller does not set keeps <c>NCLMetaField.EmptyValue</c> —
     /// BC's own per-field default. Nothing is invented.
+    ///
+    /// A column <paramref name="fill"/> asks for and the metatable does not have raises rather
+    /// than being skipped (#3015): the row would otherwise be inserted with BC's default in
+    /// that column, still be found by its key, and read correct forever after.
     /// </summary>
     private static void InsertApplicationTableRow(
         int tableId, NCLMetaTable meta, object source,
-        string requiredFieldName, Action<Action<string, object?>> fill)
+        Action<Action<string, object?>> fill)
     {
         var fieldByName = new Dictionary<string, NCLMetaField>(StringComparer.OrdinalIgnoreCase);
         for (var fi = 0; fi < meta.FieldCount; fi++)
@@ -332,12 +338,6 @@ public static partial class RecordPatches
             var f = meta.GetFieldByIndex(fi);
             fieldByName[f.FieldName] = f;
         }
-
-        if (!fieldByName.ContainsKey(requiredFieldName))
-            throw new InvalidOperationException(
-                $"Table {tableId} metatable has no \"{requiredFieldName}\" field "
-                + $"[fields={string.Join("/", fieldByName.Values.Select(f => $"{f.FieldNo}:{f.FieldName}"))}] "
-                + "— BC metadata shape changed");
 
         var values = new NavValue[meta.FieldCount];
         for (var fi = 0; fi < meta.FieldCount; fi++)
@@ -348,16 +348,30 @@ public static partial class RecordPatches
             values[idx] = f.EmptyValue;
         }
 
+        // #3015 — every Set() below is a declaration that the column is REQUIRED, so there is
+        // no second list to keep in step with the writes and no "only ID is hard-checked"
+        // asymmetry. A column that does not resolve is recorded and raised before the Insert,
+        // never skipped: see SeededRowColumns.cs for why refusing beats reporting on this path.
+        var columns = new SeededRowColumns<NCLMetaField>(
+            $"table {tableId} \"{meta.TableName}\"", fieldByName,
+            slotOf: f => f.FieldIndex,
+            describeField: f => $"{f.FieldNo}:{f.FieldName}",
+            slotCount: values.Length);
+
         void Set(string fieldName, object? value)
         {
+            // Resolve FIRST, then look at the value. A column whose value happens to be null
+            // on this run must still be proved to exist, or a rename hides behind a manifest
+            // that simply did not state a Name or a Publisher.
+            if (!columns.TryResolve(fieldName, out var f, out var idx)) return;
+            // A null is the absence of a VALUE, not a metadata mismatch: BC's own EmptyValue,
+            // already in the slot, is the faithful answer and nothing is invented.
             if (value == null) return;
-            if (!fieldByName.TryGetValue(fieldName, out var f)) return;
-            var idx = f.FieldIndex;
-            if (idx < 0 || idx >= values.Length) return;
             values[idx] = value is NavValue already ? already : NavValue.CreateNavValueFromObject(f, value);
         }
 
         fill(Set);
+        columns.ThrowIfAnyColumnCouldNotBeWritten();
 
         var perTable = _dataAccessByTable.GetValue(source,
             static _ => new System.Collections.Concurrent.ConcurrentDictionary<int, object>());

--- a/AlRunner/Patches/RecordPatches.PublishedApplicationSystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.PublishedApplicationSystemTable.cs
@@ -353,7 +353,10 @@ public static partial class RecordPatches
         // asymmetry. A column that does not resolve is recorded and raised before the Insert,
         // never skipped: see SeededRowColumns.cs for why refusing beats reporting on this path.
         var columns = new SeededRowColumns<NCLMetaField>(
-            $"table {tableId} \"{meta.TableName}\"", fieldByName,
+            // "<Name> (system table <id>)" — the api half of the refusal, and it may not
+            // contain " — ": OutOfScopeMessage.TryParse cuts the api from the reason at the
+            // first one (#2945).
+            $"{meta.TableName} (system table {tableId})", fieldByName,
             slotOf: f => f.FieldIndex,
             describeField: f => $"{f.FieldNo}:{f.FieldName}",
             slotCount: values.Length);

--- a/AlRunner/Patches/RunnerShapeGaps.cs
+++ b/AlRunner/Patches/RunnerShapeGaps.cs
@@ -240,4 +240,21 @@ internal static class RunnerShapeGap
     /// <summary>The runner could not construct the report object to run it.</summary>
     internal static RunnerOutOfScopeException ReportConstruction(string api, string detail)
         => Build(api, "report-construction", detail, RuntimeDoc);
+
+    /// <summary>
+    /// A column one of the runner's seeded system-table rows is built from is not a field of
+    /// that table's metatable, or resolves outside the row (#3015). Company (2000000006),
+    /// Published Application (2000000206) and Installed Application (2000000212) are rows a
+    /// real service tier writes before any AL runs; the runner writes them from its own state.
+    /// A column it cannot write used to be skipped, leaving BC's own default on a row that was
+    /// still inserted and still found by its key.
+    ///
+    /// This is `not-yet-implemented` rather than a `bc-shape-gap:`, deliberately. The read
+    /// SUCCEEDED — the metatable was there and answered, it simply states no field of that
+    /// name — and BcShapeGapException.cs's own "DO NOT RAISE IT" list names exactly that case
+    /// ("a metatable genuinely has no field 3") as an answer about the artifact rather than a
+    /// failed read of BC's layout.
+    /// </summary>
+    internal static RunnerOutOfScopeException SeededSystemTableRow(string api, string detail)
+        => Build(api, "seeded-system-table-row", detail, RuntimeDoc);
 }

--- a/AlRunner/Patches/SeededRowColumns.cs
+++ b/AlRunner/Patches/SeededRowColumns.cs
@@ -53,10 +53,39 @@
 //   actually states — so a BC rename is a one-line fix rather than an investigation. There is
 //   no correctness-preserving alternative, because the row would otherwise be inserted wrong.
 //
-//   The Company seeder is the one deliberate exception, and its caller — not this type — makes
-//   it: that row is seeded per app group OUTSIDE the persisted cache, so its existing
-//   catch-and-report reaches stderr on every run rather than once. See
-//   RecordPatches.CompanySystemTable.cs.
+// WHICH REFUSAL, AND WHY NOT A BARE InvalidOperationException
+//   RunnerShapeGap.SeededSystemTableRow — RunnerOutOfScopeException carrying the
+//   `not-yet-implemented` anchor, the same type FieldByNameOnUser raises for the same question
+//   on the User row, and routed through the one factory family that documents and counts these
+//   guards (docs/limitations.md#runtime-shape-gaps). The anchor matters at runtime, not only in
+//   prose: ApplicationObjectBasePatches.IsPermanentOutOfScope lets an AL [TryFunction] absorb a
+//   refusal into `false` UNLESS the reason starts with "not-yet-implemented", and a seeding gap
+//   absorbed into `false` is the silent default again.
+//
+//   NOT BcShapeGapException, though it is the type built for "BC's metadata is not the shape we
+//   were written against". Its own header draws the line at whether the runner OBTAINED the
+//   information, and puts this case on the do-not-raise side by name: "a metatable genuinely
+//   has no field 3" is an ANSWER about the artifact, not a failed read of BC's layout. The
+//   metatable was there and it answered.
+//
+//   BE PRECISE ABOUT WHAT THE CACHE ARGUMENT DECIDES, because it does not decide every site.
+//   Published Application is seeded in TWO halves: the dependency rows inside the persisted
+//   MISS branch (TestExecutor.cs:573), and the bundle's own row outside it (TestExecutor.cs:637,
+//   after CaptureInstallBaselineSnapshot and the disk write). Only the first half is subject to
+//   the cache argument. Both refuse anyway, and that is deliberate rather than an oversight in
+//   the rule: splitting the policy WITHIN one table by which half seeded the row would let the
+//   same table abort on one path and continue short on the other, in the same run, for the same
+//   metadata change. One table, one answer.
+//
+//   The Company seeder is the one place that reports instead, and its caller — not this type —
+//   makes that choice. Two things hold it up. Its row is seeded per app group outside the
+//   persisted cache (TestExecutor.cs:606), so the stderr line fires on every run rather than
+//   once on the run that poisons a cache. And, more to the point, stderr is not the only signal
+//   there: a refused Company row is a row that was never inserted, so
+//   `Company.Get(CompanyName())` raises for a company every other surface reports as existing
+//   and the tests that read it go RED. That is the mechanism, and it is worth stating because
+//   Console.Error on its own has repeatedly not been a sufficient signal in this repository.
+//   See RecordPatches.CompanySystemTable.cs.
 //
 // WHY IT IS GENERIC
 //   So it can be unit-tested. The real callers instantiate it over BC's NCLMetaField, which a
@@ -153,17 +182,21 @@ internal sealed class SeededRowColumns<TField>
     /// Raise if any column the caller asked to write could not be. Call after the row is
     /// filled and BEFORE it is inserted — a row that reaches the provider incomplete is
     /// indistinguishable from a correct one at every later read.
+    ///
+    /// Raises <c>RunnerShapeGap.SeededSystemTableRow</c>; see this file's header for why that
+    /// type and that anchor rather than a bare exception or a <c>bc-shape-gap:</c>.
     /// </summary>
     internal void ThrowIfAnyColumnCouldNotBeWritten()
     {
         if (_unwritable.Count == 0) return;
 
-        throw new InvalidOperationException(
-            $"[SeededRow] {_tableLabel}: could not write {_unwritable.Count} of the column(s) this "
-            + "row is built from — " + string.Join("; ", _unwritable)
-            + ". BC metadata shape changed; the row would otherwise be inserted with BC's own "
-            + "default in that column and every later read would look correct. Metatable states "
+        throw RunnerShapeGap.SeededSystemTableRow(
+            _tableLabel,
+            $"could not write {_unwritable.Count} of the column(s) this row is built from — "
+            + string.Join("; ", _unwritable)
+            + ". The row would otherwise be inserted with BC's own default in that column, still "
+            + "be found by its key, and read correct at every later read. Metatable states "
             + $"[fields={string.Join("/", _fieldByName.Values.Select(_describeField))}] "
-            + "— see AlRunner#3015.");
+            + "— see AlRunner#3015");
     }
 }

--- a/AlRunner/Patches/SeededRowColumns.cs
+++ b/AlRunner/Patches/SeededRowColumns.cs
@@ -1,0 +1,169 @@
+// SeededRowColumns — the columns one seeded system-table row intends to write, and whether
+// each one could actually be written (AlRunner#3015).
+//
+// WHY THIS EXISTS
+//   The runner seeds rows a real service tier would have written before any AL ran: Company
+//   (2000000006) at company-create time, Published Application (2000000206) and Installed
+//   Application (2000000212) at publish time. Each seeder locates its columns by NAME off the
+//   metatable rather than by a hardcoded ordinal, which is the right choice — an ordinal
+//   writes into whatever column happens to sit at that index once BC's metadata moves.
+//
+//   What was wrong was the failure branch. Both seeders' local `Set` helper read:
+//
+//       void Set(string fieldName, object? value)
+//       {
+//           if (value == null) return;
+//           if (!fieldByName.TryGetValue(fieldName, out var f)) return;   // <-- silent
+//           var idx = f.FieldIndex;
+//           if (idx < 0 || idx >= values.Length) return;                  // <-- silent
+//           ...
+//       }
+//
+//   Exactly one column per table was hard-checked (Published Application's "ID", Company's
+//   "Name"). Every other column was best-effort: a rename left NCLMetaField.EmptyValue in the
+//   slot, the row was STILL inserted and STILL found by its key, and nothing said so.
+//
+//   That matters most on "Runtime Package ID", because it exists to be compared.
+//   Reten. Pol. Allowed Tbl. Impl.ModuleOwnsTable:
+//
+//       if AllObj."App Runtime Package ID" <> PublishedApplication."Runtime Package ID" then
+//           exit(false);
+//
+//   With the column left at its default the comparison declines for EVERY app, and BC logs a
+//   warning rather than raising — so the failure is invisible from AL as well as from the
+//   runner. The four "Version …" columns are worse still: BC SetRanges on them before it ever
+//   reads the package id, so a rename there makes the FindFirst miss and the app simply looks
+//   unpublished. Both are the silent default .claude/rules/loud-failures.md forbids.
+//
+//   The third sibling seeder already got this right — FieldByNameOnUser in
+//   RecordPatches.UserSystemTable.cs throws, citing that same rule. Two paths writing the same
+//   kind of state, one with the guard and one without, is a defect whether or not anyone has
+//   hit it yet. This type is the shared guard.
+//
+// WHY IT THROWS RATHER THAN REPORTING
+//   The Published Application DEPENDENCY rows are seeded inside the install-baseline cache
+//   MISS branch, and that snapshot is PERSISTED to disk. A stderr line there fires once, on
+//   the run that bakes the wrong row set into the cache, and there is nothing at all to read
+//   on every later run that restores it as a HIT. Refusing is the only report that survives a
+//   cache. RecordPatches.PublishedApplicationSystemTable.cs already makes exactly this
+//   argument for a partial row set; an incomplete row is the same failure one level down.
+//
+//   The cost of refusing is bounded and the message pays it back: it names the table, every
+//   column that could not be written, why each one could not, and the field list the metatable
+//   actually states — so a BC rename is a one-line fix rather than an investigation. There is
+//   no correctness-preserving alternative, because the row would otherwise be inserted wrong.
+//
+//   The Company seeder is the one deliberate exception, and its caller — not this type — makes
+//   it: that row is seeded per app group OUTSIDE the persisted cache, so its existing
+//   catch-and-report reaches stderr on every run rather than once. See
+//   RecordPatches.CompanySystemTable.cs.
+//
+// WHY IT IS GENERIC
+//   So it can be unit-tested. The real callers instantiate it over BC's NCLMetaField, which a
+//   test cannot construct and cannot make lose a column; SeededRowColumnsTests instantiates it
+//   over a plain tuple and drives the identical resolution, range check, aggregation and
+//   message construction.
+using System.Diagnostics.CodeAnalysis;
+
+namespace AlRunner.Patches;
+
+/// <summary>
+/// Resolves the columns of one seeded system-table row by name, and refuses to let a column
+/// the caller asked to write go unwritten. See this file's header for why (AlRunner#3015).
+/// </summary>
+/// <typeparam name="TField">
+/// The metatable's field type — <c>NCLMetaField</c> in production, a plain tuple in tests.
+/// </typeparam>
+internal sealed class SeededRowColumns<TField>
+{
+    private readonly string _tableLabel;
+    private readonly IReadOnlyDictionary<string, TField> _fieldByName;
+    private readonly Func<TField, int> _slotOf;
+    private readonly Func<TField, string> _describeField;
+    private readonly int _slotCount;
+    private readonly List<string> _unwritable = new();
+
+    /// <param name="tableLabel">How the table is named in the refusal, e.g. <c>Company (2000000006)</c>.</param>
+    /// <param name="fieldByName">
+    /// The metatable's fields keyed by name. Supply the SAME dictionary the caller writes
+    /// values through, and with the same comparer — the seeders use OrdinalIgnoreCase — so a
+    /// column resolves here exactly when it resolves there.
+    /// </param>
+    /// <param name="slotOf">The field's index into the row's value array (<c>FieldIndex</c>).</param>
+    /// <param name="describeField">How one field appears in the refusal's field list.</param>
+    /// <param name="slotCount">How many value slots the row has.</param>
+    internal SeededRowColumns(
+        string tableLabel,
+        IReadOnlyDictionary<string, TField> fieldByName,
+        Func<TField, int> slotOf,
+        Func<TField, string> describeField,
+        int slotCount)
+    {
+        _tableLabel = tableLabel;
+        _fieldByName = fieldByName;
+        _slotOf = slotOf;
+        _describeField = describeField;
+        _slotCount = slotCount;
+    }
+
+    /// <summary>Every column asked for that could not be written, with the reason, in ask order.</summary>
+    internal IReadOnlyList<string> Unwritable => _unwritable;
+
+    /// <summary>
+    /// Resolve <paramref name="fieldName"/> to the metatable field and the value slot it
+    /// writes into. False means the column cannot be written, and RECORDS that fact — the
+    /// caller may return, because <see cref="ThrowIfAnyColumnCouldNotBeWritten"/> will raise
+    /// it before the row is inserted. Every call is a declaration that the column is required:
+    /// there is no separate list to keep in step with the writes.
+    /// </summary>
+    internal bool TryResolve(string fieldName, [MaybeNullWhen(false)] out TField field, out int slot)
+    {
+        if (!_fieldByName.TryGetValue(fieldName, out field))
+        {
+            Record(fieldName, "no field of that name");
+            field = default;
+            slot = -1;
+            return false;
+        }
+
+        slot = _slotOf(field);
+        if (slot < 0 || slot >= _slotCount)
+        {
+            Record(fieldName,
+                $"resolves to slot {slot}, outside this row's {_slotCount} value slot(s)");
+            field = default;
+            slot = -1;
+            return false;
+        }
+
+        return true;
+    }
+
+    private void Record(string fieldName, string why)
+    {
+        var entry = $"\"{fieldName}\" — {why}";
+        // Once per column, not once per attempt: the Published Application seeder builds one
+        // row per loaded app, and a repeated name would otherwise multiply the message by the
+        // number of modules.
+        if (!_unwritable.Contains(entry, StringComparer.Ordinal))
+            _unwritable.Add(entry);
+    }
+
+    /// <summary>
+    /// Raise if any column the caller asked to write could not be. Call after the row is
+    /// filled and BEFORE it is inserted — a row that reaches the provider incomplete is
+    /// indistinguishable from a correct one at every later read.
+    /// </summary>
+    internal void ThrowIfAnyColumnCouldNotBeWritten()
+    {
+        if (_unwritable.Count == 0) return;
+
+        throw new InvalidOperationException(
+            $"[SeededRow] {_tableLabel}: could not write {_unwritable.Count} of the column(s) this "
+            + "row is built from — " + string.Join("; ", _unwritable)
+            + ". BC metadata shape changed; the row would otherwise be inserted with BC's own "
+            + "default in that column and every later read would look correct. Metatable states "
+            + $"[fields={string.Join("/", _fieldByName.Values.Select(_describeField))}] "
+            + "— see AlRunner#3015.");
+    }
+}

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1039,7 +1039,7 @@ https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues.
 <a id="runtime-shape-gaps"></a>
 
 - **Runtime shape gaps outside the virtual tables — the runner refuses rather than answering
-  a shape it cannot produce.** 12 further guards raise `RunnerOutOfScopeException` with the
+  a shape it cannot produce.** 13 further guards raise `RunnerOutOfScopeException` with the
   reason anchor `not-yet-implemented`, so an AL `[TryFunction]` cannot absorb one into `false`
   ([#2966](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2966)). The number
   counts refusal **call sites**, which is the rule the original nine were counted under; it is
@@ -1072,6 +1072,23 @@ https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues.
     each disagreement are the runner's own, so "which BC version produced this?" has no answer.
     Both used to leave `WireFieldTriggerHandlers` reporting the table as wired, so the trigger
     never fired and AL depending on it passed anyway.
+  - a **column of one of the runner's seeded system-table rows** that the table's own metatable
+    does not state, or that resolves to a value slot outside the row
+    (`AlRunner/Patches/SeededRowColumns.cs`,
+    [#3015](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3015)). Company
+    (2000000006), Published Application (2000000206) and Installed Application (2000000212) are
+    rows a real service tier writes before any AL runs — at company-create and publish time —
+    and the runner writes them from its own state instead. It used to hard-check exactly one
+    column per table and skip the rest, so a renamed column left BC's own default on a row that
+    was still inserted and still found by its key. `Runtime Package ID` is the one that matters
+    most, because it exists to be compared:
+    `Reten. Pol. Allowed Tbl. Impl.ModuleOwnsTable` tests
+    `AllObj."App Runtime Package ID" <> PublishedApplication."Runtime Package ID"`, and at its
+    default that declines for every app while BC logs a warning rather than raising. This is a
+    **run-level abort during install seeding**, not an attributable single-test failure —
+    seeding runs once per app group before any test does. Measured on every BC artifact cached
+    at the time (27.0, 27.3, 27.5, 28.1, 28.2, 28.4), all four tables state every column the
+    seeders ask for, so no supported version reaches this refusal.
 
   Real BC does all of these, so each is the runner failing to keep up rather than a surface BC
   also lacks — which is the test for whether a refusal may cite `docs/scope.md` at all.


### PR DESCRIPTION
Closes #3015

> **Reworked after review.** The first version put the AllObj arm in the wrong place and CI
> caught it. What changed is in "Rework" at the bottom; the rest of this body describes the
> current state, and every number in it was measured on the current head.

## The column, and why the lookup fails

There is no single column: **every column except one, per table, was best-effort.**

`InsertApplicationTableRow`'s local `Set` helper hard-checked exactly one name — `ID` for
Published Application, `Runtime Package ID` for Installed Application — and skipped every
other one in silence:

```csharp
if (value == null) return;
if (!fieldByName.TryGetValue(fieldName, out var f)) return;   // <-- silent
var idx = f.FieldIndex;
if (idx < 0 || idx >= values.Length) return;                  // <-- silent
```

The lookup does not fail today. It fails the moment BC renames or removes any of `Name`,
`Publisher`, `Version Major/Minor/Build/Revision`, `Tenant ID`, `Package ID` or
`Runtime Package ID` — and when it does, the write evaporates, `NCLMetaField.EmptyValue` stays
in the slot, and the row is still inserted and still found by its key.

I measured the current shape rather than assuming it. Extracting `System.app` from every BC
artifact cached on this machine and finding the file that declares each table **by object id**
— not by filename, which picks `InplaceInstalledApplication.Table.al` and
`CompanyTriggers.Codeunit.al` and yields a false "missing":

| BC | 2000000006 Company | 2000000038 AllObj | 2000000206 Published Application | 2000000212 Installed Application |
|---|---|---|---|---|
| 27.0.38460.53934 | OK | OK | OK | OK |
| 27.3.44313.53909 | OK | OK | OK | OK |
| 27.5.46862.53398 / .53716 / .53931 | OK | OK | OK | OK |
| 28.1.49838.53910 / .53997 / .54044 / .54169 | OK | OK | OK | OK |
| 28.2.50931.53496 / .53737 | OK | OK | OK | OK |
| 28.4.53241.53989 | OK | OK | OK | OK |

Every column each seeder declares required exists on every version I could check locally, so
this change's blast radius across the matrix is measured as zero. 28.0 and 28.3 have no
`System.app` in this machine's artifact cache; CI's eight legs cover them.

The **slot-range** arm is not dead code either: Company's `Id` is field 8000 and
`Business Profile Id` is 8005, both far outside a `FieldCount`-sized value array, so field
number and value slot genuinely are different spaces on this table.

## What a caller observes today

`Runtime Package ID` is not decoration — it exists to be compared.
`Reten. Pol. Allowed Tbl. Impl.ModuleOwnsTable`, reached from every
`Reten. Pol. Allowed Tables.AddAllowedTable` call:

```al
if AllObj."App Runtime Package ID" <> PublishedApplication."Runtime Package ID" then
    exit(false);
```

Left at its default the comparison declines for **every** app, and BC logs a warning rather
than raising — so the failure is invisible from AL as well as from the runner. The four
version columns are worse: BC `SetRange`s on them before it ever reads the package id, so a
rename there makes the `FindFirst` miss and the app simply looks unpublished. That is
`.claude/rules/loud-failures.md`'s silent default, on the columns whose whole purpose is to be
matched on.

## How it is loud

`AlRunner/Patches/SeededRowColumns.cs`. Every `Set()` call is now a declaration that the
column is **required**, so there is no second list to keep in step with the writes and no
"only `ID` is hard-checked" asymmetry. A name that does not resolve, or resolves to a slot
outside the row, is recorded and raised **before** the Insert, naming the table, every column
that could not be written, why each one could not, and the field list the metatable actually
states.

Resolution now happens **before** the null check. A column whose value happens to be absent on
this run must still be proved to exist, or a rename hides behind a manifest that stated no
`Name`, or a session whose `NavCompany.companyTableId` was null.

The refusal is `RunnerShapeGap.SeededSystemTableRow` — `RunnerOutOfScopeException` carrying the
`not-yet-implemented` anchor, the same type `FieldByNameOnUser` raises for the same question on
the User row, routed through the factory family that documents and counts these guards. The
anchor is load-bearing rather than cosmetic: `ApplicationObjectBasePatches.IsPermanentOutOfScope`
lets an AL `[TryFunction]` absorb a refusal into `false` unless the reason starts with
`not-yet-implemented`, and a seeding gap absorbed into `false` is the silent default again. A
test asserts the anchor, the api and the doc link for exactly that reason.

Deliberately **not** `BcShapeGapException`, though it is the type built for "BC's metadata is
not the shape we were written against". Its own header draws the line at whether the runner
*obtained* the information, and puts this case on the do-not-raise side by name: "a metatable
genuinely has no field 3" is an answer about the artifact, not a failed read of BC's layout.
The metatable was there and it answered.

### Throw vs. report — what the cache argument does and does not decide

Published Application is seeded in **two halves**, and only one is subject to the cache
argument: the dependency rows inside the persisted install-baseline MISS branch
(`TestExecutor.cs:573`, before `CaptureInstallBaselineSnapshot` and the disk write), and the
bundle's own row outside it (`TestExecutor.cs:637`). For the first half a stderr line fires
once — on the run that bakes the wrong row set in — and there is nothing at all to read on
every later run that restores it as a HIT.

Both halves refuse anyway. That is a decision, not the rule failing to predict the code:
splitting the policy *within one table* by which half seeded the row would let the same table
abort on one path and continue short on the other, in the same run, for the same metadata
change. One table, one answer.

Company reports through its existing catch, on two grounds. Its row is seeded per app group
outside the persisted cache (`TestExecutor.cs:606`), so the stderr line fires every run rather
than once. More to the point, **stderr is not the signal that stops the run**: a refused row is
a row that was never inserted, so `Company.Get(CompanyName())` raises for a company every other
surface reports as existing and the tests reading it go red — which is how #2329 presented in
the first place. Worth naming, because `Console.Error` on its own has repeatedly not been a
sufficient signal in this repository.

## Fixing the shape, not the reported line

**1. Same wrong pattern at another call site?** Yes, one more, and it is the one that was
actually burned. `InsertAllObjRow` resolves its columns by field **number**, switching on
`field.FieldNo` while walking the metatable, so a number matching nothing is simply never
written. #3004 shipped `6`/`7` for the two package columns, which are `60`/`61`, and the stamp
silently did nothing — caught by checking, not by a failure. Now checked once per process from
`PopulateAllObjVirtualTable`, the one call site that holds the genuine AllObj metatable.

**2. Sibling function making the same assumption?** Yes — `InsertCompanyRow`, a near-duplicate
that hard-checked only `Name` and skipped `Display Name`, `Evaluation Company` and `Id`. Fixed
through the same shared ledger. `RecordPatches.TestDataHydration.cs` matches columns the other
way round (backup data against the metatable) and already refuses loudly through
`PlanTestDataColumns`; nothing to do there.

**3. Two paths writing the same state maintaining the same invariant?** They did not, and that
is what settled throw-vs-report: three seeders write rows a service tier would have written
before any AL ran, and only the User one raised on an unfindable column. All three raise now.

**Deliberately left out**, filed rather than repaired here — see #3187 —
`EnsureCompanySystemTableRowSeeded` sets `_companyRowSeededForThisBundle = true` *before* doing
the work, so a throw out of the seed leaves the flag latched and a later call returns early
having done nothing. The Published Application file's own header records that #2941's review
rejected exactly this pattern next door. Different shape from this issue's, and moving the
assignment changes what the `meta == null` / `source == null` early returns mean, so it wants
its own RED.

## RED to GREEN

RED, in two steps, both on unmodified `main`:

1. `AlRunner.Tests/SeededRowColumnsTests.cs` did not compile — `SeededRowColumns<>` did not
   exist.
2. With the type added but the seeders not yet rewired: `Failed: 2, Passed: 6`. The two
   failures are `EverySeederResolvesItsColumnsThroughTheCheckedPath` for
   `RecordPatches.PublishedApplicationSystemTable.cs` and `RecordPatches.CompanySystemTable.cs`
   — a real RED on the production call sites, not on the new type.

GREEN. Everything below was run on the current head, after the final rebase:

| what | result |
|---|---|
| `--filter FullyQualifiedName~SeededRowColumnsTests` | 8/8 pass |
| the eight classes CI showed failing on the first version (`AggregatePermissionSetVirtualTable`, `CodeunitMetadataVirtualTable`, `FeatureKeyVirtualTable`, `ObjectSystemTableBaselineExclusion`, `PermissionMetadataPopulation`, `RecordRefCompilationTargetScope`, `TimeZoneVirtualTable`, `WindowsLanguageVirtualTable`) | 10/10 pass |
| filtered `AlRunner.Tests` over the changed surface, incl. both refusal-count guards and the OOS-convention tests | 172/172 pass, 28 pre-existing conditional skips |
| `tests/runner-extras`, 55 suites, cold | 312/312 pass, 0 errors |
| the same, warm `--cache` (seeding interacts with the install baseline, so it is cache-sensitive) | 312/312 pass |
| the **corpus**, `tests/al-language/tests/al-language` | 2665/2665 pass, 0 fail, 0 error (2 `pass-oos`, 13 `pass-known-gap`, 1 `pass-divergence`) |

The AL runs are the end-to-end half and they are why the required-column set is not a guess:
with this change a misnamed required column aborts the run, so 312 + 2665 green tests against
a real BC 28.1 metatable prove every declared name resolves. They also observe the **seeded
values** — `Name` and `Publisher` against `ModuleInfo`, `Version Major`/`Minor`, BC's own
`'%1|%2'` `Tenant ID` filter finding the row, the package ids discriminating between apps, and
`Installed` computing true through BC's own `Exist` FlowField — so this is not "seeding did not
throw". The corpus run is also the direct check on the reworked AllObj arm: the first version's
spurious refusal surfaced there, through `PopulateWindowsLanguageVirtualTable`.

The negative direction is in the C# tests, which is the only place it can be: neither seeder
can be driven from a test (both need a real `NCLMetaTable` and a live `DataAccessSource`) and
BC cannot be made to lose a column. `SeededRowColumnsTests` drives the identical resolution,
range check, aggregation and message construction over a stand-in metatable missing one, and
asserts the message names the column, the reason, the table and the observed field list — plus
that a column that *did* resolve is not blamed, that every unwritable column is named rather
than only the first, and that a repeated name is reported once rather than once per module.

`EverySeederResolvesItsColumnsThroughTheCheckedPath` is a **source-text grep and proves less
than it looks**: a comment naming the type satisfies its first assertion, and its second only
rules out the one silent-skip line spelled exactly as #3015 quotes it. It is a guard against
the wiring being reverted, not evidence the wiring is correct — the AL runs are that. Its
docstring now says so.

Both refusal counts were **read out of their own failure messages** after each rebase, never
computed: `VirtualTableRefusalClaimTests` 71 → 72 (rebased over #3117, which had moved it from
68), and `FieldTriggerShapeGapCallSiteTests` 9 → 10 runtime shape-gap call sites / 12 → 13
total, with the matching `docs/limitations.md` bullet and count sentence the test asserts.

## Rework, after review

**The AllObj arm was in the wrong place, and it was the same defect class this PR removes.**
`EnsureAllObjReflection(NCLMetaTable allObjMetaTable)` has 18 callers and **17 of them pass a
metatable that is not AllObj** — every other virtual-table populator passes its own, because
that parameter only ever existed to reach the Ncl assembly. The check therefore refused
whatever the caller happened to pass: `tableId=2000000045 name='Windows Language'`, for not
declaring AllObj's columns. A loud *wrong* refusal on a surface that works.

Worse, it threw before `_aovReflectionReady` was set, so whichever populator reached that
method first decided whether the process worked at all. Six of eight legs passed on ordering
luck; the other two took down nine test classes between them. Green legs were not evidence.

Fixed by moving the check to `PopulateAllObjVirtualTable`, the one site holding the genuine
metatable, and having it verify the table id **before** it says anything about the table — so a
future re-wiring reports "wrong table" rather than inventing a shape gap in a table that has
none. That guard is an `InvalidOperationException`, not an `AllObjShapeGap`, because it is a
claim about the runner's own wiring and not about BC's metadata. Its flag latches after the
check passes, never before. The misleading parameter is renamed to `anyMetaTable` and the
method's doc comment now states that nothing table-specific may live in it, with the incident
recorded.

Also from the same review: the typed refusal, the corrected throw-vs-report rule, the Company
justification, and the honest description of the source-text guard — all above.

## Not touched

No BC business-logic body. No CLI surface, so no `README.md` / `PrintGuide()` / `docs/scope.md`
change; `docs/limitations.md` gains the runtime-shape-gap bullet its own test requires. No
`tests/al-language` pin, no `CHANGELOG.md`, and none of the files held by other agents.

Nothing here is a claim about BC behaviour, so nothing goes upstream: the corpus already
adjudicates what these tables contain (BusinessCentral.AL.Language.Tests#187), and this change
is entirely about the runner refusing to write a row it cannot write correctly.

---

Implemented by an agent (impl-9).

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf