### PR TITLE
fix(permissions): answer IsPermissionSetAssigned from Access Control instead of NREing on a null permission cache

### DIFF
--- a/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
@@ -754,6 +754,23 @@ public static partial class NclCecilRewrite
                 ByParams(Rt + "DataAccessSource", "GetDataAccessForQuery", "NCLMetaQueryDefinition"),
                 H(recordPatches, "DataAccessSource_GetDataAccessForQuery"));
 
+            // ── PermissionManagement.IsPermissionSetAssignedAsync (#3039) ────────────────
+            // The real body ends in `session.Permissions.HasRole(companyName, permissionSet)`
+            // and NavSession.Permissions is null on the skeleton session, so every AL path
+            // through NavUserAccountHelper.IsPermissionSetAssigned — codeunit 153's IsSuper,
+            // and therefore codeunit 9002's User/OnBeforeModifyEvent subscriber — NREs on a
+            // perfectly valid User.Modify. Populating Permissions for real is not available:
+            // NavUserPermissions.HasRole/GetRoles both need a SQL-backed NavTenant.Database,
+            // which BcRuntime documents as out of scope. The replacement answers from the
+            // Access Control table (2000000053) instead — see
+            // RecordPatches.PermissionSetAssignment.cs for the full mechanism and for the one
+            // stated fact it adds (the skeleton session is SUPER, as three sibling rewrites in
+            // this file and NclCecilRewrite.Metadata.cs already assume).
+            ReplaceBodyWithHelper(nclMod,
+                ByParams(Rt + "PermissionManagement", "IsPermissionSetAssignedAsync",
+                         "NavSession", "Guid", "PermissionSetKey", "String"),
+                H(recordPatches, "PermissionManagement_IsPermissionSetAssignedAsync"));
+
             // ── TempTableDataProvider ctor (NavSession,NCLMetaTable) + CalcNumeric ──
             {
                 var ttdp = nclMod.GetType(Rt + "TempTableDataProvider")

--- a/AlRunner/Patches/NavRecordTestFieldNavigationPatches.cs
+++ b/AlRunner/Patches/NavRecordTestFieldNavigationPatches.cs
@@ -133,8 +133,27 @@ public static partial class RecordPatches
         if (_mNavUserPermissionsGetEffectivePermissionForObject == null || _mNavRecordCreateErrorInfoData == null)
             return null;
 
+        // Session.Permissions is NULL on the skeleton session — it has a private setter only
+        // the real session bring-up calls, which is the same gap #3039 fixed one layer down in
+        // PermissionManagement.IsPermissionSetAssignedAsync (see
+        // RecordPatches.PermissionSetAssignment.cs). Invoking an INSTANCE method through
+        // reflection with a null target raises TargetException, and it would raise it from
+        // inside TryAddTestFieldAction — pre-empting the `throw NavTestFieldException` this
+        // whole file exists to stop being pre-empted, and reporting a null-target reflection
+        // failure where the test expects "… must have a value …".
+        //
+        // Skipped rather than answered, deliberately. The runner's skeleton session runs as
+        // SUPER, so the permission gate itself would pass — but this action is pure UI
+        // convenience with no headless observer (see the file header: the exception's message
+        // text is built separately and is unaffected), and every other unresolvable condition
+        // in this method already returns null. Skipping keeps the ONE observable thing — the
+        // real TestField error — correct, which answering could only put at risk.
+        var permissions = self.Session.Permissions;
+        if (permissions == null)
+            return null;
+
         var perm = (PermissionMask)_mNavUserPermissionsGetEffectivePermissionForObject.Invoke(
-            self.Session.Permissions, new object[] { self.Session.CompanyName, metaFormById.ApplicationObjectId })!;
+            permissions, new object[] { self.Session.CompanyName, metaFormById.ApplicationObjectId })!;
         if (!perm.HasFlag(PermissionMask.Read) && !perm.HasFlag(PermissionMask.Execute))
             return null;
 

--- a/AlRunner/Patches/RecordPatches.PermissionSetAssignment.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionSetAssignment.cs
@@ -1,0 +1,264 @@
+// RecordPatches.PermissionSetAssignment — answer "is this permission set assigned to this
+// user" from state the runner actually has, instead of dereferencing a null permission cache.
+//
+// THE DEFECT (AlRunner#3039)
+//   `User.Modify(true)` on a well-formed User row raised, from inside a Base Application
+//   subscriber, an NRE that surfaced as:
+//
+//     NavNCLDotNetInvokeException: A call to
+//     Microsoft.Dynamics.Nav.NavUserAccount.NavUserAccountHelper.IsPermissionSetAssigned
+//     failed with this message: Object reference not set to an instance of an object.
+//       "User Permissions Impl."(CodeUnit 153).HasUserPermissionSetAssigned
+//       "User Permissions Impl."(CodeUnit 153).IsSuper
+//       "User Permissions Impl."(CodeUnit 153).CanManageUsersOnTenant
+//       "User Permissions"(CodeUnit 152).CanManageUsersOnTenant
+//       "Permission Manager"(CodeUnit 9002).CheckCurrentUserCanModifyUser
+//       "User"(Table 2000000120).InjectedEventMethodScope
+//
+//   It only became reachable once #2932 (PR #2979) stopped BC's `memberId == 0` dispatch
+//   branch from discarding a precompiled subscriber's `ValueTask`. Before that the subscriber
+//   was abandoned at its first suspension and never reached `IsSuper` at all.
+//
+// THE MECHANISM, MEASURED
+//   `NavUserAccountHelper.IsPermissionSetAssigned` is a two-line forwarder (decompiled from
+//   Microsoft.Dynamics.Nav.NavUserAccount.dll, BC 28.1.49838.53910):
+//
+//     public static bool IsPermissionSetAssigned(Guid userSecurityId, string companyName,
+//                                                string roleId, Guid appId, int permissionScope)
+//         => PermissionManagement.IsPermissionSetAssignedAsync(
+//                Session, userSecurityId, new PermissionSetKey(roleId, appId,
+//                (PermissionScope)permissionScope), companyName).AsTask().GetAwaiter().GetResult();
+//
+//   and the Ncl method it forwards to is:
+//
+//     public static async ValueTask<bool> IsPermissionSetAssignedAsync(
+//         NavSession session, Guid userSecurityId, PermissionSetKey permissionSet, string companyName)
+//     {
+//         bool isCurrentUser = session.User.Id == userSecurityId;
+//         NavUser navUser = isCurrentUser ? session.User
+//                                         : await GetUserWithEntitlementAsync(session, userSecurityId);
+//         return (isCurrentUser ? session.Permissions
+//                               : new NavUserPermissions(navUser, session))
+//                .HasRole(companyName, permissionSet);
+//     }
+//
+//   The null is `session.Permissions`. `NavSession.User` is NOT null on the skeleton — it is
+//   `Authenticator.User`, and BcRuntime field-pokes a populated Authenticator — but
+//   `NavSession.Permissions` has a private setter that only the real session bring-up calls,
+//   so it stays null. Two other files in this repo already record the same fact from their own
+//   encounters with it (EventSubscriberPatches's ReplaceAttributeWithZeroedCopy, and
+//   BcRuntime's NavRecord.TestFieldNotBlank note).
+//
+// WHY THE STATE CANNOT SIMPLY BE POPULATED
+//   The obvious fix — hand the session a real NavUserPermissions so BC's own code runs — does
+//   not survive contact with `HasRole`:
+//
+//     public bool HasRole(string companyName, PermissionSetKey permissionSet)
+//         => GetRoles(tenant.Database.CompanyTokens.Get(companyName))
+//            .Contains(new NavRole(permissionSet, tenant.Database));
+//
+//     public HashSet<NavRole> GetRoles(int companyNameToken) { ...; value = FetchRoles(companyNameToken); ... }
+//
+//   Both halves need a real SQL-backed `NavTenant.Database`: `FetchRoles` reads the permission
+//   tables out of it, and `NavRole` is constructed against it. BcRuntime states plainly that
+//   populating a skeleton NavTenant "pulls in the full database-bring-up chain and is out of
+//   scope", having measured it breaking ~466 tests. So the answer has to be computed, and the
+//   only honest place to compute it from is state the runner genuinely holds.
+//
+// WHAT IT IS COMPUTED FROM
+//   The Access Control table (2000000053) — the same table real BC builds its permission cache
+//   out of, and ordinary AL-writable storage in the runner. A row matches when its User
+//   Security ID, Role ID, App ID and Scope all equal the ones asked about, and its Company Name
+//   is either the company asked about or blank (a blank Company Name is BC's "every company"
+//   assignment). That makes the answer real, observable and writable from AL in both
+//   directions: assign a permission set and it reads back true, do not and it reads back false.
+//
+//   PLUS ONE STATED FACT ABOUT THE RUNNER ITSELF: the skeleton session is SUPER. That is not
+//   invented here — it is the position this runner already ships, three times over, each with
+//   the same one-line justification:
+//
+//     * NclCecilRewrite.Metadata.cs rewrites NavSession.HasExecutePermission /
+//       HasCachedExecutePermissions / HasExecutePermissionForCompany /
+//       HasExecutePermissionForAllCompanies → `true` ("skeleton session runs as SUPER").
+//     * The same file no-ops NavSession.VerifyExecutePermission for the same reason.
+//     * NclCecilRewrite.Runtime.cs no-ops NavSession.MaximizePermissions /
+//       RemoveMaximizedPermissions ("The runner has no permission system (equivalent to SUPER
+//       everywhere)"), and BcRuntime returns true from ALDatabase.ALSetUserPassword because
+//       SessionHasSuperOrSecurityPermissionsForUser NREs on the skeleton.
+//
+//   Answering `IsSuper(UserSecurityId())` with `false` while `HasExecutePermission` answers
+//   `true` would make the runner contradict itself, and would make codeunit 9002 refuse a
+//   `User.Modify` that every real BC test tier allows, because a test tier's user is SUPER.
+//   So the SUPER fact is stated ONCE, here, narrowly: it applies to the session's own user and
+//   to the SUPER role only. It does not claim any OTHER permission set is assigned to the
+//   session user — under SUPER, "D365 BASIC" is superseded, not assigned, and answering `true`
+//   there would be exactly the silent fake .claude/rules/loud-failures.md forbids.
+//
+// KNOWN DIVERGENCE, DELIBERATE
+//   Because the SUPER fact is stated rather than seeded, the runner's Access Control table does
+//   NOT contain a row for the session user, while `IsSuper(UserSecurityId())` answers true. On
+//   a real tier those agree. Seeding the row instead was considered and rejected for this
+//   change: RecordPatches.UserSystemTable.cs's header records a deliberate decision not to seed
+//   Access Control alongside the User row, and a seed would alter table state for every test in
+//   every bundle, whereas stating the fact here can only change an answer that throws today.
+//   AlRunner#3040 tracks the seed as the alternative, and docs/limitations.md records the
+//   divergence.
+//
+// PRECOMPILED-DLL RESPECT
+//   `PermissionManagement` is in Ncl.dll — the runtime engine, ours to rewrite per
+//   .claude/rules/precompiled-dll-respect.md. No AL business-logic body is touched: codeunits
+//   152/153/9002 run their own real bodies and simply get an answer instead of an NRE. The
+//   rewrite is registered in NclCecilRewrite.Runtime.cs's cluster batch and imports only this
+//   helper's memberRef, so no new Ncl typeRefs/memberRefs are added.
+using System.Reflection;
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Runtime.Permissions;
+using Microsoft.Dynamics.Nav.Types;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    internal const int AccessControlTableId = 2000000053;
+
+    // Located by NAME off the metatable at runtime, never by hardcoded ordinal, so a BC
+    // metadata change says so loudly instead of silently reading the wrong slot. Same
+    // discipline as RecordPatches.UserSystemTable.
+    private const string AcUserSecurityIdFieldName = "User Security ID";
+    private const string AcRoleIdFieldName = "Role ID";
+    private const string AcCompanyNameFieldName = "Company Name";
+    private const string AcAppIdFieldName = "App ID";
+    private const string AcScopeFieldName = "Scope";
+
+    /// <summary>The SUPER role, the one permission set the skeleton session holds.</summary>
+    private const string SuperRoleId = "SUPER";
+
+    private static bool _accessControlMissingReported;
+
+    /// <summary>
+    /// Cecil-owned replacement for
+    /// <c>Microsoft.Dynamics.Nav.Runtime.PermissionManagement.IsPermissionSetAssignedAsync</c>.
+    /// See this file's header for the mechanism and for why the answer is computed rather than
+    /// delegated back to BC.
+    ///
+    /// Synchronous by construction — every source it reads is in memory — so it hands back an
+    /// already-completed <see cref="ValueTask{T}"/> rather than introducing a suspension point
+    /// into a call chain the runner drives from one AL thread.
+    /// </summary>
+    public static ValueTask<bool> PermissionManagement_IsPermissionSetAssignedAsync(
+        NavSession session, Guid userSecurityId, PermissionSetKey permissionSet, string companyName)
+        => new(IsPermissionSetAssignedCore(session, userSecurityId, permissionSet, companyName));
+
+    private static bool IsPermissionSetAssignedCore(
+        NavSession session, Guid userSecurityId, PermissionSetKey permissionSet, string companyName)
+    {
+        // An explicit Access Control row wins, and is checked first, so AL that assigns a
+        // permission set is always believed — including one that assigns SUPER to the session
+        // user, which then needs no special case at all.
+        if (AccessControlGrants(session, userSecurityId, permissionSet, companyName))
+            return true;
+
+        // The one stated fact: the skeleton session runs as SUPER. Narrow on purpose — this
+        // user only, this role only. See the header.
+        return IsSkeletonSessionUser(session, userSecurityId)
+               && string.Equals(RoleIdOf(permissionSet), SuperRoleId, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Is <paramref name="userSecurityId"/> the user this session actually is? Read from
+    /// <c>NavSession.User</c> — the very property BC's own body compares against — so the
+    /// runner cannot disagree with BC about who the current user is.
+    /// </summary>
+    private static bool IsSkeletonSessionUser(NavSession session, Guid userSecurityId)
+    {
+        try
+        {
+            var user = session?.User;
+            return user != null && user.Id == userSecurityId;
+        }
+        catch (NullReferenceException)
+        {
+            // A session with no Authenticator at all is not "some other user" — it is no user.
+            // Returning false keeps that case answering "not assigned" rather than claiming
+            // SUPER for an identity that does not exist.
+            return false;
+        }
+    }
+
+    private static string RoleIdOf(PermissionSetKey permissionSet)
+        => permissionSet.RoleId?.ToString() ?? string.Empty;
+
+    /// <summary>
+    /// Does the Access Control table hold a row assigning <paramref name="permissionSet"/> to
+    /// <paramref name="userSecurityId"/> for <paramref name="companyName"/>?
+    ///
+    /// Company matching follows BC's own model: a row naming the company matches that company,
+    /// and a row with a BLANK Company Name matches every company. A company-specific row does
+    /// NOT satisfy a blank (all-companies) question — which is the question codeunit 153's
+    /// <c>IsSuper</c> asks, since it passes <c>''</c>.
+    /// </summary>
+    private static bool AccessControlGrants(
+        NavSession session, Guid userSecurityId, PermissionSetKey permissionSet, string companyName)
+    {
+        var meta = EnsureTableInMetadataCache(AccessControlTableId);
+        if (meta == null)
+        {
+            // A bundle whose closure has no Access Control metatable cannot express an
+            // assignment, so "not assigned" is the truthful answer rather than a default —
+            // but say so once, because the alternative reading (a metadata regression that
+            // silently emptied the table) looks identical from AL.
+            if (!_accessControlMissingReported)
+            {
+                _accessControlMissingReported = true;
+                Console.Error.WriteLine(
+                    "[PermissionSetAssignment] this bundle's closure has no Access Control "
+                    + $"metatable ({AccessControlTableId}), so no permission-set assignment can "
+                    + "exist in it; every IsPermissionSetAssigned question about a user other "
+                    + "than the session's own answers false. See AlRunner#3039.");
+            }
+            return false;
+        }
+
+        using var probe = new NavRecord(session, AccessControlTableId, SecurityFiltering.Ignored);
+        var acMeta = probe.MetaTable ?? meta;
+
+        var userField = FieldByNameOnAccessControl(acMeta, AcUserSecurityIdFieldName);
+        var roleField = FieldByNameOnAccessControl(acMeta, AcRoleIdFieldName);
+        var companyField = FieldByNameOnAccessControl(acMeta, AcCompanyNameFieldName);
+        var appIdField = FieldByNameOnAccessControl(acMeta, AcAppIdFieldName);
+        var scopeField = FieldByNameOnAccessControl(acMeta, AcScopeFieldName);
+
+        probe.ALSetRange(userField.FieldNo, NavValue.CreateNavValueFromObject(userField, userSecurityId));
+        probe.ALSetRange(roleField.FieldNo, NavValue.CreateNavValueFromObject(roleField, RoleIdOf(permissionSet)));
+        probe.ALSetRange(appIdField.FieldNo, NavValue.CreateNavValueFromObject(appIdField, permissionSet.AppId));
+        probe.ALSetRange(scopeField.FieldNo, NavValue.CreateNavValueFromObject(scopeField, (int)permissionSet.Scope));
+
+        // CS0618: the synchronous entry points are marked obsolete in favour of the async ones.
+        // This runs on the runner's single AL thread with no await point available in the call
+        // chain — the same trade RecordPatches.UserSystemTable next door already makes.
+#pragma warning disable CS0618
+        if (!probe.ALFindFirstAsync(DataError.TrapError).GetAwaiter().GetResult())
+            return false;
+        do
+        {
+            var rowCompany = probe.GetFieldValue(companyField.FieldNo)?.ToString() ?? string.Empty;
+            if (rowCompany.Length == 0
+                || string.Equals(rowCompany, companyName ?? string.Empty, StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        while (probe.ALNextAsync().GetAwaiter().GetResult() != 0);
+#pragma warning restore CS0618
+        return false;
+    }
+
+    private static NCLMetaField FieldByNameOnAccessControl(NCLMetaTable table, string fieldName)
+    {
+        foreach (var f in GetAllFields(table) ?? Enumerable.Empty<NCLMetaField>())
+            if (string.Equals(f.FieldName, fieldName, StringComparison.OrdinalIgnoreCase))
+                return f;
+        throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            $"{table.TableName} ({table.TableId})",
+            $"permission-set-assignment — the table states no \"{fieldName}\" field, so whether a "
+            + "permission set is assigned cannot be answered from it; see docs/scope.md");
+    }
+}

--- a/AlRunner/Patches/RecordPatches.PermissionSetAssignment.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionSetAssignment.cs
@@ -101,8 +101,10 @@
 //   change: RecordPatches.UserSystemTable.cs's header records a deliberate decision not to seed
 //   Access Control alongside the User row, and a seed would alter table state for every test in
 //   every bundle, whereas stating the fact here can only change an answer that throws today.
-//   AlRunner#3040 tracks the seed as the alternative, and docs/limitations.md records the
-//   divergence.
+//   AlRunner#3176 tracks the seed as the alternative, and docs/limitations.md records the
+//   divergence. AlRunner#3174 tracks the one reader this fix cannot reach:
+//   NavUserAccountHelper.IsUserSuperInAllCompanies is `Session.Permissions.IsSuperForAllCompanies`
+//   with no Ncl hop in it at all, so no rewrite of Ncl can answer it.
 //
 // PRECOMPILED-DLL RESPECT
 //   `PermissionManagement` is in Ncl.dll — the runtime engine, ours to rewrite per

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -475,6 +475,37 @@ the exact value will see different results.
 | `Commit()` | Commits current transaction | Establishes a rollback commit-point — see "Transaction semantics" above; not a no-op |
 | `FilterGroup(n)` | Scoped filter groups | Not tracked — `FilterGroup()` is a no-op; all filters apply to group 0 |
 
+### Permission-set assignment — answered from `Access Control`, and the session user is SUPER without a row
+
+<a id="permission-set-assignment"></a>
+
+Real BC answers "is this permission set assigned to this user" out of the session's permission
+cache (`NavSession.Permissions`), which is built from the tenant's permission tables in SQL. The
+runner has no SQL-backed tenant database — `NavUserPermissions.HasRole` and `GetRoles` both need
+`NavTenant.Database`, and populating a skeleton `NavTenant` is out of scope (it was measured
+breaking ~466 tests) — so `NavSession.Permissions` stays null.
+
+Rather than let every AL path through `NavUserAccountHelper.IsPermissionSetAssigned` NRE
+(AlRunner#3039 — it made a valid `User.Modify` fail from inside codeunit 9002's subscriber), the
+runner answers the question itself:
+
+| question | Real BC | al-runner |
+|---|---|---|
+| Is permission set X assigned to user U? | From the permission cache built out of `Access Control` and entitlements | From the `Access Control` (2000000053) rows the run holds — matching User Security ID, Role ID, App ID and Scope, with a blank Company Name meaning every company |
+| Is the session's own user SUPER? | Yes on a test tier, because provisioning wrote it a row | Yes — stated directly, consistent with `NavSession.HasExecutePermission*` → `true` and `MaximizePermissions` → no-op |
+| Does `Access Control` contain a row for the session user? | Yes | **No** |
+
+The last row is the divergence worth knowing about: the session user is SUPER, but nothing in
+`Access Control` says so, because the fact is stated in the runtime rather than seeded as a row.
+Any other user is answered purely from rows, in both directions — grant SUPER and `IsSuper`
+reads back true, grant something else and it reads back false. Whether the row should be seeded
+instead is AlRunner#3176.
+
+Entitlements are not modeled at all, so a permission set that a real tier would report as
+assigned *via an entitlement* rather than via `Access Control` reads as not assigned here.
+`NavUserAccountHelper.IsUserSuperInAllCompanies` still raises, because its body has no Ncl hop
+the runner can rewrite — AlRunner#3174.
+
 ### `Record "Time Zone"` — ids follow the HOST, so they are IANA ids on Linux
 
 <a id="time-zone-virtual-table"></a>

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -784,3 +784,27 @@ first.
 No `absentOn`: both pages and both tables exist on every supported leg, and the bundle already
 declares `"application": "27.0.0.0"`. The 26 is measured from a run of the bundle, not counted
 off the source.
+
+## +6 runner-extras tests: `permission-set-assignment` (#3039)
+
+`tests/runner-extras/permission-set-assignment` is new, so `runner-extras` goes from 55 app
+groups / 306 tests to 56 / 312. No existing group's count moves. (Rebased onto the
+`microsoft-dependencies` 24 -> 26 bump above, which is why the starting total is 306 and not
+the 304 measured before that bump landed.)
+
+The suite is the RED -> GREEN for #3039: BC's
+`PermissionManagement.IsPermissionSetAssignedAsync` ends in
+`session.Permissions.HasRole(...)`, `NavSession.Permissions` is null on the skeleton session,
+and every AL path through `NavUserAccountHelper.IsPermissionSetAssigned` therefore raised
+`NavNCLDotNetInvokeException` on a valid `User.Modify`. Five of the six tests fail without the
+fix; the sixth is the `asserterror` control that must keep passing either way, because it
+proves codeunit 9002's subscriber still runs rather than having been bypassed.
+
+No `absentOn`: the bundle declares `"platform": "27.0.0.0"` / `"application": "27.0.0.0"` and
+uses only codeunit 152 `"User Permissions"` and table 2000000053 `"Access Control"`, both of
+which exist across the supported range. That was not validated locally — a self-built runner
+is compiled against Ncl 28.x and cannot run 27.x artifacts — so the 27.0/27.3/27.5 legs are
+what adjudicate it. If any of them discovers a different number, the exit-4 message names it
+and the line gains an `absentOn`.
+
+Written by agent impl-13 (automated implementation agent).

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -38,6 +38,7 @@
         "object-system-table": { "tests": 5 },
         "page-enum-control-modal": { "tests": 4 },
         "pageext-action-dispatch": { "tests": 6 },
+        "permission-set-assignment": { "tests": 6 },
         "precompiled-table-relation": { "tests": 6 },
         "published-application-system-table": { "tests": 7 },
         "query-join-aggregation-oos": { "tests": 4 },

--- a/tests/runner-extras/permission-set-assignment/PsaAssert.Codeunit.al
+++ b/tests/runner-extras/permission-set-assignment/PsaAssert.Codeunit.al
@@ -1,0 +1,27 @@
+// Standalone Assert — this suite does not import from tests/al-language.
+codeunit 65610 "PSA Assert"
+{
+    procedure AreEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if Format(Expected) <> Format(Actual) then
+            Error('Expected %1 but got %2: %3', Format(Expected), Format(Actual), Msg);
+    end;
+
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error('Expected true: %1', Msg);
+    end;
+
+    procedure IsFalse(Condition: Boolean; Msg: Text)
+    begin
+        if Condition then
+            Error('Expected false: %1', Msg);
+    end;
+
+    procedure ExpectedError(Expected: Text; Actual: Text)
+    begin
+        if StrPos(Actual, Expected) = 0 then
+            Error('Expected an error containing ''%1'' but got ''%2''', Expected, Actual);
+    end;
+}

--- a/tests/runner-extras/permission-set-assignment/PsaTests.Codeunit.al
+++ b/tests/runner-extras/permission-set-assignment/PsaTests.Codeunit.al
@@ -1,0 +1,174 @@
+// Issue #3039 — "is this permission set assigned to this user" must be ANSWERED, not NRE.
+//
+// RUNNER-MECHANISM claim. The Base Application / System Application behaviour exercised here is
+// plain BC and needs no corpus test: codeunit 153's `IsSuper` asks the platform whether SUPER is
+// assigned, and codeunit 9002's User/OnBeforeModifyEvent subscriber refuses to modify SOMEONE
+// ELSE'S user row unless the caller can manage users. What is asserted below is the runner's own
+// permission model, which no service tier can adjudicate because a service tier HAS a permission
+// database and the runner does not:
+//
+//   * `NavSession.Permissions` is null on the skeleton session, so BC's
+//     PermissionManagement.IsPermissionSetAssignedAsync dereferenced null and every one of these
+//     paths raised NavNCLDotNetInvokeException instead of returning a boolean.
+//   * The runner answers from the Access Control table (2000000053) — the same table real BC
+//     builds its permission cache from, and ordinary AL-writable storage here.
+//   * Plus exactly one stated fact: the skeleton session runs as SUPER. That is the position the
+//     runner already ships in NavSession.HasExecutePermission* (→ true),
+//     NavSession.VerifyExecutePermission (→ no-op) and NavSession.MaximizePermissions (→ no-op),
+//     each justified in-tree with the same sentence.
+//
+// See AlRunner/Patches/RecordPatches.PermissionSetAssignment.cs for the mechanism.
+//
+// WHY IT WAS INVISIBLE UNTIL NOW: codeunit 9002's subscriber is an async ValueTask state machine,
+// and BC's `memberId == 0` dispatch branch discarded the returned task (#2932), so the body was
+// abandoned at its first suspension and never reached IsSuper. PR #2979 made it run to completion
+// and this was the next thing in its path.
+codeunit 65612 "PSA Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit "PSA Assert";
+        SuperTok: Label 'SUPER', Locked = true;
+
+    local procedure NewUser(var User: Record User; Name: Code[50]): Guid
+    begin
+        User.Init();
+        User."User Security ID" := CreateGuid();
+        User."User Name" := Name;
+        User.Insert(false);
+        exit(User."User Security ID");
+    end;
+
+    local procedure GrantPermissionSet(UserSid: Guid; RoleId: Code[20]; CompanyName: Text[30])
+    var
+        AccessControl: Record "Access Control";
+        NullGuid: Guid;
+    begin
+        AccessControl.Init();
+        AccessControl."User Security ID" := UserSid;
+        AccessControl."Role ID" := RoleId;
+        AccessControl."Company Name" := CompanyName;
+        AccessControl."App ID" := NullGuid;
+        AccessControl.Scope := AccessControl.Scope::System;
+        AccessControl.Insert(false);
+    end;
+
+    // ── THE REPORTED DEFECT ────────────────────────────────────────────────────────────────
+    // Codeunit 9002's CheckCurrentUserCanModifyUser reaches its permission check only for a row
+    // that is NOT the session's own user (its own AL exits early when the security ids match),
+    // which is exactly what this does. Before the fix this raised
+    //   NavNCLDotNetInvokeException: A call to ...NavUserAccountHelper.IsPermissionSetAssigned
+    //   failed with this message: Object reference not set to an instance of an object.
+    [Test]
+    procedure ModifyingAnotherUsersRow_Succeeds_BecauseTheSessionUserIsSuper()
+    var
+        User: Record User;
+        OtherSid: Guid;
+        Reread: Record User;
+    begin
+        OtherSid := NewUser(User, 'PSA-OTHER-USER');
+        Assert.IsTrue(OtherSid <> UserSecurityId(),
+            'precondition: the row must belong to someone other than the session user, or '
+            + 'codeunit 9002 exits before the permission check');
+
+        User."Full Name" := 'Renamed By PSA';
+        User.Modify(true);
+
+        // Assert the WRITE landed, not merely that nothing was raised: a Modify that silently
+        // did nothing would satisfy "no error" just as well.
+        Assert.IsTrue(Reread.Get(OtherSid), 'the modified row must still be readable');
+        Assert.AreEqual('Renamed By PSA', Reread."Full Name", 'the modification must have been written');
+    end;
+
+    // The negative half of the same subscriber, so a fix that neutered codeunit 9002 outright
+    // could not pass the test above. The blank User Name is refused BEFORE the permission check.
+    [Test]
+    procedure ModifyingAUserWithABlankName_StillRaisesTheSubscribersError()
+    var
+        User: Record User;
+    begin
+        NewUser(User, '');
+        Assert.AreEqual('', User."User Name", 'precondition: the row must have a blank User Name');
+
+        asserterror User.Modify(true);
+
+        Assert.ExpectedError('User Name must have a value', GetLastErrorText());
+    end;
+
+    // ── THE PERMISSION ANSWER ITSELF ──────────────────────────────────────────────────────
+    // The session user is SUPER. The IsEmpty precondition matters: codeunit 153's IsSuper opens
+    // with `if User.IsEmpty() then exit(true)` — the "no users provisioned yet" bootstrap — so
+    // without it this test would pass against an empty User table without the platform ever
+    // being asked the question.
+    [Test]
+    procedure TheSessionUser_IsSuper()
+    var
+        UserPermissions: Codeunit "User Permissions";
+        User: Record User;
+    begin
+        Assert.IsFalse(User.IsEmpty(),
+            'precondition: the User table must be non-empty, or codeunit 153 answers true from '
+            + 'its bootstrap branch without asking about permission sets at all');
+
+        Assert.IsTrue(UserPermissions.IsSuper(UserSecurityId()), 'the session user must be SUPER');
+    end;
+
+    // Guards against a blanket `true`. A user who exists but holds no permission set is not
+    // SUPER, and the runner must say so.
+    [Test]
+    procedure AUserWithNoAccessControlRow_IsNotSuper()
+    var
+        UserPermissions: Codeunit "User Permissions";
+        User: Record User;
+        OtherSid: Guid;
+        AccessControl: Record "Access Control";
+    begin
+        OtherSid := NewUser(User, 'PSA-NO-ROLES');
+        AccessControl.SetRange("User Security ID", OtherSid);
+        Assert.IsTrue(AccessControl.IsEmpty(), 'precondition: this user must hold no permission set');
+
+        Assert.IsFalse(UserPermissions.IsSuper(OtherSid),
+            'a user with no Access Control row must not be SUPER');
+    end;
+
+    // Guards against a blanket `false`, and proves the answer is read from real, AL-writable
+    // state rather than from a hardcoded verdict about who is SUPER.
+    [Test]
+    procedure AUserGrantedSuperInAccessControl_IsSuper()
+    var
+        UserPermissions: Codeunit "User Permissions";
+        User: Record User;
+        OtherSid: Guid;
+    begin
+        OtherSid := NewUser(User, 'PSA-GRANTED-SUPER');
+        Assert.IsFalse(UserPermissions.IsSuper(OtherSid),
+            'precondition: this user must not be SUPER before the grant, or the grant proves nothing');
+
+        GrantPermissionSet(OtherSid, SuperTok, '');
+
+        Assert.IsTrue(UserPermissions.IsSuper(OtherSid),
+            'an Access Control row granting SUPER must make that user SUPER');
+    end;
+
+    // The Role ID is really compared: granting a DIFFERENT permission set must not answer SUPER.
+    // Without this, "any Access Control row at all → true" would pass the test above.
+    [Test]
+    procedure AUserGrantedSomeOtherPermissionSet_IsNotSuper()
+    var
+        UserPermissions: Codeunit "User Permissions";
+        User: Record User;
+        OtherSid: Guid;
+        AccessControl: Record "Access Control";
+    begin
+        OtherSid := NewUser(User, 'PSA-GRANTED-BASIC');
+        GrantPermissionSet(OtherSid, 'D365 BASIC', '');
+
+        AccessControl.SetRange("User Security ID", OtherSid);
+        Assert.IsFalse(AccessControl.IsEmpty(), 'precondition: the grant must have been written');
+
+        Assert.IsFalse(UserPermissions.IsSuper(OtherSid),
+            'a permission set other than SUPER must not answer the SUPER question');
+    end;
+}

--- a/tests/runner-extras/permission-set-assignment/app.json
+++ b/tests/runner-extras/permission-set-assignment/app.json
@@ -1,0 +1,19 @@
+{
+  "id": "5b4e1f2a-7c93-4d16-8a0e-2f61c9d84b37",
+  "name": "Runner Extras - Permission Set Assignment",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Issue #3039: 'is this permission set assigned to this user' must be answered from state the runner has, instead of dereferencing the skeleton session's null permission cache.",
+  "description": "Runner-mechanism claim, not a claim about AL. That codeunit 153's IsSuper asks the platform whether SUPER is assigned, and that codeunit 9002 refuses to modify another user's row unless the caller can manage users, is plain BC and needs no corpus test. What this pins is the runner's own permission model. BC's PermissionManagement.IsPermissionSetAssignedAsync ends in session.Permissions.HasRole(...), and NavSession.Permissions is null on the skeleton session, so every AL path through NavUserAccountHelper.IsPermissionSetAssigned raised NavNCLDotNetInvokeException on a valid User.Modify. Populating Permissions for real is not available: NavUserPermissions.HasRole and GetRoles both need a SQL-backed NavTenant.Database, which BcRuntime documents as out of scope after measuring it break ~466 tests. So the runner answers from the Access Control table (2000000053), the same table real BC builds its permission cache from, plus exactly one stated fact - the skeleton session runs as SUPER, which is the position NavSession.HasExecutePermission* (true), VerifyExecutePermission (no-op) and MaximizePermissions (no-op) already ship. The four permission tests are the two-directional proof: no row means not SUPER, a SUPER row means SUPER, a row for a different role still means not SUPER.",
+  "dependencies": [],
+  "idRanges": [
+    {
+      "from": 65610,
+      "to": 65619
+    }
+  ],
+  "platform": "27.0.0.0",
+  "application": "27.0.0.0",
+  "runtime": "17.0",
+  "target": "Cloud"
+}


### PR DESCRIPTION
Closes #3039

Opened by agent impl-13 (automated implementation agent).

## Mechanism, measured

`NavUserAccountHelper.IsPermissionSetAssigned` is a two-line forwarder. Decompiled from
`Microsoft.Dynamics.Nav.NavUserAccount.dll` at BC 28.1.49838.53910:

```csharp
public static bool IsPermissionSetAssigned(Guid userSecurityId, string companyName,
                                           string roleId, Guid appId, int permissionScope)
    => PermissionManagement.IsPermissionSetAssignedAsync(
           Session, userSecurityId, new PermissionSetKey(roleId, appId,
           (PermissionScope)permissionScope), companyName).AsTask().GetAwaiter().GetResult();
```

and the Ncl method it forwards to ends in:

```csharp
return (isCurrentUser ? session.Permissions : new NavUserPermissions(user, session))
       .HasRole(companyName, permissionSet);
```

**The null is `session.Permissions`.** `NavSession.User` is *not* null on the skeleton — it is
`Authenticator.User`, and `BcRuntime` field-pokes a populated Authenticator — but
`NavSession.Permissions` has a private setter only the real session bring-up calls. Two files in
this repo already recorded that fact from their own encounters with it
(`EventSubscriberPatches.ReplaceAttributeWithZeroedCopy`, and `BcRuntime`'s
`NavRecord.TestFieldNotBlank` note); nothing had fixed it.

The runner-side stack from the failing run confirms the frame:

```
at Microsoft.Dynamics.Nav.Runtime.PermissionManagement.IsPermissionSetAssignedAsync(...)
at Microsoft.Dynamics.Nav.NavUserAccount.NavUserAccountHelper.IsPermissionSetAssigned(...)
at Microsoft.Dynamics.Nav.BusinessApplication.Codeunit153.HasUserPermissionSetAssigned(...)
...
at Microsoft.Dynamics.Nav.BusinessApplication.Codeunit9002.CheckCurrentUserCanModifyUser(...)
```

## Defect, not a scope boundary

Real BC completes this call, and permissions are not on the permanently-out-of-scope list. The
runner already answers permission questions in three shipped places, each with the same
justification — `NavSession.HasExecutePermission*` rewritten to `true` ("skeleton session runs
as SUPER"), `VerifyExecutePermission` to a no-op, `MaximizePermissions` to a no-op. Answering
`IsSuper(UserSecurityId())` with `false` while `HasExecutePermission` answers `true` would make
the runner contradict itself.

Decompiling codeunit 9002 also settled *when* the check is even reached — it is not on every
`User.Modify`:

```al
if Rec.IsTemporary() then exit;
if Rec."License Type" = Rec."License Type"::Agent then exit;
Rec.TestField("User Name");
if not User.Get(UserSecurityId()) then exit;
if User."User Security ID" = Rec."User Security ID" then exit;   // own row: never checked
if not UserPermissions.CanManageUsersOnTenant(UserSecurityId()) then Error(...);
```

## The fix

Cecil-rewrite `PermissionManagement.IsPermissionSetAssignedAsync` (Ncl — the runtime engine,
ours per `precompiled-dll-respect.md`; no AL business-logic body is touched) to answer from the
**Access Control table (2000000053)** — the same table real BC builds its permission cache from,
and ordinary AL-writable storage here. A row matches on User Security ID, Role ID, App ID and
Scope, with a blank Company Name meaning every company.

Populating `NavSession.Permissions` for real was considered and is not available:
`NavUserPermissions.HasRole` is `GetRoles(tenant.Database.CompanyTokens.Get(companyName))
.Contains(new NavRole(permissionSet, tenant.Database))` and `GetRoles` falls through to
`FetchRoles`, so both halves need a SQL-backed `NavTenant.Database`. `BcRuntime` records that
populating a skeleton `NavTenant` "pulls in the full database-bring-up chain and is out of
scope", having measured it breaking ~466 tests.

Plus **one stated fact**, narrow on purpose: the skeleton session's own user holds SUPER. Not
"holds everything" — asking whether `D365 BASIC` is assigned to the session user still answers
from rows, because under SUPER that set is superseded, not assigned, and `true` there would be
the silent fake `loud-failures.md` forbids.

## RED -> GREEN

`tests/runner-extras/permission-set-assignment`, 6 tests. Measured on BC 28.1.49838.53910 with
the Cecil registration removed and restored:

| test | without the fix | with |
|---|---|---|
| `ModifyingAnotherUsersRow_Succeeds_BecauseTheSessionUserIsSuper` | FAIL (the reported NRE) | PASS |
| `ModifyingAUserWithABlankName_StillRaisesTheSubscribersError` | PASS | PASS |
| `TheSessionUser_IsSuper` | FAIL | PASS |
| `AUserWithNoAccessControlRow_IsNotSuper` | FAIL | PASS |
| `AUserGrantedSuperInAccessControl_IsSuper` | FAIL | PASS |
| `AUserGrantedSomeOtherPermissionSet_IsNotSuper` | FAIL | PASS |

5 of 6 fail without it. The one that passes either way is the `asserterror` control, and it is
there deliberately: it proves codeunit 9002's subscriber still runs rather than having been
bypassed, which a fix that neutered the subscriber would break.

The suite cannot pass against a default return in either direction: no Access Control row means
not SUPER, a SUPER row means SUPER, and a row for a *different* role still means not SUPER. The
`TheSessionUser_IsSuper` test asserts `not User.IsEmpty()` first, because codeunit 153's
`IsSuper` opens with `if User.IsEmpty() then exit(true)` and would otherwise answer from that
bootstrap branch without consulting any permission set.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site — yes, found and fixed.**
   `NavRecordTestFieldNavigationPatches` invokes `GetEffectivePermissionForObject` with
   `self.Session.Permissions` as the reflection target, unguarded. A null target raises
   `TargetException` out of `TryAddTestFieldAction` — pre-empting the real
   `NavTestFieldException` that file exists to stop being pre-empted. Now guarded, skipping the
   optional navigate action exactly as every other unresolvable condition in that method already
   does.
2. **Sibling function with the same assumption — yes, filed as #3174.**
   `NavUserAccountHelper.IsUserSuperInAllCompanies()` is `Session.Permissions.IsSuperForAllCompanies`
   — one property read on the same null field, with **no Ncl hop in it at all**, so no rewrite of
   Ncl can reach it. Fixing it needs either Cecil over `Microsoft.Dynamics.Nav.NavUserAccount.dll`
   (a new assembly in the pipeline) or a real `NavUserPermissions` (the tenant-database chain
   above). `GetAllowedCompanies(Guid)` has the same shape against different skeleton state.
3. **Two paths writing one state — not applicable**; this change reads, it does not write.

## What a real tier says

**No verdict is available yet, and I am not claiming one.** No corpus test covered this shape —
`rg` over `tests/al-language` for `IsSuper` / `Access Control` / `User Permissions` returned only
a prose mention in `TestUserTableSessionUser.al`.

So I opened one: **corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#204**, read-only,
asserting that a user's SUPER status is backed by an Access Control row, with a security id
belonging to no user as the negative control. That PR's 16 legs are the verdict. It is not a
dependency of this PR and no pin bump is folded in here.

## The divergence this leaves, deliberately

Because the SUPER fact is *stated* rather than *seeded*, `IsSuper(UserSecurityId())` is true
while `Access Control` holds no row for the session user. On a real tier those agree. The runner
fails corpus PR #204's first test today for exactly that reason, which is the corpus doing its
job.

Seeding the row instead was considered and rejected **for this change**:
`RecordPatches.UserSystemTable.cs` records a deliberate decision not to seed Access Control
alongside the User row, and a seed would alter table state for every test in every bundle,
whereas stating the fact can only change an answer that throws today. Tracked as #3176, which
stays open. Recorded in `docs/limitations.md` under "Permission-set assignment".

Entitlements are not modeled at all, so a permission set a real tier reports as assigned *via an
entitlement* rather than via Access Control reads as not assigned here. Also documented.

## What I ran

All on BC 28.1.49838.53910, and **re-run after the rebase onto `main`** that this PR carries as
its current head (`824cfaf9`), so none of these numbers predates the rebase:

- `tests/runner-extras/permission-set-assignment` — **6/6**, and 1/6 with the fix removed.
- Full `tests/runner-extras` exactly as `bc-tests.yml` invokes it, `--strict` plus
  `--count-baseline` — **312/312, exit 0**.
- `tests/al-language` corpus at this branch's own pin (`861a5662`), `--strict` plus
  `--count-baseline` — **2665/2665, exit 0**.
- `dotnet test AlRunner.Tests` filtered to `NavRecordTestFieldNavigationPatchesTests`,
  `TestFieldValidationErrorsTests`, `NclCecilRewriteCacheKeyTests`,
  `PermissionMetadataShapeGapTests`, `ExpectationManifest*` — **55 passed, 3 skipped, 0 failed**.

The count baseline gains `permission-set-assignment: { "tests": 6 }` (runner-extras 55 groups /
306 tests -> 56 / 312), with the rationale in `history.md`. No `absentOn`: the bundle needs only
codeunit 152 and table 2000000053. **That was not validated locally** — a self-built runner is
compiled against Ncl 28.x and cannot run 27.x artifacts — so the 27.0/27.3/27.5 legs adjudicate
it, and an exit 4 there names the number to use.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
