### PR TITLE
fix(testpage): name the AL error "The TestPage is not open." was reported in place of

### DIFF
--- a/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/MtdAssert.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/MtdAssert.Codeunit.al
@@ -1,0 +1,9 @@
+// Standalone Assert — this fixture stands alone and imports nothing.
+codeunit 70544 "MTD Assert"
+{
+    procedure AreEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if Format(Expected) <> Format(Actual) then
+            Error('Expected <%1> but got <%2>: %3', Format(Expected), Format(Actual), Msg);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/MtdCard.Page.al
+++ b/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/MtdCard.Page.al
@@ -1,0 +1,20 @@
+page 70543 "MTD Card"
+{
+    PageType = Card;
+    SourceTable = "MTD Header";
+    ApplicationArea = All;
+    UsageCategory = Administration;
+
+    layout
+    {
+        area(Content)
+        {
+            field("No."; Rec."No.") { ApplicationArea = All; }
+            part(Lines; "MTD Lines")
+            {
+                ApplicationArea = All;
+                SubPageLink = "No." = field("No.");
+            }
+        }
+    }
+}

--- a/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/MtdHeader.Table.al
+++ b/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/MtdHeader.Table.al
@@ -1,0 +1,6 @@
+table 70540 "MTD Header"
+{
+    DataClassification = SystemMetadata;
+    fields { field(1; "No."; Code[20]) { DataClassification = SystemMetadata; } }
+    keys { key(PK; "No.") { Clustered = true; } }
+}

--- a/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/MtdLine.Table.al
+++ b/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/MtdLine.Table.al
@@ -1,0 +1,12 @@
+table 70541 "MTD Line"
+{
+    DataClassification = SystemMetadata;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { DataClassification = SystemMetadata; }
+        field(2; "Line No."; Integer) { DataClassification = SystemMetadata; }
+    }
+
+    keys { key(PK; "No.", "Line No.") { Clustered = true; } }
+}

--- a/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/MtdLines.Page.al
+++ b/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/MtdLines.Page.al
@@ -1,0 +1,30 @@
+// The linked part whose row-load trigger raises. The host card page refreshes this part as part
+// of its OWN row load (LiveNavTestPage.Loaded -> RefreshLinkedParts -> LiveNavTestPart
+// .ReloadLinkedRow -> the part's Loaded), so the error below is raised inside the host's open
+// and is what LiveNavTestPage.Loaded converts.
+//
+// The text is deliberately unmistakable and appears nowhere else in this repository, so an
+// assertion that finds it cannot be finding something else.
+page 70542 "MTD Lines"
+{
+    PageType = ListPart;
+    SourceTable = "MTD Line";
+    ApplicationArea = All;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Group)
+            {
+                field("No."; Rec."No.") { ApplicationArea = All; }
+                field("Line No."; Rec."Line No.") { ApplicationArea = All; }
+            }
+        }
+    }
+
+    trigger OnAfterGetRecord()
+    begin
+        Error('MTD-BOOM-70542 the part trigger refused this row');
+    end;
+}

--- a/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/MtdSetup.Table.al
+++ b/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/MtdSetup.Table.al
@@ -1,0 +1,14 @@
+// A setup table that is NEVER given a row, so MissingTestDataDiagnosis's census can measure it
+// as genuinely empty. Its only job is to be the table a page trigger fails on.
+table 70546 "MTD Setup"
+{
+    DataClassification = SystemMetadata;
+
+    fields
+    {
+        field(1; "Primary Key"; Code[10]) { DataClassification = SystemMetadata; }
+        field(2; Name; Text[30]) { DataClassification = SystemMetadata; }
+    }
+
+    keys { key(PK; "Primary Key") { Clustered = true; } }
+}

--- a/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/MtdSetupCard.Page.al
+++ b/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/MtdSetupCard.Page.al
@@ -1,0 +1,20 @@
+page 70548 "MTD Setup Card"
+{
+    PageType = Card;
+    SourceTable = "MTD Header";
+    ApplicationArea = All;
+    UsageCategory = Administration;
+
+    layout
+    {
+        area(Content)
+        {
+            field("No."; Rec."No.") { ApplicationArea = All; }
+            part(Lines; "MTD Setup Lines")
+            {
+                ApplicationArea = All;
+                SubPageLink = "No." = field("No.");
+            }
+        }
+    }
+}

--- a/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/MtdSetupLines.Page.al
+++ b/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/MtdSetupLines.Page.al
@@ -1,0 +1,34 @@
+// The second linked part, and the one that makes the MissingTestDataDiagnosis half of #3189
+// provable. Its row trigger fails on a MISSING SETUP RECORD rather than on a bare Error(), so
+// the converted exception carries the typed evidence that diagnosis needs — the AL table id, put
+// there by RecordWritePatches.BuildRecordNotFoundException — behind the same TestPage mask.
+//
+// Without the link that MissingTestDataDiagnosis.TryNameTable now follows, that evidence is
+// unreachable and the failure gets no [test-data] explanation, which is exactly the shape #2240
+// exists to explain going unexplained because it happened inside a page trigger.
+page 70547 "MTD Setup Lines"
+{
+    PageType = ListPart;
+    SourceTable = "MTD Line";
+    ApplicationArea = All;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Group)
+            {
+                field("No."; Rec."No.") { ApplicationArea = All; }
+                field("Line No."; Rec."Line No.") { ApplicationArea = All; }
+            }
+        }
+    }
+
+    trigger OnAfterGetRecord()
+    var
+        Setup: Record "MTD Setup";
+    begin
+        // A statement-position Get() raises; "MTD Setup" has no rows and never gets any.
+        Setup.Get('X');
+    end;
+}

--- a/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/MtdTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/MtdTests.Codeunit.al
@@ -1,0 +1,76 @@
+// Three arms for issue #3189, two of which fail BY CONSTRUCTION — the diagnosis this fixture is
+// about only exists on a reported failure, so a fixture where everything passes could not
+// observe it at all. MaskedTriggerErrorDiagnosisTests asserts on each arm's reported block.
+//
+//   MaskedPartTriggerError_IsReportedWithTheCauseNamed   fails; must carry BC's message AND the
+//                                                        converted cause
+//   MaskedPartTriggerError_AlStillSeesOnlyBcsOwnMessage  passes; pins that the cause stays OUT
+//                                                        of what AL can read
+//   PlainFailure_IsReportedWithNoTestPageDiagnosis       fails; must carry NO diagnosis
+//
+// The middle one is the guard that stops the fix from becoming "leak the original into AL".
+// Real BC surfaces "The TestPage is not open." and nothing else here (#2656), so a diagnosis
+// that reached GetLastErrorText would be a runner-invented AL error.
+codeunit 70545 "MTD Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit "MTD Assert";
+        NotOpenTxt: Label 'The TestPage is not open.', Locked = true;
+
+    local procedure SeedOneHeaderWithOneLine()
+    var
+        Header: Record "MTD Header";
+        Line: Record "MTD Line";
+    begin
+        Line.DeleteAll();
+        Header.DeleteAll();
+
+        Header.Init();
+        Header."No." := 'H1';
+        Header.Insert();
+
+        // The part must FIND a row: LiveNavTestPage.Loaded only runs OnAfterGetRecord for a row
+        // it found, so without this line the part's trigger never raises and the arm would pass
+        // for a reason that has nothing to do with the fix.
+        Line.Init();
+        Line."No." := 'H1';
+        Line."Line No." := 10000;
+        Line.Insert();
+    end;
+
+    [Test]
+    procedure MaskedPartTriggerError_IsReportedWithTheCauseNamed()
+    var
+        Card: TestPage "MTD Card";
+    begin
+        SeedOneHeaderWithOneLine();
+        // Fails by construction: the linked part's OnAfterGetRecord raises while the host page
+        // is opening. What the runner REPORTS for this failure is the subject.
+        Card.OpenEdit();
+    end;
+
+    [Test]
+    procedure MaskedPartTriggerError_AlStillSeesOnlyBcsOwnMessage()
+    var
+        Card: TestPage "MTD Card";
+    begin
+        SeedOneHeaderWithOneLine();
+
+        asserterror Card.OpenEdit();
+
+        Assert.AreEqual(NotOpenTxt, GetLastErrorText(),
+            'AL must see BC''s own message and nothing else — the converted cause is diagnostic ' +
+            'output, not an AL-visible error (issue #3189)');
+    end;
+
+    [Test]
+    procedure PlainFailure_IsReportedWithNoTestPageDiagnosis()
+    begin
+        // No page, nothing converted, so nothing to name. Fails by construction; the assertion
+        // is that its reported block carries no diagnosis at all.
+        Error('MTD-PLAIN-70545 a failure with no page involved');
+    end;
+}

--- a/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/MtdTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/MtdTests.Codeunit.al
@@ -3,9 +3,12 @@
 // observe it at all. MaskedTriggerErrorDiagnosisTests asserts on each arm's reported block.
 //
 //   MaskedPartTriggerError_IsReportedWithTheCauseNamed   fails; must carry BC's message AND the
-//                                                        converted cause
+//                                                        converted cause, and NO [test-data] note
 //   MaskedPartTriggerError_AlStillSeesOnlyBcsOwnMessage  passes; pins that the cause stays OUT
 //                                                        of what AL can read
+//   MaskedSetupRecordError_CarriesBothExplanations       fails; must carry the converted cause
+//                                                        AND the [test-data] note for the empty
+//                                                        table behind it
 //   PlainFailure_IsReportedWithNoTestPageDiagnosis       fails; must carry NO diagnosis
 //
 // The middle one is the guard that stops the fix from becoming "leak the original into AL".
@@ -64,6 +67,19 @@ codeunit 70545 "MTD Tests"
         Assert.AreEqual(NotOpenTxt, GetLastErrorText(),
             'AL must see BC''s own message and nothing else — the converted cause is diagnostic ' +
             'output, not an AL-visible error (issue #3189)');
+    end;
+
+    [Test]
+    procedure MaskedSetupRecordError_CarriesBothExplanations()
+    var
+        Card: TestPage "MTD Setup Card";
+    begin
+        SeedOneHeaderWithOneLine();
+        // Fails by construction, like the arm above, but on a MISSING SETUP RECORD rather than a
+        // bare Error(). "MTD Setup" is never given a row, so the converted exception carries the
+        // typed evidence MissingTestDataDiagnosis needs (the AL table id) behind the TestPage
+        // mask — which is the only way to observe that its walk follows the link (#3189).
+        Card.OpenEdit();
     end;
 
     [Test]

--- a/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/app.json
+++ b/AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis/app.json
@@ -1,0 +1,24 @@
+{
+  "id": "0a5c9f31-6d24-4f8b-9a17-2c8b4e77d310",
+  "name": "Runner Tests Fixture - Masked Trigger Error Diagnosis",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Issue #3189: an AL error a page trigger raised is reported to AL as BC's own \"The TestPage is not open.\", and the runner must still name the error it converted.",
+  "description": "Runner-mechanism fixture. The AL-visible message is BC's, measured upstream (#2656), and this fixture pins that it does not change. What it proves is the runner's OWN reporting: the converted error is named in the failure's diagnosis line, and only when there is one to name. Declares no application floor: everything it needs is its own.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "idRanges": [
+    {
+      "from": 70540,
+      "to": 70559
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner.Tests/MaskedTriggerErrorDiagnosisTests.cs
+++ b/AlRunner.Tests/MaskedTriggerErrorDiagnosisTests.cs
@@ -1,0 +1,161 @@
+// MaskedTriggerErrorDiagnosisTests — issue #3189.
+//
+// This is a RUNNER-MECHANISM test. It asserts nothing new about Business Central.
+//
+// What BC does is already settled and is deliberately left alone: a page whose row-load trigger
+// raises an AL error is torn down, and every later use of that TestPage variable reports BC's
+// own "The TestPage is not open." — the raised error's own text never reaches AL. That was
+// measured on 27.5 / 28.3 / 28.4 for #2656 and this suite's middle arm exists to keep the fix
+// from changing it.
+//
+// What this suite proves is the runner's own REPORTING, which is where #3189 was:
+//
+//   1. a failure the runner converted names the error it converted, in the diagnosis line
+//      beside the failure (positive);
+//   2. AL still sees only BC's message — GetLastErrorText, inside the fixture, on the same
+//      error (the guard that stops the fix from leaking the cause into AL);
+//   3. a failure with nothing converted gets no diagnosis at all (negative).
+//
+// 1 and 3 together are the claim. Without 3 the "fix" could be a line printed unconditionally,
+// which would say nothing and would still make this file green.
+//
+// WHY A FIXTURE AND A SUBPROCESS, rather than calling MaskedTriggerErrorDiagnosis.Explain with a
+// hand-built exception: the thing that failed in #3189 was the WIRING. The cause was recorded
+// correctly the whole time — it was written to an Exception.Data key that nothing read, and any
+// unit test of the diagnosis in isolation would have passed against that. So the assertion has
+// to be made on what a developer actually reads out of a real run.
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class MaskedTriggerErrorDiagnosisTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static readonly string FixtureDir =
+        Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", "MaskedTriggerErrorDiagnosis");
+
+    /// <summary>The AL error the fixture's part trigger raises. Unmistakable on purpose: an
+    /// assertion that finds this string cannot be finding something else in the log.</summary>
+    private const string PartTriggerError = "MTD-BOOM-70542 the part trigger refused this row";
+
+    private static (int ExitCode, string StdOut, string StdErr) Run(string cacheDir)
+    {
+        var sb = new StringBuilder(TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner")));
+        sb.Append(' ').Append($"\"{FixtureDir}\"");
+        sb.Append(' ').Append($"--cache \"{cacheDir}\"");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = sb.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+
+        var outSb = new StringBuilder();
+        var errSb = new StringBuilder();
+        using var proc = Process.Start(psi)!;
+        proc.OutputDataReceived += (_, e) => { if (e.Data != null) lock (outSb) outSb.AppendLine(e.Data); };
+        proc.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (errSb) errSb.AppendLine(e.Data); };
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+        if (!proc.WaitForExit(180_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException("al-runner did not exit within 180s.");
+        }
+        // WaitForExit(int) does not drain the async output callbacks; the parameterless
+        // overload does. See #2496.
+        proc.WaitForExit();
+        return (proc.ExitCode, outSb.ToString(), errSb.ToString());
+    }
+
+    /// <summary>
+    /// The reported block for one test: its header line plus every indented continuation line
+    /// under it. The assertions are written against a single test's block rather than the whole
+    /// log, because "the output carries no diagnosis" would otherwise be satisfied by the
+    /// diagnosis simply landing under a different test.
+    /// </summary>
+    private static string BlockFor(string output, string testMethod)
+    {
+        var lines = output.Replace("\r\n", "\n").Split('\n');
+        var block = new StringBuilder();
+        var inBlock = false;
+        foreach (var line in lines)
+        {
+            var isHeader = line.StartsWith("FAIL ", StringComparison.Ordinal)
+                        || line.StartsWith("PASS ", StringComparison.Ordinal)
+                        || line.StartsWith("ERROR", StringComparison.Ordinal)
+                        || line.StartsWith("SKIP ", StringComparison.Ordinal);
+            if (isHeader)
+            {
+                if (inBlock) break;
+                inBlock = line.Contains($".{testMethod} (", StringComparison.Ordinal);
+                if (inBlock) block.AppendLine(line);
+                continue;
+            }
+            if (inBlock) block.AppendLine(line);
+        }
+        Assert.True(block.Length > 0,
+            $"no reported block for '{testMethod}' — the fixture did not run as expected. Full output:\n{output}");
+        return block.ToString();
+    }
+
+    [Fact]
+    public void ConvertedTriggerError_IsNamedInTheDiagnosis_AndNotShownToAl()
+    {
+        var cacheDir = TestScratch.Dir("al-runner-mtd-tests");
+        try
+        {
+            var (exit, stdout, stderr) = Run(cacheDir);
+
+            // Two of the three fixture tests fail by construction — the diagnosis only exists on
+            // a reported failure, so there is nothing to observe in an all-green fixture.
+            Assert.NotEqual(0, exit);
+
+            // ── 1. positive: the converted error is named ─────────────────────────────────
+            var masked = BlockFor(stdout, "MaskedPartTriggerError_IsReportedWithTheCauseNamed");
+
+            // BC's own message is still what the failure REPORTS. The fix adds; it does not
+            // replace.
+            Assert.Contains("NavNCLDialogException: The TestPage is not open.",
+                masked, StringComparison.Ordinal);
+
+            // And the cause the runner had been discarding is now beside it, named with the
+            // exception type as well as the text.
+            Assert.Contains("[testpage]", masked, StringComparison.Ordinal);
+            Assert.Contains(PartTriggerError, masked, StringComparison.Ordinal);
+
+            // One line, because the bundle reporter keeps only line 1 of a message (#2261).
+            var diagnosisLines = masked.Replace("\r\n", "\n").Split('\n')
+                .Where(l => l.Contains("[testpage]", StringComparison.Ordinal)).ToList();
+            Assert.Single(diagnosisLines);
+            Assert.Contains(PartTriggerError, diagnosisLines[0], StringComparison.Ordinal);
+
+            // ── 2. the guard: AL saw only BC's message ───────────────────────────────────
+            // Asserted inside the fixture, against GetLastErrorText on the very same error, so
+            // this cannot pass by the cause merely being absent from the log.
+            Assert.Contains("PASS  Codeunit70545.MaskedPartTriggerError_AlStillSeesOnlyBcsOwnMessage",
+                stdout, StringComparison.Ordinal);
+
+            // ── 3. negative: nothing converted, nothing said ─────────────────────────────
+            var plain = BlockFor(stdout, "PlainFailure_IsReportedWithNoTestPageDiagnosis");
+            Assert.Contains("MTD-PLAIN-70545 a failure with no page involved",
+                plain, StringComparison.Ordinal);
+            Assert.DoesNotContain("[testpage]", plain, StringComparison.Ordinal);
+
+            Assert.DoesNotContain("suite errors", stderr, StringComparison.Ordinal);
+        }
+        finally
+        {
+            try { Directory.Delete(cacheDir, recursive: true); } catch { /* best-effort cleanup */ }
+        }
+    }
+}

--- a/AlRunner.Tests/MaskedTriggerErrorDiagnosisTests.cs
+++ b/AlRunner.Tests/MaskedTriggerErrorDiagnosisTests.cs
@@ -14,10 +14,21 @@
 //      beside the failure (positive);
 //   2. AL still sees only BC's message — GetLastErrorText, inside the fixture, on the same
 //      error (the guard that stops the fix from leaking the cause into AL);
-//   3. a failure with nothing converted gets no diagnosis at all (negative).
+//   3. a failure with nothing converted gets no diagnosis at all (negative);
+//   4. MissingTestDataDiagnosis (#2240) can see THROUGH the mask — a page trigger that fails on
+//      a table with no rows gets its [test-data] explanation, which it did not before, because
+//      the replacement exception carries neither a table id nor a NavTestFieldException.
 //
-// 1 and 3 together are the claim. Without 3 the "fix" could be a line printed unconditionally,
-// which would say nothing and would still make this file green.
+// 1 and 3 together are the claim for the [testpage] half. Without 3 the "fix" could be a line
+// printed unconditionally, which would say nothing and would still make this file green.
+//
+// 4 EXISTS BECAUSE THE FIRST VERSION OF THIS SUITE DID NOT HAVE IT. Reverting
+// MissingTestDataDiagnosis.TryNameTable's extra link left the suite green, because every arm
+// then failed on a bare Error() carrying no typed table evidence — so the walk had nothing to
+// find with or without the link. That is tdd.md's question answered "yes": it would have passed
+// against an implementation that did nothing. MaskedSetupRecordError_CarriesBothExplanations
+// fails on a missing setup record instead, and arm 1 now also asserts it gets NO [test-data]
+// note, so the link cannot be "fixed" by firing on everything.
 //
 // WHY A FIXTURE AND A SUBPROCESS, rather than calling MaskedTriggerErrorDiagnosis.Explain with a
 // hand-built exception: the thing that failed in #3189 was the WIRING. The cause was recorded
@@ -139,17 +150,40 @@ public sealed class MaskedTriggerErrorDiagnosisTests
             Assert.Single(diagnosisLines);
             Assert.Contains(PartTriggerError, diagnosisLines[0], StringComparison.Ordinal);
 
+            // A bare Error() names no table, so nothing widens into a missing-data claim. This
+            // is the does-not-fire-spuriously half of arm 4 below: following one more link must
+            // widen the SEARCH, never manufacture evidence.
+            Assert.DoesNotContain("[test-data]", masked, StringComparison.Ordinal);
+
             // ── 2. the guard: AL saw only BC's message ───────────────────────────────────
             // Asserted inside the fixture, against GetLastErrorText on the very same error, so
             // this cannot pass by the cause merely being absent from the log.
             Assert.Contains("PASS  Codeunit70545.MaskedPartTriggerError_AlStillSeesOnlyBcsOwnMessage",
                 stdout, StringComparison.Ordinal);
 
+            // ── 4. the mask no longer hides evidence from MissingTestDataDiagnosis ───────
+            // Same conversion, but the trigger failed on a missing setup record, so the
+            // converted exception carries the AL table id that #2240's diagnosis needs. Both
+            // explanations must be there: the converted cause, AND the empty table behind it.
+            var setup = BlockFor(stdout, "MaskedSetupRecordError_CarriesBothExplanations");
+            Assert.Contains("NavNCLDialogException: The TestPage is not open.",
+                setup, StringComparison.Ordinal);
+            Assert.Contains("[testpage]", setup, StringComparison.Ordinal);
+            Assert.Contains("NavCSideRecordNotFoundException: The MTD Setup does not exist.",
+                setup, StringComparison.Ordinal);
+
+            // The half that is unreachable without TryNameTable following the converted-error
+            // link. Table id as well as name, so this cannot be satisfied by the table name
+            // merely appearing inside the [testpage] text.
+            Assert.Contains("[test-data] 'MTD Setup' (table 70546) has no rows in this run",
+                setup, StringComparison.Ordinal);
+
             // ── 3. negative: nothing converted, nothing said ─────────────────────────────
             var plain = BlockFor(stdout, "PlainFailure_IsReportedWithNoTestPageDiagnosis");
             Assert.Contains("MTD-PLAIN-70545 a failure with no page involved",
                 plain, StringComparison.Ordinal);
             Assert.DoesNotContain("[testpage]", plain, StringComparison.Ordinal);
+            Assert.DoesNotContain("[test-data]", plain, StringComparison.Ordinal);
 
             Assert.DoesNotContain("suite errors", stderr, StringComparison.Ordinal);
         }

--- a/AlRunner/Infrastructure/FailureDiagnosis.cs
+++ b/AlRunner/Infrastructure/FailureDiagnosis.cs
@@ -1,0 +1,35 @@
+// FailureDiagnosis — the one place a failing test's optional explanation is composed.
+//
+// There is more than one thing worth saying next to a failure now, and they are independent:
+// MissingTestDataDiagnosis (#2240) explains a failure against a table with no rows in it,
+// MaskedTriggerErrorDiagnosis (#3189) names the AL error a TestPage teardown was reported in
+// place of. Both can apply to one failure — a page trigger that failed on a missing setup
+// record is exactly that case — so the composer joins them rather than picking one, and it
+// exists so the four TestResult sites in TestExecutor cannot drift into asking different
+// questions.
+//
+// Everything the two of them promise individually holds here: this only ever ADDS text beside a
+// failure. It never replaces the failure's own message, never changes its outcome, and never
+// reaches AL (.claude/rules/loud-failures.md).
+//
+// ONE LINE, still. The bundle reporter keeps only line 1 of a message (#2261), so the join is a
+// space and neither half may contain a line break.
+using System;
+
+namespace AlRunner.Infrastructure;
+
+internal static class FailureDiagnosis
+{
+    internal static string? Explain(Exception? ex)
+    {
+        // Masked cause first: it says WHICH error is being explained, so a missing-data
+        // sentence after it reads as being about that error rather than about BC's stand-in
+        // message.
+        var masked = MaskedTriggerErrorDiagnosis.Explain(ex);
+        var missingData = MissingTestDataDiagnosis.Explain(ex);
+
+        if (masked == null) return missingData;
+        if (missingData == null) return masked;
+        return masked + " " + missingData;
+    }
+}

--- a/AlRunner/Infrastructure/MaskedTriggerErrorDiagnosis.cs
+++ b/AlRunner/Infrastructure/MaskedTriggerErrorDiagnosis.cs
@@ -1,0 +1,96 @@
+// MaskedTriggerErrorDiagnosis — issue #3189.
+//
+// THE PROBLEM, MEASURED
+//   A page's row-load trigger (OnAfterGetRecord / OnAfterGetCurrRecord) that raises an AL error
+//   tears the TestPage down, and what propagates to AL from then on is BC's own
+//   "The TestPage is not open." — the raised error's own text never reaches the AL caller. That
+//   is faithful (#2656, measured on 27.5 / 28.3 / 28.4) and it stays.
+//
+//   What was NOT faithful is that the runner then threw the raised error away. LiveNavTestPage
+//   .Loaded stashed it in Exception.Data and nothing ever read it, so the error existed for the
+//   length of one `throw` and became unreachable. In the Tests-SMB nightly of 2026-09-06 that
+//   cost 132 failures whose entire reported text was
+//
+//       NavNCLDialogException: The TestPage is not open.
+//
+//   with no cause in the run log, the JSON classification or the JUnit report. All 132 turned
+//   out to be one error — a CalcFields refusal raised inside a FactBox part's trigger (#3121) —
+//   and finding that out took patching the runner to print what it had discarded and re-running
+//   the bucket. Reading the message instead pointed at the TestPage close/open commits in the
+//   same window, none of which was involved.
+//
+// WHAT THIS DOES, AND WHAT IT DELIBERATELY DOES NOT DO
+//   Exactly what MissingTestDataDiagnosis (#2240) does, and for the same reason: it ADDS an
+//   explanation next to a failure. It never replaces one, never downgrades an outcome, and
+//   never touches the failing test's own message, exception type or AL call stack
+//   (.claude/rules/loud-failures.md). Above all it does not make the converted error AL-visible:
+//   asserterror and GetLastErrorText still see only BC's own message, which is what a real
+//   service tier gives them. Fixture codeunit 70545's
+//   MaskedPartTriggerError_AlStillSeesOnlyBcsOwnMessage is the arm that holds that line.
+//
+// NO GUESSING
+//   The evidence is typed and the runner recorded it itself — the converted exception, carried
+//   on the Data key below by the ONE site that builds the replacement. There is no text
+//   matching here: "The TestPage is not open." is a BC resource string like any other, and
+//   matching on it would be a guess that stops working the moment BC rewords or localises it.
+//   No key, no explanation.
+using System;
+
+namespace AlRunner.Infrastructure;
+
+internal static class MaskedTriggerErrorDiagnosis
+{
+    /// <summary>
+    /// Exception.Data key carrying the AL error a page trigger raised, on the replacement
+    /// exception the runner reports in its place. Written by
+    /// LiveNavTestPage.MakeTestPageNotOpenException; read here and — so the mask does not hide
+    /// evidence from it either — by MissingTestDataDiagnosis. A string key rather than an object
+    /// one so it survives any dictionary copy.
+    /// </summary>
+    internal const string ConvertedErrorDataKey = "al-runner.testpage.converted-error";
+
+    /// <summary>
+    /// The AL error that <paramref name="ex"/> was reported in place of, or null when
+    /// <paramref name="ex"/> is not a replacement. Walks the InnerException chain for the same
+    /// reason MissingTestDataDiagnosis.TryNameTable does: by the time a failure reaches the
+    /// reporter it may be wrapped by the reflection invoke path.
+    /// </summary>
+    internal static Exception? Unmask(Exception? ex)
+    {
+        for (var e = ex; e != null; e = e.InnerException)
+            if (e.Data[ConvertedErrorDataKey] is Exception converted)
+                return converted;
+        return null;
+    }
+
+    /// <summary>
+    /// The one-line explanation, or null when nothing was converted. One line because the bundle
+    /// reporter keeps only line 1 of a message (#2261) — an explanation whose second line
+    /// carried the actionable part would reach nobody — so the converted error's own text is
+    /// flattened rather than reproduced with its line breaks.
+    /// </summary>
+    internal static string? Explain(Exception? ex)
+    {
+        var converted = Unmask(ex);
+        if (converted == null) return null;
+
+        return $"[testpage] this is BC's own message for a page whose row-load trigger raised; "
+             + $"the error it raised, which BC does not show AL, was "
+             + $"{converted.GetType().Name}: {OneLine(converted.Message)}";
+    }
+
+    /// <summary>Collapse every run of whitespace, including line breaks, to one space.</summary>
+    private static string OneLine(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return "(no message)";
+        var sb = new System.Text.StringBuilder(text!.Length);
+        var pendingSpace = false;
+        foreach (var c in text)
+        {
+            if (char.IsWhiteSpace(c)) { pendingSpace = sb.Length > 0; continue; }
+            if (pendingSpace) { sb.Append(' '); pendingSpace = false; }
+            sb.Append(c);
+        }
+        return sb.ToString();
+    }
+}

--- a/AlRunner/Infrastructure/MissingTestDataDiagnosis.cs
+++ b/AlRunner/Infrastructure/MissingTestDataDiagnosis.cs
@@ -124,11 +124,18 @@ internal static class MissingTestDataDiagnosis
     /// Resolve the failure to exactly one table the store can answer for. Ordered by how strong
     /// the evidence is: an id the runner itself recorded, then a table name BC put on a typed
     /// property. Anything else is not evidence and returns false.
+    ///
+    /// <para>The walk follows InnerException AND the converted-error link a TestPage teardown
+    /// leaves behind (#3189). A page trigger that fails on a missing setup record is reported to
+    /// AL as BC's "The TestPage is not open.", and that replacement carries neither the table id
+    /// nor a NavTestFieldException — so without this step the mask hid the evidence from this
+    /// diagnosis too, and exactly the failure #2240 exists to explain went unexplained whenever
+    /// it happened inside a page trigger.</para>
     /// </summary>
     private static bool TryNameTable(Exception ex, out AlRunner.Patches.RecordPatches.StoredTableCensus census)
     {
         census = default!;
-        for (var e = ex; e != null; e = e.InnerException)
+        for (var e = ex; e != null; e = Next(e))
         {
             if (e.Data[TableIdDataKey] is int taggedId
                 && AlRunner.Patches.RecordPatches.TryCensusTable(taggedId, out census))
@@ -140,5 +147,11 @@ internal static class MissingTestDataDiagnosis
                 return true;
         }
         return false;
+
+        // InnerException first, so an ordinary wrapped failure walks exactly as it did before.
+        // The converted-error link is only ever present on a replacement the runner built
+        // itself, and a replacement has no InnerException on the path that carries it.
+        static Exception? Next(Exception e) =>
+            e.InnerException ?? MaskedTriggerErrorDiagnosis.Unmask(e);
     }
 }

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -722,13 +722,24 @@ internal class LiveNavTestPage : MockITestPage
             {
                 var ex = (System.Exception)ctor.Invoke(new object[] { msg });
                 // Not AL-visible (asserterror / GetLastErrorText only see the outer message,
-                // matching real BC) -- kept only so a runner-side stack trace can still show
-                // what actually failed inside the trigger.
-                if (original != null) ex.Data["OriginalTriggerError"] = original;
+                // matching real BC) -- carried so the runner can still NAME what actually
+                // failed inside the trigger. Issue #3189: this used to be written under a key
+                // nothing read, which made 132 Tests-SMB failures report a message with no
+                // cause anywhere in the run. Infrastructure.MaskedTriggerErrorDiagnosis reads
+                // it into the failure's diagnosis line, and MissingTestDataDiagnosis walks
+                // through it so the mask does not hide ITS evidence either.
+                if (original != null)
+                    ex.Data[Infrastructure.MaskedTriggerErrorDiagnosis.ConvertedErrorDataKey] = original;
                 return ex;
             }
         }
-        return new System.InvalidOperationException(msg, original);
+        // Same contract on the fallback path: the converted error is reachable both as the
+        // InnerException and under the key the diagnosis reads, so which construction path ran
+        // cannot change what the failure reports.
+        var fallback = new System.InvalidOperationException(msg, original);
+        if (original != null)
+            fallback.Data[Infrastructure.MaskedTriggerErrorDiagnosis.ConvertedErrorDataKey] = original;
+        return fallback;
     }
 
     /// <summary>

--- a/AlRunner/ProgramSupport/CliText.cs
+++ b/AlRunner/ProgramSupport/CliText.cs
@@ -37,6 +37,13 @@ internal static partial class ProgramSupport
         w.WriteLine("  dependency set is runnable (see DEPENDENCIES below); it proves only that");
         w.WriteLine("  symbols resolved.");
         w.WriteLine();
+        w.WriteLine("  \"The TestPage is not open.\" IS NEVER THE WHOLE STORY. That is BC's own message");
+        w.WriteLine("  for a page whose row-load trigger raised an AL error: the page is torn down and");
+        w.WriteLine("  the raised error's own text never reaches AL, on a real service tier as well as");
+        w.WriteLine("  here. So do NOT read it as a page-lifecycle problem. The runner prints the error");
+        w.WriteLine("  it was reported in place of on a one-line [testpage] note under the failure —");
+        w.WriteLine("  that named error is the one to fix.");
+        w.WriteLine();
 
         w.WriteLine("INVOCATION — the shortest correct command lines");
         w.WriteLine("  Run one bundle (a dir containing app.json, or any dir below one):");

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -97,10 +97,11 @@ public sealed record TestResult(string Codeunit, string Method, TestOutcome Outc
                                 // zero AL locals" is represented (AlValueCapture.Collect()
                                 // never returns null).
                                 IReadOnlyList<Infrastructure.AlCapturedValue>? CapturedValues = null,
-                                // #2240: an ADDITIONAL one-line explanation shown next to the
-                                // failure, never instead of it. Non-null only when the runner has
-                                // EVIDENCE that the failure is about a table with no rows in it —
-                                // see Infrastructure.MissingTestDataDiagnosis for why a text
+                                // #2240 / #3189: an ADDITIONAL one-line explanation shown next to
+                                // the failure, never instead of it. Non-null only when the runner
+                                // has typed EVIDENCE — a table with no rows in it, or the AL error
+                                // a TestPage teardown was reported in place of. See
+                                // Infrastructure.FailureDiagnosis, and each half for why a text
                                 // pattern alone is not evidence. Message, FullException,
                                 // AlCallStack, Outcome and Exception are all untouched by it.
                                 string? Diagnosis = null,
@@ -717,7 +718,7 @@ public sealed class TestExecutor
                 var ctorResult = new TestResult(t.Name, "<ctor>", TestOutcome.Error,
                     Unwrap(ex).Message, ex.ToString(), TimeSpan.Zero,
                     Exception: Unwrap(ex), InsideTestProc: false,
-                    Diagnosis: AlRunner.Infrastructure.MissingTestDataDiagnosis.Explain(Unwrap(ex)));
+                    Diagnosis: AlRunner.Infrastructure.FailureDiagnosis.Explain(Unwrap(ex)));
                 results.Add(ctorResult);
                 onTestComplete?.Invoke(ctorResult);
                 continue;
@@ -807,7 +808,7 @@ public sealed class TestExecutor
                             var ctorResult = new TestResult(t.Name, m.Name, TestOutcome.Error,
                                 Unwrap(ex).Message, ex.ToString(), TimeSpan.Zero,
                                 null, displayName, Unwrap(ex), InsideTestProc: false,
-                                Diagnosis: AlRunner.Infrastructure.MissingTestDataDiagnosis.Explain(Unwrap(ex)));
+                                Diagnosis: AlRunner.Infrastructure.FailureDiagnosis.Explain(Unwrap(ex)));
                             results.Add(ctorResult);
                             onTestComplete?.Invoke(ctorResult);
                             continue;
@@ -1342,7 +1343,7 @@ public sealed class TestExecutor
                 // the codeunit/test boundary that follows restores the install baseline over it,
                 // so a diagnosis derived after the fact would describe a different database than
                 // the one the test actually failed against.
-                Diagnosis: AlRunner.Infrastructure.MissingTestDataDiagnosis.Explain(inner));
+                Diagnosis: AlRunner.Infrastructure.FailureDiagnosis.Explain(inner));
         }
         catch (Exception ex)
         {
@@ -1352,7 +1353,7 @@ public sealed class TestExecutor
             return new TestResult(codeunit, m.Name, TestOutcome.Error,
                 ex.Message, ex.ToString(), sw.Elapsed, alStack, displayName,
                 ex,
-                Diagnosis: AlRunner.Infrastructure.MissingTestDataDiagnosis.Explain(ex));
+                Diagnosis: AlRunner.Infrastructure.FailureDiagnosis.Explain(ex));
         }
         finally
         {

--- a/README.md
+++ b/README.md
@@ -223,6 +223,13 @@ that table is measurably empty, so a genuine bug against a populated table is ne
 as missing data. With `--test-data` already on, the line says instead why the table is still
 empty (refused, not in this backup, or empty in it).
 
+A failure reported as `The TestPage is not open.` gets the same treatment. That is BC's own
+message for a page whose row-load trigger raised an AL error — the page is torn down and the
+raised error's text never reaches AL, on a real service tier too — so the message names the
+symptom and not the cause. The runner prints the error it was reported in place of on a one-line
+`[testpage]` note under the failure. What AL sees is unchanged: `asserterror` and
+`GetLastErrorText` still read only BC's message.
+
 Environment variables: `AL_RUNNER_VERBOSE=1`, `AL_RUNNER_SHOW_PASS=1`, `AL_RUNNER_TRACE_NRE=1` (logs every first-chance NRE before AL `asserterror` swallows it), `AL_RUNNER_BCBAK` (path to the `bcbak` backup reader used by `--test-data`), `AL_RUNNER_ARTIFACTS_ROOT` (see below).
 
 `AL_RUNNER_ARTIFACTS_ROOT=DIR` moves the BC artifact cache off the home directory — useful when it has to sit on a different volume, or on a mounted path on a CI runner. `DIR` is the root the per-version subdirectories live under (default `~/.local/share/al-runner/artifacts`), so `--bc-version`, latest-in-cache defaulting and provisioning keep working. That is what makes it different from `--artifact-path`, which pins one version's engine directory and skips version selection entirely. A relative value is resolved against the current directory. The build reads it too, so a relocated cache stays buildable from source. Moving `$HOME` instead would relocate every other runner path (`~/.cache/al-runner`, `~/.bcartifacts.cache`, `~/.local/share/al-runner/symbols`) along with it.


### PR DESCRIPTION
Closes #3189

Opened by the agent **impl-19**, sent to attribute the `Tests-SMB` MS-bucket nightly regression of 2026-09-06.

## The regression, and what actually caused it

Three nightly runs, same 1028 tests, BC 28.4.53241.54318:

| run | head | pass | fail | err |
|---|---|---|---|---|
| 03:28 | `5ca2847f` | 690 | 323 | 15 |
| 07:10 | `c9c4c463` | 690 | 323 | 15 |
| 14:42 | `be7a4de0` | **555** | 460 | 13 |

143 went PASS to FAIL. 93 of them reported `NavNCLDialogException: The TestPage is not open.` and nothing else; 132 failures in that run carried that message.

**None of the five TestPage commits in the window is involved** — not `f46c369e` (#3098), `45cd74c7` (#3060), `b78a1291` (#3061), `96e5e2da` (#2974), or `bb09fa5b` (#2951). I eliminated them by reading the masked cause rather than by bisecting, which turned out to be both cheaper and conclusive.

The cause is `1aef9e75` (#3079), `fix(record): refuse a CalcFields field that is not a FlowField or a BLOB, the way BC does`, meeting a runner gap it did not create: a FlowField contributed by a tableextension arrives with an empty `CalcFormula`, so the new refusal fires on a field that does have one in BC. That is **#3121**, already open and in progress, and #3079 is correct — it replaced a silent no-op with BC's own `RecordImplementation.CalcFieldsAsync` refusal, which is what `.claude/rules/loud-failures.md` asks for. I am not touching either.

All 132 masked originals in one local run are byte-identical:

```
NavCSideException: You must define a CalcFormula for the Outstanding Serv. Orders (LCY)
FlowField in the Customer table.
   at Page9082.CalculateFieldValues(NavCode customerNo)      <- "Customer Statistics FactBox"
   at Page9082.OnAfterGetCurrRecordAsync()
   at RunnerPageInstance.RaiseOnAfterGetRecord()
   at LiveNavTestPage.Loaded(Boolean found)                  <- converted here
```

One cause, not two. This cluster and the ~47 `must define a CalcFormula` failures in the same run are the same defect wearing two different messages.

## What this PR changes

Not the count. What it changes is that the next one of these is readable.

`LiveNavTestPage.Loaded` converts an AL error raised by a page's row-load trigger into BC's own `The TestPage is not open.`, which is faithful (#2656, measured on 27.5 / 28.3 / 28.4) and stays exactly as it is. It kept the original in `Exception.Data["OriginalTriggerError"]` — a key written at one site and **read nowhere**. So the cause existed for the length of one `throw` and then could not be recovered from the run log, the JSON classification or the JUnit report. Establishing what those 132 failures were about required patching the runner to print what it had discarded and running the bucket again.

`MaskedTriggerErrorDiagnosis` reads it into the failure's diagnosis line, the way `MissingTestDataDiagnosis` (#2240) already adds one: an addition, never a replacement, never a change of outcome, never AL-visible. The evidence is the typed exception the runner recorded itself — no text matching on `The TestPage is not open.`, which is a BC resource string like any other and would stop working the moment BC rewords or localises it.

Measured on the real failure, same test that produced the regression line above:

```
FAIL  Codeunit138000.PostSalesInvoiceFromCard (3230ms)
      NavNCLDialogException: The TestPage is not open.
      [testpage] this is BC's own message for a page whose row-load trigger raised; the error
      it raised, which BC does not show AL, was NavCSideException: You must define a CalcFormula
      for the Outstanding Serv. Orders (LCY) FlowField in the Customer table.
```

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** No. `MakeTestPageNotOpenException` is the only place in `AlRunner/` that substitutes one exception for another and drops the original — I checked every `catch (NavBaseException)` site. `RunnerPageBackgroundTaskGap` does the opposite and correctly rethrows through `ExceptionDispatchInfo`. Both construction paths inside `MakeTestPageNotOpenException` now carry the link, so which one ran cannot change what gets reported.

2. **Does a sibling make the same assumption?** Yes, and it is fixed here — **and the first version of this PR claimed that with nothing holding it.** `MissingTestDataDiagnosis.TryNameTable` walks `InnerException` looking for a table id or a `NavTestFieldException`, and the replacement exception carries neither — so a page trigger failing on a missing setup record got no missing-data explanation either. Exactly the failure #2240 exists to explain, unexplained whenever it happened inside a page trigger. Its walk now steps through the link too.

   Review reverted exactly that half at `25fe6987` (`Next` back to plain `e.InnerException`) and the suite stayed **green**, because every fixture arm then failed on a bare `Error()` carrying no typed table evidence — the walk had nothing to find either way. That is `tdd.md`'s question answered "yes", and it is fixed in `7ec3542d` rather than argued away: a fourth arm fails on a *missing setup record*, so the converted exception carries the AL table id behind the mask, which is the only shape in which following the link is observable. With the link reverted that arm now fails with `Not found: "[test-data] 'MTD Setup' (table 70546) has"` (1 failed, 4 passed); restored, 6 pass.

3. **Two paths writing the same state with different invariants?** Yes, and it is **not** fixed here — filed as **#3190**. The host page suppresses the conversion during its construction-time row load (`_suppressTeardownOnLoad`, so `OpenView()` propagates a host-trigger error as itself), but a linked part refreshed inside that same load does not inherit it, so a part's trigger error is converted and aborts the host's open. Whether real BC reports `The TestPage is not open.` when a FactBox part's `OnAfterGetRecord` errors during the host's open is unmeasured on either side, so changing it would swap one unmeasured answer for another. That belongs upstream in the corpus first. `FailureDiagnosis` composes the two diagnoses so the four `TestResult` sites in `TestExecutor` cannot drift into asking different questions.

## RED to GREEN

New fixture `AlRunner.Tests/Fixtures/MaskedTriggerErrorDiagnosis` (ids 70540-70559, its own `idRanges`, no `application` floor): card pages with linked parts whose `OnAfterGetRecord` raises. It reproduces the nightly's exact stack in isolation in 9 seconds. Four arms, three failing by construction because the diagnosis only exists on a reported failure:

* `MaskedPartTriggerError_IsReportedWithTheCauseNamed` — fails; the block must carry BC's message **and** name the converted error, on exactly one line, **and carry no `[test-data]` note** (the does-not-fire-spuriously half of the arm below).
* `MaskedPartTriggerError_AlStillSeesOnlyBcsOwnMessage` — passes; asserts `GetLastErrorText()` equals `The TestPage is not open.` inside AL, on the same error. This is the guard that stops the fix from becoming "leak the cause into AL".
* `MaskedSetupRecordError_CarriesBothExplanations` — fails on a missing setup record, so the converted exception carries the AL table id behind the mask; the block must carry the converted cause **and** `[test-data] 'MTD Setup' (table 70546) has no rows in this run`. Asserting the table **id** as well as the name, so it cannot be satisfied by `MTD Setup` merely appearing inside the `[testpage]` text.
* `PlainFailure_IsReportedWithNoTestPageDiagnosis` — fails; its block must carry neither note. Without this arm the fix could be an unconditional print and this file would still be green.

RED confirmed twice, each half against exactly its own revert:

* neuter `FailureDiagnosis`'s masked half (the pre-fix state exactly — the cause was recorded correctly all along, so only a test that reads real run output can see the bug) → `Not found: "[testpage]"`;
* revert `TryNameTable`'s extra link → `Not found: "[test-data] 'MTD Setup' (table 70546) has"`, 1 failed / 4 passed.

GREEN with both restored.

Run locally, in these states:

* `dotnet test AlRunner.Tests --filter "MissingTestDataDiagnosisTests|TestPageNewRecordValidationTests|MaskedTriggerErrorDiagnosisTests"` — 6 passed, 0 failed, 0 skipped.
* `--filter "Cli|Guide|Help|Readme"` after the doc edits — 61 passed, 7 skipped, 0 failed.
* `Tests-SMB` `Codeunit138000.PostSalesInvoiceFromCard` with `--test-data` and `--test-data-company "CRONUS International Ltd_"` on BC 28.1, before and after.

## Deliberately left out

The count. Nothing here makes a test pass, and it should not — the 229 failures are #3121's to fix. If a reviewer wants the number back, that is the issue to watch, not this PR.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
