### PR TITLE
fix(symbols): read TableRelation for a field a precompiled tableextension contributes

### DIFF
--- a/AlRunner.Tests/BcAppSymbolCacheTableExtRelationTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCacheTableExtRelationTests.cs
@@ -1,0 +1,201 @@
+// BcAppSymbolCacheTableExtRelationTests — issue #3177.
+//
+// RUNNER-MECHANISM claim. What BC does with a TableRelation is plain BC behaviour and is
+// asserted upstream in the al-language corpus against a real service tier (see the PR that
+// carries this file); what is pinned HERE is the runner's own symbol reader, because the defect
+// was that ONE CLASS, reading ONE package, disagreed with ITSELF about the same property:
+// BcAppSymbolCache.TryParseTableSymbol re-parses a precompiled TABLE field's TableRelation
+// (#2528, #2518), and BcAppSymbolCache.TryParseTableExtensionSymbol — an intentional copy of
+// that loop, kept a copy for the token-shift reason in the file header — never got the change.
+//
+// 261 fields contributed by tableextensions in the BC 28.4 platform packages carry a
+// TableRelation (154 in 28.1, the count #3177 was filed with), so FieldRef.Relation answered 0
+// for all of them and Validate() accepted a value with no matching related row. #2528 recorded
+// what that is: a wrong ANSWER, not a missing feature.
+//
+// Two of the four FAIL before the fix and pass after it
+// (PlainRelation_..., ValidateTableRelationZero_...); the other two PASS in both states and are
+// GUARDS on the shape of the fix, not RED -> GREEN evidence. Said plainly so nobody reads
+// "4 passed" as four proofs: FieldWithoutTableRelation_... refuses "invent a relation where the
+// symbol declares none", and FlowFilterTableRelation_... refuses "carry it for every field
+// class". Each is verified by breaking the fix the corresponding way, not by the run below.
+//
+// These assert on the parsed symbol rather than on runtime behaviour deliberately. The symbol
+// reader is the layer that lost the property, it is reachable without loading a BC closure
+// (no "application" floor — see .claude/rules/no-base-app-in-csharp-tests.md), and everything
+// downstream of ParsedField.RelationArms is already covered by #2528's own tests and by
+// tests/runner-extras/precompiled-table-relation.
+
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Joins CacheRootsSerialCollection for the same reason BcAppSymbolCacheTableExtTests does:
+// GetTableExtensions resolves its on-disk path through the process-global CacheRoots override.
+[Collection(CacheRootsSerialCollection.Name)]
+public class BcAppSymbolCacheTableExtRelationTests
+{
+    private static string WriteApp(string dir, string symbolReferenceJson)
+    {
+        var appPath = Path.Combine(dir, Guid.NewGuid().ToString("N") + ".app");
+        using var zip = new FileStream(appPath, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+        return appPath;
+    }
+
+    // Four fields, one extension, mirroring the four shapes Base Application actually ships on
+    // this path:
+    //   5900 "Service Zone Code"   — plain single-arm relation, the shape 6450 "Serv. Customer"
+    //                                declares on Customer. MUST arrive with the arm AND with
+    //                                RelationValidate true.
+    //   5901 "Unvalidated Code"    — same relation, ValidateTableRelation = 0. The negative
+    //                                control for the SECOND property: a fix that switched
+    //                                validation on wholesale instead of reading both properties
+    //                                makes this read true and the test fails.
+    //   5902 "No Relation"         — declares none. Must arrive with null arms, so "read the
+    //                                property" is not confused with "invent one".
+    //   5903 "Ship-to Filter"      — FlowFilter carrying a TableRelation, exactly the shape
+    //                                6450 declares. The table loop gates relation parsing on
+    //                                !IsFlowField && !IsFlowFilter with a documented reason
+    //                                (#2528); this pins the extension loop to the same gate, so
+    //                                the two paths cannot disagree in the other direction.
+    private const string SymbolReference = """
+        {
+          "RuntimeVersion": "15.1",
+          "Namespaces": [
+            {
+              "Name": "Microsoft.Service.Customer",
+              "TableExtensions": [
+                {
+                  "TargetObject": "#437dbf0e84ff417a965ded2bb9650972#Customer",
+                  "Id": 6450,
+                  "Name": "Serv. Customer",
+                  "Fields": [
+                    {
+                      "TypeDefinition": { "Name": "Code[10]" },
+                      "Properties": [
+                        { "Name": "Caption", "Value": "Service Zone Code" },
+                        { "Name": "TableRelation", "Value": "\"Service Zone\"" }
+                      ],
+                      "Id": 5900,
+                      "Name": "Service Zone Code"
+                    },
+                    {
+                      "TypeDefinition": { "Name": "Code[10]" },
+                      "Properties": [
+                        { "Name": "TableRelation", "Value": "\"Service Zone\"" },
+                        { "Name": "ValidateTableRelation", "Value": "0" }
+                      ],
+                      "Id": 5901,
+                      "Name": "Unvalidated Code"
+                    },
+                    {
+                      "TypeDefinition": { "Name": "Code[10]" },
+                      "Properties": [
+                        { "Name": "Caption", "Value": "No Relation" }
+                      ],
+                      "Id": 5902,
+                      "Name": "No Relation"
+                    },
+                    {
+                      "TypeDefinition": { "Name": "Code[10]" },
+                      "Properties": [
+                        { "Name": "FieldClass", "Value": "FlowFilter" },
+                        { "Name": "TableRelation", "Value": "\"Ship-to Address\".Code" }
+                      ],
+                      "Id": 5903,
+                      "Name": "Ship-to Filter"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private static TableExtensionSymbol ParseOnce(string dir)
+    {
+        var appPath = WriteApp(dir, SymbolReference);
+        return Assert.Single(BcAppSymbolCache.GetTableExtensions(appPath));
+    }
+
+    [Fact]
+    public void PlainRelation_ReachesRelationArmsWithTheRelatedTableName()
+    {
+        var dir = TestScratch.Dir("al-runner-bcsym-tableext-relation");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var field = ParseOnce(dir).Fields.Single(f => f.FieldId == 5900);
+
+            Assert.NotNull(field.RelationArms);
+            var arm = Assert.Single(field.RelationArms!);
+            // The related TABLE by name is the whole point: FieldRef.Relation is computed from
+            // it, and before #3177 this was null so it answered 0.
+            Assert.Equal("Service Zone", arm.TableName);
+            Assert.True(field.RelationValidate);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void ValidateTableRelationZero_IsReadAsItsOwnProperty_RelationStillPresent()
+    {
+        var dir = TestScratch.Dir("al-runner-bcsym-tableext-relation");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var field = ParseOnce(dir).Fields.Single(f => f.FieldId == 5901);
+
+            // Both halves, and both matter. The relation is still READABLE (FieldRef.Relation
+            // must answer "Service Zone")...
+            Assert.NotNull(field.RelationArms);
+            Assert.Equal("Service Zone", Assert.Single(field.RelationArms!).TableName);
+            // ...while the CHECK is off. A fix that read only TableRelation reports true here.
+            Assert.False(field.RelationValidate);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void FieldWithoutTableRelation_KeepsNullArmsAndDefaultsToValidating()
+    {
+        var dir = TestScratch.Dir("al-runner-bcsym-tableext-relation");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var field = ParseOnce(dir).Fields.Single(f => f.FieldId == 5902);
+
+            Assert.Null(field.RelationArms);
+            // AL's default when ValidateTableRelation is undeclared is true, and the table loop
+            // reports true for such a field — the two paths have to agree here as well.
+            Assert.True(field.RelationValidate);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void FlowFilterTableRelation_IsNotCarried_MatchingTheTablePathsGate()
+    {
+        var dir = TestScratch.Dir("al-runner-bcsym-tableext-relation");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var field = ParseOnce(dir).Fields.Single(f => f.FieldId == 5903);
+
+            Assert.True(field.IsFlowFilter);
+            // Refused on purpose (#2528's gate), not missed: a FlowFilter's TableRelation is a
+            // lookup hint for the filter's own UI, and carrying it would pull FlowFilter
+            // pseudo-columns into the rename-propagation reverse index.
+            Assert.Null(field.RelationArms);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}

--- a/AlRunner/Patches/BcAppSymbolCache.TableExtensions.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.TableExtensions.cs
@@ -266,13 +266,19 @@ internal static partial class BcAppSymbolCache
                 // #3177 — TableRelation, read exactly as the table loop reads it (#2528/#2518).
                 // Both properties, independently: ValidateTableRelation = 0 turns the CHECK off
                 // while leaving the relation itself readable, so reading only the first would
-                // switch validation on wholesale for fields BC does not validate. Gated on field
-                // class for the table loop's documented reason — a FlowFilter's TableRelation is
-                // a lookup hint for the filter's own UI, not a stored value's referential
-                // constraint, and RelationArms also feeds the reverse index
-                // NCLMetaTable_ComputeReferencingRelations builds for rename propagation, which
-                // filters on table id rather than field class. Ungated, the two paths would
-                // disagree again in the other direction.
+                // switch validation on wholesale for fields BC does not validate.
+                //
+                // Gated on field class to match the table loop, whose reason is that a
+                // FlowFilter's TableRelation is a lookup hint for the filter's own UI rather
+                // than a stored value's referential constraint, and that RelationArms also feeds
+                // the reverse index NCLMetaTable_ComputeReferencingRelations builds for rename
+                // propagation, which filters on table id rather than field class. Note the
+                // blast radius here is NOT the 204 fields #2528 cites on the table path: across
+                // the platform packages this gate excludes exactly ONE extension field,
+                // Customer."Ship-to Filter" (5903, FlowFilter), so 260 of the 261 gain relations.
+                // It is kept anyway because the point of the change is that the two loops read
+                // the property the same way; ungated they would disagree again, in the other
+                // direction, over that one field.
                 props.TryGetValue("TableRelation", out var tableRelation);
                 var relationArms = (!isFlowField && !isFlowFilter)
                     ? RecordPatches.TryParseRelationArmsText(tableRelation, fieldName)

--- a/AlRunner/Patches/BcAppSymbolCache.TableExtensions.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.TableExtensions.cs
@@ -145,17 +145,71 @@ internal static partial class BcAppSymbolCache
     /// TargetObject: <c>#&lt;appIdNoHyphens&gt;#&lt;TableName&gt;</c> or plain <c>&lt;TableName&gt;</c>.
     ///
     /// Field-parse loop is an intentional copy of the loop in <see cref="TryParseTableSymbol"/> —
-    /// do NOT refactor into a shared helper. A prior attempt caused SIGSEGV.
-    /// ParsedField.CalcFormula stays null here: parsing it calls RecordPatches.TryParseCalcFormula,
-    /// which must not be called at startup (RecordPatches may not yet be initialised → SIGSEGV).
-    /// The raw property TEXT is carried on TableExtensionSymbol.CalcFormulaTexts instead and
-    /// parsed by the consumer once the runtime is up (#3121).
-    /// <para>The sentence that used to stand here — "Extension FlowFields with CalcFormulas
-    /// don't exist in standard precompiled BC apps" — is false. Measured against BC 28.1:
-    /// <c>Customer."Outstanding Serv.Invoices(LCY)"</c> (Service) and
+    /// do NOT refactor into a shared helper. A prior attempt caused SIGSEGV. Keeping it a copy
+    /// is also why it drifts: every property the table loop learns to read has to be added here
+    /// by hand, and both of the ones below were missed for as long as they existed.
+    ///
+    /// <para><b>The "must not call RecordPatches at startup" constraint is FALSE, and nothing in
+    /// this file rests on it any more.</b> It is written out here because two separate changes
+    /// (#3121/#3180 and #3177/#3197) were designed around it and a third would have been. What it
+    /// used to say: parsing a property here calls into <c>RecordPatches</c>, which "may not yet be
+    /// initialised → SIGSEGV". Measured, there is no point in the process at which that is
+    /// reachable. <c>RecordPatches.AddBcAppPath</c> — the only registration-time caller — runs
+    /// these two statements consecutively, inside one <c>lock (_bcTableIndexLock)</c>:
+    /// <code>
+    /// symbols = BcAppSymbolCache.Get(appPath);      // -> TryParseTableSymbol
+    ///                                               //    -> RecordPatches.TryParseRelationArmsText (#2528)
+    /// BcAppSymbolCache.GetTableExtensions(appPath); // -> this method
+    /// </code>
+    /// so the extension loop can never run earlier than the table loop that has already called
+    /// into <c>RecordPatches</c>. The other caller (the lazy index rebuild in
+    /// <c>RecordPatches.BcAppFallback</c>) is later still. The TableRelation read below is a
+    /// direct <c>RecordPatches.TryParseRelationArmsText</c> call at parse time, and it is
+    /// exercised on every corpus and runner-extras run, cold and warm — see the #3177 paragraph
+    /// for the numbers.</para>
+    ///
+    /// <para><b>Consequence for the CalcFormula half.</b> <c>ParsedField.CalcFormula</c> is still
+    /// null here and the raw property TEXT is carried on
+    /// <see cref="TableExtensionSymbol.CalcFormulaTexts"/> for the consumer to parse once the
+    /// runtime is up (#3121/#3180). That deferral WORKS and is not being changed here — but it is
+    /// a design choice now, not a requirement: the startup hazard it was built to avoid does not
+    /// exist. Anyone consolidating the two properties onto one mechanism should know that either
+    /// direction is open, and should not re-derive the constraint from this comment.</para>
+    ///
+    /// <para>The other sentence that used to stand here — "Extension FlowFields with CalcFormulas
+    /// don't exist in standard precompiled BC apps" — is also false, and separately measured.
+    /// Against BC 28.1: <c>Customer."Outstanding Serv.Invoices(LCY)"</c> (Service) and
     /// <c>"Stockkeeping Unit"."Qty. on Prod. Order"</c> (Manufacturing) are exactly that shape,
     /// and dropping their formula made <c>CalcFields</c> refuse them with BC's own
-    /// "You must define a CalcFormula for the {0} FlowField in the {1} table".</para>
+    /// "You must define a CalcFormula for the {0} FlowField in the {1} table". Counted across the
+    /// BC 28.4 platform packages, Base Application declares <b>36</b> FlowFields on
+    /// tableextensions and all 36 carry a CalcFormula.</para>
+    ///
+    /// <para>#3177 — TableRelation is read below, directly. #2528 taught
+    /// <see cref="TryParseTableSymbol"/> to re-parse a precompiled table field's TableRelation
+    /// out of the symbol property text, because without it <c>FieldRef.Relation</c> answers 0
+    /// and <c>Validate</c> skips the relation check, so a value real BC refuses is silently
+    /// accepted — a wrong ANSWER, not a missing feature. The extension loop never got that
+    /// change, so the same class, reading the same package, disagreed with itself about the
+    /// same property.</para>
+    ///
+    /// <para><b>261</b> tableextension fields across the platform packages carry a
+    /// TableRelation, of which <b>260</b> gain one here — the gate below excludes exactly one,
+    /// <c>Customer."Ship-to Filter"</c> (5903, a FlowFilter). #3177 was filed with 154, which
+    /// is the <b>Base Application share</b>, not an older count: the other 107 are in Business
+    /// Foundation, an equally precompiled dependency read through this same loop. The total does
+    /// NOT drift with the BC version — measured 154 + 107 = 261 identically on 28.1 and 28.4
+    /// (259 on 27.5). Examples: <c>Item."Routing No."</c> → <c>"Routing Header"</c>,
+    /// <c>Item."Production BOM No."</c> → <c>"Production BOM Header"</c>,
+    /// <c>Customer."Service Zone Code"</c> → <c>"Service Zone"</c> (table 5957, contributed by
+    /// tableextension 6450 "Serv. Customer" — the case
+    /// <c>tests/runner-extras/precompiled-table-relation</c> asserts end to end).</para>
+    ///
+    /// <para>No <c>CacheVersion</c> bump: table extensions are not part of <c>CachePayload</c>
+    /// and <see cref="TableExtensionCache"/> is process-only, so there is no persisted payload
+    /// that could replay the pre-fix answer — unlike #2528, which needed one for exactly that
+    /// reason. Everything downstream that IS disk-cached (AL output, install baseline) keys on
+    /// <c>RunnerFingerprint</c>, which includes the runner assembly's content hash.</para>
     /// </summary>
     private static TableExtensionSymbol? TryParseTableExtensionSymbol(System.Text.Json.JsonElement ext)
     {
@@ -209,8 +263,25 @@ internal static partial class BcAppSymbolCache
                     && (autoIncrement == "1" || autoIncrement.Equals("true", StringComparison.OrdinalIgnoreCase));
                 props.TryGetValue("MinValue", out var minValue); // #2495
                 props.TryGetValue("MaxValue", out var maxValue);
+                // #3177 — TableRelation, read exactly as the table loop reads it (#2528/#2518).
+                // Both properties, independently: ValidateTableRelation = 0 turns the CHECK off
+                // while leaving the relation itself readable, so reading only the first would
+                // switch validation on wholesale for fields BC does not validate. Gated on field
+                // class for the table loop's documented reason — a FlowFilter's TableRelation is
+                // a lookup hint for the filter's own UI, not a stored value's referential
+                // constraint, and RelationArms also feeds the reverse index
+                // NCLMetaTable_ComputeReferencingRelations builds for rename propagation, which
+                // filters on table id rather than field class. Ungated, the two paths would
+                // disagree again in the other direction.
+                props.TryGetValue("TableRelation", out var tableRelation);
+                var relationArms = (!isFlowField && !isFlowFilter)
+                    ? RecordPatches.TryParseRelationArmsText(tableRelation, fieldName)
+                    : null;
+                var relationValidate = !(props.TryGetValue("ValidateTableRelation", out var vtr)
+                    && (vtr == "0" || vtr.Equals("false", StringComparison.OrdinalIgnoreCase)));
                 fields.Add(new ParsedField(fieldId, fieldName, typeName, SymbolTypeLength(typeName), isFlowField, null,
                     optionMembers, initValue, isAutoIncrement, IsFlowFilter: isFlowFilter,
+                    RelationArms: relationArms, RelationValidate: relationValidate,
                     MinValue: minValue, MaxValue: maxValue));
             }
         }

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -39,7 +39,7 @@
         "page-enum-control-modal": { "tests": 4 },
         "pageext-action-dispatch": { "tests": 6 },
         "permission-set-assignment": { "tests": 6 },
-        "precompiled-table-relation": { "tests": 6 },
+        "precompiled-table-relation": { "tests": 10 },
         "precompiled-tableext-keys": { "tests": 6 },
         "published-application-system-table": { "tests": 7 },
         "query-join-aggregation-oos": { "tests": 4 },

--- a/tests/runner-extras/precompiled-table-relation/PtrTests.Codeunit.al
+++ b/tests/runner-extras/precompiled-table-relation/PtrTests.Codeunit.al
@@ -172,4 +172,110 @@ codeunit 61401 "PTR Tests"
             '"My Item"."User ID" declares ValidateTableRelation = false, so an unmatched value ' +
             'must be accepted — the fix must read that property, not just TableRelation');
     end;
+
+    // ------------------------------------------------------------------------------------------
+    // #3177 — the same property, on a field a precompiled TABLEEXTENSION contributes.
+    //
+    // Everything above reads a field declared by the Base Application TABLE itself, which #2528
+    // fixed. TryParseTableExtensionSymbol is an intentional copy of that loop and never got the
+    // change, so a field a tableextension adds reached the metadata with no relation at all. The
+    // C# tests in AlRunner.Tests/BcAppSymbolCacheTableExtRelationTests.cs assert the parsed
+    // SYMBOL; these assert that the parsed symbol actually reaches FieldRef.Relation and the
+    // platform's relation check, which is the part nothing else covers.
+    //
+    // Measured from the BC 28.1 package rather than assumed:
+    //   * tableextension 6450 "Serv. Customer" targets Customer and declares
+    //     field(5900; "Service Zone Code"; Code[10]) { TableRelation = "Service Zone"; }
+    //   * table 5957 is "Service Zone".
+    //   * that field carries NO OnValidate trigger and NO ValidateTableRelation — read out of
+    //     Microsoft's own src/Service/Sales/Customer/ServCustomer.TableExt.al — so the relation
+    //     check is the only thing in the platform that can raise on it. A Validate test here
+    //     cannot pass for some other reason.
+    //   * field 5930 "Combine Service Shipments" is the other Normal-class field the same
+    //     tableextension adds, and it declares no TableRelation.
+    // ------------------------------------------------------------------------------------------
+
+    [Test]
+    procedure FieldRefRelation_PrecompiledTableExtensionField_AnswersTheRelatedTableId()
+    var
+        RecRef: RecordRef;
+        FieldRef: FieldRef;
+        Cust: Record Customer;
+    begin
+        RecRef.Open(Database::Customer);
+        FieldRef := RecRef.Field(Cust.FieldNo("Service Zone Code"));
+
+        // Concrete id: table 5957 is "Service Zone". Before #3177 this answered 0 — the
+        // tableextension field-parse loop never read the TableRelation property at all — so a
+        // non-zero check would already discriminate, but the id is asserted because a
+        // reconstruction that attached SOME arbitrary relation would pass that and fail this.
+        Assert.AreEqual(
+            Database::"Service Zone", FieldRef.Relation,
+            'Customer."Service Zone Code" (field 5900) is contributed by tableextension 6450 ' +
+            '"Serv. Customer" with TableRelation = "Service Zone", so FieldRef.Relation must ' +
+            'answer table 5957 — it answered 0 before issue #3177');
+    end;
+
+    [Test]
+    procedure FieldRefRelation_PrecompiledTableExtensionFieldWithNoRelation_AnswersZero()
+    var
+        RecRef: RecordRef;
+        FieldRef: FieldRef;
+        Cust: Record Customer;
+    begin
+        // The negative direction, on the SAME tableextension: 5930 "Combine Service Shipments"
+        // is Normal-class and declares no TableRelation, so it must stay 0. Without it, a reader
+        // that attached a relation to every extension field would pass the test above.
+        RecRef.Open(Database::Customer);
+        FieldRef := RecRef.Field(Cust.FieldNo("Combine Service Shipments"));
+
+        Assert.AreEqual(
+            0, FieldRef.Relation,
+            'Customer."Combine Service Shipments" (field 5930, same tableextension 6450) ' +
+            'declares no TableRelation, so FieldRef.Relation must be 0');
+    end;
+
+    [Test]
+    procedure Validate_PrecompiledTableExtensionRelationField_UnmatchedValue_RaisesBcsOwnError()
+    var
+        Cust: Record Customer;
+    begin
+        Cust.Init();
+        Cust."No." := 'PTR-C-3';
+
+        asserterror Cust.Validate("Service Zone Code", 'PTRNOZONE');
+
+        // BC's own message. The field has no OnValidate of its own, so the relation check is the
+        // only thing that can raise here — which is what makes this prove the relation reached
+        // the platform rather than merely reaching FieldRef.Relation.
+        Assert.IsTrue(
+            StrPos(GetLastErrorText(), 'cannot be found in the related table') > 0,
+            'Validate against a non-existent Service Zone must raise BC''s own relation error; got: '
+            + GetLastErrorText());
+        Assert.IsTrue(
+            StrPos(GetLastErrorText(), 'Service Zone') > 0,
+            'the error must name the related table (Service Zone); got: ' + GetLastErrorText());
+    end;
+
+    [Test]
+    procedure Validate_PrecompiledTableExtensionRelationField_MatchedValue_IsAccepted()
+    var
+        Cust: Record Customer;
+        ServiceZone: Record "Service Zone";
+    begin
+        // Positive direction: a relation that refused everything would pass the test above and
+        // fail this one.
+        if not ServiceZone.Get('PTRZONE') then begin
+            ServiceZone.Init();
+            ServiceZone.Code := 'PTRZONE';
+            ServiceZone.Insert();
+        end;
+
+        Cust.Init();
+        Cust."No." := 'PTR-C-4';
+        Cust.Validate("Service Zone Code", 'PTRZONE');
+
+        Assert.AreEqual('PTRZONE', Cust."Service Zone Code",
+            'a Service Zone row that exists must be accepted and stored');
+    end;
 }


### PR DESCRIPTION
Closes #3177

*Opened by agent `impl-18`; rebased, re-resolved and re-measured by agent `impl-1`. Both are automated implementation agents.*

`BcAppSymbolCache.TryParseTableSymbol` re-parses a precompiled **table** field's `TableRelation` out of the `SymbolReference.json` property text — #2528 added it, #2518 and #2851 widened what it accepts. `TryParseTableExtensionSymbol` is an intentional copy of that loop, kept a copy for the token-shift reason in the file header, and it never got the change. One class, reading one package, disagreeing with itself about one property.

#2528 recorded what that costs on the table path and it applies unchanged here: `FieldRef.Relation` answers 0 and `Validate()` skips the relation check, so a value real BC refuses is silently accepted. A wrong answer, not a missing feature.

## Scope

Counted by walking `TableExtensions[].Fields[].Properties` across the platform packages: **261 tableextension fields carry a `TableRelation`, and 260 of them gain one here** — the field-class gate excludes exactly one, `Customer."Ship-to Filter"` (5903, a FlowFilter). Among them:

```
Item."Routing No."            -> "Routing Header"
Item."Production BOM No."     -> "Production BOM Header"
Customer."Service Zone Code"  -> "Service Zone"
Requisition Line."Prod. Order No." -> "Production Order"."No." where(Status = const(Released))
```

`154` is not an older count, it is Base Application's share of the same 261. The other 107 are in **Business Foundation**, an equally precompiled dependency read through this same loop; #3177 counted one package. Measured per package, `154 + 107 = 261` identically on **28.1 and 28.4** (259 on 27.5), so the total does not drift with the BC version.

## What changed

`TableRelation` and `ValidateTableRelation` are read the way the table loop reads them: as **two independent properties**, because `ValidateTableRelation = 0` turns the *check* off while leaving the relation itself readable; and only for `!isFlowField && !isFlowFilter`, because a FlowFilter's `TableRelation` is a lookup hint for the filter's own UI rather than a stored value's referential constraint, and `RelationArms` also feeds the reverse index `NCLMetaTable_ComputeReferencingRelations` builds for rename propagation. Ungated, the two paths would disagree again in the other direction.

**No `CacheVersion` bump**, unlike #2528: table extensions are not part of `CachePayload` and `TableExtensionCache` is process-only, so no persisted payload can replay the pre-fix answer. Everything downstream that *is* disk-cached keys on `RunnerFingerprint`, which includes the runner assembly's content hash.

## The #3180 conflict, and what the resolution says

#3180 has merged. This branch is rebased onto `c0fda77e`, and the conflict it predicted showed up exactly where it said it would: the doc comment on `TryParseTableExtensionSymbol`, and the `CalcFormula` line in the field loop it documents.

**The naive union resolution compiles with 0 errors and leaves the file asserting two opposite things.** `main`'s paragraph says parsing a property here calls `RecordPatches.TryParseCalcFormula`, "which must not be called at startup (`RecordPatches` may not yet be initialised → SIGSEGV)". This PR adds a live `RecordPatches.TryParseRelationArmsText(tableRelation, fieldName)` call in that same loop. Both can sit in one file, both can compile, and nothing in CI notices.

**The constraint is false, and the resolved comment now says so once.** Two things establish it:

- **Structural.** `RecordPatches.AddBcAppPath` is the only registration-time caller, and it runs these consecutively inside one `lock (_bcTableIndexLock)`:
  ```csharp
  symbols = BcAppSymbolCache.Get(appPath);      // -> TryParseTableSymbol
                                                //    -> RecordPatches.TryParseRelationArmsText (#2528)
  BcAppSymbolCache.GetTableExtensions(appPath); // -> this method
  ```
  So the extension loop can never run earlier than a table loop that has already called into `RecordPatches`. The only other caller of `GetTableExtensions` is the lazy index rebuild in `RecordPatches.BcAppFallback`, which is later still.
- **Measured, by me, in both cache states.** `tests/runner-extras/precompiled-table-relation` cold (empty `--cache`, so `Get` parses) and warm against the same cache (so `Get` returns from the `bc-symbols` disk cache and this loop is genuinely the first caller into `RecordPatches`): 10/10 both times, no fault, no SIGSEGV. Full corpus and full `runner-extras` likewise, cold and warm — numbers below.

The resolved comment states that, and names **#3180's `CalcFormulaTexts` deferral as a design choice that still works but no longer rests on a live constraint** — so the next reader does not re-derive the constraint from a comment. `ParsedField.CalcFormula` is still `null` here and the raw text still rides on `TableExtensionSymbol.CalcFormulaTexts`; nothing about #3180's mechanism is changed. `main`'s separately-measured correction (extension FlowFields with CalcFormulas *do* exist — `Customer."Outstanding Serv.Invoices(LCY)"`, `"Stockkeeping Unit"."Qty. on Prod. Order"`) is kept as it stands.

The branch's second commit (`bc1b4f14`, comment-only) was dropped during the rebase because everything true in it is folded into the resolution; its measured detail (36 of 36 tableextension FlowFields carry a CalcFormula; 204 vs 1 field for the gate's blast radius) is preserved in the resolved text.

## RED → GREEN

Two layers. The C# tests assert the parsed **symbol**; the AL tests assert that the parsed symbol actually reaches `FieldRef.Relation` and the platform's relation check. The second layer was missing and is added here.

**AL, end to end — `tests/runner-extras/precompiled-table-relation`, four new cases (6 → 10).** Same tree both runs, both on the final base `44987f40`; only `BcAppSymbolCache.TableExtensions.cs` reverted to `origin/main` for the RED run, restored from a copy taken outside the repository, and `git diff HEAD` confirmed empty before the GREEN run. Re-run in both directions after the last rebase rather than carried forward.

```
RED   (BcAppSymbolCache.TableExtensions.cs at origin/main):  8P / 2F across 10
  FAIL FieldRefRelation_PrecompiledTableExtensionField_AnswersTheRelatedTableId
       NavNCLDialogException: Expected 5957 but got 0
  FAIL Validate_PrecompiledTableExtensionRelationField_UnmatchedValue_RaisesBcsOwnError
       NavNCLAssertErrorException: An error was expected inside an ASSERTERROR statement.

GREEN (this tree):                                          10P / 0F across 10, cold AND warm
```

The second RED line is the sharper one: `Validate` against a Service Zone that does not exist raised *nothing*. That is the silent acceptance #2528 describes, reproduced on the extension path.

Every fact the tests rest on is read out of the BC 28.1 package rather than assumed:

- tableextension **6450 "Serv. Customer"** targets `Customer` and declares `field(5900; "Service Zone Code"; Code[10]) { TableRelation = "Service Zone"; }`
- table **5957** is `"Service Zone"`
- that field carries **no `OnValidate` trigger and no `ValidateTableRelation`** — read out of Microsoft's own `src/Service/Sales/Customer/ServCustomer.TableExt.al` — so the relation check is the only thing in the platform that can raise on it, and the Validate test cannot pass for another reason
- field **5930 "Combine Service Shipments"** is the other Normal-class field the same tableextension adds and declares no relation, which is the negative direction: a reader that attached a relation to every extension field passes the positive test and fails this one

**C# — `BcAppSymbolCacheTableExtRelationTests`:** 2 passed / 2 **failed** before, 4 passed after. Two of the four pass in both states on purpose and are not counted as proof; each was verified to discriminate by breaking the fix the matching way:

| guard | broken by | result |
|---|---|---|
| `FieldWithoutTableRelation_KeepsNullArmsAndDefaultsToValidating` | inventing an arm when the symbol declares none | that test fails, nothing else |
| `FlowFilterTableRelation_IsNotCarried_MatchingTheTablePathsGate` | dropping the `!isFlowField && !isFlowFilter` gate | that test fails, nothing else |

## What was measured on the rebased tree

**Every number in the previous body was stale and has been replaced.** The old body said corpus `2684/2684` and runner-extras `306/306`; both were measured before #3101, #3180, #3216, #3257 and the corpus pin moves that came with them. Nothing was carried across the rebase. All of the following is BC 28.1.49838.53910, on `44987f40` (rebased onto `main` at `c0fda77e`), with a private `--cache` outside the repository. `main` moved five times while I was working; every number below was re-run on the final base, and nothing is carried across a rebase:

| run | result |
|---|---|
| al-language corpus, cold (3 app roots, `--strict --expectations-require-match --count-baseline`) | **2700 / 2700**, 0 fail, 0 error, **exit 0** |
| al-language corpus, warm (same cache) | **2700 / 2700**, exit 0 |
| `tests/runner-extras`, cold (`--strict --count-baseline`) | **334 / 334**, 0 fail, 0 error, **exit 0** |
| `tests/runner-extras`, warm (same cache) | **334 / 334**, exit 0 |
| `tests/runner-extras/precompiled-table-relation` alone | **10 / 10** cold, **10 / 10** warm |
| `dotnet test AlRunner.Tests --filter ~BcAppSymbolCacheTableExt\|~CountBaseline` | **50 / 50** |
| `dotnet build AlRunner/AlRunner.csproj -c Release` on the merged tree | 0 errors |

2700 is the sum over the three corpus app roots: al-language 2681, al-language-internals-fixture 0, al-language-onprem 19 — the current `test-count-baseline.json`, which the run enforces rather than my arithmetic asserting. The corpus pin is untouched by this PR, deliberately — see "The corpus test, and why the pin bump is deferred" below.

`--count-baseline` exits 0 on both suites, so `precompiled-table-relation: 6 → 10` is checked in and agreed with by the run. I did not add a `history.md` entry: the group line carries its own count and its reason is the new test file, which is the case the directory's README says needs no prose.

The full `AlRunner.Tests` sweep was not run locally; CI runs it on every leg.

## Deliberately left out

- The `CalcFormula` half of this loop. #3121 / #3180 own it, it has merged, and this PR does not touch its mechanism — only the comment that used to justify it on a false premise.
- `Financial Report."Last Run by User"` and the 40 other Base App FlowFields whose formula names a system field (`SystemCreatedAt` / `SystemId` / `SystemCreatedBy`) — #3178, a different mechanism.
- The pin bump that would put the merged corpus test in front of this runner build — deferred on purpose, see the section above.
- The 22 FlowFields whose formula carries a `Database::<Object>` const, which reaches BC as text — #3195.


## The corpus test, and why the pin bump is deferred

*Added by agent `impl-18` after corpus PR #207 merged.*

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/207

**The escape-hatch framing above is superseded.** It was correct when written — no corpus fixture asserted a `TableRelation` declared in a `.TableExt.al`, so this PR was landing on runner-local coverage with issue #3204 recorded as the follow-up. That is no longer the situation. The corpus PR merged at 19:08Z as corpus commit `6285922` ("test(tableextension): pin that a tableextension-contributed TableRelation is enforced by Validate"), so **a real BC service tier has now adjudicated the claim** on all eight required legs. This PR is no longer resting on an escape hatch.

### RED → GREEN against the merged corpus test

Measured locally on BC 28.1.49838.53910, with the submodule moved to corpus `master` tip `0bda9d69` (which contains `6285922`). Same corpus tree in both runs; only the runner build differs:

| runner | `Codeunit60827` result |
|---|---|
| `origin/main` (`c48a4925`, without this fix) | **3P / 1F** |
| this branch | **4P / 0F** |

The one failure is the point:

```
FAIL Codeunit60827.TableExt_Validate_ContributedRelation_NoRelatedRow_Throws
     NavNCLAssertErrorException: An error was expected inside an ASSERTERROR statement.
```

`Validate("Service Zone Code", 'ALTTRZONE1')` with no matching `Service Zone` row raised **nothing** — the silent acceptance #2528 describes, reproduced on the tableextension path, against a test a real tier says must throw.

**The control isolates the mechanism.** `TableExt_Validate_BaseTableRelation_NoRelatedRow_Throws` — structurally identical, but the relation is declared on base table 18 rather than contributed by tableextension 6450 — **passes in both states**. So the RED is specific to where the relation was declared, not to relation enforcement generally, which is exactly the claim this PR makes.

### Why the pin is NOT bumped here

The runner is therefore **not yet measured against `6285922` on `main`**: `main`'s pin is `7394c15f`, which predates the corpus merge. Bumping it is the natural next step and it is deliberately not taken in this PR.

Moving the pin `7394c15f` → `0bda9d69` pulls in 17 corpus commits (~5,657 added lines, +157 tests on this leg) and, with them, **19 failures in four suites that this PR neither causes nor can fix**. Measured as a controlled pair, same tree, same new pin:

| runner | corpus failures |
|---|---|
| `origin/main` + new pin | **20** |
| this branch + new pin | **19** |

The set difference is exactly one test — the one above — and **nothing is introduced**. The other 19 are pre-existing gaps newly exposed by corpus growth, each already tracked:

| suite | fails | arrived via corpus PR | tracked by |
|---|---|---|---|
| `Codeunit60338` dialog built-in actions / unattended close | 9 | #218 | issues 3283 and 3284 |
| `Codeunit60818` CalcFormula + TableRelation over system fields | 5 | #216 | issue 3178 |
| `Codeunit60823` CalcFormula naming a tableextension field | 4 | #217 | issue 3263 |
| `Codeunit60889` Access Control backs session-user SUPER | 1 | #204 | issue 3176 |

None is masked with an expectation entry, which would be the wrong instrument: those gaps are real, they are actively being worked, and entries pointing at issues that are about to be resolved would leave the gaps untracked the moment they merged.

**The pin bump belongs to whichever PR lands after those are resolved**, folded in per `bc-behavior-tests-go-upstream.md` step 4 together with the count-baseline update — measured here as `al-language` 2689 → **2846** and `al-language-onprem` 19 → **25**, with `al-language-internals-fixture` unchanged at 0.

One caveat, stated rather than smoothed over: all of the above is one BC version (28.1). This PR's legs are 27.0, 27.5 and 28.4, so **19 is a floor for what a bump would show, not an exact count** — a per-version difference in any of those four suites would move it.

---

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
