### PR TITLE
ci: run 3 BC legs on a pull request, and rename the required check to match

### DIFF
--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -109,7 +109,7 @@ Two things make it hard to see:
 
 - **A cancelled run does not necessarily report `cancelled`.** Recorded on PR #3010's head
   `95c16b20`: `Test Matrix` run `34002828792` has run-level `conclusion: cancelled`, and its
-  aggregate job **`All BC versions passed` concluded `failure`** — the aggregate runs
+  aggregate job **`BC test matrix passed` concluded `failure`** — the aggregate runs
   `if: always()` over `needs` that were killed. The live run `34004261321` was green
   throughout. Read literally, that leftover is a failing *required* context.
 - **`gh pr checks` shows one row per context name and drops the rest.** Measured on PR #3016's
@@ -165,7 +165,7 @@ reporting green from a stale run has happened at least four times. Confirm the c
 SHA matches local `HEAD` — a mismatch means "not yet reported," not "green." Never report a
 PR as done while its CI is still running.
 
-**Which contexts gate.** Two come from the big workflows: **`All BC versions passed`**
+**Which contexts gate.** Two come from the big workflows: **`BC test matrix passed`**
 (`.github/workflows/test-matrix.yml`) and **`Tests updated`**
 (`.github/workflows/require-tests.yml` — not `pr-check.yml`, which is where it used to live
 before #2726). The matrix legs report as `bc-tests / BC <ver> (required)` — the `(required)`
@@ -195,6 +195,16 @@ gh api repos/StefanMaron/BusinessCentral.AL.Runner/rules/branches/main \
 the two cannot rot apart silently — except for names it lists as `PENDING_REQUIRED_CONTEXTS`,
 which are contexts the ruleset is about to require and tolerates in either state while a
 by-hand ruleset edit catches up with a merged pull request.
+
+**A pull request runs three legs, not eight** (#3141): `.github/pr-bc-versions.txt` — 27.0,
+27.5 and 28.4. `main` still runs all eight on every push, and — the guarantee that holds when
+merges are cancelling each other — every 30 minutes from `main-verdict-floor.yml` (#3003);
+so does the release path. Two consequences for reading a verdict here. A green pull request has not
+been measured on 27.3, 28.0, 28.1, 28.2 or 28.3, so a version-specific regression in one of
+those surfaces on `main` rather than on the PR — which is what `bc-leg-rerun.yml` is for, since
+it can dispatch any of the eight against your branch. And the leg-set evidence in section 5 is
+thinner on a PR: three legs give far fewer distinguishable failing sets than eight, so prefer
+the dispatch or an empty commit over reading a pattern out of three data points.
 
 Wait in the **foreground** — `tools/ci-wait.py`, or `gh run watch <run-id>`. Never end a turn
 while CI you are responsible for is still running (`no-backgrounding-long-commands.md`).
@@ -281,7 +291,9 @@ gh workflow run bc-leg-rerun.yml --repo StefanMaron/BusinessCentral.AL.Runner \
 `bc-version` is a prefix from `.github/bc-versions.txt`; an unknown one fails the run rather
 than resolving to an empty matrix. The leg does exactly the work that leg does on a normal
 run — `required` and `unit-tests` are still computed from the full version list, so a
-dispatched 28.0 leg does not suddenly run `AlRunner.Tests` that the real 28.0 leg skips.
+dispatched 28.0 leg does not suddenly run `AlRunner.Tests` that the real 28.0 leg skips. Since
+#3141 the dispatch has a second use: it is how you get 27.3, 28.0, 28.1, 28.2 or 28.3 to run
+against a branch at all, because the pull-request matrix no longer includes them.
 
 In the AL-language corpus, `.github/workflows/ci.yml` (`bc_version` input):
 
@@ -295,7 +307,7 @@ disturbing the original: run 33962643816, dispatched against the same SHA that h
 failed, came back 2495/2495 clean.
 
 **A single-leg dispatch cannot satisfy this repository's required check**, by construction:
-`All BC versions passed` is declared in `test-matrix.yml`, and `bc-leg-rerun.yml` does not
+`BC test matrix passed` is declared in `test-matrix.yml`, and `bc-leg-rerun.yml` does not
 contain that job at all, so there is no conclusion — not success, not `skipped` — for it to
 report. `AlRunner.Tests/BcLegRerunWorkflowTests.cs` holds that property in place. Treat the
 result as evidence for a human, never as a gate that has been cleared.

--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -212,8 +212,14 @@ nowhere** — bring the closure list back for approval.
 
 Merge when **all of**:
 
-1. All 8 required legs green **on the PR's current head SHA**. `gh pr checks` reports the
-   newest *completed* run, which can predate the last push — confirm the SHA.
+1. Every required context green **on the PR's current head SHA**. `gh pr checks` reports
+   the newest *completed* run, which can predate the last push — confirm the SHA.
+   **Do not count legs.** Since #3141 a pull request runs three BC legs
+   (`.github/pr-bc-versions.txt`: 27.0, 27.5, 28.4), not eight, so a bar phrased as "all 8
+   legs green" would refuse a legitimate PR or send you hunting for legs that do not exist.
+   The legs are not required contexts anyway — the aggregate `BC test matrix passed` is, and
+   it fails when any leg of whatever matrix ran fails. The other five versions run on
+   `main` via `main-verdict-floor.yml`, not on the PR.
 2. `git merge-tree --write-tree --messages origin/main origin/<branch>` is clean.
    `mergeStateStatus: CLEAN` only covers textual conflicts.
 3. The proving test exists. If the claim is about BC's behavior, that test is upstream and

--- a/.github/pr-bc-versions.txt
+++ b/.github/pr-bc-versions.txt
@@ -1,0 +1,28 @@
+# BC version prefixes the PULL-REQUEST matrix runs. Every prefix here must also
+# appear in .github/bc-versions.txt; bc-tests.yml fails the run if one does not.
+#
+# push, schedule and the release path all still resolve the FULL list in
+# bc-versions.txt. This file narrows one path only: pull requests.
+#
+# Why (issue #3141). Over 37 days of PR and merge history, each leg was asked one
+# question: did it ever report a failure that its neighbours on the same commit did
+# not? 28.1, 28.2, 28.3 and 27.3 never once did. 27.0 and 27.5 each caught defects
+# no 28.x leg caught, and dropping to 28.4 alone would have missed five genuine
+# version-specific defects — two of which made the corpus run ZERO tests on BC 27
+# while still reporting a green leg. So the 27/28 boundary is what discriminates,
+# the minors inside a major are not, and the cheapest set that keeps every defect
+# the history contains is 27.0 + 27.5 + 28.4.
+#
+# The five legs dropped here are not dropped from the project: test-matrix.yml runs
+# the full eight on every push to main and on a daily schedule, so a regression only
+# 28.2 can see is caught within the schedule interval rather than never.
+#
+# Two invariants bc-tests.yml enforces, and AlRunner.Tests/PullRequestMatrixScopeTests.cs
+# holds in place, so this list cannot be edited into something that quietly tests less:
+#   * it must contain the PRIMARY prefix (the newest overall), which the smoke job builds
+#     against and publish.yml reads back as `required-version`;
+#   * it must contain every UNIT prefix (the newest of each major), because AlRunner.Tests
+#     runs on those legs and a 27-only C# regression is not hypothetical — run
+#     33337113550 on 2026-08-30 failed one on 27.0, 27.3 and 27.5 with every 28.x leg
+#     green.
+27.0 27.5 28.4

--- a/.github/scripts/check_required_contexts.py
+++ b/.github/scripts/check_required_contexts.py
@@ -123,7 +123,17 @@ import yaml
 # Measured 2026-09-05: exactly these two, matched by context NAME only (the
 # ruleset entries carry no integration_id), which is why a required job may move
 # between workflow files as long as its `name:` is unchanged.
-DEFAULT_REQUIRED_CONTEXTS = ["All BC versions passed", "Tests updated"]
+#
+# Renamed from "All BC versions passed" by #3141, together with the branch ruleset.
+# The pull-request matrix now runs three of the eight BC versions, so the old name
+# asserted something the run had not measured. Renaming a required status check is a
+# two-sided edit that cannot be atomic: this file (plus tools/ci-wait.py and the job's
+# `name:` in test-matrix.yml) moves in a pull request, the ruleset moves in the GitHub
+# UI, and between the two this guard reports drift. That red is expected and advisory —
+# pr-check.yml produces no required context — but the merge itself is blocked until the
+# ruleset carries the new name, because until then the PR waits on a context no workflow
+# reports any more.
+DEFAULT_REQUIRED_CONTEXTS = ["BC test matrix passed", "Tests updated"]
 
 # Contexts this repository INTENDS the branch ruleset to require, but which it
 # does not require yet (#3165). Everything in pr-gate.yml is here.

--- a/.github/scripts/test_check_required_contexts.py
+++ b/.github/scripts/test_check_required_contexts.py
@@ -146,7 +146,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   all-tests:
-    name: All BC versions passed
+    name: BC test matrix passed
     runs-on: ubuntu-latest
     steps:
       - run: 'true'
@@ -242,7 +242,7 @@ check("cancel-in-progress with no same-SHA type is fine", rc == 0, f"(rc={rc}) {
 rc, msg = run({"require-tests.yml": SAFE_NO_CONCURRENCY}, "Tests updated")
 check("same-SHA types with no concurrency block is fine", rc == 0, f"(rc={rc}) {msg}")
 
-rc, msg = run({"test-matrix.yml": DEFAULT_TYPES_CANCELLING}, "All BC versions passed")
+rc, msg = run({"test-matrix.yml": DEFAULT_TYPES_CANCELLING}, "BC test matrix passed")
 check("default pull_request types + cancel-in-progress is fine",
       rc == 0, f"(rc={rc}) {msg}")
 
@@ -271,10 +271,10 @@ check("a reusable workflow's job resolves to '<caller> / <name>'",
 
 # --- multiple required contexts: one bad is enough, and both get reported
 rc, msg = run({"pr-check.yml": CANCELLABLE_EDITED, "test-matrix.yml": DEFAULT_TYPES_CANCELLING},
-              "Tests updated,All BC versions passed")
+              "Tests updated,BC test matrix passed")
 check("a mixed set fails on the bad one only", rc == 1, f"(rc={rc})")
 check("...and does not accuse the safe one",
-      "All BC versions passed" not in msg.split("Fix:")[0], msg)
+      "BC test matrix passed" not in msg.split("Fix:")[0], msg)
 
 # --- unreadable input is exit 2, distinct from 'check failed'
 rc, msg = run({}, "Tests updated")
@@ -310,7 +310,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   all-tests:
-    name: All BC versions passed
+    name: BC test matrix passed
     runs-on: ubuntu-latest
 """,
 }
@@ -359,7 +359,7 @@ check("a required context added to the ruleset fails the guard", rc == 1, f"(rc=
 check("...and names it", "Provenance attested" in msg, msg)
 
 # --- and the other direction: a name still listed here but no longer required
-rc, msg = run_live(lambda: rules_payload(["All BC versions passed"]))
+rc, msg = run_live(lambda: rules_payload(["BC test matrix passed"]))
 check("a context no longer required by the ruleset also fails the guard",
       rc == 1, f"(rc={rc}) {msg}")
 check("...and names it", "Tests updated" in msg, msg)
@@ -407,7 +407,7 @@ check("...and the guard passes with both in agreement", rc == 0, f"(rc={rc}) {ms
 with tempfile.TemporaryDirectory() as _d:
     _fake = os.path.join(_d, "ci-wait.py")
     with open(_fake, "w", encoding="utf-8") as fh:
-        fh.write('RULESET_CONTEXTS = ("All BC versions passed",)\n')
+        fh.write('RULESET_CONTEXTS = ("BC test matrix passed",)\n')
     problems = crc.ruleset_drift_problems(
         fetch=lambda: rules_payload(crc.DEFAULT_REQUIRED_CONTEXTS), ci_wait_path=_fake)
 check("a drifted tools/ci-wait.py list is reported as a problem",

--- a/.github/scripts/test_check_required_contexts.py
+++ b/.github/scripts/test_check_required_contexts.py
@@ -452,13 +452,13 @@ check("...disjoint from DEFAULT_REQUIRED_CONTEXTS (a name is one or the other)",
 # message and a cause nowhere near it.
 _COMMA_NAME = "PR body closing references must be correct, both directions"
 check("a context name containing a comma survives the newline-separated override",
-      crc._split(f"All BC versions passed\n{_COMMA_NAME}")
-      == ["All BC versions passed", _COMMA_NAME],
-      str(crc._split(f"All BC versions passed\n{_COMMA_NAME}")))
+      crc._split(f"BC test matrix passed\n{_COMMA_NAME}")
+      == ["BC test matrix passed", _COMMA_NAME],
+      str(crc._split(f"BC test matrix passed\n{_COMMA_NAME}")))
 check("...while a single-line value still splits on commas",
-      crc._split("All BC versions passed, Tests updated")
-      == ["All BC versions passed", "Tests updated"],
-      str(crc._split("All BC versions passed, Tests updated")))
+      crc._split("BC test matrix passed, Tests updated")
+      == ["BC test matrix passed", "Tests updated"],
+      str(crc._split("BC test matrix passed, Tests updated")))
 
 PENDING_CANCELLABLE = """
 name: PR Check

--- a/.github/workflows/bc-leg-rerun.yml
+++ b/.github/workflows/bc-leg-rerun.yml
@@ -7,6 +7,10 @@ name: BC single-leg re-run (diagnostic)
 #   gh workflow run bc-leg-rerun.yml --repo StefanMaron/BusinessCentral.AL.Runner \
 #     --ref <branch> -f bc-version=28.4
 #
+# Since #3141 it has a second use. A pull request runs .github/pr-bc-versions.txt --
+# 27.0, 27.5 and 28.4 -- so 27.3, 28.0, 28.1, 28.2 and 28.3 are not on the pull-request
+# path at all, and this workflow is how you get one of them to run against a branch.
+#
 # It exists because section 3 bans `gh run rerun` outright — a re-run overwrites the failed
 # run's log in place, and those logs have been the entire evidence base for real
 # investigations. This gives the same repeat measurement while leaving the original run and
@@ -15,10 +19,11 @@ name: BC single-leg re-run (diagnostic)
 # ---------------------------------------------------------------------------------------
 # WHY THIS IS A SEPARATE FILE AND NOT A `workflow_dispatch:` ON test-matrix.yml
 # ---------------------------------------------------------------------------------------
-# `All BC versions passed` is the ONE required status check in main's branch ruleset (the
+# `BC test matrix passed` is the ONE required status check in main's branch ruleset (the
 # other is `Tests updated`; the individual `bc-tests / BC <ver>` legs are NOT required
 # contexts — verified against the live ruleset, not assumed). If a single-leg run could
-# report that context, one leg's green would satisfy a gate that means "all eight passed".
+# report that context, one leg's green would satisfy a gate that means "every leg of this
+# run passed" — three legs on a pull request since #3141, eight on main and on a release.
 # That is far worse than the flake it would be diagnosing.
 #
 # Adding `workflow_dispatch:` to test-matrix.yml could not be made safe by condition alone:

--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -109,6 +109,12 @@ jobs:
         # but the mitigation costs one line.
         env:
           BC_VERSION_FILTER: ${{ inputs.bc-version-filter }}
+          # The event that triggered the CALLING workflow: `pull_request` for
+          # test-matrix.yml on a PR, `push` / `schedule` for main, `workflow_dispatch`
+          # or `release` for publish.yml, `workflow_dispatch` for bc-leg-rerun.yml.
+          # Only `pull_request` narrows the matrix (#3141); every other path resolves
+          # the full list exactly as before.
+          GATING_EVENT: ${{ github.event_name }}
         run: |
           # Each prefix in bc-versions.txt → one matrix entry {bc-version, required}.
           #
@@ -126,7 +132,7 @@ jobs:
           # mean a BC 27 regression lands silently, which is exactly what this matrix
           # exists to prevent. One prefix is still singled out as `required-version`,
           # for single-build jobs that need to name one version.
-          BC_PREFIXES=$(cat .github/bc-versions.txt | grep -v '^#' | tr '\n' ' ')
+          ALL_PREFIXES=$(cat .github/bc-versions.txt | grep -v '^#' | tr '\n' ' ')
 
           # Both selections below are DERIVED from bc-versions.txt, never hardcoded.
           # A hardcoded pin in a path nobody exercises except during a release is
@@ -145,75 +151,165 @@ jobs:
           # Plain `sort -V` rather than an inline python -c: `python3 -c` with indented
           # source is an IndentationError on some CPython versions and not others, and
           # this block resolves the whole matrix -- if it throws, nothing runs at all.
-          PRIMARY_PREFIX=$(printf '%s\n' $BC_PREFIXES | sort -V | tail -1)
-          UNIT_PREFIXES=$(for major in $(printf '%s\n' $BC_PREFIXES | cut -d. -f1 | sort -u); do
-                            printf '%s\n' $BC_PREFIXES | grep "^${major}\." | sort -V | tail -1
+          #
+          # BOTH are computed from ALL_PREFIXES -- the FULL list -- and BOTH are computed
+          # BEFORE any narrowing below. That ordering is the whole reason a narrowed leg
+          # does exactly the work that leg does on a full run, rather than a subtly
+          # different job (#2674: AlRunner.Tests runs on 2 of the 8 legs, not all 8).
+          PRIMARY_PREFIX=$(printf '%s\n' $ALL_PREFIXES | sort -V | tail -1)
+          UNIT_PREFIXES=$(for major in $(printf '%s\n' $ALL_PREFIXES | cut -d. -f1 | sort -u); do
+                            printf '%s\n' $ALL_PREFIXES | grep "^${major}\." | sort -V | tail -1
                           done | tr '\n' ' ')
+          echo "Full list: $ALL_PREFIXES"
           echo "Primary prefix: $PRIMARY_PREFIX | unit-test prefixes: $UNIT_PREFIXES"
 
-          # Single-leg narrowing for the diagnostic dispatch (bc-leg-rerun.yml). Applied
-          # HERE, after PRIMARY_PREFIX and UNIT_PREFIXES are derived from the FULL list
-          # above and before the resolve loop below — so a dispatched leg carries the same
-          # `required` and `unit-tests` flags it carries on a normal 8-leg run. Narrowing
-          # before those two were computed would silently hand a single-leg run a different
-          # job than the leg it is supposed to be reproducing, which would make it useless
-          # as flake evidence: AlRunner.Tests runs on 2 of the 8 legs, not all 8 (#2674).
+          # GATING_PREFIXES = the legs this run actually EXECUTES. Starts as the full list;
+          # the two narrowings below are the only things that shrink it, and neither can
+          # co-occur (one is a pull_request, the other a workflow_dispatch).
+          GATING_PREFIXES="$ALL_PREFIXES"
+
+          # ---------------------------------------------------------------------------
+          # Narrowing 1 (#3141): a PULL REQUEST runs .github/pr-bc-versions.txt, not all
+          # eight. The measurement is in that file's header and in issue #3141; the short
+          # version is that 28.1, 28.2, 28.3 and 27.3 never once reported a failure a
+          # neighbouring leg on the same commit did not, over 37 days, while 27.0 and 27.5
+          # each caught defects no 28.x leg caught.
+          #
+          # push and schedule (both `main`) and the release path are untouched and still
+          # resolve all eight, so the dropped legs are caught within the schedule interval
+          # rather than never.
+          #
+          # Every failure mode here is validated rather than assumed, because all of them
+          # report GREEN: an unknown prefix, an empty file, a list missing the primary
+          # prefix (smoke would build against an empty version) or missing a unit prefix
+          # (AlRunner.Tests would silently stop running on that major for every PR).
+          # ---------------------------------------------------------------------------
+          if [ "${GATING_EVENT:-}" = "pull_request" ]; then
+            PR_FILE=.github/pr-bc-versions.txt
+            if [ ! -f "$PR_FILE" ]; then
+              echo "::error::$PR_FILE is missing — the pull-request matrix has no version list"
+              exit 1
+            fi
+            PR_PREFIXES=$(cat "$PR_FILE" | grep -v '^#' | tr '\n' ' ')
+            if [ -z "$(printf '%s' "$PR_PREFIXES" | tr -d ' ')" ]; then
+              echo "::error::.github/pr-bc-versions.txt carries no version prefixes — that would resolve to an empty matrix, and a workflow whose only real job never ran still reports success (#1976, #2065)"
+              exit 1
+            fi
+            for p in $PR_PREFIXES; do
+              case " $ALL_PREFIXES " in
+                *" $p "*) ;;
+                *) echo "::error::.github/pr-bc-versions.txt lists '$p', which is not a prefix in .github/bc-versions.txt ($ALL_PREFIXES)"; exit 1 ;;
+              esac
+            done
+            for u in $UNIT_PREFIXES; do
+              case " $PR_PREFIXES " in
+                *" $u "*) ;;
+                *) echo "::error::.github/pr-bc-versions.txt omits '$u', the newest prefix of its major — AlRunner.Tests runs on that leg (see the unit-tests flag below), so omitting it stops the C# suite covering that BC major on every pull request"; exit 1 ;;
+              esac
+            done
+            case " $PR_PREFIXES " in
+              *" $PRIMARY_PREFIX "*) ;;
+              *) echo "::error::.github/pr-bc-versions.txt omits the primary prefix '$PRIMARY_PREFIX' — required-version is emitted only for that prefix, so the smoke job would build against an empty version"; exit 1 ;;
+            esac
+            echo "Pull request: narrowing the matrix to '$PR_PREFIXES' (full list stays: $ALL_PREFIXES)"
+            GATING_PREFIXES="$PR_PREFIXES"
+          fi
+
+          # ---------------------------------------------------------------------------
+          # Narrowing 2: the single-leg diagnostic dispatch (bc-leg-rerun.yml). Membership
+          # is checked against ALL_PREFIXES, not the working list, so a dispatch names a
+          # leg from the real matrix regardless of which path narrowed before it.
           #
           # Unknown prefixes fail the run rather than resolving to an empty matrix. An empty
           # matrix means the `test` job never runs, and a workflow whose only real job never
           # ran still reports success — the silent-no-op shape this repo has been bitten by
           # repeatedly (#1976, #2065).
+          # ---------------------------------------------------------------------------
           if [ -n "${BC_VERSION_FILTER:-}" ]; then
-            case " $BC_PREFIXES " in
+            case " $ALL_PREFIXES " in
               *" $BC_VERSION_FILTER "*)
-                echo "Single-leg run: narrowing to '$BC_VERSION_FILTER' (was: $BC_PREFIXES)"
-                BC_PREFIXES="$BC_VERSION_FILTER"
+                echo "Single-leg run: narrowing to '$BC_VERSION_FILTER' (was: $GATING_PREFIXES)"
+                GATING_PREFIXES="$BC_VERSION_FILTER"
                 ;;
               *)
-                echo "::error::bc-version-filter '$BC_VERSION_FILTER' is not a prefix in .github/bc-versions.txt ($BC_PREFIXES)"
+                echo "::error::bc-version-filter '$BC_VERSION_FILTER' is not a prefix in .github/bc-versions.txt ($ALL_PREFIXES)"
                 exit 1
                 ;;
             esac
           fi
 
+          # The loop resolves the FULL list every time, and the narrowing only decides which
+          # resolved versions become matrix legs. That is deliberate and load-bearing:
+          # `versions-json` feeds the `pack` job, which builds ONE engine variant per entry
+          # and then asserts the packed count equals the number of entries in
+          # bc-versions.txt. A narrowed versions-json would turn every pull request's pack
+          # job red, and relaxing that assertion to match would ship a nupkg missing five
+          # engine variants — #2024 item 3 / #2166 are the record of what that costs.
+          # `required-version` is emitted here for the same reason: it must be the primary
+          # build whether or not the primary leg is in this run's matrix.
           ENTRIES="[]"
-          for prefix in $BC_PREFIXES; do
+          ALL_ENTRIES="[]"
+          for prefix in $ALL_PREFIXES; do
             FULL=$(dotnet run --project tools/DownloadArtifacts -- resolve-version "$prefix" dummy 2>/dev/null || true)
-            if [ -n "$FULL" ]; then
-              REQ=True
-              [ "$prefix" = "$PRIMARY_PREFIX" ] && echo "required-version=$FULL" >> "$GITHUB_OUTPUT"
-              # Issue #2674: AlRunner.Tests runs on TWO legs, not eight. It is 66% of a
-              # leg's wall clock (627s of 942s, run 33826354932) and carries no version
-              # signal: across the 25 most recent red Test Matrix runs it failed 8 times
-              # on a SCATTERED leg set (the load-dependent signature) and 3 times on ALL
-              # EIGHT (a real regression any single leg catches) — and ZERO times on a
-              # version split. On a green run all 1922 tests report an identical outcome
-              # on all 8 legs. The 6 redundant legs therefore add no signal and 6x the
-              # flake surface, which has reddened main repeatedly (#2496, #2653, #2648).
-              #
-              # The contrast is runner-extras, which stays on all 8: it has 6
-              # VERSION-SPLIT failures in the same 25 runs, because some AL surfaces are
-              # gated on preprocessor symbols only defined from 28.0 on. That 27-vs-28
-              # boundary is also why this is two legs and not one, and why they are the
-              # NEWEST minor of each major: the one failure mode that does discriminate
-              # by version shows up on the newest build first. A BC service update once
-              # rerouted callers past a Cecil rewrite and produced 53 failures on the
-              # newer build alone, and a rewrite that stops being reached fails silently
-              # — behaviour just reverts to BC's own, with nothing announcing it.
-              UNIT=False
-              case " $UNIT_PREFIXES " in *" $prefix "*) UNIT=True ;; esac
-              echo "  $prefix -> $FULL (required=$REQ, unit-tests=$UNIT)"
-              ENTRIES=$(echo "$ENTRIES" | python3 -c "import json,sys; v=json.load(sys.stdin); v.append({'bc-version':'$FULL','required':$REQ,'unit-tests':$UNIT}); print(json.dumps(v))")
-            else
+            if [ -z "$FULL" ]; then
               echo "  $prefix -> FAILED (skipping)"
+              continue
             fi
+            [ "$prefix" = "$PRIMARY_PREFIX" ] && echo "required-version=$FULL" >> "$GITHUB_OUTPUT"
+            ALL_ENTRIES=$(echo "$ALL_ENTRIES" | python3 -c "import json,sys; v=json.load(sys.stdin); v.append('$FULL'); print(json.dumps(v))")
+
+            case " $GATING_PREFIXES " in
+              *" $prefix "*) ;;
+              *) echo "  $prefix -> $FULL (resolved, NOT a leg of this run)"; continue ;;
+            esac
+
+            REQ=True
+            # Issue #2674: AlRunner.Tests runs on TWO legs, not eight. It is 66% of a
+            # leg's wall clock (627s of 942s, run 33826354932) and carries no version
+            # signal: across the 25 most recent red Test Matrix runs it failed 8 times
+            # on a SCATTERED leg set (the load-dependent signature) and 3 times on ALL
+            # EIGHT (a real regression any single leg catches) — and ZERO times on a
+            # version split.
+            #
+            # #3141 re-measured that over 288 failed Test Matrix runs (2026-08-02 to
+            # 2026-09-06) and found exactly ONE clean version split, which is why this
+            # is still TWO legs and not one: run 33337113550 (2026-08-30) failed
+            # ProvisionExplicitModesTests.TestApps_BundleDeclaresOlderMajor_StillTargetsEngineMajor
+            # on 27.0, 27.3 AND 27.5 with all four 28.x legs green. The comment inside
+            # that test names the cause — a hardcoded "27" colliding with the engine's
+            # own major only on a 27.x leg. So the 27 copy of the C# suite has caught a
+            # real defect no 28.x leg could catch, and #3141's proposal to run it once on
+            # 28.4 was measured and rejected.
+            #
+            # The contrast is runner-extras, which stays on every leg of whatever matrix
+            # ran: it has 6 VERSION-SPLIT failures in the same 25 runs, because some AL
+            # surfaces are gated on preprocessor symbols only defined from 28.0 on. That
+            # 27-vs-28 boundary is also why this is two legs and not one, and why they are
+            # the NEWEST minor of each major: the one failure mode that does discriminate
+            # by version shows up on the newest build first. A BC service update once
+            # rerouted callers past a Cecil rewrite and produced 53 failures on the
+            # newer build alone, and a rewrite that stops being reached fails silently
+            # — behaviour just reverts to BC's own, with nothing announcing it.
+            UNIT=False
+            case " $UNIT_PREFIXES " in *" $prefix "*) UNIT=True ;; esac
+            echo "  $prefix -> $FULL (required=$REQ, unit-tests=$UNIT)"
+            ENTRIES=$(echo "$ENTRIES" | python3 -c "import json,sys; v=json.load(sys.stdin); v.append({'bc-version':'$FULL','required':$REQ,'unit-tests':$UNIT}); print(json.dumps(v))")
           done
+
+          # A resolve step that produced no legs must fail here rather than hand the `test`
+          # job an empty matrix: GitHub skips a job whose matrix is empty, and the workflow
+          # then reports success having run no tests at all. Newly reachable now that a
+          # second narrowing exists, but it was always the worst outcome of this block.
+          if [ "$ENTRIES" = "[]" ]; then
+            echo "::error::resolved an empty matrix from '$GATING_PREFIXES' — no BC version resolved to a build, so the test job would be skipped and this workflow would report success having run nothing"
+            exit 1
+          fi
+
           echo "matrix={\"target\":$ENTRIES}" >> "$GITHUB_OUTPUT"
           echo "Matrix: $ENTRIES"
 
-          VERSIONS_JSON=$(echo "$ENTRIES" | python3 -c "import json,sys; v=json.load(sys.stdin); print(json.dumps([e['bc-version'] for e in v]))")
-          echo "versions-json=$VERSIONS_JSON" >> "$GITHUB_OUTPUT"
-          echo "Versions: $VERSIONS_JSON"
+          echo "versions-json=$ALL_ENTRIES" >> "$GITHUB_OUTPUT"
+          echo "Versions (full list, NOT narrowed): $ALL_ENTRIES"
 
   test:
     needs: resolve-versions

--- a/.github/workflows/main-verdict-floor.yml
+++ b/.github/workflows/main-verdict-floor.yml
@@ -7,8 +7,11 @@ name: Main verdict floor
 #
 # WHAT IS AND IS NOT BROKEN
 #
-# `All BC versions passed` still gates every pull request targeting `main`, and that is
-# untouched. This is not a hole a red PR can merge through. What the cancellation destroys is
+# `BC test matrix passed` still gates every pull request targeting `main`, and that is
+# untouched. (#3141 renamed that context from `All BC versions passed` and narrowed the
+# pull-request matrix to three legs; this workflow runs on a `schedule`, so it is unaffected
+# by that narrowing and still delegates at full width — which is now load-bearing, because it
+# is the only cadence on which 27.3, 28.0, 28.1, 28.2 and 28.3 run at all.) This is not a hole a red PR can merge through. What the cancellation destroys is
 # the POST-MERGE signal: when a merge breaks `main`, or when two individually-green PRs
 # conflict semantically after landing (#2924, and #2991 for the concrete instance), the run
 # that would have said so is cancelled by the next merge and nobody is notified.
@@ -189,7 +192,7 @@ jobs:
       ref: ${{ github.sha }}
 
   floor-verdict:
-    # Deliberately NOT named `All BC versions passed`. That context is one of main's two
+    # Deliberately NOT named `BC test matrix passed`. That context is one of main's two
     # required status checks, declared in test-matrix.yml, and a second workflow reporting it
     # on the same head SHA would make `gh pr checks` ambiguous about which run a verdict came
     # from — the stale-verdict trap ci-verdicts.md section 2 exists for.

--- a/.github/workflows/ms-bucket-nightly.yml
+++ b/.github/workflows/ms-bucket-nightly.yml
@@ -40,7 +40,7 @@ name: MS bucket (nightly)
 # ─── IT GATES NOTHING ───────────────────────────────────────────────────────────────────────
 #
 # No push, no pull_request. Not a required check, not in any branch ruleset. `main`'s gate is
-# and stays "All BC versions passed" (test-matrix.yml). Nothing here should ever be "made
+# and stays "BC test matrix passed" (test-matrix.yml). Nothing here should ever be "made
 # green" by working around it — if it is red for a reason that is NOT the known blocker, that
 # is the signal, and the fix belongs where the defect is.
 #

--- a/.github/workflows/ms-bucket.yml
+++ b/.github/workflows/ms-bucket.yml
@@ -8,7 +8,7 @@ name: MS bucket (manual)
 #   * `on: workflow_dispatch` only. No push, no pull_request, no schedule. A 9,500-test
 #     bucket is a multi-hour job and must never land on a PR.
 #   * Not a required check and not in any branch ruleset. Nothing about `main`'s gate
-#     ("All BC versions passed", test-matrix.yml) changes.
+#     ("BC test matrix passed", test-matrix.yml) changes.
 #   * It measures; it does not try to make the suite green. The job is GREEN when it
 #     produced a number (runner exit 0 or 1 plus a JUnit file) and RED only when it did not
 #     (compile fail, exec fail, crash, or no JUnit) — thousands of failing tests are the

--- a/.github/workflows/require-tests.yml
+++ b/.github/workflows/require-tests.yml
@@ -3,9 +3,11 @@ name: Require Tests
 # This job used to live in pr-check.yml. It was moved out for #2726, and the move
 # is the whole fix -- the job body below is unchanged.
 #
-# "Tests updated" is one of the two contexts the `main` branch ruleset requires
-# (the others are "All BC versions passed" from test-matrix.yml, and one per job
-# in pr-gate.yml since #3165). pr-check.yml used to trigger on 'edited',
+# "Tests updated" is one of the contexts the `main` branch ruleset requires -- ten
+# of them once #3141 and #3165 are both reflected in the ruleset: this one,
+# "BC test matrix passed" from test-matrix.yml, and one per job in pr-gate.yml.
+# (It said "one of the two" until #3141; that was true when the other was
+# "All BC versions passed" and nothing else gated.) pr-check.yml used to trigger on 'edited',
 # 'labeled' and 'unlabeled' -- event types that fire
 # WITHOUT changing the head SHA -- while also declaring cancel-in-progress: true.
 # Editing a PR body, or labelling a PR right after opening it (both routine, both

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -5,19 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  # The full eight-leg matrix, on the default branch, once a day (#3141).
-  #
-  # A pull request runs .github/pr-bc-versions.txt -- three legs, not eight -- because
-  # 28.1, 28.2, 28.3 and 27.3 never once reported a failure a neighbouring leg on the
-  # same commit did not, across 37 days of history. "Never once, in 37 days" is not
-  # "never", so the five dropped legs have to keep running somewhere or a regression
-  # only 28.2 can see would be caught never rather than late.
-  #
-  # Every push to main already runs all eight, but #3003 measured those cancelled 35
-  # times out of 40 by the next merge -- so on a busy day the push path is not a
-  # reliable full run and cannot be the only one. This is.
-  schedule:
-    - cron: '0 3 * * *'
 
 
 # Two agents pushing to the same branch used to leave BOTH runs holding job slots: every
@@ -41,14 +28,15 @@ on:
 # newest main run -- the only one whose answer is about the tree anybody has -- and drops the
 # rest instead of holding job slots for them.
 #
-# The group is keyed on the EVENT as well as the ref (#3141). A schedule fires on the
-# default branch, so a scheduled run and a merge push to main carry the identical
-# `github.ref`; keyed on the ref alone, the next merge would cancel the daily full
-# matrix, and the five legs pull requests no longer run would exist on paper only.
-# Separating them costs nothing -- push still supersedes push, and a pull request's ref
-# (`refs/pull/N/merge`) was already distinct.
+# #3141 narrowed the PULL-REQUEST matrix to three legs (.github/pr-bc-versions.txt);
+# push is untouched and still resolves all eight. That makes this cancellation policy
+# matter more, not less, for the five legs pull requests no longer run -- but the
+# cadence guarantee for them does not live here. It lives in main-verdict-floor.yml
+# (#3003/#3158), which runs the full eight against main's HEAD every 30 minutes unless
+# that SHA already has a conclusive verdict. Adding a second schedule here would run a
+# full matrix nobody asked for on top of it.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -72,10 +60,11 @@ jobs:
     # matrix to three legs. At that point the old name asserted that all BC versions
     # passed on a run where five of them had not been executed, and the name of a
     # required check is exactly what a person reads when deciding whether to trust a
-    # green pull request. "BC test matrix passed" is true on all four paths: three legs
-    # on a pull request, eight on a push to main, eight on the schedule, eight on a
-    # release. The step below prints which versions actually gated, so the run itself
-    # says what the name deliberately does not.
+    # green pull request. "BC test matrix passed" is true on all three paths this
+    # workflow has: three legs on a pull request, eight on a push to main, eight on a
+    # release (publish.yml, which calls the same reusable matrix). The step below prints
+    # which versions actually gated, so the run itself says what the name deliberately
+    # does not.
     needs: [bc-tests]
     if: always()
     runs-on: ubuntu-latest
@@ -96,5 +85,7 @@ jobs:
           echo "The BC test matrix passed."
           echo "Which versions ran is decided by resolve-versions in bc-tests.yml:"
           echo "  pull_request        -> .github/pr-bc-versions.txt (a subset, see #3141)"
-          echo "  push / schedule     -> .github/bc-versions.txt (every version)"
+          echo "  push (main)         -> .github/bc-versions.txt (every version)"
+          echo "The five versions a pull request does not run are covered on a cadence by"
+          echo "main-verdict-floor.yml, which runs all eight against main every 30 minutes."
           echo "Read the 'Resolve BC versions' step of this run for the exact list it gated on."

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -5,6 +5,19 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # The full eight-leg matrix, on the default branch, once a day (#3141).
+  #
+  # A pull request runs .github/pr-bc-versions.txt -- three legs, not eight -- because
+  # 28.1, 28.2, 28.3 and 27.3 never once reported a failure a neighbouring leg on the
+  # same commit did not, across 37 days of history. "Never once, in 37 days" is not
+  # "never", so the five dropped legs have to keep running somewhere or a regression
+  # only 28.2 can see would be caught never rather than late.
+  #
+  # Every push to main already runs all eight, but #3003 measured those cancelled 35
+  # times out of 40 by the next merge -- so on a busy day the push path is not a
+  # reliable full run and cannot be the only one. This is.
+  schedule:
+    - cron: '0 3 * * *'
 
 
 # Two agents pushing to the same branch used to leave BOTH runs holding job slots: every
@@ -27,8 +40,15 @@ on:
 # was already gated by this same matrix on its own PR before merge. So the net keeps the
 # newest main run -- the only one whose answer is about the tree anybody has -- and drops the
 # rest instead of holding job slots for them.
+#
+# The group is keyed on the EVENT as well as the ref (#3141). A schedule fires on the
+# default branch, so a scheduled run and a merge push to main carry the identical
+# `github.ref`; keyed on the ref alone, the next merge would cancel the daily full
+# matrix, and the five legs pull requests no longer run would exist on paper only.
+# Separating them costs nothing -- push still supersedes push, and a pull request's ref
+# (`refs/pull/N/merge`) was already distinct.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:
@@ -40,12 +60,22 @@ jobs:
     uses: ./.github/workflows/bc-tests.yml
 
   all-tests:
-    name: All BC versions passed
-    # Deliberately still a job in THIS file, not in bc-tests.yml: "All BC versions
-    # passed" is the one required status check on main, and a check's context is
-    # its job name qualified by the calling job. Moving it into the reusable
-    # workflow would rename it to "bc-tests / All BC versions passed" and silently
-    # leave the branch ruleset requiring a check that no longer reports.
+    name: BC test matrix passed
+    # Deliberately still a job in THIS file, not in bc-tests.yml: this is the one
+    # required status check on main (the other required context is "Tests updated",
+    # from require-tests.yml), and a check's context is its job name qualified by the
+    # calling job. Moving it into the reusable workflow would rename it to
+    # "bc-tests / BC test matrix passed" and silently leave the branch ruleset
+    # requiring a check that no longer reports.
+    #
+    # It was called "All BC versions passed" until #3141 narrowed the pull-request
+    # matrix to three legs. At that point the old name asserted that all BC versions
+    # passed on a run where five of them had not been executed, and the name of a
+    # required check is exactly what a person reads when deciding whether to trust a
+    # green pull request. "BC test matrix passed" is true on all four paths: three legs
+    # on a pull request, eight on a push to main, eight on the schedule, eight on a
+    # release. The step below prints which versions actually gated, so the run itself
+    # says what the name deliberately does not.
     needs: [bc-tests]
     if: always()
     runs-on: ubuntu-latest
@@ -63,4 +93,8 @@ jobs:
             echo "fail-fast is off, so all failing legs are reported, not just the first."
             exit 1
           fi
-          echo "All required BC versions + smoke passed."
+          echo "The BC test matrix passed."
+          echo "Which versions ran is decided by resolve-versions in bc-tests.yml:"
+          echo "  pull_request        -> .github/pr-bc-versions.txt (a subset, see #3141)"
+          echo "  push / schedule     -> .github/bc-versions.txt (every version)"
+          echo "Read the 'Resolve BC versions' step of this run for the exact list it gated on."

--- a/AlRunner.Tests/BcLegRerunWorkflowTests.cs
+++ b/AlRunner.Tests/BcLegRerunWorkflowTests.cs
@@ -3,7 +3,7 @@
 // failing-leg set across two independent runs of the same code") can be satisfied without
 // `gh run rerun`, which section 3 bans because it overwrites the failed run's log in place.
 //
-// The reason this needs a guard rather than a comment: `All BC versions passed` is the ONE
+// The reason this needs a guard rather than a comment: `BC test matrix passed` is the ONE
 // required status check in main's branch ruleset (verified against the live ruleset — the
 // other required context is `Tests updated`, and the individual `bc-tests / BC <ver>` legs
 // are NOT required). If a SINGLE-leg run could report that context, one leg's green would
@@ -28,7 +28,7 @@ public sealed class BcLegRerunWorkflowTests
         Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".github", "workflows"));
 
     private const string Workflow = "bc-leg-rerun.yml";
-    private const string RequiredCheckJobName = "All BC versions passed";
+    private const string RequiredCheckJobName = "BC test matrix passed";
 
     private static string Read(string name)
     {

--- a/AlRunner.Tests/CorpusAppEnumerationWorkflowTests.cs
+++ b/AlRunner.Tests/CorpusAppEnumerationWorkflowTests.cs
@@ -17,7 +17,7 @@
 // #2984: every one of them fails against the pre-#2984 workflow.
 //
 // What is NOT asserted here, deliberately: which BC legs run, and what reports the two
-// required contexts. `main`'s ruleset requires exactly `All BC versions passed` and
+// required contexts. `main`'s ruleset requires exactly `BC test matrix passed` and
 // `Tests updated`; the per-leg `(required)` text is part of a job's own NAME and makes no
 // leg a required context. AlRunner.Tests/BcLegRerunWorkflowTests.cs owns that property and
 // nothing here may duplicate or weaken it.

--- a/AlRunner.Tests/MainVerdictFloorWorkflowTests.cs
+++ b/AlRunner.Tests/MainVerdictFloorWorkflowTests.cs
@@ -70,7 +70,7 @@ public sealed class MainVerdictFloorWorkflowTests
 
     private const string Floor = "main-verdict-floor.yml";
     private const string Gating = "test-matrix.yml";
-    private const string RequiredCheckJobName = "All BC versions passed";
+    private const string RequiredCheckJobName = "BC test matrix passed";
 
     /// <summary>
     /// Longest `main` Test Matrix run observed in the 100-run sample above, in minutes. The
@@ -131,7 +131,7 @@ public sealed class MainVerdictFloorWorkflowTests
     [Fact]
     public void Floor_NeverDeclaresTheRequiredAggregateCheck()
     {
-        // `All BC versions passed` is one of main's two required status checks. A second
+        // `BC test matrix passed` is one of main's two required status checks. A second
         // workflow reporting that context on the same head SHA makes `gh pr checks`
         // ambiguous about which run a verdict came from — the stale-verdict trap in
         // ci-verdicts.md section 2. Matches the job-name FORM so the file's comments may

--- a/AlRunner.Tests/PullRequestMatrixScopeTests.cs
+++ b/AlRunner.Tests/PullRequestMatrixScopeTests.cs
@@ -4,9 +4,10 @@
 // The measurement behind the narrowing is in the issue: over 37 days, 28.1, 28.2, 28.3 and
 // 27.3 never once reported a failure that a neighbouring leg on the same commit did not,
 // while 27.0 and 27.5 each caught defects no 28.x leg caught. So the 27/28 split is real and
-// the middle minors are paying for a result the run already has. `main` still gets all eight,
-// on a schedule and on every push, so a regression only 28.2 can see is caught within the
-// schedule interval rather than never.
+// the middle minors are paying for a result the run already has. `main` still gets all eight:
+// on every push, and — the guarantee that actually holds when merges are cancelling each
+// other — every 30 minutes from main-verdict-floor.yml (#3003/#3158), which is why this file
+// pins that workflow's shape too.
 //
 // Why this needs a guard rather than a comment. Three separate silent-failure shapes live in
 // this change, and every one of them reports green:
@@ -224,8 +225,13 @@ public sealed class PullRequestMatrixScopeTests
         // ran still reports success.
         var step = ResolveStep();
 
+        // The predicate names the guard's OWN message, not the phrase "empty matrix" — the
+        // pull-request-list validation above also says "would resolve to an empty matrix", so
+        // a looser match stayed green with this entire `if` block deleted. Second time this
+        // file has had a test that passed without pinning what it claimed to pin.
         var errors = Regex.Matches(step, @"::error::[^\n]*").Select(m => m.Value).ToList();
-        Assert.Contains(errors, e => e.Contains("empty matrix", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(errors, e => e.Contains("resolved an empty matrix", StringComparison.Ordinal)
+                                     && e.Contains("$GATING_PREFIXES", StringComparison.Ordinal));
     }
 
     [Fact]
@@ -244,34 +250,44 @@ public sealed class PullRequestMatrixScopeTests
         Assert.Contains("expected=$(grep -v '^#' .github/bc-versions.txt", workflow, StringComparison.Ordinal);
     }
 
-    // ---- main still gets all eight -----------------------------------------------------
+    // ---- the dropped legs still run somewhere, on a cadence ---------------------------
 
     [Fact]
-    public void TestMatrix_RunsTheFullMatrixOnASchedule()
+    public void DroppedLegs_StillRunAtFullWidth_OnAPeriodicMainWorkflow()
     {
         // Narrowing pull requests is only defensible if something still runs the legs that
-        // were dropped. Without this, a 28.2-only regression is caught never rather than
-        // within the schedule interval.
-        var triggers = WorkflowTriggers.TriggersOf(Read("test-matrix.yml"));
+        // were dropped, on a cadence, without a human asking. main-verdict-floor.yml
+        // (#3003/#3158) is that thing: it delegates to the same reusable matrix, sets no
+        // version filter, and fires on a schedule — so `github.event_name` is `schedule`,
+        // never `pull_request`, and the narrowing below cannot reach it.
+        //
+        // This test is here rather than in MainVerdictFloorWorkflowTests because the floor
+        // predates #3141 and does not know it is now load-bearing for the pull-request
+        // narrowing. Deleting or `pull_request`-triggering the floor would silently make
+        // 27.3, 28.0, 28.1, 28.2 and 28.3 stop running anywhere on a cadence.
+        var floor = Read("main-verdict-floor.yml");
+        var code = CodeOnly(floor);
+        var triggers = WorkflowTriggers.TriggersOf(floor);
 
         Assert.Contains("schedule", triggers);
-        Assert.Contains("pull_request", triggers);
-        Assert.Contains("push", triggers);
-        Assert.Matches(new Regex(@"cron:\s*'[^']+'"), Read("test-matrix.yml"));
+        Assert.DoesNotContain("pull_request", triggers);
+        Assert.Matches(new Regex(@"cron:\s*'[^']+'"), code);
+        Assert.Contains("uses: ./.github/workflows/bc-tests.yml", code, StringComparison.Ordinal);
+        Assert.DoesNotContain("bc-version-filter", code, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void TestMatrix_ScheduledRunIsNotCancelledByAMergeToMain()
+    public void TestMatrix_AddsNoSecondScheduleOfItsOwn()
     {
-        // A schedule fires on the default branch, so `github.ref` is the same
-        // `refs/heads/main` a merge push carries. With cancel-in-progress: true and a group
-        // keyed on ref alone, the next merge would kill the only run that covers the five
-        // legs pull requests no longer run — the full matrix would then exist on paper only.
-        var code = CodeOnly(Read("test-matrix.yml"));
-        var group = Regex.Match(code, @"group:\s*(.+)");
+        // The first draft of #3141 put a daily `schedule:` here. main-verdict-floor.yml
+        // already runs the full eight against main's HEAD every 30 minutes, skipping when
+        // that SHA already has a conclusive verdict — a strictly stronger guarantee than a
+        // daily run, and one this workflow's `cancel-in-progress: true` cannot give. A
+        // schedule here would be ~75 job-minutes a day of duplicate, on an Actions queue
+        // that is scoped per ACCOUNT and already the binding constraint (#3141).
+        var triggers = WorkflowTriggers.TriggersOf(Read("test-matrix.yml"));
 
-        Assert.True(group.Success, "test-matrix.yml must still declare a concurrency group");
-        Assert.Contains("github.event_name", group.Groups[1].Value, StringComparison.Ordinal);
+        Assert.Equal(new[] { "push", "pull_request" }, triggers);
     }
 
     // ---- the required-context rename ----------------------------------------------------

--- a/AlRunner.Tests/PullRequestMatrixScopeTests.cs
+++ b/AlRunner.Tests/PullRequestMatrixScopeTests.cs
@@ -1,0 +1,333 @@
+// Issue #3141: the pull-request BC matrix runs 3 legs, not 8, and the required status check
+// is named for what it actually checked.
+//
+// The measurement behind the narrowing is in the issue: over 37 days, 28.1, 28.2, 28.3 and
+// 27.3 never once reported a failure that a neighbouring leg on the same commit did not,
+// while 27.0 and 27.5 each caught defects no 28.x leg caught. So the 27/28 split is real and
+// the middle minors are paying for a result the run already has. `main` still gets all eight,
+// on a schedule and on every push, so a regression only 28.2 can see is caught within the
+// schedule interval rather than never.
+//
+// Why this needs a guard rather than a comment. Three separate silent-failure shapes live in
+// this change, and every one of them reports green:
+//
+//   1. A narrowed matrix under a check still called "All BC versions passed" asserts that all
+//      BC versions passed when three of them did not run. The name is what a person reads
+//      when deciding to trust a green PR, so the rename is part of the change, and the name
+//      has to stay identical in FOUR places at once — the job in test-matrix.yml, the branch
+//      ruleset, DEFAULT_REQUIRED_CONTEXTS and RULESET_CONTEXTS. #2785 is the record of what
+//      those last two drifting apart costs.
+//   2. A typo in the pull-request version list resolves to an empty or wrong matrix. An empty
+//      matrix means the `test` job never runs, and a workflow whose only real job never ran
+//      still reports success (#1976, #2065).
+//   3. `versions-json` narrowing along with the matrix. The `pack` job builds one engine
+//      variant per entry in that output and then asserts the packed count equals the number
+//      of entries in bc-versions.txt — so a narrowed versions-json turns every pull request's
+//      pack job red, and "fixing" that by relaxing the assertion would ship a nupkg missing
+//      five engine variants (#2024, #2166).
+//
+// Deliberately NOT here: dropping the second AlRunner.Tests run. The issue proposed running
+// the C# suite once, on 28.4, on the grounds that the 27.5 copy has never disagreed with it.
+// Measured against 288 failed Test Matrix runs between 2026-08-02 and 2026-09-06, that is
+// false: run 33337113550 (2026-08-30) failed
+// ProvisionExplicitModesTests.TestApps_BundleDeclaresOlderMajor_StillTargetsEngineMajor on
+// 27.0, 27.3 AND 27.5 with all four 28.x legs green — a clean major-version split, and the
+// fix comment still sitting in that test names the cause (a hardcoded "27" that collides with
+// the engine's own major only on a 27.x leg). The duplicate earns its cost, so
+// PullRequestList_KeepsEveryLegThatRunsTheCSharpSuite holds it in place.
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PullRequestMatrixScopeTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static readonly string GithubDir = Path.Combine(RepoRoot, ".github");
+
+    private const string FullVersionsFile = "bc-versions.txt";
+    private const string PrVersionsFile = "pr-bc-versions.txt";
+
+    /// <summary>
+    /// The one required status check `main`'s ruleset gates on, besides "Tests updated".
+    /// Spelled once here; the tests below prove every other copy of it agrees.
+    /// </summary>
+    private const string RequiredContext = "BC test matrix passed";
+
+    /// <summary>The name this replaces — it over-claimed the moment the matrix narrowed.</summary>
+    private const string RetiredContext = "All BC versions passed";
+
+    private static string Read(string workflowFile) =>
+        File.ReadAllText(Path.Combine(GithubDir, "workflows", workflowFile)).Replace("\r\n", "\n");
+
+    private static string ReadRepo(string relative) =>
+        File.ReadAllText(Path.Combine(RepoRoot, relative)).Replace("\r\n", "\n");
+
+    private static string CodeOnly(string text) =>
+        string.Join('\n', text.Split('\n').Where(l => !l.TrimStart().StartsWith('#')));
+
+    private static string[] Prefixes(string file)
+    {
+        var path = Path.Combine(GithubDir, file);
+        Assert.True(File.Exists(path), $"expected {file} at {path}");
+        return File.ReadAllLines(path)
+            .Where(l => !l.TrimStart().StartsWith('#'))
+            .SelectMany(l => l.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries))
+            .ToArray();
+    }
+
+    private static string NewestOf(IEnumerable<string> prefixes) =>
+        prefixes.OrderBy(p => Version.Parse(p)).Last();
+
+    private static string ResolveStep()
+    {
+        // The `Resolve BC versions` run block — the shell that decides which legs exist.
+        var text = Read("bc-tests.yml");
+        var start = text.IndexOf("- name: Resolve BC versions", StringComparison.Ordinal);
+        Assert.True(start > 0, "bc-tests.yml must still carry a 'Resolve BC versions' step");
+        var end = text.IndexOf("\n  test:", start, StringComparison.Ordinal);
+        Assert.True(end > start, "could not find the end of the resolve-versions job");
+        return text[start..end];
+    }
+
+    // ---- the pull-request version list ------------------------------------------------
+
+    [Fact]
+    public void PullRequestList_IsAProperSubsetOfTheFullList()
+    {
+        var all = Prefixes(FullVersionsFile);
+        var pr = Prefixes(PrVersionsFile);
+
+        Assert.NotEmpty(pr);
+        // A prefix here that bc-versions.txt does not carry resolves to a leg the release
+        // path never tests, and `pack`'s per-variant assertion would not cover it either.
+        Assert.Empty(pr.Except(all, StringComparer.Ordinal));
+        // Equal lists would make this file pure overhead pretending to be a decision.
+        Assert.True(pr.Length < all.Length,
+            $"{PrVersionsFile} ({pr.Length}) must be strictly smaller than {FullVersionsFile} ({all.Length})");
+        Assert.Equal(pr.Length, pr.Distinct(StringComparer.Ordinal).Count());
+    }
+
+    [Fact]
+    public void PullRequestList_CoversEveryMajorTheFullListCarries()
+    {
+        // The whole finding is that the 27-vs-28 boundary discriminates and the minors inside
+        // each major do not. Dropping a major entirely would throw away the one axis that
+        // has actually caught defects.
+        var majors = Prefixes(FullVersionsFile).Select(p => p.Split('.')[0]).Distinct().OrderBy(m => m);
+        var prMajors = Prefixes(PrVersionsFile).Select(p => p.Split('.')[0]).Distinct().OrderBy(m => m);
+
+        Assert.Equal(majors, prMajors);
+    }
+
+    [Fact]
+    public void PullRequestList_KeepsEveryLegThatRunsTheCSharpSuite()
+    {
+        // `unit-tests` is "the newest prefix of each major", computed from the FULL list. If
+        // the pull-request list dropped one of those, AlRunner.Tests would silently stop
+        // running on that major for every pull request — and a 27-only C# regression is not
+        // hypothetical: see this file's header for the run that caught one.
+        var all = Prefixes(FullVersionsFile);
+        var pr = Prefixes(PrVersionsFile);
+
+        var unitPrefixes = all.GroupBy(p => p.Split('.')[0]).Select(g => NewestOf(g)).ToArray();
+
+        Assert.Empty(unitPrefixes.Except(pr, StringComparer.Ordinal));
+        Assert.True(unitPrefixes.Length >= 2,
+            "the C# suite must still run on more than one BC major — one run of it cannot see a version split");
+    }
+
+    [Fact]
+    public void PullRequestList_KeepsThePrimaryPrefix()
+    {
+        // resolve-versions emits `required-version` only for the primary prefix, and the
+        // smoke job builds against it. A pull-request list without it would hand smoke an
+        // empty version.
+        var all = Prefixes(FullVersionsFile);
+
+        Assert.Contains(NewestOf(all), Prefixes(PrVersionsFile));
+    }
+
+    // ---- how the shared matrix applies it ---------------------------------------------
+
+    [Fact]
+    public void SharedMatrix_NarrowsOnlyForAPullRequest()
+    {
+        // push, schedule and the release path must all still resolve the full list. The test
+        // is that the pull-request list is read under a condition on the event name and
+        // nowhere else, so a scheduled or release run cannot pick it up by accident.
+        var step = CodeOnly(ResolveStep());
+
+        // The guard: every mention of the pull-request list sits INSIDE the `if` that tests
+        // the event name. One outside it would read the narrowed list on a push, a schedule
+        // or a release — and none of those has anything that would notice.
+        var guard = step.IndexOf("if [ \"${GATING_EVENT:-}\" = \"pull_request\" ]; then", StringComparison.Ordinal);
+        Assert.True(guard > 0, "bc-tests.yml must gate the pull-request list on GATING_EVENT");
+
+        var endOfGuard = step.IndexOf("\n          fi", guard, StringComparison.Ordinal);
+        Assert.True(endOfGuard > guard, "could not find the end of the pull_request guard");
+
+        var mentions = Regex.Matches(step, Regex.Escape(PrVersionsFile)).Select(m => m.Index).ToList();
+        Assert.NotEmpty(mentions);
+        Assert.All(mentions, i => Assert.InRange(i, guard, endOfGuard));
+    }
+
+    [Fact]
+    public void SharedMatrix_PassesTheEventNameInAsAnEnvVar()
+    {
+        // Via env rather than a `${{ }}` expansion inside `run:` — the same reasoning the
+        // bc-version-filter input already carries, since a `${{ }}` in a run body is textual
+        // substitution before bash sees it.
+        Assert.Contains("GATING_EVENT: ${{ github.event_name }}", Read("bc-tests.yml"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SharedMatrix_DerivesPerLegAttributesFromTheFullList_BeforeAnyNarrowing()
+    {
+        // The property bc-leg-rerun.yml depends on, now also load-bearing for the
+        // pull-request path: `required` and `unit-tests` are computed from the FULL list, so
+        // a narrowed leg does exactly the work that leg does on a full run.
+        var step = CodeOnly(ResolveStep());
+
+        var primary = step.IndexOf("PRIMARY_PREFIX=", StringComparison.Ordinal);
+        var unit = step.IndexOf("UNIT_PREFIXES=", StringComparison.Ordinal);
+        var prNarrow = step.IndexOf(PrVersionsFile, StringComparison.Ordinal);
+        var legNarrow = step.IndexOf("if [ -n \"${BC_VERSION_FILTER:-}\" ]", StringComparison.Ordinal);
+
+        Assert.True(primary > 0 && unit > 0 && prNarrow > 0 && legNarrow > 0);
+        Assert.True(primary < prNarrow && unit < prNarrow,
+            "the primary/unit selections must be derived before the pull-request narrowing");
+        Assert.True(primary < legNarrow && unit < legNarrow,
+            "the primary/unit selections must be derived before the single-leg narrowing");
+    }
+
+    [Fact]
+    public void SharedMatrix_RefusesAPullRequestListThatIsEmptyOrNotASubset()
+    {
+        // An unknown prefix must fail the run rather than resolving to an empty matrix — the
+        // silent-no-op shape #1976/#2065 record. Same standard the single-leg filter already
+        // holds itself to.
+        var step = ResolveStep();
+
+        Assert.Contains("::error::", step, StringComparison.Ordinal);
+        var errors = Regex.Matches(step, @"::error::[^\n]*").Select(m => m.Value).ToList();
+        Assert.Contains(errors, e => e.Contains(PrVersionsFile, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void SharedMatrix_FailsWhenTheResolvedMatrixIsEmpty()
+    {
+        // The mirror image, and the reason narrowing raises the stakes: an empty `target`
+        // array means the `test` job never runs, and a workflow whose only real job never
+        // ran still reports success.
+        var step = ResolveStep();
+
+        var errors = Regex.Matches(step, @"::error::[^\n]*").Select(m => m.Value).ToList();
+        Assert.Contains(errors, e => e.Contains("empty matrix", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void SharedMatrix_StillPublishesVersionsJsonForTheFullList()
+    {
+        // `pack` builds one engine variant per entry in versions-json and then asserts the
+        // packed count equals the number of entries in bc-versions.txt. Narrowing that output
+        // alongside the matrix would turn every pull request's pack job red, and relaxing the
+        // assertion instead would ship a nupkg missing five engine variants.
+        var step = CodeOnly(ResolveStep());
+        var workflow = CodeOnly(Read("bc-tests.yml"));
+
+        Assert.Contains("for prefix in $ALL_PREFIXES", step, StringComparison.Ordinal);
+        Assert.Matches(new Regex(@"versions-json=\$\{?ALL_ENTRIES\}?"), step);
+        // The release-path assertion this protects, still reading the full list.
+        Assert.Contains("expected=$(grep -v '^#' .github/bc-versions.txt", workflow, StringComparison.Ordinal);
+    }
+
+    // ---- main still gets all eight -----------------------------------------------------
+
+    [Fact]
+    public void TestMatrix_RunsTheFullMatrixOnASchedule()
+    {
+        // Narrowing pull requests is only defensible if something still runs the legs that
+        // were dropped. Without this, a 28.2-only regression is caught never rather than
+        // within the schedule interval.
+        var triggers = WorkflowTriggers.TriggersOf(Read("test-matrix.yml"));
+
+        Assert.Contains("schedule", triggers);
+        Assert.Contains("pull_request", triggers);
+        Assert.Contains("push", triggers);
+        Assert.Matches(new Regex(@"cron:\s*'[^']+'"), Read("test-matrix.yml"));
+    }
+
+    [Fact]
+    public void TestMatrix_ScheduledRunIsNotCancelledByAMergeToMain()
+    {
+        // A schedule fires on the default branch, so `github.ref` is the same
+        // `refs/heads/main` a merge push carries. With cancel-in-progress: true and a group
+        // keyed on ref alone, the next merge would kill the only run that covers the five
+        // legs pull requests no longer run — the full matrix would then exist on paper only.
+        var code = CodeOnly(Read("test-matrix.yml"));
+        var group = Regex.Match(code, @"group:\s*(.+)");
+
+        Assert.True(group.Success, "test-matrix.yml must still declare a concurrency group");
+        Assert.Contains("github.event_name", group.Groups[1].Value, StringComparison.Ordinal);
+    }
+
+    // ---- the required-context rename ----------------------------------------------------
+
+    [Fact]
+    public void RequiredContext_IsNamedIdenticallyEverywhereThatNamesIt()
+    {
+        // #2785: two copies of this list already drifted apart once, and the copy that gates
+        // the merge was the one left stale. A rename is exactly when that happens again.
+        Assert.Contains($"name: {RequiredContext}", CodeOnly(Read("test-matrix.yml")),
+            StringComparison.Ordinal);
+
+        var guard = ReadRepo(Path.Combine(".github", "scripts", "check_required_contexts.py"));
+        var defaults = Regex.Match(guard, @"DEFAULT_REQUIRED_CONTEXTS\s*=\s*\[([^\]]*)\]");
+        Assert.True(defaults.Success, "check_required_contexts.py must still declare DEFAULT_REQUIRED_CONTEXTS");
+        Assert.Contains($"\"{RequiredContext}\"", defaults.Groups[1].Value, StringComparison.Ordinal);
+
+        var ciWait = ReadRepo(Path.Combine("tools", "ci-wait.py"));
+        var ruleset = Regex.Match(ciWait, @"RULESET_CONTEXTS\s*=\s*\(([^)]*)\)");
+        Assert.True(ruleset.Success, "ci-wait.py must still declare RULESET_CONTEXTS");
+        Assert.Contains($"\"{RequiredContext}\"", ruleset.Groups[1].Value, StringComparison.Ordinal);
+
+        // Both lists must also still agree on the OTHER required context, or the guard that
+        // compares them against the live ruleset fails on drift it did not cause.
+        Assert.Contains("\"Tests updated\"", defaults.Groups[1].Value, StringComparison.Ordinal);
+        Assert.Contains("\"Tests updated\"", ruleset.Groups[1].Value, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RetiredContextName_IsDeclaredByNoWorkflowAtAll()
+    {
+        // A job still named "All BC versions passed" would report a second, unused context
+        // and keep the false claim alive in `gh pr checks` output. The regex matches the job
+        // -name FORM, so a comment explaining the rename does not trip it.
+        var declared = Directory.GetFiles(Path.Combine(GithubDir, "workflows"), "*.yml")
+            .Where(f => Regex.IsMatch(CodeOnly(File.ReadAllText(f)),
+                @"name:\s*" + Regex.Escape(RetiredContext)))
+            .Select(Path.GetFileName)
+            .ToList();
+
+        Assert.Empty(declared);
+    }
+
+    [Fact]
+    public void RequiredContext_IsDeclaredExactlyOnce_AndOnlyOnTheGatingPath()
+    {
+        // The same structural guarantee BcLegRerunWorkflowTests holds for the old name: one
+        // declaration, in the workflow the ruleset actually gates, and none in the
+        // diagnostic single-leg path where one leg's green would satisfy it.
+        var declaring = Directory.GetFiles(Path.Combine(GithubDir, "workflows"), "*.yml")
+            .Where(f => Regex.IsMatch(CodeOnly(File.ReadAllText(f)),
+                @"name:\s*" + Regex.Escape(RequiredContext)))
+            .Select(f => Path.GetFileName(f)!)
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal(new[] { "test-matrix.yml" }, declaring);
+    }
+}

--- a/AlRunner.Tests/ReleaseTestParityTests.cs
+++ b/AlRunner.Tests/ReleaseTestParityTests.cs
@@ -255,16 +255,16 @@ public sealed class ReleaseTestParityTests
     [Fact]
     public void RequiredStatusCheck_StaysAJobInTestMatrixYml()
     {
-        // "All BC versions passed" is one of the two required checks in main's branch
+        // "BC test matrix passed" is one of the two required checks in main's branch
         // ruleset (the other is "Tests updated", produced by require-tests.yml). A
         // check's context is the job name qualified by the CALLING job, so moving this job
-        // into bc-tests.yml would rename it to "bc-tests / All BC versions passed" and leave
+        // into bc-tests.yml would rename it to "bc-tests / BC test matrix passed" and leave
         // the ruleset requiring a context that never reports again — a permanently pending
         // check that blocks every pull request, or worse, one that is quietly dropped.
         var text = Read("test-matrix.yml");
 
-        Assert.Contains("name: All BC versions passed", text, StringComparison.Ordinal);
-        Assert.DoesNotContain("All BC versions passed", Read(WorkflowParity.SharedWorkflow), StringComparison.Ordinal);
+        Assert.Contains("name: BC test matrix passed", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("BC test matrix passed", Read(WorkflowParity.SharedWorkflow), StringComparison.Ordinal);
     }
 
     // ---- release ordering: tests gate every write (#1978) ---------------------------

--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -271,7 +271,7 @@ def live_ruleset_contexts(branch: str = "main") -> tuple[str, ...] | None:
     active. That is why it is the right endpoint and /rulesets/<id> is not:
     there is no ruleset id to get wrong. Measured 2026-09-05, it answers 200
     even unauthenticated on this public repo, and reports exactly
-    ["All BC versions passed", "Tests updated"] carrying ruleset_id 15001420.
+    ["BC test matrix passed", "Tests updated"] carrying ruleset_id 15001420.
     """
     payload = live_ruleset_payload(branch)
     if payload is None:
@@ -369,9 +369,15 @@ def resolve_required_contexts(branch: str = "main", fetch=None):
 # ruleset if you do want to name an id.
 #
 # Names containing "(required)" are the bc-tests matrix legs. They are not
-# ruleset contexts themselves, but "All BC versions passed" fails when any of
+# ruleset contexts themselves, but "BC test matrix passed" fails when any of
 # them does, so a cancelled leg blocks just as surely.
-RULESET_CONTEXTS = ("All BC versions passed", "Tests updated")
+#
+# Renamed from "All BC versions passed" by #3141: a pull request now runs three of the
+# eight BC versions (.github/pr-bc-versions.txt), so the old name claimed more than the
+# run had measured. This tuple and DEFAULT_REQUIRED_CONTEXTS in
+# .github/scripts/check_required_contexts.py must stay identical to each other AND to the
+# live ruleset — that guard fails on drift in either direction (#2785).
+RULESET_CONTEXTS = ("BC test matrix passed", "Tests updated")
 
 NOT_FAILURES = ("success", "neutral", "skipped")
 

--- a/tools/test_ci_wait.py
+++ b/tools/test_ci_wait.py
@@ -868,7 +868,7 @@ def absorbed_failure_set(failing_name):
     """Required contexts all green; `failing_name` red on the live run, with a
     cancelled sibling entry left behind by a superseded run of that workflow."""
     runs = [cr(n, "success", MATRIX_RUN, 101496852900 + i) for i, n in enumerate(LEGS)]
-    runs.append(cr("All BC versions passed", "success", MATRIX_RUN, 101499731123))
+    runs.append(cr("BC test matrix passed", "success", MATRIX_RUN, 101499731123))
     runs.append(cr("Tests updated", "success", REQ_RUN, 101496768931))
     # the cancelled leftover, and a genuinely failing NEWEST entry for one name
     runs.append(cr(failing_name, "cancelled", KILLED_PR_CHECK, 101496919780))
@@ -897,7 +897,7 @@ check("...and points at the workflow run that produced the failure",
 # The mirror, so this is not just "never say harmless": a cancelled entry that a
 # newer run really did re-report as SUCCESS is still explained as harmless.
 runs = [cr(n, "success", MATRIX_RUN, 101496852900 + i) for i, n in enumerate(LEGS)]
-runs.append(cr("All BC versions passed", "success", MATRIX_RUN, 101499731123))
+runs.append(cr("BC test matrix passed", "success", MATRIX_RUN, 101499731123))
 runs.append(cr("Tests updated", "success", REQ_RUN, 101496768931))
 runs.append(cr("scripts/ unit tests", "cancelled", KILLED_PR_CHECK, 101496919785))
 runs.append(cr("scripts/ unit tests", "success", LIVE_PR_CHECK, 101496925213))
@@ -924,7 +924,7 @@ check("...and never describes that failure as harmless",
 # A failure inside a run that IS cancelled at the run level stays discountable --
 # that is the deliberate #3002 trade-off, and narrowing it is not this fix.
 runs = [cr(n, "success", MATRIX_RUN, 101496852900 + i) for i, n in enumerate(LEGS)]
-runs.append(cr("All BC versions passed", "success", MATRIX_RUN, 101499731123))
+runs.append(cr("BC test matrix passed", "success", MATRIX_RUN, 101499731123))
 runs.append(cr("Tests updated", "success", REQ_RUN, 101496768931))
 runs.append(cr("scripts/ unit tests", "failure", KILLED_PR_CHECK, 101496919785))
 v = cw.classify(runs, workflow_runs=C6377B30_RUNS)
@@ -940,7 +940,7 @@ check("...and is not announced as a real failing check",
 # exit-4 advice ("a cancelled run has no failure log to overwrite") is wrong for
 # exactly this entry: it has one, and `gh run rerun` destroys it permanently.
 runs = [cr(n, "success", MATRIX_RUN, 101496852900 + i) for i, n in enumerate(LEGS)]
-runs.append(cr("All BC versions passed", "success", MATRIX_RUN, 101499731123))
+runs.append(cr("BC test matrix passed", "success", MATRIX_RUN, 101499731123))
 runs.append(cr("Tests updated", "failure", KILLED_PR_CHECK, 101496919511))
 v = cw.classify(runs, workflow_runs=C6377B30_RUNS)
 check("a required failure inside a CANCELLED run is blocked, not failed",
@@ -954,7 +954,7 @@ check("...and says what it actually concluded, not just 'cancelled'",
 # ...and the plain case keeps the unqualified advice, or the warning above would
 # just be noise on every cancellation.
 runs = [cr(n, "success", MATRIX_RUN, 101496852900 + i) for i, n in enumerate(LEGS)]
-runs.append(cr("All BC versions passed", "success", MATRIX_RUN, 101499731123))
+runs.append(cr("BC test matrix passed", "success", MATRIX_RUN, 101499731123))
 runs.append(cr("Tests updated", "cancelled", KILLED_PR_CHECK, 101496919511))
 v = cw.classify(runs, workflow_runs=C6377B30_RUNS)
 check("a genuinely cancelled required context is blocked with no such warning",

--- a/tools/test_ci_wait.py
+++ b/tools/test_ci_wait.py
@@ -46,7 +46,7 @@ LEGS = ["bc-tests / BC 27.0 (required)", "bc-tests / BC 28.3 (required)"]
 
 def green_set(**kw):
     runs = [run(n, "success") for n in LEGS]
-    runs.append(run("All BC versions passed", "success"))
+    runs.append(run("BC test matrix passed", "success"))
     runs.append(run("Tests updated", "success"))
     runs.append(run("scripts/ unit tests", "success"))
     return runs
@@ -119,15 +119,15 @@ check("a cancellation mid-run is not called a block yet", v.code is None, f"(cod
 # --- the required contexts that are NOT named '(required)' must be waited on
 # --- and judged: reporting GREEN while 'Tests updated' is red was possible
 runs = [run(n, "success") for n in LEGS]
-runs.append(run("All BC versions passed", "success"))
+runs.append(run("BC test matrix passed", "success"))
 runs.append(run("Tests updated", "failure"))
 v = cw.classify(runs)
 check("a failing 'Tests updated' is not reported green", v.code == 1, f"(code={v.code})")
 
 runs = [run(n, "success") for n in LEGS]
-runs.append(run("All BC versions passed", None, status="queued"))
+runs.append(run("BC test matrix passed", None, status="queued"))
 v = cw.classify(runs)
-check("a queued 'All BC versions passed' keeps the verdict pending",
+check("a queued 'BC test matrix passed' keeps the verdict pending",
       v.code is None, f"(code={v.code})")
 
 # --- #2807: a required context ABSENT from the rollup is not evidence of
@@ -138,7 +138,7 @@ check("a queued 'All BC versions passed' keeps the verdict pending",
 # --- no longer decide it -- the workflow-run list for the commit is what says
 # --- whether anything is still coming.
 runs = [run(n, "success") for n in LEGS]
-runs.append(run("All BC versions passed", "success"))
+runs.append(run("BC test matrix passed", "success"))
 v = cw.classify(runs)
 check("a required context absent from the rollup is pending, not green, "
       "when nothing says whether it is still coming",
@@ -148,11 +148,11 @@ check("a required context absent from the rollup is pending, not green, "
 # --- context rather than leaving it unreported. Measured, because a proposal to
 # --- treat `skipped` as "no verdict yet" would break the documented
 # --- 'docs-only' / 'no-tests-needed' bypass: four merged PRs carry
-# --- 'Tests updated' = skipped on their head SHA with 'All BC versions passed'
+# --- 'Tests updated' = skipped on their head SHA with 'BC test matrix passed'
 # --- = success -- #2759 (451c757b), #2749 (8717aec3), #2717 (dbd3a1a2) and
 # --- #2668 (3d1e9792). GitHub's ruleset accepted every one of them.
 runs = [run(n, "success") for n in LEGS]
-runs.append(run("All BC versions passed", "success"))
+runs.append(run("BC test matrix passed", "success"))
 runs.append(run("Tests updated", "skipped"))
 v = cw.classify(runs)
 check("a skipped required context is not a failure", v.code == 0, f"(code={v.code}) {v.lines}")
@@ -169,7 +169,7 @@ check("...and a skipped required context counts as reported, not as still-pendin
 # --- one and the PR merged. Scanning every entry instead of the newest per
 # --- name reported that merged PR as FAILED.
 runs = [run(n, "success") for n in LEGS]
-runs.append(run("All BC versions passed", "success"))
+runs.append(run("BC test matrix passed", "success"))
 runs.append(run("Tests updated", "failure", cid=101297899468))
 runs.append(run("Tests updated", "skipped", cid=101297995090))
 v = cw.classify(runs)
@@ -179,7 +179,7 @@ check("a failure superseded by a newer skipped run is GREEN, not FAILED",
 # ...and the reverse ordering is still a failure, so this is not just ignoring
 # every failure that shares a name with something.
 runs = [run(n, "success") for n in LEGS]
-runs.append(run("All BC versions passed", "success"))
+runs.append(run("BC test matrix passed", "success"))
 runs.append(run("Tests updated", "skipped", cid=101297899468))
 runs.append(run("Tests updated", "failure", cid=101297995090))
 v = cw.classify(runs)
@@ -187,7 +187,7 @@ check("...but a failure that IS the newest entry still fails", v.code == 1, f"(c
 
 # --- an older cancelled entry must not hold the pool 'incomplete' forever
 runs = [run(n, "success") for n in LEGS]
-runs.append(run("All BC versions passed", "success"))
+runs.append(run("BC test matrix passed", "success"))
 runs.append(run("Tests updated", "cancelled", cid=10))
 runs.append(run("Tests updated", "success", cid=20))
 v = cw.classify(runs)
@@ -203,7 +203,7 @@ check("an empty rollup is pending, not green", v.code is None, f"(code={v.code})
 # ===========================================================================
 # Real shape, PR #2793 head 50551f4c, measured seconds after the push: the only
 # check run on the commit was "Tests updated" (8s), every bc-tests leg was still
-# pending and "All BC versions passed" was not in the rollup at all. classify()
+# pending and "BC test matrix passed" was not in the rollup at all. classify()
 # built a pool of ONE, found it complete and clean, and returned GREEN saying
 # "all 1 required checks passed".
 JUST_PUSHED = [run("Tests updated", "success")]
@@ -218,7 +218,7 @@ ALL_DONE_RUNS = [{"id": 33964656436, "name": "Test Matrix", "status": "completed
                   "conclusion": "success"}]
 
 v = cw.classify(JUST_PUSHED, workflow_runs=QUEUED_RUNS)
-check("a rollup missing 'All BC versions passed' while its run is queued is NOT green",
+check("a rollup missing 'BC test matrix passed' while its run is queued is NOT green",
       v.code is None, f"(code={v.code}) {v.lines}")
 
 v = cw.classify(JUST_PUSHED, workflow_runs=[])
@@ -238,7 +238,7 @@ v = cw.classify(JUST_PUSHED, workflow_runs=ALL_DONE_RUNS)
 check("a required context still absent once every workflow run completed is BLOCKED",
       v.code == 4, f"(code={v.code}) {v.lines}")
 check("...and names the context that never reported",
-      any("All BC versions passed" in l for l in v.lines), v.lines)
+      any("BC test matrix passed" in l for l in v.lines), v.lines)
 check("...and does not claim anything failed",
       not any("failed" in l.lower() for l in v.lines), v.lines)
 
@@ -251,7 +251,7 @@ check("...and does not claim anything failed",
 #
 # Note 'Tests updated' is `skipped` here and that is NOT the defect: a skipped
 # required context satisfies the ruleset (see the merged-PR measurement above).
-# The single missing context is 'All BC versions passed'.
+# The single missing context is 'BC test matrix passed'.
 PR2868 = [run(n, "success") for n in [
     "Agent definitions must allowlist the MCP tools they document",
     "CHANGELOG generator tests",
@@ -274,14 +274,14 @@ v = cw.classify(PR2868, workflow_runs=PR2868_RUNS)
 check("PR #2868's real rollup is NOT green while Test Matrix is still queued",
       v.code is None, f"(code={v.code}) {v.lines}")
 check("...and the progress line names the context that has not reported",
-      "All BC versions passed" in v.progress, v.progress)
+      "BC test matrix passed" in v.progress, v.progress)
 
 # ...and the ordinary green case is unaffected once both contexts are present.
 v = cw.classify(green_set(), workflow_runs=ALL_DONE_RUNS)
 check("a complete rollup with both ruleset contexts is still GREEN",
       v.code == 0, f"(code={v.code}) {v.lines}")
 check("...and says which ruleset contexts it actually confirmed",
-      any("All BC versions passed" in l and "Tests updated" in l for l in v.lines), v.lines)
+      any("BC test matrix passed" in l and "Tests updated" in l for l in v.lines), v.lines)
 
 
 # ===========================================================================
@@ -299,7 +299,7 @@ check("...and says which ruleset contexts it actually confirmed",
 # workflow run id 1 while QUEUED_RUNS has run 33964656436 queued. The control is
 # now run against a finished run list, where the only thing left to vary is the
 # context set. The "still in flight" question gets its own section further down.
-v = cw.classify(green_set(), contexts=("All BC versions passed", "Tests updated",
+v = cw.classify(green_set(), contexts=("BC test matrix passed", "Tests updated",
                                        "Provenance attested"),
                 workflow_runs=ALL_DONE_RUNS)
 check("a context newly added to the ruleset is NOT reported green",
@@ -309,14 +309,14 @@ check("...and, with every workflow run finished, reads as BLOCKED rather than pe
 check("...and names the context nothing reported",
       any("Provenance attested" in l for l in v.lines), v.lines)
 
-v = cw.classify(green_set(), contexts=("All BC versions passed", "Tests updated"),
+v = cw.classify(green_set(), contexts=("BC test matrix passed", "Tests updated"),
                 workflow_runs=ALL_DONE_RUNS)
 check("...while the same rollup and run list with the known context set is green",
       v.code == 0, f"(code={v.code}) {v.lines}")
 
 # ...and the pending path for a newly-required context is still reachable, when
 # the run list says something is genuinely still coming.
-v = cw.classify(green_set(), contexts=("All BC versions passed", "Tests updated",
+v = cw.classify(green_set(), contexts=("BC test matrix passed", "Tests updated",
                                        "Provenance attested"),
                 workflow_runs=QUEUED_RUNS)
 check("a context newly added to the ruleset keeps the verdict pending "
@@ -333,7 +333,7 @@ BRANCH_RULES = [
     {"type": "required_status_checks",
      "parameters": {"strict_required_status_checks_policy": False,
                     "do_not_enforce_on_create": False,
-                    "required_status_checks": [{"context": "All BC versions passed"},
+                    "required_status_checks": [{"context": "BC test matrix passed"},
                                                {"context": "Tests updated"}]},
      "ruleset_source_type": "Repository",
      "ruleset_source": "StefanMaron/BusinessCentral.AL.Runner",
@@ -341,7 +341,7 @@ BRANCH_RULES = [
 ]
 check("the required contexts are read out of the live branch-rules payload",
       cw.contexts_from_branch_rules(BRANCH_RULES)
-      == ("All BC versions passed", "Tests updated"),
+      == ("BC test matrix passed", "Tests updated"),
       str(cw.contexts_from_branch_rules(BRANCH_RULES)))
 
 # The trap from #2785: ruleset 15039643 is disabled and carries no
@@ -383,7 +383,7 @@ def cr(name, conclusion, wf_run, check_id, status="completed"):
 
 def two_run_set(old_conclusion, new_conclusion):
     runs = [cr(n, "success", NEW_RUN, 101303055000 + i) for i, n in enumerate(LEGS)]
-    runs.append(cr("All BC versions passed", "success", NEW_RUN, 101303055107))
+    runs.append(cr("BC test matrix passed", "success", NEW_RUN, 101303055107))
     # the OLDER run's job started later, so it carries the HIGHER check-run id
     runs.append(cr("Tests updated", old_conclusion, OLD_RUN, 101303131614))
     runs.append(cr("Tests updated", new_conclusion, NEW_RUN, 101303055037))
@@ -445,7 +445,7 @@ check("...and a details_url with no run segment reads as unknown, not as 0",
 
 # Within ONE workflow run a re-run attempt still wins on check-run id.
 runs = [cr(n, "success", NEW_RUN, 101303055000 + i) for i, n in enumerate(LEGS)]
-runs.append(cr("All BC versions passed", "success", NEW_RUN, 101303055107))
+runs.append(cr("BC test matrix passed", "success", NEW_RUN, 101303055107))
 runs.append(cr("Tests updated", "failure", NEW_RUN, 101303055037))
 runs.append(cr("Tests updated", "success", NEW_RUN, 101303099999))
 v = cw.classify(runs, workflow_runs=ALL_DONE_RUNS)
@@ -462,7 +462,7 @@ check("inside one workflow run the newer check-run id still wins",
 # it knows -- so the wording has to say that it is not the whole list yet.
 runs = [cr(LEGS[0], "failure", NEW_RUN, 101303055001),
         cr(LEGS[1], None, NEW_RUN, 101303055002, status="in_progress"),
-        cr("All BC versions passed", None, NEW_RUN, 101303055107, status="queued"),
+        cr("BC test matrix passed", None, NEW_RUN, 101303055107, status="queued"),
         cr("Tests updated", "success", NEW_RUN, 101303055037)]
 v = cw.classify(runs, workflow_runs=QUEUED_RUNS)
 check("a failure while others are still running is still a FAILED verdict",
@@ -479,7 +479,7 @@ check("...and warns the failing list can still grow",
 # bc-tests legs had not created a check run at all -- so the honest arithmetic
 # says 1 and the truth was 8.
 runs = [cr(LEGS[0], "failure", NEW_RUN, 101303055001),
-        cr("All BC versions passed", None, NEW_RUN, 101303055107, status="queued"),
+        cr("BC test matrix passed", None, NEW_RUN, 101303055107, status="queued"),
         cr("Tests updated", "success", NEW_RUN, 101303055037)]
 v = cw.classify(runs, workflow_runs=QUEUED_RUNS)
 check("the unreported count is stated as a LOWER bound, not an exact number",
@@ -490,7 +490,7 @@ check("...and the caveat says a leg with no check run yet is not counted at all"
 # When everything HAS reported the caveat must not be printed, or it is noise.
 runs = [cr(LEGS[0], "failure", NEW_RUN, 101303055001),
         cr(LEGS[1], "success", NEW_RUN, 101303055002),
-        cr("All BC versions passed", "failure", NEW_RUN, 101303055107),
+        cr("BC test matrix passed", "failure", NEW_RUN, 101303055107),
         cr("Tests updated", "success", NEW_RUN, 101303055037)]
 v = cw.classify(runs, workflow_runs=ALL_DONE_RUNS)
 check("a complete rollup's failing list carries no 'still to come' caveat",
@@ -518,7 +518,7 @@ TM_RUN, RT_RUN_OLD, RT_RUN_NEW = 33964656436, 33983248257, 33983299999
 
 def present_but_stale_rollup():
     runs = [cr(n, "success", TM_RUN, 101303055000 + i) for i, n in enumerate(LEGS)]
-    runs.append(cr("All BC versions passed", "success", TM_RUN, 101303055107))
+    runs.append(cr("BC test matrix passed", "success", TM_RUN, 101303055107))
     runs.append(cr("Tests updated", "success", RT_RUN_OLD, 101352123189))
     return runs
 
@@ -638,14 +638,14 @@ check("...and is BLOCKED once no newer run of that workflow is coming",
 #   GET /actions/runs?head_sha=95c16b20a500f638fbbe7eeb14f78545c22f92ee
 #
 # Test Matrix run 34002828792 has RUN-LEVEL conclusion `cancelled`, and its
-# aggregate job "All BC versions passed" concluded `failure` -- the aggregate
+# aggregate job "BC test matrix passed" concluded `failure` -- the aggregate
 # runs `if: always()` over `needs` that were killed, so a cancelled run reports
 # a FAILING required context. Seven of its eight legs are `cancelled`; leg 27.3
 # had already finished `success`.
 #
 # Test Matrix run 34004261321 replaced it and was green throughout, but its
 # aggregate job starts LAST, so for several minutes the newest check run named
-# "All BC versions passed" on this commit was the failure from the run that had
+# "BC test matrix passed" on this commit was the failure from the run that had
 # been abandoned. classify() put it in `bad` and returned exit 1 -- and `bad`
 # short-circuits BEFORE the in-flight guard, which is why the guard that exists
 # for exactly this shape never got consulted.
@@ -660,7 +660,7 @@ PR3010_LEGS = ["bc-tests / BC 27.0.38460.53934 (required)",
 
 def pr3010_rollup(with_live_legs: bool = False):
     """The rollup while the live Test Matrix run's aggregate job had not started."""
-    runs = [cr("All BC versions passed", "failure", PR3010_TM_CANCELLED, 101405801410)]
+    runs = [cr("BC test matrix passed", "failure", PR3010_TM_CANCELLED, 101405801410)]
     for i, n in enumerate(PR3010_LEGS):
         runs.append(cr(n, "cancelled", PR3010_TM_CANCELLED, 101404706127 + i))
     runs.append(cr("bc-tests / BC 27.3.44313.53909 (required)", "success",
@@ -708,7 +708,7 @@ v = cw.classify(pr3010_rollup(), workflow_runs=PR3010_WF_NO_REPLACEMENT)
 check("#3010: a cancelled Test Matrix run with no replacement is BLOCKED, not FAILED",
       v.code == 4, f"(code={v.code}) {v.lines}")
 check("...and names the required context it is blocked on",
-      any("All BC versions passed" in l for l in v.lines), v.lines)
+      any("BC test matrix passed" in l for l in v.lines), v.lines)
 check("...and never tells the caller something failed",
       not any("failed" in l.lower() for l in v.lines), v.lines)
 
@@ -724,7 +724,7 @@ v = cw.classify(pr3010_rollup(), workflow_runs=PR3010_WF_GENUINE)
 check("a failing required context from a run that was NOT cancelled is still FAILED",
       v.code == 1, f"(code={v.code}) {v.lines}")
 check("...and still offers the failing job for the log fetch",
-      (v.log_target or {}).get("name") == "All BC versions passed", str(v.log_target))
+      (v.log_target or {}).get("name") == "BC test matrix passed", str(v.log_target))
 
 # ---------------------------------------------------------------------------
 # #2971 / #2842, the GREEN direction. Recorded from
@@ -732,7 +732,7 @@ check("...and still offers the failing job for the log fetch",
 #   GET /actions/runs?head_sha=47f30db4d37415378f227b62e9f6d38433166f17
 #
 # All three workflow runs were created within one second of the push
-# (00:09:25-26Z), so "All BC versions passed" was always COMING. Exhaustively:
+# (00:09:25-26Z), so "BC test matrix passed" was always COMING. Exhaustively:
 # with the real two-context ruleset this rollup cannot produce a 1-count green
 # under post-#2882 code -- either the context is in the rollup (pool >= 2) or it
 # is `missing` and the Test Matrix run is in flight, so `final is not True` and
@@ -768,7 +768,7 @@ check("#3002: a NARROWED required-context set is refused, not answered",
 check("...and it is undetermined (3), not a failure and not a block",
       v.code == 3, f"(code={v.code}) {v.lines}")
 check("...and says which required context went missing from the set",
-      any("All BC versions passed" in l for l in v.lines), v.lines)
+      any("BC test matrix passed" in l for l in v.lines), v.lines)
 check("...and never prints the false-green line",
       not any("all 1 required checks passed" in l for l in v.lines), v.lines)
 
@@ -798,7 +798,7 @@ RECORDED_BRANCH_RULES = [
     {"type": "required_status_checks", "ruleset_id": 15001420, "parameters": {
         "strict_required_status_checks_policy": False,
         "do_not_enforce_on_create": False,
-        "required_status_checks": [{"context": "All BC versions passed"},
+        "required_status_checks": [{"context": "BC test matrix passed"},
                                    {"context": "Tests updated"}]}},
 ]
 DEGRADED_BRANCH_RULES = [
@@ -819,7 +819,7 @@ check("a ruleset read that drops a known required context is DEGRADED",
 check("...and the degraded set is never handed on as the required set",
       sorted(ctx) == sorted(cw.RULESET_CONTEXTS), f"{ctx}")
 check("...and the note names the context that went missing",
-      any("All BC versions passed" in n for n in notes), notes)
+      any("BC test matrix passed" in n for n in notes), notes)
 
 ctx, status, notes = cw.resolve_required_contexts(fetch=lambda b: None)
 check("an UNREADABLE ruleset falls back to the full built-in set, never a subset",
@@ -828,12 +828,12 @@ check("an UNREADABLE ruleset falls back to the full built-in set, never a subset
 
 EXTRA = RECORDED_BRANCH_RULES[:3] + [
     {"type": "required_status_checks", "ruleset_id": 15001420, "parameters": {
-        "required_status_checks": [{"context": "All BC versions passed"},
+        "required_status_checks": [{"context": "BC test matrix passed"},
                                    {"context": "Tests updated"},
                                    {"context": "Some new gate"}]}}]
 ctx, status, notes = cw.resolve_required_contexts(fetch=lambda b: EXTRA)
 check("a context ADDED in the UI is picked up and waited for",
-      sorted(ctx) == ["All BC versions passed", "Some new gate", "Tests updated"]
+      sorted(ctx) == ["BC test matrix passed", "Some new gate", "Tests updated"]
       and status == "live", f"{ctx} {status}")
 
 


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.100.0
Closes #3141

A pull request now runs three BC legs instead of eight, and the required status check is
renamed so it stops asserting something the run did not measure.

**The new required-context name, verbatim, for the ruleset edit:**

```
BC test matrix passed
```

`main`'s ruleset keeps `Tests updated` unchanged.

## What changed

- **`.github/pr-bc-versions.txt`** (new) — `27.0 27.5 28.4`. Read only when the calling
  workflow's event is `pull_request`. `push`, the release path and `main-verdict-floor.yml`
  all still resolve the full `.github/bc-versions.txt`.
- **`.github/workflows/bc-tests.yml`** — the resolve step keeps `ALL_PREFIXES` (the full list)
  separate from `GATING_PREFIXES` (the legs this run executes). `PRIMARY_PREFIX` and
  `UNIT_PREFIXES` are still derived from the full list, and still before either narrowing, so
  a narrowed leg does exactly the work that leg does on a full run.
- **`.github/workflows/test-matrix.yml`** — the aggregate job is renamed. Nothing else: no
  schedule, no concurrency change (see below).
- **`check_required_contexts.py`, `tools/ci-wait.py`** and their test suites — the new name.
- **`AlRunner.Tests/PullRequestMatrixScopeTests.cs`** (new, 15 tests), plus the old name
  updated in `BcLegRerunWorkflowTests`, `ReleaseTestParityTests` and
  `MainVerdictFloorWorkflowTests`.

## Two things `main` moved under this branch, invisible to `git merge-tree`

Both were textually clean and semantically broken. Recording them because the shape recurs.

**`#3151` broke `tools/test_ci_wait.py` on the merge.** It landed after my merge-base and
added five `cr("All BC versions passed", …)` fixtures. Those act as *the required context* in
payloads handed to `cw.classify()`, so once `RULESET_CONTEXTS` carries the new name the
payloads no longer carry one, and `classify()` correctly returns BLOCKED where the checks
assert green. Exit 0 on the branch alone, exit 1 with six failing checks on the merged tree,
and `failure` on live run 34044470236. Renamed; the suite passes.

This one blocked rather than being cosmetic: `ci-wait.py unit tests` is not a required context
today, but #3198 folds it into `tools/ unit tests`, which is about to become one. Merging this
broken and then editing the ruleset would have blocked every open PR on a red required check.

**`#3158` made this branch's `schedule:` redundant.** `main-verdict-floor.yml` runs the full
eight legs against `main`'s HEAD every 30 minutes, skipping when that SHA already has a
conclusive verdict. That is strictly stronger than the daily schedule this branch was adding
to `test-matrix.yml`, and about 75 job-minutes a day cheaper than having both. The schedule
and the `github.event_name` concurrency-group change it needed are dropped.

The floor is now load-bearing for this change — it is the only cadence on which 27.3, 28.0,
28.1, 28.2 and 28.3 run at all — and it does not know that, because it predates #3141. So
`DroppedLegs_StillRunAtFullWidth_OnAPeriodicMainWorkflow` pins its shape from this side: it
must stay scheduled, must not trigger on `pull_request` (which would narrow it), and must set
no version filter. `TestMatrix_AddsNoSecondScheduleOfItsOwn` pins the other half.

## The measurement, and the one part of the issue I did not do

The issue proposed running `AlRunner.Tests` once, on 28.4, "a duplicate that has never
disagreed with itself". I checked before acting on it, and it is false.

Every failed `Test Matrix` run between 2026-08-02 and 2026-09-06 — 288 of them — read for the
per-job step conclusion of `Run unit tests (AlRunner.Tests)`. 128 had at least one failing
unit-test step:

| shape | count |
|---|---|
| all 27.x legs failed, every 28.x leg passed | **1** |
| all 28.x legs failed, every 27.x leg passed | 0 |
| everything else (scattered single legs, or all legs) | 127 |

Run [33337113550](https://github.com/StefanMaron/BusinessCentral.AL.Runner/actions/runs/33337113550)
on 2026-08-30 failed `ProvisionExplicitModesTests.TestApps_BundleDeclaresOlderMajor_StillTargetsEngineMajor`
on 27.0, 27.3 **and** 27.5 with the same assertion each time, while all four 28.x legs passed.
The fix comment still in that test names the cause: a hardcoded `"27"` that collides with the
engine's own major only on a 27.x leg. So the 27 copy of the C# suite has caught a defect no
28.x leg could catch, inside the window. It stays, and
`PullRequestList_KeepsEveryLegThatRunsTheCSharpSuite` fails the build if someone drops it.

**What the narrowing saves.** Median job minutes over the 20 most recent green pull-request
matrix runs:

| leg | median |
|---|---|
| 27.0 | 4.8 min |
| 27.3 | 5.0 min |
| **27.5** | **19.1 min** |
| 28.0 | 6.1 min |
| 28.1 | 5.6 min |
| 28.2 | 5.7 min |
| 28.3 | 5.8 min |
| **28.4** | **20.0 min** |

8 legs = 72.2 min; 3 legs = 43.9 min. With `smoke`, `pack` and `resolve-versions` unchanged
that is 78.9 → 50.6 job-minutes, a **36% cut** — not the ~53% the issue projected, because
that figure assumed the C# dedup I am not doing.

The number that matters more is **concurrent slots**: the `test` job goes from 8 parallel jobs
to 3 per pull request, so at the 11 open PRs the issue measured, 88 legs of demand become 33.
Wall-clock to a verdict on one PR is **unchanged** at about 20 minutes, because the dropped
legs are the cheap ones and 28.4 sets the critical path. This buys queue capacity, not latency.

## Merge and ruleset ordering

**This PR cannot merge before the ruleset is edited.** Not "should not" — it will sit
permanently `BLOCKED`, because after the rename its Test Matrix reports `BC test matrix
passed` and never reports `All BC versions passed`, which is what the ruleset waits for.

1. **#3198 has merged** (`38cdaa81`). This branch is rebased onto it. The two prose conflicts
   were resolved to describe the state *after* this PR lands — ten required contexts:
   `BC test matrix passed`, `Tests updated`, and #3198's eight `pr-gate.yml` names.
   `PENDING_REQUIRED_CONTEXTS` is left exactly as #3198 shipped it: the eight stay out of
   `DEFAULT_REQUIRED_CONTEXTS` and `RULESET_CONTEXTS` until the ruleset carries them, which is
   what keeps `ci-wait.py` off exit 3 UNDETERMINED in the meantime.
2. **One ruleset edit**, all ten contexts at once. The nine that are not `Tests updated`,
   confirmed character for character against the shipped workflow files on this head — the
   eight are declared job names in `pr-gate.yml`, none of which calls a reusable workflow, so
   none is context-qualified:

   ```
   BC test matrix passed
   PR title/body must not contain a CI-skip directive
   PR body closing references must be correct, both directions
   pull_request trigger lists must keep their load-bearing event types
   Required contexts must not be cancellable on the same commit
   Agent definitions must allowlist the MCP tools they document
   tools/ unit tests
   .github/scripts/ unit tests
   scripts/ unit tests
   ```

   Safe once this PR's `BC test matrix passed` has reported success on its head — otherwise
   the edit adds a required context nothing has satisfied yet.
3. **This PR needs one re-trigger after step 2, before it can merge.** `Required contexts must
   not be cancellable on the same commit` — a `pr-gate.yml` job, and therefore about to be
   required — runs `check_required_contexts.py`, which is `failure` on this head for exactly
   three reasons, all of them the drift the edit removes:

   ```
   ::error::the branch ruleset requires context(s) this repo's lists do not carry: 'All BC versions passed'
   ::error::this repo's lists carry context(s) the branch ruleset no longer requires: 'BC test matrix passed'
   ::error::required context 'All BC versions passed' is produced by NO workflow reacting to pull_request
   ```

   The edit is what makes those pass. Missing this step stops the one PR that ends the window.
4. **Merge this PR.**
5. **Every other open PR is blocked between steps 2 and 4**, and needs one re-trigger after.
   They produce the old name and not the new one. GitHub evaluates a `pull_request` workflow
   from the merge ref, so once this lands their next run picks up the renamed job without a
   rebase — but completed runs do not change retroactively.

   **A re-trigger has to be a genuinely new event.** A label toggle does **not** work:
   `test-matrix.yml` uses the default `pull_request` types (`opened, synchronize, reopened`),
   so `labeled` fires nothing. `gh run rerun` also does not work — it replays against the
   recorded commit and workflow — and is banned by `ci-verdicts.md` §3 regardless. The two
   instruments that work are **close + reopen** (free, and the right one at ~20 PRs) or an
   empty commit (costs a full three-leg run).

**Cannot be made atomic.** A ruleset and a workflow file cannot move in one commit. The
alternatives are worse: editing the ruleset first blocks every PR *including* this one, and a
transitional job emitting both names needs a second PR and keeps the drift guard red longer.

## RED to GREEN

RED, before any implementation existed: 14 of the 15 new tests failed. Two of the 15 initially
passed while pinning nothing, and both were caught and rewritten rather than shipped:

- `SharedMatrix_FailsWhenTheResolvedMatrixIsEmpty` matched the pre-existing `ENTRIES="[]"`
  initialiser, then — after the first rewrite — still passed with the entire
  `if [ "$ENTRIES" = "[]" ]` guard deleted, because the pull-request-list error also contains
  "would resolve to an empty matrix". The predicate now names the guard's own message and
  `$GATING_PREFIXES`; verified by deleting the block and watching the test fail.
- `SharedMatrix_NarrowsOnlyForAPullRequest` over-constrained on a single occurrence; it now
  asserts every mention of the pull-request list sits inside the `GATING_EVENT` guard.

GREEN, after:

- `PullRequestMatrixScopeTests`, `BcLegRerunWorkflowTests`, `ReleaseTestParityTests`,
  `MsBucketWorkflowTests`, `CorpusAppEnumerationWorkflowTests`, `MainVerdictFloorWorkflowTests`,
  `PublishReleaseOrderingTests`, `CountBaselineMergeShapeTests` — **77 passed, 0 failed**
- `python3 tools/test_ci_wait.py` — all checks passed (this is the one that was red on the
  merged tree)
- `python3 .github/scripts/test_check_required_contexts.py` — all checks passed
- `SKIP_RULESET_DRIFT_CHECK=1 python3 .github/scripts/check_required_contexts.py` — exit 0
- The resolve step's shell, extracted and run against a stubbed version resolver on every
  path: `push` → 8 legs; `pull_request` → 27.0/27.5/28.4 with `unit-tests=true` on 27.5 and
  28.4; `workflow_dispatch` of 28.2 → that one leg with `unit-tests=false`, identical to what
  28.2 carries on a full run. All five rejection paths (missing file, empty list, unknown
  prefix, missing unit prefix, missing primary prefix) exit 1 with their own `::error::`.

I did not run the full `dotnet test AlRunner.Tests` sweep. Nothing here touches `AlRunner/`.

## Fixing the shape, not the reported line

- **Same wrong pattern elsewhere?** Yes, and it is why `versions-json` is not narrowed. `pack`
  builds one engine variant per entry in that output and asserts the packed count equals the
  entry count in `bc-versions.txt`. Narrowing it would have turned every pull request's `pack`
  job red, and relaxing the assertion instead would ship a nupkg missing five engine variants
  (#2024, #2166). The resolve loop iterates the full list; only leg selection narrows.
  `required-version` is emitted the same way, so `smoke` cannot be handed an empty version.
- **Sibling making the same assumption?** The single-leg dispatch validated its prefix against
  the working list, which with a second narrowing would have meant validating against whatever
  narrowed first. Both narrowings now validate against `ALL_PREFIXES`.
- **Two paths writing the same state, same invariant?** They did not. The single-leg filter
  failed loud on an unknown prefix; the pull-request path would have had no equivalent, and
  its failure mode is worse because a bad list can produce an *empty* matrix, which reports
  success having run nothing (#1976, #2065). Both now validate, and one explicit check refuses
  to emit an empty matrix at all — reachable before this PR too, if every version failed to
  resolve, and not caught then.
- **Documentation that became false:** `ci-verdicts.md` (the two-required-contexts paragraph,
  the leg-set flake standard, and the second use of `bc-leg-rerun.yml`) and
  `orchestrating-a-session/SKILL.md`'s merge bar, which said "all 8 required legs green" — a
  bar a PR can no longer meet, so a coordinator following it literally would refuse a
  legitimate PR.
- **Left out deliberately:** the C# dedup, measured and rejected above. `push` to `main` still
  runs all eight rather than being narrowed too; #3003 is the separate question of those runs
  being cancelled.

## Scope

CI plumbing. Asserts nothing about Business Central behaviour, so it owes nothing to the
upstream corpus. No AL objects, no `CHANGELOG.md`, no `tests/al-language` pin change.

---

*Opened by an automated agent (impl-21) on the account holder's behalf. The measurements above
are mine; the ruleset edit in step 2 is the maintainer's and is not something this PR can do.*

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf

