### PR TITLE
fix(expectations): --expectations-require-match must audit the run, not the final attempt's own discovery set

### DIFF
--- a/AlRunner.Tests/ExpectationManifestWiringTests.cs
+++ b/AlRunner.Tests/ExpectationManifestWiringTests.cs
@@ -437,6 +437,146 @@ public sealed class ExpectationManifestWiringTests : IDisposable
         Assert.True(exit == 1, $"expected the pre-#3123 behaviour, exit 1. exit={exit}\n{output}");
     }
 
+    // ── A resumed run's final attempt (#3168) ────────────────────────────────────
+    //
+    // The stand-down message for a non-final attempt promises "the final attempt audits
+    // the whole run". It did not: the discovery set is filled by TestExecutor in THIS
+    // process, and nothing folded in the attempts carried on the command line. An entry
+    // whose test ran in an earlier attempt was reported as matching nothing, and the leg
+    // exited 5 telling the reader to check CodeunitName for a typo.
+    //
+    // Measured on the fixture below before the fix (BC 28.1, Release):
+    //   entry "Ghost Resume Tests"."RanInAnEarlierAttempt", carried, --merge-results
+    //     → exit 5, "no codeunit named ... was loaded in this run"
+    // and after:
+    //     → exit 0, "all 1 entries matched a discovered test"
+    //
+    // The codeunit is deliberately one the run's OWN bundle does not contain, so the
+    // test cannot pass on the final attempt's own discovery — which is what a version of
+    // this test driven by --exclude-test alone would have done (TestExclusionFilter is
+    // consulted per METHOD, after discovery is recorded, so an excluded codeunit is still
+    // loaded and still discovered).
+
+    /// <summary>
+    /// Writes a one-attempt --merge-results carry file naming one test that ran, and
+    /// returns its path. Shape mirrors Infrastructure.ResumeCarry's payload exactly.
+    /// </summary>
+    private string CarryFile(string name, string typeName, string displayName, string method)
+    {
+        var dir = Path.Combine(_scratchRoot, name);
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "attempt-results.json");
+        File.WriteAllText(path, $$"""
+        [{"BucketPath":"/nonexistent/earlier-attempt/suite","Stage":"Ran","CompileErrors":[],
+          "ProcessError":null,
+          "Tests":[{"Codeunit":"{{typeName}}","Method":"{{method}}","Outcome":"Pass",
+            "Message":null,"FullException":null,"DurationTicks":10000,"AlCallStack":null,
+            "CodeunitDisplayName":"{{displayName}}","Expectation":null,"InsideTestProc":false,
+            "TimedOut":false,"Diagnosis":null}],
+          "EmitTicks":0,"CompileTicks":0,"RunTicks":10000,"RanGroupCount":1,"ProvisionGaps":null}]
+        """);
+        return path;
+    }
+
+    /// <summary>Writes a one-entry manifest for an arbitrary codeunit/method pair.</summary>
+    private string OneEntryManifest(string name, int codeunitId, string codeunitName, string method)
+    {
+        var dir = Path.Combine(_scratchRoot, name);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "known-gaps-fixture.json"), $$"""
+        [
+          {
+            "codeunitId": {{codeunitId}},
+            "CodeunitName": "{{codeunitName}}",
+            "Method": "{{method}}",
+            "Mode": "expect-fail-known-gap",
+            "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3168"
+          }
+        ]
+        """);
+        return dir;
+    }
+
+    /// <summary>
+    /// The final attempt of a resumed run must audit the RUN, not its own slice: an entry
+    /// whose test ran in an earlier attempt matched nothing and failed the leg with exit 5.
+    /// </summary>
+    [SkippableFact]
+    public void RequireMatch_AnEntryMatchedOnlyByACarriedAttempt_StaysGreen()
+    {
+        TestArtifacts.SkipIfMissing();
+        var manifest = OneEntryManifest(
+            "match-resumed", 60899, "Ghost Resume Tests", "RanInAnEarlierAttempt");
+        var carry = CarryFile(
+            "carry-resumed", "Codeunit60899", "Ghost Resume Tests", "RanInAnEarlierAttempt");
+
+        var (output, exit) = RunRunner(
+            $"--expectations \"{manifest}\" --expectations-require-match "
+            + $"--merge-results \"{carry}\" --test GreenPath_PlainPass \"{SuitePath}\"");
+
+        // The run's own bundle passed one test and failed none, so a non-zero exit here
+        // could only come from the audit.
+        AssertCount(output, "  pass:", 1);
+        AssertCount(output, "  fail:", 0);
+        Assert.DoesNotContain("UNMATCHED", output, StringComparison.Ordinal);
+        Assert.Contains("all 1 entries matched a discovered test", output, StringComparison.Ordinal);
+        Assert.True(exit == 0,
+            $"an entry whose test ran in an earlier resume attempt must not fail the run. "
+            + $"exit={exit}\n{output}");
+    }
+
+    /// <summary>
+    /// The control that keeps the test above from being a rubber stamp: a carried attempt
+    /// satisfies only the methods it actually ran. A method no attempt ever ran must still
+    /// reach exit 5 — and the diagnostic must not claim the codeunit "declares" no such
+    /// method, which a carry file cannot know.
+    /// </summary>
+    [SkippableFact]
+    public void RequireMatch_AMethodNoAttemptEverRan_StillFails_EvenWithACarriedAttempt()
+    {
+        TestArtifacts.SkipIfMissing();
+        var manifest = OneEntryManifest(
+            "match-resumed-typo", 60899, "Ghost Resume Tests", "NeverRanAnywhere");
+        var carry = CarryFile(
+            "carry-resumed-typo", "Codeunit60899", "Ghost Resume Tests", "RanInAnEarlierAttempt");
+
+        var (output, exit) = RunRunner(
+            $"--expectations \"{manifest}\" --expectations-require-match "
+            + $"--merge-results \"{carry}\" --test GreenPath_PlainPass \"{SuitePath}\"");
+
+        Assert.Contains("UNMATCHED", output, StringComparison.Ordinal);
+        Assert.Contains("reached only by an earlier resume attempt", output, StringComparison.Ordinal);
+        Assert.Contains("The methods it ran: RanInAnEarlierAttempt", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("declares no test method", output, StringComparison.Ordinal);
+        Assert.True(exit == 5, $"expected exit 5, got {exit}\n{output}");
+    }
+
+    /// <summary>
+    /// A carried attempt file that was named and cannot be read leaves the discovery set
+    /// knowably short by a whole attempt (#2747), so the audit must stand down rather than
+    /// accuse a correct entry. The run still refuses to report as complete — exit 2 — so
+    /// nothing is suppressed by standing down.
+    /// </summary>
+    [SkippableFact]
+    public void RequireMatch_WithALostCarriedAttempt_StandsDown_RatherThanAccusingTheEntry()
+    {
+        TestArtifacts.SkipIfMissing();
+        var manifest = OneEntryManifest(
+            "match-lost-carry", 60899, "Ghost Resume Tests", "RanInAnEarlierAttempt");
+        var missing = Path.Combine(_scratchRoot, "carry-lost", "attempt-results.json");
+
+        var (output, exit) = RunRunner(
+            $"--expectations \"{manifest}\" --expectations-require-match "
+            + $"--merge-results \"{missing}\" --test GreenPath_PlainPass \"{SuitePath}\"");
+
+        Assert.DoesNotContain("UNMATCHED", output, StringComparison.Ordinal);
+        Assert.Contains("match audit skipped: a carried attempt file could not be read",
+            output, StringComparison.Ordinal);
+        Assert.True(exit == 2,
+            $"a lost carried attempt must still refuse to report the run as complete. "
+            + $"exit={exit}\n{output}");
+    }
+
     /// <summary>
     /// The flag must not be satisfiable by having nothing to check. Pointed at a
     /// directory with no entries it fails rather than reporting a vacuous match.

--- a/AlRunner.Tests/ExpectationMatchAuditTests.cs
+++ b/AlRunner.Tests/ExpectationMatchAuditTests.cs
@@ -166,6 +166,119 @@ public sealed class ExpectationMatchAuditTests
         Assert.Empty(manifest.FindUnmatchedEntries());
     }
 
+    // ── Carried resume attempts (#3168) ──────────────────────────────────────────
+    //
+    // NoteDiscoveredTestCodeunit is called by the executor IN THIS PROCESS. A resumed
+    // run (#2280) is several processes, and the final one is handed the earlier
+    // attempts' results (--merge-results). An entry naming a test that ran in an earlier
+    // attempt was reported as matching nothing — "check CodeunitName for a typo" about a
+    // correct entry, which is the one distinction the audit exists to draw.
+
+    private static TestResult CarriedTest(
+        string typeName, string method, string? displayName) =>
+        new(typeName, method, TestOutcome.Pass, null, null, TimeSpan.FromMilliseconds(1),
+            CodeunitDisplayName: displayName);
+
+    [Fact]
+    public void AnEntryMatchedOnlyByACarriedAttempt_IsNotReportedAsUnmatched()
+    {
+        var manifest = LoadOneEntryManifest("Expct Fixture Tests", "GreenPath_KnownGapDeclared");
+        // This process discovered a DIFFERENT codeunit — the entry's own is reachable
+        // only through the carry, so nothing here can pass vacuously.
+        manifest.NoteDiscoveredTestCodeunit(
+            new DiscoveredTestCodeunit(60455, "Other Suite", "Codeunit60455", new[] { "Whatever" }));
+        Assert.Single(manifest.FindUnmatchedEntries());   // RED state, asserted in place
+
+        manifest.NoteDiscoveredFromCarriedResults(new[]
+        {
+            CarriedTest("Codeunit60810", "GreenPath_KnownGapDeclared", "Expct Fixture Tests"),
+        });
+
+        Assert.Empty(manifest.FindUnmatchedEntries());
+    }
+
+    [Fact]
+    public void ACarriedAttempt_AlsoMatchesAnEntryWrittenAgainstTheClrTypeName()
+    {
+        // The carry records both names, so both spellings an entry may use must work —
+        // matching TestExecutor.LookupExpectation, exactly as in-process discovery does.
+        var manifest = LoadOneEntryManifest("Codeunit60810", "GreenPath_KnownGapDeclared");
+        manifest.NoteDiscoveredFromCarriedResults(new[]
+        {
+            CarriedTest("Codeunit60810", "GreenPath_KnownGapDeclared", "Expct Fixture Tests"),
+        });
+
+        Assert.Empty(manifest.FindUnmatchedEntries());
+    }
+
+    [Fact]
+    public void ACarriedAttempt_DoesNotMatchAMethodItNeverRan_AndSaysSoHonestly()
+    {
+        // The audit must not become a rubber stamp: a carried codeunit satisfies only the
+        // methods that actually ran. And the diagnostic must not claim the codeunit
+        // "declares no test method X" — a carry file records what RAN, which is the full
+        // declared set only when nothing filtered it.
+        var manifest = LoadOneEntryManifest("Expct Fixture Tests", "GreenPath_PlainPass");
+        manifest.NoteDiscoveredFromCarriedResults(new[]
+        {
+            CarriedTest("Codeunit60810", "GreenPath_KnownGapDeclared", "Expct Fixture Tests"),
+        });
+
+        var unmatched = Assert.Single(manifest.FindUnmatchedEntries());
+        Assert.Contains("reached only by an earlier resume attempt", unmatched.Diagnostic,
+            StringComparison.Ordinal);
+        Assert.Contains("ran no test method 'GreenPath_PlainPass'", unmatched.Diagnostic,
+            StringComparison.Ordinal);
+        Assert.Contains("The methods it ran: GreenPath_KnownGapDeclared", unmatched.Diagnostic,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("declares no test method", unmatched.Diagnostic,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InProcessDiscovery_KeepsTheDeclaresWording_EvenAlongsideACarriedAttempt()
+    {
+        // The counterpart to the test above: when the codeunit was really loaded here,
+        // its method list IS the declared set, so the sharper wording must survive.
+        var manifest = LoadOneEntryManifest("Expct Fixture Tests", "GreenPath_PlainPas");
+        manifest.NoteDiscoveredTestCodeunit(TheFixtureCodeunit());
+        manifest.NoteDiscoveredFromCarriedResults(new[]
+        {
+            CarriedTest("Codeunit60810", "GreenPath_KnownGapDeclared", "Expct Fixture Tests"),
+        });
+
+        var unmatched = Assert.Single(manifest.FindUnmatchedEntries());
+        Assert.Contains("declares no test method 'GreenPath_PlainPas'", unmatched.Diagnostic,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ACarriedCtorPlaceholder_IsNotTreatedAsAMethodName()
+    {
+        // TestExecutor records "<ctor>" for a codeunit that would not construct. No AL
+        // author can write that name, so an entry must never match it.
+        var manifest = LoadOneEntryManifest("Expct Fixture Tests", "<ctor>");
+        manifest.NoteDiscoveredFromCarriedResults(new[]
+        {
+            CarriedTest("Codeunit60810", "<ctor>", "Expct Fixture Tests"),
+        });
+
+        Assert.Single(manifest.FindUnmatchedEntries());
+    }
+
+    [Fact]
+    public void ACarriedResultWithNoDisplayName_StillMatchesOnTheTypeName()
+    {
+        // CodeunitDisplayName is nullable in the carry format; the type name is not.
+        var manifest = LoadOneEntryManifest("Codeunit60810", "GreenPath_KnownGapDeclared");
+        manifest.NoteDiscoveredFromCarriedResults(new[]
+        {
+            CarriedTest("Codeunit60810", "GreenPath_KnownGapDeclared", null),
+        });
+
+        Assert.Empty(manifest.FindUnmatchedEntries());
+    }
+
     [Theory]
     [InlineData("Codeunit60810", 60810)]
     [InlineData("Codeunit6020", 6020)]

--- a/AlRunner/Infrastructure/ExpectationManifest.cs
+++ b/AlRunner/Infrastructure/ExpectationManifest.cs
@@ -66,12 +66,18 @@ public sealed record ExpectationEntry(
 /// <paramref name="TestMethods"/> is the UNFILTERED set of [Test] methods the type
 /// declares, so a <c>--test</c> filter narrowing what RUNS cannot make an entry look
 /// orphaned.
+/// <paramref name="MethodsAreComplete"/> is false for a codeunit reconstructed from an
+/// EARLIER attempt's carried results (#3168): a carry file records the tests that RAN,
+/// which is the codeunit's full declared set only when nothing filtered it. The audit
+/// still matches on it — a method that ran certainly exists — but must not tell the
+/// reader that a method it cannot see is undeclared.
 /// </summary>
 public sealed record DiscoveredTestCodeunit(
     int? ObjectId,
     string Name,
     string TypeName,
-    IReadOnlyCollection<string> TestMethods);
+    IReadOnlyCollection<string> TestMethods,
+    bool MethodsAreComplete = true);
 
 /// <summary>
 /// An entry the run loaded but could not attach to any discovered test, with a
@@ -110,6 +116,52 @@ public sealed class ExpectationManifest
     public void NoteDiscoveredTestCodeunit(DiscoveredTestCodeunit codeunit)
     {
         lock (_discoveredLock) _discovered.Add(codeunit);
+    }
+
+    /// <summary>
+    /// Fold an EARLIER watchdog-resume attempt's results into the discovery set (#3168).
+    ///
+    /// <see cref="NoteDiscoveredTestCodeunit"/> is called by the executor IN THIS PROCESS,
+    /// so on its own the audit can only speak for this attempt. A resumed run (#2280) is
+    /// several processes: the final one re-runs the bundle with every already-attempted
+    /// codeunit excluded and carries the earlier attempts' results in (--merge-results,
+    /// Infrastructure.ResumeCarry). Without this, an entry naming a test that ran in an
+    /// earlier attempt is reported as matching nothing — "check CodeunitName for a typo"
+    /// about an entry that is entirely correct, which is the one distinction this audit
+    /// exists to draw. Exactly the shape --count-baseline already handles by summing
+    /// `allResults` rather than this attempt's slice (#2719).
+    ///
+    /// Today the final attempt happens to load the excluded codeunits anyway —
+    /// TestExclusionFilter is consulted per METHOD, inside the loop, after discovery is
+    /// recorded — so the audit's whole-run claim currently holds by accident. This makes
+    /// it hold by construction, and covers the case the accident does not: a bucket the
+    /// final attempt never reaches (its own watchdog abort returns from the type loop,
+    /// so every later codeunit in that bucket goes unloaded).
+    ///
+    /// A carried codeunit's method list is what RAN, not what it declares, so it is
+    /// marked <see cref="DiscoveredTestCodeunit.MethodsAreComplete"/> = false.
+    /// </summary>
+    public void NoteDiscoveredFromCarriedResults(IEnumerable<TestResult> carried)
+    {
+        foreach (var group in carried
+            .Where(r => !string.IsNullOrEmpty(r.Codeunit))
+            .GroupBy(r => (Type: r.Codeunit, Display: r.CodeunitDisplayName ?? r.Codeunit)))
+        {
+            // "<ctor>" is the executor's placeholder for a codeunit that would not
+            // construct (TestExecutor), not an AL method — matching an entry against it
+            // would be matching against a name no AL author can have written.
+            var methods = group
+                .Select(r => r.Method)
+                .Where(m => !string.IsNullOrEmpty(m) && !m.StartsWith("<", StringComparison.Ordinal))
+                .Distinct(StringComparer.Ordinal)
+                .ToArray();
+            NoteDiscoveredTestCodeunit(new DiscoveredTestCodeunit(
+                TestExecutor.ParseAlObjectId(group.Key.Type),
+                group.Key.Display,
+                group.Key.Type,
+                methods,
+                MethodsAreComplete: false));
+        }
     }
 
     /// <summary>
@@ -162,6 +214,15 @@ public sealed class ExpectationManifest
             var shown = methods.Count <= 12
                 ? string.Join(", ", methods)
                 : string.Join(", ", methods.Take(12)) + $", … ({methods.Count} total)";
+            // #3168: every sighting of this codeunit came from a carried attempt, whose
+            // method list is what RAN. Saying "declares no test method" off that would be
+            // a claim the run cannot support — a filtered-out method is missing from the
+            // list for a reason that has nothing to do with the entry.
+            if (named.All(d => !d.MethodsAreComplete))
+                return $"codeunit \"{entry.CodeunitName}\" was reached only by an earlier resume "
+                     + $"attempt, which ran no test method '{entry.Method}'. The methods it ran: "
+                     + $"{shown}. A method filtered out of that attempt would look the same, so "
+                     + "check the filter before the entry";
             return $"codeunit \"{entry.CodeunitName}\" was loaded but declares no test method "
                  + $"'{entry.Method}'. Its test methods: {shown}";
         }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -4039,13 +4039,35 @@ if (expectationsRequireMatch)
     else if (willResume)
     {
         // Same reasoning as --count-baseline above: this attempt ran a slice and hands
-        // the rest to a fresh process, so its discovery set is not the run's.
+        // the rest to a fresh process, so its discovery set is not the run's. The final
+        // attempt makes that promise true by folding the carried attempts in — see the
+        // NoteDiscoveredFromCarriedResults call below (#3168).
         Console.Error.WriteLine(
             "[expectations] match audit skipped: this attempt is resuming in a fresh process; "
             + "the final attempt audits the whole run.");
     }
+    else if (carryIncomplete)
+    {
+        // #3168 + #2747: an earlier attempt's carry file was named and could not be read,
+        // so the discovery set is knowably short by a whole attempt. Reporting an entry as
+        // matching nothing from here would accuse a correct entry of a typo on the strength
+        // of a lost scratch file. The run already refuses to report as complete (exit 2
+        // below), so standing down here suppresses nothing.
+        Console.Error.WriteLine(
+            "[expectations] match audit skipped: a carried attempt file could not be read, so "
+            + "this run's discovery set is incomplete and an unmatched entry would be "
+            + "unattributable. See the resume message above.");
+    }
     else
     {
+        // #3168: the audit's claim is about the RUN, not this process. A resumed run's final
+        // attempt is handed every earlier attempt's results (--merge-results); a test that ran
+        // there is a test this run discovered. Same correction --count-baseline took in #2719
+        // — carriedResults only, because this process's own discoveries are already recorded
+        // by TestExecutor, unfiltered, which is the better record of the two.
+        if (carriedResults.Count > 0)
+            expectations.NoteDiscoveredFromCarriedResults(carriedResults.SelectMany(b => b.Tests));
+
         var unmatched = expectations.FindUnmatchedEntries();
         if (unmatched.Count > 0)
         {

--- a/AlRunner/ProgramSupport/CliText.cs
+++ b/AlRunner/ProgramSupport/CliText.cs
@@ -647,8 +647,8 @@ internal static partial class ProgramSupport
         w.WriteLine("                          passes, or an out-of-scope throw with no entry, fails");
         w.WriteLine("                          the run with a diagnostic naming the entry to fix.");
         w.WriteLine("  --expectations-require-match");
-        w.WriteLine("                          Assert that this invocation discovers a test for EVERY entry");
-        w.WriteLine("                          in the active manifest, and fail (exit 5) on any that");
+        w.WriteLine("                          Assert that this RUN discovers a test for EVERY entry in");
+        w.WriteLine("                          the active manifest, and fail (exit 5) on any that");
         w.WriteLine("                          matched nothing, naming the file, the codeunit and the");
         w.WriteLine("                          method. Without it such an entry is silently inert: one");
         w.WriteLine("                          wrong letter in CodeunitName or Method untracks a declared");
@@ -657,7 +657,10 @@ internal static partial class ProgramSupport
         w.WriteLine("                          the manifest is shared across invocations, so an entry");
         w.WriteLine("                          naming a corpus codeunit legitimately matches nothing in a");
         w.WriteLine("                          run over a different bundle. Only pass it where covering");
-        w.WriteLine("                          every entry is actually true.");
+        w.WriteLine("                          every entry is actually true. After a watchdog resume the");
+        w.WriteLine("                          final attempt folds the earlier attempts carried in with");
+        w.WriteLine("                          --merge-results into what it audits, so the claim is about");
+        w.WriteLine("                          the run and not one process (#3168).");
         w.WriteLine("  --count-baseline PATH   Load a per-suite test/app-group expected-count manifest");
         w.WriteLine("                          (schema: AlRunner/Infrastructure/CountBaseline.cs) and");
         w.WriteLine("                          fail the run (exit 4) if a suite's count does not exactly");

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -43,13 +43,33 @@ Measured on `AlRunner.Tests/Fixtures/ExpectationsBundle` (codeunit 60810
 All three printed `[expectations] loaded 1 entry from <dir>` first. `loaded` is true
 and says nothing about `matched`.
 
-`--expectations-require-match` asserts that **this invocation discovers a test for
-every entry in the active manifest**, and fails with exit code 5 on any that matched
+`--expectations-require-match` asserts that **this run discovers a test for every
+entry in the active manifest**, and fails with exit code 5 on any that matched
 nothing, naming the file, the codeunit, the method, and what was found instead — the
 object id loaded under a different name, or the test methods that do exist. A green
 audit says how much it accounted for (`match audit: all 17 entries matched a
 discovered test`), so it is never mute about its scope, and it refuses to run against
 an inactive or empty manifest rather than passing vacuously.
+
+**The run, not the process** (#3168). A watchdog resume (#2280) is several processes,
+and `--resume-aborts` defaults to 5 with nothing in the corpus step turning it off, so
+this is normal operation rather than a corner. Only the final attempt audits; it folds
+every earlier attempt's carried results (`--merge-results`) into its discovery set
+first, the same correction `--count-baseline` took in #2719. Without that fold an entry
+whose test ran in an earlier attempt reads as matching nothing, and the leg fails
+telling the reader to check `CodeunitName` for a typo about an entry that is correct —
+the one distinction this audit exists to draw.
+
+Two consequences, both deliberate:
+
+- A carried attempt records the methods that **ran**, not the methods a codeunit
+  declares. So a carried codeunit satisfies only the methods actually seen, and an
+  unmatched entry against one is reported as "reached only by an earlier resume
+  attempt, which ran no test method X" rather than the sharper "declares no test
+  method X" reserved for a codeunit loaded in this process.
+- If a carried attempt file was named and cannot be read (#2747), the discovery set is
+  knowably short by a whole attempt, so the audit stands down and says so. The run
+  already refuses to report as complete (exit 2), so nothing is suppressed.
 
 It is **opt-in**, for the same reason `--count-baseline` is. The expectations
 directory is auto-probed and shared by every invocation in this repo: the corpus leg


### PR DESCRIPTION
Closes #3168

`--expectations-require-match`'s stand-down message for a non-final attempt promises
*"the final attempt audits the whole run."* Nothing made that true:
`ExpectationManifest._discovered` is filled only by `TestExecutor` **in this process**,
and the earlier attempts a resumed run is handed on the command line (`--merge-results`,
`Infrastructure.ResumeCarry`) were never folded in. This is the same correction
`--count-baseline` took in #2719, where the code already says
`foreach (var b in allResults)   // #2719: the run, not this attempt's slice`.

## Was `allResults` available at the call site?

**Yes — the audit did not have to move.** `carriedResults` and `allResults` are built at
`AlRunner/Program.cs:3897`/`3910`; the match audit runs at `:4019`, well after both. The
audit folds **`carriedResults` only**, not `allResults`: this process's own discoveries
are already recorded by `TestExecutor` at load time and are **unfiltered**, which is the
better record of the two — a carry file records what *ran*.

## Correction to the issue's stated mechanism (measured, not assumed)

The issue says a resumed attempt "runs only the codeunits no earlier attempt reached, so
its discovery set covers only the tail of the corpus." **That is not what happens**, and
the difference is worth writing down.

`TestExclusionFilter` is consulted **per method, inside the loop, after**
`NoteDiscoveredTestCodeunit` has already run (`AlRunner/TestExecutor.cs:753` vs `:769`).
An excluded codeunit is therefore still instantiated and still discovered. Measured on
`AlRunner.Tests/Fixtures/ExpectationsBundle` (BC 28.1, Release, `main` binary), entry
`"Expct Fixture Tests"."GreenPath_KnownGapDeclared"`:

| invocation | tests run | audit | exit |
|---|---|---|---|
| `--expectations-require-match --test GreenPath_KnownGapDeclared` | 1 | `all 1 entries matched a discovered test` | 0 |
| the same **plus** `--exclude-test Codeunit60810` | 0 | `all 1 entries matched a discovered test` | 0 |

So on a corpus leg that resumes and then finishes clean, the audit's whole-run claim
**already holds** — by accident, not by construction, and nothing tests it. The
false red the issue describes is not reachable on that path today. Two reasons the fix
is still worth landing rather than closing the issue as not-reproducible:

1. **The accident is fragile in a specific, plausible way.** The obvious optimization —
   skip instantiating a codeunit whose every method is excluded — is exactly what a
   resume produces for every already-run codeunit, i.e. most of the corpus, at one BC
   codeunit instantiation each. Taking it would silently turn the audit into precisely
   the false red #3168 describes. After this change the audit no longer depends on where
   that filter is consulted.
2. **One reachable case is fixed outright, and it is the one #2747 exists for.** A carry
   file that was named and has gone missing (parent killed, scratch directory swept)
   leaves the discovery set short by a whole attempt. Measured on `main`, that run
   printed both the "refusing to report it as complete" message **and**
   `UNMATCHED: … no codeunit named "Ghost Resume Tests" … was loaded in this run` about
   an entry that is correct. The audit now stands down and says why; the run still exits
   2, so nothing is suppressed.

## RED → GREEN

Deliberately constructed so it cannot pass vacuously: the entry names a codeunit that is
**matched only by the carried attempt** and that the run's own bundle does not contain,
so no amount of the final attempt's own discovery can satisfy it. A version driven by
`--exclude-test` alone would have passed before and after (see the table above) and
proved nothing.

Same fixture, same command line, `main` binary then this branch:

```
--expectations <one entry: "Ghost Resume Tests"."RanInAnEarlierAttempt">
--expectations-require-match --merge-results <one-attempt carry naming that test>
--test GreenPath_PlainPass AlRunner.Tests/Fixtures/ExpectationsBundle/suite
```

| | pass / fail | audit line | exit |
|---|---|---|---|
| **RED** (`main`) | 1 / 0 | `UNMATCHED: … no codeunit named "Ghost Resume Tests" (id 60899) was loaded in this run` | **5** |
| **GREEN** (this branch) | 1 / 0 | `all 1 entries matched a discovered test` | **0** |

The run's own bundle passes one test and fails none, so the 5 was attributable to the
audit alone.

Controls, so the fold is not a rubber stamp — measured on this branch:

- entry `"Ghost Resume Tests"."NeverRanAnywhere"`, same carry → still **exit 5**, with
  `codeunit "Ghost Resume Tests" was reached only by an earlier resume attempt, which
  ran no test method 'NeverRanAnywhere'. The methods it ran: RanInAnEarlierAttempt.`
- `--merge-results` naming a file that does not exist → **exit 2**, audit stands down,
  no `UNMATCHED`.

Tests: 6 new in `ExpectationMatchAuditTests` (pure), 3 new in
`ExpectationManifestWiringTests` (end-to-end through the CLI, the table above).

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Everything downstream of `allResults`
   that produces a *verdict* already uses it: the exit code, `--count-baseline`,
   `--output-json`, `Reporter.WriteClassification`, and `--output-junit` via
   `--merge-counts`. The three console printers (`PrintPerTest`,
   `PrintFailureClassification`, `PrintSummary`) still take the attempt's `results` —
   examined and left alone deliberately: `AbortResume.Rerun` **inherits** stdio, so each
   attempt printed its own list live and the reader has already seen them, and
   `PrintSummary` is separately handed the carried counts.
2. **Sibling function with the same assumption?** `_discovered` has exactly one reader,
   `FindUnmatchedEntries`. No sibling.
3. **Two paths writing the same state — same invariant?** After this change `_discovered`
   has two writers, and they do **not** hold the same invariant: in-process discovery
   records the codeunit's declared, unfiltered method set, a carried attempt records only
   what ran. Rather than leave that latent, `DiscoveredTestCodeunit` now carries
   `MethodsAreComplete`, and `Explain` refuses to say "declares no test method X" about a
   codeunit only a carry file has seen — it cannot know that, and under a `--test` filter
   it would be false.

## Does this assert anything about what BC does?

**No.** It is repository hygiene over our own expectations manifest and the runner's own
exit codes. Nothing here is a statement a BC service tier could adjudicate, so it owes no
upstream corpus test.

## Effect on #3130

**Neither helps nor hinders — no shared code.** #3130 is
`CountBaselineCheck.Evaluate`'s `if (!actualBySuite.TryGetValue(suite, out var actual))
continue;`, in `AlRunner/Infrastructure/CountBaseline.cs`; this change touches
`ExpectationManifest`, the audit block in `Program.cs`, and neither the count-baseline
block nor `actualBySuite`. The only relationship is precedent: both are "a guard whose
input is narrower than the claim it makes", and this one is now fixed by widening the
input at the call site rather than by moving the guard.

## Deliberately left out

- **The console printers** (question 1 above) — argued above as not a defect, not merely
  out of scope.
- **`--test` + `--expectations-require-match`.** The audit does not stand down for a
  `--test` filter the way `--count-baseline` does, because in-process discovery is
  unfiltered by design. Folding carried results introduces the one filtered input, which
  is why the `MethodsAreComplete` wording exists; widening the stand-down rules further
  was not needed and is not done here.
- **No workflow change.** `.github/workflows/bc-tests.yml` already passes the flag on the
  full-corpus step and needs no edit.

Local runs on this branch (Release, BC 28.1): `ExpectationMatchAuditTests` 20/20,
`ExpectationManifestWiringTests` 15/15, and a combined filtered run of
`ScratchDirOwnershipGuardTests` + `VirtualTableRefusalClaimTests` (86) + `CliText`/guide
text 124/124, plus `Resume|CarriedAttempt|CountBaseline|Abort|Expectation` 158 passed,
1 pre-existing unrelated skip. The full `AlRunner.Tests` suite was **not** run locally;
CI runs it on all 8 legs.

---

Written by an agent (`stma-auto-1`, cycle 144) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
