### PR TITLE
fix(metadata): resolve a Database::/Report:: const in a where() clause to the object id

### DIFF
--- a/AlRunner.Tests/ObjectReferenceConstResolutionTests.cs
+++ b/AlRunner.Tests/ObjectReferenceConstResolutionTests.cs
@@ -1,0 +1,149 @@
+// ObjectReferenceConstResolutionTests — issue #3195.
+//
+// Why this is a RUNNER-side test and not a corpus one
+// ---------------------------------------------------
+// The BC-behaviour half of #3195 — "a const(Database::X) / const(Report::X) in a CalcFormula or
+// TableRelation where() clause contributes the referenced object's ID to the condition" — is a
+// claim about what a service tier computes, so it is asked upstream:
+// StefanMaron/BusinessCentral.AL.Language.Tests#206 (record/TestCalcFormulaDatabaseConst.Codeunit.al,
+// codeunit 60329) puts it in front of all eight BC legs. Nothing here re-states that claim, and
+// the pin is deliberately NOT bumped in this PR (#3152 carries the pin move).
+//
+// What this pins instead is the runner's own resolver, RecordPatches.ResolveObjectReferenceConst,
+// on the PRECOMPILED-DEPENDENCY route that no corpus test can reach. The corpus's fixture tables
+// and reports are all source-compiled, so they resolve out of _parsedTables / _parsedReports; the
+// 22 Base Application CalcFormulas and 5 TableRelations that actually carry this syntax live in
+// R2R .app packages and resolve out of SymbolReference.json instead. If that half regressed,
+// every "Coupled to Dataverse" FlowField would go back to raising
+//   NavNCLEvaluateException: The value "Database::"Customer"" can't be evaluated into type Integer
+// while the corpus stayed green.
+//
+// The pass-through arm matters as much as the resolving arm. ConstValueText hands a const literal
+// over as TEXT on purpose, because NCLMetaFilterConst evaluates it against the source field's own
+// type exactly as it does a user-typed filter — so an option member, a quoted literal and a
+// number must come back BYTE-IDENTICAL. A resolver that rewrote those would break the 1215 const
+// conditions the Base Application ships that are not object references.
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// MUST be serial: registering a symbol .app mutates RecordPatches' process-global _bcAppPaths and
+// the table index derived from it, and Dispose calls ResetForReload().
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class ObjectReferenceConstResolutionTests : IDisposable
+{
+    private readonly string _root;
+
+    public ObjectReferenceConstResolutionTests()
+    {
+        _root = TestScratch.Dir("al-runner-objref-const");
+        Directory.CreateDirectory(_root);
+        RecordPatches.ResetForReload();
+        RecordPatches.AddBcAppPath(WriteSymbolApp());
+    }
+
+    public void Dispose()
+    {
+        try { RecordPatches.ResetForReload(); } catch { }
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    // One .app declaring a table and a report whose NAMES need AL quoting (a space, and a period
+    // in "Interaction Tmpl. Language"-style naming), plus a second table so a resolver answering
+    // with "the first table it finds" fails. Ids are far from any Base Application id so a hit
+    // cannot come from the real packages.
+    // no-base-app-in-csharp-tests.md: a bare SymbolReference package, no application floor.
+    private string WriteSymbolApp()
+    {
+        const string SymbolReference = """
+        {
+          "AppId": "6a4f2f1e-2c53-4b0e-9f1a-0b7d1f9a3c11",
+          "Name": "ObjRef Const Fixture",
+          "Publisher": "AL Runner",
+          "Version": "1.0.0.0",
+          "Tables": [
+            { "Id": 70931, "Name": "ORC Coupling Row",
+              "Fields": [ { "Id": 1, "Name": "Entry No.", "TypeDefinition": { "Name": "Integer" } } ] },
+            { "Id": 70932, "Name": "ORC Other Row",
+              "Fields": [ { "Id": 1, "Name": "Entry No.", "TypeDefinition": { "Name": "Integer" } } ] }
+          ],
+          "Reports": [ { "Id": 70941, "Name": "ORC Merge Report" } ],
+          "Codeunits": [ { "Id": 70951, "Name": "ORC Worker" } ],
+          "Pages": [],
+          "Queries": [],
+          "XmlPorts": [],
+          "EnumTypes": []
+        }
+        """;
+
+        var appPath = Path.Combine(_root, "objref-const-fixture.app");
+        using var fs = new FileStream(appPath, FileMode.Create);
+        using var za = new ZipArchive(fs, ZipArchiveMode.Create);
+        using var w = new StreamWriter(za.CreateEntry("SymbolReference.json").Open(), Encoding.UTF8);
+        w.Write(SymbolReference);
+        return appPath;
+    }
+
+    [Theory]
+    // Database:: — the reported shape. Quoted and bare spellings of the SAME name must land on
+    // the same id, since AL quotes an identifier only when it has to.
+    [InlineData("Database::\"ORC Coupling Row\"", "70931")]
+    [InlineData("Database::\"ORC Other Row\"", "70932")]
+    // Report:: — the sibling the Base Application ships in 3 TableRelations.
+    [InlineData("Report::\"ORC Merge Report\"", "70941")]
+    // Codeunit:: — same syntax, resolved through the same object index.
+    [InlineData("Codeunit::\"ORC Worker\"", "70951")]
+    // The prefix is matched case-insensitively, as AL writes it (`XmlPort::`/`Xmlport::`).
+    [InlineData("database::\"ORC Coupling Row\"", "70931")]
+    [InlineData("DATABASE::\"ORC Other Row\"", "70932")]
+    public void ResolveObjectReferenceConst_NamesADeclaredObject_YieldsItsId(string constText, string expected)
+    {
+        Assert.Equal(expected, RecordPatches.ResolveObjectReferenceConst(constText));
+    }
+
+    [Theory]
+    // Everything that is NOT an object reference comes back byte-identical, because
+    // NCLMetaFilterConst evaluates it against the source field's own type.
+    [InlineData("SPECIAL")]
+    [InlineData("On Hold")]
+    [InlineData("0")]
+    [InlineData("60328")]
+    [InlineData("true")]
+    [InlineData("")]
+    // An enum/option member carries "::" too and must NOT be touched: BC's filter grammar
+    // resolves the member by name against the field's own type.
+    [InlineData("Some Enum::Member")]
+    [InlineData("Sales Document Type::Invoice")]
+    public void ResolveObjectReferenceConst_NotAnObjectReference_IsUnchanged(string constText)
+    {
+        Assert.Equal(constText, RecordPatches.ResolveObjectReferenceConst(constText));
+    }
+
+    [Fact]
+    public void ResolveObjectReferenceConst_UnknownObjectName_KeepsTheTextAsWritten()
+    {
+        // loud-failures.md: the honest answer is the text BC's own evaluator will then refuse by
+        // name. Answering 0 — or dropping the condition — would pin the filter to the wrong rows
+        // and the FlowField would compute a plausible, wrong number in silence.
+        Assert.Equal("Database::\"ORC No Such Table\"",
+            RecordPatches.ResolveObjectReferenceConst("Database::\"ORC No Such Table\""));
+
+        // And a name declared as a TABLE is not a REPORT: the kind is part of the lookup key.
+        Assert.Equal("Report::\"ORC Coupling Row\"",
+            RecordPatches.ResolveObjectReferenceConst("Report::\"ORC Coupling Row\""));
+    }
+
+    [Fact]
+    public void ResolveObjectReferenceConst_ResolvesRepeatedly_WithTheSameAnswer()
+    {
+        // The successful resolutions are memoised. A cache keyed carelessly (on the name alone,
+        // ignoring the kind) would answer the second lookup with the first one's id.
+        Assert.Equal("70931", RecordPatches.ResolveObjectReferenceConst("Database::\"ORC Coupling Row\""));
+        Assert.Equal("70941", RecordPatches.ResolveObjectReferenceConst("Report::\"ORC Merge Report\""));
+        Assert.Equal("70931", RecordPatches.ResolveObjectReferenceConst("Database::\"ORC Coupling Row\""));
+        Assert.Equal("70941", RecordPatches.ResolveObjectReferenceConst("Report::\"ORC Merge Report\""));
+    }
+}

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -787,7 +787,10 @@ public static partial class RecordPatches
                     return null;
                 }
                 conditionObjects.Add(BuildMetaCondition(localField.FieldId,
-                    c.Kind == ParsedCalcFilterKind.Const ? "CONST" : "FILTER", c.Value ?? ""));
+                    c.Kind == ParsedCalcFilterKind.Const ? "CONST" : "FILTER",
+                    c.Kind == ParsedCalcFilterKind.Const
+                        ? ResolveObjectReferenceConst(c.Value)
+                        : c.Value ?? ""));
             }
 
             var filterObjects = new List<object>();
@@ -826,7 +829,10 @@ public static partial class RecordPatches
                 }
 
                 filterObjects.Add(BuildMetaFilter(srcField.FieldId,
-                    w.Kind == ParsedCalcFilterKind.Const ? "CONST" : "FILTER", w.Value ?? ""));
+                    w.Kind == ParsedCalcFilterKind.Const ? "CONST" : "FILTER",
+                    w.Kind == ParsedCalcFilterKind.Const
+                        ? ResolveObjectReferenceConst(w.Value)
+                        : w.Value ?? ""));
             }
 
             var ctor = _tMetaFieldRelation.GetConstructors()
@@ -848,6 +854,122 @@ public static partial class RecordPatches
             relationObjects.Add(ctor.Invoke(args)!);
         }
         return MakeImmutableArray(_tMetaFieldRelation, relationObjects.ToArray());
+    }
+
+    /// <summary>
+    /// AL's object-reference syntax (<c>Database::"Some Table"</c>, <c>Report::"Email Merge"</c>,
+    /// …) resolved to the object ID, as the decimal text a <c>MetaFilter</c> /
+    /// <c>MetaCondition</c> carries.
+    /// <para>#3195. <see cref="ConstValueText"/> deliberately hands a const literal over as
+    /// TEXT, because <c>NCLMetaFilterConst</c> evaluates it against the SOURCE field's own type
+    /// exactly as it does a user-typed filter — right for <c>const('SPECIAL')</c> and for an
+    /// option member, and wrong for this one shape. <c>Database::X</c> is not a value a user
+    /// can type into a filter; it is compiler syntax, and by the time a real service tier reads
+    /// the metadata BC's own compiler has already replaced it with the object's id. Left as
+    /// written it reaches the runtime as the literal text and
+    /// <c>The value "Database::"Customer"" can't be evaluated into type Integer</c> is what
+    /// CalcFields raises.</para>
+    /// <para>Measured on the shipped BC 28.1 packages, walking every table and tableextension
+    /// field property in SymbolReference.json: <b>22</b> CalcFormula properties carry a
+    /// <c>Database::</c> const (every <c>"Coupled to Dataverse"</c> field, on Customer, Item,
+    /// Vendor, Contact, Currency, …), <b>2</b> TableRelation properties carry one
+    /// (<c>Interaction Template."Word Template Code"</c> and its sibling), and <b>3</b>
+    /// TableRelation properties carry a <c>Report::</c> one
+    /// (<c>Interaction Tmpl. Language."Custom Layout Code"</c>, <c>."Report Layout Name"</c>,
+    /// <c>."Report Layout AppID"</c> — all
+    /// <c>where("Report ID" = const(Report::"Email Merge"))</c>). Both prefixes are therefore
+    /// handled, and so are the other four the AL compiler accepts in this position — measured
+    /// by compiling <c>const(Page::…)</c> / <c>const(Codeunit::…)</c> / <c>const(Query::…)</c> /
+    /// <c>const(XmlPort::…)</c> in both properties with Microsoft's own compiler, which takes
+    /// all of them. (A query column's <c>ColumnFilter</c> is NOT one of these positions: the
+    /// same compiler refuses <c>const(Database::X)</c> there with
+    /// <c>error AL0118: The name 'Database' does not exist in the current context</c>.)</para>
+    /// <para>An unresolvable name is left <b>as written</b>, loudly, rather than replaced with
+    /// 0 or dropped — BC's own evaluator then fails naming the text, which is a diagnosis,
+    /// where a silently wrong id would pin the condition to the wrong rows. Same rule
+    /// <see cref="DependencyPageMetadataXml.NormalizeConstLinkValue"/> already applies to a
+    /// SubPageLink const (#2735).</para>
+    /// <para>Anything that is not one of these prefixes — a quoted literal, a number, an enum
+    /// or option member, <c>true</c>/<c>false</c> — is returned untouched, so the
+    /// evaluate-against-the-field's-own-type rule that <see cref="ConstValueText"/> documents
+    /// keeps applying to every other const.</para>
+    /// </summary>
+    internal static string ResolveObjectReferenceConst(string? constText)
+    {
+        var s = constText ?? "";
+        if (s.Length == 0 || s.IndexOf("::", StringComparison.Ordinal) < 0) return s;
+
+        foreach (var (prefix, kind) in ObjectReferenceConstPrefixes)
+        {
+            if (!s.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) continue;
+
+            // The object name may be a quoted AL identifier; ConstValueText's rule strips the
+            // quotes and resolves AL's doubled-quote escape, which is exactly what the name
+            // indices are keyed on.
+            var objectName = ConstValueText(s.Substring(prefix.Length));
+            if (objectName.Length == 0) return s;
+
+            var id = ResolveObjectIdByKindAndName(kind, objectName);
+            if (id > 0) return id.ToString(CultureInfo.InvariantCulture);
+
+            Console.Error.WriteLine(
+                $"[warn] const({s}) names a {kind.ToLowerInvariant()} no loaded app declares; the " +
+                $"condition keeps the text as written, so BC's own evaluator will refuse it by name " +
+                $"rather than the filter silently pinning to a wrong id");
+            return s;
+        }
+
+        return s;
+    }
+
+    /// <summary>The AL object-reference prefixes that name an object ID, paired with the object
+    /// kind <see cref="EnumerateKnownAlObjects"/> reports for that kind. <c>Enum::</c> is
+    /// deliberately absent: <c>"Some Enum"::Member</c> in a const is an enum VALUE, which BC's
+    /// filter grammar already resolves by member name against the source field's own type.</summary>
+    private static readonly (string Prefix, string Kind)[] ObjectReferenceConstPrefixes =
+    {
+        ("Database::", "Table"),
+        ("Page::", "Page"),
+        ("Report::", "Report"),
+        ("Codeunit::", "Codeunit"),
+        ("Query::", "Query"),
+        ("XmlPort::", "XMLport"),
+    };
+
+    /// <summary>Successful (kind, name) → id resolutions. Only successes are memoised: an id
+    /// never changes once known, but a MISS can become a hit when a further dependency .app is
+    /// registered later in the run, and caching that would freeze the miss.</summary>
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<(string Kind, string Name), int>
+        _objectRefConstIds = new();
+
+    private static int ResolveObjectIdByKindAndName(string kind, string objectName)
+    {
+        var key = (kind, objectName.ToLowerInvariant());
+        if (_objectRefConstIds.TryGetValue(key, out var cached)) return cached;
+
+        int id;
+        if (string.Equals(kind, "Table", StringComparison.OrdinalIgnoreCase))
+        {
+            // Tables have their own index, and going through it also materialises the
+            // ParsedTable — which BuildMetaCalcFormula's source-table lookup wants anyway.
+            id = ResolveTableIdByName(objectName);
+        }
+        else
+        {
+            var wantedKind = NormalizeObjectTypeName(kind);
+            id = -1;
+            foreach (var (objKind, objId, name, _) in EnumerateKnownAlObjects())
+            {
+                if (objId <= 0) continue;
+                if (!string.Equals(name, objectName, StringComparison.OrdinalIgnoreCase)) continue;
+                if (NormalizeObjectTypeName(objKind) != wantedKind) continue;
+                id = objId;
+                break;
+            }
+        }
+
+        if (id > 0) _objectRefConstIds[key] = id;
+        return id;
     }
 
     /// <summary>
@@ -951,7 +1073,11 @@ public static partial class RecordPatches
                     break;
 
                 case ParsedCalcFilterKind.Const:
-                    filterObjects.Add(BuildMetaFilter(srcFilterField.FieldId, "CONST", filter.Value ?? ""));
+                    // #3195: Database::X / Report::X and the four siblings are compiler syntax,
+                    // not a filter value — BC's compiler has already replaced them with the
+                    // object id by the time a service tier reads this metadata.
+                    filterObjects.Add(BuildMetaFilter(srcFilterField.FieldId, "CONST",
+                        ResolveObjectReferenceConst(filter.Value)));
                     break;
 
                 case ParsedCalcFilterKind.Filter:


### PR DESCRIPTION
Closes #3195

A `const(...)` condition in a CalcFormula or TableRelation `where()` clause was handed to BC as the literal source text. That is right for an ordinary literal — `NCLMetaFilterConst` evaluates it against the source field's own type exactly as it does a user-typed filter, which is what makes `const('SPECIAL')` and an option member work — and wrong for AL's object-reference syntax, which no user-typed filter can contain and which BC's own compiler has already replaced with the object id by the time a service tier reads the metadata. So `CalcFields` died with

```
NavNCLEvaluateException: The value "Database::"Customer"" can't be evaluated into type Integer.
```

## RED → GREEN

The proving test is a **BC-behaviour claim**, so it went upstream first: **corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#206** (`record/TestCalcFormulaDatabaseConst.Codeunit.al`, codeunit 60329, fixture tables 60327/60328). **All eight BC legs adjudicate it** — 27.0 through 28.4. **The pin is deliberately NOT bumped here**, per the brief: #3152 carries the pin move, and the fold belongs to that sequence.

RED and GREEN were measured by pointing the runner at the corpus branch checkout instead of `tests/al-language`:

| | before | after |
|---|---|---|
| 7 new corpus tests | **5F + 2F**, every one `NavNCLEvaluateException: The value "Database::"CDC Owner"" can't be evaluated into type Integer` / `"Report::"ALT Simple Report""` | **7 PASS** |

The `Database::` failures hit on both properties, including the `asserterror` test where the expected relation error was replaced by the evaluate exception. The full filtered GREEN run also keeps the seven pre-existing `Const*` tests passing, including `Codeunit60324.ConstDatabaseLink_PinsTheFieldToTheTableId` (the SubPageLink const, #2735), which is the neighbouring behaviour this must not disturb.

Runner-side, `AlRunner.Tests/ObjectReferenceConstResolutionTests.cs` (16 rows) pins the resolver on the **precompiled-dependency** route no corpus test can reach — the corpus's fixtures are all source-compiled, while the 27 Base Application properties that actually carry this syntax live in R2R `.app` packages and resolve out of `SymbolReference.json`. It asserts resolution to specific ids, kind-sensitivity (a name declared as a table is not a report), the unknown-name pass-through, and that eight non-object consts come back byte-identical.

## How wide the shape actually is — measured, not assumed

Walking every table and tableextension field property in the shipped BC 28.1 packages' `SymbolReference.json`:

| property | prefix | count |
|---|---|---|
| `CalcFormula` | `Database::` | **22** (every `"Coupled to Dataverse"` field — Customer, Item, Vendor, Contact, Currency, …) |
| `TableRelation` | `Database::` | **2** (`Interaction Template."Word Template Code"` and its sibling) |
| `TableRelation` | `Report::` | **3** (`Interaction Tmpl. Language."Custom Layout Code"`, `."Report Layout Name"`, `."Report Layout AppID"` — all `where("Report ID" = const(Report::"Email Merge"))`) |

**The `Report::` group is a sibling the issue did not mention**, and it has the identical defect. It is fixed here and covered upstream in the same corpus PR, with a second Integer object-id column on the fixture so its counts (3 and 1) differ from every `Database::` count on the same rows, from "no filter" and from "matched nothing".

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — three, all now routed through one resolver: the CalcFormula `where()` const, the TableRelation `where()` const, and the TableRelation `if()` arm condition. A fourth candidate, the SubPageLink const, was **already** correct (`DependencyPageMetadataXml.NormalizeConstLinkValue`, #2735) and its corpus test passes throughout.
2. **A sibling making the same assumption?** The `Report::` group above, plus the other four prefixes. `Page::`, `Codeunit::`, `Query::` and `XmlPort::` are accepted by Microsoft's own compiler in both properties — measured by compiling all six in a probe fixture, which produced no diagnostic — so all six are handled rather than only the two that ship in Base App today.
3. **Two paths writing the same state?** A query column's `ColumnFilter` looked like a fourth site and is **not** one: the same compiler refuses `ColumnFilter = TableId = const(Database::"CDC Owner");` with `error AL0118: The name 'Database' does not exist in the current context`. Measured, so `RecordPatches.NclMetaQueryBuilder`'s const path is deliberately left alone rather than "fixed" for an unreachable shape.

An unresolvable name is kept **as written**, loudly, so BC's own evaluator refuses it by name — the same rule `NormalizeConstLinkValue` already applies. A silent `0` would pin the condition to the wrong rows and produce a plausible wrong number.

## How this composes with #3180

No conflict, by construction. #3180 (`agent/fbk-1`) also edits `RecordPatches.NclMetaTableBuilder.cs`, but at two hunks that are **not** the ones changed here: `BuildMetaField`'s formula-less-FlowField diagnostic (~line 488) and `BuildMetaCalcFormula`'s **source-table** resolution failure (~line 906, `NoteUnresolvedCalcFormulaSourceTable`). This PR changes the **filter loop** ~50 lines further down, plus the two TableRelation sites, and adds a helper above `BuildMetaCondition`. Semantically they are orthogonal halves of the same function — #3180 answers "which table does this formula aggregate over", this one answers "what value does this condition compare against" — and either can land first. Nothing here touches `FlowFieldPatches.cs`, `RecordPatches.CalcFormulaRetry.cs`, `BcAppSymbolCache.TableExtensions.cs` or `RecordPatches.BcAppFallback.cs`.

## What is deliberately left out

- **The issue's own Base Application reproducer is still not fully green, and that is expected.** Measured on a throwaway Base-App bundle after this fix: a `Customer` whose SystemId sits on a `"CRM Integration Record"` row carrying `Database::Customer` now reads `"Coupled to Dataverse"` = **TRUE** — impossible before, the call raised the evaluate exception. But a *second* customer with no coupling row of its own also reads TRUE, because the `"Integration ID" = field(SystemId)` half of the same formula is still not applied. That is **#3178**, exactly as #3195's own text predicted ("the two fixes are both needed"). This PR is the const half; #3178 is the other.
- **`filter(...)` values are untouched.** A `filter()` value is parsed as a filter *expression*, so resolving object references inside one means tokenising the expression rather than matching a prefix. No Base Application property carries that shape — the measurement above found zero — so it is not speculatively implemented.
- **No pin bump, no expectations change.** Corpus PR #206 has to merge first.

## Local verification (all run in this exact state, after rebasing onto `main` at `38cdaa81`)

- Corpus at the repo's own pin: **2665/2665 pass**, exit 0, count baseline satisfied.
- `tests/runner-extras`: **312/312 pass**, exit 0.
- `dotnet test` filtered over `CalcFormula|FlowField|Relation|ObjectReferenceConst` plus the scratch-dir / parser-statics / Base-App-floor guards: **109/109 pass**.

---
Written by the automated implementation agent `stma-auto-1` (cycle 144) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
