### PR TITLE
fix(metadata): clear the object-reference const memo on a bundle reload, and cover the resolver's bare-name and call-site halves

### DIFF
--- a/AlRunner.Tests/ObjectRefConstBundleBoundaryTests.cs
+++ b/AlRunner.Tests/ObjectRefConstBundleBoundaryTests.cs
@@ -1,0 +1,193 @@
+// ObjectRefConstBundleBoundaryTests — issue #3207.
+//
+// WHAT WAS UNPINNED
+// -----------------
+// #3205 added RecordPatches._objectRefConstIds, a process-global memo of successful
+// (kind, name) -> object-id resolutions for AL's `const(Database::X)` / `const(Report::X)`
+// syntax. Nothing cleared it. ResetForReload — the per-bundle reload path a --server /
+// --watch process runs between bundles — clears _parsedTables, _metaTableCache and the
+// registered .app set (ClearPerBundleBcAppPaths, #2755) and invalidates _bcSymbolTableIndex
+// (#2478), which are precisely the three inputs this memo's answer is derived from. So the
+// memo outlived every input it was computed from and DEFEATED an invalidation its own
+// dependency performs: bundle 2 declaring the same object name at a different id kept
+// getting bundle 1's id, and the where() condition was pinned to the wrong rows while every
+// other index correctly described bundle 2.
+//
+// Silent, and plausible-looking: a FlowField whose condition names the wrong table id sums
+// a real number over the wrong rows. That is the failure #3205's own doc comment says it is
+// avoiding ("a silently wrong id would pin the condition to the wrong rows"), and it is the
+// third defect of this exact shape in this exact reset path — #2478 (an index reset that did
+// not reset enough) and #2755 (a registered set that was not cleared) were the first two.
+//
+// WHY A TEST OVER TWO BUNDLES, NOT ONE
+// ------------------------------------
+// The defect is unreachable from the corpus and from every CI leg, because a leg is one
+// single-bundle CLI invocation and a memo is only wrong across a bundle boundary. A test
+// asserting over one bundle passes identically before and after the fix and proves nothing:
+// ObjectReferenceConstResolutionTests' ResolvesRepeatedly case is exactly that, and it stays
+// green on the broken build. So the boundary is constructed deliberately here — register,
+// resolve, ResetForReload, register a DIFFERENT package declaring the same names at
+// different ids, resolve again — which is what Program.cs does between two bundles in one
+// server process (reset at 4049, re-register at 4533/4534, the reset always first).
+//
+// Two directions, because clearing the memo has to be right in both:
+//   * A name that moves id must answer with the NEW id (the reported defect).
+//   * A name that bundle 2 does not declare at all must go back to being unresolvable and
+//     come back as the text as written — loud-failures.md's answer, and the one a memo
+//     holding a phantom id would silently replace with a plausible number.
+//
+// WHY RUNNER-LOCAL AND NOT UPSTREAM
+// ---------------------------------
+// Nothing here is a claim about Business Central. The subject is the lifetime of a runner
+// cache across the runner's own bundle-reload boundary — a concept BC does not have. The
+// BC-behaviour half of #3195 (what a const(Database::X) resolves to) is asked upstream in
+// StefanMaron/BusinessCentral.AL.Language.Tests, codeunit 60329.
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// MUST be serial: this registers symbol .apps into RecordPatches' process-global _bcAppPaths
+// and calls ResetForReload(), which clears roughly twenty static dictionaries.
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class ObjectRefConstBundleBoundaryTests : IDisposable
+{
+    private readonly string _root;
+
+    public ObjectRefConstBundleBoundaryTests()
+    {
+        _root = TestScratch.Dir("al-runner-objref-const-boundary");
+        Directory.CreateDirectory(_root);
+        RecordPatches.ResetForReload();
+    }
+
+    public void Dispose()
+    {
+        try { RecordPatches.ResetForReload(); } catch { }
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    // One .app declaring a table and a report under names that are STABLE across bundles while
+    // their ids are not — the shape a --server process meets when the same object is rebuilt at
+    // a different id, or when a second workspace reuses a name. `alsoDeclareRemoved` carries an
+    // object that exists in bundle 1 and not in bundle 2, so the miss direction is testable.
+    // no-base-app-in-csharp-tests.md: a bare SymbolReference package, no application floor.
+    private string WriteSymbolApp(string fileName, int tableId, int reportId, bool alsoDeclareRemoved)
+    {
+        // Built with an explicit JSON writer rather than a raw string literal: the fixture
+        // differs between the two bundles only in the ids and in whether the third table is
+        // present, and that is the whole point of it.
+        var tables = new List<object>
+        {
+            new
+            {
+                Id = tableId,
+                Name = "ORB Shared Table",
+                Fields = new object[] { new { Id = 1, Name = "Entry No.", TypeDefinition = new { Name = "Integer" } } },
+            },
+        };
+        if (alsoDeclareRemoved)
+            tables.Add(new
+            {
+                Id = 70899,
+                Name = "ORB Bundle One Only",
+                Fields = new object[] { new { Id = 1, Name = "Entry No.", TypeDefinition = new { Name = "Integer" } } },
+            });
+
+        var symbolReference = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            AppId = Guid.NewGuid().ToString(),
+            Name = "ORB Boundary Fixture",
+            Publisher = "AL Runner",
+            Version = "1.0.0.0",
+            Tables = tables,
+            Reports = new object[] { new { Id = reportId, Name = "ORB Shared Report" } },
+            Codeunits = Array.Empty<object>(),
+            Pages = Array.Empty<object>(),
+            Queries = Array.Empty<object>(),
+            XmlPorts = Array.Empty<object>(),
+            EnumTypes = Array.Empty<object>(),
+        });
+
+        var appPath = Path.Combine(_root, fileName);
+        using (var fs = new FileStream(appPath, FileMode.Create))
+        using (var za = new ZipArchive(fs, ZipArchiveMode.Create))
+        using (var w = new StreamWriter(za.CreateEntry("SymbolReference.json").Open(), Encoding.UTF8))
+            w.Write(symbolReference);
+        return appPath;
+    }
+
+    [Fact]
+    public void AResolutionMemoisedInBundleOne_DoesNotSurviveTheReloadIntoBundleTwo()
+    {
+        // Bundle 1.
+        RecordPatches.AddBcAppPath(WriteSymbolApp("orb-bundle-1.app", 70801, 70811, alsoDeclareRemoved: true));
+
+        // Asserted, not assumed: if registration silently did not happen, every assertion below
+        // would be satisfied by "unresolvable both times" and the test would prove nothing.
+        Assert.Equal("70801", RecordPatches.ResolveObjectReferenceConst("Database::\"ORB Shared Table\""));
+        Assert.Equal("70811", RecordPatches.ResolveObjectReferenceConst("Report::\"ORB Shared Report\""));
+        Assert.Equal("70899", RecordPatches.ResolveObjectReferenceConst("Database::\"ORB Bundle One Only\""));
+
+        // The bundle boundary itself.
+        RecordPatches.ResetForReload();
+
+        // Bundle 2: same names, different ids, and one object bundle 1 had that this one drops.
+        RecordPatches.AddBcAppPath(WriteSymbolApp("orb-bundle-2.app", 70802, 70812, alsoDeclareRemoved: false));
+
+        // The reported defect. On the broken build these answer 70801 / 70811 — bundle 1's ids,
+        // held by a memo whose every input ResetForReload has just discarded.
+        Assert.Equal("70802", RecordPatches.ResolveObjectReferenceConst("Database::\"ORB Shared Table\""));
+        Assert.Equal("70812", RecordPatches.ResolveObjectReferenceConst("Report::\"ORB Shared Report\""));
+
+        // The other direction: an object bundle 2 does not declare is unresolvable again, so the
+        // text comes back as written for BC's own evaluator to refuse by name. A memo holding
+        // 70899 would instead pin the condition to a table this bundle has never heard of.
+        Assert.Equal("Database::\"ORB Bundle One Only\"",
+            RecordPatches.ResolveObjectReferenceConst("Database::\"ORB Bundle One Only\""));
+    }
+
+    [Fact]
+    public void TheMemoStillMemoises_WithinOneBundle_AndIsEmptiedByTheReload()
+    {
+        // The control that stops the fix from being "clear it so often it never caches". #3205's
+        // reason for the memo stands INSIDE a bundle: every table field carrying a Database::
+        // const re-resolves the same name, and the id genuinely cannot change without a reload.
+        RecordPatches.AddBcAppPath(WriteSymbolApp("orb-bundle-solo.app", 70821, 70831, alsoDeclareRemoved: false));
+
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.Equal("70821", RecordPatches.ResolveObjectReferenceConst("Database::\"ORB Shared Table\""));
+            Assert.Equal("70831", RecordPatches.ResolveObjectReferenceConst("Report::\"ORB Shared Report\""));
+        }
+
+        // Asserted against the memo itself, because "the same answer three times" is equally
+        // satisfied by no memo at all. The key is (kind, lower-cased name), so a cache keyed
+        // carelessly on the name alone would also show up here as one entry instead of two.
+        var memo = Memo();
+        Assert.True(memo.Contains(("Table", "orb shared table")),
+            "the Table resolution was not memoised — #3205's caching is what this PR must keep");
+        Assert.True(memo.Contains(("Report", "orb shared report")),
+            "the Report resolution was not memoised — #3205's caching is what this PR must keep");
+
+        // And the reload empties it. This is the fix stated directly: on the broken build the
+        // two entries above are still there afterwards, keyed on names whose every backing index
+        // ResetForReload has just discarded.
+        RecordPatches.ResetForReload();
+        Assert.Empty((System.Collections.IEnumerable)Memo());
+    }
+
+    /// <summary>The memo itself. Read by reflection on purpose: no public surface reports it,
+    /// and inferring "it was cleared" from a later lookup cannot tell a cleared memo from one
+    /// that happens to agree with the current bundle.</summary>
+    private static System.Collections.IDictionary Memo()
+    {
+        var field = typeof(RecordPatches).GetField("_objectRefConstIds",
+                        System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+                    ?? throw new InvalidOperationException(
+                        "RecordPatches._objectRefConstIds not found — this test tracks that field.");
+        return (System.Collections.IDictionary)field.GetValue(null)!;
+    }
+}

--- a/AlRunner.Tests/ObjectRefConstCallSiteWiringTests.cs
+++ b/AlRunner.Tests/ObjectRefConstCallSiteWiringTests.cs
@@ -1,0 +1,281 @@
+// ObjectRefConstCallSiteWiringTests — issue #3207, the coverage half.
+//
+// WHAT WAS UNPINNED, AND HOW IT WAS MEASURED
+// ------------------------------------------
+// #3205 added RecordPatches.ResolveObjectReferenceConst and applied it at the THREE places a
+// const value becomes BC metadata: a CalcFormula where() filter, a TableRelation where()
+// filter, and a TableRelation if() arm condition. Its runner-local test
+// (ObjectReferenceConstResolutionTests) pins the resolver IN ISOLATION — it calls the resolver
+// directly and never builds any metadata — so deleting all three call sites left the whole C#
+// suite green. The wiring was covered only by corpus codeunit 60329, which this repository does
+// not run yet: the submodule pin is deliberately held behind master (#3152).
+//
+// So each call site is driven here through the real builder, with a real
+// Microsoft.Dynamics.Nav.Types.Metadata.MetaFilter / MetaCondition coming back out and its
+// value read. Revert any one of the three to the pre-#3205 `filter.Value ?? ""` and exactly one
+// of these three facts goes red, naming which.
+//
+// WHY THIS IS NOT A BC-BEHAVIOUR TEST
+// -----------------------------------
+// The claim "a CalcFormula whose where() names const(Database::Customer) filters on the
+// Customer table's id" is a statement about Business Central, and it is asked upstream, on a
+// real service tier, in StefanMaron/BusinessCentral.AL.Language.Tests codeunit 60329. Nothing
+// here restates it. What is asserted here is a RUNNER mechanism: that the runner's own
+// metadata builder routes a const value through its own resolver before handing it to BC, on
+// the PRECOMPILED-dependency route (the object being named is declared only in a registered
+// SymbolReference package, never in AL source) that the corpus structurally cannot reach —
+// every object a corpus test can name is source-compiled.
+//
+// WHY THE BUILDER IS CALLED BY REFLECTION
+// ---------------------------------------
+// BuildMetaCalcFormula and BuildMetaFieldRelations are private, and their public entry point is
+// the full NCLMetaTable build, which needs the whole engine standing up. The reflection
+// statics they read (_tMetaCalcFormula, _tMetaFilter, _tMetaCondition, _tMetaFieldRelation,
+// _tFilterType) are otherwise assigned only by RecordPatches.Register(); they are set here from
+// the SAME Microsoft.Dynamics.Nav.Types types Register() resolves, which this test project
+// already references directly, so the assignment is idempotent with Register() rather than a
+// substitute for it.
+using System.Collections;
+using System.IO.Compression;
+using System.Reflection;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// MUST be serial: registers a symbol .app into the process-global _bcAppPaths, writes the
+// metadata reflection statics, and calls ResetForReload().
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class ObjectRefConstCallSiteWiringTests : IDisposable
+{
+    private const int SourceTableId = 70971;
+    private const int ReferencedTableId = 70981;
+    private const int ReferencedReportId = 70991;
+
+    private readonly string _root;
+    private readonly Dictionary<string, object?> _savedStatics = new();
+
+    public ObjectRefConstCallSiteWiringTests()
+    {
+        _root = TestScratch.Dir("al-runner-objref-const-wiring");
+        Directory.CreateDirectory(_root);
+        RecordPatches.ResetForReload();
+        EnsureMetadataReflection();
+        RecordPatches.AddBcAppPath(WriteSymbolApp());
+    }
+
+    public void Dispose()
+    {
+        // Put the reflection statics back exactly as found — including "null", the state they
+        // are in before RecordPatches.Register() runs. This class writes process-global fields
+        // it does not own, and a test asserting the pre-Register() path must not silently find
+        // them populated by whichever class happened to run first.
+        foreach (var (name, value) in _savedStatics)
+            try { Static(name).SetValue(null, value); } catch { }
+        try { RecordPatches.ResetForReload(); } catch { }
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    // no-base-app-in-csharp-tests.md: a bare SymbolReference package, no application floor. The
+    // referenced table/report exist ONLY here — not in any .al source — which is the precompiled
+    // route the corpus cannot express.
+    private string WriteSymbolApp()
+    {
+        var symbolReference = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            AppId = Guid.NewGuid().ToString(),
+            Name = "ORW Wiring Fixture",
+            Publisher = "AL Runner",
+            Version = "1.0.0.0",
+            Tables = new object[]
+            {
+                new
+                {
+                    Id = SourceTableId,
+                    Name = "ORW Source Row",
+                    Fields = new object[]
+                    {
+                        new { Id = 1, Name = "Entry No.", TypeDefinition = new { Name = "Integer" } },
+                        new { Id = 2, Name = "Table ID",  TypeDefinition = new { Name = "Integer" } },
+                        new { Id = 3, Name = "Report ID", TypeDefinition = new { Name = "Integer" } },
+                    },
+                },
+                new
+                {
+                    Id = ReferencedTableId,
+                    Name = "ORW Referenced Row",
+                    Fields = new object[]
+                    {
+                        new { Id = 1, Name = "Entry No.", TypeDefinition = new { Name = "Integer" } },
+                    },
+                },
+            },
+            Reports = new object[] { new { Id = ReferencedReportId, Name = "ORW Referenced Report" } },
+            Codeunits = Array.Empty<object>(),
+            Pages = Array.Empty<object>(),
+            Queries = Array.Empty<object>(),
+            XmlPorts = Array.Empty<object>(),
+            EnumTypes = Array.Empty<object>(),
+        });
+
+        var appPath = Path.Combine(_root, "orw-wiring-fixture.app");
+        using (var fs = new FileStream(appPath, FileMode.Create))
+        using (var za = new ZipArchive(fs, ZipArchiveMode.Create))
+        using (var w = new StreamWriter(za.CreateEntry("SymbolReference.json").Open(), Encoding.UTF8))
+            w.Write(symbolReference);
+        return appPath;
+    }
+
+    // The table declaring the FlowField / the relation. Never registered anywhere: the builders
+    // take it as an argument, which is what lets this test drive them without a bundle.
+    private static ParsedTable ReferencingTable() => new(
+        70961, "ORW Referencing Row",
+        new List<ParsedField>
+        {
+            new(1, "Entry No.", "Integer", 0),
+            new(2, "Coupled Count", "Integer", 0),
+        },
+        new List<int> { 1 });
+
+    // ── CALL SITE 3: the CalcFormula where() filter ─────────────────────────────────────────
+
+    [Fact]
+    public void ACalcFormulaWhereConst_ReachesBcMetadataAsTheObjectId()
+    {
+        var formula = new ParsedCalcFormula("Count", "ORW Source Row", null, new List<ParsedCalcFilter>
+        {
+            new("Table ID", ParsedCalcFilterKind.Const, null, "Database::\"ORW Referenced Row\""),
+        });
+
+        var meta = Invoke("BuildMetaCalcFormula", formula, ReferencingTable());
+        Assert.NotNull(meta);
+
+        var filter = Assert.Single(Enumerate(Get(meta!, "Filters")));
+        Assert.Equal("70981", (string)Get(filter, "FilterValue"));
+        // The const-ness is part of the claim: an id handed over as a FIELD filter would mean
+        // "field 70981 of the source table", which is a different and equally wrong metadata.
+        Assert.Equal("CONST", Get(filter, "FilterType").ToString());
+        Assert.Equal(2, (int)Get(filter, "FieldId"));
+    }
+
+    [Fact]
+    public void ACalcFormulaWhereConst_ThatIsNotAnObjectReference_IsStillPassedThroughUntouched()
+    {
+        // The control. A resolver applied too eagerly here would rewrite the 1215 const
+        // conditions the Base Application ships that are not object references.
+        var formula = new ParsedCalcFormula("Count", "ORW Source Row", null, new List<ParsedCalcFilter>
+        {
+            new("Table ID", ParsedCalcFilterKind.Const, null, "42"),
+        });
+
+        var meta = Invoke("BuildMetaCalcFormula", formula, ReferencingTable());
+        var filter = Assert.Single(Enumerate(Get(meta!, "Filters")));
+        Assert.Equal("42", (string)Get(filter, "FilterValue"));
+    }
+
+    // ── CALL SITES 1 AND 2: the TableRelation if() condition and where() filter ─────────────
+
+    [Fact]
+    public void ATableRelationIfConditionConst_ReachesBcMetadataAsTheObjectId()
+    {
+        // `TableRelation = if ("Coupled Count" = const(Report::"ORW Referenced Report"))
+        //                     "ORW Referenced Row"`. The condition is keyed on a field of the
+        // REFERENCING table, which is what makes this a distinct call site from the where().
+        var arm = new ParsedRelationArm("ORW Referenced Row", null,
+            new List<ParsedCalcFilter>
+            {
+                new("Coupled Count", ParsedCalcFilterKind.Const, null, "Report::\"ORW Referenced Report\""),
+            },
+            new List<ParsedCalcFilter>());
+
+        var relations = Invoke("BuildMetaFieldRelations",
+            new List<ParsedRelationArm> { arm }, ReferencingTable(), "Coupled Count");
+        Assert.NotNull(relations);
+
+        var relation = Assert.Single(Enumerate(relations!));
+        var condition = Assert.Single(Enumerate(Get(relation, "Conditions")));
+        Assert.Equal("70991", (string)Get(condition, "ConditionValue"));
+        Assert.Equal("CONST", Get(condition, "ConditionType").ToString());
+        Assert.Equal(2, (int)Get(condition, "FieldId"));
+    }
+
+    [Fact]
+    public void ATableRelationWhereConst_ReachesBcMetadataAsTheObjectId()
+    {
+        // `TableRelation = "ORW Source Row"."Entry No." where("Table ID" =
+        //                     const(Database::"ORW Referenced Row"))`. The where() is keyed on a
+        // field of the RELATED table — the other of the two call sites in this builder.
+        var arm = new ParsedRelationArm("ORW Source Row", "Entry No.",
+            new List<ParsedCalcFilter>(),
+            new List<ParsedCalcFilter>
+            {
+                new("Table ID", ParsedCalcFilterKind.Const, null, "Database::\"ORW Referenced Row\""),
+            });
+
+        var relations = Invoke("BuildMetaFieldRelations",
+            new List<ParsedRelationArm> { arm }, ReferencingTable(), "Coupled Count");
+        Assert.NotNull(relations);
+
+        var relation = Assert.Single(Enumerate(relations!));
+        var filter = Assert.Single(Enumerate(Get(relation, "Filters")));
+        Assert.Equal("70981", (string)Get(filter, "FilterValue"));
+        Assert.Equal("CONST", Get(filter, "FilterType").ToString());
+        Assert.Equal(2, (int)Get(filter, "FieldId"));
+    }
+
+    // ── plumbing ───────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Assign the metadata reflection statics RecordPatches.Register() would, from the
+    /// same Microsoft.Dynamics.Nav.Types types. Idempotent with Register(): identical values.</summary>
+    private void EnsureMetadataReflection()
+    {
+        var types = typeof(Microsoft.Dynamics.Nav.Types.Metadata.MetaTable).Assembly;
+        foreach (var (field, typeName) in new[]
+                 {
+                     ("_tMetaCalcFormula",  "Microsoft.Dynamics.Nav.Types.Metadata.MetaCalcFormula"),
+                     ("_tMetaFilter",       "Microsoft.Dynamics.Nav.Types.Metadata.MetaFilter"),
+                     ("_tMetaCondition",    "Microsoft.Dynamics.Nav.Types.Metadata.MetaCondition"),
+                     ("_tMetaFieldRelation","Microsoft.Dynamics.Nav.Types.Metadata.MetaFieldRelation"),
+                     ("_tFilterType",       "Microsoft.Dynamics.Nav.Types.Metadata.FilterType"),
+                 })
+        {
+            var t = types.GetType(typeName)
+                    ?? throw new InvalidOperationException($"{typeName} not found in {types.GetName().Name}.");
+            var f = Static(field);
+            _savedStatics[field] = f.GetValue(null);
+            f.SetValue(null, t);
+        }
+    }
+
+    private static FieldInfo Static(string name) =>
+        typeof(RecordPatches).GetField(name, BindingFlags.NonPublic | BindingFlags.Static)
+        ?? throw new InvalidOperationException($"RecordPatches.{name} not found — this test tracks that field.");
+
+    private static object? Invoke(string method, params object?[] args)
+    {
+        var m = typeof(RecordPatches).GetMethod(method, BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException($"RecordPatches.{method} not found — this test drives it.");
+        try { return m.Invoke(null, args); }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            throw new InvalidOperationException($"{method} threw: {tie.InnerException.Message}", tie.InnerException);
+        }
+    }
+
+    /// <summary>A property of a BC metadata object, by name. Throws listing what IS there rather
+    /// than returning null, so a renamed member on a future BC build reads as a named failure.</summary>
+    private static object Get(object target, string property)
+    {
+        var p = target.GetType().GetProperty(property, BindingFlags.Public | BindingFlags.Instance);
+        if (p == null)
+            throw new InvalidOperationException(
+                $"{target.GetType().FullName} has no property '{property}'. It has: " +
+                string.Join(", ", target.GetType().GetProperties().Select(x => x.Name)));
+        return p.GetValue(target)
+               ?? throw new InvalidOperationException($"{target.GetType().Name}.{property} was null.");
+    }
+
+    private static List<object> Enumerate(object immutableArrayOrList)
+        => ((IEnumerable)immutableArrayOrList).Cast<object>().ToList();
+}

--- a/AlRunner.Tests/ObjectReferenceConstResolutionTests.cs
+++ b/AlRunner.Tests/ObjectReferenceConstResolutionTests.cs
@@ -18,6 +18,18 @@
 //   NavNCLEvaluateException: The value "Database::"Customer"" can't be evaluated into type Integer
 // while the corpus stayed green.
 //
+// BARE VERSUS QUOTED (#3207)
+// -------------------------
+// This file's Theory comment claimed both spellings were covered when every fixture object had a
+// space in its name and so had to be quoted. Re-measured over the shipped BC 28.1 packages: of
+// the 22 Base Application CalcFormula properties carrying a Database:: const, 7 are written BARE
+// (Customer, Item, Currency, Vendor, Contact, Opportunity, Resource) and 15 are quoted; the 5
+// TableRelation ones are all quoted. The production code was already right — ConstValueText
+// strips only a matched pair of quotes — so this was a coverage gap and an overstated comment,
+// not a defect. It is a gap the corpus cannot fill either: every object it can name is
+// source-compiled, so the bare spelling on the precompiled SymbolReference route reaches no test
+// but this one.
+//
 // The pass-through arm matters as much as the resolving arm. ConstValueText hands a const literal
 // over as TEXT on purpose, because NCLMetaFilterConst evaluates it against the source field's own
 // type exactly as it does a user-typed filter — so an option member, a quoted literal and a
@@ -53,7 +65,8 @@ public sealed class ObjectReferenceConstResolutionTests : IDisposable
 
     // One .app declaring a table and a report whose NAMES need AL quoting (a space, and a period
     // in "Interaction Tmpl. Language"-style naming), plus a second table so a resolver answering
-    // with "the first table it finds" fails. Ids are far from any Base Application id so a hit
+    // with "the first table it finds" fails, plus a SINGLE-WORD table name that AL does not quote
+    // — see the bare-name note in the header. Ids are far from any Base Application id so a hit
     // cannot come from the real packages.
     // no-base-app-in-csharp-tests.md: a bare SymbolReference package, no application floor.
     private string WriteSymbolApp()
@@ -68,6 +81,8 @@ public sealed class ObjectReferenceConstResolutionTests : IDisposable
             { "Id": 70931, "Name": "ORC Coupling Row",
               "Fields": [ { "Id": 1, "Name": "Entry No.", "TypeDefinition": { "Name": "Integer" } } ] },
             { "Id": 70932, "Name": "ORC Other Row",
+              "Fields": [ { "Id": 1, "Name": "Entry No.", "TypeDefinition": { "Name": "Integer" } } ] },
+            { "Id": 70933, "Name": "ORCBareRow",
               "Fields": [ { "Id": 1, "Name": "Entry No.", "TypeDefinition": { "Name": "Integer" } } ] }
           ],
           "Reports": [ { "Id": 70941, "Name": "ORC Merge Report" } ],
@@ -88,10 +103,20 @@ public sealed class ObjectReferenceConstResolutionTests : IDisposable
     }
 
     [Theory]
-    // Database:: — the reported shape. Quoted and bare spellings of the SAME name must land on
-    // the same id, since AL quotes an identifier only when it has to.
+    // Database:: — the reported shape, in both spellings AL emits.
     [InlineData("Database::\"ORC Coupling Row\"", "70931")]
     [InlineData("Database::\"ORC Other Row\"", "70932")]
+    // BARE, i.e. no quotes at all, because AL quotes an identifier only when it has to. Seven of
+    // the 22 Base Application CalcFormula properties that carry a Database:: const are written
+    // this way — Customer, Item, Currency, Vendor, Contact, Opportunity, Resource, re-measured
+    // over the shipped BC 28.1 packages for #3207 — and until then no test anywhere, runner-local
+    // or corpus, asserted one. ConstValueText strips a
+    // matched pair of quotes and passes anything else through, so the quoted and bare spellings
+    // of the SAME name must land on the same id; both are asserted, because a resolver that
+    // stripped a fixed number of leading characters would satisfy one and not the other.
+    [InlineData("Database::ORCBareRow", "70933")]
+    [InlineData("Database::\"ORCBareRow\"", "70933")]
+    [InlineData("database::ORCBareRow", "70933")]
     // Report:: — the sibling the Base Application ships in 3 TableRelations.
     [InlineData("Report::\"ORC Merge Report\"", "70941")]
     // Codeunit:: — same syntax, resolved through the same object index.
@@ -134,6 +159,14 @@ public sealed class ObjectReferenceConstResolutionTests : IDisposable
         // And a name declared as a TABLE is not a REPORT: the kind is part of the lookup key.
         Assert.Equal("Report::\"ORC Coupling Row\"",
             RecordPatches.ResolveObjectReferenceConst("Report::\"ORC Coupling Row\""));
+
+        // Both halves again for a BARE name, which is the spelling seven Base Application
+        // CalcFormulas actually use: an undeclared one is kept as written rather than answered
+        // with 0 or with some other object's id, and the kind still discriminates.
+        Assert.Equal("Database::ORCNoSuchBareRow",
+            RecordPatches.ResolveObjectReferenceConst("Database::ORCNoSuchBareRow"));
+        Assert.Equal("Report::ORCBareRow",
+            RecordPatches.ResolveObjectReferenceConst("Report::ORCBareRow"));
     }
 
     [Fact]

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -284,6 +284,18 @@ public static partial class RecordPatches
             // SystemApp regression above is what that caution was warning about.
             ClearPerBundleBcAppPaths();
         }
+        // #3207: the object-reference const memo goes with them, and must be cleared HERE rather
+        // than left to expire — it has no expiry. ResolveObjectIdByKindAndName memoises
+        // (kind, name) -> id on top of ResolveTableIdByName / EnumerateKnownAlObjects, which read
+        // _parsedTables and _bcSymbolTableIndex, i.e. exactly the state the three statements above
+        // just discarded. Its doc comment justifies caching successes with "an id never changes
+        // once known", and that holds INSIDE a bundle and not across a reload: bundle 2 of a
+        // --server/--watch process declaring the same object name at a different id kept getting
+        // bundle 1's, so the memo defeated an invalidation its own dependency performs. The
+        // consequence is silent — a where() condition pinned to the wrong table id computes a
+        // plausible wrong number rather than failing — which is the failure #3205's own comment
+        // says it is avoiding, and the same shape as #2478 and #2755 in this same reset path.
+        _objectRefConstIds.Clear();
         _fieldTriggersWiredTables.Clear();
         _parsedPages.Clear();
         _parsedPageExtensions.Clear();


### PR DESCRIPTION
Closes #3207

Three commits, one subject: the object-reference const resolver added in #3205 — its cache lifetime, its coverage, and its wiring.

## 1. The fix: the memo outlived every input it was computed from

`RecordPatches._objectRefConstIds` is a process-global `ConcurrentDictionary` that nothing cleared. Verified against the merged tree rather than taken on report: three hits repo-wide (declaration, read, write), no eviction anywhere.

Its answer is derived from `ResolveTableIdByName` / `EnumerateKnownAlObjects`, which read `_parsedTables` and `_bcSymbolTableIndex`. `ResetForReload` clears `_parsedTables`, invalidates `_bcSymbolTableIndex` (#2478) and clears the registered `.app` set (#2755) — so the memo defeated an invalidation its own dependency performs. In a `--server` / `--watch` process, bundle 2 declaring the same object name at a different id kept getting bundle 1's id, and the `where()` condition was pinned to the wrong rows while every other index correctly described bundle 2. Silent: a FlowField whose condition names the wrong table sums a real number over the wrong rows.

One line in `ResetForReload`, plus the comment saying why.

### Does the omission have a sibling?

Asked three ways, and the answers are in both directions.

* **In the same file — no.** `RecordPatches.NclMetaTableBuilder.cs` holds three mutable statics: `_recordTypeCache` and `_fieldTriggersWiredTables` are both already cleared by `ResetForReload`; `_objectRefConstIds` was the only one missed. The reason it was missed is structural — the memo was added in the builder partial, and `ResetForReload` lives in `RecordPatches.cs`.
* **In the same reset path — yes, two, and they are not fixed here.** Scanning every static collection across the 58 `RecordPatches.*` partials for one that is never `Clear()`ed and is not either self-invalidating (`ConditionalWeakTable` keyed by provider instance) or nulled elsewhere leaves:
  * `_xmlPortsWithRealMetadata` / `_xmlPortsRealMetadataFailed` — **already tracked as #3172**, with the reason it was left out recorded in the file.
  * `_realMetaQueryCache` (`RecordPatches.NclMetaQueryBuilder.cs`) and `_lazyMetaQueryByGetById` (`RecordPatches.NclMetadataCachePopulator.cs`) — id-keyed caches of built `NCLMetaQuery` objects, while `ResetForReload` clears their primary `_metaQueryCache`. **Untracked; filed as #3210 rather than fixed here**, because building one needs the BC engine standing up in-process, which is the same blocker that kept #3172's fix out of #3011. Fixing them blind, with no proving test, is what this repo keeps paying for.

### RED → GREEN

`AlRunner.Tests/ObjectRefConstBundleBoundaryTests.cs` constructs the bundle boundary deliberately — register, resolve, `ResetForReload`, register a different package declaring the same names at different ids, resolve again. A single-bundle test cannot express this and would pass identically before and after; `ObjectReferenceConstResolutionTests.ResolvesRepeatedly` is exactly such a test and stays green on the broken build.

RED, running the new class alone on the merged tree:

```
TheMemoStillMemoises_WithinOneBundle_AndIsEmptiedByTheReload [FAIL]
  Assert.Empty() Failure: Collection was not empty
  Collection: [[Tuple ("Table", "orb shared table")] = 70821, [Tuple ("Report", "orb shared report")] = 70831]
AResolutionMemoisedInBundleOne_DoesNotSurviveTheReloadIntoBundleTwo [FAIL]
  Assert.Equal() Failure: Expected "70801"  Actual "70821"
```

The second failure is the defect in miniature: one test's memoised id answered another test's bundle-1 lookup through the process-global, and it broke the test's own precondition. GREEN after: `Passed: 2`.

Both directions are covered — a name that moves id must answer with the new id, and a name bundle 2 does not declare must go back to being unresolvable and come back as the text as written. The second test is the control that stops the fix from being "clear it so often it never caches": the memo must still hold both entries inside one bundle.

## 2. A comment that claimed coverage it did not have

`ObjectReferenceConstResolutionTests`' Theory comment said "Quoted and bare spellings of the SAME name must land on the same id". Every fixture object in that file has a space in its name, so every row was quoted and no bare name was ever resolved — runner-local or corpus.

Re-measured independently over the shipped BC 28.1 packages (walking every `SymbolReference.json`, classifying each `Database::`/`Report::` occurrence by the property containing it): of the **22** Base Application CalcFormula properties carrying a `Database::` const, **7 are bare** — `Customer`, `Item`, `Currency`, `Vendor`, `Contact`, `Opportunity`, `Resource` — and 15 are quoted; the 5 TableRelation ones (2 `Database::`, 3 `Report::`) are all quoted.

The production code was already right, so there is **no RED here** — `ConstValueText` strips only a matched pair of quotes. Falsified instead: a quoted-only resolver (an early return when the text after the prefix does not start with a quote) fails exactly the two new bare rows and nothing else, so they are not satisfiable by a no-op.

## 3. Closing the revert-detection gap (the standing caveat)

The caveat this work sits inside: #3205's runner-local test pins the resolver **in isolation**, so reverting all three call-site edits left the whole suite green, and the wiring is covered only by corpus codeunit 60329, which this repository does not run yet — the pin is deliberately held behind `master` by #3152. **The pin is not bumped here.**

`AlRunner.Tests/ObjectRefConstCallSiteWiringTests.cs` closes it runner-locally: each of the three sites is driven through the real private builder with real `Microsoft.Dynamics.Nav.Types.Metadata` objects coming back out, and the referenced table and report are declared **only** in a registered SymbolReference package — the precompiled route the corpus structurally cannot reach, since every object a corpus test can name is source-compiled.

Falsified one site at a time by reverting each to the pre-#3205 `Value ?? ""`:

| reverted site | test that fails | others |
|---|---|---|
| TableRelation `if()` condition | `ATableRelationIfConditionConst_ReachesBcMetadataAsTheObjectId` | 3 pass |
| TableRelation `where()` filter | `ATableRelationWhereConst_ReachesBcMetadataAsTheObjectId` | 3 pass |
| CalcFormula `where()` filter | `ACalcFormulaWhereConst_ReachesBcMetadataAsTheObjectId` | 3 pass |

One-to-one, so a reverted site names itself. The fourth test is the control: a const that is not an object reference reaches BC untouched.

## Is anything here a claim about BC?

No. Task 1 is the lifetime of a runner cache across the runner's own bundle-reload boundary — a concept BC does not have. Task 2's *subject* is BC-observable, and that claim is already asked upstream on a real service tier in corpus codeunit 60329; what is added here is a runner-local test of the same resolver on the precompiled `SymbolReference` route, which the corpus cannot express. Nothing restates an upstream assertion, and no corpus PR is needed.

## What was run

* `ObjectRefConstBundleBoundaryTests`, `ObjectRefConstCallSiteWiringTests`, `ObjectReferenceConstResolutionTests` — 25 passed.
* Tree-asserting guards and the reset-path neighbours — `VirtualTableRefusalClaimTests`, `BaseAppFloorFixtureGuardTests`, `FieldTriggerShapeGapCallSiteTests`, `BcAppPathsResetTests`, `BcAppRegistrationEpochInvalidationTests`, `RecordPatchesWarmReloadExtensionIndexTests` — 153 passed, 30 skipped.
* Every remaining test class that touches `ResetForReload` — `DependencyMetadataMemoInvalidationTests`, `InstallBaselineKeySymbolStateTests`, `ObjectEventSubscriberRegistrationMechanismTests`, `PageRealMetadataEpochRevalidationTests`, `ParserStaticsIsolationGuardTests`, `PermissionSetSymbolReadFailureTests`, `RecordPatchesBcAppSymbolReadFailureTests`, `RecordPatchesWarmReloadInstallBaselineTests`, `RecordPatchesWarmReparseTests`, `VirtualTableBitClearingTests` — 67 passed, 8 skipped.

The `Watch*` classes that spawn the runner were left to CI. No claim is made about any suite not listed.

## Deliberately left out

* The two query-metadata caches above — #3210, not fixed blind (proving either needs the BC engine in-process, the same blocker recorded on #3172).
* The submodule pin, for the three reasons in #3152's thread.
* Fixtures declare `SymbolReference.json` only, never an application floor (`no-base-app-in-csharp-tests.md`).

---

*Written by the automated implementation agent `stma-auto-1` (cycle 146) on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
