### PR TITLE
fix(test-exec): order a codeunit's test methods by a key that does not depend on reflection order

### DIFF
--- a/AlRunner.Tests/TestMethodOrderingContractTests.cs
+++ b/AlRunner.Tests/TestMethodOrderingContractTests.cs
@@ -1,0 +1,348 @@
+// TestMethodOrderingContractTests — the order a codeunit's [Test] procedures run in must be a
+// function of the METHODS, never of the array `Type.GetMethods()` happened to hand back (#3201).
+//
+// WHY THIS IS A CONTRACT TEST AND NOT AN END-TO-END ONE. `OrderTestMethodsBySourceDeclaration`
+// sorts by the AL declaration line recovered from each procedure's `{Name}_Scope_<hash>` nested
+// type (#1766). When every line resolves — which is what an AL fixture produces, every time —
+// the result is fully determined and the fallback below is unreachable. The defect lives in the
+// two paths where a line does NOT resolve, so the only way to observe it is to hand the
+// comparator a line map that is empty or partial. `TestCodeunitExecutionOrderTests` covers the
+// resolved path end to end through the AL compiler and stays the guard for that.
+//
+// WHY IT CANNOT PASS BY LUCK. `Type.GetMethods()` has no defined order — that is the whole
+// defect — so a test that fed the methods in one fixed sequence and asserted one expected
+// sequence would be asserting this box's reflection layout. Every case below instead runs ALL
+// permutations of the input and requires a single answer across them: an implementation that
+// carries any input-order dependence through to its output produces n! different results and
+// fails, whatever `GetMethods()` returns on the day. That is the same property #2801 needed and
+// the reason its fixture had to engineer a deterministic wrong answer — permutation invariance
+// gets it without engineering anything.
+using System.Reflection;
+using System.Reflection.Emit;
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestMethodOrderingContractTests : IDisposable
+{
+    /// <summary>
+    /// `TestExecutor.IsTestMethod` matches on the attribute's NAME ("TestAttribute" /
+    /// "NavTestAttribute"), so a local attribute of that name marks a probe procedure without
+    /// dragging in BC's Ncl or the AL compiler.
+    /// </summary>
+    private sealed class TestAttribute : Attribute { }
+
+    /// <summary>
+    /// Declared deliberately in neither alphabetical nor any other meaningful order. Nothing in
+    /// the assertions depends on that — the permutation sweeps make declaration order in this
+    /// file irrelevant — but it keeps a reader from mistaking C# declaration order for the rule.
+    /// </summary>
+    private sealed class ProbeCodeunit
+    {
+        [Test] public void Zeta() { }
+        [Test] public void Alpha() { }
+        [Test] public void Mid() { }
+        [Test] public void Dup(int a) { }
+        [Test] public void Dup(string a) { }
+    }
+
+    private static MethodInfo M(string name) =>
+        typeof(ProbeCodeunit).GetMethod(name, BindingFlags.Public | BindingFlags.Instance)!;
+
+    private static MethodInfo Dup(Type param) =>
+        typeof(ProbeCodeunit).GetMethod("Dup", BindingFlags.Public | BindingFlags.Instance,
+            binder: null, types: new[] { param }, modifiers: null)!;
+
+    private static readonly MethodInfo Zeta = M("Zeta");
+    private static readonly MethodInfo Alpha = M("Alpha");
+    private static readonly MethodInfo MidM = M("Mid");
+
+    public void Dispose() => TestExecutor.ResetSignatureSpanAttrTypeForTests();
+
+    /// <summary>Every ordering of <paramref name="methods"/>, so no case depends on one input sequence.</summary>
+    private static IEnumerable<MethodInfo[]> Permutations(MethodInfo[] methods)
+    {
+        if (methods.Length <= 1) { yield return methods; yield break; }
+        for (var i = 0; i < methods.Length; i++)
+        {
+            var rest = methods.Where((_, j) => j != i).ToArray();
+            foreach (var tail in Permutations(rest))
+                yield return new[] { methods[i] }.Concat(tail).ToArray();
+        }
+    }
+
+    /// <summary>
+    /// Runs the comparator over every permutation of <paramref name="methods"/> and asserts all
+    /// of them produced <paramref name="expected"/> — the single assertion that makes the output
+    /// a function of the method set rather than of the input array.
+    /// </summary>
+    private static void AssertOrderIsPermutationInvariant(
+        MethodInfo[] methods, IReadOnlyDictionary<MethodInfo, int> lines, string[] expected)
+    {
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        var permutationCount = 0;
+        foreach (var perm in Permutations(methods))
+        {
+            permutationCount++;
+            var ordered = TestExecutor.OrderMethodsByDeclarationLine(perm, lines);
+            seen.Add(string.Join(",", ordered.Select(Describe)));
+
+            // Ordering may never change WHAT runs — a comparator that dropped or duplicated a
+            // method could still be "deterministic" and satisfy the sequence check alone.
+            Assert.Equal(
+                perm.Select(Describe).OrderBy(x => x, StringComparer.Ordinal).ToArray(),
+                ordered.Select(Describe).OrderBy(x => x, StringComparer.Ordinal).ToArray());
+        }
+
+        Assert.True(permutationCount > 1, "the sweep must cover more than one input order");
+        Assert.True(seen.Count == 1,
+            $"method order must be a function of the methods, not of the Type.GetMethods() array "
+            + $"they arrived in. {permutationCount} input permutations produced {seen.Count} "
+            + $"different orders:\n  " + string.Join("\n  ", seen.OrderBy(x => x, StringComparer.Ordinal)));
+        Assert.Equal(string.Join(",", expected), seen.Single());
+    }
+
+    private static string Describe(MethodInfo m) =>
+        m.GetParameters().Length == 0
+            ? m.Name
+            : $"{m.Name}({string.Join(",", m.GetParameters().Select(p => p.ParameterType.Name))})";
+
+    // ── the two fallback paths ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// TOTAL fallback: not one line resolved. The old code returned the reflection array
+    /// untouched ("keep original order"), so the answer was whatever the CLR handed over.
+    /// </summary>
+    [Fact]
+    public void NoLineResolves_OrderIsStillAFunctionOfTheMethods()
+    {
+        AssertOrderIsPermutationInvariant(
+            new[] { Zeta, Alpha, MidM },
+            new Dictionary<MethodInfo, int>(),
+            new[] { "Alpha", "Mid", "Zeta" });
+    }
+
+    /// <summary>
+    /// PARTIAL fallback: one line resolved, two did not. The resolved one leads (it has a real
+    /// declaration position); the rest may not be ordered by their index in an undefined array.
+    /// </summary>
+    [Fact]
+    public void SomeLinesResolve_UnresolvedTailIsOrderedDeterministically()
+    {
+        AssertOrderIsPermutationInvariant(
+            new[] { Zeta, Alpha, MidM },
+            new Dictionary<MethodInfo, int> { [Zeta] = 10 },
+            new[] { "Zeta", "Alpha", "Mid" });
+    }
+
+    /// <summary>
+    /// The third instance of the same shape: two procedures that resolve to the SAME line tie,
+    /// and the tie used to be broken by the undefined index too.
+    /// </summary>
+    [Fact]
+    public void MethodsSharingADeclarationLine_TieBreakDeterministically()
+    {
+        AssertOrderIsPermutationInvariant(
+            new[] { Zeta, Alpha, MidM },
+            new Dictionary<MethodInfo, int> { [Alpha] = 5, [Zeta] = 5, [MidM] = 9 },
+            new[] { "Alpha", "Zeta", "Mid" });
+    }
+
+    /// <summary>
+    /// Overloads share a name, so the name alone is not a total key. Both are unresolved here,
+    /// which is the case where the tiebreak is doing all the work.
+    /// </summary>
+    [Fact]
+    public void UnresolvedOverloads_AreSeparatedByTheirSignature()
+    {
+        AssertOrderIsPermutationInvariant(
+            new[] { Dup(typeof(string)), Dup(typeof(int)) },
+            new Dictionary<MethodInfo, int>(),
+            new[] { "Dup(Int32)", "Dup(String)" });
+    }
+
+    // ── the resolved path must not regress ────────────────────────────────────────────────
+
+    /// <summary>
+    /// NEGATIVE CONTROL, and the reason the cases above cannot be satisfied by deleting the
+    /// line lookup and sorting by name. Declaration line beats name whenever it is known: these
+    /// three resolve to lines whose order is the exact REVERSE of alphabetical, so a plain name
+    /// sort inverts all three and fails. This case passes both before and after the fix, by
+    /// design — it pins the #1766 rule the fix must leave alone.
+    /// </summary>
+    [Fact]
+    public void ResolvedDeclarationLines_OutrankTheNameTieBreak()
+    {
+        AssertOrderIsPermutationInvariant(
+            new[] { Zeta, Alpha, MidM },
+            new Dictionary<MethodInfo, int> { [Alpha] = 30, [MidM] = 20, [Zeta] = 10 },
+            new[] { "Zeta", "Mid", "Alpha" });
+    }
+
+    /// <summary>
+    /// A resolved method always precedes an unresolved one, however the names compare. `Alpha`
+    /// sorts first by name and last by line here, so a comparator that let the fallback key leak
+    /// ahead of the line key would put it first.
+    /// </summary>
+    [Fact]
+    public void AResolvedMethodAlwaysPrecedesAnUnresolvedOne()
+    {
+        AssertOrderIsPermutationInvariant(
+            new[] { Zeta, Alpha, MidM },
+            new Dictionary<MethodInfo, int> { [MidM] = 7, [Zeta] = 3 },
+            new[] { "Zeta", "Mid", "Alpha" });
+    }
+
+    // ── the diagnostic ────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Silence is the defect (.claude/rules/loud-failures.md): a run whose source order quietly
+    /// degraded looked exactly like one that did not.
+    /// </summary>
+    [Fact]
+    public void UnresolvedTestProcedures_ProduceADiagnostic()
+    {
+        var methods = new[] { Zeta, Alpha, MidM };
+        var warning = TestExecutor.DescribeUnresolvedTestMethodOrder(
+            typeof(ProbeCodeunit), methods,
+            new Dictionary<MethodInfo, int> { [Zeta] = 3 },
+            resolverAvailable: true);
+
+        Assert.NotNull(warning);
+        var text = warning!;
+        Assert.Contains("ProbeCodeunit", text);
+        Assert.Contains("2 of 3", text);
+        Assert.Contains("Alpha", text);
+        Assert.Contains("Mid", text);
+        Assert.DoesNotContain("Zeta", text);
+    }
+
+    /// <summary>
+    /// NEGATIVE, and the half that decides whether the diagnostic is usable at all.
+    /// `GetMethods(Public|Instance)` also returns every inherited framework method — `ToString`,
+    /// `Equals`, `GetHashCode`, `GetType` — none of which has an AL declaration line or ever
+    /// will. Counting those would put a warning on every codeunit of every green run, and a
+    /// warning that is always on is the same silence in a louder font.
+    /// </summary>
+    [Fact]
+    public void FrameworkMethodsWithNoAlDeclarationLine_ProduceNoDiagnostic()
+    {
+        var all = typeof(ProbeCodeunit).GetMethods(BindingFlags.Public | BindingFlags.Instance);
+        Assert.Contains(all, m => m.Name == "ToString");   // the inherited methods really are here
+
+        var lines = new Dictionary<MethodInfo, int>
+        {
+            [Zeta] = 3, [Alpha] = 6, [MidM] = 9,
+            [Dup(typeof(int))] = 12, [Dup(typeof(string))] = 15,
+        };
+        Assert.Null(TestExecutor.DescribeUnresolvedTestMethodOrder(
+            typeof(ProbeCodeunit), all, lines, resolverAvailable: true));
+    }
+
+    /// <summary>The resolver being absent entirely is its own message — every line is missing.</summary>
+    [Fact]
+    public void ResolverUnavailable_ProducesItsOwnDiagnostic()
+    {
+        var warning = TestExecutor.DescribeUnresolvedTestMethodOrder(
+            typeof(ProbeCodeunit), new[] { Zeta, Alpha },
+            new Dictionary<MethodInfo, int>(), resolverAvailable: false);
+
+        Assert.NotNull(warning);
+        Assert.Contains("SignatureSpanAttribute", warning!);
+    }
+
+    // ── the SignatureSpanAttribute latch ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// An assembly carrying a type with the exact full name the resolver looks for, built at
+    /// runtime so the test needs neither BC's Ncl nor a type squatting in Microsoft's namespace
+    /// inside this test assembly.
+    /// </summary>
+    private static Assembly AssemblyDeclaringSignatureSpanAttribute()
+    {
+        var ab = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName("SigSpanProbe_" + Guid.NewGuid().ToString("N")), AssemblyBuilderAccess.Run);
+        var mb = ab.DefineDynamicModule("m");
+        mb.DefineType(TestExecutor.SignatureSpanAttrTypeName, TypeAttributes.Public, typeof(Attribute))
+          .CreateType();
+        Assert.NotNull(ab.GetType(TestExecutor.SignatureSpanAttrTypeName));
+        return ab;
+    }
+
+    /// <summary>
+    /// The first candidate trigger #3201 names. The flag was set BEFORE the search, and stayed
+    /// set when the search found nothing — so a single call landing before Ncl was loaded
+    /// disabled source-order dispatch for the whole process, permanently and silently. A miss
+    /// must leave the resolver willing to look again.
+    /// </summary>
+    [Fact]
+    public void AFailedSearch_DoesNotPoisonTheResolverForTheRestOfTheProcess()
+    {
+        TestExecutor.ResetSignatureSpanAttrTypeForTests();
+        var nothing = new Func<IEnumerable<Assembly>>(Array.Empty<Assembly>);
+
+        Assert.Null(TestExecutor.ResolveSignatureSpanAttrType(nothing));
+        Assert.Equal(1, TestExecutor.SignatureSpanAttrSearchCount);
+
+        Assert.Null(TestExecutor.ResolveSignatureSpanAttrType(nothing));
+        Assert.Equal(2, TestExecutor.SignatureSpanAttrSearchCount);
+
+        // Ncl shows up late — as it does when the first ordering call beats the load.
+        var withIt = AssemblyDeclaringSignatureSpanAttribute();
+        Assert.NotNull(TestExecutor.ResolveSignatureSpanAttrType(() => new[] { withIt }));
+
+        // Found once, then cached: a success DOES latch, so this is not a per-codeunit rescan.
+        var searchesAfterSuccess = TestExecutor.SignatureSpanAttrSearchCount;
+        Assert.NotNull(TestExecutor.ResolveSignatureSpanAttrType(nothing));
+        Assert.Equal(searchesAfterSuccess, TestExecutor.SignatureSpanAttrSearchCount);
+    }
+
+    /// <summary>
+    /// The second half of the same defect, and the one the issue calls "a concurrent second
+    /// caller reading the field mid-search". Publishing `resolved = true` before the value meant
+    /// a reader that arrived while the scan was still walking assemblies got `null` and silently
+    /// fell back — and, because the caller memoises per type, kept the wrong order afterwards.
+    ///
+    /// Deterministic in both directions, not a timing probe: the reader is released only once
+    /// the writer is provably inside the scan, so under the old code it always observed the
+    /// latched-but-empty window, and under a correct one it can never observe a `null` it would
+    /// act on.
+    /// </summary>
+    [Fact]
+    public void AReaderArrivingMidSearch_NeverSeesTheEmptyWindow()
+    {
+        TestExecutor.ResetSignatureSpanAttrTypeForTests();
+        var real = AssemblyDeclaringSignatureSpanAttribute();
+
+        using var writerIsInsideTheScan = new ManualResetEventSlim(false);
+        using var readerHasCalled = new ManualResetEventSlim(false);
+
+        IEnumerable<Assembly> SlowScan()
+        {
+            // A decoy first, so the scan is genuinely mid-walk and has not yet found anything.
+            yield return typeof(TestMethodOrderingContractTests).Assembly;
+            writerIsInsideTheScan.Set();
+            Assert.True(readerHasCalled.Wait(TimeSpan.FromSeconds(30)));
+            yield return real;
+        }
+
+        Type? readerSaw = null;
+        var reader = new Thread(() =>
+        {
+            Assert.True(writerIsInsideTheScan.Wait(TimeSpan.FromSeconds(30)));
+            readerHasCalled.Set();
+            readerSaw = TestExecutor.ResolveSignatureSpanAttrType(
+                () => throw new InvalidOperationException(
+                    "the reader must never start a second scan of its own"));
+        });
+        reader.Start();
+
+        var writerSaw = TestExecutor.ResolveSignatureSpanAttrType(SlowScan);
+        Assert.True(reader.Join(TimeSpan.FromSeconds(60)), "the reader thread did not finish");
+
+        Assert.NotNull(writerSaw);
+        Assert.NotNull(readerSaw);
+        Assert.Same(writerSaw, readerSaw);
+    }
+}

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -1173,37 +1173,197 @@ public sealed class TestExecutor
 
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, int?> _objectIdCache = new();
 
-    private static MethodInfo[] OrderTestMethodsBySourceDeclaration(Type t) =>
-        _sourceOrderCache.GetOrAdd(t, static type =>
-        {
-            var methods = type.GetMethods(BindingFlags.Public | BindingFlags.Instance);
-            var lineByMethod = ResolveSignatureLines(type, methods);
-            if (lineByMethod.Count == 0) return methods; // nothing resolved — keep original order
-            // Stable: a method whose line we couldn't resolve keeps its relative
-            // reflection-order position, sorted after every line we DID resolve.
-            return methods
-                .Select((m, i) => (m, i, line: lineByMethod.TryGetValue(m, out var l) ? l : int.MaxValue))
-                .OrderBy(x => x.line)
-                .ThenBy(x => x.i)
-                .Select(x => x.m)
-                .ToArray();
-        });
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, bool>
+        _orderWarningIssued = new();
 
-    private static Dictionary<MethodInfo, int> ResolveSignatureLines(Type codeunitType, MethodInfo[] methods)
+    private static MethodInfo[] OrderTestMethodsBySourceDeclaration(Type t)
+    {
+        if (_sourceOrderCache.TryGetValue(t, out var cached)) return cached;
+
+        var methods = t.GetMethods(BindingFlags.Public | BindingFlags.Instance);
+        var lineByMethod = ResolveSignatureLines(t, methods, out var resolverAvailable);
+        var ordered = OrderMethodsByDeclarationLine(methods, lineByMethod);
+
+        // #3201 / .claude/rules/loud-failures.md: degrading to a fallback order is a real
+        // change of behaviour, so it says so. Once per codeunit, and only when an actual
+        // [Test] procedure failed to resolve — never for the inherited framework members
+        // that can never have an AL line (see DescribeUnresolvedTestMethodOrder).
+        var warning = DescribeUnresolvedTestMethodOrder(t, methods, lineByMethod, resolverAvailable);
+        if (warning != null && _orderWarningIssued.TryAdd(t, true))
+            Console.Error.WriteLine(warning);
+
+        // Memoise only once the SignatureSpanAttribute lookup has actually succeeded. Before
+        // that the map is empty for a reason that can still go away — Ncl not yet loaded — and
+        // caching it would pin the degraded order for this type for the rest of the process,
+        // which is the more damaging half of #3201. GetOrAdd's single-computation guarantee is
+        // deliberately given up with it: the result is now a pure function of the method set,
+        // so two racing callers compute equal arrays and neither can win a different answer.
+        if (resolverAvailable) _sourceOrderCache.TryAdd(t, ordered);
+        return ordered;
+    }
+
+    /// <summary>
+    /// Order <paramref name="methods"/> by AL source declaration line, breaking every tie with
+    /// a stable key derived from the method itself.
+    ///
+    /// <para><b>The fallback may not be reflection order (#3201).</b> This used to return the
+    /// <c>Type.GetMethods()</c> array untouched when no line resolved, and to break ties — both
+    /// between unresolved methods and between two methods on the SAME line — with each method's
+    /// index in that array. The CLR defines no order for it, so in all three cases the execution
+    /// order of a codeunit's <c>[Test]</c> procedures was undefined: the same defect class as
+    /// the <c>Assembly.GetTypes()</c> walk in #2801, one level down. That one was not
+    /// theoretical — it reversed two codeunits on a 28.4 leg while 27.5 passed, because the two
+    /// compilers laid their TypeDefs out differently.</para>
+    ///
+    /// <para><b>Why the name, and not the metadata token.</b> The token IS that compiler layout,
+    /// so tie-breaking on it would reproduce #2801's failure exactly: deterministic within one
+    /// process, different between two BC compiler versions, and therefore a green leg and a red
+    /// leg on one commit. An ordinal comparison of name + signature depends on nothing but the
+    /// methods, so it holds across processes, across BC versions and across CLR
+    /// implementations.</para>
+    ///
+    /// <para>This is <b>not</b> a claim about what BC does. Real BC always knows a procedure's
+    /// declaration position, so it has no fallback to have behaviour in; the rule it does have —
+    /// AL source declaration order (#1766) — is the primary key here and is unchanged. What the
+    /// name key decides is only the order among procedures whose line THIS RUNNER could not
+    /// recover, which is a runner-internal metadata gap with no BC counterpart.</para>
+    /// </summary>
+    internal static MethodInfo[] OrderMethodsByDeclarationLine(
+        MethodInfo[] methods, IReadOnlyDictionary<MethodInfo, int> lineByMethod) =>
+        methods
+            .OrderBy(m => lineByMethod.TryGetValue(m, out var l) ? l : int.MaxValue)
+            .ThenBy(StableMethodKey, StringComparer.Ordinal)
+            .ToArray();
+
+    /// <summary>
+    /// A total, reflection-order-independent sort key. The name alone is not one: overloads
+    /// share it, so the parameter types and the declaring type join it — the latter because a
+    /// derived type may shadow an inherited member of identical signature with <c>new</c>.
+    /// </summary>
+    internal static string StableMethodKey(MethodInfo m)
+    {
+        var sb = new System.Text.StringBuilder(m.Name);
+        if (m.IsGenericMethodDefinition) sb.Append('`').Append(m.GetGenericArguments().Length);
+        sb.Append('(');
+        var ps = m.GetParameters();
+        for (var i = 0; i < ps.Length; i++)
+        {
+            if (i > 0) sb.Append(',');
+            sb.Append(ps[i].ParameterType.ToString());
+        }
+        return sb.Append(")@").Append(m.DeclaringType?.FullName ?? "").ToString();
+    }
+
+    /// <summary>
+    /// The message to print when a codeunit's <c>[Test]</c> procedures did not all resolve to a
+    /// declaration line, or <c>null</c> when there is nothing to report.
+    ///
+    /// <para>The filter is the whole design. <c>GetMethods(Public | Instance)</c> also returns
+    /// every INHERITED framework member — <c>ToString</c>, <c>Equals</c>, <c>GetHashCode</c>,
+    /// <c>GetType</c>, and <c>NavApplicationObjectBase</c>'s own — none of which has an AL
+    /// declaration line or ever could. Counting those would put a warning on every codeunit of
+    /// every green run, and a warning that is always on is the same silence in a louder font. So
+    /// only <c>[Test]</c> procedures DECLARED BY this codeunit count, which makes the message
+    /// fire exactly when the #1766 source-order contract has actually been dropped.</para>
+    /// </summary>
+    internal static string? DescribeUnresolvedTestMethodOrder(
+        Type codeunitType, MethodInfo[] methods,
+        IReadOnlyDictionary<MethodInfo, int> lineByMethod, bool resolverAvailable)
+    {
+        var alTests = methods.Where(m => IsTestMethod(m) && m.DeclaringType == codeunitType).ToArray();
+        if (alTests.Length == 0) return null;
+        var unresolved = alTests.Where(m => !lineByMethod.ContainsKey(m)).ToArray();
+        if (unresolved.Length == 0) return null;
+
+        var why = resolverAvailable
+            ? "no \"{procedure}_Scope_<hash>\" nested type carrying a readable SignatureSpanAttribute"
+            : $"the {SignatureSpanAttrTypeName} type is not loaded in this process";
+        return $"[test-exec] WARNING: {codeunitType.Name}: {unresolved.Length} of {alTests.Length} "
+             + $"[Test] procedure(s) have no resolvable AL declaration line ({why}). They run "
+             + "after every procedure that did resolve, ordered by name — NOT in AL source "
+             + "declaration order, which is what real BC uses and what this runner otherwise "
+             + "guarantees. A test relying on an earlier test's state may therefore run first. "
+             + "See StefanMaron/BusinessCentral.AL.Runner#3201. Affected: "
+             + string.Join(", ", unresolved.Select(m => m.Name).OrderBy(x => x, StringComparer.Ordinal));
+    }
+
+    internal const string SignatureSpanAttrTypeName =
+        "Microsoft.Dynamics.Nav.Runtime.SignatureSpanAttribute";
+
+    /// <summary>Number of times the assembly scan below has actually run. Test seam.</summary>
+    internal static int SignatureSpanAttrSearchCount;
+
+    /// <summary>
+    /// The <c>SignatureSpanAttribute</c> type, searched for once and then cached.
+    /// </summary>
+    private static readonly object _signatureSpanAttrGate = new();
+
+    /// <summary>
+    /// The <c>SignatureSpanAttribute</c> type, searched for once and then cached — the metadata
+    /// every AL declaration line is read out of, so a null here silently disables source-order
+    /// dispatch for whatever calls arrive while it lasts.
+    ///
+    /// <para><b>Two things it must not do (#3201).</b> It must not publish "resolved" before the
+    /// value: the old code set the flag and THEN walked the assemblies, writing the shared field
+    /// on every miss, so a second thread arriving mid-walk read <c>resolved == true</c> alongside
+    /// a null type, got an empty line map, and had its degraded order memoised by the caller. And
+    /// it must not latch a FAILURE: a first call landing before Ncl is loaded would otherwise
+    /// answer null for the entire process, permanently, with nothing on stderr to say the
+    /// runner had stopped honouring #1766.</para>
+    ///
+    /// <para>A success still latches, so this stays one scan per process rather than one per
+    /// codeunit; only the miss is retried, and a miss means the caller is about to warn anyway.</para>
+    /// </summary>
+    internal static Type? ResolveSignatureSpanAttrType(Func<IEnumerable<Assembly>> assemblySource)
+    {
+        if (System.Threading.Volatile.Read(ref _signatureSpanAttrTypeResolved))
+            return _signatureSpanAttrType;
+
+        lock (_signatureSpanAttrGate)
+        {
+            if (_signatureSpanAttrTypeResolved) return _signatureSpanAttrType;
+            System.Threading.Interlocked.Increment(ref SignatureSpanAttrSearchCount);
+
+            Type? found = null;
+            foreach (var asm in assemblySource())
+            {
+                // A dynamic or otherwise uncooperative assembly must not abort the scan and
+                // leave a later one unexamined.
+                try { found = asm.GetType(SignatureSpanAttrTypeName); }
+                catch { found = null; }
+                if (found != null) break;
+            }
+            if (found == null) return null; // deliberately NOT latched — Ncl may load later
+
+            _signatureSpanAttrType = found;
+            System.Threading.Volatile.Write(ref _signatureSpanAttrTypeResolved, true);
+            return found;
+        }
+    }
+
+    internal static void ResetSignatureSpanAttrTypeForTests()
+    {
+        _signatureSpanAttrTypeResolved = false;
+        _signatureSpanAttrType = null;
+        SignatureSpanAttrSearchCount = 0;
+        // Both are keyed on the resolver having worked; leaving them would carry an order
+        // computed under the old state into the next test.
+        _sourceOrderCache.Clear();
+        _orderWarningIssued.Clear();
+    }
+
+    /// <param name="resolverAvailable">
+    /// False when the <c>SignatureSpanAttribute</c> type itself could not be found, which makes
+    /// an empty result provisional rather than settled — the caller must not memoise it (#3201).
+    /// </param>
+    private static Dictionary<MethodInfo, int> ResolveSignatureLines(
+        Type codeunitType, MethodInfo[] methods, out bool resolverAvailable)
     {
         var result = new Dictionary<MethodInfo, int>();
-        if (!_signatureSpanAttrTypeResolved)
-        {
-            _signatureSpanAttrTypeResolved = true;
-            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
-            {
-                _signatureSpanAttrType = asm.GetType("Microsoft.Dynamics.Nav.Runtime.SignatureSpanAttribute");
-                if (_signatureSpanAttrType != null) break;
-            }
-        }
-        var tSig = _signatureSpanAttrType;
+        var tSig = ResolveSignatureSpanAttrType(static () => AppDomain.CurrentDomain.GetAssemblies());
         var piSig = tSig?.GetProperty("EncodedSpan");
-        if (tSig == null || piSig == null) return result;
+        resolverAvailable = tSig != null && piSig != null;
+        if (!resolverAvailable) return result;
 
         var nested = codeunitType.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic);
         foreach (var m in methods)


### PR DESCRIPTION
Closes #3201

`OrderTestMethodsBySourceDeclaration` decides the order a codeunit's `[Test]` procedures run
in, sorting by the AL declaration line recovered from each procedure's `{Name}_Scope_<hash>`
nested type (#1766). Three paths through it fell back to `Type.GetMethods()` order, which the
CLR does not define:

| path | what it did |
|---|---|
| nothing resolved | `return methods` untouched — commented "keep original order" |
| some resolved | the rest got `int.MaxValue` and `.ThenBy(index-in-that-same-array)` |
| two on the same line | that same index decided which ran first |

The issue reported the first. The second and third are the same defect and were found by
grepping the shape rather than the symptom; all three are fixed together.

## What the order should be, and the evidence

**Primary key: unchanged.** AL source declaration line, which is #1766's rule and is what real
BC does. Nothing in this PR touches it.

**Tiebreak: an ordinal comparison of name + parameter types + declaring type.** The evidence is
negative and specific — it is a choice *against* the obvious alternative. `MethodInfo.MetadataToken`
would also be deterministic, and it is the wrong answer, because the token **is** the AL
compiler's member layout. #3082's own commit message records what that costs: undefined
`Assembly.GetTypes()` order reversed two codeunits on a BC 28.4 leg while the same commit's 27.5
leg passed, because the two compilers laid their TypeDefs out differently, and three later PRs
had to be rebased past the resulting red. Tie-breaking on the token reproduces that exactly —
stable within a process, different between BC versions. An ordinal name comparison depends on
nothing but the methods themselves, so it holds across processes, BC versions and CLR
implementations. The name alone is not a total key (overloads share it), hence the signature and
declaring type.

## Runner-internal, not a BC claim — so no corpus PR

**(a), runner-internal determinism.** Real BC always knows a procedure's declaration position;
it has no fallback, so there is no BC behaviour here to be right or wrong about. The only
question this key answers is *"in what order do procedures whose declaration line THIS RUNNER
failed to recover run"*, which is a runner metadata-resolution gap with no counterpart upstream.
No AL a corpus test could write distinguishes it — by construction, since a corpus test compiled
by the AL compiler always resolves, which is why the issue reports no reproducer.

The BC-behaviour claim in this area (source declaration order) already exists, is unchanged, and
is already covered end to end by `TestCodeunitExecutionOrderTests.MethodsWithinACodeunit_KeepSourceDeclarationOrder`
through the real AL compiler.

## How the test resists passing by luck

The failure mode is *undefined* order, so asserting one expected sequence from one input
sequence would just be asserting this box's reflection layout — the trap the brief for #2801
described. Every case in `AlRunner.Tests/TestMethodOrderingContractTests.cs` instead runs **all
permutations of its input and requires a single answer across them**. An implementation carrying
any input-order dependence through to its output produces n! results and fails, whatever
`GetMethods()` returns on the day. Each case also asserts the specific expected sequence, and
that the output is a permutation of its input (so dropping or duplicating a method cannot pass).

Three negative controls, and they are what keep the fix from being "sort by name":

- `ResolvedDeclarationLines_OutrankTheNameTieBreak` — three lines whose order is the exact
  reverse of alphabetical. A name sort inverts all three.
- `AResolvedMethodAlwaysPrecedesAnUnresolvedOne` — the method that sorts *first* by name sorts
  *last* by line.
- `FrameworkMethodsWithNoAlDeclarationLine_ProduceNoDiagnostic` — see the diagnostic below.

**Cross-process stability** is already asserted end to end by
`TestCodeunitExecutionOrderTests.ExecutionOrder_IsStableAcrossProcesses` (three runner processes,
cold cache each). Permutation invariance is the stronger property for the fallback specifically:
it holds across compilers, not just across processes.

## RED → GREEN

The comparator was extracted as an internal seam **with its behaviour unchanged first**, so the
RED is behavioural rather than a compile error, and the diagnostic went in as a `=> null` stub
matching today's silence.

```
RED    Failed: 8, Passed: 3, Total: 11
GREEN  Failed: 0, Passed: 11, Total: 11
```

The 3 that passed throughout are exactly the negative controls above — they are supposed to be
green in both states.

Also run, all green:

- `TestCodeunitExecutionOrderTests` — 4/4, 36s. The end-to-end guard for this surface, and an
  independent control: it asserts `ZetaDeclaredFirst` runs before `AlphaDeclaredSecond` through
  the real AL compiler, so if the name key had leaked into the resolved path it would fail.
- `AlObjectEmitOrderDeterminismTests`, `ExpectationMatchAuditTests`, `TestIsolation*` — 31/31.
- Tree-asserting guards (#3196): `VirtualTableRefusalClaimTests`, `JmpHookOrphanAuditTests`,
  `BaseAppFloorFixtureGuardTests`, `ScratchDirOwnershipGuardTests`,
  `AgentWorktreePathCollisionGuardTests` — 123/123 with the new tests.

Not run: the full `AlRunner.Tests` suite, per `.claude/rules/local-test-scope.md`. CI runs it on
each leg.

## Also fixed: the latch the issue names as its first candidate trigger

`ResolveSignatureLines` set `_signatureSpanAttrTypeResolved = true` **before** walking
`AppDomain.CurrentDomain.GetAssemblies()`, and wrote the shared `_signatureSpanAttrType` field on
every miss. Two consequences, both silent:

- **A reader arriving mid-search** saw `resolved == true` beside a still-null type, got an empty
  line map, fell back — and the caller **memoised** that degraded order for the type, so it
  outlived the window that caused it.
- **A search that found nothing stayed latched**, disabling source-order dispatch for the entire
  process. A first call landing before Ncl is loaded silently drops #1766 for the whole run.

Resolution now happens under a lock, publishes the value **before** the flag, and latches only a
*success* — a miss is retried, since the condition can go away. A success still latches, so this
remains one scan per process, not one per codeunit. The per-type order cache is no longer written
while the resolver is unavailable.

`AReaderArrivingMidSearch_NeverSeesTheEmptyWindow` proves it deterministically in both directions
rather than by timing: the reader is released only once the writer is provably inside the scan,
so under the old code it always observed the latched-but-empty window, and under the new one it
cannot observe a null it would act on. Its assembly source throws if called, which asserts the
reader takes the cached value rather than starting a second scan.

## Also: it says so now (`.claude/rules/loud-failures.md`)

A degraded order prints one `[test-exec] WARNING:` per codeunit naming the procedures affected.

The filter is the whole design, and it is why the second diagnostic test exists.
`GetMethods(Public | Instance)` also returns every **inherited** framework member — `ToString`,
`Equals`, `GetHashCode`, `GetType`, `NavApplicationObjectBase`'s own — none of which has an AL
declaration line or ever could. A naive "count what did not resolve" warns on **every codeunit of
every green run**, and a warning that is always on is the same silence in a louder font. Only
`[Test]` procedures declared by the codeunit itself count, so the message fires exactly when the
#1766 contract has actually been dropped — which, today, is never.

## Fixing the shape: what I looked for

1. **Same wrong pattern at another call site?** Yes — one. `OrderTestCodeunitsByObjectId` (added
   by #3082 for #2801) breaks its ties on `.ThenBy(x => x.i)`, the index into the undefined
   `GetTypes()` array, for types whose object id does not resolve. **Filed as #3217, deliberately
   not folded**: PR #3175 has that exact method open in front of it (`private` → `internal` plus a
   doc paragraph) and belongs to another loop (#3171), so editing its body from a second branch
   buys a merge conflict for a defect with no reproducer. One-line follow-up once #3175 lands.
2. **Sibling function making the same assumption?** `ResolveDisplayName`'s `_piObjectNameResolved`
   has the same latch-before-work shape. Left alone, and not filed: it resolves a property off a
   compile-time `typeof(...)`, so it cannot fail transiently the way an assembly scan can — the
   flag and the value are settled in the same breath. Recorded here so the next reader does not
   have to re-derive it.
3. **Two paths writing the same state with different invariants?** `Run` and `DiscoverTests` both
   order codeunits and both order methods, and both go through the same two functions — no
   divergence. `DiscoverTests` inherits this fix automatically, which is what #3082 put it there
   for.

## Queue scan (`.claude/rules/batch-sibling-issues-by-file.md`, #3213)

Scanned the open queue for issues landing in `AlRunner/TestExecutor.cs`. **Nothing folded**, and
the map is the output:

| issue | why not folded |
|---|---|
| #3187 `EnsureCompanySystemTableRowSeeded` latches before the work | The *same defect class* as the latch fixed here, and the closest call I made. Different file (`Patches/RecordPatches.CompanySystemTable.cs`), and **already closed by open PR #3186**. Its own body says it is not a one-line move — each early exit needs a "settled vs not-yet" decision across three sibling seeders. |
| #2185 `_singleInstanceBoundHandles` grows unbounded | `Patches/CodeunitPatches.cs`. Different file, unrelated reasoning (weak-ref list lifetime). |
| #2913 `ConsoleFilterSerialCollection` fences too little | `AlRunner.Tests` collection wiring, not `TestExecutor.cs`. |
| #3086 `SuiteAbortOnTimeoutTests` flake | Excluded by the coordinator; owned by PR #3175. |
| #2994 sweep reflection guards onto `BcShapeGapException` | Touches reflection guards broadly including this file, but it is a cross-cutting sweep with its own in-progress claim; folding it would make this diff two changes to review. |

## Left out, deliberately

- **The submodule pin is not bumped** (#3202).
- **#3217** — the sibling tiebreak, above.
- **No `docs/` change.** The runner's observable contract is unchanged for every input that
  resolves, which is all of them today; what changed is a fallback that previously had no defined
  behaviour to document.
- **Textual conflict to expect:** PR #3175 adds a four-line comment immediately above the
  `if (lineByMethod.Count == 0) return methods;` line this PR deletes. Small and mechanical,
  whichever lands first.

---
*Opened by agent `stma-auto-1` (cycle 147) on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
