### PR TITLE
fix(dotnet-interop): name the surface when a .NET type refuses this OS, and stop the page-open path swallowing refusals

### DIFF
--- a/AlRunner.Tests/DotNetInteropPlatformRefusalTests.cs
+++ b/AlRunner.Tests/DotNetInteropPlatformRefusalTests.cs
@@ -78,6 +78,10 @@ public sealed class DotNetInteropPlatformRefusalTests
         Assert.Contains("System.Drawing.Common", oos.Reason, StringComparison.Ordinal);
         // .NET's own sentence, which is the part that says a native package will not help.
         Assert.Contains("not supported on non-Windows platforms", oos.Reason, StringComparison.Ordinal);
+        // The RID, because OSDescription alone can be a distribution name that never says
+        // "not Windows" — on the box #3212 was measured on it renders as "Omarchy".
+        Assert.Contains(System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier,
+            oos.Reason, StringComparison.Ordinal);
         Assert.Equal("dotnet-platform", oos.DocAnchor);
         // The rendered message keeps the stable contract prefix and lands on a real anchor.
         Assert.StartsWith("out-of-scope: NavDotNet.CreateDotNet(System.Drawing.Bitmap) — ",

--- a/AlRunner.Tests/DotNetInteropPlatformRefusalTests.cs
+++ b/AlRunner.Tests/DotNetInteropPlatformRefusalTests.cs
@@ -1,0 +1,192 @@
+// DotNetInteropPlatformRefusalTests — #3212.
+//
+// WHAT IS BEING PINNED
+//   BC's Base Application reaches .NET types through AL interop, and some of them are
+//   Windows-only in .NET 8. Table 2121 "O365 Brand Color".MakePicture builds a
+//   System.Drawing.Bitmap; on Linux the shipped System.Drawing.Common 8.0 throws
+//   PlatformNotSupportedException out of its Gdip class initializer, BC's
+//   NavAutomationHelper.Create catches the TargetInvocationException and rethrows
+//   NavNCLDotNetInvokeException, and the AL author sees "The type initializer for 'Gdip'
+//   threw an exception" — a message naming neither the surface nor the reason.
+//   .claude/rules/loud-failures.md says that half is wrong whatever the scope verdict is.
+//
+// WHY A C# TEST AND NOT AN AL ONE
+//   This is a claim about the RUNNER, not about BC: on a real service tier (Windows) the
+//   construction succeeds, so no corpus test can express "the runner refuses it here" — see
+//   the PR body for the full argument. The AL side is covered end-to-end by the Tests-SMB
+//   bucket run recorded there; what is provable in-process, on every CI leg, is the
+//   classifier itself and the exact chain shape BC produces around it.
+//
+// THE CHAIN THESE TESTS ENCODE IS MEASURED, NOT INVENTED
+//   Calling the real NavAutomationHelper.CreateDotNetObject("System.Drawing.Common",
+//   "System.Drawing.Bitmap", [10, 10]) against BC 28.2.50931.54319 on Linux produced exactly:
+//     0 System.Reflection.TargetInvocationException          src=System.Private.CoreLib
+//     1 …Types.Exceptions.NavNCLDotNetInvokeException        src=Microsoft.Dynamics.Nav.Types
+//     2 System.TypeInitializationException                   src=System.Drawing.Common
+//     3 System.PlatformNotSupportedException                 src=System.Drawing.Common
+//   Frames 1..3 are what MeasuredGdipChain() below rebuilds.
+using System;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class DotNetInteropPlatformRefusalTests
+{
+    /// <summary>An exception whose <see cref="Exception.Source"/> is set, as the CLR sets it
+    /// to the throwing method's assembly.</summary>
+    private static T WithSource<T>(T ex, string source) where T : Exception
+    {
+        ex.Source = source;
+        return ex;
+    }
+
+    /// <summary>The exact nesting BC produces for the #3212 failure — see the file header.</summary>
+    private static Exception MeasuredGdipChain()
+    {
+        var platform = WithSource(new PlatformNotSupportedException(
+                "System.Drawing.Common is not supported on non-Windows platforms. "
+                + "See https://aka.ms/systemdrawingnonwindows for more information."),
+            "System.Drawing.Common");
+        var typeInit = WithSource(new TypeInitializationException("Gdip", platform),
+            "System.Drawing.Common");
+        // Stands in for NavNCLDotNetInvokeException: the classifier reaches it only through
+        // InnerException, so its concrete type is not part of the contract.
+        return WithSource(new InvalidOperationException(
+                "A call to System.Drawing.Bitmap failed with this message: "
+                + "The type initializer for 'Gdip' threw an exception.", typeInit),
+            "Microsoft.Dynamics.Nav.Types");
+    }
+
+    [Fact]
+    public void GdipChain_IsRefusedByName_NamingTypeLibraryAndPlatformMessage()
+    {
+        var oos = DotNetInteropShims.TryClassifyPlatformRefusal(
+            "System.Drawing.Bitmap", MeasuredGdipChain());
+
+        Assert.NotNull(oos);
+        // The AL-visible type has to be in the API, or the developer still cannot tell which
+        // interop call died.
+        Assert.Equal("NavDotNet.CreateDotNet(System.Drawing.Bitmap)", oos!.Api);
+        // The anchor the expectations manifest reads (text before the first em-dash).
+        Assert.StartsWith("dotnet-platform-unsupported", oos.Reason, StringComparison.Ordinal);
+        // NOT "not-yet-implemented": this is a permanent host boundary, and that prefix is
+        // what decides whether an AL [TryFunction] traps the refusal (scope.md §4 vs §3.16).
+        Assert.DoesNotContain("not-yet-implemented", oos.Reason, StringComparison.Ordinal);
+        // The .NET library that actually refused, recovered from Exception.Source.
+        Assert.Contains("System.Drawing.Common", oos.Reason, StringComparison.Ordinal);
+        // .NET's own sentence, which is the part that says a native package will not help.
+        Assert.Contains("not supported on non-Windows platforms", oos.Reason, StringComparison.Ordinal);
+        Assert.Equal("dotnet-platform", oos.DocAnchor);
+        // The rendered message keeps the stable contract prefix and lands on a real anchor.
+        Assert.StartsWith("out-of-scope: NavDotNet.CreateDotNet(System.Drawing.Bitmap) — ",
+            oos.Message, StringComparison.Ordinal);
+        Assert.Contains("docs/scope.md#dotnet-platform", oos.Message, StringComparison.Ordinal);
+        // The bare message #3212 complained about must not be all the reader gets: the
+        // classifier's own text has to add the type name BC's wrapper omits.
+        Assert.NotEqual(
+            "The type initializer for 'Gdip' threw an exception.", oos.Reason);
+    }
+
+    [Fact]
+    public void PlatformRefusalAtTheTopOfTheChain_IsAlsoRecognised()
+    {
+        // Not every Windows-only type fails through a class initializer — SecurityIdentifier
+        // throws PlatformNotSupportedException directly. One level of nesting must not be a
+        // precondition.
+        var direct = WithSource(new PlatformNotSupportedException(
+                "Windows Principal functionality is not supported on this platform."),
+            "System.Security.Principal.Windows");
+
+        var oos = DotNetInteropShims.TryClassifyPlatformRefusal(
+            "System.Security.Principal.WindowsIdentity", direct);
+
+        Assert.NotNull(oos);
+        Assert.Equal("NavDotNet.CreateDotNet(System.Security.Principal.WindowsIdentity)", oos!.Api);
+        Assert.Contains("System.Security.Principal.Windows", oos.Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SourcelessPlatformRefusal_StillRefuses_WithoutInventingALibraryName()
+    {
+        var oos = DotNetInteropShims.TryClassifyPlatformRefusal(
+            "Some.Windows.Only.Type", new PlatformNotSupportedException("nope"));
+
+        Assert.NotNull(oos);
+        Assert.Contains("the .NET library backing this type", oos!.Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MissingTypeName_StillRefuses_WithTheBareApiName()
+    {
+        var oos = DotNetInteropShims.TryClassifyPlatformRefusal(
+            null, WithSource(new PlatformNotSupportedException("nope"), "Some.Lib"));
+
+        Assert.NotNull(oos);
+        Assert.Equal("NavDotNet.CreateDotNet", oos!.Api);
+    }
+
+    // ── The negative half: nothing else may be converted into a refusal ──────────────────
+    //
+    // This is the part that stops the change from being a catch-all. Every one of these is a
+    // failure BC handles itself (add-in fallback, "not an image", an AL authoring error), and
+    // swallowing any of them behind an out-of-scope message would be a regression.
+
+    [Fact]
+    public void MissingAssembly_IsNotAPlatformRefusal()
+    {
+        // What BC raises when the assembly is genuinely absent — the add-in path, which has
+        // its own named refusal (NavDotNetPatches.ThrowServerInteropOOS).
+        Assert.Null(DotNetInteropShims.TryClassifyPlatformRefusal(
+            "Some.Type", new System.IO.FileNotFoundException("assembly not found")));
+    }
+
+    [Fact]
+    public void ConstructorArgumentError_IsNotAPlatformRefusal()
+    {
+        var chain = new InvalidOperationException("wrapped",
+            new ArgumentException("value does not fall within the expected range"));
+        Assert.Null(DotNetInteropShims.TryClassifyPlatformRefusal("System.IO.MemoryStream", chain));
+    }
+
+    [Fact]
+    public void NotSupportedException_IsNotAPlatformRefusal()
+    {
+        // NotSupportedException is a DIFFERENT type from PlatformNotSupportedException in the
+        // direction that matters: the base type is raised by plenty of in-scope code paths
+        // (a non-seekable stream, for one) and must keep BC's own error.
+        Assert.Null(DotNetInteropShims.TryClassifyPlatformRefusal(
+            "System.IO.Stream", new NotSupportedException("stream does not support seeking")));
+    }
+
+    [Fact]
+    public void RunnerOutOfScopeExceptionInTheChain_IsLeftAlone()
+    {
+        // An existing refusal (the SecurityIdentifier shim's, MediaPatches', …) must reach the
+        // caller as itself rather than being re-wrapped under a second anchor.
+        var already = new RunnerOutOfScopeException("Email.Send", "email-smtp", "email");
+        Assert.Null(DotNetInteropShims.TryClassifyPlatformRefusal("Whatever", already));
+    }
+
+    [Fact]
+    public void NullException_IsNotAPlatformRefusal()
+    {
+        Assert.Null(DotNetInteropShims.TryClassifyPlatformRefusal("System.IO.MemoryStream", null));
+    }
+
+    [Fact]
+    public void DeeplyNestedPlatformRefusal_IsStillFound()
+    {
+        // The walk is a walk, not a peek at InnerException.InnerException. BC's nesting depth
+        // is not a contract — a future Types.dll wrapping one level deeper must not silently
+        // put the bare "type initializer" message back in front of the developer.
+        Exception e = WithSource(new PlatformNotSupportedException("nope"), "Some.Lib");
+        for (var i = 0; i < 6; i++) e = new InvalidOperationException($"wrap {i}", e);
+
+        var oos = DotNetInteropShims.TryClassifyPlatformRefusal("Deep.Type", e);
+
+        Assert.NotNull(oos);
+        Assert.Contains("Some.Lib", oos!.Reason, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner/Patches/DotNetInteropShims.cs
+++ b/AlRunner/Patches/DotNetInteropShims.cs
@@ -29,6 +29,13 @@
 //   with its own "member not found", which is loud and names the member. A shim that
 //   answered them with a plausible default would be exactly the silent fake that rule
 //   forbids.
+//
+// THE OTHER HALF: WHEN THERE IS NO HONEST SUBSTITUTE (#3212)
+//   A substitute is only possible where the answer is fully determined by the inputs. It is
+//   not for System.Drawing, whose whole job is to produce pixels only a GDI+ implementation
+//   produces — so that case gets TryClassifyPlatformRefusal below instead: BC still runs, still
+//   fails, but the failure names the type, the .NET library that refused, and the reason,
+//   rather than "The type initializer for 'Gdip' threw an exception".
 using System.Globalization;
 
 namespace AlRunner.Patches;
@@ -80,12 +87,81 @@ public static class DotNetInteropShims
         }
         catch (System.Reflection.TargetInvocationException tie) when (tie.InnerException != null)
         {
+            // A .NET type that exists but refuses this OS is a scope boundary, not a BC error
+            // — name it before BC's own wrapper buries it. Null for everything else.
+            var refusal = TryClassifyPlatformRefusal(typeName, tie.InnerException);
+            if (refusal != null) throw refusal;
+
             // Preserve BC's own exception (NavNCLDotNetCreateException drives the add-in
             // fallback in the caller's catch block) AND its stack — see the ExceptionDispatchInfo
             // note in fix_saveas_recordref_filter: `throw inner` would reset it.
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
             throw; // unreachable
         }
+    }
+
+    /// <summary>
+    /// Turn "a .NET type refused this operating system" into a named refusal, or return null
+    /// so the caller rethrows BC's own exception untouched.
+    ///
+    /// <para>WHY (#3212). BC's Base Application constructs .NET objects through AL interop, and
+    /// some of those types are Windows-only in modern .NET. Table 2121 "O365 Brand Color"
+    /// .MakePicture builds a <c>System.Drawing.Bitmap</c> to draw a colour swatch; on Linux the
+    /// shipped <c>System.Drawing.Common</c> 8.0 fails its <c>Gdip</c> class initializer, and
+    /// BC's <c>NavAutomationHelper.Create</c> catches the resulting
+    /// <c>TargetInvocationException</c> and rethrows <c>NavNCLDotNetInvokeException</c>:
+    /// "A call to System.Drawing.Bitmap failed with this message: The type initializer for
+    /// 'Gdip' threw an exception." That names neither the surface nor the reason, which is the
+    /// half <c>.claude/rules/loud-failures.md</c> forbids. Eleven Tests-SMB tests died on it.</para>
+    ///
+    /// <para>MEASURED, not assumed — and it settles the experiment #3212 could not run.
+    /// The refusal is NOT a missing <c>libgdiplus</c>: decompiled from the artifact BC ships
+    /// (28.2.50931.54319), <c>SafeNativeMethods.Gdip..cctor</c> is
+    /// <c>if (!OperatingSystem.IsWindows()) NativeLibrary.SetDllImportResolver(…, delegate {
+    /// throw new PlatformNotSupportedException(SR.PlatformNotSupported_Unix); });</c> followed
+    /// by <c>GdiplusStartup</c>, and the assembly contains no <c>libgdiplus</c> string at all —
+    /// only <c>gdiplus.dll</c>. Installing a native package cannot change the outcome, and the
+    /// .NET 6 <c>System.Drawing.EnableUnixSupport</c> switch no longer exists in 8.0. So this is
+    /// a permanent boundary on a non-Windows host, not a runner TODO.</para>
+    ///
+    /// <para>FAITHFULNESS (the audit obligation in loud-failures.md). This substitutes no value
+    /// and changes no successful path: it only fires where BC was already about to fail, and it
+    /// fires on the exception .NET itself raised rather than on a guess about which types are
+    /// Windows-only — so on a Windows host, where these constructions succeed, it never runs.
+    /// Reason deliberately does NOT begin with "not-yet-implemented", so
+    /// <c>NavApplicationObjectBase.TryInvoke</c> keeps trapping it into <c>false</c> exactly as
+    /// it traps today's <c>NavNCLDotNetInvokeException</c> — this change makes the failure
+    /// legible, it does not move its classification.</para>
+    /// </summary>
+    internal static AlRunner.Infrastructure.RunnerOutOfScopeException? TryClassifyPlatformRefusal(
+        string? typeName, Exception? thrown)
+    {
+        // Walk the whole chain rather than peeking at a fixed depth: BC wraps the platform's
+        // exception twice today (NavNCLDotNetInvokeException → TypeInitializationException →
+        // PlatformNotSupportedException), and that nesting is Types.dll's business, not a
+        // contract. A chain is acyclic by construction — InnerException is fixed at
+        // construction time — so this terminates.
+        PlatformNotSupportedException? refused = null;
+        for (var e = thrown; e != null && refused == null; e = e.InnerException)
+            refused = e as PlatformNotSupportedException;
+        if (refused == null) return null;
+
+        // Exception.Source defaults to the assembly of the throwing method, which is the .NET
+        // library that refused — "System.Drawing.Common" for the #3212 case. Reported when
+        // present because it, not the AL-visible type name, is what a reader has to look up.
+        var lib = string.IsNullOrEmpty(refused.Source) ? null : refused.Source;
+        var api = string.IsNullOrEmpty(typeName)
+            ? "NavDotNet.CreateDotNet"
+            : $"NavDotNet.CreateDotNet({typeName})";
+
+        return new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            api,
+            "dotnet-platform-unsupported — "
+            + (lib == null ? "the .NET library backing this type" : lib)
+            + $" refuses every entry point on this operating system ({System.Runtime.InteropServices.RuntimeInformation.OSDescription}). "
+            + "BC's own message for this is \"The type initializer … threw an exception\", which names "
+            + $"neither. .NET reported: {refused.Message}",
+            "dotnet-platform");
     }
 }
 

--- a/AlRunner/Patches/DotNetInteropShims.cs
+++ b/AlRunner/Patches/DotNetInteropShims.cs
@@ -158,7 +158,12 @@ public static class DotNetInteropShims
             api,
             "dotnet-platform-unsupported — "
             + (lib == null ? "the .NET library backing this type" : lib)
-            + $" refuses every entry point on this operating system ({System.Runtime.InteropServices.RuntimeInformation.OSDescription}). "
+            // OSDescription alone is not enough to act on: on the box where #3212 was measured
+            // it renders as the distribution's name, "Omarchy", which does not tell a reader
+            // this is the non-Windows case at all. The RID always names the OS family.
+            + " refuses every entry point on this operating system ("
+            + $"{System.Runtime.InteropServices.RuntimeInformation.OSDescription}, "
+            + $"{System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier}). "
             + "BC's own message for this is \"The type initializer … threw an exception\", which names "
             + $"neither. .NET reported: {refused.Message}",
             "dotnet-platform");

--- a/AlRunner/Patches/RunnerTestPageState.cs
+++ b/AlRunner/Patches/RunnerTestPageState.cs
@@ -130,7 +130,23 @@ public static class RunnerTestPageState
         // NON-NavBaseException (a runner-internal/reflection failure — the ORIGINAL reason
         // this catch exists, per the type comment above) still means "a page that cannot be
         // marked simply behaves as it did before".
-        catch (Exception ex) when (ex is not NavBaseException)
+        //
+        // Issue #3212: RunnerOutOfScopeException has to escape for the same reason a
+        // NavBaseException does, and the NavBaseException test alone could not let it — a
+        // refusal is deliberately a plain System.Exception, precisely so that no BC error path
+        // can produce one (see RunnerOutOfScopeException's type comment). So every refusal
+        // raised from an OnOpenPage was discarded here: the page opened as though the trigger
+        // had succeeded, and the test failed later on whatever the trigger had not done, with
+        // the surface and the reason gone. Found on Base Application page 2158
+        // "O365 Brand Colors", whose OnOpenPage reaches System.Drawing — the one of #3212's
+        // eleven failures that goes through a page kept reporting a downstream row count while
+        // the other ten named the surface. Nothing about it is specific to that surface: the
+        // media, table-connection and report-rendering refusals were swallowed here
+        // identically. Pinned by tests/runner-extras/task-scheduler-oos
+        // (TskPageOpen.Page.al), whose scoping control holds the other half — an ordinary
+        // OnOpenPage still runs, and a runner-internal failure is still absorbed.
+        catch (Exception ex) when (ex is not NavBaseException
+                                   && ex is not AlRunner.Infrastructure.RunnerOutOfScopeException)
         {
         }
     }

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -294,6 +294,43 @@ runs. AL that needs the target codeunit's logic to actually execute should call 
 - `System.GetDotNetType(Joker)` — resolves the `.NET` type for an arbitrary AL value; no `.NET` type resolution without BC service tier.
 - `assembly_declaration`, `dotnet_declaration`, `type_declaration` — object types that wrap .NET assemblies; not compiled in standalone mode.
 
+### `System.Drawing` — Windows-only in .NET 8, so it never runs on a Linux or macOS host
+
+<a id="system-drawing"></a>
+
+Precompiled Microsoft code does reach .NET interop, and some of what it reaches is
+Windows-only. Base Application table 2121 `"O365 Brand Color"`.`MakePicture` builds a
+`System.Drawing.Bitmap` to draw a colour swatch, which is why eleven `O365 Brand Color Tests`
+fail on a Linux host.
+
+The runner names the surface instead of letting BC's wrapper bury it. Before
+[#3212](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3212):
+
+```
+NavNCLDotNetInvokeException: A call to System.Drawing.Bitmap failed with this message:
+The type initializer for 'Gdip' threw an exception.
+```
+
+After:
+
+```
+out-of-scope: NavDotNet.CreateDotNet(System.Drawing.Bitmap) — dotnet-platform-unsupported —
+System.Drawing.Common refuses every entry point on this operating system (Linux …). …
+.NET reported: System.Drawing.Common is not supported on non-Windows platforms. …
+```
+
+**There is no workaround on the host side.** `System.Drawing.Common` 8.0 — the copy BC itself
+ships — throws `PlatformNotSupportedException` from its `Gdip` class initializer whenever
+`OperatingSystem.IsWindows()` is false, before any native library is consulted; it carries no
+`libgdiplus` reference at all, and the .NET 6 `System.Drawing.EnableUnixSupport` switch was
+removed in .NET 7. Installing a system package changes nothing.
+
+**What to do with AL that needs it.** Either run that test against a real BC service tier, or
+inject the image work behind an AL interface and pass a test double. The runner will not
+substitute a different imaging library: the pixels would not be GDI+'s, so the test would be
+asserting against the runner rather than against BC — see "Why no real SA implementations"
+below and `docs/scope.md#dotnet-platform`.
+
 ### Query — joins and dataset export work; aggregation does not
 
 <a id="query-shape-gaps"></a>

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -261,6 +261,42 @@ Reason token: `table-connections`. The test-connection path is §1.
 
 ---
 
+### §3.16. .NET libraries that refuse a non-Windows host <a id="dotnet-platform"></a>
+
+In-process .NET interop is in scope (§1) and runs as real code. A handful of .NET libraries
+are **Windows-only in modern .NET**, so on a Linux or macOS host there is no configuration in
+which they run at all — the boundary is the host, not the runner's design.
+
+| API | Reason |
+|---|---|
+| `System.Drawing` (`Bitmap`, `Graphics`, `Image`, …) constructed through BC's .NET interop | `System.Drawing.Common` 8.0 — the copy BC itself ships — throws `PlatformNotSupportedException` from its `Gdip` class initializer on every non-Windows OS. |
+| Any other .NET type whose constructor raises `PlatformNotSupportedException` | Same shape; the refusal reports whichever .NET library raised it, so it does not need a per-type list here. |
+
+Reason token: `dotnet-platform-unsupported`. The refusal names the AL-visible type, the .NET
+library that refused, this host's OS, and .NET's own message.
+
+**Installing a native package does not help, and no runtime switch exists.** Decompiled from
+the artifact BC ships, `SafeNativeMethods.Gdip..cctor` reads
+`if (!OperatingSystem.IsWindows()) NativeLibrary.SetDllImportResolver(…, delegate { throw new
+PlatformNotSupportedException(…); });` before it calls `GdiplusStartup`, and the assembly
+carries no `libgdiplus` string — only `gdiplus.dll`. The .NET 6
+`System.Drawing.EnableUnixSupport` `AppContext` switch was removed in .NET 7.
+
+**Why the runner does not substitute an imaging library.** Redirecting BC's `System.Drawing`
+calls onto SkiaSharp or ImageSharp would produce different bytes from GDI+, so an AL test
+asserting on a stored image would be asserting against the runner's imaging stack rather than
+against BC — the failure mode that got `MockImage` reverted in
+[#1502](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/1502), and the reason
+`docs/limitations.md` forbids shipping an `Image` implementation. Media content that is *not*
+an image stores normally; see `AlRunner/Patches/MediaPatches.cs`, whose `media-image-decode`
+refusal is the same boundary reached from the Media/MediaSet side.
+
+**Running the affected AL on a Windows host works**, because the refusal fires on the
+exception .NET actually raised rather than on a list of type names — there is nothing to
+disable.
+
+---
+
 ## §4. In scope, not yet implemented (TODO)
 
 These are surfaces we intend to support but haven't built yet. They throw

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -848,3 +848,27 @@ unchanged, including all eight of #198's, which their author expected to pass on
 coincidence.
 
 Written by agent stma-auto-1 (automated implementation agent), cycle 138.
+
+## +2 runner-extras tests: `task-scheduler-oos` 6 -> 8 (issue #3212)
+
+`TskPageOpen.Page.al` adds table 65604 and two pages inside the suite's existing
+`65600-65609` range, and `TskTests.Codeunit.al` adds two tests over them. No new app group:
+the suite already existed, so `runner-extras` gains two tests and no group.
+
+The pair proves a defect found while fixing #3212, not the task scheduler itself.
+`RunnerTestPageState.MarkOpened` drives a page's `OnOpenPage` from inside BC's rewritten
+`NavTestPage.Open`, behind a catch-all filtered on `ex is not NavBaseException`. A
+`RunnerOutOfScopeException` is deliberately a plain `System.Exception`, so that filter
+swallowed every refusal raised from an `OnOpenPage` — the page opened as though the trigger
+had succeeded and the test failed later on something downstream, with the surface and the
+reason gone. `PageOnOpenPage_Refusal_ReachesTheCaller` failed with "An error was expected
+inside an ASSERTERROR statement" before the fix. `PageOnOpenPage_WithoutARefusal_
+StillRunsAndThePageOpens` is the scoping control and passed both before and after: widening
+the filter must not turn into letting unrelated failures escape.
+
+The task-scheduler surface stands in for `System.Drawing` because it refuses without needing
+anything from the Base Application, and this suite already owned it. `al-language`,
+`al-language-internals-fixture`, `al-language-onprem` and every other `runner-extras` group
+are untouched; no corpus pin moves in this PR.
+
+Written by agent stma-auto-1 (automated implementation agent), cycle 147.

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -55,7 +55,7 @@
         "tableext-eviction-field-trigger-timing-dep": { "tests": 0 },
         "tableext-eviction-subscriber-timing": { "tests": 2 },
         "tableext-eviction-subscriber-timing-dep": { "tests": 0 },
-        "task-scheduler-oos": { "tests": 6 },
+        "task-scheduler-oos": { "tests": 8 },
         "temporary-virtual-table-isolation": { "tests": 6 },
         "testpage-lookup-tablerelation-oos": { "tests": 3 },
         "testpage-precompiled-dep-control": { "tests": 2 },

--- a/tests/runner-extras/task-scheduler-oos/TskAssert.Codeunit.al
+++ b/tests/runner-extras/task-scheduler-oos/TskAssert.Codeunit.al
@@ -41,4 +41,10 @@ codeunit 65600 "Tsk Assert"
             Error('Expected ''%1'' exactly once in the error text but found it %2 time(s): ''%3''',
                 Fragment, Occurrences, GetLastErrorText());
     end;
+
+    procedure AreEqualText(Expected: Text; Actual: Text; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Expected ''%1'' but got ''%2'': %3', Expected, Actual, Msg);
+    end;
 }

--- a/tests/runner-extras/task-scheduler-oos/TskPageOpen.Page.al
+++ b/tests/runner-extras/task-scheduler-oos/TskPageOpen.Page.al
@@ -1,0 +1,94 @@
+// Issue #3212 — a refusal raised from a page's OnOpenPage must reach the AL caller.
+//
+// The runner opens a TestPage by driving the page's lifecycle triggers itself, from
+// RunnerTestPageState.MarkOpened, which runs inside BC's Cecil-rewritten NavTestPage.Open
+// and therefore carries a catch-all so a runner-internal reflection failure cannot tear
+// through BC's own IL. That catch-all was filtered on `ex is not NavBaseException` — BC's
+// AL-error hierarchy — which let a genuine AL error out (#2677) but still swallowed
+// RunnerOutOfScopeException, deliberately a plain System.Exception so that no BC error path
+// can produce it.
+//
+// So EVERY out-of-scope refusal raised from an OnOpenPage was discarded silently: the page
+// opened as though the trigger had succeeded, and the test failed later on whatever the
+// trigger had not done. Found while fixing #3212, where Base Application page 2158
+// "O365 Brand Colors" reaches System.Drawing from OnOpenPage: ten of the eleven failing
+// tests named the surface once the interop refusal existed, and the eleventh — the only one
+// going through a page — still reported "Expected number of O365 Brand Color entries: 12.
+// Actual: 0", with no mention of what had actually stopped it.
+//
+// The task-scheduler surface stands in for System.Drawing here because it refuses without
+// needing anything from the Base Application, and because this suite already owns it.
+
+table 65604 "Tsk Page Row"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Entry No."; Integer) { DataClassification = CustomerContent; }
+        field(2; Marker; Text[30]) { DataClassification = CustomerContent; }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.") { Clustered = true; }
+    }
+}
+
+// OnOpenPage touches an out-of-scope surface. Opening this page must fail with the refusal.
+page 65605 "Tsk Refusing Page"
+{
+    PageType = List;
+    SourceTable = "Tsk Page Row";
+    ApplicationArea = All;
+    UsageCategory = Lists;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Group)
+            {
+                field(Marker; Rec.Marker) { ApplicationArea = All; }
+            }
+        }
+    }
+
+    trigger OnOpenPage()
+    var
+        Ignored: Boolean;
+    begin
+        Ignored := TaskScheduler.TaskExists(CreateGuid());
+    end;
+}
+
+// Scoping control for the above: an OnOpenPage that refuses nothing must still run, and the
+// page must still open. Widening the catch-all is only correct if it changes exactly the one
+// case; a fix that let unrelated failures escape would break this page instead.
+page 65606 "Tsk Quiet Page"
+{
+    PageType = List;
+    SourceTable = "Tsk Page Row";
+    ApplicationArea = All;
+    UsageCategory = Lists;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Group)
+            {
+                field(Marker; Rec.Marker) { ApplicationArea = All; }
+            }
+        }
+    }
+
+    trigger OnOpenPage()
+    var
+        Row: Record "Tsk Page Row";
+    begin
+        Row."Entry No." := 1;
+        Row.Marker := 'opened';
+        Row.Insert();
+    end;
+}

--- a/tests/runner-extras/task-scheduler-oos/TskTests.Codeunit.al
+++ b/tests/runner-extras/task-scheduler-oos/TskTests.Codeunit.al
@@ -122,4 +122,35 @@ codeunit 65603 "Tsk Tests"
         Assert.ExpectedError(NotAllowedErr);
         Assert.NotExpectedError('out-of-scope:');
     end;
+
+    [Test]
+    procedure PageOnOpenPage_Refusal_ReachesTheCaller()
+    var
+        RefusingPage: TestPage "Tsk Refusing Page";
+    begin
+        // #3212. The page-open path drives OnOpenPage from inside BC's rewritten
+        // NavTestPage.Open, behind a catch-all that must not eat a refusal. Before the fix
+        // this asserterror saw NO error at all: the page opened as though the trigger had
+        // succeeded, and an AL author lost every word of the diagnosis.
+        asserterror RefusingPage.OpenView();
+
+        Assert.ExpectedError('out-of-scope: TaskScheduler.TaskExists');
+        Assert.ExpectedError('docs/scope.md#jobs');
+        Assert.ErrorContainsExactlyOnce('see docs/scope.md');
+    end;
+
+    [Test]
+    procedure PageOnOpenPage_WithoutARefusal_StillRunsAndThePageOpens()
+    var
+        QuietPage: TestPage "Tsk Quiet Page";
+    begin
+        // Scoping control for the test above. Letting a refusal escape the open path must not
+        // turn into letting anything escape it: an ordinary OnOpenPage still runs, and what it
+        // wrote is what the opened page shows.
+        QuietPage.OpenView();
+
+        Assert.AreEqualText('opened', QuietPage.Marker.Value(),
+            'OnOpenPage must still run, and the page must still open on the row it wrote');
+        QuietPage.Close();
+    end;
 }


### PR DESCRIPTION
Closes #3212

BC's Base Application reaches .NET types through AL interop, and some of them are Windows-only in .NET 8. Table 2121 `"O365 Brand Color"`.`MakePicture` builds a `System.Drawing.Bitmap` to draw a colour swatch, and on a Linux host that died with a message naming neither the surface nor the reason — the half `.claude/rules/loud-failures.md` forbids regardless of the scope verdict.

## The inner exception, and which of the three outcomes this is

The issue asked for the inner exception and named the one experiment it could not run. Both are settled, and the answer is not what the issue expected.

Driving BC's own `NavAutomationHelper.CreateDotNetObject("System.Drawing.Common", "System.Drawing.Bitmap", [10, 10])` against BC 28.2.50931.54319 on this Linux box gives the full chain:

```
0 System.Reflection.TargetInvocationException          src=System.Private.CoreLib
1 …Types.Exceptions.NavNCLDotNetInvokeException        src=Microsoft.Dynamics.Nav.Types
2 System.TypeInitializationException                   src=System.Drawing.Common
3 System.PlatformNotSupportedException                 src=System.Drawing.Common
    "System.Drawing.Common is not supported on non-Windows platforms.
     See https://aka.ms/systemdrawingnonwindows for more information."
```

**The inner exception is `PlatformNotSupportedException`, not a missing `libgdiplus`.** The issue's stated diagnosis was that `libgdiplus` is absent; it is absent on this box, and that is not why this fails. Decompiled from the artifact BC itself ships, `System.Drawing.SafeNativeMethods.Gdip..cctor` is:

```csharp
static Gdip()
{
    if (!OperatingSystem.IsWindows())
    {
        NativeLibrary.SetDllImportResolver(Assembly.GetExecutingAssembly(),
            delegate { throw new PlatformNotSupportedException(SR.PlatformNotSupported_Unix); });
    }
    CheckStatus(GdiplusStartup(out s_initToken, StartupInputEx.GetDefault(), out var _));
}
```

The resolver throws before any native library is consulted, and the assembly carries no `libgdiplus` string at all — only `gdiplus.dll`. The .NET 6 `System.Drawing.EnableUnixSupport` `AppContext` switch was removed in .NET 7. So installing a system package cannot change the outcome, and the experiment the issue could not run is answered statically rather than left open.

BC's own wrapping is equally mechanical: `NavAutomationHelper.Create` catches `TargetInvocationException` and rethrows `NavNCLDotNetInvokeException.Create(culture, typeName, inner)`, which is exactly the message the issue reported.

**Outcome 1 — permanently out of scope, as a host boundary.** Not outcome 3: no supported configuration exists on Linux. Not outcome 2: making it work means redirecting BC's `System.Drawing` calls onto SkiaSharp or ImageSharp, whose pixels are not GDI+'s, so an AL test asserting on a stored image would be asserting against the runner's imaging stack rather than against BC — the failure that got `MockImage` reverted in #1502, and the reason `docs/limitations.md` forbids shipping an `Image` implementation. This matches the classification `MediaPatches.cs` already carries for the same boundary reached from the Media side, audited as permanent in `RunnerShapeGaps.cs`.

## What changed

**1. `AlRunner/Patches/DotNetInteropShims.cs` — name the surface.** `CallOriginal` now walks the exception chain for a `PlatformNotSupportedException` and, if it finds one, throws a `RunnerOutOfScopeException` naming the AL-visible type, the .NET library that refused (from `Exception.Source`), this host's OS description and RID, and .NET's own message.

```
out-of-scope: NavDotNet.CreateDotNet(System.Drawing.Bitmap) — dotnet-platform-unsupported —
System.Drawing.Common refuses every entry point on this operating system (Omarchy, linux-x64).
BC's own message for this is "The type initializer … threw an exception", which names neither.
.NET reported: System.Drawing.Common is not supported on non-Windows platforms. …
— see docs/scope.md#dotnet-platform
```

It fires on the exception .NET actually raised, never on a list of type names, so a Windows host is unaffected and no successful path changes. The reason deliberately does not begin with `not-yet-implemented`, so an AL `[TryFunction]` keeps trapping it exactly as it traps today's `NavNCLDotNetInvokeException` — this makes the failure legible, it does not move its classification.

**2. `AlRunner/Patches/RunnerTestPageState.cs` — a second defect the first fix surfaced.** `MarkOpened` drives a page's `OnOpenPage` from inside BC's Cecil-rewritten `NavTestPage.Open`, behind a catch-all filtered on `ex is not NavBaseException`. A `RunnerOutOfScopeException` is deliberately a plain `System.Exception`, so **every out-of-scope refusal raised from an `OnOpenPage` was silently discarded** — the page opened as though the trigger had succeeded and the test failed later on whatever the trigger had not done. This is not specific to `System.Drawing`: the media, table-connection and report-rendering refusals were swallowed identically. Found because 10 of the 11 failures named the surface after fix 1 and the eleventh — the only one going through a page — still reported a downstream row count.

**3. Docs.** `docs/scope.md` gains §3.16 with a `dotnet-platform` anchor (`MediaPatches`' existing `media-image-decode` refusal pointed at `docs/scope.md` with no section to land on); `docs/limitations.md` gains a `#system-drawing` section with the before/after message and why no host-side workaround exists.

## RED → GREEN

**End-to-end, against the real Microsoft `Tests-SMB` bucket** — the exact failure the issue reports, `--test-data` from `BusinessCentral-W1.bak`, company `CRONUS International Ltd_`, BC 28.1.49838.53910, `--filter Codeunit138931`:

| | tests | bare `type initializer for 'Gdip'` | named refusal |
|---|---|---|---|
| before | 15 total, 4 pass, **11 fail** | 11 | 0 |
| after fix 1 only | 15 total, 4 pass, 11 fail | 0 | 10 (the 11th fell to a downstream assertion) |
| after fixes 1+2 | 15 total, 4 pass, 11 fail | **0** | **11** |

The 11 still fail, and should: the surface genuinely is unavailable. What changed is that each one now names it, with the AL stack (`"O365 Brand Color"(Table 2121).MakePicture` → `CreateBrandColor` → …) intact.

**`AlRunner.Tests/DotNetInteropPlatformRefusalTests.cs`** — 10 tests over the classifier, built on the measured chain above. Proving RED: with the classifier stubbed to `return null`, **5 of 10 failed** — the 5 positives. The 5 negatives (a missing assembly, a constructor `ArgumentException`, a base `NotSupportedException`, an existing `RunnerOutOfScopeException`, a null) pass against a no-op by construction, which is the point: they are the scoping half that stops this becoming a catch-all.

**`tests/runner-extras/task-scheduler-oos`** — 2 new AL tests (table 65604, pages 65605/65606, inside the suite's own declared `65600-65609` range). RED: `PageOnOpenPage_Refusal_ReachesTheCaller` failed with `NavNCLAssertErrorException: An error was expected inside an ASSERTERROR statement` — the refusal was gone. GREEN: 8/8. The scoping control `PageOnOpenPage_WithoutARefusal_StillRunsAndThePageOpens` passed before *and* after, which is what says the widened filter did not start letting unrelated failures escape. The task-scheduler surface stands in for `System.Drawing` because it refuses without needing anything from the Base Application.

## Does this assert something about what BC does?

No, and there is no corpus test to write. The claim is "the runner refuses this surface on a non-Windows host". On a real service tier the construction **succeeds** — that is why BC ships the code at all — so a corpus test could only assert the opposite of what this PR is about, and the corpus CI would be right to make it green. This is squarely the `tests/runner-extras/` half of `bc-behavior-tests-go-upstream.md`: a `RunnerOutOfScopeException` thrown with a specific reason on a specific surface. Fix 2 is the same shape — nothing in "a refusal must reach the AL caller" is a statement about BC.

No expectations entry is needed either: no corpus test touches `System.Drawing`, and the corpus runs 2695/2695 clean against this branch.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — fix 2. `RunnerTestPageState.cs:133` was the only `is not NavBaseException` filter in `AlRunner/` (checked with `rg`), and it swallowed every refusal, not just this one.
2. **Does a sibling function make the same assumption?** The **static/instance member-invoke** path does. Refusing at construction means an instance of a Windows-only type can never exist, so instance invokes are unreachable — but a *static* call (`Image.FromStream`, `Graphics.FromImage`) never constructs anything and still produces the bare message. It has a different seam: `NavDotNet.CreateNavNCLDotNetInvokeException` (private static, Ncl, ~line 1356 of the decompile), which needs a new Cecil rewrite rather than the existing `CreateDotNetObject` call-site redirect this PR uses. **Deliberately not folded in** — it is unmeasured (no bucket failure reaches it) and a new Cecil site needs its own validation across eight BC legs. Filed separately.
3. **Two paths writing the same state, same invariant?** `docs/scope.md` had no section for the image boundary at all, while `MediaPatches.cs` had been pointing at it since #2570. §3.16 covers both reason tokens, so the two refusals now land on one row.

## Sibling issues in this file — the map

Scanned the open queue for `DotNetInteropShims.cs` and the interop surface. One candidate, **not folded**:

- **#2772** — `IsAvailable()` on a `[RunOnClient]` DotNet variable raises "Callback functions are not allowed" instead of answering false. It is labeled `status: needs-input`, and its fix lands in `NclCecilRewrite.Dispatch.cs` against `NavDotNet.CanLoadType`/`IsAvailable` — a client-callback question, not a platform-refusal one. Different file, different mechanism, no shared reasoning.

No open PR touches `AlRunner/Patches/DotNetInteropShims.cs` or `AlRunner/Patches/RunnerTestPageState.cs`. #3186, #3181 and #3101 touch `docs/limitations.md`, in other sections.

## What I deliberately left out

- **The static-invoke seam** (point 2 above) — filed rather than fixed.
- **Any imaging substitute.** The 11 tests still fail. Making them pass means shipping an image implementation, which #1502 already rejected.
- **The submodule pin** — held at 7 commits behind `master` by #3202; nothing here needs it.
- **`docs/scope.md` §3.14's wording.** It says the AL `DotNet` surface is out of scope while in-process interop is in; this failure shows interop working right up to the constructor, so §3.14 is accurate as written and §3.16 sits beside it rather than editing it.

## Verification run in this state

- `AlRunner.Tests` filtered: `DotNetInteropPlatformRefusalTests` 10/10; the tree-asserting guards `VirtualTableRefusalClaimTests`, `RunnerShapeGapClaimTests`, `TestPageRefusalClaimTests`, `OutOfScopePointerCallSiteGuardTests`, `AssertErrorOutOfScopeCatchabilityTests`, `NavDotNetPatchesTests`, `BcShapeGapConventionTests`, `ExpectationManifestSchemaTests`, `RunnerOutOfScopeMessagePointerTests` — 255/255.
- al-language corpus (all three apps, pin `6e198a97`): **2695/2695**, 0 fail.
- `tests/runner-extras` with `--strict --count-baseline`: **314/314**, exit 0 — which is what checks the 6 → 8 baseline bump.
- Microsoft `Tests-SMB` codeunit 138931 with `--test-data`: table above.

---

Written by agent `stma-auto-1` (automated implementation agent), cycle 147, on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
