### PR TITLE
fix(install): let install triggers run to completion — observe their ValueTask, and remove the three gaps that hid behind it

### DIFF
--- a/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
+++ b/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
@@ -16,12 +16,21 @@
 //
 // WHAT THIS FILE ASSERTS
 //   #3051 converted the 73 lookups that read BC's OWN internals to BcShape.Property/Method/
-//   Field/Constructor, which raise a BcShapeGapException naming Declaring.Member. 61 sites
+//   Field/Constructor, which raise a BcShapeGapException naming Declaring.Member. 63 sites
 //   remain, and every one of them is here on purpose — they are not BC-layout reads:
 //
 //     RunnerOwnMember  the receiver is `typeof(<a runner type>)`. `nameof` or not, this asks
 //                      the runner about the runner. Microsoft cannot move it, and a rename
-//                      inside this repository is a compile-time or a same-PR question. 36.
+//                      inside this repository is a compile-time or a same-PR question. 38.
+//                      36 → 38 in the #2960 install-trigger PR: two more Cecil helper
+//                      resolutions in NclCecilRewrite.Dispatch.cs, one per newly-patched Ncl
+//                      method — `NavAppModuleInfoPatches.ALNavApp_GetCurrentModuleInfo` for
+//                      the by-id `ALGetModuleInfo` overload (#2961), and
+//                      `BcRuntime.ALSession_ALStartSessionAsyncImpl` for
+//                      `ALSession.ALStartSessionAsyncImpl` (#3220). Both are
+//                      `typeof(<runner type>).GetMethod(nameof(<runner method>))!` beside
+//                      twenty existing ones in the same file, so both are the category's own
+//                      shape rather than a new kind of read.
 //     Bcl              the receiver is a BCL type — object.MemberwiseClone, Guid.NewGuid,
 //                      string.Empty, InvalidOperationException(string), Task.FromResult. The
 //                      .NET surface does not move under a BC update. 7.
@@ -94,7 +103,7 @@ public sealed class BcInternalsNullForgivingGuardTests
 
     private static readonly Dictionary<Cat, int> Expected = new()
     {
-        [Cat.RunnerOwnMember] = 36,
+        [Cat.RunnerOwnMember] = 38,
         [Cat.Bcl] = 7,
         [Cat.FrameworkTuple] = 8,
         [Cat.Listed] = 10,

--- a/AlRunner.Tests/InstallTriggerAsyncObservationTests.cs
+++ b/AlRunner.Tests/InstallTriggerAsyncObservationTests.cs
@@ -1,0 +1,204 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Pins <c>InstallTriggerRunner.InvokeTrigger</c> observing the result of the install
+/// trigger it invokes, so a <c>Subtype = Install</c> codeunit's error reaches the caller
+/// instead of being parked on a discarded <c>ValueTask</c> (#2960).
+///
+/// WHY THIS IS A C# TEST AND NOT AL. The broken shape needs an install trigger compiled as
+/// an <c>async ValueTask</c> state machine, and the runner's own AL-to-C# emitter does not
+/// produce one. Measured on BC 28.1 by printing <c>trigger.ReturnType</c> at the call site
+/// while running <c>tests/runner-extras/install-trigger-seed</c>: all sixteen precompiled
+/// platform install triggers in that bundle's closure returned <c>ValueTask</c>
+/// (Codeunit1809, 1933, 3999, 3907, 1596, 2014, 290, 4331, 5000, 7582, 7760, 7782, 8352,
+/// 9056, 9993 …) and the bundle's own source-compiled Codeunit60711 returned <c>Void</c> —
+/// for both of its triggers. So a first-party AL reproducer cannot reach the defect and
+/// would pass with and without the fix, which <c>.claude/rules/tdd.md</c> calls noise.
+///
+/// Same split, and the same reason, as <c>ObservingSubscriberMethodInfoTests</c> (#2932's
+/// table-event-subscriber half of this defect) and <c>DispatchObserveAsyncResultTests</c>.
+/// The end-to-end proof lives in CI's al-language corpus leg: with the four fixes this test
+/// belongs to, the Base Application install pass runs to completion; remove any one of them
+/// and the bundle reports EXEC-FAIL before a single test executes.
+/// </summary>
+public class InstallTriggerAsyncObservationTests
+{
+    // ---- stand-ins for an emitted Subtype=Install codeunit ---------------------------
+    //
+    // InvokeTrigger only ever touches the trigger MethodInfo and the instance it invokes it
+    // on, so a plain class is a faithful stand-in: the ITreeObject ctor and the Codeunit*
+    // naming matter to Scan(), which is not what this pins.
+
+    public sealed class Installer
+    {
+        public int Steps;
+
+        public void SyncOk() => Steps++;
+
+        public void SyncThrows()
+        {
+            Steps++;
+            throw new InvalidOperationException("SYNC-INSTALL-ERROR");
+        }
+
+        public async ValueTask AsyncOk()
+        {
+            Steps++;
+            await Task.Yield();
+            Steps++;
+        }
+
+        public async ValueTask AsyncThrows()
+        {
+            Steps++;
+            await Task.Yield();
+            throw new InvalidOperationException("ASYNC-INSTALL-ERROR");
+        }
+
+        // async ValueTask<T> is the only shape that reaches ObserveAsyncResult's reflection
+        // arm — a boxed ValueTask<T> is neither a Task nor a ValueTask, so it matches no
+        // case label. An install trigger is declared void in AL and BC does not emit this
+        // shape for one today; it is covered so the seam cannot regress into a silent
+        // fall-through if that ever changes.
+        public async ValueTask<int> AsyncGenericThrows()
+        {
+            Steps++;
+            await Task.Yield();
+            throw new InvalidOperationException("ASYNC-GENERIC-INSTALL-ERROR");
+        }
+    }
+
+    private static MethodInfo M(string name) =>
+        typeof(Installer).GetMethod(name, BindingFlags.Public | BindingFlags.Instance)!;
+
+    private static InstallTriggerRunner.InstallCodeunit Cu() =>
+        new(typeof(Installer),
+            typeof(Installer).GetConstructors()[0],
+            PerCompany: null,
+            PerDatabase: null);
+
+    /// <summary>Run InvokeTrigger with stderr redirected, returning what it wrote.</summary>
+    private static string InvokeCapturingStdErr(
+        Installer target, string method, string triggerName, out Exception? thrown)
+    {
+        var original = Console.Error;
+        var buffer = new StringWriter();
+        Console.SetError(buffer);
+        try
+        {
+            thrown = Xunit.Record.Exception(
+                () => InstallTriggerRunner.InvokeTrigger(Cu(), target, M(method), triggerName));
+        }
+        finally
+        {
+            Console.SetError(original);
+        }
+        return buffer.ToString();
+    }
+
+    // ---- the defect ------------------------------------------------------------------
+
+    [Fact]
+    public void AsyncInstallTriggerThatThrows_SurfacesTheErrorInsteadOfSwallowingIt()
+    {
+        var target = new Installer();
+
+        // The pre-#2960 behaviour, spelled out so the RED is in the test rather than only in
+        // the commit history: invoking the trigger and DISCARDING its result returns
+        // normally. The error exists only on the returned ValueTask.
+        var discarded = (ValueTask)M(nameof(Installer.AsyncThrows)).Invoke(target, null)!;
+        var onlyOnTheTask = Assert.Throws<InvalidOperationException>(
+            () => discarded.AsTask().GetAwaiter().GetResult());
+        Assert.Equal("ASYNC-INSTALL-ERROR", onlyOnTheTask.Message);
+
+        // Through InvokeTrigger the same call raises, with the ORIGINAL exception type and
+        // message — not a TargetInvocationException, and not an AggregateException.
+        var target2 = new Installer();
+        var thrown = Assert.Throws<InvalidOperationException>(
+            () => InstallTriggerRunner.InvokeTrigger(
+                Cu(), target2, M(nameof(Installer.AsyncThrows)), "OnInstallAppPerCompany"));
+        Assert.Equal("ASYNC-INSTALL-ERROR", thrown.Message);
+    }
+
+    [Fact]
+    public void AsyncInstallTriggerThatThrows_IsReportedLoudlyNamingTheCodeunitAndTrigger()
+    {
+        var stderr = InvokeCapturingStdErr(
+            new Installer(), nameof(Installer.AsyncThrows), "OnInstallAppPerCompany", out var thrown);
+
+        Assert.IsType<InvalidOperationException>(thrown);
+        // The async case must reach the SAME diagnostic the synchronous case always had.
+        // Before the fix it reached no diagnostic at all, because the state machine never
+        // let the exception out of MethodInfo.Invoke.
+        Assert.Contains("[install-trigger]", stderr);
+        Assert.Contains("Installer.OnInstallAppPerCompany", stderr);
+        Assert.Contains("InvalidOperationException", stderr);
+        Assert.Contains("ASYNC-INSTALL-ERROR", stderr);
+    }
+
+    [Fact]
+    public void AsyncGenericInstallTriggerThatThrows_SurfacesTheError()
+    {
+        var thrown = Assert.Throws<InvalidOperationException>(
+            () => InstallTriggerRunner.InvokeTrigger(
+                Cu(), new Installer(), M(nameof(Installer.AsyncGenericThrows)), "OnInstallAppPerDatabase"));
+        Assert.Equal("ASYNC-GENERIC-INSTALL-ERROR", thrown.Message);
+    }
+
+    // ---- what must NOT change --------------------------------------------------------
+
+    [Fact]
+    public void SyncInstallTriggerThatThrows_StillRaisesTheOriginalExceptionType()
+    {
+        // The pre-existing TargetInvocationException arm: MethodInfo.Invoke wraps a
+        // synchronously-thrown exception, and InvokeTrigger has always unwrapped it so a
+        // RunnerOutOfScopeException stays itself. Folding the two arms together must not
+        // start leaking the wrapper.
+        var stderr = InvokeCapturingStdErr(
+            new Installer(), nameof(Installer.SyncThrows), "OnInstallAppPerCompany", out var thrown);
+
+        var ex = Assert.IsType<InvalidOperationException>(thrown);
+        Assert.Equal("SYNC-INSTALL-ERROR", ex.Message);
+        Assert.Contains("Installer.OnInstallAppPerCompany", stderr);
+        Assert.Contains("SYNC-INSTALL-ERROR", stderr);
+    }
+
+    [Fact]
+    public void AsyncInstallTriggerThatSucceeds_RunsItsWholeBodyAndDoesNotRaise()
+    {
+        var target = new Installer();
+        InstallTriggerRunner.InvokeTrigger(
+            Cu(), target, M(nameof(Installer.AsyncOk)), "OnInstallAppPerCompany");
+
+        // Both sides of the suspension point ran. A helper that returned as soon as the
+        // ValueTask was handed to it would leave Steps at 1 whenever the continuation had
+        // not yet been scheduled, so this is the assertion that the result is genuinely
+        // awaited rather than merely touched.
+        Assert.Equal(2, target.Steps);
+    }
+
+    [Fact]
+    public void SyncInstallTriggerThatSucceeds_RunsAndDoesNotRaise()
+    {
+        var target = new Installer();
+        InstallTriggerRunner.InvokeTrigger(
+            Cu(), target, M(nameof(Installer.SyncOk)), "OnInstallAppPerDatabase");
+        Assert.Equal(1, target.Steps);
+    }
+
+    [Fact]
+    public void AbsentTrigger_IsANoOp()
+    {
+        // A codeunit declaring only one of the two lifecycle triggers passes null for the
+        // other; that must stay a no-op rather than becoming a null-reference failure now
+        // that the call site also inspects the returned value.
+        InstallTriggerRunner.InvokeTrigger(Cu(), new Installer(), null, "OnInstallAppPerCompany");
+    }
+}

--- a/AlRunner.Tests/InstallTriggerAsyncObservationTests.cs
+++ b/AlRunner.Tests/InstallTriggerAsyncObservationTests.cs
@@ -13,14 +13,29 @@ namespace AlRunner.Tests;
 /// instead of being parked on a discarded <c>ValueTask</c> (#2960).
 ///
 /// WHY THIS IS A C# TEST AND NOT AL. The broken shape needs an install trigger compiled as
-/// an <c>async ValueTask</c> state machine, and the runner's own AL-to-C# emitter does not
-/// produce one. Measured on BC 28.1 by printing <c>trigger.ReturnType</c> at the call site
-/// while running <c>tests/runner-extras/install-trigger-seed</c>: all sixteen precompiled
-/// platform install triggers in that bundle's closure returned <c>ValueTask</c>
-/// (Codeunit1809, 1933, 3999, 3907, 1596, 2014, 290, 4331, 5000, 7582, 7760, 7782, 8352,
-/// 9056, 9993 …) and the bundle's own source-compiled Codeunit60711 returned <c>Void</c> —
-/// for both of its triggers. So a first-party AL reproducer cannot reach the defect and
-/// would pass with and without the fix, which <c>.claude/rules/tdd.md</c> calls noise.
+/// an <c>async ValueTask</c> state machine, and no install trigger the runner's own compile
+/// path has produced is one. Measured on BC 28.1 by printing <c>trigger.ReturnType</c> at the
+/// call site:
+///
+/// <list type="bullet">
+/// <item>all sixteen PRECOMPILED platform install triggers in the closure returned
+/// <c>ValueTask</c> (Codeunit1809, 1933, 3999, 3907, 1596, 2014, 290, 4331, 5000, 7582,
+/// 7760, 7782, 8352, 9056, 9993 …);</item>
+/// <item>every SOURCE-COMPILED one returned <c>Void</c>: both triggers of
+/// <c>tests/runner-extras/install-trigger-seed</c>'s Codeunit60711 — whose per-company body
+/// is not just <c>Record.Init/Insert</c>, it also calls <c>StartSession</c> — and both
+/// triggers of a throwaway probe bundle written specifically to try to force the async shape,
+/// one of them a bare <c>Codeunit.Run(Codeunit::"…")</c>.</item>
+/// </list>
+///
+/// <para>WHAT THAT DOES AND DOES NOT ESTABLISH. It is not a property of "the emitter": the
+/// runner compiles AL with BC's own compiler, so <c>Void</c> versus <c>async ValueTask</c> is
+/// decided by the BODY, and the precompiled sixteen are async because their bodies await. So
+/// this is a measurement over the shapes tried, not a law — <c>Codeunit.Run</c> was the most
+/// promising candidate for reaching the async shape from first-party AL and it does not, but
+/// some other body might, and if one is ever found an AL reproducer becomes possible and
+/// should be written. Until then a first-party AL test cannot reach the defect and would pass
+/// with and without the fix, which <c>.claude/rules/tdd.md</c> calls noise.</para>
 ///
 /// Same split, and the same reason, as <c>ObservingSubscriberMethodInfoTests</c> (#2932's
 /// table-event-subscriber half of this defect) and <c>DispatchObserveAsyncResultTests</c>.

--- a/AlRunner.Tests/RunnerAssemblyReferenceTests.cs
+++ b/AlRunner.Tests/RunnerAssemblyReferenceTests.cs
@@ -17,7 +17,7 @@
 //
 //     line  31, col 24 → `            => global::AlRunner.BcRuntime.NCLEnumMetadata_CreateByIdAlAware(id);`
 //                         (12 spaces + "=> global::" is 23 characters; `AlRunner` starts at 24)
-//     line 323, col 18 → `            var (appId, name, publisher, version) = global::AlRunner…`
+//     line 327, col 18 → `            var (appId, name, publisher, version) = global::AlRunner…`
 //                         (`appId` starts at 18, and CS8130 names 'appId')
 //
 //   PolyfillReferenceCoordinatesTests below pins both, so this diagnosis cannot rot into a
@@ -189,15 +189,15 @@ public sealed class PolyfillReferenceCoordinatesTests
     }
 
     [Fact]
-    public void PolyfillLine323Column18_IsTheDeconstructionVariableCs8130Named()
+    public void PolyfillLine327Column18_IsTheDeconstructionVariableCs8130Named()
     {
         var lines = PolyfillLines();
-        var line323 = lines[322];
+        var line327 = lines[326];
 
         Assert.Contains("global::AlRunner.BcRuntime.GetModuleAppInfoFor",
-            line323, StringComparison.Ordinal);
+            line327, StringComparison.Ordinal);
         // CS8130 named 'appId'; column 18, 1-based.
-        Assert.Equal("appId", line323.Substring(17, "appId".Length));
+        Assert.Equal("appId", line327.Substring(17, "appId".Length));
     }
 
     /// <summary>

--- a/AlRunner/BcAssembler.cs
+++ b/AlRunner/BcAssembler.cs
@@ -843,12 +843,14 @@ namespace AlRunnerShim
             Microsoft.Dynamics.Nav.Types.DataError errorLevel,
             Microsoft.Dynamics.Nav.Runtime.ByRef<Microsoft.Dynamics.Nav.Runtime.NavModuleInfo> info)
         {
+            // MakeModuleInfo, not a local `new NavModuleInfo(...)`: it is the one constructor
+            // every module-info entry point shares, so this polyfill and the by-id lookup
+            // below cannot report different PackageIds for the same app. See its header —
+            // in real BC all three entry points ARE one method (#2961).
             var (appId, name, publisher, version) = global::AlRunner.BcRuntime.GetModuleAppInfoFor(
                 global::System.Reflection.Assembly.GetExecutingAssembly());
-            var navVersion = new Microsoft.Dynamics.Nav.Runtime.NavVersion(version);
-            var emptyDeps = Microsoft.Dynamics.Nav.Runtime.NavList<Microsoft.Dynamics.Nav.Runtime.NavModuleDependencyInfo>.Default;
-            info.Value = new Microsoft.Dynamics.Nav.Runtime.NavModuleInfo(
-                appId, name, publisher, navVersion, navVersion, emptyDeps, appId);
+            info.Value = global::AlRunner.Patches.NavAppModuleInfoPatches.MakeModuleInfo(
+                appId, name, publisher, version);
             return true;
         }
 
@@ -879,12 +881,11 @@ namespace AlRunnerShim
             Microsoft.Dynamics.Nav.Types.DataError errorLevel,
             Microsoft.Dynamics.Nav.Runtime.ByRef<Microsoft.Dynamics.Nav.Runtime.NavModuleInfo> info)
         {
+            // Shared constructor — see ALNavApp_GetCurrentModuleInfo above.
             var (appId, name, publisher, version) = global::AlRunner.BcRuntime.GetCallerModuleAppInfoFor(
                 global::System.Reflection.Assembly.GetExecutingAssembly());
-            var navVersion = new Microsoft.Dynamics.Nav.Runtime.NavVersion(version);
-            var emptyDeps = Microsoft.Dynamics.Nav.Runtime.NavList<Microsoft.Dynamics.Nav.Runtime.NavModuleDependencyInfo>.Default;
-            info.Value = new Microsoft.Dynamics.Nav.Runtime.NavModuleInfo(
-                appId, name, publisher, navVersion, navVersion, emptyDeps, appId);
+            info.Value = global::AlRunner.Patches.NavAppModuleInfoPatches.MakeModuleInfo(
+                appId, name, publisher, version);
             return true;
         }
 

--- a/AlRunner/BcAssembler.cs
+++ b/AlRunner/BcAssembler.cs
@@ -861,14 +861,15 @@ namespace AlRunnerShim
             global::System.Guid moduleId,
             Microsoft.Dynamics.Nav.Runtime.ByRef<Microsoft.Dynamics.Nav.Runtime.NavModuleInfo> info)
         {
-            var found = global::AlRunner.BcRuntime.TryGetModuleInfoByAppId(moduleId);
-            if (found == null) return false;
-            var (appId, name, publisher, version) = found.Value;
-            var navVersion = new Microsoft.Dynamics.Nav.Runtime.NavVersion(version);
-            var emptyDeps = Microsoft.Dynamics.Nav.Runtime.NavList<Microsoft.Dynamics.Nav.Runtime.NavModuleDependencyInfo>.Default;
-            info.Value = new Microsoft.Dynamics.Nav.Runtime.NavModuleInfo(
-                appId, name, publisher, navVersion, navVersion, emptyDeps, appId);
-            return true;
+            // ONE implementation, shared with the Cecil patch that serves PRECOMPILED callers
+            // (NclCecilRewrite.Dispatch.cs -> NavAppModuleInfoPatches.ALNavApp_GetModuleInfo).
+            // This used to be a second copy, and it had drifted: it returned false on
+            // not-found regardless of errorLevel, so the STATEMENT form of
+            // NavApp.GetModuleInfo populated nothing instead of raising the way BC does, and
+            // it reported appId as the PackageId rather than the value the runner stamps on
+            // that app's Published Application row. See that method's header (#2961).
+            return global::AlRunner.Patches.NavAppModuleInfoPatches.ALNavApp_GetModuleInfo(
+                errorLevel, moduleId, info);
         }
 
         // NavApp.GetCallerModuleInfo — the module that CALLED into the executing app

--- a/AlRunner/Infrastructure/NclCecilRewrite.Dispatch.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Dispatch.cs
@@ -688,6 +688,21 @@ public static partial class NclCecilRewrite
                     ReplaceBodyWithHelper(asm.MainModule, mCurrent, h);
                 }
 
+                // The BY-ID overload. Unpatched it raises "No installed extension was found
+                // with ID '<guid>'" for EVERY id, because BC resolves it against an app group
+                // the runner does not have — so NavApp.VersionInstalled answered for nothing,
+                // including the System Application's own id (#2961). The helper answers from
+                // the loaded-app closure and keeps BC's not-found arms intact.
+                var mById = alNavAppModuleType.Methods.FirstOrDefault(x =>
+                    x.Name == "ALGetModuleInfo" && x.Parameters.Count == 3 && x.IsStatic);
+                if (mById != null)
+                {
+                    var h = typeof(AlRunner.Patches.NavAppModuleInfoPatches).GetMethod(
+                        nameof(AlRunner.Patches.NavAppModuleInfoPatches.ALNavApp_GetModuleInfo),
+                        BindingFlags.Public | BindingFlags.Static)!;
+                    ReplaceBodyWithHelper(asm.MainModule, mById, h);
+                }
+
                 var mCaller = alNavAppModuleType.Methods.FirstOrDefault(x =>
                     x.Name == "ALGetCallerModuleInfo" && x.Parameters.Count == 2 && x.IsStatic);
                 if (mCaller != null)
@@ -696,6 +711,33 @@ public static partial class NclCecilRewrite
                         nameof(AlRunner.Patches.NavAppModuleInfoPatches.ALNavApp_GetCallerModuleInfo),
                         BindingFlags.Public | BindingFlags.Static)!;
                     ReplaceBodyWithHelper(asm.MainModule, mCaller, h);
+                }
+            }
+        }
+
+        // ── ALSession.ALStartSessionAsyncImpl → BcRuntime.ALSession_ALStartSessionAsyncImpl ──
+        //
+        // The single seam every ALStartSession / ALStartSessionAsync overload in Ncl forwards
+        // into. Source-compiled AL already reaches the runner's StartSession model through
+        // BcAssembler's polyfill redirect; precompiled AL (Base App, System App, ISV DLLs)
+        // called Ncl's real body, which opens a second NavSession and asks SQL for the
+        // database version — "Value cannot be null. (Parameter 'database')" on the skeleton.
+        // Patching the impl rather than the seven public overloads keeps ONE model of
+        // StartSession, so a precompiled and a source-compiled caller cannot diverge.
+        // See BcRuntime.ALSession_ALStartSessionAsyncImpl for the measurement (#2960).
+        {
+            var alSessionType = asm.MainModule.GetType("Microsoft.Dynamics.Nav.Runtime.ALSession");
+            if (alSessionType != null)
+            {
+                var mImpl = alSessionType.Methods.FirstOrDefault(x =>
+                    x.Name == "ALStartSessionAsyncImpl" && x.Parameters.Count == 8 && x.IsStatic);
+                if (mImpl != null)
+                {
+                    var h = typeof(AlRunner.BcRuntime).GetMethod(
+                        nameof(AlRunner.BcRuntime.ALSession_ALStartSessionAsyncImpl),
+                        BindingFlags.Public | BindingFlags.Static)!;
+                    ReplaceBodyWithHelper(asm.MainModule, mImpl, h);
+                    Console.Error.WriteLine("[Cecil] Rewrote ALSession.ALStartSessionAsyncImpl → BcRuntime.AlRunnerStartSession (inline-synchronous session model, precompiled callers included)");
                 }
             }
         }

--- a/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
@@ -181,6 +181,66 @@ public static partial class NclCecilRewrite
                 Console.Error.WriteLine("[Cecil] Neutralised WindowsIdentity.GetCurrent() in NavEnvironment..cctor → ldnull (serviceAccount=null; portable cctor)");
             }
 
+            // 1b) NavUserAuthentication.get_WindowsIdentity — the SECOND
+            //     WindowsIdentity.GetCurrent() on the startup path, and the sibling the
+            //     block above missed. Same instruction, same PlatformNotSupportedException
+            //     on Linux, same one-instruction neutralisation.
+            //
+            //     BC's body:
+            //
+            //         if (AuthenticationMethod == Windows || AuthenticationMethod == UserName)
+            //         {
+            //             if (windowsIdentity != null)            return windowsIdentity;
+            //             ... IServiceSecurityContextIdentityProvider?.GetWindowsIdentity()
+            //             ... getWindowsIdentity?.Invoke()
+            //             return WindowsIdentity.GetCurrent();     // <- Linux-fatal
+            //         }
+            //         return null;
+            //
+            //     The runner's skeleton NavUserAuthentication is built with
+            //     RuntimeHelpers.GetUninitializedObject (BcRuntime identity seed), so
+            //     AuthenticationMethod is the default enum value and the property takes the
+            //     first branch; none of the three earlier returns can produce a value here
+            //     either, so every read reached GetCurrent() and threw.
+            //
+            //     ldnull is FAITHFUL, not a silent default: there is no current Windows
+            //     identity on Linux, the property's own else-branch already returns null for
+            //     any other authentication method, and every caller null-checks —
+            //     NavUserAuthentication.Clone() reads `if (WindowsIdentity != null)` and
+            //     simply does not copy the handle. Nothing downstream receives a fabricated
+            //     identity.
+            //
+            //     Reached from ALSession.ALStartSessionAsyncImpl → NavUserAuthentication
+            //     .Clone(), which is what BC's feature-telemetry uptake logging
+            //     (Codeunit8705.UpdateFeatureUptakeStatus, performWriteTransactionsIn
+            //     ASeparateSession) does — so it fires from an ordinary Base App install
+            //     trigger, not from anything the test author wrote. Found by letting
+            //     install triggers run past their first await (#2960).
+            //
+            //     Body is byte-identical across BC 27.0 and 28.4 (decompile hash
+            //     0a36e18b2f811a5a130d8490215c5f5eb9b5813f3db8628c81feabe29ab0ef97 in both),
+            //     so requiring exactly one call site is a real invariant and the throw below
+            //     is a shape-change alarm, not a guess.
+            //     Token-safe: replaces one call's use of an existing memberRef with a
+            //     no-operand ldnull; adds no new typeRef/memberRef.
+            {
+                var getWinId = FindNclMethod(nclMod,
+                    "Microsoft.Dynamics.Nav.Runtime.NavUserAuthentication", "get_WindowsIdentity", 0);
+                var il = getWinId.Body.GetILProcessor();
+                var getCurrentCalls = getWinId.Body.Instructions
+                    .Where(i => (i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt)
+                        && i.Operand is MethodReference mr
+                        && mr.DeclaringType.FullName == "System.Security.Principal.WindowsIdentity"
+                        && mr.Name == "GetCurrent"
+                        && mr.Parameters.Count == 0)
+                    .ToList();
+                if (getCurrentCalls.Count != 1)
+                    throw new InvalidOperationException(
+                        $"[Cecil] expected exactly 1 WindowsIdentity.GetCurrent() in NavUserAuthentication.get_WindowsIdentity, found {getCurrentCalls.Count} — Ncl shape changed; do not commit");
+                il.Replace(getCurrentCalls[0], il.Create(OpCodes.Ldnull));
+                Console.Error.WriteLine("[Cecil] Neutralised WindowsIdentity.GetCurrent() in NavUserAuthentication.get_WindowsIdentity → ldnull (no Windows identity on Linux; every caller null-checks)");
+            }
+
             // 2a) NavEnvironment.get_ServiceAccount → BcRuntime.GetServiceAccountReplacement().
             //     Helper returns object?; the property returns SecurityIdentifier, so cast.
             {

--- a/AlRunner/InstallTriggerRunner.cs
+++ b/AlRunner/InstallTriggerRunner.cs
@@ -32,7 +32,7 @@ namespace AlRunner;
 
 public static class InstallTriggerRunner
 {
-    private sealed record InstallCodeunit(
+    internal sealed record InstallCodeunit(
         Type Type, ConstructorInfo Ctor, MethodInfo? PerCompany, MethodInfo? PerDatabase);
 
     // Dependency-app assemblies in dependency order (a dep's Install fires
@@ -164,30 +164,53 @@ public static class InstallTriggerRunner
             }
     }
 
-    private static void InvokeTrigger(InstallCodeunit cu, object instance, MethodInfo? trigger, string name)
+    internal static void InvokeTrigger(InstallCodeunit cu, object instance, MethodInfo? trigger, string name)
     {
         if (trigger == null) return;
         try
         {
-            trigger.Invoke(instance, null);
+            // OBSERVE the result — do not discard it (#2960). The AL compiler emits an
+            // install trigger as an async ValueTask state machine whenever the body needs
+            // one, and measured across the BC 28.1 platform closure that is every
+            // precompiled install trigger there is (Codeunit1809, 1933, 3999, 3907, 1596,
+            // 290, 2014, 4331, 7760, 7782, 8352, 9056, 9993 …). Only the runner's own
+            // source-compiled output is synchronous.
+            //
+            // Discarding that ValueTask abandoned the body at its FIRST suspension: the
+            // rest of the per-company seeding never ran, and an Error() raised past that
+            // point was captured onto the state machine instead of propagating out of
+            // MethodInfo.Invoke — so it never reached the catch arm below, which is where
+            // the loud diagnostic and the AL-stack rethrow live. A failing install trigger
+            // was therefore silent, and the runner captured an install baseline it believed
+            // was complete (.claude/rules/loud-failures.md).
+            //
+            // Same defect, same fix, as #2932's table-event subscriber half — one seam
+            // (BcRuntime.ObserveAsyncResult), not a second mechanism.
+            BcRuntime.ObserveAsyncResult(trigger.Invoke(instance, null), trigger);
         }
-        catch (TargetInvocationException tex) when (tex.InnerException != null)
+        catch (Exception ex)
         {
+            // ObserveAsyncResult rethrows the ORIGINAL exception off the awaiter rather
+            // than a TargetInvocationException, so the async case does not arrive wrapped
+            // the way the synchronous MethodInfo.Invoke case does. Unwrap when it is
+            // wrapped, and report both shapes identically.
+            var inner = (ex as TargetInvocationException)?.InnerException ?? ex;
+
             // Loud, type-preserving: name the failing surface, then rethrow the
             // ORIGINAL exception (RunnerOutOfScopeException stays itself).
             Console.Error.WriteLine(
                 $"[install-trigger] {cu.Type.Name}.{name} ({cu.Type.Assembly.GetName().Name}) threw: " +
-                $"{tex.InnerException.GetType().Name}: {tex.InnerException.Message}");
+                $"{inner.GetType().Name}: {inner.Message}");
             // Install triggers run outside a test, so GetCaptured's "fall back to the most
             // recent capture" is wrong here — under --watch that capture can belong to an
             // unrelated test from a previous cycle (#1958). GetCapturedFor has no such
             // fallback: it answers only for THIS exception instance, or not at all.
-            var alStack = AlRunner.Infrastructure.AlCallStackCapture.GetCapturedFor(tex.InnerException);
+            var alStack = AlRunner.Infrastructure.AlCallStackCapture.GetCapturedFor(inner);
             if (!string.IsNullOrEmpty(alStack))
                 Console.Error.WriteLine($"[install-trigger] AL stack:\n{alStack}");
             else
-                Console.Error.WriteLine($"[install-trigger] {tex.InnerException}");
-            ExceptionDispatchInfo.Capture(tex.InnerException).Throw();
+                Console.Error.WriteLine($"[install-trigger] {inner}");
+            ExceptionDispatchInfo.Capture(inner).Throw();
         }
     }
 

--- a/AlRunner/InstallTriggerRunner.cs
+++ b/AlRunner/InstallTriggerRunner.cs
@@ -173,8 +173,12 @@ public static class InstallTriggerRunner
             // install trigger as an async ValueTask state machine whenever the body needs
             // one, and measured across the BC 28.1 platform closure that is every
             // precompiled install trigger there is (Codeunit1809, 1933, 3999, 3907, 1596,
-            // 290, 2014, 4331, 7760, 7782, 8352, 9056, 9993 …). Only the runner's own
-            // source-compiled output is synchronous.
+            // 290, 2014, 4331, 7760, 7782, 8352, 9056, 9993 …). Every source-compiled install
+            // trigger measured so far is synchronous instead — see
+            // AlRunner.Tests/InstallTriggerAsyncObservationTests for exactly which bodies were
+            // tried, and for why that is a measurement over shapes rather than a rule the
+            // emitter enforces. Either shape has to arrive here correctly, which is what the
+            // observe-then-unwrap below is for.
             //
             // Discarding that ValueTask abandoned the body at its FIRST suspension: the
             // rest of the per-company seeding never ran, and an Error() raised past that

--- a/AlRunner/Patches/NavAppModuleInfoPatches.cs
+++ b/AlRunner/Patches/NavAppModuleInfoPatches.cs
@@ -39,6 +39,79 @@ public static class NavAppModuleInfoPatches
         return true;
     }
 
+    // Cecil patch target: static bool ALNavApp.ALGetModuleInfo(DataError, Guid, ByRef<NavModuleInfo>)
+    //
+    // WHY: this is the BY-ID overload — AL's `NavApp.GetModuleInfo(appId, info)` — and it is
+    // the one the two patches above do NOT cover. Real BC resolves the id against
+    // NavCurrentThread.TryResolveAppGroup().OrderedAppMetadata; the runner has no app group,
+    // so TryResolveAppGroup answers null, no metadata matches ANY id, and BC's own
+    // not-found arm raises
+    //
+    //     NavAppException: No installed extension was found with ID '<guid>'.
+    //
+    // for every app — including apps the runner has loaded, and including the System
+    // Application's own id. So `NavApp.VersionInstalled` / `NavApp.GetModuleInfo` could not
+    // answer "yes" about anything (#2961). That is not a missing surface; it is the runner
+    // failing to report the closure it demonstrably holds.
+    //
+    // WHAT THIS DOES: answers from BcRuntime.RegisteredModules() — the same loaded-app
+    // closure RecordPatches.EnsurePublishedApplicationRowsSeeded writes into Published
+    // Application (#2963), so the two views cannot disagree. Reconstruction of state the
+    // runner holds, not a fake.
+    //
+    // BC's NOT-FOUND SEMANTICS ARE PRESERVED EXACTLY. An id the runner has not loaded is
+    // genuinely not installed here, so the TrapError arm still returns false with a null
+    // info, and the raising arm still throws NavAppException with BC's own message. A patch
+    // that answered "installed" for every id would be the silent-fake this repo forbids.
+    //
+    // PackageId comes from AppPackageIdentity — the SAME deterministic per-app GUID stamped
+    // onto this app's Published Application row and its AllObj rows — so AL that reads
+    // ModuleInfo.PackageId and then looks the app up by package id finds it. The two
+    // stack-walk patches above still pass appId there; they predate AppPackageIdentity and
+    // are left alone rather than changed blind (#3072-adjacent, not measured here).
+    //
+    // DataVersion is reported as the app version, matching the two patches above. Real BC
+    // computes GetDataVersionForInstall/GetDataVersionForUpgrade off publish-time state the
+    // runner does not have.
+    //
+    // The moduleId == Guid.Empty branch is NOT implemented: BC answers it from
+    // NavGlobal.AppDatabase.SqlDatabaseProperties.ApplicationFamily, which the runner has no
+    // truthful source for, and inventing a family string would be a silent wrong answer.
+    // It refuses loudly instead (.claude/rules/loud-failures.md). Today that branch NREs on
+    // the skeleton, so refusing is strictly more informative than the status quo.
+    public static bool ALNavApp_GetModuleInfo(
+        Microsoft.Dynamics.Nav.Types.DataError errorLevel,
+        System.Guid moduleId,
+        Microsoft.Dynamics.Nav.Runtime.ByRef<Microsoft.Dynamics.Nav.Runtime.NavModuleInfo> info)
+    {
+        if (moduleId == System.Guid.Empty)
+            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                "NavApp.GetModuleInfo(Guid.Empty)",
+                "not-yet-implemented",
+                "docs/scope.md");
+
+        foreach (var m in AlRunner.BcRuntime.RegisteredModules())
+        {
+            if (m.AppId != moduleId) continue;
+            var navVersion = new Microsoft.Dynamics.Nav.Runtime.NavVersion(m.Version);
+            var emptyDeps = Microsoft.Dynamics.Nav.Runtime.NavList<Microsoft.Dynamics.Nav.Runtime.NavModuleDependencyInfo>.Default;
+            info.Value = new Microsoft.Dynamics.Nav.Runtime.NavModuleInfo(
+                m.AppId, m.Name, m.Publisher, navVersion, navVersion, emptyDeps,
+                AlRunner.Infrastructure.AppPackageIdentity.PackageIdFor(m.AppId));
+            return true;
+        }
+
+        // Not loaded => not installed. BC's own two arms, verbatim in behaviour.
+        info.Value = null;
+        if (errorLevel == Microsoft.Dynamics.Nav.Types.DataError.TrapError)
+            return false;
+        throw new Microsoft.Dynamics.Nav.Types.Exceptions.NavAppException(
+            Microsoft.Dynamics.Nav.Diagnostic.PrivacyClassification.SystemMetadata,
+            string.Format(
+                System.Globalization.CultureInfo.CurrentCulture,
+                "No installed extension was found with ID '{0}'.", moduleId));
+    }
+
     // Cecil patch target: static bool ALNavApp.ALGetCallerModuleInfo(DataError, ByRef<NavModuleInfo>)
     // Uses a stack-walk to identify the "caller" of the current AL module:
     // finds the first registered AL assembly (the precompiled dep = "self"), then

--- a/AlRunner/Patches/NavAppModuleInfoPatches.cs
+++ b/AlRunner/Patches/NavAppModuleInfoPatches.cs
@@ -23,6 +23,52 @@ namespace AlRunner.Patches;
 
 public static class NavAppModuleInfoPatches
 {
+    /// <summary>
+    /// The ONE place a <c>NavModuleInfo</c> is constructed for an app the runner has
+    /// identified. Every module-info entry point goes through it — the two Cecil patches in
+    /// this file that serve PRECOMPILED AL, the by-id patch below, and the two source-compiled
+    /// polyfills in <c>BcAssembler.NavRuntimeHelpersShim</c>.
+    ///
+    /// <para>WHY IT HAS TO BE ONE PLACE. Real BC has exactly one implementation:
+    /// <c>ALGetCurrentModuleInfo</c> and <c>ALGetCallerModuleInfo</c> are each a two-line
+    /// forward into <c>ALGetModuleInfo</c> (decompiled from bc281, and the same shape on every
+    /// cached version), which fills <c>PackageId</c> from
+    /// <c>navAppRuntimeMetadata.PackageId.Value</c> for all three callers. So in BC, AL asking
+    /// about one app three different ways gets three identical answers, and any runner in
+    /// which it does not is diverging from AL-observable behaviour.</para>
+    ///
+    /// <para>The runner patches the three entry points independently, so keeping them
+    /// consistent is a property of this code and nothing else. Before #2961 all five sites
+    /// passed <c>appId</c> as the <c>PackageId</c> — wrong, but at least uniformly wrong.
+    /// Fixing only the by-id one would have made <c>GetModuleInfo(x).PackageId</c> and
+    /// <c>GetCurrentModuleInfo().PackageId</c> disagree for the same app x, which is worse
+    /// than either answer on its own. Routing them all through here is what stops that
+    /// recurring the next time one of the five is touched.</para>
+    ///
+    /// <para>PACKAGE ID. <see cref="AlRunner.Infrastructure.AppPackageIdentity.PackageIdFor"/>
+    /// — the SAME deterministic per-app GUID the runner stamps onto that app's Published
+    /// Application row (#2963) and onto its AllObj rows (#3066), so AL that reads
+    /// <c>ModuleInfo.PackageId</c> and then looks the app up by package id finds it. It is
+    /// <c>Guid.Empty</c> in / <c>Guid.Empty</c> out, so an unidentified caller still reports a
+    /// blank package id rather than a derived one claiming to be some app.</para>
+    ///
+    /// <para>NOT FAITHFUL, AND SAID SO: <c>DataVersion</c> is reported as the app version. Real
+    /// BC computes it from <c>GetDataVersionForInstall</c> / <c>GetDataVersionForUpgrade</c>,
+    /// which read publish-time state the runner has no source for. The dependency list is
+    /// likewise empty where BC projects the app's real dependency set; nothing measured here
+    /// reads it, and inventing entries would be worse than an empty list a caller can see is
+    /// empty.</para>
+    /// </summary>
+    public static Microsoft.Dynamics.Nav.Runtime.NavModuleInfo MakeModuleInfo(
+        System.Guid appId, string name, string publisher, string version)
+    {
+        var navVersion = new Microsoft.Dynamics.Nav.Runtime.NavVersion(version);
+        var emptyDeps = Microsoft.Dynamics.Nav.Runtime.NavList<Microsoft.Dynamics.Nav.Runtime.NavModuleDependencyInfo>.Default;
+        return new Microsoft.Dynamics.Nav.Runtime.NavModuleInfo(
+            appId, name, publisher, navVersion, navVersion, emptyDeps,
+            AlRunner.Infrastructure.AppPackageIdentity.PackageIdFor(appId));
+    }
+
     // Cecil patch target: static bool ALNavApp.ALGetCurrentModuleInfo(DataError, ByRef<NavModuleInfo>)
     // Called from precompiled deps where the BcAssembler polyfill redirect does not apply.
     // Uses a stack-walk to identify the first registered AL assembly on the call stack —
@@ -32,10 +78,7 @@ public static class NavAppModuleInfoPatches
         Microsoft.Dynamics.Nav.Runtime.ByRef<Microsoft.Dynamics.Nav.Runtime.NavModuleInfo> info)
     {
         var (appId, name, publisher, version) = AlRunner.BcRuntime.GetCurrentModuleFromCallStack();
-        var navVersion = new Microsoft.Dynamics.Nav.Runtime.NavVersion(version);
-        var emptyDeps = Microsoft.Dynamics.Nav.Runtime.NavList<Microsoft.Dynamics.Nav.Runtime.NavModuleDependencyInfo>.Default;
-        info.Value = new Microsoft.Dynamics.Nav.Runtime.NavModuleInfo(
-            appId, name, publisher, navVersion, navVersion, emptyDeps, appId);
+        info.Value = MakeModuleInfo(appId, name, publisher, version);
         return true;
     }
 
@@ -73,15 +116,11 @@ public static class NavAppModuleInfoPatches
     // info, and the raising arm still throws NavAppException with BC's own message. A patch
     // that answered "installed" for every id would be the silent-fake this repo forbids.
     //
-    // PackageId comes from AppPackageIdentity — the SAME deterministic per-app GUID stamped
-    // onto this app's Published Application row and its AllObj rows — so AL that reads
-    // ModuleInfo.PackageId and then looks the app up by package id finds it. The two
-    // stack-walk patches above still pass appId there; they predate AppPackageIdentity and
-    // are left alone rather than changed blind (#3072-adjacent, not measured here).
-    //
-    // DataVersion is reported as the app version, matching the two patches above. Real BC
-    // computes GetDataVersionForInstall/GetDataVersionForUpgrade off publish-time state the
-    // runner does not have.
+    // PackageId, DataVersion and the dependency list all come from MakeModuleInfo above,
+    // shared with the two stack-walk patches and the two source-compiled polyfills, so the
+    // three AL-visible ways of asking about one app cannot disagree — which is exactly what
+    // real BC guarantees by having ALGetCurrentModuleInfo and ALGetCallerModuleInfo forward
+    // into THIS method. See MakeModuleInfo's header for what is and is not faithful in it.
     //
     // The moduleId == Guid.Empty branch is NOT implemented: BC answers it from
     // NavGlobal.AppDatabase.SqlDatabaseProperties.ApplicationFamily, which the runner has no
@@ -103,15 +142,23 @@ public static class NavAppModuleInfoPatches
         if (found != null)
         {
             var (appId, name, publisher, version) = found.Value;
-            var navVersion = new Microsoft.Dynamics.Nav.Runtime.NavVersion(version);
-            var emptyDeps = Microsoft.Dynamics.Nav.Runtime.NavList<Microsoft.Dynamics.Nav.Runtime.NavModuleDependencyInfo>.Default;
-            info.Value = new Microsoft.Dynamics.Nav.Runtime.NavModuleInfo(
-                appId, name, publisher, navVersion, navVersion, emptyDeps,
-                AlRunner.Infrastructure.AppPackageIdentity.PackageIdFor(appId));
+            info.Value = MakeModuleInfo(appId, name, publisher, version);
             return true;
         }
 
-        // Not loaded => not installed. BC's own two arms, verbatim in behaviour.
+        // Not loaded => not installed. Same CONTROL FLOW as BC's two arms: a TrapError caller
+        // gets false with a null info, a raising caller gets a NavAppException of the same type
+        // naming the same id.
+        //
+        // ONE DIVERGENCE, and it is in the message TEXT rather than the behaviour. BC formats
+        // Lang.NavApp_NoInstalledMatchFound under CultureInfo.CurrentCulture — a localized
+        // resource — and this inlines the English literal. Under the invariant culture the
+        // runner executes in the two are the same string, and the runner-extras test that
+        // matches on it asserts the English fragment, so nothing observes the difference today.
+        // It would become observable the moment the runner ran under a localized culture with
+        // BC's own resources loaded, which is why it is recorded here rather than left to be
+        // rediscovered. Reading the resource instead would couple this patch to a Lang class
+        // whose accessibility is not part of the DLL contract we may rely on.
         info.Value = null;
         if (errorLevel == Microsoft.Dynamics.Nav.Types.DataError.TrapError)
             return false;
@@ -133,10 +180,7 @@ public static class NavAppModuleInfoPatches
         Microsoft.Dynamics.Nav.Runtime.ByRef<Microsoft.Dynamics.Nav.Runtime.NavModuleInfo> info)
     {
         var (appId, name, publisher, version) = AlRunner.BcRuntime.GetCallerModuleFromCallStack();
-        var navVersion = new Microsoft.Dynamics.Nav.Runtime.NavVersion(version);
-        var emptyDeps = Microsoft.Dynamics.Nav.Runtime.NavList<Microsoft.Dynamics.Nav.Runtime.NavModuleDependencyInfo>.Default;
-        info.Value = new Microsoft.Dynamics.Nav.Runtime.NavModuleInfo(
-            appId, name, publisher, navVersion, navVersion, emptyDeps, appId);
+        info.Value = MakeModuleInfo(appId, name, publisher, version);
         return true;
     }
 }

--- a/AlRunner/Patches/NavAppModuleInfoPatches.cs
+++ b/AlRunner/Patches/NavAppModuleInfoPatches.cs
@@ -54,10 +54,19 @@ public static class NavAppModuleInfoPatches
     // answer "yes" about anything (#2961). That is not a missing surface; it is the runner
     // failing to report the closure it demonstrably holds.
     //
-    // WHAT THIS DOES: answers from BcRuntime.RegisteredModules() — the same loaded-app
+    // WHAT THIS DOES: answers from BcRuntime.TryGetModuleInfoByAppId — the SAME lookup the
+    // source-compiled polyfill in BcAssembler already used, and over the same loaded-app
     // closure RecordPatches.EnsurePublishedApplicationRowsSeeded writes into Published
-    // Application (#2963), so the two views cannot disagree. Reconstruction of state the
-    // runner holds, not a fake.
+    // Application (#2963), so no two views of "which apps are installed" can disagree.
+    // Reconstruction of state the runner holds, not a fake.
+    //
+    // The source-compiled polyfill now CALLS this method rather than carrying its own copy
+    // (BcAssembler.NavRuntimeHelpersShim.ALNavApp_GetModuleInfo). It had two divergences
+    // worth naming, because a single implementation is the only way they stay fixed:
+    // it returned false on not-found whatever the DataError was, so the STATEMENT form of
+    // NavApp.GetModuleInfo silently populated nothing instead of raising the way BC does;
+    // and it reported appId as the PackageId, which is not the value the runner stamps on
+    // that app's Published Application row or its AllObj rows.
     //
     // BC's NOT-FOUND SEMANTICS ARE PRESERVED EXACTLY. An id the runner has not loaded is
     // genuinely not installed here, so the TrapError arm still returns false with a null
@@ -90,14 +99,15 @@ public static class NavAppModuleInfoPatches
                 "not-yet-implemented",
                 "docs/scope.md");
 
-        foreach (var m in AlRunner.BcRuntime.RegisteredModules())
+        var found = AlRunner.BcRuntime.TryGetModuleInfoByAppId(moduleId);
+        if (found != null)
         {
-            if (m.AppId != moduleId) continue;
-            var navVersion = new Microsoft.Dynamics.Nav.Runtime.NavVersion(m.Version);
+            var (appId, name, publisher, version) = found.Value;
+            var navVersion = new Microsoft.Dynamics.Nav.Runtime.NavVersion(version);
             var emptyDeps = Microsoft.Dynamics.Nav.Runtime.NavList<Microsoft.Dynamics.Nav.Runtime.NavModuleDependencyInfo>.Default;
             info.Value = new Microsoft.Dynamics.Nav.Runtime.NavModuleInfo(
-                m.AppId, m.Name, m.Publisher, navVersion, navVersion, emptyDeps,
-                AlRunner.Infrastructure.AppPackageIdentity.PackageIdFor(m.AppId));
+                appId, name, publisher, navVersion, navVersion, emptyDeps,
+                AlRunner.Infrastructure.AppPackageIdentity.PackageIdFor(appId));
             return true;
         }
 

--- a/AlRunner/Patches/SessionPatches.cs
+++ b/AlRunner/Patches/SessionPatches.cs
@@ -410,6 +410,47 @@ public static partial class BcRuntime
     /// <para>Returns an already-completed <see cref="System.Threading.Tasks.ValueTask{T}"/>,
     /// which is faithful for this runtime: the runner drives AL synchronously, and BC's own
     /// callers await the result before reading <c>sessionId</c>.</para>
+    ///
+    /// <para>SCOPE AUDIT — two things BC's body does that this one does not
+    /// (.claude/rules/loud-failures.md asks for each to be named rather than left implicit):</para>
+    ///
+    /// <para>1. <c>timeout</c> IS DROPPED, and it is not purely decorative in BC. BC turns it
+    /// into a <c>NavCancellationTokenSource</c> that cancels the background session, and
+    /// validates it first — <c>timeoutTs.TotalMilliseconds &gt; int.MaxValue</c> raises
+    /// <c>NavNCLArgumentOutOfRangeException</c> (<c>Lang.TooLargeTimeoutALStartSession</c>).
+    /// Neither half has anything to act on here: the worker is dispatched INLINE and
+    /// synchronously, so there is no concurrent execution for a timeout to cancel and no
+    /// duration over which one could elapse. A cancellation that can never fire is not a
+    /// silent default — it is the absence of the thing being cancelled. The validation arm is
+    /// the part that is genuinely unimplemented: AL passing an absurd timeout gets no error
+    /// here where BC raises one. That is an argument-validation divergence on a value the
+    /// runner then ignores, not a wrong ANSWER to anything AL can observe about the session,
+    /// so it is recorded rather than converted into a refusal that would break every ordinary
+    /// caller passing a sane timeout. Tracked as follow-up rather than widened into this fix.</para>
+    ///
+    /// <para>2. BC REFUSES StartSession outright during an install or upgrade. Its body has,
+    /// before any of the work above:</para>
+    ///
+    /// <code>
+    ///   if (session.AppInstallationContext != null || session.AppUpgradeContext != null)
+    ///   {
+    ///       // trace: "StartSession ignored due to ongoing installation/upgrade
+    ///       //         to avoid inconsistent data in case of rollback"
+    ///       return false;
+    ///   }
+    /// </code>
+    ///
+    /// <para>That is not reproduced here, and it is worth being precise about why rather than
+    /// claiming equivalence. The runner has no <c>AppInstallationContext</c> — its install pass
+    /// is its own mechanism and never populates BC's field — so the guard has nothing to read
+    /// even if it were copied in, and it would be dead code that looked like coverage. The
+    /// consequence is real and observable: the very call this patch was written for
+    /// (<c>Codeunit8705.UpdateFeatureUptakeStatus</c>, reached from a Base App install trigger)
+    /// runs its worker here where a real tier would skip it and return false. Modelling the
+    /// install context faithfully is a separate piece of work; it is filed rather than guessed
+    /// at, because "run the worker" and "skip the worker" are different answers to an AL-visible
+    /// question and picking one by assumption is what .claude/rules/no-assumption-fixes.md
+    /// rules out.</para>
     /// </summary>
     public static System.Threading.Tasks.ValueTask<bool> ALSession_ALStartSessionAsyncImpl(
         Microsoft.Dynamics.Nav.Runtime.NavSession session,
@@ -515,12 +556,31 @@ public static partial class BcRuntime
             var trigger = ResolveOnRunTrigger(cuType);
             if (trigger != null)
             {
-                // The `record` arg is deliberately still null: BC's record-carrying
-                // StartSession overloads hand the worker a row, and this replacement has never
-                // passed it on. That is a separate defect (NavRecord does implement
-                // INavRecordHandle, so it is a drop rather than a type limitation) and it needs
-                // its own worker fixture that reads Rec — tracked separately, not widened into
-                // this fix.
+                // The caller's `record` IS passed on. It used to be hardcoded null, which was a
+                // drop rather than a type limitation (NavRecord implements INavRecordHandle),
+                // and it is why Codeunit8705.OnRunAsync NREs on a null Rec the moment install
+                // triggers are allowed to run to completion (#2960).
+                //
+                // #2751 is still open and this does NOT resolve it. What that issue asks is a
+                // question about BC that no service tier has been asked here: does the worker
+                // see a COPY of the row taken at StartSession time, or a fresh read in the new
+                // session? BC's own ALStartSessionAsyncImpl does `record.CloneRecord(newSession)`
+                // into a second session, so on a real tier the two can differ.
+                //
+                // `null` is not the conservative answer while that is unsettled, which is the
+                // reason this line changed rather than waiting:
+                //   * null is a value BC never produces on this path at all — every
+                //     record-carrying overload passes a row — so it is not "one of the two
+                //     candidate semantics", it is a third answer that is wrong under both;
+                //   * under BOTH candidate semantics the worker sees a row with these field
+                //     values, which is all any AL written against the platform contract can
+                //     rely on;
+                //   * the runner dispatches the worker INLINE in the calling session, so the
+                //     copy-vs-fresh-read distinction has no observable consequence here — #2751
+                //     says as much itself.
+                // Settling it needs an upstream corpus test with a worker that reports what it
+                // saw in Rec, plus `--isolation disabled` coverage (#2826). That belongs to
+                // #2751, and I have commented there rather than silently closing it.
                 var result = trigger.GetParameters().Length == 1
                     ? trigger.Invoke(instance, new object?[] { record })
                     : trigger.Invoke(instance, null);

--- a/AlRunner/Patches/SessionPatches.cs
+++ b/AlRunner/Patches/SessionPatches.cs
@@ -426,7 +426,8 @@ public static partial class BcRuntime
     /// here where BC raises one. That is an argument-validation divergence on a value the
     /// runner then ignores, not a wrong ANSWER to anything AL can observe about the session,
     /// so it is recorded rather than converted into a refusal that would break every ordinary
-    /// caller passing a sane timeout. Tracked as follow-up rather than widened into this fix.</para>
+    /// caller passing a sane timeout. Tracked as <b>#3291</b>, which stays open after this
+    /// merges — the divergence is real and is not fixed here.</para>
     ///
     /// <para>2. BC REFUSES StartSession outright during an install or upgrade. Its body has,
     /// before any of the work above:</para>
@@ -447,10 +448,13 @@ public static partial class BcRuntime
     /// consequence is real and observable: the very call this patch was written for
     /// (<c>Codeunit8705.UpdateFeatureUptakeStatus</c>, reached from a Base App install trigger)
     /// runs its worker here where a real tier would skip it and return false. Modelling the
-    /// install context faithfully is a separate piece of work; it is filed rather than guessed
-    /// at, because "run the worker" and "skip the worker" are different answers to an AL-visible
-    /// question and picking one by assumption is what .claude/rules/no-assumption-fixes.md
-    /// rules out.</para>
+    /// install context faithfully is a separate piece of work; it is filed as <b>#3292</b>
+    /// rather than guessed at, because "run the worker" and "skip the worker" are different
+    /// answers to an AL-visible question and picking one by assumption is what
+    /// .claude/rules/no-assumption-fixes.md rules out. #3292 stays open after this merges, and
+    /// it is related to #3268 (install-trigger ordering) by the same missing state: the runner's
+    /// install pass does not record that an install is in progress, which is what both would
+    /// read.</para>
     /// </summary>
     public static System.Threading.Tasks.ValueTask<bool> ALSession_ALStartSessionAsyncImpl(
         Microsoft.Dynamics.Nav.Runtime.NavSession session,

--- a/AlRunner/Patches/SessionPatches.cs
+++ b/AlRunner/Patches/SessionPatches.cs
@@ -374,6 +374,55 @@ public static partial class BcRuntime
         return new System.InvalidOperationException(msg);
     }
 
+    /// <summary>
+    /// Cecil patch target: <c>ALSession.ALStartSessionAsyncImpl</c> — the ONE seam every
+    /// <c>ALStartSession</c> / <c>ALStartSessionAsync</c> overload in Ncl funnels into
+    /// (each public overload's whole body is a forwarding call to it).
+    ///
+    /// <para><see cref="AlRunnerStartSession"/> above says it is "the replacement entry point
+    /// for every ALSession.ALStartSession overload", and for SOURCE-COMPILED AL it is:
+    /// BcAssembler's polyfill rewrites those call sites textually. PRECOMPILED AL —
+    /// Base Application, System Application, any ISV DLL — calls Ncl directly, so it reached
+    /// BC's real body instead, which opens a second NavSession and asks SQL for the database
+    /// version:</para>
+    ///
+    /// <code>
+    ///   ArgumentNullException: Value cannot be null. (Parameter 'database')
+    ///      at NavSqlConnectionScope.Create(NavSession, NavDatabase, ...)
+    ///      at NavSqlDatabaseProperties.ReadDatabaseVersionNo()
+    ///      at NavSession.Open()
+    ///      at ALSession.ALStartSessionAsyncImpl(...)
+    ///      at Codeunit8705.UpdateFeatureUptakeStatus(..., performWriteTransactionsInASeparateSession, ...)
+    /// </code>
+    ///
+    /// <para>That is BC's own feature-telemetry uptake logging, reached from an ordinary
+    /// Base App install trigger — nothing the test author wrote. Found by letting install
+    /// triggers run past their first await (#2960).</para>
+    ///
+    /// <para>Routing it to the same helper the source-compiled path already uses means one
+    /// model of StartSession, not two: the #2805 TestIsolation guard, the session-id
+    /// allocation and the TrapError semantics are all decided in exactly one place, so a
+    /// precompiled caller and a source-compiled caller cannot observe different behaviour.
+    /// The <c>invokeRunAsync</c> delegate BC threads through is not needed — the helper
+    /// dispatches the target codeunit inline itself — and <c>session</c> is not either: the
+    /// helper works from the skeleton session, which is the only session there is here.</para>
+    ///
+    /// <para>Returns an already-completed <see cref="System.Threading.Tasks.ValueTask{T}"/>,
+    /// which is faithful for this runtime: the runner drives AL synchronously, and BC's own
+    /// callers await the result before reading <c>sessionId</c>.</para>
+    /// </summary>
+    public static System.Threading.Tasks.ValueTask<bool> ALSession_ALStartSessionAsyncImpl(
+        Microsoft.Dynamics.Nav.Runtime.NavSession session,
+        Microsoft.Dynamics.Nav.Types.DataError errorLevel,
+        Microsoft.Dynamics.Nav.Runtime.ByRef<int> sessionId,
+        int objectId,
+        string companyName,
+        Microsoft.Dynamics.Nav.Runtime.NavRecord record,
+        Microsoft.Dynamics.Nav.Runtime.NavDuration timeout,
+        object invokeRunAsync)
+        => new System.Threading.Tasks.ValueTask<bool>(
+            AlRunnerStartSession(errorLevel, sessionId, objectId, companyName, record));
+
     public static bool AlRunnerStartSession(
         Microsoft.Dynamics.Nav.Types.DataError errorLevel,
         Microsoft.Dynamics.Nav.Runtime.ByRef<int> sessionId,
@@ -473,7 +522,7 @@ public static partial class BcRuntime
                 // its own worker fixture that reads Rec — tracked separately, not widened into
                 // this fix.
                 var result = trigger.GetParameters().Length == 1
-                    ? trigger.Invoke(instance, new object?[] { null })
+                    ? trigger.Invoke(instance, new object?[] { record })
                     : trigger.Invoke(instance, null);
                 AwaitIfTask(result);
             }

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -197,7 +197,11 @@ Measured by running the group, not computed: `9P/0F/0E across 9 tests`, cold and
 
 Five tests added to an existing app group, so no new group line and no app-group count change.
 The group has no `absentOn`, so the same +5 lands on every BC version: runner-extras goes
-301 -> 306 on 27.0/27.3/27.5 and 312 -> 317 on 28.0-28.4.
+305 -> 310 on 27.0/27.3/27.5 and 316 -> 321 on 28.0-28.4. (Re-measured after rebasing onto
+`origin/main` at 598f628a. An earlier revision of this entry said 301 -> 306 and 312 -> 317,
+read off the base this branch was originally cut from; #3101 has since added +2 to
+`object-metadata-system-table` on `main`, which moves both ends by two and changes nothing
+about this group's own +5.)
 
 Three came with the by-id `NavApp.GetModuleInfo` fix, which the two stack-walk patches did not
 cover — the boolean/statement not-found arms and the derived PackageId. Two more came out of
@@ -215,7 +219,8 @@ the review of that PR and are worth naming, because neither is about the reporte
   branch. Now it refuses loudly.
 
 Measured by running the group, not computed: `15P/0F/0E across 15 tests`, cold and warm; and
-the whole suite under `--count-baseline` on BC 28.x, `317 total / 317 pass`, exit 0.
+the whole suite under `--count-baseline` on BC 28.x, re-run on the rebased tree:
+`321 total / 321 pass / 0 fail / 0 error`, exit 0.
 
 ## Migrated log (everything above 2026-09-05, verbatim)
 

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -197,11 +197,11 @@ Measured by running the group, not computed: `9P/0F/0E across 9 tests`, cold and
 
 Five tests added to an existing app group, so no new group line and no app-group count change.
 The group has no `absentOn`, so the same +5 lands on every BC version: runner-extras goes
-305 -> 310 on 27.0/27.3/27.5 and 316 -> 321 on 28.0-28.4. (Re-measured after rebasing onto
-`origin/main` at 598f628a. An earlier revision of this entry said 301 -> 306 and 312 -> 317,
-read off the base this branch was originally cut from; #3101 has since added +2 to
-`object-metadata-system-table` on `main`, which moves both ends by two and changes nothing
-about this group's own +5.)
+321 -> 326 on 27.0/27.3/27.5 and 332 -> 337 on 28.0-28.4. (Re-measured on `origin/main` at
+f020953e. Two earlier revisions of this entry said 301 -> 306 / 312 -> 317 and then
+305 -> 310 / 316 -> 321; both were correct against the base they were measured on and both
+went stale as `main` moved. The endpoints move whenever any other group's count changes;
+this group's own +5 has never changed.)
 
 Three came with the by-id `NavApp.GetModuleInfo` fix, which the two stack-walk patches did not
 cover — the boolean/statement not-found arms and the derived PackageId. Two more came out of
@@ -219,8 +219,8 @@ the review of that PR and are worth naming, because neither is about the reporte
   branch. Now it refuses loudly.
 
 Measured by running the group, not computed: `15P/0F/0E across 15 tests`, cold and warm; and
-the whole suite under `--count-baseline` on BC 28.x, re-run on the rebased tree:
-`321 total / 321 pass / 0 fail / 0 error`, exit 0.
+the whole suite under `--count-baseline` on BC 28.1, re-run on the tree rebased onto
+f020953e: `337 total / 337 pass / 0 fail / 0 error`, exit 0, cold and warm.
 
 ## Migrated log (everything above 2026-09-05, verbatim)
 

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -193,6 +193,30 @@ the four assert something the group's name does not suggest and the reason is wo
 
 Measured by running the group, not computed: `9P/0F/0E across 9 tests`, cold and warm.
 
+### navapp-moduleinfo-main 10 -> 15 (#2960 / PR #3225)
+
+Five tests added to an existing app group, so no new group line and no app-group count change.
+The group has no `absentOn`, so the same +5 lands on every BC version: runner-extras goes
+301 -> 306 on 27.0/27.3/27.5 and 312 -> 317 on 28.0-28.4.
+
+Three came with the by-id `NavApp.GetModuleInfo` fix, which the two stack-walk patches did not
+cover — the boolean/statement not-found arms and the derived PackageId. Two more came out of
+the review of that PR and are worth naming, because neither is about the reported bug:
+
+- `ModuleInfo_ForOneApp_AgreesOnPackageIdAcrossEntryPoints` — real BC has ONE module-info
+  implementation (`ALGetCurrentModuleInfo` and `ALGetCallerModuleInfo` both forward into
+  `ALGetModuleInfo`), so AL asking about one app three ways cannot get three answers. The
+  runner patches the entry points independently, so fixing only the by-id one made this bundle
+  report two different PackageIds for ITSELF. The test fails against that state and is what
+  holds the five sites on one shared constructor.
+- `GetModuleInfo_ByEmptyGuid_RefusesLoudlyInsteadOfAnsweringNotInstalled` — folding the
+  source-compiled polyfill onto the shared implementation changed first-party AL behaviour:
+  the old private copy answered plain `false` for `Guid.Empty`, which BC never does on that
+  branch. Now it refuses loudly.
+
+Measured by running the group, not computed: `15P/0F/0E across 15 tests`, cold and warm; and
+the whole suite under `--count-baseline` on BC 28.x, `317 total / 317 pass`, exit 0.
+
 ## Migrated log (everything above 2026-09-05, verbatim)
 
 This is the `_comment` string `test-count-baseline.json` used to carry: 40,178 characters on

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -196,12 +196,13 @@ Measured by running the group, not computed: `9P/0F/0E across 9 tests`, cold and
 ### navapp-moduleinfo-main 10 -> 15 (#2960 / PR #3225)
 
 Five tests added to an existing app group, so no new group line and no app-group count change.
-The group has no `absentOn`, so the same +5 lands on every BC version. Against `origin/main`
-at c0fda77e that is 319 -> 324 on 27.0/27.3/27.5 and 330 -> 335 on 28.0-28.4.
+The group has no `absentOn`, so the same +5 lands on every BC version. Re-measured against
+`origin/main` at 216c481c (corpus pin c3531ec6), the 28.x endpoint is 344 -> 349 and the 27.x
+one 333 -> 338.
 
-Those two endpoints are the least durable thing in this entry and have already been rewritten
-four times (301/312, then 305/316, then 321/332, now 319/330) without this group's own number
-ever changing. They move whenever ANY other group's count moves, which on a busy branch is
+Those two endpoints are the least durable thing in this entry and have now been rewritten five
+times (301/312, then 305/316, then 321/332, then 319/330, now 344/333) without this group's own
+number ever changing. They move whenever ANY other group's count moves, which on a busy branch is
 every few merges. Read the endpoints off `test-count-baseline.json` at whatever base you are
 on; the durable fact is +5 on every BC version, and `--count-baseline` is what enforces the
 sum rather than this paragraph.
@@ -221,9 +222,11 @@ the review of that PR and are worth naming, because neither is about the reporte
   the old private copy answered plain `false` for `Guid.Empty`, which BC never does on that
   branch. Now it refuses loudly.
 
-Measured by running the group, not computed: `15P/0F/0E across 15 tests`, cold and warm; and
-the whole suite under `--count-baseline` on BC 28.1, re-run on the tree rebased onto
-c0fda77e: `335 total / 335 pass / 0 fail / 0 error`, exit 0, cold and warm.
+Measured by running the group, not computed. The whole suite under `--count-baseline` on BC
+28.1, re-run on the tree rebased onto 216c481c: `349 total / 349 pass / 0 fail / 0 error`,
+exit 0. The 27.x endpoint is that figure less the eleven tests in the five `absentOn`
+groups, and is not locally measurable here — a self-built runner compiles against Ncl 28.x —
+so CI measures it.
 
 ## Migrated log (everything above 2026-09-05, verbatim)
 

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -196,12 +196,15 @@ Measured by running the group, not computed: `9P/0F/0E across 9 tests`, cold and
 ### navapp-moduleinfo-main 10 -> 15 (#2960 / PR #3225)
 
 Five tests added to an existing app group, so no new group line and no app-group count change.
-The group has no `absentOn`, so the same +5 lands on every BC version: runner-extras goes
-321 -> 326 on 27.0/27.3/27.5 and 332 -> 337 on 28.0-28.4. (Re-measured on `origin/main` at
-f020953e. Two earlier revisions of this entry said 301 -> 306 / 312 -> 317 and then
-305 -> 310 / 316 -> 321; both were correct against the base they were measured on and both
-went stale as `main` moved. The endpoints move whenever any other group's count changes;
-this group's own +5 has never changed.)
+The group has no `absentOn`, so the same +5 lands on every BC version. Against `origin/main`
+at c0fda77e that is 319 -> 324 on 27.0/27.3/27.5 and 330 -> 335 on 28.0-28.4.
+
+Those two endpoints are the least durable thing in this entry and have already been rewritten
+four times (301/312, then 305/316, then 321/332, now 319/330) without this group's own number
+ever changing. They move whenever ANY other group's count moves, which on a busy branch is
+every few merges. Read the endpoints off `test-count-baseline.json` at whatever base you are
+on; the durable fact is +5 on every BC version, and `--count-baseline` is what enforces the
+sum rather than this paragraph.
 
 Three came with the by-id `NavApp.GetModuleInfo` fix, which the two stack-walk patches did not
 cover — the boolean/statement not-found arms and the derived PackageId. Two more came out of
@@ -220,7 +223,7 @@ the review of that PR and are worth naming, because neither is about the reporte
 
 Measured by running the group, not computed: `15P/0F/0E across 15 tests`, cold and warm; and
 the whole suite under `--count-baseline` on BC 28.1, re-run on the tree rebased onto
-f020953e: `337 total / 337 pass / 0 fail / 0 error`, exit 0, cold and warm.
+c0fda77e: `335 total / 335 pass / 0 fail / 0 error`, exit 0, cold and warm.
 
 ## Migrated log (everything above 2026-09-05, verbatim)
 

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -33,7 +33,7 @@
         "navapp-callermodule-dispatch-dep": { "tests": 0 },
         "navapp-callermodule-dispatch-main": { "tests": 4 },
         "navapp-moduleinfo-dep": { "tests": 0 },
-        "navapp-moduleinfo-main": { "tests": 10 },
+        "navapp-moduleinfo-main": { "tests": 15 },
         "object-metadata-system-table": { "tests": 6 },
         "object-system-table": { "tests": 3 },
         "page-enum-control-modal": { "tests": 4 },

--- a/tests/runner-extras/navapp-moduleinfo-main/XmiMainTests.Codeunit.al
+++ b/tests/runner-extras/navapp-moduleinfo-main/XmiMainTests.Codeunit.al
@@ -125,6 +125,16 @@ codeunit 61240 "XMI Main Tests"
     /// wrong answer loud-failures.md is about.
     /// </summary>
     [Test]
+    // UPSTREAM FOLLOW-UP — #3293. This one test is NOT runner-specific and does not belong
+    // here on the merits: "an app id that is not installed raises, and the message names it"
+    // is plain BC behaviour that a service tier can adjudicate with any random GUID. The rest
+    // of this suite genuinely is runner-specific (it asserts the runner's loaded-app closure
+    // is what answers, and that PackageId matches the derived identity the runner stamps —
+    // real BC has a publish step and the runner does not), so "the suite already sits in
+    // runner-extras" is a precedent, not the structural reason bc-behavior-tests-go-upstream.md
+    // asks for. The corpus covers only the POSITIVE by-id case today (TestNavApp.al:70,
+    // TestNavAppExtended.al:95). #3293 tracks writing the negative case upstream and deleting
+    // this one when the pin moves.
     procedure GetModuleInfo_ByUnknownAppId_StatementForm_RaisesNamingTheId()
     var
         Info: ModuleInfo;

--- a/tests/runner-extras/navapp-moduleinfo-main/XmiMainTests.Codeunit.al
+++ b/tests/runner-extras/navapp-moduleinfo-main/XmiMainTests.Codeunit.al
@@ -220,4 +220,99 @@ codeunit 61240 "XMI Main Tests"
             Error('Caller module inside the dep must be this bundle through the boolean form, got %1.',
                 DepApi.CallerNameBooleanForm());
     end;
+
+    /// <summary>
+    /// #2961. The THREE ways AL can ask about one app must agree on that app's PackageId.
+    ///
+    /// In real BC they cannot disagree, because there is only one implementation:
+    /// ALGetCurrentModuleInfo and ALGetCallerModuleInfo are each a two-line forward into
+    /// ALGetModuleInfo, which fills PackageId from navAppRuntimeMetadata.PackageId.Value for
+    /// all three. The runner patches the three entry points independently — five sites in
+    /// total once the source-compiled polyfills are counted — so the agreement is a property
+    /// of runner code and nothing else, and it needs a test that fails when one of the five
+    /// is changed alone.
+    ///
+    /// This is exactly what it caught: giving the by-id lookup the runner's derived package
+    /// identity while the two stack-walk patches still echoed the AppId made this bundle
+    /// report two different PackageIds for ITSELF depending on which call was used. RED
+    /// against that state, GREEN once all five share one constructor
+    /// (NavAppModuleInfoPatches.MakeModuleInfo).
+    ///
+    /// It is deliberately written against the bundle's OWN id, read back from
+    /// GetCurrentModuleInfo rather than hard-coded, so it stays true if the fixture's app id
+    /// ever changes and so it cannot pass by comparing two constants.
+    /// </summary>
+    [Test]
+    procedure ModuleInfo_ForOneApp_AgreesOnPackageIdAcrossEntryPoints()
+    var
+        Current: ModuleInfo;
+        ById: ModuleInfo;
+        EmptyId: Guid;
+    begin
+        if not NavApp.GetCurrentModuleInfo(Current) then
+            Error('GetCurrentModuleInfo must resolve the executing bundle.');
+        if Current.Id() = EmptyId then
+            Error('The executing bundle must have a non-empty AppId.');
+
+        if not NavApp.GetModuleInfo(Current.Id(), ById) then
+            Error('GetModuleInfo must resolve the executing bundle by its own AppId %1.', Current.Id());
+
+        // The same app, asked two ways: every identity field must match.
+        if ById.Id() <> Current.Id() then
+            Error('AppId disagrees across entry points: by-id %1 vs current %2.', ById.Id(), Current.Id());
+        if ById.Name() <> Current.Name() then
+            Error('Name disagrees across entry points: by-id %1 vs current %2.', ById.Name(), Current.Name());
+        if ById.PackageId() <> Current.PackageId() then
+            Error('PackageId disagrees across entry points: by-id %1 vs current %2. In BC both come from the same field.',
+                ById.PackageId(), Current.PackageId());
+
+        // ...and it is the runner's derived package identity on BOTH, not an echo of the
+        // AppId. Without this, two entry points that BOTH echoed the AppId would agree and
+        // pass the comparison above while still reporting a value that does not join to the
+        // app's Published Application row.
+        if Current.PackageId() = EmptyId then
+            Error('The executing bundle must carry a non-empty PackageId.');
+        if Current.PackageId() = Current.Id() then
+            Error('PackageId must be the derived package identity, not an echo of the AppId (%1).', Current.Id());
+    end;
+
+    /// <summary>
+    /// #2961. NavApp.GetModuleInfo(Guid.Empty) is BC's "give me the application family"
+    /// branch: real BC answers it from NavGlobal.AppDatabase.SqlDatabaseProperties.
+    /// ApplicationFamily, which the runner has no truthful source for, so it REFUSES loudly
+    /// (.claude/rules/loud-failures.md) instead of inventing a family string.
+    ///
+    /// This is here because unifying the source-compiled polyfill onto the shared
+    /// implementation CHANGED first-party AL behaviour: the old private copy returned plain
+    /// `false` for the empty id, so AL saw "not installed" — an answer BC never gives on this
+    /// branch, and one indistinguishable from a genuine miss. Refusing is the right change,
+    /// and a behaviour change to first-party AL needs a test whether or not it is an
+    /// improvement.
+    ///
+    /// asserterror DOES trap a RunnerOutOfScopeException — see the header of
+    /// AlRunner/Infrastructure/RunnerOutOfScopeException.cs — so the refusal is observable
+    /// from AL and the three fragments below pin the API, the reason and the marker
+    /// separately rather than matching one long string.
+    /// </summary>
+    [Test]
+    procedure GetModuleInfo_ByEmptyGuid_RefusesLoudlyInsteadOfAnsweringNotInstalled()
+    var
+        Info: ModuleInfo;
+        EmptyId: Guid;
+    begin
+        asserterror NavApp.GetModuleInfo(EmptyId, Info);
+
+        if StrPos(GetLastErrorText(), 'out-of-scope:') = 0 then
+            Error('Guid.Empty must raise the runner''s out-of-scope refusal, got: %1', GetLastErrorText());
+        if StrPos(GetLastErrorText(), 'NavApp.GetModuleInfo(Guid.Empty)') = 0 then
+            Error('The refusal must name the API that was touched, got: %1', GetLastErrorText());
+        if StrPos(GetLastErrorText(), 'not-yet-implemented') = 0 then
+            Error('The reason must be not-yet-implemented — this branch is in scope, just unbuilt. Got: %1',
+                GetLastErrorText());
+
+        // NOT the not-found message: answering the empty id with "no installed extension was
+        // found with ID 00000000-..." would be the silent wrong answer this replaced.
+        if StrPos(GetLastErrorText(), 'No installed extension was found') > 0 then
+            Error('Guid.Empty must not be reported as a not-found app id, got: %1', GetLastErrorText());
+    end;
 }

--- a/tests/runner-extras/navapp-moduleinfo-main/XmiMainTests.Codeunit.al
+++ b/tests/runner-extras/navapp-moduleinfo-main/XmiMainTests.Codeunit.al
@@ -99,6 +99,68 @@ codeunit 61240 "XMI Main Tests"
     end;
 
     /// <summary>
+    /// #2961. NavApp.GetModuleInfo for an app the runner has NOT loaded must answer the way
+    /// BC's own ALGetModuleInfo does, and the two arms differ. This is the trapping arm: the
+    /// boolean form compiles to DataError.TrapError, so an unresolvable id is `false` with no
+    /// error raised.
+    ///
+    /// It is the discriminating half of the pair below. A helper that answered "installed"
+    /// for every id — the shape that would make the corpus green by lying — passes
+    /// GetModuleInfo_ByDepAppId_ResolvesRegisteredDep above and fails here.
+    /// </summary>
+    [Test]
+    procedure GetModuleInfo_ByUnknownAppId_BooleanForm_ReturnsFalse()
+    var
+        Info: ModuleInfo;
+    begin
+        if NavApp.GetModuleInfo('00000000-dead-beef-0000-000000000001', Info) then
+            Error('GetModuleInfo must not resolve an app id the runner never loaded.');
+    end;
+
+    /// <summary>
+    /// #2961, the raising arm. Statement form compiles to DataError.RaiseError, and BC's
+    /// ALGetModuleInfo throws NavAppException naming the id it could not find. Before the
+    /// fix the runner's source-compiled polyfill returned false here whatever the DataError
+    /// was, so the statement form left <c>Info</c> untouched and said nothing — the silent
+    /// wrong answer loud-failures.md is about.
+    /// </summary>
+    [Test]
+    procedure GetModuleInfo_ByUnknownAppId_StatementForm_RaisesNamingTheId()
+    var
+        Info: ModuleInfo;
+    begin
+        asserterror NavApp.GetModuleInfo('00000000-dead-beef-0000-000000000002', Info);
+        if StrPos(GetLastErrorText(), 'No installed extension was found with ID') = 0 then
+            Error('GetModuleInfo must raise BC''s own not-found message, got: %1', GetLastErrorText());
+    end;
+
+    /// <summary>
+    /// #2961. The resolved module carries the runner's DERIVED package identity, not an echo
+    /// of the app id. That matters because it is the same value the runner stamps into the
+    /// app's Published Application "Package ID" / "Runtime Package ID" columns and onto its
+    /// AllObj rows (#2963, #3066), so AL that reads ModuleInfo.PackageId and then looks the
+    /// app up by package id finds it. Echoing the app id back would break that join, and is
+    /// exactly what the source-compiled polyfill used to do.
+    /// </summary>
+    [Test]
+    procedure GetModuleInfo_ByDepAppId_CarriesADerivedPackageIdNotTheAppId()
+    var
+        Info: ModuleInfo;
+        EmptyId: Guid;
+    begin
+        if not NavApp.GetModuleInfo('f6c0e4a8-7d3b-4a1c-8e5f-9b4d8c3a6f7e', Info) then
+            Error('GetModuleInfo must resolve the loaded dependency by AppId.');
+        if Info.PackageId() = EmptyId then
+            Error('The resolved module must carry a non-empty PackageId.');
+        if Info.PackageId() = Info.Id() then
+            Error('PackageId must be the derived package identity, not an echo of the AppId (%1).', Info.Id());
+        if Info.Id() <> 'f6c0e4a8-7d3b-4a1c-8e5f-9b4d8c3a6f7e' then
+            Error('GetModuleInfo(depId) must carry the dep AppId, got %1.', Info.Id());
+        if Info.Publisher() <> 'AL Runner' then
+            Error('GetModuleInfo(depId) must carry the dep publisher, got %1.', Info.Publisher());
+    end;
+
+    /// <summary>
     /// THE FIX (#1942). Before it, the source polyfill behind NavApp.GetCurrentModuleInfo
     /// was declared `void`, so the C# Roslyn compile of the emitted assembly failed with
     /// CS0023 ("operator '!' cannot be applied to operand of type 'void'") on this exact


### PR DESCRIPTION
Closes #2960
Closes #3218
Closes #3220

*Opened by agent `impl-25`; rebased, re-measured and the two open divergences filed by agent `impl-1`. Both are automated implementation agents.*

`InstallTriggerRunner.InvokeTrigger` discarded the `ValueTask` returned by
`trigger.Invoke(instance, null)`. Observing it is one line. Landing that one line is not:
it turns the al-language corpus from 2676/2676 into `EXEC-FAIL` with **0 tests run**,
because the errors it stops swallowing are real and there are three more gaps behind them.
This PR removes all four, and the corpus is back to 2676/2676 with the install pass
actually completing.

## Why these four are one PR

Not a batch of siblings that happen to share a file — a **dependency chain**. Each fix is
unreachable until the one above it lands, and landing any prefix of the chain on `main`
leaves the corpus at `EXEC-FAIL` with 0 tests:

```
main                          2676/2676 pass
+ fix 1                       EXEC-FAIL, 0 tests   No installed extension was found with ID '63ca2fa4-...'
+ fix 2                       EXEC-FAIL, 0 tests   Windows Principal functionality is not supported on this platform.
+ fix 3                       EXEC-FAIL, 0 tests   Value cannot be null. (Parameter 'database')
+ fix 4 (+ the record below)  2676/2676 pass, install pass runs to completion
```

Same command each time
(`dotnet run --project AlRunner -c Release -- tests/al-language/tests/al-language --package-cache "$HOME/.al-runner/platform-apps" --cache <dir outside the repo>`).

So this is structurally the case `al-language-submodule.md` already names for a corpus pin
bump: red by construction on its own, green only together. Splitting it would put `main` in
a state where no AL test runs at all — which is why it is not split, and the argument is
that rather than "these edits are near each other".

## What the discarded ValueTask was hiding

The AL compiler emits an install trigger as an `async ValueTask` state machine whenever the
body needs one. An `Error()` raised inside such a body is captured onto the returned task,
not propagated out of `MethodInfo.Invoke`. So discarding the task discarded the error, the
trigger's remaining seeding never ran, and the runner captured an install baseline it
believed was complete. Nothing was printed. The issue title says "abandoned at their first
await" — the sharper statement, from the measurement, is that everything up to the first
*exception* ran and everything after it did not, and nobody was told.

## The chain, measured one layer at a time

Each of these was invisible until the layer above it was fixed. Each was measured by running
the corpus, not inferred.

| # | Where | What it did |
|---|---|---|
| 1 | `InstallTriggerRunner.InvokeTrigger` | discarded the `ValueTask` (#2960) |
| 2 | `ALNavApp.ALGetModuleInfo` (by-id) | raised `No installed extension was found with ID '<guid>'` for **every** id, including the System Application's own (#2961, in part — see below) |
| 3 | `NavUserAuthentication.get_WindowsIdentity` | `WindowsIdentity.GetCurrent()`, fatal on Linux (#3218) |
| 4 | `ALSession.ALStartSessionAsyncImpl` | precompiled AL got BC's real body, which opens a second `NavSession` and asks SQL for the database version (#3220) |

`63ca2fa4-4f03-4f2b-a480-172fef340d3f` is the System Application's own app id — an app the
runner has loaded and could not say it had loaded.

## #2961 is deliberately NOT listed as a closing reference

It was, and that was wrong. #2961's title leads with `NavApp.VersionInstalled`, which this
PR fixes; its **body** asks for a second, explicitly named thing:

> table 2000000153 `NAV App Installed App` is not among the virtual tables `RecordPatches`
> serves, and anything reading it … has nothing to read.

Nothing here serves that table — `git grep "2000000153\|NAV App Installed App"` under
`AlRunner/` finds nothing — and #2961 also says "I have not surveyed how much AL beyond
`Codeunit3702.VersionInstalled` reads this table … Scope that before implementing." That
survey did not happen, so the second half is genuinely undelivered.

Of the two ways out, I picked dropping the reference rather than editing #2961's scope down
to what I delivered. Narrowing someone else's problem statement to fit my diff is a
goalpost move even when the narrowed issue is defensible, and it would have destroyed the
`RecordPatches` framing the original filer wrote. Leaving #2961 open costs nothing and
keeps the remaining work described by the person who scoped it. I have not filed a
duplicate issue for the by-id half either — an issue created only to be resolved by the
same PR is noise; this PR body and the code comments are the record.

One thing in #2961 does become stale on merge: "Until it exists, #2960 cannot land." It
can, and does. I have said so in a comment there rather than rewriting the body, and the
issue stays `status: ready` for the virtual-table half.

## What changed

**1. `AlRunner/InstallTriggerRunner.cs` (#2960).** `BcRuntime.ObserveAsyncResult(trigger.Invoke(...), trigger)`
— the same seam #2932/#2979 used for the table-event-subscriber half of this defect, not a
second mechanism. `ObserveAsyncResult` rethrows the *original* exception off the awaiter
rather than a `TargetInvocationException`, so the two catch arms are folded into one that
unwraps when wrapped; both compile shapes now reach the same `[install-trigger] … threw:`
diagnostic and the same type-preserving rethrow.

**2. `AlRunner/Patches/NavAppModuleInfoPatches.cs` + `NclCecilRewrite.Dispatch.cs`.**
`ALGetModuleInfo` is the by-id overload, and the two existing patches (`ALGetCurrentModuleInfo`,
`ALGetCallerModuleInfo`) did not cover it. BC resolves it against
`NavCurrentThread.TryResolveAppGroup().OrderedAppMetadata`; the runner has no app group, so
nothing matched any id and BC's own not-found arm raised for every app. It now answers from
`BcRuntime.TryGetModuleInfoByAppId` — the same loaded-app closure
`EnsurePublishedApplicationRowsSeeded` writes into Published Application (#2963).
**BC's not-found semantics are preserved exactly**: an id the runner has not loaded is
genuinely not installed, so `TrapError` still returns false with a null info and the raising
arm still throws `NavAppException` with BC's message.

**3. `AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs` (#3218).** One `call
WindowsIdentity::GetCurrent()` replaced with `ldnull`, the same one-instruction, token-safe
neutralisation the `NavEnvironment..cctor` block a few lines above already uses on the other
call site. Faithful, not a silent default: there is no current Windows identity on Linux,
the property's own else-branch already returns null for other authentication methods, and
`Clone()` reads `if (WindowsIdentity != null)` and skips the copy. The body is
byte-identical across BC 27.0 and 28.4 (decompile hash
`0a36e18b2f811a5a130d8490215c5f5eb9b5813f3db8628c81feabe29ab0ef97` in both), so the
"expected exactly 1" guard is a real invariant.

**4. `AlRunner/Patches/SessionPatches.cs` + `NclCecilRewrite.Dispatch.cs` (#3220).**
`BcRuntime.AlRunnerStartSession`'s own comment already calls it "the replacement entry point
for every `ALSession.ALStartSession` overload", and for source-compiled AL it is —
`BcAssembler`'s polyfill rewrites those call sites. Precompiled AL called Ncl directly.
Patching `ALStartSessionAsyncImpl`, the single method all seven overloads forward into,
keeps **one** model of StartSession, so #2805's isolation guard, the session-id allocation
and the TrapError semantics cannot diverge between a precompiled and a source-compiled
caller.

**5. `AlRunnerStartSession` now passes the caller's record to the worker.** One line, and
required: without it `Codeunit8705.OnRunAsync` NREs on a null `Rec` and the corpus stays at
0 tests. **#2751 stays open on its own terms; this PR does not repair it.** The BC question
it names — does the worker see a copy taken at StartSession time, or a fresh read in the new
session? — is still unmeasured and belongs upstream. But `null` is not a conservative answer
pending that verdict: it is a value BC never produces on this path, both candidate semantics
yield a row, and under the runner's inline model the two candidates coincide (the issue says
so itself). That reasoning now lives in the comment above the line rather than only here —
the previous revision left a comment there stating the record was still null, directly
contradicting the line beneath it.

**6. One constructor for module info, so all five entry points agree.** In real BC there is
one implementation: `ALGetCurrentModuleInfo` and `ALGetCallerModuleInfo` are each a two-line
forward into `ALGetModuleInfo`, which fills `PackageId` from
`navAppRuntimeMetadata.PackageId.Value` for every caller. Decompiled from `bc281`:

```csharp
public static bool ALGetCurrentModuleInfo(DataError errorLevel, ByRef<NavModuleInfo> info)
{
    Guid callingAppId = GetCallingAppId(Guid.Empty, excludeCurrentMethod: false);
    return ALGetModuleInfo(errorLevel, callingAppId, info);
}
```

So AL asking about one app three ways gets three identical answers on a service tier. The
runner patches the three entry points independently — **five** sites once the two
source-compiled polyfills in `BcAssembler.NavRuntimeHelpersShim` are counted — and giving
only the new by-id one the derived package identity made AL asking about the *same app* two
ways get two different `PackageId`s. Before this PR all five were uniformly wrong; after fix
2 alone they were inconsistent, which is worse than either answer on its own. All five now
call `NavAppModuleInfoPatches.MakeModuleInfo`, which is also where the faithfulness audit
for `DataVersion` and the empty dependency list now lives.

## Fixing the shape, not just the reported line

- **Does the same wrong pattern appear at another call site?** Four sites invoke an AL body
  by reflection; three already observed the result (`BcRuntime.ObserveAsyncResult`,
  `RunnerPageInstance.AwaitTriggerResult`, `BcRuntime.AwaitIfTask`). `InvokeTrigger` was the
  fourth and last.
- **Does a sibling function make the same assumption?** Yes, three times. The
  `NavEnvironment..cctor` `WindowsIdentity.GetCurrent()` patch had a sibling one method away
  that nobody had reached (#3218). `ALGetCurrentModuleInfo`/`ALGetCallerModuleInfo` were
  patched while their by-id sibling was not. And both of those, plus both source-compiled
  polyfills, echoed the app id as the package id.
- **If two code paths write the same state, do they maintain the same invariant?** They did
  not. `BcAssembler.NavRuntimeHelpersShim.ALNavApp_GetModuleInfo` was a **second copy** of
  the module lookup for source-compiled AL, and it had drifted: it returned `false` on
  not-found whatever the `DataError` was, so the *statement* form of `NavApp.GetModuleInfo`
  silently populated nothing instead of raising; and it reported `appId` as the `PackageId`.
  The shim now calls the one implementation.

**Deliberately left out:** #2751's upstream corpus test (a worker reporting what it saw in
`Rec`, run against a real service tier) — it needs `--isolation disabled` coverage per #2826
and belongs to that issue. The `NAV App Installed App` virtual table — see the #2961 section
above. And two unfaithfulnesses in `ALStartSessionAsyncImpl` that are now written down in
its XML doc instead of being silently absent, per `loud-failures.md`'s audit obligation:

- **#3291 — `timeout` is dropped, including its validation arm.** BC turns it into a
  `NavCancellationTokenSource` and validates it first: `timeoutTs.TotalMilliseconds >
  2147483647.0` raises `NavNCLArgumentOutOfRangeException` (`Lang.TooLargeTimeoutALStartSession`).
  The runner dispatches the worker inline and synchronously, so there is no concurrent
  execution to cancel and no duration to elapse — the cancellation half is correctly dropped.
  The *validation* arm is genuinely unimplemented: AL passing an absurd timeout gets an error
  on a service tier and nothing here. Recorded rather than converted into a refusal that would
  break every caller passing a sane timeout.
- **#3292 — BC refuses StartSession outright during an install or upgrade.**
  `session.AppInstallationContext != null || session.AppUpgradeContext != null` → trace and
  `return false`, third statement in the method, before any work and **outside** the `try`, so
  `DataError.ThrowError` does not turn it into an error. The runner has no
  `AppInstallationContext` — its install pass is its own mechanism — so copying the guard in
  would be dead code that looked like coverage. **This is an AL-observable behavior change
  this PR introduces**, not a pre-existing one: observing the install trigger's `ValueTask` is
  what makes `Codeunit8705.UpdateFeatureUptakeStatus` reach `StartSession` at all, and it runs
  its worker here where a real tier skips it. Modelling the install context is separate work,
  and "run the worker" vs "skip the worker" is not a choice to make by assumption.

**Both issues previously said "tracked" and "filed" in this body and in the XML doc, and
neither existed.** They now do — #3291 and #3292 — both stay open after this merges, and the
XML doc in `SessionPatches.cs` cites them by number rather than gesturing at a filing. Both
bodies quote `ALStartSessionAsyncImpl` decompiled from BC 28.1 rather than paraphrasing it.
#3292 is related to #3268 (install-trigger ordering) by the same missing state — the runner's
install pass does not record that an install is in progress — and I have **commented on
#3268** to say this PR widens its window, since more install code now runs before session-user
adoption and its "not measured in the wild" line is less safe after this merges.
- **The not-found message is an inlined English literal** where BC formats
  `Lang.NavApp_NoInstalledMatchFound` under `CultureInfo.CurrentCulture`. Identical under the
  invariant culture the runner runs in; noted at the throw site so it is not rediscovered.

## Is any of this a claim about BC?

Deliberate call, per `bc-behavior-tests-go-upstream.md`:

- **Fixes 1, 3, 4 and 5 are runner-internal plumbing.** Whether the runner observes an async
  result it already invokes, whether a Linux process has a Windows identity, and whether
  precompiled callers reach the runner's own StartSession model rather than a SQL connection
  — none of these is a statement about AL that would mean anything without AL Runner.
- **Fix 2 has a BC half that is not upstream-verified, and I am saying so rather than
  pretending otherwise.** "`NavApp.GetModuleInfo(id)` of an installed app returns that app's
  manifest, and raises for an id that is not installed" is plain BC behaviour. What is
  *runner-specific* — and what the new AL tests actually assert — is that the runner's
  **loaded app closure** is what it answers from, and that the `PackageId` matches the
  derived identity the runner stamps elsewhere. Real BC has a publish step; the runner does
  not.

  **One of the five new tests does not share that reason, and is now filed as an upstream
  follow-up: #3293.** `GetModuleInfo_ByUnknownAppId_StatementForm_RaisesNamingTheId` asserts
  that an id which is not installed raises and that the message names it — plain BC behavior a
  service tier can adjudicate with any random GUID, and the corpus covers only the positive
  by-id case (`TestNavApp.al:70`, `TestNavAppExtended.al:95`). The previous version of this
  body justified keeping it local with "the existing `navapp-moduleinfo-main` suite already
  sits in `runner-extras`", which is a precedent, not the structural reason
  `bc-behavior-tests-go-upstream.md` asks for. #3293 tracks writing the negative case upstream
  and deleting this one when the pin moves; the test itself now carries that note, so the
  record survives the squash.
- **Fix 6's BC half is settled by the DLL, not by reasoning.** That the three entry points
  return one value is not an inference: `ALGetCurrentModuleInfo` and `ALGetCallerModuleInfo`
  each *are* a call to `ALGetModuleInfo`. The corpus already pins the consequence a service
  tier can see (`NavApp_GetCurrentModuleInfo_PackageId_NonNull` in `TestNavAppExtended.al`
  and `TestBCPlatformContracts.al`); those stay green here.

## RED → GREEN

**#2960 — `AlRunner.Tests/InstallTriggerAsyncObservationTests.cs` (new, 7 tests).**

```
with trigger.Invoke(...) discarded:  Failed: 4, Passed: 3
with ObserveAsyncResult:             Failed: 0, Passed: 7
```

The four that move are the async ones. They assert the specific message reaches the caller
with its original type, that the `[install-trigger]` stderr diagnostic names the codeunit and
trigger, that the `ValueTask<T>` shape reaches `ObserveAsyncResult`'s reflection arm, and
that a *succeeding* async trigger runs its whole body across the suspension point
(`Steps == 2`, which a helper that merely touched the task without awaiting would fail).
The three that stay green are the guards: the synchronous arm still unwraps
`TargetInvocationException`, and an absent trigger is still a no-op.

**Why it is a C# test — claim narrowed after review.** The previous revision said the
runner's *emitter* does not produce `async ValueTask` install triggers. That was an
overclaim: the runner compiles AL with BC's own compiler, so `Void` vs `async ValueTask` is
a property of the **body**, and the precompiled sixteen are async because their bodies await.
So I measured the shape most likely to falsify it. A throwaway probe bundle whose
`OnInstallAppPerDatabase` is a bare `Codeunit.Run(Codeunit::"…")`, printing
`trigger.ReturnType` at the call site on BC 28.1:

```
[n4-probe] Codeunit9056.OnInstallAppPerDatabase  returnType=ValueTask   (precompiled)
[n4-probe] Codeunit1809.OnInstallAppPerCompany   returnType=ValueTask   (precompiled)
…  all sixteen platform triggers: ValueTask
[n4-probe] Codeunit69902.OnInstallAppPerCompany  returnType=Void        (source-compiled, Record.Init/Insert)
[n4-probe] Codeunit69903.OnInstallAppPerDatabase returnType=Void        (source-compiled, Codeunit.Run)
```

`Codeunit.Run` does not force the async shape, and neither does `StartSession` (which
`install-trigger-seed`'s Codeunit60711 already calls). So a first-party AL reproducer is
still unreachable and would pass either way, which `tdd.md` calls noise — but the header now
states that as a measurement over the shapes tried, not as a property of the emitter, and
says an AL test should be written if a body that compiles async is ever found.

**Five AL tests in `tests/runner-extras/navapp-moduleinfo-main` (codeunit 61240, inside its
own declared 61240-61249 range, no new object ids).** Group baseline 10 → 15.

Against `main`'s source-compiled polyfill copy:

```
11P / 4F across 15 tests
  FAIL GetModuleInfo_ByUnknownAppId_StatementForm_RaisesNamingTheId
       NavNCLAssertErrorException: An error was expected inside an ASSERTERROR statement.
  FAIL GetModuleInfo_ByDepAppId_CarriesADerivedPackageIdNotTheAppId
  FAIL ModuleInfo_ForOneApp_AgreesOnPackageIdAcrossEntryPoints
  FAIL GetModuleInfo_ByEmptyGuid_RefusesLoudlyInsteadOfAnsweringNotInstalled
       NavNCLAssertErrorException: An error was expected inside an ASSERTERROR statement.
```

Against the *previous revision of this PR* — the state in which only the by-id lookup had the
derived package identity — the cross-entry-point test isolates exactly the inconsistency it
was written for, and nothing else moves:

```
14P / 1F across 15 tests
  FAIL ModuleInfo_ForOneApp_AgreesOnPackageIdAcrossEntryPoints
       PackageId disagrees across entry points:
         by-id   {0A23EABE-F353-DECB-858F-F3BAF001BF21}
         current {A7D1F5B9-8E4C-4B2D-9F6A-0C5E9D4B7A8F}
```

`A7D1F5B9-8E4C-4B2D-9F6A-0C5E9D4B7A8F` is this bundle's own `app.json` id, which is the
proof that the "current" arm was echoing the AppId rather than reporting a package id.

After: **15/15**, cold and warm.

`GetModuleInfo_ByUnknownAppId_BooleanForm_ReturnsFalse` passes both before and after on
purpose — it is the discriminating negative direction. A helper that answered "installed"
for every id would make the corpus green by lying, pass
`GetModuleInfo_ByDepAppId_ResolvesRegisteredDep`, and fail that one.

`GetModuleInfo_ByEmptyGuid_…` covers something the previous revision changed without
testing: folding the polyfill onto the shared implementation means `Guid.Empty` now raises
`RunnerOutOfScopeException("not-yet-implemented")` on the **source-compiled** path too,
where the old private copy returned plain `false`. BC never answers "not installed" on that
branch — it answers from `SqlDatabaseProperties.ApplicationFamily` — so refusing is the
right change per `loud-failures.md`, and it is now a behaviour change with a test rather
than without one.

**#3218 and #3220 — the corpus is the proof, and CI gates it.** Neither is reachable from
first-party AL: source-compiled AL gets the `BcAssembler` polyfill for StartSession and never
touches Ncl, and nothing source-compiled constructs a `NavUserAuthentication`. What does
reach them is the Base Application install pass, which every BC leg runs. Remove either patch
and the al-language bundle reports `EXEC-FAIL` with 0 tests, as the table above shows — so
each is genuinely gated, not merely shipped.

## Count baseline

The head before the rebase failed three legs with **exit 4 — a count-baseline mismatch, not a
test failure**. `test-count-baseline.json` still said `navapp-moduleinfo-main: 10`. It is now
15, with the `history.md` rationale entry the schema requires.

**The endpoints in this section have now been wrong four times**, because `main` keeps moving
under the branch: 301 → 306 / 312 → 317, then 305 → 310 / 316 → 321, then 321 → 326 /
332 → 337, then 319 → 324 / 330 → 335, and now — re-measured against `origin/main` at
`216c481c` — **333 → 338** on 27.0/27.3/27.5 and **344 → 349** on 28.0-28.4.

Each of those was correct when it was measured. The group's own **+5 has never changed**;
only the totals around it do, and they move whenever any other group's count moves. So the
`history.md` entry now says that instead of asserting a pair of numbers that goes stale every
few merges, and points the reader at `--count-baseline` as what enforces the sum.

The 28.x endpoint is measured, not computed: `--count-baseline` exits 0 on a **349 / 349** run
(below). The 27.x endpoint is the same +5 applied to a group with no `absentOn` and is not
locally measurable — a self-built runner is compiled against Ncl 28.x — so CI measures it.

## The corpus-pin question, and the answer

This PR does **not** move the `tests/al-language` pin, and it changes the install pass every
corpus test depends on. So the thing worth checking is whether it inherits corpus content it
has never run: it was originally measured at pin `6e198a97` with the al-language baseline at
2676, and `main` has since moved to a newer pin with the baseline at **2681**. `merge-tree`
reports CLEAN, so nothing would have stopped it merging on the old measurement.

Measured rather than reasoned about: **rebased onto the current `main` (`216c481c`) and run
against the pin `main` carries (`c3531ec6`), the corpus is 2782 / 2782 cold and warm, exit 0**
under `--strict --expectations-require-match --count-baseline`. 2782 is the sum over the three
corpus app roots — al-language 2757, al-language-internals-fixture 0, al-language-onprem 25 —
and the run enforces it rather than my arithmetic asserting it. That base carries the pin 11
commits further forward than the measurement above (~79 more corpus tests across three
surfaces, plus corpus PR #221's TestPermissions fix) and #3287's Access Control SUPER-row
seed, which changes install-baseline state for every bundle and is the merge most likely to
interact with an install-trigger change. Nothing in the newly-pulled-in corpus content is
broken by this change.

## What was run, and in what state

Everything below on this exact tree (`96c35e02`), rebased onto `main` at `216c481c` with the
corpus pin at `c3531ec6`, on BC 28.1.49838.53910, with a private `--cache` directory outside
the repository. **Nothing is carried across a rebase** — `main` moved six times while this was
open and every number below was re-run on the final base, after the pin moved 11 commits
forward and #3287 changed install-baseline state for every bundle.

| run | result |
|---|---|
| al-language corpus, cold (3 app roots, `--strict --expectations-require-match --count-baseline`) | **2782 / 2782**, 0 fail, 0 error, 0 exec-fail, **exit 0** |
| al-language corpus, warm (same cache) | **2782 / 2782**, exit 0 |
| `tests/runner-extras`, cold (`--strict --count-baseline`) | **349 / 349**, 0 fail, 0 error, **exit 0** |
| `tests/runner-extras`, warm (same cache) | **349 / 349**, exit 0 |
| `tests/runner-extras/navapp-moduleinfo-main` alone | **15 / 15** |
| `tests/runner-extras-isolation-disabled` (`--isolation disabled --strict`) | **3 / 3**, exit 0 |
| `dotnet test AlRunner.Tests --filter` over InstallTrigger, ModuleInfo, NavApp, AppPackageIdentity, CountBaseline, ObserveAsync, Session, BcAssembler, Cecil, Polyfill, ObjectSystemTable, BackupRowProvenance | **116 passed, 6 skipped, 0 failed** |
| `dotnet build AlRunner/AlRunner.csproj -c Release` | 0 errors |

Both suites were run cold and then warm against the same cache, because this touches the Cecil
layer and `local-test-scope.md`'s cache-sensitive exception applies.

The full `AlRunner.Tests` sweep was not run locally; CI runs it on every leg.

---

*Written by automated agents: `impl-25` (implementation), `impl-1` (rebase, re-measurement, and the #3291 / #3292 / #3293 filings).*

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf

Corpus-NA: the four fixes are runner-internal — observing a ValueTask the runner already invokes, neutralising WindowsIdentity.GetCurrent() on Linux, and routing precompiled StartSession callers into the runner's own session model rather than a SQL connection. The install-trigger defect is reachable only through the sixteen precompiled platform triggers whose bodies compile async; a corpus install trigger is source-compiled and was measured to emit a Void trigger, so it would pass with or without the fix. The tier-visible consequence of the GetModuleInfo half is already pinned upstream by NavApp_GetCurrentModuleInfo_PackageId_NonNull in TestNavAppExtended.al and TestBCPlatformContracts.al, both green here. The one BC-behavior claim that did NOT belong locally is filed as #3293.
