### PR TITLE
fix(reload): clear the built-metadata caches that outlived the bundle they were built from

### DIFF
--- a/AlRunner.Tests/BuiltMetadataCacheBundleBoundaryTests.cs
+++ b/AlRunner.Tests/BuiltMetadataCacheBundleBoundaryTests.cs
@@ -1,0 +1,187 @@
+// BuiltMetadataCacheBundleBoundaryTests — the two siblings found by scanning the reset path
+// while fixing #3210 and #3172. Neither had an issue of its own; both are the same shape as
+// #2478, #2755, #3207, #3210 and #3172, and both are fixed in the same PR because the fix is the
+// same two lines in the same method.
+//
+//   RecordPatches._metaPermissionSetCache   permission set id -> built NCLMetaPermissionSet
+//   RecordPatches._tableExtensionTypeCache  tableextension id -> emitted CLR type
+//
+// Neither was cleared by anything, on any path, and both are derived from state ResetForReload
+// itself discards:
+//
+//   * _metaPermissionSetCache's entries come from EnumerateKnownPermissionSets(), i.e. from
+//     _parsedPermissionSets (cleared by ResetForReload) plus the registered .app set (cleared by
+//     ClearPerBundleBcAppPaths, #2755). The NULL answer is cached too, so an id that was unknown
+//     to bundle 1 kept producing BC's NavMetadataNotFoundException for the rest of a --server /
+//     --watch process even after a later bundle declared it.
+//   * _tableExtensionTypeCache's comment says outright that it mirrors _recordTypeCache — which
+//     ResetForReload has always cleared, on the first line of the method. Both map an AL object
+//     id to a CLR type resolved out of the emitted test assembly, so both name a generation of
+//     types the reload is replacing. Left stale, FindTableExtensionType(extId) hands back the
+//     PREVIOUS bundle's TableExtension{id} while every record type around it comes from the new
+//     one: #1683's two-live-modules-for-one-AL-identity shape, arriving through a cache instead
+//     of through a loader, and silent — the stale extension binds to the new record and its
+//     fields read the wrong storage.
+//
+// Not a claim about Business Central in either case: the subject is the lifetime of a runner
+// cache across the runner's own bundle-reload boundary.
+using System.Collections;
+using System.Reflection;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// MUST be serial: every case calls RecordPatches.ResetForReload() and drives the AL source
+// parsers into their process-global dictionaries.
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class BuiltMetadataCacheBundleBoundaryTests : IDisposable
+{
+    // Ids nothing in this repository declares, so bundle 1 below is genuinely a bundle that does
+    // not know about them.
+    private const int PermissionSetId = 79931;
+    private const int TableExtensionId = 79941;
+
+    private readonly string _root;
+
+    public BuiltMetadataCacheBundleBoundaryTests()
+    {
+        _root = TestScratch.Dir("al-runner-built-metadata-boundary");
+        Directory.CreateDirectory(_root);
+        RecordPatches.ResetForReload();
+    }
+
+    public void Dispose()
+    {
+        try { RecordPatches.ResetForReload(); } catch { }
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    [Fact]
+    public void APermissionSetUnknownToBundleOne_IsFoundOnceBundleTwoDeclaresIt()
+    {
+        // Bundle 1 declares no permission sets at all, so the production entry point answers
+        // "no such permission set" — and memoizes that null.
+        Assert.Null(RecordPatches.EnsurePermissionSetInMetadataCache(PermissionSetId));
+        Assert.Equal(1, RecordPatches.PermissionSetMetadataCacheCountForTests());
+
+        // The bundle boundary. Deliberately NOT followed by an emptiness check here: that is the
+        // sibling case's job, and asserting it here would make this test fail on the unfixed tree
+        // BEFORE reaching the behavioural claim below, which is the one worth reading.
+        RecordPatches.ResetForReload();
+
+        // Bundle 2 declares it. This is the behavioural half, and it is available here (unlike on
+        // the query and xmlport caches) because BuildNclMetaPermissionSet reaches its declaration
+        // lookup BEFORE any BC reflection: with a declaration in hand it either builds the
+        // NCLMetaPermissionSet (BC engine loaded in this test host) or raises the loud
+        // BcShapeGapException (engine absent). What it can never do is return null — so
+        // "answered null and did not throw" means one thing only: the memoized negative from
+        // bundle 1 was served, and the declaration was never even looked at.
+        var dir = Path.Combine(_root, "bundle-2");
+        Directory.CreateDirectory(dir);
+        // The permission-set parser DROPS a declaration whose owning app.json it cannot find
+        // (ResolveOwningApp) rather than attributing it to an invented app id, so the manifest is
+        // load-bearing here, not decoration. No "application" property: that is the Base
+        // Application floor, and no-base-app-in-csharp-tests.md forbids it in a C# fixture.
+        File.WriteAllText(Path.Combine(dir, "app.json"),
+            """
+            {
+              "id": "b3f1c0de-7931-4a11-9c7e-000000079931",
+              "name": "BMCB Bundle Two",
+              "publisher": "AL Runner",
+              "version": "1.0.0.0"
+            }
+            """);
+        var alPath = Path.Combine(dir, "BmcbFixture.PermissionSet.al");
+        File.WriteAllText(alPath,
+            $"permissionset {PermissionSetId} \"BMCB Bundle Two Set\"\n"
+            + "{\n    Caption = 'BMCB Bundle Two Set';\n    Assignable = true;\n}\n");
+        ParseOneSourceFile(alPath);
+
+        // Asserted, not assumed: if the source sweep had not picked the declaration up, the claim
+        // below would be about the parser, not about the cache.
+        Assert.Contains(RecordPatches.ParsedPermissionSets, p => p.Id == PermissionSetId);
+
+        object? built = null;
+        Exception? raised = null;
+        try { built = RecordPatches.EnsurePermissionSetInMetadataCache(PermissionSetId); }
+        catch (Exception ex) { raised = ex; }
+
+        // Deliberately not pinned to one exception type. Past the declaration lookup the build
+        // is BC's, and what comes back depends on how much of the engine this host happens to
+        // have: a real NCLMetaPermissionSet when it is bootstrapped, BcShapeGapException when
+        // Ncl's shape is missing, a NavEnvironment type-initializer failure when Ncl is loaded
+        // but no session was ever stood up (what a plain `dotnet test` host produces). All three
+        // mean the same thing and it is the only thing being claimed: the declaration was
+        // REACHED. Answering null without raising anything is reachable on exactly one path —
+        // the memoized negative from bundle 1 — which is the path this PR removes.
+        Assert.False(built == null && raised == null,
+            "bundle 2 declares permission set " + PermissionSetId + " and the lookup still "
+            + "answered null without attempting a build — bundle 1's memoized 'no such "
+            + "permission set' outlived the _parsedPermissionSets clear it was derived from");
+    }
+
+    [Fact]
+    public void APermissionSetMetadataEntryBuiltInBundleOne_DoesNotSurviveTheReload()
+    {
+        // The plain reset-contract direction, and the control that the memo really memoizes
+        // within one bundle: two ids asked twice each is two entries, not four builds.
+        RecordPatches.EnsurePermissionSetInMetadataCache(PermissionSetId);
+        RecordPatches.EnsurePermissionSetInMetadataCache(PermissionSetId + 1);
+        RecordPatches.EnsurePermissionSetInMetadataCache(PermissionSetId);
+        RecordPatches.EnsurePermissionSetInMetadataCache(PermissionSetId + 1);
+        Assert.Equal(2, RecordPatches.PermissionSetMetadataCacheCountForTests());
+
+        RecordPatches.ResetForReload();
+
+        Assert.Equal(0, RecordPatches.PermissionSetMetadataCacheCountForTests());
+    }
+
+    [Fact]
+    public void ATableExtensionTypeResolvedInBundleOne_DoesNotSurviveTheReload()
+    {
+        // Seeded rather than driven: FindTableExtensionType caches HITS only, and a hit needs a
+        // real emitted NavRecordExtension subclass named TableExtension{id} in a loaded assembly
+        // — i.e. a compiled bundle, which a unit test host has none of. The claim is therefore
+        // the reset contract, not the downstream mis-binding described in the file header.
+        var cache = TableExtensionTypeCache();
+        cache[TableExtensionId] = typeof(BuiltMetadataCacheBundleBoundaryTests);
+        Assert.True(cache.Contains(TableExtensionId));
+
+        RecordPatches.ResetForReload();
+
+        // On the unfixed tree the entry survives, and bundle 2's TableExtension79941 lookup is
+        // answered with bundle 1's CLR type. _recordTypeCache — which this cache's own comment
+        // says it mirrors — is cleared on the first line of the same method.
+        Assert.Empty(TableExtensionTypeCache());
+    }
+
+    /// <summary>
+    /// Run the production per-file source sweep over one .al file. Called instead of
+    /// <c>AddSourceDir</c> because that entry point only parses when <c>Register()</c> has already
+    /// run — i.e. when the BC engine is standing up in-process, which a unit-test host does not
+    /// guarantee and which would make this case skip on some boxes and run on others. This is the
+    /// same private method <c>AddSourceDirs</c> calls per file, so the declaration still lands in
+    /// the production dictionary by the production route.
+    /// </summary>
+    private static void ParseOneSourceFile(string alFilePath)
+    {
+        var m = typeof(RecordPatches).GetMethod("ParseSourceFileIntoAllExtractors",
+                    BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "RecordPatches.ParseSourceFileIntoAllExtractors not found — this test drives that sweep.");
+        m.Invoke(null, new object?[] { File.ReadAllText(alFilePath), alFilePath });
+    }
+
+    /// <summary>Read by reflection: no public surface reports it, and inferring "it was cleared"
+    /// from a later lookup cannot tell a cleared cache from one that agrees with this bundle.
+    /// </summary>
+    private static IDictionary TableExtensionTypeCache()
+    {
+        var field = typeof(RecordPatches).GetField("_tableExtensionTypeCache",
+                        BindingFlags.NonPublic | BindingFlags.Static)
+                    ?? throw new InvalidOperationException(
+                        "RecordPatches._tableExtensionTypeCache not found — this test tracks that field.");
+        return (IDictionary)field.GetValue(null)!;
+    }
+}

--- a/AlRunner.Tests/MetaQueryCacheBundleBoundaryTests.cs
+++ b/AlRunner.Tests/MetaQueryCacheBundleBoundaryTests.cs
@@ -1,0 +1,156 @@
+// MetaQueryCacheBundleBoundaryTests — issue #3210.
+//
+// WHAT WAS UNPINNED
+// -----------------
+// RecordPatches holds THREE id-keyed caches of query metadata, and ResetForReload — the
+// per-bundle reload path a --server / --watch process runs between bundles — cleared only the
+// first of them:
+//
+//   _metaQueryCache          (skeleton NCLMetaQuery)          cleared, always was
+//   _realMetaQueryCache      (BUILT NCLMetaQuery)             never cleared, on any path
+//   _lazyMetaQueryByGetById  (built NCLMetaQuery + FindQueryType) never cleared, on any path
+//
+// Both survivors are derived from state the same method discards. BuildRealNCLMetaQuery keys
+// on the query id ALONE while taking the emitted CLR type as an argument, so bundle 2's query
+// 50100 was answered with bundle 1's NCLMetaQuery — built against bundle 1's CLR type, out of
+// bundle 1's parsed query design. EnsureQueryInMetadataCache sits on top of it and additionally
+// memoizes BcRuntime.FindQueryType(id), which is a per-bundle answer that
+// BcRuntime.ResetForNewBundleReload clears (_queryTypeCache) in the line immediately before it
+// calls ResetForReload.
+//
+// Both memoize the NEGATIVE answer too — GetOrAdd stores whatever the factory returns, null
+// included — which is the half that bites without bundle 2 even having to declare the query
+// differently: an id asked about while it was unresolvable stayed unresolvable for the rest of
+// the process.
+//
+// This is the fourth defect of this exact shape in this exact reset path: #2478 (an index reset
+// that did not reset enough), #2755 (a registered set that was not cleared), #3207 (a memo that
+// outlived every input it was computed from), and now this.
+//
+// WHAT THESE TESTS PROVE, AND WHAT THEY DO NOT
+// --------------------------------------------
+// They prove the reset CONTRACT: each cache is really written by its production entry point,
+// really holds the entry afterwards, and is really empty on the far side of the reload. That is
+// a claim a no-op implementation cannot satisfy — both cases fail on the unfixed tree.
+//
+// They do NOT prove that the surviving entry was observably WRONG downstream, and saying so is
+// the point rather than a hedge. Producing a genuinely different NCLMetaQuery for one id in two
+// bundles means running BuildRealNCLMetaQueryCore to completion, which needs the reflection
+// handles into Microsoft.Dynamics.Nav.Types/Ncl AND CreateDynamicQuery — the BC engine standing
+// up in-process, driven by a real two-bundle --server fixture. That is the blocker recorded on
+// #3210 itself and on its sibling #3172, and it is why the population below deliberately uses an
+// id NOTHING declares: the factory then returns null identically whether or not the engine is
+// loaded, so the assertions mean the same thing on every box and every CI leg.
+//
+// WHY RUNNER-LOCAL AND NOT UPSTREAM
+// ---------------------------------
+// Nothing here is a claim about Business Central. The subject is the lifetime of a runner cache
+// across the runner's own bundle-reload boundary, which is not a concept BC has and not
+// something AL running on a service tier can observe.
+using System.Collections;
+using System.Reflection;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// MUST be serial: every case calls RecordPatches.ResetForReload(), which clears roughly twenty
+// process-global dictionaries other classes are reading.
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class MetaQueryCacheBundleBoundaryTests : IDisposable
+{
+    // Deliberately an id no fixture, corpus app or runner-extras bundle declares — see the
+    // header. Both factories then take their "cannot build this" exit before touching any BC
+    // reflection, so the memoized value is null on a box with the engine and on one without.
+    private const int UndeclaredQueryId = 79901;
+    private const int OtherUndeclaredQueryId = 79902;
+
+    public MetaQueryCacheBundleBoundaryTests() => RecordPatches.ResetForReload();
+
+    public void Dispose()
+    {
+        try { RecordPatches.ResetForReload(); } catch { }
+    }
+
+    [Fact]
+    public void ABuiltQueryMetadataMemoInBundleOne_DoesNotSurviveTheReloadIntoBundleTwo()
+    {
+        // Populated through the PRODUCTION entry point, not by poking the dictionary: that is
+        // what makes "the reload emptied it" a statement about the real memo rather than about
+        // a dictionary this test happens to own.
+        Assert.Null(RecordPatches.BuildRealNCLMetaQuery(UndeclaredQueryId, typeof(object)));
+
+        // Asserted, not assumed. If the call had not memoized anything, the emptiness assertion
+        // below would be satisfied trivially and this test would prove nothing at all.
+        var memo = RealMetaQueryCache();
+        Assert.True(memo.Contains(UndeclaredQueryId),
+            "BuildRealNCLMetaQuery did not memoize its answer — this test tracks that memo, "
+            + "and the clear it is asserting would be meaningless without it.");
+        Assert.Null(memo[UndeclaredQueryId]);
+
+        // The bundle boundary itself.
+        RecordPatches.ResetForReload();
+
+        // The fix. On the unfixed tree the entry is still there, keyed on an id whose CLR type,
+        // parsed query design and FindQueryType answer this reload has just discarded.
+        Assert.Empty(RealMetaQueryCache());
+    }
+
+    [Fact]
+    public void TheLazyGetByIdQueryMemoInBundleOne_DoesNotSurviveTheReloadIntoBundleTwo()
+    {
+        // The second cache, reached through its own production entry point. It wraps the first
+        // one AND memoizes BcRuntime.FindQueryType(id) — the per-bundle answer whose own cache
+        // ResetForNewBundleReload clears immediately before calling ResetForReload, so this memo
+        // was defeating an invalidation its dependency performs.
+        Assert.Null(RecordPatches.EnsureQueryInMetadataCache(OtherUndeclaredQueryId));
+
+        var memo = LazyMetaQueryCache();
+        Assert.True(memo.Contains(OtherUndeclaredQueryId),
+            "EnsureQueryInMetadataCache did not memoize its answer — see the sibling case.");
+        Assert.Null(memo[OtherUndeclaredQueryId]);
+
+        RecordPatches.ResetForReload();
+
+        Assert.Empty(LazyMetaQueryCache());
+    }
+
+    [Fact]
+    public void BothMemosStillMemoise_WithinOneBundle()
+    {
+        // The control that stops the fix from being "clear it so often it never caches". Both
+        // caches exist for a real reason INSIDE a bundle — BuildRealNCLMetaQueryCore builds a
+        // whole MetaQuery design and calls CreateDynamicQuery, and EnsureQueryInMetadataCache
+        // additionally re-resolves FindQueryType and re-inserts a BC metadata cache entry — and
+        // the answer genuinely cannot change without a reload.
+        for (var i = 0; i < 3; i++)
+        {
+            RecordPatches.BuildRealNCLMetaQuery(UndeclaredQueryId, typeof(object));
+            RecordPatches.EnsureQueryInMetadataCache(OtherUndeclaredQueryId);
+        }
+
+        // Exactly one entry each, three calls in: repeated calls are memo hits, not rebuilds.
+        // "The same answer three times" would be equally satisfied by no memo at all, which is
+        // why this asserts against the dictionaries rather than against the return values.
+        Assert.Equal(1, RealMetaQueryCache().Count);
+        Assert.Equal(1, LazyMetaQueryCache().Count);
+        Assert.True(RealMetaQueryCache().Contains(UndeclaredQueryId));
+        Assert.True(LazyMetaQueryCache().Contains(OtherUndeclaredQueryId));
+    }
+
+    /// <summary>The built-NCLMetaQuery memo. Read by reflection on purpose: no public surface
+    /// reports it, and inferring "it was cleared" from a later lookup cannot tell a cleared cache
+    /// from one that happens to agree with the current bundle.</summary>
+    private static IDictionary RealMetaQueryCache() => StaticDictionary("_realMetaQueryCache");
+
+    /// <summary>The GetById memo that wraps it — same reasoning.</summary>
+    private static IDictionary LazyMetaQueryCache() => StaticDictionary("_lazyMetaQueryByGetById");
+
+    private static IDictionary StaticDictionary(string fieldName)
+    {
+        var field = typeof(RecordPatches).GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                $"RecordPatches.{fieldName} not found — this test tracks that field (#3210).");
+        return (IDictionary)field.GetValue(null)!;
+    }
+}

--- a/AlRunner.Tests/XmlPortRealMetadataBundleBoundaryTests.cs
+++ b/AlRunner.Tests/XmlPortRealMetadataBundleBoundaryTests.cs
@@ -1,0 +1,206 @@
+// XmlPortRealMetadataBundleBoundaryTests — issue #3172.
+//
+// WHAT WAS UNPINNED
+// -----------------
+// RecordPatches.RealXmlPortMetadata.cs is a near-verbatim copy of
+// RecordPatches.RealPageMetadata.cs — its own header says so — and it carried the same pair of
+// bookkeeping sets:
+//
+//   _xmlPortsWithRealMetadata     "LoadMetadata() has run on this id's NCLMetaXmlPort"
+//   _xmlPortsRealMetadataFailed   "…was attempted on it and threw"
+//
+// What it did not carry is the fix #1957 gave the page side. Nothing cleared either set, on any
+// path — they appeared nowhere else in the runner. ResetForReload discards every NCLMetaXmlPort
+// instance via _metaXmlPortCache.Clear() without discarding the bookkeeping that DESCRIBES those
+// instances, so from the second --watch cycle / --server request onward:
+//
+//   1. the next lookup rebuilds a brand-new, never-loaded skeleton through
+//      _metaXmlPortCache.GetOrAdd(id, BuildNCLMetaXmlPort);
+//   2. _xmlPortsWithRealMetadata still contains the id from cycle 1, so EnsureRealXmlPortMetadata
+//      returns that skeleton AS IF its metadata had been loaded, without ever calling
+//      LoadMetadata() on it.
+//
+// Per this file's production header, an NCLMetaXmlPort with metadataLoaded = true and no schema
+// is exactly what makes every real xmlport operation NRE. The failure set has the mirror problem
+// in the same window: an xmlport whose load failed in cycle 1 could never be observed to load in
+// cycle 2, even after the edit that fixed the cause.
+//
+// HOW EACH SET IS POPULATED HERE, AND WHY THE TWO DIFFER
+// ------------------------------------------------------
+// The FAILURE set is populated by driving the real EnsureRealXmlPortMetadata: it is handed an
+// instance with no LoadMetadata method, so the load attempt fails and the id is recorded exactly
+// the way a genuine failure records it. Which exception ends the attempt depends on whether
+// Microsoft.Dynamics.Nav.Ncl happens to be loaded in the test host — with it, the metadataLoaded
+// field poke rejects a foreign instance first; without it, the missing method does — and on the
+// engine-present route the catch block's own restore poke rethrows, so the call can either return
+// null or throw. The OBSERVABLE this asserts is identical on both routes: the id is in the
+// failure set afterwards. That is why the drive is wrapped rather than asserted on directly.
+//
+// The SUCCESS set cannot be populated that way on both routes, because reaching it needs a
+// LoadMetadata() that actually succeeds against a real NCLMetaXmlPort — the BC engine standing
+// up in-process with an emit-captured metadata XML behind it, which is the blocker recorded on
+// #3172 and why #3011 left this out. So it is seeded directly, and the claim is narrowed to
+// match: the reset contract, not the downstream NRE. An honest RED that fails on the unfixed
+// tree beats a behavioural test that only runs on some boxes.
+//
+// WHAT IS DELIBERATELY NOT ASSERTED
+// ---------------------------------
+// The GROW direction #3011 fixed on the page side — a negative answer taken before the .app
+// declaring the object was registered surviving that registration — is a SEPARATE and still
+// unverified question here, and #3172 says so: the page gate reads
+// AlPageMetadataRegistry || HasDependencyPageMetadata (which walks _bcAppPaths), while the
+// xmlport gate reads AlXmlPortMetadataRegistry alone and BuildNCLMetaXmlPort gates on
+// _parsedXmlPorts alone. Neither is derived from the registered .app set, so nothing here claims
+// anything about it.
+//
+// WHY RUNNER-LOCAL AND NOT UPSTREAM
+// ---------------------------------
+// Not a claim about Business Central: the subject is the lifetime of runner bookkeeping across
+// the runner's own bundle-reload boundary, which no service tier has an equivalent of.
+using System.Collections;
+using System.Reflection;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// MUST be serial: every case calls RecordPatches.ResetForReload().
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class XmlPortRealMetadataBundleBoundaryTests : IDisposable
+{
+    private const int SucceedingXmlPortId = 79911;
+    private const int FailingXmlPortId = 79912;
+
+    /// <summary>Stands in for one generation's NCLMetaXmlPort. Deliberately carries NO
+    /// LoadMetadata method: the load attempt in <c>EnsureRealXmlPortMetadata</c> must fail, which
+    /// is the whole point of the failure-set case.</summary>
+    private sealed class GenerationSkeleton
+    {
+        public string Generation { get; init; } = "";
+    }
+
+    public XmlPortRealMetadataBundleBoundaryTests() => RecordPatches.ResetForReload();
+
+    public void Dispose()
+    {
+        try { RecordPatches.ResetForReload(); } catch { }
+        try { AlXmlPortMetadataRegistry.Clear(); } catch { }
+    }
+
+    [Fact]
+    public void ASuccessfulLoadRecordedInBundleOne_DoesNotSurviveTheReloadIntoBundleTwo()
+    {
+        SeedMetaXmlPort(SucceedingXmlPortId, new GenerationSkeleton { Generation = "bundle-1" });
+        RecordSuccessfulLoad(SucceedingXmlPortId);
+
+        // Asserted, not assumed — an emptiness assertion over something never populated proves
+        // nothing. This also pins the production accessor the assertion below reads through.
+        Assert.True(RecordPatches.XmlPortHasRealMetadataForTests(SucceedingXmlPortId),
+            "the success record was not established, so the clear below would be vacuous");
+
+        // The bundle boundary itself. This discards the NCLMetaXmlPort generation the record
+        // describes — that is the very line the record has to travel with.
+        RecordPatches.ResetForReload();
+        Assert.Empty(MetaXmlPortCache());
+
+        // The fix. On the unfixed tree this is still true, and the next EnsureRealXmlPortMetadata
+        // hands back a brand-new never-loaded skeleton as "already loaded".
+        Assert.False(RecordPatches.XmlPortHasRealMetadataForTests(SucceedingXmlPortId),
+            "the 'already loaded' record outlived the NCLMetaXmlPort generation it describes "
+            + "(#3172) — the next lookup will short-circuit a never-loaded skeleton");
+    }
+
+    [Fact]
+    public void AFailedLoadRecordedInBundleOne_DoesNotSurviveTheReloadIntoBundleTwo()
+    {
+        // Registered so the method's own first gate (AlXmlPortMetadataRegistry.TryGet) passes;
+        // the XML content is never parsed on this route because the metaxmlport is pre-seeded.
+        AlXmlPortMetadataRegistry.Register(FailingXmlPortId, "<XmlPort/>");
+        SeedMetaXmlPort(FailingXmlPortId, new GenerationSkeleton { Generation = "bundle-1" });
+
+        // The real production path records the failure. See the header for why the call is
+        // wrapped: which exception ends the attempt differs by test host, the recorded outcome
+        // does not.
+        DriveFailingLoad(FailingXmlPortId);
+        Assert.True(RecordPatches.XmlPortRealMetadataFailedForTests(FailingXmlPortId),
+            "EnsureRealXmlPortMetadata did not record the failed load — this test tracks that "
+            + "record, and the clear it asserts would be meaningless without it");
+
+        // Control, and the reason this is not "clear it so often it never remembers": WITHIN one
+        // bundle the record must stand, so a repeatedly failing xmlport is not retried on every
+        // single metadata lookup. A second drive changes nothing.
+        DriveFailingLoad(FailingXmlPortId);
+        Assert.True(RecordPatches.XmlPortRealMetadataFailedForTests(FailingXmlPortId));
+
+        RecordPatches.ResetForReload();
+
+        // The fix, mirror direction: the next cycle must get a fresh attempt against the new
+        // generation, or an edit that fixes the underlying cause could never be observed to have
+        // fixed it. On the unfixed tree this record is permanent for the life of the process.
+        Assert.False(RecordPatches.XmlPortRealMetadataFailedForTests(FailingXmlPortId),
+            "the failed-load record outlived the NCLMetaXmlPort generation it describes (#3172) "
+            + "— an xmlport that starts loading in the next cycle can never be seen to");
+    }
+
+    [Fact]
+    public void TheTwoRecordsAreIndependent_AndBothGoAtTheReload()
+    {
+        // One id in each set at once: a reset that clears only one of them (the shape the page
+        // side would have had if #1957 had only fixed the success half) fails here.
+        AlXmlPortMetadataRegistry.Register(FailingXmlPortId, "<XmlPort/>");
+        SeedMetaXmlPort(FailingXmlPortId, new GenerationSkeleton { Generation = "bundle-1" });
+        DriveFailingLoad(FailingXmlPortId);
+        SeedMetaXmlPort(SucceedingXmlPortId, new GenerationSkeleton { Generation = "bundle-1" });
+        RecordSuccessfulLoad(SucceedingXmlPortId);
+
+        Assert.True(RecordPatches.XmlPortRealMetadataFailedForTests(FailingXmlPortId));
+        Assert.True(RecordPatches.XmlPortHasRealMetadataForTests(SucceedingXmlPortId));
+        // Neither record leaks into the other set.
+        Assert.False(RecordPatches.XmlPortHasRealMetadataForTests(FailingXmlPortId));
+        Assert.False(RecordPatches.XmlPortRealMetadataFailedForTests(SucceedingXmlPortId));
+
+        RecordPatches.ResetForReload();
+
+        Assert.False(RecordPatches.XmlPortRealMetadataFailedForTests(FailingXmlPortId));
+        Assert.False(RecordPatches.XmlPortHasRealMetadataForTests(SucceedingXmlPortId));
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Drive the real <c>EnsureRealXmlPortMetadata</c> to a failed load. Tolerates the exception
+    /// the engine-present route ends on — see the file header — and nothing else: an unexpected
+    /// exception type still fails the test, and the recorded outcome is asserted by the caller.
+    /// </summary>
+    private static void DriveFailingLoad(int xmlPortId)
+    {
+        try { RecordPatches.EnsureRealXmlPortMetadata(xmlPortId); }
+        catch (ArgumentException) { /* Ncl loaded: the metadataLoaded field poke rejects a foreign instance */ }
+    }
+
+    /// <summary>
+    /// Put <paramref name="xmlPortId"/> in the success set. Seeded rather than driven because a
+    /// genuine success needs a real NCLMetaXmlPort and a real LoadMetadata() — the in-process BC
+    /// engine blocker recorded on #3172. Written through the same lock the production code uses.
+    /// </summary>
+    private static void RecordSuccessfulLoad(int xmlPortId)
+    {
+        var gate = StaticField("_realXmlPortMetadataLock").GetValue(null)!;
+        var set = (ICollection<int>)StaticField("_xmlPortsWithRealMetadata").GetValue(null)!;
+        lock (gate) set.Add(xmlPortId);
+    }
+
+    /// <summary>Pre-seed the metaxmlport cache so <c>EnsureRealXmlPortMetadata</c> gets a
+    /// non-null instance without <c>BuildNCLMetaXmlPort</c> (and therefore the BC engine) having
+    /// to run.</summary>
+    private static void SeedMetaXmlPort(int xmlPortId, object skeleton)
+        => MetaXmlPortCache()[xmlPortId] = skeleton;
+
+    private static IDictionary MetaXmlPortCache()
+        => (IDictionary)StaticField("_metaXmlPortCache").GetValue(null)!;
+
+    private static FieldInfo StaticField(string name)
+        => typeof(RecordPatches).GetField(name, BindingFlags.NonPublic | BindingFlags.Static)
+           ?? throw new InvalidOperationException(
+               $"RecordPatches.{name} not found — this test tracks that field (#3172).");
+}

--- a/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionMetadataPopulator.cs
@@ -406,6 +406,33 @@ public static partial class RecordPatches
     private static MethodInfo? _mCreateEmptyMetaPermissionSet;
 
     /// <summary>
+    /// Drop the built-<c>NCLMetaPermissionSet</c> cache on a bundle reload, called from
+    /// <see cref="RecordPatches.ResetForReload"/> next to the other built-metadata caches.
+    /// <para>
+    /// Every entry is derived from <see cref="EnumerateKnownPermissionSets"/>, i.e. from
+    /// <c>_parsedPermissionSets</c>, which that same method clears — so without this the
+    /// cache outlived the only input its answers came from. Both directions matter: a
+    /// permission set redeclared by the incoming bundle kept answering with the previous
+    /// bundle's metadata, and the NULL answer is cached too, so an id that was genuinely
+    /// unknown to bundle 1 kept producing BC's <c>NavMetadataNotFoundException</c> for the
+    /// rest of a <c>--server</c>/<c>--watch</c> process even after a later bundle declared it.
+    /// </para>
+    /// </summary>
+    internal static void ResetPermissionSetMetadataForReload()
+    {
+        lock (_permMetaGate) _metaPermissionSetCache.Clear();
+    }
+
+    /// <summary>The number of permission-set ids currently memoized (including the ids
+    /// memoized as "not declared"). Test-visible because "the reload emptied it" cannot be
+    /// inferred from a later lookup: a cleared cache and one that happens to agree with the
+    /// current bundle answer identically.</summary>
+    internal static int PermissionSetMetadataCacheCountForTests()
+    {
+        lock (_permMetaGate) return _metaPermissionSetCache.Count;
+    }
+
+    /// <summary>
     /// The <c>NCLMetaPermissionSet</c> for one permission set id, built from the runner's own
     /// inventory and cached. Null when the runner has no declaration for that id — the caller
     /// then falls through to BC's own <c>NavMetadataNotFoundException</c>, which is what

--- a/AlRunner/Patches/RecordPatches.RealXmlPortMetadata.cs
+++ b/AlRunner/Patches/RecordPatches.RealXmlPortMetadata.cs
@@ -31,21 +31,71 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
-    // KNOWN GAP — #3172. Nothing clears either of these sets, on any path: they appear
-    // nowhere else in the runner. RecordPatches.ResetForReload discards every
-    // NCLMetaXmlPort via _metaXmlPortCache.Clear() without discarding the bookkeeping that
-    // describes them, so from the second --watch cycle / --server request onward the
-    // success set short-circuits a brand-new, never-loaded skeleton as "already loaded" —
-    // the page-side defect #1957 fixed with ResetPageMetadataForReload, never mirrored
-    // here. Left out of #3011's PR because neither set can be populated from a test host
-    // without the BC engine loaded in-process, so the fix could not be proved there; see
-    // the issue for what a proving test has to look like. The GROW direction #3011 fixed on
-    // the page side is a SEPARATE and unverified question here — this file's gate reads
+    // Both sets are statements about ONE generation of NCLMetaXmlPort instances — the ones
+    // _metaXmlPortCache holds — so ResetXmlPortMetadataForReload discards them alongside it
+    // (#3172; the page-side equivalent is #1957's ResetPageMetadataForReload). The GROW
+    // direction #3011 fixed on the page side is a SEPARATE and still-unverified question
+    // here, and is deliberately NOT addressed: this file's gate reads
     // AlXmlPortMetadataRegistry and _parsedXmlPorts, neither of which is derived from the
-    // registered .app set.
+    // registered .app set, so the page side's epoch argument does not transfer unexamined.
     private static readonly HashSet<int> _xmlPortsWithRealMetadata = new();
     private static readonly HashSet<int> _xmlPortsRealMetadataFailed = new();
     private static readonly object _realXmlPortMetadataLock = new();
+
+    /// <summary>Whether <paramref name="xmlPortId"/> is recorded as having had its REAL
+    /// xmlport metadata successfully loaded — the success set #3172 requires
+    /// <see cref="ResetXmlPortMetadataForReload"/> to discard alongside the
+    /// <c>NCLMetaXmlPort</c> instances it describes.</summary>
+    internal static bool XmlPortHasRealMetadataForTests(int xmlPortId)
+    {
+        lock (_realXmlPortMetadataLock) return _xmlPortsWithRealMetadata.Contains(xmlPortId);
+    }
+
+    /// <summary>Whether <paramref name="xmlPortId"/> is recorded as having FAILED its real
+    /// metadata load. The mirror of <see cref="XmlPortHasRealMetadataForTests"/>, and the
+    /// half that suppresses every later attempt for that id until the next reload.</summary>
+    internal static bool XmlPortRealMetadataFailedForTests(int xmlPortId)
+    {
+        lock (_realXmlPortMetadataLock) return _xmlPortsRealMetadataFailed.Contains(xmlPortId);
+    }
+
+    /// <summary>
+    /// Clear the "already loaded" / "already failed" bookkeeping alongside
+    /// <c>_metaXmlPortCache</c> on a <c>--watch</c> / <c>--server</c> reload (#3172). The
+    /// verbatim mirror of <see cref="ResetPageMetadataForReload"/>, which this file's header
+    /// already declares itself a direct sibling of.
+    /// <para>
+    /// Both sets name ONE specific <c>NCLMetaXmlPort</c> instance — "this object's
+    /// <c>metadataLoaded</c> flag has been cleared and <c>LoadMetadata()</c> has run on it",
+    /// or "was attempted and threw". <see cref="ResetForReload"/> discards exactly those
+    /// instances via <c>_metaXmlPortCache.Clear()</c>, so leaving either set populated makes
+    /// <see cref="EnsureRealXmlPortMetadata"/> answer questions about a generation of objects
+    /// that no longer exists.
+    /// </para>
+    /// <para>
+    /// The success set surviving is the live defect: the next lookup rebuilds a brand-new,
+    /// never-loaded skeleton through <c>_metaXmlPortCache.GetOrAdd(id, BuildNCLMetaXmlPort)</c>
+    /// and then short-circuits it as "already loaded" — and per this file's header, an
+    /// NCLMetaXmlPort with <c>metadataLoaded = true</c> and no schema is exactly what makes
+    /// every real xmlport operation NRE (<c>CreateObjectInstance</c> has no node tree to
+    /// instantiate, <c>GetMetadataFromLoader</c> has nothing to read).
+    /// </para>
+    /// <para>
+    /// The failure set is cleared for the mirror reason, not merely for symmetry: an xmlport
+    /// whose load failed against the previous generation must get a fresh attempt against
+    /// this one, or the edit that fixes the cause could never be observed to have fixed it.
+    /// One retry per cycle, not a retry storm, and every failed attempt still logs loudly
+    /// from <see cref="EnsureRealXmlPortMetadata"/>'s catch block.
+    /// </para>
+    /// </summary>
+    internal static void ResetXmlPortMetadataForReload()
+    {
+        lock (_realXmlPortMetadataLock)
+        {
+            _xmlPortsWithRealMetadata.Clear();
+            _xmlPortsRealMetadataFailed.Clear();
+        }
+    }
 
     /// <summary>
     /// Ensure <paramref name="xmlPortId"/>'s NCLMetaXmlPort carries its real, parsed

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -231,6 +231,18 @@ public static partial class RecordPatches
     {
         _metaTableCache.Clear();
         _recordTypeCache.Clear();
+        // Sibling of the line above, and it said so in its own comment ("Cached HITS only,
+        // mirroring _recordTypeCache") while not being mirrored HERE — nothing cleared it on
+        // any path. Both map an AL object id to a CLR type resolved out of the emitted test
+        // assembly, so both name a generation of types that this reload is replacing: from
+        // the second --server request / --watch cycle onward, FindTableExtensionType(extId)
+        // handed back the PREVIOUS bundle's TableExtension{id} while every record type around
+        // it came from the new one. That is #1683's two-live-modules-for-one-AL-identity
+        // shape arriving through a cache instead of through a loader, and it is silent: the
+        // stale extension binds to the new record and its fields read the wrong storage.
+        // Safe, for the same reason _recordTypeCache's clear is: hits only, and a miss falls
+        // through to the assembly scan that repopulates it.
+        _tableExtensionTypeCache.Clear();
         _parsedTables.Clear();
         _parsedExtensionFields.Clear();
         _extensionIdsByBaseTable.Clear();
@@ -311,7 +323,31 @@ public static partial class RecordPatches
         ResetPageMetadataForReload();
         _metaReportCache.Clear();
         _metaQueryCache.Clear();
+        // #3210: the two id-keyed caches of BUILT NCLMetaQuery objects that sit on top of
+        // _metaQueryCache and were the only pieces of this chain nothing dropped.
+        // BuildRealNCLMetaQuery keys on the query id ALONE while taking the emitted CLR type
+        // as an argument, so bundle 2's query 50100 was answered with bundle 1's NCLMetaQuery
+        // built against bundle 1's CLR type; EnsureQueryInMetadataCache sits on top of it and
+        // additionally memoizes BcRuntime.FindQueryType(id), a per-bundle answer that
+        // ResetForNewBundleReload clears (_queryTypeCache) immediately before calling this.
+        // Both memoize the NEGATIVE answer too, which is the half that bites without a second
+        // bundle even declaring the query differently: an id asked about while it was
+        // unresolvable stayed null for the rest of the process.
+        _realMetaQueryCache.Clear();
+        _lazyMetaQueryByGetById.Clear();
+        // Same shape again, one object type over: id -> built NCLMetaPermissionSet, derived
+        // from EnumerateKnownPermissionSets() -> _parsedPermissionSets, which this method
+        // clears a few lines above. Nothing cleared it, so a permission set an edited bundle
+        // renames or redeclares kept answering with the previous bundle's metadata, and one
+        // that bundle 1 did not declare kept answering "no such permission set" (the null is
+        // cached) even after bundle 2 declared it.
+        ResetPermissionSetMetadataForReload();
         _metaXmlPortCache.Clear();
+        // #3172: the xmlport side of #1957, never mirrored. Both sets are statements about
+        // the specific NCLMetaXmlPort instances _metaXmlPortCache.Clear() has just discarded
+        // — see ResetXmlPortMetadataForReload's doc comment, and ResetPageMetadataForReload's
+        // for the page-side failure this prevents.
+        ResetXmlPortMetadataForReload();
         _sourceDirs.Clear();
         _installBaseline = null;
         SetActiveDepCompanyBaseline(null);


### PR DESCRIPTION
Closes #3210
Closes #3172

One shape, five caches, one method. `RecordPatches.ResetForReload` is the per-bundle reload
path a `--server` / `--watch` process runs between bundles. Every id-keyed cache of a **built
object derived from per-bundle state** must be discarded there, and four of them were not —
by anything, on any path. This is the fifth, sixth, seventh and eighth defect of that shape in
this one method: #2478 (an index reset that did not reset enough), #2755 (a registered set that
was not cleared), #3207 (a memo that outlived every input it was computed from), and now these.

Batched per `.claude/rules/batch-sibling-issues-by-file.md` (PR #3215): all four fixes are lines
in **one method in one file**, `AlRunner/Patches/RecordPatches.cs`, plus a reset helper in the
partial that owns each cache. Each closed issue has its own RED → GREEN.

## What was cleared, and why each one is a defect

| cache | file | derived from | what the stale entry did |
|---|---|---|---|
| `_realMetaQueryCache` | `RecordPatches.NclMetaQueryBuilder.cs` | the parsed query design + the emitted CLR type | keyed on the query **id alone** while `BuildRealNCLMetaQuery` takes the CLR type as an argument, so bundle 2's query 50100 got bundle 1's `NCLMetaQuery`, built against bundle 1's type |
| `_lazyMetaQueryByGetById` | `RecordPatches.NclMetadataCachePopulator.cs` | the above, plus `BcRuntime.FindQueryType(id)` | additionally defeated an invalidation its own dependency performs — `ResetForNewBundleReload` clears `_queryTypeCache` in the line before it calls `ResetForReload` |
| `_xmlPortsWithRealMetadata` / `_xmlPortsRealMetadataFailed` | `RecordPatches.RealXmlPortMetadata.cs` | the `NCLMetaXmlPort` instances `_metaXmlPortCache.Clear()` discards | the success set short-circuited a brand-new never-loaded skeleton as "already loaded" — per that file's own header, `metadataLoaded = true` with no schema is what makes every real xmlport operation NRE. The mirror half made a failed load permanent for the life of the process |
| `_metaPermissionSetCache` | `RecordPatches.PermissionMetadataPopulator.cs` | `EnumerateKnownPermissionSets()` → `_parsedPermissionSets`, which the same method clears | a redeclared permission set kept answering with the previous bundle's metadata; a set unknown to bundle 1 kept producing BC's `NavMetadataNotFoundException` after bundle 2 declared it |
| `_tableExtensionTypeCache` | `RecordPatches.CreateObjectInstance.cs` | the emitted test assembly | its own comment says it mirrors `_recordTypeCache` — which `ResetForReload` clears on its **first line**. Left stale, `FindTableExtensionType(extId)` hands back the previous bundle's `TableExtension{id}` while every record type around it comes from the new one: #1683's two-live-modules-for-one-AL-identity shape arriving through a cache instead of a loader |

All of them memoize the **negative** answer too (`GetOrAdd` / `TryGetValue`-then-store keeps a
null), so an id that was unresolvable to bundle 1 stayed unresolvable for the rest of the
process even after a later bundle declared it. That half bites without bundle 2 having to
declare anything differently.

The last two had no issue of their own; they came out of the queue-and-code scan below and are
fixed here rather than filed, per `impl-agent.md`'s "fix the shape, not just the reported line".
Neither carries a `Closes` line.

## RED → GREEN

RED is taken by reverting **only** `AlRunner/Patches/RecordPatches.cs` — the four clears are the
fix; the reset helpers and the two test-visible accessors are surface, and leaving them defined
but uncalled is exactly the broken state.

```
Failed!  - Failed: 8, Passed: 1, Skipped: 0, Total: 9   (fix reverted)
Passed!  - Failed: 0, Passed: 9, Skipped: 0, Total: 9   (fix restored)
```

The one case that passes on the broken tree is
`MetaQueryCacheBundleBoundaryTests.BothMemosStillMemoise_WithinOneBundle` — the control that
stops the fix from being "clear it so often it never caches". It is supposed to be green in
both states.

Per closed issue:

**#3210** — `MetaQueryCacheBundleBoundaryTests`

```
ABuiltQueryMetadataMemoInBundleOne_DoesNotSurviveTheReloadIntoBundleTwo [FAIL]
  Assert.Empty() Failure: Collection was not empty
  Collection: [[79901] = null]
TheLazyGetByIdQueryMemoInBundleOne_DoesNotSurviveTheReloadIntoBundleTwo [FAIL]
  Assert.Empty() Failure: Collection was not empty
  Collection: [[79902] = null]
```

**#3172** — `XmlPortRealMetadataBundleBoundaryTests`

```
ASuccessfulLoadRecordedInBundleOne_DoesNotSurviveTheReloadIntoBundleTwo [FAIL]
  the 'already loaded' record outlived the NCLMetaXmlPort generation it describes (#3172)
  — the next lookup will short-circuit a never-loaded skeleton
AFailedLoadRecordedInBundleOne_DoesNotSurviveTheReloadIntoBundleTwo [FAIL]
  the failed-load record outlived the NCLMetaXmlPort generation it describes (#3172)
  — an xmlport that starts loading in the next cycle can never be seen to
TheTwoRecordsAreIndependent_AndBothGoAtTheReload [FAIL]
```

**The two unreported siblings** — `BuiltMetadataCacheBundleBoundaryTests`

```
APermissionSetUnknownToBundleOne_IsFoundOnceBundleTwoDeclaresIt [FAIL]
  bundle 2 declares permission set 79931 and the lookup still answered null without
  attempting a build — bundle 1's memoized 'no such permission set' outlived the
  _parsedPermissionSets clear it was derived from
APermissionSetMetadataEntryBuiltInBundleOne_DoesNotSurviveTheReload [FAIL]
  Assert.Equal() Failure: Expected 0, Actual 2
ATableExtensionTypeResolvedInBundleOne_DoesNotSurviveTheReload [FAIL]
  Assert.Empty() Failure: Collection was not empty
  Collection: [[79941] = typeof(AlRunner.Tests.BuiltMetadataCacheBundleBoundaryTests)]
```

`APermissionSetUnknownToBundleOne_IsFoundOnceBundleTwoDeclaresIt` is the one **behavioural**
case in the set, and it is worth reading as the honest centre of the PR: bundle 1 asks for a
permission set nobody declares (null, memoized), the reload crosses, bundle 2's source declares
it, and the lookup must reach that declaration. Past the declaration lookup the build is BC's,
so what comes back depends on how much engine the host has — a real `NCLMetaPermissionSet`, a
`BcShapeGapException`, or a `NavEnvironment` type-initializer failure. All three mean "the
declaration was reached". Answering **null without raising anything** is reachable on exactly
one path: the memoized negative from bundle 1. That is the assertion, and it is
environment-independent.

An earlier draft of that case asserted the cache was empty right after the reload as well; it
was removed on purpose, because it made the test fail on the unfixed tree *before* reaching the
claim above. The emptiness check lives in the sibling case where it belongs.

### What the tests do NOT prove, stated plainly

Three of the five caches cannot be shown to have served an **observably wrong** value from a
unit-test host, and pretending otherwise would be the exact defect class this session has spent
its time finding.

* `_realMetaQueryCache` / `_lazyMetaQueryByGetById` — producing a genuinely different
  `NCLMetaQuery` for one id in two bundles means running `BuildRealNCLMetaQueryCore` to
  completion, which needs the reflection handles into `Microsoft.Dynamics.Nav.Types`/`Ncl`
  **and** `CreateDynamicQuery`: the BC engine standing up in-process, driven by a real
  two-bundle `--server` fixture. That is the blocker #3210 recorded on itself. The ids used are
  ones nothing declares, so the factory takes its "cannot build this" exit identically with and
  without the engine and the assertions mean the same thing on every leg.
* `_xmlPortsWithRealMetadata` — reaching the success set needs a `LoadMetadata()` that actually
  succeeds against a real `NCLMetaXmlPort`, the blocker #3172 recorded and the reason #3011 left
  it out. That set is seeded directly. The **failure** set is not: it is populated by driving
  the real `EnsureRealXmlPortMetadata`, which is why that half is stronger evidence than the
  other.
* `_tableExtensionTypeCache` — `FindTableExtensionType` caches **hits only**, and a hit needs a
  real emitted `NavRecordExtension` subclass in a loaded assembly, i.e. a compiled bundle. Seeded.

So what is pinned for those is the reset **contract**, not the downstream mis-binding. Every one
of them still fails on the unfixed tree, which is the bar; none of them is a guard that cannot
fail.

One environment note in `XmlPortRealMetadataBundleBoundaryTests`: the failure-set drive is
wrapped in a narrow `catch (ArgumentException)`. Which exception ends the load attempt depends
on whether `Microsoft.Dynamics.Nav.Ncl` happens to be loaded in the test host — with it, the
`metadataLoaded` field poke rejects a foreign instance first and the catch block's own restore
poke rethrows; without it, the missing `LoadMetadata` method does. The **recorded outcome** is
identical on both routes, and that is what is asserted.

## Does this assert anything about what BC does?

**No, and here is the argument rather than the word.** The subject of every assertion is the
lifetime of a runner-internal cache across the runner's own bundle-reload boundary. BC has no
bundle reload: a service tier loads an application once per tenant and has no equivalent of
`--server` swapping one compiled app for another inside one process. There is no AL a corpus
test could write that observes `_realMetaQueryCache`, and no BC API that reports it. The
*subjects* the caches hold — query metadata, xmlport schemas, permission-set metadata,
tableextension binding — are all BC-observable and all already asked upstream; nothing here
restates any of those claims or changes an answer given inside a single bundle. No corpus PR,
and the submodule pin is deliberately not touched (#3202).

## What I did not fold, and why

Per point 5 of the batching rule — this map is the other half of the output.

* **#2939 (`_bcQuerySymbolJsonPaths`) — deliberately left open, and I have the measurement it
  asked for.** It is the same *file family* but not the same kind of state: a **registration**
  list, not a derived cache. Clearing it destroys information only the registrant can put back,
  which is exactly what caused the SystemApp regression #2755 warned about. #2939 names the
  measurement that decides it — "whether any path reaches a query lookup with neither an emit
  nor a cache-hit having run for that bundle in the current reset window". **There is one:** the
  cross-bundle module-dedup path. `Program.cs:4878-4917` and `2770-2798` skip the entire
  cache-key/registration block when `DependencyLoader.TryGetByAppId` returns a module
  (`reusedAsm != null`), so no emit and no cache-hit registration runs for that bundle, while the
  reused module's Query CLR types are still live and still calling `GetColumnByNo`. A flat clear
  would unregister the only symbol source those ids can be resolved from — the #2755 shape
  exactly. The full comment is on #2939.
* **`_owningAppByDir` (`RecordPatches.AlProfileParser.cs`) and `_appOwnerCache`
  (`RecordPatches.PermissionMetadataPopulator.cs`)** — two more never-cleared statics found by
  the scan, both memoizing an **identity read** (an `app.json` walk-up, and a
  `NavAppRuntimeMetadata` built from one) rather than built metadata derived from a dictionary
  this method clears. A `--watch` cycle that edits `app.json`'s `id` or `name` keeps the old
  attribution for every profile and permission set. Different reasoning, different cost
  question (per-cycle filesystem reads), so filed as **#3226** rather than folded.
* **The GROW direction on the xmlport side** — #3172 says explicitly that #3011's page-side
  epoch argument does not transfer unexamined, because the xmlport gate reads
  `AlXmlPortMetadataRegistry` and `_parsedXmlPorts` and neither is derived from the registered
  `.app` set. Nothing here claims anything about it; the production comment records that it is
  still open.
* **The submodule pin** (#3202) and anything under `.github/workflows/` (#3192).

### The rest of the scan, so the map is complete

Every static collection across the 58 `RecordPatches.*` partials was classified (multi-line
declarations included — a first pass with a single-line regex missed `_owningAppByDir`, which is
how it was found). Beyond the caches above and #2939, what remains uncleared is uncleared
**correctly**:

* `ConditionalWeakTable` keyed by a provider or query-definition instance
  (`_*PopulatedByProvider`, `_materialisationGates`, `_projectionPlans`, …) — self-invalidating,
  they die with the object they are keyed by.
* Virtual-table row caches (`_pageMetaRows`, `_reportRows`, `_tableMetadataRows`,
  `_codeunitMetaRows`, `_pageControlFieldRows`, `_knownReportIds`) — each carries an
  `(Epoch, …)` generation tuple checked on every read, so a reload invalidates them without a
  clear.
* BC enum-ordinal tables (`_aovObjectTypeOrdinals`, `_objsTypeOrdinals`, `_cmvSubtypeOrdinals`,
  `_pmvPageTypeOrdinals`, `_tmvOptionOrdinals`), `_omsApplicationDatabaseTableIds` (read from
  BC's own `SystemTables.ApplicationDatabaseTables`), `_wlAllCultures` — process-constant.
* Reflection handles keyed by `Type` or `Assembly` (`_pValueByType`, `_concreteRecordCtors`,
  `_compiledReportIdsByAssembly`) — self-invalidating on the same argument.
* `_objectRefConstIds` still reads as uncleared on this branch because its fix is in PR #3209,
  which has not merged yet. Not a conflict of substance, but both PRs edit `ResetForReload`, so
  they need an order.

## What was run

* The three new classes — **9 passed** with the fix, **8 failed / 1 passed** with
  `RecordPatches.cs` reverted.
* Tree-asserting guards and reset-path neighbours: `VirtualTableRefusalClaimTests`,
  `BaseAppFloorFixtureGuardTests`, `ParserStaticsIsolationGuardTests`, `BcAppPathsResetTests`,
  `PageRealMetadataEpochRevalidationTests`, `RecordPatchesWarmReload*`,
  `RecordPatchesWarmReparseTests`, `DependencyMetadataMemoInvalidationTests`,
  `VirtualTableBitClearingTests`, `ObjectRefConst*` — **145 passed, 10 skipped**.
* The surfaces the cleared caches serve: every class matching `PermissionMetadata`,
  `PermissionSet`, `XmlPort` or `Query` — **113 passed**.
* Tableextension surface (`~TableExtension`, `~Extension`) — **38 passed, 6 skipped**.

The full `AlRunner.Tests` sweep and the AL bundles were left to CI. No claim is made about any
suite not listed.

---

*Written by the automated implementation agent `stma-auto-1` (cycle 148) on the account holder's
behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
