### PR TITLE
fix(testpage): resolve a control whose binding the AL compiler registered under another control

### DIFF
--- a/AlRunner.Tests/DependencyControlsSharingSourceExpressionTests.cs
+++ b/AlRunner.Tests/DependencyControlsSharingSourceExpressionTests.cs
@@ -1,0 +1,182 @@
+// DependencyControlsSharingSourceExpressionTests — pins the runner's own C# mechanism for
+// issue #3211's precompiled arm.
+//
+// THE DEFECT
+// ----------
+// The AL compiler registers ONE <Expression> per distinct binding TEXT on a page, named after
+// the FIRST control that uses it, and every later control over the same text points at that one
+// through its own DataColumnName. RunnerPageInstance.TryGetSourceExpression looked the binding
+// up by "Control" + controlId alone, so the SECOND control over a page global resolved to
+// nothing and was refused as unbound — blaming the source table for a control that is bound
+// perfectly well. Measured on Microsoft's Base Application 28.1: page 1612 "Office Admin.
+// Credentials" registers Control1176233145 (O365Password) and NOT Control492048779
+// (OnPremPassword), though both are declared over the same page global PasswordText.
+//
+// On a page the runner compiled itself, DataColumnName is readable straight off the merged
+// metadata. On a page that ships PRECOMPILED in a dependency .app it is not — that page's
+// reconstructed metadata carries no control tree at all (see DependencyPageMetadataXml's
+// "what is deliberately omitted"). What the dependency DOES state per control is the AL binding
+// text, and the compiler's dedup key IS that text, so the siblings can be named exactly.
+//
+// WHAT THIS PROVES, AND WHAT IT DELIBERATELY DOES NOT
+// ---------------------------------------------------
+// The BC-observable claim — that a TestPage resolves the second control over one page binding
+// as readily as the first, in both directions — is a statement about BC, not about the runner,
+// and is adjudicated by a real service tier in corpus PR
+// StefanMaron/BusinessCentral.AL.Language.Tests#209 (codeunit 60773 "TP Shared Bind Tests").
+// This file pins the narrower runner-only mechanism underneath the PRECOMPILED half of the fix,
+// at both ends: it must name the siblings a dependency page really declares, and it must name
+// nothing for a control that shares its binding with no other.
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Same reason as RecordPatchesGetPageControlFieldMapDependencyTests: RecordPatches' dependency
+// page state (_bcAppPaths and the symbol caches behind it) resolves through the process-global
+// CacheRoots override.
+[Collection(CacheRootsSerialCollection.Name)]
+public class DependencyControlsSharingSourceExpressionTests
+{
+    private static string WriteApp(string dir, string symbolReferenceJson)
+    {
+        var appPath = Path.Combine(dir, Guid.NewGuid().ToString("N") + ".app");
+        using var zip = new FileStream(appPath, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+        return appPath;
+    }
+
+    // Distinctive ids: RecordPatches' dependency-page state is process-global, so an id another
+    // test or fixture also declares would risk reading back that one's cached answer.
+    private const int PageId = 88220501;
+
+    private const int SharedFirstId = 640645001;   // SourceExpression = PasswordText
+    private const int SharedSecondId = 640645002;  // SourceExpression = PasswordText  (same binding)
+    private const int SharedThirdId = 640645003;   // SourceExpression = passwordtext  (same binding, other case)
+    private const int LoneControlId = 640645004;   // SourceExpression = OtherText     (its own binding)
+    private const int UnknownControlId = 640645099; // declared by nothing
+
+    // Modelled on the real shape: page 1612 "Office Admin. Credentials" declares two controls
+    // over the page global PasswordText and one over a different global. The third control here
+    // spells the same identifier in another case, which AL treats as the same variable.
+    private const string SymbolReference = """
+        {
+          "RuntimeVersion": "17.0",
+          "Pages": [
+            {
+              "Id": 88220501,
+              "Name": "DCSSE Dep Page",
+              "Properties": [
+                { "Name": "PageType", "Value": "Card" }
+              ],
+              "Controls": [
+                {
+                  "Kind": 1,
+                  "Id": 1,
+                  "Name": "content",
+                  "Controls": [
+                    {
+                      "Kind": 8,
+                      "Id": 640645001,
+                      "Name": "O365Password",
+                      "Properties": [ { "Name": "SourceExpression", "Value": "PasswordText" } ]
+                    },
+                    {
+                      "Kind": 8,
+                      "Id": 640645002,
+                      "Name": "OnPremPassword",
+                      "Properties": [ { "Name": "SourceExpression", "Value": "PasswordText" } ]
+                    },
+                    {
+                      "Kind": 8,
+                      "Id": 640645003,
+                      "Name": "ThirdPassword",
+                      "Properties": [ { "Name": "SourceExpression", "Value": "passwordtext" } ]
+                    },
+                    {
+                      "Kind": 8,
+                      "Id": 640645004,
+                      "Name": "Unshared",
+                      "Properties": [ { "Name": "SourceExpression", "Value": "OtherText" } ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private static void WithDependencyApp(Action body)
+    {
+        var dir = TestScratch.Dir("al-runner-shared-source-expression-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SymbolReference));
+            body();
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void SecondControlOverOneBinding_NamesTheFirstAsASibling()
+        => WithDependencyApp(() =>
+        {
+            var siblings = RecordPatches.DependencyControlsSharingSourceExpression(PageId, SharedSecondId);
+
+            // The one that matters: the control the compiler did NOT register an expression for
+            // must be able to name the control it DID register one for. Asserting membership
+            // rather than the whole set would let an implementation that returns every control
+            // on the page pass, so the exact set is asserted instead.
+            Assert.Equal(new[] { SharedFirstId, SharedThirdId }, siblings.OrderBy(x => x).ToArray());
+        });
+
+    [Fact]
+    public void FirstControlOverOneBinding_NamesTheLaterOnesAndNotItself()
+        => WithDependencyApp(() =>
+        {
+            var siblings = RecordPatches.DependencyControlsSharingSourceExpression(PageId, SharedFirstId);
+
+            // Symmetric, and never self-referential: returning the control itself would make
+            // RunnerPageInstance retry the same key it has already missed.
+            Assert.Equal(new[] { SharedSecondId, SharedThirdId }, siblings.OrderBy(x => x).ToArray());
+            Assert.DoesNotContain(SharedFirstId, siblings);
+        });
+
+    [Fact]
+    public void ControlWithItsOwnBinding_NamesNoSibling()
+        => WithDependencyApp(() =>
+        {
+            // Negative. A control whose binding nothing else declares must name nothing, so a
+            // control the page genuinely never registered stays unresolved and still refuses
+            // loudly instead of borrowing an unrelated control's value.
+            Assert.Empty(RecordPatches.DependencyControlsSharingSourceExpression(PageId, LoneControlId));
+        });
+
+    [Fact]
+    public void ControlTheDependencyDoesNotDeclare_NamesNoSibling()
+        => WithDependencyApp(() =>
+        {
+            // Negative. An id the symbol file says nothing about has no binding text to match
+            // on, so it must not collect the page's controls indiscriminately.
+            Assert.Empty(RecordPatches.DependencyControlsSharingSourceExpression(PageId, UnknownControlId));
+        });
+
+    [Fact]
+    public void PageNoDependencyDeclares_NamesNoSibling()
+        => WithDependencyApp(() =>
+        {
+            // Negative. A page the runner compiled itself (or one nothing declares) must fall
+            // through this path entirely — it is answered from DataColumnName instead.
+            Assert.Empty(RecordPatches.DependencyControlsSharingSourceExpression(88220502, SharedSecondId));
+        });
+}

--- a/AlRunner/Patches/RecordPatches.AlPageParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlPageParser.cs
@@ -512,6 +512,47 @@ public static partial class RecordPatches
     }
 
     /// <summary>
+    /// The OTHER controls of a PRECOMPILED dependency page that declare the same
+    /// <c>SourceExpression</c> TEXT as <paramref name="controlId"/> — the siblings the AL
+    /// compiler collapsed onto one registered <c>&lt;Expression&gt;</c> (issue #3211).
+    ///
+    /// <para>A page that binds two controls to one page global gets ONE expression object,
+    /// named after whichever control the compiler reached first, and every other control
+    /// points at it through its own <c>DataColumnName</c>. On a page the runner compiled
+    /// itself that attribute is readable off the merged metadata
+    /// (<c>RunnerPageInstance.TryGetSourceExpression</c> uses it directly); on a page that
+    /// ships precompiled in a dependency .app it is not, because
+    /// <see cref="TryGetDependencyPageMetadataXml"/> reconstructs no control tree. What the
+    /// dependency DOES state, per control, is the AL binding text itself — the same field
+    /// <see cref="GetPageControlFieldMap"/> and the "Page Control Field" virtual table
+    /// already read — and the compiler's dedup key IS that text, so the siblings can be
+    /// named exactly rather than guessed.</para>
+    ///
+    /// <para>Naming a sibling asserts nothing on its own: the caller still only accepts a
+    /// sibling whose <c>Control{id}</c> key the page ACTUALLY registered, so a control whose
+    /// binding was never registered at all stays unresolved and still refuses loudly.
+    /// Comparison is case-insensitive because AL identifiers are, so two spellings of one
+    /// variable name are one binding.</para>
+    /// </summary>
+    internal static IReadOnlyList<int> DependencyControlsSharingSourceExpression(int pageId, int controlId)
+    {
+        var symbol = TryGetDependencyPageSymbol(pageId);
+        if (symbol?.Controls == null || symbol.Controls.Count == 0) return Array.Empty<int>();
+
+        string? text = null;
+        foreach (var control in symbol.Controls)
+            if (control.Id == controlId) { text = control.SourceExpression; break; }
+        if (string.IsNullOrWhiteSpace(text)) return Array.Empty<int>();
+
+        var siblings = new List<int>();
+        foreach (var control in symbol.Controls)
+            if (control.Id != controlId
+                && string.Equals(control.SourceExpression, text, StringComparison.OrdinalIgnoreCase))
+                siblings.Add(control.Id);
+        return siblings;
+    }
+
+    /// <summary>
     /// Every field control of a SOURCE-PARSED page, base plus matching pageextensions,
     /// for the "Page Control Field" (2000000192) virtual table. Same base+extension merge
     /// rule as <see cref="GetPageControlFieldMap"/> (only extensions of THIS page), same

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -612,9 +612,50 @@ internal sealed partial class RunnerPageInstance
     /// The page's binding for a control id, or null when the control is not one the page
     /// publishes a source expression for (Rec-bound controls are resolved by the caller
     /// against the record instead).
+    ///
+    /// <para><b>One expression can serve several controls (issue #3211).</b> The AL compiler
+    /// registers ONE <c>&lt;Expression&gt;</c> per distinct binding TEXT, named after the
+    /// FIRST control that uses it, and every later control over the same text points at that
+    /// one through its own <c>DataColumnName</c>. Measured on the emitted PageDefinition XML
+    /// for a card page with <c>field(VarCtlA; MyVar)</c> and <c>field(VarCtlB; MyVar)</c>:</para>
+    /// <code>
+    /// &lt;Controls ID="158749901"  Name="VarCtlA" DataColumnName="Control158749901" /&gt;
+    /// &lt;Controls ID="2071839752" Name="VarCtlB" DataColumnName="Control158749901" /&gt;
+    /// &lt;Expression Name="Control158749901" SourceExpression="MyVar" … /&gt;
+    /// </code>
+    /// <para>so <c>Control2071839752</c> is never registered and the <c>"Control" + id</c>
+    /// key alone answers null for VarCtlB — the runner then refused it as unbound, blaming
+    /// the source table for a control that is bound perfectly well. Microsoft's own pages do
+    /// this constantly: page 1612 "Office Admin. Credentials" shows <c>PasswordText</c>
+    /// through both <c>O365Password</c> and <c>OnPremPassword</c>, and page 1327 "Adjust
+    /// Inventory" shows each <c>TempItemJournalLine</c> field twice, once inside the
+    /// single-location group and once inside the repeater.</para>
+    /// <para><c>DataColumnName</c> is the control's OWN statement of which registered
+    /// expression it reads, so following it can never fabricate a binding: a Rec-bound
+    /// control carries the source-table FIELD NUMBER there (<c>DataColumnName="2"</c>), which
+    /// is not a key in the expression table, and an unbound control carries none. The
+    /// <c>"Control" + id</c> lookup stays first because it is the common case and needs no
+    /// metadata read at all.</para>
+    /// <para>A page that ships PRECOMPILED in a dependency .app has no readable
+    /// <c>DataColumnName</c> — its reconstructed metadata carries no control tree at all (see
+    /// <c>DependencyPageMetadataXml</c>) — so the last step asks the dependency's
+    /// SymbolReference.json which other controls declare the same binding TEXT, and takes the
+    /// one of those the page did register. Same rule, same dedup key, read from the only
+    /// source that states it for such a page.</para>
     /// </summary>
     internal object? TryGetSourceExpression(int controlId)
-        => _sourceExpressions[SourceExpressionKey(controlId)];
+    {
+        var expression = _sourceExpressions[SourceExpressionKey(controlId)];
+        if (expression != null) return expression;
+
+        var column = ControlDefinition(controlId)?.DataColumnName;
+        if (!string.IsNullOrEmpty(column) && _sourceExpressions[column] is { } byColumn) return byColumn;
+
+        foreach (var sibling in RecordPatches.DependencyControlsSharingSourceExpression(_pageId, controlId))
+            if (_sourceExpressions[SourceExpressionKey(sibling)] is { } shared) return shared;
+
+        return null;
+    }
 
     // ── control / action state properties (Editable, Enabled, Visible) ─────────────────
     //


### PR DESCRIPTION
Closes #3211

## Root cause, measured

The AL compiler registers **one** `<Expression>` per distinct binding TEXT on a page, names it
after the **first** control that uses it, and points every later control over the same text at
that one through its own `DataColumnName`. Dumped from the emitted `PageDefinition` XML for a
card page carrying `field(VarCtlA; MyVar)` and `field(VarCtlB; MyVar)`:

```xml
<Controls ID="1830115748" Name="ValueCtl" DataColumnName="2" />
<Controls ID="158749901"  Name="VarCtlA"  DataColumnName="Control158749901" />
<Controls ID="2071839752" Name="VarCtlB"  DataColumnName="Control158749901" />
<Expressions>
  <Expression Name="Control158749901" SourceExpression="MyVar" ExpressionIsAssignable="1" />
</Expressions>
```

`RunnerPageInstance.TryGetSourceExpression` looked the binding up by `"Control" + controlId`
alone. `Control2071839752` is never registered, so the second control resolved to nothing and
`LiveNavTestPage.GetField` refused it with `testpage-control-binding` — blaming the source
table for a control that is bound perfectly well. The issue's message ("the page object has no
source expression for this control id") was accurate; what it did not say is that the binding
exists under a different key.

The same asymmetry is in Microsoft's shipped binaries. Base Application 28.1's DLL string table
contains `Control1176233145` (page 1612 "Office Admin. Credentials", control `O365Password`)
and **not** `Control492048779` (`OnPremPassword`) — both declared over the same page global
`PasswordText`. That is the control id the issue reports for `Codeunit138031`.

## The fix

`RunnerPageInstance.TryGetSourceExpression` now tries three keys in order, and only ever
returns an expression the page **actually registered**:

1. `"Control" + id` — unchanged, the common case, no metadata read.
2. the control's own `DataColumnName` off the merged metadata — the page's own statement of
   which registered expression it reads. Cannot fabricate a binding: a Rec-bound control
   carries the source-table field NUMBER there (`DataColumnName="2"`), which is not a key in
   the expression table.
3. for a page shipping **precompiled** in a dependency `.app`, whose reconstructed metadata
   carries no control tree at all, the new
   `RecordPatches.DependencyControlsSharingSourceExpression` asks that `.app`'s
   `SymbolReference.json` which other controls declare the same binding TEXT — the compiler's
   own dedup key — and step 3 takes whichever of those the page registered.

Step 3 names siblings; it does not assert anything. A control whose binding was never
registered by anyone still resolves to nothing and still refuses loudly.

## RED → GREEN

**BC-behaviour claim, upstream.** Corpus PR
[StefanMaron/BusinessCentral.AL.Language.Tests#209](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/209)
adds codeunit 60773 "TP Shared Bind Tests" (7 tests) with table 60771 and page 60772. It
adjudicates on the eight **`BC <ver> / test`** legs — those build the Cloud `tests/al-language`
app. The eight `BC OnPrem <ver> / test` legs build `tests/al-language-onprem` and do not run it.

Run against that corpus branch with this repo's runner, `--package-cache ~/.al-runner/platform-apps`:

| test | `origin/main` | this branch |
|---|---|---|
| `FirstControlOverAPageGlobal_ShowsTheGlobalsValue` | PASS | PASS |
| `SecondControlOverAPageGlobal_ShowsTheSameValue` | **FAIL** control 1058451738 | PASS |
| `WriteThroughTheFirstControlOverAPageGlobal_IsSeenByTheSecond` | **FAIL** 1058451738 | PASS |
| `WriteThroughTheSecondControlOverAPageGlobal_IsSeenByTheFirst` | **FAIL** 1058451738 | PASS |
| `SecondControlOverAGlobalRecordField_ShowsTheSameValue` | **FAIL** 1199432727 | PASS |
| `WriteThroughOneControlOverAGlobalRecordField_IsSeenByTheOther` | **FAIL** 1199432727 | PASS |
| `WriteThroughAPageGlobalControl_LeavesTheRowAlone` | PASS | PASS |

Every failure was `testpage-control-binding`. The two that pass in both columns are the
baseline and the discriminator, and they are meant to.

**On Microsoft's own precompiled pages**, in a scratch bundle declaring the Base Application
floor:

| read | `origin/main` | this branch |
|---|---|---|
| `TestPage "Office Admin. Credentials".UseO365` (base-page global, registered) | PASS | PASS |
| `.O365Password` (first control over `PasswordText`) | PASS | PASS |
| `.OnPremPassword` (second control, **control 492048779 from the issue**) | **FAIL** | PASS |
| `TestPage "Adjust Inventory".NewInventory` (**control 1403348460 from the issue**) | — | PASS |

**Runner-side mechanism**, since the pin is not being bumped here:
`AlRunner.Tests/DependencyControlsSharingSourceExpressionTests.cs`, 5 tests over a synthetic
dependency `.app` — one positive per direction (the second control names the first; the first
names the later ones and never itself), a case-insensitive third control because AL identifiers
are, and three negatives (a control with its own binding, an id the symbol file does not
declare, a page it does not declare) so an implementation returning every control on the page
fails. Its RED is that the method did not exist.

## Regression scope actually run

- `dotnet test AlRunner.Tests --filter` over `PageControlExpressionTests`,
  `PageControlExtensionFieldBindingTests`, `RecordPatchesGetPageControlFieldMapDependencyTests`,
  `RunnerFormInitSourceExpressionOptInTests`, `RunnerPageInstanceLiteralFalseTests`,
  `RunnerPageInstanceVisibleSnapshotTests`, `TestPageRefusalClaimTests`,
  `VirtualTableRefusalClaimTests` — **251 passed**, 0 failed. (The diff adds and removes no
  `throw`; `VirtualTableRefusalClaimTests` is included anyway and still asserts its 71.)
- The pinned corpus, exactly as CI runs it with `--strict --count-baseline` — **2676/2676**,
  exit 0, baseline unchanged.
- `tests/runner-extras` with both package caches, `--strict` — **312/312**, exit 0.
- The 5 new C# tests — 5/5.

## Fixing the shape, not the reported line

- **Same wrong pattern at another call site?** `"Control" + id` is built in exactly one place,
  `RunnerPageInstance.SourceExpressionKey`, with two readers. The other is
  `RequestPageTestPage.GetField`, which funnels through the very method this fixes, so a report
  request page showing one report global through two controls is fixed by the same change with
  no second edit. `RequestPageTestPage.RegisteredControlKeys` also enumerates the table, but
  only to list keys in a refusal message; it resolves nothing.
- **Sibling function making the same assumption?** `EvaluateProperty` (`Visible`/`Editable`/
  `Enabled`) resolves by the property TEXT, which the compiler already writes as the deduped
  name, so it never had the defect. `SnapshotExpressionValues` walks the whole table by key and
  is likewise unaffected.
- **Two paths writing one state?** Two controls now share one expression object, and
  `MockTestPage._pageVariableFields` keys its `PageVariableTestField` wrappers by **control
  id** — so each control keeps its own wrapper over the one shared value, which is what the
  corpus tests' both-directions writes assert. Nothing needed changing; the key was already
  right (#2088's fix put it there).

## Deliberately not in this PR

**19 of the reported 37 failures are a different shape, now #3228.** A control a
**pageextension** declares over a variable of its own is refused even when it is the only
control over that variable, because `BcCompiler` captures emitted metadata for
`IPageTypeSymbol` only — a pageextension's is dropped, so its controls never reach the merged
`NCLMetaForm` and its `RegisterSourceExpression` IL never runs. That is issue #3211's control
`636099122` (`IdSpace.GetMemberId(9204, "MyNotificationsLbl")`). Fixing it means changing the
compile-time capture and the metadata merge — a different file set and different reasoning —
so it is filed with its reproducer and measurement rather than folded in. Rec-bound
pageextension controls are unaffected and already work.

**The submodule pin is not bumped**, by instruction: it is held 7 commits behind `master` by a
forced ordering across three loops tracked as #3202. Corpus PR 209 has to merge and that
ordering has to clear before a bump; this PR carries the runner-side mechanism test instead, as
the "Tests updated" gate requires.

## Sibling-issue scan (`.claude/rules/batch-sibling-issues-by-file.md`)

Searched the open queue for `TestPage`, `RunnerPageInstance` and `SourceExpression`. Nothing
folded — the map, and why:

| issue | where its fix lands | folded? |
|---|---|---|
| #2596 control-property expression reading a source-table field | `RunnerPageInstance.EvaluateProperty` — same file, different function, and it is an unsettled BC-divergence measurement needing its own corpus pass | no — different reasoning to review |
| #3190 a linked part's trigger error during host open | error conversion in the TestPage open path, not control resolution | no — different file |
| #3185 `View()`/`Edit()` and `UISessionManager` | already has corpus PR #203 from another loop | no — do not duplicate |
| #3179 / #3057 `OnQueryClosePage` error through a `[MessageHandler]` | PR #3181 is open on it | no — in progress |
| #2461 silent navigation-mock demotion | `RunnerPageInstance.TryCreate` diagnostics + `MockTestPage` | no — a logging change, unrelated blast radius |
| #2362 `AssistEdit` on a precompiled page | `MockTestPage` / `PageVariableTestField` trigger dispatch | no — different function |
| #3009 `ValidationErrorCount()` at page level | `MockTestPage` | no — different file |

---

Written by the agent `stma-auto-1` (cycle 147) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE