### PR TITLE
fix(symbols): refuse when a dependency .app's symbols cannot be read, instead of reporting that it declares nothing

### DIFF
--- a/AlRunner.Tests/DependencyAppSymbolWalkSourceGuardTests.cs
+++ b/AlRunner.Tests/DependencyAppSymbolWalkSourceGuardTests.cs
@@ -1,0 +1,124 @@
+// DependencyAppSymbolWalkSourceGuardTests — the source-level half of issue #3143.
+//
+// WHY A SOURCE GUARD AT ALL
+//   DependencySymbolReadFailureTests pins the ten sites #3143 converted. It cannot pin the
+//   ELEVENTH, which does not exist yet: the shape is a two-line idiom, it was copied ten
+//   times before anyone noticed, and each copy reads as ordinary defensive code. #3031 fixed
+//   two of them and #3117 fixed a third INDEPENDENTLY AND CONCURRENTLY, without either agent
+//   seeing the other — which is exactly what a repeated idiom with no mechanical check looks
+//   like from the inside.
+//
+//   So this file holds the property directly: every `BcAppSymbolCache.Get(` call site in the
+//   runner is named here, with what it does on failure and why that is right. A new call site
+//   fails this test until someone writes that sentence down.
+//
+// WHAT IS DELIBERATELY NOT ASSERTED
+//   Not "no catch anywhere near a Get". Two of the sites below catch legitimately, and a
+//   guard that forbade catching outright would be wrong rather than strict. The guard is a
+//   census, which is the part a reviewer cannot do by eye.
+
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class DependencyAppSymbolWalkSourceGuardTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    /// <summary>
+    /// Every file that may call <c>BcAppSymbolCache.Get(</c>, with the number of call sites
+    /// it is allowed and why each is correct. Adding a call site anywhere else, or an extra
+    /// one here, fails — deliberately, because "one more copy of the walk" is precisely the
+    /// change that needs a human to look at it.
+    /// </summary>
+    private static readonly (string File, int Sites, string Why)[] Allowed =
+    {
+        ("AlRunner/Patches/RecordPatches.DependencyAppSymbolWalk.cs", 1,
+            "#3143: THE walk. Vanished -> [warn] + skip; present-but-unreadable -> "
+            + "BcAppSymbolReadException. Every table-facing read goes through this."),
+
+        ("AlRunner/Patches/RecordPatches.BcAppFallback.cs", 3,
+            "#2712: AddBcAppPath's eager read (refuses, and the path is never registered); "
+            + "EnsureBcSymbolTableIndex (vanished -> [warn], unreadable -> refuses); and "
+            + "DescribeParsedSymbolState, which catches broadly ON PURPOSE and returns "
+            + "\"unreadable:<Type>\" — a diagnostic string whose job is to DESCRIBE the "
+            + "state, and which differs from every healthy key, so it forces a cache miss "
+            + "rather than colliding with a good answer."),
+
+        ("AlRunner/Patches/RecordPatches.AllObjVirtualTable.cs", 1,
+            "#3117/#3133's BuildObjectOwnerIndex: refuses with AllObjShapeGap rather than "
+            + "BcAppSymbolReadException because the owner is a STORED COLUMN VALUE on rows "
+            + "AllObj is already writing, so the refusal names the AllObj shape. #3143 added "
+            + "the vanished skip in front of it."),
+
+        ("AlRunner/Patches/RecordPatches.AggregatePermissionSetVirtualTable.cs", 1,
+            "#3031: BuildKnownAppNameIndex. Vanished -> [warn] + skip; unreadable -> refuses."),
+
+        ("AlRunner/Patches/RecordPatches.MetadataPermissionSetVirtualTable.cs", 1,
+            "#3031: EnumerateKnownPermissionSets. Same split."),
+
+        ("AlRunner/Patches/EnumMetadataPatches.cs", 1,
+            "#3143: AlEnumMetadataRegistry.RegisterFromAppPath — no live callers, but public, "
+            + "so its swallow was converted to a refusal rather than left for a future caller "
+            + "to inherit."),
+    };
+
+    private static int CountSites(string relativePath)
+    {
+        var full = Path.Combine(RepoRoot, relativePath);
+        Assert.True(File.Exists(full), $"{relativePath} not found — renamed or removed.");
+        var count = 0;
+        foreach (var raw in File.ReadAllLines(full))
+        {
+            var line = raw.TrimStart();
+            // Comments quote the idiom on purpose (the walk's own header does); a census of
+            // CODE must not count those.
+            if (line.StartsWith("//") || line.StartsWith("///") || line.StartsWith("*")) continue;
+            var i = 0;
+            while ((i = line.IndexOf("BcAppSymbolCache.Get(", i, StringComparison.Ordinal)) >= 0)
+            {
+                count++;
+                i += 1;
+            }
+        }
+        return count;
+    }
+
+    [Fact]
+    public void EveryBcAppSymbolCacheGetCallSiteIsAccountedFor()
+    {
+        foreach (var (file, sites, why) in Allowed)
+            Assert.True(CountSites(file) == sites,
+                $"{file}: expected {sites} BcAppSymbolCache.Get( call site(s), found "
+                + $"{CountSites(file)}.\nWhy this file is allowed any: {why}\n"
+                + "A NEW call site here must state, in a comment at the site, what it does "
+                + "when the read fails — see .claude/rules/loud-failures.md and issue #3143 — "
+                + "and then update this census.");
+    }
+
+    [Fact]
+    public void NoOtherFileCallsBcAppSymbolCacheGet()
+    {
+        var allowed = new HashSet<string>(
+            Allowed.Select(a => a.File.Replace('/', Path.DirectorySeparatorChar)),
+            StringComparer.OrdinalIgnoreCase);
+
+        var offenders = new List<string>();
+        foreach (var full in Directory.EnumerateFiles(
+                     Path.Combine(RepoRoot, "AlRunner"), "*.cs", SearchOption.AllDirectories))
+        {
+            var relative = Path.GetRelativePath(RepoRoot, full);
+            if (allowed.Contains(relative)) continue;
+            if (CountSites(relative) > 0) offenders.Add(relative);
+        }
+
+        Assert.True(offenders.Count == 0,
+            "These files call BcAppSymbolCache.Get( without being in the #3143 census:\n  "
+            + string.Join("\n  ", offenders)
+            + "\nEvery dependency-symbol read must say what it does when the read fails. The "
+            + "default is to go through RecordPatches.EnumerateRegisteredBcAppSymbols, which "
+            + "already makes the vanished/unreadable split; a site that cannot must justify "
+            + "itself in DependencyAppSymbolWalkSourceGuardTests.Allowed.");
+    }
+}

--- a/AlRunner.Tests/DependencySymbolReadFailureTests.cs
+++ b/AlRunner.Tests/DependencySymbolReadFailureTests.cs
@@ -203,6 +203,59 @@ public sealed class DependencySymbolReadFailureTests : IDisposable
         return list;
     }
 
+    /// <summary>
+    /// The drained items of <paramref name="walk"/> that came from THIS fixture's .app.
+    ///
+    /// <para>Every assertion about what a walk did with the fixture must be scoped like
+    /// this, because <b>the registered set is never only what a test registered</b>:
+    /// <c>RegisterSystemAppPackage()</c> puts the platform SystemApp package into
+    /// <c>_bcAppPaths</c> once per process at engine bootstrap, and <c>ResetForReload</c>
+    /// deliberately KEEPS it — see <c>ClearPerBundleBcAppPaths</c> in
+    /// RecordPatches.BcAppFallback.cs and #2755, where dropping it broke the NCL-internal
+    /// system tables for the rest of a --server process. So on any run where the in-process
+    /// BC engine bootstrapped, five of these seven walks legitimately yield the System
+    /// package's own tables, codeunits, pages and objects — hundreds of them, none of which
+    /// this fixture has anything to say about. #3031's sibling file got this right
+    /// (<c>Assert.DoesNotContain("BUG3031 VANISH", …)</c>); this file did not, and a global
+    /// <c>Assert.Empty</c>/<c>Assert.NotEmpty</c> over the whole walk passed only on a
+    /// machine with no engine while failing both CI legs that run this suite.</para>
+    /// </summary>
+    private static List<object> FixtureItems(string walk)
+        => Drain(walk).Where(IsFixtureItem).ToList();
+
+    /// <summary>Ids this fixture's SymbolReference declares, across every container.</summary>
+    private static readonly HashSet<int> FixtureObjectIds =
+        new() { TableId, CodeunitId, PageId, ReportId, QueryId };
+
+    /// <summary>
+    /// Does this walk item describe the fixture .app? One arm per walk item type, and an
+    /// unrecognised type THROWS rather than answering false: a filter that silently stops
+    /// matching would turn every <c>FixtureItems</c> assertion below into a tautology.
+    /// </summary>
+    private static bool IsFixtureItem(object item) => item switch
+    {
+        // DependencyAppSymbols — one entry per registered .app.
+        BcAppSymbolCache.AppSymbols a =>
+            string.Equals(a.AppId, AppGuid, StringComparison.OrdinalIgnoreCase),
+        // EnumerateBcAppTableSymbols
+        ParsedTable t => t.TableId == TableId,
+        // EnumerateBcAppPageSymbols
+        BcAppSymbolCache.PageSymbol p => p.Id == PageId,
+        // EnumerateBcAppReportSymbols
+        BcAppSymbolCache.ReportSymbol r => r.Id == ReportId,
+        // EnumerateBcAppCodeunitSymbols
+        BcAppSymbolCache.ObjectSymbol o => FixtureObjectIds.Contains(o.Id),
+        // EnumerateBcAppProfileSymbols — (AppId, AppName, ProfileSymbol)
+        ValueTuple<Guid, string, BcAppSymbolCache.ProfileSymbol> pr =>
+            string.Equals(pr.Item3.ProfileId, ProfileId, StringComparison.OrdinalIgnoreCase),
+        // EnumerateBcAppObjects — (Kind, Id, Name, Caption)
+        ValueTuple<string, int, string, string> ob => FixtureObjectIds.Contains(ob.Item2),
+        _ => throw new Xunit.Sdk.XunitException(
+            $"unrecognised walk item type {item.GetType()} — add an arm here. A filter that "
+            + "matches nothing would make every fixture-scoped assertion in this file pass "
+            + "vacuously."),
+    };
+
     /// <summary>Every private walk this issue converted, with the surface text it must name.</summary>
     public static TheoryData<string, string> Walks() => new()
     {
@@ -222,7 +275,10 @@ public sealed class DependencySymbolReadFailureTests : IDisposable
     public void HealthyApp_EveryWalkYieldsItsSymbols(string walk, string _)
     {
         RegisterHealthy("healthy.app");
-        Assert.NotEmpty(Drain(walk));
+        // FixtureItems, not Drain: on an engine-bootstrapped process the platform SystemApp
+        // registration alone satisfies a bare NotEmpty, so this row would pass without the
+        // fixture's .app ever being read. See FixtureItems' remarks.
+        Assert.NotEmpty(FixtureItems(walk));
     }
 
     [Fact]
@@ -341,8 +397,19 @@ public sealed class DependencySymbolReadFailureTests : IDisposable
     [MemberData(nameof(Walks))]
     public void VanishedApp_EveryWalkSkipsItRatherThanRefusing(string walk, string _)
     {
+        // The positive control lives INSIDE the row on purpose: "the fixture contributes
+        // nothing" is only a claim about the skip if the same filter demonstrably finds the
+        // fixture one line earlier. Without it, a filter that matched nothing — a renamed
+        // symbol type, a changed id — would read as a passing skip.
+        RegisterHealthy("vanishing.app");
+        Assert.NotEmpty(FixtureItems(walk));
+
         RegisterThenVanish();
-        Assert.Empty(Drain(walk));
+
+        // Two claims in one line. Draining does not THROW (the vanished .app is skipped, not
+        // refused — that is the whole distinction #3143 restored), and the fixture's symbols
+        // are gone from the answer while every other registered .app's are still served.
+        Assert.Empty(FixtureItems(walk));
     }
 
     [Fact]

--- a/AlRunner.Tests/DependencySymbolReadFailureTests.cs
+++ b/AlRunner.Tests/DependencySymbolReadFailureTests.cs
@@ -1,0 +1,439 @@
+// DependencySymbolReadFailureTests — issue #3143.
+//
+// THE DEFECT
+//   Ten dependency-symbol reads outside the permission slice #3031 fixed each swallowed
+//   EVERY exception from BcAppSymbolCache.Get(appPath) and `continue`d, so "the runner could
+//   not find out what this .app declares" became "this .app declares nothing". Each fed a
+//   different surface, and in every case the caller reads the result as a fact:
+//
+//     AllObj                        objects absent      -> a table AL enumerates, short rows
+//     CodeUnit Metadata             codeunits absent
+//     Table Metadata                tables absent       -> "does this table exist" answered no
+//     Page Metadata / Page Ctrl Fld pages absent
+//     Report Metadata               reports absent
+//     All Profile                   profiles absent
+//     dependency page metadata      page symbol null    -> InsertAllowed TRUE, SourceTableId 0,
+//                                                          PageType null, IsPageShapeKnown FALSE
+//     dependency report metadata    report symbol null  -> "report N has no metadata"
+//     query symbol index            query absent, and the PARTIAL index then published
+//
+//   The only trace was a `[RecordPatches]`-tagged stderr line, and Log's default-verbosity
+//   filter drops lines that START with a bracketed component tag (measured in #3031 by
+//   driving the real filter). At the verbosity users actually run at, the loss was silent.
+//
+// WHAT THIS FILE PROVES
+//   Per surface, three rows:
+//     * healthy  — the positive control. Without it every refusal row below could pass
+//                  against a pipeline that never reads the .app at all.
+//     * poisoned — the read fails AFTER registration; the site must REFUSE, naming the .app
+//                  and the surface, instead of answering as though the app declared nothing.
+//     * vanished — the .app is gone from disk; the site must SKIP it and keep going, because
+//                  that is a legitimate --watch / --server state, and must say so on a
+//                  channel Log does not filter.
+//
+//   Four rows go through the real CALLERS rather than the private walk, because that is
+//   where the wrongness was observable: IsPageShapeKnown answered false, GetInsertAllowedForPage
+//   answered true, TryGetQuerySymbol answered null and TryBuildDependencyReportMetadata
+//   answered null — four confident wrong answers, none distinguishable from a real one.
+//
+// THE POISON
+//   Same technique as PermissionSetSymbolReadFailureTests (#3031) and
+//   RecordPatchesBcAppSymbolReadFailureTests (#2712): a SymbolReference.json whose root
+//   "AppId" is a JSON NUMBER. BcAppSymbolCache.Parse calls ReadAppIdentity LAST, after every
+//   container has already been collected, and ReadAppIdentity's unguarded GetString() throws
+//   InvalidOperationException on a non-string. That is a parse that dies part-way AFTER the
+//   data the sites want has been read — the reported shape — not a whole-file failure any
+//   code path would notice. The poisoned literal is also a different LENGTH, which is what
+//   gives the content-hash memo and the symbol cache a new key so the read really re-parses.
+//
+// No Base Application floor (.claude/rules/no-base-app-in-csharp-tests.md).
+
+using System.Collections;
+using System.IO.Compression;
+using System.Reflection;
+using System.Text;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// RecordPatchesSerialCollection: calls RecordPatches.ResetForReload() directly (#1696).
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class DependencySymbolReadFailureTests : IDisposable
+{
+    private readonly string _root;
+
+    public DependencySymbolReadFailureTests()
+    {
+        _root = TestScratch.Dir("al-runner-3143-tests");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private const string AppGuid = "c3143a00-3143-4a31-9a31-000000003143";
+    private const string AppName = "Bug3143 Symbol App";
+
+    // Ids process-wide unique among AlRunner.Tests statics (RecordPatches' dependency state is
+    // process-global, so an id another fixture also declares could answer from its payload).
+    private const int TableId = 88314301;
+    private const int CodeunitId = 88314302;
+    private const int PageId = 88314303;
+    private const int ReportId = 88314304;
+    private const int QueryId = 88314305;
+    private const string ProfileId = "BUG3143 PROFILE";
+
+    private static string SymbolReference(bool poison)
+    {
+        // The root "AppId" is the ONLY difference: a string (parseable) or a number, which
+        // throws in ReadAppIdentity after every container above has been collected.
+        var appId = poison ? "\"AppId\": 3143" : $"\"AppId\": \"{AppGuid}\"";
+        return $$"""
+            {
+              "RuntimeVersion": "15.1",
+              {{appId}},
+              "Name": "{{AppName}}",
+              "Tables": [
+                {
+                  "Id": {{TableId}},
+                  "Name": "Bug3143 Table",
+                  "Properties": [ { "Name": "Caption", "Value": "Bug3143 Table" } ],
+                  "Fields": [ { "Id": 1, "Name": "Code", "TypeDefinition": { "Name": "Code" } } ]
+                }
+              ],
+              "Codeunits": [
+                {
+                  "Id": {{CodeunitId}},
+                  "Name": "Bug3143 Codeunit",
+                  "Properties": [ { "Name": "SingleInstance", "Value": "true" } ]
+                }
+              ],
+              "Pages": [
+                {
+                  "Id": {{PageId}},
+                  "Name": "Bug3143 Page",
+                  "Properties": [
+                    { "Name": "PageType", "Value": "List" },
+                    { "Name": "SourceTable", "Value": "{{TableId}}" },
+                    { "Name": "InsertAllowed", "Value": "false" }
+                  ]
+                }
+              ],
+              "Reports": [
+                { "Id": {{ReportId}}, "Name": "Bug3143 Report", "Properties": [] }
+              ],
+              "Queries": [
+                { "Id": {{QueryId}}, "Name": "Bug3143 Query", "Properties": [] }
+              ],
+              "Profiles": [
+                {
+                  "Name": "{{ProfileId}}",
+                  "Properties": [ { "Name": "Caption", "Value": "Bug3143 Profile" } ]
+                }
+              ]
+            }
+            """;
+    }
+
+    private static void WriteApp(string path, string symbolReferenceJson)
+    {
+        using var zip = new FileStream(path, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+    }
+
+    /// <summary>Register a healthy .app and leave it healthy.</summary>
+    private string RegisterHealthy(string fileName)
+    {
+        var appPath = Path.Combine(_root, fileName);
+        WriteApp(appPath, SymbolReference(poison: false));
+        RecordPatches.ResetForReload();
+        RecordPatches.AddBcAppPath(appPath);
+        return appPath;
+    }
+
+    /// <summary>
+    /// Register a healthy .app, then rewrite it on disk into the poisoned shape — the
+    /// --watch window where a recompile lands after registration and before the lazy read.
+    /// A different length plus a bumped mtime give the content-hash memo and the symbol
+    /// cache a new key, so the read really re-parses instead of replaying the good result.
+    /// </summary>
+    private string RegisterThenPoison(string fileName = "dep.app")
+    {
+        var appPath = RegisterHealthy(fileName);
+        WriteApp(appPath, SymbolReference(poison: true));
+        File.SetLastWriteTimeUtc(appPath, File.GetLastWriteTimeUtc(appPath).AddSeconds(5));
+        return appPath;
+    }
+
+    /// <summary>Register a healthy .app, then delete it — the tolerated condition.</summary>
+    private void RegisterThenVanish(string fileName = "vanishing.app")
+        => File.Delete(RegisterHealthy(fileName));
+
+    // ── reflection into the private walks ────────────────────────────────────────────────
+    //
+    // Every one of these is a lazy iterator, so a refusal surfaces where the sequence is
+    // DRAINED, never where the method is called. Drain() forces that, which is also the
+    // property #3133 found the previous shape getting wrong.
+
+    private static MethodInfo Method(string name)
+    {
+        var m = typeof(RecordPatches).GetMethod(name, BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.True(m != null, $"RecordPatches.{name}() not found — renamed or removed.");
+        return m!;
+    }
+
+    private static object? Invoke(string name, params object?[] args)
+    {
+        try { return Method(name).Invoke(null, args.Length == 0 ? null : args); }
+        catch (TargetInvocationException tie) { throw tie.InnerException!; }
+    }
+
+    private static List<object> Drain(string name)
+    {
+        var seq = (IEnumerable)Invoke(name)!;
+        var list = new List<object>();
+        foreach (var item in seq) list.Add(item!);
+        return list;
+    }
+
+    /// <summary>Every private walk this issue converted, with the surface text it must name.</summary>
+    public static TheoryData<string, string> Walks() => new()
+    {
+        { "EnumerateBcAppObjects",         "objects (AllObj)" },
+        { "EnumerateBcAppCodeunitSymbols", "objects (CodeUnit Metadata)" },
+        { "EnumerateBcAppTableSymbols",    "tables (Table Metadata)" },
+        { "EnumerateBcAppPageSymbols",     "pages (Page Metadata)" },
+        { "EnumerateBcAppReportSymbols",   "reports (Report Metadata)" },
+        { "EnumerateBcAppProfileSymbols",  "profiles (All Profile)" },
+        { "DependencyAppSymbols",          "pages and pageextensions (dependency page metadata)" },
+    };
+
+    // ── the positive controls ────────────────────────────────────────────────────────────
+
+    [Theory]
+    [MemberData(nameof(Walks))]
+    public void HealthyApp_EveryWalkYieldsItsSymbols(string walk, string _)
+    {
+        RegisterHealthy("healthy.app");
+        Assert.NotEmpty(Drain(walk));
+    }
+
+    [Fact]
+    public void HealthyApp_TheFourCallersAnswerFromTheDependency()
+    {
+        RegisterHealthy("healthy-callers.app");
+
+        // Concrete values, not "not null": each is the exact thing the swallow used to
+        // replace with a default of the same type.
+        Assert.True(RecordPatches.IsPageShapeKnown(PageId));
+        Assert.False(RecordPatches.GetInsertAllowedForPage(PageId),
+            "the fixture page declares InsertAllowed = false; `true` here is the swallow's default");
+        Assert.Equal(TableId, RecordPatches.TryGetDependencySourceTableIdForPage(PageId));
+        Assert.Equal("List", RecordPatches.TryGetAnyPageType(PageId));
+
+        var query = RecordPatches.TryGetQuerySymbol(QueryId);
+        Assert.NotNull(query);
+        Assert.Equal(QueryId, query!.Id);
+
+        Assert.NotNull(RecordPatches.TryBuildDependencyReportMetadata(ReportId));
+    }
+
+    [Fact]
+    public void HealthyApp_ObjectOwnerIndexStampsTheDeclaringApp()
+    {
+        RegisterHealthy("healthy-owner.app");
+        var index = (IDictionary)Invoke("BuildObjectOwnerIndex")!;
+        Assert.Equal(Guid.Parse(AppGuid), index[("codeunit", CodeunitId)]);
+    }
+
+    // ── the refusals ─────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [MemberData(nameof(Walks))]
+    public void SymbolReadFailsAfterRegistration_EveryWalkRefusesNamingTheAppAndSurface(
+        string walk, string surface)
+    {
+        RegisterThenPoison();
+
+        // Before the fix: an empty (or short) sequence, and a `[RecordPatches]` line Log's
+        // default filter dropped. "This app declares nothing" is a WRONG answer here, and
+        // nothing downstream could tell it from a real one.
+        var ex = Assert.Throws<BcAppSymbolReadException>(() => Drain(walk));
+        Assert.Contains("dep.app", ex.Message);
+        Assert.Contains(surface, ex.Message);
+        // The cause is preserved rather than flattened into a message.
+        Assert.IsType<InvalidOperationException>(ex.InnerException);
+        // And it is a REFUSAL, not a one-shot complaint: asking again fails the same way
+        // rather than serving a partial answer for the rest of the process.
+        Assert.Throws<BcAppSymbolReadException>(() => Drain(walk));
+    }
+
+    [Fact]
+    public void SymbolReadFails_IsPageShapeKnown_RefusesInsteadOfAnsweringFalse()
+    {
+        RegisterThenPoison();
+
+        // BEFORE: false — "no dependency describes page N". The page is right there in a
+        // package the runner could not parse, and every TestPage decision downstream
+        // (NavTestPageBase_GetMetaTable's refusal, PrimaryKeyFields) reads that false as fact.
+        var ex = Assert.Throws<BcAppSymbolReadException>(() => RecordPatches.IsPageShapeKnown(PageId));
+        Assert.Contains("pages and pageextensions", ex.Message);
+    }
+
+    [Fact]
+    public void SymbolReadFails_GetInsertAllowedForPage_RefusesInsteadOfAnsweringTrue()
+    {
+        RegisterThenPoison();
+
+        // BEFORE: true — AL's default for an unknown page — while the .app it could not read
+        // states InsertAllowed = false. A TestPage would have allowed an insert the real page
+        // forbids, and the test would have gone green.
+        Assert.Throws<BcAppSymbolReadException>(() => RecordPatches.GetInsertAllowedForPage(PageId));
+    }
+
+    [Fact]
+    public void SymbolReadFails_TryGetQuerySymbol_RefusesInsteadOfAnsweringNull()
+    {
+        RegisterThenPoison();
+
+        // BEFORE: null, AND the partial index was published (_bcSymbolQueryIndex = idx), so
+        // every later lookup in the process was served from it without re-reading anything.
+        var ex = Assert.Throws<BcAppSymbolReadException>(() => RecordPatches.TryGetQuerySymbol(QueryId));
+        Assert.Contains("queries (query symbol index)", ex.Message);
+        // The publish-a-partial-index half: a second call must not answer from a cached
+        // partial result.
+        Assert.Throws<BcAppSymbolReadException>(() => RecordPatches.TryGetQuerySymbol(QueryId));
+    }
+
+    [Fact]
+    public void SymbolReadFails_TryBuildDependencyReportMetadata_RefusesInsteadOfAnsweringNull()
+    {
+        RegisterThenPoison();
+
+        // BEFORE: null, which the caller turns into "report N has no runtime metadata" — the
+        // AL author blamed for a report the runner simply could not read.
+        var ex = Assert.Throws<BcAppSymbolReadException>(
+            () => RecordPatches.TryBuildDependencyReportMetadata(ReportId));
+        Assert.Contains("reports (dependency report metadata)", ex.Message);
+    }
+
+    [Fact]
+    public void SymbolReadFails_ObjectOwnerIndex_StillRefuses()
+    {
+        // #3133's refusal, unchanged by #3143's vanished skip in front of it. This row exists
+        // so the skip cannot be widened into a swallow without failing.
+        RegisterThenPoison();
+        var ex = Assert.Throws<RunnerOutOfScopeException>(() => Invoke("BuildObjectOwnerIndex"));
+        Assert.Contains("dep.app", ex.Message);
+        Assert.Contains("allobj-virtual-table", ex.Message);
+    }
+
+    // ── the tolerated condition ──────────────────────────────────────────────────────────
+
+    [Theory]
+    [MemberData(nameof(Walks))]
+    public void VanishedApp_EveryWalkSkipsItRatherThanRefusing(string walk, string _)
+    {
+        RegisterThenVanish();
+        Assert.Empty(Drain(walk));
+    }
+
+    [Fact]
+    public void VanishedApp_ObjectOwnerIndexSkipsItRatherThanAbortingAllObj()
+    {
+        // #3143: #3133 refused on ANY exception here, including the file simply being gone —
+        // so a --watch iteration that removed a dependency aborted AllObj outright, while
+        // EnumerateBcAppObjects (same table, same registry) skipped the same .app and carried
+        // on. One table's two walks must not disagree about whether vanished is survivable.
+        RegisterThenVanish();
+        var index = (IDictionary)Invoke("BuildObjectOwnerIndex")!;
+        Assert.False(index.Contains(("codeunit", CodeunitId)));
+    }
+
+    [Fact]
+    public void VanishedApp_WarningSurvivesLogsDefaultFilter()
+    {
+        // The skip is only honest if the user is TOLD. This drives Log's REAL filter rather
+        // than re-implementing its regex, because the bug being guarded against is precisely
+        // a tag the regex eats — `[RecordPatches]` did, which is why the pre-fix line was
+        // invisible at default verbosity.
+        RegisterThenVanish("vanishing2.app");
+
+        var savedOut = Console.Out;
+        var savedErr = Console.Error;
+        var savedVerbose = Log.Verbose;
+        var captured = new StringWriter();
+        string text;
+        try
+        {
+            Console.SetError(captured);
+            Console.SetOut(TextWriter.Null);
+            Log.Verbose = false;      // the DEFAULT verbosity, where the old line vanished
+            Log.Install();            // wrap `captured` in the same FilteredWriter users get
+            Drain("EnumerateBcAppObjects");
+            Invoke("BuildObjectOwnerIndex");
+            Console.Error.Flush();
+            text = captured.ToString();
+        }
+        finally
+        {
+            Console.SetOut(savedOut);
+            Console.SetError(savedErr);
+            Log.Verbose = savedVerbose;
+        }
+
+        Assert.Contains("vanishing2.app", text);
+        Assert.Contains("[warn]", text);
+        Assert.Contains("no longer on disk", text);
+        // The specific claim: a `[Component]`-tagged line would NOT have survived.
+        Assert.DoesNotContain("[RecordPatches]", text);
+    }
+
+    [Fact]
+    public void RefusalMessage_SurvivesLogsDefaultFilter_UnlikeAComponentTaggedLine()
+    {
+        // A refusal that is thrown but then filtered out of the terminal is no better than
+        // the swallow it replaced, and this repository has shipped that bug repeatedly (see
+        // Log.cs's [bc] / [expectations] / [reexec] / [dap] / [warn] notes). So the message
+        // goes through the REAL FilteredWriter at default verbosity rather than trusting
+        // BcAppSymbolReadException's "no leading [tag]" comment to still be true.
+        var refusal = new BcAppSymbolReadException(
+            Path.Combine(_root, "dep.app"), "objects (AllObj)", new InvalidOperationException("boom"));
+
+        var savedOut = Console.Out;
+        var savedErr = Console.Error;
+        var savedVerbose = Log.Verbose;
+        var captured = new StringWriter();
+        string text;
+        try
+        {
+            Console.SetError(captured);
+            Console.SetOut(TextWriter.Null);
+            Log.Verbose = false;
+            Log.Install();
+            Console.Error.WriteLine(refusal.Message);
+            // The control: the tag the OLD code used, through the same writer, same call.
+            Console.Error.WriteLine("[RecordPatches] AllObj: SymbolReference read failed");
+            Console.Error.Flush();
+            text = captured.ToString();
+        }
+        finally
+        {
+            Console.SetOut(savedOut);
+            Console.SetError(savedErr);
+            Log.Verbose = savedVerbose;
+        }
+
+        Assert.Contains("symbol-read-fail", text);
+        Assert.Contains("dep.app", text);
+        Assert.Contains("objects (AllObj)", text);
+        Assert.DoesNotContain("[RecordPatches]", text);
+    }
+}

--- a/AlRunner/Patches/DependencyReportMetadata.cs
+++ b/AlRunner/Patches/DependencyReportMetadata.cs
@@ -85,26 +85,19 @@ public static partial class RecordPatches
         return xml;
     }
 
+    /// <summary>
+    /// #3143: NOT swallowed. Returning null here means "no loaded dependency declares report
+    /// N", and the caller turns that into a not-yet-implemented refusal naming the report —
+    /// so a read failure used to blame the AL author for a report that is right there in a
+    /// package the runner could not parse. See RecordPatches.DependencyAppSymbolWalk.cs.
+    /// </summary>
     private static (string AppPath, BcAppSymbolCache.ReportSymbol Report)? FindDependencyReportSymbol(int reportId)
     {
-        foreach (var appPath in _bcAppPaths.ToArray())
-        {
-            List<BcAppSymbolCache.ReportSymbol> reports;
-            try
-            {
-                reports = BcAppSymbolCache.Get(appPath).Reports;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(
-                    $"[RecordPatches] dependency report metadata: SymbolReference read failed for "
-                    + $"{Path.GetFileName(appPath)}: {ex.Message}");
-                continue;
-            }
-            foreach (var r in reports)
+        foreach (var (appPath, symbols) in
+                 EnumerateRegisteredBcAppSymbols("reports (dependency report metadata)"))
+            foreach (var r in symbols.Reports)
                 if (r.Id == reportId)
                     return (appPath, r);
-        }
         return null;
     }
 

--- a/AlRunner/Patches/EnumMetadataPatches.cs
+++ b/AlRunner/Patches/EnumMetadataPatches.cs
@@ -187,6 +187,24 @@ public static class AlEnumMetadataRegistry
 
     public static int Count => _byId.Count;
 
+    /// <summary>
+    /// Register every enum a precompiled dependency .app declares.
+    ///
+    /// <para>#3143: this had the same swallow as the ten dependency-symbol reads that issue
+    /// listed — `catch (Exception)` plus an `[EnumMetadata]`-tagged stderr line, which Log's
+    /// default-verbosity filter drops because it starts with a bracketed component tag. The
+    /// effect was that an unreadable .app registered NO enums, and AL casting one of them to
+    /// its interface then failed as an ordinary-looking AL error naming the enum rather than
+    /// the package that could not be read.</para>
+    ///
+    /// <para>#3143 confirmed what that issue only suspected: this method has NO live callers.
+    /// <c>RecordPatches.AddBcAppPath</c> is the only path by which a dependency's enums reach
+    /// this registry, and it already reads eagerly and refuses loudly. The swallow is
+    /// converted rather than left alone because it is public and a future caller would
+    /// inherit it silently; the empty/absent guard above is UNCHANGED, because "no path
+    /// given" and "the file is not there" are genuinely "nothing to register", not
+    /// "could not find out".</para>
+    /// </summary>
     public static void RegisterFromAppPath(string appPath)
     {
         if (string.IsNullOrEmpty(appPath) || !File.Exists(appPath)) return;
@@ -203,9 +221,9 @@ public static class AlEnumMetadataRegistry
                     enumSymbol.DefaultImplementations?.ToArray(),
                     enumSymbol.UnknownImplementations?.ToArray());
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not AlRunner.Infrastructure.BcAppSymbolReadException)
         {
-            Console.Error.WriteLine($"[EnumMetadata] failed to read {Path.GetFileName(appPath)}: {ex.Message}");
+            throw new AlRunner.Infrastructure.BcAppSymbolReadException(appPath, "enums", ex);
         }
     }
 

--- a/AlRunner/Patches/RecordPatches.AllObjVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AllObjVirtualTable.cs
@@ -226,24 +226,18 @@ public static partial class RecordPatches
             yield return o;
     }
 
+    /// <summary>
+    /// #3143: NOT swallowed. This used to `continue` past any read failure behind a
+    /// `[RecordPatches]`-tagged line that Log's default filter drops, so an unreadable
+    /// dependency simply had none of its objects in AllObj — a table AL enumerates to
+    /// discover what exists, answered short. Walk and failure policy now come from
+    /// EnumerateRegisteredBcAppSymbols; see RecordPatches.DependencyAppSymbolWalk.cs.
+    /// </summary>
     private static IEnumerable<(string Kind, int Id, string Name, string? Caption)> EnumerateBcAppObjects()
     {
-        foreach (var appPath in _bcAppPaths.ToArray())
-        {
-            List<BcAppSymbolCache.ObjectSymbol> objects;
-            try
-            {
-                objects = BcAppSymbolCache.Get(appPath).Objects;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(
-                    $"[RecordPatches] AllObj: SymbolReference read failed for {Path.GetFileName(appPath)}: {ex.Message}");
-                continue;
-            }
-            foreach (var o in objects)
+        foreach (var (_, symbols) in EnumerateRegisteredBcAppSymbols("objects (AllObj)"))
+            foreach (var o in symbols.Objects)
                 yield return (o.Kind, o.Id, o.Name, o.Caption);
-        }
     }
 
     /// <summary>
@@ -365,6 +359,23 @@ public static partial class RecordPatches
         var index = new Dictionary<(string Kind, int Id), Guid>();
         foreach (var appPath in _bcAppPaths.ToArray())
         {
+            // #3143: VANISHED is the one tolerated condition, and #3133 did not have it.
+            // Without this skip a --watch iteration that removed a dependency, or a --server
+            // process outliving a rebuild, ABORTS AllObj outright — while EnumerateBcAppObjects
+            // twenty lines up skips the same .app and carries on, so one table's two walks
+            // disagreed about whether a vanished dependency is survivable. Every other
+            // dependency-symbol read in the runner treats it as survivable (#2712, #3031), and
+            // the answer it produces is honest: the app contributes no AllObj rows AND no
+            // ownership entries, so nothing is stamped with a guessed owner. PRESENT BUT
+            // UNREADABLE keeps #3133's refusal below, unchanged.
+            if (!File.Exists(appPath))
+            {
+                Console.Error.WriteLine(
+                    "[warn] registered dependency .app is no longer on disk; its objects "
+                    + $"(AllObj object ownership) are not available to this run: {appPath}");
+                continue;
+            }
+
             BcAppSymbolCache.AppSymbols symbols;
             // #3117: NOT swallowed. This used to `catch { continue; }` on the reasoning that
             // "the AllObj row itself is built either way" — true, but it is then built with

--- a/AlRunner/Patches/RecordPatches.AllProfileVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AllProfileVirtualTable.cs
@@ -273,19 +273,11 @@ public static partial class RecordPatches
     private static IEnumerable<(Guid AppId, string AppName, BcAppSymbolCache.ProfileSymbol Symbol)>
         EnumerateBcAppProfileSymbols()
     {
-        foreach (var appPath in _bcAppPaths.ToArray())
+        // #3143: a read that CANNOT answer no longer reports "this app declares no
+        // profiles". The `continue` below is kept for the one case where that IS the
+        // answer — symbols read fine and list none.
+        foreach (var (appPath, symbols) in EnumerateRegisteredBcAppSymbols("profiles (All Profile)"))
         {
-            BcAppSymbolCache.AppSymbols symbols;
-            try
-            {
-                symbols = BcAppSymbolCache.Get(appPath);
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(
-                    $"[RecordPatches] All Profile: SymbolReference read failed for {Path.GetFileName(appPath)}: {ex.Message}");
-                continue;
-            }
             if (symbols.Profiles is not { Count: > 0 } profiles) continue;
             if (!Guid.TryParse(symbols.AppId, out var appId))
             {

--- a/AlRunner/Patches/RecordPatches.BcAppFallback.cs
+++ b/AlRunner/Patches/RecordPatches.BcAppFallback.cs
@@ -819,19 +819,16 @@ public static partial class RecordPatches
     {
         if (_bcSymbolQueryIndex != null) return;
         var idx = new Dictionary<int, BcAppSymbolCache.QuerySymbol>();
-        foreach (var appPath in _bcAppPaths)
-        {
-            try
-            {
-                foreach (var q in BcAppSymbolCache.Get(appPath).Queries)
-                    if (!idx.ContainsKey(q.Id))
-                        idx[q.Id] = q;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine($"[RecordPatches] BcAppFallback: query SymbolReference read failed for {Path.GetFileName(appPath)}: {ex.Message}");
-            }
-        }
+        // #3143: NOT swallowed. The old catch left the .app's queries out of the index and
+        // then PUBLISHED it (_bcSymbolQueryIndex = idx below), so the partial index was
+        // served as the complete answer for the rest of the process — AL running a query
+        // that dependency declares got "unknown query id" rather than a refusal. Same
+        // failure shape EnsureBcSymbolExtensionIndex's "#2712, no catch here" comment
+        // describes. See RecordPatches.DependencyAppSymbolWalk.cs.
+        foreach (var (_, symbols) in EnumerateRegisteredBcAppSymbols("queries (query symbol index)"))
+            foreach (var q in symbols.Queries)
+                if (!idx.ContainsKey(q.Id))
+                    idx[q.Id] = q;
         // Loose SymbolReference.json sources (the bundle's own freshly-compiled queries).
         // Registered AFTER .app sources but only filling gaps (ContainsKey guard), so a
         // prebuilt .app's authoritative ids always win.

--- a/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.CodeunitMetadataVirtualTable.cs
@@ -336,26 +336,17 @@ public static partial class RecordPatches
     /// about which codeunits a dependency contains. The codeunit-only properties ride on
     /// <see cref="BcAppSymbolCache.ObjectSymbol"/>; see its doc comment.
     /// </summary>
+    /// <summary>
+    /// #3143: NOT swallowed — see RecordPatches.DependencyAppSymbolWalk.cs. Reads the SAME
+    /// surface AllObj does, through the same walk, so the two tables cannot now disagree
+    /// about which dependency contributed codeunits either.
+    /// </summary>
     private static IEnumerable<BcAppSymbolCache.ObjectSymbol> EnumerateBcAppCodeunitSymbols()
     {
-        foreach (var appPath in _bcAppPaths.ToArray())
-        {
-            List<BcAppSymbolCache.ObjectSymbol> objects;
-            try
-            {
-                objects = BcAppSymbolCache.Get(appPath).Objects;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(
-                    $"[RecordPatches] CodeUnit Metadata: SymbolReference read failed for "
-                    + $"{Path.GetFileName(appPath)}: {ex.Message}");
-                continue;
-            }
-            foreach (var o in objects)
+        foreach (var (_, symbols) in EnumerateRegisteredBcAppSymbols("objects (CodeUnit Metadata)"))
+            foreach (var o in symbols.Objects)
                 if (o.Id > 0 && NormalizeObjectTypeName(o.Kind) == "codeunit")
                     yield return o;
-        }
     }
 
     /// <summary>

--- a/AlRunner/Patches/RecordPatches.DependencyAppSymbolWalk.cs
+++ b/AlRunner/Patches/RecordPatches.DependencyAppSymbolWalk.cs
@@ -1,0 +1,121 @@
+// RecordPatches.DependencyAppSymbolWalk — the ONE walk over the registered dependency
+// .app paths, and the one place the "vanished vs unreadable" split is spelled.
+//
+// THE DEFECT THIS CLOSES (#3143)
+//   Ten call sites each wrote their own copy of
+//
+//       foreach (var appPath in _bcAppPaths.ToArray())
+//       {
+//           try { ... = BcAppSymbolCache.Get(appPath). ...; }
+//           catch (Exception ex) { Console.Error.WriteLine($"[RecordPatches] ..."); continue; }
+//           ...
+//       }
+//
+//   and every one of them turned "the runner could not find out what this .app declares"
+//   into "this .app declares nothing" — a WRONG answer rather than a missing one, which is
+//   exactly what .claude/rules/loud-failures.md forbids. The `continue` dropped the app's
+//   objects out of AllObj, its codeunits out of CodeUnit Metadata, its tables out of Table
+//   Metadata, its pages out of Page Metadata AND out of every dependency-page property
+//   lookup, its reports out of Report Metadata and out of the synthesized report dataset,
+//   its profiles out of All Profile, and its queries out of the query symbol index. AL then
+//   read a table that was short some rows, or got `false` / `0` / `null` from a property
+//   lookup, and a test could go green having quietly done without.
+//
+//   The only trace was a `[RecordPatches]`-tagged stderr line, and Log's default-verbosity
+//   filter drops lines that START with a bracketed component tag — measured in #3031 by
+//   driving the real filter, not by reading its regex. At the verbosity users actually run
+//   at, the loss was completely silent.
+//
+// THE SPLIT (#2712, applied to the permission slice by #3031, and to every remaining
+// dependency-symbol read here)
+//
+//   * VANISHED (`!File.Exists`) — legitimate and expected. A --watch iteration removed a
+//     dependency between runs, a --server process outlived a rebuild, a fixture's temp dir
+//     was deleted. Skip the .app as a WHOLE and say so on `[warn]`, a tag Log's
+//     default-verbosity filter exempts, so the user is actually told.
+//
+//   * PRESENT BUT UNREADABLE — never legitimate. Every path in _bcAppPaths already passed
+//     AddBcAppPath's eager read (#2712), so a failure here means the bytes changed into
+//     something unparseable since, or the parser is defective. Both are runner defects, and
+//     both would otherwise be reported as ordinary-looking test results. Raise
+//     BcAppSymbolReadException naming the .app and the surface; Program.cs catches it and
+//     exits 1.
+//
+//   The check is a File.Exists precondition rather than an exception filter on purpose: a
+//   deleted file surfaces as FileNotFoundException, DirectoryNotFoundException or
+//   IOException depending on platform and timing, so filtering on type would classify the
+//   expected state by accident. The narrow TOCTOU window (deleted between the check and the
+//   read) fails loudly, which is the conservative direction.
+//
+// WHY BcAppSymbolReadException AND NOT RunnerOutOfScopeException
+//   RunnerOutOfScopeException means "this BC surface is one the runner does not support",
+//   and an expectations entry can legitimately classify it (`expect-oos`). An unreadable
+//   dependency package is neither: it is a defect that must stop the run outright, and
+//   Program.cs already has the exit-1 arm for it. Classifying it as out-of-scope would let a
+//   corrupt dependency be declared expected. BuildObjectOwnerIndex (#3117/#3133) reaches for
+//   AllObjShapeGap instead — that one is deliberate, because the owner is a STORED COLUMN
+//   VALUE on rows AllObj has already begun writing, so its refusal has to name the AllObj
+//   shape the caller was asking about. Both are loud; neither returns a default.
+//
+// WHY ONE HELPER AND NOT TEN EDITS
+//   The ten sites are one shape repeated ten times, not ten bugs. A helper makes the split
+//   impossible to get subtly different per table (#3031 and #2712 had already written it
+//   twice, with two different warning texts), and DependencyAppSymbolWalkSourceGuardTests
+//   holds the property that no NEW copy of the old shape can be added without failing.
+
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    /// <summary>
+    /// Every registered dependency .app's parsed symbols, in registration order, paired with
+    /// the path they came from.
+    ///
+    /// <para>A .app that has VANISHED from disk since registration is skipped with a
+    /// <c>[warn]</c>; a .app that is present but whose SymbolReference.json cannot be read
+    /// raises <see cref="BcAppSymbolReadException"/> naming the .app and
+    /// <paramref name="surface"/>. See this file's header for why those two are not the same
+    /// condition.</para>
+    ///
+    /// <para>This is a lazy iterator, so the refusal surfaces where the caller ENUMERATES,
+    /// not where it calls. That matters for a caller that assigns the sequence and drains it
+    /// later: wrapping the call in a try/catch catches nothing. Every caller in this
+    /// repository drains inline.</para>
+    /// </summary>
+    /// <param name="surface">
+    /// What was being read, phrased to complete both "could not read its {surface} from
+    /// SymbolReference.json" and "its {surface} are not available to this run" — e.g.
+    /// <c>"objects (AllObj)"</c>.
+    /// </param>
+    internal static IEnumerable<(string AppPath, BcAppSymbolCache.AppSymbols Symbols)>
+        EnumerateRegisteredBcAppSymbols(string surface)
+    {
+        foreach (var appPath in _bcAppPaths.ToArray())
+        {
+            if (!File.Exists(appPath))
+            {
+                // No leading `[Component]` tag: Log's default-verbosity filter drops those,
+                // and a skip the user is never told about is the same silent loss the
+                // refusal below exists to prevent.
+                Console.Error.WriteLine(
+                    "[warn] registered dependency .app is no longer on disk; its "
+                    + $"{surface} are not available to this run: {appPath}");
+                continue;
+            }
+
+            BcAppSymbolCache.AppSymbols symbols;
+            try
+            {
+                symbols = BcAppSymbolCache.Get(appPath);
+            }
+            catch (Exception ex) when (ex is not BcAppSymbolReadException)
+            {
+                throw new BcAppSymbolReadException(appPath, surface, ex);
+            }
+
+            yield return (appPath, symbols);
+        }
+    }
+}

--- a/AlRunner/Patches/RecordPatches.DependencyPageMetadata.cs
+++ b/AlRunner/Patches/RecordPatches.DependencyPageMetadata.cs
@@ -79,26 +79,20 @@ public static partial class RecordPatches
         => (IsPageParsed(pageId) && _parsedPages.TryGetValue(pageId, out var page) && page.SourceTableTemporary)
            || TryGetDependencyPageSymbol(pageId)?.SourceTableTemporary == true;
 
+    /// <summary>
+    /// #3143: NOT swallowed. This is the highest-leverage of the ten sites, because almost
+    /// every caller reads it as `TryGetDependencyPageSymbol(id)?.X ?? default` — so a read
+    /// that could not answer used to produce `InsertAllowed = true`, `SourceTableId = 0`,
+    /// `PageType = null`, `IsPageKnown = false`. Those are not missing answers, they are
+    /// wrong ones, and no AL-visible signal distinguished them. Now shares the one walk with
+    /// the pageextension lookups below; see RecordPatches.DependencyAppSymbolWalk.cs.
+    /// </summary>
     private static BcAppSymbolCache.PageSymbol? TryGetDependencyPageSymbol(int pageId)
     {
-        foreach (var appPath in _bcAppPaths.ToArray())
-        {
-            List<BcAppSymbolCache.PageSymbol> pages;
-            try
-            {
-                pages = BcAppSymbolCache.Get(appPath).Pages;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(
-                    $"[RecordPatches] dependency page metadata: SymbolReference read failed for "
-                    + $"{Path.GetFileName(appPath)}: {ex.Message}");
-                continue;
-            }
-            foreach (var p in pages)
+        foreach (var symbols in DependencyAppSymbols())
+            foreach (var p in symbols.Pages)
                 if (p.Id == pageId)
                     return p;
-        }
         return null;
     }
 
@@ -134,29 +128,20 @@ public static partial class RecordPatches
     }
 
     /// <summary>
-    /// Every loaded dependency .app's parsed symbols, in registration order, skipping (and
-    /// reporting) any whose SymbolReference.json cannot be read — factored out of
-    /// <see cref="TryGetDependencyPageSymbol"/> so the page and pageextension lookups share
-    /// one walk and one failure policy.
+    /// Every loaded dependency .app's parsed symbols, in registration order, so the page and
+    /// pageextension lookups share one walk and one failure policy.
+    ///
+    /// <para>#3143: the doc comment on <see cref="TryGetDependencyPageExtensionSymbol"/> has
+    /// always claimed a .app whose SymbolReference cannot be read is "skipped loudly, never
+    /// treated as 'declares none'". It was neither: the skip WAS "declares none", and its
+    /// only trace was a `[RecordPatches]`-tagged line Log's default filter drops. It is now
+    /// true — see RecordPatches.DependencyAppSymbolWalk.cs.</para>
     /// </summary>
     private static IEnumerable<BcAppSymbolCache.AppSymbols> DependencyAppSymbols()
     {
-        foreach (var appPath in _bcAppPaths.ToArray())
-        {
-            BcAppSymbolCache.AppSymbols symbols;
-            try
-            {
-                symbols = BcAppSymbolCache.Get(appPath);
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(
-                    $"[RecordPatches] dependency page metadata: SymbolReference read failed for "
-                    + $"{Path.GetFileName(appPath)}: {ex.Message}");
-                continue;
-            }
+        foreach (var (_, symbols) in
+                 EnumerateRegisteredBcAppSymbols("pages and pageextensions (dependency page metadata)"))
             yield return symbols;
-        }
     }
 
     /// <summary>

--- a/AlRunner/Patches/RecordPatches.DependencyPageMetadata.cs
+++ b/AlRunner/Patches/RecordPatches.DependencyPageMetadata.cs
@@ -100,8 +100,11 @@ public static partial class RecordPatches
     /// The precompiled dependency <c>pageextension</c> with object id
     /// <paramref name="extensionId"/>, or null when no loaded dependency .app declares one
     /// (issue #2723's pageextension arm). Same walk as <see cref="TryGetDependencyPageSymbol"/>,
-    /// same failure handling — a .app whose SymbolReference cannot be read is skipped loudly,
-    /// never treated as "declares none".
+    /// same failure handling: a .app that has VANISHED from disk since registration is
+    /// skipped with a <c>[warn]</c> Log's default verbosity shows, and a .app that is
+    /// present but whose SymbolReference cannot be read RAISES
+    /// <see cref="BcAppSymbolReadException"/> — neither is treated as "declares none". See
+    /// RecordPatches.DependencyAppSymbolWalk.cs for why those two are not one condition.
     /// </summary>
     private static BcAppSymbolCache.PageExtensionSymbol? TryGetDependencyPageExtensionSymbol(int extensionId)
     {
@@ -131,11 +134,12 @@ public static partial class RecordPatches
     /// Every loaded dependency .app's parsed symbols, in registration order, so the page and
     /// pageextension lookups share one walk and one failure policy.
     ///
-    /// <para>#3143: the doc comment on <see cref="TryGetDependencyPageExtensionSymbol"/> has
-    /// always claimed a .app whose SymbolReference cannot be read is "skipped loudly, never
-    /// treated as 'declares none'". It was neither: the skip WAS "declares none", and its
-    /// only trace was a `[RecordPatches]`-tagged line Log's default filter drops. It is now
-    /// true — see RecordPatches.DependencyAppSymbolWalk.cs.</para>
+    /// <para>#3143: this used to swallow EVERY read failure and <c>continue</c>, so a .app the
+    /// runner could not read reported "declares no pages" — a wrong answer rather than a
+    /// missing one, whose only trace was a `[RecordPatches]`-tagged line Log's default filter
+    /// drops. The two conditions are now separated: a VANISHED .app is skipped on `[warn]`,
+    /// and one that is present but unreadable raises
+    /// <see cref="BcAppSymbolReadException"/>. See RecordPatches.DependencyAppSymbolWalk.cs.</para>
     /// </summary>
     private static IEnumerable<BcAppSymbolCache.AppSymbols> DependencyAppSymbols()
     {

--- a/AlRunner/Patches/RecordPatches.PageMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.PageMetadataVirtualTable.cs
@@ -295,24 +295,16 @@ public static partial class RecordPatches
         }
     }
 
+    /// <summary>
+    /// #3143: NOT swallowed — an unreadable dependency used to leave every page it declares
+    /// out of Page Metadata (2000000138) AND out of Page Control Field, the other consumer of
+    /// this walk. See RecordPatches.DependencyAppSymbolWalk.cs.
+    /// </summary>
     private static IEnumerable<BcAppSymbolCache.PageSymbol> EnumerateBcAppPageSymbols()
     {
-        foreach (var appPath in _bcAppPaths.ToArray())
-        {
-            List<BcAppSymbolCache.PageSymbol> pages;
-            try
-            {
-                pages = BcAppSymbolCache.Get(appPath).Pages;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(
-                    $"[RecordPatches] Page Metadata: SymbolReference read failed for {Path.GetFileName(appPath)}: {ex.Message}");
-                continue;
-            }
-            foreach (var p in pages)
+        foreach (var (_, symbols) in EnumerateRegisteredBcAppSymbols("pages (Page Metadata)"))
+            foreach (var p in symbols.Pages)
                 yield return p;
-        }
     }
 
     /// <summary>

--- a/AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs
@@ -737,24 +737,16 @@ public static partial class RecordPatches
     /// exercising <see cref="ScanReportIdsFromPeFile"/> directly.</summary>
     internal static int[] ReadReportIdsFromPeFileForTest(string path) => ScanReportIdsFromPeFile(path) ?? Array.Empty<int>();
 
+    /// <summary>
+    /// #3143: NOT swallowed — an unreadable dependency used to leave every report it declares
+    /// out of Report Metadata (2000000139) and out of the ProcessingOnly id set built from
+    /// this same walk. See RecordPatches.DependencyAppSymbolWalk.cs.
+    /// </summary>
     private static IEnumerable<BcAppSymbolCache.ReportSymbol> EnumerateBcAppReportSymbols()
     {
-        foreach (var appPath in _bcAppPaths.ToArray())
-        {
-            List<BcAppSymbolCache.ReportSymbol> reports;
-            try
-            {
-                reports = BcAppSymbolCache.Get(appPath).Reports;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(
-                    $"[RecordPatches] Report Metadata: SymbolReference read failed for {Path.GetFileName(appPath)}: {ex.Message}");
-                continue;
-            }
-            foreach (var r in reports)
+        foreach (var (_, symbols) in EnumerateRegisteredBcAppSymbols("reports (Report Metadata)"))
+            foreach (var r in symbols.Reports)
                 yield return r;
-        }
     }
 
     private static MethodInfo? _rmvNavBooleanCreate;

--- a/AlRunner/Patches/RecordPatches.TableMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.TableMetadataVirtualTable.cs
@@ -482,23 +482,15 @@ public static partial class RecordPatches
         return pageIdsByName.TryGetValue(reference, out var id) ? id : 0;
     }
 
+    /// <summary>
+    /// #3143: NOT swallowed — an unreadable dependency used to leave every table it declares
+    /// out of Table Metadata (2000000136), which AL reads to decide whether a table EXISTS.
+    /// See RecordPatches.DependencyAppSymbolWalk.cs for the vanished/unreadable split.
+    /// </summary>
     private static IEnumerable<ParsedTable> EnumerateBcAppTableSymbols()
     {
-        foreach (var appPath in _bcAppPaths.ToArray())
-        {
-            List<ParsedTable> tables;
-            try
-            {
-                tables = BcAppSymbolCache.Get(appPath).Tables;
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(
-                    $"[RecordPatches] Table Metadata: SymbolReference read failed for {Path.GetFileName(appPath)}: {ex.Message}");
-                continue;
-            }
-            foreach (var t in tables)
+        foreach (var (_, symbols) in EnumerateRegisteredBcAppSymbols("tables (Table Metadata)"))
+            foreach (var t in symbols.Tables)
                 yield return t;
-        }
     }
 }


### PR DESCRIPTION
Closes #3143

Ten dependency-symbol reads outside the permission slice each swallowed every exception from `BcAppSymbolCache.Get(appPath)` and `continue`d, so "the runner could not find out what this `.app` declares" became "this `.app` declares nothing". That is a wrong answer, not a missing one, and the only trace was a `[RecordPatches]`-tagged stderr line that Log's default-verbosity filter drops — so at the verbosity people actually run at, the loss was silent.

All ten now go through one walk, `RecordPatches.EnumerateRegisteredBcAppSymbols`, which makes the split #2712 settled and #3031 applied to the permission slice:

* **vanished** (`!File.Exists`) — a legitimate `--watch` / `--server` / deleted-fixture state. Skip the `.app` and say so on `[warn]`, a tag Log exempts.
* **present but unreadable** — never legitimate, because every path in `_bcAppPaths` already passed `AddBcAppPath`'s eager read. Raise `BcAppSymbolReadException` naming the `.app` and the surface; `Program.cs` already exits 1 on it.

## RED, measured

Reverted the ten call sites to `origin/main` in place, kept the new tests, rebuilt, ran: **15 failed / 18 passed**. Every refusal row failed with `Assert.Throws() Failure: No exception was thrown` — the call returned normally with a confident wrong answer.

Then measured what those answers actually were, against a synthetic `.app` that states `InsertAllowed = false`, `SourceTable = 88314301`, `PageType = List`, and declares a query and a report, poisoned after registration:

| caller | pre-fix answer | what the `.app` says |
|---|---|---|
| `IsPageShapeKnown(page)` | `false` | the page is right there |
| `GetInsertAllowedForPage(page)` | `true` | `InsertAllowed = false` |
| `TryGetDependencySourceTableIdForPage(page)` | `0` | `88314301` |
| `TryGetAnyPageType(page)` | `null` | `List` |
| `TryGetQuerySymbol(query)` | `null` | declared |
| `TryBuildDependencyReportMetadata(report)` | `null` | declared |
| `EnumerateBcAppObjects` / `EnumerateBcAppTableSymbols` | empty | 6 objects |

`GetInsertAllowedForPage` is the sharpest one: a `TestPage` would have allowed an insert the real page forbids, and the test would have gone green.

## GREEN

Restored, rebuilt, **33 passed** in the two new classes. Wider runs, all in this state:

* filtered `AlRunner.Tests` over the changed surface (`AllObj`, `AllProfile`, `BcAppSymbolCache`, `CodeunitMetadata`, `DependencyPage`, `DependencyReport`, `TableMetadata`, `EnumMetadata`, `EnumCaption`, the two permission-slice read-failure classes, and the two new ones) — **145 passed, 2 skipped**
* `tests/runner-extras`, cold then warm against the same private cache outside the repo — **312/312** both times (cache-sensitive: this change is in the symbol-read path)
* `tests/al-language` corpus at the current pin — **2676/2676**

## Also in this change

**`BuildObjectOwnerIndex` gains the vanished skip it did not have.** #3133 landed its refusal on *any* exception, including the file simply being gone — so a `--watch` iteration that removed a dependency aborted AllObj outright, while `EnumerateBcAppObjects` twenty lines up skipped the same `.app` and carried on. One table's two walks disagreeing about whether a removed dependency is survivable is a defect either way; every other dependency-symbol read in the runner treats vanished as survivable. #3133's refusal for the *unreadable* case is unchanged, and there is a row pinning that it still fires.

**`AlEnumMetadataRegistry.RegisterFromAppPath`.** #3143 excluded it pending confirmation that it is dead. Confirmed dead — `AddBcAppPath` is the only live path by which a dependency's enums reach that registry, exactly as the comment at `RecordPatches.BcAppFallback.cs:439` says. It is `public`, though, so its swallow is converted rather than left for a future caller to inherit. Its `string.IsNullOrEmpty || !File.Exists` guard is unchanged: "no path given" and "the file is not there" genuinely are "nothing to register".

**A source census.** `DependencyAppSymbolWalkSourceGuardTests` names every remaining `BcAppSymbolCache.Get(` call site with what it does on failure and why that is right (8 sites, down from 14). The idiom got copied ten times before anyone noticed, and #3031 and #3117 independently fixed two instances of it *concurrently, without either agent seeing the other* — which is what a repeated idiom with no mechanical check looks like from the inside. It is a census, not a ban on catching: two of the remaining sites catch legitimately.

## Sites deliberately left alone

* `RecordPatches.BcAppFallback.DescribeParsedSymbolState` — catches broadly on purpose and returns `"unreadable:<Type>"`. That is a diagnostic string whose job is to describe the state, and it differs from every healthy key, so it forces a cache miss rather than colliding with a good answer. Honest, not a silent default. (#3143 excluded it; I agree.)
* `RegisterFromAppPath`'s `File.Exists` guard, and `AllProfile`'s `symbols.Profiles is not { Count: > 0 }` / no-`AppId` `continue`s — those fire when the read **succeeded** and the answer was genuinely "none". Converting them would be a regression.

## Fix the shape

1. *Same wrong pattern at another call site?* Yes — that is the whole PR. The census now enumerates what is left.
2. *Sibling function with the same assumption?* Yes: `RegisterFromAppPath` (above), which the issue had only suspected.
3. *Two code paths writing the same state, same invariant?* No, and that was the `BuildObjectOwnerIndex` finding above. Also worth recording: `TryGetDependencyPageExtensionSymbol`'s doc comment claimed a `.app` whose SymbolReference cannot be read is "skipped loudly, never treated as 'declares none'". It was neither — the skip *was* "declares none". That sentence is now corrected in place: unreadable is **refused**, and "skipped loudly" describes only the vanished case. (An earlier revision of this PR annotated it from a sibling member instead of fixing it, which left the wrong sentence standing.)

## Queue scan — what did not fold

Per `.claude/rules/batch-sibling-issues-by-file.md`, scanned the open queue for `swallow` / `silently` / `exception` / `symbol` / `guarded only by` / `dependency symbol`. Three same-class candidates, none in these files:

* **#3051** (143 `!`-guarded BC-internals member lookups) — measured on this tree: 142 sites across 37 files, and **zero overlap** with the nine files here. It is also not one issue; breakdown posted on the issue. Not folded, and I would not claim it as filed.
* **#2981** (`VersionExists` conflates "not published" with "could not ask") — same defect class, but it lives in `ArtifactDownloader` / `BcArtifacts`, and the issue itself says the open question is a policy decision about what to do on an inconclusive probe. That is not mine to make as a side effect.
* **#2956** (the layered pre-pass wraps `MissingDependencyException`) — `ProgramSupport/SiblingCompile.cs`. Same shape one layer out, different file, different fix.

None of the three is folded in here. #2981 and #2956 are open, unassigned and `status: ready`. **#3051 is not unclaimed** — it is assigned to `StefanMaron` and carries `status: in-progress` + `agent: stma-auto-1`; an earlier revision of this body said all three were unclaimed, which was wrong. My comment on #3051 (that I have not claimed it) is accurate; this summary was not.

## CI red, and what it was (added after the first matrix run)

The first full matrix went red on **BC 27.5 and 28.4** — the two legs that run `AlRunner.Tests` — with five `VanishedApp_EveryWalkSkipsItRatherThanRefusing` rows failing `Assert.Empty() Failure: Collection was not empty`. Identical set on both legs, so not a flake. 27.0 passed because that leg skips the C# suite.

The collection held the **platform System package's own symbols**: `AppId = 8874ed3a-0643-4247-9ced-7a7002f7135d`, `AppName = System`, tables `2000000069 Add-in` / `2000000001 Object` / `2000000071 Object Metadata`, codeunits `2000000003 Company Triggers` / `2000000012 Environment Triggers`, pages `2000000100 Agent Tasks` and friends.

That is a defect in the test, not in the fix. `RegisterSystemAppPackage()` puts the platform SystemApp package into `_bcAppPaths` once per process at engine bootstrap, and `ResetForReload` **deliberately keeps it** — see `ClearPerBundleBcAppPaths` and #2755, where dropping it unregistered the NCL-internal system tables for the rest of a `--server` process. So the registered set is never only what a test registered, and `Assert.Empty` over the whole walk was asserting something that only holds on a process with no BC engine. It passed locally for exactly that reason. Five of the seven walks failed rather than all seven, because the System package declares no reports and no profiles.

Fixed by scoping the assertion to the fixture instead of the process: a `FixtureItems(walk)` filter with one arm per walk item type, an unrecognised type **throwing** rather than answering `false` (a filter that silently stopped matching would make every row a tautology), and a positive control inside each row so "the fixture contributes nothing" is only claimed after the same filter demonstrably found it one line earlier. `HealthyApp_EveryWalkYieldsItsSymbols` got the same treatment — a bare `NotEmpty` there was satisfied by the System package alone, so that row could pass without the fixture's `.app` ever being read. #3031's sibling file already scoped this way (`Assert.DoesNotContain("BUG3031 VANISH", …)`); this file was the only place with the global shape.

### Reproduced and re-proved locally, in the configuration the legs use

Running the class alone never reproduced it. Running it alongside `BcAppPathsResetTests`, with CI's own recipe — warm the `ncl-cecil` cache with a real runner invocation, copy the rewritten `Ncl.dll` into `AlRunner.Tests/bin`, and drive `dotnet test` through the `DOTNET_STARTUP_HOOKS` runsettings from `bc-tests.yml` — reproduced it exactly: **5 failed / 31 passed**, the same five rows with the same message.

* **RED**: as above, 5 failures.
* **GREEN**: same pair, **36/36**; with the related classes (`DependencyAppSymbolWalkSourceGuardTests`, both permission-slice read-failure classes, `BcAppPathsResetTests`), **48/48**, engine ready and nothing skipped.
* **The guard still guards.** Disabled the vanished skip in `EnumerateRegisteredBcAppSymbols` (`if (!File.Exists(appPath))` → `if (false)`), so a vanished `.app` refuses again as it did before #3143: **all seven** `VanishedApp_*` walk rows fail, plus `VanishedApp_WarningSurvivesLogsDefaultFilter`, each with `BcAppSymbolReadException: symbol-read-fail vanishing.app: could not read its objects (AllObj) … FileNotFoundException`. Restored, green again. The scoped assertion is not weaker than the one it replaced: it catches the regression on all seven walks, where the old one only had five that could observe anything.
* **Full `AlRunner.Tests`, not a filter** — this is what hid the bug in the first place. **3694 passed, 0 failed, 0 skipped**, 15m45s, in the same startup-hook configuration, at head `cc832e5e`.

Rebased twice while this was in flight — the numbers above were measured at `1301843d`, then `main` took #3242, #3244, #3128 and #3240, so the branch was rebased again onto `65e5e562` and the targeted set re-run rather than carried across: **147/147**, engine ready, nothing skipped, over `DependencySymbolReadFailureTests`, `DependencyAppSymbolWalkSourceGuardTests`, both permission-slice read-failure classes, `BcAppPathsResetTests`, and the two classes `main` added over the same virtual tables (`MetadataOptionColumnOrdinalTests`, `VirtualTableRefusalClaimTests`). The diff touches only the 13 files listed above — nothing under `.github/`, `.claude/` or `tools/`. No expectations or count-baseline change in this PR, so the baseline figures are untouched.

## Not fixed here

`NavMethodScope_AssertError` (`MethodScopePatches.cs:386`) rethrows only `BcShapeGapException`, so AL `asserterror` catches the new `BcAppSymbolReadException` and could turn a corrupt-dependency test green. Inherited, not created here — `RunnerOutOfScopeException` is equally catchable there today — and tracked in #3241. Deliberately out of scope for this PR.

---
Opened by an automated agent (`impl-26`) acting on the account holder's behalf.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf

