### PR TITLE
fix(testpage): apply a RunObject action's RunPageLink instead of refusing it

### DIFF
--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -176,11 +176,15 @@ internal static partial class BcAppSymbolCache
     // effect at all, the exact pre-fix behaviour replayed from cache rather than a cache miss.
     // That is a wrong ANSWER, so it needs the bump.
     // v32: ActionRunObjectSymbol gained the PARSED RunPageLink and its declared entry count
-    // (#2942) — it used to record only that a link was present, which was enough to refuse the
-    // action and is not enough to apply it. A v31 payload deserialises RunPageLink as null and
-    // DeclaredRunPageLinkEntries as 0, which RunnerPageInstance.ResolveRunTargetFromSymbols
-    // reads as "this action declares no link" — so a linked action would open its target on the
-    // WHOLE table, replayed from cache. That is a wrong answer, so it needs the bump.
+    // (#2942) — it used to record only that a link was PRESENT, which was enough to refuse the
+    // action and is not enough to apply it. Both halves of the rule above are true of this one
+    // at once. The record's SHAPE changed and ActionRunObjectSymbol is reachable from
+    // CachePayload, so PayloadShape already gives it a different key on its own; and the PARSE
+    // changed too, because the RunPageLink property text was read for presence only and is now
+    // read for content. The bump is the explicit statement of the second half, which no
+    // structural hash can see. Without the key changing, a stale payload would answer
+    // DeclaredRunPageLinkEntries = 0 — which RunnerPageInstance.ResolveRunTargetFromSymbols
+    // reads as "this action declares no link", opening the target on its WHOLE table.
     private const int CacheVersion = 32;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
     // Issue #1820's path -> content-hash memo now lives in

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -175,7 +175,13 @@ internal static partial class BcAppSymbolCache
     // declares no RunObject" — and a TestPage that invokes one is then refused as declaring no
     // effect at all, the exact pre-fix behaviour replayed from cache rather than a cache miss.
     // That is a wrong ANSWER, so it needs the bump.
-    private const int CacheVersion = 31;
+    // v32: ActionRunObjectSymbol gained the PARSED RunPageLink and its declared entry count
+    // (#2942) — it used to record only that a link was present, which was enough to refuse the
+    // action and is not enough to apply it. A v31 payload deserialises RunPageLink as null and
+    // DeclaredRunPageLinkEntries as 0, which RunnerPageInstance.ResolveRunTargetFromSymbols
+    // reads as "this action declares no link" — so a linked action would open its target on the
+    // WHOLE table, replayed from cache. That is a wrong answer, so it needs the bump.
+    private const int CacheVersion = 32;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
     // Issue #1820's path -> content-hash memo now lives in
     // RunnerFingerprint._fileContentHashes (#2955), because AppLoader's persisted r2r-chunks
@@ -401,12 +407,27 @@ internal static partial class BcAppSymbolCache
     /// a precompiled page this is all there is and the consumer resolves the name against the
     /// run's own page inventory — see RunnerPageInstance.ResolveRunTargetFromSymbols.</para>
     ///
-    /// <para><c>HasRunPageLink</c> records only the PRESENCE of a <c>RunPageLink</c>, not its
-    /// content: the runner does not apply an action's link filters yet, and opening the target
-    /// without them would show a different rowset than real BC, so presence alone is what the
-    /// consumer needs in order to refuse loudly instead.</para>
+    /// <para><c>RunPageLink</c> is the action's link, parsed out of the same AL property text
+    /// a part's <c>SubPageLink</c> comes in — the grammar is identical, so
+    /// <c>ParseSubPageLink</c> reads both — and still unresolved: the field NAMES have to be
+    /// turned into numbers against the TARGET's and the HOST's source tables, which needs the
+    /// page inventory this layer does not have. RunnerPageInstance.ResolveRunTargetFromSymbols
+    /// does that (issue #2942).</para>
+    ///
+    /// <para><c>DeclaredRunPageLinkEntries</c> is how many top-level entries the property text
+    /// actually declared, which is NOT always <c>RunPageLink.Count</c>: an entry the parser does
+    /// not understand is dropped with a note on stderr. The consumer compares the two and
+    /// refuses when they differ, because a link applied with one entry missing selects MORE rows
+    /// than BC would — a silent wrong answer, not a smaller one.</para>
     /// </summary>
-    internal sealed record ActionRunObjectSymbol(string ObjectName, bool RunPageOnRec, bool HasRunPageLink);
+    internal sealed record ActionRunObjectSymbol(
+        string ObjectName,
+        bool RunPageOnRec,
+        int DeclaredRunPageLinkEntries,
+        List<PageSubFormLinkSymbol>? RunPageLink = null)
+    {
+        internal bool HasRunPageLink => DeclaredRunPageLinkEntries > 0;
+    }
 
     /// <summary>
     /// A precompiled dependency's <c>pageextension</c>, as far as SymbolReference.json states
@@ -1244,12 +1265,24 @@ internal static partial class BcAppSymbolCache
         var props = SymbolProperties(node);
         if (!props.TryGetValue("RunObject", out var runObject) || string.IsNullOrWhiteSpace(runObject))
             return null;
+        var hasLink = props.TryGetValue("RunPageLink", out var link) && !string.IsNullOrWhiteSpace(link);
+        var declaredEntries = 0;
+        List<PageSubFormLinkSymbol>? parsedLink = null;
+        if (hasLink)
+        {
+            foreach (var entry in SplitTopLevelCommas(link!))
+                if (entry.Trim().Length > 0) declaredEntries++;
+            // Same grammar as a part's SubPageLink -- `"Field" = field("Other")`, `= const(X)`,
+            // `= filter(A|B)`, comma-separated -- so the same parser reads it (issue #2942).
+            parsedLink = ParseSubPageLink(link);
+        }
         return new ActionRunObjectSymbol(
             runObject!,
             // AL's default is false, so only an explicit "1"/"true" sets it — the compiler
             // writes RunPageOnRec = "1" for `RunPageOnRec = true`.
             SymbolBool(props, "RunPageOnRec"),
-            props.TryGetValue("RunPageLink", out var link) && !string.IsNullOrWhiteSpace(link));
+            declaredEntries,
+            parsedLink);
     }
 
     /// <summary>

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -3284,7 +3284,7 @@ internal sealed class LiveNavTestPart : LiveNavTestPage, ITestPart
     /// SetFilter call would pass. A field the part's table does not declare is left to
     /// SetFilter, which refuses it with BC's own error naming the field number.
     /// </summary>
-    private static string ConstFilterExpression(NavRecord record, int fieldNo, string value)
+    internal static string ConstFilterExpression(NavRecord record, int fieldNo, string value)
     {
         var navType = record.MetaTable.TryGetFieldByNo(fieldNo, out var field) ? field.FieldNavType : (NavType?)null;
         var quote = value.Length == 0 || navType is NavType.Text or NavType.Code;

--- a/AlRunner/Patches/RunnerPageInstance.ActionRunObject.cs
+++ b/AlRunner/Patches/RunnerPageInstance.ActionRunObject.cs
@@ -49,13 +49,37 @@
 //   `Page.Run` / `Page.RunModal` reaches them, so a RunObject action and the equivalent AL call
 //   cannot drift apart.
 //
+// RUNPAGELINK (issue #2942)
+//   A third of the Base Application's RunObject actions carry one: measured over all 5,668
+//   action `RunObject` declarations in Base Application 28.1's SymbolReference.json, 1,819 also
+//   declare `RunPageLink` — and ZERO of them declare `RunPageOnRec` alongside it.
+//
+//   BC applies the link as ordinary table filters on the TARGET's rowset, not as anything
+//   action-specific. `ActionBuilder.GetApplicationFilters` copies every
+//   `ActionDefinition.RunFormLink.TableFilters` entry into the action's
+//   `ApplicationActionFilterContext`, and `NavOpenTaskPageAction.CreateForm` calls
+//   `FilterContext.SetFilterContext(formState, parentBindingManager)` — which turns each
+//   `FilterDefinition` into a `NavFilter` through `NavFilterHelper.AddFilter`, resolving a FIELD
+//   entry against the HOST's current row — and only THEN, separately and unconditionally, stamps
+//   `RunFormOnRecordField`'s bookmark. So the two are independent steps that both run, which is
+//   why this file applies the link and the record together rather than treating them as
+//   alternatives.
+//
+//   Here the same thing is expressed as AL would: the target's own record cursor, filtered, handed
+//   to `NavForm.RunAsync` / `RunModalAsync` exactly as `Rec.SetRange(...); Page.Run(id, Rec)`
+//   does. FIELD reads the host's field value, CONST filters to a literal, FILTER hands BC's own
+//   filter parser the compiled expression — the same three kinds, applied the same way, as
+//   `LiveNavTestPart.ApplyLink` already applies a part's SubPageLink, and the CONST quoting rule
+//   is literally shared with it (`LiveNavTestPart.ConstFilterExpression`).
+//
 // WHAT IS STILL REFUSED, LOUDLY
-//   RunObject targeting a Report / Codeunit / XmlPort / Query, and `RunPageLink` (a page target
-//   whose rowset the platform filters from the host's fields). Both raise with a
+//   RunObject targeting a Report / Codeunit / XmlPort / Query. It raises with a
 //   `not-yet-implemented` reason anchor, which `docs/expectations.md` lets a manifest track as
 //   `expect-fail-known-gap` against an OPEN issue — the classification the old `testpage-action`
-//   anchor made impossible. Answering either by opening the page unfiltered would be a silent
-//   wrong answer, which is what `loud-failures.md` exists to prevent.
+//   anchor made impossible. Answering it by opening something else would be a silent wrong
+//   answer, which is what `loud-failures.md` exists to prevent. The same applies to a link whose
+//   fields this run cannot resolve to numbers: a link that cannot be applied is refused by name,
+//   never dropped, because a dropped link shows the target's WHOLE table.
 using Microsoft.Dynamics.Nav.Runtime;
 using MetaTypes = Microsoft.Dynamics.Nav.Types.Metadata;
 
@@ -74,7 +98,25 @@ internal sealed partial class RunnerPageInstance
         int ObjectId,
         string? ObjectName,
         bool RunPageOnRec,
-        bool HasRunPageLink);
+        IReadOnlyList<ActionRunLink> Links);
+
+    /// <summary>
+    /// One entry of an action's <c>RunPageLink</c>, resolved to the three things applying it
+    /// needs. Deliberately the same triple <c>MockTestPage.SubPageLinkEntry</c> carries for a
+    /// part's <c>SubPageLink</c>, because BC represents both as a <c>FilterDefinition</c> list
+    /// and the runner applies both the same way.
+    ///
+    /// <para><paramref name="HostFieldNo"/> is meaningful only for <c>FIELD</c> (it names a
+    /// field on the HOST's source table, whose current value becomes the filter);
+    /// <paramref name="Value"/> only for <c>CONST</c> and <c>FILTER</c>.</para>
+    /// </summary>
+    private readonly record struct ActionRunLink(
+        int TargetFieldNo,
+        MetaTypes.FilterType Kind,
+        int HostFieldNo,
+        string Value);
+
+    private static readonly IReadOnlyList<ActionRunLink> NoLinks = Array.Empty<ActionRunLink>();
 
     /// <summary>
     /// Perform <paramref name="actionId"/>'s RunObject, if it declares one.
@@ -96,14 +138,6 @@ internal sealed partial class RunnerPageInstance
                 + "PAGE so far. Opening a report, codeunit, xmlport or query from an action is "
                 + "tracked by issue #2943");
 
-        if (target.HasRunPageLink)
-            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
-                $"TestPage action {actionId} on page {_pageId}",
-                $"not-yet-implemented — the action declares RunObject = Page {Describe(target)} "
-                + "together with RunPageLink, and the runner does not yet apply an action's "
-                + "RunPageLink filters. Opening the page WITHOUT them would show a different "
-                + "rowset than real BC, so it is refused instead; tracked by issue #2942");
-
         if (target.ObjectId <= 0)
             throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
                 $"TestPage action {actionId} on page {_pageId}",
@@ -113,7 +147,7 @@ internal sealed partial class RunnerPageInstance
                 + "only, with no object type) or a page that is not loaded, and the runner will "
                 + "not guess which; tracked by issue #2943");
 
-        RunTargetPage(target.ObjectId, target.RunPageOnRec);
+        RunTargetPage(actionId, target);
         return true;
     }
 
@@ -127,13 +161,20 @@ internal sealed partial class RunnerPageInstance
     /// lookup, <c>TestPage.Trap()</c> and the "Unhandled UI" refusal are BC's and not a second
     /// implementation of them.
     ///
-    /// <para><paramref name="runPageOnRec"/> is AL's <c>RunPageOnRec</c>: true hands the target
-    /// the host page's CURRENT record — the runner's equivalent of the bookmark BC stamps onto
-    /// the target's form state — false opens the page on its own rowset.</para>
+    /// <para><c>RunPageOnRec</c> is AL's: true hands the target the host page's CURRENT record —
+    /// the runner's equivalent of the bookmark BC stamps onto the target's form state — false
+    /// opens the page on its own rowset. A <c>RunPageLink</c> is applied on top of either, as
+    /// filters on the TARGET's own cursor, which is what BC's <c>CreateForm</c> does with the
+    /// two in that order (see this file's header).</para>
     /// </summary>
-    private void RunTargetPage(int pageId, bool runPageOnRec)
+    private void RunTargetPage(int actionId, ActionRunTarget target)
     {
-        var record = runPageOnRec ? _record : null;
+        var pageId = target.ObjectId;
+        var runPageOnRec = target.RunPageOnRec;
+
+        var record = target.Links.Count > 0
+            ? BuildLinkedTargetRecord(actionId, target)
+            : (runPageOnRec ? _record : null);
 
         if (TargetPageOpensModally(pageId))
         {
@@ -150,6 +191,125 @@ internal sealed partial class RunnerPageInstance
             NavForm.RunAsync(pageId, record).AsTask().GetAwaiter().GetResult();
         else
             NavForm.RunAsync(pageId).AsTask().GetAwaiter().GetResult();
+    }
+
+    /// <summary>
+    /// The TARGET page's own record cursor with the action's <c>RunPageLink</c> applied to it,
+    /// which is what makes the target open on the linked rowset instead of its whole table.
+    ///
+    /// <para>A fresh cursor, never the host's own: the host's <c>_record</c> is the live cursor
+    /// the TestPage under test is sitting on, and calling <c>SetRange</c> on it would move the
+    /// host's rowset out from under the test — the same reason
+    /// <c>LiveNavTestPart</c> keeps the part's cursor and the parent's separate.</para>
+    ///
+    /// <para>With <c>RunPageOnRec = true</c> the host's current POSITION is carried onto that
+    /// fresh cursor before the filters go on, mirroring the order BC's
+    /// <c>NavOpenTaskPageAction.CreateForm</c> uses (<c>SetFilterContext</c>, then
+    /// <c>SetBookmark</c> from the parent binding manager's current row). That combination is
+    /// only expressible when the two pages share a source table — <c>RunPageOnRec</c> hands the
+    /// target the host's record — so a target on a different table is refused by name rather
+    /// than opened on a position that means nothing there.</para>
+    /// </summary>
+    private NavRecord BuildLinkedTargetRecord(int actionId, ActionRunTarget target)
+    {
+        var pageId = target.ObjectId;
+        var tableId = RecordPatches.ResolveSourceTableIdForAnyPage(pageId);
+        if (tableId == 0)
+            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                $"TestPage action {actionId} on page {_pageId}",
+                $"not-yet-implemented — the action declares RunObject = Page {Describe(target)} "
+                + "with a RunPageLink, but the target page has no SourceTable this run can "
+                + "resolve, so there is no rowset for the link to filter. Opening it without the "
+                + "link would show a different rowset than real BC");
+
+        var isTemporary = RecordPatches.ResolveSourceTableTemporaryForAnyPage(pageId);
+        var record = TestPageFactory.TryBuildBlankRecord(_owner, tableId, isTemporary, out var why);
+        if (record == null)
+            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                $"TestPage action {actionId} on page {_pageId}",
+                $"not-yet-implemented — the action declares RunObject = Page {Describe(target)} "
+                + $"with a RunPageLink, and the runner could not build a cursor for its "
+                + $"SourceTable {tableId} to apply the link to ({why})");
+
+        if (target.RunPageOnRec)
+        {
+            if (_record == null || _record.TableID != tableId)
+                throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                    $"TestPage action {actionId} on page {_pageId}",
+                    $"not-yet-implemented — the action declares RunObject = Page {Describe(target)} "
+                    + "with both RunPageOnRec and a RunPageLink, but the target's SourceTable "
+                    + $"({tableId}) is not the host's ({_record?.TableID.ToString() ?? "none"}), "
+                    + "so there is no host row to open the target on");
+
+            // useCaptions: false for the same reason LiveNavTestPage.GetBookmark uses it — the
+            // captioned encoding round-trips through field captions, which is a display concern
+            // and not the identity of a row.
+            var position = _record.ALGetPosition(useCaptions: false);
+            if (!string.IsNullOrEmpty(position)) record.ALSetPosition(position);
+        }
+
+        foreach (var link in target.Links)
+            ApplyActionRunLink(actionId, target, record, link);
+
+        return record;
+    }
+
+    /// <summary>
+    /// Apply one resolved <c>RunPageLink</c> entry to the target's cursor. The three kinds are
+    /// AL's three, applied exactly as <c>LiveNavTestPart.ApplyLink</c> applies a part's
+    /// <c>SubPageLink</c> — a FIELD entry to the host's current value, a CONST entry to its
+    /// literal through the shared quoting rule, a FILTER entry to its expression in BC's own
+    /// filter grammar.
+    ///
+    /// <para>Every unresolvable case throws rather than skipping the entry. A skipped link is
+    /// not "a bit less filtering": it opens the target on its WHOLE table, which is the silent
+    /// wrong answer <c>loud-failures.md</c> exists to prevent.</para>
+    /// </summary>
+    private void ApplyActionRunLink(int actionId, ActionRunTarget target, NavRecord record, ActionRunLink link)
+    {
+        if (link.TargetFieldNo <= 0)
+            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                $"TestPage action {actionId} on page {_pageId}",
+                $"not-yet-implemented — the action declares RunObject = Page {Describe(target)} "
+                + "with a RunPageLink naming a field of the target's table that this run cannot "
+                + "resolve to a field number, so the link cannot be applied and the target would "
+                + "otherwise open on its whole table");
+
+        switch (link.Kind)
+        {
+            case MetaTypes.FilterType.FIELD:
+                if (_record == null || link.HostFieldNo <= 0)
+                    throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                        $"TestPage action {actionId} on page {_pageId}",
+                        $"not-yet-implemented — the action declares RunObject = Page {Describe(target)} "
+                        + $"with RunPageLink field {link.TargetFieldNo} = field(...), which reads a "
+                        + "field of the HOST page's row, and this run has "
+                        + (_record == null
+                            ? "no host record to read it from"
+                            : $"no field number for it (got {link.HostFieldNo})"));
+                record.ALSetRange(link.TargetFieldNo, _record.GetFieldValue(link.HostFieldNo));
+                break;
+
+            case MetaTypes.FilterType.CONST:
+                record.ALSetFilter(link.TargetFieldNo,
+                    LiveNavTestPart.ConstFilterExpression(record, link.TargetFieldNo, link.Value));
+                break;
+
+            case MetaTypes.FilterType.FILTER:
+                // Already in BC's filter grammar — the compiler wrote option members as ordinals,
+                // and the symbols route re-quoted AL identifiers through FilterValueText. BC's own
+                // parser reads it, and a malformed expression raises BC's own
+                // NavInvalidFilterExpressionException naming the text.
+                record.ALSetFilter(link.TargetFieldNo, link.Value);
+                break;
+
+            default:
+                throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                    $"TestPage action {actionId} on page {_pageId}",
+                    $"not-yet-implemented — the action declares RunObject = Page {Describe(target)} "
+                    + $"with a RunPageLink entry of kind {link.Kind}, which is not one of AL's "
+                    + "three link kinds (field / const / filter)");
+        }
     }
 
     /// <summary>
@@ -231,7 +391,36 @@ internal sealed partial class RunnerPageInstance
             action.TargetID,
             RecordPatches.TryGetAnyPageName(action.TargetID),
             action.RunPageOnRec,
-            action.RunFormLink?.TableFilters is { Count: > 0 });
+            LinksFromMetadata(action));
+    }
+
+    /// <summary>
+    /// The action's <c>RunPageLink</c> as BC's own compiled metadata already carries it: a
+    /// <c>FilterDefinition</c> per entry, with the target's field NUMBER in <c>FieldID</c>, the
+    /// kind in <c>FilterType</c>, and in <c>FilterValue</c> either the HOST's field number (for
+    /// <c>FIELD</c>) or the compiled literal / expression. Nothing is re-derived from AL text on
+    /// this route — the compiler resolved all of it.
+    ///
+    /// <para>A <c>FIELD</c> entry whose <c>FilterValue</c> is not a number is passed through with
+    /// <c>HostFieldNo</c> 0, which <see cref="ApplyActionRunLink"/> refuses by name. Same
+    /// convention as <c>MockTestPage.SubPageLinks</c>, and for the same reason: an entry that
+    /// cannot be applied must be loud, not dropped.</para>
+    /// </summary>
+    private static IReadOnlyList<ActionRunLink> LinksFromMetadata(MetaTypes.ActionDefinition action)
+    {
+        var filters = action.RunFormLink?.TableFilters;
+        if (filters is not { Count: > 0 }) return NoLinks;
+
+        var links = new List<ActionRunLink>(filters.Count);
+        foreach (var f in filters)
+        {
+            var hostFieldNo = 0;
+            if (f.FilterType == MetaTypes.FilterType.FIELD)
+                int.TryParse(f.FilterValue, System.Globalization.NumberStyles.Integer,
+                    System.Globalization.CultureInfo.InvariantCulture, out hostFieldNo);
+            links.Add(new ActionRunLink(f.FieldID, f.FilterType, hostFieldNo, f.FilterValue ?? string.Empty));
+        }
+        return links;
     }
 
     /// <summary>
@@ -281,6 +470,64 @@ internal sealed partial class RunnerPageInstance
             pageId,
             spec.ObjectName,
             spec.RunPageOnRec,
-            spec.HasRunPageLink);
+            LinksFromSymbols(actionId, spec, pageId));
+    }
+
+    /// <summary>
+    /// The action's <c>RunPageLink</c> for a PRECOMPILED page, resolved from the AL property
+    /// text SymbolReference.json states to the field NUMBERS applying it needs.
+    ///
+    /// <para>The left-hand side of every entry names a field of the TARGET's source table, and a
+    /// <c>field(...)</c> right-hand side names one of the HOST's — the same two-table resolution
+    /// <c>DependencyPageMetadataXml.EmitSubFormLinkXml</c> already does for a part's
+    /// <c>SubPageLink</c>, through the same
+    /// <c>RecordPatches.TryResolveDependencyFieldId</c>. <c>const(...)</c> and
+    /// <c>filter(...)</c> values go through the same two normalisers as well, so a link means
+    /// the same thing whichever route recovered it.</para>
+    ///
+    /// <para>Refuses rather than returning a partial link, in both directions: a target page
+    /// with no resolvable source table has no rowset to filter, and an entry the parser dropped
+    /// would leave the target showing MORE rows than BC does.</para>
+    /// </summary>
+    private IReadOnlyList<ActionRunLink> LinksFromSymbols(
+        int actionId, BcAppSymbolCache.ActionRunObjectSymbol spec, int targetPageId)
+    {
+        if (!spec.HasRunPageLink) return NoLinks;
+
+        var parsed = spec.RunPageLink;
+        if (parsed == null || parsed.Count != spec.DeclaredRunPageLinkEntries)
+            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                $"TestPage action {actionId} on page {_pageId}",
+                $"not-yet-implemented — the action declares RunObject = '{spec.ObjectName}' with a "
+                + $"RunPageLink of {spec.DeclaredRunPageLinkEntries} entr(ies), and this run "
+                + $"could read {parsed?.Count ?? 0} of them out of the symbol file. Applying the "
+                + "rest alone would show MORE rows than real BC, so it is refused instead");
+
+        var targetTableId = RecordPatches.ResolveSourceTableIdForAnyPage(targetPageId);
+        var hostTableId = RecordPatches.ResolveSourceTableIdForAnyPage(_pageId);
+
+        var links = new List<ActionRunLink>(parsed.Count);
+        foreach (var entry in parsed)
+        {
+            var targetFieldNo = RecordPatches.TryResolveDependencyFieldId(targetTableId, entry.PartFieldName) ?? 0;
+
+            if (string.Equals(entry.Kind, "field", StringComparison.OrdinalIgnoreCase))
+            {
+                var hostFieldName = entry.Value.Trim().Trim('"');
+                var hostFieldNo = RecordPatches.TryResolveDependencyFieldId(hostTableId, hostFieldName) ?? 0;
+                links.Add(new ActionRunLink(targetFieldNo, MetaTypes.FilterType.FIELD, hostFieldNo, hostFieldName));
+            }
+            else if (string.Equals(entry.Kind, "const", StringComparison.OrdinalIgnoreCase))
+            {
+                links.Add(new ActionRunLink(targetFieldNo, MetaTypes.FilterType.CONST, 0,
+                    RecordPatches.NormalizeConstLinkValue(entry.Value)));
+            }
+            else
+            {
+                links.Add(new ActionRunLink(targetFieldNo, MetaTypes.FilterType.FILTER, 0,
+                    RecordPatches.FilterValueText(entry.Value)));
+            }
+        }
+        return links;
     }
 }

--- a/tests/runner-extras/testpage-precompiled-member-names/PmnTests.Codeunit.al
+++ b/tests/runner-extras/testpage-precompiled-member-names/PmnTests.Codeunit.al
@@ -16,8 +16,9 @@
 //   - 9875 "Permission Set Assignments", control "Company Name" (space, OnValidate) Error(EmptyUserNameErr) on a new row
 //   - 710  "Activity Log" + precompiled pageextension 711 "Activity Log Extension", action OpenRelatedRecord
 //                                                            (precompiled pageextension) Message(NoRelatedRecordMsg) on a blank Record ID
-//   - 5098 "Task Card", action "Co&mment"                    (RunObject only) target resolved from
-//                                                            the symbol file; only its RunPageLink refused
+//   - 5098 "Task Card", action "Co&mment"                    (RunObject only) target AND its
+//                                                            three-entry RunPageLink resolved from
+//                                                            the symbol file, then applied
 //   - 31   "Item List", action "Item Substitutions"          (RunObject naming an AMBIGUOUS name)
 codeunit 64571 "PMN Precompiled Member Tests"
 {
@@ -26,6 +27,7 @@ codeunit 64571 "PMN Precompiled Member Tests"
     var
         Assert: Codeunit "PMN Assert";
         CapturedMessage: Text;
+        CapturedComments: Text;
 
     [Test]
     procedure SpacedActionName_OnPrecompiledBasePage_RunsItsOnAction()
@@ -153,39 +155,81 @@ codeunit 64571 "PMN Precompiled Member Tests"
             'the pageextension''s OnAction must run and show NoRelatedRecordMsg');
     end;
 
-    // #2931 changed what this arm proves. The runner now RESOLVES a precompiled page action's
-    // RunObject out of the dependency .app's SymbolReference.json — which states it as a bare
-    // NAME, with no object type — so the refusal is no longer "this page declares no OnAction
-    // trigger" but a precise statement about the ONE property still missing. That the runner
-    // gets as far as naming the target page and its numeric id IS the fix working on a page it
-    // never compiled.
+    // #2931 resolved a precompiled page action's RunObject target out of the dependency .app's
+    // SymbolReference.json, and refused the action anyway because it also carries a RunPageLink
+    // the runner could not apply. #2942 applies it, and this arm is what proves the SYMBOLS
+    // route of that work — the corpus cannot, because a corpus page is source-compiled and
+    // therefore takes the compiled-metadata route instead.
+    //
+    // Page 5098 "Task Card" action "Co&mment" is a genuinely three-entry link, and each entry
+    // is a different kind:
+    //
+    //     RunObject   = Page "Rlshp. Mgt. Comment Sheet"     (5072, over table 5061)
+    //     RunPageLink = "Table Name" = const("To-do"),       an ENUM const, quoted in the AL
+    //                   "No."        = field("Organizer To-do No."),   the HOST's field
+    //                   "Sub No."    = const(0)              an integer const
+    //
+    // The symbol file states all of that as raw AL TEXT with no field numbers, so every name
+    // here has to be resolved against two different tables — the target's (5061) for the
+    // left-hand sides, the host's (5080) for the field(...) right-hand side. Four rows below
+    // are seeded to fail exactly one entry each, so no single entry can be dropped without the
+    // assertion changing.
     [Test]
-    procedure RunObjectOnlyAction_OnPrecompiledBasePage_ResolvesItsTargetAndRefusesOnlyTheLink()
+    [HandlerFunctions('CommentSheetPageHandler')]
+    procedure RunObjectActionWithRunPageLink_OnPrecompiledBasePage_OpensTheTargetFiltered()
     var
+        Task: Record "To-do";
         TaskCard: TestPage "Task Card";
     begin
-        // [GIVEN] "Co&mment" on the Task Card has RunObject and no OnAction at all. Its name
-        // needs mangling too, so it exercises the SAME lookup the arms above fixed. It also
-        // carries RunPageLink, which the runner does not apply yet.
+        // [GIVEN] Two comment lines the link selects, and three that fail one entry each.
+        InsertComment("Rlshp. Mgt. Comment Line Table Name"::"To-do", 'PMN-TASK', 0, 10000, 'MATCH-A');
+        InsertComment("Rlshp. Mgt. Comment Line Table Name"::"To-do", 'PMN-TASK', 0, 20000, 'MATCH-B');
+        // Fails "No." = field("Organizer To-do No.") only.
+        InsertComment("Rlshp. Mgt. Comment Line Table Name"::"To-do", 'PMN-OTHER', 0, 10000, 'WRONG-NO');
+        // Fails "Sub No." = const(0) only.
+        InsertComment("Rlshp. Mgt. Comment Line Table Name"::"To-do", 'PMN-TASK', 1, 10000, 'WRONG-SUBNO');
+        // Fails "Table Name" = const("To-do") only.
+        InsertComment("Rlshp. Mgt. Comment Line Table Name"::Contact, 'PMN-TASK', 0, 10000, 'WRONG-TABLE');
+
+        // [GIVEN] A task whose "Organizer To-do No." is what the field(...) entry reads.
+        Task.Init();
+        Task."No." := 'PMN-TASK';
+        Task."Organizer To-do No." := 'PMN-TASK';
+        // The card's OnAfterGetRecord calls EnableFields -> GetEndDateTime, which builds a
+        // DateTime out of these four and raises "The date is not valid." on a blank Date.
+        Task.Date := Today();
+        Task."Ending Date" := Today();
+        Task."Start Time" := 080000T;
+        Task."Ending Time" := 090000T;
+        Task.Insert(false);
+
         TaskCard.OpenEdit();
+        TaskCard.GotoRecord(Task);
 
-        // [WHEN] It is invoked.
-        asserterror TaskCard."Co&mment".Invoke();
+        // [WHEN] The RunObject action is invoked. It has no OnAction trigger at all, so every
+        // observable effect below is the platform's, not AL's.
+        TaskCard."Co&mment".Invoke();
+        TaskCard.Close();
 
-        // [THEN] The refusal is loud (loud-failures.md — the fix must not turn an unperformable
-        // action into a silent no-op) and it is a GAP, not a boundary: the anchor is
-        // "not-yet-implemented", which docs/expectations.md lets a manifest track against an
-        // open issue, unlike the old "testpage-action" anchor.
-        Assert.ExpectedError('out-of-scope: TestPage action');
-        Assert.ExpectedError('not-yet-implemented');
-        Assert.ExpectedError('RunPageLink');
+        // [THEN] The target opened — and it opened on the LINKED rowset. The three near-miss
+        // rows are the whole point: an implementation that opened page 5072 unfiltered would
+        // report all five, one that dropped the field(...) entry would include WRONG-NO, one
+        // that dropped either const(...) entry would include its row.
+        Assert.AreEqual('MATCH-A,MATCH-B', CapturedComments,
+            'the action''s RunPageLink must filter the target page to the rows it selects');
+    end;
 
-        // [AND] The target itself WAS resolved, by name, out of the precompiled page's symbol
-        // file — which is the half of the work that had no source to read. Asserting the
-        // resolved name and id is what separates "the runner read the declaration" from "the
-        // runner gave up earlier and happened to refuse".
-        Assert.ExpectedError('Rlshp. Mgt. Comment Sheet');
-        Assert.ExpectedError('5072');
+    local procedure InsertComment(TableName: Enum "Rlshp. Mgt. Comment Line Table Name"; No: Code[20]; SubNo: Integer; LineNo: Integer; CommentText: Text[80])
+    var
+        Comment: Record "Rlshp. Mgt. Comment Line";
+    begin
+        Comment.Init();
+        Comment."Table Name" := TableName;
+        Comment."No." := No;
+        Comment."Sub No." := SubNo;
+        Comment."Line No." := LineNo;
+        Comment.Comment := CommentText;
+        Comment.Insert(false);
     end;
 
     // #2931, and the reason the resolution above cannot simply trust a name. A precompiled
@@ -222,5 +266,26 @@ codeunit 64571 "PMN Precompiled Member Tests"
     procedure CaptureMessage(Msg: Text[1024])
     begin
         CapturedMessage := Msg;
+    end;
+
+    // Records every non-blank Comment the target showed, in order. Blank rows are skipped
+    // rather than counted: page 5072 is an editable List, so its TestPage carries the implicit
+    // new-row line, which is not part of the rowset the link selected and would otherwise put
+    // a trailing empty entry into every expected value.
+    [PageHandler]
+    procedure CommentSheetPageHandler(var CommentSheet: TestPage "Rlshp. Mgt. Comment Sheet")
+    var
+        Value: Text;
+    begin
+        CapturedComments := '';
+        if CommentSheet.First() then
+            repeat
+                Value := CommentSheet.Comment.Value();
+                if Value <> '' then begin
+                    if CapturedComments <> '' then
+                        CapturedComments += ',';
+                    CapturedComments += Value;
+                end;
+            until not CommentSheet.Next();
     end;
 }

--- a/tests/runner-extras/testpage-promoted-actionref/ParHostPage.Page.al
+++ b/tests/runner-extras/testpage-promoted-actionref/ParHostPage.Page.al
@@ -8,10 +8,13 @@
 ///                                       PERFORMS this rather than refusing it, so with no
 ///                                       [PageHandler] declared it must fail with BC's own
 ///                                       unhandled-UI error and NOT with a runner refusal.
-///   LinkedPageAction                    the same, plus RunPageLink. The runner does not apply
-///                                       an action's link filters yet, and opening the page
-///                                       WITHOUT them would show a different rowset than real
-///                                       BC, so it refuses -- with a gap anchor.
+///   LinkedPageAction                    the same, plus RunPageLink. Since #2942 the runner
+///                                       applies the link and opens the target on the rowset it
+///                                       selects, so with no [PageHandler] declared this too
+///                                       must reach BC's own unhandled-UI error and not a
+///                                       runner refusal. What the link SELECTS is pinned
+///                                       upstream in the al-language corpus
+///                                       (handlers/TestPageActionRunPageLink.al).
 ///   ReportRunObjectAction               a RunObject naming a REPORT: in scope, not implemented.
 ///   NoEffectAction / NoEffectRef        neither a trigger nor a RunObject, so genuinely
 ///                                       nothing to run; the refusal that names the actionref's

--- a/tests/runner-extras/testpage-promoted-actionref/ParTests.Codeunit.al
+++ b/tests/runner-extras/testpage-promoted-actionref/ParTests.Codeunit.al
@@ -19,9 +19,9 @@
 /// a RunObject, and the runner now PERFORMS a RunObject that names a page, so the two arms that
 /// used to assert a runner refusal for `RunObject = page ...` would have kept a fixed defect
 /// pinned as correct. They now assert the opposite -- that no runner refusal is raised and BC's
-/// own unhandled-UI error comes through instead -- and the refusal claim moved onto the three
-/// shapes the runner genuinely still declines: a RunObject naming a REPORT, one carrying a
-/// RunPageLink, and an action declaring no effect at all.
+/// own unhandled-UI error comes through instead -- and the refusal claim moved onto the shapes
+/// the runner genuinely still declines: a RunObject naming a REPORT, and an action declaring no
+/// effect at all. #2942 moved the RunPageLink arm across the same way, for the same reason.
 ///
 /// The plain-BC half of the first eight arms is covered upstream in the al-language corpus:
 /// StefanMaron/BusinessCentral.AL.Language.Tests#79, commit c98be548, green on real BC 27.5
@@ -217,12 +217,18 @@ codeunit 64545 "Par Tests"
             'the runner must no longer raise a refusal of its own for an actionref to a RunObject page action');
     end;
 
-    // Runner-specific, #2931: RunPageLink is not applied yet. Opening the page WITHOUT its link
-    // filters would show a different rowset than real BC — a silent wrong answer — so it is
-    // refused instead, and the reason anchor says "not-yet-implemented" so an expectations entry
-    // can track it as a gap against an open issue rather than as a permanent boundary.
+    // #2942 changed what this arm proves, the same way #2931 changed the two above it. The
+    // runner used to refuse a RunObject action carrying a RunPageLink, because opening the page
+    // without its link filters would have shown a different rowset than real BC. It now APPLIES
+    // the link, so this arm asserts the opposite: no runner refusal of its own, and BC's own
+    // unhandled-UI error comes through exactly as it does for the unlinked TriggerlessAction.
+    //
+    // What the link SELECTS is plain BC behaviour, so it is proven upstream rather than here --
+    // StefanMaron/BusinessCentral.AL.Language.Tests, handlers/TestPageActionRunPageLink.al,
+    // six arms over field / const / filter links, an unlinked control and an empty rowset. The
+    // claim that stays runner-specific is this one: that the runner raises nothing itself.
     [Test]
-    procedure RunObjectWithRunPageLinkRefusesAsANotYetImplementedGap()
+    procedure RunObjectWithRunPageLinkIsPerformedWithoutARunnerRefusal()
     var
         HostPage: TestPage "Par Host Page";
     begin
@@ -231,12 +237,12 @@ codeunit 64545 "Par Tests"
         HostPage.OpenEdit();
         asserterror HostPage.LinkedPageAction.Invoke();
 
-        Assert.Contains(GetLastErrorText(), 'not-yet-implemented',
-            'an unapplied RunPageLink must be refused with a gap anchor, not a permanent-boundary one');
-        Assert.Contains(GetLastErrorText(), 'RunPageLink',
-            'the refusal must name RunPageLink as the reason, so the reader knows what is missing');
-        Assert.Contains(GetLastErrorText(), '2942',
-            'the refusal must cite the OPEN issue tracking the gap, not the one whose fix closed');
+        Assert.Contains(GetLastErrorText(), 'Unhandled UI',
+            'a RunObject action carrying a RunPageLink must reach BC''s own page dispatch');
+        Assert.NotContains(GetLastErrorText(), 'out-of-scope',
+            'the runner must no longer raise a refusal of its own for an action''s RunPageLink');
+        Assert.NotContains(GetLastErrorText(), 'not-yet-implemented',
+            'the RunPageLink gap is closed, so nothing may still be anchored as one');
     end;
 
     // Runner-specific, #2931: only a RunObject naming a PAGE is performed so far. A report


### PR DESCRIPTION
Closes #2942

A page action whose effect is `RunObject` was refused outright whenever it also carried a `RunPageLink`, because opening the target without the link would have shown a different rowset than real BC. It now applies the link.

Measured on Base Application 28.1's `SymbolReference.json`, over all 5,668 action `RunObject` declarations: **1,819 carry a `RunPageLink`** — about a third — and **zero carry `RunPageOnRec` alongside one**.

## What BC does, and where that came from

`ActionBuilder.GetApplicationFilters` (`Microsoft.Dynamics.Nav.Client.Builder.dll`, 28.1) copies every `ActionDefinition.RunFormLink.TableFilters` entry into the action's `ApplicationActionFilterContext`. `NavOpenTaskPageAction.CreateForm` (`Microsoft.Dynamics.Nav.Client.UI.dll`) then calls `FilterContext.SetFilterContext(formState, parentBindingManager)`, which turns each `FilterDefinition` into a `NavFilter` through `NavFilterHelper.AddFilter` — resolving a `FIELD` entry against the host's current row — and **only afterwards**, separately and unconditionally, stamps `RunFormOnRecordField`'s bookmark. So the link and `RunPageOnRec` are two independent steps that both run, not alternatives.

That reading is a starting point, not the verdict. The verdict is the corpus.

## The corpus verdict

**StefanMaron/BusinessCentral.AL.Language.Tests#211** — `handlers/TestPageActionRunPageLink.al`, six arms, new fixtures 60462-60468. **All 16 legs green on a real service tier** (8 cloud + 8 OnPrem, run `34054210019`), and the per-test `PASS` lines are in the log on all eight cloud versions, so the legs ran the tests rather than skipping the codeunit.

| arm | what it settles |
|---|---|
| no link at all | the control — makes "opened unfiltered" a visible different answer |
| `field("No.")` | the target is filtered to the host's current row |
| `const('H1')` | the literal wins over the host's row (the host sits on H2) |
| `filter('H1'\|'H3')` | a filter expression is applied as an expression |
| a link selecting nothing | the target opens EMPTY — no fallback to the whole table, no refusal |
| `field("No.")` + `RunPageOnRec = true` | the combination shows the host's row alone |

The last three were the open questions in the issue body. The corpus answers all of them.

## What changed

- `AlRunner/Patches/RunnerPageInstance.ActionRunObject.cs` — `ActionRunTarget` carries resolved link entries instead of a `HasRunPageLink` flag. `BuildLinkedTargetRecord` builds the TARGET's own cursor (never the host's live one — `SetRange` on that would move the rowset under the TestPage), carries the host's position onto it when `RunPageOnRec` is set, then applies the link. `ApplyActionRunLink` handles the three AL kinds exactly as `LiveNavTestPart.ApplyLink` handles a part's `SubPageLink`, and shares its CONST quoting rule (`LiveNavTestPart.ConstFilterExpression`, made `internal`).
- `AlRunner/Patches/BcAppSymbolCache.cs` — for a page that ships **precompiled**, the symbol file states `RunPageLink` as raw AL text, so `ActionRunObjectSymbol` now carries the parsed entries (same grammar as `SubPageLink`, same `ParseSubPageLink`) plus the count the property text declared. `CacheVersion` 31 → 32.
- Field names are resolved to numbers against two different tables — the target's for every left-hand side, the host's for a `field(...)` right-hand side — through the same `RecordPatches.TryResolveDependencyFieldId` that `EmitSubFormLinkXml` already uses for a part link.

**Nothing is ever dropped silently.** An unresolvable field, a target with no source table, a `RunPageOnRec` whose target is on a different table, or a parse that recovered fewer entries than the property declared — each throws `RunnerOutOfScopeException` naming the reason. A dropped link is not "less filtering", it opens the target on its whole table.

## RED → GREEN

**Corpus (compiled-metadata route)**, against my corpus branch with `--cache` outside the repository:

- RED: 5 of 6 arms raised `not-yet-implemented — … together with RunPageLink … tracked by issue #2942`; the unlinked control passed.
- GREEN: 6/6.
- Proving check: with the `ApplyActionRunLink` loop commented out and everything else in place, all five link arms fail with concrete wrong values — `H1-L1,H1-L2,H2-L1,H2-L2,H3-L1` where `H2-L1,H2-L2` was expected, `5` rows where `0` was expected, and so on — while the control still passes.

**`tests/runner-extras/testpage-precompiled-member-names` (symbols route)** — the arm on Base Application page 5098 "Task Card", action `Co&mment`, which is a real three-entry link with one entry of each shape:

```
RunObject   = Page "Rlshp. Mgt. Comment Sheet"          (5072, over table 5061)
RunPageLink = "Table Name" = const("To-do"),            an ENUM const, quoted in the AL
              "No."        = field("Organizer To-do No."),  the HOST's field
              "Sub No."    = const(0)                   an integer const
```

- RED: `Unexpected out-of-scope … RunPageLink … tracked by issue #2942` before the fix; the arm asserted that refusal.
- GREEN: the arm now seeds two matching comment lines and **three near-misses that each fail exactly one entry**, and asserts `MATCH-A,MATCH-B`.
- Proving check: with links dropped it reports `WRONG-TABLE,WRONG-NO,MATCH-A,MATCH-B,WRONG-SUBNO`.

**`tests/runner-extras/testpage-promoted-actionref`** — `RunObjectWithRunPageLinkRefusesAsANotYetImplementedGap` was the third RED site. It is rewritten the same way #2931 rewrote its two siblings: the runner must raise nothing of its own and BC's unhandled-UI error must come through. What the link selects is not re-asserted here — that claim is upstream.

## Suites run in this state

- Pinned corpus: **2676/2676** (`--strict --count-baseline`).
- All of `tests/runner-extras`: **312/312** (`--strict`).
- `dotnet test AlRunner.Tests --filter "…TestPageRefusalClaim|…RunnerOutOfScopeMessagePointer|…ActionRefTargetParser|…PrecompiledPageMemberName|…BcAppSymbolCache"`: 141 passed.
- `dotnet test AlRunner.Tests --filter "…Cache|…TestPage|…Symbol"`: 538 passed, 18 skipped.

## The pin bump is deliberately not here

Corpus #211 is green but not merged, and I do not merge corpus PRs. Pinning the submodule at a branch commit that a squash-merge will rewrite would point it at an orphan. Once #211 merges, the pin bump and the `count-baseline` update belong in this PR — or in the merge order the coordinator prefers. The runner change is provable without it: the two `runner-extras` arms above are in this diff and go RED → GREEN on their own.

## Fixing the shape, not the reported line

- **Another call site with the same pattern?** `TryRunActionRunObject` is the only site that consumes an action's `RunObject`, and both of its recovery routes (compiled metadata, symbol file) are fixed here — fixing only the metadata one would have left the 1,819 Base Application sites, which are all precompiled, still refusing.
- **A sibling function with the same blind spot?** `LiveNavTestPart.ApplyLink` is the sibling, and it already did this correctly for a part's `SubPageLink`; the CONST quoting rule is now literally shared rather than copied. `RecordPatches.ApplySourceTableViewFilters` is the third consumer of the same `FilterDefinition` shape and was already correct.
- **Two paths writing the same state?** The metadata route gets field numbers from the compiler and the symbols route resolves them from names, so only the symbols route can come up short — which is why it carries the declared-entry-count check the metadata route does not need.

## The rest of the queue in this area — checked, not folded

Scanned per `.claude/rules/batch-sibling-issues-by-file.md`. Only one issue lands in `RunnerPageInstance.ActionRunObject.cs`, and it is this one.

- **#2943** (a `RunObject` naming a report / codeunit / xmlport / query) touches the same file and the same `if` — I deliberately left it. Its own body says none of its four kinds is worth landing without a service-tier verdict, and they are four different verdicts about four different dispatch entry points (`[RequestPageHandler]` vs `[ReportHandler]` for a report, which record a codeunit target gets, whether an xmlport shows a request page, what "opening a query" is in a test session). Folding it in would put two subjects and five corpus arms of unrelated reasoning in one review. The refusal message it produces is untouched.
- **#3059** (`TestPage.Cancel()` offered on a Worksheet page) is a different subsystem — `MockTestPage.LiveNavTestPage.Offers` — and it is **already fixed on `main`**, by #3152. I verified rather than assumed: `HasDialogCancelAffordance` returns false for `Worksheet`, `AlRunner.Tests/TestPageBuiltInCancelAffordanceTests.cs` pins it, and the corpus arm on the very page #3059 names — `PlainModal_HasNoBuiltInCancelAction` on "MQC Trace Modal" — passes against the current pin. Closed with that reasoning on the issue.
- **#3029** (OnNewRecord raised twice), **#2964** (`MoveLast` and the implicit new-row line), **#3009** (`ValidationErrorCount` hardcoded at page level) all land in `MockTestPage.cs`, not here, and each needs its own diagnosis. Left alone.
- **#3179** and the `OnQueryClosePage` area are being worked on PR #3181. Not touched.

Written by an agent (impl-25).

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf