### PR TITLE
fix(preflight): retry a dropped packet, refuse a stale copy, and report what the token can merge

### DIFF
--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -206,6 +206,12 @@ Two things about the verdicts it produces, because both change what "stop" means
   saying so (a copy predating #2936 calls a healthy box unable to push). It prints the remedy;
   run `origin/main`'s copy. Nothing about the box was probed, so it is not a verdict about the
   box.
+- **The `checkout` check reports how far the tree it is measuring is behind `origin/main`**,
+  for both the checkout preflight is running from and the main checkout, and WARNs past 25
+  commits or a branch point 12 hours old. Anything read out of a checkout is as old as that
+  checkout: a coordinator once diagnosed a repository-wide CI breakage from a tree 40+ commits
+  behind, in which a tool still carried a constant `origin/main` had already renamed, and
+  misdirected four agents before the tree was the suspect.
 - **A single network failure is not a verdict either.** The push probe retries a transport
   failure and reports `1 of 3 attempts` as a WARN rather than failing the box; a genuine
   refusal — permission, authentication, no such repository — still FAILs on the first attempt

--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -199,6 +199,20 @@ check a busy coordinator can decline is not a check — one skipped step 5 acros
 ~20 agents and filled a 7.7 GB tmpfs, after which every shell on the box failed without naming
 the cause.
 
+Two things about the verdicts it produces, because both change what "stop" means:
+
+- **Exit 3 now also means the running copy of `preflight.py` is stale** — `origin/main` moved
+  that file after this checkout branched, so it would report out of an older rulebook without
+  saying so (a copy predating #2936 calls a healthy box unable to push). It prints the remedy;
+  run `origin/main`'s copy. Nothing about the box was probed, so it is not a verdict about the
+  box.
+- **A single network failure is not a verdict either.** The push probe retries a transport
+  failure and reports `1 of 3 attempts` as a WARN rather than failing the box; a genuine
+  refusal — permission, authentication, no such repository — still FAILs on the first attempt
+  and is never retried (#3076). The `github` check WARNs when the token has no `workflow`
+  scope, which is not a reason to stop: it means pull requests touching `.github/workflows/`
+  need a human to merge them, and the loop must not route them differently (#3192).
+
 1. **Known-good baseline — run the corpus.** `tests/al-language` is green or it is not, and its
    expected count lives in `tests/expectations/count-baseline/`, checked in and only moved by a
    PR that deliberately bumps it. That makes it the right health check and means no new baseline

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -1417,6 +1417,106 @@ def check_github(slug: Optional[str]) -> CheckResult:
                        detail=detail, data=data)
 
 
+# --------------------------------------------------------------------------
+# how current the checkout being measured actually is
+# --------------------------------------------------------------------------
+# freshness_refusal() below asks that question about ONE FILE, preflight.py
+# itself. This asks it about the whole checkout, because the same trap catches
+# anything read out of a tree: source, a rule, a workflow.
+#
+# Measured 2026-09-06 on this box, and it cost four agents an hour: a coordinator
+# read `tools/ci-wait.py` out of a top-level checkout that was 40+ commits behind
+# origin/main, found a constant naming a required check that had since been
+# renamed, concluded the tool was returning "could not determine" for every pull
+# request in the repository, and told four agents so. origin/main's copy had been
+# correct the whole time. Nothing warned that the tree was old -- and worktrees on
+# this box branch from whatever main happened to be, so any agent measuring its
+# own tree reproduces it exactly.
+#
+# THRESHOLDS, and why "behind at all" is not one: origin/main moves every ten to
+# forty minutes here, so a handful of commits behind is the normal state of a
+# checkout doing a task, and a warning that fires every time is a warning nobody
+# reads. Tens of commits, or a branch point from yesterday, means the tree was
+# never refreshed. The COUNT is reported either way, which is the part that was
+# missing.
+CHECKOUT_BEHIND_WARN_COMMITS = 25
+CHECKOUT_BEHIND_WARN_HOURS = 12
+
+
+def checkout_lag(label: str, root: str, ref: str = "refs/remotes/origin/main") -> dict:
+    """How far `root` is behind origin/main, and how old its branch point is."""
+    lag = {"label": label, "root": root, "branch": "", "ahead": None, "behind": None,
+           "base_age_hours": None, "error": ""}
+    if not root:
+        lag["error"] = "no checkout"
+        return lag
+    if not run(["git", "-C", root, "rev-parse", "--verify", "--quiet", ref]).out.strip():
+        lag["error"] = f"no {ref} (never fetched, or a shallow clone)"
+        return lag
+    lag["branch"] = run(["git", "-C", root, "rev-parse", "--abbrev-ref", "HEAD"]).out.strip()
+    counts = run(["git", "-C", root, "rev-list", "--left-right", "--count", f"HEAD...{ref}"])
+    parts = counts.out.split()
+    if not counts.ok or len(parts) != 2:
+        lag["error"] = f"could not count commits against {ref}"
+        return lag
+    lag["ahead"], lag["behind"] = int(parts[0]), int(parts[1])
+    base = run(["git", "-C", root, "merge-base", "HEAD", ref]).out.strip()
+    stamp = run(["git", "-C", root, "log", "-1", "--format=%ct", base]).out.strip() if base else ""
+    if stamp.isdigit():
+        lag["base_age_hours"] = max(0.0, (time.time() - int(stamp)) / 3600.0)
+    return lag
+
+
+def classify_checkout(lags: list) -> CheckResult:
+    """PASS/WARN on the lag readings, always reporting the number it measured."""
+    usable = [l for l in lags if not l.get("error")]
+    detail = []
+    for l in lags:
+        if l.get("error"):
+            detail.append(f"{l['label']}: could not measure - {l['error']}")
+            continue
+        age = ("" if l.get("base_age_hours") is None
+               else f", branched {human_age(l['base_age_hours'] * 3600)} ago")
+        detail.append(f"{l['label']}: on {l['branch'] or '?'}, {l['behind']} commit(s) behind "
+                      f"origin/main, {l['ahead']} ahead{age}")
+    if not usable:
+        return CheckResult(
+            name="checkout", status="WARN",
+            summary="could not establish how current this checkout is",
+            command="git rev-list --left-right --count HEAD...refs/remotes/origin/main",
+            detail=detail,
+            remedy="Run `git fetch origin main` so there is an origin/main to compare against.")
+    worst = max(usable, key=lambda l: (l["behind"] or 0, l.get("base_age_hours") or 0))
+    behind = worst["behind"] or 0
+    age_h = worst.get("base_age_hours") or 0.0
+    detail.append("Anything read out of a checkout is as old as the checkout: a tool's source, "
+                  "a rule, a workflow. A coordinator once diagnosed a repository-wide CI "
+                  "breakage from a tree 40+ commits behind, and misdirected four agents with "
+                  "it; origin/main's copy had been correct all along.")
+    stale = behind >= CHECKOUT_BEHIND_WARN_COMMITS or age_h >= CHECKOUT_BEHIND_WARN_HOURS
+    if not stale:
+        return CheckResult(
+            name="checkout", status="PASS",
+            summary=(f"{worst['label']} is current with origin/main" if behind == 0 else
+                     f"{worst['label']} is {behind} commit(s) behind origin/main - within the "
+                     f"normal drift ({CHECKOUT_BEHIND_WARN_COMMITS} commits or "
+                     f"{CHECKOUT_BEHIND_WARN_HOURS:g}h is where this warns)"),
+            command="git rev-list --left-right --count HEAD...refs/remotes/origin/main",
+            detail=detail, data={"lags": lags})
+    return CheckResult(
+        name="checkout", status="WARN",
+        summary=f"{worst['label']} is {behind} commit(s) behind origin/main and branched "
+                f"{human_age(age_h * 3600)} ago - what you read out of it may already be wrong",
+        command="git rev-list --left-right --count HEAD...refs/remotes/origin/main",
+        detail=detail,
+        remedy="Refresh before reading anything out of it as current:\n"
+               "    git fetch origin && git merge --ff-only origin/main\n"
+               "    git submodule update --init --recursive\n"
+               "A branch mid-task is legitimately behind -- the point is not to MEASURE from a "
+               "tree this old, or to conclude anything about a tool from the copy in it.",
+        data={"lags": lags})
+
+
 def check_budget(skip_fallback: bool = False) -> CheckResult:
     """Budget headroom: a resource that, exhausted, strands work mid-task.
 
@@ -2250,6 +2350,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         return 3
     # The MAIN checkout, not whichever worktree this copy of the script lives in:
     # the worktree census and the reaper both have to see every worktree.
+    running_root = repo
     common = run(["git", "-C", repo, "rev-parse", "--path-format=absolute",
                   "--git-common-dir"]).out.strip()
     if common.endswith("/.git"):
@@ -2270,6 +2371,10 @@ def main(argv: Optional[list[str]] = None) -> int:
     except OSError:
         mem = {}
 
+    lags = [checkout_lag("the checkout preflight is running from", running_root)]
+    if os.path.realpath(repo) != os.path.realpath(running_root or ""):
+        lags.append(checkout_lag("the main checkout", repo))
+
     slug = repo_slug(repo)
     prs, pr_status = pr_map(slug)
     rows = collect_worktrees(repo, prs, measure=not args.no_sizes)
@@ -2282,6 +2387,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         check_budget(skip_fallback=args.skip_budget_fallback),
         check_worktrees(rows, repo, pr_status),
         check_stale_scratch(scratch_root, rows, args.stale_hours),
+        classify_checkout(lags),
         check_push(repo, identity),
         check_commit(repo),
         check_github(slug),

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -42,6 +42,7 @@ Usage:
     tools/preflight.py --reap          # remove worktrees of MERGED PRs, if clean
     tools/preflight.py --with-corpus   # also run the corpus baseline (minutes)
     tools/preflight.py --no-tools      # skip the code-navigation checks (~10s)
+    tools/preflight.py --no-freshness-fetch   # skip the ls-remote in the staleness check
 """
 from __future__ import annotations
 
@@ -56,6 +57,12 @@ import sys
 import time
 from dataclasses import dataclass, field
 from typing import Any, Iterable, Optional
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+try:
+    import agent_self_freshness as _freshness
+except Exception:  # pragma: no cover - a copy detached from its sibling module
+    _freshness = None
 
 GIB = 1024 ** 3
 
@@ -80,6 +87,16 @@ BUDGET_WARN_FRACTION = 0.85
 BUDGET_STALE_MINUTES = 60
 
 OMARCHY_USAGE_BIN = "/usr/share/omarchy/bin/omarchy-agent-usage-claude"
+
+# How many times a network probe is attempted, and how long it waits in between.
+# A HEALTHY BOX PAYS NONE OF THIS: the first attempt succeeds and the probe
+# returns. The waits exist because back-to-back retries are the weakest kind --
+# they re-ask inside the same dropped-packet window -- and the measurement in
+# #3076 was a probe that failed, succeeded and failed again over several seconds
+# by hand, then succeeded six times in a row.
+PUSH_PROBE_ATTEMPTS = 3
+PUSH_RETRY_BACKOFF = (1.0, 3.0)     # before attempt 2, before attempt 3
+RETRY_BACKOFF_SECONDS = 0.7         # run_retry's base wait, multiplied by attempt number
 
 # --------------------------------------------------------------------------
 # code-navigation tooling (issue #3087)
@@ -147,7 +164,8 @@ EXIT_MEANING = {
     0: "every check passed (warnings may be present; see --strict)",
     1: "at least one check FAILED - this box would produce untrustworthy results",
     2: "--strict was given and at least one check WARNED (nothing failed)",
-    3: "preflight could not complete - bad usage, or no checks ran",
+    3: "preflight could not complete - bad usage, no checks ran, or this copy of "
+       "preflight.py is stale (see --no-freshness-fetch)",
 }
 
 
@@ -219,15 +237,30 @@ def strip_shim_banner(text: str) -> str:
     return "".join(lines[i:])
 
 
-def run_retry(argv: list[str], *, attempts: int = 3, **kw) -> Ran:
-    """Retry a network-touching command. This box's network times out
-    intermittently, and a single timeout read as a FAIL would halt a healthy
-    loop."""
+def run_retry(argv: list[str], *, attempts: int = 3, backoff: Optional[float] = None,
+              sleeper=None, **kw) -> Ran:
+    """Retry a network-touching command, spacing the attempts.
+
+    This box's network times out intermittently, and a single timeout read as a
+    FAIL halts a healthy loop. The attempts are SPACED rather than fired back to
+    back, because consecutive retries re-ask inside the same dropped-packet
+    window; #3076 measured a probe that needed seconds, not milliseconds, to
+    start working again.
+
+    It is deliberately CLASS-BLIND -- it retries any non-zero exit. A caller
+    whose failures must be told apart, because retrying one class would mask a
+    real verdict, does that itself: check_push() below is the one that does, and
+    it does not use this function.
+    """
+    backoff = RETRY_BACKOFF_SECONDS if backoff is None else backoff
+    sleeper = sleeper or time.sleep
     last = Ran(rc=127, out="", err="never ran")
-    for _ in range(attempts):
+    for i in range(attempts):
         last = run(argv, **kw)
         if last.ok:
             return last
+        if i + 1 < attempts and backoff > 0:
+            sleeper(backoff * (i + 1))
     return last
 
 
@@ -977,6 +1010,105 @@ def check_stale_scratch(tmp_dir: str, rows: list[tuple], stale_hours: float) -> 
                              "orphan_registrations": [r[0].path for r in orphan]})
 
 
+# --------------------------------------------------------------------------
+# the push probe: telling a dropped packet apart from a broken credential (#3076)
+# --------------------------------------------------------------------------
+# ONE SAMPLE CANNOT TELL THOSE TWO APART, and they need opposite responses.
+# Halting an unattended loop on a dropped packet costs a whole window; continuing
+# on a broken credential costs every push after it. Measured 2026-09-06: the
+# probe reported FAIL, and the same push by hand seconds later succeeded on 1 of
+# 3 attempts and then on 6 of 6. `ssh -T git@github.com` timed out every time
+# while pushes got through, so port 22 was filtered or flaky on that network --
+# and the reported summary, "push was refused: and the repository exists.", was
+# the trailing line of SSH boilerplate that BOTH failures print, so it read as an
+# authorization problem when the cause was reachability.
+#
+# So the line drawn here is the CLASS of the failure, never the count:
+#
+#   * a REFUSAL (permission, authentication, no such repository, host key) is a
+#     verdict. It is not retried at all -- the probe FAILs on the first attempt,
+#     which also removes a real hazard the old code had: run_retry() would retry
+#     a publickey refusal, and a later success turned a broken credential into a
+#     PASS.
+#   * a TRANSPORT failure (timeout, reset, DNS, refused connection) is retried,
+#     spaced out, up to PUSH_PROBE_ATTEMPTS.
+#   * an UNRECOGNISED failure is retried, because the alternative is treating an
+#     error nobody has classified yet as a credential verdict.
+#
+# and no number of retries can manufacture a PASS: a PASS still requires one
+# attempt to negotiate successfully with the remote. When it took more than one,
+# the verdict is a WARN that says what it measured -- the box can work, but every
+# other network round trip in the cycle is on the same unreliable path.
+_TRANSPORT_REFUSAL = re.compile(
+    r"permission denied|permission to .+ denied|authentication failed"
+    r"|invalid username or password|the requested url returned error: 40"
+    r"|403 forbidden|repository not found|does not have permission"
+    r"|terminal prompts disabled|could not read username|could not read password"
+    r"|support for password authentication was removed|access denied"
+    r"|not authorized|bad credentials|no such identity"
+    r"|host key verification failed", re.I)
+
+_TRANSPORT_TRANSIENT = re.compile(
+    r"connection timed out|connection reset|connection refused|connection closed"
+    r"|could not resolve host|temporary failure in name resolution"
+    r"|network is unreachable|no route to host|operation timed out|timed out"
+    r"|kex_exchange_identification|broken pipe|early eof|unexpected disconnect"
+    r"|remote end hung up|gnutls_handshake|ssl_read|ssl connect error"
+    r"|the requested url returned error: 5|error: 429|server hung up", re.I)
+
+# Both failure shapes end with these lines, so neither classifies anything and
+# neither may be reported as the cause. This is the exact text that reached the
+# report as "push was refused: and the repository exists."
+_TRANSPORT_BOILERPLATE = re.compile(
+    r"^(fatal: could not read from remote repository\.?"
+    r"|please make sure you have the correct access rights"
+    r"|and the repository exists\.?)$", re.I)
+
+
+def classify_transport_error(text: str) -> str:
+    """"auth" (a verdict), "transient" (worth another attempt), or "unknown".
+
+    Refusals are tested first: a refusal message never carries a transport
+    marker, but ordering it first means a message carrying both is treated as
+    the verdict rather than retried, which is the safe direction.
+    """
+    body = text or ""
+    if _TRANSPORT_REFUSAL.search(body):
+        return "auth"
+    if _TRANSPORT_TRANSIENT.search(body):
+        return "transient"
+    return "unknown"
+
+
+def transport_error_line(text: str) -> str:
+    """The line that names the CAUSE, not the last line of shared boilerplate."""
+    lines = [ln.strip() for ln in (text or "").replace("\r", "\n").splitlines()]
+    lines = [ln for ln in lines if ln and not _TRANSPORT_BOILERPLATE.match(ln)]
+    for pattern in (_TRANSPORT_REFUSAL, _TRANSPORT_TRANSIENT):
+        for ln in lines:
+            if pattern.search(ln):
+                return ln
+    return lines[0] if lines else "no message"
+
+
+def push_transport(repo: str) -> tuple[str, str]:
+    """(kind, url) of the PUSH remote. Named in the report because it is not
+    necessarily the fetch remote: the box in #3076 fetched over https and pushed
+    over ssh, and nothing said so."""
+    r = run(["git", "-C", repo, "remote", "get-url", "--push", "origin"])
+    url = r.out.strip().splitlines()[-1].strip() if r.ok and r.out.strip() else ""
+    if not url:
+        return "unknown", ""
+    low = url.lower()
+    if low.startswith(("http://", "https://")):
+        return "https", url
+    if low.startswith("ssh://") or re.match(r"^[^/]+@[^/:]+:", url):
+        return "ssh", url
+    if low.startswith("git://"):
+        return "git", url
+    return "other", url
+
+
 def check_push(repo: str, identity: str) -> CheckResult:
     """`git ls-remote` proves READ. Only a push proves push.
 
@@ -984,29 +1116,111 @@ def check_push(repo: str, identity: str) -> CheckResult:
     interactive credential agent, and a false PASS here has happened. --dry-run
     performs the full negotiation, including authentication, and transfers
     nothing, so the probe ref is never created.
+
+    The retry policy, and why a retry here cannot hide a broken credential, is in
+    the block comment above.
     """
     ref = f"refs/heads/preflight-probe-{identity}"
     cmd = f"git push --dry-run origin HEAD:{ref}"
-    r = run_retry(["git", "-C", repo, "push", "--dry-run", "--porcelain", "origin",
-                   f"HEAD:{ref}"], timeout=120, attempts=2)
-    if r.timed_out:
-        return CheckResult(name="push", status="FAIL",
-                           summary="the push probe timed out - credentials are probably "
-                                   "waiting on an interactive prompt nobody will answer",
-                           command=cmd,
-                           remedy="Configure a non-interactive credential helper, or "
-                                  "`gh auth setup-git`, then re-run.")
-    if not r.ok:
-        return CheckResult(name="push", status="FAIL",
-                           summary=f"push was refused: {(r.err or r.out).strip().splitlines()[-1] if (r.err or r.out).strip() else 'no message'}",
-                           command=cmd,
-                           detail=[(r.err or r.out).strip()[:600]],
-                           remedy="Re-authenticate (`gh auth login`, then `gh auth setup-git`) "
-                                  "and confirm the account has push permission on origin.")
-    return CheckResult(name="push", status="PASS",
-                       summary="push works (dry-run negotiated with origin; nothing was written)",
-                       command=cmd,
-                       detail=["git ls-remote would only have proven read access."])
+    argv = ["git", "-C", repo, "push", "--dry-run", "--porcelain", "origin", f"HEAD:{ref}"]
+    kind, url = push_transport(repo)
+    fetch = run(["git", "-C", repo, "remote", "get-url", "origin"]).out.strip()
+
+    total = max(1, PUSH_PROBE_ATTEMPTS)
+    outcomes: list[str] = []
+    last = Ran(rc=127, out="", err="never ran")
+    for i in range(total):
+        last = run(argv, timeout=120)
+        if last.ok:
+            outcomes.append("ok")
+            break
+        outcomes.append("timeout" if last.timed_out
+                        else classify_transport_error(last.err or last.out))
+        if outcomes[-1] == "auth":
+            break                       # a verdict; retrying it only delays the report
+        if i + 1 < total and PUSH_RETRY_BACKOFF:
+            pause = PUSH_RETRY_BACKOFF[min(i, len(PUSH_RETRY_BACKOFF) - 1)]
+            if pause:
+                time.sleep(pause)
+
+    used = len(outcomes)
+    trail = ", ".join(outcomes)
+    where = f"push transport: {kind}" + (f" ({url})" if url else "")
+    if fetch and url and fetch != url:
+        where += f"; fetch is a different remote: {fetch}"
+    detail = [where, f"attempts: {used} of {total} ({trail})"]
+    text = (last.err or last.out).strip()
+
+    if outcomes[-1] == "ok":
+        if used == 1:
+            return CheckResult(
+                name="push", status="PASS",
+                summary="push works (dry-run negotiated with origin on the first attempt; "
+                        "nothing was written)",
+                command=cmd,
+                detail=detail + ["git ls-remote would only have proven read access."])
+        return CheckResult(
+            name="push", status="WARN",
+            summary=f"push works, but the transport is FLAKY: 1 of {used} attempts "
+                    f"succeeded ({trail})",
+            command=cmd,
+            detail=detail + [f"first failure: {transport_error_line(text)}",
+                             "The credential is fine -- it negotiated. This is the network "
+                             "path, and every other round trip in the cycle uses it too."],
+            remedy="Nothing here stops the cycle. Treat a single network failure elsewhere "
+                   "in this run as unproven rather than as a verdict, and if pushes keep "
+                   "needing retries, look at the transport named above rather than at "
+                   "credentials.",
+            data={"attempts": outcomes, "transport": kind, "push_url": url})
+
+    if outcomes[-1] == "auth":
+        return CheckResult(
+            name="push", status="FAIL",
+            summary=f"push was REFUSED: {transport_error_line(text)}",
+            command=cmd,
+            detail=detail + [text[:600],
+                             "Refused on the first attempt and not retried: this is a "
+                             "credential or permission verdict, not a dropped packet."],
+            remedy="Re-authenticate (`gh auth login`, then `gh auth setup-git`) and confirm "
+                   "the account has push permission on origin.",
+            data={"attempts": outcomes, "transport": kind, "push_url": url})
+
+    if set(outcomes) == {"timeout"}:
+        return CheckResult(
+            name="push", status="FAIL",
+            summary=f"the push probe timed out on all {used} attempts - credentials are "
+                    f"probably waiting on an interactive prompt nobody will answer",
+            command=cmd, detail=detail,
+            remedy="Configure a non-interactive credential helper, or `gh auth setup-git`, "
+                   "then re-run.",
+            data={"attempts": outcomes, "transport": kind, "push_url": url})
+
+    if "transient" in outcomes or "timeout" in outcomes:
+        return CheckResult(
+            name="push", status="FAIL",
+            summary=f"push failed on all {used} attempts and the remote was not reachable: "
+                    f"{transport_error_line(text)}",
+            command=cmd,
+            detail=detail + [text[:600],
+                             "Every attempt failed on the TRANSPORT, not on a refusal, so "
+                             "nothing here has disproven the credential."],
+            remedy="This is reachability, not authorization. Check the network path to the "
+                   "push remote named above -- for ssh that is port 22, which some networks "
+                   "filter (`ssh -o BatchMode=yes -T git@github.com`); an https push remote "
+                   "avoids that port entirely. Re-run once the path is back.",
+            data={"attempts": outcomes, "transport": kind, "push_url": url})
+
+    return CheckResult(
+        name="push", status="FAIL",
+        summary=f"push failed on all {used} attempts: {transport_error_line(text)}",
+        command=cmd,
+        detail=detail + [text[:600],
+                         "The error is not one this check recognises, so it was retried "
+                         "rather than read as a credential verdict."],
+        remedy="Read the error above. If it is a credential problem, re-authenticate "
+               "(`gh auth login`, then `gh auth setup-git`); if it is the network, re-run "
+               "once the path to the push remote is back.",
+        data={"attempts": outcomes, "transport": kind, "push_url": url})
 
 
 def check_commit(repo: str) -> CheckResult:
@@ -1069,6 +1283,26 @@ def check_commit(repo: str) -> CheckResult:
         shutil.rmtree(objdir, ignore_errors=True)
 
 
+_TOKEN_SCOPES_LINE = re.compile(r"Token scopes:\s*(.+)")
+
+
+def parse_token_scopes(text: str) -> Optional[set]:
+    """The classic OAuth scopes `gh auth status` reports, or None for UNKNOWN.
+
+    None must never be rendered as "the scope is missing". A fine-grained token
+    reports `Token scopes: none` and can still be permitted to write workflow
+    files, and a `gh` that does not print the line at all says nothing either
+    way. Only a NON-EMPTY classic scope list is evidence about what the token may
+    do, so only that produces a negative answer.
+    """
+    m = _TOKEN_SCOPES_LINE.search(text or "")
+    if not m:
+        return None
+    scopes = {piece.strip().strip("'\"") for piece in m.group(1).split(",")}
+    scopes = {sc for sc in scopes if sc and sc.lower() != "none"}
+    return scopes or None
+
+
 def check_github(slug: Optional[str]) -> CheckResult:
     """Report what this account can do. Do not branch on it.
 
@@ -1112,10 +1346,25 @@ def check_github(slug: Optional[str]) -> CheckResult:
     except ValueError:
         perms = {}
     can_push = bool(perms.get("push") or perms.get("maintain") or perms.get("admin"))
+    # The REPOSITORY's permissions and the TOKEN's scopes answer different
+    # questions, and reporting only the first said "merge a PR: yes" while every
+    # PR touching .github/workflows/ was unmergeable (#3192): `gh pr merge`
+    # refuses with "refusing to allow an OAuth App to create or update workflow
+    # ... without `workflow` scope". That arrived at the LAST step, after review
+    # and after CI -- the most expensive place to discover a missing permission.
+    scopes = parse_token_scopes((auth.out or "") + "\n" + (auth.err or ""))
+    can_workflow = None if scopes is None else ("workflow" in scopes)
     detail = [f"account: {login or 'unknown'}; repository: {slug}",
               "permissions: " + ", ".join(f"{k}={v}" for k, v in sorted(perms.items())),
               f"merge a PR: {'yes' if can_push else 'no'}; label and assign: "
               f"{'yes' if (can_push or perms.get('triage')) else 'no'} (both need push or triage)"]
+    if can_workflow is None:
+        detail.append("merge a PR that touches .github/workflows/: unknown - `gh auth status` "
+                      "did not report classic token scopes (a fine-grained token reports none)")
+    else:
+        detail.append(f"merge a PR that touches .github/workflows/: "
+                      f"{'yes' if can_workflow else 'no'} - needs the token's `workflow` "
+                      f"scope; scopes: {', '.join(sorted(scopes))}")
     if not can_push:
         return CheckResult(name="github", status="FAIL",
                            summary=f"{login or 'this account'} cannot push to {slug}, so the "
@@ -1124,10 +1373,25 @@ def check_github(slug: Optional[str]) -> CheckResult:
                            remedy="Grant push access, or run the loop as an account that has it. "
                                   "This is a precondition to report, not a second mode to "
                                   "implement.")
+    data = {"login": login, "permissions": perms,
+            "token_scopes": sorted(scopes) if scopes else None,
+            "can_merge_workflow_changes": can_workflow}
+    if can_workflow is False:
+        return CheckResult(
+            name="github", status="WARN",
+            summary=f"authenticated as {login} with push access to {slug}, but the token has "
+                    f"no `workflow` scope: pull requests touching .github/workflows/ cannot "
+                    f"be merged from this box",
+            command="gh auth status; gh api repos/%s --jq .permissions" % slug,
+            detail=detail, data=data,
+            remedy="Either grant it (`gh auth refresh -h github.com -s workflow`), or accept "
+                   "that workflow-touching pull requests need a human to merge them and know "
+                   "that up front. Do NOT teach the loop to route them differently: a missing "
+                   "permission is a precondition to report, not a second mode to implement.")
     return CheckResult(name="github", status="PASS",
                        summary=f"authenticated as {login} with push access to {slug}",
                        command=f"gh auth status; gh api repos/{slug} --jq .permissions",
-                       detail=detail, data={"login": login, "permissions": perms})
+                       detail=detail, data=data)
 
 
 def check_budget(skip_fallback: bool = False) -> CheckResult:
@@ -1848,6 +2112,57 @@ def default_identity() -> str:
     return re.sub(r"[^A-Za-z0-9._-]", "-", login or os.environ.get("USER", "unknown"))
 
 
+def freshness_refusal(printer=None, *, remote_check: bool = True) -> Optional[int]:
+    """3 if the copy of preflight.py that is RUNNING is behind origin/main, else None.
+
+    The same exposure #3020 fixed in ci-wait.py and pr-body.py, one tool over. An
+    agent invokes this by relative path, so it runs whichever copy is on disk in
+    that agent's worktree -- and a worktree is created once, at the start of a
+    task, and never fast-forwarded. Measured 2026-09-06 across this box's 109
+    worktrees: 40 of the 59 carrying tools/preflight.py had a version that was not
+    origin/main's, across four distinct versions, while a tool nobody had changed
+    lately (context-pack.py) was identical in all 105 copies of it. It is the
+    tools under active repair that run old.
+
+    WHY A REFUSAL AND NOT A NOTE, for a tool whose job is reporting: because the
+    failure is a WRONG VERDICT, not a missing one. A copy predating #2936 does not
+    know that mise prints a banner on stdout, so it parses the permissions JSON
+    into {} and reports a HEALTHY account as unable to push -- FAIL, exit 1, which
+    the autonomous cycle treats as stop-everything. A copy predating #3095 reports
+    nothing at all about the code-navigation tools and does not say that it did
+    not look. Neither announces itself. Exit 3 rather than 1: "could not
+    complete", which is not a verdict about the box.
+
+    Note what this does NOT cover, because the sibling tool demonstrates it: a
+    defect in origin/main's own copy is carried faithfully by every fresh copy.
+    Staleness is the only question asked here.
+    """
+    printer = printer or (lambda m: print(m))
+    if _freshness is None:
+        printer("note: could not establish whether this copy of preflight.py is current -- "
+                "tools/agent_self_freshness.py could not be imported. Reporting anyway; "
+                "nothing has checked that this copy carries the latest checks and "
+                "thresholds.")
+        return None
+    refused = False
+    confirm = remote_check
+    for target in (os.path.abspath(__file__), os.path.abspath(_freshness.__file__)):
+        # Both halves: the staleness rule itself lives in the sibling module, and
+        # a stale copy of THAT is a stale guard. One ls-remote, reused.
+        fresh = _freshness.assess(target, remote_check=confirm)
+        confirm = False
+        for note in fresh.notes:
+            printer(note)
+        refused = refused or fresh.refuse
+    if refused:
+        printer("\nREFUSING TO REPORT ON THIS BOX -- this copy of preflight.py is STALE. It "
+                "would apply an older set of checks and thresholds without saying so, and a "
+                "copy predating #2936 reports a HEALTHY box as unable to push. NOTHING WAS "
+                "PROBED; this is not a verdict about the box.")
+        return 3
+    return None
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     epilog = "exit codes:\n" + "\n".join(f"  {k}  {v}" for k, v in sorted(EXIT_MEANING.items()))
     ap = argparse.ArgumentParser(
@@ -1879,7 +2194,31 @@ def main(argv: Optional[list[str]] = None) -> int:
                     help="skip the code-navigation checks (C# LSP, graphify, bc-decompiler). "
                          "They cost about 10s, dominated by the language server's first "
                          "answer, and only ever WARN")
+    ap.add_argument("--no-freshness-fetch", action="store_true",
+                    help="skip the single `git ls-remote` that confirms origin/main before "
+                         "the staleness check. It does NOT disable the staleness check "
+                         "itself; there is no flag for that")
     args = ap.parse_args(argv)
+
+    # BEFORE the box is probed at all: is THIS copy of preflight.py current? A
+    # stale copy reports confidently out of an older rulebook (#3164). In --json
+    # mode the refusal is still a document, so a machine reader cannot mistake
+    # silence on stdout for success.
+    refusal_notes: list[str] = []
+    stale = freshness_refusal(refusal_notes.append if args.json else None,
+                              remote_check=not args.no_freshness_fetch)
+    if stale is not None:
+        if args.json:
+            print(json.dumps({
+                "exit_code": stale,
+                "exit_code_meaning": EXIT_MEANING[stale],
+                "exit_codes": {str(k): v for k, v in EXIT_MEANING.items()},
+                "strict": args.strict,
+                "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+                "checks": [],
+                "refusal": {"reason": "stale-preflight", "notes": refusal_notes},
+            }, indent=2))
+        return stale
 
     here = os.path.dirname(os.path.abspath(__file__))
     repo = git_repo_root(here)

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -1054,7 +1054,12 @@ _TRANSPORT_TRANSIENT = re.compile(
     r"|network is unreachable|no route to host|operation timed out|timed out"
     r"|kex_exchange_identification|broken pipe|early eof|unexpected disconnect"
     r"|remote end hung up|gnutls_handshake|ssl_read|ssl connect error"
-    r"|the requested url returned error: 5|error: 429|server hung up", re.I)
+    r"|the requested url returned error: 5|error: 429|server hung up"
+    # gh's own transport failures, for the sibling call site in check_github():
+    # a dropped packet there reported "gh is installed but not authenticated",
+    # the same false verdict one function over.
+    r"|i/o timeout|dial tcp|error connecting to|context deadline exceeded"
+    r"|no such host", re.I)
 
 # Both failure shapes end with these lines, so neither classifies anything and
 # neither may be reported as the cause. This is the exact text that reached the
@@ -1322,10 +1327,28 @@ def check_github(slug: Optional[str]) -> CheckResult:
                                   "that has the GitHub MCP tools.")
     auth = run_retry(["gh", "auth", "status"], timeout=45)
     if not auth.ok:
+        # The same split the push probe makes, at the sibling call site: `gh auth
+        # status` validates the token over the network, so a dropped packet here
+        # used to be reported as "not authenticated" -- a credential verdict from
+        # a transport failure, which is exactly #3076 one function over. Both are
+        # a FAIL (a loop that cannot reach GitHub cannot work), but they send the
+        # reader to different places.
+        text = (auth.err or auth.out).strip()
+        if auth.timed_out or classify_transport_error(text) == "transient":
+            return CheckResult(
+                name="github", status="FAIL",
+                summary="could not reach github.com to check authentication: "
+                        + ("the command timed out" if auth.timed_out
+                           else transport_error_line(text)),
+                command="gh auth status", detail=[text[:400],
+                        "`gh auth status` never answered, so nothing has been established "
+                        "about the token -- this is reachability, not a credential verdict."],
+                remedy="Check the network path to github.com and re-run. Nothing here has "
+                       "disproven the credential.")
         return CheckResult(name="github", status="FAIL",
                            summary="gh is installed but not authenticated",
                            command="gh auth status",
-                           detail=[(auth.err or auth.out).strip()[:400]],
+                           detail=[text[:400]],
                            remedy="Run `gh auth login`.")
     login = run_retry(["gh", "api", "user", "--jq", ".login"], timeout=45).out.strip()
     if not slug:

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -1286,14 +1286,18 @@ check("'Token scopes: none' is unknown too -- a fine-grained token has no classi
 class GhScript:
     """pf.run replacement answering the three commands check_github issues."""
 
-    def __init__(self, auth_status=GH_AUTH_STATUS, perms=None):
+    def __init__(self, auth_status=GH_AUTH_STATUS, perms=None, auth_rc=0, auth_err=""):
         self.auth_status = auth_status
+        self.auth_rc = auth_rc
+        self.auth_err = auth_err
         self.perms = perms if perms is not None else {
             "admin": True, "maintain": True, "push": True, "pull": True, "triage": True}
 
     def __call__(self, argv, **kw):
         joined = " ".join(argv)
         if "auth" in argv and "status" in argv:
+            if self.auth_rc:
+                return pf.Ran(rc=self.auth_rc, out="", err=self.auth_err)
             return pf.Ran(rc=0, out=self.auth_status, err="")
         if "user" in joined:
             return pf.Ran(rc=0, out="StefanMaron\n", err="")
@@ -1345,6 +1349,28 @@ check("unreadable scopes are said out loud rather than assumed",
       _res.detail)
 check("and the machine-readable answer is unknown, not False",
       _res.data.get("can_merge_workflow_changes") is None, _res.data)
+
+
+# ---- the same dropped packet, one function over: `gh auth status` also uses the network
+GH_UNREACHABLE = ("error connecting to github.com\n"
+                  "Post \"https://github.com/api/v3/graphql\": dial tcp 140.82.121.4:443: "
+                  "i/o timeout\n")
+check("gh's own transport failure classifies as transient",
+      pf.classify_transport_error(GH_UNREACHABLE) == "transient",
+      pf.classify_transport_error(GH_UNREACHABLE))
+
+_res = github_result(auth_rc=1, auth_err=GH_UNREACHABLE)
+check("an unreachable github.com is not reported as a missing credential",
+      _res.status == "FAIL" and "not authenticated" not in _res.summary,
+      f"{_res.status}: {_res.summary}")
+check("it is reported as reachability instead",
+      "reach" in _res.summary, _res.summary)
+
+_res = github_result(auth_rc=1, auth_err="You are not logged into any GitHub hosts. "
+                                         "To log in, run: gh auth login\n")
+check("a genuine logged-out gh still FAILs as not authenticated",
+      _res.status == "FAIL" and "not authenticated" in _res.summary,
+      f"{_res.status}: {_res.summary}")
 
 
 # ------------------------------------- a stale copy of preflight must not answer (#3164)

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -1373,6 +1373,78 @@ check("a genuine logged-out gh still FAILs as not authenticated",
       f"{_res.status}: {_res.summary}")
 
 
+# ------------------------ how current the checkout being measured is (real git)
+# The whole-tree version of the same trap: a coordinator read tools/ci-wait.py out
+# of a top-level checkout 40+ commits behind origin/main, found a constant that
+# origin/main had already renamed, concluded the tool was broken for every pull
+# request in the repository, and misdirected four agents. origin/main's copy was
+# correct throughout. Real git here, not a fixture: the question is what git says
+# about HEAD against refs/remotes/origin/main, and a mocked answer proves nothing.
+def lag_repo(behind: int, base_age_days: float = 0.0) -> str:
+    root = tempfile.mkdtemp(prefix="preflight-lag-")
+    git("init", "-q", "-b", "main", ".", cwd=root)
+    git("config", "user.email", "t@example.com", cwd=root)
+    git("config", "user.name", "T", cwd=root)
+    when = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=base_age_days)
+    stamp = when.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    open(os.path.join(root, "f"), "w").write("base\n")
+    git("add", "f", cwd=root)
+    git("commit", "-q", "-m", "base", cwd=root,
+        env=dict(os.environ, GIT_AUTHOR_DATE=stamp, GIT_COMMITTER_DATE=stamp))
+    branch_point = git("rev-parse", "HEAD", cwd=root).stdout.strip()
+    for i in range(behind):
+        open(os.path.join(root, "f"), "w").write(f"main {i}\n")
+        git("commit", "-q", "-am", f"main {i}", cwd=root)
+    tip = git("rev-parse", "HEAD", cwd=root).stdout.strip()
+    git("update-ref", "refs/remotes/origin/main", tip, cwd=root)
+    git("checkout", "-q", "-B", "work", branch_point, cwd=root)
+    return root
+
+
+_root = lag_repo(behind=3)
+_lag = pf.checkout_lag("this checkout", _root)
+check("a checkout three commits behind measures as three",
+      _lag["behind"] == 3 and _lag["ahead"] == 0, _lag)
+check("and the branch point's age is measured, not guessed",
+      _lag["base_age_hours"] is not None and _lag["base_age_hours"] < 1, _lag)
+_res = pf.classify_checkout([_lag])
+check("normal drift is a PASS -- a warning that always fires is not read",
+      _res.status == "PASS", f"{_res.status}: {_res.summary}")
+check("but the number is reported either way, which is what was missing",
+      any("3 commit(s) behind" in d for d in _res.detail), _res.detail)
+shutil.rmtree(_root, ignore_errors=True)
+
+_root = lag_repo(behind=40)
+_res = pf.classify_checkout([pf.checkout_lag("the main checkout", _root)])
+check("40 commits behind -- the measured incident -- WARNs",
+      _res.status == "WARN", f"{_res.status}: {_res.summary}")
+check("the warning says what to stop doing, not just what to run",
+      "measure" in _res.remedy.lower() or "conclude" in _res.remedy.lower(), _res.remedy)
+shutil.rmtree(_root, ignore_errors=True)
+
+_root = lag_repo(behind=1, base_age_days=3)
+_res = pf.classify_checkout([pf.checkout_lag("this checkout", _root)])
+check("a tree branched three days ago WARNs even when it is one commit behind",
+      _res.status == "WARN", f"{_res.status}: {_res.summary}")
+shutil.rmtree(_root, ignore_errors=True)
+
+_root = tempfile.mkdtemp(prefix="preflight-lag-none-")
+git("init", "-q", "-b", "main", ".", cwd=_root)
+_lag = pf.checkout_lag("this checkout", _root)
+check("a checkout with no origin/main says so rather than reporting zero",
+      _lag["error"] and _lag["behind"] is None, _lag)
+_res = pf.classify_checkout([_lag])
+check("and that is a WARN about not knowing, never a PASS",
+      _res.status == "WARN" and "could not" in _res.summary, _res.summary)
+shutil.rmtree(_root, ignore_errors=True)
+
+_res = pf.classify_checkout([{"label": "a", "error": "no origin/main"},
+                             {"label": "b", "branch": "main", "ahead": 0, "behind": 40,
+                              "base_age_hours": 30.0, "error": ""}])
+check("one unmeasurable checkout does not hide a stale one",
+      _res.status == "WARN" and "40 commit(s)" in _res.summary, _res.summary)
+
+
 # ------------------------------------- a stale copy of preflight must not answer (#3164)
 # Same exposure #3020 fixed in ci-wait.py and pr-body.py: an agent runs the copy
 # in its own worktree, and a worktree is created once and never fast-forwarded.

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import datetime as dt
 import importlib.util
+import io
 import json
 import os
 import shutil
@@ -1062,6 +1063,388 @@ check("the navigation warnings render one line each with a name",
       _txt.count("WARN") >= 3, _txt)
 check("the rendered navigation report tells the reader what to do",
       _txt.count("-> what to do:") >= 3, _txt)
+
+
+# ------------------------------------------------ the push probe (#3076)
+# preflight's exit 1 means "this box would produce untrustworthy results", and
+# the autonomous cycle treats it as stop-everything. A SINGLE DROPPED PACKET must
+# not produce it: measured 2026-09-06, the probe was refused, then succeeded, then
+# was refused again by hand -- 1 of 3 -- and six consecutive runs seconds later
+# all succeeded. The FAIL halted a healthy box.
+#
+# The opposite error is worse, though. A retry that masks a genuinely broken
+# credential defeats the check entirely, so the line drawn here is the CLASS of
+# the failure, not the count: a REFUSAL (permission, authentication, no such
+# repository) is persistent and is never retried, and no number of retries can
+# produce a PASS without one attempt actually negotiating successfully.
+pf.PUSH_RETRY_BACKOFF = (0, 0)          # the tests must not sleep
+
+# Real git output. The last line of both is the same boilerplate, which is why
+# the reported summary read "push was refused: and the repository exists." for a
+# failure that was a dropped packet.
+SSH_TIMEOUT = ("ssh: connect to host github.com port 22: Connection timed out\r\n"
+               "fatal: Could not read from remote repository.\n\n"
+               "Please make sure you have the correct access rights\n"
+               "and the repository exists.\n")
+SSH_DENIED = ("git@github.com: Permission denied (publickey).\r\n"
+              "fatal: Could not read from remote repository.\n\n"
+              "Please make sure you have the correct access rights\n"
+              "and the repository exists.\n")
+HTTPS_403 = ("remote: Permission to StefanMaron/BusinessCentral.AL.Runner.git denied to bot.\n"
+             "fatal: unable to access 'https://github.com/StefanMaron/"
+             "BusinessCentral.AL.Runner.git/': The requested URL returned error: 403\n")
+
+
+class PushScript:
+    """A pf.run replacement that answers the push probe from a script.
+
+    Every other command it is asked (the push remote's URL) is answered
+    truthfully, so the check under test sees a normal box apart from the
+    transport.
+    """
+
+    def __init__(self, outcomes, push_url="git@github.com:StefanMaron/"
+                                          "BusinessCentral.AL.Runner.git"):
+        self.outcomes = list(outcomes)
+        self.push_calls = 0
+        self.push_url = push_url
+
+    def __call__(self, argv, **kw):
+        if "push" in argv:
+            self.push_calls += 1
+            outcome = self.outcomes[min(self.push_calls, len(self.outcomes)) - 1]
+            if outcome == "ok":
+                return pf.Ran(rc=0, out="To github.com:StefanMaron/x.git\n", err="")
+            if outcome == "timeout":
+                return pf.Ran(rc=124, out="", err="", timed_out=True)
+            return pf.Ran(rc=128, out="", err=outcome)
+        if "get-url" in argv:
+            return pf.Ran(rc=0, out=self.push_url + "\n", err="")
+        return pf.Ran(rc=0, out="", err="")
+
+
+def push_result(outcomes, **kw):
+    script = PushScript(outcomes, **kw)
+    saved = pf.run
+    pf.run = script
+    try:
+        return pf.check_push("/repo", "stma-auto-1"), script
+    finally:
+        pf.run = saved
+
+
+# ---- classification: which failures are worth a second attempt, and which are a verdict
+check("an SSH connection timeout is transient",
+      pf.classify_transport_error(SSH_TIMEOUT) == "transient",
+      pf.classify_transport_error(SSH_TIMEOUT))
+check("a publickey refusal is an authentication verdict, not a transient",
+      pf.classify_transport_error(SSH_DENIED) == "auth",
+      pf.classify_transport_error(SSH_DENIED))
+check("an HTTPS 403 is an authorization verdict",
+      pf.classify_transport_error(HTTPS_403) == "auth",
+      pf.classify_transport_error(HTTPS_403))
+check("a reset during SSH key exchange is transient",
+      pf.classify_transport_error(
+          "kex_exchange_identification: Connection reset by peer") == "transient")
+check("a name-resolution failure is transient",
+      pf.classify_transport_error(
+          "fatal: unable to access 'https://github.com/x.git/': "
+          "Could not resolve host: github.com") == "transient")
+check("'Repository not found' is persistent, not something to retry",
+      pf.classify_transport_error("ERROR: Repository not found.") == "auth",
+      pf.classify_transport_error("ERROR: Repository not found."))
+check("the shared boilerplate alone classifies as unknown, never as an auth verdict",
+      pf.classify_transport_error("fatal: Could not read from remote repository.\n"
+                                  "Please make sure you have the correct access rights\n"
+                                  "and the repository exists.\n") == "unknown",
+      pf.classify_transport_error("fatal: Could not read from remote repository.\n"
+                                  "Please make sure you have the correct access rights\n"
+                                  "and the repository exists.\n"))
+
+# ---- the reported line: the cause, not the last line of boilerplate
+check("the summary line names the transport failure, not 'and the repository exists.'",
+      pf.transport_error_line(SSH_TIMEOUT)
+      == "ssh: connect to host github.com port 22: Connection timed out",
+      pf.transport_error_line(SSH_TIMEOUT))
+check("the summary line names the publickey refusal",
+      pf.transport_error_line(SSH_DENIED) == "git@github.com: Permission denied (publickey).",
+      pf.transport_error_line(SSH_DENIED))
+check("an error with nothing but boilerplate still reports something",
+      pf.transport_error_line("") == "no message",
+      pf.transport_error_line(""))
+
+# ---- 1 of 3, the measured case: a WARN that names what it measured, never a FAIL
+_res, _script = push_result([SSH_TIMEOUT, SSH_TIMEOUT, "ok"])
+check("two dropped packets followed by a success does not fail the box",
+      _res.status == "WARN", f"{_res.status}: {_res.summary}")
+check("a flaky transport is retried to the third attempt",
+      _script.push_calls == 3, _script.push_calls)
+check("the flaky verdict says what it measured",
+      "1 of 3" in _res.summary, _res.summary)
+check("the flaky verdict names the transport",
+      "ssh" in (_res.summary + " ".join(_res.detail)).lower(),
+      f"{_res.summary} | {_res.detail}")
+
+# ---- a healthy box costs exactly one attempt, and still PASSes
+_res, _script = push_result(["ok"])
+check("a working push is a PASS", _res.status == "PASS", _res.summary)
+check("a working push costs one attempt, not three", _script.push_calls == 1,
+      _script.push_calls)
+
+# ---- a real refusal FAILs on the first attempt: retrying it would only delay a verdict
+_res, _script = push_result([SSH_DENIED, "ok", "ok"])
+check("a publickey refusal fails the box", _res.status == "FAIL", _res.summary)
+check("a refusal is never retried -- a later success cannot un-refuse it",
+      _script.push_calls == 1, _script.push_calls)
+check("the refusal summary names the refusal itself",
+      "Permission denied (publickey)" in _res.summary, _res.summary)
+check("the refusal summary is not the trailing boilerplate",
+      "and the repository exists" not in _res.summary, _res.summary)
+
+# ---- transport down for every attempt is still a FAIL, but it says reachability
+_res, _script = push_result([SSH_TIMEOUT, SSH_TIMEOUT, SSH_TIMEOUT])
+check("a transport that never works fails the box", _res.status == "FAIL", _res.summary)
+check("no number of retries invents a PASS", _script.push_calls == 3, _script.push_calls)
+check("an unreachable transport is reported as reachability, not authorization",
+      "reach" in _res.summary.lower() or "reach" in " ".join(_res.detail).lower(),
+      f"{_res.summary} | {_res.detail}")
+check("the unreachable remedy does not send the reader to re-authenticate first",
+      "port 22" in (_res.remedy + " ".join(_res.detail)) or
+      "network" in _res.remedy.lower(), _res.remedy)
+
+# ---- an unrecognised error is retried rather than treated as a verdict
+_res, _script = push_result(["something nobody has seen before\n",
+                             "something nobody has seen before\n", "ok"])
+check("an unclassifiable error is retried, not read as a broken credential",
+      _script.push_calls == 3 and _res.status == "WARN",
+      f"{_script.push_calls} {_res.status}")
+
+# ---- the hang diagnosis survives: an interactive prompt nobody answers
+_res, _script = push_result(["timeout", "timeout", "timeout"])
+check("a probe that hangs every time still reports the interactive-prompt cause",
+      _res.status == "FAIL" and "interactive" in _res.summary,
+      f"{_res.status}: {_res.summary}")
+_res, _script = push_result(["timeout", "ok"])
+check("one hung attempt followed by a success is a flaky transport, not a hang",
+      _res.status == "WARN" and _script.push_calls == 2,
+      f"{_res.status} {_script.push_calls}")
+
+# ---- run_retry spaces its attempts instead of firing them back to back
+_slept: list = []
+_calls: list = []
+
+
+def _always_fail(argv, **kw):
+    _calls.append(argv)
+    return pf.Ran(rc=1, out="", err="nope")
+
+
+_saved_run = pf.run
+pf.run = _always_fail
+try:
+    _r = pf.run_retry(["gh", "api", "user"], attempts=3, sleeper=_slept.append)
+finally:
+    pf.run = _saved_run
+check("run_retry uses every attempt before giving up", len(_calls) == 3, len(_calls))
+check("run_retry waits between attempts rather than firing them back to back",
+      len(_slept) == 2 and all(s > 0 for s in _slept), _slept)
+
+_slept, _calls = [], []
+_saved_run = pf.run
+pf.run = lambda argv, **kw: (_calls.append(argv), pf.Ran(rc=0, out="ok", err=""))[1]
+try:
+    pf.run_retry(["gh", "api", "user"], attempts=3, sleeper=_slept.append)
+finally:
+    pf.run = _saved_run
+check("run_retry never sleeps after a first-attempt success",
+      len(_calls) == 1 and _slept == [], f"{len(_calls)} {_slept}")
+
+
+# --------------------------------------- token scopes: what this box can merge (#3192)
+# check_github reported "merge a PR: yes" from the REPOSITORY's permissions while
+# the token had no `workflow` scope, so every PR touching .github/workflows/ was
+# unmergeable -- discovered at the last step, after review and after CI.
+GH_AUTH_STATUS = ("github.com\n"
+                  "  ✓ Logged in to github.com account StefanMaron (keyring)\n"
+                  "  - Active account: true\n"
+                  "  - Git operations protocol: ssh\n"
+                  "  - Token: gho_************************************\n"
+                  "  - Token scopes: 'admin:public_key', 'gist', 'read:org', 'repo'\n")
+
+check("the token's scopes are read out of a real `gh auth status`",
+      pf.parse_token_scopes(GH_AUTH_STATUS)
+      == {"admin:public_key", "gist", "read:org", "repo"},
+      pf.parse_token_scopes(GH_AUTH_STATUS))
+check("a status with no scopes line is unknown, not an empty scope set",
+      pf.parse_token_scopes("github.com\n  - Active account: true\n") is None,
+      pf.parse_token_scopes("github.com\n  - Active account: true\n"))
+check("'Token scopes: none' is unknown too -- a fine-grained token has no classic scopes",
+      pf.parse_token_scopes("  - Token scopes: none\n") is None,
+      pf.parse_token_scopes("  - Token scopes: none\n"))
+
+
+class GhScript:
+    """pf.run replacement answering the three commands check_github issues."""
+
+    def __init__(self, auth_status=GH_AUTH_STATUS, perms=None):
+        self.auth_status = auth_status
+        self.perms = perms if perms is not None else {
+            "admin": True, "maintain": True, "push": True, "pull": True, "triage": True}
+
+    def __call__(self, argv, **kw):
+        joined = " ".join(argv)
+        if "auth" in argv and "status" in argv:
+            return pf.Ran(rc=0, out=self.auth_status, err="")
+        if "user" in joined:
+            return pf.Ran(rc=0, out="StefanMaron\n", err="")
+        if "repos/" in joined:
+            return pf.Ran(rc=0, out=json.dumps(self.perms), err="")
+        return pf.Ran(rc=0, out="", err="")
+
+
+class FakeShutil:
+    which = staticmethod(lambda name: "/usr/bin/" + name)
+    rmtree = staticmethod(shutil.rmtree)
+
+
+def github_result(**kw):
+    saved_run, saved_shutil = pf.run, pf.shutil
+    pf.run, pf.shutil = GhScript(**kw), FakeShutil
+    try:
+        return pf.check_github("StefanMaron/BusinessCentral.AL.Runner")
+    finally:
+        pf.run, pf.shutil = saved_run, saved_shutil
+
+
+_res = github_result()
+check("a token without `workflow` scope is a WARN, not a silent PASS",
+      _res.status == "WARN", f"{_res.status}: {_res.summary}")
+check("the warning names the scope that is missing",
+      "workflow" in _res.summary, _res.summary)
+check("the report says which class of PR this box cannot merge",
+      any(".github/workflows/" in d for d in _res.detail), _res.detail)
+check("the machine-readable answer records it too",
+      _res.data.get("can_merge_workflow_changes") is False, _res.data)
+check("the remedy does not teach the loop a second mode",
+      "human" in _res.remedy or "gh auth refresh" in _res.remedy, _res.remedy)
+
+_res = github_result(auth_status=GH_AUTH_STATUS.replace(
+    "'read:org'", "'read:org', 'workflow'"))
+check("a token WITH `workflow` scope passes",
+      _res.status == "PASS", f"{_res.status}: {_res.summary}")
+check("and says so, rather than staying silent about the class",
+      any(".github/workflows/" in d and "yes" in d for d in _res.detail), _res.detail)
+check("the machine-readable answer records the affirmative",
+      _res.data.get("can_merge_workflow_changes") is True, _res.data)
+
+_res = github_result(auth_status="github.com\n  - Active account: true\n")
+check("unreadable scopes never manufacture a warning",
+      _res.status == "PASS", f"{_res.status}: {_res.summary}")
+check("unreadable scopes are said out loud rather than assumed",
+      any("scope" in d and ("not" in d or "could not" in d) for d in _res.detail),
+      _res.detail)
+check("and the machine-readable answer is unknown, not False",
+      _res.data.get("can_merge_workflow_changes") is None, _res.data)
+
+
+# ------------------------------------- a stale copy of preflight must not answer (#3164)
+# Same exposure #3020 fixed in ci-wait.py and pr-body.py: an agent runs the copy
+# in its own worktree, and a worktree is created once and never fast-forwarded.
+# Measured 2026-09-06, 40 of the 59 worktrees carrying tools/preflight.py had a
+# version that was not origin/main's, across 4 distinct versions. A copy predating
+# #2936 reports a HEALTHY box as unable to push -- a wrong verdict, from the tool
+# whose entire job is to produce trustworthy ones.
+class FakeFreshness:
+    def __init__(self, refuse, notes=("note: preflight.py is STALE.",)):
+        self._refuse = refuse
+        self.notes = list(notes)
+        self.targets: list = []
+        self.remote_checks: list = []
+        self.__file__ = "/repo/tools/agent_self_freshness.py"
+
+    def assess(self, target, remote_check=True, **kw):
+        self.targets.append(target)
+        self.remote_checks.append(remote_check)
+        return pf_freshness_result(self._refuse, self.notes)
+
+
+def pf_freshness_result(refuse, notes):
+    class R:
+        pass
+    r = R()
+    r.refuse = refuse
+    r.notes = list(notes)
+    r.state = "stale" if refuse else "current"
+    return r
+
+
+def refusal_with(fresh, **kw):
+    saved = pf._freshness
+    pf._freshness = fresh
+    printed: list = []
+    try:
+        return pf.freshness_refusal(printed.append, **kw), printed
+    finally:
+        pf._freshness = saved
+
+
+_fake = FakeFreshness(refuse=True)
+_code, _printed = refusal_with(_fake)
+check("a stale preflight.py refuses rather than reporting on the box",
+      _code == 3, _code)
+check("the refusal is exit 3 -- could not complete, never a verdict about the box",
+      pf.EXIT_MEANING[3] and _code == 3, pf.EXIT_MEANING.get(3))
+check("the refusal explains itself and prints the notes",
+      any("STALE" in p for p in _printed) and
+      any("preflight" in p for p in "\n".join(_printed).splitlines()),
+      _printed)
+check("both this file and the freshness module itself are checked",
+      len(_fake.targets) == 2 and
+      any(t.endswith("preflight.py") for t in _fake.targets) and
+      any(t.endswith("agent_self_freshness.py") for t in _fake.targets),
+      _fake.targets)
+check("the remote is confirmed once, not once per file",
+      _fake.remote_checks == [True, False], _fake.remote_checks)
+
+_fake = FakeFreshness(refuse=False, notes=["note: current."])
+_code, _printed = refusal_with(_fake)
+check("a current copy answers normally", _code is None, _code)
+
+_code, _printed = refusal_with(FakeFreshness(refuse=True), remote_check=False)
+check("--no-freshness-fetch skips the ls-remote but not the staleness check",
+      _code == 3, _code)
+
+_saved = pf._freshness
+pf._freshness = None
+_printed = []
+try:
+    _code = pf.freshness_refusal(_printed.append)
+finally:
+    pf._freshness = _saved
+check("a copy detached from the freshness module answers, but says nothing checked it",
+      _code is None and any("could not establish" in p for p in _printed), _printed)
+
+# ---- and the refusal happens BEFORE anything is probed
+_probed: list = []
+_saved_check_space, _saved_refusal = pf.check_space, pf.freshness_refusal
+pf.check_space = lambda *a, **k: _probed.append(a) or pf.CheckResult(
+    name="disk", status="PASS", summary="x")
+pf.freshness_refusal = lambda *a, **k: 3
+_buf = io.StringIO()
+_saved_stdout = sys.stdout
+sys.stdout = _buf
+try:
+    _rc = pf.main(["--json"])
+finally:
+    sys.stdout = _saved_stdout
+    pf.check_space, pf.freshness_refusal = _saved_check_space, _saved_refusal
+check("main returns 3 on a stale copy", _rc == 3, _rc)
+check("a refused run probes nothing at all", _probed == [], _probed)
+_doc = json.loads(_buf.getvalue())
+check("--json still emits a document, so a machine reader cannot read silence as success",
+      _doc.get("exit_code") == 3, _buf.getvalue()[:200])
+check("the JSON refusal carries no checks and says why",
+      _doc.get("checks") == [] and "refusal" in _doc, sorted(_doc))
 
 
 print()


### PR DESCRIPTION
Closes #3076
Closes #3164
Closes #3192

Three defects, one file (`tools/preflight.py`), one shape: **a verdict that answers a narrower question than the one it appears to answer.** Batched under `.claude/rules/batch-sibling-issues-by-file.md`; each has its own RED → GREEN below.

## #3076 — a dropped packet failed the whole box

Measured RED against the code on `main`, with the push command scripted:

```
1-of-3 flaky transport: attempts=2 status=FAIL
   summary='push was refused: and the repository exists.'
broken credential:      attempts=2 status=PASS
   summary='push works (dry-run negotiated with origin; nothing was written)'
```

Both lines are wrong, and the second one is the reason the fix is not simply "retry more". `run_retry` was class-blind, so it retried a **publickey refusal** too — one later success turned a broken credential into a `PASS`. The check exists to catch exactly that.

**Where the line is drawn: the class of the failure, never the count.**

| failure | response | why |
|---|---|---|
| refusal — permission, authentication, `Repository not found`, host key | **FAIL on the first attempt, never retried** | it is a verdict; a second attempt can only delay it, and a later success must not be able to un-refuse it |
| transport — timeout, reset, DNS, refused connection, `kex_exchange_identification` | retried, spaced (1s, 3s), up to 3 attempts | one sample cannot distinguish it from a dropped packet |
| unrecognised | retried | treating an unclassified error as a credential verdict is the more expensive mistake |

And no number of retries can manufacture a `PASS`: a `PASS` still requires one attempt to negotiate successfully. When it took more than one, the verdict is a **WARN that says what it measured** — `push works, but the transport is FLAKY: 1 of 3 attempts succeeded (transient, transient, ok)` — because the box can work while every other round trip in the cycle is on the same unreliable path.

Two reporting fixes the issue asked for:

- **The reported line is now the cause.** `and the repository exists.` is the last line of boilerplate that *both* failure shapes print; the summary took `splitlines()[-1]`. It now picks the line that classifies, so the same failure reads `push was REFUSED: git@github.com: Permission denied (publickey).` or `... the remote was not reachable: ssh: connect to host github.com port 22: Connection timed out`.
- **The transport is named**, including the asymmetry that made #3076 confusing. Live on this box: `push transport: ssh (git@…); fetch is a different remote: https://…`.

`run_retry` also spaces its attempts now (0.7s × attempt). Back-to-back retries re-ask inside the same dropped-packet window; the measurement in the issue needed seconds, not milliseconds.

## #3164 — a stale copy of preflight.py answering anyway

Reachable here, and the harm is concrete rather than theoretical: a copy predating #2936 does not know mise prints a banner on stdout, parses the permissions JSON into `{}`, and reports a **healthy** account as unable to push — `FAIL`, exit 1, which the autonomous cycle treats as stop-everything. A copy predating #3095 reports nothing about the code-navigation tools and does not say that it did not look. So the failure mode is a *wrong* verdict, not a missing one, and a refusal is right. Same three-line shape as `pr-body.py`'s, checking both this file and `agent_self_freshness.py` itself, one `ls-remote` reused.

**Exit code: 3** — "could not complete", never a verdict about the box (exit 1 would claim the box is broken). `--json` still emits a document, with `checks: []` and a `refusal` object, so a machine reader cannot read silence on stdout as success. `--no-freshness-fetch` skips the `ls-remote` only, not the check.

**Measured, not reasoned.** I ran the pre-#2936 copy (`git show 68281ff6^:tools/preflight.py`) against a healthy admin account whose `gh` output carries mise's banner, which is what this box actually produces:

```
PRE-#2936 copy, healthy admin account: FAIL | StefanMaron cannot push to
    StefanMaron/BusinessCentral.AL.Runner, so the loop cannot open or merge anything
exit code from that verdict: 1
```

origin/main's copy answers `PASS` on the same input. That is the reachable failure, on the actual artifact.

**One limit worth stating.** This guard answers *staleness only* — a defect in `origin/main`'s own copy is carried faithfully by every fresh copy, and no freshness check can see it. (An earlier version of this paragraph claimed `tools/ci-wait.py` was currently broken in exactly that way. It is not: `origin/main`'s `ci-wait.py:380` reads `RULESET_CONTEXTS = ("BC test matrix passed", "Tests updated")`, which is correct after #3200. I checked that myself rather than leaving the claim standing, and it is a fair illustration of why the check below exists — the report came from a checkout that was 40+ commits behind. I did not touch `ci-wait.py`.)

## Also folded: `checkout` — how current the tree being measured is

Not from an open issue; from an incident during this task. A coordinator read `tools/ci-wait.py` out of a top-level checkout 40+ commits behind `origin/main`, found a constant `origin/main` had already renamed, concluded the tool was returning "could not determine" for every PR in the repository, and told four agents so. Nothing warned that the tree was old. It is the same question as #3164 one level up — the file guard covers `preflight.py`; this covers everything else read out of a tree — so it belongs in this diff rather than in a separate one.

```
PASS  checkout  the checkout preflight is running from is 4 commit(s) behind origin/main -
                within the normal drift (25 commits or 12h is where this warns)
                the checkout preflight is running from: on agent/stma-auto-1/issue-3076,
                    4 commit(s) behind origin/main, 2 ahead, branched 38m ago
                the main checkout: on main, 1 commit(s) behind origin/main, 0 ahead,
                    branched 28m ago
```

`origin/main` moves every ten to forty minutes here, so "behind at all" would fire on every run and be read by nobody; it WARNs past 25 commits or a branch point 12 hours old, and reports the count either way — the count being the part that was missing. Proven against **real throwaway git repositories** (3 behind → PASS with the number; 40 behind → WARN; 1 behind but branched 3 days ago → WARN; no `origin/main` → WARN saying it could not measure, never a PASS), because the claim is about what git reports and a fixture would prove nothing.

## #3192 — "merge a PR: yes" from the repository's permissions while the token could not

The repository's permissions and the token's scopes answer different questions. The check reported only the first, so `gh pr merge` refused workflow-touching PRs at the last step, after review and after CI. It now reads the scopes `gh auth status` prints and reports the class:

```
WARN  github  authenticated as StefanMaron with push access to …, but the token has no
               `workflow` scope: pull requests touching .github/workflows/ cannot be merged
               from this box
               merge a PR: yes; label and assign: yes (both need push or triage)
               merge a PR that touches .github/workflows/: no - needs the token's `workflow`
               scope; scopes: admin:public_key, gist, read:org, repo
```

That is this box, live — it reproduces the issue's measurement.

**WARN, not FAIL**, and no routing change: the skill is explicit that a missing permission is a precondition to report, not a second mode to implement. The remedy names both defensible options (grant the scope, or accept that those PRs need a human) and says not to teach the loop to route around it. The decision stays with the account holder.

**Absence of evidence is not reported as a negative.** A fine-grained token prints `Token scopes: none`, and some `gh` versions print no such line; both are recorded as *unknown* (`can_merge_workflow_changes: null`), never as "the scope is missing". Only a non-empty classic scope list produces the warning.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site?** Yes — `check_github` runs `gh auth status`, which validates the token over the network, and a transient failure there reported *"gh is installed but not authenticated"*: the same false credential verdict one function over. Both still FAIL (a loop that cannot reach GitHub cannot work), but they now send the reader to different places. Covered by its own test.
2. **Sibling functions making the same assumption?** `pr_map` and the permissions read go through `run_retry`, which now spaces its attempts, and both already degrade to a reported "unavailable" rather than a verdict — the worktree census keeps everything it cannot resolve. No change needed there.
3. **Two paths writing the same state with different invariants?** Not applicable; these are read-only probes.

## Does this PR assert anything about what BC does?

**No.** `tools/preflight.py` is runner infrastructure — process configuration, git and GitHub plumbing, box health. Nothing here is a claim a BC service tier could adjudicate, so it owes no upstream corpus test (`.claude/rules/bc-behavior-tests-go-upstream.md`). Its proving tests are the Python tests next to the tool.

## Tests

70 new checks in `tools/test_preflight.py`, which the required `tools/ unit tests` context runs.

- **RED, before the fix:** the behavioral run quoted above (wrong on both directions), plus `AttributeError: module 'preflight' has no attribute 'classify_transport_error'` for the new surface.
- **GREEN:** whole file passes, 277 checks.
- **Mutation-checked**, because a passing test that proves nothing is the failure mode here. Removing the auth short-circuit, removing the refusal classification, and hardcoding `can_workflow = True` each turn the suite red (9 checks fail) rather than sliding through.
- Every `tools/test_*.py` suite passes locally.
- End-to-end on this box: `PASS push` with the transport named, `WARN github` with the scope line, and the freshness note correctly identifying this branch as *editing* the tool rather than stale.

## Deliberately not folded

- **#3149** (worktree removal refuses on the `tests/al-language` submodule) and **#3232** (122 worktrees / 19 GB, nothing reaps them). Both touch preflight's reaper, but the work is a liveness rule for deciding which worktrees are abandoned — a different question needing its own diagnosis, with unrecoverable consequences if it is wrong, plus contract/doc changes outside this file. Folding them would make this diff two unrelated reviews.
- **#3171** (two loops shared the `impl-N` pool) — agent-contract documentation, not preflight code.
- **`tools/ci-wait.py`'s stale `RULESET_CONTEXTS`** — a live defect, another agent is on it, and touching it here would collide.

---
*Written by an agent (`stma-auto-1`) acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
