### PR TITLE
fix(ci-wait): complete the built-in required-context fallback, and stop the test fixtures freezing the ruleset size

### DIFF
--- a/.github/scripts/check_required_contexts.py
+++ b/.github/scripts/check_required_contexts.py
@@ -133,7 +133,18 @@ import yaml
 # pr-check.yml produces no required context — but the merge itself is blocked until the
 # ruleset carries the new name, because until then the PR waits on a context no workflow
 # reports any more.
-DEFAULT_REQUIRED_CONTEXTS = ["BC test matrix passed", "Tests updated"]
+DEFAULT_REQUIRED_CONTEXTS = [
+    "BC test matrix passed",
+    "Tests updated",
+    "PR title/body must not contain a CI-skip directive",
+    "PR body closing references must be correct, both directions",
+    "pull_request trigger lists must keep their load-bearing event types",
+    "Required contexts must not be cancellable on the same commit",
+    "Agent definitions must allowlist the MCP tools they document",
+    "tools/ unit tests",
+    ".github/scripts/ unit tests",
+    "scripts/ unit tests",
+]
 
 # Contexts this repository INTENDS the branch ruleset to require, but which it
 # does not require yet (#3165). Everything in pr-gate.yml is here.
@@ -166,16 +177,15 @@ DEFAULT_REQUIRED_CONTEXTS = ["BC test matrix passed", "Tests updated"]
 # is outstanding -- ci-wait.py reads the LIVE ruleset first and only falls back
 # to its built-in tuple when that read fails, loudly -- so the promotion is
 # tidying, not a race.
-PENDING_REQUIRED_CONTEXTS = [
-    "PR title/body must not contain a CI-skip directive",
-    "PR body closing references must be correct, both directions",
-    "pull_request trigger lists must keep their load-bearing event types",
-    "Required contexts must not be cancellable on the same commit",
-    "Agent definitions must allowlist the MCP tools they document",
-    "tools/ unit tests",
-    ".github/scripts/ unit tests",
-    "scripts/ unit tests",
-]
+# Empty, and that is the finished state, not an oversight: the `main` ruleset
+# requires all ten names in DEFAULT_REQUIRED_CONTEXTS above, so nothing is
+# waiting to be gated (#3199, measured 2026-09-06). Keeping the list empty is
+# what makes the live drift comparison in resolve_contexts() EXACT again --
+# every pending name is a name the comparison deliberately tolerates in either
+# state, so a non-empty list is a hole in the #2785 check for as long as it
+# lasts. Refill it only while a new gating job is landing, and empty it in the
+# same pass that adds the name to the ruleset.
+PENDING_REQUIRED_CONTEXTS: list[str] = []
 
 REPO = "StefanMaron/BusinessCentral.AL.Runner"
 DEFAULT_BRANCH = "main"

--- a/.github/scripts/test_check_required_contexts.py
+++ b/.github/scripts/test_check_required_contexts.py
@@ -316,6 +316,36 @@ jobs:
 }
 
 
+def _extra_gate_workflow(contexts) -> str:
+    """A safe pull_request workflow producing exactly `contexts`.
+
+    DERIVED from DEFAULT_REQUIRED_CONTEXTS rather than written out, so the
+    fixture cannot drift from the list it is meant to exercise. When the eight
+    pr-gate.yml contexts were promoted into that list (#3199), a hand-written
+    fixture covering only the original two made four tests fail with "required
+    context ... is produced by NO workflow" -- a fixture problem wearing the
+    costume of a real finding. Generating it removes that failure mode: add a
+    required context and this fixture grows with it.
+
+    No `concurrency:` block, so it is safe under the #2726 rule even though it
+    lists the same-SHA trigger types the real pr-gate.yml does.
+    """
+    jobs = "".join(
+        f"  gate{i}:\n    name: {c}\n    runs-on: ubuntu-latest\n"
+        for i, c in enumerate(contexts)
+    )
+    return ("\nname: PR Gate\non:\n  pull_request:\n"
+            "    types: [opened, synchronize, reopened, labeled, unlabeled, edited]\n"
+            "jobs:\n" + jobs)
+
+
+# The two above are produced by the two hand-written workflows; everything else
+# the ruleset requires gets a generated job so the guard has a producer for it.
+_ALREADY = {"Tests updated", "BC test matrix passed"}
+SAFE_WORKFLOWS["pr-gate.yml"] = _extra_gate_workflow(
+    [c for c in crc.DEFAULT_REQUIRED_CONTEXTS if c not in _ALREADY])
+
+
 def rules_payload(contexts):
     """The shape GET /repos/{o}/{r}/rules/branches/main returns (measured 2026-09-05)."""
     return [
@@ -510,8 +540,12 @@ check("a PENDING context in a workflow that cannot cancel it passes",
 
 # The drift comparison, both sides of the window. This is the pair that decides
 # whether the PR is mergeable before the ruleset edit AND after it.
+# A SEPARATE key, not "pr-gate.yml": SAFE_WORKFLOWS already carries a generated
+# pr-gate.yml producing every promoted required context (#3199), and overwriting
+# it here would leave those eight with no producer, failing the guard for a
+# reason that has nothing to do with the pending seam under test.
 _PENDING_WF = dict(SAFE_WORKFLOWS)
-_PENDING_WF["pr-gate.yml"] = PENDING_SAFE
+_PENDING_WF["pending-gate.yml"] = PENDING_SAFE
 
 rc, msg = run_live(lambda: rules_payload(crc.DEFAULT_REQUIRED_CONTEXTS),
                    files=_PENDING_WF, pending="Soon To Gate")
@@ -657,6 +691,46 @@ check("...and none of them sets REQUIRED_CONTEXTS or PENDING_CONTEXTS",
       not _offenders, "; ".join(_offenders))
 check("...and at least one runs the LIVE drift comparison with no bypass",
       _unbypassed > 0, f"{_unbypassed} of {_invocations} invocation(s) unbypassed")
+
+# --- OPT-IN, network. Everything above is offline on purpose (see the note at
+# --- the REQUIRED_CONTEXTS override): making the whole file need a network call
+# --- would turn a GitHub API blip into a red unit-test job. This block asks the
+# --- one question the offline tests structurally cannot -- do the two built-in
+# --- lists match what the `main` ruleset ACTUALLY requires right now -- and runs
+# --- only when asked for with CI_LIVE_RULESET_CHECK=1.
+# ---
+# --- This is not the repository's only live enforcement, and it is not the main
+# --- one. pr-check.yml runs check_required_contexts.py itself with no bypass on
+# --- every pull request, and resolve_contexts() there fails on drift in either
+# --- direction. With PENDING_REQUIRED_CONTEXTS empty that comparison is EXACT,
+# --- so a ruleset change is caught on the next PR without anyone opting in. What
+# --- this block adds is the ability to ask the question on demand, from a
+# --- developer's machine, without opening a PR to find out (#3199).
+if os.environ.get("CI_LIVE_RULESET_CHECK") == "1":
+    print()
+    print("live ruleset comparison (CI_LIVE_RULESET_CHECK=1)")
+    try:
+        _live = sorted(crc.load_ci_wait().contexts_from_branch_rules(
+            crc.fetch_branch_rules()) or [])
+    except Exception as _exc:  # noqa: BLE001 - a failed lookup is a failed check
+        _live = None
+        check("the live branch ruleset could be read", False, repr(_exc))
+
+    if _live:
+        # A failed lookup is NOT agreement -- the same rule the guard itself
+        # applies. An empty/None parse lands in the `if _live:` false branch and
+        # is reported by the check above rather than passing silently.
+        check("DEFAULT_REQUIRED_CONTEXTS matches the live `main` ruleset exactly",
+              sorted(crc.DEFAULT_REQUIRED_CONTEXTS) == _live,
+              f"built-in={sorted(crc.DEFAULT_REQUIRED_CONTEXTS)} live={_live}")
+        check("...and so does tools/ci-wait.py's RULESET_CONTEXTS",
+              sorted(crc.load_ci_wait().RULESET_CONTEXTS) == _live,
+              f"built-in={sorted(crc.load_ci_wait().RULESET_CONTEXTS)} live={_live}")
+        # The promotion obligation from #3199: a name the ruleset already
+        # requires has no business sitting in the transitional list.
+        check("...and no PENDING name is already required by the live ruleset",
+              not (set(PENDING or []) & set(_live)),
+              f"pending={sorted(set(PENDING or []) & set(_live))}")
 
 print()
 if FAILURES:

--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -377,7 +377,18 @@ def resolve_required_contexts(branch: str = "main", fetch=None):
 # run had measured. This tuple and DEFAULT_REQUIRED_CONTEXTS in
 # .github/scripts/check_required_contexts.py must stay identical to each other AND to the
 # live ruleset — that guard fails on drift in either direction (#2785).
-RULESET_CONTEXTS = ("BC test matrix passed", "Tests updated")
+RULESET_CONTEXTS = (
+    "BC test matrix passed",
+    "Tests updated",
+    "PR title/body must not contain a CI-skip directive",
+    "PR body closing references must be correct, both directions",
+    "pull_request trigger lists must keep their load-bearing event types",
+    "Required contexts must not be cancellable on the same commit",
+    "Agent definitions must allowlist the MCP tools they document",
+    "tools/ unit tests",
+    ".github/scripts/ unit tests",
+    "scripts/ unit tests",
+)
 
 NOT_FAILURES = ("success", "neutral", "skipped")
 
@@ -787,6 +798,39 @@ def classify(runs: list[dict],
                 "whose check run does not exist yet is not in it at all. Do not scope",
                 "a diagnosis to these names until every check has reported; re-run",
                 "this tool, or read `gh pr checks` once the run finishes.",
+            ]
+        if inflight:
+            # #2922. The verdict stays exit 1 -- a failure is a verdict, and
+            # holding every genuinely-red PR back for a queued run costs real
+            # time on the common case. But the reader is now TOLD that a newer
+            # run of the same workflow is in flight on this commit, because the
+            # conclusion above is not necessarily the one a ruleset will end up
+            # reading.
+            #
+            # The concrete sequence, from #2922: require-tests.yml produces the
+            # required `Tests updated` context, carries no `concurrency` block
+            # (#2726) and triggers on 'labeled'. A `no-tests-needed` label
+            # applied mid-wait starts a second run on the same SHA; the first
+            # run's `failure` is what the rollup still shows, and the second
+            # reports `skipped`, satisfying the ruleset. Reporting the failure
+            # was right; reporting it without this caveat sent the reader to a
+            # log that had already been overtaken.
+            #
+            # Only the annotation is new. superseding_runs() already computed
+            # these pairs for the guards below -- the failure branch
+            # short-circuits ahead of them, so it was discarding information it
+            # already held.
+            lines += [
+                "",
+                "CAVEAT: a newer run of the same workflow is still in flight on this",
+                "commit, so the conclusion above may be overturned before a ruleset",
+                "reads it:",
+            ]
+            lines += [f"  {c}: superseded by workflow run {w}" for c, w in inflight]
+            lines += [
+                "Re-run this tool once that run finishes before treating the failure",
+                "above as final. Do NOT `gh run rerun` the failing run -- that destroys",
+                "its log permanently (.claude/rules/ci-verdicts.md).",
             ]
         return Verdict(1, lines, log_target=bad[0], progress=progress)
 

--- a/tools/test_ci_wait.py
+++ b/tools/test_ci_wait.py
@@ -60,6 +60,31 @@ def green_set(**kw):
     return runs
 
 
+def padded(runs, wf_run: int = 1, base_id: int = 990000):
+    """`runs` plus a passing check run for every ruleset context it omits.
+
+    Most fixtures below reconstruct ONE interesting context -- a supersession, a
+    cancellation, an ordering inversion -- and were written when the ruleset
+    required two contexts, so listing the other one by hand was the whole job.
+    With ten required contexts (#3199) an unpadded fixture leaves eight of them
+    `missing`, and classify() correctly answers "not everything has reported"
+    instead of the question the test is asking. Padding restores the intended
+    single variable: everything else is present and green, so the verdict can
+    only be about the shape under test.
+
+    Deliberately additive and name-checked -- it never overwrites an entry the
+    fixture placed itself, so it cannot mask the very conclusion being asserted.
+    """
+    have = {r["name"] for r in runs}
+    out = list(runs)
+    for i, c in enumerate(cw.RULESET_CONTEXTS):
+        if c not in have:
+            out.append({"name": c, "status": "completed", "conclusion": "success",
+                        "id": base_id + i,
+                        "details_url": f"https://x/actions/runs/{wf_run}/job/{base_id + i}"})
+    return out
+
+
 print("ci-wait.py verdict logic")
 
 # --- the plain green case must stay green, or a fix that flags everything wins
@@ -200,7 +225,7 @@ runs = [run(n, "success") for n in LEGS]
 runs.append(run("BC test matrix passed", "success"))
 runs.append(run("Tests updated", "failure", cid=101297899468))
 runs.append(run("Tests updated", "skipped", cid=101297995090))
-v = cw.classify(runs)
+v = cw.classify(padded(runs))
 check("a failure superseded by a newer skipped run is GREEN, not FAILED",
       v.code == 0, f"(code={v.code}) {v.lines}")
 
@@ -210,7 +235,7 @@ runs = [run(n, "success") for n in LEGS]
 runs.append(run("BC test matrix passed", "success"))
 runs.append(run("Tests updated", "skipped", cid=101297899468))
 runs.append(run("Tests updated", "failure", cid=101297995090))
-v = cw.classify(runs)
+v = cw.classify(padded(runs))
 check("...but a failure that IS the newest entry still fails", v.code == 1, f"(code={v.code})")
 
 # --- an older cancelled entry must not hold the pool 'incomplete' forever
@@ -218,7 +243,7 @@ runs = [run(n, "success") for n in LEGS]
 runs.append(run("BC test matrix passed", "success"))
 runs.append(run("Tests updated", "cancelled", cid=10))
 runs.append(run("Tests updated", "success", cid=20))
-v = cw.classify(runs)
+v = cw.classify(padded(runs))
 check("an older cancelled entry does not stall the verdict", v.code == 0, f"(code={v.code})")
 
 # --- an empty rollup is not a verdict
@@ -413,7 +438,10 @@ def two_run_set(old_conclusion, new_conclusion):
     # the OLDER run's job started later, so it carries the HIGHER check-run id
     runs.append(cr("Tests updated", old_conclusion, OLD_RUN, 101303131614))
     runs.append(cr("Tests updated", new_conclusion, NEW_RUN, 101303055037))
-    return runs
+    # Attributed to NEW_RUN, the live one: padding backed by an unknown run id
+    # would read as "a newer run may re-report this" and hold the verdict
+    # pending, which is the opposite of the single variable under test.
+    return padded(runs, wf_run=NEW_RUN)
 
 
 v = cw.classify(two_run_set("failure", "success"), workflow_runs=ALL_DONE_RUNS)
@@ -474,7 +502,7 @@ runs = [cr(n, "success", NEW_RUN, 101303055000 + i) for i, n in enumerate(LEGS)]
 runs.append(cr("BC test matrix passed", "success", NEW_RUN, 101303055107))
 runs.append(cr("Tests updated", "failure", NEW_RUN, 101303055037))
 runs.append(cr("Tests updated", "success", NEW_RUN, 101303099999))
-v = cw.classify(runs, workflow_runs=ALL_DONE_RUNS)
+v = cw.classify(padded(runs, wf_run=NEW_RUN), workflow_runs=ALL_DONE_RUNS)
 check("inside one workflow run the newer check-run id still wins",
       v.code == 0, f"(code={v.code}) {v.lines}")
 
@@ -507,7 +535,7 @@ check("...and warns the failing list can still grow",
 runs = [cr(LEGS[0], "failure", NEW_RUN, 101303055001),
         cr("BC test matrix passed", None, NEW_RUN, 101303055107, status="queued"),
         cr("Tests updated", "success", NEW_RUN, 101303055037)]
-v = cw.classify(runs, workflow_runs=QUEUED_RUNS)
+v = cw.classify(padded(runs, wf_run=NEW_RUN), workflow_runs=QUEUED_RUNS)
 check("the unreported count is stated as a LOWER bound, not an exact number",
       any("at least 1 required check" in l for l in v.lines), v.lines)
 check("...and the caveat says a leg with no check run yet is not counted at all",
@@ -518,7 +546,7 @@ runs = [cr(LEGS[0], "failure", NEW_RUN, 101303055001),
         cr(LEGS[1], "success", NEW_RUN, 101303055002),
         cr("BC test matrix passed", "failure", NEW_RUN, 101303055107),
         cr("Tests updated", "success", NEW_RUN, 101303055037)]
-v = cw.classify(runs, workflow_runs=ALL_DONE_RUNS)
+v = cw.classify(padded(runs, wf_run=NEW_RUN), workflow_runs=ALL_DONE_RUNS)
 check("a complete rollup's failing list carries no 'still to come' caveat",
       v.code == 1 and not any("grow" in l.lower() for l in v.lines),
       f"(code={v.code}) {v.lines}")
@@ -842,8 +870,9 @@ check("an EMPTY required-context set is refused too", v.code == 3,
 # A green must be able to account for every ruleset context BY NAME, and say so.
 # Every real green that night named 9 or 10 checks; both false greens named 1.
 v = cw.classify(green_set())
+_n = len(cw.RULESET_CONTEXTS)
 check("a green names how many ruleset contexts it accounted for",
-      any("2/2 ruleset context(s)" in l for l in v.lines), v.lines)
+      any(f"{_n}/{_n} ruleset context(s)" in l for l in v.lines), v.lines)
 check("...and names them",
       all(any(c in l for l in v.lines) for c in cw.RULESET_CONTEXTS), v.lines)
 
@@ -861,15 +890,26 @@ RECORDED_BRANCH_RULES = [
     {"type": "required_status_checks", "ruleset_id": 15001420, "parameters": {
         "strict_required_status_checks_policy": False,
         "do_not_enforce_on_create": False,
-        "required_status_checks": [{"context": "BC test matrix passed"},
-                                   {"context": "Tests updated"}]}},
+        "required_status_checks": [
+            {"context": ".github/scripts/ unit tests"},
+            {"context": "Agent definitions must allowlist the MCP tools they document"},
+            {"context": "BC test matrix passed"},
+            {"context": "PR body closing references must be correct, both directions"},
+            {"context": "PR title/body must not contain a CI-skip directive"},
+            {"context": "Required contexts must not be cancellable on the same commit"},
+            {"context": "Tests updated"},
+            {"context": "pull_request trigger lists must keep their load-bearing event types"},
+            {"context": "scripts/ unit tests"},
+            {"context": "tools/ unit tests"}]}},
 ]
 DEGRADED_BRANCH_RULES = [
     r for r in RECORDED_BRANCH_RULES if r["type"] != "required_status_checks"
 ] + [{"type": "required_status_checks", "ruleset_id": 15001420, "parameters": {
         "strict_required_status_checks_policy": False,
         "do_not_enforce_on_create": False,
-        "required_status_checks": [{"context": "Tests updated"}]}}]
+        "required_status_checks": [
+            {"context": c} for c in cw.RULESET_CONTEXTS
+            if c != "BC test matrix passed"]}}]
 
 ctx, status, notes = cw.resolve_required_contexts(fetch=lambda b: RECORDED_BRANCH_RULES)
 check("the recorded live ruleset resolves to both required contexts",
@@ -891,12 +931,11 @@ check("an UNREADABLE ruleset falls back to the full built-in set, never a subset
 
 EXTRA = RECORDED_BRANCH_RULES[:3] + [
     {"type": "required_status_checks", "ruleset_id": 15001420, "parameters": {
-        "required_status_checks": [{"context": "BC test matrix passed"},
-                                   {"context": "Tests updated"},
-                                   {"context": "Some new gate"}]}}]
+        "required_status_checks": [{"context": c} for c in cw.RULESET_CONTEXTS]
+                                  + [{"context": "Some new gate"}]}}]
 ctx, status, notes = cw.resolve_required_contexts(fetch=lambda b: EXTRA)
 check("a context ADDED in the UI is picked up and waited for",
-      sorted(ctx) == ["BC test matrix passed", "Some new gate", "Tests updated"]
+      sorted(ctx) == sorted(list(cw.RULESET_CONTEXTS) + ["Some new gate"])
       and status == "live", f"{ctx} {status}")
 
 
@@ -936,7 +975,11 @@ def absorbed_failure_set(failing_name):
     # the cancelled leftover, and a genuinely failing NEWEST entry for one name
     runs.append(cr(failing_name, "cancelled", KILLED_PR_CHECK, 101496919780))
     runs.append(cr(failing_name, "failure", LIVE_PR_CHECK, 101496925176))
-    return runs
+    # padded() never overwrites a name the caller placed, so when `failing_name`
+    # IS a ruleset context its failure stands and is not papered over by a
+    # synthetic success. The "same shape on a REQUIRED context" assertion below
+    # depends on exactly that.
+    return padded(runs, wf_run=MATRIX_RUN)
 
 
 runs = absorbed_failure_set("preflight.py unit tests")
@@ -964,7 +1007,7 @@ runs.append(cr("BC test matrix passed", "success", MATRIX_RUN, 101499731123))
 runs.append(cr("Tests updated", "success", REQ_RUN, 101496768931))
 runs.append(cr("scripts/ unit tests", "cancelled", KILLED_PR_CHECK, 101496919785))
 runs.append(cr("scripts/ unit tests", "success", LIVE_PR_CHECK, 101496925213))
-v = cw.classify(runs, workflow_runs=C6377B30_RUNS)
+v = cw.classify(padded(runs, wf_run=MATRIX_RUN), workflow_runs=C6377B30_RUNS)
 check("a cancelled entry a newer run re-reported as SUCCESS is still GREEN",
       v.code == 0, f"(code={v.code}) {v.lines}")
 check("...and is still explained as harmlessly superseded",
@@ -989,12 +1032,17 @@ check("...and never describes that failure as harmless",
 runs = [cr(n, "success", MATRIX_RUN, 101496852900 + i) for i, n in enumerate(LEGS)]
 runs.append(cr("BC test matrix passed", "success", MATRIX_RUN, 101499731123))
 runs.append(cr("Tests updated", "success", REQ_RUN, 101496768931))
-runs.append(cr("scripts/ unit tests", "failure", KILLED_PR_CHECK, 101496919785))
-v = cw.classify(runs, workflow_runs=C6377B30_RUNS)
+# _COSMETIC, not "scripts/ unit tests": that name became a REQUIRED ruleset
+# context (#3199), and a required context left `cancelled` correctly BLOCKS
+# (exit 4) rather than being discounted. The required version of this shape is
+# already asserted immediately above; this one is about the non-required path,
+# so it needs a name that is genuinely not required.
+runs.append(cr(_COSMETIC, "failure", KILLED_PR_CHECK, 101496919785))
+v = cw.classify(padded(runs, wf_run=MATRIX_RUN), workflow_runs=C6377B30_RUNS)
 check("a failure from a run that is itself CANCELLED is still discounted",
       v.code == 0, f"(code={v.code}) {v.lines}")
 check("...and is not announced as a real failing check",
-      not any("scripts/ unit tests" in l and "failure" in l for l in v.lines),
+      not any(_COSMETIC in l and "failure" in l for l in v.lines),
       "\n".join(v.lines))
 
 # A REQUIRED context whose check run concluded `failure` on its merits inside a

--- a/tools/test_ci_wait.py
+++ b/tools/test_ci_wait.py
@@ -45,10 +45,18 @@ LEGS = ["bc-tests / BC 27.0 (required)", "bc-tests / BC 28.3 (required)"]
 
 
 def green_set(**kw):
+    """Two matrix legs plus a success for EVERY ruleset context.
+
+    Derived from cw.RULESET_CONTEXTS rather than listing context names, so the
+    baseline "everything reported and passed" fixture cannot fall behind the
+    list it is exercising. It did exactly that when the eight pr-gate.yml
+    contexts were promoted (#3199): a fixture naming three contexts left the
+    other seven `missing` from the rollup, and 37 checks failed for a reason
+    that was entirely about the fixture. Deriving it means a context added to
+    the ruleset is automatically reported here too.
+    """
     runs = [run(n, "success") for n in LEGS]
-    runs.append(run("BC test matrix passed", "success"))
-    runs.append(run("Tests updated", "success"))
-    runs.append(run("scripts/ unit tests", "success"))
+    runs += [run(c, "success") for c in cw.RULESET_CONTEXTS]
     return runs
 
 
@@ -57,8 +65,16 @@ print("ci-wait.py verdict logic")
 # --- the plain green case must stay green, or a fix that flags everything wins
 v = cw.classify(green_set())
 check("an all-success rollup is GREEN", v.code == 0, f"(code={v.code}) {v.lines}")
+# The roster line a green verdict prints NAMES every ruleset context, and one of
+# them is literally "Required contexts must not be cancellable on the same
+# commit" (#3199). Substring-matching "cancel" across all lines therefore fires
+# on the context's own name and not on any finding. The claim being made here is
+# "this verdict reports no cancellation", so the roster is excluded and the rest
+# is matched as before.
+_findings = [l for l in v.lines
+             if not l.startswith("Ruleset contexts confirmed present and passing")]
 check("...and says nothing about cancellations",
-      not any("cancel" in l.lower() for l in v.lines), v.lines)
+      not any("cancel" in l.lower() for l in _findings), _findings)
 
 # --- a real failure still outranks everything, and still gets its log fetched
 runs = green_set()
@@ -92,11 +108,17 @@ check("...but is still mentioned, so the grey entries are explained",
 # --- a cancelled NON-required context does not block a merge, so it must not
 # --- produce a blocking verdict either
 runs = green_set()
-runs.append(run("scripts/ unit tests", "cancelled", cid=9999))
+# NOT "scripts/ unit tests" any more -- that became a required ruleset context
+# (#3199), so it stopped being a witness for this claim and started asserting
+# the opposite one. And not anything containing the word "required" either:
+# is_required() matches that substring to catch the bc-tests matrix legs.
+_COSMETIC = "coverage-demo / smoke"
+assert _COSMETIC not in cw.RULESET_CONTEXTS and not cw.is_required(_COSMETIC)
+runs.append(run(_COSMETIC, "cancelled", cid=9999))
 v = cw.classify(runs)
 check("a cancelled non-required context stays GREEN", v.code == 0, f"(code={v.code}) {v.lines}")
 check("...and is named as cosmetic",
-      any("scripts/ unit tests" in l for l in v.lines), v.lines)
+      any(_COSMETIC in l for l in v.lines), v.lines)
 
 # --- a cancelled required LEG is a required context too
 runs = green_set()
@@ -151,18 +173,24 @@ check("a required context absent from the rollup is pending, not green, "
 # --- 'Tests updated' = skipped on their head SHA with 'BC test matrix passed'
 # --- = success -- #2759 (451c757b), #2749 (8717aec3), #2717 (dbd3a1a2) and
 # --- #2668 (3d1e9792). GitHub's ruleset accepted every one of them.
-runs = [run(n, "success") for n in LEGS]
-runs.append(run("BC test matrix passed", "success"))
-runs.append(run("Tests updated", "skipped"))
+runs = green_set()
+for _r in runs:
+    if _r["name"] == "Tests updated":
+        _r["conclusion"] = "skipped"
 v = cw.classify(runs)
 check("a skipped required context is not a failure", v.code == 0, f"(code={v.code}) {v.lines}")
 # A DISTINCT claim, not `v.code == 0` a second time: `skipped` must count as a
 # check that HAS reported. If it were treated as unreported, the verdict would
 # still be 0 here (nothing failed) while the progress line under-counted the
 # completed pool -- green for the wrong reason, and invisible to a code check.
+# The pool size is derived, not written as a literal: every entry in green_set()
+# is required (the legs by their "(required)" suffix, the rest by being ruleset
+# contexts), so a hardcoded "4/4" silently stopped describing this fixture the
+# moment the ruleset grew.
+_pool = f"{len(runs)}/{len(runs)} complete"
 check("...and a skipped required context counts as reported, not as still-pending",
-      v.progress.startswith("4/4 complete") and "not in the rollup" not in v.progress,
-      f"progress={v.progress!r}")
+      v.progress.startswith(_pool) and "not in the rollup" not in v.progress,
+      f"progress={v.progress!r} expected to start with {_pool!r}")
 
 # --- real data, PR #2740 head 6b95477f: 'Tests updated' failed, then a
 # --- no-tests-needed label produced a newer 'skipped'. GitHub read the newer
@@ -299,8 +327,7 @@ check("...and says which ruleset contexts it actually confirmed",
 # workflow run id 1 while QUEUED_RUNS has run 33964656436 queued. The control is
 # now run against a finished run list, where the only thing left to vary is the
 # context set. The "still in flight" question gets its own section further down.
-v = cw.classify(green_set(), contexts=("BC test matrix passed", "Tests updated",
-                                       "Provenance attested"),
+v = cw.classify(green_set(), contexts=cw.RULESET_CONTEXTS + ("Provenance attested",),
                 workflow_runs=ALL_DONE_RUNS)
 check("a context newly added to the ruleset is NOT reported green",
       v.code != 0, f"(code={v.code}) {v.lines}")
@@ -309,15 +336,14 @@ check("...and, with every workflow run finished, reads as BLOCKED rather than pe
 check("...and names the context nothing reported",
       any("Provenance attested" in l for l in v.lines), v.lines)
 
-v = cw.classify(green_set(), contexts=("BC test matrix passed", "Tests updated"),
+v = cw.classify(green_set(), contexts=cw.RULESET_CONTEXTS,
                 workflow_runs=ALL_DONE_RUNS)
 check("...while the same rollup and run list with the known context set is green",
       v.code == 0, f"(code={v.code}) {v.lines}")
 
 # ...and the pending path for a newly-required context is still reachable, when
 # the run list says something is genuinely still coming.
-v = cw.classify(green_set(), contexts=("BC test matrix passed", "Tests updated",
-                                       "Provenance attested"),
+v = cw.classify(green_set(), contexts=cw.RULESET_CONTEXTS + ("Provenance attested",),
                 workflow_runs=QUEUED_RUNS)
 check("a context newly added to the ruleset keeps the verdict pending "
       "while a workflow run is still queued",
@@ -517,9 +543,18 @@ TM_RUN, RT_RUN_OLD, RT_RUN_NEW = 33964656436, 33983248257, 33983299999
 
 
 def present_but_stale_rollup():
+    """Everything reported, with `Tests updated` owned by the OLD Require Tests run.
+
+    The remaining ruleset contexts are attached to TM_RUN and derived from
+    cw.RULESET_CONTEXTS for the same reason green_set() is: only `Tests updated`
+    is meant to be stale here, and any context missing from this rollup would
+    hold the verdict pending for an unrelated reason and quietly defeat the
+    supersession assertions built on it.
+    """
     runs = [cr(n, "success", TM_RUN, 101303055000 + i) for i, n in enumerate(LEGS)]
-    runs.append(cr("BC test matrix passed", "success", TM_RUN, 101303055107))
     runs.append(cr("Tests updated", "success", RT_RUN_OLD, 101352123189))
+    for i, c in enumerate(x for x in cw.RULESET_CONTEXTS if x != "Tests updated"):
+        runs.append(cr(c, "success", TM_RUN, 101303055107 + i))
     return runs
 
 
@@ -590,6 +625,34 @@ runs[0] = cr(LEGS[0], "failure", TM_RUN, 101303055000)
 v = cw.classify(runs, workflow_runs=SUPERSEDING)
 check("a failing required leg still reports FAILED with a superseding run queued",
       v.code == 1, f"(code={v.code}) {v.lines}")
+
+# #2922: exit 1 stays, but the reader must be TOLD the conclusion can still be
+# overturned. Without this the caller sees a bare FAILED and goes off to read a
+# log for a run that a queued replacement may supersede -- the exact
+# "Tests updated goes failure -> skipped after a no-tests-needed label" sequence
+# in #2922, where the failing verdict was real when read and wrong by the time
+# it was acted on. `superseding_runs()` already computed the run id; the failure
+# branch simply short-circuited ahead of it and never printed what it knew.
+_txt = "\n".join(v.lines)
+check("...and that FAILED verdict names the in-flight run that may overturn it",
+      str(RT_RUN_NEW) in _txt, f"lines={v.lines}")
+check("...and names the context the superseding run will re-report",
+      "Tests updated" in _txt, f"lines={v.lines}")
+check("...and still points at a failing check to read (the log target survives)",
+      v.log_target is not None and v.log_target.get("name") == LEGS[0],
+      f"log_target={v.log_target}")
+
+# The control that keeps the annotation honest: with NO superseding run in
+# flight, the same failing rollup must NOT carry the caveat. Otherwise the line
+# is decoration that always prints and tells the reader nothing.
+_runs_settled = present_but_stale_rollup()
+_runs_settled[0] = cr(LEGS[0], "failure", TM_RUN, 101303055000)
+_v_settled = cw.classify(_runs_settled, workflow_runs=SETTLED)
+check("a failing leg with NO superseding run in flight is still exit 1",
+      _v_settled.code == 1, f"(code={_v_settled.code}) {_v_settled.lines}")
+check("...and carries no in-flight caveat",
+      str(RT_RUN_NEW) not in "\n".join(_v_settled.lines),
+      f"lines={_v_settled.lines}")
 
 # The sibling path with the same blind spot: a `cancelled` required context whose
 # replacement run is already queued used to read as exit 4, telling the caller to


### PR DESCRIPTION
Closes #3199
Closes #2922

## What this is, and what it is not

This is a **correctness improvement, not a fix to a live breakage.** `tools/ci-wait.py`
works correctly on `main` today: it reads the live branch ruleset on every invocation and
judges on all ten required contexts. Measured against live PR #3238 before this change:

```
GREEN on 4de6cb0b -- all 13 required checks passed (10/10 ruleset context(s) accounted for).
```

An earlier report that `ci-wait.py` returns exit 3 repo-wide was traced to a **stale working
tree** — a checkout at `1aef9e75` still carrying the pre-#3200 name `All BC versions passed`,
about twenty commits behind `origin/main`. That is recorded on #3199 and filed separately as
the worktree-staleness trap; there was no defect on `main`, and no gating hole either
(`check_required_contexts.py` exits 0, and `pr-check.yml` already runs it online with no
bypass).

What #3199 actually asks for is narrower and real: `ci-wait.py`'s built-in `RULESET_CONTEXTS`
is the **fallback** used when the branch-rules read fails, and it named two contexts where
the ruleset requires ten. So the narrower pair is harmless *only while the live read
succeeds*. This closes that window.

## 1. The promotion (#3199)

The eight `pr-gate.yml` contexts move out of `PENDING_REQUIRED_CONTEXTS` into
`DEFAULT_REQUIRED_CONTEXTS` (`.github/scripts/check_required_contexts.py`) and
`RULESET_CONTEXTS` (`tools/ci-wait.py`). The issue's own precondition is met — the live
ruleset returns ten:

```
gh api repos/StefanMaron/BusinessCentral.AL.Runner/rules/branches/main \
  --jq '[.[]|select(.type=="required_status_checks")|.parameters.required_status_checks[].context]'
```

Emptying `PENDING_REQUIRED_CONTEXTS` is what makes the live drift comparison in
`resolve_contexts()` **exact** again — a pending name is one the comparison deliberately
tolerates in either state, so a non-empty list is a hole in the #2785 check for as long as it
lasts. The mechanism and its comments stay for the next gating job to use.

**RED → GREEN, against the live ruleset.** New opt-in test, `CI_LIVE_RULESET_CHECK=1`:

```
FAIL DEFAULT_REQUIRED_CONTEXTS matches the live `main` ruleset exactly
     built-in=['BC test matrix passed', 'Tests updated'] live=[...ten...]
FAIL ...and so does tools/ci-wait.py's RULESET_CONTEXTS
FAIL ...and no PENDING name is already required by the live ruleset
```

After: all three pass. This is the **stronger** of the two bars — built-in versus the *live
ruleset*, not merely the two files against each other (that cross-check already existed and
still passes). It is opt-in because every other test in that file is offline on purpose;
making the whole file need a network call would turn a GitHub API blip into a red unit-test
job. The always-on live enforcement is unchanged and unaffected: `pr-check.yml` runs
`check_required_contexts.py` with no bypass on every PR.

## 2. The stale FAILED verdict (#2922)

`classify()` short-circuits on `bad` ahead of every in-flight guard — deliberately, since a
failure is a verdict and delaying it costs real time on the common case. That stays. What
changes is that the reader is now **told** a newer run of the same workflow is in flight, so
the conclusion may be overturned before a ruleset reads it. `superseding_runs()` had already
computed the run id; the failure branch was discarding information it held.

This is the "middle option" #2922 itself proposes, not the one-line move of the guard — exit
1 is unchanged.

**RED → GREEN.** Two new assertions fail before the change (`lines=['1 of 4 required checks
failed:', '  bc-tests / BC 27.0 (required): failure   (workflow run 33964656436)']` — no
mention of the queued run), pass after. Re-verified after the fact by reverting only the
implementation hunk.

**The control that keeps it honest:** the same failing rollup with *no* superseding run in
flight must carry **no** caveat. Without that, the line is decoration that always prints and
tells the reader nothing.

## 3. The fixture trap — worth a reviewer's attention on its own

This is independent of both issues and is the most valuable thing here. **37 checks in
`tools/test_ci_wait.py` failed the moment the required set grew from two to ten**, none of
them a real regression. To the next agent that reads as the tool breaking.

The cause: fixtures had frozen the ruleset *size* into assertions.

| fixture | what it froze |
|---|---|
| `green_set()` | named three contexts, leaving seven `missing` from every rollup built on it |
| `present_but_stale_rollup()` | same, which quietly defeated the supersession assertions built on it |
| `"2/2 ruleset context(s)"` | the ruleset size, as a string literal in a wording assertion |
| `"4/4 complete"` | the pool size |
| `"scripts/ unit tests"` | used as a stand-in for a **non-required** context — it is now required, so the test asserted the opposite of its intent |
| `contexts=("BC test matrix passed", "Tests updated")` | a narrowed set, which the #3002 guard correctly refuses to judge, so the control stopped being a control |
| `RECORDED_BRANCH_RULES` | a recorded API payload, re-taken |

The fix is to **derive them from `cw.RULESET_CONTEXTS`** rather than list names, plus a
`padded()` helper that adds a passing check run for every ruleset context a fixture omits.
`padded()` is deliberately additive and name-checked — it never overwrites an entry the
fixture placed itself, so it cannot mask the conclusion under test. That property is load
bearing: `absorbed_failure_set("Tests updated")` still asserts a genuine required-context
failure through it.

Two fixtures were *not* derived, on purpose:

- `RECORDED_BRANCH_RULES` is written out as ten literal names. Deriving it from
  `RULESET_CONTEXTS` would make "the recorded live ruleset resolves to the required contexts"
  compare the parser's output against its own input and assert nothing.
- The name collision at `...and says nothing about cancellations`: a green verdict now lists
  every ruleset context by name, and one of them is literally `Required contexts must not be
  cancellable on the same commit`. Substring-matching `cancel` fired on the context's own
  name, not on a finding. The roster line is excluded; the rest is matched as before.

## Testing

Every `tools/` and `.github/scripts/` unit suite, on this tree at `f13b54a0`:

```
tools/test_agent_self_freshness.py               rc=0 all checks passed
tools/test_ci_wait.py                            rc=0 all checks passed
tools/test_pr_body.py                            rc=0 all checks passed
tools/test_preflight.py                          rc=0 all checks passed
.github/scripts/test_check_agent_mcp_tools.py    rc=0 9/9 passed
.github/scripts/test_check_required_contexts.py  rc=0 all checks passed
.github/scripts/test_generate_changelog.py       rc=0 OK
.github/scripts/test_pe_signing.py               rc=0 OK
```

Plus `check_required_contexts.py` itself (online, no bypass) exit 0, the live-ruleset test
green, and `ci-wait.py` against live PR #3238 still `10/10`.

## Scope

Fixing the shape, not the reported line:

- **Same wrong pattern elsewhere?** Yes — that is section 3. The two files' lists were the
  reported instance; the frozen-size fixtures were the same assumption in seven more places.
- **Sibling function with the same assumption?** `DEFAULT_REQUIRED_CONTEXTS` and
  `RULESET_CONTEXTS` are exactly that pair, and both move here in one PR.
- **Two paths writing the same state?** `resolve_contexts()` (guard) and
  `resolve_required_contexts()` (tool) share one parser, `contexts_from_branch_rules`, which
  is why the "an empty answer is UNKNOWN, not 'nothing required'" rule cannot diverge. Left
  as-is; it is already correct.

**Not folded, and why:** nothing else open lands in these two files. The worktree-staleness
trap that produced the false urgency is filed separately rather than fixed here — PR #3243 is
live on `tools/preflight.py` and may already cover it.

**No corpus test is owed.** This asserts nothing about Business Central; it is CI plumbing.

**The #3002 subset guard is untouched.** It is correct — a partial ruleset read and a
deliberate removal are indistinguishable, so refusing to judge on a narrower set is the right
call. The bug was never the guard; it was the floor being narrower than the ruleset.

CI has not reported yet at the time of writing; this PR was opened without waiting on it.

---

*Written by the automated agent `stma-auto-1` on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE