### PR TITLE
fix(cache): refuse an AL-output cache identity when the key's inputs are unknown

### DIFF
--- a/AlRunner.Tests/AlOutputCacheDoNotCacheTests.cs
+++ b/AlRunner.Tests/AlOutputCacheDoNotCacheTests.cs
@@ -1,0 +1,494 @@
+// AlOutputCacheDoNotCacheTests — issue #2954. What the AL-output cache does when the key's
+// inputs are UNKNOWN rather than merely awkward.
+//
+// The defect, measured rather than reasoned about
+// -----------------------------------------------
+// `ProgramSupport.ResolveOrderedDepIds` (was `GetOrderedDepIds`) wraps the whole dependency
+// resolve in one try. Its catch used to fold the failure into the key:
+//
+//     return new[] { $"unresolved:{ex.GetType().Name}:{ex.Message}" };
+//
+// with a comment arguing that "an unresolvable closure is its own cache identity". It is not.
+// An exception type and message are deterministic across runs, so that is ONE fixed string
+// standing in for "the closure is unknown" — and, crucially, the run does not abort.
+//
+// Measured on the fixture below (a two-suite bundle whose second suite has a malformed
+// app.json, so it becomes an orphan app group that still compiles while
+// `ReadBundleDependencyRoots` throws on it):
+//
+//     → 2P/0F/0E across 2 tests
+//     [cache] WROTE key=898ae2f7…  (12800 bytes)
+//     [cache] WROTE key=3648b3fa…  (12800 bytes)
+//
+// and, with a dependency package rewritten to different bytes at the SAME declared identity
+// between two runs, `--print-cache-key` printed 898ae2f7… both times — the same key it printed
+// for the same bundle with no dependency declared at all. The key was blind to the entire
+// closure, the run was green, and the exit code was 0. A warm cache then serves the DLL
+// compiled against the other closure. That is the cache-poisoning shape #2754/#2846/#2955 each
+// removed one layer at a time, reintroduced by the error path of the very function #2754 fixed.
+//
+// Why the answer is not a better term
+// -----------------------------------
+// There is no better term available: the input was never read. #2954's framing — the honest
+// statement is "this run cannot compute a cache identity", and the honest consequence is not to
+// consult or write the cache for it. So the degraded paths report a REASON, and both cache
+// gates (the CLI loop and server mode) answer it by computing no key at all, which skips the
+// read and the write together because every read and both write sites are guarded on the key
+// being non-null.
+//
+// What each arm is for
+// --------------------
+// Arm 1 is the proof the entry is not WRITTEN, which a key-comparison test cannot give.
+// Arm 2 is the control: a healthy bundle must still write and still HIT warm, or the fix would
+// pass by disabling the cache outright — the failure mode that would cost far more than the
+// exposure it closes (the cost objection recorded on #2954 itself).
+// Arm 3 is the poisoning arm: the pre-fix runner printed one identical key for two different
+// dependency closures.
+// Arm 4 pins that `--print-cache-key` reports a deliberate refusal AS one, instead of as flag
+// misuse.
+// Arms 5-7 are the unit halves, for the two degraded paths a real run cannot reach after #2987
+// (a package that cannot be hashed, and a runner that cannot identify itself). #2954's own
+// review comment sets that bar: driven by a test rather than shipped unexercised.
+//
+// Runner-only claim, deliberately NOT upstream. AL-output cache HIT/MISS is named in
+// .claude/rules/bc-behavior-tests-go-upstream.md as a runner-specific claim — it says nothing
+// about what Business Central does, and no service tier can adjudicate it. It is also not
+// expressible as a `tests/runner-extras/` AL bundle: the assertion is about the CONTENTS OF A
+// CACHE DIRECTORY ACROSS TWO RUNNER INVOCATIONS, which AL running inside one invocation cannot
+// observe. Hence C#.
+
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class AlOutputCacheDoNotCacheTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private const string SuiteAId = "d0102954-aaaa-4b22-8c33-d44455566677";
+    private const string SuiteBId = "d0102954-bbbb-4b22-8c33-d44455566677";
+    private const string DepZId = "d0102954-dddd-4b22-8c33-d44455566677";
+    private const string DepPublisher = "Fabrikam ISV";
+    private const string DepName = "Fabrikam Dep Z";
+    private const string DepVersion = "1.0.0.0";
+
+    private readonly string _scratch;
+
+    public AlOutputCacheDoNotCacheTests()
+    {
+        _scratch = TestScratch.Dir("al-runner-do-not-cache");
+        Directory.CreateDirectory(_scratch);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_scratch, recursive: true); } catch { }
+    }
+
+    // ── arm 1: the write is refused ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A run whose dependency closure could not be resolved must write NO AL-output cache
+    /// entry — and must still run its tests. Both halves matter: refusing the cache is only
+    /// correct if the run itself is unaffected, and a fix that made this bundle fail would be
+    /// trading a silent wrong answer for a loud broken one.
+    ///
+    /// <para>Counting <c>*.dll</c> in the cache root is the assertion a key comparison cannot
+    /// make. Before this fix the same run left two of them there.</para>
+    /// </summary>
+    [SkippableFact]
+    public void UnresolvableClosure_WritesNoCacheEntry_AndTheRunStillPasses()
+    {
+        TestArtifacts.SkipIfMissing();
+        var (bundle, pkgDir, cacheDir) = Arrange("write-refused", siblingManifestValid: false);
+
+        var run = RunBundle(bundle, pkgDir, cacheDir);
+
+        Assert.Equal(0, run.ExitCode);
+        Assert.Contains("pass:        2", run.Output);
+        Assert.Contains("fail:        0", run.Output);
+
+        var written = Directory.GetFiles(cacheDir, "*.dll");
+        Assert.True(written.Length == 0,
+            "a run that could not compute a cache identity still published "
+            + $"{written.Length} AL-output cache entr(y/ies): {string.Join(", ", written.Select(Path.GetFileName))}"
+            + $"\n{run.Output}");
+        // Nothing to replay from either — a sidecar without its DLL is dead weight, and its
+        // presence would mean only half the write was refused.
+        Assert.Empty(Directory.GetFiles(cacheDir, "*.enum-registry.json"));
+
+        // Loud, and it must say WHY: a cache silently switching itself off is the shape
+        // .claude/rules/loud-failures.md exists to stop.
+        Assert.Contains("[cache] NOKEY", run.Output);
+        Assert.Contains("neither consulted nor written", run.Output);
+        Assert.Contains("could not be resolved", run.Output);
+        // And it must not have been counted as an ordinary MISS: a MISS is an entry the next
+        // run HITs, and nothing was written for a next run to find.
+        Assert.DoesNotContain("[cache] MISS", run.Output);
+    }
+
+    // ── arm 2: the control — a healthy bundle is untouched ────────────────────────────────
+
+    /// <summary>
+    /// The control this fix cannot ship without. The same fixture with a VALID sibling manifest
+    /// must still write entries on the cold run and HIT them on the warm one.
+    ///
+    /// <para>Without it, an implementation that simply never cached anything would pass arm 1,
+    /// and that implementation is strictly worse than the defect: #2954 records the cost
+    /// direction as a full emit and compile for the whole bundle, roughly two orders of
+    /// magnitude more than the exposure being closed.</para>
+    /// </summary>
+    [SkippableFact]
+    public void HealthyBundle_StillWritesAndServesACacheEntry()
+    {
+        TestArtifacts.SkipIfMissing();
+        var (bundle, pkgDir, cacheDir) = Arrange("healthy-control", siblingManifestValid: true);
+
+        var cold = RunBundle(bundle, pkgDir, cacheDir);
+        Assert.Equal(0, cold.ExitCode);
+        Assert.DoesNotContain("[cache] NOKEY", cold.Output);
+        Assert.Contains("[cache] WROTE", cold.Output);
+        Assert.Equal(2, Directory.GetFiles(cacheDir, "*.dll").Length);
+
+        var warm = RunBundle(bundle, pkgDir, cacheDir);
+        Assert.Equal(0, warm.ExitCode);
+        Assert.Contains("[cache] HIT", warm.Output);
+        Assert.DoesNotContain("[cache] MISS", warm.Output);
+        Assert.Contains("pass:        2", warm.Output);
+    }
+
+    // ── arm 3: the poisoning is gone ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Two runs of one bundle whose dependency package is REPLACED between them with different
+    /// bytes at the same declared identity, while the closure cannot be resolved.
+    ///
+    /// <para>Before the fix both runs printed the SAME 64-char key (<c>898ae2f7…</c>, which was
+    /// also the key for the same bundle with the dependency removed entirely), so the second
+    /// run HIT and executed the DLL compiled against the first package. Now neither run has a
+    /// key at all — which is the only honest answer, because neither run could describe what it
+    /// compiled against.</para>
+    ///
+    /// <para>The control half is deliberately in the same test: with the sibling manifest valid,
+    /// the same two package bodies produce two DIFFERENT keys. Without it this arm would pass
+    /// against an implementation that never produced a key for anything.</para>
+    /// </summary>
+    [SkippableFact]
+    public void UnresolvableClosure_DifferentDependencyBytes_ProduceNoKeyRatherThanOneSharedKey()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        // Degraded: no key, either time.
+        var (badBundle, badPkg, badCache) = Arrange("poison-degraded", siblingManifestValid: false);
+        WriteSyntheticApp(badPkg, payloadFill: (byte)'X');
+        var badFirst = RunPrintCacheKey(badBundle, badPkg, badCache);
+        WriteSyntheticApp(badPkg, payloadFill: (byte)'Q');
+        var badSecond = RunPrintCacheKey(badBundle, badPkg, badCache);
+
+        Assert.True(badFirst.Key == null && badSecond.Key == null,
+            "a bundle whose dependency closure could not be resolved still produced a cache key "
+            + $"(first={badFirst.Key ?? "<none>"}, second={badSecond.Key ?? "<none>"}), so two "
+            + "different dependency closures can still share one entry:\n" + badFirst.Output);
+        Assert.Contains("NO AL-output cache key", badFirst.Output);
+
+        // Control: resolvable, and the two package bodies are genuinely distinguished.
+        var (okBundle, okPkg, okCache) = Arrange("poison-control", siblingManifestValid: true);
+        WriteSyntheticApp(okPkg, payloadFill: (byte)'X');
+        var okFirst = RunPrintCacheKey(okBundle, okPkg, okCache);
+        WriteSyntheticApp(okPkg, payloadFill: (byte)'Q');
+        var okSecond = RunPrintCacheKey(okBundle, okPkg, okCache);
+
+        Assert.NotNull(okFirst.Key);
+        Assert.NotNull(okSecond.Key);
+        Assert.True(okFirst.Key != okSecond.Key,
+            "two dependency packages with different bytes at the same declared identity hashed "
+            + $"to the same AL-output cache key ({okFirst.Key}):\n" + okSecond.Output);
+    }
+
+    // ── arm 4: --print-cache-key reports a refusal as a refusal ───────────────────────────
+
+    /// <summary>
+    /// <c>--print-cache-key</c> already exited 2 with "found no key to print", explaining the
+    /// two ways the flag can be MISUSED (<c>--no-cache</c>, cross-bundle dedup). A deliberate
+    /// refusal is neither, and reporting it as one sends the caller looking for a mistake they
+    /// did not make while the actionable reason never reaches them.
+    /// </summary>
+    [SkippableFact]
+    public void PrintCacheKey_UnresolvableClosure_SaysThereIsNoKey_NotThatTheFlagWasMisused()
+    {
+        TestArtifacts.SkipIfMissing();
+        var (bundle, pkgDir, cacheDir) = Arrange("print-key", siblingManifestValid: false);
+
+        var run = RunPrintCacheKey(bundle, pkgDir, cacheDir);
+
+        Assert.Null(run.Key);
+        Assert.Equal(2, run.ExitCode);
+        Assert.Contains("this run has NO AL-output cache key", run.Output);
+        Assert.Contains("could not be resolved", run.Output);
+        Assert.DoesNotContain("Re-run without --no-cache", run.Output);
+    }
+
+    // ── arms 5-7: the unit halves ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The degraded dependency term must REPORT itself, naming the package. #2987 made this
+    /// branch unreachable through a real run (an unreadable package is no longer indexed, so it
+    /// is never resolved), which is exactly why it is driven directly here — the reachability
+    /// argument is about the CALLER, and a future caller resolving a dependency some other way
+    /// lands on it.
+    ///
+    /// <para>Both directions, or the arm proves nothing: a package that CAN be hashed must
+    /// report no degradation at all, otherwise an implementation that reported every dependency
+    /// as degraded would pass — and that implementation disables the cache for every run.</para>
+    /// </summary>
+    [Fact]
+    public void DependencyContentTerm_ReportsDegradation_OnlyWhenItCannotHashThePackage()
+    {
+        var dir = Path.Combine(_scratch, "term-report");
+        Directory.CreateDirectory(dir);
+        var real = WriteSyntheticApp(dir, payloadFill: (byte)'X');
+
+        var hashable = new List<string>();
+        var term = ProgramSupport.DependencyContentTerm(real, hashable.Add);
+        Assert.StartsWith("sha256:", term);
+        Assert.Empty(hashable);
+
+        var missing = Path.Combine(dir, "never-written.app");
+        var degraded = new List<string>();
+        var missingTerm = ProgramSupport.DependencyContentTerm(missing, degraded.Add);
+        Assert.StartsWith("unhashable:", missingTerm);
+        Assert.EndsWith(":absent", missingTerm);
+        var reason = Assert.Single(degraded);
+        // Names its OWN package: a reason that did not would leave the operator unable to tell
+        // which dependency switched the cache off.
+        Assert.Contains(Path.GetFullPath(missing), reason);
+        Assert.Contains("could not be hashed", reason);
+    }
+
+    /// <summary>
+    /// The same shape one layer up, and the one place still passing
+    /// <see cref="RunnerFingerprint.UnknownContentHash"/> into a PERSISTED key.
+    /// <see cref="RunnerFingerprint.WriteKeyLines(Action{string})"/> writes
+    /// <c>runner:&lt;hash&gt;</c> into both the AL-output key and the source-workspace key; with
+    /// the sentinel that line reads <c>runner:unknown</c>, identical for every runner build that
+    /// ever lands in that state (a single-file publish, an in-memory host, the DLL unlinked
+    /// under a running process). <c>AppLoader</c>'s manifest index (#2987) and its r2r-chunk
+    /// cache (#2955) already refuse the sentinel; this closes the third.
+    /// </summary>
+    [Fact]
+    public void RunnerFingerprint_UnknownContentHash_IsAReasonNotToCache()
+    {
+        Assert.Null(RunnerFingerprint.UncacheableReasonFor(
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"));
+
+        foreach (var degraded in new[] { RunnerFingerprint.UnknownContentHash, "", null })
+        {
+            var reason = RunnerFingerprint.UncacheableReasonFor(degraded);
+            Assert.NotNull(reason);
+            // Says which line would have been wrong, so the reason is diagnosable without
+            // reading this test.
+            Assert.Contains($"runner:{RunnerFingerprint.UnknownContentHash}", reason);
+        }
+
+        // And the live property agrees for the assembly actually running, which is on disk —
+        // if this ever flipped, every test in this suite would be running uncached and nothing
+        // else would say so.
+        Assert.Null(RunnerFingerprint.UncacheableReason);
+    }
+
+    /// <summary>
+    /// <c>AlOutputCacheBlocker</c> is the single place the CLI gate, the server-mode gate and
+    /// <c>--print-cache-key</c> read, so they cannot drift apart on what "uncacheable" means.
+    /// It must pass a dependency-side reason through, and answer null when there is none.
+    /// </summary>
+    [Fact]
+    public void AlOutputCacheBlocker_PassesADependencyReasonThrough_AndIsNullOtherwise()
+    {
+        var clean = new ProgramSupport.OrderedDependencyIds(new[] { "dep-a", "dep-b" }, null);
+        Assert.Null(ProgramSupport.AlOutputCacheBlocker(clean));
+
+        var blocked = new ProgramSupport.OrderedDependencyIds(
+            new[] { "unresolved:MissingDependencyException:Dependency not found" },
+            "the dependency closure of '/x' could not be resolved");
+        Assert.Equal("the dependency closure of '/x' could not be resolved",
+            ProgramSupport.AlOutputCacheBlocker(blocked));
+    }
+
+    // ── fixture ───────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A two-suite bundle plus a package cache holding one third-party dependency.
+    ///
+    /// <para><paramref name="siblingManifestValid"/> false writes suite B's app.json as
+    /// truncated JSON. That is what makes the closure unresolvable while the run still
+    /// succeeds: <c>InProcessAppPackager.ReadIdentity</c> answers null so
+    /// <c>BuildAppGroups</c> folds the suite into the orphan app group and compiles it, while
+    /// <c>ReadBundleDependencyRoots</c> parses the same file and throws — the two sides of the
+    /// asymmetry this issue lives in. No <c>application</c> or <c>platform</c> property on
+    /// either manifest, so the resolved closure is entirely under this test's control
+    /// (.claude/rules/no-base-app-in-csharp-tests.md).</para>
+    /// </summary>
+    private (string Bundle, string PkgDir, string CacheDir) Arrange(string name, bool siblingManifestValid)
+    {
+        var root = Path.Combine(_scratch, name);
+        var suiteA = Path.Combine(root, "bundle", "suiteA");
+        var suiteB = Path.Combine(root, "bundle", "suiteB");
+        var pkgDir = Path.Combine(root, "pkg");
+        var cacheDir = Path.Combine(root, "cache");
+        Directory.CreateDirectory(suiteA);
+        Directory.CreateDirectory(suiteB);
+        Directory.CreateDirectory(pkgDir);
+        Directory.CreateDirectory(cacheDir);
+
+        File.WriteAllText(Path.Combine(suiteA, "app.json"), $$"""
+        {
+          "id": "{{SuiteAId}}",
+          "name": "DoNotCache Probe A",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{DepZId}}", "name": "{{DepName}}", "publisher": "{{DepPublisher}}", "version": "{{DepVersion}}" }
+          ],
+          "idRanges": [ { "from": 60795, "to": 60796 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(suiteA, "ProbeA.Codeunit.al"), """
+        codeunit 60795 "DoNotCache Probe A"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure ProbeAWorks()
+            begin
+            end;
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(suiteB, "app.json"), siblingManifestValid
+            ? $$"""
+              {
+                "id": "{{SuiteBId}}",
+                "name": "DoNotCache Probe B",
+                "publisher": "AL Runner",
+                "version": "1.0.0.0",
+                "dependencies": [],
+                "idRanges": [ { "from": 60796, "to": 60797 } ],
+                "runtime": "14.0"
+              }
+              """
+            // Truncated mid-string: JsonReaderException, deterministic message.
+            : """{ "id": "not valid json """);
+        File.WriteAllText(Path.Combine(suiteB, "ProbeB.Codeunit.al"), """
+        codeunit 60796 "DoNotCache Probe B"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure ProbeBWorks()
+            begin
+            end;
+        }
+        """);
+
+        WriteSyntheticApp(pkgDir, payloadFill: (byte)'X');
+        return (Path.Combine(root, "bundle"), pkgDir, cacheDir);
+    }
+
+    /// <summary>
+    /// A minimal NAVX <c>.app</c> with a fixed-size uncompressed payload, so two packages with
+    /// the same declared identity can differ in bytes. Every zip entry carries an explicit
+    /// timestamp — <c>ZipArchive</c> stamps <c>DateTimeOffset.Now</c> otherwise, which would
+    /// make even a byte-for-byte rewrite produce different bytes and rob the control arms of
+    /// their meaning.
+    /// </summary>
+    private static string WriteSyntheticApp(string dir, byte payloadFill)
+    {
+        var xml = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{DepZId}" Name="{DepName}" Publisher="{DepPublisher}" Version="{DepVersion}"/>
+              <Dependencies />
+            </Package>
+            """;
+        var entryStamp = new DateTimeOffset(2021, 6, 7, 8, 9, 10, TimeSpan.Zero);
+        using var ms = new MemoryStream();
+        using (var zip = new System.IO.Compression.ZipArchive(
+                   ms, System.IO.Compression.ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var manifest = zip.CreateEntry("NavxManifest.xml", System.IO.Compression.CompressionLevel.NoCompression);
+            manifest.LastWriteTime = entryStamp;
+            using (var es = manifest.Open())
+                es.Write(Encoding.UTF8.GetBytes(xml));
+
+            var payload = zip.CreateEntry("payload.bin", System.IO.Compression.CompressionLevel.NoCompression);
+            payload.LastWriteTime = entryStamp;
+            using (var ps = payload.Open())
+            {
+                var buf = new byte[4096];
+                buf.AsSpan().Fill(payloadFill);
+                ps.Write(buf);
+            }
+        }
+        var zipBytes = ms.ToArray();
+        var result = new byte[8 + zipBytes.Length];
+        result[0] = (byte)'N'; result[1] = (byte)'A'; result[2] = (byte)'V'; result[3] = (byte)'X';
+        BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
+        zipBytes.CopyTo(result, 8);
+        var path = Path.Combine(dir, $"{DepPublisher}_{DepName}_{DepVersion}.app");
+        File.WriteAllBytes(path, result);
+        return path;
+    }
+
+    // ── runner invocation ─────────────────────────────────────────────────────────────────
+
+    private static (int ExitCode, string Output) RunBundle(string bundle, string pkgDir, string cacheDir)
+    {
+        var r = Spawn(bundle, pkgDir, cacheDir, extra: " --verbose");
+        return (r.ExitCode, r.Output);
+    }
+
+    private static (string? Key, int ExitCode, string Output) RunPrintCacheKey(
+        string bundle, string pkgDir, string cacheDir)
+    {
+        var r = Spawn(bundle, pkgDir, cacheDir, extra: " --print-cache-key");
+        var m = Regex.Match(r.Output, @"\[cache\]\s+KEY\s+key=([0-9a-f]{64})");
+        return (m.Success ? m.Groups[1].Value : null, r.ExitCode, r.Output);
+    }
+
+    private static (int ExitCode, string Output) Spawn(
+        string bundle, string pkgDir, string cacheDir, string extra)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" \"{bundle}\"");
+        args.Append($" --package-cache \"{pkgDir}\"");
+        args.Append($" --cache \"{cacheDir}\"");
+        args.Append(extra);
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = args.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(240_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (p.ExitCode, sb.ToString());
+    }
+}

--- a/AlRunner/Infrastructure/RunnerFingerprint.cs
+++ b/AlRunner/Infrastructure/RunnerFingerprint.cs
@@ -96,6 +96,38 @@ internal static class RunnerFingerprint
     /// </summary>
     internal const string UnknownContentHash = "unknown";
 
+    /// <summary>
+    /// Non-null when the runner cannot identify ITSELF — the reason no persisted cache key
+    /// computed in this process may be consulted or written (#2954).
+    ///
+    /// <para><see cref="ContentHash"/> answers <see cref="UnknownContentHash"/> for an
+    /// assembly with no readable on-disk location (a single-file publish, an in-memory host,
+    /// the DLL unlinked underneath a running process). Every key that calls
+    /// <see cref="WriteKeyLines(Action{string})"/> — the AL-output key and the
+    /// source-workspace key — then writes the literal line <c>runner:unknown</c>, which is
+    /// the SAME line for every runner build that ever lands in that state. That is one
+    /// shared cache identity standing in for an input the runner could not read, so a warm
+    /// entry written by one runner build is served to a different one: different rewriters,
+    /// different patches, different emit, and nothing in the run says so.</para>
+    ///
+    /// <para>The answer is not a better term — there is no term, the input is unknown — it is
+    /// to claim no cache identity at all. <see cref="AppLoader"/>'s manifest index (#2987) and
+    /// its r2r-chunk cache (#2955) already refuse the sentinel for exactly this reason; the
+    /// runner's own fingerprint was the one place still passing it into a persisted key.</para>
+    /// </summary>
+    internal static string? UncacheableReason => UncacheableReasonFor(ContentHash);
+
+    /// <summary>
+    /// Testable core of <see cref="UncacheableReason"/>: takes the hash explicitly, because a
+    /// test cannot make the RUNNING assembly location-less without unloading itself.
+    /// </summary>
+    internal static string? UncacheableReasonFor(string? contentHash) =>
+        string.IsNullOrEmpty(contentHash) || contentHash == UnknownContentHash
+            ? "the running al-runner assembly has no readable on-disk location, so every cache "
+              + $"key this process computes would carry 'runner:{UnknownContentHash}' — one "
+              + "shared identity for every runner build at once"
+            : null;
+
     // Path -> content hash memo. Moved down here from BcAppSymbolCache (#1820) so every
     // layer that needs "which bytes is this file?" as a cache-key term shares ONE memo
     // instead of each growing its own (#2955): AppLoader.ExtractAllDllPaths hashes the same

--- a/AlRunner/Infrastructure/RunnerFingerprint.cs
+++ b/AlRunner/Infrastructure/RunnerFingerprint.cs
@@ -97,23 +97,36 @@ internal static class RunnerFingerprint
     internal const string UnknownContentHash = "unknown";
 
     /// <summary>
-    /// Non-null when the runner cannot identify ITSELF — the reason no persisted cache key
-    /// computed in this process may be consulted or written (#2954).
+    /// Non-null when the runner cannot identify ITSELF — the reason the AL-output cache may
+    /// claim no identity at all this run (#2954). See the SCOPE paragraph below for what that
+    /// does and does not cover.
     ///
     /// <para><see cref="ContentHash"/> answers <see cref="UnknownContentHash"/> for an
     /// assembly with no readable on-disk location (a single-file publish, an in-memory host,
     /// the DLL unlinked underneath a running process). Every key that calls
-    /// <see cref="WriteKeyLines(Action{string})"/> — the AL-output key and the
-    /// source-workspace key — then writes the literal line <c>runner:unknown</c>, which is
-    /// the SAME line for every runner build that ever lands in that state. That is one
+    /// <see cref="WriteKeyLines(Action{string})"/> then writes the literal line
+    /// <c>runner:unknown</c>, which is the SAME line for every runner build that ever lands
+    /// in that state. That is one
     /// shared cache identity standing in for an input the runner could not read, so a warm
     /// entry written by one runner build is served to a different one: different rewriters,
     /// different patches, different emit, and nothing in the run says so.</para>
     ///
     /// <para>The answer is not a better term — there is no term, the input is unknown — it is
     /// to claim no cache identity at all. <see cref="AppLoader"/>'s manifest index (#2987) and
-    /// its r2r-chunk cache (#2955) already refuse the sentinel for exactly this reason; the
-    /// runner's own fingerprint was the one place still passing it into a persisted key.</para>
+    /// its r2r-chunk cache (#2955) already refuse the sentinel for exactly this reason.</para>
+    ///
+    /// <para>SCOPE — this property does not govern every persisted key, and reading it as
+    /// though it did would be the same defect #2954 is about, one level up: a name standing in
+    /// for coverage it does not have. Measured, it has exactly ONE consumer,
+    /// <see cref="ProgramSupport.AlOutputCacheBlocker"/>, which gates the AL-output cache
+    /// (the CLI gate and the server-mode gate both reach it through there) whose key is
+    /// <c>ProgramSupport.ComputeAlCacheKey</c>. The other three
+    /// <see cref="WriteKeyLines(Action{string})"/> call sites still write
+    /// <c>runner:unknown</c> into a persisted key with nothing consulting this property:
+    /// <c>DependencyLoader.ComputeSourceDependencyCacheKeyCore</c>,
+    /// <c>SiblingCompile.ComputeSourceWorkspaceKey</c> and
+    /// <c>InstallBaselineDiskCache.BuildKeyText</c>. Extending the gate to those is a real
+    /// behaviour change needing its own proof, not something #2954 did.</para>
     /// </summary>
     internal static string? UncacheableReason => UncacheableReasonFor(ContentHash);
 

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2716,11 +2716,20 @@ foreach (var bundle in bundles)
         // overhead, eating the "unattributed" line. Inside the factory it is also recorded
         // exactly once, on the app that actually opens the gate, instead of a zero-length row
         // on every later app.
-        var orderedDepIds = new Lazy<IReadOnlyList<string>>(() =>
+        var orderedDepIds = new Lazy<OrderedDependencyIds>(() =>
         {
             using (AlRunner.Infrastructure.PhaseLog.AppStage("ordered-dep-ids"))
-                return GetOrderedDepIds(bucketRoot, packageCacheDirs, bundleAbs);
+                return ResolveOrderedDepIds(bucketRoot, packageCacheDirs, bundleAbs);
         });
+
+        // #2954: the reason — if there is one — that this bundle may claim NO AL-output cache
+        // identity. Reported ONCE per bundle rather than once per app group: the cause is
+        // bundle-wide (an unresolvable closure, a package that could not be hashed, a runner
+        // that cannot identify itself), so a per-group line would repeat the same sentence for
+        // every module. Not gated behind --verbose, unlike HIT/MISS: HIT/MISS is a performance
+        // detail, this is "the cache is off for this run and here is why".
+        string? cacheBlocker = null;
+        var cacheBlockerReported = false;
 
         int agIdx = 0;
         foreach (var appGroup in appGroups)
@@ -2834,9 +2843,29 @@ foreach (var bundle in bundles)
             // the report's "unattributed" remainder. An AppStage, not a Stage — BeginApp is
             // already open here, and a bundle stage overlapping an app group is what #1828's
             // stage sum reports as manufactured overhead.
+            var depIds = orderedDepIds.Value;
+            cacheBlocker = AlOutputCacheBlocker(depIds);
+            if (cacheBlocker != null)
+            {
+                // Leaving cacheKey/cachePath/sidecarPath null is the whole mechanism: the HIT
+                // branch below is skipped because cachedBytes stays null, and BOTH write sites
+                // (the CLI publish and the server-mode one) are already guarded on
+                // `cachePath != null`. One skipped assignment, two skipped operations — a
+                // degraded key that got written and then read back is what #2954 is about, so
+                // the read and the write have to be refused together or not at all.
+                if (!cacheBlockerReported)
+                {
+                    cacheBlockerReported = true;
+                    Console.Error.WriteLine(
+                        $"  [{rel}] [cache] NOKEY — this run cannot compute an AL-output cache "
+                        + $"identity, so the cache is neither consulted nor written: {cacheBlocker}");
+                }
+            }
+            else
+            {
             using (AlRunner.Infrastructure.PhaseLog.AppStage("query-decl-probe"))
                 bundleDeclaresQuery = BcCompiler.BundleDeclaresQuery(allPaths);
-            cacheKey = ComputeAlCacheKey(allPaths, moduleName, ordered: orderedDepIds.Value, appRootDir: appGroup.SuiteDir);
+            cacheKey = ComputeAlCacheKey(allPaths, moduleName, ordered: depIds.Terms, appRootDir: appGroup.SuiteDir);
             cachePath = Path.Combine(alCacheDir, cacheKey + ".dll");
             sidecarPath = Path.Combine(alCacheDir, cacheKey + AlRunner.Infrastructure.AlCacheSidecars.EnumRegistrySuffix);
             querySidecarPath = Path.Combine(alCacheDir, cacheKey + AlRunner.Infrastructure.AlCacheSidecars.QuerySymbolsSuffix);
@@ -2864,6 +2893,7 @@ foreach (var bundle in bundles)
                 var missing = !File.Exists(sidecarPath) ? sidecarPath : querySidecarPath;
                 Console.Error.WriteLine($"  [cache] DLL present but sidecar missing — treating as MISS ({missing})");
             }
+            }
         }
 
         // ── --print-cache-key short-circuit (issue #1851) ──────────────────
@@ -2879,11 +2909,18 @@ foreach (var bundle in bundles)
         {
             if (cacheKey == null)
             {
-                Console.Error.WriteLine(
-                    "--print-cache-key found no key to print: either the AL-output cache is " +
-                    "disabled (--no-cache) or this app group's module was already loaded " +
-                    "earlier in this process (cross-bundle dedup, issue #1683) and so never " +
-                    "reached the ComputeAlCacheKey call. Re-run without --no-cache, alone.");
+                // #2954: distinguish "no key was computed" from "this run has no cache identity
+                // and that is the answer". Collapsing the two would report a deliberate refusal
+                // as a misuse of the flag, and the reason — which is the actionable part — would
+                // never reach the caller.
+                Console.Error.WriteLine(cacheBlocker != null
+                    ? "--print-cache-key: this run has NO AL-output cache key. It is not being "
+                      + "withheld, it does not exist: the runner cannot compute a cache identity "
+                      + $"for this bundle, so the cache is neither consulted nor written. Reason: {cacheBlocker}"
+                    : "--print-cache-key found no key to print: either the AL-output cache is "
+                      + "disabled (--no-cache) or this app group's module was already loaded "
+                      + "earlier in this process (cross-bundle dedup, issue #1683) and so never "
+                      + "reached the ComputeAlCacheKey call. Re-run without --no-cache, alone.");
                 return 2;
             }
             Console.WriteLine($"  [{rel}] {moduleName}: [cache] KEY key={cacheKey}");
@@ -2925,7 +2962,10 @@ foreach (var bundle in bundles)
         }
         if (needCompile && assemblyBytes == null)
         {
-            if (alCacheDir != null)
+            // cacheKey == null with alCacheDir set is #2954's do-not-cache path: there is no key
+            // to miss against, and counting it as a MISS would put it in the same bucket as a
+            // cold entry that the next run will HIT. It never will — nothing was written.
+            if (alCacheDir != null && cacheKey != null)
             {
                 if (AlRunner.Log.Verbose)
                     Console.Error.WriteLine($"  [cache] MISS key={cacheKey} — running Emit+Compile");
@@ -4922,11 +4962,27 @@ return strictExitCode ? computedExitCode : 0;
                 // answer "no". Outside the gate, a cross-bundle module reuse (reusedAsm != null)
                 // — the case --server exists to make fast — paid for a whole-tree scan whose
                 // answer it then threw away.
+                // #2954, the server-mode half. The CLI gate and this one must agree on when a
+                // run has no cache identity: they write into the SAME <cacheDir>, so a server
+                // request that wrote an entry under a key blind to its dependency closure would
+                // be served to a later CLI run, and the other way round. Same helper, same
+                // answer.
+                var serverDepIds = ResolveOrderedDepIds(bucketRoot, effectivePkgDirs);
+                var serverCacheBlocker = AlOutputCacheBlocker(serverDepIds);
+                if (serverCacheBlocker != null)
+                {
+                    Console.Error.WriteLine(
+                        $"  [server] {moduleName}: [cache] NOKEY — this run cannot compute an "
+                        + "AL-output cache identity, so the cache is neither consulted nor "
+                        + $"written: {serverCacheBlocker}");
+                }
+                else
+                {
                 bool bundleDeclaresQuery;
                 using (AlRunner.Infrastructure.PhaseLog.AppStage("query-decl-probe"))
                     bundleDeclaresQuery = BcCompiler.BundleDeclaresQuery(allPaths);
                 cacheKey = ComputeAlCacheKey(allPaths, moduleName,
-                    ordered: GetOrderedDepIds(bucketRoot, effectivePkgDirs), appRootDir: bucketRoot);
+                    ordered: serverDepIds.Terms, appRootDir: bucketRoot);
                 cachePath = Path.Combine(alCacheDir, cacheKey + ".dll");
                 sidecarPath = Path.Combine(alCacheDir, cacheKey + AlRunner.Infrastructure.AlCacheSidecars.EnumRegistrySuffix);
                 querySidecarPath = Path.Combine(alCacheDir, cacheKey + AlRunner.Infrastructure.AlCacheSidecars.QuerySymbolsSuffix);
@@ -4955,6 +5011,7 @@ return strictExitCode ? computedExitCode : 0;
                         cached = false;
                     }
                 }
+                }
             }
 
             var compileErrors = new List<string>();
@@ -4962,7 +5019,10 @@ return strictExitCode ? computedExitCode : 0;
             string? changeModelFallbackReason = null;
             if (reusedAsm == null && assemblyBytes == null)
             {
-                if (alCacheDir != null)
+                // cacheKey == null here means #2954's do-not-cache path (see the gate above):
+                // no key was computed, so there is nothing to have missed. Same accounting rule
+                // as the CLI loop.
+                if (alCacheDir != null && cacheKey != null)
                     AlRunner.Infrastructure.PhaseLog.NoteCacheMiss();
                 IReadOnlyList<EmittedSource> sources;
                 IReadOnlyList<string> alDiagnostics;

--- a/AlRunner/ProgramSupport/Dependencies.cs
+++ b/AlRunner/ProgramSupport/Dependencies.cs
@@ -568,7 +568,35 @@ internal static partial class ProgramSupport
         return null;
     }
 
+    /// <summary>
+    /// The resolved dependency terms for one bundle's AL-output cache key, together with the
+    /// reason — when there is one — that this run may claim NO cache identity at all (#2954).
+    ///
+    /// <para><see cref="UncacheableReason"/> non-null means every term in
+    /// <see cref="Terms"/> is present only so callers that need SOMETHING (diagnostics) still
+    /// have it. It must never be hashed into a persisted key: see
+    /// <see cref="ProgramSupport.AlOutputCacheBlocker"/>.</para>
+    /// </summary>
+    internal readonly record struct OrderedDependencyIds(
+        IReadOnlyList<string> Terms, string? UncacheableReason);
+
+    /// <summary>
+    /// Back-compat shape for callers that only want the terms (the source-workspace key, which
+    /// answers the do-not-cache question for itself — see ComputeSourceWorkspaceKey).
+    /// </summary>
     internal static IReadOnlyList<string> GetOrderedDepIds(
+        string? bucketRoot, IReadOnlyList<string> packageCacheDirs, string? bundleAbs = null)
+        => ResolveOrderedDepIds(bucketRoot, packageCacheDirs, bundleAbs).Terms;
+
+    /// <summary>
+    /// The blocker for the AL-output cache: the first reason this run cannot compute a cache
+    /// identity, or null when it can. One place, so the CLI gate, the server-mode gate and
+    /// <c>--print-cache-key</c> cannot drift apart on what "uncacheable" means.
+    /// </summary>
+    internal static string? AlOutputCacheBlocker(OrderedDependencyIds ordered)
+        => AlRunner.Infrastructure.RunnerFingerprint.UncacheableReason ?? ordered.UncacheableReason;
+
+    internal static OrderedDependencyIds ResolveOrderedDepIds(
         string? bucketRoot, IReadOnlyList<string> packageCacheDirs, string? bundleAbs = null)
     {
         // Same closure the emit actually compiles against — a parent-of-many-apps bundle has no
@@ -576,9 +604,13 @@ internal static partial class ProgramSupport
         // Keying on a DIFFERENT closure than the one used to compile would let two bundles that
         // resolve differently share a cache entry.
         var depRootDir = bucketRoot ?? bundleAbs;
-        if (depRootDir == null) return Array.Empty<string>();
+        if (depRootDir == null) return new OrderedDependencyIds(Array.Empty<string>(), null);
         var manifests = CollectBundleManifests(bucketRoot, bundleAbs ?? depRootDir);
-        if (manifests.Count == 0) return Array.Empty<string>();
+        if (manifests.Count == 0) return new OrderedDependencyIds(Array.Empty<string>(), null);
+        // Reasons ONE dependency term could not be computed from the package's content. A
+        // degraded term is not a weaker key, it is a key that describes an input the run never
+        // read — so it disqualifies the whole run from the cache rather than being hashed.
+        var degraded = new List<string>();
         try
         {
             var roots = ReadBundleDependencyRoots(manifests);
@@ -586,8 +618,8 @@ internal static partial class ProgramSupport
                 .ToList();
             var resolver = new AlRunner.DependencyResolver(
                 bundlePkgDirs.Concat(packageCacheDirs).Distinct().ToList());
-            var ordered = resolver.Resolve(roots);
-            return ordered
+            var resolvedDeps = resolver.Resolve(roots);
+            var ordered = resolvedDeps
                 // Id:Version alone is NOT a content identity: a sibling source app keeps
                 // its app.json version while its schema evolves during development, so a
                 // key without the winning .app's own identity served the test bundle a
@@ -630,9 +662,12 @@ internal static partial class ProgramSupport
                 // finding #1815/#1820 made one cache layer over: a byte-identical package
                 // re-downloaded or re-copied with a fresh mtime used to MISS
                 // unconditionally, and now HITs.
-                .Select(d => $"{d.Manifest.AppId:N}:{d.Manifest.Version}:{DependencyContentTerm(d.AppPath)}")
+                .Select(d => $"{d.Manifest.AppId:N}:{d.Manifest.Version}:{DependencyContentTerm(d.AppPath, degraded.Add)}")
                 .OrderBy(s => s, StringComparer.Ordinal)
                 .ToList();
+            return new OrderedDependencyIds(
+                ordered,
+                degraded.Count == 0 ? null : string.Join("; ", degraded));
         }
         catch (Exception ex)
         {
@@ -644,14 +679,32 @@ internal static partial class ProgramSupport
             //
             // Never collapse to "no deps": an empty list is indistinguishable from a bundle
             // that genuinely has none, so two different closures would share a key and the
-            // cache would hand back the wrong DLL. Fold the failure itself into the key
-            // instead — an unresolvable closure is its own cache identity, and it changes
-            // again as soon as the reason changes.
+            // cache would hand back the wrong DLL.
+            //
+            // #2954: folding the FAILURE into the key instead is the same defect one step
+            // removed, and it was measured rather than argued. An exception type and message
+            // are deterministic across runs, so `unresolved:JsonReaderException:<msg>` is one
+            // fixed string standing in for "the closure is unknown" — and the run does not
+            // abort. Measured on a two-suite bundle whose second suite has a malformed
+            // app.json: the run passes 2/2, writes two cache entries, and produces the SAME
+            // 64-char key for a dependency package rewritten with different bytes at the same
+            // declared identity (and the same key again with that dependency removed
+            // entirely). A warm cache then serves the DLL compiled against the other closure,
+            // green, with an unchanged exit code.
+            //
+            // The honest statement is "this run cannot compute a cache identity", and the
+            // honest consequence is not to consult or write the AL-output cache for it. The
+            // terms are still returned so a caller with a different question (diagnostics) has
+            // something to read; the blocker is what the cache gates honour.
             Console.Error.WriteLine(
                 $"  [cache] dependency resolution failed while computing the cache key for " +
-                $"{depRootDir}: {ex.GetType().Name}: {ex.Message}. Keying on the failure so this " +
-                $"bundle cannot share a cache entry with a resolvable one.");
-            return new[] { $"unresolved:{ex.GetType().Name}:{ex.Message}" };
+                $"{depRootDir}: {ex.GetType().Name}: {ex.Message}. This run cannot claim a cache " +
+                $"identity — the AL-output cache will be neither consulted nor written for it.");
+            return new OrderedDependencyIds(
+                new[] { $"unresolved:{ex.GetType().Name}:{ex.Message}" },
+                $"the dependency closure of '{depRootDir}' could not be resolved "
+                + $"({ex.GetType().Name}: {ex.Message}), so no cache key can describe the "
+                + "packages this run actually compiled against");
         }
     }
 
@@ -686,20 +739,18 @@ internal static partial class ProgramSupport
     /// makes the degraded term no less discriminating than the pre-#2754 stamp was for EVERY
     /// dependency.</para>
     ///
-    /// <para><b>Residual, stated rather than papered over.</b> A package that is unhashable on
-    /// two consecutive runs AND whose content changes between them without changing path, size
-    /// or mtime is still not distinguished — the pre-#2754 exposure, now narrowed to packages
-    /// the runner could not read at all. Closing it means not claiming a cache identity for such
-    /// a run at all (a "do not cache this run" signal threaded out to the cache gate), which is
-    /// a wider change than this one and is tracked on #2954 (carried out of #2846 when its other
-    /// two cases were fixed). It is not closed by anything
-    /// cheaper here: a per-run nonce would force a MISS, but it would also be a code path no
-    /// test in this repo can construct, and an untestable branch is what this method exists to
-    /// stop shipping.</para>
+    /// <para><b>The residual is now signalled, not absorbed (#2954).</b> A package that is
+    /// unhashable on two consecutive runs AND whose content changes between them without
+    /// changing path, size or mtime is still not distinguished by the TERM — that is what
+    /// path+mtime+size can do and no more. So the term no longer has to carry that weight
+    /// alone: <paramref name="onDegraded"/> reports the degradation to the caller, and the
+    /// AL-output cache gate answers it by claiming no cache identity for the run at all rather
+    /// than hashing a term that describes an input nothing read. The term itself is unchanged,
+    /// because the source-workspace key still needs a per-package, non-collapsing answer.</para>
     /// </summary>
     // internal, not private: #2987 made this branch unreachable end-to-end (see the
     // paragraph above), so a direct unit test is the only thing that still exercises it.
-    internal static string DependencyContentTerm(string appPath)
+    internal static string DependencyContentTerm(string appPath, Action<string>? onDegraded = null)
     {
         // #2987 — READ THIS BEFORE CHANGING THE DEGRADED PATH BELOW.
         //
@@ -713,11 +764,17 @@ internal static partial class ProgramSupport
         // the same (path, length, mtime) key this call will use. The degraded term therefore
         // cannot be reached for a resolved dependency.
         //
-        // That is also what closes #2954's residue — "unhashable on two consecutive runs while
-        // the content changes between them" — without a "do not cache this run" signal: the
-        // state it needed no longer exists. Kept rather than deleted because the reachability
-        // argument is about the CALLER, and a future caller that resolves a dependency some
-        // other way would land here; it must degrade one term, never collapse the list.
+        // Kept rather than deleted because the reachability argument is about the CALLER, and a
+        // future caller that resolves a dependency some other way would land here; it must
+        // degrade one term, never collapse the list.
+        //
+        // #2954 read that reachability argument as closing the issue. It closes only the half
+        // of it that lives in THIS method. The other half — the outer catch in
+        // ResolveOrderedDepIds, where a resolution failure becomes one deterministic
+        // `unresolved:<type>:<message>` string in the key — was reachable all along, measured
+        // end-to-end (a two-suite bundle with one malformed app.json passes green while writing
+        // cache entries under a key blind to its entire dependency closure). Both halves now
+        // report a do-not-cache signal; this one is still the defensive half.
         string failure;
         try
         {
@@ -748,6 +805,16 @@ internal static partial class ProgramSupport
             $"  [cache] could not hash dependency package '{fullPath}' for the AL-output cache " +
             $"key ({failure}) — keying it on path+stat instead. Every OTHER dependency keeps its "
             + "content hash; this one is only as precise as its mtime and size.");
+
+        // #2954. The term below is still per-package and still non-collapsing, because a caller
+        // that has no better option (the source-workspace key) must not lose every other
+        // dependency's identity. But a caller that CAN decline — the AL-output cache gate —
+        // should: path+mtime+size cannot distinguish a package rewritten in place, which is the
+        // pre-#2754 exposure this narrows rather than removes. Reporting the degradation lets
+        // that caller refuse a cache identity instead of accepting a weaker one.
+        onDegraded?.Invoke(
+            $"dependency package '{fullPath}' could not be hashed ({failure}), so its cache-key "
+            + "term describes only a path, an mtime and a size — not the bytes compiled against");
 
         return $"unhashable:{fullPath}:{stamp}";
     }


### PR DESCRIPTION
Closes #2954

A degraded cache-key term is not a weaker key. It is a key that describes an input the run never read — and a key that stands in for unknown inputs produces a HIT that is wrong. The answer is not a better term format; it is to claim no cache identity at all.

## The half of #2954 that was still open, measured end-to-end

Two comments on the issue concluded that #2987/#3035 had made the state unreachable and the issue could be closed. That reasoning is correct about **`DependencyContentTerm`** — an unreadable package is no longer indexed, so it is never resolved, so its hash is never reached — and the code comment saying so is accurate. It does not cover the other producer of a degraded term, which was reachable all along: the outer `catch` in `GetOrderedDepIds`.

```csharp
return new[] { $"unresolved:{ex.GetType().Name}:{ex.Message}" };
```

with a comment arguing "an unresolvable closure is its own cache identity". An exception type and message are deterministic across runs, so that is one fixed string standing in for "the closure is unknown" — **and the run does not abort.**

Measured on a two-suite bundle whose second suite has a truncated `app.json` (`InProcessAppPackager.ReadIdentity` answers null, so `BuildAppGroups` folds it into the orphan app group and compiles it, while `ReadBundleDependencyRoots` parses the same file and throws):

```
→ 2P/0F/0E across 2 tests
[cache] WROTE key=898ae2f7…  (12800 bytes)
[cache] WROTE key=3648b3fa…  (12800 bytes)
```

Exit code 0. Then, varying only the dependency package's bytes at the same declared identity between two `--print-cache-key` runs:

| bundle | dep bytes `X` | dep bytes `Q` | |
|---|---|---|---|
| malformed sibling | `898ae2f7…` | `898ae2f7…` | **same key** |
| valid sibling (control) | `af8585c9…` | `6e13fd7d…` | keys differ, as they must |

`898ae2f7…` is also the key the same bundle produced with the dependency removed entirely. The key was blind to the whole closure, and a warm cache serves the DLL compiled against the other one — green, unchanged exit code. Same shape #2754, #2846, #2955 and #2987 each removed one layer at a time, reintroduced by the error path of the function #2754 fixed.

## The change

- `ResolveOrderedDepIds` returns `OrderedDependencyIds(Terms, UncacheableReason)`. Both degraded producers populate the reason: the outer catch, and `DependencyContentTerm` through a new `onDegraded` callback. `GetOrderedDepIds` stays as a thin `.Terms` wrapper for the source-workspace key.
- `ProgramSupport.AlOutputCacheBlocker` is the single place the CLI gate, the server-mode gate and `--print-cache-key` read, so they cannot drift apart on what "uncacheable" means. Both gates write into the same `<cacheDir>`, so an entry one of them wrote under a blind key would be served to the other.
- Both cache gates compute **no key** when blocked. That one skipped assignment refuses the read and the write together, because every read and both write sites are already guarded on `cachePath != null`. A run that could write a bad entry and then read it back is what this issue is about, so refusing one without the other would not close it.
- `--print-cache-key` reports a deliberate refusal as one, with the reason, instead of as flag misuse ("Re-run without `--no-cache`").
- A blocked run is no longer counted as a cache MISS. A MISS is an entry the next run HITs; nothing was written for a next run to find.

Nothing here is a load-time pass over an already-cached artifact — the decision is made before `ComputeAlCacheKey` is called, inside the compile pipeline, per `precompiled-dll-respect.md`.

## Fixing the shape, not the reported line

**1. Does the same wrong pattern appear at another call site?** Yes, one layer up, in the same key. `RunnerFingerprint.ContentHash` answers the `"unknown"` sentinel for an assembly with no readable on-disk location, and `WriteKeyLines` writes it straight into the AL-output key **and** the source-workspace key as the literal line `runner:unknown` — identical for every runner build that ever lands in that state, so an entry written by one runner build is served to a different one. `AppLoader`'s manifest index (#2987) and its r2r-chunk cache (#2955) already refuse that sentinel; the runner's own fingerprint was the last place still passing it into a persisted key. `RunnerFingerprint.UncacheableReason` closes it, and feeds the same blocker.

**2. Does a sibling function make the same assumption?** `ComputeSourceWorkspaceKey` has a visually identical term, `depres-unresolved:{resolutionFailure}`. Checked, and it is safe for a different reason, so it is deliberately unchanged: `RunLayeredPrePass` only passes a failure when the workspace is cold, and the cold path immediately redoes the resolve so it throws and aborts. A `depres-unresolved:`-keyed directory therefore never gets its `*.symbols.json` written, so `hadSymbols` is always false for that key and no stale entry can be served. Narrowing that term would cost a real emit for no exposure.

**3. If two code paths write the same state, do they maintain the same invariant?** They did not — the CLI gate and the server-mode gate are separate code writing into one cache directory. Both now go through `AlOutputCacheBlocker`, so they cannot answer differently.

## Cost, which #2954 flagged as unmeasured

The issue and its first comment both name the cost direction as the thing that decides the design: a run-wide refusal costs a full emit and compile for the whole bundle, roughly two orders of magnitude more than a per-package fallback. Measured:

| bundle | NOKEY lines | cold | warm |
|---|---|---|---|
| `tests/runner-extras` (314 tests) | **0** | 62.4 s total / 146.1 s wall | 26.0 s total / 77.0 s wall, AL emit 0.0 s, C# compile 0.0 s, 56 entries |
| corpus, 3 apps (2695 tests) | **0** | 68.7 s total / 110.9 s wall | 32.9 s total / 38.9 s wall, AL emit 0.0 s, C# compile 0.0 s |

Both runs green in both states (314/314 and 2695/2695, exit 0). The refusal fires **zero** times on healthy bundles, so the cost on a normal run is nothing. It is paid only by a run that today gets a possibly-wrong answer, and such a run already prints `DEP-RESOLVE-FAIL`.

## RED → GREEN

`AlRunner.Tests/AlOutputCacheDoNotCacheTests.cs`, 7 arms. RED measured by rebuilding the runner from the pre-fix sources and re-running the same class (the test assembly untouched):

```
Failed  UnresolvableClosure_WritesNoCacheEntry_AndTheRunStillPasses
  a run that could not compute a cache identity still published 2 AL-output cache entr(y/ies):
  4a708414….dll, 5400d873….dll
Failed  PrintCacheKey_UnresolvableClosure_SaysThereIsNoKey_NotThatTheFlagWasMisused
Failed  UnresolvableClosure_DifferentDependencyBytes_ProduceNoKeyRatherThanOneSharedKey
Failed!  - Failed: 3, Passed: 4
```

GREEN after restoring: `Passed! - Failed: 0, Passed: 7`.

The **control arm passes in both states on purpose**. `HealthyBundle_StillWritesAndServesACacheEntry` asserts the same fixture with a valid sibling manifest still writes two entries cold and HITs both warm — without it, an implementation that simply never cached anything would pass every other arm, and that implementation is strictly worse than the defect.

Arm 1 counts `*.dll` in the cache root, which is the proof a key comparison cannot give: the entry was not written. Arms 5-7 drive the two branches a real run can no longer reach (`DependencyContentTerm`'s degraded path after #2987, and a location-less runner assembly) directly through `internal` seams, both directions each — a hashable package must report no degradation, and a real content hash must produce no blocker — meeting the bar #2954's own review comment sets for an unreachable branch.

## Corpus obligation

**This PR asserts nothing about what Business Central does.** AL-output cache HIT/MISS is named explicitly in `.claude/rules/bc-behavior-tests-go-upstream.md` as a runner-only claim: it is meaningless without AL Runner, and no service tier can adjudicate it. So no corpus PR, and no submodule pin bump.

It is also not expressible as a `tests/runner-extras/` AL bundle, which is where runner-only claims normally go. The assertion is about the contents of a cache directory across two runner invocations, and AL executing inside one invocation cannot observe either. Hence C#. The corpus was run anyway (above) as the cache-sensitive cold/warm check, not as the proving test.

## Same-file batching

`.claude/rules/batch-sibling-issues-by-file.md` scan run over the open queue. **Nothing folded.** What was considered:

- **#2956** (the candidate named in my brief) — "the layered pre-pass wraps `MissingDependencyException`". It does touch `SiblingCompile.cs` and `Program.cs`, and it sits in the *adjacent* `try` block. Not folded: it is an error-reporting change, not a cache-identity one, and #2956's own body records the reason — the server-mode sibling test asserts the failure arrives as a `compilationErrors` entry while the CLI test asserts the wrapped stderr text, so the fix has to decide what both modes should do. Two changes needing materially different reasoning to review is rule point 4's stop condition. It also does not touch the lines this PR touches.
- **#3132** (`ncl-cecil` `keepNewest: 8` evicting a live entry) — cache-adjacent but a different file and a different cache, and its body explicitly defers a design decision to the account holder between three options.
- **#3226, #3216, #2247, #2237** — memoization and dependency-adjacent, none landing in `Dependencies.cs`, `Program.cs`'s cache gate or `RunnerFingerprint.cs`.

## Local verification

- New class: 7/7 (RED 3/7 pre-fix, as above).
- Filtered `AlRunner.Tests`: `CacheKey|CacheGate|RunnerFingerprint|AlCache|PrintCacheKey|AlOutputCache|SourceWorkspace|LayeredSourceChain` — **79/79**.
- Filtered `AlRunner.Tests`: `ServerMode|ServerCache|ServerAffected|ServerRun` — **10/10**.
- `tests/runner-extras` cold and warm — 314/314 both.
- Corpus (3 apps) cold and warm, `--strict --expectations-require-match --count-baseline` — 2695/2695 both.

The full suite was not run locally; CI runs it on every leg.

---
Opened by Claude Code agent `stma-auto-1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
