### PR TITLE
fix(pagemeta): refuse a page whose SourceTableView or SubPageLink could not be read, and read the ones AL directives guard

### DIFF
--- a/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
+++ b/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
@@ -284,12 +284,16 @@ public class DependencyPageMetadataXmlTests
             {
               "Id": 88123520,
               "Name": "DPX Host Table",
-              "Fields": [ { "Id": 1, "Name": "Host Link Field" } ]
+              "Fields": [ { "Id": 1, "Name": "Host Link Field" }, { "Id": 2, "Name": "Chargeable Filter" } ]
             },
             {
               "Id": 88123521,
               "Name": "DPX Part Table",
-              "Fields": [ { "Id": 5, "Name": "Part Link Field" }, { "Id": 6, "Name": "Table ID" } ]
+              "Fields": [
+                { "Id": 5, "Name": "Part Link Field" },
+                { "Id": 6, "Name": "Table ID" },
+                { "Id": 7, "Name": "Chargeable Filter" }
+              ]
             }
           ],
           "Pages": [
@@ -365,6 +369,42 @@ public class DependencyPageMetadataXmlTests
                   ],
                   "Id": 88123593,
                   "Name": "DPXFilterPart"
+                },
+                {
+                  "Kind": 6,
+                  "RelatedPagePartId": { "Name": "", "Id": 88123502 },
+                  "Properties": [
+                    { "Name": "SubPageLink", "Value": "\"Part Link Field\" = field(\"Host Link Field\"), \"Table ID\" = valuefilter(1)" }
+                  ],
+                  "Id": 88123592,
+                  "Name": "DPXPartialLinkPart"
+                },
+                {
+                  "Kind": 6,
+                  "RelatedPagePartId": { "Name": "", "Id": 88123502 },
+                  "Properties": [
+                    { "Name": "SubPageLink", "Value": "\"Part Link Field\" = field(\"Host Link Field\"),\r\n#if not CLEAN25\r\n                              \"Service Zone Filter\" = field(\"Service Zone Filter\"),\r\n#endif\r\n                              \"Chargeable Filter\" = field(\"Chargeable Filter\")" }
+                  ],
+                  "Id": 88123591,
+                  "Name": "DPXDirectiveCompiledOutPart"
+                },
+                {
+                  "Kind": 6,
+                  "RelatedPagePartId": { "Name": "", "Id": 88123502 },
+                  "Properties": [
+                    { "Name": "SubPageLink", "Value": "\"Part Link Field\" = field(\"Host Link Field\"),\r\n#if not CLEAN25\r\n                              \"Table ID\" = const(88123520),\r\n#endif\r\n                              \"Chargeable Filter\" = field(\"Chargeable Filter\")" }
+                  ],
+                  "Id": 88123590,
+                  "Name": "DPXDirectiveCompiledInPart"
+                },
+                {
+                  "Kind": 6,
+                  "RelatedPagePartId": { "Name": "", "Id": 88123502 },
+                  "Properties": [
+                    { "Name": "SubPageLink", "Value": "\"Part Link Field\" = field(\"Host Link Field\"),\r\n#if not CLEAN25\r\n                              \"Service Zone Filter\" = field(\"Service Zone Filter\"),\r\n                              \"Second Absent Field\" = field(\"Host Link Field\"),\r\n#endif\r\n                              \"Chargeable Filter\" = field(\"Chargeable Filter\")" }
+                  ],
+                  "Id": 88123589,
+                  "Name": "DPXDirectiveBlockPart"
                 }
               ]
             },
@@ -593,6 +633,203 @@ public class DependencyPageMetadataXmlTests
     }
 
     /// <summary>
+    /// #2978's sibling. <c>ParseSubPageLink</c> makes the same fail-open assumption
+    /// <c>ParseSourceTableView</c> did, with the same <c>continue</c> and the same regex: an
+    /// entry it cannot read is dropped, and the remaining entries ship as if they were the
+    /// whole link. A two-condition SubPageLink reduced to one condition filters the part
+    /// LESS, so the subpage shows rows the host row does not own — the same class of wrong
+    /// answer as a widened page view, one level down.
+    ///
+    /// <para>The refusal channel is the one <c>EmitSubFormLinkXml</c> already documents:
+    /// <c>FieldID="0"</c>, which <c>MockTestPage.SubPageLinks</c> refuses by name for every
+    /// kind. Two links, not one, and the unreadable one refuses.</para>
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_UnreadableSubPageLinkEntry_KeepsARefusingLinkRatherThanWideningThePart()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, PartsSymbolReference));
+
+            var xml = RecordPatches.TryBuildDependencyPageMetadata(PartsHostPageId);
+            var doc = new XmlDocument();
+            doc.LoadXml(xml!);
+            var ns = new XmlNamespaceManager(doc.NameTable);
+            ns.AddNamespace("m", "urn:schemas-microsoft-com:dynamics:NAV:MetaObjects");
+
+            var part = GetPartControl(doc, ns, 88123592);
+            var links = part.SelectNodes("m:SubFormLink", ns)!.Cast<XmlElement>().ToList();
+
+            // BEFORE #2978 this was 1 — the part filtered on "Part Link Field" alone.
+            Assert.Equal(2, links.Count);
+
+            Assert.Equal("5", links[0].GetAttribute("FieldID"));
+            Assert.Equal("FIELD", links[0].GetAttribute("FilterType"));
+            Assert.Equal("1", links[0].GetAttribute("FilterValue"));
+
+            Assert.Equal("0", links[1].GetAttribute("FieldID"));
+            Assert.Equal("4", links[1].GetAttribute("FilterGroup"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// #2978, the half that is not hypothetical. The AL compiler records a property's SOURCE
+    /// text in SymbolReference.json, PREPROCESSOR DIRECTIVES AND ALL, and BC 27.5's Base
+    /// Application ships three subpage parts that carry one — page 76 "Resource Card"
+    /// Control1906609707, page 77 "Resource List" Control1906609707 and Control1907012907, all
+    /// three verbatim:
+    /// <code>
+    /// "No." = field("No."),
+    ///                               "Unit of Measure Filter" = field("Unit of Measure Filter"),
+    /// #if not CLEAN25
+    ///                               "Service Zone Filter" = field("Service Zone Filter"),
+    /// #endif
+    ///                               "Chargeable Filter" = field("Chargeable Filter")
+    /// </code>
+    /// <para>Comma-splitting leaves two entries the regex cannot read — one prefixed
+    /// <c>#if not CLEAN25</c>, one prefixed <c>#endif</c> — and both were dropped. So those
+    /// three parts filtered on TWO of their four conditions and showed rows the host resource
+    /// does not own. That is not the unmeasured tail this issue was filed about; it is
+    /// shipping, on a BC version this runner's own CI matrix covers.</para>
+    ///
+    /// <para>Which of the two entries is really in the compiled app is measured, not guessed:
+    /// BC 27.5's own symbol file states table <c>Resource</c> with 58 fields and NO "Service
+    /// Zone Filter", so <c>CLEAN25</c> WAS defined when Microsoft compiled it and the guarded
+    /// entry was compiled out — and BC 28.1, where the directive has been deleted from the
+    /// source, carries exactly the three unconditional entries and no "Service Zone Filter".
+    /// So the <c>#endif</c> entry must parse and apply, and the <c>#if</c> entry must be
+    /// omitted rather than turned into a refusal: refusing a page over a link the app does not
+    /// contain is a wrong answer in the other direction.</para>
+    ///
+    /// <para>Measured across every extension of BC 27.5 and 28.1 W1 — 7,646 pages, 3,655
+    /// SubPageLink entries, 981 SourceTableView pages with 547 where-entries — those six
+    /// entries on those three controls are the ONLY ones in either version that fail to
+    /// parse, and no SourceTableView carries a directive at all.</para>
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_DirectiveGuardedLinkCompiledOut_AppliesTheEntryAfterEndifAndOmitsTheGuardedOne()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, PartsSymbolReference));
+
+            var xml = RecordPatches.TryBuildDependencyPageMetadata(PartsHostPageId);
+            var doc = new XmlDocument();
+            doc.LoadXml(xml!);
+            var ns = new XmlNamespaceManager(doc.NameTable);
+            ns.AddNamespace("m", "urn:schemas-microsoft-com:dynamics:NAV:MetaObjects");
+
+            var part = GetPartControl(doc, ns, 88123591);
+            var links = part.SelectNodes("m:SubFormLink", ns)!.Cast<XmlElement>().ToList();
+
+            // BEFORE #2978 this was 1: the "#endif …Chargeable Filter" entry was dropped along
+            // with the guarded one, and the part showed every Chargeable Filter value.
+            Assert.Equal(2, links.Count);
+
+            Assert.Equal("5", links[0].GetAttribute("FieldID"));      // "Part Link Field"
+            Assert.Equal("1", links[0].GetAttribute("FilterValue"));  // <- "Host Link Field"
+
+            // The entry that only LOOKED unreadable because #endif preceded it.
+            Assert.Equal("7", links[1].GetAttribute("FieldID"));      // "Chargeable Filter"
+            Assert.Equal("FIELD", links[1].GetAttribute("FilterType"));
+            Assert.Equal("2", links[1].GetAttribute("FilterValue"));  // <- host "Chargeable Filter"
+
+            // …and NOT as a refusal: the guarded entry names a field this app does not have,
+            // which is the app saying the directive compiled it out.
+            Assert.DoesNotContain(links, l => l.GetAttribute("FieldID") == "0");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The direction that stops the test above from passing for an implementation that just
+    /// throws every conditional entry away: a <c>#if</c>-guarded entry whose fields this app
+    /// DOES have is in the app, and must filter. Same three-entry link, same directive, only
+    /// the guarded entry's field names differ.
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_DirectiveGuardedLinkCompiledIn_KeepsFilteringOnIt()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, PartsSymbolReference));
+
+            var xml = RecordPatches.TryBuildDependencyPageMetadata(PartsHostPageId);
+            var doc = new XmlDocument();
+            doc.LoadXml(xml!);
+            var ns = new XmlNamespaceManager(doc.NameTable);
+            ns.AddNamespace("m", "urn:schemas-microsoft-com:dynamics:NAV:MetaObjects");
+
+            var part = GetPartControl(doc, ns, 88123590);
+            var links = part.SelectNodes("m:SubFormLink", ns)!.Cast<XmlElement>().ToList();
+
+            Assert.Equal(3, links.Count);
+            Assert.Equal("5", links[0].GetAttribute("FieldID"));
+
+            // The guarded entry, applied: "Table ID" = const(88123520), field 6 of the part.
+            Assert.Equal("6", links[1].GetAttribute("FieldID"));
+            Assert.Equal("CONST", links[1].GetAttribute("FilterType"));
+            Assert.Equal("88123520", links[1].GetAttribute("FilterValue"));
+
+            Assert.Equal("7", links[2].GetAttribute("FieldID"));
+            Assert.DoesNotContain(links, l => l.GetAttribute("FieldID") == "0");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Conditional-ness is a property of the BLOCK, not of the entry that happens to carry the
+    /// directive text. Comma-splitting only puts <c>#if not CLEAN25</c> on the FIRST guarded
+    /// entry, so a second entry inside the same block carries no <c>#</c> line of its own —
+    /// and reading it as unconditional would turn its absent field into a refusal, i.e. a page
+    /// that will not open because of AL the compiler removed.
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_SecondEntryInsideTheSameDirectiveBlock_IsConditionalToo()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, PartsSymbolReference));
+
+            var xml = RecordPatches.TryBuildDependencyPageMetadata(PartsHostPageId);
+            var doc = new XmlDocument();
+            doc.LoadXml(xml!);
+            var ns = new XmlNamespaceManager(doc.NameTable);
+            ns.AddNamespace("m", "urn:schemas-microsoft-com:dynamics:NAV:MetaObjects");
+
+            var part = GetPartControl(doc, ns, 88123589);
+            var links = part.SelectNodes("m:SubFormLink", ns)!.Cast<XmlElement>().ToList();
+
+            Assert.Equal(2, links.Count);
+            Assert.Equal("5", links[0].GetAttribute("FieldID"));
+            Assert.Equal("7", links[1].GetAttribute("FieldID"));
+            Assert.DoesNotContain(links, l => l.GetAttribute("FieldID") == "0");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
     /// A page with no parts at all must keep the pre-#2467 shape: Content present but with
     /// no Containers child — never an empty <c>&lt;Containers&gt;</c> wrapper, which would be
     /// a needless divergence from what the real compiler emits for such a page.
@@ -700,6 +937,8 @@ public class DependencyPageMetadataXmlTests
     private const int UnresolvableViewPageId = 88123603;
     private const int WhereOnlyViewPageId = 88123604;
     private const int ViewPlusPropsPageId = 88123605;
+    private const int PartialViewPageId = 88123606;
+    private const int UnbalancedViewPageId = 88123607;
 
     private const string ViewSymbolReference = """
         {
@@ -760,6 +999,24 @@ public class DependencyPageMetadataXmlTests
                 { "Name": "LinksAllowed", "Value": "0" },
                 { "Name": "PopulateAllFields", "Value": "1" },
                 { "Name": "SourceTableView", "Value": "where(Bucket = const(7))" }
+              ]
+            },
+            {
+              "Id": 88123606,
+              "Name": "DPX Partial View Page",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "88123620" },
+                { "Name": "SourceTableView", "Value": "where(Bucket = const(7), \"Price Type\" = valuefilter(Sale))" }
+              ]
+            },
+            {
+              "Id": 88123607,
+              "Name": "DPX Unbalanced View Page",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "88123620" },
+                { "Name": "SourceTableView", "Value": "sorting(Bucket) where(Bucket = const(7)" }
               ]
             }
           ]
@@ -952,6 +1209,103 @@ public class DependencyPageMetadataXmlTests
             var filters = sourceObject.SelectNodes("m:SourceTableView/m:TableFilters", ns)!
                 .Cast<XmlElement>().ToList();
 
+            Assert.Single(filters);
+            Assert.Equal("0", filters[0].GetAttribute("FieldID"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// #2978 — the fail-OPEN half of the same feature. A <c>where(...)</c> entry
+    /// <c>ParseSourceTableView</c> cannot read used to be dropped with a
+    /// <c>Console.Error.WriteLine</c> and a <c>continue</c>, and the page shipped the
+    /// remaining entries as if they were the whole view. That is WIDER than the view the
+    /// page declares: rows the real view excludes are shown, a test asserting over them
+    /// passes against a record set BC would not give, and nothing reports it — the stderr
+    /// line is written on a symbol-cache MISS and lost on every warm run after.
+    ///
+    /// <para>So an entry that could not be read keeps its place in the emitted
+    /// <c>&lt;TableFilters&gt;</c> list with <c>FieldID="0"</c>: BC's own
+    /// <c>MetaTable.GetFieldByNo(0)</c> refuses it with NavNCLFieldNotFoundException when the
+    /// page opens, which is exactly the fail-closed choice the unresolvable-FIELD-NAME case
+    /// above already makes. The page refuses to open rather than open on the wrong rows.</para>
+    ///
+    /// <para>The trigger is a kind keyword outside <c>field</c>/<c>const</c>/<c>filter</c>,
+    /// standing in for "AL text this parser has not been taught". Whether that exact spelling
+    /// compiles is beside the point: the claim under test is what the runner does when it
+    /// cannot read an entry, not which entries it can read. Measured on BC 28.1's Base
+    /// Application, System Application, Business Foundation and Application: 2845 pages, 417
+    /// declaring a SourceTableView, 255 where-entries and 1357 SubPageLink entries, and every
+    /// single one parses — so this path is unreachable for what Microsoft ships today, and
+    /// this change cannot alter any of it.</para>
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_UnreadableViewEntry_KeepsARefusingFilterRatherThanWideningTheView()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, ViewSymbolReference));
+
+            var sourceObject = ReadSourceObjectFor(PartialViewPageId);
+            var ns = MetaNs(sourceObject.OwnerDocument!);
+            var filters = sourceObject.SelectNodes("m:SourceTableView/m:TableFilters", ns)!
+                .Cast<XmlElement>().ToList();
+
+            // BEFORE #2978 this was Single(filters) — Bucket alone, and the page opened on
+            // every "Price Type".
+            Assert.Equal(2, filters.Count);
+
+            // The entry that DID parse is untouched: field 2 of the fixture table, CONST 7.
+            Assert.Equal("2", filters[0].GetAttribute("FieldID"));
+            Assert.Equal("CONST", filters[0].GetAttribute("FilterType"));
+            Assert.Equal("7", filters[0].GetAttribute("FilterValue"));
+
+            // The one that did not is present and refusing, in the same filter group.
+            Assert.Equal("0", filters[1].GetAttribute("FieldID"));
+            Assert.Equal("2", filters[1].GetAttribute("FilterGroup"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// #2978, the clause-level half: a <c>sorting(...) where(...</c> whose parenthesis never
+    /// closes made <c>MatchingCloseParen</c> return -1 and the whole <c>where</c> clause
+    /// vanish, while the <c>sorting</c> beside it still applied. The page then came up SORTED
+    /// as declared and UNFILTERED — the most convincing possible wrong answer, because the
+    /// half that is easy to eyeball is right.
+    ///
+    /// <para>Only the case where NO clause at all could be read stays a <c>return null</c>,
+    /// and that one is safe: the caller emits no <c>&lt;SourceTableView&gt;</c> element, which
+    /// is the pre-#2820 state rather than a manufactured narrower one.</para>
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_UnbalancedViewClause_RefusesRatherThanSortingAnUnfilteredPage()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, ViewSymbolReference));
+
+            var sourceObject = ReadSourceObjectFor(UnbalancedViewPageId);
+            var ns = MetaNs(sourceObject.OwnerDocument!);
+
+            // The sorting half still reads — that is what made the drop convincing.
+            var sorting = (XmlElement?)sourceObject.SelectSingleNode("m:SourceTableView/m:Sorting", ns);
+            Assert.NotNull(sorting);
+            Assert.Equal("Field2", sorting!.GetAttribute("KeyFields"));
+
+            // BEFORE #2978 there were no TableFilters at all here.
+            var filters = sourceObject.SelectNodes("m:SourceTableView/m:TableFilters", ns)!
+                .Cast<XmlElement>().ToList();
             Assert.Single(filters);
             Assert.Equal("0", filters[0].GetAttribute("FieldID"));
         }

--- a/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
+++ b/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
@@ -698,14 +698,23 @@ public class DependencyPageMetadataXmlTests
     /// does not own. That is not the unmeasured tail this issue was filed about; it is
     /// shipping, on a BC version this runner's own CI matrix covers.</para>
     ///
-    /// <para>Which of the two entries is really in the compiled app is measured, not guessed:
-    /// BC 27.5's own symbol file states table <c>Resource</c> with 58 fields and NO "Service
-    /// Zone Filter", so <c>CLEAN25</c> WAS defined when Microsoft compiled it and the guarded
-    /// entry was compiled out — and BC 28.1, where the directive has been deleted from the
-    /// source, carries exactly the three unconditional entries and no "Service Zone Filter".
-    /// So the <c>#endif</c> entry must parse and apply, and the <c>#if</c> entry must be
-    /// omitted rather than turned into a refusal: refusing a page over a link the app does not
-    /// contain is a wrong answer in the other direction.</para>
+    /// <para>The <c>#endif</c> entry is unconditionally in the app and must parse and apply —
+    /// BC 28.1, where the directive has been deleted from the source, carries it. The
+    /// <c>#if</c> entry is CONDITIONAL, and nothing in the symbol file records whether the
+    /// compiler kept it, so the runner resolves it against the app's own field inventory
+    /// instead of guessing: applied when every name it uses resolves, omitted when one does
+    /// not. Omitted, NOT refused — refusing a page over a link the app does not contain is a
+    /// wrong answer in the other direction, and this fixture is the omitted half.</para>
+    ///
+    /// <para>On the real BC 27.5 pages the guarded name DOES resolve ("Service Zone Filter"
+    /// comes from the Serv. Resource tableextension, present in 27.5 and 28.1 alike), so the
+    /// runner applies it and those three parts go from two link conditions to four. Everything
+    /// observable says that is right: Microsoft's shipped W1 builds do not appear to define
+    /// <c>CLEANnn</c> — 28.1 still carries <c>#if not CLEAN27</c> though it is BC 28, the
+    /// 27.5 guards reading <c>CLEAN25</c>/<c>CLEAN26</c> read <c>CLEAN28</c> in 28.1 rather
+    /// than having been resolved, and 28.1 wraps one such block's body in
+    /// <c>#pragma warning disable AL0432</c>, which suppresses an obsolete-USAGE warning and
+    /// is only needed on code that compiles.</para>
     ///
     /// <para>Measured across every extension of BC 27.5 and 28.1 W1 — 7,646 pages, 3,655
     /// SubPageLink entries, 981 SourceTableView pages with 547 where-entries — those six
@@ -798,7 +807,8 @@ public class DependencyPageMetadataXmlTests
     /// directive text. Comma-splitting only puts <c>#if not CLEAN25</c> on the FIRST guarded
     /// entry, so a second entry inside the same block carries no <c>#</c> line of its own —
     /// and reading it as unconditional would turn its absent field into a refusal, i.e. a page
-    /// that will not open because of AL the compiler removed.
+    /// that will not open because of AL that is not in the app. Before this, that is exactly
+    /// what happened: the pre-fix build emitted this entry with <c>FieldID="0"</c>.
     /// </summary>
     [Fact]
     public void TryBuildDependencyPageMetadata_SecondEntryInsideTheSameDirectiveBlock_IsConditionalToo()

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -446,7 +446,23 @@ internal static partial class BcAppSymbolCache
     internal sealed record PagePartSymbol(
         int Id, string Name, int PagePartId,
         string? Caption, string? EditableExpr, string? EnabledExpr, string? VisibleExpr, string? ShowFilterExpr,
-        List<PageSubFormLinkSymbol> SubFormLink);
+        List<PageSubFormLinkSymbol> SubFormLink,
+        // The raw text of every SubPageLink entry ParseSubPageLink could NOT read (#2978).
+        // Null when there were none, which is the case for all 1357 SubPageLink entries
+        // across BC 28.1's Base Application, System Application, Business Foundation and
+        // Application.
+        //
+        // It lives in the PAYLOAD rather than being written to stderr where it is detected,
+        // for the reason PageSymbol.UnreadableBooleanProperties spells out: parsing sits
+        // behind a content-addressed on-disk cache, so a Console.Error line is emitted on a
+        // cache MISS and silently lost on every warm run after. Carrying it here means a
+        // cache HIT replays it, which is also the truthful answer — the same bytes could not
+        // be read either time.
+        //
+        // DependencyPageMetadataXml.EmitPartXml turns each one into a refusing SubFormLink
+        // rather than dropping it: a two-condition link reduced to one filters the part LESS,
+        // so the subpage shows rows the host row does not own.
+        List<string>? UnreadableSubPageLinkEntries = null);
 
     /// <summary>
     /// One entry of a part's <c>SubPageLink</c> property, still as AL source text.
@@ -457,7 +473,13 @@ internal static partial class BcAppSymbolCache
     /// compiled representation by RecordPatches.DependencyPageMetadataXml's
     /// EmitSubFormLinkXml, then applied by MockTestPage.SubPageLinks — #2469).
     /// </summary>
-    internal sealed record PageSubFormLinkSymbol(string PartFieldName, string Kind, string Value);
+    internal sealed record PageSubFormLinkSymbol(string PartFieldName, string Kind, string Value,
+        // True when this entry sits inside an AL `#if`/`#else` block in the property's source
+        // text, so it MAY not be in the compiled app at all (#2978). See SplitPropertyEntries
+        // for the measurement, and DependencyPageMetadataXml.EmitSubFormLinkXml for what the
+        // difference buys: an unresolvable field name is a refusal for an unconditional entry
+        // and an absence for a conditional one.
+        bool Conditional = false);
 
     /// <summary>
     /// A precompiled dependency page's <c>SourceTableView</c>, parsed from the AL text
@@ -470,7 +492,18 @@ internal static partial class BcAppSymbolCache
     /// the view SET it (<c>AscendingSetByView</c>).</para>
     /// </summary>
     internal sealed record PageTableViewSymbol(
-        List<string> SortingFieldNames, bool? Ascending, List<PageViewFilterSymbol> Filters);
+        List<string> SortingFieldNames, bool? Ascending, List<PageViewFilterSymbol> Filters,
+        // The raw text of every where(...) entry — and every clause whose parenthesis never
+        // closed — ParseSourceTableView could NOT read (#2978). Null when there were none,
+        // which is the case for all 255 where-entries across the 417 SourceTableView pages of
+        // BC 28.1's Base Application, System Application, Business Foundation and Application.
+        //
+        // Same payload-not-stderr reasoning as PagePartSymbol.UnreadableSubPageLinkEntries
+        // above. DependencyPageMetadataXml.EmitSourceTableViewXml turns each one into a
+        // refusing <TableFilters>, because a view shipped without one of its entries is WIDER
+        // than the view the page declares: the page opens on rows the real view excludes, and
+        // a test asserting over them passes against a record set BC would never give.
+        List<string>? UnreadableEntries = null);
 
     /// <summary>
     /// One <c>where(...)</c> entry of a <c>SourceTableView</c>: the page's OWN source-table
@@ -478,7 +511,12 @@ internal static partial class BcAppSymbolCache
     /// <c>field(...)</c>, which references a host record a page-level view has none of), and
     /// the value text verbatim.
     /// </summary>
-    internal sealed record PageViewFilterSymbol(string FieldName, string Kind, string Value);
+    internal sealed record PageViewFilterSymbol(string FieldName, string Kind, string Value,
+        // Same meaning as PageSubFormLinkSymbol.Conditional (#2978). No SourceTableView in BC
+        // 27.5 or 28.1 W1 carries a directive today — all 547 where-entries are unconditional
+        // — but the property text comes from the same compiler and through the same splitter,
+        // so the two paths answer it the same way rather than one of them being surprised.
+        bool Conditional = false);
 
     /// <summary>
     /// One field control of a precompiled dependency page, as SymbolReference.json states
@@ -1308,19 +1346,110 @@ internal static partial class BcAppSymbolCache
                 props.TryGetValue("Visible", out var visible);
                 props.TryGetValue("ShowFilter", out var showFilter);
                 props.TryGetValue("SubPageLink", out var subPageLink);
+                var links = ParseSubPageLink(subPageLink, out var unreadableLinks);
                 into.Add(new PagePartSymbol(id, name!, partPageId,
                     string.IsNullOrEmpty(caption) ? null : caption,
                     string.IsNullOrEmpty(editable) ? null : editable,
                     string.IsNullOrEmpty(enabled) ? null : enabled,
                     string.IsNullOrEmpty(visible) ? null : visible,
                     string.IsNullOrEmpty(showFilter) ? null : showFilter,
-                    ParseSubPageLink(subPageLink)));
+                    links, unreadableLinks));
             }
         }
 
         if (control.TryGetProperty("Controls", out var children) && children.ValueKind == JsonValueKind.Array)
             foreach (var child in children.EnumerateArray())
                 CollectPagePartSymbols(child, into);
+    }
+
+    /// <summary>
+    /// Split a <c>SubPageLink</c> / <c>SourceTableView where(...)</c> property text into its
+    /// comma-separated entries, stripping the AL PREPROCESSOR DIRECTIVE lines the compiler
+    /// records verbatim inside the property's source text, and saying which entries sit
+    /// inside a conditional block.
+    ///
+    /// <para>Measured, not anticipated. Across BC 27.5 and 28.1 W1 (every extension in the
+    /// artifact: 7,646 pages, 3,655 SubPageLink entries, 981 pages declaring a
+    /// SourceTableView with 547 where-entries) exactly six entries fail the entry regex, all
+    /// six on BC 27.5 Base Application, all six because of a directive:</para>
+    /// <code>
+    /// page 76 "Resource Card"  / Control1906609707
+    /// page 77 "Resource List"  / Control1906609707, Control1907012907
+    ///     "No." = field("No."),
+    ///     "Unit of Measure Filter" = field("Unit of Measure Filter"),
+    /// #if not CLEAN25
+    ///     "Service Zone Filter" = field("Service Zone Filter"),
+    /// #endif
+    ///     "Chargeable Filter" = field("Chargeable Filter")
+    /// </code>
+    /// <para>Comma-splitting that leaves <c>#if not CLEAN25\r\n"Service Zone Filter" = …</c>
+    /// and <c>#endif\r\n"Chargeable Filter" = …</c>, neither of which the entry regex can
+    /// read. Before this, both were dropped — so those three subpages filtered on TWO of
+    /// their four conditions and showed rows the host resource does not own.</para>
+    ///
+    /// <para>Which of the two is actually in the compiled app is not a guess either. BC
+    /// 27.5's own symbol file states table <c>Resource</c> with 58 fields and NO "Service Zone
+    /// Filter", so <c>CLEAN25</c> was defined when Microsoft compiled it and the guarded entry
+    /// was compiled OUT; "Chargeable Filter" exists and is unconditional, and BC 28.1 — where
+    /// the directive is gone from the source entirely — carries exactly the three
+    /// unconditional entries. So: an entry after a directive that only closes or opens a
+    /// region (<c>#endif</c>, <c>#region</c>, <c>#endregion</c>, <c>#pragma</c>,
+    /// <c>#define</c>, <c>#undef</c>) is unconditionally present and must parse; an entry
+    /// inside an <c>#if</c>/<c>#ifdef</c>/<c>#ifndef</c>/<c>#else</c>/<c>#elif</c> block is
+    /// CONDITIONAL, and the caller resolves it against this app's own fields rather than
+    /// refusing the page over it — see <c>DependencyPageMetadataXml</c>.</para>
+    ///
+    /// <para>Nesting is tracked across entries, not per entry: in
+    /// <c>#if X  A=…, B=…, #endif  C=…</c> only A carries the directive text, and B is inside
+    /// the block just as much as A is.</para>
+    /// </summary>
+    private static List<(string Text, bool Conditional)> SplitPropertyEntries(string text)
+    {
+        var result = new List<(string, bool)>();
+        var depth = 0;
+        foreach (var rawEntry in SplitTopLevelCommas(text, preserveNewlines: true))
+        {
+            var body = new System.Text.StringBuilder();
+            var sawBody = false;
+            var conditional = depth > 0;
+            foreach (var rawLine in rawEntry.Split('\n'))
+            {
+                var line = rawLine.Trim();      // also drops the '\r' of a CRLF pair
+                if (line.Length == 0) continue;
+                if (line[0] == '#')
+                {
+                    switch (DirectiveName(line))
+                    {
+                        case "if": case "ifdef": case "ifndef": depth++; break;
+                        case "endif": if (depth > 0) depth--; break;
+                        // #else / #elif keep the block open; #region / #endregion / #pragma /
+                        // #define / #undef never gate anything.
+                        default: break;
+                    }
+                    // Only directives BEFORE the entry's own text decide whether THIS entry is
+                    // conditional; ones after it belong to whatever follows.
+                    if (!sawBody) conditional = depth > 0;
+                    continue;
+                }
+                if (sawBody) body.Append(' ');
+                body.Append(line);
+                sawBody = true;
+            }
+            if (sawBody) result.Add((body.ToString(), conditional));
+        }
+        return result;
+    }
+
+    /// <summary>The directive keyword of a line starting with '#', lowercased and without
+    /// its arguments — <c>"#if not CLEAN25"</c> -&gt; <c>"if"</c>. AL allows whitespace
+    /// between the '#' and the keyword.</summary>
+    private static string DirectiveName(string line)
+    {
+        var i = 1;
+        while (i < line.Length && char.IsWhiteSpace(line[i])) i++;
+        var start = i;
+        while (i < line.Length && char.IsLetter(line[i])) i++;
+        return line.Substring(start, i - start).ToLowerInvariant();
     }
 
     private static readonly System.Text.RegularExpressions.Regex SubPageLinkEntryRegex = new(
@@ -1332,28 +1461,29 @@ internal static partial class BcAppSymbolCache
     /// field("No.")</c>, or a comma-separated list of such pairs — into (part field, kind,
     /// value) triples. Measured across Base Application 28.1's 1311 SubPageLink entries:
     /// 1168 are <c>field(...)</c>, 140 are <c>const(...)</c>, 3 are <c>filter(...)</c>; an
-    /// entry this cannot parse is dropped and reported on stderr; the three kinds the regex
-    /// accepts are the only ones AL defines, so a drop here means AL text this parser has
-    /// never seen, not a link kind the runner declines.
+    /// entry this cannot parse is returned in <paramref name="unreadable"/> — NOT dropped
+    /// (#2978), because a link shipped without one of its conditions filters the part less
+    /// than the AL says and the subpage then shows rows the host row does not own; the three
+    /// kinds the regex accepts are the only ones AL defines, so an unreadable entry means AL
+    /// text this parser has never seen, not a link kind the runner declines.
     /// </summary>
-    private static List<PageSubFormLinkSymbol> ParseSubPageLink(string? text)
+    private static List<PageSubFormLinkSymbol> ParseSubPageLink(string? text, out List<string>? unreadable)
     {
+        unreadable = null;
         var result = new List<PageSubFormLinkSymbol>();
         if (string.IsNullOrWhiteSpace(text)) return result;
-        foreach (var rawEntry in SplitTopLevelCommas(text))
+        foreach (var (entry, conditional) in SplitPropertyEntries(text!))
         {
-            var entry = rawEntry.Trim();
-            if (entry.Length == 0) continue;
             var m = SubPageLinkEntryRegex.Match(entry);
             if (!m.Success)
             {
-                Console.Error.WriteLine($"[BcAppSymbolCache] SubPageLink entry not understood, dropped: '{entry}'");
+                (unreadable ??= new List<string>()).Add(entry);
                 continue;
             }
             var partField = m.Groups["left"].Value.Trim('"');
             var kind = m.Groups["kind"].Value.ToLowerInvariant();
             var value = m.Groups["val"].Value.Trim();
-            result.Add(new PageSubFormLinkSymbol(partField, kind, value));
+            result.Add(new PageSubFormLinkSymbol(partField, kind, value, conditional));
         }
         return result;
     }
@@ -1375,7 +1505,16 @@ internal static partial class BcAppSymbolCache
     ///
     /// <para>Returns null for a page declaring no view, and for text no clause could be read
     /// out of (reported on stderr) — the caller then emits no <c>&lt;SourceTableView&gt;</c>
-    /// element at all, which is the same state as before this parse existed.</para>
+    /// element at all, which is the same state as before this parse existed, rather than a
+    /// manufactured narrower one.</para>
+    ///
+    /// <para>A <c>where(...)</c> entry this cannot read, and a clause whose parenthesis never
+    /// closes, are recorded in <see cref="PageTableViewSymbol.UnreadableEntries"/> — NOT
+    /// dropped (#2978). Dropping shipped a PARTIAL view, which is WIDER than the one the page
+    /// declares: the page opens on rows the real view excludes, and the only trace was a
+    /// Console.Error line the symbol cache loses on every warm run. The caller turns each one
+    /// into a filter the page refuses to open on, matching what
+    /// <c>EmitSourceTableViewXml</c> already does for a field name it cannot resolve.</para>
     /// </summary>
     private static PageTableViewSymbol? ParseSourceTableView(int pageId, string? text)
     {
@@ -1384,13 +1523,23 @@ internal static partial class BcAppSymbolCache
         var sorting = new List<string>();
         bool? ascending = null;
         var filters = new List<PageViewFilterSymbol>();
+        List<string>? unreadable = null;
         var sawClause = false;
 
         foreach (System.Text.RegularExpressions.Match m in ViewClauseRegex.Matches(text!))
         {
             var open = m.Index + m.Length - 1;           // the '(' itself
             var close = MatchingCloseParen(text!, open);
-            if (close < 0) continue;                     // unbalanced — reported below
+            if (close < 0)
+            {
+                // Unbalanced. Dropping the clause silently was the worst of the #2978 shapes:
+                // `sorting(X) where(Y = const(1)` came up SORTED as declared and UNFILTERED,
+                // so the half that is easy to eyeball was right. A where/sorting/order clause
+                // that could not be read is unreadable AL, whichever clause it is, so it goes
+                // to the refusal channel regardless of which keyword opened it.
+                (unreadable ??= new List<string>()).Add(text!.Substring(m.Index).Trim());
+                continue;
+            }
             var inner = text!.Substring(open + 1, close - open - 1);
             sawClause = true;
 
@@ -1412,21 +1561,19 @@ internal static partial class BcAppSymbolCache
                         $"[BcAppSymbolCache] page {pageId} SourceTableView order() not understood, ignored: '{dir}'");
                     break;
                 default:
-                    foreach (var rawEntry in SplitTopLevelCommas(inner))
+                    foreach (var (entry, conditional) in SplitPropertyEntries(inner))
                     {
-                        var entry = rawEntry.Trim();
-                        if (entry.Length == 0) continue;
                         var em = SubPageLinkEntryRegex.Match(entry);
                         if (!em.Success)
                         {
-                            Console.Error.WriteLine(
-                                $"[BcAppSymbolCache] page {pageId} SourceTableView where() entry not understood, dropped: '{entry}'");
+                            (unreadable ??= new List<string>()).Add(entry);
                             continue;
                         }
                         filters.Add(new PageViewFilterSymbol(
                             em.Groups["left"].Value.Trim('"'),
                             em.Groups["kind"].Value.ToLowerInvariant(),
-                            em.Groups["val"].Value.Trim()));
+                            em.Groups["val"].Value.Trim(),
+                            conditional));
                     }
                     break;
             }
@@ -1438,8 +1585,8 @@ internal static partial class BcAppSymbolCache
                 $"[BcAppSymbolCache] page {pageId} SourceTableView not understood, ignored: '{text!.Trim()}'");
             return null;
         }
-        if (sorting.Count == 0 && ascending == null && filters.Count == 0) return null;
-        return new PageTableViewSymbol(sorting, ascending, filters);
+        if (sorting.Count == 0 && ascending == null && filters.Count == 0 && unreadable == null) return null;
+        return new PageTableViewSymbol(sorting, ascending, filters, unreadable);
     }
 
     /// <summary>Index of the ')' closing the '(' at <paramref name="open"/>, ignoring
@@ -1468,9 +1615,16 @@ internal static partial class BcAppSymbolCache
     /// the corpus, but a nested nested-paren value like <c>field("A, B")</c> would otherwise
     /// split wrongly).
     /// </summary>
-    private static IEnumerable<string> SplitTopLevelCommas(string text)
+    /// <param name="preserveNewlines">Keep the entry's own line breaks instead of flattening
+    /// them to spaces. <see cref="SplitPropertyEntries"/> needs them: an AL preprocessor
+    /// directive is a LINE, and once the newline after <c>#if not CLEAN25</c> is a space the
+    /// directive and the entry it guards are indistinguishable from one run-on entry — which
+    /// is exactly how three BC 27.5 Base Application subpage links were silently losing half
+    /// their conditions (#2978). Everything else keeps the flattening, which is what the
+    /// entry regexes have always been handed.</param>
+    private static IEnumerable<string> SplitTopLevelCommas(string text, bool preserveNewlines = false)
     {
-        var normalized = text.Replace("\r\n", " ").Replace('\n', ' ');
+        var normalized = preserveNewlines ? text : text.Replace("\r\n", " ").Replace('\n', ' ');
         var result = new List<string>();
         int depth = 0;
         bool inQuotes = false;

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -1387,17 +1387,28 @@ internal static partial class BcAppSymbolCache
     /// read. Before this, both were dropped — so those three subpages filtered on TWO of
     /// their four conditions and showed rows the host resource does not own.</para>
     ///
-    /// <para>Which of the two is actually in the compiled app is not a guess either. BC
-    /// 27.5's own symbol file states table <c>Resource</c> with 58 fields and NO "Service Zone
-    /// Filter", so <c>CLEAN25</c> was defined when Microsoft compiled it and the guarded entry
-    /// was compiled OUT; "Chargeable Filter" exists and is unconditional, and BC 28.1 — where
-    /// the directive is gone from the source entirely — carries exactly the three
-    /// unconditional entries. So: an entry after a directive that only closes or opens a
-    /// region (<c>#endif</c>, <c>#region</c>, <c>#endregion</c>, <c>#pragma</c>,
-    /// <c>#define</c>, <c>#undef</c>) is unconditionally present and must parse; an entry
-    /// inside an <c>#if</c>/<c>#ifdef</c>/<c>#ifndef</c>/<c>#else</c>/<c>#elif</c> block is
-    /// CONDITIONAL, and the caller resolves it against this app's own fields rather than
-    /// refusing the page over it — see <c>DependencyPageMetadataXml</c>.</para>
+    /// <para>An entry after a directive that only opens or closes a region (<c>#endif</c>,
+    /// <c>#region</c>, <c>#endregion</c>, <c>#pragma</c>, <c>#define</c>, <c>#undef</c>) is
+    /// unconditionally in the app and must parse — <c>"Chargeable Filter"</c> above is only
+    /// unreadable because <c>#endif</c> happens to precede it, and BC 28.1, where the
+    /// directive has been deleted from the source, carries it. An entry inside an
+    /// <c>#if</c>/<c>#ifdef</c>/<c>#ifndef</c>/<c>#else</c>/<c>#elif</c> block is CONDITIONAL:
+    /// this parse cannot evaluate the condition, so the caller resolves it against the app's
+    /// own field inventory rather than refusing the page over it — see
+    /// <c>DependencyPageMetadataXml.EmitSubFormLinkXml</c>.</para>
+    ///
+    /// <para>What the evidence says about <c>CLEAN25</c> specifically, since the runner does
+    /// NOT encode it: the guarded entry names "Service Zone Filter", which the
+    /// <c>Serv. Resource</c> tableextension adds to Resource in BOTH 27.5 and 28.1, so it
+    /// resolves and the reconstruction applies it. Everything observable says that is right —
+    /// Microsoft's shipped W1 builds do not define <c>CLEANnn</c>. 28.1 still carries
+    /// <c>#if not CLEAN27</c> even though it is BC 28, which a defined symbol would make dead
+    /// code; the two guards that read <c>CLEAN25</c>/<c>CLEAN26</c> in 27.5 read
+    /// <c>CLEAN28</c> in 28.1, i.e. the version is bumped rather than the branch resolved;
+    /// and 28.1 wraps the body of one such block in <c>#pragma warning disable AL0432</c>,
+    /// which suppresses an obsolete-USAGE warning and is only needed on code that compiles.
+    /// A defined symbol would flip that to over-filtering — narrower than BC, which fails a
+    /// test loudly, not the silent widening this whole change is about.</para>
     ///
     /// <para>Nesting is tracked across entries, not per entry: in
     /// <c>#if X  A=…, B=…, #endif  C=…</c> only A carries the directive text, and B is inside

--- a/AlRunner/Patches/DependencyPageMetadataXml.cs
+++ b/AlRunner/Patches/DependencyPageMetadataXml.cs
@@ -398,6 +398,28 @@ public static partial class RecordPatches
         foreach (var link in part.SubFormLink)
             EmitSubFormLinkXml(w, hostPage, part, link);
 
+        // #2978: a SubPageLink entry ParseSubPageLink could not read at all. Dropping it —
+        // what this did before — left the part filtered on FEWER conditions than its AL
+        // declares, so the subpage showed rows the host row does not own, and the only trace
+        // was a Console.Error line the symbol cache loses on every warm run. Emit it as a
+        // link BC refuses instead: FieldID 0 is what MockTestPage.SubPageLinks already
+        // refuses BY NAME for every kind, the same fail-closed channel an unresolvable part
+        // field already uses two lines above.
+        if (part.UnreadableSubPageLinkEntries is { Count: > 0 } unreadable)
+            foreach (var entry in unreadable)
+            {
+                Console.Error.WriteLine(
+                    $"[RecordPatches] page {hostPage.Id} \"{hostPage.Name}\" part \"{part.Name}\": "
+                    + $"SubPageLink entry not readable: '{entry}' — the part will refuse to open "
+                    + "rather than show rows its link excludes");
+                w.WriteStartElement("SubFormLink");
+                w.WriteAttributeString("FilterGroup", "4");
+                w.WriteAttributeString("FieldID", "0");
+                w.WriteAttributeString("FilterType", "CONST");
+                w.WriteAttributeString("FilterValue", XmlSafe(entry));
+                w.WriteEndElement();
+            }
+
         w.WriteEndElement(); // Controls
     }
 
@@ -421,16 +443,37 @@ public static partial class RecordPatches
     {
         int partTableId = RecordPatches.ResolveSourceTableIdForAnyPage(part.PagePartId);
         int? partFieldId = RecordPatches.TryResolveDependencyFieldId(partTableId, link.PartFieldName);
+        var isFieldKind = string.Equals(link.Kind, "field", StringComparison.OrdinalIgnoreCase);
+        var parentFieldName = isFieldKind ? link.Value.Trim('"') : null;
+        int? parentFieldId = isFieldKind
+            ? RecordPatches.TryResolveDependencyFieldId(hostPage.SourceTableId, parentFieldName!)
+            : null;
+
+        // #2978: an entry inside an AL `#if` block MAY not be in the compiled app. BC 27.5's
+        // Base Application pages 76/77 declare `#if not CLEAN25 "Service Zone Filter" =
+        // field("Service Zone Filter")` and the same symbol file states table Resource with 58
+        // fields and no such field — CLEAN25 was defined when Microsoft compiled it, so that
+        // entry is not in the app, and BC 28.1 (directive deleted from the source) carries
+        // exactly the three unconditional entries. A field name that does not resolve is a
+        // REFUSAL for an unconditional entry and an ABSENCE for a conditional one: the app
+        // itself is the evidence for which, and refusing the page over a link it does not have
+        // would be a wrong answer in the other direction.
+        if (link.Conditional && (partFieldId is null || (isFieldKind && parentFieldId is null)))
+        {
+            Console.Error.WriteLine(
+                $"[RecordPatches] page {hostPage.Id} \"{hostPage.Name}\" part \"{part.Name}\": "
+                + $"conditional SubPageLink entry \"{link.PartFieldName}\" omitted — the field it "
+                + $"names is not in this app, so the AL directive guarding it compiled the entry out");
+            return;
+        }
 
         w.WriteStartElement("SubFormLink");
         w.WriteAttributeString("FilterGroup", "4");
         w.WriteAttributeString("FieldID",
             (partFieldId ?? 0).ToString(System.Globalization.CultureInfo.InvariantCulture));
 
-        if (string.Equals(link.Kind, "field", StringComparison.OrdinalIgnoreCase))
+        if (isFieldKind)
         {
-            var parentFieldName = link.Value.Trim('"');
-            int? parentFieldId = RecordPatches.TryResolveDependencyFieldId(hostPage.SourceTableId, parentFieldName);
             w.WriteAttributeString("FilterType", "FIELD");
             // Unresolved renders as the field NAME, not a number — MockTestPage.SubPageLinks
             // int.TryParse()s this and refuses by name when it isn't numeric, which is
@@ -543,6 +586,21 @@ public static partial class RecordPatches
         foreach (var filter in view.Filters)
         {
             var fieldId = RecordPatches.TryResolveDependencyFieldId(page.SourceTableId, filter.FieldName);
+
+            // #2978: an entry inside an AL `#if` block may not be in the compiled app at all,
+            // and this app's own field list is the evidence for which — same rule, same
+            // reasoning as EmitSubFormLinkXml's conditional arm. No SourceTableView in BC 27.5
+            // or 28.1 W1 carries a directive today; the arm exists so the two paths through
+            // the same splitter cannot answer it differently.
+            if (filter.Conditional && fieldId is null)
+            {
+                Console.Error.WriteLine(
+                    $"[RecordPatches] page {page.Id} \"{page.Name}\": conditional SourceTableView "
+                    + $"filter \"{filter.FieldName}\" omitted — the field it names is not in this "
+                    + "app, so the AL directive guarding it compiled the entry out");
+                continue;
+            }
+
             if (fieldId is null)
                 Console.Error.WriteLine(
                     $"[RecordPatches] page {page.Id} \"{page.Name}\": SourceTableView field "
@@ -566,7 +624,48 @@ public static partial class RecordPatches
             w.WriteEndElement(); // TableFilters
         }
 
+        // #2978: a where(...) entry — or a whole clause whose parenthesis never closed —
+        // ParseSourceTableView could not read. Dropping it shipped a PARTIAL view, which is
+        // WIDER than the one the page declares: the page opened on rows the real view
+        // excludes, a test asserting over them passed against a record set BC never gives,
+        // and the only trace was a Console.Error line the symbol cache loses on every warm
+        // run. FieldID 0 makes BC's own MetaTable.GetFieldByNo(0) refuse the page with
+        // NavNCLFieldNotFoundException instead — the identical fail-closed channel the
+        // unresolvable-field-name case above already uses, for the identical reason.
+        if (view.UnreadableEntries is { Count: > 0 } unreadable)
+            foreach (var entry in unreadable)
+            {
+                Console.Error.WriteLine(
+                    $"[RecordPatches] page {page.Id} \"{page.Name}\": SourceTableView entry not "
+                    + $"readable: '{entry}' — the page will refuse to open rather than show rows "
+                    + "its view excludes");
+                w.WriteStartElement("TableFilters");
+                w.WriteAttributeString("FilterGroup", "2");
+                w.WriteAttributeString("FieldID", "0");
+                w.WriteAttributeString("FilterType", "CONST");
+                w.WriteAttributeString("FilterValue", XmlSafe(entry));
+                w.WriteEndElement();
+            }
+
         w.WriteEndElement(); // SourceTableView
+    }
+
+    /// <summary>
+    /// The unreadable AL text, made safe to put in an XML attribute: characters
+    /// <see cref="XmlConvert.IsXmlChar"/> rejects would make XmlWriter throw, and the whole
+    /// point of this value is that the runner could NOT read it, so it cannot be assumed
+    /// well-formed. Capped, because it is a diagnostic for whoever reads the synthesized
+    /// metadata — BC never gets as far as reading it, since FieldID 0 refuses first.
+    /// </summary>
+    private static string XmlSafe(string text)
+    {
+        var sb = new System.Text.StringBuilder(Math.Min(text.Length, 200));
+        foreach (var c in text)
+        {
+            if (sb.Length >= 200) break;
+            sb.Append(XmlConvert.IsXmlChar(c) ? (char.IsControl(c) ? ' ' : c) : ' ');
+        }
+        return sb.ToString();
     }
 
     /// <summary>

--- a/AlRunner/Patches/DependencyPageMetadataXml.cs
+++ b/AlRunner/Patches/DependencyPageMetadataXml.cs
@@ -449,15 +449,22 @@ public static partial class RecordPatches
             ? RecordPatches.TryResolveDependencyFieldId(hostPage.SourceTableId, parentFieldName!)
             : null;
 
-        // #2978: an entry inside an AL `#if` block MAY not be in the compiled app. BC 27.5's
-        // Base Application pages 76/77 declare `#if not CLEAN25 "Service Zone Filter" =
-        // field("Service Zone Filter")` and the same symbol file states table Resource with 58
-        // fields and no such field — CLEAN25 was defined when Microsoft compiled it, so that
-        // entry is not in the app, and BC 28.1 (directive deleted from the source) carries
-        // exactly the three unconditional entries. A field name that does not resolve is a
-        // REFUSAL for an unconditional entry and an ABSENCE for a conditional one: the app
-        // itself is the evidence for which, and refusing the page over a link it does not have
+        // #2978: an entry inside an AL `#if` block may or may not be in the compiled app, and
+        // nothing in the symbol file records which — the compiler stores the property's SOURCE
+        // text, directives and all. So a field name that does not resolve means two different
+        // things depending on the entry: for an UNCONDITIONAL one it is a broken link and the
+        // page must refuse to open (the arm below), and for a CONDITIONAL one it is the app
+        // saying that AL is not in it, where refusing the page over a link it does not have
         // would be a wrong answer in the other direction.
+        //
+        // BC 27.5's Base Application pages 76 "Resource Card" and 77 "Resource List" are the
+        // only real instance: `#if not CLEAN25 "Service Zone Filter" = field("Service Zone
+        // Filter")`. That name resolves — the Serv. Resource tableextension adds it to
+        // Resource in both 27.5 and 28.1 — so this applies it, and every observable signal
+        // agrees that is right (see BcAppSymbolCache.SplitPropertyEntries for why CLEANnn
+        // reads as undefined in Microsoft's shipped builds). If that ever turns out backwards
+        // the page over-filters, which is narrower than BC and fails loudly, rather than the
+        // silent widening this change exists to stop.
         if (link.Conditional && (partFieldId is null || (isFieldKind && parentFieldId is null)))
         {
             Console.Error.WriteLine(
@@ -588,10 +595,10 @@ public static partial class RecordPatches
             var fieldId = RecordPatches.TryResolveDependencyFieldId(page.SourceTableId, filter.FieldName);
 
             // #2978: an entry inside an AL `#if` block may not be in the compiled app at all,
-            // and this app's own field list is the evidence for which — same rule, same
-            // reasoning as EmitSubFormLinkXml's conditional arm. No SourceTableView in BC 27.5
-            // or 28.1 W1 carries a directive today; the arm exists so the two paths through
-            // the same splitter cannot answer it differently.
+            // and this app's own field inventory is the only evidence available — same rule,
+            // same reasoning as EmitSubFormLinkXml's conditional arm. No SourceTableView in BC
+            // 27.5 or 28.1 W1 carries a directive today; the arm exists so the two paths
+            // through the same splitter cannot answer it differently.
             if (filter.Conditional && fieldId is null)
             {
                 Console.Error.WriteLine(


### PR DESCRIPTION
Closes #2978

`ParseSourceTableView` and `ParseSubPageLink` dropped an entry they could not read and shipped
the rest as if it were the whole thing. A page view missing one of its `where()` entries is
**wider** than the view the page declares, so the page opens on rows the real view excludes and
a test asserting over them passes against a record set BC never gives. The only trace was a
`Console.Error` line the content-addressed symbol cache emits on a miss and loses on every warm
run after.

Both parsers now carry what they could not read in the payload — the same
payload-not-stderr choice `PageSymbol.UnreadableBooleanProperties` already makes for the same
cache reason — and both emitters turn it into a filter BC refuses (`FieldID="0"`, so
`MetaTable.GetFieldByNo(0)` throws `NavNCLFieldNotFoundException` when the page opens). That is
the identical fail-closed channel an unresolvable field name already used; #2978 is exactly the
observation that the two failure modes of one feature were handled in opposite directions.

## The part that is not hypothetical

The issue scoped this as the unmeasured tail, and said every entry Microsoft ships parses. It
does not. I re-measured across **every extension of BC 27.5 and 28.1 W1** — 7,646 pages, 3,655
`SubPageLink` entries, 981 pages declaring a `SourceTableView` with 547 `where()` entries — and
six entries fail to parse, all six on BC 27.5's Base Application, because the compiler records a
property's **source text, preprocessor directives and all**:

```
page 76 "Resource Card" / Control1906609707
page 77 "Resource List" / Control1906609707, Control1907012907

    "No." = field("No."),
    "Unit of Measure Filter" = field("Unit of Measure Filter"),
  #if not CLEAN25
    "Service Zone Filter" = field("Service Zone Filter"),
  #endif
    "Chargeable Filter" = field("Chargeable Filter")
```

Comma-splitting leaves `#if not CLEAN25 … "Service Zone Filter" = …` and
`#endif … "Chargeable Filter" = …`, neither of which the entry regex can read. Dumping the
runner's own parsed symbols against the real 27.5 artifact:

| | `Control1906609707` on page 76 |
|---|---|
| before | 2 links — `[No.]`, `[Unit of Measure Filter]` |
| after | 4 links — `[No.]`, `[Unit of Measure Filter]`, `[Service Zone Filter]`, `[Chargeable Filter]` |

So those three subpages have been filtering on two of their four conditions and showing rows the
host resource does not own. Fail-closing the drop without handling this would have turned that
into three Base Application pages that refuse to open, on a BC version this matrix covers — the
two are not separable, which is why they are one change.

An entry after a directive that only opens or closes a region (`#endif`, `#region`,
`#endregion`, `#pragma`, `#define`, `#undef`) is unconditionally in the app and parses normally.
An entry inside an `#if`/`#ifdef`/`#ifndef`/`#else`/`#elif` block is **conditional**: nothing in
the symbol file records whether the compiler kept it, so the emitter resolves it against the
app's own field inventory — applied when every name it uses resolves, omitted when one does not.
Never refused, because refusing a page over a link the app does not contain is a wrong answer in
the other direction. Block nesting is tracked across entries, since comma-splitting puts the
directive text on only the first guarded entry.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — `ParseSubPageLink` is the literal sibling:
   same regex, same `continue`, same `Console.Error`. A two-condition SubPageLink reduced to one
   filters the part less, so the subpage shows rows the host row does not own. Folded in, and it
   turned out to be the arm with the shipped defect.
2. **Sibling function making the same assumption?** `MatchingCloseParen` returning -1 dropped a
   whole clause the same way. `sorting(X) where(Y = const(1)` came up sorted as declared and
   unfiltered — the most convincing wrong answer, because the half that is easy to eyeball is
   right. Same treatment.
3. **Two paths writing the same state, same invariant?** `EmitSubFormLinkXml` and
   `EmitSourceTableViewXml` both fail-closed on an unresolvable field name and both fail-open on
   a dropped entry. Both now fail-closed on both, and both grew the conditional arm, even though
   no `SourceTableView` in 27.5 or 28.1 carries a directive today — so the two paths through one
   splitter cannot answer it differently later.

Deliberately unchanged: the `order()` and `sorting()` arms still report and carry on. That is
the existing documented choice — a key cannot be made to fail loudly through this metadata,
since BC reads `KeyFields` only when `KeyFieldsSetByView` says to — and it is a wrong sort
order, not a wrong row set. The `return null` when no clause at all could be read also stays:
the caller then emits no `<SourceTableView>`, the pre-#2820 state.

No `CacheVersion` bump. `PageTableViewSymbol`, `PagePartSymbol`, `PageSubFormLinkSymbol` and
`PageViewFilterSymbol` all gained members, and all four are reachable from `CachePayload`, so
`PayloadShape` (#2335) already gives this a different cache key than any payload written without
them — the same reasoning the #2820 note in that file spells out.

## RED → GREEN

Six new tests in `AlRunner.Tests/DependencyPageMetadataXmlTests.cs`. Measured by reverting only
the two `AlRunner/Patches/` files to `origin/main` and keeping the tests: **6 failed, the 26
pre-existing passed.**

| test | before | after |
|---|---|---|
| `UnreadableViewEntry_KeepsARefusingFilterRatherThanWideningTheView` | 1 `TableFilters` — the page opened on every `Price Type` | 2, second `FieldID="0"` |
| `UnbalancedViewClause_RefusesRatherThanSortingAnUnfilteredPage` | 0 `TableFilters`, `Sorting` still applied | 1, `FieldID="0"` |
| `UnreadableSubPageLinkEntry_KeepsARefusingLinkRatherThanWideningThePart` | 1 `SubFormLink` | 2, second `FieldID="0"` |
| `DirectiveGuardedLinkCompiledOut_AppliesTheEntryAfterEndifAndOmitsTheGuardedOne` | 1 link — the `#endif` entry dropped | 2, no `FieldID="0"` |
| `DirectiveGuardedLinkCompiledIn_KeepsFilteringOnIt` | 1 link | 3, the guarded entry applied |
| `SecondEntryInsideTheSameDirectiveBlock_IsConditionalToo` | `FieldID="0"` — the page refused over AL not in the app | `FieldID="7"` |

The last two are the negative direction for the conditional rule: a conditional entry is applied
when the app has the fields, so the omission in the fourth is not "conditional entries always
vanish".

## What else was run

- `dotnet test AlRunner.Tests --filter` over `DependencyPageMetadataXmlTests`,
  `BcAppSymbolCache*`, `SourceTableView*`, `SubPageLink*`, `DependencyPage*`, `PageMetadata*`,
  `MockTestPage*`, `TestPage*` — **334 passed, 0 failed** (7 skipped).
- Full `tests/runner-extras` against BC 28.1, private `--cache` outside the repo:
  **312/312, 56 app groups**, matching the count baseline exactly (312 expected).
- Full corpus (`al-language`, `al-language-internals-fixture`, `al-language-onprem`) with
  `--strict --expectations-require-match --count-baseline`: **2695/2695, exit 0.**
- End-to-end against the real BC 27.5 and 28.1 Base Application artifacts, dumping the runner's
  own parsed part symbols — the before/after table above. Not committed as a test, since it
  needs a downloaded artifact.

One measurement caveat worth recording: my first attempt read the synthesized XML for both BC
versions in one process and got identical output. `RecordPatches` caches metadata per page id
process-globally and `_bcAppPaths` accumulates, so the second version replayed the first's
document. The numbers above are one BC version per process.

## Corrected mid-change

The first commit justified the conditional rule with "BC 27.5's table `Resource` has 58 fields
and no Service Zone Filter, so `CLEAN25` was defined". That was wrong — it missed table
extensions; the `Serv. Resource` tableextension adds the field, in 27.5 and 28.1 alike. Running
the real artifact through the runner caught it. The code never encoded that claim, only the
comments did, and the second commit fixes them. What the evidence does support is that
Microsoft's shipped W1 builds do not define `CLEANnn`: 28.1 still carries `#if not CLEAN27`
though it is BC 28; the 27.5 guards reading `CLEAN25`/`CLEAN26` read `CLEAN28` in 28.1, so the
version is bumped rather than the branch resolved; and 28.1 wraps one such block's body in
`#pragma warning disable AL0432`, which suppresses an obsolete-**usage** warning and is only
needed on code that compiles.

## Not folded in

- **#2350** (Integer virtual table's missing `IntegerWindowGuard`) — same defect *shape*, but it
  lives in `AlRunner/Patches/RecordPatches.IntegerVirtualTable.cs` and is a row-generator window
  rather than a symbol-file parser. No shared code with this diff.
- **#2943 / #2942** (TestPage action `RunObject` refusals) — impl-25 is live in that code.
- The residual question this fix leaves open — whether field resolution is the right proxy for
  "did the compiler keep this `#if`-guarded entry" — is filed as **#3247**, which stays open
  after this merges.

## Where the test lives

Runner-side, and deliberately. The claim is about the runner's reconstruction of a **precompiled
dependency** page from `SymbolReference.json`; the corpus source-compiles its pages, so BC's own
compiler produces that metadata there and this parser never runs. BC never fails to read its own
`SourceTableView`, so there is no BC-behaviour claim for a service tier to adjudicate and no
corpus PR was opened. The BC-behaviour claim underneath — that a page filters its rows by its
`SourceTableView` — is already proved upstream by #2820's work.

Opened by agent `impl-8`.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
