### PR TITLE
fix(reload): clear the query-symbol source list, and keep a bundle's own registration alive across the RAD fast path

### DIFF
--- a/AlRunner.Tests/BundleQuerySymbolsResetTests.cs
+++ b/AlRunner.Tests/BundleQuerySymbolsResetTests.cs
@@ -1,0 +1,186 @@
+// BundleQuerySymbolsResetTests — issue #2939.
+//
+// RecordPatches._bcQuerySymbolJsonPaths is the sibling of _bcAppPaths that #2755 deliberately
+// left alone: a process-global List<string> that RegisterBundleQuerySymbolsJson appends to and
+// nothing ever removes from. It is the second input to EnsureBcSymbolQueryIndex, and
+// InvalidateBcAppIndexes nulls _bcSymbolQueryIndex on every reload precisely so the next lookup
+// rebuilds it FROM this list — the same registered/derived split #2755 was about.
+//
+// ── WHY THE DEFECT IS WORSE THAN "A UNION", WHICH IS WHAT MAKES IT ASSERTABLE ────────────────
+//
+// #2939 describes the effect as bundle 2 resolving "against its own registered query symbols
+// UNION every earlier bundle's". The union is real, but the merge is FIRST-WINS:
+//
+//     foreach (var jsonPath in _bcQuerySymbolJsonPaths)
+//         foreach (var q in BcAppSymbolCache.GetFromJson(jsonPath).Queries)
+//             if (!idx.ContainsKey(q.Id)) idx[q.Id] = q;      // <- first registration wins
+//
+// and the surviving entry is the EARLIER bundle's, because it is earlier in the list. So when
+// two bundles in one --server session declare the same query id — the ordinary case for two
+// checkouts of one app, or an app whose query is edited between --watch cycles — bundle 2 does
+// not get a superset of its own answer. It gets bundle 1's answer INSTEAD of its own, and the
+// column ids it hands to NavQuery.GetColumnValueSafe are the previous bundle's.
+//
+// That is the assertion below: not "the list grew", but "query 79960 came back with the wrong
+// bundle's columns". A test that only checked the list length would pass against an
+// implementation that merged last-wins and still be measuring nothing about the ids AL reads.
+//
+// ── WHY THE FIXTURE IS A HAND-WRITTEN SymbolReference.json ───────────────────────────────────
+//
+// This list holds LOOSE SymbolReference.json files, not .app zips (see the field's own comment)
+// — BcCompiler.EmitAndRegisterBundleQuerySymbols writes one per compiled bundle that declares a
+// query, and Program.cs's two AL-output-cache HIT paths re-register the cached copy. So
+// SymbolAppFixture, which BcAppPathsResetTests uses, is the wrong shape here: it builds a
+// registrable .app for _bcAppPaths. The JSON below is the minimum BcAppSymbolCache.GetFromJson
+// parses into a QuerySymbol — Queries[].Elements[].Columns[] with explicit Ids, which are
+// exactly the BC-compiler-assigned column ids the whole mechanism exists to carry verbatim.
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// MUST be serial, for the same reason BcAppPathsResetTests is: this registers into
+// RecordPatches' process-global query-symbol source list and calls ResetForReload(), which
+// clears roughly twenty static dictionaries shared with every other test in the process.
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class BundleQuerySymbolsResetTests : IDisposable
+{
+    private const int QueryId = 79960;
+    private readonly string _root;
+
+    public BundleQuerySymbolsResetTests() => _root = TestScratch.Dir("al-runner-query-symbols-reset");
+
+    public void Dispose()
+    {
+        try { RecordPatches.ResetForReload(); } catch { }
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    /// <summary>
+    /// One bundle's freshly-compiled query symbols, in the shape BcAppSymbolCache.GetFromJson
+    /// reads. <paramref name="columnName"/> and <paramref name="columnId"/> are what the
+    /// assertions discriminate on — two bundles declaring the SAME query id with DIFFERENT
+    /// column ids is the situation the runner has to get right.
+    /// </summary>
+    private string WriteQuerySymbolsJson(string bundle, string columnName, int columnId)
+    {
+        var dir = Path.Combine(_root, bundle);
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "SymbolReference.json");
+        File.WriteAllText(path, $$"""
+        {
+          "AppId": "{{Guid.NewGuid()}}",
+          "Name": "{{bundle}}",
+          "Queries": [
+            {
+              "Id": {{QueryId}},
+              "Name": "QsrQuery",
+              "Elements": [
+                {
+                  "Id": 1,
+                  "Name": "QsrDataItem",
+                  "RelatedTable": "QsrRow",
+                  "Columns": [
+                    { "Id": {{columnId}}, "Name": "{{columnName}}", "SourceColumn": "{{columnName}}Field" }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """);
+        return path;
+    }
+
+    private static (string Name, int Id) OnlyColumnOf(int queryId)
+    {
+        var q = RecordPatches.TryGetQuerySymbol(queryId);
+        Assert.NotNull(q);
+        var dataItem = Assert.Single(q!.DataItems);
+        var column = Assert.Single(dataItem.Columns);
+        return (column.Name, column.Id);
+    }
+
+    [Fact]
+    public void ASecondBundleDoesNotInheritTheFirstBundlesQuerySymbolSources()
+    {
+        // The registered set itself, asserted directly for the same reason BcAppPathsResetTests
+        // asserts _bcAppPaths directly: inferring it from a lookup conflates this list with the
+        // DERIVED index, which InvalidateBcAppIndexes already drops on every reload — so a
+        // lookup-only test passes on the broken build for the wrong reason.
+        RecordPatches.ResetForReload();
+        var first = WriteQuerySymbolsJson("QsrFirst", "Alpha", 11);
+        RecordPatches.RegisterBundleQuerySymbolsJson(first);
+        Assert.Contains(first, RecordPatches.RegisteredBundleQuerySymbolJsonPathsForTests());
+
+        // What Program.cs does between bundles: reset, then this bundle registers its own.
+        RecordPatches.ResetForReload();
+        var second = WriteQuerySymbolsJson("QsrSecond", "Beta", 22);
+        RecordPatches.RegisterBundleQuerySymbolsJson(second);
+
+        var registered = RecordPatches.RegisteredBundleQuerySymbolJsonPathsForTests();
+        Assert.Contains(second, registered);
+        Assert.DoesNotContain(first, registered);
+    }
+
+    [Fact]
+    public void BundleTwosQueryResolvesToItsOwnColumnIds_NotBundleOnes()
+    {
+        // The AL-visible half, and the one that says what the defect COST. Two bundles in one
+        // process declare query 79960 with different column ids; bundle 2 must read its own.
+        RecordPatches.ResetForReload();
+        RecordPatches.RegisterBundleQuerySymbolsJson(WriteQuerySymbolsJson("QsrOne", "Alpha", 11));
+
+        // Precondition, asserted rather than assumed: if the JSON did not parse into a
+        // QuerySymbol at all, everything below would be measuring an absent registration.
+        Assert.Equal(("Alpha", 11), OnlyColumnOf(QueryId));
+
+        RecordPatches.ResetForReload();
+        RecordPatches.RegisterBundleQuerySymbolsJson(WriteQuerySymbolsJson("QsrTwo", "Beta", 22));
+
+        // On the broken build this is ("Alpha", 11): the merge in EnsureBcSymbolQueryIndex is
+        // first-wins and bundle 1's still-registered file is first in the list, so bundle 2's
+        // own column id 22 never reaches the index. The column ID is the load-bearing half —
+        // it is what NavQuery.ValidateExpectedType/GetColumnValueSafe are called with, so a
+        // stale one is a wrong VALUE read out of a real row, not a crash.
+        Assert.Equal(("Beta", 22), OnlyColumnOf(QueryId));
+    }
+
+    [Fact]
+    public void AfterTheReset_ReRegisteringTheSameFileStillResolves()
+    {
+        // The other direction: the control that stops the fix from being "clear it so hard the
+        // bundle loses its own queries". Every bundle that declares a query re-registers on
+        // both the compile path (BcCompiler.Emit) and the AL-output cache HIT path
+        // (Program.cs), so a cleared entry must be registrable again — RegisterBundleQuerySymbolsJson
+        // skips a path it already holds, so a clear that did not really clear shows up here.
+        RecordPatches.ResetForReload();
+        var path = WriteQuerySymbolsJson("QsrAgain", "Gamma", 33);
+        RecordPatches.RegisterBundleQuerySymbolsJson(path);
+        Assert.Equal(("Gamma", 33), OnlyColumnOf(QueryId));
+
+        RecordPatches.ResetForReload();
+        Assert.Null(RecordPatches.TryGetQuerySymbol(QueryId));
+
+        RecordPatches.RegisterBundleQuerySymbolsJson(path);
+        Assert.Equal(("Gamma", 33), OnlyColumnOf(QueryId));
+    }
+
+    [Fact]
+    public void WithinOneBundle_SeveralQuerySymbolSourcesStillAccumulate()
+    {
+        // The invariant the fix must NOT break, and the reason this is a clear-on-reload rather
+        // than a clear-on-register: a single bundled run compiles several app groups, each
+        // registering its own SymbolReference.json between two resets. Those must accumulate —
+        // only a RELOAD boundary discards them.
+        RecordPatches.ResetForReload();
+        var a = WriteQuerySymbolsJson("QsrGroupA", "Alpha", 11);
+        var b = WriteQuerySymbolsJson("QsrGroupB", "Beta", 22);
+        RecordPatches.RegisterBundleQuerySymbolsJson(a);
+        RecordPatches.RegisterBundleQuerySymbolsJson(b);
+
+        var registered = RecordPatches.RegisteredBundleQuerySymbolJsonPathsForTests();
+        Assert.Contains(a, registered);
+        Assert.Contains(b, registered);
+    }
+}

--- a/AlRunner.Tests/EnumRegistrationSurvivesReloadTests.cs
+++ b/AlRunner.Tests/EnumRegistrationSurvivesReloadTests.cs
@@ -1,0 +1,213 @@
+// EnumRegistrationSurvivesReloadTests — issue #3052 (#2888 item 4).
+//
+// The property this pins is TRUE on main today and asserted by nothing, which is exactly why
+// #3052 was filed rather than left to close silently with its parent. It is also load-bearing
+// by ACCIDENT, and that is the whole point:
+//
+//   BcRuntime.ResetForNewBundleReload() calls AlEnumMetadataRegistry.Clear() and then
+//   RecordPatches.ResetForReload(). AddBcAppPath is the only live path by which a precompiled
+//   dependency's enums reach that registry (AlEnumMetadataRegistry.RegisterFromAppPath has no
+//   callers), and its first act is:
+//
+//       if (_bcAppPaths.Contains(appPath, StringComparer.OrdinalIgnoreCase)) return;
+//
+//   So the enums come back on cycle 2 ONLY because ClearPerBundleBcAppPaths makes the next
+//   AddBcAppPath real again. Nothing states that dependency. An "obvious" optimisation that
+//   keeps already-registered paths across a reload — cheaper, and every symbol read it skips is
+//   genuinely redundant — silently drops the per-value Captions (#1775) and the enum-level
+//   DefaultImplementation / UnknownValueImplementation fallbacks (#2306), with the same exit
+//   code the run had before. That is #2478's shape: a reset that stops resetting enough, and
+//   nothing counts differently afterwards.
+//
+// ── WHAT THIS ASSERTS, AND WHY NOT "THE REGISTRY IS NON-EMPTY" ───────────────────────────────
+//
+// #3052 names the bar: "a concrete enum caption and a DefaultImplementation fallback are still
+// answered afterwards — not that the registry is non-empty, which would pass against a registry
+// holding the wrong thing". The AL-visible consequence of losing the caption is a caption that
+// comes back as its member identifier instead of its declared text, so a test asserting only
+// presence sees a fully-populated entry and passes. Both assertions below therefore name a
+// specific string and a specific codeunit id that only this fixture's symbol file can produce.
+//
+// The fixture is a REGISTRABLE .app, not a source bundle: source-declared enums land in the
+// registry through BcCompiler's emit, not through AddBcAppPath, so a source-only fixture cannot
+// express this property at all — the same trap SymbolAppFixture's own header records for
+// _bcAppPaths (#2755). Its enum-carrying variant lives here rather than in SymbolAppFixture
+// because no other test needs one.
+using System.Text;
+using System.Text.Json;
+using AlRunner;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class EnumRegistrationSurvivesReloadTests : IDisposable
+{
+    // Inside no app.json idRange that ships in this repo, and distinct from every id the
+    // neighbouring reset tests register, because all of this state is process-global.
+    private const int EnumId = 79971;
+    private const string DeclaredCaption = "Posted, and then some";
+    private const int DefaultImplCodeunitId = 79972;
+    private const int UnknownImplCodeunitId = 79973;
+
+    private readonly string _root;
+
+    public EnumRegistrationSurvivesReloadTests()
+        => _root = TestScratch.Dir("al-runner-enum-reload");
+
+    public void Dispose()
+    {
+        try { AlEnumMetadataRegistry.Clear(); } catch { }
+        try { RecordPatches.ResetForReload(); } catch { }
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    /// <summary>
+    /// A registrable .app whose SymbolReference declares one enum carrying all three of the
+    /// fields that go missing when AddBcAppPath's early-return wins: a per-value Caption
+    /// (#1775) and the two enum-level implementation fallbacks (#2306).
+    /// </summary>
+    private string WriteEnumSymbolApp(string appName)
+    {
+        var appId = Guid.NewGuid();
+        var bundleDir = Path.Combine(_root, appName);
+        Directory.CreateDirectory(bundleDir);
+        File.WriteAllText(Path.Combine(bundleDir, "app.json"), $$"""
+        {
+          "id": "{{appId}}",
+          "name": "{{appName}}",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": {{EnumId}}, "to": {{EnumId + 9}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        // A .app must carry at least one source file to be emitted; the enum's runtime identity
+        // for this test comes entirely from the symbol file below, which is the surface
+        // AddBcAppPath reads.
+        File.WriteAllText(Path.Combine(bundleDir, "Enm.al"), $$"""
+        enum {{EnumId}} "ErsState"
+        {
+            Extensible = true;
+            value(0; Open) { Caption = 'Open'; }
+            value(1; Posted) { Caption = '{{DeclaredCaption}}'; }
+        }
+        """);
+
+        var symbolJson = JsonSerializer.Serialize(new
+        {
+            AppId = appId.ToString(),
+            Name = appName,
+            Publisher = "AL Runner",
+            Version = "1.0.0.0",
+            Tables = Array.Empty<object>(),
+            Codeunits = Array.Empty<object>(),
+            Pages = Array.Empty<object>(),
+            Queries = Array.Empty<object>(),
+            EnumTypes = new object[]
+            {
+                new
+                {
+                    Id = EnumId,
+                    Name = "ErsState",
+                    // Enum-level fallbacks, read by SymbolCodeunitIdList off the enum's own
+                    // Properties bag — NOT parallel to Values.
+                    Properties = new object[]
+                    {
+                        new { Name = "DefaultImplementation", Value = DefaultImplCodeunitId.ToString() },
+                        new { Name = "UnknownValueImplementation", Value = UnknownImplCodeunitId.ToString() },
+                    },
+                    Values = new object[]
+                    {
+                        new { Name = "Open", Ordinal = 0, Properties = new object[]
+                            { new { Name = "Caption", Value = "Open" } } },
+                        new { Name = "Posted", Ordinal = 1, Properties = new object[]
+                            { new { Name = "Caption", Value = DeclaredCaption } } },
+                    },
+                },
+            },
+        });
+
+        var identity = InProcessAppPackager.ReadIdentity(Path.Combine(bundleDir, "app.json"))
+            ?? throw new InvalidOperationException("could not read the app.json this test just wrote");
+        var appPath = Path.Combine(bundleDir, appName + ".app");
+        InProcessAppPackager.EmitAppPackageToFile(
+            bundleDir, identity, appPath, Encoding.UTF8.GetBytes(symbolJson));
+        return appPath;
+    }
+
+    /// <summary>The three fields that a lost re-registration silently blanks, read together so
+    /// a failure names which one went.</summary>
+    private static (string? PostedCaption, int[]? DefaultImpl, int[]? UnknownImpl) ReadEnum()
+    {
+        Assert.True(AlEnumMetadataRegistry.TryGet(EnumId, out var entry),
+            $"enum {EnumId} is not in AlEnumMetadataRegistry at all");
+        var posted = Array.IndexOf(entry.Options, "Posted");
+        Assert.True(posted >= 0, "the enum entry does not carry a 'Posted' value");
+        return (entry.Captions?[posted], entry.DefaultImplementations, entry.UnknownImplementations);
+    }
+
+    [Fact]
+    public void ADependencysEnumCaptionAndImplementationFallbacksSurviveABundleReload()
+    {
+        AlEnumMetadataRegistry.Clear();
+        RecordPatches.ResetForReload();
+        var appPath = WriteEnumSymbolApp("ErsApp");
+
+        // Cycle 1 — what Program.cs does after DependencyLoader.LoadAll.
+        RecordPatches.AddBcAppPath(appPath);
+        var first = ReadEnum();
+        Assert.Equal(DeclaredCaption, first.PostedCaption);
+        Assert.Equal(new[] { DefaultImplCodeunitId }, first.DefaultImpl);
+        Assert.Equal(new[] { UnknownImplCodeunitId }, first.UnknownImpl);
+
+        // The reload boundary, spelled the way the runner spells it: the registry is emptied
+        // (BcRuntime.ResetForNewBundleReload's own AlEnumMetadataRegistry.Clear()) and the
+        // per-bundle reset runs. Asserted, not assumed — if the registry were NOT emptied here,
+        // the cycle-2 assertion below would pass without re-registration having happened and
+        // this test would be pinning nothing.
+        AlEnumMetadataRegistry.Clear();
+        RecordPatches.ResetForReload();
+        Assert.False(AlEnumMetadataRegistry.TryGet(EnumId, out _),
+            "the reload did not empty the enum registry — the rest of this test would be vacuous");
+
+        // Cycle 2 — the same closure is re-registered, every bundle registering its FULL
+        // resolved closure rather than a delta. This is the step AddBcAppPath's
+        // already-registered early-return would swallow if ClearPerBundleBcAppPaths stopped
+        // clearing _bcAppPaths.
+        RecordPatches.AddBcAppPath(appPath);
+        var second = ReadEnum();
+        Assert.Equal(DeclaredCaption, second.PostedCaption);
+        Assert.Equal(new[] { DefaultImplCodeunitId }, second.DefaultImpl);
+        Assert.Equal(new[] { UnknownImplCodeunitId }, second.UnknownImpl);
+    }
+
+    [Fact]
+    public void WithoutTheReload_ReRegisteringTheSamePathIsStillANoOp()
+    {
+        // The control, and the reason the test above is a statement about the RELOAD rather
+        // than about AddBcAppPath being idempotent. Inside one bundle, a second AddBcAppPath
+        // for a path already registered must do nothing — that early-return is a real
+        // optimisation and the fix must not be "re-read the symbols every time". So: blank the
+        // registry WITHOUT resetting _bcAppPaths, re-register, and the enum must stay absent.
+        // If this ever starts passing enum data back, the early-return is gone and the test
+        // above has stopped discriminating.
+        AlEnumMetadataRegistry.Clear();
+        RecordPatches.ResetForReload();
+        var appPath = WriteEnumSymbolApp("ErsControlApp");
+
+        RecordPatches.AddBcAppPath(appPath);
+        Assert.True(AlEnumMetadataRegistry.TryGet(EnumId, out _));
+
+        AlEnumMetadataRegistry.Clear();          // registry only — registration list untouched
+        RecordPatches.AddBcAppPath(appPath);     // early-returns: the path is still registered
+
+        Assert.False(AlEnumMetadataRegistry.TryGet(EnumId, out _),
+            "AddBcAppPath re-read a path it had already registered — the reload test above no "
+            + "longer proves that the reload's clear is what brings the enums back");
+    }
+}

--- a/AlRunner.Tests/Fixtures/WatchQuerySymbolsReload/WqsAssert.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/WatchQuerySymbolsReload/WqsAssert.Codeunit.al
@@ -1,0 +1,14 @@
+// Standalone Assert — this fixture must stand alone; it imports nothing.
+codeunit 70622 "WQS Assert"
+{
+    procedure AreEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if Format(Expected) <> Format(Actual) then
+            Error('Expected %1 but got %2: %3', Format(Expected), Format(Actual), Msg);
+    end;
+
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then Error('Expected true: %1', Msg);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/WatchQuerySymbolsReload/WqsRow.Table.al
+++ b/AlRunner.Tests/Fixtures/WatchQuerySymbolsReload/WqsRow.Table.al
@@ -1,0 +1,11 @@
+table 70620 "WQS Row"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; "Entry No."; Integer) { DataClassification = CustomerContent; }
+        field(2; "Cust No."; Code[20]) { DataClassification = CustomerContent; }
+        field(3; Amount; Decimal) { DataClassification = CustomerContent; }
+    }
+    keys { key(PK; "Entry No.") { Clustered = true; } }
+}

--- a/AlRunner.Tests/Fixtures/WatchQuerySymbolsReload/WqsSum.Query.al
+++ b/AlRunner.Tests/Fixtures/WatchQuerySymbolsReload/WqsSum.Query.al
@@ -1,0 +1,19 @@
+// The query whose COLUMN IDS are what is at stake. They are assigned by the BC compiler and
+// reach the runtime only through the SymbolReference.json this bundle's Emit writes and
+// registers (BcCompiler.EmitAndRegisterBundleQuerySymbols) — see the driving test's header.
+query 70621 "WQS Sum"
+{
+    QueryType = Normal;
+
+    elements
+    {
+        dataitem(Row; "WQS Row")
+        {
+            column(CustNo; "Cust No.") { }
+            column(TotalAmount; Amount)
+            {
+                Method = Sum;
+            }
+        }
+    }
+}

--- a/AlRunner.Tests/Fixtures/WatchQuerySymbolsReload/WqsTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/WatchQuerySymbolsReload/WqsTests.Codeunit.al
@@ -1,0 +1,45 @@
+// EDIT-MARKER: 1
+// The line above is what the driving test rewrites between --watch cycles. It is a comment in
+// THIS file and never in WqsSum.Query.al, deliberately: the defect is about a query the bundle
+// still declares but did not touch this cycle, so the query file stays byte-identical while
+// something else in the same app changes.
+codeunit 70623 "WQS Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "WQS Assert";
+
+    local procedure Seed()
+    var
+        Row: Record "WQS Row";
+    begin
+        Row.DeleteAll();
+        Row.Init(); Row."Entry No." := 1; Row."Cust No." := 'C1'; Row.Amount := 10; Row.Insert();
+        Row.Init(); Row."Entry No." := 2; Row."Cust No." := 'C1'; Row.Amount := 32; Row.Insert();
+        Row.Init(); Row."Entry No." := 3; Row."Cust No." := 'C2'; Row.Amount := 5;  Row.Insert();
+    end;
+
+    [Test]
+    procedure QueryReadsItsAggregatedColumnValues()
+    var
+        Q: Query "WQS Sum";
+        Seen: Integer;
+        C1Total: Decimal;
+    begin
+        Seed();
+        Assert.IsTrue(Q.Open(), 'the query must open');
+        while Q.Read() do begin
+            Seen += 1;
+            if Q.CustNo = 'C1' then
+                C1Total := Q.TotalAmount;
+        end;
+        Q.Close();
+
+        // Both halves are concrete values only a correctly-resolved column id can produce. A
+        // column id resolved from the WRONG symbol source reads another column's value or none
+        // at all — a wrong number, not a crash, which is why this asserts the numbers.
+        Assert.AreEqual(2, Seen, 'the query must group the three rows into two customers');
+        Assert.AreEqual(42, C1Total, 'C1''s two rows (10 + 32) must sum to 42');
+    end;
+}

--- a/AlRunner.Tests/Fixtures/WatchQuerySymbolsReload/app.json
+++ b/AlRunner.Tests/Fixtures/WatchQuerySymbolsReload/app.json
@@ -1,0 +1,10 @@
+{
+  "id": "5a3d8f21-64b7-4c09-91e2-7d6b0a4f3c88",
+  "name": "WatchQuerySymbolsReload",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "dependencies": [],
+  "idRanges": [ { "from": 70620, "to": 70639 } ],
+  "platform": "27.0.0.0",
+  "runtime": "15.0"
+}

--- a/AlRunner.Tests/RadQuerySymbolsSnapshotModuleScopeTests.cs
+++ b/AlRunner.Tests/RadQuerySymbolsSnapshotModuleScopeTests.cs
@@ -1,0 +1,197 @@
+// RadQuerySymbolsSnapshotModuleScopeTests — the module-scope guard for #2939's replay snapshot.
+//
+// #2939's second half shadows a bundle's query-symbol source file per module
+// (BcCompiler._radQuerySymbolsPathByModule) so the RAD fast paths can re-register it on a
+// --watch/--server cycle that never calls Emit. The value captured came from
+// BcCompiler.LastBundleQuerySymbolsPath, a PROCESS-GLOBAL static, and the code justified that
+// with "CaptureRadMetadataSnapshotFull is called from RecordIncrementalBaseline, i.e. from
+// inside that same Emit". That is true of one of RecordIncrementalBaseline's two call sites and
+// false of the other:
+//
+//   BcCompiler.Emit                                    nulls the static at the top and sets it
+//                                                      via EmitAndRegisterBundleQuerySymbols —
+//                                                      the justification holds.
+//   BcCompiler.EmitDepSymbols(trackIncrementalBaseline) never touches the static at all. It
+//                                                      reads whatever the last Emit ANYWHERE in
+//                                                      the process left behind — and source-dep
+//                                                      compilers are separate BcCompiler
+//                                                      instances from the bundle emitter
+//                                                      (Program.cs's layered pre-pass), so that
+//                                                      value names a DIFFERENT module.
+//
+// Consequence: a dependency module's snapshot gets populated with another module's
+// SymbolReference.json. TryEmitIncremental's fast-path returns then call
+// ReplayRadMetadataSnapshot(thatDepModule), which re-registers the foreign file into
+// RecordPatches._bcQuerySymbolJsonPaths. The merge in EnsureBcSymbolQueryIndex is FIRST-WINS by
+// query id, so a colliding id hands back the foreign module's column ids, which go verbatim to
+// NavQuery.GetColumnValueSafe — a wrong value out of a real row, the exact shape #2939 exists
+// to close.
+//
+// Cycle 1 is safe (the static is null before any Emit), which is why nothing else in the suite
+// sees this: WatchQuerySymbolsReloadTests drives a single-app bundle with no source dependency.
+//
+// What each test proves (tdd.md: must prove, not just pass):
+//   - The dep path, run in the same process AFTER a query-declaring bundle's Emit, records NO
+//     query-symbol path for its own module. RED before the fix: it records the bundle's.
+//   - The bundle's OWN module still records its own path — the control that stops the fix from
+//     being "capture nothing, ever", which would satisfy the first assertion and silently
+//     re-break #2939's --watch half.
+using System.Reflection;
+using Xunit;
+using AlRunner;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class RadQuerySymbolsSnapshotModuleScopeTests : IDisposable
+{
+    private readonly string _bundleRoot;
+    private readonly string _depRoot;
+    private readonly BcEngineFixture _engine;
+
+    private const string BundleModule = "RadQsBundleAlpha";
+    private const string DepModule = "RadQsDepBeta";
+
+    private static readonly Guid DepAppId = new("c4d5e6f7-9360-4b22-9222-222222222222");
+
+    public RadQuerySymbolsSnapshotModuleScopeTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        var root = TestScratch.Dir("al-runner-radqs-module-scope");
+        _bundleRoot = Path.Combine(root, "bundle");
+        _depRoot = Path.Combine(root, "dep");
+        Directory.CreateDirectory(_bundleRoot);
+        Directory.CreateDirectory(_depRoot);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(Path.GetDirectoryName(_bundleRoot)!, recursive: true); } catch { /* best-effort */ }
+    }
+
+    // A bundle that genuinely declares a query, so Emit's BundleDeclaresQuery probe fires and
+    // EmitAndRegisterBundleQuerySymbols actually writes a SymbolReference.json for it.
+    private const string BundleAl = """
+        table 90360 "RadQs Alpha Row"
+        {
+            DataClassification = CustomerContent;
+            fields
+            {
+                field(1; "Entry No."; Integer) { DataClassification = CustomerContent; }
+                field(2; Amount; Integer) { DataClassification = CustomerContent; }
+            }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+
+        query 90361 "RadQs Alpha Totals"
+        {
+            QueryType = Normal;
+            elements
+            {
+                dataitem(Row; "RadQs Alpha Row")
+                {
+                    column(EntryNo; "Entry No.") { }
+                    column(TotalAmount; Amount) { Method = Sum; }
+                }
+            }
+        }
+        """;
+
+    // The source dependency. Declares NO query, so a correct capture records nothing for it.
+    private const string DepAl = """
+        codeunit 90362 "RadQs Beta Lib"
+        {
+            procedure Ping(): Integer
+            begin
+                exit(7);
+            end;
+        }
+        """;
+
+    /// <summary>The private per-module query-symbol snapshot on a BcCompiler instance. Read by
+    /// reflection deliberately: this is runner-internal shadow state with no public surface, and
+    /// the defect is precisely that the wrong value lands IN it — asserting on a public
+    /// side effect instead would only observe it once a query id happened to collide.</summary>
+    private static IReadOnlyDictionary<string, string> QuerySymbolsSnapshotOf(BcCompiler compiler)
+    {
+        var field = typeof(BcCompiler).GetField(
+            "_radQuerySymbolsPathByModule", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException(
+                "BcCompiler._radQuerySymbolsPathByModule no longer exists — if the snapshot moved, "
+                + "move this test with it rather than deleting it.");
+        return (Dictionary<string, string>)field.GetValue(compiler)!;
+    }
+
+    [SkippableFact]
+    public void DepSymbolBaseline_DoesNotAdoptAnotherModulesQuerySymbolsPath()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+        using var identityScope = BcCompiler.ScopeCurrentAppIdentity(DepAppId, "AL Runner", new Version(1, 0, 0, 0));
+
+        File.WriteAllText(Path.Combine(_bundleRoot, "Alpha.al"), BundleAl);
+        File.WriteAllText(Path.Combine(_depRoot, "Beta.al"), DepAl);
+
+        // 1. The bundle emitter. A separate BcCompiler instance, exactly as Program.cs's layered
+        //    pre-pass builds one per source dependency and another for the bundle itself.
+        var bundleCompiler = new BcCompiler();
+        var bundleOut = bundleCompiler.Emit(new[] { _bundleRoot }, BundleModule, trackIncrementalBaseline: true);
+        Assert.Empty(bundleOut.Diagnostics);
+
+        var bundleQuerySymbolsPath = BcCompiler.LastBundleQuerySymbolsPath;
+        Assert.NotNull(bundleQuerySymbolsPath);
+        Assert.True(File.Exists(bundleQuerySymbolsPath), $"'{bundleQuerySymbolsPath}' should have been written by the bundle's Emit");
+        // The path encodes the module it belongs to (PerProcessScratch, #2967) — this is what
+        // makes "borrowed" observable at all.
+        Assert.Contains(BundleModule, bundleQuerySymbolsPath!, StringComparison.Ordinal);
+
+        // 2. The source dependency, on its own instance, in the same process, AFTER the bundle's
+        //    Emit left the static pointing at the bundle's file. Nothing on this path writes or
+        //    clears LastBundleQuerySymbolsPath.
+        var depCompiler = new BcCompiler();
+        depCompiler.EmitDepSymbols(
+            new[] { _depRoot }, DepModule, DepAppId, "AL Runner", new Version(1, 0, 0, 0),
+            Path.Combine(_depRoot, "out.symbols.json"), appRootDir: null, trackIncrementalBaseline: true);
+
+        var depSnapshot = QuerySymbolsSnapshotOf(depCompiler);
+        Assert.False(
+            depSnapshot.TryGetValue(DepModule, out var borrowed),
+            $"'{DepModule}' declares no query, so its RAD snapshot must record no query-symbol source. "
+            + $"It recorded '{borrowed}' — which belongs to '{BundleModule}'. Replaying that on a RAD "
+            + "fast path re-registers a foreign SymbolReference.json, and the first-wins merge in "
+            + "EnsureBcSymbolQueryIndex then serves the wrong column ids for any colliding query id.");
+
+        // 3. The control: the bundle's own module DID capture its own path. Without this a fix
+        //    that simply never captures anything passes the assertion above while silently
+        //    re-breaking #2939's --watch half (4 PASS cycle 1, 4 FAIL from cycle 2).
+        var bundleSnapshot = QuerySymbolsSnapshotOf(bundleCompiler);
+        Assert.True(
+            bundleSnapshot.TryGetValue(BundleModule, out var own),
+            $"'{BundleModule}' declares a query, so its own RAD snapshot must record the "
+            + "SymbolReference.json its Emit just wrote — that is what the fast paths replay.");
+        Assert.Equal(bundleQuerySymbolsPath, own);
+    }
+
+    [SkippableFact]
+    public void DepSymbolBaseline_LeavesTheBundlesOwnSnapshotUntouched()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+        using var identityScope = BcCompiler.ScopeCurrentAppIdentity(DepAppId, "AL Runner", new Version(1, 0, 0, 0));
+
+        File.WriteAllText(Path.Combine(_bundleRoot, "Alpha.al"), BundleAl);
+        File.WriteAllText(Path.Combine(_depRoot, "Beta.al"), DepAl);
+
+        var bundleCompiler = new BcCompiler();
+        bundleCompiler.Emit(new[] { _bundleRoot }, BundleModule, trackIncrementalBaseline: true);
+        var afterEmit = QuerySymbolsSnapshotOf(bundleCompiler)[BundleModule];
+
+        // A dep compile between two of the bundle's cycles must not disturb what the bundle
+        // replays. (Same instance re-emitting is the --watch shape; the dep compile in between is
+        // the multi-app bundle shape.)
+        new BcCompiler().EmitDepSymbols(
+            new[] { _depRoot }, DepModule, DepAppId, "AL Runner", new Version(1, 0, 0, 0),
+            Path.Combine(_depRoot, "out2.symbols.json"), appRootDir: null, trackIncrementalBaseline: true);
+
+        Assert.Equal(afterEmit, QuerySymbolsSnapshotOf(bundleCompiler)[BundleModule]);
+        Assert.Contains(BundleModule, afterEmit, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner.Tests/WatchQuerySymbolsReloadTests.cs
+++ b/AlRunner.Tests/WatchQuerySymbolsReloadTests.cs
@@ -1,0 +1,187 @@
+// WatchQuerySymbolsReloadTests — the regression guard for #2939's fix.
+//
+// ── WHY A SUBPROCESS --watch TEST AND NOT AN IN-PROCESS ONE ─────────────────────────────────
+//
+// #2939 is "RecordPatches._bcQuerySymbolJsonPaths accumulates across bundles and nothing clears
+// it", and BundleQuerySymbolsResetTests proves the clear in-process. Clearing it ALONE is a
+// --watch regression, and no in-process test can see that, because the thing that breaks lives
+// on the other side of the boundary: BcCompiler.TryEmitIncremental's RAD fast paths hand a
+// result back WITHOUT calling Emit, and Emit is the only caller of
+// EmitAndRegisterBundleQuerySymbols. So from --watch cycle 2 onward nothing re-registers the
+// bundle's query symbols, and before #2939 the ONLY reason queries kept working was that the
+// list was never cleared — an accidental cache doing the job
+// BcCompiler._radPageMetadataByModule does deliberately for page/xmlport metadata (#2593/#2654).
+//
+// Measured on tests/runner-extras/query-join-aggregation-oos, four --watch cycles, same machine:
+//
+//   unmodified main                       4 PASS on every cycle   (the accumulating list masks it)
+//   clear only, no replay                 4 PASS cycle 1, 4 FAIL cycles 2-4
+//   clear + _radQuerySymbolsPathByModule   4 PASS on every cycle
+//
+// The middle row is what this test exists to make impossible to ship again. It is a wrong
+// NUMBER read out of a real row rather than a crash — the column ids in that file go verbatim
+// to NavQuery.GetColumnValueSafe — so nothing else in the suite would have gone red.
+//
+// This asserts the runner's own behaviour across ITS OWN reload boundary, which is why it is a
+// runner test and not a corpus one: real BC has no --watch, no RAD baseline and no
+// SymbolReference.json sidecar. What the query COMPUTES (10 + 32 = 42, grouped into two
+// customers) is ordinary BC behaviour, and it is asserted here only as the observable that
+// discriminates a correctly-resolved column id from a stale one.
+//
+// Spawns the real runner; needs the BC artifact cache. Skips when absent, exactly like
+// WatchPageMetadataReloadTests, whose harness shape this follows.
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class WatchQuerySymbolsReloadTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string FixtureRoot = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "WatchQuerySymbolsReload"));
+
+    private const string TestName = "QueryReadsItsAggregatedColumnValues";
+    private const string TestLabel = "Codeunit70623." + TestName;
+
+    private static void CopyDir(string src, string dst)
+    {
+        Directory.CreateDirectory(dst);
+        foreach (var f in Directory.GetFiles(src))
+            File.Copy(f, Path.Combine(dst, Path.GetFileName(f)));
+    }
+
+    // Same helper and conditional shape as WatchPageMetadataReloadTests.ExtraPackageCacheArgs:
+    // CI's unit-test step provisions ~/.al-runner/platform-apps and passes it to nothing by
+    // default, so a spawned subprocess has to be told about it explicitly.
+    private static string[] ExtraPackageCacheArgs()
+    {
+        var platformApps = TestArtifacts.PlatformAppsDir();
+        return Directory.Exists(platformApps)
+            ? new[] { "--package-cache", platformApps }
+            : Array.Empty<string>();
+    }
+
+    [SkippableFact]
+    public async Task Watch_QueryStillResolvesItsOwnColumnIds_OnLaterCycles()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var bundle = TestScratch.Dir("al-runner-watch-querysymbols");
+        CopyDir(FixtureRoot, bundle);
+        var testsPath = Path.Combine(bundle, "WqsTests.Codeunit.al");
+        // The AL-output cache goes in a private directory OUTSIDE the repository: the shared
+        // ~/.cache/al-runner root is not keyed on the runner binary, so a concurrent run's
+        // payload could make this measure something other than this build.
+        var cacheDir = TestScratch.Dir("al-runner-watch-querysymbols-cache");
+
+        var lines = new List<CapturedLine>();
+        var argsBuilder = new StringBuilder(
+            TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg
+            + $" \"{bundle}\" --watch --cache \"{cacheDir}\"");
+        foreach (var a in ExtraPackageCacheArgs()) argsBuilder.Append($" \"{a}\"");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = argsBuilder.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        using var p = Process.Start(psi)!;
+        void Pump(StreamReader r, OutputStream stream) => Task.Run(async () =>
+        {
+            string? l;
+            while ((l = await r.ReadLineAsync()) != null) lock (lines) lines.Add(new CapturedLine(stream, l));
+        });
+        Pump(p.StandardOutput, OutputStream.Stdout);
+        Pump(p.StandardError, OutputStream.Stderr);
+
+        string ProcessLiveness() => p.HasExited ? $"process alive=false exit={p.ExitCode}" : "process alive=true";
+        string DumpAll() { lock (lines) return string.Join("\n", lines.Select(l => $"[{l.Stream}] {l.Text}")); }
+
+        async Task<int> WaitForMarkerAfter(int fromIndex, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                List<int> found;
+                lock (lines)
+                    found = WatchOutputSlicing.FindStdoutMarkerIndices(
+                        lines, WatchOutputSlicing.WaitingForSourceMarker, fromIndex);
+                if (found.Count > 0) return found[0];
+                if (p.HasExited)
+                {
+                    await Task.Delay(500);
+                    throw new TimeoutException(
+                        $"watch marker not seen — subprocess exited early ({ProcessLiveness()}).\n"
+                        + $"--- full subprocess output ---\n{DumpAll()}");
+                }
+                await Task.Delay(200);
+            }
+            if (p.HasExited) await Task.Delay(500);
+            throw new TimeoutException(
+                $"watch marker not seen. {ProcessLiveness()}\n--- full subprocess output ---\n{DumpAll()}");
+        }
+
+        string Segment(int from, int to) { lock (lines) return WatchOutputSlicing.MergedJoin(lines, from, to); }
+
+        void CheckCycle(string label, Action check)
+        {
+            try { check(); }
+            catch (Exception ex)
+            {
+                throw new Exception(
+                    $"{label}: {ex.Message}\n--- full subprocess output ({lines.Count} lines) ---\n{DumpAll()}", ex);
+            }
+        }
+
+        try
+        {
+            // Cycle 1 is always a full rebuild — there is no RAD baseline to diff against yet —
+            // so it exercises the ordinary Emit path and is the control: if it does not pass,
+            // nothing after it is a statement about the reload.
+            int marker = await WaitForMarkerAfter(0, TimeSpan.FromSeconds(300));
+            CheckCycle("cycle 1 (cold, full rebuild)", () =>
+            {
+                var cycle = Segment(0, marker);
+                Assert.Contains($"PASS  {TestLabel}", cycle);
+            });
+
+            // Three more cycles. More than one, because how soon the RAD fast path first engages
+            // depends on when a clean baseline was recorded — with the AL-output cache warm the
+            // first incremental cycle was observed as late as cycle 4. Every cycle after the
+            // first must still resolve the query, so asserting all of them needs no assumption
+            // about which one is the first incremental one.
+            for (int cycle = 2; cycle <= 4; cycle++)
+            {
+                // Comment-only edit to the TEST codeunit. WqsSum.Query.al is never touched, so
+                // the query is an object the app still declares and did not change this cycle —
+                // the case a RAD delta's own Emit does not cover.
+                var src = await File.ReadAllTextAsync(testsPath);
+                var edited = src.Replace($"// EDIT-MARKER: {cycle - 1}", $"// EDIT-MARKER: {cycle}");
+                Assert.NotEqual(src, edited);
+                await File.WriteAllTextAsync(testsPath, edited);
+
+                int next = await WaitForMarkerAfter(marker + 1, TimeSpan.FromSeconds(300));
+                var window = Segment(marker + 1, next);
+                marker = next;
+
+                CheckCycle($"cycle {cycle} (warm)", () =>
+                {
+                    // Asserted rather than assumed: a cycle in which the test did not run at all
+                    // would satisfy a DoesNotContain("FAIL") check trivially.
+                    Assert.Contains(TestLabel, window);
+                    Assert.DoesNotContain($"FAIL  {TestLabel}", window);
+                    Assert.Contains($"PASS  {TestLabel}", window);
+                });
+            }
+        }
+        finally
+        {
+            try { p.Kill(true); } catch { }
+        }
+    }
+}

--- a/AlRunner/BcCompiler.Incremental.cs
+++ b/AlRunner/BcCompiler.Incremental.cs
@@ -230,6 +230,26 @@ public sealed partial class BcCompiler
     private readonly Dictionary<string, Dictionary<int, string>> _radXmlPortMetadataByModule =
         new(StringComparer.Ordinal);
 
+    // #2939, and the same mechanism as the two dictionaries above. RecordPatches'
+    // _bcQuerySymbolJsonPaths — the loose SymbolReference.json files a bundle's own compiled
+    // queries are read from — is a REGISTERED list, and since #2939 the per-bundle reload path
+    // clears it. That clear is correct (bundle 2 was being served bundle 1's column ids by a
+    // first-wins merge) but on its own it is a --watch regression, because these same RAD fast
+    // paths hand a result back without ever calling Emit, and Emit is the only thing that calls
+    // EmitAndRegisterBundleQuerySymbols. Measured on tests/runner-extras/query-join-aggregation-oos
+    // driven through four --watch cycles: 4 PASS on every cycle before the clear, 4 PASS on
+    // cycle 1 and 4 FAIL from cycle 2 onward with the clear and no replay.
+    //
+    // So the registration is shadowed here exactly like the page/xmlport metadata: captured
+    // after the full Emit that produced the file, replayed at every fast-path return. The
+    // VALUE is the path rather than the parsed symbols because the file is per-process and
+    // per-module (PerProcessScratch, #2967) and is rewritten in place by each full Emit of this
+    // module — so replaying the path re-registers whatever that module's most recent real
+    // compile wrote, which is the same content the accumulating list used to hand back, minus
+    // the other bundles' files that were the actual defect.
+    private readonly Dictionary<string, string> _radQuerySymbolsPathByModule =
+        new(StringComparer.Ordinal);
+
     /// <summary>Full (re)capture — called after a clean full Emit, when every object this app
     /// declares is known and the live registries already hold its current metadata.</summary>
     private void CaptureRadMetadataSnapshotFull(
@@ -248,6 +268,17 @@ public sealed partial class BcCompiler
         }
         _radPageMetadataByModule[moduleName] = pages;
         _radXmlPortMetadataByModule[moduleName] = xmlPorts;
+
+        // #2939: the query-symbol source file this same Emit just wrote, if this module
+        // declares a query at all. LastBundleQuerySymbolsPath is set (or nulled) at the top of
+        // every Emit and this method is called from RecordIncrementalBaseline, i.e. from INSIDE
+        // that same Emit, so it names this module and no other even in a bundled multi-group
+        // run. A module that declares no query records nothing and replays nothing.
+        var querySymbolsPath = LastBundleQuerySymbolsPath;
+        if (querySymbolsPath != null && File.Exists(querySymbolsPath))
+            _radQuerySymbolsPathByModule[moduleName] = querySymbolsPath;
+        else
+            _radQuerySymbolsPathByModule.Remove(moduleName);
     }
 
     /// <summary>Incremental update — called after a successful RAD delta. Drops vacated
@@ -286,6 +317,11 @@ public sealed partial class BcCompiler
             foreach (var (id, xml) in pages) AlPageMetadataRegistry.Register(id, xml);
         if (_radXmlPortMetadataByModule.TryGetValue(moduleName, out var xmlPorts))
             foreach (var (id, xml) in xmlPorts) AlXmlPortMetadataRegistry.Register(id, xml);
+        // #2939. RegisterBundleQuerySymbolsJson is itself idempotent AND always invalidates the
+        // derived index (the file is rewritten in place by each full Emit), so replaying an
+        // already-registered path is correct rather than merely harmless.
+        if (_radQuerySymbolsPathByModule.TryGetValue(moduleName, out var querySymbolsPath))
+            AlRunner.Patches.RecordPatches.RegisterBundleQuerySymbolsJson(querySymbolsPath);
     }
 
     /// <summary>

--- a/AlRunner/BcCompiler.Incremental.cs
+++ b/AlRunner/BcCompiler.Incremental.cs
@@ -241,7 +241,9 @@ public sealed partial class BcCompiler
     // cycle 1 and 4 FAIL from cycle 2 onward with the clear and no replay.
     //
     // So the registration is shadowed here exactly like the page/xmlport metadata: captured
-    // after the full Emit that produced the file, replayed at every fast-path return. The
+    // after the full Emit that produced the file — and ONLY from that Emit, which is why the
+    // path is threaded in as a parameter rather than read from the LastBundleQuerySymbolsPath
+    // static (see CaptureRadMetadataSnapshotFull) — then replayed at every fast-path return. The
     // VALUE is the path rather than the parsed symbols because the file is per-process and
     // per-module (PerProcessScratch, #2967) and is rewritten in place by each full Emit of this
     // module — so replaying the path re-registers whatever that module's most recent real
@@ -253,7 +255,8 @@ public sealed partial class BcCompiler
     /// <summary>Full (re)capture — called after a clean full Emit, when every object this app
     /// declares is known and the live registries already hold its current metadata.</summary>
     private void CaptureRadMetadataSnapshotFull(
-        string moduleName, IEnumerable<NavCA.IApplicationObjectTypeSymbol> declared)
+        string moduleName, IEnumerable<NavCA.IApplicationObjectTypeSymbol> declared,
+        string? bundleQuerySymbolsPath)
     {
         var pages = new Dictionary<int, string>();
         var xmlPorts = new Dictionary<int, string>();
@@ -269,14 +272,35 @@ public sealed partial class BcCompiler
         _radPageMetadataByModule[moduleName] = pages;
         _radXmlPortMetadataByModule[moduleName] = xmlPorts;
 
-        // #2939: the query-symbol source file this same Emit just wrote, if this module
-        // declares a query at all. LastBundleQuerySymbolsPath is set (or nulled) at the top of
-        // every Emit and this method is called from RecordIncrementalBaseline, i.e. from INSIDE
-        // that same Emit, so it names this module and no other even in a bundled multi-group
-        // run. A module that declares no query records nothing and replays nothing.
-        var querySymbolsPath = LastBundleQuerySymbolsPath;
-        if (querySymbolsPath != null && File.Exists(querySymbolsPath))
-            _radQuerySymbolsPathByModule[moduleName] = querySymbolsPath;
+        // #2939: the query-symbol source file THIS module's own full compile just wrote, or
+        // null when it wrote none (it declares no query, or it is not the bundle-emit path at
+        // all). A module that records nothing replays nothing.
+        //
+        // This arrives as a PARAMETER, and deliberately does not read
+        // BcCompiler.LastBundleQuerySymbolsPath here. That static is process-global, and
+        // RecordIncrementalBaseline — this method's only caller — has TWO call sites, only one
+        // of which owns it:
+        //
+        //   BcCompiler.Emit                 nulls the static at the top of the method and sets
+        //                                   it via EmitAndRegisterBundleQuerySymbols, so the
+        //                                   value belongs to THIS module. Emit binds it to a
+        //                                   local and passes that local in.
+        //   BcCompiler.EmitDepSymbols       (trackIncrementalBaseline: true, reached from
+        //                                   EmitDepSymbolsIncremental) never touches the static.
+        //                                   Reading it there returns whatever the last Emit
+        //                                   ANYWHERE in the process left behind — and source-dep
+        //                                   compilers are separate BcCompiler instances from the
+        //                                   bundle emitter (Program.cs's layered pre-pass), so
+        //                                   that path names a DIFFERENT module. It passes null.
+        //
+        // Reading the static here let the dep path adopt the bundle's SymbolReference.json;
+        // ReplayRadMetadataSnapshot then re-registered that foreign file on every RAD fast-path
+        // return for the dep module, and EnsureBcSymbolQueryIndex's first-wins merge served its
+        // column ids for any colliding query id — a wrong value out of a real row, i.e. the very
+        // defect #2939 exists to close, arriving through the door its fix opened. Pinned by
+        // RadQuerySymbolsSnapshotModuleScopeTests.
+        if (bundleQuerySymbolsPath != null && File.Exists(bundleQuerySymbolsPath))
+            _radQuerySymbolsPathByModule[moduleName] = bundleQuerySymbolsPath;
         else
             _radQuerySymbolsPathByModule.Remove(moduleName);
     }
@@ -1195,16 +1219,32 @@ public sealed partial class BcCompiler
     private static string[] SplitLines(string text) => text.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
 
     /// <summary>
-    /// Called by <see cref="Emit"/> after a clean success, when its caller passed
-    /// <c>trackIncrementalBaseline: true</c>. Builds the (Kind,Id-or-Name)-keyed state
-    /// <see cref="TryEmitIncremental"/> needs for the NEXT cycle, for every object kind (see
-    /// this file's header comment for how each of the six id-less kinds is recovered).
+    /// Called after a clean success, when the caller passed <c>trackIncrementalBaseline: true</c>.
+    /// Builds the (Kind,Id-or-Name)-keyed state <see cref="TryEmitIncremental"/> needs for the
+    /// NEXT cycle, for every object kind (see this file's header comment for how each of the six
+    /// id-less kinds is recovered).
+    ///
+    /// TWO call sites, and they are not interchangeable — anything here that reaches for
+    /// process-global state has to hold for both:
+    /// <list type="bullet">
+    /// <item><see cref="Emit"/>, the per-bundle compile. Writes and registers this module's
+    /// query symbols itself, and passes the resulting path as
+    /// <paramref name="bundleQuerySymbolsPath"/>.</item>
+    /// <item><c>EmitDepSymbols(trackIncrementalBaseline: true)</c>, reached from
+    /// <c>EmitDepSymbolsIncremental</c> for a SOURCE DEPENDENCY, on a different
+    /// <see cref="BcCompiler"/> instance from the bundle emitter. Emits no bundle query symbols,
+    /// so it passes null.</item>
+    /// </list>
     /// </summary>
+    /// <param name="bundleQuerySymbolsPath">The SymbolReference.json THIS module's compile just
+    /// wrote for its own queries, or null when it wrote none. Never
+    /// <see cref="LastBundleQuerySymbolsPath"/> read at the callee — see
+    /// <see cref="CaptureRadMetadataSnapshotFull"/>.</param>
     private void RecordIncrementalBaseline(
         string moduleName, NavCA.Compilation compilation, IReadOnlyList<string> alFiles,
         IReadOnlyList<EmittedSource> captured, NavCA.SymbolReferenceSpecification[] specs,
         ManifestCompilerInputs manifestInputs, string? manifestAppJsonPath, Guid appId, string publisher, Version version,
-        string? appRootDir, BcEmitOutput fullOutput)
+        string? appRootDir, BcEmitOutput fullOutput, string? bundleQuerySymbolsPath)
     {
         var declared = compilation.GetDeclaredApplicationObjectSymbols();
         var byName = new Dictionary<string, List<(NavCA.SymbolKind Kind, int? Id, string? Path)>>(StringComparer.Ordinal);
@@ -1328,7 +1368,7 @@ public sealed partial class BcCompiler
         // the shadow copy TryEmitIncremental's fast paths replay on every later cycle that
         // does NOT run a full Emit for this app. See _radPageMetadataByModule's header
         // comment.
-        CaptureRadMetadataSnapshotFull(moduleName, declared);
+        CaptureRadMetadataSnapshotFull(moduleName, declared, bundleQuerySymbolsPath);
     }
 
     /// <summary>Drops the current baseline for a bundle — used when a caller knows the next cycle must be a full rebuild regardless (e.g. a watched suite set changed).</summary>

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -2244,9 +2244,14 @@ public sealed partial class BcCompiler
         // recompile on every single run. The symbols come from the compilation's semantic
         // model, which is intact whether or not a report layout updated.
         LastBundleQuerySymbolsPath = null;
+        // Bound as a LOCAL rather than re-read from the static below: this is the only scope in
+        // which "the query symbols the current compile wrote" is provably THIS module's, and
+        // RecordIncrementalBaseline's other call site (EmitDepSymbols) cannot see this local at
+        // all — which is the point. See CaptureRadMetadataSnapshotFull.
+        string? bundleQuerySymbolsPath = null;
         if (caught == null && outputter.Captured.Count > 0 && BundleDeclaresQuery(alFiles))
         {
-            try { EmitAndRegisterBundleQuerySymbols(compilation, moduleName); }
+            try { bundleQuerySymbolsPath = EmitAndRegisterBundleQuerySymbols(compilation, moduleName); }
             catch (Exception ex)
             {
                 // Never fail the run for this — a query that then can't build its
@@ -2274,7 +2279,7 @@ public sealed partial class BcCompiler
                 RecordIncrementalBaseline(
                     moduleName, compilation, alFiles, outputter.Captured, specs,
                     manifestInputs, manifestAppJsonPath, appId, _currentPublisher ?? "AlRunner", _currentVersion ?? new Version(1, 0, 0, 0),
-                    appRootDir, emitOutput);
+                    appRootDir, emitOutput, bundleQuerySymbolsPath);
             }
             catch (Exception ex)
             {
@@ -2434,7 +2439,12 @@ public sealed partial class BcCompiler
     // Nothing outside the writing process ever reads this file — it is registered below for
     // this process's own query-symbol lookups — so sharing the path bought nothing. Same
     // treatment as #2586's sibling symbols: put the process in the path.
-    private static void EmitAndRegisterBundleQuerySymbols(NavCA.Compilation compilation, string moduleName)
+    //
+    // Returns the path it wrote, so the caller can hold it as a LOCAL. The
+    // LastBundleQuerySymbolsPath static below still exists for Program.cs (which copies the
+    // file next to the AL-output cache DLL), but it is process-global and must not be read by
+    // anything that cannot prove the current Emit set it — see CaptureRadMetadataSnapshotFull.
+    private static string EmitAndRegisterBundleQuerySymbols(NavCA.Compilation compilation, string moduleName)
     {
         var dir = PerProcessScratch.Dir("al-runner-query-symbols", moduleName);
         var path = Path.Combine(dir, "SymbolReference.json");
@@ -2442,6 +2452,7 @@ public sealed partial class BcCompiler
             SymbolJsonWriter.WriteSymbolJson(compilation, fs);
         AlRunner.Patches.RecordPatches.RegisterBundleQuerySymbolsJson(path);
         LastBundleQuerySymbolsPath = path;
+        return path;
     }
 
     /// <summary>
@@ -2641,7 +2652,13 @@ public sealed partial class BcCompiler
             RecordIncrementalBaseline(
                 moduleName, compilation, alFiles, Array.Empty<EmittedSource>(), specs,
                 manifestInputs, foundAppJson, appId, publisher, version, effectiveAppRoot,
-                new BcEmitOutput(Array.Empty<EmittedSource>(), Array.Empty<string>(), Array.Empty<string>()));
+                new BcEmitOutput(Array.Empty<EmittedSource>(), Array.Empty<string>(), Array.Empty<string>()),
+                // This path emits no bundle query symbols — it never calls
+                // EmitAndRegisterBundleQuerySymbols — so it has none to record. Explicitly null
+                // rather than reading LastBundleQuerySymbolsPath, which here would name whatever
+                // module the last Emit ANYWHERE in this process compiled. See
+                // CaptureRadMetadataSnapshotFull and RadQuerySymbolsSnapshotModuleScopeTests.
+                bundleQuerySymbolsPath: null);
         }
     }
 

--- a/AlRunner/Patches/RecordPatches.BcAppFallback.cs
+++ b/AlRunner/Patches/RecordPatches.BcAppFallback.cs
@@ -116,7 +116,37 @@ public static partial class RecordPatches
         // immediately after the reset, so it goes.
         _bcAppPaths.RemoveAll(p =>
             !string.Equals(p, _systemAppTempPath, StringComparison.OrdinalIgnoreCase));
+        // #2939: the sibling registered list goes too. #2755 fixed _bcAppPaths and named this
+        // one as "same shape, deliberately not changed here"; it is the second input to
+        // EnsureBcSymbolQueryIndex, which InvalidateBcAppIndexes below invalidates precisely so
+        // the next lookup rebuilds FROM these two lists — the identical registered/derived
+        // split. There is no SystemApp-style exemption to make: every entry is a LOOSE
+        // SymbolReference.json written for one bundle's own freshly-compiled queries
+        // (BcCompiler.EmitAndRegisterBundleQuerySymbols), and a bundle that declares a query
+        // re-registers on BOTH paths that can reach a query lookup — the compile path and the
+        // AL-output cache HIT path (Program.cs, guarded by bundleDeclaresQuery) — so a clear
+        // removes nothing the current bundle does not immediately put back.
+        //
+        // The merge this feeds is FIRST-WINS (`if (!idx.ContainsKey(q.Id))`), and the earlier
+        // bundle's file is earlier in the list, so the effect was not the superset #2939
+        // describes: bundle 2 declaring the same query id got bundle 1's column ids INSTEAD of
+        // its own, and those ids go verbatim to NavQuery.GetColumnValueSafe. A wrong value read
+        // out of a real row, not a crash — see BundleQuerySymbolsResetTests.
+        _bcQuerySymbolJsonPaths.Clear();
         InvalidateBcAppIndexes();
+    }
+
+    /// <summary>
+    /// The loose <c>SymbolReference.json</c> files currently registered as query-symbol sources
+    /// (<see cref="_bcQuerySymbolJsonPaths"/>). Test-visible for the same reason
+    /// <see cref="RegisteredBcAppPathsForTests"/> is: "the reload emptied it" cannot be inferred
+    /// from a later query lookup, because the DERIVED index
+    /// (<see cref="_bcSymbolQueryIndex"/>) is dropped on every reload whether or not the
+    /// registered list is — so a lookup-only assertion passes on the broken build (#2939).
+    /// </summary>
+    internal static string[] RegisteredBundleQuerySymbolJsonPathsForTests()
+    {
+        lock (_bcTableIndexLock) return _bcQuerySymbolJsonPaths.ToArray();
     }
 
     /// <summary>The process-lifetime SystemApp .app <see cref="ClearPerBundleBcAppPaths"/> keeps,

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -292,12 +292,15 @@ public static partial class RecordPatches
             // precompiled tableextension fields vanish from every metatable from the second
             // server request on. That failure was silent; this one was too.
             //
-            // Still accumulating, same shape, deliberately NOT changed here: the sibling list
-            // _bcQuerySymbolJsonPaths (RecordPatches.BcAppFallback.cs), tracked in #2939. It
+            // #2939: the sibling list _bcQuerySymbolJsonPaths goes with it, and now does. It
             // feeds _bcSymbolQueryIndex through the same derived/registered split and is the
-            // other input to RegisteredBcAppSymbolStateKey. Left alone because #2755 scoped
-            // itself to _bcAppPaths and called the blast radius out explicitly — and the
-            // SystemApp regression above is what that caution was warning about.
+            // other input to RegisteredBcAppSymbolStateKey. #2755 left it alone deliberately,
+            // having scoped itself to _bcAppPaths; measured, it was the worse of the two,
+            // because its merge is first-wins and the stale file sorts first — bundle 2 got
+            // bundle 1's query column ids INSTEAD of its own rather than in addition to them.
+            // Its clear is unconditional (no SystemApp-style exemption applies: every entry is
+            // a loose per-bundle SymbolReference.json), and lives in ClearPerBundleBcAppPaths
+            // beside the one above so the two cannot drift apart the way #2478's pair did.
             ClearPerBundleBcAppPaths();
         }
         // #3207: the object-reference const memo goes with them, and must be cleared HERE rather


### PR DESCRIPTION
Closes #2939

Closes #3052

Filed and implemented by an agent (impl-10) acting on the account holder's behalf.

Two issues, one reset path. #2939's fix turned out to need a second half that nothing had
measured, and finding that is most of what this PR is.

## #2939 — the stale list, and why clearing it alone is a regression

`RecordPatches._bcQuerySymbolJsonPaths` is the sibling of `_bcAppPaths` that #2755 named and
deliberately left alone. Clearing it in `ClearPerBundleBcAppPaths` is the fix, and the effect
was worse than #2939 described. #2939 says bundle 2 resolves "against its own registered query
symbols UNION every earlier bundle's". The merge in `EnsureBcSymbolQueryIndex` is first-wins:

```
foreach (var jsonPath in _bcQuerySymbolJsonPaths)
    foreach (var q in BcAppSymbolCache.GetFromJson(jsonPath).Queries)
        if (!idx.ContainsKey(q.Id)) idx[q.Id] = q;
```

The earlier bundle's file is earlier in the list, so bundle 2 declaring the same query id got
bundle 1's column ids *instead of* its own, not in addition to them. Those ids go verbatim to
`NavQuery.GetColumnValueSafe`, so the cost is a wrong number read out of a real row.

RED, from `BundleQuerySymbolsResetTests` on the unfixed tree — two bundles, one process, a
reload between them:

```
BundleTwosQueryResolvesToItsOwnColumnIds_NotBundleOnes
  Assert.Equal() Failure: Values differ
  Expected: Tuple ("Beta", 22)
  Actual:   Tuple ("Alpha", 11)

Failed!  - Failed: 3, Passed: 1, Total: 4
```

GREEN: `Passed! - Failed: 0, Passed: 4, Total: 4`. The one case green in both states is
`WithinOneBundle_SeveralQuerySymbolSourcesStillAccumulate`, the control that stops the fix from
being "clear it so often it never accumulates" — several app groups in one bundled run register
between two resets and must accumulate.

### The half #2939 asked someone to measure first

#2939 ends with "What still needs establishing before changing it": whether any path reaches a
query lookup with neither an emit nor a cache-hit having run for that bundle in the current
reset window. There is one, and the clear alone breaks it.

`BcCompiler.TryEmitIncremental`'s RAD fast paths hand a result back without calling `Emit`, and
`Emit` is the only caller of `EmitAndRegisterBundleQuerySymbols`. So from `--watch` cycle 2
onward nothing re-registers the bundle's query symbols, and before this PR the only reason
queries kept working across cycles was that the list was never cleared — an accidental cache
doing the job `_radPageMetadataByModule` does deliberately for page and xmlport metadata
(#2593 / #2654).

Measured on `tests/runner-extras/query-join-aggregation-oos`, four `--watch` cycles, same
machine, private cache outside the repository:

| tree | result |
|---|---|
| unmodified `main` | 4 PASS on every cycle (the accumulating list masks it) |
| clear only, no replay | 4 PASS cycle 1, **4 FAIL cycles 2-4** |
| clear + `_radQuerySymbolsPathByModule` | 4 PASS on every cycle |

So the registration is now shadowed per module and replayed at the same two fast-path returns
that already replay page and xmlport metadata. The value stored is the path rather than parsed
symbols because the file is per-process and per-module (`PerProcessScratch`, #2967) and is
rewritten in place by each full `Emit` of that module — replaying the path re-registers what
that module's most recent real compile wrote, which is the same content the accumulating list
used to hand back, minus the other bundles' files that were the defect.

`WatchQuerySymbolsReloadTests` pins it, with a dedicated fixture. Its RED is the middle row
above — the replay removed, the clear kept:

```
cycle 2 (warm): Assert.DoesNotContain() Failure: Sub-string found
Found: "FAIL  Codeunit70623.QueryReadsItsAggregat"...
```

GREEN: `Passed! - Failed: 0, Passed: 1, Total: 1` (10 s).

## #3052 — enum re-registration across a reload, pinned

The property is true on `main` and asserted by nothing, which is why #3052 was filed rather
than left to close with its parent. It is also load-bearing by accident: `AddBcAppPath` is the
only live path by which a precompiled dependency's enums reach `AlEnumMetadataRegistry`, and it
early-returns on a path already in `_bcAppPaths`, so the enums come back only because
`ClearPerBundleBcAppPaths` makes the next `AddBcAppPath` real again.

`EnumRegistrationSurvivesReloadTests` asserts a concrete caption and both implementation
fallbacks after a reload, per #3052's own bar — not that the registry is non-empty, which would
pass against a registry holding the wrong thing.

RED for a pinning test is the change it exists to catch. Applying the optimisation #3052 warns
about — keep already-registered paths across a reload, since re-reading their symbols is
redundant:

```
ADependencysEnumCaptionAndImplementationFallbacksSurviveABundleReload [FAIL]
  enum 79971 is not in AlEnumMetadataRegistry at all
```

Restored, both cases pass. The second case is the control that keeps the first discriminating:
inside one bundle, re-registering an already-registered path must stay a no-op, so the fix can
never become "re-read the symbols every time".

## Answering the three "fix the shape" questions

**Does the same wrong pattern appear at another call site?** I ran a census of every static
collection in the 57 `RecordPatches` partials against what `ResetForReload` clears, expanding
the helpers it calls transitively and stripping comments so a field merely *named* in prose did
not count as cleared. 39 uncleared collection statics. 14 are epoch-guarded
(`BcAppRegistrationEpoch`, #2888) and safe. Most of the rest are safe by construction and I am
recording why, because the negative result is the useful part: `ConditionalWeakTable` keyed on
the provider instance expires with the provider; `_pValueByType` / `_concreteRecordCtors` are
reflection memos keyed on `Type`, and a new bundle emits new types; `_treeCache` is content-keyed
on a SHA-256 of the source text, and says so in its own comment; the `*TypeOrdinals` dictionaries
map an object-type name to a BC enum ordinal, which does not come from the bundle.

Two are not safe, both in `RecordPatches.PermissionMetadataPopulator.cs`, which is the file
#3227 fixed `_metaPermissionSetCache` in last night. `_permMetaPopulatedForCount` gates
`EnsurePermissionMetadataPopulated` on a **count**, which is the ABA guard
`_bcAppRegistrationEpoch`'s own comment exists to argue against, and nothing resets it across a
reload; `_permissionSetIdByName` is invalidated only inside the block that guard skips. Filed as
#3249 rather than fixed here: both are reachable only past BC reflection
(`NavAppGroup.BaseGroup`), so I could not produce a locally runnable RED, and a fix I cannot
prove is not one I should ship in this PR.

**Does a sibling function make the same assumption?**
`DependencyLoader.ReplayDependencyMetadataSidecars` replays five registries — report,
report-layout, page, xmlport, enum — and not query symbols. Separately,
`RunBundleForServer`'s cross-bundle module reuse (`reusedAsm != null`) skips the whole cache
block, so it calls neither `LoadEnumRegistrySidecar` nor `RegisterBundleQuerySymbolsJson`.
Filed as #3250. It is narrow — `TryGetByAppId` returns null when the source path matches, so
reuse needs the same AppId from a different directory — and the enum half of it is already
broken on `main` today, independently of this PR.

**If two code paths write the same state, do they maintain the same invariant?** This is the
one that produced the second commit. `Emit` and the RAD fast paths both leave a bundle's query
symbols registered; only `Emit` actually did the registering. That asymmetry was invisible while
the list accumulated.

## Not folded, and why

**#2655** (report / report-layout / enum metadata across `--watch` cycles) was claimed with these
two and released. It is no longer "not verified" — I reproduced its enum half and left the
recipe on the issue — but its fix is three more registries in a different file with their own
value shapes, and each needs its own proof. Folding it is where this diff would stop being one
change. The query-symbol snapshot added here is the template for it, and `AlReportMetadataRegistry`
is the same `int -> string` shape as the page registry already handled.

## Review round 2 — the snapshot borrowed another module's query symbols

A reviewer found the capture above reading a **process-global static** without checking it
belongs to the module being captured:

```csharp
var querySymbolsPath = LastBundleQuerySymbolsPath;   // public static, set by Emit
if (querySymbolsPath != null && File.Exists(querySymbolsPath))
    _radQuerySymbolsPathByModule[moduleName] = querySymbolsPath;
```

The comment justified it with "this is called from `RecordIncrementalBaseline`, i.e. from inside
that same Emit". That holds for one of `RecordIncrementalBaseline`'s two call sites and not the
other:

| call site | sets `LastBundleQuerySymbolsPath`? |
|---|---|
| `BcCompiler.Emit` (`BcCompiler.cs:2274`) | yes — nulled at the top, set by `EmitAndRegisterBundleQuerySymbols` |
| `BcCompiler.EmitDepSymbols(trackIncrementalBaseline: true)` (`:2641`), from `EmitDepSymbolsIncremental` | **never touches it** |

Source-dependency compilers are separate `BcCompiler` instances from the bundle emitter, so the
dep path read whatever the last `Emit` anywhere in the process had left there — a different
module's `SymbolReference.json`. A RAD fast-path return for that dep module then replayed the
foreign file into `_bcQuerySymbolJsonPaths`, and the first-wins merge in
`EnsureBcSymbolQueryIndex` served its column ids for any colliding query id. Same wrong-number
shape this PR exists to close, through the door this PR opened.

**RED**, `RadQuerySymbolsSnapshotModuleScopeTests` on the pre-fix tree — a query-declaring bundle
and a source dependency in one process, capturing on the dep path:

```
DepSymbolBaseline_DoesNotAdoptAnotherModulesQuerySymbolsPath [FAIL]
  'RadQsDepBeta' declares no query, so its RAD snapshot must record no query-symbol source.
  It recorded '/…/al-runner-query-symbols/RadQsBundleAlpha-ee6dd62c680c-8920c433…/SymbolReference.json'
  — which belongs to 'RadQsBundleAlpha'.

Failed!  - Failed: 1, Passed: 1, Total: 2
```

**GREEN**: `Passed! - Failed: 0, Passed: 2, Total: 2`.

**The fix** is the structural one, not a guard: `EmitAndRegisterBundleQuerySymbols` now returns
the path it wrote, `Emit` binds it to a **local**, and `RecordIncrementalBaseline` /
`CaptureRadMetadataSnapshotFull` take it as a parameter. `EmitDepSymbols` passes
`bundleQuerySymbolsPath: null`. The dep path can no longer capture one at all, rather than
capturing one and then being asked to notice it is wrong — a module-segment check on the path
would have worked (the path encodes the module, `PerProcessScratch`, #2967) but leaves the
wrong default in place for anyone who adds a third call site. The static stays for Program.cs's
cache-sidecar copy, with a comment saying who may read it.

The comment that asserted the false thing about both call sites is corrected, and
`RecordIncrementalBaseline`'s own doc comment — which said "Called by `Emit`" — now names both
callers, since that omission is what made the false claim look true.

### The other two-thirds of the same function, filed not fixed

`CaptureRadMetadataSnapshotFull` also captures page and xmlport metadata, and it does that by
looking the module's own declared ids up in the **process-wide** `AlPageMetadataRegistry` /
`AlXmlPortMetadataRegistry`. On the dep path nothing registered those ids — `EmitDepSymbols`
never runs the emit outputter — so a dependency declaring a page id another module has already
registered captures that other module's control tree. Same asymmetry, one level over, but it
predates this PR (it came in with #2593/#2654) and its fix has a different shape, so it is
**#3282** rather than a wider diff here. It needs two bundles in one process with overlapping
id ranges, which nothing in the suite or the corpus sets up.

`Program.cs:3402` and `:5146` also read `LastBundleQuerySymbolsPath`. Both sit in the linear
flow immediately after that same module's own compile, publishing that module's cache sidecar,
with no other `Emit` able to intervene — checked, and left alone.

## Tests run at the rebased head

Rebased onto `c2a73c25`. Everything below re-measured on that tree, not carried forward:

- `RadQuerySymbolsSnapshotModuleScopeTests` — RED then GREEN as quoted above.
- Reset-surface suite (`BcAppPathsResetTests`, `BcAppRegistrationEpochInvalidationTests`,
  `BuiltMetadataCacheBundleBoundaryTests`, `MetaQueryCacheBundleBoundaryTests`,
  `XmlPortRealMetadataBundleBoundaryTests`, `ObjectRefConstBundleBoundaryTests`,
  `BundleQuerySymbolsResetTests`, `EnumRegistrationSurvivesReloadTests`,
  `WatchQuerySymbolsReloadTests`, plus the new class): **31 passed, 0 failed, 0 skipped**, 12 s.
- Wider sweep over the shared compile path, `BcCompiler|Watch|Query|Incremental|Rad`:
  **192 passed, 0 failed, 0 skipped**, 1 m 36 s. Run **twice** against the same cache per
  `local-test-scope.md`'s cache-sensitive exception — identical both times (1 m 23 s warm).

The earlier "151 passed, 35 skipped" figure in this body was measured before
`tools/engine-test-bootstrap.sh` was run on this host, so the 35 `bc-engine-serial` skips were
asserting nothing. These runs are Release + `engine.runsettings`, which is why the same filter
now executes 192 and skips none.

I did not run the full `AlRunner.Tests` suite and am not claiming a result for it. The
`tests/al-language` pin is unmoved and no expectations or count-baseline file is touched.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf

Corpus-NA: runner infrastructure only — AL-output cache HIT/MISS, --watch reload cycles and per-bundle RAD snapshot scoping are named in bc-behavior-tests-go-upstream.md as runner-only; AL inside one invocation cannot observe a cache directory across two invocations, so no service tier can adjudicate the claim.
