### PR TITLE
fix(bc-shape): name the member at 73 BC-internals lookups guarded only by `!`

### DIFF
--- a/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
+++ b/AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs
@@ -1,0 +1,432 @@
+// BcInternalsNullForgivingGuardTests — the repo-wide half of #3051.
+//
+// WHY A SOURCE GUARD AT ALL, AND WHY #2994's SWEEP COULD NOT SEE THIS
+//   #2994 swept the runner for refusals that answer a default instead of naming the gap. Its
+//   search shape was a `throw`. A null-forgiving `!` is not a throw — it is a COMPILER
+//   ANNOTATION that emits no code — so 134 BC-internals member lookups were invisible to it,
+//   and #3046 (five sites) and #3034 (56 throw sites) each cleared only their own slice.
+//
+//   The failure mode is specific and it INVERTS results rather than merely hiding them.
+//   `t.GetProperty("X")!` on a member Microsoft has moved hands back a silent null; the
+//   NullReferenceException lands at the first USE — `.PropertyType`, `.GetValue`, `.Invoke` —
+//   on a line that no longer names X. MethodScopePatches.NavMethodScope_AssertError is an
+//   unfiltered catch(Exception), so on any AL-entered path that NRE is swallowed and
+//   `asserterror` PASSES on a read real BC performs fine. #3046 measured exactly that: all
+//   five of its AssertError arms failed pre-fix with "No exception was thrown".
+//
+// WHAT THIS FILE ASSERTS
+//   #3051 converted the 73 lookups that read BC's OWN internals to BcShape.Property/Method/
+//   Field/Constructor, which raise a BcShapeGapException naming Declaring.Member. 61 sites
+//   remain, and every one of them is here on purpose — they are not BC-layout reads:
+//
+//     RunnerOwnMember  the receiver is `typeof(<a runner type>)`. `nameof` or not, this asks
+//                      the runner about the runner. Microsoft cannot move it, and a rename
+//                      inside this repository is a compile-time or a same-PR question. 36.
+//     Bcl              the receiver is a BCL type — object.MemberwiseClone, Guid.NewGuid,
+//                      string.Empty, InvalidOperationException(string), Task.FromResult. The
+//                      .NET surface does not move under a BC update. 7.
+//     FrameworkTuple   `Item1` / `Item2` on a ValueTuple or Tuple<,>. The tuple is BC's, the
+//                      MEMBER is the framework's, so a BC update cannot move it. 8.
+//     Listed           ten sites the three rules above cannot classify structurally, each with
+//                      its own reason below. 10.
+//
+//   So the assertion is two-directional. An unclassified site fails ("account for it or
+//   convert it"), and a change in any category's count fails too — removing a site is as loud
+//   as adding one, which is what keeps the classification from rotting while nobody looks.
+//
+// WHAT IT DELIBERATELY DOES NOT ASSERT
+//   Not "no `!` anywhere". `!` on a local, a cast or a `GetType()` is ordinary C#. The scanner
+//   below looks only at MEMBER LOOKUPS — GetProperty/GetMethod/GetField/GetConstructor/
+//   GetNestedType immediately followed by `!` — because that is the shape whose failure is a
+//   silent null rather than an exception.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class BcInternalsNullForgivingGuardTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private enum Cat { RunnerOwnMember, Bcl, FrameworkTuple, Listed, Unclassified }
+
+    // ── The ten sites the structural rules cannot classify ──────────────────────────────
+    //
+    // Keyed by file + receiver expression + first lookup argument, never by line number: a
+    // line number goes stale on the next edit above it and would turn this guard into noise.
+    private static readonly Dictionary<(string File, string Recv, string Member), string> Listed = new()
+    {
+        // The runner's OWN side-loaded assembly, not BC's. AlRunner.QueryJoin.dll ships beside
+        // al-runner.dll and is loaded by path (so its Ncl-touching IL is not bound at startup),
+        // which is why these are reflection at all. A rename here is a rename inside this
+        // repository — BcShapeGapException would claim BC's layout moved, which would be false.
+        { ("AlRunner/Patches/RecordPatches.QueryJoin.cs", "_tJoinExecutor", "\"IsMultiDataItem\""),
+          "AlRunner.QueryJoin.JoinExecutor — the runner's own side-loaded assembly" },
+        { ("AlRunner/Patches/RecordPatches.QueryJoin.cs", "_tJoinExecutor", "\"Execute\""),
+          "AlRunner.QueryJoin.JoinExecutor — the runner's own side-loaded assembly" },
+        { ("AlRunner/Patches/RecordPatches.QueryJoin.cs", "_tJoinContext!", "field"),
+          "AlRunner.QueryJoin.JoinContext — the runner's own side-loaded assembly" },
+        { ("AlRunner/Patches/RecordPatches.QueryJoin.cs", "_tJoinContext!", "f"),
+          "AlRunner.QueryJoin.JoinContext — the runner's own side-loaded assembly" },
+
+        // Closed generics over a BCL type. The receiver is a local, so `typeof(...)` cannot be
+        // read off the text, but the type is the framework's and cannot move under BC.
+        { ("AlRunner/Patches/CodeunitPatches.cs", "rt", "\"AsTask\""),
+          "ValueTask<T>.AsTask — BCL" },
+        { ("AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs", "arrType", "\"Empty\""),
+          "ImmutableArray<T>.Empty — BCL" },
+        { ("AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs", "kvpType", "new[] { typeof(int), _tMetaField! }"),
+          "KeyValuePair<int, TMetaField>..ctor — BCL" },
+        { ("AlRunner/Patches/RecordPatches.cs", "stackType", "\"Push\""),
+          "Stack<T>.Push — BCL" },
+
+        // The runner's own artifacts, not BC's.
+        { ("AlRunner/Program.cs", "target", "\"OnRun\""),
+          "OnRun on a codeunit THIS runner emitted — absence is an emit defect, not BC's layout" },
+        { ("AlRunner/Reporter.cs", "f.GetType()", "\"classification\""),
+          "a property of the runner's own result record — not a BC type" },
+    };
+
+    private static readonly Dictionary<Cat, int> Expected = new()
+    {
+        [Cat.RunnerOwnMember] = 36,
+        [Cat.Bcl] = 7,
+        [Cat.FrameworkTuple] = 8,
+        [Cat.Listed] = 10,
+    };
+
+    /// <summary>Receivers of the form <c>typeof(X…)</c> that name a type in this repository.</summary>
+    private static readonly string[] RunnerTypePrefixes =
+        { "typeof(AlRunner.", "typeof(BcRuntime)", "typeof(RecordPatches)", "typeof(FlowFieldPatches)", "typeof(MediaPatches)" };
+
+    /// <summary>Receivers naming a BCL type outright.</summary>
+    private static readonly string[] BclReceivers =
+        { "typeof(object)", "typeof(Guid)", "typeof(InvalidOperationException)", "typeof(string)",
+          "typeof(System.Threading.Tasks.Task)" };
+
+    // ── The assertions ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void EveryRemainingNullForgivingMemberLookup_IsAccountedFor()
+    {
+        var unclassified = AllSites()
+            .Where(s => Classify(s) == Cat.Unclassified)
+            .Select(s => $"{s.File}:{s.Line}  {s.Recv}.{s.Kind}({Trim(s.Member)})!")
+            .ToList();
+
+        Assert.True(unclassified.Count == 0,
+            "these BC-internals member lookups are guarded only by `!`, so a member Microsoft moves "
+            + "hands back a silent null and NREs into NavMethodScope_AssertError's unfiltered "
+            + "catch(Exception) — where `asserterror` PASSES on a read real BC performs fine (#3051). "
+            + "Convert them to BcShape.Property/Method/Field/Constructor, or add them to Listed with "
+            + $"the reason they are not a BC-layout read:{Environment.NewLine}"
+            + string.Join(Environment.NewLine, unclassified));
+    }
+
+    [Fact]
+    public void TheRemainingPopulation_IsExactlyWhatWasClassified()
+    {
+        var actual = AllSites().GroupBy(Classify).ToDictionary(g => g.Key, g => g.Count());
+
+        foreach (var (cat, expected) in Expected.OrderBy(e => e.Key.ToString()))
+        {
+            actual.TryGetValue(cat, out var got);
+            Assert.True(expected == got,
+                $"{cat}: expected {expected} null-forgiving lookups, found {got}. Adding one is as "
+                + "much a change to the classification as removing one — update the count here and "
+                + "say in the PR body which it was (#3051).");
+        }
+
+        Assert.Equal(Expected.Values.Sum(), AllSites().Count);
+    }
+
+    /// <summary>
+    /// The scanner is the load-bearing part of both assertions above, so it gets its own
+    /// arms: a `!=` comparison must NOT read as a null-forgiving `!` (the naive
+    /// statement-level regex #3051 was filed with counted eight of those, which is most of
+    /// why its headline number was 143 rather than 134), and neither a comment nor a string
+    /// literal describing the shape may register as a live site.
+    /// </summary>
+    [Fact]
+    public void Scanner_FindsALiveLookup_AndIgnoresNotEquals_Comments_AndStringLiterals()
+    {
+        const string src = """
+            class C {
+                void M() {
+                    var a = t.GetProperty("Live", BindingFlags.Public)!.GetValue(x);
+                    if (t.GetProperty("NotEquals") != null) return;
+                    // t.GetProperty("InAComment")!
+                    var s = "t.GetProperty(\"InAString\")!";
+                    var b = t.GetMethod("Wrapped",
+                        BindingFlags.Public)!;
+                }
+            }
+            """;
+
+        var found = Scan("x.cs", src).ToList();
+
+        Assert.Equal(2, found.Count);
+        Assert.Equal("\"Live\"", Trim(found[0].Member));
+        Assert.Equal("GetProperty", found[0].Kind);
+        Assert.Equal("\"Wrapped\"", Trim(found[1].Member));
+        Assert.Equal("GetMethod", found[1].Kind);
+    }
+
+    /// <summary>
+    /// The converted sites are the other half of the population and they are not otherwise
+    /// pinned anywhere: without this arm, deleting every BcShape.Property call and putting the
+    /// `!` back would still leave the two assertions above green, because they only count what
+    /// is NOT converted.
+    /// </summary>
+    [Fact]
+    public void TheConvertedSites_AreStillConverted()
+    {
+        var converted = SourceFiles()
+            .Sum(f => CountConverted(File.ReadAllText(f)));
+
+        Assert.Equal(73, converted);
+    }
+
+    private static int CountConverted(string src)
+    {
+        var n = 0;
+        foreach (var name in new[] { "BcShape.Property(", "BcShape.Method(", "BcShape.Field(",
+                                     "BcShape.Constructor(", "BcShape.NestedType(" })
+        {
+            for (var i = src.IndexOf(name, StringComparison.Ordinal); i >= 0;
+                 i = src.IndexOf(name, i + 1, StringComparison.Ordinal))
+                n++;
+        }
+        return n;
+    }
+
+    // ── Classification ──────────────────────────────────────────────────────────────────
+
+    private static Cat Classify(Site s)
+    {
+        if (RunnerTypePrefixes.Any(p => s.Recv.StartsWith(p, StringComparison.Ordinal))) return Cat.RunnerOwnMember;
+        // NclCecilRewrite.Media.cs hoists `typeof(MediaSetPatches)` into a local before six
+        // consecutive lookups; the receiver text is the local, the type is still the runner's.
+        if (s.Recv == "patchTypeMi") return Cat.RunnerOwnMember;
+        if (BclReceivers.Contains(s.Recv)) return Cat.Bcl;
+        var member = Trim(s.Member);
+        if (member is "\"Item1\"" or "\"Item2\"") return Cat.FrameworkTuple;
+        if (Listed.ContainsKey((s.File, s.Recv, member))) return Cat.Listed;
+        return Cat.Unclassified;
+    }
+
+    // ── The scanner ─────────────────────────────────────────────────────────────────────
+
+    private sealed record Site(string File, int Line, string Kind, string Recv, string Member);
+
+    private static readonly string[] Kinds =
+        { "GetProperty", "GetMethod", "GetField", "GetConstructor", "GetNestedType" };
+
+    private static IReadOnlyList<Site> _all = Array.Empty<Site>();
+
+    private static IReadOnlyList<Site> AllSites()
+    {
+        if (_all.Count > 0) return _all;
+        var sites = new List<Site>();
+        foreach (var path in SourceFiles())
+        {
+            var rel = Path.GetRelativePath(RepoRoot, path).Replace('\\', '/');
+            sites.AddRange(Scan(rel, File.ReadAllText(path)));
+        }
+        _all = sites;
+        return _all;
+    }
+
+    private static IEnumerable<string> SourceFiles()
+    {
+        var root = Path.Combine(RepoRoot, "AlRunner");
+        Assert.True(Directory.Exists(root), $"AlRunner/ not found at {root} — the repo root walk is wrong.");
+        return Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories)
+            .Where(p => !p.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}",
+                                    StringComparison.Ordinal)
+                     && !p.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+                                    StringComparison.Ordinal))
+            .OrderBy(p => p, StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Every <c>.GetProperty(…)!</c> / <c>.GetMethod(…)!</c> / … in <paramref name="src"/>,
+    /// with the receiver expression and the first lookup argument. Comments and string
+    /// literals are blanked first (so prose describing the shape — this file's own header does
+    /// exactly that — is not a live read), and a <c>!=</c> is not a null-forgiving <c>!</c>.
+    /// </summary>
+    private static IEnumerable<Site> Scan(string file, string src)
+    {
+        var code = Blank(src);
+        for (var i = 0; i < code.Length; i++)
+        {
+            if (code[i] != '.') continue;
+            var kind = Kinds.FirstOrDefault(k =>
+                string.CompareOrdinal(code, i + 1, k, 0, k.Length) == 0);
+            if (kind == null) continue;
+            var j = i + 1 + kind.Length;
+            if (j < code.Length && code[j] == 's') j++;          // GetProperties / GetMethods / …
+            while (j < code.Length && char.IsWhiteSpace(code[j])) j++;
+            if (j >= code.Length || code[j] != '(') continue;
+            var close = MatchClose(code, j);
+            if (close < 0) continue;
+            var k = close + 1;
+            while (k < code.Length && char.IsWhiteSpace(code[k])) k++;
+            if (k >= code.Length || code[k] != '!') continue;
+            if (k + 1 < code.Length && code[k + 1] == '=') continue;   // `!=`
+
+            // The argument text comes from the ORIGINAL source: Blank() erases string bodies,
+            // and the member name is exactly what lives inside them.
+            var args = src.Substring(j + 1, close - j - 1);
+            yield return new Site(file, code.Take(i).Count(c => c == '\n') + 1, kind,
+                                  StripCast(Receiver(code, src, i)), FirstArg(args, kind));
+            i = close;
+        }
+    }
+
+    private static string FirstArg(string args, string kind)
+    {
+        if (kind == "GetConstructor") return args;
+        var depth = 0;
+        for (var i = 0; i < args.Length; i++)
+        {
+            var c = args[i];
+            if (c is '(' or '[' or '{') depth++;
+            else if (c is ')' or ']' or '}') depth--;
+            else if (c == ',' && depth == 0) return args.Substring(0, i);
+        }
+        return args;
+    }
+
+    /// <summary>Whitespace-normalised, so a wrapped call and a one-liner key the same.</summary>
+    private static string Trim(string s) => string.Join(" ", s.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+
+    private static string StripCast(string recv)
+    {
+        // `(NCLMetaTable)rt.GetProperty(…)!` — the cast binds to the RESULT, not the receiver.
+        if (!recv.StartsWith("(", StringComparison.Ordinal)) return recv;
+        var close = MatchClose(recv, 0);
+        if (close < 0 || close + 1 >= recv.Length) return recv;
+        var after = recv[close + 1];
+        return char.IsLetter(after) || after == '_' || after == '(' ? recv.Substring(close + 1) : recv;
+    }
+
+    private static string Receiver(string code, string src, int dot)
+    {
+        var i = dot - 1;
+        while (i >= 0 && char.IsWhiteSpace(code[i])) i--;
+        var end = i + 1;
+        while (i >= 0)
+        {
+            var c = code[i];
+            if (c is ')' or ']')
+            {
+                var open = c == ')' ? '(' : '[';
+                var depth = 0;
+                while (i >= 0)
+                {
+                    if (code[i] == c) depth++;
+                    else if (code[i] == open) { depth--; if (depth == 0) break; }
+                    i--;
+                }
+                i--;
+                continue;
+            }
+            if (char.IsLetterOrDigit(c) || c is '_' or '.' or '!' or '?') { i--; continue; }
+            if (char.IsWhiteSpace(c))
+            {
+                var j = i;
+                while (j >= 0 && char.IsWhiteSpace(code[j])) j--;
+                if (j >= 0 && code[j] == '.') { i = j; continue; }
+                break;
+            }
+            break;
+        }
+        return Trim(src.Substring(i + 1, end - i - 1));
+    }
+
+    private static int MatchClose(string s, int open)
+    {
+        var depth = 0;
+        for (var i = open; i < s.Length; i++)
+        {
+            if (s[i] == '(') depth++;
+            else if (s[i] == ')') { depth--; if (depth == 0) return i; }
+        }
+        return -1;
+    }
+
+    /// <summary>
+    /// <paramref name="src"/> with comment and string-literal CONTENT replaced by spaces,
+    /// same length so every offset still lines up with the original.
+    /// </summary>
+    private static string Blank(string src)
+    {
+        var b = new StringBuilder(src);
+        var i = 0;
+        while (i < src.Length)
+        {
+            if (src[i] == '/' && i + 1 < src.Length && src[i + 1] == '/')
+            {
+                while (i < src.Length && src[i] != '\n') { b[i] = ' '; i++; }
+                continue;
+            }
+            if (src[i] == '/' && i + 1 < src.Length && src[i + 1] == '*')
+            {
+                while (i < src.Length && !(src[i] == '*' && i + 1 < src.Length && src[i + 1] == '/'))
+                { if (src[i] != '\n') b[i] = ' '; i++; }
+                if (i < src.Length) { b[i] = ' '; b[i + 1] = ' '; i += 2; }
+                continue;
+            }
+            if (src[i] == '"' && i >= 2 && src[i - 1] == '"' && src[i - 2] == '"')
+            {
+                // raw string literal `"""…"""` — blank through the closing fence
+                var endFence = src.IndexOf("\"\"\"", i + 1, StringComparison.Ordinal);
+                var stop = endFence < 0 ? src.Length : endFence + 3;
+                for (; i < stop; i++) if (src[i] != '\n') b[i] = ' ';
+                continue;
+            }
+            if (src[i] == '@' && i + 1 < src.Length && src[i + 1] == '"')
+            {
+                b[i] = ' '; i += 2;
+                while (i < src.Length)
+                {
+                    if (src[i] == '"' && i + 1 < src.Length && src[i + 1] == '"') { b[i] = ' '; b[i + 1] = ' '; i += 2; continue; }
+                    if (src[i] == '"') { b[i] = ' '; i++; break; }
+                    if (src[i] != '\n') b[i] = ' ';
+                    i++;
+                }
+                continue;
+            }
+            if (src[i] == '"')
+            {
+                i++;
+                while (i < src.Length && src[i] != '"')
+                {
+                    if (src[i] == '\\') { b[i] = ' '; i++; if (i < src.Length) { b[i] = ' '; i++; } continue; }
+                    b[i] = ' '; i++;
+                }
+                if (i < src.Length) i++;
+                continue;
+            }
+            if (src[i] == '\'')
+            {
+                i++;
+                while (i < src.Length && src[i] != '\'')
+                {
+                    if (src[i] == '\\') { b[i] = ' '; i++; if (i < src.Length) { b[i] = ' '; i++; } continue; }
+                    b[i] = ' '; i++;
+                }
+                if (i < src.Length) i++;
+                continue;
+            }
+            i++;
+        }
+        return b.ToString();
+    }
+}

--- a/AlRunner.Tests/BcShapeMethodLookupTests.cs
+++ b/AlRunner.Tests/BcShapeMethodLookupTests.cs
@@ -287,15 +287,26 @@ public sealed class BcShapeMethodLookupTests
     // failure, so a new name-only BC-typed lookup anywhere in AlRunner/ is caught the moment it
     // is written. It does not pin the per-file distribution, so moving one site out of file A
     // and into file B nets to zero and passes; the per-file breakdown is printed on failure for
-    // whoever has to update the number. Deliberately a ratchet rather than a zero: 76 sites
+    // whoever has to update the number. Deliberately a ratchet rather than a zero: 72 sites
     // remain, and #3069 asks for them file by file so the guard never has to be weakened.
+    //
+    // 76 -> 72 by #3051, which converted the null-forgiving BC-internals lookups repo-wide.
+    // The net is not the gross, so the arithmetic is worth writing down. Six counted sites went
+    // away -- NavSymRef.ModuleDefinition.Clone in BcCompiler.Incremental.cs, LoadMetadata in
+    // RecordPatches.RealPageMetadata.cs and RecordPatches.RealXmlPortMetadata.cs, and
+    // CreateFromMetaTable / CreateForTempTable / CreateTempDataAccess in RecordPatches.cs -- and
+    // two arrived, both inside BcShapeGapException.cs itself: BcShape.Method's name-only and
+    // name-plus-flags overloads each call the reflection API once. That is exactly where a
+    // name-only lookup belongs, in the one helper that refuses by name when it misses.
+    // (#3051's other 67 conversions are GetProperty / GetField / GetConstructor, or pass an
+    // explicit signature, so this scan never counted them.)
 
     /// <summary>
     /// Every remaining name-only method lookup that could reach a Microsoft-shipped type. Lower
     /// it as sites are converted; it may never rise. On a mismatch the assertion prints the
     /// per-file breakdown, which is the number to put here.
     /// </summary>
-    private const int NameOnlyBcTypedMethodLookups = 76;
+    private const int NameOnlyBcTypedMethodLookups = 72;
 
     /// <summary>The floor is not cosmetic: a scan that silently narrowed to a handful of files
     /// would report a small number and read as progress. AlRunner/ holds ~195 sources.</summary>

--- a/AlRunner.Tests/BcShapeNullForgivingLookupTests.cs
+++ b/AlRunner.Tests/BcShapeNullForgivingLookupTests.cs
@@ -1,0 +1,428 @@
+// BcShapeNullForgivingLookupTests — the behavioural half of #3051.
+//
+// THE DEFECT, AND WHY IT INVERTS RESULTS RATHER THAN HIDING THEM
+//   `t.GetProperty("X")!` is a compiler annotation. It emits no code and it throws nothing.
+//   When Microsoft moves X the lookup returns a silent null and the NullReferenceException
+//   lands at the first USE — `.PropertyType`, `.GetValue`, `.Invoke` — on a line that no
+//   longer names X. MethodScopePatches.NavMethodScope_AssertError is an unfiltered
+//   catch(Exception), so on any AL-entered path that NRE is SWALLOWED and `asserterror`
+//   PASSES on a read real BC performs fine. That is the opposite of BC's answer, in green.
+//
+//   The two arms named *_SwallowsTheNre_WhichIsTheDefect below MEASURE that, against the
+//   production seams, using the same `!` shape the 73 converted sites used to have. They are
+//   the reason this file can claim the conversion buys something: without them "BcShape tears
+//   through" would be a statement with nothing to contrast against.
+//
+// WHAT IS PROVED HERE
+//   1. Each BcShape overload raises a BcShapeGapException naming `Declaring.Member` when the
+//      read cannot be performed, and returns the real member — unchanged — when it can. Every
+//      refusal arm is paired with a control, so a helper that threw unconditionally would fail
+//      here rather than pass.
+//   2. The overloads resolve EXACTLY what the `!` site resolved. The flags-fidelity arms are
+//      the load-bearing ones: converting 73 sites would be a behaviour change if a helper
+//      quietly widened Public|Instance to Public|NonPublic|Instance, because a non-public
+//      member could then start shadowing the public one the site had been reading.
+//   3. Both AL seams tear through a BcShapeGapException — with a control proving the seams
+//      still trap what they are supposed to trap, so "tears through" is not vacuous.
+//   4. Four PRODUCTION call sites converted by #3051, driven with a fake type standing in for
+//      a BC type whose member has moved. These are the arms that fail on an unfixed tree: they
+//      get a NullReferenceException (or, through NavMethodScope_AssertError, no exception at
+//      all) instead of a BcShapeGapException naming the member.
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using AlRunner;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class BcShapeNullForgivingLookupTests
+{
+    private const BindingFlags PublicInstance = BindingFlags.Public | BindingFlags.Instance;
+    private const BindingFlags Priv = BindingFlags.NonPublic | BindingFlags.Static;
+
+    private const string Surface = "a BC surface under test";
+
+    // ══ 1. Property ══════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Property_RaisesAShapeGapNamingTheMember_WhenBcsPropertyHasMoved()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => BcShape.Property(typeof(MovedShape), "GoneAway", PublicInstance, Surface));
+
+        Assert.Equal(Surface, ex.Surface);
+        Assert.Equal("MovedShape.GoneAway", ex.Member);
+        Assert.Contains("property not found", ex.Detail, StringComparison.Ordinal);
+        Assert.StartsWith("bc-shape-gap: ", ex.Message, StringComparison.Ordinal);
+        Assert.EndsWith(" — see docs/limitations.md#bc-shape-gaps", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Property_StillReturnsTheRealProperty_WhenItIsThere()
+    {
+        var p = BcShape.Property(typeof(MovedShape), "Present", PublicInstance, Surface);
+
+        Assert.Equal("Present", p.Name);
+        Assert.Equal(typeof(List<int>), p.PropertyType);
+    }
+
+    // The single-argument overload mirrors `GetProperty(name)`, whose default flags include
+    // Static — so this is not the same question as the flags overload above.
+    [Fact]
+    public void Property_WithoutFlags_FindsAStaticProperty_AsGetPropertyNameWould()
+        => Assert.Equal("StaticPresent", BcShape.Property(typeof(MovedShape), "StaticPresent", Surface).Name);
+
+    /// <summary>
+    /// The fidelity arm. `GetProperty(name, Public | Instance)` does NOT see a non-public
+    /// member; a helper that widened to Public | NonPublic | Instance would find one, and 73
+    /// converted sites would then be resolving a different member than before.
+    /// </summary>
+    [Fact]
+    public void Property_DoesNotWidenTheFlags_SoAConvertedSiteResolvesWhatItAlwaysDid()
+    {
+        Assert.Throws<BcShapeGapException>(
+            () => BcShape.Property(typeof(MovedShape), "Hidden", PublicInstance, Surface));
+
+        Assert.Equal(typeof(string),
+            BcShape.Property(typeof(MovedShape), "Hidden", BcShape.AnyInstance, Surface).PropertyType);
+    }
+
+    // ══ 2. Method ════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void Method_RaisesAShapeGapNamingTheMember_WhenBcsMethodHasMoved()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => BcShape.Method(typeof(MovedShape), "GoneAway", BcShape.AnyInstance, Surface));
+
+        Assert.Equal("MovedShape.GoneAway", ex.Member);
+        Assert.Contains("method not found", ex.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Method_StillReturnsTheRealMethod_WhenItIsThere()
+        => Assert.Equal(1, BcShape.Method(typeof(MovedShape), "Take", BcShape.AnyInstance, Surface)
+                                 .GetParameters().Length);
+
+    /// <summary>
+    /// The overload filter is part of the question: a method that keeps its name and changes
+    /// its parameter list is the same "BC's layout moved" case as an absent one, and the
+    /// message says which signature was looked for.
+    /// </summary>
+    [Fact]
+    public void Method_WithASignature_RefusesWhenTheOverloadIsGone_AndNamesTheSignature()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => BcShape.Method(typeof(MovedShape), "Take", BcShape.AnyInstance,
+                                 new[] { typeof(string), typeof(int) }, Surface));
+
+        Assert.Equal("MovedShape.Take(String, Int32)", ex.Member);
+
+        Assert.Equal(typeof(int),
+            BcShape.Method(typeof(MovedShape), "Take", BcShape.AnyInstance, new[] { typeof(int) }, Surface)
+                   .GetParameters()[0].ParameterType);
+    }
+
+    // ══ 3. Field, Constructor, NestedType ════════════════════════════════════════════════
+
+    [Fact]
+    public void Field_RaisesAShapeGapNamingTheMember_WhenBcsFieldHasMoved()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => BcShape.Field(typeof(MovedShape), "goneAway", BcShape.AnyInstance, Surface));
+
+        Assert.Equal("MovedShape.goneAway", ex.Member);
+        Assert.Contains("field not found", ex.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Field_StillReturnsTheRealField_WhenItIsThere()
+        => Assert.Equal(typeof(int), BcShape.Field(typeof(MovedShape), "present", BcShape.AnyInstance, Surface).FieldType);
+
+    [Fact]
+    public void Constructor_RaisesAShapeGapNamingTheSignature_WhenBcsCtorHasMoved()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => BcShape.Constructor(typeof(MovedShape), new[] { typeof(Guid) }, Surface));
+
+        Assert.Equal("MovedShape..ctor(Guid)", ex.Member);
+        Assert.Contains("constructor not found", ex.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Constructor_StillReturnsTheRealCtor_AndTheNonPublicOverloadNeedsTheFlags()
+    {
+        Assert.Single(BcShape.Constructor(typeof(MovedShape), new[] { typeof(int) }, Surface).GetParameters());
+
+        // GetConstructor(Type[]) is public-only, so the internal ctor is invisible to it and
+        // visible to the flags overload — the same fidelity property the Property arm pins.
+        Assert.Throws<BcShapeGapException>(
+            () => BcShape.Constructor(typeof(MovedShape), new[] { typeof(string) }, Surface));
+        Assert.Single(BcShape.Constructor(typeof(MovedShape), BcShape.AnyInstance,
+                                          new[] { typeof(string) }, Surface).GetParameters());
+    }
+
+    [Fact]
+    public void NestedType_RaisesAShapeGapNamingTheMember_AndReturnsTheRealOne()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => BcShape.NestedType(typeof(MovedShape), "GoneAway", BindingFlags.Public, Surface));
+        Assert.Equal("MovedShape.GoneAway", ex.Member);
+        Assert.Contains("nested type not found", ex.Detail, StringComparison.Ordinal);
+
+        Assert.Equal(typeof(MovedShape.Inner),
+            BcShape.NestedType(typeof(MovedShape), "Inner", BindingFlags.Public, Surface));
+    }
+
+    // ══ 4. The inversion, measured at both AL seams ══════════════════════════════════════
+
+    /// <summary>
+    /// The defect, reproduced against the production seam with the exact shape the 73
+    /// converted sites had. `asserterror` sees no error at all: on real BC the read succeeds
+    /// and the asserterror FAILS, so a green here is the opposite of BC's answer.
+    /// </summary>
+    [Fact]
+    public void AssertError_SwallowsTheNre_WhichIsTheDefect()
+    {
+        var swallowed = false;
+        BcRuntime.NavMethodScope_AssertError(null!, () =>
+        {
+            _ = typeof(MovedShape).GetProperty("GoneAway", PublicInstance)!.PropertyType;
+            swallowed = true;                 // never reached; the NRE happens above
+        });
+        Assert.False(swallowed);              // it threw…
+                                              // …and NavMethodScope_AssertError returned anyway.
+    }
+
+    /// <summary>
+    /// MEASURED, and it narrows the issue's claim: the [TryFunction] seam does NOT swallow the
+    /// NRE. NavApplicationObjectBase_TryInvoke swallows a trappable NavBaseException and a
+    /// permanently out-of-scope refusal, and rethrows everything else — so a NullReferenceException
+    /// tears through it. The inversion #3051 is about therefore lives at ONE seam, `asserterror`,
+    /// not at both. That is worth pinning: it is the difference between "AL cannot see this" and
+    /// "AL sees the wrong answer", and only the second is a green test that lies.
+    /// </summary>
+    [Fact]
+    public void TryFunction_LetsTheNreThrough_SoTheInversionIsTheAssertErrorSeamOnly()
+        => Assert.Throws<NullReferenceException>(() => BcRuntime.NavApplicationObjectBase_TryInvoke(
+            null, () => _ = typeof(MovedShape).GetProperty("GoneAway", PublicInstance)!.PropertyType));
+
+    [Fact]
+    public void AssertError_TearsThroughAShapeGap_InsteadOfSwallowingIt()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => BcRuntime.NavMethodScope_AssertError(
+                null!, () => BcShape.Property(typeof(MovedShape), "GoneAway", PublicInstance, Surface)));
+
+        Assert.Equal("MovedShape.GoneAway", ex.Member);
+    }
+
+    [Fact]
+    public void TryFunction_TearsThroughAShapeGap_InsteadOfSwallowingIt()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => BcRuntime.NavApplicationObjectBase_TryInvoke(
+                null, () => BcShape.Method(typeof(MovedShape), "GoneAway", BcShape.AnyInstance, Surface)));
+
+        Assert.Equal("MovedShape.GoneAway", ex.Member);
+    }
+
+    // CONTROL: the seams still trap what they are supposed to trap, so "tears through" above
+    // is a statement about BcShapeGapException and not about seams that catch nothing.
+    [Fact]
+    public void BothSeams_StillTrapAPermanentRefusal_SoTearThroughIsNotVacuous()
+    {
+        Assert.False(BcRuntime.NavApplicationObjectBase_TryInvoke(
+            null, () => throw new RunnerOutOfScopeException(
+                "NavEmail.Send", "email-smtp — no SMTP transport in the runner", "email")));
+
+        BcRuntime.NavMethodScope_AssertError(null!, () => throw new RunnerOutOfScopeException(
+            "NavEmail.Send", "email-smtp — no SMTP transport in the runner", "email"));
+    }
+
+    // ══ 5. Four converted PRODUCTION call sites ══════════════════════════════════════════
+    //
+    // Each takes the BC object (or its type) as a parameter, so a fake standing in for a BC
+    // type whose member has moved reaches the real code path without touching a BC install.
+    // Every one of these fails on an unfixed tree with NullReferenceException instead.
+
+    /// <summary>
+    /// ExecutionSchedulerShutdown.DisposeIfRealized — `lazyType.GetProperty("Value", …)!`
+    /// on BC's LazyEx&lt;ExecutionScheduler&gt;.
+    /// </summary>
+    [Fact]
+    public void ExecutionSchedulerShutdown_RaisesAShapeGap_WhenLazyExValueHasMoved()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => ExecutionSchedulerShutdown.DisposeIfRealized(new RealizedLazyWithoutValue()));
+
+        Assert.Equal("RealizedLazyWithoutValue.Value", ex.Member);
+        Assert.Equal("task-scheduler shutdown", ex.Surface);
+    }
+
+    // CONTROLS: the two answers that are NOT a shape gap still come back as answers. An
+    // unrealized lazy must not even be asked for Value — reading it would start the very
+    // scheduler thread this helper exists to stop.
+    [Fact]
+    public void ExecutionSchedulerShutdown_StillAnswers_WhenTheLazyIsIntact()
+    {
+        var realized = new RealizedLazy();
+        Assert.Equal(ExecutionSchedulerShutdown.Outcome.Disposed,
+                     ExecutionSchedulerShutdown.DisposeIfRealized(realized));
+        Assert.True(realized.Disposed);
+
+        Assert.Equal(ExecutionSchedulerShutdown.Outcome.NotRealized,
+                     ExecutionSchedulerShutdown.DisposeIfRealized(new UnrealizedLazyWithoutValue()));
+        Assert.Equal(ExecutionSchedulerShutdown.Outcome.NoEnvironment,
+                     ExecutionSchedulerShutdown.DisposeIfRealized(null));
+    }
+
+    /// <summary>
+    /// RunnerPageInstance.GetValue — `expression.GetType().GetMethod("Get", …)!` on BC's
+    /// page-field expression object.
+    /// </summary>
+    [Fact]
+    public void RunnerPageInstanceGetValue_RaisesAShapeGap_WhenTheExpressionsGetterHasMoved()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => RunnerPageInstance.GetValue(new ExpressionWithoutGet()));
+
+        // The signature is part of the member name: BC keeping `Get` while changing its
+        // parameter list is the same "layout moved" case as removing it.
+        Assert.Equal("ExpressionWithoutGet.Get()", ex.Member);
+        Assert.Equal("TestPage field expression access", ex.Surface);
+    }
+
+    // …and through both AL seams, which is where the inversion lived.
+    [Fact]
+    public void RunnerPageInstanceGetValue_TearsThroughBothAlSeams()
+    {
+        Assert.Throws<BcShapeGapException>(
+            () => BcRuntime.NavMethodScope_AssertError(null!, () => RunnerPageInstance.GetValue(new ExpressionWithoutGet())));
+        Assert.Throws<BcShapeGapException>(
+            () => BcRuntime.NavApplicationObjectBase_TryInvoke(null, () => RunnerPageInstance.GetValue(new ExpressionWithoutGet())));
+    }
+
+    /// <summary>
+    /// RecordPatches.GetList — `obj.GetType().GetProperty(name, …)!` while building a real
+    /// NCLMetaQuery out of BC's own query metadata.
+    /// </summary>
+    [Fact]
+    public void QueryMetadataGetList_RaisesAShapeGap_WhenBcsListPropertyHasMoved()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => InvokeRecordPatches("GetList", new MetaQueryWithoutDataItems(), "DataItems"));
+
+        Assert.Equal("MetaQueryWithoutDataItems.DataItems", ex.Member);
+        Assert.Equal("AL query metadata construction", ex.Surface);
+    }
+
+    [Fact]
+    public void QueryMetadataGetList_StillReturnsTheList_WhenThePropertyIsThere()
+        => Assert.Equal(2, ((IList)InvokeRecordPatches("GetList", new MetaQueryWithDataItems(), "DataItems")!).Count);
+
+    /// <summary>
+    /// EventSubscriberPatches.ReplaceAttributeWithZeroedCopy — six consecutive
+    /// `oType.GetProperty(…)!` reads on BC's NavEventSubscriber attribute.
+    /// </summary>
+    [Fact]
+    public void EventSubscriberAttributeCopy_RaisesAShapeGap_WhenBcsAttributeHasMoved()
+    {
+        var ex = Assert.Throws<BcShapeGapException>(
+            () => InvokeEventSubscriberPatches("ReplaceAttributeWithZeroedCopy",
+                                               new SubscriberMethodInfo(new AttributeWithoutTargetObjectId())));
+
+        Assert.Equal("AttributeWithoutTargetObjectId.TargetObjectId", ex.Member);
+        Assert.Equal("event-subscriber inventory", ex.Surface);
+    }
+
+    // CONTROL: an attribute BC never set is an ANSWER, not a shape gap — the method returns
+    // without raising, so the refusal above is about the member and not about the fake.
+    [Fact]
+    public void EventSubscriberAttributeCopy_ReturnsQuietly_WhenThereIsNoAttributeAtAll()
+        => InvokeEventSubscriberPatches("ReplaceAttributeWithZeroedCopy", new SubscriberMethodInfo(null));
+
+    // ══ Plumbing ═════════════════════════════════════════════════════════════════════════
+
+    private static object? InvokeRecordPatches(string name, params object?[] args)
+        => Invoke(typeof(RecordPatches), name, args);
+
+    private static object? InvokeEventSubscriberPatches(string name, params object?[] args)
+        => Invoke(typeof(EventSubscriberPatches), name, args);
+
+    private static object? Invoke(Type owner, string name, object?[] args)
+    {
+        var m = owner.GetMethod(name, Priv)
+            ?? throw new InvalidOperationException($"test setup: {owner.Name}.{name} not found");
+        try { return m.Invoke(null, args); }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            throw tie.InnerException;   // the reflection wrapper is not part of the contract
+        }
+    }
+
+    // ── Fakes standing in for BC types whose members have moved ─────────────────────────
+
+    private sealed class MovedShape
+    {
+        public MovedShape(int _) { }
+        internal MovedShape(string _) { }
+        public List<int>? Present { get; set; }
+        internal string? Hidden { get; set; }
+        public static int StaticPresent => 7;
+        public int present;
+        public int Take(int n) => n;
+        public class Inner { }
+    }
+
+    private sealed class RealizedLazyWithoutValue
+    {
+        public bool IsValueCreated => true;
+    }
+
+    private sealed class UnrealizedLazyWithoutValue
+    {
+        public bool IsValueCreated => false;
+    }
+
+    private sealed class RealizedLazy
+    {
+        public bool Disposed { get; private set; }
+        public bool IsValueCreated => true;
+        public object Value => new Disposer(() => Disposed = true);
+
+        private sealed class Disposer(Action onDispose) : IDisposable
+        {
+            public void Dispose() => onDispose();
+        }
+    }
+
+    private sealed class ExpressionWithoutGet
+    {
+        public int Set(int _) => 0;
+    }
+
+    private sealed class MetaQueryWithoutDataItems
+    {
+        public int Id => 1;
+    }
+
+    private sealed class MetaQueryWithDataItems
+    {
+        public IList DataItems { get; } = new List<object> { new(), new() };
+    }
+
+    private sealed class AttributeWithoutTargetObjectId
+    {
+        public string TargetMethodName => "OnAfterInsert";
+    }
+
+    private sealed class SubscriberMethodInfo(object? attribute)
+    {
+        public object? Attribute { get; } = attribute;
+    }
+}

--- a/AlRunner/BcCompiler.Incremental.cs
+++ b/AlRunner/BcCompiler.Incremental.cs
@@ -168,6 +168,7 @@ using NavCA = Microsoft.Dynamics.Nav.CodeAnalysis;
 using NavSyntax = Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 using NavEmit = Microsoft.Dynamics.Nav.CodeAnalysis.Emit;
 using NavSymRef = Microsoft.Dynamics.Nav.CodeAnalysis.SymbolReference;
+using AlRunner.Infrastructure;
 
 namespace AlRunner;
 
@@ -1739,8 +1740,9 @@ public sealed partial class BcCompiler
     }
 
     private static NavSymRef.ModuleDefinition CloneModuleDefinition(NavSymRef.ModuleDefinition module)
-        => (NavSymRef.ModuleDefinition)typeof(NavSymRef.ModuleDefinition)
-            .GetMethod("Clone", BindingFlags.NonPublic | BindingFlags.Instance)!.Invoke(module, null)!;
+        => (NavSymRef.ModuleDefinition)BcShape.Method(
+            typeof(NavSymRef.ModuleDefinition), "Clone", BindingFlags.NonPublic | BindingFlags.Instance,
+            "incremental AL compilation (symbol-reference cloning)").Invoke(module, null)!;
 
     /// <summary>
     /// <c>MemberwiseClone</c>, reached by reflection because it is <c>protected</c> on
@@ -1813,7 +1815,9 @@ public sealed partial class BcCompiler
     /// correctly to whichever concrete type the instance actually is.
     /// </summary>
     private static PropertyInfo RadContainerProperty(string propName)
-        => typeof(NavSymRef.IObjectContainerDefinition).GetProperty(propName)!;
+        => BcShape.Property(
+            typeof(NavSymRef.IObjectContainerDefinition), propName,
+            "incremental AL compilation (symbol-reference cloning)");
 
     /// <summary>
     /// Depth-first walk of <paramref name="root"/> and every <c>NamespaceDefinition</c> nested

--- a/AlRunner/Infrastructure/BcShapeGapException.cs
+++ b/AlRunner/Infrastructure/BcShapeGapException.cs
@@ -276,4 +276,110 @@ internal static class BcShape
         => value as IEnumerable
            ?? throw new BcShapeGapException(
                surface, member, $"holds a {value.GetType().Name}, which cannot be enumerated — {detail}");
+
+    // ── THE NULL-FORGIVING HALF (#3051) ─────────────────────────────────────────────────
+    //
+    // `t.GetProperty("X")!` is a COMPILER ANNOTATION. It throws nothing. When Microsoft moves
+    // X the lookup hands back a silent null and the NullReferenceException lands at the first
+    // USE of it — `.PropertyType`, `.GetValue`, `.Invoke` — on a line that no longer names X.
+    // MethodScopePatches.NavMethodScope_AssertError is an unfiltered catch(Exception), so on
+    // any AL-entered path that NRE is SWALLOWED and `asserterror` PASSES on a read real BC
+    // performs fine. That is an inverted result, not merely a hidden gap (#3046 measured it).
+    //
+    // The helpers below are the one-line replacement. They resolve exactly what the `!` site
+    // resolved — same BindingFlags, same overload selection — and raise a BcShapeGapException
+    // naming `Declaring.Member` when the read cannot be performed. Nothing else changes:
+    // a member that IS there comes back exactly as before.
+    //
+    // WHAT THEY ARE NOT FOR. The line in this file's header still governs. These say "the read
+    // could not be performed", so they belong on BC-internals lookups only. A lookup of the
+    // runner's OWN members (`typeof(BcRuntime).GetMethod(nameof(...))`) or of a BCL member
+    // (`typeof(string).GetField(nameof(string.Empty))`, `ValueTuple`'s Item1) is not a BC
+    // layout question at all and stays as it is — see BcInternalsNullForgivingGuardTests, which
+    // holds the remaining population to an exact per-file count.
+
+    /// <summary>Public or non-public, instance — the flags most BC-internals reads want.</summary>
+    public const BindingFlags AnyInstance =
+        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+
+    /// <summary>Public or non-public, static.</summary>
+    public const BindingFlags AnyStatic =
+        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+
+    /// <summary>
+    /// The property <paramref name="name"/> on <paramref name="declaring"/> resolved with
+    /// <paramref name="flags"/>, or a <see cref="BcShapeGapException"/> naming it.
+    /// </summary>
+    public static PropertyInfo RequiredProperty(
+        Type declaring, string name, BindingFlags flags, string surface, string? detail = null)
+        => declaring.GetProperty(name, flags)
+           ?? throw Gap(declaring, name, "property", flags, surface, detail);
+
+    /// <summary>
+    /// The method <paramref name="name"/> on <paramref name="declaring"/> resolved with
+    /// <paramref name="flags"/>, or a <see cref="BcShapeGapException"/> naming it.
+    /// </summary>
+    public static MethodInfo RequiredMethod(
+        Type declaring, string name, BindingFlags flags, string surface, string? detail = null)
+        => declaring.GetMethod(name, flags)
+           ?? throw Gap(declaring, name, "method", flags, surface, detail);
+
+    /// <summary>
+    /// The method <paramref name="name"/> whose parameter types are exactly
+    /// <paramref name="types"/>, or a <see cref="BcShapeGapException"/> naming it. The overload
+    /// filter is part of the question: a method that survives a rename but changes its parameter
+    /// list is the same "BC's layout moved" case as an absent one.
+    /// </summary>
+    public static MethodInfo RequiredMethod(
+        Type declaring, string name, BindingFlags flags, Type[] types, string surface, string? detail = null)
+        => declaring.GetMethod(name, flags, binder: null, types: types, modifiers: null)
+           ?? throw Gap(declaring, name, $"method taking ({TypeList(types)})", flags, surface, detail);
+
+    /// <summary>
+    /// The field <paramref name="name"/> on <paramref name="declaring"/> resolved with
+    /// <paramref name="flags"/>, or a <see cref="BcShapeGapException"/> naming it.
+    ///
+    /// <para>Deliberately NOT the hierarchy walk <see cref="RequiredField(Type, string, string, string)"/>
+    /// does: these sites replace a <c>GetField(name, flags)</c> that never walked either, and
+    /// silently widening the search would change which member a converted site resolves.</para>
+    /// </summary>
+    public static FieldInfo RequiredField(
+        Type declaring, string name, BindingFlags flags, string surface, string? detail = null)
+        => declaring.GetField(name, flags)
+           ?? throw Gap(declaring, name, "field", flags, surface, detail);
+
+    /// <summary>
+    /// The constructor of <paramref name="declaring"/> taking exactly <paramref name="types"/>,
+    /// or a <see cref="BcShapeGapException"/> naming the signature that was looked for.
+    /// </summary>
+    public static ConstructorInfo RequiredConstructor(
+        Type declaring, BindingFlags flags, Type[] types, string surface, string? detail = null)
+        => declaring.GetConstructor(flags, binder: null, types: types, modifiers: null)
+           ?? throw new BcShapeGapException(
+               surface,
+               $"{declaring.Name}..ctor({TypeList(types)})",
+               detail ?? $"constructor not found — the runner constructs it to serve {surface}; BC's layout has moved");
+
+    /// <inheritdoc cref="RequiredConstructor(Type, BindingFlags, Type[], string, string?)"/>
+    public static ConstructorInfo RequiredConstructor(
+        Type declaring, Type[] types, string surface, string? detail = null)
+        => RequiredConstructor(declaring, AnyInstance, types, surface, detail);
+
+    /// <summary>
+    /// The nested type <paramref name="name"/> on <paramref name="declaring"/>, or a
+    /// <see cref="BcShapeGapException"/> naming it.
+    /// </summary>
+    public static Type RequiredNestedType(
+        Type declaring, string name, BindingFlags flags, string surface, string? detail = null)
+        => declaring.GetNestedType(name, flags)
+           ?? throw Gap(declaring, name, "nested type", flags, surface, detail);
+
+    private static BcShapeGapException Gap(
+        Type declaring, string name, string kind, BindingFlags flags, string surface, string? detail)
+        => new(surface,
+               $"{declaring.Name}.{name}",
+               detail ?? $"{kind} not found with {flags} — the runner reads it to serve {surface}; BC's layout has moved");
+
+    private static string TypeList(Type[] types)
+        => types.Length == 0 ? "" : string.Join(", ", Array.ConvertAll(types, t => t.Name));
 }

--- a/AlRunner/Infrastructure/BcShapeGapException.cs
+++ b/AlRunner/Infrastructure/BcShapeGapException.cs
@@ -284,21 +284,26 @@ internal static class BcShape
     // USE of it — `.PropertyType`, `.GetValue`, `.Invoke` — on a line that no longer names X.
     // MethodScopePatches.NavMethodScope_AssertError is an unfiltered catch(Exception), so on
     // any AL-entered path that NRE is SWALLOWED and `asserterror` PASSES on a read real BC
-    // performs fine. That is an inverted result, not merely a hidden gap (#3046 measured it).
+    // performs fine. That is an INVERTED result, not merely a hidden gap (#3046 measured it:
+    // every one of its AssertError arms failed pre-fix with "No exception was thrown").
     //
-    // The helpers below are the one-line replacement. They resolve exactly what the `!` site
-    // resolved — same BindingFlags, same overload selection — and raise a BcShapeGapException
-    // naming `Declaring.Member` when the read cannot be performed. Nothing else changes:
-    // a member that IS there comes back exactly as before.
+    // The helpers below are the one-line replacement. Each overload resolves EXACTLY what the
+    // `!` site resolved — the same BindingFlags, the same overload filter, the same defaults
+    // when the site passed none — and raises a BcShapeGapException naming `Declaring.Member`
+    // when the read cannot be performed. A member that IS there comes back unchanged, which is
+    // why converting a site is not a behaviour change on any BC build where BC's layout is what
+    // the runner was written against. Widening the flags WOULD be a behaviour change (a
+    // non-public member could start shadowing a public one), so no overload does it implicitly.
     //
-    // WHAT THEY ARE NOT FOR. The line in this file's header still governs. These say "the read
+    // WHAT THEY ARE NOT FOR. The line in this file's header still governs: they say "the read
     // could not be performed", so they belong on BC-internals lookups only. A lookup of the
-    // runner's OWN members (`typeof(BcRuntime).GetMethod(nameof(...))`) or of a BCL member
-    // (`typeof(string).GetField(nameof(string.Empty))`, `ValueTuple`'s Item1) is not a BC
-    // layout question at all and stays as it is — see BcInternalsNullForgivingGuardTests, which
-    // holds the remaining population to an exact per-file count.
+    // runner's OWN members (`typeof(BcRuntime).GetMethod(nameof(...))`), of a BCL member
+    // (`typeof(string).GetField(nameof(string.Empty))`), or of a framework tuple's Item1 is not
+    // a question about BC's layout at all and stays as it is —
+    // AlRunner.Tests/BcInternalsNullForgivingGuardTests holds that remaining population to an
+    // exact per-file count so the classification cannot rot silently.
 
-    /// <summary>Public or non-public, instance — the flags most BC-internals reads want.</summary>
+    /// <summary>Public or non-public, instance.</summary>
     public const BindingFlags AnyInstance =
         BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
 
@@ -307,78 +312,101 @@ internal static class BcShape
         BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
 
     /// <summary>
-    /// The property <paramref name="name"/> on <paramref name="declaring"/> resolved with
-    /// <paramref name="flags"/>, or a <see cref="BcShapeGapException"/> naming it.
+    /// <c>declaring.GetProperty(name)</c>, or a <see cref="BcShapeGapException"/> naming it.
     /// </summary>
-    public static PropertyInfo RequiredProperty(
+    public static PropertyInfo Property(
+        Type declaring, string name, string surface, string? detail = null)
+        => declaring.GetProperty(name)
+           ?? throw Gap(declaring, name, "property", null, surface, detail);
+
+    /// <summary>
+    /// <c>declaring.GetProperty(name, flags)</c>, or a <see cref="BcShapeGapException"/> naming it.
+    /// </summary>
+    public static PropertyInfo Property(
         Type declaring, string name, BindingFlags flags, string surface, string? detail = null)
         => declaring.GetProperty(name, flags)
            ?? throw Gap(declaring, name, "property", flags, surface, detail);
 
     /// <summary>
-    /// The method <paramref name="name"/> on <paramref name="declaring"/> resolved with
-    /// <paramref name="flags"/>, or a <see cref="BcShapeGapException"/> naming it.
+    /// <c>declaring.GetMethod(name)</c>, or a <see cref="BcShapeGapException"/> naming it.
     /// </summary>
-    public static MethodInfo RequiredMethod(
+    public static MethodInfo Method(
+        Type declaring, string name, string surface, string? detail = null)
+        => declaring.GetMethod(name)
+           ?? throw Gap(declaring, name, "method", null, surface, detail);
+
+    /// <summary>
+    /// <c>declaring.GetMethod(name, flags)</c>, or a <see cref="BcShapeGapException"/> naming it.
+    /// </summary>
+    public static MethodInfo Method(
         Type declaring, string name, BindingFlags flags, string surface, string? detail = null)
         => declaring.GetMethod(name, flags)
            ?? throw Gap(declaring, name, "method", flags, surface, detail);
 
     /// <summary>
-    /// The method <paramref name="name"/> whose parameter types are exactly
-    /// <paramref name="types"/>, or a <see cref="BcShapeGapException"/> naming it. The overload
-    /// filter is part of the question: a method that survives a rename but changes its parameter
+    /// The <paramref name="name"/> overload taking exactly <paramref name="types"/>, or a
+    /// <see cref="BcShapeGapException"/> naming the signature that was looked for. The overload
+    /// filter is part of the question: a method that keeps its name but changes its parameter
     /// list is the same "BC's layout moved" case as an absent one.
     /// </summary>
-    public static MethodInfo RequiredMethod(
+    public static MethodInfo Method(
         Type declaring, string name, BindingFlags flags, Type[] types, string surface, string? detail = null)
         => declaring.GetMethod(name, flags, binder: null, types: types, modifiers: null)
-           ?? throw Gap(declaring, name, $"method taking ({TypeList(types)})", flags, surface, detail);
+           ?? throw Gap(declaring, $"{name}({TypeList(types)})", "method", flags, surface, detail);
 
     /// <summary>
-    /// The field <paramref name="name"/> on <paramref name="declaring"/> resolved with
-    /// <paramref name="flags"/>, or a <see cref="BcShapeGapException"/> naming it.
+    /// <c>declaring.GetField(name, flags)</c>, or a <see cref="BcShapeGapException"/> naming it.
     ///
-    /// <para>Deliberately NOT the hierarchy walk <see cref="RequiredField(Type, string, string, string)"/>
-    /// does: these sites replace a <c>GetField(name, flags)</c> that never walked either, and
-    /// silently widening the search would change which member a converted site resolves.</para>
+    /// <para>Deliberately NOT the hierarchy walk
+    /// <see cref="RequiredField(Type, string, string, string)"/> does: a converted site replaces
+    /// a <c>GetField(name, flags)</c> that never walked either, and widening the search would
+    /// change which member the site resolves.</para>
     /// </summary>
-    public static FieldInfo RequiredField(
+    public static FieldInfo Field(
         Type declaring, string name, BindingFlags flags, string surface, string? detail = null)
         => declaring.GetField(name, flags)
            ?? throw Gap(declaring, name, "field", flags, surface, detail);
 
     /// <summary>
-    /// The constructor of <paramref name="declaring"/> taking exactly <paramref name="types"/>,
-    /// or a <see cref="BcShapeGapException"/> naming the signature that was looked for.
+    /// <c>declaring.GetConstructor(types)</c> (public instance), or a
+    /// <see cref="BcShapeGapException"/> naming the signature that was looked for.
     /// </summary>
-    public static ConstructorInfo RequiredConstructor(
-        Type declaring, BindingFlags flags, Type[] types, string surface, string? detail = null)
-        => declaring.GetConstructor(flags, binder: null, types: types, modifiers: null)
-           ?? throw new BcShapeGapException(
-               surface,
-               $"{declaring.Name}..ctor({TypeList(types)})",
-               detail ?? $"constructor not found — the runner constructs it to serve {surface}; BC's layout has moved");
-
-    /// <inheritdoc cref="RequiredConstructor(Type, BindingFlags, Type[], string, string?)"/>
-    public static ConstructorInfo RequiredConstructor(
+    public static ConstructorInfo Constructor(
         Type declaring, Type[] types, string surface, string? detail = null)
-        => RequiredConstructor(declaring, AnyInstance, types, surface, detail);
+        => declaring.GetConstructor(types)
+           ?? throw CtorGap(declaring, types, surface, detail);
 
     /// <summary>
-    /// The nested type <paramref name="name"/> on <paramref name="declaring"/>, or a
-    /// <see cref="BcShapeGapException"/> naming it.
+    /// <c>declaring.GetConstructor(flags, null, types, null)</c>, or a
+    /// <see cref="BcShapeGapException"/> naming the signature that was looked for.
     /// </summary>
-    public static Type RequiredNestedType(
+    public static ConstructorInfo Constructor(
+        Type declaring, BindingFlags flags, Type[] types, string surface, string? detail = null)
+        => declaring.GetConstructor(flags, binder: null, types: types, modifiers: null)
+           ?? throw CtorGap(declaring, types, surface, detail);
+
+    /// <summary>
+    /// <c>declaring.GetNestedType(name, flags)</c>, or a <see cref="BcShapeGapException"/>
+    /// naming it.
+    /// </summary>
+    public static Type NestedType(
         Type declaring, string name, BindingFlags flags, string surface, string? detail = null)
         => declaring.GetNestedType(name, flags)
            ?? throw Gap(declaring, name, "nested type", flags, surface, detail);
 
     private static BcShapeGapException Gap(
-        Type declaring, string name, string kind, BindingFlags flags, string surface, string? detail)
+        Type declaring, string name, string kind, BindingFlags? flags, string surface, string? detail)
         => new(surface,
                $"{declaring.Name}.{name}",
-               detail ?? $"{kind} not found with {flags} — the runner reads it to serve {surface}; BC's layout has moved");
+               detail ?? $"{kind} not found{(flags is { } f ? $" with {f}" : "")} — the runner reads it "
+                        + $"to serve {surface}; BC's layout for this member has moved");
+
+    private static BcShapeGapException CtorGap(
+        Type declaring, Type[] types, string surface, string? detail)
+        => new(surface,
+               $"{declaring.Name}..ctor({TypeList(types)})",
+               detail ?? $"constructor not found — the runner constructs it to serve {surface}; "
+                        + "BC's layout for this type has moved");
 
     private static string TypeList(Type[] types)
         => types.Length == 0 ? "" : string.Join(", ", Array.ConvertAll(types, t => t.Name));

--- a/AlRunner/Infrastructure/ExecutionSchedulerShutdown.cs
+++ b/AlRunner/Infrastructure/ExecutionSchedulerShutdown.cs
@@ -14,6 +14,7 @@
 // LazyEx field and its IsValueCreated flag.
 
 using System.Reflection;
+using AlRunner.Infrastructure;
 
 namespace AlRunner.Infrastructure;
 
@@ -63,7 +64,8 @@ public static class ExecutionSchedulerShutdown
             ?? throw new InvalidOperationException($"{lazyType.FullName} has no IsValueCreated — BC LazyEx shape changed");
         if (!(bool)isCreated.GetValue(lazyScheduler)!) return Outcome.NotRealized;
 
-        var value = lazyType.GetProperty("Value", BindingFlags.Public | BindingFlags.Instance)!.GetValue(lazyScheduler);
+        var value = BcShape.Property(
+            lazyType, "Value", BindingFlags.Public | BindingFlags.Instance, "task-scheduler shutdown").GetValue(lazyScheduler);
         if (value is IDisposable disposable) disposable.Dispose();
         return Outcome.Disposed;
     }

--- a/AlRunner/Infrastructure/RootTreeObject.cs
+++ b/AlRunner/Infrastructure/RootTreeObject.cs
@@ -1,6 +1,7 @@
 // RootTreeObject — concrete ITreeObject used as the parent of the skeleton root scope.
 // Its TreeHandler.hostObject must be non-null so TreeHandler.IsDisposed returns false.
 using System.Reflection;
+using AlRunner.Infrastructure;
 
 namespace AlRunner.Infrastructure;
 
@@ -16,8 +17,9 @@ internal sealed class RootTreeObject : Microsoft.Dynamics.Nav.Runtime.ITreeObjec
 internal sealed class RootHandler : Microsoft.Dynamics.Nav.Runtime.TreeHandler
 {
     private static readonly FieldInfo _fHost =
-        typeof(Microsoft.Dynamics.Nav.Runtime.TreeHandler)
-            .GetField("hostObject", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        BcShape.Field(
+            typeof(Microsoft.Dynamics.Nav.Runtime.TreeHandler), "hostObject",
+            BindingFlags.NonPublic | BindingFlags.Instance, "tree-object host binding");
     public RootHandler(Microsoft.Dynamics.Nav.Runtime.ITreeObject host) : base()
     {
         // IsDisposed = (hostObject == null) — flip it.

--- a/AlRunner/Patches/AlCompilerStreamPatches.cs
+++ b/AlRunner/Patches/AlCompilerStreamPatches.cs
@@ -44,6 +44,7 @@
 // real .NET stream's bytes.
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using AlRunner.Infrastructure;
 
 namespace AlRunner;
 
@@ -70,14 +71,15 @@ public static partial class BcRuntime
 
         if (obj == null)
         {
-            _mNavOutStreamDefault ??= tNavOutStream.GetMethod("Default",
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static,
-                null, new[] { tITreeObject }, null)!;
+            _mNavOutStreamDefault ??= BcShape.Method(
+                tNavOutStream, "Default", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static,
+                new[] { tITreeObject }, "AL InStream/OutStream construction");
             return _mNavOutStreamDefault.Invoke(null, new[] { parentOfResult })!;
         }
 
-        _pNavDotNetValue ??= obj.GetType().GetProperty("Value",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!;
+        _pNavDotNetValue ??= BcShape.Property(
+            obj.GetType(), "Value", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            "AL InStream/OutStream construction");
         var value = _pNavDotNetValue.GetValue(obj);
         if (value is System.IO.Stream stream)
         {
@@ -86,17 +88,17 @@ public static partial class BcRuntime
             {
                 var tProvider = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.NavStreamProvider")!;
                 var tIContainer = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.ITreeSharedObjectContainer")!;
-                _ctorNavStreamProviderFromStream = tProvider.GetConstructor(
-                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
-                    null, new[] { typeof(System.IO.Stream), tIContainer }, null)!;
+                _ctorNavStreamProviderFromStream = BcShape.Constructor(
+                    tProvider, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                    new[] { typeof(System.IO.Stream), tIContainer }, "AL InStream/OutStream construction");
             }
             var provider = _ctorNavStreamProviderFromStream.Invoke(new object[] { stream, container });
             if (_ctorNavOutStream == null)
             {
                 var tINavStreamProvider = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.INavStreamProvider")!;
-                _ctorNavOutStream = tNavOutStream.GetConstructor(
-                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
-                    null, new[] { tITreeObject, tINavStreamProvider }, null)!;
+                _ctorNavOutStream = BcShape.Constructor(
+                    tNavOutStream, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                    new[] { tITreeObject, tINavStreamProvider }, "AL InStream/OutStream construction");
             }
             return _ctorNavOutStream.Invoke(new[] { parentOfResult, provider })!;
         }
@@ -107,7 +109,8 @@ public static partial class BcRuntime
             var tEx = AppDomain.CurrentDomain.GetAssemblies()
                 .Select(a => a.GetType("Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLConversionException"))
                 .First(t => t != null)!;
-            _ctorNavNclConversionException = tEx.GetConstructor(new[] { typeof(Type), typeof(Type) })!;
+            _ctorNavNclConversionException = BcShape.Constructor(
+                tEx, new[] { typeof(Type), typeof(Type) }, "AL InStream/OutStream construction");
         }
         throw (Exception)_ctorNavNclConversionException.Invoke(new object[] { obj.GetType(), tNavOutStream });
     }
@@ -127,14 +130,15 @@ public static partial class BcRuntime
 
         if (obj == null)
         {
-            _mNavInStreamDefault ??= tNavInStream.GetMethod("Default",
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static,
-                null, new[] { tITreeObject }, null)!;
+            _mNavInStreamDefault ??= BcShape.Method(
+                tNavInStream, "Default", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static,
+                new[] { tITreeObject }, "AL InStream/OutStream construction");
             return _mNavInStreamDefault.Invoke(null, new[] { parentOfResult })!;
         }
 
-        _pNavDotNetValue ??= obj.GetType().GetProperty("Value",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!;
+        _pNavDotNetValue ??= BcShape.Property(
+            obj.GetType(), "Value", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            "AL InStream/OutStream construction");
         var value = _pNavDotNetValue.GetValue(obj);
         if (value is System.IO.Stream stream)
         {
@@ -143,9 +147,9 @@ public static partial class BcRuntime
             {
                 var tProvider = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.NavStreamProvider")!;
                 var tIContainer = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.ITreeSharedObjectContainer")!;
-                _ctorNavStreamProviderFromStream = tProvider.GetConstructor(
-                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
-                    null, new[] { typeof(System.IO.Stream), tIContainer }, null)!;
+                _ctorNavStreamProviderFromStream = BcShape.Constructor(
+                    tProvider, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                    new[] { typeof(System.IO.Stream), tIContainer }, "AL InStream/OutStream construction");
             }
             // Same NavStreamProvider type the OutStream direction uses above — it is
             // shared infrastructure, not tied to In vs Out.
@@ -153,9 +157,9 @@ public static partial class BcRuntime
             if (_ctorNavInStream == null)
             {
                 var tINavStreamProvider = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.INavStreamProvider")!;
-                _ctorNavInStream = tNavInStream.GetConstructor(
-                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
-                    null, new[] { tITreeObject, tINavStreamProvider }, null)!;
+                _ctorNavInStream = BcShape.Constructor(
+                    tNavInStream, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                    new[] { tITreeObject, tINavStreamProvider }, "AL InStream/OutStream construction");
             }
             return _ctorNavInStream.Invoke(new[] { parentOfResult, provider })!;
         }
@@ -166,7 +170,8 @@ public static partial class BcRuntime
             var tEx = AppDomain.CurrentDomain.GetAssemblies()
                 .Select(a => a.GetType("Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLConversionException"))
                 .First(t => t != null)!;
-            _ctorNavNclConversionException = tEx.GetConstructor(new[] { typeof(Type), typeof(Type) })!;
+            _ctorNavNclConversionException = BcShape.Constructor(
+                tEx, new[] { typeof(Type), typeof(Type) }, "AL InStream/OutStream construction");
         }
         throw (Exception)_ctorNavNclConversionException.Invoke(new object[] { obj.GetType(), tNavInStream });
     }
@@ -190,7 +195,8 @@ public static partial class BcRuntime
             var navNcl = NclAssembly();
             var tContainer = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.TreeSharedObjectContainer")!;
             var tITree = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.ITreeObject")!;
-            _skeletonSharedObjectContainer = tContainer.GetConstructor(new[] { tITree })!
+            _skeletonSharedObjectContainer = BcShape.Constructor(
+                tContainer, new[] { tITree }, "AL InStream/OutStream construction")
                 .Invoke(new object?[] { RootTreeStub });
         }
         return _skeletonSharedObjectContainer;

--- a/AlRunner/Patches/AsyncStateMachineSpike.cs
+++ b/AlRunner/Patches/AsyncStateMachineSpike.cs
@@ -147,9 +147,9 @@ public static partial class BcRuntime
         var tree = treeProp!.GetValue(self)!;
 
         var treeType = tree.GetType();
-        var mGet = treeType.GetMethod("GetReferenceTarget",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
-            null, Type.EmptyTypes, null)!;
+        var mGet = BcShape.Method(
+            treeType, "GetReferenceTarget", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            Type.EmptyTypes, "async AL method dispatch");
         var existing = mGet.Invoke(tree, null);
         if (existing != null) return existing;
 
@@ -169,9 +169,9 @@ public static partial class BcRuntime
         var ctor = _sharedNavObjectDictCtorByClosed.GetOrAdd(selfType, _ =>
         {
             var closedShared = _tSharedNavObjectDictionaryOpen!.MakeGenericType(typeArgs);
-            return closedShared.GetConstructor(
-                BindingFlags.Public | BindingFlags.Instance,
-                null, new[] { _tITreeSharedObjectContainer! }, null)!;
+            return BcShape.Constructor(
+                closedShared, BindingFlags.Public | BindingFlags.Instance, new[] { _tITreeSharedObjectContainer! },
+                "async AL method dispatch");
         });
 
         // Lazily build the skeleton container if NavRecordRef.get_Target hasn't yet.
@@ -181,7 +181,8 @@ public static partial class BcRuntime
                 .First(a => a.GetName().Name == "Microsoft.Dynamics.Nav.Ncl");
             var tContainer = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.TreeSharedObjectContainer")!;
             var tITree = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.ITreeObject")!;
-            _skeletonSharedObjectContainer = tContainer.GetConstructor(new[] { tITree })!
+            _skeletonSharedObjectContainer = BcShape.Constructor(
+                tContainer, new[] { tITree }, "async AL method dispatch")
                 .Invoke(new object?[] { RootTreeStub });
         }
 

--- a/AlRunner/Patches/CodeunitEventDispatcher.cs
+++ b/AlRunner/Patches/CodeunitEventDispatcher.cs
@@ -11,6 +11,7 @@
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using AlRunner.Patches;
+using AlRunner.Infrastructure;
 
 namespace AlRunner;
 
@@ -705,8 +706,8 @@ public static partial class BcRuntime
         if (vt.IsGenericType
             && vt.GetGenericTypeDefinition() == typeof(Microsoft.Dynamics.Nav.Runtime.ByRef<>))
         {
-            object? inner = vt
-                .GetProperty("Value", BindingFlags.Public | BindingFlags.Instance)!
+            object? inner = BcShape.Property(
+                vt, "Value", BindingFlags.Public | BindingFlags.Instance, "AL event dispatch (var parameter)")
                 .GetValue(value);
             return CoerceArg(inner, paramType);
         }

--- a/AlRunner/Patches/EventSubscriberPatches.cs
+++ b/AlRunner/Patches/EventSubscriberPatches.cs
@@ -1289,18 +1289,21 @@ public static class EventSubscriberPatches
         var original = attrProp?.GetValue(methodInfoObj);
         if (original == null) return;
         var oType = original.GetType();
-        var targetObjectId = oType.GetProperty("TargetObjectId")!.GetValue(original)!;
+        var targetObjectId = BcShape.Property(
+            oType, "TargetObjectId", "event-subscriber inventory").GetValue(original)!;
         var oidT = targetObjectId.GetType();
-        var ot = (int)oidT.GetProperty("ObjectType")!.GetValue(targetObjectId)!;
-        var on = (int)oidT.GetProperty("ObjectNumber")!.GetValue(targetObjectId)!;
-        var methodName = (string)oType.GetProperty("TargetMethodName")!.GetValue(original)!;
-        var memberId = (int)oType.GetProperty("MemberId")!.GetValue(original)!;
+        var ot = (int)BcShape.Property(oidT, "ObjectType", "event-subscriber inventory").GetValue(targetObjectId)!;
+        var on = (int)BcShape.Property(oidT, "ObjectNumber", "event-subscriber inventory").GetValue(targetObjectId)!;
+        var methodName = (string)BcShape.Property(
+            oType, "TargetMethodName", "event-subscriber inventory").GetValue(original)!;
+        var memberId = (int)BcShape.Property(oType, "MemberId", "event-subscriber inventory").GetValue(original)!;
         // Preserve the field target — for field-based events (OnBefore/OnAfterValidateEvent) the
         // NavEventSubscription ctor resolves the publisher field from these and, if it can't,
         // returns early with ErrorFieldNotFound leaving SubscriberParameters null → an NRE later
         // in TriggerPrepareParametersCallBack. Zeroing the field name (as the original code did)
         // was harmless for table-level Insert/Modify/… events but broke validate-event dispatch.
-        var fieldName = (string?)oType.GetProperty("TargetFieldName")!.GetValue(original) ?? "";
+        var fieldName = (string?)BcShape.Property(
+            oType, "TargetFieldName", "event-subscriber inventory").GetValue(original) ?? "";
         var fieldId = (int)(oType.GetProperty("TargetFieldId")?.GetValue(original) ?? 0);
         object? replacement = null;
         if (!string.IsNullOrEmpty(fieldName))

--- a/AlRunner/Patches/NavRecordRefPatches.cs
+++ b/AlRunner/Patches/NavRecordRefPatches.cs
@@ -12,6 +12,7 @@ using System.Runtime.CompilerServices;
 using AlRunner.Patches;
 using Microsoft.Dynamics.Nav.Runtime;
 using Microsoft.Dynamics.Nav.Types;
+using AlRunner.Infrastructure;
 
 namespace AlRunner;
 
@@ -306,7 +307,8 @@ public static partial class BcRuntime
         {
             var tContainer = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.TreeSharedObjectContainer")!;
             var tITree = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.ITreeObject")!;
-            _skeletonSharedObjectContainer = tContainer.GetConstructor(new[] { tITree })!
+            _skeletonSharedObjectContainer = BcShape.Constructor(
+                tContainer, new[] { tITree }, "RecordRef and stream skeleton state")
                 .Invoke(new object?[] { RootTreeStub });
         }
 
@@ -317,9 +319,9 @@ public static partial class BcRuntime
             var openShared = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.SharedNavObjectList`1")!;
             var closedShared = openShared.MakeGenericType(tArg);
             var tIContainer = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.ITreeSharedObjectContainer")!;
-            return closedShared.GetConstructor(
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
-                null, new[] { tIContainer }, null)!;
+            return BcShape.Constructor(
+                closedShared, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                new[] { tIContainer }, "RecordRef and stream skeleton state");
         });
         var shared = ctor.Invoke(new[] { _skeletonSharedObjectContainer });
         _mTreeSetReferenceTarget?.Invoke(tree, new[] { shared });
@@ -519,15 +521,17 @@ public static partial class BcRuntime
         {
             var tContainer = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.TreeSharedObjectContainer")!;
             var tITree = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.ITreeObject")!;
-            _skeletonSharedObjectContainer = tContainer.GetConstructor(new[] { tITree })!
+            _skeletonSharedObjectContainer = BcShape.Constructor(
+                tContainer, new[] { tITree }, "RecordRef and stream skeleton state")
                 .Invoke(new object?[] { RootTreeStub });
         }
         if (_ctorSharedNavStream == null)
         {
             var tShared = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.SharedNavStream")!;
             var tIContainer = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.ITreeSharedObjectContainer")!;
-            _ctorSharedNavStream = tShared.GetConstructor(
-                BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { tIContainer }, null)!;
+            _ctorSharedNavStream = BcShape.Constructor(
+                tShared, BindingFlags.NonPublic | BindingFlags.Instance, new[] { tIContainer },
+                "RecordRef and stream skeleton state");
         }
         var shared = _ctorSharedNavStream.Invoke(new object?[] { _skeletonSharedObjectContainer });
         _mTreeSetReferenceTarget?.Invoke(tree, new object?[] { shared });
@@ -567,7 +571,8 @@ public static partial class BcRuntime
         {
             var tContainer = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.TreeSharedObjectContainer")!;
             var tITree = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.ITreeObject")!;
-            _skeletonSharedObjectContainer = tContainer.GetConstructor(new[] { tITree })!
+            _skeletonSharedObjectContainer = BcShape.Constructor(
+                tContainer, new[] { tITree }, "RecordRef and stream skeleton state")
                 .Invoke(new object?[] { RootTreeStub });
         }
         if (_ctorSharedHttpReq == null)
@@ -612,7 +617,8 @@ public static partial class BcRuntime
         {
             var tContainer = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.TreeSharedObjectContainer")!;
             var tITree = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.ITreeObject")!;
-            _skeletonSharedObjectContainer = tContainer.GetConstructor(new[] { tITree })!
+            _skeletonSharedObjectContainer = BcShape.Constructor(
+                tContainer, new[] { tITree }, "RecordRef and stream skeleton state")
                 .Invoke(new object?[] { RootTreeStub });
         }
         if (_ctorSharedHttpResponseMsg == null)
@@ -656,7 +662,8 @@ public static partial class BcRuntime
         {
             var tContainer = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.TreeSharedObjectContainer")!;
             var tITree = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.ITreeObject")!;
-            _skeletonSharedObjectContainer = tContainer.GetConstructor(new[] { tITree })!
+            _skeletonSharedObjectContainer = BcShape.Constructor(
+                tContainer, new[] { tITree }, "RecordRef and stream skeleton state")
                 .Invoke(new object?[] { RootTreeStub });
         }
         if (_ctorSharedHttpClient == null)
@@ -727,8 +734,8 @@ public static partial class BcRuntime
         var navNcl = AppDomain.CurrentDomain.GetAssemblies()
             .First(a => a.GetName().Name == "Microsoft.Dynamics.Nav.Ncl");
         var tVdp = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.VirtualDataProvider")!;
-        var fPermSet = tVdp.GetField("PermissionSet",
-            BindingFlags.NonPublic | BindingFlags.Static)!;
+        var fPermSet = BcShape.Field(
+            tVdp, "PermissionSet", BindingFlags.NonPublic | BindingFlags.Static, "RecordRef and stream skeleton state");
         _allGrantedPermSet = fPermSet.GetValue(null)!;
         return _allGrantedPermSet;
     }

--- a/AlRunner/Patches/RecordPatches.NclMetaQueryBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaQueryBuilder.cs
@@ -17,6 +17,7 @@
 // builder + precompiled-query support in later tasks.
 using System.Collections;
 using System.Reflection;
+using AlRunner.Infrastructure;
 
 namespace AlRunner.Patches;
 
@@ -71,7 +72,8 @@ public static partial class RecordPatches
     }
 
     private static IList GetList(object obj, string name)
-        => (IList)obj.GetType().GetProperty(name, BindingFlags.Public | BindingFlags.Instance)!.GetValue(obj)!;
+        => (IList)BcShape.Property(
+            obj.GetType(), name, BindingFlags.Public | BindingFlags.Instance, "AL query metadata construction").GetValue(obj)!;
 
     /// <summary>
     /// Build (and cache) a real NCLMetaQuery for the given query id, or null if it

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -13,6 +13,7 @@ using System.Globalization;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Dynamics.Nav.Runtime;
+using AlRunner.Infrastructure;
 
 namespace AlRunner.Patches;
 
@@ -407,7 +408,8 @@ public static partial class RecordPatches
                     var kvpCtor = kvpType.GetConstructor(new[] { typeof(int), _tMetaField! })!;
                     for (int j = 0; j < fields.Length; j++)
                     {
-                        var fid = (int)_tMetaField!.GetProperty("Id")!.GetValue(fields[j])!;
+                        var fid = (int)BcShape.Property(
+                            _tMetaField!, "Id", "AL table metadata construction").GetValue(fields[j])!;
                         kvpArray.SetValue(kvpCtor.Invoke(new[] { (object)fid, fields[j] }), j);
                     }
                     args[i] = createRangeMethod.Invoke(null, new object[] { kvpArray })!;
@@ -1506,8 +1508,10 @@ public static partial class RecordPatches
                 if (attrs.Length == 0) continue;
                 foreach (var a in attrs)
                 {
-                    var fieldNo = (int)attrType.GetProperty("FieldNo")!.GetValue(a)!;
-                    var ttObj = attrType.GetProperty("TriggerType")!.GetValue(a)!;
+                    var fieldNo = (int)BcShape.Property(
+                        attrType, "FieldNo", "AL table metadata construction").GetValue(a)!;
+                    var ttObj = BcShape.Property(
+                        attrType, "TriggerType", "AL table metadata construction").GetValue(a)!;
                     var ttName = Enum.GetName(triggerTypeEnum, ttObj);
                     byField.TryGetValue(fieldNo, out var pair);
                     if (ttName == "OnValidate") pair.validate = mi;
@@ -1652,8 +1656,10 @@ public static partial class RecordPatches
                 if (attrs.Length == 0) continue;
                 foreach (var a in attrs)
                 {
-                    var fieldNo = (int)_tFieldTriggerHandlerAttr!.GetProperty("FieldNo")!.GetValue(a)!;
-                    var ttObj = _tFieldTriggerHandlerAttr.GetProperty("TriggerType")!.GetValue(a)!;
+                    var fieldNo = (int)BcShape.Property(
+                        _tFieldTriggerHandlerAttr!, "FieldNo", "AL table metadata construction").GetValue(a)!;
+                    var ttObj = BcShape.Property(
+                        _tFieldTriggerHandlerAttr, "TriggerType", "AL table metadata construction").GetValue(a)!;
                     var ttName = Enum.GetName(_tFieldTriggerType!, ttObj);
                     if (ttName == "OnValidate" || ttName == "OnLookup")
                     {

--- a/AlRunner/Patches/RecordPatches.QueryJoin.cs
+++ b/AlRunner/Patches/RecordPatches.QueryJoin.cs
@@ -31,6 +31,7 @@
 // forwards to the same ComputeAggregateCore the single-dataitem path uses.
 using System.Collections;
 using System.Reflection;
+using AlRunner.Infrastructure;
 
 namespace AlRunner.Patches;
 
@@ -194,7 +195,9 @@ public static partial class RecordPatches
     private static IEnumerable ExecuteJoinQuery(object nclMetaQuery, object? flowFiltersAndMarks)
     {
         EnsureJoinExecutorLoaded();
-        var queryDef = _tNCLMetaQuery!.GetProperty("QueryDefinition", BindingFlags.Public | BindingFlags.Instance)!
+        var queryDef = BcShape.Property(
+            _tNCLMetaQuery!, "QueryDefinition", BindingFlags.Public | BindingFlags.Instance,
+            "AL query execution (multi-dataitem join)")
             .GetValue(nclMetaQuery)!;
         if (!_joinSourceByQueryDef.TryGetValue(queryDef, out var dataAccessSource))
             throw RunnerShapeGap.Query(

--- a/AlRunner/Patches/RecordPatches.QueryProjection.cs
+++ b/AlRunner/Patches/RecordPatches.QueryProjection.cs
@@ -109,10 +109,16 @@ public static partial class RecordPatches
             ?? throw new InvalidOperationException("ReadOnlyRecordBuffer(NCLMetaApplicationObject, NavValue[]) ctor not found");
 
         var reqBase = nclAsm.GetType("Microsoft.Dynamics.Nav.Runtime.DataProviderRequest")!;
-        _pReqMetaAppObj = reqBase.GetProperty("MetaApplicationObject", BindingFlags.Public | BindingFlags.Instance)!;
+        _pReqMetaAppObj = BcShape.Property(
+            reqBase, "MetaApplicationObject", BindingFlags.Public | BindingFlags.Instance,
+            "AL query execution (projection and filter push-down)");
         var findReq = nclAsm.GetType("Microsoft.Dynamics.Nav.Runtime.FindProviderRequest")!;
-        _pReqFindType = findReq.GetProperty("FindType", BindingFlags.Public | BindingFlags.Instance)!;
-        _pReqTopNumberOfRows = findReq.GetProperty("TopNumberOfRowsToReturn", BindingFlags.Public | BindingFlags.Instance)!;
+        _pReqFindType = BcShape.Property(
+            findReq, "FindType", BindingFlags.Public | BindingFlags.Instance,
+            "AL query execution (projection and filter push-down)");
+        _pReqTopNumberOfRows = BcShape.Property(
+            findReq, "TopNumberOfRowsToReturn", BindingFlags.Public | BindingFlags.Instance,
+            "AL query execution (projection and filter push-down)");
     }
 
     /// <summary>
@@ -426,7 +432,10 @@ public static partial class RecordPatches
             foreach (var col in cols)
             {
                 if (IsFilterOnlyColumnQ(col)) continue;
-                _pColColumnIndexQ2 ??= _tNCLMetaQueryColumn!.GetProperty("ColumnIndex", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!;
+                _pColColumnIndexQ2 ??= BcShape.Property(
+                    _tNCLMetaQueryColumn!, "ColumnIndex",
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                    "AL query execution (projection and filter push-down)");
                 var idx = (int)_pColColumnIndexQ2.GetValue(col)!;
                 if (idx < 0) continue;
                 map[col] = idx;
@@ -489,11 +498,15 @@ public static partial class RecordPatches
             return request; // ordinary table read — nothing to translate.
 
         EnsureFilterReflection();
-        var filtersAndMarks = request.GetType().GetProperty("FiltersAndMarks", BindingFlags.Public | BindingFlags.Instance)!
+        var filtersAndMarks = BcShape.Property(
+            request.GetType(), "FiltersAndMarks", BindingFlags.Public | BindingFlags.Instance,
+            "AL query execution (projection and filter push-down)")
             .GetValue(request);
         object? filters = null;
         if (filtersAndMarks != null)
-            filters = _tFiltersAndMarks!.GetProperty("Filters", BindingFlags.Public | BindingFlags.Instance)!
+            filters = BcShape.Property(
+                _tFiltersAndMarks!, "Filters", BindingFlags.Public | BindingFlags.Instance,
+                "AL query execution (projection and filter push-down)")
                 .GetValue(filtersAndMarks);
 
         // FilterFieldDictionary.Items : Tuple<INavFieldMetadata, FilterExpression>[]
@@ -535,10 +548,14 @@ public static partial class RecordPatches
                         continue;
                     }
 
-                    var srcField = key.GetType().GetProperty("SourceTableField", BindingFlags.Public | BindingFlags.Instance)!.GetValue(key);
+                    var srcField = BcShape.Property(
+                        key.GetType(), "SourceTableField", BindingFlags.Public | BindingFlags.Instance,
+                        "AL query execution (projection and filter push-down)").GetValue(key);
                     if (srcField != null && expr != null)
                     {
-                        var srcCtx = srcField.GetType().GetProperty("ExpressionContext", BindingFlags.Public | BindingFlags.Instance)!.GetValue(srcField);
+                        var srcCtx = BcShape.Property(
+                            srcField.GetType(), "ExpressionContext", BindingFlags.Public | BindingFlags.Instance,
+                            "AL query execution (projection and filter push-down)").GetValue(srcField);
                         var retargeted = RetargetFilterExpression(expr, srcCtx!);
                         translatedTuples.Add(MakeFieldTuple(srcField, retargeted));
                         anyTranslated = true;
@@ -588,7 +605,9 @@ public static partial class RecordPatches
         // Build FilterFieldDictionary(IEnumerable<Tuple<INavFieldMetadata, FilterExpression>>)
         var newFilters = BuildFilterFieldDictionary(translatedTuples);
         var markedRecords = filtersAndMarks == null ? null
-            : _tFiltersAndMarks!.GetProperty("MarkedRecords", BindingFlags.Public | BindingFlags.Instance)!.GetValue(filtersAndMarks);
+            : BcShape.Property(
+                _tFiltersAndMarks!, "MarkedRecords", BindingFlags.Public | BindingFlags.Instance,
+                "AL query execution (projection and filter push-down)").GetValue(filtersAndMarks);
         var newFam = Activator.CreateInstance(_tFiltersAndMarks!, newFilters, markedRecords)!;
         return CloneRequestWithFilters(request, newFam);
     }
@@ -685,8 +704,12 @@ public static partial class RecordPatches
         if (_tUnaryFilterExpr!.IsInstanceOfType(expr))
         {
             // new UnaryFilterExpression(FilterExpressionType, NavValue, FilterExpressionContext, valueToken, isConstInMetadata)
-            var exprType = _tFilterExpr!.GetProperty("ExpressionType", BindingFlags.Public | BindingFlags.Instance)!.GetValue(expr);
-            var value = t.GetProperty("Value", BindingFlags.Public | BindingFlags.Instance)!.GetValue(expr);
+            var exprType = BcShape.Property(
+                _tFilterExpr!, "ExpressionType", BindingFlags.Public | BindingFlags.Instance,
+                "AL query execution (projection and filter push-down)").GetValue(expr);
+            var value = BcShape.Property(
+                t, "Value", BindingFlags.Public | BindingFlags.Instance,
+                "AL query execution (projection and filter push-down)").GetValue(expr);
             var ctor = _tUnaryFilterExpr.GetConstructors()
                 .First(c => c.GetParameters().Length >= 3
                     && c.GetParameters()[0].ParameterType.Name == "FilterExpressionType");
@@ -698,9 +721,15 @@ public static partial class RecordPatches
         }
         if (_tBinaryFilterExpr!.IsInstanceOfType(expr))
         {
-            var exprType = _tFilterExpr!.GetProperty("ExpressionType", BindingFlags.Public | BindingFlags.Instance)!.GetValue(expr);
-            var left = t.GetProperty("Left", BindingFlags.Public | BindingFlags.Instance)!.GetValue(expr);
-            var right = t.GetProperty("Right", BindingFlags.Public | BindingFlags.Instance)!.GetValue(expr);
+            var exprType = BcShape.Property(
+                _tFilterExpr!, "ExpressionType", BindingFlags.Public | BindingFlags.Instance,
+                "AL query execution (projection and filter push-down)").GetValue(expr);
+            var left = BcShape.Property(
+                t, "Left", BindingFlags.Public | BindingFlags.Instance,
+                "AL query execution (projection and filter push-down)").GetValue(expr);
+            var right = BcShape.Property(
+                t, "Right", BindingFlags.Public | BindingFlags.Instance,
+                "AL query execution (projection and filter push-down)").GetValue(expr);
             var newLeft = RetargetFilterExpression(left!, targetCtx);
             var newRight = RetargetFilterExpression(right!, targetCtx);
             var ctor = _tBinaryFilterExpr.GetConstructors()
@@ -718,9 +747,15 @@ public static partial class RecordPatches
         if (_tWildcardFilterExpr!.IsInstanceOfType(expr))
         {
             // public WildcardFilterExpression(bool isNegated, string pattern, bool isCaseAndAccentInsensitive, FilterExpressionContext expressionContext)
-            var isNegated = t.GetProperty("IsNegated", BindingFlags.Public | BindingFlags.Instance)!.GetValue(expr);
-            var pattern = t.GetProperty("Pattern", BindingFlags.Public | BindingFlags.Instance)!.GetValue(expr);
-            var isCaseAndAccentInsensitive = t.GetProperty("IsCaseAndAccentInsensitive", BindingFlags.Public | BindingFlags.Instance)!.GetValue(expr);
+            var isNegated = BcShape.Property(
+                t, "IsNegated", BindingFlags.Public | BindingFlags.Instance,
+                "AL query execution (projection and filter push-down)").GetValue(expr);
+            var pattern = BcShape.Property(
+                t, "Pattern", BindingFlags.Public | BindingFlags.Instance,
+                "AL query execution (projection and filter push-down)").GetValue(expr);
+            var isCaseAndAccentInsensitive = BcShape.Property(
+                t, "IsCaseAndAccentInsensitive", BindingFlags.Public | BindingFlags.Instance,
+                "AL query execution (projection and filter push-down)").GetValue(expr);
             var ctor = _tWildcardFilterExpr.GetConstructors()
                 .First(c => c.GetParameters().Length == 4 && c.GetParameters()[0].ParameterType == typeof(bool));
             return ctor.Invoke(new object?[] { isNegated, pattern, isCaseAndAccentInsensitive, targetCtx });
@@ -736,7 +771,8 @@ public static partial class RecordPatches
         // Both FindProviderRequest and PositionedFindProviderRequest share the same field
         // set; reconstruct via the full ctor pulling every other field off the original.
         var t = request.GetType();
-        object Get(string n) => t.GetProperty(n, BindingFlags.Public | BindingFlags.Instance)!.GetValue(request)!;
+        object Get(string n) => BcShape.Property(
+            t, n, BindingFlags.Public | BindingFlags.Instance, "AL query execution (projection and filter push-down)").GetValue(request)!;
         var isPositioned = t.Name == "PositionedFindProviderRequest";
         var ctor = t.GetConstructors().First(c =>
         {
@@ -800,7 +836,9 @@ public static partial class RecordPatches
         // Multi-dataitem JOIN: ignore the single-table `rows` (the root scan the engine
         // requested) and produce the joined+projected result set ourselves by reading
         // every dataitem's table. See RecordPatches.QueryJoin.cs.
-        var queryDef = _tNCLMetaQuery.GetProperty("QueryDefinition", BindingFlags.Public | BindingFlags.Instance)!
+        var queryDef = BcShape.Property(
+            _tNCLMetaQuery, "QueryDefinition", BindingFlags.Public | BindingFlags.Instance,
+            "AL query execution (projection and filter push-down)")
             .GetValue(metaAppObj);
         if (queryDef != null && IsMultiDataItemQuery(queryDef))
         {
@@ -902,7 +940,9 @@ public static partial class RecordPatches
             .GetValue(request);
         object? filters = null;
         if (fam != null)
-            filters = _tFiltersAndMarks!.GetProperty("Filters", BindingFlags.Public | BindingFlags.Instance)!
+            filters = BcShape.Property(
+                _tFiltersAndMarks!, "Filters", BindingFlags.Public | BindingFlags.Instance,
+                "AL query execution (projection and filter push-down)")
                 .GetValue(fam);
         var items = filters == null ? null : (Array?)_tFilterFieldDictionary!.GetProperty("Items", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?
             .GetValue(filters);
@@ -1375,7 +1415,9 @@ public static partial class RecordPatches
 
     private static ProjectionPlan BuildProjectionPlan(object nclMetaQuery)
     {
-        var queryDef = (NCLMetaQueryDefinition)_tNCLMetaQuery!.GetProperty("QueryDefinition", BindingFlags.Public | BindingFlags.Instance)!
+        var queryDef = (NCLMetaQueryDefinition)BcShape.Property(
+            _tNCLMetaQuery!, "QueryDefinition", BindingFlags.Public | BindingFlags.Instance,
+            "AL query execution (projection and filter push-down)")
             .GetValue(nclMetaQuery)!;
 
         var columnPlans = new List<ColumnPlan>();

--- a/AlRunner/Patches/RecordPatches.RealPageMetadata.cs
+++ b/AlRunner/Patches/RecordPatches.RealPageMetadata.cs
@@ -32,6 +32,7 @@
 //   continuing with a skeleton, which would answer TestPage questions wrongly instead of
 //   refusing to answer them.
 using System.Reflection;
+using AlRunner.Infrastructure;
 
 namespace AlRunner.Patches;
 
@@ -236,8 +237,10 @@ public static partial class RecordPatches
                 if (_fNCLMetaAppObjMetadataLoaded != null)
                     AlRunner.Infrastructure.FieldPoke.SetInstance(_fNCLMetaAppObjMetadataLoaded, meta, false);
 
-                meta.GetType()
-                    .GetMethod("LoadMetadata", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!
+                BcShape.Method(
+                    meta.GetType(), "LoadMetadata",
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                    "Page Metadata read from BC's own page metadata")
                     .Invoke(meta, null);
 
                 _pagesWithRealMetadata.Add(pageId);

--- a/AlRunner/Patches/RecordPatches.RealXmlPortMetadata.cs
+++ b/AlRunner/Patches/RecordPatches.RealXmlPortMetadata.cs
@@ -26,6 +26,7 @@
 //   something to paper over: the caller is told (null) and the skeleton is restored
 //   exactly as it was, so behaviour never silently degrades into "wrong answer" territory.
 using System.Reflection;
+using AlRunner.Infrastructure;
 
 namespace AlRunner.Patches;
 
@@ -123,8 +124,10 @@ public static partial class RecordPatches
                 if (_fNCLMetaAppObjMetadataLoaded != null)
                     AlRunner.Infrastructure.FieldPoke.SetInstance(_fNCLMetaAppObjMetadataLoaded, meta, false);
 
-                meta.GetType()
-                    .GetMethod("LoadMetadata", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!
+                BcShape.Method(
+                    meta.GetType(), "LoadMetadata",
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                    "XmlPort Metadata read from BC's own xmlport metadata")
                     .Invoke(meta, null);
 
                 _xmlPortsWithRealMetadata.Add(xmlPortId);

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -554,8 +554,9 @@ public static partial class RecordPatches
 
         // NCLMetaTable and factory (Microsoft.Dynamics.Nav.Runtime / Ncl)
         _tNCLMetaTable = nclAsm.GetType("Microsoft.Dynamics.Nav.Runtime.NCLMetaTable")!;
-        _mCreateFromMetaTable = _tNCLMetaTable.GetMethod("CreateFromMetaTable",
-            BindingFlags.NonPublic | BindingFlags.Static)!;
+        _mCreateFromMetaTable = BcShape.Method(
+            _tNCLMetaTable, "CreateFromMetaTable", BindingFlags.NonPublic | BindingFlags.Static,
+            "AL record data access");
 
         // NCLMetadata.GetMetaTableById(int,bool,int), NCLMetadata.GetMetaApplicationObject
         // (ObjectType,int,bool,int and ApplicationObjectId,bool,int), and
@@ -564,18 +565,21 @@ public static partial class RecordPatches
 
         // DataAccessTableVersionTokens.CreateForTempTable()
         var tDatv = nclAsm.GetType("Microsoft.Dynamics.Nav.Runtime.DataAccessTableVersionTokens")!;
-        _mCreateForTempTable = tDatv.GetMethod("CreateForTempTable",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)!;
+        _mCreateForTempTable = BcShape.Method(
+            tDatv, "CreateForTempTable", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static,
+            "AL record data access");
 
         // VirtualAndTempTransactionalDataCache.Instance
         var tVatdc = nclAsm.GetType("Microsoft.Dynamics.Nav.Runtime.VirtualAndTempTransactionalDataCache")!;
-        _fVatdcInstance = tVatdc.GetField("Instance",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)!;
+        _fVatdcInstance = BcShape.Field(
+            tVatdc, "Instance", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static,
+            "AL record data access");
 
         // DataAccessSource and CreateTempDataAccess
         _tDataAccessSource = nclAsm.GetType("Microsoft.Dynamics.Nav.Runtime.DataAccessSource")!;
-        _mCreateTempDataAccess = _tDataAccessSource.GetMethod("CreateTempDataAccess",
-            BindingFlags.NonPublic | BindingFlags.Instance)!;
+        _mCreateTempDataAccess = BcShape.Method(
+            _tDataAccessSource, "CreateTempDataAccess", BindingFlags.NonPublic | BindingFlags.Instance,
+            "AL record data access");
         // GetVirtualDataAccess(NCLMetaTable) — BC's real router for virtual/system tables
         // (Field=2000000041 → FieldDataProvider, AllObj=2000000038 → AllObjDataProvider, …).
         // We re-route virtual tables here instead of dumping them into the empty temp store.
@@ -938,10 +942,12 @@ public static partial class RecordPatches
         EnsureDateStoreCoversProviderRequest(self, request);
 
         var rt = request.GetType();
-        var companyToken   = (int)rt.GetProperty("CompanyToken")!.GetValue(request)!;
-        var filtersAndMarks = rt.GetProperty("FiltersAndMarks")!.GetValue(request);
-        var sourceTable    = (NCLMetaTable)rt.GetProperty("MetaApplicationObject")!.GetValue(request)!;
-        var fieldsToCalc   = (FieldList)rt.GetProperty("FieldsToCalculate")!.GetValue(request)!;
+        var companyToken   = (int)BcShape.Property(rt, "CompanyToken", "AL record data access").GetValue(request)!;
+        var filtersAndMarks = BcShape.Property(rt, "FiltersAndMarks", "AL record data access").GetValue(request);
+        var sourceTable    = (NCLMetaTable)BcShape.Property(
+            rt, "MetaApplicationObject", "AL record data access").GetValue(request)!;
+        var fieldsToCalc   = (FieldList)BcShape.Property(
+            rt, "FieldsToCalculate", "AL record data access").GetValue(request)!;
         int fieldCount     = fieldsToCalc.Count;
 
         var primaryKeySortingFields = _fTtdpPrimaryKeySortingFields!.GetValue(self);

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -34,6 +34,7 @@
 using System.Reflection;
 using AlRunner;
 using Microsoft.Dynamics.Nav.Runtime;
+using AlRunner.Infrastructure;
 
 namespace AlRunner.Patches;
 
@@ -1044,15 +1045,15 @@ internal sealed partial class RunnerPageInstance
     internal static string SourceExpressionKey(int controlId) => "Control" + controlId;
 
     internal static NavValue? GetValue(object expression)
-        => (NavValue?)expression.GetType()
-            .GetMethod("Get", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
-                binder: null, types: Type.EmptyTypes, modifiers: null)!
+        => (NavValue?)BcShape.Method(
+            expression.GetType(), "Get", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            Type.EmptyTypes, "TestPage field expression access")
             .Invoke(expression, null);
 
     internal static void SetValue(object expression, NavValue value)
-        => expression.GetType()
-            .GetMethod("Set", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
-                binder: null, types: new[] { typeof(NavValue) }, modifiers: null)!
+        => BcShape.Method(
+            expression.GetType(), "Set", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            new[] { typeof(NavValue) }, "TestPage field expression access")
             .Invoke(expression, new object?[] { value });
 
     /// <summary>

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1081,6 +1081,30 @@ because four readers of one private BC structure raised three different exceptio
 them. `AlRunner/Infrastructure/BcShapeGapException.cs` carries the full derivation, including
 why it is a separate type rather than a third reason anchor.
 
+### The `!` sweep — 73 more member lookups that used to fail as a silent null
+
+[#3051](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/3051) closed the other
+half of the same defect. `t.GetProperty("X")!` is a compiler annotation: it emits no code and
+throws nothing, so a member Microsoft has moved hands the runner a silent null and the
+`NullReferenceException` lands at the first *use* of it, on a line that no longer names X. On an
+AL-entered path `asserterror` then swallows it and **passes** — the inversion described above,
+with nothing in the output naming the member.
+
+134 such lookups existed across `AlRunner/`. 73 of them read BC's own internals and now resolve
+through `BcShape.Property` / `.Method` / `.Field` / `.Constructor`, which raise a
+`bc-shape-gap:` naming `Declaring.Member`. They span AL query execution and its filter
+push-down, table and query metadata construction, record data access, `RecordRef` and stream
+skeleton state, `InStream`/`OutStream` construction, the event-subscriber inventory, Page and
+XmlPort Metadata, TestPage field expressions, task-scheduler shutdown, and incremental AL
+compilation.
+
+The remaining 61 stay as they are on purpose, and none of them is a question about BC's layout:
+the receiver is a type in this repository (36), a BCL type (7 outright plus 4 more behind a
+local), a framework tuple's `Item1`/`Item2` (8), the runner's own side-loaded
+`AlRunner.QueryJoin.dll` (4), or an artifact the runner emitted itself (2).
+`AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs` holds that classification to an exact
+count in both directions, so neither adding a lookup nor quietly dropping one goes unnoticed.
+
 Two shape gaps live on the TestPage surface
 ([#2999](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2999)), and both are
 reached only when BC's own metadata is not the shape the runner reads:


### PR DESCRIPTION
Closes #3051

`t.GetProperty("X")!` is a compiler annotation. It emits no code and throws nothing, so a
member Microsoft has moved hands the runner a silent null and the `NullReferenceException`
lands at the first *use* of it — `.PropertyType`, `.GetValue`, `.Invoke` — on a line that no
longer names X. `MethodScopePatches.NavMethodScope_AssertError` is an unfiltered
`catch(Exception)`, so on any AL-entered path that NRE is swallowed and `asserterror`
**passes** on a read real BC performs fine. That is an inverted result, not merely a hidden
gap, and #2994's sweep could not see any of it because its search shape is a `throw`.

## The count: 134, not 143 — and the difference is a defect in the measurement, not drift

I re-measured against `origin/main` (`1d308c90` when I started; the branch is now rebased onto
`65e5e562`, and the number is the same on both).

| measurement | result |
|---|---|
| the issue's regex, statement-joined, on `origin/main` | **142** (the issue said 143; #3051's own comment already re-measured 142) |
| an actual parse — balanced parens, comment- and string-aware, `!=` excluded | **134** |

The 142 is high for two independent reasons, and both are properties of a statement-level
regex rather than of the tree:

- **Eight `!=` comparisons counted as null-forgiving `!`.** `at.GetProperty("TargetMethodName")?.GetValue(a) != name`
  matches `\)\s*!` on the `!` of `!=`. `InstallTriggerRunner.cs`, `AllProfileWritePatches.cs`,
  `RecordPatches.FeatureKeyVirtualTable.cs`, `AlCoverageInstrumentedStatements.cs`,
  `NclCecilRewrite.cs` and `TestExecutor.cs` are in the 37-file list for this reason alone and
  contain no null-forgiving member lookup at all.
- **Statements holding two sites counted once.** Six `EventSubscriberPatches.cs` lines, the
  `Item1`/`Item2` tuple pairs, and the `Left`/`Right` filter reads each collapse.

Those pull in opposite directions and do not cancel: the real per-site population is 134.
The scanner is in `AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs` and has its own test
arm proving it ignores `!=`, comments and string literals — so the number is reproducible
rather than asserted.

## What changed

**73 lookups that read BC's own internals** now resolve through `BcShape.Property` /
`.Method` / `.Field` / `.Constructor`, which raise a `BcShapeGapException` naming
`Declaring.Member`. 16 files: AL query execution and its filter push-down, table and query
metadata construction, record data access, `RecordRef` and stream skeleton state,
`InStream`/`OutStream` construction, the event-subscriber inventory, Page and XmlPort
Metadata, TestPage field expressions, task-scheduler shutdown, incremental AL compilation.

Each overload resolves **exactly** what the `!` site resolved — same `BindingFlags`, same
overload filter, the same defaults where the site passed none. Widening `Public | Instance` to
`Public | NonPublic | Instance` would be a real behaviour change (a non-public member could
start shadowing the public one), so no overload does it implicitly and two test arms pin that.

**61 remain, every one classified**, and none is a question about BC's layout: the receiver is
a type in this repository (36), a BCL type (7 outright, 4 more behind a local), a framework
tuple's `Item1`/`Item2` (8), the runner's own side-loaded `AlRunner.QueryJoin.dll` (4), or an
artifact the runner emitted itself (2). The guard holds that to an exact count **in both
directions** — adding a lookup fails, and so does quietly dropping one.

Five sites the mechanical pass converted were reverted after checking what the receiver
actually is: `_tJoinExecutor` / `_tJoinContext` are `AlRunner.QueryJoin.dll`, the runner's own
side-loaded assembly, and `arrType` is `ImmutableArray<T>`. Calling either a `bc-shape-gap:`
would have been a false claim about BC.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** That is the whole PR — the issue named one
   file's worth and the sweep is repo-wide.
2. **Sibling function with the same assumption?** Yes, and it narrows the issue's claim.
   `NavApplicationObjectBase_TryInvoke` — the `[TryFunction]` seam — does **not** swallow the
   NRE: it swallows a trappable `NavBaseException` and a permanently out-of-scope refusal and
   rethrows everything else. So the inversion lives at **one** seam, `asserterror`, not both.
   `TryFunction_LetsTheNreThrough_SoTheInversionIsTheAssertErrorSeamOnly` pins that, because
   the difference between "AL cannot see this" and "AL sees the wrong answer" is the difference
   between a hidden gap and a green test that lies.
3. **Two paths writing the same state with different invariants?** `BcShape` already had a
   `RequiredMethod(declaring, name, flags, surface, member, detail, types)` taking an explicit
   member string. Rather than overload it into ambiguity, the new family is named
   `Property`/`Method`/`Field`/`Constructor`/`NestedType` and derives the member name; the
   header says which is for what. One pre-existing name-only lookup ratchet moved as a
   consequence — see below.

## Proving tests

`AlRunner.Tests/BcShapeNullForgivingLookupTests.cs` (25 arms) and
`AlRunner.Tests/BcInternalsNullForgivingGuardTests.cs` (4 arms).

**RED, measured, not asserted.** With `EventSubscriberPatches.cs` reverted to `origin/main`,
three guard arms fail and the message names all six sites. With the four production files
behind the production-path arms reverted, five behavioural arms fail:

```
Assert.Throws() Failure: Exception type was not an exact match
Actual:   typeof(System.NullReferenceException)
```

and, for the arm that drives `RunnerPageInstance.GetValue` through
`NavMethodScope_AssertError`:

```
Assert.Throws() Failure: No exception was thrown
```

That second one **is** the inversion: the seam swallowed the NRE and `asserterror` came back
clean on a read real BC performs fine. GREEN after restoring: 25/25 and 4/4.

The behavioural file covers each overload with a refusal arm **and** a control that still
returns the real member (a helper that threw unconditionally would fail here, not pass), both
flags-fidelity arms, both AL seams with a control proving the seams still trap what they should,
and four converted **production** call sites driven with a fake type standing in for a BC type
whose member has moved — `ExecutionSchedulerShutdown.DisposeIfRealized`,
`RunnerPageInstance.GetValue`, `RecordPatches.GetList` and
`EventSubscriberPatches.ReplaceAttributeWithZeroedCopy`.

The guard file additionally pins the 73 **converted** sites, because the population count alone
would stay green if someone deleted every `BcShape.Property` call and put the `!` back.

## Does this PR assert anything about what BC does? No — and the corpus cannot adjudicate it

It asserts what the **runner** does when it cannot read BC's internals. On every BC build in
the matrix (27.0–28.4) these members are present, so what AL observes is byte-for-byte
unchanged; the behaviour only differs on a build where a member has moved, which is precisely
the case a service tier cannot be asked to produce. That puts it in
`bc-behavior-tests-go-upstream.md`'s runner-specific column, next to "`RunnerOutOfScopeException`
thrown with a specific reason on a specific surface".

`tests/runner-extras/` cannot express it either, and for the same reason rather than a
different one: a runner-extras bundle is AL, and no AL can reach a shape gap on a BC build
whose members are all there. Reaching one requires injecting a fake type into the production
call path, which is a C# mechanism test — the shape #3046 used and the shape here.

**No corpus PR, and none is owed.** I did run the corpus rather than assume: 2676/2676 on the
`--package-cache "$HOME/.al-runner/platform-apps"` invocation CI uses.

## Same-file batching (#3215): nothing folded, and why

Seven open issues name a file this PR edits. None of their fixes lands in the same *code*:

- **#2994** (`BcShapeGapException.cs`) — the umbrella sweep for `throw` sites: 233 of them, a
  different search shape from this one, and #3051 exists precisely because #2994 cannot see a
  `!`. Folding 233 per-site reclassifications on top of 73 fails the "one coherent change"
  test outright.
- **#3236** (`RecordPatches.cs`) — Object Metadata's payload refusal being disarmed by the
  runner's own synthesised rows. Same file, different region, and its judgement is about which
  rows are real, not about reading a BC member.
- **#3216** (`RecordPatches.NclMetaTableBuilder.cs`) — tableextension-declared keys missing from
  key metadata: the key-building function, not the trigger/field reads touched here.
- **#3121** (`NclMetaTableBuilder.cs`, `QueryProjection.cs`) — in flight as PR #3180 under
  `agent: fbk-1`. Not mine to touch.
- **#2929** and **#2655** (`BcCompiler.Incremental.cs`) — the incremental fast path's id-change
  detection and the `--watch` metadata registries; #2655 is in flight under `agent: impl-10`.
- **#3241** — `asserterror` swallowing `BcAppSymbolReadException` is the same *shape* as this
  defect at a different seam, but it lives in the symbol reader and needs its own diagnosis.
  Linked, not folded.

## One count moved that I did not add

`BcShapeMethodLookupTests.NameOnlyBcTypedMethodLookups` went 76 → 72. The number is read from
the failing test's own printed breakdown, not computed. The net is not the gross: six counted
sites went away (`NavSymRef.ModuleDefinition.Clone`, `LoadMetadata` in the two Real*Metadata
files, and `CreateFromMetaTable` / `CreateForTempTable` / `CreateTempDataAccess` in
`RecordPatches.cs`) and two arrived, both inside `BcShapeGapException.cs` — `BcShape.Method`'s
two name-only overloads, which is exactly where a name-only lookup belongs: in the one helper
that refuses by name when it misses.

`VirtualTableRefusalClaimTests`' total is untouched (the conversions add no `throw …ShapeGap(`
text) and its `(?<!Bc)` lookbehind was not modified.

## What I ran

| | result |
|---|---|
| `BcShapeNullForgivingLookupTests` | 25/25 |
| `BcInternalsNullForgivingGuardTests` | 4/4 |
| corpus, exactly as `bc-tests.yml` invokes it | **2676/2676**, exit 0 |
| `tests/runner-extras` (both package caches, `--count-baseline`) | **314/314**, exit 0 |
| `tests/runner-extras-isolation-disabled` | 3/3, exit 0 |
| full `AlRunner.Tests` — run because the blast radius covers `RecordPatches`, `QueryProjection`, `EventSubscriberPatches`, `NavRecordRefPatches` | **3478 passed, 0 failed**, 202 skipped, 14m24s |

All on `30dc007b`, rebased onto `65e5e562`, after the rebase — no result is carried across it.

## Deliberately left out

- The 61 classified sites. Converting a `typeof(BcRuntime).GetMethod(nameof(…))!` to a
  `bc-shape-gap:` would claim Microsoft moved a member of this repository.
- `Program.cs`'s `target.GetMethod("OnRun", …)!`. It is a lookup on a codeunit **this runner
  emitted**; absence is an emit defect, and `BcShapeGapException.cs`'s own header puts an
  artifact's state on the "do not raise it" side. It is in the guard's `Listed` table with that
  reason rather than converted.
- The `NclCecilRewrite.*` sites, for the reason #3051 and #2994 both already concede: they fire
  at rewrite time, before any AL executes, where no AL seam can trap the refusal.

---
*Opened by an automated agent (`stma-auto-1`) acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE
