### PR TITLE
test(fixtures): discharge the last three Base Application floor entries

### DIFF
--- a/.claude/rules/no-base-app-in-csharp-tests.md
+++ b/.claude/rules/no-base-app-in-csharp-tests.md
@@ -57,6 +57,12 @@ turned out to need the floor — each needed one specific thing the floor happen
   declares three tables of its own and asserts **two different** empty tables are each explained
   with their own id — a stronger claim than one hardcoded id could make.
 
+End to end, the three suites together (11 tests, same 11 before and after), three reps each,
+`dotnet test --no-build` on one loaded box: **191.6 s → 55.3 s, -71%**. The control in the same
+sweep — `PlaceholderFloorProvisioningTests`, untouched and still declaring the floor because the
+floor is its subject — was 10.0 s → 10.2 s, flat. That pairing is what makes the delta a
+measurement rather than a claim about a busy machine.
+
 So the pattern for the next class that looks like it needs the floor: work out which single
 property of Base Application it is actually leaning on, and supply that. In three out of three
 cases it was cheaper to supply than to load.

--- a/.claude/rules/no-base-app-in-csharp-tests.md
+++ b/.claude/rules/no-base-app-in-csharp-tests.md
@@ -41,17 +41,25 @@ unnoticed. Add to the allowlist only with the reason the floor is genuinely the 
   `Fixtures/RecordTriggerXRec`, shared with 13 other classes — so it got a fixture of its own
   and the floor is paid once per CI leg instead of 28 times.
 
-**Outstanding violations, tracked in #2364 — debt, not permission:**
+**There are no outstanding violations.** #2364 discharged the last three, and none of them
+turned out to need the floor — each needed one specific thing the floor happened to supply:
 
-- `InstallBaselineDiskCacheTests`, `InstallSeedDepCompanyCacheTests` — they test #1867
-  install-baseline caching and need a closure whose install triggers WRITE ROWS; without one
-  the runner logs `not persisting: snapshot has 0 DataAccessSource(s)` and the assertions have
-  nothing to observe, so they would pass vacuously.
-- `MissingTestDataDiagnosisTests` — resolves "Source Code Setup" (table 242) against real
-  metadata, asserting BC's own table id so the diagnosis cannot pass by echoing a name back.
+- `InstallBaselineDiskCacheTests`, `InstallSeedDepCompanyCacheTests` test #1867
+  install-baseline caching, and needed a dependency closure whose install triggers WRITE ROWS
+  (without one the runner logs `not persisting: snapshot has 0 DataAccessSource(s)`, nothing is
+  persisted, and the assertions pass vacuously). They now use `AlRunner.Tests/InstallSeedClosure.cs`
+  — a dependency app with one table and one `OnInstallAppPerCompany` trigger that inserts two
+  rows, read back by value in AL. Measured on that fixture with two bundles in both arms so only
+  the floor differs (BC 28.1, `perf stat` instructions-retired): **249.6e9 → 63.7e9 cold
+  (-74.5%)** and **47.9e9 → 14.9e9 warm (-68.9%)**; wall 33.9 s → 10.9 s and 6.9 s → 2.8 s.
+- `MissingTestDataDiagnosisTests` resolved "Source Code Setup" (table 242) against real
+  metadata, asserting a table id so the diagnosis could not pass by echoing a name back. It now
+  declares three tables of its own and asserts **two different** empty tables are each explained
+  with their own id — a stronger claim than one hardcoded id could make.
 
-None is a precedent to cite. Do not add another. When #2364 lands, this section shrinks to the
-legitimate cases.
+So the pattern for the next class that looks like it needs the floor: work out which single
+property of Base Application it is actually leaning on, and supply that. In three out of three
+cases it was cheaper to supply than to load.
 
 The violation the class list missed was a checked-in fixture rather than a class-generated
 manifest: `AlRunner.Tests/Fixtures/RecordTriggerXRec/app.json`, a bundle with

--- a/AlRunner.Tests/BaseAppFloorFixtureGuardTests.cs
+++ b/AlRunner.Tests/BaseAppFloorFixtureGuardTests.cs
@@ -217,21 +217,24 @@ public sealed class BaseAppFloorFixtureGuardTests
     };
 
     /// <summary>
-    /// C# test sources permitted to write the floor into a manifest they generate. Three
-    /// are debt tracked in #2364, not permission; two are legitimate. Keep the reasons —
-    /// the rule was ignored once already because it read as advice. Paths are relative to
-    /// AlRunner.Tests/ with '/' separators, exactly like <see cref="AllowedFixtures"/>; for a
-    /// top-level file that is just the file name, which is why widening the scan (#3000) left
-    /// every entry below unchanged.
+    /// C# test sources permitted to write the floor into a manifest they generate. Both
+    /// remaining entries are legitimate: the floor itself is what they assert about. Keep the
+    /// reasons — the rule was ignored once already because it read as advice. Paths are
+    /// relative to AlRunner.Tests/ with '/' separators, exactly like
+    /// <see cref="AllowedFixtures"/>; for a top-level file that is just the file name, which
+    /// is why widening the scan (#3000) left every entry below unchanged.
+    ///
+    /// #2364 removed the three debt entries this list used to carry. They were not exceptions
+    /// to the rule, they were unpaid debt, and each was discharged by giving the class what it
+    /// actually needed instead of the whole Base Application closure:
+    /// InstallBaselineDiskCacheTests and InstallSeedDepCompanyCacheTests needed a dependency
+    /// closure whose install triggers write rows (now <see cref="InstallSeedClosure"/>, one
+    /// table and one OnInstallAppPerCompany trigger), and MissingTestDataDiagnosisTests needed
+    /// a table with real metadata whose id it could assert (now three tables the fixture
+    /// declares itself). Do not add a fourth entry here in place of doing the same.
     /// </summary>
     private static readonly Dictionary<string, string> AllowedSources = new()
     {
-        ["InstallBaselineDiskCacheTests.cs"] =
-            "#2364 debt — #1867 install-baseline caching needs a closure whose install writes rows",
-        ["InstallSeedDepCompanyCacheTests.cs"] =
-            "#2364 debt — same install-baseline closure requirement",
-        ["MissingTestDataDiagnosisTests.cs"] =
-            "#2364 debt — resolves 'Source Code Setup' (table 242) against real metadata",
         ["PlaceholderFloorProvisioningTests.cs"] =
             "legitimate — the placeholder 1.0.0.0 floor IS the subject",
         ["ProvisionExplicitModesTests.cs"] =
@@ -258,7 +261,7 @@ public sealed class BaseAppFloorFixtureGuardTests
     }
 
     [Fact]
-    public void NoTestSource_WritesTheBaseApplicationFloor_ExceptTheAllowlistedFive()
+    public void NoTestSource_WritesTheBaseApplicationFloor_ExceptTheAllowlistedTwo()
     {
         var offenders = new List<string>();
         foreach (var path in TestSourcePaths())
@@ -271,8 +274,9 @@ public sealed class BaseAppFloorFixtureGuardTests
         Assert.True(offenders.Count == 0,
             "These test sources write \"application\" into a manifest without being on the " +
             "allowlist in this file:\n  " + string.Join("\n  ", offenders) +
-            "\n\nSee .claude/rules/no-base-app-in-csharp-tests.md, and #2364 for the three " +
-            "outstanding violations that are debt rather than precedent.");
+            "\n\nSee .claude/rules/no-base-app-in-csharp-tests.md. #2364 discharged the last " +
+            "three debt entries on this list; give the class the closure or the metadata it " +
+            "actually needs rather than adding a fourth.");
     }
 
     /// <summary>

--- a/AlRunner.Tests/InstallBaselineDiskCacheTests.cs
+++ b/AlRunner.Tests/InstallBaselineDiskCacheTests.cs
@@ -314,7 +314,7 @@ public class InstallBaselineDiskCacheTests
             // Measured by mutation (#2364): flattening the WHOLE
             // TestExecutor.CurrentInstallBaselineCacheKey() to a constant fails this test.
             // Flattening only its dependency-set component, or only its symbol-state
-            // component, does NOT — the two are redundant here, so this pins the key as a
+            // component, does NOT — the two are redundant here (#3254), so this pins the key as a
             // whole rather than the dependency set specifically. See the longer note in
             // InstallSeedDepCompanyCacheTests.AppGroupWithOwnDependencyApp_*.
             var written = WriteDigests(output);

--- a/AlRunner.Tests/InstallBaselineDiskCacheTests.cs
+++ b/AlRunner.Tests/InstallBaselineDiskCacheTests.cs
@@ -308,8 +308,15 @@ public class InstallBaselineDiskCacheTests
                 $"expected both main app groups to pass, got:\n{output}");
 
             // [THEN] Two closures that differ by one dependency assembly produced two distinct
-            // cache keys and two distinct files. A key that ignored the dependency set (or a
-            // path that collided) would show one.
+            // cache keys and two distinct files. A key that collapsed these two closures
+            // together (or a path that collided) would show one.
+            //
+            // Measured by mutation (#2364): flattening the WHOLE
+            // TestExecutor.CurrentInstallBaselineCacheKey() to a constant fails this test.
+            // Flattening only its dependency-set component, or only its symbol-state
+            // component, does NOT — the two are redundant here, so this pins the key as a
+            // whole rather than the dependency set specifically. See the longer note in
+            // InstallSeedDepCompanyCacheTests.AppGroupWithOwnDependencyApp_*.
             var written = WriteDigests(output);
             Assert.True(written.Count >= 2,
                 $"expected at least 2 distinct dependency-closure keys to be persisted, got "

--- a/AlRunner.Tests/InstallBaselineDiskCacheTests.cs
+++ b/AlRunner.Tests/InstallBaselineDiskCacheTests.cs
@@ -37,26 +37,21 @@ namespace AlRunner.Tests;
 ///   4. SCOPING — two app groups whose dependency closures differ get two different keys and
 ///      therefore two different files; a baseline is never shared across closures.
 ///
-/// Every case also asserts the app group's own AL test still passes against REAL
-/// Company-Initialize-seeded data (Company Information's singleton row), so a "cache" that
-/// restored nothing at all would fail the assertion rather than merely run fast.
+/// Every case also asserts the app group's own AL test still passes, reading the rows the
+/// dependency's OnInstallAppPerCompany trigger seeded back BY VALUE — so a "cache" that
+/// restored nothing at all fails the assertion rather than merely running fast.
+///
+/// #2364: these fixtures used to declare the Base Application floor and assert on Company
+/// Information's Company-Initialize-seeded singleton row. Neither this suite's claims nor
+/// #1867's are about Base Application — what they need is a dependency closure whose install
+/// triggers WRITE ROWS, because an empty snapshot is never persisted
+/// (<c>not persisting: snapshot has 0 DataAccessSource(s)</c>) and leaves every assertion
+/// here with nothing to observe. <see cref="InstallSeedClosure"/> supplies exactly that
+/// closure and nothing else; see .claude/rules/no-base-app-in-csharp-tests.md for what the
+/// floor cost, and that file's header for the measurement of dropping it.
 ///
 /// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
 /// </summary>
-/// <para>
-/// <b>#2364 — the <c>"application"</c> floor in this file's fixtures is an OUTSTANDING
-/// VIOLATION of <c>.claude/rules/no-base-app-in-csharp-tests.md</c>, not an exception to
-/// it.</b> Every other fixture in <c>AlRunner.Tests</c> dropped it (#2358): it pulls in the
-/// whole Base Application closure and costs ~70s cold / ~6s warm per runner invocation.
-/// </para>
-/// <para>
-/// This class does not test Base Application — it tests #1867 install-baseline caching. It
-/// needs a dependency closure whose install triggers WRITE ROWS; without one the runner logs
-/// <c>not persisting: snapshot has 0 DataAccessSource(s)</c> and the assertions have nothing
-/// to observe, so the tests would pass vacuously. The fix is a small fixture dependency app
-/// with its own table and an <c>OnInstallAppPerCompany</c> trigger, tracked in #2364.
-/// Do not copy this floor into a new test.
-/// </para>
 public class InstallBaselineDiskCacheTests
 {
     private static readonly string RepoRoot = Path.GetFullPath(
@@ -94,80 +89,15 @@ public class InstallBaselineDiskCacheTests
     }
 
     /// <summary>
-    /// A two-app closure whose dependency set is unique to this test invocation: the main app
-    /// depends on a private dependency app whose id AND source text carry a fresh GUID, so the
-    /// dependency assembly it compiles to has an MVID no other run has ever produced — and
-    /// therefore an InstallTriggerRunner.CurrentDependencySetKey(), and an on-disk baseline
-    /// entry, that starts out guaranteed absent. Without that these tests could not tell a
-    /// genuine first-run MISS from a hit on an entry some earlier run left behind.
+    /// A dependency closure that seeds rows and is unique to this test invocation. See
+    /// <see cref="InstallSeedClosure"/> for why the seed app is a sibling source dependency
+    /// rather than a second bundle, and for how the fresh-GUID identity guarantees the
+    /// on-disk entry starts out absent — without which these tests could not tell a genuine
+    /// first-run MISS from a hit on an entry some earlier run left behind.
     /// </summary>
-    private static (string dep, string main) WriteUniqueClosure(string root, int baseId, string tag)
-    {
-        var depId = Guid.NewGuid().ToString();
-        var marker = Guid.NewGuid().ToString("N");
-        var depDir = Path.Combine(root, tag + "-dep");
-        var mainDir = Path.Combine(root, tag + "-main");
-
-        Directory.CreateDirectory(depDir);
-        File.WriteAllText(Path.Combine(depDir, "app.json"), $$"""
-        {
-          "id": "{{depId}}",
-          "name": "IBDisk {{tag}} Dep",
-          "publisher": "InstallBaselineDiskTest",
-          "version": "1.0.0.0",
-          "dependencies": [],
-          "platform": "1.0.0.0",
-          "application": "1.0.0.0",
-          "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 4}} } ],
-          "runtime": "14.0"
-        }
-        """);
-        File.WriteAllText(Path.Combine(depDir, "Dep.al"), $$"""
-        codeunit {{baseId}} "IBDisk {{tag}} Dep Cu"
-        {
-            procedure Marker(): Text
-            begin
-                exit('{{marker}}');
-            end;
-        }
-        """);
-
-        Directory.CreateDirectory(mainDir);
-        File.WriteAllText(Path.Combine(mainDir, "app.json"), $$"""
-        {
-          "id": "{{Guid.NewGuid()}}",
-          "name": "IBDisk {{tag}} Main",
-          "publisher": "InstallBaselineDiskTest",
-          "version": "1.0.0.0",
-          "dependencies": [
-            { "id": "{{depId}}", "name": "IBDisk {{tag}} Dep", "publisher": "InstallBaselineDiskTest", "version": "1.0.0.0" }
-          ],
-          "platform": "1.0.0.0",
-          "application": "1.0.0.0",
-          "idRanges": [ { "from": {{baseId + 5}}, "to": {{baseId + 9}} } ],
-          "runtime": "14.0"
-        }
-        """);
-        File.WriteAllText(Path.Combine(mainDir, "Tests.al"), $$"""
-        codeunit {{baseId + 5}} "IBDisk {{tag}} Test"
-        {
-            Subtype = Test;
-
-            [Test]
-            procedure CompanyInitializeSeededRealData()
-            var
-                CompanyInformation: Record "Company Information";
-            begin
-                // [THEN] Whether this app group computed the dependency+company baseline or
-                // restored it from disk, the real Base App codeunit 2 "Company-Initialize"
-                // result is present: Company Information's singleton row exists. A disk
-                // restore that dropped rows fails here rather than merely being fast.
-                CompanyInformation.Get();
-            end;
-        }
-        """);
-        return (depDir, mainDir);
-    }
+    /// <returns>The one directory to hand the runner.</returns>
+    private static string WriteUniqueClosure(string root, int baseId, string tag)
+        => InstallSeedClosure.Write(root, tag, baseId).BundleDir;
 
     // ── log parsing ────────────────────────────────────────────────────────────────────
 
@@ -208,24 +138,24 @@ public class InstallBaselineDiskCacheTests
         var root = TestScratch.Dir("al-runner-ib-disk-roundtrip");
         try
         {
-            var (dep, main) = WriteUniqueClosure(root, 62000, "rt");
+            var main = WriteUniqueClosure(root, 62000, "rt");
 
-            var (out1, exit1) = RunRunner(null, dep, main);
+            var (out1, exit1) = RunRunner(null, main);
             Assert.Equal(0, exit1);
             Assert.True(Count(out1, "1P/0F/0E") >= 1, $"main app group should pass, got:\n{out1}");
 
             // [THEN] First process: this closure has never been seen, so its key is computed
-            // fresh and persisted — and it is NOT among the keys this run restored from disk.
-            // (The bundle's plain MS-platform app group may legitimately hit an entry an
-            // earlier run left; the assertion is about THIS closure's key, not about the
-            // process having no hits at all.)
+            // fresh and persisted, and NOTHING in this process is restored from disk. #2364
+            // made that the flat assertion it now is: while the seed app was passed as its own
+            // bundle it formed a second app group whose dependency closure was empty, and an
+            // empty snapshot is never persisted — so that group logged a MISS on every process
+            // forever and this could only be written as a key-set intersection.
             var written = WriteDigests(out1);
-            Assert.True(written.Count >= 1, $"expected at least one DISK-WRITE, got:\n{out1}");
-            Assert.Empty(HitDigests(out1).Keys.Intersect(written.Keys));
-            Assert.True(Count(out1, "InstallBaseline.DepCompanyCache MISS") >= 1,
-                $"expected at least one fresh computation, got:\n{out1}");
+            Assert.Single(written);
+            Assert.Empty(HitDigests(out1));
+            Assert.Equal(1, Count(out1, "InstallBaseline.DepCompanyCache MISS"));
 
-            var (out2, exit2) = RunRunner(null, dep, main);
+            var (out2, exit2) = RunRunner(null, main);
             Assert.Equal(0, exit2);
             Assert.True(Count(out2, "1P/0F/0E") >= 1, $"main app group should pass, got:\n{out2}");
 
@@ -262,17 +192,17 @@ public class InstallBaselineDiskCacheTests
         var root = TestScratch.Dir("al-runner-ib-disk-killswitch");
         try
         {
-            var (dep, main) = WriteUniqueClosure(root, 62020, "ks");
+            var main = WriteUniqueClosure(root, 62020, "ks");
 
             // Seed an entry that the kill-switched run would hit if the switch did nothing.
-            var (out1, exit1) = RunRunner(null, dep, main);
+            var (out1, exit1) = RunRunner(null, main);
             Assert.Equal(0, exit1);
             var paths = WrittenPaths(out1);
             Assert.True(paths.Count >= 1, $"expected the first run to write an entry, got:\n{out1}");
             var before = paths.ToDictionary(p => p, File.ReadAllBytes);
 
             var (out2, exit2) = RunRunner(
-                new Dictionary<string, string> { ["AL_RUNNER_NO_DEP_COMPANY_CACHE"] = "1" }, dep, main);
+                new Dictionary<string, string> { ["AL_RUNNER_NO_DEP_COMPANY_CACHE"] = "1" }, main);
 
             // [THEN] Seeding still happened — the switch disables the cache, not the work.
             Assert.Equal(0, exit2);
@@ -307,9 +237,9 @@ public class InstallBaselineDiskCacheTests
         var root = TestScratch.Dir("al-runner-ib-disk-corrupt");
         try
         {
-            var (dep, main) = WriteUniqueClosure(root, 62040, "cx");
+            var main = WriteUniqueClosure(root, 62040, "cx");
 
-            var (out1, exit1) = RunRunner(null, dep, main);
+            var (out1, exit1) = RunRunner(null, main);
             Assert.Equal(0, exit1);
             var paths = WrittenPaths(out1);
             Assert.True(paths.Count >= 1, $"expected the first run to write an entry, got:\n{out1}");
@@ -324,7 +254,7 @@ public class InstallBaselineDiskCacheTests
                 File.WriteAllBytes(path, junk);
             }
 
-            var (out2, exit2) = RunRunner(null, dep, main);
+            var (out2, exit2) = RunRunner(null, main);
 
             // [THEN] The damage was noticed, not swallowed and not fatal.
             Assert.Equal(0, exit2);
@@ -342,7 +272,7 @@ public class InstallBaselineDiskCacheTests
 
             // [THEN] And the replacement is genuinely usable: a third process restores from it
             // with the digest the rewriting process recorded.
-            var (out3, exit3) = RunRunner(null, dep, main);
+            var (out3, exit3) = RunRunner(null, main);
             Assert.Equal(0, exit3);
             Assert.Equal(0, Count(out3, "InstallBaseline.DepCompanyCache MISS"));
             var hits = HitDigests(out3);
@@ -368,10 +298,10 @@ public class InstallBaselineDiskCacheTests
         var root = TestScratch.Dir("al-runner-ib-disk-scope");
         try
         {
-            var (depA, mainA) = WriteUniqueClosure(root, 62060, "sa");
-            var (depB, mainB) = WriteUniqueClosure(root, 62080, "sb");
+            var mainA = WriteUniqueClosure(root, 62060, "sa");
+            var mainB = WriteUniqueClosure(root, 62080, "sb");
 
-            var (output, exit) = RunRunner(null, depA, mainA, depB, mainB);
+            var (output, exit) = RunRunner(null, mainA, mainB);
 
             Assert.Equal(0, exit);
             Assert.True(Count(output, "1P/0F/0E") >= 2,

--- a/AlRunner.Tests/InstallSeedClosure.cs
+++ b/AlRunner.Tests/InstallSeedClosure.cs
@@ -1,0 +1,308 @@
+// InstallSeedClosure — the fixture shape #1867's two caching suites need, WITHOUT the Base
+// Application floor (#2364).
+//
+// WHAT THE CALLERS ACTUALLY NEED, AND WHY IT IS NOT BASE APPLICATION
+//   InstallBaselineDiskCacheTests and InstallSeedDepCompanyCacheTests are about the CACHING of
+//   install-trigger state. The one thing that caching needs in order to be observable is a
+//   dependency closure whose install triggers WRITE ROWS: with an empty snapshot the codec
+//   logs `not persisting: snapshot has 0 DataAccessSource(s), expected exactly 1`, nothing is
+//   written, no DISK-HIT/DISK-WRITE marker exists, and every assertion in both suites would
+//   pass having observed nothing.
+//
+//   Both suites used to buy that closure by declaring `"application"` in their generated
+//   manifests, which loads the whole Base Application closure on every runner invocation
+//   (~70 s cold, ~6 s warm each — .claude/rules/no-base-app-in-csharp-tests.md). Neither suite
+//   ever asserted anything about Base Application; it was Base App's own install-time writes
+//   they were riding on. A dependency app carrying ONE table and ONE Subtype=Install codeunit
+//   that inserts two rows produces the same non-empty snapshot for none of the cost.
+//
+//   Measured on this fixture (BC 28.1, perf stat instructions-retired, two bundles in both
+//   arms so only the floor differs): 249.6e9 -> 63.7e9 instructions cold (-74.5%) and
+//   47.9e9 -> 14.9e9 warm (-68.9%); wall 33.9 s -> 10.9 s cold and 6.9 s -> 2.8 s warm.
+//
+// THE SEED IS A DEPENDENCY, NOT A BUNDLE
+//   Only <see cref="Closure.BundleDir"/> is handed to the runner. The seed app sits beside it
+//   and is picked up by SiblingCompile.BuildSiblingSourceDeps, which compiles a declared
+//   dependency that ships only as AL source in a sibling directory. That matters for the
+//   assertions rather than for speed (measured: one app group vs two is within noise, 14.8e9
+//   vs 14.9e9 instructions): passing the seed as its own bundle would give it an app group of
+//   its own whose dependency closure is EMPTY, so it seeds nothing, is never persisted, and
+//   logs a fresh MISS on every process forever — which would force "no key was recomputed"
+//   to be written as a weaker key-set intersection instead of the flat count it can be here.
+//
+// EVERY CLOSURE IS UNIQUE TO ITS INVOCATION
+//   The seed app's id and its seeded Description both carry a fresh GUID, so the dependency
+//   assembly compiles to an MVID no earlier run has produced — and therefore to an
+//   InstallTriggerRunner.CurrentDependencySetKey(), and an on-disk entry, that is guaranteed
+//   absent at the start. Without that, neither suite could tell a genuine first-run MISS from
+//   a hit on an entry some earlier run left behind.
+//
+// THE AL ASSERTION IS THE NON-VACUITY GUARD
+//   The bundle's test reads the seeded rows back by VALUE — the marker text, a positive
+//   decimal, a negative decimal, and the row count. A cache that restored nothing, or restored
+//   a truncated or re-lengthened value, fails that test rather than merely running fast. It is
+//   deliberately not an `Assert.IsTrue(true)`-shaped "the row exists" check: see
+//   .claude/rules/tdd.md.
+
+namespace AlRunner.Tests;
+
+internal static class InstallSeedClosure
+{
+    /// <summary>
+    /// One writable dependency closure on disk.
+    /// </summary>
+    /// <param name="BundleDir">The directory to hand the runner. The seed app is NOT in this
+    /// list — it is resolved as a sibling source dependency.</param>
+    /// <param name="SeedDir">The seed app's directory, for tests that need to name it.</param>
+    /// <param name="Marker">The GUID text the seed writes into row SEED-1's Description, and
+    /// the bundle's test asserts back. Unique per call.</param>
+    internal sealed record Closure(string BundleDir, string SeedDir, string Marker);
+
+    /// <summary>The rows the seed app's OnInstallAppPerCompany trigger inserts.</summary>
+    internal const int SeededRowCount = 2;
+
+    /// <summary>
+    /// Writes <c>&lt;root&gt;/&lt;tag&gt;/seed</c> and <c>&lt;root&gt;/&lt;tag&gt;/main</c> and
+    /// returns them. Each closure gets its OWN parent directory so that sibling-source-dep
+    /// discovery, which scans the parent of every bundle root, cannot offer one closure's seed
+    /// app to another closure's bundle.
+    /// </summary>
+    /// <param name="root">A scratch directory owned by the caller.</param>
+    /// <param name="tag">A short identifier, unique within <paramref name="root"/>. Becomes part
+    /// of every AL object name, so two closures in one runner invocation never collide.</param>
+    /// <param name="baseId">First object id. Uses <paramref name="baseId"/> (table),
+    /// <c>+1</c> (install codeunit) and <c>+5</c> (test codeunit); callers must leave 10 ids
+    /// clear.</param>
+    internal static Closure Write(string root, string tag, int baseId)
+    {
+        var parent = Path.Combine(root, tag);
+        var seedDir = Path.Combine(parent, "seed");
+        var mainDir = Path.Combine(parent, "main");
+        var seedId = Guid.NewGuid().ToString();
+        var marker = Guid.NewGuid().ToString("N");
+        var seedName = $"Seed {tag}";
+
+        WriteSeedApp(seedDir, tag, baseId, seedId, seedName, marker);
+        WriteBundle(mainDir, tag, baseId, marker, ($"{seedId}", seedName));
+        return new Closure(mainDir, seedDir, marker);
+    }
+
+    /// <summary>
+    /// The same closure, but with TWO bundles sharing the one seed app — so both app groups
+    /// resolve to the SAME InstallTriggerRunner.CurrentDependencySetKey(). That identity is
+    /// what <c>InstallSeedDepCompanyCacheTests</c>'s HIT direction is about, so it has to come
+    /// from the apps genuinely sharing a dependency rather than from the two happening to
+    /// declare nothing.
+    /// </summary>
+    /// <returns>The two bundle directories, in the order they should be passed.</returns>
+    internal static (string first, string second, string marker) WriteSharedClosure(
+        string root, string tag, int baseId)
+    {
+        var parent = Path.Combine(root, tag);
+        var seedId = Guid.NewGuid().ToString();
+        var marker = Guid.NewGuid().ToString("N");
+        var seedName = $"Seed {tag}";
+
+        WriteSeedApp(Path.Combine(parent, "seed"), tag, baseId, seedId, seedName, marker);
+        var a = Path.Combine(parent, "main-a");
+        var b = Path.Combine(parent, "main-b");
+        WriteBundle(a, tag + "A", baseId, marker, (seedId, seedName));
+        WriteBundle(b, tag + "B", baseId + 10, marker, (seedId, seedName));
+        return (a, b, marker);
+    }
+
+    /// <summary>
+    /// A bundle whose dependency closure is the shared seed PLUS one extra dependency app, so
+    /// its key differs from <see cref="WriteSharedClosure"/>'s by exactly one assembly. The
+    /// extra app carries a table and no install trigger: the point is to change the dependency
+    /// SET, not what it seeds.
+    /// </summary>
+    internal static string WriteBundleWithExtraDependency(
+        string root, string tag, int baseId, string seedTag)
+    {
+        var parent = Path.Combine(root, seedTag);      // beside the shared seed app
+        var seedName = $"Seed {seedTag}";
+        var seedId = ReadAppId(Path.Combine(parent, "seed", "app.json"));
+        var marker = ReadMarker(Path.Combine(parent, "seed", "Seed.al"));
+
+        var extraId = Guid.NewGuid().ToString();
+        var extraName = $"Extra {tag}";
+        var extraDir = Path.Combine(parent, "extra-" + tag);
+        Directory.CreateDirectory(extraDir);
+        File.WriteAllText(Path.Combine(extraDir, "app.json"), $$"""
+        {
+          "id": "{{extraId}}",
+          "name": "{{extraName}}",
+          "publisher": "AL Runner Install Seed",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 4}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(extraDir, "Extra.al"), $$"""
+        table {{baseId}} "Extra {{tag}} Table"
+        {
+            DataClassification = SystemMetadata;
+            fields { field(1; "Code"; Code[20]) { } }
+            keys { key(PK; "Code") { Clustered = true; } }
+        }
+        """);
+
+        var mainDir = Path.Combine(parent, "main-" + tag);
+        WriteBundle(mainDir, tag, baseId + 5, marker, (seedId, seedName), (extraId, extraName));
+        return mainDir;
+    }
+
+    // ── the two app shapes ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The seed app: one table, and one Subtype=Install codeunit whose OnInstallAppPerCompany
+    /// trigger inserts <see cref="SeededRowCount"/> rows into it. That trigger is what
+    /// InstallTriggerRunner.RunDependenciesOnly() fires, inside the window
+    /// RecordPatches.CaptureInstallBaselineSnapshot() then captures — which is the whole reason
+    /// the snapshot is non-empty and the disk tier has something to persist.
+    ///
+    /// The rows carry a positive decimal, a negative one and a blank text alongside the marker
+    /// so the round-trip digest is over a value set with more than one NclType in it.
+    /// </summary>
+    private static void WriteSeedApp(
+        string dir, string tag, int baseId, string appId, string appName, string marker)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{appId}}",
+          "name": "{{appName}}",
+          "publisher": "AL Runner Install Seed",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 4}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Seed.al"), $$"""
+        table {{baseId}} "Seed {{tag}} Table"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "Code"; Code[20]) { }
+                field(2; "Description"; Text[50]) { }
+                field(3; "Amount"; Decimal) { }
+            }
+            keys { key(PK; "Code") { Clustered = true; } }
+        }
+
+        codeunit {{baseId + 1}} "Seed {{tag}} Install"
+        {
+            Subtype = Install;
+
+            // Fired by InstallTriggerRunner.RunDependenciesOnly() for every app group whose
+            // dependency closure contains this app — the exact work the #1867 baseline cache
+            // exists to avoid repeating, and the only reason the captured snapshot has rows.
+            trigger OnInstallAppPerCompany()
+            var
+                SeedRow: Record "Seed {{tag}} Table";
+            begin
+                SeedRow.Init();
+                SeedRow.Code := 'SEED-1';
+                SeedRow.Description := '{{marker}}';
+                SeedRow.Amount := 42.5;
+                SeedRow.Insert(true);
+
+                SeedRow.Init();
+                SeedRow.Code := 'SEED-2';
+                SeedRow.Description := '';
+                SeedRow.Amount := -7.25;
+                SeedRow.Insert(true);
+            end;
+        }
+        """);
+    }
+
+    /// <summary>
+    /// A bundle depending on the seed app (and optionally more), whose single test reads the
+    /// seeded rows back BY VALUE. Whether this app group computed the dependency+company
+    /// baseline or restored it from memory or from disk, these are the values it must see; a
+    /// restore that dropped rows, truncated a text or re-lengthened a decimal fails here rather
+    /// than merely being fast.
+    /// </summary>
+    private static void WriteBundle(
+        string dir, string tag, int baseId, string marker, params (string Id, string Name)[] deps)
+    {
+        Directory.CreateDirectory(dir);
+        var depJson = string.Join(",\n    ", deps.Select(d =>
+            $$"""{ "id": "{{d.Id}}", "name": "{{d.Name}}", "publisher": "AL Runner Install Seed", "version": "1.0.0.0" }"""));
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{Guid.NewGuid()}}",
+          "name": "Main {{tag}}",
+          "publisher": "AL Runner Install Seed",
+          "version": "1.0.0.0",
+          "dependencies": [
+            {{depJson}}
+          ],
+          "platform": "1.0.0.0",
+          "idRanges": [ { "from": {{baseId + 5}}, "to": {{baseId + 9}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        // The seed app's table is named after the SEED's tag, which is the first dependency's
+        // name minus its "Seed " prefix — the bundle tag can differ (WriteSharedClosure gives
+        // its two bundles distinct tags while they share one seed).
+        var seedTag = deps[0].Name["Seed ".Length..];
+        File.WriteAllText(Path.Combine(dir, "Tests.al"), $$"""
+        codeunit {{baseId + 5}} "Main {{tag}} Test"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure DependencyInstallSeedIsPresentWithItsValues()
+            var
+                SeedRow: Record "Seed {{seedTag}} Table";
+            begin
+                // [THEN] Both rows the dependency's OnInstallAppPerCompany trigger inserted are
+                // present, with the values it wrote. Asserted value-by-value rather than as a
+                // bare Get(), so a cache tier that restored an empty or partial snapshot fails
+                // here instead of passing quietly.
+                if SeedRow.Count() <> {{SeededRowCount}} then
+                    Error('expected {{SeededRowCount}} seeded row(s), found %1', SeedRow.Count());
+
+                SeedRow.Get('SEED-1');
+                if SeedRow.Description <> '{{marker}}' then
+                    Error('SEED-1 Description was ''%1''', SeedRow.Description);
+                if SeedRow.Amount <> 42.5 then
+                    Error('SEED-1 Amount was %1', SeedRow.Amount);
+
+                SeedRow.Get('SEED-2');
+                if SeedRow.Description <> '' then
+                    Error('SEED-2 Description was ''%1''', SeedRow.Description);
+                if SeedRow.Amount <> -7.25 then
+                    Error('SEED-2 Amount was %1', SeedRow.Amount);
+            end;
+        }
+        """);
+    }
+
+    // ── reading back what Write* produced ────────────────────────────────────────────────
+
+    private static string ReadAppId(string appJsonPath)
+    {
+        using var doc = System.Text.Json.JsonDocument.Parse(File.ReadAllText(appJsonPath));
+        return doc.RootElement.GetProperty("id").GetString()!;
+    }
+
+    /// <summary>The marker is written into the seed's AL source; read it back rather than
+    /// threading it through every call site.</summary>
+    private static string ReadMarker(string seedAlPath)
+    {
+        var m = System.Text.RegularExpressions.Regex.Match(
+            File.ReadAllText(seedAlPath), @"Description := '([0-9a-f]{32})';");
+        if (!m.Success)
+            throw new InvalidOperationException($"no seed marker found in {seedAlPath}");
+        return m.Groups[1].Value;
+    }
+}

--- a/AlRunner.Tests/InstallSeedDepCompanyCacheTests.cs
+++ b/AlRunner.Tests/InstallSeedDepCompanyCacheTests.cs
@@ -200,7 +200,7 @@ public class InstallSeedDepCompanyCacheTests
         // in-memory HIT. A cache keyed so that these two closures collide would show one
         // resolution and one HIT; this shows two resolutions and no HIT.
         //
-        // WHAT THIS DOES AND DOES NOT PIN, measured by mutation (#2364, follow-up filed):
+        // WHAT THIS DOES AND DOES NOT PIN, measured by mutation (#2364; gap tracked in #3254):
         // TestExecutor.CurrentInstallBaselineCacheKey() concatenates three components, and the
         // first two — InstallTriggerRunner.CurrentDependencySetKey() and
         // RecordPatches.RegisteredBcAppSymbolStateKey() — are REDUNDANT for this scenario:

--- a/AlRunner.Tests/InstallSeedDepCompanyCacheTests.cs
+++ b/AlRunner.Tests/InstallSeedDepCompanyCacheTests.cs
@@ -25,27 +25,20 @@ namespace AlRunner.Tests;
 /// dependency-set boundaries. Both directions are asserted from the
 /// AL_RUNNER_PERF=1 "InstallBaseline.DepCompanyCache HIT/MISS" markers TestExecutor.Run
 /// logs at the exact point the cache lookup happens (see TestExecutor.cs), plus each
-/// app group's own test assertion against REAL Company-Initialize-seeded data (Company
-/// Information's Name, seeded by the actual Base App codeunit 2 body) proving the
-/// restored/cached baseline is not a stub — a no-op cache that skipped the seed
-/// entirely would fail every one of these AL assertions, not just run faster.
+/// app group's own test assertion reading the dependency's install-seeded rows back BY
+/// VALUE, proving the restored/cached baseline is not a stub — a no-op cache that skipped
+/// the seed entirely would fail every one of these AL assertions, not just run faster.
+///
+/// #2364: the two app groups used to share their closure by declaring NOTHING but the Base
+/// Application floor, and asserted on Company Information's Company-Initialize-seeded row.
+/// Neither half of that is what this suite claims. They now share a real dependency —
+/// <see cref="InstallSeedClosure"/>'s seed app, one table and one OnInstallAppPerCompany
+/// trigger — so the shared key comes from the apps genuinely sharing a dependency assembly
+/// rather than from both declaring none, and the AL assertion is about rows this fixture
+/// seeded rather than rows Base App did. See .claude/rules/no-base-app-in-csharp-tests.md.
 ///
 /// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
 /// </summary>
-/// <para>
-/// <b>#2364 — the <c>"application"</c> floor in this file's fixtures is an OUTSTANDING
-/// VIOLATION of <c>.claude/rules/no-base-app-in-csharp-tests.md</c>, not an exception to
-/// it.</b> Every other fixture in <c>AlRunner.Tests</c> dropped it (#2358): it pulls in the
-/// whole Base Application closure and costs ~70s cold / ~6s warm per runner invocation.
-/// </para>
-/// <para>
-/// This class does not test Base Application — it tests #1867 install-baseline caching. It
-/// needs a dependency closure whose install triggers WRITE ROWS; without one the runner logs
-/// <c>not persisting: snapshot has 0 DataAccessSource(s)</c> and the assertions have nothing
-/// to observe, so the tests would pass vacuously. The fix is a small fixture dependency app
-/// with its own table and an <c>OnInstallAppPerCompany</c> trigger, tracked in #2364.
-/// Do not copy this floor into a new test.
-/// </para>
 public class InstallSeedDepCompanyCacheTests
 {
     private static readonly string RepoRoot = Path.GetFullPath(
@@ -60,10 +53,10 @@ public class InstallSeedDepCompanyCacheTests
     {
         var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
         args.Append(TestBuildConfig.BcVersionArg);
-        // Company Information (and every other real Base App table these tests assert
-        // against) only resolves with the platform apps on the package-cache path —
-        // without it dependency resolution silently skips Microsoft/Application and
-        // Microsoft/System, and the bundle fails to compile at all (AL0185).
+        // The platform apps have to be on the package-cache path or dependency resolution
+        // silently skips Microsoft/System and the bundle fails to compile at all (AL0185).
+        // The bundles no longer declare the Base Application floor (#2364), but they still
+        // need the platform closure they compile against.
         args.Append(" --package-cache \"").Append(TestArtifacts.PlatformAppsDir()).Append('"');
         foreach (var b in bundles) args.Append(" \"").Append(b).Append('"');
         var psi = new ProcessStartInfo
@@ -86,43 +79,6 @@ public class InstallSeedDepCompanyCacheTests
         lock (sb) return (sb.ToString(), p.ExitCode);
     }
 
-    private static void WriteSameDepClosureApp(string dir, int baseId, string name)
-    {
-        Directory.CreateDirectory(dir);
-        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
-        {
-          "id": "{{Guid.NewGuid()}}",
-          "name": "{{name}}",
-          "publisher": "IssueTest1867",
-          "version": "1.0.0.0",
-          "dependencies": [],
-          "platform": "1.0.0.0",
-          "application": "1.0.0.0",
-          "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 9}} } ],
-          "runtime": "14.0"
-        }
-        """);
-        File.WriteAllText(Path.Combine(dir, "Tests.al"), $$"""
-        codeunit {{baseId}} "IT1867 {{name}}"
-        {
-            Subtype = Test;
-
-            [Test]
-            procedure CompanyInitializeSeededRealData()
-            var
-                CompanyInformation: Record "Company Information";
-            begin
-                // [THEN] The real Base App codeunit 2 "Company-Initialize" body actually
-                // ran (whether via a fresh computation or a restored cache snapshot) —
-                // not a no-op that silently skipped the seed. Company Information is a
-                // singleton row Company-Initialize inserts; Get() failing here means the
-                // baseline this app group is running against was never seeded at all.
-                CompanyInformation.Get();
-            end;
-        }
-        """);
-    }
-
     [SkippableFact]
     public void SecondAppGroupWithSameDependencyClosure_ReusesCachedDepCompanyBaseline()
     {
@@ -131,36 +87,35 @@ public class InstallSeedDepCompanyCacheTests
         var root = TestScratch.Dir("al-runner-depcompany-cache");
         try
         {
-            var appA = Path.Combine(root, "app-a");
-            var appB = Path.Combine(root, "app-b");
-            WriteSameDepClosureApp(appA, 61900, "AppA");
-            WriteSameDepClosureApp(appB, 61910, "AppB");
+            var (appA, appB, _) = InstallSeedClosure.WriteSharedClosure(root, "hit", 61900);
 
             var (output, exitCode) = RunRunner(appA, appB);
 
-            // [THEN] Both app groups' Company-Initialize assertion actually passed — the
-            // cache did not silently skip seeding for either.
+            // [THEN] Both app groups' AL assertion actually passed — each read the seed
+            // app's two install-seeded rows back by value, so the cache did not silently skip
+            // seeding for either.
             Assert.Equal(0, exitCode);
             var passLines = CountOccurrences(output, "1P/0F/0E");
             Assert.True(passLines >= 2,
                 $"expected both app groups to report 1P/0F/0E, got:\n{output}");
 
-            // [THEN] The shared MS-platform-only dependency closure was resolved exactly ONCE
-            // in this process — and the second app group reused that result rather than
-            // re-running dependency Install triggers + Company-Initialize from scratch.
+            // [THEN] The shared dependency closure was resolved exactly ONCE in this process —
+            // and the second app group reused that result rather than re-running the
+            // dependency's Install triggers from scratch.
             //
-            // "Resolved once" is MISS + DISK-HIT, not MISS alone: since the cross-process
-            // on-disk tier landed (InstallBaselineDiskCacheTests), the first app group's
-            // lookup answers from disk whenever an earlier invocation on this machine already
-            // computed the same closure, and from a fresh computation otherwise. Which of the
-            // two it is depends on the state of ~/.cache/al-runner/install-baseline and is not
-            // what THIS test is about; that exactly one of them happened, and that the second
-            // app group took neither, is.
+            // Both halves are exact rather than ">= 1" because #2364 made the closure unique
+            // per invocation: the seed app's id and seeded marker carry a fresh GUID, so its
+            // assembly has an MVID no earlier run produced and the on-disk tier is guaranteed
+            // not to hold an entry for this key. Before that the two app groups shared only
+            // the MS platform closure, whose entry any earlier invocation on the machine may
+            // already have written, so the first lookup could legitimately answer MISS or
+            // DISK-HIT and only their SUM could be asserted.
             var missCount = CountOccurrences(output, "InstallBaseline.DepCompanyCache MISS");
             var diskHitCount = CountOccurrences(output, "InstallBaseline.DepCompanyCache DISK-HIT");
             var hitCount = CountOccurrences(output, "InstallBaseline.DepCompanyCache HIT");
-            Assert.Equal(1, missCount + diskHitCount);
-            Assert.True(hitCount >= 1, $"expected at least one in-memory cache HIT, got:\n{output}");
+            Assert.Equal(1, missCount);
+            Assert.Equal(0, diskHitCount);
+            Assert.Equal(1, hitCount);
         }
         finally
         {
@@ -173,8 +128,8 @@ public class InstallSeedDepCompanyCacheTests
     /// same two-app-group, same-dependency-closure scenario, but with the permanent kill
     /// switch (AL_RUNNER_NO_DEP_COMPANY_CACHE=1) set on the spawned process. Proves the
     /// switch actually disables reuse rather than merely existing — both app groups must
-    /// independently MISS (fresh dependency Install triggers + Company-Initialize) and
-    /// neither may HIT, even though their dependency-set key is identical.
+    /// independently MISS (fresh dependency Install triggers) and neither may HIT, even
+    /// though their dependency-set key is identical.
     /// </summary>
     [SkippableFact]
     public void KillSwitchEnvVar_ForcesEveryLookupToMiss_EvenForSameDependencyClosure()
@@ -184,17 +139,14 @@ public class InstallSeedDepCompanyCacheTests
         var root = TestScratch.Dir("al-runner-depcompany-cache-killswitch");
         try
         {
-            var appA = Path.Combine(root, "app-a");
-            var appB = Path.Combine(root, "app-b");
-            WriteSameDepClosureApp(appA, 61950, "AppA");
-            WriteSameDepClosureApp(appB, 61960, "AppB");
+            var (appA, appB, _) = InstallSeedClosure.WriteSharedClosure(root, "ks", 61950);
 
             var (output, exitCode) = RunRunner(
                 new System.Collections.Generic.Dictionary<string, string> { ["AL_RUNNER_NO_DEP_COMPANY_CACHE"] = "1" },
                 appA, appB);
 
-            // [THEN] Both app groups' Company-Initialize assertion still passed — the kill
-            // switch disables the cache, not the seeding itself.
+            // [THEN] Both app groups' AL assertion still passed — the kill switch disables
+            // the cache, not the seeding itself.
             Assert.Equal(0, exitCode);
             var passLines = CountOccurrences(output, "1P/0F/0E");
             Assert.True(passLines >= 2,
@@ -227,89 +179,35 @@ public class InstallSeedDepCompanyCacheTests
         var root = TestScratch.Dir("al-runner-depcompany-cache-neg");
         try
         {
-        var appA = Path.Combine(root, "app-a");
-        WriteSameDepClosureApp(appA, 61920, "AppA");
+        // appA's closure is the shared seed app alone. The second bundle declares the SAME
+        // seed PLUS one extra dependency app, so its dependency closure differs from appA's by
+        // exactly one loaded assembly and therefore by
+        // InstallTriggerRunner.CurrentDependencySetKey(). Both still seed rows, so both are
+        // genuinely persistable — a difference in KEY, not a difference in whether there is
+        // anything to cache.
+        var (appA, _, _) = InstallSeedClosure.WriteSharedClosure(root, "neg", 61920);
+        var withExtra = InstallSeedClosure.WriteBundleWithExtraDependency(root, "x", 61930, "neg");
 
-        // A second app group whose dependency CLOSURE genuinely differs from AppA's: it
-        // depends on its own extra app, which is loaded as an additional dependency
-        // assembly and therefore changes InstallTriggerRunner.CurrentDependencySetKey().
-        var depDir = Path.Combine(root, "extra-dep");
-        var mainDir = Path.Combine(root, "app-with-extra-dep");
-        Directory.CreateDirectory(depDir);
-        var depId = Guid.NewGuid().ToString();
-        File.WriteAllText(Path.Combine(depDir, "app.json"), $$"""
-        {
-          "id": "{{depId}}",
-          "name": "IT1867 Extra Dep",
-          "publisher": "IssueTest1867",
-          "version": "1.0.0.0",
-          "dependencies": [],
-          "platform": "1.0.0.0",
-          "application": "1.0.0.0",
-          "idRanges": [ { "from": 61930, "to": 61939 } ],
-          "runtime": "14.0"
-        }
-        """);
-        File.WriteAllText(Path.Combine(depDir, "Dep.al"), """
-        table 61930 "IT1867 Extra Dep Table"
-        {
-            DataClassification = SystemMetadata;
-            fields { field(1; "Code"; Code[10]) { } }
-            keys { key(PK; "Code") { Clustered = true; } }
-        }
-        """);
-        Directory.CreateDirectory(mainDir);
-        File.WriteAllText(Path.Combine(mainDir, "app.json"), $$"""
-        {
-          "id": "{{Guid.NewGuid()}}",
-          "name": "IT1867 App With Extra Dep",
-          "publisher": "IssueTest1867",
-          "version": "1.0.0.0",
-          "dependencies": [
-            { "id": "{{depId}}", "name": "IT1867 Extra Dep", "publisher": "IssueTest1867", "version": "1.0.0.0" }
-          ],
-          "platform": "1.0.0.0",
-          "application": "1.0.0.0",
-          "idRanges": [ { "from": 61940, "to": 61949 } ],
-          "runtime": "14.0"
-        }
-        """);
-        File.WriteAllText(Path.Combine(mainDir, "Tests.al"), """
-        codeunit 61940 "IT1867 WithExtraDep"
-        {
-            Subtype = Test;
-
-            [Test]
-            procedure CompanyInitializeSeededRealData()
-            var
-                CompanyInformation: Record "Company Information";
-            begin
-                CompanyInformation.Get();
-            end;
-        }
-        """);
-
-        var (output, exitCode) = RunRunner(appA, depDir, mainDir);
+        var (output, exitCode) = RunRunner(appA, withExtra);
 
         Assert.Equal(0, exitCode);
         var passLines = CountOccurrences(output, "1P/0F/0E");
         Assert.True(passLines >= 2,
             $"expected both independently-keyed app groups to report 1P/0F/0E, got:\n{output}");
 
-        // [THEN] Two DIFFERENT dependency closures (AppA's MS-platform-only closure vs.
-        // the extra-dep app's closure, which includes one more dependency assembly) each
-        // get their OWN resolution — never a cross-key in-memory HIT. A cache keyed
-        // incorrectly (e.g. ignoring the dependency set entirely) would show one resolution
-        // and one HIT; this must show at least two resolutions.
+        // [THEN] Two DIFFERENT dependency closures (the seed app alone vs. the seed app plus
+        // one more dependency assembly) each get their OWN resolution — never a cross-key
+        // in-memory HIT. A cache keyed incorrectly (e.g. ignoring the dependency set entirely)
+        // would show one resolution and one HIT; this shows two resolutions and no HIT.
         //
-        // As above, a resolution is MISS or DISK-HIT: the on-disk tier may answer AppA's
-        // MS-platform closure from an earlier invocation. The claim is that the two closures
-        // are resolved SEPARATELY, not which tier answered either of them.
+        // Exact, for the same reason as the positive test above: both closures are unique to
+        // this invocation, so neither can be answered by the on-disk tier.
         var missCount = CountOccurrences(output, "InstallBaseline.DepCompanyCache MISS");
         var diskHitCount = CountOccurrences(output, "InstallBaseline.DepCompanyCache DISK-HIT");
-        Assert.True(missCount + diskHitCount >= 2,
-            $"expected at least 2 distinct-dependency-closure resolutions, got "
-            + $"{missCount} MISS + {diskHitCount} DISK-HIT:\n{output}");
+        var hitCount = CountOccurrences(output, "InstallBaseline.DepCompanyCache HIT");
+        Assert.Equal(2, missCount);
+        Assert.Equal(0, diskHitCount);
+        Assert.Equal(0, hitCount);
         }
         finally
         {

--- a/AlRunner.Tests/InstallSeedDepCompanyCacheTests.cs
+++ b/AlRunner.Tests/InstallSeedDepCompanyCacheTests.cs
@@ -197,8 +197,20 @@ public class InstallSeedDepCompanyCacheTests
 
         // [THEN] Two DIFFERENT dependency closures (the seed app alone vs. the seed app plus
         // one more dependency assembly) each get their OWN resolution — never a cross-key
-        // in-memory HIT. A cache keyed incorrectly (e.g. ignoring the dependency set entirely)
-        // would show one resolution and one HIT; this shows two resolutions and no HIT.
+        // in-memory HIT. A cache keyed so that these two closures collide would show one
+        // resolution and one HIT; this shows two resolutions and no HIT.
+        //
+        // WHAT THIS DOES AND DOES NOT PIN, measured by mutation (#2364, follow-up filed):
+        // TestExecutor.CurrentInstallBaselineCacheKey() concatenates three components, and the
+        // first two — InstallTriggerRunner.CurrentDependencySetKey() and
+        // RecordPatches.RegisteredBcAppSymbolStateKey() — are REDUNDANT for this scenario:
+        // flattening either one alone to a constant leaves this test (and every other test in
+        // both install-cache suites) green, because the other still separates the two closures.
+        // Flattening BOTH fails this test and
+        // InstallBaselineDiskCacheTests.DifferentDependencyClosures_*. So the claim this
+        // actually establishes is "the key separates these two closures", not "the DEPENDENCY
+        // SET component does". An earlier version of this comment asserted the latter; it was
+        // not true and no test had ever checked it.
         //
         // Exact, for the same reason as the positive test above: both closures are unique to
         // this invocation, so neither can be answered by the on-disk tier.

--- a/AlRunner.Tests/MissingTestDataDiagnosisTests.cs
+++ b/AlRunner.Tests/MissingTestDataDiagnosisTests.cs
@@ -26,23 +26,40 @@ using Xunit;
 
 namespace AlRunner.Tests;
 
-// #2364 -- the "application" floor in this file's fixtures is an OUTSTANDING VIOLATION of
-// .claude/rules/no-base-app-in-csharp-tests.md, not an exception to it. Every other fixture
-// dropped it (#2358). These tests keep it only because they resolve "Source Code Setup"
-// (table 242) against REAL metadata -- the assertion is on BC's own table id precisely so
-// the diagnosis cannot pass by echoing a name back out of the message. A fixture table
-// carrying its own metadata would serve the same claim without the closure; until someone
-// does that, this stays and is tracked in #2364. Do not copy this floor into a new test.
+// #2364 -- WHY THE TABLES ARE THIS FIXTURE'S OWN
+//   These tests used to name "Source Code Setup" (242) and "Payment Method", which meant
+//   declaring the Base Application floor and loading its whole closure on every one of the
+//   four runner invocations below (.claude/rules/no-base-app-in-csharp-tests.md: ~70 s cold,
+//   ~6 s warm each). The claim was never about those tables. It is that the diagnosis
+//   RESOLVED the table against real metadata rather than echoing a name back out of BC's
+//   message -- and an id is what proves that, because no message here contains one.
+//
+//   A fixture table's id proves it exactly as well: 62441 is produced only by looking the
+//   name up through the same NCLMetaTable the runner records on the exception
+//   (MissingTestDataDiagnosis.TagTable) or resolves from NavTestFieldException.TableName
+//   (RecordPatches.TryCensusTableByName). Two DIFFERENT empty tables are asserted below, each
+//   explained with its own id, so a diagnosis that hardcoded or mis-attributed an id fails --
+//   a guard the single-table Base App version did not have.
+//
+//   It also removed a hazard rather than only cost: "Source Code Setup" stopped being
+//   guaranteed empty once #2348 fixed the install-time bug that had been keeping it empty by
+//   accident, so both "empty" tests needed a DeleteAll() to re-establish the precondition
+//   they used to inherit. A table only this fixture declares is empty by construction.
 public sealed class MissingTestDataDiagnosisTests : IDisposable
 {
     private static readonly string RepoRoot = Path.GetFullPath(
         Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
     private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
 
-    /// <summary>BC's own id for "Source Code Setup". Asserted literally so the diagnosis has to
-    /// have RESOLVED the table against real metadata; echoing a name back out of the message
-    /// would not produce it.</summary>
-    private const int SourceCodeSetupTableId = 242;
+    /// <summary>This fixture's own empty setup table. Asserted literally so the diagnosis has
+    /// to have RESOLVED the table against real metadata; no message below contains an id, so
+    /// echoing a name back could not produce it.</summary>
+    private const int DiagSetupTableId = 62441;
+
+    /// <summary>A SECOND empty table, so the id in the message is shown to track the table
+    /// rather than being a constant the diagnosis could carry. This is what the Base App
+    /// version could not assert with only one empty table in play.</summary>
+    private const int DiagOtherSetupTableId = 62443;
 
     private readonly string _root;
 
@@ -61,25 +78,26 @@ public sealed class MissingTestDataDiagnosisTests : IDisposable
     // ────────────────────────────────────────────────────────── the fixture ──
 
     /// <summary>
-    /// Four failures, chosen so that the two that must be explained and the two that must not
+    /// Six failures, chosen so that the ones that must be explained and the ones that must not
     /// are indistinguishable by exception type or message shape:
     ///
-    ///   EmptySetupTable_Get       — record-not-found on a table with NO rows        → explained
-    ///   PopulatedTable_Get        — record-not-found on a table WITH a row          → not explained
-    ///   EmptySetupTable_TestField — TestField on a table with NO rows               → explained
-    ///   PopulatedTable_TestField  — TestField on a table WITH a row                 → not explained
-    ///   PlainError                — an ordinary AL Error naming no table            → not explained
+    ///   EmptySetupTable_Get        — record-not-found on a table with NO rows       → explained
+    ///   PopulatedTable_Get         — record-not-found on a table WITH a row         → not explained
+    ///   EmptySetupTable_TestField  — TestField on a table with NO rows              → explained
+    ///   PopulatedTable_TestField   — TestField on a table WITH a row                → not explained
+    ///   OtherEmptyTable_Get        — record-not-found on a DIFFERENT empty table    → explained, own id
+    ///   PlainError                 — an ordinary AL Error naming no table           → not explained
     ///
-    /// "Source Code Setup" is the table #2240 measured 12 of its 16 failures on. "Payment
-    /// Method" is a Base App table the runner starts empty and this fixture inserts into, so
-    /// "populated" is a fact the test creates rather than one it inherits.
+    /// Every table here is declared by this fixture (#2364), so "empty" and "populated" are
+    /// both facts THIS TEST establishes: the empty ones are empty because nothing ever writes
+    /// to them, and the populated one is populated because the test inserts into it. The Base
+    /// App version of this fixture could say that only of the populated half — it had to call
+    /// DeleteAll() on "Source Code Setup" first, because a correct runner may seed it during
+    /// install (#2348).
     ///
-    /// "Source Code Setup" itself is NOT guaranteed empty by construction any more (#2348):
-    /// fixing IncludeSender sender-position dispatch also fixed a latent install-time bug that
-    /// used to leave Codeunit2's OnBeforeSourceCodeSetupInsert NRE-ing silently, which — before
-    /// that fix — happened to keep this table permanently empty as a side effect. A correct
-    /// runner may now legitimately seed it during install, so the two "EmptySetupTable_*"
-    /// procedures below call DeleteAll() first to make "no rows" a fact THIS TEST guarantees.
+    /// "Sales Journal" keeps its name from the real failure #2240 measured
+    /// (`Invoice Nos. must have a value in Purchases &amp; Payables Setup`), so the
+    /// NavTestFieldException route is exercised on the message shape that route actually sees.
     /// </summary>
     private static void WriteFixture(string dir)
     {
@@ -91,10 +109,43 @@ public sealed class MissingTestDataDiagnosisTests : IDisposable
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "27.0.0.0",
-          "application": "27.0.0.0",
           "idRanges": [ { "from": 62440, "to": 62449 } ],
           "runtime": "17.0",
           "target": "Cloud"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(dir, "DiagTables.al"), """
+        table 62441 "Diag Setup"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "Primary Key"; Code[10]) { }
+                field(2; "Sales Journal"; Code[10]) { }
+            }
+            keys { key(PK; "Primary Key") { Clustered = true; } }
+        }
+
+        table 62442 "Diag Populated"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "Code"; Code[10]) { }
+                field(2; "Description"; Text[50]) { }
+            }
+            keys { key(PK; "Code") { Clustered = true; } }
+        }
+
+        table 62443 "Diag Other Setup"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "Primary Key"; Code[10]) { }
+            }
+            keys { key(PK; "Primary Key") { Clustered = true; } }
         }
         """);
 
@@ -106,50 +157,49 @@ public sealed class MissingTestDataDiagnosisTests : IDisposable
             [Test]
             procedure EmptySetupTable_Get()
             var
-                SourceCodeSetup: Record "Source Code Setup";
+                DiagSetup: Record "Diag Setup";
             begin
-                // #2348: fixing IncludeSender sender-position dispatch also fixed a latent
-                // install-time bug that used to leave this table's own default-row insert
-                // silently broken, so a fresh company may now legitimately arrive with a row
-                // already in it (Codeunit2's OnBeforeSourceCodeSetupInsert firing correctly).
-                // DeleteAll() first so "no rows" is still a fact this test GUARANTEES, not one
-                // it merely used to inherit from a broken install.
-                SourceCodeSetup.DeleteAll();
-                SourceCodeSetup.Get();
+                DiagSetup.Get();
             end;
 
             [Test]
             procedure PopulatedTable_Get()
             var
-                PaymentMethod: Record "Payment Method";
+                DiagPopulated: Record "Diag Populated";
             begin
-                PaymentMethod.Init();
-                PaymentMethod.Code := 'DIAG-A';
-                PaymentMethod.Description := 'populated on purpose';
-                PaymentMethod.Insert(true);
-                PaymentMethod.Get('NOPE');
+                DiagPopulated.Init();
+                DiagPopulated.Code := 'DIAG-A';
+                DiagPopulated.Description := 'populated on purpose';
+                DiagPopulated.Insert(true);
+                DiagPopulated.Get('NOPE');
             end;
 
             [Test]
             procedure EmptySetupTable_TestField()
             var
-                SourceCodeSetup: Record "Source Code Setup";
+                DiagSetup: Record "Diag Setup";
             begin
-                // Same #2348 guarantee as EmptySetupTable_Get above — DeleteAll() first.
-                SourceCodeSetup.DeleteAll();
-                SourceCodeSetup.Init();
-                SourceCodeSetup.TestField("Sales Journal");
+                DiagSetup.Init();
+                DiagSetup.TestField("Sales Journal");
             end;
 
             [Test]
             procedure PopulatedTable_TestField()
             var
-                PaymentMethod: Record "Payment Method";
+                DiagPopulated: Record "Diag Populated";
             begin
-                PaymentMethod.Init();
-                PaymentMethod.Code := 'DIAG-B';
-                PaymentMethod.Insert(true);
-                PaymentMethod.TestField(Description);
+                DiagPopulated.Init();
+                DiagPopulated.Code := 'DIAG-B';
+                DiagPopulated.Insert(true);
+                DiagPopulated.TestField(Description);
+            end;
+
+            [Test]
+            procedure OtherEmptyTable_Get()
+            var
+                DiagOtherSetup: Record "Diag Other Setup";
+            begin
+                DiagOtherSetup.Get();
             end;
 
             [Test]
@@ -240,16 +290,26 @@ public sealed class MissingTestDataDiagnosisTests : IDisposable
         var emptyGet = BlockFor(output, "EmptySetupTable_Get");
         // BC's own failure, untouched. If this line ever changes shape the diagnosis is
         // replacing the failure instead of sitting next to it, which #2240 forbids.
-        Assert.Contains("NavCSideRecordNotFoundException: The Source Code Setup does not exist.",
+        Assert.Contains("NavCSideRecordNotFoundException: The Diag Setup does not exist.",
             emptyGet, StringComparison.Ordinal);
-        Assert.Contains($"[test-data] 'Source Code Setup' (table {SourceCodeSetupTableId}) has no rows in this run",
+        Assert.Contains($"[test-data] 'Diag Setup' (table {DiagSetupTableId}) has no rows in this run",
             emptyGet, StringComparison.Ordinal);
         // It must say what to do, not merely what happened.
         Assert.Contains("--test-data", emptyGet, StringComparison.Ordinal);
 
+        // ── explained, with ITS OWN id: a second empty table, same failure shape. Together
+        // with the block above this is what makes "the diagnosis resolved the table" a claim
+        // rather than a coincidence — one hardcoded or mis-attributed id cannot satisfy both.
+        var otherGet = BlockFor(output, "OtherEmptyTable_Get");
+        Assert.Contains("NavCSideRecordNotFoundException: The Diag Other Setup does not exist.",
+            otherGet, StringComparison.Ordinal);
+        Assert.Contains($"[test-data] 'Diag Other Setup' (table {DiagOtherSetupTableId}) has no rows in this run",
+            otherGet, StringComparison.Ordinal);
+        Assert.DoesNotContain($"table {DiagSetupTableId}", otherGet, StringComparison.Ordinal);
+
         // ── NOT explained: same exception type, same message shape, table has a row ──
         var populatedGet = BlockFor(output, "PopulatedTable_Get");
-        Assert.Contains("NavCSideRecordNotFoundException: The Payment Method does not exist.",
+        Assert.Contains("NavCSideRecordNotFoundException: The Diag Populated does not exist.",
             populatedGet, StringComparison.Ordinal);
         Assert.DoesNotContain("[test-data]", populatedGet, StringComparison.Ordinal);
     }
@@ -269,13 +329,13 @@ public sealed class MissingTestDataDiagnosisTests : IDisposable
         var (output, _) = RunRunner();
 
         var emptyTestField = BlockFor(output, "EmptySetupTable_TestField");
-        Assert.Contains("NavTestFieldException: Sales Journal must have a value in Source Code Setup",
+        Assert.Contains("NavTestFieldException: Sales Journal must have a value in Diag Setup",
             emptyTestField, StringComparison.Ordinal);
-        Assert.Contains($"[test-data] 'Source Code Setup' (table {SourceCodeSetupTableId}) has no rows in this run",
+        Assert.Contains($"[test-data] 'Diag Setup' (table {DiagSetupTableId}) has no rows in this run",
             emptyTestField, StringComparison.Ordinal);
 
         var populatedTestField = BlockFor(output, "PopulatedTable_TestField");
-        Assert.Contains("NavTestFieldException: Description must have a value in Payment Method",
+        Assert.Contains("NavTestFieldException: Description must have a value in Diag Populated",
             populatedTestField, StringComparison.Ordinal);
         Assert.DoesNotContain("[test-data]", populatedTestField, StringComparison.Ordinal);
     }
@@ -329,10 +389,10 @@ public sealed class MissingTestDataDiagnosisTests : IDisposable
 
         var emptyGet = BlockFor(output, "EmptySetupTable_Get");
         // Still BC's own failure, still untouched.
-        Assert.Contains("NavCSideRecordNotFoundException: The Source Code Setup does not exist.",
+        Assert.Contains("NavCSideRecordNotFoundException: The Diag Setup does not exist.",
             emptyGet, StringComparison.Ordinal);
         // And a DIFFERENT sentence from the flag-off one — this is the whole claim.
-        Assert.Contains($"[test-data] 'Source Code Setup' (table {SourceCodeSetupTableId}) still has no rows although --test-data is on",
+        Assert.Contains($"[test-data] 'Diag Setup' (table {DiagSetupTableId}) still has no rows although --test-data is on",
             emptyGet, StringComparison.Ordinal);
         Assert.Contains("refused", emptyGet, StringComparison.Ordinal);
         // The flag-off wording must NOT appear: telling a user who already passed --test-data
@@ -344,17 +404,21 @@ public sealed class MissingTestDataDiagnosisTests : IDisposable
     }
 
     /// <summary>
-    /// A `bcbak` stand-in: one company, one table in scope ("Source Code Setup", AL id 242,
-    /// non-zero row count so BuildPlan keeps it), and a read that hands back a column the AL
-    /// table has no field for so the hydration refuses it and the table stays empty.
-    /// No `$ext` companion, so the once-per-run merge probe does not run.
+    /// A `bcbak` stand-in: one company, one table in scope ("Diag Setup", non-zero row count
+    /// so BuildPlan keeps it), and a read that hands back a column the AL table has no field
+    /// for so the hydration refuses it and the table stays empty. No `$ext` companion, so the
+    /// once-per-run merge probe does not run.
+    ///
+    /// #2364: the app name in the resolution column is free text as far as BackupCatalog is
+    /// concerned — nothing keys on "Base Application" — so naming this fixture's own app here
+    /// exercises the same parse and the same plan.
     /// </summary>
     private static string FakeReaderScript() =>
         "#!/bin/sh\n"
         + "cmd=\"$1\"\n"
         + "case \"$cmd\" in\n"
         + "  companies) echo 'CRONUS' ;;\n"
-        + $"  tables) printf '%s\\n' '   4 Table\tCRONUS\tSource Code Setup\t{SourceCodeSetupTableId} \"Source Code Setup\" (Base Application)' ;;\n"
+        + $"  tables) printf '%s\\n' '   4 Table\tCRONUS\tDiag Setup\t{DiagSetupTableId} \"Diag Setup\" (Missing Test Data Diagnosis Fixture)' ;;\n"
         + "  read) echo '[{\"Not An AL Field Of This Table\": 1}]' ;;\n"
         + "esac\n";
 }


### PR DESCRIPTION
Closes #2364

Opened by agent impl-9.

The three entries on `BaseAppFloorFixtureGuardTests`'s `AllowedSources` list were debt, not
permission. None of them asserted anything about Base Application — each leaned on one property
the floor happened to supply, and all three properties turned out cheaper to supply directly than
to load the whole closure for.

`AllowedSources` is now two entries, both legitimate. `.claude/rules/no-base-app-in-csharp-tests.md`
loses its "outstanding violations" section.

## What each class needed, and what it got

**`InstallBaselineDiskCacheTests`, `InstallSeedDepCompanyCacheTests`** needed a dependency closure
whose install triggers write rows. Without one the codec logs `not persisting: snapshot has 0
DataAccessSource(s)`, nothing reaches disk, and every assertion in both suites passes having
observed nothing. They now share `AlRunner.Tests/InstallSeedClosure.cs`: a dependency app with one
table and one `OnInstallAppPerCompany` trigger inserting two rows, read back **by value** in AL —
marker text, a positive decimal, a negative decimal, and the row count.

The seed app is a sibling source dependency rather than a second bundle, so each closure is one app
group. That is for the assertions, not for speed (measured: one app group vs two is within noise).
It let two assertions get *stronger*: `Assert.Equal(0, MISS count)` is now exact instead of a
key-set intersection, and the HIT test asserts `1 MISS / 0 DISK-HIT / 1 HIT` exactly instead of
`MISS + DISK-HIT == 1`, because a fresh-GUID closure cannot be answered by an entry an earlier run
left behind.

**`MissingTestDataDiagnosisTests`** needed a table it could resolve against real metadata and assert
the id of, so the diagnosis could not pass by echoing a name back. It now declares three tables of
its own and asserts that **two different** empty tables are each explained with their own id. That
is a stronger claim than the Base App version could make with one id — see the RED evidence below.

It also removed a hazard. "Source Code Setup" stopped being empty by construction once #2348 fixed
the install-time bug that had been keeping it empty by accident, so both "empty" tests needed a
`DeleteAll()` to re-establish their own precondition. A table only this fixture declares is empty
because nothing writes to it.

## RED → GREEN

Every claim was mutated in `AlRunner/` (never in the tests), rebuilt, and re-run. All mutations
reverted; the tree that CI measures has none of them.

| mutation | expected | observed |
|---|---|---|
| diagnosis: flip the emptiness guard (`Rows == 0` → bail) | positives fail | 3 of 4 fail, `Assert.Contains` on `(table 62441)` |
| diagnosis: drop the emptiness guard entirely | negatives fail | 3 of 4 fail, `Assert.DoesNotContain` — a populated table got explained |
| diagnosis: hardcode the id in the message to `62441` | only the second-table assertion fails | exactly 1 of 4 fails, on `'Diag Other Setup' (table 62443)` |
| disk codec: persist a snapshot with no tables | the AL assertion fails, not just the digest | second process logs `DISK-HIT` and the AL test **fails** on `The Seed sa Table does not exist` |
| in-memory tier: never store the snapshot | the HIT test fails | 1 of 3 fails |
| whole cache key constant | both scoping tests fail | 2 of 7 fail |

The fourth row is the one that matters most for #2364's stated bar. Under it the cache reports
`DISK-HIT` — so a marker-only test would pass — while the AL assertion fails on the missing seeded
row. That is the vacuity this rework had to avoid and does.

The third row is the specific strengthening: with the id hardcoded, the three assertions inherited
from the Base App version all still pass, and only the newly added second-table assertion catches
it.

GREEN: `dotnet test -c Release --no-build AlRunner.Tests --filter` over all four affected classes —
**26 passed, 0 failed**. Test count across the three reworked suites is 11 before and 11 after;
nothing was dropped to get the saving.

## Measurement

Per invocation, BC 28.1, `perf stat` instructions-retired (wall clock is unreliable here — several
agents were running on this box), private `--cache` root outside the repository, **two bundles in
both arms so only the floor differs**:

| | instructions | wall |
|---|---|---|
| with `"application"`, cold | 249.6e9 | 33.9 s |
| without, cold | **63.7e9 (-74.5%)** | 10.9 s |
| with `"application"`, warm | 47.9e9 | 6.9 s |
| without, warm | **14.9e9 (-68.9%)** | 2.8 s |

Run-to-run spread on instructions was 0.1-1.3%, against wall-clock spread of up to 40% on the same
runs — which is why the instruction counts lead.

End to end, the three suites together, three reps each, `dotnet test --no-build`:

| arm | rep 1 | rep 2 | rep 3 | mean |
|---|---|---|---|---|
| before | 176.4 s | 209.8 s | 188.5 s | **191.6 s** |
| after | 40.0 s | 75.0 s | 50.8 s | **55.3 s** |
| control (`PlaceholderFloorProvisioningTests`, untouched, keeps the floor) — before | 8.1 s | 11.1 s | 10.7 s | **10.0 s** |
| control — after | 9.1 s | 11.2 s | 10.4 s | **10.2 s** |

**-71%, about 136 s per CI leg.** The control moved +0.2 s, well inside the spread of both arms,
which is what makes the delta a measurement rather than a statement about a loaded machine. Both
arms were measured from worktrees at the same base commit.

## Where my measurement contradicts the rule's own account

The rule's table says 94.9 s cold with the floor and 25.2 s without. I measured 33.9 s and 10.9 s
on this box. The **ratio** reproduces closely (-73.4% there, -67.8% wall / -74.5% instructions
here); the absolute cold numbers do not, because a private `--cache` root still shares
`~/.al-runner/platform-apps`, so my "cold" is colder than a first-ever run but warmer than theirs.
I left the rule's original table alone and added mine beside it rather than overwriting a
measurement I could not reproduce the conditions for.

## A gap I found and did not fix — #3254

While mutating for the RED evidence I found the two scoping tests cannot attribute what they prove.
`TestExecutor.CurrentInstallBaselineCacheKey()` has two components that are redundant for this
scenario: flattening `CurrentDependencySetKey()` alone leaves all 7 tests green, flattening
`RegisteredBcAppSymbolStateKey()` alone leaves all 7 green, and only flattening both turns the two
scoping tests red. Their comment claimed the first specifically. It was wrong and no test had ever
checked it.

Pre-existing, and unchanged in either direction by this PR. I corrected both comments to state what
is actually pinned and filed #3254 for closing the gap, rather than leaving a claim in place that
measurement contradicts. #3254 stays open after this merges.

## The three sibling questions

1. **Same wrong pattern at another call site?** No. `AllowedSources` and `AllowedFixtures` are the
   complete inventory, the guard enforces both halves, and its stale-entry fact fails if an entry
   stops being a violation — so removing the three entries is checked, not asserted.
2. **Sibling making the same assumption?** The two remaining `AllowedSources` entries and both
   remaining `AllowedFixtures` entries were re-read. All four have the floor itself as their
   subject: `PlaceholderFloorProvisioningTests`, `ProvisionExplicitModesTests`, `BcFloorSkip`
   (two fixtures) and `SubscriberScanAudit`. None is the shape I just fixed.
3. **Two paths writing the same state with different invariants?** The one I found is #3254 above.

## Scope

Six files, none under `AlRunner/` — so `require-tests` does not trigger. No `CHANGELOG.md`, no
corpus submodule change, no `tests/expectations/count-baseline` change (no AL corpus test is added
or removed). Rebased onto current `origin/main`; `git merge-tree` reports CLEAN.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
