### PR TITLE
fix(testpage): make TestPage.View() and TestPage.Edit() open the CardPageId card

### DIFF
--- a/AlRunner.Tests/TestPageViewEditActionBindingTests.cs
+++ b/AlRunner.Tests/TestPageViewEditActionBindingTests.cs
@@ -1,0 +1,216 @@
+// TestPageViewEditActionBindingTests — the runner-internal half of issue #3185.
+//
+// AL's `SomePage.View()` / `SomePage.Edit()` raised
+//     InvalidOperationException: The UISessionManager was expected to be initialized.
+//     at TestPageClientSession.GetTestLogicalDispatcher()
+// because NavTestPageBase.ALView()/ALEdit() wrap their result in
+// TestClientProxy<ITestAction>.Proxy(...) and NclCecilRewrite's step 4 stripped that call from
+// a HARD-CODED LIST OF SIX method names, while NavTestPageBase has EIGHT Proxy call sites. The
+// two the list did not name were exactly ALView and ALEdit.
+//
+// WHAT IS PINNED WHERE. What the built-in View/Edit actions DO on real BC — the card opens,
+// once, on the list's current row, read-only for View and editable for Edit — is a plain
+// BC-behaviour claim and is measured upstream on a service tier: corpus codeunit 60461
+// "TPVE Tests" (StefanMaron/BusinessCentral.AL.Language.Tests#203). Nothing here duplicates it.
+//
+// These are RUNNER-INTERNAL claims only:
+//   * that our Cecil pass leaves NO TestClientProxy.Proxy call anywhere on NavTestPageBase,
+//     rather than on six named methods — the defect was the list, so the test is over the type;
+//   * that it removed the PROXY and not the call underneath it, so ALView still asks the
+//     runner's ITestPage for its View action;
+//   * that RunnerPendingPageOpenMode, the runner's stand-in for the FormState(ViewMode) BC's
+//     client hands its form builder, is consumed exactly once and only by the page it was
+//     armed for.
+using System.Linq;
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Runtime;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Reads the Ncl image this process actually loaded, which BcEngineBootstrap has already
+// Cecil-rewritten in place — so it must share the serial bc-engine collection.
+[Collection(BcEngineCollection.Name)]
+public class TestPageViewEditActionBindingTests
+{
+    private readonly BcEngineFixture _engine;
+
+    public TestPageViewEditActionBindingTests(BcEngineFixture engine) => _engine = engine;
+
+    private static TypeDefinition NavTestPageBase()
+    {
+        var nclPath = typeof(ITreeObject).Assembly.Location;
+        var asm = AssemblyDefinition.ReadAssembly(nclPath);
+        var type = asm.MainModule.GetType("Microsoft.Dynamics.Nav.Runtime.NavTestPageBase");
+        Assert.NotNull(type);
+        return type!;
+    }
+
+    private static bool CallsProxy(MethodDefinition m)
+        => m.HasBody && m.Body.Instructions.Any(i =>
+            i.OpCode == OpCodes.Call
+            && i.Operand is MethodReference mr
+            && mr.Name == "Proxy"
+            && mr.DeclaringType.Name.StartsWith("TestClientProxy", System.StringComparison.Ordinal));
+
+    private static bool CallsInterfaceMember(MethodDefinition m, string memberName)
+        => m.HasBody && m.Body.Instructions.Any(i =>
+            (i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt)
+            && i.Operand is MethodReference mr
+            && mr.Name == memberName
+            && mr.DeclaringType.Name == "ITestPage");
+
+    private static MethodDefinition Method(TypeDefinition type, string name)
+    {
+        var m = type.Methods.FirstOrDefault(x => x.Name == name && x.HasBody);
+        Assert.True(m != null, $"NavTestPageBase.{name}() not found — Ncl shape changed.");
+        return m!;
+    }
+
+    // THE REGRESSION. Named per method so a failure says which one came back, and stated over
+    // the WHOLE type so a ninth call site in a future Ncl fails here rather than in the corpus.
+    [SkippableFact]
+    public void NoNavTestPageBaseMethodStillCallsTestClientProxy()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var offenders = NavTestPageBase().Methods.Where(CallsProxy).Select(m => m.Name).ToList();
+        Assert.True(offenders.Count == 0,
+            "Every TestClientProxy.Proxy call site on NavTestPageBase must be stripped — Proxy "
+            + "needs the client's test dispatcher, which does not exist in this process, and "
+            + "reaching one raises 'The UISessionManager was expected to be initialized.' Still "
+            + $"calling it: {string.Join(", ", offenders)}");
+    }
+
+    // The two the old six-name list missed, called out on their own so the failure message
+    // names issue #3185's actual surface rather than a set difference.
+    [SkippableTheory]
+    [InlineData("ALView")]
+    [InlineData("ALEdit")]
+    public void PageModeAffordanceDoesNotReachTheClientDispatcher(string methodName)
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        Assert.False(CallsProxy(Method(NavTestPageBase(), methodName)),
+            $"NavTestPageBase.{methodName}() is AL's TestPage.{methodName.Substring(2)}(); with "
+            + "the Proxy call left in place it raises 'The UISessionManager was expected to be "
+            + "initialized.' before any page can open (#3185).");
+    }
+
+    // The other direction, and the one a blunt "delete the instruction" fix would break: the
+    // rewrite removes the PROXY WRAPPER, not the call it wraps. ALView must still ask the
+    // runner's own ITestPage for its View action, otherwise it would hand BC a null
+    // NavTestAction and AL's .Invoke() would surface as a bare NullReferenceException.
+    [SkippableTheory]
+    [InlineData("ALView", "View")]
+    [InlineData("ALEdit", "Edit")]
+    public void PageModeAffordanceStillAsksTheRunnersTestPage(string methodName, string member)
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        Assert.True(CallsInterfaceMember(Method(NavTestPageBase(), methodName), member),
+            $"NavTestPageBase.{methodName}() must still call ITestPage.{member}() — that call is "
+            + "what reaches LiveNavTestPage's built-in page-mode action.");
+    }
+
+    // The six methods the old list DID name, so the sweep that replaced it cannot be a
+    // regression for them either.
+    [SkippableTheory]
+    [InlineData("GetField")]
+    [InlineData("GetAction")]
+    [InlineData("GetDataItem")]
+    [InlineData("GetPart")]
+    [InlineData("GetBuiltInAction")]
+    [InlineData("FindBuiltInAction")]
+    public void PreviouslyStrippedMethodsStayStripped(string methodName)
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        Assert.False(CallsProxy(Method(NavTestPageBase(), methodName)));
+    }
+}
+
+// The ambient open mode, as a pure unit — no BC runtime, so every row of its contract is
+// reachable. BC carries the requested mode as `new FormState(ViewMode)` into its form builder;
+// NavForm.RunAsync hands back no form to configure, so the runner parks the mode here for
+// RunnerModalDispatch to stamp onto the form it is about to open.
+public class RunnerPendingPageOpenModeTests
+{
+    public RunnerPendingPageOpenModeTests() => RunnerPendingPageOpenMode.Disarm();
+
+    [Fact]
+    public void NothingArmed_ConsumesNothing()
+    {
+        Assert.False(RunnerPendingPageOpenMode.TryConsume(60458, out var readOnly));
+        Assert.False(readOnly);
+    }
+
+    [Fact]
+    public void ArmedReadOnly_IsConsumedByTheArmedPage()
+    {
+        RunnerPendingPageOpenMode.Arm(60458, readOnly: true);
+        Assert.True(RunnerPendingPageOpenMode.TryConsume(60458, out var readOnly));
+        Assert.True(readOnly);
+    }
+
+    // Edit mode arms too, and must answer FALSE rather than "nothing armed" — the two are
+    // different: RunnerModalDispatch leaves NavForm.Editable exactly as InitializeFromMetadata
+    // set it in both cases, so a caller cannot tell them apart from the return value alone, and
+    // a future caller that could would read a wrong answer here.
+    [Fact]
+    public void ArmedEditable_IsConsumedAndReportsNotReadOnly()
+    {
+        RunnerPendingPageOpenMode.Arm(60458, readOnly: false);
+        Assert.True(RunnerPendingPageOpenMode.TryConsume(60458, out var readOnly));
+        Assert.False(readOnly);
+    }
+
+    // The load-bearing one: a page opened from inside the target's OWN OnOpenPage is a
+    // different open and must not inherit this mode.
+    [Fact]
+    public void ConsumedOnce_TheSecondReadFindsNothing()
+    {
+        RunnerPendingPageOpenMode.Arm(60458, readOnly: true);
+        Assert.True(RunnerPendingPageOpenMode.TryConsume(60458, out _));
+        Assert.False(RunnerPendingPageOpenMode.TryConsume(60458, out var readOnly));
+        Assert.False(readOnly);
+    }
+
+    // Armed for one page, asked about another — the mode stays armed for its own page rather
+    // than leaking onto whatever opens first.
+    [Fact]
+    public void ADifferentPageDoesNotConsumeIt()
+    {
+        RunnerPendingPageOpenMode.Arm(60458, readOnly: true);
+        Assert.False(RunnerPendingPageOpenMode.TryConsume(60459, out var readOnly));
+        Assert.False(readOnly);
+        Assert.True(RunnerPendingPageOpenMode.TryConsume(60458, out readOnly));
+        Assert.True(readOnly);
+    }
+
+    // Page id 0 is "the form's page number could not be read", never a wildcard.
+    [Fact]
+    public void PageIdZeroNeverConsumes()
+    {
+        RunnerPendingPageOpenMode.Arm(60458, readOnly: true);
+        Assert.False(RunnerPendingPageOpenMode.TryConsume(0, out _));
+        Assert.True(RunnerPendingPageOpenMode.TryConsume(60458, out _));
+    }
+
+    // Disarm is what RunnerPendingPageOpenMode's caller runs in a finally: an open that never
+    // reached the dispatch (the page refused to open) must not leave the mode armed for a
+    // later, unrelated open of the same page on this thread.
+    [Fact]
+    public void Disarm_DropsAnUnconsumedMode()
+    {
+        RunnerPendingPageOpenMode.Arm(60458, readOnly: true);
+        RunnerPendingPageOpenMode.Disarm();
+        Assert.False(RunnerPendingPageOpenMode.TryConsume(60458, out _));
+    }
+}

--- a/AlRunner/Infrastructure/NclCecilRewrite.Forms.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Forms.cs
@@ -838,31 +838,53 @@ public static partial class NclCecilRewrite
                 + "(the runner's ITestPage is in-process; no client dispatcher exists)");
         }
 
-        // 4. Remove TestClientProxy<T>.Proxy(T) call from all NavTestPageBase methods that use it.
-        //    Removing the call leaves the raw ITest* value on the stack in the right place.
+        // 4. Remove TestClientProxy<T>.Proxy(T) call from EVERY NavTestPageBase method that
+        //    uses it. Removing the call leaves the raw ITest* value on the stack in the right
+        //    place, because the runner's ITestPage is in-process and needs no marshalling.
+        //
+        //    This used to be a hard-coded list of six method names — GetField, GetAction,
+        //    GetDataItem, GetPart, GetBuiltInAction, FindBuiltInAction — and NavTestPageBase
+        //    has EIGHT Proxy call sites, not six. The two it left out are ALView() and
+        //    ALEdit(), i.e. AL's `SomePage.View()` and `SomePage.Edit()`, so both raised
+        //    "The UISessionManager was expected to be initialized." from
+        //    TestPageClientSession.GetTestLogicalDispatcher() before any page could open
+        //    (issue #3185). A list of names cannot notice a call site it does not name, and a
+        //    later Ncl version adding a ninth would reintroduce exactly the same defect, so
+        //    the sweep is over the type — the same shape step 3 above already uses for
+        //    NavTestExecution.
         {
-            var methodsToFix = new[] { "GetField", "GetAction", "GetDataItem", "GetPart", "GetBuiltInAction", "FindBuiltInAction" };
             int removedCount = 0;
-            foreach (var methodName in methodsToFix)
+            var touched = new List<string>();
+            foreach (var method in navTestPageBaseType.Methods.Where(m => m.HasBody))
             {
-                foreach (var method in navTestPageBaseType.Methods
-                    .Where(m => m.Name == methodName && m.HasBody))
+                var il = method.Body.GetILProcessor();
+                var proxyCalls = method.Body.Instructions
+                    .Where(i => i.OpCode == OpCodes.Call &&
+                           i.Operand is MethodReference mr &&
+                           mr.Name == "Proxy" &&
+                           mr.DeclaringType.Name.StartsWith("TestClientProxy", StringComparison.Ordinal))
+                    .ToList();
+                if (proxyCalls.Count == 0) continue;
+                foreach (var instr in proxyCalls)
                 {
-                    var il = method.Body.GetILProcessor();
-                    var proxyCalls = method.Body.Instructions
-                        .Where(i => i.OpCode == OpCodes.Call &&
-                               i.Operand is MethodReference mr &&
-                               mr.Name == "Proxy" &&
-                               mr.DeclaringType.Name.StartsWith("TestClientProxy"))
-                        .ToList();
-                    foreach (var instr in proxyCalls)
-                    {
-                        il.Remove(instr);
-                        removedCount++;
-                    }
+                    il.Remove(instr);
+                    removedCount++;
                 }
+                touched.Add(method.Name);
             }
-            Console.Error.WriteLine($"[Cecil] Removed {removedCount} TestClientProxy.Proxy call(s) from NavTestPageBase");
+
+            // A shape guard, not a formality: if a future Ncl stops routing these through
+            // TestClientProxy the sweep silently removes nothing and every TestPage member
+            // goes back to needing a client dispatcher, which is the failure this step exists
+            // to prevent. Eight call sites across eight methods in BC 28.1.
+            if (removedCount == 0)
+                throw new InvalidOperationException(
+                    "[Cecil] NavTestPageBase has no TestClientProxy.Proxy call sites — Ncl shape "
+                    + "changed; do not commit");
+
+            Console.Error.WriteLine(
+                $"[Cecil] Removed {removedCount} TestClientProxy.Proxy call(s) from NavTestPageBase "
+                + $"({string.Join(", ", touched)})");
         }
 
         // 5. NavTestPageBase.LoadMetadata() — replace body with `ldnull; ret`.

--- a/AlRunner/Patches/BuiltInPageModeAction.cs
+++ b/AlRunner/Patches/BuiltInPageModeAction.cs
@@ -1,0 +1,169 @@
+// BuiltInPageModeAction — AL's `SomePage.View()` and `SomePage.Edit()` on a TestPage.
+//
+// THE GAP (issue #3185)
+//   Both raised "InvalidOperationException: The UISessionManager was expected to be
+//   initialized." from TestPageClientSession.GetTestLogicalDispatcher(), before any page could
+//   open. Two independent causes, and the first one hid the second:
+//
+//   1. NavTestPageBase.ALView()/ALEdit() wrap their result in TestClientProxy<ITestAction>
+//      .Proxy(...), which needs the client's dispatcher. NclCecilRewrite step 4 strips that
+//      call from NavTestPageBase — but it used to strip it from a hard-coded list of six
+//      method names, and NavTestPageBase has EIGHT Proxy call sites. ALView and ALEdit were
+//      the two the list did not name. That step now sweeps the whole type.
+//
+//   2. Underneath it, ITestPage.View()/Edit() answered `new MockITestAction()`, whose Invoke()
+//      is a literal no-op. So even with the proxy gone, invoking either did nothing at all.
+//      This file is that half.
+//
+// WHAT REAL BC DOES, AND HOW THAT WAS ESTABLISHED
+//   Nothing in the application declares these actions; the CLIENT supplies them. The
+//   reference implementation is Microsoft.Dynamics.Nav.Client.TestPageClient.TestPageProxy
+//   (BC 28.1), and it is a lookup, not an effect:
+//
+//     public ITestAction View()  => the first ActionControl whose Action is a
+//         NavOpenTaskPageAction { IsPageModeAction: not false } with ViewMode == PageMode.View,
+//         wrapped in a TestActionProxy — or NULL when the page has none.
+//
+//   Edit() is the same with PageMode.Edit. Those actions are created by
+//   Microsoft.Dynamics.Nav.Client.FormBuilder.ActionBuilder, from MenuActionType.View /
+//   MenuActionType.Edit, and everything this file needs is in three of its methods:
+//
+//     * ResolveCardFormId — the TARGET. For a system menu action `actionDef.TargetID` is 0, so
+//       it falls back to the card page id in the builder context (a list page's CardPageId),
+//       then FormState.CardPageId, and only then — when the parent form is NOT a List — to the
+//       parent page's OWN id.
+//     * IsModifyAllowedInCard — the Edit action is not created at all when the card does not
+//       allow modification, which is why Edit() can legitimately answer null.
+//     * NavOpenTaskPageAction.FindFormState / CreateForm — the ROW and the MODE. `new
+//       FormState(ViewMode)` carries the requested mode onto the target, and the parent
+//       binding manager's CurrentRow bookmark is stamped onto it, so the card opens on the
+//       row the list is standing on.
+//
+//   And the service tier has adjudicated the result: corpus codeunit 60461 "TPVE Tests"
+//   (StefanMaron/BusinessCentral.AL.Language.Tests#203) drives a List with CardPageId, parks it
+//   on its second row, invokes each action, and asserts that the card opens exactly once, on
+//   that row, that the [PageHandler] ran, and that View gives the handler a read-only page
+//   while Edit gives it an editable one.
+//
+// WHAT THIS FILE IMPLEMENTS
+//   Exactly the measured shape: a page that declares a resolvable CardPageId opens that card,
+//   on the host's current row, in the requested mode, through BC's own NavForm front door —
+//   so handler lookup, TestPage.Trap() and the "Unhandled UI" refusal stay BC's.
+//
+// WHAT IT REFUSES, LOUDLY
+//   The in-place variant, where ResolveCardFormId lands on the host page's own id and
+//   NavOpenTaskPageAction.InvokeCore switches THAT page's mode instead of opening anything
+//   (UseCurrentForm -> PageModeAggregator.ChangePageMode). No corpus test measures it, the
+//   runner models a TestPage's editability as a value fixed at open time, and answering it by
+//   opening a second copy of the page would be a silent wrong answer. Issue #3258.
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+
+namespace AlRunner.Patches;
+
+/// <summary>
+/// The open mode a built-in page-mode action asked for, handed to the page BC is about to
+/// open. BC carries it as <c>FormState(ViewMode)</c> into the builder; the runner has no
+/// builder, and <c>NavForm.RunAsync</c> hands back no form to configure, so it is parked here
+/// for the dispatch that DOES see the form — <see cref="RunnerModalDispatch"/>, immediately
+/// before it raises OnOpenPage.
+///
+/// <para>Read ONCE, and only by the page id it was armed for. A page opened from inside the
+/// target's own OnOpenPage is a different open and must not inherit this one's mode; consuming
+/// on the first matching read is what keeps that true without tracking a stack.</para>
+/// </summary>
+internal static class RunnerPendingPageOpenMode
+{
+    [ThreadStatic] private static int _pageId;
+    [ThreadStatic] private static bool _readOnly;
+
+    /// <summary>Arm the mode for the next open of <paramref name="pageId"/> on this thread.</summary>
+    internal static void Arm(int pageId, bool readOnly)
+    {
+        _pageId = pageId;
+        _readOnly = readOnly;
+    }
+
+    /// <summary>Drop an armed mode that was never consumed — the page refused to open, or BC
+    /// answered the run some other way. Without this a later, unrelated open of the same page
+    /// on this thread would pick it up.</summary>
+    internal static void Disarm() => _pageId = 0;
+
+    /// <summary>
+    /// The mode armed for <paramref name="pageId"/>, consumed. False when nothing was armed
+    /// for that page, which is the normal case for every other page open in the run.
+    /// </summary>
+    internal static bool TryConsume(int pageId, out bool readOnly)
+    {
+        readOnly = false;
+        if (pageId == 0 || _pageId != pageId) return false;
+        readOnly = _readOnly;
+        _pageId = 0;
+        return true;
+    }
+}
+
+/// <summary>
+/// A page's built-in View / Edit action, wired to the page it actually opens. See this file's
+/// header for what BC's own client does and where each rule below is read from.
+/// </summary>
+internal sealed class BuiltInPageModeAction : ITestAction
+{
+    private readonly LiveNavTestPage _host;
+    private readonly NavRecord? _record;
+    private readonly int _targetPageId;
+    private readonly bool _viewMode;
+
+    internal BuiltInPageModeAction(LiveNavTestPage host, NavRecord? record, int targetPageId, bool viewMode)
+    {
+        _host = host;
+        _record = record;
+        _targetPageId = targetPageId;
+        _viewMode = viewMode;
+    }
+
+    /// <summary>
+    /// Save the current row, then open the card on it — the same order
+    /// <see cref="LiveNavTestAction"/> uses, and BC's: <c>LogicalAction.RequiresSave</c> is set
+    /// to true in <c>NavOpenTaskPageAction</c>'s constructor, so a real client sends the row it
+    /// is standing on to the server before the action runs.
+    /// </summary>
+    public void Invoke()
+    {
+        _host.SaveCurrentRow();
+
+        // The mode has to be in place BEFORE the form opens: OnOpenPage is AL that can read
+        // CurrPage.Editable, and the [PageHandler] reads it through TestPage.Editable().
+        RunnerPendingPageOpenMode.Arm(_targetPageId, readOnly: _viewMode);
+        try
+        {
+            // The host's current row, which is what BC stamps onto the target's form state as
+            // `parentBindingManager.CurrentRow.Bookmark` — the runner's equivalent of a
+            // bookmark is handing BC's own page-run front door the record itself, exactly as
+            // an action's `RunPageOnRec` already does (RunnerPageInstance.ActionRunObject).
+            RunnerPageInstance.RunPageThroughBcFrontDoor(_targetPageId, _record);
+        }
+        finally
+        {
+            RunnerPendingPageOpenMode.Disarm();
+        }
+    }
+
+    /// <summary>
+    /// True, and the reason is structural rather than a default: in BC these two properties
+    /// answer <c>LogicalAction.CanInvoke</c>, whereas whether the action EXISTS at all is
+    /// decided earlier, by ActionBuilder — and that is the half this runner models, in
+    /// <see cref="LiveNavTestPage.BuiltInPageModeActionFor"/>. An action that got this far was
+    /// created by the builder's own rules.
+    ///
+    /// <para>What is NOT modelled: CanInvoke additionally refuses a multi-row selection
+    /// (<c>IsMultipleSelectionDisabledAction</c>), and consults the action's FilterContext and
+    /// any already-open form for the same page. None of those has a runner equivalent — the
+    /// runner has no selection model and no window list — and no corpus test reads
+    /// <c>Visible</c>/<c>Enabled</c> on a built-in page-mode action. Issue #3258.</para>
+    /// </summary>
+    public bool Visible => true;
+
+    /// <inheritdoc cref="Visible"/>
+    public bool Enabled => true;
+}

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -66,8 +66,11 @@ internal class MockITestPage : ITestPage
     public virtual object?    GetBookmark()                                             => null;
     public virtual bool       GoToBookmark(object bookmark)                             => false;
     public virtual object[]   GetTableFieldValues(int[] fieldIds)                       => Array.Empty<object>();
-    public ITestAction        Edit()                                                    => new MockITestAction();
-    public ITestAction        View()                                                    => new MockITestAction();
+    // Virtual since #3185: LiveNavTestPage answers these with the page's real built-in
+    // page-mode actions. The base mock keeps the no-op action a page with no live instance
+    // has always had.
+    public virtual ITestAction Edit()                                                   => new MockITestAction();
+    public virtual ITestAction View()                                                   => new MockITestAction();
     public bool               Expand(bool doExpand)                                     => false;
 
     public int        ValidationErrorCount => 0;
@@ -521,6 +524,73 @@ internal class LiveNavTestPage : MockITestPage
         => pageType == null
            || string.Equals(pageType, "StandardDialog", StringComparison.OrdinalIgnoreCase)
            || string.Equals(pageType, "NavigatePage", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// AL's <c>SomePage.View()</c> — the page's built-in "open read-only" page-mode action.
+    /// Before #3185 this answered the base mock's no-op action, and could not even be reached:
+    /// NavTestPageBase.ALView() wraps it in TestClientProxy.Proxy, which NclCecilRewrite's
+    /// hard-coded method list did not strip, so every call raised "The UISessionManager was
+    /// expected to be initialized." See AlRunner/Patches/BuiltInPageModeAction.cs.
+    /// </summary>
+    public override ITestAction View() => BuiltInPageModeActionFor(viewMode: true);
+
+    /// <summary>AL's <c>SomePage.Edit()</c> — the editable twin of <see cref="View"/>.</summary>
+    public override ITestAction Edit() => BuiltInPageModeActionFor(viewMode: false);
+
+    /// <summary>
+    /// The built-in page-mode action for one of the two modes, resolved the way BC's own UI
+    /// builder resolves it (<c>ActionBuilder.ResolveCardFormId</c> /
+    /// <c>IsModifyAllowedInCard</c>, BC 28.1) — see BuiltInPageModeAction.cs for the full read.
+    ///
+    /// <para>Refuses by name rather than answering null, which is what
+    /// <c>TestPageProxy.View()/Edit()</c> do for a page that has no such action: BC's
+    /// <c>NavTestAction</c> takes that null without checking it, so AL's <c>.Invoke()</c>
+    /// would surface as a bare NullReferenceException inside Ncl with nothing naming the
+    /// page or the reason.</para>
+    /// </summary>
+    private ITestAction BuiltInPageModeActionFor(bool viewMode)
+    {
+        if (_tornDown || RunnerPageInstance.WasClosedFromAl(_page?.Form))
+            throw MakeTestPageNotOpenException();
+
+        var actionName = viewMode ? "View" : "Edit";
+        var cardPageId = RecordPatches.TryGetAnyCardPageId(_pageId);
+
+        // No resolvable CardPageId. BC's ResolveCardFormId then falls back to the HOST page's
+        // own id whenever the host is not a List, and NavOpenTaskPageAction.InvokeCore takes
+        // its UseCurrentForm branch: the action switches the OPEN page's mode in place through
+        // PageModeAggregator.ChangePageMode, opening nothing. That is a real AL shape —
+        // SubscriptionBilling's ContractRenewalTest does
+        // `if not Card.Editable then Card.Edit().Invoke();` inside a [ModalPageHandler] — and it
+        // is NOT what this class implements. Answering it by opening a second copy of the page
+        // would be a silent wrong answer (two OnOpenPage runs where BC has none), so it
+        // refuses. On a List with no CardPageId the builder creates no action at all.
+        if (cardPageId <= 0)
+            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                $"TestPage.{actionName}() on page {_pageId}",
+                $"not-yet-implemented — page {_pageId} declares no CardPageId this run can "
+                + $"resolve, so its built-in {actionName} action is not a page open. On a page "
+                + "that is not a list BC switches the OPEN page's own mode in place "
+                + "(NavOpenTaskPageAction.UseCurrentForm -> PageModeAggregator.ChangePageMode), "
+                + "which the runner does not model; on a list with no CardPageId BC's builder "
+                + "creates no such action at all. Tracked by issue #3258");
+
+        // BC's IsModifyAllowedInCard: with a card page id in context, the Edit action is
+        // created only when that CARD allows modification — so a read-only card has a View
+        // action and no Edit action. Unknown (the card is not in this run's inventory) keeps
+        // the permissive answer, the same rule TryGetAnyPageType's callers use: refusing on a
+        // lookup miss would refuse pages on the strength of the runner's own inventory.
+        if (!viewMode && RecordPatches.TryGetAnyPageModifyAllowed(cardPageId) == false)
+            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                $"TestPage.Edit() on page {_pageId}",
+                $"not-yet-implemented — the CardPageId target, page {cardPageId}, does not allow "
+                + "modification (Editable = false or ModifyAllowed = false), and BC's own UI "
+                + "builder creates no Edit action for such a card "
+                + "(ActionBuilder.IsModifyAllowedInCard), so real BC has nothing to invoke here "
+                + "either. Tracked by issue #3258");
+
+        return new BuiltInPageModeAction(this, _record, cardPageId, viewMode);
+    }
 
     private sealed class RecordingBuiltInAction : ITestAction
     {

--- a/AlRunner/Patches/RecordPatches.PageMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.PageMetadataVirtualTable.cs
@@ -295,6 +295,59 @@ public static partial class RecordPatches
         }
     }
 
+    // The same rows EnumerateKnownPageMetadata builds, keyed by page id, so the by-id lookups
+    // below are not a linear scan of every page in the run (Base Application 28.1 alone
+    // contributes several thousand). Rebuilt whenever the row list itself is rebuilt —
+    // reference equality against the cached list is the cheapest correct invalidation, since
+    // EnumerateKnownPageMetadata already owns the generation check.
+    private static List<PageMetaRow>? _pageMetaRowsIndexedFrom;
+    private static Dictionary<int, PageMetaRow>? _pageMetaRowsById;
+    private static readonly object _pageMetaIndexLock = new();
+
+    /// <summary>
+    /// One page's resolved Page Metadata row, or null when neither the runner's own parsed AL
+    /// nor a registered dependency .app's SymbolReference.json declares that page.
+    /// </summary>
+    private static PageMetaRow? TryGetPageMetaRow(int pageId)
+    {
+        var rows = EnumerateKnownPageMetadata();
+        var index = _pageMetaRowsById;
+        if (!ReferenceEquals(_pageMetaRowsIndexedFrom, rows) || index == null)
+            lock (_pageMetaIndexLock)
+            {
+                if (!ReferenceEquals(_pageMetaRowsIndexedFrom, rows) || _pageMetaRowsById == null)
+                {
+                    var built = new Dictionary<int, PageMetaRow>(rows.Count);
+                    foreach (var row in rows) built[row.Id] = row;
+                    _pageMetaRowsById = built;
+                    _pageMetaRowsIndexedFrom = rows;
+                }
+                index = _pageMetaRowsById;
+            }
+        return index.TryGetValue(pageId, out var found) ? found : null;
+    }
+
+    /// <summary>
+    /// <paramref name="pageId"/>'s <c>CardPageId</c>, already resolved from the declared NAME
+    /// to a real page id — 0 when the page declares none, when the declared page is not in this
+    /// run's inventory (reported by <see cref="EnumerateKnownPageMetadata"/>, never silent), or
+    /// when the page itself is unknown here.
+    ///
+    /// <para>Issue #3185's consumer is <c>LiveNavTestPage.View()/Edit()</c>: the built-in
+    /// page-mode actions a client puts on a list open exactly this page, and
+    /// <c>ActionBuilder.ResolveCardFormId</c> (BC 28.1's own UI builder) reads it from the same
+    /// declaration Page Metadata reports here.</para>
+    /// </summary>
+    internal static int TryGetAnyCardPageId(int pageId) => TryGetPageMetaRow(pageId)?.CardPageId ?? 0;
+
+    /// <summary>
+    /// Whether <paramref name="pageId"/> allows modification — its declared
+    /// <c>ModifyAllowed</c> narrowed by its declared <c>Editable</c>. Null when the page is not
+    /// in this run's inventory, which a caller must not read as either answer.
+    /// </summary>
+    internal static bool? TryGetAnyPageModifyAllowed(int pageId)
+        => TryGetPageMetaRow(pageId) is { } row ? row.Editable && row.ModifyAllowed : null;
+
     /// <summary>
     /// #3143: NOT swallowed — an unreadable dependency used to leave every page it declares
     /// out of Page Metadata (2000000138) AND out of Page Control Field, the other consumer of

--- a/AlRunner/Patches/RunnerModalDispatch.cs
+++ b/AlRunner/Patches/RunnerModalDispatch.cs
@@ -30,6 +30,7 @@
 //   decision that matters (which handler, what it does, what OK/Cancel means) stays in BC's
 //   code and in the AL handler.
 using System.Reflection;
+using Microsoft.Dynamics.Nav.Runtime;
 
 namespace AlRunner.Patches;
 
@@ -61,6 +62,7 @@ public static class RunnerModalDispatch
         // Deliberately NOT wrapped in a catch: OnOpenPage is AL, and an Error() raised there
         // is a real test failure that must reach the test, not a runner detail to absorb.
         var form = RegisteredForm(handle);
+        ApplyPendingPageOpenMode(form);
         var opened = TryOpenForm(form);
 
         // BC's own ShowDialog: pops dialogHandlerStack and runs the pushed handler delegate,
@@ -143,6 +145,7 @@ public static class RunnerModalDispatch
         // Same reasoning as the modal path: a real client opens the form as part of this round
         // trip, and opening is what raises OnOpenPage. Not wrapped in a catch — an Error()
         // raised in OnOpenPage is a real test failure.
+        ApplyPendingPageOpenMode(form);
         var opened = TryOpenForm(form);
 
         var showForm = type.GetMethod("ShowForm", BindingFlags.NonPublic | BindingFlags.Instance)
@@ -167,6 +170,40 @@ public static class RunnerModalDispatch
     }
 
     /// <summary>
+    /// Stamp the open MODE a built-in View/Edit action asked for onto the form BC is about to
+    /// open — the runner's stand-in for the <c>FormState(ViewMode)</c> BC's client hands the
+    /// builder (issue #3185, see BuiltInPageModeAction.cs).
+    ///
+    /// <para>Only the read-only direction writes anything. <c>NavForm.Editable</c> is
+    /// initialised from the page's own declared <c>Editable</c> in InitializeFromMetadata, and
+    /// that is exactly the value an Edit-mode open should keep — BC narrows Edit by the page's
+    /// declaration too (<c>CanSwitchViewMode</c> refuses Edit on a page whose FormDescription
+    /// is not Editable), so forcing it true would open pages BC would not. It is also the same
+    /// rule LiveNavTestPage.MarkOpened applies to a page the test opens itself:
+    /// <c>viewMode != View &amp;&amp; PageEditable</c>.</para>
+    ///
+    /// <para>Applied BEFORE OpenForm so the page's own OnOpenPage sees it, and read once, so a
+    /// page opened from inside that trigger does not inherit it.</para>
+    /// </summary>
+    private static void ApplyPendingPageOpenMode(object? form)
+    {
+        if (form is not NavForm navForm) return;
+        if (!RunnerPendingPageOpenMode.TryConsume(PageIdOf(form), out var readOnly)) return;
+        if (readOnly) navForm.Editable = false;
+    }
+
+    /// <summary>The page number of <paramref name="form"/>, or 0 when it cannot be read.</summary>
+    private static int PageIdOf(object? form)
+    {
+        var objectId = form?.GetType()
+            .GetProperty("ObjectId", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?
+            .GetValue(form);
+        return objectId?.GetType()
+            .GetProperty("ObjectNumber", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?
+            .GetValue(objectId) is int pageNo ? pageNo : 0;
+    }
+
+    /// <summary>
     /// Whether the test has an outstanding TestPage.Trap() for this form's page, asked through
     /// BC's own NavTestExecution.HasTrap so the answer is the one ShowForm will act on.
     /// </summary>
@@ -174,13 +211,8 @@ public static class RunnerModalDispatch
     {
         if (form == null) return false;
 
-        var objectId = form.GetType()
-            .GetProperty("ObjectId", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?
-            .GetValue(form);
-        if (objectId?.GetType()
-                .GetProperty("ObjectNumber", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?
-                .GetValue(objectId) is not int pageNo)
-            return false;
+        var pageNo = PageIdOf(form);
+        if (pageNo == 0) return false;
 
         var hasTrap = testExecution.GetType().GetMethod("HasTrap",
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,

--- a/AlRunner/Patches/RunnerPageInstance.ActionRunObject.cs
+++ b/AlRunner/Patches/RunnerPageInstance.ActionRunObject.cs
@@ -168,14 +168,23 @@ internal sealed partial class RunnerPageInstance
     /// two in that order (see this file's header).</para>
     /// </summary>
     private void RunTargetPage(int actionId, ActionRunTarget target)
+        => RunPageThroughBcFrontDoor(
+            target.ObjectId,
+            target.Links.Count > 0
+                ? BuildLinkedTargetRecord(actionId, target)
+                : (target.RunPageOnRec ? _record : null));
+
+    /// <summary>
+    /// Open <paramref name="pageId"/> through BC's own <c>NavForm.RunAsync</c> /
+    /// <c>RunModalAsync</c>, on <paramref name="record"/> when one is supplied.
+    ///
+    /// <para>Static and internal since #3185, because the other caller has no
+    /// RunnerPageInstance to go through: a list page's BUILT-IN View/Edit action opens the
+    /// page's <c>CardPageId</c> card, and the runner can know that card's id from the page
+    /// inventory even for a list it never compiled a page instance for.</para>
+    /// </summary>
+    internal static void RunPageThroughBcFrontDoor(int pageId, NavRecord? record)
     {
-        var pageId = target.ObjectId;
-        var runPageOnRec = target.RunPageOnRec;
-
-        var record = target.Links.Count > 0
-            ? BuildLinkedTargetRecord(actionId, target)
-            : (runPageOnRec ? _record : null);
-
         if (TargetPageOpensModally(pageId))
         {
             // isInLookupTrigger / isLookup both false — the shape the AL compiler emits for a


### PR DESCRIPTION
Closes #3185

`TestPage.View()` and `TestPage.Edit()` raised `InvalidOperationException: The UISessionManager was expected to be initialized.` from `TestPageClientSession.GetTestLogicalDispatcher()` before any page could open. Two causes, and the first hid the second.

## The mechanism

**1. The Cecil pass stripped `TestClientProxy.Proxy` from a hard-coded list of six method names, and `NavTestPageBase` has eight call sites.**

`NavTestPageBase.ALView()` is, in BC 28.1's Ncl:

```csharp
public NavTestAction ALView()
{
    CheckPageOpened();
    if (!viewModeActions.TryGetValue(ViewMode.View, out var value))
    {
        value = new NavTestAction(TestClientProxy<ITestAction>.Proxy(TestPage.View()));
        viewModeActions.Add(ViewMode.View, value);
    }
    return value;
}
```

`Proxy` wraps the value in the client's test dispatcher, which does not exist in this process. `NclCecilRewrite.Forms.cs` step 4 removed that call — from `GetField`, `GetAction`, `GetDataItem`, `GetPart`, `GetBuiltInAction`, `FindBuiltInAction`. Enumerated over the type, `NavTestPageBase` has **eight** `Proxy` call sites in eight methods, and the two the list did not name are exactly `ALView` and `ALEdit`. Step 4 now sweeps the whole type — the shape step 3 already uses for `NavTestExecution` — and throws if it finds none, so a ninth call site in a later Ncl cannot reintroduce this.

**2. Underneath it, `ITestPage.View()`/`Edit()` answered a no-op action.**

`MockITestPage.View()` returned `new MockITestAction()`, whose `Invoke()` is a literal no-op, and `LiveNavTestPage` did not override it. So even with the proxy gone, invoking either did nothing at all — the failure would just have moved to the assertion.

## What the fix does, and where each rule comes from

Nothing in the application declares these actions; the client supplies them. The reference implementation is `Microsoft.Dynamics.Nav.Client.TestPageClient.TestPageProxy` (BC 28.1, decompiled), and it is a lookup, not an effect:

```csharp
public ITestAction View()
    => form.ContainedControls.FindAllByType<ActionControl>().FirstOrDefault(c =>
           c.Action is NavOpenTaskPageAction { IsPageModeAction: not false } a
           && a.ViewMode == PageMode.View) is { } control
       ? new TestActionProxy(this, control) : null;
```

Those actions are built by `Microsoft.Dynamics.Nav.Client.FormBuilder.ActionBuilder` from `MenuActionType.View` / `MenuActionType.Edit`, and three of its methods contain everything the runner needs:

| BC method | what it decides | runner equivalent |
|---|---|---|
| `ActionBuilder.ResolveCardFormId` | the **target**: `actionDef.TargetID` (0 for a system menu action) → the card page id in context (the list's `CardPageId`) → `FormState.CardPageId` → the parent page's own id when the parent is not a List | `RecordPatches.TryGetAnyCardPageId(pageId)`, resolved from the same declaration Page Metadata already reports |
| `ActionBuilder.IsModifyAllowedInCard` | whether the **Edit** action is created at all | `RecordPatches.TryGetAnyPageModifyAllowed(cardPageId)` |
| `NavOpenTaskPageAction.FindFormState` / `CreateForm` | the **row** (`parentBindingManager.CurrentRow.Bookmark` stamped onto the target's form state) and the **mode** (`new FormState(ViewMode)`) | the host's own `NavRecord` handed to BC's `NavForm.RunAsync`, plus `RunnerPendingPageOpenMode` |

So: a page with a resolvable `CardPageId` opens that card, on the host's current row, in the requested mode, **through BC's own `NavForm` front door** — handler lookup, `TestPage.Trap()` and the "Unhandled UI" refusal stay BC's, exactly as an action's `RunObject` already does.

The read-only half needs a channel, because `NavForm.RunAsync` hands back no form to configure. `RunnerPendingPageOpenMode` is armed for one page id, read once, by `RunnerModalDispatch` immediately before it raises `OnOpenPage`, and only the View direction writes anything (`NavForm.Editable = false`). Edit deliberately leaves `Editable` as `InitializeFromMetadata` set it: BC narrows Edit by the page's own declaration too (`CanSwitchViewMode` refuses Edit on a page whose `FormDescription.Editable` is false), and that is the same rule `LiveNavTestPage.MarkOpened` already applies to a page the test opens itself.

## Proving tests — upstream, already merged

The corpus carries them: **codeunit 60461 "TPVE Tests"** (StefanMaron/BusinessCentral.AL.Language.Tests#203, merged as `b693416`), measured on a real service tier. No new corpus PR was needed and none was opened.

CI here cannot see them yet — the pin in `main` is 15 commits behind corpus `master` and **this PR deliberately does not bump it** (a pin bump is red by construction; sequencing belongs to #3202). The proof below is local, against corpus `master` at `28869bc` checked out in the worktree.

**RED**, on `main`, tip corpus, Release, `--package-cache "$HOME/.al-runner/platform-apps"`:

```
FAIL  Codeunit60461.ListViewActionOpensTheCardOnTheListsCurrentRowReadOnly (185ms)
      InvalidOperationException: The UISessionManager was expected to be initialized.
      at Microsoft.Dynamics.Nav.Client.TestPageClient.TestPageClientSession.GetTestLogicalDispatcher()
```

**GREEN**, same command on this branch:

```
PASS  Codeunit60461.ListViewActionOpensTheCardOnTheListsCurrentRowReadOnly (1142ms)
PASS  Codeunit60461.ListEditActionOpensTheCardOnTheListsCurrentRowEditable (237ms)
```

Both arms assert the card opened **exactly once**, on the list's **second** row (`'Bravo'`, not `'Alpha'`), that the `[PageHandler]` ran, and that the mode followed the action — `IsFalse(Editable)` for View, `IsTrue(Editable)` for Edit. The corpus's third arm opens the card directly both ways, so neither half can be passing because the card is always one or the other.

**Whole-corpus differential**, tip corpus, same package cache, both runs on this machine:

| | failures | 60461 arms |
|---|---|---|
| `origin/main` @ `65e5e562` | 17 | 2 failing |
| this branch | 15 | 0 failing |

Set difference: the only tests that move are the two `Codeunit60461` arms, from fail to pass. (Measured before the rebase, when this branch was based on `1301843d`, the fix branch also showed the five `Codeunit60468` `ActionRunPageLink_*` failures that #3240 fixes on `main`; rebasing onto `65e5e562` removes them. That was a base difference, not a regression.)

## Runner-side mechanism tests (`AlRunner.Tests/TestPageViewEditActionBindingTests.cs`)

The BC-behaviour claim is not duplicated here. What is pinned is runner-internal:

- **no** method on `NavTestPageBase` still calls `TestClientProxy.Proxy` — stated over the type, because the defect *was* the list;
- `ALView`/`ALEdit` specifically, named on their own so a failure points at #3185;
- the other direction — `ALView` still calls `ITestPage.View()`, so a fix that deleted the wrong instruction fails here;
- the six previously-stripped methods stay stripped;
- `RunnerPendingPageOpenMode`: consumed once, only by the armed page id, page id 0 is never a wildcard, `Disarm` drops an unconsumed mode.

RED → GREEN measured by restoring the old six-name list and rebuilding: 3 of 11 fail (`NoNavTestPageBaseMethodStillCallsTestClientProxy` plus both `PageModeAffordanceDoesNotReachTheClientDispatcher` rows). With the fix, 18/18 pass. Like `NonModalPageRunDispatchBindingTests`, the Cecil half needs the in-process BC engine, so it skips on a first local pass and runs in CI via `engine.runsettings`; the numbers above are from a local run with that wiring.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — that *was* the bug. Enumerated all eight `Proxy` call sites on `NavTestPageBase` and replaced the name list with a sweep over the type plus a shape guard.
2. **Sibling function making the same assumption?** `NavTestExecution`'s equivalent step already swept the whole type; `NavTestPageBase`'s did not. They now match. `RunnerModalDispatch.HasTrap` was open-coding the same "page number of this form" reflection the new mode hook needs — folded into one `PageIdOf`.
3. **Two paths writing the same state, same invariant?** Editability has two writers: `MarkOpened` (a page the test opens) and now the built-in action's open. Both apply the same rule — read-only only for View, narrowed by the page's declared `Editable` — rather than one forcing a value the other computes.

## What is deliberately left out

Refused loudly, never approximated, and tracked by **#3258** (filed with this work):

- **The in-place mode switch.** When `ResolveCardFormId` finds no `CardPageId` it falls back to the host page's own id, `NavOpenTaskPageAction.UseCurrentForm` returns true, and `InvokeCore` calls `PageModeAggregator.ChangePageMode(ViewMode)` — nothing opens, the page on screen changes mode. Real AL does this (`SubscriptionBilling`'s `ContractRenewalTest`, BCApps' `PlanConfigurationE2ETest`, both named in #3185). It is not implemented because the runner models a TestPage's editability as fixed at open time, BC gates the switch (`CanSwitchViewMode`), and nothing upstream measures any of it. Opening a second copy of the page would produce an `OnOpenPage` run real BC does not have.
- **`Visible` / `Enabled`** answer `true`. The *existence* half of BC's rule is modelled (`ResolveCardFormId`, `IsModifyAllowedInCard`); `LogicalAction.CanInvoke`'s remaining conditions — multi-row selection, an already-open form for the same page, `FilterContext.CanInvoke` — have no runner equivalent, and no corpus test reads either property on a built-in page-mode action.

**Not folded, and why** (`.claude/rules/batch-sibling-issues-by-file.md`). Four open issues also land in `MockTestPage.cs`: #2964 (`MoveLast()` and the implicit new-row line), #3009 (`ValidationErrorCount`/`GetValidationError` hardcoded at page level), #3029 (`OnNewRecord` raised twice for one draft-line row), #2361 (blank `DateTime`/`Date`/`Time` through a control). None touches the built-in page-mode action path — they share a 3,500-line file, not the code — and each is a plain BC-behaviour claim needing its own upstream corpus test before it can be proven, which is a materially different review. #3223 and #3228 are TestPage issues in other files. #3131 is the same "inferred from a UI-builder fact, not measured" problem for `Cancel()` and is now joined by #3258.

No submodule pin change is in this diff.

---

Implemented by an agent (stma-auto-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoqL2HDmJSknfYaD89v8gE

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/203
