### PR TITLE
fix(pagemeta): pass the unreadable-entry out parameter at the RunObject call site

### DIFF
--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -1316,7 +1316,12 @@ internal static partial class BcAppSymbolCache
                 if (entry.Trim().Length > 0) declaredEntries++;
             // Same grammar as a part's SubPageLink -- `"Field" = field("Other")`, `= const(X)`,
             // `= filter(A|B)`, comma-separated -- so the same parser reads it (issue #2942).
-            parsedLink = ParseSubPageLink(link);
+            // The unreadable list is discarded here, and only here: an unreadable entry is
+            // counted in declaredEntries but never reaches the result, so this path already
+            // refuses through DeclaredRunPageLinkEntries != RunPageLink.Count (applied in
+            // RunnerPageInstance.ActionRunObject.cs). PagePartSymbol carries the list instead
+            // because a part has no such count to compare against.
+            parsedLink = ParseSubPageLink(link, out _);
         }
         return new ActionRunObjectSymbol(
             runObject!,


### PR DESCRIPTION
`main` at `598f628a` does not compile, so every open PR is red through its merge commit.

```
AlRunner/Patches/BcAppSymbolCache.cs(1319,26): error CS7036: There is no argument given
that corresponds to the required parameter 'unreadable' of
'BcAppSymbolCache.ParseSubPageLink(string?, out List<string>?)'
```

`Test Matrix` run 34059449059 on `598f628a` is the failing verdict on `main` itself.

## Cause

Two PRs, each green on its own head, wrong only together:

- **#3240** (`65e5e562`) added a second `ParseSubPageLink` call site — `TryReadActionRunObject`, reading an action's `RunPageLink`.
- **#3248** (`598f628a`) gave `ParseSubPageLink` a required `out List<string>? unreadable` and updated the one call site that existed when its own CI ran.

Branch protection here runs with `strict=false`, so #3248 was never rebuilt against a `main` that had #3240 in it. Bisected rather than inferred: `65e5e562` builds, `598f628a` does not, and `f329a7ce` in between touches nothing in this file.

## Why the RunObject path discards the list

`out _` here does **not** reintroduce the silence #3248 removed. An unreadable entry is counted in `declaredEntries` and never reaches the result list, so `DeclaredRunPageLinkEntries != RunPageLink.Count` already holds, and `RunnerPageInstance.ActionRunObject.cs:498` refuses on exactly that comparison with the entry counts in the message. `PagePartSymbol` carries the list instead because a part declares no equivalent count to compare against.

The reason is now a comment at the call site, so the next reader does not have to re-derive it.

## RED / GREEN

Measured in a worktree at `origin/main`:

| tree | `dotnet build AlRunner/AlRunner.csproj` |
|---|---|
| `598f628a` | `1 Error(s)` — CS7036 |
| this branch | `Build succeeded. 0 Error(s)` |

## What this PR does not do

No test is added. A compile error cannot be pinned by a unit test — the build is the check, and it did fire, on `main`, 19 minutes after the merge. Preventing the *class* of failure is a branch-protection question (`strict`), not a test, and I have left it alone rather than fold an unrelated policy change into an urgent fix.

Separately, I could find no test anywhere in `AlRunner.Tests/` that pins the `DeclaredRunPageLinkEntries != RunPageLink.Count` refusal this fix relies on. That gap predates this PR and I am filing it rather than widening this one.

Corpus-NA: this changes no AL-observable behavior — it restores an argument list so the existing refusal path compiles. The behavior it preserves is a runner diagnostic (this run could not read N of M declared entries), which is runner-specific and has no BC-side claim for a service tier to adjudicate.

Closes #3267

Opened by the coordinator agent on the account holder's behalf.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf