### PR TITLE
fix(symbolcache): bump CacheVersion for #3248's parse change, and count a RunPageLink's entries the way it parses them

### DIFF
--- a/AlRunner.Tests/ActionRunPageLinkUnreadableEntryTests.cs
+++ b/AlRunner.Tests/ActionRunPageLinkUnreadableEntryTests.cs
@@ -1,0 +1,219 @@
+// ActionRunPageLinkUnreadableEntryTests — pins how BcAppSymbolCache reads the RunPageLink an
+// ACTION of a precompiled dependency page declares, for issue #3267.
+//
+// What broke, and why "add an `out _`" was the wrong fix
+// -----------------------------------------------------
+// #3240 taught TryReadActionRunObject to parse an action's RunPageLink with the same parser a
+// part's SubPageLink uses (the grammar is identical). Seventeen minutes later #3248 gave that
+// parser an `out List<string>? unreadable` and updated the part call site only — its CI had
+// run against a base that did not yet contain #3240's call site — so main stopped compiling.
+//
+// Discarding the new out-parameter at the action call site would have compiled and would have
+// been wrong twice over. #3248's whole argument is that a link entry the parser cannot read
+// must make the link REFUSE rather than apply its remaining entries, because a link applied
+// with one condition missing selects MORE rows than BC's does. That argument does not care
+// which property the entries came out of.
+//
+// It also would have left the real defect in place, which is on the OTHER side of the same
+// comparison. The action path's fail-closed channel is DeclaredRunPageLinkEntries vs
+// RunPageLink.Count, and #3240 counted the declared entries with a bare SplitTopLevelCommas
+// while #3248's parse used the directive-aware SplitPropertyEntries. The AL compiler records a
+// property's SOURCE text with its preprocessor directives in it — measured on BC 27.5's Base
+// Application part SubPageLinks (#2978), the same grammar — and a comma-split chunk of such
+// text can be a directive and nothing else. So the two counters disagree on links that are
+// perfectly readable, and the direction of the disagreement is a FALSE REFUSAL: a link the
+// parser read in full, refused for being incomplete. Both counters now use one splitter.
+//
+// These are runner-internal symbol-file parsing claims, not claims about BC
+// -------------------------------------------------------------------------
+// Nothing here asserts what Business Central does. The subject is how this runner reads
+// SymbolReference.json — a Microsoft build artifact — and what it does when a byte sequence in
+// it defeats the parser. A BC service tier has no opinion on that: it never reads
+// SymbolReference.json at all, because a real tier has the compiled page metadata this whole
+// code path exists to substitute for. So these belong in AlRunner.Tests and owe no corpus PR.
+//
+// The BC-observable behaviour underneath — that an action's RunPageLink filters the page it
+// opens — is separately proven upstream and in tests/runner-extras/testpage-promoted-actionref.
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(CacheRootsSerialCollection.Name)]
+public class ActionRunPageLinkUnreadableEntryTests
+{
+    private static string WriteApp(string dir, string symbolReferenceJson)
+    {
+        var appPath = Path.Combine(dir, Guid.NewGuid().ToString("N") + ".app");
+        using var zip = new FileStream(appPath, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+        return appPath;
+    }
+
+    // Ids distinct from every other fixture in this suite: BcAppSymbolCache's on-disk cache and
+    // RecordPatches' dependency state are both process-global, so a shared id risks reading
+    // back another test's answer.
+    private const int PageId = 88231701;
+    private const int PlainActionId = 640647001;
+    private const int DirectiveActionId = 640647002;
+    private const int UnreadableActionId = 640647003;
+    private const int NoLinkActionId = 640647004;
+
+    // Every RunPageLink below is verbatim-plausible AL property text as the compiler records
+    // it. The directive one is the BC 27.5 Base Application shape #2978 measured on parts
+    // (page 76 "Resource Card" / page 77 "Resource List"), moved onto an action: the trailing
+    // "#endif" line is what a bare comma split turns into a third "declared" entry.
+    private const string SymbolReference = """
+        {
+          "RuntimeVersion": "17.0",
+          "Pages": [
+            {
+              "Id": 88231701,
+              "Name": "ARPL Dep Page",
+              "Properties": [ { "Name": "PageType", "Value": "List" } ],
+              "Actions": [
+                {
+                  "Id": 2, "Name": "processing",
+                  "Actions": [
+                    { "Kind": 2, "Id": 640647001, "Name": "Plain Link",
+                      "Properties": [
+                        { "Name": "RunObject", "Value": "ARPL Target" },
+                        { "Name": "RunPageLink", "Value": "\"Document No.\" = field(\"No.\"), \"Line No.\" = const(0)" }
+                      ] },
+                    { "Kind": 2, "Id": 640647002, "Name": "Directive Link",
+                      "Properties": [
+                        { "Name": "RunObject", "Value": "ARPL Target" },
+                        { "Name": "RunPageLink", "Value": "\"Document No.\" = field(\"No.\"),\n#if not CLEAN25\n\"Zone Filter\" = field(\"Zone Filter\"),\n#endif\n" }
+                      ] },
+                    { "Kind": 2, "Id": 640647003, "Name": "Unreadable Link",
+                      "Properties": [
+                        { "Name": "RunObject", "Value": "ARPL Target" },
+                        { "Name": "RunPageLink", "Value": "\"Document No.\" = field(\"No.\"), \"Amount\" whenever(42)" }
+                      ] },
+                    { "Kind": 2, "Id": 640647004, "Name": "No Link",
+                      "Properties": [
+                        { "Name": "RunObject", "Value": "ARPL Target" }
+                      ] }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private static void WithRunObjects(Action<Dictionary<int, BcAppSymbolCache.ActionRunObjectSymbol>> body)
+    {
+        var dir = TestScratch.Dir("al-runner-action-runpagelink-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var appPath = WriteApp(dir, SymbolReference);
+            var page = Assert.Single(BcAppSymbolCache.Get(appPath).Pages, p => p.Id == PageId);
+            body(page.MemberIdToRunObject!);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    /// <summary>
+    /// The regression #3267 is really about. `"Document No." = field("No."),` + `#if not
+    /// CLEAN25` + `"Zone Filter" = field("Zone Filter"),` + `#endif` comma-splits into THREE
+    /// chunks, the third of which holds only the `#endif` line. Counting declared entries with
+    /// a bare SplitTopLevelCommas made that 3, the directive-aware parse correctly produced 2,
+    /// and LinksFromSymbols refuses whenever those two differ — so this link, which the parser
+    /// read completely and correctly, was refused for being incomplete.
+    ///
+    /// <para>Both entries must also be PRESENT and correct, not merely counted: a fix that made
+    /// the numbers agree by dropping the guarded entry would satisfy a count assertion while
+    /// re-introducing exactly the under-filtering #2978 removed.</para>
+    /// </summary>
+    [Fact]
+    public void DirectiveGuardedRunPageLink_CountsDeclaredEntriesTheWayItParsesThem_SoAReadableLinkIsNotRefused()
+        => WithRunObjects(runObjects =>
+        {
+            var spec = runObjects[DirectiveActionId];
+
+            // 2, not 3. The "#endif"-only chunk is not a declared entry.
+            Assert.Equal(2, spec.DeclaredRunPageLinkEntries);
+            Assert.Equal(2, spec.RunPageLink!.Count);
+            // The equality LinksFromSymbols refuses on — stated directly, because it is the
+            // thing that was false.
+            Assert.Equal(spec.DeclaredRunPageLinkEntries, spec.RunPageLink.Count);
+            Assert.Null(spec.UnreadableRunPageLinkEntries);
+
+            Assert.Equal("Document No.", spec.RunPageLink[0].PartFieldName);
+            Assert.Equal("field", spec.RunPageLink[0].Kind);
+            Assert.Equal("\"No.\"", spec.RunPageLink[0].Value);
+            Assert.False(spec.RunPageLink[0].Conditional);
+
+            // The directive-guarded entry is kept AND marked conditional — it may not be in the
+            // compiled app, and the consumer resolves that against the app's field inventory
+            // rather than guessing (#2978).
+            Assert.Equal("Zone Filter", spec.RunPageLink[1].PartFieldName);
+            Assert.Equal("field", spec.RunPageLink[1].Kind);
+            Assert.Equal("\"Zone Filter\"", spec.RunPageLink[1].Value);
+            Assert.True(spec.RunPageLink[1].Conditional,
+                "an entry inside #if not CLEAN25 is conditional; treating it as unconditional " +
+                "would refuse the whole page when the guarded field is absent");
+        });
+
+    /// <summary>
+    /// The half `out _` would have thrown away. `"Amount" whenever(42)` is not AL the parser
+    /// has ever seen — the three kinds the entry regex accepts (field/const/filter) are the
+    /// only ones AL defines — so the link cannot be applied. It must be carried, by TEXT, and
+    /// the entry count must still record that two entries were declared, because that
+    /// difference is what makes the consumer refuse instead of applying the readable half.
+    /// </summary>
+    [Fact]
+    public void UnreadableRunPageLinkEntry_IsCarriedByTextAndStillCountedAsDeclared()
+        => WithRunObjects(runObjects =>
+        {
+            var spec = runObjects[UnreadableActionId];
+
+            Assert.Equal(2, spec.DeclaredRunPageLinkEntries);
+            Assert.Equal(1, spec.RunPageLink!.Count);
+            Assert.NotEqual(spec.DeclaredRunPageLinkEntries, spec.RunPageLink.Count);
+
+            var unreadable = Assert.Single(spec.UnreadableRunPageLinkEntries!);
+            Assert.Equal("\"Amount\" whenever(42)", unreadable);
+
+            // The readable entry is read correctly — the point is that it is NOT applied alone,
+            // not that it failed to parse.
+            Assert.Equal("Document No.", spec.RunPageLink[0].PartFieldName);
+            Assert.Equal("field", spec.RunPageLink[0].Kind);
+        });
+
+    /// <summary>
+    /// Negative direction, both arms, so neither assertion above can be satisfied by a
+    /// constant. A plain two-entry link declares 2, parses 2 and carries no unreadable text;
+    /// an action with a RunObject and no RunPageLink at all declares 0 and reports
+    /// HasRunPageLink false, which is what stops the consumer refusing an action that simply
+    /// has no link to apply.
+    /// </summary>
+    [Fact]
+    public void PlainRunPageLink_CarriesNoUnreadableEntries_AndAnActionWithNoLinkDeclaresNone()
+        => WithRunObjects(runObjects =>
+        {
+            var plain = runObjects[PlainActionId];
+            Assert.Equal(2, plain.DeclaredRunPageLinkEntries);
+            Assert.Equal(2, plain.RunPageLink!.Count);
+            Assert.Null(plain.UnreadableRunPageLinkEntries);
+            Assert.True(plain.HasRunPageLink);
+            Assert.Equal("const", plain.RunPageLink[1].Kind);
+            Assert.Equal("0", plain.RunPageLink[1].Value);
+            Assert.False(plain.RunPageLink[0].Conditional,
+                "no directive is present, so no entry may be marked conditional");
+
+            var noLink = runObjects[NoLinkActionId];
+            Assert.Equal("ARPL Target", noLink.ObjectName);
+            Assert.Equal(0, noLink.DeclaredRunPageLinkEntries);
+            Assert.Null(noLink.RunPageLink);
+            Assert.Null(noLink.UnreadableRunPageLinkEntries);
+            Assert.False(noLink.HasRunPageLink);
+        });
+}

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -185,7 +185,17 @@ internal static partial class BcAppSymbolCache
     // structural hash can see. Without the key changing, a stale payload would answer
     // DeclaredRunPageLinkEntries = 0 — which RunnerPageInstance.ResolveRunTargetFromSymbols
     // reads as "this action declares no link", opening the target on its WHOLE table.
-    private const int CacheVersion = 32;
+    // v33: two parse changes in this file that a structural hash cannot see, plus one record
+    // shape change that it can (#3267). #3248 taught SplitPropertyEntries to strip AL
+    // preprocessor directives and both link/view parsers to KEEP what they could not read,
+    // which changes the VALUES parsed out of unchanged bytes without changing any record's
+    // shape — a payload written before it replays the old, wider answer from a warm cache for
+    // as long as the .app's content hash holds. This change then fixed the action path's
+    // declared-entry count to use that same directive-aware splitter, which likewise changes a
+    // parsed value only. ActionRunObjectSymbol also gained UnreadableRunPageLinkEntries, and
+    // that half PayloadShape would have keyed on by itself; the bump is the explicit statement
+    // of the two halves it would not.
+    private const int CacheVersion = 33;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
     // Issue #1820's path -> content-hash memo now lives in
     // RunnerFingerprint._fileContentHashes (#2955), because AppLoader's persisted r2r-chunks
@@ -420,15 +430,30 @@ internal static partial class BcAppSymbolCache
     ///
     /// <para><c>DeclaredRunPageLinkEntries</c> is how many top-level entries the property text
     /// actually declared, which is NOT always <c>RunPageLink.Count</c>: an entry the parser does
-    /// not understand is dropped with a note on stderr. The consumer compares the two and
-    /// refuses when they differ, because a link applied with one entry missing selects MORE rows
-    /// than BC would — a silent wrong answer, not a smaller one.</para>
+    /// not understand is not applied. The consumer compares the two and refuses when they
+    /// differ, because a link applied with one entry missing selects MORE rows than BC would —
+    /// a silent wrong answer, not a smaller one. It is counted with the directive-aware
+    /// splitter the parse itself uses, so a chunk that is nothing but an AL preprocessor
+    /// directive is not miscounted as a declared entry (#3267).</para>
+    ///
+    /// <para><c>UnreadableRunPageLinkEntries</c> is the raw text of every entry
+    /// <c>ParseSubPageLink</c> could NOT read, null when there were none. The count above
+    /// already makes such a link refuse, so this does not change WHETHER it refuses — it
+    /// makes the refusal name the text that could not be read instead of only a number, which
+    /// is the difference between a message a developer can act on and one that sends them
+    /// back to the symbol file. It rides in the PAYLOAD for the reason
+    /// <see cref="PagePartSymbol.UnreadableSubPageLinkEntries"/> spells out: parsing sits
+    /// behind a content-addressed on-disk cache, so anything written to stderr at parse time
+    /// is emitted on a cache MISS and silently lost on every warm run after.</para>
     /// </summary>
     internal sealed record ActionRunObjectSymbol(
         string ObjectName,
         bool RunPageOnRec,
         int DeclaredRunPageLinkEntries,
-        List<PageSubFormLinkSymbol>? RunPageLink = null)
+        List<PageSubFormLinkSymbol>? RunPageLink = null,
+        // Trailing + optional so the record still deserialises positionally; guarded by the
+        // v33 CacheVersion bump, so null here only ever means "every entry was readable".
+        List<string>? UnreadableRunPageLinkEntries = null)
     {
         internal bool HasRunPageLink => DeclaredRunPageLinkEntries > 0;
     }
@@ -1310,18 +1335,34 @@ internal static partial class BcAppSymbolCache
         var hasLink = props.TryGetValue("RunPageLink", out var link) && !string.IsNullOrWhiteSpace(link);
         var declaredEntries = 0;
         List<PageSubFormLinkSymbol>? parsedLink = null;
+        List<string>? unreadableLink = null;
         if (hasLink)
         {
-            foreach (var entry in SplitTopLevelCommas(link!))
-                if (entry.Trim().Length > 0) declaredEntries++;
+            // Counted with the SAME directive-aware splitter the parser uses, NOT a bare
+            // SplitTopLevelCommas (#3267). The compiler records a property's SOURCE text with
+            // its AL preprocessor directives in it, and a comma-split chunk can then be
+            // directives and whitespace only -- `"A" = field("B"), #if X "C" = field("D"),
+            // #endif` splits into three chunks of which the third is just `#endif`. Counting
+            // that as a DECLARED entry made declaredEntries 3 against a correctly-read
+            // parsed.Count of 2, and LinksFromSymbols refuses on that difference -- so a link
+            // this parser read completely was refused for being incomplete. Directives inside
+            // a RunPageLink are the same shipping shape #2978 measured on BC 27.5's part
+            // SubPageLinks, read by the same grammar, so the count has to be blind to them the
+            // same way the parse is.
+            declaredEntries = SplitPropertyEntries(link!).Count;
             // Same grammar as a part's SubPageLink -- `"Field" = field("Other")`, `= const(X)`,
             // `= filter(A|B)`, comma-separated -- so the same parser reads it (issue #2942).
-            // The unreadable list is discarded here, and only here: an unreadable entry is
-            // counted in declaredEntries but never reaches the result, so this path already
-            // refuses through DeclaredRunPageLinkEntries != RunPageLink.Count (applied in
-            // RunnerPageInstance.ActionRunObject.cs). PagePartSymbol carries the list instead
-            // because a part has no such count to compare against.
-            parsedLink = ParseSubPageLink(link, out _);
+            // The list IS carried here, not discarded. #3270 discarded it on the reasoning
+            // that "an unreadable entry is counted in declaredEntries but never reaches the
+            // result, so this path already refuses through DeclaredRunPageLinkEntries !=
+            // RunPageLink.Count". The first half is true and the conclusion does not follow,
+            // because that comparison was not sound: the two sides were computed by two
+            // splitters that disagree about AL preprocessor directives (see the count above).
+            // A count that can be wrong in the FALSE-REFUSAL direction is not a channel to
+            // rest a fail-closed decision on alone, so the refusal now has two independent
+            // signals, and the one made of text can say WHICH entry defeated the parser
+            // instead of only how many did.
+            parsedLink = ParseSubPageLink(link, out unreadableLink);
         }
         return new ActionRunObjectSymbol(
             runObject!,
@@ -1329,7 +1370,8 @@ internal static partial class BcAppSymbolCache
             // writes RunPageOnRec = "1" for `RunPageOnRec = true`.
             SymbolBool(props, "RunPageOnRec"),
             declaredEntries,
-            parsedLink);
+            parsedLink,
+            unreadableLink);
     }
 
     /// <summary>

--- a/AlRunner/Patches/RunnerPageInstance.ActionRunObject.cs
+++ b/AlRunner/Patches/RunnerPageInstance.ActionRunObject.cs
@@ -486,8 +486,13 @@ internal sealed partial class RunnerPageInstance
     /// the same thing whichever route recovered it.</para>
     ///
     /// <para>Refuses rather than returning a partial link, in both directions: a target page
-    /// with no resolvable source table has no rowset to filter, and an entry the parser dropped
-    /// would leave the target showing MORE rows than BC does.</para>
+    /// with no resolvable source table has no rowset to filter, and an entry the parser could
+    /// not read would leave the target showing MORE rows than BC does. The refusal fires on the
+    /// entry count AND on the unreadable entries the parse now carries alongside it (#3267) —
+    /// the count alone was load-bearing while it was also being computed by a splitter that
+    /// disagreed with the parse about AL preprocessor directives, and two independent signals
+    /// for one fail-closed decision is the cheaper arrangement than one that has to stay
+    /// exactly right.</para>
     /// </summary>
     private IReadOnlyList<ActionRunLink> LinksFromSymbols(
         int actionId, BcAppSymbolCache.ActionRunObjectSymbol spec, int targetPageId)
@@ -495,13 +500,24 @@ internal sealed partial class RunnerPageInstance
         if (!spec.HasRunPageLink) return NoLinks;
 
         var parsed = spec.RunPageLink;
-        if (parsed == null || parsed.Count != spec.DeclaredRunPageLinkEntries)
+        var unreadable = spec.UnreadableRunPageLinkEntries;
+        if (parsed == null || parsed.Count != spec.DeclaredRunPageLinkEntries
+            || unreadable is { Count: > 0 })
             throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
                 $"TestPage action {actionId} on page {_pageId}",
                 $"not-yet-implemented — the action declares RunObject = '{spec.ObjectName}' with a "
                 + $"RunPageLink of {spec.DeclaredRunPageLinkEntries} entr(ies), and this run "
                 + $"could read {parsed?.Count ?? 0} of them out of the symbol file. Applying the "
-                + "rest alone would show MORE rows than real BC, so it is refused instead");
+                + "rest alone would show MORE rows than real BC, so it is refused instead"
+                // The entry TEXT, not just the shortfall. The count says how many were lost and
+                // the developer still has to open SymbolReference.json to find out which; the
+                // text is the thing that says whether this is AL grammar the parser has never
+                // seen or a link that was never going to work. Carried through the payload
+                // (#3267) so a warm content-addressed cache hit replays it -- the same reason
+                // PagePartSymbol.UnreadableSubPageLinkEntries exists rather than a stderr line.
+                + (unreadable is { Count: > 0 }
+                    ? $". The entr(ies) it could not read: {string.Join(" | ", unreadable)}"
+                    : string.Empty));
 
         var targetTableId = RecordPatches.ResolveSourceTableIdForAnyPage(targetPageId);
         var hostTableId = RecordPatches.ResolveSourceTableIdForAnyPage(_pageId);


### PR DESCRIPTION
Closes #3277

Bumps `BcAppSymbolCache.CacheVersion` 32 -> 33, and fixes the parse defect that makes the bump load-bearing rather than bookkeeping.

**This PR's scope changed after it was opened.** It was written to restore a broken build *and* fix a deeper defect; PR #3270 merged first and restored the build by passing `out _`, and issue #3267 went with it. What remains here is the part #3270 did not do: the two sides of the action path's fail-closed comparison are still computed by two splitters that disagree, and the cache key still does not reflect it. Rebased onto `c2a73c25`, and the earlier build-restoration claim is gone from the commit message.

## What this changes

1. **Count a RunPageLink's declared entries with `SplitPropertyEntries`** — the directive-aware splitter the parse itself uses — instead of a bare `SplitTopLevelCommas`. This is what stops the fail-closed guard raising FALSE refusals.
2. **Carry the unreadable-entry list** rather than discarding it via `out _`, through the payload, so a refusal names the text it could not read instead of only a count.
3. **Correct the comment #3270 left** at what is now line ~1319-1324. It asserts the count guard is sound, at the precise line where it misfires.
4. **`CacheVersion` 32 -> 33** with a `v33:` note in the enumerated block. This is the part issue #3277 asks for.

## The defect, and its exact boundary

`#3240` counted declared entries with `SplitTopLevelCommas`; `#3248` parsed them with `SplitPropertyEntries`. The action path's only fail-closed channel is `DeclaredRunPageLinkEntries` vs `RunPageLink.Count`, so those two splitters disagreeing means the guard compares two numbers produced by different rules.

The disagreement runs in the **false-refusal** direction. Property text the AL compiler records with its preprocessor directives intact:

```
"Document No." = field("No."),
#if not CLEAN25
"Zone Filter" = field("Zone Filter"),
#endif
```

comma-splits into three chunks, the third holding only `#endif`. Counted bare that is 3, against a correctly-read parsed count of 2 — so a link the parser read **completely and correctly** was refused as incomplete.

**The boundary, stated because it makes the bug narrower than "any directive":** a real entry *after* the `#endif` cancels the miscount. `SplitPropertyEntries` drops a chunk only when it has no body (`if (sawBody)`), so a trailing entry gives the final chunk a body and both sides agree again. The defect therefore requires a directive block that **closes at the end of the property text** — which is the shape #2978 measured shipping on BC 27.5's Base Application part `SubPageLink`s, read by the same grammar.

Measured on both splitters lifted verbatim into a standalone harness:

| input | declared (bare) | parsed (directive-aware) | verdict |
|---|---|---|---|
| directive-guarded, both entries readable | 3 | 2 | refuses — **falsely** |
| plain two-entry link (control) | 2 | 2 | applies, correct |
| genuinely unreadable entry | 2 | 1 | refuses, correctly |
| directive block with a **trailing** real entry | 3 | 3 | applies, correct |

## Why the CacheVersion bump is the case that integer exists for

`PayloadShape` keys on the structural shape of `CachePayload`. #3248 changed how the same schema is *read* — directive stripping, and retaining unreadable entries — without changing any record's shape, so a pre-#3248 payload deserialises cleanly under the same key and replays the old, wider answers from a warm shared `~/.cache/al-runner/bc-symbols` for as long as the `.app` content hash holds. That is the v28/v29/v30 situation each enumerated in the same comment block. The `v33:` note follows their style and records all three: two parse changes a structural hash cannot see, plus the `UnreadableRunPageLinkEntries` shape change that it can.

## RED -> GREEN, on the rebased tree

Full rebuild each time — `--no-build` after a rebase measures the old binary.

**RED** (count line reverted to the bare splitter, everything else intact):

```
DirectiveGuardedRunPageLink_CountsDeclaredEntriesTheWayItParsesThem_SoAReadableLinkIsNotRefused [FAIL]
  Assert.Equal() Failure: Values differ
  Expected: 2
  Actual:   3
Failed! - Failed: 1, Passed: 2, Total: 3
```

**GREEN:** `Passed! - Failed: 0, Passed: 3, Total: 3`

Adjacent surface, same tree: `BcAppSymbolCache|SubPageLink|ActionRunObject|ActionRunPageLink|SourceTableView` -> **43/43 passed**.

Reverting the *carrying* half instead (back to the `out _` shape) produces `Expected 2, Actual 3` plus an `ArgumentNullException` — so both production hunks are load-bearing. The tests assert the guarded entry is **present** (`PartFieldName`, `Kind`, `Value`, `Conditional == true`), so a "fix" that bought count-agreement by dropping the guarded entry would fail the first assertion rather than pass it.

## Where the tests live, and why not upstream

`AlRunner.Tests/ActionRunPageLinkUnreadableEntryTests.cs`. Nothing here asserts what Business Central does — the subject is how this runner reads `SymbolReference.json`, a Microsoft build artifact, and what it does when a byte sequence in it defeats the parser. A real service tier never reads that file at all; it has the compiled page metadata this code path exists to substitute for. So there is no corpus PR to open. The BC-observable behaviour underneath — that an action's `RunPageLink` filters the page it opens — is separately proven upstream and in `tests/runner-extras/testpage-promoted-actionref`.

## Related, deliberately not folded

**#3271** — the `sorting()` arm of `ParseSourceTableView` still splits with `SplitTopLevelCommas` while its sibling `where()` arm uses `SplitPropertyEntries`. Same file and the same directive-blindness family, but a **distinct mechanism**: it never strips directives at all, so it does not miscount — it emits corrupted field names like `#if not CLEAN25 "Zone Code`. It fails safe today. Another agent (`stma-auto-2`) is working it, so this PR leaves that arm untouched.

Referenced for context only, and none of them is a closing target of this PR: #3267 (already handled by #3270), #3240, #3248, #2978.

Opened by an autonomous implementation agent (`stma-auto-1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4

Corpus-NA: the subject is how the runner counts and parses a RunPageLink's entries out of SymbolReference.json inside a precompiled .app, and the CacheVersion keying the resulting payload. A real service tier never reads that file — it has the compiled page metadata this code path exists to substitute for — and a corpus-declared page would be source-compiled and never reach this parser, so no corpus test can go RED on it. The BC behaviour underneath, that an action's RunPageLink filters the page it opens, is already pinned upstream by corpus PR 211.
