### PR TITLE
test(cache): drive the server-mode do-not-cache gate, which no arm entered

### DIFF
--- a/AlRunner.Tests/AlOutputCacheDoNotCacheTests.cs
+++ b/AlRunner.Tests/AlOutputCacheDoNotCacheTests.cs
@@ -59,6 +59,7 @@
 
 using System.Diagnostics;
 using System.Text;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using AlRunner.Infrastructure;
 using Xunit;
@@ -320,6 +321,109 @@ public sealed class AlOutputCacheDoNotCacheTests : IDisposable
             ProgramSupport.AlOutputCacheBlocker(blocked));
     }
 
+    // ── arm 8: the SERVER-MODE gate, which arms 1-7 never entered (#3262) ─────────────────
+
+    /// <summary>
+    /// Issue #3262. Arms 1-7 above drive the CLI gate, <c>--print-cache-key</c> and the two
+    /// helpers as units. Not one of them starts <c>--server</c>, so the server-mode half of the
+    /// gate — <c>Program.cs</c>'s <c>serverCacheBlocker</c> branch — was reachable code that no
+    /// test entered in either direction. Deleting it left all seven green.
+    ///
+    /// <para><b>Why that is a real exposure and not a symmetry nit.</b> The CLI gate and the
+    /// server-mode gate write into the SAME <c>&lt;cacheDir&gt;</c>. A server request that wrote
+    /// an entry under a key blind to its dependency closure is served to a later CLI run against
+    /// that same directory, and the other way round. So a regression dropping only the
+    /// server-mode half reintroduces the whole of #2954 for CLI runs too, through a poisoned
+    /// shared directory, with every one of arms 1-7 still passing.</para>
+    ///
+    /// <para><b>Both directions in one arm, deliberately.</b> The blocked half alone would pass
+    /// against a server that never cached anything — the exact "would this still pass against a
+    /// do-nothing implementation?" failure in <c>.claude/rules/tdd.md</c> that this issue is
+    /// about. Re-shipping that here would be worse than the gap it closes. So the healthy half
+    /// runs the same fixture with a valid sibling manifest and must still write an entry cold
+    /// and still HIT it warm.</para>
+    ///
+    /// <para><b>The cache decision is read from the phase log, not from stderr.</b> Server mode
+    /// emits no <c>[cache] WROTE</c> or <c>[cache] HIT</c> line at all — those two
+    /// <c>Console.Error</c> calls exist only on the CLI path — so an stderr grep for them would
+    /// assert nothing and would keep passing whatever the server did. <c>AL_RUNNER_PHASE_LOG</c>
+    /// records <c>cache_hits</c> / <c>cache_misses</c> per bundle row, which is the server's
+    /// actual decision rather than a proxy for it, and is machine-readable.</para>
+    ///
+    /// <para>Runner-specific, not a BC claim — see this file's header. Server-mode process
+    /// configuration and AL-output cache HIT/MISS say nothing about what Business Central does,
+    /// and no service tier can adjudicate either, so this belongs in <c>AlRunner.Tests</c>
+    /// rather than upstream in the corpus.</para>
+    /// </summary>
+    [SkippableFact]
+    public async Task ServerMode_UnresolvableClosure_WritesNoCacheEntry_WhileAHealthyBundleStillCaches()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        // ── blocked half: the closure cannot be resolved ──────────────────────────────────
+        var (badBundle, badPkg, badCache) = Arrange("server-write-refused", siblingManifestValid: false);
+        var bad = await RunServerBundleAsync(badBundle, badPkg, badCache, "server-nokey");
+
+        // The run itself is unaffected. Refusing the cache is only the right answer if the
+        // tests still execute — a fix that made this request fail would trade a silent wrong
+        // answer for a loud broken one.
+        Assert.Equal(2, bad.Summary.GetProperty("total").GetInt32());
+        Assert.Equal(2, bad.Summary.GetProperty("passed").GetInt32());
+        Assert.Equal(0, bad.Summary.GetProperty("failed").GetInt32());
+        Assert.Equal(0, bad.Summary.GetProperty("errors").GetInt32());
+
+        // THE assertion the seven existing arms could not make: nothing was published into the
+        // directory a later CLI run would read. Counting files, not comparing keys — a key
+        // comparison cannot tell you whether a write happened.
+        var badWritten = Directory.GetFiles(badCache, "*.dll");
+        Assert.True(badWritten.Length == 0,
+            "a SERVER request that could not compute a cache identity still published "
+            + $"{badWritten.Length} AL-output cache entr(y/ies) into a directory shared with CLI "
+            + $"runs: {string.Join(", ", badWritten.Select(Path.GetFileName))}\n{bad.Diagnostics}");
+        // A sidecar without its DLL would mean only half the write was refused.
+        Assert.Empty(Directory.GetFiles(badCache, "*.enum-registry.json"));
+
+        // Loud, naming the reason, and tagged as the SERVER line specifically: the CLI gate
+        // emits "  [<rel>] [cache] NOKEY", so asserting the bare "[cache] NOKEY" text would
+        // also match a CLI emission and could not tell the two gates apart.
+        Assert.Contains("[server]", bad.StdErr);
+        Assert.Contains("[cache] NOKEY", bad.StdErr);
+        Assert.Contains("neither consulted nor written", bad.StdErr);
+        Assert.Contains("could not be resolved", bad.StdErr);
+
+        // Never accounted as an ordinary MISS: a MISS is an entry the next run HITs, and
+        // nothing was written for a next run to find. Read from the phase log, so this is the
+        // server's own recorded decision and not the absence of a line it never prints.
+        Assert.Equal(0, bad.CacheHits);
+        Assert.Equal(0, bad.CacheMisses);
+
+        // ── healthy half: the control, same fixture, valid sibling manifest ───────────────
+        var (okBundle, okPkg, okCache) = Arrange("server-healthy-control", siblingManifestValid: true);
+
+        var cold = await RunServerBundleAsync(okBundle, okPkg, okCache, "server-cold");
+        Assert.Equal(2, cold.Summary.GetProperty("passed").GetInt32());
+        Assert.DoesNotContain("[cache] NOKEY", cold.StdErr);
+        Assert.True(cold.CacheMisses > 0,
+            $"the control's cold run recorded no cache MISS, so it never reached the cache at "
+            + $"all and the warm assertion below would prove nothing\n{cold.Diagnostics}");
+        Assert.Equal(0, cold.CacheHits);
+        var okWritten = Directory.GetFiles(okCache, "*.dll");
+        Assert.True(okWritten.Length > 0,
+            "the control half wrote NO cache entry, so the blocked half above proves nothing — "
+            + $"an implementation that simply never caches would satisfy it\n{cold.Diagnostics}");
+
+        // Warm: a FRESH server process against the same directory must SERVE what the cold one
+        // wrote. A second request to the same process would be answered from the in-process
+        // module cache without consulting the on-disk cache this arm is about.
+        var warm = await RunServerBundleAsync(okBundle, okPkg, okCache, "server-warm");
+        Assert.Equal(2, warm.Summary.GetProperty("passed").GetInt32());
+        Assert.DoesNotContain("[cache] NOKEY", warm.StdErr);
+        Assert.True(warm.CacheHits > 0,
+            $"the control's warm run did not HIT the entry its cold run wrote, so the "
+            + $"server-mode cache is off for every bundle and the blocked half is vacuous"
+            + $"\n{warm.Diagnostics}");
+    }
+
     // ── fixture ───────────────────────────────────────────────────────────────────────────
 
     /// <summary>
@@ -460,6 +564,80 @@ public sealed class AlOutputCacheDoNotCacheTests : IDisposable
         var r = Spawn(bundle, pkgDir, cacheDir, extra: " --print-cache-key");
         var m = Regex.Match(r.Output, @"\[cache\]\s+KEY\s+key=([0-9a-f]{64})");
         return (m.Success ? m.Groups[1].Value : null, r.ExitCode, r.Output);
+    }
+
+    /// <summary>
+    /// One <c>--server</c> spawn, one <c>runTests</c> request over <paramref name="bundle"/>,
+    /// returning the protocol-v2 summary, the process's whole stderr, and the cache decision
+    /// the server actually recorded for that bundle.
+    ///
+    /// <para>A fresh process per call is the point, not overhead. The warm half of arm 8 has to
+    /// prove the entry survives to a LATER run, and a second request to the same process is
+    /// answered from the in-process cross-bundle module cache without ever consulting the
+    /// on-disk AL-output cache the assertion is about.</para>
+    ///
+    /// <para><paramref name="phaseTag"/> gives each call its own <c>AL_RUNNER_PHASE_LOG</c>
+    /// file, so <c>cache_hits</c> / <c>cache_misses</c> are this request's and not a running
+    /// total across the three spawns.</para>
+    ///
+    /// <para>The process is shut down BEFORE stderr is read. The summary line arriving on
+    /// stdout establishes nothing about how much of the request's stderr the background drain
+    /// task has appended (the two-pipe race <see cref="CliServer.StdErrSinceAsync"/>
+    /// documents), and arm 8's negative assertions on stderr are unsound until the stream is
+    /// closed and drained. Disposal waits for exit, which is EOF on stderr.</para>
+    /// </summary>
+    private async Task<ServerCacheObservation> RunServerBundleAsync(
+        string bundle, string pkgDir, string cacheDir, string phaseTag)
+    {
+        var phaseLog = Path.Combine(_scratch, $"{phaseTag}.phase.jsonl");
+        var server = await CliServer.StartAsync(
+            new[] { "--cache", cacheDir, "--package-cache", pkgDir, "--verbose" },
+            extraEnv: new Dictionary<string, string> { ["AL_RUNNER_PHASE_LOG"] = phaseLog });
+
+        JsonElement summary;
+        try
+        {
+            var req = JsonSerializer.Serialize(new
+            {
+                command = "runTests",
+                sourcePaths = new[] { bundle },
+                packagePaths = new[] { pkgDir },
+            });
+            var lines = await server.SendRequestStreamingAsync(req, TimeSpan.FromSeconds(240));
+            (_, summary) = ProtocolV2Streaming.Split(lines);
+        }
+        finally
+        {
+            await server.DisposeAsync();
+        }
+        var stdErr = server.StdErr;
+
+        // Sum across bundle rows rather than taking a single row: a request carries one
+        // sourcePaths entry here, but summing states the claim in a form that cannot silently
+        // read only the first of several.
+        var bundleRows = File.Exists(phaseLog)
+            ? File.ReadAllLines(phaseLog)
+                .Where(l => l.Length > 0)
+                .Select(l => JsonDocument.Parse(l).RootElement)
+                .Where(e => e.TryGetProperty("kind", out var k) && k.GetString() == "bundle")
+                .ToList()
+            : new List<JsonElement>();
+        Assert.True(bundleRows.Count > 0,
+            $"no phase-log bundle row for '{phaseTag}' — the cache-decision assertions below "
+            + $"would read 0/0 and pass vacuously.\n--- stderr ---\n{stdErr}");
+
+        var hits = bundleRows.Sum(r => r.TryGetProperty("cache_hits", out var h) ? h.GetInt32() : 0);
+        var misses = bundleRows.Sum(r => r.TryGetProperty("cache_misses", out var m) ? m.GetInt32() : 0);
+        return new ServerCacheObservation(summary, stdErr, hits, misses);
+    }
+
+    /// <summary>What one server request did about the AL-output cache, and the evidence.</summary>
+    private sealed record ServerCacheObservation(
+        JsonElement Summary, string StdErr, int CacheHits, int CacheMisses)
+    {
+        /// <summary>Everything an assertion failure needs, assembled only when one fails.</summary>
+        public string Diagnostics =>
+            $"cache_hits={CacheHits} cache_misses={CacheMisses}\n--- stderr ---\n{StdErr}";
     }
 
     private static (int ExitCode, string Output) Spawn(

--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -117,6 +117,14 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
     public static readonly IReadOnlyDictionary<string, int> MeasuredWeightSeconds =
         new Dictionary<string, int>(StringComparer.Ordinal)
         {
+            // #3262: 8 tests, most spawning a real runner subprocess, several of them twice
+            // (a cold write then a warm read from a fresh server process, so the in-process
+            // module cache cannot answer instead of the disk). Absent from this table on its
+            // first CI run: measured 64.2s on the BC 28.4 leg, which tripped
+            // check-collection-weights.py. Rounded down per the gate's own instruction; at
+            // 64.2s it sits far enough above the 60s freshness threshold that rounding down
+            // does not leave it back on the fallback the way a 60.9s entry would.
+            ["AlOutputCacheDoNotCacheTests"] = 64,
             // perf/boot-overhead: added with the on-disk install-baseline tier. Measured
             // 125.6s on the first CI run of that branch (BC 28.4 leg), where it was absent
             // from this table, fell back to UnmeasuredWeightSeconds and was dispatched at


### PR DESCRIPTION
Closes #3262

Adds arm 8 to `AlOutputCacheDoNotCacheTests`, driving the **server-mode** half of the #2954
AL-output cache gate — the branch at `AlRunner/Program.cs:4971` that no existing test entered
in either direction.

## The measurement, which is the whole point of this PR

The issue's claim reproduced exactly, then closed. Same tree, same filter, one line changed in
`Program.cs`:

| `Program.cs` state | result of `--filter FullyQualifiedName~AlOutputCacheDoNotCacheTests` |
|---|---|
| gate **deleted** (pre-#3246 shape restored) | **7 passed, 1 failed** — the 7 pre-existing arms all green, arm 8 red |
| gate **present** | **8 passed, 0 failed** |
| gate **inverted** to always-refuse (`if (true)`) | **1 failed** — arm 8 red again, from the control half |

The RED is the real defect, not a proxy for it. With the gate deleted the server request
**published a cache entry**:

```
a SERVER request that could not compute a cache identity still published 1 AL-output cache
entr(y/ies) into a directory shared with CLI runs:
4b45aab147741757524bc373dc444344224450d2524bc4d59e578be55301ec27.dll
cache_hits=0 cache_misses=1
```

That entry is keyed blind to the bundle's entire dependency closure, and it lands in the same
`<cacheDir>` a later CLI run reads — so dropping only the server-mode half reintroduces the
whole of #2954 for CLI runs too, with CI green. That is the exposure the seven existing arms
could not see.

The third row matters as much as the first: a gate made unconditional (a server that never
caches anything) also turns arm 8 red. The arm pins the gate in both directions, so it cannot
be satisfied by a do-nothing implementation — the `.claude/rules/tdd.md` failure this issue is
about, which would have been worse to re-ship than the gap.

## What arm 8 does

Reuses the file's existing two-suite fixture and runs it through a real `--server` process:

- **blocked** (`siblingManifestValid: false`, so `ReadBundleDependencyRoots` throws): 2/2 tests
  still pass, zero `*.dll` and zero `*.enum-registry.json` in the cache dir, a
  `[server] … [cache] NOKEY` line naming the reason, and `cache_hits == cache_misses == 0`.
- **control** (valid sibling manifest): the cold run MISSes and writes an entry; a **fresh**
  server process then HITs it.

Three deliberate choices:

- **The cache decision is read from `AL_RUNNER_PHASE_LOG`, not from stderr.** Server mode emits
  no `[cache] WROTE` or `[cache] HIT` line at all — both `Console.Error` calls are CLI-only
  (`Program.cs:2958` and `:3414`). My first draft asserted on `[cache] WROTE` and failed for
  exactly that reason. An stderr grep for those strings would have asserted nothing and kept
  passing whatever the server did; `cache_hits`/`cache_misses` per bundle row is the server's
  own recorded decision.
- **A fresh process for the warm half.** A second request to the same process is answered from
  the in-process cross-bundle module cache (#1683/#1892) without consulting the on-disk cache
  the assertion is about.
- **stderr is read after the process exits.** The summary line on stdout says nothing about how
  much stderr the drain task has appended (the two-pipe race `CliServer.StdErrSinceAsync`
  documents), and every negative stderr assertion here is unsound until the stream is drained.

## Does this assert anything about BC? No

Server-mode process configuration and AL-output cache HIT/MISS are runner-specific — they say
nothing about what Business Central does, and no service tier can adjudicate either, so nothing
here is owed upstream to the corpus. It is also not expressible as a `tests/runner-extras/` AL
bundle: the assertion is about the contents of a cache directory across separate runner
invocations, which AL running inside one invocation cannot observe. Hence C#, per
`.claude/rules/bc-behavior-tests-go-upstream.md`.

The gate refuses loudly and names its reason (`.claude/rules/loud-failures.md`), and arm 8
asserts that — including `[server]`, so it cannot be satisfied by the CLI gate's own `NOKEY`
line.

## #3246 has merged, so this diff is now the test file alone

**The gate #3262 is about is on `main` now.** PR #3246 (the #2954 fix) merged on 2026-09-06 as
`1044bacc`. This branch used to carry a merge of `agent/stma-auto-1/issue-2954` so there would
be something to test; that merge is gone. Rebased with `git rebase --onto origin/main`, the
diff against `main` is `AlRunner.Tests/AlOutputCacheDoNotCacheTests.cs` alone — +178 lines, no
production file touched — exactly as this section predicted it would narrow to. Nothing about
the test or its scope changed in the rebase.

## The inherited CS7036 is gone

`main` at `3cd3f06b` did not compile — `AlRunner/Patches/BcAppSymbolCache.cs:1319` called
`ParseSubPageLink(link)` against a definition taking `(string?, out List<string>?)`, CS7036,
issue #3267. That landed on `main` via PR #3273. Re-measured at this head:
`dotnet build AlRunner/AlRunner.csproj` reports 0 errors, and
`git diff origin/main -- AlRunner/Patches/BcAppSymbolCache.cs` is empty.

## Sibling scan — nothing folded, and why

`.claude/rules/batch-sibling-issues-by-file.md`, scanned before implementing:

| issue | why it does not fold |
|---|---|
| **#3250** — server cross-bundle module reuse skips enum-registry/query-symbol replay | Closest candidate: same function (`RunBundleForServer`), adjacent lines in the same cache block. Still not foldable — it is a behavior change, not a coverage fix, and its author explicitly declined to fold it into #2939 on `no-assumption-fixes.md` grounds because there is no reproducer. Settling it needs a two-directories-one-AppId server session with an enum caption observable: a different fixture and a different mechanism. Also untriaged (no `status: ready`). Folding it would break rule 4 — a reviewer could not hold both as one change. |
| **#2471** — C# suite 4-lane floor / warm-server route | Assessed on the merits as the brief asked. Touches server mode only as a consumer; its fix lands in lane sizing, `xunit.runner.json` and the CI workflow, not in `Program.cs`. Different files entirely. |
| **#3254** — install-baseline cache key components mutually redundant | A different key in different files (`InstallBaselineDiskCache.BuildKeyText`, `TestExecutor`). This is precisely the scope boundary #3246 documents in `RunnerFingerprint.cs`: `UncacheableReason` gates only the AL-output key, and extending it to the other three persisted-key paths is its own behavior change. |
| **#2954** | PR #3246's own issue — closed by that PR, not this one. |

Nothing else in the open queue lands in `Program.cs`'s cache gate.

## Testing

- `dotnet test AlRunner.Tests --filter FullyQualifiedName~AlOutputCacheDoNotCacheTests` — 8/8
  passed with the gate present, run to completion locally on BC 28.4.
- The three-way mutation table above, each row a completed run.
- **Re-measured after the rebase onto `main` at `492394be`** (head `4aa064f8`): same filter,
  **8 passed, 0 failed, 0 skipped**, 58 s. The mutation table was NOT re-run at the new head —
  it was measured against the same gate code, which `main` now carries unchanged from #3246.

Filed by agent `impl-9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4

Rebased onto `main` at `492394be` by agent `impl-2`; the three #3246 commits and the merge commit were dropped as already on `main`.
