### PR TITLE
fix(metatable): resolve system fields named by a CalcFormula or a TableRelation

### DIFF
--- a/AlRunner.Tests/CalcFormulaSystemFieldResolutionTests.cs
+++ b/AlRunner.Tests/CalcFormulaSystemFieldResolutionTests.cs
@@ -1,0 +1,157 @@
+// CalcFormulaSystemFieldResolutionTests — runner-mechanism guard for #3178.
+//
+// The gap
+// -------
+// Every BC table carries five system fields it does not declare — SystemId (2000000000),
+// SystemCreatedAt (2000000001), SystemCreatedBy (2000000002), SystemModifiedAt (2000000003)
+// and SystemModifiedBy (2000000004). RecordPatches materialises all five onto every
+// NCLMetaTable it builds, but the field-name lookups in BuildMetaCalcFormula and in the
+// TableRelation builder read ParsedTable.Fields only, which does not carry them. So a
+// CalcFormula naming one resolved to nothing: an unresolvable SOURCE field lost the whole
+// formula (CalcFields then raised BC's "You must define a CalcFormula ..."), while an
+// unresolvable WHERE-ARM field was dropped and the FlowField still calculated, over the wrong
+// rows. Seven Base Application FlowFields have that shape, and so does every API page's
+// `TableRelation = <Table>.SystemId`.
+//
+// What this file pins
+// -------------------
+// The runner-only C# mechanism: that RecordPatches declares the system-field set ONCE and that
+// its field-name resolver answers from it for a ParsedTable that does not list them. The
+// BC-observable claims underneath — what `max(T.SystemCreatedAt where(...))` calculates, and
+// that a TableRelation onto SystemId is enforced — are plain BC behaviour and are pinned
+// upstream in the al-language corpus (record/TestCalcFormulaSystemFields*, corpus PR #216),
+// verified on a BC 28.4.53241.0 container, not duplicated here.
+//
+// The invariant that matters is "resolver set == materialised set": resolving a name to an id
+// the built NCLMetaTable does not carry would fault inside NCL instead of refusing loudly
+// here, which is why SystemRowVersion is deliberately NOT in the set.
+
+using System.Reflection;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class CalcFormulaSystemFieldResolutionTests
+{
+    private static readonly Type RecordPatchesType = typeof(RecordPatches);
+
+    private static ParsedField[] SystemParsedFields()
+    {
+        var f = RecordPatchesType.GetField("SystemParsedFields",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(f);
+        return (ParsedField[])f!.GetValue(null)!;
+    }
+
+    private static bool TryResolve(ParsedTable table, string fieldName, out ParsedField field)
+    {
+        var m = RecordPatchesType.GetMethod("TryResolveTableFieldByName",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(m);
+        var args = new object?[] { table, fieldName, null };
+        var ok = (bool)m!.Invoke(null, args)!;
+        field = ok ? (ParsedField)args[2]! : null!;
+        return ok;
+    }
+
+    private static ParsedTable TableWithoutSystemFields() => new ParsedTable(
+        50700, "CFSF Line",
+        new List<ParsedField>
+        {
+            new ParsedField(1, "Entry No.", "Integer", 0),
+            new ParsedField(2, "Doc No.", "Code", 20),
+        },
+        new List<int> { 1 });
+
+    /// The set is exactly BC's five system fields, with BC's own ids and types. A sixth entry
+    /// added here without also being materialised in BuildNCLMetaTable would resolve to an id
+    /// the built table does not carry.
+    [Fact]
+    public void SystemParsedFields_AreExactlyBcsFiveSystemFields()
+    {
+        var expected = new (int Id, string Name, string Type)[]
+        {
+            (2000000000, "SystemId",         "Guid"),
+            (2000000001, "SystemCreatedAt",  "DateTime"),
+            (2000000002, "SystemCreatedBy",  "Guid"),
+            (2000000003, "SystemModifiedAt", "DateTime"),
+            (2000000004, "SystemModifiedBy", "Guid"),
+        };
+
+        var actual = SystemParsedFields();
+
+        Assert.Equal(expected.Length, actual.Length);
+        for (var i = 0; i < expected.Length; i++)
+        {
+            Assert.Equal(expected[i].Id, actual[i].FieldId);
+            Assert.Equal(expected[i].Name, actual[i].FieldName);
+            Assert.Equal(expected[i].Type, actual[i].TypeName);
+        }
+    }
+
+    /// SystemRowVersion is NOT materialised onto a built table, so it must NOT resolve —
+    /// answering an id NCL has no MetaField for is worse than refusing.
+    [Fact]
+    public void SystemRowVersion_DoesNotResolve()
+    {
+        Assert.False(TryResolve(TableWithoutSystemFields(), "SystemRowVersion", out _));
+        Assert.DoesNotContain(SystemParsedFields(), f => f.FieldName == "SystemRowVersion");
+    }
+
+    [Theory]
+    [InlineData("SystemId", 2000000000)]
+    [InlineData("SystemCreatedAt", 2000000001)]
+    [InlineData("SystemCreatedBy", 2000000002)]
+    [InlineData("SystemModifiedAt", 2000000003)]
+    [InlineData("SystemModifiedBy", 2000000004)]
+    public void SystemFieldName_ResolvesOnATableThatDoesNotListIt(string fieldName, int expectedId)
+    {
+        var table = TableWithoutSystemFields();
+        Assert.DoesNotContain(table.Fields, f => f.FieldName == fieldName);
+
+        Assert.True(TryResolve(table, fieldName, out var resolved));
+        Assert.Equal(expectedId, resolved.FieldId);
+        Assert.Equal(fieldName, resolved.FieldName);
+    }
+
+    /// AL is case-insensitive about field names, and BC's own metadata spells these in camel
+    /// case; a CalcFormula may not.
+    [Fact]
+    public void SystemFieldName_ResolvesCaseInsensitively()
+    {
+        Assert.True(TryResolve(TableWithoutSystemFields(), "systemcreatedat", out var resolved));
+        Assert.Equal(2000000001, resolved.FieldId);
+    }
+
+    /// The table's own fields still win, and still resolve to their own ids.
+    [Fact]
+    public void DeclaredField_StillResolvesToItsOwnId()
+    {
+        Assert.True(TryResolve(TableWithoutSystemFields(), "Doc No.", out var resolved));
+        Assert.Equal(2, resolved.FieldId);
+        Assert.Equal("Code", resolved.TypeName);
+    }
+
+    /// A field that is neither declared nor a system field must stay unresolved, so the callers
+    /// keep logging and refusing rather than silently building a formula over the wrong id.
+    [Fact]
+    public void UnknownFieldName_DoesNotResolve()
+    {
+        Assert.False(TryResolve(TableWithoutSystemFields(), "No Such Field", out _));
+        Assert.False(TryResolve(TableWithoutSystemFields(), "SystemCreatedAtX", out _));
+    }
+
+    /// A table that DECLARES a field with a system field's name — legal in AL for a low field
+    /// id — must resolve to its own field, not to the system one.
+    [Fact]
+    public void DeclaredFieldShadowingASystemFieldName_WinsOverTheSystemField()
+    {
+        var table = new ParsedTable(50701, "Shadowing",
+            new List<ParsedField> { new ParsedField(7, "SystemCreatedBy", "Code", 50) },
+            new List<int> { 7 });
+
+        Assert.True(TryResolve(table, "SystemCreatedBy", out var resolved));
+        Assert.Equal(7, resolved.FieldId);
+    }
+}

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -142,11 +142,6 @@ public static partial class RecordPatches
             // SystemCreatedBy (2000000002), SystemModifiedAt (2000000003), SystemModifiedBy
             // (2000000004). These are required for system-field access via FieldRef and RecordRef.
             var timestampParsed       = new ParsedField(0,          "timestamp",         "BigInteger", 0);
-            var systemIdParsed        = new ParsedField(2000000000, "SystemId",          "Guid",       0);
-            var systemCreatedAtParsed = new ParsedField(2000000001, "SystemCreatedAt",   "DateTime",   0);
-            var systemCreatedByParsed = new ParsedField(2000000002, "SystemCreatedBy",   "Guid",       0);
-            var systemModifiedAtParsed= new ParsedField(2000000003, "SystemModifiedAt",  "DateTime",   0);
-            var systemModifiedByParsed= new ParsedField(2000000004, "SystemModifiedBy",  "Guid",       0);
             // Merge any tableextension fields for this base table.
             // De-duplicate by field id: precompiled .app SymbolReference.json sometimes lists
             // extension fields both in the base table's Tables[].Fields entry AND in
@@ -160,8 +155,7 @@ public static partial class RecordPatches
             var extFieldsNew = extFields.Where(f => !baseFieldIds.Contains(f.FieldId));
             var allParsed = new[] { timestampParsed }.Concat(parsed.Fields)
                 .Concat(extFieldsNew)
-                .Concat(new[] { systemIdParsed, systemCreatedAtParsed, systemCreatedByParsed,
-                                systemModifiedAtParsed, systemModifiedByParsed }).ToArray();
+                .Concat(SystemParsedFields).ToArray();
             var fields = allParsed.Select((f, idx) =>
                 BuildMetaField(f, idx, parsed.PkFieldIds.Contains(f.FieldId), parsed)).ToArray();
 
@@ -750,9 +744,7 @@ public static partial class RecordPatches
             int fieldId = 0;
             if (target != null && arm.FieldName != null)
             {
-                var tf = target.Fields.FirstOrDefault(x =>
-                    string.Equals(x.FieldName, arm.FieldName, StringComparison.OrdinalIgnoreCase));
-                if (tf != null)
+                if (TryResolveTableFieldByName(target, arm.FieldName, out var tf))
                 {
                     fieldId = tf.FieldId;
                 }
@@ -778,9 +770,8 @@ public static partial class RecordPatches
             var conditionObjects = new List<object>();
             foreach (var c in arm.Conditions)
             {
-                var localField = referencingTable?.Fields.FirstOrDefault(x =>
-                    string.Equals(x.FieldName, c.SourceFieldName, StringComparison.OrdinalIgnoreCase));
-                if (localField == null)
+                if (referencingTable == null
+                    || !TryResolveTableFieldByName(referencingTable, c.SourceFieldName, out var localField))
                 {
                     Console.Error.WriteLine(
                         $"[RecordPatches] TableRelation on '{forFieldName}': condition field '{c.SourceFieldName}' not found on '{referencingTable?.TableName}' — relation dropped");
@@ -796,9 +787,7 @@ public static partial class RecordPatches
             var filterObjects = new List<object>();
             foreach (var w in arm.Filters)
             {
-                var srcField = target.Fields.FirstOrDefault(x =>
-                    string.Equals(x.FieldName, w.SourceFieldName, StringComparison.OrdinalIgnoreCase));
-                if (srcField == null)
+                if (!TryResolveTableFieldByName(target, w.SourceFieldName, out var srcField))
                 {
                     Console.Error.WriteLine(
                         $"[RecordPatches] TableRelation on '{forFieldName}': where() field '{w.SourceFieldName}' not found on '{target.TableName}' — relation dropped");
@@ -814,9 +803,8 @@ public static partial class RecordPatches
                 // field(upperlimit(X)).
                 if (w.Kind == ParsedCalcFilterKind.Field)
                 {
-                    var refField = referencingTable?.Fields.FirstOrDefault(x =>
-                        string.Equals(x.FieldName, w.ParentFieldName, StringComparison.OrdinalIgnoreCase));
-                    if (refField == null)
+                    if (referencingTable == null
+                        || !TryResolveTableFieldByName(referencingTable, w.ParentFieldName!, out var refField))
                     {
                         Console.Error.WriteLine(
                             $"[RecordPatches] TableRelation on '{forFieldName}': where() field() link '{w.ParentFieldName}' not found on '{referencingTable?.TableName}' — relation dropped");
@@ -999,6 +987,57 @@ public static partial class RecordPatches
         return ctor.Invoke(args)!;
     }
 
+    /// <summary>
+    /// The BC system fields every table carries, in the id order BC itself uses. This is the
+    /// ONE declaration of the set: <see cref="BuildNCLMetaTable"/> appends exactly these to
+    /// the MetaField[] it builds, and <see cref="TryResolveTableFieldByName"/> resolves a
+    /// CalcFormula field name against exactly these. Keeping resolver and materialised set
+    /// the same array is the invariant that matters — resolving a name to an id the built
+    /// NCLMetaTable does not carry faults inside NCL instead of refusing loudly here.
+    /// </summary>
+    private static readonly ParsedField[] SystemParsedFields = new[]
+    {
+        new ParsedField(2000000000, "SystemId",         "Guid",     0),
+        new ParsedField(2000000001, "SystemCreatedAt",  "DateTime", 0),
+        new ParsedField(2000000002, "SystemCreatedBy",  "Guid",     0),
+        new ParsedField(2000000003, "SystemModifiedAt", "DateTime", 0),
+        new ParsedField(2000000004, "SystemModifiedBy", "Guid",     0),
+    };
+
+    /// <summary>
+    /// Resolve a field NAME a CalcFormula or a TableRelation names, on
+    /// <paramref name="table"/>, to the
+    /// <see cref="ParsedField"/> the built NCLMetaTable carries for it.
+    /// <para>#3178: the table's own parsed field list does not carry the system fields, so a
+    /// formula naming one — <c>max(T.SystemCreatedAt where(...))</c>,
+    /// <c>where(X = field(SystemId))</c>, <c>where(SystemCreatedBy = field(Y))</c> — resolved
+    /// to nothing and the whole formula (or, worse, one silently dropped where-arm) went
+    /// missing. Seven Base App FlowFields have that shape. The system fields ARE materialised
+    /// on every built table, so the only thing missing was this second lookup layer. The
+    /// TableRelation builder above resolves field names the same way and had the identical
+    /// miss — <c>TableRelation = T.SystemId</c>, the shape an API page's foreign key uses,
+    /// dropped the whole relation — so it goes through this too.</para>
+    /// <para>Returns false for a genuinely unknown name; the caller then logs and refuses, so
+    /// an unresolvable formula stays loud.</para>
+    /// </summary>
+    private static bool TryResolveTableFieldByName(ParsedTable table, string fieldName, out ParsedField field)
+    {
+        foreach (var f in table.Fields)
+            if (string.Equals(f.FieldName, fieldName, StringComparison.OrdinalIgnoreCase))
+            {
+                field = f;
+                return true;
+            }
+        foreach (var f in SystemParsedFields)
+            if (string.Equals(f.FieldName, fieldName, StringComparison.OrdinalIgnoreCase))
+            {
+                field = f;
+                return true;
+            }
+        field = default!;
+        return false;
+    }
+
     private static object? BuildMetaCalcFormula(ParsedCalcFormula cf, ParsedTable parentTable)
     {
         if (_tMetaCalcFormula == null || _tMetaFilter == null || _tFilterType == null) return null;
@@ -1025,9 +1064,7 @@ public static partial class RecordPatches
         int srcFieldId = 0;
         if (cf.SourceFieldName != null)
         {
-            var srcField = srcTable.Fields.FirstOrDefault(f =>
-                string.Equals(f.FieldName, cf.SourceFieldName, StringComparison.OrdinalIgnoreCase));
-            if (srcField == null)
+            if (!TryResolveTableFieldByName(srcTable, cf.SourceFieldName, out var srcField))
             {
                 Console.Error.WriteLine($"[RecordPatches] BuildMetaCalcFormula: source field '{cf.SourceFieldName}' not found in table '{cf.SourceTableName}'");
                 return null;
@@ -1044,9 +1081,7 @@ public static partial class RecordPatches
         var filterObjects = new List<object>();
         foreach (var filter in cf.Filters)
         {
-            var srcFilterField = srcTable.Fields.FirstOrDefault(f =>
-                string.Equals(f.FieldName, filter.SourceFieldName, StringComparison.OrdinalIgnoreCase));
-            if (srcFilterField == null)
+            if (!TryResolveTableFieldByName(srcTable, filter.SourceFieldName, out var srcFilterField))
             {
                 Console.Error.WriteLine($"[RecordPatches] BuildMetaCalcFormula: filter source field '{filter.SourceFieldName}' not found in '{cf.SourceTableName}'");
                 continue;
@@ -1055,9 +1090,7 @@ public static partial class RecordPatches
             switch (filter.Kind)
             {
                 case ParsedCalcFilterKind.Field:
-                    var parentFilterField = parentTable.Fields.FirstOrDefault(f =>
-                        string.Equals(f.FieldName, filter.ParentFieldName, StringComparison.OrdinalIgnoreCase));
-                    if (parentFilterField == null)
+                    if (!TryResolveTableFieldByName(parentTable, filter.ParentFieldName!, out var parentFilterField))
                     {
                         Console.Error.WriteLine($"[RecordPatches] BuildMetaCalcFormula: filter parent field '{filter.ParentFieldName}' not found in '{parentTable.TableName}'");
                         continue;


### PR DESCRIPTION
Closes #3178

*Opened by agent `fbk-3` (automated implementation agent).*

## The defect

Every BC table carries five system fields it never declares — `SystemId` (2000000000), `SystemCreatedAt` (2000000001), `SystemCreatedBy` (2000000002), `SystemModifiedAt` (2000000003), `SystemModifiedBy` (2000000004). `RecordPatches` already materialises all five onto every `NCLMetaTable` it builds, but the field-name lookups in `BuildMetaCalcFormula` read `ParsedTable.Fields` only, which does not carry them. A formula naming one resolved to nothing.

The two halves fail differently, and the second one is the worse of the pair:

- an unresolvable **source** field returns `null` for the whole formula, so `CalcFields` raises BC's own `You must define a CalcFormula for the {0} FlowField in the {1} table` (the same wrong refusal #3121 fixed for two other causes);
- an unresolvable **where-arm** field hits a `continue` — the arm is dropped and the FlowField still calculates, over the wrong rows, and answers a **wrong number** with no error.

## Fix the shape, not the reported line

Three questions, answered:

1. **Same wrong pattern at another call site?** Yes — four more, in the TableRelation builder in the same file (`BuildMetaFieldRelations`): the relation target field, the condition field on the referencing table, the `where()` field on the target, and the `field()` link back to the referencing table. `TableRelation = <Table>.SystemId` — what every API page's foreign key looks like — logged `did not resolve to a parsed table` and dropped the whole relation, so it stopped being enforced. That is in this PR, with its own RED arm.
2. **Sibling function making the same assumption?** `BuildMetaCondition` takes a field **id**, not a name, so it is not a lookup site. `TryGetParsedFieldMinMax` is by id too.
3. **Two paths writing the same state with different invariants?** The system-field set was declared inline inside `BuildNCLMetaTable` and nowhere else; a resolver reading a different set could answer an id the built table has no `MetaField` for, which faults inside NCL instead of refusing here. So there is now ONE `SystemParsedFields` array, used by both the MetaField build and the resolver, and `SystemRowVersion` is deliberately **not** in it — it is not materialised.

All seven lookups now go through `TryResolveTableFieldByName(table, name, out field)`: the table's own fields first, then the system fields. A genuinely unknown name still logs and refuses, so `loud-failures.md` is unchanged and #3079's refusal is not weakened (the corpus still passes `Record_CalcFields_FlowFieldWithoutCalcFormula_Throws`).

## RED → GREEN

Repro `tmp/gap-repros/calcformula-system-fields` (own tables + one Base App arm), run with `--package-cache <platform-apps> --package-cache <test-apps> --verbose`.

RED, on `main`:

```
[RecordPatches] BuildMetaCalcFormula: filter parent field 'SystemId' not found in 'R3 SysField Parent'
[RecordPatches] BuildMetaCalcFormula: source field 'SystemCreatedAt' not found in table 'R3 SysField Child'
[RecordPatches] BuildMetaCalcFormula: source field 'SystemCreatedBy' not found in table 'R3 SysField Child'
[RecordPatches] BuildMetaCalcFormula: filter source field 'SystemCreatedBy' not found in 'R3 SysField Child'
[RecordPatches] BuildMetaCalcFormula: source field 'SystemCreatedAt' not found in table 'Sales Header Archive'
[RecordPatches] BuildMetaCalcFormula: source field 'SystemCreatedAt' not found in table 'Financial Report Audit Log'
[RecordPatches] TableRelation target 'R3 SysField Child.SystemId' did not resolve to a parsed table - relation dropped
```

| arm | shape | RED | GREEN |
|---|---|---|---|
| control | `count(Child where("Parent Code" = field(Code)))` | 3 | 3 |
| A | `count(Child where("Parent SysId" = field(SystemId)))` | **3** (arm dropped, expected 2) | 2 |
| B | `max(Child.SystemCreatedAt where(...))` | `You must define a CalcFormula ...` | max of the read-back values |
| C | `lookup(Child.SystemCreatedBy where(...))` | `You must define a CalcFormula ...` | the child's `SystemCreatedBy` |
| E | `count(Child where(SystemCreatedBy = field("Owner Id")))` | **3** for an unrelated Owner Id (expected 0) | 3 / 0 |
| G | `TableRelation = Child.SystemId` | `asserterror` fired nothing — relation dropped | accepts an existing SystemId, refuses an unknown one |
| D | Base App `"Sales Header Archive"."Last Archived Date"` | `You must define a CalcFormula ...` | calculates |

Arms A and E are the silent-wrong-number half: on `main` they produce a number, and it is wrong.

## What was run, in this state

- repro: 7/7 pass (`EXIT=0`), all 7 failing or wrong before the fix
- al-language corpus: **2681P/0F/0E** with `--strict --count-baseline`
- `tests/runner-extras`: **316P/0F/0E**
- `AlRunner.Tests` filtered on `Relation|CalcFormula|FlowField|MetaTable|TableExtension|ObjectRefConst`: **82 passed**
- `CalcFormulaSystemFieldResolutionTests`: **11 passed**

The TableRelation half changes every Base App field with `TableRelation = X.SystemId` from dropped-relation to enforced, which is why the full corpus and all of `runner-extras` were run rather than one area.

## Where the proving test lives

The BC claims — what `max(T.SystemCreatedAt where(...))` calculates, and that a relation onto `SystemId` is enforced — are plain BC behaviour, so they are upstream: **corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#216** (`record/TestCalcFormulaSystemFields*`, objects 60816-60818). Container-verified before opening it, on BC 28.4.53241.0: all six tests pass, and the relation refusal reads `The field Line Sys Id of table CFSF Header contains a value ({...}) that cannot be found in the related table (CFSF Line).` The pin bump and the count-baseline update fold into this PR once that merges.

`AlRunner.Tests/CalcFormulaSystemFieldResolutionTests.cs` pins the runner-side mechanism only — the set, the resolver, the shadowing rule, and that `SystemRowVersion` does not resolve.

## Deliberately not in this PR

- **The `continue` on an unresolvable where-arm field.** It is what turns a resolution gap into a wrong number instead of a refusal (arms A and E above are the evidence). Changing it to a refusal has its own blast radius, so it is filed separately rather than folded in.
- **`_parsedExtensionFields` as a third lookup layer.** That is #3263's tableextension case; the helper is shaped so it slots in between the declared fields and the system fields.
- The Base App arm stays in the local repro only — `"Sales Header Archive"."Last Archived Date"` would have to exist on all eight corpus legs from 27.0 up, and the own-table arms prove the same mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016YetuBaizYtaWMHmsDsLNh