### PR TITLE
fix(symbolcache): strip AL directives from a SourceTableView's sorting() clause too

### DIFF
--- a/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
+++ b/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
@@ -949,6 +949,10 @@ public class DependencyPageMetadataXmlTests
     private const int ViewPlusPropsPageId = 88123605;
     private const int PartialViewPageId = 88123606;
     private const int UnbalancedViewPageId = 88123607;
+    private const int DirectiveSortViewOutPageId = 88123608;
+    private const int DirectiveSortViewInPageId = 88123609;
+    private const int DirectiveSortViewSecondInBlockPageId = 88123610;
+    private const int UnconditionalUnresolvableSortViewPageId = 88123611;
 
     private const string ViewSymbolReference = """
         {
@@ -1027,6 +1031,42 @@ public class DependencyPageMetadataXmlTests
                 { "Name": "PageType", "Value": "List" },
                 { "Name": "SourceTable", "Value": "88123620" },
                 { "Name": "SourceTableView", "Value": "sorting(Bucket) where(Bucket = const(7)" }
+              ]
+            },
+            {
+              "Id": 88123608,
+              "Name": "DPX Directive Sort Compiled Out Page",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "88123620" },
+                { "Name": "SourceTableView", "Value": "sorting(Bucket,\r\n#if not CLEAN25\r\n                             \"Zone Code\",\r\n#endif\r\n                             \"No.\")" }
+              ]
+            },
+            {
+              "Id": 88123609,
+              "Name": "DPX Directive Sort Compiled In Page",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "88123620" },
+                { "Name": "SourceTableView", "Value": "sorting(Bucket,\r\n#if not CLEAN25\r\n                             \"Price Type\",\r\n#endif\r\n                             \"No.\")" }
+              ]
+            },
+            {
+              "Id": 88123610,
+              "Name": "DPX Directive Sort Second In Block Page",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "88123620" },
+                { "Name": "SourceTableView", "Value": "sorting(Bucket,\r\n#if not CLEAN25\r\n                             \"Price Type\",\r\n                             \"Zone Code\",\r\n#endif\r\n                             \"No.\")" }
+              ]
+            },
+            {
+              "Id": 88123611,
+              "Name": "DPX Unconditional Unresolvable Sort Page",
+              "Properties": [
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "88123620" },
+                { "Name": "SourceTableView", "Value": "sorting(Bucket, \"Zone Code\", \"No.\") order(descending)" }
               ]
             }
           ]
@@ -1318,6 +1358,182 @@ public class DependencyPageMetadataXmlTests
                 .Cast<XmlElement>().ToList();
             Assert.Single(filters);
             Assert.Equal("0", filters[0].GetAttribute("FieldID"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// #3271. <c>ParseSourceTableView</c> read its two clauses with two different splitters,
+    /// in the same <c>switch</c>, twenty lines apart: <c>where(...)</c> went through
+    /// <c>SplitPropertyEntries</c>, which strips the AL preprocessor directive LINES the
+    /// compiler records verbatim inside a property's source text (#2978), and
+    /// <c>sorting(...)</c> went through the bare <c>SplitTopLevelCommas</c>, which does not.
+    ///
+    /// <para>The symptom is NOT a miscount — it is CORRUPTED FIELD NAMES. The bare splitter
+    /// is called without <c>preserveNewlines</c>, so it flattens the property's newlines to
+    /// spaces first; <c>sorting(Bucket,\n#if not CLEAN25\n"Zone Code",\n#endif\n"No.")</c>
+    /// therefore split into <c>Bucket</c>, the literal string <c>#if not CLEAN25 "Zone
+    /// Code"</c>, and the literal string <c>#endif "No."</c>. Two of the three "field names"
+    /// were directive text glued onto a real name.</para>
+    ///
+    /// <para>It failed SAFE, which is why this was filed rather than hotfixed: a corrupted
+    /// name cannot resolve against the source table, so <c>EmitSourceTableViewXml</c> set
+    /// <c>unresolved</c> and left the key alone — the page came up on the table's DEFAULT key
+    /// rather than on a wrong one. Wrong ORDER, not a wrong ROWSET. Still wrong: BC applies
+    /// the sort and the runner did not, and the only trace was a <c>Console.Error</c> line
+    /// the content-addressed symbol cache emits on a MISS and loses on every warm run.</para>
+    ///
+    /// <para>This fixture is the compiled-OUT half: the guarded name <c>"Zone Code"</c> is not
+    /// a field of table 88123620, which is this app saying the directive compiled that entry
+    /// out. The remaining two names are real and must produce a real key — <c>Field2,Field1</c>
+    /// — where before the fix nothing resolved and <c>KeyFields</c> was never written at
+    /// all.</para>
+    ///
+    /// <para>Omitted, not refused, and that is a deliberate choice rather than an analogy to
+    /// the <c>where(...)</c> arm: a key is not a filter, so dropping one field changes the
+    /// ORDER instead of widening the rowset. It is still right, because the compiled app's
+    /// page really does declare <c>sorting(Bucket, "No.")</c> — the guarded entry is not in it
+    /// — so the two-field key is a reconstruction of what the compiler kept, not an
+    /// approximation of a three-field one.</para>
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_DirectiveGuardedSortFieldCompiledOut_KeysOnTheFieldsTheAppActuallyHas()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, ViewSymbolReference));
+
+            var sourceObject = ReadSourceObjectFor(DirectiveSortViewOutPageId);
+            var ns = MetaNs(sourceObject.OwnerDocument!);
+            var sorting = (XmlElement?)sourceObject.SelectSingleNode("m:SourceTableView/m:Sorting", ns);
+            Assert.NotNull(sorting);
+
+            // BEFORE #3271: KeyFields was "" and KeyFieldsSetByView was "" — the first entry
+            // the loop met was `#if not CLEAN25 "Zone Code"`, which resolved to nothing, so it
+            // broke out with unresolved=true and wrote neither attribute.
+            Assert.Equal("Field2,Field1", sorting!.GetAttribute("KeyFields"));
+            Assert.Equal("1", sorting.GetAttribute("KeyFieldsSetByView"));
+
+            // The view states no order(), so ApplySourceTableView must not touch ALAscending.
+            Assert.Equal("", sorting.GetAttribute("AscendingSetByView"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// #3271, the direction that stops the test above from passing for an implementation that
+    /// simply throws every directive-guarded sorting entry away. Same three-entry
+    /// <c>sorting(...)</c>, same directive, only the guarded name differs: <c>"Price Type"</c>
+    /// IS a field of table 88123620, which is this app saying the directive did NOT compile
+    /// that entry out — so it belongs in the key, in the position the view declares it.
+    ///
+    /// <para>A key's field ORDER is its identity, so this also pins that the guarded entry is
+    /// reinserted in the middle rather than appended: <c>Field2,Field3,Field1</c>, not
+    /// <c>Field2,Field1,Field3</c>.</para>
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_DirectiveGuardedSortFieldCompiledIn_KeepsItInTheDeclaredPosition()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, ViewSymbolReference));
+
+            var sourceObject = ReadSourceObjectFor(DirectiveSortViewInPageId);
+            var ns = MetaNs(sourceObject.OwnerDocument!);
+            var sorting = (XmlElement?)sourceObject.SelectSingleNode("m:SourceTableView/m:Sorting", ns);
+            Assert.NotNull(sorting);
+
+            Assert.Equal("Field2,Field3,Field1", sorting!.GetAttribute("KeyFields"));
+            Assert.Equal("1", sorting.GetAttribute("KeyFieldsSetByView"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// #3271, the third arm — conditional-ness is a property of the BLOCK, not of the entry
+    /// that happens to carry the directive text, exactly as
+    /// <c>TryBuildDependencyPageMetadata_SecondEntryInsideTheSameDirectiveBlock_IsConditionalToo</c>
+    /// pins for a SubPageLink. Comma-splitting puts <c>#if not CLEAN25</c> on the FIRST guarded
+    /// entry only, so a second entry inside the same block carries no <c>#</c> line of its own.
+    ///
+    /// <para>Reading that second entry as UNCONDITIONAL is the failure this arm catches: here
+    /// the block guards <c>"Price Type"</c> (in the app) followed by <c>"Zone Code"</c> (not
+    /// in the app). Treating <c>"Zone Code"</c> as unconditional makes the whole key
+    /// unresolvable and the page falls back to its default order, which is the pre-#3271
+    /// answer arrived at by a different route. Treating it as conditional — which it is, being
+    /// inside the same <c>#if</c> — omits it and keeps the rest.</para>
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_SecondSortFieldInsideTheSameDirectiveBlock_IsConditionalToo()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, ViewSymbolReference));
+
+            var sourceObject = ReadSourceObjectFor(DirectiveSortViewSecondInBlockPageId);
+            var ns = MetaNs(sourceObject.OwnerDocument!);
+            var sorting = (XmlElement?)sourceObject.SelectSingleNode("m:SourceTableView/m:Sorting", ns);
+            Assert.NotNull(sorting);
+
+            Assert.Equal("Field2,Field3,Field1", sorting!.GetAttribute("KeyFields"));
+            Assert.Equal("1", sorting.GetAttribute("KeyFieldsSetByView"));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// #3271's negative direction, and the one that keeps the three tests above from passing
+    /// for an implementation that simply drops every name it cannot resolve. An
+    /// UNCONDITIONAL sorting field that does not resolve is not evidence of anything having
+    /// been compiled out — it is a name this run cannot make sense of — so the key must be
+    /// left alone rather than silently narrowed to the fields that happened to resolve.
+    ///
+    /// <para>Same three names as the compiled-out fixture, with the directive lines removed,
+    /// so <c>"Zone Code"</c> is an ordinary unresolvable name rather than a guarded one — and
+    /// with an <c>order(descending)</c> beside it, so the assertion can tell "the KEY was
+    /// refused" from "the whole <c>&lt;Sorting&gt;</c> element was dropped".</para>
+    /// </summary>
+    [Fact]
+    public void TryBuildDependencyPageMetadata_UnconditionalSortFieldThatDoesNotResolve_LeavesTheKeyAloneRatherThanNarrowingIt()
+    {
+        var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, ViewSymbolReference));
+
+            var sourceObject = ReadSourceObjectFor(UnconditionalUnresolvableSortViewPageId);
+            var ns = MetaNs(sourceObject.OwnerDocument!);
+            var sorting = (XmlElement?)sourceObject.SelectSingleNode("m:SourceTableView/m:Sorting", ns);
+            Assert.NotNull(sorting);
+
+            // NOT "Field2,Field1": narrowing the key here would sort the page on a key the AL
+            // does not declare, which is a wrong answer rather than a missing one.
+            Assert.Equal("", sorting!.GetAttribute("KeyFields"));
+            Assert.Equal("", sorting.GetAttribute("KeyFieldsSetByView"));
+
+            // …and the order() beside it is still carried, so this is a refusal of the KEY
+            // rather than of the whole <Sorting> element.
+            Assert.Equal("1", sorting.GetAttribute("AscendingSetByView"));
+            Assert.Equal("0", sorting.GetAttribute("Ascending"));
         }
         finally
         {

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -517,7 +517,7 @@ internal static partial class BcAppSymbolCache
     /// the view SET it (<c>AscendingSetByView</c>).</para>
     /// </summary>
     internal sealed record PageTableViewSymbol(
-        List<string> SortingFieldNames, bool? Ascending, List<PageViewFilterSymbol> Filters,
+        List<PageViewSortFieldSymbol> SortingFields, bool? Ascending, List<PageViewFilterSymbol> Filters,
         // The raw text of every where(...) entry — and every clause whose parenthesis never
         // closed — ParseSourceTableView could NOT read (#2978). Null when there were none,
         // which is the case for all 255 where-entries across the 417 SourceTableView pages of
@@ -542,6 +542,36 @@ internal static partial class BcAppSymbolCache
         // — but the property text comes from the same compiler and through the same splitter,
         // so the two paths answer it the same way rather than one of them being surprised.
         bool Conditional = false);
+
+    /// <summary>
+    /// One <c>sorting(...)</c> field of a <c>SourceTableView</c>: the page's own source-table
+    /// field name, in the order the view declares it.
+    ///
+    /// <para>This used to be a bare <c>string</c>, and the <c>sorting</c> arm used to be split
+    /// by the bare <see cref="SplitTopLevelCommas"/> while the <c>where</c> arm beside it went
+    /// through <see cref="SplitPropertyEntries"/> (#3271). The bare splitter does not strip the
+    /// AL preprocessor directive LINES the compiler records verbatim inside a property's source
+    /// text (#2978) — and, called without <c>preserveNewlines</c>, it flattens them into the
+    /// entry beside them first. So <c>sorting(Bucket, #if not CLEAN25 "Zone Code", #endif
+    /// "No.")</c> did not merely MISCOUNT: it produced the literal field names
+    /// <c>#if not CLEAN25 "Zone Code</c> and <c>#endif "No.</c>, destroying a real name in
+    /// the process.</para>
+    ///
+    /// <para><paramref name="Conditional"/> has the same meaning as on
+    /// <see cref="PageViewFilterSymbol"/>: the entry sat inside an <c>#if</c> block, so nothing
+    /// in the symbol file records whether the compiler kept it, and
+    /// <c>DependencyPageMetadataXml.EmitSourceTableViewXml</c> resolves it against the app's own
+    /// field inventory — applied when the name resolves, OMITTED when it does not.</para>
+    ///
+    /// <para>Omitting is a deliberate decision here and not an analogy to the filter arm, since
+    /// a key is not a filter: dropping one field changes the ORDER rather than widening the
+    /// rowset. It is still the right answer, because a guarded entry the app does not contain
+    /// is not in the compiled page either — the compiled page really does declare the shorter
+    /// key, so the shorter key is a reconstruction rather than an approximation. The
+    /// alternative, refusing the whole key, leaves the page on the table's DEFAULT order, which
+    /// is further from what BC does, not closer.</para>
+    /// </summary>
+    internal sealed record PageViewSortFieldSymbol(string FieldName, bool Conditional = false);
 
     /// <summary>
     /// One field control of a precompiled dependency page, as SymbolReference.json states
@@ -1573,7 +1603,7 @@ internal static partial class BcAppSymbolCache
     {
         if (string.IsNullOrWhiteSpace(text)) return null;
 
-        var sorting = new List<string>();
+        var sorting = new List<PageViewSortFieldSymbol>();
         bool? ascending = null;
         var filters = new List<PageViewFilterSymbol>();
         List<string>? unreadable = null;
@@ -1599,10 +1629,19 @@ internal static partial class BcAppSymbolCache
             switch (m.Groups["clause"].Value.ToLowerInvariant())
             {
                 case "sorting":
-                    foreach (var f in SplitTopLevelCommas(inner))
+                    // SplitPropertyEntries, not the bare SplitTopLevelCommas (#3271). Both arms
+                    // of this switch read text the SAME compiler wrote, so both must strip the
+                    // AL preprocessor directive lines it records verbatim inside a property's
+                    // source (#2978). The bare splitter did not, AND it flattened the newlines
+                    // that make a directive a LINE — so a guarded sorting() did not produce a
+                    // short field list, it produced field names with directive text glued onto
+                    // them (`#if not CLEAN25 "Zone Code`), which is also how it destroyed the
+                    // real name on the line after the #endif.
+                    foreach (var (entry, conditional) in SplitPropertyEntries(inner))
                     {
-                        var fieldName = f.Trim().Trim('"');
-                        if (fieldName.Length > 0) sorting.Add(fieldName);
+                        var fieldName = entry.Trim().Trim('"');
+                        if (fieldName.Length > 0)
+                            sorting.Add(new PageViewSortFieldSymbol(fieldName, conditional));
                     }
                     break;
                 case "order":

--- a/AlRunner/Patches/DependencyPageMetadataXml.cs
+++ b/AlRunner/Patches/DependencyPageMetadataXml.cs
@@ -553,13 +553,31 @@ public static partial class RecordPatches
     {
         w.WriteStartElement("SourceTableView");
 
-        if (view.SortingFieldNames.Count > 0 || view.Ascending.HasValue)
+        if (view.SortingFields.Count > 0 || view.Ascending.HasValue)
         {
-            var keyFieldIds = new List<string>(view.SortingFieldNames.Count);
+            var keyFieldIds = new List<string>(view.SortingFields.Count);
             var unresolved = false;
-            foreach (var fieldName in view.SortingFieldNames)
+            foreach (var sortField in view.SortingFields)
             {
-                var id = RecordPatches.TryResolveDependencyFieldId(page.SourceTableId, fieldName);
+                var id = RecordPatches.TryResolveDependencyFieldId(page.SourceTableId, sortField.FieldName);
+
+                // #3271: an entry inside an AL `#if` block may not be in the compiled app at
+                // all, and this app's own field inventory is the only evidence available —
+                // same rule and same reasoning as the conditional filter arm below, and as
+                // EmitSubFormLinkXml's. Omit it and keep the rest of the key: a guarded entry
+                // the app does not contain is not in the compiled page either, so the shorter
+                // key is what that page actually declares. Refusing the whole key instead
+                // would leave the page on the table's DEFAULT order, which is further from
+                // what BC does rather than closer.
+                if (sortField.Conditional && id is null)
+                {
+                    Console.Error.WriteLine(
+                        $"[RecordPatches] page {page.Id} \"{page.Name}\": conditional SourceTableView "
+                        + $"sorting field \"{sortField.FieldName}\" omitted — the field it names is not "
+                        + "in this app, so the AL directive guarding it compiled the entry out");
+                    continue;
+                }
+
                 if (id is null) { unresolved = true; break; }
                 // BC's own spelling for MetaTable.GetKeyFieldIds: "Field<id>", in view order.
                 keyFieldIds.Add("Field" + id.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));
@@ -579,7 +597,7 @@ public static partial class RecordPatches
                 // KeyFields only when KeyFieldsSetByView says to).
                 Console.Error.WriteLine(
                     $"[RecordPatches] page {page.Id} \"{page.Name}\": SourceTableView sorting("
-                    + string.Join(", ", view.SortingFieldNames)
+                    + string.Join(", ", view.SortingFields.Select(f => f.FieldName))
                     + $") not applied — a field name did not resolve against table {page.SourceTableId}");
             }
             if (view.Ascending.HasValue)


### PR DESCRIPTION
Closes #3271

`ParseSourceTableView` read its two clauses with two different splitters, in the same `switch`, twenty lines apart: `where(...)` went through `SplitPropertyEntries`, which strips the AL preprocessor directive lines the compiler records verbatim inside a property's source text (#2978), and `sorting(...)` went through the bare `SplitTopLevelCommas`, which does not.

## The symptom is corrupted field names, not a miscount

This is the distinction from the sibling defect in PR #3273, and it matters for reading the fix. The bare splitter is called **without `preserveNewlines`**, so it flattens the property's newlines to spaces *before* splitting. A directive is a LINE, so once the newline is a space the directive and the entry beside it are one run-on string. Reproduced against the real splitter logic:

```
sorting(Bucket,
#if not CLEAN25
        "Zone Code",
#endif
        "No.")
```

splits into exactly three entries:

```
['Bucket', '#if not CLEAN25   "Zone Code', '#endif   "No.']
```

Two of the three "field names" are directive text glued onto a real name — and note the second one: the `#endif` destroyed `"No."`, a name that is unconditionally in the app and had nothing to do with the guard. The count is right; the names are wrong.

## Severity: it failed safe, so this is correctness in principle

A corrupted name cannot resolve against the source table, so `EmitSourceTableViewXml` set `unresolved`, wrote a stderr line, and left the key alone rather than setting a wrong one. The page came up on the table's **default** key — a wrong ORDER, not a wrong ROWSET. That is why #3271 was filed separately rather than hotfixed, and the framing is unchanged here.

**Nothing shipping is affected today, and I could not fully re-measure that.** The issue and the comment at `DependencyPageMetadataXml.cs:598` both record that no `SourceTableView` in BC 27.5 or 28.1 W1 carries a directive. I tried to reproduce that scan independently and could not: the symbol files reachable from this box (`~/.al-runner/platform-apps/`, `~/work-stma-auto-1/pkgcache/`) are trimmed fixtures — Base Application 28.1 resolves to **10 pages with 1 `SourceTableView`**, against the 386 the existing comments cite. So the "no BC page carries one" claim in this PR rests on the prior measurement recorded in the code, not on one I repeated. Stating that plainly rather than implying a scan I did not run.

## The design decision, made deliberately rather than by analogy

`where(...)` resolves a conditional entry against the app's own field inventory: applied when the name resolves, omitted when it does not. `sorting(...)` now does the same — but the issue is right that a key is not a filter, so this needed deciding rather than copying:

- **Omitting** one field from a multi-field key changes the ORDER, it does not widen the rowset.
- It is still correct, because a guarded entry the app does not contain **is not in the compiled page either**. The compiled page really does declare the shorter key, so the shorter key is a *reconstruction* of what the compiler kept, not an approximation of a longer one.
- The alternative — refusing the whole key — leaves the page on the table's **default** order, which is further from what BC does, not closer. It is also exactly the pre-fix answer.

An **unconditional** name that does not resolve still refuses the whole key, unchanged.

## RED → GREEN

Four tests in `AlRunner.Tests/DependencyPageMetadataXmlTests.cs`, on the existing `ViewSymbolReference` fixture (table 88123620 has fields `No.`=1, `Bucket`=2, `Price Type`=3):

| test | asserts |
|---|---|
| `...DirectiveGuardedSortFieldCompiledOut_KeysOnTheFieldsTheAppActuallyHas` | guarded `"Zone Code"` is not in the app → `KeyFields="Field2,Field1"`, `KeyFieldsSetByView="1"`, and no `AscendingSetByView` (the view states no `order()`) |
| `...DirectiveGuardedSortFieldCompiledIn_KeepsItInTheDeclaredPosition` | guarded `"Price Type"` IS in the app → `KeyFields="Field2,Field3,Field1"` — pins the middle position, since a key's field order is its identity |
| `...SecondSortFieldInsideTheSameDirectiveBlock_IsConditionalToo` | conditional-ness belongs to the BLOCK: the second entry inside one `#if` carries no `#` line of its own and must still be conditional |
| `...UnconditionalSortFieldThatDoesNotResolve_LeavesTheKeyAloneRatherThanNarrowingIt` | the negative arm — `KeyFields` and `KeyFieldsSetByView` both empty, while `AscendingSetByView="1"`/`Ascending="0"` are still written, so it distinguishes "the KEY was refused" from "the `<Sorting>` element was dropped" |

**RED:** the first three failed with `Expected: "Field2,Field1" / Actual: ""` — the loop's first entry was `#if not CLEAN25 "Zone Code"`, which resolved to nothing, so it broke out with `unresolved=true` and wrote neither attribute. The fourth passed already, by design: it pins behavior the fix must not break, and would fail for an implementation that drops every unresolvable name.

**GREEN:** 36/36 in `DependencyPageMetadataXmlTests`. Wider targeted run over the changed surface (`BcAppSymbolCache`, `SourceTableView`, `DependencyPageMetadata`, `RecordShapeFingerprint`): **79/79 passed**. I did not run the full `AlRunner.Tests` suite and am not claiming it.

## No `CacheVersion` bump — deliberately, and it must not get one here

`PageTableViewSymbol.SortingFieldNames` (`List<string>`) became `SortingFields` (`List<PageViewSortFieldSymbol>`). That is a **shape** change reachable from `CachePayload`, and `RecordShapeFingerprint` walks transitively through the runner's own types spelling out generic arguments — so `PayloadShape` gives this a different cache key by construction. No stale payload can replay the pre-fix answer.

This is precisely the case the note above `private const int CacheVersion` already records for #2820: `CacheVersion` means "the PARSE changed while the SHAPE did not", which no structural hash can see. That is not this change.

It is also the right call for a second reason: PR #3273 (agent `stma-auto-1`, issue #3277) is bumping `CacheVersion` 32→33 in this same file right now. Touching it here would conflict for no benefit. **This PR touches no `CacheVersion`, no RunPageLink counting path and no `ParseSubPageLink`** — the diff is confined to `ParseSourceTableView`'s `sorting()` arm, the record it fills, and the emitter that reads it.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** `git grep SplitTopLevelCommas` over `AlRunner/` leaves two live call sites in `BcAppSymbolCache.cs`: line 1493 is `SplitPropertyEntries`'s own correct use (`preserveNewlines: true`), and line 1345 is the RunPageLink declared-entry count — **that one is #3277 / PR #3273's, explicitly not touched here.** After this change no bare use feeds a `SourceTableView` parse.
2. **Sibling making the same assumption?** `RecordPatches.AlSourceParser.cs` has its own private `SplitTopLevelCommas`, used by `TryParseColumnFilterText` for a query's `ColumnFilter` — the same class of symbol-file property text, also directive-blind. **Not folded**, and not silently: it is a different file with a different discipline (an unrecognized shape refuses the WHOLE property with a `[ColumnFilter] REFUSED` line rather than fabricating a name), so it fails loudly rather than corrupting, and I have no measurement of a BC query carrying a directive there. Flagging it for a reviewer rather than expanding this diff.
3. **Two paths writing the same state, same invariant?** `EmitSourceTableViewXml` now handles `Conditional` on all three of its consumers — `EmitSubFormLinkXml`'s link arm (line 468), the new sorting arm (572) and the filter arm (620). Before this, one of the three had no conditional handling at all.

**Open-issue queue scan for this file:** #3277 is the only other open issue landing in `BcAppSymbolCache.cs`, and it is claimed and in flight as PR #3273. Nothing else to fold.

---

Implemented by agent `stma-auto-2` on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4

Corpus-NA: the defect is in how the runner parses a SourceTableView's sorting() clause out of SymbolReference.json inside a precompiled .app. A real service tier never reads that file, and a corpus-declared page would be source-compiled and never reach this parser, so no corpus test can go RED on it — the body also records that no shipping BC page carries a directive in a SourceTableView, so the input cannot be constructed against Base Application either. The BC behaviour underneath, that a page's SourceTableView is applied before OnOpenPage, is already pinned upstream by corpus PR 166.
