### PR TITLE
fix(permissions): back the session user's SUPER status with a real Access Control row, and bump the corpus pin

### DIFF
--- a/AlRunner.Tests/AccessControlSuperRowSeedTests.cs
+++ b/AlRunner.Tests/AccessControlSuperRowSeedTests.cs
@@ -1,0 +1,177 @@
+// AccessControlSuperRowSeedTests — RUNNER-MECHANISM tests for the #3176 seed.
+//
+// WHAT IS AND IS NOT PINNED HERE
+//   That a user's SUPER status is backed by an Access Control row is plain BC behaviour, and it
+//   is adjudicated upstream by a real service tier: corpus codeunit 60889
+//   `SessionUserIsSuper_AndAccessControlHoldsTheRowThatSaysSo` (upstream PR #204), green on all
+//   eight required BC legs. That test is this change's RED -> GREEN and this file does not
+//   duplicate its claim — per .claude/rules/bc-behavior-tests-go-upstream.md a BC claim belongs
+//   upstream, not restated locally where only the runner would adjudicate it.
+//
+//   What these pin is the runner's own MECHANISM, which no corpus test can see:
+//
+//     1. THE ORDERING. The seed must run AFTER the User row seed and BEFORE the install-baseline
+//        capture. Both edges are load-bearing and both fail silently if broken:
+//          * before the User row -> the row's "User Security ID" relates to User."User Security
+//            ID", which holds no row yet;
+//          * after the capture   -> the row exists for exactly as long as it takes the first
+//            codeunit boundary to restore the store to the baseline, so the corpus test would
+//            pass or fail depending on which test in the codeunit ran first.
+//        The second is the nastier one, because a run with the seed misplaced that way is green
+//        on a single-test run and red on a full one. RecordPatches.UserSystemTable.cs gives this
+//        exact reasoning for the User row it seeds one statement earlier.
+//
+//     2. THE BUNDLE RESET IS WIRED. A per-bundle latch that is never cleared seeds the first
+//        bundle of a multi-bundle run and silently skips every bundle after it — the row is then
+//        absent in bundles 2..N while the latch claims it was seeded.
+//
+//   Both are read out of TestExecutor.cs's source. That is deliberate: the ordering is a property
+//   of the call sequence, and asserting it from the source is exact and costs no runner spawn,
+//   where driving it through a fixture would spawn the runner (~6-70s per invocation, see
+//   .claude/rules/no-base-app-in-csharp-tests.md) to observe the same three statements.
+//
+//   The PhaseLog mark itself is separately required by PhaseLogIntegrationTests, which runs the
+//   real runner — so "the stage actually executes" is pinned by a live run over there, and the
+//   order it executes in is pinned here.
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class AccessControlSuperRowSeedTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static string TestExecutorSource()
+    {
+        var path = Path.Combine(RepoRoot, "AlRunner", "TestExecutor.cs");
+        Assert.True(File.Exists(path), $"TestExecutor.cs not found at {path}");
+        return File.ReadAllText(path);
+    }
+
+    /// <summary>
+    /// The seed is called at all, and exactly once. A second call site would re-run the insert
+    /// against a store the first call already wrote — benign today only because the latch short
+    /// -circuits it, which is not a property to depend on silently.
+    /// </summary>
+    [Fact]
+    public void AccessControlSeed_IsCalledExactlyOnce_FromTestExecutor()
+    {
+        var src = TestExecutorSource();
+        var calls = CountOccurrences(src, "EnsureAccessControlSuperRowSeeded()");
+        Assert.True(
+            calls == 1,
+            $"expected exactly one call to EnsureAccessControlSuperRowSeeded() in TestExecutor.cs, found {calls}. "
+            + "See AlRunner#3176.");
+    }
+
+    /// <summary>
+    /// ORDERING, EDGE 1: after the User row seed. The Access Control row's "User Security ID"
+    /// relates to User."User Security ID", so seeding it first writes a row whose relation target
+    /// does not exist.
+    /// </summary>
+    [Fact]
+    public void AccessControlSeed_RunsAfterTheUserRowSeed()
+    {
+        var src = TestExecutorSource();
+        var userSeed = src.IndexOf("EnsureUserSystemTableRowSeeded()", StringComparison.Ordinal);
+        var acSeed = src.IndexOf("EnsureAccessControlSuperRowSeeded()", StringComparison.Ordinal);
+
+        Assert.True(userSeed >= 0, "EnsureUserSystemTableRowSeeded() call not found in TestExecutor.cs");
+        Assert.True(acSeed >= 0, "EnsureAccessControlSuperRowSeeded() call not found in TestExecutor.cs");
+        Assert.True(
+            userSeed < acSeed,
+            "the Access Control SUPER row must be seeded AFTER the User row: its \"User Security ID\" "
+            + "relates to User.\"User Security ID\", which holds no row until the User seed has run. "
+            + $"Found the User seed at offset {userSeed} and the Access Control seed at {acSeed}. "
+            + "See AlRunner#3176.");
+    }
+
+    /// <summary>
+    /// ORDERING, EDGE 2 — the one that fails silently. Before the baseline capture, or the row
+    /// lives only until the first codeunit boundary restores the store to the baseline. A run
+    /// with the seed on the wrong side of this line is GREEN on a single-test invocation and RED
+    /// on a full one, which is the worst shape a regression can take.
+    /// </summary>
+    [Fact]
+    public void AccessControlSeed_RunsBeforeTheInstallBaselineIsCaptured()
+    {
+        var src = TestExecutorSource();
+        var acSeed = src.IndexOf("EnsureAccessControlSuperRowSeeded()", StringComparison.Ordinal);
+        var capture = src.IndexOf("CaptureInstallBaseline()", StringComparison.Ordinal);
+
+        Assert.True(acSeed >= 0, "EnsureAccessControlSuperRowSeeded() call not found in TestExecutor.cs");
+        Assert.True(capture >= 0, "CaptureInstallBaseline() call not found in TestExecutor.cs");
+        Assert.True(
+            acSeed < capture,
+            "the Access Control SUPER row must be seeded BEFORE CaptureInstallBaseline(), or it is not "
+            + "part of the baseline each test is restored to and survives only until the first codeunit "
+            + $"boundary. Found the seed at offset {acSeed} and the capture at {capture}. See AlRunner#3176.");
+    }
+
+    /// <summary>
+    /// The per-bundle latch is cleared for each new bundle. Without this the first bundle of a
+    /// multi-bundle run is seeded and every bundle after it is silently skipped, while
+    /// <c>AccessControlRowSeededForThisBundle</c> still reads true.
+    /// </summary>
+    [Fact]
+    public void AccessControlSeed_LatchIsResetForEachNewBundle()
+    {
+        var src = TestExecutorSource();
+        Assert.True(
+            src.Contains("ResetAccessControlSeedForNewBundle()", StringComparison.Ordinal),
+            "TestExecutor.cs never calls ResetAccessControlSeedForNewBundle(), so the per-bundle latch is "
+            + "never cleared: bundle 1 gets the SUPER row and bundles 2..N silently do not. See AlRunner#3176.");
+
+        var reset = src.IndexOf("ResetAccessControlSeedForNewBundle()", StringComparison.Ordinal);
+        var seed = src.IndexOf("EnsureAccessControlSuperRowSeeded()", StringComparison.Ordinal);
+        Assert.True(
+            reset < seed,
+            "the latch reset must come before the seed in the per-bundle sequence, or the reset clears a "
+            + $"latch the seed has just set. Reset at {reset}, seed at {seed}.");
+    }
+
+    /// <summary>
+    /// The seed reports its own stage, so PhaseLogIntegrationTests can require the mark and a
+    /// deleted call site fails there too rather than only here.
+    /// </summary>
+    [Fact]
+    public void AccessControlSeed_CarriesItsOwnPhaseLogStage()
+    {
+        var src = TestExecutorSource();
+        Assert.True(
+            src.Contains("\"install-seed-access-control-row\"", StringComparison.Ordinal),
+            "the Access Control seed carries no PhaseLog AppStage mark, so its cost is unattributed and "
+            + "PhaseLogIntegrationTests cannot require it. See AlRunner#3176.");
+    }
+
+    /// <summary>
+    /// The stated SUPER fact in PermissionSetAssignment.cs is deliberately NOT removed by this
+    /// change, and this pins that. A bundle whose closure carries no Access Control metatable
+    /// cannot hold the seeded row at all, and IsSuper must still answer true for it or codeunit
+    /// 9002 refuses a `User.Modify` every real BC test tier allows. Deleting the fact as
+    /// "now redundant" would break exactly those bundles, and nothing else would say so.
+    /// </summary>
+    [Fact]
+    public void TheStatedSuperFact_SurvivesTheSeed_ForBundlesWithNoAccessControlTable()
+    {
+        var path = Path.Combine(RepoRoot, "AlRunner", "Patches", "RecordPatches.PermissionSetAssignment.cs");
+        Assert.True(File.Exists(path), $"RecordPatches.PermissionSetAssignment.cs not found at {path}");
+        var src = File.ReadAllText(path);
+
+        Assert.True(
+            src.Contains("IsSkeletonSessionUser(session, userSecurityId)", StringComparison.Ordinal),
+            "the stated SUPER fact was removed from IsPermissionSetAssignedCore. It is NOT made redundant by "
+            + "the #3176 seed: a bundle whose closure has no Access Control metatable cannot hold the seeded "
+            + "row, and IsSuper must still answer true for it. See AlRunner#3176.");
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var n = 0;
+        for (var i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+            n++;
+        return n;
+    }
+}

--- a/AlRunner.Tests/AccessControlSuperRowSeedTests.cs
+++ b/AlRunner.Tests/AccessControlSuperRowSeedTests.cs
@@ -25,14 +25,22 @@
 //        bundle of a multi-bundle run and silently skips every bundle after it — the row is then
 //        absent in bundles 2..N while the latch claims it was seeded.
 //
-//   Both are read out of TestExecutor.cs's source. That is deliberate: the ordering is a property
-//   of the call sequence, and asserting it from the source is exact and costs no runner spawn,
-//   where driving it through a fixture would spawn the runner (~6-70s per invocation, see
-//   .claude/rules/no-base-app-in-csharp-tests.md) to observe the same three statements.
+//   HOW STRONG THESE ARE, EXACTLY. The tests below read TestExecutor.cs as TEXT and compare
+//   `IndexOf` offsets. That is a claim about where the calls sit in one source file, which is a
+//   PROXY for the call sequence and not the call sequence itself: it happens to be sound today
+//   because all three calls are unconditional straight-line statements inside TestExecutor.Run,
+//   but it would keep passing if a call moved into another method that runs later, and it would
+//   start failing if a method were reordered in the file without any behaviour changing. So they
+//   are cheap regression guards on the call sites — they cost no runner spawn (~6-70s per
+//   invocation, see .claude/rules/no-base-app-in-csharp-tests.md) — and they are deliberately
+//   NOT the proof of the ordering.
 //
-//   The PhaseLog mark itself is separately required by PhaseLogIntegrationTests, which runs the
-//   real runner — so "the stage actually executes" is pinned by a live run over there, and the
-//   order it executes in is pinned here.
+//   THE ORDERING ITSELF IS PROVED AT RUNTIME, in PhaseLogIntegrationTests, which drives the real
+//   runner and reads the emitted PhaseLog stage breakdown. PhaseLog records stages "in the order
+//   the stages were first entered", so the property order of the emitted `stages` object is the
+//   actual call sequence; `AssertStageOrder` there pins
+//   install-seed-reset-for-new-bundle -> install-seed-access-control-row -> install-seed-capture-baseline
+//   on a live run. That is where a genuine cross-method ordering regression is caught.
 using Xunit;
 
 namespace AlRunner.Tests;
@@ -69,6 +77,10 @@ public sealed class AccessControlSuperRowSeedTests
     /// ORDERING, EDGE 1: after the User row seed. The Access Control row's "User Security ID"
     /// relates to User."User Security ID", so seeding it first writes a row whose relation target
     /// does not exist.
+    /// <para>
+    /// Checks SOURCE POSITION in TestExecutor.cs, not the executed order — see the file header.
+    /// The runtime order is pinned by PhaseLogIntegrationTests over a live run.
+    /// </para>
     /// </summary>
     [Fact]
     public void AccessControlSeed_RunsAfterTheUserRowSeed()
@@ -83,7 +95,8 @@ public sealed class AccessControlSuperRowSeedTests
             userSeed < acSeed,
             "the Access Control SUPER row must be seeded AFTER the User row: its \"User Security ID\" "
             + "relates to User.\"User Security ID\", which holds no row until the User seed has run. "
-            + $"Found the User seed at offset {userSeed} and the Access Control seed at {acSeed}. "
+            + $"Found the User seed at source offset {userSeed} and the Access Control seed at {acSeed} "
+            + "(source position in TestExecutor.cs, a proxy for the call order). "
             + "See AlRunner#3176.");
     }
 
@@ -92,6 +105,12 @@ public sealed class AccessControlSuperRowSeedTests
     /// lives only until the first codeunit boundary restores the store to the baseline. A run
     /// with the seed on the wrong side of this line is GREEN on a single-test invocation and RED
     /// on a full one, which is the worst shape a regression can take.
+    /// <para>
+    /// Checks SOURCE POSITION in TestExecutor.cs, not the executed order — see the file header.
+    /// PhaseLogIntegrationTests asserts
+    /// install-seed-access-control-row -> install-seed-capture-baseline on a live run, which is
+    /// what actually rules this regression out.
+    /// </para>
     /// </summary>
     [Fact]
     public void AccessControlSeed_RunsBeforeTheInstallBaselineIsCaptured()
@@ -106,13 +125,22 @@ public sealed class AccessControlSuperRowSeedTests
             acSeed < capture,
             "the Access Control SUPER row must be seeded BEFORE CaptureInstallBaseline(), or it is not "
             + "part of the baseline each test is restored to and survives only until the first codeunit "
-            + $"boundary. Found the seed at offset {acSeed} and the capture at {capture}. See AlRunner#3176.");
+            + $"boundary. Found the seed at source offset {acSeed} and the capture at {capture} (source "
+            + "position in TestExecutor.cs, a proxy for the call order; PhaseLogIntegrationTests "
+            + "pins the executed order). See AlRunner#3176.");
     }
 
     /// <summary>
     /// The per-bundle latch is cleared for each new bundle. Without this the first bundle of a
     /// multi-bundle run is seeded and every bundle after it is silently skipped, while
     /// <c>AccessControlRowSeededForThisBundle</c> still reads true.
+    /// <para>
+    /// The "reset is called at all" half is a real claim about TestExecutor.cs. The
+    /// reset-before-seed half compares SOURCE POSITION across two call sites ~200 lines apart —
+    /// a proxy, not the executed order, and the weakest check in this file. The live-run
+    /// equivalent is PhaseLogIntegrationTests asserting
+    /// install-seed-reset-for-new-bundle -> install-seed-access-control-row.
+    /// </para>
     /// </summary>
     [Fact]
     public void AccessControlSeed_LatchIsResetForEachNewBundle()
@@ -128,7 +156,9 @@ public sealed class AccessControlSuperRowSeedTests
         Assert.True(
             reset < seed,
             "the latch reset must come before the seed in the per-bundle sequence, or the reset clears a "
-            + $"latch the seed has just set. Reset at {reset}, seed at {seed}.");
+            + $"latch the seed has just set. Reset at source offset {reset}, seed at {seed} (source "
+            + "position in TestExecutor.cs, a proxy for the call order; PhaseLogIntegrationTests "
+            + "pins the executed order).");
     }
 
     /// <summary>

--- a/AlRunner.Tests/PhaseLogIntegrationTests.cs
+++ b/AlRunner.Tests/PhaseLogIntegrationTests.cs
@@ -471,7 +471,14 @@ public sealed class PhaseLogIntegrationTests : IDisposable
                          // (always fresh, never cached) Install triggers.
                          "install-seed-reset-per-test", "install-seed-reset-for-new-bundle",
                          "install-seed-set-test-assembly", "install-seed-dep-company-baseline",
-                         "install-seed-run-own-install-triggers", "install-seed-capture-baseline",
+                         "install-seed-run-own-install-triggers",
+                         // #3176 — the Access Control SUPER row that backs the session user's
+                         // IsSuper answer. Named here so deleting the mark fails, and because
+                         // its position between the User row and the baseline capture is the
+                         // load-bearing part: seeded after the capture it would survive only
+                         // until the first codeunit boundary restored the store.
+                         "install-seed-access-control-row",
+                         "install-seed-capture-baseline",
                          "codeunit-scan",
                          "event-subscriber-inject", "codeunit-reset", "codeunit-instantiate",
                          "resolve-display-name", "run-test-methods", "codeunit-dispose",

--- a/AlRunner.Tests/PhaseLogIntegrationTests.cs
+++ b/AlRunner.Tests/PhaseLogIntegrationTests.cs
@@ -486,6 +486,22 @@ public sealed class PhaseLogIntegrationTests : IDisposable
                 Assert.True(stages.ContainsKey(required),
                     $"app stage '{required}' missing: {string.Join(", ", stages.Keys)}");
 
+            // #3176 — the ORDER of the install-seed marks, measured from a real run rather
+            // than read off the source text. PhaseLog keeps stage timings "in the order the
+            // stages were first entered" (PhaseLog.Stages) and serialises them in that order,
+            // so the property order of this object IS the runtime call sequence. Both edges
+            // the Access Control seed depends on are load-bearing, and neither is observable
+            // from a source-position comparison — a source check passes just as happily when
+            // the two calls sit in different methods, or on branches that never both run.
+            var order = s.EnumerateObject().Select(p => p.Name).ToList();
+            //   after the per-bundle reset: the reset clears the seed latch, so a seed entered
+            //   before it is discarded and bundles 2..N silently run without the SUPER row.
+            AssertStageOrder(order, "install-seed-reset-for-new-bundle", "install-seed-access-control-row");
+            //   before the baseline capture: a row added after the capture is not part of the
+            //   baseline each test is restored to, so it survives only until the first
+            //   codeunit boundary restores the store.
+            AssertStageOrder(order, "install-seed-access-control-row", "install-seed-capture-baseline");
+
             var runMs = app.GetProperty("run_ms").GetInt64();
             var staged = stages.Values.Sum();
 
@@ -502,6 +518,24 @@ public sealed class PhaseLogIntegrationTests : IDisposable
                 $"{unattributed}ms of app run_ms is attributed to nothing "
                 + $"(run_ms {runMs}ms, stages {staged}ms) — add a stage mark: {app}");
         }
+    }
+
+    /// <summary>
+    /// Asserts one stage was entered before another, against the emitted first-entry order.
+    /// This is the runtime call sequence, not a position in a source file: a mark that moves
+    /// to a different method, or onto a branch that does not run, changes this verdict, and a
+    /// method reordered in the file does not.
+    /// </summary>
+    private static void AssertStageOrder(List<string> order, string first, string second)
+    {
+        var a = order.IndexOf(first);
+        var b = order.IndexOf(second);
+        Assert.True(a >= 0, $"stage '{first}' missing from the ordered breakdown: {string.Join(" -> ", order)}");
+        Assert.True(b >= 0, $"stage '{second}' missing from the ordered breakdown: {string.Join(" -> ", order)}");
+        Assert.True(a < b,
+            $"'{first}' must be entered before '{second}', but the run entered them the other "
+            + $"way round. PhaseLog records stages in first-entry order, so this is the actual "
+            + $"call sequence. Got: {string.Join(" -> ", order)}");
     }
 
     private static int CountOccurrences(string haystack, string needle)

--- a/AlRunner/Patches/RecordPatches.AccessControlSeed.cs
+++ b/AlRunner/Patches/RecordPatches.AccessControlSeed.cs
@@ -1,0 +1,248 @@
+// SEED THE ACCESS CONTROL ROW THAT BACKS THE SESSION USER'S SUPER STATUS (#3176)
+//
+// WHAT THIS FIXES
+//   Before this file the runner answered `UserPermissions.IsSuper(UserSecurityId())` with true
+//   while `Record "Access Control"` held NO row for that user. Those are two views of one fact
+//   on a real tier, and the runner made them disagree.
+//
+//   That divergence was recorded deliberately in RecordPatches.PermissionSetAssignment.cs's
+//   header and tracked as AlRunner#3176, which stated plainly that deciding it "needs a view on
+//   whether the runner's synthetic user is 'provisioned' state (seed it) or 'configured' state
+//   (do not)". A real service tier has now supplied that view. Corpus codeunit 60889
+//   `SessionUserIsSuper_AndAccessControlHoldsTheRowThatSaysSo` (upstream PR #204, green on all
+//   eight required BC legs) asserts both halves together:
+//
+//       UserPermissions.IsSuper(UserSecurityId())                       -> true
+//       AccessControl.SetRange("User Security ID", UserSecurityId());
+//       AccessControl.SetRange("Role ID", 'SUPER');
+//       AccessControl.IsEmpty()                                         -> false
+//
+//   So SUPER status IS backed by a row, measured rather than reasoned. #3176's open question is
+//   answered in favour of the seed, and this file is that seed.
+//
+// WHY THE SEED, AND NOT A WIDER STATED FACT
+//   The alternative — keep stating the fact and additionally fake the table read — would be the
+//   silent fake .claude/rules/loud-failures.md forbids: AL that lists the session user's
+//   permission sets would still find none, while being told the user is SUPER. Seeding one real
+//   row makes the answer come from ordinary AL-writable storage, so every reader agrees by
+//   construction rather than by each one being special-cased. It also lets
+//   IsPermissionSetAssignedCore's Access-Control arm — which is checked FIRST — carry the
+//   session user's SUPER answer on its own, without reaching the stated fact at all.
+//
+//   The stated fact in PermissionSetAssignment.cs is deliberately LEFT IN PLACE. It is not
+//   redundant: a bundle whose closure has no Access Control metatable, or one whose install code
+//   refuses the seed, still needs IsSuper to answer true or codeunit 9002 refuses a `User.Modify`
+//   every real BC test tier allows. The seed makes the table agree when the table exists; the
+//   stated fact remains the floor when it does not.
+//
+// WHY IT IS SAFE TO SEED HERE, WHICH #3176 LISTED AS THE COST
+//   #3176's objection was that "a seed changes table state for every test in every bundle and
+//   becomes part of the install baseline". Both are true and both are intended — that is exactly
+//   what makes the row survive the per-codeunit restore, the same reasoning
+//   RecordPatches.UserSystemTable.cs gives for the User row it seeds one statement earlier. What
+//   the objection was protecting against is a row appearing where a test counts rows; measured,
+//   the corpus and runner-extras hold no test that asserts Access Control's row COUNT, and the
+//   one test that reads the table at all is the corpus test above, which requires the row.
+//
+//   RecordPatches.UserSystemTable.cs's header says it "does not seed User Setup (91), Access
+//   Control (2000000053) or User Personalization (2000000073) ... they are application-level rows
+//   created when someone configures them". That reasoning stands for User Setup and User
+//   Personalization and this file does not touch them. It does NOT stand for the SUPER row: a
+//   tier's first user is SUPER by provisioning, before anyone configures anything, which is what
+//   the corpus test measures. That header is corrected in this change rather than left to
+//   contradict the file next to it.
+//
+// COLUMN VALUES, AND WHY EACH ONE
+//   User Security ID  <- the session's own id, the same NavGuid the User row seed writes.
+//   Role ID           <- 'SUPER'.
+//   Company Name      <- BLANK. BC's "every company" assignment, and the only value that
+//                        satisfies codeunit 153's IsSuper, which passes '' as the company.
+//                        A company-specific row would NOT satisfy it — see
+//                        AccessControlGrants' company-matching rules in the sibling file.
+//   App ID            <- the null guid. SUPER is a platform permission set, not one an app
+//                        contributes, and PermissionSetKey for it carries the null AppId.
+//   Scope             <- 0 (System). Same reason: SUPER is a system-scoped set.
+//
+//   Nothing else is written. Access Control has no other columns the runner can honestly fill.
+//
+// PRECOMPILED-DLL RESPECT
+//   No BC method body is touched. This writes a row through NavRecord.ALInsert, the same public
+//   AL entry point ordinary AL uses, so the row is indistinguishable from one AL wrote itself.
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    /// <summary>What a call to <see cref="EnsureAccessControlSuperRowSeeded"/> achieved.</summary>
+    internal enum AccessControlSeedOutcome
+    {
+        /// <summary>A row was inserted for the session user.</summary>
+        Inserted,
+        /// <summary>Already done for this bundle; nothing attempted.</summary>
+        AlreadySeededThisBundle,
+        /// <summary>This bundle's closure has no Access Control metatable.</summary>
+        NoAccessControlTable,
+        /// <summary>There is no skeleton session user to seed a row for.</summary>
+        NoSessionIdentity,
+        /// <summary>A row assigning SUPER to the session user was already present.</summary>
+        AlreadyPresent,
+        /// <summary>The insert was refused AND no such row exists.</summary>
+        Refused,
+    }
+
+    private static bool _accessControlRowSeededForThisBundle;
+    private static bool _accessControlRowSeedInProgress;
+
+    internal static void ResetAccessControlSeedForNewBundle()
+        => _accessControlRowSeededForThisBundle = false;
+
+    /// <summary>
+    /// True only when Access Control actually holds a SUPER row for the session user. Not set by
+    /// a refusal — a flag reading "seeded" over a table with no such row is the silent-wrong
+    /// answer this file's loud-failures obligation forbids, the same discipline
+    /// <see cref="UserRowSeededForThisBundle"/> follows.
+    /// </summary>
+    internal static bool AccessControlRowSeededForThisBundle => _accessControlRowSeededForThisBundle;
+
+    /// <summary>
+    /// Insert the Access Control row that backs the session user's SUPER status, once per bundle.
+    /// Call AFTER <see cref="EnsureUserSystemTableRowSeeded"/> — the row's "User Security ID"
+    /// relates to User."User Security ID", so the User row must exist first — and BEFORE
+    /// <c>CaptureInstallBaseline()</c>, so it is part of the baseline every test is restored to.
+    /// </summary>
+    internal static AccessControlSeedOutcome EnsureAccessControlSuperRowSeeded()
+    {
+        if (_accessControlRowSeededForThisBundle) return AccessControlSeedOutcome.AlreadySeededThisBundle;
+        // Same re-entry guard as the User seed next door: the insert re-enters NavRecord, so the
+        // window is closed explicitly rather than on there being no such path today.
+        if (_accessControlRowSeedInProgress) return AccessControlSeedOutcome.AlreadySeededThisBundle;
+        _accessControlRowSeedInProgress = true;
+        try
+        {
+            return SeedAccessControlSuperRowCore();
+        }
+        finally
+        {
+            _accessControlRowSeedInProgress = false;
+        }
+    }
+
+    private static AccessControlSeedOutcome SeedAccessControlSuperRowCore()
+    {
+        var meta = EnsureTableInMetadataCache(AccessControlTableId);
+        if (meta == null)
+            // A bundle with no Access Control metatable has no assignment concept to seed. The
+            // stated SUPER fact in PermissionSetAssignment.cs still answers IsSuper for it, which
+            // is precisely why that fact is not removed by this change. Silent on purpose: the
+            // sibling file already reports this exact condition once, loudly, the first time an
+            // assignment question is asked of such a bundle.
+            return AccessControlSeedOutcome.NoAccessControlTable;
+
+        var session = AlRunner.BcRuntime.SkeletonSession;
+        if (session == null) return AccessControlSeedOutcome.NoSessionIdentity;
+
+        var (_, _, userSid) = ReadSkeletonUserIdentity(session);
+        if (userSid == null)
+        {
+            // Loud, never silent — the same obligation the User seed carries. Without this row
+            // the runner reports the session user SUPER while the table that is supposed to say
+            // so is empty, which is the exact divergence this file exists to remove.
+            Console.Error.WriteLine(
+                "[warn] AccessControlSeed: the skeleton session exposes no user security id, so the "
+                + $"SUPER row in Access Control ({AccessControlTableId}) was not seeded — "
+                + "UserPermissions.IsSuper(UserSecurityId()) will answer true while the table holds "
+                + "no row saying so. See AlRunner#3176.");
+            return AccessControlSeedOutcome.NoSessionIdentity;
+        }
+
+        try
+        {
+            var outcome = InsertAccessControlSuperRow(session, meta, userSid);
+            if (outcome is AccessControlSeedOutcome.Inserted or AccessControlSeedOutcome.AlreadyPresent)
+            {
+                _accessControlRowSeededForThisBundle = true;
+                PerfTrace.Log($"AccessControlSeed: SUPER row {outcome}");
+                return outcome;
+            }
+
+            Console.Error.WriteLine(
+                "[warn] AccessControlSeed: the SUPER row for the session user was refused and no such "
+                + $"row is present in Access Control ({AccessControlTableId}). "
+                + "UserPermissions.IsSuper(UserSecurityId()) still answers true from the stated fact in "
+                + "RecordPatches.PermissionSetAssignment.cs, so AL guarding on IsSuper still works, but "
+                + "AL that READS the table will find no assignment. See AlRunner#3176.");
+            return AccessControlSeedOutcome.Refused;
+        }
+        catch (Exception ex)
+        {
+            // Never let a seed failure take the run down: the stated SUPER fact keeps IsSuper
+            // answering, so a refused seed degrades to the pre-#3176 behaviour rather than to a
+            // crash. Loud, because the divergence is back when this prints.
+            Console.Error.WriteLine(
+                $"[warn] AccessControlSeed: seeding the session user's SUPER row raised {ex.GetType().Name}: "
+                + $"{ex.Message}. The Access Control table holds no row for the session user; "
+                + "IsSuper still answers true from the stated fact. See AlRunner#3176.");
+            return AccessControlSeedOutcome.Refused;
+        }
+    }
+
+    private static AccessControlSeedOutcome InsertAccessControlSuperRow(
+        object session, NCLMetaTable meta, NavGuid userSid)
+    {
+        using var ac = new NavRecord((NavSession)session, AccessControlTableId, SecurityFiltering.Ignored);
+        var acMeta = ac.MetaTable ?? meta;
+
+        var userField = FieldByNameOnAccessControl(acMeta, AcUserSecurityIdFieldName);
+        var roleField = FieldByNameOnAccessControl(acMeta, AcRoleIdFieldName);
+        var companyField = FieldByNameOnAccessControl(acMeta, AcCompanyNameFieldName);
+        var appIdField = FieldByNameOnAccessControl(acMeta, AcAppIdFieldName);
+        var scopeField = FieldByNameOnAccessControl(acMeta, AcScopeFieldName);
+
+        ac.SetFieldValue(userField.FieldNo, userSid);
+        ac.SetFieldValue(roleField.FieldNo, NavValue.CreateNavValueFromObject(roleField, SuperRoleId));
+        // Blank company: BC's "every company" assignment, and the only value codeunit 153's
+        // IsSuper — which passes '' — is satisfied by. See the header.
+        ac.SetFieldValue(companyField.FieldNo, NavValue.CreateNavValueFromObject(companyField, string.Empty));
+        ac.SetFieldValue(appIdField.FieldNo, NavValue.CreateNavValueFromObject(appIdField, Guid.Empty));
+        ac.SetFieldValue(scopeField.FieldNo, NavValue.CreateNavValueFromObject(scopeField, 0));
+
+        // TrapError so a bundle whose install code already assigned SUPER to this user leaves the
+        // existing row alone instead of turning the seed into a duplicate-key failure — the same
+        // trade the User row seed makes. runApplicationTrigger: false matches BC's own
+        // platform-level provisioning, which does not run AL triggers.
+        //
+        // CS0618: BC marks the synchronous ALInsert obsolete in favour of the async form. One AL
+        // thread, no await point available in this chain — same trade as the sibling seeds.
+#pragma warning disable CS0618
+        var inserted = ac.ALInsert(DataError.TrapError, runApplicationTrigger: false, insertWithSystemId: false);
+#pragma warning restore CS0618
+        if (inserted) return AccessControlSeedOutcome.Inserted;
+
+        // Refused. Ask the TABLE which refusal this was rather than assuming the benign one —
+        // the seed's promise is a SUPER row for THIS user, not merely that the insert did not
+        // raise.
+        return AccessControlSuperRowExists(session, meta, userSid)
+            ? AccessControlSeedOutcome.AlreadyPresent
+            : AccessControlSeedOutcome.Refused;
+    }
+
+    /// <summary>
+    /// Is there an all-companies SUPER row for <paramref name="userSid"/>? This is the whole
+    /// difference between "already present" and "refused".
+    /// </summary>
+    private static bool AccessControlSuperRowExists(object session, NCLMetaTable meta, NavGuid userSid)
+    {
+        using var probe = new NavRecord((NavSession)session, AccessControlTableId, SecurityFiltering.Ignored);
+        var acMeta = probe.MetaTable ?? meta;
+        var userField = FieldByNameOnAccessControl(acMeta, AcUserSecurityIdFieldName);
+        var roleField = FieldByNameOnAccessControl(acMeta, AcRoleIdFieldName);
+
+        probe.ALSetRange(userField.FieldNo, userSid);
+        probe.ALSetRange(roleField.FieldNo, NavValue.CreateNavValueFromObject(roleField, SuperRoleId));
+#pragma warning disable CS0618
+        return probe.ALFindFirstAsync(DataError.TrapError).GetAwaiter().GetResult();
+#pragma warning restore CS0618
+    }
+}

--- a/AlRunner/Patches/RecordPatches.PermissionSetAssignment.cs
+++ b/AlRunner/Patches/RecordPatches.PermissionSetAssignment.cs
@@ -94,15 +94,22 @@
 //   session user — under SUPER, "D365 BASIC" is superseded, not assigned, and answering `true`
 //   there would be exactly the silent fake .claude/rules/loud-failures.md forbids.
 //
-// KNOWN DIVERGENCE, DELIBERATE
-//   Because the SUPER fact is stated rather than seeded, the runner's Access Control table does
-//   NOT contain a row for the session user, while `IsSuper(UserSecurityId())` answers true. On
-//   a real tier those agree. Seeding the row instead was considered and rejected for this
-//   change: RecordPatches.UserSystemTable.cs's header records a deliberate decision not to seed
-//   Access Control alongside the User row, and a seed would alter table state for every test in
-//   every bundle, whereas stating the fact here can only change an answer that throws today.
-//   AlRunner#3176 tracks the seed as the alternative, and docs/limitations.md records the
-//   divergence. AlRunner#3174 tracks the one reader this fix cannot reach:
+// THE DIVERGENCE THIS USED TO CARRY IS GONE (#3176)
+//   This header used to record a deliberate divergence: because the SUPER fact was stated rather
+//   than seeded, the Access Control table held NO row for the session user while
+//   `IsSuper(UserSecurityId())` answered true, and AlRunner#3176 tracked seeding the row as the
+//   alternative. A real service tier has since settled it — corpus codeunit 60889
+//   `SessionUserIsSuper_AndAccessControlHoldsTheRowThatSaysSo` (upstream PR #204) asserts that
+//   the two are views of one fact and is green on all eight required BC legs — so
+//   RecordPatches.AccessControlSeed.cs now seeds that row and the table agrees.
+//
+//   THE STATED FACT BELOW IS STILL LOAD-BEARING AND MUST NOT BE DELETED AS REDUNDANT. It is
+//   reached whenever the seeded row cannot exist or cannot be found: a bundle whose closure
+//   carries no Access Control metatable at all, and a bundle whose install code refuses the
+//   seed. IsSuper must answer true in both, or codeunit 9002 refuses a `User.Modify` that every
+//   real BC test tier allows. The Access-Control arm is checked FIRST, so wherever the row does
+//   exist it — not this fact — is what answers.
+//   AlRunner#3174 tracks the one reader this fix cannot reach:
 //   NavUserAccountHelper.IsUserSuperInAllCompanies is `Session.Permissions.IsSuperForAllCompanies`
 //   with no Ncl hop in it at all, so no rewrite of Ncl can answer it.
 //

--- a/AlRunner/Patches/RecordPatches.UserSystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.UserSystemTable.cs
@@ -61,11 +61,20 @@
 //   storage), so the backup's users land BEFORE this row rather than being loaded over it.
 //
 // WHAT THIS DELIBERATELY DOES NOT DO
-//   It does not seed User Setup (91), Access Control (2000000053) or User Personalization
-//   (2000000073) for this user. Real BC does not create any of those with the account either —
-//   they are application-level rows created when someone configures them — so seeding them
-//   would be inventing state BC does not have. Cascade behaviour on delete/rename across those
-//   tables is #2356, and remains out of this file.
+//   It does not seed User Setup (91) or User Personalization (2000000073) for this user. Real BC
+//   does not create either with the account — they are application-level rows created when
+//   someone configures them — so seeding them would be inventing state BC does not have. Cascade
+//   behaviour on delete/rename across those tables is #2356, and remains out of this file.
+//
+//   ACCESS CONTROL (2000000053) USED TO BE ON THAT LIST AND IS NOT ANY MORE (#3176). The
+//   reasoning above does not hold for it: a tier's user is SUPER by PROVISIONING, before anyone
+//   configures anything, and a real service tier has now said so — corpus codeunit 60889
+//   `SessionUserIsSuper_AndAccessControlHoldsTheRowThatSaysSo` (upstream PR #204) asserts that
+//   `IsSuper(UserSecurityId())` answering true and Access Control holding a matching SUPER row
+//   are two views of ONE fact, and it is green on all eight required BC legs. The runner made
+//   them disagree. RecordPatches.AccessControlSeed.cs seeds that one row, immediately after this
+//   one and before the same baseline capture; the rest of this paragraph's reasoning is
+//   unchanged for the two tables that remain.
 //
 // WHEN THE INSERT IS REFUSED (#2941 review)
 //   The insert uses DataError.TrapError, whose entire purpose is to report a refusal as a

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -443,6 +443,7 @@ public sealed class TestExecutor
             CompanyInitializer.ResetForNewBundle();
             AlRunner.Patches.RecordPatches.ResetCompanySystemTableForNewBundle();
             AlRunner.Patches.RecordPatches.ResetUserSystemTableForNewBundle();
+            AlRunner.Patches.RecordPatches.ResetAccessControlSeedForNewBundle();
             AlRunner.Patches.RecordPatches.ResetPublishedApplicationSystemTableForNewBundle();
         }
         using (AlRunner.Infrastructure.PhaseLog.AppStage("install-seed-set-test-assembly"))
@@ -643,6 +644,12 @@ public sealed class TestExecutor
         // User."User Security ID" refuses the id UserSecurityId() itself returns.
         using (AlRunner.Infrastructure.PhaseLog.AppStage("install-seed-user-row"))
             AlRunner.Patches.RecordPatches.EnsureUserSystemTableRowSeeded();
+        // #3176: the Access Control row that BACKS that user's SUPER status. Ordered after the
+        // User row (its "User Security ID" relates to User's) and before the baseline capture,
+        // for the same reason the User row is: a row added after the capture survives only until
+        // the first codeunit boundary restores the store.
+        using (AlRunner.Infrastructure.PhaseLog.AppStage("install-seed-access-control-row"))
+            AlRunner.Patches.RecordPatches.EnsureAccessControlSuperRowSeeded();
         using (AlRunner.Infrastructure.PhaseLog.AppStage("install-seed-capture-baseline"))
             AlRunner.Patches.RecordPatches.CaptureInstallBaseline();
         seedSw.Stop();

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -542,7 +542,7 @@ the exact value will see different results.
 | `Commit()` | Commits current transaction | Establishes a rollback commit-point — see "Transaction semantics" above; not a no-op |
 | `FilterGroup(n)` | Scoped filter groups | Not tracked — `FilterGroup()` is a no-op; all filters apply to group 0 |
 
-### Permission-set assignment — answered from `Access Control`, and the session user is SUPER without a row
+### Permission-set assignment — answered from `Access Control`, including the session user's own SUPER row
 
 <a id="permission-set-assignment"></a>
 
@@ -559,14 +559,25 @@ runner answers the question itself:
 | question | Real BC | al-runner |
 |---|---|---|
 | Is permission set X assigned to user U? | From the permission cache built out of `Access Control` and entitlements | From the `Access Control` (2000000053) rows the run holds — matching User Security ID, Role ID, App ID and Scope, with a blank Company Name meaning every company |
-| Is the session's own user SUPER? | Yes on a test tier, because provisioning wrote it a row | Yes — stated directly, consistent with `NavSession.HasExecutePermission*` → `true` and `MaximizePermissions` → no-op |
-| Does `Access Control` contain a row for the session user? | Yes | **No** |
+| Is the session's own user SUPER? | Yes on a test tier, because provisioning wrote it a row | Yes — and, since AlRunner#3176, for the same reason: a seeded row |
+| Does `Access Control` contain a row for the session user? | Yes | Yes — seeded alongside the User row, before the install baseline is captured |
 
-The last row is the divergence worth knowing about: the session user is SUPER, but nothing in
-`Access Control` says so, because the fact is stated in the runtime rather than seeded as a row.
+The row in `Access Control` used to be missing while `IsSuper(UserSecurityId())` answered true,
+because the SUPER fact was stated in the runtime rather than seeded. A real service tier settled
+that: corpus codeunit 60889 `SessionUserIsSuper_AndAccessControlHoldsTheRowThatSaysSo` (upstream
+PR #204, green on all eight required BC legs) asserts that the permission answer and the
+permission table are two views of one fact. `RecordPatches.AccessControlSeed.cs` now seeds one
+all-companies SUPER row for the session user, so AL that READS the table finds the assignment
+that AL asking `IsSuper` is told about.
+
+The stated fact is still in `IsPermissionSetAssignedCore`, and deliberately so: a bundle whose
+closure carries no `Access Control` metatable cannot hold the seeded row, and `IsSuper` must
+still answer true for it or codeunit 9002 refuses a `User.Modify` every real BC test tier
+allows. The seed makes the table agree wherever the table exists; the stated fact is the floor
+where it does not.
+
 Any other user is answered purely from rows, in both directions — grant SUPER and `IsSuper`
-reads back true, grant something else and it reads back false. Whether the row should be seeded
-instead is AlRunner#3176.
+reads back true, grant something else and it reads back false.
 
 Entitlements are not modeled at all, so a permission set that a real tier would report as
 assigned *via an entitlement* rather than via `Access Control` reads as not assigned here.

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -95,40 +95,60 @@ number, reported `expected 2665, actual 2681`; the run after merging `main` repo
 count-baseline line at all with 2681 in place, 2700 tests over the three roots, exit 0. CI
 agreed on every leg of run 34046877973 — no leg printed a count-baseline message.
 
-### 2681 -> 2757, and onprem 19 -> 25 (pin b0c6248 -> c3531ec)
+### 2689 -> 2757, and onprem 19 -> 25 (pin 7394c15 -> c3531ec)
 
-The pin advanced to consume StefanMaron/BusinessCentral.AL.Language.Tests#215, which pins the
-`SecretText` runtime surface — the immediate reason for the bump. Corpus history in this range
-is linear, so thirteen other merged corpus PRs came with it:
+The pin advances to consume StefanMaron/BusinessCentral.AL.Language.Tests#204, which pins that a
+user's SUPER status is backed by an Access Control row — the fix in this PR. Corpus history in
+this range is linear, so ten other merged corpus PRs come with it. Every one of them needed a
+runner fix or needed nothing, and all of those fixes are now on `main`:
 
-| corpus PR | what it pins |
-|---|---|
-| #196 | the ordinal Page Metadata reports for a PageType its column does not name |
-| #197 | what the legacy Object (2000000001) table holds on a real tier (OnPrem app) |
-| #199 | CalcFields on FlowFields a tableextension contributes |
-| #200 | a refusal raised in a table subscriber below a control write |
-| #202 | what an error raised in OnQueryClosePage does |
-| #203 | what a list page's built-in View and Edit actions do |
-| #204 | a user's SUPER status is backed by an Access Control row |
-| #206 | what a `Database::<Object>` const in a `where()` clause resolves to |
-| #207 | a tableextension-contributed TableRelation is enforced by Validate |
-| #208 | a tableextension adds keys and field properties, not just columns |
-| #209 | a second control over one page binding resolves |
-| #210 | what the Session virtual table (2000000009) holds for the reading session |
-| #211 | what an action's RunPageLink does to its RunObject target |
-| #215 | the SecretText runtime surface (this PR's own reason for bumping) |
+| corpus PR | what it pins | runner gap | state |
+|---|---|---|---|
+| #197 | what the legacy Object (2000000001) table holds, OnPrem app | #3071 | merged, PR #3265 |
+| #206 | what a `Database::<Object>` const in a `where()` clause resolves to | — | needs nothing |
+| #204 | a user's SUPER status is backed by an Access Control row | **#3176** | **this PR** |
+| #203 | what a list page's built-in View and Edit actions do | — | needs nothing |
+| #207 | a tableextension-contributed TableRelation is enforced by Validate | #3177 | merged, PR #3197 |
+| #209 | a second control over one page binding resolves | — | needs nothing |
+| #210 | what the Session virtual table (2000000009) holds | #2940 | merged, PR #3234 |
+| #211 | what an action's RunPageLink does to its RunObject target | — | needs nothing |
+| #208 | a tableextension adds keys and field properties, not just columns | #3216 | merged, PR #3257 |
+| #212 | whether AL short-circuits and/or | — | needs nothing |
+| #215 | the SecretText runtime surface | — | needs nothing (16/16 measured) |
 
-Both numbers are measured, not computed, on BC 28.1 against this PR's own build: the cloud app
-root reported `Tests: 2757 total` and the OnPrem root `Tests: 25 total`, and with the two
-numbers written in, `--count-baseline` printed no message on either root. The
-`al-language-internals-fixture` root stays at 0.
+`c3531ec` is deliberately NOT the corpus tip, which is `0bda9d6`. Walking forward past it, the
+next commit that needs a runner fix nobody has written is `b1fdb6d` (corpus #216, a CalcFormula
+and a TableRelation naming a system field). Measured at the tip against this branch's build:
+**19 failures**, in three clusters, each already tracked by an open runner issue:
 
-The OnPrem suite moves for the first time in a while because #197 added
-`record/TestObjectSystemTable.al` (6 tests) to the OnPrem app — the legacy Object table is
-`Scope = OnPrem`, so the test could not live in the cloud app.
+| corpus PR | failing codeunit | tests | open issue holding it |
+|---|---|---|---|
+| #216 | Codeunit60818 | 5 | #3178 — a CalcFormula over a system field never builds |
+| #217 | Codeunit60823 | 4 | #3263 — a CalcFormula never resolves a tableextension field |
+| #218 | Codeunit60338 | 9 | #3284 — the FormResult for a handler that invokes nothing is OK, not Cancel |
 
-No per-version override is needed: the range adds no preprocessor version guards, so
-`default` is correct for every leg. Measured on one BC version; the other seven are CI's word.
+Corpus #219 and #220 pass and need nothing; they are held back only because they sit behind
+#216 in a linear history. So `c3531ec` is the newest commit all of whose predecessors are
+satisfied, per the third case in `.claude/rules/al-language-submodule.md`, and #3178, #3263 and
+#3284 hold the remainder. All three stay open after this PR merges.
+
+Both numbers are MEASURED, by a run of this branch's build at the new pin on BC 28.1, not
+computed: three roots, `Tests: 2782 total, pass: 2782, fail: 0`, exit 0 — and exit 0 is itself
+the count-baseline check passing, since `--count-baseline` exits 4 on a mismatch in either
+direction. 2757 cloud + 25 OnPrem + 0 internals-fixture = 2782.
+
+Counted independently per file as a cross-check, with AL comments, string literals and
+preprocessor-disabled code excluded: the same 2757 and 25. That per-file method reproduces the
+outgoing pin's 2689 exactly as well. The gap between a raw source count and what a run reports
+is exactly 2 tests, behind `session/TestFinalCoverage.al`'s `#if BC143PLUS`, which is never
+defined — the corpus's only preprocessor-disabled block, unchanged across this range.
+
+The OnPrem suite moves because #197 added `record/TestObjectSystemTable.al` (6 tests) to the
+OnPrem app — the legacy Object table is `Scope = OnPrem`, so the test could not live in the
+cloud app.
+
+No per-version override is needed: the range adds no preprocessor version guards, so `default`
+is correct for every leg. Measured on BC 28.1; the other seven legs are CI's word.
 
 ## runner-extras
 

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -95,6 +95,41 @@ number, reported `expected 2665, actual 2681`; the run after merging `main` repo
 count-baseline line at all with 2681 in place, 2700 tests over the three roots, exit 0. CI
 agreed on every leg of run 34046877973 — no leg printed a count-baseline message.
 
+### 2681 -> 2757, and onprem 19 -> 25 (pin b0c6248 -> c3531ec)
+
+The pin advanced to consume StefanMaron/BusinessCentral.AL.Language.Tests#215, which pins the
+`SecretText` runtime surface — the immediate reason for the bump. Corpus history in this range
+is linear, so thirteen other merged corpus PRs came with it:
+
+| corpus PR | what it pins |
+|---|---|
+| #196 | the ordinal Page Metadata reports for a PageType its column does not name |
+| #197 | what the legacy Object (2000000001) table holds on a real tier (OnPrem app) |
+| #199 | CalcFields on FlowFields a tableextension contributes |
+| #200 | a refusal raised in a table subscriber below a control write |
+| #202 | what an error raised in OnQueryClosePage does |
+| #203 | what a list page's built-in View and Edit actions do |
+| #204 | a user's SUPER status is backed by an Access Control row |
+| #206 | what a `Database::<Object>` const in a `where()` clause resolves to |
+| #207 | a tableextension-contributed TableRelation is enforced by Validate |
+| #208 | a tableextension adds keys and field properties, not just columns |
+| #209 | a second control over one page binding resolves |
+| #210 | what the Session virtual table (2000000009) holds for the reading session |
+| #211 | what an action's RunPageLink does to its RunObject target |
+| #215 | the SecretText runtime surface (this PR's own reason for bumping) |
+
+Both numbers are measured, not computed, on BC 28.1 against this PR's own build: the cloud app
+root reported `Tests: 2757 total` and the OnPrem root `Tests: 25 total`, and with the two
+numbers written in, `--count-baseline` printed no message on either root. The
+`al-language-internals-fixture` root stays at 0.
+
+The OnPrem suite moves for the first time in a while because #197 added
+`record/TestObjectSystemTable.al` (6 tests) to the OnPrem app — the legacy Object table is
+`Scope = OnPrem`, so the test could not live in the cloud app.
+
+No per-version override is needed: the range adds no preprocessor version guards, so
+`default` is correct for every leg. Measured on one BC version; the other seven are CI's word.
+
 ## runner-extras
 
 ### object-metadata-system-table 4 -> 6 (PR for #2771)

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,11 +2,11 @@
   "_comment": "Schema, semantics and how to bump: README.md in this directory. Per-bump rationale: history.md, never a prose line in here (#2485).",
   "suites": {
     "al-language": {
-      "tests": { "default": 2689 },
+      "tests": { "default": 2757 },
       "appGroups": { "default": 1 }
     },
     "al-language-internals-fixture": { "tests": { "default": 0 }, "appGroups": { "default": 1 } },
-    "al-language-onprem": { "tests": { "default": 19 }, "appGroups": { "default": 1 } },
+    "al-language-onprem": { "tests": { "default": 25 }, "appGroups": { "default": 1 } },
     "runner-extras": {
       "groups": {
         "bundle-page-over-dep-table": { "tests": 2 },


### PR DESCRIPTION
Closes #3176

## What this PR does

Two things: it backs the session user's SUPER status with a real `Access Control` row, and it advances the corpus pin far enough to pull in the upstream test that adjudicates that claim.

## The pin, re-verified after review

Review's verdict was that pinning corpus `c3531ec` was red by construction — its BC 27.0 leg had failed, and the stated reason for going that far (corpus #215, `SecretText`) was bought for nothing, since this PR's own measurement found `SecretText` needs no runner change at all:

```
Tests: 16 total   pass: 16   fail: 0   error: 0
```

**That was correct at the time.** Four of the five runner fixes the range depended on were still open. They have all merged since — #3265 (corpus #197), #3234 (corpus #210), #3257 (corpus #208) and **#3197** (corpus #207), which landed during review and took #3177 with it.

So I re-walked the range rather than taking any target on trust, including the `b693416e` I was pointed at. With #3197 in, the answer moves back to **`c3531ec`**: the original target was right, just premature.

Every commit in the range, and what it needed:

| corpus PR | what it pins | runner gap | state |
|---|---|---|---|
| #197 | legacy Object (2000000001) table contents, OnPrem app | #3071 | merged, PR #3265 |
| #206 | a `Database::<Object>` const in a `where()` clause | — | needs nothing |
| #204 | a user's SUPER status is backed by an Access Control row | **#3176** | **this PR** |
| #203 | a list page's built-in View and Edit actions | — | needs nothing |
| #207 | a tableextension-contributed TableRelation enforced by Validate | #3177 | merged, PR #3197 |
| #209 | a second control over one page binding resolves | — | needs nothing |
| #210 | the Session virtual table (2000000009) | #2940 | merged, PR #3234 |
| #211 | an action's RunPageLink against its RunObject target | — | needs nothing |
| #208 | a tableextension adds keys and field properties | #3216 | merged, PR #3257 |
| #212 | whether AL short-circuits and/or | — | needs nothing |
| #215 | the SecretText runtime surface | — | needs nothing (16/16 measured) |

Forward-only, verified before pushing:

```
$ gh api repos/.../compare/7394c15f...c3531ec6 --jq '"ahead=\(.ahead_by) behind=\(.behind_by)"'
ahead=11 behind=0
```

### Why not the corpus tip

`c3531ec` is deliberately **not** the tip (`0bda9d6`). I measured the tip against this branch's build rather than guessing: **19 failures**, in three clusters, each already tracked by an open issue.

| corpus PR | failing codeunit | tests | open issue |
|---|---|---|---|
| #216 | Codeunit60818 | 5 | #3178 — a CalcFormula over a system field never builds |
| #217 | Codeunit60823 | 4 | #3263 — a CalcFormula never resolves a tableextension field |
| #218 | Codeunit60338 | 9 | #3284 — a handler that invokes nothing yields OK, not Cancel |

Corpus #219 and #220 pass and need nothing; they are held back only because they sit behind #216 in a linear history. So `c3531ec` is the newest commit all of whose predecessors are satisfied — the third case in `.claude/rules/al-language-submodule.md` — and **#3178, #3263 and #3284 hold the remainder**. All three stay open after this merges.

## Counts, measured by a run

`al-language` **2689 → 2757**, `al-language-onprem` **19 → 25**, `al-language-internals-fixture` unchanged at 0. Not carried over from the earlier revision, and not computed. A full corpus run of this branch's build at the new pin, BC 28.1, all three roots:

```
Tests: 2782 total   pass: 2782   fail: 0   error: 0   exit 0
```

Exit 0 **is** the count-baseline verdict — `--count-baseline` exits 4 on a mismatch in either direction — and 2757 + 25 + 0 = 2782.

As an independent cross-check I also counted per file, with AL comments, string literals and preprocessor-disabled code excluded (never a raw `grep -c '[Test]'`, which overcounts here). It reproduces both numbers, and reproduces the outgoing pin's 2689 as well. The gap between a raw source count and what a run reports is exactly 2 tests, behind `session/TestFinalCoverage.al`'s `#if BC143PLUS`, which is never defined — the corpus's only preprocessor-disabled block, unchanged across this range.

## The change: answering the open question in #3176 with a service tier's verdict

`RecordPatches.PermissionSetAssignment.cs` recorded a deliberate divergence — `IsSuper(UserSecurityId())` answered `true` while `Access Control` (2000000053) held no row saying so — and #3176 said deciding it "needs a view on whether the runner's synthetic user is 'provisioned' state (seed it) or 'configured' state (do not)".

Corpus PR #204 supplies that view, green on all eight required BC legs: SUPER status **is** backed by a row. That is a measurement, not a reading, so #3176 resolves in favour of the seed.

`RecordPatches.AccessControlSeed.cs` seeds one all-companies SUPER row for the session user. Both ordering edges are load-bearing:

- **after** the User row seed — the row's `User Security ID` relates to `User."User Security ID"`;
- **before** `CaptureInstallBaseline()` — otherwise the row survives only until the first codeunit boundary restores the store, which is green on a single-test run and red on a full one.

**The stated SUPER fact in `IsPermissionSetAssignedCore` is deliberately kept.** A bundle whose closure carries no `Access Control` metatable cannot hold the seeded row, and `IsSuper` must still answer `true` there or codeunit 9002 refuses a `User.Modify` every real BC test tier allows. The Access-Control arm is checked first, so wherever the row exists it — not the fact — answers. One of the new tests pins that the fact is not deleted as "now redundant".

## RED → GREEN, re-proved on this tree

Not inherited from the earlier revision. With `TestExecutor.cs` reverted to `origin/main`:

```
FAIL  Codeunit60889.SessionUserIsSuper_AndAccessControlHoldsTheRowThatSaysSo
PASS  Codeunit60889.ASecurityIdBelongingToNoUser_IsNotSuper
```

The negative sibling still passing is what rules out a test that fails for any reason. Restored, the full corpus is 2782/2782.

## Review follow-up: the seed ordering is now proved where it is observable

Review found that `AccessControlSeed_LatchIsResetForEachNewBundle` and `AccessControlSeed_RunsBeforeTheInstallBaselineIsCaptured` read `TestExecutor.cs` as text and compared `IndexOf` offsets, so they measured **file position rather than call sequence**. A call moved into another method keeps them green; a method reordered in the file turns them red with no behaviour change.

`PhaseLog` records stage timings "in the order the stages were first entered", so the property order of an emitted app row's `stages` object *is* the executed call sequence. `PhaseLogIntegrationTests` — which already drives the real runner — now asserts, via a new `AssertStageOrder` helper:

```
install-seed-reset-for-new-bundle -> install-seed-access-control-row -> install-seed-capture-baseline
```

Proved non-vacuous: inverting one expected pair fails, and the failure prints the order a live run actually produced —

```
... install-seed-reset-for-new-bundle -> install-seed-set-test-assembly
 -> install-seed-arm-event-subscribers -> install-seed-dep-company-baseline
 -> install-seed-run-own-install-triggers -> install-seed-company-row
 -> install-seed-published-application-row -> install-seed-user-row
 -> install-seed-access-control-row -> install-seed-capture-baseline -> codeunit-scan ...
```

That also confirms the User-row edge at runtime, which no source-position check established.

The two source-reading tests are **kept** as cheap call-site guards. Their doc comments and failure messages now say plainly that they check source position as a proxy, and point at the live-run test for the real claim. One correction to the review's premise, measured: all three calls are straight-line statements inside one method, `TestExecutor.Run` (lines 446, 652, 654), not across two different methods — which is why the proxy happened to be sound. It is still only a proxy.

`PhaseLogIntegrationTests` 4/4, `AccessControlSuperRowSeedTests` 6/6.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site?** No. `AccessControlGrants` is the only other reader of this table, and it needed no change — the seeded row satisfies it through the arm already checked first.
2. **Sibling function with the same assumption?** Yes, and it is corrected: `RecordPatches.UserSystemTable.cs`'s header listed Access Control alongside User Setup (91) and User Personalization (2000000073) as rows "created when someone configures them". That still holds for those two and this PR does not touch them; it does not hold for the SUPER row, and the header now says so instead of contradicting the file next to it.
3. **Two paths writing the same state, same invariant?** The seed and `AccessControlGrants` now agree by construction, because both go through the table. Before, one read a table and the other consulted a fact stated in C#.

**Left out deliberately:** #3174 (`NavUserAccountHelper.IsUserSuperInAllCompanies` reads `Session.Permissions.IsSuperForAllCompanies` with no Ncl hop to rewrite, so no seeded row can reach it) and #2356 (cascade on user delete/rename). Both stay open; neither lands in these files.

---

*Opened by automated implementation agent `stma-auto-3`; re-verified and revised by agent `impl-2`, both on the account holder's behalf.*

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/204
Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/215
