### PR TITLE
ci: refuse a pull request that moves the corpus pin backward

### DIFF
--- a/.github/scripts/check_corpus_pin_forward.sh
+++ b/.github/scripts/check_corpus_pin_forward.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+# Refuses a pull request that moves the tests/al-language pin BACKWARD (#3288).
+#
+# THE GAP
+# -------
+# The corpus is this project's ratchet. .claude/skills/autonomous-cycle states
+# its purpose directly: every behaviour pinned there "is validated on real BC on
+# every push and can never silently regress afterwards." Nothing enforced the
+# second half. A pull request whose tests/al-language pin is BEHIND the pin on
+# the branch it merges into passes every required context, and merging it
+# un-pins every corpus commit in between -- suites a real service tier has
+# already adjudicated.
+#
+# It is silent in a way an ordinary regression is not: the un-pinned suites do
+# not fail, they stop existing, and the next green run reports success over a
+# smaller set. Nothing else catches it, either:
+#
+#   * No other required context compares the two pins.
+#   * The count baseline does not. A backward pin means FEWER tests, and a
+#     smaller baseline updated to match is an internally consistent state. The
+#     baseline pins the count against the pin; it never pins the pin against its
+#     own history.
+#   * mergeStateStatus cannot. A pin change is a one-line tree diff, and two
+#     branches moving it in opposite directions is not a textual conflict when
+#     only one of them touched it.
+#   * A green CI run means "green at the revision this PR pins" -- which is
+#     exactly the older revision. The tests that would have gone red are the
+#     ones being removed.
+#
+# Caught for real on PR #3181, which was green and CLEAN while about to drop
+# corpus #199 and #201. That PR did nothing wrong: it bumped the pin forward
+# from the main that existed when it was written, and main's pin advanced
+# afterwards. Nothing rebased it and nothing told it to. That is why this is a
+# guard rather than a note in a rules file -- it is a merge-order accident, not
+# an authoring mistake, and it gets likelier as more agents run in parallel.
+#
+# THE FOUR VERDICTS, AND WHY THERE ARE FOUR RATHER THAN THREE
+# -----------------------------------------------------------
+# The issue's truth table has three rows. Implementing exactly three is the trap
+# that would make this guard worse than not shipping it:
+#
+#   pin untouched (base == head)          -> 0  pass
+#   base pin IS an ancestor of head pin   -> 0  pass, a genuine bump
+#   otherwise (backward, or divergent)    -> 1  fail
+#   the corpus history is not present     -> 3  CANNOT DETERMINE
+#
+# `git merge-base --is-ancestor` cannot tell the third row from the fourth, and
+# it fails in the DIRECTION THAT BLOCKS. Measured, not assumed:
+#
+#   * When an endpoint is absent from the clone, it exits 128 with a fatal --
+#     which a naive `|| exit 1` converts into "your PR moves the pin backward".
+#   * Worse, when BOTH endpoints are present as objects but the history between
+#     them has been truncated -- exactly what a shallow submodule clone leaves
+#     behind -- it exits **1**, cleanly, for a pin that genuinely IS a forward
+#     bump. That exit 1 is byte-for-byte the signal a real backward pin
+#     produces. Unshallowing the same clone flips the same command to 0.
+#
+# So a guard reading the exit code alone tells an author their PR moves the
+# corpus pin backward when it does not, on every PR, until somebody works out
+# that the clone depth was the problem. pr-gate.yml's header sets the bar for
+# anything that gates: it must not be able to fail for an environmental reason.
+# A missing fetch is an environmental reason. Hence a fourth verdict with its own
+# exit code and its own message, which the workflow surfaces as a hard error
+# about the CHECKOUT rather than about the pin -- loud, actionable, and never
+# confusable with the defect this exists to catch.
+#
+# Exit 3 is deliberately not exit 0. "Cannot determine" must not read as "fine":
+# a guard that passes when it could not measure anything is the green-tick-
+# meaning-nothing-was-read failure that pr_changed_files.sh and
+# pr_commit_messages.sh also refuse.
+#
+# THE ENDPOINTS
+# -------------
+# Both come from the event payload, never from the checked-out HEAD, for the
+# reason pr_changed_files.sh documents at length (#3261): actions/checkout leaves
+# refs/pull/N/merge checked out -- a merge commit whose FIRST PARENT is the base
+# branch. Here that matters even more sharply than it does for a file diff. The
+# merge ref's tree carries the MERGED pin, and git resolves a gitlink conflict
+# toward the newer commit, so reading the pin from HEAD reads something that is
+# not the pull request's pin at all, and a backward pin becomes invisible -- the
+# guard would pass on precisely the case it exists to catch. A symbolic ref is
+# therefore refused outright rather than resolved.
+#
+# Inputs (environment variables, both required):
+#   BASE_SHA  - github.event.pull_request.base.sha
+#   HEAD_SHA  - github.event.pull_request.head.sha
+#
+# Optional:
+#   SUBMODULE_PATH - defaults to tests/al-language
+#
+# Exit codes
+#   0  the pin is unchanged, or it moved strictly forward
+#   1  the pin moved backward, or the two pins have diverged
+#   2  the check could not run: a missing input, or an endpoint that is not a
+#      commit SHA present in this checkout
+#   3  the answer cannot be determined from this checkout -- the corpus history
+#      needed to compare the two pins is not present. NOT a pass and NOT a
+#      backward-pin verdict.
+
+set -uo pipefail
+
+SUBMODULE_PATH="${SUBMODULE_PATH:-tests/al-language}"
+
+die_usage() {
+  echo "::error::check_corpus_pin_forward.sh: $1" >&2
+  exit 2
+}
+
+die_undetermined() {
+  echo "::error::check_corpus_pin_forward.sh: $1" >&2
+  exit 3
+}
+
+# --- Inputs ------------------------------------------------------------------
+#
+# "Unset" is distinguished from "set but empty", the same way pr_changed_files.sh
+# and check_corpus_linkage.sh do: an unset input means the caller never computed
+# it, and a guard handed nothing checks nothing and passes.
+for var in BASE_SHA HEAD_SHA; do
+  if [ -z "${!var+set}" ]; then
+    die_usage "$var is required. Pass \${{ github.event.pull_request.base.sha }} and \${{ github.event.pull_request.head.sha }}."
+  fi
+  if [ -z "${!var}" ]; then
+    die_usage "$var was passed but is empty. An empty endpoint makes this guard read a pin that is not this pull request's."
+  fi
+done
+
+for var in BASE_SHA HEAD_SHA; do
+  v="${!var}"
+  case "$v" in
+    *[!0-9a-fA-F]*)
+      die_usage "$var must be a commit SHA from the pull_request event payload, not '$v'. Under actions/checkout, HEAD is refs/pull/N/merge, whose tree carries the MERGED submodule pin rather than this pull request's -- so reading the pin from a symbolic ref hides exactly the backward pin this guard exists to catch. Pass \${{ github.event.pull_request.head.sha }}."
+      ;;
+  esac
+  if [ "${#v}" -lt 7 ]; then
+    die_usage "$var='$v' is too short to be a commit SHA."
+  fi
+  if ! git cat-file -e "${v}^{commit}" 2>/dev/null; then
+    die_usage "$var='$v' is not a commit in this checkout. actions/checkout needs fetch-depth: 0 for both endpoints of a pull request comparison to be present."
+  fi
+done
+
+# --- Read both pins from the superproject trees ------------------------------
+#
+# git ls-tree against an explicit commit, so neither answer depends on what is
+# checked out or on the state of the working tree.
+read_pin() {
+  local rev="$1" line
+  line="$(git ls-tree "$rev" "$SUBMODULE_PATH" 2>/dev/null)" || return 1
+  # mode object-type object-sha<TAB>path ; a submodule is mode 160000, type commit
+  case "$line" in
+    160000\ commit\ *) printf '%s' "$line" | awk '{print $3}' ;;
+    *) return 1 ;;
+  esac
+}
+
+base_pin="$(read_pin "$BASE_SHA")" || base_pin=""
+head_pin="$(read_pin "$HEAD_SHA")" || head_pin=""
+
+if [ -z "$base_pin" ] && [ -z "$head_pin" ]; then
+  echo "Neither $BASE_SHA nor $HEAD_SHA carries a $SUBMODULE_PATH submodule; there is no corpus pin to compare."
+  exit 0
+fi
+
+# One side carrying no submodule is a structural change to the repository, not a
+# pin bump, and this guard has no basis for a verdict on it.
+if [ -z "$base_pin" ] || [ -z "$head_pin" ]; then
+  die_undetermined "the $SUBMODULE_PATH submodule is present at one endpoint and absent at the other (base='${base_pin:-<absent>}', head='${head_pin:-<absent>}'). Adding or removing the corpus submodule is not a pin bump, and this guard cannot judge it. A human reviewer should."
+fi
+
+# --- Case 1: untouched -------------------------------------------------------
+
+if [ "$base_pin" = "$head_pin" ]; then
+  echo "The $SUBMODULE_PATH pin is unchanged by this pull request ($head_pin). Nothing to compare."
+  exit 0
+fi
+
+# --- The comparison needs the corpus history ---------------------------------
+
+if [ ! -e "$SUBMODULE_PATH/.git" ]; then
+  die_undetermined "the $SUBMODULE_PATH submodule is not checked out, so the corpus history needed to compare $base_pin with $head_pin is not present. This is a CHECKOUT problem, not a verdict about the pin: add 'submodules: true' to actions/checkout and fetch the corpus history before running this guard."
+fi
+
+# Both pins must be present as objects before the ancestry question means
+# anything. A missing one exits 128 from merge-base, which must never be reported
+# as a backward pin.
+for pin in "$base_pin" "$head_pin"; do
+  if ! git -C "$SUBMODULE_PATH" cat-file -e "${pin}^{commit}" 2>/dev/null; then
+    die_undetermined "corpus commit $pin is not present in the $SUBMODULE_PATH clone, so the ancestry between the two pins cannot be established. This is a CHECKOUT problem, not a verdict about the pin -- a shallow submodule clone produces exactly this. Fetch the corpus history (git -C $SUBMODULE_PATH fetch --unshallow, or fetch the two revisions) before running this guard."
+  fi
+done
+
+# The dangerous case: BOTH objects present, history truncated between them.
+# merge-base --is-ancestor then answers a clean 1 -- indistinguishable from a
+# real backward pin -- for a pin that is genuinely a forward bump. So a shallow
+# clone disqualifies the measurement outright rather than being read as a
+# verdict.
+if [ "$(git -C "$SUBMODULE_PATH" rev-parse --is-shallow-repository 2>/dev/null)" = "true" ]; then
+  die_undetermined "the $SUBMODULE_PATH clone is SHALLOW, so ancestry between $base_pin and $head_pin cannot be established. In a shallow clone 'git merge-base --is-ancestor' returns a clean 'not an ancestor' for commits that ARE ancestors, which is byte-for-byte the signal a genuine backward pin produces -- so this guard refuses to answer rather than blame the author for the clone depth. Run 'git -C $SUBMODULE_PATH fetch --unshallow' before this check."
+fi
+
+# --- Cases 2 and 3: the ancestry question ------------------------------------
+
+is_ancestor() {
+  # 0 = yes, 1 = no, anything else = git could not answer, which is never a
+  # verdict here.
+  local rc=0
+  git -C "$SUBMODULE_PATH" merge-base --is-ancestor "$1" "$2" 2>/dev/null || rc=$?
+  if [ "$rc" -ne 0 ] && [ "$rc" -ne 1 ]; then
+    die_undetermined "'git merge-base --is-ancestor $1 $2' failed with exit $rc inside $SUBMODULE_PATH rather than answering yes or no. That is a broken measurement, not a backward pin."
+  fi
+  return $rc
+}
+
+if is_ancestor "$base_pin" "$head_pin"; then
+  ahead="$(git -C "$SUBMODULE_PATH" rev-list --count "${base_pin}..${head_pin}" 2>/dev/null || echo '?')"
+  echo "The $SUBMODULE_PATH pin moves forward: the base pin $base_pin is an ancestor of the head pin $head_pin ($ahead corpus commit(s) ahead). Nothing already validated is being un-pinned."
+  exit 0
+fi
+
+# Not a forward bump. Which of the two failing shapes is it? They need different
+# remedies, so they get different messages.
+REMEDY="Re-pin the corpus forward before merging:
+    git fetch origin main
+    git checkout origin/main -- $SUBMODULE_PATH
+  ...or, if this PR genuinely needs a different corpus revision, rebase the pin
+  onto the one main carries so nothing already validated is dropped. Then update
+  tests/expectations/count-baseline/test-count-baseline.json to match."
+
+if is_ancestor "$head_pin" "$base_pin"; then
+  dropped="$(git -C "$SUBMODULE_PATH" log --oneline "${head_pin}..${base_pin}" 2>/dev/null || true)"
+  count="$(git -C "$SUBMODULE_PATH" rev-list --count "${head_pin}..${base_pin}" 2>/dev/null || echo '?')"
+  echo "::error::This pull request moves the $SUBMODULE_PATH corpus pin BACKWARD, from $base_pin on the base branch to $head_pin. The head pin is an ANCESTOR of the base pin, so merging this would un-pin $count corpus commit(s) already validated against a real BC service tier -- and it would do so silently: those suites do not fail, they stop existing, and the next green run reports success over a smaller set. The corpus is this project's ratchet (.claude/skills/autonomous-cycle); this is the one operation that breaks it. $REMEDY" >&2
+  if [ -n "$dropped" ]; then
+    echo "Corpus commits that would be un-pinned:" >&2
+    printf '%s\n' "$dropped" >&2
+  fi
+  exit 1
+fi
+
+merge_base="$(git -C "$SUBMODULE_PATH" merge-base "$base_pin" "$head_pin" 2>/dev/null || true)"
+echo "::error::This pull request's $SUBMODULE_PATH corpus pin has diverged from the base branch's. Neither $base_pin (base) nor $head_pin (head) is an ancestor of the other${merge_base:+, and their most recent common corpus commit is $merge_base}. That is not a forward bump: merging it would un-pin whatever the base branch reached along its own line. A corpus pin should only ever advance along the corpus's master branch, so this usually means the pin was taken from a corpus branch that was never merged. $REMEDY" >&2
+if [ -n "$merge_base" ]; then
+  dropped="$(git -C "$SUBMODULE_PATH" log --oneline "${merge_base}..${base_pin}" 2>/dev/null || true)"
+  if [ -n "$dropped" ]; then
+    echo "Corpus commits on the base branch's line that would be un-pinned:" >&2
+    printf '%s\n' "$dropped" >&2
+  fi
+fi
+exit 1

--- a/.github/scripts/check_required_contexts.py
+++ b/.github/scripts/check_required_contexts.py
@@ -185,16 +185,18 @@ DEFAULT_REQUIRED_CONTEXTS = [
 # hole in the #2785 check for as long as it lasts.
 #
 # #3244 also said what refills it -- "only while a new gating job is landing" --
-# and that is the case for BOTH entries below. Each names a blocking job that
-# pr-gate.yml already produces and the `main` ruleset does not require yet, so
-# each is listed for exactly as long as that is true, and each comes out in the
-# same pass that adds its name to the ruleset.
+# and that is the case for ALL THREE entries below. Each names a blocking job
+# that pr-gate.yml already produces and the `main` ruleset does not require yet,
+# so each is listed for exactly as long as that is true, and each comes out in
+# the same pass that adds its name to the ruleset.
 #
-# Two entries, not one, and that is deliberate: #3255 and #3089 landed their
-# gating jobs independently, and dropping either name while its job blocks would
-# reopen precisely the #2785 hole this file exists to close -- a context the
-# ruleset requires that nothing here analyses. Merging these two refills by
-# keeping only one side is the mistake to avoid.
+# Three entries, not one, and that is deliberate: #3255, #3089 and #3288 landed
+# their gating jobs independently, and dropping any one of those names while its
+# job blocks would reopen precisely the #2785 hole this file exists to close -- a
+# context the ruleset requires that nothing here analyses. Merging these refills
+# by keeping only one side is the mistake to avoid, and it is a live one: this
+# list has now been refilled by three separate pull requests that could not see
+# each other, and each rebase presents exactly that conflict.
 PENDING_REQUIRED_CONTEXTS: list[str] = [
     # #3255's gate. pr-gate.yml's require-corpus-linkage job produces this
     # context. Analysed here exactly like a required one -- produced by a
@@ -214,6 +216,13 @@ PENDING_REQUIRED_CONTEXTS: list[str] = [
     # workflow, not cancellable on the head commit -- which is the whole point of
     # the seam.
     "A PR closing a gap issue must not leave its known-gap entry behind",
+    # #3288's gate. pr-gate.yml's require-forward-corpus-pin job produces this
+    # context, which refuses a pull request whose tests/al-language pin is not a
+    # descendant of the base branch's. Same discipline as the two above, and for
+    # the same #3002 reason: listed here so it is ANALYSED like a required one,
+    # deliberately NOT promoted into DEFAULT_REQUIRED_CONTEXTS or into
+    # ci-wait.py's RULESET_CONTEXTS until the ruleset actually requires it.
+    "The corpus pin must not move backward",
 ]
 
 REPO = "StefanMaron/BusinessCentral.AL.Runner"

--- a/.github/scripts/test_check_corpus_pin_forward.sh
+++ b/.github/scripts/test_check_corpus_pin_forward.sh
@@ -1,0 +1,419 @@
+#!/usr/bin/env bash
+# Tests for check_corpus_pin_forward.sh -- the guard that stops a pull request
+# moving the tests/al-language pin BACKWARD (#3288).
+#
+# WHY THESE TESTS LOOK THE WAY THEY DO
+# ------------------------------------
+# The guard's whole value is in telling four situations apart, and three of them
+# produce a non-zero exit from `git merge-base --is-ancestor`. So a suite that
+# only asserted "backward fails" would pass against a script that fails for
+# every bump, which would block every corpus PR in the repository -- a worse
+# outcome than not shipping the guard at all. Each case below therefore pins a
+# SPECIFIC exit code, and the two "prove, not pass" cases at the bottom assert
+# that a stub which always exits 0, and a stub which always exits 1, are both
+# caught by this suite.
+#
+# The four situations, and why the last one is not a footnote:
+#
+#   pin untouched                     -> 0
+#   base pin is an ancestor of head   -> 0   a genuine forward bump
+#   otherwise (backward / divergent)  -> 1   the defect
+#   corpus history not present        -> 3   CANNOT DETERMINE, and loudly
+#
+# The fourth is measured, not hypothetical, and it is the reason this guard is
+# dangerous to write naively. Reproduced in REPRODUCE_THE_SHALLOW_LIE below:
+# in a shallow clone where BOTH pins are present as objects but the history
+# between them has been truncated, `git merge-base --is-ancestor <base> <head>`
+# exits 1 for a pin that genuinely IS a forward bump. That exit 1 is byte-for-
+# byte the same signal a real backward pin produces. A guard that reads the exit
+# code alone therefore reports "your PR moves the corpus pin backward" to an
+# author whose PR does nothing of the sort, on every PR, until somebody works
+# out that the clone depth was the problem. `.claude/rules/ci-verdicts.md` puts
+# it directly: a guard that can go red for something the author did not do does
+# not belong on the gating side. So "cannot determine" gets its own exit code
+# and its own message, and the shallow case must never be reported as backward.
+#
+# Run directly: bash .github/scripts/test_check_corpus_pin_forward.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check_corpus_pin_forward.sh"
+WORKFLOW_DIR="$(cd "$SCRIPT_DIR/../workflows" && pwd)"
+
+pass=0
+fail=0
+
+ok()  { echo "ok   - $1"; pass=$((pass + 1)); }
+bad() { echo "FAIL - $1"; fail=$((fail + 1)); }
+
+check_eq() {
+  local desc="$1" expected="$2" got="$3"
+  if [ "$expected" = "$got" ]; then ok "$desc"; else
+    bad "$desc: expected '$expected', got '$got'"
+  fi
+}
+
+# Runs the script under test in $SUPER with the given environment, returning its
+# exit code and capturing combined output into $LAST_OUTPUT.
+LAST_OUTPUT=""
+run_guard() {
+  local rc=0
+  LAST_OUTPUT="$(cd "$SUPER" && env "$@" bash "$SCRIPT" 2>&1)" || rc=$?
+  return $rc
+}
+
+assert_rc() {
+  local desc="$1" expected="$2"; shift 2
+  local rc=0
+  run_guard "$@" || rc=$?
+  check_eq "$desc" "$expected" "$rc"
+}
+
+assert_output_has() {
+  local desc="$1" needle="$2"
+  if printf '%s' "$LAST_OUTPUT" | command grep -qF -- "$needle"; then
+    ok "$desc"
+  else
+    bad "$desc: output did not contain '$needle'. Got: $LAST_OUTPUT"
+  fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --- A corpus repository with a real, linear history -------------------------
+#
+#   C0 --- C1 --- C2        master
+#            \
+#             D1            a divergent branch, no ancestry either way with C2
+#
+# C1 stands for the pin main carried when a PR branched; C2 for the pin main
+# carries now. The #3181 shape is head=C1, base=C2.
+
+CORPUS="$TMP/corpus"
+git init -q -b master "$CORPUS"
+git -C "$CORPUS" config user.email test@example.com
+git -C "$CORPUS" config user.name Test
+
+echo t0 > "$CORPUS/spec.al"
+git -C "$CORPUS" add -A && git -C "$CORPUS" commit -qm "C0: corpus root"
+C0=$(git -C "$CORPUS" rev-parse HEAD)
+
+echo t1 >> "$CORPUS/spec.al"
+git -C "$CORPUS" commit -qam "C1: pin CalcFields on FlowFields (#199)"
+C1=$(git -C "$CORPUS" rev-parse HEAD)
+
+echo t2 >> "$CORPUS/spec.al"
+git -C "$CORPUS" commit -qam "C2: pin Subtype = Install reads back as Normal (#201)"
+C2=$(git -C "$CORPUS" rev-parse HEAD)
+
+git -C "$CORPUS" checkout -q -b divergent "$C1"
+echo d1 > "$CORPUS/other.al"
+git -C "$CORPUS" add -A && git -C "$CORPUS" commit -qm "D1: a divergent corpus commit"
+D1=$(git -C "$CORPUS" rev-parse HEAD)
+git -C "$CORPUS" checkout -q master
+
+# --- A superproject shaped like a real pull request --------------------------
+#
+# The submodule is added once; the pin is then moved by writing the gitlink
+# directly with `git update-index --cacheinfo`, which is exactly what a pin bump
+# is at the tree level and avoids needing a working submodule checkout per case.
+
+SUPER="$TMP/super"
+git init -q -b main "$SUPER"
+git -C "$SUPER" config user.email test@example.com
+git -C "$SUPER" config user.name Test
+git -C "$SUPER" config protocol.file.allow always
+
+mkdir -p "$SUPER/tests"
+echo "runner" > "$SUPER/README.md"
+git -C "$SUPER" add -A && git -C "$SUPER" commit -qm "super: root"
+
+# protocol.file.allow must be passed with -c on the command itself; setting it
+# in the repository config is NOT consulted for the submodule's own clone, which
+# fails with "transport 'file' not allowed". Errors here are deliberately NOT
+# swallowed -- swallowing this one produced a fixture with no submodule at all,
+# and every case below then passed the script's "nothing to compare" path while
+# looking like it had tested something.
+if ! git -C "$SUPER" -c protocol.file.allow=always \
+       submodule add -q "file://$CORPUS" tests/al-language; then
+  echo "FAIL - fixture setup: could not add the corpus submodule" >&2
+  exit 1
+fi
+git -C "$SUPER" add -A && git -C "$SUPER" commit -qm "super: add corpus submodule"
+
+# The fixture is worthless if the submodule did not actually land, so assert it
+# rather than discovering it as thirteen confusing failures further down.
+if [ "$(git -C "$SUPER" ls-files -s tests/al-language | awk '{print $1}')" != "160000" ]; then
+  echo "FAIL - fixture setup: tests/al-language is not a gitlink" >&2
+  exit 1
+fi
+
+# Writes commit $1 as the tests/al-language gitlink and commits it, printing the
+# resulting superproject commit SHA.
+# `git commit` prints "nothing to commit" on STDOUT when the pin is already the
+# requested one, so every git call here is silenced explicitly -- letting that
+# text into the command substitution produced a multi-line "SHA" that the script
+# under test then correctly refused, turning six real cases into usage errors.
+# --allow-empty keeps a repeated pin a distinct commit, which the untouched-pin
+# case needs.
+pin_to() {
+  git -C "$SUPER" update-index --cacheinfo "160000,$1,tests/al-language" >/dev/null 2>&1
+  git -C "$SUPER" commit -q --allow-empty -m "pin corpus at $1" >/dev/null 2>&1
+  git -C "$SUPER" rev-parse HEAD
+}
+
+BASE_AT_C2=$(pin_to "$C2")     # main today: the newer pin
+HEAD_AT_C1=$(pin_to "$C1")     # a PR still carrying the older pin  -- the #3181 shape
+HEAD_AT_C2=$(pin_to "$C2")     # a PR that did not touch the pin
+HEAD_AT_D1=$(pin_to "$D1")     # a PR carrying a divergent corpus commit
+BASE_AT_C1=$(pin_to "$C1")     # main at the older pin, for the forward-bump case
+
+# Make the corpus history reachable inside the superproject's submodule clone,
+# the way the shipped job's fetch step does.
+git -C "$SUPER/tests/al-language" fetch -q origin '+refs/heads/*:refs/remotes/origin/*'
+
+# --- The three verdicts ------------------------------------------------------
+
+assert_rc "pin untouched (base == head) passes" 0 \
+  BASE_SHA="$BASE_AT_C2" HEAD_SHA="$HEAD_AT_C2"
+assert_output_has "an untouched pin says so rather than claiming it checked ancestry" "unchanged"
+
+assert_rc "a genuine forward bump passes" 0 \
+  BASE_SHA="$BASE_AT_C1" HEAD_SHA="$HEAD_AT_C2"
+assert_output_has "a forward bump names the direction it verified" "ancestor"
+
+# The centre of the suite: #3181's real shape, reconstructed. The head pin is an
+# ancestor of the base pin, so merging it would un-pin every corpus commit in
+# between -- suites already validated against a real service tier.
+assert_rc "a BACKWARD pin fails (#3181's shape: head pin is an ancestor of base pin)" 1 \
+  BASE_SHA="$BASE_AT_C2" HEAD_SHA="$HEAD_AT_C1"
+assert_output_has "the backward failure is a GitHub error annotation" "::error::"
+# head=C1, base=C2, so the corpus commit that would be un-pinned is C2 -- the
+# one main reached and this PR's pin does not.
+assert_output_has "the backward failure names the corpus commit that would be dropped" \
+  "C2: pin Subtype = Install reads back as Normal (#201)"
+
+assert_rc "a DIVERGENT pin fails (neither commit is an ancestor of the other)" 1 \
+  BASE_SHA="$BASE_AT_C2" HEAD_SHA="$HEAD_AT_D1"
+assert_output_has "the divergent failure is a GitHub error annotation" "::error::"
+
+# A divergent pin is not a backward one and must not be described as one -- the
+# remedy differs (rebase the pin forward vs. work out where the pin came from).
+if printf '%s' "$LAST_OUTPUT" | command grep -qF "diverged"; then
+  ok "the divergent case is reported as divergent, not as backward"
+else
+  bad "the divergent case should say the pins diverged. Got: $LAST_OUTPUT"
+fi
+
+# --- REPRODUCE_THE_SHALLOW_LIE ----------------------------------------------
+#
+# Both halves are asserted, the same way test_pr_changed_files.sh asserts the
+# range collapse: that raw git really does answer wrongly here, and that the
+# script does not.
+
+SHALLOW_SUPER="$TMP/shallow-super"
+cp -r "$SUPER" "$SHALLOW_SUPER"
+rm -rf "$SHALLOW_SUPER/tests/al-language"
+git -C "$SHALLOW_SUPER" -c protocol.file.allow=always clone -q --depth 1 \
+  "file://$CORPUS" "$SHALLOW_SUPER/tests/al-language"
+# Bring both endpoints in as objects WITHOUT their connecting history, which is
+# the state actions/checkout leaves behind when it clones a submodule shallowly.
+git -C "$SHALLOW_SUPER/tests/al-language" fetch -q --depth 1 origin "$C1" 2>/dev/null
+git -C "$SHALLOW_SUPER/tests/al-language" fetch -q --depth 1 origin "$C2" 2>/dev/null
+
+both_present=0
+git -C "$SHALLOW_SUPER/tests/al-language" cat-file -e "${C1}^{commit}" 2>/dev/null || both_present=1
+git -C "$SHALLOW_SUPER/tests/al-language" cat-file -e "${C2}^{commit}" 2>/dev/null || both_present=1
+check_eq "the shallow submodule really does have BOTH pins as objects" "0" "$both_present"
+
+raw_rc=0
+git -C "$SHALLOW_SUPER/tests/al-language" merge-base --is-ancestor "$C1" "$C2" 2>/dev/null || raw_rc=$?
+check_eq "raw git answers 'not an ancestor' for a pin that IS a forward bump" "1" "$raw_rc"
+
+# ...and that wrong answer is indistinguishable from the genuine backward case
+# above, which is exactly why the guard may not read the exit code alone.
+SUPER_REAL="$SUPER"
+SUPER="$SHALLOW_SUPER"
+
+assert_rc "a forward bump in a shallow clone is CANNOT-DETERMINE, not a bogus failure" 3 \
+  BASE_SHA="$BASE_AT_C1" HEAD_SHA="$HEAD_AT_C2"
+assert_output_has "cannot-determine explains the clone depth rather than blaming the author" \
+  "shallow"
+# The one thing it must never do is pass silently -- that would leave the guard
+# reporting green while having checked nothing, on every PR.
+if [ "$LAST_OUTPUT" != "${LAST_OUTPUT/::error::/}" ] || \
+   [ "$LAST_OUTPUT" != "${LAST_OUTPUT/::warning::/}" ]; then
+  ok "cannot-determine is annotated in the CI log rather than silent"
+else
+  bad "cannot-determine produced no ::error:: or ::warning:: annotation. Got: $LAST_OUTPUT"
+fi
+
+SUPER="$SUPER_REAL"
+
+# --- A pin whose object is absent entirely ----------------------------------
+#
+# Distinct from the shallow case above: there the objects are present and only
+# the history between them is missing. Here an endpoint is not in the clone at
+# all, which makes merge-base exit 128 with a fatal -- the exit code a naive
+# `|| exit 1` converts into a false "moves the pin backward" accusation.
+#
+# Built as its own superproject whose submodule clone genuinely lacks the commit,
+# rather than by writing a synthetic gitlink: `git update-index --cacheinfo`
+# refuses a path that is not already in the index (it wants --add), so the
+# synthetic version silently left the pin untouched and the case passed against
+# the shallow branch above instead of the one it names.
+
+ABSENT_SUPER="$TMP/absent-super"
+git init -q -b main "$ABSENT_SUPER"
+git -C "$ABSENT_SUPER" config user.email test@example.com
+git -C "$ABSENT_SUPER" config user.name Test
+
+echo "runner" > "$ABSENT_SUPER/README.md"
+git -C "$ABSENT_SUPER" add -A && git -C "$ABSENT_SUPER" commit -qm "super: root"
+
+# The submodule is cloned from a corpus that only has C0..C1 -- so C2, which the
+# head pin below names, is genuinely not an object in it.
+PARTIAL="$TMP/partial-corpus"
+git clone -q --no-local "$CORPUS" "$PARTIAL"
+git -C "$PARTIAL" checkout -q "$C1"
+git -C "$PARTIAL" branch -q -f master "$C1"
+git -C "$PARTIAL" checkout -q master
+git -C "$PARTIAL" reflog expire --expire=now --all
+git -C "$PARTIAL" gc -q --prune=now 2>/dev/null || true
+
+if ! git -C "$ABSENT_SUPER" -c protocol.file.allow=always \
+       submodule add -q "file://$PARTIAL" tests/al-language; then
+  echo "FAIL - fixture setup: could not add the partial corpus submodule" >&2
+  exit 1
+fi
+git -C "$ABSENT_SUPER" add -A
+git -C "$ABSENT_SUPER" commit -qm "super: add partial corpus submodule"
+ABSENT_BASE=$(git -C "$ABSENT_SUPER" rev-parse HEAD)
+
+# Confirm the fixture really is what it claims before asserting anything on it.
+if git -C "$ABSENT_SUPER/tests/al-language" cat-file -e "${C2}^{commit}" 2>/dev/null; then
+  bad "fixture setup: the partial corpus clone unexpectedly has C2; the absent-object case would prove nothing"
+else
+  ok "the fixture's corpus clone genuinely lacks the head pin's commit"
+fi
+
+git -C "$ABSENT_SUPER" update-index --cacheinfo "160000,$C2,tests/al-language"
+git -C "$ABSENT_SUPER" commit -q -m "pin corpus at a commit this clone does not have"
+ABSENT_HEAD=$(git -C "$ABSENT_SUPER" rev-parse HEAD)
+
+SUPER="$ABSENT_SUPER"
+assert_rc "a pin whose object is absent is CANNOT-DETERMINE, not backward" 3 \
+  BASE_SHA="$ABSENT_BASE" HEAD_SHA="$ABSENT_HEAD"
+assert_output_has "an absent pin object is reported as a checkout problem" "not present"
+SUPER="$SUPER_REAL"
+
+# --- Endpoints: the #3261 lesson, applied here -------------------------------
+#
+# Both endpoints must come from the event payload. Under actions/checkout, HEAD
+# is refs/pull/N/merge -- a merge commit whose FIRST PARENT is the base branch --
+# so reading the pin from HEAD reads main's pin, not the PR's, and a backward pin
+# becomes invisible. Refusing a symbolic ref is what makes that unmissable.
+
+assert_rc "HEAD_SHA=HEAD is refused rather than silently reading the merge ref's pin" 2 \
+  BASE_SHA="$BASE_AT_C2" HEAD_SHA=HEAD
+assert_rc "BASE_SHA=HEAD is refused too" 2 BASE_SHA=HEAD HEAD_SHA="$HEAD_AT_C1"
+assert_rc "a branch name is refused" 2 BASE_SHA="$BASE_AT_C2" HEAD_SHA=main
+assert_rc "a refs/ spelling is refused" 2 BASE_SHA="$BASE_AT_C2" HEAD_SHA=refs/pull/1/merge
+assert_rc "an empty HEAD_SHA is refused" 2 BASE_SHA="$BASE_AT_C2" HEAD_SHA=
+assert_rc "an empty BASE_SHA is refused" 2 BASE_SHA= HEAD_SHA="$HEAD_AT_C1"
+assert_rc "an abbreviation too short to be a SHA is refused" 2 \
+  BASE_SHA="$BASE_AT_C2" HEAD_SHA=abc
+assert_rc "a hex string that is not a commit here is refused" 2 \
+  BASE_SHA="$BASE_AT_C2" HEAD_SHA=0123456789abcdef0123456789abcdef01234567
+
+rc=0
+(cd "$SUPER" && env -u HEAD_SHA BASE_SHA="$BASE_AT_C2" bash "$SCRIPT" >/dev/null 2>&1) || rc=$?
+check_eq "an unset HEAD_SHA is a usage error, not a pass" "2" "$rc"
+
+rc=0
+(cd "$SUPER" && env -u BASE_SHA HEAD_SHA="$HEAD_AT_C1" bash "$SCRIPT" >/dev/null 2>&1) || rc=$?
+check_eq "an unset BASE_SHA is a usage error, not a pass" "2" "$rc"
+
+# The verdict must depend on the endpoints, never on what happens to be checked
+# out -- this is the property that makes the refusals above meaningful.
+git -C "$SUPER" checkout -q --detach "$BASE_AT_C2"
+assert_rc "a backward pin is still caught whatever is checked out" 1 \
+  BASE_SHA="$BASE_AT_C2" HEAD_SHA="$HEAD_AT_C1"
+git -C "$SUPER" checkout -q main
+
+# --- Prove, not pass: both stub directions must be caught --------------------
+#
+# .claude/rules/tdd.md asks whether the suite would still pass against an
+# implementation that always returns the same answer. Rather than leaving that
+# to the reader, it is asserted: a stub that always exits 0 and a stub that
+# always exits 1 are each run through the cases above and must FAIL this suite.
+
+STUB_DIR="$TMP/stubs"
+mkdir -p "$STUB_DIR"
+printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB_DIR/always0.sh"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$STUB_DIR/always1.sh"
+chmod +x "$STUB_DIR/always0.sh" "$STUB_DIR/always1.sh"
+
+stub_rc() {
+  local stub="$1"; shift
+  local rc=0
+  (cd "$SUPER" && env "$@" bash "$stub" >/dev/null 2>&1) || rc=$?
+  echo "$rc"
+}
+
+# always-0 must be caught by the backward case, which is the one that matters.
+got=$(stub_rc "$STUB_DIR/always0.sh" BASE_SHA="$BASE_AT_C2" HEAD_SHA="$HEAD_AT_C1")
+if [ "$got" != "1" ]; then
+  ok "a stub that always exits 0 fails this suite's backward case"
+else
+  bad "a stub that always exits 0 would pass the backward case -- the suite proves nothing"
+fi
+
+# always-1 must be caught by BOTH passing cases, not just one.
+got=$(stub_rc "$STUB_DIR/always1.sh" BASE_SHA="$BASE_AT_C2" HEAD_SHA="$HEAD_AT_C2")
+if [ "$got" != "0" ]; then
+  ok "a stub that always exits 1 fails this suite's pin-untouched case"
+else
+  bad "a stub that always exits 1 would pass the pin-untouched case"
+fi
+
+got=$(stub_rc "$STUB_DIR/always1.sh" BASE_SHA="$BASE_AT_C1" HEAD_SHA="$HEAD_AT_C2")
+if [ "$got" != "0" ]; then
+  ok "a stub that always exits 1 fails this suite's forward-bump case"
+else
+  bad "a stub that always exits 1 would pass the forward-bump case"
+fi
+
+# --- The wiring: a tested script the gating job does not call is decoration ---
+
+if command grep -q 'check_corpus_pin_forward.sh' "$WORKFLOW_DIR/pr-gate.yml"; then
+  ok "pr-gate.yml calls check_corpus_pin_forward.sh"
+else
+  bad "pr-gate.yml does not call check_corpus_pin_forward.sh -- the tested path is not the shipped one"
+fi
+
+# The endpoints must reach the script from the event payload. If the job ever
+# stops passing them, every case above is testing something CI does not run.
+pin_job=$(command sed -n '/^  require-forward-corpus-pin:/,/^  [a-z]/p' "$WORKFLOW_DIR/pr-gate.yml")
+if [ -z "$pin_job" ]; then
+  bad "pr-gate.yml has no require-forward-corpus-pin job"
+elif printf '%s' "$pin_job" | command grep -q 'github.event.pull_request.head.sha'; then
+  ok "the pin job passes the PR head SHA from the event payload"
+else
+  bad "the pin job does not pass github.event.pull_request.head.sha"
+fi
+
+# The guard is worthless if the corpus history is not fetched before it runs:
+# every PR would land on the cannot-determine path and the job would never
+# actually compare anything.
+if printf '%s' "$pin_job" | command grep -qE 'unshallow|--filter|fetch'; then
+  ok "the pin job fetches corpus history rather than relying on a shallow clone"
+else
+  bad "the pin job does not fetch corpus history -- it would never reach a verdict"
+fi
+
+echo
+echo "passed: $pass, failed: $fail"
+[ "$fail" -eq 0 ]

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -207,6 +207,73 @@ jobs:
           CHANGED_FILES: ${{ steps.changed.outputs.files }}
         run: bash .github/scripts/check_corpus_linkage.sh
 
+  require-forward-corpus-pin:
+    name: The corpus pin must not move backward
+    runs-on: ubuntu-latest
+    # #3288. The corpus is this project's ratchet: every behaviour pinned in
+    # tests/al-language "is validated on real BC on every push and can never
+    # silently regress afterwards" (.claude/skills/autonomous-cycle). Nothing
+    # enforced the second half. A pull request whose pin is BEHIND main's passes
+    # every required context, and merging it un-pins corpus suites a real service
+    # tier has already adjudicated -- silently, because those suites do not fail,
+    # they stop existing, and the next green run reports success over a smaller
+    # set.
+    #
+    # Caught for real on PR #3181, green and CLEAN while about to drop corpus
+    # #199 and #201. That PR did nothing wrong: it bumped the pin forward from
+    # the main that existed when it was written, and main's pin advanced
+    # afterwards. It is a merge-order accident, which is why it needs a guard
+    # rather than a rule -- and it gets likelier as more agents run in parallel.
+    #
+    # It gates, so by the rule of thumb at the top of this file it must not be
+    # able to fail for an environmental reason. Two things make that true, and
+    # both are load-bearing:
+    #
+    #   * The whole job is offline apart from the checkout. No api.github.com.
+    #   * The corpus history is fetched BEFORE the comparison, and the script
+    #     refuses to answer (exit 3) rather than guess when it is missing. That
+    #     matters more than it sounds: in a shallow clone with both pins present
+    #     as objects, `git merge-base --is-ancestor` returns a clean exit 1 for a
+    #     pin that IS a forward bump -- byte-for-byte the signal a real backward
+    #     pin produces. A guard reading the exit code alone would tell every
+    #     author their PR moves the pin backward, forever.
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Both endpoints of the comparison must be present as superproject
+          # commits, so the full history is needed here for the same reason the
+          # corpus-linkage job above needs it.
+          fetch-depth: 0
+          submodules: true
+
+      - name: Fetch the corpus history the comparison needs
+        # actions/checkout applies its fetch-depth to submodules too, and a
+        # shallow corpus clone is exactly the state in which merge-base lies (see
+        # above). Unshallowing here is what turns "cannot determine" into a real
+        # verdict. It is deliberately tolerant of failure: if this step cannot
+        # complete, the guard reports CANNOT-DETERMINE with a message about the
+        # checkout rather than a false accusation about the pin.
+        continue-on-error: true
+        run: |
+          set -x
+          git -C tests/al-language fetch --unshallow origin 2>/dev/null \
+            || git -C tests/al-language fetch --depth=2147483647 origin 2>/dev/null \
+            || git -C tests/al-language fetch origin '+refs/heads/*:refs/remotes/origin/*'
+
+      - name: Compare this PR's corpus pin against the base branch's
+        # BOTH endpoints come from the event payload, never the checked-out HEAD.
+        # That is #3261's lesson, and it bites harder here than it does for a file
+        # diff: actions/checkout leaves refs/pull/N/merge checked out, whose tree
+        # carries the MERGED pin -- git resolves a gitlink conflict toward the
+        # newer commit -- so reading the pin from HEAD would read something that
+        # is not this PR's pin at all, and the guard would pass on precisely the
+        # case it exists to catch. check_corpus_pin_forward.sh refuses a symbolic
+        # ref outright rather than resolving one.
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash .github/scripts/check_corpus_pin_forward.sh
+
   verify-trigger-list:
     name: pull_request trigger lists must keep their load-bearing event types
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #3288

Nothing compared a pull request's `tests/al-language` pin against the pin on the branch it merges into. A PR carrying an older pin passed every required context, and merging it un-pins corpus suites already validated against a real BC service tier — silently, because those suites do not fail, they stop existing, and the next green run reports success over a smaller set.

Caught for real on #3181, which was green and `CLEAN` while about to drop corpus #199 and #201. That PR did nothing wrong: it bumped the pin forward from the `main` that existed when it was written, and `main`'s pin advanced afterwards. It is a merge-order accident, which is why it needs a guard rather than a rule.

## What ships

- `.github/scripts/check_corpus_pin_forward.sh` — the logic, so the endpoints are testable.
- `.github/scripts/test_check_corpus_pin_forward.sh` — 35 assertions, modelled on `test_pr_changed_files.sh`.
- `.github/workflows/pr-gate.yml` — a new gating job, `The corpus pin must not move backward`.
- `.github/scripts/check_required_contexts.py` — the new context added to `PENDING_REQUIRED_CONTEXTS`.

## Four verdicts, not three, and the fourth is the whole risk

The issue's truth table has three rows. Implementing exactly three would have made this guard worse than not shipping it.

| case | verdict |
|---|---|
| pin untouched (base == head) | 0 pass |
| base pin **is** an ancestor of head pin | 0 pass — a genuine bump |
| otherwise (backward, or divergent) | **1 fail** |
| corpus history not present | **3 cannot determine** |

`git merge-base --is-ancestor` cannot tell row 3 from row 4, and it fails in the direction that **blocks**. Measured here, not assumed:

- With an endpoint absent from the clone it exits **128** with a fatal, which a naive `|| exit 1` turns into "your PR moves the pin backward".
- Worse: with **both** endpoints present as objects but the history between them truncated — exactly what a shallow submodule clone leaves — it exits **1**, cleanly, for a pin that genuinely *is* a forward bump. That is byte-for-byte the signal a real backward pin produces. Unshallowing the same clone flips the same command to **0**.

So a guard reading the exit code alone would tell every author their PR moves the corpus pin backward, on every PR, until somebody worked out that clone depth was the cause. `pr-gate.yml`'s header sets the bar for anything that gates: it must not fail for an environmental reason, and a missing fetch is one. Exit 3 is deliberately not exit 0 — "cannot determine" must not read as "fine".

The job fetches corpus history before comparing, so in practice it reaches a real verdict; the fetch step is `continue-on-error` so a fetch problem surfaces as a loud message about the checkout rather than a false accusation about the pin.

## Endpoints

Both come from the event payload, never the checked-out `HEAD` — #3261's lesson, and it bites harder here than for a file diff. `actions/checkout` leaves `refs/pull/N/merge` checked out, and that tree carries the **merged** pin (git resolves a gitlink conflict toward the newer commit), so reading the pin from `HEAD` would read something that is not the PR's pin at all and the guard would pass on precisely the case it exists to catch. A symbolic ref is refused outright rather than resolved.

## Verified against the real repository, not only fixtures

Run against this repo with the real submodule, using #3181's actual head `d1dcf88`:

- **backward** → exit 1, naming both commits that would be dropped: `b0c6248` (#199) and `ae64da1` (#201). Exactly what the issue predicted.
- **real forward bump** (`4d7a2ae` → current `main`, 12 corpus commits) → exit 0.
- **pin untouched** → exit 0.

## Both stub directions verified

As asked. Replacing the script with a stub and re-running the suite:

| stub | assertions failed |
|---|---|
| always `exit 0` | **24** |
| always `exit 1` | **23** |
| the real script | **0** (35/35 pass) |

So neither trivial implementation survives the suite: always-0 is caught by the backward and divergent cases, always-1 by the untouched and forward-bump cases. The suite proves rather than passes.

## RED → GREEN

Tests written first and run against a non-existent script: **7 passed, 26 failed**. Then the implementation, iterating on genuine harness defects the RED run exposed — three worth naming, because each produced a suite that looked like it was testing something and was not:

- `git submodule add` needs `-c protocol.file.allow=always` **on the command**; setting it in the repo config is not consulted for the submodule's own clone. Swallowing that error produced a fixture with no submodule at all, and every case then passed the script's "nothing to compare" path.
- `git commit` prints "nothing to commit" on **stdout**, which a `$(...)` capture turned into a multi-line "SHA" the script correctly refused — six real cases became usage errors.
- `git update-index --cacheinfo` refuses a path not already in the index, so a synthetic absent-object fixture silently left the pin unchanged and the case passed against the wrong branch. Rebuilt as a real partial clone, with an assertion that the fixture genuinely lacks the commit before anything is concluded from it.

Final: **35/35**. The full `.github/scripts/` suite — the `.github/scripts/ unit tests` required context — is green.

## What I did not fold, and why

Per `.claude/rules/batch-sibling-issues-by-file.md`, I scanned the open queue for issues landing in these files. **Nothing folds.** The map:

- **#3202** — records that the pin bump needs four PRs in a forced order (#3152 → #3180 → #3181, with #3128 first). Closest in subject, but it is a coordination record with no change in these files; this guard *helps* it by making a wrong order fail loudly instead of merging.
- **#3196** — three PRs broke tree-asserting guards a filtered local run excluded. Lands in `.claude/rules/local-test-scope.md` and `AlRunner.Tests/`, and it explicitly asks for a decision among three options rather than a patch. Different files, different reasoning.
- **#2980** — shared session scratchpad collisions; touches `tools/`, not `.github/scripts/`.
- **#3149** — worktree accumulation from `git worktree remove` refusing on the submodule. Same submodule, entirely different mechanism and files.

## Notes

- This PR does **not** change the `tests/al-language` pin — verified before pushing, so the guard does not fire on its own PR.
- The new context goes in `PENDING_REQUIRED_CONTEXTS` following #3261's pattern, so the code half lands before the by-hand ruleset edit. I read the live ruleset rather than trusting a list: it currently requires exactly the ten names in `DEFAULT_REQUIRED_CONTEXTS`, so both this and #3261's corpus-linkage context are still pending. Empty both entries in the same pass that adds them to the ruleset and to `RULESET_CONTEXTS` in `tools/ci-wait.py`.
- No `AlRunner/` file is touched, so `require-tests` does not trigger.

Corpus-NA: this is CI plumbing that compares two git revisions of a submodule pointer. It changes nothing about what AL observes and no corpus test could express it — the claim is about this repository's merge process, not about BC.

---

Opened by an automated agent (tag `stma-auto-2`) acting on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4
