### PR TITLE
fix(ci-wait): reach a verdict on a concluded run, refuse when freshness is unknown

### DIFF
--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -83,8 +83,25 @@ Two things it cannot do, so do them yourself:
   run `origin/main`'s copy directly:
   ```bash
   git fetch origin main
-  git show origin/main:tools/ci-wait.py > /tmp/ci-wait.py && python3 /tmp/ci-wait.py <PR>
+  d=$(mktemp -d) && mkdir -p "$d/tools"
+  for f in ci-wait.py agent_self_freshness.py; do
+    git show "origin/main:tools/$f" > "$d/tools/$f"
+  done
+  python3 "$d/tools/ci-wait.py" <PR>
   ```
+  **Extract both files, not just `ci-wait.py`** (#3295). A lone copy cannot import its sibling
+  guard, and that used to print a note and judge the PR anyway — so the recipe *recommended
+  here* was itself a way to reach the one path where nothing checked the running code. It now
+  exits 3 instead, so the one-file version of this recipe no longer works at all, which is the
+  intended outcome: a tool whose job is to withhold an unsafe verdict must not have a path that
+  emits one with the safety check skipped.
+
+  Expect two loud `unknown` notes from the copy above — a directory under `/tmp` is not inside
+  a git repository, so neither file can check its own freshness. That is fine *here* and only
+  here: you just extracted both from `origin/main` yourself, so their provenance is the
+  guarantee the check would otherwise provide. It is not fine in general, and the same
+  fails-open-on-`unknown` path is reachable by other routes in `pr-body.py` and `preflight.py`
+  too — tracked in #3296.
 - **It cannot turn a network failure into a verdict.** `refs/remotes/origin/main` is shared by
   every worktree of the repository, so the check itself costs no network; one `git ls-remote`
   confirms that shared ref against the remote. If the remote is unreachable, that is a loud

--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -393,6 +393,35 @@ RULESET_CONTEXTS = (
 NOT_FAILURES = ("success", "neutral", "skipped")
 
 
+def has_concluded(r: dict) -> bool:
+    """Has this check run / workflow run finished? Read the CONCLUSION first.
+
+    `status == "completed"` is the obvious test and it is not sufficient. GitHub
+    can leave a run at `status=in_progress` while it already carries a
+    `conclusion` and a `completed_at`, and it is the conclusion the branch
+    ruleset acts on. Measured on PR #3234's head (#3294):
+
+        name=PR body closing references must be correct, both directions
+        id=101566184213  status=in_progress  conclusion=success
+        completed_at=2026-09-06T22:01:46Z
+
+    `gh pr view --json statusCheckRollup` rendered that entry as plain SUCCESS
+    and the merge was available, while this tool -- counting on `status` --
+    reported "12/13 complete, 0 failing" across four calls over roughly 40
+    minutes and never reached a verdict. The poll cannot terminate, because
+    nothing about that run is ever going to change.
+
+    A non-null conclusion is GitHub's own statement that the run is over, so it
+    is the primary signal and `status` only breaks the tie when there is none.
+    This never resolves an unknown toward green: a run with no conclusion is
+    still unfinished here, which is what keeps every in-flight guard below
+    working.
+    """
+    if r.get("conclusion") is not None:
+        return True
+    return r.get("status") == "completed"
+
+
 def is_required(name: str | None, contexts: tuple[str, ...] = RULESET_CONTEXTS) -> bool:
     name = name or ""
     return "required" in name or name in contexts
@@ -488,7 +517,7 @@ def rollup_is_final(workflow_runs: list[dict] | None) -> bool | None:
         # Nothing registered for the commit yet. The push is seconds old and the
         # rollup is at its emptiest, which is precisely when it lies best.
         return False
-    return all(w.get("status") == "completed" for w in workflow_runs)
+    return all(has_concluded(w) for w in workflow_runs)
 
 
 def superseding_runs(newest: dict[str, dict],
@@ -526,7 +555,7 @@ def superseding_runs(newest: dict[str, dict],
     """
     if not workflow_runs:
         return []
-    pending = [w for w in workflow_runs if w.get("status") != "completed"]
+    pending = [w for w in workflow_runs if not has_concluded(w)]
     if not pending:
         return []
     by_id = {w.get("id"): w for w in workflow_runs}
@@ -611,7 +640,7 @@ def supersession(newest: dict[str, dict],
     latest_pending_of_workflow: dict[object, int] = {}
     for w in workflow_runs:
         wid = w.get("id")
-        if not isinstance(wid, int) or w.get("status") == "completed":
+        if not isinstance(wid, int) or has_concluded(w):
             continue
         name = w.get("name")
         if wid > latest_pending_of_workflow.get(name, -1):
@@ -743,7 +772,7 @@ def classify(runs: list[dict],
         newest[n] = r
 
     pool = [r for n, r in newest.items() if is_required(n, contexts)] or list(newest.values())
-    done = [r for r in pool if r.get("status") == "completed"]
+    done = [r for r in pool if has_concluded(r)]
     # A superseded name is excluded from `bad` outright. `bad` short-circuits
     # ahead of every in-flight guard below -- deliberately, since a failure is a
     # verdict -- so a guard placed after it never gets consulted, which is
@@ -757,6 +786,20 @@ def classify(runs: list[dict],
     inflight = superseding_runs(newest, contexts, workflow_runs)
 
     progress = f"{len(done)}/{len(pool)} complete, {len(bad)} failing"
+    # NAME what is still outstanding, do not just count it (#3294). "12/13
+    # complete" says how many and never which, so a reader watching a poll that
+    # will not terminate has no way to tell a leg that is legitimately still
+    # running from the one entry that is wedged. Finding that name by hand --
+    # the check-runs API filtered on status, not on conclusion, since the run
+    # HAS a conclusion -- is what turned a one-line diagnosis into a 40-minute
+    # one. Capped, because a fresh push leaves every leg outstanding and the
+    # full roster would bury the counts it is meant to annotate.
+    waiting = sorted((r.get("name") or "?") for r in pool if not has_concluded(r))
+    if waiting:
+        shown = ", ".join(waiting[:6])
+        if len(waiting) > 6:
+            shown += f", +{len(waiting) - 6} more"
+        progress += f"; waiting on: {shown}"
     if missing:
         progress += (f", {len(missing)} ruleset context(s) not in the rollup yet: "
                      + ", ".join(missing))
@@ -894,7 +937,7 @@ def classify(runs: list[dict],
     # absorb in the first place.
     undiscounted = sorted(
         (r for r in newest.values()
-         if r.get("status") == "completed"
+         if has_concluded(r)
          and r.get("conclusion") not in NOT_FAILURES
          and r.get("conclusion") != "cancelled"
          and discount_reason(r.get("name") or "", superseded, killed) is None),
@@ -1040,9 +1083,28 @@ def main() -> int:
     # and #3002's false GREEN is still on disk in most of this box's worktrees
     # (#3020). A refusal here is exit 3 -- undetermined, never a verdict.
     if _freshness is None:
-        print("note: could not establish whether this copy of ci-wait.py is current "
-              "-- tools/agent_self_freshness.py could not be imported. Answering "
-              "anyway; nothing has checked that this copy carries the latest fixes.")
+        # REFUSE, do not answer (#3295). This used to print the note below and
+        # judge the PR anyway -- so the one condition under which the running
+        # copy is MOST likely to be unusual, a copy sitting somewhere with no
+        # tools/ beside it, was exactly the condition under which nothing
+        # checked it. A note is not a refusal, and this one went to stdout next
+        # to the verdict, where a caller reading the exit code never saw it.
+        #
+        # Exit 3 for the same reason the narrowed-context path below uses it:
+        # this is "no verdict could be established", which is what 3 already
+        # means to every caller. It is not a new failure mode being invented --
+        # it is the existing one being reached honestly.
+        print("REFUSING to judge PR #%s: could not establish whether this copy of "
+              "ci-wait.py is current -- tools/agent_self_freshness.py could not be "
+              "imported alongside it." % args.pr)
+        print("This is NOT a verdict -- nothing was asked of GitHub.")
+        print("")
+        print("Run this tool from a checkout of the repository, where tools/ has "
+              "both files in it. To judge a PR with origin/main's copy rather "
+              "than your worktree's, use a worktree or a full checkout of "
+              "origin/main -- a lone file copied out of the tree cannot check "
+              "its own freshness, which is the whole point of the check.")
+        return 3
     else:
         # Both halves, not just this file. The verdict logic lives here, but the
         # freshness rule itself lives in the sibling module, and a stale copy of

--- a/tools/test_ci_wait.py
+++ b/tools/test_ci_wait.py
@@ -11,6 +11,7 @@ Run: python3 tools/test_ci_wait.py
 from __future__ import annotations
 
 import importlib.util
+import io
 import os
 import sys
 
@@ -1090,6 +1091,262 @@ check("the module docstring does not carry the falsified claim either",
       "no failure log" not in (cw.__doc__ or ""), (cw.__doc__ or "")[:0])
 check("...and defers to the rule file as the normative statement",
       "ci-verdicts.md" in (cw.__doc__ or ""), "")
+
+# ---------------------------------------------------------------------------
+# #3294: a check run can report status=in_progress WITH conclusion=success and a
+# completed_at. Observed on PR #3234 head, from the check-runs API:
+#
+#   name=PR body closing references must be correct, both directions
+#   id=101566184213  status=in_progress  conclusion=success
+#   completed_at=2026-09-06T22:01:46Z
+#
+# `gh pr view --json statusCheckRollup` rendered that same entry as plain
+# SUCCESS, so the ruleset was satisfied and the merge was available -- while
+# this tool, counting progress on `status == "completed"`, printed
+# "12/13 complete, 0 failing" across four calls over ~40 minutes and never
+# reached a verdict. A conclusion is GitHub's word that the run finished; the
+# status field is not load-bearing once it exists.
+# ---------------------------------------------------------------------------
+STUCK = {"status": "in_progress", "completed_at": "2026-09-06T22:01:46Z"}
+
+
+def stuck(name, conclusion="success", cid=None):
+    r = run(name, conclusion, status="in_progress", cid=cid)
+    r["completed_at"] = "2026-09-06T22:01:46Z"
+    return r
+
+
+_VICTIM = "PR body closing references must be correct, both directions"
+assert _VICTIM in cw.RULESET_CONTEXTS
+
+runs = [r for r in green_set() if r["name"] != _VICTIM]
+runs.append(stuck(_VICTIM))
+v = cw.classify(runs)
+check("a check run with conclusion=success but status=in_progress reaches a VERDICT",
+      v.code is not None, f"(code={v.code}) progress={v.progress}")
+check("...and that verdict is GREEN, matching what the ruleset reads",
+      v.code == 0, f"(code={v.code}) {v.lines}")
+check("...and it is counted as complete, not left outstanding",
+      v.progress is None or "/" not in (v.progress or "") or
+      v.progress.split("/")[0] == v.progress.split("/")[1].split()[0],
+      f"progress={v.progress}")
+
+# The same shape carrying a FAILING conclusion must not be swallowed either --
+# before the fix it was invisible in both directions, and a required failure
+# that never reports is the more dangerous half.
+runs = [r for r in green_set() if r["name"] != _VICTIM]
+runs.append(stuck(_VICTIM, "failure"))
+v = cw.classify(runs)
+check("a stuck check run concluding FAILURE is reported as a failure",
+      v.code == 1, f"(code={v.code}) {v.lines}")
+check("...and names the context that failed",
+      any(_VICTIM in l for l in v.lines), v.lines)
+
+# NEGATIVE, and the guard that must not be weakened: a genuinely in-flight run
+# has NO conclusion, and must still be pending. If this ever goes green the fix
+# has turned "waiting" into "passed", which is the one direction a verdict may
+# never go.
+runs = [r for r in green_set() if r["name"] != _VICTIM]
+runs.append(run(_VICTIM, None, status="in_progress"))
+v = cw.classify(runs)
+check("a genuinely in-flight run (no conclusion) is still NOT a verdict",
+      v.code is None, f"(code={v.code})")
+runs = [r for r in green_set() if r["name"] != _VICTIM]
+runs.append(run(_VICTIM, None, status="queued"))
+v = cw.classify(runs)
+check("a queued run with no conclusion is still NOT a verdict",
+      v.code is None, f"(code={v.code})")
+
+# --- the progress line must NAME what it is waiting on (#3294). "12/13" says
+# --- how many but never which, and that is what turned a one-line diagnosis
+# --- into a 40-minute one.
+runs = [r for r in green_set() if r["name"] != _VICTIM]
+runs.append(run(_VICTIM, None, status="in_progress"))
+v = cw.classify(runs)
+check("the progress line names the context still outstanding",
+      v.progress is not None and _VICTIM in v.progress, f"progress={v.progress}")
+check("...and still reports the count",
+      v.progress is not None and "complete" in v.progress, f"progress={v.progress}")
+
+# --- the same assumption, one level down: WORKFLOW runs are read with the same
+# --- status test in three more places, and a workflow run stuck the same way
+# --- wedges the poll just as thoroughly (superseding_runs / supersession /
+# --- rollup_is_final all treat "not completed" as "can still overturn this").
+check("rollup_is_final: a workflow run with a conclusion counts as finished",
+      cw.rollup_is_final([{"id": 1, "name": "Test Matrix", "status": "in_progress",
+                           "conclusion": "success"}]) is True, "")
+check("rollup_is_final: one with NO conclusion is still unfinished",
+      cw.rollup_is_final([{"id": 1, "name": "Test Matrix", "status": "in_progress",
+                           "conclusion": None}]) is False, "")
+
+# Run 41 produced the check run being judged and has finished; run 42 is the
+# newer run of the SAME workflow that carries the stuck shape. Both are listed,
+# so supersession() can resolve the owner by id -- without run 41 present the
+# lookup falls out early and the assertion below would pass vacuously.
+_wf_stuck = [{"id": 41, "name": "PR Check", "status": "completed",
+              "conclusion": "success"},
+             {"id": 42, "name": "PR Check", "status": "in_progress",
+              "conclusion": "success"}]
+_newest = {_VICTIM: {"name": _VICTIM, "status": "completed", "conclusion": "success",
+                     "id": 7, "details_url": "https://x/actions/runs/41/job/7"}}
+check("superseding_runs: a concluded-but-in_progress workflow run supersedes nothing",
+      cw.superseding_runs(_newest, cw.RULESET_CONTEXTS, _wf_stuck) == [],
+      str(cw.superseding_runs(_newest, cw.RULESET_CONTEXTS, _wf_stuck)))
+_sup, _killed = cw.supersession(_newest, _wf_stuck)
+check("supersession: it is not treated as a pending run of the same workflow",
+      _sup == set(), f"superseded={_sup}")
+
+# ...and the negative for both: with no conclusion it IS still pending, so the
+# in-flight guards keep working.
+_wf_live = [{"id": 41, "name": "PR Check", "status": "completed", "conclusion": "success"},
+            {"id": 42, "name": "PR Check", "status": "in_progress", "conclusion": None}]
+_sup_live, _ = cw.supersession(_newest, _wf_live)
+check("supersession: a genuinely pending newer run still supersedes",
+      _sup_live == {_VICTIM}, f"superseded={_sup_live}")
+check("superseding_runs: a genuinely pending newer run still supersedes",
+      cw.superseding_runs(_newest, (_VICTIM,), _wf_live) == [(_VICTIM, 42)],
+      str(cw.superseding_runs(_newest, (_VICTIM,), _wf_live)))
+
+
+# ---------------------------------------------------------------------------
+# #3295: the staleness guard must REFUSE, not answer, when it cannot run.
+#
+# `tools/agent_self_freshness.py` is what stops a stale copy of this file
+# printing a false GREEN -- measured in .claude/rules/ci-verdicts.md, 71 of the
+# 99 copies of ci-wait.py on one box were not origin/main's, and replaying a
+# recorded rollup through them 59 printed a false GREEN. When that helper cannot
+# be imported the guard used to print a note and answer anyway, so the one
+# condition under which the copy is MOST likely to be unusual -- running from a
+# path with no tools/ beside it -- was exactly the condition under which nothing
+# checked it. And the note went to stdout next to the verdict, so a caller
+# reading only the exit code never saw it.
+#
+# The claim proved here is behavioural, not textual: with the helper missing,
+# main() returns 3 and asks GitHub NOTHING.
+# ---------------------------------------------------------------------------
+import contextlib
+
+
+class _ReachedGitHub(Exception):
+    """Raised by the head_sha stub -- proves the gate let the run through."""
+
+
+@contextlib.contextmanager
+def _main_with(freshness, argv=("ci-wait.py", "3234")):
+    """Run cw.main() with a stubbed freshness module and no network."""
+    old_f, old_h, old_argv = cw._freshness, cw.head_sha, sys.argv
+    cw._freshness = freshness
+
+    def _boom(pr):
+        raise _ReachedGitHub(pr)
+
+    cw.head_sha = _boom
+    sys.argv = list(argv)
+    buf = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(buf):
+            yield buf
+    finally:
+        cw._freshness, cw.head_sha, sys.argv = old_f, old_h, old_argv
+
+
+_reached = False
+_code = None
+with _main_with(None) as _buf:
+    try:
+        _code = cw.main()
+    except _ReachedGitHub:
+        _reached = True
+_out = _buf.getvalue()
+
+check("an unimportable freshness helper REFUSES rather than answering",
+      _code == 3, f"(code={_code}) {_out}")
+check("...and nothing is asked of GitHub before refusing", not _reached, "")
+check("...and it no longer says it is answering anyway",
+      "Answering anyway" not in _out, _out)
+check("...and says which check could not be run",
+      "agent_self_freshness" in _out, _out)
+
+
+class _FreshStub:
+    """Stands in for a freshness helper that reports this copy is current."""
+    __file__ = os.path.join(HERE, "agent_self_freshness.py")
+
+    class _R:
+        notes: list[str] = []
+        refuse = False
+
+    @staticmethod
+    def assess(target, remote_check=False):
+        return _FreshStub._R()
+
+
+_reached = False
+_code = None
+with _main_with(_FreshStub()) as _buf:
+    try:
+        _code = cw.main()
+    except _ReachedGitHub:
+        _reached = True
+
+check("a normal run is unaffected -- a fresh copy still proceeds to GitHub",
+      _reached and _code is None, f"(code={_code}, reached={_reached})")
+
+
+class _StaleStub(_FreshStub):
+    class _R:
+        notes = ["note: this copy is behind origin/main"]
+        refuse = True
+
+    @staticmethod
+    def assess(target, remote_check=False):
+        return _StaleStub._R()
+
+
+_reached = False
+_code = None
+with _main_with(_StaleStub()) as _buf:
+    try:
+        _code = cw.main()
+    except _ReachedGitHub:
+        _reached = True
+check("a stale copy is still refused with exit 3 (the #3020 guard is intact)",
+      _code == 3 and not _reached, f"(code={_code}, reached={_reached})")
+
+# End to end, the exact invocation .claude/rules/ci-verdicts.md used to
+# recommend: a copy of this file alone in a directory with no tools/ beside it.
+# PATH is emptied so that any attempt to shell out to `gh` fails loudly instead
+# of quietly succeeding -- exit 3 here therefore also proves no GitHub call.
+import shutil
+import subprocess
+import tempfile
+
+with tempfile.TemporaryDirectory() as _td:
+    _lone = os.path.join(_td, "ci-wait.py")
+    shutil.copy(os.path.join(HERE, "ci-wait.py"), _lone)
+    _env = dict(os.environ, PATH=_td)
+    _p = subprocess.run([sys.executable, _lone, "3234"], capture_output=True,
+                        text=True, env=_env, timeout=120)
+    check("a lone copy in a scratch directory exits 3 rather than judging a PR",
+          _p.returncode == 3, f"(rc={_p.returncode}) {_p.stdout}{_p.stderr}")
+    check("...and never reports a verdict",
+          "GREEN" not in _p.stdout and "all " not in _p.stdout,
+          _p.stdout)
+
+# The rule file may not keep recommending an invocation that now refuses. This
+# is an INVARIANT, not a blocklist of the two spellings that were wrong on the
+# day: any shell block that extracts ci-wait.py out of origin/main must extract
+# agent_self_freshness.py too, or it hands the reader a copy that exits 3.
+_rule = os.path.join(HERE, os.pardir, ".claude", "rules", "ci-verdicts.md")
+_rule_text = open(_rule).read() if os.path.exists(_rule) else ""
+_blocks = _rule_text.split("```")[1::2]  # the fenced blocks only
+_extracting = [b for b in _blocks if "tools/ci-wait.py" in b and "git show" in b]
+check("ci-verdicts.md still shows how to run origin/main's copy",
+      len(_extracting) >= 1, f"{len(_extracting)} extraction block(s)")
+check("...and every such recipe extracts the freshness helper alongside it",
+      all("agent_self_freshness.py" in b for b in _extracting),
+      "\n---\n".join(b for b in _extracting if "agent_self_freshness.py" not in b))
+
 
 print()
 if FAILURES:


### PR DESCRIPTION
Closes #3294
Closes #3295

Two defects in `tools/ci-wait.py`, folded into one PR because they are the same file and the same class of failure: a state the tool reads as "not finished yet" when it is not, and a state it reads as "safe to answer" when it is not.

## Defect 1 - a concluded check run that never says `completed`

A check run can report `status=in_progress` together with a `conclusion` and a `completed_at`. On PR #3234:

```
name=PR body closing references must be correct, both directions
id=101566184213  status=in_progress  conclusion=success  completed_at=2026-09-06T22:01:46Z
```

`classify()` counted progress with `status == "completed"`, so that run was never counted as done and the poll could not terminate - `12/13 complete, 0 failing` across four calls over roughly 40 minutes, while the rollup rendered the same entry `SUCCESS` and the merge was available.

A non-null `conclusion` is GitHub's own statement that the run is over. New `has_concluded()` reads the conclusion first and falls back to `status` only when there is none, so **a run with no conclusion is still unfinished** and every in-flight guard keeps working.

The progress line now names what it is waiting on, capped at six names. `12/13` says how many and never which, which is what turned a one-line diagnosis into a long one.

## Defect 2 - the staleness guard answered when it could not check

When `tools/agent_self_freshness.py` could not be imported, the guard printed a note ending "Answering anyway" and judged the PR. So the condition under which the running copy is most likely to be unusual - a copy sitting somewhere with no `tools/` beside it - was exactly the condition under which nothing checked it. The note went to stdout beside the verdict, where a caller reading only the exit code never saw it.

It now exits 3, the code that already means "no verdict, do not act", the same treatment the narrowed-required-context path gets.

`.claude/rules/ci-verdicts.md` recommended the one-file extraction that reached that path, so the recipe now extracts both files. Verified working: the two-file version reaches a real verdict.

## Fixing the shape, not the reported line

**1. Does the same wrong pattern appear at another call site?** Yes - four more, all reading `status == "completed"`: `rollup_is_final`, `superseding_runs`, `supersession`, and the undiscounted red-X list in `classify`. All five now share `has_concluded()`. A workflow run stuck the same way wedges the poll just as thoroughly, since `superseding_runs` and `supersession` both treat "not completed" as "can still overturn this", and each has its own test here.

**2. Does a sibling function make the same assumption?** Yes, and it is the reason this is one PR rather than a one-line change. It is also true of the freshness guard: `assess()` fails open a second way, returning `Freshness("unknown", refuse=False)` outside a git repository. Measured, not inferred - the fixed tool still printed `GREEN on 207adb70 - all 13 required checks passed` from a scratch directory with nothing having checked the running code.

**I did not change that**, deliberately: `Freshness` documents `"unknown"` as not-refused and gives a reason, and the state is shared with `pr-body.py` and `preflight.py`, so flipping it changes three tools at once. Filed as #3296 with the measurement and a proposed shape, and the doc says plainly that the recipe relies on provenance rather than on a check.

**3. If two code paths write the same state, do they maintain the same invariant?** They do now. Before this, the check-run path and the workflow-run path disagreed about what "finished" means, which is the whole defect.

## Guards deliberately untouched

The `floor <= set(contexts)` check and the newest-run-per-name resolution are both unchanged - I did not need to touch either, and the new tests assert the guards they protect still hold. Negative tests pin the direction that matters: a run with **no** conclusion is still not a verdict, in `classify`, `rollup_is_final`, `superseding_runs` and `supersession`.

## Tests

RED first, per defect. Before the fix: 14 failing checks, `classify` reporting `11/12 complete, 0 failing` with no verdict - the issue's `12/13` shape - and the subprocess test crashing with `FileNotFoundError: 'gh'`, proving the old code reached GitHub with the safety check skipped.

`tools/test_ci_wait.py`: **114 -> 139 checks**. Suite total across `tools/test_*.py`: **585 -> 610**, all green.

```
tools/test_agent_self_freshness.py: 44   (unchanged)
tools/test_ci_wait.py:             139   (was 114)
tools/test_pr_body.py:             150   (unchanged)
tools/test_preflight.py:           277   (unchanged)
```

The end-to-end test copies `ci-wait.py` alone into a scratch directory with `PATH` emptied, so exit 3 also proves no GitHub call was made. The doc assertion is an invariant, not a blocklist of the two spellings that were wrong today: any fenced block extracting `ci-wait.py` from `origin/main` must extract `agent_self_freshness.py` too.

## Corpus

Nothing owed upstream. This is runner tooling and asserts nothing about Business Central, so there is no BC-behavior claim for a service tier to adjudicate. No submodule pin move, no `CHANGELOG.md`.

`AlRunner/` is untouched, so the `Tests updated` gate does not trigger; `tools/ unit tests` is the context that covers this change, and it runs on every PR.

---

Opened by the impl-1 agent on the account holder's behalf.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
