### PR TITLE
docs(weights): correct why AlOutputCacheDoNotCacheTests is recorded at 64s

### DIFF
--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -120,10 +120,18 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
             // #3262: 8 tests, most spawning a real runner subprocess, several of them twice
             // (a cold write then a warm read from a fresh server process, so the in-process
             // module cache cannot answer instead of the disk). Absent from this table on its
-            // first CI run: measured 64.2s on the BC 28.4 leg, which tripped
-            // check-collection-weights.py. Rounded down per the gate's own instruction; at
-            // 64.2s it sits far enough above the 60s freshness threshold that rounding down
-            // does not leave it back on the fallback the way a 60.9s entry would.
+            // first CI run: measured 64.2s on the BC 28.4 leg, one leg only, which is the
+            // ceiling of that claim rather than a settled figure.
+            //
+            // Recorded at 64, rounded down. The reason is #2175's dispatch-order rule, NOT
+            // the freshness gate: check-collection-weights.py only inspects collections
+            // ABSENT from this table, so once a key is present no recorded value can make
+            // that gate fire on it. What a too-low value would cost is dispatch order --
+            // record something near UnmeasuredWeightSeconds (30) and the collection is
+            // scheduled as if it were still absent, which is the #1887 tail this table
+            // exists to prevent. 64 is far enough above 30 that rounding down cannot do
+            // that. That is also the real reason the two 60.9s entries below carry their
+            // observed maximum: their LOW end across legs approaches 30, not 60.
             ["AlOutputCacheDoNotCacheTests"] = 64,
             // perf/boot-overhead: added with the on-disk install-baseline tier. Measured
             // 125.6s on the first CI run of that branch (BC 28.4 leg), where it was absent


### PR DESCRIPTION
A comment-only correction to a comment I wrote in #3276. The recorded value stays at 64; only the reasoning changes.

## What was wrong

The comment said rounding 64.2 down to 64 was safe because the value sits "far enough above the 60s freshness threshold that rounding down does not leave it back on the fallback the way a 60.9s entry would." Two errors, both verified in the source rather than argued:

**1. The gate cannot fire on an entry that is present, at any value.** `scripts/check-collection-weights.py:174`:

```python
if cls not in table and secs >= threshold_seconds
```

It only inspects collections **absent** from the table. Once `["AlOutputCacheDoNotCacheTests"]` is a key, no recorded value re-trips it — not 64, not 60, not 1. The script's own header states this ("Deliberately NOT checking drift on entries that ARE already present in the table"). So the mechanism the comment invoked does not exist, and the same is true of the 60.9s entries it cited for support.

**2. The failing band is 75s, not 60s.** `.github/workflows/bc-tests.yml:552` passes `--fail-threshold 75` (2.5x), moved there by #3110. The 60s figure came from the failing log that prompted the entry — run `34064485786`, which predated #3110 landing. Under the gate as it stands, a 64.2s absent collection is an advisory annotation, not a failed leg.

## What is actually true

The reason a too-low value would matter is #2175's dispatch-order rule, recorded in this file's own header: record something near `UnmeasuredWeightSeconds` (30) and the collection is dispatched as if it were still absent, which is the #1887 single-threaded tail the table exists to prevent. 64 is far enough above 30 that rounding down cannot do that.

That is also the real reason the two 60.9s entries carry their observed maximum — their **low end across legs** approaches 30, not 60. The corrected comment says that, so the next person adding an entry gets the rule that applies rather than one that reads plausibly and is not enforced anywhere.

The comment now also records that 64.2s is a **single-leg sample** (BC 28.4 only), which is the ceiling of the claim. Every neighbour carrying an observed maximum earned it by being measured across legs with a wide range; this one has not been.

## Why no test

No behavior changes — this is prose inside a dictionary initializer, and the recorded integer is untouched. `CollectionCostOrdererTests` passes 9/9 unchanged, and the build is clean. There is nothing here for a test to assert that the existing nine do not already cover.

Corpus-NA: a comment in a C# test-ordering table. It asserts nothing about Business Central, so no service tier can adjudicate it.

Found by a reviewer I asked to check my own commit adversarially rather than defer to it, which is the only reason it surfaced.

Opened by the coordinator agent on the account holder's behalf.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf

No linked issue: this corrects the reasoning in a code comment I wrote in #3276. No behavior changes and the recorded value is unchanged, so there is no gap to track — the correction is the whole deliverable.
