### PR TITLE
ci(corpus-pin): make a misconfigured SUBMODULE_PATH loud, and correct the #3181 provenance claim

### DIFF
--- a/.github/scripts/check_corpus_pin_forward.sh
+++ b/.github/scripts/check_corpus_pin_forward.sh
@@ -27,12 +27,43 @@
 #     exactly the older revision. The tests that would have gone red are the
 #     ones being removed.
 #
-# Caught for real on PR #3181, which was green and CLEAN while about to drop
-# corpus #199 and #201. That PR did nothing wrong: it bumped the pin forward
-# from the main that existed when it was written, and main's pin advanced
-# afterwards. Nothing rebased it and nothing told it to. That is why this is a
-# guard rather than a note in a rules file -- it is a merge-order accident, not
-# an authoring mistake, and it gets likelier as more agents run in parallel.
+# The shape is a merge-order accident, not an authoring mistake: a PR bumps the
+# pin forward from the main that existed when it was written, main's pin advances
+# afterwards, and nothing rebases it or tells it to. That is why this is a guard
+# rather than a note in a rules file, and it gets likelier as more agents run in
+# parallel.
+#
+# WHAT THIS GUARD ACTUALLY MEASURES, AND WHAT IT DOES NOT
+# -------------------------------------------------------
+# An earlier version of this header said the shape was "caught for real on PR
+# #3181, green and CLEAN while about to drop corpus #199 and #201". That was
+# wrong, and it is corrected here rather than quietly deleted, because the
+# measurement behind it is the honest statement of this guard's reach:
+#
+#   * #3181's base.sha was c0fda77e (2026-09-06T23:03:32Z) and its head pin was
+#     7394c15f. c0fda77e's pin is b0c6248a, and b0c6248a IS an ancestor of
+#     7394c15f -- a strictly forward bump. At #3181's first commit (6cbdfff5)
+#     the pin was b0c6248a, identical to base, which is the untouched case.
+#     So this guard would have PASSED #3181 at every revision it ever had.
+#   * Corpus #199 (b0c6248) and #201 (ae64da1) are both ANCESTORS of b0c6248a,
+#     so they were pinned at #3181's base and still pinned at its head. Nothing
+#     was about to drop them.
+#   * main's pin has only ever moved forward: 6e198a97 -> b0c6248a -> 7394c15f.
+#
+# The real limitation is narrower than that claim and worth stating plainly.
+# BASE_SHA comes from github.event.pull_request.base.sha, which is frozen at the
+# pull request's last event and does NOT follow the base branch. Measured on this
+# repository: #3181's base.sha stayed c0fda77e while main advanced to 9fe2b1d2 at
+# 23:29Z, and it did not move; pull requests touched after 23:29Z carried the
+# newer base. So the verdict is point-in-time -- it compares against the base as
+# of the PR's last event, not against main as of the merge.
+#
+# `edited` and `labeled` are in pr-gate.yml's trigger list, so setting
+# `status: review-ready` re-fires this job against a fresher base. That narrows
+# the window; it does not close it. A pin that was forward when the check last
+# ran can still be behind main by the time the merge button is pressed, and this
+# guard will not say so. Closing that would need a re-check at merge time
+# (a merge queue, or a push-triggered job on main), which is not what this is.
 #
 # THE FOUR VERDICTS, AND WHY THERE ARE FOUR RATHER THAN THREE
 # -----------------------------------------------------------
@@ -157,8 +188,35 @@ read_pin() {
 base_pin="$(read_pin "$BASE_SHA")" || base_pin=""
 head_pin="$(read_pin "$HEAD_SHA")" || head_pin=""
 
+# Declared submodule paths at either endpoint, one per line, read from the
+# committed .gitmodules rather than from the working tree.
+declared_submodule_paths() {
+  local rev
+  for rev in "$HEAD_SHA" "$BASE_SHA"; do
+    git show "$rev:.gitmodules" 2>/dev/null \
+      | sed -n 's/^[[:space:]]*path[[:space:]]*=[[:space:]]*//p'
+  done | sed 's/[[:space:]]*$//' | sort -u | sed '/^$/d'
+}
+
 if [ -z "$base_pin" ] && [ -z "$head_pin" ]; then
-  echo "Neither $BASE_SHA nor $HEAD_SHA carries a $SUBMODULE_PATH submodule; there is no corpus pin to compare."
+  # "No pin at either endpoint" has two very different causes, and passing on
+  # both is how this guard would stop guarding without anyone noticing.
+  #
+  # SUBMODULE_PATH is a HARDCODED default. Nothing ties it to what .gitmodules
+  # actually declares, so renaming the submodule -- or mistyping the default --
+  # lands here, prints "there is no corpus pin to compare", exits 0, and passes
+  # every pull request forever while reporting a green tick. That is the
+  # green-run-that-measured-nothing failure this script spends a whole exit code
+  # (3) refusing to commit elsewhere; it must not commit it here either.
+  #
+  # So: if either endpoint declares submodules at all and SUBMODULE_PATH is not
+  # among them, the configuration is wrong and no verdict is available. Only a
+  # repository that genuinely declares no such submodule passes.
+  declared="$(declared_submodule_paths)"
+  if [ -n "$declared" ] && ! printf '%s\n' "$declared" | command grep -qxF "$SUBMODULE_PATH"; then
+    die_undetermined "SUBMODULE_PATH is '$SUBMODULE_PATH', which neither $BASE_SHA nor $HEAD_SHA declares as a submodule. They do declare: $(printf '%s' "$declared" | tr '\n' ' '). This is a CONFIGURATION problem, not a verdict about the pin: with a path that matches no submodule this guard would find no pin at either endpoint and pass every pull request. Fix SUBMODULE_PATH, or the default in this script, to name the corpus submodule."
+  fi
+  echo "Neither $BASE_SHA nor $HEAD_SHA carries a $SUBMODULE_PATH submodule, and neither declares it in .gitmodules; there is no corpus pin to compare."
   exit 0
 fi
 

--- a/.github/scripts/test_check_corpus_pin_forward.sh
+++ b/.github/scripts/test_check_corpus_pin_forward.sh
@@ -89,7 +89,16 @@ trap 'rm -rf "$TMP"' EXIT
 #             D1            a divergent branch, no ancestry either way with C2
 #
 # C1 stands for the pin main carried when a PR branched; C2 for the pin main
-# carries now. The #3181 shape is head=C1, base=C2.
+# carries now. The BACKWARD-PIN shape is head=C1, base=C2 -- a PR still carrying
+# the older pin while its base has advanced.
+#
+# This shape is NOT attributed to a specific pull request here. An earlier
+# version of these fixtures and of the script header named PR #3181 as the case
+# "caught for real"; that was measured and found to be wrong -- #3181's pin moved
+# strictly forward at every revision it had, and corpus #199 and #201 were
+# ancestors of its base pin throughout. check_corpus_pin_forward.sh's header
+# carries the full measurement. The shape below is still exactly the defect the
+# guard exists for; it just has no real-world instance to point at yet.
 
 CORPUS="$TMP/corpus"
 git init -q -b master "$CORPUS"
@@ -101,11 +110,11 @@ git -C "$CORPUS" add -A && git -C "$CORPUS" commit -qm "C0: corpus root"
 C0=$(git -C "$CORPUS" rev-parse HEAD)
 
 echo t1 >> "$CORPUS/spec.al"
-git -C "$CORPUS" commit -qam "C1: pin CalcFields on FlowFields (#199)"
+git -C "$CORPUS" commit -qam "C1: an earlier corpus commit"
 C1=$(git -C "$CORPUS" rev-parse HEAD)
 
 echo t2 >> "$CORPUS/spec.al"
-git -C "$CORPUS" commit -qam "C2: pin Subtype = Install reads back as Normal (#201)"
+git -C "$CORPUS" commit -qam "C2: a later corpus commit"
 C2=$(git -C "$CORPUS" rev-parse HEAD)
 
 git -C "$CORPUS" checkout -q -b divergent "$C1"
@@ -129,6 +138,9 @@ git -C "$SUPER" config protocol.file.allow always
 mkdir -p "$SUPER/tests"
 echo "runner" > "$SUPER/README.md"
 git -C "$SUPER" add -A && git -C "$SUPER" commit -qm "super: root"
+# Captured BEFORE the submodule is added: an endpoint that predates the corpus
+# submodule entirely, which is the one shape that legitimately has no pin.
+SUPER_ROOT=$(git -C "$SUPER" rev-parse HEAD)
 
 # protocol.file.allow must be passed with -c on the command itself; setting it
 # in the repository config is NOT consulted for the submodule's own clone, which
@@ -165,7 +177,7 @@ pin_to() {
 }
 
 BASE_AT_C2=$(pin_to "$C2")     # main today: the newer pin
-HEAD_AT_C1=$(pin_to "$C1")     # a PR still carrying the older pin  -- the #3181 shape
+HEAD_AT_C1=$(pin_to "$C1")     # a PR still carrying the older pin -- the backward shape
 HEAD_AT_C2=$(pin_to "$C2")     # a PR that did not touch the pin
 HEAD_AT_D1=$(pin_to "$D1")     # a PR carrying a divergent corpus commit
 BASE_AT_C1=$(pin_to "$C1")     # main at the older pin, for the forward-bump case
@@ -184,16 +196,16 @@ assert_rc "a genuine forward bump passes" 0 \
   BASE_SHA="$BASE_AT_C1" HEAD_SHA="$HEAD_AT_C2"
 assert_output_has "a forward bump names the direction it verified" "ancestor"
 
-# The centre of the suite: #3181's real shape, reconstructed. The head pin is an
-# ancestor of the base pin, so merging it would un-pin every corpus commit in
-# between -- suites already validated against a real service tier.
-assert_rc "a BACKWARD pin fails (#3181's shape: head pin is an ancestor of base pin)" 1 \
+# The centre of the suite: the backward shape. The head pin is an ancestor of the
+# base pin, so merging it would un-pin every corpus commit in between -- suites
+# already validated against a real service tier.
+assert_rc "a BACKWARD pin fails (head pin is an ancestor of base pin)" 1 \
   BASE_SHA="$BASE_AT_C2" HEAD_SHA="$HEAD_AT_C1"
 assert_output_has "the backward failure is a GitHub error annotation" "::error::"
 # head=C1, base=C2, so the corpus commit that would be un-pinned is C2 -- the
 # one main reached and this PR's pin does not.
 assert_output_has "the backward failure names the corpus commit that would be dropped" \
-  "C2: pin Subtype = Install reads back as Normal (#201)"
+  "C2: a later corpus commit"
 
 assert_rc "a DIVERGENT pin fails (neither commit is an ancestor of the other)" 1 \
   BASE_SHA="$BASE_AT_C2" HEAD_SHA="$HEAD_AT_D1"
@@ -335,6 +347,52 @@ check_eq "an unset HEAD_SHA is a usage error, not a pass" "2" "$rc"
 rc=0
 (cd "$SUPER" && env -u BASE_SHA HEAD_SHA="$HEAD_AT_C1" bash "$SCRIPT" >/dev/null 2>&1) || rc=$?
 check_eq "an unset BASE_SHA is a usage error, not a pass" "2" "$rc"
+
+# --- A SUBMODULE_PATH naming nothing must not be a silent pass ---------------
+#
+# The "neither endpoint carries a submodule" branch prints "there is no corpus
+# pin to compare" and exits 0. That branch is reachable for a reason that has
+# nothing to do with the repository having no submodule: SUBMODULE_PATH defaults
+# to a HARDCODED string, and nothing tied that string to what .gitmodules
+# actually declares. Rename the submodule, or mistype the default, and the guard
+# passes every pull request forever while reporting a green tick -- the
+# green-run-that-measured-nothing shape this script's own header refuses
+# elsewhere by spending exit 3 on it.
+#
+# The endpoints below are the real backward-pin case, so a guard that is looking
+# at the right path answers 1. Anything that answers 0 here is answering about a
+# path it never found.
+assert_rc "a SUBMODULE_PATH that names no submodule is not a silent pass" 3 \
+  BASE_SHA="$BASE_AT_C2" HEAD_SHA="$HEAD_AT_C1" SUBMODULE_PATH="tests/nonexistent"
+assert_output_has "the misconfigured path is named in the message" "tests/nonexistent"
+
+# The mirror of the case above: a repository that genuinely declares no
+# submodule at either endpoint has no pin to compare and must still PASS. Without
+# this, hardening the misconfigured-path case would turn every pull request on a
+# submodule-free history into a hard error -- trading a silent never-fire for a
+# loud always-fire, which is not an improvement.
+assert_rc "an endpoint predating the submodule is still a legitimate pass" 0 \
+  BASE_SHA="$SUPER_ROOT" HEAD_SHA="$SUPER_ROOT"
+assert_output_has "the no-submodule pass says so" "there is no corpus pin to compare"
+
+# And the default really is the path this repository declares. The case above
+# proves a wrong path is loud; this proves the shipped default is not that wrong
+# path. Read out of .gitmodules rather than restated, so renaming the submodule
+# without updating the script fails here.
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+default_path="$(sed -n 's/^SUBMODULE_PATH="\${SUBMODULE_PATH:-\(.*\)}"$/\1/p' "$SCRIPT" | head -1)"
+check_eq "the script has a readable default SUBMODULE_PATH" "tests/al-language" "$default_path"
+
+if [ -f "$REPO_ROOT/.gitmodules" ]; then
+  if git config -f "$REPO_ROOT/.gitmodules" --get-regexp '^submodule\..*\.path$' \
+       | awk '{print $2}' | command grep -qxF "$default_path"; then
+    ok "the default SUBMODULE_PATH is a submodule this repository really declares"
+  else
+    bad "the default SUBMODULE_PATH ('$default_path') is not declared in .gitmodules -- the guard would find no pin and pass every PR"
+  fi
+else
+  bad "no .gitmodules at $REPO_ROOT, so the default SUBMODULE_PATH cannot be verified"
+fi
 
 # The verdict must depend on the endpoints, never on what happens to be checked
 # out -- this is the property that makes the refusals above meaningful.

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -219,11 +219,21 @@ jobs:
     # they stop existing, and the next green run reports success over a smaller
     # set.
     #
-    # Caught for real on PR #3181, green and CLEAN while about to drop corpus
-    # #199 and #201. That PR did nothing wrong: it bumped the pin forward from
-    # the main that existed when it was written, and main's pin advanced
-    # afterwards. It is a merge-order accident, which is why it needs a guard
-    # rather than a rule -- and it gets likelier as more agents run in parallel.
+    # The shape is a merge-order accident: a PR bumps the pin forward from the
+    # main that existed when it was written, and main's pin advances afterwards.
+    # Nothing rebases it. That is why it needs a guard rather than a rule, and it
+    # gets likelier as more agents run in parallel.
+    #
+    # THE VERDICT IS POINT-IN-TIME. BASE_SHA below is
+    # github.event.pull_request.base.sha, which is frozen at this PR's last event
+    # and does NOT follow the base branch. Measured: PR #3181's base.sha stayed
+    # c0fda77e while main advanced to 9fe2b1d2, and it did not move. `edited` and
+    # `labeled` are in this workflow's trigger list, so setting
+    # `status: review-ready` re-fires the job against a fresher base -- that
+    # narrows the window but does not close it. A pin forward at check time can
+    # still be behind main at merge time. check_corpus_pin_forward.sh's header
+    # has the full measurement, including why the "caught for real on #3181"
+    # claim this comment used to carry was wrong.
     #
     # It gates, so by the rule of thumb at the top of this file it must not be
     # able to fail for an environmental reason. Two things make that true, and


### PR DESCRIPTION
Closes #3299

Review follow-up on PR #3290, which merged before these could be folded into it. The comparison logic is unchanged — reviewers asked for it to stay as it is, and it does.

## 1. The silent never-fire path now has a test, and no longer fires silently

`check_corpus_pin_forward.sh` exited **0** when neither endpoint carried a `tests/al-language` gitlink. `SUBMODULE_PATH` defaults to a hardcoded string and nothing tied it to what `.gitmodules` declares, so renaming the submodule — or mistyping the default — would pass every pull request forever behind a green tick.

The branch now separates the two causes:

- either endpoint declares submodules and `SUBMODULE_PATH` is not among them → **exit 3**, naming the path and what is actually declared. A configuration problem, not a verdict.
- the repository genuinely declares no such submodule → still **exit 0**.

The second half is tested too, so this does not trade a silent never-fire for a loud always-fire on submodule-free history.

**RED → GREEN.** The new `SUBMODULE_PATH=tests/nonexistent` case reported `expected '3', got '0'` before the script change and passes after:

```
FAIL - a SUBMODULE_PATH that names no submodule is not a silent pass: expected '3', got '0'
passed: 38, failed: 1
```

**Suite count: 35 → 41, all green.** The whole `.github/scripts/` set is green alongside it (`test_check_corpus_linkage.sh` 64/64, `test_pr_changed_files.sh` 19/19, every other suite exit 0).

Two of the four new assertions are the ones that make the hardcoded default trustworthy: the default is read out of the script and compared against `.gitmodules`, so renaming the submodule without updating the script fails here rather than silently disabling the guard.

## 2. The "caught for real on PR #3181" claim was wrong, measurably

Review's point was that `BASE_SHA` is `github.event.pull_request.base.sha`, frozen at the PR's last event and not following the base branch, so the verdict is point-in-time. Confirmed on the live repository: **#3181's `base.sha` was `c0fda77e`** (23:03:32Z) while `main` advanced to `9fe2b1d2` at 23:29Z, and it did not move. `edited`/`labeled` are in the trigger list, so `status: review-ready` re-fires the job against a fresher base — that narrows the window, it does not close it. All of that is now written down.

While checking it I found the claim also fails on a more basic axis, so it is corrected rather than softened:

| measurement | value |
|---|---|
| #3181 base pin, at frozen base `c0fda77e` | `b0c6248a` |
| #3181 base pin, at live main `9fe2b1d2` | `b0c6248a` — the same |
| #3181 head pin | `7394c15f` |
| `b0c6248a` ancestor of `7394c15f`? | **yes — strictly forward** |
| #3181 pin at its first commit `6cbdfff5` | `b0c6248a` — unchanged from base |
| corpus #199 (`b0c6248`), #201 (`ae64da1`) | both ancestors of `b0c6248a` |
| `main`'s pin history | `6e198a97` → `b0c6248a` → `7394c15f`, monotonically forward |

So this guard would have **passed** #3181 at every revision it ever had, and #199 and #201 were pinned at its base and still pinned at its head. Nothing was about to drop them.

The script header, the `pr-gate.yml` comment and the test fixtures now state the real, narrower limitation, and the fixtures no longer attribute the backward shape to a pull request that never had it. The shape itself is still exactly the defect the guard exists for — it just has no real-world instance to point at yet, and saying so is more useful to the next reader than a citation that does not hold.

## Why this is a separate PR

#3290 merged as `c48a4925` about five minutes before this work started, so there was no open PR left to push these into.

---

*Opened by automated implementation agent `impl-2` on the account holder's behalf.*

Corpus-NA: CI guard and its unit tests only. Nothing here is AL-observable — the diff touches `.github/scripts/` and `.github/workflows/` and no runner code, so no corpus test can express it.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
