### PR TITLE
fix(jmphook): apply the disabled and Cecil-owned guards to InstallIndirect

### DIFF
--- a/AlRunner.Tests/JmpHookInstallIndirectGuardTests.cs
+++ b/AlRunner.Tests/JmpHookInstallIndirectGuardTests.cs
@@ -1,0 +1,198 @@
+using System.Reflection;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #3281 — <see cref="JmpHook.InstallIndirect"/> consulted NEITHER of the two guards
+/// <see cref="JmpHook.Apply"/> has, so it wrote a native precode patch on top of a method whose
+/// body a Cecil IL rewrite already owns, on a runtime where the whole JmpHook layer is supposed
+/// to be off.
+///
+/// The two guards, and why each matters here:
+///
+///   1. <c>_disabled</c> — the documented default is "Cecil-only on EVERY runtime (JmpHooks
+///      OFF)", because the native-precode parsing "is tuned to .NET 10's layout and SEGFAULTS
+///      on .NET 8 — which is BC28's REAL runtime". <c>Apply</c> honours that switch;
+///      <c>InstallIndirect</c> did not, so <c>AL_RUNNER_NO_JMPHOOK=1</c> did not actually
+///      disable every JmpHook and the escape hatch could not be used to bisect one.
+///
+///   2. <c>NclCecilRewrite.CecilOwned</c> — "a method migrated to a Cecil IL rewrite must be
+///      owned by EXACTLY ONE mechanism. Installing a JmpHook on top of the Cecil body recreates
+///      the coexistence double-dispatch spin." <c>Apply</c> checks the registry;
+///      <c>InstallIndirect</c> did not.
+///
+/// Those two facts met on <c>RecordImplementation.CalcFieldsAsync</c>. Both overloads are
+/// registered in <c>CecilOwned</c> (NclCecilRewrite.Records.cs), under a comment saying the keys
+/// are there "so FlowFieldPatches.Register's JmpHook.Apply fallback becomes a no-op" — but
+/// FlowFieldPatches.Register never reaches <c>Apply</c> for them. It calls
+/// <c>InstallIndirect</c> FIRST and only falls back to <c>Apply</c> when that returns false, so
+/// the guarded path was unreachable and the registration was inert for exactly the two methods
+/// it names.
+///
+/// It is also invisible: <c>Apply</c> records every skip into the orphaned/redundant sets that
+/// <c>AL_RUNNER_HOOK_AUDIT=1</c> prints, and <c>InstallIndirect</c> recorded nothing. Measured
+/// on the #3281 reproducer bundle, <c>CalcFieldsAsync/2</c> and <c>/3</c> appear in neither
+/// audit list while the runner is patching both — the audit that exists to make hook ownership
+/// measurable had its blind spot precisely where the double ownership was.
+///
+/// These tests pin the DECISION (a pure function over the same two inputs Apply uses), not the
+/// native memory write, for the same reason <see cref="JmpHookRegionSizeTests"/> pins the page
+/// arithmetic: the behavioural proof is a process kill, which is not CI-runnable.
+/// </summary>
+public class JmpHookInstallIndirectGuardTests
+{
+    // A real MethodBase/MethodInfo pair to hand the decision function. Nothing is patched --
+    // ClassifyIndirectInstall never touches native memory.
+    private static readonly MethodInfo SomeMethod =
+        typeof(JmpHookInstallIndirectGuardTests).GetMethod(
+            nameof(SampleTarget), BindingFlags.NonPublic | BindingFlags.Static)!;
+
+    private static void SampleTarget() { }
+
+    /// <summary>
+    /// Guard 1. With the JmpHook layer disabled -- the shipped default on every runtime -- an
+    /// indirect install must SKIP. Before the fix InstallIndirect ignored the switch entirely
+    /// and this returned <see cref="JmpHook.IndirectInstallDecision.Install"/>.
+    /// </summary>
+    [Fact]
+    public void WhenLayerDisabled_SkipsInsteadOfPatching()
+    {
+        var decision = JmpHook.ClassifyIndirectInstall(
+            SomeMethod, jmpHookDisabled: true, cecilOwnsTarget: false);
+
+        Assert.Equal(JmpHook.IndirectInstallDecision.SkipDisabled, decision);
+    }
+
+    /// <summary>
+    /// Guard 2. Even with the layer explicitly re-enabled (AL_RUNNER_ENABLE_JMPHOOK=1), a method
+    /// a Cecil rewrite already owns must not be patched a second time -- that is the coexistence
+    /// double-dispatch the CecilOwned registry exists to prevent. This is the assertion the
+    /// escape hatch makes load-bearing: it is the ONLY configuration in which the old code could
+    /// double-own a method, and it is exactly the configuration an agent reaches for when
+    /// bisecting.
+    /// </summary>
+    [Fact]
+    public void WhenCecilOwnsTheMethod_SkipsEvenWithLayerEnabled()
+    {
+        var decision = JmpHook.ClassifyIndirectInstall(
+            SomeMethod, jmpHookDisabled: false, cecilOwnsTarget: true);
+
+        Assert.Equal(JmpHook.IndirectInstallDecision.SkipCecilOwned, decision);
+    }
+
+    /// <summary>
+    /// The negative direction, and the reason neither assertion above is satisfied by an
+    /// implementation that just always skips: with the layer enabled and no Cecil owner, the
+    /// install must still proceed. A blanket "never install" would break every hook the escape
+    /// hatch exists to restore.
+    /// </summary>
+    [Fact]
+    public void WhenEnabledAndNotCecilOwned_StillInstalls()
+    {
+        var decision = JmpHook.ClassifyIndirectInstall(
+            SomeMethod, jmpHookDisabled: false, cecilOwnsTarget: false);
+
+        Assert.Equal(JmpHook.IndirectInstallDecision.Install, decision);
+    }
+
+    /// <summary>
+    /// Disabled AND Cecil-owned reports the disabled reason, matching Apply's ordering (its
+    /// <c>_disabled</c> branch runs first and classifies into redundant-vs-orphaned from there).
+    /// Pinned so the two mechanisms cannot drift on which reason they attribute a skip to.
+    /// </summary>
+    [Fact]
+    public void DisabledAndCecilOwned_ReportsDisabled_MatchingApplyOrdering()
+    {
+        var decision = JmpHook.ClassifyIndirectInstall(
+            SomeMethod, jmpHookDisabled: true, cecilOwnsTarget: true);
+
+        Assert.Equal(JmpHook.IndirectInstallDecision.SkipDisabled, decision);
+    }
+
+    /// <summary>
+    /// The call-site contract, which is where a naive fix goes wrong. FlowFieldPatches.Register
+    /// reads a <c>false</c> return as "the precode had a shape I could not patch" and falls back
+    /// to <see cref="JmpHook.Apply"/>. So a SKIP must report <c>true</c> -- "handled, do not fall
+    /// back" -- or the guard just reroutes the same install through the other entry point.
+    ///
+    /// Returning false for a skip would leave the observable behaviour of #3281 completely
+    /// unchanged while looking like a fix, which is why this is asserted separately from the
+    /// classification above.
+    /// </summary>
+    [Fact]
+    public void ASkipReportsHandled_SoTheCallerDoesNotFallBackToApply()
+    {
+        const string why =
+            "a skipped indirect install must return true, or FlowFieldPatches.Register falls "
+            + "back to JmpHook.Apply and the native patch lands anyway";
+
+        Assert.True(
+            JmpHook.IndirectInstallReportsHandled(JmpHook.IndirectInstallDecision.SkipDisabled), why);
+        Assert.True(
+            JmpHook.IndirectInstallReportsHandled(JmpHook.IndirectInstallDecision.SkipCecilOwned), why);
+    }
+
+    /// <summary>
+    /// And the converse: only a real install reports handled-via-patching. Without this the
+    /// theory above is satisfied by a function returning true unconditionally.
+    /// </summary>
+    [Fact]
+    public void AnInstallAlsoReportsHandled_ButIsADistinctDecision()
+    {
+        Assert.True(JmpHook.IndirectInstallReportsHandled(JmpHook.IndirectInstallDecision.Install));
+        Assert.NotEqual(JmpHook.IndirectInstallDecision.Install,
+            JmpHook.IndirectInstallDecision.SkipDisabled);
+        Assert.NotEqual(JmpHook.IndirectInstallDecision.Install,
+            JmpHook.IndirectInstallDecision.SkipCecilOwned);
+    }
+
+    /// <summary>
+    /// The registry fact the whole defect rests on: both CalcFieldsAsync overloads really are
+    /// Cecil-owned, so guard 2 really does fire for them. If someone ever removes those keys,
+    /// this fails and names the reason rather than silently re-opening the double-ownership.
+    /// </summary>
+    [Theory]
+    [InlineData("Microsoft.Dynamics.Nav.Runtime.RecordImplementation::CalcFieldsAsync/2")]
+    [InlineData("Microsoft.Dynamics.Nav.Runtime.RecordImplementation::CalcFieldsAsync/3")]
+    public void BothCalcFieldsAsyncOverloads_AreCecilOwned(string key)
+    {
+        Assert.Contains(key, NclCecilRewrite.CecilOwned);
+    }
+
+    /// <summary>
+    /// A skipped indirect install must be VISIBLE to <c>AL_RUNNER_HOOK_AUDIT=1</c>, the way a
+    /// skipped <c>Apply</c> already is. The audit's entire purpose is that hook ownership be
+    /// measurable rather than invisible; InstallIndirect recorded nothing, so on the #3281
+    /// bundle these two methods appeared in neither the orphaned nor the redundant list while
+    /// the runner was in fact patching both.
+    /// </summary>
+    [Fact]
+    public void ASkippedIndirectInstall_IsRecordedForTheHookAudit()
+    {
+        var label = "AuditProbe.InstallIndirect/" + Guid.NewGuid().ToString("N");
+
+        JmpHook.RecordIndirectInstallSkip(
+            JmpHook.IndirectInstallDecision.SkipCecilOwned, SomeMethod, label);
+
+        Assert.Contains(JmpHook.RedundantHooks, e => e.Contains(label, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The other audit bucket, and the one that carries real information: a target owned by
+    /// NEITHER mechanism is an orphan -- the patch is supposed to act and silently does not.
+    /// Recording it as "redundant" instead would file a live gap under "safe to delete".
+    /// </summary>
+    [Fact]
+    public void ADisabledSkipOfANonCecilTarget_IsRecordedAsOrphanedNotRedundant()
+    {
+        var label = "AuditProbe.InstallIndirect.Orphan/" + Guid.NewGuid().ToString("N");
+
+        JmpHook.RecordIndirectInstallSkip(
+            JmpHook.IndirectInstallDecision.SkipDisabled, SomeMethod, label);
+
+        Assert.Contains(JmpHook.OrphanedHooks, e => e.Contains(label, StringComparison.Ordinal));
+        Assert.DoesNotContain(JmpHook.RedundantHooks, e => e.Contains(label, StringComparison.Ordinal));
+    }
+}

--- a/AlRunner/Infrastructure/JmpHook.cs
+++ b/AlRunner/Infrastructure/JmpHook.cs
@@ -132,6 +132,92 @@ internal static class JmpHook
     /// <summary>Clears the orphan audit (test seam).</summary>
     public static void ResetOrphanAudit() { _orphaned.Clear(); _redundant.Clear(); }
 
+    // ── #3281: InstallIndirect's guards, as a pure decision ──────────────────────────
+    //
+    // InstallIndirect used to consult NEITHER guard Apply has. It called
+    // RuntimeHelpers.PrepareMethod and went straight to patching the indirection cell, so:
+    //
+    //   * the documented default ("Cecil-only on EVERY runtime, JmpHooks OFF" — see
+    //     ComputeDisabled above) did not hold for any of its three call sites, and
+    //     AL_RUNNER_NO_JMPHOOK=1 could not turn one off; and
+    //   * a method already owned by a Cecil IL rewrite got a second, native owner — the
+    //     "coexistence double-dispatch" the CecilOwned registry exists to prevent.
+    //
+    // Both applied at once to RecordImplementation.CalcFieldsAsync/2 and /3. Their bodies are
+    // Cecil-rewritten (NclCecilRewrite.Records.cs) AND their keys are in CecilOwned, under a
+    // comment saying the keys are there "so FlowFieldPatches.Register's JmpHook.Apply fallback
+    // becomes a no-op" — but Register tries InstallIndirect FIRST and only falls back to Apply
+    // when it returns false, so the guarded path was unreachable and the registration was inert
+    // for exactly the two methods it names.
+    //
+    // The decision is a pure function of the same two inputs Apply branches on, so the guard is
+    // unit-testable without patching native memory — same approach as PageRoundedRegionSize.
+    public enum IndirectInstallDecision
+    {
+        /// <summary>Patch the indirection cell.</summary>
+        Install,
+        /// <summary>The JmpHook layer is off (the shipped default on every runtime).</summary>
+        SkipDisabled,
+        /// <summary>A Cecil IL rewrite already owns this method's body.</summary>
+        SkipCecilOwned,
+    }
+
+    /// <summary>
+    /// Whether an indirect install should proceed. Mirrors <see cref="Apply"/>'s branch order:
+    /// the disabled check runs first, so a target that is both disabled and Cecil-owned reports
+    /// <see cref="IndirectInstallDecision.SkipDisabled"/> — matching how Apply attributes the
+    /// same situation, so the two mechanisms cannot drift on the reason they give.
+    /// </summary>
+    public static IndirectInstallDecision ClassifyIndirectInstall(
+        MethodBase original, bool jmpHookDisabled, bool cecilOwnsTarget)
+    {
+        if (jmpHookDisabled) return IndirectInstallDecision.SkipDisabled;
+        if (cecilOwnsTarget) return IndirectInstallDecision.SkipCecilOwned;
+        return IndirectInstallDecision.Install;
+    }
+
+    /// <summary>
+    /// What <see cref="InstallIndirect"/> returns for a decision. Every decision reports
+    /// <c>true</c> — "handled, do not fall back". Its callers spell the fallback
+    /// <c>if (!InstallIndirect(...)) Apply(...)</c>, where <c>false</c> means "this precode
+    /// shape was not patchable, try the other mechanism". Returning <c>false</c> for a
+    /// deliberate skip would hand the refused install straight to <see cref="Apply"/>.
+    /// </summary>
+    public static bool IndirectInstallReportsHandled(IndirectInstallDecision decision) => true;
+
+    /// <summary>
+    /// Files a skipped indirect install into the same audit buckets <see cref="Apply"/> uses, so
+    /// <c>AL_RUNNER_HOOK_AUDIT=1</c> can see it. Before #3281 InstallIndirect recorded nothing:
+    /// on the reproducer bundle both CalcFieldsAsync overloads appeared in NEITHER audit list
+    /// while the runner was patching both, which is the blind spot that let the double ownership
+    /// sit unnoticed. Cecil-owned ⇒ redundant (provably inert, safe to delete); anything else
+    /// ⇒ orphaned (a patch that is supposed to act and silently does not).
+    /// </summary>
+    public static void RecordIndirectInstallSkip(
+        IndirectInstallDecision decision, MethodBase original, string label)
+    {
+        if (decision == IndirectInstallDecision.Install) return;
+        string key;
+        try { key = NclCecilRewrite.Key(original); } catch { key = "<unresolvable-key>"; }
+        var entry = $"{label}  [{key}]";
+        if (decision == IndirectInstallDecision.SkipCecilOwned || NclCecilRewrite.CecilOwned.Contains(key))
+            _redundant.TryAdd(entry, 0);
+        else
+            _orphaned.TryAdd(entry, 0);
+    }
+
+    /// <summary>
+    /// Whether a Cecil IL rewrite owns this method's body. Never throws: an unresolvable key is
+    /// answered "not owned", which is the conservative side for the disabled-layer default
+    /// (the run is Cecil-only anyway) and keeps a reflection quirk from turning into a crash
+    /// inside patch install.
+    /// </summary>
+    private static bool NclCecilRewriteOwns(MethodBase original)
+    {
+        try { return NclCecilRewrite.CecilOwned.Contains(NclCecilRewrite.Key(original)); }
+        catch { return false; }
+    }
+
     private static readonly bool _audit =
         Environment.GetEnvironmentVariable("AL_RUNNER_HOOK_AUDIT") == "1";
 
@@ -281,6 +367,24 @@ internal static class JmpHook
     /// </returns>
     public static bool InstallIndirect(MethodBase original, MethodInfo replacement, string label)
     {
+        // #3281 — the two guards Apply has, which this entry point used to skip entirely.
+        // Without them InstallIndirect wrote a native precode patch on top of a Cecil-rewritten
+        // body, on a runtime where the whole JmpHook layer is supposed to be off. See
+        // ClassifyIndirectInstall for the full reasoning and for why a skip returns TRUE.
+        var decision = ClassifyIndirectInstall(original, _disabled,
+            NclCecilRewriteOwns(original));
+        if (decision != IndirectInstallDecision.Install)
+        {
+            LastAttempt = label;
+            RecordIndirectInstallSkip(decision, original, label);
+            if (_trace)
+                TraceLine($"[JmpHook.InstallIndirect] SKIP ({decision}) {label}");
+            // TRUE, not false: the caller's `if (!InstallIndirect(...)) Apply(...)` reads false
+            // as "that precode shape was unpatchable, try the other mechanism", which would
+            // route the very install this guard just refused straight into Apply.
+            return true;
+        }
+
         RuntimeHelpers.PrepareMethod(original.MethodHandle);
         RuntimeHelpers.PrepareMethod(replacement.MethodHandle);
 


### PR DESCRIPTION
Closes #3281

*Opened by agent `stma-auto-1` (automated implementation agent).*

## What is wrong

`JmpHook.InstallIndirect` consulted **neither** of the two guards `JmpHook.Apply` has, and went
straight to `RuntimeHelpers.PrepareMethod` + patching the indirection cell:

1. **`_disabled`** — the documented default is "Cecil-only on EVERY runtime (JmpHooks OFF)",
   because the native-precode parsing "is tuned to .NET 10's layout and SEGFAULTS on .NET 8 —
   which is BC28's REAL runtime". `Apply` honours it; `InstallIndirect` did not. So
   `AL_RUNNER_NO_JMPHOOK=1` did not in fact disable every JmpHook, and the escape hatch could
   not be used to bisect one.
2. **`NclCecilRewrite.CecilOwned`** — "a method migrated to a Cecil IL rewrite must be owned by
   EXACTLY ONE mechanism. Installing a JmpHook on top of the Cecil body recreates the
   coexistence double-dispatch spin." `Apply` checks the registry; `InstallIndirect` did not.

Both applied at once to `RecordImplementation.CalcFieldsAsync/2` and `/3` — the two frames the
issue's stack trace names. Their bodies are Cecil-rewritten in
`NclCecilRewrite.Records.cs`, **and** their keys are registered in `CecilOwned`, under a comment
saying the keys are there

> so `FlowFieldPatches.Register`'s `JmpHook.Apply` fallback becomes a no-op

but `Register` never reaches `Apply` for them. It spells the install
`if (!JmpHook.InstallIndirect(...)) JmpHook.Apply(...)` — `InstallIndirect` is tried **first**
and succeeds, so the guarded path was unreachable and the `CecilOwned` registration was inert
for exactly the two methods it names. The runner installed the native precode patch on top of
the Cecil-rewritten body.

It was also invisible. `Apply` records every skip into the orphaned/redundant sets that
`AL_RUNNER_HOOK_AUDIT=1` prints; `InstallIndirect` recorded nothing. Measured on the reproducer
bundle before this change, `CalcFieldsAsync/2` and `/3` appear in **neither** audit list while
the runner is patching both — the audit that exists to make hook ownership measurable had its
blind spot precisely where the double ownership was.

## The fix

The guard is inside `InstallIndirect`, so all three call sites get it. The decision is a pure
function of the same two inputs `Apply` branches on (`ClassifyIndirectInstall`), mirroring
`PageRoundedRegionSize` — unit-testable without patching native memory, since the behavioural
proof is a process kill and is not CI-runnable.

Two details a reviewer should check, because getting either wrong makes the fix look applied
and change nothing:

- **A skip returns `true`, not `false`.** The callers read `false` as "that precode shape was
  not patchable, try the other mechanism", so returning `false` for a deliberate skip would
  route the refused install straight into `Apply`.
- **Branch order matches `Apply`.** Disabled is checked first, so a target that is both disabled
  and Cecil-owned reports the disabled reason — the two mechanisms cannot drift on the reason
  they attribute a skip to. Pinned by a test.

## RED → GREEN

RED: the new suite fails at compile (`CS0426`/`CS0117` — `IndirectInstallDecision` does not
exist), because the decision had no seam to assert on at all.

GREEN: 24 passed in `--filter FullyQualifiedName~JmpHook` (10 new + the 14 existing
`JmpHookRegionSizeTests`).

Behavioural proof, on the reproducer bundle from
`AlRunner.Tests/QueryFlowFieldFlowFilterTests.WriteBundle()` with `AL_RUNNER_HOOK_AUDIT=1`:

| | before | after |
|---|---|---|
| redundant registrations | 5 | **7** |
| `CalcFieldsAsync/2`, `/3` | in neither audit list, natively patched | `REDUNDANT` (Cecil owns them), not patched |

The tests must **prove**: `WhenEnabledAndNotCecilOwned_StillInstalls` is why a blanket
"never install" does not satisfy the suite, and
`ASkipReportsHandled_SoTheCallerDoesNotFallBackToApply` is why returning `false` does not.
Nothing here swallows an exception — the change removes a redundant native write, it does not
suppress a failure.

## Measurements

All on BC 28.1.49838.53910, Linux, `--package-cache ~/.al-runner/platform-apps`.

| run | result |
|---|---|
| corpus `tests/al-language/tests/al-language`, **cold** | 2689/2689 pass, 0 fail, 0 error |
| corpus, **warm** (cache HIT, AL emit 0.0s) | 2689/2689 pass, 0 fail, 0 error |
| reproducer bundle, cold then 4× warm | 6P/0F/0E every run, exit 0 |
| `--filter ~JmpHook\|~FlowField\|~Cecil\|~QueryFlowField\|~Hook` | 65 passed, 0 failed, 16 skipped |

Cold **and** warm were run for every corpus measurement, per
`.claude/rules/local-test-scope.md` — a warm second run is the exception that rule names, and
this issue is exactly that case.

## What I could NOT reproduce, stated plainly

**I never made the process kill happen on Linux, before or after the change.** The reporter
measured 8/8 warm on Windows 11; I ran the same bundle cold-then-warm many times on Linux with
`al-out`, `ncl-cecil` and `r2r-chunks` cleared and in every combination, and got 6P/0F/0E and
exit 0 every time, with `[cache] HIT ... skipping Emit+Compile` confirmed under `--verbose`.

So **the warm runs above are not my RED.** My RED is the compile failure of the new suite, and
the evidence for the diagnosis is static plus the audit measurement, not a reproduced crash.
What that evidence establishes:

- The double ownership is real, is on `RecordImplementation.CalcFieldsAsync/2` and `/3`
  specifically, and those are the exact two frames in the reported stack.
- The repository's own code says this shape is dangerous, in the comment on `Apply`'s
  `CecilOwned` check and in `NclCecilRewrite.Records.cs`'s note about the "COEXISTENCE
  double-dispatch double-dispatch spin". It is the documented hazard, not one I inferred.
- `JmpHook`'s own header says the native-precode layer "SEGFAULTS on .NET 8 — which is BC28's
  REAL runtime", which fits a fatal-error exit through the CLR's own path rather than an AL
  failure, and fits being platform-dependent.

What it does **not** establish is the causal link from the double patch to
`0x80131506` on Windows specifically, or why a warm cache is the trigger. A reviewer should read
this as "removes a documented-dangerous double ownership on the exact methods that crashed",
not as "reproduced the crash and made it stop". If the crash recurs on Windows after this
merges, the diagnosis was incomplete and the issue should be reopened rather than the fix
reverted — the double ownership is worth removing regardless.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — three `InstallIndirect` call sites, all
   unguarded. Fixing inside `InstallIndirect` covers all three.
2. **Does a sibling function make the same assumption?** The reverse, and it is the sharpest
   instance: `AlRunner/Patches/EventPipeJitListener.cs` calls `JmpHook.Apply` at line 262 and
   then `JmpHook.InstallIndirect` at line 269 for the **same** method — so the guarded call
   correctly skipped while the unguarded one patched anyway. Now both skip. (That listener is
   off by default, behind `AL_RUNNER_JIT_LISTENER=1`.) The third site,
   `BcRuntime.ApplyInstallIndirectSpike`, is dead — its only caller is commented out.
3. **Two code paths writing the same state, same invariant?** No — that was the defect.
   `Apply` and `InstallIndirect` both install a native patch and only one enforced the
   ownership invariant. They now share `ClassifyIndirectInstall` and the same audit buckets.

## Queue scan

I scanned the open issues for `JmpHook`, `InstallIndirect`, `CecilOwned`, `FlowFieldPatches` and
`CalcFieldsAsync`. Nothing else lands in `AlRunner/Infrastructure/JmpHook.cs`, so there was
nothing to fold in per `.claude/rules/batch-sibling-issues-by-file.md`. This PR closes one issue.

## Deliberately left out

- **The misleading `[FlowFieldPatches] hooked ...` log lines.** `Register` prints "hooked" for
  both overloads whether or not anything was installed. Now that the install is a recorded skip
  the line is actively wrong, but rewording it touches `AlRunner/Patches/` and would pull this
  diff into the corpus-linkage scope for a cosmetic change. Worth a follow-up.
- **An install-baseline cache-key instability I noticed while diagnosing**, unrelated to this
  fix: the same bundle produced entry path `b37dab05…` on the cold run and `c6fbc6f5…` on the
  warm run. Neither persisted (`snapshot has 0 DataAccessSource(s)`), so it is inert today, but
  a key that moves between two runs of the same bundle is a latent cache-correctness bug. Not
  folded in — different file, different subsystem.
- **No `CacheVersion` bump.** This change touches no cache key and no cache-key input. It
  changes when a native precode patch is installed at runtime; the AL-output cache key hashes
  the runner assembly's content, so a rebuilt runner already re-keys every entry on its own.
  Per `BcAppSymbolCache.cs`'s rule, `CacheVersion` is for when the *parse* changed while the
  *shape* did not — neither happened here.
- **Corpus pin untouched** at `7394c15f`.

Corpus-NA: this changes when the runner installs a native precode patch over a Cecil-rewritten
body — a runner-internal patch-install mechanism with no AL-observable surface. The AL behaviour
on this path (FlowField `CalcFormula` with a `FlowFilter` where-condition) is already asserted
upstream by corpus PR #175, and both the cold and warm corpus runs above are 2689/2689
unchanged, which is the evidence that AL observes nothing different.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4