### PR TITLE
test(runner-extras): pin the source-parsed reader for a tableextension's TableRelation

### DIFF
--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -49,6 +49,7 @@
         "server-reload-dep": { "tests": 0 },
         "server-reload-main": { "tests": 1 },
         "session-user-row": { "tests": 4 },
+        "source-tableext-relation": { "tests": 5 },
         "standalone-suites": { "tests": 113 },
         "static-runmodal-record": { "tests": 5 },
         "table-connection-live-oos": { "tests": 2 },

--- a/tests/runner-extras/source-tableext-relation/StrAssert.Codeunit.al
+++ b/tests/runner-extras/source-tableext-relation/StrAssert.Codeunit.al
@@ -1,0 +1,28 @@
+// Standalone Assert — this suite does not import from tests/al-language.
+codeunit 65720 "STR Assert"
+{
+    procedure AreEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if Format(Expected) <> Format(Actual) then
+            Error('Expected %1 but got %2: %3', Format(Expected), Format(Actual), Msg);
+    end;
+
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error('Expected true: %1', Msg);
+    end;
+
+    // Asserts the last error text CONTAINS a fragment. Used instead of a bare `asserterror`,
+    // which would pass on any error at all — including one raised by the test's own setup.
+    procedure ExpectedError(Fragment: Text)
+    var
+        Actual: Text;
+    begin
+        Actual := GetLastErrorText();
+        if Actual = '' then
+            Error('Expected an error containing "%1" but no error was raised', Fragment);
+        if StrPos(Actual, Fragment) = 0 then
+            Error('Expected an error containing "%1" but got: %2', Fragment, Actual);
+    end;
+}

--- a/tests/runner-extras/source-tableext-relation/StrObjects.al
+++ b/tests/runner-extras/source-tableext-relation/StrObjects.al
@@ -1,0 +1,53 @@
+// The related table this bundle's tableextension points at. Compiled from AL SOURCE, so the
+// relation's TARGET is a source-parsed table while the relation's HOST is a precompiled one —
+// which is the crossing this bundle exists to pin.
+table 65721 "STR Related"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Code"; Code[20]) { DataClassification = CustomerContent; }
+    }
+
+    keys { key(PK; "Code") { Clustered = true; } }
+}
+
+// A SOURCE-PARSED tableextension on a PRECOMPILED base table (Job, 167, Base Application).
+//
+// The base table's metadata comes from BC's own precompiled metadata; these fields come from
+// RecordPatches.AlSourceParser's ParseFieldSyntax and are grafted on by MergeExtensionFields.
+// RelationArms has to survive that graft, and nothing asserted that it does.
+tableextension 65722 "STR Job Ext" extends Job
+{
+    fields
+    {
+        // The subject: a plain single-arm relation declared by a source-parsed extension.
+        // No OnValidate and no ValidateTableRelation, so the relation check is the only thing
+        // in Validate that can raise on it.
+        field(65723; "STR Ext Rel Code"; Code[20])
+        {
+            DataClassification = CustomerContent;
+            TableRelation = "STR Related"."Code";
+        }
+
+        // Control for the SECOND property: same shape, but ValidateTableRelation = false. A
+        // change that switched relation checking on wholesale rather than reading both
+        // properties makes this refuse a value real BC accepts — the inverse of #3286's
+        // reported symptom, and equally silent.
+        field(65724; "STR Ext Rel No Validate"; Code[20])
+        {
+            DataClassification = CustomerContent;
+            TableRelation = "STR Related"."Code";
+            ValidateTableRelation = false;
+        }
+
+        // Control: same extension, same type and length, NO TableRelation. This is what makes
+        // the refusal an assertion about the relation rather than about extension fields in
+        // general.
+        field(65725; "STR Ext No Rel"; Code[20])
+        {
+            DataClassification = CustomerContent;
+        }
+    }
+}

--- a/tests/runner-extras/source-tableext-relation/StrTests.Codeunit.al
+++ b/tests/runner-extras/source-tableext-relation/StrTests.Codeunit.al
@@ -1,0 +1,176 @@
+// Issue #3286 — a TableRelation a SOURCE-PARSED tableextension declares on a PRECOMPILED base
+// table must reach the extended table's metadata, so Validate enforces it.
+//
+// RUNNER-MECHANISM claim. That Validate enforces a tableextension-contributed TableRelation is
+// plain BC behaviour, and it is pinned upstream twice — corpus codeunit 60827 for a relation a
+// PRECOMPILED tableextension contributes (corpus #207, the case PR #3197 fixed), and corpus
+// codeunit 60407 for one the corpus itself DECLARES on a Base Application table (corpus #222).
+// Neither can reach the crossing this bundle pins.
+//
+// THE CROSSING. Two independent readers produce a field's RelationArms:
+//
+//   * BcAppSymbolCache.TryParseTableExtensionSymbol — a PRECOMPILED tableextension's fields,
+//     re-parsed out of the package's SymbolReference.json. This is the reader #3177/#3197
+//     fixed; before that fix it dropped TableRelation for all 261 relation-bearing extension
+//     fields in the platform packages.
+//   * RecordPatches.AlSourceParser.ParseFieldSyntax — a SOURCE tableextension's fields.
+//
+// Both feed RecordPatches.MergeExtensionFields, which grafts the fields onto the extended
+// table. When the extended table is PRECOMPILED, the resulting metatable is built from BC's own
+// metadata with these parsed fields merged in, and RelationArms has to survive that graft.
+// Nothing asserted that it does: every corpus bundle is one app compiled as a whole, so a
+// corpus test cannot separate the two readers, and the runner-extras suite only covered the
+// precompiled reader (tests/runner-extras/precompiled-table-relation, #2528/#3197).
+//
+// WHY THIS BUNDLE EXISTS RATHER THAN A FIX. #3286 was filed as the source-parsed counterpart of
+// #3177, reporting that corpus codeunit 60827 fails on the runner. Measured on this tree, that
+// codeunit's subject — Customer 5900 "Service Zone Code" — is contributed by tableextension
+// 6450 "Serv. Customer" shipped INSIDE the Base Application package, so it exercises the
+// PRECOMPILED reader, and all five of its tests pass here. Reverting only #3197's
+// TryParseRelationArmsText call turns exactly that one test red and leaves every source-parsed
+// probe green, which is what identifies the reader. The source-parsed path was already correct;
+// what it lacked was a test, so a regression in it would have been silent in both suites.
+codeunit 65726 "STR Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit "STR Assert";
+
+    [Test]
+    procedure SourceTableExtRelation_OnPrecompiledBase_NoRelatedRow_Throws()
+    // CLAIM: Validate refuses a value with no row in the related table, for a relation a
+    // source-parsed tableextension declared on a precompiled base table.
+    var
+        Job: Record Job;
+    begin
+        Initialize();
+
+        // [GIVEN] No "STR Related" row carries this code.
+        Clear(Job);
+        Job.Init();
+
+        // [WHEN/THEN] Validating the extension-declared field with it is refused.
+        asserterror Job.Validate("STR Ext Rel Code", 'STRREL1');
+        Assert.ExpectedError('cannot be found in the related table');
+    end;
+
+    [Test]
+    procedure SourceTableExtRelation_OnPrecompiledBase_RelatedRowExists_AssignsTheValue()
+    // CLAIM: the SAME value the test above refused is accepted once the related row exists, so
+    // the refusal was the relation check and not a blanket rejection — and the relation
+    // resolved to the RIGHT related table, since a row anywhere else would not rescue it.
+    var
+        Job: Record Job;
+    begin
+        Initialize();
+
+        // [GIVEN] A "STR Related" row with exactly the code the previous test was refused.
+        InsertRelated('STRREL1');
+
+        // [WHEN] The extension-declared field is validated with it.
+        Clear(Job);
+        Job.Init();
+        Job.Validate("STR Ext Rel Code", 'STRREL1');
+
+        // [THEN] Validate succeeds and the field holds the value.
+        Assert.AreEqual(
+            'STRREL1', Job."STR Ext Rel Code",
+            'Validate must accept a value that exists in the table the source-parsed ' +
+            'tableextension''s TableRelation points at, and store it');
+    end;
+
+    [Test]
+    procedure SourceTableExtRelation_ValidateTableRelationFalse_IsNotChecked()
+    // CLAIM: the SECOND property survives the graft too. ValidateTableRelation = false turns the
+    // CHECK off while leaving the relation readable, so this field takes the very value the
+    // subject was refused. A change that switched relation checking on wholesale — rather than
+    // reading both properties — makes this refuse a value real BC accepts.
+    var
+        Job: Record Job;
+    begin
+        Initialize();
+
+        // [GIVEN] No "STR Related" row carries this code.
+        Clear(Job);
+        Job.Init();
+
+        // [WHEN] The ValidateTableRelation = false field is validated with it.
+        Job.Validate("STR Ext Rel No Validate", 'STRREL1');
+
+        // [THEN] Validate succeeds — the relation is present but not enforced.
+        Assert.AreEqual(
+            'STRREL1', Job."STR Ext Rel No Validate",
+            'ValidateTableRelation = false must suppress the check on a source-parsed ' +
+            'tableextension field, not the relation itself');
+    end;
+
+    [Test]
+    procedure SourceTableExtRelation_FieldWithNoRelation_SameValue_IsAccepted()
+    // CLAIM: control — a field the SAME extension adds with NO TableRelation takes that very
+    // value. So the refusal in the first test is the relation, not a blanket refusal of writes
+    // to fields a source-parsed tableextension added.
+    var
+        Job: Record Job;
+    begin
+        Initialize();
+
+        // [GIVEN] No "STR Related" row carries this code.
+        Clear(Job);
+        Job.Init();
+
+        // [WHEN] The relation-less field of the same extension is validated with it.
+        Job.Validate("STR Ext No Rel", 'STRREL1');
+
+        // [THEN] Validate succeeds — there is no relation to check.
+        Assert.AreEqual(
+            'STRREL1', Job."STR Ext No Rel",
+            'A source-parsed tableextension field with no TableRelation must accept any ' +
+            'value of its type');
+    end;
+
+    [Test]
+    procedure SourceTableExtRelation_DirectAssignment_IsNotChecked()
+    // CLAIM: a direct assignment bypasses the relation entirely, so the refusal in the first
+    // test is Validate's relation check — not the value, and not the field.
+    var
+        Job: Record Job;
+    begin
+        Initialize();
+
+        // [GIVEN] No "STR Related" row carries this code.
+        Clear(Job);
+        Job.Init();
+
+        // [WHEN] The value is assigned directly rather than validated.
+        Job."STR Ext Rel Code" := 'STRREL1';
+
+        // [THEN] The assignment stands — no relation check ran.
+        Assert.AreEqual(
+            'STRREL1', Job."STR Ext Rel Code",
+            'A direct assignment must not consult the source-parsed tableextension''s ' +
+            'TableRelation');
+    end;
+
+    local procedure Initialize()
+    var
+        Related: Record "STR Related";
+    begin
+        // "STR Related" belongs to this bundle alone, so a blanket DeleteAll is safe here —
+        // unlike the corpus counterpart, whose related table is shared with other codeunits.
+        // No Job row is ever written (Init() plus Validate() is the whole scenario), so none
+        // has to be removed.
+        Related.Reset();
+        Related.DeleteAll(false);
+    end;
+
+    local procedure InsertRelated(RelatedCode: Code[20])
+    var
+        Related: Record "STR Related";
+    begin
+        Related.Init();
+        Related."Code" := RelatedCode;
+        Related.Insert(false);
+    end;
+}

--- a/tests/runner-extras/source-tableext-relation/app.json
+++ b/tests/runner-extras/source-tableext-relation/app.json
@@ -1,0 +1,26 @@
+{
+  "id": "b4e17c39-5a26-4d80-91f3-7c8ea2b0d5f6",
+  "name": "Runner Extras - Source TableExt Relation",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Issue #3286: a TableRelation a SOURCE-PARSED tableextension declares on a PRECOMPILED base table must reach the extended table's metadata, so Validate enforces it.",
+  "description": "Runner-mechanism claim, not a claim about AL. That a tableextension's TableRelation is enforced by Validate is plain BC behaviour and is pinned upstream twice: corpus codeunit 60827 for a relation a PRECOMPILED tableextension contributes, and corpus codeunit 60407 for one this corpus DECLARES on a Base Application table. What neither can reach is the crossing this bundle exercises -- an extension the runner source-parses grafted onto a base table it never source-parsed, where RecordPatches.MergeExtensionFields has to carry RelationArms from the AL-source reader into a metatable built from BC's own precompiled metadata. A corpus bundle is one app compiled as a whole, so it cannot separate the two readers; only a runner bundle can.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "idRanges": [
+    {
+      "from": 65720,
+      "to": 65739
+    }
+  ],
+  "platform": "27.0.0.0",
+  "application": "27.0.0.0",
+  "runtime": "17.0",
+  "target": "Cloud",
+  "features": []
+}


### PR DESCRIPTION
Closes #3286

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/222

## The finding: this is not the same bug as #3177, and it is not a bug

#3286 was filed as the **source-parsed** counterpart of #3177/#3197 (the **precompiled** reader). Measured on this tree, there is no source-parsed defect — and the reproducer the issue names measures the *other* reader, the one #3197 already fixed.

The issue's reproducer is corpus codeunit `60827`, subject `Customer` 5900 `"Service Zone Code"`. That field is contributed by tableextension 6450 `"Serv. Customer"`, which ships **inside the Base Application package**, so it goes through `BcAppSymbolCache.TryParseTableExtensionSymbol` — not through the AL-source parser. The corpus declares no tableextension on `Customer` at all, and across every tableextension the corpus declares in AL (60024, 60025, 60205, 60390) **none declares a `TableRelation` of any kind**. The corpus test's own header says so too: "contributed by tableextension 6450 ... shipped INSIDE the Base Application package".

All five of codeunit 60827's tests pass on `origin/main` today.

PR #3289 independently reached the same conclusion while bumping the pin — it attributes codeunit 60827 to PR #3197 and correctly declines to add a known-gap entry, noting #3286 was "filed as #3286 from this branch before that was known".

## Evidence: the two readers separated

Not inferred from the symptom. Each reader was disabled in turn and both suites run (BC 28.1):

| reader disabled | this bundle (source) | corpus 60827 (precompiled) |
|---|---|---|
| `ParseRelationArms` (AL source) | **FAIL** | PASS |
| `TryParseRelationArmsText` (precompiled, = pre-#3197) | PASS | **FAIL** |

Each suite detects exactly its own reader. That symmetry is what identifies the path.

Three further source-parsed probes were run against a pre-#3197 build and all stayed green — source extension on a source base, source extension on a precompiled base, and a `where(... = const(...))`-filtered relation contributed from source. The source path handles every shape tried.

## What was genuinely missing

A test. `tests/runner-extras/precompiled-table-relation`'s header *asserts* that "the AL-source parser has carried RelationArms for a long time" with nothing pinning it. A regression in that reader would have been silent in both suites — the same silent-acceptance shape #3286 describes, just not present yet.

This bundle pins the crossing neither existing suite reaches: a **source-parsed tableextension on a precompiled base table** (`Job`, 167), where `RecordPatches.MergeExtensionFields` carries `RelationArms` from the AL-source reader into a metatable built from BC's own precompiled metadata. A corpus bundle is one app compiled as a whole, so it cannot separate the two readers; only a runner bundle can.

Five tests: refused with no related row; accepted once the row exists (which also pins that the relation resolved to the right table); a `ValidateTableRelation = false` field taking that same value (the second property, whose loss is the *inverse* silent wrongness — refusing values real BC accepts); a relation-less control field of the same extension; and a direct assignment not being checked.

## The upstream half

The BC-behaviour claim — "a `TableRelation` a tableextension **declares** is enforced by `Validate`" — went upstream as corpus PR #222, since the corpus pinned only the precompiled-contributed half (#207) and declared no relation on any of its own tableextensions. Its four tests are green on the runner and were confirmed non-vacuous by commenting the relation out. Its CI adjudicates the claim against a real service tier; I do not merge it.

## Sibling scan

`.claude/rules/batch-sibling-issues-by-file.md` — nothing folded, and here is why:

- **#2789** (follow-ups to precompiled `TableRelation`: conditional arms, rename cascade, name-only target resolution) — lands in `ParseRelationArms`/`BuildMetaFieldRelations`, and every refusal there is already **loud** (`[TableRelation] REFUSED ...` on stderr). Different change, different reasoning.
- **#2876** (`ALTRelationWhereField` cannot detect a swapped `where(... = field(...))` role) — a corpus-fixture design issue, no runner file.
- **#2383** (Config. Template Line default not checked against the target's `TableRelation`) — RapidStart, `AlRunner/Patches/` elsewhere.
- **#3263 / #3178 / #3279** — held by open PR #3289, which touches `RecordPatches.NclMetaTableBuilder.cs`, `FlowFieldPatches.cs` and `RecordPatches.cs`. This PR touches **no** `AlRunner/` file, so there is no conflict in either direction.
- **#3204** (corpus has no test that a tableextension-contributed relation is enforced) — satisfied by corpus #207 already; corpus #222 extends it to the declared half. Deliberately **not** closed here: it is a corpus-side tracker and closing it is not this PR's call.

## What I deliberately left out

- **No runner code change**, because no defect was found. Fixing something here would have been an assumption-based change against a measurement that says otherwise.
- **No pin bump.** `tests/al-language` stays at `7394c15f`, verified on the committed tree. Corpus #222's tests are therefore not yet consumed here; they will arrive with whichever PR next moves the pin.
- **No `history.md` entry** — `tests/expectations/count-baseline/README.md` says a runner-extras change usually needs none when the group entry is self-explanatory, and skipping it avoids the three-way conflicts that file has attracted.

## Verification

- New bundle: 5/5 pass, and 1/5 fails with the source reader disabled (the RED).
- Full `tests/runner-extras`: **344/344, exit 0**, run exactly as `bc-tests.yml` does (`--strict --count-baseline`), on BC 28.1.49838.53910.
- Corpus codeunit 60827: 5/5 pass unchanged.
- Diff touches no `AlRunner/` file, so `require-tests` does not fire.

Opened by agent `stma-auto-2` (automated implementation agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4