### PR TITLE
fix(page-metadata): answer the nine SourceObject columns from BC's own parsed metadata

### DIFF
--- a/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
+++ b/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
@@ -1207,13 +1207,39 @@ public class DependencyPageMetadataXmlTests
     }
 
     /// <summary>
-    /// A view with a <c>where(...)</c> and no <c>sorting(...)</c>/<c>order(...)</c> gets no
-    /// <c>&lt;Sorting&gt;</c> element: ApplySourceTableView reads that element only through
-    /// its two <c>*SetByView</c> flags, so one with neither set can do nothing, and 178 of
-    /// Base Application 28.1's 386 SourceTableView pages declare sorting at all.
+    /// A view with a <c>where(...)</c> and no <c>sorting(...)</c>/<c>order(...)</c> STILL gets
+    /// a <c>&lt;Sorting&gt;</c> element — empty, with both <c>*SetByView</c> flags off (#3063).
+    ///
+    /// <para>THIS ASSERTION USED TO SAY THE OPPOSITE, and the reasoning it carried was true
+    /// about the wrong consumer. It read: "ApplySourceTableView reads that element only
+    /// through its two <c>*SetByView</c> flags, so one with neither set can do nothing."
+    /// Correct — and <c>ApplySourceTableView</c> is not the only thing that reads the view.
+    /// BC's own <c>PageDataProvider.GenerateSourceTableViewString</c>, which renders Page
+    /// Metadata's <c>SourceTableView</c> column (field 15), opens with</para>
+    /// <code>
+    /// if (view == null || view.Sorting == null) return NavText.Empty;
+    /// </code>
+    /// <para>so a <c>MetaViewDefinition</c> carrying real <c>TableFilters</c> and a null
+    /// <c>Sorting</c> formats as the empty string: the WHERE segment is never reached and the
+    /// whole view is discarded. Page Metadata therefore reported "this page declares no view"
+    /// for a page that declares one — measured on Base Application 1710 "Deferral Lines -
+    /// G/L", whose <c>where("Deferral Doc. Type" = const("G/L"))</c> read back empty. Across
+    /// this machine's platform .apps, 211 of the 417 pages carrying a SourceTableView declare
+    /// a where with no sorting, so this was the majority case rather than a corner.</para>
+    ///
+    /// <para>The real AL compiler writes the element unconditionally, and writes it EMPTY for
+    /// a page declaring only a where — verified with <c>AL_RUNNER_TRACE_PAGE_METADATA=2</c> on
+    /// a source-compiled page declaring <c>SourceTableView = where("Kind Code" = const('X'))</c>:
+    /// <c>&lt;Sorting KeyFields="" KeyFieldsSetByView="0" AscendingSetByView="0" Ascending="1" /&gt;</c>.
+    /// Those exact attribute values are asserted below, so the two page origins produce the
+    /// same document rather than merely a working one.</para>
+    ///
+    /// <para>Nothing about the old claim's own consumer changes: both <c>*SetByView</c> flags
+    /// are still off, so <c>ApplySourceTableView</c> still applies no ordering the page did not
+    /// declare. The element only stops the filters being thrown away.</para>
     /// </summary>
     [Fact]
-    public void TryBuildDependencyPageMetadata_SourceTableViewWithoutSorting_EmitsFiltersButNoSortingElement()
+    public void TryBuildDependencyPageMetadata_SourceTableViewWithoutSorting_EmitsEmptySortingSoTheFiltersSurvive()
     {
         var dir = TestScratch.Dir("al-runner-dep-pagemeta-xml-tests");
         Directory.CreateDirectory(dir);
@@ -1226,7 +1252,21 @@ public class DependencyPageMetadataXmlTests
             var view = (XmlElement?)sourceObject.SelectSingleNode("m:SourceTableView", ns);
             Assert.NotNull(view);
 
-            Assert.Null(view!.SelectSingleNode("m:Sorting", ns));
+            // The element is PRESENT — the whole point. A null Sorting is what
+            // GenerateSourceTableViewString bails on, so its absence silently voids the
+            // filters asserted below.
+            var sorting = (XmlElement?)view!.SelectSingleNode("m:Sorting", ns);
+            Assert.NotNull(sorting);
+
+            // ...and empty, in the compiler's own spelling. KeyFieldsSetByView="0" is what
+            // keeps this from imposing an order the page never declared, so it is asserted
+            // rather than assumed: this test must not be satisfiable by an implementation
+            // that fabricated a key.
+            Assert.Equal(string.Empty, sorting!.GetAttribute("KeyFields"));
+            Assert.Equal("0", sorting.GetAttribute("KeyFieldsSetByView"));
+            Assert.Equal("0", sorting.GetAttribute("AscendingSetByView"));
+            Assert.Equal("1", sorting.GetAttribute("Ascending"));
+
             var filter = (XmlElement)view.SelectSingleNode("m:TableFilters", ns)!;
             Assert.Equal("2", filter.GetAttribute("FieldID"));
             Assert.Equal("CONST", filter.GetAttribute("FilterType"));
@@ -1420,7 +1460,12 @@ public class DependencyPageMetadataXmlTests
             Assert.Equal("1", sorting.GetAttribute("KeyFieldsSetByView"));
 
             // The view states no order(), so ApplySourceTableView must not touch ALAscending.
-            Assert.Equal("", sorting.GetAttribute("AscendingSetByView"));
+            // The flag is written "0" rather than left absent since #3063: the two mean the
+            // same thing to BC, and "0" is what the real AL compiler writes for a page
+            // declaring no order() (measured with AL_RUNNER_TRACE_PAGE_METADATA=2), so the
+            // two page origins produce the same document. What this assertion is about is
+            // that the flag is OFF, which is unchanged — it is emphatically not "1".
+            Assert.Equal("0", sorting.GetAttribute("AscendingSetByView"));
         }
         finally
         {

--- a/AlRunner.Tests/PageMetadataSourceObjectRefusalTests.cs
+++ b/AlRunner.Tests/PageMetadataSourceObjectRefusalTests.cs
@@ -1,0 +1,84 @@
+// PageMetadataSourceObjectRefusalTests — pins the runner-only half of issue #3063:
+// what RecordPatches.GetPageSourceObject does when it CANNOT read a page's <SourceObject>.
+//
+// What this proves, and what it deliberately does NOT
+// -----------------------------------------------------
+// The BC-observable claim — that Page Metadata (2000000138) reports a page's declared
+// SourceTableView / DelayedInsert / ShowFilter / MultipleNewLines / SaveValues /
+// AutoSplitKey / DataCaptionFields / LinksAllowed / PopulateAllFields rather than the
+// column's type default — is plain BC behaviour and belongs upstream against a real service
+// tier (.claude/rules/bc-behavior-tests-go-upstream.md). It is proved there, in corpus
+// codeunit 60993 "Test Page Metadata Src Object".
+//
+// This file pins the narrower runner-only claim underneath it, which no service tier can
+// adjudicate because real BC never lacks the metadata: when the runner has no loadable page
+// metadata for a page, the nine columns must REFUSE rather than quietly answer BC's default.
+// That distinction is the whole point of the issue — the defect being fixed was a silent
+// wrong answer, and replacing it with a *different* silent wrong answer would be no fix at
+// all (.claude/rules/loud-failures.md).
+//
+// The refusal also has to carry the "not-yet-implemented" anchor, or
+// ApplicationObjectBasePatches.IsPermanentOutOfScope classifies it as permanently out of
+// scope and an AL [TryFunction] traps it into `false` — turning the loud failure back into
+// the silent one, one layer up. That is asserted, not assumed.
+
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class PageMetadataSourceObjectRefusalTests
+{
+    // An id no fixture, no dependency .app and no corpus page declares, so
+    // EnsureRealPageMetadata genuinely has nothing to load for it. Deliberately far from the
+    // 88123xxx block DependencyPageMetadataXmlTests uses and from every 6xxxx corpus range.
+    private const int PageNoRunnerMetadataFor = 77451903;
+
+    [Fact]
+    public void GetPageSourceObject_PageWithNoLoadableMetadata_ThrowsInsteadOfAnsweringBcDefaults()
+    {
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
+            () => RecordPatches.GetPageSourceObject(PageNoRunnerMetadataFor));
+
+        // The page has to be named, or the refusal cannot be acted on: "some page's
+        // SourceObject could not be read" is not a diagnosis.
+        Assert.Contains(PageNoRunnerMetadataFor.ToString(), ex.Message);
+
+        // The refusal must say the surface is unimplemented, NOT permanently out of scope.
+        // IsPermanentOutOfScope treats any reason that does not start with
+        // "not-yet-implemented" as permanent, and an AL [TryFunction] over a permanent
+        // refusal yields `false` — which would restore the silent wrong answer this whole
+        // change removes.
+        Assert.StartsWith("not-yet-implemented", ex.Reason);
+        Assert.Contains("page-metadata-virtual-table", ex.Reason);
+
+        // And it must name what could not be answered, so the reader knows which columns are
+        // affected rather than only that something failed.
+        Assert.Contains("SourceTableView", ex.Message);
+        Assert.Contains("DataCaptionFields", ex.Message);
+    }
+
+    [Fact]
+    public void PageSourceObjectInfoNone_MatchesWhatBcsOwnProviderAnswersForAPageWithNoSourceObject()
+    {
+        // A page declaring no SourceTable carries no <SourceObject> element at all, and BC's
+        // own PageDataProvider reads all nine columns off it as
+        // `metaSourceObjectDefinition?.X ?? false` (or NavText.Empty for the two text
+        // columns). So THAT case is a real answer rather than a gap, and this pins the value
+        // it answers with — the one place in this change where a default is legitimate, so
+        // the one place it must be stated explicitly rather than fallen into.
+        var none = RecordPatches.PageSourceObjectInfo.None;
+
+        Assert.False(none.Declared);
+        Assert.Equal(string.Empty, none.SourceTableView);
+        Assert.Equal(string.Empty, none.DataCaptionFields);
+        Assert.False(none.DelayedInsert);
+        Assert.False(none.ShowFilter);
+        Assert.False(none.MultipleNewLines);
+        Assert.False(none.SaveValues);
+        Assert.False(none.AutoSplitKey);
+        Assert.False(none.LinksAllowed);
+        Assert.False(none.PopulateAllFields);
+    }
+}

--- a/AlRunner/Patches/DependencyPageMetadataXml.cs
+++ b/AlRunner/Patches/DependencyPageMetadataXml.cs
@@ -553,7 +553,34 @@ public static partial class RecordPatches
     {
         w.WriteStartElement("SourceTableView");
 
-        if (view.SortingFields.Count > 0 || view.Ascending.HasValue)
+        // <Sorting> IS UNCONDITIONAL, and the "only when the page declares sorting" version of
+        // this guard silently discarded the WHOLE view for half the pages that have one
+        // (#3063). BC's own PageDataProvider.GenerateSourceTableViewString opens with
+        //
+        //     if (view == null || view.Sorting == null) return NavText.Empty;
+        //
+        // so a MetaViewDefinition with real TableFilters and a null Sorting formats as the
+        // empty string — the WHERE segment is never reached. The runner emitted exactly that
+        // document for any page declaring `where(...)` and no `sorting(...)`, so Page Metadata
+        // reported "this page declares no view" for a page that declares one. Measured across
+        // this machine's platform .apps: 211 of the 417 pages carrying a SourceTableView
+        // declare a where with no sorting, Base Application 1710 "Deferral Lines - G/L"
+        // (`where("Deferral Doc. Type" = const("G/L"))`) among them.
+        //
+        // The real AL compiler always writes the element, and for a page declaring only a
+        // where it writes it EMPTY — verified with AL_RUNNER_TRACE_PAGE_METADATA=2 on a
+        // source-compiled page declaring `SourceTableView = where("Kind Code" = const('X'))`:
+        //
+        //     <SourceTableView>
+        //       <Sorting KeyFields="" KeyFieldsSetByView="0" AscendingSetByView="0" Ascending="1" />
+        //       <TableFilters FilterGroup="2" FieldID="3" FilterType="CONST" FilterValue="X" />
+        //     </SourceTableView>
+        //
+        // Those are the attribute values written below when the page declares no sorting, so
+        // the two page origins produce the same document rather than merely a working one:
+        // KeyFields absent, both SetByView flags off, Ascending on. BC reads KeyFields only
+        // when KeyFieldsSetByView says to, so an unconditional element adds no ordering the
+        // page did not declare — it only stops the filters being thrown away.
         {
             var keyFieldIds = new List<string>(view.SortingFields.Count);
             var unresolved = false;
@@ -600,10 +627,27 @@ public static partial class RecordPatches
                     + string.Join(", ", view.SortingFields.Select(f => f.FieldName))
                     + $") not applied — a field name did not resolve against table {page.SourceTableId}");
             }
+            else
+            {
+                // No sorting declared. The compiler still writes both attributes, empty and
+                // off; matching it keeps the two page origins byte-identical here, and BC
+                // ignores KeyFields entirely while KeyFieldsSetByView is "0".
+                w.WriteAttributeString("KeyFields", string.Empty);
+                w.WriteAttributeString("KeyFieldsSetByView", "0");
+            }
             if (view.Ascending.HasValue)
             {
                 w.WriteAttributeString("AscendingSetByView", "1");
                 w.WriteAttributeString("Ascending", view.Ascending.Value ? "1" : "0");
+            }
+            else
+            {
+                // The compiler's own shape for a page that declares no order(...): the flag
+                // off and Ascending nonetheless "1". Written rather than omitted so a page
+                // reached through a dependency .app and the same page compiled from source
+                // produce byte-identical <Sorting> attributes.
+                w.WriteAttributeString("AscendingSetByView", "0");
+                w.WriteAttributeString("Ascending", "1");
             }
             w.WriteEndElement(); // Sorting
         }

--- a/AlRunner/Patches/RecordPatches.PageMetadataSourceObject.cs
+++ b/AlRunner/Patches/RecordPatches.PageMetadataSourceObject.cs
@@ -138,9 +138,21 @@ public static partial class RecordPatches
         {
             if (_pmvViewFormatterResolved) return _pmvGenerateSourceTableViewString;
             var type = typeof(NCLMetadata).Assembly.GetType("Microsoft.Dynamics.Nav.Runtime.PageDataProvider");
-            _pmvGenerateSourceTableViewString = type?.GetMethod(
-                "GenerateSourceTableViewString",
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            // BcShape.FindMethod, not Type.GetMethod (#3069). A bare-name lookup throws
+            // AmbiguousMatchException the day Microsoft ships a second overload of this name,
+            // and MethodScopePatches.NavMethodScope_AssertError rethrows only
+            // BcShapeGapException and absorbs everything else — so that throw would be
+            // SWALLOWED under an AL `asserterror`, passing it on a call real BC performs fine.
+            // FindMethod refuses with the right type instead, and still answers null on
+            // absence, which ReadSourceTableView already turns into a named refusal.
+            _pmvGenerateSourceTableViewString = type == null ? null : BcShape.FindMethod(
+                type, "GenerateSourceTableViewString",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static,
+                "Page Metadata (virtual table 2000000138)",
+                "PageDataProvider.GenerateSourceTableViewString",
+                "it is how BC renders the SourceTableView column (field 15), so the runner "
+                + "cannot pick an overload on the page's behalf",
+                new[] { typeof(MetaViewDefinition) });
             _pmvViewFormatterResolved = true;
             return _pmvGenerateSourceTableViewString;
         }

--- a/AlRunner/Patches/RecordPatches.PageMetadataSourceObject.cs
+++ b/AlRunner/Patches/RecordPatches.PageMetadataSourceObject.cs
@@ -1,0 +1,238 @@
+// RecordPatches.PageMetadataSourceObject — the nine "Page Metadata" (2000000138) columns
+// that come off a page's <SourceObject>, read from BC's OWN parsed metadata (#3063).
+//
+// ── THE DEFECT ───────────────────────────────────────────────────────────────────────────
+//   BuildPageMetadataValue's switch answered 11 columns by name and let every other one
+//   fall through to NavValue.GetDefaultNavValue. Nine of the fall-throughs are values the
+//   page genuinely declares, so AL reading them got a plausible wrong answer rather than a
+//   refusal — the worst class here, because nothing looks broken. Measured on a
+//   source-compiled page declaring all of them (issue #3063 has the AL):
+//
+//     LinksAllowed=No ShowFilter=No SaveValues=No PopulateAllFields=No DataCaptionFields=[]
+//     AutoSplitKey=No DelayedInsert=No MultipleNewLines=No SourceTableView=[]
+//
+//   Six of those nine readings are wrong rather than merely absent; LinksAllowed and
+//   ShowFilter read right only because that fixture happens to declare `false`.
+//
+// ── WHERE THE VALUES COME FROM, AND WHY NOT FROM THE TWO OBVIOUS PLACES ──────────────────
+//   The issue proposed feeding these from the two row sources EnumerateKnownPageMetadata
+//   already walks — ParsedPage for source-compiled pages, BcAppSymbolCache.PageSymbol for
+//   pages in a precompiled dependency .app. That is not what this does, and the reason is
+//   the failure mode the issue itself names: "the table starts answering differently
+//   depending on where a page came from — which is worse than answering BC's default
+//   uniformly."
+//
+//   Feeding two independent parsers into one column set makes that outcome the DEFAULT.
+//   ParsedPage carries none of the nine (measured: RecordPatches.AlPageParser.cs mentions
+//   not one of them), so the source-parsed half would have to grow nine new AL-property
+//   parsers whose agreement with the symbol-file half is asserted by nobody. Worse, one of
+//   the nine cannot be parsed from AL source into the shape BC reports at all without a
+//   second resolution step: AL states `DataCaptionFields = "No.", Descr` — field NAMES —
+//   where Page Metadata reports field NUMBERS.
+//
+//   There is a third source that is neither of those and is strictly better than both: BC's
+//   OWN MetaSourceObjectDefinition, the object BC's real PageDataProvider reads these nine
+//   columns off on a service tier. Both page origins already converge on it:
+//
+//     * a source-compiled page — the REAL AL compiler emits the metadata XML, captured into
+//       AlPageMetadataRegistry, and it has already done the name→number resolution:
+//       `DataCaptionFields = "No.", Descr` on a page over table 65600 emits
+//       <SourceObject DataCaptionFields="1,2" ...>. Verified with
+//       AL_RUNNER_TRACE_PAGE_METADATA=2 on this machine.
+//     * a page in a precompiled dependency — DependencyPageMetadataXml reconstructs the same
+//       <SourceObject> element from SymbolReference.json (#2820/#2860 put all nine there).
+//
+//   EnsureRealPageMetadata (RecordPatches.RealPageMetadata.cs) already loads either one
+//   through BC's own NCLMetaForm.LoadMetadata(), and BC's own deserializer turns it into the
+//   MetaSourceObjectDefinition below. So this file parses nothing: it asks BC for the object
+//   BC would have read, and hands out what is on it. The two origins cannot disagree about
+//   these nine columns, because after the load there is only one object.
+//
+// ── SourceTableView IS BC'S OWN FORMATTER, NOT A REIMPLEMENTATION ────────────────────────
+//   Field 15 is not the AL text. BC formats it — SORTING(...) ORDER(1) WHERE(Field3=CONST(X))
+//   — with field NUMBERS, the filter type's own ToString(), and three conditional segments.
+//   PageDataProvider.GenerateSourceTableViewString is `public static` and is the exact method
+//   BC's provider calls, so it is invoked here rather than reimplemented. Every detail of
+//   that format (when SORTING appears, that ORDER carries the literal '1', the comma join)
+//   is then correct by construction instead of by a matching guess.
+//
+// ── WHAT IS REFUSED RATHER THAN DEFAULTED (loud-failures.md) ─────────────────────────────
+//   A page whose real metadata will not load has no MetaSourceObjectDefinition to read, and
+//   this file will NOT answer BC's default for it — that is the defect, one level down.
+//   PageMetadataSourceObjectGap names the page and the column. See TryGetPageSourceObject
+//   for the one case that is genuinely an answer rather than a gap: a page that declares no
+//   SourceTable at all has no <SourceObject>, and BC's own provider answers `?? false` /
+//   NavText.Empty for exactly that case — a null definition there is BC's answer, not ours.
+//
+// ── PRECOMPILED-DLL RESPECT ──────────────────────────────────────────────────────────────
+//   Runtime-engine and metadata types only (NCLMetaForm, MetaPageDefinition,
+//   MetaSourceObjectDefinition, PageDataProvider's own public static formatter). No AL
+//   business-logic body is touched, and nothing here re-implements a BC behaviour that BC
+//   itself is present to perform.
+using System.Reflection;
+using AlRunner.Infrastructure;
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types.Metadata;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    /// <summary>
+    /// A refusal for a Page Metadata column this file could not answer from BC's own parsed
+    /// metadata. Category (2) of RecordPatches.VirtualTableShapeGap.cs — in scope, real BC
+    /// answers it, the runner could not — so it carries the "not-yet-implemented" anchor and
+    /// an AL <c>[TryFunction]</c> does not trap it into <c>false</c>.
+    /// </summary>
+    internal static RunnerOutOfScopeException PageMetadataSourceObjectGap(int pageId, string column, string detail)
+        => PageMetadataShapeGap(
+            $"page {pageId} column \"{column}\": {detail} — refusing rather than answering "
+            + "BC's default, which would be a plausible wrong value for a property the page declares");
+
+    /// <summary>
+    /// The nine <c>&lt;SourceObject&gt;</c>-derived Page Metadata columns for one page, in the
+    /// representation the column carries — already formatted for
+    /// <see cref="PageSourceObjectInfo.SourceTableView"/>, already field NUMBERS for
+    /// <see cref="PageSourceObjectInfo.DataCaptionFields"/>.
+    ///
+    /// <para><see cref="Declared"/> is false for a page that declares no <c>SourceTable</c>:
+    /// such a page has no <c>&lt;SourceObject&gt;</c> element, and every value below is then
+    /// the same one BC's own provider produces from its <c>?? false</c> / <c>NavText.Empty</c>
+    /// arms. That is a real answer, not a gap — see <see cref="TryGetPageSourceObject"/>.</para>
+    /// </summary>
+    internal sealed record PageSourceObjectInfo(
+        bool Declared,
+        string SourceTableView,
+        bool DelayedInsert,
+        bool ShowFilter,
+        bool MultipleNewLines,
+        bool SaveValues,
+        bool AutoSplitKey,
+        string DataCaptionFields,
+        bool LinksAllowed,
+        bool PopulateAllFields)
+    {
+        /// <summary>What BC's own PageDataProvider produces for a page with no
+        /// <c>&lt;SourceObject&gt;</c> at all: every boolean <c>?? false</c>, both text
+        /// columns <c>NavText.Empty</c>.</summary>
+        internal static readonly PageSourceObjectInfo None =
+            new(false, string.Empty, false, false, false, false, false, string.Empty, false, false);
+    }
+
+    // Resolved once per process. PageDataProvider is `internal` in Ncl.dll, so its public
+    // static formatter is reached by reflection rather than by a direct call — the type, not
+    // the method, is what is inaccessible.
+    private static MethodInfo? _pmvGenerateSourceTableViewString;
+    private static bool _pmvViewFormatterResolved;
+    private static readonly object _pmvViewFormatterLock = new();
+
+    /// <summary>
+    /// BC's own <c>PageDataProvider.GenerateSourceTableViewString(MetaViewDefinition)</c> —
+    /// the method BC's real provider formats field 15 with. Null when the shape moved, which
+    /// <see cref="ReadSourceTableView"/> turns into a refusal rather than an empty string.
+    /// </summary>
+    private static MethodInfo? ResolveSourceTableViewFormatter()
+    {
+        if (_pmvViewFormatterResolved) return _pmvGenerateSourceTableViewString;
+        lock (_pmvViewFormatterLock)
+        {
+            if (_pmvViewFormatterResolved) return _pmvGenerateSourceTableViewString;
+            var type = typeof(NCLMetadata).Assembly.GetType("Microsoft.Dynamics.Nav.Runtime.PageDataProvider");
+            _pmvGenerateSourceTableViewString = type?.GetMethod(
+                "GenerateSourceTableViewString",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            _pmvViewFormatterResolved = true;
+            return _pmvGenerateSourceTableViewString;
+        }
+    }
+
+    /// <summary>
+    /// Format <paramref name="view"/> exactly as BC's own provider formats field 15.
+    /// A null view is BC's own <c>NavText.Empty</c> arm (its formatter returns empty for a
+    /// null view or a null Sorting), so it needs no refusal; a MISSING FORMATTER does, because
+    /// answering an empty string then would be indistinguishable from "this page declares no
+    /// view" for a page that declares one.
+    /// </summary>
+    private static string ReadSourceTableView(object? view, int pageId)
+    {
+        if (view == null) return string.Empty;
+        var formatter = ResolveSourceTableViewFormatter()
+            ?? throw PageMetadataSourceObjectGap(
+                pageId, "SourceTableView",
+                "BC's own PageDataProvider.GenerateSourceTableViewString could not be resolved");
+        return formatter.Invoke(null, new[] { view }) as string ?? string.Empty;
+    }
+
+    /// <summary>
+    /// The nine <c>&lt;SourceObject&gt;</c> columns for <paramref name="pageId"/>, read off
+    /// BC's own parsed page metadata — the same <c>MetaSourceObjectDefinition</c> BC's real
+    /// <c>PageDataProvider</c> reads them off.
+    ///
+    /// <para>Throws rather than defaulting when the page's real metadata will not load, since
+    /// a default here is a plausible wrong answer for a property the page declares. Returns
+    /// <see cref="PageSourceObjectInfo.None"/> — a real answer — for a page whose metadata
+    /// loads and states no <c>&lt;SourceObject&gt;</c>, which is what a page declaring no
+    /// SourceTable looks like and what BC itself answers <c>false</c>/empty for.</para>
+    /// </summary>
+    internal static PageSourceObjectInfo GetPageSourceObject(int pageId)
+    {
+        var meta = EnsureRealPageMetadata(pageId)
+            ?? throw PageMetadataSourceObjectGap(
+                pageId, "SourceObject properties",
+                "the runner has no loadable page metadata for this page, so its declared "
+                + "SourceTableView/DelayedInsert/ShowFilter/MultipleNewLines/SaveValues/"
+                + "AutoSplitKey/DataCaptionFields/LinksAllowed/PopulateAllFields cannot be read");
+
+        return TryGetPageSourceObject(meta, pageId);
+    }
+
+    /// <summary>
+    /// Read the nine columns off an already-loaded <c>NCLMetaForm</c>. Split out from
+    /// <see cref="GetPageSourceObject"/> so the metadata-load half and the read half fail
+    /// separately and say which of the two failed.
+    /// </summary>
+    private static PageSourceObjectInfo TryGetPageSourceObject(object meta, int pageId)
+    {
+        MetaPageDefinition? definition;
+        try
+        {
+            definition = (meta as NCLMetaForm)
+                ?.GetFrozenPageDefinitionWithExtensionWithoutMergedMultiLanguage().Item;
+        }
+        catch (Exception ex)
+        {
+            throw PageMetadataSourceObjectGap(
+                pageId, "SourceObject properties",
+                $"BC's own page definition could not be read ({ex.GetType().Name}: {ex.Message})");
+        }
+
+        if (definition == null)
+            throw PageMetadataSourceObjectGap(
+                pageId, "SourceObject properties",
+                "BC's own page definition is null even though the page's metadata loaded");
+
+        // A page that declares no SourceTable carries no <SourceObject>, and BC's own provider
+        // reads every one of these nine through `metaSourceObjectDefinition?.X ?? false` (or
+        // NavText.Empty). So null here is BC's ANSWER, not a gap — the one case in this file
+        // that is defaulted rather than refused, and it is defaulted to exactly what BC
+        // produces for it.
+        var sourceObject = definition.Properties?.SourceObject;
+        if (sourceObject == null) return PageSourceObjectInfo.None;
+
+        return new PageSourceObjectInfo(
+            Declared: true,
+            SourceTableView: ReadSourceTableView(sourceObject.SourceTableView, pageId),
+            DelayedInsert: sourceObject.DelayedInsert,
+            ShowFilter: sourceObject.ShowFilter,
+            MultipleNewLines: sourceObject.MultipleNewLines,
+            SaveValues: sourceObject.SaveValues,
+            AutoSplitKey: sourceObject.AutoSplitKey,
+            // BC reads this straight through as text; the AL compiler and the symbol file both
+            // already state it as the comma-separated FIELD NUMBER list the column carries, so
+            // there is nothing to resolve here (DependencyPageMetadataXml.IsFieldNumberList
+            // holds the symbol-file half to that shape before it ever reaches this point).
+            DataCaptionFields: sourceObject.DataCaptionFields ?? string.Empty,
+            LinksAllowed: sourceObject.LinksAllowed,
+            PopulateAllFields: sourceObject.PopulateAllFields);
+    }
+}

--- a/AlRunner/Patches/RecordPatches.PageMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.PageMetadataVirtualTable.cs
@@ -49,11 +49,25 @@
 //   disagree about which pages exist.
 //
 // COLUMNS NOT IMPLEMENTED
-//   Everything outside Id/Name/Caption/SourceTable/PageType/Editable/InsertAllowed/
-//   ModifyAllowed/DeleteAllowed/SourceTableTemporary/CardPageID (API*, DataCaptionExpr.,
-//   DelayedInsert, …) gets BC's own NavValue.GetDefaultNavValue for that column's type —
-//   the same "declares none of them" default a real row carries for a page that states
-//   nothing about them.
+//   Twenty of the table's 32 columns are answered here. Eleven come off PageMetaRow
+//   (Id/Name/Caption/SourceTable/PageType/Editable/InsertAllowed/ModifyAllowed/
+//   DeleteAllowed/SourceTableTemporary/CardPageID); the nine <SourceObject> ones
+//   (SourceTableView/DelayedInsert/ShowFilter/MultipleNewLines/SaveValues/AutoSplitKey/
+//   DataCaptionFields/LinksAllowed/PopulateAllFields) were added by #3063 and are read from
+//   BC's OWN parsed page metadata — see RecordPatches.PageMetadataSourceObject.cs, which is
+//   also where the refusal policy for them lives.
+//
+//   The remaining twelve still get BC's own NavValue.GetDefaultNavValue for the column's
+//   type — the same "declares none of them" default a real row carries for a page that
+//   states nothing about them. They are DataCaptionExpr., RefreshOnActivate, APIPublisher,
+//   APIGroup, APIVersion, EntitySetName, EntityName, ChangeTrackingAllowed, AppID,
+//   InherentPermissions, InherentEntitlements and Namespace. Unlike the nine above, none of
+//   these has a value sitting parsed and unused in the process today: the API* / Entity* /
+//   DataCaptionExpr. / RefreshOnActivate / ChangeTrackingAllowed group is <Properties>-level
+//   rather than <SourceObject>-level and is not carried on either row source, and the last
+//   four are computed by BC from an app-identity and permission-mask surface the runner does
+//   not populate at all. Each is therefore a separate piece of work, not a fall-through this
+//   file could close by widening its switch.
 //
 // PRECOMPILED-DLL RESPECT
 //   Runtime-engine types only (VirtualDataProvider, NCLMetaTable, NavValue,
@@ -134,13 +148,26 @@ public static partial class RecordPatches
         foreach (var row in EnumerateKnownPageMetadata())
         {
             if (!done.TryAdd(row.Id, 0)) continue;
+
+            // One lazy slot per ROW, shared by that row's nine <SourceObject> columns (#3063).
+            // The read behind it loads the page's real metadata through BC's own
+            // LoadMetadata(); nine columns asking independently would ask nine times for an
+            // answer that cannot differ between them. Lazy rather than eager because most
+            // rows are never asked for any of the nine, and a page whose metadata will not
+            // load must refuse only when something actually reads one of its columns — not
+            // take the whole table's population down with it.
+            PageSourceObjectInfo? sourceObject = null;
+            PageSourceObjectInfo SourceObjectFor(PageMetaRow r) => sourceObject ??= GetPageSourceObject(r.Id);
+
             InsertVirtualRow(provider, metaTable,
                 new object[] { PageMetadataVirtualTableId, row.Id, 0, 0 },
-                field => BuildPageMetadataValue(field, row, pageTypeOrdinals));
+                field => BuildPageMetadataValue(field, row, pageTypeOrdinals, SourceObjectFor));
         }
     }
 
-    private static object? BuildPageMetadataValue(NCLMetaField field, PageMetaRow row, Dictionary<string, int> pageTypeOrdinals)
+    private static object? BuildPageMetadataValue(
+        NCLMetaField field, PageMetaRow row, Dictionary<string, int> pageTypeOrdinals,
+        Func<PageMetaRow, PageSourceObjectInfo> SourceObjectFor)
     {
         object? Text(string s) => _aovNavTextCreateTruncated!.Invoke(null, new object?[] { field.FieldDefinedLength, s ?? string.Empty });
 
@@ -173,6 +200,36 @@ public static partial class RecordPatches
                 return NavBoolean(row.DeleteAllowed);
             case "sourcetabletemporary":
                 return NavBoolean(row.SourceTableTemporary);
+
+            // The nine <SourceObject> columns (#3063). Read from BC's own parsed page
+            // metadata — the same MetaSourceObjectDefinition BC's real PageDataProvider reads
+            // them off — so a source-compiled page and a page from a dependency .app cannot
+            // answer differently. See RecordPatches.PageMetadataSourceObject.cs, which also
+            // states which of them refuses rather than defaulting and why.
+            //
+            // Resolved lazily and ONCE per row build, not per column: the read reaches
+            // EnsureRealPageMetadata, which loads the page's real metadata through BC's own
+            // LoadMetadata() on first use. Nine columns of one row would otherwise ask nine
+            // times for an answer that cannot change between them.
+            case "sourcetableview":
+                return Text(SourceObjectFor(row).SourceTableView);
+            case "delayedinsert":
+                return NavBoolean(SourceObjectFor(row).DelayedInsert);
+            case "showfilter":
+                return NavBoolean(SourceObjectFor(row).ShowFilter);
+            case "multiplenewlines":
+                return NavBoolean(SourceObjectFor(row).MultipleNewLines);
+            case "savevalues":
+                return NavBoolean(SourceObjectFor(row).SaveValues);
+            case "autosplitkey":
+                return NavBoolean(SourceObjectFor(row).AutoSplitKey);
+            case "datacaptionfields":
+                return Text(SourceObjectFor(row).DataCaptionFields);
+            case "linksallowed":
+                return NavBoolean(SourceObjectFor(row).LinksAllowed);
+            case "populateallfields":
+                return NavBoolean(SourceObjectFor(row).PopulateAllFields);
+
             default:
                 return _aovGetDefaultNavValue!.Invoke(null, new object?[] { field, false });
         }


### PR DESCRIPTION
Closes #3063

Page Metadata (2000000138) answered BC's own type default for the nine columns computed from a page's `<SourceObject>` declaration, so AL reading them got a plausible wrong answer rather than a refusal. Reproduced before the fix on two source-compiled pages declaring all nine:

```
DECLARING LinksAllowed=No ShowFilter=No SaveValues=No PopulateAllFields=No DataCaptionFields=[]
FLAGS     AutoSplitKey=No DelayedInsert=No MultipleNewLines=No SourceTableView=[]
```

After:

```
DECLARING LinksAllowed=No ShowFilter=No SaveValues=Yes PopulateAllFields=Yes DataCaptionFields=[1,2]
FLAGS     AutoSplitKey=Yes DelayedInsert=Yes MultipleNewLines=Yes SourceTableView=[WHERE(Field3=CONST(X))]
```

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/226

That corpus PR adds codeunit 60993 `Test Page Metadata Src Object` (five tests, two fixture pages) pinning what real BC reports for all nine columns. **It has merged**, all 8 cloud BC legs green, with execution verified rather than inferred from the tick: 9 distinct `Record_PageMetadata_*` tests, 9 PASS on each leg, 0 FAIL. That settles the caveat this PR originally carried — the exact strings `WHERE(Field6=CONST(2))` and `1,2` are what eight real service tiers report, so the runner's rendering matches BC rather than merely matching itself.

**This PR still does not bump the pin**, which stays at `c3531ec6`: the bump is blocked on four issues owned by another account (#3304), so the coordinator sequences it separately.

## The design decision, and why it is not what the issue proposed

The issue proposed feeding the nine from the two row sources `EnumerateKnownPageMetadata` already walks — `ParsedPage` for source-compiled pages, `PageSymbol` for pages from a dependency `.app`. I did not do that, for the reason the issue itself names: *"the table starts answering differently depending on where a page came from — which is worse than answering BC's default uniformly."* Two independent parsers feeding one column set makes that the default outcome.

Two corrections to the issue's premises, both measured:

- **`ParsedPage` carries none of the nine.** The issue says it carries `AutoSplitKey`/`MultipleNewLines`/`DelayedInsert`; those are on `PageSymbol`. `RecordPatches.AlPageParser.cs` mentions not one of the nine, so the source-parsed half would have needed nine new AL-property parsers whose agreement with the symbol half nothing asserts.
- **`DataCaptionFields` needs no name resolution.** The issue anticipated that AL states field NAMES where the column reports NUMBERS, and that the source-parsed path would have to resolve them. It does not: the real AL compiler has already done it. Verified with `AL_RUNNER_TRACE_PAGE_METADATA=2` — `DataCaptionFields = "No.", Descr` on a page over table 65600 emits `<SourceObject DataCaptionFields="1,2" ...>`.

There is a third source better than both: **BC's own `MetaSourceObjectDefinition`**, the object BC's real `PageDataProvider` reads these nine off on a service tier. Both page origins already converge on it — a source-compiled page through the compiler-emitted XML in `AlPageMetadataRegistry`, a dependency page through `DependencyPageMetadataXml`'s reconstruction — and `EnsureRealPageMetadata` already loads either through BC's own `LoadMetadata()`. So the new file parses nothing; it asks BC for the object BC would have read. The two origins cannot disagree, because after the load there is only one object.

`SourceTableView` is BC's own `PageDataProvider.GenerateSourceTableViewString`, invoked rather than reimplemented — it is `public static`, and the format has three conditional segments, field numbers and a filter-type `ToString()` that a matching guess would get subtly wrong.

## Nine columns, nine claims

All nine are answerable, and all nine are proved. Per column, what the value is and where it comes from:

| column | id | source | proved by |
|---|---:|---|---|
| `SourceTableView` | 15 | `MetaViewDefinition`, formatted by BC's own formatter | corpus tests 3 and 4 |
| `DelayedInsert` | 19 | `MetaSourceObjectDefinition.DelayedInsert` | corpus test 2 |
| `ShowFilter` | 20 | `.ShowFilter` | corpus test 1 |
| `MultipleNewLines` | 21 | `.MultipleNewLines` | corpus test 2 |
| `SaveValues` | 22 | `.SaveValues` | corpus test 1 |
| `AutoSplitKey` | 23 | `.AutoSplitKey` | corpus test 2 |
| `DataCaptionFields` | 24 | `.DataCaptionFields`, already field numbers | corpus test 1 |
| `LinksAllowed` | 26 | `.LinksAllowed` | corpus tests 1 and 5 |
| `PopulateAllFields` | 28 | `.PopulateAllFields` | corpus tests 1 and 5 |

## A sibling defect this found — and an existing test that had encoded it as correct

Verifying the dependency-app origin, Base Application 1710 "Deferral Lines - G/L" reported an **empty** `SourceTableView` for a page whose symbol file declares `where("Deferral Doc. Type" = const("G/L"))`. The synthesized XML was correct — `FieldID="1" FilterType="CONST" FilterValue="G/L"` — and BC discarded it, because `GenerateSourceTableViewString` opens with

```csharp
if (view == null || view.Sorting == null) return NavText.Empty;
```

`EmitSourceTableViewXml` emitted `<Sorting>` only when the page declared sorting, so for a where-only view the whole thing formatted as empty. **211 of the 417 pages carrying a `SourceTableView` across this machine's platform `.app`s declare a where with no sorting** — the majority case, not a corner. The real AL compiler always writes the element, empty for a where-only page (`<Sorting KeyFields="" KeyFieldsSetByView="0" AscendingSetByView="0" Ascending="1" />`, measured), so the emitter now matches it and the two origins produce the same document.

`DependencyPageMetadataXmlTests.TryBuildDependencyPageMetadata_SourceTableViewWithoutSorting_EmitsFiltersButNoSortingElement` **asserted the defect as correct**. Its reasoning was true about `ApplySourceTableView`, which reads the element only through its two `*SetByView` flags — and missed the second consumer. It is inverted, renamed, and carries the mechanism. Both flags stay off, so nothing imposes an order the page never declared; the element only stops the filters being thrown away. One neighbouring assertion moved from `AscendingSetByView=""` to `"0"` for the same reason — same meaning to BC, and `"0"` is what the compiler writes.

## Refusal, not a different silent default

`loud-failures.md`: a page whose real metadata will not load has no `MetaSourceObjectDefinition`, and the nine columns now **throw** rather than answer BC's default — replacing a silent wrong answer with a different silent wrong answer would be no fix. The refusal names the page, names the columns, and carries the `not-yet-implemented` anchor so `IsPermanentOutOfScope` does not let an AL `[TryFunction]` trap it back into `false`. `AlRunner.Tests/PageMetadataSourceObjectRefusalTests.cs` asserts all of that.

One case is legitimately defaulted rather than refused, and it is stated explicitly: a page declaring no `SourceTable` carries no `<SourceObject>` at all, and BC's own provider reads all nine as `?? false` / `NavText.Empty` for exactly that. That is BC's answer, not ours; `PageSourceObjectInfo.None` pins the value.

## RED → GREEN

- **RED** — the five corpus tests against the pre-fix runner: `SaveValues` expected Yes got No; `AutoSplitKey` expected Yes got No; both `SourceTableView` tests got `''`; and the **negative control** failed too, on `LinksAllowed` expected Yes got No — because that column's AL default is `true` while `GetDefaultNavValue` answers `false`.
- **GREEN** — all five pass. Restored via file copies, `git status` clean against the committed fix before rebuilding, per `no-git-stash-with-worktrees.md`.

Would a no-op implementation pass? No: every fixture declares each property as the **opposite** of its AL default, and the negative control fails a fixed non-default row.

## What was run

- Full corpus, CI's invocation: **2757/2757**, 0 fail, 0 error.
- `tests/runner-extras`: **349/349**.
- `dotnet test --filter DependencyPageMetadataXmlTests`: 36/36.
- `dotnet test --filter PageMetadataSourceObjectRefusalTests`: 2/2.
- Combined filter over `PageMetadata|SourceTableView|BcAppSymbolCachePage|RealPageMetadata|DependencyMetadataMemo`: 48 passed, 3 skipped (the `bc-engine-serial` rows that skip without local bootstrap).

## Sibling-issue scan

Nothing folded. All three unassigned candidates land in different files:

- **#2200** — `ParseMemberNames` in `RecordPatches.AlPageParser.cs`. This PR touches neither that file nor that walk; the nine columns deliberately do not come from `ParsedPage`.
- **#2325** — Tenant Profile Page Metadata plus a profile-rename cascade. A different virtual table and a different registry.
- **#3228** — pageextension metadata capture on the TestPage path. Shares the word "page metadata" and no code with this.

**#2460** and **#2457** are claimed by another loop; untouched. **#2655** and **#2417** are different registries.

## `CacheVersion` not bumped

Deliberately, and it is the right call. The change alters no parse and no cached record shape: `PageSymbol` and `PageTableViewSymbol` are unchanged, and the nine columns are read at row-build time from BC's own loaded metadata, downstream of anything the symbol cache stores. The one emitter change writes an extra `<Sorting>` element into XML that is **not** cached under `CacheVersion` — `_depPageMetadataXml` is an in-process memo dropped by `InvalidateBcAppIndexes`. A bump would be ceremony.

## Remaining Page Metadata columns

Twelve of 32 still answer the type default, and the header note now names them rather than gesturing at "API*, DataCaptionExpr., DelayedInsert, …" — which had gone stale, since `DelayedInsert` is one this PR implements. None has a value sitting parsed and unused: the `API*`/`Entity*`/`DataCaptionExpr.`/`RefreshOnActivate`/`ChangeTrackingAllowed` group is `<Properties>`-level rather than `<SourceObject>`-level and is on neither row source, and `AppID`/`InherentPermissions`/`InherentEntitlements`/`Namespace` are computed by BC from an app-identity and permission-mask surface the runner does not populate. Each is separate work rather than a fall-through this file could close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4
