### PR TITLE
fix(published-app): answer NAV App Extra, so the other two FlowFields stop reading false

### DIFF
--- a/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
+++ b/AlRunner.Tests/VirtualTableRefusalClaimTests.cs
@@ -74,6 +74,7 @@ public sealed class VirtualTableRefusalClaimTests
         "RecordPatches.FieldVirtualTable.cs",
         "RecordPatches.IntegerVirtualTable.cs",
         "RecordPatches.MetadataPermissionSetVirtualTable.cs",
+        "RecordPatches.NavAppExtraVirtualTable.cs",
         "RecordPatches.PageControlFieldVirtualTable.cs",
         "RecordPatches.PageMetadataVirtualTable.cs",
         "RecordPatches.ReportLayoutListVirtualTable.cs",
@@ -114,6 +115,7 @@ public sealed class VirtualTableRefusalClaimTests
         new object[] { "FieldVirtualShapeGap",           "Field (virtual table 2000000041)",                    "field-virtual-table",                     GapDoc },
         new object[] { "IntegerShapeGap",                "Integer (virtual table 2000000026)",                  "integer-virtual-table",                   GapDoc },
         new object[] { "MetadataPermissionSetShapeGap",  "Metadata Permission Set (virtual table 2000000250)",  "metadata-permission-set-virtual-table",   GapDoc },
+        new object[] { "NavAppExtraShapeGap",            "NAV App Extra (virtual table 2000000157)",            "nav-app-extra-virtual-table",             GapDoc },
         new object[] { "PageControlFieldShapeGap",       "Page Control Field (virtual table 2000000192)",       "page-control-field-virtual-table",        GapDoc },
         new object[] { "PageMetadataShapeGap",           "Page Metadata (virtual table 2000000138)",            "page-metadata-virtual-table",             GapDoc },
         new object[] { "ReportDataItemsShapeGap",        "Report Data Items (virtual table 2000000203)",        "report-data-items-virtual-table",         GapDoc },
@@ -401,7 +403,19 @@ public sealed class VirtualTableRefusalClaimTests
         // Actual: 82") after rebasing this branch onto main with #3128 merged, not arrived at by
         // adding 6 to 76. The branch had previously written 78 against a base of 72; that running
         // total did not survive the rebase, which is exactly what the note above predicts.
-        Assert.Equal(82, total);
+        // +3 (#3072): the NAV App Extra (2000000157) populator joined with two refusals of its
+        // own, plus the third in RecordPatches.cs's dispatch chain. Its file was added to
+        // CoveredFiles in the same change -- worth noting because adding the file is what makes
+        // two of the three countable at all: a populator absent from that list is not covered
+        // by the whole-file guard above either, so it could construct the refusal directly and
+        // cite docs/scope.md with nothing objecting. The refusal that matters is the one for an
+        // empty row set: an empty 2000000157 makes both of Published Application's Lookup
+        // FlowFields read false for every app, so answering empty is a wrong answer, not a
+        // missing one.
+        //
+        // Per the note above: 85 was READ OUT of this test's own failure message
+        // ("Expected: 82, Actual: 85"), not arrived at by adding 3 to 82.
+        Assert.Equal(85, total);
     }
 
 

--- a/AlRunner/Patches/RecordPatches.NavAppExtraVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.NavAppExtraVirtualTable.cs
@@ -362,8 +362,27 @@ public static partial class RecordPatches
             .FirstOrDefault(c => c.GetParameters().Length == 1
                                  && c.GetParameters()[0].ParameterType.Name == "NavSession");
 
-        _naeGetAllItems = _naeProviderType?.GetMethod("GetAllItems",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        // BcShape.FindMethod, not Type.GetMethod (#3069). A bare-name lookup throws
+        // AmbiguousMatchException the day Microsoft ships a second GetAllItems overload on
+        // this provider, and MethodScopePatches.NavMethodScope_AssertError rethrows only
+        // BcShapeGapException while absorbing everything else — so that throw would be
+        // SWALLOWED under an AL `asserterror`, passing it on a call real BC performs fine.
+        //
+        // The signature is pinned to the one BC's own provider declares —
+        // `protected override IEnumerable<ReadOnlyRecordBuffer> GetAllItems(out bool)`, so
+        // one `bool&` parameter — which makes an ADDED overload refuse by name rather than
+        // being picked between. FindMethod still answers null on absence, and null is the
+        // route this file already handles: TryEnsureNavAppExtraReflection returns false and
+        // the loaded-module fallback answers, which is what happens on every BC build
+        // measured so far anyway (BC's provider returns 0 rows here).
+        _naeGetAllItems = _naeProviderType == null ? null : BcShape.FindMethod(
+            _naeProviderType, "GetAllItems",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            "NAV App Extra (virtual table 2000000157)",
+            "NavAppExtraDataProvider.GetAllItems",
+            "it is the row set BC's own provider computes for this table, so the runner "
+            + "cannot pick an overload on the table's behalf",
+            new[] { typeof(bool).MakeByRefType() });
 
         return _naeProviderCtor != null && _naeGetAllItems != null;
     }

--- a/AlRunner/Patches/RecordPatches.NavAppExtraVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.NavAppExtraVirtualTable.cs
@@ -1,0 +1,370 @@
+// RecordPatches.NavAppExtraVirtualTable — managed provider for the "NAV App Extra"
+// (2000000157) system virtual table, which is what Published Application's other two
+// FlowFields are computed over (#3072).
+//
+// WHY THIS EXISTS
+//   Published Application (2000000206) carries three Boolean FlowFields. #3066 settled the
+//   first one — Installed — by seeding the ordinary application-database table it is an
+//   Exist() over. The other two are Lookups over a DIFFERENT table:
+//
+//       field(30; "Tenant Visible"; Boolean)
+//       {
+//           CalcFormula = Lookup("NAV App Extra"."Tenant Visible"
+//                                WHERE("Runtime Package ID" = FIELD("Runtime Package ID")));
+//       }
+//       field(31; "PerTenant Or Installed"; Boolean)
+//       {
+//           CalcFormula = Lookup("NAV App Extra"."PerTenant Or Installed"
+//                                WHERE("Runtime Package ID" = FIELD("Runtime Package ID")));
+//       }
+//
+//   2000000157 is VIRTUAL — System.app ships it under src/Virtual Tables/ and Ncl's own
+//   NavAppExtraDataProvider computes every row — so there is no row to seed the way there was
+//   for Installed Application (2000000212). It routed to the same empty in-memory store as
+//   every other unprovided table here, so it had zero rows and both FlowFields read FALSE.
+//
+//   That false is the shape this repository has already been wrong about once. Both columns
+//   are Boolean, so "computed no" and "computed nothing" are the same observable, and #3066's
+//   header records the runner having pinned Installed as false on exactly that reasoning
+//   before a real tier said true. "Tenant Visible" gates what the extension-management pages
+//   and several System Application callers consider visible to a tenant, so answering false
+//   for every app is the runner saying "no app is visible to this tenant" — a plausible-looking
+//   wrong answer that stays invisible until something unrelated fails.
+//
+// WHAT BC'S OWN PROVIDER COMPUTES (Ncl.dll, measured on 27.5 — NavAppExtraDataProvider)
+//   Four columns, and the two the FlowFields read are both derived, never stored:
+//
+//       GetAllItems():
+//           buffer[0] = RuntimePackageId
+//           buffer[1] = IsAppVisibleToTenant(app, session tenant)
+//           buffer[2] = app.Scope == NavAppScope.Tenant || app is in this tenant's app group
+//           buffer[3] = PackageId
+//
+//       IsAppVisibleToTenant(app, tenantId):
+//           Scope == Global -> true
+//           Scope == Tenant -> app.TenantId == tenantId
+//           otherwise       -> false
+//
+//   So for a GLOBALLY-scoped app that is installed in the session's tenant, both columns are
+//   true. That is the reading, and it is not what this file rests on — see the next section.
+//
+// BC'S OWN PROVIDER IS TRIED FIRST, AND THE FALLBACK IS NOT A SECOND OPINION
+//   PopulateNavAppExtraVirtualTable constructs Ncl's NavAppExtraDataProvider on the skeleton
+//   session and takes its rows, exactly the way the Feature Key populator does. When that
+//   works, the rows are BC's own and nothing here decides anything.
+//
+//   MEASURED, not predicted: on BC 28.1.49838.53910 it produces **0 rows** here, and the
+//   fallback below is what answers. The reason is structural rather than incidental — the
+//   provider reads NavEnvironment.Instance.NavAppMetadataRetriever.GetAllMetadata() and
+//   NavCurrentThread.Session.Tenant.NavAppGroup. The runner publishes nothing and installs
+//   nothing, so the retriever is empty and the app group is NavAppGroup.BaseGroup — see
+//   BcRuntime's OverriddenAppGroup note. An empty retriever makes the provider return an empty
+//   row set, and an empty row set is indistinguishable from "no app is visible" at every later
+//   read.
+//
+//   It is still tried first, and that is deliberate rather than decorative: the day the runner
+//   populates NavAppMetadataRetriever — which is a plausible future, since several other
+//   surfaces would want it — BC's own rows are the ones that should win, without this file
+//   needing to be found and changed. Nothing about the fallback makes the BC path harder to
+//   reach; it only fires on an empty result.
+//
+//   So the fallback builds the same four columns from the SAME app list the Published
+//   Application seeder uses — BcRuntime.RegisteredModules(), the manifests the runner already
+//   parses for NavApp.GetModuleInfo — with the SAME AppPackageIdentity values, so a row here
+//   and that app's 2000000206 row can never disagree about which app they describe. The two
+//   derived columns then answer for what the runner can actually establish about an app it
+//   LOADED into this session:
+//
+//       Tenant Visible          — the runner has one tenant and one session, and every app it
+//                                 loaded is loaded FOR that session. There is no per-tenant
+//                                 scoping to be excluded by, so BC's Global branch is the one
+//                                 that applies: true.
+//       PerTenant Or Installed  — the "Or Installed" half. #3066 already seeds an Installed
+//                                 Application (2000000212) row for every one of these apps, on
+//                                 the same runtime package id, and Published Application.Installed
+//                                 reads true from it on a real tier. An app the runner reports
+//                                 as installed cannot also report as not-installed here without
+//                                 the two tables contradicting each other: true.
+//
+//   Both are stated as what the runner can establish, not as a claim about what a service tier
+//   reports for an arbitrary app. The tier's answer is asked upstream, in the corpus's
+//   Target = OnPrem app (BusinessCentral.AL.Language.Tests#228), because
+//   .claude/rules/bc-behavior-tests-go-upstream.md is the rule #3066 exists because nobody
+//   followed.
+//
+// WHAT IS NOT ANSWERED, AND THROWS RATHER THAN GUESSING
+//   A column this file does not recognise keeps BC's own GetDefaultNavValue — the same
+//   treatment every other populator here gives a column it has no source for. What it does NOT
+//   do is invent a row set: if the runner has no loaded modules, or the store is not there, or
+//   the metatable is not the shape BC's own provider fills, it REFUSES. Answering with an
+//   empty table would put back precisely the false-for-every-app reading this file exists to
+//   remove, and .claude/rules/loud-failures.md is explicit that replacing one silent wrong
+//   answer with another is the failure mode.
+//
+// PRECOMPILED-DLL RESPECT
+//   NavAppExtraDataProvider, NavSession and ReadOnlyRecordBuffer are runtime-engine types,
+//   which .claude/rules/precompiled-dll-respect.md makes ours to drive. No AL business-logic
+//   body is touched: the rows go into BC's own in-memory provider through BC's own Insert, and
+//   BC's own CalcFields computes the FlowFields off them. Nothing writes to a FlowField, which
+//   would be silently discarded.
+
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using AlRunner.Infrastructure;
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    /// <summary>
+    /// Every refusal in this file, built in one place. See
+    /// RecordPatches.VirtualTableShapeGap.cs for the three-bucket classification and for
+    /// why the anchor is "not-yet-implemented" rather than a docs/scope.md section (#2945).
+    /// </summary>
+    /// <remarks>
+    /// Category (2) for all of them. Every one fires where the runner cannot answer at all —
+    /// no in-memory store, no loaded modules to describe, or a metatable that is not the shape
+    /// BC's own NavAppExtraDataProvider fills. None of them is a value choice: the two derived
+    /// columns are answers this file gives on purpose and never throws for.
+    /// </remarks>
+    internal static RunnerOutOfScopeException NavAppExtraShapeGap(string detail)
+        => VirtualTableShapeGap("NAV App Extra (virtual table 2000000157)", "nav-app-extra-virtual-table", detail);
+
+    internal const int NavAppExtraVirtualTableId = 2000000157;
+
+    // Per (store, runtime package id), NOT one-shot per store — and that distinction is the
+    // whole correctness argument for this ledger.
+    //
+    // BcRuntime.RegisteredModules() is a LIVE view of registration state, not a fixed list:
+    // the Published Application seeder itself splits into a dependency pass and a later
+    // bundle pass for exactly that reason (EnsurePublishedApplicationDependencyRowsSeeded /
+    // EnsurePublishedApplicationBundleRowSeeded). A one-shot latch here would therefore be a
+    // race with a silent wrong answer on the losing side: the first AL read of 2000000157
+    // that happens before the bundle registers would populate the table WITHOUT the bundle's
+    // row, latch, and every later read — including the bundle asking about itself — would get
+    // false from a table that looks populated. Two writers of the same state, one of them
+    // holding an invariant the other does not.
+    //
+    // Topping up per app id makes repeated handouts idempotent and late registrations visible,
+    // at the cost of one dictionary lookup per app per handout.
+    private static readonly ConditionalWeakTable<object, ConcurrentDictionary<Guid, byte>> _naeSeededByStore = new();
+
+    // Separate, and only for BC's own provider: its rows are pre-built buffers whose key this
+    // file does not read, so they cannot go in the ledger above. Once BC's provider has
+    // answered for a store there is nothing to top up — its row set is the session's app
+    // metadata, which the runner does not add to mid-run.
+    private static readonly ConditionalWeakTable<object, object> _naeBcProviderAnswered = new();
+
+    private static bool _naeReflectionReady;
+    private static Type? _naeProviderType;          // Microsoft.Dynamics.Nav.Runtime.NavAppExtraDataProvider
+    private static ConstructorInfo? _naeProviderCtor;   // .ctor(NavSession)
+    private static MethodInfo? _naeGetAllItems;     // protected IEnumerable<ReadOnlyRecordBuffer> GetAllItems(out bool)
+
+    private static bool IsNavAppExtraVirtualTable(NCLMetaTable? table)
+        => table != null && table.TableId == NavAppExtraVirtualTableId;
+
+    /// <summary>
+    /// Populate the in-memory store behind NAV App Extra (2000000157). BC's own
+    /// NavAppExtraDataProvider is tried first and its rows are used whenever it produces any;
+    /// otherwise the rows are built from the same loaded-module list and the same
+    /// <see cref="AppPackageIdentity"/> values the Published Application seeder uses, so the
+    /// two tables can never disagree about which app a runtime package id names.
+    ///
+    /// <para>Never answers with an empty table: an empty 2000000157 makes both
+    /// <c>Published Application</c> Lookup FlowFields read false for every app, which is a
+    /// wrong answer rather than a missing one (#3072).</para>
+    ///
+    /// <para>Idempotent and topping-up, called on every 2000000157 data-access handout, so an
+    /// app registered after the first read still gets its row — see the ledger's own comment
+    /// for why a one-shot latch here would be a race with a silent wrong answer.</para>
+    /// </summary>
+    private static void PopulateNavAppExtraVirtualTable(object dataAccess, NCLMetaTable metaTable, object session)
+    {
+        EnsureAllObjReflection(metaTable);
+        EnsureReportMetadataReflection(metaTable);   // NavBoolean.Create(bool)
+        EnsureDataAccessProviderReflection(dataAccess);
+
+        var store = _pDataAccessDataProvider!.GetValue(dataAccess)
+            ?? throw NavAppExtraShapeGap("data access has no in-memory provider");
+
+        // 1. BC's own provider, once per store. When the session carries real app metadata
+        //    this is the whole answer and nothing below runs.
+        var seeded = _naeSeededByStore.GetValue(store, static _ => new ConcurrentDictionary<Guid, byte>());
+        var inserted = 0;
+
+        if (!_naeBcProviderAnswered.TryGetValue(store, out _))
+        {
+            inserted = TryPopulateNavAppExtraFromBcProvider(store, session);
+            if (inserted > 0) _naeBcProviderAnswered.Add(store, new object());
+        }
+
+        // 2. The runner's own app list, topped up on every handout. Reached when BC's
+        //    retriever has nothing in it, which is the normal state here: the runner
+        //    publishes and installs nothing, so NavAppMetadataRetriever is empty and
+        //    NavAppGroup is BaseGroup. Measured on BC 28.1: BC's provider returns 0 rows and
+        //    this is the path that answers.
+        if (!_naeBcProviderAnswered.TryGetValue(store, out _))
+            inserted += PopulateNavAppExtraFromLoadedModules(store, metaTable, seeded);
+
+        // Only the FIRST handout may refuse. A later one legitimately inserts nothing — every
+        // registered app already has its row — and raising there would turn the idempotent
+        // top-up into a failure on the second read of a correctly populated table.
+        if (seeded.IsEmpty && inserted == 0)
+            throw NavAppExtraShapeGap(
+                "neither BC's own NavAppExtraDataProvider nor the runner's loaded-module list "
+                + "produced a single row. Answering with an empty table would make "
+                + "Published Application's \"Tenant Visible\" and \"PerTenant Or Installed\" "
+                + "read false for every app — the runner reporting that no app is visible to "
+                + "this tenant, which is a wrong answer and not a missing one. See AlRunner#3072");
+    }
+
+    /// <summary>
+    /// Take the rows BC's own NavAppExtraDataProvider produces, when it produces any. Returns
+    /// the number inserted; 0 means the provider is not usable on this session (its metadata
+    /// retriever is empty, or it threw), which is the expected case in the runner and is
+    /// handled by the caller rather than raised here.
+    /// </summary>
+    private static int TryPopulateNavAppExtraFromBcProvider(object store, object session)
+    {
+        if (!TryEnsureNavAppExtraReflection()) return 0;
+
+        object provider;
+        try
+        {
+            provider = _naeProviderCtor!.Invoke(new object?[] { session });
+        }
+        catch
+        {
+            // The provider reads the session's tenant and app group in its base constructor.
+            // On the skeleton session that can throw; it is not a shape gap, it is the case
+            // the loaded-module fallback exists for.
+            return 0;
+        }
+
+        object? rows;
+        try
+        {
+            rows = _naeGetAllItems!.Invoke(provider, new object?[] { false });
+        }
+        catch
+        {
+            return 0;
+        }
+
+        if (rows is not System.Collections.IEnumerable enumerable) return 0;
+
+        var inserted = 0;
+        try
+        {
+            foreach (var buffer in enumerable)
+            {
+                if (buffer == null) continue;
+                InsertPreBuiltVirtualRow(store, buffer);
+                inserted++;
+            }
+        }
+        catch
+        {
+            // Enumeration is lazy in BC's provider, so a throw can arrive here rather than
+            // above. Rows already inserted stay: they are BC's own and are not wrong. The
+            // caller tops the table up from the loaded-module list only when NOTHING arrived,
+            // so a partial BC answer is never mixed with a synthesised one.
+            return inserted;
+        }
+
+        return inserted;
+    }
+
+    /// <summary>
+    /// Build one row per app the runner loaded, from the same <c>BcRuntime.RegisteredModules()</c>
+    /// list and the same <see cref="AppPackageIdentity"/> values that produce this app's
+    /// Published Application (2000000206) and Installed Application (2000000212) rows — so a
+    /// runtime package id names the same app in all three tables.
+    /// </summary>
+    private static int PopulateNavAppExtraFromLoadedModules(
+        object store, NCLMetaTable metaTable, ConcurrentDictionary<Guid, byte> seeded)
+    {
+        var modules = AlRunner.BcRuntime.RegisteredModules();
+        var inserted = 0;
+
+        foreach (var m in modules)
+        {
+            var runtimePackageId = AppPackageIdentity.RuntimePackageIdFor(m.AppId);
+            // The ledger does double duty. Within one call it absorbs an app id listed more
+            // than once (an app split across R2R chunks — #3067). Across calls it is what
+            // makes the top-up idempotent, so a second handout inserts nothing rather than
+            // colliding on the primary key. Either way the row COUNT stays equal to the number
+            // of distinct apps, which is what makes "one row per published app" a checkable
+            // property rather than a coincidence.
+            if (!seeded.TryAdd(runtimePackageId, 0)) continue;
+
+            var packageId = AppPackageIdentity.PackageIdFor(m.AppId);
+            InsertVirtualRow(store, metaTable,
+                new object[] { NavAppExtraVirtualTableId, seeded.Count, 0, 0 },
+                field => BuildNavAppExtraValue(field, runtimePackageId, packageId));
+            inserted++;
+        }
+
+        return inserted;
+    }
+
+    /// <summary>
+    /// One column of a NAV App Extra row, matched by the metatable's own FIELD NAME so the
+    /// mapping tracks what the System package in the resolved artifact declares rather than a
+    /// hardcoded field-number table.
+    ///
+    /// <para>The two Boolean columns are the ones Published Application's FlowFields read.
+    /// Both answer <c>true</c>, and the header states what that rests on: every app in this
+    /// list was loaded into this session's single tenant, so BC's own Global branch of
+    /// <c>IsAppVisibleToTenant</c> is the one that applies, and every one of them already has
+    /// an Installed Application row that makes <c>Published Application.Installed</c> read
+    /// true. A <c>false</c> here would have the runner contradicting its own 2000000212 rows.</para>
+    /// </summary>
+    private static object? BuildNavAppExtraValue(NCLMetaField field, Guid runtimePackageId, Guid packageId)
+    {
+        switch (NormalizeObjectTypeName(field.FieldName ?? string.Empty))
+        {
+            // new NavGuid(Guid) is exactly what BC's own NavAppExtraDataProvider writes into
+            // these two slots — buffer[0] and buffer[3] of its GetAllItems.
+            case "runtimepackageid":
+                return new NavGuid(runtimePackageId);
+            case "packageid":
+                return new NavGuid(packageId);
+            case "tenantvisible":
+                return NavBoolean(true);
+            case "pertenantorinstalled":
+                return NavBoolean(true);
+            default:
+                return _aovGetDefaultNavValue!.Invoke(null, new object?[] { field, false });
+        }
+    }
+
+    /// <summary>
+    /// Resolve BC's own NavAppExtraDataProvider. Unlike the Feature Key populator this does
+    /// NOT throw when the type is absent or the wrong shape: BC's provider is an optimisation
+    /// here rather than the only source, and the loaded-module fallback answers the same four
+    /// columns. Returning false routes to it instead of failing a run over a type the runner
+    /// does not strictly need.
+    /// </summary>
+    private static bool TryEnsureNavAppExtraReflection()
+    {
+        if (_naeReflectionReady) return _naeProviderCtor != null && _naeGetAllItems != null;
+        _naeReflectionReady = true;
+
+        var navNcl = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(a => a.GetName().Name == "Microsoft.Dynamics.Nav.Ncl");
+        _naeProviderType = navNcl?.GetType("Microsoft.Dynamics.Nav.Runtime.NavAppExtraDataProvider");
+
+        _naeProviderCtor = _naeProviderType?.GetConstructors(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            .FirstOrDefault(c => c.GetParameters().Length == 1
+                                 && c.GetParameters()[0].ParameterType.Name == "NavSession");
+
+        _naeGetAllItems = _naeProviderType?.GetMethod("GetAllItems",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+
+        return _naeProviderCtor != null && _naeGetAllItems != null;
+    }
+}

--- a/AlRunner/Patches/RecordPatches.PublishedApplicationSystemTable.cs
+++ b/AlRunner/Patches/RecordPatches.PublishedApplicationSystemTable.cs
@@ -66,12 +66,16 @@
 //   on all eight OnPrem legs, 27.0 through 28.4. There WAS something behind it — a table the
 //   runner had simply never seeded.
 //
-//   Still deliberately NOT filled: "Tenant Visible" and "PerTenant Or Installed" are
+//   Not filled HERE, and correctly so: "Tenant Visible" and "PerTenant Or Installed" are
 //   Lookup FlowFields over "NAV App Extra" (2000000157), which is a VIRTUAL table (System.app
-//   ships it under src/Virtual Tables/), so there is no row for the runner to insert the way
-//   there is for 2000000212. They keep reading as the Boolean default here. What a real tier
-//   reports for them is unmeasured, and is tracked as #3072 rather than asserted from a
-//   reading — which is the mistake this file's own header records two of.
+//   ships it under src/Virtual Tables/), so there is no row to insert into 2000000206 the way
+//   there is for 2000000212. They are answered by a PROVIDER for 2000000157 instead — see
+//   RecordPatches.NavAppExtraVirtualTable.cs (#3072), which builds its rows from this same
+//   loaded-module list and these same AppPackageIdentity values so the two tables cannot
+//   disagree about which app a runtime package id names. Until that provider existed both
+//   columns read the Boolean default for every app, which is the runner saying "no app is
+//   visible to this tenant" — the same false-is-unfalsifiable shape a real tier had already
+//   contradicted for Installed above.
 //
 //   Every other column keeps NCLMetaField.EmptyValue, BC's own per-field default — nothing is
 //   invented. Fields are located by NAME off the metatable at runtime, so a BC metadata change

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -2305,6 +2305,33 @@ public static partial class RecordPatches
                 return windowsLanguageDa;
             }
 
+            // ── NAV App Extra (2000000157) ───────────────────────────────────────────────
+            // Virtual on the service tier too (NavAppExtraDataProvider computes one row per
+            // app from the session's app metadata). An empty store made Published
+            // Application's "Tenant Visible" and "PerTenant Or Installed" Lookup FlowFields
+            // read FALSE for every app — the runner answering "no app is visible to this
+            // tenant", which is a wrong answer and not a missing one, and the same
+            // Boolean-default shape a real tier already contradicted once for the Installed
+            // FlowField next door (#3066). BC's own provider is tried first; the fallback
+            // builds the rows from the same loaded-module list and the same
+            // AppPackageIdentity values as the Published Application seeder, so the two
+            // tables cannot disagree about which app a runtime package id names.
+            // See RecordPatches.NavAppExtraVirtualTable.cs (#3072).
+            if (IsNavAppExtraVirtualTable(table))
+            {
+                if (!perTable.TryGetValue(tableId, out var navAppExtraDa))
+                {
+                    var createdNavAppExtra = _mCreateTempDataAccess!.Invoke(self, new object[] { table })!;
+                    navAppExtraDa = perTable.GetOrAdd(tableId, createdNavAppExtra);
+                }
+                var navAppExtraSession = _fDasSession?.GetValue(self)
+                    ?? throw NavAppExtraShapeGap(
+                        "DataAccessSource has no skeleton session, so BC's own "
+                        + "NavAppExtraDataProvider cannot be constructed");
+                PopulateNavAppExtraVirtualTable(navAppExtraDa, table, navAppExtraSession);
+                return navAppExtraDa;
+            }
+
             // ── CodeUnit Metadata (2000000137) ───────────────────────────────────────────
             // Virtual on the service tier too (CodeUnitDataProvider computes one row per
             // codeunit from NCLMetadata). An empty store makes every lookup answer "no such

--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -1175,3 +1175,40 @@ fails the run with "remove the entry", so the staleness was corrected rather tha
 `runner-extras` is untouched by this PR.
 
 Written by agent fbk-2 (automated implementation agent).
+
+## 2026-09-07 — `runner-extras` `published-application-system-table` 7 → 9 (#3072)
+
+Two tests added to `tests/runner-extras/published-application-system-table`, which the BC 27.0
+leg reported as `[count-baseline] GROWTH: suite 'runner-extras' tests count: expected 338,
+actual 340`. Both are the runner-mechanism half of #3072 — that `NAV App Extra` (2000000157)
+now has a provider, so `Published Application`'s `"Tenant Visible"` and `"PerTenant Or
+Installed"` Lookup FlowFields compute `true` through BC's own `CalcFields` instead of reading
+the Boolean default for every app:
+
+- `TenantVisibleAndPerTenantOrInstalledReadTrueThroughNavAppExtra`
+- `NavAppExtraAnswersPerRuntimePackageIdRatherThanForEverything`
+
+Only the `runner-extras` figure moves, and it is a per-group edit, so what it adds up to
+depends on which leg you ask. Re-measured against `main` at `6027df55` rather than carried
+forward from the first draft of this entry — the endpoint totals here go stale as soon as
+another PR moves a sibling group:
+
+| leg | declared runner-extras total before | after |
+|---|---|---|
+| BC 27.0 | 338 | 340 |
+| BC 28.1 | 349 | 351 |
+
+The two legs differ because five groups carry `absentOn` for the 27.x line; the +2 is the same
+on both, and the group's own entry is what moved (7 → 9). The 27.0 pair is unchanged from the
+first measurement, which is a fact about which groups the intervening merges touched, not a
+reason to skip re-measuring.
+
+Nothing else here is this PR's to move. `al-language` is 2814 and the corpus pin is `2cba52d4`,
+both arriving from the #3263/#3178/#3279 entry immediately above rather than from here — this
+branch rebased onto it and kept both entries. The BC-behaviour half of #3072 is corpus PR #228,
+which has now **merged** (`17b015ef`), but its pin bump is deliberately NOT taken here: it sits
+past `2cba52d4` and is sequenced separately (#3304). So `al-language-onprem` stays at 25 and
+picks up its own +4 with that later bump. Growth is the expected direction; this file exists to
+catch the count going down.
+
+Written by agent stma-auto-3 (automated implementation agent).

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -41,7 +41,7 @@
         "permission-set-assignment": { "tests": 6 },
         "precompiled-table-relation": { "tests": 10 },
         "precompiled-tableext-keys": { "tests": 6 },
-        "published-application-system-table": { "tests": 7 },
+        "published-application-system-table": { "tests": 9 },
         "query-join-aggregation-oos": { "tests": 4 },
         "report-precompiled-dep-metadata": { "tests": 2 },
         "server-multibundle-dep": { "tests": 0 },

--- a/tests/runner-extras/published-application-system-table/PastTests.Codeunit.al
+++ b/tests/runner-extras/published-application-system-table/PastTests.Codeunit.al
@@ -118,11 +118,10 @@ codeunit 65572 "PAST Tests"
         // silently discarded, and stamping a DIFFERENT id on the 2000000212 row would leave
         // Installed false with the row present — neither is visible from the upstream test.
         //
-        // "Tenant Visible" and "PerTenant Or Installed" are deliberately NOT asserted here.
-        // They are Lookup FlowFields over "NAV App Extra" (2000000157), which System.app ships
-        // as a VIRTUAL table, so there is no row for the runner to seed the way there is for
-        // 2000000212, and no service tier has been asked what it reports for them (#3072).
-        // An unmeasured pin is exactly what #3066 had to undo.
+        // "Tenant Visible" and "PerTenant Or Installed" have their own two tests below, added
+        // by #3072. They are Lookup FlowFields over "NAV App Extra" (2000000157), a VIRTUAL
+        // table with no row to seed, so the runner answers them through a provider instead -
+        // and the tier's own answer is asked upstream in corpus PR #228, not pinned here.
         NavApp.GetCurrentModuleInfo(Mi);
         PublishedApplication.SetRange(ID, Mi.Id());
         PublishedApplication.FindFirst();
@@ -144,6 +143,99 @@ codeunit 65572 "PAST Tests"
         Assert.IsFalse(
             InstalledApplication.Get(CreateGuid(), ''),
             'Installed Application must not answer for a runtime package id nothing was seeded under.');
+    end;
+
+    [Test]
+    procedure TenantVisibleAndPerTenantOrInstalledReadTrueThroughNavAppExtra()
+    var
+        PublishedApplication: Record "Published Application";
+        Mi: ModuleInfo;
+    begin
+        // THE RUNNER-SIDE HALF of upstream's two "NAV App Extra" FlowField tests (#3072,
+        // corpus PR #228). Upstream asserts the observable on a real tier; this asserts that
+        // the runner reaches the same answer through the mechanism BC uses, which upstream
+        // cannot see.
+        //
+        //   field(30; "Tenant Visible";         Lookup("NAV App Extra"."Tenant Visible"         WHERE(...)))
+        //   field(31; "PerTenant Or Installed"; Lookup("NAV App Extra"."PerTenant Or Installed" WHERE(...)))
+        //
+        // "NAV App Extra" (2000000157) is a VIRTUAL table - System.app ships it under
+        // src/Virtual Tables/ and Ncl's own NavAppExtraDataProvider computes every row from
+        // the session's app metadata. So there is no row to seed the way there is for
+        // Installed Application (2000000212); the runner answers by providing the rows the
+        // way BC's provider would.
+        //
+        // WHY TRUE AND NOT FALSE IS THE ASSERTION. Both columns are Boolean, so an
+        // implementation that computes NOTHING reads false, and so does one that computes
+        // "no". Pinning false would pass against either, which is exactly how the Installed
+        // FlowField's wrong reading survived until #3066 measured it. True can only come from
+        // a computation.
+        NavApp.GetCurrentModuleInfo(Mi);
+        PublishedApplication.SetRange(ID, Mi.Id());
+        Assert.IsTrue(PublishedApplication.FindFirst(), 'The bundle under test must have a Published Application row.');
+
+        PublishedApplication.CalcFields("Tenant Visible", "PerTenant Or Installed");
+        Assert.IsTrue(PublishedApplication."Tenant Visible",
+            'Tenant Visible must compute true through NAV App Extra for an app this session loaded.');
+        Assert.IsTrue(PublishedApplication."PerTenant Or Installed",
+            'PerTenant Or Installed must compute true through NAV App Extra for an app this session loaded.');
+    end;
+
+    [Test]
+    procedure NavAppExtraAnswersPerRuntimePackageIdRatherThanForEverything()
+    var
+        PublishedApplication: Record "Published Application";
+        NavAppExtra: Record "NAV App Extra";
+        Mi: ModuleInfo;
+        Rpid: Guid;
+        SeededCount: Integer;
+    begin
+        // The negative half, and what stops "answer true to everything" passing the test
+        // above. NAV App Extra is keyed on "Runtime Package ID": a row exists for each app
+        // this session loaded and carries THAT app's package id, and an id nobody loaded has
+        // no row at all. A provider that returned one row for every key, or answered a
+        // constant, fails here.
+        NavApp.GetCurrentModuleInfo(Mi);
+        PublishedApplication.SetRange(ID, Mi.Id());
+        PublishedApplication.FindFirst();
+        Rpid := PublishedApplication."Runtime Package ID";
+
+        Assert.IsTrue(NavAppExtra.Get(Rpid),
+            'NAV App Extra must have a row for an app this session loaded.');
+        Assert.AreEqual(PublishedApplication."Package ID", NavAppExtra."Package ID",
+            'The NAV App Extra row must carry the same package id as the published row, not a second value.');
+        Assert.IsTrue(NavAppExtra."Tenant Visible", 'The row itself must carry Tenant Visible true, not just the FlowField.');
+        Assert.IsTrue(NavAppExtra."PerTenant Or Installed", 'The row itself must carry PerTenant Or Installed true.');
+
+        Assert.IsFalse(NavAppExtra.Get(CreateGuid()),
+            'NAV App Extra must not answer for a runtime package id nothing was loaded under.');
+
+        // EVERY app the runner listed as published must have its own row here, checked row by
+        // row rather than by comparing two counts. Two equal counts prove nothing when both
+        // are 1, and they would also be satisfied by a table carrying the right NUMBER of
+        // rows under the wrong keys - which is the state that makes some apps read true and
+        // others false, from a table that looks the right size.
+        Clear(PublishedApplication);
+        PublishedApplication.FindSet();
+        repeat
+            Clear(NavAppExtra);
+            Assert.IsTrue(
+                NavAppExtra.Get(PublishedApplication."Runtime Package ID"),
+                'Every published app needs its own NAV App Extra row, or that app reads false.');
+            Assert.AreEqual(
+                PublishedApplication."Package ID", NavAppExtra."Package ID",
+                'Each row must carry its own app''s package id, not another app''s.');
+            Assert.IsTrue(NavAppExtra."Tenant Visible", 'Every published app must read visible.');
+            Assert.IsTrue(NavAppExtra."PerTenant Or Installed", 'Every published app must read per-tenant or installed.');
+            SeededCount += 1;
+        until PublishedApplication.Next() = 0;
+
+        // And nothing EXTRA: a row the runner cannot name a published app for would answer
+        // true for an id no Published Application row carries.
+        Clear(NavAppExtra);
+        Assert.AreEqual(SeededCount, NavAppExtra.Count(),
+            'NAV App Extra must carry exactly one row per published app - no more.');
+        Assert.IsTrue(SeededCount > 0, 'The loop above must have checked at least one app.');
     end;
 
     [Test]


### PR DESCRIPTION
Closes #3072

`Published Application` (2000000206) carries three Boolean FlowFields. #3066 settled the first
one — `Installed` — and deliberately left the other two open. This is those two.

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/228

That corpus PR asked a real tier what it reports for both columns, and **the tier answered `true` for both, on all eight OnPrem legs, BC 27.0 through 28.4** (run 34076138834, all 16 legs green). So the runner change below is no longer resting on a reading — a service tier adjudicated it.

**That corpus PR has since MERGED** as `17b015ef`. The pin is deliberately **not** bumped here. Rebased onto `6027df55`, this branch now carries `main`'s own pin `2cba52d4` (moved there by the #3263/#3178/#3279 merge, not by me) — `git diff origin/main...HEAD` shows no submodule entry at all. The bump that would pick up corpus #228 sits past `2cba52d4` and is sequenced separately under #3304, so `al-language-onprem` stays at **25** in the count baseline and takes its own +4 with that later bump.

Per-leg, read out of the job logs by test name rather than inferred from a total — all four new tests **executed and passed** on every OnPrem leg, and each leg went 25 → 29 tests:

| leg | new tests passed | new failures | leg total |
|---|---|---|---|
| OnPrem 27.0 / 27.3 / 27.5 | 4 / 4 each | 0 | 29 passed each |
| OnPrem 28.0 / 28.1 / 28.2 / 28.3 / 28.4 | 4 / 4 each | 0 | 29 passed each |

One measurement note worth recording, because it nearly produced a wrong report: the 27.x legs print `PASS  <name>` and the 28.x legs print `PASS <name> (675ms)`, so a single regex written for one spelling reports **0 executed** on the other three legs while they are in fact green. The counts above come from a pattern checked against real lines in the log.

## The gap

`NAV App Extra` (2000000157) had no provider. It routed to the same empty in-memory store as any
unprovided table, so both Lookup FlowFields read the Boolean default for every app.

`false` is not a *missing* answer on this surface. `Tenant Visible` gates what the
extension-management pages and several System Application callers consider visible to a tenant, so
a runner answering false for every app answers **"no app is visible to this tenant"**. And because
the columns are Boolean, "computed no" and "computed nothing" produce the same observable — which
is precisely how `Installed`'s wrong reading survived here until a tier contradicted it.

## What BC actually computes

Read off Ncl's own `NavAppExtraDataProvider` (`get_TableId => 2000000157`), identical on 27.5 and
28.1 — not inferred from the AL:

```
GetAllItems():
    buffer[0] = RuntimePackageId
    buffer[1] = IsAppVisibleToTenant(app, session tenant)
    buffer[2] = app.Scope == NavAppScope.Tenant || app is in this tenant's app group
    buffer[3] = PackageId

IsAppVisibleToTenant(app, tenantId):
    Scope == Global -> true
    Scope == Tenant -> app.TenantId == tenantId
    otherwise       -> false
```

## Per column, as the issue asked

Both are answerable, and neither needed a value invented.

| column | what the data carries | what the runner answers |
|---|---|---|
| `Tenant Visible` | `IsAppVisibleToTenant`, driven by app scope | **true.** The runner has one tenant and one session, and every app it loaded is loaded *for* that session. There is no per-tenant scoping to be excluded by, so BC's `Global` branch is the one that applies. |
| `PerTenant Or Installed` | scope, OR membership of this tenant's installed app group | **true.** #3066 already seeds an `Installed Application` (2000000212) row for every one of these apps on the same runtime package id, and `Published Application.Installed` reads true from it. An app the runner reports as installed cannot also report as not-installed here without the two tables contradicting each other. |

Neither is stated as a claim about what a tier reports for an arbitrary app — that is what corpus
PR #228 is for.

## BC's own provider is tried first, and produces 0 rows here — measured

The `FeatureKeyVirtualTable` precedent is followed: construct Ncl's own provider on the skeleton
session and take its rows. Instrumented on BC 28.1.49838.53910, it returns **0 rows**, and the
fallback is what answers. Structural, not incidental — the provider reads
`NavEnvironment.Instance.NavAppMetadataRetriever.GetAllMetadata()` and
`Session.Tenant.NavAppGroup`; the runner publishes and installs nothing, so the retriever is empty
and the group is `NavAppGroup.BaseGroup`.

It is still tried first on purpose: the day the runner populates that retriever, BC's rows should
win without this file needing to be found and changed.

The fallback builds the same four columns from the **same** `BcRuntime.RegisteredModules()` list
and the **same** `AppPackageIdentity` values the Published Application seeder uses, so a row here
and that app's 2000000206 row can never disagree about which app they describe.

## Fix the shape, not the reported line

**1. Same wrong pattern at another call site?** No other table reads `NAV App Extra`; grep for
2000000157 across the tree found only this file and the seeder's own comment saying the columns
were unanswered. That comment is now corrected rather than left stale — a stale header is how the
two `Installed` errors survived, and #3066's own body says so.

**2. Does a sibling make the same assumption?** Yes, and it is fixed here. The Published
Application seeder splits into `EnsurePublishedApplicationDependencyRowsSeeded` and a later
`EnsurePublishedApplicationBundleRowSeeded` — because `RegisteredModules()` is a **live** view, not
a fixed list.

**3. Two code paths writing the same state, same invariant?** This is the one that changed the
design. A one-shot `ConditionalWeakTable` latch — the shape `FeatureKeyVirtualTable` and
`WindowsLanguageVirtualTable` both use, and what this file had first — is safe for *those* tables
because BC's culture list and feature list cannot change mid-run. It is **not** safe here: a read
of 2000000157 landing before the bundle registers would populate the table without the bundle's
row, latch, and every later read — including the bundle asking about itself — would get `false`
from a table that looks populated. Replaced with a per-runtime-package-id ledger topped up on every
handout, mirroring `AllObj`. Only the first handout may refuse; a later one legitimately inserts
nothing.

## RED → GREEN

`tests/runner-extras/published-application-system-table`, two new tests, both runner-mechanism
claims (the BC-behaviour half is corpus #228):

- `TenantVisibleAndPerTenantOrInstalledReadTrueThroughNavAppExtra` — both FlowFields compute true
  through BC's own `CalcFields`. Nothing writes to a FlowField, which would be silently discarded.
- `NavAppExtraAnswersPerRuntimePackageIdRatherThanForEverything` — the negative half. Iterates
  **every** Published Application row and requires each to have its own 2000000157 row carrying
  *that app's* package id; then requires no extra rows; then requires an unloaded id to have no row
  at all.

```
RED  (dispatch branch disabled): 7P / 2F — exactly the two new tests fail, nothing else moves
GREEN (as committed):            9P / 0F
```

Neither test can pass against an implementation returning `false` — `false` is the bug. The
per-row loop replaced an earlier count-vs-count assertion that compared 1 to 1 in this
floor-free bundle and therefore proved nothing.

Also run: the full al-language corpus, **2757 / 2757 pass**, 0 fail, 0 error (`--strict
--count-baseline`).

## Not folded, and why

- **#2961** (`NAV App Installed App`, 2000000153 — `NavApp.VersionInstalled` answers for nothing).
  Adjacent in subject and the closest thing to a sibling in the queue, but a **different table** in
  a different file, and its own body states its reader/column scope is unsurveyed. Folding it would
  mean doing that survey inside this PR. Left open and unclaimed.
- **#3063** (Page Metadata, nine columns). Another virtual table, different file. It touches the
  same `GetDataAccessForTableCore` if-chain, which is the standing conflict point for every
  virtual-table PR — no open PR carries it right now, so nothing to coordinate yet, but whichever
  lands second rebases there.

## Not touched

`CacheVersion` (33) — no parse changed and no record shape changed. This adds rows to a virtual
table computed at data-access handout time; nothing that a cached record is decoded from moved. The
corpus pin stays at whatever `main` carries (`2cba52d4` as of `6027df55`); this branch does not move it.

---
*Implemented by an agent (`stma-auto-3`) acting on the account holder's behalf.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4
