### PR TITLE
fix(ci-wait): fall through to the API when a failing-log fetch comes back empty

### DIFF
--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -281,6 +281,50 @@ evidence a diagnosis needs, and section 5's flake-evidence standard needs a seco
 run, not the same one overwritten in place. See "Getting a second run of the same commit"
 under section 5 for how to get one without this.
 
+### An empty log fetch is a refusal, not an empty log
+
+Both recipes above can print **nothing at all** for a job whose log is thousands of lines,
+and neither says "refused" anywhere a caller reading stdout will see it. This is the same
+family as the `grep -E` and `rg --hidden` traps in `CLAUDE.md`: a failure that looks like a
+result. It matters more here than an inconvenience, because the instinct an empty log
+provokes is to re-run and see — the one thing section 3 exists to forbid.
+
+They fail on **different** jobs, so neither alone is a fallback for the other:
+
+| recipe | empty when | how it looks |
+|---|---|---|
+| `gh run view --log-failed` | the job has no step whose conclusion is `failure` — a `cancelled` job, or one whose failing step was cancelled | **exit 0**, zero bytes: indistinguishable from success on an empty log |
+| `gh api .../jobs/<id>/logs` | the log carries terminal escape sequences, which BC logs do routinely | exit 1, zero bytes on **stdout**, the reason only on stderr |
+
+Measured 2026-09-07 against `gh` 2.98.0, on two jobs of the same repository:
+
+```
+job 101602519097 (BC 28.4, failure)   --log-failed 875921 B   api 0 B   api+flag 709372 B
+job 101605637617 (Smoke, cancelled)   --log-failed      0 B   api 0 B   api+flag  26388 B
+```
+
+So when one comes back empty, try the other before concluding anything:
+
+```bash
+gh api repos/<owner>/<repo>/actions/runs/<run-id>/jobs \
+  --jq '.jobs[]|select(.conclusion=="failure" or .conclusion=="cancelled")|"\(.id) \(.name)"'
+gh api repos/<owner>/<repo>/actions/jobs/<job-id>/logs --allow-escape-sequences
+```
+
+`--allow-escape-sequences` is not optional on the API form. Without it `gh` writes nothing to
+stdout and puts `the response contains terminal escape sequences` on stderr, so a `$(...)`
+capture or a pipe sees an empty log and no error at all.
+
+`tools/ci-wait.py` does this for you on exit 1 — it tries `--log-failed`, falls through to the
+API form, and when both come back empty says so rather than pointing you back at the command
+that just returned nothing (#3309). What it prints when it has no log is a statement that both
+were refused, never that the job has none.
+
+The cost of not knowing this was a wrong diagnosis, not a lost minute: diagnosing PR #3305's
+red 28.4 leg, an empty `--log-failed` was read as "the log is not available yet" and the PR was
+handed back with a guessed hypothesis instead of the failing test name, which was in the log
+the whole time.
+
 ### "Cancelled" does not mean "no log to lose"
 
 This rule used to exempt cancelled runs outright, on the reasoning that a cancelled run never

--- a/.claude/skills/al-runner-workflow/SKILL.md
+++ b/.claude/skills/al-runner-workflow/SKILL.md
@@ -66,7 +66,7 @@ Once detected, here is which tool covers which operation:
 | Open a PR | `gh pr create` | `mcp__github__create_pull_request` |
 | Label a PR | `gh pr edit --add-label` | `mcp__github__update_pull_request` |
 | **Edit a PR body** | `tools/pr-body.py <N> --replace OLD NEW` (never a hand-rolled fetch/modify/upload — see `.claude/rules/branch-and-pr.md`) | `mcp__github__update_pull_request` after reading the body back, with the same care |
-| Read failing CI logs | `gh run view --log-failed` | `mcp__github__get_job_logs` (`failed_only: true`, `return_content: true`) |
+| Read failing CI logs | `gh run view --log-failed` — **empty output is a refusal, not an empty log**; see `.claude/rules/ci-verdicts.md` §3 | `mcp__github__get_job_logs` (`failed_only: true`, `return_content: true`) |
 | Search for duplicates | `gh issue list --search` | `mcp__github__search_issues` |
 
 Any agent definition granting `Bash` for GitHub work must also grant the

--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -238,7 +238,11 @@ failed" as "only BC 27.0 is affected" started a version-specific investigation o
 turned out to be eight failing legs.
 
 **Never `gh run rerun` a failed job** — it destroys the log permanently. Read
-`--log-failed` first, then push a new commit.
+`--log-failed` first, then push a new commit. An **empty** `--log-failed` is a
+refusal rather than an empty log — the job's failing step was cancelled, so
+there is no `failure` step to print; fetch it with
+`gh api repos/<o>/<r>/actions/jobs/<id>/logs --allow-escape-sequences` instead
+of concluding there is nothing to read (`.claude/rules/ci-verdicts.md` §3).
 
 **A CANCELLED check blocks the merge, with everything green and nothing saying why.**
 A ruleset satisfies a required check from the *newest* check run carrying that context name on

--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -25,8 +25,9 @@ keep getting wrong:
     head SHA, so a newer completed run for an older push is never reported as
     this push's result.
   * NEVER re-run a failed job -- it destroys the log. On failure this fetches
-    `--log-failed` for you, so there is no reason to reach for a re-run and no
-    second round trip to read it.
+    the log for you -- through `--log-failed`, falling back to the API form
+    that survives escape sequences (#3309) -- so there is no reason to reach
+    for a re-run and no second round trip to read it.
 
 Usage
 -----
@@ -185,6 +186,37 @@ def job_id_from(details_url: str | None) -> str | None:
         return None
     m = re.search(r"/job/(\d+)", details_url)
     return m.group(1) if m else None
+
+
+def failing_log(job: str) -> str:
+    """A failing job's log, through whichever of the two recipes answers (#3309).
+
+    Both documented ways of reading a failed job's log have an empty-output
+    failure mode, they fail on different jobs, and neither says "refused" in a
+    way a caller reading stdout can see:
+
+      * `gh run view --log-failed` prints only steps whose conclusion is
+        `failure`. A job that concluded `cancelled`, or whose failing step was
+        cancelled, has no such step -- so it prints ZERO BYTES and exits 0.
+        Measured on job 101605637617 (`bc-tests / Smoke net8.0`, cancelled):
+        0 bytes here, 26388 bytes from the API.
+      * `gh api .../jobs/<id>/logs` refuses a response carrying terminal escape
+        sequences unless `--allow-escape-sequences` is passed. BC logs carry
+        them routinely. Measured on job 101602519097: 0 bytes on stdout, exit 1,
+        and the reason on stderr -- which reads as an empty log.
+
+    So try --log-failed (it filters to the failing step, which is what a reader
+    wants), and fall through to the API when it comes back empty. An empty
+    string from here means both refused, never "this job has no log".
+    """
+    rc, out = gh(["run", "view", "--repo", REPO, "--log-failed", "--job", job])
+    if rc == 0 and out:
+        return out
+    # `--allow-escape-sequences` is not optional: without it gh exits 1 with
+    # nothing on stdout, which is indistinguishable from an empty log.
+    rc, out = gh(["api", f"repos/{REPO}/actions/jobs/{job}/logs",
+                  "--allow-escape-sequences"])
+    return out if rc == 0 and out else ""
 
 
 def head_sha(pr: str) -> str | None:
@@ -1185,16 +1217,22 @@ def main() -> int:
                 # wants; passing it fails with "could not find job". The job id is the
                 # trailing path segment of details_url (.../actions/runs/<run>/job/<job>).
                 job = job_id_from((v.log_target or {}).get("details_url"))
-                rc, out = (gh(["run", "view", "--repo", REPO, "--log-failed", "--job", job])
-                           if job else (1, ""))
-                if rc == 0 and out:
+                out = failing_log(job) if job else ""
+                if out:
                     tail = out.split("\n")[-120:]
                     print("\n--- failing log (tail) ---")
                     print("\n".join(tail))
                 else:
+                    # Both recipes came back empty, so do NOT send the reader to
+                    # the one that just did -- name the other one too (#3309).
                     where = job or "<job id>"
-                    print("\n(could not fetch the failing log; read it with "
-                          f"`gh run view --repo {REPO} --log-failed --job {where}`)")
+                    print("\n(could not fetch the failing log; BOTH recipes came back "
+                          "empty, which is a refusal, not an absent log -- try")
+                    print(f"   gh run view --repo {REPO} --log-failed --job {where}")
+                    print(f"   gh api repos/{REPO}/actions/jobs/{where}/logs "
+                          "--allow-escape-sequences")
+                    print(" -- an empty --log-failed means the failing step was "
+                          "cancelled; an empty api means escape sequences)")
                     if (v.log_target or {}).get("details_url"):
                         print(f" or open {v.log_target['details_url']}")
             print("\nNEVER `gh run rerun` -- it overwrites this log permanently. "

--- a/tools/test_ci_wait.py
+++ b/tools/test_ci_wait.py
@@ -1348,6 +1348,104 @@ check("...and every such recipe extracts the freshness helper alongside it",
       "\n---\n".join(b for b in _extracting if "agent_self_freshness.py" not in b))
 
 
+# ---------------------------------------------------------------------------
+# #3309 -- an empty failing-log fetch is a REFUSAL, not an empty log.
+#
+# Both documented recipes have an empty-output failure mode, and they fail on
+# DIFFERENT jobs, which is why one alone is not enough:
+#
+#   * `gh run view --log-failed` prints only steps whose conclusion is
+#     `failure`. A job that concluded `cancelled` -- or whose failing step was
+#     cancelled -- has none, so it prints ZERO BYTES and exits 0. Measured on
+#     job 101605637617 of run 34077033494 (`bc-tests / Smoke net8.0`,
+#     conclusion `cancelled`, its `Build Release` step `cancelled`): 0 bytes
+#     from --log-failed, 26388 bytes from the API.
+#   * `gh api .../jobs/<id>/logs` REFUSES when the log carries terminal escape
+#     sequences, which BC logs do routinely: exit 1, zero bytes on stdout, and
+#     the reason on stderr. Measured on job 101602519097 of run 34076096593:
+#     0 bytes without the flag, 709372 bytes with --allow-escape-sequences.
+#
+# The claim proved here is that failing_log() tries the second when the first
+# comes back empty, and that an empty answer from BOTH is reported as a
+# refusal naming the reason -- never as "there is no log".
+# ---------------------------------------------------------------------------
+
+
+def _log_calls(stub):
+    """Run cw.failing_log() against a stubbed gh, returning (text, calls)."""
+    calls: list[list[str]] = []
+    old = cw.gh
+
+    def _gh(args, attempts=4):
+        calls.append(list(args))
+        return stub(list(args))
+
+    cw.gh = _gh
+    try:
+        return cw.failing_log("123"), calls
+    finally:
+        cw.gh = old
+
+
+def _is_api(args):
+    return args[0] == "api" and "logs" in args[1]
+
+
+def _is_run_view(args):
+    return args[:2] == ["run", "view"]
+
+
+# 1. The happy path stays one call: --log-failed answers, the API is not asked.
+_text, _calls = _log_calls(lambda a: (0, "boom: Assert.AreEqual failed") if _is_run_view(a) else (1, ""))
+check("#3309: a non-empty --log-failed is used as-is",
+      _text == "boom: Assert.AreEqual failed", repr(_text))
+check("#3309: ...and the API is not asked when --log-failed answered",
+      not any(_is_api(a) for a in _calls), repr(_calls))
+
+# 2. The cancelled-job shape: --log-failed exits 0 with nothing. An empty
+#    success is NOT an answer -- fall through to the API.
+_text, _calls = _log_calls(
+    lambda a: (0, "") if _is_run_view(a) else (0, "the 3021 lines nobody could see"))
+check("#3309: an EMPTY --log-failed falls through to the API",
+      _text == "the 3021 lines nobody could see", repr(_text))
+check("#3309: ...and the API call passes --allow-escape-sequences",
+      any(_is_api(a) and "--allow-escape-sequences" in a for a in _calls), repr(_calls))
+check("#3309: ...and the API call targets the job's logs endpoint",
+      any(a[0] == "api" and a[1].endswith("/actions/jobs/123/logs") for a in _calls),
+      repr(_calls))
+
+# 3. Both empty: report the refusal, and say WHY it is not "no log". This is
+#    the exit-1 message that used to send the reader back to the command that
+#    had just returned nothing.
+_text, _calls = _log_calls(lambda a: (0, "") if _is_run_view(a) else (1, "escape sequences"))
+check("#3309: both empty yields no log text",
+      not _text, repr(_text))
+check("#3309: ...and both recipes were actually tried",
+      any(_is_run_view(a) for a in _calls) and any(_is_api(a) for a in _calls), repr(_calls))
+
+# 4. A stub that ALWAYS returns empty must not look like success, and a stub
+#    that ALWAYS succeeds must not hide the fallback -- the two directions the
+#    brief for #3309 asked this test to distinguish.
+_text, _ = _log_calls(lambda a: (0, ""))
+check("#3309: an always-empty gh produces no text (never a false log)", not _text, repr(_text))
+_text, _ = _log_calls(lambda a: (0, "always"))
+check("#3309: an always-succeeding gh produces text", _text == "always", repr(_text))
+
+# 5. The exit-1 hint must not send the reader back to the command that just
+#    came back empty without also naming the API form. Textual, deliberately:
+#    the failure it prevents is a human reading a dead end.
+_src = open(os.path.join(HERE, "ci-wait.py")).read()
+_hint = _src.split("could not fetch the failing log")[1][:900] if "could not fetch the failing log" in _src else ""
+check("#3309: the exit-1 hint still exists", bool(_hint), "")
+check("#3309: ...and offers the API form that survives escape sequences",
+      "--allow-escape-sequences" in _hint, _hint)
+
+# 6. The rule file has to carry the trap, or the next agent rediscovers it.
+check("#3309: ci-verdicts.md records that an empty --log-failed is not an empty log",
+      "--allow-escape-sequences" in _rule_text and "cancelled" in _rule_text,
+      "ci-verdicts.md does not mention the escape-sequence refusal")
+
+
 print()
 if FAILURES:
     print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")


### PR DESCRIPTION
Closes #3309

An empty log fetch is a **refusal**, not an empty log. Both documented recipes have that failure mode, they fail on **different** jobs, and neither says "refused" anywhere a caller reading stdout can see — so neither alone is a fallback for the other.

## What I measured

I reproduced the mechanism on real failed jobs before changing anything, as the brief asked. `gh` 2.98.0, 2026-09-07:

| job | `--log-failed` | `gh api .../logs` | `gh api … --allow-escape-sequences` |
|---|---|---|---|
| `101602519097` — BC 28.4, `failure` | 875921 B | **0 B** (exit 1) | 709372 B |
| `101605637617` — `Smoke net8.0`, `cancelled` | **0 B** (exit 0) | 0 B | 26388 B |

Two independent causes:

- **`gh run view --log-failed` prints only steps whose conclusion is `failure`.** Job `101605637617` concluded `cancelled` with its `Build Release` step `cancelled`, so there is no `failure` step to print: **zero bytes, exit 0**, indistinguishable from success on an empty log.
- **`gh api .../jobs/<id>/logs` refuses a response carrying terminal escape sequences** unless `--allow-escape-sequences` is passed. It writes nothing to stdout and puts the reason on **stderr**, so a pipe or a `$(...)` capture sees an empty log and no error.

**The issue had the mechanism the other way round** — it attributed the escape-sequence suppression to `--log-failed`. Measuring first showed `--log-failed` strips escapes and succeeds, while `gh api` is the one that refuses; it also turned up the cancelled-job path, which the issue did not have. The conclusion the issue drew is right; the cause is not the one it names, and a fix built on the issue body alone would have missed half the problem.

## The tool half (the one that matters)

`ci-wait.py`'s exit-1 path fetched only `--log-failed` and, when that came back empty, printed a hint pointing the reader at the very command that had just returned nothing.

New `failing_log(job)` tries `--log-failed` first (it filters to the failing step, which is what a reader wants), falls through to the API form with `--allow-escape-sequences`, and returns an empty string only when **both** refused. The exit-1 message now says both refused, names both recipes, and explains what each empty result means — rather than implying the job has no log.

End-to-end against the real cancelled job, this turns **0 characters into 26365**.

## RED → GREEN

RED: `AttributeError: module 'ci_wait' has no attribute 'failing_log'`.

GREEN: 12 new checks in `tools/test_ci_wait.py`, following that file's `check(...)` convention. The suite gates via `pr-gate.yml`'s glob-discovered `Run every tools/test_*.py` job.

Proven against three mutants, per the brief's requirement that a no-op implementation must fail:

| mutant | result |
|---|---|
| no API fallback (the pre-fix behaviour) | **4 checks fail** |
| `failing_log` always returns empty | **6 checks fail** |
| `failing_log` always returns text | **8 checks fail** |
| real implementation | all pass |

The tests assert the call *arguments*, not just the return value, so an implementation that fetched the API without `--allow-escape-sequences` — the bug itself — fails too.

## The doc half

`.claude/rules/ci-verdicts.md` §3 gets the trap with the measurement table, placed beside the existing `--log-failed` guidance and just before the complementary *"Cancelled" does not mean "no log to lose"* subsection.

The two skills that name the recipe in passing get a **cross-reference**, not a restatement — `al-runner-workflow`'s operation table and `orchestrating-a-session`'s re-run warning. Writing the trap out in three places invites exactly the drift this repo has been bitten by before.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site?** No. `ci-wait.py` is the only log-fetching call site in `tools/`; its three other `gh api` calls return JSON, which cannot carry raw escape sequences.
2. **Sibling function making the same assumption?** No sibling fetches logs. The two skills *documenting* the recipe are the sibling surface, and both are updated.
3. **Two paths writing the same state?** The success and failure paths of the exit-1 block are now consistent: both rest on `failing_log`, so there is no way for one to fetch differently from what the other reports.

## Scope

Kept to one coherent change: the tool fix and the documentation are the same finding, and splitting them would leave the rule pointing at a tool that does not do what it says.

Not folded in: **#3296** (the freshness guard failing open on an "unknown" state) touches `agent_self_freshness.py` with entirely different reasoning, and **#3245** (stale worktrees) is not a log-fetch question. Neither lands in these files.

## Gates

- `require-tests` does not trigger — no `AlRunner/` paths in the diff.
- **No `Corpus-NA:` trailer is required**, and I verified this rather than assuming: `check_corpus_linkage.sh` scopes to `AlRunner/Patches|Rewriters|NclCecilRewrite*|BcCompiler*|BcAssembler.cs`. Run against this diff it reports *"No file in this diff can change what AL observes, so no corpus declaration is required."* Adding a trailer anyway would be the reflexive paste the script's own comments warn about.
- Corpus pin untouched. `CacheVersion` untouched. Nothing under `AlRunner/Patches/`, so no overlap with PR #3308.

## Also run

`tools/test_preflight.py`, `tools/test_agent_self_freshness.py`, `.github/scripts/test_check_required_contexts.py` — all pass.

Opened by autonomous agent `stma-auto-1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4
