### PR TITLE
fix(tools): count a corpus run's per-leg passes correctly, and write down the five false zeros

### DIFF
--- a/.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md
+++ b/.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md
@@ -97,6 +97,8 @@ writing it into a comment, a doc table, or an issue as though it were establishe
 
 - `bc-behavior-tests-go-upstream.md` — where a BC-behavior test must live, and how to
   get a verdict out of the corpus CI
+- `verify-execution-not-the-tick.md` — a green corpus test is evidence only if it *ran*;
+  the check for that has produced a false zero five ways
 - `no-assumption-fixes.md` — understand the AL pattern before patching
 - `al-language-submodule.md` — the corpus is read-only here; how to bump the pin
 - `file-issues-for-gaps.md` — gaps get tracked, never silently worked around

--- a/.claude/rules/bc-behavior-tests-go-upstream.md
+++ b/.claude/rules/bc-behavior-tests-go-upstream.md
@@ -66,6 +66,8 @@ information the reviewer needs.
 - `ask-the-corpus-before-claiming-bc-behavior.md` — before you act on a belief
   about what BC does, read the corpus CI's verdict; a green corpus test outranks
   reading, a container differential, the docs, and a codeunit's name
+- `verify-execution-not-the-tick.md` — a green corpus leg does not prove your tests ran;
+  `tools/corpus-pass-count.py` answers it, and the hand-rolled check false-zeros five ways
 - `al-language-submodule.md` — the corpus is read-only here; how to bump the pin
 - `tdd.md` — every fix needs a RED → GREEN, and tests must prove, not just pass
 - `no-assumption-fixes.md` — understand the AL pattern before patching

--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -464,3 +464,5 @@ narrowly-scoped tool, not an addition to `ci-wait.py`.
 
 - `no-backgrounding-long-commands.md` — how to wait on anything long-running
 - `branch-and-pr.md` — branch naming, `Closes #N`, the assignee boundary
+- `verify-execution-not-the-tick.md` — the corpus-side companion: a green leg does not
+  prove the tests you added executed, and the check for that false-zeros

--- a/.claude/rules/verify-execution-not-the-tick.md
+++ b/.claude/rules/verify-execution-not-the-tick.md
@@ -1,0 +1,110 @@
+# A green tick does not prove execution — and the check for it false-zeros
+
+Corpus PR #220 carried 32 new tests. All 16 legs went green. **None of the 32 ever
+ran** — BC's per-object codegen had failed, and the other 2639 tests carried the run.
+So "did the tests I added actually execute" is a real step before merging a corpus PR,
+not ceremony.
+
+The problem is that the step itself has produced a **wrong answer — always zero, always
+in the shape of a result** — by five separate mechanisms, four of them on one day
+(#3311). Zero is exactly the answer that ends an investigation, so a false zero here
+silently removes the only guard against a green run that measured nothing. Twice an
+agent came within one step of reporting that passing tests had never executed.
+
+`CLAUDE.md` documents two members of this family already — `grep -E` exiting 0 after
+rejecting a flag, and `rg` skipping dot-directories. These are the same shape.
+
+## Use the tool
+
+```bash
+tools/corpus-pass-count.py <run-id> <prefix>     # prefix read from the .al file
+```
+
+It does the per-leg distinct count correctly in one call: both log spellings, distinct
+names rather than lines, per leg, and it separates "0 because the codeunit did not run
+here" from "0 because your pattern matched nothing". Exit 0 = at least one leg ran the
+codeunit and nothing failed; exit 1 = nothing matched anywhere, a leg disagrees with the
+others on the count, or something failed.
+
+Everything below is why the hand-rolled version keeps going wrong. Read it when the tool
+does not apply — a non-corpus log, a different harness — not instead of running it.
+
+## The five mechanisms
+
+**1. The per-leg log format is not the same on every leg.** Measured on run
+`34079169063`, all legs green, all 16 running:
+
+```
+BC 27.x:      PASS  TestPart_Visible_AnswersTrueForAReachablePart
+BC 28.x:        PASS TestPart_Visible_AnswersTrueForAReachablePart (240ms)
+```
+
+Two spaces and no timing on 27.x; one space, a duration, and a deeper indent on 28.x.
+`FAIL` differs the same way. A pattern written against either fixed spelling reports
+**0 on the other half of the matrix while those legs are green and executing** — on that
+run the fixed two-space pattern returned 0 on 28.0, 28.3 and 28.4, each of which had run
+all 28 tests. Use `PASS +<prefix>` with a `+` quantifier, never a literal run of spaces,
+and count **distinct names** so a duplicated line cannot inflate the figure either.
+
+**2. A guessed test-name prefix returns zero and looks like a finding.** Verifying corpus
+#225, an agent used `FPB_` by analogy; the real prefix was `FilterPageBuilder_`. Zero
+matches, and it was one step from reporting that 32 passing tests had never executed.
+**Read the prefix out of the diff or the `.al` file.** Never infer it from the feature's
+surface name.
+
+**3. A compiler that could not run reports no errors.** On corpus #227 the package cache
+had been cleared between turns, so `alc` failed with `AL1018` and emitted **no
+diagnostics at all** — which reads as "no errors" through a grep for `: error`. A real
+`AL0166` reached CI that way. Check that the compile *ran*, not merely that it printed
+nothing.
+
+**4. `rg` across `.github/workflows/` says a test file is un-gated when it is gated.**
+`pr-gate.yml`'s `tools-tests` job discovers suites by glob — `suites=(tools/test_*.py)` —
+so no filename appears anywhere in the workflow and searching for one finds nothing. An
+agent nearly concluded its own new test suite did not gate. A correctly-named
+`tools/test_*.py` gates the day it lands, with no workflow edit; `.github/scripts/test_*`
+works the same way.
+
+**5. `gh api .../logs` writes nothing, and exits 0, on a log carrying ANSI colour.**
+Measured while building `corpus-pass-count.py`: every corpus job log is coloured, so
+
+```bash
+gh api "repos/$CORPUS/actions/jobs/$id/logs" > leg.log     # 0 bytes, exit 0
+```
+
+produces an empty file and the message `the response contains terminal escape sequences;
+pass --allow-escape-sequences to output it anyway` — on **stdout**, so a redirect swallows
+it. An empty log then greps as "no matches". Pass `--allow-escape-sequences`, and treat an
+empty body as *unavailable*, never as zero passes.
+
+## The general rule these share
+
+**A zero from a pattern you chose is not evidence.** Confirm it with a second,
+differently-shaped query before believing it — and prefer one whose shape does not depend
+on the same assumption. Useful second queries on a corpus leg:
+
+- the harness's own summary line, `2915 total, 2915 passed, 0 failed, 0 skipped` — it
+  distinguishes a leg that ran a suite from one that never reached the test phase;
+- the count of *all* PASS names on the leg, which tells you the log parsed at all;
+- for a prefix question, grep for one full test name copied from the `.al` file.
+
+## Which legs were ever going to run it
+
+The corpus runs 16 legs: eight cloud and eight OnPrem, and **only the eight cloud legs are
+the required contexts**. The OnPrem legs run a different, much smaller suite — 29 tests
+against 2915 on run `34079169063` — and have run none of the recent cloud additions. They
+are green for unrelated reasons. So on a cloud-app corpus PR, eight zeros are the correct
+answer and eight non-zeros are the finding; reading the OnPrem zeros as "half the matrix
+did not run my tests" is a false alarm, and `corpus-pass-count.py` labels them `not-run`
+for exactly that reason.
+
+## Sister rules
+
+- `ci-verdicts.md` — the other half of "a green tick is not a verdict": stale runs,
+  cancelled leftovers in the rollup, and why a required context can be green on a commit
+  that is not yours
+- `bc-behavior-tests-go-upstream.md` — why the corpus adjudicates a BC claim at all;
+  `docs/upstream-corpus-workflow.md` § "Step 2 in full" is the long form
+- `ask-the-corpus-before-claiming-bc-behavior.md` — a corpus test green on a real service
+  tier is evidence only if it *ran*
+- `no-assumption-fixes.md` — a zero you cannot attribute is not a diagnosis

--- a/.claude/rules/verify-execution-not-the-tick.md
+++ b/.claude/rules/verify-execution-not-the-tick.md
@@ -42,7 +42,7 @@ BC 28.x:        PASS TestPart_Visible_AnswersTrueForAReachablePart (240ms)
 Two spaces and no timing on 27.x; one space, a duration, and a deeper indent on 28.x.
 `FAIL` differs the same way. A pattern written against either fixed spelling reports
 **0 on the other half of the matrix while those legs are green and executing** — on that
-run the fixed two-space pattern returned 0 on 28.0, 28.3 and 28.4, each of which had run
+run the fixed two-space pattern returned 0 on every 28.x cloud leg, each of which had run
 all 28 tests. Use `PASS +<prefix>` with a `+` quantifier, never a literal run of spaces,
 and count **distinct names** so a duplicated line cannot inflate the figure either.
 

--- a/docs/upstream-corpus-workflow.md
+++ b/docs/upstream-corpus-workflow.md
@@ -44,6 +44,27 @@ it. Having no
 container is the normal case for agents in web/remote sessions and is fully
 handled by this workflow.
 
+### Green is not the same as executed
+
+A green leg says the suite passed, not that *your* tests were in it. Corpus PR #220
+carried 32 new tests, went green on all 16 legs, and ran none of them — BC's per-object
+codegen had failed and the other 2639 tests carried the run. So before a corpus PR is
+merged, confirm the new tests actually executed, per leg:
+
+```bash
+tools/corpus-pass-count.py <run-id> <prefix>
+```
+
+Do not hand-roll that count. The 27.x and 28.x legs print `PASS` differently, a guessed
+name prefix returns zero that reads as a finding, and `gh api .../logs` writes an empty
+file and exits 0 on a coloured log — each of which reports zero while the tests are
+running fine. `.claude/rules/verify-execution-not-the-tick.md` has all five measured
+mechanisms and the second-query habit that catches them.
+
+Expect the eight OnPrem legs to report zero: they run a much smaller separate suite (29
+tests against 2915 on run `34079169063`) and are green for unrelated reasons. Only the
+eight cloud legs are the required contexts.
+
 ## Step 3 in full — why the orchestrator merges, not the authoring agent
 
 An impl agent opens the corpus PR and stops there. The orchestrator reviews

--- a/tools/corpus-pass-count.py
+++ b/tools/corpus-pass-count.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Did a corpus PR's tests actually RUN? Per-leg distinct counts, in one call.
+
+A green tick does not prove execution. Corpus PR #220 carried 32 new tests, all
+16 legs green, and **none of the 32 ever ran** -- BC's per-object codegen had
+failed and the other 2639 tests carried the run. Checking that the tests you
+added actually executed is therefore a real step, not ceremony.
+
+Doing that check by hand has produced a wrong answer -- always *zero*, always in
+the shape of a result -- by four separate mechanisms (#3311). This tool exists
+because a rule tells an agent what to do and a tool does it for them:
+
+  tools/corpus-pass-count.py <run-id> <prefix>
+
+It answers three questions that a grep conflates into one number:
+
+  * how many DISTINCT test names matching <prefix> passed, per leg;
+  * which legs ran the codeunit at all, versus which never saw it;
+  * whether a zero means "the codeunit did not run here" or "your pattern
+    matched nothing anywhere" -- different answers, and conflating them is the
+    whole defect this closes.
+
+Measured properties of the corpus log this parser is built on (run 34079169063,
+corpus PR #227, and run 34073808538 for the failing spellings):
+
+  BC 27.x:  `    PASS  Name`                 two spaces, no timing
+  BC 28.x:  `      PASS Name (675ms)`        one space, a duration
+  BC 27.x:  `    FAIL  Name - detail`
+  BC 28.x:  `      FAIL Name (308ms)`
+
+A pattern written against either fixed spelling reports 0 on the other half of
+the matrix while those legs are green and executing. `PASS +<prefix>` -- a `+`
+quantifier, never a literal run of spaces -- matches both.
+
+The eight OnPrem legs run a different, much smaller suite (29 tests on that run
+against 2915 cloud) and have run none of the recent cloud additions. They are
+green for unrelated reasons, so a 0 there is expected and is reported as
+`not-run`, not as a failure.
+
+Run: tools/corpus-pass-count.py 34079169063 TestPart_
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+import time
+
+CORPUS = "StefanMaron/BusinessCentral.AL.Language.Tests"
+
+# One space or many, so both the 27.x and the 28.x spelling match. A `+`, never
+# a fixed count -- the fixed count IS the bug (#3311 variant 1).
+_RESULT = re.compile(r"\b(PASS|FAIL)\s+([A-Za-z_][A-Za-z0-9_]*)")
+
+# The harness's own per-leg total, used as an INDEPENDENT second query: it tells
+# a leg that ran a suite apart from one that ran nothing at all.
+_TOTALS = re.compile(
+    r"(\d+) total, (\d+) passed, (\d+) failed, (\d+) skipped")
+
+TRANSIENT = ("i/o timeout", "connection reset", "502 Bad", "dial tcp",
+             "could not connect", "TLS handshake")
+
+
+def gh(args: list[str], attempts: int = 4) -> tuple[int, str]:
+    """Run gh, retrying transient network failures. Returns (rc, stdout)."""
+    last = ""
+    for i in range(attempts):
+        p = subprocess.run(["gh", *args], capture_output=True, text=True)
+        out = (p.stdout or "") + (p.stderr or "")
+        # mise prints a banner on stdout; drop it so JSON parses.
+        out = "\n".join(l for l in out.split("\n") if not l.startswith("mise "))
+        if not any(t.lower() in out.lower() for t in TRANSIENT):
+            return p.returncode, out.strip()
+        last = out
+        time.sleep(3 * (i + 1))
+    return 1, last.strip()
+
+
+def parse_leg(log: str, prefix: str) -> dict:
+    """Distinct PASS/FAIL names matching `prefix`, plus the harness's own total.
+
+    Distinct NAMES, not matching lines: a retried or re-echoed line would
+    otherwise inflate the figure, and an inflated count is as wrong as a zero.
+
+    `total` is None when the log carries no summary line -- which is what a leg
+    that never reached the test phase looks like, and is exactly the case that
+    must not be reported as "ran the suite, found none of yours".
+    """
+    passed: set[str] = set()
+    failed: set[str] = set()
+    all_names: set[str] = set()
+    for verdict, name in _RESULT.findall(log):
+        all_names.add(name)
+        if not name.startswith(prefix):
+            continue
+        (passed if verdict == "PASS" else failed).add(name)
+
+    total = None
+    for m in _TOTALS.finditer(log):
+        total = {"total": int(m.group(1)), "passed": int(m.group(2)),
+                 "failed": int(m.group(3)), "skipped": int(m.group(4))}
+    return {"passed": sorted(passed), "failed": sorted(failed),
+            "suite_names": len(all_names), "total": total}
+
+
+def classify(leg: dict) -> str:
+    """Why is this leg's count what it is?
+
+    The distinction this tool exists for. A zero has three different meanings and
+    a bare grep gives all three the same answer:
+
+      ran      - the codeunit executed here
+      failed   - it executed and something did not pass
+      not-run  - this leg ran a suite, and the codeunit was not part of it
+      no-suite - this leg never reached the test phase; a 0 here says nothing
+                 about your tests at all
+    """
+    if leg["failed"]:
+        return "failed"
+    if leg["passed"]:
+        return "ran"
+    if leg["total"] is None and leg["suite_names"] == 0:
+        return "no-suite"
+    return "not-run"
+
+
+def fetch_jobs(run_id: str) -> list[dict]:
+    rc, out = gh(["api", f"repos/{CORPUS}/actions/runs/{run_id}/jobs?per_page=100",
+                  "--jq", '.jobs[] | "\\(.id)\t\\(.name)\t\\(.conclusion)"'])
+    if rc != 0:
+        print(f"could not list jobs for run {run_id}:\n{out}", file=sys.stderr)
+        sys.exit(3)
+    jobs = []
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) == 3 and "/ test" in parts[1]:
+            jobs.append({"id": parts[0], "name": parts[1], "conclusion": parts[2]})
+    return jobs
+
+
+def fetch_log(job_id: str) -> str:
+    """A job's raw log.
+
+    `--allow-escape-sequences` is REQUIRED and its absence is a silent false
+    zero of its own: the corpus log carries ANSI colour, and without the flag gh
+    writes **nothing** to stdout and still exits 0. Redirected to a file that is
+    an empty file and a "no matches" answer, not an error anyone notices.
+    """
+    rc, out = gh(["api", "--allow-escape-sequences",
+                  f"repos/{CORPUS}/actions/jobs/{job_id}/logs"])
+    if rc != 0 or not out.strip():
+        return ""
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Per-leg distinct pass counts for a corpus run, done right.")
+    ap.add_argument("run_id", help="corpus Actions run id")
+    ap.add_argument("prefix", help="test-name prefix, read from the .al file -- never guessed")
+    ap.add_argument("--repo", default=CORPUS, help=argparse.SUPPRESS)
+    args = ap.parse_args()
+
+    globals()["CORPUS"] = args.repo
+
+    jobs = fetch_jobs(args.run_id)
+    if not jobs:
+        print(f"run {args.run_id} has no '/ test' legs -- wrong run id, or it "
+              f"never got past prepare", file=sys.stderr)
+        return 3
+
+    rows = []
+    for job in jobs:
+        log = fetch_log(job["id"])
+        if not log:
+            rows.append((job, None, "log-unavailable"))
+            continue
+        leg = parse_leg(log, args.prefix)
+        rows.append((job, leg, classify(leg)))
+
+    width = max(len(j["name"]) for j in jobs)
+    ran = [r for r in rows if r[2] == "ran"]
+    failed = [r for r in rows if r[2] == "failed"]
+    notrun = [r for r in rows if r[2] == "not-run"]
+
+    print(f"run {args.run_id}  prefix {args.prefix!r}\n")
+    for job, leg, kind in rows:
+        if leg is None:
+            print(f"  {job['name']:<{width}}  log-unavailable")
+            continue
+        suite = (f"suite {leg['total']['passed']}/{leg['total']['total']}"
+                 if leg["total"] else "no suite total in log")
+        n = len(leg["passed"])
+        note = {"ran": "", "failed": f" ({len(leg['failed'])} FAILED)",
+                "not-run": "  <- codeunit not in this leg's suite",
+                "no-suite": "  <- leg never reached the test phase"}[kind]
+        print(f"  {job['name']:<{width}}  {n:>4} distinct PASS  [{suite}]{note}")
+
+    print()
+    counts = {len(r[1]['passed']) for r in ran}
+    if failed:
+        for job, leg, _ in failed:
+            print(f"FAILING on {job['name']}: {', '.join(leg['failed'])}")
+        print()
+
+    if not ran and not failed:
+        # THE case this tool exists for. Every leg zero is not "the tests did
+        # not run" until you have shown the prefix appears somewhere.
+        anywhere = any(r[1] and r[1]["suite_names"] for r in rows)
+        print(f"NO leg ran any test matching {args.prefix!r}.")
+        if anywhere:
+            print("  Legs DID run suites, so either the codeunit genuinely did "
+                  "not execute\n  or the prefix is wrong. Read it out of the "
+                  ".al file -- do not infer it from\n  the feature name (#3311 "
+                  "variant 2). Then re-check.")
+        else:
+            print("  No leg produced any PASS/FAIL line at all, so this says "
+                  "nothing about\n  your tests -- the run did not reach the "
+                  "test phase.")
+        return 1
+
+    print(f"{len(ran)} leg(s) ran the codeunit; {len(notrun)} ran a suite "
+          f"without it; {len(failed)} had failures.")
+    if len(counts) > 1:
+        print(f"WARNING: legs disagree on how many passed: {sorted(counts)} -- "
+              f"a leg short of the others\n  is a real finding, not a log-format "
+              f"artifact (this tool matches both spellings).")
+        return 1
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_corpus_pass_count.py
+++ b/tools/test_corpus_pass_count.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/corpus-pass-count.py's log parsing and classification.
+
+Every fixture below is **verbatim from a real corpus run** -- run 34079169063
+(corpus PR #227, prefix `TestPart_`) for the passing spellings and the OnPrem
+suite, run 34073808538 for the failing ones. That matters more than usual here:
+the defect this tool closes is a parser written against one leg's spelling and
+believed on all of them, so a synthetic fixture shaped to satisfy the regex
+would test the author's idea of the log rather than the log (#3311).
+
+Run: python3 tools/test_corpus_pass_count.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "corpus_pass_count", os.path.join(HERE, "corpus-pass-count.py"))
+cpc = importlib.util.module_from_spec(_spec)
+sys.modules["corpus_pass_count"] = cpc
+_spec.loader.exec_module(cpc)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+# --------------------------------------------------------------------------
+# Recorded fixtures. Copied byte-for-byte, including the leading timestamp and
+# the indentation, which differs between the two BC families and is part of
+# what a hand-written pattern gets wrong.
+# --------------------------------------------------------------------------
+
+# BC 27.0 leg (job 101611063472): `PASS  Name` -- two spaces, no timing.
+LOG_27X = """2026-09-07T03:24:39.8545666Z     PASS  TestPart_Visible_AnswersTrueForAReachablePart
+2026-09-07T03:24:39.8546083Z     PASS  TestPart_InvisiblePart_IsNotInTheControlTreeAtAll
+2026-09-07T03:24:39.8546817Z     PASS  TestPart_Enabled_AnswersTrueForAReachablePart
+2026-09-07T03:24:39.8547274Z     PASS  TestPart_Editable_IsNotDrivenByTheHostControlsEditableProperty
+2026-09-07T03:27:42.7740689Z 2915 total, 2915 passed, 0 failed, 0 skipped, 0 codeunit error(s) in 411s
+"""
+
+# BC 28.4 leg (job 101611063464): `PASS Name (240ms)` -- one space, a duration.
+LOG_28X = """2026-09-07T03:26:47.4624638Z       PASS TestPart_Visible_AnswersTrueForAReachablePart (240ms)
+2026-09-07T03:26:47.4624821Z       PASS TestPart_InvisiblePart_IsNotInTheControlTreeAtAll (703ms)
+2026-09-07T03:26:47.4624990Z       PASS TestPart_Enabled_AnswersTrueForAReachablePart (282ms)
+2026-09-07T03:26:47.4625228Z       PASS TestPart_Editable_IsNotDrivenByTheHostControlsEditableProperty (766ms)
+2026-09-07T03:26:47.5267023Z 2948 total, 2948 passed, 0 failed, 0 skipped, 0 codeunit error(s) in 357s
+"""
+
+# BC OnPrem 27.0 leg (job 101611063560): green, ran a 29-test suite, and none of
+# it is TestPart_. A zero here is expected and means something different.
+LOG_ONPREM = """2026-09-07T03:20:59.4650313Z     PASS  Object_Get_UnknownKey_RaisesRecordNotFound
+2026-09-07T03:20:59.4653118Z     PASS  Object_HoldsNoRows_WhileObjectMetadataDoes
+2026-09-07T03:21:01.6546957Z 29 total, 29 passed, 0 failed, 0 skipped, 0 codeunit error(s) in 10s
+"""
+
+# Run 34073808538, a 28.x leg: FAIL carries the 28.x spelling too.
+LOG_28X_FAIL = """2026-09-07T01:49:19.7778707Z       FAIL FilterPageBuilder_AddTable_ZeroTableId_Throws (308ms)
+2026-09-07T01:49:19.7781836Z       FAIL FilterPageBuilder_Name_IndexZero_Throws (129ms)
+2026-09-07T01:49:19.7790000Z       PASS FilterPageBuilder_AddTable_KnownTable_Succeeds (44ms)
+2026-09-07T01:52:00.0000000Z 2915 total, 2911 passed, 4 failed, 0 skipped, 0 codeunit error(s) in 299s
+"""
+
+# Run 34073808538, the BC 27.5 leg: FAIL carries the 27.x spelling, and the
+# detail after the name must not be mistaken for another test.
+LOG_27X_FAIL = """2026-09-07T01:50:40.0711423Z     FAIL  FilterPageBuilder_AddTable_ZeroTableId_Throws — Assert.ExpectedError failed. Expected: . Actual: The filter page table ID must be a positive number greater than zero..
+2026-09-07T01:50:40.0745038Z     FAIL  FilterPageBuilder_Name_IndexZero_Throws — Assert.ExpectedError failed. Expected: . Actual: The filter control index value 0 is out of range.
+2026-09-07T01:52:00.0000000Z 2915 total, 2913 passed, 2 failed, 0 skipped, 0 codeunit error(s) in 299s
+"""
+
+# A leg that died before the test phase. No PASS/FAIL, no summary line -- so a
+# zero from it says nothing about anyone's tests.
+LOG_NO_SUITE = """2026-09-07T03:06:36.2318892Z Starting BC container
+2026-09-07T03:08:33.0862095Z error AL1018: Could not resolve dependency
+"""
+
+
+# --------------------------------------------------------------------------
+# 1. Both spellings, and the exact false zero this closes.
+# --------------------------------------------------------------------------
+print("both log spellings")
+
+r27 = cpc.parse_leg(LOG_27X, "TestPart_")
+r28 = cpc.parse_leg(LOG_28X, "TestPart_")
+
+check("the 27.x spelling (`PASS  Name`, two spaces, no timing) yields 4",
+      len(r27["passed"]) == 4, str(r27["passed"]))
+check("the 28.x spelling (`PASS Name (240ms)`) yields 4 as well",
+      len(r28["passed"]) == 4, str(r28["passed"]))
+check("...and both legs name the SAME four tests",
+      r27["passed"] == r28["passed"], f"{r27['passed']} vs {r28['passed']}")
+
+# The proof that the fixtures really do differ -- otherwise the two checks above
+# could both pass against one spelling accidentally pasted twice.
+check("the recorded fixtures genuinely carry different spellings",
+      "PASS  TestPart_Visible" in LOG_27X
+      and "PASS  TestPart_" not in LOG_28X
+      and "PASS TestPart_" in LOG_28X
+      and "ms)" in LOG_28X and "ms)" not in LOG_27X)
+
+# This is #3311 variant 1, held as an executable statement: the pattern an agent
+# actually wrote reports zero on a green leg that ran everything.
+check("a FIXED two-space pattern would report 0 on the 28.x leg (the bug)",
+      LOG_28X.count("PASS  TestPart_") == 0)
+check("...while the parser reports 4 there",
+      len(r28["passed"]) == 4)
+
+# The 28.x timing suffix must not be swallowed into the name.
+check("the (240ms) suffix is not part of the parsed name",
+      "TestPart_Visible_AnswersTrueForAReachablePart" in r28["passed"],
+      str(r28["passed"]))
+
+
+# --------------------------------------------------------------------------
+# 2. Distinct names, not matching lines.
+# --------------------------------------------------------------------------
+print("\ndistinct names, not lines")
+
+dup = LOG_27X + LOG_27X
+rdup = cpc.parse_leg(dup, "TestPart_")
+check("a log carrying every line twice still counts 4, not 8",
+      len(rdup["passed"]) == 4, str(len(rdup["passed"])))
+
+
+# --------------------------------------------------------------------------
+# 3. The three meanings of zero -- the point of the tool.
+# --------------------------------------------------------------------------
+print("\nzero has three different meanings")
+
+ronprem = cpc.parse_leg(LOG_ONPREM, "TestPart_")
+rnosuite = cpc.parse_leg(LOG_NO_SUITE, "TestPart_")
+
+check("a leg that ran the codeunit classifies as `ran`",
+      cpc.classify(r27) == "ran", cpc.classify(r27))
+check("a green OnPrem leg that ran a different suite is `not-run`, not a failure",
+      cpc.classify(ronprem) == "not-run", cpc.classify(ronprem))
+check("...and it is recognised as having run a suite (29 tests) all the same",
+      ronprem["total"] == {"total": 29, "passed": 29, "failed": 0, "skipped": 0},
+      str(ronprem["total"]))
+check("a leg that never reached the test phase is `no-suite`, a different answer",
+      cpc.classify(rnosuite) == "no-suite", cpc.classify(rnosuite))
+check("...and reports no suite total at all, rather than zero",
+      rnosuite["total"] is None, str(rnosuite["total"]))
+check("`not-run` and `no-suite` are distinguished, not collapsed",
+      cpc.classify(ronprem) != cpc.classify(rnosuite))
+
+# The guessed-prefix case (#3311 variant 2): a wrong prefix against a leg that
+# demonstrably ran 2915 tests must not look like "the codeunit did not run".
+rwrong = cpc.parse_leg(LOG_27X, "TPart_")
+check("a wrong prefix on a leg that ran 2915 tests yields 0 passes",
+      len(rwrong["passed"]) == 0)
+check("...but the leg is still seen to have run a suite, so the zero is "
+      "attributable",
+      rwrong["total"]["total"] == 2915 and rwrong["suite_names"] == 4,
+      str(rwrong))
+
+
+# --------------------------------------------------------------------------
+# 4. Failures are surfaced, in both spellings.
+# --------------------------------------------------------------------------
+print("\nfailures, both spellings")
+
+f28 = cpc.parse_leg(LOG_28X_FAIL, "FilterPageBuilder_")
+f27 = cpc.parse_leg(LOG_27X_FAIL, "FilterPageBuilder_")
+
+check("the 28.x FAIL spelling is picked up (2 failed, 1 passed)",
+      len(f28["failed"]) == 2 and len(f28["passed"]) == 1,
+      f"{f28['failed']} / {f28['passed']}")
+check("the 27.x FAIL spelling is picked up too",
+      len(f27["failed"]) == 2, str(f27["failed"]))
+check("a leg with failures classifies as `failed`, never as `ran`",
+      cpc.classify(f28) == "failed" and cpc.classify(f27) == "failed")
+check("the em-dash detail after a 27.x FAIL is not parsed as another test",
+      f27["failed"] == ["FilterPageBuilder_AddTable_ZeroTableId_Throws",
+                        "FilterPageBuilder_Name_IndexZero_Throws"],
+      str(f27["failed"]))
+check("a failed test is not also counted as passed",
+      not (set(f28["failed"]) & set(f28["passed"])))
+
+
+# --------------------------------------------------------------------------
+# 5. Anti-stub checks -- tdd.md. These are the ones a gutted implementation
+#    must not survive.
+# --------------------------------------------------------------------------
+print("\na stub implementation must not survive")
+
+# A parser returning a constant count fails: the same fixture yields different
+# counts for different prefixes, and different fixtures yield different counts.
+check("a constant-count stub is refused: same log, two prefixes, two answers",
+      len(cpc.parse_leg(LOG_27X, "TestPart_")["passed"]) == 4
+      and len(cpc.parse_leg(LOG_27X, "TestPart_Visible")["passed"]) == 1)
+check("...and different logs yield different counts",
+      len(cpc.parse_leg(LOG_ONPREM, "Object_")["passed"]) == 2
+      and len(cpc.parse_leg(LOG_27X, "TestPart_")["passed"]) == 4)
+
+# An always-zero stub fails on every `ran` fixture above; state it directly so
+# the intent is legible rather than implied.
+check("an always-zero stub is refused: three fixtures report non-zero",
+      all(len(cpc.parse_leg(lg, px)["passed"]) > 0
+          for lg, px in ((LOG_27X, "TestPart_"), (LOG_28X, "TestPart_"),
+                         (LOG_ONPREM, "Object_"))))
+
+# An always-`ran` classifier fails, and so does an always-`not-run` one.
+kinds = {cpc.classify(r27), cpc.classify(ronprem), cpc.classify(rnosuite),
+         cpc.classify(f28)}
+check("classify() returns four distinct verdicts across the four fixtures",
+      kinds == {"ran", "not-run", "no-suite", "failed"}, str(sorted(kinds)))
+
+
+# --------------------------------------------------------------------------
+# 6. The pattern itself, and the flag whose absence is its own false zero.
+# --------------------------------------------------------------------------
+print("\nthe parser's own shape")
+
+check("the result pattern uses a `+` quantifier on whitespace, not a fixed run",
+      r"\s+" in cpc._RESULT.pattern, cpc._RESULT.pattern)
+check("...so it cannot be a literal two-space or one-space match",
+      "PASS  " not in cpc._RESULT.pattern)
+
+# gh writes NOTHING and exits 0 on an ANSI-carrying log without this flag --
+# measured on this very run while building the tool. An empty file reads as
+# "no matches", so the flag is load-bearing, not cosmetic.
+import inspect  # noqa: E402
+src = inspect.getsource(cpc.fetch_log)
+check("fetch_log passes --allow-escape-sequences (without it gh emits nothing, "
+      "exit 0)",
+      "--allow-escape-sequences" in src)
+check("...and treats an empty body as unavailable rather than as zero passes",
+      "not out.strip()" in src)
+
+print()
+if FAILURES:
+    print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")
+    sys.exit(1)
+print("all checks passed")


### PR DESCRIPTION
Closes #3311

Verifying that a corpus PR's tests actually **ran** — rather than trusting a green tick — produced a wrong answer, always *zero*, four times in one day. Each time by a different mechanism; none was written down.

The step matters because a green tick does not prove execution: corpus PR #220 carried 32 new tests, went green on all 16 legs, and **ran none of them** — BC's per-object codegen had failed and the other 2639 tests carried the run. A check that itself false-zeros silently removes the only guard against that, and twice an agent came within one step of reporting that passing tests had never executed.

## Verified before building, not taken on trust

Reproduced against real corpus runs rather than accepted from the issue body.

**Variant 1 — the two log spellings — confirmed** on run `34079169063` (corpus PR #227, prefix `TestPart_`, 16 legs, all green):

```
BC 27.x:      PASS  TestPart_Visible_AnswersTrueForAReachablePart
BC 28.x:        PASS TestPart_Visible_AnswersTrueForAReachablePart (240ms)
```

Two spaces and no timing on 27.x; one space, a duration and a deeper indent on 28.x. Measured per leg, the fixed two-space pattern an agent actually wrote returns **0 on BC 28.0, 28.3 and 28.4** — each of which had run all 28 tests. `FAIL` differs the same way (`FAIL  Name — detail` vs `FAIL Name (308ms)`), confirmed on run `34073808538`.

**Variant 4 — `rg` says un-gated when gated — confirmed.** `pr-gate.yml:393` reads `suites=(tools/test_*.py)`. Glob discovery, so no filename appears anywhere in the workflow and a filename search finds nothing.

**Variants 2 and 3 are historical** and cited from the issue, not manufactured. Run `34073808538` incidentally corroborates variant 2: the real prefix was `FilterPageBuilder_`, not the guessed `FPB_`.

**A fifth, hit while building this.** `gh api .../logs` writes **nothing** and exits **0** on a log carrying ANSI colour — every corpus job log does. The warning goes to *stdout*, so a redirect swallows it, and the empty file greps as "no matches". This is the same family and is now documented.

## What ships

**1. `tools/corpus-pass-count.py <run-id> <prefix>`** — the higher-value half. One call, 20 seconds, for the whole matrix:

```
run 34079169063  prefix 'TestPart_'

  BC 27.3 / test           28 distinct PASS  [suite 2915/2915]
  BC 28.4 / test           28 distinct PASS  [suite 2948/2948]
  ...
  BC OnPrem 27.0 / test     0 distinct PASS  [suite 29/29]  <- codeunit not in this leg's suite
  ...
8 leg(s) ran the codeunit; 8 ran a suite without it; 0 had failures.
```

It handles both spellings, counts **distinct names** rather than lines, reports **per leg**, and separates the two zeros the issue is about. A wrong prefix no longer yields a bare zero:

```
NO leg ran any test matching 'TPart_'.
  Legs DID run suites, so either the codeunit genuinely did not execute
  or the prefix is wrong. Read it out of the .al file — do not infer it from
  the feature name (#3311 variant 2). Then re-check.
```

The eight OnPrem legs run a separate 29-test suite and are green for unrelated reasons, so their zeros are labelled `not-run` rather than reported as a failure.

**2. `.claude/rules/verify-execution-not-the-tick.md`** — all five mechanisms, the `PASS +<prefix>` form, read-the-prefix-from-the-file, count distinct, which legs were ever going to run it, and the habit these share: *a zero from a pattern you chose is not evidence — confirm with a second, differently-shaped query.* Written in the same register as `CLAUDE.md`'s `grep -E` and `rg --hidden` entries, which are the same family. Cross-linked from the three rules that send an agent to read a corpus verdict, and from `docs/upstream-corpus-workflow.md` § "Step 2 in full", where the step it guards is described.

## TDD

RED was real: the first run of `tools/test_corpus_pass_count.py` failed at import — `SyntaxError: name 'CORPUS' is used prior to global declaration`. A second RED followed on a fixture assertion I had written wrong, which the suite caught.

Every fixture is **verbatim from a real run** — `34079169063` for the passing spellings and the OnPrem suite, `34073808538` for the failing ones — because a synthetic fixture tests the author's idea of the log rather than the log. That is variant 1 in miniature.

Four mutants, each restored afterwards:

| mutant | checks failed |
|---|---|
| fixed two-space `_RESULT` (the real-world bug) | 9 |
| constant count | 12 |
| count lines instead of distinct names | 1 |
| `classify()` always returns `ran` | 5 |

The two the issue names explicitly — a stub returning a constant count, and one reporting zero for every leg — both fail. 30 checks pass on the real implementation; all five `tools/test_*.py` suites green together.

## Scope

Tool plus rule, judged as one coherent change: the rule's central advice *is* "run the tool", and shipping either alone leaves the other half of #3311 open. Nothing else in the queue lands in these files.

No `Corpus-NA:` trailer — `.github/scripts/check_corpus_linkage.sh` run against this exact diff reports *"No file in this diff can change what AL observes"*, exit 0. A `tools/` and `.claude/` change asserts nothing about BC. `require-tests` skips for the same reason (no `AlRunner/` paths). Corpus pin, `CacheVersion` and `tests/expectations/count-baseline/history.md` untouched.

Opened by an autonomous implementation agent (`stma-auto-1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4