### PR TITLE
test(corpus): advance the pin seven commits, as far as it goes green

### DIFF
--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -150,6 +150,44 @@ cloud app.
 No per-version override is needed: the range adds no preprocessor version guards, so `default`
 is correct for every leg. Measured on BC 28.1; the other seven legs are CI's word.
 
+### 2814 -> 2887, and onprem 25 -> 29 (pin 2cba52d4 -> 17b015e, corpus #220, #214, #221, #222, #225, #226, #228)
+
+A catch-up bump: every corpus PR in the range was already adjudicated on a real service tier
+upstream, and no runner fix was pending for any of the seven commits taken. It is green on its
+own, which is why it is its own PR (`al-language-submodule.md`, the catch-up case).
+
+`al-language` 2814 -> 2887 (+73) and `al-language-onprem` 25 -> 29 (+4). Both numbers were
+read off a run, not computed: the run at this pin reported them in its `[count-baseline]
+GROWTH` lines, and the run with these numbers in place exits 0. The onprem suite moves because
+corpus #228 added four `Published Application` FlowField tests to
+`record/TestPublishedApplicationSysTable.al`, and that table is `Scope = OnPrem`.
+
+Cross-checked by hand against the corpus source, per file, with comments and string literals
+stripped: 2889 `[Test]` procedures in the `al-language` app, of which two --
+`JsonObject_ReadFromYaml_OnCloudRuntime_IsNotSupported` and its `WriteToYaml` sibling in
+`session/TestFinalCoverage.al` -- sit behind `#if BC143PLUS`, which is not defined, so they
+compile out. 2889 - 2 = 2887, the runner's number exactly. A raw `[Test]` count over that
+subtree is 2889 and is wrong; the preprocessor is the reason.
+
+No per-version override is needed: none of the arriving files adds a preprocessor version
+guard. Measured on BC 28.1; the other seven legs are CI's word.
+
+**The pin stops at `17b015e`, two commits short of corpus `master`,** because corpus history is
+linear and the two commits after it fail against the runner today: `0bbe376` (corpus #227,
+TestPart, codeunit 60346, 11 tests) and `d025203` (corpus #229, TestFilter, codeunit 60350, 6
+tests). Measured at the tip on this same build: 17 failures, exactly those two codeunits and
+nothing else. Tracked by issues #3312, #3313 and #3009 for the TestPart cluster, and by #3316
+for five of the six TestFilter failures (`TestPage.Filter.CurrentKey` reporting field numbers,
+`SetCurrentKey`/`Ascending` not changing the walk order); the sixth is #3312's part-page id 0
+problem again.
+No `tests/expectations/` entry was added for any of them -- declaring a live, owned gap as
+settled classification is what `ask-the-corpus-before-claiming-bc-behavior.md` forbids, and
+leaving the two commits unpinned keeps the gap honest instead.
+
+`runner-extras` is untouched by this PR.
+
+Written by agent impl-1 (automated implementation agent).
+
 ## runner-extras
 
 ### object-metadata-system-table 4 -> 6 (PR for #2771)

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,11 +2,11 @@
   "_comment": "Schema, semantics and how to bump: README.md in this directory. Per-bump rationale: history.md, never a prose line in here (#2485).",
   "suites": {
     "al-language": {
-      "tests": { "default": 2814 },
+      "tests": { "default": 2887 },
       "appGroups": { "default": 1 }
     },
     "al-language-internals-fixture": { "tests": { "default": 0 }, "appGroups": { "default": 1 } },
-    "al-language-onprem": { "tests": { "default": 25 }, "appGroups": { "default": 1 } },
+    "al-language-onprem": { "tests": { "default": 29 }, "appGroups": { "default": 1 } },
     "runner-extras": {
       "groups": {
         "bundle-page-over-dep-table": { "tests": 2 },


### PR DESCRIPTION
Advances `tests/al-language` from `2cba52d4` to `17b015e`, seven of the nine commits upstream `master` is ahead by. This is the catch-up case in `.claude/rules/al-language-submodule.md`: every corpus PR in the range was already adjudicated on a real BC service tier, no runner fix is pending for any of them, and the bump is green on its own — so it is its own PR and is not folded into anything.

## The move is strictly forward

```
gh api repos/StefanMaron/BusinessCentral.AL.Language.Tests/compare/2cba52d4...17b015e
  ahead=7 behind=0 total=7

gh api .../compare/17b015e...d0252039        # what stays behind
  ahead=2 behind=0
```

## What comes in

Seven commits, corpus PRs #220, #214, #221, #222, #225, #226 and #228: `WebServiceActionContext`, the Windows nightly CI workflow, `TestPermissions = Disabled` across 100 suites, a tableextension `TableRelation` enforced by `Validate`, `FilterPageBuilder`, the nine `SourceObject` columns of `Page Metadata`, and the two remaining `Published Application` FlowFields.

The last one only became takeable a few minutes before I pinned it. Against `6027df55` its three tests (codeunit 61201) failed; #3308 merged as `fe8a8f26` while I was measuring, and they pass on that base. I re-measured rather than assuming, and this PR is based on `fe8a8f26`.

## Measured

Runner built from `fe8a8f26`, BC 28.1, `--strict --expectations-require-match --count-baseline`, private AL-output cache outside the repository, all three corpus apps enumerated by `scripts/corpus-app-dirs.py` exactly as `bc-tests.yml` does.

| run | pin | tests | pass | fail | exit |
|---|---|---|---|---|---|
| control | `2cba52d4` (current) | 2839 | 2839 | 0 | 0 |
| **this PR, cold** | **`17b015e`** | **2916** | **2916** | **0** | **0** |
| **this PR, warm** | **`17b015e`** | **2916** | **2916** | **0** | **0** |
| corpus tip | `d0252039` | 2956 | 2939 | 17 | 1 |

The warm run reuses the cold run's cache (AL emit 0.0s, C# compile 0.0s, 44s against 80s) and returns identical results, so nothing here is cache-sensitive. The control being clean is what makes the tip's 17 failures attributable to the two commits I left out rather than to this machine.

## Counts

`al-language` 2814 → 2887, `al-language-onprem` 29 (was 25), `al-language-internals-fixture` unchanged at 0. `runner-extras` untouched — I diffed the JSON and its 60 group entries are byte-identical.

Both numbers were read off a run. The run at this pin printed them in its `[count-baseline] GROWTH` lines, and the run with them in place exits 0.

I also counted by hand as a cross-check, per file, with comments and string literals stripped: 2889 `[Test]` procedures in the `al-language` app. Two of those — `JsonObject_ReadFromYaml_OnCloudRuntime_IsNotSupported` and its `WriteToYaml` sibling in `session/TestFinalCoverage.al` — sit behind `#if BC143PLUS`, which is not defined, so they compile out. 2889 − 2 = 2887, the runner's number exactly. A raw count over that subtree gives 2889 and is wrong; the preprocessor is the reason, and I checked that every one of the 2889 sits in a `Subtype = Test` codeunit with no duplicate object ids and no duplicate method names.

## Why the pin stops at `17b015e`

Corpus history is linear, so I cannot take a later commit without its predecessors, and the next two fail today. Measured at the tip on this same build: 17 failures, exactly two codeunits, nothing else.

| corpus commit | corpus PR | codeunit | fails | tracked by |
|---|---|---|---|---|
| `0bbe376` | #227 (TestPart) | 60346 | 11 | #3312 (6), #3313 (2), #3009 (3) |
| `d025203` | #229 (TestFilter) | 60350 | 6 | #3316 (5), #3312 (1) |

#3316 is new — I filed it while working on this, because the five `TestPage.Filter` failures had no issue. `CurrentKey()` returns the current key's field numbers (`2, 3` where BC names `Grp` and `Rank`) and is blank on a page that has not had a key set, and `SetCurrentKey()`/`Ascending()` are stored and reported back but never change the order the page walks. The sixth failure in that codeunit is #3312's part-page id 0 problem again, not a `TestFilter` problem.

**No `tests/expectations/` entry was added for any of the 17.** Declaring a live, owned gap as settled classification is what `ask-the-corpus-before-claiming-bc-behavior.md` forbids. Leaving the two commits unpinned keeps the gap visible; an expectations entry would have hidden it behind a green run.

## Note on #3304

#3304 is the standing record of this gap and its body is now stale — it was written when the pin was `c3531ec6` and the four blockers were #3283, #3284, #3178 and #3263, all since resolved. After this PR the pin is 2 commits behind, not 9, and the blockers are the three above. I have not edited it, since commenting needs approval; someone should refresh it.

## Not done here

The `al-runner-tests` skill still states flatly that a pin bump cannot be its own PR, which contradicts the catch-up case now in `.claude/rules/al-language-submodule.md`. I left the skill alone to keep this diff to the pin, but it will mislead the next agent.

Corpus-NA: a pin bump asserts nothing new about Business Central — corpus PRs #220, #214, #221, #222, #225, #226 and #228 were each adjudicated on a real service tier before merging upstream, and this only moves the gitlink to them. `check_corpus_linkage.sh` run against this diff agrees: "No file in this diff can change what AL observes, so no corpus declaration is required."

No linked issue: a catch-up corpus pin bump. It advances the pin but does not fully drain the gap #3304 tracks, so nothing is closed here.

Opened by agent impl-1 (automated implementation agent).

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
