### PR TITLE
docs(agents): ask where a comment's reader is, and stop reviews asking for more prose

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -134,6 +134,31 @@ Not scope creep: fixing one of N instances closes the issue while leaving the bu
 
 In one day this step found: a sibling `_parsedPages` gap in `GetInsertAllowedForPage`, called at every TestPage construction site (#2088); five more call sites doing the same unrooted `Path.Combine` on a home directory (#2114); a `--help` section listing a shipped feature as unimplemented (#2118); a wrong statement-attribution bug an existing test had encoded as correct (#2074); a `WorkDate` regression that would have broken nearly every `execute` call (#2117). CI was green in all five and would have stayed green.
 
+### Where the prose goes
+
+Measured on `AlRunner/**/*.cs`, 295 files with `obj/` and `bin/` excluded: **54,520 comment lines against 63,256 code lines — 46% of every non-blank line.** Over the hundred files added since #3260 was filed, comment prose grew about twice as fast as code. Finding and reading code is already the largest token cost in this repository (`CLAUDE.md`), and every read pays for the prose sitting in it.
+
+This is not "write fewer comments", and several rules require one: `loud-failures.md` requires the *observably equivalent* justification in a code comment on every new patch under `AlRunner/Patches/`, and `precompiled-dll-respect.md`'s token-shift constraint belongs at the Cecil call site that could violate it. Those stay. What changes is where everything else goes.
+
+**The question, per comment block: would this change what the next person TYPES?** If it would — they are about to edit this line and would get it wrong — it stays, as short as still prevents the mistake. If it only changes what they *know*, it belongs somewhere a reader goes deliberately:
+
+| the reader | where it goes |
+|---|---|
+| is about to change *this line* and would otherwise get it wrong | **stays in code** |
+| is deciding whether to merge *this diff* | **the PR body** |
+| is asking how the runner does X, and is not editing this line now | **`docs/`**, with a one-line `// see docs/<file>.md#<anchor>` left behind |
+| does not exist — it narrates what the code used to do, or restates the line under it | **delete it**; git has the history |
+
+Ask it of yourself and you will answer "it stays" — everyone does about their own prose. The question is written about the *reader* so that a reviewer, who did not write it, can answer it too.
+
+**The trigger is a comment block over ten lines.** Blocks longer than that hold 60% of all comment mass, and they hold it in `///` doc comments as much as in `//` ones — 12,892 of 21,013 doc-comment lines against 19,343 of 32,763 plain ones. Moving an essay into XML doc syntax does not make it shorter. Under ten lines, just write it; over ten, answer the question above and say in one line of the PR body where you put it.
+
+Three shapes are the wrong place whatever their length:
+
+- **What you tried and rejected.** PR body. Someone reading the code is not choosing between your options.
+- **The derivation.** The conclusion and its citation stay — "`find_callers` resolves this through the async state machine", "corpus codeunit X adjudicated this on eight legs" — the walk that reached them goes to `docs/` or the PR body. A citation is what lets a reader find the evidence; reproducing the evidence is what makes the file long.
+- **A measurement table.** `docs/`, where it is versioned and can be re-run. A number in a comment goes stale the first time the thing it measures improves, and nothing tells you it has.
+
 ### Code navigation, and `grep` failing silently
 
 Both live in `CLAUDE.md` under "Code navigation: use these before grepping" — `tools/context-pack.py` / `tools/lsp-query.py` / `graphify` instead of grep sweeps, why the `LSP` tool is unavailable to you, and why a bare `grep -E` here exits 0 with no output instead of erroring. Read that section; do not rediscover any of it.

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -1,6 +1,6 @@
 ---
 name: reviewer
-description: Review a pull request on AL Runner or the corpus against this repository's actual failure modes — whether the proving test proves anything, whether a BC-behaviour claim reached a real service tier, whether a measurement is sound, and whether anything fails silently. Use before merging, and as the review step of an unattended cycle. Reports findings; never merges.
+description: Review a pull request on AL Runner or the corpus against this repository's actual failure modes — whether the proving test proves anything, whether a BC-behaviour claim reached a real service tier, whether a measurement is sound, whether anything fails silently, and whether the prose it adds belongs in the code at all. Use before merging, and as the review step of an unattended cycle. Reports findings; never merges.
 tools: Bash, Read, Grep, ToolSearch, mcp__github__add_issue_comment, mcp__github__get_me, mcp__github__list_pull_requests, mcp__github__pull_request_read, mcp__github__list_issues, mcp__github__issue_read, mcp__github__get_job_logs
 model: opus
 ---
@@ -116,6 +116,47 @@ not have been.
 
 Prefer a complete negative result over a speculative fix. "I could not reproduce it, here is
 what I ruled out" is a finished piece of work.
+
+## 7. Does the prose live where it is read?
+
+Comment prose in `AlRunner/` is **46% of every non-blank line** — 54,520 comment lines against
+63,256 code lines across 295 files — and it grew roughly twice as fast as code over the last
+hundred files added. Reading code is the largest token cost in this repository, so this is a
+review finding, not a style preference.
+
+**The review step is part of the mechanism rather than a check on it.** In one batch, reviews
+asked for the reasoning in a code comment to be corrected and for doc comments to be made more
+explicit and more honest. Every request was locally reasonable. Together they are the trend,
+because nothing in this definition ever pointed the other way.
+
+**So: a defect in a comment is not fixed by more comment.** When you find one that is wrong,
+stale, or claims more than its evidence carries, your finding is *delete it*, or *move it to
+`docs/` and leave a one-line pointer* — not *correct it in place*. "Correct it in place" is
+right only when a rule requires that comment at that line: `loud-failures.md`'s observably-equivalent
+justification on a new patch, a Cecil token-shift note, a trap that would make the next edit wrong.
+Say which of the three you are invoking, or ask for the deletion.
+
+**Never ask for prose to be added to `AlRunner/` that reads as a PR body, a measurement table,
+or a history of how the code came to be.** Ask for it in the PR body — where you are already
+reading, and where it does not get re-read on every navigation. This is the same instinct as
+"does any number have a durable, versioned home" in the section below, applied to the code.
+
+Apply one question to the largest comment block the diff adds: **would it change what the next
+person types?** If yes it stays. If it only changes what they know, it belongs in `docs/` with a
+pointer, in the PR body, or nowhere. `impl-agent.md` carries the full disposition table; the
+trigger there is a block over ten lines, which is where 60% of the comment mass sits — in `///`
+doc comments as much as in `//` ones, so "put it in an XML doc comment" is not a remedy.
+
+State the number in one line whenever the diff touches `AlRunner/`: comment lines added against
+code lines added. It is not a threshold to pass — 23 of the last 26 commits touching `AlRunner/`
+added more comment than code, so a gate at 1:1 would fire on nearly everything and be ignored
+within a week. It is there so the trend is visible at the moment someone is creating it.
+
+```bash
+gh pr diff <N> --repo <owner>/<repo> -- 'AlRunner/*' | awk '
+  /^\+\+\+/ {next} /^\+[[:space:]]*(\/\/|\*|\/\*)/ {c++; next} /^\+[[:space:]]*[^[:space:]]/ {k++}
+  END {printf "+%d comment / +%d code\n", c, k}'
+```
 
 ## Reviewing a change to how agents work
 


### PR DESCRIPTION
Part of #3260 — the two agent-definition changes. The one-time cleanup pass over `AlRunner/**` and the `GenerateDocumentationFile` flag are still open there.

No linked issue: issue #3260 stays open after this merges. It lands two of that issue's three parts; the cleanup pass and the compiler flag remain.

Corpus-NA: agent instructions assert nothing about BC, so there is nothing for a service tier to adjudicate.

## The measurement I took

Counted over `AlRunner/**/*.cs`, 295 files, `obj/` and `bin/` excluded, handling `//`, `///` and `/* */`:

| | at filing | issue comment | mine |
|---|---|---|---|
| files | 194 | 295 | 295 |
| comment lines | 39,600 | 53,776 | 54,520 |
| code lines | 56,543 | 63,938 | 63,256 |
| **comment share of non-blank** | **41.2%** | **45.7%** | **46.3%** |

My 46.3% differs from 45.7% only in how a `/* … */` block's closing line and trailing code are attributed. The trend is the same and I used my own numbers.

Two further measurements shaped the rule, and one of them killed my first draft:

- **The mass is in long blocks, not in changelog and not in quoted evidence.** Comment blocks over ten lines hold **60% of all comment mass** (32,306 of 53,776). Lines narrating past state are 1.1%, lines citing an issue number 5.7%, and lines that look like reproduced code — a decompiled body, a quoted SQL statement — only **3.0%**. My first draft was "cite the evidence, do not reproduce it"; measured, that reaches 3% of the problem, so I dropped it. The mass is ordinary English prose in long blocks, which is why the trigger is block length.
- **`///` doc comments are already 21,013 lines, and 61% of those sit in blocks over ten lines.** The essay habit has migrated into the XML doc surface, so turning `GenerateDocumentationFile` on does not by itself fix anything, and a rule saying "put it in `///`" would just relabel the mass. Both definitions say so explicitly.

## The rule I landed on

I replaced the proposed content taxonomy with a question about the reader, for one reason: a taxonomy asks a writer to classify their own prose, and writers classify their own prose as essential. The question is written about the reader so a reviewer, who did not write it, can answer it too.

> **Would this comment change what the next person TYPES?**

Yes — they are about to edit this line and would get it wrong — it stays. If it only changes what they *know*, it belongs somewhere a reader goes deliberately: `docs/` with a one-line pointer left in the code, the PR body, or nowhere. `impl-agent.md` carries the four-row disposition table; `reviewer.md` carries the same question applied to the largest block a diff adds.

The trigger is a comment block over ten lines, chosen because that is where 60% of the mass is, and stated as a trigger for the question rather than a limit. Under ten lines, just write it.

**What explicitly stays.** `loud-failures.md` requires the *observably equivalent* justification in a code comment on every new patch under `AlRunner/Patches/`; `precompiled-dll-respect.md`'s token-shift constraint belongs at the Cecil call site. Both definitions name those as staying, so nothing here diverges from a rule. I did not need to amend any rule.

## Why a reviewer applying this would have pushed back on the requests in that batch

This is the part the change turns on, so I want to be precise about the mechanism rather than just assert it.

`reviewer.md` never asked for comment prose — I checked, and no line in it did. The reward was structural. Sections 1 through 6 all reward finding something wrong, and when the wrong thing is a comment there was exactly one available remedy: ask for it to be corrected. Nothing in the file offered "delete it" or "move it" as a finding, so a thorough reviewer produced "expand this", "make this more honest" every time — locally right each time, and additive every time.

Section 7 supplies the missing remedy and makes it the default:

- **"A defect in a comment is not fixed by more comment."** The three requests in that batch were a comment whose reasoning was wrong, and doc comments that were not explicit or honest enough. Under section 7 the first finding is still valid, but the remedy inverts: wrong reasoning in a *narrative* comment is a reason to delete it or move it to `docs/`, not to correct it in place. "Correct it in place" survives only where a rule requires that comment at that line, and the reviewer now has to name which of the three that is. A reviewer that cannot name one has to ask for the deletion.
- **"Never ask for prose to be added to `AlRunner/` that reads as a PR body, a measurement table, or a history of how the code came to be."** "Make this doc comment more explicit about why we do it this way" is a request for a derivation, and the derivation is the shape the rule sends to the PR body — where the reviewer is already reading it.
- **The number, stated every time.** The review now reports comment-lines-added against code-lines-added for any diff touching `AlRunner/`, with a working one-liner. A reviewer that has just written `+244 comment / +150 code` at the top of its report is in a materially different position when it reaches for "and please expand this comment."

The number is deliberately **not** a gate. I measured it: **23 of the last 26 commits touching `AlRunner/` added more comment lines than code lines**, so a 1:1 threshold would fire on 88% of PRs and be ignored inside a week. It is reported so the trend is visible at the moment it is being created, and the file says why it is not a threshold, so nobody later "fixes" it into one.

## Checks

`check_agent_mcp_tools.py` is a required context and this PR edits both files it reads.

```
$ python3 .github/scripts/check_agent_mcp_tools.py
OK: every MCP tool mentioned in 4 agent definition(s) is allowlisted     exit 0

$ python3 .github/scripts/test_check_agent_mcp_tools.py
9/9 passed                                                              exit 0
```

Both were green before my change and are green after. **No tool mention changed** — I diffed the `mcp__*` mention set of each file against `origin/main` and both are identical (47 in `impl-agent.md`, 8 in `reviewer.md`), so the checker passing is not masking a mention I added and allowlisted.

`tools/test_agent_self_freshness.py` also passes. `check_agent_mcp_tools.py` is the only gate that reads `.claude/agents/`; I confirmed that with `command grep -rln`, because `rg` returns nothing for `.github/**` on this box even with `--hidden` and `command grep -rl` finds the files.

The awk one-liner added to `reviewer.md` is verified, not written from memory: run against `fe8a8f26` it prints `+244 comment / +150 code`, matching the independent Python count of that commit exactly.

## Scope, and what I deliberately left out

- **`AlRunner/**` is untouched.** `git diff --name-only` is exactly the two agent definitions. No cleanup, no comment deleted, however tempting `RecordPatches.ObjectMetadataSystemTable.cs` was at 213 comment lines in its header.
- **`GenerateDocumentationFile` stays `false`** (`AlRunner/AlRunner.csproj:14`). Follow-up, not this PR. Worth recording for whoever picks it up: `CS1591` (missing XML comment on a public member) would need `NoWarn` across ~295 files, while `CS1574` and `CS1580` — a `cref` that does not resolve — are the two worth keeping, since they are what makes a doc comment's citations checkable rather than decorative. And on the measurement above, turning the flag on is not a reduction lever by itself.
- **No `CHANGELOG.md`, no submodule pin movement.**
- **Applying the new rule to the two files I just wrote** would be circular — they are instructions, not code — but for the record the added prose is 61 lines across two files that agents load once per session, not per navigation.

Opened by an automated implementation agent (`impl-1`) acting on the account holder's behalf.

https://claude.ai/code/session_01MWCA1Yyt5wdrwqpKQ9TXPf
