### PR TITLE
fix(testpage): land Last() on the new-row line when it finds nothing, as First() does

### DIFF
--- a/AlRunner.Tests/TestPageMoveLastNewRowLineTests.cs
+++ b/AlRunner.Tests/TestPageMoveLastNewRowLineTests.cs
@@ -1,0 +1,172 @@
+// TestPageMoveLastNewRowLineTests — issue #2964.
+//
+// LiveNavTestPage has three cursor moves that LAND ON A ROW by searching for one, rather than
+// stepping relative to where the cursor already is: MoveFirst, MoveLast, and the part's
+// ReloadLinkedRow. On an editable, insert-allowed page a client that finds no matching row
+// still renders exactly one row — the implicit new-row line — so all three have to leave the
+// cursor parked there when they find nothing, or a subsequent write has nowhere to land.
+//
+// MoveFirst got that fallback in #2392 and ReloadLinkedRow in #2923. MoveLast was left out,
+// so `TP.OpenEdit(); TP.Last(); TP.SomeField.SetValue('X');` wrote into a record nothing had
+// positioned and inserted no row at all.
+//
+// These are RUNNER-MECHANISM tests, not claims about what real BC does. They pin the
+// SYMMETRY of our own wiring — that the three searching moves agree with each other, and that
+// the two stepping moves (MoveNext, MovePrevious) deliberately do not join them, because
+// stepping off the end of a rowset is a different question from failing to find a row in one.
+//
+// The BEHAVIORAL claims are measured upstream against a live BC service tier: corpus codeunit
+// 60757 "Test Page Last New Row Line" in tests/al-language/handlers/TestPageLastNewRowLine_Tests.al,
+// StefanMaron/BusinessCentral.AL.Language.Tests PR #231, per
+// .claude/rules/bc-behavior-tests-go-upstream.md. Run against that corpus branch, its twelve
+// arms went 10 pass / 2 fail before this change and 12 pass after — the two failures being
+// EmptyEditableList_SetValueAfterLast_InsertsARow and its linked-part twin
+// ModalHostPart_EmptyPart_SetValueAfterLast_InsertsARow, one per code path.
+//
+// Cecil rather than a live page because the claim is about which IL each method contains: a
+// behavioural test of the same thing is the corpus's job, and duplicating it here would be
+// asserting BC behaviour in the wrong repository.
+using System.Linq;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPageMoveLastNewRowLineTests
+{
+    private static TypeDefinition LoadType(System.Type type)
+    {
+        var asm = AssemblyDefinition.ReadAssembly(type.Assembly.Location);
+        var cecilType = asm.MainModule.GetType(type.FullName);
+        Assert.NotNull(cecilType);
+        return cecilType!;
+    }
+
+    private static MethodDefinition Method(TypeDefinition type, string name)
+    {
+        var m = type.Methods.FirstOrDefault(x => x.Name == name && x.HasBody);
+        Assert.NotNull(m);
+        return m!;
+    }
+
+    private static bool Calls(MethodDefinition m, string memberName)
+        => m.Body.Instructions.Any(i =>
+            (i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt)
+            && i.Operand is MethodReference mr && mr.Name == memberName);
+
+    private static int IndexOfCall(MethodDefinition m, string memberName)
+    {
+        var instructions = m.Body.Instructions;
+        for (var i = 0; i < instructions.Count; i++)
+            if ((instructions[i].OpCode == OpCodes.Call || instructions[i].OpCode == OpCodes.Callvirt)
+                && instructions[i].Operand is MethodReference mr && mr.Name == memberName)
+                return i;
+        return -1;
+    }
+
+    // THE FIX. MoveLast must park on the draft line when its find comes back empty, exactly as
+    // MoveFirst does. Without EnterNewRowLine in the body there is no cursor for a following
+    // SetValue to write into.
+    [Fact]
+    public void MoveLast_FallsOntoTheNewRowLineWhenItFindsNothing()
+    {
+        var type = LoadType(typeof(AlRunner.LiveNavTestPage));
+        var moveLast = Method(type, "MoveLast");
+
+        Assert.True(Calls(moveLast, "ALFindLastAsync"),
+            "LiveNavTestPage.MoveLast must still locate the last row with ALFindLastAsync — "
+            + "the fallback is for the empty case only, and must not replace the search.");
+
+        Assert.True(Calls(moveLast, "EnterNewRowLine"),
+            "LiveNavTestPage.MoveLast must call EnterNewRowLine so that a Last() finding no row "
+            + "on an editable, insert-allowed page leaves the cursor on the implicit new-row "
+            + "line — otherwise a following SetValue writes into a record nothing positioned "
+            + "and inserts nothing (issue #2964). MoveFirst has done this since #2392.");
+    }
+
+    // THE SYMMETRY, which is the actual defect: MoveLast differed from MoveFirst for no
+    // reason anyone had measured. Asserting the pair together is what stops the two drifting
+    // apart again — a future edit that drops the fallback from either one fails here.
+    [Fact]
+    public void TheThreeSearchingCursorMoves_AllParkOnTheNewRowLineWhenTheyFindNothing()
+    {
+        var page = LoadType(typeof(AlRunner.LiveNavTestPage));
+        var part = page.Module.GetType("AlRunner.LiveNavTestPart");
+        Assert.NotNull(part);
+
+        foreach (var (declaring, name, why) in new[]
+        {
+            (page, "MoveFirst", "First() on an empty editable list — issue #2392"),
+            (page, "MoveLast", "Last() on an empty editable list — issue #2964"),
+            (part!, "ReloadLinkedRow", "a linked part whose SubPageLink matches no row — issue #2923"),
+        })
+        {
+            var m = Method(declaring, name);
+            Assert.True(Calls(m, "EnterNewRowLine"),
+                $"{declaring.Name}.{name} must call EnterNewRowLine: it locates a row by "
+                + "searching, so finding nothing on an editable, insert-allowed page has to "
+                + $"leave the cursor on the implicit new-row line ({why}). All three searching "
+                + "cursor moves must agree — the asymmetry between them WAS issue #2964.");
+        }
+    }
+
+    // The fallback must not change what Last() ANSWERS, only where the cursor sits. The
+    // return value is computed from the find's own result, so EnterNewRowLine's return value
+    // must be discarded (pop) rather than returned.
+    //
+    // This is load-bearing for FindRowFromTableFieldValues, whose backward scan starts at
+    // MoveLast() and enters `while (hasRow)` only on true: a MoveLast that answered true for
+    // the draft line would let a search for an empty value "find" a row that is not in the
+    // table.
+    [Fact]
+    public void MoveLast_StillAnswersFromTheFind_NotFromTheFallback()
+    {
+        var type = LoadType(typeof(AlRunner.LiveNavTestPage));
+        var moveLast = Method(type, "MoveLast");
+
+        var enter = IndexOfCall(moveLast, "EnterNewRowLine");
+        var loaded = IndexOfCall(moveLast, "Loaded");
+
+        Assert.True(enter >= 0, "MoveLast must call EnterNewRowLine (see the arm above).");
+        Assert.True(loaded >= 0,
+            "MoveLast must return through Loaded(bool), which is what raises the row's "
+            + "OnAfterGetRecord for the found case.");
+        Assert.True(enter < loaded,
+            "EnterNewRowLine must run BEFORE the Loaded() that produces the return value, so "
+            + "the answer comes from the find and not from the fallback "
+            + $"(enter={enter}, loaded={loaded}).");
+
+        Assert.True(
+            moveLast.Body.Instructions.Any(i => i.OpCode == OpCodes.Pop),
+            "EnterNewRowLine returns bool, and MoveLast must DISCARD it — Last() answers false "
+            + "on an empty editable page whether or not the draft line exists. Returning the "
+            + "fallback's own result would make Last() answer true there, and would let "
+            + "FindRowFromTableFieldValues's backward scan match the blank line.");
+    }
+
+    // THE NEGATIVE. MoveNext and MovePrevious step relative to the current row rather than
+    // searching for one, and must NOT gain the fallback: MoveNext reaching the end of the
+    // rowset is how the draft line is ENTERED (a different, already-measured path), and
+    // MovePrevious stepping back off the first row must leave the cursor where it is
+    // (corpus codeunit 60756 TestPage_Previous_OnTheFirstRow_ReturnsFalseAndKeepsTheCursorThere).
+    //
+    // Without this arm, "call EnterNewRowLine everywhere" would satisfy every assertion above.
+    [Fact]
+    public void MovePrevious_DoesNotParkOnTheNewRowLine()
+    {
+        var type = LoadType(typeof(AlRunner.LiveNavTestPage));
+        var movePrevious = Method(type, "MovePrevious");
+
+        Assert.False(Calls(movePrevious, "EnterNewRowLine"),
+            "LiveNavTestPage.MovePrevious must NOT call EnterNewRowLine. Previous() steps "
+            + "backwards from the current row; it never searches, so it has no not-found case "
+            + "to fall back from. Stepping back off the first row leaves the cursor on that "
+            + "row (corpus codeunit 60756), and parking it on a blank line instead would "
+            + "silently move the page somewhere the test never navigated to.");
+
+        Assert.True(Calls(movePrevious, "LeaveNewRowLine"),
+            "MovePrevious must still LEAVE the draft line when it is parked on one — stepping "
+            + "back off the blank line lands on the last data row.");
+    }
+}

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -1634,7 +1634,49 @@ internal class LiveNavTestPage : MockITestPage
         if (!found) EnterNewRowLine(record);
         return Loaded(found);
     }
-    public override bool MoveLast() { var record = RequireRecord("MoveLast()"); FlushParts(); FlushRow(); LeaveNewRowLine(); return Loaded(record.ALFindLastAsync(DataError.TrapError).GetAwaiter().GetResult()); }
+
+    /// <summary>
+    /// Go to the last row of the page's rowset.
+    ///
+    /// The empty case falls onto the implicit new-row line exactly as <see cref="MoveFirst"/>
+    /// does, and for the same reason: on an editable, insert-allowed page a client that finds
+    /// no matching row still renders one row — the blank line — and a subsequent write has to
+    /// have somewhere to land. Without it, `Last()` on such a page left the cursor on nothing
+    /// and `TP.SomeField.SetValue('X')` afterwards wrote into a record nothing had positioned
+    /// (issue #2964; the same gap #2392 fixed for First() and #2923 for a linked part).
+    ///
+    /// The RETURN VALUE stays false, so this changes internal cursor state only, never what
+    /// Last() answers. That matters for the one internal caller,
+    /// FindRowFromTableFieldValues's backward scan, which starts at MoveLast() and enters its
+    /// `while (hasRow)` loop only on true — the identical guarantee the MoveFirst() arm of
+    /// that same line already relies on.
+    ///
+    /// WHERE Last() LANDS on a page that DOES have rows is the last DATA row, not the blank
+    /// line past it — so this is a fallback for the empty case only, never a step onto the
+    /// draft line from a rowset that has data. Both halves are measured on a real service
+    /// tier, corpus codeunit 60757 "Test Page Last New Row Line"
+    /// (StefanMaron/BusinessCentral.AL.Language.Tests#231), over the same fixture family
+    /// codeunit 60743 uses:
+    ///
+    ///   * EditableInsertableList_Last_LandsOnTheLastDataRow — three seeded rows, Last() reads
+    ///     'CHARLIE', so "last data row" and "new-row line" are two distinct positions no
+    ///     off-by-one can conflate;
+    ///   * EditableInsertableList_NextAfterLast_ReachesTheNewRowLine — the blank line is still
+    ///     there, one Next() past where Last() stopped;
+    ///   * EmptyEditableList_LastReturnsFalse — asserted in the same procedure as First(), so
+    ///     an implementation aliasing the two cannot satisfy both;
+    ///   * EmptyEditableList_SetValueAfterLast_InsertsARow and its linked-part twin
+    ///     ModalHostPart_EmptyPart_SetValueAfterLast_InsertsARow — the arms this fallback
+    ///     exists for, and the only two of the twelve that failed before it.
+    /// </summary>
+    public override bool MoveLast()
+    {
+        var record = RequireRecord("MoveLast()");
+        FlushParts(); FlushRow(); LeaveNewRowLine();
+        var found = record.ALFindLastAsync(DataError.TrapError).GetAwaiter().GetResult();
+        if (!found) EnterNewRowLine(record);
+        return Loaded(found);
+    }
 
     /// <summary>
     /// Advance to the next row the CLIENT has, which past the last data row of an editable,


### PR DESCRIPTION
Closes #2964

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/231

## The defect

`LiveNavTestPage` has three cursor moves that locate a row by **searching** for one, rather than
stepping relative to where the cursor already is: `MoveFirst`, `MoveLast`, and the part's
`ReloadLinkedRow`. On an editable, insert-allowed page a client that finds no matching row still
renders exactly one row — the implicit new-row line — so all three have to leave the cursor
parked there when they find nothing, or a following write has nowhere to land.

`MoveFirst` got that fallback in #2392 and `ReloadLinkedRow` in #2923. `MoveLast` was left out:

```al
TP.OpenEdit();
TP.Last();                      // false, and the cursor is left on nothing
TP.SomeField.SetValue('X');     // writes into a record nothing had positioned
```

That inserted no row at all. Reproduced as `NavCSideRecordNotFoundException: The Test Page New
Row Line Row does not exist. Identification fields and values: No.='AFTERLAST'`.

## The fix

One method. `MoveLast` now mirrors `MoveFirst` exactly — search, and on an empty result park on
the draft line as a side effect.

**The return value is unchanged.** `Last()` still answers from the find, never from the fallback.
That is load-bearing for the one internal caller, `FindRowFromTableFieldValues`'s backward scan,
which starts at `MoveLast()` and enters its `while (hasRow)` loop only on `true` — the identical
guarantee the `MoveFirst` arm of that same line already relies on. A `MoveLast` that answered
`true` for the draft line would let a search for an empty value match a row that is not in the
table.

## Which page mode this targets, and why

`OpenEdit()`, not `OpenView()` — the new-row line exists only where the page is editable **and**
insert-allowed. `OpenView` is one of the gating arms and must keep answering the last *data* row.
Both directions are asserted.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** Audited all four `ALFindFirstAsync` /
   `ALFindLastAsync` sites in `MockTestPage.cs`. Three position the page cursor and now all three
   carry the fallback. The fourth (`CaptureInsertPosition`, line ~1209) operates on a **cloned
   probe** record for AutoSplitKey computation, not on the page cursor — a fallback there would
   be wrong, and it is deliberately left alone.
2. **Does a sibling make the same assumption?** `MoveNext` and `MovePrevious` step relative to the
   current row and have no not-found case, so they must **not** gain the fallback — `MoveNext`
   reaching the end of the rowset is how the draft line is *entered*, and `Previous()` off the
   first row must leave the cursor on that row (corpus codeunit 60756). There is an explicit
   negative test for this.
3. **Two paths writing the same state?** The invariant is "after a searching move that found
   nothing on a page showing the blank line, `_onNewRowLine` is set". `MoveFirst` and
   `ReloadLinkedRow` maintained it; `MoveLast` did not. That asymmetry *was* the bug, and it is
   now uniform across all three.

## Proof

**Upstream (the BC claim).** Corpus codeunit 60757 "Test Page Last New Row Line", corpus PR #231.
It reuses codeunit 60743's existing fixture family (table 60737, pages 60738–60742) rather than
duplicating it. Twelve arms pin where `Last()` lands on a **three-row** seed (so "last data row"
and "new-row line" are two positions no off-by-one can conflate), what it returns on an empty
editable list (asserted in the same procedure as `First()`, so an implementation aliasing the two
fails), and whether a write after it inserts — for a standalone page and a linked part — plus
`OpenView` / `Editable = false` / `InsertAllowed = false` gating arms.

Run against that corpus branch:

| | before | after |
|---|---|---|
| corpus CU60757 (12 arms) | 10 pass / **2 fail** | **12 pass** |

The two failures were exactly `EmptyEditableList_SetValueAfterLast_InsertsARow` and
`ModalHostPart_EmptyPart_SetValueAfterLast_InsertsARow` — one per code path.

`TestPage.MoveLast` is not in `Microsoft.Dynamics.Nav.Ncl.dll` at all
(`NavTestPageBase.ALLast()` is just `CheckPageOpened(); return TestPage.MoveLast();`), so this
could not be settled by reading BC's assemblies — only a running tier can answer it.

**Runner-side mechanism test.** `AlRunner.Tests/TestPageMoveLastNewRowLineTests.cs` (Cecil, in the
shape of `TestPageNewRowLinePromotionTests`) pins our own wiring symmetry. **3 of its 4 arms fail
against the pre-fix build**, verified by reverting the fix and re-running; the `MovePrevious`
negative passes in both states, which is what makes it a guard rather than padding.

**Regressions.** Pinned corpus **2814/2814**, `runner-extras` **351/351**, filtered
`AlRunner.Tests` (`TestPageMoveLastNewRowLine|TestPageNewRowLine|TestPageImplicitPositioning|TestPageGoToRecord`)
**27/27**. Corpus codeunit 60743's forward arms and 60756's `Previous` arms re-run individually
and green.

## Deliberately left out

- **The corpus pin is not touched** (sequenced behind #3304). The proving test therefore lives
  upstream and unmerged; the pin bump and the `known-gaps` bookkeeping fold into whichever PR
  bumps it, per `al-language-submodule.md`. The mechanism test is what satisfies the
  `Tests updated` gate here.
- **#3029** (`EnterNewRowLine` and the promotion both call `TryNewRecord`, double-firing
  `OnNewRecord`) lives in this same file and I did **not** fold it in. It needs a different corpus
  measurement — an `OnNewRecord` firing counter over a new log table — and a different code
  change, so folding it would put two independent unmeasured BC claims in one PR, each needing its
  own upstream adjudication. It is unclaimed and unaffected by this change.
- **#3009** (`ValidationErrorCount`/`GetValidationError`) is being worked by another agent and is
  untouched here — this diff does not go near `LiveNavTestField`'s validation recording.
- **#3055, #3179** are TestPage issues in other areas (`OnModify` on same-value writes, and a
  separate surface); neither lands in `MoveLast` or the new-row-line mechanism.

---

Implemented by an agent (`stma-auto-5`) on the account holder's behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4