### PR TITLE
fix(testpage): give the PAGE its own validation-error ledger, so AL stops reading a hardcoded 0

### DIFF
--- a/AlRunner.Tests/TestPageOptionValueEnumCaptionTests.cs
+++ b/AlRunner.Tests/TestPageOptionValueEnumCaptionTests.cs
@@ -276,7 +276,11 @@ public sealed class TestPageOptionValueEnumCaptionTests
         var field = new PageVariableTestField(
             BuildPage(),
             new FakeExpression("Kind", NavOption.Create(metadata, 0)),
-            controlId: 50100);
+            controlId: 50100,
+            // Not the subject here — these two pin option-caption rendering, not the #3009
+            // page-level validation-error ledger, and a control built without a page reports
+            // its refusals only to its own.
+            pageValidationErrors: null);
 
         Assert.Equal(3, field.OptionCount);
         Assert.Equal("Fields", field.GetOption(0));
@@ -291,7 +295,11 @@ public sealed class TestPageOptionValueEnumCaptionTests
         var field = new PageVariableTestField(
             BuildPage(),
             new FakeExpression("Kind", NavOption.Create(metadata, 0)),
-            controlId: 50100);
+            controlId: 50100,
+            // Not the subject here — these two pin option-caption rendering, not the #3009
+            // page-level validation-error ledger, and a control built without a page reports
+            // its refusals only to its own.
+            pageValidationErrors: null);
 
         Assert.Equal(string.Empty, field.GetOption(-1));
         Assert.Equal(string.Empty, field.GetOption(7));

--- a/AlRunner.Tests/TestPageValidationErrorsTests.cs
+++ b/AlRunner.Tests/TestPageValidationErrorsTests.cs
@@ -1,0 +1,218 @@
+// TestPageValidationErrorsTests — contract tests for AlRunner.TestPageValidationErrors, the
+// PAGE-level ledger behind AL's TestPage.ValidationErrorCount() / GetValidationError(Index)
+// (issue #3009).
+//
+// WHAT IS PINNED HERE AND WHAT IS NOT
+//
+// The BC claim — that a control write a part's own validation refuses leaves
+// `Part.ValidationErrorCount() > 0`, that `GetValidationError(1)` carries that message, and
+// that `GetValidationError(0)` raises a CATCHABLE AL error — is a statement about Business
+// Central and lives upstream, not here (.claude/rules/bc-behavior-tests-go-upstream.md). It is
+// already adjudicated: corpus codeunit 60346 "Test TestPart"
+// (StefanMaron/BusinessCentral.AL.Language.Tests, PR #227, merged 0bbe3765) asserts all four
+// arms on eight BC Cloud legs. This file pins the runner-side MECHANISM those claims need.
+//
+// RED/GREEN, measured against corpus master d025203 with the runner at this branch's parent:
+//
+//   TestPart_ValidationErrorCount_IsZeroOnACleanPart            PASS -> PASS  (the control arm)
+//   TestPart_ValidationErrorCount_CountsARefusedFieldValidation FAIL -> PASS
+//   TestPart_GetValidationError_IsOneBasedAndCarriesTheMessage  FAIL -> PASS
+//   TestPart_GetValidationError_ErrorsOnIndexZero               FAIL -> PASS
+//
+// The first of those is why the fix cannot be "return 1": it passed BEFORE the fix, against
+// the hardcoded 0, and has to keep passing after it.
+//
+// THE ONE PLACE THIS LEDGER DELIBERATELY DIFFERS FROM THE FIELD LEDGER is the exception an
+// out-of-range read raises, and it is a real BC asymmetry rather than a tidy-up. Both AL
+// boundaries subtract 1 and translate, but they catch different types (unmodified Ncl.dll,
+// 28.1):
+//
+//     NavTestField.ALGetValidationError(index)     catch (IndexOutOfRangeException)
+//     NavTestPageBase.ALGetValidationError(index)  catch (ArgumentOutOfRangeException)
+//
+// Enumerable.ElementAt raises the ARGUMENT flavour, so the field's catch is dead (measured,
+// corpus run 34002487601: the exception escapes as "Unexpected CLR exception thrown." and AL
+// asserterror does not trap it) while the page's catch is LIVE.
+//
+// WHICH LAYER PROVES WHICH, because it is easy to overclaim here. The corpus test asserts
+// `GetLastErrorText() <> ''`, so it pins that index 0 is OUT of the 1-based range — the
+// off-by-one that matters, and the assertion a 0-based ledger fails. It does NOT discriminate
+// the exception flavours: probed on this branch, an IndexOutOfRangeException implementation
+// passes it too, because the runner surfaces that as a trappable AL error as well. The flavour
+// is pinned HERE, against the decompiled catch above, and nowhere else.
+using System;
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPageValidationErrorsTests
+{
+    [Fact]
+    public void ACleanPage_ReportsZeroAndHasNothingToRead()
+    {
+        var page = new TestPageValidationErrors();
+
+        Assert.Equal(0, page.Count);
+        // Nothing recorded, so index 0 is already past the end. This is the arm that makes the
+        // "always report one error" implementation fail.
+        Assert.Throws<ArgumentOutOfRangeException>(() => page.Get(0));
+    }
+
+    [Fact]
+    public void ARecordedRefusal_IsCountedAndReadableAtZeroBasedIndexZero()
+    {
+        var page = new TestPageValidationErrors();
+        page.Record("ALT TestPart Line refuses the grade BADGRADE");
+
+        Assert.Equal(1, page.Count);
+        // BC's AL boundary has already subtracted 1, so AL's GetValidationError(1) arrives here
+        // as Get(0). The exact text, not merely non-empty: an implementation that stored a
+        // placeholder would pass a non-empty assertion.
+        Assert.Equal("ALT TestPart Line refuses the grade BADGRADE", page.Get(0));
+    }
+
+    [Fact]
+    public void SeveralRefusals_KeepTheOrderTheyWereRecordedIn()
+    {
+        var page = new TestPageValidationErrors();
+        page.Record("first");
+        page.Record("second");
+        page.Record("third");
+
+        Assert.Equal(3, page.Count);
+        Assert.Equal("first", page.Get(0));
+        Assert.Equal("second", page.Get(1));
+        Assert.Equal("third", page.Get(2));
+    }
+
+    [Fact]
+    public void ReadingIsNotAConsume_UnlikeTheFieldLedger()
+    {
+        // ITestPage carries no LastUsedValidationErrorId / MaxValidationErrorId at all — BC's
+        // "is there something new since the snapshot" test has no page-level counterpart — so a
+        // read must be repeatable rather than marking anything used. Verified against 28.1:
+        // search_members("ValidationErrorId") filtered to ITestPage returns nothing.
+        var page = new TestPageValidationErrors();
+        page.Record("only");
+
+        Assert.Equal("only", page.Get(0));
+        Assert.Equal("only", page.Get(0));
+        Assert.Equal(1, page.Count);
+    }
+
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(1)]
+    [InlineData(5)]
+    public void ReadingOutOfRange_RaisesTheFlavourTheAlBoundaryActuallyCatches(int index)
+    {
+        // ArgumentOutOfRangeException, NOT IndexOutOfRangeException. This is the whole reason
+        // Get uses Enumerable.ElementAt rather than the list indexer: it is the call BC's own
+        // client makes, and NavTestPageBase.ALGetValidationError(int) catches precisely this
+        // type and turns it into a NavNCLIndexOutOfBoundsException that AL asserterror traps.
+        // The corpus test does not catch a wrong flavour (see this file's header), so this
+        // assertion is the only thing standing between the runner and a page-side chain that
+        // merely looks right. Probed both ways on this branch: swapping ElementAt for an
+        // indexer + IndexOutOfRangeException keeps the corpus green and turns these four red.
+        var page = new TestPageValidationErrors();
+        page.Record("only");
+        Assert.Equal("only", page.Get(0));
+
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => page.Get(index));
+        Assert.Equal("index", ex.ParamName);
+    }
+
+    [Fact]
+    public void AControlRefusal_LandsInBothTheFieldLedgerAndThePageLedger()
+    {
+        // The invariant that keeps the two views from drifting: TestFieldValidationErrors.Record
+        // is the single write route, and it feeds both. Real BC keeps one client-side error list
+        // per page of which the control's is a view, so a refusal counted on the control and not
+        // on the page (or the reverse) would be a state split BC does not have.
+        var page = new TestPageValidationErrors();
+        var field = new TestFieldValidationErrors(page);
+
+        field.Record("Deliberate OnValidate failure for VAL-1", appendRefreshSuffix: true);
+
+        Assert.Equal(1, field.Count);
+        Assert.Equal(1, page.Count);
+        // The SAME stored text, refresh suffix included — the page does not re-derive it.
+        Assert.Equal("Deliberate OnValidate failure for VAL-1" + TestFieldValidationErrors.RefreshSuffix,
+            field.Get(0));
+        Assert.Equal("Deliberate OnValidate failure for VAL-1" + TestFieldValidationErrors.RefreshSuffix,
+            page.Get(0));
+    }
+
+    [Fact]
+    public void TwoControlsOnOnePage_AccumulateOnThatOnePageInWriteOrder()
+    {
+        // A page's count is the page's, not any one control's. Each control still reports only
+        // its own — which is what BC's NavTestField.CheckError arithmetic subtracts to decide
+        // whether the PAGE gained an error the written control did not raise.
+        var page = new TestPageValidationErrors();
+        var a = new TestFieldValidationErrors(page);
+        var b = new TestFieldValidationErrors(page);
+
+        a.Record("control A refused", appendRefreshSuffix: false);
+        b.Record("control B refused", appendRefreshSuffix: false);
+
+        Assert.Equal(1, a.Count);
+        Assert.Equal(1, b.Count);
+        Assert.Equal(2, page.Count);
+        Assert.Equal("control A refused", page.Get(0));
+        Assert.Equal("control B refused", page.Get(1));
+    }
+
+    [Fact]
+    public void AFieldWithNoPage_RecordsOnlyOnItself()
+    {
+        // The record-only LiveNavTestField ctor and the degraded MockITestPage path have no page
+        // ledger to report to. That must be a null sink rather than a crash.
+        var field = new TestFieldValidationErrors(null);
+
+        field.Record("refused", appendRefreshSuffix: false);
+
+        Assert.Equal(1, field.Count);
+        Assert.Equal("refused", field.Get(0));
+    }
+
+    [Fact]
+    public void RunRecordingRefusal_FeedsThePageLedgerToo()
+    {
+        // The route a real control write takes. A BC/AL error is recorded on both ledgers rather
+        // than escaping, so BC's own CheckError can raise it afterwards and AL can still read
+        // either count once the asserterror has trapped it.
+        var page = new TestPageValidationErrors();
+        var field = new TestFieldValidationErrors(page);
+
+        field.RunRecordingRefusal(
+            () => throw new Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLDialogException(
+                      "ALT TestPart Line refuses the grade BADGRADE"),
+            appendRefreshSuffix: false);
+
+        Assert.Equal(1, page.Count);
+        Assert.Equal("ALT TestPart Line refuses the grade BADGRADE", page.Get(0));
+    }
+
+    [Fact]
+    public void ALoudRunnerRefusal_IsNotRecordedOnThePageEither()
+    {
+        // .claude/rules/loud-failures.md, extended to the new ledger: a RunnerOutOfScopeException
+        // is not a validation error and must tear straight through. Recording it on the page
+        // would let AL's asserterror absorb a loud refusal and read as a green test — the same
+        // silent-failure shape the field ledger already refuses, now checked on the half this
+        // change added.
+        var page = new TestPageValidationErrors();
+        var field = new TestFieldValidationErrors(page);
+
+        Assert.Throws<AlRunner.Infrastructure.RunnerOutOfScopeException>(
+            () => field.RunRecordingRefusal(
+                      () => throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                                "NavEmail.Send", "email-smtp — see docs/scope.md#email"),
+                      appendRefreshSuffix: false));
+
+        Assert.Equal(0, page.Count);
+        Assert.Equal(0, field.Count);
+    }
+}

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -30,6 +30,14 @@ internal class MockITestPage : ITestPage
     private bool   _ascending        = true;
     private int[]? _currentKeyFields;
 
+    /// <summary>
+    /// The refusals this PAGE's controls have recorded, read back by ValidationErrorCount /
+    /// GetValidationError below (#3009). Protected so LiveNavTestPage can hand it to every
+    /// control it builds — one ledger per page, shared by all of that page's controls, which
+    /// is the shape real BC has.
+    /// </summary>
+    private protected readonly TestPageValidationErrors _validationErrors = new();
+
     // ── ITestPage ──────────────────────────────────────────────────────────
 
     // IsOpened() = false so NavTestPageBase.Open() "already open" guard passes.
@@ -60,7 +68,12 @@ internal class MockITestPage : ITestPage
     public virtual bool       MovePrevious()                                            => false;
     public virtual bool       MoveFirst()                                               => false;
     public virtual bool       MoveLast()                                                => false;
-    public string             GetValidationError(int index)                             => string.Empty;
+    // #3009: was hardcoded `string.Empty`, so a validation error real BC reports on the PAGE
+    // came back blank. Backed by a real ledger now; the base mock simply never has anything in
+    // it, because a page with no live instance has no controls that can record a refusal. Not
+    // virtual: LiveNavTestPage feeds the SAME ledger rather than overriding, which is what
+    // stops the two views from drifting. See TestPageValidationErrors.
+    public string             GetValidationError(int index)                             => _validationErrors.Get(index);
     public virtual bool       FindRowFromTableFieldValues(int[] f, object[] v, bool fw) => false;
     public virtual bool       FindRowFromControlFieldValue(int fId, object v, bool fw)  => false;
     public virtual object?    GetBookmark()                                             => null;
@@ -73,7 +86,11 @@ internal class MockITestPage : ITestPage
     public virtual ITestAction View()                                                   => new MockITestAction();
     public bool               Expand(bool doExpand)                                     => false;
 
-    public int        ValidationErrorCount => 0;
+    // #3009: was hardcoded 0. BC's NavTestPageBase.ALValidationErrorCount() reads this member
+    // straight through to AL's TestPage.ValidationErrorCount(), and NavTestField.CheckError
+    // reads it before and after every control write, so a constant 0 made the page branch of
+    // CheckError unreachable and made AL's own read answer 0 after a refusal BC counts.
+    public int        ValidationErrorCount => _validationErrors.Count;
     public virtual FormResult FormResult   => FormResult.OK;
     public string     Name                 => string.Empty;
     public virtual string Caption          => string.Empty;
@@ -1580,7 +1597,7 @@ internal class LiveNavTestPage : MockITestPage
             if (!_fields.TryGetValue(id, out var field))
                 _fields[id] = field =
                     new LiveNavTestField(_record!, tableFieldNo, _page, id,
-                        MarkEdited, PromoteNewRowLineForWrite);
+                        MarkEdited, PromoteNewRowLineForWrite, _validationErrors);
             return field;
         }
 
@@ -1590,7 +1607,8 @@ internal class LiveNavTestPage : MockITestPage
         if (expression != null)
         {
             if (!_pageVariableFields.TryGetValue(id, out var pageField))
-                _pageVariableFields[id] = pageField = new PageVariableTestField(_page!, expression, id);
+                _pageVariableFields[id] = pageField =
+                    new PageVariableTestField(_page!, expression, id, _validationErrors);
             return pageField;
         }
 
@@ -2684,10 +2702,11 @@ internal sealed class LiveNavTestField : ITestField
     private readonly Action? _onBeforeEdit;
 
     public LiveNavTestField(NavRecord record, int fieldNo)
-        : this(record, fieldNo, page: null, controlId: 0, onEdited: null, onBeforeEdit: null) { }
+        : this(record, fieldNo, page: null, controlId: 0, onEdited: null, onBeforeEdit: null,
+               pageValidationErrors: null) { }
 
     public LiveNavTestField(NavRecord record, int fieldNo, RunnerPageInstance? page, int controlId,
-        Action? onEdited, Action? onBeforeEdit)
+        Action? onEdited, Action? onBeforeEdit, TestPageValidationErrors? pageValidationErrors)
     {
         _record = record;
         _fieldNo = fieldNo;
@@ -2695,6 +2714,7 @@ internal sealed class LiveNavTestField : ITestField
         _controlId = controlId;
         _onEdited = onEdited;
         _onBeforeEdit = onBeforeEdit;
+        _validationErrors = new TestFieldValidationErrors(pageValidationErrors);
     }
 
     // The refusals this control has recorded, read back by ValidationErrorCount /
@@ -2702,7 +2722,11 @@ internal sealed class LiveNavTestField : ITestField
     // ITestField setter RECORDS a refusal, it does not throw it — NavTestField.CheckError
     // (BC's own precompiled code, wrapping every SetValue) is what raises it afterwards, and
     // it can only do that if the ledger survives the write (#2900).
-    private readonly TestFieldValidationErrors _validationErrors = new();
+    //
+    // Constructed with the owning PAGE's ledger (#3009) so a refusal lands in both: BC reads
+    // the field's count AND the page's around every write, and AL can read either afterwards.
+    // Null for the record-only ctor above, which has no page to report to.
+    private readonly TestFieldValidationErrors _validationErrors;
 
     public string Value
     {
@@ -2953,11 +2977,13 @@ internal sealed class PageVariableTestField : ITestField
     private readonly object _expression;
     private readonly int _controlId;
 
-    public PageVariableTestField(RunnerPageInstance page, object expression, int controlId)
+    public PageVariableTestField(RunnerPageInstance page, object expression, int controlId,
+        TestPageValidationErrors? pageValidationErrors)
     {
         _page = page;
         _expression = expression;
         _controlId = controlId;
+        _validationErrors = new TestFieldValidationErrors(pageValidationErrors);
     }
 
     // The Rec-bound sibling's ledger, for the same reason and read the same way — see
@@ -2965,7 +2991,10 @@ internal sealed class PageVariableTestField : ITestField
     // refuses a write through its OnValidate exactly as a Rec-bound one does, so leaving this
     // half hardcoded would have made the same AL assertion answer differently depending only
     // on how the control happens to be bound.
-    private readonly TestFieldValidationErrors _validationErrors = new();
+    //
+    // Constructed with the owning PAGE's ledger (#3009), same as the Rec-bound sibling — the
+    // page counts a refusal whichever way the control that raised it is bound.
+    private readonly TestFieldValidationErrors _validationErrors;
 
     public string Value
     {
@@ -3131,6 +3160,14 @@ internal sealed class MockITestField : ITestField
     public string Name          => string.Empty;
     public string Caption       => string.Empty;
     public NavType FieldType    => NavType.Text;
+    // 0/0/0 and the empty GetValidationError below are FAITHFUL here, not the #2900/#3009
+    // hardcoding that was fixed on the live controls — stated rather than left bare, because
+    // they read identically. This class is only ever built by MockITestPage.GetField, the
+    // degraded path for a page with no live RunnerPageInstance (see
+    // TestPageClientConstructionRule, which warns on stderr when a handle site lands here).
+    // Its Value setter is a plain string store that runs no AL: no OnValidate, no record
+    // write, nothing that can refuse. So there is genuinely never anything to count, and a
+    // ledger here would only ever report the same 0 with more machinery.
     public int    ValidationErrorCount        => 0;
     public long   LastUsedValidationErrorId   => 0;
     public long   MaxValidationErrorId        => 0;

--- a/AlRunner/Patches/RequestPageTestPage.cs
+++ b/AlRunner/Patches/RequestPageTestPage.cs
@@ -180,7 +180,10 @@ internal sealed class RequestPageTestPage : MockITestPage
                 + string.Join(", ", RegisteredControlKeys().DefaultIfEmpty("(none)"))
                 + ". See docs/scope.md");
 
-        var field = new PageVariableTestField(page!, expression, id);
+        // _validationErrors is MockITestPage's own page-level ledger (#3009) — a request page
+        // counts a refused control write exactly as a page does, and AL reads it through the
+        // same TestRequestPage.ValidationErrorCount() / GetValidationError(Index) pair.
+        var field = new PageVariableTestField(page!, expression, id, _validationErrors);
         _controlFields[id] = field;
         return field;
     }

--- a/AlRunner/Patches/TestFieldValidationErrors.cs
+++ b/AlRunner/Patches/TestFieldValidationErrors.cs
@@ -101,6 +101,17 @@ internal sealed class TestFieldValidationErrors
     private readonly List<string> _errors = new();
     private long _lastUsedId;
 
+    /// <summary>
+    /// The PAGE-level ledger this control reports into as well as its own, when the control
+    /// belongs to a live page. See <see cref="TestPageValidationErrors"/> for why both exist
+    /// and what BC does with each (#3009).
+    /// </summary>
+    private readonly TestPageValidationErrors? _page;
+
+    internal TestFieldValidationErrors() { }
+
+    internal TestFieldValidationErrors(TestPageValidationErrors? page) { _page = page; }
+
     /// <summary>How many refusals this control has recorded. BC's <c>ValidationErrorCount</c>.</summary>
     internal int Count => _errors.Count;
 
@@ -129,7 +140,16 @@ internal sealed class TestFieldValidationErrors
     /// "Validation error for Field: …" wrapper — that is composed one layer out.
     /// </summary>
     internal void Record(string message, bool appendRefreshSuffix)
-        => _errors.Add((message ?? string.Empty) + (appendRefreshSuffix ? RefreshSuffix : string.Empty));
+    {
+        var stored = (message ?? string.Empty) + (appendRefreshSuffix ? RefreshSuffix : string.Empty);
+        _errors.Add(stored);
+        // The same refusal is ALSO the page's, and it is stored with the same text — real BC
+        // has one client-side error list per page and the field's view of it is a filter, not
+        // a separate list (#3009). Feeding both here rather than at the call sites is what
+        // keeps them from drifting: every route that records a control refusal goes through
+        // this method.
+        _page?.Record(stored);
+    }
 
     /// <summary>
     /// The recorded error at a ZERO-based index, marking its id used.
@@ -193,4 +213,83 @@ internal sealed class TestFieldValidationErrors
             Record(ex.Message, appendRefreshSuffix);
         }
     }
+}
+
+/// <summary>
+/// Per-PAGE ledger of the validation errors a TestPage's controls produced, exposed through
+/// <see cref="Microsoft.Dynamics.Nav.Types.Data.ITestPage"/>'s <c>ValidationErrorCount</c> /
+/// <c>GetValidationError</c> members — the pair AL's <c>TestPage.ValidationErrorCount()</c>
+/// and <c>TestPage.GetValidationError(Index)</c> read (#3009).
+///
+/// <para>WHY THIS IS SEPARATE FROM THE FIELD LEDGER. BC reads BOTH around every control write.
+/// <c>NavTestField.CheckError</c> (unmodified Ncl.dll, 28.1) is:</para>
+/// <code>
+///     int num = parent.ALValidationErrorCount();          // the PAGE, before the write
+///     T result = operation();
+///     if (testField.MaxValidationErrorId &gt; lastUsedValidationErrorId)
+///         throw ... testField.Name ...;                   // the FIELD branch, checked first
+///     int num2 = num - (validationErrorCount - testField.ValidationErrorCount);
+///     if (parent.ALValidationErrorCount() &gt; num2)
+///         throw ... parent.Name, parent.ALGetValidationError();
+/// </code>
+/// <para>The field branch is checked first and wins whenever the written control recorded the
+/// refusal itself, so feeding this ledger alongside the field's never changes which exception
+/// a refused write raises. What it changes is what AL can READ afterwards: the page pair was
+/// hardcoded to <c>0</c> / <c>""</c>, so a count real BC reports as 1 came back 0 and the
+/// message came back empty.</para>
+///
+/// <para>THE RANGE CHECK IS NOT THE FIELD'S. This is the one place the two ledgers genuinely
+/// differ, and it is a real BC asymmetry rather than a tidy-up. Both AL boundaries subtract 1
+/// and translate an out-of-range read, but they catch DIFFERENT exception types (unmodified
+/// Ncl.dll, 28.1, read with the decompiler rather than inferred):</para>
+/// <code>
+///     NavTestField.ALGetValidationError(index)     catch (IndexOutOfRangeException)
+///     NavTestPageBase.ALGetValidationError(index)  catch (ArgumentOutOfRangeException)
+/// </code>
+/// <para>LINQ's <c>ElementAt</c> — the call BC's own client makes — raises the ARGUMENT
+/// flavour. So on the FIELD that catch is dead and an out-of-range read escapes as a raw CLR
+/// exception (measured, corpus run 34002487601; see <see cref="TestFieldValidationErrors.Get"/>),
+/// while on the PAGE it is live and the read becomes a <c>NavNCLIndexOutOfBoundsException</c>.
+/// <c>ElementAt</c> here is therefore the call that reproduces BC's page-side chain rather than
+/// merely producing a similar outcome.</para>
+///
+/// <para>WHAT PROVES WHICH, stated precisely because it is easy to overclaim. Corpus
+/// <c>TestPart_GetValidationError_ErrorsOnIndexZero</c> asserts
+/// <c>GetLastErrorText() &lt;&gt; ''</c>, so it pins that index 0 is OUT of the 1-based range —
+/// which is the off-by-one that matters and the assertion a 0-based ledger fails. It does NOT
+/// discriminate the two exception flavours: probed here, an <c>IndexOutOfRangeException</c>
+/// implementation also passes it, because the runner surfaces that as a trappable AL error too.
+/// The flavour is pinned instead by <c>TestPageValidationErrorsTests</c> on the C# side, against
+/// the decompiled catch above.</para>
+/// </summary>
+internal sealed class TestPageValidationErrors
+{
+    private readonly List<string> _errors = new();
+
+    /// <summary>How many refusals this page has recorded. BC's <c>ITestPage.ValidationErrorCount</c>.</summary>
+    internal int Count => _errors.Count;
+
+    /// <summary>
+    /// Record a refusal already formatted exactly as the control stored it — including the
+    /// refresh suffix when the control's binding earns one. The page does not re-derive the
+    /// text: real BC keeps one list and the control's is a view onto it, so re-deriving would
+    /// be the one way the two could disagree.
+    /// </summary>
+    internal void Record(string storedMessage) => _errors.Add(storedMessage ?? string.Empty);
+
+    /// <summary>
+    /// The recorded error at a ZERO-based index (BC's AL boundary has already subtracted 1).
+    /// <para>Deliberately <see cref="Enumerable.ElementAt{TSource}(IEnumerable{TSource}, int)"/>
+    /// and not <c>_errors[index]</c>: it is the call BC's own client makes, and it raises
+    /// <see cref="ArgumentOutOfRangeException"/> — the type
+    /// <c>NavTestPageBase.ALGetValidationError(int)</c> catches and turns into a
+    /// <c>NavNCLIndexOutOfBoundsException</c>. Unlike the field ledger's identical-looking
+    /// call, that catch is LIVE here, which is what makes an out-of-range page read trappable
+    /// from AL. See this class's summary.</para>
+    /// <para>No id is consumed. The page pair has no <c>LastUsedValidationErrorId</c> /
+    /// <c>MaxValidationErrorId</c> on <see cref="Microsoft.Dynamics.Nav.Types.Data.ITestPage"/>
+    /// at all — the "is there something new since the snapshot" test BC runs against the field
+    /// ledger has no page-level counterpart, so there is nothing for a read to mark used.</para>
+    /// </summary>
+    internal string Get(int index) => _errors.ElementAt(index);
 }


### PR DESCRIPTION
Closes #3009

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/233

## The gap

`MockITestPage` answered `ValidationErrorCount => 0` and `GetValidationError(int) => string.Empty`, and `LiveNavTestPage`, `LiveNavTestPart` and `RequestPageTestPage` all inherit them — so every TestPage the runner builds reported no page-level validation errors regardless of what happened. Neither member was even `virtual`, so no subclass could correct it.

That is the `loud-failures.md` anti-pattern exactly: AL got a plausible number and nothing looked broken.

It is not decoration. BC's `NavTestPageBase.ALValidationErrorCount()` is `CheckPageOpened(); return TestPage.ValidationErrorCount;` — our mock, straight through to AL's `TestPage.ValidationErrorCount()`. And `NavTestField.CheckError`, which wraps every control write, reads it before and after, so the page branch of `CheckError` could never fire.

## The answer already existed on a service tier

Issue #3009's "What I do not know" section asked which AL shape produces a page-level validation error and said settling it needed a corpus test. Corpus PR #227 (merged `0bbe3765`) supplies one, on a **TestPart** — a shape the issue did not consider. Codeunit 60346 asserts the count, the 1-based message read and the index-0 range check, green on eight BC Cloud legs. **Real BC does count it; the hardcoded `0` is not faithful.**

## The fix

`TestPageValidationErrors` — one ledger per page — handed to every control the page builds. `TestFieldValidationErrors.Record`, the single write route, now feeds both with the same stored text. That mirrors real BC, which keeps one client-side error list per page of which the control's view is a filter, and it is why the two cannot drift: there is no second place to record a refusal.

**Which exception a refused write raises is unchanged.** `CheckError` tests the field branch first, and it wins whenever the written control recorded the refusal itself. Worked through in the code comments, including the accepted-write and two-controls cases, to confirm feeding the page ledger cannot make the page branch fire spuriously.

**The page's range check is deliberately not the field's.** `Ncl.dll` 28.1 shows the two AL boundaries catch different types:

```
NavTestField.ALGetValidationError(index)     catch (IndexOutOfRangeException)
NavTestPageBase.ALGetValidationError(index)  catch (ArgumentOutOfRangeException)
```

`Enumerable.ElementAt` raises the Argument flavour, so the field's catch is dead (already measured, corpus run 34002487601) while the page's is live. Both ledgers use `ElementAt`, so each reproduces its own side of that asymmetry rather than merely producing a similar outcome.

## RED → GREEN

Against corpus `master` `d025203`, which carries PR #227's tests (the pin here is **not** moved — see below):

| test | before | after |
|---|---|---|
| `TestPart_ValidationErrorCount_IsZeroOnACleanPart` | PASS | PASS |
| `TestPart_ValidationErrorCount_CountsARefusedFieldValidation` | **FAIL** | PASS |
| `TestPart_GetValidationError_IsOneBasedAndCarriesTheMessage` | **FAIL** | PASS |
| `TestPart_GetValidationError_ErrorsOnIndexZero` | **FAIL** | PASS |

The first row is the point: it passed **before** the fix, against the hardcoded `0`, so "return 1" is not a fix. That is the proving-test bar in `tdd.md`.

The four new corpus tests in PR #233 (page-level, on a full page) were run the same way against this branch's parent: 3 FAIL reading `0` and `""`, 1 PASS, and all 4 PASS on this branch.

## What I also ran

- **Full corpus at the current pin** — 2814/2814, `--strict --count-baseline`. No regression.
- **`tests/runner-extras`** — 351/351, `--strict`.
- **All 16 corpus validation-error tests** (field-level, page-var, subscriber-refusal, request-page) — 16/16.
- **`dotnet test --filter "…TestPage|…ValidationError|…RequestPage"`** — 258 passed, 0 failed, 16 skipped.

## Fix the shape, not the reported line

1. **Same wrong pattern at another call site?** Yes — one the issue named and the compiler found: `RequestPageTestPage` also derives from `MockITestPage`, and its `GetField` builds a `PageVariableTestField`. Wired to the same ledger, so `TestRequestPage.ValidationErrorCount()` gets the fix too.
2. **Sibling making the same assumption?** `MockITestField` still answers `0` / `""`. Checked rather than assumed: it is built **only** by `MockITestPage.GetField` (the degraded no-live-instance path), and its `Value` setter is a plain string store that runs no AL — no `OnValidate`, no record write, nothing that can refuse. So the constant is **faithful** here, and it now says so in a comment instead of sitting there unexplained — the "if it does not count it, say so" branch #3009 asked for.
3. **Two paths writing the same state?** Deliberately made impossible. `TestFieldValidationErrors.Record` is the only write route (verified by search), and it feeds both ledgers, so a refusal cannot land on one and not the other. Pinned by a test.

## Tests

`AlRunner.Tests/TestPageValidationErrorsTests.cs`, 12 cases pinning the runner-side mechanism (the BC claim itself lives upstream). Both directions probed rather than assumed:

- Removing the page feed turns **3** of them red.
- Swapping `ElementAt` for an indexer + `IndexOutOfRangeException` turns **4** red.

That second probe found an overclaim in my own first draft, and the comments now say so plainly: **the corpus test does not discriminate the two exception flavours** — an `IndexOutOfRangeException` implementation also passes `ErrorsOnIndexZero`, because the runner surfaces it as a trappable AL error too. The corpus pins the 1-based-ness (the off-by-one that matters); the flavour is pinned only by the C# test, against the decompiled catch.

Includes the `loud-failures.md` arm: a `RunnerOutOfScopeException` must not be recorded on the page ledger either, or `asserterror` would absorb a loud refusal.

## Deliberately left out

- **The corpus pin is not moved** (`2cba52d4`, unchanged — `git status` shows no `M tests/al-language`). Sequenced behind #3304, and PR #3317 is the catch-up; it stops at `17b015e`, one commit short of #227, which is precisely this gap. This fix is the prerequisite for advancing past it. The RED → GREEN above was measured against a separate corpus checkout instead.
- **#2964** (`MoveLast()` and the new-row line) — claimed by `stma-auto-5`, branch `agent/stma-auto-5/issue-2964`. It touches `MockTestPage.cs` too, but a different region: `git merge-tree` against my branch reports **CLEAN**. Not folded, because it is in flight.
- **#3029** (`OnNewRecord` raised twice), **#3055** (`SetValue` writing back the same value), **#3179** (`OnQueryClosePage` close refusal). All three name `MockTestPage.cs`, but none lands in the validation-ledger region: #3029 is row lifecycle (`EnterNewRowLine` / `TryNewRecord`), #3055 is the write-back decision and needs its own corpus measurement, #3179 is the close path plus `RunnerFormCloseHandler.cs`. Each needs materially different reasoning to review, so folding them would break the "one coherent change" bound in `batch-sibling-issues-by-file.md`.
- **#3312 / #3313** — the other TestPart failures visible in my runs (`GoToKey`, `FindFirstField`, `GetField`, the invisible part). Unchanged by this PR, filed and owned separately; failing counts are identical before and after.

`CacheVersion` untouched: no parse change and no change to any cached record shape — the ledger is per-run TestPage state that never reaches the compile cache.

Opened by an automated implementation agent (`stma-auto-3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4