### PR TITLE
fix(calcformula): resolve SystemRowVersion, which BC puts at field id 0

### DIFF
--- a/AlRunner.Tests/CalcFormulaSystemFieldResolutionTests.cs
+++ b/AlRunner.Tests/CalcFormulaSystemFieldResolutionTests.cs
@@ -24,7 +24,17 @@
 //
 // The invariant that matters is "resolver set == materialised set": resolving a name to an id
 // the built NCLMetaTable does not carry would fault inside NCL instead of refusing loudly
-// here, which is why SystemRowVersion is deliberately NOT in the set.
+// here.
+//
+// #3307 — that invariant is about IDS, not about which array a name lives in, and this file
+// used to conflate the two. SystemRowVersion was asserted here as deliberately unresolvable,
+// on the reading that it is a sixth system field at id 2000000005 the runner does not
+// materialise. Both halves were wrong: the AL compiler synthesizes it at field id 0 with
+// metadata name `timestamp`, and no field 2000000005 exists anywhere in BC. Since
+// BuildNCLMetaTable already materialises id 0 as the synthetic `timestamp` column, resolving
+// SystemRowVersion to 0 SATISFIES the invariant — the built table does carry that id. It stays
+// out of SystemParsedFields because that array is what gets APPENDED, and appending id 0 a
+// second time would corrupt the field layout. Resolvable, not appended.
 
 using System.Reflection;
 using AlRunner.Patches;
@@ -90,13 +100,62 @@ public class CalcFormulaSystemFieldResolutionTests
         }
     }
 
-    /// SystemRowVersion is NOT materialised onto a built table, so it must NOT resolve —
-    /// answering an id NCL has no MetaField for is worse than refusing.
+    /// #3307 — SystemRowVersion resolves, and it resolves to field id 0.
+    ///
+    /// It used to be asserted here as deliberately UNRESOLVABLE, on the reading that it was a
+    /// sixth system field at id 2000000005 that the runner does not materialise. That reading
+    /// was wrong in both halves. Microsoft's AL compiler synthesizes it at field id 0 with
+    /// metadata name `timestamp` — SynthesizedFieldHelper.AppendSystemFields in
+    /// Microsoft.Dynamics.Nav.CodeAnalysis:
+    ///
+    ///     if (runtimeVersionOrCurrent >= RuntimeVersion.Fall2022)
+    ///         builder.Add(SynthesizedFieldSymbol.Create(
+    ///             owner, 0, "SystemRowVersion", NavCorLib.BigIntegerType, "timestamp"));
+    ///
+    /// and there is no field 2000000005 anywhere: NCL's NCLMetaTable.SetSystemFields switches
+    /// on 2000000000-2000000004 with no 2000000005 case, and NCL carries no SystemRowVersion
+    /// string at all.
+    ///
+    /// So the resolver-set == materialised-set invariant is SATISFIED by resolving it, not by
+    /// refusing it: BuildNCLMetaTable already puts id 0 in the MetaField[] as the synthetic
+    /// `timestamp` column, so id 0 is a field the built table genuinely carries.
     [Fact]
-    public void SystemRowVersion_DoesNotResolve()
+    public void SystemRowVersion_ResolvesToFieldZero()
     {
-        Assert.False(TryResolve(TableWithoutSystemFields(), "SystemRowVersion", out _));
+        Assert.True(TryResolve(TableWithoutSystemFields(), "SystemRowVersion", out var resolved));
+        Assert.Equal(0, resolved.FieldId);
+        Assert.Equal("SystemRowVersion", resolved.FieldName);
+        Assert.Equal("BigInteger", resolved.TypeName);
+    }
+
+    /// It resolves case-insensitively, like every other field name in a CalcFormula.
+    [Fact]
+    public void SystemRowVersion_ResolvesCaseInsensitively()
+    {
+        Assert.True(TryResolve(TableWithoutSystemFields(), "SYSTEMROWVERSION", out var resolved));
+        Assert.Equal(0, resolved.FieldId);
+    }
+
+    /// It must NOT be in SystemParsedFields, and that is a live constraint rather than
+    /// bookkeeping: BuildNCLMetaTable APPENDS that array to a MetaField[] that already opens
+    /// with the synthetic `timestamp` column at id 0. Adding SystemRowVersion there would put
+    /// id 0 in the array twice and corrupt the field layout R2R-precompiled BC code holds
+    /// offsets for. Resolvable, not appended.
+    [Fact]
+    public void SystemRowVersion_IsNotAppendedToTheMaterialisedSet()
+    {
         Assert.DoesNotContain(SystemParsedFields(), f => f.FieldName == "SystemRowVersion");
+        Assert.DoesNotContain(SystemParsedFields(), f => f.FieldId == 0);
+    }
+
+    /// `timestamp` is the field's METADATA name, not an AL identifier, so a CalcFormula may
+    /// not name it. Only the AL-visible spelling resolves. Without this, "resolve field 0 by
+    /// name" could be satisfied by opening the door to both spellings, which would accept AL
+    /// the real compiler rejects.
+    [Fact]
+    public void MetadataNameTimestamp_DoesNotResolve()
+    {
+        Assert.False(TryResolve(TableWithoutSystemFields(), "timestamp", out _));
     }
 
     [Theory]

--- a/AlRunner.Tests/FlowFieldSourceFieldZeroSentinelTests.cs
+++ b/AlRunner.Tests/FlowFieldSourceFieldZeroSentinelTests.cs
@@ -1,0 +1,118 @@
+// FlowFieldSourceFieldZeroSentinelTests — field id 0 is a REAL field, not "no field" (#3307).
+//
+// The defect
+// ----------
+// FlowFieldPatches.CalcFlowFieldValuesCore resolves a formula's aggregated SOURCE field from
+// the MetaCalcFormula's FieldId. It used to gate that lookup on `fieldId != 0`, reading id 0
+// as "this formula names no source field" — which is true for count() and exist(), the two
+// CalculationMethods that carry no source field.
+//
+// That sentinel was only ever safe because nothing could NAME field 0. SystemRowVersion can.
+// Microsoft's AL compiler synthesizes it at field id 0 with metadata name `timestamp` —
+// SynthesizedFieldHelper.AppendSystemFields in Microsoft.Dynamics.Nav.CodeAnalysis:
+//
+//     if (runtimeVersionOrCurrent >= RuntimeVersion.Fall2022)
+//         builder.Add(SynthesizedFieldSymbol.Create(
+//             owner, 0, "SystemRowVersion", NavCorLib.BigIntegerType, "timestamp"));
+//
+// confirmed a second time in the same assembly by XmlPortMetadataEmitter.GetFieldName, which
+// special-cases exactly the triple (Id == 0, Name == "SystemRowVersion", MetadataName ==
+// "timestamp"). So `max("T".SystemRowVersion where(...))` arrived with fieldId == 0, skipped
+// the lookup, left srcFieldColumn at -1, and the aggregate branch was never entered. The
+// FlowField answered TypedDefaultForField — 0 — for every possible row set.
+//
+// That is the silent-wrong-answer shape `.claude/rules/loud-failures.md` exists to prevent,
+// and it is the worst-disguised version of it: a rowversion of 0 reads like "this row was
+// never stamped" rather than like a bug, so nothing about the answer looks wrong.
+//
+// What this file pins, and what it deliberately does not
+// ------------------------------------------------------
+// The BC-observable claim — what max/min/lookup over SystemRowVersion actually answers, and
+// that a where-arm still narrows it — is plain BC behaviour and is asserted UPSTREAM, against
+// a real service tier, in the al-language corpus: CFSF Tests (codeunit 60818,
+// record/TestCalcFormulaSystemFieldsTests.Codeunit.al), which is the same fixture corpus PR
+// #216 used for the other five system fields. Repeating it here would be the runner agreeing
+// with itself.
+//
+// So this file pins only the runner-side MECHANISM that made the claim unprovable: that the
+// source-field lookup is gated on the CalculationMethod, which is where BC states "this
+// formula has no source field", rather than on an id being zero, which merely correlated with
+// it until BC put a real field at id 0.
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class FlowFieldSourceFieldZeroSentinelTests
+{
+    private static string FlowFieldPatchesSource()
+    {
+        var path = Path.Combine(RepoRoot(), "AlRunner", "Patches", "FlowFieldPatches.cs");
+        Assert.True(File.Exists(path), $"expected FlowFieldPatches.cs at {path}");
+        return File.ReadAllText(path);
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        for (var d = new DirectoryInfo(dir); d != null; d = d.Parent)
+            if (File.Exists(Path.Combine(d.FullName, "AlRunner.sln"))
+                || Directory.Exists(Path.Combine(d.FullName, "AlRunner", "Patches")))
+                return d.FullName;
+        throw new InvalidOperationException("could not locate the repository root from " + dir);
+    }
+
+    /// The source-field lookup must not be gated on the field id being non-zero.
+    ///
+    /// Stated as the absence of the specific guard rather than as a general "no zero
+    /// comparisons anywhere", so it names the one line that regressed and cannot be satisfied
+    /// by renaming a variable.
+    [Fact]
+    public void SourceFieldLookup_IsNotGatedOnFieldIdBeingNonZero()
+    {
+        var src = FlowFieldPatchesSource();
+
+        Assert.DoesNotContain("srcTable != null && fieldId != 0", src);
+        Assert.DoesNotMatch(
+            new Regex(@"if\s*\(\s*srcTable\s*!=\s*null\s*&&\s*fieldId\s*!=\s*0\s*\)"),
+            src);
+    }
+
+    /// ...and it IS gated on the CalculationMethod instead, which is the fact the id was
+    /// standing in for. Count and Exist are exactly the two methods BC gives no source field.
+    [Fact]
+    public void SourceFieldLookup_IsGatedOnTheCalculationMethodInstead()
+    {
+        var src = FlowFieldPatchesSource();
+
+        Assert.Contains("formulaHasSourceField", src);
+        Assert.Matches(
+            new Regex(
+                @"bool\s+formulaHasSourceField\s*=\s*!Equals\(calcMethod,\s*_cmCount\)\s*"
+                + @"&&\s*!Equals\(calcMethod,\s*_cmExist\)\s*;"),
+            src);
+        Assert.Contains("if (srcTable != null && formulaHasSourceField)", src);
+    }
+
+    /// The rewritten guard has to keep the property the old one had: count() and exist() must
+    /// still take the no-source-field path. If a future edit dropped either method from the
+    /// predicate, a count formula would resolve field 0 — the timestamp column — as its source
+    /// field, which is exactly the confusion this issue was about, pointed the other way.
+    [Fact]
+    public void CountAndExist_AreBothStillExcluded()
+    {
+        var src = FlowFieldPatchesSource();
+        var m = Regex.Match(src, @"bool\s+formulaHasSourceField\s*=\s*([^;]+);");
+
+        Assert.True(m.Success, "formulaHasSourceField must be declared with an initialiser");
+        var predicate = m.Groups[1].Value;
+
+        Assert.Contains("_cmCount", predicate);
+        Assert.Contains("_cmExist", predicate);
+        Assert.DoesNotContain("_cmSum", predicate);
+        Assert.DoesNotContain("_cmMin", predicate);
+        Assert.DoesNotContain("_cmMax", predicate);
+        Assert.DoesNotContain("_cmLookup", predicate);
+        Assert.DoesNotContain("_cmAverage", predicate);
+    }
+}

--- a/AlRunner/Patches/FlowFieldPatches.cs
+++ b/AlRunner/Patches/FlowFieldPatches.cs
@@ -1020,7 +1020,26 @@ public static class FlowFieldPatches
             if (tableId != 0)
                 srcTable = ResolveTableById(tableId);
 
-            if (srcTable != null && fieldId != 0)
+            // #3307 — `fieldId != 0` used to guard this lookup, reading id 0 as "this formula
+            // names no source field" (true for count/exist, which carry no source field). That
+            // sentinel was safe only while nothing could NAME field 0, and SystemRowVersion
+            // can: Microsoft's AL compiler synthesizes it at field id 0 with metadata name
+            // `timestamp` (SynthesizedFieldHelper.AppendSystemFields), not in the
+            // 2000000000-2000000004 block. So `max("T".SystemRowVersion where(...))` arrived
+            // here with fieldId == 0, skipped the lookup, left srcFieldColumn at -1, and the
+            // aggregate branch below was never entered — the FlowField answered
+            // TypedDefaultForField, i.e. 0, for every row set. Silent and plausible: a
+            // rowversion of 0 reads like "not yet stamped" rather than like a bug.
+            //
+            // The right discriminator is the CalculationMethod, which BC already carries and
+            // which says exactly what the sentinel was standing in for: Count and Exist have
+            // no source field, every other method has one. Asking the metatable for field 0 on
+            // a Count formula would otherwise resolve the timestamp column and make
+            // srcFieldColumn >= 0, but the aggregate branch below tests the method too, so
+            // that would be inert — gating here keeps the "no source field" fact where BC
+            // states it rather than inferring it from an id.
+            bool formulaHasSourceField = !Equals(calcMethod, _cmCount) && !Equals(calcMethod, _cmExist);
+            if (srcTable != null && formulaHasSourceField)
             {
                 try
                 {

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -1025,8 +1025,14 @@ public static partial class RecordPatches
     /// a name to an id the built NCLMetaTable does not carry faults inside NCL instead of
     /// refusing loudly here (#3178).</para>
     ///
-    /// <para><c>timestamp</c> (id 0) is deliberately not here. It is a synthetic column the
-    /// runner adds for RecordRef access, not a field AL can name in a formula.</para>
+    /// <para><c>SystemRowVersion</c> is deliberately not here, and that is NOT because the
+    /// runner refuses it — see <see cref="SystemRowVersionParsedField"/>. It is not in THIS
+    /// array because this array is what <c>BuildNCLMetaTable</c> APPENDS, and the field it
+    /// names is already in the MetaField[] under its other name: BC gives it id 0, the same
+    /// id as the synthetic <c>timestamp</c> column. Appending it here would put id 0 in the
+    /// array twice and corrupt the field layout R2R-precompiled BC code holds offsets for.
+    /// It is resolvable but not appended, which is why the two sets are now read through
+    /// separate members rather than through this one.</para>
     /// </summary>
     private static readonly ParsedField[] SystemParsedFields = new[]
     {
@@ -1036,6 +1042,49 @@ public static partial class RecordPatches
         new ParsedField(2000000003, "SystemModifiedAt", "DateTime", 0),
         new ParsedField(2000000004, "SystemModifiedBy", "Guid",     0),
     };
+
+    /// <summary>
+    /// BC's SIXTH system field, which is not shaped like the other five and must not be
+    /// filed with them (#3307).
+    ///
+    /// <para>Microsoft's AL compiler synthesizes it at <b>field id 0</b> with metadata name
+    /// <c>timestamp</c>, not in the 2000000000-2000000004 block —
+    /// <c>SynthesizedFieldHelper.AppendSystemFields</c> in
+    /// <c>Microsoft.Dynamics.Nav.CodeAnalysis</c>, verbatim:</para>
+    ///
+    /// <code>
+    /// if (runtimeVersionOrCurrent >= RuntimeVersion.Fall2022)
+    ///     builder.Add(SynthesizedFieldSymbol.Create(
+    ///         owner, 0, "SystemRowVersion", NavCorLib.BigIntegerType, "timestamp"));
+    /// </code>
+    ///
+    /// <para>Confirmed twice in the same assembly: <c>XmlPortMetadataEmitter.GetFieldName</c>
+    /// special-cases exactly the pair <c>(Id == 0, Name == "SystemRowVersion",
+    /// MetadataName == "timestamp")</c>, alongside the SystemId pair, to emit the metadata
+    /// name rather than the AL name. BC's RUNTIME confirms the negative half: NCL's
+    /// <c>NCLMetaTable.SetSystemFields</c> switches on field numbers 2000000000-2000000004
+    /// and has no 2000000005 case at all, and NCL contains no <c>SystemRowVersion</c> string.
+    /// So the id in this field's name is 0, and there is no field 2000000005 anywhere.</para>
+    ///
+    /// <para>The runner already materialises id 0 on every built metatable (the
+    /// <c>timestampParsed</c> column in <c>BuildNCLMetaTable</c>) and already stamps it with
+    /// a strictly increasing rowversion on Insert and Modify (<c>RowVersionPatches</c>), so
+    /// plain AL reading <c>Rec.SystemRowVersion</c>, filtering on it, or asking
+    /// <c>FieldNo(SystemRowVersion)</c> has always worked. What did NOT work is naming it in
+    /// a <b>CalcFormula</b> or a <b>TableRelation</b>, because those go through
+    /// <see cref="TryResolveTableFieldByName"/>, which only ever saw the column under the
+    /// name <c>timestamp</c>. The AL author writes <c>SystemRowVersion</c>, so the lookup
+    /// missed and the formula was refused (CalcFormula, loudly since #3279) or the relation
+    /// silently dropped (TableRelation) — the two halves of #3307.</para>
+    ///
+    /// <para>The type is BigInteger, matching both <c>NavCorLib.BigIntegerType</c> above and
+    /// the <c>timestampParsed</c> column the runner builds, so resolving to id 0 answers a
+    /// MetaField that is genuinely there and genuinely that type. This is the one system
+    /// field whose resolution does NOT extend the materialised set — it names a column the
+    /// set already contains.</para>
+    /// </summary>
+    private static readonly ParsedField SystemRowVersionParsedField =
+        new ParsedField(0, "SystemRowVersion", "BigInteger", 0);
 
     /// <summary>
     /// Resolve a field NAME that a CalcFormula or a TableRelation states, on
@@ -1072,11 +1121,23 @@ public static partial class RecordPatches
     }
 
     /// <summary>Every field a formula on <paramref name="table"/> may name: the table's own,
-    /// its tableextensions', and the system fields. Materialise it once when a caller resolves
+    /// its tableextensions', the five appended system fields, and
+    /// <see cref="SystemRowVersionParsedField"/>. Materialise it once when a caller resolves
     /// several names against one table — <see cref="GetAllFieldsIncludingExtensions"/> builds a
-    /// HashSet on each call whenever the table carries extension fields.</summary>
+    /// HashSet on each call whenever the table carries extension fields.
+    ///
+    /// <para>The invariant this has to keep is "every name resolvable here maps to an id the
+    /// built NCLMetaTable carries" — resolving to an id that is NOT there faults inside NCL
+    /// instead of refusing loudly (#3178). SystemRowVersion satisfies it through the
+    /// <c>timestamp</c> column at id 0 rather than through <see cref="SystemParsedFields"/>,
+    /// which is why it is concatenated separately and NOT added to that array (#3307).
+    /// <c>timestamp</c> itself stays unresolvable by that name: BC's AL surface calls the
+    /// field SystemRowVersion, and <c>timestamp</c> is its metadata name, not an AL
+    /// identifier a formula may use.</para></summary>
     private static IEnumerable<ParsedField> ResolvableFields(ParsedTable table)
-        => GetAllFieldsIncludingExtensions(table).Concat(SystemParsedFields);
+        => GetAllFieldsIncludingExtensions(table)
+            .Concat(SystemParsedFields)
+            .Append(SystemRowVersionParsedField);
 
     /// <summary>
     /// Build the <c>MetaCalcFormula</c> for one FlowField.


### PR DESCRIPTION
Closes #3307

## The issue's premise was wrong, and checking it is most of this change

Issue #3307 says `SystemRowVersion` is field **2000000005**, that the runner materialises five of six system fields, and that "AL that reads it cannot run". None of the three holds. I measured rather than reasoned, per `no-assumption-fixes.md`.

**Microsoft's AL compiler synthesizes `SystemRowVersion` at field id 0** with metadata name `timestamp` — `SynthesizedFieldHelper.AppendSystemFields` in `Microsoft.Dynamics.Nav.CodeAnalysis`, verbatim:

```csharp
if (runtimeVersionOrCurrent >= RuntimeVersion.Fall2022)
{
    builder.Add(SynthesizedFieldSymbol.Create(owner, 0, "SystemRowVersion", NavCorLib.BigIntegerType, "timestamp"));
}
```

Confirmed a second time in the same assembly: `XmlPortMetadataEmitter.GetFieldName` special-cases exactly the triple `(Id == 0, Name == "SystemRowVersion", MetadataName == "timestamp")`, alongside the `SystemId` pair.

The negative half is confirmed in the runtime: NCL's `NCLMetaTable.SetSystemFields` switches on field numbers `2000000000`-`2000000004` and has **no `2000000005` case**, and `Microsoft.Dynamics.Nav.Ncl.dll` contains no `SystemRowVersion` string at all. **There is no field 2000000005 anywhere in BC.**

So the issue's step 1 ("materialise the field ... with BC's own type for it") was already done, under the other name, and its step 3 (add it to `SystemParsedFields`) would have been actively harmful — see below.

## What actually worked, and what did not

The runner already materialises id 0 on every built metatable (the `timestampParsed` column in `BuildNCLMetaTable`) and already stamps it with a strictly increasing rowversion on Insert and Modify (`RowVersionPatches`, #1980). I probed each AL shape against the built runner:

| AL naming `SystemRowVersion` | before this PR |
|---|---|
| `Rec.SystemRowVersion` read | worked, non-zero |
| advances on `Modify` | worked |
| survives `Get` | worked |
| `FieldNo(SystemRowVersion)` = 0 | worked |
| `SetFilter` / `SetRange` | worked |
| `RecordRef.Field(0).Name` = `timestamp` | worked |
| **`CalcFormula` naming it** | **refused** (`calcformula-reference-unresolved`) |
| **`TableRelation` naming it** | **silently dropped** |

The corpus already agreed: `session/TestTransactionContracts.al` pins non-zero-after-`Insert` and non-decreasing-after-`Modify`, and both pass on the runner today. So "AL that reads it cannot run" was already falsified upstream.

## Two defects, failing differently

**1. The name never resolved.** `TryResolveTableFieldByName` saw the column only as `timestamp`, never as `SystemRowVersion`. A CalcFormula naming it was refused loudly (correct, thanks to #3279); a TableRelation naming it was **silently dropped**, so `Validate` accepted a value BC refuses.

Fixed by making `SystemRowVersion` resolvable to id 0. It stays **out** of `SystemParsedFields`, and that is load-bearing rather than bookkeeping: that array is what `BuildNCLMetaTable` **appends**, and id 0 is already in the `MetaField[]` as the timestamp column. Following the issue's step 3 literally would have put id 0 in the array **twice** and corrupted the field layout R2R-precompiled BC code holds offsets for. Resolvable, not appended — the two sets are now read through separate members so the distinction is explicit.

This keeps the `#3178` invariant intact. "Resolver set == materialised set" is about **ids**, not about which array a name lives in: resolving `SystemRowVersion` to 0 *satisfies* it, because the built table genuinely carries id 0.

**2. `fieldId != 0` was a sentinel that stopped being safe.** `FlowFieldPatches.CalcFlowFieldValuesCore` gated its source-field lookup on the field id being non-zero, reading 0 as "this formula names no source field" — true for `count`/`exist`, false once BC puts a real field at id 0. So `max`/`min`/`lookup` over `SystemRowVersion` resolved no source field, left `srcFieldColumn` at `-1`, skipped the aggregate branch entirely, and answered `TypedDefaultForField` — **0** — for every possible row set.

That is the silent-wrong-answer shape `loud-failures.md` exists to prevent, in its best-disguised form: a rowversion of 0 reads like "this row was never stamped", not like a bug. The gate is now on the `CalculationMethod`, which is where BC states the fact the id was merely correlated with.

This second defect is why fixing only the resolver was not enough — with resolution fixed, the formula built and calculated and still answered `0`.

## The proving test is upstream, and a real service tier has answered

Per `bc-behavior-tests-go-upstream.md`, what a CalcFormula over `SystemRowVersion` answers is plain BC behaviour. Corpus PR:

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/232

It extends the `CFSF Header` / `CFSF Line` fixture that StefanMaron/BusinessCentral.AL.Language.Tests#216 built for the other five system fields, covering the same three positions for the sixth: aggregated as the SOURCE field, narrowed by a system-field where-arm, and looked up.

**All 8 required BC legs are green (27.0, 27.3, 27.5, 28.0, 28.1, 28.2, 28.3, 28.4), and I confirmed from the run log that the three tests executed and passed on every one** — not skipped. So this is a measurement, not an inference.

Every assertion is an **ordering** between two rowversions read in the same run, never a literal — a rowversion's absolute value is a property of the database, not of AL. The seeded rows make the two outcomes different *values* rather than a value versus a default: lines 1 and 2 carry the header's `SystemId`, line 3 does not and was inserted last, so a dropped arm answers line 3's rowversion where the arm answers line 2's.

**I have not bumped the pin.** Per the brief, the bump is sequenced behind #3304 — please sequence it.

## RED → GREEN

- **Corpus tests**, run against my corpus branch with this branch's runner: 3 FAIL before (`calcformula-reference-unresolved`), then after the resolver fix alone they still failed — `Expected:<7481> Actual:<0>`, which is defect 2 surfacing — and 3 PASS after both fixes.
- **`CalcFormulaSystemFieldResolutionTests`**: 2 fail with the resolver change reverted, 14/14 pass with it.
- **`FlowFieldSourceFieldZeroSentinelTests`** (new): 3 fail with the sentinel change reverted, 3/3 pass with it.

The obsolete `SystemRowVersion_DoesNotResolve` assertion is replaced rather than deleted. It encoded the issue's wrong premise as an invariant, so it had to move with the fix; four tests now pin the corrected one, including that the metadata name `timestamp` stays **un**resolvable — only the AL-visible spelling resolves, so the fix cannot be satisfied by accepting AL the real compiler rejects.

## Test results

| suite | result |
|---|---|
| al-language corpus (pinned `2cba52d4`) | **2814/2814 pass**, 0 fail |
| `tests/runner-extras` | **351/351 pass**, 0 fail |
| `AlRunner.Tests` filtered (`FlowField`, `CalcFormula`, `Relation`, `MetaTable`) | **84 pass**, 0 fail, 8 skipped |

## Fixing the shape, not the reported line

**Does the same wrong pattern appear at another call site?** I grepped for the `fieldId == 0` / `!= 0` sentinel across `AlRunner/`. Three sites total. The other two are both in `EventSubscriberPatches` (`ResolveValidateField` line 830, and line 1326) and are **genuinely different**: they bind `OnValidate` subscribers, where a compiler-synthesized field has no trigger to subscribe to, and both try a **name**-based lookup first, so the id is a fallback rather than the gate. Left alone deliberately.

**Does a sibling function make the same assumption?** `ResolvableFields` is the single resolver both the CalcFormula and TableRelation builders go through, so both were fixed by the one change — that is why the TableRelation half needed no separate edit.

**Do two code paths write the same state with different invariants?** Yes, and this was the substantive finding: the **materialised** set (`BuildNCLMetaTable`, which prepends `timestamp` at id 0) and the **resolver** set (`ResolvableFields`) had drifted apart at exactly id 0 — the built table carried a field the resolver would not name. Fixed in the safe direction, and the drift is now pinned by `SystemRowVersion_IsNotAppendedToTheMaterialisedSet`.

## Open-issue queue scan

Per `batch-sibling-issues-by-file.md`. Nothing folded, and here is why each:

- See #3306 (`BuildMetaFieldRelations` dropping an unresolvable TableRelation), the closest — it is the *general* form of the TableRelation half I hit here, and `stma-auto-2` is working it now. **Deliberately not folded in**: my hunks in `RecordPatches.NclMetaTableBuilder.cs` are all at lines 1028-1140 (the declaration and `ResolvableFields`); `BuildMetaFieldRelations` is at line ~754 and is **untouched** by this PR, so there is no textual conflict. The two compose — this PR makes the name resolve, and the other makes an unresolvable name refuse loudly instead of dropping.
- **#3204** (corpus has no test that a tableextension-contributed TableRelation is enforced) — corpus-side, `status: blocked`, different repo.
- **#3144** (Date FlowField materialises the whole window) — same file, `FlowFieldPatches.cs`, but a performance concern in the row-enumeration path, not the source-field resolution path. Different reasoning to review.
- **#2789** (precompiled TableRelation follow-ups), **#2383** (Config. Template Line TableRelation) — TableRelation subsystem, but neither lands in either file I touched.

## Left out deliberately

**`TableRelation = T.SystemRowVersion` now enforces rather than silently dropping** — that half of #3307 is fixed. But I did **not** add a test asserting *what* it enforces. With the relation live, BC's lookup goes through the primary key and `timestamp` is not a key field, so a probe refused a rowversion that genuinely exists. Whether real BC accepts such a relation at all is a BC-behaviour question I have no verdict on, and guessing it is exactly the failure mode called out in the brief. Filing it separately rather than asserting a guess.

## `CacheVersion` (33) — not bumped, deliberately

`CacheVersion` keys `BcAppSymbolCache`, the `.app` symbol **parse** cache. This change touches neither a parse nor any cached record shape: `SystemRowVersionParsedField` is a `static readonly` built at runtime and never serialized, and the `FlowFieldPatches` change reads a `MetaCalcFormula` already in memory. A stale payload cannot replay a wrong answer through either edit, so a bump would invalidate every cache for no correctness gain.

Implemented by agent `stma-auto-1` (automated implementation agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4
