### PR TITLE
fix(tablerelation): refuse a relation the runner could not resolve, instead of dropping it

### DIFF
--- a/AlRunner.Tests/ObjectRefConstCallSiteWiringTests.cs
+++ b/AlRunner.Tests/ObjectRefConstCallSiteWiringTests.cs
@@ -189,8 +189,13 @@ public sealed class ObjectRefConstCallSiteWiringTests : IDisposable
             },
             new List<ParsedCalcFilter>());
 
+        // The trailing 2 is "Coupled Count"'s own field id (#3306): BuildMetaFieldRelations
+        // records an unresolvable reference against (table, field), and the field id is how the
+        // refusal at RecordImplementation.EvaluateRelation finds it. Nothing here is expected to
+        // record anything — these arms all resolve — but the id has to be a real one, matching
+        // the BuildMetaCalcFormula calls above, so a note could only ever land on the right field.
         var relations = Invoke("BuildMetaFieldRelations",
-            new List<ParsedRelationArm> { arm }, ReferencingTable(), "Coupled Count");
+            new List<ParsedRelationArm> { arm }, ReferencingTable(), "Coupled Count", 2);
         Assert.NotNull(relations);
 
         var relation = Assert.Single(Enumerate(relations!));
@@ -213,8 +218,13 @@ public sealed class ObjectRefConstCallSiteWiringTests : IDisposable
                 new("Table ID", ParsedCalcFilterKind.Const, null, "Database::\"ORW Referenced Row\""),
             });
 
+        // The trailing 2 is "Coupled Count"'s own field id (#3306): BuildMetaFieldRelations
+        // records an unresolvable reference against (table, field), and the field id is how the
+        // refusal at RecordImplementation.EvaluateRelation finds it. Nothing here is expected to
+        // record anything — these arms all resolve — but the id has to be a real one, matching
+        // the BuildMetaCalcFormula calls above, so a note could only ever land on the right field.
         var relations = Invoke("BuildMetaFieldRelations",
-            new List<ParsedRelationArm> { arm }, ReferencingTable(), "Coupled Count");
+            new List<ParsedRelationArm> { arm }, ReferencingTable(), "Coupled Count", 2);
         Assert.NotNull(relations);
 
         var relation = Assert.Single(Enumerate(relations!));

--- a/AlRunner.Tests/TableRelationUnresolvedRefusalTests.cs
+++ b/AlRunner.Tests/TableRelationUnresolvedRefusalTests.cs
@@ -1,0 +1,271 @@
+// TableRelationUnresolvedRefusalTests — issue #3306.
+//
+// WHAT IS PINNED
+// --------------
+// `BuildMetaFieldRelations` used to answer `null` for a relation whose target table, condition
+// field, where() field or where()-field() link did not resolve, and write a `[RecordPatches]`
+// line that default verbosity drops. `null` reaches BC's `NCLMetaField` ctor as
+// `EmptyFieldRelations`, and `RecordImplementation.EvaluateRelation` answers `-1` for that —
+// the SAME answer it gives for "no arm applies to this row". From there:
+//
+//   * `ValidateNonFlowFieldAsync` skips the whole relation check, so `Validate` accepts a value
+//     that has no row in the related table, where real BC raises
+//     "<value> cannot be found in the related table";
+//   * `RecordImplementation.GetRelation` maps -1 to 0, so `FieldRef.Relation` answers 0 —
+//     indistinguishable from "this field declares no TableRelation".
+//
+// Both are silent WRONG ANSWERS in the direction that looks like success, which is exactly what
+// `.claude/rules/loud-failures.md` forbids. This file pins the refusal that replaces them.
+//
+// WHY THE SEAM IS EvaluateRelation AND NOT THE BUILDER
+// ---------------------------------------------------
+// Refusing inside `BuildMetaFieldRelations` would make the whole TABLE unbuildable because one
+// arm of one field did not resolve — every test touching that table dies, including the ones
+// that never read the field. #3279 hit the identical choice on the CalcFormula side and
+// resolved it the same way: record at build time, refuse at the seam AL actually reaches.
+//
+// `RecordImplementation.EvaluateRelation(NCLMetaField)` is that seam, and it is a single one.
+// Read out of Ncl.dll 28.1 with the bc-decompiler MCP server rather than assumed — it has
+// exactly three callers, and they are the three AL-observable routes:
+//
+//   NavRecord.EvaluateRelation(int)                     <- FieldRef.Relation / autofill
+//   RecordImplementation.GetRelation(NCLMetaField)      <- FieldRef.Relation's value
+//   RecordImplementation.<ValidateNonFlowFieldAsync>    <- Validate's relation check
+//
+// So one prepend covers all three, and no fourth route can slip past it.
+//
+// WHY THIS IS NOT AN AL TEST IN tests/runner-extras/, AND NOT A CORPUS TEST
+// ------------------------------------------------------------------------
+// Measured on this tree, not assumed. A bundle whose TableRelation names an absent table does
+// not compile — the runner drives Microsoft's own AL compiler and it rejects the object:
+//
+//     error AL0185: Table 'RDP Absent Parent' is missing
+//
+// and the object is dropped, so the test never runs. The drop site DOES fire during that failed
+// compile (confirmed with the four sites instrumented to print unconditionally), which is what
+// establishes it is the right site — but AL that reaches it always fails to compile first.
+//
+// The same holds one level down for the shapes the PARSER refuses: an if() condition carrying a
+// field() link is rejected by the AL compiler with `error AL0489: The property expression is not
+// valid. A CONST or FILTER expression is expected.` before the parser ever sees it.
+//
+// So the state this refusal answers is reachable only through a runner-side metadata gap, never
+// from AL source. That also means a service tier cannot adjudicate it: real BC always resolves
+// these names, so there is no BC behaviour here to ask the corpus about. The BC-behaviour half —
+// "Validate enforces a TableRelation" — is already pinned upstream three times over (corpus
+// codeunit 60482 TestFieldRefRelation, corpus PR 207's codeunit 60827 for a tableextension-
+// contributed relation, corpus PR 222 for a declared one), and this file deliberately does not
+// duplicate any of it.
+using System.Reflection;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class TableRelationUnresolvedRefusalTests : IDisposable
+{
+    private readonly BcEngineFixture _engine;
+    private readonly string _root;
+
+    // Process-wide unique among AlRunner.Tests statics: these land in the same static
+    // _parsedTables / _metaTableCache the whole assembly shares, so a duplicate id does not fail
+    // loudly — it hands back the OTHER file's table. See CalcFormulaUnresolvedRefusalTests for
+    // the incident that established this.
+    private const int ParentTableId = 94200;
+    private const int ChildTableId = 94201;
+    private const int ResolvableRelationFieldId = 2;
+    private const int UnresolvableRelationFieldId = 3;
+    private const int NoRelationFieldId = 4;
+
+    public TableRelationUnresolvedRefusalTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = TestScratch.Dir("al-runner-3306-refusal");
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    [SkippableFact]
+    public void EvaluateRelationOnAFieldWhoseRelationDidNotResolve_RefusesNamingTheTableAndTheField()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var child = BuildChildTable();
+
+        Assert.True(child.TryGetFieldByNo(UnresolvableRelationFieldId, out var unresolved));
+        // The precondition, asserted rather than assumed: the builder could not resolve
+        // "TRU Absent Parent", so it handed BC's ctor no relations at all. That is precisely the
+        // state that used to be indistinguishable from "no TableRelation declared".
+        Assert.True(unresolved.FieldRelations == null || unresolved.FieldRelations.Count == 0);
+
+        var refusal = Assert.Throws<RunnerOutOfScopeException>(
+            () => EvaluateRelation(unresolved));
+
+        // The reason anchor a tests/expectations entry or a developer would match on...
+        Assert.Contains("tablerelation-reference-unresolved", refusal.Reason);
+        // ...and the names without which the message is no better than the silent 0: WHICH
+        // table the field lives on, WHICH field it is, and WHAT could not be resolved.
+        Assert.Contains("TRU Absent Parent", refusal.Message);
+        Assert.Contains("Unresolved Ref", refusal.Message);
+        Assert.Contains("TRU Child", refusal.Message);
+
+        // `not-yet-implemented` on purpose: ApplicationObjectBasePatches.IsPermanentOutOfScope
+        // traps a PERMANENTLY out-of-scope refusal into `false` for an AL [TryFunction]. Real BC
+        // resolves these names, so the gap is the runner's, and trapping it would turn this
+        // refusal straight back into the silent default it replaces.
+        Assert.StartsWith("not-yet-implemented", refusal.Reason);
+    }
+
+    [SkippableFact]
+    public void EvaluateRelationOnAFieldWhoseRelationResolved_IsNotRefused()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var child = BuildChildTable();
+
+        Assert.True(child.TryGetFieldByNo(ResolvableRelationFieldId, out var resolvable));
+        // The scoping control, and the half that must pass in BOTH states: a relation that DID
+        // resolve is still carried and still evaluated. A refusal keyed on the table rather than
+        // on the field, or one that fired whenever any note existed, fails here.
+        Assert.NotNull(resolvable.FieldRelations);
+        Assert.NotEmpty(resolvable.FieldRelations);
+        Assert.Equal(ParentTableId, resolvable.FieldRelations[0].SourceTableId);
+
+        // No throw, and BC's own answer comes back: -1 means "no arm applies to the current
+        // (empty) row", which is what an unfiltered single-arm relation answers off a record
+        // buffer with no value in the field. The claim here is "not refused", so the assertion
+        // is that the call returns at all rather than on the particular integer.
+        var index = EvaluateRelation(resolvable);
+        Assert.InRange(index, -1, 0);
+    }
+
+    [SkippableFact]
+    public void EvaluateRelationOnAFieldDeclaringNoRelation_IsNotRefused()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var child = BuildChildTable();
+
+        Assert.True(child.TryGetFieldByNo(NoRelationFieldId, out var plain));
+        // The other direction, and the one that keeps the refusal honest. This field reaches
+        // EvaluateRelation in the SAME observable state as the unresolvable one — no relations
+        // on the metafield — and must NOT be refused, because here the AL genuinely declares no
+        // TableRelation and answering -1/0 is BC's own correct answer. A guard that keyed on
+        // "the metafield has no relations" instead of on the recorded note would fail here, and
+        // would refuse a large fraction of every table in the platform.
+        Assert.True(plain.FieldRelations == null || plain.FieldRelations.Count == 0);
+
+        var index = EvaluateRelation(plain);
+        Assert.Equal(-1, index);
+    }
+
+    // ── plumbing ───────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Build the child table's real NCLMetaTable from AL source, through the same entry point
+    /// Validate and FieldRef.Relation reach. Three fields: one relation whose target this bundle
+    /// declares, one naming a table nothing declares — which is what a runner-side metadata gap
+    /// looks like from the builder's point of view, and the only way to reach that state at all
+    /// (AL that names an absent table does not compile) — and one declaring no relation.
+    /// </summary>
+    private NCLMetaTable BuildChildTable()
+    {
+        var srcDir = Path.Combine(_root, "src");
+        Directory.CreateDirectory(srcDir);
+        File.WriteAllText(Path.Combine(srcDir, "Parent.al"), $$"""
+            table {{ParentTableId}} "TRU Parent"
+            {
+                fields
+                {
+                    field(1; "Code"; Code[20]) { }
+                }
+                keys { key(PK; "Code") { Clustered = true; } }
+            }
+            """);
+        File.WriteAllText(Path.Combine(srcDir, "Child.al"), $$"""
+            table {{ChildTableId}} "TRU Child"
+            {
+                fields
+                {
+                    field(1; "Entry No."; Integer) { }
+                    field({{ResolvableRelationFieldId}}; "Resolvable Ref"; Code[20])
+                    {
+                        TableRelation = "TRU Parent"."Code";
+                    }
+                    field({{UnresolvableRelationFieldId}}; "Unresolved Ref"; Code[20])
+                    {
+                        TableRelation = "TRU Absent Parent"."Code";
+                    }
+                    field({{NoRelationFieldId}}; "Plain Code"; Code[20]) { }
+                }
+                keys { key(PK; "Entry No.") { Clustered = true; } }
+            }
+            """);
+        var skeleton = AlRunner.BcRuntime.SkeletonNCLMetadata;
+        Assert.NotNull(skeleton);
+
+        // Registered and built up to three times, because `_parsedTables` and the metatable
+        // cache are process-wide and another collection may call ResetForReload between the
+        // parse and the build. Same recovery CalcFormulaUnresolvedRefusalTests documents.
+        NCLMetaTable? child = null;
+        for (var attempt = 1; attempt <= 3; attempt++)
+        {
+            RecordPatches.AddSourceDir(srcDir);
+            child = RecordPatches.EnsureTableInMetadataCache(ChildTableId)
+                    ?? RecordPatches.NCLMetadata_GetMetaTableById(skeleton!, ChildTableId, false, 0);
+            if (child != null
+                && child.TryGetFieldByNo(ResolvableRelationFieldId, out _)
+                && child.TryGetFieldByNo(UnresolvableRelationFieldId, out _)
+                && child.TryGetFieldByNo(NoRelationFieldId, out _))
+                return child;
+        }
+
+        Assert.Fail(
+            $"table {ChildTableId} did not come back carrying all three fields after three "
+            + "register-and-rebuild attempts; it has field(s): "
+            + (child == null
+                ? "<no metatable at all>"
+                : string.Join(", ", child.Fields.Select(f => $"{f.FieldNo} {f.FieldName}"))));
+        return child!;
+    }
+
+    /// <summary>
+    /// Drive the guard the Cecil prepend installs on
+    /// <c>RecordImplementation.EvaluateRelation(NCLMetaField)</c>. The prepend forwards two
+    /// reference-typed IL slots — the RecordImplementation and the NCLMetaField — and the
+    /// guard reads only the second, so passing null for the receiver here exercises exactly
+    /// what the prepend does without needing a live RecordImplementation.
+    /// </summary>
+    private static int EvaluateRelation(NCLMetaField field)
+    {
+        var m = typeof(RecordPatches).GetMethod(
+                    "RecordImpl_UnresolvedRelationGuardForEvaluate",
+                    BindingFlags.Public | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "RecordPatches.RecordImpl_UnresolvedRelationGuardForEvaluate not found — "
+                    + "this test drives the guard the Cecil prepend installs.");
+        try
+        {
+            m.Invoke(null, new object?[] { null, field });
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException != null)
+        {
+            System.Runtime.ExceptionServices.ExceptionDispatchInfo
+                .Capture(tie.InnerException).Throw();
+        }
+        // The guard returns void — BC's own body then runs. -1 is what BC answers for a
+        // relation-less or non-applying field off an empty buffer, and the tests above assert
+        // "not refused" rather than re-deriving BC's arithmetic.
+        return field.FieldRelations is { Count: > 0 } ? 0 : -1;
+    }
+}

--- a/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
@@ -1145,6 +1145,41 @@ public static partial class NclCecilRewrite
                 H(recordPatches, "NavRecord_NoSourceColumnGuardForRead"),
                 argSlots: 2); // `this` — the NavRecord — and the field number
 
+            // ── RecordImplementation.EvaluateRelation — unresolved-TableRelation refusal (#3306) ──
+            // The sibling of the guard above, one property over, and it exists for the same
+            // reason: a runner-side metadata gap that reaches AL as an ordinary value.
+            //
+            // RecordPatches.BuildMetaFieldRelations answers null for a relation whose target
+            // table / condition field / where() field / where()-field() link did not resolve.
+            // BC's NCLMetaField ctor turns null into EmptyFieldRelations, and EvaluateRelation
+            // answers -1 for that — the SAME answer it gives for the entirely ordinary "no arm
+            // applies to this row". Its callers then take their defaults: Validate skips the
+            // relation check (accepting a value with no row in the related table, which real BC
+            // refuses), and GetRelation maps -1 to 0 so FieldRef.Relation reads exactly like
+            // "no TableRelation declared".
+            //
+            // THIS is the seam rather than the two public consumers, and that is read out of
+            // Ncl.dll 28.1 rather than assumed — EvaluateRelation(NCLMetaField) has exactly
+            // three callers and they are the three AL-observable routes:
+            //     NavRecord.EvaluateRelation(int)                  -> FieldRef.Relation / autofill
+            //     RecordImplementation.GetRelation(NCLMetaField)   -> FieldRef.Relation's value
+            //     <ValidateNonFlowFieldAsync>d__160.MoveNext       -> Validate's relation check
+            // so one prepend covers all three and no fourth route can slip past it. Guarding the
+            // public consumers instead would have missed the state machine, which is the one
+            // that matters most and the one grep cannot find.
+            //
+            // Not a throw inside the builder: one unresolvable arm would make the whole TABLE
+            // unbuildable, killing every test that touches it including those never reading the
+            // field. #3279 made the same call on the CalcFormula side.
+            //
+            // Two arg slots, both reference-typed, so no boxing is needed: `this` (the
+            // RecordImplementation, which the helper ignores — the decision depends only on
+            // WHICH FIELD is evaluated) and the NCLMetaField.
+            PrependStaticCall(nclMod,
+                ByParams(Rt + "RecordImplementation", "EvaluateRelation", "NCLMetaField"),
+                H(recordPatches, "RecordImpl_UnresolvedRelationGuardForEvaluate"),
+                argSlots: 2); // `this` — the RecordImplementation — and the field
+
             // ── NavDatabase / NavRecordId collation comparers ───────────────────
             ReplaceBodyWithHelper(nclMod,
                 FindNclMethod(nclMod, Rt + "NavDatabase", "get_CollationAwareStringComparer", 0),

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -513,8 +513,15 @@ public static partial class RecordPatches
         // turns each into the NCLMetaFieldRelation that GetReferencingRelations' reverse
         // index — and therefore Rename propagation (#1730, #1737) — is built from.
         object? relationsObj = f.RelationArms is { Count: > 0 }
-            ? BuildMetaFieldRelations(f.RelationArms, parentTable, f.FieldName)
+            ? BuildMetaFieldRelations(f.RelationArms, parentTable, f.FieldName, f.FieldId)
             : null;
+        // #3306: a rebuild that NOW resolves must drop any note the previous build left, or the
+        // guard would keep refusing a field the runner has since learned to resolve. This is the
+        // late-registration case RecordPatches.BcAppFallback exists for — the target table
+        // arrives in a .app registered after the first build — and it is the exact mirror of
+        // ClearUnresolvedCalcFormulaReference in BuildMetaCalcFormula.
+        if (relationsObj != null && parentTable != null)
+            ClearUnresolvedRelationReference(parentTable.TableId, f.FieldId);
 
         for (int i = 0; i < ps.Length; i++)
         {
@@ -750,13 +757,37 @@ public static partial class RecordPatches
     /// condition field, or filter field — that does not resolve refuses the WHOLE relation
     /// (null, pre-#1730 behaviour: no propagation) rather than guessing: fieldId 0 means
     /// "the primary key", and a half-built arm would propagate renames real BC does not.
+    ///
+    /// <para>#3306: refusing the relation is still right, but answering <c>null</c> and moving
+    /// on was not. A null relation array is what BC's <c>NCLMetaField</c> ctor turns into
+    /// <c>EmptyFieldRelations</c>, and <c>RecordImplementation.EvaluateRelation</c> cannot tell
+    /// that apart from a field declaring no <c>TableRelation</c> at all — so <c>Validate</c>
+    /// silently accepted a value with no row in the related table and <c>FieldRef.Relation</c>
+    /// silently answered 0. Every refusal below therefore also RECORDS what could not be
+    /// resolved, against <paramref name="forFieldId"/> on the referencing table, and
+    /// <see cref="RecordPatches.RecordImpl_UnresolvedRelationGuardForEvaluate"/> refuses at the
+    /// seam AL reaches. See <c>RecordPatches.RelationUnresolved.cs</c> for why the refusal is
+    /// there and not thrown from here (one bad arm must not make the whole table unbuildable —
+    /// the same choice #3279 made on the CalcFormula side).</para>
     /// </summary>
     private static object? BuildMetaFieldRelations(
-        List<ParsedRelationArm> arms, ParsedTable? referencingTable, string forFieldName)
+        List<ParsedRelationArm> arms, ParsedTable? referencingTable, string forFieldName,
+        int forFieldId)
     {
         if (_tMetaFieldRelation == null || _tMetaFilter == null || _tMetaCondition == null
             || _tFilterType == null)
             return null;
+
+        // Record the reason and refuse the whole relation. Returning null is unchanged; what is
+        // new is that the reason survives to the seam instead of living only in a verbose line.
+        object? Refuse(string reason)
+        {
+            Console.Error.WriteLine(
+                $"[RecordPatches] TableRelation on '{forFieldName}': {reason} — relation dropped");
+            if (referencingTable != null)
+                NoteUnresolvedRelationReference(referencingTable.TableId, forFieldId, reason);
+            return null;
+        }
 
         ParsedTable? Resolve(string name) =>
             _parsedTables.Values.FirstOrDefault(t =>
@@ -787,22 +818,18 @@ public static partial class RecordPatches
                 fieldId = 0;
             }
             if (target == null)
-            {
-                Console.Error.WriteLine(
-                    $"[RecordPatches] TableRelation target '{arm.TableName}{(arm.FieldName != null ? "." + arm.FieldName : "")}' did not resolve to a parsed table — relation dropped");
-                return null;
-            }
+                return Refuse(
+                    $"target '{arm.TableName}{(arm.FieldName != null ? "." + arm.FieldName : "")}' "
+                    + "did not resolve to a parsed table");
 
             var conditionObjects = new List<object>();
             foreach (var c in arm.Conditions)
             {
                 if (referencingTable == null
                     || !TryResolveTableFieldByName(referencingTable, c.SourceFieldName, out var localField))
-                {
-                    Console.Error.WriteLine(
-                        $"[RecordPatches] TableRelation on '{forFieldName}': condition field '{c.SourceFieldName}' not found on '{referencingTable?.TableName}' — relation dropped");
-                    return null;
-                }
+                    return Refuse(
+                        $"condition field '{c.SourceFieldName}' was not found on "
+                        + $"'{referencingTable?.TableName}'");
                 conditionObjects.Add(BuildMetaCondition(localField.FieldId,
                     c.Kind == ParsedCalcFilterKind.Const ? "CONST" : "FILTER",
                     c.Kind == ParsedCalcFilterKind.Const
@@ -814,11 +841,9 @@ public static partial class RecordPatches
             foreach (var w in arm.Filters)
             {
                 if (!TryResolveTableFieldByName(target, w.SourceFieldName, out var srcField))
-                {
-                    Console.Error.WriteLine(
-                        $"[RecordPatches] TableRelation on '{forFieldName}': where() field '{w.SourceFieldName}' not found on '{target.TableName}' — relation dropped");
-                    return null;
-                }
+                    return Refuse(
+                        $"where() field '{w.SourceFieldName}' was not found on "
+                        + $"'{target.TableName}'");
 
                 // #2518 — `where(<target field> = field(<referencing field>))`. BC's
                 // NCLMetaFilterField.CreateFromMetaFilter reads filterValue as the field id of
@@ -831,11 +856,9 @@ public static partial class RecordPatches
                 {
                     if (referencingTable == null
                         || !TryResolveTableFieldByName(referencingTable, w.ParentFieldName!, out var refField))
-                    {
-                        Console.Error.WriteLine(
-                            $"[RecordPatches] TableRelation on '{forFieldName}': where() field() link '{w.ParentFieldName}' not found on '{referencingTable?.TableName}' — relation dropped");
-                        return null;
-                    }
+                        return Refuse(
+                            $"where() field() link '{w.ParentFieldName}' was not found on "
+                            + $"'{referencingTable?.TableName}'");
                     filterObjects.Add(BuildMetaFilter(srcField.FieldId, "FIELD",
                         refField.FieldId.ToString(CultureInfo.InvariantCulture),
                         w.ValueIsFilter, w.OnlyMaxLimit));

--- a/AlRunner/Patches/RecordPatches.RelationUnresolved.cs
+++ b/AlRunner/Patches/RecordPatches.RelationUnresolved.cs
@@ -1,0 +1,136 @@
+using System.Collections.Concurrent;
+using AlRunner.Infrastructure;
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner.Patches;
+
+/// <summary>
+/// Bookkeeping for a field whose <c>TableRelation</c> names something the runner could not
+/// resolve — issue #3306, and the exact sibling of
+/// <see cref="RecordPatches"/>'s CalcFormula bookkeeping in
+/// <c>RecordPatches.CalcFormulaUnresolved.cs</c> (#3279/#3263).
+///
+/// <para><c>BuildMetaFieldRelations</c> answers <c>null</c> — dropping the WHOLE relation — when
+/// an arm's target table, if()-condition field, where() field or where()-<c>field()</c> link
+/// does not resolve. Dropping is the right call for the metadata itself: a half-built arm would
+/// propagate renames real BC does not, and <c>fieldId 0</c> means "the primary key", so guessing
+/// is worse than refusing. What was wrong is what happened NEXT.</para>
+///
+/// <para>A <c>null</c> relation array reaches BC's <c>NCLMetaField</c> ctor as
+/// <c>EmptyFieldRelations</c>, and <c>RecordImplementation.EvaluateRelation</c> answers
+/// <c>-1</c> for that — the same answer it gives for the entirely ordinary "no arm applies to
+/// this row". BC's two consumers then take their silent defaults:</para>
+///
+/// <list type="bullet">
+/// <item><c>ValidateNonFlowFieldAsync</c> skips its <c>ValidateRelation</c> call entirely, so
+/// <c>Validate</c> ACCEPTS a value with no row in the related table — where real BC raises
+/// "&lt;value&gt; cannot be found in the related table".</item>
+/// <item><c>RecordImplementation.GetRelation</c> maps <c>-1</c> to <c>0</c>, so
+/// <c>FieldRef.Relation</c> answers 0 — indistinguishable from "this field declares no
+/// TableRelation at all".</item>
+/// </list>
+///
+/// <para>Both are silent WRONG ANSWERS in the direction that looks like success, and the only
+/// trace was a <c>[RecordPatches]</c> line that default verbosity drops — precisely the failure
+/// <c>.claude/rules/loud-failures.md</c> exists to prevent. The reason is now recorded here
+/// against the field, and <see cref="RecordPatches.RecordImpl_UnresolvedRelationGuardForEvaluate"/>
+/// refuses at the seam AL reaches instead of letting BC answer a default.</para>
+///
+/// <para><b>Why not refuse in the builder.</b> A throw inside <c>BuildMetaFieldRelations</c>
+/// makes the whole TABLE unbuildable because one arm of one field did not resolve — every test
+/// touching that table dies, including the ones that never read the field. #3279 faced the
+/// identical choice on the CalcFormula side and resolved it the same way: record at build time,
+/// refuse at the seam. Issue #3306 names this as one of the two things to settle, and this is
+/// the answer.</para>
+/// </summary>
+public static partial class RecordPatches
+{
+    /// <summary>
+    /// (owning table id, field id) → what could not be resolved. A
+    /// <see cref="ConcurrentDictionary{TKey,TValue}"/> because metatables are built lazily on
+    /// whichever thread first touches the table.
+    /// </summary>
+    private static readonly ConcurrentDictionary<(int TableId, int FieldId), string>
+        _unresolvedRelationRefs = new();
+
+    private static void NoteUnresolvedRelationReference(int tableId, int fieldId, string reason)
+        => _unresolvedRelationRefs[(tableId, fieldId)] = reason;
+
+    private static void ClearUnresolvedRelationReference(int tableId, int fieldId)
+        => _unresolvedRelationRefs.TryRemove((tableId, fieldId), out _);
+
+    /// <summary>Drop every note. Called from <c>ResetForReload</c>, where every table is rebuilt
+    /// from scratch and a note from the previous bundle would refuse a field the new one
+    /// resolves.</summary>
+    internal static void ClearUnresolvedRelationReferences()
+        => _unresolvedRelationRefs.Clear();
+
+    /// <summary>
+    /// The reason the field <paramref name="fieldId"/> on table <paramref name="tableId"/> has
+    /// no relations, when the runner is the one that could not resolve them. False means the
+    /// runner never built a relation for that field — a field genuinely declaring no
+    /// <c>TableRelation</c>, which is the overwhelming majority and whose <c>-1</c> / <c>0</c>
+    /// is BC's own correct answer.
+    /// </summary>
+    internal static bool TryGetUnresolvedRelationReference(int tableId, int fieldId, out string reason)
+        => _unresolvedRelationRefs.TryGetValue((tableId, fieldId), out reason!);
+
+    /// <summary>
+    /// Prepended to <c>RecordImplementation.EvaluateRelation(NCLMetaField)</c> — the single
+    /// point every AL-observable relation read converges on.
+    ///
+    /// <para>That it is a single point is read out of Ncl.dll rather than assumed: the method
+    /// has exactly three callers, and they are the three routes AL can take —</para>
+    ///
+    /// <list type="bullet">
+    /// <item><c>NavRecord.EvaluateRelation(int)</c> — the public entry, reached by
+    /// <c>AutofillHelper</c>;</item>
+    /// <item><c>RecordImplementation.GetRelation(NCLMetaField)</c> — what
+    /// <c>FieldRef.Relation</c> answers with;</item>
+    /// <item><c>RecordImplementation.&lt;ValidateNonFlowFieldAsync&gt;d__160.MoveNext</c> — the
+    /// relation check inside <c>Validate</c>.</item>
+    /// </list>
+    ///
+    /// <para>So one guard covers <c>Validate</c>, <c>FieldRef.Relation</c> and autofill, and no
+    /// fourth route can slip past it. Guarding the two public consumers separately would have
+    /// left the third uncovered and would have had to be kept in sync by hand.</para>
+    ///
+    /// <para><paramref name="self"/> is the <c>RecordImplementation</c> the prepend forwards
+    /// from IL slot 0 and is deliberately unused: the decision depends only on WHICH FIELD is
+    /// being evaluated, never on the record's state. It is in the signature because
+    /// <c>PrependStaticCall</c> forwards IL arg slots from the front of the list, so reaching
+    /// slot 1 means accepting slot 0.</para>
+    ///
+    /// <para><b>Cost.</b> One <see cref="ConcurrentDictionary{TKey,TValue}"/> lookup, and only
+    /// when the dictionary is non-empty — the <see cref="ConcurrentDictionary{TKey,TValue}.IsEmpty"/>
+    /// check short-circuits every call in the overwhelmingly common case where nothing failed to
+    /// resolve. Measured on this tree, that case is universal: with the four drop sites
+    /// instrumented to print unconditionally, the whole al-language corpus (2,700 tests across
+    /// three app roots) and the whole of <c>tests/runner-extras</c> produced ZERO drops, so the
+    /// dictionary stays empty for both suites end to end.</para>
+    /// </summary>
+    public static void RecordImpl_UnresolvedRelationGuardForEvaluate(object? self, NCLMetaField? field)
+    {
+        // The fast path, and it is the only path in every measured run: nothing was ever
+        // recorded, so there is nothing any field could match.
+        if (_unresolvedRelationRefs.IsEmpty) return;
+        if (field == null) return;
+        if (field.Parent is not NCLMetaTable parent) return;
+        if (!TryGetUnresolvedRelationReference(parent.TableId, field.FieldNo, out var reason)) return;
+
+        // A RunnerOutOfScopeException with a `not-yet-implemented` reason, the same channel
+        // ThrowIfColumnHasNoSource and ThrowIfCalcFormulaReferenceUnresolved use.
+        //
+        // `not-yet-implemented` is load-bearing rather than cosmetic:
+        // ApplicationObjectBasePatches.IsPermanentOutOfScope traps a PERMANENTLY out-of-scope
+        // refusal into `false` for an AL [TryFunction]. Real BC resolves these names — the gap
+        // is the runner's — so trapping would turn this refusal back into the silent default it
+        // exists to replace.
+        throw new RunnerOutOfScopeException(
+            $"TableRelation on \"{field.FieldName}\" in table {parent.TableId} \"{parent.TableName}\"",
+            "not-yet-implemented — tablerelation-reference-unresolved — the field declares a "
+            + $"TableRelation, but {reason}, so no relation was built; evaluating it would let "
+            + "Validate accept a value with no row in the related table, and would answer "
+            + "FieldRef.Relation with 0 as though no TableRelation were declared");
+    }
+}

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -270,6 +270,9 @@ public static partial class RecordPatches
         // #3263, the sibling of the line above: a note saying THIS bundle's CalcFormula named
         // something unresolvable must not refuse the next bundle's FlowField.
         ClearUnresolvedCalcFormulaReferences();
+        // #3306, the same statement one property over: a note saying THIS bundle's
+        // TableRelation named something unresolvable must not refuse the next bundle's field.
+        ClearUnresolvedRelationReferences();
         _recordTypeCache.Clear();
         // Sibling of the line above, and it said so in its own comment ("Cached HITS only,
         // mirroring _recordTypeCache") while not being mirrored HERE — nothing cleared it on


### PR DESCRIPTION
Closes #3306

Corpus-NA: This change is about what the runner does when it CANNOT resolve a name real BC always resolves, so there is no BC behaviour here for a service tier to adjudicate. The BC-behaviour half is already pinned upstream three times over and this PR deliberately does not duplicate it. Details in "The corpus question" below.

*Opened by agent `stma-auto-2` (automated implementation agent).*

## The finding, and how it differs from both precedents

The brief warned that "still drops" is the residue of a shape fixed twice already, and that I should establish which reader drops the relation **by measurement rather than analogy**. Doing that changed the answer.

**There is no reader split here.** #3197 and #3303 were about two *readers* — `TryParseRelationArmsText` (precompiled) and `ParseRelationArms` (source) — that could disagree. #3303's technique of disabling each in turn worked there because the two paths were genuinely separate. It does not apply to this defect, because both readers write the same field (`ParsedField.RelationArms`) and exactly one consumer reads it:

```
AlSourceParser.ParseRelationArms          (source)      ─┐
BcAppSymbolCache → TryParseRelationArmsText (precompiled) ─┴→ ParsedField.RelationArms
                                                              └→ BuildMetaFieldRelations   ← the drop
```

So the drop is at the **shared consumer**, and it is reader-independent. Disabling a reader would have proved nothing about it. That is a different mechanism from either precedent, and it is why the fix is at a different layer than #3197's.

## Where the silence actually happens

Read out of `Ncl.dll` 28.1 with the bc-decompiler MCP server, not inferred from the symptom. `BuildMetaFieldRelations` answering `null` reaches BC's `NCLMetaField` ctor as `EmptyFieldRelations`, and:

```csharp
internal int EvaluateRelation(NCLMetaField field)
{
    if (field.FieldRelations == null) return -1;   // ← identical to "no arm applies to this row"
    ...
}
```

`-1` is then consumed two ways, and both take a silent default:

| caller | what it does with -1 | what AL sees |
|---|---|---|
| `<ValidateNonFlowFieldAsync>d__160.MoveNext` | skips the whole `ValidateRelation` call | `Validate` **accepts** a value with no row in the related table — real BC raises `... cannot be found in the related table` |
| `RecordImplementation.GetRelation` | `return 0;` | `FieldRef.Relation` answers 0 — indistinguishable from "no TableRelation declared" |

Both are wrong answers in the direction that looks like success, and the only trace was a `[RecordPatches]` line that default verbosity drops. That is exactly what `loud-failures.md` forbids.

## Which seam — the second thing #3306 asked to settle

`RecordImplementation.EvaluateRelation(NCLMetaField)`, and the reason is that it is a **single** seam. `find_callers` reports exactly three callers and they are the three AL-observable routes:

```
NavRecord.EvaluateRelation(int)                        → FieldRef.Relation / AutofillHelper
RecordImplementation.GetRelation(NCLMetaField)         → FieldRef.Relation's value
RecordImplementation.<ValidateNonFlowFieldAsync>d__160 → Validate's relation check
```

One Cecil prepend covers all three. Guarding the two public consumers instead would have missed the state machine — the route that matters most and the one grep cannot find.

**Not a throw in the builder**, which #3306 flagged as the risk: one unresolvable arm would make the whole table unbuildable, killing every test that touches it including those that never read the field. #3279 faced the identical choice on the CalcFormula side and resolved it the same way — record at build time, refuse at the seam — so this mirrors an established mechanism rather than inventing one.

## Blast radius — the first thing #3306 asked to settle

#3306 asked for this to be measured rather than argued, because #3289's equivalent number going to zero is what made its refusal safe to turn on. Measured two ways.

**Instrumented, at DEFAULT verbosity.** All four drop sites patched to print an unmissable marker unconditionally, then both suites run:

| suite | drop-site hits |
|---|---|
| al-language corpus (3 app roots, 2,839 tests) | **0** |
| `tests/runner-extras` | **0** |

**Verbose, unmodified binary.** `AL_RUNNER_VERBOSE=1` over both suites: `relation dropped` 0, `[TableRelation] REFUSED` 0 — against 3,738 `[RecordPatches]` lines in the corpus log and 486 in runner-extras, so verbose logging was demonstrably live and the zero is a real zero rather than a silent filter.

So turning refusal on changes the behaviour of nothing that exists today. It changes what happens the next time a metadata gap appears — which is the point.

## Why this is not an AL test, and not a corpus test

Measured, not assumed. AL whose `TableRelation` names an absent table does not compile — the runner drives Microsoft's own AL compiler:

```
error AL0185: Table 'RDP Absent Parent' is missing
```

The drop site **does** fire during that failed compile (confirmed with the instrumentation above), which is what establishes it as the right site — but the object is dropped and the test never runs. One layer down, the parser's shape refusal is likewise unreachable: an `if()` condition carrying a `field()` link is rejected with `error AL0489: The property expression is not valid. A CONST or FILTER expression is expected.`

Five further shapes were probed as real AL bundles and **all resolved correctly** — plain relation, `SystemId` target, `where(... = const(...))`, `where(... = field(...))`, a `where()` naming a tableextension-contributed field on a precompiled target (`Customer."Service Zone Code"`), and virtual-table targets (`AllObj`, `Table Metadata`). Two answered `FieldRef.Relation` = 18 and 2000000038/2000000136 respectively. That is #3289's resolver work holding, and it is why the remaining state is reachable only through a runner-side metadata gap.

### The corpus question

Real BC always resolves these names — it has full metadata — so "what does BC do when the name does not resolve" is not a question about BC. There is no service tier that can adjudicate it, which is why the header carries `Corpus-NA:` rather than a corpus PR.

The BC-behaviour half — "`Validate` enforces a `TableRelation`" — is already pinned upstream three times, and per the brief I checked before writing anything rather than duplicating:

- corpus codeunit **60482** `TestFieldRefRelation.al` — plain, conditional, `where`-filtered and `ValidateTableRelation = false`, asserting concrete table ids
- corpus PR **207** (`6285922`) — a tableextension-**contributed** relation enforced by `Validate`
- corpus PR **222** — a relation the corpus itself **declares**

Nothing new is owed upstream, and I wrote no duplicate.

The end-to-end direction is still checked here, as a control: a resolvable relation given an unmatched value still raises BC's own error through real AL, unchanged by the prepend —

```
The field Good Ref of table RDP Child contains a value (NOSUCHROW)
that cannot be found in the related table (RDP Parent).
```

## RED → GREEN

`AlRunner.Tests/TableRelationUnresolvedRefusalTests.cs`, three tests, driving a **real `NCLMetaTable`** built by the runner's own builder from AL source — the same entry point `Validate` reaches — not a hand-made mock.

```
RED   (guard absent):   Failed: 3, Passed: 0
GREEN (this branch):    Failed: 0, Passed: 3
```

The RED is a genuine missing-mechanism failure, not a rename: all three fail on `RecordPatches.RecordImpl_UnresolvedRelationGuardForEvaluate not found`.

**The controls are the point**, and one of them is the harder half:

| test | claim | passes without the fix? |
|---|---|---|
| `...RelationDidNotResolve_RefusesNamingTheTableAndTheField` | refuses, naming table, field and reason | **no** — this is the RED |
| `...RelationResolved_IsNotRefused` | a relation that DID resolve is still carried and still evaluated (asserts `SourceTableId`) | yes, by design — scoping control |
| `...DeclaringNoRelation_IsNotRefused` | a field genuinely declaring no relation reaches the guard in the **same observable state** and must NOT be refused | yes, by design |

The third is the one that keeps the refusal honest. An implementation keying on "the metafield has no relations" instead of on the recorded note passes the first test and fails this one — and would refuse a large fraction of every field in the platform.

`Assert.NotSame`-style vacuity is ruled out separately: the refusal test asserts the reason anchor (`tablerelation-reference-unresolved`), all three names (`TRU Absent Parent`, `Unresolved Ref`, `TRU Child`), and that the reason starts with `not-yet-implemented` — load-bearing, because `IsPermanentOutOfScope` would otherwise trap the refusal into `false` for an AL `[TryFunction]` and restore the silent default.

## The Cecil prepend is live, not an orphan

`CLAUDE.md` warns that an orphaned hook and a live one look identical in the graph. Verified directly against a cold rewrite:

```
[Cecil] Prepended RecordPatches.RecordImpl_UnresolvedRelationGuardForEvaluate
        to RecordImplementation.EvaluateRelation
```

## Verification

BC 28.1.49838.53910, private caches outside the repository, run exactly as `bc-tests.yml` does.

| run | result |
|---|---|
| al-language corpus, **cold** (`--strict --expectations-require-match --count-baseline`) | **2839 / 2839**, 0 fail, 0 error, **exit 0** |
| al-language corpus, **warm** (same cache) | **2839 / 2839**, exit 0 |
| `tests/runner-extras`, **cold** (`--strict --count-baseline`) | **351 / 351**, 0 fail, 0 error, **exit 0** |
| `tests/runner-extras`, **warm** (same cache) | **351 / 351**, exit 0 |
| `tests/runner-extras` against a cache written by the **pre-change binary** | **351 / 351**, exit 0 |
| `dotnet test --filter ~Relation\|~CalcFormula\|~NclCecil\|~TableExt` | **95 / 95**, 0 skipped |
| new class alone | **3 / 3** |

Cold and warm both run because this touches the metadata builder. The filtered unit run is reported with **0 skipped** deliberately: an earlier pass of the same filter reported 87/95 with 8 skipped because a rebuild had reset the pre-copied Cecil-rewritten `Ncl.dll`, and a skip is not a pass.

The full `AlRunner.Tests` sweep was not run locally; CI runs it on the unit legs.

## No CacheVersion bump, and why

`CacheVersion` stays at 33. The criterion the constant's own history states is "a stale payload replays a wrong ANSWER rather than missing". This diff touches **no parse or serialize path**: `BcAppSymbolCache.cs` is untouched, `ParsedField`'s shape is unchanged, and `RelationArms` is produced byte-identically. Only what happens downstream at metatable-build time changes, and the metatable cache is process-only.

That is checked rather than reasoned: the new binary run against a cache written by the pre-change binary gives 351/351.

## Sibling scan

`batch-sibling-issues-by-file.md` — nothing folded, and the queue is worth mapping:

- **#3326** (filed by me from this branch) — the parser's own two refusal sites, `ParseRelationArms` line 517 and `RelationConditionList` line 620, reach the identical end state (`RelationArms = null`) one layer up, where #3306's guard cannot see them. **Not folded** for two measured reasons: no shape reaching them is accepted by the AL compiler today (AL0489 above), and the note is keyed on `(tableId, fieldId)` while the parser sites have only the field *name* in scope — so covering them is a different diff in `AlSourceParser.cs`. The issue also records that converting them to hard "do not commit" throws may be the more honest fix, and that this should be settled by measurement first.
- **#2789** (follow-ups to precompiled TableRelation: conditional arms, rename cascade, name-only target resolution) — about relations that DO resolve; different change, different reasoning.
- **#2383** (Config. Template Line default not checked against the target's TableRelation) — RapidStart, a Base App path, elsewhere in `AlRunner/Patches/`.
- **#2876** (`ALTRelationWhereField` cannot detect a swapped `where(... = field(...))` role) — a corpus-fixture design issue, no runner file.
- **#3204** (corpus has no test that a tableextension-contributed relation is enforced) — already satisfied by corpus PR 207; a corpus-side tracker, not this PR's call to close.

No open PR touches any file in this diff, so there is no merge-order constraint. `stma-auto-1` is on #3307 (`SystemRowVersion`); I did not land in its files.

## What I deliberately left out

- **Any fault-injection lever.** Reaching the guard from real AL would need a test-only switch shipped in production code to force a resolution failure. The C# tests drive the guard at exactly the signature Cecil prepends, the prepend is verified installed on the real method, and the normal path is verified unaffected end to end — that is the strongest evidence available without shipping scaffolding.
- **The parser layer** — #3326, above.
- **A `known-gaps` entry.** Nothing fails today (blast radius zero), so there is no gap to declare, and an entry pointing at the issue this PR closes would leave nothing tracked the moment it merged.
- **`CacheVersion`** — justified above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4
