### PR TITLE
fix(cecil): give the zero-parameter no-op its own shim, and refuse an arity mismatch

### DIFF
--- a/AlRunner.Tests/CecilReplaceBodyArityTests.cs
+++ b/AlRunner.Tests/CecilReplaceBodyArityTests.cs
@@ -1,0 +1,171 @@
+// CecilReplaceBodyArityTests — issue #3328.
+//
+// The defect
+// ----------
+// NclCecilRewrite.Runtime.cs no-ops BC's three NavDialog.ALUpdateAsync overloads by
+// replacing each body with a `ReturnValueTaskN` shim. The shim was chosen from the
+// method's DECLARED parameter count, but ReplaceBodyWithHelper forwards declared
+// params PLUS `this`, and `ReturnValueTaskN` takes exactly N arguments. So the
+// zero-declared-parameter overload emitted ONE `ldarg` and then called a TWO-parameter
+// shim — invalid IL. There was no `ReturnValueTask1` for it to have picked.
+//
+// The JIT rejects that body the first time it is reached, as a bare
+//     InvalidProgramException: Common Language Runtime detected an invalid program.
+//        at Microsoft.Dynamics.Nav.Runtime.NavDialog.ALUpdateAsync()
+// naming no method of ours. Any AL that calls `Dialog.Update()` with no arguments hits
+// it; BC's Codeunit550 (VAT Rate Change Tool) does, which is why 202 Tests-VAT tests
+// failed on this one line.
+//
+// Why these are RUNNER-INTERNAL claims, not BC-behaviour claims
+// ------------------------------------------------------------
+// Every assertion here is about IL that OUR Cecil pass emits into BC's runtime engine
+// (Ncl.dll) and about OUR rewrite helper refusing a mismatch. What BC's Dialog.Update()
+// does is not in question and is not asserted. See the PR body for why a corpus test
+// cannot reach this path.
+using System.Linq;
+using System.Reflection;
+using AlRunner.Infrastructure;
+using Microsoft.Dynamics.Nav.Runtime;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Reads the Ncl image this process actually loaded, which BcEngineBootstrap has already
+// Cecil-rewritten in place — so it must share the serial bc-engine collection.
+[Collection(BcEngineCollection.Name)]
+public class CecilReplaceBodyArityTests
+{
+    private readonly BcEngineFixture _engine;
+
+    public CecilReplaceBodyArityTests(BcEngineFixture engine) => _engine = engine;
+
+    private static TypeDefinition NavDialog()
+    {
+        var nclPath = typeof(ITreeObject).Assembly.Location;
+        var asm = AssemblyDefinition.ReadAssembly(nclPath);
+        var t = asm.MainModule.GetType("Microsoft.Dynamics.Nav.Runtime.NavDialog");
+        Assert.NotNull(t);
+        return t!;
+    }
+
+    /// <summary>
+    /// The number of values a body pushes before its `call`, and the callee's parameter
+    /// count. For a rewritten no-op body these must be equal, or the IL is invalid.
+    /// </summary>
+    private static (int pushes, int calleeParams, string calleeName) ShimShape(MethodDefinition m)
+    {
+        int pushes = 0;
+        foreach (var i in m.Body.Instructions)
+        {
+            if (i.OpCode == OpCodes.Ldarg || i.OpCode == OpCodes.Ldarg_S
+                || i.OpCode == OpCodes.Ldarg_0 || i.OpCode == OpCodes.Ldarg_1
+                || i.OpCode == OpCodes.Ldarg_2 || i.OpCode == OpCodes.Ldarg_3)
+            {
+                pushes++;
+                continue;
+            }
+            if (i.OpCode == OpCodes.Box) continue;      // consumes and re-pushes one slot
+            if (i.OpCode == OpCodes.Call && i.Operand is MethodReference mr)
+                return (pushes, mr.Parameters.Count, mr.Name);
+        }
+        return (pushes, -1, "<no call>");
+    }
+
+    // RED before the fix: ALUpdateAsync() pushed 1 and called ReturnValueTask2.
+    // This asserts the concrete arities, so a wrong-but-different body (say, a
+    // 3-parameter shim, or a shim reached with two pushes) still fails it.
+    [SkippableTheory]
+    [InlineData(0, 1)]   // `this` only              → 1-arg shim
+    [InlineData(1, 2)]   // `this` + controlId       → 2-arg shim
+    [InlineData(2, 3)]   // `this` + controlId+value → 3-arg shim
+    public void ALUpdateAsync_ForwardsExactlyAsManyArgsAsTheShimTakes(int declaredParams, int expectedSlots)
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var m = NavDialog().Methods.FirstOrDefault(
+            x => x.Name == "ALUpdateAsync" && x.HasBody && x.HasThis && x.Parameters.Count == declaredParams);
+        Assert.NotNull(m);
+
+        var (pushes, calleeParams, calleeName) = ShimShape(m!);
+        Assert.Equal(expectedSlots, pushes);
+        Assert.Equal(expectedSlots, calleeParams);
+        Assert.Equal($"ReturnValueTask{expectedSlots}", calleeName);
+    }
+
+    // The AL-observable half: the JIT must accept the body. Before the fix this threw
+    // InvalidProgramException on the zero-parameter overload — the exact failure that
+    // took out every Dialog.Update() call. Invoking it here reaches the JIT, which is
+    // the thing that rejected it; an IL-shape assertion alone would not.
+    [SkippableFact]
+    public void ALUpdateAsync_NoArgOverload_IsJitAcceptedAndCompletesAsANoOp()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var t = typeof(NavDialog);
+        var mi = t.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            .FirstOrDefault(x => x.Name == "ALUpdateAsync" && x.GetParameters().Length == 0);
+        Assert.NotNull(mi);
+
+        // GetUninitializedObject: the no-op body reads no field, so an unconstructed
+        // receiver is enough to reach the JIT — and it deliberately avoids BC's real
+        // ctor, which needs the service-tier state a headless run does not have.
+        var inst = System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(t);
+
+        var ex = Record.Exception(() => mi!.Invoke(inst, null));
+        Assert.Null(ex?.InnerException ?? ex);
+
+        // Positive, not just "did not throw": the shim's job is to hand back a completed
+        // ValueTask, which is what makes `Dialog.Update()` a no-op instead of a hang.
+        var vt = (System.Threading.Tasks.ValueTask)mi!.Invoke(inst, null)!;
+        Assert.True(vt.IsCompletedSuccessfully);
+    }
+
+    // The generalising half: the guard that would have made the defect impossible.
+    // ReplaceBodyWithHelper had no arity check at all, while its sibling
+    // PrependStaticCall throws on precisely this mistake — so a wrong shim choice
+    // produced a malformed body that survived the rewrite, survived being cached, and
+    // only failed when the JIT reached it at runtime.
+
+    [Fact]
+    public void ArityGuard_Throws_WhenTheHelperTakesFewerArgsThanTheTargetForwards()
+    {
+        // The #3328 shape exactly: 1 slot forwarded (`this` on a 0-parameter instance
+        // method), a 2-parameter shim.
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            NclCecilRewrite.AssertHelperArityMatches(
+                "Microsoft.Dynamics.Nav.Runtime.NavDialog::ALUpdateAsync()",
+                "BcRuntime.ReturnValueTask2", helperParamCount: 2, argCount: 1));
+
+        // Name both numbers and both methods — a guard whose message says only "arity
+        // mismatch" leaves the next reader doing this arithmetic by hand.
+        Assert.Contains("ALUpdateAsync", ex.Message);
+        Assert.Contains("ReturnValueTask2", ex.Message);
+        Assert.Contains("2", ex.Message);
+        Assert.Contains("1", ex.Message);
+    }
+
+    [Fact]
+    public void ArityGuard_Throws_WhenTheHelperTakesMoreArgsThanTheTargetForwards()
+    {
+        // The mirror direction, which is equally invalid IL and equally silent today.
+        Assert.Throws<InvalidOperationException>(() =>
+            NclCecilRewrite.AssertHelperArityMatches(
+                "T::M(int,int)", "BcRuntime.ReturnValueTask2", helperParamCount: 2, argCount: 3));
+    }
+
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(2, 2)]
+    [InlineData(5, 5)]
+    public void ArityGuard_DoesNotThrow_WhenTheArityMatches(int helperParamCount, int argCount)
+    {
+        // Negative control. Without this pair, a guard that threw unconditionally —
+        // or one stubbed to throw nothing — would satisfy the tests above.
+        NclCecilRewrite.AssertHelperArityMatches(
+            "T::M", "BcRuntime.Shim", helperParamCount, argCount);
+    }
+}

--- a/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.Runtime.cs
@@ -1218,7 +1218,11 @@ public static partial class NclCecilRewrite
                     ReplaceBodyWithHelper(nclMod, m,
                         H(helperShims, m.Parameters.Count switch
                         {
-                            0 => "ReturnValueTask2",   // +1 for `this`; shim arity counts it
+                            // +1 for `this`; shim arity counts it. #3328: the 0 arm used to
+                            // say ReturnValueTask2 — stating the rule and then breaking it —
+                            // which emitted one push into a two-parameter call and made every
+                            // AL `Dialog.Update()` raise InvalidProgramException.
+                            0 => "ReturnValueTask1",
                             1 => "ReturnValueTask2",
                             _ => "ReturnValueTask3",
                         }));

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -505,6 +505,43 @@ public static partial class NclCecilRewrite
     /// CreateTarget helpers that live on CodeunitPatches / RecordPatches / XmlPortPatches.
     /// Same forwarding + per-arg boxing semantics as the name-based overload.
     /// </summary>
+    /// <summary>
+    /// Refuse a helper whose parameter count does not match the number of IL arg slots the
+    /// rewritten body will forward. <see cref="PrependStaticCall"/> has always thrown on
+    /// exactly this mistake; <see cref="ReplaceBodyWithHelper"/> did not, and that asymmetry
+    /// is issue #3328.
+    ///
+    /// Why this has to throw rather than adapt: a mismatch emits a body whose stack does not
+    /// balance its `call`, which is INVALID IL. Cecil writes it out happily, the rewritten
+    /// image is saved to the Ncl Cecil cache happily, and nothing objects until the JIT
+    /// reaches the method — at which point it raises a bare
+    /// `InvalidProgramException: Common Language Runtime detected an invalid program.`
+    /// naming only the BC method, with no frame of ours anywhere in the stack. In #3328 that
+    /// took out every AL `Dialog.Update()` call (202 Tests-VAT failures via BC's Codeunit550)
+    /// and the diagnosis cost a disassembly of the emitted assembly.
+    ///
+    /// Failing here instead moves the error from "runtime, in a stack that names nobody" to
+    /// "rewrite time, naming both methods and both counts" — `loud-failures.md` applied to
+    /// the rewrite layer, where a silently-wrong body is exactly the anti-pattern it names.
+    ///
+    /// Pure and internal so the guard itself is provable in isolation with constructed
+    /// numbers, with no BC artifacts required — the same shape as
+    /// <c>BcEngineReadinessGuard.AssertReadyOnCi</c>.
+    /// </summary>
+    internal static void AssertHelperArityMatches(
+        string targetName, string helperName, int helperParamCount, int argCount)
+    {
+        if (helperParamCount == argCount) return;
+
+        throw new InvalidOperationException(
+            $"[Cecil] replacement helper {helperName} takes {helperParamCount} parameter(s), "
+            + $"but the rewritten body of {targetName} forwards {argCount} IL arg slot(s) "
+            + "(declared parameters + `this` on an instance method). Emitting that body would "
+            + "produce invalid IL that only fails when the JIT reaches the method, as a bare "
+            + "InvalidProgramException naming no method of ours (issue #3328). Pick the helper "
+            + $"whose arity is {argCount}, or add one — do not force the wrong shim to fit.");
+    }
+
     private static void ReplaceBodyWithHelper(
         ModuleDefinition module, MethodDefinition target, MethodInfo helperMi)
     {
@@ -512,6 +549,17 @@ public static partial class NclCecilRewrite
         var helperParams = helperMi.GetParameters();
         // Total IL arg slots: declared params + 1 for `this` on an instance method.
         int argCount = target.Parameters.Count + (target.HasThis ? 1 : 0);
+
+        // #3328: refuse a helper that cannot take what this body is about to push. Every
+        // slot counted above IS forwarded by the loop below, so helper arity and argCount
+        // must be equal or the emitted body is invalid IL. Checked BEFORE anything is
+        // written, so a mismatch never reaches the Cecil cache.
+        AssertHelperArityMatches(
+            target.FullName,
+            $"{helperMi.DeclaringType?.Name}.{helperMi.Name}",
+            helperParams.Length,
+            argCount);
+
         var body = target.Body;
         body.Instructions.Clear();
         body.Variables.Clear();
@@ -543,8 +591,15 @@ public static partial class NclCecilRewrite
             // too — in both cases the helper param index equals the IL-arg slot index i.
             // If it's NOT a value type (object / interface / class), the value-type arg must
             // be boxed to satisfy the reference parameter.
-            var helperParamType = i < helperParams.Length ? helperParams[i].ParameterType : null;
-            bool helperWantsReference = helperParamType != null && !helperParamType.IsValueType;
+            // #3328: this used to read `i < helperParams.Length ? ... : null`, silently
+            // treating an out-of-range helper index as "no boxing needed". That tolerance is
+            // what let a too-short helper list through: the wrong shim produced a body that
+            // was BOTH unbalanced and under-boxed, and neither was reported. The arity guard
+            // above now makes i < helperParams.Length an invariant, so index directly — an
+            // IndexOutOfRangeException here would mean the guard itself is wrong, which is
+            // worth surfacing rather than papering over.
+            var helperParamType = helperParams[i].ParameterType;
+            bool helperWantsReference = !helperParamType.IsValueType;
             if (helperWantsReference)
                 il.Append(il.Create(OpCodes.Box, targetParamType));
         }

--- a/AlRunner/Patches/HelperShims.cs
+++ b/AlRunner/Patches/HelperShims.cs
@@ -80,6 +80,12 @@ public static partial class BcRuntime
         ReturnEmptyNavTextList_2Args(object? a, object? b)
         => Microsoft.Dynamics.Nav.Runtime.NavList<Microsoft.Dynamics.Nav.Runtime.NavText>.Default;
 
+    // #3328: the family starts at 1, not 2. A no-op replacement for a ZERO-parameter
+    // instance method still forwards one IL arg slot — `this` — so it needs a 1-argument
+    // shim. Without this one, NavDialog.ALUpdateAsync() was given ReturnValueTask2 and the
+    // emitted body pushed one value into a two-parameter call: invalid IL, rejected by the
+    // JIT on first execution, which broke every AL `Dialog.Update()` call.
+    [MethodImpl(MethodImplOptions.NoInlining)] public static System.Threading.Tasks.ValueTask ReturnValueTask1(object? a) => default;
     [MethodImpl(MethodImplOptions.NoInlining)] public static System.Threading.Tasks.ValueTask ReturnValueTask2(object? a, object? b) => default;
     [MethodImpl(MethodImplOptions.NoInlining)] public static System.Threading.Tasks.ValueTask ReturnValueTask3(object? a, object? b, object? c) => default;
     [MethodImpl(MethodImplOptions.NoInlining)] public static System.Threading.Tasks.ValueTask ReturnValueTask4(object? a, object? b, object? c, object? d) => default;


### PR DESCRIPTION
Closes #3328

BC ships three `NavDialog.ALUpdateAsync` overloads and the runner no-ops all three by replacing each body with a `ReturnValueTaskN` shim. The shim was picked from the method's **declared** parameter count, but `ReplaceBodyWithHelper` forwards **declared params + `this`**. The comment on the very line stated that rule and the code broke it:

```csharp
0 => "ReturnValueTask2",   // +1 for `this`; shim arity counts it
```

So the zero-declared-parameter overload emitted one `ldarg` into a two-parameter call. That is invalid IL: Cecil writes it out, the rewritten image is cached, and nothing objects until the JIT reaches the method and raises a bare `InvalidProgramException` naming no method of ours. Every AL `Dialog.Update()` with no arguments hit it, BC's `Codeunit550` does, and that took out 202 `Tests-VAT` tests.

There was no `ReturnValueTask1` to pick — the family started at 2 — so this adds one rather than forcing a wrong shim to fit.

## Reproduced independently before changing anything

Disassembling the rewritten `Ncl` from a clean cache, and then invoking each overload reflectively to reach the JIT:

```
--- ALUpdateAsync()          ldarg; call ReturnValueTask2(Object,Object)   <- 1 push, 2 wanted
--- ALUpdateAsync(Int32)     ldarg; ldarg; box; call ReturnValueTask2      <- ok
--- ALUpdateAsync(Int32,NavValue)                     call ReturnValueTask3 <- ok

PROBE 0: InvalidProgramException: Common Language Runtime detected an invalid program.
PROBE 1: OK (no exception)
PROBE 2: OK (no exception)
```

After the fix the zero-arg body reads `ldarg; call ReturnValueTask1(Object)` and all three probes return OK.

## The generalising half: the guard

`ReplaceBodyWithHelper` had **no arity check at all**, while its sibling `PrependStaticCall` throws on precisely this mistake. `ValidateRewrittenAssembly` did not catch it either — it validates metadata tokens and opcode decoding, and this body decoded perfectly with every token resolving. That is why a wrong shim survived the rewrite, survived the cache, and only failed at the JIT.

`AssertHelperArityMatches` now refuses a mismatch at rewrite time, naming both methods and both counts, before anything is written. It is a pure `internal` function so the guard is provable with constructed numbers and no BC artifacts, the same shape as `BcEngineReadinessGuard.AssertReadyOnCi`.

That also makes the short-helper-list tolerance in the boxing lookup unreachable — `i < helperParams.Length ? ... : null` silently treated an out-of-range helper index as "no boxing needed", so the wrong shim produced a body that was **both** unbalanced **and** under-boxed with neither reported. It now indexes directly.

## Answering the three shape questions

1. **Same wrong pattern at another call site?** No. Running the new guard over the entire rewrite pass — every `ReplaceBodyWithHelper` site in the assembly — completes without firing, which confirms by measurement rather than by reading that this was the only arity mismatch.
2. **Sibling functions making the same assumption?** Checked all body-emitting helpers. `PrependStaticCall` already guards; `PrependFieldFindGuard` validates its own shape explicitly; `ReplaceBodyConst` forwards no arguments so has no arity to mismatch. `ReplaceBodyWithHelper` was the only unguarded forwarder.
3. **Two paths writing the same state with different invariants?** Yes, and that was the defect: two rewrite helpers emitting argument-forwarding bodies, one guarding arity and one not. They now share the invariant.

**Open-issue queue scanned** for these files — no other open issue lands in `NclCecilRewrite*.cs` or `HelperShims.cs`, so there was nothing to fold in.

## Cache safety

No `CacheVersion` bump is needed, and this was verified rather than reasoned about. The Ncl Cecil cache key folds in `RunnerFingerprint.ContentHash` — the content hash of `al-runner.dll`, which both changed files compile into — so every existing entry misses. Measured across the fix: key went `390839ab...` to `f41944bc...`, so no cached artifact can replay the old body.

## Corpus

This is a **BC-behaviour claim**, and a corpus test does reach it — tested, not assumed. The corpus already exercises this exact rewrite path in `TestHandlersDialogProgressNoOp.al`, and missed the bug only because both its tests call `Window.Update(1, ...)`. Adding a zero-argument `Window.Update()` test reproduces the production failure on a corpus-shaped AL test against the pre-fix runner:

```
FAIL  Codeunit60218.ProgressDialog_UpdateWithNoArguments_IsNoOp_CodeAfterRuns
      InvalidProgramException: Common Language Runtime detected an invalid program.
      at Microsoft.Dynamics.Nav.Runtime.NavDialog.ALUpdateAsync()
      at Microsoft.Dynamics.Nav.Runtime.NavDialog.ALUpdate()
```

and passes after it. So the proving test for the BC half went upstream rather than into `tests/runner-extras/`.

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/235

The submodule pin is deliberately **not** bumped by this PR. It is identical to `origin/main` at `17b015ef`, so `git diff origin/main..HEAD -- tests/al-language` is empty and the corpus-pin-forward guard reports "unchanged by this pull request".

That took a rebase, and the trap is worth recording because it is silent. This branch forked when the pin was `2cba52d4`; `main` then advanced it to `17b015ef` (the catch-up PR 3317), so the branch was carrying a **backward** pin move that would have un-pinned six already-validated corpus suites. Immediately after `git rebase`, the commit carries the new pin while the submodule **working tree** is still at the old one — `git status` shows `M tests/al-language` — and committing from that state rewrites the regression. `git submodule update` is the step that resolves it.

The runner-side tests in this PR are deliberately runner-internal claims — the IL our Cecil pass emits, and our rewrite helper refusing a mismatch — not a restatement of the BC claim.

## RED to GREEN

`AlRunner.Tests/CecilReplaceBodyArityTests.cs`, 9 tests. RED first, with **zero skips** (a skipped engine test is not a pass):

- `ALUpdateAsync_ForwardsExactlyAsManyArgsAsTheShimTakes` — RED at `Expected: 1, Actual: 2` for the zero-param overload; the two correct overloads passed throughout, so the test discriminates. Asserts concrete arities and the exact shim name, so a wrong-but-different body still fails it.
- `ALUpdateAsync_NoArgOverload_IsJitAcceptedAndCompletesAsANoOp` — RED with the real `InvalidProgramException`. Invokes the method so the JIT actually runs; also asserts the returned `ValueTask.IsCompletedSuccessfully`, so a shim returning something unusable would fail.
- Guard pair, both directions plus a matching-arity negative control — without the control, a guard that threw unconditionally would satisfy the throwing tests.

GREEN: 9/9 passed, 0 skipped.

## Tests run

All Release, engine warm and pre-copied so nothing skipped silently:

- `CecilReplaceBodyArityTests` — 9 passed, 0 skipped
- `~Cecil|~Ncl` — 125 passed, 0 skipped
- `~Patch|~Dialog|~Hook|~Shim|~Binding|~Engine` — 356 passed, 0 skipped
- Pinned AL corpus at `17b015ef` — **2887/2887 pass, 0 fail** (the advanced pin adds the previously-unpinned suites; all green)
- Corpus `master` tip incl. the new tests — 2952/2966, and all four `Codeunit60218` dialog tests pass including the two new ones. The 14 remaining failures are confined to `Codeunit60346` (TestPart) and `Codeunit60350` (TestFilter), corpus-tip suites not yet in the pin and tracked by open issues 3313 and 3316. None is in the area this PR touches.

All figures above are re-measured on the rebased tree, not carried over.

Two measurement corrections worth recording, because both would have been reported as regressions. A throwaway out-of-tree IL probe reported `NullReferenceException` from all three `ALUpdateAsync` overloads after the rebase — including the two that were never broken. That "all three" pattern is the tell that it was the probe, not the arity: the harness resolves `Ncl` and `BcRuntime` into different load contexts. `ALUpdateAsync_NoArgOverload_IsJitAcceptedAndCompletesAsANoOp`, which runs against the properly bootstrapped engine and asserts `IsCompletedSuccessfully`, passes.

And earlier: a comparison appeared to show six new validation-error failures. That was a confound — the pre-fix tree was built at `8d0c76ef`, which already contained the validation-error ledger fix, while this branch was based on the older `c59e79d3`. After rebasing onto current `origin/main` the regression set is empty. The apparent regression was the base commit, not the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4
