### PR TITLE
fix(testpart): resolve a part's page id from its client, and resume a control-field search from the cursor

### DIFF
--- a/AlRunner.Tests/TestPageGoToRecordNotFoundRestoreRefreshTests.cs
+++ b/AlRunner.Tests/TestPageGoToRecordNotFoundRestoreRefreshTests.cs
@@ -32,14 +32,23 @@ public sealed class TestPageGoToRecordNotFoundRestoreRefreshTests
         return File.ReadAllText(path);
     }
 
+    // The scan body FindRowFromTableFieldValues runs. Since #3312 the method itself is a
+    // one-line delegation: FindRowFromControlFieldValue needs the same scan started from the
+    // CURRENT row rather than from the top, so the body moved into a shared
+    // FindRowFromFieldValues that both entry points call with a start policy. The not-found
+    // restore this class pins lives in that shared body, unchanged and still reached by
+    // FindRowFromTableFieldValues -- so this locator follows it rather than asserting the
+    // body sits inline under the public signature, which is a detail #2537 never claimed.
     private static string FindRowFromTableFieldValuesBody(string source)
     {
-        var start = source.IndexOf("public override bool FindRowFromTableFieldValues(int[] fieldNos, object[] values, bool forward)", StringComparison.Ordinal);
-        Assert.True(start >= 0, "could not locate FindRowFromTableFieldValues in MockTestPage.cs");
+        var start = source.IndexOf("private bool FindRowFromFieldValues(int[] fieldNos, object[] values, bool forward, bool startFromCurrentRow)", StringComparison.Ordinal);
+        Assert.True(start >= 0, "could not locate FindRowFromFieldValues in MockTestPage.cs");
 
         // Take a generous window past the signature -- enough to contain the whole method
-        // body without needing a real brace-matcher for a test this narrow.
-        var window = source.Substring(start, Math.Min(4000, source.Length - start));
+        // body without needing a real brace-matcher for a test this narrow. Widened with
+        // #3312, which added the start-policy commentary ahead of the scan; 4000 stopped
+        // short of the not-found restore this class is actually about.
+        var window = source.Substring(start, Math.Min(9000, source.Length - start));
         return window;
     }
 

--- a/AlRunner.Tests/TestPartPageIdAndSearchStartTests.cs
+++ b/AlRunner.Tests/TestPartPageIdAndSearchStartTests.cs
@@ -1,0 +1,240 @@
+// TestPartPageIdAndSearchStartTests — the C# half of issue #3312.
+//
+// The AL-observable claims (TestPart.GoToKey lands on the keyed row; FindFirstField finds the
+// earliest match; FindNextField advances; FindPreviousField goes back) are claims about BC, so
+// they do not belong here. They are measured against a real service tier by corpus codeunit
+// 60346 "Test TestPart", merged as StefanMaron/BusinessCentral.AL.Language.Tests#227 — six
+// tests that fail on the runner before this fix and pass after it.
+//
+// What this file pins is the two runner-side mechanisms that fix depends on, both of which are
+// invisible to the corpus because the corpus can only see the AL answer, not which of two
+// plausible implementations produced it.
+//
+// ── Mechanism 1: a part's page id does not come from pageUnderTestId ────────────────────────
+//
+// BC hardcodes page id 0 for every part. Microsoft.Dynamics.Nav.Ncl.dll, NavTestPart's only
+// constructor (get_members_of_type reports exactly one):
+//
+//     internal NavTestPart(ITreeObject parent, ITestPart testPart)
+//         : base(parent, new ApplicationObjectId(ObjectType.Page, 0), testPart)
+//
+// so pageUnderTestId.ObjectNumber is 0 by construction, never because anything is unknown.
+// BC's own base constructor agrees it is an expected value rather than an error
+// (`if (pageUnderTestId.ObjectNumber != 0) metaPage = LoadMetadata();`), and NavTestPart then
+// resolves its metadata from the OTHER field — NavTestPart.LoadMetadata() is
+// `Tree.Session.MetadataProvider.GetPageDefinition(testPart.PageId)`. So BC's own answer to
+// "which page is this part" is ITestPage.PageId off the client object.
+//
+// Not version-specific: the NavTestPart constructor decompiles to the byte-identical hash
+// 6c0201fa8b48b1cd7880446ce4605fefc1e1d58449d795516d3f9ed2fa5415fd on both BC 27.0 and 28.1,
+// and compare_symbols across the type reports no added, removed or changed members between
+// them.
+//
+// ── Mechanism 2: FindRowFromControlFieldValue resumes, FindRowFromTableFieldValues restarts ─
+//
+// The two ITestPage search entry points are NOT interchangeable, because their BC callers
+// position the cursor differently before calling them:
+//
+//   InternalFindRowFromControlFieldValue (FindFirstField/FindNextField/FindPreviousField)
+//     switch (initialMove) {
+//       case InitialMove.First:    TestPage.MoveFirst(); break;
+//       case InitialMove.Next:     if (!TestPage.MoveNext())     return false; break;
+//       case InitialMove.Previous: if (!TestPage.MovePrevious()) return false; break;
+//     }
+//     return TestPage.FindRowFromControlFieldValue(fieldNo, value, initialMove != InitialMove.Previous);
+//
+//   InternalFindRowFromTableFieldValues (GoToKey/GoToRecord)
+//     TestPage.MoveFirst();
+//     bool num = TestPage.FindRowFromTableFieldValues(fieldNos, values, forward);
+//
+// The second unconditionally seeks to the first row, so for THAT caller "scan the whole
+// rowset" and "resume from the cursor" give the same answer — which is why the runner's
+// always-restart scan was correct for GoToRecord (#2537, tests/runner-extras
+// testpage-gotorecord) and stayed that way. The first deliberately positions elsewhere, and
+// re-seeking discards it: FindNextField then re-finds the row FindFirstField already returned
+// and never advances, FindPreviousField likewise never goes back.
+//
+// Verified against Microsoft.Dynamics.Nav.Ncl.dll via the bc-decompiler tools.
+using System;
+using System.IO;
+using System.Reflection;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPartPageIdAndSearchStartTests
+{
+    private const int PartPageId = 60342;
+
+    // ── Mechanism 1 ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The client object a part is built over must name the part's OWN page. This is the
+    /// value BC's NavTestPart.LoadMetadata reads (testPart.PageId), and — since #3312 — the
+    /// value CodeunitPatches.GetPageIdFromTestPage falls back to when pageUnderTestId reads 0.
+    /// A part answering 0 here is what made GetMetaTable refuse "TestPage 0".
+    /// </summary>
+    [Fact]
+    public void LiveNavTestPart_ReportsThePartPagesOwnId_NotZero()
+    {
+        var part = Part(PartPageId);
+
+        Assert.Equal(PartPageId, part.PageId);
+        Assert.NotEqual(0, part.PageId);
+    }
+
+    /// <summary>
+    /// PageId must be a real ITestPage member, not a runner-only convenience: the fallback
+    /// reads it through the interface off a field typed as ITestPage, so a rename or a
+    /// runner-local-only declaration would silently stop resolving.
+    /// </summary>
+    [Fact]
+    public void PageId_IsDeclaredOnBcsOwnITestPageInterface()
+    {
+        var declared = typeof(Microsoft.Dynamics.Nav.Types.ITestPage)
+            .GetProperty("PageId", BindingFlags.Public | BindingFlags.Instance);
+
+        Assert.NotNull(declared);
+        Assert.Equal(typeof(int), declared!.PropertyType);
+        // And the runner's part really is an ITestPage, so the fallback's type test matches.
+        Assert.IsAssignableFrom<Microsoft.Dynamics.Nav.Types.ITestPage>(Part(PartPageId));
+    }
+
+    /// <summary>
+    /// The fallback is narrow ON PURPOSE. A part whose client cannot name its page still
+    /// yields 0, which leaves GetMetaTable's refusal intact rather than substituting a guess —
+    /// the #2341 hole that refusal exists to plug. The mock client is exactly that case.
+    /// </summary>
+    [Fact]
+    public void AClientThatCannotNameItsPage_StillAnswersZero_SoTheRefusalSurvives()
+    {
+        Assert.Equal(0, new MockITestPart().PageId);
+    }
+
+    /// <summary>
+    /// The two readers of the page id in CodeunitPatches — GetMetaTable (PrimaryKeyFields,
+    /// which GoToKey and every Find*Field go through) and ALGoToRecord — must share ONE
+    /// resolver. They were separate copies of the same reflection, so fixing either alone
+    /// would have left the other refusing on a part.
+    /// </summary>
+    [Fact]
+    public void BothPageIdReaders_GoThroughTheSharedResolver()
+    {
+        var source = SourceOf("CodeunitPatches.cs");
+
+        // GetMetaTable no longer reads the field itself.
+        var getMetaTable = Slice(source, "public static NCLMetaTable NavTestPageBase_GetMetaTable(object self)", 900);
+        Assert.Contains("GetPageIdFromTestPage(self)", getMetaTable, StringComparison.Ordinal);
+        Assert.DoesNotContain("FindInstanceField(self.GetType(), \"pageUnderTestId\")", getMetaTable,
+            StringComparison.Ordinal);
+
+        // ALGoToRecord already did, and still does.
+        var alGoToRecord = Slice(source, "public static bool NavTestPageBase_ALGoToRecord(", 900);
+        Assert.Contains("GetPageIdFromTestPage(self)", alGoToRecord, StringComparison.Ordinal);
+
+        // And exactly one place reads the raw field: the resolver.
+        Assert.Equal(1, Occurrences(source, "FindInstanceField(self.GetType(), \"pageUnderTestId\")"));
+    }
+
+    /// <summary>
+    /// The resolver's fallback must fire ONLY on 0. A top-level page has a real
+    /// pageUnderTestId and must keep answering it — reading the client unconditionally would
+    /// make a directly-opened TestPage's id depend on whichever client it got, including the
+    /// navigation mock's 0.
+    /// </summary>
+    [Fact]
+    public void TheFallbackIsGuardedOnZero_SoATopLevelPageIsUnaffected()
+    {
+        var resolver = Slice(SourceOf("CodeunitPatches.cs"),
+            "private static int GetPageIdFromTestPage(object self)", 900);
+
+        Assert.Contains("if (pageId != 0) return pageId;", resolver, StringComparison.Ordinal);
+        Assert.Contains("ITestPage client", resolver, StringComparison.Ordinal);
+        Assert.Contains("client.PageId", resolver, StringComparison.Ordinal);
+    }
+
+    // ── Mechanism 2 ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The two entry points must reach the shared scan with OPPOSITE start policies. Asserted
+    /// on the delegations rather than on a live search, because the scan needs a NavRecord and
+    /// so a loaded BC session — which is what corpus codeunit 60346 measures. What is provable
+    /// here is that the distinction exists and points the right way round; collapsing it in
+    /// either direction is the defect.
+    /// </summary>
+    [Fact]
+    public void ControlFieldSearchResumesFromTheCursor_TableFieldSearchRestarts()
+    {
+        var source = SourceOf("MockTestPage.cs");
+
+        var byControl = Slice(source,
+            "public override bool FindRowFromControlFieldValue(int controlId, object value, bool forward)", 300);
+        Assert.Contains("startFromCurrentRow: true", byControl, StringComparison.Ordinal);
+
+        var byTableField = Slice(source,
+            "public override bool FindRowFromTableFieldValues(int[] fieldNos, object[] values, bool forward)", 300);
+        Assert.Contains("startFromCurrentRow: false", byTableField, StringComparison.Ordinal);
+
+        // FindRowFromControlFieldValue must NOT simply forward to the table-field entry point,
+        // which is the pre-#3312 shape and the one that threw the cursor away.
+        Assert.DoesNotContain("=> FindRowFromTableFieldValues(new[] { ControlIdToTableFieldNo(controlId) }",
+            byControl, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The resume branch must be conditional on the record actually standing on a row.
+    /// An unpositioned record has no current row, and honouring "start here" then would scan
+    /// nothing at all — so FindFirstField, whose BC caller reaches this after MoveFirst(),
+    /// would answer false for a value that is on the page.
+    /// </summary>
+    [Fact]
+    public void TheResumeBranchRequiresAnActualCurrentRow()
+    {
+        var scan = Slice(SourceOf("MockTestPage.cs"),
+            "private bool FindRowFromFieldValues(int[] fieldNos, object[] values, bool forward, bool startFromCurrentRow)",
+            7000);
+
+        Assert.Contains("startFromCurrentRow && hasCurrent", scan, StringComparison.Ordinal);
+        // The restart arm is still the fallback for both "not resuming" and "nowhere to
+        // resume from".
+        Assert.Contains("forward ? MoveFirst() : MoveLast()", scan, StringComparison.Ordinal);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────────────────
+
+    private static LiveNavTestPart Part(int pageId)
+        => new(
+            record: null,
+            controlIdToFieldNo: new Dictionary<int, int>(),
+            creatable: false,
+            page: null,
+            owner: new object(),
+            pageId: pageId,
+            parentRecord: null,
+            links: []);
+
+    private static string SourceOf(string fileName)
+    {
+        var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+        var path = Path.Combine(repoRoot, "AlRunner", "Patches", fileName);
+        Assert.True(File.Exists(path), $"expected to find {path}");
+        return File.ReadAllText(path);
+    }
+
+    private static string Slice(string source, string anchor, int length)
+    {
+        var start = source.IndexOf(anchor, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"could not locate '{anchor}'");
+        return source.Substring(start, Math.Min(length, source.Length - start));
+    }
+
+    private static int Occurrences(string source, string needle)
+    {
+        var count = 0;
+        for (var i = source.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = source.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+            count++;
+        return count;
+    }
+}

--- a/AlRunner/Patches/CodeunitPatches.cs
+++ b/AlRunner/Patches/CodeunitPatches.cs
@@ -583,11 +583,7 @@ public static partial class BcRuntime
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static NCLMetaTable NavTestPageBase_GetMetaTable(object self)
     {
-        var pageIdField = FindInstanceField(self.GetType(), "pageUnderTestId");
-        var objId = pageIdField?.GetValue(self);
-        var idProp = objId?.GetType().GetProperty("ObjectNumber",
-            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-        var pageId = idProp?.GetValue(objId) is int value ? value : 0;
+        var pageId = GetPageIdFromTestPage(self);
 
         // BC's own body returns null when the page's SourceObject.SourceTable is 0 — a page
         // without a source table is legal AL, and PrimaryKeyFields then reads as empty.
@@ -667,13 +663,53 @@ public static partial class BcRuntime
             live.FlushPendingNewRow();
     }
 
+    /// <summary>
+    /// The page id a NavTestPageBase is standing on — the one thing every reader below needs,
+    /// and the one thing <c>pageUnderTestId</c> alone cannot answer for a PART.
+    ///
+    /// <para>BC hardcodes page id 0 for every part. <c>NavTestPart</c> has exactly one
+    /// constructor and it writes the literal:</para>
+    /// <code>
+    /// internal NavTestPart(ITreeObject parent, ITestPart testPart)
+    ///     : base(parent, new ApplicationObjectId(ObjectType.Page, 0), testPart)
+    /// </code>
+    /// <para>so a part's <c>pageUnderTestId.ObjectNumber</c> is 0 by construction, never
+    /// because anything is unknown. BC's own base constructor treats it as an expected value
+    /// rather than an error — <c>if (pageUnderTestId.ObjectNumber != 0) metaPage =
+    /// LoadMetadata();</c> — and <c>NavTestPart</c> then resolves its metadata from the
+    /// OTHER field: <c>NavTestPart.LoadMetadata()</c> is
+    /// <c>Tree.Session.MetadataProvider.GetPageDefinition(testPart.PageId)</c>. So BC's own
+    /// answer for "which page is this part" is <c>ITestPage.PageId</c> off the client object,
+    /// and that is exactly what this reads.</para>
+    ///
+    /// <para>Verified against Microsoft.Dynamics.Nav.Ncl.dll. Not version-specific: the
+    /// <c>NavTestPart</c> constructor decompiles to the byte-identical hash
+    /// <c>6c0201fa…5415fd</c> on 27.0 and 28.1, and <c>compare_symbols</c> across the type
+    /// reports no added, removed or changed members between them. <c>ITestPage.PageId</c> is a
+    /// real interface member of <c>Microsoft.Dynamics.Nav.Types.ITestPage</c> (inherited by
+    /// <c>ITestPart</c>), which the runner's <c>LiveNavTestPage</c> already implements with the
+    /// part page's real id — <c>MockTestPage.GetPart</c> passes <c>partPageId</c> into every
+    /// <c>LiveNavTestPart</c> it builds. Issue #3312.</para>
+    ///
+    /// <para>The fallback is deliberately narrow: it fires ONLY when the id read from
+    /// <c>pageUnderTestId</c> is 0, so a top-level page keeps answering exactly what it
+    /// answered before, and a part whose client cannot name its page still yields 0 — which
+    /// leaves the caller's refusal intact rather than substituting a guess.</para>
+    /// </summary>
     private static int GetPageIdFromTestPage(object self)
     {
         var pageIdField = FindInstanceField(self.GetType(), "pageUnderTestId");
         var objId = pageIdField?.GetValue(self);
         var idProp = objId?.GetType().GetProperty("ObjectNumber",
             BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-        return idProp?.GetValue(objId) is int value ? value : 0;
+        var pageId = idProp?.GetValue(objId) is int value ? value : 0;
+        if (pageId != 0) return pageId;
+
+        // A part: ask the client object, which is where BC asks too.
+        var testPageField = FindInstanceField(self.GetType(), "testPage");
+        if (testPageField?.GetValue(self) is Microsoft.Dynamics.Nav.Types.ITestPage client)
+            return client.PageId;
+        return 0;
     }
 
     private static FieldInfo? FindInstanceField(Type type, string name)

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -2125,11 +2125,43 @@ internal class LiveNavTestPage : MockITestPage
     public override object[] GetTableFieldValues(int[] fieldIds)
         => fieldIds.Select(fieldNo => ReadClientObject(fieldNo) ?? string.Empty).ToArray();
 
-    // The only ITestPage entry point that genuinely receives a CONTROL id.
+    /// <summary>
+    /// The only ITestPage entry point that genuinely receives a CONTROL id — and, unlike
+    /// <see cref="FindRowFromTableFieldValues"/>, the one whose caller has ALREADY positioned
+    /// the cursor where the search must begin. That is why it does not simply forward.
+    ///
+    /// <para>BC's <c>NavTestPageBase.InternalFindRowFromControlFieldValue</c> drives all three
+    /// of FindFirstField/FindNextField/FindPreviousField, and it makes the initial move
+    /// itself before calling in here:</para>
+    /// <code>
+    /// switch (initialMove) {
+    ///   case InitialMove.First:    TestPage.MoveFirst(); break;
+    ///   case InitialMove.Next:     if (!TestPage.MoveNext())     return false; break;
+    ///   case InitialMove.Previous: if (!TestPage.MovePrevious()) return false; break;
+    /// }
+    /// return TestPage.FindRowFromControlFieldValue(fieldNo, value, initialMove != InitialMove.Previous);
+    /// </code>
+    /// <para>So the position on entry IS the argument: for FindNextField it is one row past
+    /// the last match, for FindPreviousField one row before it. Re-seeking to the first (or
+    /// last) row here discards it, and both members then answer the row FindFirstField
+    /// already returned — FindNextField never advances and FindPreviousField never goes back
+    /// (issue #3312).</para>
+    ///
+    /// <para>The sibling path is genuinely different and stays as it was:
+    /// <c>InternalFindRowFromTableFieldValues</c> — which is what GoToKey and GoToRecord
+    /// reach — calls <c>TestPage.MoveFirst()</c> unconditionally before its own
+    /// <c>FindRowFromTableFieldValues</c>, so for THAT caller "scan the whole rowset" and
+    /// "resume from the cursor" are the same answer. Verified against
+    /// Microsoft.Dynamics.Nav.Ncl.dll.</para>
+    /// </summary>
     public override bool FindRowFromControlFieldValue(int controlId, object value, bool forward)
-        => FindRowFromTableFieldValues(new[] { ControlIdToTableFieldNo(controlId) }, new[] { value }, forward);
+        => FindRowFromFieldValues(new[] { ControlIdToTableFieldNo(controlId) }, new[] { value }, forward,
+            startFromCurrentRow: true);
 
     public override bool FindRowFromTableFieldValues(int[] fieldNos, object[] values, bool forward)
+        => FindRowFromFieldValues(fieldNos, values, forward, startFromCurrentRow: false);
+
+    private bool FindRowFromFieldValues(int[] fieldNos, object[] values, bool forward, bool startFromCurrentRow)
     {
         if (fieldNos.Length != values.Length) return false;
 
@@ -2160,12 +2192,22 @@ internal class LiveNavTestPage : MockITestPage
             }
         }
 
-        // Scan the WHOLE rowset, always starting from the first (or last, when searching
-        // backward) row — never from wherever the page happens to be positioned. `forward`
-        // is a direction, not "resume from the cursor": BC's client locates the requested
-        // row anywhere in the rowset. Starting at the current row silently failed to find
-        // any row BEHIND the cursor, so navigating C -> A returned false even though A is
-        // on the page (tests/runner-extras/testpage-gotorecord GoToRecord_MovesBetweenRows).
+        // Where the scan STARTS is the caller's decision, not the direction's.
+        //
+        // startFromCurrentRow: false (FindRowFromTableFieldValues — GoToKey, GoToRecord) scans
+        // the WHOLE rowset from the first (or last, when searching backward) row, never from
+        // wherever the page happens to be positioned. `forward` is then a direction, not
+        // "resume from the cursor": BC's client locates the requested row anywhere in the
+        // rowset. Starting at the current row silently failed to find any row BEHIND the
+        // cursor, so navigating C -> A returned false even though A is on the page
+        // (tests/runner-extras/testpage-gotorecord GoToRecord_MovesBetweenRows). BC agrees
+        // for this caller by construction: InternalFindRowFromTableFieldValues calls
+        // TestPage.MoveFirst() itself before reaching here.
+        //
+        // startFromCurrentRow: true (FindRowFromControlFieldValue — FindFirstField and
+        // friends) resumes from the cursor, because BC's InternalFindRowFromControlFieldValue
+        // already made the MoveNext()/MovePrevious() that says where to begin. See that
+        // method's own doc comment above for the decompiled shape (issue #3312).
         //
         // Issue #2677: the scan below runs Loaded(true) — and so this page's own
         // OnAfterGetRecord — for every intermediate row it passes through before landing on
@@ -2176,7 +2218,14 @@ internal class LiveNavTestPage : MockITestPage
         _suppressPartRefreshDuringScan = true;
         try
         {
-            var hasRow = forward ? MoveFirst() : MoveLast();
+            // startFromCurrentRow: the caller positioned the cursor and that position is the
+            // search's starting point (see FindRowFromControlFieldValue). "Current row" means
+            // the row the record is actually standing on — an unpositioned record has no such
+            // row, so it falls back to the end the direction starts from, which is also what
+            // BC's InitialMove.First arm produces after its MoveFirst().
+            var hasRow = startFromCurrentRow && hasCurrent
+                ? true
+                : forward ? MoveFirst() : MoveLast();
 
             while (hasRow)
             {


### PR DESCRIPTION
Closes #3312

Filed and implemented by agent `stma-auto-1` (automated implementation agent).

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/227

## What was wrong

Two defects stacked on the same code path. The second was invisible until the first was fixed.

### 1. "TestPage 0" is BC's marker for a part, not a missing page

`NavTestPageBase_GetMetaTable` read `pageUnderTestId.ObjectNumber`, got `0`, and refused:

```
InvalidOperationException: TestPage 0 is declared neither in this bundle's AL source nor in
any loaded dependency .app — cannot resolve its SourceTable, and guessing would silently
yield an empty primary key.
```

That `0` is not missing information. **BC hardcodes it for every part.** Verified against
`Microsoft.Dynamics.Nav.Ncl.dll` with the bc-decompiler tools rather than taken from the issue:

- `get_members_of_type(NavTestPart, kind: Constructor)` returns **exactly one** constructor, and
  it writes the literal: `base(parent, new ApplicationObjectId(ObjectType.Page, 0), testPart)`.
- BC's base constructor treats `0` as an expected value, not an error:
  `if (pageUnderTestId.ObjectNumber != 0) { metaPage = LoadMetadata(); }`.
- BC's own answer for "which page is this part" comes from the **other** field —
  `NavTestPart.LoadMetadata()` is `Tree.Session.MetadataProvider.GetPageDefinition(testPart.PageId)`.

So the fix reads what BC reads. `GetPageIdFromTestPage` falls back to `ITestPage.PageId` off the
client object when `pageUnderTestId` reads `0`, and `GetMetaTable` now routes through that shared
resolver instead of keeping its own copy of the reflection.

`ITestPage.PageId` is a real interface member of `Microsoft.Dynamics.Nav.Types.ITestPage`
(inherited by `ITestPart`), and the runner's `LiveNavTestPage` already implements it with the
part page's real id — `MockTestPage.GetPart` passes `partPageId` into every `LiveNavTestPart` it
builds. The value was already there; this reader was not consulting it.

**Not version-specific.** The `NavTestPart` constructor decompiles to the byte-identical hash
`6c0201fa…5415fd` on 27.0 and 28.1, and `compare_symbols` across the type reports no added,
removed or changed members between them.

### 2. A control-field search threw away the position its caller had just set

With the refusal gone, four of the six tests passed and **two still failed** — on a different
defect the refusal had been masking:

```
FindNextField() must advance past the row FindFirstField landed on.  Expected:<30>  Actual:<20>
FindPreviousField() must land on the earlier of the two matching rows. Expected:<20> Actual:<30>
```

`FindRowFromControlFieldValue` forwarded to `FindRowFromTableFieldValues`, whose scan always
re-seeks to the first (or last) row. The two ITestPage entry points are **not** interchangeable,
because their BC callers position the cursor differently before calling them:

```csharp
// InternalFindRowFromControlFieldValue — FindFirstField/FindNextField/FindPreviousField
switch (initialMove) {
  case InitialMove.First:    TestPage.MoveFirst(); break;
  case InitialMove.Next:     if (!TestPage.MoveNext())     return false; break;
  case InitialMove.Previous: if (!TestPage.MovePrevious()) return false; break;
}
return TestPage.FindRowFromControlFieldValue(fieldNo, value, initialMove != InitialMove.Previous);

// InternalFindRowFromTableFieldValues — GoToKey/GoToRecord
TestPage.MoveFirst();
bool num = TestPage.FindRowFromTableFieldValues(fieldNos, values, forward);
```

The second seeks to the first row unconditionally, so for **that** caller "scan the whole rowset"
and "resume from the cursor" are the same answer — which is why the always-restart scan was
correct for GoToRecord (#2537) and stays exactly as it was. The first deliberately positions
elsewhere, and re-seeking discarded it: `FindNextField` re-found the row `FindFirstField` had
already returned.

The scan body is now shared as `FindRowFromFieldValues(..., bool startFromCurrentRow)`, with each
entry point passing its own policy. The resume arm is guarded on the record actually standing on
a row, so an unpositioned record still falls back to the direction's starting end.

## Fixing the shape, not the reported line

**Does the same wrong pattern appear at another call site?** Yes — and the issue named it.
`pageUnderTestId` had **two** readers doing identical reflection: `GetMetaTable` and
`GetPageIdFromTestPage` (feeding `NavTestPageBase_ALGoToRecord`). Fixing either alone would have
left the other refusing on a part. They now share one resolver, and a test asserts exactly one
place in the file reads the raw field.

**Does a sibling function make the same assumption?** Checked all of them, and two that look like
they might do not:

- `CreateTestPageClient` reads `ObjectNumber` off an `objId` **argument**, at the top-level
  `NavTestPage` construction site, before any object exists. No part reaches it.
- `RunnerTestClientSession.PageIdOf` reads a **`NavForm`'s** own `ObjectId`, which is a real page
  id — a part's `NavForm` names the part page. Unaffected.

`NavTestPageBase_FlushPendingNewRow`, the third `NavTestPageBase_*` patch, reads the `testPage`
field directly and never touches a page id.

**If two code paths write the same state, do they maintain the same invariant?** This is where
defect 2 came from. The two search entry points were sharing one implementation while their BC
callers maintain *different* invariants about the cursor. They now differ explicitly, and the
distinction is asserted in both directions rather than left implicit.

## Open-issue queue scan — nothing folded, and why

Scanned the open queue for the symbols and files this lands in (`GetMetaTable`,
`pageUnderTestId`, `FindRowFromControlFieldValue`, `CodeunitPatches.cs`, `MockTestPage.cs`).
Nothing folds:

- **#3313** — the other two failures in this same corpus codeunit, worked in parallel by
  `stma-auto-3`. Its fixes land in `MockTestPage.GetPart` (control-tree visibility gating) and
  `GetField` (control-id vs table-field-no rejection), around lines 202-360 of `MockTestPage.cs`.
  Mine are at ~2130-2230 plus `CodeunitPatches.cs`. **Same file, different regions** — git should
  merge cleanly, but flagging it since we overlap in one file.
- **#3316** (`TestPage.Filter` CurrentKey/SetCurrentKey/Ascending) is the nearest neighbour by
  subject. It lands in the filter/key surface, not the row-search path, and needs materially
  different reasoning to review.
- **#2361, #2362** are TestPage issues in the field-value and AssistEdit paths — different code.

## RED → GREEN

Measured against corpus `0bbe376` (PR #227, merged), runner build from this branch, BC 28.1,
Linux, with `--package-cache "$HOME/.al-runner/platform-apps"`.

**Before** — 28 tests, 8 fail. Six are this issue, all with the same `TestPage 0` refusal at
`CodeunitPatches.cs:605`:

```
FAIL TestPart_GoToKey_PositionsOnTheKeyedRow
FAIL TestPart_GoToKey_ReturnsFalseForAKeyThatDoesNotExist
FAIL TestPart_FindFirstField_LandsOnTheEarliestMatchingRow
FAIL TestPart_FindFirstField_AnswersFalseForAValueNoRowCarries
FAIL TestPart_FindNextField_AdvancesToTheNextMatchingRow
FAIL TestPart_FindPreviousField_MovesBackToTheEarlierMatchingRow
```

**After** — 28 tests, 26 pass. All six green. The two that remain are #3313's
(`TestPart_InvisiblePart_IsNotInTheControlTreeAtAll`, `TestPart_GetField_TakesAControlIdNotATableFieldNo`),
untouched by this PR and owned by `stma-auto-3`.

**No regressions**, both suites run to completion on this branch:

| suite | result |
|---|---|
| full corpus at the current pin (`17b015ef`), `--strict --count-baseline` | **2887/2887 pass**, 0 fail |
| `tests/runner-extras` | **351/351 pass**, 0 fail |
| `AlRunner.Tests` filtered to `TestPage`/`TestPart` | **277 pass**, 15 skipped (pre-existing: `SkippableFact` on the in-process BC engine), 0 fail |

## The pin is deliberately not bumped

`tests/al-language` stays at `17b015ef`. #3313 has to land before the pin can move past
`0bbe376`, and sequencing that bump belongs to the coordinator. `git diff origin/main...HEAD`
carries no submodule entry.

## Runner-side mechanism test

`AlRunner.Tests/TestPartPageIdAndSearchStartTests.cs` (7 tests) pins the two mechanisms the
corpus cannot see — the corpus observes the AL answer, not which of two plausible
implementations produced it. Verified RED: 4 of the 7 fail against pre-fix
`CodeunitPatches.cs`/`MockTestPage.cs`. The other 3 assert preconditions the fix rests on
(`ITestPage.PageId` is a real BC interface member; `LiveNavTestPart` reports its own page id;
the mock client still answers 0 so the #2341 refusal survives) and are correctly green in both
states.

`AlRunner.Tests/TestPageGoToRecordNotFoundRestoreRefreshTests.cs` needed two locator updates and
**caught this itself** — it went red when the scan body moved, which is exactly what it exists
for. Its #2537 assertions are unchanged and still pass; only the anchor it reads the body from
(now `FindRowFromFieldValues`) and its window size moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4
