### PR TITLE
fix(testpage): refuse a part BC does not render, and an id outside GetField's id space

### DIFF
--- a/AlRunner.Tests/TestPageControlTreeReachabilityTests.cs
+++ b/AlRunner.Tests/TestPageControlTreeReachabilityTests.cs
@@ -16,9 +16,8 @@
 //     not found on the page." The corpus test asserts alongside it that 3 really IS a valid
 //     table field number on that part's source table, so what it pins is the ID SPACE.
 //
-// What is provable without a loaded BC page object is the mechanism underneath both, and that
-// is what these tests pin: the runner hands BC's own precompiled GetField/GetPart a NULL, which
-// is the input those methods are written to refuse, instead of either answering a handle or
+// The mechanism underneath both is that the runner hands BC's own precompiled GetField/GetPart
+// a NULL — the input those methods are written to refuse — instead of answering a handle or
 // raising a runner-invented RunnerOutOfScopeException. Ncl.dll 28.1:
 //
 //   NavTestPageBase.GetField(int, bool):  ... TestClientProxy<ITestField>.Proxy(testPage.GetField(id));
@@ -26,9 +25,20 @@
 //   NavTestPageBase.GetPart(int, bool):   ... TestClientProxy<ITestPart>.Proxy(testPage.GetPart(id));
 //                                         if (testPart == null) throw NavTestPartNotFoundException.Create(...)
 //
-// Each refusal row below is paired with a row that must still be ACCEPTED or must still refuse
-// as a runner gap. That pairing is the point: an implementation that refused everything — the
-// cheapest way to make the corpus's two negative assertions pass — fails the paired rows.
+// WHAT THESE TESTS CAN AND CANNOT REACH, stated plainly because it decides what a green run
+// here means. Both new branches need a live RunnerPageInstance over a NavForm whose
+// MetadataHelper carries real control and InfopartPageDefinition metadata, and only the
+// page-build pipeline produces one. So the end-to-end claim is proved by the corpus run, not
+// here, and the rows below split into two kinds:
+//
+//   * OwnDeclaredVisible — the actual defect, extracted so it is reachable. It FAILS against
+//     the pre-fix code, which read a control's Visible and nothing else.
+//
+//   * The gap-refusal and accept rows — regression rows around the change rather than proof of
+//     it. They pass before and after by design: what they pin is that the fix did NOT widen
+//     into refusing things it should not, which is the cheapest wrong way to make the corpus's
+//     two negative assertions pass. A row that passes both before and after is stated as such
+//     rather than presented as evidence.
 
 using AlRunner.Infrastructure;
 using AlRunner.Patches;
@@ -72,6 +82,52 @@ public sealed class TestPageControlTreeReachabilityTests
     [InlineData("NOT ShowIt")]
     public void AnythingElse_DoesNotEliminate(string? raw)
         => Assert.False(RunnerPageInstance.IsLiteralFalse(raw));
+
+    // ── The defect itself: where the declared Visible is looked up ─────────────────────
+
+    // THE ROW THAT FAILS WITHOUT THE FIX. A subpage part is not a ControlDefinition — the AL
+    // compiler emits it as an InfopartPageDefinition in a different metadata collection — so
+    // reading only the control collection answered null for a part declaring Visible = false,
+    // null is "declared nothing", and "declared nothing" is the AL default of TRUE. That is
+    // how a part BC never renders stayed reachable.
+    //
+    // Pre-fix this expression was `ControlDefinition(id)?.Visible` alone, so this row returned
+    // null and the assertion below failed.
+    [Fact]
+    public void APartsDeclaredVisible_IsFound_WhenTheControlCollectionHasNothing()
+        => Assert.Equal("false", RunnerPageInstance.OwnDeclaredVisible(controlVisible: null, partVisible: "false"));
+
+    // The other direction, and the row that stops the fix from being "always read the part
+    // collection": a control that DOES declare Visible keeps its own answer. If the fallback
+    // had been written the other way round, every field control on a page hosting a part would
+    // read the part's property instead of its own.
+    [Fact]
+    public void AControlsDeclaredVisible_Wins_OverThePartCollection()
+        => Assert.Equal("true", RunnerPageInstance.OwnDeclaredVisible(controlVisible: "true", partVisible: "false"));
+
+    // Neither collection declares anything — the ordinary case for the overwhelming majority
+    // of controls, which say nothing about Visible at all. It must stay null so IsLiteralFalse
+    // answers false and the element is NOT eliminated; an implementation that defaulted to
+    // "false" here would make every undecorated control unreachable.
+    [Fact]
+    public void NeitherCollectionDeclaringVisible_StaysUndeclared()
+        => Assert.Null(RunnerPageInstance.OwnDeclaredVisible(controlVisible: null, partVisible: null));
+
+    // And the composition that is the actual decision: a part declaring the literal false is
+    // eliminated, while a part declaring an expression that merely evaluates false right now
+    // is not. The second row is the one that keeps the fix narrow — without it, "hide the part
+    // when Visible is false" would also delete every conditionally-shown part from the tree.
+    [Theory]
+    [InlineData("false", true)]
+    [InlineData("0", true)]
+    [InlineData("true", false)]
+    [InlineData("ShowTheHiddenPart", false)]
+    [InlineData(null, false)]
+    public void APartIsEliminated_OnlyForTheLiteralFalse(string? partVisible, bool eliminated)
+        => Assert.Equal(
+            eliminated,
+            RunnerPageInstance.IsLiteralFalse(
+                RunnerPageInstance.OwnDeclaredVisible(controlVisible: null, partVisible: partVisible)));
 
     // ── GetField: BC's own refusal vs. the runner's gap refusal ────────────────────────
 

--- a/AlRunner.Tests/TestPageControlTreeReachabilityTests.cs
+++ b/AlRunner.Tests/TestPageControlTreeReachabilityTests.cs
@@ -1,0 +1,176 @@
+// TestPageControlTreeReachabilityTests — the C# half of issue #3313: what is, and is not, in a
+// test page's control tree.
+//
+// The AL-observable claims are claims about BC, so they are NOT made here. Both are measured on
+// a real service tier by corpus codeunit 60346, merged as
+// StefanMaron/BusinessCentral.AL.Language.Tests PR #227, green on all 8 cloud legs:
+//
+//   * TestPart_InvisiblePart_IsNotInTheControlTreeAtAll — reaching a part declared
+//     Visible = false errors "The part with ID = N was not found on the page." rather than
+//     yielding a handle that reports false. The suite's FIRST revision asserted the pair
+//     (a visible part answering true, an invisible one answering false on one open host) and
+//     every leg falsified it identically; that falsification is the finding.
+//
+//   * TestPart_GetField_TakesAControlIdNotATableFieldNo — GetField(Id) keys on the page
+//     CONTROL's generated id, and refuses a table field number with "The field with ID = 3 is
+//     not found on the page." The corpus test asserts alongside it that 3 really IS a valid
+//     table field number on that part's source table, so what it pins is the ID SPACE.
+//
+// What is provable without a loaded BC page object is the mechanism underneath both, and that
+// is what these tests pin: the runner hands BC's own precompiled GetField/GetPart a NULL, which
+// is the input those methods are written to refuse, instead of either answering a handle or
+// raising a runner-invented RunnerOutOfScopeException. Ncl.dll 28.1:
+//
+//   NavTestPageBase.GetField(int, bool):  ... TestClientProxy<ITestField>.Proxy(testPage.GetField(id));
+//                                         if (testField == null) throw NavTestFieldNotFoundException.Create(...)
+//   NavTestPageBase.GetPart(int, bool):   ... TestClientProxy<ITestPart>.Proxy(testPage.GetPart(id));
+//                                         if (testPart == null) throw NavTestPartNotFoundException.Create(...)
+//
+// Each refusal row below is paired with a row that must still be ACCEPTED or must still refuse
+// as a runner gap. That pairing is the point: an implementation that refused everything — the
+// cheapest way to make the corpus's two negative assertions pass — fails the paired rows.
+
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPageControlTreeReachabilityTests
+{
+    private const int HostPageId = 79851;
+
+    private static LiveNavTestPage PageWithoutMetadata(IReadOnlyDictionary<int, int> controlMap)
+        => new(
+            record: null,
+            controlIdToFieldNo: controlMap,
+            creatable: false,
+            page: null,
+            owner: new object(),
+            pageId: HostPageId);
+
+    // ── The literal-vs-expression distinction the whole elimination rule rests on ───────
+
+    // A part declared Visible = false is unreachable because the AL compiler folded the
+    // property to the literal false. A property bound to a variable or an expression is NOT
+    // eliminated, however that expression currently evaluates — it stays in the tree and its
+    // visibility is a live question. Losing this distinction would make every conditionally
+    // hidden control unreachable, which is a far larger wrong answer than the one #3313 fixes.
+    [Theory]
+    [InlineData("false")]
+    [InlineData("False")]
+    [InlineData("FALSE")]
+    [InlineData("0")]
+    public void ALiteralFalseVisible_Eliminates(string raw)
+        => Assert.True(RunnerPageInstance.IsLiteralFalse(raw));
+
+    [Theory]
+    [InlineData("true")]
+    [InlineData("1")]
+    [InlineData(null)]                 // the AL default for Visible is true
+    [InlineData("ShowTheHiddenPart")]  // a page global that may well be false right now
+    [InlineData("NOT ShowIt")]
+    public void AnythingElse_DoesNotEliminate(string? raw)
+        => Assert.False(RunnerPageInstance.IsLiteralFalse(raw));
+
+    // ── GetField: BC's own refusal vs. the runner's gap refusal ────────────────────────
+
+    // THE REGRESSION ROW for the table-field-number half. The runner must not classify an id
+    // BC refuses BY DESIGN as an unimplemented runner surface. Without a live page object the
+    // runner cannot ask the declaration question at all, so it must keep the gap refusal —
+    // this row pins the conservative branch, which is the honest answer there: the runner does
+    // not know whether BC would have found the control.
+    //
+    // It is also the paired control for AControlIdInTheMap_StillResolvesToItsOwnField below:
+    // if the fix had simply deleted the gap refusal, or had refused everything, the two rows
+    // could not both hold.
+    [Fact]
+    public void WithoutAPageObject_AnUnresolvableFieldStaysARunnerGap()
+    {
+        var page = PageWithoutMetadata(new Dictionary<int, int>());
+
+        var ex = Assert.Throws<RunnerOutOfScopeException>(() => page.GetField(3));
+
+        Assert.Contains("testpage-control-binding", ex.Message);
+        Assert.Contains("TestPage control 3", ex.Message);
+        // The reason must say the page object is missing, not blame the table for a field it
+        // was never asked about.
+        Assert.Contains("no AL page object was built", ex.Message);
+    }
+
+    // The ACCEPT side, and the row an implementation that refuses everything cannot pass: a
+    // control id that IS in the page's control map still resolves to a working field handle.
+    // Asserted through the handle's own control id so the test cannot pass by being handed
+    // some other control's instance — the #2088-class defect this map's keying exists to stop.
+    [Fact]
+    public void AControlIdInTheMap_StillResolvesToItsOwnField()
+    {
+        const int ControlId = 450598965;
+        var page = PageWithoutMetadata(new Dictionary<int, int> { [ControlId] = 3 });
+
+        var field = page.GetField(ControlId);
+
+        // Not merely non-null: it must be the LIVE field type, not the base mock's
+        // answer-anything MockITestField, which hands back a handle for any id at all and is
+        // indistinguishable from a real hit until something reads a value off it.
+        Assert.IsType<LiveNavTestField>(field);
+    }
+
+    // And the discrimination itself, stated as one assertion over one page: the SAME page that
+    // resolves its real control id refuses the table field number that control is bound to.
+    // This is the C# shadow of what the corpus measures, and it is what makes "GetField keys on
+    // control ids" a property of the runner rather than a coincidence of two separate tests.
+    [Fact]
+    public void OnOnePage_TheControlIdResolvesAndItsTableFieldNumberDoesNot()
+    {
+        const int ControlId = 450598965;
+        const int TableFieldNo = 3;
+        var page = PageWithoutMetadata(new Dictionary<int, int> { [ControlId] = TableFieldNo });
+
+        Assert.NotNull(page.GetField(ControlId));
+        Assert.Throws<RunnerOutOfScopeException>(() => page.GetField(TableFieldNo));
+    }
+
+    // ── GetPart ────────────────────────────────────────────────────────────────────────
+
+    // The paired control for the invisible-part fix. Without a page object the runner has no
+    // part definitions at all, so it still refuses by name as a gap rather than returning null
+    // — returning null here would hand BC's GetPart a "not found" for a part the runner simply
+    // failed to build, reporting a runner gap as BC's own refusal, which is the mirror image of
+    // the bug being fixed and just as silent.
+    [Fact]
+    public void WithoutAPageObject_APartStaysARunnerGap()
+    {
+        var page = PageWithoutMetadata(new Dictionary<int, int>());
+
+        var ex = Assert.Throws<RunnerOutOfScopeException>(() => page.GetPart(450598965));
+
+        Assert.Contains("testpage-part", ex.Message);
+        Assert.Contains("no AL page object was built", ex.Message);
+    }
+
+    // ── The constant that is now load-bearing ──────────────────────────────────────────
+
+    // LiveNavTestPart.Visible/Enabled answer a constant true, and after #3313 that is a
+    // CONSEQUENCE of the reachability rule rather than a hardcode: no LiveNavTestPart is ever
+    // constructed for an eliminated part control, so every instance that exists is one BC would
+    // render. Pinning it here means a future change that starts constructing parts for
+    // eliminated controls — reintroducing the bug — has to confront this test, because the
+    // constant would then be answering for a control BC never put in the tree.
+    [Fact]
+    public void AReachablePart_ReportsVisibleAndEnabled()
+    {
+        var part = new LiveNavTestPart(
+            record: null,
+            controlIdToFieldNo: new Dictionary<int, int>(),
+            creatable: false,
+            page: null,
+            owner: new object(),
+            pageId: HostPageId,
+            parentRecord: null,
+            links: []);
+
+        Assert.True(part.Visible);
+        Assert.True(part.Enabled);
+    }
+}

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -221,6 +221,38 @@ internal class LiveNavTestPage : MockITestPage
         if (_tornDown) throw MakeTestPageNotOpenException();
         if (_parts.TryGetValue(controlId, out var cached)) return cached;
 
+        // A part whose own Visible — or that of any group enclosing it — is the compile-time
+        // LITERAL false is not rendered into the test page's control tree at all, exactly as
+        // an eliminated FIELD control is not (see LiveNavTestPage.GetField, which has done
+        // this since #1778). Returning null is what makes that faithful: the caller is
+        // NavTestPageBase.GetPart(int,bool), a precompiled BC method, and when ITestPage.GetPart
+        // answers null it raises BC's own NavTestPartNotFoundException ("The part with ID = ...
+        // was not found on the page.") itself — so this part gets the EXACT exception real BC
+        // raises, not a runner-invented one, and not a RunnerOutOfScopeException, which would
+        // wrongly classify implementable BC behaviour as out of scope.
+        //
+        // Measured on a real service tier by corpus codeunit 60346
+        // (StefanMaron/BusinessCentral.AL.Language.Tests#227, all 8 cloud legs): the suite's
+        // first revision asserted the PAIR — a Visible = true part answering true and a
+        // Visible = false part answering false on one open host — and every leg falsified it
+        // identically with "The part with ID = 1318487454 was not found on the page." The
+        // suite's own fixture comment records the conclusion: reaching a part declared
+        // Visible = false errors; it does not yield a handle reporting false.
+        //
+        // NOTE what this does NOT say. NavTestPart genuinely overrides ALVisible/ALEnabled in
+        // the IL as `return testPart.Visible` / `return testPart.Enabled`, reading the part
+        // control's own metadata — those overrides are real and are not being contradicted.
+        // What the tier establishes is that AL cannot REACH a control whose Visible would be
+        // false, so those overrides can never be observed returning false. The claim here is
+        // about reachability, not about what the accessors return.
+        //
+        // A Visible bound to a variable or an expression is never eliminated this way, even
+        // while it currently evaluates false — see
+        // RunnerPageInstance.ControlIsCompileTimeEliminated for the literal-vs-expression
+        // distinction and the ancestor walk, which this shares with the field path rather
+        // than re-deriving.
+        if (_page?.ControlIsCompileTimeEliminated(controlId) == true) return null!;
+
         if (Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_PAGE_METADATA") == "1")
             Console.Out.WriteLine($"[MockTestPage.GetPart] controlId={controlId} pageId={_pageId} _page={(_page == null ? "null" : "set")} _page.Form={( _page?.Form == null ? "null" : _page.Form.GetType().FullName)}");
 
@@ -1695,10 +1727,43 @@ internal class LiveNavTestPage : MockITestPage
             return pageField;
         }
 
-        // Neither. Historically `id` was handed to the record as a FIELD NUMBER, which
-        // produced "The supplied field number '<hash>' cannot be found in the '<table>'
-        // table" — a control-name hash reported as a missing field, blaming the table for
-        // the runner's own inability to resolve the control. Say what actually happened.
+        // Neither — and from here there are TWO different answers, which this site used to
+        // collapse into one runner-gap refusal (issue #3313).
+        //
+        // If the page declares no control with this id AT ALL, the id is not in the page's
+        // control-id space and BC refuses it BY DESIGN. NavTestPageBase.GetField(int,bool) —
+        // the precompiled BC method the AL compiler emits for TestPage.GetField(Id) — is
+        // `fields.TryGetValue(id, ...)` over the page's own control dictionary, falling back
+        // to ITestPage.GetField(id), and raises its own NavTestFieldNotFoundException ("The
+        // field with ID = N is not found on the page.") when that answers null. Returning
+        // null hands BC's method exactly the input it is written to refuse, so AL sees BC's
+        // own exception rather than one the runner invented.
+        //
+        // The reachable case in ordinary AL is confusing GetField's id space with the source
+        // table's: `Host.Lines.GetField(Rec.FieldNo(Descr))`. Table field numbers are keys in
+        // neither dictionary. Answering a field for one was a SILENT WRONG ANSWER in the sense
+        // .claude/rules/loud-failures.md names — AL got a handle it could never have obtained
+        // on a real tier, and nothing looked broken until the same test ran against one.
+        //
+        // Measured on a real service tier by corpus codeunit 60346
+        // (StefanMaron/BusinessCentral.AL.Language.Tests#227, all 8 cloud legs): the suite's
+        // first revision passed table field 3 and every leg answered "The field with ID = 3
+        // is not found on the page." The corpus test asserts alongside it that 3 really IS a
+        // valid table field number on that part's source table, so the refusal it pins is
+        // about the ID SPACE and not about a meaningless argument.
+        //
+        // If the page DOES declare the control and the runner merely could not resolve its
+        // binding, that is a genuine runner gap and keeps the named refusal below — this
+        // narrows what gets reported as unimplemented, it does not widen it. Only a live page
+        // object can answer the declaration question, so a page the runner built no metadata
+        // for keeps the gap refusal too, which is the honest answer there: the runner does not
+        // know whether BC would have found the control.
+        if (_page?.DeclaresControl(id) == false) return null!;
+
+        // Historically `id` was handed to the record as a FIELD NUMBER, which produced "The
+        // supplied field number '<hash>' cannot be found in the '<table>' table" — a
+        // control-name hash reported as a missing field, blaming the table for the runner's
+        // own inability to resolve the control. Say what actually happened.
         throw TestPageShapeGap.ControlBinding(
             $"TestPage control {id}",
             "this control is bound neither to a field of the page's "
@@ -3455,6 +3520,27 @@ internal sealed class LiveNavTestPart : LiveNavTestPage, ITestPart
         _links = links;
     }
 
+    // Constant true, and -- since #3313 -- for a stated reason rather than as an unexplained
+    // hardcode. NavTestPart.ALVisible/ALEnabled read exactly these two properties
+    // (`return testPart.Visible` / `return testPart.Enabled` in Ncl.dll), so hardcoding them
+    // would normally be exactly the silent answer .claude/rules/loud-failures.md refuses.
+    // What makes it faithful is the reachability rule LiveNavTestPage.GetPart now enforces: a
+    // part control whose Visible is the compile-time literal false is not in the test page's
+    // control tree at all, so no LiveNavTestPart is ever constructed for one and AL has no
+    // handle on which to call either accessor. Every part that reaches this class is therefore
+    // one BC would render, for which both answers are true.
+    //
+    // Measured on a real service tier by corpus codeunit 60346
+    // (StefanMaron/BusinessCentral.AL.Language.Tests#227): its first revision tried to assert
+    // the false arm of each pair, and all 8 cloud legs answered "The part with ID = ... was
+    // not found on the page." instead -- Visible() and Enabled() can never be observed
+    // returning false from AL.
+    //
+    // The limit of that argument, stated so a later reader need not re-derive it: a part whose
+    // Visible is an EXPRESSION currently evaluating false IS reachable (expressions are never
+    // compile-time eliminated -- see ControlIsCompileTimeEliminated), and this would answer
+    // true for it. No service tier has measured that shape, because the corpus fixture
+    // declares the literal, so it is not guessed at here.
     public bool Enabled => true;
     public bool Visible => true;
 

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -768,18 +768,9 @@ internal sealed partial class RunnerPageInstance
     {
         if (_form is not NavForm form) return false;
 
-        // A part control is NOT a ControlDefinition — the AL compiler emits it as an
-        // InfopartPageDefinition reached through MetadataHelper.InfoPartDefinitions, so
-        // ControlDefinition answers null for one and the own-Visible read below silently
-        // skipped every part (issue #3313). Both element kinds derive from
-        // UIElementDefinition, which is where Visible lives, so asking the part collection
-        // as a fallback is one property read on the same declared property, not a second
-        // rule. The ancestor walk beneath is already element-kind agnostic: it walks up from
-        // an id, and a part nested inside a group whose Visible is the literal false is
-        // eliminated for exactly the reason a field there is.
-        var ownVisible = ControlDefinition(controlId)?.Visible
-            ?? TryGetPartDefinition(controlId)?.Visible;
-        if (IsLiteralFalse(ownVisible)) return true;
+        if (IsLiteralFalse(OwnDeclaredVisible(
+                ControlDefinition(controlId)?.Visible, TryGetPartDefinition(controlId)?.Visible)))
+            return true;
 
         var helper = form.MetadataHelper;
         var currentId = controlId;
@@ -808,6 +799,31 @@ internal sealed partial class RunnerPageInstance
             currentId = group.ID;
         }
     }
+
+    /// <summary>
+    /// The <c>Visible</c> an element DECLARES, whichever metadata collection it lives in.
+    ///
+    /// <para>Before #3313 the elimination check read only <c>ControlDefinition(id)?.Visible</c>,
+    /// and that silently answered null for every subpage PART: a part is not a
+    /// <c>ControlDefinition</c> at all — the AL compiler emits it as an
+    /// <c>InfopartPageDefinition</c>, reached through <c>MetadataHelper.InfoPartDefinitions</c>
+    /// rather than through the control lookup. So a part declared <c>Visible = false</c> read
+    /// as declaring nothing, which is the AL default of true, and the part stayed reachable.</para>
+    ///
+    /// <para>Both element kinds derive from <c>UIElementDefinition</c>, which is where
+    /// <c>Visible</c> lives, so this is ONE property read over two collections rather than a
+    /// second rule: whichever collection holds the element, the declared string is the same
+    /// property with the same meaning. An id is never in both — a control id and a part id come
+    /// from one generated id space — so the order of the two is not a tie-break, and the null
+    /// coalesce says exactly that.</para>
+    ///
+    /// <para>Static and internal so <c>AlRunner.Tests</c> can pin the collection-fallback
+    /// directly. The alternative needs a live <c>NavForm</c> whose <c>MetadataHelper</c> carries
+    /// a real <c>InfopartPageDefinition</c>, which only the page-build pipeline produces — the
+    /// AL-observable half is measured upstream instead, by corpus codeunit 60346.</para>
+    /// </summary>
+    internal static string? OwnDeclaredVisible(string? controlVisible, string? partVisible)
+        => controlVisible ?? partVisible;
 
     /// <summary>
     /// True only for the compile-time literal spelling ("false"/"0", case-insensitive on the

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -768,7 +768,18 @@ internal sealed partial class RunnerPageInstance
     {
         if (_form is not NavForm form) return false;
 
-        if (IsLiteralFalse(ControlDefinition(controlId)?.Visible)) return true;
+        // A part control is NOT a ControlDefinition — the AL compiler emits it as an
+        // InfopartPageDefinition reached through MetadataHelper.InfoPartDefinitions, so
+        // ControlDefinition answers null for one and the own-Visible read below silently
+        // skipped every part (issue #3313). Both element kinds derive from
+        // UIElementDefinition, which is where Visible lives, so asking the part collection
+        // as a fallback is one property read on the same declared property, not a second
+        // rule. The ancestor walk beneath is already element-kind agnostic: it walks up from
+        // an id, and a part nested inside a group whose Visible is the literal false is
+        // eliminated for exactly the reason a field there is.
+        var ownVisible = ControlDefinition(controlId)?.Visible
+            ?? TryGetPartDefinition(controlId)?.Visible;
+        if (IsLiteralFalse(ownVisible)) return true;
 
         var helper = form.MetadataHelper;
         var currentId = controlId;
@@ -816,6 +827,29 @@ internal sealed partial class RunnerPageInstance
     // rather than inheriting a freeze from a measurement that was not about it.
     internal bool ActionVisible(int actionId)
         => EvaluateProperty(ActionDefinition(actionId)?.Visible, "Visible", actionId, atOpen: false);
+
+    /// <summary>
+    /// Whether <paramref name="controlId"/> names a control this page DECLARES at all — the
+    /// question "is this id in the page's control-id space", asked of the page's own merged
+    /// metadata rather than of any binding the runner did or did not manage to resolve.
+    ///
+    /// <para>It exists to keep two different answers apart at <c>LiveNavTestPage.GetField</c>
+    /// (issue #3313), which used to give both the same runner-gap refusal:</para>
+    /// <list type="bullet">
+    /// <item>the id names a real control here and the runner could not resolve its binding —
+    /// a genuine runner gap, and still a <c>RunnerOutOfScopeException</c>;</item>
+    /// <item>the id names no control here at all — BC's OWN refusal, and the runner must
+    /// raise BC's own <c>NavTestFieldNotFoundException</c> instead of classifying documented
+    /// BC behaviour as an unimplemented runner surface.</item>
+    /// </list>
+    ///
+    /// <para>A control's id is compiler-generated per compilation and lives in its own id
+    /// space; a table field number is not in it. That is what makes the second case reachable
+    /// from ordinary AL — <c>GetField(Rec.FieldNo(X))</c> confuses the two spaces — and it is
+    /// what corpus codeunit 60346 measures.</para>
+    /// </summary>
+    internal bool DeclaresControl(int controlId)
+        => _form is NavForm form && form.MetadataHelper.TryGetControlDefinitionById(controlId, out _);
 
     private Microsoft.Dynamics.Nav.Types.Metadata.ControlDefinition? ControlDefinition(int controlId)
         => _form is NavForm form && form.MetadataHelper.TryGetControlDefinitionById(controlId, out var d) ? d : null;


### PR DESCRIPTION
Closes #3313

Filed and implemented by agent `stma-auto-3` (automated implementation agent).

Corpus-PR: https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/227

Two halves of one missing notion — what is actually in a test page's control tree. Both were
**silent wrong answers**: AL got something it could never have obtained on a real tier, and
nothing looked broken until the same test met one.

## RED → GREEN

Corpus codeunit 60346 (the `TestPart` suite), run against corpus `0bbe376`, BC 28.1:

| | before | after |
|---|---|---|
| `TestPart_InvisiblePart_IsNotInTheControlTreeAtAll` | FAIL | **PASS** |
| `TestPart_GetField_TakesAControlIdNotATableFieldNo` | FAIL | **PASS** |
| codeunit 60346 total | 8 fail / 20 pass | **6 fail / 22 pass** |

The remaining 6 are #3312's `GetMetaTable` shape, which `stma-auto-1` is taking in PR #3336.
No pin bump here, by instruction — sequencing that is the coordinator's once both land.

## 1. A part declared `Visible = false` was still reachable

`RunnerPageInstance.ControlIsCompileTimeEliminated` could not see a part **at all**. A part is
not a `ControlDefinition` — the AL compiler emits it as an `InfopartPageDefinition`, reached
through `MetadataHelper.InfoPartDefinitions` — so the own-`Visible` read answered `null`, `null`
means "declared nothing", and "declared nothing" is the AL default of **true**. `GetPart` then
resolved and built the part, handing AL a working handle.

Both element kinds derive from `UIElementDefinition`, which is where `Visible` lives, so the
fix is one property read over two collections, not a second rule. The ancestor walk beneath it
was already element-kind agnostic and is unchanged. `LiveNavTestPage.GetPart` now returns `null`
for an eliminated part, which is what makes it faithful: BC's own precompiled
`NavTestPageBase.GetPart(int, bool)` raises `NavTestPartNotFoundException` on `null`.

**This is a claim about reachability, not about what the accessors return.** `NavTestPart`
genuinely overrides `ALVisible`/`ALEnabled` in the IL as `return testPart.Visible` /
`return testPart.Enabled` — I confirmed both bodies in Ncl.dll 28.1 rather than taking it from
the issue. Those overrides are real and are not contradicted. What the tier established is that
AL cannot *reach* a control where either would answer false, so they can never be observed
returning false. The corpus suite's first revision asserted the pair and all 8 cloud legs
falsified it identically; that falsification is the finding.

## 2. `GetField()` accepted a table field number BC refuses

`TestPage.GetField(Id)` keys on a page control id. The runner refused a table field number as a
runner **gap** — `RunnerOutOfScopeException`, reason `not-yet-implemented` — which classified
documented BC behaviour as an unimplemented runner surface and produced an error text no real
tier emits, so the corpus `asserterror` caught an exception with the wrong message.

Two genuinely different answers were collapsed into one. They are now separated:

- **the page declares no control with this id** → BC's own refusal. Return `null`, and
  `NavTestPageBase.GetField(int, bool)` raises `NavTestFieldNotFoundException` itself.
- **the page declares the control and the runner could not resolve its binding** → a real runner
  gap, and it keeps the named refusal. This narrows what is reported as unimplemented; it does
  not widen it.

A page the runner built no metadata for keeps the gap refusal too, which is the honest answer
there: the runner does not know whether BC would have found the control.

Verified against `Microsoft.Dynamics.Nav.Types.dll` 28.1 that both factories produce exactly the
texts the tier reported — `The part with ID = N was not found on the page.` and
`The field with ID = N is not found on the page.` — so these are BC's own resources, not a
runner re-implementation.

## Proving tests

The AL-observable claims are BC's, measured upstream, so they are not restated here. The
runner-side file is `AlRunner.Tests/TestPageControlTreeReachabilityTests.cs`, and it is honest
about what it reaches — **the first version of it was not, and that is worth stating**: all 14
rows passed against the pre-fix code, because both changed branches need a live
`RunnerPageInstance` over a `NavForm` carrying real metadata, which only the page-build pipeline
produces. They were regression rows presented as proof.

So the changed decision is extracted as `RunnerPageInstance.OwnDeclaredVisible` — which metadata
collection a declared `Visible` is read from — and verified in both directions. Reducing that
expression to its pre-fix form (`controlVisible` alone) fails exactly 3 rows: the
part-declares-false row and the two literal arms. The narrowness rows (`true`, an expression,
undeclared) stay green under both, so "refuse everything" — the cheapest wrong way to pass the
corpus's two negative assertions — cannot pass either. The file header now says which rows are
proof and which are regression rows that pass before and after by design.

## Fixing the shape

- **Same wrong pattern at another call site?** `EagerlyBuildParts` (#2677) calls `GetPart` for
  every declared part, so it was eagerly building the invisible one and firing an `OnOpenPage`
  BC does not fire. The gate covers it through the shared `GetPart`, and the null short-circuits
  before the cache, so nothing is cached for an eliminated id.
- **Does a sibling function make the same assumption?** `LiveNavTestPart.Visible`/`Enabled`
  answer a constant `true`, which read as an unexplained hardcode of exactly the kind
  `loud-failures.md` refuses. After this change it is a *consequence*: no `LiveNavTestPart` is
  constructed for an eliminated part, so every instance is one BC would render. Documented as
  such, with its limit stated — a part whose `Visible` is an *expression* currently evaluating
  false is still reachable and would answer `true`, and no tier has measured that shape.
- **Two paths writing the same state?** `GetField` and `GetPart` now share one elimination rule
  rather than each carrying its own; previously only the field path had one.

## Deliberately not done

- **`GetAction` has the identical shape.** `NavTestPageBase.GetAction` raises
  `NavTestActionNotFoundException` on a `null` from `ITestPage.GetAction` (confirmed in Ncl.dll
  28.1), and `LiveNavTestPage.GetAction` hands back a live `LiveNavTestAction` for any id at
  all. But actions are a separate id space and **no corpus test covers `GetAction`** — I
  checked. Changing it on an IL reading alone is what
  `ask-the-corpus-before-claiming-bc-behavior.md` exists to stop, especially here, where the
  issue's own history is an IL reading that was correct while the conclusion drawn from it was
  not. Filed separately as #3339, with what a corpus suite would need to settle it.
- **`RequestPageTestPage.GetField`** makes a comparable conflation, but a request page is a
  different BC surface (`TestRequestPage.GetField`) with no source table, and no tier
  measurement covers it. Left alone.
- **#3258** (`TestPage.View()`/`Edit()`) also lands in `MockTestPage.cs`, so I checked it for
  folding per `batch-sibling-issues-by-file.md`. Not folded: its subject is the in-place
  page-mode switch and `_staticEditableOverride`, materially different reasoning to review, and
  the "Visible/Enabled answer true unmeasured" half is about field and action controls with no
  tier measurement behind it.
- **No pin bump**, by instruction. #3312 must land too.

## Coordination note

`AlRunner/Patches/MockTestPage.cs` is also edited by PR #3336 (`stma-auto-1`), the PR whose
linked issue is 3312.
The hunks do not overlap — theirs are at `GoToBookmark` / `FindRowFromTableFieldValues`
(~2125-2218), mine at `GetPart` (~219), `GetField` (~1700) and `LiveNavTestPart` (~3520) — so a
textual conflict is unlikely, but whichever merges second should re-run rather than assume.
Reporting rather than resolving blind, as instructed.

## What was run

- Corpus codeunit 60346 at corpus `0bbe376`: 8 fail → 6 fail, both named tests passing.
- Full corpus at the pin on `main` (`17b015ef`), all three apps, `--strict
  --expectations-require-match --count-baseline`: **2916/2916**.
- `tests/runner-extras`, `--strict --count-baseline`: **351/351**.
- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~TestPage|~RunnerPageInstance|~LiveNavTestPart"`:
  **311 passed, 0 failed**, 15 skipped.
- New file alone: **22/22**; 3 fail with the lookup reduced to its pre-fix form.

All on BC 28.1, Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4
