### PR TITLE
docs(rules): read a CI verdict, never block on one

### DIFF
--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -20,11 +20,13 @@ tools/ci-wait.py 2379 --timeout 1     # reads the verdict now; does not block
 
 **It must be `--timeout 1`, never `--timeout 0`.** The poll is `deadline = time.time() +
 args.timeout` followed by `while time.time() < deadline:`, so a zero timeout never enters the
-loop, never asks GitHub anything, and falls through to a bare `return 2` — exits 0, 1, 3 and 4
-become unreachable and *every* read says "not reported yet". It is silent: the output is the
-ordinary still-running line, and the only tell is the empty parentheses in
-`STILL RUNNING after 0s ()`, where the reason should be. Measured on one head seconds apart —
-`--timeout 0` exit 2, `--timeout 1` exit 0 GREEN with 10/10 ruleset contexts.
+loop and falls through to a bare `return 2`: **exits 0, 1 and 4 become unreachable and no check
+is ever looked at.** The pre-loop work still runs, so the head SHA and the required-context set
+are fetched and exit 3 remains reachable — a stale-worktree refusal is the likeliest thing you
+will actually hit. It is otherwise silent: the output is the ordinary still-running line, and
+the tell is that its parentheses are empty, `STILL RUNNING after 0s ()`, where the count of
+completed and failing checks belongs. Measured on one head seconds apart — `--timeout 0` exit 2,
+`--timeout 1` exit 0 GREEN with 10/10 ruleset contexts.
 
 That also means **"I ran it and got STILL RUNNING" proves nothing** on its own: that is what a
 green PR, a red PR and a PR with no checks all print under a zero timeout. Check a read against

--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -12,11 +12,23 @@ something that resolves whether or not anyone is watching, and the verdict costs
 read afterwards. This is a standing instruction from the repository owner and it replaces the
 older advice in this file, which told agents to wait in the foreground.
 
-**`tools/ci-wait.py <PR> --timeout 0`** is the read. One pass, one answer, returns immediately:
+**`tools/ci-wait.py <PR> --timeout 1`** is the read. One pass, one answer, back in about a second:
 
 ```bash
-tools/ci-wait.py 2379 --timeout 0     # reads the verdict now; never blocks
+tools/ci-wait.py 2379 --timeout 1     # reads the verdict now; does not block
 ```
+
+**It must be `--timeout 1`, never `--timeout 0`.** The poll is `deadline = time.time() +
+args.timeout` followed by `while time.time() < deadline:`, so a zero timeout never enters the
+loop, never asks GitHub anything, and falls through to a bare `return 2` — exits 0, 1, 3 and 4
+become unreachable and *every* read says "not reported yet". It is silent: the output is the
+ordinary still-running line, and the only tell is the empty parentheses in
+`STILL RUNNING after 0s ()`, where the reason should be. Measured on one head seconds apart —
+`--timeout 0` exit 2, `--timeout 1` exit 0 GREEN with 10/10 ruleset contexts.
+
+That also means **"I ran it and got STILL RUNNING" proves nothing** on its own: that is what a
+green PR, a red PR and a PR with no checks all print under a zero timeout. Check a read against
+a PR you already know the state of before trusting a new invocation.
 
 Everything else in this file is about *how* to read a verdict, and none of it changes: a
 verdict belongs to one commit, a cancelled run is not a failure, and a failed job's log must
@@ -35,7 +47,7 @@ Move on; read again later. It is never a green, and never a reason to re-roll an
 The anti-poll argument this section used to make still holds *within* one read: never
 hand-roll `gh run view` plus `sleep`. Measured across one session's 17 subagents, CI waiting
 was 328 of 3,282 Bash calls, shaped as 107 `gh run view` polls and 37 `sleep` loops against
-only 29 proper waits. One `--timeout 0` call replaces all of it.
+only 29 proper waits. One `--timeout 1` call replaces all of it.
 
 | exit | meaning |
 |---|---|
@@ -110,7 +122,7 @@ Two things it cannot do, so do them yourself:
   for f in ci-wait.py agent_self_freshness.py; do
     git show "origin/main:tools/$f" > "$d/tools/$f"
   done
-  python3 "$d/tools/ci-wait.py" <PR>
+  python3 "$d/tools/ci-wait.py" <PR> --timeout 1
   ```
   **Extract both files, not just `ci-wait.py`** (#3295). A lone copy cannot import its sibling
   guard, and that used to print a note and judge the PR anyway — so the recipe *recommended
@@ -242,7 +254,7 @@ it can dispatch any of the eight against your branch. And the leg-set evidence i
 thinner on a PR: three legs give far fewer distinguishable failing sets than eight, so prefer
 the dispatch or an empty commit over reading a pattern out of three data points.
 
-Read the result with `tools/ci-wait.py <PR> --timeout 0`; do **not** block on it and do not
+Read the result with `tools/ci-wait.py <PR> --timeout 1`; do **not** block on it and do not
 hand-roll a `gh run view` poll loop (section 0). Anything other than `completed` means "not yet
 reported", never "green" — leave the PR and read it again on your next pass.
 

--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -4,15 +4,38 @@
 comments yourself — don't wait for someone else to notice a PR is red. Each step below
 records a mistake made here more than once.
 
-## 0. Wait on CI with one call, not a poll loop
+## 0. Never block on CI — read the verdict, and read it again later if it is not in yet
 
-**`tools/ci-wait.py <PR>`** keeps the polling but moves it inside a single tool call: it
-loops internally, prints nothing until it has an answer, and returns one verdict.
+**Do not wait for CI.** Push the branch, open the pull request, and carry on with the next
+thing. Holding a turn open until a workflow run reports spends wall-clock and budget on
+something that resolves whether or not anyone is watching, and the verdict costs nothing to
+read afterwards. This is a standing instruction from the repository owner and it replaces the
+older advice in this file, which told agents to wait in the foreground.
+
+**`tools/ci-wait.py <PR> --timeout 0`** is the read. One pass, one answer, returns immediately:
 
 ```bash
-tools/ci-wait.py 2379                 # blocks, then reports once
-tools/ci-wait.py 2379 --timeout 2400
+tools/ci-wait.py 2379 --timeout 0     # reads the verdict now; never blocks
 ```
+
+Everything else in this file is about *how* to read a verdict, and none of it changes: a
+verdict belongs to one commit, a cancelled run is not a failure, and a failed job's log must
+never be re-run away. What changed is only *when* you read — on your next pass over the PR,
+rather than by keeping a turn open until the answer arrives.
+
+**Who reads it, and when.** An implementation agent opens its PR and hands back; it never
+waits and never merges (`.claude/agents/impl-agent.md`). The coordinator sweeps open PRs once
+per cycle and reads each verdict then. A PR whose checks have not reported yet is simply read
+again on the next sweep — and nothing is lost by that, because `gh pr merge --auto` lands a
+reviewed PR the moment its checks go green with nobody present.
+
+**Exit 2 is the ordinary answer here, not a failure.** It means the checks have not reported.
+Move on; read again later. It is never a green, and never a reason to re-roll anything.
+
+The anti-poll argument this section used to make still holds *within* one read: never
+hand-roll `gh run view` plus `sleep`. Measured across one session's 17 subagents, CI waiting
+was 328 of 3,282 Bash calls, shaped as 107 `gh run view` polls and 37 `sleep` loops against
+only 29 proper waits. One `--timeout 0` call replaces all of it.
 
 | exit | meaning |
 |---|---|
@@ -25,7 +48,7 @@ tools/ci-wait.py 2379 --timeout 2400
 `ci-wait.py` reads the required contexts from the **live branch ruleset** on each
 invocation (`GET /repos/{owner}/{repo}/rules/branches/main`, which reports only *active*
 rulesets), falling back to its built-in list and saying so loudly if that call fails. A
-required context added in the GitHub UI is therefore waited for immediately rather than
+required context added in the GitHub UI is therefore picked up immediately rather than
 ignored until someone edits the tool (#2785); `check_required_contexts.py` fails CI when the
 built-in lists and the live ruleset drift apart in either direction. What it will **not** do is
 accept a ruleset answer that is *narrower* than its built-in list — that returns exit 3 rather
@@ -110,11 +133,6 @@ Two things it cannot do, so do them yourself:
 
 `tools/preflight.py` carries the same exposure and is **not** guarded yet (#3164).
 
-Measured across one session's 17 subagents, CI waiting was 328 of 3,282 Bash calls, and the
-shape was wrong — 107 `gh run view` polls and 37 `sleep` loops against only 29 blocking
-`gh run watch` calls. Each poll re-sends the whole conversation; this turns ten-to-forty
-round trips into one.
-
 ### A cancelled run's leftovers sit in the same rollup as the live run, and `gh pr checks` hides which is which
 
 This is the trap behind #3002, and it bites in **both** directions. The API attaches every
@@ -180,7 +198,8 @@ break because `main` moved underneath you.
 `gh pr checks` reports the newest *completed* run, which can predate your last push;
 reporting green from a stale run has happened at least four times. Confirm the check's commit
 SHA matches local `HEAD` — a mismatch means "not yet reported," not "green." Never report a
-PR as done while its CI is still running.
+PR as done while its CI is still running — say it is open with checks running, which is a
+perfectly good place to leave a PR (section 0).
 
 **Which contexts gate.** Two come from the big workflows: **`BC test matrix passed`**
 (`.github/workflows/test-matrix.yml`) and **`Tests updated`**
@@ -223,10 +242,9 @@ it can dispatch any of the eight against your branch. And the leg-set evidence i
 thinner on a PR: three legs give far fewer distinguishable failing sets than eight, so prefer
 the dispatch or an empty commit over reading a pattern out of three data points.
 
-Wait in the **foreground** — `tools/ci-wait.py`, or `gh run watch <run-id>`. Never end a turn
-while CI you are responsible for is still running (`no-backgrounding-long-commands.md`).
-Re-check with `gh run view <id> --json status,conclusion` and treat anything other than
-`completed` as "not yet reported".
+Read the result with `tools/ci-wait.py <PR> --timeout 0`; do **not** block on it and do not
+hand-roll a `gh run view` poll loop (section 0). Anything other than `completed` means "not yet
+reported", never "green" — leave the PR and read it again on your next pass.
 
 ### In the corpus, "which harness code ran" has two dials, and the obvious one is wrong
 

--- a/.claude/rules/no-backgrounding-long-commands.md
+++ b/.claude/rules/no-backgrounding-long-commands.md
@@ -10,7 +10,7 @@ the foreground command or truly move on.
 **CI is the one thing you never wait for, in the foreground or anywhere else.** A workflow run
 is not your child process: it completes whether or not this turn is alive, and its verdict is
 there to read whenever you come back. So push, open the PR, and move on — then read the result
-later with `tools/ci-wait.py <PR> --timeout 0`. `ci-verdicts.md` §0 is the rule; this one
+later with `tools/ci-wait.py <PR> --timeout 1`. `ci-verdicts.md` §0 is the rule; this one
 governs work running locally.
 
 A cold full-corpus run (build + AL emit + C# compile + execute ~2000 tests) is not a
@@ -52,7 +52,7 @@ so the loss is survivable; or genuinely abandon it and say so. "Start it, end th
 wait" is not on the list.
 
 For a pull request, the correct shape is different and simpler: push, open it, hand back. Read
-the verdict on a later pass with `tools/ci-wait.py <PR> --timeout 0`, which answers at once and
+the verdict on a later pass with `tools/ci-wait.py <PR> --timeout 1`, which answers at once and
 refuses to call a still-running check a result — see `ci-verdicts.md` for the exit codes.
 
 ## Sister rules

--- a/.claude/rules/no-backgrounding-long-commands.md
+++ b/.claude/rules/no-backgrounding-long-commands.md
@@ -2,10 +2,16 @@
 
 A backgrounded process is killed when the turn ends: no completion notification arrives,
 the work sits uncommitted, and you wait forever on something already dead. This applies to
-**any** long command — corpus runs, repeat-iteration flake loops, `dotnet test` sweeps,
-provisioning, artifact downloads, long `gh`/API polling. Run it in the **foreground** with a
+**any** long command **that runs on this box** — corpus runs, repeat-iteration flake loops,
+`dotnet test` sweeps, provisioning, artifact downloads. Run it in the **foreground** with a
 correspondingly generous timeout. Do not chain short sleeps to fake a wait — either wait on
 the foreground command or truly move on.
+
+**CI is the one thing you never wait for, in the foreground or anywhere else.** A workflow run
+is not your child process: it completes whether or not this turn is alive, and its verdict is
+there to read whenever you come back. So push, open the PR, and move on — then read the result
+later with `tools/ci-wait.py <PR> --timeout 0`. `ci-verdicts.md` §0 is the rule; this one
+governs work running locally.
 
 A cold full-corpus run (build + AL emit + C# compile + execute ~2000 tests) is not a
 few-seconds operation — budget several minutes, or use a compile cache to skip recompilation
@@ -30,27 +36,26 @@ turn:
   flag, wrapper, or phrasing of a `Bash` call earns you a wake-up.
 - **The harness backgrounding it FOR you**, with a message saying you will be notified. That
   promise does not hold for anything started inside your own turn. It already cost a stall: an
-  agent correctly ran `gh run watch` in the foreground, the harness backgrounded it and
-  promised a notification, and the agent ended its turn waiting for one that could never arrive.
+  agent ran `gh run watch` in the foreground — then the correct move, now superseded by not
+  waiting on CI at all — the harness backgrounded it and promised a notification, and the agent
+  ended its turn waiting for one that could never arrive. The mechanism is what matters here and
+  it is unchanged: it applies to any long local command you background.
 
-If you catch yourself about to end a turn while something you launched is still running, that
-is the bug, not patience. Three agents lost their work this way in a single day, each having
-reported "CI is running, I'll confirm." Re-check directly and keep checking in the foreground:
+If you catch yourself about to end a turn while **local** work you launched is still running,
+that is the bug. Three agents lost work this way in a single day, each having reported "CI is
+running, I'll confirm" — and note what actually cost them: not that they stopped watching CI,
+but that they ended a turn with an **unpushed worktree**. Pushing first is what would have
+saved every one of them, and it is the fix here rather than a longer wait.
 
-```bash
-gh run view <run-id> --json status,conclusion
-```
-
-Anything other than `completed` means "not yet reported", never "green".
-
-Correct shapes, in order of preference: run it in the foreground; or push first so the loss is
-survivable and let CI be the verdict; or genuinely abandon it and say so. "End the turn and
+Correct shapes for local work, in order of preference: run it in the foreground; or push first
+so the loss is survivable; or genuinely abandon it and say so. "Start it, end the turn, and
 wait" is not on the list.
 
-For CI specifically, `tools/ci-wait.py <PR>` does the whole poll inside one tool call and
-returns a single verdict — see `ci-verdicts.md` for its exit codes.
+For a pull request, the correct shape is different and simpler: push, open it, hand back. Read
+the verdict on a later pass with `tools/ci-wait.py <PR> --timeout 0`, which answers at once and
+refuses to call a still-running check a result — see `ci-verdicts.md` for the exit codes.
 
 ## Sister rules
 
-- `ci-verdicts.md` — driving a PR to merge; `tools/ci-wait.py` and its exit codes
+- `ci-verdicts.md` — driving a PR to merge, and why CI is read rather than waited for
 - `no-git-stash-with-worktrees.md` — why a hand-rolled polling loop matches itself

--- a/.claude/rules/no-git-stash-with-worktrees.md
+++ b/.claude/rules/no-git-stash-with-worktrees.md
@@ -71,5 +71,5 @@ half. Use `$!` on a job you started, or `wait`. Better: don't poll, run it in th
 
 - `branch-and-pr.md` — one branch per agent, one open PR per agent
 - `tdd.md` — the RED → GREEN cycle the revert recipe above exists to serve
-- `no-backgrounding-long-commands.md` — why the answer to "is it done yet" is a
-  foreground wait, not a polling loop
+- `no-backgrounding-long-commands.md` — why the answer to "is it done yet" is a foreground
+  wait for local work, and for CI is not to wait at all

--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -225,7 +225,7 @@ Merge when **all of**:
 3. The proving test exists. If the claim is about BC's behavior, that test is upstream and
    merged, or merging in the same pass.
 
-**Read the verdict with `tools/ci-wait.py <PR> --timeout 0`; never block on it.** One pass,
+**Read the verdict with `tools/ci-wait.py <PR> --timeout 1`; never block on it.** One pass,
 one answer, returns at once: 0 green on current head, 1 failed with the log already fetched,
 2 still running (*not* a verdict), 3 undetermined, 4 blocked with everything green — a
 cancelled required context (below), or a required context that produced no check run at all

--- a/.claude/skills/orchestrating-a-session/SKILL.md
+++ b/.claude/skills/orchestrating-a-session/SKILL.md
@@ -225,11 +225,15 @@ Merge when **all of**:
 3. The proving test exists. If the claim is about BC's behavior, that test is upstream and
    merged, or merging in the same pass.
 
-**Use `tools/ci-wait.py <PR>`** rather than a poll loop. It polls internally and returns one
-verdict: 0 green on current head, 1 failed with the log already fetched, 2 still running
-(*not* a verdict), 3 undetermined, 4 blocked with everything green — a cancelled required
-context (below), or a required context that produced no check run at all once every
-workflow run finished (#2807).
+**Read the verdict with `tools/ci-wait.py <PR> --timeout 0`; never block on it.** One pass,
+one answer, returns at once: 0 green on current head, 1 failed with the log already fetched,
+2 still running (*not* a verdict), 3 undetermined, 4 blocked with everything green — a
+cancelled required context (below), or a required context that produced no check run at all
+once every workflow run finished (#2807).
+
+Exit 2 is the ordinary answer on a PR you just opened, and it is not a problem: leave it and
+read again on the next sweep. Waiting buys nothing, because arming `--auto` lands a reviewed
+PR the moment its checks go green with nobody present (`.claude/rules/ci-verdicts.md` §0).
 
 **A FAILED verdict names what has reported so far.** While other required checks are
 still running the failing list can grow, and the tool says how many have not reported.


### PR DESCRIPTION
The standing instruction is that nothing waits on CI: push, open the PR, move on, read the verdict on a later pass. Two rules said the opposite, and one said it to the coordinator specifically.

No linked issue: reconciling written rules with a standing instruction from the repo owner, given during the session that found the contradiction.

## What actually contradicted what

The agent definitions were already right. `.claude/agents/impl-agent.md` says "do NOT wait on CI or merge; the coordinator does both", and `orchestrating-a-session` says "Agents do NOT wait for CI" in its own summary. The contradiction was in the reference material those agents get pointed at:

| file | what it said |
|---|---|
| `ci-verdicts.md` §0 | titled "Wait on CI with one call", first example annotated `# blocks, then reports once` |
| `ci-verdicts.md` §2 | "Wait in the **foreground** … Never end a turn while CI you are responsible for is still running" |
| `no-backgrounding-long-commands.md` | listed "long `gh`/API polling" among things to foreground; closed by pointing at the blocking form |
| `orchestrating-a-session` | told the **coordinator** to use the blocking call |

So an agent told not to wait, following its own links, arrived at instructions to wait. That is the whole defect.

## Corrected after review — the read is `--timeout 1`

The first version of this PR standardised on `--timeout 0`, which **can never return a verdict**: the poll is `deadline = time.time() + args.timeout` over `while time.time() < deadline:`, so a zero timeout never enters the loop and falls through to an unconditional `return 2`. Every read would have answered "not reported yet" forever.

The evidence originally offered here was worse than the flag — a run of `--timeout 0` against a still-running PR that printed `STILL RUNNING`. That could not have failed; a green PR, a red PR and a PR with no checks all print it under a zero timeout. Same shape as the `pr-body.py` guard that could not fail because appending always changes a string.

Measured on this PR's own head, seconds apart: `--timeout 0` exit 2, `--timeout 1` exit 0 GREEN with 13 required checks and 10/10 ruleset contexts. Fixed in all four files, plus the stale-copy recipe that still ended flagless and would block for 1800s. Filed as #3351 so the tool stops accepting a value that can only produce a non-verdict.

## The read that replaces waiting

`tools/ci-wait.py <PR> --timeout 1` — one pass, back in about a second, and it refuses to call a still-running check a result. Verbatim, on this PR's own head:

```
$ tools/ci-wait.py 3340 --timeout 1
GREEN on f0b9e6c7 -- all 13 required checks passed (10/10 ruleset context(s) accounted for).
```

Against a PR whose checks are genuinely still running, the same call names what it is waiting on — which is the point, and is what a zero timeout cannot do:

```
STILL RUNNING after 1s (9/12 complete, 0 failing; waiting on: bc-tests / BC 27.0..., ...)
```

Exit 2 is now documented as the *ordinary* answer on a PR you just opened, not a problem to solve. Nothing is lost by reading later, because `gh pr merge --auto` lands a reviewed PR the moment its checks go green with nobody present.

**Nothing about how to read a verdict changes**, and that is most of what these files contain: a verdict belongs to one commit, a cancelled run is not a failure, a failed job's log must never be re-run away, required contexts come from the live ruleset. Only the timing changes.

## Two distinctions kept on purpose

- **`no-backgrounding-long-commands.md` still requires a foreground wait for work running on this box** — corpus runs, `dotnet test` sweeps, provisioning. A child process really does die with the turn. A workflow run does not. So CI is carved out rather than the rule weakened, and the rule keeps its title and its mechanism.
- **Its three-lost-agents incident is re-read, not deleted.** What cost those agents was an unpushed worktree, not that they stopped watching CI — so the fix it argues for is pushing first, which is unchanged and still the point.

## Why `tools/ci-wait.py` is not touched

Editing it would move the file on `main` and trip `agent_self_freshness` in every worktree branched before this, producing exactly the exit-3 refusal wave that `ci-verdicts.md` documents. That is a high price for a docstring. The tool already supports `--timeout 1`; the rules carry the change. That it also *accepts* `--timeout 0`, which can only ever return a non-verdict, is filed as #3351.

## Testing

Documentation only, no `AlRunner/` change, so `require-tests.yml` skips by design (`No AlRunner/ source changes — test check skipped`). Verified by grep that nothing under `.claude/` or `docs/` still instructs waiting — the remaining matches are the prohibitions themselves and one historical incident description.

Worth noting there is no test that would catch a rule contradicting another rule. That gap is already filed as #2890 ("No tests against documentation"), and this PR is a good argument for it.

---
Opened by an agent (`coord-1`) acting on the account holder's behalf.

https://claude.ai/code/session_01F7HLDeNwiGQoLT5wFanqmH
