### PR TITLE
test(corpus): advance the pin to 0bbe376, the newest prefix that is green

### DIFF
--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -190,6 +190,52 @@ leaving the two commits unpinned keeps the gap honest instead.
 
 Written by agent impl-1 (automated implementation agent).
 
+## 2026-09-07 — corpus pin `17b015ef` → `0bbe376` (al-language 2887 → 2915)
+
+One commit, and one is the whole of what the runner can take today. The pin advances to
+corpus #227 (`0bbe376`, TestPart — 5 fixture pages/tables plus `TestTestPart.al`), which the
+entry immediately above listed as blocked. It is no longer blocked: the two runner fixes it
+was waiting on merged earlier today, #3312 via PR #3336 and #3313 via PR #3338, and this
+pin bump is the catch-up that consumes them.
+
+2915 is measured, not computed — a full corpus run on this branch at this pin, BC 28.1,
+`--package-cache ~/.al-runner/platform-apps --strict`: **2915 total, 2915 pass, 0 fail,
+0 error, exit 0** (2 `pass-oos`, 11 `pass-known-gap`, 1 `pass-divergence`). The +28 over
+2887 is corpus #227's codeunit 60346 and nothing else; `0bbe376` touches no file under
+`al-language-onprem`, so that suite stays at 29 and `runner-extras` is untouched.
+
+**The wall is `d025203` (corpus #229, TestFilter), and it was measured rather than
+inferred.** Three runs on one build decided the prefix: the tip `3331aa6` gives 2966 tests
+with 5 failures, `0bbe376` gives 2915/2915 clean, and `d025203` gives 2927 with the same 5
+failures — so the first red commit is `d025203` and every commit past it is untested behind
+it, because corpus history here is linear (0 merge commits across the 8).
+
+All 5 are codeunit 60350 and all are one shape, already tracked as **#3316**:
+
+| test | expected | runner answered |
+|---|---|---|
+| `TestFilter_CurrentKey_NamesTheKeyThePageIsWalking` | `Entry No.` a substring | `` (empty) |
+| `TestFilter_SetCurrentKey_ChangesBothTheReportedKeyAndTheWalkOrder` | `Rank` a substring | `3` |
+| `TestFilter_SetCurrentKey_AcceptsACompositeKey` | `Grp` a substring | `2, 3` |
+| `TestFilter_Ascending_False_ReversesTheWalkAndIsReportedBack` | `3|2|1` | `1|2|3` |
+| `TestFilter_Ascending_AppliesToTheKeySetBySetCurrentKey` | `1|3|2` | `1|2|3` |
+
+`MockTestPage`'s `ITestFilter` members are a write-only store. `CurrentKey` is
+`string.Join(", ", _currentKeyFields)` over raw field *numbers*, which is where `3` and
+`2, 3` come from; it is empty on a freshly-opened page because nothing seeds
+`_currentKeyFields` from the table's primary key. And `GetCurrentKeyFields` and `_ascending`
+have **zero** consumers anywhere in `AlRunner/` — measured, not read off — so the last two
+rows are the same defect seen through the walk order rather than through the reported string.
+BC's own `NavTestFilter.ALCurrentKey` is `filter.CurrentKey`, delegating to the `ITestFilter`
+the runner supplies, so the gap is entirely runner-side.
+
+No `tests/expectations/` entry is added for those 5. They stay unpinned behind the wall,
+for the same reason the entry above gives: classifying a live, owned gap as settled is what
+`ask-the-corpus-before-claiming-bc-behavior.md` forbids, and leaving `d025203` and the six
+commits after it unpinned keeps the gap honest.
+
+Written by agent stma-auto-1 (automated implementation agent).
+
 ## runner-extras
 
 ### object-metadata-system-table 4 -> 6 (PR for #2771)

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Schema, semantics and how to bump: README.md in this directory. Per-bump rationale: history.md, never a prose line in here (#2485).",
   "suites": {
     "al-language": {
-      "tests": { "default": 2887 },
+      "tests": { "default": 2915 },
       "appGroups": { "default": 1 }
     },
     "al-language-internals-fixture": { "tests": { "default": 0 }, "appGroups": { "default": 1 } },


### PR DESCRIPTION
No linked issue: this is a catch-up corpus pin bump. It consumes fixes that already merged (#3312 via #3336, #3313 via #3338) and closes nothing of its own; the wall it stops at is tracked by the already-open #3316, which must stay open.

## What this moves

`tests/al-language` pin `17b015ef` -> `0bbe3765` — **one commit**, corpus #227 (TestPart).

Corpus history between the old pin and `master` tip `3331aa6` is **8 commits with 0 merge commits**. Linear history means the pin can only advance as a *prefix* of that list, so one red commit blocks everything past it. This PR pins the newest green prefix.

## Measurement, not inference

Three full corpus runs on one build, BC 28.1, `--package-cache ~/.al-runner/platform-apps --strict`:

| pin | tests | fail | exit |
|---|---|---|---|
| `3331aa6` (master tip) | 2966 | 5 | 1 |
| **`0bbe376` (this PR)** | **2915** | **0** | **0** |
| `d025203` | 2927 | 5 | 1 |

`0bbe376` is green: 2915 total, 2915 pass, 0 fail, 0 error (2 `pass-oos`, 11 `pass-known-gap`, 1 `pass-divergence`). No tests were skipped.

I bisected **by pin position** rather than guessing from failure names — `d025203` was pinned and run directly, which is what establishes it as the first red commit rather than the failing test names merely pointing at it.

## This is a partial advance. The wall is `d025203` (corpus #229, TestFilter)

All 5 failures behind the wall are codeunit 60350 and all are one shape, already tracked by **#3316** (open, unassigned, `status: ready`, no open PR closing it):

| test | expected | runner answered |
|---|---|---|
| `TestFilter_CurrentKey_NamesTheKeyThePageIsWalking` | `Entry No.` a substring | `` (empty) |
| `TestFilter_SetCurrentKey_ChangesBothTheReportedKeyAndTheWalkOrder` | `Rank` a substring | `3` |
| `TestFilter_SetCurrentKey_AcceptsACompositeKey` | `Grp` a substring | `2, 3` |
| `TestFilter_Ascending_False_ReversesTheWalkAndIsReportedBack` | `3\|2\|1` | `1\|2\|3` |
| `TestFilter_Ascending_AppliesToTheKeySetBySetCurrentKey` | `1\|3\|2` | `1\|2\|3` |

Diagnosed while measuring, in case it is useful to whoever takes #3316: `MockTestPage`'s `ITestFilter` members are a **write-only store**.

- `CurrentKey` is `string.Join(", ", _currentKeyFields)` over raw field *numbers* — that is where `3` and `2, 3` come from.
- It is empty on a freshly-opened page because nothing seeds `_currentKeyFields` from the table's primary key.
- `GetCurrentKeyFields` and `_ascending` have **zero consumers** anywhere in `AlRunner/` (measured with `rg --hidden`, not read off), so `SetCurrentKey` and `Ascending` never reach the walk order — which is the last two rows, the same defect seen through ordering rather than through the reported string.
- BC's own `NavTestFilter.ALCurrentKey` is `filter.CurrentKey`, delegating to the `ITestFilter` the runner supplies, so the gap is entirely runner-side. `NavTestFilter.GetFieldName(int) => fieldNo.ToString()` is BC's, and is not the cause here.

The six commits after `d025203` are **untested against this runner** — they sit behind the wall and linearity means they cannot be evaluated independently. They are not claimed to be red; they are unmeasured.

## Why no expectations entry

None is added for those 5. Leaving `d025203` and the six commits after it unpinned keeps the gap honest; declaring a live, owned gap as settled classification is what `ask-the-corpus-before-claiming-bc-behavior.md` forbids. #3316 must stay open after this merges.

## Count baseline

`al-language` 2887 -> 2915, taken from the run above rather than computed. The +28 is corpus #227's codeunit 60346 and nothing else.

- `al-language-onprem` unchanged at 29 — `0bbe376` touches no file under the onprem suite (verified against the commit's file list).
- `runner-extras` untouched.
- `history.md` entry added under `## al-language` recording the measurement and the wall.

## Scope questions

- **Same wrong pattern elsewhere / sibling functions:** not applicable — this diff contains no runner code. The sibling-defect analysis that *would* apply lives in #3316 and is written up above rather than acted on here, because fixing it is a different PR with its own RED -> GREEN.
- **Corpus linkage gate:** this diff touches only `tests/`, which `check_corpus_linkage.sh` scopes out explicitly ("tests and fixtures, including the corpus pin and the expectations manifests. These record behaviour, they do not change it"), so no `Corpus-PR:`/`Corpus-NA:` trailer is required.

Opened by agent stma-auto-1 (automated implementation agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4