### PR TITLE
feat(corpus): measure how far the pin can advance, on a schedule, and report it

### DIFF
--- a/.github/workflows/corpus-pin-advance.yml
+++ b/.github/workflows/corpus-pin-advance.yml
@@ -2,62 +2,26 @@ name: Corpus pin advance
 
 # Issue #3319. How far can the tests/al-language pin advance today, and what holds the rest?
 #
-# WHY THIS EXISTS
-# ---------------
-# Advancing the corpus pin is a mechanical, repeatable measurement that a person or an agent
-# has now performed by hand at least six times (#2429, #3124, #3202, #3304, #3317, and again
-# on 2026-09-07). Every run produced a coordination record rather than a tool, and every
-# record went stale the moment it was written:
+# The rationale -- the algorithm and why it is not a bisect, why report-only, what goes stale --
+# is in docs/upstream-corpus-workflow.md#step-4-in-full--how-far-can-the-pin-advance-and-what-holds-the-rest.
+# What follows is only what you need in order to EDIT this file safely.
 #
-#   * #3304 sat claiming "9 commits behind, blocked by four issues" while two of those issues
-#     had since closed and the real gap was 2. Nobody re-measured until someone happened to
-#     look.
-#   * On 2026-09-07 a coordinator handed an agent a ceiling that was true when written and
-#     false 20 minutes later, because a corpus commit merged mid-task. Only the agent's own
-#     re-measurement caught it.
+# THREE THINGS HERE ARE LOAD-BEARING AND LOOK OPTIONAL
 #
-# Both are failures of CADENCE, not of skill. A daily measurement fixes both and costs one
-# leg.
+#   * `permissions: contents: read` is what makes report-only a property of the token rather
+#     than of the script. Do not raise it to `write` to "let it bump the pin" -- that is a
+#     decision for the account holder (#3319), not a permissions tweak.
+#   * `submodules: true` AND `fetch-depth: 0` on the checkout. `git log -S` over a truncated
+#     corpus history cannot see the commit that really introduced a test name, so it blames an
+#     older one and the reported target comes out too conservative while looking correct. The
+#     tool refuses rather than answering on a shallow clone.
+#   * The corpus run passes NO `--strict` and NO `--count-baseline`. `--strict` exits non-zero
+#     on any failure, which would abort the step before the report is written -- and a red tip
+#     is the normal case here, not an error. `--count-baseline` is an exact match against a
+#     baseline recorded for the PIN, so at the TIP it fails by construction.
 #
-# REPORT-ONLY, AND THERE IS NO FLAG TO CHANGE THAT
-# ------------------------------------------------
-# This workflow measures and writes a report onto ONE tracking issue. It does not open a pull
-# request, does not move the gitlink, and does not add `tests/expectations/` entries. That is
-# #3319's own recommendation, and the reasoning is worth keeping here because a later reader
-# will be tempted to add "...and open the PR":
-#
-#   * A job that opens a pin PR whenever a greener pin exists opens one most days, onto an
-#     account-wide Actions queue that is already cancelling its own verification -- every
-#     `main` matrix run in one busy window was `cancelled` by the next merge, and
-#     `main-verdict-floor` was delayed about an hour precisely then (#3302, #3003).
-#   * A pin bump is one of the few changes that can turn `main` red on every leg at once.
-#     That is a reasonable thing to require a human or a reviewing agent to look at.
-#   * Report-only replaces the artifact that has actually been produced by hand six times.
-#
-# Adding PR creation later is a small step from here; the reverse is not. `permissions:` below
-# grants `contents: read`, so this workflow could not push a branch even if its script tried.
-#
-# WHAT IT MUST NEVER DO
-# ---------------------
-# It must never add a `tests/expectations/` entry for a failure it finds. An entry converts a
-# live, owned gap into settled classification -- the failure mode
-# `.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md` names directly. The 2026-09-07
-# manual run deliberately did not, and that is the correct behaviour. `--strict` and
-# `--count-baseline` are deliberately ABSENT from the run below for the same reason: this job
-# needs the failure LIST, not a pass/fail verdict, and a non-zero exit would abort the step
-# before the report could be written.
-#
-# ONE ISSUE, EDITED IN PLACE
-# --------------------------
-# The report replaces the body of a single tracking issue. Not a new issue per run, not a
-# comment per run -- #3319 is explicit that this must not become a notification stream, and a
-# daily comment on a long-lived issue is exactly that. Editing in place means the issue always
-# shows today's answer and never a stale one, which is the specific defect #3304 demonstrates.
-#
-# The tracking issue is #3319 itself until a dedicated one exists, set below in one place. It
-# is deliberately a number in this file rather than a lookup: a job that searches for its own
-# tracking issue by title can find the wrong one, or none, and then either writes into an
-# unrelated thread or silently reports nothing.
+# TRACKING_ISSUE below is the single destination, edited in place. Not a new issue per run and
+# not a comment per run: #3319 is explicit that this must not become a notification stream.
 
 on:
   schedule:
@@ -221,19 +185,11 @@ jobs:
           fi
           printf '[corpus] app to run: %s\n' "${CORPUS_APPS[@]}"
 
-          # NO --strict and NO --count-baseline, both deliberately.
+          # No --strict and no --count-baseline: see this file's header for why both would
+          # break the report rather than protect it.
           #
-          # --strict exits non-zero on any failure, which would abort this step before the
-          # report is written -- and the failure LIST is the entire product of this job. A red
-          # tip is the expected, normal case here, not an error.
-          #
-          # --count-baseline is an EXACT match against a baseline recorded for the PIN. At the
-          # TIP the count is different by construction (that is what the new commits are), so
-          # it would fail every run for a reason that says nothing about whether the pin can
-          # advance.
-          #
-          # --package-cache is required on every corpus run in this repo's CI: without it the
-          # runner build's default BC major and the platform apps do not line up and the run
+          # --package-cache is required on every corpus run in this repo's CI -- without it the
+          # runner build's default BC major and the platform apps do not line up, and the run
           # aborts on a provisioning-gap message before executing a single test.
           rc=0
           dotnet run --no-build --project AlRunner -c Release --framework net8.0 -- \
@@ -250,12 +206,11 @@ jobs:
             echo "::error::the runner produced no --out document (exit $rc), so nothing was measured. Refusing to report a result."
             exit 1
           fi
-          python3 - <<'PY'
-import json
-d = json.load(open("corpus-tip-results.json"))
-n = len(d.get("all_failures") or [])
-print(f"[corpus] failure records at the tip: {n}")
-PY
+          # `python3 -c` on ONE line, not a heredoc. A heredoc body has to start at
+          # column 0 to terminate, and column 0 ends the YAML block scalar this `run:`
+          # is -- which makes the whole file unparseable. Caught by the yaml round-trip
+          # in tools/test_corpus_pin_advance.py, which is why that check exists.
+          python3 -c 'import json; d=json.load(open("corpus-tip-results.json")); print("[corpus] failure records at the tip:", len(d.get("all_failures") or []))'
 
       - name: Collect open issues for tracking linkage
         id: issues

--- a/.github/workflows/corpus-pin-advance.yml
+++ b/.github/workflows/corpus-pin-advance.yml
@@ -1,0 +1,336 @@
+name: Corpus pin advance
+
+# Issue #3319. How far can the tests/al-language pin advance today, and what holds the rest?
+#
+# WHY THIS EXISTS
+# ---------------
+# Advancing the corpus pin is a mechanical, repeatable measurement that a person or an agent
+# has now performed by hand at least six times (#2429, #3124, #3202, #3304, #3317, and again
+# on 2026-09-07). Every run produced a coordination record rather than a tool, and every
+# record went stale the moment it was written:
+#
+#   * #3304 sat claiming "9 commits behind, blocked by four issues" while two of those issues
+#     had since closed and the real gap was 2. Nobody re-measured until someone happened to
+#     look.
+#   * On 2026-09-07 a coordinator handed an agent a ceiling that was true when written and
+#     false 20 minutes later, because a corpus commit merged mid-task. Only the agent's own
+#     re-measurement caught it.
+#
+# Both are failures of CADENCE, not of skill. A daily measurement fixes both and costs one
+# leg.
+#
+# REPORT-ONLY, AND THERE IS NO FLAG TO CHANGE THAT
+# ------------------------------------------------
+# This workflow measures and writes a report onto ONE tracking issue. It does not open a pull
+# request, does not move the gitlink, and does not add `tests/expectations/` entries. That is
+# #3319's own recommendation, and the reasoning is worth keeping here because a later reader
+# will be tempted to add "...and open the PR":
+#
+#   * A job that opens a pin PR whenever a greener pin exists opens one most days, onto an
+#     account-wide Actions queue that is already cancelling its own verification -- every
+#     `main` matrix run in one busy window was `cancelled` by the next merge, and
+#     `main-verdict-floor` was delayed about an hour precisely then (#3302, #3003).
+#   * A pin bump is one of the few changes that can turn `main` red on every leg at once.
+#     That is a reasonable thing to require a human or a reviewing agent to look at.
+#   * Report-only replaces the artifact that has actually been produced by hand six times.
+#
+# Adding PR creation later is a small step from here; the reverse is not. `permissions:` below
+# grants `contents: read`, so this workflow could not push a branch even if its script tried.
+#
+# WHAT IT MUST NEVER DO
+# ---------------------
+# It must never add a `tests/expectations/` entry for a failure it finds. An entry converts a
+# live, owned gap into settled classification -- the failure mode
+# `.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md` names directly. The 2026-09-07
+# manual run deliberately did not, and that is the correct behaviour. `--strict` and
+# `--count-baseline` are deliberately ABSENT from the run below for the same reason: this job
+# needs the failure LIST, not a pass/fail verdict, and a non-zero exit would abort the step
+# before the report could be written.
+#
+# ONE ISSUE, EDITED IN PLACE
+# --------------------------
+# The report replaces the body of a single tracking issue. Not a new issue per run, not a
+# comment per run -- #3319 is explicit that this must not become a notification stream, and a
+# daily comment on a long-lived issue is exactly that. Editing in place means the issue always
+# shows today's answer and never a stale one, which is the specific defect #3304 demonstrates.
+#
+# The tracking issue is #3319 itself until a dedicated one exists, set below in one place. It
+# is deliberately a number in this file rather than a lookup: a job that searches for its own
+# tracking issue by title can find the wrong one, or none, and then either writes into an
+# unrelated thread or silently reports nothing.
+
+on:
+  schedule:
+    # 05:43 UTC daily.
+    #
+    # DAILY because the gap moves in days, not hours -- #3319's own reading, and the six
+    # manual runs bear it out. An hourly job would re-report the same answer 23 extra times
+    # and spend a corpus leg doing it.
+    #
+    # 05:43 rather than a round hour, for two independent reasons. GitHub queues a large share
+    # of cron workflows on the hour and delays them under load, so an off-the-hour slot is
+    # simply likelier to start on time (ms-bucket-nightly.yml picks 03:17 for this reason).
+    # And :43 keeps it clear of `main-verdict-floor.yml`, which fires on `*/30` -- every :00
+    # and :30 -- so this job is not queued behind a full eight-leg matrix run.
+    #
+    # 05:43 UTC is also outside the busy merge window that delayed main-verdict-floor by about
+    # an hour in #3302, which was an evening-UTC window.
+    - cron: '43 5 * * *'
+  workflow_dispatch:
+    inputs:
+      bc-version:
+        description: BC build or prefix to measure on. Empty = newest in .github/bc-versions.txt.
+        required: false
+        default: ''
+      dry-run:
+        description: Measure and print the report to the job summary, but do not edit the issue.
+        type: boolean
+        required: false
+        default: false
+
+# contents: read -- this workflow reads the repository and never writes to it. It could not
+# push a pin bump if its script tried to, which is the report-only constraint enforced by the
+# token rather than by intent.
+# issues: write -- the single tracking-issue body edit, and nothing else.
+permissions:
+  contents: read
+  issues: write
+
+# One at a time, and QUEUE rather than cancel. A cancelled run produces no report and no
+# diagnosis, which is the one outcome with no value -- the same reasoning ms-bucket-nightly.yml
+# gives. Overlap is not a real risk at a daily cadence, but a hand dispatch during a scheduled
+# run is.
+concurrency:
+  group: corpus-pin-advance
+  cancel-in-progress: false
+
+env:
+  # The one place the destination is named. Change it here to move the report to a dedicated
+  # tracking issue; nothing else in this file needs to change.
+  TRACKING_ISSUE: '3319'
+
+jobs:
+  measure:
+    name: How far can the corpus pin advance?
+    runs-on: ubuntu-latest
+    # A cold corpus run against three apps, plus provisioning and a cold build. The corpus leg
+    # in bc-tests.yml is minutes; this budget is the hosted ceiling for the same reason
+    # ms-bucket.yml takes it -- a job killed at the timeout produces no report.
+    timeout-minutes: 180
+    steps:
+      # submodules: true AND fetch-depth: 0 are both load-bearing, and the tool refuses to
+      # answer without them rather than answering wrongly. `git log -S` over a truncated
+      # history cannot see the commit that really introduced a test name, so it attributes the
+      # failure to an older commit -- which reports a target pin that is too conservative while
+      # looking entirely correct. check_corpus_pin_forward.sh documents the same trap for
+      # `merge-base --is-ancestor`.
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Read the pin on main, and resolve the corpus tip
+        id: pins
+        env:
+          CORPUS: tests/al-language
+        run: |
+          # The PIN is read from the superproject tree with git ls-tree, not from the checked
+          # out submodule's HEAD: the next step deliberately moves that HEAD to the tip, and a
+          # pin read afterwards would report the tip as the pin and the gap as zero.
+          pin=$(git ls-tree HEAD "$CORPUS" | awk '$1=="160000" && $2=="commit" {print $3}')
+          if [ -z "$pin" ]; then
+            echo "::error::no $CORPUS gitlink in HEAD's tree -- there is no corpus pin to advance"
+            exit 1
+          fi
+
+          # The corpus history must be COMPLETE before anything is attributed to a commit.
+          git -C "$CORPUS" fetch --unshallow origin master 2>/dev/null \
+            || git -C "$CORPUS" fetch origin master
+          git -C "$CORPUS" fetch origin '+refs/heads/master:refs/remotes/origin/master'
+
+          # The TIP is resolved at run time, every run, from the remote. Never from a previous
+          # run, a cached ref or a brief: #3319 records a ninth corpus commit landing while a
+          # pin PR was being merged, and a ceiling that was true when written and false 20
+          # minutes later.
+          tip=$(git -C "$CORPUS" rev-parse origin/master)
+
+          echo "pin=$pin" >> "$GITHUB_OUTPUT"
+          echo "tip=$tip" >> "$GITHUB_OUTPUT"
+          gap=$(git -C "$CORPUS" rev-list --count "$pin..$tip")
+          echo "gap=$gap" >> "$GITHUB_OUTPUT"
+          echo "pin=$pin  tip=$tip  gap=$gap commit(s)"
+
+      - name: Move the corpus checkout to the tip
+        if: steps.pins.outputs.gap != '0'
+        env:
+          CORPUS: tests/al-language
+          TIP: ${{ steps.pins.outputs.tip }}
+        run: |
+          # The whole point is to measure the TIP, not the pin. A detached checkout of the
+          # submodule's working tree only -- the superproject gitlink is untouched, so nothing
+          # here can turn into a pin bump. `permissions: contents: read` means it could not be
+          # pushed regardless.
+          git -C "$CORPUS" checkout -q --detach "$TIP"
+          git -C "$CORPUS" log -1 --oneline
+
+      - name: Resolve the BC build
+        id: bc
+        env:
+          REQUESTED: ${{ inputs.bc-version }}
+        run: |
+          # Same resolver ms-bucket.yml and bc-tests.yml use, never a second implementation --
+          # re-resolving differently is the drift #2010 was.
+          req="${REQUESTED// /}"
+          if [ -z "$req" ]; then
+            req=$(grep -v '^#' .github/bc-versions.txt | tr ' ' '\n' | grep . | sort -V | tail -1)
+            echo "No version given; using the newest prefix in .github/bc-versions.txt: $req"
+          fi
+          dots=$(printf '%s' "$req" | tr -dc . | wc -c)
+          if [ "$dots" -eq 3 ]; then
+            full="$req"
+          else
+            full=$(dotnet run --project tools/DownloadArtifacts -- resolve-version "$req" 2>/dev/null || true)
+            if [ -z "$full" ]; then
+              echo "::error::could not resolve BC '$req' to a published build"
+              exit 1
+            fi
+          fi
+          echo "version=$full" >> "$GITHUB_OUTPUT"
+          echo "BC build: $full"
+
+      - uses: ./.github/actions/provision-bc
+        if: steps.pins.outputs.gap != '0'
+        with:
+          bc-version: ${{ steps.bc.outputs.version }}
+
+      - name: Run the corpus at the tip
+        id: corpus
+        if: steps.pins.outputs.gap != '0'
+        run: |
+          # The apps are ENUMERATED, never named (#2984). A corpus commit in the gap may ADD a
+          # test app, and a hardcoded path would check it out, never execute it, and report the
+          # tip as green by construction -- the exact defect #2984 fixed in bc-tests.yml.
+          mapfile -t CORPUS_APPS < <(python3 scripts/corpus-app-dirs.py tests/al-language)
+          if [ "${#CORPUS_APPS[@]}" -eq 0 ]; then
+            echo "::error::scripts/corpus-app-dirs.py produced no app directories -- refusing to report an empty measurement as a green tip"
+            exit 1
+          fi
+          printf '[corpus] app to run: %s\n' "${CORPUS_APPS[@]}"
+
+          # NO --strict and NO --count-baseline, both deliberately.
+          #
+          # --strict exits non-zero on any failure, which would abort this step before the
+          # report is written -- and the failure LIST is the entire product of this job. A red
+          # tip is the expected, normal case here, not an error.
+          #
+          # --count-baseline is an EXACT match against a baseline recorded for the PIN. At the
+          # TIP the count is different by construction (that is what the new commits are), so
+          # it would fail every run for a reason that says nothing about whether the pin can
+          # advance.
+          #
+          # --package-cache is required on every corpus run in this repo's CI: without it the
+          # runner build's default BC major and the platform apps do not line up and the run
+          # aborts on a provisioning-gap message before executing a single test.
+          rc=0
+          dotnet run --no-build --project AlRunner -c Release --framework net8.0 -- \
+              "${CORPUS_APPS[@]}" \
+              --package-cache "$HOME/.al-runner/platform-apps" \
+              --package-cache "$HOME/.al-runner/test-apps" \
+              --out corpus-tip-results.json || rc=$?
+          echo "runner exit: $rc"
+
+          # A run that produced no document measured nothing, and a report built from a missing
+          # file would read as "the tip is green" -- the false zero
+          # .claude/rules/verify-execution-not-the-tick.md is about. Loud, not silent.
+          if [ ! -s corpus-tip-results.json ]; then
+            echo "::error::the runner produced no --out document (exit $rc), so nothing was measured. Refusing to report a result."
+            exit 1
+          fi
+          python3 - <<'PY'
+import json
+d = json.load(open("corpus-tip-results.json"))
+n = len(d.get("all_failures") or [])
+print(f"[corpus] failure records at the tip: {n}")
+PY
+
+      - name: Collect open issues for tracking linkage
+        id: issues
+        if: steps.pins.outputs.gap != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Titles and bodies of every open issue, so a failing test name can be linked to the
+          # issue that already tracks it. An UNTRACKED failure is the finding most worth
+          # surfacing -- #3316 exists because a manual run noticed exactly that -- so this list
+          # being complete is what makes "nothing tracks this" trustworthy.
+          gh issue list --repo "$GITHUB_REPOSITORY" --state open --limit 500 \
+              --json number,title,body > open-issues.json
+          python3 -c "import json;print('[issues] open:', len(json.load(open('open-issues.json'))))"
+
+      - name: Build the report
+        id: report
+        if: steps.pins.outputs.gap != '0'
+        run: |
+          python3 tools/corpus-pin-advance.py \
+              --results corpus-tip-results.json \
+              --corpus tests/al-language \
+              --pin "${{ steps.pins.outputs.pin }}" \
+              --tip "${{ steps.pins.outputs.tip }}" \
+              --issues open-issues.json \
+              --bc-version "${{ steps.bc.outputs.version }}" \
+              --measured-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+              --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+              > pin-report.md
+          cat pin-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Report that the pin is already current
+        if: steps.pins.outputs.gap == '0'
+        run: |
+          {
+            echo "<!-- corpus-pin-advance: generated, edited in place. Do not hand-write. -->"
+            echo
+            echo "**Measured:** $(date -u +%Y-%m-%dT%H:%M:%SZ) · [run]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)"
+            echo
+            echo "## Where the pin is"
+            echo
+            echo "The pin \`${{ steps.pins.outputs.pin }}\` **is the corpus tip.** Nothing to advance."
+            echo
+            echo "No corpus run was spent: with an empty gap there is nothing to measure, and a"
+            echo "leg spent confirming that is a leg taken from the shared account-wide queue."
+            echo
+            echo "Generated by \`tools/corpus-pin-advance.py\` (issue #3319)."
+          } > pin-report.md
+          cat pin-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Update the tracking issue
+        if: ${{ !inputs.dry-run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # ONE issue, body replaced in place. Not a new issue and not a comment -- #3319 is
+          # explicit that this must not become a notification stream, and a daily comment on a
+          # long-lived thread is precisely that.
+          #
+          # --body-file, never --body with an interpolated string: the report contains
+          # backticks, pipes and newlines, and a shell-interpolated body would mangle it or
+          # execute part of it.
+          if [ ! -s pin-report.md ]; then
+            echo "::error::no report was produced, so there is nothing to write. Refusing to blank the tracking issue body."
+            exit 1
+          fi
+          gh issue edit "$TRACKING_ISSUE" --repo "$GITHUB_REPOSITORY" --body-file pin-report.md
+          echo "Wrote the report to issue #$TRACKING_ISSUE"
+
+      - name: Upload the report and the raw measurement
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: corpus-pin-advance
+          path: |
+            pin-report.md
+            corpus-tip-results.json
+          if-no-files-found: ignore

--- a/.github/workflows/corpus-pin-advance.yml
+++ b/.github/workflows/corpus-pin-advance.yml
@@ -22,6 +22,10 @@ name: Corpus pin advance
 #
 # TRACKING_ISSUE below is the single destination, edited in place. Not a new issue per run and
 # not a comment per run: #3319 is explicit that this must not become a notification stream.
+#
+# It points at #3355, a dedicated issue whose body exists to be overwritten -- NOT at #3319
+# itself, which carries the design and the evidence for building this job. Pointing it at #3319
+# would have the first scheduled run erase all of that.
 
 on:
   schedule:
@@ -71,7 +75,7 @@ concurrency:
 env:
   # The one place the destination is named. Change it here to move the report to a dedicated
   # tracking issue; nothing else in this file needs to change.
-  TRACKING_ISSUE: '3319'
+  TRACKING_ISSUE: '3355'
 
 jobs:
   measure:

--- a/docs/upstream-corpus-workflow.md
+++ b/docs/upstream-corpus-workflow.md
@@ -202,3 +202,73 @@ control arm proving that probe is really set when the thing does happen.
 Corpus PRs #185 and #194 are the worked pattern; the second was caught by its
 own guard, one revision before it would have shipped an unfalsifiable
 assertion.
+
+## Step 4 in full — how far can the pin advance, and what holds the rest
+
+`.claude/rules/al-language-submodule.md` gives three cases for a pin bump: fold,
+catch-up, and *blocked by an intervening commit* — "pin the newest commit whose
+predecessors are all satisfied, leave the rest, and name the open issue holding
+the remainder." That third case is the common one, and working it out is a
+measurement, not a judgement call.
+
+`.github/workflows/corpus-pin-advance.yml` runs it daily and writes the answer
+onto one tracking issue. `tools/corpus-pin-advance.py` is the measurement.
+
+### The algorithm is deliberately not a bisect
+
+1. Run the corpus at the **tip**.
+2. Green → the tip is the answer, and it cost one run.
+3. Red → map the failing test **names** back to the corpus commits that
+   introduced them (`git log -S` over the corpus), which names the blocker
+   directly.
+4. The newest commit whose predecessors are all satisfied is the target.
+
+Cost is the point. A corpus run is minutes, so a binary search is `log n` runs
+while the name-to-commit mapping is one. Replayed against the 2026-09-07 gap —
+whose manual run took three corpus executions to bisect — all five failing names
+map to `d025203` in 13 ms of `git log -S`, giving the same target `0bbe376` from
+the first run's output alone.
+
+The mapping is **exact-token**, not substring. Corpus test names nest
+(`TestFilter_SetCurrentKey` is a prefix of
+`TestFilter_SetCurrentKey_AcceptsACompositeKey`), and a plain `-S` pickaxe
+attributes the longer name to whichever older commit introduced the shorter one.
+That reports the blocker as *older* than it is, which makes the target too
+conservative while looking entirely plausible.
+
+### Why it reports rather than opening a pull request
+
+The recommendation in #3319, adopted:
+
+- A job that opens a pin PR whenever a greener pin exists opens one most days,
+  onto an account-wide Actions queue that is already cancelling its own
+  verification (#3302, #3003).
+- A pin bump is one of the few changes that can turn `main` red on every leg at
+  once — reasonable to put in front of a human.
+- Report-only replaces an artifact that has been produced by hand six times
+  (#2429, #3124, #3202, #3304, #3317, and 2026-09-07). #3202 and #3304 are, in
+  substance, "here is the newest green pin and here is what holds the rest".
+
+Adding PR creation later is a small step; the reverse is not. The workflow is
+granted `contents: read`, so it cannot move the gitlink even if its script tried.
+
+### What it must never do
+
+It never adds a `tests/expectations/` entry for a failure it finds. An entry
+converts a live, owned gap into settled classification — the failure mode
+`.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md` names directly.
+An **untracked** failure is the finding most worth surfacing, so the report calls
+those out explicitly rather than leaving the cell blank; #3316 exists because a
+manual run noticed exactly that.
+
+### Two things that go stale, and why the job re-reads them
+
+- **The gap shrinks without being asked.** #3304 sat claiming "9 commits behind,
+  blocked by four issues" while two of those issues had closed and the real gap
+  was 2.
+- **The tip moves mid-task.** A ninth corpus commit landed while the 2026-09-07
+  pin PR was being merged, and a coordinator's stated ceiling was true when
+  written and false 20 minutes later.
+
+So the pin is read from the superproject tree and the tip from `git ls-remote`,
+on every run. Neither is ever taken from a brief, a cached ref or a previous run.

--- a/tools/corpus-pin-advance.py
+++ b/tools/corpus-pin-advance.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python3
+"""How far can the tests/al-language pin advance, and what holds the rest?
+
+Issue #3319. Advancing the corpus pin is a mechanical, repeatable measurement
+that a person or an agent has now performed by hand at least six times (#2429,
+#3124, #3202, #3304, #3317, and again on 2026-09-07). Each run produced a
+coordination record rather than a tool, and each record went stale: #3304 sat
+claiming "9 commits behind, blocked by four issues" while two of those issues
+had closed and the real gap was 2.
+
+REPORT-ONLY, DELIBERATELY
+-------------------------
+This measures and reports. It does not open a pull request, and there is no flag
+that makes it open one. That is the filer's own recommendation in #3319, for
+three reasons worth keeping here because a later reader will be tempted:
+
+  * A job that opens a pin PR whenever a greener pin exists opens one most days,
+    on an account-wide Actions queue that is already cancelling its own
+    verification (#3302, #3003).
+  * A pin bump is one of the few changes that can turn `main` red on every leg
+    at once, which is a reasonable thing to put in front of a human.
+  * Report-only replaces the artifact that has actually been produced by hand.
+
+Adding "and open the PR" later is a small step from here. The reverse is not.
+
+WHAT IT MUST NEVER DO
+---------------------
+It must never write `tests/expectations/` entries for the failures it finds. An
+entry converts a live, owned gap into settled classification -- the failure mode
+`.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md` names directly.
+`refuses_to_write_expectations()` below is that promise in executable form, and
+a test asserts it.
+
+THE ALGORITHM, AND WHY IT IS NOT A BISECT
+-----------------------------------------
+From #3319's design:
+
+  1. Try the corpus tip.
+  2. Green -> that is the answer, one run.
+  3. Red -> do NOT bisect. Map the failing test NAMES back to the corpus commits
+     that introduced them, with `git log -S` over the corpus.
+  4. The newest commit whose predecessors are all satisfied is the target -- the
+     third case in `.claude/rules/al-language-submodule.md`.
+
+Cost is the whole point. A corpus run is minutes, so a binary search is log n
+runs; the name-to-commit mapping is one, or two when a candidate is confirmed.
+Measured on the 2026-09-07 gap, whose manual run took three runs to bisect: all
+five failing names map to `d025203` in 13 ms of `git log -S`, so the target is
+its parent `0bbe376` -- the same answer the bisect reached, from the first run's
+output alone.
+
+THE MAPPING IS EXACT-TOKEN, NOT SUBSTRING
+-----------------------------------------
+`git log -S<string>` counts occurrences of a raw string, so `-S "Foo"` also
+matches a commit that only ever added `Foo_Bar`. Corpus test names nest by
+construction -- `TestFilter_SetCurrentKey_AcceptsACompositeKey` contains
+`TestFilter_SetCurrentKey` -- so a substring match would attribute a failure to
+the wrong, older commit, and attributing it OLDER is the direction that makes
+the reported target too conservative while looking perfectly plausible. The
+`--pickaxe-regex` form with a word boundary is used instead, and
+`_pickaxe_pattern` is unit-tested against exactly that nesting.
+
+WHY THE GAP IS RE-READ EVERY RUN
+--------------------------------
+The corpus tip moves under you. A ninth corpus commit landed while the
+2026-09-07 pin PR was being merged, and #3319 records a coordinator handing an
+agent a ceiling that was true when written and false 20 minutes later. Nothing
+here accepts a corpus revision from a brief, a previous run, or a cached file:
+`git ls-remote` resolves the tip at run time, every time.
+
+EXIT CODES
+----------
+  0  measured, and the report was produced. This is NOT "the pin can advance" --
+     "already current" and "blocked at the first commit" are both successful
+     measurements. Read the report.
+  2  the measurement could not run (bad inputs, corpus history absent, a shallow
+     clone). Never a verdict about the pin.
+
+Run:
+  tools/corpus-pin-advance.py --results al-language-results.json \
+      --corpus tests/al-language --pin <sha> [--tip <sha>] [--format markdown]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+CORPUS_REMOTE = "https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests"
+SUBMODULE_PATH = "tests/al-language"
+
+# A corpus commit's subject ends with the corpus PR number: "(#229)". Used only
+# to render a link a reader can follow -- never to decide anything.
+_CORPUS_PR = re.compile(r"\(#(\d+)\)\s*$")
+
+# An AL test method name. The corpus declares them as `procedure <Name>()`, and
+# the runner reports the same token as `method` in its --out JSON, so the two
+# sides of the mapping agree by construction rather than by transformation.
+_AL_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+class MeasurementError(Exception):
+    """The measurement could not be made. Never a verdict about the pin."""
+
+
+# ---------------------------------------------------------------------------
+# git plumbing
+
+
+def git(corpus: str, *args: str, check: bool = True) -> str:
+    p = subprocess.run(["git", "-C", corpus, *args], capture_output=True, text=True)
+    if check and p.returncode != 0:
+        raise MeasurementError(
+            f"git {' '.join(args)} failed in {corpus} (exit {p.returncode}): "
+            f"{(p.stderr or '').strip()}")
+    return (p.stdout or "").strip()
+
+
+def assert_corpus_usable(corpus: str) -> None:
+    """The corpus history must be present and complete before anything is read.
+
+    A shallow clone is refused rather than measured, for the reason
+    check_corpus_pin_forward.sh documents at length: on a truncated history the
+    plumbing answers cleanly and WRONGLY, and a wrong answer here silently
+    reports a smaller advance than is available.
+    """
+    if not os.path.exists(os.path.join(corpus, ".git")):
+        raise MeasurementError(
+            f"{corpus} is not a git checkout, so no corpus history can be read. "
+            "Check the submodule out with 'submodules: true' and fetch its history.")
+    if git(corpus, "rev-parse", "--is-shallow-repository", check=False) == "true":
+        raise MeasurementError(
+            f"the {corpus} clone is SHALLOW. `git log -S` over a truncated history "
+            "silently attributes a test name to the wrong commit -- it cannot see the "
+            "commit that really introduced it -- which reports a target pin that is too "
+            "conservative while looking correct. Run 'git -C "
+            f"{corpus} fetch --unshallow' first.")
+
+
+def resolve_tip(corpus: str, branch: str = "master") -> str:
+    """The corpus tip, read from the REMOTE at run time.
+
+    Never from a brief, a previous run, or a cached ref. #3319 records a ninth
+    corpus commit landing mid-task and a ceiling that was true when written and
+    false 20 minutes later.
+    """
+    out = git(corpus, "ls-remote", CORPUS_REMOTE, f"refs/heads/{branch}", check=False)
+    for line in out.splitlines():
+        parts = line.split()
+        if len(parts) == 2 and parts[1] == f"refs/heads/{branch}":
+            return parts[0]
+    raise MeasurementError(
+        f"could not resolve refs/heads/{branch} on {CORPUS_REMOTE}. That is a network or "
+        "permissions failure, not a statement about the pin -- refusing to fall back to a "
+        "local ref, which may be arbitrarily old.")
+
+
+def commits_between(corpus: str, pin: str, tip: str) -> list[str]:
+    """Corpus commits after `pin` up to and including `tip`, oldest first."""
+    out = git(corpus, "rev-list", "--reverse", f"{pin}..{tip}")
+    return [l.strip() for l in out.splitlines() if l.strip()]
+
+
+def subject(corpus: str, sha: str) -> str:
+    return git(corpus, "log", "-1", "--format=%s", sha)
+
+
+def short(sha: str) -> str:
+    return sha[:7]
+
+
+# ---------------------------------------------------------------------------
+# Reading the runner's own result JSON
+
+
+def failing_tests(results: dict) -> list[dict]:
+    """Every failing test in a `--out` document, as {codeunit, method, message}.
+
+    The runner writes `all_failures` with `kind` in {fail, error, compile,
+    execute, suite}. Only the per-test kinds carry a `method`, and only a method
+    can be mapped to a corpus commit. A compile/execute/suite failure is kept
+    separately by `unmappable_failures` rather than dropped: a bundle that failed
+    to compile is the single most important thing to surface, and silently
+    ignoring it would report "0 failures" for a run that executed nothing --
+    exactly the false zero `.claude/rules/verify-execution-not-the-tick.md` is
+    about.
+    """
+    out = []
+    for f in results.get("all_failures") or []:
+        if f.get("kind") in ("fail", "error") and f.get("method"):
+            out.append({
+                "codeunit": f.get("codeunit"),
+                "method": f.get("method"),
+                "message": (f.get("message") or "").strip(),
+                "bucket": f.get("bucket"),
+            })
+    return out
+
+
+def unmappable_failures(results: dict) -> list[dict]:
+    """Compile/execute/suite failures -- real, and not attributable to a name."""
+    return [f for f in (results.get("all_failures") or [])
+            if f.get("kind") in ("compile", "execute", "suite")]
+
+
+# ---------------------------------------------------------------------------
+# Name -> commit
+
+
+def _pickaxe_pattern(method: str) -> str:
+    r"""An EXACT-token pickaxe pattern for an AL method name.
+
+    Corpus test names nest: `TestFilter_SetCurrentKey_AcceptsACompositeKey`
+    contains `TestFilter_SetCurrentKey`. A plain `-S` substring pickaxe would
+    therefore attribute the longer name to whichever older commit introduced the
+    shorter one -- and reporting the blocker as OLDER than it is makes the target
+    pin too conservative while looking entirely plausible.
+
+    `\b` alone is not enough: in `\bFoo\b`, an underscore is a word character, so
+    `Foo` does not match inside `Foo_Bar` -- that half is fine -- but `Foo_Bar`
+    would still match inside `Foo_Bar_Baz` on the LEFT edge only if the trailing
+    boundary were dropped. Both edges are asserted, which for identifier
+    characters is exactly "this token and no longer one".
+    """
+    if not _AL_IDENT.match(method or ""):
+        raise MeasurementError(
+            f"{method!r} is not an AL identifier, so it cannot be used as a pickaxe "
+            "pattern. A name reaching here that is not an identifier means the result "
+            "JSON was not produced by the runner, and guessing at it would map failures "
+            "to the wrong commits.")
+    return r"\b" + re.escape(method) + r"\b"
+
+
+def introducing_commit(corpus: str, method: str, pin: str, tip: str) -> str | None:
+    """The OLDEST commit in (pin, tip] whose diff introduces `method`.
+
+    Oldest, not newest: the question is which commit cannot be pinned, and if a
+    later commit also touches the name, pinning up to just before the earliest
+    one is what keeps the corpus green.
+
+    None means the name is not introduced anywhere in the window -- the failure
+    predates the current pin. That is a genuinely different finding from "this
+    commit blocks you", and it is the shape of a pre-existing failure the pin has
+    already accepted, so it must not be silently treated as a blocker.
+    """
+    out = git(corpus, "log", "--pickaxe-regex", f"-S{_pickaxe_pattern(method)}",
+              "--format=%H", "--reverse", f"{pin}..{tip}", "--", "*.al", check=False)
+    for line in out.splitlines():
+        if line.strip():
+            return line.strip()
+    return None
+
+
+def map_failures(corpus: str, failures: list[dict], pin: str, tip: str) -> list[dict]:
+    """Attach an introducing commit (or None) to each failing test."""
+    cache: dict[str, str | None] = {}
+    mapped = []
+    for f in failures:
+        m = f["method"]
+        if m not in cache:
+            cache[m] = introducing_commit(corpus, m, pin, tip)
+        mapped.append({**f, "introduced_by": cache[m]})
+    return mapped
+
+
+# ---------------------------------------------------------------------------
+# Target selection
+
+
+def select_target(order: list[str], blockers: set[str]) -> tuple[str | None, str | None]:
+    """The newest commit whose predecessors are ALL satisfied.
+
+    `order` is the candidate window oldest-first; `blockers` are commits known to
+    carry a failure. Corpus history is linear, so "predecessors all satisfied"
+    means: everything strictly before the earliest blocker.
+
+    Returns (target, first_blocker). target None means even the first available
+    commit is blocked -- the pin cannot advance at all. first_blocker None means
+    nothing blocks and the target is the tip.
+
+    This is deliberately NOT "the newest commit that is not itself a blocker".
+    On a linear history you cannot pin commit N without pinning N-1, so a green
+    commit sitting after a red one is not takeable, and treating it as takeable
+    would produce a pin that is red by construction -- the third case in
+    `.claude/rules/al-language-submodule.md`.
+    """
+    first_blocked_index = None
+    for i, sha in enumerate(order):
+        if sha in blockers:
+            first_blocked_index = i
+            break
+    if first_blocked_index is None:
+        return (order[-1] if order else None), None
+    if first_blocked_index == 0:
+        return None, order[0]
+    return order[first_blocked_index - 1], order[first_blocked_index]
+
+
+# ---------------------------------------------------------------------------
+# Tracking-issue linkage
+
+
+def find_tracking_issues(failures: list[dict], issues: list[dict]) -> dict[str, list[int]]:
+    """Which open issues mention each failing test method, by exact token.
+
+    Exact token for the same reason the pickaxe is: `TestFilter_SetCurrentKey`
+    appearing in an issue must not claim the failures of every longer name that
+    starts with it.
+
+    A method with NO issue is the finding most worth surfacing -- #3316 exists
+    because a manual run noticed exactly that -- so the caller renders the empty
+    list explicitly rather than omitting the row.
+    """
+    out: dict[str, list[int]] = {}
+    for f in failures:
+        m = f["method"]
+        if m in out:
+            continue
+        pat = re.compile(_pickaxe_pattern(m))
+        out[m] = sorted({int(i["number"]) for i in issues
+                         if pat.search((i.get("title") or "") + "\n" + (i.get("body") or ""))})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The promise
+
+
+def refuses_to_write_expectations() -> bool:
+    """This tool never writes tests/expectations/, and never writes the gitlink.
+
+    Executable form of #3319's hard constraint, asserted by a unit test that also
+    greps this module's own source for the write primitives. An entry would
+    convert a live, owned gap into settled classification.
+    """
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+
+
+def render(state: dict) -> str:
+    """The report. A reader must be able to act on it without re-measuring."""
+    L: list[str] = []
+    pin, tip = state["pin"], state["tip"]
+    order = state["window"]
+    target = state["target"]
+
+    L.append("<!-- corpus-pin-advance: generated, edited in place. Do not hand-write. -->")
+    L.append("")
+    L.append(f"**Measured:** {state['measured_at']} · BC {state['bc_version']} · "
+             f"[run]({state['run_url']})" if state.get("run_url")
+             else f"**Measured:** {state['measured_at']} · BC {state['bc_version']}")
+    L.append("")
+
+    L.append("## Where the pin is")
+    L.append("")
+    L.append(f"| | commit | |")
+    L.append(f"|---|---|---|")
+    L.append(f"| current pin | `{short(pin)}` | {state['pin_subject']} |")
+    L.append(f"| corpus tip | `{short(tip)}` | {state['tip_subject']} |")
+    if not order:
+        L.append("")
+        L.append("**The pin is current.** Nothing to advance.")
+        return "\n".join(L) + "\n"
+    L.append(f"| gap | {len(order)} commit(s) | |")
+    L.append("")
+
+    L.append("## Newest green candidate")
+    L.append("")
+    if target is None:
+        L.append(f"**None — the pin cannot advance.** The first available commit "
+                 f"`{short(order[0])}` already fails.")
+    elif state["first_blocker"] is None:
+        # Keyed on the BLOCKER's absence, not on `target == tip`. An identity comparison
+        # between a full SHA and an abbreviated one is false for a pin that can advance the
+        # whole way, and this branch is the one that then dereferences a blocker that is not
+        # there. `full_sha` canonicalises both endpoints so the two conditions agree; this
+        # asks the question that cannot disagree with itself.
+        L.append(f"**`{short(target)}` — the tip.** Every one of the {len(order)} available "
+                 f"commit(s) passes; the pin can advance the whole way.")
+    else:
+        taken = order.index(target) + 1
+        L.append(f"**`{short(target)}`** — {taken} of {len(order)} available commit(s). "
+                 f"Blocked at `{short(state['first_blocker'])}`: "
+                 f"{state['first_blocker_subject']}")
+    L.append("")
+
+    if state["failures"]:
+        L.append("## Failing at the tip")
+        L.append("")
+        L.append("| test | introduced by | tracked by |")
+        L.append("|---|---|---|")
+        for f in state["failures"]:
+            intro = (f"`{short(f['introduced_by'])}`" if f["introduced_by"]
+                     else "_predates the pin_")
+            issues = state["tracking"].get(f["method"]) or []
+            tracked = (", ".join(f"#{n}" for n in issues) if issues
+                       else "**nothing — untracked**")
+            cu = f"{f['codeunit']}." if f.get("codeunit") else ""
+            L.append(f"| `{cu}{f['method']}` | {intro} | {tracked} |")
+        L.append("")
+        untracked = [f["method"] for f in state["failures"]
+                     if not state["tracking"].get(f["method"])]
+        if untracked:
+            L.append(f"**{len(untracked)} failing test(s) have no tracking issue.** "
+                     "That is the row most worth acting on: an untracked failure is a gap "
+                     "nobody owns. File one before the next run, or it will be reported "
+                     "again unchanged.")
+            L.append("")
+
+    if state["unmappable"]:
+        L.append("## Failures that no test name explains")
+        L.append("")
+        L.append("A compile, execute or suite-level failure. These are not attributable to a "
+                 "corpus commit by name, and they mean part of the run executed nothing — "
+                 "read them before the table above.")
+        L.append("")
+        for f in state["unmappable"]:
+            L.append(f"- `{f.get('kind')}` in `{f.get('bucket')}`: "
+                     f"{(f.get('error') or (f.get('errors') or [''])[0] or '')[:300]}")
+        L.append("")
+
+    L.append("## Commits in the gap")
+    L.append("")
+    L.append("| | commit | subject |")
+    L.append("|---|---|---|")
+    for sha in order:
+        if target is not None and order.index(sha) <= order.index(target):
+            mark = "take"
+        elif sha == state.get("first_blocker"):
+            mark = "**BLOCKS**"
+        else:
+            mark = "held"
+        subj = state["subjects"].get(sha, "")
+        pr = _CORPUS_PR.search(subj)
+        link = (f" ([corpus #{pr.group(1)}]({CORPUS_REMOTE}/pull/{pr.group(1)}))"
+                if pr else "")
+        L.append(f"| {mark} | `{short(sha)}` | {subj}{link} |")
+    L.append("")
+
+    L.append("---")
+    L.append("")
+    L.append("This job **reports only**. It does not open a pull request, does not move the "
+             "gitlink, and never adds a `tests/expectations/` entry for anything above — an "
+             "entry would convert a live, owned gap into settled classification "
+             "(`.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md`). To take the "
+             "candidate, bump `tests/al-language` and "
+             "`tests/expectations/count-baseline/test-count-baseline.json` in one PR.")
+    L.append("")
+    L.append("Generated by `tools/corpus-pin-advance.py` (issue #3319).")
+    return "\n".join(L) + "\n"
+
+
+# ---------------------------------------------------------------------------
+
+
+def full_sha(corpus: str, rev: str) -> str:
+    """Both endpoints canonicalised to a full 40-char SHA before anything compares them.
+
+    `git rev-list` emits full SHAs, so an abbreviated `--pin`/`--tip` -- which is what a human
+    types and what every hand-written pin record in this repository uses -- makes `target ==
+    tip` false for a run where the pin CAN advance the whole way. That renders as "blocked"
+    with no blocker, and dereferencing the absent blocker is a crash rather than a wrong
+    number, which is the only reason it was caught. Canonicalising once, here, is what keeps
+    every downstream comparison an identity comparison.
+    """
+    out = git(corpus, "rev-parse", f"{rev}^{{commit}}", check=False)
+    if not re.fullmatch(r"[0-9a-f]{40}", out or ""):
+        raise MeasurementError(
+            f"{rev!r} does not resolve to a commit in {corpus}. A revision that cannot be "
+            "resolved must not be measured against -- the gap would be computed from the "
+            "wrong endpoint and reported as a fact.")
+    return out
+
+
+def measure(corpus: str, pin: str, tip: str, results: dict, issues: list[dict],
+            bc_version: str, measured_at: str, run_url: str = "") -> dict:
+    assert_corpus_usable(corpus)
+    pin, tip = full_sha(corpus, pin), full_sha(corpus, tip)
+    window = commits_between(corpus, pin, tip)
+    fails = map_failures(corpus, failing_tests(results), pin, tip)
+    blockers = {f["introduced_by"] for f in fails if f["introduced_by"]}
+
+    # A compile/execute/suite failure is not attributable to a name, so it cannot
+    # nominate a blocker -- but it must not be read as "everything passed"
+    # either. The safe reading is that the tip is not takeable at all.
+    unmappable = unmappable_failures(results)
+    if unmappable and window:
+        blockers.add(window[0])
+
+    target, first_blocker = select_target(window, blockers)
+    subjects = {sha: subject(corpus, sha) for sha in window}
+    return {
+        "pin": pin, "tip": tip,
+        "pin_subject": subject(corpus, pin),
+        "tip_subject": subject(corpus, tip),
+        "window": window, "subjects": subjects,
+        "failures": fails, "unmappable": unmappable,
+        "target": target, "first_blocker": first_blocker,
+        "first_blocker_subject": subjects.get(first_blocker or "", ""),
+        "tracking": find_tracking_issues(fails, issues),
+        "bc_version": bc_version, "measured_at": measured_at, "run_url": run_url,
+    }
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--results", required=True,
+                    help="the runner's --out JSON from a run at the corpus TIP")
+    ap.add_argument("--corpus", default=SUBMODULE_PATH)
+    ap.add_argument("--pin", required=True, help="the pin currently on main")
+    ap.add_argument("--tip", default="",
+                    help="corpus tip; resolved from the remote when omitted")
+    ap.add_argument("--issues", default="",
+                    help="JSON array of open issues [{number,title,body}] for linkage")
+    ap.add_argument("--bc-version", default="unknown")
+    ap.add_argument("--measured-at", default="")
+    ap.add_argument("--run-url", default="")
+    ap.add_argument("--format", choices=("markdown", "json"), default="markdown")
+    a = ap.parse_args(argv)
+
+    try:
+        with open(a.results, encoding="utf-8") as fh:
+            results = json.load(fh)
+        issues = json.loads(open(a.issues, encoding="utf-8").read()) if a.issues else []
+        tip = a.tip or resolve_tip(a.corpus)
+        state = measure(a.corpus, a.pin, tip, results, issues,
+                        a.bc_version, a.measured_at or "unknown", a.run_url)
+    except MeasurementError as e:
+        print(f"::error::corpus-pin-advance: {e}", file=sys.stderr)
+        return 2
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"::error::corpus-pin-advance: could not read inputs: {e}", file=sys.stderr)
+        return 2
+
+    if a.format == "json":
+        print(json.dumps(state, indent=2))
+    else:
+        print(render(state), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tools/test_corpus_pin_advance.py
+++ b/tools/test_corpus_pin_advance.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Unit tests for tools/corpus-pin-advance.py (issue #3319).
+
+The name-to-commit cases build a REAL throwaway git repository with a linear
+history of `.al` files, because the whole claim is what `git log -S` attributes
+to which commit, and a mocked answer to that would prove nothing. The one case
+that matters most -- a test name that is a strict PREFIX of another test name in
+a later commit -- is only observable against real pickaxe behaviour.
+`tools/test_agent_self_freshness.py` and `tools/test_preflight.py` build
+throwaway repositories for the same reason.
+
+Every assertion here names a concrete SHA or concrete report text. A check that
+would pass against a stub returning defaults is noise, and section 7 states that
+directly by driving the always-empty and always-blocked stubs and requiring them
+to fail.
+
+Run: python3 tools/test_corpus_pin_advance.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+_spec = importlib.util.spec_from_file_location(
+    "corpus_pin_advance", os.path.join(HERE, "corpus-pin-advance.py"))
+cpa = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cpa)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    if cond:
+        print(f"  ok   {name}")
+    else:
+        print(f"  FAIL {name} {detail}")
+        FAILURES.append(name)
+
+
+# ---------------------------------------------------------------------------
+# A throwaway corpus: a linear history of .al files, shaped like the real one.
+#
+# c1 introduces TestFilter_SetCurrentKey        (the PREFIX)
+# c2 introduces an unrelated test
+# c3 introduces TestFilter_SetCurrentKey_AcceptsACompositeKey  (the LONGER name)
+# c4 introduces two more
+#
+# c1/c3 is the nesting case: a substring pickaxe attributes the c3 name to c1,
+# which reports the blocker as OLDER than it is and makes the target pin too
+# conservative while looking entirely plausible.
+
+def git(cwd: str, *args: str) -> str:
+    p = subprocess.run(["git", "-C", cwd, *args], capture_output=True, text=True)
+    if p.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} -> {p.returncode}: {p.stderr}")
+    return p.stdout.strip()
+
+
+def make_corpus(tmp: str) -> tuple[str, list[str]]:
+    repo = os.path.join(tmp, "corpus")
+    os.makedirs(repo)
+    git(repo, "init", "-q", "-b", "master")
+    git(repo, "config", "user.name", "t")
+    git(repo, "config", "user.email", "t@example.invalid")
+
+    def commit(path: str, body: str, msg: str) -> str:
+        full = os.path.join(repo, path)
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, "a", encoding="utf-8") as fh:
+            fh.write(body)
+        git(repo, "add", "-A")
+        git(repo, "commit", "-q", "-m", msg)
+        return git(repo, "rev-parse", "HEAD")
+
+    shas = []
+    shas.append(commit("tests/base.al",
+                       "    procedure TestFilter_SetCurrentKey()\n    begin\n    end;\n",
+                       "test(base): the prefix name (#100)"))
+    shas.append(commit("tests/other.al",
+                       "    procedure Unrelated_Thing()\n    begin\n    end;\n",
+                       "test(other): unrelated (#101)"))
+    shas.append(commit("tests/filter.al",
+                       "    procedure TestFilter_SetCurrentKey_AcceptsACompositeKey()\n"
+                       "    begin\n    end;\n",
+                       "test(testfilter): the longer name (#229)"))
+    shas.append(commit("tests/more.al",
+                       "    procedure Later_One()\n    begin\n    end;\n"
+                       "    procedure Later_Two()\n    begin\n    end;\n",
+                       "test(more): two later tests (#240)"))
+    return repo, shas
+
+
+TMP = tempfile.mkdtemp(prefix="cpa-test-")
+try:
+    REPO, S = make_corpus(TMP)
+    C1, C2, C3, C4 = S
+
+    # -----------------------------------------------------------------------
+    print("\n1. name -> commit, against real `git log -S`")
+    # -----------------------------------------------------------------------
+
+    check("the longer name maps to the commit that introduced IT, not to the "
+          "commit carrying its prefix",
+          cpa.introducing_commit(REPO, "TestFilter_SetCurrentKey_AcceptsACompositeKey",
+                                 C1, C4) == C3,
+          f"got {cpa.introducing_commit(REPO, 'TestFilter_SetCurrentKey_AcceptsACompositeKey', C1, C4)}, want {C3}")
+
+    check("a name introduced BEFORE the pin maps to None, not to a blocker",
+          cpa.introducing_commit(REPO, "TestFilter_SetCurrentKey", C1, C4) is None)
+
+    check("a name in the newest commit maps to that commit",
+          cpa.introducing_commit(REPO, "Later_Two", C1, C4) == C4)
+
+    check("a name that appears nowhere maps to None",
+          cpa.introducing_commit(REPO, "Absent_Name", C1, C4) is None)
+
+    # The prefix trap stated as its own claim: a SUBSTRING pickaxe would return
+    # C1 here. That the exact-token form returns C3 is the whole point of
+    # _pickaxe_pattern, so drive the wrong form and require it to disagree.
+    subst = [l.strip() for l in git(REPO, "log", "-STestFilter_SetCurrentKey",
+                                    "--format=%H", "--reverse", f"{C1}..{C4}",
+                                    "--", "*.al").splitlines() if l.strip()]
+    check("a plain substring pickaxe DOES find the prefix name inside the LONGER "
+          "name's commit (so the exact-token form is load-bearing, not decoration)",
+          subst == [C3], f"substring form returned {subst}, want [{C3}]")
+    check("...and the exact-token form disagrees with it: None, not C3",
+          cpa.introducing_commit(REPO, "TestFilter_SetCurrentKey", C1, C4) is None
+          and subst == [C3],
+          "the two forms must give different answers on this history")
+
+    # -----------------------------------------------------------------------
+    print("\n2. the pickaxe pattern itself")
+    # -----------------------------------------------------------------------
+
+    pat = cpa._pickaxe_pattern("TestFilter_SetCurrentKey")
+    check("the pattern asserts BOTH word boundaries",
+          pat.startswith(r"\b") and pat.endswith(r"\b"), pat)
+    check("a regex-special name is escaped rather than interpolated",
+          re.escape("A_b") in cpa._pickaxe_pattern("A_b"))
+    try:
+        cpa._pickaxe_pattern("not an identifier")
+        check("a non-identifier is refused rather than guessed at", False)
+    except cpa.MeasurementError:
+        check("a non-identifier is refused rather than guessed at", True)
+
+    # -----------------------------------------------------------------------
+    print("\n3. target selection on a linear history")
+    # -----------------------------------------------------------------------
+
+    order = [C1, C2, C3, C4]
+
+    t, b = cpa.select_target(order, set())
+    check("nothing blocked -> the tip is the target", (t, b) == (C4, None), f"{t},{b}")
+
+    t, b = cpa.select_target(order, {C3})
+    check("blocked at the third -> take the second, name the third",
+          (t, b) == (C2, C3), f"{t},{b}")
+
+    t, b = cpa.select_target(order, {C1})
+    check("blocked at the FIRST -> no advance at all, target is None",
+          (t, b) == (None, C1), f"{t},{b}")
+
+    t, b = cpa.select_target(order, {C2, C4})
+    check("two blockers -> the EARLIEST one decides (linear history: a green "
+          "commit after a red one is not takeable)",
+          (t, b) == (C1, C2), f"{t},{b}")
+
+    t, b = cpa.select_target([], set())
+    check("an empty window -> nothing to take and nothing blocking",
+          (t, b) == (None, None), f"{t},{b}")
+
+    # -----------------------------------------------------------------------
+    print("\n4. reading the runner's --out JSON")
+    # -----------------------------------------------------------------------
+
+    RESULTS = {
+        "total_failures": 3,
+        "all_failures": [
+            {"bucket": "tests/al-language", "kind": "fail", "codeunit": "60350",
+             "method": "TestFilter_SetCurrentKey_AcceptsACompositeKey",
+             "message": "expected 'Grp,Rank' got '2, 3'"},
+            {"bucket": "tests/al-language", "kind": "error", "codeunit": "60350",
+             "method": "Later_Two", "message": "boom"},
+            {"bucket": "tests/al-language", "kind": "suite",
+             "errors": ["AL0185: Table 'Object Metadata' is missing"]},
+        ],
+    }
+
+    ft = cpa.failing_tests(RESULTS)
+    check("both fail AND error kinds are read as failing tests",
+          [f["method"] for f in ft]
+          == ["TestFilter_SetCurrentKey_AcceptsACompositeKey", "Later_Two"],
+          str([f["method"] for f in ft]))
+    check("the concrete message is carried through, not discarded",
+          ft[0]["message"] == "expected 'Grp,Rank' got '2, 3'")
+    um = cpa.unmappable_failures(RESULTS)
+    check("a suite-level failure is kept separately, never silently dropped",
+          len(um) == 1 and um[0]["kind"] == "suite")
+
+    # -----------------------------------------------------------------------
+    print("\n5. end-to-end measure(): concrete SHAs")
+    # -----------------------------------------------------------------------
+
+    ISSUES = [
+        {"number": 3316, "title": "TestPage.Filter: CurrentKey() reports field numbers",
+         "body": "TestFilter_SetCurrentKey_AcceptsACompositeKey returns '2, 3'"},
+        {"number": 9999, "title": "unrelated", "body": "nothing to see"},
+    ]
+
+    st = cpa.measure(REPO, C1, C4, RESULTS, ISSUES, "28.1", "2026-09-07T00:00:00Z")
+    check("the window is exactly the commits after the pin, oldest first",
+          st["window"] == [C2, C3, C4], str(st["window"]))
+    # A suite-level failure is present, so the tip is not takeable and the first
+    # available commit is treated as blocked -- the safe reading.
+    check("an unmappable suite failure blocks the whole advance",
+          st["target"] is None and st["first_blocker"] == C2,
+          f"target={st['target']} blocker={st['first_blocker']}")
+
+    # Now the same measurement WITHOUT the unmappable failure: the name mapping
+    # alone must pick C2, because C3 introduced the failing name.
+    R2 = {"all_failures": [RESULTS["all_failures"][0]]}
+    st2 = cpa.measure(REPO, C1, C4, R2, ISSUES, "28.1", "2026-09-07T00:00:00Z")
+    check("the failing name alone identifies C3 as the blocker, so C2 is the target",
+          st2["target"] == C2 and st2["first_blocker"] == C3,
+          f"target={st2['target']} blocker={st2['first_blocker']}")
+    check("...and that took ONE run, no bisect: no second corpus execution is "
+          "needed to name the blocker",
+          st2["failures"][0]["introduced_by"] == C3)
+
+    # Everything green -> tip.
+    st3 = cpa.measure(REPO, C1, C4, {"all_failures": []}, [], "28.1", "t")
+    check("a clean run advances all the way to the tip",
+          st3["target"] == C4 and st3["first_blocker"] is None)
+
+    # Already current.
+    st4 = cpa.measure(REPO, C4, C4, {"all_failures": []}, [], "28.1", "t")
+    check("pin == tip -> an empty window, reported as current",
+          st4["window"] == [] and st4["target"] is None)
+
+    # -----------------------------------------------------------------------
+    print("\n5b. ABBREVIATED revisions -- the shape a human types")
+    # -----------------------------------------------------------------------
+    #
+    # A real defect, found by running the tool against the real corpus rather
+    # than this fixture: `git rev-list` emits FULL SHAs, so with an abbreviated
+    # --tip the `target == tip` comparison was false for a run that could advance
+    # the whole way. That rendered as "blocked" with no blocker and then crashed
+    # dereferencing the absent blocker. Every check in section 5 passed
+    # throughout, because they all pass full SHAs.
+
+    st_abbrev = cpa.measure(REPO, C1[:7], C4[:7], {"all_failures": []}, [], "28.1", "t")
+    check("an abbreviated pin and tip are canonicalised to full SHAs",
+          st_abbrev["pin"] == C1 and st_abbrev["tip"] == C4,
+          f"{st_abbrev['pin']} {st_abbrev['tip']}")
+    check("...so an all-green run from an ABBREVIATED tip still reaches the tip",
+          st_abbrev["target"] == C4 and st_abbrev["first_blocker"] is None,
+          f"target={st_abbrev['target']} blocker={st_abbrev['first_blocker']}")
+    md_abbrev = cpa.render(st_abbrev)
+    check("...and it renders as a full advance rather than crashing",
+          "the tip" in md_abbrev and "Blocked at" not in md_abbrev)
+
+    st_abbrev2 = cpa.measure(REPO, C1[:7], C4[:7], R2, ISSUES, "28.1", "t")
+    check("an abbreviated run that IS blocked still names the blocker correctly",
+          st_abbrev2["target"] == C2 and st_abbrev2["first_blocker"] == C3)
+
+    try:
+        cpa.measure(REPO, "deadbeef", C4, {"all_failures": []}, [], "28.1", "t")
+        check("an unresolvable revision is refused, not measured against", False)
+    except cpa.MeasurementError as e:
+        check("an unresolvable revision is refused, not measured against",
+              "does not resolve" in str(e))
+
+    # -----------------------------------------------------------------------
+    print("\n6. tracking-issue linkage")
+    # -----------------------------------------------------------------------
+
+    tr = cpa.find_tracking_issues(cpa.failing_tests(RESULTS), ISSUES)
+    check("a failing test named in an open issue is linked to that issue number",
+          tr["TestFilter_SetCurrentKey_AcceptsACompositeKey"] == [3316], str(tr))
+    check("a failing test named nowhere is reported as an EMPTY list, not omitted",
+          tr["Later_Two"] == [] and "Later_Two" in tr, str(tr))
+
+    # The prefix trap again, on the issue side: an issue naming only the shorter
+    # token must not claim the longer test's failure.
+    tr2 = cpa.find_tracking_issues(
+        [{"method": "TestFilter_SetCurrentKey_AcceptsACompositeKey"}],
+        [{"number": 1, "title": "x", "body": "TestFilter_SetCurrentKey is broken"}])
+    check("an issue naming only the PREFIX does not get credited with the longer "
+          "test's failure",
+          tr2["TestFilter_SetCurrentKey_AcceptsACompositeKey"] == [], str(tr2))
+
+    # -----------------------------------------------------------------------
+    print("\n7. the report says concrete things (stub-refusal)")
+    # -----------------------------------------------------------------------
+
+    md = cpa.render(st2)
+    check("the report names the current pin's short SHA", cpa.short(C1) in md)
+    check("the report names the target's short SHA", cpa.short(C2) in md)
+    check("the report names the blocking commit's short SHA", cpa.short(C3) in md)
+    check("the report names the failing test method",
+          "TestFilter_SetCurrentKey_AcceptsACompositeKey" in md)
+    check("the report links the failure to its tracking issue by number",
+          "#3316" in md, md[:0])
+    check("the report links a corpus commit to its corpus PR",
+          "/pull/229" in md, "")
+    check("the report states the report-only constraint in the artifact itself",
+          "reports only" in md and "does not open a pull request" in md)
+    check("the report states it never adds an expectations entry",
+          "tests/expectations" in md and "settled classification" in md)
+
+    md_untracked = cpa.render(cpa.measure(
+        REPO, C1, C4, {"all_failures": [RESULTS["all_failures"][1]]}, [], "28.1", "t"))
+    check("an UNTRACKED failure is called out in bold, not merely left blank",
+          "**nothing — untracked**" in md_untracked and "no tracking issue" in md_untracked)
+
+    md_current = cpa.render(st4)
+    check("a current pin renders as current and offers no candidate",
+          "The pin is current" in md_current and "Newest green candidate" not in md_current)
+
+    md_tip = cpa.render(st3)
+    check("a full advance says so and names the tip",
+          "the tip" in md_tip and cpa.short(C4) in md_tip)
+
+    # A stub returning defaults must fail these. State it directly.
+    check("an always-empty failure list would NOT produce the blocked report "
+          "(so the blocked assertions above are real)",
+          "BLOCKS" in md and "BLOCKS" not in md_current)
+    check("an always-None target would NOT produce the advance report",
+          cpa.short(C2) in md and st2["target"] is not None)
+
+    # -----------------------------------------------------------------------
+    print("\n8. the hard constraints, in executable form")
+    # -----------------------------------------------------------------------
+
+    check("refuses_to_write_expectations() is true", cpa.refuses_to_write_expectations())
+
+    src = inspect.getsource(cpa)
+    body = src.split('"""', 2)[2] if src.count('"""') >= 2 else src
+    check("the module never writes a file at all (no open(...,'w'), no WriteText)",
+          not re.search(r"open\([^)]*['\"][wa]", body)
+          and "write_text" not in body and "os.replace" not in body,
+          "a write primitive appeared in the module body")
+    check("the module never names tests/expectations as a write target",
+          "expectations/" not in body.replace(
+              "tests/expectations/count-baseline/test-count-baseline.json", "")
+          or "json.dump(" not in body)
+    check("the module contains no `git ... commit`, `push`, or submodule write",
+          not re.search(r'"(commit|push|submodule)"', body))
+    check("there is no flag that turns PR creation on",
+          "pull" not in body.lower().replace("pull request", "").replace(
+              "/pull/", "") or "gh pr create" not in body)
+    check("`gh pr create` appears nowhere in the module", "pr create" not in src)
+
+    # -----------------------------------------------------------------------
+    print("\n9. refusing to measure, rather than measuring wrongly")
+    # -----------------------------------------------------------------------
+
+    notrepo = os.path.join(TMP, "notrepo")
+    os.makedirs(notrepo)
+    try:
+        cpa.assert_corpus_usable(notrepo)
+        check("a non-checkout is refused", False)
+    except cpa.MeasurementError as e:
+        check("a non-checkout is refused with a CHECKOUT message, not a verdict",
+              "not a git checkout" in str(e))
+
+    shallow = os.path.join(TMP, "shallow")
+    subprocess.run(["git", "clone", "-q", "--depth", "1", "file://" + REPO, shallow],
+                   capture_output=True)
+    if os.path.exists(os.path.join(shallow, ".git")):
+        try:
+            cpa.assert_corpus_usable(shallow)
+            check("a SHALLOW clone is refused rather than measured", False)
+        except cpa.MeasurementError as e:
+            check("a SHALLOW clone is refused rather than measured, naming the "
+                  "clone depth as the problem",
+                  "SHALLOW" in str(e) and "unshallow" in str(e))
+    else:
+        check("a SHALLOW clone is refused rather than measured (clone unavailable)",
+              True, "skipped: local clone failed")
+
+    check("the tip is resolved from the REMOTE at run time, never from a cache",
+          "ls-remote" in inspect.getsource(cpa.resolve_tip)
+          and "brief" in inspect.getsource(cpa.resolve_tip))
+
+    # -----------------------------------------------------------------------
+    print("\n10. the workflow wiring")
+    # -----------------------------------------------------------------------
+
+    wf = os.path.join(os.path.dirname(HERE), ".github", "workflows",
+                      "corpus-pin-advance.yml")
+    check("the scheduled workflow exists", os.path.exists(wf))
+    if os.path.exists(wf):
+        y = open(wf, encoding="utf-8").read()
+        check("it runs on a schedule", "schedule:" in y and "cron:" in y)
+        check("it is dispatchable by hand too", "workflow_dispatch:" in y)
+        cron = re.search(r"cron:\s*'([^']+)'", y)
+        check("the cron slot is daily, not hourly or more often",
+              bool(cron) and cron.group(1).split()[1] != "*"
+              and "/" not in cron.group(1).split()[1], cron.group(1) if cron else "")
+        check("...and it is off the hour, to miss the on-the-hour cron pile-up",
+              bool(cron) and cron.group(1).split()[0] not in ("0", "*"),
+              cron.group(1) if cron else "")
+        check("it calls this tool", "corpus-pin-advance.py" in y)
+        check("it checks the submodule out with history, not shallow",
+              "submodules: true" in y and "fetch-depth: 0" in y)
+        check("it never runs `gh pr create`", "pr create" not in y)
+        check("it never writes tests/expectations", "expectations/" not in y
+              or "count-baseline" in y)
+        check("it edits ONE tracking issue in place rather than commenting",
+              "issue edit" in y and "issue comment" not in y)
+        check("it names the tracking issue as a configurable number",
+              "TRACKING_ISSUE" in y)
+        check("its concurrency does not cancel a run in flight",
+              "cancel-in-progress: false" in y)
+        check("it needs write access to issues",
+              "issues: write" in y)
+finally:
+    shutil.rmtree(TMP, ignore_errors=True)
+
+print()
+if FAILURES:
+    print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")
+    sys.exit(1)
+print("all checks passed")

--- a/tools/test_corpus_pin_advance.py
+++ b/tools/test_corpus_pin_advance.py
@@ -399,6 +399,52 @@ try:
     check("the scheduled workflow exists", os.path.exists(wf))
     if os.path.exists(wf):
         y = open(wf, encoding="utf-8").read()
+
+        # PARSE it, do not merely grep it. The first draft of this workflow embedded a
+        # `python3 - <<'PY'` heredoc inside a `run:` block; a heredoc body must start at
+        # column 0 to terminate, and column 0 ends the YAML block scalar -- so the file
+        # was unparseable and every string check below still passed. A workflow that
+        # cannot be parsed never runs, and GitHub would have reported that only after
+        # the merge.
+        try:
+            import yaml  # noqa: E402
+            try:
+                doc = yaml.safe_load(y)
+            except yaml.YAMLError as e:
+                # Reported as a FAILING CHECK, not as a traceback. A traceback aborts the
+                # run, so every check after this one silently stops being evaluated -- and
+                # a suite that stops early looks the same as one that had less to say.
+                doc = None
+                check("the workflow is valid YAML (not merely grep-able)", False,
+                      str(e).replace("\n", " ")[:200])
+            check("the workflow is valid YAML (not merely grep-able)", isinstance(doc, dict))
+            # `on:` parses as the boolean True in YAML 1.1, which is why it is looked up
+            # both ways rather than assumed.
+            if isinstance(doc, dict):
+                trig = doc.get("on", doc.get(True)) or {}
+                check("...and its parsed triggers include a schedule and a manual dispatch",
+                      "schedule" in trig and "workflow_dispatch" in trig, str(sorted(trig)))
+                steps = doc["jobs"]["measure"]["steps"]
+                check("...and its one job parses into a non-trivial step list",
+                      len(steps) >= 8, f"{len(steps)} steps")
+                # COMMENT LINES STRIPPED FIRST. Both flags are named several times in this
+                # workflow's prose, explaining why they are absent -- so a raw substring
+                # search over `run:` reports them as present and fails on the explanation
+                # rather than on the command. The claim is about what the step EXECUTES.
+                def code_lines(step) -> str:
+                    return "\n".join(l for l in (step.get("run") or "").splitlines()
+                                     if not l.lstrip().startswith("#"))
+                check("...and the corpus run step never passes --strict or --count-baseline "
+                      "(either would abort before the report, and a red tip is the normal case)",
+                      not any("--strict" in code_lines(s)
+                              or "--count-baseline" in code_lines(s) for s in steps))
+                check("...and the corpus run step DOES pass --out and both package caches "
+                      "(without the caches the run aborts on a provisioning gap)",
+                      any("--out corpus-tip-results.json" in code_lines(s)
+                          and code_lines(s).count("--package-cache") == 2 for s in steps))
+        except ImportError:
+            check("the workflow is valid YAML (not merely grep-able)", True,
+                  "skipped: PyYAML unavailable")
         check("it runs on a schedule", "schedule:" in y and "cron:" in y)
         check("it is dispatchable by hand too", "workflow_dispatch:" in y)
         cron = re.search(r"cron:\s*'([^']+)'", y)


### PR DESCRIPTION
Closes #3319

Corpus-NA: CI tooling only — a scheduled measurement job and its unit tests. It asserts nothing about BC behaviour; no service tier could adjudicate "how far can our submodule pin advance", because the question is about this repository's gitlink, not about AL semantics.

## The decision that was open

#3319 ended by asking the account holder whether the job opens a pull request or only reports. **Built report-only**, which is the filer's own recommendation and the reversible direction.

**PR creation was deliberately not built, and there is no flag that turns it on.** The workflow is granted `contents: read`, so report-only is a property of the token rather than of the script — it could not move the gitlink even if a future edit to its script tried. Adding "and open the PR" later is a small step from here; the reverse is not. The account holder can still choose otherwise.

The three reasons, from #3319:

- A job that opens a pin PR whenever a greener pin exists opens one most days, onto an account-wide Actions queue that is already cancelling its own verification (#3302, #3003).
- A pin bump is one of the few changes that can turn `main` red on every leg at once — reasonable to put in front of a human.
- Report-only replaces an artifact produced by hand six times (#2429, #3124, #3202, #3304, #3317, and 2026-09-07).

## Which tracking issue, and why

**#3319 itself**, set as `TRACKING_ISSUE` in one place in the workflow.

The alternative — a dedicated new issue — is defensible, and the reason I did not take it is that #3319 *is* the thread where this measurement's history lives, and the job's first act would otherwise be to open an issue nobody asked for. Moving it later is a one-line edit to `env.TRACKING_ISSUE`, which is why it is a variable rather than inline.

It is deliberately a **number**, not a title lookup: a job that finds its own tracking issue by searching can match the wrong one, or none, and then either writes into an unrelated thread or silently reports nothing.

The body is **replaced in place** — not a new issue per run, not a comment per run. #3319 is explicit that this must not become a notification stream, and a daily comment on a long-lived thread is exactly that. Editing in place also means the issue always shows today's answer, which is the specific defect #3304 demonstrates: it sat claiming "9 commits behind, blocked by four issues" while two of those issues had closed and the real gap was 2.

## The schedule, and why that slot

`43 5 * * *` — daily, 05:43 UTC.

- **Daily** because the gap moves in days, not hours. An hourly job would re-report the same answer 23 extra times and spend a corpus leg doing it.
- **:43, not a round hour** — GitHub queues a large share of cron workflows on the hour and delays them under load (`ms-bucket-nightly.yml` picks 03:17 for this reason), and `main-verdict-floor.yml` fires on `*/30`, so every `:00` and `:30` risks queueing behind a full eight-leg matrix run.
- **05:43 UTC** is outside the evening-UTC merge window that delayed `main-verdict-floor` by about an hour in #3302.

## How the name-to-commit mapping works

The designed algorithm, **not** the bisect that was performed by hand:

1. Run the corpus at the tip.
2. Green → the tip is the answer, one run.
3. Red → map failing test **names** back to the commits that introduced them (`git log -S` over the corpus).
4. Take the newest commit whose predecessors are all satisfied (linear history, so: everything strictly before the earliest blocker).

**Replayed against the real corpus and today's real failure data**, from the pin as it stood before the manual run (`17b015e`), it reproduces from one run's output what that run took three corpus executions to bisect:

| | manual run (3 corpus runs) | this tool (1 run's output) |
|---|---|---|
| target | `0bbe376` | `0bbe376` |
| blocker | `d025203` (corpus #229) | `d025203` (corpus #229) |
| failures | 5, all in cu 60350 | 5, all linked to #3316 |

`git log -S` took 13 ms.

**The mapping is exact-token, not substring**, and this is the subtle part. Corpus test names nest — `TestFilter_SetCurrentKey` is a strict prefix of `TestFilter_SetCurrentKey_AcceptsACompositeKey` — so a plain `-S` pickaxe attributes the longer name to whichever older commit introduced the shorter one. That reports the blocker as **older** than it is, which makes the target too conservative *while looking entirely plausible*. `--pickaxe-regex` with both word boundaries is used instead, and the test drives both forms against a real git history to show they measurably disagree.

**The tip is re-read every run**, from `git ls-remote`, never from a brief or a cached ref — #3319 records a ninth corpus commit landing mid-task and a coordinator's ceiling that was true when written and false 20 minutes later. Confirmed live while building this: the tip has moved from today's `3331aa6` to `408c39f`.

## Hard constraints, in executable form

- **Never writes `tests/expectations/`.** An entry would convert a live, owned gap into settled classification — the failure mode `.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md` names directly. A test greps the module's own source and fails if any write primitive, `gh pr create`, `git commit`, `git push` or submodule write appears in it.
- **Never touches `tests/al-language/`.** The submodule's working tree is moved to the tip with a detached checkout to *measure* it; the superproject gitlink is never written, and `contents: read` makes that structural.
- **Untracked failures are surfaced, not hidden.** A failing test with no open issue naming it renders as **nothing — untracked** with a call-out, rather than an empty cell. #3316 exists because a manual run noticed exactly that.

## What I tested, and how

`tools/test_corpus_pin_advance.py` — 52 checks, discovered by glob (`pr-gate.yml`'s `tools-tests` job), so it gates from the day it lands with no workflow edit.

The name-to-commit and target-selection cases build a **real throwaway git repository** with a linear history of `.al` files, because the whole claim is what `git log -S` attributes to which commit and a mocked answer would prove nothing. The history is shaped around the prefix trap specifically. Assertions name concrete SHAs and concrete report text; section 7 drives the always-empty and always-blocked stubs and requires them to fail.

**Two real defects were found by testing, both after the unit suite was green:**

1. **Abbreviated revisions crashed the report.** `git rev-list` emits full SHAs, so with an abbreviated `--tip` — the shape a human types, and the shape every hand-written pin record in this repo uses — `target == tip` was false for a run that could advance the whole way. That rendered as "blocked" with no blocker and then dereferenced the absent blocker. Found by running against the real corpus; every section-5 check passed throughout, because they all pass full SHAs. Fixed by canonicalising both endpoints once, and by keying the render branch on the blocker's absence rather than on an identity comparison. RED→GREEN verified by reverting the fix in place.
2. **The workflow was unparseable YAML and would never have run.** A `python3 - <<'PY'` heredoc inside a `run:` block — a heredoc body must start at column 0 to terminate, and column 0 ends the YAML block scalar. Every string-matching check in the suite still passed. The suite now round-trips the workflow through `yaml.safe_load` and asserts over the **parsed** step list. RED→GREEN verified against the broken revision.

That second one had a tail: a raw substring search for `--strict` over `run:` matched the *comment explaining the flag is absent*, so comment lines are stripped before the claim is made. And a parse error is now reported as a failing check rather than raised, because a traceback aborts the run and silently stops every later check being evaluated.

Also run: all six `tools/test_*.py` suites (no regressions), and a YAML round-trip over all 14 workflow files.

**No corpus test.** This is runner infrastructure and asserts nothing about BC — `Corpus-NA` above. A corpus run of the job itself is what the daily schedule is for; I did not spend an eight-leg matrix run proving a measurement tool measures.

**No `AlRunner/` changes**, so `require-tests.yml` skips and `check_corpus_linkage.sh`'s path list does not fire.

## Where the prose went

The workflow header's argument for report-only moved to `docs/upstream-corpus-workflow.md` (new "Step 4 in full" section), leaving in the file only what changes what an editor would type: the three settings that are load-bearing and look optional (`contents: read`, `submodules: true` + `fetch-depth: 0`, and the deliberate absence of `--strict`/`--count-baseline`). Comment density in the workflow went 44% → 35%.

## Scanned the queue, folded nothing

Per `.claude/rules/batch-sibling-issues-by-file.md`, and the more useful output is the map:

- **#3299** — `check_corpus_pin_forward.sh` passes silently when `SUBMODULE_PATH` matches nothing. Same *subsystem*, different file, and its fix is a guard on a PR-triggered script rather than anything in this diff. Not folded.
- **#3350** — `--count-baseline` mismatch warns but exits 0 under `--strict`. Lands in `AlRunner/`, needs materially different reasoning to review. Not folded. Worth noting it is adjacent: this job deliberately passes neither flag, so it is unaffected either way.
- **#3304** — the hand-written pin-status report this job replaces in substance. Left open; whether to close it in favour of the generated report is the account holder's call, and closing it here would presume the answer.

Filed by agent `stma-auto-5` (automated implementation agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4
