### PR TITLE
fix(preflight): verify the corpus baseline against its own numbers, not the exit code

### DIFF
--- a/.claude/skills/autonomous-cycle/SKILL.md
+++ b/.claude/skills/autonomous-cycle/SKILL.md
@@ -232,6 +232,12 @@ Two things about the verdicts it produces, because both change what "stop" means
    this catches is a cache left inconsistent by a killed run, which once cost 76% of passing
    tests with no error and an unchanged exit code — a private cache is blind to exactly that.
 
+   The verdict is the **numbers**, not the exit code. `preflight.py --with-corpus` reads
+   `test-count-baseline.json`, enumerates the corpus apps the way CI does, and compares the
+   observed pass count **per app** against that file, failing on any difference in either
+   direction. A non-zero exit adds a failure; it can never grant a pass. It used to be the only
+   thing checked, which made the check blind to the one failure it is named for (#3357).
+
    If it does not reproduce: stop, notify, and open an issue. Everything downstream is untrusted
    until it does.
 

--- a/tools/corpus-pass-count.py
+++ b/tools/corpus-pass-count.py
@@ -51,7 +51,18 @@ CORPUS = "StefanMaron/BusinessCentral.AL.Language.Tests"
 
 # One space or many, so both the 27.x and the 28.x spelling match. A `+`, never
 # a fixed count -- the fixed count IS the bug (#3311 variant 1).
-_RESULT = re.compile(r"\b(PASS|FAIL)\s+([A-Za-z_][A-Za-z0-9_]*)")
+#
+# Two more spellings, both from AL Runner's OWN output rather than a corpus leg's
+# (#3357). It prints `PASS  Codeunit65551.Method (45ms)`, so the name carries a
+# dot -- an undotted pattern silently counts distinct CODEUNITS instead of tests,
+# collapsing thousands to dozens. And an expectations-reclassified pass prints
+# `PASS (known-gap) Codeunit65551.Method`, which an unqualified pattern skips
+# entirely. Both are additive for a corpus log, which has neither dots nor
+# qualifiers in its names: see test_corpus_pass_count.py, where the real-log
+# fixtures parse to the same names before and after.
+_RESULT = re.compile(
+    r"\b(PASS|FAIL)\s+(?:\((?:oos|known-gap|divergence)\)\s+)?"
+    r"([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z0-9_]+)*)")
 
 # The harness's own per-leg total, used as an INDEPENDENT second query: it tells
 # a leg that ran a suite apart from one that ran nothing at all.

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -2114,6 +2114,140 @@ def probe_decompiler(repo: str, timeout: float = 90) -> DecompilerState:
     return st
 
 
+# --------------------------------------------------------------------------
+# the corpus baseline
+# --------------------------------------------------------------------------
+CORPUS_BASELINE_REL = "tests/expectations/count-baseline/test-count-baseline.json"
+CORPUS_APP_ENUMERATOR = "scripts/corpus-app-dirs.py"
+CORPUS_SUBMODULE = "tests/al-language"
+
+# `=== <bundle> ===`, and the three variants that carry a stage after an em dash
+# (`— COMPILE FAIL`, `— EXEC FAIL`, `— SUITE ERRORS (n)`). The `=== ` with a
+# trailing space is what keeps the summary block's row of `=` out of it.
+_CORPUS_BUCKET = re.compile(r"^=== (?P<name>[^=].*?) ===$")
+_CORPUS_TOTAL = re.compile(r"^Tests:\s+(\d+) total\s*$")
+_CORPUS_FIELD = re.compile(r"^ {2}(pass|fail|error|skipped):\s+(\d+)\s*$")
+
+
+@dataclass
+class CorpusRun:
+    """What a corpus run actually reported, read from its own output."""
+    per_bucket: dict = field(default_factory=dict)   # bundle dir -> distinct passing tests
+    summary: Optional[dict] = None                   # total/pass/fail/error/skipped
+    lost_suites: list = field(default_factory=list)
+    broken_buckets: list = field(default_factory=list)
+
+
+def corpus_pass_parser():
+    """tools/corpus-pass-count.py, loaded as a module.
+
+    Reused rather than re-implemented: counting passes out of a run is the thing
+    that has produced a confident WRONG answer -- always zero, always shaped like
+    a result -- five separate ways (`verify-execution-not-the-tick.md`), and that
+    parser is the one with fixtures behind it. Its name has hyphens, so it needs
+    importlib rather than an import statement.
+    """
+    import importlib.util
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                        "corpus-pass-count.py")
+    spec = importlib.util.spec_from_file_location("corpus_pass_count", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def parse_corpus_run(text: str, parser=None) -> CorpusRun:
+    """Read a local corpus run's own report: passes per bundle, plus its summary.
+
+    TWO differently-shaped readings of the same run, on purpose. The per-bundle
+    count comes from the `PASS` lines, the totals from the summary block, and
+    check_corpus refuses a run whose two readings disagree -- the second query
+    `verify-execution-not-the-tick.md` asks for, because a single pattern that
+    silently stops matching reports zero and zero reads like a measurement.
+
+    A missing summary is None, never `{"pass": 0}`: "the run printed nothing to
+    read" and "the run passed no tests" are different facts and only one of them
+    is about the box.
+    """
+    parser = parser or corpus_pass_parser()
+    sections: dict[str, list[str]] = {}
+    out = CorpusRun()
+    current: Optional[str] = None
+    summary: Optional[dict] = None
+    for line in text.splitlines():
+        m = _CORPUS_BUCKET.match(line.rstrip())
+        if m:
+            name, _, stage = m.group("name").partition(" — ")
+            name, stage = name.strip(), stage.strip()
+            if stage.startswith("COMPILE FAIL") or stage.startswith("EXEC FAIL"):
+                out.broken_buckets.append(f"{name}: {stage}")
+                current = None
+            elif stage.startswith("SUITE ERRORS"):
+                # The bucket RAN and its surviving tests are real, but the tests
+                # the lost suites declare are missing rather than passing (#2762).
+                out.lost_suites.append(f"{name}: {stage}")
+                current = None
+            else:
+                current = name
+                sections.setdefault(name, [])
+            continue
+        if line.startswith("===="):        # the summary block's separator
+            current = None
+        mt = _CORPUS_TOTAL.match(line.rstrip())
+        if mt:
+            summary = {"total": int(mt.group(1))}
+            continue
+        mf = _CORPUS_FIELD.match(line.rstrip())
+        if mf and summary is not None:
+            summary[mf.group(1)] = int(mf.group(2))
+            continue
+        if current is not None:
+            sections[current].append(line)
+    out.summary = summary
+    for name, lines in sections.items():
+        out.per_bucket[name] = len(parser.parse_leg("\n".join(lines), "")["passed"])
+    return out
+
+
+def corpus_expected_counts(doc: dict, suites: Iterable[str]) -> tuple[dict, list]:
+    """Expected test count per suite, read from the checked-in baseline document.
+
+    Anything it cannot compute is a PROBLEM, never a zero. A suite silently
+    treated as expecting 0 tests is a check that passes when the run executes
+    none of it, which is the failure this whole function exists inside of.
+    """
+    counts: dict[str, int] = {}
+    problems: list[str] = []
+    suites_doc = (doc or {}).get("suites")
+    if not isinstance(suites_doc, dict):
+        return {}, [f"the baseline file has no `suites` object "
+                    f"(see {CORPUS_BASELINE_REL})"]
+    for s in suites:
+        entry = suites_doc.get(s)
+        if not isinstance(entry, dict):
+            problems.append(f"{s}: the run would execute this app, and the baseline "
+                            f"has no entry for it")
+            continue
+        tests = entry.get("tests")
+        if not isinstance(tests, dict) or not isinstance(tests.get("default"), int):
+            problems.append(f"{s}: baseline entry has no flat `tests.default` "
+                            f"(the per-app-group form is not one this check reads)")
+            continue
+        extra = sorted(k for k in tests if k != "default")
+        if extra:
+            # byBcVersion overrides the default per BC version, and preflight does
+            # not know which BC version this box will select. Refusing is loud and
+            # fixable; guessing `default` would quietly compare against a number
+            # that does not apply to this box.
+            problems.append(f"{s}: baseline entry carries {', '.join(extra)}, which "
+                            f"this check cannot resolve without knowing the BC version")
+            continue
+        counts[s] = tests["default"]
+    return counts, problems
+
+
 def check_corpus(repo: str, enabled: bool) -> CheckResult:
     """The skill's step 1: the corpus is the known-good baseline, and its expected
     count is checked in at tests/expectations/count-baseline/.
@@ -2122,13 +2256,25 @@ def check_corpus(repo: str, enabled: bool) -> CheckResult:
     run before every cycle; --with-corpus turns it on. A SKIP is reported as a
     SKIP, never folded into the passing count, so nobody reads a green preflight
     as "the baseline reproduced".
+
+    The verdict is the NUMBERS, never the exit code (#3357). This check used to
+    pass on `if r.ok:` alone, having computed the path of the baseline file and
+    never opened it -- so the one failure it names, a shared cache left
+    inconsistent by a killed run costing 76% of passing tests "with no error and
+    an unchanged exit code", was the one thing it could not see. A non-zero exit
+    can still ADD a failure here; it can never grant a pass.
     """
-    baseline = os.path.join(repo, "tests/expectations/count-baseline/test-count-baseline.json")
+    baseline = os.path.join(repo, CORPUS_BASELINE_REL)
+    invocation = ("mapfile -t APPS < <(python3 scripts/corpus-app-dirs.py tests/al-language)\n"
+                  "dotnet run --project AlRunner -c Release -- \"${APPS[@]}\" "
+                  "--package-cache ~/.al-runner/platform-apps "
+                  "--package-cache ~/.al-runner/test-apps --show-pass --strict "
+                  "--count-baseline " + CORPUS_BASELINE_REL)
     if not enabled:
         return CheckResult(name="corpus-baseline", status="SKIP",
                            summary="not run (multi-minute); pass --with-corpus to run it",
                            command="tools/preflight.py --with-corpus",
-                           detail=[f"expected counts live in {os.path.relpath(baseline, repo)}",
+                           detail=[f"expected counts live in {CORPUS_BASELINE_REL}",
                                    "A box that cannot reproduce the corpus baseline produces "
                                    "results that cannot be trusted - notably a shared cache "
                                    "left inconsistent by a killed run, which once cost 76% of "
@@ -2141,23 +2287,123 @@ def check_corpus(repo: str, enabled: bool) -> CheckResult:
                            summary=f"no baseline file at {baseline}",
                            command=f"ls {baseline}",
                            remedy="Check out the repository fully, including tests/expectations.")
-    r = run(["dotnet", "run", "--project", "AlRunner", "--", "test",
-             "--bundle", "tests/al-language", "--package-cache",
-             os.path.expanduser("~/.al-runner/platform-apps")],
+    try:
+        with open(baseline) as fh:
+            doc = json.load(fh)
+    except (OSError, ValueError) as exc:
+        return CheckResult(name="corpus-baseline", status="FAIL",
+                           summary=f"the baseline file could not be read: {exc}",
+                           command=f"python3 -m json.tool {CORPUS_BASELINE_REL}",
+                           remedy="Repair or re-check-out the baseline file.")
+
+    def fail(summary: str, detail: list, remedy: str, data: Optional[dict] = None) -> CheckResult:
+        return CheckResult(name="corpus-baseline", status="FAIL", summary=summary,
+                           command=invocation, detail=detail, remedy=remedy,
+                           data=data or {})
+
+    # The apps are ENUMERATED, never named (#2984): a hardcoded path is green by
+    # construction the day the corpus gains an app, because the new app is checked
+    # out and never executed.
+    enum = run(["python3", CORPUS_APP_ENUMERATOR, CORPUS_SUBMODULE], cwd=repo, timeout=120)
+    apps = [ln.strip() for ln in enum.out.splitlines() if ln.strip()]
+    if not enum.ok or not apps:
+        return fail("the corpus apps could not be enumerated, so nothing was measured",
+                    [(enum.out + enum.err).strip()[-800:] or "no output"],
+                    f"Check {CORPUS_APP_ENUMERATOR} and that the {CORPUS_SUBMODULE} "
+                    f"submodule is checked out (git submodule update --init).")
+
+    suites = [os.path.basename(a.rstrip("/")) for a in apps]
+    expected, problems = corpus_expected_counts(doc, suites)
+    if problems:
+        return fail("the expected count cannot be computed, so the run cannot be judged",
+                    problems,
+                    f"Add or correct the entries in {CORPUS_BASELINE_REL} "
+                    f"(its README.md has the schema), then re-run.",
+                    {"apps": apps, "expected": expected})
+    want = sum(expected.values())
+
+    r = run(["dotnet", "run", "--project", "AlRunner", "-c", "Release", "--", *apps,
+             "--package-cache", os.path.expanduser("~/.al-runner/platform-apps"),
+             "--package-cache", os.path.expanduser("~/.al-runner/test-apps"),
+             "--show-pass", "--strict", "--expectations-require-match",
+             "--count-baseline", CORPUS_BASELINE_REL],
             cwd=repo, timeout=3600)
-    if r.ok:
-        return CheckResult(name="corpus-baseline", status="PASS",
-                           summary="the corpus baseline reproduced on this box",
-                           command="dotnet run --project AlRunner -- test --bundle "
-                                   "tests/al-language --package-cache ~/.al-runner/platform-apps")
-    tail = "\n".join((r.out + r.err).strip().splitlines()[-15:])
-    return CheckResult(name="corpus-baseline", status="FAIL",
-                       summary="the corpus baseline did NOT reproduce - everything downstream "
-                               "is untrusted until it does",
-                       command="dotnet run --project AlRunner -- test --bundle tests/al-language",
-                       detail=[tail],
-                       remedy="Stop, notify, and open an issue. Do not start a cycle on a box "
-                              "whose baseline does not reproduce.")
+    text = r.out + "\n" + r.err
+    tail = "\n".join(text.strip().splitlines()[-15:])
+    if r.timed_out:
+        return fail("the corpus run timed out - the baseline was never measured",
+                    [tail or "no output"],
+                    "Re-run it by hand and find out where it hangs; a box that cannot "
+                    "finish the corpus cannot be trusted to finish a cycle.")
+    try:
+        obs = parse_corpus_run(text)
+    except Exception as exc:                                  # noqa: BLE001
+        return fail(f"the run's output could not be read ({exc}), so nothing was verified",
+                    [tail or "no output"],
+                    "Fix tools/corpus-pass-count.py / this parser before trusting any "
+                    "result from this box.")
+
+    data = {"expected": expected, "observed": obs.per_bucket, "apps": apps,
+            "exit_code": r.rc, "summary": obs.summary}
+    lines = [f"{s}: expected {expected[s]}, observed {obs.per_bucket.get(s, 0)}"
+             for s in suites]
+
+    if obs.summary is None:
+        return fail("the run printed no test summary, so nothing was verified - "
+                    "this is NOT a report of zero passes",
+                    [tail or "no output"] + lines,
+                    "Re-run the invocation by hand and read its output; the run did "
+                    "not get as far as reporting.", data)
+    if obs.broken_buckets or obs.lost_suites:
+        return fail("a bundle did not run in full, so the baseline was not reproduced",
+                    obs.broken_buckets + obs.lost_suites + lines,
+                    "Fix the compile/suite error above - the tests those suites "
+                    "declare are MISSING from this run, not passing.", data)
+    if obs.summary.get("fail") or obs.summary.get("error"):
+        return fail(f"{obs.summary.get('fail', 0)} test(s) failed and "
+                    f"{obs.summary.get('error', 0)} errored on this box",
+                    [tail] + lines,
+                    "Stop, notify, and open an issue. Do not start a cycle on a box "
+                    "whose baseline does not reproduce.", data)
+
+    mism = [f"{s}: expected {expected[s]}, observed {obs.per_bucket.get(s, 0)} "
+            f"({obs.per_bucket.get(s, 0) - expected[s]:+d})"
+            for s in suites if obs.per_bucket.get(s, 0) != expected[s]]
+    if mism:
+        # Both directions, deliberately. A shortfall is the incident this check is
+        # named for; a SURPLUS is only reachable through double counting or a tree
+        # whose pin and baseline disagree, and both mean the numbers this box
+        # produces describe something other than the corpus. A floor ("at least N")
+        # is the shape that let a stale baseline hide a later real drop (#1880).
+        return fail("the corpus baseline did NOT reproduce - the pass count does not "
+                    "match the checked-in baseline",
+                    mism + [f"total: expected {want}, "
+                            f"observed {sum(obs.per_bucket.values())}"],
+                    "Stop, notify, and open an issue. Do not start a cycle on a box "
+                    "whose baseline does not reproduce. If the corpus pin moved, the "
+                    f"baseline in {CORPUS_BASELINE_REL} moves with it, in that PR.",
+                    data)
+    if obs.summary.get("pass") != want:
+        return fail("the run's own summary disagrees with its per-bundle PASS lines - "
+                    f"summary says {obs.summary.get('pass')}, the lines add up to {want}",
+                    [tail] + lines,
+                    "Do not trust either number until they agree; one of the two "
+                    "readings stopped measuring what it names.", data)
+    if not r.ok:
+        # Every number checked out and the process still failed: --count-baseline
+        # (exit 4), --expectations-require-match (exit 5) or a crash. Reported as a
+        # FAIL rather than explained away, because the run is saying something the
+        # counts above cannot see.
+        return fail(f"every count matched but the run exited {r.rc} - something the "
+                    f"counts cannot see went wrong",
+                    [tail] + lines,
+                    "Read the tail above: 4=count-baseline mismatch, "
+                    "5=an expectations entry matched no test, 134/139=crash.", data)
+    return CheckResult(name="corpus-baseline", status="PASS",
+                       summary=f"the corpus baseline reproduced on this box: {want} tests "
+                               f"passed across {len(apps)} app(s), matching "
+                               f"{CORPUS_BASELINE_REL}",
+                       command=invocation, detail=lines, data=data)
 
 
 # --------------------------------------------------------------------------

--- a/tools/test_corpus_pass_count.py
+++ b/tools/test_corpus_pass_count.py
@@ -237,6 +237,64 @@ check("fetch_log passes --allow-escape-sequences (without it gh emits nothing, "
 check("...and treats an empty body as unavailable rather than as zero passes",
       "not out.strip()" in src)
 
+
+# --------------------------------------------------------------------------
+# 7. AL Runner's own output is a THIRD spelling (#3357).
+#
+# preflight.py's corpus-baseline check parses a local run with this same
+# parser rather than hand-rolling a second one, and a local run names a test
+# `Codeunit65551.Method`, not `Method`. Captured verbatim from
+#   dotnet run --project AlRunner -c Release -- tests/runner-extras/object-system-table \
+#     --package-cache ~/.al-runner/platform-apps --show-pass
+# on 2026-09-07.
+# --------------------------------------------------------------------------
+print("\nAL Runner's local per-test spelling")
+
+LOG_LOCAL = """\
+=== object-system-table ===
+PASS  Codeunit65551.Object_IsEmpty_WhileAllObj_StillListsTheSameObjects (45ms)
+PASS  Codeunit65551.EmptyObject_StillAnswersOnAllFourRequestPaths (10ms)
+PASS  Codeunit65551.OemTextColumns_ReadAsEmptyText_RatherThanRaising (1ms)
+"""
+
+rloc = cpc.parse_leg(LOG_LOCAL, "Codeunit65551.")
+check("a dotted local name is captured WHOLE, not truncated at the codeunit",
+      rloc["passed"] == [
+          "Codeunit65551.EmptyObject_StillAnswersOnAllFourRequestPaths",
+          "Codeunit65551.Object_IsEmpty_WhileAllObj_StillListsTheSameObjects",
+          "Codeunit65551.OemTextColumns_ReadAsEmptyText_RatherThanRaising"],
+      str(rloc["passed"]))
+check("...so three tests in one codeunit count as three, not as one",
+      len(rloc["passed"]) == 3, str(len(rloc["passed"])))
+
+# An expectations-reclassified pass carries a qualifier between the verdict and
+# the name. Skipping those undercounts by exactly the number of oos/known-gap
+# entries in tests/expectations/ -- a shortfall that looks like a real one.
+LOG_QUALIFIED = """\
+=== al-language ===
+PASS (oos) Codeunit60101.SendEmail_IsOutOfScope (2ms)
+PASS (known-gap) Codeunit60101.TestPageBlankTemporal (3ms)
+PASS (divergence) Codeunit60101.SessionIdDiverges (1ms)
+PASS  Codeunit60101.PlainPass (1ms)
+FAIL  Codeunit60101.Broken (4ms)
+"""
+rq = cpc.parse_leg(LOG_QUALIFIED, "Codeunit60101.")
+check("PASS (oos) / (known-gap) / (divergence) all count as passes",
+      len(rq["passed"]) == 4, str(rq["passed"]))
+check("...and a FAIL next to them is still a FAIL",
+      rq["failed"] == ["Codeunit60101.Broken"], str(rq["failed"]))
+
+# The additive half: the corpus fixtures must parse to exactly what they did
+# before the pattern learned the local spelling.
+check("the 27.x corpus fixture is unaffected by the widened pattern",
+      cpc.parse_leg(LOG_27X, "TestPart_")["passed"] == r27["passed"],
+      str(cpc.parse_leg(LOG_27X, "TestPart_")["passed"]))
+check("the 28.x corpus fixture is unaffected too",
+      cpc.parse_leg(LOG_28X, "TestPart_")["passed"] == r28["passed"],
+      str(cpc.parse_leg(LOG_28X, "TestPart_")["passed"]))
+check("a bare corpus name is still captured without a dot",
+      all("." not in n for n in r27["passed"]), str(r27["passed"]))
+
 print()
 if FAILURES:
     print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")

--- a/tools/test_preflight.py
+++ b/tools/test_preflight.py
@@ -1545,6 +1545,249 @@ check("the JSON refusal carries no checks and says why",
       _doc.get("checks") == [] and "refusal" in _doc, sorted(_doc))
 
 
+
+# ------------------------------------------------- corpus baseline (--with-corpus)
+print()
+print("preflight.py -- corpus baseline")
+
+# The three corpus apps `scripts/corpus-app-dirs.py` enumerates, and the shape
+# tests/expectations/count-baseline/test-count-baseline.json records for them.
+# Numbers deliberately unlike the live ones: the check must read the file it is
+# handed, not a constant that happened to be right the day it was written.
+CORPUS_APPS = ["tests/al-language/tests/al-language",
+               "tests/al-language/tests/al-language-internals-fixture",
+               "tests/al-language/tests/al-language-onprem"]
+CORPUS_BASELINE = {
+    "suites": {
+        "al-language": {"tests": {"default": 12}, "appGroups": {"default": 1}},
+        "al-language-internals-fixture": {"tests": {"default": 0},
+                                          "appGroups": {"default": 1}},
+        "al-language-onprem": {"tests": {"default": 3}, "appGroups": {"default": 1}},
+        "runner-extras": {"groups": {"x": {"tests": 2}}},
+    }
+}
+
+
+def corpus_repo(baseline=CORPUS_BASELINE):
+    """A throwaway repo root carrying only the baseline file the check reads."""
+    root = tempfile.mkdtemp(prefix="preflight-corpus-")
+    d = os.path.join(root, "tests/expectations/count-baseline")
+    os.makedirs(d)
+    if baseline is not None:
+        with open(os.path.join(d, "test-count-baseline.json"), "w") as fh:
+            json.dump(baseline, fh)
+    return root
+
+
+# Verbatim shape of a real run, captured from
+#   dotnet run --project AlRunner -c Release -- tests/runner-extras/object-system-table \
+#     --package-cache ... --show-pass
+# on 2026-09-07. The labels, the two spaces after PASS, the `(45ms)` suffix and
+# every summary line below are that output, not an idea of it -- a fixture shaped
+# to satisfy the parser would test the author rather than the runner (#3311).
+def corpus_output(counts, *, fail=0, error=0, skipped=0, oos=0, known_gap=0,
+                  reported_pass=None, summary=True, suite_errors=(), compile_fail=()):
+    """Synthesise runner output for `counts` = {bundle dir name: passing tests}."""
+    lines = ["al-runner — running %d bundle(s)" % (len(counts) + len(compile_fail))]
+    for name in compile_fail:
+        lines += ["", f"=== {name} — COMPILE FAIL ===", "  AL0185: something"]
+    for name, n in counts.items():
+        if name in suite_errors:
+            lines += ["", f"=== {name} — SUITE ERRORS (1) ===", "  lost a suite",
+                      "  → the tests these suites declare are MISSING from this run, "
+                      "not passing."]
+        if n == 0:
+            continue
+        lines += ["", f"=== {name} ==="]
+        for i in range(n):
+            label = "PASS "
+            if i < oos:
+                label = "PASS (oos)"
+            elif i < oos + known_gap:
+                label = "PASS (known-gap)"
+            lines.append(f"{label} Codeunit6555{len(name) % 10}.Test_{name.replace('-', '_')}_{i} ({i}ms)")
+        for i in range(fail if name == list(counts)[0] else 0):
+            lines.append(f"FAIL  Codeunit65551.Broken_{i} (3ms)")
+            lines.append("      Assert.AreEqual failed")
+    if not summary:
+        return "\n".join(lines) + "\n"
+    total = sum(counts.values()) + fail + error + skipped
+    shown = sum(counts.values()) if reported_pass is None else reported_pass
+    lines += ["", "=" * 65, "al-runner — test run summary", "=" * 65,
+              f"Buckets:       {len(counts)} total",
+              f"  ran:         {len(counts)}",
+              "  compile-fail:%d" % len(compile_fail),
+              "  exec-fail:   0",
+              f"Tests:         {total} total",
+              f"  pass:        {shown}"]
+    if oos:
+        lines.append(f"    pass-oos:        {oos}")
+    if known_gap:
+        lines.append(f"    pass-known-gap:  {known_gap}")
+    lines += [f"  fail:        {fail}", f"  error:       {error}"]
+    if skipped:
+        lines.append(f"  skipped:     {skipped}")
+    lines += ["Time:", "  AL emit:     2.1s", "  C# compile:  1.7s",
+              "  test run:    0.2s", "  total:       4.0s", "  wall:        6.3s",
+              "=" * 65]
+    return "\n".join(lines) + "\n"
+
+
+class CorpusScript:
+    """A pf.run replacement answering both commands check_corpus issues."""
+
+    def __init__(self, output, rc=0, apps=None, timed_out=False, enumerator_rc=0):
+        self.output, self.rc, self.timed_out = output, rc, timed_out
+        self.apps = CORPUS_APPS if apps is None else apps
+        self.enumerator_rc = enumerator_rc
+        self.calls = []
+
+    def __call__(self, argv, **kw):
+        self.calls.append(argv)
+        if any("corpus-app-dirs" in a for a in argv):
+            return pf.Ran(rc=self.enumerator_rc,
+                          out="".join(a + "\n" for a in self.apps), err="")
+        return pf.Ran(rc=self.rc, out=self.output, err="", timed_out=self.timed_out)
+
+
+def corpus_result(output, *, baseline=CORPUS_BASELINE, **kw):
+    script = CorpusScript(output, **kw)
+    root = corpus_repo(baseline)
+    saved = pf.run
+    pf.run = script
+    try:
+        return pf.check_corpus(root, True), script
+    finally:
+        pf.run = saved
+        shutil.rmtree(root, ignore_errors=True)
+
+
+# ---- THE defect: a run that exits 0 having passed far fewer tests than the
+# baseline records used to report "the corpus baseline reproduced on this box".
+_short = corpus_output({"al-language": 3,
+                        "al-language-internals-fixture": 0,
+                        "al-language-onprem": 3})
+_res, _ = corpus_result(_short)
+check("a shortfall FAILs even though the process exited 0",
+      _res.status == "FAIL", f"{_res.status}: {_res.summary}")
+check("...and names both numbers, so the reader can act on it",
+      any("3" in d and "12" in d for d in _res.detail + [_res.summary]),
+      f"{_res.summary} {_res.detail}")
+check("...and names the suite that fell short",
+      any("al-language" in d for d in _res.detail + [_res.summary]), _res.detail)
+check("...and the machine-readable answer carries the counts",
+      _res.data.get("observed", {}).get("al-language") == 3
+      and _res.data.get("expected", {}).get("al-language") == 12, _res.data)
+
+# ---- the positive: the exact baseline, and nothing else, is a PASS
+_full = corpus_output({"al-language": 12,
+                       "al-language-internals-fixture": 0,
+                       "al-language-onprem": 3}, oos=2, known_gap=1)
+_res, _script = corpus_result(_full)
+check("reproducing the baseline exactly PASSes",
+      _res.status == "PASS", f"{_res.status}: {_res.summary} {_res.detail}")
+check("...and the summary states the count it verified, not just 'ok'",
+      "15" in _res.summary or any("15" in d for d in _res.detail),
+      f"{_res.summary} {_res.detail}")
+check("expectation-reclassified passes -- PASS (oos) / PASS (known-gap) -- still count",
+      _res.data.get("observed", {}).get("al-language") == 12, _res.data)
+
+# ---- the invocation itself: the flags used to be fabricated (#3357 defect 1)
+_argv = [a for a in _script.calls if "dotnet" in a[0]][0]
+check("the runner is invoked with the bundle paths POSITIONALLY",
+      all(app in _argv for app in CORPUS_APPS), _argv)
+check("there is no invented `test` subcommand or `--bundle` flag",
+      "--bundle" not in _argv and "test" not in _argv, _argv)
+check("the corpus apps are enumerated, never hardcoded to one path",
+      any("corpus-app-dirs" in a for c in _script.calls for a in c), _script.calls)
+check("the SHARED package caches are used -- a private one is blind to this failure",
+      _argv.count("--package-cache") == 2, _argv)
+
+# ---- growth fails too, and says which direction
+_over = corpus_output({"al-language": 13,
+                       "al-language-internals-fixture": 0,
+                       "al-language-onprem": 3})
+_res, _ = corpus_result(_over)
+check("a count ABOVE the baseline FAILs as well", _res.status == "FAIL",
+      f"{_res.status}: {_res.summary}")
+check("...and the direction is named", any("more" in d or "above" in d or "13" in d
+                                           for d in _res.detail), _res.detail)
+
+# ---- the RUN-WIDE total is not enough: one suite's tests can vanish into
+# another's count and leave the sum intact. Without a per-suite comparison this
+# case is indistinguishable from a healthy run.
+_redistributed = corpus_output({"al-language": 15,
+                                "al-language-internals-fixture": 0,
+                                "al-language-onprem": 0})
+_res, _ = corpus_result(_redistributed)
+check("a per-suite mismatch FAILs even when the run-wide total is exactly right",
+      _res.status == "FAIL", f"{_res.status}: {_res.summary}")
+check("...and names both suites that moved",
+      any("al-language-onprem" in d for d in _res.detail)
+      and any("al-language:" in d for d in _res.detail), _res.detail)
+
+# ---- a failing test is a FAIL even when the counts add up
+_failing = corpus_output({"al-language": 11,
+                          "al-language-internals-fixture": 0,
+                          "al-language-onprem": 3}, fail=1)
+_res, _ = corpus_result(_failing, rc=1)
+check("a corpus test that FAILED is a FAIL", _res.status == "FAIL", _res.summary)
+
+# ---- absence of evidence is never a pass
+_res, _ = corpus_result("al-runner — running 3 bundle(s)\n")
+check("a run that printed no summary FAILs rather than passing on the exit code",
+      _res.status == "FAIL", f"{_res.status}: {_res.summary}")
+check("...and says the run was not verified rather than reporting 0 passes as fact",
+      "summary" in (_res.summary + " ".join(_res.detail)).lower(),
+      f"{_res.summary} {_res.detail}")
+
+_res, _ = corpus_result("", timed_out=True)
+check("a timeout is a FAIL of its own", _res.status == "FAIL", _res.summary)
+check("...and is not reported as a count mismatch",
+      "timed out" in (_res.summary + " ".join(_res.detail)).lower(),
+      f"{_res.summary} {_res.detail}")
+
+# ---- a lost suite is a FAIL even when every surviving test passed
+_lost = corpus_output({"al-language": 12,
+                       "al-language-internals-fixture": 0,
+                       "al-language-onprem": 3}, suite_errors=("al-language",))
+_res, _ = corpus_result(_lost)
+check("a bundle that lost a suite FAILs even with the counts intact",
+      _res.status == "FAIL", f"{_res.status}: {_res.summary}")
+
+# ---- the exit code may add a FAIL, never grant a PASS
+_res, _ = corpus_result(_full, rc=4)
+check("a non-zero exit still FAILs when every number checks out",
+      _res.status == "FAIL", f"{_res.status}: {_res.summary}")
+check("...and says the exit code is what disagreed", "exit" in _res.summary.lower()
+      or any("exit" in d.lower() for d in _res.detail), f"{_res.summary} {_res.detail}")
+
+# ---- and the summary's own total is cross-checked against the per-bundle lines
+_lying = corpus_output({"al-language": 12,
+                        "al-language-internals-fixture": 0,
+                        "al-language-onprem": 3}, reported_pass=15 + 4)
+_res, _ = corpus_result(_lying)
+check("a summary that disagrees with the per-bundle PASS lines FAILs",
+      _res.status == "FAIL", f"{_res.status}: {_res.summary}")
+
+# ---- a baseline it cannot compute an expected count from is a refusal, not a pass
+_res, _ = corpus_result(_full, baseline={"suites": {"al-language": {"tests": {"default": 12}}}})
+check("an enumerated app with no baseline entry FAILs rather than counting as 0",
+      _res.status == "FAIL", f"{_res.status}: {_res.summary}")
+check("...and names the suite it has no expected count for",
+      any("al-language-onprem" in d for d in _res.detail + [_res.summary]),
+      f"{_res.summary} {_res.detail}")
+
+_res, _ = corpus_result(_full, apps=[])
+check("an enumerator that produced no apps FAILs -- a run of nothing is not a baseline",
+      _res.status == "FAIL", f"{_res.status}: {_res.summary}")
+
+# ---- SKIP stays honest, and still points at the file it is about
+_res = pf.check_corpus(corpus_repo(), False)
+check("the default is still SKIP, never folded into the passing count",
+      _res.status == "SKIP", _res.status)
+
+
 print()
 if FAILURES:
     print(f"FAILED: {len(FAILURES)} check(s): {', '.join(FAILURES)}")


### PR DESCRIPTION
Closes #3357

`tools/preflight.py`'s `corpus-baseline` check is the gate that decides whether results from a box can be trusted at all. It had two defects, and the second is the one that mattered.

**Defect 1 — the invocation did not exist.** It ran `dotnet run --project AlRunner -- test --bundle tests/al-language …`. There is no `test` subcommand and no `--bundle` flag, so `--with-corpus` could only ever print `Unknown option --bundle` and report FAIL — with remedy text telling the reader to halt the cycle because the machine is untrustworthy.

**Defect 2 — a PASS proved only that the process exited 0.** The function computed the path of `test-count-baseline.json`, called `os.path.exists` on it, and never opened it. The entire PASS condition was `if r.ok:`. So a run passing far fewer tests than the baseline still reported "the corpus baseline reproduced on this box" — which is precisely the failure the check's own SKIP text names: *a shared cache left inconsistent by a killed run, which once cost 76% of passing tests with no error and an unchanged exit code.*

## What it does now

- **Enumerates the corpus apps** with `scripts/corpus-app-dirs.py`, the way `bc-tests.yml` does, and passes them **positionally**. A hardcoded path is green by construction the day the corpus gains an app (#2984) — that is how `al-language-onprem` would have been checked out and never executed.
- **Reads the baseline and compares the observed pass count per app**, naming both numbers and the direction. Per app, not run-wide: one suite's tests can vanish into another's count and leave the sum intact.
- **Two differently-shaped readings of the same run**, as `verify-execution-not-the-tick.md` asks for. The per-app count comes from the `PASS` lines; the totals come from the summary block; a run whose two readings disagree fails. A missing summary is `None`, never `{"pass": 0}` — "the run printed nothing to read" and "the run passed no tests" are different facts and only one is about the box.
- **The exit code can add a failure; it can never grant a pass.** That ordering is deliberate and is now load-bearing: #3350 reports a `--count-baseline` mismatch warning and exiting 0 under `--strict`. The flags are still passed (`--strict`, `--count-baseline`, `--expectations-require-match`) because they print the exact numbers, but nothing rests on them.
- **Anything it cannot compute is a refusal, not a zero** — an enumerated app with no baseline entry, a `byBcVersion` override it cannot resolve without knowing the BC version, an enumerator that produced no apps, an unparseable run. Each fails loudly and says which.
- Keeps the shared-cache requirement (both `--package-cache` roots), because a private cache is blind to the failure this catches.

## Should a count ABOVE the baseline fail too?

Yes, and the check fails on any difference in either direction, naming which.

Two reasons, neither of them "the runner does it that way". First, this check compares *passes*, and the baseline records *discovered tests* — a surplus of passes over expected tests is arithmetically unreachable unless something is double-counted (a resumed run's carried totals, a duplicate bundle path) or the tree's pin and baseline disagree. Both mean the numbers this box produces describe something other than the corpus. Second, a floor ("at least N") is exactly the shape that let a stale baseline hide a later real drop in #1880: the drop lands above the stale number and passes unnoticed. A preflight that says "the baseline reproduced" has to mean reproduced, not exceeded.

## Why `corpus-pass-count.py` needed two more spellings

The task said to reuse `tools/corpus-pass-count.py` rather than hand-roll the count, and I did — but its pattern did not match AL Runner's own output, and reusing it unchanged would have produced a confident wrong number rather than an error:

- the runner prints `PASS  Codeunit65551.Method (45ms)`, and the old `([A-Za-z_][A-Za-z0-9_]*)` stops at the dot — so distinct-name counting would have counted distinct **codeunits**, collapsing thousands of tests to dozens;
- an expectations-reclassified pass prints `PASS (known-gap) Codeunit…`, which an unqualified pattern skips entirely.

Both are additive for a corpus log, which has neither dots nor qualifiers, and `test_corpus_pass_count.py` now asserts the real 27.x and 28.x fixtures parse to exactly the same names as before. **The second spelling is load-bearing, measured**: the real corpus run below carried 4 `PASS (oos)`, 16 `PASS (known-gap)` and 1 `PASS (divergence)` line. Ignoring them would have observed 2977 against an expected 2998 and failed a healthy box.

## RED → GREEN

RED, against `main`'s `preflight.py`: 21 of the new checks failed, including the one that matters —

```
FAIL a shortfall FAILs even though the process exited 0   PASS: the corpus baseline reproduced on this box
```

GREEN after the fix: `tools/test_preflight.py` and `tools/test_corpus_pass_count.py` both pass, as do all six `tools/test_*.py` suites.

**Deliberate-break check** (the new tests must be able to fail — a check that cannot fail is the family of defect this issue belongs to). Each guard was broken one at a time and the suite re-run:

| break | suite |
|---|---|
| `mism = []` — neuter the per-app comparison | **red** |
| summary-vs-lines cross-check → `if False:` | **red** |
| missing-summary guard → `if False:` | **red** |
| exit-code guard inside `check_corpus` → `if False:` | **red** |
| skip all verdict branches, always PASS | **red** |
| revert `_RESULT` to the undotted pattern | **red**, in *both* suites |

The first attempt at the exit-code break edited the wrong `if not r.ok:` (there are five in the file) and the suite stayed green; that is why the table above says which function.

**And a real run.** `check_corpus` against an actual corpus run on this box, BC 28.1, shared caches:

```
PASS | the corpus baseline reproduced on this box: 2998 tests passed across 3 app(s)
    al-language: expected 2969, observed 2969
    al-language-internals-fixture: expected 0, observed 0
    al-language-onprem: expected 29, observed 29
```

79s cold, 43s warm. The internals fixture prints no bucket header at all (0 visible tests), which is why "absent" has to mean 0 observed and match only an expected 0.

## Where the proving test lives

`bc-behavior-tests-go-upstream.md`: this asserts nothing about Business Central. It is runner tooling — whether a Python health check reads a JSON file and compares two integers — and no service tier can adjudicate it. It belongs in `tools/test_preflight.py`, and nothing is owed upstream. (`require-tests.yml` is not triggered either: the diff touches no file under `AlRunner/`.)

## Sibling scan, and #3335

`batch-sibling-issues-by-file.md`. Open issues naming `preflight.py`: **#3335** (`--reap` treats submodule pointer drift as uncommitted work), **#3264** (a `bc260` decompiler context that can never be present), **#3296** (the freshness guard fails open on `unknown`, in three tools), **#3350** (`--count-baseline` warns and exits 0).

I folded **none** of them, and #3335 is the one worth explaining. It does touch `preflight.py`, but a different function and a materially different review: `reap()` decides whether to **delete** a worktree, where being wrong destroys an agent's only copy of its work, while this change decides whether to trust a number. One diff asking a reviewer to hold both is the case point 4 of the rule describes. #3335 is also still untriaged (`bug` only, no `status: ready`).

#3350 is the closest in subject and is not foldable at all — its fix is in `AlRunner/Program.cs`, not here. It is the reason this check no longer trusts `--count-baseline`'s exit code, and it stays open and gets more useful, not less, once this merges.

#3264 and #3296 are separate functions with separate reasoning; #3296 in particular spans three tools and is a decision about failing open, which deserves its own review.

---
Written by an agent (`coord-1`) acting on the account holder's behalf.

https://claude.ai/code/session_01F7HLDeNwiGQoLT5wFanqmH
