### PR TITLE
test(corpus): advance the pin to 9ee6bbc, where the count goes down by one

### DIFF
--- a/tests/expectations/count-baseline/history.md
+++ b/tests/expectations/count-baseline/history.md
@@ -1405,3 +1405,55 @@ above already records `17b015ef` → `0bbe376` (+28), so naming `17b015ef` here 
 would double-count it. Only this PR's step belongs here.
 
 Written by agent fbk-2 (automated implementation agent).
+
+## 2026-09-07 — corpus pin `ddb9b5ab` → `9ee6bbc` (al-language 2978 → 2977)
+
+**The count goes DOWN, which is the unusual part.** A pin bump almost always grows the
+count, so this entry exists mainly to say why this one shrinks: corpus PR
+[#250](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/250) **deletes
+codeunit 60878 "Test Report SaveAs Pdf"** — the whole file, carrying its single `[Test]`.
+Upstream's rationale is that 60878 asserted only that `Report.SaveAs(..., ReportFormat::Pdf,
+...)` returns false, which is true on the Linux tier (RDLC stubbed) and false on a Windows
+tier that renders, so it was red on Windows by construction. Codeunit 60774 "Test Report
+SaveAs Pdf Body" asserts a strict superset — it branches on the same return value and
+additionally reads the blob back, requiring an empty stream on false and a `%PDF-` signature
+on true. No coverage is lost; one test is.
+
+This is a **catch-up** bump (`al-language-submodule.md`): every fix these four commits need
+had already merged, so nothing here is folded into a runner fix. Corpus history is linear, so
+all four come as a prefix:
+
+| corpus PR | what it changes | effect on the count |
+|---|---|---|
+| [#250](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/250) | deletes cu 60878, superseded by cu 60774 | **−1** |
+| [#251](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/251) | `.github/workflows/` only — nightly artifact type | ±0 |
+| [#252](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/252) | rewrites one existing assertion in `TestMediaPngImport.al` (dimensions, not byte length) | ±0 |
+| [#253](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/253) | `.github/` scripts and workflows, plus comments only in `TestIsolatedStorage.al` | ±0 |
+
+**2977 is the number the guard itself reported**, not one computed by subtracting 1 from 2978.
+Measured on BC 28.1.49838.53910 on a real 3-bundle run: with the pin moved and the baseline
+still at 2978 the run exited 4 with
+`DROP: suite 'al-language' tests count: expected 2978, actual 2977 (BC 28.1)`, and 2977 is that
+`actual`. Re-run after the bump: **3006 tests total, 3006 pass, 0 fail, exit 0**, of which
+`al-language-onprem` contributes 29 and `al-language-internals-fixture` 0 — both unchanged, and
+neither reported a mismatch.
+
+The guard is symmetric in practice, not just in the README: running the **old** pin against
+this PR's 2977 exits 1 with
+`GROWTH: suite 'al-language' tests count: expected 2977, actual 2978 (BC 28.1)`. So the
+decrease is attributable to these four commits and to nothing else in the tree.
+
+**One entry in `tests/expectations/` had to go with it**, and it is not optional — the run
+cannot be green without it. `oos-reports.json` declared an `expect-oos` for
+`Test Report SaveAs Pdf.SaveAsPdf_RdlcLayout_ReturnsFalseWithLastErrorTextOnLinux` (cu 60878).
+With that codeunit deleted upstream, `--expectations-require-match` reports
+`UNMATCHED: ... matched no test in this run — no codeunit named "Test Report SaveAs Pdf"
+(id 60878) was loaded in this run`, which is exit 5. The sibling entry for cu 60774 stays and
+still matches (`PASS (oos)`), so the same permanently-out-of-scope surface
+(`docs/scope.md#report-rendering`) remains declared — the deleted entry was the redundant half,
+exactly as upstream's supersession implies. Expectation entries now: 24, all matched.
+
+The starting point is `ddb9b5ab`/2978, not `408c39fe`/2969: `5ad50bc2` on `main` moved both the
+pin and the count in one commit, and its own step is already recorded by that PR.
+
+Written by agent stma-auto-11 (automated implementation agent).

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Schema, semantics and how to bump: README.md in this directory. Per-bump rationale: history.md, never a prose line in here (#2485).",
   "suites": {
     "al-language": {
-      "tests": { "default": 2978 },
+      "tests": { "default": 2977 },
       "appGroups": { "default": 1 }
     },
     "al-language-internals-fixture": { "tests": { "default": 0 }, "appGroups": { "default": 1 } },

--- a/tests/expectations/oos-reports.json
+++ b/tests/expectations/oos-reports.json
@@ -1,14 +1,5 @@
 [
   {
-    "codeunitId": 60878,
-    "CodeunitName": "Test Report SaveAs Pdf",
-    "Method": "SaveAsPdf_RdlcLayout_ReturnsFalseWithLastErrorTextOnLinux",
-    "Mode": "expect-oos",
-    "Reason": "report-rendering-external",
-    "Doc": "docs/scope.md#report-rendering",
-    "Note": "RDLC rendering needs an external renderer and is permanently out of scope (docs/scope.md §3.5.1). ReportResultSetProcessorFactory.GetRdlcResultSetProcessor is Cecil-rewritten to throw the documented 'out-of-scope: <api> — report-rendering-external — …' message; expect-oos matches that message convention as of #1743. The upstream test asserts a BC-on-Linux platform limitation, not Cloud SaaS behaviour — real BC SaaS renders RDLC."
-  },
-  {
     "codeunitId": 60774,
     "CodeunitName": "Test Report SaveAs Pdf Body",
     "Method": "Report_SaveAs_Pdf_ReturnValueAgreesWithTheBytesInTheStream",


### PR DESCRIPTION
No linked issue: catch-up corpus pin bump. Every fix these four corpus commits need had
already merged, so there is no runner issue for this PR to close — it advances the pin and
records the count, nothing else.

## What moved

`tests/al-language` pin `ddb9b5ab` → `9ee6bbc` (corpus `master`'s tip). Four commits, taken as
a prefix because corpus history is linear.

| corpus PR | what it changes | effect on the count |
|---|---|---|
| [#250](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/250) | deletes cu 60878 "Test Report SaveAs Pdf", superseded by cu 60774 | **−1** |
| [#251](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/251) | `.github/workflows/` only — nightly artifact type | ±0 |
| [#252](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/252) | rewrites one existing assertion in `TestMediaPngImport.al` | ±0 |
| [#253](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/253) | `.github/` scripts and workflows, plus comments only in `TestIsolatedStorage.al` | ±0 |

This is the **catch-up** case in `.claude/rules/al-language-submodule.md`, so it is legitimately
its own PR rather than folded into a fix.

## The count goes DOWN, and it was predicted to

Predicted **−1** before running; **measured −1**. `al-language` **2978 → 2977**.

2977 is the number the guard reported, not a computed `2978 − 1`. With the pin moved and the
baseline untouched, the run exits 4:

```
[count-baseline] DROP: suite 'al-language' tests count: expected 2978, actual 2977 (BC 28.1)
```

Re-run after the bump — **exit 0, 3006 tests total, 3006 pass, 0 fail, 0 error**.

### Measured per-leg counts (BC 28.1.49838.53910, local, 3 bundles)

| suite | baseline before | measured | delta |
|---|---|---|---|
| `al-language` | 2978 | **2977** | **−1** |
| `al-language-onprem` | 29 | 29 | 0 |
| `al-language-internals-fixture` | 0 | 0 | 0 |
| run total (all 3 bundles) | — | 3006 pass / 3006 | — |

Neither of the two unchanged suites reported a mismatch. Nothing was skipped: `compile-fail: 0`,
`exec-fail: 0`, buckets `3 total / 3 ran`.

### The guard is symmetric on the way down

Worth stating because most bumps go up. Running the **old** pin against this PR's 2977 exits 1
with `GROWTH: suite 'al-language' tests count: expected 2977, actual 2978 (BC 28.1)` — the exact
mirror. So the −1 is attributable to these four commits and to nothing else in the tree.

Relevant to **#3350** (a `--count-baseline` mismatch printing GROWTH but exiting 0 under
`--strict`): I could not reproduce that. Three arms, all non-zero:

| arm | baseline | actual | message | exit |
|---|---|---|---|---|
| new pin, stale baseline | 2978 | 2977 | `DROP` | **4** |
| old pin, new baseline | 2977 | 2978 | `GROWTH` | 1 |
| new pin, baseline hand-set to 2970 | 2970 | 2977 | `GROWTH` | **4** |

The third arm is deliberate. The second cannot isolate the count's own exit code, because a
genuine test failure was present in it (cu 60878 throwing OOS with its entry removed), so its
exit 1 is attributable to the failure. The third has `fail: 0`, `pass: 3006` and a pure count
mismatch — and exits **4**. So on this build the exit-4 path exists, `--strict` is wired to the
count comparison, and GROWTH and DROP are treated alike; the "growth-is-benign by design"
possibility #3350 floats is ruled out here. Measurements posted to #3350, which **stays open** —
not reproducing it on a later build is not the same as it never having happened.

## One expectations entry had to go with the pin

Not scope creep — the run cannot be green while it stands. Deleting cu 60878 upstream orphaned
its `expect-oos` entry in `tests/expectations/oos-reports.json`, and
`--expectations-require-match` refuses it:

```
[expectations] UNMATCHED: oos-reports.json: Test Report SaveAs Pdf.SaveAsPdf_RdlcLayout_ReturnsFalseWithLastErrorTextOnLinux (ExpectOos)
matched no test in this run — no codeunit named "Test Report SaveAs Pdf" (id 60878) was loaded in this run.
```

That is exit 5. Removed. The sibling entry for cu 60774 "Test Report SaveAs Pdf Body" stays and
still matches (`PASS (oos)`), so the same permanently-out-of-scope surface
(`docs/scope.md#report-rendering`) remains declared — the deleted entry was the redundant half,
which is exactly what upstream's supersession implies. Expectation entries after this PR: **24,
all matched**.

## Forward-pin verification

The submodule trap is real and it bit once during this task: after `git submodule update` the
working tree snapped back to the index's `ddb9b5ab`, so committing at that moment would have
written no pin change at all. Staged the gitlink explicitly by name and re-verified:

```
git diff origin/main...HEAD -- tests/al-language
-Subproject commit ddb9b5ab32c0e05200ee648c13372461e57ec199
+Subproject commit 9ee6bbcd12d433547f230d36d017231d53a17937

git -C tests/al-language merge-base --is-ancestor ddb9b5ab 9ee6bbc   # succeeds
```

Re-verified against `origin/main` as fetched at finalisation time, which still holds `ddb9b5ab`
— so this moves the pin **forward**, not backward.

## Gates

- Diff is `tests/`-only (gitlink + three files under `tests/expectations/`), so
  `require-tests.yml` does not trigger.
- `check_corpus_linkage.sh` **run against this exact diff**, not assumed:
  `No file in this diff can change what AL observes, so no corpus declaration is required.`
  (exit 0). No `Corpus-PR:` / `Corpus-NA:` line needed.
- `CHANGELOG.md` untouched.

## What I deliberately left out

Nothing else is in the diff. I did not touch the runner, and I did not adjust any other
baseline number to make something fit.

Written by agent `stma-auto-11` (automated implementation agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcnvQR71br5UAVmGN4Dew4
